### PR TITLE
Fix Coverage not finding resource files when generating a report

### DIFF
--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -276,7 +276,12 @@ async def generate_coverage_reports(
     transitive_targets = await Get(TransitiveTargets, TransitiveTargetsRequest(all_used_addresses))
     sources = await Get(
         PythonSourceFiles,
-        PythonSourceFilesRequest(transitive_targets.closure, include_resources=False),
+        # Coverage sometimes includes non-Python files in its `.coverage` data. We need to
+        # ensure that they're present when generating the report. We include all the files included
+        # by `pytest_runner.py`.
+        PythonSourceFilesRequest(
+            transitive_targets.closure, include_files=True, include_resources=True
+        ),
     )
     input_digest = await Get(
         Digest,


### PR DESCRIPTION
Toolchain has a test that for some weird reason results in Coverage.py reporting on an HTML file. At report time, we weren't including that HTML file, so Coverage was throwing an exception.

```
No source for code: '/private/var/folders/sx/pdpbqz4x5cscn9hhfpbsbqvm0000gn/T/process-executionzVYpJg/src/python/toolchain/.../base.html'.
Aborting report output, consider using -i.
```

For absolute safety, we should include the same files at report time as we had at Pytest run time. The only downside is a coarser cache key, but changing a file will already invalidate the test result, which will likely generate new coverage data, which will invalidate the coverage report; so this isn't a big deal.
 
[ci skip-rust]
[ci skip-build-wheels]