### PR TITLE
Upgrade to Rust v1.49.0 again

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.48.0"
+channel = "1.49.0"
 components = [
   "cargo",
   "clippy",

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -1282,7 +1282,7 @@ pub fn extract_output_files(
 
         let mut digest = root_digest;
 
-        if dir.path != "" {
+        if !dir.path.is_empty() {
           for component in dir.path.rsplit('/') {
             let component = component.to_owned();
             let directory = remexec::Directory {

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -84,7 +84,7 @@ impl<'x> Params {
       .binary_search_by(|probe| probe.type_id().cmp(&type_id))
   }
 
-  pub fn type_ids<'a>(&'a self) -> impl Iterator<Item = TypeId> + 'a {
+  pub fn type_ids(&self) -> impl Iterator<Item = TypeId> + '_ {
     self.0.iter().map(|k| *k.type_id())
   }
 }


### PR DESCRIPTION
This is necessary to compile the engine on Mac Silicon.

We can now safely upgrade thanks to https://github.com/pantsbuild/pants/pull/11452 fixing the issue with macOS.