### PR TITLE
Remove more obsolete code from RunTracker

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -218,8 +218,7 @@ class LocalPantsRunner:
         metrics = self.graph_session.scheduler_session.metrics()
         run_tracker.set_pantsd_scheduler_metrics(metrics)
         outcome = WorkUnit.SUCCESS if code == PANTS_SUCCEEDED_EXIT_CODE else WorkUnit.FAILURE
-        run_tracker.set_root_outcome(outcome)
-        run_tracker.end()
+        run_tracker.end_run(outcome)
 
     def _print_help(self, request: HelpRequest) -> ExitCode:
         global_options = self.options.for_global_scope()

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -48,9 +48,6 @@ class RunTracker(Subsystem):
     # The name of the tracking root for the main thread (and the foreground worker threads).
     DEFAULT_ROOT_NAME = "main"
 
-    # The name of the tracking root for the background worker threads.
-    BACKGROUND_ROOT_NAME = "background"
-
     @classmethod
     def register_options(cls, register):
         register(
@@ -108,9 +105,6 @@ class RunTracker(Subsystem):
         # Note that multiple threads may share a name (e.g., all the threads in a pool).
         self._threadlocal = threading.local()
 
-        # For background work.  Created lazily if needed.
-        self._background_root_workunit = None
-
         self._aborted = False
 
         self._end_memoized_result: Optional[ExitCode] = None
@@ -133,13 +127,6 @@ class RunTracker(Subsystem):
         Multiple threads may have the same parent (e.g., all the threads in a pool).
         """
         self._threadlocal.current_workunit = parent_workunit
-
-    def is_under_background_root(self, workunit):
-        """Is the workunit running under the background thread's root."""
-        return workunit.is_background(self._background_root_workunit)
-
-    def is_background_root_workunit(self, workunit):
-        return workunit is self._background_root_workunit
 
     def start(self, all_options: Options, run_start_time: float) -> None:
         """Start tracking this pants run."""
@@ -248,8 +235,6 @@ class RunTracker(Subsystem):
         self.end_workunit(self._main_root_workunit)
 
         outcome = self._main_root_workunit.outcome()
-        if self._background_root_workunit:
-            outcome = min(outcome, self._background_root_workunit.outcome())
         outcome_str = WorkUnit.outcome_string(outcome)
 
         if self.run_info.get_info("outcome") is None:

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -201,13 +201,9 @@ class RunTracker(Subsystem):
         return dict(self._pantsd_metrics)  # defensive copy
 
     @classmethod
-    def _json_dump_options(cls, stats: dict) -> str:
-        return json.dumps(stats, cls=RunTrackerOptionEncoder)
-
-    @classmethod
     def write_stats_to_json(cls, file_name: str, stats: dict) -> None:
         """Write stats to a local json file."""
-        params = cls._json_dump_options(stats)
+        params = json.dumps(stats, cls=RunTrackerOptionEncoder)
         try:
             safe_file_dump(file_name, params, mode="w")
         except Exception as e:  # Broad catch - we don't want to fail in stats related failure.
@@ -221,18 +217,15 @@ class RunTracker(Subsystem):
         run_information = self.run_info.get_as_dict()
         return run_information
 
-    def _stats(self) -> dict:
+    def store_stats(self) -> None:
+        """Store stats about this run in local and optionally remote stats dbs."""
+
         stats = {
             "run_info": self.run_information(),
             "pantsd_stats": self.pantsd_scheduler_metrics,
             "cumulative_timings": self.get_cumulative_timings(),
             "recorded_options": self.get_options_to_record(),
         }
-        return stats
-
-    def store_stats(self):
-        """Store stats about this run in local and optionally remote stats dbs."""
-        stats = self._stats()
 
         # Write stats to user-defined json file.
         stats_json_file_name = self.options.stats_local_json_file

--- a/src/python/pants/reporting/reporter.py
+++ b/src/python/pants/reporting/reporter.py
@@ -78,10 +78,6 @@ class Reporter:
         """
         pass
 
-    def is_under_background_root(self, workunit):
-        """Is the workunit running under the main thread's root."""
-        return self.run_tracker.is_under_background_root(workunit)
-
     def level_for_workunit(self, workunit: WorkUnit, default_level: int) -> int:
         if workunit.log_config:
             # The value of the level option is a string defined in global_options.py


### PR DESCRIPTION
### Problem

`RunTracker` still has a lot of code paths many years old that have been obsolete for a long time. 

### Solution

This commit consolidates several methods on `RunTracker` that are being called in only one place, adds type annotations to functions that did not previously have them, and removing code that pertains to the old Python-only `WorkUnit` class (unrelated to Rust-level engine workunits). 

### Result

Nothing in this change should be user-visible.
