### PR TITLE
Upgrade to cpython 0.5.2.

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -427,9 +427,9 @@ checksum = "6d375c433320f6c5057ae04a04376eef4d04ce2801448cf8863a78da99107be4"
 
 [[package]]
 name = "cpython"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0473cc11511ce00b9405a2f96adf71fe3078a7c4543330de44c14081d57c6d59"
+checksum = "0f11357af68648b6a227e7e2384d439cec8595de65970f45e3f7f4b2600be472"
 dependencies = [
  "libc",
  "num-traits",
@@ -2071,9 +2071,9 @@ dependencies = [
 
 [[package]]
 name = "python3-sys"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf23dd54ae7b15c36ae352ec00f82503d6aa04c9fb951e0738c63f41047dd09a"
+checksum = "5b29b99c6868eb02beb3bf6ed025c8bcdf02efc149b8e80347d3e5d059a806db"
 dependencies = [
  "libc",
  "regex",


### PR DESCRIPTION
### Problem

`cpython` `0.5.2` includes a fix for an abort caused by dropping running Python code on Linux. We're cancelling code much more than we were, so this is potentially related to #11364.

### Solution

Upgrade to `cpython` `0.5.2`.

[ci skip-build-wheels]