### PR TITLE
Set the soft ulimit value more conservatively

### DIFF
--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -782,14 +782,17 @@ pub fn increase_limits() -> Result<String, String> {
         for more information.",
         TARGET_NOFILE_LIMIT
       );
-      // If we might be able to increase the limit, try to.
+      // If we might be able to increase the soft limit, try to.
       if cur < max {
-        rlimit::Resource::NOFILE.set(max, max).map_err(|e| {
-          format!(
-            "Could not raise file handle limit above {}: `{}`. {}",
-            cur, e, err_suffix
-          )
-        })?;
+        let target_soft_limit = std::cmp::min(max, TARGET_NOFILE_LIMIT);
+        rlimit::Resource::NOFILE
+          .set(target_soft_limit, max)
+          .map_err(|e| {
+            format!(
+              "Could not raise soft file handle limit above {}: `{}`. {}",
+              cur, e, err_suffix
+            )
+          })?;
       } else {
         return Err(format!(
           "File handle limit is capped to: {}. {}",


### PR DESCRIPTION
### Problem

Big Sur seemingly sets a hard ulimit value of "maxint", which results in our soft ulimit also becoming maxint. That would be fine, but some (badly behaved, imo) libraries consume the soft ulimit as a default value for their configuration.

### Solution

We are fairly certain that we don't need more than 10k file handles in standard usage, so set the soft ulimit value more conservatively to `soft_limit = min(hard_limit, 10k)`.

[ci skip-build-wheels]