### PR TITLE
Use newlines in `./pants help $target_type`

### DIFF
--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -49,7 +49,7 @@ class PythonAwsLambdaHandlerField(StringField, AsyncFieldMixin, SecondaryOwnerMi
     alias = "handler"
     required = True
     value: str
-    description = (
+    help = (
         "Entry point to the AWS Lambda handler.\n\nYou can specify a full module like "
         "'path.to.module:handler_func' or use a shorthand to specify a file name, using the same "
         "syntax as the `sources` field, e.g. 'lambda.py:handler_func'.\n\nYou must use the file "
@@ -162,7 +162,7 @@ class PythonAwsLambdaRuntime(StringField):
     alias = "runtime"
     required = True
     value: str
-    description = (
+    help = (
         "The identifier of the AWS Lambda runtime to target (pythonX.Y). See "
         "https://docs.aws.amazon.com/lambda/latest/dg/lambda-python.html."
     )
@@ -204,7 +204,7 @@ class PythonAWSLambda(Target):
         PythonAwsLambdaHandlerField,
         PythonAwsLambdaRuntime,
     )
-    description = (
+    help = (
         "A self-contained Python function suitable for uploading to AWS Lambda.\n\nSee "
         "https://www.pantsbuild.org/docs/awslambda-python."
     )

--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -46,17 +46,15 @@ class PythonAwsLambdaSources(PythonSources):
 
 
 class PythonAwsLambdaHandlerField(StringField, AsyncFieldMixin, SecondaryOwnerMixin):
-    """Entry point to the AWS Lambda handler.
-
-    You can specify a full module like 'path.to.module:handler_func' or use a shorthand to specify a
-    file name, using the same syntax as the `sources` field, e.g. 'lambda.py:handler_func'.
-
-    You must use the file name shorthand for file arguments to work with this target.
-    """
-
     alias = "handler"
     required = True
     value: str
+    description = (
+        "Entry point to the AWS Lambda handler.\n\nYou can specify a full module like "
+        "'path.to.module:handler_func' or use a shorthand to specify a file name, using the same "
+        "syntax as the `sources` field, e.g. 'lambda.py:handler_func'.\n\nYou must use the file "
+        "name shorthand for file arguments to work with this target."
+    )
 
     @classmethod
     def compute_value(cls, raw_value: Optional[str], *, address: Address) -> str:
@@ -159,16 +157,15 @@ async def inject_lambda_handler_dependency(
 
 
 class PythonAwsLambdaRuntime(StringField):
-    """The identifier of the AWS Lambda runtime to target (pythonX.Y).
-
-    See https://docs.aws.amazon.com/lambda/latest/dg/lambda-python.html.
-    """
-
     PYTHON_RUNTIME_REGEX = r"python(?P<major>\d)\.(?P<minor>\d+)"
 
     alias = "runtime"
     required = True
     value: str
+    description = (
+        "The identifier of the AWS Lambda runtime to target (pythonX.Y). See "
+        "https://docs.aws.amazon.com/lambda/latest/dg/lambda-python.html."
+    )
 
     @classmethod
     def compute_value(cls, raw_value: Optional[str], *, address: Address) -> str:
@@ -197,11 +194,6 @@ class DeprecatedAwsLambdaInterpreterConstraints(InterpreterConstraintsField):
 
 
 class PythonAWSLambda(Target):
-    """A self-contained Python function suitable for uploading to AWS Lambda.
-
-    See https://www.pantsbuild.org/docs/awslambda-python.
-    """
-
     alias = "python_awslambda"
     core_fields = (
         *COMMON_TARGET_FIELDS,
@@ -211,6 +203,10 @@ class PythonAWSLambda(Target):
         PythonAwsLambdaDependencies,
         PythonAwsLambdaHandlerField,
         PythonAwsLambdaRuntime,
+    )
+    description = (
+        "A self-contained Python function suitable for uploading to AWS Lambda.\n\nSee "
+        "https://www.pantsbuild.org/docs/awslambda-python."
     )
 
 

--- a/src/python/pants/backend/codegen/protobuf/python/additional_fields.py
+++ b/src/python/pants/backend/codegen/protobuf/python/additional_fields.py
@@ -12,7 +12,7 @@ class ProtobufPythonInterpreterConstraints(InterpreterConstraintsField):
 
 class PythonSourceRootField(StringField):
     alias = "python_source_root"
-    description = (
+    help = (
         "The source root to generate Python sources under.\n\nIf unspecified, the source root the "
         "protobuf_library is under will be used."
     )

--- a/src/python/pants/backend/codegen/protobuf/python/additional_fields.py
+++ b/src/python/pants/backend/codegen/protobuf/python/additional_fields.py
@@ -11,12 +11,11 @@ class ProtobufPythonInterpreterConstraints(InterpreterConstraintsField):
 
 
 class PythonSourceRootField(StringField):
-    """The source root to generate Python sources under.
-
-    If unspecified, the source root the protobuf_library is under will be used.
-    """
-
     alias = "python_source_root"
+    description = (
+        "The source root to generate Python sources under.\n\nIf unspecified, the source root the "
+        "protobuf_library is under will be used."
+    )
 
 
 def rules():

--- a/src/python/pants/backend/codegen/protobuf/target_types.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types.py
@@ -16,17 +16,15 @@ class ProtobufSources(Sources):
 
 
 class ProtobufGrpcToggle(BoolField):
-    """Whether to generate gRPC code or not."""
-
     alias = "grpc"
     default = False
+    description = "Whether to generate gRPC code or not."
 
 
 class ProtobufLibrary(Target):
-    """Protobuf files used to generate various languages.
-
-    See https://www.pantsbuild.org/docs/protobuf.
-    """
-
     alias = "protobuf_library"
     core_fields = (*COMMON_TARGET_FIELDS, ProtobufDependencies, ProtobufSources, ProtobufGrpcToggle)
+    description = (
+        "Protobuf files used to generate various languages.\n\nSee "
+        "https://www.pantsbuild.org/docs/protobuf."
+    )

--- a/src/python/pants/backend/codegen/protobuf/target_types.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types.py
@@ -18,13 +18,13 @@ class ProtobufSources(Sources):
 class ProtobufGrpcToggle(BoolField):
     alias = "grpc"
     default = False
-    description = "Whether to generate gRPC code or not."
+    help = "Whether to generate gRPC code or not."
 
 
 class ProtobufLibrary(Target):
     alias = "protobuf_library"
     core_fields = (*COMMON_TARGET_FIELDS, ProtobufDependencies, ProtobufSources, ProtobufGrpcToggle)
-    description = (
+    help = (
         "Protobuf files used to generate various languages.\n\nSee "
         "https://www.pantsbuild.org/docs/protobuf."
     )

--- a/src/python/pants/backend/python/lint/pylint/plugin_target_type.py
+++ b/src/python/pants/backend/python/lint/pylint/plugin_target_type.py
@@ -9,54 +9,26 @@ class PylintPluginSources(PythonSources):
     required = True
 
 
-# NB: We solely subclass this to change the docstring.
 class PylintPluginDependencies(Dependencies):
-    """Addresses to other targets that this plugin depends on.
-
-    Due to restrictions with Pylint plugins, these targets must either be third-party Python
-    dependencies (https://www.pantsbuild.org/docs/python-third-party-dependencies) or be located
-    within this target's same directory or a subdirectory.
-    """
+    help = (
+        "Addresses to other targets that this plugin depends on.\n\nDue to restrictions with "
+        "Pylint plugins, these targets must either be third-party Python dependencies "
+        "(https://www.pantsbuild.org/docs/python-third-party-dependencies) or be located within "
+        "this target's same directory or a subdirectory."
+    )
 
 
 class PylintSourcePlugin(Target):
-    """A Pylint plugin loaded through source code.
-
-    To load a source plugin:
-
-        1. Write your plugin. See http://pylint.pycqa.org/en/latest/how_tos/plugins.html.
-        2. Define a `pylint_source_plugin` target with the plugin's Python file(s) included in the
-            `sources` field.
-        3. Add the parent directory of your target to the `root_patterns` option in the `[source]`
-            scope. For example, if your plugin is at `build-support/pylint/custom_plugin.py`, add
-            'build-support/pylint'. This is necessary for Pants to know how to tell Pylint to
-            discover your plugin. See https://www.pantsbuild.org/docs/source-roots.
-        4. Add `load-plugins=$module_name` to your Pylint config file. For example, if your Python
-            file is called `custom_plugin.py`, set `load-plugins=custom_plugin`. Set the `config`
-            option in the `[pylint]` scope to point to your Pylint config file.
-        5. Set the option `source_plugins` in the `[pylint]` scope to include this target's
-            address, e.g. `source_plugins = ["build-support/pylint:plugin"]`.
-
-    To instead load a third-party plugin, set the option `extra_requirements` in the `[pylint]`
-    scope (see https://www.pantsbuild.org/docs/python-linters-and-formatters). Set `load-plugins` in
-    your config file, like you'd do with a source plugin.
-
-    This target type is treated similarly to a `python_library` target. For example, Python linters
-    and formatters will run on this target.
-
-    You can include other targets in the `dependencies` field, so long as those targets are
-    third-party dependencies or are located in the same directory or a subdirectory.
-
-    Other targets can depend on this target. This allows you to write a `python_tests` target for
-    this code or a `python_distribution` target to distribute the plugin externally.
-    """
-
     alias = "pylint_source_plugin"
     core_fields = (
         *COMMON_TARGET_FIELDS,
         InterpreterConstraintsField,
         PylintPluginDependencies,
         PylintPluginSources,
+    )
+    help = (
+        "A Pylint plugin loaded through source code.\n\nRun `./pants help-advanced pylint` for "
+        "instructions with the `--source-plugins` option."
     )
 
     deprecated_removal_version = "2.3.0.dev0"

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -47,7 +47,7 @@ class PythonSources(Sources):
 
 class InterpreterConstraintsField(StringSequenceField):
     alias = "interpreter_constraints"
-    description = (
+    help = (
         "The Python interpreters this code is compatible with.\n\nEach element should be written "
         "in pip-style format, e.g. 'CPython==2.7.*' or 'CPython>=3.6,<4'. You can leave off "
         "`CPython` as a shorthand, e.g. '>=2.7' will be expanded to 'CPython>=2.7'.\n\nSpecify "
@@ -114,7 +114,7 @@ class PexBinaryDependencies(Dependencies):
 
 class PexEntryPointField(StringField, AsyncFieldMixin, SecondaryOwnerMixin):
     alias = "entry_point"
-    description = (
+    help = (
         "The entry point for the binary, i.e. what gets run when executing `./my_binary.pex`.\n\n"
         "You can specify a full module like 'path.to.module' and 'path.to.module:func', or use a "
         "shorthand to specify a file name, using the same syntax as the `sources` field:\n\n    1) "
@@ -150,7 +150,7 @@ class ResolvePexEntryPointRequest:
 
 class PexPlatformsField(StringSequenceField):
     alias = "platforms"
-    description = (
+    help = (
         "The platforms the built PEX should be compatible with.\n\nThis defaults to the current "
         "platform, but can be overridden to different platforms. You can give a list of multiple "
         "platforms to create a multiplatform PEX.\n\nTo use wheels for specific "
@@ -167,7 +167,7 @@ class PexPlatformsField(StringSequenceField):
 class PexInheritPathField(StringField):
     alias = "inherit_path"
     valid_choices = ("false", "fallback", "prefer")
-    description = (
+    help = (
         "Whether to inherit the `sys.path` (aka PYTHONPATH) of the environment that the binary "
         "runs in.\n\nUse `false` to not inherit `sys.path`; use `fallback` to inherit `sys.path` "
         "after packaged dependencies; and use `prefer` to inherit `sys.path` before packaged "
@@ -188,7 +188,7 @@ class PexZipSafeField(BoolField):
     alias = "zip_safe"
     default = True
     value: bool
-    description = (
+    help = (
         "Whether or not this binary is safe to run in compacted (zip-file) form.\n\nIf the PEX is "
         "not zip safe, it will be written to disk prior to execution. You may need to mark "
         "`zip_safe=False` if you're having issues loading your code."
@@ -199,7 +199,7 @@ class PexAlwaysWriteCacheField(BoolField):
     alias = "always_write_cache"
     default = False
     value: bool
-    description = (
+    help = (
         "Whether PEX should always write the .deps cache of the .pex file to disk or not. This "
         "can use less memory in RAM-constrained environments."
     )
@@ -209,12 +209,12 @@ class PexIgnoreErrorsField(BoolField):
     alias = "ignore_errors"
     default = False
     value: bool
-    description = "Should PEX ignore when it cannot resolve dependencies?"
+    help = "Should PEX ignore when it cannot resolve dependencies?"
 
 
 class PexShebangField(StringField):
     alias = "shebang"
-    description = (
+    help = (
         "Set the generated PEX to use this shebang, rather than the default of PEX choosing a "
         "shebang based on the interpreter constraints.\n\nThis influences the behavior of running "
         "`./result.pex`. You can ignore the shebang by instead running "
@@ -224,7 +224,7 @@ class PexShebangField(StringField):
 
 class PexEmitWarningsField(BoolField):
     alias = "emit_warnings"
-    description = (
+    help = (
         "Whether or not to emit PEX warnings at runtime.\n\nThe default is determined by the "
         "option `emit_warnings` in the `[pex-binary-defaults]` scope."
     )
@@ -262,7 +262,7 @@ class PexBinary(Target):
         PexShebangField,
         PexEmitWarningsField,
     )
-    description = (
+    help = (
         "A Python target that can be converted into an executable PEX file.\n\nPEX files are "
         "self-contained executable files that contain a complete Python environment capable of "
         "running the target. For more information, see https://www.pantsbuild.org/docs/pex-files."
@@ -292,7 +292,7 @@ class PythonTestsDependencies(Dependencies):
 
 class PythonRuntimePackageDependencies(SpecialCasedDependencies):
     alias = "runtime_package_dependencies"
-    description = (
+    help = (
         "Addresses to targets that can be built with the `./pants package` goal and whose "
         "resulting artifacts should be included in the test run.\n\nPants will build the artifacts "
         "as if you had run `./pants package`. It will include the results in your test's chroot, "
@@ -304,7 +304,7 @@ class PythonRuntimePackageDependencies(SpecialCasedDependencies):
 
 class PythonTestsTimeout(IntField):
     alias = "timeout"
-    description = (
+    help = (
         "A timeout (in seconds) which covers the total runtime of all tests in this target.\n\n"
         "This only applies if the option `--pytest-timeouts` is set to True."
     )
@@ -344,7 +344,7 @@ class PythonTests(Target):
         PythonRuntimePackageDependencies,
         PythonTestsTimeout,
     )
-    description = (
+    help = (
         "Python tests, written in either Pytest style or unittest style.\n\nAll test util code, "
         "other than `conftest.py`, should go into a dedicated `python_library()` target and then "
         "be included in the `dependencies` field.\n\nSee "
@@ -369,7 +369,7 @@ class PythonLibrary(Target):
         Dependencies,
         PythonLibrarySources,
     )
-    description = (
+    help = (
         "Python source code.\n\nA `python_library` does not necessarily correspond to a "
         "distribution you publish (see `python_distribution` and `pex_binary` for that); multiple "
         "`python_library` targets may be packaged into a distribution or binary."
@@ -416,7 +416,7 @@ class PythonRequirementsField(Field):
     alias = "requirements"
     required = True
     value: Tuple[Requirement, ...]
-    description = (
+    help = (
         "A sequence of pip-style requirement strings, e.g. ['foo==1.8', "
         "'bar<=3 ; python_version<'3']."
     )
@@ -461,7 +461,7 @@ class PythonRequirementsField(Field):
 
 class ModuleMappingField(DictStringToStringSequenceField):
     alias = "module_mapping"
-    description = (
+    help = (
         "A mapping of requirement names to a list of the modules they provide.\n\nFor example, "
         '`{"ansicolors": ["colors"]}`. Any unspecified requirements will use the requirement '
         'name as the default module, e.g. "Django" will default to `["django"]`.\n\nThis is '
@@ -472,7 +472,7 @@ class ModuleMappingField(DictStringToStringSequenceField):
 class PythonRequirementLibrary(Target):
     alias = "python_requirement_library"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, PythonRequirementsField, ModuleMappingField)
-    description = (
+    help = (
         "Python requirements installable by pip.\n\nThis target is useful when you want to declare "
         "Python requirements inline in a BUILD file. If you have a `requirements.txt` file "
         "already, you can instead use the macro `python_requirements()` to convert each "
@@ -493,7 +493,7 @@ class PythonRequirementsFileSources(Sources):
 class PythonRequirementsFile(Target):
     alias = "_python_requirements_file"
     core_fields = (*COMMON_TARGET_FIELDS, PythonRequirementsFileSources)
-    description = "A private, helper target type for requirements.txt files."
+    help = "A private, helper target type for requirements.txt files."
 
 
 # -----------------------------------------------------------------------------------------------
@@ -508,10 +508,10 @@ class PythonDistributionDependencies(Dependencies):
 
 class PythonProvidesField(ScalarField, ProvidesField):
     expected_type = PythonArtifact
-    expected_type_description = "setup_py(name='my-dist', **kwargs)"
+    expected_type_help = "setup_py(name='my-dist', **kwargs)"
     value: PythonArtifact
     required = True
-    description = (
+    help = (
         "The setup.py kwargs for the external artifact built from this target.\n\nSee "
         "https://www.pantsbuild.org/docs/python-setup-py-goal."
     )
@@ -525,11 +525,11 @@ class PythonProvidesField(ScalarField, ProvidesField):
 
 class SetupPyCommandsField(StringSequenceField):
     alias = "setup_py_commands"
-    expected_type_description = (
+    expected_type_help = (
         "an iterable of string commands to invoke setup.py with, or "
         "an empty list to just create a chroot with a setup() function."
     )
-    description = (
+    help = (
         "The runtime commands to invoke setup.py with to create the distribution, e.g. "
         '["bdist_wheel", "--python-tag=py36.py37", "sdist"].\n\nIf empty or unspecified, '
         "will just create a chroot with a setup() function.\n\nSee "
@@ -545,4 +545,4 @@ class PythonDistribution(Target):
         PythonProvidesField,
         SetupPyCommandsField,
     )
-    description = "A publishable Python setuptools distribution (e.g. an sdist or wheel)."
+    help = "A publishable Python setuptools distribution (e.g. an sdist or wheel)."

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -46,21 +46,16 @@ class PythonSources(Sources):
 
 
 class InterpreterConstraintsField(StringSequenceField):
-    """The Python interpreters this code is compatible with.
-
-    Each element should be written in pip-style format, e.g. 'CPython==2.7.*' or 'CPython>=3.6,<4'.
-    You can leave off `CPython` as a shorthand, e.g. '>=2.7' will be expanded to 'CPython>=2.7'.
-
-    Specify more than one element to OR the constraints, e.g. `['PyPy==3.7.*', 'CPython==3.7.*']`
-    means either PyPy 3.7 _or_ CPython 3.7.
-
-    If the field is not set, it will default to the option
-    `[python-setup].interpreter_constraints]`.
-
-    See https://www.pantsbuild.org/docs/python-interpreter-compatibility.
-    """
-
     alias = "interpreter_constraints"
+    description = (
+        "The Python interpreters this code is compatible with.\n\nEach element should be written "
+        "in pip-style format, e.g. 'CPython==2.7.*' or 'CPython>=3.6,<4'. You can leave off "
+        "`CPython` as a shorthand, e.g. '>=2.7' will be expanded to 'CPython>=2.7'.\n\nSpecify "
+        "more than one element to OR the constraints, e.g. `['PyPy==3.7.*', 'CPython==3.7.*']` "
+        "means either PyPy 3.7 _or_ CPython 3.7.\n\nIf the field is not set, it will default to "
+        "the option `[python-setup].interpreter_constraints`.\n\nSee "
+        "https://www.pantsbuild.org/docs/python-interpreter-compatibility."
+    )
 
     def value_or_global_default(self, python_setup: PythonSetup) -> Tuple[str, ...]:
         """Return either the given `compatibility` field or the global interpreter constraints.
@@ -101,15 +96,6 @@ class PexBinaryDefaults(Subsystem):
 
 
 class DeprecatedPexBinarySources(PythonSources):
-    """A single file containing the executable, such as ['app.py'].
-
-    You can leave this off if you include the executable file in one of this target's
-    `dependencies` and explicitly set this target's `entry_point`.
-
-    This must have 0 or 1 files, but no more. If you depend on more files, put them in a
-    `python_library` target and include that target in the `dependencies` field.
-    """
-
     expected_num_files = range(0, 2)
     deprecated_removal_version = "2.3.0.dev0"
     deprecated_removal_hint = (
@@ -127,20 +113,15 @@ class PexBinaryDependencies(Dependencies):
 
 
 class PexEntryPointField(StringField, AsyncFieldMixin, SecondaryOwnerMixin):
-    """The entry point for the binary, i.e. what gets run when executing `./my_binary.pex`.
-
-    You can specify a full module like 'path.to.module' and 'path.to.module:func', or use a
-    shorthand to specify a file name, using the same syntax as the `sources` field:
-
-        1) 'app.py', Pants will convert into the module `path.to.app`;
-        2) 'app.py:func', Pants will convert into `path.to.app:func`.
-
-    You must use the file name shorthand for file arguments to work with this target.
-
-    To leave off an entry point, set to '<none>'.
-    """
-
     alias = "entry_point"
+    description = (
+        "The entry point for the binary, i.e. what gets run when executing `./my_binary.pex`.\n\n"
+        "You can specify a full module like 'path.to.module' and 'path.to.module:func', or use a "
+        "shorthand to specify a file name, using the same syntax as the `sources` field:\n\n    1) "
+        "'app.py', Pants will convert into the module `path.to.app`;\n    2) 'app.py:func', Pants "
+        "will convert into `path.to.app:func`.\n\nYou must use the file name shorthand for file "
+        "arguments to work with this target.\n\nTo leave off an entry point, set to '<none>'."
+    )
 
     @property
     def filespec(self) -> Filespec:
@@ -168,31 +149,30 @@ class ResolvePexEntryPointRequest:
 
 
 class PexPlatformsField(StringSequenceField):
-    """The platforms the built PEX should be compatible with.
-
-    This defaults to the current platform, but can be overridden to different platforms. You can
-    give a list of multiple platforms to create a multiplatform PEX.
-
-    To use wheels for specific interpreter/platform tags, you can append them to the platform with
-    hyphens like: PLATFORM-IMPL-PYVER-ABI (e.g. "linux_x86_64-cp-27-cp27mu",
-    "macosx_10.12_x86_64-cp-36-cp36m"). PLATFORM is the host platform e.g. "linux-x86_64",
-    "macosx-10.12-x86_64", etc". IMPL is the Python implementation abbreviation
-    (e.g. "cp", "pp", "jp"). PYVER is a two-digit string representing the python version
-    (e.g. "27", "36"). ABI is the ABI tag (e.g. "cp36m", "cp27mu", "abi3", "none").
-    """
-
     alias = "platforms"
+    description = (
+        "The platforms the built PEX should be compatible with.\n\nThis defaults to the current "
+        "platform, but can be overridden to different platforms. You can give a list of multiple "
+        "platforms to create a multiplatform PEX.\n\nTo use wheels for specific "
+        "interpreter/platform tags, you can append them to the platform with hyphens like: "
+        'PLATFORM-IMPL-PYVER-ABI (e.g. "linux_x86_64-cp-27-cp27mu", '
+        '"macosx_10.12_x86_64-cp-36-cp36m"):\n\n    - PLATFORM: the host platform, e.g. '
+        '"linux-x86_64", "macosx-10.12-x86_64".\n    - IMPL: the Python implementation '
+        'abbreviation, e.g. "cp", "pp", "jp".\n    - PYVER: a two-digit string representing '
+        'the Python version, e.g. "27", "36".\n    - ABI: the ABI tag, e.g. "cp36m", '
+        '"cp27mu", "abi3", "none".'
+    )
 
 
 class PexInheritPathField(StringField):
-    """Whether to inherit the `sys.path` of the environment that the binary runs in.
-
-    Use `false` to not inherit `sys.path`; use `fallback` to inherit `sys.path` after packaged
-    dependencies; and use `prefer` to inherit `sys.path` before packaged dependencies.
-    """
-
     alias = "inherit_path"
     valid_choices = ("false", "fallback", "prefer")
+    description = (
+        "Whether to inherit the `sys.path` (aka PYTHONPATH) of the environment that the binary "
+        "runs in.\n\nUse `false` to not inherit `sys.path`; use `fallback` to inherit `sys.path` "
+        "after packaged dependencies; and use `prefer` to inherit `sys.path` before packaged "
+        "dependencies."
+    )
 
     # TODO(#9388): deprecate allowing this to be a `bool`.
     @classmethod
@@ -205,54 +185,49 @@ class PexInheritPathField(StringField):
 
 
 class PexZipSafeField(BoolField):
-    """Whether or not this binary is safe to run in compacted (zip-file) form.
-
-    If the PEX is not zip safe, it will be written to disk prior to execution. You may need to mark
-    `zip_safe=False` if you're having issues loading your code.
-    """
-
     alias = "zip_safe"
     default = True
     value: bool
+    description = (
+        "Whether or not this binary is safe to run in compacted (zip-file) form.\n\nIf the PEX is "
+        "not zip safe, it will be written to disk prior to execution. You may need to mark "
+        "`zip_safe=False` if you're having issues loading your code."
+    )
 
 
 class PexAlwaysWriteCacheField(BoolField):
-    """Whether PEX should always write the .deps cache of the .pex file to disk or not.
-
-    This can use less memory in RAM constrained environments.
-    """
-
     alias = "always_write_cache"
     default = False
     value: bool
+    description = (
+        "Whether PEX should always write the .deps cache of the .pex file to disk or not. This "
+        "can use less memory in RAM-constrained environments."
+    )
 
 
 class PexIgnoreErrorsField(BoolField):
-    """Should we ignore when PEX cannot resolve dependencies?"""
-
     alias = "ignore_errors"
     default = False
     value: bool
+    description = "Should PEX ignore when it cannot resolve dependencies?"
 
 
 class PexShebangField(StringField):
-    """Set the generated PEX to use this shebang, rather than the default of PEX choosing a shebang
-    based on the interpreter constraints.
-
-    This influences the behavior of running `./result.pex`. You can ignore the shebang by instead
-    running `/path/to/python_interpreter ./result.pex`.
-    """
-
     alias = "shebang"
+    description = (
+        "Set the generated PEX to use this shebang, rather than the default of PEX choosing a "
+        "shebang based on the interpreter constraints.\n\nThis influences the behavior of running "
+        "`./result.pex`. You can ignore the shebang by instead running "
+        "`/path/to/python_interpreter ./result.pex`."
+    )
 
 
 class PexEmitWarningsField(BoolField):
-    """Whether or not to emit PEX warnings at runtime.
-
-    The default is determined by the option `emit_warnings` in the `[pex-binary-defaults]` scope.
-    """
-
     alias = "emit_warnings"
+    description = (
+        "Whether or not to emit PEX warnings at runtime.\n\nThe default is determined by the "
+        "option `emit_warnings` in the `[pex-binary-defaults]` scope."
+    )
 
     def value_or_global_default(self, pex_binary_defaults: PexBinaryDefaults) -> bool:
         if self.value is None:
@@ -271,12 +246,6 @@ class DeprecatedPexBinaryInterpreterConstraints(InterpreterConstraintsField):
 
 
 class PexBinary(Target):
-    """A Python target that can be converted into an executable PEX file.
-
-    PEX files are self-contained executable files that contain a complete Python environment capable
-    of running the target. For more information, see https://www.pantsbuild.org/docs/pex-files.
-    """
-
     alias = "pex_binary"
     core_fields = (
         *COMMON_TARGET_FIELDS,
@@ -292,6 +261,11 @@ class PexBinary(Target):
         PexIgnoreErrorsField,
         PexShebangField,
         PexEmitWarningsField,
+    )
+    description = (
+        "A Python target that can be converted into an executable PEX file.\n\nPEX files are "
+        "self-contained executable files that contain a complete Python environment capable of "
+        "running the target. For more information, see https://www.pantsbuild.org/docs/pex-files."
     )
 
 
@@ -317,27 +291,23 @@ class PythonTestsDependencies(Dependencies):
 
 
 class PythonRuntimePackageDependencies(SpecialCasedDependencies):
-    """Addresses to targets that can be built with the `./pants package` goal and whose resulting
-    assets should be included in the test run.
-
-    Pants will build the assets as if you had run `./pants package`. It will include the
-    results in your archive using the same name they would normally have, but without the
-    `--distdir` prefix (e.g. `dist/`).
-
-    You can include anything that can be built by `./pants package`, e.g. a `pex_binary`,
-    `python_awslambda`, or an `archive`.
-    """
-
     alias = "runtime_package_dependencies"
+    description = (
+        "Addresses to targets that can be built with the `./pants package` goal and whose "
+        "resulting artifacts should be included in the test run.\n\nPants will build the artifacts "
+        "as if you had run `./pants package`. It will include the results in your test's chroot, "
+        "using the same name they would normally have, but without the `--distdir` prefix (e.g. "
+        "`dist/`).\n\nYou can include anything that can be built by `./pants package`, e.g. a "
+        "`pex_binary`, `python_awslambda`, or an `archive`."
+    )
 
 
 class PythonTestsTimeout(IntField):
-    """A timeout (in seconds) which covers the total runtime of all tests in this target.
-
-    This only applies if the option `--pytest-timeouts` is set to True.
-    """
-
     alias = "timeout"
+    description = (
+        "A timeout (in seconds) which covers the total runtime of all tests in this target.\n\n"
+        "This only applies if the option `--pytest-timeouts` is set to True."
+    )
 
     @classmethod
     def compute_value(cls, raw_value: Optional[int], *, address: Address) -> Optional[int]:
@@ -365,16 +335,6 @@ class PythonTestsTimeout(IntField):
 
 
 class PythonTests(Target):
-    """Python tests.
-
-    These may be written in either Pytest-style or unittest style.
-
-    All test util code, other than `conftest.py`, should go into a dedicated `python_library()`
-    target and then be included in the `dependencies` field.
-
-    See https://www.pantsbuild.org/docs/python-test-goal.
-    """
-
     alias = "python_tests"
     core_fields = (
         *COMMON_TARGET_FIELDS,
@@ -383,6 +343,12 @@ class PythonTests(Target):
         PythonTestsDependencies,
         PythonRuntimePackageDependencies,
         PythonTestsTimeout,
+    )
+    description = (
+        "Python tests, written in either Pytest style or unittest style.\n\nAll test util code, "
+        "other than `conftest.py`, should go into a dedicated `python_library()` target and then "
+        "be included in the `dependencies` field.\n\nSee "
+        "https://www.pantsbuild.org/docs/python-test-goal."
     )
 
 
@@ -396,19 +362,17 @@ class PythonLibrarySources(PythonSources):
 
 
 class PythonLibrary(Target):
-    """Python source code.
-
-    A `python_library` does not necessarily correspond to a distribution you publish (see
-    `python_distribution` and `pex_binary` for that); multiple `python_library` targets may be
-    packaged into a distribution or binary.
-    """
-
     alias = "python_library"
     core_fields = (
         *COMMON_TARGET_FIELDS,
         InterpreterConstraintsField,
         Dependencies,
         PythonLibrarySources,
+    )
+    description = (
+        "Python source code.\n\nA `python_library` does not necessarily correspond to a "
+        "distribution you publish (see `python_distribution` and `pex_binary` for that); multiple "
+        "`python_library` targets may be packaged into a distribution or binary."
     )
 
 
@@ -449,12 +413,13 @@ def format_invalid_requirement_string_error(
 
 
 class PythonRequirementsField(Field):
-    """A sequence of pip-style requirement strings, e.g. ['foo==1.8', 'bar<=3 ;
-    python_version<'3']."""
-
     alias = "requirements"
     required = True
     value: Tuple[Requirement, ...]
+    description = (
+        "A sequence of pip-style requirement strings, e.g. ['foo==1.8', "
+        "'bar<=3 ; python_version<'3']."
+    )
 
     @classmethod
     def compute_value(
@@ -495,30 +460,25 @@ class PythonRequirementsField(Field):
 
 
 class ModuleMappingField(DictStringToStringSequenceField):
-    """A mapping of requirement names to a list of the modules they provide.
-
-    For example, `{"ansicolors": ["colors"]}`. Any unspecified requirements will use the
-    requirement name as the default module, e.g. "Django" will default to ["django"]`.
-
-    This is used for Pants to be able to infer dependencies in BUILD files.
-    """
-
     alias = "module_mapping"
+    description = (
+        "A mapping of requirement names to a list of the modules they provide.\n\nFor example, "
+        '`{"ansicolors": ["colors"]}`. Any unspecified requirements will use the requirement '
+        'name as the default module, e.g. "Django" will default to `["django"]`.\n\nThis is '
+        "used for Pants to be able to infer dependencies in BUILD files."
+    )
 
 
 class PythonRequirementLibrary(Target):
-    """Python requirements installable by pip.
-
-    This target is useful when you want to declare Python requirements inline in a BUILD file. If
-    you have a `requirements.txt` file already, you can instead use the macro
-    `python_requirements()` to convert each requirement into a `python_requirement_library()` target
-    automatically.
-
-    See https://www.pantsbuild.org/docs/python-third-party-dependencies.
-    """
-
     alias = "python_requirement_library"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, PythonRequirementsField, ModuleMappingField)
+    description = (
+        "Python requirements installable by pip.\n\nThis target is useful when you want to declare "
+        "Python requirements inline in a BUILD file. If you have a `requirements.txt` file "
+        "already, you can instead use the macro `python_requirements()` to convert each "
+        "requirement into a `python_requirement_library()` target automatically.\n\nSee "
+        "https://www.pantsbuild.org/docs/python-third-party-dependencies."
+    )
 
 
 # -----------------------------------------------------------------------------------------------
@@ -531,10 +491,9 @@ class PythonRequirementsFileSources(Sources):
 
 
 class PythonRequirementsFile(Target):
-    """A private, helper target type for requirements.txt files."""
-
     alias = "_python_requirements_file"
     core_fields = (*COMMON_TARGET_FIELDS, PythonRequirementsFileSources)
+    description = "A private, helper target type for requirements.txt files."
 
 
 # -----------------------------------------------------------------------------------------------
@@ -548,15 +507,14 @@ class PythonDistributionDependencies(Dependencies):
 
 
 class PythonProvidesField(ScalarField, ProvidesField):
-    """The setup.py kwargs for the external artifact built from this target.
-
-    See https://www.pantsbuild.org/docs/python-setup-py-goal.
-    """
-
     expected_type = PythonArtifact
     expected_type_description = "setup_py(name='my-dist', **kwargs)"
     value: PythonArtifact
     required = True
+    description = (
+        "The setup.py kwargs for the external artifact built from this target.\n\nSee "
+        "https://www.pantsbuild.org/docs/python-setup-py-goal."
+    )
 
     @classmethod
     def compute_value(
@@ -566,25 +524,20 @@ class PythonProvidesField(ScalarField, ProvidesField):
 
 
 class SetupPyCommandsField(StringSequenceField):
-    """The runtime commands to invoke setup.py with to create the distribution.
-
-    E.g., ["bdist_wheel", "--python-tag=py36.py37", "sdist"]
-
-    If empty or unspecified, will just create a chroot with a setup() function.
-
-    See https://www.pantsbuild.org/docs/python-setup-py-goal.
-    """
-
     alias = "setup_py_commands"
     expected_type_description = (
         "an iterable of string commands to invoke setup.py with, or "
         "an empty list to just create a chroot with a setup() function."
     )
+    description = (
+        "The runtime commands to invoke setup.py with to create the distribution, e.g. "
+        '["bdist_wheel", "--python-tag=py36.py37", "sdist"].\n\nIf empty or unspecified, '
+        "will just create a chroot with a setup() function.\n\nSee "
+        "https://www.pantsbuild.org/docs/python-setup-py-goal."
+    )
 
 
 class PythonDistribution(Target):
-    """A publishable Python setuptools distribution (e.g. an sdist or wheel)."""
-
     alias = "python_distribution"
     core_fields = (
         *COMMON_TARGET_FIELDS,
@@ -592,3 +545,4 @@ class PythonDistribution(Target):
         PythonProvidesField,
         SetupPyCommandsField,
     )
+    description = "A publishable Python setuptools distribution (e.g. an sdist or wheel)."

--- a/src/python/pants/backend/python/typecheck/mypy/plugin_target_type.py
+++ b/src/python/pants/backend/python/typecheck/mypy/plugin_target_type.py
@@ -10,42 +10,16 @@ class MyPyPluginSources(PythonSources):
 
 
 class MyPySourcePlugin(Target):
-    """A MyPy plugin loaded through source code.
-
-    To load a source plugin:
-
-        1. Write your plugin. See https://mypy.readthedocs.io/en/stable/extending_mypy.html.
-        2. Define a `mypy_source_plugin` target with the plugin's Python file(s) included in the
-            `sources` field.
-        3. Add `plugins = path.to.module` to your MyPy config file, using the name of the module
-            without source roots. For example, if your Python file is called
-            `pants-plugins/mypy_plugins/custom_plugin.py`, and you set `pants-plugins` as a source root,
-            then set `plugins = mypy_plugins.custom_plugin`. Set the `config`
-            option in the `[mypy]` scope to point to your MyPy config file.
-        4. Set the option `source_plugins` in the `[mypy]` scope to include this target's
-            address, e.g. `source_plugins = ["pants-plugins/mypy_plugins:plugin"]`.
-
-    To instead load a third-party plugin, set the option `extra_requirements` in the `[mypy]`
-    scope (see https://www.pantsbuild.org/v2.0/docs/python-typecheck-goal). Set `plugins` in
-    your config file, like you'd do with a source plugin.
-
-    This target type is treated similarly to a `python_library` target. For example, Python linters
-    and formatters will run on this target.
-
-    You can depend on other targets and Pants's dependency inference will add them to the `dependencies` field,
-    including any third-party requirements and `python_library` targets (even if their source files live in a different
-    directory).
-
-    Other targets can depend on this target. This allows you to write a `python_tests` target for
-    this code or a `python_distribution` target to distribute the plugin externally.
-    """
-
     alias = "mypy_source_plugin"
     core_fields = (
         *COMMON_TARGET_FIELDS,
         InterpreterConstraintsField,
         Dependencies,
         MyPyPluginSources,
+    )
+    help = (
+        "A MyPy plugin loaded through source code.\n\nRun `./pants help-advanced mypy` for "
+        "instructions with the `--source-plugins` option."
     )
 
     deprecated_removal_version = "2.3.0.dev0"

--- a/src/python/pants/core/goals/package.py
+++ b/src/python/pants/core/goals/package.py
@@ -47,17 +47,14 @@ class BuiltPackage:
 
 
 class OutputPathField(StringField):
-    """Where the built asset should be located.
-
-    If undefined, this will use the path to the the BUILD, followed by the target name. For
-    example, `src/python/project:app` would be `src.python.project/app.ext`.
-
-    When running `./pants package`, this path will be prefixed by `--distdir` (e.g. `dist/`).
-
-    Warning: setting this value risks naming collisions with other package targets you may have.
-    """
-
     alias = "output_path"
+    description = (
+        "Where the built asset should be located.\n\nIf undefined, this will use the path to the "
+        "BUILD file, followed by the target name. For example, `src/python/project:app` would be "
+        "`src.python.project/app.ext.\n\nWhen running `./pants package`, this path will be "
+        "prefixed by `--distdir` (e.g. `dist/`).\n\nWarning: setting this value risks naming "
+        "collisions with other package targets you may have."
+    )
 
     def value_or_default(self, address: Address, *, file_ending: str) -> str:
         assert not file_ending.startswith("."), "`file_ending` should not start with `.`"

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
+from textwrap import dedent
 
 from pants.core.goals.package import (
     BuiltPackage,
@@ -42,15 +43,14 @@ class FilesSources(Sources):
 
 
 class Files(Target):
-    """Loose files that live outside code packages.
-
-    Files are placed directly in archives, outside of code artifacts such as Python wheels or JVM
-    JARs. The sources of a `files` target are accessed via filesystem APIs, such as Python's
-    `open()`, via paths relative to the repo root.
-    """
-
     alias = "files"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, FilesSources)
+    description = (
+        "Loose files that live outside code packages.\n\nFiles are placed directly in archives, "
+        "outside of code artifacts such as Python wheels or JVM JARs. The sources of a `files` "
+        "target are accessed via filesystem APIs, such as Python's `open()`, via paths relative to "
+        "the repo root."
+    )
 
 
 # -----------------------------------------------------------------------------------------------
@@ -65,77 +65,37 @@ class RelocatedFilesSources(Sources):
 
 
 class RelocatedFilesOriginalTargets(SpecialCasedDependencies):
-    """Addresses to the original `files()` targets that you want to relocate, such as
-    `['//:json_files']`.
-
-    Every target will be relocated using the same mapping. This means that every target must include
-    the value from the `src` field in their original path.
-    """
-
     alias = "files_targets"
     required = True
+    description = (
+        "Addresses to the original `files()` targets that you want to relocate, such as "
+        "`['//:json_files']`.\n\nEvery target will be relocated using the same mapping. This means "
+        "that every target must include the value from the `src` field in their original path."
+    )
 
 
 class RelocatedFilesSrcField(StringField):
-    """The original prefix that you want to replace, such as `src/resources`.
-
-    You can set this field to `""` to preserve the original path; the value in the `dest` field will
-    then be added to the beginning of this original path.
-    """
-
     alias = "src"
     required = True
+    description = (
+        "The original prefix that you want to replace, such as `src/resources`.\n\nYou can set "
+        "this field to `"
+        "` to preserve the original path; the value in the `dest` field will "
+        "then be added to the beginning of this original path."
+    )
 
 
 class RelocatedFilesDestField(StringField):
-    """The new prefix that you want to add to the beginning of the path, such as `data`.
-
-    You can set this field to `""` to avoid adding any new values to the path; the value in the
-    `src` field will then be stripped, rather than replaced.
-    """
-
     alias = "dest"
     required = True
+    description = (
+        "The new prefix that you want to add to the beginning of the path, such as `data`.\n\nYou "
+        'can set this field to "" to avoid adding any new values to the path; the value in the '
+        "`src` field will then be stripped, rather than replaced."
+    )
 
 
 class RelocatedFiles(Target):
-    """Loose files with path manipulation applied.
-
-    Allows you to relocate the files at runtime to something more convenient than
-    their actual paths in your project.
-
-    For example, you can relocate `src/resources/project1/data.json` to instead be
-    `resources/data.json`. Your other target types can then add this target to their
-    `dependencies` field, rather than using the original `files` target.
-
-    To remove a prefix:
-
-        # Results in `data.json`.
-        relocated_files(
-            file_targets=["src/resources/project1:target"],
-            src="src/resources/project1",
-            dest="",
-        )
-
-    To add a prefix:
-
-        # Results in `images/logo.svg`.
-        relocated_files(
-            file_targets=["//:logo"],
-            src="",
-            dest="images",
-        )
-
-    To replace a prefix:
-
-        # Results in `new_prefix/project1/data.json`.
-        relocated_files(
-            file_targets=["src/resources/project1:target"],
-            src="src/resources",
-            dest="new_prefix",
-        )
-    """
-
     alias = "relocated_files"
     core_fields = (
         *COMMON_TARGET_FIELDS,
@@ -143,6 +103,42 @@ class RelocatedFiles(Target):
         RelocatedFilesOriginalTargets,
         RelocatedFilesSrcField,
         RelocatedFilesDestField,
+    )
+    description = (
+        "Loose files with path manipulation applied.\n\nAllows you to relocate the files at "
+        "runtime to something more convenient than their actual paths in your project.\n\nFor "
+        "example, you can relocate `src/resources/project1/data.json` to instead be "
+        "`resources/data.json`. Your other target types can then add this target to their "
+        "`dependencies` field, rather than using the original `files` target.\n\n"
+    ) + dedent(
+        """\
+        To remove a prefix:
+
+            # Results in `data.json`.
+            relocated_files(
+                file_targets=["src/resources/project1:target"],
+                src="src/resources/project1",
+                dest="",
+            )
+
+        To add a prefix:
+
+            # Results in `images/logo.svg`.
+            relocated_files(
+                file_targets=["//:logo"],
+                src="",
+                dest="images",
+            )
+
+        To replace a prefix:
+
+            # Results in `new_prefix/project1/data.json`.
+            relocated_files(
+                file_targets=["src/resources/project1:target"],
+                src="src/resources",
+                dest="new_prefix",
+            )
+        """
     )
 
 
@@ -195,15 +191,14 @@ class ResourcesSources(Sources):
 
 
 class Resources(Target):
-    """Data emebdded in a code package and accessed in a location-independent manner.
-
-    Resources are embedded in code artifacts such as Python wheels or JVM JARs. The sources of a
-    `resources` target are accessed via language-specific resource APIs, such as Python's pkgutil or
-    JVM's ClassLoader, via paths relative to the target's source root.
-    """
-
     alias = "resources"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, ResourcesSources)
+    description = (
+        "Data embedded in a code package and accessed in a location-independent manner.\n\n"
+        "Resources are embedded in code artifacts such as Python wheels or JVM JARs. The sources "
+        "of a `resources` target are accessed via language-specific resource APIs, such as "
+        "Python's pkgutil or JVM's ClassLoader, via paths relative to the target's source root."
+    )
 
 
 # -----------------------------------------------------------------------------------------------
@@ -212,14 +207,13 @@ class Resources(Target):
 
 
 class GenericTarget(Target):
-    """A generic target with no specific type.
-
-    This can be used as a generic "bag of dependencies", i.e. you can group several different
-    targets into one single target so that your other targets only need to depend on one thing.
-    """
-
     alias = "target"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies)
+    description = (
+        'A generic target with no specific type.\n\nThis can be used as a generic "bag of '
+        'dependencies", i.e. you can group several different targets into one single target so '
+        "that your other targets only need to depend on one thing."
+    )
 
 
 # -----------------------------------------------------------------------------------------------
@@ -228,45 +222,38 @@ class GenericTarget(Target):
 
 
 class ArchivePackages(SpecialCasedDependencies):
-    """Addresses to any targets that can be built with `./pants package`.
-
-    Pants will build the assets as if you had run `./pants package`. It will include the
-    results in your archive using the same name they would normally have, but without the
-    `--distdir` prefix (e.g. `dist/`).
-
-    You can include anything that can be built by `./pants package`, e.g. a `pex_binary`,
-    `python_awslambda`, or even another `archive`.
-    """
-
     alias = "packages"
+    description = (
+        "Addresses to any targets that can be built with `./pants package`, e.g. "
+        '`["project:app"]`.\n\nPants will build the assets as if you had run `./pants package`. '
+        "It will include the results in your archive using the same name they would normally have, "
+        "but without the `--distdir` prefix (e.g. `dist/`).\n\nYou can include anything that can "
+        "be built by `./pants package`, e.g. a `pex_binary`, `python_awslambda`, or even another "
+        "`archive`."
+    )
 
 
 class ArchiveFiles(SpecialCasedDependencies):
-    """Addresses to any `files` or `relocated_files` targets to include in the archive, e.g.
-    `["resources:logo"]`.
-
-    This is useful to include any loose files, like data files, image assets, or config files.
-
-    This will ignore any targets that are not `files` or `relocated_files` targets. If you instead
-    want those files included in any packages specified in the `packages` field for this target,
-    then use a `resources` target and have the original package depend on the resources.
-    """
-
     alias = "files"
+    description = (
+        "Addresses to any `files` or `relocated_files` targets to include in the archive, e.g. "
+        '`["resources:logo"]`.\n\nThis is useful to include any loose files, like data files, '
+        "image assets, or config files.\n\nThis will ignore any targets that are not `files` or "
+        "`relocated_files` targets. If you instead want those files included in any packages "
+        "specified in the `packages` field for this target, then use a `resources` target and have "
+        "the original package depend on the resources."
+    )
 
 
 class ArchiveFormatField(StringField):
-    """The type of archive file to be generated."""
-
     alias = "format"
     valid_choices = ArchiveFormat
     required = True
     value: str
+    description = "The type of archive file to be generated."
 
 
 class ArchiveTarget(Target):
-    """A ZIP or TAR file containing loose files and code packages."""
-
     alias = "archive"
     core_fields = (
         *COMMON_TARGET_FIELDS,
@@ -275,6 +262,7 @@ class ArchiveTarget(Target):
         ArchiveFiles,
         ArchiveFormatField,
     )
+    description = "A ZIP or TAR file containing loose files and code packages."
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -45,7 +45,7 @@ class FilesSources(Sources):
 class Files(Target):
     alias = "files"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, FilesSources)
-    description = (
+    help = (
         "Loose files that live outside code packages.\n\nFiles are placed directly in archives, "
         "outside of code artifacts such as Python wheels or JVM JARs. The sources of a `files` "
         "target are accessed via filesystem APIs, such as Python's `open()`, via paths relative to "
@@ -67,7 +67,7 @@ class RelocatedFilesSources(Sources):
 class RelocatedFilesOriginalTargets(SpecialCasedDependencies):
     alias = "files_targets"
     required = True
-    description = (
+    help = (
         "Addresses to the original `files()` targets that you want to relocate, such as "
         "`['//:json_files']`.\n\nEvery target will be relocated using the same mapping. This means "
         "that every target must include the value from the `src` field in their original path."
@@ -77,7 +77,7 @@ class RelocatedFilesOriginalTargets(SpecialCasedDependencies):
 class RelocatedFilesSrcField(StringField):
     alias = "src"
     required = True
-    description = (
+    help = (
         "The original prefix that you want to replace, such as `src/resources`.\n\nYou can set "
         "this field to `"
         "` to preserve the original path; the value in the `dest` field will "
@@ -88,7 +88,7 @@ class RelocatedFilesSrcField(StringField):
 class RelocatedFilesDestField(StringField):
     alias = "dest"
     required = True
-    description = (
+    help = (
         "The new prefix that you want to add to the beginning of the path, such as `data`.\n\nYou "
         'can set this field to "" to avoid adding any new values to the path; the value in the '
         "`src` field will then be stripped, rather than replaced."
@@ -104,7 +104,7 @@ class RelocatedFiles(Target):
         RelocatedFilesSrcField,
         RelocatedFilesDestField,
     )
-    description = (
+    help = (
         "Loose files with path manipulation applied.\n\nAllows you to relocate the files at "
         "runtime to something more convenient than their actual paths in your project.\n\nFor "
         "example, you can relocate `src/resources/project1/data.json` to instead be "
@@ -193,7 +193,7 @@ class ResourcesSources(Sources):
 class Resources(Target):
     alias = "resources"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, ResourcesSources)
-    description = (
+    help = (
         "Data embedded in a code package and accessed in a location-independent manner.\n\n"
         "Resources are embedded in code artifacts such as Python wheels or JVM JARs. The sources "
         "of a `resources` target are accessed via language-specific resource APIs, such as "
@@ -209,7 +209,7 @@ class Resources(Target):
 class GenericTarget(Target):
     alias = "target"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies)
-    description = (
+    help = (
         'A generic target with no specific type.\n\nThis can be used as a generic "bag of '
         'dependencies", i.e. you can group several different targets into one single target so '
         "that your other targets only need to depend on one thing."
@@ -223,7 +223,7 @@ class GenericTarget(Target):
 
 class ArchivePackages(SpecialCasedDependencies):
     alias = "packages"
-    description = (
+    help = (
         "Addresses to any targets that can be built with `./pants package`, e.g. "
         '`["project:app"]`.\n\nPants will build the assets as if you had run `./pants package`. '
         "It will include the results in your archive using the same name they would normally have, "
@@ -235,7 +235,7 @@ class ArchivePackages(SpecialCasedDependencies):
 
 class ArchiveFiles(SpecialCasedDependencies):
     alias = "files"
-    description = (
+    help = (
         "Addresses to any `files` or `relocated_files` targets to include in the archive, e.g. "
         '`["resources:logo"]`.\n\nThis is useful to include any loose files, like data files, '
         "image assets, or config files.\n\nThis will ignore any targets that are not `files` or "
@@ -250,7 +250,7 @@ class ArchiveFormatField(StringField):
     valid_choices = ArchiveFormat
     required = True
     value: str
-    description = "The type of archive file to be generated."
+    help = "The type of archive file to be generated."
 
 
 class ArchiveTarget(Target):
@@ -262,7 +262,7 @@ class ArchiveTarget(Target):
         ArchiveFiles,
         ArchiveFormatField,
     )
-    description = "A ZIP or TAR file containing loose files and code packages."
+    help = "A ZIP or TAR file containing loose files and code packages."
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1228,6 +1228,11 @@ class Sources(StringSequenceField, AsyncFieldMixin):
     alias = "sources"
     expected_file_extensions: ClassVar[Optional[Tuple[str, ...]]] = None
     expected_num_files: ClassVar[Optional[Union[int, range]]] = None
+    description = (
+        "A list of files and globs that belong to this target.\n\nPaths are relative to the BUILD "
+        "file's directory. You can ignore files/globs by prefixing them with `!`.\n\nExample: "
+        "`sources=['example.py', 'test_*.py', '!test_ignore.py']`."
+    )
 
     def validate_resolved_files(self, files: Sequence[str]) -> None:
         """Perform any additional validation on the resulting source files, e.g. ensuring that
@@ -1519,23 +1524,26 @@ class SecondaryOwnerMixin(ABC):
 # `Dependencies` field
 # -----------------------------------------------------------------------------------------------
 
-# NB: To hydrate the dependencies, use one of:
-#   await Get(Addresses, DependenciesRequest(tgt[Dependencies])
-#   await Get(Targets, DependenciesRequest(tgt[Dependencies])
+
 class Dependencies(StringSequenceField, AsyncFieldMixin):
-    """Addresses to other targets that this target depends on, e.g. ['helloworld/subdir:lib'].
+    """The dependencies field.
 
-    Alternatively, you may include file names. Pants will find which target owns that file, and
-    create a new target from that which only includes the file in its `sources` field. For files
-    relative to the current BUILD file, prefix with `./`; otherwise, put the full path, e.g.
-    ['./sibling.txt', 'resources/demo.json'].
-
-    You may exclude dependencies by prefixing with `!`, e.g. `['!helloworld/subdir:lib',
-    '!./sibling.txt']`. Ignores are intended for false positives with dependency inference;
-    otherwise, simply leave off the dependency from the BUILD file.
+    To resolve all dependencies—including the results of dependency injection and inference—use
+    either `await Get(Addresses, DependenciesRequest(tgt[Dependencies])` or `await Get(Targets,
+    DependenciesRequest(tgt[Dependencies])`.
     """
 
     alias = "dependencies"
+    description = (
+        "Addresses to other targets that this target depends on, e.g. ['helloworld/subdir:lib']."
+        "\n\nAlternatively, you may include file names. Pants will find which target owns that "
+        "file, and create a new target from that which only includes the file in its `sources` "
+        "field. For files relative to the current BUILD file, prefix with `./`; otherwise, put the "
+        "full path, e.g. ['./sibling.txt', 'resources/demo.json'].\n\nYou may exclude dependencies "
+        "by prefixing with `!`, e.g. `['!helloworld/subdir:lib', '!./sibling.txt']`. Ignores are "
+        "intended for false positives with dependency inference; otherwise, simply leave off the "
+        "dependency from the BUILD file."
+    )
     supports_transitive_excludes = False
 
     @memoized_property
@@ -1721,22 +1729,20 @@ class SpecialCasedDependencies(StringSequenceField, AsyncFieldMixin):
 
 
 class Tags(StringSequenceField):
-    """Arbitrary strings that you can use to describe a target.
-
-    For example, you may tag some test targets with 'integration_test' so that you could run
-    `./pants --tags='integration_test' test ::` to only run on targets with that tag.
-    """
-
     alias = "tags"
+    description = (
+        "Arbitrary strings to describe a target.\n\nFor example, you may tag some test targets "
+        "with 'integration_test' so that you could run `./pants --tags='integration_test' test ::` "
+        "to only run on targets with that tag."
+    )
 
 
 class DescriptionField(StringField):
-    """A human-readable description of the target.
-
-    Use `./pants list --documented ::` to see all targets with descriptions.
-    """
-
     alias = "description"
+    description = (
+        "A human-readable description of the target.\n\nUse `./pants list --documented ::` to see "
+        "all targets with descriptions."
+    )
 
 
 COMMON_TARGET_FIELDS = (Tags, DescriptionField)
@@ -1745,8 +1751,7 @@ COMMON_TARGET_FIELDS = (Tags, DescriptionField)
 # TODO: figure out what support looks like for this with the Target API. The expected value is an
 #  Artifact, there is no common Artifact interface.
 class ProvidesField(Field):
-    """An `artifact`, such as `setup_py`, that describes how to represent this target to the outside
-    world."""
+    """An `artifact` that describes how to represent this target to the outside world."""
 
     alias = "provides"
     default: ClassVar[Optional[Any]] = None

--- a/src/python/pants/help/help_formatter.py
+++ b/src/python/pants/help/help_formatter.py
@@ -9,6 +9,7 @@ from typing import List, Optional
 from pants.help.help_info_extracter import OptionHelpInfo, OptionScopeHelpInfo, to_help_str
 from pants.help.maybe_color import MaybeColor
 from pants.option.ranked_value import Rank, RankedValue
+from pants.util.strutil import hard_wrap
 
 
 class HelpFormatter(MaybeColor):
@@ -108,11 +109,7 @@ class HelpFormatter(MaybeColor):
             for rv in interesting_ranked_values
             for line in format_value(rv, "overrode: ", f"{indent}    ")
         ]
-        description_lines = ohi.help.splitlines()
-        # wrap() returns [] for an empty line, but we want to emit those, hence the "or [line]".
-        description_lines = [
-            f"{indent}{s}" for line in description_lines for s in wrap(line, 96) or [line]
-        ]
+        description_lines = hard_wrap(ohi.help, indent=len(indent))
         lines = [
             *arg_lines,
             *choices_lines,

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -32,6 +32,7 @@ from pants.option.option_util import is_dict_option, is_list_option
 from pants.option.options import Options
 from pants.option.parser import OptionValueHistory, Parser
 from pants.util.objects import get_docstring, get_docstring_summary, pretty_print_type_hint
+from pants.util.strutil import first_paragraph
 
 
 class HelpJSONEncoder(json.JSONEncoder):
@@ -165,25 +166,28 @@ class TargetFieldHelpInfo:
         # This is a an awkward edge of our heuristic and it's not intentional since these core
         # `Field` types have documentation oriented to the plugin author and not the end user
         # filling in fields in a BUILD file.
-        description = get_docstring(
-            field,
-            flatten=True,
-            fallback_to_ancestors=True,
-            ignored_ancestors={
-                *Field.mro(),
-                AsyncFieldMixin,
-                BoolField,
-                DictStringToStringField,
-                DictStringToStringSequenceField,
-                FloatField,
-                Generic,  # type: ignore[arg-type]
-                IntField,
-                ScalarField,
-                SequenceField,
-                StringField,
-                StringSequenceField,
-            },
-        )
+        if hasattr(field, "description"):
+            description = field.description
+        else:
+            description = get_docstring(
+                field,
+                flatten=True,
+                fallback_to_ancestors=True,
+                ignored_ancestors={
+                    *Field.mro(),
+                    AsyncFieldMixin,
+                    BoolField,
+                    DictStringToStringField,
+                    DictStringToStringSequenceField,
+                    FloatField,
+                    Generic,  # type: ignore[arg-type]
+                    IntField,
+                    ScalarField,
+                    SequenceField,
+                    StringField,
+                    StringSequenceField,
+                },
+            )
         raw_value_type = get_type_hints(field.compute_value)["raw_value"]
         type_hint = pretty_print_type_hint(raw_value_type)
 
@@ -227,10 +231,16 @@ class TargetTypeHelpInfo:
     def create(
         cls, target_type: Type[Target], *, union_membership: UnionMembership
     ) -> TargetTypeHelpInfo:
+        if hasattr(target_type, "description"):
+            description = target_type.description
+            summary = first_paragraph(description)
+        else:
+            description = get_docstring(target_type)
+            summary = get_docstring_summary(target_type)
         return cls(
             alias=target_type.alias,
-            summary=get_docstring_summary(target_type),
-            description=get_docstring(target_type),
+            summary=summary,
+            description=description,
             fields=tuple(
                 TargetFieldHelpInfo.create(field)
                 for field in target_type.class_field_types(union_membership=union_membership)

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -166,8 +166,8 @@ class TargetFieldHelpInfo:
         # This is a an awkward edge of our heuristic and it's not intentional since these core
         # `Field` types have documentation oriented to the plugin author and not the end user
         # filling in fields in a BUILD file.
-        if hasattr(field, "description"):
-            description = field.description
+        if hasattr(field, "help"):
+            description = field.help  # type: ignore[attr-defined]
         else:
             description = get_docstring(
                 field,
@@ -231,8 +231,9 @@ class TargetTypeHelpInfo:
     def create(
         cls, target_type: Type[Target], *, union_membership: UnionMembership
     ) -> TargetTypeHelpInfo:
-        if hasattr(target_type, "description"):
-            description = target_type.description
+        summary: Optional[str]
+        if hasattr(target_type, "help"):
+            description = target_type.help  # type: ignore[attr-defined]
             summary = first_paragraph(description)
         else:
             description = get_docstring(target_type)

--- a/src/python/pants/help/help_integration_test.py
+++ b/src/python/pants/help/help_integration_test.py
@@ -53,13 +53,14 @@ def test_help_specific_target() -> None:
     assert (
         textwrap.dedent(
             """
-    archive
-    -------
+            archive
+            -------
 
-    A ZIP or TAR file containing loose files and code packages.
+            A ZIP or TAR file containing loose files and code packages.
 
-    Valid fields:
-    """
+
+            Valid fields:
+            """
         )
         in pants_run.stdout
     )
@@ -67,11 +68,11 @@ def test_help_specific_target() -> None:
     assert (
         textwrap.dedent(
             """
-    format
-        type: 'tar' | 'tar.bz2' | 'tar.gz' | 'tar.xz' | 'zip'
-        required
-        The type of archive file to be generated.
-    """
+            format
+                type: 'tar' | 'tar.bz2' | 'tar.gz' | 'tar.xz' | 'zip'
+                required
+                The type of archive file to be generated.
+            """
         )
         in pants_run.stdout
     )

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -22,6 +22,7 @@ from pants.option.arg_splitter import (
     VersionHelp,
 )
 from pants.option.scope import GLOBAL_SCOPE
+from pants.util.strutil import hard_wrap
 
 
 class HelpPrinter(MaybeColor):
@@ -249,8 +250,9 @@ class HelpPrinter(MaybeColor):
         self._print_title(target_alias)
         tinfo = self._all_help_info.name_to_target_type_info[target_alias]
         if tinfo.description:
-            print(tinfo.description)
-        print("\nValid fields:")
+            formatted_desc = "\n".join(hard_wrap(tinfo.description))
+            print(formatted_desc)
+        print("\n\nValid fields:")
         for field in sorted(tinfo.fields, key=lambda x: x.alias):
             print()
             print(self.maybe_magenta(field.alias))
@@ -259,8 +261,8 @@ class HelpPrinter(MaybeColor):
             print(self.maybe_cyan(f"{indent}type: {field.type_hint}"))
             print(self.maybe_cyan(f"{indent}{required_or_default}"))
             if field.description:
-                for line in textwrap.wrap(field.description, 80):
-                    print(f"{indent}{line}")
+                formatted_desc = "\n".join(hard_wrap(field.description, indent=len(indent)))
+                print(formatted_desc)
         print()
 
     def _get_help_json(self) -> str:

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -4,6 +4,8 @@
 from textwrap import dedent
 from typing import Any, Iterable, Optional, Type, Union
 
+from pants.util.strutil import first_paragraph
+
 
 def get_docstring_summary(
     cls: Type, *, fallback_to_ancestors: bool = False, ignored_ancestors: Iterable[Type] = (object,)
@@ -16,15 +18,7 @@ def get_docstring_summary(
     all_docstring = get_docstring(
         cls, fallback_to_ancestors=fallback_to_ancestors, ignored_ancestors=ignored_ancestors
     )
-
-    if all_docstring is None:
-        return None
-
-    lines = all_docstring.splitlines()
-    first_blank_line_index = next(
-        (i for i, line in enumerate(lines) if line.strip() == ""), len(lines)
-    )
-    return " ".join(lines[:first_blank_line_index])
+    return first_paragraph(all_docstring) if all_docstring else None
 
 
 def get_docstring(

--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -3,7 +3,8 @@
 
 import re
 import shlex
-from typing import Dict, Iterable, List, Optional, Union
+import textwrap
+from typing import Dict, Iterable, List, Optional, Sequence, Union
 
 
 def ensure_binary(text_or_binary: Union[bytes, str]) -> bytes:
@@ -133,3 +134,28 @@ def strip_v2_chroot_path(v: Union[bytes, str]) -> str:
     if isinstance(v, bytes):
         v = v.decode()
     return re.sub(r"/.*/process-execution[a-zA-Z0-9]+/", "", v)
+
+
+def hard_wrap(s: str, *, indent: int = 0, width: int = 96) -> Sequence[str]:
+    """Hard wrap a string while still preserving any prior hard wrapping (new lines).
+
+    This works well when the input uses soft wrapping, e.g. via Python's implicit string
+    concatenation.
+
+    Usually, you will want to join the lines together with "\n".join().
+    """
+    # wrap() returns [] for an empty line, but we want to emit those, hence the `or [line]`.
+    return [
+        f"{' ' * indent}{wrapped_line}"
+        for line in s.splitlines()
+        for wrapped_line in textwrap.wrap(line, width=width - indent) or [line]
+    ]
+
+
+def first_paragraph(s: str) -> str:
+    """Get the first paragraph, where paragraphs are separated by blank lines."""
+    lines = s.splitlines()
+    first_blank_line_index = next(
+        (i for i, line in enumerate(lines) if line.strip() == ""), len(lines)
+    )
+    return " ".join(lines[:first_blank_line_index])

--- a/src/python/pants/util/strutil_test.py
+++ b/src/python/pants/util/strutil_test.py
@@ -7,6 +7,8 @@ from textwrap import dedent
 from pants.util.strutil import (
     ensure_binary,
     ensure_text,
+    first_paragraph,
+    hard_wrap,
     pluralize,
     strip_prefix,
     strip_v2_chroot_path,
@@ -87,3 +89,44 @@ def test_strip_chroot_path() -> None:
     # Confirm we can handle values with no chroot path.
     assert strip_v2_chroot_path("") == ""
     assert strip_v2_chroot_path("hello world") == "hello world"
+
+
+def test_hard_wrap() -> None:
+    assert hard_wrap("Hello world!", width=6) == ["Hello", "world!"]
+
+    # Indents play into the width.
+    assert hard_wrap("Hello world!", width=6, indent=2) == ["  Hell", "  o wo", "  rld!"]
+    assert hard_wrap("Hello world!", width=8, indent=2) == ["  Hello", "  world!"]
+
+    # Preserve prior newlines.
+    assert hard_wrap("- 1\n- 2\n\n") == ["- 1", "- 2", ""]
+    assert hard_wrap("Hello world!\n\n- 1 some text\n- 2\n\nHola mundo!", width=6) == [
+        "Hello",
+        "world!",
+        "",
+        "- 1",
+        "some",
+        "text",
+        "- 2",
+        "",
+        "Hola",
+        "mundo!",
+    ]
+
+
+def test_first_paragraph() -> None:
+    assert (
+        first_paragraph(
+            dedent(
+                """\
+            Hello! I'm spread out
+            over multiple
+               lines.
+
+            Second paragraph.
+            """
+            )
+        )
+        == "Hello! I'm spread out over multiple    lines."
+    )
+    assert first_paragraph("Only one paragraph.") == "Only one paragraph."


### PR DESCRIPTION
Newlines are important for readability.

However, we weren't preserving the newlines from target docstring because it's tricky to render correctly. Docstring is written with _hard wrapping_, whereas our options system uses _soft wrapping_ (e.g. via implicit string concatenation). Because we wrap `./pants help` to 96 characters, this could create weird situations where we could end up with really short lines. Instead, we decided to flatten everything into a single paragraph.

This PR changes the description to come from a class property `description`, rather than from the class's docstring, which allows for much tighter control of the rendering. Now, authors can limit use of `\n` to when it is only intentional, rather than unintentionally from their source code having hard wrapping due to line limits.

Before:

```
platforms
    type: Iterable[str] | None
    default: None
    The platforms the built PEX should be compatible with. This defaults to the
    current platform, but can be overridden to different platforms. You can give a
    list of multiple platforms to create a multiplatform PEX. To use wheels for
    specific interpreter/platform tags, you can append them to the platform with
    hyphens like: PLATFORM-IMPL-PYVER-ABI (e.g. "linux_x86_64-cp-27-cp27mu",
    "macosx_10.12_x86_64-cp-36-cp36m"). PLATFORM is the host platform e.g.
    "linux-x86_64", "macosx-10.12-x86_64", etc". IMPL is the Python implementation
    abbreviation (e.g. "cp", "pp", "jp"). PYVER is a two-digit string representing
    the python version (e.g. "27", "36"). ABI is the ABI tag (e.g. "cp36m",
    "cp27mu", "abi3", "none").
```

After:

```
platforms
    type: Iterable[str] | None
    default: None
    The platforms the built PEX should be compatible with.

    This defaults to the current platform, but can be overridden to different platforms. You can
    give a list of multiple platforms to create a multiplatform PEX.

    To use wheels for specific interpreter/platform tags, you can append them to the platform
    with hyphens like: PLATFORM-IMPL-PYVER-ABI (e.g. "linux_x86_64-cp-27-cp27mu",
    "macosx_10.12_x86_64-cp-36-cp36m"):

        - PLATFORM: the host platform, e.g. "linux-x86_64", "macosx-10.12-x86_64".
        - IMPL: the Python implementation abbreviation, e.g. "cp", "pp", "jp".
        - PYVER: a two-digit string representing the Python version, e.g. "27", "36".
        - ABI: the ABI tag, e.g. "cp36m", "cp27mu", "abi3", "none".
```

### Added benefit: reclaim docstrings

Before, the docstring for targets/fields had to be user-facing, rather than developer-facing. Now, the docstring can mention the implementation.

[ci skip-rust]