### PR TITLE
Upgrade to Pex 2.1.24. (#11312)

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -21,7 +21,7 @@ mypy==0.780
 Markdown==2.1.1
 packaging==20.3
 pathspec==0.8.0
-pex==2.1.14
+pex==2.1.24
 psutil==5.7.0
 Pygments==2.6.1
 pystache==0.5.4

--- a/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
@@ -88,7 +88,7 @@ class MypyTask(LintTaskMixin, ResolveRequirementsTaskBase):
         interpreters = self._interpreter_cache.setup(
             filters=[self._MYPY_COMPATIBLE_INTERPRETER_CONSTRAINT]
         )
-        return min(interpreters) if interpreters else None
+        return min(interpreters, key=lambda i: i.version) if interpreters else None
 
     @staticmethod
     def is_non_synthetic_python_target(target):

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -372,7 +372,9 @@ class ExportTask(ResolveRequirementsTaskBase, CoursierMixin):
             #
             # For now, make our arbitrary historical choice of a default interpreter explicit and use the
             # lowest version.
-            default_interpreter = min(python_interpreter_targets_mapping.keys())
+            default_interpreter = min(
+                python_interpreter_targets_mapping.keys(), key=lambda i: i.version
+            )
 
             interpreters_info = {}
             for interpreter, targets in python_interpreter_targets_mapping.items():

--- a/src/python/pants/backend/python/interpreter_cache.py
+++ b/src/python/pants/backend/python/interpreter_cache.py
@@ -117,7 +117,7 @@ class PythonInterpreterCache(Subsystem):
                 )
             )
         # Return the lowest compatible interpreter.
-        return min(allowed_interpreters)
+        return min(allowed_interpreters, key=lambda i: i.version)
 
     def _interpreter_from_relpath(self, path, filters=()):
         path = os.path.join(self._cache_dir, path)

--- a/src/python/pants/backend/python/rules/BUILD
+++ b/src/python/pants/backend/python/rules/BUILD
@@ -87,5 +87,5 @@ python_tests(
     'src/python/pants/testutil:int-test',
   ],
   tags = {'integration', 'partially_type_checked'},
-  timeout = 480,
+  timeout = 600,
 )

--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -25,9 +25,9 @@ class PexBin(ExternalTool):
 
     options_scope = "download-pex-bin"
     name = "pex"
-    default_version = "v2.1.14"
+    default_version = "v2.1.24"
     default_known_versions = [
-        f"v2.1.14|{plat}|12937da9ad5ad2c60564aa35cb4b3992ba3cc5ef7efedd44159332873da6fe46|2637138"
+        f"v2.1.24|{plat}|561da5a7c76a8a88567a306fa60dfcb5c6924bb71c18b892080d5c2b3eea7133|2936466"
         for plat in ["darwin", "linux "]
     ]
 

--- a/src/python/pants/backend/python/targets/python_binary.py
+++ b/src/python/pants/backend/python/targets/python_binary.py
@@ -4,6 +4,7 @@
 import os
 from typing import cast
 
+from pex.inherit_path import InheritPath
 from pex.pex_info import PexInfo
 
 from pants.backend.python.targets.python_target import PythonTarget
@@ -170,7 +171,7 @@ class PythonBinary(PythonTarget):
         info = PexInfo.default()
         info.zip_safe = self.payload.zip_safe
         info.always_write_cache = self.payload.always_write_cache
-        info.inherit_path = self.payload.inherit_path
+        info.inherit_path = InheritPath.for_value(self.payload.inherit_path)
         info.entry_point = self.entry_point
         info.ignore_errors = self.payload.ignore_errors
         info.emit_warnings = self.payload.emit_warnings

--- a/src/python/pants/backend/python/tasks/python_execution_task_base.py
+++ b/src/python/pants/backend/python/tasks/python_execution_task_base.py
@@ -90,8 +90,7 @@ class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
             with temporary_file() as fp:
                 fp.write(self.content)
                 fp.close()
-                add = builder.add_source if self.path.endswith(".py") else builder.add_resource
-                add(fp.name, self.path)
+                builder.add_source(fp.name, self.path)
 
     @classmethod
     def subsystem_dependencies(cls):

--- a/src/python/pants/backend/python/tasks/python_tool_prep_base.py
+++ b/src/python/pants/backend/python/tasks/python_tool_prep_base.py
@@ -153,7 +153,7 @@ class PythonToolPrepBase(Task):
                     tool_subsystem.options_scope, tool_subsystem.get_interpreter_constraints()
                 )
             )
-        interpreter = min(interpreters)
+        interpreter = min(interpreters, key=lambda i: i.version)
 
         pex_path = self._generate_fingerprinted_pex_path(tool_subsystem, interpreter)
         if not os.path.exists(pex_path):

