### PR TITLE
Add `[python-setup].requirement_constraints_target` for upcoming Poetry macro

### DIFF
--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -26,6 +26,7 @@ from pants.backend.python.target_types import (
     PexBinary,
     PythonDistribution,
     PythonLibrary,
+    PythonRequirementConstraintsTarget,
     PythonRequirementLibrary,
     PythonRequirementsFile,
     PythonTests,
@@ -80,5 +81,6 @@ def target_types():
         PythonLibrary,
         PythonRequirementLibrary,
         PythonRequirementsFile,
+        PythonRequirementConstraintsTarget,
         PythonTests,
     ]

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -26,7 +26,7 @@ from pants.backend.python.target_types import (
     PexBinary,
     PythonDistribution,
     PythonLibrary,
-    PythonRequirementConstraintsTarget,
+    PythonRequirementConstraints,
     PythonRequirementLibrary,
     PythonRequirementsFile,
     PythonTests,
@@ -81,6 +81,6 @@ def target_types():
         PythonLibrary,
         PythonRequirementLibrary,
         PythonRequirementsFile,
-        PythonRequirementConstraintsTarget,
+        PythonRequirementConstraints,
         PythonTests,
     ]

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -648,7 +648,25 @@ class PythonRequirementsFileSources(Sources):
 class PythonRequirementsFile(Target):
     alias = "_python_requirements_file"
     core_fields = (*COMMON_TARGET_FIELDS, PythonRequirementsFileSources)
-    help = "A private, helper target type for requirements.txt files."
+    help = "A private helper target type for requirements.txt files."
+
+
+# -----------------------------------------------------------------------------------------------
+# `_python_constraints` target
+# -----------------------------------------------------------------------------------------------
+
+
+class PythonRequirementConstraints(StringSequenceField):
+    alias = "constraints"
+    required = True
+    value: tuple[str, ...]
+    help = "A list of pip-style requirement strings, e.g. `my_dist==4.2.1`."
+
+
+class PythonRequirementConstraintsTarget(Target):
+    alias = "_python_constraints"
+    core_fields = (*COMMON_TARGET_FIELDS, PythonRequirementConstraints)
+    help = "A private helper target for inlined requirements constraints, used by macros."
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -22,7 +22,10 @@ from typing_extensions import Protocol
 
 from pants.backend.python.target_types import InterpreterConstraintsField, MainSpecification
 from pants.backend.python.target_types import PexPlatformsField as PythonPlatformsField
-from pants.backend.python.target_types import PythonRequirementConstraints, PythonRequirementsField
+from pants.backend.python.target_types import (
+    PythonRequirementConstraintsField,
+    PythonRequirementsField,
+)
 from pants.backend.python.util_rules import pex_cli
 from pants.backend.python.util_rules.pex_cli import PexCliProcess, PexPEX
 from pants.backend.python.util_rules.pex_environment import (
@@ -516,12 +519,14 @@ async def resolve_requirements_constraints_file(python_setup: PythonSetup) -> Ma
             ),
         )
         tgt = targets.expect_single()
-        if not tgt.has_field(PythonRequirementConstraints):
+        if not tgt.has_field(PythonRequirementConstraintsField):
             raise ValueError(
                 "Invalid target type for `[python-setup].requirement_constraints_target`. Please "
                 f"use a `_python_constraints` target instead of a `{tgt.alias}` target."
             )
