### PR TITLE
Modernize `scheduler_test.py` and `process_test.py`

### DIFF
--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -991,7 +991,7 @@ def setup_codegen_protocol_tgt(rule_runner: RuleRunner) -> Address:
     return Address("src/avro", target_name="lib")
 
 
-def test_generate_sources(codegen_rule_runner: RuleRunner) -> None:
+def test_codegen_generates_sources(codegen_rule_runner: RuleRunner) -> None:
     addr = setup_codegen_protocol_tgt(codegen_rule_runner)
     protocol_sources = AvroSources(["*.avro"], address=addr)
     assert (
@@ -1026,7 +1026,7 @@ def test_generate_sources(codegen_rule_runner: RuleRunner) -> None:
     assert generated_via_hydrate_sources.sources_type == SmalltalkSources
 
 
-def test_works_with_subclass_fields(codegen_rule_runner: RuleRunner) -> None:
+def test_codegen_works_with_subclass_fields(codegen_rule_runner: RuleRunner) -> None:
     addr = setup_codegen_protocol_tgt(codegen_rule_runner)
 
     class CustomAvroSources(AvroSources):
@@ -1048,7 +1048,7 @@ def test_works_with_subclass_fields(codegen_rule_runner: RuleRunner) -> None:
     assert generated.snapshot.files == ("src/smalltalk/f.st",)
 
 
-def test_cannot_generate_language(codegen_rule_runner: RuleRunner) -> None:
+def test_codegen_cannot_generate_language(codegen_rule_runner: RuleRunner) -> None:
     addr = setup_codegen_protocol_tgt(codegen_rule_runner)
 
     class AdaSources(Sources):

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -77,7 +77,6 @@ from pants.engine.target import (
 from pants.engine.unions import UnionMembership, UnionRule, union
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
-from pants.testutil.test_base import TestBase
 from pants.util.ordered_set import FrozenOrderedSet
 
 
@@ -793,7 +792,7 @@ def test_find_valid_field_sets() -> None:
 
 
 # -----------------------------------------------------------------------------------------------
-# Test the Sources field, including codegen. Also see `engine/target_test.py`.
+# Test the Sources field. Also see `engine/target_test.py`.
 # -----------------------------------------------------------------------------------------------
 
 
@@ -933,6 +932,11 @@ def test_sources_expected_num_files(sources_rule_runner: RuleRunner) -> None:
     )
 
 
+# -----------------------------------------------------------------------------------------------
+# Test codegen. Also see `engine/target_test.py`.
+# -----------------------------------------------------------------------------------------------
+
+
 class SmalltalkSources(Sources):
     pass
 
@@ -970,97 +974,102 @@ async def generate_smalltalk_from_avro(
     return GeneratedSources(result)
 
 
-class TestCodegen(TestBase):
-    @classmethod
-    def rules(cls):
-        return (
-            *super().rules(),
+@pytest.fixture
+def codegen_rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
             generate_smalltalk_from_avro,
-            QueryRule(UnionMembership, ()),
-            QueryRule(HydratedSources, (HydrateSourcesRequest,)),
-            QueryRule(GeneratedSources, (GenerateSmalltalkFromAvroRequest,)),
+            QueryRule(UnionMembership, []),
+            QueryRule(HydratedSources, [HydrateSourcesRequest]),
+            QueryRule(GeneratedSources, [GenerateSmalltalkFromAvroRequest]),
             UnionRule(GenerateSourcesRequest, GenerateSmalltalkFromAvroRequest),
-        )
+        ],
+        target_types=[AvroLibrary],
+    )
 
-    @classmethod
-    def target_types(cls):
-        return [AvroLibrary]
 
-    def setUp(self) -> None:
-        self.address = Address("src/avro", target_name="lib")
-        self.create_files("src/avro", files=["f.avro"])
-        self.add_to_build_file("src/avro", "avro_library(name='lib', sources=['*.avro'])")
-        self.union_membership = self.request(UnionMembership, [])
+def setup_codegen_protocol_tgt(rule_runner: RuleRunner) -> Address:
+    rule_runner.create_files("src/avro", files=["f.avro"])
+    rule_runner.add_to_build_file("src/avro", "avro_library(name='lib', sources=['*.avro'])")
+    return Address("src/avro", target_name="lib")
 
