### PR TITLE
Remove deprecated `compatibility` field in favor of `interpreter_constraints`

### DIFF
--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -4,7 +4,7 @@
 import re
 from typing import Match, Optional, Tuple, cast
 
-from pants.backend.python.target_types import PythonInterpreterCompatibility, PythonSources
+from pants.backend.python.target_types import InterpreterConstraintsField, PythonSources
 from pants.core.goals.package import OutputPathField
 from pants.engine.addresses import Address
 from pants.engine.target import (
@@ -16,24 +16,8 @@ from pants.engine.target import (
 )
 
 
-class DeprecatedPythonAwsLambdaSources(PythonSources):
+class PythonAwsLambdaSources(PythonSources):
     expected_num_files = range(0, 1)
-    deprecated_removal_version = "2.2.0.dev0"
-    deprecated_removal_hint = (
-        "Remove the `sources` field and create a new `python_library()` target (if you do not "
-        "yet have one), then add the `python_library()` to the `dependencies` field of this "
-        "`python_awslambda`. See https://www.pantsbuild.org/docs/awslambda-python for an example."
-    )
-
-
-class DeprecatedPythonInterpreterCompatibility(PythonInterpreterCompatibility):
-    deprecated_removal_version = "2.2.0.dev0"
-    deprecated_removal_hint = (
-        "Because the `sources` field will be removed, it no longer makes sense to have a "
-        "`compatibility` field for `python_awslambda` targets. Instead, set the "
-        "`interpreter_constraints` field on the `python_library` target containing this lambda's "
-        "handler code."
-    )
 
 
 class PythonAwsLambdaDependencies(Dependencies):
@@ -85,8 +69,8 @@ class PythonAWSLambda(Target):
     alias = "python_awslambda"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        DeprecatedPythonAwsLambdaSources,
-        DeprecatedPythonInterpreterCompatibility,
+        PythonAwsLambdaSources,
+        InterpreterConstraintsField,
         OutputPathField,
         PythonAwsLambdaDependencies,
         PythonAwsLambdaHandler,

--- a/src/python/pants/backend/codegen/protobuf/python/additional_fields.py
+++ b/src/python/pants/backend/codegen/protobuf/python/additional_fields.py
@@ -2,27 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.backend.codegen.protobuf.target_types import ProtobufLibrary
-from pants.backend.python.target_types import (
-    InterpreterConstraintsField,
-    PythonInterpreterCompatibility,
-)
+from pants.backend.python.target_types import InterpreterConstraintsField
 from pants.engine.target import StringField
 
 
 class ProtobufPythonInterpreterConstraints(InterpreterConstraintsField):
     alias = "python_interpreter_constraints"
-
-
-class ProtobufPythonInterpreterCompatibility(PythonInterpreterCompatibility):
-    """Deprecated in favor of the `python_interpreter_constraints` field."""
-
-    alias = "python_compatibility"
-    deprecated_removal_version = "2.2.0.dev0"
-    deprecated_removal_hint = (
-        "Use the field `python_interpreter_constraints`. The field does not work with bare strings "
-        "and expects a list of strings, so replace `python_compatibility='>3.6'` with "
-        "`python_interpreter_constraints=['>3.6']`."
-    )
 
 
 class PythonSourceRootField(StringField):
@@ -37,6 +22,5 @@ class PythonSourceRootField(StringField):
 def rules():
     return [
         ProtobufLibrary.register_plugin_field(ProtobufPythonInterpreterConstraints),
-        ProtobufLibrary.register_plugin_field(ProtobufPythonInterpreterCompatibility),
         ProtobufLibrary.register_plugin_field(PythonSourceRootField),
     ]

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -5,11 +5,7 @@ from dataclasses import dataclass
 from typing import Optional, Tuple
 
 from pants.backend.python.lint.bandit.subsystem import Bandit
-from pants.backend.python.target_types import (
-    InterpreterConstraintsField,
-    PythonInterpreterCompatibility,
-    PythonSources,
-)
+from pants.backend.python.target_types import InterpreterConstraintsField, PythonSources
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import (
     Pex,
@@ -36,7 +32,6 @@ class BanditFieldSet(FieldSet):
     required_fields = (PythonSources,)
 
     sources: PythonSources
-    compatibility: PythonInterpreterCompatibility
     interpreter_constraints: InterpreterConstraintsField
 
 

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -7,7 +7,7 @@ import pytest
 
 from pants.backend.python.lint.bandit.rules import BanditFieldSet, BanditRequest
 from pants.backend.python.lint.bandit.rules import rules as bandit_rules
-from pants.backend.python.target_types import PythonInterpreterCompatibility, PythonLibrary
+from pants.backend.python.target_types import InterpreterConstraintsField, PythonLibrary
 from pants.core.goals.lint import LintResult, LintResults
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents, FileContent
@@ -41,7 +41,11 @@ def make_target(
     for source_file in source_files:
         rule_runner.create_file(source_file.path, source_file.content.decode())
     return PythonLibrary(
-        {PythonInterpreterCompatibility.alias: interpreter_constraints},
+        {
+            InterpreterConstraintsField.alias: [interpreter_constraints]
+            if interpreter_constraints
+            else None
+        },
         address=Address("", target_name="target"),
     )
 

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -8,11 +8,7 @@ from typing import Tuple
 
 from pants.backend.python.lint.black.subsystem import Black
 from pants.backend.python.lint.python_fmt import PythonFmtRequest
-from pants.backend.python.target_types import (
-    InterpreterConstraintsField,
-    PythonInterpreterCompatibility,
-    PythonSources,
-)
+from pants.backend.python.target_types import InterpreterConstraintsField, PythonSources
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import (
     Pex,
@@ -41,7 +37,6 @@ class BlackFieldSet(FieldSet):
 
     sources: PythonSources
     interpreter_constraints: InterpreterConstraintsField
-    deprecated_interpreter_constraints: PythonInterpreterCompatibility
 
 
 class BlackRequest(PythonFmtRequest, LintRequest):
@@ -87,14 +82,7 @@ async def setup_black(
     # `>=3.6` to result in requiring Python 3.8, which would error if 3.8 is not installed on the
     # machine.
     all_interpreter_constraints = PexInterpreterConstraints.create_from_compatibility_fields(
-        (
-            PexInterpreterConstraints.resolve_conflicting_fields(
-                field_set.deprecated_interpreter_constraints,
-                field_set.interpreter_constraints,
-                field_set.address,
-            )
-            for field_set in setup_request.request.field_sets
-        ),
+        (field_set.interpreter_constraints for field_set in setup_request.request.field_sets),
         python_setup,
     )
     tool_interpreter_constraints = PexInterpreterConstraints(

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -5,11 +5,7 @@ from dataclasses import dataclass
 from typing import Optional, Tuple
 
 from pants.backend.python.lint.flake8.subsystem import Flake8
-from pants.backend.python.target_types import (
-    InterpreterConstraintsField,
-    PythonInterpreterCompatibility,
-    PythonSources,
-)
+from pants.backend.python.target_types import InterpreterConstraintsField, PythonSources
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import (
     Pex,
@@ -36,7 +32,6 @@ class Flake8FieldSet(FieldSet):
     required_fields = (PythonSources,)
 
     sources: PythonSources
-    compatibility: PythonInterpreterCompatibility
     interpreter_constraints: InterpreterConstraintsField
 
 

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -7,7 +7,7 @@ import pytest
 
 from pants.backend.python.lint.flake8.rules import Flake8FieldSet, Flake8Request
 from pants.backend.python.lint.flake8.rules import rules as flake8_rules
-from pants.backend.python.target_types import PythonInterpreterCompatibility, PythonLibrary
+from pants.backend.python.target_types import InterpreterConstraintsField, PythonLibrary
 from pants.core.goals.lint import LintResult, LintResults
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents, FileContent
@@ -40,7 +40,11 @@ def make_target(
     for source_file in source_files:
         rule_runner.create_file(source_file.path, source_file.content.decode())
     return PythonLibrary(
-        {PythonInterpreterCompatibility.alias: interpreter_constraints},
+        {
+            InterpreterConstraintsField.alias: [interpreter_constraints]
+            if interpreter_constraints
+            else None
+        },
         address=Address("", target_name="target"),
     )
 

--- a/src/python/pants/backend/python/lint/pylint/plugin_target_type.py
+++ b/src/python/pants/backend/python/lint/pylint/plugin_target_type.py
@@ -1,8 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.python.target_types import COMMON_PYTHON_FIELDS, PythonSources
-from pants.engine.target import Dependencies, Target
+from pants.backend.python.target_types import InterpreterConstraintsField, PythonSources
+from pants.engine.target import COMMON_TARGET_FIELDS, Dependencies, Target
 
 
 class PylintPluginSources(PythonSources):
@@ -52,4 +52,9 @@ class PylintSourcePlugin(Target):
     """
 
     alias = "pylint_source_plugin"
-    core_fields = (*COMMON_PYTHON_FIELDS, PylintPluginDependencies, PylintPluginSources)
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        InterpreterConstraintsField,
+        PylintPluginDependencies,
+        PylintPluginSources,
+    )

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -8,7 +8,6 @@ from typing import Iterable, List, Tuple
 from pants.backend.python.lint.pylint.subsystem import Pylint
 from pants.backend.python.target_types import (
     InterpreterConstraintsField,
-    PythonInterpreterCompatibility,
     PythonRequirementsField,
     PythonSources,
 )
@@ -244,13 +243,9 @@ async def pylint_lint(
     plugin_targets, linted_targets = await MultiGet(plugin_targets_request, linted_targets_request)
 
     plugin_targets_compatibility_fields = tuple(
-        PexInterpreterConstraints.resolve_conflicting_fields(
-            plugin_tgt[PythonInterpreterCompatibility],
-            plugin_tgt[InterpreterConstraintsField],
-            plugin_tgt.address,
-        )
+        plugin_tgt[InterpreterConstraintsField]
         for plugin_tgt in plugin_targets.closure
-        if plugin_tgt.has_fields([PythonInterpreterCompatibility, InterpreterConstraintsField])
+        if plugin_tgt.has_field(InterpreterConstraintsField)
     )
 
     # Pylint needs direct dependencies in the chroot to ensure that imports are valid. However, it
@@ -272,13 +267,9 @@ async def pylint_lint(
         interpreter_constraints = PexInterpreterConstraints.create_from_compatibility_fields(
             (
                 *(
-                    PexInterpreterConstraints.resolve_conflicting_fields(
-                        tgt[PythonInterpreterCompatibility],
-                        tgt[InterpreterConstraintsField],
-                        tgt.address,
-                    )
+                    tgt[InterpreterConstraintsField]
                     for tgt in [tgt, *dependencies]
-                    if tgt.has_fields([PythonInterpreterCompatibility, InterpreterConstraintsField])
+                    if tgt.has_field(InterpreterConstraintsField)
                 ),
                 *plugin_targets_compatibility_fields,
             ),

--- a/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints.py
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints.py
@@ -8,10 +8,7 @@ from textwrap import fill, indent
 from typing import cast
 
 from pants.backend.project_info.dependees import Dependees, DependeesRequest
-from pants.backend.python.target_types import (
-    InterpreterConstraintsField,
-    PythonInterpreterCompatibility,
-)
+from pants.backend.python.target_types import InterpreterConstraintsField
 from pants.backend.python.util_rules.pex import PexInterpreterConstraints
 from pants.base.specs import AddressSpecs, DescendantAddresses
 from pants.engine.addresses import Addresses
@@ -90,7 +87,6 @@ async def py_constraints(
                 t
                 for t in (*all_expanded_targets, *all_explicit_targets)
                 if t.has_field(InterpreterConstraintsField)
-                or t.has_field(PythonInterpreterCompatibility)
             },
             key=lambda tgt: tgt.address,
         )
@@ -158,7 +154,6 @@ async def py_constraints(
             tgt_type.alias
             for tgt_type in registered_target_types.types
             if tgt_type.class_has_field(InterpreterConstraintsField, union_membership)
-            or tgt_type.class_has_field(PythonInterpreterCompatibility, union_membership)
         )
         logger.warning(
             "No Python files/targets matched for the `py-constraints` goal. All target types with "

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -80,32 +80,6 @@ class InterpreterConstraintsField(StringSequenceField):
         return python_setup.compatibility_or_constraints(self.value)
 
 
-class PythonInterpreterCompatibility(StringOrStringSequenceField):
-    """Deprecated in favor of the `interpreter_constraints` field."""
-
-    alias = "compatibility"
-    deprecated_removal_version = "2.2.0.dev0"
-    deprecated_removal_hint = (
-        "Use the field `interpreter_constraints`. The field does not work with bare strings "
-        "and expects a list of strings, so replace `compatibility='>3.6'` with "
-        "interpreter_constraints=['>3.6']`."
-    )
-
-    def value_or_global_default(self, python_setup: PythonSetup) -> Tuple[str, ...]:
-        """Return either the given `compatibility` field or the global interpreter constraints.
-
-        If interpreter constraints are supplied by the CLI flag, return those only.
-        """
-        return python_setup.compatibility_or_constraints(self.value)
-
-
-COMMON_PYTHON_FIELDS = (
-    *COMMON_TARGET_FIELDS,
-    InterpreterConstraintsField,
-    PythonInterpreterCompatibility,
-)
-
-
 # -----------------------------------------------------------------------------------------------
 # `pex_binary` target
 # -----------------------------------------------------------------------------------------------
@@ -341,7 +315,8 @@ class PexBinary(Target):
 
     alias = "pex_binary"
     core_fields = (
-        *COMMON_PYTHON_FIELDS,
+        *COMMON_TARGET_FIELDS,
+        InterpreterConstraintsField,
         OutputPathField,
         PexBinarySources,
         PexBinaryDependencies,
@@ -438,7 +413,8 @@ class PythonTests(Target):
 
     alias = "python_tests"
     core_fields = (
-        *COMMON_PYTHON_FIELDS,
+        *COMMON_TARGET_FIELDS,
+        InterpreterConstraintsField,
         PythonTestsSources,
         PythonTestsDependencies,
         PythonRuntimePackageDependencies,
@@ -464,7 +440,12 @@ class PythonLibrary(Target):
     """
 
     alias = "python_library"
-    core_fields = (*COMMON_PYTHON_FIELDS, Dependencies, PythonLibrarySources)
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        InterpreterConstraintsField,
+        Dependencies,
+        PythonLibrarySources,
+    )
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/backend/python/typecheck/mypy/plugin_target_type.py
+++ b/src/python/pants/backend/python/typecheck/mypy/plugin_target_type.py
@@ -1,8 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.python.target_types import COMMON_PYTHON_FIELDS, PythonSources
-from pants.engine.target import Dependencies, Target
+from pants.backend.python.target_types import InterpreterConstraintsField, PythonSources
+from pants.engine.target import COMMON_TARGET_FIELDS, Dependencies, Target
 
 
 class MyPyPluginSources(PythonSources):
@@ -41,4 +41,9 @@ class MyPySourcePlugin(Target):
     """
 
     alias = "mypy_source_plugin"
-    core_fields = (*COMMON_PYTHON_FIELDS, Dependencies, MyPyPluginSources)
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        InterpreterConstraintsField,
+        Dependencies,
+        MyPyPluginSources,
+    )

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -26,10 +26,7 @@ from typing_extensions import Protocol
 
 from pants.backend.python.target_types import InterpreterConstraintsField
 from pants.backend.python.target_types import PexPlatformsField as PythonPlatformsField
-from pants.backend.python.target_types import (
-    PythonInterpreterCompatibility,
-    PythonRequirementsField,
-)
+from pants.backend.python.target_types import PythonRequirementsField
 from pants.backend.python.util_rules import pex_cli
 from pants.backend.python.util_rules.pex_cli import PexCliProcess
 from pants.backend.python.util_rules.pex_environment import (
@@ -58,7 +55,7 @@ from pants.engine.process import (
     UncacheableProcess,
 )
 from pants.engine.rules import Get, collect_rules, rule
-from pants.engine.target import InvalidFieldException, Target
+from pants.engine.target import Target
 from pants.python.python_repos import PythonRepos
 from pants.python.python_setup import PythonSetup
 from pants.util.frozendict import FrozenDict
@@ -84,13 +81,9 @@ class PexRequirements(DeduplicatedCollection[str]):
 
 # This protocol allows us to work with any arbitrary FieldSet. See
 # https://mypy.readthedocs.io/en/stable/protocols.html.
-class FieldSetWithCompatibility(Protocol):
+class FieldSetWithInterpreterConstraints(Protocol):
     @property
     def address(self) -> Address:
-        ...
-
-    @property
-    def compatibility(self) -> PythonInterpreterCompatibility:
         ...
 
     @property
@@ -98,7 +91,7 @@ class FieldSetWithCompatibility(Protocol):
         ...
 
 
-_FS = TypeVar("_FS", bound=FieldSetWithCompatibility)
+_FS = TypeVar("_FS", bound=FieldSetWithInterpreterConstraints)
 
 
 # Normally we would subclass `DeduplicatedCollection`, but we want a custom constructor.
@@ -188,49 +181,21 @@ class PexInterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParame
         )
 
     @classmethod
-    def resolve_conflicting_fields(
-        cls,
-        deprecated: PythonInterpreterCompatibility,
-        new: InterpreterConstraintsField,
-        address: Address,
-    ) -> Union[PythonInterpreterCompatibility, InterpreterConstraintsField]:
-        if deprecated.value and new.value:
-            raise InvalidFieldException(
-                f"Specified both the deprecated `{deprecated.alias}` field and the new "
-                f"`{new.alias}` field for the target {address}. Please use only one "
-                f"(preferably {new.alias})"
-            )
-        if deprecated.value:
-            return deprecated
-        return new
-
-    @classmethod
     def create_from_targets(
         cls, targets: Iterable[Target], python_setup: PythonSetup
     ) -> "PexInterpreterConstraints":
-        fields = []
-        for tgt in targets:
-            has_deprecated = tgt.has_field(PythonInterpreterCompatibility)
-            has_new = tgt.has_field(InterpreterConstraintsField)
-            if has_deprecated and has_new:
-                fields.append(
-                    cls.resolve_conflicting_fields(
-                        tgt[PythonInterpreterCompatibility],
-                        tgt[InterpreterConstraintsField],
-                        tgt.address,
-                    )
-                )
-            elif has_deprecated:
-                fields.append(tgt[PythonInterpreterCompatibility])
-            elif has_new:
-                fields.append(tgt[InterpreterConstraintsField])
-        return cls.create_from_compatibility_fields(fields, python_setup)
+        return cls.create_from_compatibility_fields(
+            (
+                tgt[InterpreterConstraintsField]
+                for tgt in targets
+                if tgt.has_field(InterpreterConstraintsField)
+            ),
+            python_setup,
+        )
 
     @classmethod
     def create_from_compatibility_fields(
-        cls,
-        fields: Iterable[Union[InterpreterConstraintsField, PythonInterpreterCompatibility]],
-        python_setup: PythonSetup,
+        cls, fields: Iterable[InterpreterConstraintsField], python_setup: PythonSetup
     ) -> "PexInterpreterConstraints":
         constraint_sets = {field.value_or_global_default(python_setup) for field in fields}
         # This will OR within each field and AND across fields.
@@ -243,10 +208,9 @@ class PexInterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParame
     ) -> FrozenDict["PexInterpreterConstraints", Tuple[_FS, ...]]:
         results = defaultdict(set)
         for fs in field_sets:
-            constraints_field = cls.resolve_conflicting_fields(
-                fs.compatibility, fs.interpreter_constraints, fs.address
+            constraints = cls.create_from_compatibility_fields(
+                [fs.interpreter_constraints], python_setup
             )
-            constraints = cls.create_from_compatibility_fields([constraints_field], python_setup)
             results[constraints].add(fs)
         return FrozenDict(
             {

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -11,10 +11,7 @@ from typing import Dict, Iterable, Iterator, List, Mapping, Optional, Tuple, cas
 import pytest
 from pkg_resources import Requirement
 
-from pants.backend.python.target_types import (
-    InterpreterConstraintsField,
-    PythonInterpreterCompatibility,
-)
+from pants.backend.python.target_types import InterpreterConstraintsField
 from pants.backend.python.util_rules.pex import (
     Pex,
     PexInterpreterConstraints,
@@ -218,7 +215,6 @@ def test_interpreter_constraints_do_not_require_python38(constraints):
 @dataclass(frozen=True)
 class MockFieldSet(FieldSet):
     interpreter_constraints: InterpreterConstraintsField
-    compatibility: PythonInterpreterCompatibility
 
     @classmethod
     def create_for_test(cls, address: Address, compat: Optional[str]) -> "MockFieldSet":
@@ -227,7 +223,6 @@ class MockFieldSet(FieldSet):
             interpreter_constraints=InterpreterConstraintsField(
                 [compat] if compat else None, address=address
             ),
-            compatibility=PythonInterpreterCompatibility(None, address=address),
         )
 
 


### PR DESCRIPTION
[ci skip-rust]
[ci skip-build-wheels]
