### PR TITLE
Deprecate `--remote-store-server` and `--remote-execution-server` in favor of `--remote-store-address` and `--remote-execution-address`

### DIFF
--- a/pants.remote-cache.toml
+++ b/pants.remote-cache.toml
@@ -1,12 +1,8 @@
 # Enable remote caching by running `./pants --pants-config-files=pants.remote-cache.toml`.
 #
-# You must also set:
-#
-#  - `remote_oauth_bearer_token_path`
-#  - `remote_ca_certs_path`, which is usually "/etc/ssl/certs/ca-certificates.crt" on Linux and
-#      "/usr/local/etc/openssl/cert.pem" on macOS.
-#
-# You may want to set those values in a pantsrc file or an `.envrc` file and use `direnv` (https://direnv.net/).
+# You must also set `remote_ca_certs_path`, which is usually "/etc/ssl/certs/ca-certificates.crt" on Linux and
+# "/usr/local/etc/openssl/cert.pem" on macOS. You may want to set this value in a pantsrc file or an `.envrc` file
+# and use `direnv` (https://direnv.net/).
 
 [GLOBAL]
 remote_cache_read = true
@@ -17,6 +13,6 @@ remote_store_timeout_multiplier = 1.5
 remote_store_maximum_timeout = 5000
 
 # NB: this is used for Toolchain's remote caching and may need to change for other implementations.
-remote_store_server = "build.toolchain.com:443"
+remote_store_address = "grpcs://build.toolchain.com:443"
 remote_instance_name = "main"
 remote_auth_plugin = "toolchain.pants.auth.plugin:toolchain_auth_plugin"

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -198,16 +198,30 @@ class ExecutionOptions:
                     )
                     remote_instance_name = auth_plugin_result.instance_name
 
-        # Prefix the remote servers with a scheme.
+        # Determine the remote servers.
+        # NB: Tonic expects the schemes `http` and `https`, even though they are gRPC requests.
+        # We have users set `grpc` and `grpcs` in the options system for clarity, but then
+        # normalize to `http`/`https`.
         remote_address_scheme = "https://" if bootstrap_options.remote_ca_certs_path else "http://"
