### PR TITLE
Use annotations import to avoid string type annotations

### DIFF
--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import argparse
 import html
 import json
@@ -43,7 +45,7 @@ class ReferenceGenerator:
     """
 
     @classmethod
-    def create(cls) -> "ReferenceGenerator":
+    def create(cls) -> ReferenceGenerator:
         # Note that we want to be able to run this script using `./pants run`, so having it
         # invoke `./pants help-all` itself would be unnecessarily complicated.
         # So we require the input to be provided externally.

--- a/build-support/bin/packages.py
+++ b/build-support/bin/packages.py
@@ -1,6 +1,8 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import argparse
 import os
 import re
@@ -373,7 +375,7 @@ class PrebuiltWheel(NamedTuple):
     url: str
 
     @classmethod
-    def create(cls, path: str) -> "PrebuiltWheel":
+    def create(cls, path: str) -> PrebuiltWheel:
         return cls(path, quote_plus(path))
 
 

--- a/src/python/pants/backend/project_info/source_file_validator.py
+++ b/src/python/pants/backend/project_info/source_file_validator.py
@@ -1,6 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import re
 import textwrap
 from dataclasses import dataclass
@@ -81,7 +83,7 @@ class ValidationConfig:
     required_matches: FrozenDict[str, Tuple[str]]  # path pattern name -> content pattern names.
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> "ValidationConfig":
+    def from_dict(cls, d: Dict[str, Any]) -> ValidationConfig:
         return cls(
             path_patterns=tuple(PathPattern(**kwargs) for kwargs in d["path_patterns"]),
             content_patterns=tuple(ContentPattern(**kwargs) for kwargs in d["content_patterns"]),

--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import PurePath
@@ -27,7 +29,7 @@ class PythonModule:
     module: str
 
     @classmethod
-    def create_from_stripped_path(cls, path: PurePath) -> "PythonModule":
+    def create_from_stripped_path(cls, path: PurePath) -> PythonModule:
         module_name_with_slashes = (
             path.parent if path.name == "__init__.py" else path.with_suffix("")
         )

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import configparser
 from dataclasses import dataclass
 from enum import Enum
@@ -77,8 +79,8 @@ class CoverageReportType(Enum):
 
     _report_name: str
 
-    def __new__(cls, value: str, report_name: Optional[str] = None) -> "CoverageReportType":
-        member: "CoverageReportType" = object.__new__(cls)
+    def __new__(cls, value: str, report_name: Optional[str] = None) -> CoverageReportType:
+        member: CoverageReportType = object.__new__(cls)
         member._value_ = value
         member._report_name = report_name if report_name is not None else value
         return member

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -1,6 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import dataclasses
 import functools
 import itertools
@@ -74,7 +76,7 @@ class PexRequirements(DeduplicatedCollection[str]):
         fields: Iterable[PythonRequirementsField],
         *,
         additional_requirements: Iterable[str] = (),
-    ) -> "PexRequirements":
+    ) -> PexRequirements:
         field_requirements = {str(python_req) for field in fields for python_req in field.value}
         return PexRequirements({*field_requirements, *additional_requirements})
 
@@ -183,7 +185,7 @@ class PexInterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParame
     @classmethod
     def create_from_targets(
         cls, targets: Iterable[Target], python_setup: PythonSetup
-    ) -> "PexInterpreterConstraints":
+    ) -> PexInterpreterConstraints:
         return cls.create_from_compatibility_fields(
             (
                 tgt[InterpreterConstraintsField]
@@ -196,7 +198,7 @@ class PexInterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParame
     @classmethod
     def create_from_compatibility_fields(
         cls, fields: Iterable[InterpreterConstraintsField], python_setup: PythonSetup
-    ) -> "PexInterpreterConstraints":
+    ) -> PexInterpreterConstraints:
         constraint_sets = {field.value_or_global_default(python_setup) for field in fields}
         # This will OR within each field and AND across fields.
         merged_constraints = cls.merge_constraint_sets(constraint_sets)
@@ -303,7 +305,7 @@ class PexPlatforms(DeduplicatedCollection[str]):
     sort_input = True
 
     @classmethod
-    def create_from_platforms_field(cls, field: PythonPlatformsField) -> "PexPlatforms":
+    def create_from_platforms_field(cls, field: PythonPlatformsField) -> PexPlatforms:
         return cls(field.value or ())
 
     def generate_pex_arg_list(self) -> List[str]:

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -1,6 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import dataclasses
 import itertools
 import logging
@@ -140,7 +142,7 @@ class PexFromTargetsRequest:
         hardcoded_interpreter_constraints: Optional[PexInterpreterConstraints] = None,
         zip_safe: bool = False,
         direct_deps_only: bool = False,
-    ) -> "PexFromTargetsRequest":
+    ) -> PexFromTargetsRequest:
         """Create an instance that can be used to get a requirements pex.
 
         Useful to ensure that these requests are uniform (e.g., the using the same output filename),

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -1,6 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import json
 import os.path
 import textwrap
