### PR TITLE
Use PEP 604 for some type hints

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import DefaultDict, Dict, List, Optional, Set, Tuple, cast
+from typing import DefaultDict, Dict, List, Set, Tuple, cast
 
 from pants.backend.python.target_types import (
     ModuleMappingField,
@@ -162,7 +162,7 @@ async def map_first_party_python_targets_to_modules(
 
 
 class ThirdPartyPythonModuleMapping(FrozenDict[str, Address]):
-    def address_for_module(self, module: str) -> Optional[Address]:
+    def address_for_module(self, module: str) -> Address | None:
         address = self.get(module)
         if address is not None:
             return address

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -1,7 +1,9 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import List, Optional, cast
+from __future__ import annotations
+
+from typing import List, cast
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.engine.addresses import UnparsedAddressInputs
@@ -71,8 +73,8 @@ class Pylint(PythonToolBase):
         return cast(List[str], self.options.args)
 
     @property
-    def config(self) -> Optional[str]:
-        return cast(Optional[str], self.options.config)
+    def config(self) -> str | None:
+        return cast("str | None", self.options.config)
 
     @property
     def source_plugins(self) -> UnparsedAddressInputs:

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -1,7 +1,9 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Optional, Tuple, cast
+from __future__ import annotations
+
+from typing import Tuple, cast
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.engine.addresses import UnparsedAddressInputs
@@ -67,8 +69,8 @@ class MyPy(PythonToolBase):
         return tuple(self.options.args)
 
     @property
-    def config(self) -> Optional[str]:
-        return cast(Optional[str], self.options.config)
+    def config(self) -> str | None:
+        return cast("str | None", self.options.config)
 
     @property
     def source_plugins(self) -> UnparsedAddressInputs:

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -12,18 +12,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import PurePath
 from textwrap import dedent
-from typing import (
-    FrozenSet,
-    Iterable,
-    List,
-    Mapping,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    TypeVar,
-    Union,
-)
+from typing import FrozenSet, Iterable, List, Mapping, Sequence, Set, Tuple, TypeVar
 
 from pkg_resources import Requirement
 from typing_extensions import Protocol
@@ -102,7 +91,7 @@ _FS = TypeVar("_FS", bound=FieldSetWithInterpreterConstraints)
 
 # Normally we would subclass `DeduplicatedCollection`, but we want a custom constructor.
 class PexInterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter):
-    def __init__(self, constraints: Iterable[Union[str, Requirement]] = ()) -> None:
+    def __init__(self, constraints: Iterable[str | Requirement] = ()) -> None:
         super().__init__(
             v if isinstance(v, Requirement) else self.parse_constraint(v)
             for v in sorted(constraints, key=lambda c: str(c))
@@ -249,7 +238,7 @@ class PexInterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParame
         last_py27_patch_version = 18
         return self._includes_version("2.7", last_patch=last_py27_patch_version)
 
-    def minimum_python_version(self) -> Optional[str]:
+    def minimum_python_version(self) -> str | None:
         """Find the lowest major.minor Python version that will work with these constraints.
 
         The constraints may also be compatible with later versions; this is the lowest version that
@@ -327,12 +316,12 @@ class PexRequest(EngineAwareParameter):
     requirements: PexRequirements
     interpreter_constraints: PexInterpreterConstraints
     platforms: PexPlatforms
-    sources: Optional[Digest]
-    additional_inputs: Optional[Digest]
-    entry_point: Optional[str]
+    sources: Digest | None
+    additional_inputs: Digest | None
+    entry_point: str | None
     additional_args: Tuple[str, ...]
     pex_path: Tuple[Pex, ...]
-    description: Optional[str] = dataclasses.field(compare=False)
+    description: str | None = dataclasses.field(compare=False)
 
     def __init__(
         self,
@@ -342,12 +331,12 @@ class PexRequest(EngineAwareParameter):
         requirements: PexRequirements = PexRequirements(),
         interpreter_constraints=PexInterpreterConstraints(),
         platforms=PexPlatforms(),
-        sources: Optional[Digest] = None,
-        additional_inputs: Optional[Digest] = None,
-        entry_point: Optional[str] = None,
+        sources: Digest | None = None,
+        additional_inputs: Digest | None = None,
+        entry_point: str | None = None,
         additional_args: Iterable[str] = (),
         pex_path: Iterable[Pex] = (),
-        description: Optional[str] = None,
+        description: str | None = None,
     ) -> None:
         """A request to create a PEX from its inputs.
 
@@ -418,7 +407,7 @@ class Pex:
 
     digest: Digest
     name: str
-    python: Optional[PythonExecutable]
+    python: PythonExecutable | None
 
 
 @dataclass(frozen=True)
@@ -496,7 +485,7 @@ class BuildPexResult:
     result: ProcessResult
     pex_filename: str
     digest: Digest
-    python: Optional[PythonExecutable]
+    python: PythonExecutable | None
 
     def create_pex(self) -> Pex:
         return Pex(digest=self.digest, name=self.pex_filename, python=self.python)
@@ -527,7 +516,7 @@ async def build_pex(
         *request.additional_args,
     ]
 
-    python: Optional[PythonExecutable] = None
+    python: PythonExecutable | None = None
 
     # NB: If `--platform` is specified, this signals that the PEX should not be built locally.
     # `--interpreter-constraint` only makes sense in the context of building locally. These two
@@ -813,7 +802,7 @@ async def two_step_create_pex(two_step_pex_request: TwoStepPexRequest) -> TwoSte
     request = two_step_pex_request.pex_request
     req_pex_name = "__requirements.pex"
 
-    additional_inputs: Optional[Digest]
+    additional_inputs: Digest | None
 
     # Create a pex containing just the requirements.
     if request.requirements:
@@ -857,13 +846,13 @@ class PexProcess:
     argv: Tuple[str, ...]
     description: str = dataclasses.field(compare=False)
     level: LogLevel
-    input_digest: Optional[Digest]
-    extra_env: Optional[FrozenDict[str, str]]
-    output_files: Optional[Tuple[str, ...]]
-    output_directories: Optional[Tuple[str, ...]]
-    timeout_seconds: Optional[int]
-    execution_slot_variable: Optional[str]
-    cache_scope: Optional[ProcessCacheScope]
+    input_digest: Digest | None
+    extra_env: FrozenDict[str, str] | None
+    output_files: tuple[str, ...] | None
+    output_directories: tuple[str, ...] | None
+    timeout_seconds: int | None
+    execution_slot_variable: str | None
+    cache_scope: ProcessCacheScope | None
 
     def __init__(
         self,
@@ -872,13 +861,13 @@ class PexProcess:
         description: str,
         argv: Iterable[str] = (),
         level: LogLevel = LogLevel.INFO,
-        input_digest: Optional[Digest] = None,
-        extra_env: Optional[Mapping[str, str]] = None,
-        output_files: Optional[Iterable[str]] = None,
-        output_directories: Optional[Iterable[str]] = None,
-        timeout_seconds: Optional[int] = None,
-        execution_slot_variable: Optional[str] = None,
-        cache_scope: Optional[ProcessCacheScope] = None,
+        input_digest: Digest | None = None,
+        extra_env: Mapping[str, str] | None = None,
+        output_files: Iterable[str] | None = None,
+        output_directories: Iterable[str] | None = None,
+        timeout_seconds: int | None = None,
+        execution_slot_variable: str | None = None,
+        cache_scope: ProcessCacheScope | None = None,
     ) -> None:
         self.pex = pex
         self.argv = tuple(argv)
@@ -927,13 +916,13 @@ class VenvPexProcess:
     argv: Tuple[str, ...]
     description: str = dataclasses.field(compare=False)
     level: LogLevel
-    input_digest: Optional[Digest]
-    extra_env: Optional[FrozenDict[str, str]]
-    output_files: Optional[Tuple[str, ...]]
-    output_directories: Optional[Tuple[str, ...]]
-    timeout_seconds: Optional[int]
-    execution_slot_variable: Optional[str]
-    cache_scope: Optional[ProcessCacheScope]
+    input_digest: Digest | None
+    extra_env: FrozenDict[str, str] | None
+    output_files: tuple[str, ...] | None
+    output_directories: tuple[str, ...] | None
+    timeout_seconds: int | None
+    execution_slot_variable: str | None
+    cache_scope: ProcessCacheScope | None
 
     def __init__(
         self,
@@ -942,13 +931,13 @@ class VenvPexProcess:
         description: str,
         argv: Iterable[str] = (),
         level: LogLevel = LogLevel.INFO,
-        input_digest: Optional[Digest] = None,
-        extra_env: Optional[Mapping[str, str]] = None,
-        output_files: Optional[Iterable[str]] = None,
-        output_directories: Optional[Iterable[str]] = None,
-        timeout_seconds: Optional[int] = None,
-        execution_slot_variable: Optional[str] = None,
-        cache_scope: Optional[ProcessCacheScope] = None,
+        input_digest: Digest | None = None,
+        extra_env: Mapping[str, str] | None = None,
+        output_files: Iterable[str] | None = None,
+        output_directories: Iterable[str] | None = None,
+        timeout_seconds: int | None = None,
+        execution_slot_variable: str | None = None,
+        cache_scope: ProcessCacheScope | None = None,
     ) -> None:
         self.venv_pex = venv_pex
         self.argv = tuple(argv)

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -7,7 +7,7 @@ import dataclasses
 import itertools
 import logging
 from dataclasses import dataclass
-from typing import Iterable, Optional, Tuple
+from typing import Iterable, Tuple
 
 from packaging.utils import canonicalize_name as canonicalize_project_name
 from pkg_resources import Requirement
@@ -57,18 +57,18 @@ class PexFromTargetsRequest:
     addresses: Addresses
     output_filename: str
     internal_only: bool
-    entry_point: Optional[str]
+    entry_point: str | None
     platforms: PexPlatforms
     additional_args: Tuple[str, ...]
     additional_requirements: Tuple[str, ...]
     include_source_files: bool
-    additional_sources: Optional[Digest]
-    additional_inputs: Optional[Digest]
-    hardcoded_interpreter_constraints: Optional[PexInterpreterConstraints]
+    additional_sources: Digest | None
+    additional_inputs: Digest | None
+    hardcoded_interpreter_constraints: PexInterpreterConstraints | None
     direct_deps_only: bool
     # This field doesn't participate in comparison (and therefore hashing), as it doesn't affect
     # the result.
-    description: Optional[str] = dataclasses.field(compare=False)
+    description: str | None = dataclasses.field(compare=False)
 
     def __init__(
         self,
@@ -76,16 +76,16 @@ class PexFromTargetsRequest:
         *,
         output_filename: str,
         internal_only: bool,
-        entry_point: Optional[str] = None,
+        entry_point: str | None = None,
         platforms: PexPlatforms = PexPlatforms(),
         additional_args: Iterable[str] = (),
         additional_requirements: Iterable[str] = (),
         include_source_files: bool = True,
-        additional_sources: Optional[Digest] = None,
-        additional_inputs: Optional[Digest] = None,
-        hardcoded_interpreter_constraints: Optional[PexInterpreterConstraints] = None,
+        additional_sources: Digest | None = None,
+        additional_inputs: Digest | None = None,
+        hardcoded_interpreter_constraints: PexInterpreterConstraints | None = None,
         direct_deps_only: bool = False,
-        description: Optional[str] = None,
+        description: str | None = None,
     ) -> None:
         """Request to create a Pex from the transitive closure of the given addresses.
 
@@ -139,7 +139,7 @@ class PexFromTargetsRequest:
         addresses: Iterable[Address],
         *,
         internal_only: bool,
-        hardcoded_interpreter_constraints: Optional[PexInterpreterConstraints] = None,
+        hardcoded_interpreter_constraints: PexInterpreterConstraints | None = None,
         zip_safe: bool = False,
         direct_deps_only: bool = False,
     ) -> PexFromTargetsRequest:

--- a/src/python/pants/backend/python/util_rules/python_sources_test.py
+++ b/src/python/pants/backend/python/util_rules/python_sources_test.py
@@ -1,8 +1,10 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 from textwrap import dedent
-from typing import Iterable, List, Optional, Type
+from typing import Iterable, List, Type
 
 import pytest
 
@@ -62,8 +64,8 @@ def get_stripped_sources(
     *,
     include_resources: bool = True,
     include_files: bool = False,
-    source_roots: Optional[List[str]] = None,
-    extra_args: Optional[List[str]] = None,
+    source_roots: list[str] | None = None,
+    extra_args: list[str] | None = None,
 ) -> StrippedPythonSourceFiles:
     rule_runner.set_options(
         [
@@ -88,8 +90,8 @@ def get_unstripped_sources(
     *,
     include_resources: bool = True,
     include_files: bool = False,
-    source_roots: Optional[List[str]] = None,
-    extra_args: Optional[List[str]] = None,
+    source_roots: list[str] | None = None,
+    extra_args: list[str] | None = None,
 ) -> PythonSourceFiles:
     rule_runner.set_options(
         [

--- a/src/python/pants/base/hash_utils.py
+++ b/src/python/pants/base/hash_utils.py
@@ -1,6 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import hashlib
 import json
 import logging
@@ -8,7 +10,7 @@ import typing
 from collections import OrderedDict
 from collections.abc import Iterable, Mapping, Set
 from enum import Enum
-from typing import Any, Optional, Type, Union
+from typing import Any
 
 from pants.util.ordered_set import OrderedSet
 from pants.util.strutil import ensure_binary
@@ -16,7 +18,7 @@ from pants.util.strutil import ensure_binary
 logger = logging.getLogger(__name__)
 
 
-def hash_all(strs: typing.Iterable[Union[bytes, str]]) -> str:
+def hash_all(strs: typing.Iterable[bytes | str]) -> str:
     """Returns a hash of the concatenation of all the strings in strs using sha1."""
     digest = hashlib.sha1()
     for s in strs:
@@ -104,7 +106,7 @@ class CoercingEncoder(json.JSONEncoder):
         return super().encode(self.default(o))
 
 
-def json_hash(obj: Any, encoder: Optional[Type[json.JSONEncoder]] = CoercingEncoder) -> str:
+def json_hash(obj: Any, encoder: type[json.JSONEncoder] | None = CoercingEncoder) -> str:
     """Hashes `obj` by dumping to JSON.
 
     :API: public

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -7,7 +7,7 @@ import itertools
 import os
 from abc import ABC, ABCMeta, abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Iterable, Mapping, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Iterable, Mapping, Sequence, Tuple
 
 from pants.base.exceptions import ResolveError
 from pants.build_graph.address import Address
@@ -256,8 +256,8 @@ class FilesystemIgnoreSpec(FilesystemSpec):
 @frozen_after_init
 @dataclass(unsafe_hash=True)
 class FilesystemSpecs:
-    includes: Tuple[Union[FilesystemLiteralSpec, FilesystemGlobSpec], ...]
-    ignores: Tuple[FilesystemIgnoreSpec, ...]
+    includes: tuple[FilesystemLiteralSpec | FilesystemGlobSpec, ...]
+    ignores: tuple[FilesystemIgnoreSpec, ...]
 
     def __init__(self, specs: Iterable[FilesystemSpec]) -> None:
         includes = []
@@ -294,7 +294,7 @@ class FilesystemSpecs:
 
     def path_globs_for_spec(
         self,
-        spec: Union[FilesystemLiteralSpec, FilesystemGlobSpec],
+        spec: FilesystemLiteralSpec | FilesystemGlobSpec,
         glob_match_error_behavior: GlobMatchErrorBehavior,
     ) -> PathGlobs:
         """Generate PathGlobs for the specific spec, automatically including the instance's

--- a/src/python/pants/base/specs_parser.py
+++ b/src/python/pants/base/specs_parser.py
@@ -1,9 +1,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import os
 from pathlib import Path, PurePath
-from typing import Iterable, Union
+from typing import Iterable
 
 from pants.base.specs import (
     AddressLiteralSpec,
@@ -64,7 +66,7 @@ class SpecsParser:
             normalized = ""
         return normalized
 
-    def parse_spec(self, spec: str) -> Union[AddressSpec, FilesystemSpec]:
+    def parse_spec(self, spec: str) -> AddressSpec | FilesystemSpec:
         """Parse the given spec into an `AddressSpec` or `FilesystemSpec` object.
 
         :raises: CmdLineSpecParser.BadSpecError if the address selector could not be parsed.

--- a/src/python/pants/base/specs_parser_test.py
+++ b/src/python/pants/base/specs_parser_test.py
@@ -1,9 +1,10 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import os
 from pathlib import Path
-from typing import Optional, Union
 
 import pytest
 
@@ -20,7 +21,7 @@ from pants.base.specs import (
 from pants.base.specs_parser import SpecsParser
 
 
-def address_literal(directory: str, name: Optional[str] = None) -> AddressLiteralSpec:
+def address_literal(directory: str, name: str | None = None) -> AddressLiteralSpec:
     name = name if name is not None else os.path.basename(directory)
     return AddressLiteralSpec(directory, name)
 
@@ -162,9 +163,7 @@ def test_ambiguous_files(tmp_path: Path, spec: str) -> None:
         ("a.txt", file_literal("a.txt")),
     ],
 )
-def test_absolute(
-    tmp_path: Path, spec_suffix: str, expected: Union[AddressSpec, FilesystemSpec]
-) -> None:
+def test_absolute(tmp_path: Path, spec_suffix: str, expected: AddressSpec | FilesystemSpec) -> None:
     spec = os.path.join(tmp_path, spec_suffix)
     if isinstance(expected, AddressSpec):
         assert_address_spec_parsed(tmp_path, spec, expected)

--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, DefaultDict, Dict, Set, Type, Union, cast
+from typing import Any, DefaultDict, Dict, Set, Type, cast
 
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.goal import GoalSubsystem
@@ -156,7 +156,7 @@ class BuildConfiguration:
         # in this because we pass whatever people put in their `register.py`s to this function;
         # I.e., this is an impure function that reads from the outside world. So, we use the type
         # hint `Any` and perform runtime type checking.
-        def register_optionables(self, optionables: Union[typing.Iterable[Type[Optionable]], Any]):
+        def register_optionables(self, optionables: typing.Iterable[Type[Optionable]] | Any):
             """Registers the given subsystem types."""
             if not isinstance(optionables, Iterable):
                 raise TypeError("The optionables must be an iterable, given {}".format(optionables))
@@ -198,9 +198,7 @@ class BuildConfiguration:
         # this because we pass whatever people put in their `register.py`s to this function;
         # I.e., this is an impure function that reads from the outside world. So, we use the type
         # hint `Any` and perform runtime type checking.
-        def register_target_types(
-            self, target_types: Union[typing.Iterable[Type[Target]], Any]
-        ) -> None:
+        def register_target_types(self, target_types: typing.Iterable[Type[Target]] | Any) -> None:
             """Registers the given target types."""
             if not isinstance(target_types, Iterable):
                 raise TypeError(

--- a/src/python/pants/engine/collection.py
+++ b/src/python/pants/engine/collection.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Any, ClassVar, Iterable, Tuple, TypeVar, Union, cast, overload
+from typing import Any, ClassVar, Iterable, Tuple, TypeVar, cast, overload
 
 from pants.util.ordered_set import FrozenOrderedSet
 
@@ -33,7 +33,7 @@ class Collection(Tuple[T, ...]):
     def __getitem__(self, index: slice) -> Collection[T]:
         ...
 
-    def __getitem__(self, index: Union[int, slice]) -> Union[T, "Collection[T]"]:  # noqa: F811
+    def __getitem__(self, index: int | slice) -> T | Collection[T]:  # noqa: F811
         result = super().__getitem__(index)
         if isinstance(index, int):
             return cast(T, result)

--- a/src/python/pants/engine/engine_aware.py
+++ b/src/python/pants/engine/engine_aware.py
@@ -1,8 +1,10 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 from abc import ABC
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional
 
 from pants.engine.fs import FileDigest, Snapshot
 from pants.util.logging import LogLevel
@@ -31,7 +33,7 @@ class EngineAwareReturnType(ABC):
     otherwise, it will use the additional metadata provided.
     """
 
-    def level(self) -> Optional[LogLevel]:
+    def level(self) -> LogLevel | None:
         """If implemented, this method will modify the level of the workunit associated with any
         `@rule`s that return the annotated type.
 
@@ -40,7 +42,7 @@ class EngineAwareReturnType(ABC):
         """
         return None
 
-    def message(self) -> Optional[str]:
+    def message(self) -> str | None:
         """If implemented, this adds a result message to the workunit for any `@rule`'s that return
         the annotated type.
 
@@ -49,7 +51,7 @@ class EngineAwareReturnType(ABC):
         """
         return None
 
-    def artifacts(self) -> Optional[Dict[str, Union[FileDigest, Snapshot]]]:
+    def artifacts(self) -> dict[str, FileDigest | Snapshot] | None:
         """If implemented, this sets the `artifacts` entry for the workunit of any `@rule`'s that
         return the annotated type.
 
@@ -57,7 +59,7 @@ class EngineAwareReturnType(ABC):
         """
         return None
 
-    def metadata(self) -> Optional[Dict[str, Any]]:
+    def metadata(self) -> dict[str, Any] | None:
         """If implemented, adds arbitrary key-value pairs to the `metadata` entry of the `@rule`
         workunit."""
 

--- a/src/python/pants/engine/internals/target_adaptor.py
+++ b/src/python/pants/engine/internals/target_adaptor.py
@@ -1,7 +1,9 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Any, Union
+from __future__ import annotations
+
+from typing import Any
 
 from typing_extensions import final
 
@@ -19,7 +21,7 @@ class TargetAdaptor:
     def __repr__(self) -> str:
         return f"TargetAdaptor(type_alias={self.type_alias}, name={self.name})"
 
-    def __eq__(self, other: Union[Any, "TargetAdaptor"]) -> bool:
+    def __eq__(self, other: Any | TargetAdaptor) -> bool:
         if not isinstance(other, TargetAdaptor):
             return NotImplemented
         return (

--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -7,7 +7,7 @@ import inspect
 import os
 import re
 from enum import Enum
-from typing import Dict, Iterable, List, Optional, Pattern, Sequence, Type, Union
+from typing import Dict, Iterable, List, Pattern, Sequence
 
 from pants.option.errors import ParseError
 from pants.util.eval import parse_expression
@@ -29,7 +29,7 @@ class UnsetBool:
         )
 
     @classmethod
-    def coerce_bool(cls, value: Optional[Union[Type["UnsetBool"], bool]], default: bool) -> bool:
+    def coerce_bool(cls, value: type[UnsetBool] | bool | None, default: bool) -> bool:
         if value is None:
             return default
         if value is cls:

--- a/src/python/pants/option/options_test.py
+++ b/src/python/pants/option/options_test.py
@@ -1,6 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import json
 import os
 import shlex
@@ -10,7 +12,7 @@ from collections import defaultdict
 from enum import Enum
 from functools import partial
 from textwrap import dedent
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, cast
 
 import pytest
 import toml
@@ -180,7 +182,7 @@ def create_options(options, passthru_args=None, fingerprintable_options=None):
 
 class OptionsTest(unittest.TestCase):
     @staticmethod
-    def _create_config(config: Optional[Dict[str, Dict[str, str]]] = None) -> Config:
+    def _create_config(config: dict[str, dict[str, str]] | None = None) -> Config:
         with open(os.path.join(safe_mkdtemp(), "test_config.toml"), "w") as fp:
             toml.dump(config or {}, fp)
         return Config.load(config_paths=[fp.name])
@@ -189,8 +191,8 @@ class OptionsTest(unittest.TestCase):
         self,
         *,
         flags: str = "",
-        env: Optional[Dict[str, str]] = None,
-        config: Optional[Dict[str, Dict[str, Any]]] = None,
+        env: dict[str, str] | None = None,
+        config: dict[str, dict[str, Any]] | None = None,
         bootstrap_option_values=None,
     ) -> Options:
         args = ["./pants", *shlex.split(flags)]
@@ -593,8 +595,8 @@ class OptionsTest(unittest.TestCase):
             *,
             expected: List[int],
             flags: str = "",
-            env_val: Optional[str] = None,
-            config_val: Optional[str] = None,
+            env_val: str | None = None,
+            config_val: str | None = None,
         ) -> None:
             env = {"PANTS_GLOBAL_LISTY": env_val} if env_val else None
             config = {"GLOBAL": {"listy": config_val}} if config_val else None
@@ -691,8 +693,8 @@ class OptionsTest(unittest.TestCase):
             *,
             expected: List[Dict[str, int]],
             flags: str = "",
-            env_val: Optional[str] = None,
-            config_val: Optional[str] = None,
+            env_val: str | None = None,
+            config_val: str | None = None,
         ) -> None:
             env = {"PANTS_GLOBAL_DICT_LISTY": env_val} if env_val else None
             config = {"GLOBAL": {"dict_listy": config_val}} if config_val else None
@@ -730,8 +732,8 @@ class OptionsTest(unittest.TestCase):
             *,
             expected: List[str],
             flags: str = "",
-            env_val: Optional[str] = None,
-            config_val: Optional[str] = None,
+            env_val: str | None = None,
+            config_val: str | None = None,
         ) -> None:
             env = {"PANTS_GLOBAL_TARGET_LISTY": env_val} if env_val else None
             config = {"GLOBAL": {"target_listy": config_val}} if config_val else None
@@ -761,8 +763,8 @@ class OptionsTest(unittest.TestCase):
             *,
             expected: List[str],
             flags: str = "",
-            env_val: Optional[str] = None,
-            config_val: Optional[str] = None,
+            env_val: str | None = None,
+            config_val: str | None = None,
         ) -> None:
             env = {"PANTS_GLOBAL_SHELL_STR_LISTY": env_val} if env_val else None
             config = {"GLOBAL": {"shell_str_listy": config_val}} if config_val else None
@@ -794,7 +796,7 @@ class OptionsTest(unittest.TestCase):
             *,
             expected: Dict[str, str],
             flags: str = "",
-            config_val: Optional[str] = None,
+            config_val: str | None = None,
         ) -> None:
             config = {"GLOBAL": {"dicty": config_val}} if config_val else None
             global_options = self._parse(flags=flags, config=config).for_global_scope()
@@ -1131,10 +1133,10 @@ class OptionsTest(unittest.TestCase):
             *,
             flags: str = "",
             option: str,
-            expected: Union[str, bool],
-            scope: Optional[str] = None,
-            env: Optional[Dict[str, str]] = None,
-            config: Optional[Dict[str, Dict[str, str]]] = None,
+            expected: str | bool,
+            scope: str | None = None,
+            env: dict[str, str] | None = None,
+            config: dict[str, dict[str, str]] | None = None,
         ) -> None:
             warnings.simplefilter("always")
             with pytest.warns(DeprecationWarning) as record:
@@ -1236,9 +1238,9 @@ class OptionsTest(unittest.TestCase):
         def assert_mutually_exclusive_raised(
             *,
             flags: str,
-            scope: Optional[str] = None,
-            env: Optional[Dict[str, str]] = None,
-            config: Optional[Dict[str, Dict[str, str]]] = None,
+            scope: str | None = None,
+            env: dict[str, str] | None = None,
+            config: dict[str, dict[str, str]] | None = None,
         ) -> None:
             with self.assertRaises(MutuallyExclusiveOptionError):
                 options = self._parse(flags=flags, env=env, config=config)
@@ -1294,9 +1296,9 @@ class OptionsTest(unittest.TestCase):
             *,
             flags: str = "",
             other_option: str,
-            scope: Optional[str] = None,
-            env: Optional[Dict[str, str]] = None,
-            config: Optional[Dict[str, Dict[str, str]]] = None,
+            scope: str | None = None,
+            env: dict[str, str] | None = None,
+            config: dict[str, dict[str, str]] | None = None,
         ) -> None:
             options = self._parse(flags=flags, env=env, config=config)
             scoped_options = options.for_global_scope() if not scope else options.for_scope(scope)

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -1,6 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import copy
 import inspect
 import json
@@ -11,20 +13,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import (
-    Any,
-    Callable,
-    DefaultDict,
-    Dict,
-    Iterable,
-    List,
-    Mapping,
-    Optional,
-    Set,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import Any, Callable, DefaultDict, Dict, Iterable, List, Mapping, Set, Tuple, Type
 
 import yaml
 
@@ -90,7 +79,7 @@ class Parser:
     """
 
     @staticmethod
-    def _ensure_bool(val: Union[bool, str]) -> bool:
+    def _ensure_bool(val: bool | str) -> bool:
         if isinstance(val, bool):
             return val
         if isinstance(val, str):
@@ -103,7 +92,7 @@ class Parser:
         raise BooleanConversionError(f"Got {val}. Expected True or False.")
 
     @classmethod
-    def _invert(cls, s: Optional[Union[bool, str]]) -> Optional[bool]:
+    def _invert(cls, s: bool | str | None) -> bool | None:
         if s is None:
             return None
         b = cls._ensure_bool(s)
@@ -123,7 +112,7 @@ class Parser:
         env: Mapping[str, str],
         config: Config,
         scope_info: ScopeInfo,
-        parent_parser: Optional["Parser"],
+        parent_parser: Parser | None,
     ) -> None:
         """Create a Parser instance.
 
@@ -165,7 +154,7 @@ class Parser:
     def known_args(self) -> Set[str]:
         return self._known_args
 
-    def history(self, dest: str) -> Optional[OptionValueHistory]:
+    def history(self, dest: str) -> OptionValueHistory | None:
         return self._history.get(dest)
 
     def walk(self, callback: Callable) -> None:
@@ -196,16 +185,16 @@ class Parser:
             self.passthrough_args = passthrough_args
 
         @staticmethod
-        def _create_flag_value_map(flags: Iterable[str]) -> DefaultDict[str, List[Optional[str]]]:
+        def _create_flag_value_map(flags: Iterable[str]) -> DefaultDict[str, list[str | None]]:
             """Returns a map of flag -> list of values, based on the given flag strings.
 
             None signals no value given (e.g., -x, --foo). The value is a list because the user may
             specify the same flag multiple times, and that's sometimes OK (e.g., when appending to
             list- valued options).
             """
-            flag_value_map: DefaultDict[str, List[Optional[str]]] = defaultdict(list)
+            flag_value_map: DefaultDict[str, list[str | None]] = defaultdict(list)
             for flag in flags:
-                flag_val: Optional[str]
+                flag_val: str | None
                 key, has_equals_sign, flag_val = flag.partition("=")
                 if not has_equals_sign:
                     if not flag.startswith("--"):  # '-xfoo' style.
@@ -246,9 +235,9 @@ class Parser:
             if implicit_value is None and kwargs.get("type") == bool:
                 implicit_value = True  # Allows --foo to mean --foo=true.
 
-            flag_vals: List[Union[int, float, bool, str]] = []
+            flag_vals: list[int | float | bool | str] = []
 
-            def add_flag_val(v: Optional[Union[int, float, bool, str]]) -> None:
+            def add_flag_val(v: int | float | bool | str | None) -> None:
                 if v is None:
                     if implicit_value is None:
                         raise ParseError(
@@ -473,7 +462,7 @@ class Parser:
 
         def error(
             exception_type: Type[RegistrationError],
-            arg_name: Optional[str] = None,
+            arg_name: str | None = None,
             **msg_kwargs,
         ) -> None:
             if arg_name is None:
@@ -804,7 +793,7 @@ class Parser:
 
         return value_history
 
-    def _inverse_arg(self, arg: str) -> Optional[str]:
+    def _inverse_arg(self, arg: str) -> str | None:
         if not arg.startswith("--"):
             return None
         if arg.startswith("--no-"):
@@ -814,7 +803,7 @@ class Parser:
     def _register_child_parser(self, child: "Parser") -> None:
         self._child_parsers.append(child)
 
-    def _scope_str(self, scope: Optional[str] = None) -> str:
+    def _scope_str(self, scope: str | None = None) -> str:
         return self.scope_str(scope if scope is not None else self.scope)
 
     def __str__(self) -> str:

--- a/src/python/pants/option/ranked_value.py
+++ b/src/python/pants/option/ranked_value.py
@@ -34,8 +34,6 @@ class Rank(Enum):
 
 
 Value = Union[str, int, float, None, Dict, Enum, List]
-
-
 ValueAndDetails = Tuple[Optional[Value], Optional[str]]
 
 
@@ -98,4 +96,4 @@ class RankedValue:
 
     rank: Rank
     value: Value
-    details: Optional[str] = None  # Optional details about the derivation of the value.
+    details: str | None = None  # Optional details about the derivation of the value.

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -8,7 +8,7 @@ import logging
 import os
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Dict, Iterable, Optional, Set, Tuple, Union
+from typing import Dict, Iterable, Optional, Set, Tuple
 
 from pants.build_graph.address import Address
 from pants.engine.collection import DeduplicatedCollection
@@ -56,7 +56,7 @@ class InvalidMarkerFileError(SourceRootError):
 class NoSourceRootError(SourceRootError):
     """Indicates we failed to map a source file to a source root."""
 
-    def __init__(self, path: Union[str, PurePath], extra_msg: str = ""):
+    def __init__(self, path: str | PurePath, extra_msg: str = ""):
         super().__init__(f"No source root found for `{path}`. {extra_msg}")
 
 

--- a/src/python/pants/testutil/option_util.py
+++ b/src/python/pants/testutil/option_util.py
@@ -1,7 +1,9 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Iterable, Mapping, Optional, Type, TypeVar, Union, cast
+from __future__ import annotations
+
+from typing import Iterable, Mapping, Type, TypeVar, cast
 
 from pants.engine.goal import GoalSubsystem
 from pants.option.option_value_container import OptionValueContainer, OptionValueContainerBuilder
@@ -11,9 +13,7 @@ from pants.option.subsystem import Subsystem
 
 
 def create_options_bootstrapper(
-    args: Optional[Iterable[str]] = None,
-    *,
-    env: Optional[Mapping[str, str]] = None,
+    args: Iterable[str] | None = None, *, env: Mapping[str, str] | None = None
 ) -> OptionsBootstrapper:
     return OptionsBootstrapper.create(
         args=("--pants-config-files=[]", *(args or [])),
@@ -23,7 +23,7 @@ def create_options_bootstrapper(
 
 
 def create_option_value_container(
-    default_rank: Rank = Rank.NONE, **options: Union[RankedValue, Value]
+    default_rank: Rank = Rank.NONE, **options: RankedValue | Value
 ) -> OptionValueContainer:
     scoped_options = OptionValueContainerBuilder()
     for key, value in options.items():
@@ -39,7 +39,7 @@ _GS = TypeVar("_GS", bound=GoalSubsystem)
 def create_goal_subsystem(
     goal_subsystem_type: Type[_GS],
     default_rank: Rank = Rank.NONE,
-    **options: Union[RankedValue, Value],
+    **options: RankedValue | Value,
 ) -> _GS:
     """Creates a new goal subsystem instance populated with the given option values.
 
