### PR TITLE
Deprecate the `sources` field for `pex_binary` and `python_awslambda`

### DIFF
--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -32,6 +32,17 @@ from pants.source.source_root import SourceRoot, SourceRootRequest
 
 class PythonAwsLambdaSources(PythonSources):
     expected_num_files = range(0, 2)
+    deprecated_removal_version = "2.3.0.dev0"
+    deprecated_removal_hint = (
+        "Remove the `sources` field and create a `python_library` target with the handler "
+        "file included (if it does not yet exist). Pants will infer a dependency, which you can "
+        "check with `./pants dependencies path/to:lambda`. See "
+        "https://www.pantsbuild.org/v2.2/docs/awslambda-python for an example.\n\nYou can also "
+        "update the `handler` field to use the file name, "
+        "e.g. `handler='lambda.py:handler_func'`. This will allow file arguments to still work "
+        "with this target, meaning you can still use `./pants package path/to/lambda.py` instead "
+        "of needing to use `./pants package path/to:lambda`."
+    )
 
 
 class PythonAwsLambdaHandlerField(StringField, AsyncFieldMixin, SecondaryOwnerMixin):
@@ -175,6 +186,16 @@ class PythonAwsLambdaRuntime(StringField):
         return int(mo.group("major")), int(mo.group("minor"))
 
 
+class DeprecatedAwsLambdaInterpreterConstraints(InterpreterConstraintsField):
+    deprecated_removal_version = "2.3.0.dev0"
+    deprecated_removal_hint = (
+        "Because the `sources` field will be removed from `python_awslambda` targets, it no longer "
+        "makes sense to also have an `interpreter_constraints` field. Instead, set the "
+        "`interpreter_constraints` field on the `python_library` target containing the lambda's "
+        "handler code."
+    )
+
+
 class PythonAWSLambda(Target):
     """A self-contained Python function suitable for uploading to AWS Lambda.
 
@@ -185,7 +206,7 @@ class PythonAWSLambda(Target):
     core_fields = (
         *COMMON_TARGET_FIELDS,
         PythonAwsLambdaSources,
-        InterpreterConstraintsField,
+        DeprecatedAwsLambdaInterpreterConstraints,
         OutputPathField,
         PythonAwsLambdaDependencies,
         PythonAwsLambdaHandlerField,

--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -5,9 +5,9 @@ from dataclasses import dataclass
 from typing import Tuple
 
 from pants.backend.python.target_types import (
+    DeprecatedPexBinarySources,
     PexAlwaysWriteCacheField,
     PexBinaryDefaults,
-    PexBinarySources,
     PexEmitWarningsField,
     PexEntryPointField,
     PexIgnoreErrorsField,
@@ -39,9 +39,9 @@ from pants.util.logging import LogLevel
 
 @dataclass(frozen=True)
 class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
-    required_fields = (PexEntryPointField, PexBinarySources)
+    required_fields = (PexEntryPointField, DeprecatedPexBinarySources)
 
-    sources: PexBinarySources
+    sources: DeprecatedPexBinarySources
     entry_point: PexEntryPointField
 
     output_path: OutputPathField

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -112,15 +112,13 @@ def create_test_target(
 
 def create_pex_binary_target(rule_runner: RuleRunner, source_file: FileContent) -> None:
     rule_runner.create_file(source_file.path, source_file.content.decode())
+    file_name = PurePath(source_file.path).name
     rule_runner.add_to_build_file(
         relpath=PACKAGE,
         target=dedent(
             f"""\
