### PR TITLE
[internal] Upgrade toolchain pants plugin

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -20,7 +20,7 @@ backend_packages.add = [
 ]
 
 plugins = [
-  "toolchain.pants.plugin==0.4.0",
+  "toolchain.pants.plugin==0.5.0",
 ]
 
 build_file_prelude_globs = ["pants-plugins/python_integration_tests_macro.py"]


### PR DESCRIPTION
this version adds support for the auth plugin API that was added in https://github.com/pantsbuild/pants/pull/11503

I will have a follow up PR to enable use of that plugin instead of the current way to get token for usage w/ remote cache.