### PR TITLE
Add shorthand to use a file name for `pex_binary`'s `entry_point` and `python_awslambda`'s `handler` field

### DIFF
--- a/src/python/pants/backend/awslambda/python/rules_test.py
+++ b/src/python/pants/backend/awslambda/python/rules_test.py
@@ -71,7 +71,7 @@ def test_create_hello_world_lambda(rule_runner: RuleRunner) -> None:
             python_awslambda(
                 name='lambda',
                 dependencies=[':lib'],
-                handler='foo.bar.hello_world',
+                handler='foo.bar.hello_world:handler',
                 runtime='python3.7',
             )
             """

--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -1,6 +1,7 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import os.path
 import re
 from dataclasses import dataclass
 from typing import Match, Optional, Tuple, cast
@@ -10,6 +11,7 @@ from pants.backend.python.dependency_inference.rules import PythonInferSubsystem
 from pants.backend.python.target_types import InterpreterConstraintsField, PythonSources
 from pants.core.goals.package import OutputPathField
 from pants.engine.addresses import Address
+from pants.engine.fs import GlobMatchErrorBehavior, PathGlobs, Paths
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
@@ -23,6 +25,7 @@ from pants.engine.target import (
     WrappedTarget,
 )
 from pants.engine.unions import UnionRule
+from pants.source.source_root import SourceRoot, SourceRootRequest
 
 
 class PythonAwsLambdaSources(PythonSources):
@@ -30,11 +33,25 @@ class PythonAwsLambdaSources(PythonSources):
 
 
 class PythonAwsLambdaHandlerField(StringField, AsyncFieldMixin):
-    """AWS Lambda handler entrypoint (module.dotted.name:handler_func)."""
+    """Entry point to the AWS Lambda handler.
+
+    You can specify a full module like 'path.to.module:handler_func' or use a shorthand to specify a
+    file name, using the same syntax as the `sources` field, e.g. 'lambda.py:handler_func'.
+    """
 
     alias = "handler"
     required = True
     value: str
+
+    @classmethod
+    def compute_value(cls, raw_value: Optional[str], *, address: Address) -> str:
+        value = cast(str, super().compute_value(raw_value, address=address))
+        if ":" not in value:
+            raise InvalidFieldException(
+                f"The `{cls.alias}` field in target at {address} must end in the "
+                f"format `:my_handler_func`, but was {value}."
+            )
+        return value
 
 
 @dataclass(frozen=True)
@@ -47,11 +64,49 @@ class ResolvePythonAwsHandlerRequest:
     field: PythonAwsLambdaHandlerField
 
 
-@rule
+@rule(desc="Determining the handler for a `python_awslambda` target")
 async def resolve_python_aws_handler(
     request: ResolvePythonAwsHandlerRequest,
 ) -> ResolvedPythonAwsHandler:
-    return ResolvedPythonAwsHandler(request.field.value)
+    handler_val = request.field.value
+    field_alias = request.field.alias
+    address = request.field.address
+    path, _, func = handler_val.partition(":")
+
+    # If it's already a module, simply use that. Otherwise, convert the file name into a module
+    # path.
+    if not path.endswith(".py"):
+        return ResolvedPythonAwsHandler(handler_val)
+
+    # We don't actually need to use the engine here, but we do this to validate that the file
+    # exists and that it resolves to only one file.
+    full_glob = os.path.join(address.spec_path, path)
+    handler_paths = await Get(
+        Paths,
+        PathGlobs(
+            [full_glob],
+            glob_match_error_behavior=GlobMatchErrorBehavior.error,
+            description_of_origin=f"{address}'s `{field_alias}` field",
+        ),
+    )
+    # We will have already raised if the glob did not match, i.e. if there were no files. But
+    # we need to check if they used a file glob (`*` or `**`) that resolved to >1 file.
+    if len(handler_paths.files) != 1:
+        raise InvalidFieldException(
+            f"Multiple files matched for the `{field_alias}` {repr(handler_val)} for the target "
+            f"{address}, but only one file expected. Are you using a glob, rather than a file "
+            f"name?\n\nAll matching files: {list(handler_paths.files)}."
+        )
+    handler_path = handler_paths.files[0]
+    source_root = await Get(
+        SourceRoot,
+        SourceRootRequest,
+        SourceRootRequest.for_file(handler_path),
+    )
+    stripped_source_path = os.path.relpath(handler_path, source_root.path)
+    module_base, _ = os.path.splitext(stripped_source_path)
+    normalized_path = module_base.replace(os.path.sep, ".")
+    return ResolvedPythonAwsHandler(f"{normalized_path}:{func}")
 
 
 class PythonAwsLambdaDependencies(Dependencies):
@@ -98,8 +153,8 @@ class PythonAwsLambdaRuntime(StringField):
         value = cast(str, super().compute_value(raw_value, address=address))
         if not re.match(cls.PYTHON_RUNTIME_REGEX, value):
             raise InvalidFieldException(
-                f"runtime field in python_awslambda target at {address.spec} must "
-                f"be of the form pythonX.Y, but was {value}"
+                f"The `{cls.alias}` field in target at {address} must be of the form pythonX.Y, "
+                f"but was {value}."
             )
         return value
 

--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -78,8 +78,7 @@ async def resolve_python_aws_handler(
     if not path.endswith(".py"):
         return ResolvedPythonAwsHandler(handler_val)
 
-    # We don't actually need to use the engine here, but we do this to validate that the file
-    # exists and that it resolves to only one file.
+    # Use the engine to validate that the file exists and that it resolves to only one file.
     full_glob = os.path.join(address.spec_path, path)
     handler_paths = await Get(
         Paths,

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -118,10 +118,13 @@ class PexBinaryDependencies(Dependencies):
 class PexEntryPointField(StringField, AsyncFieldMixin):
     """The entry point for the binary, i.e. what gets run when executing `./my_binary.pex`.
 