-            pex_binary(
-              name='bin',
-              sources=['{PurePath(source_file.path).name}'],
-              output_path="bin.pex",
-            )
+            python_library(name='bin_lib', sources=['{file_name}'])
+            pex_binary(name='bin', entry_point='{file_name}', output_path="bin.pex")
             """
         ),
     )

--- a/src/python/pants/backend/python/goals/run_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary_integration_test.py
@@ -12,8 +12,8 @@ from pants.testutil.pants_integration_test import run_pants, setup_tmpdir
     "tgt_content",
     [
         "pex_binary(sources=['app.py'])",
-        "python_library()\npex_binary(entry_point='app.py')",
-        "python_library()\npex_binary(entry_point='app.py:main')",
+        "python_library(name='lib')\npex_binary(entry_point='app.py')",
+        "python_library(name='lib')\npex_binary(entry_point='app.py:main')",
     ],
 )
 def test_run_sample_script(tgt_content: str) -> None:

--- a/src/python/pants/backend/python/goals/run_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary_integration_test.py
@@ -12,8 +12,8 @@ from pants.testutil.pants_integration_test import run_pants, setup_tmpdir
     "tgt_content",
     [
         "pex_binary(sources=['app.py'])",
-        "pex_binary(sources=['app.py'], entry_point='project.app')",
-        "pex_binary(sources=['app.py'], entry_point='project.app:main')",
+        "python_library()\npex_binary(entry_point='app.py')",
+        "python_library()\npex_binary(entry_point='app.py:main')",
     ],
 )
 def test_run_sample_script(tgt_content: str) -> None:

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, List, Mapping, Set, Tuple, cast
 from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.subsystems.setuptools import Setuptools
 from pants.backend.python.target_types import (
-    PexBinarySources,
+    DeprecatedPexBinarySources,
     PexEntryPointField,
     PythonProvidesField,
     PythonRequirementsField,
@@ -522,7 +522,7 @@ async def generate_chroot(request: SetupPyChrootRequest) -> SetupPyChroot:
     )
     entry_point_requests = []
     for binary in binaries:
-        if not binary.has_fields([PexEntryPointField, PexBinarySources]):
+        if not binary.has_fields([PexEntryPointField, DeprecatedPexBinarySources]):
             raise InvalidEntryPoint(
                 "Expected addresses to `pex_binary` targets in `.with_binaries()` for the "
                 f"`provides` field for {exported_addr}, but found {binary.address} with target "
@@ -535,21 +535,19 @@ async def generate_chroot(request: SetupPyChrootRequest) -> SetupPyChroot:
                 "Every `pex_binary` used in `.with_binaries()` for the `provides` field for "
                 f"{exported_addr} must explicitly set the `entry_point` field, but "
                 f"{binary.address} left the field off. Set `entry_point` to either "
-                "`path.to.module:func`, or the shorthand `:func` (requires setting the `sources` "
-                f"field to exactly one file). See {url}."
+                "`app.py:func` or the longhand `path.to.app:func`. See {url}."
             )
         if ":" not in entry_point:
-            # We already validated that `entry_point` was set, so we can assume that we're not
-            # using the shorthand `:my_func` because they would have already used the `:` char.
             raise InvalidEntryPoint(
                 "Every `pex_binary` used in `with_binaries()` for the `provides()` field for "
                 f"{exported_addr} must end in the format `:my_func` for the `entry_point` field, "
                 f"but {binary.address} set it to {repr(entry_point)}. For example, set "
-                f"`entry_point='{entry_point}:main'. You may also use the shorthand "
-                f"`entry_point=':func'` if you set the `sources` field to a single file. See {url}."
+                f"`entry_point='{entry_point}:main'. See {url}."
             )
         entry_point_requests.append(
-            ResolvePexEntryPointRequest(binary[PexEntryPointField], binary[PexBinarySources])
+            ResolvePexEntryPointRequest(
+                binary[PexEntryPointField], binary[DeprecatedPexBinarySources]
+            )
         )
     binary_entry_points = await MultiGet(
         Get(ResolvedPexEntryPoint, ResolvePexEntryPointRequest, request)

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -535,7 +535,7 @@ async def generate_chroot(request: SetupPyChrootRequest) -> SetupPyChroot:
                 "Every `pex_binary` used in `.with_binaries()` for the `provides` field for "
                 f"{exported_addr} must explicitly set the `entry_point` field, but "
                 f"{binary.address} left the field off. Set `entry_point` to either "
-                "`app.py:func` or the longhand `path.to.app:func`. See {url}."
+                f"`app.py:func` or the longhand `path.to.app:func`. See {url}."
             )
         if ":" not in entry_point:
             raise InvalidEntryPoint(

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -100,7 +100,7 @@ class PexBinaryDefaults(Subsystem):
         return cast(bool, self.options.emit_warnings)
 
 
-class PexBinarySources(PythonSources):
+class DeprecatedPexBinarySources(PythonSources):
     """A single file containing the executable, such as ['app.py'].
 
     You can leave this off if you include the executable file in one of this target's
@@ -111,6 +111,14 @@ class PexBinarySources(PythonSources):
     """
 
     expected_num_files = range(0, 2)
+    deprecated_removal_version = "2.3.0.dev0"
+    deprecated_removal_hint = (
+        "Remove the `sources` field and set the `entry_point` field to the file name, "
+        "e.g. `entry_point='app.py'` or `entry_point='app.py:func'`. Create a `python_library` "
+        "target with the entry point's file included (if it does not yet exist). Pants will infer "
+        "a dependency, which you can check with `./pants dependencies path/to:app`. See "
+        "https://www.pantsbuild.org/v2.2/docs/python-package-goal for more instructions."
+    )
 
 
 # See `target_types_rules.py` for a dependency injection rule.
@@ -156,7 +164,7 @@ class ResolvePexEntryPointRequest:
     """Determine the `entry_point` for a `pex_binary` after applying all syntactic sugar."""
 
     entry_point_field: PexEntryPointField
-    sources: PexBinarySources
+    sources: DeprecatedPexBinarySources
 
 
 class PexPlatformsField(StringSequenceField):
@@ -252,6 +260,16 @@ class PexEmitWarningsField(BoolField):
         return self.value
 
 
+class DeprecatedPexBinaryInterpreterConstraints(InterpreterConstraintsField):
+    deprecated_removal_version = "2.3.0.dev0"
+    deprecated_removal_hint = (
+        "Because the `sources` field will be removed from `pex_binary` targets, it no longer makes "
+        "sense to also have an `interpreter_constraints` field. Instead, set the "
+        "`interpreter_constraints` field on the `python_library` target containing the binary's "
+        "entry point."
+    )
+
+
 class PexBinary(Target):
     """A Python target that can be converted into an executable PEX file.
 
