### PR TITLE
Add partition metadata to lint and typecheck goals

### DIFF
--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -4,7 +4,7 @@
 import itertools
 import logging
 from dataclasses import dataclass
-from typing import Iterable, Optional, Tuple, cast
+from typing import Any, Dict, Iterable, Optional, Tuple, cast
 
 from pants.core.goals.style_request import StyleRequest
 from pants.core.util_rules.filter_empty_sources import (
@@ -38,7 +38,7 @@ class InvalidLinterReportsError(Exception):
 
 
 @dataclass(frozen=True)
-class LintResult:
+class LintResult(EngineAwareReturnType):
     exit_code: int
     stdout: str
     stderr: str
@@ -64,6 +64,9 @@ class LintResult:
             partition_description=partition_description,
             report=report,
         )
+
+    def metadata(self) -> Dict[str, Any]:
+        return {"partition": self.partition_description}
 
 
 @frozen_after_init

--- a/src/python/pants/core/goals/typecheck.py
+++ b/src/python/pants/core/goals/typecheck.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Iterable, Optional, Tuple
+from typing import Any, Dict, Iterable, Optional, Tuple
 
 from pants.core.goals.style_request import StyleRequest
 from pants.core.util_rules.filter_empty_sources import (
@@ -23,7 +23,7 @@ from pants.util.strutil import strip_v2_chroot_path
 
 
 @dataclass(frozen=True)
-class TypecheckResult:
+class TypecheckResult(EngineAwareReturnType):
     exit_code: int
     stdout: str
     stderr: str
@@ -45,6 +45,9 @@ class TypecheckResult:
             stderr=prep_output(process_result.stderr),
             partition_description=partition_description,
         )
+
+    def metadata(self) -> Dict[str, Any]:
+        return {"partition": self.partition_description}
 
 
 @frozen_after_init


### PR DESCRIPTION
Add the `partition` field of `LintResult` and `TypecheckResult` to these types' workunit metadata, to facilitate richer error messages for consumers of that workunit metadata.