### PR TITLE
Handle case where there where no observation histograms during the pants run.

### DIFF
--- a/src/python/pants/goal/stats_aggregator.py
+++ b/src/python/pants/goal/stats_aggregator.py
@@ -88,9 +88,13 @@ class StatsAggregatorCallback(WorkunitsCallback):
             return
         from hdrh.histogram import HdrHistogram
 
-        histogram_info = context.get_observation_histograms()
+        histograms = context.get_observation_histograms()["histograms"]
+        if not histograms:
+            logger.info("No observation histogram were recorded.")
+            return
+
         logger.info("Observation histogram summaries:")
-        for name, encoded_histogram in histogram_info["histograms"].items():
+        for name, encoded_histogram in histograms.items():
             # Note: The Python library for HDR Histogram will only decode compressed histograms
             # that are further encoded with base64. See
             # https://github.com/HdrHistogram/HdrHistogram_py/issues/29.


### PR DESCRIPTION
### Problem

If there are no observation histograms in the current pants run, then just the title is shown with no actual data, which is confusing.

### Solution

Log the proper message dedpending on wether observation histograms were collected or not.