### PR TITLE
record observation of blob sizes read

### DIFF
--- a/src/rust/engine/workunit_store/src/metrics.rs
+++ b/src/rust/engine/workunit_store/src/metrics.rs
@@ -91,6 +91,7 @@ impl Metric {
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum ObservationMetric {
   TestObservation,
+  LocalStoreReadBlobSize,
   RemoteExecutionRPCFirstResponseTime,
   RemoteStoreTimeToFirstByte,
 }
@@ -101,6 +102,7 @@ impl ObservationMetric {
 
     match *self {
       TestObservation => "test_observation",
+      LocalStoreReadBlobSize => "local_store_read_blob_size",
       RemoteExecutionRPCFirstResponseTime => "remote_execution_rpc_first_response_time",
       RemoteStoreTimeToFirstByte => "remote_store_time_to_first_byte",
     }


### PR DESCRIPTION
[ci skip-build-wheels]

Add an observation metric for the blobs read from the local store. This allows measuring the distribution of blob sizes in a run.
