### PR TITLE
Bump to tokio 0.2.25.

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -3103,9 +3103,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.24"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099837d3464c16a808060bb3f02263b412f6fafcb5d01c533d309985fbeebe48"
+checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
 dependencies = [
  "bytes",
  "fnv",


### PR DESCRIPTION
### Problem

A newer `tokio` has been released with a fix for one panic and some additional debug output.

### Solution

Bump to it. This may or may not affect the panic on #11364, but we can do our due diligence to rule it out.

[ci skip-build-wheels]