### PR TITLE
Include `files` and `relocated_files` targets in `pex_binary`

### DIFF
--- a/src/python/pants/backend/python/goals/BUILD
+++ b/src/python/pants/backend/python/goals/BUILD
@@ -6,11 +6,10 @@ python_library()
 python_tests(
   name='tests',
   sources=['*_test.py', '!*_integration_test.py'],
-  timeout=180,
 )
 
 python_integration_tests(
   name='integration',
   uses_pants_run=True,
-  timeout=480,
+  timeout=250,
 )

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -276,15 +276,7 @@ async def generate_coverage_reports(
 ) -> CoverageReports:
     """Takes all Python test results and generates a single coverage report."""
     transitive_targets = await Get(TransitiveTargets, TransitiveTargetsRequest(all_used_addresses))
-    sources = await Get(
-        PythonSourceFiles,
-        # Coverage sometimes includes non-Python files in its `.coverage` data. We need to
-        # ensure that they're present when generating the report. We include all the files included
-        # by `pytest_runner.py`.
-        PythonSourceFilesRequest(
-            transitive_targets.closure, include_files=True, include_resources=True
-        ),
-    )
+    sources = await Get(PythonSourceFiles, PythonSourceFilesRequest(transitive_targets.closure))
     input_digest = await Get(
         Digest,
         MergeDigests(

--- a/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
@@ -1,0 +1,81 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from textwrap import dedent
+
+import pytest
+
+from pants.backend.python import target_types_rules
+from pants.backend.python.goals import package_pex_binary
+from pants.backend.python.goals.package_pex_binary import PexBinaryFieldSet
+from pants.backend.python.target_types import PexBinary
+from pants.backend.python.util_rules import pex_from_targets
+from pants.build_graph.address import Address
+from pants.core.goals.package import BuiltPackage
+from pants.core.target_types import Files, RelocatedFiles, Resources
+from pants.core.target_types import rules as core_target_types_rules
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *package_pex_binary.rules(),
+            *pex_from_targets.rules(),
+            *target_types_rules.rules(),
+            *core_target_types_rules(),
+            QueryRule(BuiltPackage, [PexBinaryFieldSet]),
+        ],
+        target_types=[PexBinary, Files, RelocatedFiles, Resources],
+    )
+
+
+def test_warn_files_targets(rule_runner: RuleRunner, caplog) -> None:
+    rule_runner.create_file("assets/f.txt")
+    rule_runner.add_to_build_file(
+        "assets",
+        dedent(
+            """\
+            files(name='files', sources=['f.txt'])
+            relocated_files(
+                name='relocated',
+                files_targets=[':files'],
+                src='assets',
+                dest='new_assets',
+            )
+            
+            # Resources are fine.
+            resources(name='resources', sources=['f.txt'])
+            """
+        ),
+    )
+    rule_runner.create_file("src/py/project/__init__.py")
+    rule_runner.create_file("src/py/project/app.py", "print('hello')")
+    rule_runner.add_to_build_file(
+        "src/py/project",
+        dedent(
+            """\
+            pex_binary(
+                dependencies=['assets:files', 'assets:relocated', 'assets:resources'],
+                execution_mode='zipapp',
+                entry_point="none",
+            )
+            """
+        ),
+    )
+    tgt = rule_runner.get_target(Address("src/py/project"))
+    field_set = PexBinaryFieldSet.create(tgt)
+
+    assert not caplog.records
+    result = rule_runner.request(BuiltPackage, [field_set])
+    assert caplog.records
+    assert f"The pex_binary target {tgt.address} depends on" in caplog.text
+    assert "assets/f.txt:files" in caplog.text
+    assert "assets:relocated" in caplog.text
+    assert "assets:resources" not in caplog.text
+
+    assert len(result.artifacts) == 1
+    assert result.artifacts[0].relpath == "src.py.project/project.pex"

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -148,9 +148,7 @@ async def setup_pytest_for_target(
         ),
     )
 
-    prepared_sources_request = Get(
-        PythonSourceFiles, PythonSourceFilesRequest(all_targets, include_files=True)
-    )
+    prepared_sources_request = Get(PythonSourceFiles, PythonSourceFilesRequest(all_targets))
 
     # Create any assets that the test depends on through the `runtime_package_dependencies` field.
     assets: Tuple[BuiltPackage, ...] = ()

--- a/src/python/pants/backend/python/goals/repl.py
+++ b/src/python/pants/backend/python/goals/repl.py
@@ -29,9 +29,7 @@ async def create_python_repl_request(repl: PythonRepl, pex_env: PexEnvironment) 
             (tgt.address for tgt in repl.targets), internal_only=True
         ),
     )
-    sources_request = Get(
-        PythonSourceFiles, PythonSourceFilesRequest(repl.targets, include_files=True)
-    )
+    sources_request = Get(PythonSourceFiles, PythonSourceFilesRequest(repl.targets))
     requirements_pex, sources = await MultiGet(requirements_request, sources_request)
     merged_digest = await Get(
         Digest, MergeDigests((requirements_pex.digest, sources.source_files.snapshot.digest))
@@ -70,9 +68,7 @@ async def create_ipython_repl_request(
 
     requirements_request = Get(Pex, PexRequest, requirements_pex_request)
 
-    sources_request = Get(
-        PythonSourceFiles, PythonSourceFilesRequest(repl.targets, include_files=True)
-    )
+    sources_request = Get(PythonSourceFiles, PythonSourceFilesRequest(repl.targets))
 
     ipython_request = Get(
         Pex,

--- a/src/python/pants/backend/python/goals/run_pex_binary.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary.py
@@ -48,9 +48,7 @@ async def create_pex_binary_run_request(
 
     requirements_request = Get(Pex, PexRequest, requirements_pex_request)
 
-    sources_request = Get(
-        PythonSourceFiles, PythonSourceFilesRequest(transitive_targets.closure, include_files=True)
-    )
+    sources_request = Get(PythonSourceFiles, PythonSourceFilesRequest(transitive_targets.closure))
 
     output_filename = f"{field_set.address.target_name}.pex"
     runner_pex_request = Get(

--- a/src/python/pants/backend/python/util_rules/python_sources.py
+++ b/src/python/pants/backend/python/util_rules/python_sources.py
@@ -59,7 +59,7 @@ class PythonSourceFilesRequest:
         targets: Iterable[Target],
         *,
         include_resources: bool = True,
-        include_files: bool = False
+        include_files: bool = True
     ) -> None:
         self.targets = tuple(targets)
         self.include_resources = include_resources


### PR DESCRIPTION
Now that we have the venv and unzip execution modes, it is sensible to include loose files in a PEX and to access them using the filesystem API, like `with open()`. 

However, usually, things won't work as expected when using a traditional zip app. So, we add a warning in this case. We don't want to error because advanced users do have ways to make this work, but we warn as the majority of users should change to use venv or unzip mode.

```
16:55:04.50 [WARN] The pex_binary target build-support/bin:changelog depends on the below files targets, but it's packaged as a zip app, so you will likely not be able to open the files like you'd expect.

Instead, consider setting the field `execution_mode='unzip' or `execution_mode='venv'` on build-support/bin:changelog to be able to use Python's filesystem API (e.g. `with open()`) like you'd expect.

Files targets dependencies: ['build-support/bin/bootstrap_pants_pex.sh:bash_scripts', 'build-support/bin/check_rust_formatting.sh:bash_scripts', ...]
```
[ci skip-rust]
[ci skip-build-wheels]
