### PR TITLE
Better unrecognized symbol error

### DIFF
--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -109,14 +109,13 @@ class Parser:
             dym = "Did you mean "
 
             candidates = get_close_matches(build_file_content,valid_symbols)
-            if build_file_content not in candidates:
-                if len(candidates) == 1:
-                    dym += candidates[0] + '?'
-                    err_string = dym + err_string
-                elif len(candidates) > 1:
-                    dym += ", ".join(candidates)[:-1]
-                    dym += ", or  " + candidates[-1]  # naturally, we use the oxford comma
-                    err_string = dym + err_string
+            if len(candidates) == 1:
+                dym += candidates[0] + '?'
+                err_string = dym + err_string
+            elif len(candidates) > 1:
+                dym += ", ".join(candidates)[:-1]
+                dym += ", or  " + candidates[-1]  # naturally, we use the oxford comma
+                err_string = dym + err_string
             raise ParseError(f"{err_string}\n\n{original}.\n\nAll registered symbols: {valid_symbols}")
 
         error_on_imports(build_file_content, filepath)

--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -105,7 +105,7 @@ class Parser:
             original = e.args[0].capitalize()
             help_str = (
                 "If you expect to see more symbols activated in the below list,"
-                f" refer to {docs_url('enabling_backends')} for all available"
+                f" refer to {docs_url('enabling-backends')} for all available"
                 " backends to activate."
             )
 

--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -103,24 +103,24 @@ class Parser:
         except NameError as e:
             valid_symbols = sorted(s for s in global_symbols.keys() if s != "__builtins__")
             original = e.args[0].capitalize()
