### PR TITLE
Deprecate --python-setup-resolver-version option.

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -60,7 +60,6 @@ root_patterns = [
 ]
 
 [python-setup]
-resolver_version = "pip-2020-resolver"
 requirement_constraints = "3rdparty/python/constraints.txt"
 resolve_all_constraints = "nondeployables"
 interpreter_constraints = [">=3.7,<3.9"]

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -118,11 +118,10 @@ class PythonSetup(Subsystem):
             "--resolver-version",
             advanced=True,
             type=ResolverVersion,
-            default=ResolverVersion.PIP_LEGACY,
+            default=ResolverVersion.PIP_2020,
             help=(
                 "The resolver implementation to use when resolving Python requirements.\n\nSupport "
-                f"for the {ResolverVersion.PIP_LEGACY.value!r} will be removed in Pants 2.5; so "
-                f"you're encouraged to start using the {ResolverVersion.PIP_2020.value!r} early. "
+                f"for the {ResolverVersion.PIP_LEGACY.value!r} will be removed in Pants 2.5. "
                 "For more information on this change see "
                 "https://pip.pypa.io/en/latest/user_guide/#changes-to-the-pip-dependency-resolver-in-20-2-2020"
             ),
@@ -183,19 +182,30 @@ class PythonSetup(Subsystem):
     # changes
     @memoized_property
     def resolver_version(self) -> ResolverVersion:
-        if self.options.is_default("resolver_version"):
-            warn_or_error(
-                removal_version="2.4.0.dev0",
-                deprecated_entity_description="defaulting to the legacy pip resolver",
-                hint=(
-                    "In Pants 2.4.0, Pants will default to using pip's new resolver. The legacy "
-                    "resolver will be removed in Pants 2.5.\n\nSet "
-                    "`[python-setup].resolver_version = 'pip-2020-resolver` to prepare for the "
-                    "default changing. Refer to "
-                    "https://pip.pypa.io/en/latest/user_guide/#changes-to-the-pip-dependency-resolver-in-20-2-2020"
-                    " for more information on the new resolver."
-                ),
-            )
+        if not self.options.is_default("resolver_version"):
+            if self.options.resolver_version == ResolverVersion.PIP_LEGACY:
+                warn_or_error(
+                    removal_version="2.5.0.dev0",
+                    deprecated_entity_description="resolver_version",
+                    hint=(
+                        "Support for configuring resolver_version and selecting pip's legacy "
+                        "resolver will be removed in Pants 2.5. Refer to "
+                        "https://pip.pypa.io/en/latest/user_guide/"
+                        "#changes-to-the-pip-dependency-resolver-in-20-2-2020 for more information "
+                        "on the new resolver."
+                    ),
+                )
+            else:
+                warn_or_error(
+                    removal_version="2.5.0.dev0",
+                    deprecated_entity_description="resolver_version",
+                    hint=(
+                        "Support for configuring resolver_version will be removed in Pants 2.5. "
+                        "You're already using the default of "
+                        f"{ResolverVersion.PIP_2020.value!r}; so the option configuration can "
+                        "simply be removed."
+                    ),
+                )
         return cast(ResolverVersion, self.options.resolver_version)
 
     @property

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -12,7 +12,6 @@ from typing import Callable, Iterable, List, Optional, Tuple, cast
 from pex.variables import Variables
 
 from pants.base.build_environment import get_buildroot
-from pants.base.deprecated import warn_or_error
 from pants.option.custom_types import file_option
 from pants.option.subsystem import Subsystem
 from pants.util.memo import memoized_property
@@ -119,11 +118,13 @@ class PythonSetup(Subsystem):
             advanced=True,
             type=ResolverVersion,
             default=ResolverVersion.PIP_2020,
-            help=(
-                "The resolver implementation to use when resolving Python requirements.\n\nSupport "
-                f"for the {ResolverVersion.PIP_LEGACY.value!r} will be removed in Pants 2.5. "
-                "For more information on this change see "
-                "https://pip.pypa.io/en/latest/user_guide/#changes-to-the-pip-dependency-resolver-in-20-2-2020"
+            help="The resolver implementation to use when resolving Python requirements.",
+            removal_version="2.5.0.dev0",
+            removal_hint=(
+                "Support for configuring --resolver-version and selecting pip's legacy resolver "
+                "will be removed in Pants 2.5. Refer to https://pip.pypa.io/en/latest/user_guide/"
+                "#changes-to-the-pip-dependency-resolver-in-20-2-2020 for more information on the "
+                "new resolver."
             ),
         )
         register(
@@ -178,34 +179,8 @@ class PythonSetup(Subsystem):
     def interpreter_search_paths(self):
         return self.expand_interpreter_search_paths(self.options.interpreter_search_paths)
 
-    # Note: only memoized to avoid the deprecation happening multiple times. Change back once the default
-    # changes
-    @memoized_property
+    @property
     def resolver_version(self) -> ResolverVersion:
-        if not self.options.is_default("resolver_version"):
-            if self.options.resolver_version == ResolverVersion.PIP_LEGACY:
-                warn_or_error(
-                    removal_version="2.5.0.dev0",
-                    deprecated_entity_description="resolver_version",
-                    hint=(
-                        "Support for configuring resolver_version and selecting pip's legacy "
-                        "resolver will be removed in Pants 2.5. Refer to "
-                        "https://pip.pypa.io/en/latest/user_guide/"
-                        "#changes-to-the-pip-dependency-resolver-in-20-2-2020 for more information "
-                        "on the new resolver."
-                    ),
-                )
-            else:
-                warn_or_error(
-                    removal_version="2.5.0.dev0",
-                    deprecated_entity_description="resolver_version",
-                    hint=(
-                        "Support for configuring resolver_version will be removed in Pants 2.5. "
-                        "You're already using the default of "
-                        f"{ResolverVersion.PIP_2020.value!r}; so the option configuration can "
-                        "simply be removed."
-                    ),
-                )
         return cast(ResolverVersion, self.options.resolver_version)
 
     @property


### PR DESCRIPTION
Switch the default --python-setup-resolver-version to the pip-2020-resolver
and update warnings for removal of the option in 2.5.

[ci skip-rust]
[ci skip-build-wheels]
