### PR TITLE
Record how long a process takes to run

### DIFF
--- a/src/rust/engine/concrete_time/src/lib.rs
+++ b/src/rust/engine/concrete_time/src/lib.rs
@@ -28,7 +28,6 @@
 #![allow(clippy::mutex_atomic)]
 
 use serde_derive::Serialize;
-use std::ops::Add;
 
 /// A concrete data representation of a duration.
 /// Unlike std::time::Duration, it doesn't hide how the time is stored as the purpose of this
@@ -139,27 +138,6 @@ impl TimeSpan {
         time_span_description, end, start
       )),
     }
-  }
-
-  /// Duration since the UNIX_EPOCH.
-  pub fn end(&self) -> Duration {
-    let start: std::time::Duration = self.start.into();
-    start.add(self.duration.into()).into()
-  }
-
-  /// The start and end time of the span as Prost Timestamps.
-  pub fn as_timestamps(&self) -> (prost_types::Timestamp, prost_types::Timestamp) {
-    let end = self.end();
-    (
-      prost_types::Timestamp {
-        seconds: self.start.secs as i64,
-        nanos: self.start.nanos as i32,
-      },
-      prost_types::Timestamp {
-        seconds: end.secs as i64,
-        nanos: end.nanos as i32,
-      },
-    )
   }
 }
 

--- a/src/rust/engine/concrete_time/src/tests.rs
+++ b/src/rust/engine/concrete_time/src/tests.rs
@@ -51,19 +51,33 @@ fn time_span_from_start_and_duration_in_seconds(
 }
 
 #[test]
