### PR TITLE
[tests] Use a bandit version that works with older python versions. (cherrypick of #11268)

### DIFF
--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -55,7 +55,10 @@ def run_bandit(
     skip: bool = False,
     additional_args: Optional[List[str]] = None,
 ) -> Sequence[LintResult]:
-    args = ["--backend-packages=pants.backend.python.lint.bandit"]
+    args = [
+        "--backend-packages=pants.backend.python.lint.bandit",
+        "--bandit-version=bandit==1.6.2",
+    ]
     if config:
         rule_runner.create_file(relpath=".bandit", contents=config)
         args.append("--bandit-config=.bandit")


### PR DESCRIPTION
### Problem

Build is busted due to a new version of bandit that dropped support for older python versions.

### Solution

Pin bandit version used in this integration tests.

[ci skip-rust]
[ci skip-build-wheels]