### PR TITLE
Clean the graph speculatively, and cancel nodes when interest is lost. (cherrypick of #11308)

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -63,6 +63,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_value"
+version = "0.0.1"
+dependencies = [
+ "futures 0.3.5",
+ "tokio",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,6 +1075,7 @@ name = "graph"
 version = "0.0.1"
 dependencies = [
  "async-trait",
+ "async_value",
  "env_logger",
  "fnv",
  "futures 0.3.5",
@@ -3141,9 +3150,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.22"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
+checksum = "099837d3464c16a808060bb3f02263b412f6fafcb5d01c533d309985fbeebe48"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
@@ -3185,9 +3194,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
+checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
  "proc-macro2 1.0.12",
  "quote 1.0.4",

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -20,6 +20,7 @@ codegen-units = 1
 members = [
   ".",
   "async_semaphore",
+  "async_value",
   "boxfuture",
   "concrete_time",
   "fs",
@@ -56,6 +57,7 @@ members = [
 default-members = [
   ".",
   "async_semaphore",
+  "async_value",
   "boxfuture",
   "concrete_time",
   "fs",

--- a/src/rust/engine/async_value/Cargo.toml
+++ b/src/rust/engine/async_value/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+version = "0.0.1"
+edition = "2018"
+name = "async_value"
+authors = [ "Pants Build <pantsbuild@gmail.com>" ]
+publish = false
+
+[dependencies]
+futures = "0.3"
+tokio = { version = "0.2.22", features = ["sync", "macros"] }

--- a/src/rust/engine/async_value/src/lib.rs
+++ b/src/rust/engine/async_value/src/lib.rs
@@ -1,0 +1,125 @@
+// Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+#![deny(warnings)]
+// Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
+#![deny(
+  clippy::all,
+  clippy::default_trait_access,
+  clippy::expl_impl_clone_on_copy,
+  clippy::if_not_else,
+  clippy::needless_continue,
+  clippy::unseparated_literal_suffix,
+  // TODO: Falsely triggers for async/await:
+  //   see https://github.com/rust-lang/rust-clippy/issues/5360
+  // clippy::used_underscore_binding
+)]
+// It is often more clear to show that nothing is being moved.
+#![allow(clippy::match_ref_pats)]
+// Subjective style.
+#![allow(
+  clippy::len_without_is_empty,
+  clippy::redundant_field_names,
+  clippy::too_many_arguments
+)]
+// Default isn't as big a deal as people seem to think it is.
+#![allow(clippy::new_without_default, clippy::new_ret_no_self)]
+// Arc<Mutex> can be more clear than needing to grok Orderings:
+#![allow(clippy::mutex_atomic)]
+
+use std::sync::{Arc, Weak};
+
+use tokio::sync::{oneshot, watch};
+
+///
+/// A cancellable value computed by one sender, and broadcast to multiple receivers.
+///
+/// Supports canceling the work associated with the pool either:
+///   1. explicitly if the pool is dropped
+///   2. implicitly if all receivers go away
+///
+/// NB: This is currently a `tokio::sync::watch` (which supports the second case), plus a
+/// separate cancellation signal via `tokio::sync::oneshot` (to support the first case).
+///
+#[derive(Debug)]
+pub struct AsyncValue<T: Clone + Send + Sync + 'static> {
+  item_receiver: Weak<watch::Receiver<Option<T>>>,
+  // NB: Stored only for drop.
+  #[allow(dead_code)]
+  abort_sender: oneshot::Sender<()>,
+}
+
+impl<T: Clone + Send + Sync + 'static> AsyncValue<T> {
+  pub fn new() -> (AsyncValue<T>, AsyncValueSender<T>, AsyncValueReceiver<T>) {
+    let (abort_sender, abort_receiver) = oneshot::channel();
+    let (item_sender, item_receiver) = watch::channel(None);
+    let item_receiver = Arc::new(item_receiver);
+    (
+      AsyncValue {
+        item_receiver: Arc::downgrade(&item_receiver),
+        abort_sender,
+      },
+      AsyncValueSender {
+        item_sender,
+        abort_receiver,
+      },
+      AsyncValueReceiver { item_receiver },
+    )
+  }
+
+  ///
+  /// Returns an AsyncValueReceiver for this value if the associated work has not already been
+  /// canceled.
+  ///
+  pub fn receiver(&self) -> Option<AsyncValueReceiver<T>> {
+    self
+      .item_receiver
+      .upgrade()
+      .map(|item_receiver| AsyncValueReceiver { item_receiver })
+  }
+}
+
+pub struct AsyncValueReceiver<T: Clone + Send + Sync + 'static> {
+  item_receiver: Arc<watch::Receiver<Option<T>>>,
+}
+
+impl<T: Clone + Send + Sync + 'static> AsyncValueReceiver<T> {
+  ///
+  /// Returns a Future that will wait for the result of this value, or None if the work was
+  /// canceled.
+  ///
+  pub async fn recv(&self) -> Option<T> {
+    let mut item_receiver = (*self.item_receiver).clone();
+    loop {
+      match item_receiver.recv().await {
+        Some(None) => {
+          // Observing the initial value of the channel.
+          continue;
+        }
+        Some(t) => break t,
+        None => break None,
+      }
+    }
+  }
+}
+
+pub struct AsyncValueSender<T: Clone + Send + Sync + 'static> {
+  item_sender: watch::Sender<Option<T>>,
+  abort_receiver: oneshot::Receiver<()>,
+}
+
+impl<T: Clone + Send + Sync + 'static> AsyncValueSender<T> {
+  pub fn send(self, item: T) {
+    let _ = self.item_sender.broadcast(Some(item));
+  }
+
+  pub async fn closed(&mut self) {
+    tokio::select! {
+      _ = &mut self.abort_receiver => {}
+      _ = self.item_sender.closed() => {}
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/rust/engine/async_value/src/tests.rs
+++ b/src/rust/engine/async_value/src/tests.rs
@@ -1,0 +1,51 @@
+use crate::AsyncValue;
+
+use std::time::Duration;
+
+use tokio;
+use tokio::time::delay_for;
+
+#[tokio::test]
+async fn send() {
+  let (_value, sender, receiver) = AsyncValue::new();
+  let _send_task = tokio::spawn(async move { sender.send(42) });
+  assert_eq!(Some(42), receiver.recv().await);
+}
+
+#[tokio::test]
+async fn cancel_explicit() {
+  let (value, mut sender, receiver) = AsyncValue::<()>::new();
+
+  // A task that will never do any meaningful work, and just wait to be canceled.
+  let _send_task = tokio::spawn(async move { sender.closed().await });
+
+  // Ensure that a value is not received.
+  tokio::select! {
+    _ = delay_for(Duration::from_secs(1)) => {},
+    _ = receiver.recv() => { panic!("Should have continued to wait.") }
+  }
+
+  // Then drop the AsyncValue and confirm that the background task returns.
+  std::mem::drop(value);
+  assert_eq!(None, receiver.recv().await);
+}
+
+#[tokio::test]
+async fn cancel_implicit() {
+  let (value, mut sender, receiver) = AsyncValue::<()>::new();
+
+  // A task that will never do any meaningful work, and just wait to be canceled.
+  let send_task = tokio::spawn(async move { sender.closed().await });
+
+  // Ensure that a value is not received.
+  tokio::select! {
+    _ = delay_for(Duration::from_secs(1)) => {},
+    _ = receiver.recv() => { panic!("Should have continued to wait.") }
+  }
+
+  // Then drop the only receiver and confirm that the background task returns, and that new
+  // receivers cannot be created.
+  std::mem::drop(receiver);
+  send_task.await.unwrap();
+  assert!(value.receiver().is_none());
+}

--- a/src/rust/engine/graph/Cargo.toml
+++ b/src/rust/engine/graph/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [dependencies]
 async-trait = "0.1"
+async_value = { path = "../async_value" }
 fnv = "1.0.5"
 futures = "0.3"
 log = "0.4"

--- a/src/rust/engine/graph/src/entry.rs
+++ b/src/rust/engine/graph/src/entry.rs
@@ -4,8 +4,9 @@ use std::sync::Arc;
 use crate::node::{EntryId, Node, NodeContext, NodeError};
 use crate::test_trace_log;
 
+use async_value::{AsyncValue, AsyncValueReceiver, AsyncValueSender};
 use futures::channel::oneshot;
-use futures::future::{self, AbortHandle, Abortable, Aborted, BoxFuture, FutureExt};
+use futures::future::{self, BoxFuture, FutureExt};
 use parking_lot::Mutex;
 
 ///
@@ -151,7 +152,7 @@ impl<N: Node> AsRef<N::Item> for EntryResult<N> {
   }
 }
 
-type Waiter<N> = oneshot::Sender<Result<(<N as Node>::Item, Generation), <N as Node>::Error>>;
+pub type NodeResult<N> = Result<(<N as Node>::Item, Generation), <N as Node>::Error>;
 
 #[derive(Debug)]
 pub enum EntryState<N: Node> {
@@ -170,12 +171,14 @@ pub enum EntryState<N: Node> {
   // A node that is running. A running node that has been marked dirty re-runs rather than
   // completing.
   //
+  // Holds an AsyncValue, which is canceled if either 1) all AsyncValueReceivers go away, 2) the
+  // AsyncValue itself is dropped.
+  //
   // The `previous_result` value for a Running node is not a valid value. See NotStarted.
   Running {
     run_token: RunToken,
-    abort_handle: AbortHandle,
+    pending_value: AsyncValue<NodeResult<N>>,
     generation: Generation,
-    waiters: Vec<Waiter<N>>,
     previous_result: Option<EntryResult<N>>,
   },
   // A node that has completed, and then possibly been marked dirty. Because marking a node
@@ -300,39 +303,33 @@ impl<N: Node> Entry<N> {
     generation: Generation,
     previous_dep_generations: Option<Vec<Generation>>,
     previous_result: Option<EntryResult<N>>,
-  ) -> EntryState<N> {
+  ) -> (EntryState<N>, AsyncValueReceiver<NodeResult<N>>) {
     // Increment the RunToken to uniquely identify this work.
     let run_token = run_token.next();
     let context = context_factory.clone_for(entry_id);
+    let context2 = context.clone();
     let node = node.clone();
-    let (abort_handle, abort_registration) = AbortHandle::new_pair();
+    let (value, mut sender, receiver) = AsyncValue::new();
 
-    context_factory.spawn(async move {
+    let run_or_clean = async move {
       // If we have previous result generations, compare them to all current dependency
       // generations (which, if they are dirty, will cause recursive cleaning). If they
       // match, we can consider the previous result value to be clean for reuse.
       let was_clean = if let Some(previous_dep_generations) = previous_dep_generations {
-        match context.graph().dep_generations(entry_id, &context).await {
-          Ok(ref dep_generations) if dep_generations == &previous_dep_generations => {
-            // Dependencies have not changed: Node is clean.
-            context.stats().cleaning_succeeded += 1;
-            true
-          }
-          // `x` is unused if `test_trace_log`ging is disabled.
-          #[allow(unused_variables)]
-          x => {
-            // If dependency generations mismatched or failed to fetch, clear its
-            // dependencies and indicate that it should re-run.
-            context.graph().clear_deps(entry_id, run_token);
-            context.stats().cleaning_failed += 1;
-            test_trace_log!(
-              "Failed to clean {}: {:?} vs {:?}",
-              node,
-              x,
-              previous_dep_generations
-            );
-            false
-          }
+        if context
+          .graph()
+          .dependencies_changed(entry_id, previous_dep_generations, &context)
+          .await
+        {
+          // If dependency generations mismatched or failed to fetch, clear the node's dependencies
+          // and indicate that it should re-run.
+          context.graph().clear_deps(entry_id, run_token);
+          context.stats().cleaning_failed += 1;
+          false
+        } else {
+          // Dependencies have not changed: Node is clean.
+          context.stats().cleaning_succeeded += 1;
+          true
         }
       } else {
         false
@@ -342,31 +339,41 @@ impl<N: Node> Entry<N> {
       if was_clean {
         // No dependencies have changed: we can complete the Node without changing its
         // previous_result or generation.
-        context
-          .graph()
-          .complete(&context, entry_id, run_token, None);
+        None
       } else {
-        // The Node needs to (re-)run! Wrap the potentially long running computation in an
-        // Abortable.
-        let res = match Abortable::new(node.run(context.clone()), abort_registration).await {
-          Ok(r) => r,
-          Err(Aborted) => Err(N::Error::invalidated()),
-        };
-
+        // The Node needs to (re-)run!
+        let res = node.run(context.clone()).await;
         context.stats().ran += 1;
-        context
-          .graph()
-          .complete(&context, entry_id, run_token, Some(res));
+        Some(res)
+      }
+    };
+
+    context_factory.spawn(async move {
+      tokio::select! {
+        _ = sender.closed() => {
+          // We've been explicitly canceled: exit.
+          context2
+            .graph()
+            .cancel(entry_id, run_token);
+        }
+        maybe_res = run_or_clean => {
+          // The node completed.
+          context2
+            .graph()
+            .complete(&context2, entry_id, run_token, sender, maybe_res);
+        }
       }
     });
 
-    EntryState::Running {
-      run_token,
-      abort_handle,
-      waiters: Vec::new(),
-      generation,
-      previous_result,
-    }
+    (
+      EntryState::Running {
+        run_token,
+        pending_value: value,
+        generation,
+        previous_result,
+      },
+      receiver,
+    )
   }
 
   ///
@@ -377,98 +384,135 @@ impl<N: Node> Entry<N> {
   /// need to consume the state (which avoids cloning some of the values held there), so we take it
   /// by value.
   ///
-  #[allow(clippy::type_complexity)] // This return type is not particularly complex.
   pub(crate) fn get_node_result(
     &mut self,
     context: &N::Context,
     entry_id: EntryId,
-  ) -> BoxFuture<Result<(N::Item, Generation), N::Error>> {
-    {
-      let mut state = self.state.lock();
+  ) -> BoxFuture<NodeResult<N>> {
+    let mut state = self.state.lock();
 
-      // First check whether the Node is already complete, or is currently running: in both of these
-      // cases we return early without swapping the state of the Node.
-      match *state {
-        EntryState::Running {
-          ref mut waiters, ..
-        } => {
-          let (send, recv) = oneshot::channel();
-          waiters.push(send);
-          return async move { recv.await.map_err(|_| N::Error::invalidated())? }.boxed();
+    // First check whether the Node is already complete, or is currently running: in both of these
+    // cases we return early without swapping the state of the Node.
+    match *state {
+      EntryState::Running {
+        ref pending_value, ..
+      } => {
+        if let Some(receiver) = pending_value.receiver() {
+          return async move { receiver.recv().await.ok_or_else(N::Error::invalidated)? }.boxed();
         }
-        EntryState::Completed {
-          ref result,
-          generation,
-          ..
-        } if result.is_clean(context) => {
-          return future::ready(Ok((result.as_ref().clone(), generation))).boxed();
-        }
-        _ => (),
-      };
+        // Else: this node was just canceled: fall through to restart it.
+      }
+      EntryState::Completed {
+        ref result,
+        generation,
+        ..
+      } if result.is_clean(context) => {
+        return future::ready(Ok((result.as_ref().clone(), generation))).boxed();
+      }
+      _ => (),
+    };
 
-      // Otherwise, we'll need to swap the state of the Node, so take it by value.
-      let next_state = match mem::replace(&mut *state, EntryState::initial()) {
-        EntryState::NotStarted {
-          run_token,
-          generation,
-          previous_result,
-        } => Self::spawn_node_execution(
+    // Otherwise, we'll need to swap the state of the Node, so take it by value.
+    let (next_state, receiver) = match mem::replace(&mut *state, EntryState::initial()) {
+      EntryState::NotStarted {
+        run_token,
+        generation,
+        previous_result,
+      }
+      | EntryState::Running {
+        run_token,
+        generation,
+        previous_result,
+        ..
+      } => Self::spawn_node_execution(
+        context,
+        &self.node,
+        entry_id,
+        run_token,
+        generation,
+        None,
+        previous_result,
+      ),
+      EntryState::Completed {
+        run_token,
+        generation,
+        result,
+        dep_generations,
+        ..
+      } => {
+        test_trace_log!(
+          "Re-starting node {:?}. It was: previous_result={:?}",
+          self.node,
+          result,
+        );
+        assert!(
+          !result.is_clean(context),
+          "A clean Node should not reach this point: {:?}",
+          result
+        );
+        // The Node has already completed but needs to re-run. If the Node is dirty, we are the
+        // first caller to request it since it was marked dirty. We attempt to clean it (which
+        // will cause it to re-run if the dep_generations mismatch).
+        //
+        // On the other hand, if the Node is uncacheable, we store the previous result as
+        // Uncacheable, which allows its value to be used only within the current Run.
+        Self::spawn_node_execution(
           context,
           &self.node,
           entry_id,
           run_token,
           generation,
-          None,
-          previous_result,
-        ),
-        EntryState::Completed {
-          run_token,
-          generation,
-          result,
-          dep_generations,
-          ..
-        } => {
-          test_trace_log!(
-            "Re-starting node {:?}. It was: previous_result={:?}",
-            self.node,
-            result,
-          );
-          assert!(
-            !result.is_clean(context),
-            "A clean Node should not reach this point: {:?}",
-            result
-          );
-          // The Node has already completed but needs to re-run. If the Node is dirty, we are the
-          // first caller to request it since it was marked dirty. We attempt to clean it (which
-          // will cause it to re-run if the dep_generations mismatch).
-          //
-          // On the other hand, if the Node is uncacheable, we store the previous result as
-          // Uncacheable, which allows its value to be used only within the current Run.
-          Self::spawn_node_execution(
-            context,
-            &self.node,
-            entry_id,
-            run_token,
-            generation,
-            // TODO: This check shouldn't matter... it's whether we recompute the generations that
-            // matters.
-            if self.cacheable_with_output(Some(result.as_ref())) {
-              Some(dep_generations)
-            } else {
-              None
-            },
-            Some(result),
-          )
-        }
-        EntryState::Running { .. } => {
-          panic!("A Running Node should not reach this point.");
-        }
-      };
+          // TODO: This check shouldn't matter... it's whether we recompute the generations that
+          // matters.
+          if self.cacheable_with_output(Some(result.as_ref())) {
+            Some(dep_generations)
+          } else {
+            None
+          },
+          Some(result),
+        )
+      }
+    };
 
-      // Swap in the new state and then recurse.
-      *state = next_state;
+    // Swap in the new state, and return the receiver.
+    *state = next_state;
+
+    async move { receiver.recv().await.ok_or_else(N::Error::invalidated)? }.boxed()
+  }
+
+  ///
+  /// Called from the Executor when a Node is cancelled.
+  ///
+  /// See also: `Self::complete`.
+  ///
+  pub(crate) fn cancel(&mut self, result_run_token: RunToken) {
+    let mut state = self.state.lock();
+
+    // We care about exactly one case: a Running state with the same run_token. All other states
+    // represent various (legal) race conditions. See `RunToken`'s docs for more information.
+    match *state {
+      EntryState::Running { run_token, .. } if result_run_token == run_token => {}
+      _ => {
+        return;
+      }
     }
-    self.get_node_result(context, entry_id)
+
+    *state = match mem::replace(&mut *state, EntryState::initial()) {
+      EntryState::Running {
+        run_token,
+        generation,
+        previous_result,
+        ..
+      } => {
+        test_trace_log!("Canceling {:?} of {}.", run_token, self.node);
+        EntryState::NotStarted {
+          run_token: run_token.next(),
+          generation,
+          previous_result,
+        }
+      }
+      s => s,
+    };
   }
 
   ///
@@ -484,11 +528,14 @@ impl<N: Node> Entry<N> {
   /// complete _while_ a batch of nodes are being marked as dirty, and this exclusive access ensures
   /// that can't happen.
   ///
+  /// See also: `Self::cancel`.
+  ///
   pub(crate) fn complete(
     &mut self,
     context: &N::Context,
     result_run_token: RunToken,
     dep_generations: Vec<Generation>,
+    sender: AsyncValueSender<NodeResult<N>>,
     result: Option<Result<N::Item, N::Error>>,
     has_uncacheable_deps: bool,
     _graph: &mut super::InnerGraph<N>,
@@ -513,7 +560,6 @@ impl<N: Node> Entry<N> {
     *state = match mem::replace(&mut *state, EntryState::initial()) {
       EntryState::Running {
         run_token,
-        waiters,
         mut generation,
         mut previous_result,
         ..
@@ -523,7 +569,7 @@ impl<N: Node> Entry<N> {
             if let Some(previous_result) = previous_result.as_mut() {
               previous_result.dirty();
             }
-            self.notify_waiters(waiters, Err(e));
+            sender.send(Err(e));
             EntryState::NotStarted {
               run_token: run_token.next(),
               generation,
@@ -538,7 +584,7 @@ impl<N: Node> Entry<N> {
               // Node was re-executed (ie not cleaned) and had a different result value.
               generation = generation.next()
             };
-            self.notify_waiters(waiters, Ok((next_result.as_ref().clone(), generation)));
+            sender.send(Ok((next_result.as_ref().clone(), generation)));
             EntryState::Completed {
               result: next_result,
               pollers: Vec::new(),
@@ -557,7 +603,7 @@ impl<N: Node> Entry<N> {
               self.cacheable_with_output(Some(result.as_ref())),
               has_uncacheable_deps,
             );
-            self.notify_waiters(waiters, Ok((result.as_ref().clone(), generation)));
+            sender.send(Ok((result.as_ref().clone(), generation)));
             EntryState::Completed {
               result,
               pollers: Vec::new(),
@@ -570,34 +616,6 @@ impl<N: Node> Entry<N> {
       }
       s => s,
     };
-  }
-
-  ///
-  /// Notify the given waiters (ignoring any that have gone away).
-  ///
-  /// A waiter will go away whenever they drop the `Future` `Receiver` of the value, perhaps due
-  /// to failure of another Future in a `join` or `join_all`, or due to a timeout at the root of
-  /// a request.
-  ///
-  fn notify_waiters(
-    &self,
-    mut waiters: Vec<Waiter<N>>,
-    next_result: Result<(N::Item, Generation), N::Error>,
-  ) {
-    test_trace_log!(
-      "Notifying {} waiters of node {:?}: {:?}",
-      waiters.len(),
-      self.node,
-      next_result,
-    );
-    // We pop off one waiter to avoid cloning for the last waiter (which might be the only waiter).
-    let last_waiter = waiters.pop();
-    for waiter in waiters {
-      let _ = waiter.send(next_result.clone());
-    }
-    if let Some(waiter) = last_waiter {
-      let _ = waiter.send(next_result);
-    }
   }
 
   ///
@@ -651,12 +669,12 @@ impl<N: Node> Entry<N> {
         } => (run_token, generation, previous_result),
         EntryState::Running {
           run_token,
-          abort_handle,
+          pending_value,
           generation,
           previous_result,
           ..
         } => {
-          abort_handle.abort();
+          std::mem::drop(pending_value);
           (run_token, generation, previous_result)
         }
         EntryState::Completed {
@@ -718,14 +736,14 @@ impl<N: Node> Entry<N> {
     *state = match mem::replace(&mut *state, EntryState::initial()) {
       EntryState::Running {
         run_token,
-        abort_handle,
+        pending_value,
         generation,
         previous_result,
         ..
       } => {
         // Dirtying a Running node immediately cancels it.
         test_trace_log!("Node {:?} was dirtied while running.", self.node);
-        abort_handle.abort();
+        std::mem::drop(pending_value);
         EntryState::NotStarted {
           run_token,
           generation,
@@ -740,6 +758,13 @@ impl<N: Node> Entry<N> {
     match *self.state.lock() {
       EntryState::NotStarted { .. } => false,
       EntryState::Completed { .. } | EntryState::Running { .. } => true,
+    }
+  }
+
+  pub fn is_running(&self) -> bool {
+    match *self.state.lock() {
+      EntryState::Running { .. } => true,
+      EntryState::Completed { .. } | EntryState::NotStarted { .. } => false,
     }
   }
 

--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -25,7 +25,7 @@ pub type EntryId = stable_graph::NodeIndex<u32>;
 pub trait Node: Clone + Debug + Display + Eq + Hash + Send + 'static {
   type Context: NodeContext<Node = Self>;
 
-  type Item: Clone + Debug + Eq + Send + 'static;
+  type Item: Clone + Debug + Eq + Send + Sync + 'static;
   type Error: NodeError;
 
   async fn run(self, context: Self::Context) -> Result<Self::Item, Self::Error>;
@@ -43,7 +43,7 @@ pub trait Node: Clone + Debug + Display + Eq + Hash + Send + 'static {
   }
 }
 
-pub trait NodeError: Clone + Debug + Eq + Send {
+pub trait NodeError: Clone + Debug + Eq + Send + Sync {
   ///
   /// Creates an instance that represents that a Node was invalidated out of the
   /// Graph (generally while running).

--- a/src/rust/engine/graph/src/tests.rs
+++ b/src/rust/engine/graph/src/tests.rs
@@ -8,6 +8,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
+use futures::future;
 use parking_lot::Mutex;
 use rand::{self, Rng};
 use tokio::time::{delay_for, timeout, Elapsed};
@@ -115,7 +116,7 @@ async fn invalidate_with_changed_dependencies() {
 
   // Request with a new context that truncates execution at the middle Node.
   let context = TContext::new(graph.clone())
-    .with_dependencies(vec![(TNode::new(1), None)].into_iter().collect());
+    .with_dependencies(vec![(TNode::new(1), vec![])].into_iter().collect());
   assert_eq!(
     graph.create(TNode::new(2), &context).await,
     Ok(vec![T(1, 0), T(2, 0)])
@@ -340,17 +341,11 @@ async fn uncacheable_node_only_runs_once() {
     graph.create(TNode::new(2), &context).await,
     Ok(vec![T(0, 0), T(1, 0), T(2, 0)])
   );
-  // TNode(0) and TNode(2) are cleared and dirtied (respectively) before completing, and
-  // so run twice each. But the uncacheable node runs once.
+  // TNode(0) is cleared before completing, and so will run twice. But the uncacheable node and its
+  // dependee each run once.
   assert_eq!(
     context.runs(),
-    vec![
-      TNode::new(2),
-      TNode::new(1),
-      TNode::new(0),
-      TNode::new(2),
-      TNode::new(0),
-    ]
+    vec![TNode::new(2), TNode::new(1), TNode::new(0), TNode::new(0),]
   );
 }
 
@@ -482,7 +477,7 @@ async fn retries() {
 }
 
 #[tokio::test]
-async fn canceled_immediately() {
+async fn canceled_on_invalidation() {
   let _logger = env_logger::try_init();
   let invalidation_delay = Duration::from_millis(10);
   let graph = Arc::new(Graph::new_with_invalidation_delay(invalidation_delay));
@@ -531,13 +526,91 @@ async fn canceled_immediately() {
 }
 
 #[tokio::test]
+async fn canceled_on_loss_of_interest() {
+  let _logger = env_logger::try_init();
+  let graph = Arc::new(Graph::new());
+
+  let delay_for_middle = Duration::from_millis(2000);
+  let start_time = Instant::now();
+  let context = {
+    let mut delays = HashMap::new();
+    delays.insert(TNode::new(1), delay_for_middle);
+    TContext::new(graph.clone()).with_delays(delays)
+  };
+
+  // Start a run, but cancel it well before the delayed middle node can complete.
+  tokio::select! {
+    _ = delay_for(Duration::from_millis(100)) => {},
+    _ = graph.create(TNode::new(2), &context) => { panic!("Should have timed out.") }
+  }
+
+  // Then start again, and allow to run to completion.
+  assert_eq!(
+    graph.create(TNode::new(2), &context).await,
+    Ok(vec![T(0, 0), T(1, 0), T(2, 0)])
+  );
+
+  // We should have waited more than the delay, but less than the time it would have taken to
+  // run twice.
+  assert!(Instant::now() >= start_time + delay_for_middle);
+  assert!(Instant::now() < start_time + (delay_for_middle * 2));
+
+  // And the top nodes should have seen one abort each.
+  assert_eq!(vec![TNode::new(2), TNode::new(1),], context.aborts(),);
+}
+
+#[tokio::test]
+async fn clean_speculatively() {
+  let _logger = env_logger::try_init();
+  let graph = Arc::new(Graph::new());
+
+  // Create a graph with a node with two dependencies, one of which takes much longer
+  // to run.
+  let mut dependencies = vec![
+    (TNode::new(3), vec![TNode::new(2), TNode::new(1)]),
+    (TNode::new(2), vec![TNode::new(0)]),
+    (TNode::new(1), vec![TNode::new(0)]),
+  ]
+  .into_iter()
+  .collect::<HashMap<_, _>>();
+  let delay = Duration::from_millis(2000);
+  let context = {
+    let mut delays = HashMap::new();
+    delays.insert(TNode::new(2), delay);
+    TContext::new(graph.clone())
+      .with_delays(delays)
+      .with_dependencies(dependencies.clone())
+  };
+
+  // Run it to completion, and then clear a node at the bottom of the graph to force cleaning of
+  // both dependencies.
+  assert_eq!(
+    graph.create(TNode::new(3), &context).await,
+    Ok(vec![T(0, 0), T(2, 0), T(3, 0)])
+  );
+  graph.invalidate_from_roots(|n| n == &TNode::new(0));
+
+  // Then request again with the slow node removed from the dependencies, and confirm that it is
+  // cleaned much sooner than it would been if it had waited for the slow node.
+  dependencies.insert(TNode::new(3), vec![TNode::new(1)]);
+  let context = context.with_salt(1).with_dependencies(dependencies);
+  let start_time = Instant::now();
+  assert_eq!(
+    graph.create(TNode::new(3), &context).await,
+    Ok(vec![T(0, 1), T(1, 1), T(3, 1)])
+  );
+  assert!(Instant::now() < start_time + delay);
+  assert_eq!(context.stats().cleaning_failed, 3);
+}
+
+#[tokio::test]
 async fn cyclic_failure() {
   // Confirms that an attempt to create a cycle fails.
   let graph = Arc::new(Graph::new());
   let top = TNode::new(2);
   let context = TContext::new(graph.clone()).with_dependencies(
     // Request creation of a cycle by sending the bottom most node to the top.
-    vec![(TNode::new(0), Some(top))].into_iter().collect(),
+    vec![(TNode::new(0), vec![top])].into_iter().collect(),
   );
 
   assert_eq!(
@@ -565,9 +638,12 @@ async fn cyclic_dirtying() {
   graph.invalidate_from_roots(|n| n == &initial_bot);
   let context_up = context_down.with_salt(1).with_dependencies(
     // Reverse the path from bottom to top.
-    vec![(TNode::new(1), None), (TNode::new(0), Some(TNode::new(1)))]
-      .into_iter()
-      .collect(),
+    vec![
+      (TNode::new(1), vec![]),
+      (TNode::new(0), vec![TNode::new(1)]),
+    ]
+    .into_iter()
+    .collect(),
   );
 
   let res = graph.create(initial_bot, &context_up).await;
@@ -718,12 +794,21 @@ impl Node for TNode {
     context.ran(self.clone());
     let token = T(self.0, context.salt());
     context.maybe_delay(&self).await;
-    let res = if let Some(dep) = context.dependency_of(&self) {
-      let mut v = context.get(dep).await?;
-      v.push(token);
-      Ok(v)
-    } else {
-      Ok(vec![token])
+    let res = match context.dependencies_of(&self) {
+      deps if !deps.is_empty() => {
+        // Request all dependencies, but include only the first in our output value.
+        let mut values = future::try_join_all(
+          deps
+            .into_iter()
+            .map(|dep| context.get(dep))
+            .collect::<Vec<_>>(),
+        )
+        .await?;
+        let mut v = values.swap_remove(0);
+        v.push(token);
+        Ok(v)
+      }
+      _ => Ok(vec![token]),
     };
     abort_guard.did_not_abort();
     res
@@ -797,11 +882,10 @@ struct TContext {
   // outside world". A test that wants to "change the outside world" and observe its effect on the
   // graph should change the salt to do so.
   salt: usize,
-  // A mapping from source to optional destination that drives what values each TNode depends on.
+  // A mapping from source to destinations that drives what values each TNode depends on.
   // If there is no entry in this map for a node, then TNode::run will default to requesting
-  // the next smallest node. Finally, if a None entry is present, a node will have no
-  // dependencies.
-  edges: Arc<HashMap<TNode, Option<TNode>>>,
+  // the next smallest node.
+  edges: Arc<HashMap<TNode, Vec<TNode>>>,
   delays: Arc<HashMap<TNode, Duration>>,
   uncacheable: Arc<HashSet<TNode>>,
   graph: Arc<Graph<TNode>>,
@@ -866,7 +950,7 @@ impl TContext {
     }
   }
 
-  fn with_dependencies(mut self, edges: HashMap<TNode, Option<TNode>>) -> TContext {
+  fn with_dependencies(mut self, edges: HashMap<TNode, Vec<TNode>>) -> TContext {
     self.edges = Arc::new(edges);
     self
   }
@@ -927,18 +1011,17 @@ impl TContext {
   ///
   /// If the given TNode should declare a dependency on another TNode, returns that dependency.
   ///
-  fn dependency_of(&self, node: &TNode) -> Option<TNode> {
+  fn dependencies_of(&self, node: &TNode) -> Vec<TNode> {
     match self.edges.get(node) {
-      Some(Some(ref dep)) => Some(dep.clone()),
-      Some(None) => None,
+      Some(deps) => deps.clone(),
       None if node.0 > 0 => {
         let new_node_id = node.0 - 1;
-        Some(TNode(
+        vec![TNode(
           new_node_id,
           !self.uncacheable.contains(&TNode::new(new_node_id)),
-        ))
+        )]
       }
-      None => None,
+      None => vec![],
     }
   }
 


### PR DESCRIPTION
### Problem

#11290 describes a case where attempting to clean a (relatively) long-running uncacheable node (a test that has failed) causes us to run the test twice. This is caused by graph cleaning: the attempt to clean the graph requests all of the node's previous dependencies in parallel, but waits until they have all returned before determining whether the node could be cleaned or not. Concretely, this meant that although the sources of the test had changed, we would re-run the (uncacheable) failed test again to completion before noticing the changed sources, and running it a second time with the changed sources.

### Solution

As mentioned on #11290, [other monadic build systems](https://neilmitchell.blogspot.com/2020/11/data-types-for-build-system-dependencies.html) have taken the approach of sequencing requests for dependencies during cleaning, rather than requesting them in parallel. In this case, that would mean sequentially requesting the sources of the node before running the test. But because Pants uses future based concurrency aggressively, it is more challenging for us to preserve the structure of an `@rule` `MultiGet` all the way down into a single request to the `Graph`: without custom tuple-based combinators, we would lose type safety when we needed to request a `Vec<Node<_>>` rather than `future::join_all`ing a series of type-safe requests.

Instead, this change takes a different strategy, and [speculates](https://en.wikipedia.org/wiki/Speculative_execution) while cleaning. All dependencies are still requested in parallel, but we now fail fast as soon as we detect a mismatch, and all speculative branches that were incorrect are canceled. When compared to sequentially requesting dependencies, this should almost always be faster (*as long as the total number of processes being cleaned is smaller than the constraints we have on concurrent processes: `--process-execution-local-parallelism`). The case where more tests are being speculated on than there are concurrency slots is also interesting, but less important than per-test latency -- followup work can improve our prioritization of processes to improve that case (see #11303).

In order to cancel work in the `Graph` based on interest, we add an `AsyncValue` type that implements a model where if all "waiters" for the computed value go away, the work is canceled. This interest-based cancellation also represents 90% of the work for #11252.

### Result

Fixes #11290, and should improve the latency of all types of incremental rebuilds.

[ci skip-build-wheels]