### PR TITLE
Remove support for docstring help.

### DIFF
--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -122,17 +122,6 @@ class Field:
         self._check_deprecated(raw_value, address)
         self.value: Optional[ImmutableValue] = self.compute_value(raw_value, address=address)
 
-        if not address.is_file_target and not hasattr(self, "help"):
-            warn_or_error(
-                removal_version="2.3.0.dev0",
-                deprecated_entity_description="not setting `help` on a `Field`",
-                hint=(
-                    "Please set the class property `help: str` for the field "
-                    f"`{self.__class__}`. In Pants 2.3, Pants will no longer look at the docstring "
-                    "for help messages and it will error if `help` is not defined."
-                ),
-            )
-
     @classmethod
     def compute_value(cls, raw_value: Optional[Any], *, address: Address) -> ImmutableValue:
         """Convert the `raw_value` into `self.value`.
@@ -315,17 +304,6 @@ class Target:
                 hint=(
                     f"Using the `{self.alias}` target type for {address}. "
                     f"{self.deprecated_removal_hint}"
-                ),
-            )
-
-        if not address.is_file_target and not hasattr(self, "help"):
-            warn_or_error(
-                removal_version="2.3.0.dev0",
-                deprecated_entity_description="not setting `help` on a `Target`",
-                hint=(
-                    "Please set the class property `help: str` for the target type "
-                    f"`{self.__class__}`. In Pants 2.3, Pants will no longer look at the docstring "
-                    "for help messages and it will error if `help` is not defined."
                 ),
             )
 

--- a/src/python/pants/option/options_integration_test.py
+++ b/src/python/pants/option/options_integration_test.py
@@ -49,7 +49,7 @@ def test_deprecation_and_ignore_pants_warnings(use_pantsd: bool) -> None:
         from pants.engine.rules import SubsystemRule
 
         class Options(Subsystem):
-            '''Options just for a test.'''
+            help = "Options just for a test."
             options_scope = "mock-options"
 
             @classmethod

--- a/src/python/pants/option/scope.py
+++ b/src/python/pants/option/scope.py
@@ -4,9 +4,7 @@
 from dataclasses import dataclass
 from typing import Optional, Type, cast
 
-from pants.base.deprecated import warn_or_error
 from pants.option.option_value_container import OptionValueContainer
-from pants.util.memo import memoized_property
 
 GLOBAL_SCOPE = ""
 GLOBAL_SCOPE_CONFIG_SECTION = "GLOBAL"
@@ -36,22 +34,9 @@ class ScopeInfo:
     removal_version: Optional[str] = None
     removal_hint: Optional[str] = None
 
-    # TODO: We only memoize this to avoid repeating the deprecation warning. Revert back once the
-    #  deprecation is finished.
-    @memoized_property
+    @property
     def description(self) -> str:
-        if hasattr(self.optionable_cls, "help"):
-            return cast(str, getattr(self.optionable_cls, "help"))
-        warn_or_error(
-            removal_version="2.3.0.dev0",
-            deprecated_entity_description="not setting `help` on a `Subsystem`",
-            hint=(
-                "Please set the class property `help: str` for the subsystem "
-                f"`{self.optionable_cls}`. In Pants 2.3, Pants will no longer look at the "
-                f"docstring or help messages and it will error if `help` is not defined."
-            ),
-        )
-        return cast(str, self._optionable_cls_attr("get_description", lambda: "")())
+        return cast(str, getattr(self.optionable_cls, "help"))
 
     @property
     def deprecated_scope(self) -> Optional[str]:


### PR DESCRIPTION
Optionables (Subsystems), Targets and Fields must all now define a help
attribute.

[ci skip-rust]
[ci skip-build-wheels]