### PR TITLE
Put test stdout/stderr onto EnrichedTestResult workunit

### DIFF
--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -28,7 +28,15 @@ from pants.core.util_rules.filter_empty_sources import (
 )
 from pants.engine.addresses import Address
 from pants.engine.desktop import OpenFiles, OpenFilesRequest
-from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, FileContent, MergeDigests, Workspace
+from pants.engine.fs import (
+    EMPTY_DIGEST,
+    EMPTY_FILE_DIGEST,
+    CreateDigest,
+    Digest,
+    FileContent,
+    MergeDigests,
+    Workspace,
+)
 from pants.engine.process import InteractiveProcess, InteractiveRunner
 from pants.engine.target import (
     Sources,
@@ -69,7 +77,9 @@ class MockTestFieldSet(TestFieldSet, metaclass=ABCMeta):
         return EnrichedTestResult(
             exit_code=self.exit_code(self.address),
             stdout="",
+            stdout_digest=EMPTY_FILE_DIGEST,
             stderr="",
+            stderr_digest=EMPTY_FILE_DIGEST,
             address=self.address,
             coverage_data=MockCoverageData(self.address),
             output_setting=ShowOutput.ALL,
@@ -266,7 +276,12 @@ def test_coverage(rule_runner: RuleRunner) -> None:
 
 def sort_results() -> None:
     create_test_result = partial(
-        EnrichedTestResult, stdout="", stderr="", output_setting=ShowOutput.ALL
+        EnrichedTestResult,
+        stdout="",
+        stdout_digest=EMPTY_FILE_DIGEST,
+        stderr="",
+        stderr_digest=EMPTY_FILE_DIGEST,
+        output_setting=ShowOutput.ALL,
     )
     skip1 = create_test_result(exit_code=None, address=Address("t1"))
     skip2 = create_test_result(exit_code=None, address=Address("t2"))
@@ -296,7 +311,9 @@ def assert_streaming_output(
     result = EnrichedTestResult(
         exit_code=exit_code,
         stdout=stdout,
+        stdout_digest=EMPTY_FILE_DIGEST,
         stderr=stderr,
+        stderr_digest=EMPTY_FILE_DIGEST,
         output_setting=output_setting,
         address=Address("demo_test"),
     )

--- a/src/python/pants/engine/engine_aware.py
+++ b/src/python/pants/engine/engine_aware.py
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from abc import ABC
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
-from pants.engine.fs import Snapshot
+from pants.engine.fs import FileDigest, Snapshot
 from pants.util.logging import LogLevel
 
 
@@ -49,11 +49,11 @@ class EngineAwareReturnType(ABC):
         """
         return None
 
-    def artifacts(self) -> Optional[Dict[str, Snapshot]]:
+    def artifacts(self) -> Optional[Dict[str, Union[FileDigest, Snapshot]]]:
         """If implemented, this sets the `artifacts` entry for the workunit of any `@rule`'s that
         return the annotated type.
 
-        `artifacts` is a mapping of arbitrary string keys to `Snapshot`s.
+        `artifacts` is a mapping of arbitrary string keys to `Snapshot`s or `FileDigest`s.
         """
         return None
 

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Dict, Iterable, Mapping, Optional, Tuple, Unio
 from pants.base.deprecated import deprecated_conditional
 from pants.base.exception_sink import ExceptionSink
 from pants.engine.engine_aware import EngineAwareReturnType
-from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, FileContent
+from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, FileContent, FileDigest
 from pants.engine.internals.selectors import MultiGet
 from pants.engine.platform import Platform
 from pants.engine.rules import Get, collect_rules, rule, side_effecting
@@ -173,7 +173,9 @@ class ProcessResult:
     """
 
     stdout: bytes
+    stdout_digest: FileDigest
     stderr: bytes
+    stderr_digest: FileDigest
     output_digest: Digest
 
 
@@ -185,7 +187,9 @@ class FallibleProcessResult:
     """
 
     stdout: bytes
+    stdout_digest: FileDigest
     stderr: bytes
+    stderr_digest: FileDigest
     exit_code: int
     output_digest: Digest
 
@@ -195,7 +199,9 @@ class FallibleProcessResultWithPlatform:
     """Result of executing a process which might fail, along with the platform it ran on."""
 
     stdout: bytes
+    stdout_digest: FileDigest
     stderr: bytes
+    stderr_digest: FileDigest
     exit_code: int
     output_digest: Digest
     platform: Platform
@@ -248,9 +254,11 @@ def fallible_to_exec_result_or_raise(
 
     if fallible_result.exit_code == 0:
         return ProcessResult(
-            fallible_result.stdout,
-            fallible_result.stderr,
-            fallible_result.output_digest,
+            stdout=fallible_result.stdout,
+            stdout_digest=fallible_result.stdout_digest,
+            stderr=fallible_result.stderr,
+            stderr_digest=fallible_result.stderr_digest,
+            output_digest=fallible_result.output_digest,
         )
     raise ProcessExecutionFailure(
         fallible_result.exit_code,
@@ -265,7 +273,9 @@ def remove_platform_information(res: FallibleProcessResultWithPlatform) -> Falli
     return FallibleProcessResult(
         exit_code=res.exit_code,
         stdout=res.stdout,
+        stdout_digest=res.stdout_digest,
         stderr=res.stderr,
+        stderr_digest=res.stderr_digest,
         output_digest=res.output_digest,
     )
 

--- a/src/rust/engine/src/externs/engine_aware.rs
+++ b/src/rust/engine/src/externs/engine_aware.rs
@@ -3,7 +3,7 @@
 
 use crate::core::Value;
 use crate::externs;
-use crate::nodes::{lift_file_digest, lift_directory_digest};
+use crate::nodes::{lift_directory_digest, lift_file_digest};
 use crate::Failure;
 use crate::Types;
 
@@ -127,15 +127,15 @@ impl EngineAwareInformation for Artifacts {
           .map_err(|e| {
             log::error!("Error in EngineAware.artifacts() - no `digest` attr: {}", e);
           })
-        .ok()?;
+          .ok()?;
 
-          match lift_directory_digest(&Value::new(digest_value)) {
-            Ok(digest) => ArtifactOutput::Snapshot(digest),
-            Err(e) => {
-              log::error!("Error in EngineAware.artifacts() implementation: {}", e);
-              return None;
-            }
+        match lift_directory_digest(&Value::new(digest_value)) {
+          Ok(digest) => ArtifactOutput::Snapshot(digest),
+          Err(e) => {
+            log::error!("Error in EngineAware.artifacts() implementation: {}", e);
+            return None;
           }
+        }
       };
       output.push((key_name, artifact_output));
     }

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -69,7 +69,9 @@ use regex::Regex;
 use rule_graph::{self, RuleGraph};
 use std::collections::hash_map::HashMap;
 use task_executor::Executor;
-use workunit_store::{ObservationMetric, UserMetadataItem, Workunit, WorkunitState, ArtifactOutput};
+use workunit_store::{
+  ArtifactOutput, ObservationMetric, UserMetadataItem, Workunit, WorkunitState,
+};
 
 use crate::{
   externs, nodes, Core, ExecutionRequest, ExecutionStrategyOptions, ExecutionTermination, Failure,
@@ -987,7 +989,7 @@ async fn workunit_to_py_value(
     let py_val = match digest {
       ArtifactOutput::FileDigest(digest) => {
         crate::nodes::Snapshot::store_file_digest(&core, digest)
-      },
+      }
       ArtifactOutput::Snapshot(digest) => {
         let snapshot = store::Snapshot::from_digest(store, *digest)
           .await
@@ -1004,10 +1006,7 @@ async fn workunit_to_py_value(
       }
     };
 
-    artifact_entries.push((
-      externs::store_utf8(artifact_name.as_str()),
-      py_val
-    ))
+    artifact_entries.push((externs::store_utf8(artifact_name.as_str()), py_val))
   }
 
   let mut user_metadata_entries = Vec::new();
@@ -1670,8 +1669,7 @@ fn ensure_remote_has_recursive(
     // NB: Supports either a FileDigest or Digest as input.
     let digests: Vec<Digest> = py_digests
       .iter(py)
-      .map(|item| {
-        let value = item.into();
+      .map(|value| {
         crate::nodes::lift_directory_digest(&value)
           .or_else(|_| crate::nodes::lift_file_digest(&core.types, &value))
       })
@@ -1794,7 +1792,7 @@ fn write_digest(
       // TODO: A parent_id should be an explicit argument.
       session.workunit_store().init_thread_state(None);
 
-      let lifted_digest = nodes::lift_directory_digest(&digest.into())
+      let lifted_digest = nodes::lift_directory_digest(&digest)
         .map_err(|e| PyErr::new::<exc::ValueError, _>(py, (e,)))?;
 
       // Python will have already validated that path_prefix is a relative path.

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1692,7 +1692,7 @@ fn single_file_digests_to_bytes(
 
     let digests: Vec<Digest> = py_file_digests
       .iter(py)
-      .map(|item| crate::nodes::lift_file_digest(&core.types, &item.into()))
+      .map(|item| crate::nodes::lift_file_digest(&core.types, &item))
       .collect::<Result<Vec<Digest>, _>>()
       .map_err(|e| PyErr::new::<exc::Exception, _>(py, (e,)))?;
 

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -37,7 +37,7 @@ pub fn none() -> PyObject {
   gil.python().None()
 }
 
-pub fn get_type_for(val: &Value) -> TypeId {
+pub fn get_type_for(val: &PyObject) -> TypeId {
   let gil = Python::acquire_gil();
   let py = gil.python();
   (&val.get_type(py)).into()

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -185,7 +185,9 @@ fn multi_platform_process_request_to_process_result(
       context.core.types.process_result,
       &[
         externs::store_bytes(&stdout_bytes),
+        Snapshot::store_file_digest(&context.core, &result.stdout_digest),
         externs::store_bytes(&stderr_bytes),
+        Snapshot::store_file_digest(&context.core, &result.stderr_digest),
         externs::store_i64(result.exit_code.into()),
         Snapshot::store_directory_digest(&result.output_directory).map_err(|s| throw(&s))?,
         externs::unsafe_call(

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -39,7 +39,7 @@ use reqwest::Error;
 use std::pin::Pin;
 use store::{self, StoreFileByDigest};
 use workunit_store::{
-  with_workunit, Level, UserMetadataItem, UserMetadataPyValue, WorkunitMetadata, ArtifactOutput
+  with_workunit, ArtifactOutput, Level, UserMetadataItem, UserMetadataPyValue, WorkunitMetadata,
 };
 
 pub type NodeResult<T> = Result<T, Failure>;

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -214,8 +214,8 @@ pub fn lift_directory_digest(digest: &Value) -> Result<hashing::Digest, String> 
   externs::fs::from_py_digest(digest).map_err(|e| format!("{:?}", e))
 }
 
-pub fn lift_file_digest(types: &Types, digest: &Value) -> Result<hashing::Digest, String> {
-  if types.file_digest != externs::get_type_for(digest) {
+pub fn lift_file_digest(types: &Types, digest: &PyObject) -> Result<hashing::Digest, String> {
+  if types.file_digest != externs::get_type_for(&digest) {
     return Err(format!("{} is not of type {}.", digest, types.file_digest));
   }
   let fingerprint = externs::getattr_as_string(&digest, "fingerprint");

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -39,7 +39,7 @@ use reqwest::Error;
 use std::pin::Pin;
 use store::{self, StoreFileByDigest};
 use workunit_store::{
-  with_workunit, Level, UserMetadataItem, UserMetadataPyValue, WorkunitMetadata,
+  with_workunit, Level, UserMetadataItem, UserMetadataPyValue, WorkunitMetadata, ArtifactOutput
 };
 
 pub type NodeResult<T> = Result<T, Failure>;
@@ -210,7 +210,7 @@ impl From<Select> for NodeKey {
   }
 }
 
-pub fn lift_directory_digest(digest: &Value) -> Result<hashing::Digest, String> {
+pub fn lift_directory_digest(digest: &PyObject) -> Result<hashing::Digest, String> {
   externs::fs::from_py_digest(digest).map_err(|e| format!("{:?}", e))
 }
 
@@ -1023,7 +1023,7 @@ pub struct PythonRuleOutput {
   value: Value,
   new_level: Option<log::Level>,
   message: Option<String>,
-  new_artifacts: Vec<(String, hashing::Digest)>,
+  new_artifacts: Vec<(String, ArtifactOutput)>,
   new_metadata: Vec<(String, Value)>,
 }
 

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -128,6 +128,12 @@ pub enum WorkunitState {
 }
 
 #[derive(Clone, Debug)]
+pub enum ArtifactOutput {
+  FileDigest(hashing::Digest),
+  Snapshot(hashing::Digest),
+}
+
+#[derive(Clone, Debug)]
 pub struct WorkunitMetadata {
   pub desc: Option<String>,
   pub message: Option<String>,
@@ -135,7 +141,7 @@ pub struct WorkunitMetadata {
   pub blocked: bool,
   pub stdout: Option<hashing::Digest>,
   pub stderr: Option<hashing::Digest>,
-  pub artifacts: Vec<(String, hashing::Digest)>,
+  pub artifacts: Vec<(String, ArtifactOutput)>,
   pub user_metadata: Vec<(String, UserMetadataItem)>,
 }
 


### PR DESCRIPTION
### Problem

We created the `EnrichedTestResult` wrapper type - which is returned from an uncacheable rule - in order to ensure that pants runs would always have a workunit with test output metadata on it, even if the test had been cached. However, the stdout and stderr digests from the test were still being put on the underlying process execution workunit, which doesn't get created when the process result is cached.

### Solution

In order to do this correctly, the engine's treatment of `Digest`s had to be modified. Some `Digest`s, like the stdout/stderr output ones, represent just a single conceptual file and correspond to a Python `FileDigest`; and others represent a file-system subtree and correspond to a Python `Snapshot`. The code that handles workunit artifacts in the engine needs to keep these two interpretations of the Rust `hashing::Digest` type straight to avoid runtime errors converting and deconverting from Python types, which was done by introducing the `ArtifactResult` wrapper type. 

As well, the signature of `EngineAwareReturnType.artifacts` was modified to be a dictionary of `Union[Snapshot, FileDigest]` rather than just `Snapshot`. Note that the custom code to put the stdout/stderr digests on the process workunit was previously violating the type contract, by placing `FileDigest` Python Values into a dictionary that was supposed to only contain `Snapshot`s - but because this was done in engine FFI code, there was no opportunity for MyPy to verify this.
