### PR TITLE
Pin references to docs to the current version

### DIFF
--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -18,7 +18,7 @@ import requests
 from common import die
 
 from pants.help.help_info_extracter import to_help_str
-from pants.version import VERSION
+from pants.version import MAJOR_MINOR
 
 logger = logging.getLogger(__name__)
 
@@ -81,8 +81,7 @@ class ReferenceGenerator:
     def __init__(self, args):
         self._args = args
 
-        # Set the version based on VERSION, e.g. 2.1.0.dev0 becomes 2.1.
-        self._version = ".".join(VERSION.split(".")[:2])
+        self._version = MAJOR_MINOR
         key_confirmation = input(
             f"Generating docs for Pants {self._version}. Is this the correct version? [Y/n]: "
         )

--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -28,6 +28,7 @@ from pants.engine.target import (
 from pants.engine.unions import UnionRule
 from pants.source.filespec import Filespec
 from pants.source.source_root import SourceRoot, SourceRootRequest
+from pants.util.docutil import docs_url
 
 
 class PythonAwsLambdaSources(PythonSources):
@@ -37,7 +38,7 @@ class PythonAwsLambdaSources(PythonSources):
         "Remove the `sources` field and create a `python_library` target with the handler "
         "file included (if it does not yet exist). Pants will infer a dependency, which you can "
         "check with `./pants dependencies path/to:lambda`. See "
-        "https://www.pantsbuild.org/v2.2/docs/awslambda-python for an example.\n\nYou can also "
+        f"{docs_url('awslambda-python')} for an example.\n\nYou can also "
         "update the `handler` field to use the file name, "
         "e.g. `handler='lambda.py:handler_func'`. This will allow file arguments to still work "
         "with this target, meaning you can still use `./pants package path/to/lambda.py` instead "
@@ -206,7 +207,7 @@ class PythonAWSLambda(Target):
     )
     help = (
         "A self-contained Python function suitable for uploading to AWS Lambda.\n\nSee "
-        "https://www.pantsbuild.org/docs/awslambda-python."
+        f"{docs_url('awslambda-python')}."
     )
 
 

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -10,14 +10,12 @@ from pants.engine.target import InjectDependenciesRequest, InjectedDependencies
 from pants.engine.unions import UnionRule
 from pants.option.custom_types import target_option
 from pants.option.subsystem import Subsystem
+from pants.util.docutil import docs_url
 
 
 class PythonProtobufSubsystem(Subsystem):
     options_scope = "python-protobuf"
-    help = (
-        "Options related to the Protobuf Python backend.\n\nSee "
-        "https://www.pantsbuild.org/docs/protobuf."
-    )
+    help = f"Options related to the Protobuf Python backend.\n\nSee {docs_url('protobuf')}."
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/codegen/protobuf/target_types.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.engine.target import COMMON_TARGET_FIELDS, BoolField, Dependencies, Sources, Target
+from pants.util.docutil import docs_url
 
 
 # NB: We subclass Dependencies so that specific backends can add dependency injection rules to
@@ -24,7 +25,4 @@ class ProtobufGrpcToggle(BoolField):
 class ProtobufLibrary(Target):
     alias = "protobuf_library"
     core_fields = (*COMMON_TARGET_FIELDS, ProtobufDependencies, ProtobufSources, ProtobufGrpcToggle)
