### PR TITLE
Change `AsyncField` to be `AsyncFieldMixin`

### DIFF
--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -776,8 +776,8 @@ def test_sources_normal_hydration(sources_rule_runner: RuleRunner) -> None:
     assert (
         sources.filespec
         == {
-            "includes": ["src/fortran/*.f03", "src/fortran/f1.f95"],
-            "excludes": ["src/fortran/**/ignore*", "src/fortran/ignored.f03"],
+            "includes": ["src/fortran/f1.f95", "src/fortran/*.f03"],
+            "excludes": ["src/fortran/ignored.f03", "src/fortran/**/ignore*"],
         }
         == hydrated_sources.filespec
     )

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -157,12 +157,12 @@ class Field:
         return f"{self.alias}={self.value}"
 
     def __hash__(self) -> int:
-        return hash((self.alias, self.value))
+        return hash((self.__class__, self.value))
 
     def __eq__(self, other: Union[Any, Field]) -> bool:
         if not isinstance(other, Field):
             return NotImplemented
-        return (self.alias, self.value) == (other.alias, other.value)
+        return (self.__class__, self.value) == (other.__class__, other.value)
 
 
 # NB: By subclassing `Field`, MyPy understands our type hints, and it means it doesn't matter which
@@ -229,12 +229,16 @@ class AsyncFieldMixin(Field):
         )
 
     def __hash__(self) -> int:
-        return hash((self.alias, self.value, self.address))
+        return hash((self.__class__, self.value, self.address))
 
     def __eq__(self, other: Union[Any, AsyncFieldMixin]) -> bool:
         if not isinstance(other, AsyncFieldMixin):
             return NotImplemented
-        return (self.alias, self.value, self.address) == (other.alias, other.value, other.address)
+        return (self.__class__, self.value, self.address) == (
+            other.__class__,
+            other.value,
+            other.address,
+        )
 
 
 # -----------------------------------------------------------------------------------------------
@@ -344,13 +348,13 @@ class Target:
         return f"{self.alias}({address}{fields})"
 
     def __hash__(self) -> int:
-        return hash((self.alias, self.address, self.field_values))
+        return hash((self.__class__, self.address, self.field_values))
 
     def __eq__(self, other: Union[Target, Any]) -> bool:
         if not isinstance(other, Target):
             return NotImplemented