@@ -57,7 +57,7 @@ _SS = TypeVar("_SS", bound=Subsystem)
 
 
 def create_subsystem(
-    subsystem_type: Type[_SS], default_rank: Rank = Rank.NONE, **options: Union[RankedValue, Value]
+    subsystem_type: Type[_SS], default_rank: Rank = Rank.NONE, **options: RankedValue | Value
 ) -> _SS:
     """Creates a new subsystem instance populated with the given option values.
 

--- a/src/python/pants/testutil/pants_integration_test.py
+++ b/src/python/pants/testutil/pants_integration_test.py
@@ -1,6 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import glob
 import os
 import subprocess
@@ -60,9 +62,7 @@ class PantsJoinHandle:
     process: subprocess.Popen
     workdir: str
 
-    def join(
-        self, stdin_data: Optional[Union[bytes, str]] = None, tee_output: bool = False
-    ) -> PantsResult:
+    def join(self, stdin_data: bytes | str | None = None, tee_output: bool = False) -> PantsResult:
         """Wait for the pants process to complete, and return a PantsResult for it."""
 
         communicate_fn = self.process.communicate
@@ -96,8 +96,8 @@ def run_pants_with_workdir_without_waiting(
     workdir: str,
     hermetic: bool = True,
     use_pantsd: bool = True,
-    config: Optional[Mapping] = None,
-    extra_env: Optional[Mapping[str, str]] = None,
+    config: Mapping | None = None,
+    extra_env: Mapping[str, str] | None = None,
     print_stacktrace: bool = True,
     **kwargs: Any,
 ) -> PantsJoinHandle:
@@ -185,8 +185,8 @@ def run_pants_with_workdir(
     workdir: str,
     hermetic: bool = True,
     use_pantsd: bool = True,
-    config: Optional[Mapping] = None,
-    stdin_data: Optional[Union[bytes, str]] = None,
+    config: Mapping | None = None,
+    stdin_data: bytes | str | None = None,
     tee_output: bool = False,
     **kwargs: Any,
 ) -> PantsResult:
@@ -203,9 +203,9 @@ def run_pants(
     *,
     hermetic: bool = True,
     use_pantsd: bool = True,
-    config: Optional[Mapping] = None,
-    extra_env: Optional[Mapping[str, str]] = None,
-    stdin_data: Optional[Union[bytes, str]] = None,
+    config: Mapping | None = None,
+    extra_env: Mapping[str, str] | None = None,
+    stdin_data: bytes | str | None = None,
     **kwargs: Any,
 ) -> PantsResult:
     """Runs Pants in a subprocess.

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -10,19 +10,7 @@ from io import StringIO
 from pathlib import PurePath
 from tempfile import mkdtemp
 from types import CoroutineType, GeneratorType
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Iterable,
-    Mapping,
-    Optional,
-    Sequence,
-    Type,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import Any, Callable, Iterable, Mapping, Sequence, Type, TypeVar, cast
 
 from colors import blue, cyan, green, magenta, red, yellow
 