@@ -262,9 +280,9 @@ class PexBinary(Target):
     alias = "pex_binary"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        InterpreterConstraintsField,
         OutputPathField,
-        PexBinarySources,
+        DeprecatedPexBinaryInterpreterConstraints,
+        DeprecatedPexBinarySources,
         PexBinaryDependencies,
         PexEntryPointField,
         PexPlatformsField,

--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -12,8 +12,8 @@ import os.path
 from pants.backend.python.dependency_inference.module_mapper import PythonModule, PythonModuleOwners
 from pants.backend.python.dependency_inference.rules import PythonInferSubsystem, import_rules
 from pants.backend.python.target_types import (
+    DeprecatedPexBinarySources,
     PexBinaryDependencies,
-    PexBinarySources,
     PexEntryPointField,
     PythonDistributionDependencies,
     PythonProvidesField,
@@ -53,8 +53,8 @@ async def resolve_pex_entry_point(request: ResolvePexEntryPointRequest) -> Resol
     #  3) `path.to.module:func` => preserve exactly.
     #  4) `app.py` => convert into `path.to.app`.
     #  5) `app.py:func` => convert into `path.to.app:func`.
-    #  6) `:func` => if there's a sources field, convert to `path.to.sources:func` (soon to be deprecated).
-    #  7) no entry point field, but `sources` field => convert to `path.to.sources` (soon to be deprecated).
+    #  6) `:func` => if there's a sources field, convert to `path.to.sources:func` (deprecated).
+    #  7) no entry point field, but `sources` field => convert to `path.to.sources` (deprecated).
 
     # Handle deprecated cases #6 and #7, which are the only cases where the `sources` field matters
     # for calculating the entry point.
@@ -75,7 +75,7 @@ async def resolve_pex_entry_point(request: ResolvePexEntryPointRequest) -> Resol
                 f"{repr(ep_val)}, but the `sources` field is not set. Pants requires the "
                 "`sources` field to expand the entry point to the normalized form "
                 f"`path.to.module:{ep_val}`. Please either set the `sources` field to exactly one "
-                f"file or set `{ep_alias}='my_file.py:{ep_val}'`. See "
+                f"file (deprecated) or set `{ep_alias}='my_file.py:{ep_val}'`. See "
                 f"{instructions_url}."
             )
         entry_point_path = binary_source_paths.files[0]
