### PR TITLE
Fix `--opt` options in constraints.txt files erroring

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -47,6 +47,11 @@ pants_ignore.add = [
   "!/pants.pex",
 ]
 
+ignore_pants_warnings.add = [
+  "DEPRECATED: Subsystem.global_instance()",
+  "DEPRECATED: not setting `help` on a `Subsystem`",
+]
+
 [source]
 root_patterns = [
   "src/*",

--- a/src/python/pants/backend/python/macros/python_requirements.py
+++ b/src/python/pants/backend/python/macros/python_requirements.py
@@ -67,7 +67,7 @@ class PythonRequirements:
 
         req_file = Path(get_buildroot(), self._parse_context.rel_path, requirements_relpath)
         requirements = parse_requirements_file(
-            req_file.read_text(), rel_path=req_file.relative_to(get_buildroot())
+            req_file.read_text(), rel_path=str(req_file.relative_to(get_buildroot()))
         )
         for parsed_req in requirements:
             req_module_mapping = (

--- a/src/python/pants/backend/python/macros/python_requirements.py
+++ b/src/python/pants/backend/python/macros/python_requirements.py
@@ -4,9 +4,7 @@ import os
 from pathlib import Path
 from typing import Iterable, Mapping, Optional
 
-from pkg_resources import Requirement
-
-from pants.backend.python.target_types import format_invalid_requirement_string_error
+from pants.backend.python.target_types import parse_requirements_file
 from pants.base.build_environment import get_buildroot
 
 
@@ -60,27 +58,6 @@ class PythonRequirements:
             requirement name as the default module, e.g. "Django" will default to
             `modules=["django"]`.
         """
-
-        req_file = Path(get_buildroot(), self._parse_context.rel_path, requirements_relpath)
-        requirements = []
-        for i, line in enumerate(req_file.read_text().splitlines()):
-            line = line.strip()
-            if not line or line.startswith("#") or line.startswith("-"):
-                continue
-            try:
-                req = Requirement.parse(line)
-            except Exception as e:
-                raise ValueError(
-                    format_invalid_requirement_string_error(
-                        line,
-                        e,
-                        description_of_origin=(
-                            f"{req_file.relative_to(get_buildroot())} at line {i + 1}"
-                        ),
-                    )
-                )
-            requirements.append(req)
-
         req_file_tgt = self._parse_context.create_object(
             "_python_requirements_file",
             name=requirements_relpath.replace(os.path.sep, "_"),
@@ -88,6 +65,10 @@ class PythonRequirements:
         )
         requirements_dep = f":{req_file_tgt.name}"
 
+        req_file = Path(get_buildroot(), self._parse_context.rel_path, requirements_relpath)
+        requirements = parse_requirements_file(
+            req_file.read_text(), rel_path=req_file.relative_to(get_buildroot())
+        )
         for parsed_req in requirements:
             req_module_mapping = (
                 {parsed_req.project_name: module_mapping[parsed_req.project_name]}

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -10,9 +10,9 @@ from dataclasses import dataclass
 from typing import Iterable, Optional, Tuple
 
 from packaging.utils import canonicalize_name as canonicalize_project_name
-from pkg_resources import Requirement, parse_requirements
+from pkg_resources import Requirement
 
-from pants.backend.python.target_types import PythonRequirementsField
+from pants.backend.python.target_types import PythonRequirementsField, parse_requirements_file
 from pants.backend.python.util_rules.pex import (
     PexInterpreterConstraints,
     PexPlatforms,
@@ -246,7 +246,10 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
             ),
         )
         constraints_file_reqs = set(
-            parse_requirements(next(iter(constraints_file_contents)).content.decode())
+            parse_requirements_file(
+                constraints_file_contents[0].content.decode(),
+                rel_path=python_setup.requirement_constraints,
+            )
         )
         constraint_file_projects = {
             canonicalize_project_name(req.project_name) for req in constraints_file_reqs

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -44,7 +44,9 @@ def test_constraints_validation(rule_runner: RuleRunner) -> None:
         "constraints1.txt",
         dedent(
             """
-            Foo._-BAR==1.0.0
+            # Comment.
+            --find-links=https://duckduckgo.com
+            Foo._-BAR==1.0.0  # Inline comment.
             bar==5.5.5
             baz==2.2.2
             qux==3.4.5


### PR DESCRIPTION
An entry like `--extra-index-url` would break when used as a constraints file, but be fine as a requirements file. This was simply an oversight.

[ci skip-rust]
[ci skip-build-wheels]