### PR TITLE
Rename `WorkUnitState` to `WorkunitStoreHandle`

### DIFF
--- a/src/rust/engine/fs/store/src/local.rs
+++ b/src/rust/engine/fs/store/src/local.rs
@@ -300,8 +300,8 @@ impl ByteStore {
       return Ok(Some(self.executor().spawn_blocking(move || f(&[])).await));
     }
 
-    if let Some(workunit_state) = workunit_store::get_workunit_state() {
-      workunit_state.store.record_observation(
+    if let Some(workunit_store_handle) = workunit_store::get_workunit_store_handle() {
+      workunit_store_handle.store.record_observation(
         ObservationMetric::LocalStoreReadBlobSize,
         digest.size_bytes as u64,
       );

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -177,9 +177,16 @@ impl ByteStore {
       }
     });
 
-    if let Some(workunit_state) = workunit_store::get_workunit_state() {
-      let store = workunit_state.store;
-      with_workunit(store, workunit_name, metadata, result_future, |_, md| md).await
+    if let Some(workunit_store_handle) = workunit_store::get_workunit_store_handle() {
+      let workunit_store = workunit_store_handle.store;
+      with_workunit(
+        workunit_store,
+        workunit_name,
+        metadata,
+        result_future,
+        |_, md| md,
+      )
+      .await
     } else {
       result_future.await
     }
@@ -242,13 +249,13 @@ impl ByteStore {
           if !got_first_response {
             got_first_response = true;
 
-            if let Some(workunit_state) = workunit_store::get_workunit_state() {
+            if let Some(workunit_store_handle) = workunit_store::get_workunit_store_handle() {
               let timing: Result<u64, _> = Instant::now()
                 .duration_since(start_time)
                 .as_micros()
                 .try_into();
               if let Ok(obs) = timing {
-                workunit_state
+                workunit_store_handle
                   .store
                   .record_observation(ObservationMetric::RemoteStoreTimeToFirstByte, obs);
               }
@@ -282,9 +289,15 @@ impl ByteStore {
       }
     };
 
-    if let Some(workunit_state) = workunit_store::get_workunit_state() {
-      let store = workunit_state.store;
-      with_workunit(store, workunit_name, metadata, result_future, |_, md| md).await
+    if let Some(workunit_store_handle) = workunit_store::get_workunit_store_handle() {
+      with_workunit(
+        workunit_store_handle.store,
+        workunit_name,
+        metadata,
+        result_future,
+        |_, md| md,
+      )
+      .await
     } else {
       result_future.await
     }
@@ -326,9 +339,15 @@ impl ByteStore {
         .collect::<Result<HashSet<_>, _>>()
     };
     async {
-      if let Some(workunit_state) = workunit_store::get_workunit_state() {
-        let store = workunit_state.store;
-        with_workunit(store, workunit_name, metadata, result_future, |_, md| md).await
+      if let Some(workunit_store_handle) = workunit_store::get_workunit_store_handle() {
+        with_workunit(
+          workunit_store_handle.store,
+          workunit_name,
+          metadata,
+          result_future,
+          |_, md| md,
+        )
+        .await
       } else {
         result_future.await
       }

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -310,9 +310,9 @@ impl CommandRunner {
     execute_response: &ExecuteResponse,
     metadata: &ExecutedActionMetadata,
   ) {
-    let workunit_state = workunit_store::expect_workunit_state();
-    let workunit_store = workunit_state.store;
-    let parent_id = workunit_state.parent_id;
+    let workunit_thread_handle = workunit_store::expect_workunit_store_handle();
+    let workunit_store = workunit_thread_handle.store;
+    let parent_id = workunit_thread_handle.parent_id;
     let result_cached = execute_response.cached_result;
 
     if let (Some(queued_timestamp), Some(worker_start_timestamp)) = (

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1242,7 +1242,7 @@ impl Node for NodeKey {
   type Error = Failure;
 
   async fn run(self, context: Context) -> Result<NodeOutput, Failure> {
-    let workunit_state = workunit_store::expect_workunit_state();
+    let workunit_store_handle = workunit_store::expect_workunit_store_handle();
 
     let user_facing_name = self.user_facing_name();
     let workunit_name = self.workunit_name();
@@ -1393,7 +1393,7 @@ impl Node for NodeKey {
     };
 
     with_workunit(
-      workunit_state.store,
+      workunit_store_handle.store,
       workunit_name,
       metadata,
       result_future,


### PR DESCRIPTION
We had a type named `WorkunitState` and another named `WorkUnitState`. This is confusing. The former was well named, so we rename the latter to better reflect what it does.

[ci skip-build-wheels]