### PR TITLE
[internal] allow Toolchain plugin to request restriected access token for Github Actions PR builds

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -111,7 +111,7 @@ jobs:
             ${{ runner.os }}-engine-${{ steps.get-engine-hash.outputs.hash }}
       - name: Set env vars
         run: |
-          echo "PANTS_CONFIG_FILES=${{ github.workspace }}/pants.ci.toml" >> ${GITHUB_ENV}
+          echo 'PANTS_CONFIG_FILES=+["${{ github.workspace }}/pants.ci.toml", "${{ github.workspace }}/pants.remote-cache.toml"]' >> ${GITHUB_ENV}
       - name: Bootstrap Pants
         run: |
           ./pants --version
@@ -170,7 +170,7 @@ jobs:
           path: src/python/pants/engine/internals/
       - name: Set env vars
         run: |
-          echo "PANTS_CONFIG_FILES=${{ github.workspace }}/pants.ci.toml" >> ${GITHUB_ENV}
+          echo 'PANTS_CONFIG_FILES=+["${{ github.workspace }}/pants.ci.toml", "${{ github.workspace }}/pants.remote-cache.toml"]' >> ${GITHUB_ENV}
       - name: Run Python tests
         run: |
           ./pants test ::
@@ -203,12 +203,11 @@ jobs:
           path: src/python/pants/engine/internals/
       - name: Set env vars
         run: |
-          echo "PANTS_CONFIG_FILES=${{ github.workspace }}/pants.ci.toml" >> ${GITHUB_ENV}
+          echo 'PANTS_CONFIG_FILES=+["${{ github.workspace }}/pants.ci.toml", "${{ github.workspace }}/pants.remote-cache.toml"]' >> ${GITHUB_ENV}
       - name: Lint
         run: |
           ./pants validate '**'
           ./pants lint typecheck ::
-
 
   bootstrap_pants_macos:
     name: Bootstrap Pants, test Rust (MacOS)
@@ -283,7 +282,7 @@ jobs:
             ${{ runner.os }}-engine-${{ steps.get-engine-hash.outputs.hash }}
       - name: Set env vars
         run: |
-          echo "PANTS_CONFIG_FILES=${{ github.workspace }}/pants.ci.toml" >> ${GITHUB_ENV}
+          echo 'PANTS_CONFIG_FILES=+["${{ github.workspace }}/pants.ci.toml", "${{ github.workspace }}/pants.remote-cache.toml"]' >> ${GITHUB_ENV}
       - name: Bootstrap Pants
         run: |
           ./pants --version
@@ -332,7 +331,7 @@ jobs:
           path: src/python/pants/engine/internals/
       - name: Set env vars
         run: |
-          echo "PANTS_CONFIG_FILES=${{ github.workspace }}/pants.ci.toml" >> ${GITHUB_ENV}
+          echo 'PANTS_CONFIG_FILES=+["${{ github.workspace }}/pants.ci.toml", "${{ github.workspace }}/pants.remote-cache.toml"]' >> ${GITHUB_ENV}
       - name: Run Python tests
         run: |
           ./pants --tag=+platform_specific_behavior test ::

--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -19,7 +19,10 @@ report = ["raw", "xml"]
 [auth]
 from_env_var = "TOOLCHAIN_AUTH_TOKEN"
 org = "pantsbuild"
-ci_env_variables = ["TRAVIS", "TRAVIS_JOB_ID", "TRAVIS_BUILD_ID", "TRAVIS_PULL_REQUEST", "TRAVIS_BUILD_WEB_URL"]
+ci_env_variables = [
+  "TRAVIS", "TRAVIS_JOB_ID", "TRAVIS_BUILD_ID", "TRAVIS_PULL_REQUEST", "TRAVIS_BUILD_WEB_URL",
+  "GITHUB_ACTIONS", "GITHUB_RUN_ID", "GITHUB_REF", "GITHUB_EVENT_NAME", "GITHUB_SHA",
+]
 
 [buildsense]
 enable = true


### PR DESCRIPTION
This will allow the Toolchain pants plugin to request a restricted access token in order to allow pants to use Toolchain's Buildsense and remote caching APIs.

~Note that toolchain service doesn't support restricted access tokens for Github Actions CI yet, but this is coming in the next few days.~

~NO NEED TO MERGE THIS PR YET.~