### PR TITLE
[Internal] Log target size when starting GC

### DIFF
--- a/src/python/pants/pantsd/service/store_gc_service.py
+++ b/src/python/pants/pantsd/service/store_gc_service.py
@@ -56,7 +56,7 @@ class StoreGCService(PantsService):
     def _maybe_garbage_collect(self):
         if time.time() < self._next_gc:
             return
-        self._logger.info("Garbage collecting store")
+        self._logger.info(f"Garbage collecting store. target_size={self._target_size_bytes}")
         self._scheduler_session.garbage_collect_store(self._target_size_bytes)
         self._logger.info("Done garbage collecting store")
         self._set_next_gc()

--- a/src/python/pants/pantsd/service/store_gc_service.py
+++ b/src/python/pants/pantsd/service/store_gc_service.py
@@ -56,7 +56,7 @@ class StoreGCService(PantsService):
     def _maybe_garbage_collect(self):
         if time.time() < self._next_gc:
             return
-        self._logger.info(f"Garbage collecting store. target_size={self._target_size_bytes}")
+        self._logger.info(f"Garbage collecting store. target_size={self._target_size_bytes:,}")
         self._scheduler_session.garbage_collect_store(self._target_size_bytes)
         self._logger.info("Done garbage collecting store")
         self._set_next_gc()


### PR DESCRIPTION
Looking at pantsd log should yield more information about values being used.
In this case, it is useful to log this bit of info so we don't have to go look for that value elsewhere.