### PR TITLE
Find remote roots for private internal packages.

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/subsystems/fetcher.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/fetcher.py
@@ -1,7 +1,6 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import itertools
 import logging
 from abc import ABC, abstractmethod
 from collections import namedtuple
@@ -78,26 +77,31 @@ class CloningFetcher(Fetcher):
         if imported_repo:
             return imported_repo.import_prefix
 
-        components = list(
-            itertools.takewhile(lambda package: package != "internal", self.import_path.split("/"))
-        )
-        if len(components) >= 2:
-            # The import path is for an internal package is described here:
-            # https://golang.org/cmd/go/#hdr-Internal_Directories. Since an internal directory is
-            # only importable in the tree rooted at its parent, we assume it's parent must have a
-            # public meta tag page. Failing that, we crawl all the way back up the ancestry.
-            host, parents = components[0], components[1:]
-            while parents:
-                parent_import_path = "/".join((host, *parents))
-                imported_repo = self._meta_tag_reader.get_imported_repo(parent_import_path)
-                if imported_repo:
-                    logger.info(
-                        "Found public root for private internal import {} in parent {}.".format(
-                            self.import_path, parent_import_path
-                        )
+        # The import path is for an internal package which is described here:
+        #   https://golang.org/cmd/go/#hdr-Internal_Directories.
+        #
+        # Since an internal directory is only importable in the tree rooted at its parent, we
+        # assume its parent must have a public meta tag page. Failing that, we crawl all the way
+        # back up the ancestry.
+        import_path_components = self.import_path.split("/")
+        try:
+            internal_index = import_path_components.index("internal")
+        except ValueError:
+            internal_import_public_parent_candidates = []
+        else:
+            internal_import_public_parent_candidates = import_path_components[:internal_index]
+
+        while internal_import_public_parent_candidates:
+            parent_import_path = "/".join(internal_import_public_parent_candidates)
+            imported_repo = self._meta_tag_reader.get_imported_repo(parent_import_path)
+            if imported_repo:
+                logger.info(
+                    "Found public root for private internal import {} in parent {}.".format(
+                        self.import_path, parent_import_path
                     )
-                    return imported_repo.import_prefix
-                parents.pop()
+                )
+                return imported_repo.import_prefix
+            internal_import_public_parent_candidates.pop()
 
         raise FetchError(f'No <meta name="go-import"> tag found at {self.import_path}')
 

--- a/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_fetchers.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_fetchers.py
@@ -4,6 +4,7 @@
 from pants.testutil.subsystem.util import global_subsystem_instance
 from pants.testutil.test_base import TestBase
 
+from pants.contrib.go.subsystems.fetch_error import FetchError
 from pants.contrib.go.subsystems.fetcher_factory import FetcherFactory
 
 
@@ -49,3 +50,9 @@ class FetchersTest(TestBase):
         self.check_default(
             "cloud.google.com/go/internal/pubsub", expected_root="cloud.google.com/go"
         )
+
+        with self.assertRaises(FetchError):
+            self.fetcher("internal").root()
+
+        with self.assertRaises(FetchError):
+            self.fetcher("host/internal").root()

--- a/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_fetchers.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_fetchers.py
@@ -39,3 +39,13 @@ class FetchersTest(TestBase):
 
     def test_default_gopkg(self):
         self.check_default("gopkg.in/check.v1", expected_root="gopkg.in/check.v1")
+
+    def test_default_cloud_google_com(self):
+        self.check_default("cloud.google.com/go/pubsub", expected_root="cloud.google.com/go")
+
+    def test_default_cloud_google_com_issues_11579(self):
+        # This internal package has no meta tag page / is not publicly addressable. Test that
+        # we fall back to searching for the internal package's root in parents.
+        self.check_default(
+            "cloud.google.com/go/internal/pubsub", expected_root="cloud.google.com/go"
+        )


### PR DESCRIPTION
Many internal packages have public meta-tag pages. For example:
```
$ curl -sL --fail golang.org/x/net/internal/timeseries | grep meta | grep go-import
<meta name="go-import" content="golang.org/x/net git https://go.googlesource.com/net">
```

Some do not though:
```
$ curl -L --fail cloud.google.com/go/internal/pubsub
curl: (22) The requested URL returned error: 404
```

Fix the repo cloning fetcher to look for meta-tag pages in internal
package parents when the internal package has no meta-tag page of
its own.

Fixes #11579

[ci skip-rust-tests]
[ci skip-jvm-tests]