### PR TITLE
Temporarily disable the Toolchain plugin to facilitate landing Python 3.9

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -14,14 +14,14 @@ backend_packages.add = [
   "pants.backend.python.typecheck.mypy",
   "pants.backend.python.mixed_interpreter_constraints",
   "internal_plugins.releases",
-  "toolchain.pants.auth",
-  "toolchain.pants.buildsense",
-  "toolchain.pants.common",
+#  "toolchain.pants.auth",
+#  "toolchain.pants.buildsense",
+#  "toolchain.pants.common",
 ]
 
-plugins = [
-  "toolchain.pants.plugin==0.3.0",
-]
+#plugins = [
+#  "toolchain.pants.plugin==0.3.0",
+#]
 
 build_file_prelude_globs = ["pants-plugins/python_integration_tests_macro.py"]
 
@@ -142,5 +142,5 @@ interpreter_constraints = [">=3.7,<3.9"]
 [sourcefile-validation]
 config = "@build-support/regexes/config.yaml"
 
-[toolchain-setup]
-repo = "pants"
+#[toolchain-setup]
+#repo = "pants"

--- a/pants.travis-ci.toml
+++ b/pants.travis-ci.toml
@@ -17,10 +17,10 @@ junit_xml_dir = "dist/test-results/"
 [coverage-py]
 report = ["raw", "xml"]
 
-[auth]
-from_env_var = "TOOLCHAIN_AUTH_TOKEN"
-org = "pantsbuild"
-ci_env_variables = ["TRAVIS", "TRAVIS_JOB_ID", "TRAVIS_BUILD_ID", "TRAVIS_PULL_REQUEST", "TRAVIS_BUILD_WEB_URL"]
-
-[buildsense]
-enable = true
+#[auth]
+#from_env_var = "TOOLCHAIN_AUTH_TOKEN"
+#org = "pantsbuild"
+#ci_env_variables = ["TRAVIS", "TRAVIS_JOB_ID", "TRAVIS_BUILD_ID", "TRAVIS_PULL_REQUEST", "TRAVIS_BUILD_WEB_URL"]
+#
+#[buildsense]
+#enable = true


### PR DESCRIPTION
The plugin depends on pantsbuild.pants, but there is no 3.9 wheel available for Pants. 

We could force the plugin to not depend on pantsbuild.pants, which we may want to do anyways. But for simplicity, we simply disable the plugin for now.

[ci skip-rust]
[ci skip-build-wheels]