### PR TITLE
Generate `protobuf_library` targets with `./pants tailor`

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/python/register.py
+++ b/src/python/pants/backend/codegen/protobuf/python/register.py
@@ -8,6 +8,7 @@ See https://www.pantsbuild.org/docs/protobuf.
 
 from pants.backend.codegen import export_codegen_goal
 from pants.backend.codegen.protobuf import protobuf_dependency_inference
+from pants.backend.codegen.protobuf import tailor as protobuf_tailor
 from pants.backend.codegen.protobuf.python import (
     additional_fields,
     python_protobuf_module_mapper,
@@ -24,6 +25,7 @@ def rules():
         *python_rules(),
         *python_protobuf_module_mapper.rules(),
         *protobuf_dependency_inference.rules(),
+        *protobuf_tailor.rules(),
         *export_codegen_goal.rules(),
     ]
 

--- a/src/python/pants/backend/codegen/protobuf/tailor.py
+++ b/src/python/pants/backend/codegen/protobuf/tailor.py
@@ -1,0 +1,54 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import logging
+import os.path
+from dataclasses import dataclass
+
+from pants.backend.codegen.protobuf.target_types import ProtobufLibrary
+from pants.core.goals.tailor import (
+    AllOwnedSources,
+    PutativeTarget,
+    PutativeTargets,
+    PutativeTargetsRequest,
+    group_by_dir,
+)
+from pants.engine.fs import PathGlobs, Paths
+from pants.engine.internals.selectors import Get
+from pants.engine.rules import collect_rules, rule
+from pants.engine.unions import UnionRule
+from pants.util.logging import LogLevel
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PutativeProtobufTargetsRequest:
+    pass
+
+
+@rule(level=LogLevel.DEBUG, desc="Determine candidate Protobuf targets to create")
+async def find_putative_targets(
+    _: PutativeProtobufTargetsRequest, all_owned_sources: AllOwnedSources
+) -> PutativeTargets:
+    all_proto_files = await Get(Paths, PathGlobs(["**/*.proto"]))
+    unowned_proto_files = set(all_proto_files.files) - set(all_owned_sources)
+    pts = [
+        PutativeTarget.for_target_type(
+            ProtobufLibrary,
+            path=dirname,
+            name=os.path.basename(dirname),
+            triggering_sources=sorted(filenames),
+        )
+        for dirname, filenames in group_by_dir(unowned_proto_files).items()
+    ]
+    return PutativeTargets(pts)
+
+
+def rules():
+    return [
+        *collect_rules(),
+        UnionRule(PutativeTargetsRequest, PutativeProtobufTargetsRequest),
+    ]

--- a/src/python/pants/backend/codegen/protobuf/tailor.py
+++ b/src/python/pants/backend/codegen/protobuf/tailor.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import logging
 import os.path
 from dataclasses import dataclass
 
@@ -20,8 +19,6 @@ from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/codegen/protobuf/tailor_test.py
+++ b/src/python/pants/backend/codegen/protobuf/tailor_test.py
@@ -1,0 +1,42 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.backend.codegen.protobuf.tailor import PutativeProtobufTargetsRequest
+from pants.backend.codegen.protobuf.tailor import rules as tailor_rules
+from pants.backend.codegen.protobuf.target_types import ProtobufLibrary
+from pants.core.goals.tailor import AllOwnedSources, PutativeTarget, PutativeTargets
+from pants.engine.rules import QueryRule
+from pants.testutil.rule_runner import RuleRunner
+
+
+def test_find_putative_targets() -> None:
+    rule_runner = RuleRunner(
+        rules=[
+            *tailor_rules(),
+            QueryRule(PutativeTargets, (PutativeProtobufTargetsRequest, AllOwnedSources)),
+        ],
+        target_types=[],
+    )
+    for path in [
+        "protos/foo/f.proto",
+        "protos/foo/bar/baz1.proto",
+        "protos/foo/bar/baz2.proto",
+        "protos/foo/bar/baz3.proto",
+    ]:
+        rule_runner.create_file(path)
+
+    pts = rule_runner.request(
+        PutativeTargets,
+        [PutativeProtobufTargetsRequest(), AllOwnedSources(["protos/foo/bar/baz1.proto"])],
+    )
+    assert (
+        PutativeTargets(
+            [
+                PutativeTarget.for_target_type(ProtobufLibrary, "protos/foo", "foo", ["f.proto"]),
+                PutativeTarget.for_target_type(
+                    ProtobufLibrary, "protos/foo/bar", "bar", ["baz2.proto", "baz3.proto"]
+                ),
+            ]
+        )
+        == pts
+    )

--- a/src/python/pants/backend/python/goals/tailor.py
+++ b/src/python/pants/backend/python/goals/tailor.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import logging
 import os
-from collections import defaultdict
 from dataclasses import dataclass
 from typing import Iterable
 
@@ -15,6 +14,7 @@ from pants.core.goals.tailor import (
     PutativeTarget,
     PutativeTargets,
     PutativeTargetsRequest,
+    group_by_dir,
 )
 from pants.engine.fs import PathGlobs, Paths
 from pants.engine.internals.selectors import Get
@@ -41,15 +41,6 @@ def classify_source_files(paths: Iterable[str]) -> dict[type[Target], set[str]]:
     test_files = {path for path in paths if os.path.basename(path) in test_filenames}
     library_files = set(paths) - test_files
     return {PythonTests: test_files, PythonLibrary: library_files}
