### PR TITLE
Provide a peek goal to easily view BUILD metadata from command line

### DIFF
--- a/src/python/pants/backend/project_info/peek.py
+++ b/src/python/pants/backend/project_info/peek.py
@@ -1,0 +1,76 @@
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from enum import Enum
+from typing import Iterable, cast
+
+from pants.engine.addresses import Address, Addresses, BuildFileAddress
+from pants.engine.console import Console
+from pants.engine.fs import DigestContents, PathGlobs
+from pants.engine.goal import Goal, GoalSubsystem
+from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
+from pants.engine.target import Target, Targets
+
+
+class OutputOptions(Enum):
+    RAW = "raw"
+    JSON = "json"
+
+
+class PeekSubsystem(GoalSubsystem):
+    """Display BUILD file info to the console.
+
+    In its most basic form, `peek` just prints the contents of a BUILD file. It can also display
+    multiple BUILD files, or render normalized target metadata as JSON for consumption by other
+    programs.
+    """
+
+    name = "peek"
+
+    @classmethod
+    def register_options(cls, register):
+        super().register_options(register)
+        register(
+            "--output",
+            type=OutputOptions,
+            default=OutputOptions.RAW,
+            help="which output style peek should use",
+        )
+
+    @property
+    def output(self) -> OutputOptions:
+        return cast(OutputOptions, self.options.output)
+
+
+class Peek(Goal):
+    subsystem_cls = PeekSubsystem
+
+
+@goal_rule
+async def peek(
+    console: Console,
+    subsys: PeekSubsystem,
+    addresses: Addresses,
+) -> Peek:
+    # TODO: better options for target selection (globs, transitive, etc)?
+    targets: Iterable[Target]
+    targets = await Get(Targets, Addresses, addresses)
+    build_file_addresses = await MultiGet(
+        Get(BuildFileAddress, Address, t.address) for t in targets
+    )
+    build_file_paths = {a.rel_path for a in build_file_addresses}
+    digests = await Get(DigestContents, PathGlobs(build_file_paths))
+
+    # TODO: programmatically determine correct encoding
+    encoding = "utf-8"
+    if len(digests) == 1:
+        content = digests[0].content.decode(encoding)
+        console.print_stdout(content)
+    else:
+        raise NotImplementedError("do it")
+
+    return Peek(exit_code=0)
+
+
+def rules():
+    return collect_rules()

--- a/src/python/pants/backend/project_info/peek.py
+++ b/src/python/pants/backend/project_info/peek.py
@@ -1,12 +1,14 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import os
 from enum import Enum
-from typing import Iterable, cast
+from itertools import repeat
+from typing import Iterable, TypeVar, Union, cast
 
 from pants.engine.addresses import Address, Addresses, BuildFileAddress
 from pants.engine.console import Console
-from pants.engine.fs import DigestContents, PathGlobs
+from pants.engine.fs import DigestContents, FileContent, PathGlobs
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
 from pants.engine.target import Target, Targets
@@ -46,6 +48,32 @@ class Peek(Goal):
     subsystem_cls = PeekSubsystem
 
 
