### PR TITLE
Update to nails `0.8.0`

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1706,9 +1706,9 @@ dependencies = [
 
 [[package]]
 name = "nails"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a495346f7367d386ab5fd0a487554cd338062adf11fd91c25396eef9e5557411"
+checksum = "324d0793d44314222dc61947ffecc0325fb1c824dd6ef6b231b98e0b1f06b11b"
 dependencies = [
  "byteorder",
  "bytes 0.5.4",

--- a/src/rust/engine/nailgun/Cargo.toml
+++ b/src/rust/engine/nailgun/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 bytes = "0.5"
 futures = "0.3.5"
 log = "0.4"
-nails = "0.7.0"
+nails = "0.8"
 os_pipe = "0.9"
 task_executor = { path = "../task_executor" }
 tokio = { version = "0.2.23", features = ["tcp", "fs", "sync", "io-std"] }

--- a/src/rust/engine/nailgun/src/server.rs
+++ b/src/rust/engine/nailgun/src/server.rs
@@ -28,7 +28,7 @@
 #![allow(clippy::mutex_atomic)]
 
 use nails::execution::{self, sink_for, stream_for, ChildInput, ChildOutput, ExitCode};
-use nails::{Child, Nail};
+use nails::Nail;
 use task_executor::Executor;
 use tokio::fs::File;
 use tokio::net::TcpListener;
@@ -157,7 +157,7 @@ impl Server {
         async move {
           let ongoing_connection_guard = ongoing_connections.read().await;
           connection_started.notify();
-          let result = nails::server_handle_connection(config, nail, tcp_stream).await;
+          let result = nails::server::handle_connection(config, nail, tcp_stream).await;
           std::mem::drop(ongoing_connection_guard);
           result
         }
@@ -230,7 +230,7 @@ impl Nail for RawFdNail {
     &self,
     cmd: execution::Command,
     input_stream: mpsc::Receiver<ChildInput>,
-  ) -> Result<Child, io::Error> {
+  ) -> Result<nails::server::Child, io::Error> {
     let env = cmd.env.iter().cloned().collect::<HashMap<_, _>>();
 
     // Handle stdin.
@@ -287,7 +287,7 @@ impl Nail for RawFdNail {
       })
       .boxed();
 
-    Ok(Child {
+    Ok(nails::server::Child {
       output_stream,
       accepts_stdin,
     })

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -21,7 +21,7 @@ grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "ed3afa3c24d
 hashing = { path = "../hashing" }
 libc = "0.2.39"
 log = "0.4"
-nails = "0.7.0"
+nails = "0.8"
 protobuf = { version = "2.0.6", features = ["with-bytes"] }
 sha2 = "0.9"
 sharded_lmdb = {  path = "../sharded_lmdb" }


### PR DESCRIPTION
### Problem

#11223 needs to use `nails` `0.8.0` in order to cancel connections.

### Solution

Update to nails `0.8.0`.

[ci skip-build-wheels]