### PR TITLE
Upgrade hyper to fix RUSTSEC-2021-0020.

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.9"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
+checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
 dependencies = [
  "bytes",
  "futures-channel",


### PR DESCRIPTION
The nightly CRON picked this out.
The advisory is here: https://rustsec.org/advisories/RUSTSEC-2021-0020

[ci skip-build-wheels]