### PR TITLE
Fix broken Rust remoting tests

### DIFF
--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -231,7 +231,7 @@ async fn write_file_errors() {
 #[tokio::test]
 async fn write_connection_error() {
   let store = ByteStore::new(
-    vec![String::from("doesnotexist.example")],
+    vec![String::from("http://doesnotexist.example")],
     None,
     None,
     BTreeMap::new(),

--- a/src/rust/engine/testutil/mock/src/action_cache.rs
+++ b/src/rust/engine/testutil/mock/src/action_cache.rs
@@ -184,6 +184,6 @@ impl StubActionCache {
   /// The address on which this server is listening over insecure HTTP transport.
   ///
   pub fn address(&self) -> String {
-    format!("{}", self.local_addr)
+    format!("http://{}", self.local_addr)
   }
 }

--- a/src/rust/engine/testutil/mock/src/cas.rs
+++ b/src/rust/engine/testutil/mock/src/cas.rs
@@ -222,7 +222,7 @@ impl StubCAS {
   /// The address on which this server is listening over insecure HTTP transport.
   ///
   pub fn address(&self) -> String {
-    format!("{}", self.local_addr)
+    format!("http://{}", self.local_addr)
   }
 
   pub fn read_request_count(&self) -> usize {

--- a/src/rust/engine/testutil/mock/src/execution_server.rs
+++ b/src/rust/engine/testutil/mock/src/execution_server.rs
@@ -159,7 +159,7 @@ impl TestServer {
   /// The address on which this server is listening over insecure HTTP transport.
   ///
   pub fn address(&self) -> String {
-    format!("{}", self.local_addr)
+    format!("http://{}", self.local_addr)
   }
 }
 

--- a/tests/python/pants_test/integration/remote_cache_integration_test.py
+++ b/tests/python/pants_test/integration/remote_cache_integration_test.py
@@ -13,7 +13,6 @@ def test_warns_on_remote_cache_errors():
     builder = PyStubCAS.builder()
     builder.always_errors()
     cas = builder.build(executor)
-    address = cas.address()
 
     pants_run = run_pants(
         [
@@ -28,7 +27,9 @@ def test_warns_on_remote_cache_errors():
             GLOBAL_SCOPE_CONFIG_SECTION: {
                 "remote_cache_read": True,
                 "remote_cache_write": True,
-                "remote_store_server": address,
+                # NB: Our options code expects `grpc://`, which it will then convert back to
+                # `http://` before sending over FFI.
+                "remote_store_address": cas.address().replace("http://", "grpc://"),
             }
         },
     )


### PR DESCRIPTION
This was a regression from https://github.com/pantsbuild/pants/pull/11569 and wasn't caught due to `[ci skip-rust]`.