### PR TITLE
Fix missing counters by adding more workunits

### DIFF
--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -113,7 +113,8 @@ impl crate::CommandRunner for CommandRunner {
         }
       }
       Ok(result)
-    };
+    }
+    .boxed();
     with_workunit(
       context2.workunit_store,
       "local_cache_read".to_owned(),

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -476,37 +476,43 @@ impl crate::CommandRunner for CommandRunner {
     };
 
     if result.exit_code == 0 && self.cache_write {
-      context
-        .workunit_store
-        .increment_counter(Metric::RemoteCacheWriteStarted, 1);
       let command_runner = self.clone();
       let result = result.clone();
+      let context2 = context.clone();
       // NB: We use `TaskExecutor::spawn` instead of `tokio::spawn` to ensure logging still works.
-      let _write_join = self.executor.spawn(
-        async move {
-          let write_result = command_runner
-            .update_action_cache(
-              &context,
-              &request,
-              &result,
-              &command_runner.metadata,
-              &command,
-              action_digest,
-              command_digest,
-            )
-            .await;
-          context
+      let cache_write_future = async move {
+        context2
+          .workunit_store
+          .increment_counter(Metric::RemoteCacheWriteStarted, 1);
+        let write_result = command_runner
+          .update_action_cache(
+            &context2,
+            &request,
+            &result,
+            &command_runner.metadata,
+            &command,
+            action_digest,
+            command_digest,
+          )
+          .await;
+        context2
+          .workunit_store
+          .increment_counter(Metric::RemoteCacheWriteFinished, 1);
+        if let Err(err) = write_result {
+          log::warn!("Failed to write to remote cache: {}", err);
+          context2
             .workunit_store
-            .increment_counter(Metric::RemoteCacheWriteFinished, 1);
-          if let Err(err) = write_result {
-            log::warn!("Failed to write to remote cache: {}", err);
-            context
-              .workunit_store
-              .increment_counter(Metric::RemoteCacheWriteErrors, 1);
-          };
-        }
-        .boxed(),
-      );
+            .increment_counter(Metric::RemoteCacheWriteErrors, 1);
+        };
+      };
+
+      let _write_join = self.executor.spawn(with_workunit(
+        context.workunit_store,
+        "remote_cache_write".to_owned(),
+        WorkunitMetadata::with_level(Level::Debug),
+        cache_write_future,
+        |_, md| md,
+      ));
     }
 
     Ok(result)

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -504,7 +504,8 @@ impl crate::CommandRunner for CommandRunner {
             .workunit_store
             .increment_counter(Metric::RemoteCacheWriteErrors, 1);
         };
-      };
+      }
+      .boxed();
 
       let _write_join = self.executor.spawn(with_workunit(
         context.workunit_store,


### PR DESCRIPTION
As found in https://github.com/pantsbuild/pants/issues/11548, the remote cache write counters were missing because they referred to a workunit that was already complete. This works around that by adding a new workunit in the async block.

We also add a new workunit for local cache reads. Technically, we don't need this, but it will be necessary if/when we land the proposed fix in https://github.com/pantsbuild/pants/issues/11548 because we won't have a way of passing the parent workunit to the `ComandRunner.run()` method, given its trait signature that we can't change.