### PR TITLE
Fix one graph test, and disable another that has been flaky for a while.

### DIFF
--- a/src/rust/engine/graph/src/tests.rs
+++ b/src/rust/engine/graph/src/tests.rs
@@ -132,6 +132,7 @@ async fn invalidate_with_changed_dependencies() {
   );
 }
 
+#[ignore] // flaky: https://github.com/pantsbuild/pants/issues/10839
 #[tokio::test]
 async fn invalidate_randomly() {
   let graph = Arc::new(Graph::new());
@@ -330,7 +331,7 @@ async fn uncacheable_node_only_runs_once() {
   let graph2 = graph.clone();
   let (send, recv) = mpsc::channel::<()>();
   let _join = thread::spawn(move || {
-    recv.recv_timeout(Duration::from_millis(100)).unwrap();
+    recv.recv_timeout(Duration::from_secs(10)).unwrap();
     thread::sleep(Duration::from_millis(50));
     graph2.invalidate_from_roots(|&TNode(n, _)| n == 0);
   });


### PR DESCRIPTION
### Problem

`invalidate_randomly` has been flaky for a while (see #10839), and `uncacheable_node_only_runs_once` flaked once the other day.

### Solution

Disable `invalidate_randomly`, and increase timeouts to reduce the chances of flakes in `uncacheable_node_only_runs_once`.

[ci skip-build-wheels]