### PR TITLE
Fix `--pex-verbosity` to work with the interpreter selection PEX (Cherry-pick of #11108)

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -9,7 +9,11 @@ from typing import Iterable, List, Mapping, Optional, Tuple
 
 from pants.backend.python.subsystems.python_native_code import PythonNativeCode
 from pants.backend.python.util_rules import pex_environment
-from pants.backend.python.util_rules.pex_environment import PexEnvironment, PythonExecutable
+from pants.backend.python.util_rules.pex_environment import (
+    PexEnvironment,
+    PexRuntimeEnvironment,
+    PythonExecutable,
+)
 from pants.core.util_rules import external_tool
 from pants.core.util_rules.external_tool import (
     DownloadedExternalTool,
@@ -97,6 +101,7 @@ async def setup_pex_cli_process(
     pex_env: PexEnvironment,
     python_native_code: PythonNativeCode,
     global_options: GlobalOptions,
+    pex_runtime_env: PexRuntimeEnvironment,
 ) -> Process:
     tmpdir = ".tmp"
     gets: List[Get] = [
@@ -126,7 +131,7 @@ async def setup_pex_cli_process(
     input_digest = await Get(Digest, MergeDigests(digests_to_merge))
 
     pex_root_path = ".cache/pex_root"
-    argv = pex_env.create_argv(
+    argv = [
         downloaded_pex_bin.exe,
         *cert_args,
         "--python-path",
@@ -144,11 +149,14 @@ async def setup_pex_cli_process(
         # CWD can find the TMPDIR.
         "--tmpdir",
         tmpdir,
-        # NB: This comes at the end of the argv because the request may use `--` passthrough args,
-        # which must come at the end.
-        *request.argv,
-        python=request.python,
-    )
+    ]
+    if pex_runtime_env.verbosity > 0:
+        argv.append(f"-{'v' * pex_runtime_env.verbosity}")
+
+    # NB: This comes at the end of the argv because the request may use `--` passthrough args,
+    # which must come at the end.
+    argv.extend(request.argv)
+    normalized_argv = pex_env.create_argv(*argv, python=request.python)
     env = {
         **pex_env.environment_dict(python_configured=request.python is not None),
         **python_native_code.environment_dict,
@@ -156,7 +164,7 @@ async def setup_pex_cli_process(
     }
 
     return Process(
-        argv,
+        normalized_argv,
         description=request.description,
         input_digest=input_digest,
         env=env,


### PR DESCRIPTION
We don't wire up correctly when building the PEX that chooses which interpreter to use for `internal_only` PEXes.

[ci skip-rust]
[ci skip-build-wheels]