### PR TITLE
Change schema expanded target

### DIFF
--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -37,6 +37,7 @@ from pants.engine.rules import Get, MultiGet, rule
 from pants.engine.streaming_workunit_handler import (
     StreamingWorkunitContext,
     StreamingWorkunitHandler,
+    TargetInfo,
 )
 from pants.goal.run_tracker import RunTracker
 from pants.testutil.option_util import create_options_bootstrapper
@@ -874,13 +875,13 @@ def test_streaming_workunits_expanded_specs(run_tracker: RunTracker) -> None:
         assert isinstance(context, StreamingWorkunitContext)
 
         expanded = context.get_expanded_specs()
-        files = expanded.files
+        targets = expanded.targets
 
-        assert len(files.keys()) == 2
-        assert files["src/python/others/b.py"] == ["src/python/others/b.py"]
-        assert set(files["src/python/somefiles"]) == {
-            "src/python/somefiles/a.py",
-            "src/python/somefiles/b.py",
+        assert len(targets.keys()) == 2
+        assert targets["src/python/others/b.py"] == [TargetInfo(filename="src/python/others/b.py")]
+        assert set(targets["src/python/somefiles"]) == {
+            TargetInfo(filename="src/python/somefiles/a.py"),
+            TargetInfo(filename="src/python/somefiles/b.py"),
         }
 
     handler = StreamingWorkunitHandler(

--- a/src/python/pants/engine/streaming_workunit_handler.py
+++ b/src/python/pants/engine/streaming_workunit_handler.py
@@ -25,8 +25,13 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
+class TargetInfo:
+    filename: str
+
+
+@dataclass(frozen=True)
 class ExpandedSpecs:
-    files: Dict[str, List[str]]
+    targets: Dict[str, List[TargetInfo]]
 
 
 @dataclass(frozen=True)
@@ -77,13 +82,17 @@ class StreamingWorkunitContext:
         expanded_targets = self._scheduler.product_request(
             Targets, [Params(Addresses([addr])) for addr in unexpanded_addresses]
         )
-        files = {}
+        targets_dict: Dict[str, List[TargetInfo]] = {}
         for addr, targets in zip(unexpanded_addresses, expanded_targets):
-            files[addr.spec] = [
-                tgt.address.filename if tgt.address.is_file_target else str(tgt.address)
+            targets_dict[addr.spec] = [
+                TargetInfo(
+                    filename=(
+                        tgt.address.filename if tgt.address.is_file_target else str(tgt.address)
+                    )
+                )
                 for tgt in targets
             ]
-        return ExpandedSpecs(files=files)
+        return ExpandedSpecs(targets=targets_dict)
 
 
 class WorkunitsCallback(Protocol):


### PR DESCRIPTION
This commit changes the schema of the `ExpandedSpecs` dataclass returned by `get_expanded_specs`, by adding a new `TargetInfo` dataclass that wraps the filename `str`, so that we can more flexibly add additional per-spec data.