@@ -95,12 +83,12 @@ class RuleRunner:
     def __init__(
         self,
         *,
-        rules: Optional[Iterable] = None,
-        target_types: Optional[Iterable[Type[Target]]] = None,
-        objects: Optional[Dict[str, Any]] = None,
-        context_aware_object_factories: Optional[Dict[str, Any]] = None,
+        rules: Iterable | None = None,
+        target_types: Iterable[type[Target]] | None = None,
+        objects: dict[str, Any] | None = None,
+        context_aware_object_factories: dict[str, Any] | None = None,
         isolated_local_store: bool = False,
-        ca_certs_path: Optional[str] = None,
+        ca_certs_path: str | None = None,
     ) -> None:
         self.build_root = os.path.realpath(mkdtemp(suffix="_BUILD_ROOT"))
         safe_mkdir(self.build_root, clean=True)
@@ -194,9 +182,9 @@ class RuleRunner:
         self,
         goal: Type[Goal],
         *,
-        global_args: Optional[Iterable[str]] = None,
-        args: Optional[Iterable[str]] = None,
-        env: Optional[Mapping[str, str]] = None,
+        global_args: Iterable[str] | None = None,
+        args: Iterable[str] | None = None,
+        env: Mapping[str, str] | None = None,
     ) -> GoalRuleResult:
         merged_args = (*(global_args or []), goal.name, *(args or []))
         self.set_options(merged_args, env=env)
