### PR TITLE
Add dependency inference for Python imports of Protobuf/gRPC

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_module_mapper.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_module_mapper.py
@@ -1,0 +1,74 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from typing import Dict, Set
+
+from pants.backend.codegen.protobuf.python.python_protobuf_subsystem import PythonProtobufSubsystem
+from pants.backend.codegen.protobuf.target_types import ProtobufGrcpToggle, ProtobufSources
+from pants.backend.python.dependency_inference.module_mapper import (
+    PythonFirstPartyModuleMappingPlugin,
+    PythonFirstPartyModuleMappingPluginRequest,
+)
+from pants.base.specs import AddressSpecs, DescendantAddresses
+from pants.core.util_rules.stripped_source_files import StrippedSourceFileNames
+from pants.engine.addresses import Address
+from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.target import SourcesPathsRequest, Target, Targets
+from pants.engine.unions import UnionRule
+from pants.util.frozendict import FrozenDict
+from pants.util.logging import LogLevel
+
+
+def proto_path_to_py_module(stripped_path: str, *, suffix: str) -> str:
+    return stripped_path.replace(".proto", suffix).replace("/", ".")
+
+
+# This is only used to register our implementation with the plugin hook via unions.
+class PythonProtobufMappingRequest(PythonFirstPartyModuleMappingPluginRequest):
+    pass
+
+
+@rule(desc="Creating map of Protobuf targets to generated Python modules", level=LogLevel.DEBUG)
+async def map_protobuf_to_python_modules(
+    _: PythonProtobufMappingRequest, python_protobuf_subsystem: PythonProtobufSubsystem
+) -> PythonFirstPartyModuleMappingPlugin:
+    if not python_protobuf_subsystem.dependency_inference:
+        return PythonFirstPartyModuleMappingPlugin(FrozenDict())
+
+    all_expanded_targets = await Get(Targets, AddressSpecs([DescendantAddresses("")]))
+    protobuf_targets = tuple(tgt for tgt in all_expanded_targets if tgt.has_field(ProtobufSources))
+    stripped_sources_per_target = await MultiGet(
+        Get(StrippedSourceFileNames, SourcesPathsRequest(tgt[ProtobufSources]))
+        for tgt in protobuf_targets
+    )
+
+    modules_to_addresses: Dict[str, Address] = {}
+    modules_with_multiple_owners: Set[str] = set()
+
+    def add_module(module: str, tgt: Target) -> None:
+        if module in modules_to_addresses:
+            modules_with_multiple_owners.add(module)
+        else:
+            modules_to_addresses[module] = tgt.address
+
+    for tgt, stripped_sources in zip(protobuf_targets, stripped_sources_per_target):
+        for stripped_f in stripped_sources:
+            # NB: We don't consider the MyPy plugin, which generates `_pb2.pyi`. The stubs end up
+            # sharing the same module as the implementation `_pb2.py`. Because both generated files
+            # come from the same original Protobuf target, we're covered.
+            add_module(proto_path_to_py_module(stripped_f, suffix="_pb2"), tgt)
+            if tgt.get(ProtobufGrcpToggle).value:
+                add_module(proto_path_to_py_module(stripped_f, suffix="_pb2_grpc"), tgt)
+
+    # Remove modules with ambiguous owners.
+    for ambiguous_module in modules_with_multiple_owners:
+        modules_to_addresses.pop(ambiguous_module)
+
+    return PythonFirstPartyModuleMappingPlugin(FrozenDict(modules_to_addresses))
+
+
+def rules():
+    return (
+        *collect_rules(),
+        UnionRule(PythonFirstPartyModuleMappingPluginRequest, PythonProtobufMappingRequest),
+    )

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_module_mapper.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_module_mapper.py
@@ -3,8 +3,7 @@
 
 from typing import Dict, Set
 
