### PR TITLE
Bump Coursier to version v2.0.11

### DIFF
--- a/src/python/pants/backend/jvm/tasks/coursier/coursier_subsystem.py
+++ b/src/python/pants/backend/jvm/tasks/coursier/coursier_subsystem.py
@@ -15,10 +15,10 @@ class CoursierSubsystem(Script):
     """
 
     options_scope = "coursier"
-    default_version = "1.1.0.cf365ea27a710d5f09db1f0a6feee129aa1fc417"
+    default_version = "v2.0.11"
 
     _default_urls = [
-        "https://github.com/coursier/coursier/releases/download/pants_release_1.5.x/coursier-cli-{version}.jar",
+        "https://github.com/coursier/coursier/releases/download/{version}/coursier.jar",
     ]
 
     class Error(Exception):


### PR DESCRIPTION
### Problem

Pants has a problem with exporting data about large sub-projects or large lists of targets. This seems to be caused by GC issues in Coursier 1.1.0.

### Solution

The latest version of Coursier seems to be free of those issues.