-    def test_generate_sources(self) -> None:
-        bootstrapper = create_options_bootstrapper()
-        protocol_sources = AvroSources(["*.avro"], address=self.address)
-        assert protocol_sources.can_generate(SmalltalkSources, self.union_membership) is True
 
-        # First, get the original protocol sources.
-        hydrated_protocol_sources = self.request(
-            HydratedSources, [HydrateSourcesRequest(protocol_sources), bootstrapper]
-        )
-        assert hydrated_protocol_sources.snapshot.files == ("src/avro/f.avro",)
+def test_generate_sources(codegen_rule_runner: RuleRunner) -> None:
+    addr = setup_codegen_protocol_tgt(codegen_rule_runner)
+    bootstrapper = create_options_bootstrapper()
+    protocol_sources = AvroSources(["*.avro"], address=addr)
+    assert protocol_sources.can_generate(SmalltalkSources, codegen_rule_runner.union_membership) is True
 
-        # Test directly feeding the protocol sources into the codegen rule.
-        tgt = self.request(WrappedTarget, [self.address, bootstrapper]).target
-        generated_sources = self.request(
-            GeneratedSources,
-            [
-                GenerateSmalltalkFromAvroRequest(hydrated_protocol_sources.snapshot, tgt),
-                bootstrapper,
-            ],
-        )
-        assert generated_sources.snapshot.files == ("src/smalltalk/f.st",)
+    # First, get the original protocol sources.
+    hydrated_protocol_sources = codegen_rule_runner.request(
+        HydratedSources, [HydrateSourcesRequest(protocol_sources), bootstrapper]
+    )
+    assert hydrated_protocol_sources.snapshot.files == ("src/avro/f.avro",)
 
-        # Test that HydrateSourcesRequest can also be used.
-        generated_via_hydrate_sources = self.request(
-            HydratedSources,
-            [
-                HydrateSourcesRequest(
-                    protocol_sources, for_sources_types=[SmalltalkSources], enable_codegen=True
-                ),
-                bootstrapper,
-            ],
-        )
-        assert generated_via_hydrate_sources.snapshot.files == ("src/smalltalk/f.st",)
-        assert generated_via_hydrate_sources.sources_type == SmalltalkSources
+    # Test directly feeding the protocol sources into the codegen rule.
+    tgt = codegen_rule_runner.request(WrappedTarget, [addr, bootstrapper]).target
+    generated_sources = codegen_rule_runner.request(
+        GeneratedSources,
+        [
+            GenerateSmalltalkFromAvroRequest(hydrated_protocol_sources.snapshot, tgt),
+            bootstrapper,
+        ],
+    )
+    assert generated_sources.snapshot.files == ("src/smalltalk/f.st",)
 
-    def test_works_with_subclass_fields(self) -> None:
-        class CustomAvroSources(AvroSources):
-            pass
+    # Test that HydrateSourcesRequest can also be used.
+    generated_via_hydrate_sources = codegen_rule_runner.request(
+        HydratedSources,
+        [
+            HydrateSourcesRequest(
+                protocol_sources, for_sources_types=[SmalltalkSources], enable_codegen=True
+            ),
+            bootstrapper,
+        ],
+    )
+    assert generated_via_hydrate_sources.snapshot.files == ("src/smalltalk/f.st",)
+    assert generated_via_hydrate_sources.sources_type == SmalltalkSources
 
-        protocol_sources = CustomAvroSources(["*.avro"], address=self.address)
-        assert protocol_sources.can_generate(SmalltalkSources, self.union_membership) is True
-        generated = self.request(
-            HydratedSources,
-            [
-                HydrateSourcesRequest(
-                    protocol_sources, for_sources_types=[SmalltalkSources], enable_codegen=True
-                ),
-                create_options_bootstrapper(),
-            ],
-        )
-        assert generated.snapshot.files == ("src/smalltalk/f.st",)
 
