### PR TITLE
fix Prost revision that did not get updated in prior PR

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -145,12 +145,12 @@ name = "bazel_protos"
 version = "0.0.1"
 dependencies = [
  "build_utils",
- "bytes 0.5.4",
+ "bytes",
  "copy_dir",
  "dir-diff",
  "futures 0.1.29",
  "hashing",
- "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=a1cccbcee343e2c444e1cd2738c7fba2599fc391)",
+ "prost",
  "prost-build",
  "prost-types",
  "tempfile",
@@ -207,7 +207,7 @@ name = "brfs"
 version = "0.0.1"
 dependencies = [
  "bazel_protos",
- "bytes 0.5.4",
+ "bytes",
  "clap",
  "dirs",
  "env_logger",
@@ -262,12 +262,6 @@ name = "bytes"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
-
-[[package]]
-name = "bytes"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
 
 [[package]]
 name = "cargo_metadata"
@@ -380,7 +374,7 @@ name = "concrete_time"
 version = "0.0.1"
 dependencies = [
  "log 0.4.8",
- "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=423f5ec5bd165a7007a388edfb2b485d5bbf40c7)",
+ "prost",
  "prost-types",
  "serde",
  "serde_derive",
@@ -660,7 +654,7 @@ dependencies = [
  "async_latch",
  "async_semaphore",
  "boxfuture",
- "bytes 0.5.4",
+ "bytes",
  "concrete_time",
  "cpython",
  "crossbeam-channel",
@@ -768,7 +762,7 @@ name = "fs"
 version = "0.0.1"
 dependencies = [
  "async-trait",
- "bytes 0.5.4",
+ "bytes",
  "dirs",
  "futures 0.3.5",
  "glob",
@@ -789,7 +783,7 @@ version = "0.0.1"
 dependencies = [
  "bazel_protos",
  "boxfuture",
- "bytes 0.5.4",
+ "bytes",
  "clap",
  "env_logger",
  "fs",
@@ -798,7 +792,7 @@ dependencies = [
  "grpc_util",
  "hashing",
  "parking_lot",
- "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=a1cccbcee343e2c444e1cd2738c7fba2599fc391)",
+ "prost",
  "rand 0.6.5",
  "serde",
  "serde_derive",
@@ -1047,7 +1041,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5c295d1c0c68e4e42003d75f908f5e16a1edd1cbe0b0d02e4dc2006a384f47"
 dependencies = [
- "bytes 0.5.4",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1103,7 +1097,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b708cc7f06493459026f53b9a61a7a121a5d1ec6238dee58ea4941132b30156b"
 dependencies = [
- "bytes 0.5.4",
+ "bytes",
  "fnv",
  "itoa",
 ]
@@ -1114,7 +1108,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes 0.5.4",
+ "bytes",
  "http",
 ]
 
@@ -1139,7 +1133,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed6081100e960d9d74734659ffc9cc91daf1c0fc7aceb8eaa94ee1a3f5046f2e"
 dependencies = [
- "bytes 0.5.4",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1163,7 +1157,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac965ea399ec3a25ac7d13b8affd4b8f39325cca00858ddf5eb29b79e6b14b08"
 dependencies = [
- "bytes 0.5.4",
+ "bytes",
  "ct-logs",
  "futures-util",
  "hyper",
@@ -1544,14 +1538,14 @@ version = "0.0.1"
 dependencies = [
  "async-stream",
  "bazel_protos",
- "bytes 0.5.4",
+ "bytes",
  "futures 0.1.29",
  "futures 0.3.5",
  "hashing",
  "hyper",
  "log 0.4.8",
  "parking_lot",
- "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=a1cccbcee343e2c444e1cd2738c7fba2599fc391)",
+ "prost",
  "prost-types",
  "testutil",
  "tokio",
@@ -1569,7 +1563,7 @@ name = "nailgun"
 version = "0.0.1"
 dependencies = [
  "async_latch",
- "bytes 0.5.4",
+ "bytes",
  "futures 0.3.5",
  "log 0.4.8",
  "nails",
@@ -1585,7 +1579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "324d0793d44314222dc61947ffecc0325fb1c824dd6ef6b231b98e0b1f06b11b"
 dependencies = [
  "byteorder",
- "bytes 0.5.4",
+ "bytes",
  "futures 0.3.5",
  "log 0.4.8",
  "tokio",
@@ -1967,7 +1961,7 @@ dependencies = [
  "bazel_protos",
  "bincode",
  "boxfuture",
- "bytes 0.5.4",
+ "bytes",
  "concrete_time",
  "derivative",
  "double-checked-cell-async",
@@ -1984,7 +1978,7 @@ dependencies = [
  "mock",
  "nails",
  "parking_lot",
- "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=a1cccbcee343e2c444e1cd2738c7fba2599fc391)",
+ "prost",
  "prost-types",
  "rand 0.6.5",
  "regex",
@@ -2029,18 +2023,9 @@ dependencies = [
 [[package]]
 name = "prost"
 version = "0.6.1"
-source = "git+https://github.com/danburkert/prost?rev=423f5ec5bd165a7007a388edfb2b485d5bbf40c7#423f5ec5bd165a7007a388edfb2b485d5bbf40c7"
-dependencies = [
- "bytes 0.6.0",
- "prost-derive 0.6.1 (git+https://github.com/danburkert/prost?rev=423f5ec5bd165a7007a388edfb2b485d5bbf40c7)",
-]
-
-[[package]]
-name = "prost"
-version = "0.6.1"
 source = "git+https://github.com/danburkert/prost?rev=a1cccbcee343e2c444e1cd2738c7fba2599fc391#a1cccbcee343e2c444e1cd2738c7fba2599fc391"
 dependencies = [
- "bytes 0.5.4",
+ "bytes",
  "prost-derive 0.6.1 (git+https://github.com/danburkert/prost?rev=a1cccbcee343e2c444e1cd2738c7fba2599fc391)",
 ]
 
@@ -2049,13 +2034,13 @@ name = "prost-build"
 version = "0.6.1"
 source = "git+https://github.com/danburkert/prost?rev=a1cccbcee343e2c444e1cd2738c7fba2599fc391#a1cccbcee343e2c444e1cd2738c7fba2599fc391"
 dependencies = [
- "bytes 0.5.4",
+ "bytes",
  "heck",
  "itertools 0.9.0",
  "log 0.4.8",
  "multimap",
  "petgraph 0.5.1",
- "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=a1cccbcee343e2c444e1cd2738c7fba2599fc391)",
+ "prost",
  "prost-types",
  "tempfile",
  "which",
@@ -2069,18 +2054,6 @@ checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
 dependencies = [
  "anyhow",
  "itertools 0.8.2",
- "proc-macro2 1.0.24",
- "quote 1.0.4",
- "syn 1.0.54",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.6.1"
-source = "git+https://github.com/danburkert/prost?rev=423f5ec5bd165a7007a388edfb2b485d5bbf40c7#423f5ec5bd165a7007a388edfb2b485d5bbf40c7"
-dependencies = [
- "anyhow",
- "itertools 0.9.0",
  "proc-macro2 1.0.24",
  "quote 1.0.4",
  "syn 1.0.54",
@@ -2103,8 +2076,8 @@ name = "prost-types"
 version = "0.6.1"
 source = "git+https://github.com/danburkert/prost?rev=a1cccbcee343e2c444e1cd2738c7fba2599fc391#a1cccbcee343e2c444e1cd2738c7fba2599fc391"
 dependencies = [
- "bytes 0.5.4",
- "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=a1cccbcee343e2c444e1cd2738c7fba2599fc391)",
+ "bytes",
+ "prost",
 ]
 
 [[package]]
@@ -2113,7 +2086,7 @@ version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da78e04bc0e40f36df43ecc6575e4f4b180e8156c4efd73f13d5619479b05696"
 dependencies = [
- "bytes 0.5.4",
+ "bytes",
 ]
 
 [[package]]
@@ -2413,7 +2386,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b81e49ddec5109a9dcfc5f2a317ff53377c915e9ae9d4f2fb50914b85614e2"
 dependencies = [
  "base64 0.11.0",
- "bytes 0.5.4",
+ "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -2736,7 +2709,7 @@ dependencies = [
 name = "sharded_lmdb"
 version = "0.0.1"
 dependencies = [
- "bytes 0.5.4",
+ "bytes",
  "fs",
  "futures 0.3.5",
  "hashing",
@@ -2818,7 +2791,7 @@ dependencies = [
  "async-trait",
  "bazel_protos",
  "boxfuture",
- "bytes 0.5.4",
+ "bytes",
  "concrete_time",
  "criterion",
  "fs",
@@ -2835,7 +2808,7 @@ dependencies = [
  "mock",
  "num_cpus",
  "parking_lot",
- "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=a1cccbcee343e2c444e1cd2738c7fba2599fc391)",
+ "prost",
  "prost-types",
  "serde",
  "serde_derive",
@@ -2950,11 +2923,11 @@ version = "0.0.1"
 dependencies = [
  "async-stream",
  "bazel_protos",
- "bytes 0.5.4",
+ "bytes",
  "fs",
  "grpc_util",
  "hashing",
- "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=a1cccbcee343e2c444e1cd2738c7fba2599fc391)",
+ "prost",
 ]
 
 [[package]]
@@ -3008,7 +2981,7 @@ version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6d7ad61edd59bfcc7e80dababf0f4aed2e6d5e0ba1659356ae889752dfc12ff"
 dependencies = [
- "bytes 0.5.4",
+ "bytes",
  "fnv",
  "futures-core",
  "iovec",
@@ -3067,7 +3040,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
 dependencies = [
- "bytes 0.5.4",
+ "bytes",
  "futures-core",
  "futures-sink",
  "log 0.4.8",
@@ -3081,7 +3054,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes 0.5.4",
+ "bytes",
  "futures-core",
  "futures-sink",
  "log 0.4.8",
@@ -3107,7 +3080,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.12.3",
- "bytes 0.5.4",
+ "bytes",
  "futures-core",
  "futures-util",
  "http",
@@ -3115,7 +3088,7 @@ dependencies = [
  "hyper",
  "percent-encoding",
  "pin-project",
- "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=a1cccbcee343e2c444e1cd2738c7fba2599fc391)",
+ "prost",
  "prost-derive 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls-native-certs 0.4.0",
  "tokio",

--- a/src/rust/engine/concrete_time/Cargo.toml
+++ b/src/rust/engine/concrete_time/Cargo.toml
@@ -6,7 +6,7 @@ name = "concrete_time"
 publish = false
 
 [dependencies]
-prost = { git = "https://github.com/danburkert/prost", rev = "423f5ec5bd165a7007a388edfb2b485d5bbf40c7" }
+prost = { git = "https://github.com/danburkert/prost", rev = "a1cccbcee343e2c444e1cd2738c7fba2599fc391" }
 prost-types = "0.6"
 serde_derive = "1.0.98"
 serde = "1.0.98"


### PR DESCRIPTION
### Problem

Landed https://github.com/pantsbuild/pants/pull/11342 without updating the `prost` crate version in the `concrete_time` crate.

### Solution

Update the revision to conform.

### Result

Existing tests pass.
