### PR TITLE
Increase Pants' python recursion limit by default, and allow it to be overridden. (cherrypick of #11271)

### DIFF
--- a/src/python/pants/bin/pants_loader.py
+++ b/src/python/pants/bin/pants_loader.py
@@ -4,6 +4,7 @@
 import importlib
 import locale
 import os
+import sys
 import warnings
 from textwrap import dedent
 
@@ -13,6 +14,8 @@ class PantsLoader:
 
     ENTRYPOINT_ENV_VAR = "PANTS_ENTRYPOINT"
     DEFAULT_ENTRYPOINT = "pants.bin.pants_exe:main"
+
+    RECURSION_LIMIT_ENV_VAR = "PANTS_RECURSION_LIMIT"
 
     ENCODING_IGNORE_ENV_VAR = "PANTS_IGNORE_UNRECOGNIZED_ENCODING"
 
@@ -67,6 +70,10 @@ class PantsLoader:
                 )
             )
 
+    @classmethod
+    def set_recursion_limit(cls):
+        sys.setrecursionlimit(int(os.environ.get(cls.RECURSION_LIMIT_ENV_VAR, "10000")))
+
     @staticmethod
     def determine_entrypoint(env_var, default):
         return os.environ.pop(env_var, default)
@@ -86,6 +93,7 @@ class PantsLoader:
     def run(cls):
         cls.setup_warnings()
         cls.ensure_locale()
+        cls.set_recursion_limit()
         entrypoint = cls.determine_entrypoint(cls.ENTRYPOINT_ENV_VAR, cls.DEFAULT_ENTRYPOINT)
         cls.load_and_execute(entrypoint)
 


### PR DESCRIPTION
### Problem

Pants uses a default Python recursion limit that makes some build graph shapes fail to cycle detect: see #11201.

### Solution

Increase the default recursion limit, and allow it to be overridden via an environment variable.

Although increasing the recursion limit is not always the best approach to solving a problem, having the capability to do so is frequently useful as a workaround. We also know that the default value is too low for otherwise reasonable graph shapes.

### Result

Fixes #11201.

[ci skip-rust]
[ci skip-build-wheels]