### PR TITLE
Internal change: enable pantsd in CI

### DIFF
--- a/pants.travis-ci.toml
+++ b/pants.travis-ci.toml
@@ -4,10 +4,6 @@ colors = true
 # TODO: See #9924.
 dynamic_ui = false
 
-# TODO: Eventually we would like pantsd enabled in CI as well, but we blanket disable it for
-# now in order to smooth off rough edges locally.
-pantsd = false
-
 [test]
 use_coverage = true
 


### PR DESCRIPTION
We will need Pantsd to be used for remote cache writes to work properly, post https://github.com/pantsbuild/pants/pull/11479.

Generally, pantsd has seen major improvements that this is a good change to make either way.

[ci skip-rust]
[ci skip-build-wheels]