### PR TITLE
Automatically set the version in generate_docs.py

### DIFF
--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -39,7 +39,7 @@ class ReferenceGenerator:
     Then:
 
     ./pants run build-support/bin/generate_docs.py -- \
-       --input=/tmp/help_info --api-key=<API_KEY> --sync \
+       --input=/tmp/help_info --sync --api-key=<API_KEY>
 
     where API_KEY is your readme.io API Key, found here:
       https://dash.readme.com/project/pants/v2.0/api-key

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -651,7 +651,7 @@ class GlobalOptions(Subsystem):
             "--process-execution-cache-namespace",
             advanced=True,
             type=str,
-            default="",
+            default=DEFAULT_EXECUTION_OPTIONS.process_execution_cache_namespace,
             help=(
                 "The cache namespace for process execution. "
                 "Change this value to invalidate every artifact's execution, or to prevent "


### PR DESCRIPTION
We now have generated references for 2.0, 2.1, and 2.2. This change facilitates targeting the correct version.

[ci skip-rust]
[ci skip-build-wheels]