@@ -217,7 +219,7 @@ class MockFieldSet(FieldSet):
     interpreter_constraints: InterpreterConstraintsField
 
     @classmethod
-    def create_for_test(cls, address: Address, compat: Optional[str]) -> "MockFieldSet":
+    def create_for_test(cls, address: Address, compat: Optional[str]) -> MockFieldSet:
         return cls(
             address=address,
             interpreter_constraints=InterpreterConstraintsField(
@@ -283,7 +285,7 @@ class ExactRequirement:
     version: str
 
     @classmethod
-    def parse(cls, requirement: str) -> "ExactRequirement":
+    def parse(cls, requirement: str) -> ExactRequirement:
         req = Requirement.parse(requirement)
         assert len(req.specs) == 1, (
             f"Expected an exact requirement with only 1 specifier, given {requirement} with "

--- a/src/python/pants/base/exceptions.py
+++ b/src/python/pants/base/exceptions.py
@@ -1,6 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 from typing import Iterable
 
 
@@ -36,7 +38,7 @@ class ResolveError(MappingError):
     @classmethod
     def did_you_mean(
         cls, *, bad_name: str, known_names: Iterable[str], namespace: str
-    ) -> "ResolveError":
+    ) -> ResolveError:
         possibilities = "\n  ".join(f":{target_name}" for target_name in sorted(known_names))
         return cls(
             f"'{bad_name}' was not found in namespace '{namespace}'. Did you mean one "

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -1,6 +1,8 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import logging
 import os
 from dataclasses import dataclass, replace
@@ -110,7 +112,7 @@ class LocalPantsRunner:
         options_bootstrapper: OptionsBootstrapper,
         scheduler: Optional[GraphScheduler] = None,
         cancellation_latch: Optional[PySessionCancellationLatch] = None,
-    ) -> "LocalPantsRunner":
+    ) -> LocalPantsRunner:
         """Creates a new LocalPantsRunner instance by parsing options.
 
         By the time this method runs, logging will already have been initialized in either

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -1,6 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import os
 from dataclasses import dataclass
 from pathlib import PurePath
@@ -61,7 +63,7 @@ class AddressInput:
         spec: str,
         relative_to: Optional[str] = None,
         subproject_roots: Optional[Sequence[str]] = None,
-    ) -> "AddressInput":
+    ) -> AddressInput:
         """Parse a string into an AddressInput.
 
         :param spec: Target address spec.
@@ -136,7 +138,7 @@ class AddressInput:
 
         return cls(path_component, target_component)
 
-    def file_to_address(self) -> "Address":
+    def file_to_address(self) -> Address:
         """Converts to an Address by assuming that the path_component is a file on disk."""
         if self.target_component is None:
             # Use the default target in the same directory as the file.
@@ -186,7 +188,7 @@ class AddressInput:
         target_name = os.path.basename(self.target_component)
         return Address(spec_path, relative_file_path=relative_file_path, target_name=target_name)
 
-    def dir_to_address(self) -> "Address":
+    def dir_to_address(self) -> Address:
         """Converts to an Address by assuming that the path_component is a directory on disk."""
         return Address(spec_path=self.path_component, target_name=self.target_component)
 
@@ -330,7 +332,7 @@ class Address(EngineAwareParameter):
             target_portion = f"{parent_prefix}{target_name}"
         return f"{self.spec_path.replace(os.path.sep, '.')}{file_portion}{target_portion}"
 
-    def maybe_convert_to_build_target(self) -> "Address":
+    def maybe_convert_to_build_target(self) -> Address:
         """If this address is for a file target, convert it back into its BUILD target.
 
         Otherwise, return itself unmodified.

--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -1,6 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import logging
 import typing
 from collections import defaultdict
@@ -220,7 +222,7 @@ class BuildConfiguration:
                 )
             self._target_types.update(target_types)
 
-        def create(self) -> "BuildConfiguration":
+        def create(self) -> BuildConfiguration:
             registered_aliases = BuildFileAliases(
                 objects=self._exposed_object_by_alias.copy(),
                 context_aware_object_factories=self._exposed_context_aware_object_factory_by_alias.copy(),

--- a/src/python/pants/build_graph/build_file_aliases.py
+++ b/src/python/pants/build_graph/build_file_aliases.py
@@ -1,6 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional
 
@@ -97,7 +99,7 @@ class BuildFileAliases:
         """
         return self._context_aware_object_factories
 
-    def merge(self, other: "BuildFileAliases") -> "BuildFileAliases":
+    def merge(self, other: BuildFileAliases) -> BuildFileAliases:
         """Merges a set of build file aliases and returns a new set of aliases containing both.
 
         Any duplicate aliases from `other` will trump.

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -1,6 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import itertools
 from collections import defaultdict
 from dataclasses import dataclass
@@ -47,7 +49,7 @@ class FmtResult:
         original_digest: Digest,
         formatter_name: str,
         strip_chroot_path: bool = False,
-    ) -> "FmtResult":
+    ) -> FmtResult:
         def prep_output(s: bytes) -> str:
             return strip_v2_chroot_path(s) if strip_chroot_path else s.decode()
 

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -1,6 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import itertools
 import logging
 from dataclasses import dataclass
@@ -53,7 +55,7 @@ class LintResult(EngineAwareReturnType):
         partition_description: Optional[str] = None,
         strip_chroot_path: bool = False,
         report: Optional[LintReport] = None,
-    ) -> "LintResult":
+    ) -> LintResult:
         def prep_output(s: bytes) -> str:
             return strip_v2_chroot_path(s) if strip_chroot_path else s.decode()
 

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -1,6 +1,8 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import itertools
 import logging
 from abc import ABC, ABCMeta
@@ -49,7 +51,7 @@ class TestResult:
     __test__ = False
 
     @classmethod
-    def skip(cls, address: Address) -> "TestResult":
+    def skip(cls, address: Address) -> TestResult:
         return cls(exit_code=None, stdout="", stderr="", address=address)
 
     @classmethod
@@ -60,7 +62,7 @@ class TestResult:
         *,
         coverage_data: Optional["CoverageData"] = None,
         xml_results: Optional[Snapshot] = None,
-    ) -> "TestResult":
+    ) -> TestResult:
         return cls(
             exit_code=process_result.exit_code,
             stdout=process_result.stdout.decode(),

--- a/src/python/pants/core/goals/typecheck.py
+++ b/src/python/pants/core/goals/typecheck.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, Optional, Tuple
 
@@ -35,7 +37,7 @@ class TypecheckResult(EngineAwareReturnType):
         *,
         partition_description: Optional[str] = None,
         strip_chroot_path: bool = False,
-    ) -> "TypecheckResult":
+    ) -> TypecheckResult:
         def prep_output(s: bytes) -> str:
             return strip_v2_chroot_path(s) if strip_chroot_path else s.decode()
 

--- a/src/python/pants/engine/collection.py
+++ b/src/python/pants/engine/collection.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 from typing import Any, ClassVar, Iterable, Tuple, TypeVar, Union, cast, overload
 
 from pants.util.ordered_set import FrozenOrderedSet
@@ -28,7 +30,7 @@ class Collection(Tuple[T, ...]):
         ...
 
     @overload  # noqa: F811
-    def __getitem__(self, index: slice) -> "Collection[T]":
+    def __getitem__(self, index: slice) -> Collection[T]:
         ...
 
     def __getitem__(self, index: Union[int, slice]) -> Union[T, "Collection[T]"]:  # noqa: F811

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import functools
 import itertools
 import logging
@@ -939,7 +941,7 @@ class NoApplicableTargetsException(Exception):
         goal_description: str,
         union_membership: UnionMembership,
         registered_target_types: RegisteredTargetTypes,
-    ) -> "NoApplicableTargetsException":
+    ) -> NoApplicableTargetsException:
         applicable_target_types = {
             target_type
             for field_set_type in field_set_types

--- a/src/python/pants/engine/internals/mapper.py
+++ b/src/python/pants/engine/internals/mapper.py
@@ -1,6 +1,8 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import re
 from dataclasses import dataclass
 from typing import Callable, Dict, Iterable, Mapping, Optional, Pattern, Tuple
@@ -32,7 +34,7 @@ class AddressMap:
         build_file_content: str,
         parser: Parser,
         extra_symbols: BuildFilePreludeSymbols,
-    ) -> "AddressMap":
+    ) -> AddressMap:
         """Parses a source for targets.
 
         The target adaptors are all 'thin': any targets they point to in other namespaces or even in
@@ -79,7 +81,7 @@ class AddressFamily:
     name_to_target_adaptors: Dict[str, Tuple[str, TargetAdaptor]]
 
     @classmethod
-    def create(cls, spec_path: str, address_maps: Iterable[AddressMap]) -> "AddressFamily":
+    def create(cls, spec_path: str, address_maps: Iterable[AddressMap]) -> AddressFamily:
         """Creates an address family from the given set of address maps.
 
         :param spec_path: The directory prefix shared by all address_maps.

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -1,6 +1,8 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import logging
 import os
 import time
@@ -343,7 +345,7 @@ class Scheduler:
         should_report_workunits: bool = False,
         session_values: Optional[SessionValues] = None,
         cancellation_latch: Optional[PySessionCancellationLatch] = None,
-    ) -> "SchedulerSession":
+    ) -> SchedulerSession:
         """Creates a new SchedulerSession for this Scheduler."""
         return SchedulerSession(
             self,
@@ -636,7 +638,7 @@ class SchedulerSession:
 
     def run_local_interactive_process(
         self, request: "InteractiveProcess"
-    ) -> "InteractiveProcessResult":
+    ) -> InteractiveProcessResult:
         sched_pointer = self._scheduler._scheduler
         session_pointer = self._session
         result: "InteractiveProcessResult" = (

--- a/src/python/pants/engine/internals/selectors.py
+++ b/src/python/pants/engine/internals/selectors.py
@@ -1,6 +1,8 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import ast
 import itertools
 from dataclasses import dataclass
@@ -205,7 +207,7 @@ class Get(GetConstraints, Generic[_Output, _Input]):
 
     def __await__(
         self,
-    ) -> "Generator[Get[_Output, _Input], None, _Output]":
+    ) -> Generator[Get[_Output, _Input], None, _Output]:
         """Allow a Get to be `await`ed within an `async` method, returning a strongly-typed result.
 
         The `yield`ed value `self` is interpreted by the engine within `extern_generator_send()` in

--- a/src/python/pants/engine/internals/uuid.py
+++ b/src/python/pants/engine/internals/uuid.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import uuid
 from dataclasses import dataclass
 from enum import Enum
@@ -30,7 +32,7 @@ class UUIDRequest:
         return cast(str, scope.value)
 
     @classmethod
-    def scoped(cls, scope: UUIDScope) -> "UUIDRequest":
+    def scoped(cls, scope: UUIDScope) -> UUIDRequest:
         return cls(cls._to_scope_name(scope))
 
 

--- a/src/python/pants/engine/platform.py
+++ b/src/python/pants/engine/platform.py
@@ -1,6 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 from enum import Enum
 from typing import Iterable
 
@@ -15,7 +17,7 @@ class Platform(Enum):
 
     # TODO: try to turn all of these accesses into v2 dependency injections!
     @memoized_classproperty
-    def current(cls) -> "Platform":
+    def current(cls) -> Platform:
         return Platform(get_normalized_os_name())
 
 

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -1,6 +1,8 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import dataclasses
 import hashlib
 import logging
@@ -300,7 +302,7 @@ class InteractiveProcess:
     @classmethod
     def from_process(
         cls, process: Process, *, hermetic_env: bool = True, forward_signals_to_process: bool = True
-    ) -> "InteractiveProcess":
+    ) -> InteractiveProcess:
         return InteractiveProcess(
             argv=process.argv,
             env=process.env,
@@ -382,7 +384,7 @@ class BinaryPath:
     @classmethod
     def fingerprinted(
         cls, path: str, representative_content: Union[bytes, bytearray, memoryview]
-    ) -> "BinaryPath":
+    ) -> BinaryPath:
         return cls(path, fingerprint=cls._fingerprint(representative_content))
 
 

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -1,6 +1,8 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import ast
 import inspect
 import itertools
