### PR TITLE
Fix docstring deprecation warning for Bandit. (cherrypick of #11395)

### DIFF
--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -8,9 +8,9 @@ from pants.option.custom_types import file_option, shell_str
 
 
 class Bandit(PythonToolBase):
-    """A tool for finding security issues in Python code (https://bandit.readthedocs.io)."""
-
     options_scope = "bandit"
+    help = """A tool for finding security issues in Python code (https://bandit.readthedocs.io)."""
+
     default_version = "bandit>=1.6.2,<1.7"
     # `setuptools<45` is for Python 2 support. `stevedore` is because the 3.0 release breaks Bandit.
     default_extra_requirements = ["setuptools<45", "stevedore<3"]


### PR DESCRIPTION
### Problem

`bandit` was not updated for #11380.

### Solution

Move the `bandit` docstring to a `help` property. 

[ci skip-rust]
[ci skip-build-wheels]