### PR TITLE
Add goals to run_info

### DIFF
--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -179,6 +179,7 @@ class RunTracker(Subsystem):
         self._main_root_workunit.start(run_start_time)
         self.report.start_workunit(self._main_root_workunit)
 
+        self.run_info.add_info("goals", all_options.goals)
         goal_names: Tuple[str, ...] = tuple(all_options.goals)
         self._v2_goal_rule_names = goal_names
 


### PR DESCRIPTION
Add a new key "goals" containing the list of goals executed in this pants run, to the `run_info` structure in `RunTracker`, which will be output when the `run_information` method is called. This will allow us to get rid of the slightly-messy code around `_v2_goal_rule_names`, which contains the same information.