### PR TITLE
Fix tests not using an absolute or relative path with `Process`

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -406,12 +406,11 @@ def test_pex_execution(rule_runner: RuleRunner) -> None:
     assert "main.py" in pex_files
     assert "subdir/sub.py" in pex_files
 
-    # We reasonably expect there to be a python interpreter on the test-running process's path.
-    env = {"PATH": os.getenv("PATH", "")}
-
+    # This should run the Pex using the same interpreter used to create it. We must set the `PATH` so that the shebang
+    # works.
     process = Process(
-        argv=("python", "test.pex"),
-        env=env,
+        argv=("./test.pex",),
+        env={"PATH": os.getenv("PATH", "")},
         input_digest=pex_output["pex"].digest,
         description="Run the pex and make sure it works",
     )

--- a/tests/python/pants_test/init/test_plugin_resolver.py
+++ b/tests/python/pants_test/init/test_plugin_resolver.py
@@ -81,10 +81,10 @@ def _run_setup_py(
     )
     merged_digest = rule_runner.request(Digest, [MergeDigests([pex_obj.digest, source_digest])])
 
+    # This should run the Pex using the same interpreter used to create it. We must set the `PATH` so that the shebang
+    # works.
     process = Process(
-        argv=("python", "setup-py-runner.pex", "setup.py") + tuple(setup_py_args),
-        # We reasonably expect there to be a python interpreter on the test-running
-        # process's path.
+        argv=("./setup-py-runner.pex", "setup.py", *setup_py_args),
         env={"PATH": os.getenv("PATH", "")},
         input_digest=merged_digest,
         description="Run setup.py",


### PR DESCRIPTION
From the Remote Execution API:

https://github.com/bazelbuild/remote-apis/blob/9e72daff42c941baaf43a4c370e2607a984c58a7/build/bazel/remote/execution/v2/remote_execution.proto#L472-L475

> The first argument must be the path to the executable, which must be either a relative path, in which case it is evaluated with respect to the input root, or an absolute path.

These tests were causing https://github.com/pantsbuild/pants/pull/11452 to fail because the unconstrained `python` looked like a relative path even though it isn't.

[ci skip-build-wheels]
[ci skip-rust]