### PR TITLE
Work around grpcio-tools missing dependency.

### DIFF
--- a/src/python/pants/backend/codegen/grpcio/python/grpcio.py
+++ b/src/python/pants/backend/codegen/grpcio/python/grpcio.py
@@ -9,6 +9,14 @@ class Grpcio(PythonToolBase):
 
     grpcio_version = "1.17.1"
     default_version = f"grpcio=={grpcio_version}"
-    default_extra_requirements = [f"grpcio-tools=={grpcio_version}"]
+    default_extra_requirements = [
+        f"grpcio-tools=={grpcio_version}",
+        # The grpcio-tools distribution depends on setuptools but does not declare the dependency.
+        # See: https://github.com/grpc/grpc/issues/24746
+        #
+        # We pick setuptools 44.0.0 since its the last setuptools version compatible with both
+        # Python 2 and Python 3.
+        "setuptools==44.0.0",
+    ]
 
     default_entry_point = "grpc_tools.protoc"


### PR DESCRIPTION
The grpcio-tools distribution has a real dependency on setuptools it
does not declare. We work around by adding a dependency for it. More
information can be found here: https://github.com/grpc/grpc/issues/24746

[ci skip-rust-tests]
[ci skip-jvm-tests]
