### PR TITLE
Add a specific error for target names containing slashes

### DIFF
--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -22,6 +22,14 @@ class InvalidTargetName(ValueError):
     """Indicate an invalid target name for `Address`."""
 
 
+class AmbiguousTargetName(ValueError):
+    """A specific error for the case where a target name contains a slash.
+
+    Target names containing slashes used to be supported, but slashes are now used to support file
+    addresses, and so we specifically enrich the error.
+    """
+
+
 @dataclass(frozen=True)
 class AddressInput:
     """A string that has been parsed and normalized using the Address syntax.
@@ -171,10 +179,12 @@ class AddressInput:
 
         expected_prefix = f"..{os.path.sep}" * parent_count
         if self.target_component[: self.target_component.rfind(os.path.sep) + 1] != expected_prefix:
-            raise InvalidTargetName(
-                "A target may only be defined in a directory containing a file that it owns in "
-                f"the filesystem: `{self.target_component}` is not at-or-above the file "
-                f"`{self.path_component}`."
+            raise AmbiguousTargetName(
+                "The target component `{self.target_component}` is ambiguous, because it might "
+                "represent either a target with a slash (`/`) in the name, or a target nested "
+                "inside of a directory.\n\nIf there is a target with a slash in its name, "
+                "consider replacing the slash with another separator character like `_`, or "
+                "moving the target closer to the file(s) that it owns."
             )
 
         # Split the path_component into a spec_path and relative_file_path at the appropriate

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -6,12 +6,13 @@ from dataclasses import dataclass
 from pathlib import PurePath
 from typing import Optional, Sequence
 
+from pants.base.deprecated import warn_or_error
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.util.dirutil import fast_relpath, longest_dir_prefix
 from pants.util.strutil import strip_prefix
 
 # Currently unused, but reserved for possible future needs.
-BANNED_CHARS_IN_TARGET_NAME = frozenset("@!?=")
+BANNED_CHARS_IN_TARGET_NAME = frozenset(r"@!?/\:=")
 
 
 class InvalidSpecPath(ValueError):
@@ -38,13 +39,6 @@ class AddressInput:
             if not self.target_component:
                 raise InvalidTargetName(
                     f"Address spec {self.path_component}:{self.target_component} has no name part."
-                )
-
-            banned_chars = BANNED_CHARS_IN_TARGET_NAME & set(self.target_component)
-            if banned_chars:
-                raise InvalidTargetName(
-                    f"Banned chars found in target name. {banned_chars} not allowed in target "
-                    f"name: {self.target_component}"
                 )
 
         # A root is okay.
@@ -233,10 +227,31 @@ class Address(EngineAwareParameter):
         """
         self.spec_path = spec_path
         self._relative_file_path = relative_file_path
+
         # If the target_name is the same as the default name would be, we normalize to None.
