### PR TITLE
add "time to first byte" metric for remote CAS reads

### DIFF
--- a/src/rust/engine/workunit_store/src/metrics.rs
+++ b/src/rust/engine/workunit_store/src/metrics.rs
@@ -82,6 +82,7 @@ impl Metric {
 pub enum ObservationMetric {
   TestObservation,
   RemoteExecutionRPCFirstResponseTime,
+  RemoteStoreTimeToFirstByte,
 }
 
 impl ObservationMetric {
@@ -91,6 +92,7 @@ impl ObservationMetric {
     match *self {
       TestObservation => "test_observation",
       RemoteExecutionRPCFirstResponseTime => "remote_execution_rpc_first_response_time",
+      RemoteStoreTimeToFirstByte => "remote_store_time_to_first_byte",
     }
   }
 }


### PR DESCRIPTION
Add an observation metric to instrument read latency for remote CAS reads. The metric measures the time from the submission of the RPC to receipt of the first byte of the response. This is a better measure of latency since total latency of CAS depends on blob size whereas this just measures the roundtrip time to receive the first byte.