### PR TITLE
Add Python tool support for console scripts.

### DIFF
--- a/src/python/pants/backend/awslambda/python/lambdex.py
+++ b/src/python/pants/backend/awslambda/python/lambdex.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.target_types import ConsoleScript
 
 
 class Lambdex(PythonToolBase):
@@ -14,4 +15,4 @@ class Lambdex(PythonToolBase):
     default_extra_requirements = ["setuptools>=50.3.0,<50.4"]
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.5"]
-    default_entry_point = "lambdex.bin.lambdex"
+    default_main = ConsoleScript("lambdex")

--- a/src/python/pants/backend/awslambda/python/rules.py
+++ b/src/python/pants/backend/awslambda/python/rules.py
@@ -69,7 +69,7 @@ async def package_python_awslambda(
         PexFromTargetsRequest(
             addresses=[field_set.address],
             internal_only=False,
-            entry_point=None,
+            main=None,
             output_filename=output_filename,
             platforms=PexPlatforms([platform]),
             additional_args=[
@@ -87,7 +87,7 @@ async def package_python_awslambda(
         internal_only=True,
         requirements=PexRequirements(lambdex.all_requirements),
         interpreter_constraints=PexInterpreterConstraints(lambdex.interpreter_constraints),
-        entry_point=lambdex.entry_point,
+        main=lambdex.main,
     )
 
     lambdex_pex, pex_result, handler = await MultiGet(

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -11,6 +11,7 @@ from pathlib import PurePath
 from typing import List, Optional, Tuple, cast
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.target_types import ConsoleScript
 from pants.backend.python.util_rules.pex import (
     PexInterpreterConstraints,
     PexRequest,
@@ -99,7 +100,7 @@ class CoverageSubsystem(PythonToolBase):
     help = "Configuration for Python test coverage measurement."
 
     default_version = "coverage>=5.0.3,<5.1"
-    default_entry_point = "coverage"
+    default_main = ConsoleScript("coverage")
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.6"]
 
@@ -228,7 +229,7 @@ async def setup_coverage(coverage: CoverageSubsystem) -> CoverageSetup:
             internal_only=True,
             requirements=PexRequirements(coverage.all_requirements),
             interpreter_constraints=PexInterpreterConstraints(coverage.interpreter_constraints),
-            entry_point=coverage.entry_point,
+            main=coverage.main,
         ),
     )
     return CoverageSetup(pex)

--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -113,7 +113,9 @@ async def package_pex_binary(
             PexFromTargetsRequest(
                 addresses=[field_set.address],
                 internal_only=False,
-                entry_point=resolved_entry_point.val,
+                # TODO(John Sirois): Support ConsoleScript in PexBinary targets:
+                #  https://github.com/pantsbuild/pants/issues/11619
+                main=resolved_entry_point.val,
                 platforms=PexPlatforms.create_from_platforms_field(field_set.platforms),
                 output_filename=output_filename,
                 additional_args=field_set.generate_additional_args(pex_binary_defaults),

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -14,6 +14,7 @@ from pants.backend.python.goals.coverage_py import (
 )
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.backend.python.target_types import (
+    EntryPoint,
     PythonRuntimePackageDependencies,
     PythonTestsSources,
     PythonTestsTimeout,
@@ -172,7 +173,9 @@ async def setup_pytest_for_target(
         PexRequest(
             output_filename="pytest_runner.pex",
             interpreter_constraints=interpreter_constraints,
-            entry_point="pytest",
+            # TODO(John Sirois): Switch to ConsoleScript once Pex supports discovering console
+            #  scripts via the PEX_PATH: https://github.com/pantsbuild/pex/issues/1257
+            main=EntryPoint("pytest"),
             internal_only=True,
             pex_path=[pytest_pex, requirements_pex],
         ),

--- a/src/python/pants/backend/python/goals/repl.py
+++ b/src/python/pants/backend/python/goals/repl.py
@@ -78,7 +78,7 @@ async def create_ipython_repl_request(
         Pex,
         PexRequest(
             output_filename="ipython.pex",
-            entry_point=ipython.entry_point,
+            main=ipython.main,
             requirements=PexRequirements(ipython.all_requirements),
             interpreter_constraints=requirements_pex_request.interpreter_constraints,
             internal_only=True,

--- a/src/python/pants/backend/python/goals/run_pex_binary.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary.py
@@ -62,7 +62,9 @@ async def create_pex_binary_run_request(
             internal_only=True,
             # Note that the entry point file is not in the PEX itself. It's loaded by setting
             # `PEX_EXTRA_SYS_PATH`.
-            entry_point=entry_point.val,
+            # TODO(John Sirois): Support ConsoleScript in PexBinary targets:
+            #  https://github.com/pantsbuild/pants/issues/11619
+            main=entry_point.val,
         ),
     )
 

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -535,7 +535,7 @@ async def generate_chroot(request: SetupPyChrootRequest) -> SetupPyChroot:
                 f"{binary.address} left the field off. Set `entry_point` to either "
                 f"`app.py:func` or the longhand `path.to.app:func`. See {url}."
             )
-        if ":" not in entry_point:
+        if not entry_point.function:
             raise InvalidEntryPoint(
                 "Every `pex_binary` used in `with_binaries()` for the `provides()` field for "
                 f"{exported_addr} must end in the format `:my_func` for the `entry_point` field, "

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -550,7 +550,8 @@ async def generate_chroot(request: SetupPyChrootRequest) -> SetupPyChroot:
     for key, binary_entry_point in zip(key_to_binary_spec.keys(), binary_entry_points):
         entry_points = setup_kwargs.setdefault("entry_points", {})
         console_scripts = entry_points.setdefault("console_scripts", [])
-        console_scripts.append(f"{key}={binary_entry_point.val}")
+        if binary_entry_point.val is not None:
+            console_scripts.append(f"{key}={binary_entry_point.val.spec}")
 
     # Generate the setup script.
     setup_py_content = SETUP_BOILERPLATE.format(

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -539,8 +539,8 @@ async def generate_chroot(request: SetupPyChrootRequest) -> SetupPyChroot:
             raise InvalidEntryPoint(
                 "Every `pex_binary` used in `with_binaries()` for the `provides()` field for "
                 f"{exported_addr} must end in the format `:my_func` for the `entry_point` field, "
-                f"but {binary.address} set it to {repr(entry_point)}. For example, set "
-                f"`entry_point='{entry_point}:main'. See {url}."
+                f"but {binary.address} set it to {entry_point.spec!r}. For example, set "
+                f"`entry_point='{entry_point.module}:main'. See {url}."
             )
         entry_point_requests.append(ResolvePexEntryPointRequest(binary[PexEntryPointField]))
     binary_entry_points = await MultiGet(

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -69,7 +69,7 @@ async def bandit_lint_partition(
             internal_only=True,
             requirements=PexRequirements(bandit.all_requirements),
             interpreter_constraints=partition.interpreter_constraints,
-            entry_point=bandit.entry_point,
+            main=bandit.main,
         ),
     )
 

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -4,6 +4,7 @@
 from typing import Optional, Tuple, cast
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.target_types import ConsoleScript
 from pants.option.custom_types import file_option, shell_str
 
 
@@ -14,7 +15,7 @@ class Bandit(PythonToolBase):
     default_version = "bandit>=1.6.2,<1.7"
     # `setuptools<45` is for Python 2 support. `stevedore` is because the 3.0 release breaks Bandit.
     default_extra_requirements = ["setuptools<45", "stevedore<3"]
-    default_entry_point = "bandit"
+    default_main = ConsoleScript("bandit")
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -101,7 +101,7 @@ async def setup_black(
             internal_only=True,
             requirements=PexRequirements(black.all_requirements),
             interpreter_constraints=tool_interpreter_constraints,
-            entry_point=black.entry_point,
+            main=black.main,
         ),
     )
 

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -4,6 +4,7 @@
 from typing import Optional, Tuple, cast
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.target_types import ConsoleScript
 from pants.option.custom_types import file_option, shell_str
 
 
@@ -14,7 +15,7 @@ class Black(PythonToolBase):
     # TODO: simplify `test_works_with_python39()` to stop using a VCS version.
     default_version = "black==20.8b1"
     default_extra_requirements = ["setuptools"]
-    default_entry_point = "black:patched_main"
+    default_main = ConsoleScript("black")
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.6"]
 

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -66,7 +66,7 @@ async def setup_docformatter(setup_request: SetupRequest, docformatter: Docforma
             internal_only=True,
             requirements=PexRequirements(docformatter.all_requirements),
             interpreter_constraints=PexInterpreterConstraints(docformatter.interpreter_constraints),
-            entry_point=docformatter.entry_point,
+            main=docformatter.main,
         ),
     )
 

--- a/src/python/pants/backend/python/lint/docformatter/subsystem.py
+++ b/src/python/pants/backend/python/lint/docformatter/subsystem.py
@@ -4,6 +4,7 @@
 from typing import Tuple, cast
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.target_types import ConsoleScript
 from pants.option.custom_types import shell_str
 
 
@@ -12,7 +13,7 @@ class Docformatter(PythonToolBase):
     help = "The Python docformatter tool (https://github.com/myint/docformatter)."
 
     default_version = "docformatter>=1.3.1,<1.4"
-    default_entry_point = "docformatter"
+    default_main = ConsoleScript("docformatter")
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython==2.7.*", "CPython>=3.4,<3.9"]
 

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -69,7 +69,7 @@ async def flake8_lint_partition(
             internal_only=True,
             requirements=PexRequirements(flake8.all_requirements),
             interpreter_constraints=partition.interpreter_constraints,
-            entry_point=flake8.entry_point,
+            main=flake8.main,
         ),
     )
 

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -4,6 +4,7 @@
 from typing import Optional, Tuple, cast
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.target_types import ConsoleScript
 from pants.option.custom_types import file_option, shell_str
 
 
@@ -16,7 +17,7 @@ class Flake8(PythonToolBase):
         "setuptools<45; python_full_version == '2.7.*'",
         "setuptools; python_version > '2.7'",
     ]
-    default_entry_point = "flake8"
+    default_main = ConsoleScript("flake8")
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -77,7 +77,7 @@ async def setup_isort(setup_request: SetupRequest, isort: Isort) -> Setup:
             internal_only=True,
             requirements=PexRequirements(isort.all_requirements),
             interpreter_constraints=PexInterpreterConstraints(isort.interpreter_constraints),
-            entry_point=isort.entry_point,
+            main=isort.main,
         ),
     )
 

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -4,6 +4,7 @@
 from typing import Tuple, cast
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.target_types import ConsoleScript
 from pants.option.custom_types import file_option, shell_str
 
 
@@ -15,7 +16,7 @@ class Isort(PythonToolBase):
     default_extra_requirements = ["setuptools"]
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.6"]
-    default_entry_point = "isort.main"
+    default_main = ConsoleScript("isort")
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -179,7 +179,7 @@ async def pylint_lint_partition(partition: PylintPartition, pylint: Pylint) -> L
         PexRequest(
             output_filename="pylint_runner.pex",
             interpreter_constraints=partition.interpreter_constraints,
-            entry_point=pylint.entry_point,
+            main=pylint.main,
             internal_only=True,
             pex_path=[pylint_pex, requirements_pex],
         ),

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import List, cast
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.target_types import EntryPoint
 from pants.engine.addresses import UnparsedAddressInputs
 from pants.option.custom_types import file_option, shell_str, target_option
 from pants.util.docutil import docs_url
@@ -16,7 +17,9 @@ class Pylint(PythonToolBase):
     help = "The Pylint linter for Python code (https://www.pylint.org/)."
 
     default_version = "pylint>=2.4.4,<2.5"
-    default_entry_point = "pylint"
+    # TODO(John Sirois): Switch to ConsoleScript once Pex supports discovering console
+    #  scripts via the PEX_PATH: https://github.com/pantsbuild/pex/issues/1257
+    default_main = EntryPoint("pylint")
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/python/subsystems/ipython.py
+++ b/src/python/pants/backend/python/subsystems/ipython.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.target_types import ConsoleScript
 
 
 class IPython(PythonToolBase):
@@ -9,7 +10,7 @@ class IPython(PythonToolBase):
     help = "The IPython enhanced REPL (https://ipython.org/)."
 
     default_version = "ipython==7.16.1"  # The last version to support Python 3.6.
-    default_entry_point = "IPython:start_ipython"
+    default_main = ConsoleScript("ipython")
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -66,7 +66,7 @@ class PythonToolBase(PythonToolRequirementsBase):
             "--console-script",
             type=str,
             advanced=True,
-            default=cls.default_main if isinstance(cls.default_main, ConsoleScript) else None,
+            default=cls.default_main.spec if isinstance(cls.default_main, ConsoleScript) else None,
             help=(
                 "The console script for the tool. Using this option is generally preferable to "
                 "(and mutually exclusive with) specifying an --entry-point since console script "
@@ -78,7 +78,7 @@ class PythonToolBase(PythonToolRequirementsBase):
             "--entry-point",
             type=str,
             advanced=True,
-            default=cls.default_main if isinstance(cls.default_main, EntryPoint) else None,
+            default=cls.default_main.spec if isinstance(cls.default_main, EntryPoint) else None,
             help=(
                 "The entry point for the tool. Generally you only want to use this option if the "
                 "tool does not offer a --console-script (which this option is mutually exclusive "
@@ -112,9 +112,9 @@ class PythonToolBase(PythonToolRequirementsBase):
         is_default_entry_point = self.options.is_default("entry_point")
         if not is_default_console_script and not is_default_entry_point:
             raise OptionsError(
-                f"Both --console-script={self.options.console_script} and "
-                f"--entry-point={self.options.entry_point} are configured but these options are "
-                f"mutually exclusive. Pick one."
+                f"Both [{self.scope}].console-script={self.options.console_script} and "
+                f"[{self.scope}].entry-point={self.options.entry_point} are configured but these "
+                f"options are mutually exclusive. Please pick one."
             )
         if not is_default_console_script:
             return ConsoleScript(cast(str, self.options.console_script))

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -112,6 +112,11 @@ class MainSpecification(ABC):
     def iter_pex_args(self) -> Iterator[str]:
         ...
 
+    @property
+    @abstractmethod
+    def spec(self) -> str:
+        ...
+
 
 @dataclass(frozen=True)
 class EntryPoint(MainSpecification):
@@ -160,7 +165,8 @@ class EntryPoint(MainSpecification):
         yield "--entry-point"
         yield str(self)
 
-    def __str__(self) -> str:
+    @property
+    def spec(self) -> str:
         return self.module if self.function is None else f"{self.module}:{self.function}"
 
 
@@ -171,6 +177,10 @@ class ConsoleScript(MainSpecification):
     def iter_pex_args(self) -> Iterator[str]:
         yield "--console-script"
         yield self.name
+
+    @property
+    def spec(self) -> str:
+        return self.name
 
 
 class PexEntryPointField(AsyncFieldMixin, SecondaryOwnerMixin, Field):
@@ -190,9 +200,9 @@ class PexEntryPointField(AsyncFieldMixin, SecondaryOwnerMixin, Field):
         ep = super().compute_value(raw_value, address=address)
         if ep is None:
             raise InvalidFieldException(
-                f"An entry point must be specified for for {address}. It must indicate a Python "
-                "module by name or path and an optional nullary function in that module separated "
-                "by a colon, i.e.: module_name_or_path(':'function_name)?"
+                f"An entry point must be specified for {address}. It must indicate a Python module "
+                "by name or path and an optional nullary function in that module separated by a "
+                "colon, i.e.: module_name_or_path(':'function_name)?"
             )
         try:
             return EntryPoint.parse(ep, provenance=f"for {address}")

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -163,7 +163,7 @@ class EntryPoint(MainSpecification):
 
     def iter_pex_args(self) -> Iterator[str]:
         yield "--entry-point"
-        yield str(self)
+        yield self.spec
 
     @property
     def spec(self) -> str:

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -1,9 +1,12 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import collections.abc
 import logging
 import os.path
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from textwrap import dedent
@@ -104,7 +107,73 @@ class PexBinaryDependencies(Dependencies):
     supports_transitive_excludes = True
 
 
-class PexEntryPointField(StringField, AsyncFieldMixin, SecondaryOwnerMixin):
+class MainSpecification(ABC):
+    @abstractmethod
+    def iter_pex_args(self) -> Iterator[str]:
+        ...
+
+
+@dataclass(frozen=True)
+class EntryPoint(MainSpecification):
+    module: str
+    function: str | None = None
+
+    @classmethod
+    def parse(cls, value: str, provenance: str | None = None) -> EntryPoint:
+        given = f"entry point {provenance}" if provenance else "entry point"
+        entry_point = value.strip()
+        if not entry_point:
+            raise ValueError(
+                f"The {given} cannot be blank. It must indicate a Python module by name or path "
+                f"and an optional nullary function in that module separated by a colon, i.e.: "
+                f"module_name_or_path(':'function_name)?"
+            )
+        module_or_path, sep, func = entry_point.partition(":")
+        if not module_or_path:
+            raise ValueError(f"The {given} must specify a module; given: {value!r}")
+        if ":" in func:
+            raise ValueError(
+                f"The {given} can only contain one colon separating the entry point's module from "
+                f"the entry point function in that module; given: {value!r}"
+            )
+        if sep and not func:
+            logger.warning(
+                f"Assuming no entry point function and stripping trailing ':' from the {given}: "
+                f"{value!r}. Consider deleting it to make it clear no entry point function is "
+                f"intended."
+            )
+        return cls(module=module_or_path, function=func if func else None)
+
+    def __post_init__(self):
+        if ":" in self.module:
+            raise ValueError(
+                "The `:` character is not valid in a module name. Given an entry point module of "
+                f"{self.module}. Did you mean to use EntryPoint.parse?"
+            )
+        if self.function and ":" in self.function:
+            raise ValueError(
+                "The `:` character is not valid in a function name. Given an entry point function"
+                f" of {self.function}."
+            )
+
+    def iter_pex_args(self) -> Iterator[str]:
+        yield "--entry-point"
+        yield str(self)
+
+    def __str__(self) -> str:
+        return self.module if self.function is None else f"{self.module}:{self.function}"
+
+
+@dataclass(frozen=True)
+class ConsoleScript(MainSpecification):
+    name: str
+
+    def iter_pex_args(self) -> Iterator[str]:
+        yield "--console-script"
+        yield self.name
+
+
+class PexEntryPointField(AsyncFieldMixin, SecondaryOwnerMixin, Field):
     alias = "entry_point"
     help = (
         "The entry point for the binary, i.e. what gets run when executing `./my_binary.pex`.\n\n"
@@ -114,51 +183,36 @@ class PexEntryPointField(StringField, AsyncFieldMixin, SecondaryOwnerMixin):
         "will convert into `path.to.app:func`.\n\nYou must use the file name shorthand for file "
         "arguments to work with this target.\n\nTo leave off an entry point, set to '<none>'."
     )
+    required = True
 
     @classmethod
-    def compute_value(cls, raw_value: Optional[str], *, address: Address) -> Optional[str]:
+    def compute_value(cls, raw_value: Optional[str], *, address: Address) -> Optional[EntryPoint]:
         ep = super().compute_value(raw_value, address=address)
-        entry_point = ep.strip() if ep is not None else None
-        if not entry_point:
+        if ep is None:
             raise InvalidFieldException(
-                f"The entry point for {address} cannot be blank. It must indicate a Python module "
-                "by name or path and an optional nullary function in that module separated by a "
-                "colon, i.e.: module_name_or_path(':'function_name)?"
+                f"An entry point must be specified for for {address}. It must indicate a Python "
+                "module by name or path and an optional nullary function in that module separated "
+                "by a colon, i.e.: module_name_or_path(':'function_name)?"
             )
-        module_or_path, sep, func = entry_point.partition(":")
-        if not module_or_path:
-            raise InvalidFieldException(
-                f"The entry point for {address} must specify a module; given: {ep!r}"
-            )
-        if ":" in module_or_path or ":" in func:
-            raise InvalidFieldException(
-                f"The entry point for {address} can only contain one colon separating the entry "
-                f"point's module from the entry point function in that module; given: {ep!r}"
-            )
-        if sep and not func:
-            logger.warning(
-                f"Assuming no entry point function and stripping trailing ':' from the entry point "
-                f"{ep!r} declared in {address}. Consider deleting it to make it clear no entry "
-                f"point function is intended."
-            )
-            return module_or_path
-        return entry_point
+        try:
+            return EntryPoint.parse(ep, provenance=f"for {address}")
+        except ValueError as e:
+            raise InvalidFieldException(str(e))
 
     @property
     def filespec(self) -> Filespec:
         if not self.value:
             return {"includes": []}
-        path, _, func = self.value.partition(":")
-        if not path.endswith(".py"):
+        if not self.value.module.endswith(".py"):
             return {"includes": []}
-        full_glob = os.path.join(self.address.spec_path, path)
+        full_glob = os.path.join(self.address.spec_path, self.value.module)
         return {"includes": [full_glob]}
 
 
 # See `target_types_rules.py` for the `ResolvePexEntryPointRequest -> ResolvedPexEntryPoint` rule.
 @dataclass(frozen=True)
 class ResolvedPexEntryPoint:
-    val: Optional[str]
+    val: Optional[EntryPoint]
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -86,7 +86,7 @@ async def resolve_pex_entry_point(request: ResolvePexEntryPointRequest) -> Resol
     # we need to check if they used a file glob (`*` or `**`) that resolved to >1 file.
     if len(entry_point_paths.files) != 1:
         raise InvalidFieldException(
-            f"Multiple files matched for the `{ep_alias}` {repr(ep_val)} for the target "
+            f"Multiple files matched for the `{ep_alias}` {ep_val.spec!r} for the target "
             f"{address}, but only one file expected. Are you using a glob, rather than a file "
             f"name?\n\nAll matching files: {list(entry_point_paths.files)}."
         )

--- a/src/python/pants/backend/python/target_types_test.py
+++ b/src/python/pants/backend/python/target_types_test.py
@@ -13,6 +13,7 @@ from pants.backend.python.dependency_inference.rules import import_rules
 from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.backend.python.target_types import (
+    EntryPoint,
     PexBinary,
     PexBinaryDependencies,
     PexEntryPointField,
@@ -105,7 +106,7 @@ def test_entry_point_validation(caplog: LogCaptureFixture) -> None:
 
     ep = "custom.entry_point:"
     with caplog.at_level(logging.WARNING):
-        assert "custom.entry_point" == PexEntryPointField(ep, address=addr).value
+        assert EntryPoint("custom.entry_point") == PexEntryPointField(ep, address=addr).value
 
     assert len(caplog.record_tuples) == 1
     _, levelno, message = caplog.record_tuples[0]
@@ -122,7 +123,7 @@ def test_resolve_pex_binary_entry_point() -> None:
         ]
     )
 
-    def assert_resolved(*, entry_point: Optional[str], expected: Optional[str]) -> None:
+    def assert_resolved(*, entry_point: Optional[str], expected: Optional[EntryPoint]) -> None:
         addr = Address("src/python/project")
         rule_runner.create_file("src/python/project/app.py")
         rule_runner.create_file("src/python/project/f2.py")
@@ -131,22 +132,26 @@ def test_resolve_pex_binary_entry_point() -> None:
         assert result.val == expected
 
     # Full module provided.
-    assert_resolved(entry_point="custom.entry_point", expected="custom.entry_point")
-    assert_resolved(entry_point="custom.entry_point:func", expected="custom.entry_point:func")
+    assert_resolved(entry_point="custom.entry_point", expected=EntryPoint("custom.entry_point"))
+    assert_resolved(
+        entry_point="custom.entry_point:func", expected=EntryPoint.parse("custom.entry_point:func")
+    )
 
     # File names are expanded into the full module path.
-    assert_resolved(entry_point="app.py", expected="project.app")
-    assert_resolved(entry_point="app.py:func", expected="project.app:func")
+    assert_resolved(entry_point="app.py", expected=EntryPoint(module="project.app"))
+    assert_resolved(
+        entry_point="app.py:func", expected=EntryPoint(module="project.app", function="func")
+    )
 
     # We special case the strings `<none>` and `<None>`.
     assert_resolved(entry_point="<none>", expected=None)
     assert_resolved(entry_point="<None>", expected=None)
 
     with pytest.raises(ExecutionError):
-        assert_resolved(entry_point="doesnt_exist.py", expected="doesnt matter")
+        assert_resolved(entry_point="doesnt_exist.py", expected=EntryPoint("doesnt matter"))
     # Resolving >1 file is an error.
     with pytest.raises(ExecutionError):
-        assert_resolved(entry_point="*.py", expected="doesnt matter")
+        assert_resolved(entry_point="*.py", expected=EntryPoint("doesnt matter"))
 
 
 def test_inject_pex_binary_entry_point_dependency() -> None:

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -205,7 +205,7 @@ async def mypy_typecheck_partition(partition: MyPyPartition, mypy: MyPy) -> Type
         PexRequest(
             output_filename="mypy.pex",
             internal_only=True,
-            entry_point=mypy.entry_point,
+            main=mypy.main,
             requirements=PexRequirements((*mypy.all_requirements, *plugin_requirements)),
             interpreter_constraints=tool_interpreter_constraints,
         ),

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import Tuple, cast
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.target_types import ConsoleScript
 from pants.engine.addresses import UnparsedAddressInputs
 from pants.option.custom_types import file_option, shell_str, target_option
 
@@ -15,7 +16,7 @@ class MyPy(PythonToolBase):
     help = "The MyPy Python type checker (http://mypy-lang.org/)."
 
     default_version = "mypy==0.800"
-    default_entry_point = "mypy"
+    default_main = ConsoleScript("mypy")
     # See `mypy/rules.py`. We only use these default constraints in some situations. Technically,
     # MyPy only requires 3.5+, but some popular plugins like `django-stubs` require 3.6+. Because
     # 3.5 is EOL, and users can tweak this back, this seems like a more sensible default.

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -13,7 +13,11 @@ from typing import Dict, Iterable, Iterator, List, Mapping, Tuple, cast
 import pytest
 from pkg_resources import Requirement
 
-from pants.backend.python.target_types import InterpreterConstraintsField
+from pants.backend.python.target_types import (
+    EntryPoint,
+    InterpreterConstraintsField,
+    MainSpecification,
+)
 from pants.backend.python.util_rules.pex import (
     Pex,
     PexInterpreterConstraints,
@@ -326,7 +330,7 @@ def create_pex_and_get_all_data(
     *,
     pex_type: type[Pex | VenvPex] = Pex,
     requirements: PexRequirements = PexRequirements(),
-    entry_point: str | None = None,
+    main: MainSpecification | None = None,
     interpreter_constraints: PexInterpreterConstraints = PexInterpreterConstraints(),
     platforms: PexPlatforms = PexPlatforms(),
     sources: Digest | None = None,
@@ -342,7 +346,7 @@ def create_pex_and_get_all_data(
         requirements=requirements,
         interpreter_constraints=interpreter_constraints,
         platforms=platforms,
-        entry_point=entry_point,
+        main=main,
         sources=sources,
         additional_inputs=additional_inputs,
         additional_args=additional_pex_args,
@@ -376,7 +380,7 @@ def create_pex_and_get_pex_info(
     *,
     pex_type: type[Pex | VenvPex] = Pex,
     requirements: PexRequirements = PexRequirements(),
-    entry_point: str | None = None,
+    main: MainSpecification | None = None,
     interpreter_constraints: PexInterpreterConstraints = PexInterpreterConstraints(),
     platforms: PexPlatforms = PexPlatforms(),
     sources: Digest | None = None,
@@ -390,7 +394,7 @@ def create_pex_and_get_pex_info(
             rule_runner,
             pex_type=pex_type,
             requirements=requirements,
-            entry_point=entry_point,
+            main=main,
             interpreter_constraints=interpreter_constraints,
             platforms=platforms,
             sources=sources,
@@ -413,7 +417,7 @@ def test_pex_execution(rule_runner: RuleRunner) -> None:
             ),
         ],
     )
-    pex_output = create_pex_and_get_all_data(rule_runner, entry_point="main", sources=sources)
+    pex_output = create_pex_and_get_all_data(rule_runner, main=EntryPoint("main"), sources=sources)
 
     pex_files = pex_output["files"]
     assert "pex" not in pex_files
@@ -458,7 +462,7 @@ def test_pex_environment(rule_runner: RuleRunner, pex_type: type[Pex | VenvPex])
     pex_output = create_pex_and_get_all_data(
         rule_runner,
         pex_type=pex_type,
-        entry_point="main",
+        main=EntryPoint("main"),
         sources=sources,
         additional_pants_args=(
             "--subprocess-environment-env-vars=LANG",  # Value should come from environment.
@@ -531,7 +535,7 @@ def test_requirement_constraints(rule_runner: RuleRunner) -> None:
 
 def test_entry_point(rule_runner: RuleRunner) -> None:
     entry_point = "pydoc"
-    pex_info = create_pex_and_get_pex_info(rule_runner, entry_point=entry_point)
+    pex_info = create_pex_and_get_pex_info(rule_runner, main=EntryPoint(entry_point))
     assert pex_info["entry_point"] == entry_point
 
 


### PR DESCRIPTION
Introduce `MainSpecification` which can either be an `EntryPoint` or
a `ConsoleScript`. Both `PexRequest` and `PexFromTargetsRequest` are
updated to take a `MainSpecification` as is `PythonToolBase`. All
internal rules are updated to use `ConsoleScript` where possible for
improved stability of entry points across requirement upgrades.

Fixes #11583

[ci skip-rust]
[ci skip-build-wheels]