### PR TITLE
Update the MyPy requirement sync comment.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -4,13 +4,11 @@ fasteners==0.15.0
 
 # The MyPy requirement should be maintained in lockstep with the requirement the Pants repo uses
 # for the mypy task since it configures custom MyPy plugins. That requirement can be found via:
-#
-#   ./pants \
-#       options \
-#         --output-format=json \
-#         --scope=mypy \
-#         --name=version \
-#     | jq -r '."mypy.version".value'
+#   ./pants help-all | \
+#   jq -r '
+#     .scope_to_help_info.mypy.advanced[] | select(.config_key == "version") |
+#     .value_history.ranked_values[-1].value
+#   '
 #
 mypy==0.782
 


### PR DESCRIPTION
This updates the suggested command to get the configured mypy version
for @rules.

[ci skip-rust]
[ci skip-build-wheels]