### PR TITLE
Infer imports of the style __import__("string_literal").

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/import_parser.py
+++ b/src/python/pants/backend/python/dependency_inference/import_parser.py
@@ -61,16 +61,22 @@ class AstVisitor(ast.NodeVisitor):
 
     def visit_Call(self, node):
       # Handle __import__("string_literal").  This is commonly used in __init__.py files,
-      # to explicitly mark namespace packages.
+      # to explicitly mark namespace packages.  Note that we don't handle more complex
+      # uses, such as those that set `level`.
       if (
           isinstance(node.func, ast.Name)
           and node.func.id == "__import__"
           and len(node.args) == 1
       ):
           if sys.version_info[0:2] < (3, 8) and isinstance(node.args[0], ast.Str):
-              self.explicit_imports.add(node.args[0].s)
+              arg_s = node.args[0].s
+              val = arg_s.decode("utf-8") if isinstance(arg_s, bytes) else arg_s
+              self.explicit_imports.add(arg_s)
+              return
           elif isinstance(node.args[0], ast.Constant):
               self.explicit_imports.add(str(node.args[0].value))
+              return
+      self.generic_visit(node)
 
 # String handling changes a bit depending on Python version. We dynamically add the appropriate
 # logic.

--- a/src/python/pants/backend/python/dependency_inference/import_parser_test.py
+++ b/src/python/pants/backend/python/dependency_inference/import_parser_test.py
@@ -80,6 +80,8 @@ def test_normal_imports(rule_runner: RuleRunner) -> None:
             import subprocess
         except ImportError:
             import subprocess23 as subprocess
+
+        __import__("pkg_resources")
         """
     )
     # We create a second file, in addition to what `assert_imports_parsed` does, to ensure we can
@@ -101,6 +103,7 @@ def test_normal_imports(rule_runner: RuleRunner) -> None:
             "second_import",
             "subprocess",
             "subprocess23",
+            "pkg_resources",
         ],
         expected_string=[],
     )

--- a/src/python/pants/backend/python/dependency_inference/import_parser_test.py
+++ b/src/python/pants/backend/python/dependency_inference/import_parser_test.py
@@ -203,7 +203,6 @@ def test_works_with_python2(rule_runner: RuleRunner) -> None:
         import demo
         from project.demo import Demo
 
-        __import__(b"pkg_resources")
         __import__(u"pkg_resources")
         __import__(b"treat.as.a.regular.import.not.a.string.import")
 

--- a/src/python/pants/backend/python/dependency_inference/import_parser_test.py
+++ b/src/python/pants/backend/python/dependency_inference/import_parser_test.py
@@ -203,6 +203,10 @@ def test_works_with_python2(rule_runner: RuleRunner) -> None:
         import demo
         from project.demo import Demo
 
+        __import__(b"pkg_resources")
+        __import__(u"pkg_resources")
+        __import__(b"treat.as.a.regular.import.not.a.string.import")
+
         importlib.import_module(b"dep.from.bytes")
         importlib.import_module(u"dep.from.str")
         """
@@ -211,7 +215,12 @@ def test_works_with_python2(rule_runner: RuleRunner) -> None:
         rule_runner,
         content,
         constraints="==2.7.*",
-        expected_explicit=["demo", "project.demo.Demo"],
+        expected_explicit=[
+            "demo",
+            "project.demo.Demo",
+            "pkg_resources",
+            "treat.as.a.regular.import.not.a.string.import",
+        ],
         expected_string=["dep.from.bytes", "dep.from.str"],
     )
 
@@ -227,6 +236,9 @@ def test_works_with_python38(rule_runner: RuleRunner) -> None:
         import demo
         from project.demo import Demo
 
+        __import__("pkg_resources")
+        __import__("treat.as.a.regular.import.not.a.string.import")
+
         importlib.import_module("dep.from.str")
         """
     )
@@ -234,7 +246,12 @@ def test_works_with_python38(rule_runner: RuleRunner) -> None:
         rule_runner,
         content,
         constraints=">=3.8",
-        expected_explicit=["demo", "project.demo.Demo"],
+        expected_explicit=[
+            "demo",
+            "project.demo.Demo",
+            "pkg_resources",
+            "treat.as.a.regular.import.not.a.string.import",
+        ],
         expected_string=["dep.from.str"],
     )
 
@@ -252,6 +269,9 @@ def test_works_with_python39(rule_runner: RuleRunner) -> None:
         import demo
         from project.demo import Demo
 
+        __import__("pkg_resources")
+        __import__("treat.as.a.regular.import.not.a.string.import")
+
         importlib.import_module("dep.from.str")
         """
     )
@@ -259,6 +279,11 @@ def test_works_with_python39(rule_runner: RuleRunner) -> None:
         rule_runner,
         content,
         constraints=">=3.9",
-        expected_explicit=["demo", "project.demo.Demo"],
+        expected_explicit=[
+            "demo",
+            "project.demo.Demo",
+            "pkg_resources",
+            "treat.as.a.regular.import.not.a.string.import",
+        ],
         expected_string=["dep.from.str"],
     )


### PR DESCRIPTION
These are commonly used for explicitly marking namespace packages,
and they are effectively like import statements, not like string
inference, which is looser.

[ci skip-rust]

[ci skip-build-wheels]