-    def test_cannot_generate_language(self) -> None:
-        class AdaSources(Sources):
-            pass
+def test_works_with_subclass_fields(codegen_rule_runner: RuleRunner) -> None:
+    addr = setup_codegen_protocol_tgt(codegen_rule_runner)
 
-        protocol_sources = AvroSources(["*.avro"], address=self.address)
-        assert protocol_sources.can_generate(AdaSources, self.union_membership) is False
-        generated = self.request(
-            HydratedSources,
-            [
-                HydrateSourcesRequest(
-                    protocol_sources, for_sources_types=[AdaSources], enable_codegen=True
-                ),
-                create_options_bootstrapper(),
-            ],
-        )
-        assert generated.snapshot.files == ()
-        assert generated.sources_type is None
+    class CustomAvroSources(AvroSources):
+        pass
+
+    protocol_sources = CustomAvroSources(["*.avro"], address=addr)
+    assert protocol_sources.can_generate(SmalltalkSources, codegen_rule_runner.union_membership) is True
+    generated = codegen_rule_runner.request(
+        HydratedSources,
+        [
+            HydrateSourcesRequest(
+                protocol_sources, for_sources_types=[SmalltalkSources], enable_codegen=True
+            ),
+            create_options_bootstrapper(),
+        ],
+    )
+    assert generated.snapshot.files == ("src/smalltalk/f.st",)
+
+
+def test_cannot_generate_language(codegen_rule_runner: RuleRunner) -> None:
+    addr = setup_codegen_protocol_tgt(codegen_rule_runner)
+
+    class AdaSources(Sources):
+        pass
+
+    protocol_sources = AvroSources(["*.avro"], address=addr)
+    assert protocol_sources.can_generate(AdaSources, codegen_rule_runner.union_membership) is False
+    generated = codegen_rule_runner.request(
+        HydratedSources,
+        [
+            HydrateSourcesRequest(
+                protocol_sources, for_sources_types=[AdaSources], enable_codegen=True
+            ),
+            create_options_bootstrapper(),
+        ],
+    )
+    assert generated.snapshot.files == ()
+    assert generated.sources_type is None
 
 
 def test_ambiguous_codegen_implementations_exception() -> None:

--- a/src/python/pants/engine/process_test.py
+++ b/src/python/pants/engine/process_test.py
@@ -2,19 +2,10 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-from dataclasses import dataclass
 
 import pytest
 
-from pants.engine.fs import (
-    EMPTY_DIGEST,
-    CreateDigest,
-    Digest,
-    DigestContents,
-    FileContent,
-    PathGlobs,
-    Snapshot,
-)
+from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, DigestContents, FileContent
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.process import (
     BinaryPathRequest,
@@ -24,10 +15,8 @@ from pants.engine.process import (
     Process,
     ProcessResult,
 )
-from pants.engine.rules import Get, rule
 from pants.testutil.rule_runner import QueryRule, RuleRunner
-from pants.testutil.test_base import TestBase
-from pants.util.contextutil import temporary_dir
+from pants.util.contextutil import environment_as, temporary_dir
 from pants.util.dirutil import safe_mkdir, touch
 
 
@@ -36,253 +25,106 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             QueryRule(BinaryPaths, [BinaryPathRequest]),
+            QueryRule(ProcessResult, [Process]),
+            QueryRule(FallibleProcessResult, [Process]),
         ],
     )
 
 
