### PR TITLE
make a few minor reliability fixes to remote caching code

### DIFF
--- a/src/rust/engine/workunit_store/src/metrics.rs
+++ b/src/rust/engine/workunit_store/src/metrics.rs
@@ -34,6 +34,8 @@ pub enum Metric {
   RemoteCacheRequests,
   RemoteCacheRequestsCached,
   RemoteCacheRequestsUncached,
+  RemoteCacheReadErrors,
+  RemoteCacheWriteErrors,
 }
 
 impl Metric {
@@ -46,6 +48,8 @@ impl Metric {
       RemoteCacheRequests => "remote_cache_requests",
       RemoteCacheRequestsCached => "remote_cache_requests_cached",
       RemoteCacheRequestsUncached => "remote_cache_requests_uncached",
+      RemoteCacheReadErrors => "remote_cache_read_errors",
+      RemoteCacheWriteErrors => "remote_cache_write_errors",
     }
   }
 }


### PR DESCRIPTION
### Problem

The remote caching code contains an `.unwrap` and similar code in various places. That code should just return the errors in question.

### Solution

Get rid of some `.unwrap` calls. Add some metrics for failure to read or write from the remote cache.

### Result

Existing tests pass.

[ci skip-build-wheels]
