### PR TITLE
Add test address metadata

### DIFF
--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -140,6 +140,9 @@ class EnrichedTestResult(TestResult, EngineAwareReturnType):
             output = f"{output.rstrip()}\n\n"
         return f"{message}{output}"
 
+    def metadata(self) -> Dict[str, Any]:
+        return {"address": self.address.spec}
+
 
 @dataclass(frozen=True)
 class TestDebugRequest:


### PR DESCRIPTION
Implement the `metadata` method for `EnrichedTestResult`, with an `address` key corresponding to the address of the targets tested in this test run.