### PR TITLE
Deprecate `TransitiveTargetsRequestLite` and `DependenciesRequestLite` now that graph cycle is fixed

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/python/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules.py
@@ -37,7 +37,7 @@ from pants.engine.target import (
     GenerateSourcesRequest,
     Sources,
     TransitiveTargets,
-    TransitiveTargetsRequestLite,
+    TransitiveTargetsRequest,
 )
 from pants.engine.unions import UnionRule
 from pants.source.source_root import SourceRoot, SourceRootRequest
@@ -66,9 +66,8 @@ async def generate_python_from_protobuf(
     # Protoc needs all transitive dependencies on `protobuf_libraries` to work properly. It won't
     # actually generate those dependencies; it only needs to look at their .proto files to work
     # with imports.
-    # TODO(#10917): Use TransitiveTargets instead of TransitiveTargetsLite.
     transitive_targets = await Get(
-        TransitiveTargets, TransitiveTargetsRequestLite([request.protocol_target.address])
+        TransitiveTargets, TransitiveTargetsRequest([request.protocol_target.address])
     )
 
     # NB: By stripping the source roots, we avoid having to set the value `--proto_path`

--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -12,14 +12,11 @@ from pants.backend.python.target_types import (
     PythonSources,
 )
 from pants.base.specs import AddressSpecs, DescendantAddresses
+from pants.core.util_rules.stripped_source_files import StrippedSourceFileNames
 from pants.engine.addresses import Address
 from pants.engine.collection import Collection
-from pants.engine.fs import PathGlobs, Paths
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import Targets
-from pants.option.global_options import GlobalOptions
-from pants.source.source_root import SourceRoot, SourceRootRequest
-from pants.util.dirutil import fast_relpath
+from pants.engine.target import SourcesPathsRequest, Targets
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 
@@ -68,54 +65,23 @@ class FirstPartyModuleToAddressMapping:
         return self.mapping.get(parent_module, ())
 
 
-@dataclass(frozen=True)
-class _StrippedFileNamesRequest:
-    sources: PythonSources
-
-
-class _StrippedFileNames(Collection[str]):
-    pass
-
-
-@rule
-async def _stripped_file_names(
-    request: _StrippedFileNamesRequest, global_options: GlobalOptions
-) -> _StrippedFileNames:
-    sources_field_path_globs = request.sources.path_globs(
-        global_options.options.files_not_found_behavior
-    )
-    source_root, paths = await MultiGet(
-        Get(SourceRoot, SourceRootRequest, SourceRootRequest.for_address(request.sources.address)),
-        Get(Paths, PathGlobs, sources_field_path_globs),
-    )
-    if source_root.path == ".":
-        return _StrippedFileNames(paths.files)
-    return _StrippedFileNames(fast_relpath(f, source_root.path) for f in paths.files)
-
-
 @rule(desc="Creating map of first party targets to Python modules", level=LogLevel.DEBUG)
 async def map_first_party_modules_to_addresses() -> FirstPartyModuleToAddressMapping:
     all_expanded_targets = await Get(Targets, AddressSpecs([DescendantAddresses("")]))
     candidate_targets = tuple(tgt for tgt in all_expanded_targets if tgt.has_field(PythonSources))
-    # NB: We use a custom implementation to resolve the stripped source paths, rather than
-    # `StrippedSourceFiles`, so that we can use `Get(Paths, PathGlobs)` instead of
-    # `Get(Snapshot, PathGlobs)`, which is much faster.
-    #
-    # This implementation is kept private because it's not fully comprehensive, such as not looking
-    # at codegen. That's fine for dep inference, but not in other contexts.
-    stripped_sources_per_explicit_target = await MultiGet(
-        Get(_StrippedFileNames, _StrippedFileNamesRequest(tgt[PythonSources]))
+    stripped_sources_per_target = await MultiGet(
+        Get(StrippedSourceFileNames, SourcesPathsRequest(tgt[PythonSources]))
         for tgt in candidate_targets
     )
 
     modules_to_addresses: DefaultDict[str, List[Address]] = defaultdict(list)
     modules_with_multiple_implementations: Set[str] = set()
-    for tgt, stripped_sources in zip(candidate_targets, stripped_sources_per_explicit_target):
+    for tgt, stripped_sources in zip(candidate_targets, stripped_sources_per_target):
         for stripped_f in stripped_sources:
             module = PythonModule.create_from_stripped_path(PurePath(stripped_f)).module
             if module in modules_to_addresses:
-                # We check if one of the targets is an implementation (.py file) and the other is a type stub (.pyi
-                # file), which we allow. Otherwise, we have ambiguity.
+                # We check if one of the targets is an implementation (.py file) and the other is
+                # a type stub (.pyi file), which we allow. Otherwise, we have ambiguity.
                 either_targets_are_type_stubs = len(modules_to_addresses[module]) == 1 and (
                     tgt.address.filename.endswith(".pyi")
                     or modules_to_addresses[module][0].filename.endswith(".pyi")

--- a/src/python/pants/core/util_rules/source_files.py
+++ b/src/python/pants/core/util_rules/source_files.py
@@ -14,11 +14,7 @@ from pants.util.meta import frozen_after_init
 
 @dataclass(frozen=True)
 class SourceFiles:
-    """A merged snapshot of the `sources` fields of multiple targets.
-
-    Possibly containing a subset of the `sources` when using `SpecifiedSourceFilesRequest` (instead
-    of `AllSourceFilesRequest`).
-    """
+    """A merged snapshot of the `sources` fields of multiple targets."""
 
     snapshot: Snapshot
 

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -53,6 +53,8 @@ from pants.engine.target import (
     InjectDependenciesRequest,
     InjectedDependencies,
     Sources,
+    SourcesPaths,
+    SourcesPathsRequest,
     SpecialCasedDependencies,
     Tags,
     Target,
@@ -747,7 +749,12 @@ def test_find_valid_field_sets() -> None:
 
 @pytest.fixture
 def sources_rule_runner() -> RuleRunner:
-    return RuleRunner(rules=[QueryRule(HydratedSources, (HydrateSourcesRequest,))])
+    return RuleRunner(
+        rules=[
+            QueryRule(HydratedSources, [HydrateSourcesRequest]),
+            QueryRule(SourcesPaths, [SourcesPathsRequest]),
+        ]
+    )
 
 
 def test_sources_normal_hydration(sources_rule_runner: RuleRunner) -> None:
@@ -761,7 +768,11 @@ def test_sources_normal_hydration(sources_rule_runner: RuleRunner) -> None:
     )
     assert hydrated_sources.snapshot.files == ("src/fortran/f1.f03", "src/fortran/f1.f95")
 
-    # Also test that the Filespec is correct. This does not need hydration to be calculated.
+    # Test that `SourcesPaths` works too.
+    sources_paths = sources_rule_runner.request(SourcesPaths, [SourcesPathsRequest(sources)])
+    assert sources_paths.files == ("src/fortran/f1.f03", "src/fortran/f1.f95")
+
+    # Also test that the Filespec is correct. This does not need the engine to be calculated.
     assert (
         sources.filespec
         == {


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/10917. This cycle made sense. We were trying to use `HydratedSources` in a dep inference rule when `HydratedSources` already uses dependencies. This is why with the rule for `-> Subtargets`, we were avoiding `HydratedSources` in the first place.

https://github.com/pantsbuild/pants/pull/11094 ended up fixing this without us realizing.

This PR also factors up `SourcesPaths` and `StrippedSourceFileNames`, which are the reason we were able to fix this cycle. We'll want to use these types in other places, such as https://github.com/pantsbuild/pants/issues/11184.

[ci skip-rust]
[ci skip-build-wheels]
