### PR TITLE
Two enhancements to tailor.

### DIFF
--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -351,9 +351,10 @@ async def edit_build_files(req: EditBuildFilesRequest) -> EditedBuildFiles:
     # such as MacOS. We detect such cases and use an alt BUILD file name to fix.
     existing_paths = await Get(Paths, PathGlobs(ptgts_by_build_file.keys()))
     existing_dirs = set(existing_paths.dirs)
-    # Technically there could be a dir named "BUILD.alt" as well, but that's pretty unlikely.
+    # Technically there could be a dir named "BUILD.pants" as well, but that's pretty unlikely.
     ptgts_by_build_file = {
-        (f"{bf}.alt" if bf in existing_dirs else bf): pts for bf, pts in ptgts_by_build_file.items()
+        (f"{bf}.pants" if bf in existing_dirs else bf): pts
+        for bf, pts in ptgts_by_build_file.items()
     }
     existing_build_files_contents = await Get(DigestContents, PathGlobs(ptgts_by_build_file.keys()))
     existing_build_files_contents_by_path = {

--- a/src/python/pants/core/goals/tailor_test.py
+++ b/src/python/pants/core/goals/tailor_test.py
@@ -223,12 +223,12 @@ def test_edit_build_files(rule_runner: RuleRunner) -> None:
     )
     edited_build_files = rule_runner.request(EditedBuildFiles, [req])
 
-    assert edited_build_files.created_paths == ("src/fortran/baz/BUILD.alt",)
+    assert edited_build_files.created_paths == ("src/fortran/baz/BUILD.pants",)
     assert edited_build_files.updated_paths == ("src/fortran/foo/BUILD",)
 
     contents = rule_runner.request(DigestContents, [edited_build_files.digest])
     expected = [
-        FileContent("src/fortran/baz/BUILD.alt", "fortran_library()\n".encode()),
+        FileContent("src/fortran/baz/BUILD.pants", "fortran_library()\n".encode()),
         FileContent(
             "src/fortran/foo/BUILD",
             textwrap.dedent(


### PR DESCRIPTION
1. We require root-level targets to be
   explicitly named, so this change makes tailor
   take care of that.

2. It's possible for directory named BUILD to collide
   with a file we want to create under the same name.
   This is not as unlikely as you may think on systems
   where paths are case-insensitive, such as MacOS.
   This change detects this case and renames the BUILD
   file.

[ci skip-rust]

[ci skip-build-wheels]
