### PR TITLE
Fix logs for `test`, `lint`, `fmt`, and `typecheck` to always print, even if cached

### DIFF
--- a/src/python/pants/backend/python/lint/python_fmt.py
+++ b/src/python/pants/backend/python/lint/python_fmt.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Iterable, List, Type
 
 from pants.backend.python.target_types import PythonSources
-from pants.core.goals.fmt import FmtResult, LanguageFmtResults, LanguageFmtTargets
+from pants.core.goals.fmt import EnrichedFmtResult, LanguageFmtResults, LanguageFmtTargets
 from pants.core.goals.style_request import StyleRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, Snapshot
@@ -33,13 +33,13 @@ async def format_python_target(
     )
     prior_formatter_result = original_sources.snapshot
 
-    results: List[FmtResult] = []
+    results: List[EnrichedFmtResult] = []
     fmt_request_types: Iterable[Type[PythonFmtRequest]] = union_membership.union_rules[
         PythonFmtRequest
     ]
     for fmt_request_type in fmt_request_types:
         result = await Get(
-            FmtResult,
+            EnrichedFmtResult,
             PythonFmtRequest,
             fmt_request_type(
                 (

--- a/src/python/pants/backend/python/lint/python_fmt_integration_test.py
+++ b/src/python/pants/backend/python/lint/python_fmt_integration_test.py
@@ -9,7 +9,7 @@ from pants.backend.python.lint.black.rules import rules as black_rules
 from pants.backend.python.lint.isort.rules import rules as isort_rules
 from pants.backend.python.lint.python_fmt import PythonFmtTargets, format_python_target
 from pants.backend.python.target_types import PythonLibrary
-from pants.core.goals.fmt import LanguageFmtResults
+from pants.core.goals.fmt import LanguageFmtResults, enrich_fmt_result
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.target import Targets
@@ -20,6 +20,7 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
+            enrich_fmt_result,
             format_python_target,
             *black_rules(),
             *isort_rules(),

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -75,6 +75,12 @@ class FmtResult:
 
 @dataclass(frozen=True)
 class EnrichedFmtResult(FmtResult, EngineAwareReturnType):
+    """A `FmtResult` that is enriched for the sake of logging results as they come in.
+
+    Plugin authors only need to return `FmtResult`, and a rule will upcast those into
+    `EnrichedFmtResult`.
+    """
+
     def level(self) -> Optional[LogLevel]:
         if self.skipped:
             return LogLevel.DEBUG

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -92,6 +92,8 @@ class EnrichedFmtResult(FmtResult, EngineAwareReturnType):
         return f"{self.formatter_name} {message}{output}"
 
 
+# NB: We mark this uncachable to ensure that the results are always streamed, even if the
+# underlying FmtResult is memoized. This rule is very cheap, so there's little performance hit.
 @_uncacheable_rule(desc="fmt")
 async def enrich_fmt_result(result: FmtResult) -> EnrichedFmtResult:
     return EnrichedFmtResult(

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -4,7 +4,7 @@
 import itertools
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import ClassVar, Iterable, List, Optional, Tuple, Type, cast
+from typing import ClassVar, Iterable, List, Optional, Tuple, Type, TypeVar, cast
 
 from pants.core.util_rules.filter_empty_sources import TargetsWithSources, TargetsWithSourcesRequest
 from pants.engine.console import Console
@@ -18,6 +18,8 @@ from pants.engine.unions import UnionMembership, union
 from pants.util.logging import LogLevel
 from pants.util.strutil import strip_v2_chroot_path
 
+_F = TypeVar("_F", bound="FmtResult")
+
 
 @dataclass(frozen=True)
 class FmtResult:
@@ -28,7 +30,7 @@ class FmtResult:
     formatter_name: str
 
     @classmethod
-    def skip(cls, *, formatter_name: str) -> "FmtResult":
+    def skip(cls: Type[_F], *, formatter_name: str) -> _F:
         return cls(
             input=EMPTY_DIGEST,
             output=EMPTY_DIGEST,

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -12,7 +12,7 @@ from pants.engine.engine_aware import EngineAwareReturnType
 from pants.engine.fs import EMPTY_DIGEST, Digest, MergeDigests, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import ProcessResult
-from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
+from pants.engine.rules import Get, MultiGet, _uncacheable_rule, collect_rules, goal_rule
 from pants.engine.target import Field, Target, Targets
 from pants.engine.unions import UnionMembership, union
 from pants.util.logging import LogLevel
@@ -20,7 +20,7 @@ from pants.util.strutil import strip_v2_chroot_path
 
 
 @dataclass(frozen=True)
-class FmtResult(EngineAwareReturnType):
+class FmtResult:
     input: Digest
     output: Digest
     stdout: str
@@ -70,6 +70,9 @@ class FmtResult(EngineAwareReturnType):
     def did_change(self) -> bool:
         return self.output != self.input
 
+
+@dataclass(frozen=True)
+class EnrichedFmtResult(FmtResult, EngineAwareReturnType):
     def level(self) -> Optional[LogLevel]:
         if self.skipped:
             return LogLevel.DEBUG
@@ -77,7 +80,7 @@ class FmtResult(EngineAwareReturnType):
 
     def message(self) -> Optional[str]:
         if self.skipped:
-            return "skipped."
+            return f"{self.formatter_name} skipped."
         message = "made changes." if self.did_change else "made no changes."
         output = ""
         if self.stdout:
@@ -86,7 +89,18 @@ class FmtResult(EngineAwareReturnType):
             output += f"\n{self.stderr}"
         if output:
             output = f"{output.rstrip()}\n\n"
-        return f"{message}{output}"
+        return f"{self.formatter_name} {message}{output}"
+
+
+@_uncacheable_rule(desc="fmt")
+async def enrich_fmt_result(result: FmtResult) -> EnrichedFmtResult:
+    return EnrichedFmtResult(
+        input=result.input,
+        output=result.output,
+        stdout=result.stdout,
+        stderr=result.stderr,
+        formatter_name=result.formatter_name,
+    )
 
 
 @union

--- a/src/python/pants/core/goals/fmt_test.py
+++ b/src/python/pants/core/goals/fmt_test.py
@@ -7,6 +7,7 @@ from textwrap import dedent
 from typing import ClassVar, List, Optional, Type, cast
 
 from pants.core.goals.fmt import (
+    EnrichedFmtResult,
     Fmt,
     FmtResult,
     FmtSubsystem,
@@ -269,14 +270,14 @@ class FmtTest(TestBase):
 
 
 def test_streaming_output_skip() -> None:
-    result = FmtResult.skip(formatter_name="formatter")
+    result = EnrichedFmtResult.skip(formatter_name="formatter")
     assert result.level() == LogLevel.DEBUG
-    assert result.message() == "skipped."
+    assert result.message() == "formatter skipped."
 
 
 def test_streaming_output_changed() -> None:
     changed_digest = Digest(EMPTY_DIGEST.fingerprint, 2)
-    result = FmtResult(
+    result = EnrichedFmtResult(
         input=EMPTY_DIGEST,
         output=changed_digest,
         stdout="stdout",
@@ -286,7 +287,7 @@ def test_streaming_output_changed() -> None:
     assert result.level() == LogLevel.WARN
     assert result.message() == dedent(
         """\
-        made changes.
+        formatter made changes.
         stdout
         stderr
 
@@ -295,7 +296,7 @@ def test_streaming_output_changed() -> None:
 
 
 def test_streaming_output_not_changed() -> None:
-    result = FmtResult(
+    result = EnrichedFmtResult(
         input=EMPTY_DIGEST,
         output=EMPTY_DIGEST,
         stdout="stdout",
@@ -305,7 +306,7 @@ def test_streaming_output_not_changed() -> None:
     assert result.level() == LogLevel.INFO
     assert result.message() == dedent(
         """\
-        made no changes.
+        formatter made no changes.
         stdout
         stderr
 

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -79,6 +79,10 @@ class LintResults:
     results: Tuple[LintResult, ...]
     linter_name: str
 
+    def __init__(self, results: Iterable[LintResult], *, linter_name: str) -> None:
+        self.results = tuple(results)
+        self.linter_name = linter_name
+
     @property
     def skipped(self) -> bool:
         return bool(self.results) is False
@@ -90,10 +94,6 @@ class LintResults:
     @memoized_property
     def reports(self) -> Tuple[LintReport, ...]:
         return tuple(result.report for result in self.results if result.report)
-
-    def __init__(self, results: Iterable[LintResult], *, linter_name: str) -> None:
-        self.results = tuple(results)
-        self.linter_name = linter_name
 
 
 class EnrichedLintResults(LintResults, EngineAwareReturnType):

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -97,6 +97,12 @@ class LintResults:
 
 
 class EnrichedLintResults(LintResults, EngineAwareReturnType):
+    """`LintResults` that are enriched for the sake of logging results as they come in.
+
+    Plugin authors only need to return `LintResults`, and a rule will upcast those into
+    `EnrichedLintResults`.
+    """
+
     def level(self) -> Optional[LogLevel]:
         if self.skipped:
             return LogLevel.DEBUG

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -22,7 +22,7 @@ from pants.engine.engine_aware import EngineAwareReturnType
 from pants.engine.fs import Digest, MergeDigests, Snapshot, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import FallibleProcessResult, InteractiveProcess, InteractiveRunner
-from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
+from pants.engine.rules import Get, MultiGet, _uncacheable_rule, collect_rules, goal_rule, rule
 from pants.engine.target import (
     FieldSet,
     Sources,
@@ -70,17 +70,6 @@ class TestResult:
             xml_results=xml_results,
         )
 
-
-@dataclass(frozen=True)
-class EnrichedTestResult(EngineAwareReturnType):
-    exit_code: Optional[int]
-    stdout: str
-    stderr: str
-    address: Address
-    output_setting: "ShowOutput"
-    coverage_data: Optional["CoverageData"] = None
-    xml_results: Optional[Snapshot] = None
-
     @property
     def skipped(self) -> bool:
         return (
@@ -90,6 +79,32 @@ class EnrichedTestResult(EngineAwareReturnType):
             and not self.coverage_data
             and not self.xml_results
         )
+
+    def __lt__(self, other: Union[Any, "EnrichedTestResult"]) -> bool:
+        """We sort first by status (skipped vs failed vs succeeded), then alphanumerically within
+        each group."""
+        if not isinstance(other, EnrichedTestResult):
+            return NotImplemented
+        if self.exit_code == other.exit_code:
+            return self.address.spec < other.address.spec
+        if self.exit_code is None:
+            return True
+        if other.exit_code is None:
+            return False
+        return self.exit_code < other.exit_code
+
+
+class ShowOutput(Enum):
+    """Which tests to emit detailed output for."""
+
+    ALL = "all"
+    FAILED = "failed"
+    NONE = "none"
+
+
+@dataclass(frozen=True)
+class EnrichedTestResult(TestResult, EngineAwareReturnType):
+    output_setting: ShowOutput = ShowOutput.ALL
 
     def artifacts(self) -> Optional[Dict[str, Snapshot]]:
         if not self.xml_results:
@@ -118,19 +133,6 @@ class EnrichedTestResult(EngineAwareReturnType):
         if output:
             output = f"{output.rstrip()}\n\n"
         return f"{message}{output}"
-
-    def __lt__(self, other: Union[Any, "EnrichedTestResult"]) -> bool:
-        """We sort first by status (skipped vs failed vs succeeded), then alphanumerically within
-        each group."""
-        if not isinstance(other, EnrichedTestResult):
-            return NotImplemented
-        if self.exit_code == other.exit_code:
-            return self.address.spec < other.address.spec
-        if self.exit_code is None:
-            return True
-        if other.exit_code is None:
-            return False
-        return self.exit_code < other.exit_code
 
 
 @dataclass(frozen=True)
@@ -238,14 +240,6 @@ class CoverageReports(EngineAwareReturnType):
         return artifacts or None
 
 
-class ShowOutput(Enum):
-    """Which tests to emit detailed output for."""
-
-    ALL = "all"
-    FAILED = "failed"
-    NONE = "none"
-
-
 class TestSubsystem(GoalSubsystem):
     """Run tests."""
 
@@ -330,11 +324,6 @@ class TestSubsystem(GoalSubsystem):
     @property
     def open_coverage(self) -> bool:
         return cast(bool, self.options.open_coverage)
-
-
-@dataclass(frozen=True)
-class TestExtraEnv:
-    env: FrozenDict[str, str]
 
 
 class Test(Goal):
@@ -448,6 +437,11 @@ async def run_tests(
     return Test(exit_code)
 
 
+@dataclass(frozen=True)
+class TestExtraEnv:
+    env: FrozenDict[str, str]
+
+
 @rule
 def get_filtered_environment(
     test_subsystem: TestSubsystem, pants_env: PantsEnvironment
@@ -460,7 +454,9 @@ def get_filtered_environment(
     return TestExtraEnv(env)
 
 
-@rule(desc="Run tests")
+# NB: We mark this uncachable to ensure that the results are always streamed, even if the
+# underlying TestResult is memoized. This rule is very cheap, so there's little performance hit.
+@_uncacheable_rule(desc="test")
 def enrich_test_result(
     test_result: TestResult, test_subsystem: TestSubsystem
 ) -> EnrichedTestResult:

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -104,6 +104,12 @@ class ShowOutput(Enum):
 
 @dataclass(frozen=True)
 class EnrichedTestResult(TestResult, EngineAwareReturnType):
+    """A `TestResult` that is enriched for the sake of logging results as they come in.
+
+    Plugin authors only need to return `TestResult`, and a rule will upcast those into
+    `EnrichedTestResult`.
+    """
+
     output_setting: ShowOutput = ShowOutput.ALL
 
     def artifacts(self) -> Optional[Dict[str, Snapshot]]:

--- a/src/python/pants/core/goals/typecheck.py
+++ b/src/python/pants/core/goals/typecheck.py
@@ -74,6 +74,12 @@ class TypecheckResults:
 
 
 class EnrichedTypecheckResults(TypecheckResults, EngineAwareReturnType):
+    """`TypecheckResults` that are enriched for the sake of logging results as they come in.
+
+    Plugin authors only need to return `TypecheckResults`, and a rule will upcast those into
+    `TypecheckResults`.
+    """
+
     def level(self) -> Optional[LogLevel]:
         if self.skipped:
             return LogLevel.DEBUG

--- a/src/python/pants/core/goals/typecheck.py
+++ b/src/python/pants/core/goals/typecheck.py
@@ -13,7 +13,7 @@ from pants.engine.console import Console
 from pants.engine.engine_aware import EngineAwareReturnType
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import FallibleProcessResult
-from pants.engine.rules import Get, MultiGet, QueryRule, collect_rules, goal_rule
+from pants.engine.rules import Get, MultiGet, QueryRule, _uncacheable_rule, collect_rules, goal_rule
 from pants.engine.target import Targets
 from pants.engine.unions import UnionMembership, union
 from pants.util.logging import LogLevel
@@ -49,7 +49,7 @@ class TypecheckResult:
 
 @frozen_after_init
 @dataclass(unsafe_hash=True)
-class TypecheckResults(EngineAwareReturnType):
+class TypecheckResults:
     """Zero or more TypecheckResult objects for a single type checker.
 
     Typically, type checkers will return one result. If they no-oped, they will return zero results.
@@ -72,6 +72,8 @@ class TypecheckResults(EngineAwareReturnType):
     def exit_code(self) -> int:
         return next((result.exit_code for result in self.results if result.exit_code != 0), 0)
 
+
+class EnrichedTypecheckResults(TypecheckResults, EngineAwareReturnType):
     def level(self) -> Optional[LogLevel]:
         if self.skipped:
             return LogLevel.DEBUG
@@ -79,8 +81,11 @@ class TypecheckResults(EngineAwareReturnType):
 
     def message(self) -> Optional[str]:
         if self.skipped:
-            return "skipped."
-        message = "succeeded." if self.exit_code == 0 else f"failed (exit code {self.exit_code})."
+            return f"{self.typechecker_name} skipped."
+        message = self.typechecker_name
+        message += (
+            " succeeded." if self.exit_code == 0 else f" failed (exit code {self.exit_code})."
+        )
 
         def msg_for_result(result: TypecheckResult) -> str:
             msg = ""
@@ -150,7 +155,7 @@ async def typecheck(
         if request
     )
     all_results = await MultiGet(
-        Get(TypecheckResults, TypecheckRequest, request) for request in valid_requests
+        Get(EnrichedTypecheckResults, TypecheckRequest, request) for request in valid_requests
     )
 
     exit_code = 0
@@ -170,6 +175,16 @@ async def typecheck(
         console.print_stderr(f"{sigil} {results.typechecker_name} {status}.")
 
     return Typecheck(exit_code)
+
+
+# NB: We mark this uncachable to ensure that the results are always streamed, even if the
+# underlying TypecheckResults is memoized. This rule is very cheap, so there's little performance
+# hit.
+@_uncacheable_rule(desc="typecheck")
+def enrich_typecheck_results(results: TypecheckResults) -> EnrichedTypecheckResults:
+    return EnrichedTypecheckResults(
+        results=results.results, typechecker_name=results.typechecker_name
+    )
 
 
 def rules():


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/10918.

Rather than inventing some new engine mechanism like a `force_log=True` toggle—which would be costly to maintain—we leverage uncachable rules. We use a pattern where the downstream plugins return the data (e.g. `LintResults`), and then we automatically enrich it for the sake of IO (e.g. `EnrichedLintResults`). This ensures that the data computation is memoized, while the IO is forced to rerun. As we were doing before, we can augment the logging with extra info, e.g. using `--test-output` to determine what to log.

### Result

Regardless of how many times you run this command, we get consistent output (modulo inconsistent ordering of logs):

```
▶ ./pants --changed-since=HEAD~1 lint
01:26:44.10 [INFO] Completed: lint - Docformatter succeeded.
01:26:44.21 [INFO] Completed: lint - isort succeeded.
01:26:44.51 [INFO] Completed: lint - Flake8 succeeded.
01:26:44.75 [INFO] Completed: lint - Black succeeded.
All done! ✨ 🍰 ✨
8 files would be left unchanged.
```

[ci skip-rust]
[ci skip-build-wheels]