### PR TITLE
Simplify and fix the @ensure_daemon decorator.

### DIFF
--- a/src/python/pants/base/exiter_integration_test.py
+++ b/src/python/pants/base/exiter_integration_test.py
@@ -5,13 +5,14 @@ from pants.testutil.pants_integration_test import ensure_daemon, run_pants
 
 
 @ensure_daemon
-def test_unicode_containing_exception():
+def test_unicode_containing_exception(use_pantsd: bool) -> None:
     pants_run = run_pants(
         [
             "--backend-packages=pants.backend.python",
             "run",
             "testprojects/src/python/unicode/compilation_failure/main.py",
-        ]
+        ],
+        use_pantsd=use_pantsd,
     )
     pants_run.assert_failure()
     assert "import sys¡" in pants_run.stderr

--- a/src/python/pants/core/goals/fmt_integration_test.py
+++ b/src/python/pants/core/goals/fmt_integration_test.py
@@ -13,7 +13,7 @@ from pants.util.dirutil import read_file
 
 
 @ensure_daemon
-def test_fmt_then_edit():
+def test_fmt_then_edit(use_pantsd: bool) -> None:
     f = "testprojects/src/python/hello/greet/greet.py"
     with temporary_workdir() as workdir:
 
@@ -25,6 +25,7 @@ def test_fmt_then_edit():
                     f,
                 ],
                 workdir=workdir,
+                use_pantsd=use_pantsd,
             ).assert_success()
 
         # Run once to start up, and then capture the file content.

--- a/src/python/pants/engine/internals/scheduler_integration_test.py
+++ b/src/python/pants/engine/internals/scheduler_integration_test.py
@@ -25,13 +25,14 @@ def test_visualize_to():
 
 
 @ensure_daemon
-def test_graceful_termination():
+def test_graceful_termination(use_pantsd: bool) -> None:
     result = run_pants(
         [
             "--backend-packages=['pants.backend.python', 'internal_plugins.rules_for_testing']",
             "list-and-die-for-testing",
             "testprojects/src/python/hello/greet",
-        ]
+        ],
+        use_pantsd=use_pantsd,
     )
     result.assert_failure()
     assert result.stdout == "testprojects/src/python/hello/greet\n"

--- a/src/python/pants/option/options_integration_test.py
+++ b/src/python/pants/option/options_integration_test.py
@@ -42,7 +42,7 @@ def test_invalid_options() -> None:
 
 
 @ensure_daemon
-def test_deprecation_and_ignore_pants_warnings() -> None:
+def test_deprecation_and_ignore_pants_warnings(use_pantsd: bool) -> None:
     plugin = dedent(
         """\
         from pants.option.subsystem import Subsystem
@@ -73,7 +73,7 @@ def test_deprecation_and_ignore_pants_warnings() -> None:
             },
             "mock-options": {"deprecated": "foo"},
         }
-        result = run_pants(["help"], config=config)
+        result = run_pants(["help"], config=config, use_pantsd=use_pantsd)
         result.assert_success()
         assert (
             "DEPRECATED: option 'deprecated' in scope 'mock-options' will be removed in version "
@@ -82,7 +82,7 @@ def test_deprecation_and_ignore_pants_warnings() -> None:
 
         # Now use `ignore_pants_warnings`.
         config["GLOBAL"]["ignore_pants_warnings"] = ["DEPRECATED: option 'deprecated'"]  # type: ignore[index]
-        ignore_result = run_pants(["help"], config=config)
+        ignore_result = run_pants(["help"], config=config, use_pantsd=use_pantsd)
         ignore_result.assert_success()
         assert "DEPRECATED: option 'deprecated'" not in ignore_result.stderr
 

--- a/src/python/pants/vcs/changed_integration_test.py
+++ b/src/python/pants/vcs/changed_integration_test.py
@@ -12,12 +12,7 @@ from typing import Iterator, List, Optional
 import pytest
 
 from pants.base.build_environment import get_buildroot
-from pants.testutil.pants_integration_test import (
-    PantsResult,
-    ensure_daemon,
-    run_pants,
-    run_pants_with_workdir,
-)
+from pants.testutil.pants_integration_test import PantsResult, run_pants, run_pants_with_workdir
 from pants.testutil.test_base import AbstractTestGenerator
 from pants.util.contextutil import environment_as, temporary_dir
 from pants.util.dirutil import safe_delete, safe_mkdir, safe_open, touch
@@ -380,13 +375,12 @@ class ChangedIntegrationTest(unittest.TestCase, AbstractTestGenerator):
             pants_run.assert_success()
             self.assertEqual(pants_run.stdout.strip(), "")
 
-    @ensure_daemon
-    def test_list_changed(self, use_pantsd: bool) -> None:
+    def test_list_changed(self) -> None:
         deleted_file = "src/python/sources/sources.py"
 
         with create_isolated_git_repo() as worktree:
             safe_delete(os.path.join(worktree, deleted_file))
-            pants_run = self.run_pants(["--changed-since=HEAD", "list"], use_pantsd=use_pantsd)
+            pants_run = self.run_pants(["--changed-since=HEAD", "list"])
             pants_run.assert_success()
             self.assertEqual(pants_run.stdout.strip(), "src/python/sources")
 

--- a/src/python/pants/vcs/changed_integration_test.py
+++ b/src/python/pants/vcs/changed_integration_test.py
@@ -381,12 +381,12 @@ class ChangedIntegrationTest(unittest.TestCase, AbstractTestGenerator):
             self.assertEqual(pants_run.stdout.strip(), "")
 
     @ensure_daemon
-    def test_list_changed(self):
+    def test_list_changed(self, use_pantsd: bool) -> None:
         deleted_file = "src/python/sources/sources.py"
 
         with create_isolated_git_repo() as worktree:
             safe_delete(os.path.join(worktree, deleted_file))
-            pants_run = self.run_pants(["--changed-since=HEAD", "list"])
+            pants_run = self.run_pants(["--changed-since=HEAD", "list"], use_pantsd=use_pantsd)
             pants_run.assert_success()
             self.assertEqual(pants_run.stdout.strip(), "src/python/sources")
 

--- a/tests/python/pants_test/integration/goal_rule_integration_test.py
+++ b/tests/python/pants_test/integration/goal_rule_integration_test.py
@@ -14,8 +14,8 @@ from pants_test.pantsd.pantsd_integration_test_base import PantsDaemonIntegratio
 
 
 @ensure_daemon
-def test_goal_validation():
-    result = run_pants(["blah", "::"])
+def test_goal_validation(use_pantsd: bool) -> None:
+    result = run_pants(["blah", "::"], use_pantsd=use_pantsd)
     result.assert_failure()
     assert "Unknown goal: blah" in result.stdout
 


### PR DESCRIPTION
### Problem

While investigating #11335, I noticed that the `@ensure_daemon` decorator (intended to run a test twice: once with `pantsd`, and once without) was broken by the introduction of the explicit `use_pantsd` parameter to the `run_pants` helper methods. 

### Solution

Preserve the decorator to assist with the common case, but implement it in terms of `pytest.mark.parametrize` to make it less fragile and more explicit.

### Result

Tests that had only been running with `pantsd` will run without it as well.

[ci skip-rust]
[ci skip-build-wheels]