### PR TITLE
Deprecate `mypy_source_plugin` and `pylint_source_plugin` targets in favor of `python_library`

### DIFF
--- a/pants-plugins/mypy_plugins/BUILD
+++ b/pants-plugins/mypy_plugins/BUILD
@@ -1,7 +1,4 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-mypy_source_plugin(
-  name="total_ordering",
-  sources=["total_ordering.py"],
-)
+python_library()

--- a/pants.toml
+++ b/pants.toml
@@ -76,7 +76,7 @@ config = ["pyproject.toml"]
 
 [mypy]
 config = "build-support/mypy/mypy.ini"
-source_plugins = ["pants-plugins/mypy_plugins:total_ordering"]
+source_plugins = ["pants-plugins/mypy_plugins"]
 
 [pants-releases]
 release_notes = """

--- a/src/python/pants/backend/python/lint/pylint/plugin_target_type.py
+++ b/src/python/pants/backend/python/lint/pylint/plugin_target_type.py
@@ -58,3 +58,9 @@ class PylintSourcePlugin(Target):
         PylintPluginDependencies,
         PylintPluginSources,
     )
+
+    deprecated_removal_version = "2.3.0.dev0"
+    deprecated_removal_hint = (
+        "Use a `python_library` target rather than `pylint_source_plugin`, which behaves "
+        "identically. If you change the target's name, update `[pylint].source_plugins`."
+    )

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -7,7 +7,6 @@ from typing import Any, List, Optional, Sequence
 
 import pytest
 
-from pants.backend.python.lint.pylint.plugin_target_type import PylintSourcePlugin
 from pants.backend.python.lint.pylint.rules import PylintFieldSet, PylintRequest
 from pants.backend.python.lint.pylint.rules import rules as pylint_rules
 from pants.backend.python.target_types import PythonLibrary, PythonRequirementLibrary
@@ -26,7 +25,7 @@ def rule_runner() -> RuleRunner:
             *pylint_rules(),
             QueryRule(LintResults, (PylintRequest,)),
         ],
-        target_types=[PythonLibrary, PythonRequirementLibrary, PylintSourcePlugin],
+        target_types=[PythonLibrary, PythonRequirementLibrary],
     )
 
 
@@ -412,15 +411,7 @@ def test_source_plugin(rule_runner: RuleRunner) -> None:
     )
     rule_runner.add_to_build_file(
         "pants-plugins/plugins",
-        dedent(
-            """\
-            pylint_source_plugin(
-                name='print_plugin',
-                sources=['print_plugin.py'],
-                dependencies=['//:pylint', 'pants-plugins/plugins/subdir'],
-            )
-            """
-        ),
+        "python_library(dependencies=['//:pylint', 'pants-plugins/plugins/subdir'])",
     )
     config_content = dedent(
         """\
@@ -434,7 +425,7 @@ def test_source_plugin(rule_runner: RuleRunner) -> None:
             rule_runner,
             [tgt],
             additional_args=[
-                "--pylint-source-plugins=['pants-plugins/plugins:print_plugin']",
+                "--pylint-source-plugins=['pants-plugins/plugins']",
                 f"--source-root-patterns=['pants-plugins/plugins', '{PACKAGE}']",
             ],
             config=config_content,
@@ -450,9 +441,7 @@ def test_source_plugin(rule_runner: RuleRunner) -> None:
     assert f"{PACKAGE}/source_plugin.py:2:0: C9871" in result.stdout
 
     # Ensure that running Pylint on the plugin itself still works.
-    plugin_tgt = rule_runner.get_target(
-        Address("pants-plugins/plugins", target_name="print_plugin")
-    )
+    plugin_tgt = rule_runner.get_target(Address("pants-plugins/plugins"))
     result = run_pylint_with_plugin(plugin_tgt)
     assert result.exit_code == 0
     assert "Your code has been rated at 10.00/10" in result.stdout

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -46,9 +46,18 @@ class Pylint(PythonToolBase):
             member_type=target_option,
             advanced=True,
             help=(
-                "An optional list of `pylint_source_plugin` target addresses. This allows you to "
-                "load custom plugins defined in source code. Run `./pants help "
-                "pylint_source_plugin` for instructions, including how to load third-party plugins."
+                "An optional list of `python_library` target addresses to load first-party "
+                "plugins.\n\nYou must set the plugin's parent directory as a source root. For "
+                "example, if your plugin is at `build-support/pylint/custom_plugin.py`, add "
+                "'build-support/pylint' to `[source].root_patterns` in `pants.toml`. This is "
+                "necessary for Pants to know how to tell Pylint to discover your plugin. See "
+                "https://www.pantsbuild.org/docs/source-roots.\n\nYou must also set "
+                "`load-plugins=$module_name` in your Pylint config file, and set the "
+                "`[pylint].config` option in `pants.toml`.\n\nWhile your plugin's code can depend "
+                "on other first-party code and third-party requirements, all first-party "
+                "dependencies of the plugin must live in the same directory or a subdirectory.\n\n"
+                "To instead load third-party plugins, set the option `[pylint].extra_requirements` "
+                "and set the `load-plugins` option in your Pylint config."
             ),
         )
 

--- a/src/python/pants/backend/python/typecheck/mypy/plugin_target_type.py
+++ b/src/python/pants/backend/python/typecheck/mypy/plugin_target_type.py
@@ -47,3 +47,9 @@ class MyPySourcePlugin(Target):
         Dependencies,
         MyPyPluginSources,
     )
+
+    deprecated_removal_version = "2.3.0.dev0"
+    deprecated_removal_hint = (
+        "Use a `python_library` target rather than `mypy_source_plugin`, which behaves "
+        "identically. If you change the target's name, update `[mypy].source_plugins`."
+    )

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -50,9 +50,11 @@ class MyPy(PythonToolBase):
             member_type=target_option,
             advanced=True,
             help=(
-                "An optional list of `mypy_source_plugin` target addresses. This allows you to "
-                "load custom plugins defined in source code. Run `./pants help mypy_source_plugin` "
-                "for instructions, including how to load third-party plugins."
+                "An optional list of `python_library` target addresses to load first-party "
+                "plugins.\n\nYou must also set `plugins = path.to.module` in your `mypy.ini`, and"
+                "set the `[mypy].config` option in your `pants.toml`.\n\nTo instead load "
+                "third-party plugins, set the option `[mypy].extra_requirements` and set the "
+                "`plugins` option in `mypy.ini`."
             ),
         )
 


### PR DESCRIPTION
As explained in the [proposal to remove `sources` from `pex_binary`](https://docs.google.com/document/d/1i0FDDvSd8BjgfkM6fq28p5KDojBy1xBf-mXTa8WL-sg/edit), we are moving to a world where only the `python_library` and `python_tests` targets have `sources` fields for Python code. This removes a common gotcha with multiple targets "owning" the same file and breaking dep inference, and it unlocks future improvements like implicit targets.

These two targets behaved identically to `python_library`, outside of the default for the `sources` field. They only existed for namespacing purposes, e.g. to have instructions with `./pants help mypy_source_plugin`. This is not worth it to keep.
 
[ci skip-rust]
[ci skip-build-wheels]