### PR TITLE
[internal] Make python coverage interpreter constrains match the python-setup  interpreter constrains.

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -129,5 +129,8 @@ pytest_plugins.add = [
 ]
 timeout_default = 60
 
+[coverage-py]
+interpreter_constraints = [">=3.7,<3.9"]
+
 [sourcefile-validation]
 config = "@build-support/regexes/config.yaml"

--- a/pants.travis-ci.toml
+++ b/pants.travis-ci.toml
@@ -12,4 +12,4 @@ pantsd = false
 use_coverage = true
 
 [coverage-py]
-report = ["raw"]
+report = ["raw", "xml"]


### PR DESCRIPTION
### Problem

Due to #11137, `coverage.py` runs under an older version of the python interpreter so it fails to parse some python 3.7 specific syntax (`from __future__ import annotations`).

### Solution

Set the `coverage-py` `interpreter_constraints` options to the same value we have under `python-setup`
Also enable xml reports for coverage so those kind of errors get caught in the future.