### PR TITLE
move counter increment into check_action_cache

### DIFF
--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -1283,7 +1283,12 @@ pub async fn check_action_cache(
           .increment_counter(Metric::RemoteCacheRequestsUncached, 1);
         Ok(None)
       }
-      _ => Err(rpcerror_to_string(err)),
+      _ => {
+        context
+          .workunit_store
+          .increment_counter(Metric::RemoteCacheReadErrors, 1);
+        Err(rpcerror_to_string(err))
+      }
     },
   }
 }

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -440,9 +440,6 @@ impl crate::CommandRunner for CommandRunner {
         }
         Err(err) => {
           log::warn!("Failed to read from remote cache: {}", err);
-          context
-            .workunit_store
-            .increment_counter(Metric::RemoteCacheReadErrors, 1);
         }
       };
     }


### PR DESCRIPTION
Move the increment of counter for "remote cache read errors" into the `check_action_cache` method so that the counter is also appropriately incremented in remote execution mode.

[ci skip-build-wheels]
