### PR TITLE
Use the whole description for `./pants help $subsystem`

### DIFF
--- a/pants-plugins/internal_plugins/releases/register.py
+++ b/pants-plugins/internal_plugins/releases/register.py
@@ -14,9 +14,8 @@ from pants.version import PANTS_SEMVER, VERSION
 
 
 class PantsReleases(Subsystem):
-    """Options for Pants's release process."""
-
     options_scope = "pants-releases"
+    help = "Options for Pants's release process."
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/awslambda/python/lambdex.py
+++ b/src/python/pants/backend/awslambda/python/lambdex.py
@@ -5,9 +5,9 @@ from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 
 
 class Lambdex(PythonToolBase):
-    """A tool for turning .pex files into AWS Lambdas (https://github.com/wickman/lambdex)."""
-
     options_scope = "lambdex"
+    help = "A tool for turning .pex files into AWS Lambdas (https://github.com/wickman/lambdex)."
+
     default_version = "lambdex==0.1.3"
     # TODO(John Sirois): Remove when we can upgrade to a version of lambdex with
     # https://github.com/wickman/lambdex/issues/6 fixed.

--- a/src/python/pants/backend/codegen/export_codegen_goal.py
+++ b/src/python/pants/backend/codegen/export_codegen_goal.py
@@ -21,9 +21,8 @@ logger = logging.getLogger(__name__)
 
 
 class ExportCodegenSubsystem(GoalSubsystem):
-    """Write generated files to `dist/codegen` for use outside of Pants."""
-
     name = "export-codegen"
+    help = "Write generated files to `dist/codegen` for use outside of Pants."
 
     required_union_implementations = (GenerateSourcesRequest,)
 

--- a/src/python/pants/backend/codegen/protobuf/protoc.py
+++ b/src/python/pants/backend/codegen/protobuf/protoc.py
@@ -8,9 +8,9 @@ from pants.engine.platform import Platform
 
 
 class Protoc(TemplatedExternalTool):
-    """The protocol buffer compiler (https://developers.google.com/protocol-buffers)."""
-
     options_scope = "protoc"
