### PR TITLE
Pytest and pylint entry points are console scripts.

### DIFF
--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -14,7 +14,7 @@ from pants.backend.python.goals.coverage_py import (
 )
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.backend.python.target_types import (
-    EntryPoint,
+    ConsoleScript,
     PythonRuntimePackageDependencies,
     PythonTestsSources,
     PythonTestsTimeout,
@@ -197,9 +197,7 @@ async def setup_pytest_for_target(
         PexRequest(
             output_filename="pytest_runner.pex",
             interpreter_constraints=interpreter_constraints,
-            # TODO(John Sirois): Switch to ConsoleScript once Pex supports discovering console
-            #  scripts via the PEX_PATH: https://github.com/pantsbuild/pex/issues/1257
-            main=EntryPoint("pytest"),
+            main=ConsoleScript("pytest"),
             internal_only=True,
             pex_path=[pytest_pex, requirements_pex],
         ),

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from typing import List, cast
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
-from pants.backend.python.target_types import EntryPoint
+from pants.backend.python.target_types import ConsoleScript
 from pants.engine.addresses import UnparsedAddressInputs
 from pants.option.custom_types import file_option, shell_str, target_option
 from pants.util.docutil import docs_url
@@ -17,9 +17,7 @@ class Pylint(PythonToolBase):
     help = "The Pylint linter for Python code (https://www.pylint.org/)."
 
     default_version = "pylint>=2.4.4,<2.5"
-    # TODO(John Sirois): Switch to ConsoleScript once Pex supports discovering console
-    #  scripts via the PEX_PATH: https://github.com/pantsbuild/pex/issues/1257
-    default_main = EntryPoint("pylint")
+    default_main = ConsoleScript("pylint")
 
     @classmethod
     def register_options(cls, register):


### PR DESCRIPTION
Pex 2.1.33 supports specifying a console script that is available only
on the PEX_PATH as an entry point. This allows us to convert pytest and
pylint to depend on their respective console script names instead of
executable module names in the projects.

[ci skip-rust]
[ci skip-build-wheels]