-        return (self.alias, self.address, self.field_values) == (
-            other.alias,
+        return (self.__class__, self.address, self.field_values) == (
+            other.__class__,
             other.address,
             other.field_values,
         )

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -366,7 +366,7 @@ def test_required_field() -> None:
 
 
 def test_async_field_mixin() -> None:
-    class ExampleField(AsyncFieldMixin, IntField):
+    class ExampleField(IntField, AsyncFieldMixin):
         alias = "field"
         default = 10
 
@@ -374,6 +374,7 @@ def test_async_field_mixin() -> None:
     field = ExampleField(None, address=addr)
     assert field.value == 10
     assert field.address == addr
+    ExampleField.mro()  # Regression test that the mro is resolvable.
 
     # Ensure equality and __hash__ work correctly.
     other = ExampleField(None, address=addr)

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -119,6 +119,21 @@ def test_field_and_target_eq() -> None:
     with pytest.raises(FrozenInstanceError):
         tgt.y = "foo"  # type: ignore[attr-defined]
 
+    # Ensure that subclasses are not equal.
+    class SubclassField(FortranVersion):
+        pass
+
+    subclass_field = SubclassField("dev0", address=addr)
+    assert field != subclass_field
+    assert hash(field) != hash(subclass_field)
+
+    class SubclassTarget(FortranTarget):
+        pass
+
+    subclass_tgt = SubclassTarget({"version": "dev0"}, address=addr)
+    assert tgt != subclass_tgt
+    assert hash(tgt) != hash(subclass_tgt)
+
 
 def test_invalid_fields_rejected() -> None:
     with pytest.raises(InvalidFieldException) as exc:
@@ -393,6 +408,14 @@ def test_async_field_mixin() -> None:
     # Ensure it's still frozen.
     with pytest.raises(FrozenInstanceError):
         field.y = "foo"  # type: ignore[attr-defined]
+
+    # Ensure that subclasses are not equal.
+    class Subclass(ExampleField):
+        pass
+
+    subclass = Subclass(None, address=addr)
+    assert field != subclass
+    assert hash(field) != hash(subclass)
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -9,14 +9,14 @@ import pytest
 
 from pants.engine.addresses import Address
 from pants.engine.target import (
-    AsyncField,
-    AsyncStringSequenceField,
+    AsyncFieldMixin,
     BoolField,
     Dependencies,
     DictStringToStringField,
     DictStringToStringSequenceField,
     Field,
     FieldSet,
+    IntField,
     InvalidFieldChoiceException,
     InvalidFieldException,
     InvalidFieldTypeException,
@@ -76,6 +76,48 @@ class UnrelatedField(BoolField):
 class FortranTarget(Target):
     alias = "fortran"
     core_fields = (FortranExtensions, FortranVersion)
+
+
+def test_field_and_target_eq() -> None:
+    addr = Address("", target_name="tgt")
+    field = FortranVersion("dev0", address=addr)
+    assert field.value == "dev0"
+
+    other = FortranVersion("dev0", address=addr)
+    assert field == other
+    assert hash(field) == hash(other)
+
+    other = FortranVersion("dev1", address=addr)
+    assert field != other
+    assert hash(field) != hash(other)
+
+    # NB: because normal `Field`s throw away the address, these are equivalent.
+    other = FortranVersion("dev0", address=Address("", target_name="other"))
+    assert field == other
+    assert hash(field) == hash(other)
+
+    # Ensure the field is frozen.
+    with pytest.raises(FrozenInstanceError):
+        field.y = "foo"  # type: ignore[attr-defined]
+
+    tgt = FortranTarget({"version": "dev0"}, address=addr)
+    assert tgt.address == addr
+
+    other_tgt = FortranTarget({"version": "dev0"}, address=addr)
+    assert tgt == other_tgt
+    assert hash(tgt) == hash(other_tgt)
+
+    other_tgt = FortranTarget({"version": "dev1"}, address=addr)
+    assert tgt != other_tgt
+    assert hash(tgt) != hash(other_tgt)
+
+    other_tgt = FortranTarget({"version": "dev0"}, address=Address("", target_name="other"))
+    assert tgt != other_tgt
+    assert hash(tgt) != hash(other_tgt)
+
+    # Ensure the target is frozen.
+    with pytest.raises(FrozenInstanceError):
+        tgt.y = "foo"  # type: ignore[attr-defined]
 
 
 def test_invalid_fields_rejected() -> None:
@@ -323,8 +365,8 @@ def test_required_field() -> None:
     assert "field" in str(exc.value)
 
 
-def test_async_field() -> None:
-    class ExampleField(AsyncField):
+def test_async_field_mixin() -> None:
+    class ExampleField(AsyncFieldMixin, IntField):
         alias = "field"
         default = 10
 
@@ -342,6 +384,7 @@ def test_async_field() -> None:
     assert field != other
     assert hash(field) != hash(other)
 
+    # Whereas normally the address is not considered, it is considered for async fields.
     other = ExampleField(None, address=Address("", target_name="other"))
     assert field != other
     assert hash(field) != hash(other)
@@ -646,16 +689,3 @@ def test_dict_string_to_string_sequence_field() -> None:
         default = FrozenDict({"default": ("val",)})
 
     assert ExampleDefault(None, address=addr).value == FrozenDict({"default": ("val",)})
-
-
-def test_async_string_sequence_field() -> None:
-    class Example(AsyncStringSequenceField):
-        alias = "example"
-
-    addr = Address("", target_name="example")
-    assert Example(["hello", "world"], address=addr).value == ("hello", "world")
-    assert Example(None, address=addr).value is None
-    with pytest.raises(InvalidFieldTypeException):
-        Example("strings are technically iterable...", address=addr)
-    with pytest.raises(InvalidFieldTypeException):
-        Example(["hello", 0, "world"], address=addr)

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -11,8 +11,7 @@ from typing import Any, Callable, Dict, Generic, List, Optional, Tuple, Type, ca
 from pants.base import deprecated
 from pants.engine.goal import GoalSubsystem
 from pants.engine.target import (
-    AsyncField,
-    AsyncStringSequenceField,
+    AsyncFieldMixin,
     BoolField,
     DictStringToStringField,
     DictStringToStringSequenceField,
@@ -170,8 +169,7 @@ class TargetFieldHelpInfo:
             fallback_to_ancestors=True,
             ignored_ancestors={
                 *Field.mro(),
-                AsyncField,
-                AsyncStringSequenceField,
+                AsyncFieldMixin,
                 BoolField,
                 DictStringToStringField,
                 DictStringToStringSequenceField,


### PR DESCRIPTION
By doing this, it's now possible to combine any arbitrary field template with being an async field. Previously, we duplicated the templates, like `AsyncStringSequenceField`. This also builds off of https://github.com/pantsbuild/pants/pull/11231 to make async fields far less magical - literally, all they do is add an `address: Address` field.

To land this, we remove both `@dataclass` and `ABC` from `Field`, which were causing unnecessary confusion and messing up inheritance. The dataclass was only generating a custom `__eq__` and `__hash__`, which is easy to set explicitly. We also remove both things from `Target` for simplicity.

[ci skip-rust]
[ci skip-build-wheels]