@@ -223,7 +211,7 @@ class RuleRunner:
         console.flush()
         return GoalRuleResult(exit_code, stdout.getvalue(), stderr.getvalue())
 
-    def set_options(self, args: Iterable[str], *, env: Optional[Mapping[str, str]] = None) -> None:
+    def set_options(self, args: Iterable[str], *, env: Mapping[str, str] | None = None) -> None:
         """Update the engine session with new options and/or environment variables.
 
         The environment variables will be used to set the `PantsEnvironment`, which is the
@@ -262,7 +250,7 @@ class RuleRunner:
         self._invalidate_for(relpath)
         return path
 
-    def create_file(self, relpath: str, contents: Union[bytes, str] = "", mode: str = "w") -> str:
+    def create_file(self, relpath: str, contents: bytes | str = "", mode: str = "w") -> str:
         """Writes to a file under the buildroot.
 
         :API: public
@@ -289,7 +277,7 @@ class RuleRunner:
             self.create_file(os.path.join(path, f), contents=f)
 
     def add_to_build_file(
-        self, relpath: Union[str, PurePath], target: str, *, overwrite: bool = False
+        self, relpath: str | PurePath, target: str, *, overwrite: bool = False
     ) -> str:
         """Adds the given target specification to the BUILD file at relpath.
 
@@ -305,7 +293,7 @@ class RuleRunner:
         mode = "w" if overwrite else "a"
         return self.create_file(str(build_path), target, mode=mode)
 
-    def make_snapshot(self, files: Mapping[str, Union[str, bytes]]) -> Snapshot:
+    def make_snapshot(self, files: Mapping[str, str | bytes]) -> Snapshot:
         """Makes a snapshot from a map of file name to file content."""
         with temporary_dir() as temp_dir:
             for file_name, content in files.items():
@@ -350,9 +338,9 @@ class MockGet:
 def run_rule_with_mocks(
     rule: Callable,
     *,
-    rule_args: Optional[Sequence[Any]] = None,
-    mock_gets: Optional[Sequence[MockGet]] = None,
-    union_membership: Optional[UnionMembership] = None,
+    rule_args: Sequence[Any] | None = None,
+    mock_gets: Sequence[MockGet] | None = None,
+    union_membership: UnionMembership | None = None,
 ):
     """A test helper function that runs an @rule with a set of arguments and mocked Get providers.
 

