### PR TITLE
Cancel GitHub Actions jobs for stale SHAs.

### DIFF
--- a/.github/workflows/cancel.yaml
+++ b/.github/workflows/cancel.yaml
@@ -1,0 +1,16 @@
+name: Cancel
+on:
+  workflow_run:
+    workflows: ["Pull Request CI"]
+    types:
+      - requested
+jobs:
+  cancel:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          # Note that this job runs in the context of the default branch, so its token
+          # has permission to cancel workflows (i.e., it is not the PR's read-only token).
+          workflow_id: ${{ github.event.workflow.id }}
+          access_token: ${{ github.token }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,6 +24,7 @@
 
 # There is no need to run linters on both platforms...
 
+# NOTE: This name must be synced to cancel.yaml if changed.
 name: Pull Request CI
 
 on:


### PR DESCRIPTION
If pushing a new commit to a branch/PR we might as well
cancel any pending jobs on earlier commits.

In GHA this is achieved using a 3rdparty action someone
has kindly written to do this: 

https://github.com/marketplace/actions/cancel-workflow-action

Note that testing this is slightly tricky, as the .yaml file must land
in the default branch before it takes effect. So there may have to be 
follow-up tweaks.

[ci skip-rust]

[ci skip-build-wheels]

