### PR TITLE
Ignore envrc file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__/
 *~
 *#
 .#*
+.envrc
 .DS_Store
 .build.properties
 .buildcache/


### PR DESCRIPTION
[direnv](https://direnv.net/) is a tool that allows setting environment variables based on the current folder.
This PR ignores the direnv config file, which in turn, will allow pants developers to have this file and use it to set enviroment variables (specifically PANTS_XXXXX ones) to configure pants running locally to match their setup.