### PR TITLE
Fix `rule_runner.py` not being included in `pantsbuild.pants.testutil`

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -115,7 +115,7 @@ function pkg_testutil_install_test() {
   shift
   local PIP_ARGS=("$@")
   pip install "${PIP_ARGS[@]}" "pantsbuild.pants.testutil==${version}" && \
-  python -c "import pants.testutil.option_util"
+  python -c "import pants.testutil.option_util, pants.testutil.rule_runner, pants.testutil.pants_integration_test"
 }
 
 #

--- a/src/python/pants/testutil/BUILD
+++ b/src/python/pants/testutil/BUILD
@@ -6,7 +6,7 @@ python_distribution(
   dependencies=[
     ':testutil',
     ':int-test-for-export',
-    ':rule-runner',
+    ':rule_runner',
   ],
   setup_py_commands=["bdist_wheel", "--python-tag", "py37.py38", "sdist"],
   provides=setup_py(

--- a/src/python/pants/testutil/BUILD
+++ b/src/python/pants/testutil/BUILD
@@ -6,6 +6,7 @@ python_distribution(
   dependencies=[
     ':testutil',
     ':int-test-for-export',
+    ':rule-runner',
   ],
   setup_py_commands=["bdist_wheel", "--python-tag", "py37.py38", "sdist"],
   provides=setup_py(


### PR DESCRIPTION
We were only including it by happenstance, thanks to a transitive dep. That transitive dep was removed in d3de097b30ebde6304300605b5f659b8005a0a8c.

This adds a regression test.

[ci skip-rust]