@@ -80,7 +82,7 @@ class _RuleVisitor(ast.NodeVisitor):
 # We could refactor this to be a class with __call__() defined, but we would lose the `@memoized`
 # decorator.
 @memoized
-def SubsystemRule(optionable_factory: Type[OptionableFactory]) -> "TaskRule":
+def SubsystemRule(optionable_factory: Type[OptionableFactory]) -> TaskRule:
     """Returns a TaskRule that constructs an instance of the subsystem."""
     return TaskRule(**optionable_factory.signature())
 
@@ -466,7 +468,7 @@ class RuleIndex:
     union_rules: FrozenOrderedSet[UnionRule]
 
     @classmethod
-    def create(cls, rule_entries) -> "RuleIndex":
+    def create(cls, rule_entries) -> RuleIndex:
         """Creates a RuleIndex with tasks indexed by their output type."""
         rules: OrderedSet[TaskRule] = OrderedSet()
         queries: OrderedSet[QueryRule] = OrderedSet()

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -659,7 +659,7 @@ class RegisteredTargetTypes:
         self.aliases_to_types = FrozenDict(aliases_to_types)
 
     @classmethod
-    def create(cls, target_types: Iterable[Type[Target]]) -> "RegisteredTargetTypes":
+    def create(cls, target_types: Iterable[Type[Target]]) -> RegisteredTargetTypes:
         return cls(
             {
                 target_type.alias: target_type
@@ -796,6 +796,7 @@ def _get_field_set_fields_from_target(
         for dataclass_field in dataclasses.fields(field_set)
         if isinstance(dataclass_field.type, type) and issubclass(dataclass_field.type, Field)  # type: ignore[unreachable]
     }
+
     return {
         dataclass_field_name: (
             target[field_cls] if field_cls in field_set.required_fields else target.get(field_cls)

--- a/src/python/pants/engine/unions.py
+++ b/src/python/pants/engine/unions.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import DefaultDict, Iterable, Mapping, Type, TypeVar
@@ -61,7 +63,7 @@ class UnionMembership:
     union_rules: FrozenDict[Type, FrozenOrderedSet[Type]]
 
     @classmethod
-    def from_rules(cls, rules: Iterable[UnionRule]) -> "UnionMembership":
+    def from_rules(cls, rules: Iterable[UnionRule]) -> UnionMembership:
         mapping: DefaultDict[Type, OrderedSet[Type]] = defaultdict(OrderedSet)
         for rule in rules:
             mapping[rule.union_base].add(rule.union_member)

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -1,6 +1,8 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import dataclasses
 import inspect
 import json
@@ -151,7 +153,7 @@ class TargetFieldHelpInfo:
     default: Optional[str]
 
     @classmethod
-    def create(cls, field: Type[Field]) -> "TargetFieldHelpInfo":
+    def create(cls, field: Type[Field]) -> TargetFieldHelpInfo:
         # NB: It is very common (and encouraged) to subclass Fields to give custom behavior, e.g.
         # `PythonSources` subclassing `Sources`. Here, we set `fallback_to_ancestors=True` so that
         # we can still generate meaningful documentation for all these custom fields without
@@ -223,7 +225,7 @@ class TargetTypeHelpInfo:
     @classmethod
     def create(
         cls, target_type: Type[Target], *, union_membership: UnionMembership
-    ) -> "TargetTypeHelpInfo":
+    ) -> TargetTypeHelpInfo:
         return cls(
             alias=target_type.alias,
             summary=get_docstring_summary(target_type),

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -1,6 +1,8 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import logging
 from dataclasses import dataclass
 from pathlib import Path
@@ -52,7 +54,7 @@ class GraphScheduler:
         should_report_workunits=False,
         session_values: Optional[SessionValues] = None,
         cancellation_latch: Optional[PySessionCancellationLatch] = None,
-    ) -> "GraphSession":
+    ) -> GraphSession:
         session = self.scheduler.new_session(
             build_id,
             dynamic_ui,

--- a/src/python/pants/option/config.py
+++ b/src/python/pants/option/config.py
@@ -1,6 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import configparser
 import getpass
 import io
@@ -130,7 +132,7 @@ class Config(ABC):
     @classmethod
     def _parse_toml(
         cls, config_content: str, normalized_seed_values: Dict[str, str]
-    ) -> "_ConfigValues":
+    ) -> _ConfigValues:
         """Attempt to parse as TOML, raising an exception on failure."""
         toml_values = cast(Dict[str, Any], toml.loads(config_content))
         toml_values["DEFAULT"] = {

--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -1,6 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import inspect
 import os
 import re
@@ -156,7 +158,7 @@ class ListValueComponent:
         return [s]
 
     @classmethod
-    def merge(cls, components: Iterable["ListValueComponent"]) -> "ListValueComponent":
+    def merge(cls, components: Iterable[ListValueComponent]) -> ListValueComponent:
         """Merges components into a single component, applying their actions appropriately.
 
         This operation is associative:  M(M(a, b), c) == M(a, M(b, c)) == M(a, b, c).
@@ -196,7 +198,7 @@ class ListValueComponent:
         return self._action
 
     @classmethod
-    def create(cls, value, member_type=str) -> "ListValueComponent":
+    def create(cls, value, member_type=str) -> ListValueComponent:
         """Interpret value as either a list or something to extend another list with.
 
         Note that we accept tuple literals, but the internal value is always a list.
@@ -257,7 +259,7 @@ class DictValueComponent:
     EXTEND = "EXTEND"
 
     @classmethod
-    def merge(cls, components: Iterable["DictValueComponent"]) -> "DictValueComponent":
+    def merge(cls, components: Iterable["DictValueComponent"]) -> DictValueComponent:
         """Merges components into a single component, applying their actions appropriately.
 
         This operation is associative:  M(M(a, b), c) == M(a, M(b, c)) == M(a, b, c).
@@ -281,7 +283,7 @@ class DictValueComponent:
         self.val = val
 
     @classmethod
-    def create(cls, value) -> "DictValueComponent":
+    def create(cls, value) -> DictValueComponent:
         """Interpret value as either a dict or something to extend another dict with.
 
         :param value: The value to convert.  Can be an instance of DictValueComponent, a dict,

--- a/src/python/pants/option/option_value_container.py
+++ b/src/python/pants/option/option_value_container.py
@@ -1,6 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import copy
 from dataclasses import dataclass
 from typing import Dict, Iterator, List, Optional
@@ -39,7 +41,7 @@ class OptionValueContainerBuilder:
             return super().__setattr__(key, value)
         self._set(key, value)
 
-    def build(self) -> "OptionValueContainer":
+    def build(self) -> OptionValueContainer:
         return OptionValueContainer(copy.copy(self._value_map))
 
 

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -1,6 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import copy
 import logging
 from typing import Dict, Iterable, List, Mapping, Optional, Sequence
@@ -114,7 +116,7 @@ class Options:
         known_scope_infos: Iterable[ScopeInfo],
         args: Sequence[str],
         bootstrap_option_values: Optional[OptionValueContainer] = None,
-    ) -> "Options":
+    ) -> Options:
         """Create an Options instance.
 
         :param env: a dict of environment variables.
@@ -264,7 +266,7 @@ class Options:
                 "remove.\n(Specify --no-verify-config to disable this check.)"
             )
 
-    def drop_flag_values(self) -> "Options":
+    def drop_flag_values(self) -> Options:
         """Returns a copy of these options that ignores values specified via flags.
 
         Any pre-cached option values are cleared and only option values that come from option

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -1,6 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import itertools
 import os
 import warnings
@@ -99,7 +101,7 @@ class OptionsBootstrapper:
     @classmethod
     def create(
         cls, env: Mapping[str, str], args: Sequence[str], *, allow_pantsrc: bool
-    ) -> "OptionsBootstrapper":
+    ) -> OptionsBootstrapper:
         """Parses the minimum amount of configuration necessary to create an OptionsBootstrapper.
 
         :param env: An environment dictionary, or None to use `os.environ`.

--- a/src/python/pants/option/ranked_value.py
+++ b/src/python/pants/option/ranked_value.py
@@ -1,6 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from enum import Enum
 from functools import total_ordering
@@ -19,7 +21,7 @@ class Rank(Enum):
 
     _rank: int
 
-    def __new__(cls, rank: int, display: str) -> "Rank":
+    def __new__(cls, rank: int, display: str) -> Rank:
         member: "Rank" = object.__new__(cls)
         member._value_ = display
         member._rank = rank

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -1,6 +1,8 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import logging
 import os
 import sys
@@ -45,7 +47,7 @@ class PantsDaemon(PantsDaemonProcessManager):
         """Represents a pantsd failure at runtime, usually from an underlying service failure."""
 
     @classmethod
-    def create(cls, options_bootstrapper: OptionsBootstrapper) -> "PantsDaemon":
+    def create(cls, options_bootstrapper: OptionsBootstrapper) -> PantsDaemon:
 
         with warnings.catch_warnings(record=True):
             bootstrap_options = options_bootstrapper.bootstrap_options

--- a/src/python/pants/pantsd/pants_daemon_client.py
+++ b/src/python/pants/pantsd/pants_daemon_client.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import logging
 from dataclasses import dataclass
 
@@ -29,7 +31,7 @@ class PantsDaemonClient(PantsDaemonProcessManager):
     def __init__(self, bootstrap_options: Options):
         super().__init__(bootstrap_options, daemon_entrypoint=pants_daemon.__name__)
 
-    def maybe_launch(self) -> "PantsDaemonClient.Handle":
+    def maybe_launch(self) -> PantsDaemonClient.Handle:
         """Creates and launches a daemon instance if one does not already exist."""
         with self.lifecycle_lock:
             if self.needs_restart(self.options_fingerprint):
@@ -42,13 +44,13 @@ class PantsDaemonClient(PantsDaemonProcessManager):
                     metadata_base_dir=self._metadata_base_dir,
                 )
 
-    def restart(self) -> "PantsDaemonClient.Handle":
+    def restart(self) -> PantsDaemonClient.Handle:
         """Restarts a running daemon instance."""
         with self.lifecycle_lock:
             # N.B. This will call `pantsd.terminate()` before starting.
             return self._launch()
 
-    def _launch(self) -> "PantsDaemonClient.Handle":
+    def _launch(self) -> PantsDaemonClient.Handle:
         """Launches pantsd in a subprocess.
 
         N.B. This should always be called under care of the `lifecycle_lock`.

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -1,6 +1,8 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import itertools
 import logging
 import os
