### PR TITLE
Support deprecation_start_version in help info.

### DIFF
--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -47,6 +47,10 @@ class BadDecoratorNestingError(DeprecationApplicationError):
     """Indicates the @deprecated decorator was innermost in a sequence of layered decorators."""
 
 
+def is_deprecation_active(deprecation_start_version: Optional[str]) -> bool:
+    return deprecation_start_version is None or Version(deprecation_start_version) <= PANTS_SEMVER
+
+
 def get_deprecated_tense(
     removal_version: str, future_tense: str = "will be", past_tense: str = "was"
 ) -> str:

--- a/src/python/pants/base/deprecated_test.py
+++ b/src/python/pants/base/deprecated_test.py
@@ -18,6 +18,7 @@ from pants.base.deprecated import (
     deprecated,
     deprecated_conditional,
     deprecated_module,
+    is_deprecation_active,
     resolve_conflicting_options,
     warn_or_error,
 )
@@ -295,3 +296,9 @@ def test_resolve_conflicting_options() -> None:
         option_resolved(old_configured=True, new_configured=True)
     assert "--old-scope-my-opt" in str(e.value)
     assert "--new-scope-my-opt" in str(e.value)
+
+
+def test_is_deprecation_active() -> None:
+    assert is_deprecation_active(deprecation_start_version=None)
+    assert is_deprecation_active(deprecation_start_version="1.0.0")
+    assert not is_deprecation_active(deprecation_start_version=FUTURE_VERSION)

--- a/src/python/pants/help/help_formatter.py
+++ b/src/python/pants/help/help_formatter.py
@@ -122,7 +122,8 @@ class HelpFormatter(MaybeColor):
             *description_lines,
         ]
         if ohi.deprecated_message:
-            lines.append(self.maybe_red(f"{indent}{ohi.deprecated_message}"))
+            maybe_colorize = self.maybe_red if ohi.deprecation_active else self.maybe_yellow
+            lines.append(maybe_colorize(f"{indent}{ohi.deprecated_message}"))
             if ohi.removal_hint:
-                lines.append(self.maybe_red(f"{indent}{ohi.removal_hint}"))
+                lines.append(maybe_colorize(f"{indent}{ohi.removal_hint}"))
         return lines

--- a/src/python/pants/help/help_formatter_test.py
+++ b/src/python/pants/help/help_formatter_test.py
@@ -26,6 +26,7 @@ class OptionHelpFormatterTest(unittest.TestCase):
             typ=bool,
             default=None,
             help="help for foo",
+            deprecation_active=False,
             deprecated_message=None,
             removal_version=None,
             removal_hint=None,

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -152,6 +152,27 @@ def test_deprecated():
     assert "999.99.9" == ohi.removal_version
     assert "do not use this" == ohi.removal_hint
     assert ohi.deprecated_message is not None
+    assert ohi.deprecation_active
+
+
+def test_not_deprecated():
+    ohi = HelpInfoExtracter("").get_option_help_info(["--foo"], {})
+    assert ohi.removal_version is None
+    assert not ohi.deprecation_active
+
+
+def test_deprecation_start_version_past():
+    kwargs = {"deprecation_start_version": "1.0.0", "removal_version": "999.99.9"}
+    ohi = HelpInfoExtracter("").get_option_help_info(["--foo"], kwargs)
+    assert "999.99.9" == ohi.removal_version
+    assert ohi.deprecation_active
+
+
+def test_deprecation_start_version_future():
+    kwargs = {"deprecation_start_version": "999.99.8", "removal_version": "999.99.9"}
+    ohi = HelpInfoExtracter("").get_option_help_info(["--foo"], kwargs)
+    assert "999.99.9" == ohi.removal_version
+    assert not ohi.deprecation_active
 
 
 def test_passthrough():
@@ -297,6 +318,7 @@ def test_get_all_help_info():
                         "typ": int,
                         "default": 42,
                         "help": "Option 1",
+                        "deprecation_active": False,
                         "deprecated_message": None,
                         "removal_version": None,
                         "removal_hint": None,
@@ -328,6 +350,7 @@ def test_get_all_help_info():
                         "typ": bool,
                         "default": True,
                         "help": "Option 2",
+                        "deprecation_active": False,
                         "deprecated_message": None,
                         "removal_version": None,
                         "removal_hint": None,
@@ -349,6 +372,7 @@ def test_get_all_help_info():
                         "typ": str,
                         "default": None,
                         "help": "No help available.",
+                        "deprecation_active": False,
                         "deprecated_message": None,
                         "removal_version": None,
                         "removal_hint": None,

--- a/src/python/pants/help/maybe_color.py
+++ b/src/python/pants/help/maybe_color.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from colors import cyan, green, magenta, red
+from colors import cyan, green, magenta, red, yellow
 
 
 class MaybeColor:
@@ -14,6 +14,7 @@ class MaybeColor:
         self.maybe_green = green if color else noop
         self.maybe_red = red if color else noop
         self.maybe_magenta = magenta if color else noop
+        self.maybe_yellow = yellow if color else noop
 
     @property
     def color(self) -> bool:


### PR DESCRIPTION
Display a warning for upcoming (inactive) deprecations instead of
displaying an error (red text) and incorrectly categorizing the upcoming
deprecation as a current one.

[ci skip-rust]
[ci skip-build-wheels]