### PR TITLE
[Internal] make audit.yaml consistent with generator file

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -38,4 +38,4 @@ jobs:
 name: Cargo Audit
 'on':
   schedule:
-  - cron: 11 23 * * *
+  - cron: 11 7 * * *


### PR DESCRIPTION
Somehow, there's a minor difference between the state of the currently-checked-in `.github/workflows/audit.yaml` and what `generate_github_workflows.py` is set to generate. I re-ran `./pants run build-support/bin/generate_github_workflows.py` and am checking in the resulting yaml file in this commit, to avoid confusion when editing the generator file later.