### PR TITLE
Remove `PrimitiveField` and align `AsyncField` with `Field`

### DIFF
--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -22,12 +22,12 @@ from pants.engine.target import (
     BoolField,
     Dependencies,
     DictStringToStringSequenceField,
+    Field,
     InjectDependenciesRequest,
     InjectedDependencies,
     IntField,
     InvalidFieldException,
     InvalidFieldTypeException,
-    PrimitiveField,
     ProvidesField,
     ScalarField,
     Sources,
@@ -484,7 +484,7 @@ def format_invalid_requirement_string_error(
     )
 
 
-class PythonRequirementsField(PrimitiveField):
+class PythonRequirementsField(Field):
     """A sequence of pip-style requirement strings, e.g. ['foo==1.8', 'bar<=3 ;
     python_version<'3']."""
 

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -699,7 +699,7 @@ def parse_dependencies_field(
 
     addresses: List[AddressInput] = []
     ignored_addresses: List[AddressInput] = []
-    for v in field.sanitized_raw_value or ():
+    for v in field.value or ():
         is_ignore = v.startswith("!")
         if is_ignore:
             # Check if it's a transitive exclude, rather than a direct exclude.

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -828,7 +828,7 @@ def test_sources_default_globs(sources_rule_runner: RuleRunner) -> None:
     # than the normal `all` conjunction.
     sources_rule_runner.create_files("src/fortran", files=["default.f95", "f1.f08", "ignored.f08"])
     sources = DefaultSources(None, address=addr)
-    assert set(sources.sanitized_raw_value or ()) == set(DefaultSources.default)
+    assert set(sources.value or ()) == set(DefaultSources.default)
 
     hydrated_sources = sources_rule_runner.request(
         HydratedSources, [HydrateSourcesRequest(sources)]

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1729,3 +1729,4 @@ class ProvidesField(Field):
     world."""
 
     alias = "provides"
+    default: ClassVar[Optional[Any]] = None

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -12,13 +12,13 @@ from pants.base import deprecated
 from pants.engine.goal import GoalSubsystem
 from pants.engine.target import (
     AsyncField,
+    AsyncStringSequenceField,
     BoolField,
     DictStringToStringField,
     DictStringToStringSequenceField,
     Field,
     FloatField,
     IntField,
-    PrimitiveField,
     RegisteredTargetTypes,
     ScalarField,
     SequenceField,
@@ -159,11 +159,11 @@ class TargetFieldHelpInfo:
         # we can still generate meaningful documentation for all these custom fields without
         # requiring the Field author to rewrite the docstring.
         #
-        # However, if the original `Field` author did not define docstring, then this means we
-        # would typically fall back to the docstring for `AsyncField`, `PrimitiveField`, or a
-        # helper class like `StringField`. This is a quirk of this heuristic and it's not
-        # intentional since these core `Field` types have documentation oriented to the custom
-        # `Field` author and not the end user filling in fields in a BUILD file target.
+        # However, if the original plugin author did not define docstring, then this means we
+        # would typically fall back to the docstring for `Field` or a template like `StringField`.
+        # This is a an awkward edge of our heuristic and it's not intentional since these core
+        # `Field` types have documentation oriented to the plugin author and not the end user
+        # filling in fields in a BUILD file.
         description = get_docstring(
             field,
             flatten=True,
@@ -171,7 +171,7 @@ class TargetFieldHelpInfo:
             ignored_ancestors={
                 *Field.mro(),
                 AsyncField,
-                PrimitiveField,
+                AsyncStringSequenceField,
                 BoolField,
                 DictStringToStringField,
                 DictStringToStringSequenceField,
@@ -185,12 +185,7 @@ class TargetFieldHelpInfo:
                 StringSequenceField,
             },
         )
-        if issubclass(field, PrimitiveField):
-            raw_value_type = get_type_hints(field.compute_value)["raw_value"]
-        elif issubclass(field, AsyncField):
-            raw_value_type = get_type_hints(field.sanitize_raw_value)["raw_value"]
-        else:
-            raw_value_type = get_type_hints(field.__init__)["raw_value"]
+        raw_value_type = get_type_hints(field.compute_value)["raw_value"]
         type_hint = pretty_print_type_hint(raw_value_type)
 
         # Check if the field only allows for certain choices.

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from abc import ABC, abstractmethod
-from dataclasses import FrozenInstanceError
+from dataclasses import FrozenInstanceError as FrozenInstanceError
 from functools import wraps
 from typing import Any, Callable, Optional, Type, TypeVar, Union
 

--- a/src/python/pants/util/meta_test.py
+++ b/src/python/pants/util/meta_test.py
@@ -313,6 +313,13 @@ def test_add_new_field_after_init() -> None:
     with pytest.raises(FrozenInstanceError):
         test.y = "abc"  # type: ignore[attr-defined]
 
+    test._unfreeze_instance()  # type: ignore[attr-defined]
+    test.y = "abc"  # type: ignore[attr-defined]
+
+    test._freeze_instance()  # type: ignore[attr-defined]
+    with pytest.raises(FrozenInstanceError):
+        test.z = "abc"  # type: ignore[attr-defined]
+
 
 def test_explicitly_call_setattr_after_init() -> None:
     @frozen_after_init
@@ -323,6 +330,13 @@ def test_explicitly_call_setattr_after_init() -> None:
     test = Test(x=0)
     with pytest.raises(FrozenInstanceError):
         setattr(test, "x", 1)
+
+    test._unfreeze_instance()  # type: ignore[attr-defined]
+    setattr(test, "x", 1)
+
+    test._freeze_instance()  # type: ignore[attr-defined]
+    with pytest.raises(FrozenInstanceError):
+        test.y = "abc"  # type: ignore[attr-defined]
 
 
 def test_works_with_dataclass() -> None:


### PR DESCRIPTION
Broken out of https://github.com/pantsbuild/pants/pull/10932.

The difference between `AsyncField` and `PrimitiveField` is fairly artificial and it creates more complexity than we need. Really, the only difference is a) storing the `Address` and b) an expression of intent.

This makes `Field` act like `PrimitiveField`, which is now deleted. `AsyncField` now uses the same naming as `PrimitiveField` used to, i.e.`value` instead of `sanitized_raw_value` and `compute_value()` instead of `sanitize_raw_value()`.

This also cleans up some of the relevant `target_test.py`. We were testing something that's no longer worth it, as it's outside the scope of the code and we have multiple places we test this pattern. We add a new test that `__eq__` and `__hash__` are correct.

[ci skip-rust]
[ci skip-build-wheels]