### PR TITLE
[internal] Switch to toolchain pants plugin

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -20,7 +20,7 @@ backend_packages.add = [
 ]
 
 plugins = [
-  "toolchain.pants.buildsense.plugin==0.1.0",
+  "toolchain.pants.plugin==0.1.0",
 ]
 
 build_file_prelude_globs = ["pants-plugins/python_integration_tests_macro.py"]

--- a/pants.travis-ci.toml
+++ b/pants.travis-ci.toml
@@ -21,5 +21,5 @@ report = ["raw", "xml"]
 
 [auth]
 from_env_var = "TOOLCHAIN_AUTH_TOKEN"
-customer = "pantsbuild"
+org = "pantsbuild"
 ci_env_variables = ["TRAVIS", "TRAVIS_JOB_ID", "TRAVIS_BUILD_ID", "TRAVIS_PULL_REQUEST", "TRAVIS_BUILD_WEB_URL"]


### PR DESCRIPTION
This change upgrades to the new version of the Toolchain pants plugin (which was also renamed).
There are a bunch of bug fixes and removed internal feature flags that are no longer needed.
https://pypi.org/project/toolchain.pants.plugin/0.1.0/
See https://github.com/pantsbuild/pants/pull/11287#issue-535416870 for more context