### PR TITLE
Add shortcut public API method to return cumulative timings data.

### DIFF
--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -16,7 +16,7 @@ from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE,
 from pants.base.run_info import RunInfo
 from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.engine.internals.native import Native
-from pants.goal.aggregated_timings import AggregatedTimings
+from pants.goal.aggregated_timings import AggregatedTimings, TimingData
 from pants.option.config import Config
 from pants.option.options import Options
 from pants.option.options_fingerprinter import CoercingOptionEncoder
@@ -286,7 +286,7 @@ class RunTracker(Subsystem):
             self.self_timings.add_timing(path, self_time, is_tool)
             self.outcomes[path] = workunit.outcome_string(workunit.outcome())
 
-    def get_cumulative_timings(self) -> List[dict]:
+    def get_cumulative_timings(self) -> TimingData:
         return self.cumulative_timings.get_all()
 
     def get_critical_path_timings(self):

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -225,7 +225,7 @@ class RunTracker(Subsystem):
         stats = {
             "run_info": self.run_information(),
             "pantsd_stats": self.pantsd_scheduler_metrics,
-            "cumulative_timings": self.cumulative_timings.get_all(),
+            "cumulative_timings": self.get_cumulative_timings(),
             "recorded_options": self.get_options_to_record(),
         }
         return stats
@@ -286,13 +286,16 @@ class RunTracker(Subsystem):
             self.self_timings.add_timing(path, self_time, is_tool)
             self.outcomes[path] = workunit.outcome_string(workunit.outcome())
 
+    def get_cumulative_timings(self) -> List[dict]:
+        return self.cumulative_timings.get_all()
+
     def get_critical_path_timings(self):
         """Get the cumulative timings of each goal and all of the goals it (transitively) depended
         on."""
         setup_workunit = WorkUnitLabel.SETUP.lower()
         transitive_dependencies = dict()
         raw_timings = dict()
-        for entry in self.cumulative_timings.get_all():
+        for entry in self.get_cumulative_timings():
             raw_timings[entry["label"]] = entry["timing"]
 
         critical_path_timings = AggregatedTimings()

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -287,7 +287,7 @@ class RunTracker(Subsystem):
             self.outcomes[path] = workunit.outcome_string(workunit.outcome())
 
     def get_cumulative_timings(self) -> TimingData:
-        return self.cumulative_timings.get_all()
+        return self.cumulative_timings.get_all()  # type: ignore[no-any-return]
 
     def get_critical_path_timings(self):
         """Get the cumulative timings of each goal and all of the goals it (transitively) depended


### PR DESCRIPTION
### Problem

Accessing RunTracker.cumulative_timings.get_all() exposes RunTracker implementation details, which is sub-optimal.

### Solution
Encapdulating logic and exposing a simple get_cumulative_timings() method