### PR TITLE
Change default for [pytest].pytest_plugins to use pytest-cov 2.11.x

### DIFF
--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -34,7 +34,7 @@ class PyTest(Subsystem):
             "--pytest-plugins",
             type=list,
             advanced=True,
-            default=["pytest-cov>=2.10.1,<2.11"],
+            default=["pytest-cov>=2.10.1,<2.12"],
             help=(
                 "Requirement strings for any plugins or additional requirements you'd like to use."
             ),


### PR DESCRIPTION
2.11.1 (2021-01-20)
-------------------

* Fixed support for newer setuptools (v42+).
  Contributed by Michał Górny in `#451 <https://github.com/pytest-dev/pytest-cov/pull/451>`_.

2.11.0 (2021-01-18)
-------------------

* Bumped minimum coverage requirement to 5.2.1. This prevents reporting issues.
  Contributed by Mateus Berardo de Souza Terra in `#433 <https://github.com/pytest-dev/pytest-cov/pull/433>`_.
* Improved sample projects (from the `examples <https://github.com/pytest-dev/pytest-cov/tree/master/examples>`_
  directory) to support running `tox -e pyXY`. Now the example configures a suffixed coverage data file,
  and that makes the cleanup environment unnecessary.
  Contributed by Ganden Schaffner in `#435 <https://github.com/pytest-dev/pytest-cov/pull/435>`_.
* Removed the empty `console_scripts` entrypoint that confused some Gentoo build script.
  I didn't ask why it was so broken cause I didn't want to ruin my day.
  Contributed by Michał Górny in `#434 <https://github.com/pytest-dev/pytest-cov/pull/434>`_.
* Fixed the missing `coverage context <https://coverage.readthedocs.io/en/stable/contexts.html>`_
  when using subprocesses.
  Contributed by Bernát Gábor in `#443 <https://github.com/pytest-dev/pytest-cov/pull/443>`_.
* Updated the config section in the docs.
  Contributed by Pamela McA'Nulty in `#429 <https://github.com/pytest-dev/pytest-cov/pull/429>`_.
* Migrated CI to travis-ci.com (from .org).

https://github.com/pytest-dev/pytest-cov/blob/master/CHANGELOG.rst