### PR TITLE
Fix target globs for deprecated test helper file

### DIFF
--- a/src/python/pants/testutil/BUILD
+++ b/src/python/pants/testutil/BUILD
@@ -23,7 +23,6 @@ python_library(
     "!rule_runner.py",
     "!test_base.py",
     "!pants_integration_test.py",
-    "!pants_run_integration_test.py",
     "!_test.py",
   ],
 )
@@ -36,7 +35,7 @@ python_library(
 
 python_library(
   name = 'int-test-for-export',
-  sources = ['pants_integration_test.py', 'pants_run_integration_test.py'],
+  sources = ['pants_integration_test.py'],
   dependencies = [
     '//:build_root',
     'src/python/pants:entry_point'
@@ -47,7 +46,7 @@ target(
   name = 'int-test',
   dependencies=[
     ':int-test-for-export',
-    # NB: 'pants_run_integration_test.py' runs ./pants in a subprocess using the PYTHONPATH
+    # NB: 'pants_integration_test.py' runs ./pants in a subprocess using the PYTHONPATH
     # of the testrunner. We include the pants binary itself to fully populate the path.
     'src/python/pants/bin:pants_local_binary',
   ],
@@ -55,5 +54,5 @@ target(
 
 python_tests(
   name='tests',
-  sources=['*_test.py', '!pants_integration_test.py', '!pants_run_integration_test.py']
+  sources=['*_test.py', '!pants_integration_test.py']
 )


### PR DESCRIPTION
### Problem

`pants_run_integration_test.py` was deleted (after a deprecation) in #11119, but the target globs were not updated for that change, which triggered a warning on master.

### Solution

Update target globs. Fixes #11124.

[ci skip-rust]
[ci skip-build-wheels]