@@ -152,7 +154,7 @@ class SourceRootsRequest:
                 raise ValueError(f"SourceRootRequest path must be relative: {path}")
 
     @classmethod
-    def for_files(cls, file_paths: Iterable[str]) -> "SourceRootsRequest":
+    def for_files(cls, file_paths: Iterable[str]) -> SourceRootsRequest:
         """Create a request for the source root for the given file."""
         return cls({PurePath(file_path) for file_path in file_paths}, ())
 
@@ -174,19 +176,19 @@ class SourceRootRequest(EngineAwareParameter):
             raise ValueError(f"SourceRootRequest path must be relative: {self.path}")
 
     @classmethod
-    def for_file(cls, file_path: str) -> "SourceRootRequest":
+    def for_file(cls, file_path: str) -> SourceRootRequest:
         """Create a request for the source root for the given file."""
         # The file itself cannot be a source root, so we may as well start the search
         # from its enclosing directory, and save on some superfluous checking.
         return cls(PurePath(file_path).parent)
 
     @classmethod
-    def for_address(cls, address: Address) -> "SourceRootRequest":
+    def for_address(cls, address: Address) -> SourceRootRequest:
         # Note that we don't use for_file() here because the spec_path is a directory.
         return cls(PurePath(address.spec_path))
 
     @classmethod
