### PR TITLE
Fix some newlines not rendering correctly on docsite

### DIFF
--- a/build-support/bin/docs_templates/options_scope_reference.md.mustache
+++ b/build-support/bin/docs_templates/options_scope_reference.md.mustache
@@ -1,8 +1,8 @@
 {{#is_goal}}```
 ./pants {{scope}} [args]
 ```{{/is_goal}}
-{{! Use a div to render as plain text, rather than markdown. }}
-<div>{{description}}</div>
+{{! Mark as a paragraph to render as plain text, rather than markdown. }}
+<p>{{description}}</p>
 
 Config section: <span style="color: purple"><code>[{{scope}}{{^scope}}GLOBAL{{/scope}}]</code></span>
 

--- a/build-support/bin/docs_templates/single_option_reference.md.mustache
+++ b/build-support/bin/docs_templates/single_option_reference.md.mustache
@@ -3,16 +3,15 @@
   <code>{{env_var}}</code><br>
   <code>{{config_key}}</code>
 </div>
-{{! NB: This div causes the help message + deprecation to render as plain text, rather than markdown. }}
 <div style="padding-left: 2em;">
   {{#comma_separated_choices}}
   <span style="color: green">one of: <code>{{comma_separated_choices}}</code></span><br>
   {{/comma_separated_choices}}
-  <span style="color: green">default: {{{marked_up_default}}}
-  </span>{{#deprecated_message}}<br><span style="color: darkred">{{deprecated_message}}
-  </span>{{/deprecated_message}}{{#removal_hint}}<br><span style="color: darkred">{{removal_hint}}
-  </span>{{/removal_hint}}
-  <br>{{help}}
+  <span style="color: green">default: {{{marked_up_default}}}</span>
+  {{! Mark each of these as paragraphs to render as plain text, rather than markdown. }}
+  {{#deprecated_message}}<br><p style="color: darkred">{{deprecated_message}}</p>{{/deprecated_message}}
+  {{#removal_hint}}<br><p style="color: darkred">{{removal_hint}}</p>{{/removal_hint}}
+  <br><p>{{help}}</p>
 </div>
 <br>
 

--- a/build-support/bin/docs_templates/target_reference.md.mustache
+++ b/build-support/bin/docs_templates/target_reference.md.mustache
@@ -1,5 +1,5 @@
-{{! Use a div to render as plain text, rather than markdown. }}
-<div>{{description}}</div>
+{{! Mark as a paragraph to render as plain text, rather than markdown. }}
+<p>{{description}}</p>
 
 {{#fields}}
 ## <code>{{alias}}</code>
@@ -7,7 +7,7 @@
 <span style="color: purple">type: <code>{{type_hint}}</code></span>
 <span style="color: green">{{{default_or_required}}}</span>
 
-{{! Use a div to render as plain text, rather than markdown. }}
-<div>{{description}}</div>
+{{! Mark as a paragraph to render as plain text, rather than markdown. }}
+<p>{{description}}</p>
 
 {{/fields}}

--- a/src/python/pants/core/goals/package.py
+++ b/src/python/pants/core/goals/package.py
@@ -48,7 +48,7 @@ class BuiltPackage:
 
 class OutputPathField(StringField):
     alias = "output_path"
-    description = (
+    help = (
         "Where the built asset should be located.\n\nIf undefined, this will use the path to the "
         "BUILD file, followed by the target name. For example, `src/python/project:app` would be "
         "`src.python.project/app.ext.\n\nWhen running `./pants package`, this path will be "

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1219,16 +1219,10 @@ class DictStringToStringSequenceField(Field):
 
 
 class Sources(StringSequenceField, AsyncFieldMixin):
-    """A list of files and globs that belong to this target.
-
-    Paths are relative to the BUILD file's directory. You can ignore files/globs by prefixing them
-    with `!`. Example: `sources=['example.py', 'test_*.py', '!test_ignore.py']`.
-    """
-
     alias = "sources"
     expected_file_extensions: ClassVar[Optional[Tuple[str, ...]]] = None
     expected_num_files: ClassVar[Optional[Union[int, range]]] = None
-    description = (
+    help = (
         "A list of files and globs that belong to this target.\n\nPaths are relative to the BUILD "
         "file's directory. You can ignore files/globs by prefixing them with `!`.\n\nExample: "
         "`sources=['example.py', 'test_*.py', '!test_ignore.py']`."
@@ -1534,7 +1528,7 @@ class Dependencies(StringSequenceField, AsyncFieldMixin):
     """
 
     alias = "dependencies"
-    description = (
+    help = (
         "Addresses to other targets that this target depends on, e.g. ['helloworld/subdir:lib']."
         "\n\nAlternatively, you may include file names. Pants will find which target owns that "
         "file, and create a new target from that which only includes the file in its `sources` "
@@ -1730,7 +1724,7 @@ class SpecialCasedDependencies(StringSequenceField, AsyncFieldMixin):
 
 class Tags(StringSequenceField):
     alias = "tags"
-    description = (
+    help = (
         "Arbitrary strings to describe a target.\n\nFor example, you may tag some test targets "
         "with 'integration_test' so that you could run `./pants --tags='integration_test' test ::` "
         "to only run on targets with that tag."
@@ -1739,7 +1733,7 @@ class Tags(StringSequenceField):
 
 class DescriptionField(StringField):
     alias = "description"
-    description = (
+    help = (
         "A human-readable description of the target.\n\nUse `./pants list --documented ::` to see "
         "all targets with descriptions."
     )


### PR DESCRIPTION
The space between the first paragraph and second paragraph was not showing. This is fixed by wrapping the text in `<p>` instead of `<div>`.