-from pants.backend.codegen.protobuf.python.python_protobuf_subsystem import PythonProtobufSubsystem
-from pants.backend.codegen.protobuf.target_types import ProtobufGrcpToggle, ProtobufSources
+from pants.backend.codegen.protobuf.target_types import ProtobufGrpcToggle, ProtobufSources
 from pants.backend.python.dependency_inference.module_mapper import (
     PythonFirstPartyModuleMappingPlugin,
     PythonFirstPartyModuleMappingPluginRequest,
@@ -30,11 +29,8 @@ class PythonProtobufMappingRequest(PythonFirstPartyModuleMappingPluginRequest):
 
 @rule(desc="Creating map of Protobuf targets to generated Python modules", level=LogLevel.DEBUG)
 async def map_protobuf_to_python_modules(
-    _: PythonProtobufMappingRequest, python_protobuf_subsystem: PythonProtobufSubsystem
+    _: PythonProtobufMappingRequest
 ) -> PythonFirstPartyModuleMappingPlugin:
-    if not python_protobuf_subsystem.dependency_inference:
-        return PythonFirstPartyModuleMappingPlugin(FrozenDict())
-
     all_expanded_targets = await Get(Targets, AddressSpecs([DescendantAddresses("")]))
     protobuf_targets = tuple(tgt for tgt in all_expanded_targets if tgt.has_field(ProtobufSources))
     stripped_sources_per_target = await MultiGet(
@@ -57,7 +53,7 @@ async def map_protobuf_to_python_modules(
             # sharing the same module as the implementation `_pb2.py`. Because both generated files
             # come from the same original Protobuf target, we're covered.
             add_module(proto_path_to_py_module(stripped_f, suffix="_pb2"), tgt)
-            if tgt.get(ProtobufGrcpToggle).value:
+            if tgt.get(ProtobufGrpcToggle).value:
                 add_module(proto_path_to_py_module(stripped_f, suffix="_pb2_grpc"), tgt)
 
     # Remove modules with ambiguous owners.

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_module_mapper.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_module_mapper.py
@@ -1,12 +1,12 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Dict, Set
+from typing import Dict, Set, Tuple
 
 from pants.backend.codegen.protobuf.target_types import ProtobufGrpcToggle, ProtobufSources
 from pants.backend.python.dependency_inference.module_mapper import (
-    PythonFirstPartyModuleMappingPlugin,
-    PythonFirstPartyModuleMappingPluginRequest,
+    FirstPartyPythonMappingImpl,
+    FirstPartyPythonMappingImplMarker,
 )
 from pants.base.specs import AddressSpecs, DescendantAddresses
 from pants.core.util_rules.stripped_source_files import StrippedSourceFileNames
@@ -14,7 +14,6 @@ from pants.engine.addresses import Address
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import SourcesPathsRequest, Target, Targets
 from pants.engine.unions import UnionRule
-from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 
 
@@ -23,14 +22,14 @@ def proto_path_to_py_module(stripped_path: str, *, suffix: str) -> str:
 
 
 # This is only used to register our implementation with the plugin hook via unions.
-class PythonProtobufMappingRequest(PythonFirstPartyModuleMappingPluginRequest):
+class PythonProtobufMappingMarker(FirstPartyPythonMappingImplMarker):
     pass
 
 
 @rule(desc="Creating map of Protobuf targets to generated Python modules", level=LogLevel.DEBUG)
 async def map_protobuf_to_python_modules(
-    _: PythonProtobufMappingRequest
-) -> PythonFirstPartyModuleMappingPlugin:
+    _: PythonProtobufMappingMarker,
+) -> FirstPartyPythonMappingImpl:
     all_expanded_targets = await Get(Targets, AddressSpecs([DescendantAddresses("")]))
     protobuf_targets = tuple(tgt for tgt in all_expanded_targets if tgt.has_field(ProtobufSources))
     stripped_sources_per_target = await MultiGet(
@@ -38,14 +37,14 @@ async def map_protobuf_to_python_modules(
         for tgt in protobuf_targets
     )
 
-    modules_to_addresses: Dict[str, Address] = {}
+    modules_to_addresses: Dict[str, Tuple[Address]] = {}
     modules_with_multiple_owners: Set[str] = set()
 
     def add_module(module: str, tgt: Target) -> None:
         if module in modules_to_addresses:
             modules_with_multiple_owners.add(module)
         else:
-            modules_to_addresses[module] = tgt.address
+            modules_to_addresses[module] = (tgt.address,)
 
     for tgt, stripped_sources in zip(protobuf_targets, stripped_sources_per_target):
         for stripped_f in stripped_sources:
@@ -60,11 +59,11 @@ async def map_protobuf_to_python_modules(
     for ambiguous_module in modules_with_multiple_owners:
         modules_to_addresses.pop(ambiguous_module)
 
-    return PythonFirstPartyModuleMappingPlugin(FrozenDict(modules_to_addresses))
+    return FirstPartyPythonMappingImpl(modules_to_addresses)
 
 
 def rules():
     return (
         *collect_rules(),
-        UnionRule(PythonFirstPartyModuleMappingPluginRequest, PythonProtobufMappingRequest),
+        UnionRule(FirstPartyPythonMappingImplMarker, PythonProtobufMappingMarker),
     )

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_module_mapper_test.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_module_mapper_test.py
@@ -1,0 +1,60 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import pytest
+
+from pants.backend.codegen.protobuf.python import additional_fields, python_protobuf_module_mapper
+from pants.backend.codegen.protobuf.python.python_protobuf_module_mapper import (
+    PythonProtobufMappingRequest,
+)
+from pants.backend.codegen.protobuf.target_types import ProtobufLibrary
+from pants.backend.python.dependency_inference.module_mapper import (
+    PythonFirstPartyModuleMappingPlugin,
+)
+from pants.core.util_rules import stripped_source_files
+from pants.engine.addresses import Address
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.util.frozendict import FrozenDict
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *additional_fields.rules(),
+            *stripped_source_files.rules(),
+            *python_protobuf_module_mapper.rules(),
+            QueryRule(PythonFirstPartyModuleMappingPlugin, [PythonProtobufMappingRequest]),
+        ],
+        target_types=[ProtobufLibrary],
+    )
+
+
+def test_map_first_party_modules_to_addresses(rule_runner: RuleRunner) -> None:
+    rule_runner.set_options(["--source-root-patterns=['root1', 'root2', 'root3']"])
+    # Two proto files belonging to the same target. We should use two file addresses.
+    rule_runner.create_files("root1/protos", ["f1.proto", "f2.proto"])
+    rule_runner.add_to_build_file("root1/protos", "protobuf_library()")
+    # These protos would result in the same module name, so neither should be used.
+    rule_runner.create_file("root1/two_owners/f.proto")
+    rule_runner.add_to_build_file("root1/two_owners", "protobuf_library()")
+    rule_runner.create_file("root2/two_owners/f.proto")
+    rule_runner.add_to_build_file("root2/two_owners", "protobuf_library()")
+    # A file with grpc. This also uses the `python_source_root` mechanism, which should be
+    # irrelevant to the module mapping because we strip source roots.
+    rule_runner.create_file("root1/tests/f.proto")
+    rule_runner.add_to_build_file(
+        "root1/tests", "protobuf_library(grpc=True, python_source_root='root3')"
+    )
+
+    result = rule_runner.request(
+        PythonFirstPartyModuleMappingPlugin, [PythonProtobufMappingRequest()]
+    )
+    assert result.mapping == FrozenDict(
+        {
+            "protos.f1_pb2": Address("root1/protos", relative_file_path="f1.proto"),
+            "protos.f2_pb2": Address("root1/protos", relative_file_path="f2.proto"),
+            "tests.f_pb2": Address("root1/tests", relative_file_path="f.proto"),
+            "tests.f_pb2_grpc": Address("root1/tests", relative_file_path="f.proto"),
+        }
+    )

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_module_mapper_test.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_module_mapper_test.py
@@ -29,14 +29,17 @@ def rule_runner() -> RuleRunner:
 
 def test_map_first_party_modules_to_addresses(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(["--source-root-patterns=['root1', 'root2', 'root3']"])
+
     # Two proto files belonging to the same target. We should use two file addresses.
     rule_runner.create_files("root1/protos", ["f1.proto", "f2.proto"])
     rule_runner.add_to_build_file("root1/protos", "protobuf_library()")
+
     # These protos would result in the same module name, so neither should be used.
     rule_runner.create_file("root1/two_owners/f.proto")
     rule_runner.add_to_build_file("root1/two_owners", "protobuf_library()")
     rule_runner.create_file("root2/two_owners/f.proto")
     rule_runner.add_to_build_file("root2/two_owners", "protobuf_library()")
+
     # A file with grpc. This also uses the `python_source_root` mechanism, which should be
     # irrelevant to the module mapping because we strip source roots.
     rule_runner.create_file("root1/tests/f.proto")

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -60,7 +60,7 @@ class PythonProtobufSubsystem(Subsystem):
             advanced=True,
             help=(
                 "Infer when Python code depends on generated Protobuf files. This requires that "
-                "`[python-infer].inits` is also true (the default)."
+                "`[python-infer].imports` is also true (the default)."
             ),
         )
 

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -53,16 +53,6 @@ class PythonProtobufSubsystem(Subsystem):
                 "`--mypy-plugin` for this option to be used."
             ),
         )