@@ -144,7 +144,7 @@ async def inject_pex_binary_entry_point_dependency(
     entry_point = await Get(
         ResolvedPexEntryPoint,
         ResolvePexEntryPointRequest(
-            original_tgt.target[PexEntryPointField], original_tgt.target[PexBinarySources]
+            original_tgt.target[PexEntryPointField], original_tgt.target[DeprecatedPexBinarySources]
         ),
     )
     if entry_point.val is None:

--- a/src/python/pants/backend/python/target_types_test.py
+++ b/src/python/pants/backend/python/target_types_test.py
@@ -11,9 +11,9 @@ from pants.backend.python.dependency_inference.rules import import_rules
 from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.backend.python.target_types import (
+    DeprecatedPexBinarySources,
     PexBinary,
     PexBinaryDependencies,
-    PexBinarySources,
     PexEntryPointField,
     PythonDistribution,
     PythonDistributionDependencies,
@@ -109,7 +109,7 @@ def test_resolve_pex_binary_entry_point() -> None:
         rule_runner.create_file("src/python/project/app.py")
         rule_runner.create_file("src/python/project/f2.py")
         ep_field = PexEntryPointField(entry_point, address=addr)
-        sources = PexBinarySources([source] if source else None, address=addr)
+        sources = DeprecatedPexBinarySources([source] if source else None, address=addr)
         result = rule_runner.request(
             ResolvedPexEntryPoint, [ResolvePexEntryPointRequest(ep_field, sources)]
         )

--- a/src/python/pants/base/exiter_integration_test.py
+++ b/src/python/pants/base/exiter_integration_test.py
@@ -10,7 +10,7 @@ def test_unicode_containing_exception():
         [
             "--backend-packages=pants.backend.python",
             "run",
-            "testprojects/src/python/unicode/compilation_failure",
+            "testprojects/src/python/unicode/compilation_failure/main.py",
         ]
     )
     pants_run.assert_failure()

--- a/testprojects/src/python/coordinated_runs/BUILD
+++ b/testprojects/src/python/coordinated_runs/BUILD
@@ -1,17 +1,8 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-pex_binary(
-  name='creator',
-  sources=['creator.py'],
-)
+python_library()
 
-pex_binary(
-  name='phaser',
-  sources=['phaser.py'],
-)
-
-pex_binary(
-  name='waiter',
-  sources=['waiter.py'],
-)
+pex_binary(name='creator', entry_point='creator.py')
+pex_binary(name='phaser', entry_point='phaser.py')
+pex_binary(name='waiter', entry_point='waiter.py')

--- a/testprojects/src/python/hello/greet/BUILD
+++ b/testprojects/src/python/hello/greet/BUILD
@@ -1,13 +1,4 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-
-# Note that the target has no explicit name, so it defaults to the name
-# of the directory, in this case 'greet'.
-# It also has no explicit sources, so it defaults to the sources implied
-# by the target type, in this case "['*.py']".
-python_library(
-  dependencies=[
-    '3rdparty/python:ansicolors',
-  ],
-)
+python_library()

--- a/testprojects/src/python/hello/main/BUILD
+++ b/testprojects/src/python/hello/main/BUILD
@@ -1,15 +1,5 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-# Like Hello world, but built with Pants.
-pex_binary(
-    sources=['main.py'],
-  dependencies=[
-    'testprojects/src/python/hello/greet:greet',
-    ':lib',
-  ],
-)
-
-python_library(
-    name='lib',
-)
+python_library(name="lib")
+pex_binary(name="main", entry_point='main.py')

--- a/testprojects/src/python/unicode/compilation_failure/BUILD
+++ b/testprojects/src/python/unicode/compilation_failure/BUILD
@@ -1,14 +1,5 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-pex_binary(
-  sources = ['main.py'],
-  dependencies = [':lib'],
-  tags = {"nolint"},
-)
-
-python_library(
-  name='lib',
-  sources = ['__init__.py'],
-  tags = {"nolint"},
-)
+python_library(name="lib")
+pex_binary(name="main", entry_point="main.py", tags=["nolint"])

--- a/testprojects/src/python/unicode/compilation_failure/BUILD
+++ b/testprojects/src/python/unicode/compilation_failure/BUILD
@@ -1,5 +1,5 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library(name="lib")
+python_library(name="lib", tags=["nolint"])
 pex_binary(name="main", entry_point="main.py", tags=["nolint"])

--- a/tests/python/pants_test/integration/prelude_integration_test.py
+++ b/tests/python/pants_test/integration/prelude_integration_test.py
@@ -12,10 +12,10 @@ def test_build_file_prelude() -> None:
         "prelude.py": dedent(
             """\
             def make_binary_macro():
-                pex_binary(name="main", sources=["main.py"])
+                pex_binary(name="main", entry_point="main.py")
             """
         ),
-        "BUILD": "make_binary_macro()",
+        "BUILD": "pex_library()\nmake_binary_macro()",
         "main.py": "print('Hello world!')",
     }
     with setup_tmpdir(sources) as tmpdir:

--- a/tests/python/pants_test/integration/prelude_integration_test.py
+++ b/tests/python/pants_test/integration/prelude_integration_test.py
@@ -15,7 +15,7 @@ def test_build_file_prelude() -> None:
                 pex_binary(name="main", entry_point="main.py")
             """
         ),
-        "BUILD": "pex_library()\nmake_binary_macro()",
+        "BUILD": "python_library()\nmake_binary_macro()",
         "main.py": "print('Hello world!')",
     }
     with setup_tmpdir(sources) as tmpdir:

--- a/tests/python/pants_test/pantsd/pantsd_integration_test.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test.py
@@ -77,7 +77,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
         with self.pantsd_test_context() as (workdir, pantsd_config, checker):
             # Run target that throws an exception in pants.
             self.run_pants_with_workdir(
-                ["lint", "testprojects/src/python/unicode/compilation_failure"],
+                ["lint", "testprojects/src/python/unicode/compilation_failure/main:lib"],
                 workdir=workdir,
                 config=pantsd_config,
             ).assert_failure()


### PR DESCRIPTION
See https://docs.google.com/document/d/1i0FDDvSd8BjgfkM6fq28p5KDojBy1xBf-mXTa8WL-sg/edit#heading=h.y51b5dgfg for the motivation, along with how we avoid UX regressions. Thanks to dependency inference and "secondary ownership", users can continue to leave off `dependencies` and can still use file arguments.

[ci skip-rust]
[ci skip-build-wheels]