### PR TITLE
Require `pex_binary`'s ``platforms` field to be a list

### DIFF
--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -12,7 +12,6 @@ from pkg_resources import Requirement
 
 from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.subsystems.pytest import PyTest
-from pants.base.deprecated import warn_or_error
 from pants.core.goals.package import OutputPathField
 from pants.engine.addresses import Address, Addresses, UnparsedAddressInputs
 from pants.engine.fs import PathGlobs, Paths
@@ -33,7 +32,6 @@ from pants.engine.target import (
     Sources,
     SpecialCasedDependencies,
     StringField,
-    StringOrStringSequenceField,
     StringSequenceField,
     Target,
     WrappedTarget,
@@ -205,7 +203,7 @@ async def resolve_pex_entry_point(request: ResolvePexEntryPointRequest) -> Resol
     )
 
 
-class PexPlatformsField(StringOrStringSequenceField):
+class PexPlatformsField(StringSequenceField):
     """The platforms the built PEX should be compatible with.
 
     This defaults to the current platform, but can be overridden to different platforms. You can
@@ -220,21 +218,6 @@ class PexPlatformsField(StringOrStringSequenceField):
     """
 
     alias = "platforms"
-
-    @classmethod
-    def compute_value(
-        cls, raw_value: Optional[Iterable[str]], *, address: Address
-    ) -> Optional[Tuple[str, ...]]:
-        if isinstance(raw_value, str) and not address.is_file_target:
-            warn_or_error(
-                deprecated_entity_description=f"Using a bare string for the `{cls.alias}` field",
-                removal_version="2.2.0.dev1",
-                hint=(
-                    f"Using a bare string for the `{cls.alias}` field for {address}. Please "
-                    f"instead use a list of strings, i.e. use `[{raw_value}]`."
-                ),
-            )
-        return super().compute_value(raw_value, address=address)
 
 
 class PexInheritPathField(StringField):

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1155,29 +1155,6 @@ class StringSequenceField(SequenceField[str]):
         return super().compute_value(raw_value, address=address)
 
 
-class StringOrStringSequenceField(SequenceField[str]):
-    """The raw_value may either be a string or be an iterable of strings.
-
-    This is syntactic sugar that we use for certain fields to make BUILD files simpler when the user
-    has no need for more than one element.
-
-    Generally, this should not be used by any new Fields. This mechanism is a misfeature.
-    """
-
-    expected_element_type = str
-    expected_type_description = (
-        "either a single string or an iterable of strings (e.g. a list of strings)"
-    )
-
-    @classmethod
-    def compute_value(
-        cls, raw_value: Optional[Union[str, Iterable[str]]], *, address: Address
-    ) -> Optional[Tuple[str, ...]]:
-        if isinstance(raw_value, str):
-            return (raw_value,)
-        return super().compute_value(raw_value, address=address)
-
-
 class DictStringToStringField(Field):
     value: Optional[FrozenDict[str, str]]
     default: ClassVar[Optional[FrozenDict[str, str]]] = None

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -25,7 +25,6 @@ from pants.engine.target import (
     SequenceField,
     Sources,
     StringField,
-    StringOrStringSequenceField,
     StringSequenceField,
     Tags,
     Target,
@@ -637,17 +636,6 @@ def test_string_sequence_field() -> None:
     assert Example(None, address=addr).value is None
     with pytest.raises(InvalidFieldTypeException):
         Example("strings are technically iterable...", address=addr)
-    with pytest.raises(InvalidFieldTypeException):
-        Example(["hello", 0, "world"], address=addr)
-
-
-def test_string_or_string_sequence_field() -> None:
-    class Example(StringOrStringSequenceField):
-        alias = "example"
-
-    addr = Address("", target_name="example")
-    assert Example(["hello", "world"], address=addr).value == ("hello", "world")
-    assert Example("hello world", address=addr).value == ("hello world",)
     with pytest.raises(InvalidFieldTypeException):
         Example(["hello", 0, "world"], address=addr)
 

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -22,7 +22,6 @@ from pants.engine.target import (
     ScalarField,
     SequenceField,
     StringField,
-    StringOrStringSequenceField,
     StringSequenceField,
     Target,
 )
@@ -179,7 +178,6 @@ class TargetFieldHelpInfo:
                 ScalarField,
                 SequenceField,
                 StringField,
-                StringOrStringSequenceField,
                 StringSequenceField,
             },
         )


### PR DESCRIPTION
With that, we can remove `StringOrStringSequenceField`, which was a misfeature.

[ci skip-rust]
[ci skip-build-wheels]