### PR TITLE
Bump default for [python-protobuf].mypy_plugin_version to 2.4

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -43,7 +43,7 @@ class PythonProtobufSubsystem(Subsystem):
         register(
             "--mypy-plugin-version",
             type=str,
-            default="mypy-protobuf==1.23",
+            default="mypy-protobuf==2.4",
             advanced=True,
             help=(
                 "The pip-style requirement string for `mypy-protobuf`. You must still set "


### PR DESCRIPTION
Bumping default mypy plugin version to 2.4, as requested in #11658.