### PR TITLE
[internal] House development venvs in home.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -93,7 +93,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            build-support/virtualenvs
+            ~/.cache/pants/pants_dev_deps
           key: |
             ${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles('pants/3rdparty/python/**', 'pants.toml') }}
       - name: Get Engine Hash
@@ -160,7 +160,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            build-support/virtualenvs
+            ~/.cache/pants/pants_dev_deps
           key: |
             ${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles('pants/3rdparty/python/**', 'pants.toml') }}
       - name: Download native_engine.so
@@ -193,7 +193,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            build-support/virtualenvs
+            ~/.cache/pants/pants_dev_deps
           key: |
             ${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles('pants/3rdparty/python/**', 'pants.toml') }}
       - name: Download native_engine.so
@@ -265,7 +265,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            build-support/virtualenvs
+            ~/.cache/pants/pants_dev_deps
           key: |
             ${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles('pants/3rdparty/python/**', 'pants.toml') }}
       - name: Get Engine Hash
@@ -322,7 +322,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            build-support/virtualenvs
+            ~/.cache/pants/pants_dev_deps
           key: |
             ${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles('pants/3rdparty/python/**', 'pants.toml') }}
       - name: Download native_engine.so

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,6 @@ out/
 # remove root-level /bin, which is created by Eclipse
 /bin/
 /build-support/*.pex
-/build-support/virtualenvs
 /build-support/virtualenv-*
 /build-support/virtualenv.dist/
 /build-support/phab/

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
       - ${PYENV_ROOT_OSX}
       - ${HOME}/.rustup
       - ${HOME}/.cargo
-      - build-support/virtualenvs
+      - ${HOME}/.cache/pants/pants_dev_deps
       - src/rust/engine/target
       timeout: 500
     dist: bionic
@@ -115,7 +115,7 @@ jobs:
       - ${PYENV_ROOT_OSX}
       - ${HOME}/.rustup
       - ${HOME}/.cargo
-      - build-support/virtualenvs
+      - ${HOME}/.cache/pants/pants_dev_deps
       - src/rust/engine/target
       timeout: 500
     dist: bionic
@@ -162,7 +162,7 @@ jobs:
       - ${PYENV_ROOT_OSX}
       - ${HOME}/.rustup
       - ${HOME}/.cargo
-      - build-support/virtualenvs
+      - ${HOME}/.cache/pants/pants_dev_deps
       - src/rust/engine/target
       timeout: 500
     env:
@@ -206,7 +206,7 @@ jobs:
       - ${PYENV_ROOT_OSX}
       - ${HOME}/.rustup
       - ${HOME}/.cargo
-      - build-support/virtualenvs
+      - ${HOME}/.cache/pants/pants_dev_deps
       - src/rust/engine/target
       timeout: 500
     env:
@@ -351,7 +351,7 @@ jobs:
       - ${PYENV_ROOT_OSX}
       - ${HOME}/.rustup
       - ${HOME}/.cargo
-      - build-support/virtualenvs
+      - ${HOME}/.cache/pants/pants_dev_deps
       - src/rust/engine/target
       timeout: 500
     dist: xenial
@@ -385,7 +385,7 @@ jobs:
       - ${PYENV_ROOT_OSX}
       - ${HOME}/.rustup
       - ${HOME}/.cargo
-      - build-support/virtualenvs
+      - ${HOME}/.cache/pants/pants_dev_deps
       - src/rust/engine/target
       timeout: 500
     dist: xenial
@@ -522,7 +522,7 @@ jobs:
       - ${PYENV_ROOT_OSX}
       - ${HOME}/.rustup
       - ${HOME}/.cargo
-      - build-support/virtualenvs
+      - ${HOME}/.cache/pants/pants_dev_deps
       - src/rust/engine/target
       timeout: 500
     dist: xenial
@@ -554,7 +554,7 @@ jobs:
       - ${PYENV_ROOT_OSX}
       - ${HOME}/.rustup
       - ${HOME}/.cargo
-      - build-support/virtualenvs
+      - ${HOME}/.cache/pants/pants_dev_deps
       - src/rust/engine/target
       timeout: 500
     env:
@@ -648,7 +648,7 @@ jobs:
       - ${PYENV_ROOT_OSX}
       - ${HOME}/.rustup
       - ${HOME}/.cargo
-      - build-support/virtualenvs
+      - ${HOME}/.cache/pants/pants_dev_deps
       - src/rust/engine/target
       timeout: 500
     env:

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -219,7 +219,7 @@ CACHE_NATIVE_ENGINE = {
             *_cache_common_directories,
             "${HOME}/.rustup",
             "${HOME}/.cargo",
-            "build-support/virtualenvs",
+            "${HOME}/.cache/pants/pants_dev_deps",
             "src/rust/engine/target",
         ],
     },

--- a/build-support/bin/prune_travis_cache.sh
+++ b/build-support/bin/prune_travis_cache.sh
@@ -26,11 +26,11 @@ function nuke_if_too_big() {
 
 nuke_if_too_big "${HOME}/.pants_pyenv" 512
 nuke_if_too_big "${HOME}/.aws_cli" 128
+nuke_if_too_big "${HOME}/.cache/pants/pants_dev_deps" 128
 nuke_if_too_big "${HOME}/.cache/pants/tools" 128
 nuke_if_too_big "${HOME}/.cache/pants/zinc" 128
 nuke_if_too_big "${HOME}/.ivy2/pants" 512
 nuke_if_too_big "${HOME}/.npm" 128
-nuke_if_too_big build-support/virtualenvs 128
 nuke_if_too_big src/rust/engine/target 3072
 
 # Note that we don't prune all of ${HOME}/.cache/pants/rust/cargo, as it mostly contains git

--- a/build-support/bin/shellcheck.py
+++ b/build-support/bin/shellcheck.py
@@ -32,8 +32,6 @@ def run_shellcheck() -> None:
         "./build-support/githooks/pre-commit",
         "./build-support/githooks/prepare-commit-msg",
     }
-    targets -= set(glob("./build-support/virtualenv.dist/**/*.sh", recursive=True))
-    targets -= set(glob("./build-support/virtualenvs/**/*.sh", recursive=True))
     targets -= set(glob("./build-support/twine-deps.venv/**/*.sh", recursive=True))
     command = ["shellcheck", "--shell=bash", "--external-sources"] + sorted(targets)
     try:

