### PR TITLE
[internal] Enable the Toolchain plugin in CI.

### DIFF
--- a/pants.travis-ci.toml
+++ b/pants.travis-ci.toml
@@ -8,6 +8,8 @@ dynamic_ui = false
 # now in order to smooth off rough edges locally.
 pantsd = false
 
+streaming_workunits_handlers = ["toolchain.pants.buildsense.reporter.Reporter"]
+
 [test]
 use_coverage = true
 


### PR DESCRIPTION
This PR enables the toolchain plugin when running under travis CI.
