### PR TITLE
[internal] Upgrade toolchain pants plugin

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -20,7 +20,7 @@ backend_packages.add = [
 ]
 
 plugins = [
-  "toolchain.pants.plugin==0.2.0",
+  "toolchain.pants.plugin==0.3.0",
 ]
 
 build_file_prelude_globs = ["pants-plugins/python_integration_tests_macro.py"]


### PR DESCRIPTION
This version of the plugin adds a plugin that allows dumping historgram data to the log (see https://github.com/pantsbuild/pants/pull/11185)
It also improves handling of failed auth scenarions.