### PR TITLE
Move to having the Scheduler directly handle SIGINT to cancel all relevant Sessions. (cherrypick of #11399)

### DIFF
--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -15,7 +15,6 @@ from typing import Callable, Dict, Iterator
 import psutil
 import setproctitle
 
-from pants.engine.internals.native_engine import session_cancel_all
 from pants.util.dirutil import safe_mkdir, safe_open
 from pants.util.osutil import Pid
 
@@ -75,7 +74,6 @@ class SignalHandler:
             child_process.send_signal(received_signal)
 
     def handle_sigint(self, signum: int, _frame):
-        session_cancel_all()
         self._send_signal_to_children(signum, "SIGINT")
         raise KeyboardInterrupt("User interrupted execution with control-c!")
 
@@ -102,12 +100,10 @@ class SignalHandler:
                 )
 
     def handle_sigquit(self, signum, _frame):
-        session_cancel_all()
         self._send_signal_to_children(signum, "SIGQUIT")
         raise self.SignalHandledNonLocalExit(signum, "SIGQUIT")
 
     def handle_sigterm(self, signum, _frame):
-        session_cancel_all()
         self._send_signal_to_children(signum, "SIGTERM")
         raise self.SignalHandledNonLocalExit(signum, "SIGTERM")
 

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -4,8 +4,6 @@ from typing import Any, Callable, Dict, List, Tuple
 #   see https://github.com/psf/black/issues/1548
 # flake8: noqa: E302
 
-def session_cancel_all() -> None: ...
-
 class PyDigest:
     def __init__(self, fingerprint: str, serialized_bytes_length: int) -> None: ...
     @property

--- a/src/rust/engine/async_value/src/lib.rs
+++ b/src/rust/engine/async_value/src/lib.rs
@@ -34,8 +34,8 @@ use tokio::sync::{oneshot, watch};
 ///
 /// A cancellable value computed by one sender, and broadcast to multiple receivers.
 ///
-/// Supports canceling the work associated with the pool either:
-///   1. explicitly if the pool is dropped
+/// Supports canceling the work associated with the value either:
+///   1. explicitly if the value is dropped
 ///   2. implicitly if all receivers go away
 ///
 /// NB: This is currently a `tokio::sync::watch` (which supports the second case), plus a

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 use crate::core::Failure;
 use crate::intrinsics::Intrinsics;
 use crate::nodes::{NodeKey, WrappedNode};
-use crate::session::Session;
+use crate::session::{Session, Sessions};
 use crate::tasks::{Rule, Tasks};
 use crate::types::Types;
 
@@ -66,6 +66,7 @@ pub struct Core {
   pub watcher: Arc<InvalidationWatcher>,
   pub build_root: PathBuf,
   pub local_parallelism: usize,
+  pub sessions: Sessions,
 }
 
 #[derive(Clone, Debug)]
@@ -458,6 +459,8 @@ impl Core {
     let watcher = InvalidationWatcher::new(executor.clone(), build_root.clone(), ignorer.clone())?;
     watcher.start(&graph);
 
+    let sessions = Sessions::new(&executor)?;
+
     Ok(Core {
       graph,
       tasks,
@@ -475,6 +478,7 @@ impl Core {
       build_root,
       watcher,
       local_parallelism: exec_strategy_opts.local_parallelism,
+      sessions,
     })
   }
 

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -72,9 +72,8 @@ use task_executor::Executor;
 use workunit_store::{UserMetadataItem, Workunit, WorkunitState};
 
 use crate::{
-  externs, nodes, sessions_cancel, Core, ExecutionRequest, ExecutionStrategyOptions,
-  ExecutionTermination, Failure, Function, Intrinsics, Params, RemotingOptions, Rule, Scheduler,
-  Session, Tasks, Types, Value,
+  externs, nodes, Core, ExecutionRequest, ExecutionStrategyOptions, ExecutionTermination, Failure,
+  Function, Intrinsics, Params, RemotingOptions, Rule, Scheduler, Session, Tasks, Types, Value,
 };
 
 py_exception!(native_engine, PollTimeout);
@@ -294,12 +293,6 @@ py_module_initializer!(native_engine, |py, m| {
     "session_new_run_id",
     py_fn!(py, session_new_run_id(a: PySession)),
   )?;
-  m.add(
-    py,
-    "session_cancel",
-    py_fn!(py, session_cancel(a: PySession)),
-  )?;
-  m.add(py, "session_cancel_all", py_fn!(py, session_cancel_all()))?;
   m.add(
     py,
     "session_poll_workunits",
@@ -1335,20 +1328,6 @@ fn graph_visualize(
 fn session_new_run_id(py: Python, session_ptr: PySession) -> PyUnitResult {
   with_session(py, session_ptr, |session| {
     session.new_run_id();
-    Ok(None)
-  })
-}
-
-fn session_cancel(py: Python, session_ptr: PySession) -> PyUnitResult {
-  with_session(py, session_ptr, |session| {
-    session.core().executor.block_on(session.cancel());
-    Ok(None)
-  })
-}
-
-fn session_cancel_all(py: Python) -> PyUnitResult {
-  py.allow_threads(|| {
-    sessions_cancel();
     Ok(None)
   })
 }

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -48,6 +48,6 @@ pub use crate::context::{Core, ExecutionStrategyOptions, RemotingOptions};
 pub use crate::core::{Failure, Function, Key, Params, TypeId, Value};
 pub use crate::intrinsics::Intrinsics;
 pub use crate::scheduler::{ExecutionRequest, ExecutionTermination, Scheduler};
-pub use crate::session::{sessions_cancel, Session};
+pub use crate::session::Session;
 pub use crate::tasks::{Rule, Tasks};
 pub use crate::types::Types;


### PR DESCRIPTION
### Problem

#11223 moved to using `Session::cancel` to interrupt 1) `InteractiveProcess`, 2) work happening in `Scheduler::execute`.

In the context of `pantsd`, `session.cancel()` is called when the read-half of the `pantsd` connection is closed. When `pantsd` is not used, `ExceptionSink` was expected to run `sessions_cancel_all` to cancel all Sessions.

But as demonstrated in #11359 (and as we previously knew from @gshuflin's work), Python signal handlers do not run until you interact with certain types of Python code... and none of this code was present directly inside of the `Scheduler::execute` loop (although `InteractiveProcess` instances were appropriately interrupted).

### Solution

Move SIGINT handling (for this usecase) out of `ExceptionSink` and into the rust `Scheduler` code in a new `Sessions` struct that cancels all active `Sessions` each time a SIGINT arrives.

### Result

Fixes #11359.

[ci skip-build-wheels]