### PR TITLE
Apply deprecation removal from bf5e7894.

### DIFF
--- a/src/python/pants/backend/project_info/list_targets.py
+++ b/src/python/pants/backend/project_info/list_targets.py
@@ -28,20 +28,6 @@ class ListSubsystem(LineOriented, GoalSubsystem):
             ),
         )
         register(
-            "--provides-columns",
-            default="address,artifact_id",
-            help=(
-                "Display these columns when --provides is specified. Available columns are: "
-                "address, artifact_id, repo_name, repo_url, push_db_basedir"
-            ),
-            removal_version="2.0.1.dev0",
-            removal_hint=(
-                "The option `--provides-columns` no longer does anything. It was specific to the "
-                "JVM backend, so no longer makes sense with Pants 2.0 initially only supporting "
-                "Python."
-            ),
-        )
-        register(
             "--documented",
             type=bool,
             default=False,


### PR DESCRIPTION
This fixes `./pants` on the 2.0.x branch which otherwise fails when
bootstrapping options.

Obtained via:
```
git diff bf5e78945b16b5f2312e146d4708ce50f9e866c0^! \
  -- src/python/pants/backend/project_info/list_targets.py > /tmp/patch
```

[ci skip-rust]
[ci skip-build-wheels]
