### PR TITLE
Resolve plugins via PEX rules in a bootstrap scheduler

### DIFF
--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -19,7 +19,6 @@ from pants.init.logging import (
     set_logging_handlers,
     setup_logging,
 )
-from pants.init.options_initializer import BuildConfigInitializer
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.pantsd.pants_daemon_core import PantsDaemonCore
 from pants.util.contextutil import argv_as, hermetic_environment_as, stdio_as
@@ -144,7 +143,6 @@ class DaemonPantsRunner(RawFdRunner):
         # of a local run: once we allow for concurrent runs, this information should be
         # propagated down from the caller.
         #   see https://github.com/pantsbuild/pants/issues/7654
-        BuildConfigInitializer.reset()
         options_bootstrapper = OptionsBootstrapper.create(
             env=os.environ, args=sys.argv, allow_pantsrc=True
         )

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -151,11 +151,12 @@ class DaemonPantsRunner(RawFdRunner):
         # Run using the pre-warmed Session.
         with self._stderr_logging(global_bootstrap_options):
             try:
-                scheduler = self._core.prepare_scheduler(options_bootstrapper)
+                scheduler, options_initializer = self._core.prepare(options_bootstrapper)
                 runner = LocalPantsRunner.create(
                     os.environ,
                     options_bootstrapper,
                     scheduler=scheduler,
+                    options_initializer=options_initializer,
                     cancellation_latch=cancellation_latch,
                 )
                 return runner.run(start_time)

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -73,7 +73,9 @@ class LocalPantsRunner:
     ) -> GraphSession:
         native = Native()
         native.set_panic_handler()
-        graph_scheduler_helper = scheduler or EngineInitializer.setup_graph(options, build_config)
+        graph_scheduler_helper = scheduler or EngineInitializer.setup_graph(
+            options_bootstrapper, build_config
+        )
         with OptionsInitializer.handle_unknown_flags(options_bootstrapper, raise_=True):
             global_options = options.for_global_scope()
         return graph_scheduler_helper.new_session(

--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -12,8 +12,8 @@ from typing import List, Mapping
 from pants.base.exiter import ExitCode
 from pants.engine.internals.native import Native
 from pants.engine.internals.native_engine import PyExecutor
-from pants.init.options_initializer import OptionsInitializer
 from pants.nailgun.nailgun_protocol import NailgunProtocol
+from pants.option.global_options import GlobalOptions
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.pantsd.pants_daemon_client import PantsDaemonClient
 
@@ -103,7 +103,7 @@ class RemotePantsRunner:
         native = Native()
 
         global_options = self._bootstrap_options.for_global_scope()
-        executor = PyExecutor(*OptionsInitializer.compute_executor_arguments(global_options))
+        executor = PyExecutor(*GlobalOptions.compute_executor_arguments(global_options))
 
         # Merge the nailgun TTY capability environment variables with the passed environment dict.
         ng_env = NailgunProtocol.ttynames_to_env(sys.stdin, sys.stdout.buffer, sys.stderr.buffer)

--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -43,6 +43,7 @@ class BuildConfiguration:
     rules: FrozenOrderedSet[Rule]
     union_rules: FrozenOrderedSet[UnionRule]
     target_types: FrozenOrderedSet[Type[Target]]
+    allow_unknown_options: bool
 
     @property
     def all_optionables(self) -> FrozenOrderedSet[Type[Optionable]]:
@@ -93,6 +94,7 @@ class BuildConfiguration:
         _rules: OrderedSet = field(default_factory=OrderedSet)
         _union_rules: OrderedSet = field(default_factory=OrderedSet)
         _target_types: OrderedSet[Type[Target]] = field(default_factory=OrderedSet)
+        _allow_unknown_options: bool = False
 
         def registered_aliases(self) -> BuildFileAliases:
             """Return the registered aliases exposed in BUILD files.
@@ -217,6 +219,14 @@ class BuildConfiguration:
                 )
             self._target_types.update(target_types)
 
+        def allow_unknown_options(self, allow: bool = True) -> None:
+            """Allows overriding whether Options parsing will fail for unrecognized Options.
+
+            Used to defer options failures while bootstrapping BuildConfiguration until after the
+            complete set of plugins is known.
+            """
+            self._allow_unknown_options = True
+
         def create(self) -> BuildConfiguration:
             registered_aliases = BuildFileAliases(
                 objects=self._exposed_object_by_alias.copy(),
@@ -228,4 +238,5 @@ class BuildConfiguration:
                 rules=FrozenOrderedSet(self._rules),
                 union_rules=FrozenOrderedSet(self._union_rules),
                 target_types=FrozenOrderedSet(self._target_types),
+                allow_unknown_options=self._allow_unknown_options,
             )

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -284,7 +284,7 @@ class WorkunitTracker:
 
 
 def new_run_tracker() -> RunTracker:
-    # NB: A RunTracker usually observes "all options" (`get_full_options`), but it only actually
+    # NB: A RunTracker usually observes "all options" (`full_options_for_scopes`), but it only actually
     # directly consumes bootstrap options.
     return RunTracker(create_options_bootstrapper([]).bootstrap_options)
 

--- a/src/python/pants/engine/internals/options_parsing.py
+++ b/src/python/pants/engine/internals/options_parsing.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.engine.internals.session import SessionValues
 from pants.engine.rules import collect_rules, rule
-from pants.init.options_initializer import OptionsInitializer
 from pants.option.global_options import GlobalOptions
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
@@ -33,7 +32,7 @@ class _Options:
 
     @memoized_property
     def options(self) -> Options:
-        return OptionsInitializer.create(self.options_bootstrapper, self.build_config)
+        return self.options_bootstrapper.full_options(self.build_config)
 
 
 @rule

--- a/src/python/pants/engine/internals/scheduler_integration_test.py
+++ b/src/python/pants/engine/internals/scheduler_integration_test.py
@@ -1,6 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import os
 from pathlib import Path
 
 from pants.testutil.pants_integration_test import ensure_daemon, run_pants
@@ -11,7 +12,7 @@ def test_visualize_to():
     # Tests usage of the `--native-engine-visualize-to=` option, which triggers background
     # visualization of the graph. There are unit tests confirming the content of the rendered
     # results.
-    with temporary_dir() as destdir:
+    with temporary_dir(root_dir=os.getcwd()) as destdir:
         run_pants(
             [
                 f"--native-engine-visualize-to={destdir}",

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -108,6 +108,8 @@ class Process:
             result = await Get(ProcessResult, Process(["/bin/echo", "hello world"], description="demo"))
             assert result.stdout == b"hello world"
         """
+        if isinstance(argv, str):
+            raise ValueError("argv must be a sequence of strings, but was a single string.")
         self.argv = tuple(argv)
         self.description = description
         self.level = level

--- a/src/python/pants/help/help_formatter_test.py
+++ b/src/python/pants/help/help_formatter_test.py
@@ -65,7 +65,7 @@ class OptionHelpFormatterTest(unittest.TestCase):
         )
         parser.register(*args, **kwargs)
         # Force a parse to generate the derivation history.
