### PR TITLE
Use named field struct syntax for Digest

### DIFF
--- a/src/python/pants/engine/fs_test.py
+++ b/src/python/pants/engine/fs_test.py
@@ -725,9 +725,9 @@ def test_remove_prefix(rule_runner: RuleRunner) -> None:
                 [RemovePrefix(snapshot_with_extra_files.digest, "characters/dark_tower")],
             )
         assert (
-            "Cannot strip prefix characters/dark_tower from root directory Digest(Fingerprint<"
-            "28c47f77867f0c8d577d2ada2f06b03fc8e5ef2d780e8942713b26c5e3f434b8>, 243) - root "
-            "directory contained non-matching directory named: books and file named: index"
+            "Cannot strip prefix characters/dark_tower from root directory (Digest "
+            "with hash Fingerprint<28c47f77867f0c8d577d2ada2f06b03fc8e5ef2d780e8942713b26c5e3f434b8>)"
+            " - root directory contained non-matching directory named: books and file named: index"
         ) in str(exc.value)
 
 

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -85,7 +85,7 @@ pub fn digest_from_filepath(str: &str) -> Result<Digest, String> {
     .ok_or_else(|| format!("Invalid digest: {} wasn't of form fingerprint-size", str))?
     .parse::<usize>()
     .map_err(|err| format!("Invalid digest; size {} not a number: {}", str, err))?;
-  Ok(Digest(fingerprint, size_bytes))
+  Ok(Digest::new(fingerprint, size_bytes))
 }
 
 type Inode = u64;
