### PR TITLE
Fix some streaming workunit handlers crashing when `--dynamic-ui` set

### DIFF
--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -522,6 +522,12 @@ class SchedulerSession:
         :param timeout: See self.execution_request.
         :returns: A list of the requested products, with length match len(subjects).
         """
+        # NB: It's possible to have synchronous requests still running after the console has
+        # shutdown, and those will crash if they attempt to write to the dynamic UI.
+        #
+        # The only time we want to use the dynamic UI is possibly when running goal rules with the
+        # asynchronous Rules API. Here, it's safest to always ensure we are logging.
+        self.teardown_dynamic_ui()
         request = self.execution_request([product], subjects, poll=poll, timeout=timeout)
         returns, throws = self.execute(request)
 


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/11484 adds a method that makes a `.product_request()`. When this is run in the background after a Pants run has finished a la https://github.com/pantsbuild/pants/pull/11683, Pants tries to write to the dynamic UI and fails, causing the handler to fail and write the exception to the Pantsd logs:

```
   4   │ 14:32:50.44 [INFO] stderr: "Exception in thread "
   5   │ 14:32:50.44 [INFO] stderr: "Thread-2"
   6   │ 14:32:50.44 [INFO] stderr: ":\n"
   7   │ 14:32:50.44 [INFO] stderr: "Traceback (most recent call last):\n"
   8   │ 14:32:50.44 [INFO] stderr: "  File \"/Users/eric/.pyenv/versions/3.9.1/lib/python3.9/threadin
       │ g.py\", line 954, in _bootstrap_inner\n"
   9   │ 14:32:50.44 [INFO] stderr: "    "
  10   │ 14:32:50.44 [INFO] stderr: "self.run()"
  11   │ 14:32:50.44 [INFO] stderr: "\n"
  12   │ 14:32:50.44 [INFO] stderr: "  File \"/Users/eric/code/pants/src/python/pants/engine/streaming
       │ _workunit_handler.py\", line 268, in run\n"
  13   │ 14:32:50.44 [INFO] stderr: "    "
  14   │ 14:32:50.44 [INFO] stderr: "self.poll_workunits(finished=True)"
  15   │ 14:32:50.44 [INFO] stderr: "\n"
  16   │ 14:32:50.44 [INFO] stderr: "  File \"/Users/eric/code/pants/src/python/pants/engine/streaming
       │ _workunit_handler.py\", line 252, in poll_workunits\n"
  17   │ 14:32:50.44 [INFO] stderr: "    "
  18   │ 14:32:50.44 [INFO] stderr: "callback("
  19   │ 14:32:50.44 [INFO] stderr: "\n"
  20   │ 14:32:50.44 [INFO] stderr: "  File \"/Users/eric/code/pants/src/python/pants/goal/stats_aggre
       │ gator.py\", line 84, in __call__\n"
  21   │ 14:32:50.44 [INFO] stderr: "    "
  22   │ 14:32:50.44 [INFO] stderr: "context.get_expanded_specs()"
  23   │ 14:32:50.44 [INFO] stderr: "\n"
  24   │ 14:32:50.44 [INFO] stderr: "  File \"/Users/eric/code/pants/src/python/pants/engine/streaming
       │ _workunit_handler.py\", line 84, in get_expanded_specs\n"
  25   │ 14:32:50.44 [INFO] stderr: "    "
  26   │ 14:32:50.44 [INFO] stderr: "(unexpanded_addresses,) = self._scheduler.product_request("
  27   │ 14:32:50.44 [INFO] stderr: "\n"
  28   │ 14:32:50.44 [INFO] stderr: "  File \"/Users/eric/code/pants/src/python/pants/engine/internals
       │ /scheduler.py\", line 527, in product_request\n"
  29   │ 14:32:50.44 [INFO] stderr: "    "
  30   │ 14:32:50.44 [INFO] stderr: "returns, throws = self.execute(request)"
  31   │ 14:32:50.44 [INFO] stderr: "\n"
  32   │ 14:32:50.44 [INFO] stderr: "  File \"/Users/eric/code/pants/src/python/pants/engine/internals
       │ /scheduler.py\", line 420, in execute\n"
  33   │ 14:32:50.44 [INFO] stderr: "    "
  34   │ 14:32:50.44 [INFO] stderr: "raw_roots = native_engine.scheduler_execute("
  35   │ 14:32:50.44 [INFO] stderr: "\n"
  36   │ 14:32:50.44 [INFO] stderr: "KeyboardInterrupt"
  37   │ 14:32:50.44 [INFO] stderr: ""
  38   │ 14:32:50.44 [INFO] stderr: "\n"
```

We can fix this by simply never using the dynamic UI with the synchronous engine API `.product_request()`, given that we only want the dynamic UI with goal rules and the async Rules API.

[ci skip-rust]
[ci skip-build-wheels]
