### PR TITLE
Improve error message for no applicable targets

### DIFF
--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -923,6 +923,10 @@ class NoApplicableTargetsException(Exception):
             )
         else:
             msg += "However, you did not specify any files/targets."
+        msg += (
+            f"\n\nRun `./pants filter --target-type={','.join(applicable_target_aliases)} ::` to "
+            "find all applicable targets in your project."
+        )
         super().__init__(msg)
 
     @classmethod


### PR DESCRIPTION
We now give a remedy for this error.

```
Exception message: 1 Exception encountered:

NoApplicableTargetsException: The `run` goal only works with these target types:
  * pex_binary

However, you only specified files/targets with these target types:
  * python_library

Run `./pants filter --target-type=pex_binary ::` to find all applicable targets in your project.
```

[ci skip-rust]
[ci skip-build-wheels]