### PR TITLE
Fix older versions of `tar` not working when creating an `archive`

### DIFF
--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -53,8 +53,13 @@ class TarBinary(BinaryPath):
     def create_archive_argv(self, request: "CreateArchive") -> Tuple[str, ...]:
         # Note that the parent directory for the output_filename must already exist.
         #
-        # The `a` arg means `tar` will choose the compression based on the file ending.
-        return (self.path, "caf", request.output_filename, *request.snapshot.files)
+        # We do not use `-a` (auto-set compression) because it does not work with older tar
+        # versions. Not all tar implementations will support these compression formats - in that
+        # case, the user will need to choose a different format.
+        compression = {ArchiveFormat.TGZ: "z", ArchiveFormat.TBZ2: "j", ArchiveFormat.TXZ: "J"}.get(
+            request.format, ""
+        )
+        return (self.path, f"c{compression}f", request.output_filename, *request.snapshot.files)
 
     def extract_archive_argv(self, *, archive_path: str, output_dir: str) -> Tuple[str, ...]:
         # Note that the `output_dir` must already exist.


### PR DESCRIPTION
A user reported that the builtin `tar` on macOS Mojave (2.8) was erroring because of the argv including `a`. We instead can explicitly specify the format.

Note that not all formats will still work on older tar versions, e.g. 2.8 does not support the `J` flag to create `.tar.xz`. The user will need to choose a compatible `format` instead like `tar`. We do not eagerly detect this situation because there are so many implementations of `tar` - it's an open question if we should check the failed process, though, so that we can augment the error message with info on this possible gotcha?

[ci skip-rust]
[ci skip-build-wheels]