### PR TITLE
Remove references to PANTS_DEV env var

### DIFF
--- a/build-support/bin/ci.py
+++ b/build-support/bin/ci.py
@@ -131,13 +131,7 @@ def create_parser() -> argparse.ArgumentParser:
 
 def setup_environment(*, python_version: PythonVersion):
     set_cxx_compiler()
-    set_pants_dev()
     setup_python_interpreter(python_version)
-
-
-def set_pants_dev() -> None:
-    """We do this because we are running against a Pants clone."""
-    os.environ["PANTS_DEV"] = "1"
 
 
 def set_cxx_compiler() -> None:

--- a/pants
+++ b/pants
@@ -106,12 +106,4 @@ if [[ -n "${WRAPPER_SRCPATH}" ]]; then
   log "*** Running pants with extra sources ${WRAPPER_SRCPATH} ***"
 fi
 
-if [[ -n "$PANTS_DEV" && "$PANTS_DEV" -eq 0 ]]; then
-  # Unexport PANTS_DEV if explicitly set to 0.
-  export -n PANTS_DEV
-else
-  # We're running against a Pants clone.
-  export PANTS_DEV=1
-fi
-
 exec_pants_bare "$@"


### PR DESCRIPTION
This environment variable was apparently previously used to control some kind of linting that pants no longer does, so we can get rid of the code that sets it.