### PR TITLE
Auto-discover CA certs if TLS is used and `--remote-ca-certs-path` is unset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,6 @@ jobs:
       timeout: 500
     dist: bionic
     env:
-    - PANTS_REMOTE_CA_CERTS_PATH=/etc/ssl/certs/ca-certificates.crt
     - CACHE_NAME=bootstrap.linux.py37
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
     language: python
@@ -121,7 +120,6 @@ jobs:
       timeout: 500
     dist: bionic
     env:
-    - PANTS_REMOTE_CA_CERTS_PATH=/etc/ssl/certs/ca-certificates.crt
     - CACHE_NAME=bootstrap.linux.py38
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py38.linux
     language: python
@@ -265,7 +263,6 @@ jobs:
       timeout: 500
     dist: bionic
     env:
-    - PANTS_REMOTE_CA_CERTS_PATH=/etc/ssl/certs/ca-certificates.crt
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
     - CACHE_NAME=lint.py37
     language: python
@@ -315,7 +312,6 @@ jobs:
       timeout: 500
     dist: bionic
     env:
-    - PANTS_REMOTE_CA_CERTS_PATH=/etc/ssl/certs/ca-certificates.crt
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py38.linux
     - CACHE_NAME=lint.py38
     language: python
@@ -439,7 +435,6 @@ jobs:
       timeout: 500
     dist: bionic
     env:
-    - PANTS_REMOTE_CA_CERTS_PATH=/etc/ssl/certs/ca-certificates.crt
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
     - CACHE_NAME=python_tests.py37
     language: python
@@ -491,7 +486,6 @@ jobs:
       timeout: 500
     dist: bionic
     env:
-    - PANTS_REMOTE_CA_CERTS_PATH=/etc/ssl/certs/ca-certificates.crt
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py38.linux
     - CACHE_NAME=python_tests.py38
     language: python
@@ -611,7 +605,6 @@ jobs:
       timeout: 500
     dist: bionic
     env:
-    - PANTS_REMOTE_CA_CERTS_PATH=/etc/ssl/certs/ca-certificates.crt
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
     - PREPARE_DEPLOY=1
     - CACHE_NAME=wheels.linux
@@ -873,7 +866,6 @@ jobs:
       skip_cleanup: true
     dist: bionic
     env:
-    - PANTS_REMOTE_CA_CERTS_PATH=/etc/ssl/certs/ca-certificates.crt
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
     - RUN_PANTS_FROM_PEX=1
     - PANTS_PEX_RELEASE=stable
@@ -921,7 +913,6 @@ jobs:
       timeout: 500
     dist: bionic
     env:
-    - PANTS_REMOTE_CA_CERTS_PATH=/etc/ssl/certs/ca-certificates.crt
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
     - RUN_PANTS_FROM_PEX=1
     - PREPARE_DEPLOY=1

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -330,7 +330,7 @@ def linux_shard(
         ],
         "after_failure": ["./build-support/bin/ci-failure.sh"],
         "stage": python_version.default_stage().value,
-        "env": ["PANTS_REMOTE_CA_CERTS_PATH=/etc/ssl/certs/ca-certificates.crt"],
+        "env": [],
     }
     if load_test_config:
         setup["before_script"] = [AWS_GET_PANTS_PEX_COMMAND]

--- a/pants.remote-cache.toml
+++ b/pants.remote-cache.toml
@@ -1,8 +1,4 @@
 # Enable remote caching by running `./pants --pants-config-files=pants.remote-cache.toml`.
-#
-# You must also set `remote_ca_certs_path`, which is usually "/etc/ssl/certs/ca-certificates.crt" on Linux and
-# "/usr/local/etc/openssl/cert.pem" on macOS. You may want to set this value in a pantsrc file or an `.envrc` file
-# and use `direnv` (https://direnv.net/).
 
 [GLOBAL]
 remote_cache_read = true

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -871,7 +871,9 @@ class GlobalOptions(Subsystem):
             advanced=True,
             help=(
                 "Path to a PEM file containing CA certificates used for verifying secure "
-                "connections to --remote-execution-address and --remote-store-address."
+                "connections to --remote-execution-address and --remote-store-address.\n\nIf "
+                "unspecified, Pants will attempt to auto-discover root CA certificates when TLS "
+                "is enabled with remote execution and caching."
             ),
         )
         register(

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1032,6 +1032,7 @@ dependencies = [
  "futures",
  "prost",
  "prost-types",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tokio-util 0.2.0",
@@ -1377,9 +1378,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
 
 [[package]]
 name = "lmdb"

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -54,9 +54,14 @@ impl ByteStore {
     rpc_retries: usize,
     _connection_limit: usize,
   ) -> Result<ByteStore, String> {
-    let tls_client_config = match root_ca_certs {
-      Some(pem_bytes) => Some(grpc_util::create_tls_config(pem_bytes)?),
-      None => None,
+    let tls_client_config = if cas_addresses
+      .first()
+      .map(|addr| addr.starts_with("https://"))
+      .unwrap_or(false)
+    {
+      Some(grpc_util::create_tls_config(root_ca_certs)?)
+    } else {
+      None
     };
 
     let (endpoints, errors): (Vec<Endpoint>, Vec<String>) = cas_addresses

--- a/src/rust/engine/grpc_util/Cargo.toml
+++ b/src/rust/engine/grpc_util/Cargo.toml
@@ -10,6 +10,7 @@ bytes = "0.5"
 futures = "0.3"
 prost = "0.6"
 prost-types = "0.6"
+rustls-native-certs = "0.4"
 tokio = { version = "0.2.23", features = ["process", "rt-threaded", "sync", "tcp", "time"] }
 tokio-rustls = "0.14"
 tokio-util = { version = "0.2", features = ["codec"] }

--- a/src/rust/engine/grpc_util/src/lib.rs
+++ b/src/rust/engine/grpc_util/src/lib.rs
@@ -31,7 +31,6 @@ use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::str::FromStr;
 
-use rustls_native_certs;
 use tokio_rustls::rustls::ClientConfig;
 use tonic::metadata::{AsciiMetadataKey, AsciiMetadataValue, KeyAndValueRef, MetadataMap};
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
@@ -88,7 +87,6 @@ pub fn create_tls_config(root_ca_certs: Option<Vec<u8>>) -> Result<ClientConfig,
             the correct PEM file.\n\n{}",
             e
           )
-          .to_owned()
         })?;
     }
   }

