### PR TITLE
Expose --resolver-version, deprecate --cache-ttl.

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -61,6 +61,7 @@ root_patterns = [
 ]
 
 [python-setup]
+resolver_version = "pip-2020-resolver"
 requirement_constraints = "3rdparty/python/constraints.txt"
 resolve_all_constraints = "nondeployables"
 interpreter_constraints = [">=3.7,<3.9"]

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -12,7 +12,10 @@ class Flake8(PythonToolBase):
 
     options_scope = "flake8"
     default_version = "flake8>=3.7.9,<3.9"
-    default_extra_requirements = ["setuptools<45"]  # NB: `<45` is for Python 2 support
+    default_extra_requirements = [
+        "setuptools<45; python_full_version == '2.7.*'",
+        "setuptools; python_version > '2.7'",
+    ]
     default_entry_point = "flake8"
 
     @classmethod

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -497,8 +497,8 @@ async def create_pex(
         "--no-pypi",
         *(f"--index={index}" for index in python_repos.indexes),
         *(f"--repo={repo}" for repo in python_repos.repos),
-        "--cache-ttl",
-        str(python_setup.resolver_http_cache_ttl),
+        "--resolver-version",
+        python_setup.resolver_version.value,
         *request.additional_args,
     ]
 


### PR DESCRIPTION
Update to the new and deprecated features of Pex 2.1.24 by exposing
--resolver-version and deprecating --cache-ttl. For now we keep the
pip-legacy-resolver default for --resolver-version, but encourage users
migrating to the pip-2020-resolver.

[ci skip-rust]
[ci skip-build-wheels]