-        register(
-            "--dependency-inference",
-            type=bool,
-            default=True,
-            advanced=True,
-            help=(
-                "Infer when Python code depends on generated Protobuf files. This requires that "
-                "`[python-infer].imports` is also true (the default)."
-            ),
-        )
 
     @property
     def runtime_dependencies(self) -> UnparsedAddressInputs:
@@ -75,10 +65,6 @@ class PythonProtobufSubsystem(Subsystem):
     @property
     def mypy_plugin_version(self) -> str:
         return cast(str, self.options.mypy_plugin_version)
-
-    @property
-    def dependency_inference(self) -> bool:
-        return cast(bool, self.options.dependency_inference)
 
 
 class InjectPythonProtobufDependencies(InjectDependenciesRequest):

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -53,6 +53,16 @@ class PythonProtobufSubsystem(Subsystem):
                 "`--mypy-plugin` for this option to be used."
             ),
         )
+        register(
+            "--dependency-inference",
+            type=bool,
+            default=True,
+            advanced=True,
+            help=(
+                "Infer when Python code depends on generated Protobuf files. This requires that "
+                "`[python-infer].inits` is also true (the default)."
+            ),
+        )
 
     @property
     def runtime_dependencies(self) -> UnparsedAddressInputs:
@@ -65,6 +75,10 @@ class PythonProtobufSubsystem(Subsystem):
     @property
     def mypy_plugin_version(self) -> str:
         return cast(str, self.options.mypy_plugin_version)
