### PR TITLE
Stop logging warning when Pyenv is not installed

### DIFF
--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -298,5 +298,4 @@ def get_pyenv_root():
     try:
         return subprocess.check_output(["pyenv", "root"]).decode().strip()
     except (OSError, subprocess.CalledProcessError):
-        logger.info("No pyenv binary found. Will not use pyenv interpreters.")
-    return None
+        return None


### PR DESCRIPTION
Now that we include Pyenv by default, this log is a little confusing to new users and it's noisy.

We keep the warnings for <PYENV_LOCAL> and <PEXRC> though, as those must be opted into.

[ci skip-rust]
[ci skip-build-wheels]