### PR TITLE
Set explicit required components for rustup

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,3 @@
-1.48.0
+[toolchain]
+channel = "1.48.0"
+components = ["cargo", "clippy", "rustfmt", "rustc"]


### PR DESCRIPTION
### Problem

The default components installed for a `rustup` toolchain are not guaranteed to include `cargo`, `clippy`, etc.

### Solution

Expand our `rust-toolchain` file to explicitly list the components that we need. We do not pin `rustup` for now, as it generally changes backwards-compatibly. We can revisit that in the future if it continues to change in breaking ways.

[ci skip-build-wheels]