+_T = TypeVar("_T")
+_U = TypeVar("_U")
+
+_nothing = object()
+
+
+def _intersperse(x: _T, ys: Iterable[_U]) -> Iterable[Union[_T, _U]]:
+    it = iter(ys)
+    y = next(it, _nothing)
+    if y is _nothing:
+        return
+    yield cast(_U, y)
+    for x, y in zip(repeat(x), ys):
+        yield x
+        yield y
+
+
+def _render_raw(fc: FileContent, encoding: str = "utf-8") -> str:
+    dashes = "-" * len(fc.path)
+    content = fc.content.decode(encoding)
+    parts = [dashes, fc.path, dashes, content]
+    if not content.endswith(os.linesep):
+        parts.append("")
+    return os.linesep.join(parts)
+
+
 @goal_rule
 async def peek(
     console: Console,
@@ -59,15 +87,12 @@ async def peek(
         Get(BuildFileAddress, Address, t.address) for t in targets
     )
     build_file_paths = {a.rel_path for a in build_file_addresses}
-    digests = await Get(DigestContents, PathGlobs(build_file_paths))
+    digest_contents = await Get(DigestContents, PathGlobs(build_file_paths))
 
     # TODO: programmatically determine correct encoding
-    encoding = "utf-8"
-    if len(digests) == 1:
-        content = digests[0].content.decode(encoding)
-        console.print_stdout(content)
-    else:
-        raise NotImplementedError("do it")
+    rendereds = map(_render_raw, digest_contents)
+    for output in _intersperse("\n\n", rendereds):
+        console.print_stdout(output)
 
     return Peek(exit_code=0)
 

--- a/src/python/pants/backend/project_info/peek.py
+++ b/src/python/pants/backend/project_info/peek.py
@@ -83,7 +83,7 @@ def _render_raw_build_file(fc: FileContent, encoding: str = "utf-8") -> str:
 
 def _render_json(ts: Iterable[Target], exclude_defaults: bool = False) -> str:
     targets = [_target_to_dict(t, exclude_defaults) for t in ts]
-    data = dict(targets=targets)
+    data = dict(targets=targets, excludeDefaults=exclude_defaults)
     return json.dumps(data, indent=2, cls=_PeekJsonEncoder)
 
 

--- a/src/python/pants/backend/project_info/peek.py
+++ b/src/python/pants/backend/project_info/peek.py
@@ -1,12 +1,13 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import collections.abc
 import json
 import os
 from dataclasses import asdict, is_dataclass
 from enum import Enum
 from itertools import repeat
-from typing import Iterable, Mapping, Tuple, TypeVar, Union, cast
+from typing import Iterable, Tuple, TypeVar, Union, cast
 
 from pkg_resources import Requirement
 
@@ -39,7 +40,7 @@ class PeekSubsystem(GoalSubsystem):
         register(
             "--output",
             type=OutputOptions,
-            default=OutputOptions.RAW,
+            default=OutputOptions.JSON,
             help="which output style peek should use",
         )
 
@@ -104,8 +105,10 @@ class _PeekJsonEncoder(json.JSONEncoder):
         """Return a serializable object for o."""
         if is_dataclass(o):
             return asdict(o)
-        elif isinstance(o, Mapping):
+        elif isinstance(o, collections.abc.Mapping):
             return dict(o)
+        elif isinstance(o, collections.abc.Sequence):
+            return list(o)
         elif isinstance(o, self.safe_to_str_types):
             return str(o)
         else:

--- a/src/python/pants/backend/project_info/peek.py
+++ b/src/python/pants/backend/project_info/peek.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import collections.abc
@@ -10,7 +10,7 @@ from typing import Any, Iterable, Mapping, cast
 
 from pkg_resources import Requirement
 
-from pants.engine.addresses import Address, Addresses, BuildFileAddress
+from pants.engine.addresses import Address, BuildFileAddress
 from pants.engine.console import Console
 from pants.engine.fs import DigestContents, FileContent, PathGlobs
 from pants.engine.goal import Goal, GoalSubsystem, Outputting
@@ -130,11 +130,8 @@ class _PeekJsonEncoder(json.JSONEncoder):
 async def peek(
     console: Console,
     subsys: PeekSubsystem,
-    addresses: Addresses,
+    targets: UnexpandedTargets,
 ) -> Peek:
-    targets: Iterable[Target]
-    targets = await Get(UnexpandedTargets, Addresses, addresses)
-
     if subsys.output_type == OutputOptions.RAW:
         build_file_addresses = await MultiGet(
             Get(BuildFileAddress, Address, t.address) for t in targets

--- a/src/python/pants/backend/project_info/peek.py
+++ b/src/python/pants/backend/project_info/peek.py
@@ -104,8 +104,7 @@ def _render_json(ts: Iterable[Target], exclude_defaults: bool = False) -> str:
         }
         for t in ts
     ]
-    data = dict(targets=targets, excludeDefaults=exclude_defaults)
-    return json.dumps(data, indent=2, cls=_PeekJsonEncoder)
+    return f"{json.dumps(targets, indent=2, cls=_PeekJsonEncoder)}\n"
 
 
 class _PeekJsonEncoder(json.JSONEncoder):

