### PR TITLE
Remove `Externs` FFI mechanism

### DIFF
--- a/src/python/pants/base/exception_sink_integration_test.py
+++ b/src/python/pants/base/exception_sink_integration_test.py
@@ -130,20 +130,16 @@ def test_fails_ctrl_c_ffi_extern() -> None:
         pants_run = run_pants_with_workdir(
             command=lifecycle_stub_cmdline(),
             workdir=tmpdir,
-            extra_env={"_RAISE_KEYBOARDINTERRUPT_IN_EXTERNS": "run_lifecycle_stubs"},
+            extra_env={"_RAISE_KEYBOARD_INTERRUPT_FFI": "1"},
         )
         pants_run.assert_failure()
-
-        assert (
-            "KeyboardInterrupt: ctrl-c interrupted execution of a ffi method!" in pants_run.stderr
-        )
+        assert "KeyboardInterrupt: ctrl-c interrupted execution during FFI" in pants_run.stderr
 
         pid_specific_log_file, shared_log_file = get_log_file_paths(tmpdir, pants_run.pid)
-
-        assert "KeyboardInterrupt: ctrl-c interrupted execution of a ffi method!" in read_file(
+        assert "KeyboardInterrupt: ctrl-c interrupted execution during FFI" in read_file(
             pid_specific_log_file
         )
-        assert "KeyboardInterrupt: ctrl-c interrupted execution of a ffi method!" in read_file(
+        assert "KeyboardInterrupt: ctrl-c interrupted execution during FFI" in read_file(
             shared_log_file
         )
 

--- a/src/python/pants/engine/internals/selectors.py
+++ b/src/python/pants/engine/internals/selectors.py
@@ -210,7 +210,7 @@ class Get(GetConstraints, Generic[_Output, _Input]):
     ) -> Generator[Get[_Output, _Input], None, _Output]:
         """Allow a Get to be `await`ed within an `async` method, returning a strongly-typed result.
 
-        The `yield`ed value `self` is interpreted by the engine within `extern_generator_send()` in
+        The `yield`ed value `self` is interpreted by the engine within `generator_send()` in
         `native.py`. This class will yield a single Get instance, which is converted into
         `PyGeneratorResponse::Get` from `externs.rs` via the python `cffi` library and the rust
         `cbindgen` crate.
@@ -403,7 +403,7 @@ async def MultiGet(  # noqa: F811
     """Yield a tuple of Get instances all at once.
 
     The `yield`ed value `self.gets` is interpreted by the engine within
-    `extern_generator_send()` in `native.py`. This class will yield a tuple of Get instances,
+    `generator_send()` in `native.py`. This class will yield a tuple of Get instances,
     which is converted into `PyGeneratorResponse::GetMulti` from `externs.rs`.
 
     The engine will fulfill these Get instances in parallel, and return a tuple of _Output

--- a/src/python/pants/engine/unions.py
+++ b/src/python/pants/engine/unions.py
@@ -32,6 +32,11 @@ def union(cls):
     return union.define_instance_of(cls)
 
 
+def is_union(input_type: type) -> bool:
+    """Return whether or not a type has been annotated with `@union`."""
+    return union.is_instance(input_type)
+
+
 @dataclass(frozen=True)
 class UnionRule:
     """Specify that an instance of `union_member` can be substituted wherever `union_base` is

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -161,8 +161,6 @@ py_module_initializer!(native_engine, |py, m| {
 
   m.add(py, "set_panic_handler", py_fn!(py, set_panic_handler()))?;
 
-  m.add(py, "externs_set", py_fn!(py, externs_set(a: PyObject)))?;
-
   m.add(
     py,
     "match_path_globs",
@@ -751,11 +749,6 @@ fn py_result_from_root(py: Python, result: Result<Value, Failure>) -> CPyResult<
 
 // TODO: It's not clear how to return "nothing" (None) in a CPyResult, so this is a placeholder.
 type PyUnitResult = CPyResult<Option<bool>>;
-
-fn externs_set(_: Python, externs: PyObject) -> PyUnitResult {
-  externs::set_externs(externs);
-  Ok(None)
-}
 
 fn nailgun_client_create(
   py: Python,


### PR DESCRIPTION
It's less boilerplate to directly call Python from Rust.

[ci skip-build-wheels]