### PR TITLE
[internal] Install rustup on the lint shards.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -177,6 +177,9 @@ jobs:
     - '3.6'
     - '3.7'
     script:
+    - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain
+      none
+    - source ${HOME}/.cargo/env
     - travis-wait-enhanced --timeout 50m --interval 9m -- ./build-support/bin/ci.py
       --githooks --smoke-tests --python-version 3.7
     - travis-wait-enhanced --timeout 40m --interval 9m -- ./build-support/bin/ci.py

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -485,6 +485,7 @@ def lint(python_version: PythonVersion) -> Dict:
         **linux_shard(python_version=python_version, install_travis_wait=True),
         "name": f"Self-checks and lint (Python {python_version.decimal})",
         "script": [
+            *_install_rust(),
             (
                 "travis-wait-enhanced --timeout 50m --interval 9m -- ./build-support/bin/ci.py "
                 f"--githooks --smoke-tests --python-version {python_version.decimal}"


### PR DESCRIPTION
If rust code has been edited, the `lint` shard needs `rustup` installed in order to run `cargo check` or `cargo fmt`.

[ci skip-rust]
[ci skip-build-wheels]