### PR TITLE
Improve error message for unmatched globs

### DIFF
--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -421,21 +421,20 @@ async fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
           args.value_of("root").unwrap(),
         ));
         let store_copy = store.clone();
+        let path_globs = fs::PathGlobs::new(
+          args
+            .values_of("globs")
+            .unwrap()
+            .map(str::to_string)
+            .collect::<Vec<String>>(),
+          // By using `Ignore`, we say that we don't care if some globs fail to expand. Is
+          // that a valid assumption?
+          fs::StrictGlobMatching::Ignore,
+          fs::GlobExpansionConjunction::AllMatch,
+        )
+        .parse()?;
         let paths = posix_fs
-          .expand_globs(
-            fs::PathGlobs::new(
-              args
-                .values_of("globs")
-                .unwrap()
-                .map(str::to_string)
-                .collect::<Vec<String>>(),
-              // By using `Ignore`, we say that we don't care if some globs fail to expand. Is
-              // that a valid assumption?
-              fs::StrictGlobMatching::Ignore,
-              fs::GlobExpansionConjunction::AllMatch,
-            )
-            .parse()?,
-          )
+          .expand_globs(path_globs, None)
           .await
           .map_err(|e| format!("Error expanding globs: {:?}", e))?;
 

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -370,8 +370,13 @@ pub trait GlobMatching<E: Display + Send + Sync + 'static>: VFS<E> {
   ///
   /// Recursively expands PathGlobs into PathStats while applying excludes.
   ///
-  async fn expand_globs(&self, path_globs: PreparedPathGlobs) -> Result<Vec<PathStat>, E> {
-    GlobMatchingImplementation::expand_globs(self, path_globs).await
+  async fn expand_globs(
+    &self,
+    path_globs: PreparedPathGlobs,
+    unmatched_globs_additional_context: Option<String>,
+  ) -> Result<Vec<PathStat>, E> {
+    GlobMatchingImplementation::expand_globs(self, path_globs, unmatched_globs_additional_context)
+      .await
   }
 }
 
@@ -442,7 +447,11 @@ trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: VFS<E> {
     Ok(path_stats.into_iter().filter_map(|pso| pso).collect())
   }
 
