### PR TITLE
Deprecate Subsystems as global singletons

### DIFF
--- a/src/python/pants/base/exception_sink_integration_test.py
+++ b/src/python/pants/base/exception_sink_integration_test.py
@@ -130,7 +130,7 @@ def test_fails_ctrl_c_ffi_extern() -> None:
         pants_run = run_pants_with_workdir(
             command=lifecycle_stub_cmdline(),
             workdir=tmpdir,
-            extra_env={"_RAISE_KEYBOARDINTERRUPT_IN_EXTERNS": "True"},
+            extra_env={"_RAISE_KEYBOARDINTERRUPT_IN_EXTERNS": "run_lifecycle_stubs"},
         )
         pants_run.assert_failure()
 

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -81,12 +81,10 @@ class LocalPantsRunner:
             cls._handle_unknown_flags(err, options_bootstrapper)
             raise
 
-        stream_workunits = len(options.for_global_scope().streaming_workunits_handlers) != 0
         return graph_scheduler_helper.new_session(
             RunTracker.global_instance().run_id,
             dynamic_ui=global_scope.dynamic_ui,
             use_colors=global_scope.get("colors", True),
-            should_report_workunits=stream_workunits,
             session_values=SessionValues(
                 {
                     OptionsBootstrapper: options_bootstrapper,

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -86,7 +86,7 @@ class LocalPantsRunner:
             raise
 
         return graph_scheduler_helper.new_session(
-            RunTracker.global_instance().run_id,
+            RunTracker.global_instance(silent=True).run_id,
             dynamic_ui=global_scope.dynamic_ui,
             use_colors=global_scope.get("colors", True),
             session_values=SessionValues(
@@ -253,7 +253,7 @@ class LocalPantsRunner:
         return tuple(callbacks)
 
     def run(self, start_time: float) -> ExitCode:
-        run_tracker = RunTracker.global_instance()
+        run_tracker = RunTracker.global_instance(silent=True)
         self._start_run(run_tracker, start_time)
 
         with maybe_profiled(self.profile_path):

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -34,7 +34,11 @@ from pants.option.errors import UnknownFlagsError
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.option.subsystem import Subsystem
-from pants.reporting.streaming_workunit_handler import StreamingWorkunitHandler
+from pants.reporting.streaming_workunit_handler import (
+    StreamingWorkunitHandler,
+    WorkunitsCallback,
+    WorkunitsCallbackFactories,
+)
 from pants.util.contextutil import maybe_profiled
 
 logger = logging.getLogger(__name__)
@@ -234,6 +238,20 @@ class LocalPantsRunner:
         )
         return help_printer.print_help()
 
+    def _get_workunits_callbacks(self) -> Tuple[WorkunitsCallback, ...]:
+        # Load WorkunitsCallbacks with the legacy `get_streaming_workunit_callbacks` method, and with
+        # the new WorkunitsCallbackFactories method.
+        # NB: When the `--streaming-workunits-handlers` deprecation triggers, the first method will be
+        # removed.
+        streaming_handlers = self.options.for_global_scope().streaming_workunits_handlers
+        callbacks = list(Subsystem.get_streaming_workunit_callbacks(streaming_handlers))
+        (workunits_callback_factories,) = self.graph_session.scheduler_session.product_request(
+            WorkunitsCallbackFactories, [self.union_membership]
+        )
+        for wcf in workunits_callback_factories:
+            callbacks.append(wcf.callback_factory())
+        return tuple(callbacks)
+
     def run(self, start_time: float) -> ExitCode:
         run_tracker = RunTracker.global_instance()
         self._start_run(run_tracker, start_time)
@@ -244,12 +262,10 @@ class LocalPantsRunner:
             if self.options.help_request:
                 return self._print_help(self.options.help_request)
 
-            streaming_handlers = global_options.streaming_workunits_handlers
-            callbacks = Subsystem.get_streaming_workunit_callbacks(streaming_handlers)
             streaming_reporter = StreamingWorkunitHandler(
                 self.graph_session.scheduler_session,
                 run_tracker=run_tracker,
-                callbacks=callbacks,
+                callbacks=self._get_workunits_callbacks(),
                 report_interval_seconds=global_options.streaming_workunits_report_interval,
             )
 

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -250,6 +250,7 @@ class LocalPantsRunner:
             callbacks = Subsystem.get_streaming_workunit_callbacks(streaming_handlers)
             streaming_reporter = StreamingWorkunitHandler(
                 self.graph_session.scheduler_session,
+                run_tracker=run_tracker,
                 callbacks=callbacks,
                 report_interval_seconds=global_options.streaming_workunits_report_interval,
             )

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -281,9 +281,7 @@ class StreamingWorkunitTests(unittest.TestCase, SchedulerTestBase):
     def _fixture_for_rules(
         self, rules, max_workunit_verbosity: LogLevel = LogLevel.INFO
     ) -> Tuple[SchedulerSession, WorkunitTracker, StreamingWorkunitHandler]:
-        scheduler = self.mk_scheduler(
-            rules, include_trace_on_error=False, should_report_workunits=True
-        )
+        scheduler = self.mk_scheduler(rules, include_trace_on_error=False)
 
         tracker = WorkunitTracker()
         handler = StreamingWorkunitHandler(

--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -218,7 +218,6 @@ class Native(metaclass=SingletonMetaclass):
         scheduler,
         dynamic_ui: bool,
         build_id,
-        should_report_workunits: bool,
         session_values: SessionValues,
         cancellation_latch: PySessionCancellationLatch,
     ) -> PySession:
@@ -226,7 +225,6 @@ class Native(metaclass=SingletonMetaclass):
             scheduler=scheduler,
             should_render_ui=dynamic_ui,
             build_id=build_id,
-            should_report_workunits=should_report_workunits,
             session_values=session_values,
             cancellation_latch=cancellation_latch,
         )

--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -45,7 +45,7 @@ class Externs:
     def __init__(self, lib):
         self.lib = lib
 
-    _do_raise_keyboardinterrupt = bool(os.environ.get("_RAISE_KEYBOARDINTERRUPT_IN_EXTERNS", False))
+    _do_raise_keyboardinterrupt_in = os.environ.get("_RAISE_KEYBOARDINTERRUPT_IN_EXTERNS", None)
 
     def is_union(self, input_type):
         """Return whether or not a type is a member of a union."""
@@ -61,7 +61,10 @@ class Externs:
         self, func, arg
     ) -> Union[PyGeneratorResponseGet, PyGeneratorResponseGetMulti, PyGeneratorResponseBreak]:
         """Given a generator, send it the given value and return a response."""
-        if self._do_raise_keyboardinterrupt:
+        if (
+            self._do_raise_keyboardinterrupt_in
+            and self._do_raise_keyboardinterrupt_in in func.__name__
+        ):
             raise KeyboardInterrupt("ctrl-c interrupted execution of a ffi method!")
         try:
             res = func.send(arg)

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -344,7 +344,6 @@ class Scheduler:
         self,
         build_id,
         dynamic_ui: bool = False,
-        should_report_workunits: bool = False,
         session_values: Optional[SessionValues] = None,
         cancellation_latch: Optional[PySessionCancellationLatch] = None,
     ) -> SchedulerSession:
@@ -355,7 +354,6 @@ class Scheduler:
                 self._scheduler,
                 dynamic_ui,
                 build_id,
-                should_report_workunits,
                 session_values or SessionValues(),
                 cancellation_latch or PySessionCancellationLatch(),
             ),

