### PR TITLE
Expose all counter names to streaming workunit handlers

### DIFF
--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -1,6 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import getpass
 import logging
 import os
@@ -188,3 +190,7 @@ class RunTracker:
             logger.warning("Error retrieving per-run logs from RunTracker.", exc_info=e)
 
         return output
+
+    @property
+    def counter_names(self) -> tuple[str, ...]:
+        return tuple(self.native.lib.all_counter_names())

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -2959,6 +2959,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c"
+
+[[package]]
+name = "strum_macros"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
+dependencies = [
+ "heck",
+ "proc-macro2 1.0.24",
+ "quote 1.0.8",
+ "syn 1.0.55",
+]
+
+[[package]]
 name = "syn"
 version = "0.15.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3828,6 +3846,8 @@ dependencies = [
  "parking_lot",
  "petgraph 0.4.13",
  "rand 0.6.5",
+ "strum",
+ "strum_macros",
  "tokio",
  "uuid",
 ]

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1062,7 +1062,7 @@ async fn workunit_to_py_value(
       .iter()
       .map(|(counter_name, counter_value)| {
         (
-          externs::store_utf8(counter_name.as_str()),
+          externs::store_utf8(counter_name.as_ref()),
           externs::store_u64(*counter_value),
         )
       })

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -70,7 +70,7 @@ use rule_graph::{self, RuleGraph};
 use std::collections::hash_map::HashMap;
 use task_executor::Executor;
 use workunit_store::{
-  ArtifactOutput, ObservationMetric, UserMetadataItem, Workunit, WorkunitState,
+  ArtifactOutput, Metric, ObservationMetric, UserMetadataItem, Workunit, WorkunitState,
 };
 
 use crate::{
@@ -321,6 +321,7 @@ py_module_initializer!(native_engine, |py, m| {
       session_record_test_observation(a: PyScheduler, b: PySession, c: u64)
     ),
   )?;
+  m.add(py, "all_counter_names", py_fn!(py, all_counter_names()))?;
 
   m.add(
     py,
@@ -1147,6 +1148,10 @@ fn scheduler_metrics(
       externs::store_dict(values).map(|d| d.consume_into_py_object(py))
     })
   })
