### PR TITLE
Remove support for pex_binary sources.

### DIFF
--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from typing import Tuple
 
 from pants.backend.python.target_types import (
-    DeprecatedPexBinarySources,
     PexAlwaysWriteCacheField,
     PexBinaryDefaults,
     PexEmitWarningsField,
@@ -39,9 +38,8 @@ from pants.util.logging import LogLevel
 
 @dataclass(frozen=True)
 class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
-    required_fields = (PexEntryPointField, DeprecatedPexBinarySources)
+    required_fields = (PexEntryPointField,)
 
-    sources: DeprecatedPexBinarySources
     entry_point: PexEntryPointField
 
     output_path: OutputPathField
@@ -75,7 +73,7 @@ async def package_pex_binary(
     field_set: PexBinaryFieldSet, pex_binary_defaults: PexBinaryDefaults
 ) -> BuiltPackage:
     resolved_entry_point = await Get(
-        ResolvedPexEntryPoint, ResolvePexEntryPointRequest(field_set.entry_point, field_set.sources)
+        ResolvedPexEntryPoint, ResolvePexEntryPointRequest(field_set.entry_point)
     )
     output_filename = field_set.output_path.value_or_default(field_set.address, file_ending="pex")
     two_step_pex = await Get(

--- a/src/python/pants/backend/python/goals/run_pex_binary.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary.py
@@ -33,7 +33,7 @@ async def create_pex_binary_run_request(
     entry_point, transitive_targets = await MultiGet(
         Get(
             ResolvedPexEntryPoint,
-            ResolvePexEntryPointRequest(field_set.entry_point, field_set.sources),
+            ResolvePexEntryPointRequest(field_set.entry_point),
         ),
         Get(TransitiveTargets, TransitiveTargetsRequest([field_set.address])),
     )

--- a/src/python/pants/backend/python/goals/run_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary_integration_test.py
@@ -11,7 +11,6 @@ from pants.testutil.pants_integration_test import run_pants, setup_tmpdir
 @pytest.mark.parametrize(
     "tgt_content",
     [
-        "pex_binary(sources=['app.py'])",
         "python_library(name='lib')\npex_binary(entry_point='app.py')",
         "python_library(name='lib')\npex_binary(entry_point='app.py:main')",
     ],

--- a/src/python/pants/backend/python/goals/setup_py_test.py
+++ b/src/python/pants/backend/python/goals/setup_py_test.py
@@ -232,8 +232,8 @@ def test_invalid_binary(chroot_rule_runner: RuleRunner) -> None:
         textwrap.dedent(
             """
             python_library(name='not_a_binary', sources=[])
-            pex_binary(name='no_explicit_entrypoint', sources=["app1.py"])
-            pex_binary(name='malformed_entrypoint', entry_point='invalid_binary.app2')
+            pex_binary(name='invalid_entrypoint_unowned1', entry_point='app1.py')
+            pex_binary(name='invalid_entrypoint_unowned2', entry_point='invalid_binary.app2')
             python_distribution(
                 name='invalid_bin1',
                 provides=setup_py(
@@ -244,13 +244,13 @@ def test_invalid_binary(chroot_rule_runner: RuleRunner) -> None:
                 name='invalid_bin2',
                 provides=setup_py(
                     name='invalid_bin2', version='1.1.1'
-                ).with_binaries(foo=':no_explicit_entrypoint')
+                ).with_binaries(foo=':invalid_entrypoint_unowned1')
             )
             python_distribution(
                 name='invalid_bin3',
                 provides=setup_py(
                     name='invalid_bin3', version='1.1.1'
-                ).with_binaries(foo=':malformed_entrypoint')
+                ).with_binaries(foo=':invalid_entrypoint_unowned2')
             )
             """
         ),
@@ -279,7 +279,8 @@ def test_binary_shorthand(chroot_rule_runner: RuleRunner) -> None:
         "src/python/project",
         textwrap.dedent(
             """
-            pex_binary(name='bin', sources=["app.py"], entry_point=':func')
+            python_library()
+            pex_binary(name='bin', entry_point='app.py:func')
             python_distribution(
                 name='dist',
                 provides=setup_py(

--- a/src/python/pants/core/target_types_test.py
+++ b/src/python/pants/core/target_types_test.py
@@ -186,7 +186,7 @@ def test_archive() -> None:
     )
 
     rule_runner.create_file("project/app.py", "print('hello world!')")
-    rule_runner.add_to_build_file("project", "pex_binary(sources=['app.py'])")
+    rule_runner.add_to_build_file("project", "pex_binary(entry_point='app.py')")
 
     rule_runner.add_to_build_file(
         "",


### PR DESCRIPTION
This also removes support for pex_binary interpreter_constraints which
no longer apply to any relevant entity.

[ci skip-rust]
[ci skip-build-wheels]