### PR TITLE
Fall back to the previous commit as merge-base if no tracking branch (cherrypick of #11519)

### DIFF
--- a/build-support/common.sh
+++ b/build-support/common.sh
@@ -65,8 +65,11 @@ function fingerprint_data() {
 }
 
 function git_merge_base() {
-  # This prints the tracking branch if set and otherwise falls back to local "master".
-  git rev-parse --symbolic-full-name --abbrev-ref HEAD@\{upstream\} 2>/dev/null || echo 'master'
+  # This prints the tracking branch if set and otherwise falls back to the commit before HEAD.
+  # We fall back to the commit before HEAD to attempt to account for situations without a tracking
+  # branch, which might include `master` builds, but can also include branch-PR builds, where
+  # Travis checks out a specially crafted Github `+refs/pull/11516/merge` branch.
+  git rev-parse --symbolic-full-name --abbrev-ref HEAD@\{upstream\} 2>/dev/null || git rev-parse HEAD^
 }
 
 function determine_python() {


### PR DESCRIPTION
### Problem

Branch-PR builds (e.g. PRs merging to stable branches like `2.2.x`) currently fail to calculate the merge-base because HEAD is not a branch, and thus doesn't have an upstream branch. Currently we fall back to diffing against `master`, but that won't necessarily exist in a shallowly created clone.

### Solution

Rather than `master`, use the previous commit as the merge-base when there is no tracking branch.

### Result

Verified in #11520 that PR branch builds are fixed.

[ci skip-rust]