### PR TITLE
Refactor `WorkunitMetadata` to use `Default`

### DIFF
--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -97,7 +97,10 @@ impl ByteStore {
       digest.size_bytes,
     );
     let workunit_name = format!("store_bytes({})", resource_name.clone());
-    let metadata = workunit_store::WorkunitMetadata::with_level(Level::Debug);
+    let workunit_metadata = workunit_store::WorkunitMetadata {
+      level: Level::Debug,
+      ..Default::default()
+    };
     let store = self.clone();
 
     let mut client = self.byte_stream_client.as_ref().clone();
@@ -153,7 +156,7 @@ impl ByteStore {
       with_workunit(
         workunit_store,
         workunit_name,
-        metadata,
+        workunit_metadata,
         result_future,
         |_, md| md,
       )
@@ -179,7 +182,10 @@ impl ByteStore {
       digest.size_bytes
     );
     let workunit_name = format!("load_bytes_with({})", resource_name.clone());
-    let metadata = workunit_store::WorkunitMetadata::with_level(Level::Debug);
+    let workunit_metadata = workunit_store::WorkunitMetadata {
+      level: Level::Debug,
+      ..Default::default()
+    };
     let resource_name = resource_name.clone();
     let f = f.clone();
 
@@ -264,7 +270,7 @@ impl ByteStore {
       with_workunit(
         workunit_store_handle.store,
         workunit_name,
-        metadata,
+        workunit_metadata,
         result_future,
         |_, md| md,
       )
@@ -287,7 +293,10 @@ impl ByteStore {
       "list_missing_digests({})",
       store.instance_name.clone().unwrap_or_default()
     );
-    let metadata = workunit_store::WorkunitMetadata::with_level(Level::Debug);
+    let workunit_metadata = workunit_store::WorkunitMetadata {
+      level: Level::Debug,
+      ..Default::default()
+    };
     let result_future = async move {
       let store2 = store.clone();
       let mut client = store2.cas_client.as_ref().clone();
@@ -314,7 +323,7 @@ impl ByteStore {
         with_workunit(
           workunit_store_handle.store,
           workunit_name,
-          metadata,
+          workunit_metadata,
           result_future,
           |_, md| md,
         )

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -18,7 +18,7 @@ use log::Level;
 use remexec::content_addressable_storage_client::ContentAddressableStorageClient;
 use tonic::transport::Channel;
 use tonic::{Code, Interceptor, Request};
-use workunit_store::{with_workunit, ObservationMetric};
+use workunit_store::{with_workunit, ObservationMetric, WorkunitMetadata};
 
 #[derive(Clone)]
 pub struct ByteStore {
@@ -97,9 +97,9 @@ impl ByteStore {
       digest.size_bytes,
     );
     let workunit_name = format!("store_bytes({})", resource_name.clone());
-    let workunit_metadata = workunit_store::WorkunitMetadata {
+    let workunit_metadata = WorkunitMetadata {
       level: Level::Debug,
-      ..Default::default()
+      ..WorkunitMetadata::default()
     };
     let store = self.clone();
 
@@ -182,9 +182,9 @@ impl ByteStore {
       digest.size_bytes
     );
     let workunit_name = format!("load_bytes_with({})", resource_name.clone());
-    let workunit_metadata = workunit_store::WorkunitMetadata {
+    let workunit_metadata = WorkunitMetadata {
       level: Level::Debug,
-      ..Default::default()
+      ..WorkunitMetadata::default()
     };
     let resource_name = resource_name.clone();
     let f = f.clone();
@@ -293,9 +293,9 @@ impl ByteStore {
       "list_missing_digests({})",
       store.instance_name.clone().unwrap_or_default()
     );
-    let workunit_metadata = workunit_store::WorkunitMetadata {
+    let workunit_metadata = WorkunitMetadata {
       level: Level::Debug,
-      ..Default::default()
+      ..WorkunitMetadata::default()
     };
     let result_future = async move {
       let store2 = store.clone();

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -130,7 +130,10 @@ impl crate::CommandRunner for CommandRunner {
     with_workunit(
       context2.workunit_store,
       "local_cache_read".to_owned(),
-      WorkunitMetadata::with_level(Level::Debug),
+      WorkunitMetadata {
+        level: Level::Debug,
+        ..Default::default()
+      },
       cache_read_future,
       |_, md| md,
     )

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -132,7 +132,7 @@ impl crate::CommandRunner for CommandRunner {
       "local_cache_read".to_owned(),
       WorkunitMetadata {
         level: Level::Debug,
-        ..Default::default()
+        ..WorkunitMetadata::default()
       },
       cache_read_future,
       |_, md| md,

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -536,7 +536,7 @@ impl CommandRunner for BoundedCommandRunner {
       // BoundedCommandRunner to show in the dynamic UI, so set the `blocked` flag
       // on the workunit metadata in order to prevent this.
       blocked: true,
-      ..Default::default()
+      ..WorkunitMetadata::default()
     };
 
     let bounded_fut = {
@@ -554,7 +554,7 @@ impl CommandRunner for BoundedCommandRunner {
         let metadata = WorkunitMetadata {
           level: req.workunit_level(),
           desc: Some(desc),
-          ..Default::default()
+          ..WorkunitMetadata::default()
         };
 
         let metadata_updater = |result: &Result<FallibleProcessResultWithPlatform, String>,

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -312,7 +312,10 @@ impl CommandRunner {
           time_span,
           parent_id,
           &workunit_store,
-          WorkunitMetadata::with_level(Level::Debug),
+          WorkunitMetadata {
+            level: Level::Debug,
+            ..Default::default()
+          },
         ),
         Err(s) => warn!("{}", s),
       }
@@ -334,7 +337,10 @@ impl CommandRunner {
           time_span,
           parent_id,
           &workunit_store,
-          WorkunitMetadata::with_level(Level::Debug),
+          WorkunitMetadata {
+            level: Level::Debug,
+            ..Default::default()
+          },
         ),
         Err(s) => warn!("{}", s),
       }
@@ -356,7 +362,10 @@ impl CommandRunner {
           time_span,
           parent_id,
           &workunit_store,
-          WorkunitMetadata::with_level(Level::Debug),
+          WorkunitMetadata {
+            level: Level::Debug,
+            ..Default::default()
+          },
         ),
         Err(s) => warn!("{}", s),
       }
@@ -378,7 +387,10 @@ impl CommandRunner {
           time_span,
           parent_id,
           &workunit_store,
-          WorkunitMetadata::with_level(Level::Debug),
+          WorkunitMetadata {
+            level: Level::Debug,
+            ..Default::default()
+          },
         ),
         Err(s) => warn!("{}", s),
       }
@@ -758,7 +770,10 @@ impl crate::CommandRunner for CommandRunner {
     let (command_digest, action_digest) = with_workunit(
       context.workunit_store.clone(),
       "ensure_action_stored_locally".to_owned(),
-      WorkunitMetadata::with_level(Level::Debug),
+      WorkunitMetadata {
+        level: Level::Debug,
+        ..Default::default()
+      },
       ensure_action_stored_locally(&self.store, &command, &action),
       |_, md| md,
     )
@@ -769,7 +784,10 @@ impl crate::CommandRunner for CommandRunner {
     let cached_response_opt = with_workunit(
       context.workunit_store.clone(),
       "check_action_cache".to_owned(),
-      WorkunitMetadata::with_level(Level::Debug),
+      WorkunitMetadata {
+        level: Level::Debug,
+        ..Default::default()
+      },
       check_action_cache(
         action_digest,
         &self.metadata,
@@ -794,7 +812,10 @@ impl crate::CommandRunner for CommandRunner {
     with_workunit(
       context.workunit_store.clone(),
       "ensure_action_uploaded".to_owned(),
-      WorkunitMetadata::with_level(Level::Debug),
+      WorkunitMetadata {
+        level: Level::Debug,
+        ..Default::default()
+      },
       ensure_action_uploaded(&store, command_digest, action_digest, request.input_files),
       |_, md| md,
     )
@@ -809,7 +830,10 @@ impl crate::CommandRunner for CommandRunner {
     let response = with_workunit(
       context.workunit_store.clone(),
       "run_execute_request".to_owned(),
-      WorkunitMetadata::with_level(Level::Debug),
+      WorkunitMetadata {
+        level: Level::Debug,
+        ..Default::default()
+      },
       timeout_fut,
       |result, mut metadata| {
         if result.is_err() {

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -314,7 +314,7 @@ impl CommandRunner {
           &workunit_store,
           WorkunitMetadata {
             level: Level::Debug,
-            ..Default::default()
+            ..WorkunitMetadata::default()
           },
         ),
         Err(s) => warn!("{}", s),
@@ -339,7 +339,7 @@ impl CommandRunner {
           &workunit_store,
           WorkunitMetadata {
             level: Level::Debug,
-            ..Default::default()
+            ..WorkunitMetadata::default()
           },
         ),
         Err(s) => warn!("{}", s),
@@ -364,7 +364,7 @@ impl CommandRunner {
           &workunit_store,
           WorkunitMetadata {
             level: Level::Debug,
-            ..Default::default()
+            ..WorkunitMetadata::default()
           },
         ),
         Err(s) => warn!("{}", s),
@@ -389,7 +389,7 @@ impl CommandRunner {
           &workunit_store,
           WorkunitMetadata {
             level: Level::Debug,
-            ..Default::default()
+            ..WorkunitMetadata::default()
           },
         ),
         Err(s) => warn!("{}", s),
@@ -772,7 +772,7 @@ impl crate::CommandRunner for CommandRunner {
       "ensure_action_stored_locally".to_owned(),
       WorkunitMetadata {
         level: Level::Debug,
-        ..Default::default()
+        ..WorkunitMetadata::default()
       },
       ensure_action_stored_locally(&self.store, &command, &action),
       |_, md| md,
@@ -786,7 +786,7 @@ impl crate::CommandRunner for CommandRunner {
       "check_action_cache".to_owned(),
       WorkunitMetadata {
         level: Level::Debug,
-        ..Default::default()
+        ..WorkunitMetadata::default()
       },
       check_action_cache(
         action_digest,
@@ -814,7 +814,7 @@ impl crate::CommandRunner for CommandRunner {
       "ensure_action_uploaded".to_owned(),
       WorkunitMetadata {
         level: Level::Debug,
-        ..Default::default()
+        ..WorkunitMetadata::default()
       },
       ensure_action_uploaded(&store, command_digest, action_digest, request.input_files),
       |_, md| md,
@@ -832,7 +832,7 @@ impl crate::CommandRunner for CommandRunner {
       "run_execute_request".to_owned(),
       WorkunitMetadata {
         level: Level::Debug,
-        ..Default::default()
+        ..WorkunitMetadata::default()
       },
       timeout_fut,
       |result, mut metadata| {

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -343,7 +343,7 @@ impl CommandRunner {
       "ensure_action_uploaded".to_owned(),
       WorkunitMetadata {
         level: Level::Debug,
-        ..Default::default()
+        ..WorkunitMetadata::default()
       },
       crate::remote::ensure_action_uploaded(
         &self.store,
@@ -409,7 +409,7 @@ impl crate::CommandRunner for CommandRunner {
       "ensure_action_stored_locally".to_owned(),
       WorkunitMetadata {
         level: Level::Debug,
-        ..Default::default()
+        ..WorkunitMetadata::default()
       },
       crate::remote::ensure_action_stored_locally(&self.store, &command, &action),
       |_, md| md,
@@ -426,7 +426,7 @@ impl crate::CommandRunner for CommandRunner {
           "check_action_cache".to_owned(),
           WorkunitMetadata {
             level: Level::Debug,
-            ..Default::default()
+            ..WorkunitMetadata::default()
           },
           crate::remote::check_action_cache(
             action_digest,
@@ -528,7 +528,7 @@ impl crate::CommandRunner for CommandRunner {
         "remote_cache_write".to_owned(),
         WorkunitMetadata {
           level: Level::Debug,
-          ..Default::default()
+          ..WorkunitMetadata::default()
         },
         cache_write_future,
         |_, md| md,

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -341,7 +341,10 @@ impl CommandRunner {
     with_workunit(
       context.workunit_store.clone(),
       "ensure_action_uploaded".to_owned(),
-      WorkunitMetadata::with_level(Level::Debug),
+      WorkunitMetadata {
+        level: Level::Debug,
+        ..Default::default()
+      },
       crate::remote::ensure_action_uploaded(
         &self.store,
         command_digest,
@@ -404,7 +407,10 @@ impl crate::CommandRunner for CommandRunner {
     let (command_digest, action_digest) = with_workunit(
       context.workunit_store.clone(),
       "ensure_action_stored_locally".to_owned(),
-      WorkunitMetadata::with_level(Level::Debug),
+      WorkunitMetadata {
+        level: Level::Debug,
+        ..Default::default()
+      },
       crate::remote::ensure_action_stored_locally(&self.store, &command, &action),
       |_, md| md,
     )
@@ -418,7 +424,10 @@ impl crate::CommandRunner for CommandRunner {
         let response = with_workunit(
           context.workunit_store.clone(),
           "check_action_cache".to_owned(),
-          WorkunitMetadata::with_level(Level::Debug),
+          WorkunitMetadata {
+            level: Level::Debug,
+            ..Default::default()
+          },
           crate::remote::check_action_cache(
             action_digest,
             &self.metadata,
@@ -517,7 +526,10 @@ impl crate::CommandRunner for CommandRunner {
       let _write_join = self.executor.spawn(with_workunit(
         context.workunit_store,
         "remote_cache_write".to_owned(),
-        WorkunitMetadata::with_level(Level::Debug),
+        WorkunitMetadata {
+          level: Level::Debug,
+          ..Default::default()
+        },
         cache_write_future,
         |_, md| md,
       ));

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -145,8 +145,8 @@ pub struct WorkunitMetadata {
   pub user_metadata: Vec<(String, UserMetadataItem)>,
 }
 
-impl WorkunitMetadata {
-  pub fn new() -> Self {
+impl Default for WorkunitMetadata {
+  fn default() -> WorkunitMetadata {
     WorkunitMetadata {
       level: Level::Info,
       desc: None,
@@ -157,12 +157,6 @@ impl WorkunitMetadata {
       artifacts: Vec::new(),
       user_metadata: Vec::new(),
     }
-  }
-
-  pub fn with_level(level: Level) -> Self {
-    let mut metadata = WorkunitMetadata::new();
-    metadata.level = level;
-    metadata
   }
 }
 


### PR DESCRIPTION
This makes it easier to change fields in the constructor than the status quo of having to create a mutable value.

[ci skip-build-wheels]