### PR TITLE
Make config options linkable.

### DIFF
--- a/build-support/bin/docs_templates/single_option_reference.md.mustache
+++ b/build-support/bin/docs_templates/single_option_reference.md.mustache
@@ -1,5 +1,5 @@
-### <code>{{config_key}}</code>
 <div style="color: purple">
+  <h3><code>{{config_key}}</code></h3>
   <code>{{comma_separated_display_args}}</code><br>
   <code>{{env_var}}</code><br>
 </div>

--- a/build-support/bin/docs_templates/single_option_reference.md.mustache
+++ b/build-support/bin/docs_templates/single_option_reference.md.mustache
@@ -1,7 +1,7 @@
+### <code>{{config_key}}</code>
 <div style="color: purple">
   <code>{{comma_separated_display_args}}</code><br>
   <code>{{env_var}}</code><br>
-  <code>{{config_key}}</code>
 </div>
 <div style="padding-left: 2em;">
   {{#comma_separated_choices}}


### PR DESCRIPTION
Currently individual options are not linkable in our reference docs
which makes sharing information harder than it should be.

[ci skip-rust]
[ci skip-build-wheels]
