### PR TITLE
Simplify native code bootstrapping.

### DIFF
--- a/build-support/bin/rust/bootstrap_code.sh
+++ b/build-support/bin/rust/bootstrap_code.sh
@@ -4,13 +4,6 @@
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../../.. && pwd -P)"
 
 # Defines:
-# + CACHE_ROOT: The pants cache directory, ie: ~/.cache/pants.
-# Exposes:
-# + die: Exit in a failure state and optionally log an error message to the console.
-# shellcheck source=build-support/common.sh
-source "${REPO_ROOT}/build-support/common.sh"
-
-# Defines:
 # + NATIVE_ROOT: The Rust code directory, ie: src/rust/engine.
 # + MODE: Whether to run in debug or release mode.
 # + MODE_FLAG: The string to pass to Cargo to determine if we're in debug or release mode.
@@ -35,7 +28,6 @@ esac
 readonly NATIVE_ENGINE_BINARY="native_engine.so"
 readonly NATIVE_ENGINE_RESOURCE="${REPO_ROOT}/src/python/pants/engine/internals/${NATIVE_ENGINE_BINARY}"
 readonly NATIVE_ENGINE_RESOURCE_METADATA="${NATIVE_ENGINE_RESOURCE}.metadata"
-readonly NATIVE_ENGINE_CACHE_DIR=${CACHE_ROOT}/bin/native-engine
 
 function _build_native_code() {
   # NB: See Cargo.toml with regard to the `extension-module` feature.
@@ -56,12 +48,14 @@ function bootstrap_native_code() {
     return
   fi
   # Bootstraps the native code only if needed.
-  local native_engine_version
-  native_engine_version="$(calculate_current_hash)"
-  local engine_version_hdr="engine_version: ${native_engine_version}"
-  local target_binary="${NATIVE_ENGINE_CACHE_DIR}/${native_engine_version}/${NATIVE_ENGINE_BINARY}"
-  local target_binary_metadata="${target_binary}.metadata"
-  if [[ ! -f "${target_binary}" || ! -f "${target_binary_metadata}" ]]; then
+  local engine_version_calculated
+  engine_version_calculated="$(calculate_current_hash)"
+  local engine_version_in_metadata
+  if [[ -f "${NATIVE_ENGINE_RESOURCE_METADATA}" ]]; then
+    engine_version_in_metadata="$(sed -n 's/^engine_version: //p' "${NATIVE_ENGINE_RESOURCE_METADATA}")"
+  fi
+  if [[ ! -f "${NATIVE_ENGINE_RESOURCE}" || "${engine_version_calculated}" != "${engine_version_in_metadata}" ]]; then
+    echo "Building native engine"
     local -r native_binary="$(_build_native_code)"
 
     # If bootstrapping the native engine fails, don't attempt to run pants
@@ -71,26 +65,15 @@ function bootstrap_native_code() {
     fi
 
     # Pick up Cargo.lock changes if any caused by the `cargo build`.
-    native_engine_version="$(calculate_current_hash)"
-    engine_version_hdr="engine_version: ${native_engine_version}"
+    engine_version_calculated="$(calculate_current_hash)"
 
-    mkdir -p "$(dirname "${target_binary}")"
-    cp "${native_binary}" "${target_binary}"
+    # Create the native engine resource.
+    cp "${native_binary}" "${NATIVE_ENGINE_RESOURCE}"
 
+    # Create the accompanying metadata file.
     local -r metadata_file=$(mktemp -t pants.native_engine.metadata.XXXXXX)
-    echo "${engine_version_hdr}" > "${metadata_file}"
+    echo "engine_version: ${engine_version_calculated}" > "${metadata_file}"
     echo "repo_version: $(git describe --dirty)" >> "${metadata_file}"
-    mv "${metadata_file}" "${target_binary_metadata}"
-  fi
-
-  # Establishes the native engine wheel resource if it doesn't exist or its metadata mismatches.
-  if [[
-    ! -f "${NATIVE_ENGINE_RESOURCE}" ||
-    ! -f "${NATIVE_ENGINE_RESOURCE_METADATA}" ||
-    "$(head -1 "${NATIVE_ENGINE_RESOURCE_METADATA}" | tr '\0' '\n' 2>/dev/null)" != "${engine_version_hdr}"
-  ]]; then
-    rm -f "${NATIVE_ENGINE_RESOURCE_METADATA}" "${NATIVE_ENGINE_RESOURCE}"
-    cp "${target_binary}" "${NATIVE_ENGINE_RESOURCE}"
-    cp "${target_binary_metadata}" "${NATIVE_ENGINE_RESOURCE_METADATA}"
+    mv "${metadata_file}" "${NATIVE_ENGINE_RESOURCE_METADATA}"
   fi
 }


### PR DESCRIPTION
Previously we cached the native_engine.so and its metadata
under ~/.cache/pants/bin/native-engine, and during native code bootstrapping we 
performed the hash checks against the cached copies, requiring them to exist
even if the actual resource already exists in its final location at the right hash.

This is unintuitive, as you'd expect that deleting a cache shouldn't matter if the 
underlying resource is up to date in its final location. For example, complicates CI, 
as it requires that cache directory to be conserved across runs to avoid a rebuild, 
even if the resource is conserved.

Furthermore, the cache itself is unnecessary. Cargo will rebuild incrementally, and 
without Rust code changes the invocation only takes ~250 ms. So the only value 
of the cache is to avoid an incremental rebuild when restoring to an early version 
of the Rust code that was already built and cached. That alone does not seem
worth the complexity.

This change eliminates that caching and simplifies bootstrapping to
merely ensure that the final resource is up to date.

[ci skip-build-wheels]

