### PR TITLE
Tighten up PythonToolBase.

### DIFF
--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -416,7 +416,11 @@ async def run_setup_py(req: RunSetupPyRequest, setuptools: Setuptools) -> RunSet
             output_filename="setuptools.pex",
             internal_only=True,
             requirements=PexRequirements(setuptools.all_requirements),
-            interpreter_constraints=req.interpreter_constraints,
+            interpreter_constraints=(
+                req.interpreter_constraints
+                if setuptools.options.is_default("interpreter_constraints")
+                else PexInterpreterConstraints(setuptools.interpreter_constraints)
+            ),
         ),
     )
     input_digest = await Get(Digest, MergeDigests((req.chroot.digest, setuptools_pex.digest)))

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -416,11 +416,7 @@ async def run_setup_py(req: RunSetupPyRequest, setuptools: Setuptools) -> RunSet
             output_filename="setuptools.pex",
             internal_only=True,
             requirements=PexRequirements(setuptools.all_requirements),
-            interpreter_constraints=(
-                req.interpreter_constraints
-                if setuptools.options.is_default("interpreter_constraints")
-                else PexInterpreterConstraints(setuptools.interpreter_constraints)
-            ),
+            interpreter_constraints=req.interpreter_constraints,
         ),
     )
     input_digest = await Get(Digest, MergeDigests((req.chroot.digest, setuptools_pex.digest)))

--- a/src/python/pants/backend/python/subsystems/setuptools.py
+++ b/src/python/pants/backend/python/subsystems/setuptools.py
@@ -1,6 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from typing import Tuple
+
 from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
 
 
@@ -28,12 +30,16 @@ class Setuptools(PythonToolRequirementsBase):
             type=list,
             advanced=True,
             help=(
-                "DEPRECATED: Unused. Interpreter constraints for setup.py execution are now "
-                "derived from the `python_distribution` being packaged."
+                "DEPRECATED: Python interpreter constraints to use when selecting an interpreter "
+                "to package `python_distribution` targets using setup.py."
             ),
             removal_version="2.5.0.dev0",
             removal_hint=(
-                "This is no longer used. Interpreter constraints for setup.py execution are now "
-                "derived from the `python_distribution` being packaged."
+                "Interpreter constraints for setup.py execution are now derived from the "
+                "`python_distribution` being packaged so this option is not needed."
             ),
         )
+
+    @property
+    def interpreter_constraints(self) -> Tuple[str, ...]:
+        return tuple(self.options.interpreter_constraints)

--- a/src/python/pants/backend/python/subsystems/setuptools.py
+++ b/src/python/pants/backend/python/subsystems/setuptools.py
@@ -10,3 +10,30 @@ class Setuptools(PythonToolRequirementsBase):
 
     default_version = "setuptools>=50.3.0,<54.0"
     default_extra_requirements = ["wheel>=0.35.1,<0.37"]
+
+    @classmethod
+    def register_options(cls, register):
+        super().register_options(register)
+        register(
+            "--entry-point",
+            type=str,
+            advanced=True,
+            help="DEPRECATED: Unused.",
+            removal_version="2.5.0.dev0",
+            removal_hint="This option was never used.",
+        )
+
+        register(
+            "--interpreter-constraints",
+            type=list,
+            advanced=True,
+            help=(
+                "DEPRECATED: Unused. Interpreter constraints for setup.py execution are now "
+                "derived from the `python_distribution` being packaged."
+            ),
+            removal_version="2.5.0.dev0",
+            removal_hint=(
+                "This is no longer used. Interpreter constraints for setup.py execution are now "
+                "derived from the `python_distribution` being packaged."
+            ),
+        )

--- a/src/python/pants/backend/python/subsystems/setuptools.py
+++ b/src/python/pants/backend/python/subsystems/setuptools.py
@@ -1,16 +1,12 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
 
 
-class Setuptools(PythonToolBase):
+class Setuptools(PythonToolRequirementsBase):
     options_scope = "setuptools"
     help = "The Python setuptools library (https://github.com/pypa/setuptools)."
 
-    # NB: setuptools doesn't have an entrypoint, unlike most python tools.
-    # We call it via a generated setup.py script.
     default_version = "setuptools>=50.3.0,<54.0"
     default_extra_requirements = ["wheel>=0.35.1,<0.37"]
-    register_interpreter_constraints = True
-    default_interpreter_constraints = ["CPython>=3.5"]


### PR DESCRIPTION
Previously "required" attributes weren't actually.

In the case of `default_version`, a default simply shouldn't have been
applied.

In the case of `default_entry_point`, a default was needed only to
support the `Setuptools` case which was already warped by providing a
`default_interpreter_constraints` it had no business supplying. Fix
this by splitting out a `PythonToolRequirementsBase` for tools that have
no main / just need requirements.

[ci skip-rust]
[ci skip-build-wheels]
