### PR TITLE
Enable post-run stats logging in CI

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -20,6 +20,7 @@ backend_packages.add = [
 ]
 
 plugins = [
+  "hdrhistogram",  # For use with `--stats-log`.
   "toolchain.pants.plugin==0.5.0",
 ]
 

--- a/pants.travis-ci.toml
+++ b/pants.travis-ci.toml
@@ -4,6 +4,9 @@ colors = true
 # TODO: See #9924.
 dynamic_ui = false
 
+[stats]
+log = true
+
 [test]
 use_coverage = true
 


### PR DESCRIPTION
It's useful to see in our CI logs things like how many cache hits we had.

[ci skip-rust]