### PR TITLE
Implement `ProcessMetadata::default()` to clean up tests

### DIFF
--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -51,17 +51,11 @@ fn create_cached_runner(
   )
   .unwrap();
 
-  let metadata = ProcessMetadata {
-    instance_name: None,
-    cache_key_gen_version: None,
-    platform_properties: vec![],
-  };
-
   let runner = Box::new(crate::cache::CommandRunner::new(
     local.into(),
     process_execution_store,
     store,
-    metadata,
+    ProcessMetadata::default(),
   ));
 
   (runner, cache_dir)

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -338,7 +338,7 @@ impl From<Process> for MultiPlatformProcess {
 /// externally from the engine graph (e.g. when using remote execution or an external process
 /// cache).
 ///
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ProcessMetadata {
   pub instance_name: Option<String>,
   pub cache_key_gen_version: Option<String>,

--- a/src/rust/engine/process_execution/src/nailgun/tests.rs
+++ b/src/rust/engine/process_execution/src/nailgun/tests.rs
@@ -21,14 +21,14 @@ fn mock_nailgun_runner(workdir_base: Option<PathBuf>) -> CommandRunner {
     NamedCaches::new(named_cache_dir.path().to_owned()),
     true,
   );
-  let metadata = ProcessMetadata {
-    instance_name: None,
-    cache_key_gen_version: None,
-    platform_properties: vec![],
-  };
   let workdir_base = workdir_base.unwrap_or(std::env::temp_dir());
 
-  CommandRunner::new(local_runner, metadata, workdir_base, executor.clone())
+  CommandRunner::new(
+    local_runner,
+    ProcessMetadata::default(),
+    workdir_base,
+    executor.clone(),
+  )
 }
 
 fn unique_temp_dir(base_dir: PathBuf, prefix: Option<String>) -> TempDir {

--- a/src/rust/engine/process_execution/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_cache_tests.rs
@@ -64,19 +64,11 @@ fn create_cached_runner(
   store: Store,
 ) -> (Box<dyn CommandRunnerTrait>, TempDir, StubActionCache) {
   let cache_dir = TempDir::new().unwrap();
-
-  let metadata = ProcessMetadata {
-    instance_name: None,
-    cache_key_gen_version: None,
-    platform_properties: vec![],
-  };
-
   let action_cache = StubActionCache::new().unwrap();
-
   let runner = Box::new(
     crate::remote_cache::CommandRunner::new(
       local.into(),
-      metadata,
+      ProcessMetadata::default(),
       store,
       &action_cache.address(),
       None,
@@ -88,7 +80,6 @@ fn create_cached_runner(
     )
     .expect("caching command runner"),
   );
-
   (runner, cache_dir, action_cache)
 }
 
@@ -331,18 +322,10 @@ async fn make_action_result_basic() {
     .expect("Error saving directory");
 
   let mock_command_runner = Arc::new(MockCommandRunner);
-
-  let metadata = ProcessMetadata {
-    instance_name: None,
-    cache_key_gen_version: None,
-    platform_properties: vec![],
-  };
-
   let action_cache = StubActionCache::new().unwrap();
-
   let runner = crate::remote_cache::CommandRunner::new(
     mock_command_runner.clone(),
-    metadata,
+    ProcessMetadata::default(),
     store.clone(),
     &action_cache.address(),
     None,

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -134,7 +134,7 @@ async fn make_execute_request() {
   };
 
   assert_eq!(
-    crate::remote::make_execute_request(&req, empty_request_metadata()),
+    crate::remote::make_execute_request(&req, ProcessMetadata::default()),
     Ok((want_action, want_command, want_execute_request))
   );
 }
@@ -373,7 +373,7 @@ async fn make_execute_request_with_jdk() {
   };
 
   assert_eq!(
-    crate::remote::make_execute_request(&req, empty_request_metadata()),
+    crate::remote::make_execute_request(&req, ProcessMetadata::default()),
     Ok((want_action, want_command, want_execute_request))
   );
 }
@@ -539,7 +539,7 @@ async fn make_execute_request_with_timeout() {
   };
 
   assert_eq!(
-    crate::remote::make_execute_request(&req, empty_request_metadata()),
+    crate::remote::make_execute_request(&req, ProcessMetadata::default()),
     Ok((want_action, want_command, want_execute_request))
   );
 }
@@ -554,7 +554,7 @@ async fn successful_with_only_call_to_execute() {
   let mock_server = {
     let (action, _, execute_request) = crate::remote::make_execute_request(
       &execute_request.clone().try_into().unwrap(),
-      empty_request_metadata(),
+      ProcessMetadata::default(),
     )
     .unwrap();
     let action_digest = digest(&action).unwrap();
@@ -603,7 +603,7 @@ async fn successful_after_reconnect_with_wait_execution() {
   let mock_server = {
     let (action, _, execute_request) = crate::remote::make_execute_request(
       &execute_request.clone().try_into().unwrap(),
-      empty_request_metadata(),
+      ProcessMetadata::default(),
     )
     .unwrap();
     let action_digest = digest(&action).unwrap();
@@ -654,7 +654,7 @@ async fn successful_after_reconnect_from_retryable_error() {
   let mock_server = {
     let (action, _, execute_request) = crate::remote::make_execute_request(
       &execute_request.clone().try_into().unwrap(),
-      empty_request_metadata(),
+      ProcessMetadata::default(),
     )
     .unwrap();
 
@@ -712,7 +712,7 @@ async fn successful_served_from_action_cache() {
   let mock_server = {
     let (action, _, _) = crate::remote::make_execute_request(
       &execute_request.clone().try_into().unwrap(),
-      empty_request_metadata(),
+      ProcessMetadata::default(),
     )
     .unwrap();
 
@@ -767,7 +767,7 @@ async fn server_rejecting_execute_request_gives_error() {
       ExpectedAPICall::Execute {
         execute_request: crate::remote::make_execute_request(
           &Process::new(owned_string_vec(&["/bin/echo", "-n", "bar"])),
-          empty_request_metadata(),
+          ProcessMetadata::default(),
         )
         .unwrap()
         .2,
@@ -794,7 +794,7 @@ async fn server_sending_triggering_timeout_with_deadline_exceeded() {
   let mock_server = {
     let (action, _, execute_request) = crate::remote::make_execute_request(
       &execute_request.clone().try_into().unwrap(),
-      empty_request_metadata(),
+      ProcessMetadata::default(),
     )
     .unwrap();
 
@@ -832,7 +832,7 @@ async fn sends_headers() {
   let mock_server = {
     let (action, _, execute_request) = crate::remote::make_execute_request(
       &execute_request.clone().try_into().unwrap(),
-      empty_request_metadata(),
+      ProcessMetadata::default(),
     )
     .unwrap();
 
@@ -882,7 +882,7 @@ async fn sends_headers() {
   let command_runner = CommandRunner::new(
     &mock_server.address(),
     vec![mock_server.address().clone()],
-    empty_request_metadata(),
+    ProcessMetadata::default(),
     None,
     Some(String::from("catnip-will-get-you-anywhere")),
     btreemap! {
@@ -1030,7 +1030,7 @@ async fn ensure_inline_stdio_is_stored() {
 
     let (action, _, execute_request) = crate::remote::make_execute_request(
       &echo_roland_request().try_into().unwrap(),
-      empty_request_metadata(),
+      ProcessMetadata::default(),
     )
     .unwrap();
 
@@ -1082,7 +1082,7 @@ async fn ensure_inline_stdio_is_stored() {
   let cmd_runner = CommandRunner::new(
     &mock_server.address(),
     vec![mock_server.address().clone()],
-    empty_request_metadata(),
+    ProcessMetadata::default(),
     None,
     None,
     BTreeMap::new(),
@@ -1140,7 +1140,7 @@ async fn bad_result_bytes() {
       mock::execution_server::MockExecution::new(vec![ExpectedAPICall::Execute {
         execute_request: crate::remote::make_execute_request(
           &execute_request.clone().try_into().unwrap(),
-          empty_request_metadata(),
+          ProcessMetadata::default(),
         )
         .unwrap()
         .2,
@@ -1183,7 +1183,7 @@ async fn initial_response_error() {
 
     let (action, _, execute_request) = crate::remote::make_execute_request(
       &execute_request.clone().try_into().unwrap(),
-      empty_request_metadata(),
+      ProcessMetadata::default(),
     )
     .unwrap();
 
@@ -1238,7 +1238,7 @@ async fn initial_response_missing_response_and_error() {
 
     let (action, _, execute_request) = crate::remote::make_execute_request(
       &execute_request.clone().try_into().unwrap(),
-      empty_request_metadata(),
+      ProcessMetadata::default(),
     )
     .unwrap();
 
@@ -1282,7 +1282,7 @@ async fn fails_after_retry_limit_exceeded() {
   let mock_server = {
     let (action, _, execute_request) = crate::remote::make_execute_request(
       &execute_request.clone().try_into().unwrap(),
-      empty_request_metadata(),
+      ProcessMetadata::default(),
     )
     .unwrap();
 
@@ -1344,7 +1344,7 @@ async fn fails_after_retry_limit_exceeded_with_stream_close() {
     let op_name = "foo-bar".to_owned();
     let (action, _, execute_request) = crate::remote::make_execute_request(
       &execute_request.clone().try_into().unwrap(),
-      empty_request_metadata(),
+      ProcessMetadata::default(),
     )
     .unwrap();
 
@@ -1409,7 +1409,7 @@ async fn execute_missing_file_uploads_if_known() {
 
     let (action, _, execute_request) = crate::remote::make_execute_request(
       &cat_roland_request().try_into().unwrap(),
-      empty_request_metadata(),
+      ProcessMetadata::default(),
     )
     .unwrap();
 
@@ -1433,7 +1433,7 @@ async fn execute_missing_file_uploads_if_known() {
         ExpectedAPICall::Execute {
           execute_request: crate::remote::make_execute_request(
             &cat_roland_request().try_into().unwrap(),
-            empty_request_metadata(),
+            ProcessMetadata::default(),
           )
           .unwrap()
           .2,
@@ -1482,7 +1482,7 @@ async fn execute_missing_file_uploads_if_known() {
   let command_runner = CommandRunner::new(
     &mock_server.address(),
     vec![mock_server.address().clone()],
-    empty_request_metadata(),
+    ProcessMetadata::default(),
     None,
     None,
     BTreeMap::new(),
@@ -1556,7 +1556,7 @@ async fn execute_missing_file_errors_if_unknown() {
   let runner = CommandRunner::new(
     &mock_server.address(),
     vec![mock_server.address().clone()],
-    empty_request_metadata(),
+    ProcessMetadata::default(),
     None,
     None,
     BTreeMap::new(),
@@ -2257,7 +2257,7 @@ fn create_command_runner(
   let command_runner = CommandRunner::new(
     &address,
     vec![address.clone()],
-    empty_request_metadata(),
+    ProcessMetadata::default(),
     None,
     None,
     BTreeMap::new(),
@@ -2427,14 +2427,6 @@ pub(crate) fn echo_roland_request() -> MultiPlatformProcess {
   req.timeout = one_second();
   req.description = "unleash a roaring meow".to_string();
   req.into()
-}
-
-pub(crate) fn empty_request_metadata() -> ProcessMetadata {
-  ProcessMetadata {
-    instance_name: None,
-    cache_key_gen_version: None,
-    platform_properties: vec![],
-  }
 }
 
 pub(crate) fn assert_cancellation_requests(


### PR DESCRIPTION
[ci skip-build-wheels]