### PR TITLE
use Bytes instead of Vec<u8> for protobuf binary fields

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -145,12 +145,13 @@ name = "bazel_protos"
 version = "0.0.1"
 dependencies = [
  "build_utils",
- "bytes",
+ "bytes 0.5.4",
  "copy_dir",
  "dir-diff",
  "futures 0.1.29",
  "hashing",
- "prost",
+ "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=a1cccbcee343e2c444e1cd2738c7fba2599fc391)",
+ "prost-build",
  "prost-types",
  "tempfile",
  "tonic",
@@ -206,7 +207,7 @@ name = "brfs"
 version = "0.0.1"
 dependencies = [
  "bazel_protos",
- "bytes",
+ "bytes 0.5.4",
  "clap",
  "dirs",
  "env_logger",
@@ -261,6 +262,12 @@ name = "bytes"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
+
+[[package]]
+name = "bytes"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
 
 [[package]]
 name = "cargo_metadata"
@@ -373,9 +380,8 @@ name = "concrete_time"
 version = "0.0.1"
 dependencies = [
  "log 0.4.8",
- "prost",
+ "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=423f5ec5bd165a7007a388edfb2b485d5bbf40c7)",
  "prost-types",
- "protobuf",
  "serde",
  "serde_derive",
 ]
@@ -654,7 +660,7 @@ dependencies = [
  "async_latch",
  "async_semaphore",
  "boxfuture",
- "bytes",
+ "bytes 0.5.4",
  "concrete_time",
  "cpython",
  "crossbeam-channel",
@@ -762,7 +768,7 @@ name = "fs"
 version = "0.0.1"
 dependencies = [
  "async-trait",
- "bytes",
+ "bytes 0.5.4",
  "dirs",
  "futures 0.3.5",
  "glob",
@@ -783,7 +789,7 @@ version = "0.0.1"
 dependencies = [
  "bazel_protos",
  "boxfuture",
- "bytes",
+ "bytes 0.5.4",
  "clap",
  "env_logger",
  "fs",
@@ -791,8 +797,7 @@ dependencies = [
  "futures 0.3.5",
  "hashing",
  "parking_lot",
- "prost",
- "protobuf",
+ "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=a1cccbcee343e2c444e1cd2738c7fba2599fc391)",
  "rand 0.6.5",
  "serde",
  "serde_derive",
@@ -1038,7 +1043,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5c295d1c0c68e4e42003d75f908f5e16a1edd1cbe0b0d02e4dc2006a384f47"
 dependencies = [
- "bytes",
+ "bytes 0.5.4",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1094,7 +1099,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b708cc7f06493459026f53b9a61a7a121a5d1ec6238dee58ea4941132b30156b"
 dependencies = [
- "bytes",
+ "bytes 0.5.4",
  "fnv",
  "itoa",
 ]
@@ -1105,7 +1110,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes",
+ "bytes 0.5.4",
  "http",
 ]
 
@@ -1130,7 +1135,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed6081100e960d9d74734659ffc9cc91daf1c0fc7aceb8eaa94ee1a3f5046f2e"
 dependencies = [
- "bytes",
+ "bytes 0.5.4",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1154,7 +1159,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac965ea399ec3a25ac7d13b8affd4b8f39325cca00858ddf5eb29b79e6b14b08"
 dependencies = [
- "bytes",
+ "bytes 0.5.4",
  "ct-logs",
  "futures-util",
  "hyper",
@@ -1535,16 +1540,15 @@ version = "0.0.1"
 dependencies = [
  "async-stream",
  "bazel_protos",
- "bytes",
+ "bytes 0.5.4",
  "futures 0.1.29",
  "futures 0.3.5",
  "hashing",
  "hyper",
  "log 0.4.8",
  "parking_lot",
- "prost",
+ "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=a1cccbcee343e2c444e1cd2738c7fba2599fc391)",
  "prost-types",
- "protobuf",
  "testutil",
  "tokio",
  "tonic",
@@ -1561,7 +1565,7 @@ name = "nailgun"
 version = "0.0.1"
 dependencies = [
  "async_latch",
- "bytes",
+ "bytes 0.5.4",
  "futures 0.3.5",
  "log 0.4.8",
  "nails",
@@ -1577,7 +1581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "324d0793d44314222dc61947ffecc0325fb1c824dd6ef6b231b98e0b1f06b11b"
 dependencies = [
  "byteorder",
- "bytes",
+ "bytes 0.5.4",
  "futures 0.3.5",
  "log 0.4.8",
  "tokio",
@@ -1959,7 +1963,7 @@ dependencies = [
  "bazel_protos",
  "bincode",
  "boxfuture",
- "bytes",
+ "bytes 0.5.4",
  "concrete_time",
  "derivative",
  "double-checked-cell-async",
@@ -1976,9 +1980,8 @@ dependencies = [
  "mock",
  "nails",
  "parking_lot",
- "prost",
+ "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=a1cccbcee343e2c444e1cd2738c7fba2599fc391)",
  "prost-types",
- "protobuf",
  "rand 0.6.5",
  "regex",
  "serde",
@@ -2022,26 +2025,33 @@ dependencies = [
 [[package]]
 name = "prost"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
+source = "git+https://github.com/danburkert/prost?rev=423f5ec5bd165a7007a388edfb2b485d5bbf40c7#423f5ec5bd165a7007a388edfb2b485d5bbf40c7"
 dependencies = [
- "bytes",
- "prost-derive",
+ "bytes 0.6.0",
+ "prost-derive 0.6.1 (git+https://github.com/danburkert/prost?rev=423f5ec5bd165a7007a388edfb2b485d5bbf40c7)",
+]
+
+[[package]]
+name = "prost"
+version = "0.6.1"
+source = "git+https://github.com/danburkert/prost?rev=a1cccbcee343e2c444e1cd2738c7fba2599fc391#a1cccbcee343e2c444e1cd2738c7fba2599fc391"
+dependencies = [
+ "bytes 0.5.4",
+ "prost-derive 0.6.1 (git+https://github.com/danburkert/prost?rev=a1cccbcee343e2c444e1cd2738c7fba2599fc391)",
 ]
 
 [[package]]
 name = "prost-build"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
+source = "git+https://github.com/danburkert/prost?rev=a1cccbcee343e2c444e1cd2738c7fba2599fc391#a1cccbcee343e2c444e1cd2738c7fba2599fc391"
 dependencies = [
- "bytes",
+ "bytes 0.5.4",
  "heck",
- "itertools 0.8.2",
+ "itertools 0.9.0",
  "log 0.4.8",
  "multimap",
  "petgraph 0.5.1",
- "prost",
+ "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=a1cccbcee343e2c444e1cd2738c7fba2599fc391)",
  "prost-types",
  "tempfile",
  "which",
@@ -2061,13 +2071,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.6.1"
+source = "git+https://github.com/danburkert/prost?rev=423f5ec5bd165a7007a388edfb2b485d5bbf40c7#423f5ec5bd165a7007a388edfb2b485d5bbf40c7"
+dependencies = [
+ "anyhow",
+ "itertools 0.9.0",
+ "proc-macro2 1.0.24",
+ "quote 1.0.4",
+ "syn 1.0.54",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.6.1"
+source = "git+https://github.com/danburkert/prost?rev=a1cccbcee343e2c444e1cd2738c7fba2599fc391#a1cccbcee343e2c444e1cd2738c7fba2599fc391"
+dependencies = [
+ "anyhow",
+ "itertools 0.9.0",
+ "proc-macro2 1.0.24",
+ "quote 1.0.4",
+ "syn 1.0.54",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
+source = "git+https://github.com/danburkert/prost?rev=a1cccbcee343e2c444e1cd2738c7fba2599fc391#a1cccbcee343e2c444e1cd2738c7fba2599fc391"
 dependencies = [
- "bytes",
- "prost",
+ "bytes 0.5.4",
+ "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=a1cccbcee343e2c444e1cd2738c7fba2599fc391)",
 ]
 
 [[package]]
@@ -2076,7 +2109,7 @@ version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da78e04bc0e40f36df43ecc6575e4f4b180e8156c4efd73f13d5619479b05696"
 dependencies = [
- "bytes",
+ "bytes 0.5.4",
 ]
 
 [[package]]
@@ -2376,7 +2409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b81e49ddec5109a9dcfc5f2a317ff53377c915e9ae9d4f2fb50914b85614e2"
 dependencies = [
  "base64 0.11.0",
- "bytes",
+ "bytes 0.5.4",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -2699,7 +2732,7 @@ dependencies = [
 name = "sharded_lmdb"
 version = "0.0.1"
 dependencies = [
- "bytes",
+ "bytes 0.5.4",
  "fs",
  "futures 0.3.5",
  "hashing",
@@ -2781,7 +2814,7 @@ dependencies = [
  "async-trait",
  "bazel_protos",
  "boxfuture",
- "bytes",
+ "bytes 0.5.4",
  "concrete_time",
  "criterion",
  "fs",
@@ -2798,7 +2831,7 @@ dependencies = [
  "mock",
  "num_cpus",
  "parking_lot",
- "prost",
+ "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=a1cccbcee343e2c444e1cd2738c7fba2599fc391)",
  "prost-types",
  "serde",
  "serde_derive",
@@ -2913,11 +2946,10 @@ version = "0.0.1"
 dependencies = [
  "async-stream",
  "bazel_protos",
- "bytes",
+ "bytes 0.5.4",
  "fs",
  "hashing",
- "prost",
- "protobuf",
+ "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=a1cccbcee343e2c444e1cd2738c7fba2599fc391)",
 ]
 
 [[package]]
@@ -2971,7 +3003,7 @@ version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6d7ad61edd59bfcc7e80dababf0f4aed2e6d5e0ba1659356ae889752dfc12ff"
 dependencies = [
- "bytes",
+ "bytes 0.5.4",
  "fnv",
  "futures-core",
  "iovec",
@@ -3030,7 +3062,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
 dependencies = [
- "bytes",
+ "bytes 0.5.4",
  "futures-core",
  "futures-sink",
  "log 0.4.8",
@@ -3044,7 +3076,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes",
+ "bytes 0.5.4",
  "futures-core",
  "futures-sink",
  "log 0.4.8",
@@ -3070,7 +3102,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.12.3",
- "bytes",
+ "bytes 0.5.4",
  "futures-core",
  "futures-util",
  "http",
@@ -3078,8 +3110,8 @@ dependencies = [
  "hyper",
  "percent-encoding",
  "pin-project",
- "prost",
- "prost-derive",
+ "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=a1cccbcee343e2c444e1cd2738c7fba2599fc391)",
+ "prost-derive 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls-native-certs 0.4.0",
  "tokio",
  "tokio-rustls 0.14.1",

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -141,3 +141,9 @@ workunit_store = { path = "workunit_store" }
 testutil = { path = "./testutil" }
 fs = { path = "./fs" }
 env_logger = "0.5.4"
+
+[patch.crates-io]
+# Patch all transitive uses of Prost to refer to the version with `Bytes` support.
+prost = { git = "https://github.com/danburkert/prost", rev = "a1cccbcee343e2c444e1cd2738c7fba2599fc391" }
+prost-build = { git = "https://github.com/danburkert/prost",  rev = "a1cccbcee343e2c444e1cd2738c7fba2599fc391" }
+prost-types = { git = "https://github.com/danburkert/prost",  rev = "a1cccbcee343e2c444e1cd2738c7fba2599fc391" }

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -144,6 +144,7 @@ env_logger = "0.5.4"
 
 [patch.crates-io]
 # Patch all transitive uses of Prost to refer to the version with `Bytes` support.
+# Specifically, this Prost commit: https://github.com/danburkert/prost/commit/a1cccbcee343e2c444e1cd2738c7fba2599fc391
 prost = { git = "https://github.com/danburkert/prost", rev = "a1cccbcee343e2c444e1cd2738c7fba2599fc391" }
 prost-build = { git = "https://github.com/danburkert/prost",  rev = "a1cccbcee343e2c444e1cd2738c7fba2599fc391" }
 prost-types = { git = "https://github.com/danburkert/prost",  rev = "a1cccbcee343e2c444e1cd2738c7fba2599fc391" }

--- a/src/rust/engine/concrete_time/Cargo.toml
+++ b/src/rust/engine/concrete_time/Cargo.toml
@@ -6,9 +6,8 @@ name = "concrete_time"
 publish = false
 
 [dependencies]
-prost = "0.6"
+prost = { git = "https://github.com/danburkert/prost", rev = "423f5ec5bd165a7007a388edfb2b485d5bbf40c7" }
 prost-types = "0.6"
-protobuf = { version = "2.0.6", features = ["with-bytes"] }
 serde_derive = "1.0.98"
 serde = "1.0.98"
 log = "0.4"

--- a/src/rust/engine/concrete_time/src/lib.rs
+++ b/src/rust/engine/concrete_time/src/lib.rs
@@ -116,38 +116,11 @@ impl TimeSpan {
     }
   }
 
-  fn std_duration_from_protobuf_timestamp(
-    t: &protobuf::well_known_types::Timestamp,
-  ) -> std::time::Duration {
-    std::time::Duration::new(t.seconds as u64, t.nanos as u32)
-  }
-
   fn std_duration_from_prost_timestamp(t: &prost_types::Timestamp) -> std::time::Duration {
     std::time::Duration::new(t.seconds as u64, t.nanos as u32)
   }
 
-  /// Construct a `TimeSpan` given a start and an end `Timestamp` from protobuf
-  // TODO(tonic): Determine if this function can be removed in favor of `from_start_and_end_prost`.
-  pub fn from_start_and_end(
-    start: &protobuf::well_known_types::Timestamp,
-    end: &protobuf::well_known_types::Timestamp,
-    time_span_description: &str,
-  ) -> Result<Self, String> {
-    let start = Self::std_duration_from_protobuf_timestamp(start);
-    let end = Self::std_duration_from_protobuf_timestamp(end);
-    let time_span = end.checked_sub(start).map(|duration| TimeSpan {
-      start: start.into(),
-      duration: duration.into(),
-    });
-    time_span.ok_or_else(|| {
-      format!(
-        "Got negative {} time: {:?} - {:?}",
-        time_span_description, end, start
-      )
-    })
-  }
-
-  /// Construct a `TimeSpan` given a start and an end `Timestamp` from protobuf
+  /// Construct a `TimeSpan` given a start and an end `Timestamp` from protobuf timestamp.
   pub fn from_start_and_end_prost(
     start: &prost_types::Timestamp,
     end: &prost_types::Timestamp,

--- a/src/rust/engine/concrete_time/src/lib.rs
+++ b/src/rust/engine/concrete_time/src/lib.rs
@@ -116,18 +116,18 @@ impl TimeSpan {
     }
   }
 
-  fn std_duration_from_prost_timestamp(t: &prost_types::Timestamp) -> std::time::Duration {
+  fn std_duration_from_timestamp(t: &prost_types::Timestamp) -> std::time::Duration {
     std::time::Duration::new(t.seconds as u64, t.nanos as u32)
   }
 
   /// Construct a `TimeSpan` given a start and an end `Timestamp` from protobuf timestamp.
-  pub fn from_start_and_end_prost(
+  pub fn from_start_and_end(
     start: &prost_types::Timestamp,
     end: &prost_types::Timestamp,
     time_span_description: &str,
   ) -> Result<Self, String> {
-    let start = Self::std_duration_from_prost_timestamp(start);
-    let end = Self::std_duration_from_prost_timestamp(end);
+    let start = Self::std_duration_from_timestamp(start);
+    let end = Self::std_duration_from_timestamp(end);
     let time_span = end.checked_sub(start).map(|duration| TimeSpan {
       start: start.into(),
       duration: duration.into(),

--- a/src/rust/engine/concrete_time/src/tests.rs
+++ b/src/rust/engine/concrete_time/src/tests.rs
@@ -35,11 +35,18 @@ fn time_span_from_start_and_duration_in_seconds(
   start: i64,
   duration: i64,
 ) -> Result<TimeSpan, String> {
-  use protobuf::well_known_types::Timestamp;
-  let mut start_timestamp = Timestamp::new();
-  start_timestamp.set_seconds(start);
-  let mut end_timestamp = Timestamp::new();
-  end_timestamp.set_seconds(start + duration);
+  use prost_types::Timestamp;
+
+  let start_timestamp = Timestamp {
+    seconds: start,
+    nanos: 0,
+  };
+
+  let end_timestamp = Timestamp {
+    seconds: start + duration,
+    nanos: 0,
+  };
+
   TimeSpan::from_start_and_end(&start_timestamp, &end_timestamp, "")
 }
 

--- a/src/rust/engine/fs/fs_util/Cargo.toml
+++ b/src/rust/engine/fs/fs_util/Cargo.toml
@@ -16,8 +16,7 @@ futures01 = { package = "futures", version = "0.1" }
 futures = { version = "0.3", features = ["compat"] }
 hashing = { path = "../../hashing" }
 parking_lot = "0.11"
-prost = "0.6"
-protobuf = { version = "2.0.6", features = ["with-bytes"] }
+prost = { git = "https://github.com/danburkert/prost", rev = "a1cccbcee343e2c444e1cd2738c7fba2599fc391" }
 rand = "0.6"
 serde = "1.0"
 serde_json = "1.0"

--- a/src/rust/engine/fs/store/Cargo.toml
+++ b/src/rust/engine/fs/store/Cargo.toml
@@ -22,7 +22,7 @@ itertools = "0.7.2"
 lmdb = { git = "https://github.com/pantsbuild/lmdb-rs.git", rev = "06bdfbfc6348f6804127176e561843f214fc17f8" }
 log = "0.4"
 parking_lot = "0.11"
-prost = "0.6"
+prost = { git = "https://github.com/danburkert/prost", rev = "a1cccbcee343e2c444e1cd2738c7fba2599fc391" }
 prost-types = "0.6"
 serverset = { path = "../../serverset" }
 serde = "1.0"

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -193,7 +193,7 @@ impl ByteStore {
           finish_write: next_offset == bytes.len(),
           // TODO(tonic): Explore using the unreleased `Bytes` support in Prost from:
           // https://github.com/danburkert/prost/pull/341
-          data: Vec::from(&bytes[offset..next_offset]),
+          data: bytes.slice(offset..next_offset),
         };
         futures::future::ready(Some((req, (next_offset, true))))
       }

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -21,7 +21,6 @@ hashing = { path = "../hashing" }
 libc = "0.2.39"
 log = "0.4"
 nails = "0.8"
-protobuf = { version = "2.0.6", features = ["with-bytes"] }
 sha2 = "0.9"
 sharded_lmdb = {  path = "../sharded_lmdb" }
 shell-quote = "0.1.0"
@@ -43,7 +42,7 @@ serde = "1.0.104"
 bincode = "1.2.1"
 double-checked-cell-async = "2.0"
 rand = "0.6"
-prost = "0.6"
+prost = { git = "https://github.com/danburkert/prost", rev = "a1cccbcee343e2c444e1cd2738c7fba2599fc391" }
 prost-types = "0.6"
 tonic = { version = "0.3", features = ["transport", "codegen", "tls", "tls-roots", "prost"] }
 

--- a/src/rust/engine/process_execution/bazel_protos/Cargo.toml
+++ b/src/rust/engine/process_execution/bazel_protos/Cargo.toml
@@ -9,7 +9,8 @@ publish = false
 bytes = "0.5"
 futures = "^0.1.16"
 hashing = { path = "../../hashing" }
-prost = "0.6"
+prost = { git = "https://github.com/danburkert/prost", rev = "a1cccbcee343e2c444e1cd2738c7fba2599fc391" }
+prost-build = { git = "https://github.com/danburkert/prost",  rev = "a1cccbcee343e2c444e1cd2738c7fba2599fc391" }
 prost-types = "0.6"
 tonic = { version = "0.3", features = ["transport", "codegen", "tls", "tls-roots"] }
 
@@ -18,5 +19,6 @@ build_utils = { path = "../../build_utils" }
 copy_dir = "0.1.2"
 dir-diff = "0.3.1"
 tempfile = "3"
+prost-build = { git = "https://github.com/danburkert/prost",  rev = "a1cccbcee343e2c444e1cd2738c7fba2599fc391" }
 tonic-build = { version = "0.3", features = ["prost"] }
 walkdir = "2"

--- a/src/rust/engine/process_execution/bazel_protos/build.rs
+++ b/src/rust/engine/process_execution/bazel_protos/build.rs
@@ -1,11 +1,17 @@
 // Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+use prost_build::Config;
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+  let mut config = Config::new();
+  config.bytes(&["."]);
+
   tonic_build::configure()
     .build_client(true)
     .build_server(true)
-    .compile(
+    .compile_with_config(
+      config,
       &[
         "protos/bazelbuild_remote-apis/build/bazel/remote/execution/v2/remote_execution.proto",
         "protos/bazelbuild_remote-apis/build/bazel/semver/semver.proto",

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -344,11 +344,8 @@ impl CommandRunner {
       metadata.queued_timestamp.as_ref(),
       metadata.worker_start_timestamp.as_ref(),
     ) {
-      let span_result = TimeSpan::from_start_and_end_prost(
-        queued_timestamp,
-        worker_start_timestamp,
-        "remote queue",
-      );
+      let span_result =
+        TimeSpan::from_start_and_end(queued_timestamp, worker_start_timestamp, "remote queue");
       match span_result {
         Ok(time_span) => maybe_add_workunit(
           result_cached,
@@ -366,7 +363,7 @@ impl CommandRunner {
       metadata.input_fetch_start_timestamp.as_ref(),
       metadata.input_fetch_completed_timestamp.as_ref(),
     ) {
-      let span_result = TimeSpan::from_start_and_end_prost(
+      let span_result = TimeSpan::from_start_and_end(
         input_fetch_start_timestamp,
         input_fetch_completed_timestamp,
         "remote input fetch",
@@ -388,7 +385,7 @@ impl CommandRunner {
       metadata.execution_start_timestamp.as_ref(),
       metadata.execution_completed_timestamp.as_ref(),
     ) {
-      let span_result = TimeSpan::from_start_and_end_prost(
+      let span_result = TimeSpan::from_start_and_end(
         execution_start_timestamp,
         execution_completed_timestamp,
         "remote execution",
@@ -410,7 +407,7 @@ impl CommandRunner {
       metadata.output_upload_start_timestamp.as_ref(),
       metadata.output_upload_completed_timestamp.as_ref(),
     ) {
-      let span_result = TimeSpan::from_start_and_end_prost(
+      let span_result = TimeSpan::from_start_and_end(
         output_upload_start_timestamp,
         output_upload_completed_timestamp,
         "remote output store",

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -1577,8 +1577,8 @@ async fn execute_missing_file_errors_if_unknown() {
 #[tokio::test]
 async fn extract_execute_response_success() {
   let wanted_exit_code = 17;
-  let wanted_stdout = "roland".as_bytes();
-  let wanted_stderr = "simba".as_bytes();
+  let wanted_stdout = Bytes::from_static(b"roland");
+  let wanted_stderr = Bytes::from_static(b"simba");
 
   let operation = Operation {
     name: "cat".to_owned(),
@@ -1588,8 +1588,8 @@ async fn extract_execute_response_success() {
         &remexec::ExecuteResponse {
           result: Some(remexec::ActionResult {
             exit_code: wanted_exit_code,
-            stdout_raw: wanted_stdout.to_vec(),
-            stderr_raw: wanted_stderr.to_vec(),
+            stdout_raw: wanted_stdout.clone(),
+            stderr_raw: wanted_stderr.clone(),
             output_files: vec![remexec::OutputFile {
               path: "cats/roland".into(),
               digest: Some((&TestData::roland().digest()).into()),
@@ -2096,7 +2096,7 @@ pub(crate) fn make_action_result(
   let mut action_result = remexec::ActionResult::default();
   match stdout {
     StdoutType::Raw(stdout_raw) => {
-      action_result.stdout_raw = stdout_raw.into_bytes();
+      action_result.stdout_raw = stdout_raw.into_bytes().into();
     }
     StdoutType::Digest(stdout_digest) => {
       action_result.stdout_digest = Some((&stdout_digest).into());
@@ -2104,7 +2104,7 @@ pub(crate) fn make_action_result(
   }
   match stderr {
     StderrType::Raw(stderr_raw) => {
-      action_result.stderr_raw = stderr_raw.into_bytes();
+      action_result.stderr_raw = stderr_raw.into_bytes().into();
     }
     StderrType::Digest(stderr_digest) => {
       action_result.stderr_digest = Some((&stderr_digest).into());

--- a/src/rust/engine/testutil/Cargo.toml
+++ b/src/rust/engine/testutil/Cargo.toml
@@ -11,5 +11,4 @@ bazel_protos = { path = "../process_execution/bazel_protos" }
 bytes = "0.5"
 fs = { path = "../fs" }
 hashing = { path = "../hashing" }
-prost = "0.6"
-protobuf = { version = "2.0.6", features = ["with-bytes"] }
+prost = { git = "https://github.com/danburkert/prost", rev = "a1cccbcee343e2c444e1cd2738c7fba2599fc391" }

--- a/src/rust/engine/testutil/mock/Cargo.toml
+++ b/src/rust/engine/testutil/mock/Cargo.toml
@@ -15,9 +15,8 @@ hashing = { path = "../../hashing" }
 hyper = { version = "0.13", features = ["stream", "tcp"] }
 log = "0.4"
 parking_lot = "0.11"
-prost = "0.6"
+prost = { git = "https://github.com/danburkert/prost", rev = "a1cccbcee343e2c444e1cd2738c7fba2599fc391" }
 prost-types = "0.6"
-protobuf = { version = "2.0.6", features = ["with-bytes"] }
 testutil = { path = ".." }
 tokio = { version = "0.2.23", features = ["time"] }
 tonic = { version = "0.3" }

--- a/src/rust/engine/testutil/mock/src/cas.rs
+++ b/src/rust/engine/testutil/mock/src/cas.rs
@@ -307,7 +307,9 @@ impl StubCASResponder {
       Some(bytes) => Ok(
         bytes
           .chunks(self.chunk_size_bytes as usize)
-          .map(|b| ReadResponse { data: Vec::from(b) })
+          .map(|b| ReadResponse {
+            data: bytes.slice_ref(b),
+          })
           .collect(),
       ),
       None => Err(Status::not_found(format!(


### PR DESCRIPTION
### Problem

https://github.com/pantsbuild/pants/pull/11307 upgraded the gRPC code to [Tonic](https://github.com/hyperium/tonic) from grpcio. As part of that upgrade, Pants now uses [Prost](https://github.com/danburkert/prost) to generate Rust structs for protobuf types. By default, Prost encodes binary fields as `Vec<u8>`. Given the attendant problems of `Vec<u8>` of needing to copy around bytes when structs are cloned, the more efficient method is to use `Bytes` for the representation to avoid unnecessary copies.

### Solution

Upgrade Prost to https://github.com/danburkert/prost/commit/a1cccbcee343e2c444e1cd2738c7fba2599fc391 and enable using `Bytes` for all binary fields.

### Result

Existing tests pass.
