### PR TITLE
Scala 2.13 support for 1.x

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/scala_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/scala_platform.py
@@ -21,6 +21,7 @@ scala_build_info = {
     "2.10": major_version_info(full_version="2.10.6"),
     "2.11": major_version_info(full_version="2.11.12"),
     "2.12": major_version_info(full_version="2.12.8"),
+    "2.13": major_version_info(full_version="2.13.5"),
 }
 
 
@@ -115,7 +116,7 @@ class ScalaPlatform(JvmToolMixin, ZincLanguageMixin, InjectablesMixin, Subsystem
             "--version",
             advanced=True,
             default="2.12",
-            choices=["2.10", "2.11", "2.12", "custom"],
+            choices=["2.10", "2.11", "2.12", "2.13", "custom"],
             fingerprint=True,
             help="The scala platform version. If --version=custom, the targets "
             "//:scala-library, //:scalac, //:scala-repl and //:scalastyle will be used, "
@@ -143,6 +144,10 @@ class ScalaPlatform(JvmToolMixin, ZincLanguageMixin, InjectablesMixin, Subsystem
         register_scala_compiler_tool("2.12")
         register_scala_repl_tool("2.12")
         register_style_tool("2.12")
+
+        register_scala_compiler_tool("2.13")
+        register_scala_repl_tool("2.13")
+        register_style_tool("2.13")
 
         # Register the custom tools. We provide a dummy classpath, so that register_jvm_tool won't
         # require that a target with the given spec actually exist (not everyone will define custom

--- a/src/python/pants/backend/jvm/subsystems/zinc.py
+++ b/src/python/pants/backend/jvm/subsystems/zinc.py
@@ -70,7 +70,7 @@ class Zinc:
                 help="Use a pre-compiled native-image for zinc. Requires running in hermetic mode",
             )
 
-            zinc_rev = "1.1.7"
+            zinc_rev = "1.3.5"
 
             shader_rules = [
                 # The compiler-interface and compiler-bridge tool jars carry xsbt and

--- a/src/python/pants/backend/jvm/subsystems/zinc.py
+++ b/src/python/pants/backend/jvm/subsystems/zinc.py
@@ -70,7 +70,7 @@ class Zinc:
                 help="Use a pre-compiled native-image for zinc. Requires running in hermetic mode",
             )
 
-            zinc_rev = "1.0.3"
+            zinc_rev = "1.1.7"
 
             shader_rules = [
                 # The compiler-interface and compiler-bridge tool jars carry xsbt and

--- a/src/python/pants/backend/jvm/subsystems/zinc.py
+++ b/src/python/pants/backend/jvm/subsystems/zinc.py
@@ -133,11 +133,11 @@ class Zinc:
                 custom_rules=shader_rules,
             )
 
-            # Register scalac for fixed versions of Scala, 2.10, 2.11 and 2.12.
+            # Register scalac for fixed versions of Scala.
             # Relies on ScalaPlatform to get the revision version from the major.minor version.
             # The tool with the correct scala version will be retrieved later,
             # taking the user-passed option into account.
-            supported_scala_versions = ["2.10", "2.11", "2.12"]
+            supported_scala_versions = ["2.10", "2.11", "2.12", "2.13"]
             wanted_jars = ["scala-compiler", "scala-library", "scala-reflect"]
             for scala_version in supported_scala_versions:
                 cls.register_jvm_tool(


### PR DESCRIPTION
### Problem

There is no [Compiler Bridge 2.13](https://repo1.maven.org/maven2/org/scala-sbt/compiler-bridge_2.13/) published for Zinc 1.0.3

### Solution

Bump to the nearest version of Zinc with Scala Bridge 2.13 available — 1.1.7

### Result

Scala 2.13 is now supported