+
+    @property
+    def dependency_inference(self) -> bool:
+        return cast(bool, self.options.dependency_inference)
 
 
 class InjectPythonProtobufDependencies(InjectDependenciesRequest):

--- a/src/python/pants/backend/codegen/protobuf/python/register.py
+++ b/src/python/pants/backend/codegen/protobuf/python/register.py
@@ -7,7 +7,11 @@ See https://www.pantsbuild.org/docs/protobuf.
 """
 
 from pants.backend.codegen import export_codegen_goal
-from pants.backend.codegen.protobuf.python import additional_fields, python_protobuf_subsystem
+from pants.backend.codegen.protobuf.python import (
+    additional_fields,
+    python_protobuf_module_mapper,
+    python_protobuf_subsystem,
+)
 from pants.backend.codegen.protobuf.python.rules import rules as python_rules
 from pants.backend.codegen.protobuf.target_types import ProtobufLibrary
 
@@ -17,6 +21,7 @@ def rules():
         *additional_fields.rules(),
         *python_protobuf_subsystem.rules(),
         *python_rules(),
+        *python_protobuf_module_mapper.rules(),
         *export_codegen_goal.rules(),
     ]
 

--- a/src/python/pants/backend/codegen/protobuf/python/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules.py
@@ -7,7 +7,7 @@ from pants.backend.codegen.protobuf.protoc import Protoc
 from pants.backend.codegen.protobuf.python.additional_fields import PythonSourceRootField
 from pants.backend.codegen.protobuf.python.grpc_python_plugin import GrpcPythonPlugin
 from pants.backend.codegen.protobuf.python.python_protobuf_subsystem import PythonProtobufSubsystem
-from pants.backend.codegen.protobuf.target_types import ProtobufGrcpToggle, ProtobufSources
+from pants.backend.codegen.protobuf.target_types import ProtobufGrpcToggle, ProtobufSources
 from pants.backend.python.target_types import PythonSources
 from pants.backend.python.util_rules import extract_pex, pex
 from pants.backend.python.util_rules.extract_pex import ExtractedPexDistributions
@@ -119,7 +119,7 @@ async def generate_python_from_protobuf(
             ExternalToolRequest,
             grpc_python_plugin.get_request(Platform.current),
         )
-        if request.protocol_target.get(ProtobufGrcpToggle).value
+        if request.protocol_target.get(ProtobufGrpcToggle).value
         else None
     )
 

--- a/src/python/pants/backend/codegen/protobuf/target_types.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types.py
@@ -15,7 +15,7 @@ class ProtobufSources(Sources):
     expected_file_extensions = (".proto",)
 
 
-class ProtobufGrcpToggle(BoolField):
+class ProtobufGrpcToggle(BoolField):
     """Whether to generate gRPC code or not."""
 
     alias = "grpc"
@@ -29,4 +29,4 @@ class ProtobufLibrary(Target):
     """
 
     alias = "protobuf_library"
-    core_fields = (*COMMON_TARGET_FIELDS, ProtobufDependencies, ProtobufSources, ProtobufGrcpToggle)
+    core_fields = (*COMMON_TARGET_FIELDS, ProtobufDependencies, ProtobufSources, ProtobufGrpcToggle)

--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -17,7 +17,7 @@ from pants.engine.addresses import Address
 from pants.engine.collection import Collection
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import SourcesPathsRequest, Targets
-from pants.engine.unions import UnionMembership, union
+from pants.engine.unions import UnionMembership, UnionRule, union
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 
@@ -34,47 +34,43 @@ class PythonModule:
         return cls(module_name_with_slashes.as_posix().replace("/", "."))
 
 
-@dataclass(frozen=True)
-class PythonFirstPartyModuleMappingPlugin:
-    """A mapping of module names to owning addresses that a plugin adds for Python import dependency
-    inference."""
+# -----------------------------------------------------------------------------------------------
+# First-party module mapping
+# -----------------------------------------------------------------------------------------------
 
-    mapping: FrozenDict[str, Address]
+
+class FirstPartyPythonMappingImpl(FrozenDict[str, Tuple[Address, ...]]):
+    """A mapping of module names to owning addresses that a specific implementation adds for Python
+    import dependency inference.
+
+    For almost every implementation, there should only be one address per module to avoid ambiguity.
+    However, the built-in implementation allows for 2 addresses when `.pyi` type stubs are used.
+    """
 
 
 @union
