### PR TITLE
[Internal] fix cron time specified in github action configuration

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -38,4 +38,4 @@ jobs:
 name: Cargo Audit
 'on':
   schedule:
-  - cron: 11 7 * * *
+  - cron: 11 8 * * *

--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -417,4 +417,4 @@ jobs:
 name: Daily Extended Python Testing
 'on':
   schedule:
-  - cron: 45 23 * * *
+  - cron: 45 8 * * *

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -315,8 +315,8 @@ def generate() -> dict[Path, str]:
     audit_yaml = yaml.dump(
         {
             "name": "Cargo Audit",
-            # 7:11 UTC / 11:11 PT: arbitrary time after hours.
-            "on": {"schedule": [{"cron": "11 7 * * *"}]},
+            # 08:11 UTC / 12:11AM PST, 1:11AM PDT: arbitrary time after hours.
+            "on": {"schedule": [{"cron": "11 8 * * *"}]},
             "jobs": {
                 "audit": {
                     "runs-on": "ubuntu-latest",
@@ -335,8 +335,8 @@ def generate() -> dict[Path, str]:
     test_cron_yaml = yaml.dump(
         {
             "name": "Daily Extended Python Testing",
-            # 7:45 UTC / 11:45 PT: arbitrary time after hours.
-            "on": {"schedule": [{"cron": "45 23 * * *"}]},
+            # 08:45 UTC / 12:45AM PST, 1:45AM PDT: arbitrary time after hours.
+            "on": {"schedule": [{"cron": "45 8 * * *"}]},
             "jobs": test_workflow_jobs(["3.8.3"]),
         },
         Dumper=NoAliasDumper,


### PR DESCRIPTION
The Github Actions docs say that the time in the `on: schedule:` specifier is in UTC, but one of them was written at a time which is late at night in UTC and therefore in the afternoon in Pacific Time. This commit makes the scheduled times for both the daily extended testing and `cargo audit` jobs be at times in UTC that correspond to times late at night in Pacific Time, and clarifies the comments around this.