### PR TITLE
Update to nails 0.11.0

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1568,9 +1568,9 @@ dependencies = [
 
 [[package]]
 name = "nails"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324d0793d44314222dc61947ffecc0325fb1c824dd6ef6b231b98e0b1f06b11b"
+checksum = "b52b33b5ba2d46687c2d42625e3c26d496e9247a0f430a398c9ce7f167b65df1"
 dependencies = [
  "byteorder",
  "bytes",

--- a/src/rust/engine/nailgun/Cargo.toml
+++ b/src/rust/engine/nailgun/Cargo.toml
@@ -10,7 +10,7 @@ async_latch = { path = "../async_latch" }
 bytes = "0.5"
 futures = "0.3"
 log = "0.4"
-nails = "0.8"
+nails = "0.11"
 os_pipe = "0.9"
 task_executor = { path = "../task_executor" }
 tokio = { version = "0.2.23", features = ["tcp", "fs", "sync", "io-std", "signal"] }

--- a/src/rust/engine/nailgun/src/client.rs
+++ b/src/rust/engine/nailgun/src/client.rs
@@ -67,10 +67,6 @@ async fn handle_client_output(
               NailgunClientError::PostConnect(format!("Failed to flush stderr: {}", err))
             })?
           },
-          Some(ChildOutput::Exit(_)) => {
-            // NB: We ignore exit here and allow the main thread to handle exiting. This API is
-            // error prone: see https://github.com/stuhood/nails/issues/1 for more info.
-          }
           None => break,
         }
       }
@@ -100,10 +96,6 @@ async fn handle_client_input(mut stdin_write: mpsc::Sender<ChildInput>) -> Resul
       .await
       .map_err(send_to_io)?;
   }
-  stdin_write
-    .send(ChildInput::StdinEOF)
-    .await
-    .map_err(send_to_io)?;
   Ok(())
 }
 

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0.3"
 hashing = { path = "../hashing" }
 libc = "0.2.39"
 log = "0.4"
-nails = "0.8"
+nails = "0.11"
 sha2 = "0.9"
 sharded_lmdb = {  path = "../sharded_lmdb" }
 shell-quote = "0.1.0"

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -20,7 +20,7 @@ use fs::{
 use futures::future::{BoxFuture, FutureExt, TryFutureExt};
 use futures::stream::{BoxStream, StreamExt, TryStreamExt};
 use log::{debug, info};
-use nails::execution::{ChildOutput, ExitCode};
+use nails::execution::ExitCode;
 use shell_quote::bash;
 use store::{OneOffStoreFileByDigest, Snapshot, Store};
 use tokio::process::{Child, Command};
@@ -176,6 +176,16 @@ impl HermeticCommand {
       .stderr(stderr)
       .spawn()
   }
+}
+
+// TODO: A Stream that ends with `Exit` is error prone: we should consider creating a Child struct
+// similar to nails::server::Child (which is itself shaped like `std::process::Child`).
+// See https://github.com/stuhood/nails/issues/1 for more info.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ChildOutput {
+  Stdout(Bytes),
+  Stderr(Bytes),
+  Exit(ExitCode),
 }
 
 ///


### PR DESCRIPTION
Update to nails 0.11.0 to pull in some type safety (and hopefully correctness) improvements around cancellation.

[ci skip-build-wheels]