### PR TITLE
[tests] Use a bandit version that works with older python versions.

### DIFF
--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -59,7 +59,8 @@ def run_bandit(
     skip: bool = False,
     additional_args: Optional[List[str]] = None,
 ) -> Sequence[LintResult]:
-    args = ["--backend-packages=pants.backend.python.lint.bandit"]
+    args = ["--backend-packages=pants.backend.python.lint.bandit", 
+            "--bandit-version==1.6.2"]
     if config:
         rule_runner.create_file(relpath=".bandit", contents=config)
         args.append("--bandit-config=.bandit")

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -59,8 +59,7 @@ def run_bandit(
     skip: bool = False,
     additional_args: Optional[List[str]] = None,
 ) -> Sequence[LintResult]:
-    args = ["--backend-packages=pants.backend.python.lint.bandit", 
-            "--bandit-version==1.6.2"]
+    args = ["--backend-packages=pants.backend.python.lint.bandit", "--bandit-version==1.6.2"]
     if config:
         rule_runner.create_file(relpath=".bandit", contents=config)
         args.append("--bandit-config=.bandit")

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -61,7 +61,7 @@ def run_bandit(
 ) -> Sequence[LintResult]:
     args = [
         "--backend-packages=pants.backend.python.lint.bandit",
-        "--bandit-version='bandit==1.6.2'",
+        "--bandit-version=bandit==1.6.2",
     ]
     if config:
         rule_runner.create_file(relpath=".bandit", contents=config)

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -59,7 +59,10 @@ def run_bandit(
     skip: bool = False,
     additional_args: Optional[List[str]] = None,
 ) -> Sequence[LintResult]:
-    args = ["--backend-packages=pants.backend.python.lint.bandit", "--bandit-version==1.6.2"]
+    args = [
+        "--backend-packages=pants.backend.python.lint.bandit",
+        "--bandit-version='bandit==1.6.2'",
+    ]
     if config:
         rule_runner.create_file(relpath=".bandit", contents=config)
         args.append("--bandit-config=.bandit")


### PR DESCRIPTION
### Problem

Build is busted due to a new version of bandit that dropped support for older python versions.
https://travis-ci.com/github/pantsbuild/pants/jobs/455792761#L661
<img width="1202" alt="Screen Shot 2020-12-07 at 9 48 08 PM" src="https://user-images.githubusercontent.com/1268088/101445240-fe442380-38d5-11eb-968c-71c5ca23f022.png">


### Solution

Pin bandit version used in this integration tests.