--- a/src/python/pants/engine/internals/scheduler_test_base.py
+++ b/src/python/pants/engine/internals/scheduler_test_base.py
@@ -8,7 +8,7 @@ from dataclasses import asdict
 from pants.base.file_system_project_tree import FileSystemProjectTree
 from pants.engine.internals.native import Native
 from pants.engine.internals.native_engine import PyExecutor
-from pants.engine.internals.scheduler import Scheduler
+from pants.engine.internals.scheduler import Scheduler, SchedulerSession
 from pants.engine.unions import UnionMembership
 from pants.option.global_options import DEFAULT_EXECUTION_OPTIONS, ExecutionOptions
 from pants.util.contextutil import temporary_file_path
@@ -52,7 +52,7 @@ class SchedulerTestBase:
         should_report_workunits=False,
         execution_options=None,
         ca_certs_path=None,
-    ):
+    ) -> SchedulerSession:
         """Creates a SchedulerSession for a Scheduler with the given Rules installed."""
         rules = rules or []
         work_dir = work_dir or self._create_work_dir()

--- a/src/python/pants/engine/internals/scheduler_test_base.py
+++ b/src/python/pants/engine/internals/scheduler_test_base.py
@@ -49,7 +49,6 @@ class SchedulerTestBase:
         project_tree=None,
         work_dir=None,
         include_trace_on_error=True,
-        should_report_workunits=False,
         execution_options=None,
         ca_certs_path=None,
     ) -> SchedulerSession:
@@ -81,7 +80,6 @@ class SchedulerTestBase:
         )
         return scheduler.new_session(
             build_id="buildid_for_test",
-            should_report_workunits=should_report_workunits,
         )
 
     def execute(self, scheduler, product, *subjects):

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -33,6 +33,7 @@ from pants.init.options_initializer import OptionsInitializer
 from pants.option.global_options import DEFAULT_EXECUTION_OPTIONS, ExecutionOptions
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.option.subsystem import Subsystem
+from pants.reporting.streaming_workunit_handler import rules as streaming_workunit_handler_rules
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.vcs.changed import rules as changed_rules
 
