### PR TITLE
(blocked on upstream bug) Update to rust 1.50

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.49.0"
+channel = "1.50.0"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
Latest stable Rust version is now 1.50