### PR TITLE
Rename `SourcesSnapshot` to `SpecsSnapshot`

### DIFF
--- a/src/python/pants/backend/project_info/count_loc.py
+++ b/src/python/pants/backend/project_info/count_loc.py
@@ -9,7 +9,7 @@ from pants.core.util_rules.external_tool import (
     TemplatedExternalTool,
 )
 from pants.engine.console import Console
-from pants.engine.fs import Digest, MergeDigests, SourcesSnapshot
+from pants.engine.fs import Digest, MergeDigests, SpecsSnapshot
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessResult
@@ -73,9 +73,9 @@ class CountLinesOfCode(Goal):
 async def count_loc(
     console: Console,
     succinct_code_counter: SuccinctCodeCounter,
-    sources_snapshot: SourcesSnapshot,
+    specs_snapshot: SpecsSnapshot,
 ) -> CountLinesOfCode:
-    if not sources_snapshot.snapshot.files:
+    if not specs_snapshot.snapshot.files:
         return CountLinesOfCode(exit_code=0)
 
     scc_program = await Get(
@@ -84,7 +84,7 @@ async def count_loc(
         succinct_code_counter.get_request(Platform.current),
     )
     input_digest = await Get(
-        Digest, MergeDigests((scc_program.digest, sources_snapshot.snapshot.digest))
+        Digest, MergeDigests((scc_program.digest, specs_snapshot.snapshot.digest))
     )
     result = await Get(
         ProcessResult,
@@ -92,7 +92,7 @@ async def count_loc(
             argv=(scc_program.exe, *succinct_code_counter.args),
             input_digest=input_digest,
             description=(
-                f"Count lines of code for {pluralize(len(sources_snapshot.snapshot.files), 'file')}"
+                f"Count lines of code for {pluralize(len(specs_snapshot.snapshot.files), 'file')}"
             ),
             level=LogLevel.DEBUG,
         ),

--- a/src/python/pants/backend/project_info/source_file_validator.py
+++ b/src/python/pants/backend/project_info/source_file_validator.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Set, Tuple, cast
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE
 from pants.engine.collection import Collection
 from pants.engine.console import Console
-from pants.engine.fs import Digest, DigestContents, SourcesSnapshot
+from pants.engine.fs import Digest, DigestContents, SpecsSnapshot
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.rules import Get, collect_rules, goal_rule
 from pants.option.subsystem import Subsystem
@@ -280,12 +280,12 @@ class MultiMatcher:
 @goal_rule
 async def validate(
     console: Console,
-    sources_snapshot: SourcesSnapshot,
+    specs_snapshot: SpecsSnapshot,
     validate_subsystem: ValidateSubsystem,
     source_file_validation: SourceFileValidation,
 ) -> Validate:
     multi_matcher = source_file_validation.get_multi_matcher()
-    digest_contents = await Get(DigestContents, Digest, sources_snapshot.snapshot.digest)
+    digest_contents = await Get(DigestContents, Digest, specs_snapshot.snapshot.digest)
     regex_match_results = RegexMatchResults(
         multi_matcher.check_source_file(file_content.path, file_content.content)
         for file_content in sorted(digest_contents, key=lambda fc: fc.path)

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -282,8 +282,8 @@ EMPTY_SNAPSHOT = Snapshot(EMPTY_DIGEST, files=(), dirs=())
 
 
 @dataclass(frozen=True)
-class SourcesSnapshot:
-    """Sources matched by command line specs.
+class SpecsSnapshot:
+    """All files matched by command line specs.
 
     `@goal_rule`s may request this when they only need source files to operate and do not need any
     target information. This allows running on files with no owning targets.

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -35,7 +35,7 @@ from pants.engine.fs import (
     PathGlobs,
     Paths,
     Snapshot,
-    SourcesSnapshot,
+    SpecsSnapshot,
 )
 from pants.engine.internals.target_adaptor import TargetAdaptor
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
@@ -589,8 +589,8 @@ async def resolve_addresses_with_origins(specs: Specs) -> AddressesWithOrigins:
 
 
 @rule(desc="Find all sources from input specs", level=LogLevel.DEBUG)
-async def resolve_sources_snapshot(specs: Specs, global_options: GlobalOptions) -> SourcesSnapshot:
-    """Request a snapshot for the given specs.
+async def resolve_specs_snapshot(specs: Specs, global_options: GlobalOptions) -> SpecsSnapshot:
+    """Resolve all files matching the given specs.
 
     Address specs will use their `Sources` field, and Filesystem specs will use whatever args were
     given. Filesystem specs may safely refer to files with no owning target.
@@ -620,7 +620,7 @@ async def resolve_sources_snapshot(specs: Specs, global_options: GlobalOptions) 
     if filesystem_specs_digest:
         digests.append(filesystem_specs_digest)
     result = await Get(Snapshot, MergeDigests(digests))
-    return SourcesSnapshot(result)
+    return SpecsSnapshot(result)
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -32,7 +32,7 @@ from pants.engine.fs import (
     DigestContents,
     FileContent,
     Snapshot,
-    SourcesSnapshot,
+    SpecsSnapshot,
 )
 from pants.engine.internals.graph import (
     AmbiguousCodegenImplementationsException,
@@ -454,7 +454,7 @@ def test_resolve_generated_subtarget() -> None:
     )
 
 
-def test_resolve_sources_snapshot() -> None:
+def test_resolve_specs_snapshot() -> None:
     """This tests that convert filesystem specs and/or address specs into a single snapshot.
 
     Some important edge cases:
@@ -463,15 +463,13 @@ def test_resolve_sources_snapshot() -> None:
     - If a file is covered both by an address spec and by a filesystem spec, we should merge it
       so that the file only shows up once.
     """
-    rule_runner = RuleRunner(
-        rules=[QueryRule(SourcesSnapshot, (Specs,))], target_types=[MockTarget]
-    )
+    rule_runner = RuleRunner(rules=[QueryRule(SpecsSnapshot, (Specs,))], target_types=[MockTarget])
     rule_runner.create_files("demo", ["f1.txt", "f2.txt"])
     rule_runner.add_to_build_file("demo", "target(sources=['*.txt'])")
     specs = SpecsParser(rule_runner.build_root).parse_specs(
         ["demo:demo", "demo/f1.txt", "demo/BUILD"]
     )
-    result = rule_runner.request(SourcesSnapshot, [specs])
+    result = rule_runner.request(SpecsSnapshot, [specs])
     assert result.snapshot.files == ("demo/BUILD", "demo/f1.txt", "demo/f2.txt")
 
 


### PR DESCRIPTION
We have too many types that use the name `Sources`; it's confusing what does what (https://github.com/pantsbuild/pants/pull/11113#discussion_r519196311).
 
[ci skip-rust]
[ci skip-build-wheels]