### PR TITLE
Relative imports are relative to the containing package.

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/import_parser.py
+++ b/src/python/pants/backend/python/dependency_inference/import_parser.py
@@ -58,7 +58,7 @@ def parse_file(*, filename: str, content: str) -> Optional[Tuple]:
 
 
 def find_python_imports(*, filename: str, content: str) -> ParsedPythonImports:
-    package = ".".join(PurePath(filename).parts[0:-1])
+    package_parts = PurePath(filename).parts[0:-1]
     parse_result = parse_file(filename=filename, content=content)
     # If there were syntax errors, gracefully early return. This is more user friendly than
     # propagating the exception. Dependency inference simply won't be used for that file, and
@@ -66,7 +66,7 @@ def find_python_imports(*, filename: str, content: str) -> ParsedPythonImports:
     if parse_result is None:
         return ParsedPythonImports(FrozenOrderedSet(), FrozenOrderedSet())
     tree, ast_visitor_cls = parse_result
-    ast_visitor = ast_visitor_cls(package)
+    ast_visitor = ast_visitor_cls(package_parts)
     ast_visitor.visit(tree)
     return ParsedPythonImports(
         explicit_imports=FrozenOrderedSet(sorted(ast_visitor.explicit_imports)),
@@ -80,8 +80,8 @@ _INFERRED_IMPORT_REGEX = re.compile(r"^([a-z_][a-z_\d]*\.){2,}[a-zA-Z_]\w*$")
 
 
 class _BaseAstVisitor:
-    def __init__(self, package: str) -> None:
-        self._package_parts = package.split(".")
+    def __init__(self, package_parts: Tuple[str, ...]) -> None:
+        self._package_parts = package_parts
         self.explicit_imports: Set[str] = set()
         self.inferred_imports: Set[str] = set()
 

--- a/src/python/pants/backend/python/dependency_inference/import_parser.py
+++ b/src/python/pants/backend/python/dependency_inference/import_parser.py
@@ -99,7 +99,7 @@ class _BaseAstVisitor:
             rel_module = node.module
             abs_module = ".".join(
                 self._package_parts[0 : len(self._package_parts) - node.level + 1]
-                + ([] if rel_module is None else [rel_module])
+                + (tuple() if rel_module is None else (rel_module,))
             )
         else:
             abs_module = node.module

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import itertools
-from pathlib import PurePath
 from typing import List, cast
 
 from pants.backend.python.dependency_inference import module_mapper
@@ -108,18 +107,13 @@ async def infer_python_dependencies(
         return InferredDependencies([], sibling_dependencies_inferrable=False)
 
     stripped_sources = await Get(StrippedSourceFiles, SourceFilesRequest([request.sources_field]))
-    modules = tuple(
-        PythonModule.create_from_stripped_path(PurePath(fp))
-        for fp in stripped_sources.snapshot.files
-    )
     digest_contents = await Get(DigestContents, Digest, stripped_sources.snapshot.digest)
 
     owners_requests: List[Get[PythonModuleOwners, PythonModule]] = []
-    for file_content, module in zip(digest_contents, modules):
+    for file_content in digest_contents:
         file_imports_obj = find_python_imports(
             filename=file_content.path,
             content=file_content.content.decode(),
-            module_name=module.module,
         )
         detected_imports = (
             file_imports_obj.all_imports


### PR DESCRIPTION
The existing code assumed they were relative to the module
(i.e., that relative imports in foo.py and __init__.py should
behave differently), but that is not the case.

See, e.g., https://docs.python.org/3/reference/import.html.

[ci skip-rust]

[ci skip-build-wheels]