--- a/src/python/pants/backend/project_info/peek.py
+++ b/src/python/pants/backend/project_info/peek.py
@@ -32,6 +32,7 @@ class PeekSubsystem(Outputting, GoalSubsystem):
     """
 
     name = "peek"
+    help = "Display BUILD target info"
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/project_info/peek_test.py
+++ b/src/python/pants/backend/project_info/peek_test.py
@@ -1,12 +1,13 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import pytest
 from textwrap import dedent
 
-from pants.core.target_types import Files
+import pytest
+
 from pants.backend.project_info import peek
 from pants.backend.project_info.peek import Peek
+from pants.core.target_types import Files
 from pants.testutil.rule_runner import RuleRunner
 
 

--- a/src/python/pants/backend/project_info/peek_test.py
+++ b/src/python/pants/backend/project_info/peek_test.py
@@ -1,0 +1,30 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import pytest
+from textwrap import dedent
+
+from pants.core.target_types import Files
+from pants.backend.project_info import peek
+from pants.backend.project_info.peek import Peek
+from pants.testutil.rule_runner import RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(rules=peek.rules(), target_types=[Files])
+
+
+def test_example(rule_runner: RuleRunner) -> None:
+    rule_runner.add_to_build_file("project", "# A comment\nfiles(sources=[])")
+    result = rule_runner.run_goal_rule(Peek, args=["project"])
+    assert result.stdout == dedent(
+        """\
+        -------------
+        project/BUILD
+        -------------
+        # A comment
+        files(sources=[])
+
+        """
+    )

--- a/src/python/pants/backend/project_info/peek_test.py
+++ b/src/python/pants/backend/project_info/peek_test.py
@@ -7,7 +7,8 @@ import pytest
 
 from pants.backend.project_info import peek
 from pants.backend.project_info.peek import Peek
-from pants.core.target_types import Files
+from pants.core.target_types import ArchiveTarget, Files
+from pants.engine.addresses import Address
 from pants.testutil.rule_runner import RuleRunner
 
 
@@ -18,16 +19,86 @@ from pants.testutil.rule_runner import RuleRunner
             [],
             False,
             "[]\n",
-            # dedent(
-            #     """\
-            #     {
-            #       "targets": [],
-            #       "excludeDefaults": false
-            #     }
-            #     """
-            # ),
             id="null-case",
-        )
+        ),
+        pytest.param(
+            [Files({"sources": []}, Address("example", target_name="files_target"))],
+            True,
+            dedent(
+                """\
+                [
+                  {
+                    "address": "example:files_target",
+                    "target_type": "files",
+                    "sources": []
+                  }
+                ]
+                """
+            ),
+            id="single-files-target/exclude-defaults",
+        ),
+        pytest.param(
+            [Files({"sources": []}, Address("example", target_name="files_target"))],
+            False,
+            dedent(
+                """\
+                [
+                  {
+                    "address": "example:files_target",
+                    "target_type": "files",
+                    "dependencies": null,
+                    "description": null,
+                    "sources": [],
+                    "tags": null
+                  }
+                ]
+                """
+            ),
+            id="single-files-target/include-defaults",
+        ),
+        pytest.param(
+            [
+                Files(
+                    {"sources": ["*.txt"], "tags": ["zippable"]},
+                    Address("example", target_name="files_target"),
+                ),
+                ArchiveTarget(
+                    {
+                        "output_path": "my-archive.zip",
+                        "format": "zip",
+                        "files": ["example:files_target"],
+                    },
+                    Address("example", target_name="archive_target"),
+                ),
+            ],
+            True,
+            dedent(
+                """\
+                [
+                  {
+                    "address": "example:files_target",
+                    "target_type": "files",
+                    "sources": [
+                      "*.txt"
+                    ],
+                    "tags": [
+                      "zippable"
+                    ]
+                  },
+                  {
+                    "address": "example:archive_target",
+                    "target_type": "archive",
+                    "files": [
+                      "example:files_target"
+                    ],
+                    "format": "zip",
+                    "output_path": "my-archive.zip"
+                  }
+                ]
+                """
+            ),
+            id="single-files-target/exclude-defaults",
+        ),
     ],
 )
 def test_render_targets_as_json(targets, exclude_defaults, expected_output):
@@ -42,7 +113,7 @@ def rule_runner() -> RuleRunner:
 
 def test_raw_output_single_build_file(rule_runner: RuleRunner) -> None:
     rule_runner.add_to_build_file("project", "# A comment\nfiles(sources=[])")
