### PR TITLE
Deprecate the `sources` field for `python_awslambda`

### DIFF
--- a/src/python/pants/backend/awslambda/python/rules_test.py
+++ b/src/python/pants/backend/awslambda/python/rules_test.py
@@ -65,25 +65,22 @@ def test_create_hello_world_lambda(rule_runner: RuleRunner) -> None:
         "src/python/foo/bar",
         textwrap.dedent(
             """
-            python_library(
-              name='hello_world',
-              sources=['hello_world.py']
-            )
+            python_library(name='lib')
 
             python_awslambda(
-              name='hello_world_lambda',
-              dependencies=[':hello_world'],
-              handler='foo.bar.hello_world',
-              runtime='python3.7'
+                name='lambda',
+                dependencies=[':lib'],
+                handler='foo.bar.hello_world',
+                runtime='python3.7',
             )
             """
         ),
     )
 
     zip_file_relpath, content = create_python_awslambda(
-        rule_runner, Address("src/python/foo/bar", target_name="hello_world_lambda")
+        rule_runner, Address("src/python/foo/bar", target_name="lambda")
     )
-    assert "src.python.foo.bar/hello_world_lambda.zip" == zip_file_relpath
+    assert "src.python.foo.bar/lambda.zip" == zip_file_relpath
     zipfile = ZipFile(BytesIO(content))
     names = set(zipfile.namelist())
     assert "lambdex_handler.py" in names

--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -4,9 +4,36 @@
 import re
 from typing import Match, Optional, Tuple, cast
 
-from pants.backend.python.target_types import COMMON_PYTHON_FIELDS, PythonSources
+from pants.backend.python.target_types import PythonInterpreterCompatibility, PythonSources
+from pants.core.goals.package import OutputPathField
 from pants.engine.addresses import Address
-from pants.engine.target import Dependencies, InvalidFieldException, StringField, Target
+from pants.engine.target import (
+    COMMON_TARGET_FIELDS,
+    Dependencies,
+    InvalidFieldException,
+    StringField,
+    Target,
+)
+
+
+class DeprecatedPythonAwsLambdaSources(PythonSources):
+    expected_num_files = range(0, 1)
+    deprecated_removal_version = "2.2.0.dev0"
+    deprecated_removal_hint = (
+        "Remove the `sources` field and create a new `python_library()` target (if you do not "
+        "yet have one), then add the `python_library()` to the `dependencies` field of this "
+        "`python_awslambda`. See https://www.pantsbuild.org/docs/awslambda-python for an example."
+    )
+
+
+class DeprecatedPythonInterpreterCompatibility(PythonInterpreterCompatibility):
+    deprecated_removal_version = "2.2.0.dev0"
+    deprecated_removal_hint = (
+        "Because the `sources` field will be removed, it no longer makes sense to have a "
+        "`compatibility` field for `python_awslambda` targets. Instead, set the "
+        "`interpreter_constraints` field on the `python_library` target containing this lambda's "
+        "handler code."
+    )
 
 
 class PythonAwsLambdaDependencies(Dependencies):
@@ -57,8 +84,10 @@ class PythonAWSLambda(Target):
 
     alias = "python_awslambda"
     core_fields = (
-        *COMMON_PYTHON_FIELDS,
-        PythonSources,
+        *COMMON_TARGET_FIELDS,
+        DeprecatedPythonAwsLambdaSources,
+        DeprecatedPythonInterpreterCompatibility,
+        OutputPathField,
         PythonAwsLambdaDependencies,
         PythonAwsLambdaHandler,
         PythonAwsLambdaRuntime,


### PR DESCRIPTION
We missed this when making files the atomic unit. It was possible to have >1 file in the `sources` field, which would cause `./pants package` to try building the same lambda >1 time, which would result in a `MergeDigests` error. We knew about this problem with `setup_py()` and fixed it by adding `python_distribution`, but didn't catch this.

Generally, we don't want the `sources` field for this target. It's too common that a `python_library()` uses default sources, but then a `python_awslambda` uses explicit sources for a file, and there end up with >1 owner for that file. This turns off dep inference for that file, which is extremely confusing. We instead follow the `python_distribution` model of no `sources`.

Deprecations:

```
18:24:16.43 [WARN] /Users/eric/DocsLocal/code/projects/pants/src/python/pants/engine/target.py:226: DeprecationWarning: DEPRECATED: the 'sources' field will be removed in version 2.2.0.dev0.
  Using the `sources` field in the target src/python/pants/backend/awslambda/python:lambda. Remove the `sources` field and create a new `python_library()` target (if you do not yet have one), then add the `python_library()` to the `dependencies` field of this `python_awslambda`. See https://www.pantsbuild.org/docs/awslambda-python for an example.
  super().__init__(raw_value, address=address)
18:24:16.43 [WARN] /Users/eric/DocsLocal/code/projects/pants/src/python/pants/engine/target.py:134: DeprecationWarning: DEPRECATED: the 'compatibility' field will be removed in version 2.2.0.dev0.
  Using the `compatibility` field in the target src/python/pants/backend/awslambda/python:lambda. Because the `sources` field will be removed, it no longer makes sense to have a `compatibility` field for `python_awslambda` targets. Instead, set the `interpreter_constraints` field on the `python_library` target containing this Lambda's handler code.
  super().__init__(raw_value, address=address)
```
[ci skip-rust]
[ci skip-build-wheels]