### PR TITLE
[internal] Add toolchain plugin (disabled).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -595,6 +595,11 @@ jobs:
     - mkdir -p dist/deploy/pex/
     - mv dist/pants*.pex dist/deploy/pex/
     stage: Deploy Pants Pex Unstable
+notifications:
+  webhooks:
+    on_start: always
+    urls:
+    - https://webhooks.toolchain.com/travis/repo/pantsbuild/pants/
 stages:
 - if: type != cron
   name: Bootstrap Pants

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -766,6 +766,12 @@ def main() -> None:
             # Conditions are documented here: https://docs.travis-ci.com/user/conditions-v1
             "conditions": "v1",
             "env": {"global": GLOBAL_ENV_VARS},
+            "notifications": {
+                "webhooks": {
+                    "on_start": "always",
+                    "urls": ["https://webhooks.toolchain.com/travis/repo/pantsbuild/pants/"],
+                }
+            },
             "stages": Stage.all_entries(),
             "deploy": DEPLOY_SETTINGS,
             "jobs": {

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -143,6 +143,7 @@ function execute_packaged_pants_with_internal_backends() {
     --no-verify-config \
     --no-pantsd \
     --pythonpath="['pants-plugins']" \
+    --streaming-workunits-handlers="[]" \
     --backend-packages="[\
         'pants.backend.awslambda.python',\
         'pants.backend.python',\

--- a/pants.toml
+++ b/pants.toml
@@ -14,7 +14,16 @@ backend_packages.add = [
   "pants.backend.python.typecheck.mypy",
   "pants.backend.python.mixed_interpreter_constraints",
   "internal_plugins.releases",
+  "toolchain.pants.auth",
+  "toolchain.pants.buildsense",
+  "toolchain.pants.common",
 ]
+
+plugins = [
+  "toolchain.pants.buildsense.plugin==0.1.0",
+]
+
+streaming_workunits_report_interval = 1
 
 build_file_prelude_globs = ["pants-plugins/python_integration_tests_macro.py"]
 
@@ -134,3 +143,9 @@ interpreter_constraints = [">=3.7,<3.9"]
 
 [sourcefile-validation]
 config = "@build-support/regexes/config.yaml"
+
+[run-tracker]
+stats_option_scopes_to_record = ["*"]
+
+[toolchain-setup]
+repo = "pants"

--- a/pants.travis-ci.toml
+++ b/pants.travis-ci.toml
@@ -11,5 +11,13 @@ pantsd = false
 [test]
 use_coverage = true
 
+[pytest]
+junit_xml_dir = "dist/test-results/"
+
 [coverage-py]
 report = ["raw", "xml"]
+
+[auth]
+from_env_var = "TOOLCHAIN_AUTH_TOKEN"
+customer = "pantsbuild"
+ci_env_variables = ["TRAVIS", "TRAVIS_JOB_ID", "TRAVIS_BUILD_ID", "TRAVIS_PULL_REQUEST"]


### PR DESCRIPTION
This PR adds the toolchain plugin that collects pants metrics into the toolchain SaaS platform.
The plugin just loads, it is not enabled/running.
This change will allow further testing before enabling it in CI.
It will always be optional for local/desktop pants runs

This PR also configures travis to send webhooks to the Toolchain platform, those webhooks are used to enrich pants data by associating travis jobs data with pants run data in the Toolchain SaaS platform.