@@ -252,6 +253,7 @@ class EngineInitializer:
                 *process.rules(),
                 *platform.rules(),
                 *changed_rules(),
+                *streaming_workunit_handler_rules(),
                 *specs_calculator.rules(),
                 *rules,
             )

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -51,14 +51,12 @@ class GraphScheduler:
         build_id,
         dynamic_ui: bool = False,
         use_colors=True,
-        should_report_workunits=False,
         session_values: Optional[SessionValues] = None,
         cancellation_latch: Optional[PySessionCancellationLatch] = None,
     ) -> GraphSession:
         session = self.scheduler.new_session(
             build_id,
             dynamic_ui,
-            should_report_workunits,
             session_values=session_values,
             cancellation_latch=cancellation_latch,
         )

--- a/src/python/pants/init/extension_loader.py
+++ b/src/python/pants/init/extension_loader.py
@@ -54,8 +54,8 @@ def load_plugins(
     is already on the path and an error will be thrown if it is not. Plugins should define their
     entrypoints in the `pantsbuild.plugin` group when configuring their distribution.
 
-    Like source backends, the `build_file_aliases`, `global_subsystems` and `register_goals` methods
-    are called if those entry points are defined.
+    Like source backends, the `build_file_aliases`, and `register_goals` methods are called if
+    those entry points are defined.
 
     * Plugins are loaded in the order they are provided. *
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -945,9 +945,16 @@ class GlobalOptions(Subsystem):
             member_type=str,
             default=[],
             advanced=True,
-            help="Use this option to name Subsystems which will receive streaming workunit events. "
-            "For instance, `--streaming-workunits-handlers=\"['pants.reporting.workunit.Workunits']\"` will "
-            'register a Subsystem called Workunits defined in the module "pants.reporting.workunit".',
+            removal_version="2.3.0.dev1",
+            removal_hint=(
+                "To register a StreamingWorkunitHandler callback, install a UnionRule "
+                "for type `WorkunitsCallbackFactoryRequest`."
+            ),
+            help=(
+                "Use this option to name Subsystems which will receive streaming workunit events. "
+                "For instance, `--streaming-workunits-handlers=\"['pants.reporting.workunit.Workunits']\"` will "
+                'register a Subsystem called Workunits defined in the module "pants.reporting.workunit".'
+            ),
         )
 
     @classmethod

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -945,7 +945,7 @@ class GlobalOptions(Subsystem):
             member_type=str,
             default=[],
             advanced=True,
