### PR TITLE
[internal] Bump to version 0.7.0 of toolchain.pants.plugin

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -21,7 +21,7 @@ backend_packages.add = [
 
 plugins = [
   "hdrhistogram",  # For use with `--stats-log`.
-  "toolchain.pants.plugin==0.6.0",
+  "toolchain.pants.plugin==0.7.0",
 ]
 
 build_file_prelude_globs = ["pants-plugins/python_integration_tests_macro.py"]


### PR DESCRIPTION
Bump to version 0.7.0 of toolchain.pants.plugin to pull in explicit environment usage, which unblocks #11641.

[ci skip-rust]
[ci skip-build-wheels]