### PR TITLE
Remove the explicit `pants` namespace package.

### DIFF
--- a/build-support/bin/check_inits.py
+++ b/build-support/bin/check_inits.py
@@ -21,13 +21,7 @@ def main() -> None:
     files = itertools.chain.from_iterable(
         [Path().glob(f"{d}/**/__init__.py") for d in DIRS_TO_CHECK]
     )
-    root_init = Path("src/python/pants/__init__.py")
-    if '__import__("pkg_resources").declare_namespace(__name__)' not in root_init.read_text():
-        die(
-            f"{root_init} must have the line "
-            '`__import__("pkg_resources").declare_namespace(__name__)` in it.'
-        )
-    non_empty_inits = [f for f in files if bool(f.read_text()) and f != root_init]
+    non_empty_inits = [f for f in files if bool(f.read_text())]
     if non_empty_inits:
         die(
             "All `__init__.py` file should be empty, but the following had content: "

--- a/src/python/pants/__init__.py
+++ b/src/python/pants/__init__.py
@@ -1,3 +1,0 @@
-# NB: We need to declare a namespace package because we have the dists `pantsbuild.pants` and
-# `pantsbuild.pants.testutil`, which both have the module `pants`.
-__import__("pkg_resources").declare_namespace(__name__)


### PR DESCRIPTION
Since Pants runs on Python 3.7+ and Pex fully supports implicit
namespace packages, the explicit `pkg_resources` namespace package can
be removed resulting in better performance due to the newfound lack of
a `pkg_resources` `sys.path` scan in many cases.

[ci skip-rust]