### PR TITLE
Streaming workunit handler can finalize async when pantsd used

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -239,7 +239,7 @@ class LocalPantsRunner:
             )
 
             goals = tuple(self.options.goals)
-            with streaming_reporter.session():
+            with streaming_reporter.session(pantsd=global_options.pantsd):
                 if not goals:
                     return PANTS_SUCCEEDED_EXIT_CODE
                 engine_result = PANTS_FAILED_EXIT_CODE

--- a/src/python/pants/engine/streaming_workunit_handler.py
+++ b/src/python/pants/engine/streaming_workunit_handler.py
@@ -121,13 +121,13 @@ class WorkunitsCallback(ABC):
 
     @property
     def can_finish_async(self) -> bool:
-        """Can this callback finish it's work in the background after the Pants run has already
+        """Can this callback finish its work in the background after the Pants run has already
         completed?
 
         The main reason to `return False` is if your callback logs in its final call, when
         `finished=True`, as it may end up logging to `.pantsd.d/pants.log` instead of the console,
-        which is harder for users to find. Otherwise, most callbacks should return
-        `True` to avoid slowing down Pants from finishing the run.
+        which is harder for users to find. Otherwise, most callbacks should return `True` to avoid
+        slowing down Pants from finishing the run.
         """
         return False
 

--- a/src/python/pants/engine/streaming_workunit_handler.py
+++ b/src/python/pants/engine/streaming_workunit_handler.py
@@ -119,6 +119,18 @@ class WorkunitsCallback(ABC):
         :context: A context providing access to functionality relevant to the run.
         """
 
+    @property
+    def can_finish_async(self) -> bool:
+        """Can this callback finish it's work in the background after the Pants run has already
+        completed?
+
+        The main reason to `return False` is if your callback logs in its final call, when
+        `finished=True`, as it may end up logging to `.pantsd.d/pants.log` instead of the console,
+        which is harder for users to find. Otherwise, most callbacks should return
+        `True` to avoid slowing down Pants from finishing the run.
+        """
+        return False
+
 
 @dataclass(frozen=True)
 class WorkunitsCallbackFactory:
@@ -185,30 +197,33 @@ class StreamingWorkunitHandler:
         self.max_workunit_verbosity = max_workunit_verbosity
 
     def start(self) -> None:
-        if self.callbacks:
-            self._thread_runner = _InnerHandler(
-                scheduler=self.scheduler,
-                context=self._context,
-                callbacks=self.callbacks,
-                report_interval=self.report_interval,
-                max_workunit_verbosity=self.max_workunit_verbosity,
-            )
-            self._thread_runner.start()
+        if not self.callbacks:
+            return
+        self._thread_runner = _InnerHandler(
+            scheduler=self.scheduler,
+            context=self._context,
+            callbacks=self.callbacks,
+            report_interval=self.report_interval,
+            max_workunit_verbosity=self.max_workunit_verbosity,
+        )
+        self._thread_runner.start()
 
-    def end(self) -> None:
-        if self._thread_runner:
-            self._thread_runner.join()
-
-            # After stopping the thread, poll workunits one last time to make sure
-            # we report any workunits that were added after the last time the thread polled.
-            self._thread_runner.poll_workunits(finished=True)
+    def end(self, *, pantsd: bool) -> None:
+        if not self._thread_runner:
+            return
+        # TODO: Have a thread per callback so that some callbacks can always finish async even
+        #  if others must be finished synchronously.
+        block_until_complete = not pantsd or any(
+            callback.can_finish_async is False for callback in self.callbacks
+        )
+        self._thread_runner.end(block_until_complete=block_until_complete)
 
     @contextmanager
-    def session(self) -> Iterator[None]:
+    def session(self, *, pantsd: bool) -> Iterator[None]:
         try:
             self.start()
             yield
-            self.end()
+            self.end(pantsd=pantsd)
         except Exception as e:
             if self._thread_runner:
                 self._thread_runner.join()
@@ -251,10 +266,15 @@ class _InnerHandler(threading.Thread):
         while not self.stop_request.isSet():  # type: ignore[attr-defined]
             self.poll_workunits(finished=False)
             self.stop_request.wait(timeout=self.report_interval)
+        else:
+            # Make one final call. Note that this may run after the Pants run has already
+            # completed, depending on whether the thread was joined or not.
+            self.poll_workunits(finished=True)
 
-    def join(self, timeout: float | None = None) -> None:
+    def end(self, *, block_until_complete: bool) -> None:
         self.stop_request.set()
-        super().join(timeout)
+        if block_until_complete:
+            super().join()
 
 
 def rules():

--- a/src/python/pants/goal/stats_aggregator.py
+++ b/src/python/pants/goal/stats_aggregator.py
@@ -53,6 +53,11 @@ class StatsAggregatorCallback(WorkunitsCallback):
         self.has_histogram_module = has_histogram_module
         self.counters: Counter = Counter()
 
+    @property
+    def can_finish_async(self) -> bool:
+        # If the callback is activated, we need to finish synchronously for access to the console.
+        return not self.enabled
+
     def __call__(
         self,
         *,

--- a/testprojects/pants-plugins/src/python/workunit_logger/register.py
+++ b/testprojects/pants-plugins/src/python/workunit_logger/register.py
@@ -32,6 +32,11 @@ class WorkunitsLoggerRequest:
 class WorkunitsLogger(WorkunitsCallback):
     dest: str
 
+    @property
+    def can_finish_async(self) -> bool:
+        # Because we don't write to the console, it's safe to finalize in the background.
+        return True
+
     def __call__(self, *, completed_workunits: Tuple[Workunit, ...], **kwargs) -> None:
         with open(self.dest, "a") as dest:
             print(str(completed_workunits), file=dest)


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/11433. When pantsd is used, streaming workunit callbacks can now finish in a background thread, rather than blocking the completion of the Pants run.

However, plugin authors must tell us if their plugin is safe to do this. The main downside is that any logging to the console will instead go to `.pantsd.d/pants.log`.

[ci skip-rust]
[ci skip-build-wheels]