### PR TITLE
Change filename -> spec_or_filename in TargetInfo struct

### DIFF
--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -877,11 +877,13 @@ def test_streaming_workunits_expanded_specs(run_tracker: RunTracker) -> None:
         expanded = context.get_expanded_specs()
         targets = expanded.targets
 
-        assert len(targets.keys()) == 2
-        assert targets["src/python/others/b.py"] == [TargetInfo(filename="src/python/others/b.py")]
+        assert set(targets.keys()) == {"src/python/others/b.py", "src/python/somefiles"}
+        assert targets["src/python/others/b.py"] == [
+            TargetInfo(spec_or_filename="src/python/others/b.py")
+        ]
         assert set(targets["src/python/somefiles"]) == {
-            TargetInfo(filename="src/python/somefiles/a.py"),
-            TargetInfo(filename="src/python/somefiles/b.py"),
+            TargetInfo(spec_or_filename="src/python/somefiles/a.py"),
+            TargetInfo(spec_or_filename="src/python/somefiles/b.py"),
         }
 
     handler = StreamingWorkunitHandler(

--- a/src/python/pants/engine/streaming_workunit_handler.py
+++ b/src/python/pants/engine/streaming_workunit_handler.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class TargetInfo:
-    filename: str
+    spec_or_filename: str
 
 
 @dataclass(frozen=True)
@@ -86,7 +86,7 @@ class StreamingWorkunitContext:
         for addr, targets in zip(unexpanded_addresses, expanded_targets):
             targets_dict[addr.spec] = [
                 TargetInfo(
-                    filename=(
+                    spec_or_filename=(
                         tgt.address.filename if tgt.address.is_file_target else str(tgt.address)
                     )
                 )


### PR DESCRIPTION
The `TargetInfo` struct returned by `get_expanded_specs` currently lists the name of the target under the dataclass key `filename`. However, not all targets are files, so this key name is misleading. This commit changes the name of that key to `spec_or_filename`.