-        parser.parse_args(Parser.ParseArgsRequest((), OptionValueContainerBuilder(), []))
+        parser.parse_args(Parser.ParseArgsRequest((), OptionValueContainerBuilder(), [], False))
         oshi = HelpInfoExtracter("").get_option_scope_help_info("", parser, False)
         return HelpFormatter(
             show_advanced=show_advanced, show_deprecated=show_deprecated, color=False

--- a/src/python/pants/init/bootstrap_scheduler.py
+++ b/src/python/pants/init/bootstrap_scheduler.py
@@ -1,0 +1,13 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from dataclasses import dataclass
+
+from pants.engine.internals.scheduler import Scheduler
+
+
+@dataclass(frozen=True)
+class BootstrapScheduler:
+    """A Scheduler that has been configured with only the rules for bootstrapping."""
+
+    scheduler: Scheduler

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -166,6 +166,7 @@ class EngineInitializer:
         options_bootstrapper: OptionsBootstrapper,
         build_configuration: BuildConfiguration,
         executor: Optional[PyExecutor] = None,
+        execution_options: Optional[ExecutionOptions] = None,
     ) -> GraphScheduler:
         native = Native()
         build_root = get_buildroot()
@@ -175,9 +176,10 @@ class EngineInitializer:
         executor = executor or PyExecutor(
             *GlobalOptions.compute_executor_arguments(bootstrap_options)
         )