-    help = (
-        "Protobuf files used to generate various languages.\n\nSee "
-        "https://www.pantsbuild.org/docs/protobuf."
-    )
+    help = f"Protobuf files used to generate various languages.\n\nSee {docs_url('protobuf')}."

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -67,6 +67,7 @@ from pants.engine.target import (
 from pants.engine.unions import UnionMembership, UnionRule, union
 from pants.option.subsystem import Subsystem
 from pants.python.python_setup import PythonSetup
+from pants.util.docutil import docs_url
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized_property
 from pants.util.meta import frozen_after_init
@@ -92,7 +93,7 @@ class OwnershipError(Exception):
 
     def __init__(self, msg: str):
         super().__init__(
-            f"{msg} See https://www.pantsbuild.org/v2.0/docs/python-setup-py-goal for "
+            f"{msg} See {docs_url('python-distributions')} for "
             f"how python_library targets are mapped to distributions."
         )
 

--- a/src/python/pants/backend/python/lint/pylint/plugin_target_type.py
+++ b/src/python/pants/backend/python/lint/pylint/plugin_target_type.py
@@ -3,6 +3,7 @@
 
 from pants.backend.python.target_types import InterpreterConstraintsField, PythonSources
 from pants.engine.target import COMMON_TARGET_FIELDS, Dependencies, Target
+from pants.util.docutil import docs_url
 
 
 class PylintPluginSources(PythonSources):
@@ -13,7 +14,7 @@ class PylintPluginDependencies(Dependencies):
     help = (
         "Addresses to other targets that this plugin depends on.\n\nDue to restrictions with "
         "Pylint plugins, these targets must either be third-party Python dependencies "
-        "(https://www.pantsbuild.org/docs/python-third-party-dependencies) or be located within "
+        f"({docs_url('python-third-party-dependencies')}) or be located within "
         "this target's same directory or a subdirectory."
     )
 

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -6,6 +6,7 @@ from typing import List, Optional, cast
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.engine.addresses import UnparsedAddressInputs
 from pants.option.custom_types import file_option, shell_str, target_option
+from pants.util.docutil import docs_url
 
 
 class Pylint(PythonToolBase):
@@ -51,13 +52,13 @@ class Pylint(PythonToolBase):
                 "example, if your plugin is at `build-support/pylint/custom_plugin.py`, add "
                 "'build-support/pylint' to `[source].root_patterns` in `pants.toml`. This is "
                 "necessary for Pants to know how to tell Pylint to discover your plugin. See "
-                "https://www.pantsbuild.org/docs/source-roots.\n\nYou must also set "
-                "`load-plugins=$module_name` in your Pylint config file, and set the "
-                "`[pylint].config` option in `pants.toml`.\n\nWhile your plugin's code can depend "
-                "on other first-party code and third-party requirements, all first-party "
-                "dependencies of the plugin must live in the same directory or a subdirectory.\n\n"
-                "To instead load third-party plugins, set the option `[pylint].extra_requirements` "
-                "and set the `load-plugins` option in your Pylint config."
+                f"{docs_url('source-roots')}\n\nYou must also set `load-plugins=$module_name` in "
+                "your Pylint config file, and set the `[pylint].config` option in `pants.toml`."
+                "\n\nWhile your plugin's code can depend on other first-party code and third-party "
+                "requirements, all first-party dependencies of the plugin must live in the same "
+                "directory or a subdirectory.\n\nTo instead load third-party plugins, set the "
+                "option `[pylint].extra_requirements` and set the `load-plugins` option in your "
+                "Pylint config."
             ),
         )
 

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -35,6 +35,7 @@ from pants.engine.target import (
 from pants.option.subsystem import Subsystem
 from pants.python.python_setup import PythonSetup
 from pants.source.filespec import Filespec
+from pants.util.docutil import docs_url
 
 # -----------------------------------------------------------------------------------------------
 # Common fields
@@ -54,7 +55,7 @@ class InterpreterConstraintsField(StringSequenceField):
         "more than one element to OR the constraints, e.g. `['PyPy==3.7.*', 'CPython==3.7.*']` "
         "means either PyPy 3.7 _or_ CPython 3.7.\n\nIf the field is not set, it will default to "
         "the option `[python-setup].interpreter_constraints`.\n\nSee "
-        "https://www.pantsbuild.org/docs/python-interpreter-compatibility."
+        f"{docs_url('python-interpreter-compatibility')}."
     )
 
     def value_or_global_default(self, python_setup: PythonSetup) -> Tuple[str, ...]:
@@ -102,7 +103,7 @@ class DeprecatedPexBinarySources(PythonSources):
         "e.g. `entry_point='app.py'` or `entry_point='app.py:func'`. Create a `python_library` "
         "target with the entry point's file included (if it does not yet exist). Pants will infer "
         "a dependency, which you can check with `./pants dependencies path/to:app`. See "
-        "https://www.pantsbuild.org/v2.2/docs/python-package-goal for more instructions."
+        f"{docs_url('python-package-goal')} for more instructions."
     )
 
 
@@ -264,7 +265,7 @@ class PexBinary(Target):
     help = (
         "A Python target that can be converted into an executable PEX file.\n\nPEX files are "
         "self-contained executable files that contain a complete Python environment capable of "
-        "running the target. For more information, see https://www.pantsbuild.org/docs/pex-files."
+        f"running the target. For more information, see {docs_url('pex-files')}."
     )
 
 
@@ -346,8 +347,7 @@ class PythonTests(Target):
     help = (
         "Python tests, written in either Pytest style or unittest style.\n\nAll test util code, "
         "other than `conftest.py`, should go into a dedicated `python_library()` target and then "
-        "be included in the `dependencies` field.\n\nSee "
-        "https://www.pantsbuild.org/docs/python-test-goal."
+        f"be included in the `dependencies` field.\n\nSee {docs_url('python-test-goal')}."
     )
 
 