-@dataclass(frozen=True)
-class Concatted:
-    value: str
+def test_argv_executable(rule_runner: RuleRunner) -> None:
+    def run_process(*, is_executable: bool) -> ProcessResult:
+        digest = rule_runner.request(
+            Digest,
+            [
+                CreateDigest(
+                    [
+                        FileContent(
+                            "echo.sh",
+                            b'#!/bin/bash -eu\necho "Hello"\n',
+                            is_executable=is_executable,
+                        )
+                    ]
+                )
+            ],
+        )
+        process = Process(
+            argv=("./echo.sh",),
+            input_digest=digest,
+            description="cat the contents of this file",
+        )
+        return rule_runner.request(ProcessResult, [process])
+
+    assert run_process(is_executable=True).stdout == b"Hello\n"
+
+    with pytest.raises(ExecutionError) as exc:
+        run_process(is_executable=False)
+    assert "Permission" in str(exc.value)
 
 
-@dataclass(frozen=True)
-class BinaryLocation:
-    bin_path: str
-
-    def __post_init__(self):
-        if not os.path.isfile(self.bin_path) or not os.access(self.bin_path, os.X_OK):
-            raise ValueError(f"path {self.bin_path} does not name an existing executable file.")
-
-
-@dataclass(frozen=True)
-class ShellCat:
-    """Wrapper class to show an example of using an auxiliary class (which wraps an executable) to
-    generate an argv instead of doing it all in CatExecutionRequest.
-
-    This can be used to encapsulate operations such as sanitizing command-line arguments which are
-    specific to the executable, which can reduce boilerplate for generating Process instances if the
-    executable is used in different ways across multiple different types of process execution
-    requests.
-    """
-
-    binary_location: BinaryLocation
-
-    @property
-    def bin_path(self):
-        return self.binary_location.bin_path
-
-    def argv_from_snapshot(self, snapshot):
-        cat_file_paths = snapshot.files
-
-        option_like_files = [p for p in cat_file_paths if p.startswith("-")]
-        if option_like_files:
-            raise ValueError(
-                f"invalid file names: '{option_like_files}' look like command-line options"
-            )
-
-        # Add /dev/null to the list of files, so that cat doesn't hang forever if no files are in the
-        # Snapshot.
-        return (self.bin_path, "/dev/null") + tuple(cat_file_paths)
+def test_env(rule_runner: RuleRunner) -> None:
+    with environment_as(VAR1="VAL"):
+        process = Process(argv=("/usr/bin/env",), description="", env={"VAR2": "VAL"})
+        result = rule_runner.request(ProcessResult, [process])
+    assert b"VAR1=VAL" not in result.stdout
+    assert b"VAR2=VAL" in result.stdout
 
 
-@dataclass(frozen=True)
-class CatExecutionRequest:
-    shell_cat: ShellCat
-    path_globs: PathGlobs
-
-
-@rule
-async def cat_files_process_result_concatted(cat_exe_req: CatExecutionRequest) -> Concatted:
-    cat_bin = cat_exe_req.shell_cat
-    cat_files_snapshot = await Get(Snapshot, PathGlobs, cat_exe_req.path_globs)
+def test_output_digest(rule_runner: RuleRunner) -> None:
     process = Process(
-        argv=cat_bin.argv_from_snapshot(cat_files_snapshot),
-        input_digest=cat_files_snapshot.digest,
-        description="cat some files",
+        argv=("/bin/bash", "-c", "echo -n 'European Burmese' > roland"),
+        description="echo roland",
+        output_files=("roland",),
     )
-    cat_process_result = await Get(ProcessResult, Process, process)
-    return Concatted(cat_process_result.stdout.decode())
+    result = rule_runner.request(ProcessResult, [process])
+    assert result.output_digest == Digest(
+        fingerprint="63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16",
+        serialized_bytes_length=80,
+    )
+
+    digest_contents = rule_runner.request(DigestContents, [result.output_digest])
+    assert digest_contents == DigestContents([FileContent("roland", b"European Burmese", False)])
 
 
-def cat_stdout_rules():
-    return [cat_files_process_result_concatted, QueryRule(Concatted, (CatExecutionRequest,))]
+def test_timeout(rule_runner: RuleRunner) -> None:
+    process = Process(
+        argv=("/bin/bash", "-c", "/bin/sleep 0.2; /bin/echo -n 'European Burmese'"),
+        timeout_seconds=0.1,
+        description="sleepy-cat",
+    )
+    result = rule_runner.request(FallibleProcessResult, [process])
+    assert result.exit_code != 0
+    assert b"Exceeded timeout" in result.stdout
+    assert b"sleepy-cat" in result.stdout
 
 
-class TestInputFileCreation(TestBase):
-    @classmethod
-    def rules(cls):
-        return (
-            *super().rules(),
-            QueryRule(ProcessResult, (Process,)),
-            QueryRule(FallibleProcessResult, (Process,)),
-        )
+def test_failing_process(rule_runner: RuleRunner) -> None:
+    process = Process(argv=("/bin/bash", "-c", "exit 1"), description="failure")
+    result = rule_runner.request(FallibleProcessResult, [process])
+    assert result.exit_code == 1
 
