### PR TITLE
Add a specific error for target names containing slashes (cherrypick of #11115)

### DIFF
--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -6,13 +6,13 @@ from dataclasses import dataclass
 from pathlib import PurePath
 from typing import Optional, Sequence
 
-from pants.base.deprecated import deprecated
+from pants.base.deprecated import deprecated, warn_or_error
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.util.dirutil import fast_relpath, longest_dir_prefix
 from pants.util.strutil import strip_prefix
 
 # Currently unused, but reserved for possible future needs.
-BANNED_CHARS_IN_TARGET_NAME = frozenset("@!?=")
+BANNED_CHARS_IN_TARGET_NAME = frozenset(r"@!?/\:=")
 
 
 class InvalidSpecPath(ValueError):
@@ -39,13 +39,6 @@ class AddressInput:
             if not self.target_component:
                 raise InvalidTargetName(
                     f"Address spec {self.path_component}:{self.target_component} has no name part."
-                )
-
-            banned_chars = BANNED_CHARS_IN_TARGET_NAME & set(self.target_component)
-            if banned_chars:
-                raise InvalidTargetName(
-                    f"Banned chars found in target name. {banned_chars} not allowed in target "
-                    f"name: {self.target_component}"
                 )
 
         # A root is okay.
@@ -257,10 +250,35 @@ class Address(EngineAwareParameter):
         """
         self.spec_path = spec_path
         self._relative_file_path = relative_file_path
+
         # If the target_name is the same as the default name would be, we normalize to None.
-        self._target_name = (
-            target_name if target_name and target_name != os.path.basename(self.spec_path) else None
-        )
+        self._target_name: Optional[str]
+        if target_name and target_name != os.path.basename(self.spec_path):
+            banned_chars = BANNED_CHARS_IN_TARGET_NAME & set(target_name)
+            deprecated_banned_chars = banned_chars & set(r"/\:")
+            if deprecated_banned_chars:
+                warn_or_error(
+                    removal_version="2.2.0.dev1",
+                    deprecated_entity_description=(
+                        r"Using any of the `\`, `/`, or `:` characters in a target name."
+                    ),
+                    hint=(
+                        f"The target name {target_name} (defined in directory {self.spec_path}) "
+                        f"contains deprecated characters (`{deprecated_banned_chars}`), which will "
+                        "cause some usecases to fail. Please replace these characters with another "
+                        "separator character like `_` or `-`."
+                    ),
+                )
+            elif banned_chars:
+                raise InvalidTargetName(
+                    f"The target name {target_name} (defined in directory {self.spec_path}) "
+                    f"contains banned characters (`{banned_chars}`). Please replace these "
+                    "characters with another separator character like `_` or `-`."
+                )
+            self._target_name = target_name
+        else:
+            self._target_name = None
+
         self._hash = hash((self.spec_path, self._relative_file_path, self._target_name))
         if PurePath(spec_path).name.startswith("BUILD"):
             raise InvalidSpecPath(

--- a/src/python/pants/build_graph/address_test.py
+++ b/src/python/pants/build_graph/address_test.py
@@ -1,6 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import warnings
 from typing import Optional
 
 import pytest
@@ -93,10 +94,10 @@ def test_address_input_parse_bad_path_component() -> None:
     assert_bad_path_component("///a")
 
 
-def test_address_input_parse_bad_target_component() -> None:
+def test_address_bad_target_component() -> None:
     def assert_bad_target_component(spec: str) -> None:
         with pytest.raises(InvalidTargetName):
-            repr(AddressInput.parse(spec))
+            repr(AddressInput.parse(spec).dir_to_address())
 
     # Missing target_component
     assert_bad_target_component("")
@@ -110,6 +111,12 @@ def test_address_input_parse_bad_target_component() -> None:
     assert_bad_target_component("//:!t")
     assert_bad_target_component("//:?t")
     assert_bad_target_component("//:=t")
+
+    # Deprecated banned chars. This should convert into an error in `2.2.0.dev1`.
+    with warnings.catch_warnings(record=True) as w:
+        AddressInput.parse(r"a:b\c").dir_to_address()
+        assert len(w) == 1
+        assert "deprecated" in str(w[0].message)
 
 
 def test_subproject_spec() -> None:


### PR DESCRIPTION
### Problem

Having slashes (`/`) in target names used to be implicitly supported, but the new file address syntax in `2.0.x` makes having a slash in a target name ambiguous:
```
this/is/a/file.txt:../../with/a/target
```

### Solution

We believe that it should be possible to safely rename all targets with slashes in their names, and we think that the file address syntax is worth keeping. So this change deprecates including the relevant characters in target names.

### Result

Fixes #11106.

[ci skip-rust]
[ci skip-build-wheels]