### PR TITLE
Add support for filtering file vs base targets

### DIFF
--- a/src/python/pants/backend/project_info/filter_targets.py
+++ b/src/python/pants/backend/project_info/filter_targets.py
@@ -22,7 +22,7 @@ from pants.util.filtering import and_filters, create_filters
 class TargetGranularity(Enum):
     all_targets = "all"
     file_targets = "file"
-    base_targets = "base"
+    build_targets = "BUILD"
 
 
 class FilterSubsystem(LineOriented, GoalSubsystem):
@@ -53,8 +53,8 @@ class FilterSubsystem(LineOriented, GoalSubsystem):
             type=TargetGranularity,
             default=TargetGranularity.all_targets,
             help=(
-                "Filter to rendering only base targets (those declared in BUILD files), "
-                "only file-level targets, or all targets."
+                "Filter to rendering only targets declared in BUILD files, only file-level "
+                "targets, or all targets."
             ),
         )
         register(
@@ -111,7 +111,7 @@ def filter_targets(
             {
                 TargetGranularity.all_targets: lambda _: True,
                 TargetGranularity.file_targets: lambda tgt: not tgt.address.is_base_target,
-                TargetGranularity.base_targets: lambda tgt: tgt.address.is_base_target,
+                TargetGranularity.build_targets: lambda tgt: tgt.address.is_base_target,
             },
         )
 

--- a/src/python/pants/backend/project_info/filter_targets.py
+++ b/src/python/pants/backend/project_info/filter_targets.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import re
+from enum import Enum
 from typing import Callable, Pattern
 
 from pants.engine.console import Console
@@ -17,10 +18,16 @@ from pants.engine.target import (
 from pants.util.filtering import and_filters, create_filters
 
 
+class TargetGranularity(Enum):
+    all_targets = "all"
+    file_targets = "file"
+    base_targets = "base"
+
+
 class FilterSubsystem(LineOriented, GoalSubsystem):
     """Filter the input targets based on various criteria.
 
-    Each of the filtering options below is a comma-separated list of filtering criteria, with an
+    Most of the filtering options below are comma-separated lists of filtering criteria, with an
     implied logical OR between them, so that a target passes the filter if it matches any of the
     criteria in the list.  A '-' prefix inverts the sense of the entire comma-separated list, so
     that a target passes the filter only if it matches none of the criteria in the list.
@@ -39,6 +46,15 @@ class FilterSubsystem(LineOriented, GoalSubsystem):
             type=list,
             metavar="[+-]type1,type2,...",
             help="Filter on these target types, e.g. `resources` or `python_library`.",
+        )
+        register(
+            "--granularity",
+            type=TargetGranularity,
+            default=TargetGranularity.all_targets,
+            help=(
+                "Filter to rendering only base targets (those declared in BUILD files), "
+                "only file-level targets, or all targets."
+            ),
         )
         register(
             "--address-regex",
@@ -88,11 +104,21 @@ def filter_targets(
         regex = compile_regex(tag_regex)
         return lambda tgt: any(bool(regex.search(tag)) for tag in tgt.get(Tags).value or ())
 
+    def filter_granularity(granularity: TargetGranularity) -> TargetFilter:
+        if granularity == TargetGranularity.all_targets:
+            return lambda _: True
+        elif granularity == TargetGranularity.file_targets:
+            return lambda tgt: not tgt.address.is_base_target
+        else:
+            assert granularity == TargetGranularity.base_targets
+            return lambda tgt: tgt.address.is_base_target
+
     anded_filter: TargetFilter = and_filters(
         [
             *(create_filters(filter_subsystem.options.target_type, filter_target_type)),
             *(create_filters(filter_subsystem.options.address_regex, filter_address_regex)),
             *(create_filters(filter_subsystem.options.tag_regex, filter_tag_regex)),
+            filter_granularity(filter_subsystem.options.granularity),
         ]
     )
     addresses = sorted(target.address for target in targets if anded_filter(target))

--- a/src/python/pants/backend/project_info/filter_targets_test.py
+++ b/src/python/pants/backend/project_info/filter_targets_test.py
@@ -159,5 +159,5 @@ def test_filter_by_granularity() -> None:
         MockTarget({}, address=Address("p1", relative_file_path="file.txt")),
     ]
     assert run_goal(targets, granularity=TargetGranularity.all_targets).strip() == "p1\np1/file.txt"
-    assert run_goal(targets, granularity=TargetGranularity.base_targets).strip() == "p1"
+    assert run_goal(targets, granularity=TargetGranularity.build_targets).strip() == "p1"
     assert run_goal(targets, granularity=TargetGranularity.file_targets).strip() == "p1/file.txt"


### PR DESCRIPTION
### Problem

As described in #11050: currently there is no way to filter to select only base targets (those declared in `BUILD` files), or only file targets (those generated from the files owned by base targets).

### Solution

Add a flag to `--filter` to enable filtering to just file, just base, or both. As mentioned on the ticket, the types of cases where this filtering are likely to be necessary will probably already be using the `filter` goal: the global filter options (`--tag`, `--exclude-target-regexp`) are more specialized shorthands.

### Result

Usecases like:
```
# Request file targets, and then strip off the owning target name using unix tools.
./pants --changed-since ... filter --granularity=file | cut -d: -f1 | sort | uniq
# Request base targets, and then ask pants to expand targets to files.
./pants --changed-since ... filter --granularity=target | xargs ./pants filedeps
```
... are enabled. Fixes #11050.

[ci skip-rust]
[ci skip-build-wheels]