-
-
-def group_by_dir(paths: Iterable[str]) -> dict[str, set[str]]:
-    """For a list of file paths, returns a dict of directory path -> files in that dir."""
-    ret = defaultdict(set)
-    for path in paths:
-        dirname, filename = os.path.split(path)
-        ret[dirname].add(filename)
-    return ret
 
 
 @rule(level=LogLevel.DEBUG, desc="Determine candidate Python targets to create")

--- a/src/python/pants/backend/python/goals/tailor.py
+++ b/src/python/pants/backend/python/goals/tailor.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import logging
 import os
 from dataclasses import dataclass
 from typing import Iterable
@@ -23,8 +22,6 @@ from pants.engine.target import Target
 from pants.engine.unions import UnionRule
 from pants.source.filespec import Filespec, matches_filespec
 from pants.util.logging import LogLevel
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/goals/tailor_test.py
+++ b/src/python/pants/backend/python/goals/tailor_test.py
@@ -1,31 +1,12 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import pytest
-
 from pants.backend.python.goals import tailor
-from pants.backend.python.goals.tailor import (
-    PutativePythonTargetsRequest,
-    classify_source_files,
-    group_by_dir,
-)
+from pants.backend.python.goals.tailor import PutativePythonTargetsRequest, classify_source_files
 from pants.backend.python.target_types import PythonLibrary, PythonTests
 from pants.core.goals.tailor import AllOwnedSources, PutativeTarget, PutativeTargets
-from pants.core.util_rules import source_files
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
-
-
-@pytest.fixture
-def rule_runner() -> RuleRunner:
-    return RuleRunner(
-        rules=[
-            *tailor.rules(),
-            *source_files.rules(),
-            QueryRule(PutativeTargets, (PutativePythonTargetsRequest, AllOwnedSources)),
-        ],
-        target_types=[PythonLibrary, PythonTests],
-    )
 
 
 def test_classify_source_files() -> None:
@@ -45,30 +26,16 @@ def test_classify_source_files() -> None:
     )
 
 
-def test_group_by_dir() -> None:
-    paths = {
-        "foo/bar/baz1.py",
-        "foo/bar/baz1_test.py",
-        "foo/bar/qux/quux1.py",
-        "foo/__init__.py",
-        "foo/bar/__init__.py",
-        "foo/bar/baz2.py",
-        "foo/bar1.py",
-        "foo1.py",
-        "__init__.py",
-    }
-    assert {
-        "": {"__init__.py", "foo1.py"},
-        "foo": {"__init__.py", "bar1.py"},
-        "foo/bar": {"__init__.py", "baz1.py", "baz1_test.py", "baz2.py"},
-        "foo/bar/qux": {"quux1.py"},
-    } == group_by_dir(paths)
-
-
-def test_find_putative_targets(rule_runner: RuleRunner) -> None:
+def test_find_putative_targets() -> None:
+    rule_runner = RuleRunner(
+        rules=[
+            *tailor.rules(),
+            QueryRule(PutativeTargets, (PutativePythonTargetsRequest, AllOwnedSources)),
+        ],
+        target_types=[],
+    )
     for path in [
         "src/python/foo/__init__.py",
-        "src/python/foo/bar/BUILD",
         "src/python/foo/bar/__init__.py",
         "src/python/foo/bar/baz1.py",
         "src/python/foo/bar/baz1_test.py",

--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import dataclasses
 import itertools
-import logging
 import os
 from abc import ABCMeta
 from collections import defaultdict
@@ -40,8 +39,6 @@ from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized
 from pants.util.meta import frozen_after_init
-
-logger = logging.getLogger(__name__)
 
 
 @union

--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -197,6 +197,8 @@ class TailorSubsystem(GoalSubsystem):
     name = "tailor"
     help = "Auto-generate BUILD file targets for new source files."
 
+    required_union_implementations = (PutativeTargetsRequest,)
+
     @classmethod
     def register_options(cls, register):
         super().register_options(register)

--- a/src/python/pants/core/goals/tailor_test.py
+++ b/src/python/pants/core/goals/tailor_test.py
@@ -17,6 +17,7 @@ from pants.core.goals.tailor import (
     TailorSubsystem,
     UniquelyNamedPutativeTargets,
     default_sources_for_target_type,
+    group_by_dir,
     make_content_str,
 )
 from pants.core.util_rules import source_files
@@ -239,6 +240,26 @@ def test_edit_build_files(rule_runner: RuleRunner) -> None:
         assert efc.path == afc.path
         assert efc.content.decode() == afc.content.decode()
         assert efc.is_executable == afc.is_executable
+
+
+def test_group_by_dir() -> None:
+    paths = {
+        "foo/bar/baz1.ext",
+        "foo/bar/baz1_test.ext",
+        "foo/bar/qux/quux1.ext",
+        "foo/__init__.ext",
+        "foo/bar/__init__.ext",
+        "foo/bar/baz2.ext",
+        "foo/bar1.ext",
+        "foo1.ext",
+        "__init__.ext",
+    }
+    assert {
+        "": {"__init__.ext", "foo1.ext"},
+        "foo": {"__init__.ext", "bar1.ext"},
+        "foo/bar": {"__init__.ext", "baz1.ext", "baz1_test.ext", "baz2.ext"},
+        "foo/bar/qux": {"quux1.ext"},
+    } == group_by_dir(paths)
 
 
 def test_tailor_rule(rule_runner: RuleRunner) -> None:


### PR DESCRIPTION
We can easily infer `protobuf_library` targets because they have default sources.