### PR TITLE
[internal] Require the `rust-std` component in rustup.

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,9 @@
 [toolchain]
 channel = "1.48.0"
-components = ["cargo", "clippy", "rustfmt", "rustc"]
+components = [
+  "cargo",
+  "clippy",
+  "rust-std",
+  "rustc",
+  "rustfmt",
+]


### PR DESCRIPTION
Followup to #11420: we additionally need the stdlib.