### PR TITLE
Prepare 2.0.1rc4 (again).

### DIFF
--- a/src/python/pants/notes/2.0.x.rst
+++ b/src/python/pants/notes/2.0.x.rst
@@ -6,11 +6,23 @@ This document describes releases leading up to the ``2.0.x`` ``stable`` series.
 See https://www.pantsbuild.org/v2.0/docs/release-notes-2-0 for an overview of the changes in this release, and
 https://www.pantsbuild.org/docs/plugin-upgrade-guide for a plugin upgrade guide.
 
-2.0.1rc4 (12/09/2020)
+2.0.1rc4 (12/16/2020)
 ---------------------
 
 Bugfixes
 ~~~~~~~~
+
+* Fix filtering of log messages generated in native code. (cherrypick of #11313) (#11318)
+  `PR #11318 <https://github.com/pantsbuild/pants/pull/11318>`_
+
+* Upgrade to Pex 2.1.24 to fix macOS Big Sur. (cherrypick of #11312) (#11314)
+  `PR #11314 <https://github.com/pantsbuild/pants/pull/11314>`_
+
+* Clean the graph speculatively, and cancel nodes when interest is lost (cherrypick of #11308) (#11310)
+  `PR #11310 <https://github.com/pantsbuild/pants/pull/11310>`_
+
+* Implement native Process cache scoping to fix --test-force (cherrypick of #11291) (#11299)
+  `PR #11299 <https://github.com/pantsbuild/pants/pull/11299>`_
 
 * Revert "Move graph cycle detection to rust. (#11202)" (cherrypick of #11272) (#11277)
   `PR #11202 <https://github.com/pantsbuild/pants/pull/11202>`_


### PR DESCRIPTION
The release of `2.0.1rc4` was paused while some broken windows were fixed. It can now be resumed.

[ci skip-rust]