### PR TITLE
Fix the "local_only" option to properly disable remote execution and caching

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -21,7 +21,13 @@ backend_packages.add = [
 
 plugins = [
   "hdrhistogram",  # For use with `--stats-log`.
+  # TODO: Remove the relevant `ignore_pants_warning` entry when this is bumped.
   "toolchain.pants.plugin==0.7.0",
+]
+
+ignore_pants_warnings = [
+  # TODO: Remove when `toolchain.pants.plugin` is bumped past `0.7.0`.
+  "DeprecationWarning: DEPRECATED: pants.core.util_rules.pants_environment",
 ]
 
 build_file_prelude_globs = ["pants-plugins/python_integration_tests_macro.py"]

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -141,10 +141,10 @@ class ExecutionOptions:
         remote_execution_headers = cast(Dict[str, str], bootstrap_options.remote_execution_headers)
         remote_store_headers = cast(Dict[str, str], bootstrap_options.remote_store_headers)
         remote_instance_name = cast(Optional[str], bootstrap_options.remote_instance_name)
-        remote_execution = cast(bool, bootstrap_options.remote_execution)
-        remote_cache_read = cast(bool, bootstrap_options.remote_cache_read)
-        remote_cache_write = cast(bool, bootstrap_options.remote_cache_write)
-        if bootstrap_options.remote_oauth_bearer_token_path:
+        remote_execution = cast(bool, bootstrap_options.remote_execution) and not local_only
+        remote_cache_read = cast(bool, bootstrap_options.remote_cache_read) and not local_only
+        remote_cache_write = cast(bool, bootstrap_options.remote_cache_write) and not local_only
+        if not local_only and bootstrap_options.remote_oauth_bearer_token_path:
             oauth_token = (
                 Path(bootstrap_options.remote_oauth_bearer_token_path).resolve().read_text().strip()
             )

--- a/src/python/pants/option/global_options_test.py
+++ b/src/python/pants/option/global_options_test.py
@@ -111,6 +111,7 @@ def test_execution_options_local_only() -> None:
     assert not exec_options.remote_execution
     assert not exec_options.remote_cache_read
     assert not exec_options.remote_cache_write
+    assert exec_options.remote_store_headers == {}
     assert exec_options.remote_execution_headers == {}
 
 

--- a/src/python/pants/option/global_options_test.py
+++ b/src/python/pants/option/global_options_test.py
@@ -26,6 +26,7 @@ def create_execution_options(
     plugin: str | None = None,
     remote_store_address: str = "grpc://fake.url:10",
     remote_execution_address: str = "grpc://fake.url:10",
+    local_only: bool = False,
 ) -> ExecutionOptions:
     args = [
         "--remote-cache-read",
@@ -44,7 +45,7 @@ def create_execution_options(
     _build_config, options = OptionsInitializer(ob, env).build_config_and_options(
         ob, env, raise_=False
     )
-    return ExecutionOptions.from_options(options, env)
+    return ExecutionOptions.from_options(options, env, local_only=local_only)
 
 
 def test_execution_options_remote_oauth_bearer_token_path() -> None:
@@ -93,6 +94,24 @@ def test_execution_options_remote_addresses() -> None:
             remote_store_address=f"grpc://{host}",
             remote_execution_address=f"https:://{host}",
         )
+
+
+def test_execution_options_local_only() -> None:
+    # Test that local_only properly disables remote execution. It doesn't need to prune all
+    # settings, only those which would trigger usage.
+    host = "fake-with-http-in-url.com:10"
+    exec_options = create_execution_options(
+        initial_headers={},
+        remote_store_address=f"grpc://{host}",
+        remote_execution_address=f"grpc://{host}",
+        local_only=True,
+    )
+    # Remote execution should be disabled, and the headers should still be empty, indicating that
+    # the auth plugin has not run.
+    assert not exec_options.remote_execution
+    assert not exec_options.remote_cache_read
+    assert not exec_options.remote_cache_write
+    assert exec_options.remote_execution_headers == {}
 
 
 def test_execution_options_auth_plugin() -> None:


### PR DESCRIPTION
### Problem

#11641 changed how `ExecutionOptions` are computed for the "bootstrap" `Scheduler` that is used for plugin resolution (in order to allow any local-affecting options to still be used, while only disabling remote execution). But the `local_only` flag was sloppily applied, and did not affect the boolean flags that actually enable or disable remote caching and execution.

### Solution

Apply the `ExecutionOptions.from_options(local_only)` flag more thoroughly, so that both caching and execution are disabled (in addition to skipping the auth plugin).

### Result

Repositories that use auth plugins and remote execution will not experience errors during plugin bootstrapping.

[ci skip-build-wheels]
[ci skip-rust]