-    def for_target(cls, target: Target) -> "SourceRootRequest":
+    def for_target(cls, target: Target) -> SourceRootRequest:
         return cls.for_address(target.address)
 
     def debug_hint(self) -> str:

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import os
 from dataclasses import dataclass
 from io import StringIO
@@ -74,7 +76,7 @@ class GoalRuleResult:
     stderr: str
 
     @staticmethod
-    def noop() -> "GoalRuleResult":
+    def noop() -> GoalRuleResult:
         return GoalRuleResult(0, stdout="", stderr="")
 
 

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -1,6 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import os
 import unittest
 from abc import ABC, ABCMeta, abstractmethod
@@ -83,7 +85,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
 
     _O = TypeVar("_O")
 
-    def request(self, output_type: Type["TestBase._O"], inputs: Iterable[Any]) -> "TestBase._O":
+    def request(self, output_type: Type[TestBase._O], inputs: Iterable[Any]) -> TestBase._O:
         # TODO: Update all callsites to pass this explicitly via session values.
         session = self.scheduler
         for value in inputs:

--- a/src/python/pants/util/dirutil_test.py
+++ b/src/python/pants/util/dirutil_test.py
@@ -1,6 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import errno
 import os
 import unittest
@@ -153,11 +155,11 @@ class DirutilTest(unittest.TestCase):
         contents: str
 
         @classmethod