@@ -263,7 +263,7 @@ impl BuildResultFS {
     self.inode_digest_cache.get(&inode).map(|f| {
       attr_for(
         inode,
-        f.digest.1 as u64,
+        f.digest.size as u64,
         fuse::FileType::RegularFile,
         if f.is_executable { 0o555 } else { 0o444 },
       )

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -263,7 +263,7 @@ impl BuildResultFS {
     self.inode_digest_cache.get(&inode).map(|f| {
       attr_for(
         inode,
-        f.digest.size as u64,
+        f.digest.size_bytes as u64,
         fuse::FileType::RegularFile,
         if f.is_executable { 0o555 } else { 0o444 },
       )

--- a/src/rust/engine/fs/brfs/src/tests.rs
+++ b/src/rust/engine/fs/brfs/src/tests.rs
@@ -222,7 +222,7 @@ async fn files_are_correctly_executable() {
 }
 
 pub fn digest_to_filepath(digest: &hashing::Digest) -> String {
-  format!("{}-{}", digest.0, digest.1)
+  format!("{}-{}", digest.fingerprint, digest.size)
 }
 
 pub fn make_dirs() -> (tempfile::TempDir, tempfile::TempDir) {

--- a/src/rust/engine/fs/brfs/src/tests.rs
+++ b/src/rust/engine/fs/brfs/src/tests.rs
@@ -222,7 +222,7 @@ async fn files_are_correctly_executable() {
 }
 
 pub fn digest_to_filepath(digest: &hashing::Digest) -> String {
-  format!("{}-{}", digest.fingerprint, digest.size)
+  format!("{}-{}", digest.hash, digest.size_bytes)
 }
 
 pub fn make_dirs() -> (tempfile::TempDir, tempfile::TempDir) {

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -542,9 +542,7 @@ async fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
             maybe_v
               .map(|v| {
                 v.into_iter()
-                  .map(|(name, digest)| {
-                    format!("{} {} {}\n", name, digest.fingerprint, digest.size)
-                  })
+                  .map(|(name, digest)| format!("{} {} {}\n", name, digest.hash, digest.size_bytes))
                   .collect::<Vec<String>>()
                   .join("")
               })
@@ -602,7 +600,7 @@ async fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
           .all_local_digests(::store::EntryType::Directory)
           .expect("Error opening store")
         {
-          println!("{} {}", digest.fingerprint, digest.size);
+          println!("{} {}", digest.hash, digest.size_bytes);
         }
         Ok(())
       }
@@ -708,7 +706,7 @@ async fn ensure_uploaded_to_remote(
 fn print_upload_summary(mode: Option<&str>, report: &SummaryWithDigest) {
   match mode {
     Some("json") => println!("{}", serde_json::to_string_pretty(&report).unwrap()),
-    Some("simple") => println!("{} {}", report.digest.fingerprint, report.digest.size),
+    Some("simple") => println!("{} {}", report.digest.hash, report.digest.size_bytes),
     // This should never be reached, as clap should error with unknown formats.
     _ => eprintln!("Unknown summary format."),
   };

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -368,7 +368,7 @@ async fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
             .unwrap()
             .parse::<usize>()
             .expect("size_bytes must be a non-negative number");
-          let digest = Digest(fingerprint, size_bytes);
+          let digest = Digest::new(fingerprint, size_bytes);
           let write_result = store
             .load_file_bytes_with(digest, |bytes| io::stdout().write_all(&bytes).unwrap())
             .await?;
@@ -431,7 +431,7 @@ async fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
           .unwrap()
           .parse::<usize>()
           .expect("size_bytes must be a non-negative number");
-        let digest = Digest(fingerprint, size_bytes);
+        let digest = Digest::new(fingerprint, size_bytes);
         store
           .materialize_directory(destination, digest)
           .await
@@ -489,7 +489,7 @@ async fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
           .unwrap()
           .parse::<usize>()
           .expect("size_bytes must be a non-negative number");
-        let mut digest = Digest(fingerprint, size_bytes);
+        let mut digest = Digest::new(fingerprint, size_bytes);
 
         if let Some(prefix_to_strip) = args.value_of("child-dir") {
           let mut result = store
@@ -542,7 +542,9 @@ async fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
             maybe_v
               .map(|v| {
                 v.into_iter()
-                  .map(|(name, digest)| format!("{} {} {}\n", name, digest.0, digest.1))
+                  .map(|(name, digest)| {
+                    format!("{} {} {}\n", name, digest.fingerprint, digest.size)
+                  })
                   .collect::<Vec<String>>()
                   .join("")
               })
@@ -572,7 +574,7 @@ async fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
         .unwrap()
         .parse::<usize>()
         .expect("size_bytes must be a non-negative number");
-      let digest = Digest(fingerprint, size_bytes);
+      let digest = Digest::new(fingerprint, size_bytes);
       let v = match store
         .load_file_bytes_with(digest, |bytes| Bytes::copy_from_slice(bytes))
         .await?
@@ -600,7 +602,7 @@ async fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
           .all_local_digests(::store::EntryType::Directory)
           .expect("Error opening store")
         {
-          println!("{} {}", digest.0, digest.1);
+          println!("{} {}", digest.fingerprint, digest.size);
         }
         Ok(())
       }
@@ -706,7 +708,7 @@ async fn ensure_uploaded_to_remote(
 fn print_upload_summary(mode: Option<&str>, report: &SummaryWithDigest) {
   match mode {
     Some("json") => println!("{}", serde_json::to_string_pretty(&report).unwrap()),
-    Some("simple") => println!("{} {}", report.digest.0, report.digest.1),
+    Some("simple") => println!("{} {}", report.digest.fingerprint, report.digest.size),
     // This should never be reached, as clap should error with unknown formats.
     _ => eprintln!("Unknown summary format."),
   };

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -540,8 +540,8 @@ impl Store {
       )
       .await?;
 
-      let ingested_file_sizes = ingested_digests.iter().map(|(digest, _)| digest.1);
-      let uploaded_file_sizes = uploaded_digests.iter().map(|digest| digest.1);
+      let ingested_file_sizes = ingested_digests.iter().map(|(digest, _)| digest.size);
+      let uploaded_file_sizes = uploaded_digests.iter().map(|digest| digest.size);
 
       Ok(UploadSummary {
         ingested_file_count: ingested_file_sizes.len(),
@@ -722,7 +722,7 @@ impl Store {
     if digests.len() < 3 {
       let mut num_bytes = 0;
       for digest in digests.keys() {
-        num_bytes += digest.1;
+        num_bytes += digest.size;
       }
       num_bytes < 1024 * 1024
     } else {
@@ -751,7 +751,7 @@ impl Store {
         .map(|digest| {
           let store = self.clone();
           async move {
-            match store.local.entry_type(digest.0).await {
+            match store.local.entry_type(digest.fingerprint).await {
               Ok(Some(EntryType::File)) => Ok(Either::Left(*digest)),
               Ok(Some(EntryType::Directory)) => {
                 let store_for_expanding = match missing_behavior {

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -540,8 +540,8 @@ impl Store {
       )
       .await?;
 
-      let ingested_file_sizes = ingested_digests.iter().map(|(digest, _)| digest.size);
-      let uploaded_file_sizes = uploaded_digests.iter().map(|digest| digest.size);
+      let ingested_file_sizes = ingested_digests.iter().map(|(digest, _)| digest.size_bytes);
+      let uploaded_file_sizes = uploaded_digests.iter().map(|digest| digest.size_bytes);
 
       Ok(UploadSummary {
         ingested_file_count: ingested_file_sizes.len(),
@@ -722,7 +722,7 @@ impl Store {
     if digests.len() < 3 {
       let mut num_bytes = 0;
       for digest in digests.keys() {
-        num_bytes += digest.size;
+        num_bytes += digest.size_bytes;
       }
       num_bytes < 1024 * 1024
     } else {
@@ -751,7 +751,7 @@ impl Store {
         .map(|digest| {
           let store = self.clone();
           async move {
-            match store.local.entry_type(digest.fingerprint).await {
+            match store.local.entry_type(digest.hash).await {
               Ok(Some(EntryType::File)) => Ok(Either::Left(*digest)),
               Ok(Some(EntryType::Directory)) => {
                 let store_for_expanding = match missing_behavior {

--- a/src/rust/engine/fs/store/src/local_tests.rs
+++ b/src/rust/engine/fs/store/src/local_tests.rs
@@ -124,7 +124,7 @@ async fn garbage_collect_nothing_to_do() {
     load_bytes(
       &store,
       EntryType::File,
-      Digest(
+      Digest::new(
         Fingerprint::from_hex_string(
           "84d89877f0d4041efb6bf91a16f0248f2fd573e6af05c19f96bedb9f882f7882",
         )
@@ -150,7 +150,7 @@ async fn garbage_collect_nothing_to_do_with_lease() {
     "84d89877f0d4041efb6bf91a16f0248f2fd573e6af05c19f96bedb9f882f7882",
   )
   .unwrap();
-  let file_digest = Digest(file_fingerprint, 10);
+  let file_digest = Digest::new(file_fingerprint, 10);
   store
     .lease_all(vec![(file_digest, EntryType::File)].into_iter())
     .await
@@ -175,7 +175,7 @@ async fn garbage_collect_expired() {
   )
   .unwrap();
   let file_len = 10;
-  let file_digest = Digest(file_fingerprint, file_len);
+  let file_digest = Digest::new(file_fingerprint, file_len);
 
   // Store something (in a store with a shortened lease). Confirm that it hasn't immediately
   // expired, and then wait for it to expire.
@@ -213,13 +213,13 @@ async fn garbage_collect_remove_one_of_two_files_no_leases() {
     "84d89877f0d4041efb6bf91a16f0248f2fd573e6af05c19f96bedb9f882f7882",
   )
   .unwrap();
-  let digest_1 = Digest(fingerprint_1, 10);
+  let digest_1 = Digest::new(fingerprint_1, 10);
   let bytes_2 = Bytes::from("9876543210");
   let fingerprint_2 = Fingerprint::from_hex_string(
     "7619ee8cea49187f309616e30ecf54be072259b43760f1f550a644945d5572f2",
   )
   .unwrap();
-  let digest_2 = Digest(fingerprint_2, 10);
+  let digest_2 = Digest::new(fingerprint_2, 10);
   store
     .store_bytes(EntryType::File, bytes_1.clone(), false)
     .await
@@ -259,13 +259,13 @@ async fn garbage_collect_remove_both_files_no_leases() {
     "84d89877f0d4041efb6bf91a16f0248f2fd573e6af05c19f96bedb9f882f7882",
   )
   .unwrap();
-  let digest_1 = Digest(fingerprint_1, 10);
+  let digest_1 = Digest::new(fingerprint_1, 10);
   let bytes_2 = Bytes::from("9876543210");
   let fingerprint_2 = Fingerprint::from_hex_string(
     "7619ee8cea49187f309616e30ecf54be072259b43760f1f550a644945d5572f2",
   )
   .unwrap();
-  let digest_2 = Digest(fingerprint_2, 10);
+  let digest_2 = Digest::new(fingerprint_2, 10);
   store
     .store_bytes(EntryType::File, bytes_1.clone(), false)
     .await

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -122,8 +122,8 @@ impl ByteStore {
       "{}/uploads/{}/blobs/{}/{}",
       self.instance_name.clone().unwrap_or_default(),
       uuid::Uuid::new_v4(),
-      digest.fingerprint,
-      digest.size,
+      digest.hash,
+      digest.size_bytes,
     );
     let workunit_name = format!("store_bytes({})", resource_name.clone());
     let metadata = workunit_store::WorkunitMetadata::with_level(Level::Debug);
@@ -197,8 +197,8 @@ impl ByteStore {
     let resource_name = format!(
       "{}/blobs/{}/{}",
       store.instance_name.clone().unwrap_or_default(),
-      digest.fingerprint,
-      digest.size
+      digest.hash,
+      digest.size_bytes
     );
     let workunit_name = format!("load_bytes_with({})", resource_name.clone());
     let metadata = workunit_store::WorkunitMetadata::with_level(Level::Debug);
@@ -236,7 +236,7 @@ impl ByteStore {
 
       let read_result_closure = async {
         let mut got_first_response = false;
-        let mut buf = BytesMut::with_capacity(digest.size);
+        let mut buf = BytesMut::with_capacity(digest.size_bytes);
         while let Some(response) = stream.next().await {
           // Record the observed time to receive the first response for this read.
           if !got_first_response {

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -122,8 +122,8 @@ impl ByteStore {
       "{}/uploads/{}/blobs/{}/{}",
       self.instance_name.clone().unwrap_or_default(),
       uuid::Uuid::new_v4(),
-      digest.0,
-      digest.1,
+      digest.fingerprint,
+      digest.size,
     );
     let workunit_name = format!("store_bytes({})", resource_name.clone());
     let metadata = workunit_store::WorkunitMetadata::with_level(Level::Debug);
@@ -197,8 +197,8 @@ impl ByteStore {
     let resource_name = format!(
       "{}/blobs/{}/{}",
       store.instance_name.clone().unwrap_or_default(),
-      digest.0,
-      digest.1
+      digest.fingerprint,
+      digest.size
     );
     let workunit_name = format!("load_bytes_with({})", resource_name.clone());
     let metadata = workunit_store::WorkunitMetadata::with_level(Level::Debug);
@@ -236,7 +236,7 @@ impl ByteStore {
 
       let read_result_closure = async {
         let mut got_first_response = false;
-        let mut buf = BytesMut::with_capacity(digest.1);
+        let mut buf = BytesMut::with_capacity(digest.size);
         while let Some(response) = stream.next().await {
           // Record the observed time to receive the first response for this read.
           if !got_first_response {

--- a/src/rust/engine/fs/store/src/snapshot_ops.rs
+++ b/src/rust/engine/fs/store/src/snapshot_ops.rs
@@ -723,9 +723,9 @@ pub trait SnapshotOps: StoreWrapper + 'static {
           (false, false) => {
             // Prefer "No subdirectory found" error to "had extra files" error.
             return Err(format!(
-              "Cannot strip prefix {} from root directory {:?} - {}directory{} didn't contain a directory named {}{}",
+              "Cannot strip prefix {} from root directory (Digest with hash {:?}) - {}directory{} didn't contain a directory named {}{}",
               already_stripped.join(&prefix).display(),
-              root_digest,
+              root_digest.hash,
               if has_already_stripped_any { "sub" } else { "root " },
               if has_already_stripped_any { format!(" {}", already_stripped.display()) } else { String::new() },
               component_to_strip_str,
@@ -734,9 +734,9 @@ pub trait SnapshotOps: StoreWrapper + 'static {
           },
           (true, false) => {
             return Err(format!(
-              "Cannot strip prefix {} from root directory {:?} - {}directory{} contained non-matching {}",
+              "Cannot strip prefix {} from root directory (Digest with hash {:?}) - {}directory{} contained non-matching {}",
               already_stripped.join(&prefix).display(),
-              root_digest,
+              root_digest.hash,
               if has_already_stripped_any { "sub" } else { "root " },
               if has_already_stripped_any { format!(" {}", already_stripped.display()) } else { String::new() },
               Snapshot::directories_and_files(&extra_directories, &files),

--- a/src/rust/engine/fs/store/src/snapshot_ops.rs
+++ b/src/rust/engine/fs/store/src/snapshot_ops.rs
@@ -195,7 +195,10 @@ async fn error_for_collisions<T: StoreWrapper + 'static>(
     .iter()
     .map(|file_node| async move {
       let digest: Digest = require_digest(file_node.digest.as_ref())?;
-      let header = format!("file digest={} size={}:\n\n", digest.0, digest.1);
+      let header = format!(
+        "file digest={} size={}:\n\n",
+        digest.fingerprint, digest.size
+      );
 
       let contents = store_wrapper
         .load_file_bytes_with(digest, |bytes| {
@@ -227,7 +230,10 @@ async fn error_for_collisions<T: StoreWrapper + 'static>(
     .map(|dir_node| async move {
       // TODO(tonic): Avoid using .unwrap here!
       let digest = require_digest(dir_node.digest.as_ref())?;
-      let detail = format!("dir digest={} size={}:\n\n", digest.0, digest.1);
+      let detail = format!(
+        "dir digest={} size={}:\n\n",
+        digest.fingerprint, digest.size
+      );
       let res: Result<_, String> = Ok((dir_node.name.clone(), detail));
       res
     })
@@ -808,8 +814,8 @@ impl From<PathGlob> for RestrictedPathGlob {
 // TODO(tonic): Replace uses of this method with `.into` or equivalent.
 fn to_bazel_digest(digest: Digest) -> remexec::Digest {
   remexec::Digest {
-    hash: digest.0.to_hex(),
-    size_bytes: digest.1 as i64,
+    hash: digest.fingerprint.to_hex(),
+    size_bytes: digest.size as i64,
   }
 }
 

--- a/src/rust/engine/fs/store/src/snapshot_ops.rs
+++ b/src/rust/engine/fs/store/src/snapshot_ops.rs
@@ -197,7 +197,7 @@ async fn error_for_collisions<T: StoreWrapper + 'static>(
       let digest: Digest = require_digest(file_node.digest.as_ref())?;
       let header = format!(
         "file digest={} size={}:\n\n",
-        digest.fingerprint, digest.size
+        digest.hash, digest.size_bytes
       );
 
       let contents = store_wrapper
@@ -230,10 +230,7 @@ async fn error_for_collisions<T: StoreWrapper + 'static>(
     .map(|dir_node| async move {
       // TODO(tonic): Avoid using .unwrap here!
       let digest = require_digest(dir_node.digest.as_ref())?;
-      let detail = format!(
-        "dir digest={} size={}:\n\n",
-        digest.fingerprint, digest.size
-      );
+      let detail = format!("dir digest={} size={}:\n\n", digest.hash, digest.size_bytes);
       let res: Result<_, String> = Ok((dir_node.name.clone(), detail));
       res
     })
@@ -814,8 +811,8 @@ impl From<PathGlob> for RestrictedPathGlob {
 // TODO(tonic): Replace uses of this method with `.into` or equivalent.
 fn to_bazel_digest(digest: Digest) -> remexec::Digest {
   remexec::Digest {
-    hash: digest.fingerprint.to_hex(),
-    size_bytes: digest.size as i64,
+    hash: digest.hash.to_hex(),
+    size_bytes: digest.size_bytes as i64,
   }
 }
 

--- a/src/rust/engine/fs/store/src/snapshot_tests.rs
+++ b/src/rust/engine/fs/store/src/snapshot_tests.rs
@@ -54,7 +54,7 @@ async fn snapshot_one_file() {
   assert_eq!(
     snapshot,
     Snapshot {
-      digest: Digest(
+      digest: Digest::new(
         Fingerprint::from_hex_string(
           "63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16",
         )
@@ -82,7 +82,7 @@ async fn snapshot_recursive_directories() {
   assert_eq!(
     snapshot,
     Snapshot {
-      digest: Digest(
+      digest: Digest::new(
         Fingerprint::from_hex_string(
           "8b1a7ea04eaa2527b35683edac088bc826117b53b7ec6601740b55e20bce3deb",
         )
@@ -136,7 +136,7 @@ async fn snapshot_recursive_directories_including_empty() {
       .await
       .unwrap(),
     Snapshot {
-      digest: Digest(
+      digest: Digest::new(
         Fingerprint::from_hex_string(
           "fbff703bdaac62accf2ea5083bcfed89292073bf710ef9ad14d9298c637e777b",
         )

--- a/src/rust/engine/fs/store/src/snapshot_tests.rs
+++ b/src/rust/engine/fs/store/src/snapshot_tests.rs
@@ -456,7 +456,7 @@ async fn strip_prefix_non_matching_file() {
   let prefix = RelativePath::new(PathBuf::from("cats")).unwrap();
   let result = store.strip_prefix(dir.digest(), prefix).await;
 
-  assert_eq!(result, Err(format!("Cannot strip prefix cats from root directory {:?} - root directory contained non-matching file named: treats", dir.digest()).into()));
+  assert_eq!(result, Err(format!("Cannot strip prefix cats from root directory (Digest with hash {:?}) - root directory contained non-matching file named: treats", dir.digest().hash).into()));
 }
 
 #[tokio::test]
@@ -475,7 +475,7 @@ async fn strip_prefix_non_matching_dir() {
   let prefix = RelativePath::new(PathBuf::from("animals/cats")).unwrap();
   let result = store.strip_prefix(dir.digest(), prefix).await;
 
-  assert_eq!(result, Err(format!("Cannot strip prefix animals/cats from root directory {:?} - subdirectory animals contained non-matching directory named: birds", dir.digest()).into()));
+  assert_eq!(result, Err(format!("Cannot strip prefix animals/cats from root directory (Digest with hash {:?}) - subdirectory animals contained non-matching directory named: birds", dir.digest().hash).into()));
 }
 
 #[tokio::test]
@@ -492,7 +492,7 @@ async fn strip_subdir_not_in_dir() {
     .expect("Error storing directory");
   let prefix = RelativePath::new(PathBuf::from("cats/ugly")).unwrap();
   let result = store.strip_prefix(dir.digest(), prefix).await;
-  assert_eq!(result, Err(format!("Cannot strip prefix cats/ugly from root directory {:?} - subdirectory cats didn't contain a directory named ugly but did contain file named: roland", dir.digest()).into()));
+  assert_eq!(result, Err(format!("Cannot strip prefix cats/ugly from root directory (Digest with hash {:?}) - subdirectory cats didn't contain a directory named ugly but did contain file named: roland", dir.digest().hash).into()));
 }
 
 fn make_dir_stat(root: &Path, relpath: &Path) -> PathStat {

--- a/src/rust/engine/fs/store/src/tests.rs
+++ b/src/rust/engine/fs/store/src/tests.rs
@@ -36,7 +36,7 @@ pub fn big_file_fingerprint() -> Fingerprint {
 }
 
 pub fn big_file_digest() -> Digest {
-  Digest(big_file_fingerprint(), big_file_bytes().len())
+  Digest::new(big_file_fingerprint(), big_file_bytes().len())
 }
 
 pub fn big_file_bytes() -> Bytes {
@@ -58,7 +58,7 @@ pub fn extra_big_file_fingerprint() -> Fingerprint {
 }
 
 pub fn extra_big_file_digest() -> Digest {
-  Digest(extra_big_file_fingerprint(), extra_big_file_bytes().len())
+  Digest::new(extra_big_file_fingerprint(), extra_big_file_bytes().len())
 }
 
 pub fn extra_big_file_bytes() -> Bytes {
@@ -370,7 +370,7 @@ async fn non_canonical_remote_directory_is_error() {
   });
   let non_canonical_directory_bytes = non_canonical_directory.to_bytes();
   let directory_digest = Digest::of_bytes(&non_canonical_directory_bytes);
-  let non_canonical_directory_fingerprint = directory_digest.0;
+  let non_canonical_directory_fingerprint = directory_digest.fingerprint;
 
   let dir = TempDir::new().unwrap();
 
@@ -808,7 +808,7 @@ async fn uploading_digest_with_wrong_size_is_error() {
 
   assert_eq!(cas.blobs.lock().get(&testdata.fingerprint()), None);
 
-  let wrong_digest = Digest(testdata.fingerprint(), testdata.len() + 1);
+  let wrong_digest = Digest::new(testdata.fingerprint(), testdata.len() + 1);
 
   new_store(dir.path(), cas.address())
     .ensure_remote_has_recursive(vec![wrong_digest])
@@ -1301,9 +1301,9 @@ async fn returns_upload_summary_on_empty_cas() {
 
   // We store all 3 files, and so we must sum their digests
   let test_data = vec![
-    testdir.digest().1,
-    testroland.digest().1,
-    testcatnip.digest().1,
+    testdir.digest().size,
+    testroland.digest().size,
+    testcatnip.digest().size,
   ];
   let test_bytes = test_data.iter().sum();
   summary.upload_wall_time = Duration::default();
@@ -1354,9 +1354,9 @@ async fn summary_does_not_count_things_in_cas() {
     data_summary,
     UploadSummary {
       ingested_file_count: 1,
-      ingested_file_bytes: testroland.digest().1,
+      ingested_file_bytes: testroland.digest().size,
       uploaded_file_count: 1,
-      uploaded_file_bytes: testroland.digest().1,
+      uploaded_file_bytes: testroland.digest().size,
       upload_wall_time: Duration::default(),
     }
   );
@@ -1375,9 +1375,11 @@ async fn summary_does_not_count_things_in_cas() {
     dir_summary,
     UploadSummary {
       ingested_file_count: 3,
-      ingested_file_bytes: testdir.digest().1 + testroland.digest().1 + testcatnip.digest().1,
+      ingested_file_bytes: testdir.digest().size
+        + testroland.digest().size
+        + testcatnip.digest().size,
       uploaded_file_count: 2,
-      uploaded_file_bytes: testdir.digest().1 + testcatnip.digest().1,
+      uploaded_file_bytes: testdir.digest().size + testcatnip.digest().size,
       upload_wall_time: Duration::default(),
     }
   );

--- a/src/rust/engine/fs/store/src/tests.rs
+++ b/src/rust/engine/fs/store/src/tests.rs
@@ -370,7 +370,7 @@ async fn non_canonical_remote_directory_is_error() {
   });
   let non_canonical_directory_bytes = non_canonical_directory.to_bytes();
   let directory_digest = Digest::of_bytes(&non_canonical_directory_bytes);
-  let non_canonical_directory_fingerprint = directory_digest.fingerprint;
+  let non_canonical_directory_fingerprint = directory_digest.hash;
 
   let dir = TempDir::new().unwrap();
 
@@ -1301,9 +1301,9 @@ async fn returns_upload_summary_on_empty_cas() {
 
   // We store all 3 files, and so we must sum their digests
   let test_data = vec![
-    testdir.digest().size,
-    testroland.digest().size,
-    testcatnip.digest().size,
+    testdir.digest().size_bytes,
+    testroland.digest().size_bytes,
+    testcatnip.digest().size_bytes,
   ];
   let test_bytes = test_data.iter().sum();
   summary.upload_wall_time = Duration::default();
@@ -1354,9 +1354,9 @@ async fn summary_does_not_count_things_in_cas() {
     data_summary,
     UploadSummary {
       ingested_file_count: 1,
-      ingested_file_bytes: testroland.digest().size,
+      ingested_file_bytes: testroland.digest().size_bytes,
       uploaded_file_count: 1,
-      uploaded_file_bytes: testroland.digest().size,
+      uploaded_file_bytes: testroland.digest().size_bytes,
       upload_wall_time: Duration::default(),
     }
   );
@@ -1375,11 +1375,11 @@ async fn summary_does_not_count_things_in_cas() {
     dir_summary,
     UploadSummary {
       ingested_file_count: 3,
-      ingested_file_bytes: testdir.digest().size
-        + testroland.digest().size
-        + testcatnip.digest().size,
+      ingested_file_bytes: testdir.digest().size_bytes
+        + testroland.digest().size_bytes
+        + testcatnip.digest().size_bytes,
       uploaded_file_count: 2,
-      uploaded_file_bytes: testdir.digest().size + testcatnip.digest().size,
+      uploaded_file_bytes: testdir.digest().size_bytes + testcatnip.digest().size_bytes,
       upload_wall_time: Duration::default(),
     }
   );

--- a/src/rust/engine/hashing/src/digest_tests.rs
+++ b/src/rust/engine/hashing/src/digest_tests.rs
@@ -5,7 +5,7 @@ use serde_test;
 
 #[test]
 fn serialize_and_deserialize() {
-  let digest = Digest(
+  let digest = Digest::new(
     Fingerprint::from_hex_string(
       "0123456789abcdeffedcba98765432100000000000000000ffffffffffffffff",
     )

--- a/src/rust/engine/hashing/src/hasher_tests.rs
+++ b/src/rust/engine/hashing/src/hasher_tests.rs
@@ -6,7 +6,7 @@ fn hashes() {
   let mut hasher = super::WriterHasher::new(dst);
   assert_eq!(std::io::copy(&mut src, &mut hasher).unwrap(), 4);
   let want = (
-    super::Digest(
+    super::Digest::new(
       super::Fingerprint::from_hex_string(
         "23e92dfba8fb0c93cfba31ad2962b4e35a47054296d1d375d7f7e13e0185de7a",
       )

--- a/src/rust/engine/hashing/src/lib.rs
+++ b/src/rust/engine/hashing/src/lib.rs
@@ -47,8 +47,8 @@ pub const EMPTY_FINGERPRINT: Fingerprint = Fingerprint([
   0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c, 0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55,
 ]);
 pub const EMPTY_DIGEST: Digest = Digest {
-  fingerprint: EMPTY_FINGERPRINT,
-  size: 0,
+  hash: EMPTY_FINGERPRINT,
+  size_bytes: 0,
 };
 
 pub const FINGERPRINT_SIZE: usize = 32;
@@ -184,8 +184,8 @@ impl TryFrom<&str> for Fingerprint {
 ///
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Digest {
-  pub fingerprint: Fingerprint,
-  pub size: usize,
+  pub hash: Fingerprint,
+  pub size_bytes: usize,
 }
 
 impl Serialize for Digest {
@@ -194,8 +194,8 @@ impl Serialize for Digest {
     S: Serializer,
   {
     let mut obj = serializer.serialize_struct("digest", 2)?;
-    obj.serialize_field("fingerprint", &self.fingerprint)?;
-    obj.serialize_field("size_bytes", &self.size)?;
+    obj.serialize_field("fingerprint", &self.hash)?;
+    obj.serialize_field("size_bytes", &self.size_bytes)?;
     obj.end()
   }
 }
@@ -257,8 +257,8 @@ impl<'de> Deserialize<'de> for Digest {
 }
 
 impl Digest {
-  pub fn new(fingerprint: Fingerprint, size: usize) -> Digest {
-    Digest { fingerprint, size }
+  pub fn new(hash: Fingerprint, size_bytes: usize) -> Digest {
+    Digest { hash, size_bytes }
   }
 
   pub fn of_bytes(bytes: &[u8]) -> Self {

--- a/src/rust/engine/process_execution/bazel_protos/src/conversions.rs
+++ b/src/rust/engine/process_execution/bazel_protos/src/conversions.rs
@@ -3,8 +3,8 @@ use std::convert::TryFrom;
 impl<'a> From<&'a hashing::Digest> for crate::gen::build::bazel::remote::execution::v2::Digest {
   fn from(d: &'a hashing::Digest) -> Self {
     Self {
-      hash: d.0.to_hex(),
-      size_bytes: d.1 as i64,
+      hash: d.fingerprint.to_hex(),
+      size_bytes: d.size as i64,
     }
   }
 }
@@ -12,8 +12,8 @@ impl<'a> From<&'a hashing::Digest> for crate::gen::build::bazel::remote::executi
 impl From<hashing::Digest> for crate::gen::build::bazel::remote::execution::v2::Digest {
   fn from(d: hashing::Digest) -> Self {
     Self {
-      hash: d.0.to_hex(),
-      size_bytes: d.1 as i64,
+      hash: d.fingerprint.to_hex(),
+      size_bytes: d.size as i64,
     }
   }
 }
@@ -26,7 +26,7 @@ impl<'a> TryFrom<&'a crate::gen::build::bazel::remote::execution::v2::Digest> fo
   ) -> Result<Self, Self::Error> {
     hashing::Fingerprint::from_hex_string(&d.hash)
       .map_err(|err| format!("Bad fingerprint in Digest {:?}: {:?}", &d.hash, err))
-      .map(|fingerprint| hashing::Digest(fingerprint, d.size_bytes as usize))
+      .map(|fingerprint| hashing::Digest::new(fingerprint, d.size_bytes as usize))
   }
 }
 
@@ -38,7 +38,7 @@ impl TryFrom<crate::gen::build::bazel::remote::execution::v2::Digest> for hashin
   ) -> Result<Self, Self::Error> {
     hashing::Fingerprint::from_hex_string(&d.hash)
       .map_err(|err| format!("Bad fingerprint in Digest {:?}: {:?}", &d.hash, err))
-      .map(|fingerprint| hashing::Digest(fingerprint, d.size_bytes as usize))
+      .map(|fingerprint| hashing::Digest::new(fingerprint, d.size_bytes as usize))
   }
 }
 

--- a/src/rust/engine/process_execution/bazel_protos/src/conversions.rs
+++ b/src/rust/engine/process_execution/bazel_protos/src/conversions.rs
@@ -3,8 +3,8 @@ use std::convert::TryFrom;
 impl<'a> From<&'a hashing::Digest> for crate::gen::build::bazel::remote::execution::v2::Digest {
   fn from(d: &'a hashing::Digest) -> Self {
     Self {
-      hash: d.fingerprint.to_hex(),
-      size_bytes: d.size as i64,
+      hash: d.hash.to_hex(),
+      size_bytes: d.size_bytes as i64,
     }
   }
 }
@@ -12,8 +12,8 @@ impl<'a> From<&'a hashing::Digest> for crate::gen::build::bazel::remote::executi
 impl From<hashing::Digest> for crate::gen::build::bazel::remote::execution::v2::Digest {
   fn from(d: hashing::Digest) -> Self {
     Self {
-      hash: d.fingerprint.to_hex(),
-      size_bytes: d.size as i64,
+      hash: d.hash.to_hex(),
+      size_bytes: d.size_bytes as i64,
     }
   }
 }

--- a/src/rust/engine/process_execution/bazel_protos/src/conversions_tests.rs
+++ b/src/rust/engine/process_execution/bazel_protos/src/conversions_tests.rs
@@ -6,7 +6,7 @@ use crate::gen::build::bazel::remote::execution::v2 as remexec;
 
 #[test]
 fn from_our_digest() {
-  let our_digest = &hashing::Digest(
+  let our_digest = &hashing::Digest::new(
     hashing::Fingerprint::from_hex_string(
       "0123456789abcdeffedcba98765432100000000000000000ffffffffffffffff",
     )
@@ -28,7 +28,7 @@ fn from_bazel_digest() {
     size_bytes: 10,
   };
   let converted: Result<hashing::Digest, String> = (&bazel_digest).try_into();
-  let want = hashing::Digest(
+  let want = hashing::Digest::new(
     hashing::Fingerprint::from_hex_string(
       "0123456789abcdeffedcba98765432100000000000000000ffffffffffffffff",
     )

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -65,7 +65,7 @@ impl crate::CommandRunner for CommandRunner {
       .increment_counter(Metric::LocalCacheRequests, 1);
 
     let digest = crate::digest(req.clone(), &self.metadata);
-    let key = digest.fingerprint;
+    let key = digest.hash;
 
     let cache_failures = req
       .0

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -65,7 +65,7 @@ impl crate::CommandRunner for CommandRunner {
       .increment_counter(Metric::LocalCacheRequests, 1);
 
     let digest = crate::digest(req.clone(), &self.metadata);
-    let key = digest.0;
+    let key = digest.fingerprint;
 
     let cache_failures = req
       .0

--- a/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
@@ -355,7 +355,7 @@ impl NailgunProcessFingerprint {
       .map_err(|err| format!("Error getting the realpath of the jdk home: {}", err))?;
 
     let mut hasher = Sha256::default();
-    hasher.update(nailgun_server_req_digest.fingerprint);
+    hasher.update(nailgun_server_req_digest.hash);
     hasher.update(jdk_realpath.to_string_lossy().as_bytes());
     Ok(NailgunProcessFingerprint(Fingerprint::from_bytes(
       hasher.finalize(),

--- a/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
@@ -355,7 +355,7 @@ impl NailgunProcessFingerprint {
       .map_err(|err| format!("Error getting the realpath of the jdk home: {}", err))?;
 
     let mut hasher = Sha256::default();
-    hasher.update(nailgun_server_req_digest.0);
+    hasher.update(nailgun_server_req_digest.fingerprint);
     hasher.update(jdk_realpath.to_string_lossy().as_bytes());
     Ok(NailgunProcessFingerprint(Fingerprint::from_bytes(
       hasher.finalize(),

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -434,7 +434,7 @@ impl CommandRunner {
         }
       };
 
-      missing_digests.push(Digest(fingerprint, size));
+      missing_digests.push(Digest::new(fingerprint, size));
     }
 
     if missing_digests.is_empty() {

--- a/src/rust/engine/process_execution/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_cache_tests.rs
@@ -176,7 +176,7 @@ fn insert_into_action_cache(
   action_cache
     .action_map
     .lock()
-    .insert(action_digest.0, action_result);
+    .insert(action_digest.fingerprint, action_result);
 }
 
 #[tokio::test]
@@ -325,7 +325,7 @@ async fn cache_write_success() {
   let action_map_mutex_guard = action_cache.action_map.lock();
   assert_eq!(
     action_map_mutex_guard
-      .get(&action_digest.0)
+      .get(&action_digest.fingerprint)
       .unwrap()
       .exit_code,
     0
@@ -384,7 +384,7 @@ async fn cache_write_does_not_block() {
   let action_map_mutex_guard = action_cache.action_map.lock();
   assert_eq!(
     action_map_mutex_guard
-      .get(&action_digest.0)
+      .get(&action_digest.fingerprint)
       .unwrap()
       .exit_code,
     0

--- a/src/rust/engine/process_execution/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_cache_tests.rs
@@ -176,7 +176,7 @@ fn insert_into_action_cache(
   action_cache
     .action_map
     .lock()
-    .insert(action_digest.fingerprint, action_result);
+    .insert(action_digest.hash, action_result);
 }
 
 #[tokio::test]
@@ -325,7 +325,7 @@ async fn cache_write_success() {
   let action_map_mutex_guard = action_cache.action_map.lock();
   assert_eq!(
     action_map_mutex_guard
-      .get(&action_digest.fingerprint)
+      .get(&action_digest.hash)
       .unwrap()
       .exit_code,
     0
@@ -384,7 +384,7 @@ async fn cache_write_does_not_block() {
   let action_map_mutex_guard = action_cache.action_map.lock();
   assert_eq!(
     action_map_mutex_guard
-      .get(&action_digest.fingerprint)
+      .get(&action_digest.hash)
       .unwrap()
       .exit_code,
     0

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -106,7 +106,7 @@ async fn make_execute_request() {
 
   let want_action = remexec::Action {
     command_digest: Some(
-      (&Digest(
+      (&Digest::new(
         Fingerprint::from_hex_string(
           "369820f9643feb39980c51fb6d35d59567256946ff3234a371cba8f4de95339c",
         )
@@ -121,7 +121,7 @@ async fn make_execute_request() {
 
   let want_execute_request = remexec::ExecuteRequest {
     action_digest: Some(
-      (&Digest(
+      (&Digest::new(
         Fingerprint::from_hex_string(
           "51cda3b6c18ddd47005162010e898b20faf842b3ba1a840d1a619bd962d53192",
         )
@@ -188,7 +188,7 @@ async fn make_execute_request_with_instance_name() {
 
   let want_action = remexec::Action {
     command_digest: Some(
-      (&Digest(
+      (&Digest::new(
         Fingerprint::from_hex_string(
           "ce536af7c6334e325a99507409535d50acf05338d4cbdd031425bdaa55a87d6d",
         )
@@ -204,7 +204,7 @@ async fn make_execute_request_with_instance_name() {
   let want_execute_request = remexec::ExecuteRequest {
     instance_name: "dark-tower".to_owned(),
     action_digest: Some(
-      (&Digest(
+      (&Digest::new(
         Fingerprint::from_hex_string(
           "11cc69e6e2376c57a54a42db3d3dd22b2996a1527f976589d2d200623097b5c8",
         )
@@ -280,7 +280,7 @@ async fn make_execute_request_with_cache_key_gen_version() {
 
   let want_action = remexec::Action {
     command_digest: Some(
-      (&Digest(
+      (&Digest::new(
         Fingerprint::from_hex_string(
           "09e54a4817a36e164a0e395fac36091fd5b4aac185b8bafa90842ac4aff92a34",
         )
@@ -295,7 +295,7 @@ async fn make_execute_request_with_cache_key_gen_version() {
 
   let want_execute_request = remexec::ExecuteRequest {
     action_digest: Some(
-      (&Digest(
+      (&Digest::new(
         Fingerprint::from_hex_string(
           "dc554a1ed77588e1bac90896dcfeba255f8178ebc01893231415841109216944",
         )
@@ -345,7 +345,7 @@ async fn make_execute_request_with_jdk() {
 
   let want_action = remexec::Action {
     command_digest: Some(
-      (&Digest(
+      (&Digest::new(
         Fingerprint::from_hex_string(
           "9e969561212af080f0b6c346cdf954265a489f9c9fae63d11d61869174b13e29",
         )
@@ -360,7 +360,7 @@ async fn make_execute_request_with_jdk() {
 
   let want_execute_request = remexec::ExecuteRequest {
     action_digest: Some(
-      (&Digest(
+      (&Digest::new(
         Fingerprint::from_hex_string(
           "f90182cd453f36577868fc05a605ac84c19882c18bd907ff241923d98a7bca1e",
         )
@@ -421,7 +421,7 @@ async fn make_execute_request_with_jdk_and_extra_platform_properties() {
 
   let want_action = remexec::Action {
     command_digest: Some(
-      (&Digest(
+      (&Digest::new(
         Fingerprint::from_hex_string(
           "8d59966fac1f1a7c209ca33f8ca003ed3985b9835043fc114c45aaafa119a77b",
         )
@@ -436,7 +436,7 @@ async fn make_execute_request_with_jdk_and_extra_platform_properties() {
 
   let want_execute_request = remexec::ExecuteRequest {
     action_digest: Some(
-      (&Digest(
+      (&Digest::new(
         Fingerprint::from_hex_string(
           "190e7b28a9e32be6cb0beaad97d175c6882857991598de3585c91aec183b14b3",
         )
@@ -510,7 +510,7 @@ async fn make_execute_request_with_timeout() {
 
   let want_action = remexec::Action {
     command_digest: Some(
-      (&Digest(
+      (&Digest::new(
         Fingerprint::from_hex_string(
           "369820f9643feb39980c51fb6d35d59567256946ff3234a371cba8f4de95339c",
         )
@@ -526,7 +526,7 @@ async fn make_execute_request_with_timeout() {
 
   let want_execute_request = remexec::ExecuteRequest {
     action_digest: Some(
-      (&Digest(
+      (&Digest::new(
         Fingerprint::from_hex_string(
           "151e4bfce1244eb7ae74ed09d8759088557d9c63fbaaa5fcca662998266f4b09",
         )
@@ -750,7 +750,7 @@ async fn server_rejecting_execute_request_gives_error() {
   let mock_server = mock::execution_server::TestServer::new(
     mock::execution_server::MockExecution::new(vec![
       ExpectedAPICall::GetActionResult {
-        action_digest: hashing::Digest(
+        action_digest: hashing::Digest::new(
           hashing::Fingerprint::from_hex_string(
             "bf10cd168ad711602f7a241cbcbc9a3d32497fdd1465d8a01d4549ee7d8ebc08",
           )
@@ -1493,7 +1493,7 @@ async fn execute_missing_file_errors_if_unknown() {
   let mock_server = {
     mock::execution_server::TestServer::new(
       mock::execution_server::MockExecution::new(vec![ExpectedAPICall::GetActionResult {
-        action_digest: hashing::Digest(
+        action_digest: hashing::Digest::new(
           hashing::Fingerprint::from_hex_string(
             "63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16",
           )
@@ -1545,7 +1545,7 @@ async fn execute_missing_file_errors_if_unknown() {
     .run(cat_roland_request(), Context::default())
     .await
     .expect_err("Want error");
-  assert_contains(&error, &format!("{}", missing_digest.0));
+  assert_contains(&error, &format!("{}", missing_digest.fingerprint));
 }
 
 #[tokio::test]
@@ -1846,10 +1846,10 @@ async fn digest_command() {
   let digest = crate::remote::digest(&command).unwrap();
 
   assert_eq!(
-    &digest.0.to_hex(),
+    &digest.fingerprint.to_hex(),
     "a32cd427e5df6a998199266681692989f56c19cabd1cc637bdd56ae2e62619b4"
   );
-  assert_eq!(digest.1, 32)
+  assert_eq!(digest.size, 32)
 }
 
 #[tokio::test]
@@ -1987,7 +1987,7 @@ async fn extract_output_files_from_response_directories_and_files() {
 
   assert_eq!(
     extract_output_files_from_response(&execute_response).await,
-    Ok(Digest(
+    Ok(Digest::new(
       Fingerprint::from_hex_string(
         "639b4b84bb58a9353d49df8122e7987baf038efe54ed035e67910846c865b1e2"
       )
@@ -2369,7 +2369,7 @@ pub(crate) fn missing_preconditionfailure_violation(
   {
     bazel_protos::gen::google::rpc::precondition_failure::Violation {
       r#type: "MISSING".to_owned(),
-      subject: format!("blobs/{}/{}", digest.0, digest.1),
+      subject: format!("blobs/{}/{}", digest.fingerprint, digest.size),
       ..Default::default()
     }
   }

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -1545,7 +1545,7 @@ async fn execute_missing_file_errors_if_unknown() {
     .run(cat_roland_request(), Context::default())
     .await
     .expect_err("Want error");
-  assert_contains(&error, &format!("{}", missing_digest.fingerprint));
+  assert_contains(&error, &format!("{}", missing_digest.hash));
 }
 
 #[tokio::test]
@@ -1846,10 +1846,10 @@ async fn digest_command() {
   let digest = crate::remote::digest(&command).unwrap();
 
   assert_eq!(
-    &digest.fingerprint.to_hex(),
+    &digest.hash.to_hex(),
     "a32cd427e5df6a998199266681692989f56c19cabd1cc637bdd56ae2e62619b4"
   );
-  assert_eq!(digest.size, 32)
+  assert_eq!(digest.size_bytes, 32)
 }
 
 #[tokio::test]
@@ -2369,7 +2369,7 @@ pub(crate) fn missing_preconditionfailure_violation(
   {
     bazel_protos::gen::google::rpc::precondition_failure::Violation {
       r#type: "MISSING".to_owned(),
-      subject: format!("blobs/{}/{}", digest.fingerprint, digest.size),
+      subject: format!("blobs/{}/{}", digest.hash, digest.size_bytes),
       ..Default::default()
     }
   }

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -353,11 +353,11 @@ async fn make_request(
     args.buildbarn_url.as_ref(),
   ) {
     (Some(input_digest), Some(input_digest_length), None, None, None) => {
-      make_request_from_flat_args(args, Digest(input_digest, input_digest_length))
+      make_request_from_flat_args(args, Digest::new(input_digest, input_digest_length))
 
     }
     (None, None, Some(action_fingerprint), Some(action_digest_length), None) => {
-      extract_request_from_action_digest(store, Digest(action_fingerprint, action_digest_length), args.remote_instance_name.clone()).await
+      extract_request_from_action_digest(store, Digest::new(action_fingerprint, action_digest_length), args.remote_instance_name.clone()).await
     }
     (None, None, None, None, Some(buildbarn_url)) => {
       extract_request_from_buildbarn_url(store, buildbarn_url).await
@@ -539,7 +539,7 @@ async fn extract_request_from_buildbarn_url(
       let action_digest_length: usize = interesting_parts[3]
         .parse()
         .map_err(|err| format!("Couldn't parse action digest length as a number: {:?}", err))?;
-      Digest(action_fingerprint, action_digest_length)
+      Digest::new(action_fingerprint, action_digest_length)
     }
     "uncached_action_result" => {
       let action_result_fingerprint = Fingerprint::from_hex_string(interesting_parts[2])?;
@@ -549,7 +549,8 @@ async fn extract_request_from_buildbarn_url(
           err
         )
       })?;
-      let action_result_digest = Digest(action_result_fingerprint, action_result_digest_length);
+      let action_result_digest =
+        Digest::new(action_result_fingerprint, action_result_digest_length);
 
       let action_result = store
         .load_file_bytes_with(action_result_digest, |bytes| {

--- a/src/rust/engine/src/externs/fs.rs
+++ b/src/rust/engine/src/externs/fs.rs
@@ -75,11 +75,11 @@ py_class!(pub class PyDigest |py| {
     }
 
     @property def fingerprint(&self) -> PyResult<String> {
-      Ok(self.digest(py).fingerprint.to_hex())
+      Ok(self.digest(py).hash.to_hex())
     }
 
     @property def serialized_bytes_length(&self) -> PyResult<usize> {
-      Ok(self.digest(py).size)
+      Ok(self.digest(py).size_bytes)
     }
 
     def __richcmp__(&self, other: PyDigest, op: CompareOp) -> PyResult<PyObject> {
@@ -97,7 +97,7 @@ py_class!(pub class PyDigest |py| {
     }
 
     def __hash__(&self) -> PyResult<u64> {
-      Ok(self.digest(py).fingerprint.prefix_hash())
+      Ok(self.digest(py).hash.prefix_hash())
     }
 });
 
@@ -147,6 +147,6 @@ py_class!(pub class PySnapshot |py| {
     }
 
     def __hash__(&self) -> PyResult<u64> {
-      Ok(self.snapshot(py).digest.fingerprint.prefix_hash())
+      Ok(self.snapshot(py).digest.hash.prefix_hash())
     }
 });

--- a/src/rust/engine/src/externs/fs.rs
+++ b/src/rust/engine/src/externs/fs.rs
@@ -71,15 +71,15 @@ py_class!(pub class PyDigest |py| {
         .map_err(|e| {
           PyErr::new::<exc::Exception, _>(py, format!("Invalid digest hex: {}", e))
         })?;
-      Self::create_instance(py, Digest(fingerprint, serialized_bytes_length))
+      Self::create_instance(py, Digest::new(fingerprint, serialized_bytes_length))
     }
 
     @property def fingerprint(&self) -> PyResult<String> {
-      Ok(self.digest(py).0.to_hex())
+      Ok(self.digest(py).fingerprint.to_hex())
     }
 
     @property def serialized_bytes_length(&self) -> PyResult<usize> {
-      Ok(self.digest(py).1)
+      Ok(self.digest(py).size)
     }
 
     def __richcmp__(&self, other: PyDigest, op: CompareOp) -> PyResult<PyObject> {
@@ -97,7 +97,7 @@ py_class!(pub class PyDigest |py| {
     }
 
     def __hash__(&self) -> PyResult<u64> {
-      Ok(self.digest(py).0.prefix_hash())
+      Ok(self.digest(py).fingerprint.prefix_hash())
     }
 });
 
@@ -147,6 +147,6 @@ py_class!(pub class PySnapshot |py| {
     }
 
     def __hash__(&self) -> PyResult<u64> {
-      Ok(self.snapshot(py).digest.0.prefix_hash())
+      Ok(self.snapshot(py).digest.fingerprint.prefix_hash())
     }
 });

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -220,7 +220,7 @@ pub fn lift_file_digest(types: &Types, digest: &Value) -> Result<hashing::Digest
   }
   let fingerprint = externs::getattr_as_string(&digest, "fingerprint");
   let digest_length: usize = externs::getattr(&digest, "serialized_bytes_length").unwrap();
-  Ok(hashing::Digest(
+  Ok(hashing::Digest::new(
     hashing::Fingerprint::from_hex_string(&fingerprint)?,
     digest_length,
   ))
@@ -635,8 +635,8 @@ impl Snapshot {
     externs::unsafe_call(
       core.types.file_digest,
       &[
-        externs::store_utf8(&item.0.to_hex()),
-        externs::store_i64(item.1 as i64),
+        externs::store_utf8(&item.fingerprint.to_hex()),
+        externs::store_i64(item.size as i64),
       ],
     )
   }
@@ -851,9 +851,9 @@ impl DownloadedFile {
       }
 
       let mut hasher = hashing::WriterHasher::new(SizeLimiter {
-        writer: bytes::BytesMut::with_capacity(expected_digest.1).writer(),
+        writer: bytes::BytesMut::with_capacity(expected_digest.size).writer(),
         written: 0,
-        size_limit: expected_digest.1,
+        size_limit: expected_digest.size,
       });
 
       while let Some(next_chunk) = response_stream.next().await {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -635,8 +635,8 @@ impl Snapshot {
     externs::unsafe_call(
       core.types.file_digest,
       &[
-        externs::store_utf8(&item.fingerprint.to_hex()),
-        externs::store_i64(item.size as i64),
+        externs::store_utf8(&item.hash.to_hex()),
+        externs::store_i64(item.size_bytes as i64),
       ],
     )
   }
@@ -851,9 +851,9 @@ impl DownloadedFile {
       }
 
       let mut hasher = hashing::WriterHasher::new(SizeLimiter {
-        writer: bytes::BytesMut::with_capacity(expected_digest.size).writer(),
+        writer: bytes::BytesMut::with_capacity(expected_digest.size_bytes).writer(),
         written: 0,
-        size_limit: expected_digest.size,
+        size_limit: expected_digest.size_bytes,
       });
 
       while let Some(next_chunk) = response_stream.next().await {

--- a/src/rust/engine/testutil/mock/src/action_cache.rs
+++ b/src/rust/engine/testutil/mock/src/action_cache.rs
@@ -91,7 +91,7 @@ impl ActionCache for ActionCacheResponder {
     };
 
     let action_map = self.action_map.lock();
-    let action_result = match action_map.get(&action_digest.fingerprint) {
+    let action_result = match action_map.get(&action_digest.hash) {
       Some(ar) => ar.clone(),
       None => {
         return Err(Status::not_found(format!(
@@ -131,7 +131,7 @@ impl ActionCache for ActionCacheResponder {
     };
 
     let mut action_map = self.action_map.lock();
-    action_map.insert(action_digest.fingerprint, action_result.clone());
+    action_map.insert(action_digest.hash, action_result.clone());
 
     Ok(Response::new(action_result))
   }

--- a/src/rust/engine/testutil/mock/src/action_cache.rs
+++ b/src/rust/engine/testutil/mock/src/action_cache.rs
@@ -91,7 +91,7 @@ impl ActionCache for ActionCacheResponder {
     };
 
     let action_map = self.action_map.lock();
-    let action_result = match action_map.get(&action_digest.0) {
+    let action_result = match action_map.get(&action_digest.fingerprint) {
       Some(ar) => ar.clone(),
       None => {
         return Err(Status::not_found(format!(
@@ -131,7 +131,7 @@ impl ActionCache for ActionCacheResponder {
     };
 
     let mut action_map = self.action_map.lock();
-    action_map.insert(action_digest.0, action_result.clone());
+    action_map.insert(action_digest.fingerprint, action_result.clone());
 
     Ok(Response::new(action_result))
   }

--- a/src/rust/engine/testutil/mock/src/cas.rs
+++ b/src/rust/engine/testutil/mock/src/cas.rs
@@ -491,7 +491,7 @@ impl ContentAddressableStorage for StubCASResponder {
     for digest in request.blob_digests {
       let hashing_digest_result: Result<Digest, String> = digest.try_into();
       let hashing_digest = hashing_digest_result.expect("Bad digest");
-      if !blobs.contains_key(&hashing_digest.fingerprint) {
+      if !blobs.contains_key(&hashing_digest.hash) {
         response.missing_blob_digests.push(hashing_digest.into())
       }
     }

--- a/src/rust/engine/testutil/mock/src/cas.rs
+++ b/src/rust/engine/testutil/mock/src/cas.rs
@@ -491,7 +491,7 @@ impl ContentAddressableStorage for StubCASResponder {
     for digest in request.blob_digests {
       let hashing_digest_result: Result<Digest, String> = digest.try_into();
       let hashing_digest = hashing_digest_result.expect("Bad digest");
-      if !blobs.contains_key(&hashing_digest.0) {
+      if !blobs.contains_key(&hashing_digest.fingerprint) {
         response.missing_blob_digests.push(hashing_digest.into())
       }
     }

--- a/src/rust/engine/testutil/src/data.rs
+++ b/src/rust/engine/testutil/src/data.rs
@@ -41,7 +41,7 @@ impl TestData {
   }
 
   pub fn fingerprint(&self) -> hashing::Fingerprint {
-    self.digest().0
+    self.digest().fingerprint
   }
 
   pub fn digest(&self) -> hashing::Digest {
@@ -305,7 +305,7 @@ impl TestDirectory {
   }
 
   pub fn fingerprint(&self) -> hashing::Fingerprint {
-    self.digest().0
+    self.digest().fingerprint
   }
 
   pub fn digest(&self) -> hashing::Digest {
@@ -333,7 +333,7 @@ impl TestTree {
   }
 
   pub fn fingerprint(&self) -> hashing::Fingerprint {
-    self.digest().0
+    self.digest().fingerprint
   }
 
   pub fn digest(&self) -> hashing::Digest {

--- a/src/rust/engine/testutil/src/data.rs
+++ b/src/rust/engine/testutil/src/data.rs
@@ -41,7 +41,7 @@ impl TestData {
   }
 
   pub fn fingerprint(&self) -> hashing::Fingerprint {
-    self.digest().fingerprint
+    self.digest().hash
   }
 
   pub fn digest(&self) -> hashing::Digest {
@@ -305,7 +305,7 @@ impl TestDirectory {
   }
 
   pub fn fingerprint(&self) -> hashing::Fingerprint {
-    self.digest().fingerprint
+    self.digest().hash
   }
 
   pub fn digest(&self) -> hashing::Digest {
@@ -333,7 +333,7 @@ impl TestTree {
   }
 
   pub fn fingerprint(&self) -> hashing::Fingerprint {
-    self.digest().fingerprint
+    self.digest().hash
   }
 
   pub fn digest(&self) -> hashing::Digest {


### PR DESCRIPTION
### Problem

We might want to add an additional field on `Digest` in order to support correctly handling `Digest`s created from a file (a Python `FileDigest`) vs `Digest`s created from a directory (a Python `Digest` or `Snapshot`). Since this would involve changing the same code in a bunch of different places in the codebase where we create a `Digest` literal, preemptively change the syntax to named-field-struct-style so this only needs to happen once.

### Solution

Change the syntax and add a `::new()` associated function to avoid having to reference the literal struct syntax all over the codebase.
