### PR TITLE
Fix `pytest.pex` leaking into coverage data (Cherry-pick of #11110)

### DIFF
--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -186,8 +186,8 @@ def _validate_and_update_config(
         )
     coverage_config.set("run", "relative_files", "True")
     omit_elements = [em for em in run_section.get("omit", "").split("\n")] or ["\n"]
-    if "test_runner.pex/*" not in omit_elements:
-        omit_elements.append("test_runner.pex/*")
+    if "pytest.pex/*" not in omit_elements:
+        omit_elements.append("pytest.pex/*")
     run_section["omit"] = "\n".join(omit_elements)
 
 
@@ -314,9 +314,7 @@ async def generate_coverage_reports(
         pex_processes.append(
             PexProcess(
                 coverage_setup.pex,
-                # We pass `--ignore-errors` because Pants dynamically injects missing `__init__.py`
-                # files and this will cause Coverage to fail.
-                argv=(report_type.report_name, "--ignore-errors"),
+                argv=(report_type.report_name,),
                 input_digest=input_digest,
                 output_directories=("htmlcov",) if report_type == CoverageReportType.HTML else None,
                 output_files=(output_file,) if output_file else None,

--- a/src/python/pants/backend/python/goals/coverage_py_test.py
+++ b/src/python/pants/backend/python/goals/coverage_py_test.py
@@ -56,7 +56,7 @@ def test_default_no_config() -> None:
             [run]
             relative_files = True
             omit = 
-            \ttest_runner.pex/*
+            \tpytest.pex/*
 
         """  # noqa: W291
     )
@@ -79,7 +79,7 @@ def test_simple_config() -> None:
             relative_files = True
             jerry = HELLO
             omit = 
-            \ttest_runner.pex/*
+            \tpytest.pex/*
 
             """  # noqa: W291
     )
@@ -101,7 +101,7 @@ def test_config_no_run_section() -> None:
             [run]
             relative_files = True
             omit = 
-            \ttest_runner.pex/*
+            \tpytest.pex/*
 
             """  # noqa: W291
     )
@@ -124,7 +124,7 @@ def test_append_omits() -> None:
             omit = 
             \tjerry/seinfeld/*.py
             \tfestivus/tinsel/*.py
-            \ttest_runner.pex/*
+            \tpytest.pex/*
             relative_files = True
 
             """  # noqa: W291


### PR DESCRIPTION
This happened when we removed `test_runner.pex`. We didn't catch it because we set `--ignore-errors`, which should be safe to remove now that we no longer magically inject `__init__.py` files like we did before.

[ci skip-rust]
[ci skip-build-wheels]