### PR TITLE
[1.25.x-twtr] pin cryptography for pants pex

### DIFF
--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -3,6 +3,7 @@
 
 python_library(
   dependencies=[
+    '3rdparty/python:cryptography',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python:setproctitle',
     'src/python/pants/backend/jvm/tasks:nailgun_task',


### PR DESCRIPTION
### Problem

`cryptography` was likely floating, so bootstrapping pants.pex starts to fail with
```
pants.pex is outdated or does not yet exist. Bootstrapping...
+ ./pants --quiet binary src/python/pants/bin:pants_local_binary
Scrubbed PYTHONPATH=/root/pants/src/python:/opt/rh/devtoolset-7/root/usr/lib64/python2.6/site-packages:/opt/rh/devtoolset-7/root/usr/lib/python2.6/site-packages from the environment.
**** Failed to install cryptography-3.4.6 (caused by: NonZeroExit("received exit code 1 during execution of `['/root/pants/build-support/virtualenvs/Linux/pants_dev_deps.py36.venv/bin/python3.6', '-s', '-', 'bdist_wheel', '--dist-dir=/tmp/tmpvm_orq3u']` while trying to execute `['/root/pants/build-support/virtualenvs/Linux/pants_dev_deps.py36.venv/bin/python3.6', '-s', '-', 'bdist_wheel', '--dist-dir=/tmp/tmpvm_orq3u']`",)
):
stdout:

        =============================DEBUG ASSISTANCE==========================
        If you are seeing an error here please try the following to
        successfully install cryptography:

        Upgrade to the latest pip and try again. This will fix errors for most
        users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
        =============================DEBUG ASSISTANCE==========================
        

stderr:
Traceback (most recent call last):
  File "<stdin>", line 14, in <module>
  File "<string>", line 14, in <module>
ModuleNotFoundError: No module named 'setuptools_rust'
```

### Solution

Pin cryptography to 2.7, same as the previous passing build: https://travis-ci.com/github/pantsbuild/pants/jobs/439489666