-class PythonFirstPartyModuleMappingPluginRequest:
-    """A request for a plugin to create a mapping of module names to owning addresses to be added
-    for Python import dependency inference.
+class FirstPartyPythonMappingImplMarker:
+    """An entry point for a specific implementation of mapping module names to owning targets for
+    Python import dependency inference.
 
-    These modules will be combined with the built-in first-party module mapping. Any conflicting
-    modules will be removed due to ambiguity.
+    All implementations will be merged together. Any conflicting modules will be removed due to
+    ambiguity.
 
     The addresses should all be file addresses, rather than BUILD addresses.
     """
 
 
-@dataclass(frozen=True)
-class PythonFirstPartyModuleMapping:
-    """A mapping of module names to owning addresses.
+class FirstPartyPythonModuleMapping(FrozenDict[str, Tuple[Address, ...]]):
+    """A merged mapping of module names to owning addresses.
 
-    All mapped addresses will be file addresses, aka generated subtargets. That is, each target
-    will own no more than one single source file.
-
-    If there are >1 original owning targets that refer to the same module—such as `//:a` and `//:b`
-    both owning module `foo`—then we will not add any of the targets to the mapping because there
-    is ambiguity. (We make an exception if one target is an implementation (.py file) and the other
-    is a type stub (.pyi file).
+    This mapping may have been constructed from multiple distinct implementations, e.g.
+    implementations for each codegen backends.
     """
 
-    # The mapping should either have 1 or 2 addresses per module, depending on if there is a type
-    # stub.
-    mapping: FrozenDict[str, Tuple[Address, ...]]
-
     def addresses_for_module(self, module: str) -> Tuple[Address, ...]:
-        targets = self.mapping.get(module)
-        if targets:
-            return targets
+        addresses = self.get(module)
+        if addresses:
+            return addresses
         # If the module is not found, try the parent, if any. This is to accommodate `from`
         # imports, where we don't care about the specific symbol, but only the module. For example,
         # with `from my_project.app import App`, we only care about the `my_project.app` part.
@@ -85,22 +81,44 @@ class PythonFirstPartyModuleMapping:
         if "." not in module:
             return ()
         parent_module = module.rsplit(".", maxsplit=1)[0]
