### PR TITLE
Stop pinning `zipp` by default in `[pytest].pytest_plugins` to reduce risk of issues with pip's new resolver

### DIFF
--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -34,13 +34,10 @@ class PyTest(Subsystem):
             "--pytest-plugins",
             type=list,
             advanced=True,
-            default=[
-                "pytest-cov>=2.10.1,<2.11",
-                # NB: zipp has frequently destabilized builds due to floating transitive versions
-                # under pytest.
-                "zipp==2.1.0",
-            ],
-            help="Requirement strings for any plugins or additional requirements you'd like to use.",
+            default=["pytest-cov>=2.10.1,<2.11"],
+            help=(
+                "Requirement strings for any plugins or additional requirements you'd like to use."
+            ),
         )
         register(
             "--timeouts",


### PR DESCRIPTION
Pip's new resolver now errors when a constraints.txt value != an explicit requirement, such as one provided via `[pytest].pytest_plugins`. This means that if a user has `zipp` in their constraints.txt, they must either pin to the old `2.1.0` or they must override the default for `[pytest].pytest_plugins`. Both are very non-obvious what to do.

We had pinned zipp as a convenience because it was unstable for some time, but it seems to have become more stable. It's been working robustly to use zipp 3.* in Toolchain. Now, this is likely to be much more of a gotcha and nuisance than a value-add to users. So, we stop pinning.

[ci skip-rust]
[ci skip-build-wheels]