### PR TITLE
Do not interpret passthrough args

### DIFF
--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -661,7 +661,13 @@ class Parser:
         # Get value from cmd-line flags.
         flag_vals = [to_value_type(expand(x)) for x in flag_val_strs]
         if kwargs.get("passthrough"):
-            flag_vals.extend(to_value_type(x) for x in passthru_arg_strs)
+            # NB: Passthrough arguments are either of type `str` or `shell_str`
+            # (see self._validate): the former never need interpretation, and the latter do not
+            # need interpretation when they have been provided directly via `sys.argv` as the
+            # passthrough args have been.
+            flag_vals.append(
+                ListValueComponent(ListValueComponent.MODIFY, [*passthru_arg_strs], [])
+            )
 
         if is_list_option(kwargs):
             # Note: It's important to set flag_val to None if no flags were specified, so we can


### PR DESCRIPTION
### Problem

Pants currently interprets passthrough args to attempt to apply our list syntax to them.

### Solution

Do not interpret passthrough args, which are already guaranteed to be the appropriate type for their container.

### Result

Fixes #11648.

[ci skip-rust]
[ci skip-build-wheels]