--- a/src/python/pants/backend/python/tasks/unpack_wheels.py
+++ b/src/python/pants/backend/python/tasks/unpack_wheels.py
@@ -70,7 +70,7 @@ class UnpackWheels(UnpackRemoteSourcesBase):
             unpacked_whls.compatibility
         )
         allowable_interpreters = PythonInterpreterCache.global_instance().setup(filters=constraints)
-        return min(allowable_interpreters)
+        return min(allowable_interpreters, key=lambda i: i.version)
 
     class WheelUnpackingError(TaskError):
         pass

--- a/src/python/pants/python/pex_build_util.py
+++ b/src/python/pants/python/pex_build_util.py
@@ -362,10 +362,7 @@ class PexBuilderWrapper:
             dest_path = get_chroot_path(relpath)
 
             self._all_added_sources_resources.append(Path(dest_path))
-            if has_resources(tgt):
-                self._builder.add_resource(filename=source_path, env_filename=dest_path)
-            else:
-                self._builder.add_source(filename=source_path, env_filename=dest_path)
+            self._builder.add_source(filename=source_path, env_filename=dest_path)
 
         return dump_source
 
@@ -490,14 +487,14 @@ class PexBuilderWrapper:
         with temporary_file(permissions=0o644) as ipex_info_file:
             ipex_info_file.write(json.dumps(ipex_info).encode())
             ipex_info_file.flush()
-            self._builder.add_resource(filename=ipex_info_file.name, env_filename="IPEX-INFO")
+            self._builder.add_source(filename=ipex_info_file.name, env_filename="IPEX-INFO")
 
         # BOOTSTRAP-PEX-INFO: The original PEX-INFO, which should be the PEX-INFO in the hydrated .pex
         #                     file that is generated when the .ipex is first executed.
         with temporary_file(permissions=0o644) as bootstrap_pex_info_file:
             bootstrap_pex_info_file.write(orig_pex_info.dump().encode())
             bootstrap_pex_info_file.flush()
-            self._builder.add_resource(
+            self._builder.add_source(
                 filename=bootstrap_pex_info_file.name, env_filename="BOOTSTRAP-PEX-INFO"
             )
 

--- a/src/python/pants/python/pex_build_util.py
+++ b/src/python/pants/python/pex_build_util.py
@@ -426,9 +426,10 @@ class PexBuilderWrapper:
         )
 
         # Remove all the original top-level requirements in favor of the transitive == requirements.
-        self._builder.info = ipex_launcher.modify_pex_info(self._builder.info, requirements=[])
-        transitive_reqs = [dist.as_requirement() for dist in self._distributions.values()]
-        self.add_direct_requirements(transitive_reqs)
+        transitive_reqs = [str(dist.as_requirement()) for dist in self._distributions.values()]
+        self._builder.info = ipex_launcher.modify_pex_info(
+            self._builder.info, requirements=transitive_reqs
+        )
 
         orig_info = self._builder.info.copy()
 
@@ -560,10 +561,6 @@ class PexBuilderWrapper:
         for constraint_tuple in constraint_tuples:
             for constraint in constraint_tuple:
                 self.add_interpreter_constraint(constraint)
-
-    def add_direct_requirements(self, reqs):
-        for req in reqs:
-            self._builder.add_requirement(str(req))
 
     def add_distribution(self, dist):
         self._builder.add_distribution(dist)

--- a/tests/python/pants_test/backend/python/tasks/test_select_interpreter.py
+++ b/tests/python/pants_test/backend/python/tasks/test_select_interpreter.py
@@ -37,6 +37,8 @@ class SelectInterpreterTest(TaskTestBase):
             binary = os.path.join(interpreter_dir, "python")
             values = dict(
                 binary=binary,
+                prefix="",
+                base_prefix="",
                 python_tag=python_tag,
                 abi_tag=abi_tag,
                 platform_tag="",

--- a/tests/python/pants_test/backend/python/test_interpreter_cache.py
+++ b/tests/python/pants_test/backend/python/test_interpreter_cache.py
@@ -99,7 +99,10 @@ class TestInterpreterCache(TestBase):
             self.assertGreater(len(interpreters), 0)
 
             cache = self._setup_cache_at(path)
-            self.assertEqual(sorted(interpreters), sorted(list(cache._setup_cached())))
+            self.assertEqual(
+                sorted(interpreters, key=lambda i: i.version),
+                sorted(list(cache._setup_cached()), key=lambda i: i.version),
+            )
 
     def test_setup_cached_cold(self):
         with self._setup_cache() as (cache, _):


### PR DESCRIPTION
This pulls in support for macOS BigSur, the latest manylinux PEP (1)
and Python 3.10. For the inital commit we do not expose the new
pip-2020-resolver option and instead keep the status quo using the
legacy resolver.

1) https://www.python.org/dev/peps/pep-0600/

Fixes #11305

[ci skip-jvm-tests]