-        remote_execution_address = (
-            f"{remote_address_scheme}{bootstrap_options.remote_execution_server}"
-            if bootstrap_options.remote_execution_server
-            else None
-        )
-        remote_store_addresses = [
-            f"{remote_address_scheme}{addr}" for addr in bootstrap_options.remote_store_server
-        ]
+        if bootstrap_options.remote_execution_address:
+            remote_execution_address = bootstrap_options.remote_execution_address.replace(
+                "grpc", "http"
+            )
+        elif bootstrap_options.remote_execution_server:
+            remote_execution_address = (
+                f"{remote_address_scheme}{bootstrap_options.remote_execution_server}"
+            )
+        else:
+            remote_execution_address = None
+
+        if bootstrap_options.remote_store_address:
+            remote_store_addresses = [
+                bootstrap_options.remote_store_address.replace("grpc", "http")
+            ]
+        else:
+            remote_store_addresses = [
+                f"{remote_address_scheme}{addr}" for addr in bootstrap_options.remote_store_server
+            ]
 
         return cls(
             # Remote execution strategy.
@@ -854,16 +868,17 @@ class GlobalOptions(Subsystem):
         register(
             "--remote-ca-certs-path",
             advanced=True,
-            help="Path to a PEM file containing CA certificates used for verifying secure "
-            "connections to --remote-execution-server and --remote-store-server. "
-            "If not specified, TLS will not be used.",
+            help=(
+                "Path to a PEM file containing CA certificates used for verifying secure "
+                "connections to --remote-execution-address and --remote-store-address."
+            ),
         )
         register(
             "--remote-oauth-bearer-token-path",
             advanced=True,
             help=(
                 "Path to a file containing an oauth token to use for gGRPC connections to "
-                "--remote-execution-server and --remote-store-server.\n\nIf specified, Pants will "
+                "--remote-execution-address and --remote-store-address.\n\nIf specified, Pants will "
                 "add a header in the format `authorization: Bearer <token>`. You can also manually "
                 "add this header via `--remote-execution-headers` and `--remote-store-headers`, or "
                 "use `--remote-auth-plugin` to provide a plugin to dynamically set the relevant "
@@ -901,6 +916,25 @@ class GlobalOptions(Subsystem):
             type=list,
             default=DEFAULT_EXECUTION_OPTIONS.remote_store_addresses,
             help="host:port of grpc server to use as remote execution file store.",
+            removal_version="2.4.0.dev0",
+            removal_hint=(
+                "Use `--remote-store-address` instead.\n\nNote that you must add the scheme "
+                "prefix `grpc://` or `grpcs://`, i.e. gRPC with TLS enabled.\n\n"
+                "`--remote-store-address` also is a string option, rather than list option; if you "
+                "still need support for multiple servers, please open a GitHub issue or reach out "
+                f"on Slack in the #remoting channel. See {docs_url('community')}."
+            ),
+        )
+        register(
+            "--remote-store-address",
+            advanced=True,
+            type=str,
+            default=None,
+            help=(
+                "The URI of a server used for the remote file store.\n\nFormat: "
+                "`scheme://host:port`. The supported schemes are `grpc` and `grpcs`, i.e. gRPC "
+                "with TLS enabled. If `grpc` is used, TLS will be disabled."
+            ),
         )
         register(
             "--remote-store-headers",
@@ -908,7 +942,7 @@ class GlobalOptions(Subsystem):
             type=dict,
             default=DEFAULT_EXECUTION_OPTIONS.remote_store_headers,
             help=(
-                "Headers to set on remote store requests. Format: header=value. Pants "
+                "Headers to set on remote store requests.\n\nFormat: header=value. Pants "
                 "may add additional headers.\n\nSee `--remote-execution-headers` as well."
             ),
         )
@@ -988,6 +1022,23 @@ class GlobalOptions(Subsystem):
             type=str,
             default=DEFAULT_EXECUTION_OPTIONS.remote_execution_address,
             help="host:port of grpc server to use as remote execution scheduler.",
+            removal_version="2.4.0.dev0",
+            removal_hint=(
+                "Use `--remote-execution-address` instead.\n\nNote that you must add the scheme "
+                "prefix `grpc://` or `grpcs://`, i.e. gRPC with TLS enabled."
+            ),
+        )
+        register(
+            "--remote-execution-address",
+            advanced=True,
+            type=str,
+            default=None,
+            help=(
+                "The URI of a server used as a remote execution scheduler.\n\nFormat: "
+                "`scheme://host:port`. The supported schemes are `grpc` and `grpcs`, i.e. gRPC "
+                "with TLS enabled. If `grpc` is used, TLS will be disabled.\n\nYou must also set "
+                "`--remote-store-address`, which will often be the same value."
+            ),
         )
         register(
             "--remote-execution-extra-platform-properties",
@@ -1151,14 +1202,32 @@ class GlobalOptions(Subsystem):
                 "enabled, it will already use remote caching."
             )
 
-        if opts.remote_execution and not opts.remote_execution_server:
+        if opts.remote_execution_address and opts.remote_execution_server:
+            raise OptionsError(
+                "Conflicting options used. You used the new, preferred remote_execution_address, "
+                "but also used the deprecated remote_execution_server.\n\nPlease use only of these "
+                "(preferably remote_execution_address)."
+            )
+        if opts.remote_store_address and opts.remote_store_server:
+            raise OptionsError(
+                "Conflicting options used. You used the new, preferred remote_store_address, but "
+                "also used the deprecated remote_store_server.\n\nPlease use only of these "
+                "(preferably remote_store_address)."
+            )
+        remote_execution_address_configured = (
+            opts.remote_execution_server or opts.remote_execution_address
+        )
+        remote_store_address_configured = opts.remote_store_server or opts.remote_store_address
+        if opts.remote_execution and not remote_execution_address_configured:
             raise OptionsError(
                 "The `--remote-execution` option requires also setting "
+                "either `--remote-execution-address` or the deprecated "
                 "`--remote-execution-server` to work properly."
             )
-        if opts.remote_execution_server and not opts.remote_store_server:
+        if remote_execution_address_configured and not remote_store_address_configured:
             raise OptionsError(
-                "The `--remote-execution-server` option requires also setting "
+                "The `--remote-execution-address` and deprecated `--remote-execution-server` "
+                "options require also setting `--remote-store-address` or the deprecated "
                 "`--remote-store-server`. Often these have the same value."
             )
 
@@ -1190,8 +1259,19 @@ class GlobalOptions(Subsystem):
                 "milliseconds."
             )
 
