### PR TITLE
Require Python 3.7 or 3.8 to run Pants

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -566,9 +566,8 @@ jobs:
       "TRAVIS_UID=$(id -u)" --build-arg "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id
       -g)" build-support/docker/travis_ci/
     - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
-      travis_ci:latest sh -c "./build-support/bin/release.sh -n && USE_PY37=true ./build-support/bin/release.sh
-      -n && USE_PY38=true ./build-support/bin/release.sh -n && ./build-support/bin/release.sh
-      -f"
+      travis_ci:latest sh -c "./build-support/bin/release.sh -n && USE_PY38=true ./build-support/bin/release.sh
+      -n && ./build-support/bin/release.sh -f"
     services:
     - docker
     stage: Test Pants
@@ -581,8 +580,7 @@ jobs:
       -o /usr/local/bin/jq
     - chmod 755 /usr/local/bin/jq
     - ./build-support/bin/install_aws_cli_for_ci.sh
-    - ./build-support/bin/install_python_for_ci.sh ${MACOS_PYENV_PY36_VERSION} ${MACOS_PYENV_PY37_VERSION}
-      ${MACOS_PYENV_PY38_VERSION}
+    - ./build-support/bin/install_python_for_ci.sh ${MACOS_PYENV_PY37_VERSION} ${MACOS_PYENV_PY38_VERSION}
     before_script:
     - ulimit -n 8192
     - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${AWS_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
@@ -613,7 +611,6 @@ jobs:
     osx_image: xcode8
     script:
     - ./build-support/bin/release.sh -n
-    - USE_PY37=true ./build-support/bin/release.sh -n
     - USE_PY38=true ./build-support/bin/release.sh -n
     - ./build-support/bin/release.sh -f
     stage: Test Pants

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -548,7 +548,6 @@ def python_tests(python_version: PythonVersion) -> Dict:
 def _build_wheels_command() -> List[str]:
     return [
         "./build-support/bin/release.sh -n",
-        "USE_PY37=true ./build-support/bin/release.sh -n",
         "USE_PY38=true ./build-support/bin/release.sh -n",
         # NB: We also build `fs_util` in this shard to leverage having had compiled the engine.
         "./build-support/bin/release.sh -f",
@@ -579,7 +578,7 @@ def build_wheels_osx() -> Dict:
         "name": "Build macOS wheels and fs_util",
         "script": _build_wheels_command(),
         "before_install": _osx_before_install(
-            python_versions=[PythonVersion.py36, PythonVersion.py37, PythonVersion.py38],
+            python_versions=[PythonVersion.py37, PythonVersion.py38],
             install_py27=False,
         ),
         "if": SKIP_WHEELS_CONDITION,

--- a/build-support/bin/packages.py
+++ b/build-support/bin/packages.py
@@ -438,10 +438,10 @@ def check_prebuilt_wheels(check_dir: str) -> None:
         if not local_files:
             missing_packages.append(package.name)
             continue
-        if is_cross_platform(local_files) and len(local_files) != 6:
+        if is_cross_platform(local_files) and len(local_files) != 4:
             formatted_local_files = ", ".join(f.name for f in local_files)
             missing_packages.append(
-                f"{package.name} (expected 6 wheels, {{macosx, linux}} x {{cp36m, cp37m, cp38}}, "
+                f"{package.name} (expected 4 wheels, {{macosx, linux}} x {{cp37m, cp38}}, "
                 f"but found {formatted_local_files})"
             )
     if missing_packages:

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -23,15 +23,12 @@ source "${ROOT}/build-support/common.sh"
 
 # TODO: make this less hacky when porting to Python 3. Use proper `--python-version` flags, like
 #  those used by ci.py.
-if [[ "${USE_PY37:-false}" == "true" ]]; then
-  default_python=python3.7
-  interpreter_constraint="==3.7.*"
-elif [[ "${USE_PY38:-false}" == "true" ]]; then
+if [[ "${USE_PY38:-false}" == "true" ]]; then
   default_python=python3.8
   interpreter_constraint="==3.8.*"
 else
-  default_python=python3.6
-  interpreter_constraint="==3.6.*"
+  default_python=python3.7
+  interpreter_constraint="==3.7.*"
 fi
 
 export PY="${PY:-${default_python}}"
@@ -39,8 +36,8 @@ if ! command -v "${PY}" >/dev/null; then
   die "Python interpreter ${PY} not discoverable on your PATH."
 fi
 py_major_minor=$(${PY} -c 'import sys; print(".".join(map(str, sys.version_info[0:2])))')
-if [[ "${py_major_minor}" != "3.6"  && "${py_major_minor}" != "3.7" && "${py_major_minor}" != "3.8" ]]; then
-  die "Invalid interpreter. The release script requires Python 3.6, 3.7, or 3.8 (you are using ${py_major_minor})."
+if [[ "${py_major_minor}" != "3.7" && "${py_major_minor}" != "3.8" ]]; then
+  die "Invalid interpreter. The release script requires Python 3.7 or 3.8 (you are using ${py_major_minor})."
 fi
 
 # This influences what setuptools is run with, which determines the interpreter used for building
@@ -337,7 +334,7 @@ function build_pex() {
       ;;
     fetch)
       local distribution_target_flags=()
-      abis=("cp-36-m" "cp-37-m" "cp-38-cp38")
+      abis=("cp-37-m" "cp-38-cp38")
       for platform in "${linux_platform_noabi}" "${osx_platform_noabi}"; do
         for abi in "${abis[@]}"; do
           distribution_target_flags=("${distribution_target_flags[@]}" "--platform=${platform}-${abi}")

--- a/src/python/pants/testutil/BUILD
+++ b/src/python/pants/testutil/BUILD
@@ -7,7 +7,7 @@ python_distribution(
     ':testutil',
     ':int-test-for-export',
   ],
-  setup_py_commands=["bdist_wheel", "--python-tag", "py36.py37.py38", "sdist"],
+  setup_py_commands=["bdist_wheel", "--python-tag", "py37.py38", "sdist"],
   provides=setup_py(
     name='pantsbuild.pants.testutil',
     description='Test support for writing Pants plugins.',


### PR DESCRIPTION
This will make it easier for us to add support for more platforms in our release*, as we now have fewer wheels to need to build. For example, we may want to start building a 3.9 wheel for Pants (given that we need to run with Py39 for dep inference to understand Py39-only code).

We can also start using Py37 features, including `from __future__ import annotations`.

*The more robust solution is https://github.com/pantsbuild/pants/issues/7369.

**Clarification for users: this does not mean your own code must use Python 3.7+. You only need a Py37 or Py38 interpreter in your environment to run Pants. You'll also likely want the latest version of https://github.com/pantsbuild/setup/blob/gh-pages/pants so that your script uses the correct interpreter)

[ci skip-rust]
[ci skip-build-wheels]