### PR TITLE
Stabilize git references for indicatif/console changes

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -356,7 +356,7 @@ dependencies = [
 [[package]]
 name = "console"
 version = "0.14.0"
-source = "git+https://github.com/stuhood/console?branch=stuhood/term-target-for-arbitrary-handles#a29180f638c1aa2b44efcd725b126bc89305fff7"
+source = "git+https://github.com/pantsbuild/console?rev=b6e9aa7ce734517691934d558d79a459609633db#b6e9aa7ce734517691934d558d79a459609633db"
 dependencies = [
  "encode_unicode",
  "lazy_static",
@@ -1251,7 +1251,7 @@ dependencies = [
 [[package]]
 name = "indicatif"
 version = "0.15.0"
-source = "git+https://github.com/stuhood/indicatif?branch=stuhood/properly-query-width#7345638238a37fc2fc99faf87dbbd7a8b137b948"
+source = "git+https://github.com/mitsuhiko/indicatif?rev=fa5e3c7ccc877c117f1db88bdaf19c48498d9616#fa5e3c7ccc877c117f1db88bdaf19c48498d9616"
 dependencies = [
  "console",
  "lazy_static",

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -152,4 +152,4 @@ prost = { git = "https://github.com/danburkert/prost", rev = "a1cccbcee343e2c444
 prost-build = { git = "https://github.com/danburkert/prost",  rev = "a1cccbcee343e2c444e1cd2738c7fba2599fc391" }
 prost-types = { git = "https://github.com/danburkert/prost",  rev = "a1cccbcee343e2c444e1cd2738c7fba2599fc391" }
 # TODO: Posted as https://github.com/mitsuhiko/console/pull/93.
-console = { git = "https://github.com/stuhood/console", branch = "stuhood/term-target-for-arbitrary-handles" }
+console = { git = "https://github.com/pantsbuild/console", rev = "b6e9aa7ce734517691934d558d79a459609633db" }

--- a/src/rust/engine/ui/Cargo.toml
+++ b/src/rust/engine/ui/Cargo.toml
@@ -11,8 +11,8 @@ path = "src/console_ui.rs"
 console = "0.14"
 futures = "0.3"
 indexmap = "1.4"
-# TODO: Posted as https://github.com/mitsuhiko/indicatif/pull/241.
-indicatif = { git = "https://github.com/stuhood/indicatif", branch = "stuhood/properly-query-width" }
+# TODO: Waiting for https://github.com/mitsuhiko/indicatif/pull/241 to be released.
+indicatif = { git = "https://github.com/mitsuhiko/indicatif", rev = "fa5e3c7ccc877c117f1db88bdaf19c48498d9616" }
 stdio = { path = "../stdio" }
 task_executor = { path = "../task_executor" }
 uuid = { version = "0.7", features = ["v4"] }


### PR DESCRIPTION
### Problem

In order to support thread-local IO, changes were necessary in https://github.com/mitsuhiko/indicatif and https://github.com/mitsuhiko/console. One of those sets of changes has landed but not been released; the other is still under review.

### Solution

Stabilize git references for indicatif/console changes that were necessary for thread-local IO.

[ci skip-build-wheels]
