### PR TITLE
Add dependency inference for Protobuf <-> Protobuf imports

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -5,6 +5,7 @@ print_stacktrace = true
 pythonpath = ["%(buildroot)s/pants-plugins"]
 backend_packages.add = [
   "pants.backend.python",
+  "pants.backend.codegen.protobuf.python",
   "pants.backend.python.lint.black",
   "pants.backend.python.lint.docformatter",
   "pants.backend.python.lint.flake8",

--- a/src/python/pants/backend/codegen/protobuf/BUILD
+++ b/src/python/pants/backend/codegen/protobuf/BUILD
@@ -2,3 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library()
+
+python_tests(name="tests")

--- a/src/python/pants/backend/codegen/protobuf/protobuf_dependency_inference.py
+++ b/src/python/pants/backend/codegen/protobuf/protobuf_dependency_inference.py
@@ -56,7 +56,6 @@ async def map_protobuf_files() -> ProtobufMapping:
 
 # See https://developers.google.com/protocol-buffers/docs/reference/proto3-spec for the Proto
 # language spec.
-# PROTO_FILE_CHARS = r"a-zA-Z0-9/\\\-\_"
 QUOTE_CHAR = r"(?:'|\")"
 IMPORT_MODIFIERS = r"(?:\spublic|\sweak)?"
 FILE_NAME = r"(.+?\.proto)"

--- a/src/python/pants/backend/codegen/protobuf/protobuf_dependency_inference.py
+++ b/src/python/pants/backend/codegen/protobuf/protobuf_dependency_inference.py
@@ -19,6 +19,7 @@ from pants.engine.target import (
     SourcesPathsRequest,
     Targets,
 )
+from pants.engine.unions import UnionRule
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
@@ -92,4 +93,4 @@ async def infer_protobuf_dependencies(
 
 
 def rules():
-    return collect_rules()
+    return (*collect_rules(), UnionRule(InferDependenciesRequest, InferProtobufDependencies))

--- a/src/python/pants/backend/codegen/protobuf/protobuf_dependency_inference.py
+++ b/src/python/pants/backend/codegen/protobuf/protobuf_dependency_inference.py
@@ -1,0 +1,95 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import re
+from typing import Dict, Set
+
+from pants.backend.codegen.protobuf.protoc import Protoc
+from pants.backend.codegen.protobuf.target_types import ProtobufSources
+from pants.base.specs import AddressSpecs, DescendantAddresses
+from pants.core.util_rules.stripped_source_files import StrippedSourceFileNames
+from pants.engine.addresses import Address
+from pants.engine.fs import Digest, DigestContents
+from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.target import (
+    HydratedSources,
+    HydrateSourcesRequest,
+    InferDependenciesRequest,
+    InferredDependencies,
+    SourcesPathsRequest,
+    Targets,
+)
+from pants.util.frozendict import FrozenDict
+from pants.util.logging import LogLevel
+from pants.util.ordered_set import FrozenOrderedSet
+
+
+class ProtobufMapping(FrozenDict[str, Address]):
+    """A mapping of stripped .proto file names to their owning file address."""
+
+
+@rule(desc="Creating map of Protobuf file names to Protobuf targets", level=LogLevel.DEBUG)
+async def map_protobuf_files() -> ProtobufMapping:
+    all_expanded_targets = await Get(Targets, AddressSpecs([DescendantAddresses("")]))
+    protobuf_targets = tuple(tgt for tgt in all_expanded_targets if tgt.has_field(ProtobufSources))
+    stripped_sources_per_target = await MultiGet(
+        Get(StrippedSourceFileNames, SourcesPathsRequest(tgt[ProtobufSources]))
+        for tgt in protobuf_targets
+    )
+
+    stripped_files_to_addresses: Dict[str, Address] = {}
+    stripped_files_with_multiple_owners: Set[str] = set()
+    for tgt, stripped_sources in zip(protobuf_targets, stripped_sources_per_target):
+        for stripped_f in stripped_sources:
+            if stripped_f in stripped_files_to_addresses:
+                stripped_files_with_multiple_owners.add(stripped_f)
+            else:
+                stripped_files_to_addresses[stripped_f] = tgt.address
+
+    # Remove files with ambiguous owners.
+    for ambiguous_stripped_f in stripped_files_with_multiple_owners:
+        stripped_files_to_addresses.pop(ambiguous_stripped_f)
+
+    return ProtobufMapping(stripped_files_to_addresses)
+
+
+# See https://developers.google.com/protocol-buffers/docs/reference/proto3-spec for the Proto
+# language spec.
+# PROTO_FILE_CHARS = r"a-zA-Z0-9/\\\-\_"
+QUOTE_CHAR = r"(?:'|\")"
+IMPORT_MODIFIERS = r"(?:\spublic|\sweak)?"
+FILE_NAME = r"(.+?\.proto)"
+# NB: We don't specify what a valid file name looks like to avoid accidentally breaking unicode.
+IMPORT_REGEX = re.compile(rf"import\s*{IMPORT_MODIFIERS}\s*{QUOTE_CHAR}{FILE_NAME}{QUOTE_CHAR}\s*;")
+
+
+def parse_proto_imports(file_content: str) -> FrozenOrderedSet[str]:
+    return FrozenOrderedSet(IMPORT_REGEX.findall(file_content))
+
+
+class InferProtobufDependencies(InferDependenciesRequest):
+    infer_from = ProtobufSources
+
+
+@rule(desc="Inferring Protobuf dependencies by analyzing imports")
+async def infer_protobuf_dependencies(
+    request: InferProtobufDependencies, protobuf_mapping: ProtobufMapping, protoc: Protoc
+) -> InferredDependencies:
+    if not protoc.dependency_inference:
+        return InferredDependencies([], sibling_dependencies_inferrable=False)
+
+    hydrated_sources = await Get(HydratedSources, HydrateSourcesRequest(request.sources_field))
+    digest_contents = await Get(DigestContents, Digest, hydrated_sources.snapshot.digest)
+    result = sorted(
+        {
+            protobuf_mapping[import_path]
+            for file_content in digest_contents
+            for import_path in parse_proto_imports(file_content.content.decode())
+            if import_path in protobuf_mapping
+        }
+    )
+    return InferredDependencies(result, sibling_dependencies_inferrable=True)
+
+
+def rules():
+    return collect_rules()

--- a/src/python/pants/backend/codegen/protobuf/protobuf_dependency_inference_test.py
+++ b/src/python/pants/backend/codegen/protobuf/protobuf_dependency_inference_test.py
@@ -1,0 +1,149 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from textwrap import dedent
+from typing import Set
+
+import pytest
+
+from pants.backend.codegen.protobuf import protobuf_dependency_inference
+from pants.backend.codegen.protobuf.protobuf_dependency_inference import (
+    InferProtobufDependencies,
+    ProtobufMapping,
+    parse_proto_imports,
+)
+from pants.backend.codegen.protobuf.target_types import ProtobufLibrary, ProtobufSources
+from pants.core.util_rules import stripped_source_files
+from pants.engine.addresses import Address
+from pants.engine.target import InferredDependencies
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+
+@pytest.mark.parametrize(
+    "file_content,expected",
+    [
+        ("import 'foo.proto';", {"foo.proto"}),
+        ("import'foo.proto';", {"foo.proto"}),
+        ("import\t   'foo.proto'   \t;", {"foo.proto"}),
+        ('import "foo.proto";', {"foo.proto"}),
+        ("syntax = 'proto3';\nimport \"foo.proto\";", {"foo.proto"}),
+        # We don't worry about matching opening and closing ' vs. " quotes; Protoc will error if
+        # invalid.
+        ("import 'foo.proto\";", {"foo.proto"}),
+        ("import \"foo.proto';", {"foo.proto"}),
+        # `public` modifier.
+        ("import public 'foo.proto';", {"foo.proto"}),
+        ("import\t  public'foo.proto';", {"foo.proto"}),
+        ("importpublic 'foo.proto';", set()),
+        # `weak` modifier.
+        ("import weak 'foo.proto';", {"foo.proto"}),
+        ("import\t  weak'foo.proto';", {"foo.proto"}),
+        ("importweak 'foo.proto';", set()),
+        # More complex file names.
+        ("import 'path/to_dir/f.proto';", {"path/to_dir/f.proto"}),
+        ("import 'path/to dir/f.proto';", {"path/to dir/f.proto"}),
+        ("import 'path\\to-dir\\f.proto';", {"path\\to-dir\\f.proto"}),
+        ("import 'âčĘï.proto';", {"âčĘï.proto"}),
+        ("import '123.proto';", {"123.proto"}),
+        # Invalid imports.
+        ("import foo.proto;", set()),
+        ("import 'foo.proto'", set()),
+        ("import 'foo.protobuf';", set()),
+        ("imprt 'foo.proto';", set()),
+        # Multiple imports in a file.
+        ("import 'foo.proto'; import \"bar.proto\";", {"foo.proto", "bar.proto"}),
+        (
+            dedent(
+                """\
+                syntax = "proto3";
+
+                import 'dir/foo.proto';
+                some random proto code;
+                import public 'ábč.proto';
+                """
+            ),
+            {"dir/foo.proto", "ábč.proto"},
+        ),
+    ],
+)
+def test_parse_proto_imports(file_content: str, expected: Set[str]) -> None:
+    assert set(parse_proto_imports(file_content)) == expected
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *stripped_source_files.rules(),
+            *protobuf_dependency_inference.rules(),
+            QueryRule(ProtobufMapping, []),
+            QueryRule(InferredDependencies, [InferProtobufDependencies]),
+        ],
+        target_types=[ProtobufLibrary],
+    )
+
+
+def test_protobuf_mapping(rule_runner: RuleRunner) -> None:
+    rule_runner.set_options(["--source-root-patterns=['root1', 'root2', 'root3']"])
+
+    # Two proto files belonging to the same target. We should use two file addresses.
+    rule_runner.create_files("root1/protos", ["f1.proto", "f2.proto"])
+    rule_runner.add_to_build_file("root1/protos", "protobuf_library()")
+
+    # These protos would result in the same stripped file name, so neither should be used.
+    rule_runner.create_file("root1/two_owners/f.proto")
+    rule_runner.add_to_build_file("root1/two_owners", "protobuf_library()")
+    rule_runner.create_file("root2/two_owners/f.proto")
+    rule_runner.add_to_build_file("root2/two_owners", "protobuf_library()")
+
+    result = rule_runner.request(ProtobufMapping, [])
+    assert result == ProtobufMapping(
+        {
+            "protos/f1.proto": Address("root1/protos", relative_file_path="f1.proto"),
+            "protos/f2.proto": Address("root1/protos", relative_file_path="f2.proto"),
+        }
+    )
+
+
+def test_dependency_inference(rule_runner: RuleRunner) -> None:
+    rule_runner.create_file(
+        "src/protos/project/f1.proto",
+        dedent(
+            """\
+            import 'tests/f.proto';
+            import 'unrelated_path/foo.proto";
+            """
+        ),
+    )
+    rule_runner.create_file("src/protos/project/f2.proto", "import 'project/f1.proto';")
+    rule_runner.add_to_build_file("src/protos/project", "protobuf_library()")
+
+    rule_runner.create_file("src/protos/tests/f.proto")
+    rule_runner.add_to_build_file("src/protos/tests", "protobuf_library()")
+
+    def run_dep_inference(address: Address) -> InferredDependencies:
+        rule_runner.set_options(
+            [
+                "--backend-packages=pants.backend.codegen.protobuf.python",
+                "--source-root-patterns=['src/protos']",
+            ]
+        )
+        target = rule_runner.get_target(address)
+        return rule_runner.request(
+            InferredDependencies, [InferProtobufDependencies(target[ProtobufSources])]
+        )
+
+    build_address = Address("src/protos/project")
+    assert run_dep_inference(build_address) == InferredDependencies(
+        [
+            Address("src/protos/tests", relative_file_path="f.proto"),
+            Address("src/protos/project", relative_file_path="f1.proto"),
+        ],
+        sibling_dependencies_inferrable=True,
+    )
+
+    file_address = Address("src/protos/project", relative_file_path="f1.proto")
+    assert run_dep_inference(file_address) == InferredDependencies(
+        [Address("src/protos/tests", relative_file_path="f.proto")],
+        sibling_dependencies_inferrable=True,
+    )