-    result = rule_runner.run_goal_rule(Peek, args=[ "--output=raw", "project"])
+    result = rule_runner.run_goal_rule(Peek, args=["--output=raw", "project"])
     expected_output = dedent(
         """\
         -------------
@@ -58,7 +129,7 @@ def test_raw_output_single_build_file(rule_runner: RuleRunner) -> None:
 def test_raw_output_two_build_files(rule_runner: RuleRunner) -> None:
     rule_runner.add_to_build_file("project1", "# A comment\nfiles(sources=[])")
     rule_runner.add_to_build_file("project2", "# Another comment\nfiles(sources=[])")
-    result = rule_runner.run_goal_rule(Peek, args=[ "--output=raw", "project1", "project2"])
+    result = rule_runner.run_goal_rule(Peek, args=["--output=raw", "project1", "project2"])
     expected_output = dedent(
         """\
         --------------

--- a/src/python/pants/backend/project_info/peek_test.py
+++ b/src/python/pants/backend/project_info/peek_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from textwrap import dedent

--- a/src/python/pants/backend/project_info/peek_test.py
+++ b/src/python/pants/backend/project_info/peek_test.py
@@ -11,21 +11,79 @@ from pants.core.target_types import Files
 from pants.testutil.rule_runner import RuleRunner
 
 
+@pytest.mark.parametrize(
+    "targets, exclude_defaults, expected_output",
+    [
+        pytest.param(
+            [],
+            False,
+            "[]\n",
+            # dedent(
+            #     """\
+            #     {
+            #       "targets": [],
+            #       "excludeDefaults": false
+            #     }
+            #     """
+            # ),
+            id="null-case",
+        )
+    ],
+)
+def test_render_targets_as_json(targets, exclude_defaults, expected_output):
+    actual_output = peek._render_json(targets, exclude_defaults)
+    assert actual_output == expected_output
+
+
 @pytest.fixture
 def rule_runner() -> RuleRunner:
     return RuleRunner(rules=peek.rules(), target_types=[Files])
 
 
-def test_example(rule_runner: RuleRunner) -> None:
+def test_raw_output_single_build_file(rule_runner: RuleRunner) -> None:
     rule_runner.add_to_build_file("project", "# A comment\nfiles(sources=[])")
-    result = rule_runner.run_goal_rule(Peek, args=["project"])
-    assert result.stdout == dedent(
+    result = rule_runner.run_goal_rule(Peek, args=[ "--output=raw", "project"])
+    expected_output = dedent(
         """\
         -------------
         project/BUILD
         -------------
         # A comment
         files(sources=[])
-
         """
     )
+    assert result.stdout == expected_output
+
+
+def test_raw_output_two_build_files(rule_runner: RuleRunner) -> None:
+    rule_runner.add_to_build_file("project1", "# A comment\nfiles(sources=[])")
+    rule_runner.add_to_build_file("project2", "# Another comment\nfiles(sources=[])")
+    result = rule_runner.run_goal_rule(Peek, args=[ "--output=raw", "project1", "project2"])
+    expected_output = dedent(
+        """\
+        --------------
+        project1/BUILD
+        --------------
+        # A comment
+        files(sources=[])
+
+        --------------
+        project2/BUILD
+        --------------
+        # Another comment
+        files(sources=[])
+        """
+    )
+    assert result.stdout == expected_output
+
+
+def test_raw_output_non_matching_build_target(rule_runner: RuleRunner) -> None:
+    rule_runner.add_to_build_file("some_name", "files(sources=[])")
+    result = rule_runner.run_goal_rule(Peek, args=["--output=raw", "other_name"])
+    assert result.stdout == ""
+
+
+def test_standard_json_output_non_matching_build_target(rule_runner: RuleRunner) -> None:
+    rule_runner.add_to_build_file("some_name", "files(sources=[])")
+    result = rule_runner.run_goal_rule(Peek, args=["other_name"])
+    assert result.stdout == "[]\n"

--- a/src/python/pants/backend/project_info/register.py
+++ b/src/python/pants/backend/project_info/register.py
@@ -11,6 +11,7 @@ from pants.backend.project_info import (
     filter_targets,
     list_roots,
     list_targets,
+    peek,
     source_file_validator,
 )
 
@@ -24,5 +25,6 @@ def rules():
         *filter_targets.rules(),
         *list_roots.rules(),
         *list_targets.rules(),
+        *peek.rules(),
         *source_file_validator.rules(),
     ]


### PR DESCRIPTION
### Problem

It would be convenient to have pants able to export build metadata, either for human consumption or programmatic consumption. This seems to be the essence of issue #4861, which the PR addresses.

### Solution

This PR adds a new `peek` goal, which allows us to look at the BUILD files for given targets. 
