### PR TITLE
Remove support for 'Lite' request object hacks.

### DIFF
--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -41,7 +41,6 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     Dependencies,
     DependenciesRequest,
-    DependenciesRequestLite,
     FieldSet,
     FieldSetsPerTarget,
     FieldSetsPerTargetRequest,
@@ -67,7 +66,6 @@ from pants.engine.target import (
     Targets,
     TransitiveTargets,
     TransitiveTargetsRequest,
-    TransitiveTargetsRequestLite,
     UnexpandedTargets,
     UnrecognizedTargetTypeException,
     WrappedTarget,
@@ -296,59 +294,6 @@ async def transitive_targets(request: TransitiveTargetsRequest) -> TransitiveTar
         transitive_excludes = FrozenOrderedSet(
             itertools.chain.from_iterable(excludes for excludes in nested_transitive_excludes)
         )
-
-    return TransitiveTargets(
-        tuple(roots_as_targets), FrozenOrderedSet(visited.difference(transitive_excludes))
-    )
-
-
-@rule(desc="Resolve transitive targets")
-async def transitive_targets_lite(request: TransitiveTargetsRequestLite) -> TransitiveTargets:
-    roots_as_targets = await Get(Targets, Addresses(request.roots))
-    visited: OrderedSet[Target] = OrderedSet()
-    queued = FrozenOrderedSet(roots_as_targets)
-    dependency_mapping: Dict[Address, Tuple[Address, ...]] = {}
-    while queued:
-        direct_dependencies_addresses_per_tgt = await MultiGet(
-            Get(Addresses, DependenciesRequestLite(tgt.get(Dependencies))) for tgt in queued
-        )
-        direct_dependencies_per_tgt = []
-        for addresses_per_tgt in direct_dependencies_addresses_per_tgt:
-            wrapped_tgts = await MultiGet(
-                Get(WrappedTarget, Address, addr) for addr in addresses_per_tgt
-            )
-            direct_dependencies_per_tgt.append(
-                tuple(wrapped_t.target for wrapped_t in wrapped_tgts)
-            )
-
-        dependency_mapping.update(
-            zip(
-                (t.address for t in queued),
-                (tuple(t.address for t in deps) for deps in direct_dependencies_per_tgt),
-            )
-        )
-
-        queued = FrozenOrderedSet(
-            itertools.chain.from_iterable(direct_dependencies_per_tgt)
-        ).difference(visited)
-        visited.update(queued)
-
-    # NB: We use `roots_as_targets` to get the root addresses, rather than `request.roots`. This
-    # is because expanding from the `Addresses` -> `Targets` may have resulted in generated
-    # subtargets being used, so we need to use `roots_as_targets` to have this expansion.
-    _detect_cycles(tuple(t.address for t in roots_as_targets), dependency_mapping)
-
-    # Apply any transitive excludes (`!!` ignores).
-    wrapped_transitive_excludes = await MultiGet(
-        Get(
-            WrappedTarget, AddressInput, AddressInput.parse(addr, relative_to=tgt.address.spec_path)
-        )
-        for tgt in (*roots_as_targets, *visited)
-        for addr in tgt.get(Dependencies).unevaluated_transitive_excludes.values
-    )
-    transitive_excludes = FrozenOrderedSet(
-        wrapped_t.target for wrapped_t in wrapped_transitive_excludes
-    )
 
     return TransitiveTargets(
         tuple(roots_as_targets), FrozenOrderedSet(visited.difference(transitive_excludes))
@@ -866,52 +811,6 @@ async def resolve_dependencies(
             *itertools.chain.from_iterable(injected),
             *itertools.chain.from_iterable(inferred),
             *special_cased,
-        )
-        if addr not in ignored_addresses
-    }
-    return Addresses(sorted(result))
-
-
-@rule(desc="Resolve direct dependencies")
-async def resolve_dependencies_lite(
-    request: DependenciesRequestLite,
-    union_membership: UnionMembership,
-    registered_target_types: RegisteredTargetTypes,
-    global_options: GlobalOptions,
-) -> Addresses:
-    provided = parse_dependencies_field(
-        request.field,
-        subproject_roots=global_options.options.subproject_roots,
-        registered_target_types=registered_target_types.types,
-        union_membership=union_membership,
-    )
-    literal_addresses = await MultiGet(Get(Address, AddressInput, ai) for ai in provided.addresses)
-    ignored_addresses = set(
-        await MultiGet(Get(Address, AddressInput, ai) for ai in provided.ignored_addresses)
-    )
-
-    # Inject any dependencies.
-    inject_request_types = union_membership.get(InjectDependenciesRequest)
-    injected = await MultiGet(
-        Get(InjectedDependencies, InjectDependenciesRequest, inject_request_type(request.field))
-        for inject_request_type in inject_request_types
-        if isinstance(request.field, inject_request_type.inject_for)
-    )
-
-    # Inject dependencies on all the BUILD target's generated file targets.
-    subtargets = await Get(
-        Subtargets, Address, request.field.address.maybe_convert_to_build_target()
-    )
-    subtarget_addresses = tuple(
-        t.address for t in subtargets.subtargets if t.address != request.field.address
-    )
-
-    result = {
-        addr
-        for addr in (
-            *subtarget_addresses,
-            *literal_addresses,
-            *itertools.chain.from_iterable(injected),
         )
         if addr not in ignored_addresses
     }

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -663,31 +663,6 @@ class TransitiveTargetsRequest:
 
 @frozen_after_init
 @dataclass(unsafe_hash=True)
-class TransitiveTargetsRequestLite:
-    """A request to get the transitive dependencies of the input roots, but without considering
-    dependency inference.
-
-    This solely exists due to graph ambiguity with codegen implementations. Use
-    `TransitiveTargetsRequest` everywhere other than codegen.
-    """
-
-    roots: Tuple[Address, ...]
-
-    def __init__(self, roots: Iterable[Address]) -> None:
-        warn_or_error(
-            removal_version="2.3.0.dev0",
-            deprecated_entity_description="`TransitiveTargetsRequestLite`",
-            hint=(
-                "Rather than `Get(TransitiveTargets, TransitiveTargetsRequestLite)`, use "
-                "`Get(TransitiveTargets, TransitiveTargetsRequest)`. There is no more need for "
-                "`TransitiveTargetsRequestLite` because the rule graph cycle has been resolved."
-            ),
-        )
-        self.roots = tuple(roots)
-
-
-@frozen_after_init
-@dataclass(unsafe_hash=True)
 class RegisteredTargetTypes:
     aliases_to_types: FrozenDict[str, Type[Target]]
 
@@ -1590,31 +1565,6 @@ class Dependencies(StringSequenceField, AsyncFieldMixin):
 class DependenciesRequest(EngineAwareParameter):
     field: Dependencies
     include_special_cased_deps: bool = False
-
-    def debug_hint(self) -> str:
-        return self.field.address.spec
-
-
-@dataclass(frozen=True)
-class DependenciesRequestLite(EngineAwareParameter):
-    """Like DependenciesRequest, but does not use dependency inference.
-
-    This solely exists due to graph ambiguity with codegen. Use `DependenciesRequest` everywhere but
-    with codegen.
-    """
-
-    field: Dependencies
-
-    def __post_init__(self) -> None:
-        warn_or_error(
-            removal_version="2.3.0.dev0",
-            deprecated_entity_description="`DependenciesRequestLite`",
-            hint=(
-                "Rather than `Get(Targets, DependenciesRequestLite)`, use "
-                "`Get(Targets, DependenciesRequest)`. There is no more need for "
-                "`DependenciesRequestLite` because the rule graph cycle has been resolved."
-            ),
-        )
 
     def debug_hint(self) -> str:
         return self.field.address.spec


### PR DESCRIPTION
TransitiveTargetsRequestLite and DependenciesRequestLite were needed to
temporarily work around limitations in the rule engine that have since
been remedied.

[ci skip-rust]
[ci skip-build-wheels]
