### PR TITLE
[internal] Enable RUST_BACKTRACE=1 in tests.

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -137,10 +137,16 @@ pytest_plugins.add = [
 timeout_default = 60
 
 [test]
-# TODO: These are exposed to tests in order to allow for python interpreter discovery when
-# Pants-tests-Pants: in particular, the [python-setup] subsystem consumes them.
-#   see https://github.com/pantsbuild/pants/issues/11638
-extra_env_vars = ["PYENV_ROOT", "HOME", "PATH"]
+extra_env_vars = [
+  # TODO: These are exposed to tests in order to allow for python interpreter discovery when
+  # Pants-tests-Pants: in particular, the [python-setup] subsystem consumes them.
+  #   see https://github.com/pantsbuild/pants/issues/11638
+  "PYENV_ROOT",
+  "HOME",
+  "PATH",
+  # We'd always like complete backtraces in tests.
+  "RUST_BACKTRACE=1",
+]
 
 [coverage-py]
 interpreter_constraints = [">=3.7,<3.9"]


### PR DESCRIPTION
### Problem

`RUST_BACKTRACE` is not passed through to hermetic tests, but we'd like it set in all cases there.

### Solution

Set `RUST_BACKTRACE=1` for tests.

[ci skip-rust]
[ci skip-build-wheels]