### PR TITLE
[internal] Upgrade toolchain plugin to 0.6.0

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -21,7 +21,7 @@ backend_packages.add = [
 
 plugins = [
   "hdrhistogram",  # For use with `--stats-log`.
-  "toolchain.pants.plugin==0.5.0",
+  "toolchain.pants.plugin==0.6.0",
 ]
 
 build_file_prelude_globs = ["pants-plugins/python_integration_tests_macro.py"]


### PR DESCRIPTION
The new version of the Toolchain plugin adds support for new pants API for counters & targets spec.
As well as fixing Github Actions CI integration.