### PR TITLE
Add `pants.remote-cache.toml`

### DIFF
--- a/pants.remote-cache.toml
+++ b/pants.remote-cache.toml
@@ -7,8 +7,7 @@
 #  - `remote_ca_certs_path`, which is usually "/etc/ssl/certs/ca-certificates.crt" on Linux and
 #      "/usr/local/etc/openssl/cert.pem" on macOS.
 #
-# You may want to set those values in an `.envrc` file and use `direnv` (https://direnv.net/) to automatically set the
-# values.
+# You may want to set those values in a pantsrc file or an an `.envrc` file and use `direnv` (https://direnv.net/).
 
 [GLOBAL]
 remote_cache_read = true

--- a/pants.remote-cache.toml
+++ b/pants.remote-cache.toml
@@ -1,0 +1,25 @@
+# Enable remote caching by running `./pants --pants-config-files=pants.remote-cache.toml`.
+#
+# You must also set:
+#
+#  - `remote_store_store`
+#  - `remote_oauth_bearer_token_path`
+#  - `remote_ca_certs_path`, which is usually "/etc/ssl/certs/ca-certificates.crt" on Linux and
+#      "/usr/local/etc/openssl/cert.pem" on macOS.
+#
+# You may want to set those values in an `.envrc` file and use `direnv` (https://direnv.net/) to automatically set the
+# values.
+
+[GLOBAL]
+remote_cache_read = true
+remote_cache_write = true
+
+remote_store_initial_timeout = 250
+remote_store_timeout_multiplier = 1.5
+remote_store_maximum_timeout = 5000
+
+# NB: this is used for Toolchain's remote caching and may need to change for other implementations.
+remote_instance_name = "main"
+
+# Normally, we wouldn't want this, but it's helpful while we iterate on remote caching to force the remote to be used.
+process_execution_use_local_cache = false


### PR DESCRIPTION
Toolchain is making improvements to remote caching, and this change facilitates setting that up to be used.

There are two contexts where we often use remote caching:

1) Locally, typically by spinning up a local server.
2) In CI

These have different settings, such as which server to point to. Instead of having two separate config files, we leave out the context-specific settings. Developers can use `.envrc` to automatically set them, and in CI, we can set `.travis.yml` appropriately.

[ci skip-build-wheels]
[ci skip-rust]