--- a/src/python/pants/util/collections.py
+++ b/src/python/pants/util/collections.py
@@ -1,9 +1,11 @@
 # Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import collections
 import collections.abc
-from typing import Any, Iterable, List, MutableMapping, Type, TypeVar, Union
+from typing import Any, Iterable, List, MutableMapping, TypeVar
 
 
 def recursively_update(d: MutableMapping, d2: MutableMapping) -> None:
@@ -37,8 +39,8 @@ def assert_single_element(iterable: Iterable[_T]) -> _T:
 
 
 def ensure_list(
-    val: Union[Any, Iterable[Any]], *, expected_type: Type[_T], allow_single_scalar: bool = False
-) -> List[_T]:
+    val: Any | Iterable[Any], *, expected_type: type[_T], allow_single_scalar: bool = False
+) -> list[_T]:
     """Ensure that every element of an iterable is the expected type and convert the result to a
     list.
 
@@ -63,7 +65,7 @@ def ensure_list(
     return result
 
 
-def ensure_str_list(val: Union[str, Iterable[str]], *, allow_single_str: bool = False) -> List[str]:
+def ensure_str_list(val: str | Iterable[str], *, allow_single_str: bool = False) -> list[str]:
     """Ensure that every element of an iterable is a string and convert the result to a list.
 
     If `allow_single_str` is True, a single `str` will be wrapped into a `List[str]`.

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -1,6 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import logging
 import os
 import shutil
