### PR TITLE
Ensure that ancestor files at the buildroot are found.

### DIFF
--- a/src/python/pants/backend/python/util_rules/ancestor_files.py
+++ b/src/python/pants/backend/python/util_rules/ancestor_files.py
@@ -49,9 +49,10 @@ def identify_missing_ancestor_files(name: str, sources: Sequence[str]) -> Frozen
         if not source.endswith(".py"):
             continue
         pkg_dir = os.path.dirname(source)
-        if not pkg_dir or pkg_dir in packages:
+        if pkg_dir in packages:
             continue
         package = ""
+        packages.add(package)
         for component in pkg_dir.split(os.sep):
             package = os.path.join(package, component)
             packages.add(package)

--- a/src/python/pants/backend/python/util_rules/ancestor_files_test.py
+++ b/src/python/pants/backend/python/util_rules/ancestor_files_test.py
@@ -64,10 +64,11 @@ def test_unstripped(rule_runner: RuleRunner) -> None:
             "src/python/no_init/lib.py",
         ],
         original_undeclared_files=[
+            "src/python/__init__.py",
             "src/python/project/__init__.py",
             "tests/python/project/__init__.py",
         ],
-        expected_discovered=["src/python/project/__init__.py"],
+        expected_discovered=["src/python/__init__.py", "src/python/project/__init__.py"],
     )
 
 
@@ -82,20 +83,22 @@ def test_unstripped_source_root_at_buildroot(rule_runner: RuleRunner) -> None:
             "no_init/lib.py",
         ],
         original_undeclared_files=[
+            "__init__.py",
             "project/__init__.py",
         ],
-        expected_discovered=["project/__init__.py"],
+        expected_discovered=["__init__.py", "project/__init__.py"],
     )
 
 
 def test_identify_missing_ancestor_files() -> None:
-    assert {"a/__init__.py", "a/b/__init__.py", "a/b/c/d/__init__.py"} == set(
+    assert {"__init__.py", "a/__init__.py", "a/b/__init__.py", "a/b/c/d/__init__.py"} == set(
         identify_missing_ancestor_files(
             "__init__.py", ["a/b/foo.py", "a/b/c/__init__.py", "a/b/c/d/bar.py", "a/e/__init__.py"]
         )
     )
 
     assert {
+        "__init__.py",
         "src/__init__.py",
         "src/python/__init__.py",
         "src/python/a/__init__.py",


### PR DESCRIPTION
Previously we would find ancestor files correctly all the
way to the source root, and even above, but would stop short
at the buildroot.

However there are real-world cases in which the buildroot is
the source root, and can contain, e.g., conftest.py files which
we fail to discover.

This change fixes this oversight.

[ci skip-rust]

[ci skip-build-wheels]
