### PR TITLE
Allow file arguments to work with the `app.py` shorthand for `pex_binary` and `python_awslambda`

### DIFF
--- a/build-support/bin/BUILD
+++ b/build-support/bin/BUILD
@@ -1,87 +1,21 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-files(
-  name = 'bash_scripts',
-  sources = ['*.sh'],
-)
+python_library()
+python_tests(name="tests", timeout=90)  # reversion_test.py times out occasionally.
 
-python_tests(
-  name="tests",
-  # reversion_test.py times out occasionally.
-  timeout=90,
-)
+files(name="bash_scripts", sources=["*.sh"])
+resources(name="docs_templates", sources=["docs_templates/*.mustache"])
 
-pex_binary(
-   name = 'bootstrap_and_deploy_ci_pants_pex',
-   sources = ['bootstrap_and_deploy_ci_pants_pex.py'],
-)
-
-pex_binary(
-  name="changelog",
-  sources=["changelog.py"],
-)
-
-pex_binary(
-  name = 'check_banned_imports',
-  sources = ['check_banned_imports.py'],
-)
-
-pex_binary(
-  name = 'check_inits',
-  sources = ['check_inits.py'],
-)
-
-pex_binary(
-  name = 'ci',
-  sources = ['ci.py'],
-)
-
-python_library(
-  name = 'common',
-  sources = ['common.py'],
-)
-
-pex_binary(
-  name = 'deploy_to_s3',
-  sources = ['deploy_to_s3.py'],
-)
-
-pex_binary(
-  name = 'generate_travis_yml',
-  sources = ['generate_travis_yml.py'],
-)
-
-pex_binary(
-  name = 'generate_docs',
-  sources = ['generate_docs.py'],
-  dependencies = [
-    ':docs_templates'
-  ],
-)
-
-resources(
-  name = 'docs_templates',
-  sources = ['docs_templates/*.mustache'],
-)
-
-pex_binary(
-  name = 'get_rbe_token',
-  sources = ['get_rbe_token.py'],
-)
-
-pex_binary(
-  name='reversion',
-  sources=["reversion.py"],
-)
-
-pex_binary(
-  name = 'shellcheck',
-  sources = ['shellcheck.py'],
-)
-
-# TODO: rename this to `release.py` once done porting Bash to Python.
-pex_binary(
-  name = "packages",
-  sources = ["packages.py"],
-)
+pex_binary(name="bootstrap_and_deploy_ci_pants_pex", entry_point="bootstrap_and_deploy_ci_pants_pex.py")
+pex_binary(name="changelog", entry_point="changelog.py")
+pex_binary(name="check_banned_imports", entry_point="check_banned_imports.py")
+pex_binary(name="check_inits", entry_point="check_inits.py")
+pex_binary(name="ci", entry_point="ci.py")
+pex_binary(name="deploy_to_s3", entry_point="deploy_to_s3.py")
+pex_binary(name="generate_travis_yml", entry_point="generate_travis_yml.py")
+pex_binary(name="generate_docs", entry_point="generate_docs.py", dependencies=[":docs_templates"])
+pex_binary(name="get_rbe_token", entry_point="get_rbe_token.py")
+pex_binary(name="reversion", entry_point="reversion.py",)
+pex_binary(name="shellcheck", entry_point="shellcheck.py")
+pex_binary(name="packages", entry_point="packages.py")  # TODO: rename to `release.py` after removing `release.sh`.

