### PR TITLE
Bump deprecation removal to 2.1.0.dev0.

### DIFF
--- a/src/python/pants/backend/project_info/list_targets.py
+++ b/src/python/pants/backend/project_info/list_targets.py
@@ -34,7 +34,7 @@ class ListSubsystem(LineOriented, GoalSubsystem):
                 "Display these columns when --provides is specified. Available columns are: "
                 "address, artifact_id, repo_name, repo_url, push_db_basedir"
             ),
-            removal_version="2.0.1.dev0",
+            removal_version="2.1.0.dev0",
             removal_hint=(
                 "The option `--provides-columns` no longer does anything. It was specific to the "
                 "JVM backend, so no longer makes sense with Pants 2.0 initially only supporting "


### PR DESCRIPTION
The original deprecation value was a mistake and this fixes `./pants`
on the 2.0.x branch which otherwise fails when bootstrapping options.

[ci skip-rust]
[ci skip-build-wheels]