-  async fn expand_globs(&self, path_globs: PreparedPathGlobs) -> Result<Vec<PathStat>, E> {
+  async fn expand_globs(
+    &self,
+    path_globs: PreparedPathGlobs,
+    unmatched_globs_additional_context: Option<String>,
+  ) -> Result<Vec<PathStat>, E> {
     let PreparedPathGlobs {
       include,
       exclude,
@@ -528,8 +537,12 @@ trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: VFS<E> {
           }
         };
         let msg = format!(
-          "{}{}{}{}",
-          prefix, origin, unmatched_globs, excludes_portion
+          "{}{}{}{}{}",
+          prefix,
+          origin,
+          unmatched_globs,
+          excludes_portion,
+          unmatched_globs_additional_context.unwrap_or("".to_owned())
         );
         if strict_match_behavior.should_throw_on_error() {
           return Err(Self::mk_error(&msg));
@@ -661,7 +674,7 @@ trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: VFS<E> {
     let path_globs =
       PreparedPathGlobs::from_globs(link_globs).map_err(|e| Self::mk_error(e.as_str()))?;
     let mut path_stats = context
-      .expand_globs(path_globs)
+      .expand_globs(path_globs, None)
       .map_err(move |e| Self::mk_error(&format!("While expanding link {:?}: {}", link.0, e)))
       .await?;
 

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -542,7 +542,7 @@ trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: VFS<E> {
           origin,
           unmatched_globs,
           excludes_portion,
-          unmatched_globs_additional_context.unwrap_or("".to_owned())
+          unmatched_globs_additional_context.unwrap_or_else(|| "".to_owned())
         );
         if strict_match_behavior.should_throw_on_error() {
           return Err(Self::mk_error(&msg));

--- a/src/rust/engine/fs/src/posixfs_tests.rs
+++ b/src/rust/engine/fs/src/posixfs_tests.rs
@@ -356,7 +356,7 @@ async fn memfs_expand_basic() {
   .unwrap();
 
   assert_eq!(
-    fs.expand_globs(globs).await.unwrap(),
+    fs.expand_globs(globs, None).await.unwrap(),
     vec![
       PathStat::file(
         p1.clone(),

--- a/src/rust/engine/fs/store/src/snapshot.rs
+++ b/src/rust/engine/fs/store/src/snapshot.rs
@@ -265,7 +265,7 @@ impl Snapshot {
       )?);
 
       let path_stats = posix_fs
-        .expand_globs(path_globs)
+        .expand_globs(path_globs, None)
         .await
         .map_err(|err| format!("Error expanding globs: {}", err))?;
       Snapshot::from_path_stats(

--- a/src/rust/engine/fs/store/src/snapshot_tests.rs
+++ b/src/rust/engine/fs/store/src/snapshot_tests.rs
@@ -516,14 +516,14 @@ fn make_file_stat(root: &Path, relpath: &Path, contents: &[u8], is_executable: b
 }
 
 pub async fn expand_all_sorted(posix_fs: Arc<PosixFS>) -> Vec<PathStat> {
-  let path_globs =       // Don't error or warn if there are no paths matched -- that is a valid state.
-      PathGlobs::new(
-        vec!["**".to_owned()],
-        StrictGlobMatching::Ignore,
-        GlobExpansionConjunction::AllMatch,
-      )
-      .parse()
-      .unwrap();
+  let path_globs = PathGlobs::new(
+    vec!["**".to_owned()],
+    // Don't error or warn if there are no paths matched -- that is a valid state.
+    StrictGlobMatching::Ignore,
+    GlobExpansionConjunction::AllMatch,
+  )
+  .parse()
+  .unwrap();
   let mut v = posix_fs.expand_globs(path_globs, None).await.unwrap();
   v.sort_by(|a, b| a.path().cmp(b.path()));
   v

--- a/src/rust/engine/fs/store/src/snapshot_tests.rs
+++ b/src/rust/engine/fs/store/src/snapshot_tests.rs
@@ -516,19 +516,15 @@ fn make_file_stat(root: &Path, relpath: &Path, contents: &[u8], is_executable: b
 }
 
 pub async fn expand_all_sorted(posix_fs: Arc<PosixFS>) -> Vec<PathStat> {
-  let mut v = posix_fs
-    .expand_globs(
-      // Don't error or warn if there are no paths matched -- that is a valid state.
+  let path_globs =       // Don't error or warn if there are no paths matched -- that is a valid state.
       PathGlobs::new(
         vec!["**".to_owned()],
         StrictGlobMatching::Ignore,
         GlobExpansionConjunction::AllMatch,
       )
       .parse()
-      .unwrap(),
-    )
-    .await
-    .unwrap();
+      .unwrap();
+  let mut v = posix_fs.expand_globs(path_globs, None).await.unwrap();
   v.sort_by(|a, b| a.path().cmp(b.path()));
   v
 }

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -106,7 +106,7 @@ impl CommandRunner {
 
     Box::pin(async move {
       let path_stats = posix_fs
-        .expand_globs(output_globs)
+        .expand_globs(output_globs, None)
         .map_err(|err| format!("Error expanding output globs: {}", err))
         .await?;
       Snapshot::from_path_stats(

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -255,6 +255,22 @@ pub fn val_to_log_level(obj: &PyObject) -> Result<log::Level, String> {
   res.map(|py_level| py_level.into())
 }
 
+#[allow(dead_code)]
+/// Link to the Pants docs using the current version of Pants.
+pub fn docs_url(slug: &str) -> String {
+  let gil = Python::acquire_gil();
+  let py = gil.python();
+  let docutil = py.import("pants.util.docutil").unwrap();
+  py.eval(
+    &format!("docs_url(\"{}\")", slug),
+    None,
+    Some(&docutil.dict(py)),
+  )
+  .unwrap()
+  .extract(py)
+  .unwrap()
+}
+
 pub fn create_exception(msg: &str) -> Value {
   Value::from(with_externs(|py, e| e.call_method(py, "create_exception", (msg,), None)).unwrap())
 }

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -260,14 +260,11 @@ pub fn docs_url(slug: &str) -> String {
   let gil = Python::acquire_gil();
   let py = gil.python();
   let docutil = py.import("pants.util.docutil").unwrap();
-  py.eval(
-    &format!("docs_url(\"{}\")", slug),
-    None,
-    Some(&docutil.dict(py)),
-  )
-  .unwrap()
-  .extract(py)
-  .unwrap()
+  docutil
+    .call(py, "docs_url", (slug,), None)
+    .unwrap()
+    .extract(py)
+    .unwrap()
 }
 
 pub fn create_exception(msg: &str) -> Value {

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -255,7 +255,6 @@ pub fn val_to_log_level(obj: &PyObject) -> Result<log::Level, String> {
   res.map(|py_level| py_level.into())
 }
 
-#[allow(dead_code)]
 /// Link to the Pants docs using the current version of Pants.
 pub fn docs_url(slug: &str) -> String {
   let gil = Python::acquire_gil();

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -496,9 +496,9 @@ impl From<Scandir> for NodeKey {
 
 fn unmatched_globs_additional_context() -> Option<String> {
   Some(format!(
-    "\n\nDoes the file exist? If so, check if the file is in your `.gitignore` or the global \
-    `pants_ignore` option, which may result in Pants not being able to see the file even though it \
-    exists on disk. Refer to {}.",
+    "\n\nDo the file(s) exist? If so, check if the file(s) are in your `.gitignore` or the global \
+    `pants_ignore` option, which may result in Pants not being able to see the file(s) even though \
+    they exist on disk. Refer to {}.",
     externs::docs_url("troubleshooting#pants-cannot-find-a-file-in-your-project")
   ))
 }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -494,6 +494,15 @@ impl From<Scandir> for NodeKey {
   }
 }
 
+fn unmatched_globs_additional_context() -> Option<String> {
+  Some(format!(
+    "\n\nDoes the file exist? If so, check if the file is in your `.gitignore` or the global \
+    `pants_ignore` option, which may result in Pants not being able to see the file even though it \
+    exists on disk. Refer to {}.",
+    externs::docs_url("troubleshooting#pants-cannot-find-a-file-in-your-project")
+  ))
+}
+
 ///
 /// A node that captures Vec<PathStat> for resolved files/dirs from PathGlobs.
 ///
@@ -511,7 +520,7 @@ impl Paths {
   }
   async fn create(context: Context, path_globs: PreparedPathGlobs) -> NodeResult<Vec<PathStat>> {
     context
-      .expand_globs(path_globs)
+      .expand_globs(path_globs, unmatched_globs_additional_context())
       .map_err(|e| throw(&format!("{}", e)))
       .await
   }
@@ -588,7 +597,7 @@ impl Snapshot {
     // We rely on Context::expand_globs tracking dependencies for scandirs,
     // and store::Snapshot::from_path_stats tracking dependencies for file digests.
     let path_stats = context
-      .expand_globs(path_globs)
+      .expand_globs(path_globs, unmatched_globs_additional_context())
       .map_err(|e| throw(&format!("{}", e)))
       .await?;
     store::Snapshot::from_path_stats(context.core.store(), context.clone(), path_stats)


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/11629. Example:

```
❯ ./pants --no-print-stacktrace lint src/fake.txt --no-pantsd
16:03:43.20 [ERROR] Exception caught: (pants.engine.internals.scheduler.ExecutionError)
...
Exception message: 1 Exception encountered:

  Exception: Unmatched glob from file arguments: "src/fake.txt"

Does the file exist? If so, check if the file is in your `.gitignore` or the global `pants_ignore` option, which may result in Pants not being able to see the file even though it exists on disk. Refer to https://www.pantsbuild.org/v2.4/docs/troubleshooting#pants-cannot-find-a-file-in-your-project.
```
