### PR TITLE
Enable TLS for remoting in Python instead of Rust

### DIFF
--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -251,8 +251,8 @@ class Native(metaclass=SingletonMetaclass):
 
         remoting_options = PyRemotingOptions(
             execution_enable=execution_options.remote_execution,
-            store_servers=execution_options.remote_store_server,
-            execution_server=execution_options.remote_execution_server,
+            store_addresses=execution_options.remote_store_addresses,
+            execution_address=execution_options.remote_execution_address,
             execution_process_cache_namespace=execution_options.process_execution_cache_namespace,
             instance_name=execution_options.remote_instance_name,
             root_ca_certs_path=execution_options.remote_ca_certs_path,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -111,7 +111,7 @@ class ExecutionOptions:
     process_execution_use_local_cache: bool
     process_execution_local_enable_nailgun: bool
 
-    remote_store_server: List[str]
+    remote_store_addresses: list[str]
     remote_store_headers: Dict[str, str]
     remote_store_thread_count: int
     remote_store_chunk_bytes: Any
@@ -124,7 +124,7 @@ class ExecutionOptions:
 
     remote_cache_eager_fetch: bool
 
-    remote_execution_server: Optional[str]
+    remote_execution_address: str | None
     remote_execution_extra_platform_properties: List[str]
     remote_execution_headers: Dict[str, str]
     remote_execution_overall_deadline_secs: int
@@ -184,6 +184,16 @@ class ExecutionOptions:
                 remote_execution_headers = auth_plugin_result.execution_headers
                 remote_store_headers = auth_plugin_result.store_headers
 
+        # Prefix the remote servers with a scheme.
+        remote_address_scheme = "https://" if bootstrap_options.remote_ca_certs_path else "http://"
+        remote_execution_address = (
+            f"{remote_address_scheme}{bootstrap_options.remote_execution_server}"
+            if bootstrap_options.remote_execution_server else None
+        )
+        remote_store_addresses = [
+            f"{remote_address_scheme}{addr}" for addr in bootstrap_options.remote_store_server
+        ]
+
         return cls(
             # Remote execution strategy.
             remote_execution=remote_execution,
@@ -200,7 +210,7 @@ class ExecutionOptions:
             process_execution_cache_namespace=bootstrap_options.process_execution_cache_namespace,
             process_execution_local_enable_nailgun=bootstrap_options.process_execution_local_enable_nailgun,
             # Remote store setup.
-            remote_store_server=bootstrap_options.remote_store_server,
+            remote_store_addresses=remote_store_addresses,
             remote_store_headers=remote_store_headers,
             remote_store_thread_count=bootstrap_options.remote_store_thread_count,
             remote_store_chunk_bytes=bootstrap_options.remote_store_chunk_bytes,
@@ -213,7 +223,7 @@ class ExecutionOptions:
             # Remote cache setup.
             remote_cache_eager_fetch=bootstrap_options.remote_cache_eager_fetch,
             # Remote execution setup.
-            remote_execution_server=bootstrap_options.remote_execution_server,
+            remote_execution_address=remote_execution_address,
             remote_execution_extra_platform_properties=bootstrap_options.remote_execution_extra_platform_properties,
             remote_execution_headers=remote_execution_headers,
             remote_execution_overall_deadline_secs=bootstrap_options.remote_execution_overall_deadline_secs,
@@ -241,7 +251,7 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     process_execution_use_local_cache=True,
     process_execution_local_enable_nailgun=False,
     # Remote store setup.
-    remote_store_server=[],
+    remote_store_addresses=[],
     remote_store_headers={},
     remote_store_thread_count=1,
     remote_store_chunk_bytes=1024 * 1024,
@@ -254,7 +264,7 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     # Remote cache setup.
     remote_cache_eager_fetch=True,
     # Remote execution setup.
-    remote_execution_server=None,
+    remote_execution_address=None,
     remote_execution_extra_platform_properties=[],
     remote_execution_headers={},
     remote_execution_overall_deadline_secs=60 * 60,  # one hour
@@ -867,7 +877,7 @@ class GlobalOptions(Subsystem):
             "--remote-store-server",
             advanced=True,
             type=list,
-            default=DEFAULT_EXECUTION_OPTIONS.remote_store_server,
+            default=DEFAULT_EXECUTION_OPTIONS.remote_store_addresses,
             help="host:port of grpc server to use as remote execution file store.",
         )
         register(
@@ -953,6 +963,8 @@ class GlobalOptions(Subsystem):
         register(
             "--remote-execution-server",
             advanced=True,
+            type=str,
+            default=DEFAULT_EXECUTION_OPTIONS.remote_execution_address,
             help="host:port of grpc server to use as remote execution scheduler.",
         )
         register(

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -188,7 +188,8 @@ class ExecutionOptions:
         remote_address_scheme = "https://" if bootstrap_options.remote_ca_certs_path else "http://"
         remote_execution_address = (
             f"{remote_address_scheme}{bootstrap_options.remote_execution_server}"
-            if bootstrap_options.remote_execution_server else None
+            if bootstrap_options.remote_execution_server
+            else None
         )
         remote_store_addresses = [
             f"{remote_address_scheme}{addr}" for addr in bootstrap_options.remote_store_server

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -59,17 +59,7 @@ impl ByteStore {
       None => None,
     };
 
-    let scheme = if tls_client_config.is_some() {
-      "https"
-    } else {
-      "http"
-    };
-    let cas_addresses_with_scheme: Vec<_> = cas_addresses
-      .iter()
-      .map(|addr| format!("{}://{}", scheme, addr))
-      .collect();
-
-    let (endpoints, errors): (Vec<Endpoint>, Vec<String>) = cas_addresses_with_scheme
+    let (endpoints, errors): (Vec<Endpoint>, Vec<String>) = cas_addresses
       .iter()
       .map(|addr| grpc_util::create_endpoint(addr, tls_client_config.as_ref()))
       .partition_map(|result| match result {

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -63,14 +63,7 @@ impl CommandRunner {
       _ => None,
     };
 
-    let scheme = if tls_client_config.is_some() {
-      "https"
-    } else {
-      "http"
-    };
-    let address_with_scheme = format!("{}://{}", scheme, action_cache_address);
-
-    let endpoint = grpc_util::create_endpoint(&address_with_scheme, tls_client_config.as_ref())?;
+    let endpoint = grpc_util::create_endpoint(&action_cache_address, tls_client_config.as_ref())?;
     let channel = tonic::transport::Channel::balance_list(vec![endpoint].into_iter());
     let action_cache_client = Arc::new(if headers.is_empty() {
       ActionCacheClient::new(channel)

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -543,8 +543,8 @@ py_class!(class PyRemotingOptions |py| {
   def __new__(
     _cls,
     execution_enable: bool,
-    store_servers: Vec<String>,
-    execution_server: Option<String>,
+    store_addresses: Vec<String>,
+    execution_address: Option<String>,
     execution_process_cache_namespace: Option<String>,
     instance_name: Option<String>,
     root_ca_certs_path: Option<String>,
@@ -565,8 +565,8 @@ py_class!(class PyRemotingOptions |py| {
     Self::create_instance(py,
       RemotingOptions {
         execution_enable,
-        store_servers,
-        execution_server,
+        store_addresses,
+        execution_address,
         execution_process_cache_namespace,
         instance_name,
         root_ca_certs_path: root_ca_certs_path.map(PathBuf::from),


### PR DESCRIPTION
We want users to explicitly specify the scheme for their remote servers, which is how they'll enable/disable TLS post https://github.com/pantsbuild/pants/issues/11545. As prework, we move the setup of the scheme from Rust into Python.

We also rename the Rust code to use "address" instead of "server", which is the name we'll use for the new options where users will explicitly set the scheme.

[ci skip-rust]
[ci skip-build-wheels]