### PR TITLE
Add `./cargo` script to facilitate Rust development

### DIFF
--- a/build-support/bin/check_clippy.sh
+++ b/build-support/bin/check_clippy.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-REPO_ROOT="$(git rev-parse --show-toplevel)"
-cd "${REPO_ROOT}"
-
-./build-support/bin/native/cargo clippy --manifest-path="${REPO_ROOT}/src/rust/engine/Cargo.toml" --all

--- a/build-support/bin/check_rust_formatting.sh
+++ b/build-support/bin/check_rust_formatting.sh
@@ -33,10 +33,8 @@ while getopts "hf" opt; do
   esac
 done
 
-NATIVE_ROOT="${REPO_ROOT}/src/rust/engine"
-
 cmd=(
-  "${REPO_ROOT}/build-support/bin/native/cargo" fmt --all --
+  "${REPO_ROOT}/cargo" fmt --all --
 )
 if [[ "${check}" == "true" ]]; then
   cmd=("${cmd[@]}" "--check")
@@ -46,12 +44,10 @@ fi
 # shellcheck disable=SC2207
 bad_files=(
   $(
-    cd "${NATIVE_ROOT}" || exit "${PIPESTATUS[0]}"
-
     # Ensure generated code is present since `cargo fmt` needs to do enough parsing to follow use's
     # and these will land in generated code.
     echo >&2 "Ensuring generated code is present for downstream formatting checks..."
-    "${REPO_ROOT}/build-support/bin/native/cargo" check -p bazel_protos
+    "${REPO_ROOT}/cargo" check -p bazel_protos
 
     "${cmd[@]}" | \
       awk '$0 ~ /^Diff in/ {print $3}' | \
@@ -63,15 +59,13 @@ exit_code=$?
 
 if [[ ${exit_code} -ne 0 ]]; then
   if [[ "${check}" == "true" ]]; then
-    echo >&2 "The following rust files were incorrectly formatted, run \`$0 -f\` to reformat them:"
+    echo >&2 "The following Rust files were incorrectly formatted, run \`$0 -f\` to reformat them:"
     for bad_file in ${bad_files[*]}; do
       echo >&2 "${bad_file}"
     done
   else
     cat << EOF >&2
-An error occurred while checking the formatting of rust files.
-Try running \`(cd "${NATIVE_ROOT}" && ${cmd[@]})\` to investigate.
-Its error is:
+An error occurred while checking the formatting of Rust files:
 EOF
     cd "${NATIVE_ROOT}" && "${cmd[@]}" >/dev/null
   fi

--- a/build-support/bin/check_rust_target_headers.sh
+++ b/build-support/bin/check_rust_target_headers.sh
@@ -2,11 +2,9 @@
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-cargo="${REPO_ROOT}/build-support/bin/native/cargo"
+"${REPO_ROOT}/cargo" install cargo-ensure-prefix --version "=0.1.3"
 
-"${cargo}" install cargo-ensure-prefix --version "=0.1.3"
-
-if ! out="$("${cargo}" ensure-prefix \
+if ! out="$("${REPO_ROOT}/cargo" ensure-prefix \
   --manifest-path="${REPO_ROOT}/src/rust/engine/Cargo.toml" \
   --prefix-path="${REPO_ROOT}/build-support/rust-target-prefix.txt" \
   --all --exclude=bazel_protos)"; then

--- a/build-support/bin/ci.py
+++ b/build-support/bin/ci.py
@@ -320,7 +320,7 @@ def run_lint(*, oauth_token_path: Optional[str] = None) -> None:
 
 def run_clippy() -> None:
     _run_command(
-        ["build-support/bin/check_clippy.sh"],
+        ["./cargo", "clippy", "--all"],
         slug="RustClippy",
         start_message="Running Clippy on Rust code.",
         die_message="Clippy failure.",
@@ -333,7 +333,7 @@ def run_cargo_audit() -> None:
         try:
             subprocess.run(
                 [
-                    "build-support/bin/native/cargo",
+                    "./cargo",
                     "ensure-installed",
                     "--package=cargo-audit",
                     "--version=0.11.2",
@@ -342,7 +342,7 @@ def run_cargo_audit() -> None:
             )
             subprocess.run(
                 [
-                    "build-support/bin/native/cargo",
+                    "./cargo",
                     "audit",
                     "-f",
                     "src/rust/engine/Cargo.lock",
@@ -361,13 +361,12 @@ def run_cargo_audit() -> None:
 def run_rust_tests() -> None:
     is_macos = platform.system() == "Darwin"
     command = [
-        "build-support/bin/native/cargo",
+        "./cargo",
         "test",
         "--all",
-        # We pass --tests to skip doc tests, because our generated protos contain invalid doc tests in
-        # their comments.
+        # We pass --tests to skip doc tests because our generated protos contain invalid doc tests
+        # in their comments.
         "--tests",
-        "--manifest-path=src/rust/engine/Cargo.toml",
         "--",
         "--nocapture",
     ]

--- a/build-support/bin/native/bootstrap_code.sh
+++ b/build-support/bin/native/bootstrap_code.sh
@@ -46,8 +46,7 @@ function _build_native_code() {
     # should be using.
     # NB: See Cargo.toml with regard to the `extension-module` feature.
     cd "${REPO_ROOT}"
-    "${REPO_ROOT}/build-support/bin/native/cargo" build --features=extension-module ${MODE_FLAG} \
-      --manifest-path "${NATIVE_ROOT}/Cargo.toml" -p engine
+    "${REPO_ROOT}/cargo" build --features=extension-module ${MODE_FLAG} -p engine
   ) || die
   echo "${NATIVE_ROOT}/target/${MODE}/libengine.${LIB_EXTENSION}"
 }

--- a/build-support/bin/packages.py
+++ b/build-support/bin/packages.py
@@ -246,14 +246,7 @@ def build_fs_util() -> None:
     # it in our releases because it can be a useful standalone tool.
     with travis_section("fs_util", "Building fs_util"):
         subprocess.run(
-            [
-                "build-support/bin/native/cargo",
-                "build",
-                "--release",
-                "--manifest-path=src/rust/engine/Cargo.toml",
-                "-p",
-                "fs_util",
-            ],
+            ["./cargo", "build", "--release", "-p", "fs_util"],
             check=True,
             env={**os.environ, "RUST_BACKTRACE": "1"},
         )

--- a/build-support/bin/shellcheck.py
+++ b/build-support/bin/shellcheck.py
@@ -25,6 +25,7 @@ def ensure_shellcheck_installed() -> None:
 
 def run_shellcheck() -> None:
     targets = set(glob("./**/*.sh", recursive=True)) | {
+        "./cargo",
         "./pants",
         "./build-support/pants_venv",
         "./build-support/virtualenv",

--- a/build-support/githooks/pre-commit
+++ b/build-support/githooks/pre-commit
@@ -25,8 +25,8 @@ if git rev-parse --verify "${MERGE_BASE}" &>/dev/null; then
     # The TRAVIS env var is documented here:
     #   https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
     if [[ "${TRAVIS}" != "true" ]]; then
-      echo "* Running cargo clippy"
-      ./build-support/bin/check_clippy.sh || exit 1
+      echo "* Running \`./cargo clippy --all\`"
+      ./cargo clippy --all || exit 1
     fi
     echo "* Checking formatting of Rust files"
     ./build-support/bin/check_rust_formatting.sh || exit 1

--- a/cargo
+++ b/cargo
@@ -3,7 +3,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
-NATIVE_ROOT="${REPO_ROOT}/src/rust/engine"
 
-cd "${NATIVE_ROOT}" || exit "${PIPESTATUS[0]}"
+cd "${REPO_ROOT}/src/rust/engine" || exit "${PIPESTATUS[0]}"
 exec "${REPO_ROOT}/build-support/bin/native/cargo.sh" "$@"

--- a/cargo
+++ b/cargo
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+NATIVE_ROOT="${REPO_ROOT}/src/rust/engine"
+
+cd "${NATIVE_ROOT}" || exit "${PIPESTATUS[0]}"
+exec "${REPO_ROOT}/build-support/bin/native/cargo.sh" "$@"


### PR DESCRIPTION
Now you can simply run `./cargo check` and `./cargo fmt` for example.

[ci skip-rust]
[ci skip-build-wheels]