### PR TITLE
Add `relocated_resources` target type

### DIFF
--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -7,7 +7,14 @@ These are always activated and cannot be disabled.
 """
 
 from pants.core.goals import fmt, lint, package, repl, run, tailor, test, typecheck
-from pants.core.target_types import ArchiveTarget, Files, GenericTarget, RelocatedFiles, Resources
+from pants.core.target_types import (
+    ArchiveTarget,
+    Files,
+    GenericTarget,
+    RelocatedFiles,
+    RelocatedResources,
+    Resources,
+)
 from pants.core.target_types import rules as target_type_rules
 from pants.core.util_rules import (
     archive,
@@ -50,4 +57,4 @@ def rules():
 
 
 def target_types():
-    return [ArchiveTarget, Files, GenericTarget, Resources, RelocatedFiles]
+    return [ArchiveTarget, Files, GenericTarget, Resources, RelocatedFiles, RelocatedResources]

--- a/src/python/pants/help/help_integration_test.py
+++ b/src/python/pants/help/help_integration_test.py
@@ -32,7 +32,7 @@ def test_help_advanced_global() -> None:
 def test_help_targets() -> None:
     pants_run = run_pants(["help", "targets"])
     pants_run.assert_success()
-    assert "archive          A ZIP or TAR file containing loose files" in pants_run.stdout
+    assert re.search(r"archive\s+A ZIP or TAR file containing loose files", pants_run.stdout)
     assert "to get help for a specific target" in pants_run.stdout
 
 


### PR DESCRIPTION
As re-found in https://github.com/pantsbuild/pants/pull/11551, we intentionally do not include `files()` targets when packaging a PEX because the files cannot be easily accessed via the traditional filesystem APIs. Even when using unzip and venv modes, you must still relativize the `open()` to the `__file__`, rather than using a path relative to the build root. When you have source roots, `__file__` behaves differently between `./pants run` and `./pants package`, as the latter strips source roots.

When dealing with `pex_binary`, almost always you should either use `resources` or use `archive`. But a user needs the flexibility of `relocated_files` - they have a file `common_assets/common.css`, along with several projects in the format `<project>/assets/*.css`. They need `common.css` to be in that final path `<project>/assets/*.css` when the PEX is built, but they don't want to copy that file in several places; symlinks work but are not first-class. They want to use the equivalent of `relocated_files`, but for it to work with their PEX.

`relocated_resources` are pretty advanced and will likely confuse some users with getting source roots correct. But this isn't necessarily a reason to avoid the feature; for the right user, this advanced feature will be necessary to their workflow. Beyond good docs, we leave it to the user to get the path manipulation working properly. Most users can ignore this.

[ci skip-rust]
[ci skip-build-wheels]