### PR TITLE
Support setting env vars in the run goal.

### DIFF
--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -90,8 +90,8 @@ class RunSubsystem(GoalSubsystem):
         return tuple(self.options.args)
 
     @property
-    def env_vars(self) -> List[str]:
-        return cast(List[str], self.options.env_vars)
+    def extra_env_vars(self) -> List[str]:
+        return cast(List[str], self.options.extra_env_vars)
 
 
 class Run(Goal):
@@ -128,8 +128,8 @@ async def run(
         args = (arg.format(chroot=tmpdir) for arg in request.args)
         extra_env = {k: v.format(chroot=tmpdir) for k, v in request.extra_env.items()}
         user_env = (
-            pants_env.get_subset(run_subsystem.env_vars)
-            if run_subsystem.env_vars
+            pants_env.get_subset(run_subsystem.extra_env_vars)
+            if run_subsystem.extra_env_vars
             else FrozenDict({})
         )
         conflicting_env_keys = set(user_env.keys()) & set(extra_env.keys())

--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -74,14 +74,14 @@ class RunSubsystem(GoalSubsystem):
             '`--run-args="val1 val2 --debug"`',
         )
         register(
-            "--env-vars",
+            "--extra-env-vars",
             type=list,
             member_type=str,
             default=[],
             help=(
-                "Environment variables to set in the running process. "
-                "Entries are strings in the form `ENV_VAR=value` to use explicitly; or just "
-                "`ENV_VAR` to copy the value of a variable in Pants's own environment."
+                "Extra environment variables to set in the running process. "
+                "Entries are strings of the form `ENV_VAR=value`. "
+                "Note that Pants's own environment is also passed through to the run process."
             ),
         )
 


### PR DESCRIPTION
Requested by a user (see https://pantsbuild.slack.com/archives/C046T6T9U/p1609873321407200 for context), and does seem like something generally useful (and aligns with the ability to set env vars in tests).

[ci skip-rust]

[ci skip-build-wheels]

