### PR TITLE
Add metrics for time saved from local and remote caching

### DIFF
--- a/src/rust/engine/fs/store/src/local.rs
+++ b/src/rust/engine/fs/store/src/local.rs
@@ -302,7 +302,7 @@ impl ByteStore {
 
     if let Some(workunit_store_handle) = workunit_store::get_workunit_store_handle() {
       workunit_store_handle.store.record_observation(
-        ObservationMetric::LocalStoreReadBlobSize,
+        ObservationMetric::LocalCacheReadBlobSize,
         digest.size_bytes as u64,
       );
     }

--- a/src/rust/engine/fs/store/src/local.rs
+++ b/src/rust/engine/fs/store/src/local.rs
@@ -302,7 +302,7 @@ impl ByteStore {
 
     if let Some(workunit_store_handle) = workunit_store::get_workunit_store_handle() {
       workunit_store_handle.store.record_observation(
-        ObservationMetric::LocalCacheReadBlobSize,
+        ObservationMetric::LocalStoreReadBlobSize,
         digest.size_bytes as u64,
       );
     }

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -83,10 +83,13 @@ impl crate::CommandRunner for CommandRunner {
             .workunit_store
             .increment_counter(Metric::LocalCacheRequestsCached, 1);
           if let Some(time_saved) = result.metadata.time_saved_from_cache(lookup_elapsed) {
-            context.workunit_store.record_observation(
-              ObservationMetric::LocalCacheTimeSavedMs,
-              time_saved.as_millis() as u64,
-            );
+            let time_saved = time_saved.as_millis() as u64;
+            context
+              .workunit_store
+              .increment_counter(Metric::LocalCacheTotalTimeSavedMs, time_saved);
+            context
+              .workunit_store
+              .record_observation(ObservationMetric::LocalCacheTimeSavedMs, time_saved);
           }
           return Ok(result);
         }

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -375,13 +375,23 @@ impl ProcessResultMetadata {
   ///
   /// This includes the overhead of setting up and cleaning up the process for execution, and it
   /// should include all overhead for the cache lookup.
+  ///
+  /// If the cache hit was slower than the original process, we return 0. Note that the cache hit
+  /// may still have been faster than rerunning the process a second time, e.g. if speculation
+  /// is used and the cache hit completed before the rerun; still, we cannot know how long the
+  /// second run would have taken, so the best we can do is report 0.
+  ///
+  /// If the original process's execution time was not recorded, we return None because we
+  /// cannot make a meaningful comparison.
   pub fn time_saved_from_cache(
     &self,
     cache_lookup: std::time::Duration,
   ) -> Option<std::time::Duration> {
     self.total_elapsed.and_then(|original_process| {
       let original_process: std::time::Duration = original_process.into();
-      original_process.checked_sub(cache_lookup)
+      original_process
+        .checked_sub(cache_lookup)
+        .or(Some(std::time::Duration::new(0, 0)))
     })
   }
 }

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -370,6 +370,23 @@ impl ProcessResultMetadata {
   pub fn new(total_elapsed: Option<Duration>) -> Self {
     ProcessResultMetadata { total_elapsed }
   }
+
+  /// How much faster a cache hit was than running the process again.
+  ///
+  /// This includes the overhead of setting up and cleaning up the process for execution, and it
+  /// should include all overhead for the cache lookup.
+  pub fn time_saved_from_cache(
+    &self,
+    cache_lookup: std::time::Duration,
+  ) -> Option<std::time::Duration> {
+    match self.total_elapsed {
+      None => None,
+      Some(original_process) => {
+        let original_process: std::time::Duration = original_process.into();
+        original_process.checked_sub(cache_lookup)
+      }
+    }
+  }
 }
 
 impl From<ExecutedActionMetadata> for ProcessResultMetadata {

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -379,13 +379,10 @@ impl ProcessResultMetadata {
     &self,
     cache_lookup: std::time::Duration,
   ) -> Option<std::time::Duration> {
-    match self.total_elapsed {
-      None => None,
-      Some(original_process) => {
-        let original_process: std::time::Duration = original_process.into();
-        original_process.checked_sub(cache_lookup)
-      }
-    }
+    self.total_elapsed.and_then(|original_process| {
+      let original_process: std::time::Duration = original_process.into();
+      original_process.checked_sub(cache_lookup)
+    })
   }
 }
 

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -391,7 +391,7 @@ impl ProcessResultMetadata {
       let original_process: std::time::Duration = original_process.into();
       original_process
         .checked_sub(cache_lookup)
-        .or(Some(std::time::Duration::new(0, 0)))
+        .or_else(|| Some(std::time::Duration::new(0, 0)))
     })
   }
 }

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -457,14 +457,14 @@ impl crate::CommandRunner for CommandRunner {
             let lookup_elapsed = cache_lookup_start.elapsed();
             context.workunit_store.increment_counter(Metric::RemoteCacheSpeculationRemoteCompletedFirst, 1);
             if let Some(time_saved) = cached_response.metadata.time_saved_from_cache(lookup_elapsed) {
-            let time_saved = time_saved.as_millis() as u64;
-            context
-              .workunit_store
-              .increment_counter(Metric::RemoteCacheTotalTimeSavedMs, time_saved);
-            context
-              .workunit_store
-              .record_observation(ObservationMetric::RemoteCacheTimeSavedMs, time_saved);
-            }
+              let time_saved = time_saved.as_millis() as u64;
+              context
+                .workunit_store
+                .increment_counter(Metric::RemoteCacheTotalTimeSavedMs, time_saved);
+              context
+                .workunit_store
+                .record_observation(ObservationMetric::RemoteCacheTimeSavedMs, time_saved);
+              }
             return Ok(cached_response);
           } else {
             // Note that we don't increment a counter here, as there is nothing of note in this

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::ffi::OsString;
 use std::path::Component;
 use std::sync::Arc;
+use std::time::Instant;
 
 use async_trait::async_trait;
 use bazel_protos::gen::build::bazel::remote::execution::v2 as remexec;
@@ -14,7 +15,7 @@ use remexec::action_cache_client::ActionCacheClient;
 use remexec::{ActionResult, Command, FileNode, Tree};
 use store::Store;
 use tonic::transport::Channel;
-use workunit_store::{with_workunit, Level, Metric, WorkunitMetadata};
+use workunit_store::{with_workunit, Level, Metric, ObservationMetric, WorkunitMetadata};
 
 use crate::remote::make_execute_request;
 use crate::{
@@ -391,6 +392,7 @@ impl crate::CommandRunner for CommandRunner {
     req: MultiPlatformProcess,
     context: Context,
   ) -> Result<FallibleProcessResultWithPlatform, String> {
+    let cache_lookup_start = Instant::now();
     // Construct the REv2 ExecuteRequest and related data for this execution request.
     let request = self
       .extract_compatible_request(&req)
@@ -452,7 +454,14 @@ impl crate::CommandRunner for CommandRunner {
       tokio::select! {
         cache_result = cache_read_future => {
           if let Some(cached_response) = cache_result {
+            let lookup_elapsed = cache_lookup_start.elapsed();
             context.workunit_store.increment_counter(Metric::RemoteCacheSpeculationRemoteCompletedFirst, 1);
+            if let Some(time_saved) = cached_response.metadata.time_saved_from_cache(lookup_elapsed) {
+              context.workunit_store.record_observation(
+                ObservationMetric::RemoteCacheTimeSavedMs,
+                time_saved.as_millis() as u64,
+              );
+            }
             return Ok(cached_response);
           } else {
             // Note that we don't increment a counter here, as there is nothing of note in this

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -457,10 +457,13 @@ impl crate::CommandRunner for CommandRunner {
             let lookup_elapsed = cache_lookup_start.elapsed();
             context.workunit_store.increment_counter(Metric::RemoteCacheSpeculationRemoteCompletedFirst, 1);
             if let Some(time_saved) = cached_response.metadata.time_saved_from_cache(lookup_elapsed) {
-              context.workunit_store.record_observation(
-                ObservationMetric::RemoteCacheTimeSavedMs,
-                time_saved.as_millis() as u64,
-              );
+            let time_saved = time_saved.as_millis() as u64;
+            context
+              .workunit_store
+              .increment_counter(Metric::RemoteCacheTotalTimeSavedMs, time_saved);
+            context
+              .workunit_store
+              .record_observation(ObservationMetric::RemoteCacheTimeSavedMs, time_saved);
             }
             return Ok(cached_response);
           } else {

--- a/src/rust/engine/process_execution/src/tests.rs
+++ b/src/rust/engine/process_execution/src/tests.rs
@@ -95,14 +95,14 @@ fn process_result_metadata_time_saved_from_cache() {
   let time_saved = metadata.time_saved_from_cache(Duration::new(1, 100));
   assert_eq!(time_saved, Some(Duration::new(4, 50)));
 
+  // If the cache lookup took more time than the process, we return 0.
+  let metadata = ProcessResultMetadata::new(Some(concrete_time::Duration::new(1, 0)));
+  let time_saved = metadata.time_saved_from_cache(Duration::new(5, 0));
+  assert_eq!(time_saved, Some(Duration::new(0, 0)));
+
   // If the original process time wasn't recorded, we can't compute the time saved.
   assert_eq!(
     ProcessResultMetadata::default().time_saved_from_cache(Duration::new(1, 100)),
     None
   );
-
-  // If the cache lookup took more time than the process, we return None.
-  let metadata = ProcessResultMetadata::new(Some(concrete_time::Duration::new(1, 0)));
-  let time_saved = metadata.time_saved_from_cache(Duration::new(5, 0));
-  assert_eq!(time_saved, None);
 }

--- a/src/rust/engine/process_execution/src/tests.rs
+++ b/src/rust/engine/process_execution/src/tests.rs
@@ -88,3 +88,16 @@ fn process_result_metadata_to_and_from_executed_action_metadata() {
   let process_result_missing: ExecutedActionMetadata = ProcessResultMetadata::default().into();
   assert_eq!(process_result_missing, ExecutedActionMetadata::default());
 }
+
+#[test]
+fn process_result_metadata_time_saved_from_cache() {
+  let metadata = ProcessResultMetadata::new(Some(concrete_time::Duration::new(5, 150)));
+  let time_saved = metadata.time_saved_from_cache(Duration::new(1, 100));
+  assert_eq!(time_saved, Some(Duration::new(4, 50)));
+
+  // If the original process time wasn't recorded, we can't compute the time saved.
+  assert_eq!(
+    ProcessResultMetadata::default().time_saved_from_cache(Duration::new(1, 100)),
+    None
+  );
+}

--- a/src/rust/engine/process_execution/src/tests.rs
+++ b/src/rust/engine/process_execution/src/tests.rs
@@ -100,4 +100,9 @@ fn process_result_metadata_time_saved_from_cache() {
     ProcessResultMetadata::default().time_saved_from_cache(Duration::new(1, 100)),
     None
   );
+
+  // If the cache lookup took more time than the process, we return None.
+  let metadata = ProcessResultMetadata::new(Some(concrete_time::Duration::new(1, 0)));
+  let time_saved = metadata.time_saved_from_cache(Duration::new(5, 0));
+  assert_eq!(time_saved, None);
 }

--- a/src/rust/engine/workunit_store/src/metrics.rs
+++ b/src/rust/engine/workunit_store/src/metrics.rs
@@ -48,6 +48,9 @@ pub enum Metric {
   LocalCacheRequestsUncached,
   LocalCacheReadErrors,
   LocalCacheWriteErrors,
+  /// The total time saved (in milliseconds) thanks to local cache hits instead of running the
+  /// processes directly.
+  LocalCacheTotalTimeSavedMs,
   LocalExecutionRequests,
   RemoteCacheRequests,
   RemoteCacheRequestsCached,
@@ -58,6 +61,9 @@ pub enum Metric {
   RemoteCacheWriteFinished,
   RemoteCacheSpeculationLocalCompletedFirst,
   RemoteCacheSpeculationRemoteCompletedFirst,
+  /// The total time saved (in milliseconds) thanks to remote cache hits instead of running the
+  /// processes directly.
+  RemoteCacheTotalTimeSavedMs,
   RemoteExecutionErrors,
   RemoteExecutionRequests,
   RemoteExecutionRPCErrors,
@@ -78,13 +84,13 @@ impl Metric {
 #[strum(serialize_all = "snake_case")]
 pub enum ObservationMetric {
   TestObservation,
-  LocalStoreReadBlobSize,
+  LocalCacheReadBlobSize,
   RemoteExecutionRPCFirstResponseTime,
   RemoteStoreTimeToFirstByte,
-  /// The time saved (in milliseconds) thanks to a local cache hit compared to running the process
-  /// again.
+  /// The time saved (in milliseconds) thanks to a local cache hit instead of running the process
+  /// directly.
   LocalCacheTimeSavedMs,
-  /// The time saved (in milliseconds) thanks to a remote cache hit compared to running the process
-  /// again.
+  /// The time saved (in milliseconds) thanks to a remote cache hit instead of running the process
+  /// directly.
   RemoteCacheTimeSavedMs,
 }

--- a/src/rust/engine/workunit_store/src/metrics.rs
+++ b/src/rust/engine/workunit_store/src/metrics.rs
@@ -81,4 +81,10 @@ pub enum ObservationMetric {
   LocalStoreReadBlobSize,
   RemoteExecutionRPCFirstResponseTime,
   RemoteStoreTimeToFirstByte,
+  /// The time saved (in milliseconds) thanks to a local cache hit compared to running the process
+  /// again.
+  LocalCacheTimeSavedMs,
+  /// The time saved (in milliseconds) thanks to a remote cache hit compared to running the process
+  /// again.
+  RemoteCacheTimeSavedMs,
 }

--- a/src/rust/engine/workunit_store/src/metrics.rs
+++ b/src/rust/engine/workunit_store/src/metrics.rs
@@ -84,7 +84,7 @@ impl Metric {
 #[strum(serialize_all = "snake_case")]
 pub enum ObservationMetric {
   TestObservation,
-  LocalCacheReadBlobSize,
+  LocalStoreReadBlobSize,
   RemoteExecutionRPCFirstResponseTime,
   RemoteStoreTimeToFirstByte,
   /// The time saved (in milliseconds) thanks to a local cache hit instead of running the process


### PR DESCRIPTION
This is useful for users to tune caching -- for example, how much time is saved by local caching in CI, and how does this compare to the cache download/upload time?

```
❯ ./pants --plugins=hdrhistogram --stats-log --pants-config-files=pants.remote-cache.toml lint src/python/pants/util/strutil.py --no-pantsd --no-process-execution-use-local-cache
...
03:02:24.70 [INFO] Counters:
  ...
  remote_cache_total_time_saved_ms: 22222
  ...
03:02:24.70 [INFO] Observation histogram summaries:
03:02:24.98 [INFO] Summary of `remote_cache_time_saved_ms` observation histogram:
  min: 67
  max: 8239
  mean: 2777.750
  std dev: 2866.382
  total observations: 8
  p25: 201
  p50: 222
  p75: 4359
  p90: 5007
  p95: 8239
  p99: 8239
```

```
❯ ./pants --plugins=hdrhistogram --stats-log lint src/python/pants/util/strutil.py --no-pantsd
...
03:04:46.64 [INFO] Counters:
  ...
  local_cache_total_time_saved_ms: 22314
  ...
03:04:46.64 [INFO] Observation histogram summaries:
03:04:46.72 [INFO] Summary of `local_cache_time_saved_ms` observation histogram:
  min: 76
  max: 8247
  mean: 2789.125
  std dev: 2866.593
  total observations: 8
  p25: 207
  p50: 238
  p75: 4371
  p90: 5027
  p95: 8247
  p99: 8247
```

[ci skip-build-wheels]