-        self._target_name = (
-            target_name if target_name and target_name != os.path.basename(self.spec_path) else None
-        )
+        self._target_name: Optional[str]
+        if target_name and target_name != os.path.basename(self.spec_path):
+            banned_chars = BANNED_CHARS_IN_TARGET_NAME & set(target_name)
+            deprecated_banned_chars = banned_chars & set(r"/\:")
+            if deprecated_banned_chars:
+                warn_or_error(
+                    removal_version="2.2.0.dev1",
+                    deprecated_entity_description=r"Using any of the `\`, `/`, or `:` characters in a target name.",
+                    hint=(
+                        "The target name {target_name}, defined in directory {self.spec_path} "
+                        "contains deprecated characters (`{banned_chars}`). Please replace these "
+                        "characters with another separator character like `_` or `-`."
+                    ),
+                )
+            elif banned_chars:
+                raise InvalidTargetName(
+                    f"Banned chars found in target name. {banned_chars} not allowed in target "
+                    f"name: {target_name}"
+                )
+            self._target_name = target_name
+        else:
+            self._target_name = None
+
         self._hash = hash((self.spec_path, self._relative_file_path, self._target_name))
         if PurePath(spec_path).name.startswith("BUILD"):
             raise InvalidSpecPath(

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -22,14 +22,6 @@ class InvalidTargetName(ValueError):
     """Indicate an invalid target name for `Address`."""
 
 
-class AmbiguousTargetName(ValueError):
-    """A specific error for the case where a target name contains a slash.
-
-    Target names containing slashes used to be supported, but slashes are now used to support file
-    addresses, and so we specifically enrich the error.
-    """
-
-
 @dataclass(frozen=True)
 class AddressInput:
     """A string that has been parsed and normalized using the Address syntax.
@@ -179,12 +171,10 @@ class AddressInput:
 
         expected_prefix = f"..{os.path.sep}" * parent_count
         if self.target_component[: self.target_component.rfind(os.path.sep) + 1] != expected_prefix:
-            raise AmbiguousTargetName(
-                "The target component `{self.target_component}` is ambiguous, because it might "
-                "represent either a target with a slash (`/`) in the name, or a target nested "
-                "inside of a directory.\n\nIf there is a target with a slash in its name, "
-                "consider replacing the slash with another separator character like `_`, or "
-                "moving the target closer to the file(s) that it owns."
+            raise InvalidTargetName(
+                "A target may only be defined in a directory containing a file that it owns in "
+                f"the filesystem: `{self.target_component}` is not at-or-above the file "
+                f"`{self.path_component}`."
             )
 
         # Split the path_component into a spec_path and relative_file_path at the appropriate

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -236,17 +236,21 @@ class Address(EngineAwareParameter):
             if deprecated_banned_chars:
                 warn_or_error(
                     removal_version="2.2.0.dev1",
-                    deprecated_entity_description=r"Using any of the `\`, `/`, or `:` characters in a target name.",
+                    deprecated_entity_description=(
+                        r"Using any of the `\`, `/`, or `:` characters in a target name."
+                    ),
                     hint=(
-                        "The target name {target_name}, defined in directory {self.spec_path} "
-                        "contains deprecated characters (`{banned_chars}`). Please replace these "
-                        "characters with another separator character like `_` or `-`."
+                        f"The target name {target_name} (defined in directory {self.spec_path}) "
+                        f"contains deprecated characters (`{deprecated_banned_chars}`), which will "
+                        "cause some usecases to fail. Please replace these characters with another "
+                        "separator character like `_` or `-`."
                     ),
                 )
             elif banned_chars:
                 raise InvalidTargetName(
-                    f"Banned chars found in target name. {banned_chars} not allowed in target "
-                    f"name: {target_name}"
+                    f"The target name {target_name} (defined in directory {self.spec_path}) "
+                    f"contains banned characters (`{banned_chars}`). Please replace these "
+                    "characters with another separator character like `_` or `-`."
                 )
             self._target_name = target_name
         else:

--- a/src/python/pants/build_graph/address_test.py
+++ b/src/python/pants/build_graph/address_test.py
@@ -5,7 +5,13 @@ from typing import Optional
 
 import pytest
 
-from pants.build_graph.address import Address, AddressInput, InvalidSpecPath, InvalidTargetName
+from pants.build_graph.address import (
+    Address,
+    AddressInput,
+    AmbiguousTargetName,
+    InvalidSpecPath,
+    InvalidTargetName,
+)
 
 
 def assert_address_input_parsed(
@@ -177,11 +183,11 @@ def test_address_input_from_file() -> None:
     ).file_to_address() == Address("", target_name="original", relative_file_path="a/b/c.txt")
 
     # These refer to targets "below" the file, which is illegal.
-    with pytest.raises(InvalidTargetName):
+    with pytest.raises(AmbiguousTargetName):
         AddressInput("f.txt", target_component="subdir/tgt").file_to_address()
-    with pytest.raises(InvalidTargetName):
+    with pytest.raises(AmbiguousTargetName):
         AddressInput("f.txt", target_component="subdir../tgt").file_to_address()
-    with pytest.raises(InvalidTargetName):
+    with pytest.raises(AmbiguousTargetName):
         AddressInput("a/f.txt", target_component="../a/original").file_to_address()
 
     # Top-level files must include a target_name.

--- a/src/python/pants/build_graph/address_test.py
+++ b/src/python/pants/build_graph/address_test.py
@@ -1,6 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import warnings
 from typing import Optional
 
 import pytest
@@ -93,10 +94,10 @@ def test_address_input_parse_bad_path_component() -> None:
     assert_bad_path_component("///a")
 
 
-def test_address_input_parse_bad_target_component() -> None:
+def test_address_bad_target_component() -> None:
     def assert_bad_target_component(spec: str) -> None:
         with pytest.raises(InvalidTargetName):
-            repr(AddressInput.parse(spec))
+            repr(AddressInput.parse(spec).dir_to_address())
 
     # Missing target_component
     assert_bad_target_component("")
@@ -110,6 +111,12 @@ def test_address_input_parse_bad_target_component() -> None:
     assert_bad_target_component("//:!t")
     assert_bad_target_component("//:?t")
     assert_bad_target_component("//:=t")
+
+    # Deprecated banned chars. This should convert into an error in `2.2.0.dev1`.
+    with warnings.catch_warnings(record=True) as w:
+        AddressInput.parse(r"a:b\c").dir_to_address()
+        assert len(w) == 1
+        assert "deprecated" in str(w[0].message)
 
 
 def test_subproject_spec() -> None:

--- a/src/python/pants/build_graph/address_test.py
+++ b/src/python/pants/build_graph/address_test.py
@@ -5,13 +5,7 @@ from typing import Optional
 
 import pytest
 
-from pants.build_graph.address import (
-    Address,
-    AddressInput,
-    AmbiguousTargetName,
-    InvalidSpecPath,
-    InvalidTargetName,
-)
+from pants.build_graph.address import Address, AddressInput, InvalidSpecPath, InvalidTargetName
 
 
 def assert_address_input_parsed(
@@ -183,11 +177,11 @@ def test_address_input_from_file() -> None:
     ).file_to_address() == Address("", target_name="original", relative_file_path="a/b/c.txt")
 
     # These refer to targets "below" the file, which is illegal.
-    with pytest.raises(AmbiguousTargetName):
+    with pytest.raises(InvalidTargetName):
         AddressInput("f.txt", target_component="subdir/tgt").file_to_address()
-    with pytest.raises(AmbiguousTargetName):
+    with pytest.raises(InvalidTargetName):
         AddressInput("f.txt", target_component="subdir../tgt").file_to_address()
-    with pytest.raises(AmbiguousTargetName):
+    with pytest.raises(InvalidTargetName):
         AddressInput("a/f.txt", target_component="../a/original").file_to_address()
 
     # Top-level files must include a target_name.


### PR DESCRIPTION
### Problem

Having slashes (`/`) in target names used to be implicitly supported, but the new file address syntax in `2.0.x` makes having a slash in a target name ambiguous:
```
# Could refer either to a target named "with/a/target", or a target named "target" in a directory "with/a".
this/is/a/file.txt:../../with/a/target
```

### Solution

We believe that it should be possible to safely rename all targets with slashes in their names, and we think that the file address syntax is worth keeping. So this change deprecates including the relevant characters in target names.

### Result

Fixes #11106.

[ci skip-rust]
[ci skip-build-wheels]