-    def test_input_file_creation(self):
-        file_name = "some.filename"
-        file_contents = b"some file contents"
-
-        digest = self.request(
-            Digest, [CreateDigest([FileContent(path=file_name, content=file_contents)])]
-        )
-        req = Process(
-            argv=("/bin/cat", file_name),
-            input_digest=digest,
-            description="cat the contents of this file",
-        )
-
-        result = self.request(ProcessResult, [req])
-        self.assertEqual(result.stdout, file_contents)
-
-    def test_multiple_file_creation(self):
-        digest = self.request(
-            Digest,
-            [
-                CreateDigest(
-                    (
-                        FileContent(path="a.txt", content=b"hello"),
-                        FileContent(path="b.txt", content=b"goodbye"),
-                    )
-                )
-            ],
-        )
-
-        req = Process(
-            argv=("/bin/cat", "a.txt", "b.txt"),
-            input_digest=digest,
-            description="cat the contents of this file",
-        )
-
-        result = self.request(ProcessResult, [req])
-        self.assertEqual(result.stdout, b"hellogoodbye")
-
-    def test_file_in_directory_creation(self):
-        path = "somedir/filename"
-        content = b"file contents"
-
-        digest = self.request(Digest, [CreateDigest([FileContent(path=path, content=content)])])
-        req = Process(
-            argv=("/bin/cat", "somedir/filename"),
-            input_digest=digest,
-            description="Cat a file in a directory to make sure that doesn't break",
-        )
-
-        result = self.request(ProcessResult, [req])
-        self.assertEqual(result.stdout, content)
-
-    def test_not_executable(self):
-        file_name = "echo.sh"
-        file_contents = b'#!/bin/bash -eu\necho "Hello"\n'
-
-        digest = self.request(
-            Digest, [CreateDigest([FileContent(path=file_name, content=file_contents)])]
-        )
-        req = Process(
-            argv=("./echo.sh",),
-            input_digest=digest,
-            description="cat the contents of this file",
-        )
-
-        with pytest.raises(ExecutionError) as exc:
-            self.request(ProcessResult, [req])
-        assert "Permission" in str(exc.value)
-
-    def test_executable(self):
-        file_name = "echo.sh"
-        file_contents = b'#!/bin/bash -eu\necho "Hello"\n'
-
-        digest = self.request(
-            Digest,
-            [
-                CreateDigest(
-                    [FileContent(path=file_name, content=file_contents, is_executable=True)]
-                )
-            ],
-        )
-        req = Process(
-            argv=("./echo.sh",),
-            input_digest=digest,
-            description="cat the contents of this file",
-        )
-
-        result = self.request(ProcessResult, [req])
-        self.assertEqual(result.stdout, b"Hello\n")
+    with pytest.raises(ExecutionError) as exc:
+        rule_runner.request(ProcessResult, [process])
+    assert "Process 'failure' failed with exit code 1." in str(exc.value)
 
 
-class ProcessTest(TestBase):
-    @classmethod
-    def rules(cls):
-        return (
-            *super().rules(),
-            *cat_stdout_rules(),
-            QueryRule(ProcessResult, (Process,)),
-            QueryRule(FallibleProcessResult, (Process,)),
-        )
+# TODO: Move to fs_test.py.
+def test_create_files(rule_runner: RuleRunner) -> None:
+    files = [FileContent("a.txt", b"hello"), FileContent("somedir/b.txt", b"goodbye")]
+    digest = rule_runner.request(
+        Digest,
+        [CreateDigest(files)],
+    )
 
