### PR TITLE
Prepare 2.1.1rc2 (again).

### DIFF
--- a/src/python/pants/notes/2.1.x.rst
+++ b/src/python/pants/notes/2.1.x.rst
@@ -5,11 +5,23 @@ This document describes releases leading up to the ``2.1.x`` ``stable`` series.
 
 See https://www.pantsbuild.org/v2.1/docs/release-notes-2-1 for an overview of the changes in this release.
 
-2.1.1rc2 (12/09/2020)
+2.1.1rc2 (12/16/2020)
 ---------------------
 
 Bugfixes
 ~~~~~~~~
+
+* Fix filtering of log messages generated in native code. (cherrypick of #11313) (#11316)
+  `PR #11316 <https://github.com/pantsbuild/pants/pull/11316>`_
+
+* Upgrade to Pex 2.1.24. (cherrypick of #11312) (#11315)
+  `PR #11315 <https://github.com/pantsbuild/pants/pull/11315>`_
+
+* Clean the graph speculatively, and cancel nodes when interest is lost (cherrypick of #11308) (#11311)
+  `PR #11311 <https://github.com/pantsbuild/pants/pull/11311>`_
+
+* Implement native Process cache scoping to fix --test-force (cherrypick of #11291) (#11298)
+  `PR #11298 <https://github.com/pantsbuild/pants/pull/11298>`_
 
 * Increase Pants' python recursion limit by default, and allow it to be overridden. (cherrypick of #11271) (#11274)
   `PR #11274 <https://github.com/pantsbuild/pants/pull/11274>`_


### PR DESCRIPTION
The release of `2.1.1rc2` was paused while some broken windows were fixed. It can now be resumed.

[ci skip-rust]