### PR TITLE
Fix Black to work by default with Python 3.9

### DIFF
--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -85,13 +85,13 @@ async def setup_black(
         (field_set.interpreter_constraints for field_set in setup_request.request.field_sets),
         python_setup,
     )
-    tool_interpreter_constraints = PexInterpreterConstraints(
+    tool_interpreter_constraints = (
         all_interpreter_constraints
         if (
             all_interpreter_constraints.requires_python38_or_newer()
             and black.options.is_default("interpreter_constraints")
         )
-        else black.interpreter_constraints
+        else PexInterpreterConstraints(black.interpreter_constraints)
     )
 
     black_pex_request = Get(

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -77,16 +77,16 @@ async def setup_black(
     setup_request: SetupRequest, black: Black, python_setup: PythonSetup
 ) -> Setup:
     # Black requires 3.6+ but uses the typed-ast library to work with 2.7, 3.4, 3.5, 3.6, and 3.7.
-    # However, typed-ast does not understand 3.8, so instead we must run Black with Python 3.8 when
-    # relevant. We only do this if if <3.8 can't be used, as we don't want a loose requirement like
-    # `>=3.6` to result in requiring Python 3.8, which would error if 3.8 is not installed on the
-    # machine.
+    # However, typed-ast does not understand 3.8+, so instead we must run Black with Python 3.8+
+    # when relevant. We only do this if if <3.8 can't be used, as we don't want a loose requirement
+    # like `>=3.6` to result in requiring Python 3.8, which would error if 3.8 is not installed on
+    # the machine.
     all_interpreter_constraints = PexInterpreterConstraints.create_from_compatibility_fields(
         (field_set.interpreter_constraints for field_set in setup_request.request.field_sets),
         python_setup,
     )
     tool_interpreter_constraints = PexInterpreterConstraints(
-        ("CPython>=3.8",)
+        all_interpreter_constraints
         if (
             all_interpreter_constraints.requires_python38_or_newer()
             and black.options.is_default("interpreter_constraints")

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -1,5 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
 import dataclasses
 from textwrap import dedent
 from typing import List, Optional, Sequence, Tuple
@@ -15,7 +18,10 @@ from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.target import Target
-from pants.testutil.python_interpreter_selection import skip_unless_python38_present
+from pants.testutil.python_interpreter_selection import (
+    skip_unless_python38_present,
+    skip_unless_python39_present,
+)
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
@@ -65,11 +71,12 @@ def make_target(
 
 def run_black(
     rule_runner: RuleRunner,
-    targets: List[Target],
+    targets: list[Target],
     *,
-    config: Optional[str] = None,
-    passthrough_args: Optional[str] = None,
+    config: str | None = None,
+    passthrough_args: str | None = None,
     skip: bool = False,
+    version: str | None = None,
 ) -> Tuple[Sequence[LintResult], FmtResult]:
     args = ["--backend-packages=pants.backend.python.lint.black"]
     if config is not None:
@@ -79,6 +86,8 @@ def run_black(
         args.append(f"--black-args='{passthrough_args}'")
     if skip:
         args.append("--black-skip")
+    if version:
+        args.append(f"--black-version={version}")
     rule_runner.set_options(args)
     field_sets = [BlackFieldSet.create(tgt) for tgt in targets]
     lint_results = rule_runner.request(LintResults, [BlackRequest(field_sets)])
@@ -209,6 +218,36 @@ def test_works_with_python38(rule_runner: RuleRunner) -> None:
     assert "1 file would be left unchanged" in lint_results[0].stderr
     assert "1 file left unchanged" in fmt_result.stderr
     assert fmt_result.output == get_digest(rule_runner, [py38_sources])
+    assert fmt_result.did_change is False
+
+
+@skip_unless_python39_present
+def test_works_with_python39(rule_runner: RuleRunner) -> None:
+    """Black's typed-ast dependency does not understand Python 3.9, so we must instead run Black
+    with Python 3.9 when relevant."""
+    py39_sources = FileContent(
+        "py39.py",
+        dedent(
+            """\
+            @lambda _: int
+            def replaced(x: bool) -> str:
+                return "42" if x is True else "1/137"
+            """
+        ).encode(),
+    )
+    target = make_target(rule_runner, [py39_sources], interpreter_constraints=">=3.9")
+    lint_results, fmt_result = run_black(
+        rule_runner,
+        [target],
+        # TODO: remove this and go back to using the default version once the new Black release
+        #  comes out.
+        version="Black@ git+https://github.com/psf/black.git@aebd3c37b28bbc0183a58d13b80e7595db3c09bb",
+    )
+    assert len(lint_results) == 1
+    assert lint_results[0].exit_code == 0
+    assert "1 file would be left unchanged" in lint_results[0].stderr
+    assert "1 file left unchanged" in fmt_result.stderr
+    assert fmt_result.output == get_digest(rule_runner, [py39_sources])
     assert fmt_result.did_change is False
 
 

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -11,6 +11,7 @@ class Black(PythonToolBase):
     options_scope = "black"
     help = "The Black Python code formatter (https://black.readthedocs.io/)."
 
+    # TODO: simplify `test_works_with_python39()` to stop using a VCS version.
     default_version = "black==20.8b1"
     default_extra_requirements = ["setuptools"]
     default_entry_point = "black:patched_main"


### PR DESCRIPTION
Similar to how https://github.com/pantsbuild/pants/pull/11537 fixed MyPy to work with 3.9 by default, this does the same for Black.

Note that this won't actually impact most end-users - the latest release of Black does not understand PEP 614, the new decorators grammar. But this future-proofs Pants for when the new Black release comes out.

[ci skip-rust]
[ci skip-build-wheels]