### PR TITLE
Fix off-by-one error for `python_awslambda` `sources` field validation

### DIFF
--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -17,7 +17,7 @@ from pants.engine.target import (
 
 
 class PythonAwsLambdaSources(PythonSources):
-    expected_num_files = range(0, 1)
+    expected_num_files = range(0, 2)
 
 
 class PythonAwsLambdaDependencies(Dependencies):


### PR DESCRIPTION
This mistake meant that you could never set the sources field for `python_awslambda`.

[ci skip-rust]
[ci skip-build-wheels]