### PR TITLE
Do not interpret passthrough args. (cherrypick of #11656)

### DIFF
--- a/src/python/pants/option/options_test.py
+++ b/src/python/pants/option/options_test.py
@@ -1046,6 +1046,27 @@ class OptionsTest(unittest.TestCase):
             "(args after `--`) is ambiguous."
         ) in str(exc.value)
 
+    def test_passthru_args_not_interpreted(self):
+        # Test that passthrough args are not interpreted.
+        options = Options.create(
+            env={},
+            config=self._create_config(),
+            known_scope_infos=[global_scope(), task("test"), subsystem("consumer")],
+            args=["./pants", "--consumer-shlexed=a", "--consumer-string=b", "test", "--", "[bar]"],
+        )
+        options.register(
+            "consumer", "--shlexed", passthrough=True, type=list, member_type=shell_str
+        )
+        options.register("consumer", "--string", passthrough=True, type=list, member_type=str)
+        self.assertEqual(
+            ["a", "[bar]"],
+            options.for_scope("consumer").shlexed,
+        )
+        self.assertEqual(
+            ["b", "[bar]"],
+            options.for_scope("consumer").string,
+        )
+
     def test_global_scope_env_vars(self):
         def check_pants_foo(expected_val, env):
             val = self._parse(env=env).for_global_scope().pants_foo

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -669,7 +669,13 @@ class Parser:
         # Get value from cmd-line flags.
         flag_vals = [to_value_type(expand(x)) for x in flag_val_strs]
         if kwargs.get("passthrough"):
-            flag_vals.extend(to_value_type(x) for x in passthru_arg_strs)
+            # NB: Passthrough arguments are either of type `str` or `shell_str`
+            # (see self._validate): the former never need interpretation, and the latter do not
+            # need interpretation when they have been provided directly via `sys.argv` as the
+            # passthrough args have been.
+            flag_vals.append(
+                ListValueComponent(ListValueComponent.MODIFY, [*passthru_arg_strs], [])
+            )
 
         if is_list_option(kwargs):
             # Note: It's important to set flag_val to None if no flags were specified, so we can


### PR DESCRIPTION
### Problem

Pants currently interprets passthrough args to attempt to apply our list syntax to them.

### Solution

Do not interpret passthrough args, which are already guaranteed to be the appropriate type for their container.

### Result

Fixes #11648.

[ci skip-rust]
[ci skip-build-wheels]