-        def empty(cls, path: str) -> "DirutilTest.File":
+        def empty(cls, path: str) -> DirutilTest.File:
             return cls(path, contents="")
 
         @classmethod
-        def read(cls, root: str, relpath: str) -> "DirutilTest.File":
+        def read(cls, root: str, relpath: str) -> DirutilTest.File:
             with open(os.path.join(root, relpath), "r") as fp:
                 return cls(relpath, fp.read())
 

--- a/src/python/pants/util/logging.py
+++ b/src/python/pants/util/logging.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import logging
 from enum import Enum
 
@@ -17,7 +19,7 @@ class LogLevel(Enum):
 
     _level: int
 
-    def __new__(cls, value: str, level: int) -> "LogLevel":
+    def __new__(cls, value: str, level: int) -> LogLevel:
         member: "LogLevel" = object.__new__(cls)
         member._value_ = value
         member._level = level

--- a/src/python/pants/vcs/changed.py
+++ b/src/python/pants/vcs/changed.py
@@ -1,6 +1,8 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional, Tuple, cast
@@ -62,7 +64,7 @@ class ChangedOptions:
     dependees: DependeesOption
 
     @classmethod
-    def from_options(cls, options: OptionValueContainer) -> "ChangedOptions":
+    def from_options(cls, options: OptionValueContainer) -> ChangedOptions:
         return cls(options.since, options.diffspec, options.dependees)
 
     @property


### PR DESCRIPTION
Use `from __future__ import annotations` in a bunch of places in Python code. This allows us to change a bunch of type annotations from strings to Python symbols.