### PR TITLE
Fix logs for `test`, `lint`, `fmt`, and `typecheck` to always print, even if cached (Cherry-pick of #11111)

### DIFF
--- a/src/python/pants/backend/python/lint/python_fmt.py
+++ b/src/python/pants/backend/python/lint/python_fmt.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Iterable, List, Type
 
 from pants.backend.python.target_types import PythonSources
-from pants.core.goals.fmt import FmtResult, LanguageFmtResults, LanguageFmtTargets
+from pants.core.goals.fmt import EnrichedFmtResult, LanguageFmtResults, LanguageFmtTargets
 from pants.core.goals.style_request import StyleRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, Snapshot
@@ -33,13 +33,13 @@ async def format_python_target(
     )
     prior_formatter_result = original_sources.snapshot
 
-    results: List[FmtResult] = []
+    results: List[EnrichedFmtResult] = []
     fmt_request_types: Iterable[Type[PythonFmtRequest]] = union_membership.union_rules[
         PythonFmtRequest
     ]
     for fmt_request_type in fmt_request_types:
         result = await Get(
-            FmtResult,
+            EnrichedFmtResult,
             PythonFmtRequest,
             fmt_request_type(
                 (

--- a/src/python/pants/backend/python/lint/python_fmt_integration_test.py
+++ b/src/python/pants/backend/python/lint/python_fmt_integration_test.py
@@ -9,7 +9,7 @@ from pants.backend.python.lint.black.rules import rules as black_rules
 from pants.backend.python.lint.isort.rules import rules as isort_rules
 from pants.backend.python.lint.python_fmt import PythonFmtTargets, format_python_target
 from pants.backend.python.target_types import PythonLibrary
-from pants.core.goals.fmt import LanguageFmtResults
+from pants.core.goals.fmt import LanguageFmtResults, enrich_fmt_result
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.target import Targets
@@ -20,6 +20,7 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
+            enrich_fmt_result,
             format_python_target,
             *black_rules(),
             *isort_rules(),

--- a/src/python/pants/core/goals/fmt_test.py
+++ b/src/python/pants/core/goals/fmt_test.py
@@ -7,6 +7,7 @@ from textwrap import dedent
 from typing import ClassVar, List, Optional, Type, cast
 
 from pants.core.goals.fmt import (
+    EnrichedFmtResult,
     Fmt,
     FmtResult,
     FmtSubsystem,
@@ -266,14 +267,14 @@ class FmtTest(TestBase):
 
 
 def test_streaming_output_skip() -> None:
-    result = FmtResult.skip(formatter_name="formatter")
+    result = EnrichedFmtResult.skip(formatter_name="formatter")
     assert result.level() == LogLevel.DEBUG
-    assert result.message() == "skipped."
+    assert result.message() == "formatter skipped."
 
 
 def test_streaming_output_changed() -> None:
     changed_digest = Digest(EMPTY_DIGEST.fingerprint, 2)
-    result = FmtResult(
+    result = EnrichedFmtResult(
         input=EMPTY_DIGEST,
         output=changed_digest,
         stdout="stdout",
@@ -283,7 +284,7 @@ def test_streaming_output_changed() -> None:
     assert result.level() == LogLevel.WARN
     assert result.message() == dedent(
         """\
-        made changes.
+        formatter made changes.
         stdout
         stderr
 
@@ -292,7 +293,7 @@ def test_streaming_output_changed() -> None:
 
 
 def test_streaming_output_not_changed() -> None:
-    result = FmtResult(
+    result = EnrichedFmtResult(
         input=EMPTY_DIGEST,
         output=EMPTY_DIGEST,
         stdout="stdout",
@@ -302,7 +303,7 @@ def test_streaming_output_not_changed() -> None:
     assert result.level() == LogLevel.INFO
     assert result.message() == dedent(
         """\
-        made no changes.
+        formatter made no changes.
         stdout
         stderr
 

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -17,7 +17,7 @@ from pants.engine.engine_aware import EngineAwareReturnType
 from pants.engine.fs import Digest, MergeDigests, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import FallibleProcessResult
-from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
+from pants.engine.rules import Get, MultiGet, _uncacheable_rule, collect_rules, goal_rule
 from pants.engine.target import Targets
 from pants.engine.unions import UnionMembership, union
 from pants.util.logging import LogLevel
@@ -69,7 +69,7 @@ class LintResult:
 
 @frozen_after_init
 @dataclass(unsafe_hash=True)
-class LintResults(EngineAwareReturnType):
+class LintResults:
     """Zero or more LintResult objects for a single linter.
 
     Typically, linters will return one result. If they no-oped, they will return zero results.
@@ -96,6 +96,14 @@ class LintResults(EngineAwareReturnType):
     def reports(self) -> Tuple[LintReport, ...]:
         return tuple(result.report for result in self.results if result.report)
 
+
+class EnrichedLintResults(LintResults, EngineAwareReturnType):
+    """`LintResults` that are enriched for the sake of logging results as they come in.
+
+    Plugin authors only need to return `LintResults`, and a rule will upcast those into
+    `EnrichedLintResults`.
+    """
+
     def level(self) -> Optional[LogLevel]:
         if self.skipped:
             return LogLevel.DEBUG
@@ -103,8 +111,11 @@ class LintResults(EngineAwareReturnType):
 
     def message(self) -> Optional[str]:
         if self.skipped:
-            return "skipped."
-        message = "succeeded." if self.exit_code == 0 else f"failed (exit code {self.exit_code})."
+            return f"{self.linter_name} skipped."
+        message = self.linter_name
+        message += (
+            " succeeded." if self.exit_code == 0 else f" failed (exit code {self.exit_code})."
+        )
 
         def msg_for_result(result: LintResult) -> str:
             msg = ""
@@ -238,19 +249,19 @@ async def lint(
 
     if lint_subsystem.per_file_caching:
         all_per_file_results = await MultiGet(
-            Get(LintResults, LintRequest, request.__class__([field_set]))
+            Get(EnrichedLintResults, LintRequest, request.__class__([field_set]))
             for request in valid_requests
             for field_set in request.field_sets
         )
 
-        def key_fn(results: LintResults):
+        def key_fn(results: EnrichedLintResults):
             return results.linter_name
 
         # NB: We must pre-sort the data for itertools.groupby() to work properly.
         sorted_all_per_files_results = sorted(all_per_file_results, key=key_fn)
         # We consolidate all results for each linter into a single `LintResults`.
         all_results = tuple(
-            LintResults(
+            EnrichedLintResults(
                 itertools.chain.from_iterable(
                     per_file_results.results for per_file_results in all_linter_results
                 ),
@@ -262,7 +273,7 @@ async def lint(
         )
     else:
         all_results = await MultiGet(
-            Get(LintResults, LintRequest, lint_request) for lint_request in valid_requests
+            Get(EnrichedLintResults, LintRequest, lint_request) for lint_request in valid_requests
         )
 
     all_results = tuple(sorted(all_results, key=lambda results: results.linter_name))
@@ -308,6 +319,13 @@ async def lint(
         console.print_stderr(f"{sigil} {results.linter_name} {status}.")
 
     return Lint(exit_code)
+
+
+# NB: We mark this uncachable to ensure that the results are always streamed, even if the
+# underlying LintResults is memoized. This rule is very cheap, so there's little performance hit.
+@_uncacheable_rule(desc="lint")
+def enrich_lint_results(results: LintResults) -> EnrichedLintResults:
+    return EnrichedLintResults(results=results.results, linter_name=results.linter_name)
 
 
 def rules():


### PR DESCRIPTION
[ci skip-rust]