--- a/build-support/bin/shellcheck.py
+++ b/build-support/bin/shellcheck.py
@@ -32,6 +32,7 @@ def run_shellcheck() -> None:
         "./build-support/githooks/pre-commit",
         "./build-support/githooks/prepare-commit-msg",
     }
+    targets -= set(glob("./build-support/virtualenv.dist/**/*.sh", recursive=True))
     targets -= set(glob("./build-support/twine-deps.venv/**/*.sh", recursive=True))
     command = ["shellcheck", "--shell=bash", "--external-sources"] + sorted(targets)
     try:

--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -11,7 +11,9 @@ REQUIREMENTS=(
   "${REPO_ROOT}/3rdparty/python/requirements.txt"
 )
 
-venv_dir_prefix="${REPO_ROOT}/build-support/virtualenvs/$(uname)/pants_dev_deps"
+# NB: We house these outside the working copy to avoid needing to gitignore them, but also to
+# dodge https://github.com/hashicorp/vagrant/issues/12057.
+venv_dir_prefix="${HOME}/.cache/pants/pants_dev_deps/$(uname)"
 
 function venv_dir() {
   py_venv_version=$(${PY} -c 'import sys; print("".join(map(str, sys.version_info[0:2])))')

--- a/build-support/python/clean.sh
+++ b/build-support/python/clean.sh
@@ -2,11 +2,6 @@
 
 PANTS_BASE=$(dirname "$0")/../..
 rm -rf "${HOME}/.pex"
-rm -rf "${PANTS_BASE}/build-support/virtualenvs"
+rm -rf "${HOME}/.cache/pants/pants_dev_deps"
 rm -rf "${PANTS_BASE}/.pants.d"
 find "${PANTS_BASE}" -name '*.pyc' -print0 | xargs -0 rm -f
-
-# Legacy:
-rm -rf "${PANTS_BASE}/build-support/pants_dev_deps.venv"
-rm -rf "${PANTS_BASE}/build-support/pants_dev_deps.py{2,3}.venv"
-rm -rf "${PANTS_BASE}/build-support/pants_dev_deps.py{2,3}?.venv"

--- a/build-support/python/clean.sh
+++ b/build-support/python/clean.sh
@@ -5,3 +5,9 @@ rm -rf "${HOME}/.pex"
 rm -rf "${HOME}/.cache/pants/pants_dev_deps"
 rm -rf "${PANTS_BASE}/.pants.d"
 find "${PANTS_BASE}" -name '*.pyc' -print0 | xargs -0 rm -f
+
+# Legacy:
+rm -rf "${PANTS_BASE}/build-support/virtualenvs"
+rm -rf "${PANTS_BASE}/build-support/pants_dev_deps.venv"
+rm -rf "${PANTS_BASE}/build-support/pants_dev_deps.py{2,3}.venv"
+rm -rf "${PANTS_BASE}/build-support/pants_dev_deps.py{2,3}?.venv"

--- a/pants.toml
+++ b/pants.toml
@@ -38,7 +38,6 @@ pantsd_invalidation_globs.add = [
 # Path patterns to ignore for filesystem operations on top of the builtin patterns.
 pants_ignore.add = [
   # venv directories under build-support.
-  "/build-support/virtualenvs/",
   "/build-support/*.venv/",
   # We shouldn't walk or watch the rust compiler artifacts because it is slow.
   "/src/rust/engine/target",


### PR DESCRIPTION
### Problem

The venv for Pants' development dependencies currently lives in the working copy. This means that we need to gitignore it, but it also causes some trouble in the presence of virtualbox/vagrant mounts of the working copy, where it triggers https://github.com/hashicorp/vagrant/issues/12057.

### Solution

Move the virtualenvs directory into `$HOME`.

[ci skip-build-wheels]