### PR TITLE
Implement StreamingWorkunitContext.get_expanded_specs

### DIFF
--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -1,6 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import itertools
 import os
 from abc import ABC, ABCMeta, abstractmethod
@@ -307,6 +309,6 @@ class Specs:
         """Did the user provide specs?"""
         return bool(self.address_specs) or bool(self.filesystem_specs)
 
-
-def empty_specs() -> Specs:
-    return Specs(AddressSpecs([], filter_by_global_options=True), FilesystemSpecs([]))
+    @classmethod
+    def empty(cls) -> Specs:
+        return Specs(AddressSpecs([], filter_by_global_options=True), FilesystemSpecs([]))

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -306,3 +306,7 @@ class Specs:
     def provided(self) -> bool:
         """Did the user provide specs?"""
         return bool(self.address_specs) or bool(self.filesystem_specs)
+
+
+def empty_specs() -> Specs:
+    return Specs(AddressSpecs([], filter_by_global_options=True), FilesystemSpecs([]))

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -35,8 +35,8 @@ Snapshot = PySnapshot
 class Paths:
     """A Paths object is a collection of sorted file paths and dir paths.
 
-    Paths is like a Snapshot, but has a performance optimization that it does digest the files or
-    save them to the LMDB store.
+    Paths is like a Snapshot, but has the performance optimization that it does not digest the files
+    or save them to the LMDB store.
     """
 
     files: Tuple[str, ...]

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -10,6 +10,7 @@ from typing import List, Optional, Tuple
 
 import pytest
 
+from pants.base.specs import empty_specs
 from pants.engine.engine_aware import EngineAwareReturnType
 from pants.engine.fs import (
     EMPTY_FILE_DIGEST,
@@ -302,6 +303,8 @@ class StreamingWorkunitTests(unittest.TestCase, SchedulerTestBase):
             callbacks=[tracker.add],
             report_interval_seconds=0.01,
             max_workunit_verbosity=max_workunit_verbosity,
+            specs=empty_specs(),
+            options_bootstrapper=create_options_bootstrapper([]),
         )
         return (scheduler, tracker, handler)
 