@@ -476,7 +476,7 @@ class PythonRequirementLibrary(Target):
         "Python requirements inline in a BUILD file. If you have a `requirements.txt` file "
         "already, you can instead use the macro `python_requirements()` to convert each "
         "requirement into a `python_requirement_library()` target automatically.\n\nSee "
-        "https://www.pantsbuild.org/docs/python-third-party-dependencies."
+        f"{docs_url('python-third-party-dependencies')}."
     )
 
 
@@ -512,7 +512,7 @@ class PythonProvidesField(ScalarField, ProvidesField):
     required = True
     help = (
         "The setup.py kwargs for the external artifact built from this target.\n\nSee "
-        "https://www.pantsbuild.org/docs/python-setup-py-goal."
+        f"{docs_url('python-distributions')}."
     )
 
     @classmethod
@@ -532,7 +532,7 @@ class SetupPyCommandsField(StringSequenceField):
         "The runtime commands to invoke setup.py with to create the distribution, e.g. "
         '["bdist_wheel", "--python-tag=py36.py37", "sdist"].\n\nIf empty or unspecified, '
         "will just create a chroot with a setup() function.\n\nSee "
-        "https://www.pantsbuild.org/docs/python-setup-py-goal."
+        f"{docs_url('python-distributions')}."
     )
 
 

--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -32,6 +32,7 @@ from pants.engine.target import (
 from pants.engine.unions import UnionRule
 from pants.option.global_options import FilesNotFoundBehavior
 from pants.source.source_root import SourceRoot, SourceRootRequest
+from pants.util.docutil import docs_url
 
 # -----------------------------------------------------------------------------------------------
 # `pex_binary` rules
@@ -63,7 +64,9 @@ async def resolve_pex_entry_point(request: ResolvePexEntryPointRequest) -> Resol
             Paths, PathGlobs, request.sources.path_globs(FilesNotFoundBehavior.error)
         )
         if len(binary_source_paths.files) != 1:
