### PR TITLE
Refactor `StreamingWorkunitHandler` to be a class-based context manager

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -224,13 +224,8 @@ class LocalPantsRunner:
         self.run_tracker.start(run_start_time=start_time, specs=specs)
 
         with maybe_profiled(self.profile_path):
-            if self.options.help_request:
-                return self._print_help(self.options.help_request)
-
             global_options = self.options.for_global_scope()
             goals = tuple(self.options.goals)
-            if not goals:
-                return PANTS_SUCCEEDED_EXIT_CODE
 
             streaming_reporter = StreamingWorkunitHandler(
                 self.graph_session.scheduler_session,
@@ -242,6 +237,11 @@ class LocalPantsRunner:
                 pantsd=global_options.pantsd,
             )
             with streaming_reporter:
+                if self.options.help_request:
+                    return self._print_help(self.options.help_request)
+                if not goals:
+                    return PANTS_SUCCEEDED_EXIT_CODE
+
                 try:
                     engine_result = self._perform_run(goals)
                 except Exception as e:

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -246,7 +246,6 @@ class LocalPantsRunner:
                     engine_result = self._perform_run(goals)
                 except Exception as e:
                     ExceptionSink.log_exception(e)
-                else:
                     engine_result = PANTS_FAILED_EXIT_CODE
 
                 metrics = self.graph_session.scheduler_session.metrics()

--- a/src/python/pants/engine/streaming_workunit_handler.py
+++ b/src/python/pants/engine/streaming_workunit_handler.py
@@ -6,9 +6,8 @@ from __future__ import annotations
 import logging
 import threading
 from abc import ABC, abstractmethod
-from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Callable, Iterable, Iterator, Sequence, Tuple
+from typing import Any, Callable, Iterable, Sequence, Tuple
 
 from pants.base.specs import Specs
 from pants.engine.addresses import Addresses
@@ -170,7 +169,10 @@ async def construct_workunits_callback_factories(
 
 
 class StreamingWorkunitHandler:
-    """Periodically calls each registered WorkunitsCallback in a dedicated thread."""
+    """Periodically calls each registered WorkunitsCallback in a dedicated thread.
+
+    This class should be used as a context manager.
+    """
 
     def __init__(
         self,
@@ -180,54 +182,42 @@ class StreamingWorkunitHandler:
         options_bootstrapper: OptionsBootstrapper,
         specs: Specs,
         report_interval_seconds: float,
+        pantsd: bool,
         max_workunit_verbosity: LogLevel = LogLevel.TRACE,
     ) -> None:
-        self.scheduler = scheduler
-        self.report_interval = report_interval_seconds
         self.callbacks = callbacks
-        self._thread_runner: _InnerHandler | None = None
-        self._context = StreamingWorkunitContext(
-            _scheduler=self.scheduler,
+        self.context = StreamingWorkunitContext(
+            _scheduler=scheduler,
             _run_tracker=run_tracker,
             _specs=specs,
             _options_bootstrapper=options_bootstrapper,
         )
-        # TODO(10092) The max verbosity should be a per-client setting, rather than a global
-        #  setting.
-        self.max_workunit_verbosity = max_workunit_verbosity
-
-    def start(self) -> None:
-        if not self.callbacks:
-            return
-        self._thread_runner = _InnerHandler(
-            scheduler=self.scheduler,
-            context=self._context,
-            callbacks=self.callbacks,
-            report_interval=self.report_interval,
-            max_workunit_verbosity=self.max_workunit_verbosity,
+        self.thread_runner = (
+            _InnerHandler(
+                scheduler=scheduler,
+                context=self.context,
+                callbacks=self.callbacks,
+                report_interval=report_interval_seconds,
+                # TODO(10092) The max verbosity should be a per-client setting, rather than a global
+                #  setting.
+                max_workunit_verbosity=max_workunit_verbosity,
+                pantsd=pantsd,
+            )
+            if callbacks
+            else None
         )
-        self._thread_runner.start()
 
-    def end(self, *, pantsd: bool) -> None:
-        if not self._thread_runner:
+    def __enter__(self) -> None:
+        if not self.thread_runner:
             return
-        # TODO: Have a thread per callback so that some callbacks can always finish async even
-        #  if others must be finished synchronously.
-        block_until_complete = not pantsd or any(
-            callback.can_finish_async is False for callback in self.callbacks
-        )
-        self._thread_runner.end(block_until_complete=block_until_complete)
+        self.thread_runner.start()
 
-    @contextmanager
-    def session(self, *, pantsd: bool) -> Iterator[None]:
-        try:
-            self.start()
-            yield
-            self.end(pantsd=pantsd)
-        except Exception as e:
-            if self._thread_runner:
-                self._thread_runner.join()
-            raise e
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        if not self.thread_runner:
+            return
+        self.thread_runner.end()
+        if exc_type is not None:
+            self.thread_runner.join()
 
 
 class _InnerHandler(threading.Thread):
@@ -238,14 +228,20 @@ class _InnerHandler(threading.Thread):
         callbacks: Iterable[WorkunitsCallback],
         report_interval: float,
         max_workunit_verbosity: LogLevel,
+        pantsd: bool,
     ) -> None:
         super().__init__(daemon=True)
         self.scheduler = scheduler
-        self._context = context
+        self.context = context
         self.stop_request = threading.Event()
         self.report_interval = report_interval
         self.callbacks = callbacks
         self.max_workunit_verbosity = max_workunit_verbosity
+        # TODO: Have a thread per callback so that some callbacks can always finish async even
+        #  if others must be finished synchronously.
+        self.block_until_complete = not pantsd or any(
+            callback.can_finish_async is False for callback in self.callbacks
+        )
         # Get the parent thread's logging destination. Note that this thread has not yet started
         # as we are only in the constructor.
         self.logging_destination = native_engine.stdio_thread_get_destination()
@@ -257,7 +253,7 @@ class _InnerHandler(threading.Thread):
                 started_workunits=workunits["started"],
                 completed_workunits=workunits["completed"],
                 finished=finished,
-                context=self._context,
+                context=self.context,
             )
 
     def run(self) -> None:
@@ -271,9 +267,9 @@ class _InnerHandler(threading.Thread):
             # completed, depending on whether the thread was joined or not.
             self.poll_workunits(finished=True)
 
-    def end(self, *, block_until_complete: bool) -> None:
+    def end(self) -> None:
         self.stop_request.set()
-        if block_until_complete:
+        if self.block_until_complete:
             super().join()
 
 


### PR DESCRIPTION
Before, it was possible to call `StreamingWorkunitHandler.session()` multiple times, meaning we'd be starting and stopping the same threads during the same Pants run. While this wasn't done in practice beyond a test, it complicates future changes and is an inaccurate representation of what we expect.

Even though it is still possible to do this with a class-based context manager, the class better expresses the intention than a reusable method. Further, this change will result in a RuntimeException if the user does use the context manager twice.

[ci skip-rust]
[ci skip-build-wheels]