### PR TITLE
Fix test-cron.

### DIFF
--- a/.github/actions/expose-pythons/action.yml
+++ b/.github/actions/expose-pythons/action.yml
@@ -1,0 +1,22 @@
+name: Expose Pythons
+description: Exposes Pythons on the PATH.
+runs:
+  using: composite
+  steps:
+    - name: Expose Pythons
+      run: |
+        if [[ "$(uname -s)" == "Darwin" ]]; then
+          toolcache="/Users/runner/hostedtoolcache"
+        else
+          toolcache="/opt/hostedtoolcache"
+        fi
+
+        echo "::group::Exposing Pythons"
+        for python_bin_dir in ${toolcache}/Python/*/x64/bin; do
+          echo "Exposing ${python_bin_dir}: $(${python_bin_dir}/python --version)"
+          PATH="${PATH}:${python_bin_dir}"
+        done
+        echo "::endgroup::"
+
+        echo "PATH=${PATH}" >> $GITHUB_ENV
+      shell: bash

--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -347,6 +347,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Expose Pythons
+      uses: ./.github/actions/expose-pythons
     - name: Cache Pants Virtualenv
       uses: actions/cache@v2
       with:
@@ -386,6 +388,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Expose Pythons
+      uses: ./.github/actions/expose-pythons
     - name: Cache Pants Virtualenv
       uses: actions/cache@v2
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -347,6 +347,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Expose Pythons
+      uses: ./.github/actions/expose-pythons
     - name: Cache Pants Virtualenv
       uses: actions/cache@v2
       with:
@@ -386,6 +388,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Expose Pythons
+      uses: ./.github/actions/expose-pythons
     - name: Cache Pants Virtualenv
       uses: actions/cache@v2
       with:

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -136,6 +136,25 @@ def native_engine_so_download() -> Sequence[Step]:
     ]
 
 
+def setup_primary_python() -> Sequence[Step]:
+    return [
+        {
+            "name": "Set up Python ${{ matrix.python-version }}",
+            "uses": "actions/setup-python@v2",
+            "with": {"python-version": "${{ matrix.python-version }}"},
+        }
+    ]
+
+
+def expose_all_pythons() -> Sequence[Step]:
+    return [
+        {
+            "name": "Expose Pythons",
+            "uses": "./.github/actions/expose-pythons",
+        }
+    ]
+
+
 def test_workflow_jobs(python_versions: Sequence[str]) -> Jobs:
     return {
         "bootstrap_pants_linux": {
@@ -145,11 +164,7 @@ def test_workflow_jobs(python_versions: Sequence[str]) -> Jobs:
             "env": {"rust_version": "1.49.0"},
             "steps": [
                 *checkout(),
-                {
-                    "name": "Set up Python ${{ matrix.python-version }}",
-                    "uses": "actions/setup-python@v2",
-                    "with": {"python-version": "${{ matrix.python-version }}"},
-                },
+                *setup_primary_python(),
                 *bootstrap_caches(),
                 {
                     "name": "Set env vars",
@@ -175,11 +190,8 @@ def test_workflow_jobs(python_versions: Sequence[str]) -> Jobs:
             "strategy": {"matrix": {"python-version": python_versions}},
             "steps": [
                 *checkout(),
-                {
-                    "name": "Set up Python ${{ matrix.python-version }}",
-                    "uses": "actions/setup-python@v2",
-                    "with": {"python-version": "${{ matrix.python-version }}"},
-                },
+                *setup_primary_python(),
+                *expose_all_pythons(),
                 *pants_virtualenv_cache(),
                 *native_engine_so_download(),
                 *pants_config_files(),
@@ -193,11 +205,7 @@ def test_workflow_jobs(python_versions: Sequence[str]) -> Jobs:
             "strategy": {"matrix": {"python-version": python_versions}},
             "steps": [
                 *checkout(),
-                {
-                    "name": "Set up Python ${{ matrix.python-version }}",
-                    "uses": "actions/setup-python@v2",
-                    "with": {"python-version": "${{ matrix.python-version }}"},
-                },
+                *setup_primary_python(),
                 *pants_virtualenv_cache(),
                 *native_engine_so_download(),
                 *pants_config_files(),
@@ -214,11 +222,7 @@ def test_workflow_jobs(python_versions: Sequence[str]) -> Jobs:
             "env": {"rust_version": "1.49.0"},
             "steps": [
                 *checkout(),
-                {
-                    "name": "Set up Python ${{ matrix.python-version }}",
-                    "uses": "actions/setup-python@v2",
-                    "with": {"python-version": "${{ matrix.python-version }}"},
-                },
+                *setup_primary_python(),
                 *bootstrap_caches(),
                 *pants_config_files(),
                 {"name": "Bootstrap Pants", "run": "./pants --version\n"},
@@ -238,11 +242,8 @@ def test_workflow_jobs(python_versions: Sequence[str]) -> Jobs:
             "strategy": {"matrix": {"python-version": python_versions}},
             "steps": [
                 {"name": "Check out code", "uses": "actions/checkout@v2"},
-                {
-                    "name": "Set up Python ${{ matrix.python-version }}",
-                    "uses": "actions/setup-python@v2",
-                    "with": {"python-version": "${{ matrix.python-version }}"},
-                },
+                *setup_primary_python(),
+                *expose_all_pythons(),
                 *pants_virtualenv_cache(),
                 *native_engine_so_download(),
                 *pants_config_files(),


### PR DESCRIPTION
Previously the pylint test_uses_correct_python_version test failed
because no Python 3.7 was available.

[ci skip-rust]
[ci skip-build-wheels]