--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -40,8 +40,7 @@ class PythonAwsLambdaHandlerField(StringField, AsyncFieldMixin, SecondaryOwnerMi
     You can specify a full module like 'path.to.module:handler_func' or use a shorthand to specify a
     file name, using the same syntax as the `sources` field, e.g. 'lambda.py:handler_func'.
 
-    You must use the file name shorthand for file arguments and `--changed-since` to work with this
-    target.
+    You must use the file name shorthand for file arguments to work with this target.
     """
 
     alias = "handler"

--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -20,11 +20,13 @@ from pants.engine.target import (
     InjectDependenciesRequest,
     InjectedDependencies,
     InvalidFieldException,
+    SecondaryOwnerMixin,
     StringField,
     Target,
     WrappedTarget,
 )
 from pants.engine.unions import UnionRule
+from pants.source.filespec import Filespec
 from pants.source.source_root import SourceRoot, SourceRootRequest
 
 
@@ -32,11 +34,14 @@ class PythonAwsLambdaSources(PythonSources):
     expected_num_files = range(0, 2)
 
 
-class PythonAwsLambdaHandlerField(StringField, AsyncFieldMixin):
+class PythonAwsLambdaHandlerField(StringField, AsyncFieldMixin, SecondaryOwnerMixin):
     """Entry point to the AWS Lambda handler.
 
     You can specify a full module like 'path.to.module:handler_func' or use a shorthand to specify a
     file name, using the same syntax as the `sources` field, e.g. 'lambda.py:handler_func'.
+
+    You must use the file name shorthand for file arguments and `--changed-since` to work with this
+    target.
     """
 
     alias = "handler"
@@ -52,6 +57,14 @@ class PythonAwsLambdaHandlerField(StringField, AsyncFieldMixin):
                 f"format `:my_handler_func`, but was {value}."
             )
         return value
+
+    @property
+    def filespec(self) -> Filespec:
+        path, _, func = self.value.partition(":")
+        if not path.endswith(".py"):
+            return {"includes": []}
+        full_glob = os.path.join(self.address.spec_path, path)
+        return {"includes": [full_glob]}
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -127,8 +127,7 @@ class PexEntryPointField(StringField, AsyncFieldMixin, SecondaryOwnerMixin):
         1) 'app.py', Pants will convert into the module `path.to.app`;
         2) 'app.py:func', Pants will convert into `path.to.app:func`.
 
-    You must use the file name shorthand for file arguments and `--changed-since` to work with this
-    target.
+    You must use the file name shorthand for file arguments to work with this target.
 
     To leave off an entry point, set to '<none>'.
     """

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import collections.abc
+import os.path
 from dataclasses import dataclass
 from textwrap import dedent
 from typing import Iterable, Optional, Tuple, Union, cast
@@ -24,6 +25,7 @@ from pants.engine.target import (
     InvalidFieldTypeException,
     ProvidesField,
     ScalarField,
+    SecondaryOwnerMixin,
     Sources,
     SpecialCasedDependencies,
     StringField,
@@ -32,6 +34,7 @@ from pants.engine.target import (
 )
 from pants.option.subsystem import Subsystem
 from pants.python.python_setup import PythonSetup
+from pants.source.filespec import Filespec
 
 # -----------------------------------------------------------------------------------------------
 # Common fields
@@ -115,7 +118,7 @@ class PexBinaryDependencies(Dependencies):
     supports_transitive_excludes = True
 
 
-class PexEntryPointField(StringField, AsyncFieldMixin):
+class PexEntryPointField(StringField, AsyncFieldMixin, SecondaryOwnerMixin):
     """The entry point for the binary, i.e. what gets run when executing `./my_binary.pex`.
 
     You can specify a full module like 'path.to.module' and 'path.to.module:func', or use a
@@ -124,10 +127,23 @@ class PexEntryPointField(StringField, AsyncFieldMixin):
         1) 'app.py', Pants will convert into the module `path.to.app`;
         2) 'app.py:func', Pants will convert into `path.to.app:func`.
 
+    You must use the file name shorthand for file arguments and `--changed-since` to work with this
+    target.
+
     To leave off an entry point, set to '<none>'.
     """
 
     alias = "entry_point"
+
+    @property
+    def filespec(self) -> Filespec:
+        if not self.value:
+            return {"includes": []}
+        path, _, func = self.value.partition(":")
+        if not path.endswith(".py"):
+            return {"includes": []}
+        full_glob = os.path.join(self.address.spec_path, path)
+        return {"includes": [full_glob]}
 
 
 # See `target_types_rules.py` for the `ResolvePexEntryPointRequest -> ResolvedPexEntryPoint` rule.

--- a/src/python/pants/backend/python/target_types_test.py
+++ b/src/python/pants/backend/python/target_types_test.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from textwrap import dedent
-from typing import Optional
+from typing import List, Optional
 
 import pytest
 from pkg_resources import Requirement
@@ -74,6 +74,24 @@ def test_timeout_calculation() -> None:
     assert_timeout_calculated(field_value=None, expected=None)
     assert_timeout_calculated(field_value=None, global_default=20, global_max=10, expected=10)
     assert_timeout_calculated(field_value=10, timeouts_enabled=False, expected=None)
+
+
+@pytest.mark.parametrize(
+    ["entry_point", "expected"],
+    (
+        ("<none>", []),
+        ("path.to.module", []),
+        ("path.to.module:func", []),
+        ("lambda.py", ["project/dir/lambda.py"]),
+        ("lambda.py:func", ["project/dir/lambda.py"]),
+        # Soon to be deprecated.
+        (None, []),
+        (":func", []),
+    ),
+)
+def test_entry_point_filespec(entry_point: Optional[str], expected: List[str]) -> None:
+    field = PexEntryPointField(entry_point, address=Address("project/dir"))
+    assert field.filespec == {"includes": expected}
 
 
 def test_resolve_pex_binary_entry_point() -> None:

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1483,9 +1483,14 @@ class SecondaryOwnerMixin(ABC):
     Why use this? In a dependency inference world, multiple targets including the same file in the
     `sources` field causes issues due to ambiguity over which target to use. So, only one target
     should have "primary ownership" of the file. However, you may still want other targets to be
-    used when that file is included in file arguments. Secondary ownership means that both
+    used when that file is included in file arguments. For example, a `python_library` target
+    being the primary owner of the `.py` file, but a `pex_binary` still working with file
+    arguments for that file. Secondary ownership means that the target won't be used for things like
+    dependency inference and hydrating sources, but file arguments will still work.
 
-    There should be a primary owner
+    There should be a primary owner of the file(s), e.g. the `python_library` in the above example.
+    Typically, you will want to add a dependency injection rule to infer a dep on that primary
+    owner.
 
     All associated files must live in the BUILD target's directory or a subdirectory to work
     properly, like the `sources` field.

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -7,7 +7,7 @@ import collections.abc
 import dataclasses
 import itertools
 import os.path
-from abc import ABC, ABCMeta
+from abc import ABC, ABCMeta, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import PurePath
@@ -1474,6 +1474,33 @@ class SourcesPathsRequest(EngineAwareParameter):
 
     def debug_hint(self) -> str:
         return self.field.address.spec
+
+
+class SecondaryOwnerMixin(ABC):
+    """Add to a Field for the target to work with file arguments and `--changed-since`, without it
+    needing a `Sources` field.
+
+    Why use this? In a dependency inference world, multiple targets including the same file in the
+    `sources` field causes issues due to ambiguity over which target to use. So, only one target
+    should have "primary ownership" of the file. However, you may still want other targets to be
+    used when that file is included in file arguments. Secondary ownership means that both
+
+    There should be a primary owner
+
+    All associated files must live in the BUILD target's directory or a subdirectory to work
+    properly, like the `sources` field.
+    """
+
+    @property
+    @abstractmethod
+    def filespec(self) -> Filespec:
+        """A dictionary in the form {'globs': ['full/path/to/f.ext']} representing the field's
+        associated files.
+
+        Typically, users should use a file name/glob relative to the BUILD file, like the `sources`
+        field. Then, you can use `os.path.join(self.address.spec_path, self.value)` to relative to
+        the build root.
+        """
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/vcs/changed_integration_test.py
+++ b/src/python/pants/vcs/changed_integration_test.py
@@ -173,31 +173,41 @@ class ChangedIntegrationTest(PantsIntegrationTest, AbstractTestGenerator):
     hermetic = False
 
     TEST_MAPPING = {
-        # A `pex_binary` with `sources=['file.name']`.
+        # A `pex_binary` with `entry_point='file.name'` (secondary ownership), and a
+        # `python_library` with primary ownership of the file.
         "src/python/python_targets/test_binary.py": dict(
-            none=["src/python/python_targets/test_binary.py:test"],
+            none=[
+                "src/python/python_targets/test_binary.py:binary_file",
+                "src/python/python_targets:test_binary",
+            ],
             direct=[
-                "src/python/python_targets/test_binary.py:test",
-                "src/python/python_targets:test",
+                "src/python/python_targets/test_binary.py:binary_file",
+                "src/python/python_targets:test_binary",
+                "src/python/python_targets:binary_file",
             ],
             transitive=[
-                "src/python/python_targets/test_binary.py:test",
-                "src/python/python_targets:test",
+                "src/python/python_targets/test_binary.py:binary_file",
+                "src/python/python_targets:test_binary",
+                "src/python/python_targets:binary_file",
             ],
         ),
         # A `python_library` with `sources=['file.name']`.
         "src/python/python_targets/test_library.py": dict(
             none=["src/python/python_targets/test_library.py:test_library"],
             direct=[
-                "src/python/python_targets/test_binary.py:test",
+                "src/python/python_targets/test_binary.py:binary_file",
                 "src/python/python_targets/test_library.py:test_library",
-                "src/python/python_targets:test",
+                "src/python/python_targets:binary_file",
                 "src/python/python_targets:test_library",
+                # NB: 'src/python/python_targets:test_binary' does not show up here because it is
+                # not a direct dependee of `test_library.py:test_library`; instead, it depends on
+                # `test_binary.py:binary_file`, which is itself a direct dependee.
             ],
             transitive=[
-                "src/python/python_targets/test_binary.py:test",
+                "src/python/python_targets/test_binary.py:binary_file",
                 "src/python/python_targets/test_library.py:test_library",
-                "src/python/python_targets:test",
+                "src/python/python_targets:binary_file",
+                "src/python/python_targets:test_binary",
                 "src/python/python_targets:test_library",
                 "src/python/python_targets:test_library_direct_dependee",
                 "src/python/python_targets:test_library_transitive_dependee",

--- a/testprojects/src/python/python_targets/BUILD
+++ b/testprojects/src/python/python_targets/BUILD
@@ -1,10 +1,16 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+python_library(
+  name="binary_file",
+  sources=["test_binary.py"],
+  dependencies=[":test_library"],
+)
+
 pex_binary(
-  name='test',
-  sources=['test_binary.py'],
-  dependencies=[':test_library']
+  name="test_binary",
+  entry_point="test_binary.py",
+  dependencies=[':binary_file']
 )
 
 python_library(


### PR DESCRIPTION
This implements the proposal in https://docs.google.com/document/d/1mqE-DlotpiThYdTYD9HCxEDmKsMJCq1odxW_mI0nikI/edit to add Secondary Owners.

Now, file arguments work with `run` and `package` for this target, without causing issues with dependency inference and two targets having "primary ownership" of the same file.

```python
python_library()
pex_binary(name="app", entry_point="app.py")
```

[ci skip-rust]