### PR TITLE
Fix a few references to the deprecated pants log location.

### DIFF
--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -52,7 +52,7 @@ def stdio_destination(stdin_fileno: int, stdout_fileno: int, stderr_fileno: int)
     """Sets a destination for both logging and stdio: must be called after `initialize_stdio`.
 
     After `initialize_stdio` and outside of this contextmanager, the default stdio destination is
-    the pantsd.log. But inside of this block, all engine "tasks"/@rules that are spawned will have
+    the pants.log. But inside of this block, all engine "tasks"/@rules that are spawned will have
     thread/task-local state that directs their IO to the given destination. When the contextmanager
     exits all tasks will be restored to the default destination (regardless of whether they have
     completed).
@@ -133,7 +133,7 @@ def initialize_stdio(global_bootstrap_options: OptionValueContainer) -> Iterator
     message_regex_filters = global_bootstrap_options.ignore_pants_warnings
     print_stacktrace = global_bootstrap_options.print_stacktrace
 
-    # Set the pantsd log destination.
+    # Set the pants log destination.
     deprecated_log_path = os.path.join(
         global_bootstrap_options.pants_workdir, "pantsd", "pantsd.log"
     )

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -37,7 +37,6 @@ class PantsDaemon(PantsDaemonProcessManager):
     """A daemon that manages PantsService instances."""
 
     JOIN_TIMEOUT_SECONDS = 1
-    LOG_NAME = "pantsd.log"
 
     class StartupFailure(Exception):
         """Represents a failure to start pantsd."""

--- a/src/python/pants/testutil/pants_integration_test.py
+++ b/src/python/pants/testutil/pants_integration_test.py
@@ -294,7 +294,7 @@ def ensure_daemon(func):
 def render_logs(workdir: str) -> None:
     """Renders all potentially relevant logs from the given workdir to stdout."""
     filenames = list(glob.glob(os.path.join(workdir, "logs/exceptions*log"))) + list(
-        glob.glob(os.path.join(workdir, "pantsd/pantsd.log"))
+        glob.glob(os.path.join(workdir, "pants.log"))
     )
     for filename in filenames:
         rel_filename = fast_relpath(filename, workdir)
@@ -305,8 +305,8 @@ def render_logs(workdir: str) -> None:
 
 
 def read_pants_log(workdir: str) -> Iterator[str]:
-    """Yields all lines from the pantsd log under the given workdir."""
-    # Surface the pantsd log for easy viewing via pytest's `-s` (don't capture stdio) option.
+    """Yields all lines from the pants log under the given workdir."""
+    # Surface the pants log for easy viewing via pytest's `-s` (don't capture stdio) option.
     for line in _read_log(f"{workdir}/pants.log"):
         yield line
 


### PR DESCRIPTION
### Problem

A few references to the deprecated `.pants.d/pantsd/pantsd.log` location survived after #11536.

### Solution

Fixup the references to point to the new location at `.pants.d/pants.log`.

[ci skip-rust]
[ci skip-build-wheels]