@@ -14,7 +16,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from queue import Queue
 from socketserver import TCPServer
-from typing import IO, Any, Callable, Iterator, Mapping, Optional, Tuple, Type, Union
+from typing import IO, Any, Callable, Iterator, Mapping, Tuple, Type
 
 from colors import green
 
@@ -26,7 +28,7 @@ class InvalidZipPath(ValueError):
 
 
 @contextmanager
-def environment_as(**kwargs: Optional[str]) -> Iterator[None]:
+def environment_as(**kwargs: str | None) -> Iterator[None]:
     """Update the environment to the supplied values, for example:
 
     with environment_as(PYTHONPATH='foo:bar:baz',
@@ -36,7 +38,7 @@ def environment_as(**kwargs: Optional[str]) -> Iterator[None]:
     new_environment = kwargs
     old_environment = {}
 
-    def setenv(key: str, val: Optional[str]) -> None:
+    def setenv(key: str, val: str | None) -> None:
         if val is not None:
             os.environ[key] = val
         else:
@@ -70,7 +72,7 @@ def _restore_env(env: Mapping[str, str]) -> None:
 
 
 @contextmanager
-def hermetic_environment_as(**kwargs: Optional[str]) -> Iterator[None]:
+def hermetic_environment_as(**kwargs: str | None) -> Iterator[None]:
     """Set the environment to the supplied values from an empty state."""
     old_environment = os.environ.copy()
     _purge_env()
@@ -152,11 +154,11 @@ def stdio_as(stdout_fd: int, stderr_fd: int, stdin_fd: int) -> Iterator[None]:
 
 @contextmanager
 def temporary_dir(
-    root_dir: Optional[str] = None,
+    root_dir: str | None = None,
     cleanup: bool = True,
-    suffix: Optional[str] = None,
-    permissions: Optional[int] = None,
-    prefix: Optional[str] = tempfile.template,
+    suffix: str | None = None,
+    permissions: int | None = None,
+    prefix: str | None = tempfile.template,
 ) -> Iterator[str]:
     """A with-context that creates a temporary directory.
 
