### PR TITLE
Remove unused `process_execution::ExecutionStats`

### DIFF
--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -155,7 +155,6 @@ impl CommandRunner {
         crate::remote::populate_fallible_execution_result(
           self.file_store.clone(),
           action_result,
-          vec![],
           platform,
           true,
         )

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -35,11 +35,8 @@ pub use log::Level;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryFrom;
-use std::ops::AddAssign;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
-use store::UploadSummary;
 use workunit_store::{with_workunit, UserMetadataItem, WorkunitMetadata, WorkunitStore};
 
 use async_semaphore::AsyncSemaphore;
@@ -350,32 +347,7 @@ pub struct FallibleProcessResultWithPlatform {
   pub stderr_digest: Digest,
   pub exit_code: i32,
   pub platform: Platform,
-
-  // It's unclear whether this should be a Snapshot or a digest of a Directory. A Directory digest
-  // is handy, so let's try that out for now.
   pub output_directory: hashing::Digest,
-
-  pub execution_attempts: Vec<ExecutionStats>,
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct ExecutionStats {
-  uploaded_bytes: usize,
-  uploaded_file_count: usize,
-  upload: Duration,
-  remote_queue: Option<Duration>,
-  remote_input_fetch: Option<Duration>,
-  remote_execution: Option<Duration>,
-  remote_output_store: Option<Duration>,
-  was_cache_hit: bool,
-}
-
-impl AddAssign<UploadSummary> for ExecutionStats {
-  fn add_assign(&mut self, summary: UploadSummary) {
-    self.uploaded_file_count += summary.uploaded_file_count;
-    self.uploaded_bytes += summary.uploaded_file_bytes;
-    self.upload += summary.upload_wall_time;
-  }
 }
 
 #[derive(Clone)]

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -621,7 +621,6 @@ export {}
           stderr_digest,
           exit_code: child_results.exit_code,
           output_directory: output_snapshot.digest,
-          execution_attempts: vec![],
           platform,
         })
       }
@@ -637,7 +636,6 @@ export {}
           stderr_digest: hashing::EMPTY_DIGEST,
           exit_code: -libc::SIGTERM,
           output_directory: hashing::EMPTY_DIGEST,
-          execution_attempts: vec![],
           platform,
         })
       }

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -41,7 +41,6 @@ async fn stdout() {
   assert_eq!(result.stderr_bytes, "".as_bytes());
   assert_eq!(result.original.exit_code, 0);
   assert_eq!(result.original.output_directory, EMPTY_DIGEST);
-  assert_eq!(result.original.execution_attempts, vec![]);
 }
 
 #[tokio::test]
@@ -61,7 +60,6 @@ async fn stdout_and_stderr_and_exit_code() {
   assert_eq!(result.stderr_bytes, "bar".as_bytes());
   assert_eq!(result.original.exit_code, 1);
   assert_eq!(result.original.output_directory, EMPTY_DIGEST);
-  assert_eq!(result.original.execution_attempts, vec![]);
 }
 
 #[tokio::test]
@@ -161,7 +159,6 @@ async fn output_files_none() {
   assert_eq!(result.stderr_bytes, "".as_bytes());
   assert_eq!(result.original.exit_code, 0);
   assert_eq!(result.original.output_directory, EMPTY_DIGEST);
-  assert_eq!(result.original.execution_attempts, vec![]);
 }
 
 #[tokio::test]

--- a/src/rust/engine/process_execution/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_cache_tests.rs
@@ -44,7 +44,6 @@ impl MockLocalCommandRunner {
         stderr_digest: EMPTY_DIGEST,
         exit_code,
         output_directory: EMPTY_DIGEST,
-        execution_attempts: vec![],
         platform: Platform::current().unwrap(),
       }),
       call_counter,
@@ -564,7 +563,6 @@ async fn make_action_result_basic() {
     exit_code: 102,
     platform: Platform::Linux,
     output_directory: directory_digest,
-    execution_attempts: Vec::new(),
   };
 
   let (action_result, digests) = runner


### PR DESCRIPTION
This has not been used since removing the "polling" remote execution implementation in https://github.com/pantsbuild/pants/pull/10306. We are still interested in metrics for remote execution, but we can add this back in a way that makes sense for the streaming implementation once we are ready to do so.

[ci skip-build-wheels]