-            instructions_url = "https://www.pantsbuild.org/docs/python-package-goal#creating-a-pex-file-from-a-pex_binary-target"
+            instructions_url = docs_url(
+                "python-package-goal#creating-a-pex-file-from-a-pex_binary-target"
+            )
             if not ep_val:
                 raise InvalidFieldException(
                     f"The `{ep_alias}` field is not set for the target {address}. Run "

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -42,6 +42,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import FieldSet, Target, TransitiveTargets, TransitiveTargetsRequest
 from pants.engine.unions import UnionRule
 from pants.python.python_setup import PythonSetup
+from pants.util.docutil import docs_url
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 from pants.util.strutil import pluralize
@@ -99,7 +100,7 @@ def check_and_warn_if_python_version_configured(
         logger.warning(
             f"You set {formatted_configured}. Normally, Pants would automatically set this for you "
             "based on your code's interpreter constraints "
-            "(https://www.pantsbuild.org/docs/python-interpreter-compatibility). Instead, it will "
+            f"({docs_url('python-interpreter-compatibility')}). Instead, it will "
             "use what you set.\n\n(Automatically setting the option allows Pants to partition your "
             "targets by their constraints, so that, for example, you can run MyPy on Python 2-only "
             "code and Python 3-only code at the same time. This feature may no longer work.)"

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -78,6 +78,7 @@ from pants.engine.target import (
 from pants.engine.unions import UnionMembership
 from pants.option.global_options import GlobalOptions, OwnersNotFoundBehavior
 from pants.source.filespec import matches_filespec
+from pants.util.docutil import docs_url
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 
@@ -463,7 +464,7 @@ def _log_or_raise_unmatched_owners(
         msgs.append(
             f"No owning targets could be found for the file `{file_path}`.\n\nPlease check "
             f"that there is a BUILD file in `{file_path.parent}` with a target whose `sources` "
-            f"field includes `{file_path}`. See https://www.pantsbuild.org/docs/targets for more "
+            f"field includes `{file_path}`. See {docs_url('targets')} for more "
             f"information on target definitions.{option_msg}"
         )
 

--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -11,6 +11,7 @@ from pants.base.exceptions import MappingError
 from pants.base.parse_context import ParseContext
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.internals.target_adaptor import TargetAdaptor
+from pants.util.docutil import docs_url
 from pants.util.frozendict import FrozenDict
 
 
@@ -122,6 +123,6 @@ def error_on_imports(build_file_content: str, filepath: str) -> None:
         raise ParseError(
             f"Import used in {filepath} at line {lineno}. Import statements are banned in "
             "BUILD files because they can easily break Pants caching and lead to stale results. "
-            "\n\nInstead, consider writing a macro (https://www.pantsbuild.org/docs/macros) or "
-            "writing a plugin (https://www.pantsbuild.org/docs/plugins-overview)."
+            f"\n\nInstead, consider writing a macro ({docs_url('macros')}) or "
+            f"writing a plugin ({docs_url('plugins-overview')}."
         )

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -18,6 +18,7 @@ from pants.option.custom_types import dir_option
 from pants.option.errors import OptionsError
 from pants.option.scope import GLOBAL_SCOPE
 from pants.option.subsystem import Subsystem
+from pants.util.docutil import docs_url
 from pants.util.logging import LogLevel
 
 
@@ -278,7 +279,7 @@ class GlobalOptions(Subsystem):
             help="Use this Pants version. Note that Pants only uses this to verify that you are "
             "using the requested version, as Pants cannot dynamically change the version it "
             "is using once the program is already running.\n\nIf you use the `./pants` script from "
-            "https://www.pantsbuild.org/docs/installation, however, changing the value in your "
+            f"{docs_url('installation')}, however, changing the value in your "
             "`pants.toml` will cause the new version to be installed and run automatically.\n\n"
             "Run `./pants --version` to check what is being used.",
         )
@@ -845,7 +846,7 @@ class GlobalOptions(Subsystem):
             metavar="[+-]tag1,tag2,...",
             help=(
                 "Include only targets with these tags (optional '+' prefix) or without these "
-                "tags ('-' prefix). See https://www.pantsbuild.org/docs/advanced-target-selection."
+                f"tags ('-' prefix). See {docs_url('advanced-target-selection')}."
             ),
         )
         register(
@@ -905,7 +906,7 @@ class GlobalOptions(Subsystem):
             default=[],
             help=(
                 "Python files to evaluate and whose symbols should be exposed to all BUILD files. "
-                "See https://www.pantsbuild.org/docs/macros."
+                f"See {docs_url('macros')}."
             ),
         )
         register(

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -17,6 +17,7 @@ from pants.engine.fs import PathGlobs, Paths
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import Target
 from pants.option.subsystem import Subsystem
+from pants.util.docutil import docs_url
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized_method
@@ -41,9 +42,7 @@ class SourceRootError(Exception):
     """An error related to SourceRoot computation."""
 
     def __init__(self, msg: str):
-        super().__init__(
-            f"{msg}See https://www.pantsbuild.org/docs/source-roots for how to define source roots."
-        )
+        super().__init__(f"{msg}See {docs_url('source-roots')} for how to define source roots.")
 
 
 class InvalidSourceRootPatternError(SourceRootError):
@@ -112,7 +111,7 @@ class SourceRootConfig(Subsystem):
             "`<buildroot>/project1/src/python`. A `*` wildcard will match a single path segment, "
             "e.g., `src/*` will match `<buildroot>/src/python` and `<buildroot>/src/rust`. "
             "Use `/` to signify that the buildroot itself is a source root. "
-            "See https://www.pantsbuild.org/docs/source-roots.",
+            f"See {docs_url('source-roots')}",
         )
         register(
             "--marker-filenames",

--- a/src/python/pants/util/docutil.py
+++ b/src/python/pants/util/docutil.py
@@ -1,0 +1,9 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.version import MAJOR_MINOR
+
+
+def docs_url(slug: str) -> str:
+    """Link to the Pants docs using the current version of Pants."""
+    return f"https://www.pantsbuild.org/v{MAJOR_MINOR}/docs/{slug}"

--- a/src/python/pants/vcs/changed.py
+++ b/src/python/pants/vcs/changed.py
@@ -16,6 +16,7 @@ from pants.engine.internals.graph import Owners, OwnersRequest
 from pants.engine.rules import Get, collect_rules, rule
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.subsystem import Subsystem
+from pants.util.docutil import docs_url
 from pants.vcs.git import Git
 
 
@@ -89,7 +90,7 @@ class Changed(Subsystem):
     options_scope = "changed"
     help = (
         "Tell Pants to detect what files and targets have changed from Git.\n\nSee "
-        "https://www.pantsbuild.org/docs/advanced-target-selection."
+        f"{docs_url('advanced-target-selection')}."
     )
 
     @classmethod

--- a/src/python/pants/version.py
+++ b/src/python/pants/version.py
@@ -17,5 +17,7 @@ VERSION: str = (
     pkgutil.get_data(__name__, "VERSION").decode().strip()  # type: ignore[union-attr]
 )
 
+# E.g. 2.0 or 2.2.
+MAJOR_MINOR = ".".join(VERSION.split(".")[:2])
 
 PANTS_SEMVER = Version(VERSION)


### PR DESCRIPTION
Without pinning to particular versions, we have too much of a risk that the docs will become stale and might not even exist on new versions of the docs. 

It should be safe to pin as Readme.com does not have a restriction on how many versions we can maintain of the docs.