### PR TITLE
Remove --stats-json-file options

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -415,12 +415,6 @@ class GlobalOptions(Subsystem):
         )
 
         register(
-            "--stats-json-file",
-            advanced=True,
-            default=None,
-            help="Write stats to this local json file on run completion.",
-        )
-        register(
             "--stats-record-option-scopes",
             advanced=True,
             type=list,


### PR DESCRIPTION
In a recent commit, the RunTracker-specific option to write build stats to a JSON file was deprecated and its functionality moved to a new global option `--stats-json-file`. But in modern pants the ability to write this JSON file isn't particularly useful, so we might as well remove it and the code that supports it.