### PR TITLE
Simplify use of run_tracker in LocalPantsRunner

### DIFF
--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -105,7 +105,7 @@ class RunTracker:
     def goals(self) -> List[str]:
         return self._all_options.goals if self._all_options else []
 
-    def start(self, run_start_time: float) -> None:
+    def start(self, run_start_time: float, specs: List[str]) -> None:
         """Start tracking this pants run."""
         if self._has_started:
             raise AssertionError("RunTracker.start must not be called multiple times.")
@@ -116,6 +116,7 @@ class RunTracker:
         self.run_info.add_basic_info(self.run_id, run_start_time)
         cmd_line = " ".join(["pants"] + sys.argv[1:])
         self.run_info.add_info("cmd_line", cmd_line)
+        self.run_info.add_info("specs_from_command_line", specs, stringify=False)
 
         # Create a 'latest' symlink, after we add_infos, so we're guaranteed that the file exists.
         link_to_latest = os.path.join(os.path.dirname(self.run_info_dir), "latest")

--- a/src/python/pants/goal/run_tracker_test.py
+++ b/src/python/pants/goal/run_tracker_test.py
@@ -17,7 +17,7 @@ def test_run_tracker_timing_output(**kwargs) -> None:
     with temporary_dir() as buildroot:
         with environment_as(PANTS_BUILDROOT_OVERRIDE=buildroot):
             run_tracker = RunTracker(create_options_bootstrapper([]).bootstrap_options)
-            run_tracker.start(run_start_time=time.time())
+            run_tracker.start(run_start_time=time.time(), specs=["::"])
             frozen_time = kwargs["frozen_time"]
             frozen_time.tick(delta=datetime.timedelta(seconds=1))
             run_tracker.end_run(PANTS_SUCCEEDED_EXIT_CODE)


### PR DESCRIPTION
This commit makes the code in `LocalPantsRunner` that sets up and updates the `RunTracker` more concise, reducing the total number of calls that need to be made from external code to `RunTracker`.