### PR TITLE
[Internal] Include TRAVIS_BUILD_WEB_URL in the environment variables sent to Toolchain.

### DIFF
--- a/pants.travis-ci.toml
+++ b/pants.travis-ci.toml
@@ -20,4 +20,4 @@ report = ["raw", "xml"]
 [auth]
 from_env_var = "TOOLCHAIN_AUTH_TOKEN"
 customer = "pantsbuild"
-ci_env_variables = ["TRAVIS", "TRAVIS_JOB_ID", "TRAVIS_BUILD_ID", "TRAVIS_PULL_REQUEST"]
+ci_env_variables = ["TRAVIS", "TRAVIS_JOB_ID", "TRAVIS_BUILD_ID", "TRAVIS_PULL_REQUEST", "TRAVIS_BUILD_WEB_URL"]


### PR DESCRIPTION
This will help track down issues in travis jobs since it is not always possible to track travis jobs just by using job/build IDs.
(the url will indicate the GH account and repo the job build is running for, which might be the case when a build is running on a fork of the pants repo)