+        def validate_remote_address(opt_name: str) -> None:
+            valid_schemes = ["grpc", "grpcs"]
+            address = getattr(opts, opt_name)
+            if address and not any(address.startswith(f"{scheme}//:") for scheme in valid_schemes):
+                raise OptionsError(
+                    f"The `{opt_name}` option must begin with one of {valid_schemes}."
+                )
+
+        validate_remote_address("remote_execution_address")
+        validate_remote_address("remote_store_address")
+
         # Ensure that remote headers are ASCII.
-        def validate_headers(opt_name: str) -> None:
+        def validate_remote_headers(opt_name: str) -> None:
             command_line_opt_name = f"--{opt_name.replace('_', '-')}"
             for k, v in getattr(opts, opt_name).items():
                 if not k.isascii():
@@ -1205,5 +1285,5 @@ class GlobalOptions(Subsystem):
                         f"`{k}: {v}` has non-ASCII characters."
                     )
 
-        validate_headers("remote_execution_headers")
-        validate_headers("remote_store_headers")
+        validate_remote_headers("remote_execution_headers")
+        validate_remote_headers("remote_store_headers")

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -200,12 +200,12 @@ class ExecutionOptions:
 
         # Determine the remote servers.
         # NB: Tonic expects the schemes `http` and `https`, even though they are gRPC requests.
