### PR TITLE
Speed up `./pants filedeps`

### DIFF
--- a/src/python/pants/backend/project_info/filedeps.py
+++ b/src/python/pants/backend/project_info/filedeps.py
@@ -11,9 +11,9 @@ from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
 from pants.engine.target import (
-    HydratedSources,
-    HydrateSourcesRequest,
     Sources,
+    SourcesPaths,
+    SourcesPathsRequest,
     Target,
     Targets,
     TransitiveTargets,
@@ -103,12 +103,12 @@ async def file_deps(
             itertools.chain.from_iterable(tgt.get(Sources).filespec["includes"] for tgt in targets)
         )
     else:
-        all_hydrated_sources = await MultiGet(
-            Get(HydratedSources, HydrateSourcesRequest(tgt.get(Sources))) for tgt in targets
+        all_sources_paths = await MultiGet(
+            Get(SourcesPaths, SourcesPathsRequest(tgt.get(Sources))) for tgt in targets
         )
         unique_rel_paths.update(
             itertools.chain.from_iterable(
-                hydrated_sources.snapshot.files for hydrated_sources in all_hydrated_sources
+                sources_paths.files for sources_paths in all_sources_paths
             )
         )
 

--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -95,8 +95,8 @@ async def map_first_party_modules_to_addresses() -> FirstPartyModuleToAddressMap
     # `StrippedSourceFiles`, so that we can use `Get(SourcesPaths, SourcesPathsRequest)` instead of
     # `Get(HydratedSources, HydrateSourcesRequest)`, which is much faster.
     #
-    # This implementation is kept private because it's not fully comprehensive, such as not looking
-    # at codegen. That's fine for dep inference, but not in other contexts.
+    # This implementation is kept private because we don't yet want to add an abstraction to get
+    # the stripped source file names, until we have another use.
     stripped_sources_per_explicit_target = await MultiGet(
         Get(_StrippedFileNames, _StrippedFileNamesRequest(tgt[PythonSources]))
         for tgt in candidate_targets

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -56,6 +56,8 @@ from pants.engine.target import (
     InjectedDependencies,
     RegisteredTargetTypes,
     Sources,
+    SourcesPaths,
+    SourcesPathsRequest,
     SpecialCasedDependencies,
     Subtargets,
     Target,
@@ -88,7 +90,7 @@ logger = logging.getLogger(__name__)
 
 
 @rule
-async def generate_subtargets(address: Address, global_options: GlobalOptions) -> Subtargets:
+async def generate_subtargets(address: Address) -> Subtargets:
     if not address.is_base_target:
         raise ValueError(f"Cannot generate file Targets for a file Address: {address}")
     wrapped_base_target = await Get(WrappedTarget, Address, address)
@@ -99,15 +101,8 @@ async def generate_subtargets(address: Address, global_options: GlobalOptions) -
         # the base target from depending on its splits.
         return Subtargets(base_target, ())
 
-    # Create subtargets for matched sources.
-    sources_field = base_target[Sources]
-    sources_field_path_globs = sources_field.path_globs(
-        global_options.options.files_not_found_behavior
-    )
-
     # Generate a subtarget per source.
-    paths = await Get(Paths, PathGlobs, sources_field_path_globs)
-    sources_field.validate_resolved_files(paths.files)
+    paths = await Get(SourcesPaths, SourcesPathsRequest(base_target[Sources]))
     wrapped_subtargets = await MultiGet(
         Get(
             WrappedTarget,
@@ -116,7 +111,6 @@ async def generate_subtargets(address: Address, global_options: GlobalOptions) -
         )
         for subtarget_file in paths.files
     )
-
     return Subtargets(base_target, tuple(wt.target for wt in wrapped_subtargets))
 
 
@@ -737,6 +731,17 @@ async def hydrate_sources(
     return HydratedSources(
         generated_sources.snapshot, sources_field.filespec, sources_type=sources_type
     )
+
+
+@rule(desc="Resolve `sources` field file names")
+async def resolve_source_paths(
+    request: SourcesPathsRequest, global_options: GlobalOptions
+) -> SourcesPaths:
+    sources_field = request.field
+    path_globs = sources_field.path_globs(global_options.options.files_not_found_behavior)
+    paths = await Get(Paths, PathGlobs, path_globs)
+    sources_field.validate_resolved_files(paths.files)
+    return SourcesPaths(files=paths.files, dirs=paths.dirs)
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -61,6 +61,8 @@ from pants.engine.target import (
     InjectDependenciesRequest,
     InjectedDependencies,
     Sources,
+    SourcesPaths,
+    SourcesPathsRequest,
     SpecialCasedDependencies,
     Tags,
     Target,
@@ -801,7 +803,12 @@ def test_find_valid_field_sets() -> None:
 
 @pytest.fixture
 def sources_rule_runner() -> RuleRunner:
-    return RuleRunner(rules=[QueryRule(HydratedSources, (HydrateSourcesRequest,))])
+    return RuleRunner(
+        rules=[
+            QueryRule(HydratedSources, [HydrateSourcesRequest]),
+            QueryRule(SourcesPaths, [SourcesPathsRequest]),
+        ]
+    )
 
 
 def test_sources_normal_hydration(sources_rule_runner: RuleRunner) -> None:
@@ -815,7 +822,11 @@ def test_sources_normal_hydration(sources_rule_runner: RuleRunner) -> None:
     )
     assert hydrated_sources.snapshot.files == ("src/fortran/f1.f03", "src/fortran/f1.f95")
 
-    # Also test that the Filespec is correct. This does not need hydration to be calculated.
+    # Test that `SourcesPaths` works too.
+    sources_paths = sources_rule_runner.request(SourcesPaths, [SourcesPathsRequest(sources)])
+    assert sources_paths.files == ("src/fortran/f1.f03", "src/fortran/f1.f95")
+
+    # Also test that the Filespec is correct. This does not need the engine to be calculated.
     assert (
         sources.filespec
         == {

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -33,7 +33,13 @@ from pants.base.specs import Spec
 from pants.engine.addresses import Address, UnparsedAddressInputs, assert_single_address
 from pants.engine.collection import Collection, DeduplicatedCollection
 from pants.engine.engine_aware import EngineAwareParameter
-from pants.engine.fs import GlobExpansionConjunction, GlobMatchErrorBehavior, PathGlobs, Snapshot
+from pants.engine.fs import (
+    GlobExpansionConjunction,
+    GlobMatchErrorBehavior,
+    PathGlobs,
+    Paths,
+    Snapshot,
+)
 from pants.engine.unions import UnionMembership, UnionRule, union
 from pants.option.global_options import FilesNotFoundBehavior
 from pants.source.filespec import Filespec, matches_filespec
@@ -1518,6 +1524,32 @@ class GenerateSourcesRequest(EngineAwareParameter):
 @dataclass(frozen=True)
 class GeneratedSources:
     snapshot: Snapshot
+
+
+class SourcesPaths(Paths):
+    """The resolved file names of the `sources` field.
+
+    This does not consider codegen, and only captures the files from the `sources` field.
+    """
+
+
+@dataclass(frozen=True)
+class SourcesPathsRequest(EngineAwareParameter):
+    """A request to resolve the file names of the `sources` field.
+
+    Use via `Get(SourcesPaths, SourcesPathRequest(tgt.get(Sources))`.
+
+    This is faster than `Get(HydratedSources, HydrateSourcesRequest)` because it does not snapshot
+    the files and it only resolves the file names.
+
+    This does not consider codegen, and only captures the files from the `sources` field. Use
+    `HydrateSourcesRequest` to use codegen.
+    """
+
+    field: Sources
+
+    def debug_hint(self) -> str:
+        return self.field.address.spec
 
 
 # -----------------------------------------------------------------------------------------------


### PR DESCRIPTION
We use `Paths` to avoid digesting files.

Before (25 times):

```
./pants --no-pantsd filedeps ::
            Mean        Std.Dev.    Min         Median      Max
real        3.314       0.078       3.168       3.323       3.496
user        3.783       0.081       3.676       3.758       3.989
sys         2.517       0.072       2.323       2.535       2.637
```

After (25 times):

```
./pants --no-pantsd filedeps ::
            Mean        Std.Dev.    Min         Median      Max
real        3.371       0.214       3.024       3.367       3.972
user        3.392       0.194       3.081       3.419       3.878
sys         2.054       0.111       1.840       2.043       2.272
```

[ci skip-rust]
[ci skip-build-wheels]