### PR TITLE
Remove deprecated v1 Subsystem facilities

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -143,7 +143,6 @@ function execute_packaged_pants_with_internal_backends() {
     --no-verify-config \
     --no-pantsd \
     --pythonpath="['pants-plugins']" \
-    --streaming-workunits-handlers="[]" \
     --backend-packages="[\
         'pants.backend.awslambda.python',\
         'pants.backend.python',\

--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -16,7 +16,7 @@ from pants.engine.goal import GoalSubsystem
 from pants.engine.rules import Rule, RuleIndex
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule
-from pants.goal.run_tracker import RunTracker
+from pants.goal.run_tracker import DeprecatedRunTracker
 from pants.option.global_options import GlobalOptions
 from pants.option.optionable import Optionable
 from pants.option.scope import normalize_scope
@@ -33,7 +33,7 @@ _RESERVED_NAMES = {"global", "targets", "goals"}
 
 # Subsystems used outside of any rule.
 _GLOBAL_SUBSYSTEMS: FrozenOrderedSet[Type[Optionable]] = FrozenOrderedSet(
-    {GlobalOptions, RunTracker, Changed}
+    {GlobalOptions, DeprecatedRunTracker, Changed}
 )
 
 

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -6,5 +6,15 @@ python_library()
 python_tests(
   name='tests',
   dependencies=['src/python/pants/engine/internals:fs_test_data'],
+  sources=["*_test.py", "!*_integration_test.py"],
   timeout=90,
+)
+
+python_integration_tests(
+  name='integration_tests',
+  uses_pants_run=True,
+  dependencies=[
+      # Loaded reflectively as a backend in `streaming_workunit_handler_integration_test.py`.
+      'testprojects/pants-plugins/src/python/workunit_logger',
+  ],
 )

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -286,7 +286,7 @@ class StreamingWorkunitTests(unittest.TestCase, SchedulerTestBase):
         tracker = WorkunitTracker()
         handler = StreamingWorkunitHandler(
             scheduler,
-            run_tracker=RunTracker("run-tracker", None),
+            run_tracker=RunTracker(None),  # type: ignore[arg-type]
             callbacks=[tracker.add],
             report_interval_seconds=0.01,
             max_workunit_verbosity=max_workunit_verbosity,
@@ -648,7 +648,7 @@ def test_more_complicated_engine_aware(rule_runner: RuleRunner) -> None:
     tracker = WorkunitTracker()
     handler = StreamingWorkunitHandler(
         rule_runner.scheduler,
-        run_tracker=RunTracker("run-tracker", None),
+        run_tracker=RunTracker(None),  # type: ignore[arg-type]
         callbacks=[tracker.add],
         report_interval_seconds=0.01,
         max_workunit_verbosity=LogLevel.TRACE,
@@ -705,7 +705,7 @@ def test_process_digests_on_streaming_workunits(rule_runner: RuleRunner) -> None
     tracker = WorkunitTracker()
     handler = StreamingWorkunitHandler(
         scheduler,
-        run_tracker=RunTracker("run-tracker", None),
+        run_tracker=RunTracker(None),  # type: ignore[arg-type]
         callbacks=[tracker.add],
         report_interval_seconds=0.01,
         max_workunit_verbosity=LogLevel.INFO,
@@ -735,7 +735,7 @@ def test_process_digests_on_streaming_workunits(rule_runner: RuleRunner) -> None
     tracker = WorkunitTracker()
     handler = StreamingWorkunitHandler(
         scheduler,
-        run_tracker=RunTracker("run-tracker", None),
+        run_tracker=RunTracker(None),  # type: ignore[arg-type]
         callbacks=[tracker.add],
         report_interval_seconds=0.01,
         max_workunit_verbosity=LogLevel.INFO,
@@ -792,7 +792,7 @@ def test_context_object_on_streaming_workunits(rule_runner: RuleRunner) -> None:
 
     handler = StreamingWorkunitHandler(
         scheduler,
-        run_tracker=RunTracker("run-tracker", None),
+        run_tracker=RunTracker(None),  # type: ignore[arg-type]
         callbacks=[callback],
         report_interval_seconds=0.01,
         max_workunit_verbosity=LogLevel.INFO,

--- a/src/python/pants/engine/internals/options_parsing.py
+++ b/src/python/pants/engine/internals/options_parsing.py
@@ -33,9 +33,7 @@ class _Options:
 
     @memoized_property
     def options(self) -> Options:
-        return OptionsInitializer.create(
-            self.options_bootstrapper, self.build_config, init_subsystems=False
-        )
+        return OptionsInitializer.create(self.options_bootstrapper, self.build_config)
 
 
 @rule

--- a/src/python/pants/engine/streaming_workunit_handler_integration_test.py
+++ b/src/python/pants/engine/streaming_workunit_handler_integration_test.py
@@ -1,0 +1,23 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+
+from pants.testutil.pants_integration_test import run_pants, setup_tmpdir
+from pants.util.dirutil import maybe_read_file
+
+
+def test_workunits_logger() -> None:
+    with setup_tmpdir({}) as tmpdir:
+        dest = os.path.join(tmpdir, "dest.log")
+        pants_run = run_pants(
+            [
+                "--backend-packages=+['workunit_logger','pants.backend.python']",
+                f"--workunit-logger-dest={dest}",
+                "list",
+                "3rdparty::",
+            ]
+        )
+        pants_run.assert_success()
+        # Assert that the file was created and non-empty.
+        assert maybe_read_file(dest)

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -17,7 +17,6 @@ from pants.option.global_options import GlobalOptions
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
-from pants.option.subsystem import Subsystem
 from pants.util.dirutil import fast_relpath_optional
 from pants.util.ordered_set import OrderedSet
 
@@ -158,7 +157,6 @@ class OptionsInitializer:
         cls,
         options_bootstrapper: OptionsBootstrapper,
         build_configuration: BuildConfiguration,
-        init_subsystems: bool = True,
     ) -> Options:
         global_bootstrap_options = options_bootstrapper.get_bootstrap_options().for_global_scope()
 
@@ -178,8 +176,5 @@ class OptionsInitializer:
         options = options_bootstrapper.get_full_options(known_scope_infos)
 
         GlobalOptions.validate_instance(options.for_global_scope())
-
-        if init_subsystems:
-            Subsystem.set_options(options)
 
         return options

--- a/src/python/pants/init/util.py
+++ b/src/python/pants/init/util.py
@@ -7,7 +7,6 @@ from typing import cast
 from pants.fs.fs import safe_filename_from_path
 from pants.init.options_initializer import BuildConfigInitializer
 from pants.option.option_value_container import OptionValueContainer
-from pants.option.subsystem import Subsystem
 from pants.util.dirutil import absolute_symlink, safe_mkdir, safe_rmtree
 
 
@@ -54,8 +53,6 @@ def init_workdir(global_options: OptionValueContainer) -> str:
 
 def clean_global_runtime_state() -> None:
     """Resets the global runtime state of a pants runtime."""
-
-    Subsystem.reset()
 
     # Reset global plugin state.
     BuildConfigInitializer.reset()

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -982,23 +982,6 @@ class GlobalOptions(Subsystem):
             advanced=True,
             help="Interval in seconds between when streaming workunit event receivers will be polled.",
         )
-        register(
-            "--streaming-workunits-handlers",
-            type=list,
-            member_type=str,
-            default=[],
-            advanced=True,
-            removal_version="2.3.0.dev0",
-            removal_hint=(
-                "To register a StreamingWorkunitHandler callback, install a UnionRule "
-                "for type `WorkunitsCallbackFactoryRequest`."
-            ),
-            help=(
-                "Use this option to name Subsystems which will receive streaming workunit events. "
-                "For instance, `--streaming-workunits-handlers=\"['pants.reporting.workunit.Workunits']\"` will "
-                'register a Subsystem called Workunits defined in the module "pants.reporting.workunit".'
-            ),
-        )
 
     @classmethod
     def validate_instance(cls, opts):

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -421,6 +421,25 @@ class GlobalOptions(Subsystem):
         )
 
         register(
+            "--stats-json-file",
+            advanced=True,
+            default=None,
+            help="Write stats to this local json file on run completion.",
+        )
+        register(
+            "--stats-record-option-scopes",
+            advanced=True,
+            type=list,
+            default=["*"],
+            help=(
+                "Option scopes to record in stats on run completion. "
+                "Options may be selected by joining the scope and the option with a ^ character, "
+                "i.e. to get option `pantsd` in the GLOBAL scope, you'd pass `GLOBAL^pantsd`. "
+                "Add a '*' to the list to capture all known scopes."
+            ),
+        )
+
+        register(
             "--pants-ignore",
             advanced=True,
             type=list,

--- a/src/python/pants/option/subsystem_test.py
+++ b/src/python/pants/option/subsystem_test.py
@@ -45,37 +45,6 @@ def si(scope, subsystem_cls):
     return ScopeInfo(scope, subsystem_cls)
 
 
-@pytest.fixture(autouse=True)
-def init_subsystems():
-    DummySubsystem._options = DummyOptions()
-    WorkunitSubscriptableSubsystem._options = DummyOptions()
-
-
-def test_global_instance() -> None:
-    # Verify that we get the same instance back every time.
-    global_instance = DummySubsystem.global_instance()
-    assert global_instance is DummySubsystem.global_instance()
-
-
-def test_scoped_instance() -> None:
-    # Verify that we get the same instance back every time.
-    task = DummyOptionable()
-    task_instance = DummySubsystem.scoped_instance(task)
-    assert task_instance is DummySubsystem.scoped_instance(task)
-
-
-def test_invalid_subsystem_class():
-    class NoScopeSubsystem(Subsystem):
-        pass
-
-    NoScopeSubsystem._options = DummyOptions()
-    with pytest.raises(TypeError) as exc:
-        NoScopeSubsystem.global_instance()
-    assert str(exc.value) == (
-        "Can't instantiate abstract class NoScopeSubsystem with abstract methods options_scope"
-    )
-
-
 def test_scoping_simple() -> None:
     assert {si("dummy", DummySubsystem)} == DummySubsystem.known_scope_infos()
     assert {
@@ -220,29 +189,6 @@ def test_scoping_complex() -> None:
         si("c.b.d", SubsystemC),
         si("e", SubsystemE),
     }
-
-
-def test_uninitialized_global() -> None:
-    Subsystem.reset()
-    with pytest.raises(
-        Subsystem.UninitializedSubsystemError,
-        match=r"UninitializedSubsystem.*uninitialized-scope",
-    ):
-        UninitializedSubsystem.global_instance()
-
-
-def test_uninitialized_scoped_instance() -> None:
-    Subsystem.reset()
-
-    class UninitializedOptional(Optionable):
-        options_scope = "optional"
-
-    optional = UninitializedOptional()
-    with pytest.raises(
-        Subsystem.UninitializedSubsystemError,
-        match=r"UninitializedSubsystem.*uninitialized-scope",
-    ):
-        UninitializedSubsystem.scoped_instance(optional)
 
 
 def test_subsystem_dependencies_iter() -> None:

--- a/src/python/pants/option/subsystem_test.py
+++ b/src/python/pants/option/subsystem_test.py
@@ -252,39 +252,3 @@ def test_subsystem_closure_iter_cycle() -> None:
 
     with pytest.raises(Subsystem.CycleException):
         list(SubsystemB.subsystem_closure_iter())
-
-
-def test_get_streaming_workunit_callbacks() -> None:
-    import_str = "pants.option.subsystem_test.WorkunitSubscriptableSubsystem"
-    callables_list = Subsystem.get_streaming_workunit_callbacks([import_str])
-    assert len(callables_list) == 1
-
-
-def test_streaming_workunit_callbacks_bad_module(caplog) -> None:
-    import_str = "nonexistent_module.AClassThatDoesntActuallyExist"
-    callables_list = Subsystem.get_streaming_workunit_callbacks([import_str])
-    assert len(callables_list) == 0
-    warnings = [record for record in caplog.records if record.levelname == "WARNING"]
-    assert len(warnings) == 1
-    assert "No module named 'nonexistent_module'" in warnings[0].msg
-
-
-def test_streaming_workunit_callbacks_good_module_bad_class(caplog) -> None:
-    import_str = "pants.option.subsystem_test.ANonexistentClass"
-    callables_list = Subsystem.get_streaming_workunit_callbacks([import_str])
-    assert len(callables_list) == 0
-    warnings = [record for record in caplog.records if record.levelname == "WARNING"]
-    assert len(warnings) == 1
-    assert (
-        "module 'pants.option.subsystem_test' has no attribute 'ANonexistentClass'"
-        in warnings[0].msg
-    )
-
-
-def test_streaming_workunit_callbacks_with_invalid_subsystem(caplog) -> None:
-    import_str = "pants.option.subsystem_test.DummySubsystem"
-    callables_list = Subsystem.get_streaming_workunit_callbacks([import_str])
-    assert len(callables_list) == 0
-    warnings = [record for record in caplog.records if record.levelname == "WARNING"]
-    assert len(warnings) == 1
-    assert "does not have a method named `handle_workunits` defined" in warnings[0].msg

--- a/testprojects/pants-plugins/src/python/workunit_logger/BUILD
+++ b/testprojects/pants-plugins/src/python/workunit_logger/BUILD
@@ -1,0 +1,5 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# A plugin that logs workunits via a WorkunitsCallback.
+python_library()

--- a/testprojects/pants-plugins/src/python/workunit_logger/__init__.py
+++ b/testprojects/pants-plugins/src/python/workunit_logger/__init__.py
@@ -1,0 +1,1 @@
+__import__("pkg_resources").declare_namespace(__name__)

--- a/testprojects/pants-plugins/src/python/workunit_logger/register.py
+++ b/testprojects/pants-plugins/src/python/workunit_logger/register.py
@@ -1,0 +1,53 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from dataclasses import dataclass
+from typing import Tuple
+
+from pants.engine.internals.scheduler import Workunit
+from pants.engine.rules import collect_rules, rule
+from pants.engine.streaming_workunit_handler import (
+    WorkunitsCallback,
+    WorkunitsCallbackFactory,
+    WorkunitsCallbackFactoryRequest,
+)
+from pants.engine.unions import UnionRule
+from pants.option.subsystem import Subsystem
+
+
+class WorkunitsLoggerOptions(Subsystem):
+    options_scope = "workunit-logger"
+    help = """Example plugin that logs workunits to a file."""
+
+    @classmethod
+    def register_options(cls, register):
+        register("--dest", type=str, help="A filename to log workunits to.")
+
+
+class WorkunitsLoggerRequest:
+    pass
+
+
+@dataclass(frozen=True)
+class WorkunitsLogger(WorkunitsCallback):
+    dest: str
+
+    def __call__(self, *, completed_workunits: Tuple[Workunit, ...], **kwargs) -> None:
+        with open(self.dest, "a") as dest:
+            print(str(completed_workunits), file=dest)
+
+
+@rule
+def construct_workunits_logger_callback(
+    _: WorkunitsLoggerRequest,
+    opts: WorkunitsLoggerOptions,
+) -> WorkunitsCallbackFactory:
+    output_file = opts.options.dest
+    return WorkunitsCallbackFactory(lambda: WorkunitsLogger(output_file))
+
+
+def rules():
+    return [
+        UnionRule(WorkunitsCallbackFactoryRequest, WorkunitsLoggerRequest),
+        *collect_rules(),
+    ]


### PR DESCRIPTION
### Problem

As initiated in #11388, the v1 `Subsystem.{global_instance,scoped_instance}()` facilities are being removed.

### Solution

Remove `Subsystem.{global_instance,scoped_instance}()` and their support code. To reduce bootstrap dependencies, the `RunTracker` is no longer a `Subsystem`: its options have moved to being global options, and are deprecated in their previous locations. The `--streaming-workunit-handlers` option (which relied on singleton `Subsystem`s) is also removed in favor of the APIs added in #11388.

### Result

Plugins that need access to `Subsystem`s should do so via `@rule` arguments, and callers outside of `@rule`s should use `Scheduler.product_request(<subsystem_cls>, [Params()])` to get an instance.