+}
+
+fn all_counter_names(_: Python) -> CPyResult<Vec<String>> {
+  Ok(Metric::all_metrics())
 }
 
 fn scheduler_execute(

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -15,4 +15,6 @@ rand = "0.6"
 tokio = { version = "0.2.23", features = ["rt-util"] }
 petgraph = "0.4.5"
 log = "0.4"
+strum = "0.20"
+strum_macros = "0.20"
 uuid = { version = "0.7", features = ["v4"] }

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -749,12 +749,12 @@ impl WorkunitStore {
         .map_err(|err| {
           format!(
             "Failed to encode histogram for key `{}`: {}",
-            metric.as_str(),
+            metric.as_ref(),
             err
           )
         })?;
 
-      result.insert(metric.as_str().to_owned(), writer.into_inner().freeze());
+      result.insert(metric.as_ref().to_owned(), writer.into_inner().freeze());
     }
 
     Ok(result)

--- a/src/rust/engine/workunit_store/src/metrics.rs
+++ b/src/rust/engine/workunit_store/src/metrics.rs
@@ -27,7 +27,10 @@ clippy::unseparated_literal_suffix,
 // Arc<Mutex> can be more clear than needing to grok Orderings:
 #![allow(clippy::mutex_atomic)]
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+use strum_macros::AsRefStr;
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, AsRefStr)]
+#[strum(serialize_all = "snake_case")]
 pub enum Metric {
   LocalCacheRequests,
   LocalCacheRequestsCached,
@@ -54,57 +57,11 @@ pub enum Metric {
   RemoteExecutionTimeouts,
 }
 
-impl Metric {
-  pub fn as_str(&self) -> &'static str {
-    use Metric::*;
-
-    match *self {
-      LocalCacheRequests => "local_cache_requests",
-      LocalCacheRequestsCached => "local_cache_requests_cached",
-      LocalCacheRequestsUncached => "local_cache_requests_uncached",
-      LocalCacheReadErrors => "local_cache_read_errors",
-      LocalCacheWriteErrors => "local_cache_write_errors",
-      LocalExecutionRequests => "local_execution_requests",
-      RemoteCacheRequests => "remote_cache_requests",
-      RemoteCacheRequestsCached => "remote_cache_requests_cached",
-      RemoteCacheRequestsUncached => "remote_cache_requests_uncached",
-      RemoteCacheReadErrors => "remote_cache_read_errors",
-      RemoteCacheWriteErrors => "remote_cache_write_errors",
-      RemoteCacheWriteStarted => "remote_cache_write_started",
-      RemoteCacheWriteFinished => "remote_cache_write_finished",
-      RemoteCacheSpeculationLocalCompletedFirst => "remote_cache_speculation_local_completed_first",
-      RemoteCacheSpeculationRemoteCompletedFirst => {
-        "remote_cache_speculation_remote_completed_first"
-      }
-      RemoteExecutionErrors => "remote_execution_errors",
-      RemoteExecutionRequests => "remote_execution_requests",
-      RemoteExecutionRPCRetries => "remote_execution_rpc_retries",
-      RemoteExecutionRPCErrors => "remote_execution_rpc_errors",
-      RemoteExecutionRPCExecute => "remote_execution_rpc_execute",
-      RemoteExecutionRPCWaitExecution => "remote_execution_rpc_wait_execution",
-      RemoteExecutionSuccess => "remote_execution_success",
-      RemoteExecutionTimeouts => "remote_execution_timeouts",
-    }
-  }
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, AsRefStr)]
+#[strum(serialize_all = "snake_case")]
 pub enum ObservationMetric {
   TestObservation,
   LocalStoreReadBlobSize,
   RemoteExecutionRPCFirstResponseTime,
   RemoteStoreTimeToFirstByte,
-}
-
-impl ObservationMetric {
-  pub fn as_str(&self) -> &'static str {
-    use ObservationMetric::*;
-
-    match *self {
-      TestObservation => "test_observation",
-      LocalStoreReadBlobSize => "local_store_read_blob_size",
-      RemoteExecutionRPCFirstResponseTime => "remote_execution_rpc_first_response_time",
-      RemoteStoreTimeToFirstByte => "remote_store_time_to_first_byte",
-    }
-  }
 }

--- a/src/rust/engine/workunit_store/src/metrics.rs
+++ b/src/rust/engine/workunit_store/src/metrics.rs
@@ -27,9 +27,20 @@ clippy::unseparated_literal_suffix,
 // Arc<Mutex> can be more clear than needing to grok Orderings:
 #![allow(clippy::mutex_atomic)]
 
-use strum_macros::AsRefStr;
+use std::string::ToString;
+use strum::IntoEnumIterator;
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, AsRefStr)]
+#[derive(
+  Clone,
+  Copy,
+  PartialEq,
+  Eq,
+  Hash,
+  Debug,
+  strum_macros::AsRefStr,
+  strum_macros::EnumIter,
+  strum_macros::ToString,
+)]
 #[strum(serialize_all = "snake_case")]
 pub enum Metric {
   LocalCacheRequests,
@@ -57,7 +68,13 @@ pub enum Metric {
   RemoteExecutionTimeouts,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, AsRefStr)]
+impl Metric {
+  pub fn all_metrics() -> Vec<String> {
+    Metric::iter().map(|variant| variant.to_string()).collect()
+  }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, strum_macros::AsRefStr)]
 #[strum(serialize_all = "snake_case")]
 pub enum ObservationMetric {
   TestObservation,


### PR DESCRIPTION
Currently, counters are only reported if their value is >0. However, it can be useful for consumers to know when a counter is set to 0, e.g. having positive confirmation that there were 0 remote caching errors.

We still keep individual workunits as only recording what counters were actually used; this keeps that code simpler and avoids unnecessary allocations.

Instead, we add a new property to `RunTracker` to access a list of all the counter names. Consumers can use this to then backtrack what is missing, so infer the count is 0. The `RunTracker` can be accessed via `StreamingWorkunitContext`.
