### PR TITLE
Reduce interning overhead

### DIFF
--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -116,7 +116,11 @@ impl fmt::Display for Params {
 
 pub type Id = u64;
 
-// A pointer to an underlying PyTypeObject instance.
+///
+/// A pointer to an underlying PyTypeObject instance.
+///
+/// NB: This is a void pointer because the `cpython::ffi::PyTypeObject` is not public.
+///
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct TypeId(*mut std::ffi::c_void);
 


### PR DESCRIPTION
### Problem

Profiles of high-contention situations (including #11201) showed a non-trivial amount of time waiting on the `Interns` lock.

### Solution

In two commits, remove the need to separately intern python types, and simplify our GIL/`Interns` locking strategy by implementing it internally to the `Interns` struct.

### Result

Simpler code, and a slight (~5%) speedup for `./pants dependencies --transitive ::`. #11201 remains open: likely we will want to make structural changes to `TransitiveTargets` to avoid the redundant/contending computation. 
