### PR TITLE
acquire GIL during work unit conversion

### DIFF
--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1084,6 +1084,11 @@ async fn workunits_to_py_tuple_value<'a>(
   core: &Arc<Core>,
   session: &Session,
 ) -> CPyResult<Value> {
+  // Acquire the GIL here so that calls into the externs::store_* helpers via workunit_to_py_value
+  // do not block on obtaining the GIL for every value conversion. (This API supports recursive
+  // acquisition of the GIL.)
+  let _gil = Python::acquire_gil();
+
   let mut workunit_values = Vec::new();
   for workunit in workunits {
     let py_value = workunit_to_py_value(workunit, core, session).await?;


### PR DESCRIPTION
### Problem

I noticed while implementing metrics that the conversion of a `Workunit` to Python takes the GIL independently for each value in the work unit because the `externs::store_*` helpers each acquire the GIL. Going up the call stack to `poll_session_workunits`, the GIL is released during the work unit conversion to Python values because of a call to `py.allow_threads` and not reacquired until execution is inside each `externs::store_*` function.

### Solution

Acquire the GIL within `workunits_to_py_tuple_value` so that all work units being converted in that call do not need to re-acquire the GIL. The `Python::acquire_gil()` API supports recursive acquisition of the GIL.

This is a micro-optimization, but seems simple enough to make.

### Result

Existing tests pass.

[ci skip-build-wheels]