-fn time_span_from_start_and_end_given_positive_duration() {
-  let span = time_span_from_start_and_duration_in_seconds(42, 10);
+fn time_span_to_and_from_prost_timestamp() {
+  let span = time_span_from_start_and_duration_in_seconds(42, 10).unwrap();
   assert_eq!(
-    Ok(TimeSpan {
+    TimeSpan {
       start: Duration::new(42, 0),
       duration: Duration::new(10, 0),
-    }),
+    },
     span
   );
-}
 
-#[test]
-fn time_span_from_start_and_end_given_negative_duration() {
+  let (start, end) = span.as_timestamps();
+  assert_eq!(
+    start,
+    prost_types::Timestamp {
+      seconds: 42,
+      nanos: 0,
+    }
+  );
+  assert_eq!(
+    end,
+    prost_types::Timestamp {
+      seconds: 42 + 10,
+      nanos: 0,
+    }
+  );
+
+  // A negative duration is invalid.
   let span = time_span_from_start_and_duration_in_seconds(42, -10);
   assert!(span.is_err());
 }

--- a/src/rust/engine/concrete_time/src/tests.rs
+++ b/src/rust/engine/concrete_time/src/tests.rs
@@ -51,7 +51,7 @@ fn time_span_from_start_and_duration_in_seconds(
 }
 
 #[test]
-fn time_span_to_and_from_prost_timestamp() {
+fn time_span_from_prost_timestamp() {
   let span = time_span_from_start_and_duration_in_seconds(42, 10).unwrap();
   assert_eq!(
     TimeSpan {
@@ -59,22 +59,6 @@ fn time_span_to_and_from_prost_timestamp() {
       duration: Duration::new(10, 0),
     },
     span
-  );
-
-  let (start, end) = span.as_timestamps();
-  assert_eq!(
-    start,
-    prost_types::Timestamp {
-      seconds: 42,
-      nanos: 0,
-    }
-  );
-  assert_eq!(
-    end,
-    prost_types::Timestamp {
-      seconds: 42 + 10,
-      nanos: 0,
-    }
   );
 
   // A negative duration is invalid.

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -193,18 +193,20 @@ impl CommandRunner {
     let stdout_digest = result.stdout_digest;
     let stderr_digest = result.stderr_digest;
 
+    let action_result = remexec::ActionResult {
+      exit_code: result.exit_code,
+      output_directories: vec![remexec::OutputDirectory {
+        path: String::new(),
+        tree_digest: Some((&result.output_directory).into()),
+      }],
+      stdout_digest: Some((&stdout_digest).into()),
+      stderr_digest: Some((&stderr_digest).into()),
+      execution_metadata: Some(result.metadata.clone().into()),
+      ..remexec::ActionResult::default()
+    };
     let execute_response = remexec::ExecuteResponse {
       cached_result: true,
-      result: Some(remexec::ActionResult {
-        exit_code: result.exit_code,
-        output_directories: vec![remexec::OutputDirectory {
-          path: String::new(),
-          tree_digest: Some((&result.output_directory).into()),
-        }],
-        stdout_digest: Some((&stdout_digest).into()),
-        stderr_digest: Some((&stderr_digest).into()),
-        ..remexec::ActionResult::default()
-      }),
+      result: Some(action_result),
       ..remexec::ExecuteResponse::default()
     };
 

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -32,6 +32,7 @@ use workunit_store::Metric;
 
 use crate::{
   Context, FallibleProcessResultWithPlatform, MultiPlatformProcess, NamedCaches, Platform, Process,
+  ProcessResultMetadata,
 };
 
 pub const USER_EXECUTABLE_MODE: u32 = 0o100755;
@@ -579,6 +580,7 @@ pub trait CapturedWorkdir {
           exit_code: child_results.exit_code,
           output_directory: output_snapshot.digest,
           platform,
+          metadata: ProcessResultMetadata::default(),
         })
       }
       Err(msg) if msg == "deadline has elapsed" => {
@@ -594,6 +596,7 @@ pub trait CapturedWorkdir {
           exit_code: -libc::SIGTERM,
           output_directory: hashing::EMPTY_DIGEST,
           platform,
+          metadata: ProcessResultMetadata::default(),
         })
       }
       Err(msg) => Err(msg),

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -273,6 +273,7 @@ impl CommandRunner {
       exit_code: result.exit_code,
       stdout_digest: Some(result.stdout_digest.into()),
       stderr_digest: Some(result.stderr_digest.into()),
+      execution_metadata: Some(result.metadata.clone().into()),
       ..ActionResult::default()
     };
 

--- a/src/rust/engine/process_execution/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_cache_tests.rs
@@ -21,7 +21,7 @@ use workunit_store::WorkunitStore;
 use crate::remote::{ensure_action_stored_locally, make_execute_request};
 use crate::{
   CommandRunner as CommandRunnerTrait, Context, FallibleProcessResultWithPlatform,
-  MultiPlatformProcess, Platform, Process, ProcessMetadata,
+  MultiPlatformProcess, Platform, Process, ProcessMetadata, ProcessResultMetadata,
 };
 
 /// A mock of the local runner used for better hermeticity of the tests.
@@ -45,6 +45,7 @@ impl MockLocalCommandRunner {
         exit_code,
         output_directory: EMPTY_DIGEST,
         platform: Platform::current().unwrap(),
+        metadata: ProcessResultMetadata::default(),
       }),
       call_counter,
       delay: Duration::from_millis(delay_ms),
@@ -560,9 +561,10 @@ async fn make_action_result_basic() {
   let process_result = FallibleProcessResultWithPlatform {
     stdout_digest: TestData::roland().digest(),
     stderr_digest: TestData::robin().digest(),
+    output_directory: directory_digest,
     exit_code: 102,
     platform: Platform::Linux,
-    output_directory: directory_digest,
+    metadata: ProcessResultMetadata::default(),
   };
 
   let (action_result, digests) = runner

--- a/src/rust/engine/process_execution/src/tests.rs
+++ b/src/rust/engine/process_execution/src/tests.rs
@@ -1,7 +1,14 @@
-use crate::Process;
+// Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::time::Duration;
+
+use crate::{Process, ProcessResultMetadata};
+use bazel_protos::gen::build::bazel::remote::execution::v2 as remexec;
+use prost_types::Timestamp;
+use remexec::ExecutedActionMetadata;
 
 #[test]
 fn process_equality() {
@@ -26,14 +33,58 @@ fn process_equality() {
   let d = process_generator("One thing".to_string(), None);
 
   // Process should derive a PartialEq and Hash that ignores the description
-  assert!(a == b);
-  assert!(hash(&a) == hash(&b));
+  assert_eq!(a, b);
+  assert_eq!(hash(&a), hash(&b));
 
   // ..but not other fields.
-  assert!(a != c);
-  assert!(hash(&a) != hash(&c));
+  assert_ne!(a, c);
+  assert_ne!(hash(&a), hash(&c));
 
   // Absence of timeout is included in hash.
-  assert!(a != d);
-  assert!(hash(&a) != hash(&d));
+  assert_ne!(a, d);
+  assert_ne!(hash(&a), hash(&d));
+}
+
+#[test]
+fn process_result_metadata_to_and_from_executed_action_metadata() {
+  let action_metadata = ExecutedActionMetadata {
+    execution_start_timestamp: Some(Timestamp {
+      seconds: 100,
+      nanos: 20,
+    }),
+    execution_completed_timestamp: Some(Timestamp {
+      seconds: 120,
+      nanos: 50,
+    }),
+    ..ExecutedActionMetadata::default()
+  };
+
+  let converted_process_result: ProcessResultMetadata = action_metadata.into();
+  assert_eq!(
+    converted_process_result,
+    ProcessResultMetadata::new(Some(concrete_time::Duration::new(20, 30)))
+  );
+
+  // The conversion from `ExecutedActionMetadata` to `ProcessResultMetadata` is lossy.
+  let restored_action_metadata: ExecutedActionMetadata = converted_process_result.into();
+  assert_eq!(
+    restored_action_metadata,
+    ExecutedActionMetadata {
+      execution_start_timestamp: Some(Timestamp {
+        seconds: 0,
+        nanos: 0,
+      }),
+      execution_completed_timestamp: Some(Timestamp {
+        seconds: 20,
+        nanos: 30,
+      }),
+      ..ExecutedActionMetadata::default()
+    }
+  );
+
+  // The relevant metadata may be missing from either type.
+  let action_metadata_missing: ProcessResultMetadata = ExecutedActionMetadata::default().into();
+  assert_eq!(action_metadata_missing, ProcessResultMetadata::default());
+  let process_result_missing: ExecutedActionMetadata = ProcessResultMetadata::default().into();
+  assert_eq!(process_result_missing, ExecutedActionMetadata::default());
 }

--- a/src/rust/engine/process_execution/src/tests.rs
+++ b/src/rust/engine/process_execution/src/tests.rs
@@ -48,11 +48,11 @@ fn process_equality() {
 #[test]
 fn process_result_metadata_to_and_from_executed_action_metadata() {
   let action_metadata = ExecutedActionMetadata {
-    execution_start_timestamp: Some(Timestamp {
+    worker_start_timestamp: Some(Timestamp {
       seconds: 100,
       nanos: 20,
     }),
-    execution_completed_timestamp: Some(Timestamp {
+    worker_completed_timestamp: Some(Timestamp {
       seconds: 120,
       nanos: 50,
     }),
@@ -70,11 +70,11 @@ fn process_result_metadata_to_and_from_executed_action_metadata() {
   assert_eq!(
     restored_action_metadata,
     ExecutedActionMetadata {
-      execution_start_timestamp: Some(Timestamp {
+      worker_start_timestamp: Some(Timestamp {
         seconds: 0,
         nanos: 0,
       }),
-      execution_completed_timestamp: Some(Timestamp {
+      worker_completed_timestamp: Some(Timestamp {
         seconds: 20,
         nanos: 30,
       }),


### PR DESCRIPTION
This will allow us to answer questions like how much time caching (both local and remote) is saving vs. running the process again. For example, we can compare the cache time vs. the original recorded execution time.

To preserve the execution time, we must store the metadata both on `FallibleProcessResultWithPlatform` _and_ `ActionResult`, which is what we serialize to for the local and remote caches. This introduces `ProcessResultMetadata`, which is a sibling to [REAPI's `ExecutedActionMetadata`](https://github.com/bazelbuild/remote-apis/blob/9e72daff42c941baaf43a4c370e2607a984c58a7/build/bazel/remote/execution/v2/remote_execution.proto#L859-L895).

For remote execution, it's up to them to correctly set the `ExecutedActionMetadata`, which we then convert into `ProcessResultMetadata`. But for local execution, we can ensure we set up both types correctly.

The timings match what we see with the dynamic UI:

```
12:43:46.35 [INFO] Starting: Building pytest.pex with 5 requirements: ipdb, pygments, pytest-cov>=2.10.1,<2.12, pytest-icdiff, pytest>=6.0.1,<6.3
12:43:50.92 [INFO] Completed: Building pytest.pex with 5 requirements: ipdb, pygments, pytest-cov>=2.10.1,<2.12, pytest-icdiff, pytest>=6.0.1,<6.3
12:43:50.92 [INFO] Some(Duration { secs: 4, nanos: 565505208 })
```
