### PR TITLE
scoverage bump 1.0.3-twitter on 1.25.x-twtr

### DIFF
--- a/3rdparty/jvm/com/twitter/scoverage/BUILD
+++ b/3rdparty/jvm/com/twitter/scoverage/BUILD
@@ -10,6 +10,6 @@
 
 jar_library(name='scalac-scoverage-plugin',
   jars=[
-    scala_jar(org='com.twitter.scoverage', name='scalac-scoverage-plugin', rev='1.0.2-twitter'),
+    scala_jar(org='com.twitter.scoverage', name='scalac-scoverage-plugin', rev='1.0.3-twitter-dev0'),
     ],
   )

--- a/3rdparty/jvm/com/twitter/scoverage/BUILD
+++ b/3rdparty/jvm/com/twitter/scoverage/BUILD
@@ -10,6 +10,6 @@
 
 jar_library(name='scalac-scoverage-plugin',
   jars=[
-    scala_jar(org='com.twitter.scoverage', name='scalac-scoverage-plugin', rev='1.0.3-twitter-dev0'),
+    scala_jar(org='com.twitter.scoverage', name='scalac-scoverage-plugin', rev='1.0.3-twitter'),
     ],
   )

--- a/src/python/pants/backend/jvm/subsystems/scoverage_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/scoverage_platform.py
@@ -49,12 +49,12 @@ class ScoveragePlatform(InjectablesMixin, Subsystem):
             JarDependency(
                 org="com.twitter.scoverage",
                 name="scalac-scoverage-plugin_2.12",
-                rev="1.0.3-twitter-dev0",
+                rev="1.0.3-twitter",
             ),
             JarDependency(
                 org="com.twitter.scoverage",
                 name="scalac-scoverage-runtime_2.12",
-                rev="1.0.3-twitter-dev0",
+                rev="1.0.3-twitter",
             ),
         ]
 

--- a/src/python/pants/backend/jvm/subsystems/scoverage_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/scoverage_platform.py
@@ -49,12 +49,12 @@ class ScoveragePlatform(InjectablesMixin, Subsystem):
             JarDependency(
                 org="com.twitter.scoverage",
                 name="scalac-scoverage-plugin_2.12",
-                rev="1.0.2-twitter",
+                rev="1.0.3-twitter-dev0",
             ),
             JarDependency(
                 org="com.twitter.scoverage",
                 name="scalac-scoverage-runtime_2.12",
-                rev="1.0.2-twitter",
+                rev="1.0.3-twitter-dev0",
             ),
         ]
 

--- a/src/python/pants/backend/jvm/tasks/coverage/scoverage.py
+++ b/src/python/pants/backend/jvm/tasks/coverage/scoverage.py
@@ -28,7 +28,7 @@ class Scoverage(CoverageEngine):
 
             def scoverage_jar(name, **kwargs):
                 return JarDependency(
-                    org="com.twitter.scoverage", name=name, rev="1.0.3-twitter-dev0", **kwargs
+                    org="com.twitter.scoverage", name=name, rev="1.0.3-twitter", **kwargs
                 )
 
             def slf4j_jar(name):

--- a/src/python/pants/backend/jvm/tasks/coverage/scoverage.py
+++ b/src/python/pants/backend/jvm/tasks/coverage/scoverage.py
@@ -28,7 +28,7 @@ class Scoverage(CoverageEngine):
 
             def scoverage_jar(name, **kwargs):
                 return JarDependency(
-                    org="com.twitter.scoverage", name=name, rev="1.0.2-twitter", **kwargs
+                    org="com.twitter.scoverage", name=name, rev="1.0.3-twitter-dev0", **kwargs
                 )
 
             def slf4j_jar(name):


### PR DESCRIPTION
### Problem

We have released a new version of scalac-scoverage-plugin that supports scala 2.12.13. `scoverage` plugin and runtime versions are baked into the pants source code, so a revision bump needs to be done at the pants source code layer.  This plugin has been updated and released with https://github.com/twitter-forks/scalac-scoverage-plugin/pull/6 

### Solution

`scalac-scoverage-plugin` revision will be bumped from `1.0.2-twitter` to `1.0.3-twitter`.

### Result

`scoverage` plugin and report generator will no longer have API breakage when code is built with scala 2.12.13. Working with @wisechengyi internally to ensure this does not break existing behavior. 