-            err_string = (
-                    "If you expect to see more symbols activated in the below list,"
-                    f"refer to {docs_url('enabling_backends')} for all available"
-                    " backends to activate."
+            help_str = (
+                "If you expect to see more symbols activated in the below list,"
+                f" refer to {docs_url('enabling_backends')} for all available"
+                " backends to activate."
             )
-            dym = "Did you mean "
 
-            # note that this only includes 3 matches at the most by default
-            candidates = get_close_matches(build_file_content,valid_symbols)
-            if len(candidates) == 1:
-                dym += candidates[0] + '?\n\n'
-                err_string = dym + err_string
-            elif len(candidates) > 1:
-                dym += ", ".join(candidates[:-1])
-                # no oxford comma for len==2
-                dym += " or " + candidates[-1] + "?\n\n"
-                err_string = dym + err_string
-            raise ParseError(f"{original}.\n\n{err_string}\n\nAll registered symbols: {valid_symbols}")
+            candidates = get_close_matches(build_file_content, valid_symbols)
+            if candidates:
+                if len(candidates) == 1:
+                    formatted_candidates = candidates[0]
+                elif len(candidates) == 2:
+                    formatted_candidates = " or ".join(candidates)
+                else:
+                    formatted_candidates = f"{', '.join(candidates[:-1])}, or {candidates[-1]}"
+                help_str = f"Did you mean {formatted_candidates}?\n\n" + help_str
+            raise ParseError(
+                f"{original}.\n\n{help_str}\n\nAll registered symbols: {valid_symbols}"
+            )
 
         error_on_imports(build_file_content, filepath)
 

--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -103,20 +103,24 @@ class Parser:
         except NameError as e:
             valid_symbols = sorted(s for s in global_symbols.keys() if s != "__builtins__")
             original = e.args[0].capitalize()
-            err_string = f"""If you expect to see more symbols activated in the 
-                below list, refer to {docs_url("enabling_backends")} for all available
-                backends to activate."""
+            err_string = (
+                    "If you expect to see more symbols activated in the below list,"
+                    f"refer to {docs_url('enabling_backends')} for all available"
+                    " backends to activate."
+            )
             dym = "Did you mean "
 
+            # note that this only includes 3 matches at the most by default
             candidates = get_close_matches(build_file_content,valid_symbols)
             if len(candidates) == 1:
-                dym += candidates[0] + '?'
+                dym += candidates[0] + '?\n\n'
                 err_string = dym + err_string
             elif len(candidates) > 1:
-                dym += ", ".join(candidates)[:-1]
-                dym += ", or  " + candidates[-1]  # naturally, we use the oxford comma
+                dym += ", ".join(candidates[:-1])
+                # no oxford comma for len==2
+                dym += " or " + candidates[-1] + "?\n\n"
                 err_string = dym + err_string
-            raise ParseError(f"{err_string}\n\n{original}.\n\nAll registered symbols: {valid_symbols}")
+            raise ParseError(f"{original}.\n\n{err_string}\n\nAll registered symbols: {valid_symbols}")
 
         error_on_imports(build_file_content, filepath)
 

--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -91,7 +91,6 @@ class Parser:
         # those extra symbols will not see our target aliases etc. This also means that if multiple
         # prelude files are present, they probably cannot see each others' symbols. We may choose
         # to change this at some point.
-        # did you mean?
 
         global_symbols = dict(self._symbols)
         for k, v in extra_symbols.symbols.items():
@@ -104,27 +103,21 @@ class Parser:
         except NameError as e:
             valid_symbols = sorted(s for s in global_symbols.keys() if s != "__builtins__")
             original = e.args[0].capitalize()
-            err_string = f"""If you expect to see more symbols activated in the
+            err_string = f"""If you expect to see more symbols activated in the 
                 below list, refer to {docs_url("enabling_backends")} for all available
                 backends to activate."""
             dym = "Did you mean "
-            # then get did u mean: store in var, if var empty, then we dont
-            # append otherwise we create list. otherwise, use join etc to
-            # create the list of did u mean candidates, stick it at the
-            # beginning.
-            # add to error if need
 
-            candidates = get_close_matches(original,valid_symbols)
-            if len(candidates) == 1:
-                dym += candidates[0] + '?'
-                err_string = dym + err_string
-            elif len(candidates) > 1:
-                dym += ", ".join(candidates)[:-1]
-                dym += ", or  " + candidates[-1]  # naturally, we use the oxford comma
-                err_string = dym + err_string
-
+            candidates = get_close_matches(build_file_content,valid_symbols)
+            if build_file_content not in candidates:
+                if len(candidates) == 1:
+                    dym += candidates[0] + '?'
+                    err_string = dym + err_string
+                elif len(candidates) > 1:
+                    dym += ", ".join(candidates)[:-1]
+                    dym += ", or  " + candidates[-1]  # naturally, we use the oxford comma
+                    err_string = dym + err_string
             raise ParseError(f"{err_string}\n\n{original}.\n\nAll registered symbols: {valid_symbols}")
-            # raise ParseError(f"{original}.\n\nAll registered symbols: {valid_symbols}")
 
         error_on_imports(build_file_content, filepath)
 

--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -4,6 +4,7 @@
 import os.path
 import tokenize
 from dataclasses import dataclass
+from difflib import get_close_matches
 from io import StringIO
 from typing import Any, Dict, Iterable, List, Tuple, cast
 
@@ -90,6 +91,8 @@ class Parser:
         # those extra symbols will not see our target aliases etc. This also means that if multiple
         # prelude files are present, they probably cannot see each others' symbols. We may choose
         # to change this at some point.
+        # did you mean?
+
         global_symbols = dict(self._symbols)
         for k, v in extra_symbols.symbols.items():
             if hasattr(v, "__globals__"):
@@ -101,7 +104,27 @@ class Parser:
         except NameError as e:
             valid_symbols = sorted(s for s in global_symbols.keys() if s != "__builtins__")
             original = e.args[0].capitalize()
-            raise ParseError(f"{original}.\n\nAll registered symbols: {valid_symbols}")
+            err_string = f"""If you expect to see more symbols activated in the
+                below list, refer to {docs_url("enabling_backends")} for all available
+                backends to activate."""
+            dym = "Did you mean "
+            # then get did u mean: store in var, if var empty, then we dont
+            # append otherwise we create list. otherwise, use join etc to
+            # create the list of did u mean candidates, stick it at the
+            # beginning.
+            # add to error if need
+
+            candidates = get_close_matches(original,valid_symbols)
+            if len(candidates) == 1:
+                dym += candidates[0] + '?'
+                err_string = dym + err_string
+            elif len(candidates) > 1:
+                dym += ", ".join(candidates)[:-1]
+                dym += ", or  " + candidates[-1]  # naturally, we use the oxford comma
+                err_string = dym + err_string
+
+            raise ParseError(f"{err_string}\n\n{original}.\n\nAll registered symbols: {valid_symbols}")
+            # raise ParseError(f"{original}.\n\nAll registered symbols: {valid_symbols}")
 
         error_on_imports(build_file_content, filepath)
 

--- a/src/python/pants/engine/internals/parser_test.py
+++ b/src/python/pants/engine/internals/parser_test.py
@@ -3,10 +3,11 @@
 
 import pytest
 
+
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.internals.parser import BuildFilePreludeSymbols, ParseError, Parser
+from pants.util.docutil import docs_url
 from pants.util.frozendict import FrozenDict
-
 
 def test_imports_banned() -> None:
     parser = Parser(target_type_aliases=[], object_aliases=BuildFileAliases())
@@ -17,18 +18,70 @@ def test_imports_banned() -> None:
     assert "Import used in dir/BUILD at line 4" in str(exc.value)
 
 
-def test_unrecognized_symbol() -> None:
-    parser = Parser(
-        target_type_aliases=["tgt"],
-        object_aliases=BuildFileAliases(
-            objects={"obj": 0},
-            context_aware_object_factories={"caof": lambda parse_context: lambda _: None},
-        ),
+def test_unrecogonized_symbol() -> None:
+    def perform_test(tta: list, good_err: str) -> None:
+        parser = Parser(
+            target_type_aliases=tta,
+            object_aliases=BuildFileAliases(
+                objects={"obj": 0},
+                context_aware_object_factories={"caof": lambda parse_context: lambda _: None},
+            ),
+        )
+        prelude_symbols = BuildFilePreludeSymbols(FrozenDict({"prelude": 0}))
+        with pytest.raises(ParseError) as exc:
+            parser.parse("dir/BUILD", "fake", prelude_symbols)
+        assert (
+            str(exc.value)
+            == good_err
     )
-    prelude_symbols = BuildFilePreludeSymbols(FrozenDict({"prelude": 0}))
-    with pytest.raises(ParseError) as exc:
-        parser.parse("dir/BUILD", "fake", prelude_symbols)
-    assert (
-        str(exc.value)
-        == "Name 'fake' is not defined.\n\nAll registered symbols: ['caof', 'obj', 'prelude', 'tgt']"
+
+    # confirm that it works if there's nothing similar
+    no_match_tta = ["tgt"]
+    no_match_str = ("Name 'fake' is not defined.\n\n"
+                    "If you expect to see more symbols activated in the below list,"
+                    f"refer to {docs_url('enabling_backends')} for all available"
+                    " backends to activate.\n\n"
+                    "All registered symbols: ['caof', 'obj', 'prelude', 'tgt']"
     )
+
+    # confirm that "did you mean x" works
+    one_match_tta = ["tgt","fake1"]
+    one_match_str = ("Name 'fake' is not defined.\n\n"
+                    "Did you mean fake1?\n\n"
+                    "If you expect to see more symbols activated in the below list,"
+                    f"refer to {docs_url('enabling_backends')} for all available"
+                    " backends to activate.\n\n"
+                    "All registered symbols: ['caof', 'fake1', 'obj', 'prelude', 'tgt']"
+    )
+
+
+    # confirm that "did you mean x or y" works
+    two_match_tta = ["tgt","fake1","fake2"]
+    two_match_str = ("Name 'fake' is not defined.\n\n"
+                    "Did you mean fake2 or fake1?\n\n"
+                    "If you expect to see more symbols activated in the below list,"
+                    f"refer to {docs_url('enabling_backends')} for all available"
+                    " backends to activate.\n\n"
+                    "All registered symbols: ['caof', 'fake1', 'fake2', 'obj', 'prelude', 'tgt']"
+    )
+
+
+    # confirm that "did you mean x, y or z" works (limit to 3 match)
+    many_match_tta = ["tgt","fake1","fake2","fake3","fake4","fake5"]
+    many_match_str = ("Name 'fake' is not defined.\n\n"
+                    "Did you mean fake5, fake4 or fake3?\n\n"
+                    "If you expect to see more symbols activated in the below list,"
+                    f"refer to {docs_url('enabling_backends')} for all available"
+                    " backends to activate.\n\n"
+                    "All registered symbols: ['caof', 'fake1', 'fake2',"
+                    " 'fake3', 'fake4', 'fake5', 'obj', 'prelude', 'tgt']"
+    )
+
+
+    perform_test(no_match_tta,no_match_str)
+    perform_test(one_match_tta,one_match_str)
+    perform_test(two_match_tta,two_match_str)
+    perform_test(many_match_tta,many_match_str)
+
+
+

--- a/src/python/pants/engine/internals/parser_test.py
+++ b/src/python/pants/engine/internals/parser_test.py
@@ -22,6 +22,7 @@ def test_imports_banned() -> None:
 
 def test_unrecogonized_symbol() -> None:
     def perform_test(extra_targets: list[str], dym: str) -> None:
+
         parser = Parser(
             target_type_aliases=["tgt", *extra_targets],
             object_aliases=BuildFileAliases(
@@ -30,28 +31,23 @@ def test_unrecogonized_symbol() -> None:
             ),
         )
         prelude_symbols = BuildFilePreludeSymbols(FrozenDict({"prelude": 0}))
+        fmt_extra_sym = str(extra_targets)[1:-1] + (", ") if len(extra_targets) != 0 else ""
         with pytest.raises(ParseError) as exc:
             parser.parse("dir/BUILD", "fake", prelude_symbols)
         assert str(exc.value) == (
             f"Name 'fake' is not defined.\n\n{dym}"
             "If you expect to see more symbols activated in the below list,"
-            f" refer to {docs_url('enabling_backends')} for all available"
+            f" refer to {docs_url('enabling-backends')} for all available"
             " backends to activate.\n\n"
-            "All registered symbols: ['caof', "
-            f"{str(extra_targets)[1:-1] + (', ') if len(extra_targets) != 0 else ''}"
-            "'obj', 'prelude', 'tgt']"
+            f"All registered symbols: ['caof', {fmt_extra_sym}'obj', 'prelude', 'tgt']"
         )
 
     test_targs = ["fake1", "fake2", "fake3", "fake4", "fake5"]
 
-    dym_one = "Did you mean fake1?\n\n"
-    dym_two = "Did you mean fake2 or fake1?\n\n"
-    dym_many = "Did you mean fake5, fake4, or fake3?\n\n"
-
-    # This first test tests the error message when no matches are found (i.e.
-    # we don't need to add any additional targets and don't have a "Did you
-    # mean...? message.
     perform_test([], "")
+    dym_one = "Did you mean fake1?\n\n"
     perform_test(test_targs[:1], dym_one)
+    dym_two = "Did you mean fake2 or fake1?\n\n"
     perform_test(test_targs[:2], dym_two)
+    dym_many = "Did you mean fake5, fake4, or fake3?\n\n"
     perform_test(test_targs, dym_many)


### PR DESCRIPTION
Improved error message for unrecognized symbol (Closes #11258) and associated test cases.

In particular, error messages are updated to include a "Did you mean...?" message along with a reference to the docs to show potential backends.

The "Did you mean...?" component is dependent on the number of potential symbols that could be what the user intended. This component is excluded if there are no potential matches, includes the singular match if there is one, includes "x or y" for two, and has "x,y or z" for multiple - essentially, they're comma-delimited without an Oxford comma for the final. 

This follows the original "Name ____ is not defined" message if present. The error component linking to the docs ("If you expect to see more symbols activated in the below list, refer to {doc link about enabling backends} for all available backends to activate") follows this, and is finally followed by the original list of all registered symbols.