### PR TITLE
Release the Pants PEX in `--venv` mode.

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -364,14 +364,11 @@ function build_pex() {
     requirements=("${requirements[@]}" "${pkg_name}==${PANTS_UNSTABLE_VERSION}")
   done
 
-  # Pants depends on twitter.common libraries that trigger pex warnings for not properly declaring
-  # their dependency on setuptools (for namespace package support). To prevent these known warnings
-  # from polluting stderr we pass `--no-emit-warnings`.
   execute_pex \
     -o "${dest}" \
-    --no-emit-warnings \
     --no-strip-pex-env \
     --script=pants \
+    --venv \
     "${distribution_target_flags[@]}" \
     "${requirements[@]}"
 


### PR DESCRIPTION
This speeds things up:
```
$ hyperfine --warmup 2 './dist/pants.2.3.0.dev3+gitddc75f42..pex -V' '../pants/dist/pants.2.3.0.dev3+gitddc75f42..pex -V'
Benchmark #1: ./dist/pants.2.3.0.dev3+gitddc75f42..pex -V
  Time (mean ± σ):     636.7 ms ±  23.3 ms    [User: 441.7 ms, System: 35.9 ms]
  Range (min … max):   618.9 ms … 694.6 ms    10 runs

Benchmark #2: ../pants/dist/pants.2.3.0.dev3+gitddc75f42..pex -V
  Time (mean ± σ):      1.170 s ±  0.017 s    [User: 959.8 ms, System: 56.2 ms]
  Range (min … max):    1.155 s …  1.212 s    10 runs

Summary
  './dist/pants.2.3.0.dev3+gitddc75f42..pex -V' ran
    1.84 ± 0.07 times faster than '../pants/dist/pants.2.3.0.dev3+gitddc75f42..pex -V'
```

[ci skip-rust]