--- a/src/python/pants/backend/codegen/protobuf/protoc.py
+++ b/src/python/pants/backend/codegen/protobuf/protoc.py
@@ -25,9 +25,26 @@ class Protoc(TemplatedExternalTool):
         "linux": "linux",
     }
 
+    @classmethod
+    def register_options(cls, register):
+        super().register_options(register)
+        register(
+            "--dependency-inference",
+            default=True,
+            type=bool,
+            help=(
+                "Infer Protobuf dependencies on other Protobuf files by analyzing import "
+                "statements."
+            ),
+        )
+
     def generate_exe(self, plat: Platform) -> str:
         return "./bin/protoc"
 
     @property
     def runtime_targets(self) -> List[str]:
         return cast(List[str], self.options.runtime_targets)
+
+    @property
+    def dependency_inference(self) -> bool:
+        return cast(bool, self.options.dependency_inference)

--- a/src/python/pants/backend/codegen/protobuf/python/register.py
+++ b/src/python/pants/backend/codegen/protobuf/python/register.py
@@ -7,6 +7,7 @@ See https://www.pantsbuild.org/docs/protobuf.
 """
 
 from pants.backend.codegen import export_codegen_goal
+from pants.backend.codegen.protobuf import protobuf_dependency_inference
 from pants.backend.codegen.protobuf.python import (
     additional_fields,
     python_protobuf_module_mapper,
@@ -22,6 +23,7 @@ def rules():
         *python_protobuf_subsystem.rules(),
         *python_rules(),
         *python_protobuf_module_mapper.rules(),
+        *protobuf_dependency_inference.rules(),
         *export_codegen_goal.rules(),
     ]
 

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -99,7 +99,7 @@ class InferPythonDependencies(InferDependenciesRequest):
     infer_from = PythonSources
 
 
-@rule(desc="Inferring Python dependencies.")
+@rule(desc="Inferring Python dependencies by analyzing imports")
 async def infer_python_dependencies(
     request: InferPythonDependencies, python_inference: PythonInference
 ) -> InferredDependencies:
@@ -127,10 +127,7 @@ async def infer_python_dependencies(
         )
 
     owners_per_import = await MultiGet(owners_requests)
-    # We remove the request's address so that we don't infer dependencies on self.
-    merged_result = sorted(
-        set(itertools.chain.from_iterable(owners_per_import)) - {request.sources_field.address}
-    )
+    merged_result = sorted(set(itertools.chain.from_iterable(owners_per_import)))
     return InferredDependencies(merged_result, sibling_dependencies_inferrable=True)
 
 


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/10804.

We use an approach similar to Python import analysis, but with some simplifications as there is no concept of "modules" nor third-party requirements (at least for now).

Rather than trying to tokenize the `.proto` file, we use regex to match the language spec: https://developers.google.com/protocol-buffers/docs/reference/proto3-spec#import_statement

[ci skip-rust]
[ci skip-build-wheels]