### PR TITLE
Revert premature deprecation of `sources` field for `python_awslambda`

### DIFF
--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -16,24 +16,8 @@ from pants.engine.target import (
 )
 
 
-class DeprecatedPythonAwsLambdaSources(PythonSources):
+class PythonAwsLambdaSources(PythonSources):
     expected_num_files = range(0, 1)
-    deprecated_removal_version = "2.2.0.dev0"
-    deprecated_removal_hint = (
-        "Remove the `sources` field and create a new `python_library()` target (if you do not "
-        "yet have one), then add the `python_library()` to the `dependencies` field of this "
-        "`python_awslambda`. See https://www.pantsbuild.org/docs/awslambda-python for an example."
-    )
-
-
-class DeprecatedPythonInterpreterCompatibility(PythonInterpreterCompatibility):
-    deprecated_removal_version = "2.2.0.dev0"
-    deprecated_removal_hint = (
-        "Because the `sources` field will be removed, it no longer makes sense to have a "
-        "`compatibility` field for `python_awslambda` targets. Instead, set the "
-        "`compatibility` field on the `python_library` target containing this lambda's "
-        "handler code."
-    )
 
 
 class PythonAwsLambdaDependencies(Dependencies):
@@ -85,8 +69,8 @@ class PythonAWSLambda(Target):
     alias = "python_awslambda"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        DeprecatedPythonAwsLambdaSources,
-        DeprecatedPythonInterpreterCompatibility,
+        PythonAwsLambdaSources,
+        PythonInterpreterCompatibility,
         OutputPathField,
         PythonAwsLambdaDependencies,
         PythonAwsLambdaHandler,


### PR DESCRIPTION
While the `sources` field results in lots of issues, we did not offer an adequate replacement - there is more boilerplate now.

We likely should still deprecate the `sources` field, but we can do much better. For example, we can teach the `handler` field to allow for a source file, which we then convert into the handler module. Then, we can use dependency inference to avoid the user having to specify `dependencies`.

Status quo, with the deprecation in place:

```python
python_library()

python_awslambda(
  name="lambda",
  handler="path.to.lambda:func",
  dependencies=["./lambda.py"],
)
```

After, with still deprecating, but with the proposed improvements:

```python
python_library()

python_awslambda(
  name="lambda",
  handler="lambda.py:func",
)
```

This new feature shouldn't go into 2.0, so we for now revert the deprecation.

We still keep the bug fix of enforcing that `sources` is <=1 file.