### PR TITLE
Add helper to extract distribution info from a VenvPex

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -1026,13 +1026,13 @@ class PexDistributionInfo:
     requires_dists: tuple[Requirement, ...]
 
 
-class PexDistributionsInfo(Collection[PexDistributionInfo]):
-    """Information about all distributions in a PEX file, as reported by `PEX_TOOLS=1 repository
-    info -v`."""
+class PexResolveInfo(Collection[PexDistributionInfo]):
+    """Information about all distributions resolved in a PEX file, as reported by `PEX_TOOLS=1
+    repository info -v`."""
 
 
 @rule
-async def extract_venv_pex_distribution(venv_pex: VenvPex) -> PexDistributionsInfo:
+async def determine_venv_pex_resolve_info(venv_pex: VenvPex) -> PexResolveInfo:
     process_result = await Get(
         ProcessResult,
         VenvPexProcess(
@@ -1057,7 +1057,7 @@ async def extract_venv_pex_distribution(venv_pex: VenvPex) -> PexDistributionsIn
                 ),
             )
         )
-    return PexDistributionsInfo(sorted(dists, key=lambda dist: dist.project_name))
+    return PexResolveInfo(sorted(dists, key=lambda dist: dist.project_name))
 
 
 def rules():

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import dataclasses
 import functools
 import itertools
+import json
 import logging
 import shlex
 from collections import defaultdict
@@ -28,7 +29,7 @@ from pants.backend.python.util_rules.pex_environment import (
     PythonExecutable,
 )
 from pants.engine.addresses import Address
-from pants.engine.collection import DeduplicatedCollection
+from pants.engine.collection import Collection, DeduplicatedCollection
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import (
     EMPTY_DIGEST,
@@ -738,6 +739,7 @@ class VenvScriptWriter:
 @dataclass(frozen=True)
 class VenvPex:
     digest: Digest
+    pex_filename: str
     pex: Script
     python: Script
     bin: FrozenDict[str, Script]
@@ -825,6 +827,7 @@ async def create_venv_pex(
 
     return VenvPex(
         digest=input_digest,
+        pex_filename=result.pex_filename,
         pex=pex.script,
         python=python.script,
         bin=FrozenDict((bin_name, venv_script.script) for bin_name, venv_script in scripts.items()),
@@ -1008,6 +1011,49 @@ async def setup_venv_pex_process(request: VenvPexProcess) -> Process:
         execution_slot_variable=request.execution_slot_variable,
         cache_scope=request.cache_scope,
     )
+
+
+@dataclass(frozen=True)
+class PexDistributionInfo:
+    """Information about an individual distribution in a PEX file, as reported by
+    `PEX_TOOLS=1 repository info -v`."""
+
+    project_name: str
+    version: str
+    requires_python: str | None
+    requires_dists: list[str]
+
+
+class PexDistributionsInfo(Collection[PexDistributionInfo]):
+    """Information about all distributions in a PEX file, as reported by
+    `PEX_TOOLS=1 repository info -v`."""
+
+
+@rule
+async def extract_venv_pex_distribution(venv_pex: VenvPex) -> PexDistributionsInfo:
+    process_result = await Get(
+        ProcessResult,
+        VenvPexProcess(
+            venv_pex,
+            argv=["repository", "info", "-v"],
+            extra_env={"PEX_TOOLS": "1"},
+            input_digest=venv_pex.digest,
+            description=f"Determine distributions found in {venv_pex.pex_filename}",
+            level=LogLevel.DEBUG,
+        ),
+    )
+    dists = []
+    for line in process_result.stdout.decode().splitlines():
+        info = json.loads(line)
+        dists.append(
+            PexDistributionInfo(
+                project_name=info["project_name"],
+                version=info["version"],
+                requires_python=info.get("requires_python"),
+                requires_dists=info.get("requires_dists", []),
+            )
+        )
+    return PexDistributionsInfo(sorted(dists, key=lambda dist: dist.project_name))
 
 
 def rules():

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -23,12 +23,12 @@ from pants.backend.python.target_types import (
 from pants.backend.python.util_rules.pex import (
     Pex,
     PexDistributionInfo,
-    PexDistributionsInfo,
     PexInterpreterConstraints,
     PexPlatforms,
     PexProcess,
     PexRequest,
     PexRequirements,
+    PexResolveInfo,
     VenvPex,
     VenvPexProcess,
 )
@@ -325,7 +325,7 @@ def rule_runner() -> RuleRunner:
             QueryRule(Process, (PexProcess,)),
             QueryRule(Process, (VenvPexProcess,)),
             QueryRule(ProcessResult, (Process,)),
-            QueryRule(PexDistributionsInfo, (VenvPex,)),
+            QueryRule(PexResolveInfo, (VenvPex,)),
         ]
     )
 
@@ -614,11 +614,11 @@ def test_additional_inputs(rule_runner: RuleRunner) -> None:
     assert main_content[: len(preamble)] == preamble
 
 
-def test_venv_pex_distributions_info(rule_runner: RuleRunner) -> None:
+def test_venv_pex_resolve_info(rule_runner: RuleRunner) -> None:
     venv_pex = create_pex_and_get_all_data(
         rule_runner, pex_type=VenvPex, requirements=PexRequirements(["requests==2.23.0"])
     )["pex"]
-    dists = rule_runner.request(PexDistributionsInfo, [venv_pex])
+    dists = rule_runner.request(PexResolveInfo, [venv_pex])
     assert dists[0] == PexDistributionInfo("certifi", Version("2020.12.5"), SpecifierSet(""), ())
     assert dists[1] == PexDistributionInfo("chardet", Version("3.0.4"), SpecifierSet(""), ())
     assert dists[2] == PexDistributionInfo(


### PR DESCRIPTION
This is useful for querying what version of a dist is being used, such as is required by https://github.com/pantsbuild/pants/pull/11658.

[ci skip-rust]
[ci skip-build-wheels]