-        formatted_constraints = "\n".join(tgt[PythonRequirementConstraints].value)
+        formatted_constraints = "\n".join(
+            str(constraint) for constraint in tgt[PythonRequirementConstraintsField].value
+        )
         path = "constraints.generated.txt"
         digest = await Get(
             Digest, CreateDigest([FileContent(path, formatted_constraints.encode())])

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -22,7 +22,7 @@ from typing_extensions import Protocol
 
 from pants.backend.python.target_types import InterpreterConstraintsField, MainSpecification
 from pants.backend.python.target_types import PexPlatformsField as PythonPlatformsField
-from pants.backend.python.target_types import PythonRequirementsField
+from pants.backend.python.target_types import PythonRequirementConstraints, PythonRequirementsField
 from pants.backend.python.util_rules import pex_cli
 from pants.backend.python.util_rules.pex_cli import PexCliProcess, PexPEX
 from pants.backend.python.util_rules.pex_environment import (
@@ -30,7 +30,7 @@ from pants.backend.python.util_rules.pex_environment import (
     PexRuntimeEnvironment,
     PythonExecutable,
 )
-from pants.engine.addresses import Address
+from pants.engine.addresses import Address, UnparsedAddressInputs
 from pants.engine.collection import Collection, DeduplicatedCollection
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import (
@@ -53,7 +53,7 @@ from pants.engine.process import (
     ProcessResult,
 )
 from pants.engine.rules import Get, collect_rules, rule
-from pants.engine.target import Target
+from pants.engine.target import Target, Targets
 from pants.python.python_repos import PythonRepos
 from pants.python.python_setup import PythonSetup
 from pants.util.frozendict import FrozenDict
@@ -489,6 +489,49 @@ async def find_interpreter(
 
 
 @dataclass(frozen=True)
+class MaybeConstraintsFile:
+    path: str | None
+    digest: Digest
+
+
+@rule(desc="Resolve requirements constraints file")
+async def resolve_requirements_constraints_file(python_setup: PythonSetup) -> MaybeConstraintsFile:
+    if python_setup.requirement_constraints:
+        digest = await Get(
+            Digest,
+            PathGlobs(
+                [python_setup.requirement_constraints],
+                glob_match_error_behavior=GlobMatchErrorBehavior.error,
+                conjunction=GlobExpansionConjunction.all_match,
+                description_of_origin="the option `[python-setup].requirement_constraints`",
+            ),
+        )
+        return MaybeConstraintsFile(python_setup.requirement_constraints, digest)
+
+    if python_setup.requirement_constraints_target:
+        targets = await Get(
+            Targets,
+            UnparsedAddressInputs(
+                [python_setup.requirement_constraints_target], owning_address=None
+            ),
+        )
+        tgt = targets.expect_single()
+        if not tgt.has_field(PythonRequirementConstraints):
+            raise ValueError(
+                "Invalid target type for `[python-setup].requirement_constraints_target`. Please "
+                f"use a `_python_constraints` target instead of a `{tgt.alias}` target."
+            )
+        formatted_constraints = "\n".join(tgt[PythonRequirementConstraints].value)
+        path = "constraints.generated.txt"
+        digest = await Get(
+            Digest, CreateDigest([FileContent(path, formatted_constraints.encode())])
+        )
+        return MaybeConstraintsFile(path, digest)
+
+    return MaybeConstraintsFile(None, EMPTY_DIGEST)
+
+
+@dataclass(frozen=True)
 class BuildPexResult:
     result: ProcessResult
     pex_filename: str
@@ -506,6 +549,7 @@ async def build_pex(
     python_repos: PythonRepos,
     platform: Platform,
     pex_runtime_env: PexRuntimeEnvironment,
+    constraints_file: MaybeConstraintsFile,
 ) -> BuildPexResult:
     """Returns a PEX with the given settings."""
 
@@ -564,17 +608,9 @@ async def build_pex(
     argv.extend(request.requirements)
 
     constraint_file_digest = EMPTY_DIGEST
-    if request.apply_requirement_constraints and python_setup.requirement_constraints is not None:
-        argv.extend(["--constraints", python_setup.requirement_constraints])
-        constraint_file_digest = await Get(
-            Digest,
-            PathGlobs(
-                [python_setup.requirement_constraints],
-                glob_match_error_behavior=GlobMatchErrorBehavior.error,
-                conjunction=GlobExpansionConjunction.all_match,
-                description_of_origin="the option `--python-setup-requirement-constraints`",
-            ),
-        )
+    if request.apply_requirement_constraints and constraints_file.path is not None:
+        argv.extend(["--constraints", constraints_file.path])
+        constraint_file_digest = constraints_file.digest
 
     sources_digest_as_subdir = await Get(
         Digest, AddPrefix(request.sources or EMPTY_DIGEST, source_dir_name)

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -18,6 +18,7 @@ from pants.backend.python.target_types import (
     parse_requirements_file,
 )
 from pants.backend.python.util_rules.pex import (
+    MaybeConstraintsFile,
     PexInterpreterConstraints,
     PexPlatforms,
     PexRequest,
@@ -31,14 +32,7 @@ from pants.backend.python.util_rules.python_sources import (
 )
 from pants.backend.python.util_rules.python_sources import rules as python_sources_rules
 from pants.engine.addresses import Address, Addresses
-from pants.engine.fs import (
-    Digest,
-    DigestContents,
-    GlobExpansionConjunction,
-    GlobMatchErrorBehavior,
-    MergeDigests,
-    PathGlobs,
-)
+from pants.engine.fs import Digest, DigestContents, MergeDigests
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     Dependencies,
@@ -185,7 +179,11 @@ class TwoStepPexFromTargetsRequest:
 
 
 @rule(level=LogLevel.DEBUG)
-async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonSetup) -> PexRequest:
+async def pex_from_targets(
+    request: PexFromTargetsRequest,
+    python_setup: PythonSetup,
+    constraints_file: MaybeConstraintsFile,
+) -> PexRequest:
     if request.direct_deps_only:
         targets = await Get(Targets, Addresses(request.addresses))
         direct_deps = await MultiGet(
@@ -232,37 +230,34 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
     requirements = exact_reqs
     description = request.description
 
-    if python_setup.requirement_constraints:
-        # In requirement strings Foo_-Bar.BAZ and foo-bar-baz refer to the same project. We let
-        # packaging canonicalize for us.
-        # See: https://www.python.org/dev/peps/pep-0503/#normalized-names
-
-        exact_req_projects = {
-            canonicalize_project_name(Requirement.parse(req).project_name) for req in exact_reqs
-        }
-        constraints_file_contents = await Get(
-            DigestContents,
-            PathGlobs(
-                [python_setup.requirement_constraints],
-                glob_match_error_behavior=GlobMatchErrorBehavior.error,
-                conjunction=GlobExpansionConjunction.all_match,
-                description_of_origin="the option `--python-setup-requirement-constraints`",
-            ),
-        )
+    if constraints_file.path:
+        constraints_file_contents = await Get(DigestContents, Digest, constraints_file.digest)
         constraints_file_reqs = set(
             parse_requirements_file(
                 constraints_file_contents[0].content.decode(),
-                rel_path=python_setup.requirement_constraints,
+                rel_path=constraints_file.path,
             )
         )
+
+        # In requirement strings, Foo_-Bar.BAZ and foo-bar-baz refer to the same project. We let
+        # packaging canonicalize for us.
+        # See: https://www.python.org/dev/peps/pep-0503/#normalized-names
+        exact_req_projects = {
+            canonicalize_project_name(Requirement.parse(req).project_name) for req in exact_reqs
+        }
         constraint_file_projects = {
             canonicalize_project_name(req.project_name) for req in constraints_file_reqs
         }
         unconstrained_projects = exact_req_projects - constraint_file_projects
         if unconstrained_projects:
+            constraints_descr = (
+                f"constraints file {constraints_file.path}"
+                if python_setup.requirement_constraints
+                else f"_python_constraints target {python_setup.requirement_constraints_target}"
+            )
             logger.warning(
-                f"The constraints file {python_setup.requirement_constraints} does not contain "
-                f"entries for the following requirements: {', '.join(unconstrained_projects)}"
+                f"The {constraints_descr} does not contain entries for the following "
+                f"requirements: {', '.join(unconstrained_projects)}"
             )
 
         if python_setup.resolve_all_constraints == ResolveAllConstraintsOption.ALWAYS or (
@@ -271,8 +266,8 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
         ):
             if unconstrained_projects:
                 logger.warning(
-                    "Ignoring resolve_all_constraints setting in [python_setup] scope "
-                    "because constraints file does not cover all requirements."
+                    "Ignoring `[python_setup].resolve_all_constraints` option because constraints "
+                    "file does not cover all requirements."
                 )
             else:
                 requirements = PexRequirements(str(req) for req in constraints_file_reqs)
@@ -282,9 +277,10 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
         and python_setup.resolve_all_constraints_was_set_explicitly()
     ):
         raise ValueError(
-            f"[python-setup].resolve_all_constraints is set to "
+            "[python-setup].resolve_all_constraints is set to "
             f"{python_setup.resolve_all_constraints.value}, so "
-            f"[python-setup].requirement_constraints must also be provided."
+            "either [python-setup].requirement_constraints or "
+            "[python-setup].requirement_constraints_target must also be provided."
         )
 
     return PexRequest(

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -110,7 +110,8 @@ def test_constraints_validation(rule_runner: RuleRunner) -> None:
     assert isinstance(err.value.wrapped_exceptions[0], ValueError)
     assert (
         "[python-setup].resolve_all_constraints is set to always, so "
-        "[python-setup].requirement_constraints must also be provided."
+        "either [python-setup].requirement_constraints or "
+        "[python-setup].requirement_constraints_target must also be provided."
     ) in str(err.value)
 
     # Shouldn't error, as we don't explicitly set --resolve-all-constraints.

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -19,7 +19,7 @@ from pants.backend.python.target_types import (
     EntryPoint,
     InterpreterConstraintsField,
     MainSpecification,
-    PythonRequirementConstraintsTarget,
+    PythonRequirementConstraints,
 )
 from pants.backend.python.util_rules.pex import (
     MaybeConstraintsFile,
@@ -302,7 +302,7 @@ def test_maybe_constraints_file() -> None:
             SubsystemRule(PythonSetup),
             QueryRule(MaybeConstraintsFile, []),
         ],
-        target_types=[PythonRequirementConstraintsTarget],
+        target_types=[PythonRequirementConstraints],
     )
     constraints = ["c1==1.1.1", "c2==2.2.2"]
     constraints_file = "\n".join(constraints)

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -19,8 +19,10 @@ from pants.backend.python.target_types import (
     EntryPoint,
     InterpreterConstraintsField,
     MainSpecification,
+    PythonRequirementConstraintsTarget,
 )
 from pants.backend.python.util_rules.pex import (
+    MaybeConstraintsFile,
     Pex,
     PexDistributionInfo,
     PexInterpreterConstraints,
@@ -31,12 +33,14 @@ from pants.backend.python.util_rules.pex import (
     PexResolveInfo,
     VenvPex,
     VenvPexProcess,
+    resolve_requirements_constraints_file,
 )
 from pants.backend.python.util_rules.pex import rules as pex_rules
 from pants.backend.python.util_rules.pex_cli import PexPEX
 from pants.engine.addresses import Address
-from pants.engine.fs import CreateDigest, Digest, FileContent
+from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, FileContent
 from pants.engine.process import Process, ProcessResult
+from pants.engine.rules import SubsystemRule
 from pants.engine.target import FieldSet
 from pants.python.python_setup import PythonSetup
 from pants.testutil.option_util import create_subsystem
@@ -289,6 +293,40 @@ def test_group_field_sets_by_constraints_with_unsorted_inputs() -> None:
             Address("src/python/c_dir/path.py", target_name="test"), "==3.6.*"
         ),
     )
+
+
+def test_maybe_constraints_file() -> None:
+    rule_runner = RuleRunner(
+        rules=[
+            resolve_requirements_constraints_file,
+            SubsystemRule(PythonSetup),
+            QueryRule(MaybeConstraintsFile, []),
+        ],
+        target_types=[PythonRequirementConstraintsTarget],
+    )
+    constraints = ["c1==1.1.1", "c2==2.2.2"]
+    constraints_file = "\n".join(constraints)
+    rule_runner.create_file("constraints.txt", constraints_file)
+    rule_runner.add_to_build_file(
+        "", f"_python_constraints(name='constraints', constraints={repr(constraints)})"
+    )
+
+    def get_constraints(arg: str | None) -> MaybeConstraintsFile:
+        if arg:
+            rule_runner.set_options([arg])
+        return rule_runner.request(MaybeConstraintsFile, [])
+
+    assert get_constraints(None) == MaybeConstraintsFile(None, EMPTY_DIGEST)
+    expected_digest = rule_runner.make_snapshot({"constraints.txt": constraints_file}).digest
+    assert get_constraints(
+        "--python-setup-requirement-constraints=constraints.txt"
+    ) == MaybeConstraintsFile("constraints.txt", expected_digest)
+    expected_digest = rule_runner.make_snapshot(
+        {"constraints.generated.txt": constraints_file}
+    ).digest
+    assert get_constraints(
+        "--python-setup-requirement-constraints-target=//:constraints"
+    ) == MaybeConstraintsFile("constraints.generated.txt", expected_digest)
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -14,7 +14,7 @@ from pex.variables import Variables
 
 from pants.base.build_environment import get_buildroot
 from pants.engine.environment import Environment
-from pants.option.custom_types import file_option
+from pants.option.custom_types import file_option, target_option
 from pants.option.subsystem import Subsystem
 from pants.util.memo import memoized_method
 
@@ -71,11 +71,27 @@ class PythonSetup(Subsystem):
             "--requirement-constraints",
             advanced=True,
             type=file_option,
+            mutually_exclusive_group="constraints",
             help=(
                 "When resolving third-party requirements, use this "
                 "constraints file to determine which versions to use.\n\nSee "
                 "https://pip.pypa.io/en/stable/user_guide/#constraints-files for more information "
                 "on the format of constraint files and how constraints are applied in Pex and pip."
+                "\n\nMutually exclusive with `--requirement-constraints-target`."
+            ),
+        )
+        register(
+            "--requirement-constraints-target",
+            advanced=True,
+            type=target_option,
+            mutually_exclusive_group="constraints",
+            help=(
+                "When resolving third-party requirements, use this "
+                "_python_constraints target to determine which versions to use.\n\nThis is "
+                "primarily intended for macros (for now). Normally, use "
+                "`--requirement-constraints` instead with a constraints file.\n\nSee "
+                "https://pip.pypa.io/en/stable/user_guide/#constraints-files for more information "
+                "on the format of constraints and how constraints are applied in Pex and pip."
             ),
         )
         register(
@@ -157,9 +173,14 @@ class PythonSetup(Subsystem):
         return tuple(self.options.interpreter_constraints)
 
     @property
-    def requirement_constraints(self) -> Optional[str]:
+    def requirement_constraints(self) -> str | None:
         """Path to constraint file."""
-        return cast(Optional[str], self.options.requirement_constraints)
+        return cast("str | None", self.options.requirement_constraints)
+
+    @property
+    def requirement_constraints_target(self) -> str | None:
+        """Address for a _python_constraints target."""
+        return cast("str | None", self.options.requirement_constraints_target)
 
     @property
     def resolve_all_constraints(self) -> ResolveAllConstraintsOption:


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/10723. This adds a new `_python_constraints` target, which allows defining the constraints as a list of strings in a BUILD file, rather than needing a constraints file on disk. This is useful for macros because they can generate this target.

As decided in that issue, we do not require using this new target - users can continue to use a file on disk via `[python-setup].requirement_constraints`.

It's not yet clear how this new target type will be used as we add support for multiple lockfiles, so the target is made private for now and its main intended use is macros like Pipenv and Poetry.

[ci skip-rust]
[ci skip-build-wheels]