### PR TITLE
Support extracting PexResolveInfo from a Pex.

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -97,20 +97,29 @@ class PexCliProcess:
             raise ValueError("`--pex-root` flag not allowed. We set its value for you.")
 
 
+class PexPEX(DownloadedExternalTool):
+    """The Pex PEX binary."""
+
+
+@rule
+async def download_pex_pex(pex_binary: PexBinary) -> PexPEX:
+    pex_pex = await Get(
+        DownloadedExternalTool, ExternalToolRequest, pex_binary.get_request(Platform.current)
+    )
+    return PexPEX(digest=pex_pex.digest, exe=pex_pex.exe)
+
+
 @rule
 async def setup_pex_cli_process(
     request: PexCliProcess,
-    pex_binary: PexBinary,
+    pex_binary: PexPEX,
     pex_env: PexEnvironment,
     python_native_code: PythonNativeCode,
     global_options: GlobalOptions,
     pex_runtime_env: PexRuntimeEnvironment,
 ) -> Process:
     tmpdir = ".tmp"
-    gets: List[Get] = [
-        Get(DownloadedExternalTool, ExternalToolRequest, pex_binary.get_request(Platform.current)),
-        Get(Digest, CreateDigest([Directory(tmpdir)])),
-    ]
+    gets: List[Get] = [Get(Digest, CreateDigest([Directory(tmpdir)]))]
     cert_args = []
 
     # The certs file will typically not be in the repo, so we can't digest it via a PathGlobs.
@@ -127,15 +136,15 @@ async def setup_pex_cli_process(
         )
         cert_args = ["--cert", chrooted_ca_certs_path]
 
-    downloaded_pex_bin, *digests_to_merge = await MultiGet(gets)
-    digests_to_merge.append(downloaded_pex_bin.digest)
+    digests_to_merge = [pex_binary.digest]
+    digests_to_merge.extend(await MultiGet(gets))
     if request.additional_input_digest:
         digests_to_merge.append(request.additional_input_digest)
     input_digest = await Get(Digest, MergeDigests(digests_to_merge))
 
     pex_root_path = ".cache/pex_root"
     argv = [
-        downloaded_pex_bin.exe,
+        pex_binary.exe,
         *cert_args,
         "--python-path",
         create_path_env_var(pex_env.interpreter_search_paths),

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -325,6 +325,7 @@ def rule_runner() -> RuleRunner:
             QueryRule(Process, (PexProcess,)),
             QueryRule(Process, (VenvPexProcess,)),
             QueryRule(ProcessResult, (Process,)),
+            QueryRule(PexResolveInfo, (Pex,)),
             QueryRule(PexResolveInfo, (VenvPex,)),
         ]
     )
@@ -614,13 +615,14 @@ def test_additional_inputs(rule_runner: RuleRunner) -> None:
     assert main_content[: len(preamble)] == preamble
 
 
-def test_venv_pex_resolve_info(rule_runner: RuleRunner) -> None:
+@pytest.mark.parametrize("pex_type", [Pex, VenvPex])
+def test_venv_pex_resolve_info(rule_runner: RuleRunner, pex_type: type[Pex | VenvPex]) -> None:
     venv_pex = create_pex_and_get_all_data(
-        rule_runner, pex_type=VenvPex, requirements=PexRequirements(["requests==2.23.0"])
+        rule_runner, pex_type=pex_type, requirements=PexRequirements(["requests==2.23.0"])
     )["pex"]
     dists = rule_runner.request(PexResolveInfo, [venv_pex])
-    assert dists[0] == PexDistributionInfo("certifi", Version("2020.12.5"), SpecifierSet(""), ())
-    assert dists[1] == PexDistributionInfo("chardet", Version("3.0.4"), SpecifierSet(""), ())
+    assert dists[0] == PexDistributionInfo("certifi", Version("2020.12.5"), None, ())
+    assert dists[1] == PexDistributionInfo("chardet", Version("3.0.4"), None, ())
     assert dists[2] == PexDistributionInfo(
         "idna", Version("2.10"), SpecifierSet("!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"), ()
     )


### PR DESCRIPTION
There was no reason this was limited to just VenvPex. This allows, for
example, resolving a Pex, testing its contents, and then assembling a
VenvPex that uses its resolve via the pex_path.

[ci skip-rust]
[ci skip-build-wheels]