+        execution_options = execution_options or ExecutionOptions.from_options(options)
         return EngineInitializer.setup_graph_extended(
             build_configuration,
-            ExecutionOptions.from_options(options),
+            execution_options,
             native=native,
             executor=executor,
             pants_ignore_patterns=GlobalOptions.compute_pants_ignore(build_root, bootstrap_options),

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -30,9 +30,8 @@ from pants.engine.streaming_workunit_handler import rules as streaming_workunit_
 from pants.engine.target import RegisteredTargetTypes
 from pants.engine.unions import UnionMembership
 from pants.init import specs_calculator
-from pants.init.options_initializer import OptionsInitializer
-from pants.option.global_options import DEFAULT_EXECUTION_OPTIONS, ExecutionOptions
-from pants.option.options import Options
+from pants.option.global_options import DEFAULT_EXECUTION_OPTIONS, ExecutionOptions, GlobalOptions
+from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.option.subsystem import Subsystem
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.vcs.changed import rules as changed_rules
@@ -164,25 +163,24 @@ class EngineInitializer:
 
     @staticmethod
     def setup_graph(
-        options: Options,
+        options_bootstrapper: OptionsBootstrapper,
         build_configuration: BuildConfiguration,
         executor: Optional[PyExecutor] = None,
     ) -> GraphScheduler:
         native = Native()
         build_root = get_buildroot()
-        bootstrap_options = options.bootstrap_option_values()
+        bootstrap_options = options_bootstrapper.bootstrap_options.for_global_scope()
+        options = options_bootstrapper.full_options(build_configuration)
         assert bootstrap_options is not None
         executor = executor or PyExecutor(
-            *OptionsInitializer.compute_executor_arguments(bootstrap_options)
+            *GlobalOptions.compute_executor_arguments(bootstrap_options)
         )
         return EngineInitializer.setup_graph_extended(
             build_configuration,
             ExecutionOptions.from_options(options),
             native=native,
             executor=executor,
-            pants_ignore_patterns=OptionsInitializer.compute_pants_ignore(
-                build_root, bootstrap_options
-            ),
+            pants_ignore_patterns=GlobalOptions.compute_pants_ignore(build_root, bootstrap_options),
             use_gitignore=bootstrap_options.pants_ignore_use_gitignore,
             local_store_dir=bootstrap_options.local_store_dir,
             local_execution_root_dir=bootstrap_options.local_execution_root_dir,

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -3,7 +3,6 @@
 
 import dataclasses
 import logging
-import os
 import sys
 from contextlib import contextmanager
 from typing import Iterator, Tuple
@@ -15,11 +14,8 @@ from pants.help.flag_error_help_printer import FlagErrorHelpPrinter
 from pants.init.extension_loader import load_backends_and_plugins
 from pants.init.plugin_resolver import PluginResolver
 from pants.option.errors import UnknownFlagsError
-from pants.option.option_value_container import OptionValueContainer
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
-from pants.util.dirutil import fast_relpath_optional
-from pants.util.ordered_set import OrderedSet
 
 logger = logging.getLogger(__name__)
 
@@ -53,91 +49,6 @@ def _initialize_build_configuration(
 
 class OptionsInitializer:
     """Initializes BuildConfiguration and Options instances."""
-
-    @staticmethod
-    def compute_executor_arguments(bootstrap_options: OptionValueContainer) -> Tuple[int, int]:
-        """Computes the arguments to construct a PyExecutor.
-
-        Does not directly construct a PyExecutor to avoid cycles.
-        """
-        if bootstrap_options.rule_threads_core < 2:
-            # TODO: This is a defense against deadlocks due to #11329: we only run one `@goal_rule`
-            # at a time, and a `@goal_rule` will only block one thread.
-            raise ValueError("--rule-threads-core values less than 2 are not supported.")
-        rule_threads_max = (
-            bootstrap_options.rule_threads_max
-            if bootstrap_options.rule_threads_max
-            else 4 * bootstrap_options.rule_threads_core
-        )
-        return bootstrap_options.rule_threads_core, rule_threads_max
-
-    @staticmethod
-    def compute_pants_ignore(buildroot, global_options):
-        """Computes the merged value of the `--pants-ignore` flag.
-
-        This inherently includes the workdir and distdir locations if they are located under the
-        buildroot.
-        """
-        pants_ignore = list(global_options.pants_ignore)
-
-        def add(absolute_path, include=False):
-            # To ensure that the path is ignored regardless of whether it is a symlink or a directory, we
-            # strip trailing slashes (which would signal that we wanted to ignore only directories).
-            maybe_rel_path = fast_relpath_optional(absolute_path, buildroot)
-            if maybe_rel_path:
-                rel_path = maybe_rel_path.rstrip(os.path.sep)
-                prefix = "!" if include else ""
-                pants_ignore.append(f"{prefix}/{rel_path}")
-
-        add(global_options.pants_workdir)
-        add(global_options.pants_distdir)
-        add(global_options.pants_subprocessdir)
-
-        return pants_ignore
-
-    @staticmethod
-    def compute_pantsd_invalidation_globs(
-        buildroot: str, bootstrap_options: OptionValueContainer
-    ) -> Tuple[str, ...]:
-        """Computes the merged value of the `--pantsd-invalidation-globs` option.
-
-        Combines --pythonpath and --pants-config-files files that are in {buildroot} dir with those
-        invalidation_globs provided by users.
-        """
-        invalidation_globs: OrderedSet[str] = OrderedSet()
-
-        # Globs calculated from the sys.path and other file-like configuration need to be sanitized
-        # to relative globs (where possible).
-        potentially_absolute_globs = (
-            *sys.path,
-            *bootstrap_options.pythonpath,
-            *bootstrap_options.pants_config_files,
-        )
-        for glob in potentially_absolute_globs:
-            # NB: We use `relpath` here because these paths are untrusted, and might need to be
-            # normalized in addition to being relativized.
-            glob_relpath = os.path.relpath(glob, buildroot)
-            if glob_relpath == "." or glob_relpath.startswith(".."):
-                logger.debug(
-                    f"Changes to {glob}, outside of the buildroot, will not be invalidated."
-                )
-            else:
-                invalidation_globs.update([glob_relpath, glob_relpath + "/**"])
-
-        # Explicitly specified globs are already relative, and are added verbatim.
-        invalidation_globs.update(
-            (
-                "!*.pyc",
-                "!__pycache__/",
-                # TODO: This is a bandaid for https://github.com/pantsbuild/pants/issues/7022:
-                # macros should be adapted to allow this dependency to be automatically detected.
-                "requirements.txt",
-                "3rdparty/**/requirements.txt",
-                *bootstrap_options.pantsd_invalidation_globs,
-            )
-        )
-
-        return tuple(invalidation_globs)
 
     @classmethod
     def create_with_build_config(

--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -1,30 +1,31 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import hashlib
 import logging
-import os
-import shutil
 import site
-import uuid
-from typing import Iterable, Iterator, List, Optional, Type, TypeVar, cast
+import sys
+from typing import Optional, TypeVar, cast
 
-from pex import resolver
-from pex.interpreter import PythonInterpreter
-from pex.network_configuration import NetworkConfiguration
-from pkg_resources import Distribution, WorkingSet
+from pkg_resources import WorkingSet
 from pkg_resources import working_set as global_working_set
 
+from pants.backend.python.util_rules.pex import (
+    PexInterpreterConstraints,
+    PexRequest,
+    PexRequirements,
+    VenvPex,
+    VenvPexProcess,
+)
+from pants.core.util_rules.pants_environment import PantsEnvironment
+from pants.engine.collection import DeduplicatedCollection
+from pants.engine.internals.session import SessionValues
+from pants.engine.process import ProcessCacheScope, ProcessResult
+from pants.engine.rules import Get, QueryRule, collect_rules, rule
+from pants.init.bootstrap_scheduler import BootstrapScheduler
 from pants.option.global_options import GlobalOptions
-from pants.option.optionable import Optionable
 from pants.option.options_bootstrapper import OptionsBootstrapper
-from pants.option.scope import ScopeInfo
 from pants.option.subsystem import Subsystem
-from pants.python.python_repos import PythonRepos
-from pants.util.contextutil import temporary_dir
-from pants.util.dirutil import safe_concurrent_rename, safe_delete, safe_open
-from pants.util.memo import memoized_property
-from pants.version import PANTS_SEMVER
+from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
 
@@ -32,26 +33,72 @@ logger = logging.getLogger(__name__)
 S = TypeVar("S", bound=Subsystem)
 
 
-class PluginResolver:
-    @staticmethod
-    def _is_wheel(path) -> bool:
-        return os.path.isfile(path) and path.endswith(".whl")
+class ResolvedPluginDistributions(DeduplicatedCollection[str]):
+    sort_input = True
 
+
+@rule
+async def resolve_plugins(
+    interpreter_constraints: PexInterpreterConstraints, global_options: GlobalOptions
+) -> ResolvedPluginDistributions:
+    """This rule resolves plugins using a VenvPex, and exposes the absolute paths of their dists.
+
+    NB: This relies on the fact that PEX constructs venvs in a stable location (within the
+    `named_caches` directory), but consequently needs to disable the process cache: see the
+    ProcessCacheScope reference in the body.
+    """
+    requirements = PexRequirements(sorted(global_options.options.plugins))
+    plugins_pex = await Get(
+        VenvPex,
+        PexRequest(
+            output_filename="pants_plugins.pex",
+            internal_only=True,
+            requirements=requirements,
+            interpreter_constraints=interpreter_constraints,
+            # The repository's constraints are not relevant here, because this resolve is mixed
+            # into the Pants' process' path, and never into user code.
+            apply_requirement_constraints=False,
+            description=f"Resolving plugins: {requirements}",
+        ),
+    )
+
+    # NB: We run this Process per-restart because it (intentionally) leaks named cache
+    # paths in a way that invalidates the Process-cache. See the method doc.
+    cache_scope = (
+        ProcessCacheScope.NEVER
+        if global_options.options.plugins_force_resolve
+        else ProcessCacheScope.PER_RESTART
+    )
+
+    plugins_process_result = await Get(
+        ProcessResult,
+        VenvPexProcess(
+            plugins_pex,
+            argv=("-c", "import os, site; print(os.linesep.join(site.getsitepackages()))"),
+            description="Extracting plugin locations",
+            level=LogLevel.DEBUG,
+            cache_scope=cache_scope,
+        ),
+    )
+    return ResolvedPluginDistributions(plugins_process_result.stdout.decode().strip().split("\n"))
+
+
+class PluginResolver:
     def __init__(
         self,
-        options_bootstrapper: OptionsBootstrapper,
-        *,
-        interpreter: Optional[PythonInterpreter] = None,
+        scheduler: BootstrapScheduler,
+        interpreter_constraints: Optional[PexInterpreterConstraints] = None,
     ) -> None:
-        self._options_bootstrapper = options_bootstrapper
-        self._interpreter = interpreter or PythonInterpreter.get()
+        self._scheduler = scheduler
+        self._interpreter_constraints = (
+            interpreter_constraints
+            if interpreter_constraints is not None
+            else PexInterpreterConstraints([f"=={'.'.join(map(str, sys.version_info[:3]))}"])
+        )
 
-        bootstrap_options = self._options_bootstrapper.get_bootstrap_options().for_global_scope()
-        self._plugin_requirements: List[str] = sorted(bootstrap_options.plugins)
-        self._plugin_cache_dir: str = bootstrap_options.plugin_cache_dir
-        self._plugins_force_resolve: bool = bootstrap_options.plugins_force_resolve
-
-    def resolve(self, working_set: Optional[WorkingSet] = None) -> WorkingSet:
+    def resolve(
+        self, options_bootstrapper: OptionsBootstrapper, working_set: Optional[WorkingSet] = None
+    ) -> WorkingSet:
         """Resolves any configured plugins and adds them to the global working set.
 
         :param working_set: The working set to add the resolved plugins to instead of the global
@@ -59,143 +106,35 @@ class PluginResolver:
         :type: :class:`pkg_resources.WorkingSet`
         """
         working_set = working_set or global_working_set
-        if self._plugin_requirements:
-            for resolved_plugin_location in self._resolve_plugin_locations():
-                site.addsitedir(
-                    resolved_plugin_location
-                )  # Activate any .pth files plugin wheels may have.
-                working_set.add_entry(resolved_plugin_location)
+        for resolved_plugin_location in self._resolve_plugins(options_bootstrapper):
+            site.addsitedir(
+                resolved_plugin_location
+            )  # Activate any .pth files plugin wheels may have.
+            working_set.add_entry(resolved_plugin_location)
         return working_set
 
-    def _resolve_plugin_locations(self) -> Iterator[str]:
-        hasher = hashlib.sha1()
-
-        # Assume we have platform-specific plugin requirements and pessimistically mix the ABI
-        # identifier into the hash to ensure re-resolution of plugins for different interpreter ABIs.
-        hasher.update(self._interpreter.identity.abi_tag.encode())  # EG: cp36m
-
-        for req in sorted(self._plugin_requirements):
-            hasher.update(req.encode())
-        resolve_hash = hasher.hexdigest()
-        resolved_plugins_list = os.path.join(self.plugin_cache_dir, f"plugins-{resolve_hash}.txt")
-
-        if self._plugins_force_resolve:
-            safe_delete(resolved_plugins_list)
-
-        if not os.path.exists(resolved_plugins_list):
-            tmp_plugins_list = f"{resolved_plugins_list}.{uuid.uuid4().hex}"
-            with safe_open(tmp_plugins_list, "w") as fp:
-                for plugin in self._resolve_plugins():
-                    fp.write(f"{plugin}\n")
-            os.rename(tmp_plugins_list, resolved_plugins_list)
-        with open(resolved_plugins_list, "r") as fp:
-            for plugin in fp:
-                plugin_path = plugin.strip()
-                yield self._plugin_location(plugin_path)
-
-    def _resolve_plugins(self) -> Iterable[str]:
-        logger.info(
-            "Resolving new plugins...:\n  {}".format("\n  ".join(self._plugin_requirements))
-        )
-        resolved_dists = resolver.resolve(
-            self._plugin_requirements,
-            indexes=self._python_repos.indexes,
-            find_links=self._python_repos.repos,
-            interpreter=self._interpreter,
-            cache=self.plugin_cache_dir,
-            allow_prereleases=PANTS_SEMVER.is_prerelease,
-            network_configuration=NetworkConfiguration.create(
-                cert=self._global_options.options.ca_certs_path
+    def _resolve_plugins(
+        self, options_bootstrapper: OptionsBootstrapper
+    ) -> ResolvedPluginDistributions:
+        session = self._scheduler.scheduler.new_session(
+            "plugin_resolver",
+            session_values=SessionValues(
+                {
+                    OptionsBootstrapper: options_bootstrapper,
+                    PantsEnvironment: PantsEnvironment(dict(options_bootstrapper.env_tuples)),
+                }
             ),
         )
-        return [
-            self._install_plugin(resolved_dist.distribution) for resolved_dist in resolved_dists
-        ]
+        return cast(
+            ResolvedPluginDistributions,
+            session.product_request(ResolvedPluginDistributions, [self._interpreter_constraints])[
+                0
+            ],
+        )
 
-    @classmethod
-    def _plugin_location(cls, plugin_path: str) -> str:
-        return f"{plugin_path}-install"
 
-    def _install_plugin(self, distribution: Distribution) -> str:
-        # We don't actually install the distribution. It's installed for us by the Pex resolver in
-        # a chroot. We just copy that chroot out of the Pex cache to a location we control.
-        # Historically though, Pex did not install wheels it resolved and we did this here by hand.
-        # We retain the terminology and, more importantly, the final resting "install" path and the
-        # contents of plugin-<hash>.txt files to keep the plugin cache forwards and backwards
-        # compatible between Pants releases.
-        #
-        # Concretely:
-        #
-        # 1. In the past Pex resolved the wheel file below and we installed it to the "-install"
-        #    directory:
-        #
-        #    ~/.cache/pants/plugins/
-        #       requests-2.23.0-py2.py3-none-any.whl
-        #       requests-2.23.0-py2.py3-none-any.whl-install/
-        #
-        #    The plugins-<hash>.txt file that records plugin locations contained the un-installed
-        #    wheel file path:
-        #
-        #    $ cat ~/.cache/pants/plugins/plugins-418c36b574edbcf4720b266b0709750ad588c281.txt
-        #    /home/jsirois/.cache/pants/plugins/requests-2.23.0-py2.py3-none-any.whl
-        #
-        # 2. Now Pex resolves an installed wheel chroot directory and we copy that directory to the
-        #    "-install" directory:
-        #
-        #    ~/.cache/pants/plugins/
-        #      installed_wheels/6ce6cd759a2d13badb1f6b9e665e2aded7a012dd/requests-2.23.0-py2.py3-none-any.whl/
-        #      requests-2.23.0-py2.py3-none-any.whl-install/
-        #
-        #    The plugins-<hash>.txt file that records plugin locations now contains the final
-        #    installed wheel path with the "-install" suffix omitted which leads to the same file
-        #    contents as past Pants versions:
-        #
-        #    $ cat ~/.cache/pants/plugins/plugins-418c36b574edbcf4720b266b0709750ad588c281.txt
-        #        /home/jsirois/.cache/pants/plugins/requests-2.23.0-py2.py3-none-any.whl
-        #
-        #    We add the suffix on after reading the file to find the actual installed wheel path.
-
-        wheel_basename = os.path.basename(distribution.location)
-        plugin_path = os.path.join(self.plugin_cache_dir, wheel_basename)
-
-        with temporary_dir() as td:
-            temp_install_dir = os.path.join(td, wheel_basename)
-            shutil.copytree(distribution.location, temp_install_dir)
-            safe_concurrent_rename(temp_install_dir, self._plugin_location(plugin_path))
-            return plugin_path
-
-    @property
-    def plugin_cache_dir(self) -> str:
-        """The path of the directory pants plugins bdists are cached in."""
-        return self._plugin_cache_dir
-
-    @memoized_property
-    def _global_options(self):
-        return self._create_global_subsystem(GlobalOptions)
-
-    @memoized_property
-    def _python_repos(self) -> PythonRepos:
-        return self._create_global_subsystem(PythonRepos)
-
-    @memoized_property
-    def _defaulted_only_options(self):
-        # NB: The PluginResolver runs very early in the pants startup sequence before the standard
-        # Subsystem facility is wired up.  As a result PluginResolver is not itself a Subsystem with
-        # PythonRepos as a dependency.  Instead it does the minimum possible work to hand-roll
-        # bootstrapping of the Subsystems it needs.
-        optionables: Iterable[Type[Optionable]] = (GlobalOptions, PythonRepos)
-        known_scope_infos: List[ScopeInfo] = [
-            ksi for optionable in optionables for ksi in optionable.known_scope_infos()
-        ]
-        options = self._options_bootstrapper.full_options_for_scopes(known_scope_infos)
-
-        # Ignore command line flags since we'd blow up on any we don't understand (most of them).
-        # If someone wants to bootstrap plugins in a one-off custom way they'll need to use env vars
-        # or a --pants-config-files pointing to a custom pants.toml snippet.
-        return options.drop_flag_values()
-
-    def _create_global_subsystem(self, subsystem_type: Type[S]) -> S:
-        options_scope = cast(str, subsystem_type.options_scope)
-
-        # Finally, construct the Subsystem.
-        return subsystem_type(options_scope, self._defaulted_only_options.for_scope(options_scope))
+def rules():
+    return [
+        QueryRule(ResolvedPluginDistributions, [PexInterpreterConstraints]),
+        *collect_rules(),
+    ]

--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -187,7 +187,7 @@ class PluginResolver:
         known_scope_infos: List[ScopeInfo] = [
             ksi for optionable in optionables for ksi in optionable.known_scope_infos()
         ]
-        options = self._options_bootstrapper.get_full_options(known_scope_infos)
+        options = self._options_bootstrapper.full_options_for_scopes(known_scope_infos)
 
         # Ignore command line flags since we'd blow up on any we don't understand (most of them).
         # If someone wants to bootstrap plugins in a one-off custom way they'll need to use env vars

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -344,6 +344,10 @@ class GlobalOptions(Subsystem):
             advanced=True,
             default=os.path.join(get_pants_cachedir(), "plugins"),
             help="Cache resolved plugin requirements here.",
+            removal_version="2.5.0.dev0",
+            removal_hint=(
+                "This option now no-ops, the plugins cache is now housed in the named caches."
+            ),
         )
 
         register(

--- a/src/python/pants/option/global_options_test.py
+++ b/src/python/pants/option/global_options_test.py
@@ -39,7 +39,7 @@ def create_execution_options(
     if plugin:
         args.append(f"--remote-auth-plugin={plugin}")
     ob = create_options_bootstrapper(args)
-    _build_config, options = OptionsInitializer.create_with_build_config(ob, raise_=False)
+    _build_config, options = OptionsInitializer(ob).build_config_and_options(ob, raise_=False)
     return ExecutionOptions.from_options(options)
 
 

--- a/src/python/pants/option/global_options_test.py
+++ b/src/python/pants/option/global_options_test.py
@@ -9,9 +9,11 @@ from textwrap import dedent
 
 import pytest
 
+from pants.base.build_environment import get_buildroot
 from pants.init.options_initializer import OptionsInitializer
 from pants.option.errors import OptionsError
-from pants.option.global_options import ExecutionOptions
+from pants.option.global_options import ExecutionOptions, GlobalOptions
+from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.util.contextutil import temporary_dir
 
@@ -138,3 +140,14 @@ def test_execution_options_auth_plugin() -> None:
     exec_options = compute_exec_options("UNAVAILABLE")
     assert exec_options.remote_cache_read is False
     assert exec_options.remote_instance_name == "main"
+
+
+def test_invalidation_globs() -> None:
+    # Confirm that an un-normalized relative path in the pythonpath is filtered out.
+    suffix = "something-ridiculous"
+    ob = OptionsBootstrapper.create(env={}, args=[f"--pythonpath=../{suffix}"], allow_pantsrc=False)
+    globs = GlobalOptions.compute_pantsd_invalidation_globs(
+        get_buildroot(), ob.bootstrap_options.for_global_scope()
+    )
+    for glob in globs:
+        assert suffix not in glob

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -116,6 +116,7 @@ class Options:
         known_scope_infos: Iterable[ScopeInfo],
         args: Sequence[str],
         bootstrap_option_values: Optional[OptionValueContainer] = None,
+        allow_unknown_options: bool = False,
     ) -> Options:
         """Create an Options instance.
 
@@ -162,6 +163,7 @@ class Options:
             parser_hierarchy=parser_hierarchy,
             bootstrap_option_values=bootstrap_option_values,
             known_scope_to_info=known_scope_to_info,
+            allow_unknown_options=allow_unknown_options,
         )
 
     def __init__(
@@ -174,6 +176,7 @@ class Options:
         parser_hierarchy: ParserHierarchy,
         bootstrap_option_values: Optional[OptionValueContainer],
         known_scope_to_info: Dict[str, ScopeInfo],
+        allow_unknown_options: bool = False,
     ) -> None:
         """The low-level constructor for an Options instance.
 
@@ -187,6 +190,7 @@ class Options:
         self._parser_hierarchy = parser_hierarchy
         self._bootstrap_option_values = bootstrap_option_values
         self._known_scope_to_info = known_scope_to_info
+        self._allow_unknown_options = allow_unknown_options
         self._frozen = False
 
     # TODO: Eliminate this in favor of a builder/factory.
@@ -388,6 +392,7 @@ class Options:
             flags_in_scope=flags_in_scope,
             namespace=namespace,
             passthrough_args=self._passthru,
+            allow_unknown_flags=self._allow_unknown_options,
         )
 
     # TODO: Eagerly precompute backing data for this?

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -210,7 +210,9 @@ class OptionsBootstrapper:
         return self.bootstrap_options
 
     @memoized_method
-    def _full_options(self, known_scope_infos: FrozenOrderedSet[ScopeInfo]) -> Options:
+    def _full_options(
+        self, known_scope_infos: FrozenOrderedSet[ScopeInfo], allow_unknown_options: bool = False
+    ) -> Options:
         bootstrap_option_values = self.get_bootstrap_options().for_global_scope()
         options = Options.create(
             self.env,
@@ -218,6 +220,7 @@ class OptionsBootstrapper:
             known_scope_infos,
             args=self.args,
             bootstrap_option_values=bootstrap_option_values,
+            allow_unknown_options=allow_unknown_options,
         )
 
         distinct_optionable_classes: Set[Type[Optionable]] = set()
@@ -229,7 +232,9 @@ class OptionsBootstrapper:
 
         return options
 
-    def full_options_for_scopes(self, known_scope_infos: Iterable[ScopeInfo]) -> Options:
+    def full_options_for_scopes(
+        self, known_scope_infos: Iterable[ScopeInfo], allow_unknown_options: bool = False
+    ) -> Options:
         """Get the full Options instance bootstrapped by this object for the given known scopes.
 
         :param known_scope_infos: ScopeInfos for all scopes that may be encountered.
@@ -237,7 +242,8 @@ class OptionsBootstrapper:
                   scopes.
         """
         return self._full_options(
-            FrozenOrderedSet(sorted(known_scope_infos, key=lambda si: si.scope))
+            FrozenOrderedSet(sorted(known_scope_infos, key=lambda si: si.scope)),
+            allow_unknown_options=allow_unknown_options,
         )
 
     def full_options(self, build_configuration: BuildConfiguration) -> Options:
@@ -254,6 +260,8 @@ class OptionsBootstrapper:
             for optionable in build_configuration.all_optionables
             for si in optionable.known_scope_infos()
         ]
-        options = self.full_options_for_scopes(known_scope_infos)
+        options = self.full_options_for_scopes(
+            known_scope_infos, allow_unknown_options=build_configuration.allow_unknown_options
+        )
         GlobalOptions.validate_instance(options.for_global_scope())
         return options

--- a/src/python/pants/option/options_bootstrapper_test.py
+++ b/src/python/pants/option/options_bootstrapper_test.py
@@ -139,7 +139,7 @@ class OptionsBootstrapperTest(unittest.TestCase):
             bootstrapper = OptionsBootstrapper.create(
                 env={"PANTS_SUPPORTDIR": "/pear"}, args=args, allow_pantsrc=False
             )
-            opts = bootstrapper.get_full_options(
+            opts = bootstrapper.full_options_for_scopes(
                 known_scope_infos=[
                     ScopeInfo(""),
                     ScopeInfo("foo"),
@@ -180,7 +180,7 @@ class OptionsBootstrapperTest(unittest.TestCase):
             *,
             expected_worker_count: int,
         ) -> None:
-            options = options_bootstrapper.get_full_options(
+            options = options_bootstrapper.full_options_for_scopes(
                 known_scope_infos=[
                     ScopeInfo(""),
                     ScopeInfo("compile.apt"),
@@ -253,7 +253,7 @@ class OptionsBootstrapperTest(unittest.TestCase):
             )
             fp.close()
             bootstrapped_options = create_options_bootstrapper(fp.name)
-            opts_single_config = bootstrapped_options.get_full_options(
+            opts_single_config = bootstrapped_options.full_options_for_scopes(
                 known_scope_infos=[
                     ScopeInfo(""),
                     ScopeInfo("resolver"),
@@ -268,13 +268,13 @@ class OptionsBootstrapperTest(unittest.TestCase):
             args = self._config_path(config)
             bootstrapper = OptionsBootstrapper.create(env={}, args=args, allow_pantsrc=False)
 
-            opts1 = bootstrapper.get_full_options(
+            opts1 = bootstrapper.full_options_for_scopes(
                 known_scope_infos=[
                     ScopeInfo(""),
                     ScopeInfo("foo"),
                 ]
             )
-            opts2 = bootstrapper.get_full_options(
+            opts2 = bootstrapper.full_options_for_scopes(
                 known_scope_infos=[
                     ScopeInfo("foo"),
                     ScopeInfo(""),
@@ -282,7 +282,7 @@ class OptionsBootstrapperTest(unittest.TestCase):
             )
             assert opts1 is opts2
 
-            opts3 = bootstrapper.get_full_options(
+            opts3 = bootstrapper.full_options_for_scopes(
                 known_scope_infos=[
                     ScopeInfo(""),
                     ScopeInfo("foo"),
@@ -291,10 +291,10 @@ class OptionsBootstrapperTest(unittest.TestCase):
             )
             assert opts1 is opts3
 
-            opts4 = bootstrapper.get_full_options(known_scope_infos=[ScopeInfo("")])
+            opts4 = bootstrapper.full_options_for_scopes(known_scope_infos=[ScopeInfo("")])
             assert opts1 is not opts4
 
-            opts5 = bootstrapper.get_full_options(known_scope_infos=[ScopeInfo("")])
+            opts5 = bootstrapper.full_options_for_scopes(known_scope_infos=[ScopeInfo("")])
             assert opts4 is opts5
             assert opts1 is not opts5
 

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -169,12 +169,14 @@ class Parser:
         flag_value_map: Dict[str, List[Any]]
         namespace: OptionValueContainerBuilder
         passthrough_args: List[str]
+        allow_unknown_flags: bool
 
         def __init__(
             self,
             flags_in_scope: Iterable[str],
             namespace: OptionValueContainerBuilder,
             passthrough_args: List[str],
+            allow_unknown_flags: bool,
         ) -> None:
             """
             :param flags_in_scope: Iterable of arg strings to parse into flag values.
@@ -183,6 +185,7 @@ class Parser:
             self.flag_value_map = self._create_flag_value_map(flags_in_scope)
             self.namespace = namespace
             self.passthrough_args = passthrough_args
+            self.allow_unknown_flags = allow_unknown_flags
 
         @staticmethod
         def _create_flag_value_map(flags: Iterable[str]) -> DefaultDict[str, list[str | None]]:
@@ -296,7 +299,7 @@ class Parser:
 
             setattr(namespace, dest, val)
 
-        if flag_value_map:
+        if not parse_args_request.allow_unknown_flags and flag_value_map:
             # There were unconsumed flags.
             raise UnknownFlagsError(tuple(flag_value_map.keys()), self.scope)
         return namespace.build()

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -20,8 +20,8 @@ from pants.engine.internals.native import Native
 from pants.engine.internals.native_engine import PyExecutor
 from pants.init.engine_initializer import GraphScheduler
 from pants.init.logging import setup_logging, setup_logging_to_file
-from pants.init.options_initializer import OptionsInitializer
 from pants.init.util import init_workdir
+from pants.option.global_options import GlobalOptions
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
@@ -58,9 +58,7 @@ class PantsDaemon(PantsDaemonProcessManager):
         native = Native()
         native.override_thread_logging_destination_to_just_pantsd()
 
-        executor = PyExecutor(
-            *OptionsInitializer.compute_executor_arguments(bootstrap_options_values)
-        )
+        executor = PyExecutor(*GlobalOptions.compute_executor_arguments(bootstrap_options_values))
         core = PantsDaemonCore(executor, cls._setup_services)
 
         server = native.new_nailgun_server(
@@ -90,7 +88,7 @@ class PantsDaemon(PantsDaemonProcessManager):
         """
         build_root = get_buildroot()
 
-        invalidation_globs = OptionsInitializer.compute_pantsd_invalidation_globs(
+        invalidation_globs = GlobalOptions.compute_pantsd_invalidation_globs(
             build_root,
             bootstrap_options,
         )

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -59,7 +59,7 @@ class PantsDaemon(PantsDaemonProcessManager):
         native.override_thread_logging_destination_to_just_pantsd()
 
         executor = PyExecutor(*GlobalOptions.compute_executor_arguments(bootstrap_options_values))
-        core = PantsDaemonCore(executor, cls._setup_services)
+        core = PantsDaemonCore(options_bootstrapper, executor, cls._setup_services)
 
         server = native.new_nailgun_server(
             executor,

--- a/src/python/pants/pantsd/pants_daemon_core.py
+++ b/src/python/pants/pantsd/pants_daemon_core.py
@@ -3,7 +3,7 @@
 
 import logging
 import threading
-from typing import Optional
+from typing import Optional, Tuple
 
 from typing_extensions import Protocol
 
@@ -36,7 +36,13 @@ class PantsDaemonCore:
     PantsServices.
     """
 
-    def __init__(self, executor: PyExecutor, services_constructor: PantsServicesConstructor):
+    def __init__(
+        self,
+        options_bootstrapper: OptionsBootstrapper,
+        executor: PyExecutor,
+        services_constructor: PantsServicesConstructor,
+    ):
+        self._options_initializer = OptionsInitializer(options_bootstrapper, executor=executor)
         self._executor = executor
         self._services_constructor = services_constructor
         self._lifecycle_lock = threading.RLock()
@@ -61,7 +67,7 @@ class PantsDaemonCore:
                 return True
             return self._services.are_all_alive()
 
-    def _init_scheduler(
+    def _initialize(
         self, options_fingerprint: str, options_bootstrapper: OptionsBootstrapper
     ) -> None:
         """(Re-)Initialize the scheduler.
@@ -75,7 +81,7 @@ class PantsDaemonCore:
                 logger.info("initializing pantsd...")
             if self._services:
                 self._services.shutdown()
-            build_config, options = OptionsInitializer.create_with_build_config(
+            build_config, options = self._options_initializer.build_config_and_options(
                 options_bootstrapper, raise_=True
             )
             self._scheduler = EngineInitializer.setup_graph(
@@ -92,7 +98,9 @@ class PantsDaemonCore:
             self._scheduler = None
             raise e
 
-    def prepare_scheduler(self, options_bootstrapper: OptionsBootstrapper) -> GraphScheduler:
+    def prepare(
+        self, options_bootstrapper: OptionsBootstrapper
+    ) -> Tuple[GraphScheduler, OptionsInitializer]:
         """Get a scheduler for the given options_bootstrapper.
 
         Runs in a client context (generally in DaemonPantsRunner) so logging is sent to the client.
@@ -113,6 +121,6 @@ class PantsDaemonCore:
                 # The fingerprint mismatches, either because this is the first run (and there is no
                 # fingerprint) or because relevant options have changed. Create a new scheduler
                 # and services.
-                self._init_scheduler(options_fingerprint, options_bootstrapper)
-                assert self._scheduler is not None
-            return self._scheduler
+                self._initialize(options_fingerprint, options_bootstrapper)
+            assert self._scheduler is not None
+            return self._scheduler, self._options_initializer

--- a/src/python/pants/pantsd/pants_daemon_core.py
+++ b/src/python/pants/pantsd/pants_daemon_core.py
@@ -9,7 +9,7 @@ from typing_extensions import Protocol
 
 from pants.engine.internals.native_engine import PyExecutor
 from pants.init.engine_initializer import EngineInitializer, GraphScheduler
-from pants.init.options_initializer import BuildConfigInitializer, OptionsInitializer
+from pants.init.options_initializer import OptionsInitializer
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.option.options_fingerprinter import OptionsFingerprinter
@@ -75,9 +75,9 @@ class PantsDaemonCore:
                 logger.info("initializing pantsd...")
             if self._services:
                 self._services.shutdown()
-            with OptionsInitializer.handle_unknown_flags(options_bootstrapper, raise_=True):
-                build_config = BuildConfigInitializer.get(options_bootstrapper)
-                options = OptionsInitializer.create(options_bootstrapper, build_config)
+            build_config, options = OptionsInitializer.create_with_build_config(
+                options_bootstrapper, raise_=True
+            )
             self._scheduler = EngineInitializer.setup_graph(
                 options, build_config, executor=self._executor
             )

--- a/src/python/pants/pantsd/pants_daemon_core.py
+++ b/src/python/pants/pantsd/pants_daemon_core.py
@@ -79,7 +79,7 @@ class PantsDaemonCore:
                 options_bootstrapper, raise_=True
             )
             self._scheduler = EngineInitializer.setup_graph(
-                options, build_config, executor=self._executor
+                options_bootstrapper, build_config, executor=self._executor
             )
             bootstrap_options_values = options.bootstrap_option_values()
             assert bootstrap_options_values is not None

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -35,7 +35,6 @@ from pants.engine.rules import Rule
 from pants.engine.target import Target, WrappedTarget
 from pants.engine.unions import UnionMembership
 from pants.init.engine_initializer import EngineInitializer
-from pants.init.options_initializer import OptionsInitializer
 from pants.option.global_options import ExecutionOptions, GlobalOptions
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.source import source_root
@@ -126,7 +125,7 @@ class RuleRunner:
         named_caches_dir = global_options.named_caches_dir
 
         graph_session = EngineInitializer.setup_graph_extended(
-            pants_ignore_patterns=OptionsInitializer.compute_pants_ignore(
+            pants_ignore_patterns=GlobalOptions.compute_pants_ignore(
                 self.build_root, global_options
             ),
             use_gitignore=False,

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -115,7 +115,7 @@ class RuleRunner:
         self.build_config = build_config_builder.create()
 
         options_bootstrapper = create_options_bootstrapper()
-        options = OptionsInitializer.create(options_bootstrapper, self.build_config)
+        options = options_bootstrapper.full_options(self.build_config)
         global_options = options_bootstrapper.bootstrap_options.for_global_scope()
         local_store_dir = (
             os.path.realpath(safe_mkdtemp())
@@ -190,7 +190,7 @@ class RuleRunner:
         self.set_options(merged_args, env=env)
         options_bootstrapper = create_options_bootstrapper(args=merged_args, env=env)
 
-        raw_specs = options_bootstrapper.get_full_options(
+        raw_specs = options_bootstrapper.full_options_for_scopes(
             [*GlobalOptions.known_scope_infos(), *goal.subsystem_cls.known_scope_infos()]
         ).specs
         specs = SpecsParser(self.build_root).parse_specs(raw_specs)

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -37,6 +37,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33954243bd79057c2de7338850b85983a44588021f8a5fee574a8888c6de4344"
 
 [[package]]
+name = "arc-swap"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d7d63395147b81a9e570bcc6243aaf71c017bd666d4909cfef0085bdda8d73"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2995,7 +3001,9 @@ checksum = "36474e732d1affd3a6ed582781b3683df3d0563714c59c39591e8ff707cf078e"
 name = "task_executor"
 version = "0.0.1"
 dependencies = [
+ "arc-swap",
  "futures",
+ "lazy_static",
  "logging",
  "tokio",
  "workunit_store",

--- a/src/rust/engine/fs/store/benches/store.rs
+++ b/src/rust/engine/fs/store/benches/store.rs
@@ -53,7 +53,7 @@ pub fn criterion_benchmark_materialize(c: &mut Criterion) {
   // Create an executor, store containing the stuff to materialize, and a digest for the stuff.
   // To avoid benchmarking the deleting of things, we create a parent temporary directory (which
   // will be deleted at the end of the benchmark) and then skip deletion of the per-run directories.
-  let executor = Executor::new_owned(num_cpus::get(), num_cpus::get() * 4);
+  let executor = Executor::global(num_cpus::get(), num_cpus::get() * 4);
   let (store, _tempdir, digest) = large_snapshot(&executor, 100);
   let parent_dest = TempDir::new().unwrap();
   let parent_dest_path = parent_dest.path();
@@ -77,7 +77,7 @@ pub fn criterion_benchmark_materialize(c: &mut Criterion) {
 }
 
 pub fn criterion_benchmark_subset_wildcard(c: &mut Criterion) {
-  let executor = Executor::new_owned(num_cpus::get(), num_cpus::get() * 4);
+  let executor = Executor::global(num_cpus::get(), num_cpus::get() * 4);
   // NB: We use a much larger snapshot size compared to the materialize benchmark!
   let (store, _tempdir, digest) = large_snapshot(&executor, 1000);
 
@@ -105,7 +105,7 @@ pub fn criterion_benchmark_subset_wildcard(c: &mut Criterion) {
 }
 
 pub fn criterion_benchmark_merge(c: &mut Criterion) {
-  let executor = Executor::new_owned(num_cpus::get(), num_cpus::get() * 4);
+  let executor = Executor::global(num_cpus::get(), num_cpus::get() * 4);
   let num_files: usize = 4000;
   let (store, _tempdir, digest) = large_snapshot(&executor, num_files);
 

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -493,7 +493,7 @@ py_class!(class PyTypes |py| {
 py_class!(pub class PyExecutor |py| {
     data executor: Executor;
     def __new__(_cls, core_threads: usize, max_threads: usize) -> CPyResult<Self> {
-      let executor = Executor::new_owned(core_threads, max_threads).map_err(|e| PyErr::new::<exc::Exception, _>(py, (e,)))?;
+      let executor = Executor::global(core_threads, max_threads).map_err(|e| PyErr::new::<exc::Exception, _>(py, (e,)))?;
       Self::create_instance(py, executor)
     }
 });

--- a/src/rust/engine/task_executor/Cargo.toml
+++ b/src/rust/engine/task_executor/Cargo.toml
@@ -6,7 +6,9 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
 
 [dependencies]
+arc-swap = "1.2"
 futures = "0.3"
+lazy_static = "1"
 logging = { path = "../logging" }
 tokio = { version = "0.2.23", features = ["blocking", "rt-threaded"] }
 workunit_store = { path = "../workunit_store" }

--- a/tests/python/pants_test/init/test_options_initializer.py
+++ b/tests/python/pants_test/init/test_options_initializer.py
@@ -3,7 +3,6 @@
 
 import unittest
 
-from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import BuildConfigurationError
 from pants.init.options_initializer import OptionsInitializer
 from pants.option.errors import OptionsError
@@ -29,15 +28,3 @@ class OptionsInitializerTest(unittest.TestCase):
         with self.assertRaises(OptionsError) as exc:
             OptionsInitializer.create_with_build_config(ob, raise_=True)
         self.assertIn("The `--remote-execution` option requires", str(exc.exception))
-
-    def test_invalidation_globs(self) -> None:
-        # Confirm that an un-normalized relative path in the pythonpath is filtered out.
-        suffix = "something-ridiculous"
-        ob = OptionsBootstrapper.create(
-            env={}, args=[f"--pythonpath=../{suffix}"], allow_pantsrc=False
-        )
-        globs = OptionsInitializer.compute_pantsd_invalidation_globs(
-            get_buildroot(), ob.bootstrap_options.for_global_scope()
-        )
-        for glob in globs:
-            assert suffix not in glob

--- a/tests/python/pants_test/init/test_options_initializer.py
+++ b/tests/python/pants_test/init/test_options_initializer.py
@@ -18,7 +18,9 @@ class OptionsInitializerTest(unittest.TestCase):
         )
 
         with self.assertRaises(BuildConfigurationError):
-            OptionsInitializer.create_with_build_config(options_bootstrapper, raise_=True)
+            OptionsInitializer(options_bootstrapper).build_config_and_options(
+                options_bootstrapper, raise_=True
+            )
 
     def test_global_options_validation(self):
         # Specify an invalid combination of options.
@@ -26,5 +28,5 @@ class OptionsInitializerTest(unittest.TestCase):
             env={}, args=["--backend-packages=[]", "--remote-execution"], allow_pantsrc=False
         )
         with self.assertRaises(OptionsError) as exc:
-            OptionsInitializer.create_with_build_config(ob, raise_=True)
+            OptionsInitializer(ob).build_config_and_options(ob, raise_=True)
         self.assertIn("The `--remote-execution` option requires", str(exc.exception))

--- a/tests/python/pants_test/init/test_options_initializer.py
+++ b/tests/python/pants_test/init/test_options_initializer.py
@@ -5,7 +5,7 @@ import unittest
 
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import BuildConfigurationError
-from pants.init.options_initializer import BuildConfigInitializer, OptionsInitializer
+from pants.init.options_initializer import OptionsInitializer
 from pants.option.errors import OptionsError
 from pants.option.options_bootstrapper import OptionsBootstrapper
 
@@ -17,19 +17,17 @@ class OptionsInitializerTest(unittest.TestCase):
             args=["--backend-packages=[]", "--pants-version=99.99.9999"],
             allow_pantsrc=False,
         )
-        build_config = BuildConfigInitializer.get(options_bootstrapper)
 
         with self.assertRaises(BuildConfigurationError):
-            OptionsInitializer.create(options_bootstrapper, build_config)
+            OptionsInitializer.create_with_build_config(options_bootstrapper, raise_=True)
 
     def test_global_options_validation(self):
         # Specify an invalid combination of options.
         ob = OptionsBootstrapper.create(
             env={}, args=["--backend-packages=[]", "--remote-execution"], allow_pantsrc=False
         )
-        build_config = BuildConfigInitializer.get(ob)
         with self.assertRaises(OptionsError) as exc:
-            OptionsInitializer.create(ob, build_config)
+            OptionsInitializer.create_with_build_config(ob, raise_=True)
         self.assertIn("The `--remote-execution` option requires", str(exc.exception))
 
     def test_invalidation_globs(self) -> None:

--- a/tests/python/pants_test/pantsd/test_pants_daemon.py
+++ b/tests/python/pants_test/pantsd/test_pants_daemon.py
@@ -10,6 +10,7 @@ from pants.engine.internals.native_engine import PyExecutor
 from pants.pantsd.pants_daemon import PantsDaemon
 from pants.pantsd.pants_daemon_core import PantsDaemonCore
 from pants.pantsd.service.pants_service import PantsServices
+from pants.testutil.option_util import create_options_bootstrapper
 from pants.util.contextutil import stdio_as
 
 PATCH_OPTS = dict(autospec=True, spec_set=True)
@@ -20,10 +21,7 @@ TEST_LOG_LEVEL = logging.INFO
 
 @unittest.mock.patch("os.close", **PATCH_OPTS)
 def test_close_stdio(mock_close):
-    mock_options = unittest.mock.Mock()
-    mock_options_values = unittest.mock.Mock()
-    mock_options.for_global_scope.return_value = mock_options_values
-    mock_options_values.pants_subprocessdir = "non_existent_dir"
+    ob = create_options_bootstrapper([])
     mock_server = unittest.mock.Mock()
 
     def create_services(bootstrap_options, legacy_graph_scheduler):
@@ -34,9 +32,9 @@ def test_close_stdio(mock_close):
         work_dir="test_work_dir",
         log_level=logging.INFO,
         server=mock_server,
-        core=PantsDaemonCore(PyExecutor(2, 4), create_services),
+        core=PantsDaemonCore(ob, PyExecutor(2, 4), create_services),
         metadata_base_dir="/tmp/pants_test_metadata_dir",
-        bootstrap_options=mock_options,
+        bootstrap_options=ob.bootstrap_options,
     )
 
     with stdio_as(-1, -1, -1):

--- a/tests/python/pants_test/pantsd/test_pants_daemon_core.py
+++ b/tests/python/pants_test/pantsd/test_pants_daemon_core.py
@@ -12,8 +12,13 @@ def test_prepare_scheduler():
     def create_services(bootstrap_options, legacy_graph_scheduler):
         return PantsServices()
 
-    core = PantsDaemonCore(PyExecutor(2, 4), create_services)
+    core = PantsDaemonCore(create_options_bootstrapper([]), PyExecutor(2, 4), create_services)
 
-    first_scheduler = core.prepare_scheduler(create_options_bootstrapper(["-ldebug"]))
-    second_scheduler = core.prepare_scheduler(create_options_bootstrapper(["-lwarn"]))
+    first_scheduler, first_options_initializer = core.prepare(
+        create_options_bootstrapper(["-ldebug"])
+    )
+    second_scheduler, second_options_initializer = core.prepare(
+        create_options_bootstrapper(["-lwarn"])
+    )
     assert first_scheduler is not second_scheduler
+    assert first_options_initializer is second_options_initializer


### PR DESCRIPTION
### Problem

#11536 moves from using POSIX-level replacement of the `stdio` file descriptors `{0, 1, 2}`, to replacing `sys.std*` with a thread-local implementation. Unfortunately, Python `subprocess`/`Popen` APIs hardcode `{0, 1, 2}` rather than actually inspecting `sys.std*.fileno()`, and so usages of those APIs that use `std*=None` (i.e. "inherit" mode), will inherit intentionally dead/closed file handles under `pantsd`.

PEX uses inherit mode when spawning `pip` (in order to pass through `stderr` to the parent process), and this runs afoul of the above behavior. Pants has used PEX as a library for a very long time, but 95% of usecases have now migrated to using PEX as a binary, with wrappers exposed via the `@rule` API. The `PluginResolver` that Pants uses to resolve its own code is the last usage of PEX as a library. 

### Solution

In a series of commits, introduce a "bootstrap" `Scheduler` that is able to resolve plugins after an `OptionsBootstrapper` has been created, but before creating the `BuildConfiguration` (which contains plugin information).

### Result

Although Pants has some stray references to PEX APIs, it no longer uses PEX as a library to resolve dependencies. #11536 and #7654 are unblocked.

In future, if the options required to construct a minimal scheduler can be further pruned, the bootstrap `Scheduler` might also be able to be used to create the `OptionsBootstrapper`, which would allow for addressing #10360.