@@ -674,6 +677,8 @@ def test_more_complicated_engine_aware(rule_runner: RuleRunner, run_tracker: Run
         callbacks=[tracker.add],
         report_interval_seconds=0.01,
         max_workunit_verbosity=LogLevel.TRACE,
+        specs=empty_specs(),
+        options_bootstrapper=create_options_bootstrapper([]),
     )
     with handler.session():
         input_1 = CreateDigest(
@@ -733,6 +738,8 @@ def test_process_digests_on_streaming_workunits(
         callbacks=[tracker.add],
         report_interval_seconds=0.01,
         max_workunit_verbosity=LogLevel.INFO,
+        specs=empty_specs(),
+        options_bootstrapper=create_options_bootstrapper([]),
     )
 
     stdout_process = Process(
@@ -763,6 +770,8 @@ def test_process_digests_on_streaming_workunits(
         callbacks=[tracker.add],
         report_interval_seconds=0.01,
         max_workunit_verbosity=LogLevel.INFO,
+        specs=empty_specs(),
+        options_bootstrapper=create_options_bootstrapper([]),
     )
 
     stderr_process = Process(
@@ -809,6 +818,8 @@ def test_context_object_on_streaming_workunits(
         context = kwargs["context"]
         assert isinstance(context, StreamingWorkunitContext)
 
+        assert {} == context.get_expanded_specs()
+
         completed_workunits = kwargs["completed_workunits"]
         for workunit in completed_workunits:
             if "artifacts" in workunit and "stdout_digest" in workunit["artifacts"]:
@@ -822,6 +833,8 @@ def test_context_object_on_streaming_workunits(
         callbacks=[callback],
         report_interval_seconds=0.01,
         max_workunit_verbosity=LogLevel.INFO,
+        specs=empty_specs(),
+        options_bootstrapper=create_options_bootstrapper([]),
     )
 
     stdout_process = Process(

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -541,7 +541,7 @@ class SchedulerSession:
     def run_goal_rule(
         self,
         product: Type,
-        subject: Union[Any, Params],
+        subject: Params,
         poll: bool = False,
         poll_delay: Optional[float] = None,
     ) -> int:

--- a/src/python/pants/engine/streaming_workunit_handler.py
+++ b/src/python/pants/engine/streaming_workunit_handler.py
@@ -1,25 +1,35 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import logging
 import threading
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Callable, Iterable, Iterator, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Sequence, Tuple
 
 from typing_extensions import Protocol
 
+from pants.base.specs import Specs
+from pants.engine.addresses import Addresses
 from pants.engine.fs import Digest, DigestContents, Snapshot
 from pants.engine.internals.scheduler import SchedulerSession, Workunit
+from pants.engine.internals.selectors import Params
 from pants.engine.rules import Get, MultiGet, QueryRule, collect_rules, rule
+from pants.engine.target import Targets
 from pants.engine.unions import UnionMembership, union
 from pants.goal.run_tracker import RunTracker
+from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.util.logging import LogLevel
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
 class StreamingWorkunitContext:
     _scheduler: SchedulerSession
     _run_tracker: RunTracker
+    _specs: Specs
+    _options_bootstrapper: OptionsBootstrapper
 
     @property
     def run_tracker(self) -> RunTracker:
@@ -50,6 +60,23 @@ class StreamingWorkunitContext:
         These metrics are useful for debugging Pants internals.
         """
         return self._scheduler.get_observation_histograms()
+
+    def get_expanded_specs(self) -> Dict[str, List[str]]:
+        """Return a dict containing the canonicalized addresses of the specs for this run, and what
+        files they expand to."""
+
+        (addresses,) = self._scheduler.product_request(
+            Addresses, [Params(self._specs, self._options_bootstrapper)]
+        )
+
+        ret = {}
+        for addr in addresses:
+            (targets,) = self._scheduler.product_request(Targets, [Params(Addresses([addr]))])
+            ret[addr.spec] = [
+                tgt.address.filename if tgt.address.is_file_target else str(tgt.address)
+                for tgt in targets
+            ]
+        return ret
 
 
 class WorkunitsCallback(Protocol):
@@ -98,6 +125,8 @@ class StreamingWorkunitHandler:
         scheduler: SchedulerSession,
         run_tracker: RunTracker,
         callbacks: Iterable[WorkunitsCallback],
+        options_bootstrapper: OptionsBootstrapper,
+        specs: Specs,
         report_interval_seconds: float,
         max_workunit_verbosity: LogLevel = LogLevel.TRACE,
     ):
@@ -106,7 +135,10 @@ class StreamingWorkunitHandler:
         self.callbacks = callbacks
         self._thread_runner: Optional[_InnerHandler] = None
         self._context = StreamingWorkunitContext(
-            _scheduler=self.scheduler, _run_tracker=run_tracker
+            _scheduler=self.scheduler,
+            _run_tracker=run_tracker,
+            _specs=specs,
+            _options_bootstrapper=options_bootstrapper,
         )
         # TODO(10092) The max verbosity should be a per-client setting, rather than a global setting.
         self.max_workunit_verbosity = max_workunit_verbosity
@@ -192,4 +224,15 @@ async def construct_workunits_callback_factories(
 
 
 def rules():
-    return [QueryRule(WorkunitsCallbackFactories, (UnionMembership,)), *collect_rules()]
+    return [
+        QueryRule(WorkunitsCallbackFactories, (UnionMembership,)),
+        QueryRule(Targets, (Addresses,)),
+        QueryRule(
+            Addresses,
+            (
+                Specs,
+                OptionsBootstrapper,
+            ),
+        ),
+        *collect_rules(),
+    ]

--- a/src/python/pants/init/specs_calculator.py
+++ b/src/python/pants/init/specs_calculator.py
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import logging
-from typing import Optional, cast
+from typing import cast
 
-from pants.base.build_environment import get_buildroot, get_git
+from pants.base.build_environment import get_git
 from pants.base.specs import AddressLiteralSpec, AddressSpecs, FilesystemSpecs, Specs
 from pants.base.specs_parser import SpecsParser
 from pants.engine.addresses import AddressInput
@@ -27,10 +27,9 @@ def calculate_specs(
     options: Options,
     session: SchedulerSession,
     *,
-    build_root: Optional[str] = None,
+    build_root: str,
 ) -> Specs:
     """Determine the specs for a given Pants run."""
-    build_root = build_root or get_buildroot()
     specs = SpecsParser(build_root).parse_specs(options.specs)
     changed_options = ChangedOptions.from_options(options.for_scope("changed"))
 


### PR DESCRIPTION
This PR adds a new method that streaming workunit clients might call on `StreamingWorkunitContext`, `get_expanded_specs()`. This method returns a dictionary mapping the canonicalized addresses of the command-line specs, to a list of files specified by each spec.