--- a/src/rust/engine/grpc_util/src/lib.rs
+++ b/src/rust/engine/grpc_util/src/lib.rs
@@ -31,6 +31,7 @@ use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::str::FromStr;
 
+use rustls_native_certs;
 use tokio_rustls::rustls::ClientConfig;
 use tonic::metadata::{AsciiMetadataKey, AsciiMetadataValue, KeyAndValueRef, MetadataMap};
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
@@ -55,8 +56,9 @@ pub fn create_endpoint(
   Ok(maybe_tls_endpoint)
 }
 
-/// Create a rust-tls `ClientConfig` from root CA certs.
-pub fn create_tls_config(pem_bytes: Vec<u8>) -> Result<ClientConfig, String> {
+/// Create a rust-tls `ClientConfig` from root CA certs, falling back to the rust-tls-native-certs
+/// crate if specific root CA certs were not given.
+pub fn create_tls_config(root_ca_certs: Option<Vec<u8>>) -> Result<ClientConfig, String> {
   let mut tls_config = ClientConfig::new();
 
   // Must set HTTP/2 as ALPN protocol otherwise cannot connect over TLS to gRPC servers.
@@ -64,11 +66,32 @@ pub fn create_tls_config(pem_bytes: Vec<u8>) -> Result<ClientConfig, String> {
   // any helper function to encapsulate this knowledge.
   tls_config.set_protocols(&[Vec::from(&"h2"[..])]);
 
-  let mut reader = std::io::Cursor::new(pem_bytes);
-  tls_config
-    .root_store
-    .add_pem_file(&mut reader)
-    .map_err(|_| "unexpected state in PEM file add".to_owned())?;
+  // Add the root store.
+  match root_ca_certs {
+    Some(pem_bytes) => {
+      let mut reader = std::io::Cursor::new(pem_bytes);
+      tls_config
+        .root_store
+        .add_pem_file(&mut reader)
+        .map_err(|_| {
+          "Unexpected state when adding PEM file from `--remote-ca-certs-path`. Please \
+          check that it points to a valid file."
+            .to_owned()
+        })?;
+    }
+    None => {
+      tls_config.root_store =
+        rustls_native_certs::load_native_certs().map_err(|(_maybe_store, e)| {
+          format!(
+            "Could not discover root CA cert files to use TLS with remote caching and remote \
+            execution. Consider setting `--remote-ca-certs-path` instead to explicitly point to \
+            the correct PEM file.\n\n{}",
+            e
+          )
+          .to_owned()
+        })?;
+    }
+  }
 
   Ok(tls_config)
 }

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -58,9 +58,10 @@ impl CommandRunner {
     cache_write: bool,
     eager_fetch: bool,
   ) -> Result<Self, String> {
-    let tls_client_config = match root_ca_certs {
-      Some(pem_bytes) => Some(grpc_util::create_tls_config(pem_bytes)?),
-      _ => None,
+    let tls_client_config = if action_cache_address.starts_with("https://") {
+      Some(grpc_util::create_tls_config(root_ca_certs)?)
+    } else {
+      None
     };
 
     let endpoint = grpc_util::create_endpoint(&action_cache_address, tls_client_config.as_ref())?;


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/11545. This makes it easier for folks to get set up with remote caching and execution.

Users can still set their own cert file with `--remote-ca-certs-path`.

By now setting up TLS based on the scheme used for `--remote-store-address` and `--remote-execution-address`, rather than if `--remote-ca-certs-path` is set, users can now optionally use TLS for only the store or only remote execution, for example.

[ci skip-rust]
[ci skip-build-wheels]