-    def test_env(self):
-        req = Process(argv=("foo",), description="Some process", env={"VAR": "VAL"})
-        assert dict(req.env) == {"VAR": "VAL"}
-
-    def test_integration_concat_with_snapshots_stdout(self):
-        self.create_file("f1", "one\n")
-        self.create_file("f2", "two\n")
-
-        cat_exe_req = CatExecutionRequest(
-            ShellCat(BinaryLocation("/bin/cat")),
-            PathGlobs(["f*"]),
-        )
-
-        concatted = self.request(Concatted, [cat_exe_req])
-        self.assertEqual(Concatted("one\ntwo\n"), concatted)
-
-    def test_write_file(self):
-        request = Process(
-            argv=("/bin/bash", "-c", "echo -n 'European Burmese' > roland"),
-            description="echo roland",
-            output_files=("roland",),
-        )
-
-        process_result = self.request(ProcessResult, [request])
-
-        self.assertEqual(
-            process_result.output_digest,
-            Digest(
-                fingerprint="63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16",
-                serialized_bytes_length=80,
-            ),
-        )
-
-        digest_contents = self.request(DigestContents, [process_result.output_digest])
-        assert digest_contents == DigestContents(
-            [FileContent("roland", b"European Burmese", False)]
-        )
-
-    def test_timeout(self):
-        request = Process(
-            argv=("/bin/bash", "-c", "/bin/sleep 0.2; /bin/echo -n 'European Burmese'"),
-            timeout_seconds=0.1,
-            description="sleepy-cat",
-        )
-        result = self.request(FallibleProcessResult, [request])
-        self.assertNotEqual(result.exit_code, 0)
-        self.assertIn(b"Exceeded timeout", result.stdout)
-        self.assertIn(b"sleepy-cat", result.stdout)
-
-    def test_fallible_failing_command_returns_exited_result(self):
-        request = Process(argv=("/bin/bash", "-c", "exit 1"), description="one-cat")
-
-        result = self.request(FallibleProcessResult, [request])
-
-        self.assertEqual(result.exit_code, 1)
-
-    def test_non_fallible_failing_command_raises(self):
-        request = Process(argv=("/bin/bash", "-c", "exit 1"), description="one-cat")
-
-        with self.assertRaises(ExecutionError) as cm:
-            self.request(ProcessResult, [request])
-        assert "Process 'one-cat' failed with exit code 1." in str(cm.exception)
+    process = Process(
+        argv=("/bin/cat", "a.txt", "somedir/b.txt"),
+        input_digest=digest,
+        description="",
+    )
+    result = rule_runner.request(ProcessResult, [process])
+    assert result.stdout == b"hellogoodbye"
 
 
-def test_running_interactive_process_in_workspace_cannot_have_input_files() -> None:
+def test_interactive_process_cannot_have_input_files_and_workspace() -> None:
     mock_digest = Digest(EMPTY_DIGEST.fingerprint, 1)
     with pytest.raises(ValueError):
         InteractiveProcess(argv=["/bin/echo"], input_digest=mock_digest, run_in_workspace=True)

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -97,7 +97,8 @@ class RuleRunner:
             *(rules or ()),
             *source_root.rules(),
             *pants_environment.rules(),
-            QueryRule(WrappedTarget, (Address,)),
+            QueryRule(WrappedTarget, [Address]),
+            QueryRule(UnionMembership, []),
         )
         build_config_builder = BuildConfiguration.Builder()
         build_config_builder.register_aliases(
@@ -149,6 +150,11 @@ class RuleRunner:
     @property
     def target_types(self) -> FrozenOrderedSet[Type[Target]]:
         return self.build_config.target_types
+
+    @property
+    def union_membership(self) -> UnionMembership:
+        """An instance of `UnionMembership` with all the test's registered `UnionRule`s."""
+        return self.request(UnionMembership, [])
 
     def request(self, output_type: Type[_O], inputs: Iterable[Any]) -> _O:
         result = assert_single_element(


### PR DESCRIPTION
This rewrites them to use `RuleRunner`/Pytest, and also removes some complexity in `process_test.py`.

[ci skip-rust]
[ci skip-build-wheels]