### PR TITLE
restore some try_future uses that were recently removed

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -2805,6 +2805,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.14.1",
  "tonic",
+ "tryfuture",
  "uuid",
  "walkdir 2.3.1",
  "workunit_store",

--- a/src/rust/engine/fs/store/Cargo.toml
+++ b/src/rust/engine/fs/store/Cargo.toml
@@ -30,6 +30,7 @@ task_executor = { path = "../../task_executor" }
 tempfile = "3"
 tokio-rustls = "0.14"
 tonic = { version = "0.3", features = ["transport", "codegen", "tls", "tls-roots", "prost"] }
+tryfuture = { path = "../../tryfuture" }
 uuid = { version = "0.7.1", features = ["v4"] }
 workunit_store = {path = "../../workunit_store" }
 


### PR DESCRIPTION
Restore some recently-removed `try_future!` usages now that https://github.com/pantsbuild/pants/pull/11352 has landed and there is a version of the `try_future` macro that works with `futures` v0.3.x.

[ci skip-build-wheels]
