### PR TITLE
Hotfix unbound `$PY` variable breaking cargo script

### DIFF
--- a/build-support/common.sh
+++ b/build-support/common.sh
@@ -70,7 +70,7 @@ function git_merge_base() {
 }
 
 function determine_python() {
-  if [[ -n "${PY}" ]]; then
+  if [[ -n "${PY:-}" ]]; then
     echo "${PY}"
     return 0
   fi


### PR DESCRIPTION
If `set -u` is configured, then it errors that `$PY` is not set.

[ci skip-rust]
[ci skip-build-wheels]