-            removal_version="2.3.0.dev1",
+            removal_version="2.3.0.dev0",
             removal_hint=(
                 "To register a StreamingWorkunitHandler callback, install a UnionRule "
                 "for type `WorkunitsCallbackFactoryRequest`."

--- a/src/python/pants/option/subsystem.py
+++ b/src/python/pants/option/subsystem.py
@@ -155,7 +155,7 @@ class Subsystem(Optionable):
         # updated to access it in other ways.
         deprecated_conditional(
             predicate=lambda: not silent,
-            removal_version="2.3.0.dev1",
+            removal_version="2.3.0.dev0",
             entity_description="Subsystem.global_instance()",
             hint_message=(
                 "Note that `global_instance` is a v1-idiom only. v2 @rules should request a "
@@ -167,7 +167,7 @@ class Subsystem(Optionable):
 
     @classmethod
     @deprecated(
-        removal_version="2.3.0.dev1",
+        removal_version="2.3.0.dev0",
         subject="Subsystem.scoped_instance(..)",
         hint_message=(
             "Scoped Subsystem instances were a v1 idiom, which do not have a v2 equivalent. "

--- a/src/python/pants/option/subsystem.py
+++ b/src/python/pants/option/subsystem.py
@@ -24,6 +24,7 @@ from typing import (
     cast,
 )
 
+from pants.base.deprecated import deprecated, deprecated_conditional
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.optionable import Optionable, OptionableFactory
 from pants.option.options import Options
@@ -139,7 +140,7 @@ class Subsystem(Optionable):
         return cls._options is not None
 
     @classmethod
-    def global_instance(cls: Type[_S]) -> _S:
+    def global_instance(cls: Type[_S], silent: bool = False) -> _S:
         """Returns the global instance of this subsystem.
 
         :API: public
@@ -149,9 +150,31 @@ class Subsystem(Optionable):
         Note that `global_instance` is a v1-idiom only. v2 rules should always request a subsystem as a rule input, rather than
         trying to call <subsystem>.global_instance() in the body of an `@rule`.
         """
+        # NB: This entire method is deprecated, but the deprecation only triggers if `not silent` in
+        # order to allow the RunTracker to continue to be a Subsystem until consumers have been
+        # updated to access it in other ways.
+        deprecated_conditional(
+            predicate=lambda: not silent,
+            removal_version="2.3.0.dev1",
+            entity_description="Subsystem.global_instance()",
+            hint_message=(
+                "Note that `global_instance` is a v1-idiom only. v2 @rules should request a "
+                "Subsystem as a @rule argument, and callers outside of @rules should use "
+                "`Scheduler.product_request(<subsystem_cls>, [Params()])` to get an instance."
+            ),
+        )
         return cls._instance_for_scope(cls.options_scope)  # type: ignore[arg-type]  # MyPy is treating cls.options_scope as a Callable, rather than `str`
 
     @classmethod
+    @deprecated(
+        removal_version="2.3.0.dev1",
+        subject="Subsystem.scoped_instance(..)",
+        hint_message=(
+            "Scoped Subsystem instances were a v1 idiom, which do not have a v2 equivalent. "
+            "If you have a usecase for scoped Subsystems, please open an issue at "
+            "https://github.com/pantsbuild/pants/issues/new."
+        ),
+    )
     def scoped_instance(cls: Type[_S], optionable: Union[Optionable, Type[Optionable]]) -> _S:
         """Returns an instance of this subsystem for exclusive use by the given `optionable`.
 

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -156,7 +156,6 @@ class RuleRunner:
             session_values=SessionValues(
                 {OptionsBootstrapper: options_bootstrapper, PantsEnvironment: PantsEnvironment()}
             ),
-            should_report_workunits=True,
         )
         self.scheduler = graph_session.scheduler_session
 
@@ -236,7 +235,6 @@ class RuleRunner:
         options_bootstrapper = create_options_bootstrapper(args=args, env=env)
         self.scheduler = self.scheduler.scheduler.new_session(
             build_id="buildid_for_test",
-            should_report_workunits=True,
             session_values=SessionValues(
                 {OptionsBootstrapper: options_bootstrapper, PantsEnvironment: PantsEnvironment(env)}
             ),

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -580,7 +580,6 @@ py_class!(class PySession |py| {
           scheduler: PyScheduler,
           should_render_ui: bool,
           build_id: String,
-          should_report_workunits: bool,
           session_values: PyObject,
           cancellation_latch: PySessionCancellationLatch,
     ) -> CPyResult<Self> {
@@ -588,7 +587,6 @@ py_class!(class PySession |py| {
           scheduler.scheduler(py),
           should_render_ui,
           build_id,
-          should_report_workunits,
           session_values.into(),
           cancellation_latch.cancelled(py).clone(),
         )

--- a/src/rust/engine/src/session.rs
+++ b/src/rust/engine/src/session.rs
@@ -114,7 +114,6 @@ struct InnerSession {
   // purposes, each iteration of a loop should be considered to be a new Session, but for now the
   // Session/build_id would be stable.
   run_id: Mutex<Uuid>,
-  should_report_workunits: bool,
   workunit_metadata_map: RwLock<HashMap<UserMetadataPyValue, Value>>,
 }
 
@@ -136,7 +135,6 @@ impl Session {
     scheduler: &Scheduler,
     should_render_ui: bool,
     build_id: String,
-    should_report_workunits: bool,
     session_values: Value,
     cancelled: AsyncLatch,
   ) -> Session {
@@ -165,7 +163,6 @@ impl Session {
       build_id,
       session_values: Mutex::new(session_values),
       run_id: Mutex::new(Uuid::new_v4()),
-      should_report_workunits,
       workunit_metadata_map: RwLock::new(HashMap::new()),
     });
     sessions_add(&inner_session);
@@ -224,10 +221,6 @@ impl Session {
 
   pub fn preceding_graph_size(&self) -> usize {
     self.0.preceding_graph_size
-  }
-
-  pub fn should_report_workunits(&self) -> bool {
-    self.0.should_report_workunits
   }
 
   pub fn workunit_store(&self) -> WorkunitStore {


### PR DESCRIPTION
### Problem

In order to allow multiple concurrent runs in the same process (#7654), we must remove all usage of global mutable singletons. This includes the "global" and "scoped" `Subsystem` instances (which used to be the only way to consume `Subsystem`s, but which have been replaced by access via the engine).

### Solution

Deprecate `Subsystem.{global_instance,scoped_instance}()`, and implement alternative APIs for:
1. accessing the `RunTracker` from a `StreamingWorkunitHandler` callback
2. registering `StreamingWorkunitHandler` callbacks

The former is accomplished by adding the `RunTracker` to `StreamingWorkunitContext`, and the latter by adding a `@union WorkunitsCallbackFactoryRequest` that can be used to install a `@rule` to construct a `WorkunitsCallbackFactory`.

### Result

In a future version, `Subsystem.{global_instance,scoped_instance}()` will be removed. #7654 gets a little bit closer.

[ci skip-build-wheels]