-        # We have users set `grpc` and `grpcs` in the options system for clarity, but then
+        # We validate that users set `grpc` and `grpcs` in the options system for clarity, but then
         # normalize to `http`/`https`.
         remote_address_scheme = "https://" if bootstrap_options.remote_ca_certs_path else "http://"
         if bootstrap_options.remote_execution_address:
             remote_execution_address = bootstrap_options.remote_execution_address.replace(
-                "grpc", "http"
+                "grpc", "http", 1
             )
         elif bootstrap_options.remote_execution_server:
             remote_execution_address = (
@@ -216,7 +216,7 @@ class ExecutionOptions:
 
         if bootstrap_options.remote_store_address:
             remote_store_addresses = [
-                bootstrap_options.remote_store_address.replace("grpc", "http")
+                bootstrap_options.remote_store_address.replace("grpc", "http", 1)
             ]
         else:
             remote_store_addresses = [
@@ -918,8 +918,8 @@ class GlobalOptions(Subsystem):
             help="host:port of grpc server to use as remote execution file store.",
             removal_version="2.4.0.dev0",
             removal_hint=(
-                "Use `--remote-store-address` instead.\n\nNote that you must add the scheme "
-                "prefix `grpc://` or `grpcs://`, i.e. gRPC with TLS enabled.\n\n"
+                "Use `--remote-store-address` instead.\n\nNote that you must add the prefix "
+                "`grpc://` or `grpcs://` to identify whether TLS should be used.\n\n"
                 "`--remote-store-address` also is a string option, rather than list option; if you "
                 "still need support for multiple servers, please open a GitHub issue or reach out "
                 f"on Slack in the #remoting channel. See {docs_url('community')}."
@@ -1024,8 +1024,8 @@ class GlobalOptions(Subsystem):
             help="host:port of grpc server to use as remote execution scheduler.",
             removal_version="2.4.0.dev0",
             removal_hint=(
-                "Use `--remote-execution-address` instead.\n\nNote that you must add the scheme "
-                "prefix `grpc://` or `grpcs://`, i.e. gRPC with TLS enabled."
+                "Use `--remote-execution-address` instead.\n\nNote that you must add the prefix "
+                "`grpc://` or `grpcs://` to identify whether TLS should be used."
             ),
         )
         register(

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -7,6 +7,7 @@ import enum
 import importlib
 import logging
 import os
+import re
 import sys
 import tempfile
 from dataclasses import dataclass
@@ -204,8 +205,8 @@ class ExecutionOptions:
         # normalize to `http`/`https`.
         remote_address_scheme = "https://" if bootstrap_options.remote_ca_certs_path else "http://"
         if bootstrap_options.remote_execution_address:
-            remote_execution_address = bootstrap_options.remote_execution_address.replace(
-                "grpc", "http", 1
+            remote_execution_address = re.sub(
+                r"^grpc", "http", bootstrap_options.remote_execution_address
             )
         elif bootstrap_options.remote_execution_server:
             remote_execution_address = (
@@ -216,7 +217,7 @@ class ExecutionOptions:
 
         if bootstrap_options.remote_store_address:
             remote_store_addresses = [
-                bootstrap_options.remote_store_address.replace("grpc", "http", 1)
+                re.sub(r"^grpc", "http", bootstrap_options.remote_store_address)
             ]
         else:
             remote_store_addresses = [

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1214,6 +1214,7 @@ class GlobalOptions(Subsystem):
                 "also used the deprecated remote_store_server.\n\nPlease use only of these "
                 "(preferably remote_store_address)."
             )
+
         remote_execution_address_configured = (
             opts.remote_execution_server or opts.remote_execution_address
         )
@@ -1231,15 +1232,17 @@ class GlobalOptions(Subsystem):
                 "`--remote-store-server`. Often these have the same value."
             )
 
-        if opts.remote_cache_read and not opts.remote_store_server:
+        if opts.remote_cache_read and not remote_store_address_configured:
             raise OptionsError(
                 "The `--remote-cache-read` option requires also setting "
-                "`--remote-store-server` to work properly."
+                "`--remote-store-address` or the deprecated `--remote-store-server` to work "
+                "properly."
             )
-        if opts.remote_cache_write and not opts.remote_store_server:
+        if opts.remote_cache_write and not remote_store_address_configured:
             raise OptionsError(
                 "The `--remote-cache-write` option requires also setting "
-                "`--remote-store-server` to work properly."
+                "`--remote-store-address` or the deprecated `--remote-store-server` to work "
+                "properly."
             )
 
         # Ensure that timeout values are non-zero.
@@ -1260,11 +1263,12 @@ class GlobalOptions(Subsystem):
             )
 
         def validate_remote_address(opt_name: str) -> None:
-            valid_schemes = ["grpc", "grpcs"]
+            valid_schemes = [f"{scheme}://" for scheme in ("grpc", "grpcs")]
             address = getattr(opts, opt_name)
-            if address and not any(address.startswith(f"{scheme}//:") for scheme in valid_schemes):
+            if address and not any(address.startswith(scheme) for scheme in valid_schemes):
                 raise OptionsError(
-                    f"The `{opt_name}` option must begin with one of {valid_schemes}."
+                    f"The `{opt_name}` option must begin with one of {valid_schemes}, but "
+                    f"was {address}."
                 )
 
         validate_remote_address("remote_execution_address")

--- a/src/python/pants/option/global_options_test.py
+++ b/src/python/pants/option/global_options_test.py
@@ -58,7 +58,7 @@ def test_execution_options_remote_oauth_bearer_token_path() -> None:
 
 def test_execution_options_remote_addresses() -> None:
     # Test that we properly validate and normalize the scheme.
-    host = "fake.com:10"
+    host = "fake-with-http-in-url.com:10"
     exec_options = create_execution_options(
         initial_headers={},
         remote_store_address=f"grpc://{host}",

--- a/src/python/pants/option/global_options_test.py
+++ b/src/python/pants/option/global_options_test.py
@@ -6,9 +6,11 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 from textwrap import dedent
-from typing import Dict, Optional
+
+import pytest
 
 from pants.init.options_initializer import OptionsInitializer
+from pants.option.errors import OptionsError
 from pants.option.global_options import ExecutionOptions
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.util.contextutil import temporary_dir
@@ -16,13 +18,16 @@ from pants.util.contextutil import temporary_dir
 
 def create_execution_options(
     *,
-    initial_headers: Dict[str, str],
-    token_path: Optional[str] = None,
-    plugin: Optional[str] = None,
+    initial_headers: dict[str, str],
+    token_path: str | None = None,
+    plugin: str | None = None,
+    remote_store_address: str = "grpc://fake.url:10",
+    remote_execution_address: str = "grpc://fake.url:10",
 ) -> ExecutionOptions:
     args = [
         "--remote-cache-read",
-        "--remote-store-server=www.fake.url",
+        f"--remote-execution-address={remote_execution_address}",
+        f"--remote-store-address={remote_store_address}",
         f"--remote-store-headers={initial_headers}",
         f"--remote-execution-headers={initial_headers}",
         "--remote-instance-name=main",
@@ -51,6 +56,39 @@ def test_execution_options_remote_oauth_bearer_token_path() -> None:
     }
 
 
+def test_execution_options_remote_addresses() -> None:
+    # Test that we properly validate and normalize the scheme.
+    host = "fake.com:10"
+    exec_options = create_execution_options(
+        initial_headers={},
+        remote_store_address=f"grpc://{host}",
+        remote_execution_address=f"grpc://{host}",
+    )
+    assert exec_options.remote_execution_address == f"http://{host}"
+    assert exec_options.remote_store_addresses == [f"http://{host}"]
+
+    exec_options = create_execution_options(
+        initial_headers={},
+        remote_store_address=f"grpcs://{host}",
+        remote_execution_address=f"grpcs://{host}",
+    )
+    assert exec_options.remote_execution_address == f"https://{host}"
+    assert exec_options.remote_store_addresses == [f"https://{host}"]
+
+    with pytest.raises(OptionsError):
+        create_execution_options(
+            initial_headers={},
+            remote_store_address=f"http://{host}",
+            remote_execution_address=f"grpc://{host}",
+        )
+    with pytest.raises(OptionsError):
+        create_execution_options(
+            initial_headers={},
+            remote_store_address=f"grpc://{host}",
+            remote_execution_address=f"https:://{host}",
+        )
+
+
 def test_execution_options_auth_plugin() -> None:
     def compute_exec_options(state: str) -> ExecutionOptions:
         with temporary_dir() as tempdir:
@@ -73,7 +111,7 @@ def test_execution_options_auth_plugin() -> None:
                             store_headers={{
                                 **{{k: "baz" for k in initial_store_headers}},
                                 "store": "abc",
-                                "store_url": options.for_global_scope().remote_store_server,
+                                "store_url": options.for_global_scope().remote_store_address,
                             }},
                             instance_name="custom_instance",
                         )
@@ -91,7 +129,7 @@ def test_execution_options_auth_plugin() -> None:
     assert exec_options.remote_store_headers == {
         "store": "abc",
         "foo": "baz",
-        "store_url": ["www.fake.url"],
+        "store_url": "www.fake.url",
     }
     assert exec_options.remote_execution_headers == {"exec": "xyz", "foo": "baz"}
     assert exec_options.remote_cache_read is True

--- a/src/python/pants/option/global_options_test.py
+++ b/src/python/pants/option/global_options_test.py
@@ -129,7 +129,7 @@ def test_execution_options_auth_plugin() -> None:
     assert exec_options.remote_store_headers == {
         "store": "abc",
         "foo": "baz",
-        "store_url": "www.fake.url",
+        "store_url": "grpc://fake.url:10",
     }
     assert exec_options.remote_execution_headers == {"exec": "xyz", "foo": "baz"}
     assert exec_options.remote_cache_read is True


### PR DESCRIPTION
This addresses two problems:

1. Fixes the remote store address to be a single string, rather than a list. The list was an old design requirement from Twitter, but it's unused and introduced additional complexity, such as client logic to shuffle which address is pinged first. That is better handled by the server than the client.
2. The user now explicitly sets the scheme `grpc://` or `grpcs://`. This provides an explicit toggle for whether to use TLS, which we will need for https://github.com/pantsbuild/pants/issues/11545.

[ci skip-rust]
[ci skip-build-wheels]