-        return self.mapping.get(parent_module, ())
+        return self.get(parent_module, ())
 
 
-@rule(desc="Creating map of first party targets to Python modules", level=LogLevel.DEBUG)
-async def map_first_party_modules_to_addresses(
+@rule(level=LogLevel.DEBUG)
+async def merge_first_party_module_mappings(
     union_membership: UnionMembership,
-) -> PythonFirstPartyModuleMapping:
-    plugin_mappings = await MultiGet(
+) -> FirstPartyPythonModuleMapping:
+    all_mappings = await MultiGet(
         Get(
-            PythonFirstPartyModuleMappingPlugin,
-            PythonFirstPartyModuleMappingPluginRequest,
-            request_cls(),
+            FirstPartyPythonMappingImpl,
+            FirstPartyPythonMappingImplMarker,
+            marker_cls(),
         )
-        for request_cls in union_membership.get(PythonFirstPartyModuleMappingPluginRequest)
+        for marker_cls in union_membership.get(FirstPartyPythonMappingImplMarker)
     )
+    modules_to_addresses: Dict[str, Tuple[Address, ...]] = {}
+    modules_with_multiple_implementations: Set[str] = set()
+    for mapping in all_mappings:
+        for module, addresses in mapping.items():
+            if module in modules_to_addresses:
+                modules_with_multiple_implementations.add(module)
+            else:
+                modules_to_addresses[module] = addresses
+    for module in modules_with_multiple_implementations:
+        modules_to_addresses.pop(module)
+    return FirstPartyPythonModuleMapping(sorted(modules_to_addresses.items()))
 
+
+# This is only used to register our implementation with the plugin hook via unions. Note that we
+# implement this like any other plugin implementation so that we can run them all in parallel.
+class FirstPartyPythonTargetsMappingMarker(FirstPartyPythonMappingImplMarker):
+    pass
+
+
+@rule(desc="Creating map of first party Python targets to Python modules", level=LogLevel.DEBUG)
+async def map_first_party_python_targets_to_modules(
+    _: FirstPartyPythonTargetsMappingMarker,
+) -> FirstPartyPythonMappingImpl:
     all_expanded_targets = await Get(Targets, AddressSpecs([DescendantAddresses("")]))
     candidate_targets = tuple(tgt for tgt in all_expanded_targets if tgt.has_field(PythonSources))
     stripped_sources_per_target = await MultiGet(
@@ -131,32 +149,21 @@ async def map_first_party_modules_to_addresses(
     for module in modules_with_multiple_implementations:
         modules_to_addresses.pop(module)
 
-    # Merge in the plugin mappings. If the same module is used by >1 implementation, we ignore
-    # it, regardless of the above semantics of `.pyi` type stub files.
-    merged_modules_to_addresses: Dict[str, Tuple[Address, ...]] = {
-        module: tuple(sorted(addresses)) for module, addresses in modules_to_addresses.items()
-    }
-    merged_modules_with_multiple_implementations: Set[str] = set()
-    for plugin_mapping in plugin_mappings:
-        for module, address in plugin_mapping.mapping.items():
-            if module in merged_modules_to_addresses:
-                merged_modules_with_multiple_implementations.add(module)
-            else:
-                merged_modules_to_addresses[module] = (address,)
-    for module in merged_modules_with_multiple_implementations:
-        merged_modules_to_addresses.pop(module)
-
-    return PythonFirstPartyModuleMapping(FrozenDict(sorted(merged_modules_to_addresses.items())))
+    return FirstPartyPythonMappingImpl(
+        {k: tuple(sorted(v)) for k, v in modules_to_addresses.items()}
+    )
 
 
-@dataclass(frozen=True)
-class PythonThirdPartyModuleMapping:
-    mapping: FrozenDict[str, Address]
+# -----------------------------------------------------------------------------------------------
+# Third party module mapping
+# -----------------------------------------------------------------------------------------------
 
+
+class ThirdPartyPythonModuleMapping(FrozenDict[str, Address]):
     def address_for_module(self, module: str) -> Optional[Address]:
-        target = self.mapping.get(module)
-        if target is not None:
-            return target
+        address = self.get(module)
+        if address is not None:
+            return address
         # If the module is not found, recursively try the ancestor modules, if any. For example,
         # pants.task.task.Task -> pants.task.task -> pants.task -> pants
         if "." not in module:
@@ -166,7 +173,7 @@ class PythonThirdPartyModuleMapping:
 
 
 @rule(desc="Creating map of third party targets to Python modules", level=LogLevel.DEBUG)
-async def map_third_party_modules_to_addresses() -> PythonThirdPartyModuleMapping:
+async def map_third_party_modules_to_addresses() -> ThirdPartyPythonModuleMapping:
     all_targets = await Get(Targets, AddressSpecs([DescendantAddresses("")]))
     modules_to_addresses: Dict[str, Address] = {}
     modules_with_multiple_owners: Set[str] = set()
@@ -187,7 +194,12 @@ async def map_third_party_modules_to_addresses() -> PythonThirdPartyModuleMappin
     # Remove modules with ambiguous owners.
     for module in modules_with_multiple_owners:
         modules_to_addresses.pop(module)
-    return PythonThirdPartyModuleMapping(FrozenDict(sorted(modules_to_addresses.items())))
+    return ThirdPartyPythonModuleMapping(sorted(modules_to_addresses.items()))
+
+
+# -----------------------------------------------------------------------------------------------
+# module -> owners
+# -----------------------------------------------------------------------------------------------
 
 
 class PythonModuleOwners(Collection[Address]):
@@ -201,8 +213,8 @@ class PythonModuleOwners(Collection[Address]):
 @rule
 async def map_module_to_address(
     module: PythonModule,
-    first_party_mapping: PythonFirstPartyModuleMapping,
-    third_party_mapping: PythonThirdPartyModuleMapping,
+    first_party_mapping: FirstPartyPythonModuleMapping,
+    third_party_mapping: ThirdPartyPythonModuleMapping,
 ) -> PythonModuleOwners:
     third_party_address = third_party_mapping.address_for_module(module.module)
     first_party_addresses = first_party_mapping.addresses_for_module(module.module)
@@ -233,4 +245,7 @@ async def map_module_to_address(
 
 
 def rules():
-    return collect_rules()
+    return (
+        *collect_rules(),
+        UnionRule(FirstPartyPythonMappingImplMarker, FirstPartyPythonTargetsMappingMarker),
+    )

--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -17,6 +17,7 @@ from pants.engine.addresses import Address
 from pants.engine.collection import Collection
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import SourcesPathsRequest, Targets
+from pants.engine.unions import UnionMembership, union
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 
@@ -34,15 +35,36 @@ class PythonModule:
 
 
 @dataclass(frozen=True)
-class FirstPartyModuleToAddressMapping:
+class PythonFirstPartyModuleMappingPlugin:
+    """A mapping of module names to owning addresses that a plugin adds for Python import dependency
+    inference."""
+
+    mapping: FrozenDict[str, Address]
+
+
+@union
+class PythonFirstPartyModuleMappingPluginRequest:
+    """A request for a plugin to create a mapping of module names to owning addresses to be added
+    for Python import dependency inference.
+
+    These modules will be combined with the built-in first-party module mapping. Any conflicting
+    modules will be removed due to ambiguity.
+
+    The addresses should all be file addresses, rather than BUILD addresses.
+    """
+
+
+@dataclass(frozen=True)
+class PythonFirstPartyModuleMapping:
     """A mapping of module names to owning addresses.
 
     All mapped addresses will be file addresses, aka generated subtargets. That is, each target
     will own no more than one single source file.
 
-    If there are >1 original owning targets that refer to the same module—such as `//:a` and `//:b` both owning module
-    `foo`—then we will not add any of the targets to the mapping because there is ambiguity. (We make an exception if
-    one target is an implementation (.py file) and the other is a type stub (.pyi file).
+    If there are >1 original owning targets that refer to the same module—such as `//:a` and `//:b`
+    both owning module `foo`—then we will not add any of the targets to the mapping because there
+    is ambiguity. (We make an exception if one target is an implementation (.py file) and the other
+    is a type stub (.pyi file).
     """
 
     # The mapping should either have 1 or 2 addresses per module, depending on if there is a type
@@ -57,8 +79,9 @@ class FirstPartyModuleToAddressMapping:
         # imports, where we don't care about the specific symbol, but only the module. For example,
         # with `from my_project.app import App`, we only care about the `my_project.app` part.
         #
-        # We do not look past the direct parent, as this could cause multiple ambiguous owners to be resolved. This
-        # contrasts with the third-party module mapping, which will try every ancestor.
+        # We do not look past the direct parent, as this could cause multiple ambiguous owners to
+        # be resolved. This contrasts with the third-party module mapping, which will try every
+        # ancestor.
         if "." not in module:
             return ()
         parent_module = module.rsplit(".", maxsplit=1)[0]
@@ -66,7 +89,18 @@ class FirstPartyModuleToAddressMapping:
 
 
 @rule(desc="Creating map of first party targets to Python modules", level=LogLevel.DEBUG)
-async def map_first_party_modules_to_addresses() -> FirstPartyModuleToAddressMapping:
+async def map_first_party_modules_to_addresses(
+    union_membership: UnionMembership,
+) -> PythonFirstPartyModuleMapping:
+    plugin_mappings = await MultiGet(
+        Get(
+            PythonFirstPartyModuleMappingPlugin,
+            PythonFirstPartyModuleMappingPluginRequest,
+            request_cls(),
+        )
+        for request_cls in union_membership.get(PythonFirstPartyModuleMappingPluginRequest)
+    )
+
     all_expanded_targets = await Get(Targets, AddressSpecs([DescendantAddresses("")]))
     candidate_targets = tuple(tgt for tgt in all_expanded_targets if tgt.has_field(PythonSources))
     stripped_sources_per_target = await MultiGet(
@@ -96,18 +130,27 @@ async def map_first_party_modules_to_addresses() -> FirstPartyModuleToAddressMap
     # Remove modules with ambiguous owners.
     for module in modules_with_multiple_implementations:
         modules_to_addresses.pop(module)
-    return FirstPartyModuleToAddressMapping(
-        FrozenDict(
-            {
-                module: tuple(sorted(addresses))
-                for module, addresses in sorted(modules_to_addresses.items())
-            }
-        )
-    )
+
+    # Merge in the plugin mappings. If the same module is used by >1 implementation, we ignore
+    # it, regardless of the above semantics of `.pyi` type stub files.
+    merged_modules_to_addresses: Dict[str, Tuple[Address, ...]] = {
+        module: tuple(sorted(addresses)) for module, addresses in modules_to_addresses.items()
+    }
+    merged_modules_with_multiple_implementations: Set[str] = set()
+    for plugin_mapping in plugin_mappings:
+        for module, address in plugin_mapping.mapping.items():
+            if module in merged_modules_to_addresses:
+                merged_modules_with_multiple_implementations.add(module)
+            else:
+                merged_modules_to_addresses[module] = (address,)
+    for module in merged_modules_with_multiple_implementations:
+        merged_modules_to_addresses.pop(module)
+
+    return PythonFirstPartyModuleMapping(FrozenDict(sorted(merged_modules_to_addresses.items())))
 
 
 @dataclass(frozen=True)
-class ThirdPartyModuleToAddressMapping:
+class PythonThirdPartyModuleMapping:
     mapping: FrozenDict[str, Address]
 
     def address_for_module(self, module: str) -> Optional[Address]:
@@ -123,7 +166,7 @@ class ThirdPartyModuleToAddressMapping:
 
 
 @rule(desc="Creating map of third party targets to Python modules", level=LogLevel.DEBUG)
-async def map_third_party_modules_to_addresses() -> ThirdPartyModuleToAddressMapping:
+async def map_third_party_modules_to_addresses() -> PythonThirdPartyModuleMapping:
     all_targets = await Get(Targets, AddressSpecs([DescendantAddresses("")]))
     modules_to_addresses: Dict[str, Address] = {}
     modules_with_multiple_owners: Set[str] = set()
@@ -144,7 +187,7 @@ async def map_third_party_modules_to_addresses() -> ThirdPartyModuleToAddressMap
     # Remove modules with ambiguous owners.
     for module in modules_with_multiple_owners:
         modules_to_addresses.pop(module)
-    return ThirdPartyModuleToAddressMapping(FrozenDict(sorted(modules_to_addresses.items())))
+    return PythonThirdPartyModuleMapping(FrozenDict(sorted(modules_to_addresses.items())))
 
 
 class PythonModuleOwners(Collection[Address]):
@@ -158,15 +201,16 @@ class PythonModuleOwners(Collection[Address]):
 @rule
 async def map_module_to_address(
     module: PythonModule,
-    first_party_mapping: FirstPartyModuleToAddressMapping,
-    third_party_mapping: ThirdPartyModuleToAddressMapping,
+    first_party_mapping: PythonFirstPartyModuleMapping,
+    third_party_mapping: PythonThirdPartyModuleMapping,
 ) -> PythonModuleOwners:
     third_party_address = third_party_mapping.address_for_module(module.module)
     first_party_addresses = first_party_mapping.addresses_for_module(module.module)
 
-    # It's possible for a user to write type stubs (`.pyi` files) for their third-party dependencies. We check if that
-    # happened, but we're strict in validating that there is only a single third party address and a single first-party
-    # address referring to a `.pyi` file; otherwise, we have ambiguous implementations, so no-op.
+    # It's possible for a user to write type stubs (`.pyi` files) for their third-party
+    # dependencies. We check if that happened, but we're strict in validating that there is only a
+    # single third party address and a single first-party address referring to a `.pyi` file;
+    # otherwise, we have ambiguous implementations, so no-op.
     third_party_resolved_only = third_party_address and not first_party_addresses
     third_party_resolved_with_type_stub = (
         third_party_address

--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -120,15 +120,15 @@ async def map_first_party_python_targets_to_modules(
     _: FirstPartyPythonTargetsMappingMarker,
 ) -> FirstPartyPythonMappingImpl:
     all_expanded_targets = await Get(Targets, AddressSpecs([DescendantAddresses("")]))
-    candidate_targets = tuple(tgt for tgt in all_expanded_targets if tgt.has_field(PythonSources))
+    python_targets = tuple(tgt for tgt in all_expanded_targets if tgt.has_field(PythonSources))
     stripped_sources_per_target = await MultiGet(
         Get(StrippedSourceFileNames, SourcesPathsRequest(tgt[PythonSources]))
-        for tgt in candidate_targets
+        for tgt in python_targets
     )
 
     modules_to_addresses: DefaultDict[str, List[Address]] = defaultdict(list)
     modules_with_multiple_implementations: Set[str] = set()
-    for tgt, stripped_sources in zip(candidate_targets, stripped_sources_per_target):
+    for tgt, stripped_sources in zip(python_targets, stripped_sources_per_target):
         for stripped_f in stripped_sources:
             module = PythonModule.create_from_stripped_path(PurePath(stripped_f)).module
             if module in modules_to_addresses:

--- a/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
@@ -85,21 +85,26 @@ def test_map_first_party_modules_to_addresses(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(
         ["--source-root-patterns=['src/python', 'tests/python', 'build-support']"]
     )
+
     # Two modules belonging to the same target. We should generate subtargets for each file.
     rule_runner.create_files("src/python/project/util", ["dirutil.py", "tarutil.py"])
     rule_runner.add_to_build_file("src/python/project/util", "python_library()")
+
     # A module with two owners, meaning that neither should be resolved.
     rule_runner.create_file("src/python/two_owners.py")
     rule_runner.add_to_build_file("src/python", "python_library()")
     rule_runner.create_file("build-support/two_owners.py")
     rule_runner.add_to_build_file("build-support", "python_library()")
+
     # A package module. Because there's only one source file belonging to the target, we should
     # not generate subtargets.
     rule_runner.create_file("tests/python/project_test/demo_test/__init__.py")
     rule_runner.add_to_build_file("tests/python/project_test/demo_test", "python_library()")
+
     # A module with both an implementation and a type stub.
     rule_runner.create_files("src/python/stubs", ["stub.py", "stub.pyi"])
     rule_runner.add_to_build_file("src/python/stubs", "python_library()")
+
     # Check that plugin mappings work. Note that we duplicate one of the files with a normal
     # python_library(), which means neither the Protobuf nor Python targets should be used.
     rule_runner.create_files("src/python/protos", ["f1.proto", "f2.proto", "f2_pb2.py"])


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/11184. Protobuf and gRPC are very predictable with the modules they generate. Further, we strip source roots, so we don't need to worry about where the files are located or the `python_source_root` field.

The only challenge is exposing an entry point for `[python-infer].imports`. We add a hook for different implementations to contribute to the final merged first-party module mapping. We use this hook with our original implementation so that it runs in parallel with all plugin implementations.

[ci skip-rust]
[ci skip-build-wheels]