@@ -180,10 +182,10 @@ def temporary_dir(
 
 @contextmanager
 def temporary_file_path(
-    root_dir: Optional[str] = None,
+    root_dir: str | None = None,
     cleanup: bool = True,
-    suffix: Optional[str] = None,
-    permissions: Optional[int] = None,
+    suffix: str | None = None,
+    permissions: int | None = None,
 ) -> Iterator[str]:
     """A with-context that creates a temporary file and returns its path.
 
@@ -200,10 +202,10 @@ def temporary_file_path(
 
 @contextmanager
 def temporary_file(
-    root_dir: Optional[str] = None,
+    root_dir: str | None = None,
     cleanup: bool = True,
-    suffix: Optional[str] = None,
-    permissions: Optional[int] = None,
+    suffix: str | None = None,
+    permissions: int | None = None,
     binary_mode: bool = True,
 ) -> Iterator[IO]:
     """A with-context that creates a temporary file and returns a writeable file descriptor to it.
@@ -232,8 +234,8 @@ def temporary_file(
 
 @contextmanager
 def overwrite_file_content(
-    file_path: Union[str, Path],
-    temporary_content: Optional[Union[bytes, str, Callable[[bytes], bytes]]] = None,
+    file_path: str | Path,
+    temporary_content: bytes | str | Callable[[bytes], bytes] | None = None,
 ) -> Iterator[None]:
     """A helper that resets a file after the method runs.
 
@@ -272,7 +274,7 @@ def pushd(directory: str) -> Iterator[str]:
 
 
 @contextmanager
-def open_zip(path_or_file: Union[str, Any], *args, **kwargs) -> Iterator[zipfile.ZipFile]:
+def open_zip(path_or_file: str | Any, *args, **kwargs) -> Iterator[zipfile.ZipFile]:
     """A with-context for zip files.
 
     Passes through *args and **kwargs to zipfile.ZipFile.
@@ -301,7 +303,7 @@ def open_zip(path_or_file: Union[str, Any], *args, **kwargs) -> Iterator[zipfile
 
 
 @contextmanager
-def maybe_profiled(profile_path: Optional[str]) -> Iterator[None]:
+def maybe_profiled(profile_path: str | None) -> Iterator[None]:
     """A profiling context manager.
 
     :param profile_path: The path to write profile information to. If `None`, this will no-op.
@@ -330,7 +332,7 @@ def maybe_profiled(profile_path: Optional[str]) -> Iterator[None]:
 
 
 @contextmanager
-def http_server(handler_class: Type, ssl_context: Optional[ssl.SSLContext] = None) -> Iterator[int]:
+def http_server(handler_class: Type, ssl_context: ssl.SSLContext | None = None) -> Iterator[int]:
     def serve(port_queue: "Queue[int]", shutdown_queue: "Queue[bool]") -> None:
         httpd = TCPServer(("", 0), handler_class)
         httpd.timeout = 0.1

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -1,6 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import atexit
 import errno
 import os
@@ -11,26 +13,14 @@ import threading
 import uuid
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import (
-    Any,
-    Callable,
-    DefaultDict,
-    Iterator,
-    List,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    Union,
-    overload,
-)
+from typing import Any, Callable, DefaultDict, Iterator, Sequence, Set, overload
 
 from typing_extensions import Literal
 
 from pants.util.strutil import ensure_text
 
 
-def longest_dir_prefix(path: str, prefixes: Sequence[str]) -> Optional[str]:
+def longest_dir_prefix(path: str, prefixes: Sequence[str]) -> str | None:
     """Given a list of prefixes, return the one that is the longest prefix to the given path.
 
     Returns None if there are no matches.
@@ -51,7 +41,7 @@ def fast_relpath(path: str, start: str) -> str:
     return relpath
 
 
-def fast_relpath_optional(path: str, start: str) -> Optional[str]:
+def fast_relpath_optional(path: str, start: str) -> str | None:
     """A prefix-based relpath, with no normalization or support for returning `..`.
 
     Returns None if `start` is not a directory-aware prefix of `path`.
@@ -97,7 +87,7 @@ def safe_mkdir_for(path: str, clean: bool = False) -> None:
 
 
 def safe_file_dump(
-    filename: str, payload: Union[bytes, str] = "", mode: str = "w", makedirs: bool = False
+    filename: str, payload: bytes | str = "", mode: str = "w", makedirs: bool = False
 ) -> None:
     """Write a string to a file.
 
@@ -120,26 +110,26 @@ def safe_file_dump(
 
 
 @overload
-def maybe_read_file(filename: str) -> Optional[str]:
+def maybe_read_file(filename: str) -> str | None:
     ...
 
 
 @overload
-def maybe_read_file(filename: str, binary_mode: Literal[False]) -> Optional[str]:
+def maybe_read_file(filename: str, binary_mode: Literal[False]) -> str | None:
     ...
 
 
 @overload
-def maybe_read_file(filename: str, binary_mode: Literal[True]) -> Optional[bytes]:
+def maybe_read_file(filename: str, binary_mode: Literal[True]) -> bytes | None:
     ...
 
 
 @overload
-def maybe_read_file(filename: str, binary_mode: bool) -> Optional[Union[bytes, str]]:
+def maybe_read_file(filename: str, binary_mode: bool) -> bytes | str | None:
     ...
 
 
-def maybe_read_file(filename: str, binary_mode: bool = False) -> Optional[Union[bytes, str]]:
+def maybe_read_file(filename: str, binary_mode: bool = False) -> bytes | str | None:
     """Read and return the contents of a file in a single file.read().
 
     :param filename: The filename of the file to read.
@@ -168,11 +158,11 @@ def read_file(filename: str, binary_mode: Literal[True]) -> bytes:
 
 
 @overload
-def read_file(filename: str, binary_mode: bool) -> Union[str, bytes]:
+def read_file(filename: str, binary_mode: bool) -> bytes | str:
     ...
 
 
-def read_file(filename: str, binary_mode: bool = False) -> Union[bytes, str]:
+def read_file(filename: str, binary_mode: bool = False) -> bytes | str:
     """Read and return the contents of a file in a single file.read().
 
     :param filename: The filename of the file to read.
@@ -181,11 +171,11 @@ def read_file(filename: str, binary_mode: bool = False) -> Union[bytes, str]:
     """
     mode = "rb" if binary_mode else "r"
     with open(filename, mode) as f:
-        content: Union[bytes, str] = f.read()
+        content: bytes | str = f.read()
         return content
 
 
-def safe_walk(path: Union[bytes, str], **kwargs: Any) -> Iterator[Tuple[str, List[str], List[str]]]:
+def safe_walk(path: bytes | str, **kwargs: Any) -> Iterator[tuple[str, list[str], list[str]]]:
     """Just like os.walk, but ensures that the returned values are unicode objects.
 
     This isn't strictly safe, in that it is possible that some paths
@@ -203,7 +193,7 @@ def safe_walk(path: Union[bytes, str], **kwargs: Any) -> Iterator[Tuple[str, Lis
 
 
 _MkdtempCleanerType = Callable[[], None]
-_MKDTEMP_CLEANER: Optional[_MkdtempCleanerType] = None
+_MKDTEMP_CLEANER: _MkdtempCleanerType | None = None
 _MKDTEMP_DIRS: DefaultDict[int, Set[str]] = defaultdict(set)
 _MKDTEMP_LOCK = threading.RLock()
 
@@ -392,7 +382,7 @@ def relative_symlink(source_path: str, link_path: str) -> None:
             raise
 
 
-def touch(path: str, times: Optional[Union[int, Tuple[int, int]]] = None):
+def touch(path: str, times: int | tuple[int, int] | None = None):
     """Equivalent of unix `touch path`.
 
     :API: public

--- a/src/python/pants/util/dirutil_test.py
+++ b/src/python/pants/util/dirutil_test.py
@@ -9,7 +9,7 @@ import unittest
 import unittest.mock
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Iterator, Tuple, Union
+from typing import Iterator, Tuple
 
 from pants.util import dirutil
 from pants.util.contextutil import pushd, temporary_dir
@@ -167,10 +167,8 @@ class DirutilTest(unittest.TestCase):
     class Symlink:
         path: str
 
-    def assert_tree(self, root: str, *expected: Union[Dir, File, Symlink]):
-        def collect_tree() -> Iterator[
-            Union[DirutilTest.Dir, DirutilTest.File, DirutilTest.Symlink]
-        ]:
+    def assert_tree(self, root: str, *expected: Dir | File | Symlink):
+        def collect_tree() -> Iterator[DirutilTest.Dir | DirutilTest.File | DirutilTest.Symlink]:
             for path, dirnames, filenames in os.walk(root, followlinks=False):
                 relpath = os.path.relpath(path, root)
                 if relpath == os.curdir:

--- a/src/python/pants/util/eval.py
+++ b/src/python/pants/util/eval.py
@@ -1,14 +1,16 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 from textwrap import dedent
-from typing import Any, Optional, Tuple, Type, Union
+from typing import Any, Type
 
 
 def parse_expression(
     val: str,
-    acceptable_types: Union[Type, Tuple[Type, ...]],
-    name: Optional[str] = None,
+    acceptable_types: type | tuple[type, ...],
+    name: str | None = None,
     raise_type: Type[BaseException] = ValueError,
 ) -> Any:
     """Attempts to parse the given `val` as a python expression of the specified `acceptable_types`.

--- a/src/python/pants/util/frozendict.py
+++ b/src/python/pants/util/frozendict.py
@@ -1,7 +1,9 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Any, Iterable, Iterator, Mapping, Tuple, TypeVar, Union, overload
+from __future__ import annotations
+
+from typing import Any, Iterable, Iterator, Mapping, Tuple, TypeVar, overload
 
 K = TypeVar("K")
 V = TypeVar("V")
@@ -27,7 +29,7 @@ class FrozenDict(Mapping[K, V]):
     def __init__(self, **kwargs: V) -> None:
         ...
 
-    def __init__(self, *item: Union[Mapping[K, V], Iterable[Tuple[K, V]]], **kwargs: V) -> None:
+    def __init__(self, *item: Mapping[K, V] | Iterable[Tuple[K, V]], **kwargs: V) -> None:
         """Creates a `FrozenDict` with arguments accepted by `dict` that also must be hashable."""
         if len(item) > 1:
             raise ValueError(

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -1,15 +1,17 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 from textwrap import dedent
-from typing import Any, Iterable, Optional, Type, Union
+from typing import Any, Iterable, Type, Union
 
 from pants.util.strutil import first_paragraph
 
 
 def get_docstring_summary(
     cls: Type, *, fallback_to_ancestors: bool = False, ignored_ancestors: Iterable[Type] = (object,)
-) -> Optional[str]:
+) -> str | None:
     """Get the summary line(s) of docstring for a class.
 
     If the summary is one more than one line, this will flatten them into a single line.
@@ -27,7 +29,7 @@ def get_docstring(
     flatten: bool = False,
     fallback_to_ancestors: bool = False,
     ignored_ancestors: Iterable[Type] = (object,),
-) -> Optional[str]:
+) -> str | None:
     """Get the docstring for a class with properly handled indentation.
 
     :param cls: the class, e.g. MyClass.

--- a/src/python/pants/util/ordered_set.py
+++ b/src/python/pants/util/ordered_set.py
@@ -12,6 +12,8 @@ Recipes by Raymond Hettiger and released under the MIT license:
 http://code.activestate.com/recipes/576694/.
 """
 
+from __future__ import annotations
+
 import itertools
 from typing import (
     AbstractSet,
@@ -21,7 +23,6 @@ from typing import (
     Iterable,
     Iterator,
     MutableSet,
-    Optional,
     Set,
     TypeVar,
     cast,
@@ -35,7 +36,7 @@ _TAbstractOrderedSet = TypeVar("_TAbstractOrderedSet", bound="_AbstractOrderedSe
 class _AbstractOrderedSet(AbstractSet[T]):
     """Common functionality shared between OrderedSet and FrozenOrderedSet."""
 
-    def __init__(self, iterable: Optional[Iterable[T]] = None) -> None:
+    def __init__(self, iterable: Iterable[T] | None = None) -> None:
         # Using a dictionary, rather than using the recipe's original `self |= iterable`, results
         # in a ~20% performance increase for the constructor.
         #
@@ -82,12 +83,16 @@ class _AbstractOrderedSet(AbstractSet[T]):
 
         Each item's order is defined by its first appearance.
         """
-        # Differences with AbstractSet: our set union forces "other" to have the same type. That is, while
-        # AbstractSet allows {1, 2, 3} | {(True, False)} resulting in Set[Union[int, Tuple[bool, bool]]], the analogous
-        # for descendants  of _TAbstractOrderedSet is not allowed.
+        # Differences with AbstractSet: our set union forces "other" to have the same type. That
+        # is, while AbstractSet allows {1, 2, 3} | {(True, False)} resulting in
+        # set[int | tuple[bool, bool]], the analogous for descendants  of _TAbstractOrderedSet is
+        # not allowed.
+        #
         # GOTCHA: given _TAbstractOrderedSet[S]:
-        #   if T is a subclass of S => _TAbstractOrderedSet[S] => *appears* to perform unification but it doesn't
-        #   if S is a subclass of T => type error (while AbstractSet would resolve to AbstractSet[T])
+        #   if T is a subclass of S => _TAbstractOrderedSet[S] => *appears* to perform
+        #     unification but it doesn't
+        #   if S is a subclass of T => type error (while AbstractSet would resolve to
+        #     AbstractSet[T])
         merged_iterables = itertools.chain([cast(Iterable[T], self)], others)
         return self.__class__(itertools.chain.from_iterable(merged_iterables))
 
@@ -208,9 +213,9 @@ class FrozenOrderedSet(_AbstractOrderedSet[T_co], Hashable):
     This is safe to use with the V2 engine.
     """
 
-    def __init__(self, iterable: Optional[Iterable[T_co]] = None) -> None:
+    def __init__(self, iterable: Iterable[T_co] | None = None) -> None:
         super().__init__(iterable)
-        self._hash: Optional[int] = None
+        self._hash: int | None = None
 
     def __hash__(self) -> int:
         if self._hash is None:

--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -1,13 +1,15 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import re
 import shlex
 import textwrap
-from typing import Dict, Iterable, List, Optional, Sequence, Union
+from typing import Iterable, List, Sequence
 
 
-def ensure_binary(text_or_binary: Union[bytes, str]) -> bytes:
+def ensure_binary(text_or_binary: bytes | str) -> bytes:
     if isinstance(text_or_binary, bytes):
         return text_or_binary
     elif isinstance(text_or_binary, str):
@@ -16,7 +18,7 @@ def ensure_binary(text_or_binary: Union[bytes, str]) -> bytes:
         raise TypeError(f"Argument is neither text nor binary type.({type(text_or_binary)})")
 
 
-def ensure_text(text_or_binary: Union[bytes, str]) -> str:
+def ensure_text(text_or_binary: bytes | str) -> str:
     if isinstance(text_or_binary, bytes):
         return text_or_binary.decode()
     elif isinstance(text_or_binary, str):
@@ -25,7 +27,7 @@ def ensure_text(text_or_binary: Union[bytes, str]) -> str:
         raise TypeError(f"Argument is neither text nor binary type ({type(text_or_binary)})")
 
 
-def safe_shlex_split(text_or_binary: Union[bytes, str]) -> List[str]:
+def safe_shlex_split(text_or_binary: bytes | str) -> List[str]:
     """Split a string using shell-like syntax.
 
     Safe even on python versions whose shlex.split() method doesn't accept unicode.
@@ -61,7 +63,7 @@ def safe_shlex_join(arg_list: Iterable[str]) -> str:
 
 def create_path_env_var(
     new_entries: Iterable[str],
-    env: Optional[Dict[str, str]] = None,
+    env: dict[str, str] | None = None,
     env_var: str = "PATH",
     delimiter: str = ":",
     prepend: bool = False,
@@ -123,7 +125,7 @@ def strip_prefix(string: str, prefix: str) -> str:
 
 
 # NB: We allow bytes because `ProcessResult.std{err,out}` uses bytes.
-def strip_v2_chroot_path(v: Union[bytes, str]) -> str:
+def strip_v2_chroot_path(v: bytes | str) -> str:
     """Remove all instances of the chroot tmpdir path from the str so that it only uses relative
     paths.
 


### PR DESCRIPTION
MyPy adds support for PEP 604 https://www.python.org/dev/peps/pep-0604/ even to Python 3.7 and 3.8. This new syntax is less verbose and reduces nesting, e.g. `str | bytes | None` vs. `Optional[Union[str, bytes]]`.

This PR does not update every file, but gets us closer to critical mass.

[ci skip-build-wheels]
[ci skip-rust]