-    If omitted, Pants will use the module name from the `sources` field, e.g. `project/app.py` will
-    become the entry point `project.app` .
+    You can specify a full module like 'path.to.module' and 'path.to.module:func', or use a
+    shorthand to specify a file name, using the same syntax as the `sources` field:
 
-    You can set `entry_point='<none>'` to leave off an entry point from the built PEX.
+        1) 'app.py', Pants will convert into the module `path.to.app`;
+        2) 'app.py:func', Pants will convert into `path.to.app:func`.
+
+    To leave off an entry point, set to '<none>'.
     """
 
     alias = "entry_point"

--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -21,7 +21,7 @@ from pants.backend.python.target_types import (
     ResolvePexEntryPointRequest,
 )
 from pants.engine.addresses import Address, Addresses, UnparsedAddressInputs
-from pants.engine.fs import PathGlobs, Paths
+from pants.engine.fs import GlobMatchErrorBehavior, PathGlobs, Paths
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import (
     InjectDependenciesRequest,
@@ -38,47 +38,96 @@ from pants.source.source_root import SourceRoot, SourceRootRequest
 # -----------------------------------------------------------------------------------------------
 
 
-@rule
+@rule(desc="Determining the entry point for a `pex_binary` target")
 async def resolve_pex_entry_point(request: ResolvePexEntryPointRequest) -> ResolvedPexEntryPoint:
-    entry_point_value = request.entry_point_field.value
-    if entry_point_value and not entry_point_value.startswith(":"):
-        if entry_point_value in ("<none>", "<None>"):
-            return ResolvedPexEntryPoint(None)
-        return ResolvedPexEntryPoint(entry_point_value)
-    binary_source_paths = await Get(
-        Paths, PathGlobs, request.sources.path_globs(FilesNotFoundBehavior.error)
-    )
-    if len(binary_source_paths.files) != 1:
-        instructions_url = "https://www.pantsbuild.org/docs/python-package-goal#creating-a-pex-file-from-a-pex_binary-target"
-        if not entry_point_value:
+    ep_val = request.entry_point_field.value
+    ep_alias = request.entry_point_field.alias
+    address = request.entry_point_field.address
+    # This code is tricky, as we support several different schemes:
+    #  1) `<none>` or `<None>` => set to `None`.
+    #  2) `path.to.module` => preserve exactly.
+    #  3) `path.to.module:func` => preserve exactly.
+    #  4) `app.py` => convert into `path.to.app`.
+    #  5) `app.py:func` => convert into `path.to.app:func`.
+    #  6) `:func` => if there's a sources field, convert to `path.to.sources:func` (soon to be deprecated).
+    #  7) no entry point field, but `sources` field => convert to `path.to.sources` (soon to be deprecated).
+
+    # Handle deprecated cases #6 and #7, which are the only cases where the `sources` field matters
+    # for calculating the entry point.
+    if not ep_val or ep_val.startswith(":"):
+        binary_source_paths = await Get(
+            Paths, PathGlobs, request.sources.path_globs(FilesNotFoundBehavior.error)
+        )
+        if len(binary_source_paths.files) != 1:
+            instructions_url = "https://www.pantsbuild.org/docs/python-package-goal#creating-a-pex-file-from-a-pex_binary-target"
+            if not ep_val:
+                raise InvalidFieldException(
+                    f"The `{ep_alias}` field is not set for the target {address}. Run "
+                    f"`./pants help pex_binary` for more information on how to set the field or "
+                    f"see {instructions_url}."
+                )
             raise InvalidFieldException(
-                "Both the `entry_point` and `sources` fields are not set for the target "
-                f"{request.sources.address}, so Pants cannot determine an entry point. Please "
-                "either explicitly set the `entry_point` field and/or the `sources` field to "
-                "exactly one file. You can set `entry_point='<none>' to leave off the entry point."
-                f"See {instructions_url}."
-            )
-        else:
-            raise InvalidFieldException(
-                f"The `entry_point` field for the target {request.sources.address} is set to "
-                f"the short-hand value {repr(entry_point_value)}, but the `sources` field is not "
-                "set. Pants requires the `sources` field to expand the entry point to the "
-                f"normalized form `path.to.module:{entry_point_value}`. Please either set the "
-                "`sources` field to exactly one file or use a full value for `entry_point`. See "
+                f"The `{ep_alias}` field for the target {address} is set to the short-hand value "
+                f"{repr(ep_val)}, but the `sources` field is not set. Pants requires the "
+                "`sources` field to expand the entry point to the normalized form "
+                f"`path.to.module:{ep_val}`. Please either set the `sources` field to exactly one "
+                f"file or set `{ep_alias}='my_file.py:{ep_val}'`. See "
                 f"{instructions_url}."
             )
-    entry_point_path = binary_source_paths.files[0]
-    source_root = await Get(
-        SourceRoot,
-        SourceRootRequest,
-        SourceRootRequest.for_file(entry_point_path),
-    )
-    stripped_source_path = os.path.relpath(entry_point_path, source_root.path)
-    module_base, _ = os.path.splitext(stripped_source_path)
-    normalized_path = module_base.replace(os.path.sep, ".")
-    return ResolvedPexEntryPoint(
-        f"{normalized_path}{entry_point_value}" if entry_point_value else normalized_path
-    )
+        entry_point_path = binary_source_paths.files[0]
+        source_root = await Get(
+            SourceRoot,
+            SourceRootRequest,
+            SourceRootRequest.for_file(entry_point_path),
+        )
+        stripped_source_path = os.path.relpath(entry_point_path, source_root.path)
+        module_base, _ = os.path.splitext(stripped_source_path)
+        normalized_path = module_base.replace(os.path.sep, ".")
+        return ResolvedPexEntryPoint(f"{normalized_path}{ep_val}" if ep_val else normalized_path)
+
+    # Case #1.
+    if ep_val in ("<none>", "<None>"):
+        return ResolvedPexEntryPoint(None)
+
+    # Split out the possible `:func` suffix so that we can determine if an explicit entry point was
+    # provided vs. a file name.
+    path, _, func = ep_val.partition(":")
+
+    # If it's already a module (cases #2 and #3), simply use that. Otherwise, convert the file name
+    # into a module path (cases #4 and #5).
+    if not path.endswith(".py"):
+        normalized_path = path
+    else:
+        # We don't actually need to use the engine here, but we do this to validate that the file
+        # exists and that it resolves to only one file.
+        full_glob = os.path.join(address.spec_path, path)
+        entry_point_paths = await Get(
+            Paths,
+            PathGlobs(
+                [full_glob],
+                glob_match_error_behavior=GlobMatchErrorBehavior.error,
+                description_of_origin=f"{address}'s `{request.entry_point_field.alias}` field",
+            ),
+        )
+        # We will have already raised if the glob did not match, i.e. if there were no files. But
+        # we need to check if they used a file glob (`*` or `**`) that resolved to >1 file.
+        if len(entry_point_paths.files) != 1:
+            raise InvalidFieldException(
+                f"Multiple files matched for the `{ep_alias}` {repr(ep_val)} for the target "
+                f"{address}, but only one file expected. Are you using a glob, rather than a file "
+                f"name?\n\nAll matching files: {list(entry_point_paths.files)}."
+            )
+        entry_point_path = entry_point_paths.files[0]
+        source_root = await Get(
+            SourceRoot,
+            SourceRootRequest,
+            SourceRootRequest.for_file(entry_point_path),
+        )
+        stripped_source_path = os.path.relpath(entry_point_path, source_root.path)
+        module_base, _ = os.path.splitext(stripped_source_path)
+        normalized_path = module_base.replace(os.path.sep, ".")
+
+    return ResolvedPexEntryPoint(f"{normalized_path}:{func}" if func else normalized_path)
 
 
 class InjectPexBinaryEntryPointDependency(InjectDependenciesRequest):

--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -43,6 +43,10 @@ async def resolve_pex_entry_point(request: ResolvePexEntryPointRequest) -> Resol
     ep_val = request.entry_point_field.value
     ep_alias = request.entry_point_field.alias
     address = request.entry_point_field.address
+
+    # TODO: factor up some of this code between python_awslambda and pex_binary once `sources` is
+    #  removed.
+
     # This code is tricky, as we support several different schemes:
     #  1) `<none>` or `<None>` => set to `None`.
     #  2) `path.to.module` => preserve exactly.
@@ -96,8 +100,7 @@ async def resolve_pex_entry_point(request: ResolvePexEntryPointRequest) -> Resol
     if not path.endswith(".py"):
         return ResolvedPexEntryPoint(ep_val)
 
-    # We don't actually need to use the engine here, but we do this to validate that the file
-    # exists and that it resolves to only one file.
+    # Use the engine to validate that the file exists and that it resolves to only one file.
     full_glob = os.path.join(address.spec_path, path)
     entry_point_paths = await Get(
         Paths,


### PR DESCRIPTION
For example:

```python
python_library()
pex_binary(name="app", entry_point="app.py")
```

Now, Pants will expand that into `path.to.app`. Thanks to https://github.com/pantsbuild/pants/pull/11245, Pants will also infer a dependency on the python_library. That is, there is no need* to have the `sources` field specified for a `pex_binary`.

*The last missing piece is to get file arguments working with this format.