### PR TITLE
Fix the mypy-protobuf interpreter constraint.

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -4,11 +4,14 @@
 from typing import cast
 
 from pants.backend.codegen.protobuf.target_types import ProtobufDependencies
+from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
+from pants.base.deprecated import deprecated_conditional
 from pants.engine.addresses import Addresses, UnparsedAddressInputs
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import InjectDependenciesRequest, InjectedDependencies
 from pants.engine.unions import UnionRule
 from pants.option.custom_types import target_option
+from pants.option.ranked_value import Rank
 from pants.option.subsystem import Subsystem
 from pants.util.docutil import docs_url
 
@@ -43,7 +46,6 @@ class PythonProtobufSubsystem(Subsystem):
         register(
             "--mypy-plugin-version",
             type=str,
-            default="mypy-protobuf==2.4",
             advanced=True,
             help=(
                 "The pip-style requirement string for `mypy-protobuf`. You must still set "
@@ -59,9 +61,42 @@ class PythonProtobufSubsystem(Subsystem):
     def mypy_plugin(self) -> bool:
         return cast(bool, self.options.mypy_plugin)
 
-    @property
-    def mypy_plugin_version(self) -> str:
-        return cast(str, self.options.mypy_plugin_version)
+
+class PythonProtobufMypyPlugin(PythonToolRequirementsBase):
+    options_scope = PythonProtobufSubsystem.subscope("mypy-plugin")
+    help = (
+        "Configuration of the mypy-protobuf type stub generation plugin for the Protobuf Python "
+        "backend."
+    )
+
+    default_version = "mypy-protobuf==2.4"
+    register_interpreter_constraints = True
+    default_interpreter_constraints = ["CPython>=3.6"]
+
+    def plugin_requirement(self, python_protobuf_subsystem: PythonProtobufSubsystem) -> str:
+        deprecated_key = "mypy_plugin_version"
+        mypy_plugin_requirement = python_protobuf_subsystem.options.get(deprecated_key)
+        if mypy_plugin_requirement:
+            # TODO(John Sirois): When removing this deprecation, its safe to remove the
+            #  `--mypy-plugin-version` option registration in PythonProtobufSubsystem above since
+            #  the `version` option registered by this subsystem is in a subscope picked to shadow
+            #  the deprecated option in flag and environment variable namespaces; i.e.: both
+            #  --python-protobuf-mypy-plugin-version and PANTS_PYTHON_PROTOBUF_MYPY_PLUGIN_VERSION
+            #  will continue to work."
+            deprecated_conditional(
+                predicate=lambda: (
+                    python_protobuf_subsystem.options.get_rank(deprecated_key) == Rank.CONFIG
+                ),
+                removal_version="2.5.0.dev0",
+                entity_description=f"[{PythonProtobufSubsystem.options_scope}] {deprecated_key}",
+                hint_message=(
+                    f"Instead of configuring the `{deprecated_key}` in the "
+                    f"`[{PythonProtobufSubsystem.options_scope}]` options section, configure the "
+                    f"`version` in the `[{self.options_scope}]` options section."
+                ),
+            )
+            return cast(str, mypy_plugin_requirement)
+        return self.requirement
 
 
 class InjectPythonProtobufDependencies(InjectDependenciesRequest):

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -39,6 +39,13 @@ class PythonToolRequirementsBase(Subsystem):
             "tool allows you to install plugins or if you need to constrain a dependency to "
             "a certain version.",
         )
+        if cls.default_interpreter_constraints and not cls.register_interpreter_constraints:
+            raise ValueError(
+                f"`default_interpreter_constraints` are configured for `{cls.options_scope}`, but "
+                "`register_interpreter_constraints` is not set to `True`, so the "
+                "`--interpreter-constraints` option will not be registered. Did you mean to set "
+                "this?"
+            )
         if cls.register_interpreter_constraints:
             register(
                 "--interpreter-constraints",


### PR DESCRIPTION
Also add an option to allow a user to adjust the interpreter constraint
when adjusting the mypy-protobuf plugin version as they can with other
python tools.

Fixes #11565

[ci skip-rust]
[ci skip-build-wheels]