### PR TITLE
Fix UUIDRequest and --test-force

### DIFF
--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -145,6 +145,7 @@ def run_pytest(
     execution_slot_var: Optional[str] = None,
     extra_env_vars: Optional[str] = None,
     env: Optional[Mapping[str, str]] = None,
+    force: bool = False,
 ) -> TestResult:
     args = [
         "--backend-packages=pants.backend.python",
@@ -163,6 +164,8 @@ def run_pytest(
         args.append("--test-use-coverage")
     if execution_slot_var:
         args.append(f"--pytest-execution-slot-var={execution_slot_var}")
+    if force:
+        args.append("--test-force")
     rule_runner.set_options(args, env=env)
 
     inputs = [PythonTestFieldSet.create(test_target)]
@@ -179,6 +182,16 @@ def test_single_passing_test(rule_runner: RuleRunner) -> None:
     result = run_pytest(rule_runner, tgt)
     assert result.exit_code == 0
     assert f"{PACKAGE}/test_good.py ." in result.stdout
+
+
+def test_force(rule_runner: RuleRunner) -> None:
+    tgt = create_test_target(rule_runner, [GOOD_SOURCE])
+    result_one = run_pytest(rule_runner, tgt, force=True)
+    assert result_one.exit_code == 0
+    result_two = run_pytest(rule_runner, tgt, force=True)
+    assert result_two.exit_code == 0
+    # Should not receive a memoized result.
+    assert result_one is not result_two
 
 
 def test_single_failing_test(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/engine/internals/uuid.py
+++ b/src/python/pants/engine/internals/uuid.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional, cast
 
-from pants.engine.rules import collect_rules, rule
+from pants.engine.rules import _uncacheable_rule, collect_rules
 from pants.util.meta import frozen_after_init
 
 
@@ -36,7 +36,7 @@ class UUIDRequest:
         return cls(cls._to_scope_name(scope))
 
 
-@rule
+@_uncacheable_rule
 async def generate_uuid(_: UUIDRequest) -> uuid.UUID:
     """A rule to generate a UUID.
 


### PR DESCRIPTION
### Problem

Comments in the `UUIDRequest` body indicate that the rule is marked `@_uncacheable_rule`, which it needs to be in order for the rule to re-run and re-consider the content of the request in every `Session`. But the rule was not actually marked, and so `--test-force` and other facilities that depended on `UncacheableProcess` were not re-running in every `Session`.

### Solution

Mark `generate_uuid` as an `@_uncacheable_rule`.

In the short term, we should likely merge `Process.cache_failures` and `UncacheableProcess` into:
```
pub enum ProcessCacheScope {
  // Cached in all locations, regardless of success or failure.
  Always,
  // Cached in all locations, but only if the process returns successfully.
  Successful,
  // Never cached anywhere: will run once per Session.
  Never,
}
```
... but this fix is independent for easier cherry-picking.

### Result

`--test-force` is fixed.

Unfortunately, this also increases our noop re-run time by 1.2 seconds on my machine, because interpreter and binary discovery were already wrapped as `UncacheableProcess`, but weren't re-running.