### PR TITLE
Add support for gRPC mypy stub files

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/python/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules.py
@@ -127,7 +127,7 @@ async def generate_python_from_protobuf(
                 dist_info.project_name == "mypy-protobuf" and dist_info.version.major >= 2
                 for dist_info in mypy_info
             ):
-                # TODO: merge PEXes together using `pex_path instead once possible through
+                # TODO: merge PEXes together using `pex_path` instead once possible through
                 #  the `VenvPex` abstraction.
                 mypy_pex = await Get(
                     VenvPex,

--- a/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
@@ -17,6 +17,28 @@ from pants.engine.target import GeneratedSources, HydratedSources, HydrateSource
 from pants.source.source_root import NoSourceRootError
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
+GRPC_PROTO_STANZA = """
+syntax = "proto3";
+
+package dir1;
+
+// The greeter service definition.
+service Greeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+  string message = 1;
+}
+"""
+
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
@@ -243,29 +265,7 @@ def test_mypy_plugin(rule_runner: RuleRunner) -> None:
 def test_grpc(rule_runner: RuleRunner) -> None:
     rule_runner.create_file(
         "src/protobuf/dir1/f.proto",
-        dedent(
-            """\
-            syntax = "proto3";
-
-            package dir1;
-
-            // The greeter service definition.
-            service Greeter {
-              // Sends a greeting
-              rpc SayHello (HelloRequest) returns (HelloReply) {}
-            }
-
-            // The request message containing the user's name.
-            message HelloRequest {
-              string name = 1;
-            }
-
-            // The response message containing the greetings
-            message HelloReply {
-              string message = 1;
-            }
-            """
-        ),
+        dedent(GRPC_PROTO_STANZA),
     )
     rule_runner.add_to_build_file("src/protobuf/dir1", "protobuf_library(grpc=True)")
     assert_files_generated(
@@ -279,29 +279,7 @@ def test_grpc(rule_runner: RuleRunner) -> None:
 def test_grpc_mypy_plugin(rule_runner: RuleRunner) -> None:
     rule_runner.create_file(
         "src/protobuf/dir1/f.proto",
-        dedent(
-            """\
-            syntax = "proto3";
-
-            package dir1;
-
-            // The greeter service definition.
-            service Greeter {
-              // Sends a greeting
-              rpc SayHello (HelloRequest) returns (HelloReply) {}
-            }
-
-            // The request message containing the user's name.
-            message HelloRequest {
-              string name = 1;
-            }
-
-            // The response message containing the greetings
-            message HelloReply {
-              string message = 1;
-            }
-            """
-        ),
+        dedent(GRPC_PROTO_STANZA),
     )
     rule_runner.add_to_build_file("src/protobuf/dir1", "protobuf_library(grpc=True)")
     assert_files_generated(
@@ -321,29 +299,7 @@ def test_grpc_mypy_plugin(rule_runner: RuleRunner) -> None:
 def test_grpc_pre_v2_mypy_plugin(rule_runner: RuleRunner) -> None:
     rule_runner.create_file(
         "src/protobuf/dir1/f.proto",
-        dedent(
-            """\
-            syntax = "proto3";
-
-            package dir1;
-
-            // The greeter service definition.
-            service Greeter {
-              // Sends a greeting
-              rpc SayHello (HelloRequest) returns (HelloReply) {}
-            }
-
-            // The request message containing the user's name.
-            message HelloRequest {
-              string name = 1;
-            }
-
-            // The response message containing the greetings
-            message HelloReply {
-              string message = 1;
-            }
-            """
-        ),
+        dedent(GRPC_PROTO_STANZA),
     )
     rule_runner.add_to_build_file("src/protobuf/dir1", "protobuf_library(grpc=True)")
 

--- a/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
@@ -271,3 +271,45 @@ def test_grpc(rule_runner: RuleRunner) -> None:
         source_roots=["src/protobuf"],
         expected_files=["src/protobuf/dir1/f_pb2.py", "src/protobuf/dir1/f_pb2_grpc.py"],
     )
+
+
+def test_grpc_mypy_plugin(rule_runner: RuleRunner) -> None:
+    rule_runner.create_file(
+        "src/protobuf/dir1/f.proto",
+        dedent(
+            """\
+            syntax = "proto3";
+
+            package dir1;
+
+            // The greeter service definition.
+            service Greeter {
+              // Sends a greeting
+              rpc SayHello (HelloRequest) returns (HelloReply) {}
+            }
+
+            // The request message containing the user's name.
+            message HelloRequest {
+              string name = 1;
+            }
+
+            // The response message containing the greetings
+            message HelloReply {
+              string message = 1;
+            }
+            """
+        ),
+    )
+    rule_runner.add_to_build_file("src/protobuf/dir1", "protobuf_library(grpc=True)")
+    assert_files_generated(
+        rule_runner,
+        "src/protobuf/dir1",
+        source_roots=["src/protobuf"],
+        mypy=True,
+        expected_files=[
+            "src/protobuf/dir1/f_pb2.py",
+            "src/protobuf/dir1/f_pb2.pyi",
+            "src/protobuf/dir1/f_pb2_grpc.py",
+            "src/protobuf/dir1/f_pb2_grpc.pyi",
+        ],
+    )


### PR DESCRIPTION
### Problem

Pants currently supports generating mypy stubs for the generated protobuf code, which makes mypy very happy. However, when type checking a codebase that has generated gRPC code as well, mypy throws quite the hissy fit due to the lack of gRPC stubs.

### Solution

mypy-protobuf can ([since version 2.0](https://github.com/dropbox/mypy-protobuf/blob/master/CHANGELOG.md#20) at least) generate gRPC stubs as well, and it can be used in Pants with some minor changes. It will, of course, only work on mypy-protobuf 2.0+, and anyone using an older version will have a bad time. I'm not familiar enough with the Pants codebase to know if adding a version check to `if downloaded_grpc_plugin:` will be enough to prevent failure or if `VenvPexRequest` will crash and burn if a potentially invalid binary is referenced.

### Result

Stubs are now generated for the generated gRPC code as well! Awesome!