+    help = "The protocol buffer compiler (https://developers.google.com/protocol-buffers)."
+
     default_version = "3.11.4"
     default_known_versions = [
         "3.11.4|darwin|8c6af11e1058efe953830ecb38324c0e0fd2fb67df3891896d138c535932e7db|2482119",

--- a/src/python/pants/backend/codegen/protobuf/python/grpc_python_plugin.py
+++ b/src/python/pants/backend/codegen/protobuf/python/grpc_python_plugin.py
@@ -5,9 +5,9 @@ from pants.core.util_rules.external_tool import TemplatedExternalTool
 
 
 class GrpcPythonPlugin(TemplatedExternalTool):
-    """The grpc protobuf plugin for python."""
-
     options_scope = "grpc_python_plugin"
+    help = "The gRPC Protobuf plugin for Python."
+
     default_version = "1.32.0"
     default_known_versions = [
         "1.32.0|darwin|b2db586656463841aa2fd4aab34fb6bd3ef887b522d80e4f2f292146c357f533|6215304",

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -13,12 +13,11 @@ from pants.option.subsystem import Subsystem
 
 
 class PythonProtobufSubsystem(Subsystem):
-    """Options related to the Protobuf Python backend.
-
-    See https://www.pantsbuild.org/docs/protobuf.
-    """
-
     options_scope = "python-protobuf"
+    help = (
+        "Options related to the Protobuf Python backend.\n\nSee "
+        "https://www.pantsbuild.org/docs/protobuf."
+    )
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/project_info/count_loc.py
+++ b/src/python/pants/backend/project_info/count_loc.py
@@ -20,9 +20,9 @@ from pants.util.strutil import pluralize
 
 
 class SuccinctCodeCounter(TemplatedExternalTool):
-    """The Succinct Code Counter, aka `scc` (https://github.com/boyter/scc)."""
-
     options_scope = "scc"
+    help = "The Succinct Code Counter, aka `scc` (https://github.com/boyter/scc)."
+
     default_version = "2.12.0"
     default_known_versions = [
         "2.12.0|darwin|70b7002cd1e4541cb37b7b9cbc0eeedd13ceacb49628e82ab46332bb2e65a5a6|1842530",
@@ -60,9 +60,8 @@ class SuccinctCodeCounter(TemplatedExternalTool):
 
 
 class CountLinesOfCodeSubsystem(GoalSubsystem):
-    """Count lines of code."""
-
     name = "count-loc"
+    help = "Count lines of code."
 
 
 class CountLinesOfCode(Goal):

--- a/src/python/pants/backend/project_info/dependees.py
+++ b/src/python/pants/backend/project_info/dependees.py
@@ -96,9 +96,8 @@ class DependeesOutputFormat(Enum):
 
 
 class DependeesSubsystem(LineOriented, GoalSubsystem):
-    """List all targets that depend on any of the input files/targets."""
-
     name = "dependees"
+    help = "List all targets that depend on any of the input files/targets."
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/project_info/dependencies.py
+++ b/src/python/pants/backend/project_info/dependencies.py
@@ -27,9 +27,8 @@ class DependencyType(Enum):
 
 
 class DependenciesSubsystem(LineOriented, GoalSubsystem):
-    """List the dependencies of the input files/targets."""
-
     name = "dependencies"
+    help = "List the dependencies of the input files/targets."
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/project_info/filedeps.py
+++ b/src/python/pants/backend/project_info/filedeps.py
@@ -23,9 +23,8 @@ from pants.engine.target import (
 
 
 class FiledepsSubsystem(LineOriented, GoalSubsystem):
-    """List all source and BUILD files a target depends on."""
-
     name = "filedeps"
+    help = "List all source and BUILD files a target depends on."
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/project_info/filter_targets.py
+++ b/src/python/pants/backend/project_info/filter_targets.py
@@ -26,18 +26,16 @@ class TargetGranularity(Enum):
 
 
 class FilterSubsystem(LineOriented, GoalSubsystem):
-    """Filter the input targets based on various criteria.
-
-    Most of the filtering options below are comma-separated lists of filtering criteria, with an
-    implied logical OR between them, so that a target passes the filter if it matches any of the
-    criteria in the list.  A '-' prefix inverts the sense of the entire comma-separated list, so
-    that a target passes the filter only if it matches none of the criteria in the list.
-
-    Each of the filtering options may be specified multiple times, with an implied logical AND
-    between them.
-    """
-
     name = "filter"
+    help = (
+        "Filter the input targets based on various criteria.\n\nMost of the filtering options "
+        "below are comma-separated lists of filtering criteria, with an implied logical OR between "
+        "them, so that a target passes the filter if it matches any of the criteria in the list. "
+        "A '-' prefix inverts the sense of the entire comma-separated list, so that a target "
+        "passes the filter only if it matches none of the criteria in the list.\n\nEach of the "
+        "filtering options may be specified multiple times, with an implied logical AND between "
+        "them."
+    )
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/project_info/list_roots.py
+++ b/src/python/pants/backend/project_info/list_roots.py
@@ -8,9 +8,8 @@ from pants.source.source_root import AllSourceRoots
 
 
 class RootsSubsystem(LineOriented, GoalSubsystem):
-    """List the repo's registered source roots."""
-
     name = "roots"
+    help = "List the repo's registered source roots."
 
 
 class Roots(Goal):

--- a/src/python/pants/backend/project_info/list_targets.py
+++ b/src/python/pants/backend/project_info/list_targets.py
@@ -11,9 +11,8 @@ from pants.engine.target import DescriptionField, ProvidesField, UnexpandedTarge
 
 
 class ListSubsystem(LineOriented, GoalSubsystem):
-    """Lists all targets matching the file or target arguments."""
-
     name = "list"
+    help = "Lists all targets matching the file or target arguments."
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/project_info/source_file_validator.py
+++ b/src/python/pants/backend/project_info/source_file_validator.py
@@ -38,9 +38,8 @@ class DetailLevel(Enum):
 
 
 class ValidateSubsystem(GoalSubsystem):
-    """Validate sources against regexes."""
-
     name = "validate"
+    help = "Validate sources against regexes."
 
     @classmethod
     def register_options(cls, register):
@@ -92,9 +91,8 @@ class ValidationConfig:
 
 
 class SourceFileValidation(Subsystem):
-    """Configuration for source file validation."""
-
     options_scope = "sourcefile-validation"
+    help = "Configuration for source file validation."
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -33,9 +33,8 @@ from pants.python.python_setup import PythonSetup
 
 
 class PythonInferSubsystem(Subsystem):
-    """Options controlling which dependencies will be inferred for Python targets."""
-
     options_scope = "python-infer"
+    help = "Options controlling which dependencies will be inferred for Python targets."
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -95,9 +95,9 @@ class CoverageReportType(Enum):
 
 
 class CoverageSubsystem(PythonToolBase):
-    """Configuration for Python test coverage measurement."""
-
     options_scope = "coverage-py"
+    help = "Configuration for Python test coverage measurement."
+
     default_version = "coverage>=5.0.3,<5.1"
     default_entry_point = "coverage"
     register_interpreter_constraints = True

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -309,9 +309,8 @@ class FirstPartyDependencyVersionScheme(enum.Enum):
 
 
 class SetupPyGeneration(Subsystem):
-    """Options to control how setup.py is generated from a `python_distribution` target."""
-
     options_scope = "setup-py-generation"
+    help = "Options to control how setup.py is generated from a `python_distribution` target."
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -8,9 +8,9 @@ from pants.option.custom_types import file_option, shell_str
 
 
 class Black(PythonToolBase):
-    """The Black Python code formatter (https://black.readthedocs.io/)."""
-
     options_scope = "black"
+    help = "The Black Python code formatter (https://black.readthedocs.io/)."
+
     default_version = "black==20.8b1"
     default_extra_requirements = ["setuptools"]
     default_entry_point = "black:patched_main"

--- a/src/python/pants/backend/python/lint/docformatter/subsystem.py
+++ b/src/python/pants/backend/python/lint/docformatter/subsystem.py
@@ -8,9 +8,9 @@ from pants.option.custom_types import shell_str
 
 
 class Docformatter(PythonToolBase):
-    """The Python docformatter tool (https://github.com/myint/docformatter)."""
-
     options_scope = "docformatter"
+    help = "The Python docformatter tool (https://github.com/myint/docformatter)."
+
     default_version = "docformatter>=1.3.1,<1.4"
     default_entry_point = "docformatter:main"
     register_interpreter_constraints = True

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -8,9 +8,9 @@ from pants.option.custom_types import file_option, shell_str
 
 
 class Flake8(PythonToolBase):
-    """The Flake8 Python linter (https://flake8.pycqa.org/)."""
-
     options_scope = "flake8"
+    help = "The Flake8 Python linter (https://flake8.pycqa.org/)."
+
     default_version = "flake8>=3.7.9,<3.9"
     default_extra_requirements = [
         "setuptools<45; python_full_version == '2.7.*'",

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -8,9 +8,9 @@ from pants.option.custom_types import file_option, shell_str
 
 
 class Isort(PythonToolBase):
-    """The Python import sorter tool (https://timothycrosley.github.io/isort/)."""
-
     options_scope = "isort"
+    help = "The Python import sorter tool (https://timothycrosley.github.io/isort/)."
+
     default_version = "isort[pyproject]>=5.5.1,<5.6"
     default_extra_requirements = ["setuptools"]
     register_interpreter_constraints = True

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -9,9 +9,9 @@ from pants.option.custom_types import file_option, shell_str, target_option
 
 
 class Pylint(PythonToolBase):
-    """The PyLint linter for Python code (https://www.pylint.org/)."""
-
     options_scope = "pylint"
+    help = "The Pylint linter for Python code (https://www.pylint.org/)."
+
     default_version = "pylint>=2.4.4,<2.5"
     default_entry_point = "pylint"
 

--- a/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints.py
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints.py
@@ -29,9 +29,8 @@ logger = logging.getLogger(__name__)
 
 
 class PyConstraintsSubsystem(Outputting, GoalSubsystem):
-    """Determine what Python interpreter constraints are used by files/targets."""
-
     name = "py-constraints"
+    help = "Determine what Python interpreter constraints are used by files/targets."
 
     @classmethod
     def register_options(cls, register) -> None:

--- a/src/python/pants/backend/python/subsystems/ipython.py
+++ b/src/python/pants/backend/python/subsystems/ipython.py
@@ -5,9 +5,9 @@ from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 
 
 class IPython(PythonToolBase):
-    """The IPython enhanced REPL (https://ipython.org/)."""
-
     options_scope = "ipython"
+    help = "The IPython enhanced REPL (https://ipython.org/)."
+
     default_version = "ipython==7.16.1"  # The last version to support Python 3.6.
     default_entry_point = "IPython:start_ipython"
 

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -8,9 +8,8 @@ from pants.option.subsystem import Subsystem
 
 
 class PyTest(Subsystem):
-    """The pytest Python test framework (https://docs.pytest.org/)."""
-
     options_scope = "pytest"
+    help = "The pytest Python test framework (https://docs.pytest.org/)."
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -10,9 +10,8 @@ from pants.util.strutil import safe_shlex_join, safe_shlex_split
 
 
 class PythonNativeCode(Subsystem):
-    """Options for building native code using Python, e.g. when resolving distributions."""
-
     options_scope = "python-native-code"
+    help = "Options for building native code using Python, e.g. when resolving distributions."
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/python/subsystems/setuptools.py
+++ b/src/python/pants/backend/python/subsystems/setuptools.py
@@ -5,11 +5,11 @@ from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 
 
 class Setuptools(PythonToolBase):
-    """The Python setuptools library (https://github.com/pypa/setuptools)."""
+    options_scope = "setuptools"
+    help = "The Python setuptools library (https://github.com/pypa/setuptools)."
 
     # NB: setuptools doesn't have an entrypoint, unlike most python tools.
     # We call it via a generated setup.py script.
-    options_scope = "setuptools"
     default_version = "setuptools>=50.3.0,<50.4"
     default_extra_requirements = ["wheel==0.35.1"]
     register_interpreter_constraints = True

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -71,9 +71,8 @@ class InterpreterConstraintsField(StringSequenceField):
 
 
 class PexBinaryDefaults(Subsystem):
-    """Default settings for creating PEX executables."""
-
     options_scope = "pex-binary-defaults"
+    help = "Default settings for creating PEX executables."
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -9,9 +9,9 @@ from pants.option.custom_types import file_option, shell_str, target_option
 
 
 class MyPy(PythonToolBase):
-    """The MyPy Python type checker (http://mypy-lang.org/)."""
-
     options_scope = "mypy"
+    help = "The MyPy Python type checker (http://mypy-lang.org/)."
+
     default_version = "mypy==0.782"
     default_entry_point = "mypy"
     # See `mypy/rules.py`. We only use these default constraints in some situations. Technically,

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -33,10 +33,10 @@ from pants.util.strutil import create_path_env_var
 
 
 class PexBinary(TemplatedExternalTool):
-    """The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."""
-
     options_scope = "download-pex-bin"
     name = "pex"
+    help = "The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."
+
     default_version = "v2.1.24"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
 

--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -24,9 +24,8 @@ from pants.util.strutil import create_path_env_var
 
 
 class PexRuntimeEnvironment(Subsystem):
-    """How Pants uses Pex to run Python subprocesses."""
-
     options_scope = "pex"
+    help = "How Pants uses Pex to run Python subprocesses."
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -154,9 +154,8 @@ class LanguageFmtResults:
 
 
 class FmtSubsystem(GoalSubsystem):
-    """Autoformat source code."""
-
     name = "fmt"
+    help = "Autoformat source code."
 
     required_union_implementations = (LanguageFmtTargets,)
 

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -155,9 +155,8 @@ class LintRequest(StyleRequest):
 
 
 class LintSubsystem(GoalSubsystem):
-    """Run all linters and/or formatters in check mode."""
-
     name = "lint"
+    help = "Run all linters and/or formatters in check mode."
 
     required_union_implementations = (LintRequest,)
 

--- a/src/python/pants/core/goals/package.py
+++ b/src/python/pants/core/goals/package.py
@@ -64,9 +64,8 @@ class OutputPathField(StringField):
 
 
 class PackageSubsystem(GoalSubsystem):
-    """Create a distributable package."""
-
     name = "package"
+    help = "Create a distributable package."
 
     required_union_implementations = (PackageFieldSet,)
 

--- a/src/python/pants/core/goals/repl.py
+++ b/src/python/pants/core/goals/repl.py
@@ -38,9 +38,9 @@ class ReplImplementation(ABC):
 
 
 class ReplSubsystem(GoalSubsystem):
-    """Open a REPL with the specified code loadable."""
-
     name = "repl"
+    help = "Open a REPL with the specified code loadable."
+
     required_union_implementations = (ReplImplementation,)
 
     @classmethod

--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -53,13 +53,11 @@ class RunRequest:
 
 
 class RunSubsystem(GoalSubsystem):
-    """Runs a binary target.
-
-    This goal propagates the return code of the underlying executable. Run `echo $?` to inspect the
-    resulting return code.
-    """
-
     name = "run"
+    help = (
+        "Runs a binary target.\n\nThis goal propagates the return code of the underlying "
+        "executable. Run `echo $?` to inspect the resulting return code."
+    )
 
     required_union_implementations = (RunFieldSet,)
 

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -253,9 +253,8 @@ class CoverageReports(EngineAwareReturnType):
 
 
 class TestSubsystem(GoalSubsystem):
-    """Run tests."""
-
     name = "test"
+    help = "Run tests."
 
     required_union_implementations = (TestFieldSet,)
 

--- a/src/python/pants/core/goals/typecheck.py
+++ b/src/python/pants/core/goals/typecheck.py
@@ -132,9 +132,8 @@ class TypecheckRequest(StyleRequest):
 
 
 class TypecheckSubsystem(GoalSubsystem):
-    """Run type checkers."""
-
     name = "typecheck"
+    help = "Run type checkers."
 
     required_union_implementations = (TypecheckRequest,)
 

--- a/src/python/pants/core/util_rules/subprocess_environment.py
+++ b/src/python/pants/core/util_rules/subprocess_environment.py
@@ -36,9 +36,8 @@ SETTABLE_ENV_VARS = (
 #  Can be done via scoped subsystems, possibly.  However we should only do this if there
 #  is a real need.
 class SubprocessEnvironment(Subsystem):
-    """Environment settings for forked subprocesses."""
-
     options_scope = "subprocess-environment"
+    help = "Environment settings for forked subprocesses."
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -42,9 +42,8 @@ class RunTrackerOptionEncoder(CoercingOptionEncoder):
 
 
 class RunTracker(Subsystem):
-    """Tracks and times the execution of a pants run."""
-
     options_scope = "run-tracker"
+    help = "Tracks and times the execution of a pants run."
 
     # The name of the tracking root for the main thread (and the foreground worker threads).
     DEFAULT_ROOT_NAME = "main"

--- a/src/python/pants/help/help_formatter.py
+++ b/src/python/pants/help/help_formatter.py
@@ -33,9 +33,8 @@ class HelpFormatter(MaybeColor):
                 # The basic options section gets the description and options scope info.
                 # No need to repeat those in the advanced section.
                 title = f"{display_scope} options"
-                lines.append(self.maybe_green(f"{title}\n{'-' * len(title)}"))
-                if oshi.description:
-                    lines.append(f"\n{oshi.description}")
+                lines.append(self.maybe_green(f"{title}\n{'-' * len(title)}\n"))
+                lines.extend(hard_wrap(oshi.description))
                 lines.append(" ")
                 config_section = f"[{oshi.scope or 'GLOBAL'}]"
                 lines.append(f"Config section: {self.maybe_magenta(config_section)}")

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -286,12 +286,10 @@ class HelpInfoExtracter:
                 )
                 raise ValueError(
                     f"Subsystem {cls_name} with scope `{scope_info.scope}` has no description. "
-                    f"Add a docstring or implement get_description()."
+                    f"Add a class property `help`."
                 )
             is_goal = optionable_cls is not None and issubclass(optionable_cls, GoalSubsystem)
-            oshi: OptionScopeHelpInfo = HelpInfoExtracter(
-                scope_info.scope
-            ).get_option_scope_help_info(
+            oshi = HelpInfoExtracter(scope_info.scope).get_option_scope_help_info(
                 scope_info.description, options.get_parser(scope_info.scope), is_goal
             )
             scope_to_help_info[oshi.scope] = oshi

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -226,18 +226,16 @@ def test_grouping():
 
 def test_get_all_help_info():
     class Global(Subsystem):
-        """Global options."""
-
         options_scope = GLOBAL_SCOPE
+        help = "Global options."
 
         @classmethod
         def register_options(cls, register):
             register("-o", "--opt1", type=int, default=42, help="Option 1")
 
     class Foo(Subsystem):
-        """A foo."""
-
         options_scope = "foo"
+        help = "A foo."
 
         @classmethod
         def register_options(cls, register):
@@ -245,32 +243,22 @@ def test_get_all_help_info():
             register("--opt3", advanced=True, choices=["a", "b", "c"])
 
     class Bar(GoalSubsystem):
-        """The bar goal."""
-
         name = "bar"
+        help = "The bar goal."
 
     class QuxField(StringField):
-        """A qux string."""
-
         alias = "qux"
         default = "blahblah"
+        help = "A qux string."
 
     class QuuxField(IntField):
-        """A quux int.
-
-        Must be non-zero. Or zero. Whatever you like really.
-        """
-
         alias = "quux"
         required = True
+        help = "A quux int.\n\nMust be non-zero. Or zero. Whatever you like really."
 
     class BazLibrary(Target):
-        """A library of baz-es.
-
-        Use it however you like.
-        """
-
         alias = "baz_library"
+        help = "A library of baz-es.\n\nUse it however you like."
 
         core_fields = [QuxField, QuuxField]
 
@@ -415,7 +403,7 @@ def test_get_all_help_info():
                     {
                         "alias": "quux",
                         "default": None,
-                        "description": "A quux int. Must be non-zero. Or zero. "
+                        "description": "A quux int.\n\nMust be non-zero. Or zero. "
                         "Whatever you like really.",
                         "required": True,
                         "type_hint": "int",

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -22,7 +22,7 @@ from pants.option.arg_splitter import (
     VersionHelp,
 )
 from pants.option.scope import GLOBAL_SCOPE
-from pants.util.strutil import hard_wrap
+from pants.util.strutil import first_paragraph, hard_wrap
 
 
 class HelpPrinter(MaybeColor):
@@ -144,7 +144,7 @@ class HelpPrinter(MaybeColor):
         subsystem_description: Dict[str, str] = {}
         for alias, help_info in self._all_help_info.scope_to_help_info.items():
             if not help_info.is_goal and alias:
-                subsystem_description[alias] = help_info.description
+                subsystem_description[alias] = first_paragraph(help_info.description)
 
         longest_subsystem_alias = max(len(alias) for alias in subsystem_description.keys())
         chars_before_description = longest_subsystem_alias + 2

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -158,9 +158,8 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
 
 
 class GlobalOptions(Subsystem):
-    """Options to control the overall behavior of Pants."""
-
     options_scope = GLOBAL_SCOPE
+    help = "Options to control the overall behavior of Pants."
 
     @classmethod
     def register_bootstrap_options(cls, register):

--- a/src/python/pants/option/scope.py
+++ b/src/python/pants/option/scope.py
@@ -37,7 +37,7 @@ class ScopeInfo:
     @property
     def description(self) -> str:
         if hasattr(self.optionable_cls, "help"):
-            return getattr(self.optionable_cls, "help")
+            return cast(str, getattr(self.optionable_cls, "help"))
         return cast(str, self._optionable_cls_attr("get_description", lambda: "")())
 
     @property

--- a/src/python/pants/option/scope.py
+++ b/src/python/pants/option/scope.py
@@ -36,6 +36,8 @@ class ScopeInfo:
 
     @property
     def description(self) -> str:
+        if hasattr(self.optionable_cls, "help"):
+            return getattr(self.optionable_cls, "help")
         return cast(str, self._optionable_cls_attr("get_description", lambda: "")())
 
     @property

--- a/src/python/pants/python/python_repos.py
+++ b/src/python/pants/python/python_repos.py
@@ -7,12 +7,11 @@ from pants.option.subsystem import Subsystem
 
 
 class PythonRepos(Subsystem):
-    """External Python code repositories, such as PyPI.
-
-    These options may be used to point to custom cheeseshops when resolving requirements.
-    """
-
     options_scope = "python-repos"
+    help = (
+        "External Python code repositories, such as PyPI.\n\nThese options may be used to point to "
+        "custom cheeseshops when resolving requirements."
+    )
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -45,9 +45,8 @@ class ResolverVersion(Enum):
 
 
 class PythonSetup(Subsystem):
-    """A Python environment."""
-
     options_scope = "python-setup"
+    help = "Options for Pants's Python support."
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -91,9 +91,8 @@ class SourceRootPatternMatcher:
 
 
 class SourceRootConfig(Subsystem):
-    """Configuration for roots of source trees."""
-
     options_scope = "source"
+    help = "Configuration for roots of source trees."
 
     DEFAULT_ROOT_PATTERNS = ["/", "src", "src/python", "src/py"]
 

--- a/src/python/pants/vcs/changed.py
+++ b/src/python/pants/vcs/changed.py
@@ -86,12 +86,11 @@ class ChangedOptions:
 
 
 class Changed(Subsystem):
-    """Tell Pants to detect what files and targets have changed from Git.
-
-    See https://www.pantsbuild.org/docs/advanced-target-selection.
-    """
-
     options_scope = "changed"
+    help = (
+        "Tell Pants to detect what files and targets have changed from Git.\n\nSee "
+        "https://www.pantsbuild.org/docs/advanced-target-selection."
+    )
 
     @classmethod
     def register_options(cls, register):


### PR DESCRIPTION
Before, we would only render the first line of the docstring. Now, we use a `help` property to be able to safely render the entire thing - see https://github.com/pantsbuild/pants/pull/11355 for why we use a property rather than continuing to use the docstring.

Before:

```
▶ ./pants help changed
`changed` subsystem options
---------------------------

Tell Pants to detect what files and targets have changed from Git.

Config section: [changed]
```

After:

```
▶ ./pants help changed
`changed` subsystem options
---------------------------

Tell Pants to detect what files and targets have changed from Git.

See https://www.pantsbuild.org/docs/advanced-target-selection.

Config section: [changed]
```

[ci skip-rust]
[ci skip-build-wheels]