### PR TITLE
Revert "Add goals to run_info (#11374)"

### DIFF
--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -179,7 +179,6 @@ class RunTracker(Subsystem):
         self._main_root_workunit.start(run_start_time)
         self.report.start_workunit(self._main_root_workunit)
 
-        self.run_info.add_info("goals", all_options.goals)
         goal_names: Tuple[str, ...] = tuple(all_options.goals)
         self._v2_goal_rule_names = goal_names
 


### PR DESCRIPTION
Changing the schema of the `run_info` field names (even by adding an additional one) is problematic with respect to some Toolchain code, so we're reverting this change.