### PR TITLE
Redirect pantsd stdio to the pants.log rather than entirely closing it.

### DIFF
--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -9,7 +9,7 @@ import sys
 from contextlib import contextmanager
 from io import BufferedReader, TextIOWrapper
 from logging import Formatter, LogRecord, StreamHandler
-from pathlib import Path
+from pathlib import PurePath
 from typing import Dict, Iterator
 
 import pants.util.logging as pants_logging
@@ -140,7 +140,7 @@ def initialize_stdio(global_bootstrap_options: OptionValueContainer) -> Iterator
     deprecated_log_path = os.path.join(
         global_bootstrap_options.pants_workdir, "pantsd", "pantsd.log"
     )
-    log_path = str(pants_log_path(Path(global_bootstrap_options.pants_workdir)))
+    log_path = str(pants_log_path(PurePath(global_bootstrap_options.pants_workdir)))
     safe_mkdir_for(deprecated_log_path)
     safe_mkdir_for(log_path)
     # NB: We append to the deprecated log location with a deprecated conditional that never
@@ -183,7 +183,7 @@ def initialize_stdio(global_bootstrap_options: OptionValueContainer) -> Iterator
         sys.__stdin__, sys.__stdout__, sys.__stderr__ = sys.stdin, sys.stdout, sys.stderr
 
 
-def pants_log_path(workdir: Path) -> Path:
+def pants_log_path(workdir: PurePath) -> PurePath:
     """Given the path of the workdir, returns the `pants.log` path."""
     return workdir / "pants.log"
 

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -9,6 +9,7 @@ import sys
 from contextlib import contextmanager
 from io import BufferedReader, TextIOWrapper
 from logging import Formatter, LogRecord, StreamHandler
+from pathlib import Path
 from typing import Dict, Iterator
 
 import pants.util.logging as pants_logging
@@ -139,7 +140,7 @@ def initialize_stdio(global_bootstrap_options: OptionValueContainer) -> Iterator
     deprecated_log_path = os.path.join(
         global_bootstrap_options.pants_workdir, "pantsd", "pantsd.log"
     )
-    log_path = os.path.join(global_bootstrap_options.pants_workdir, "pants.log")
+    log_path = str(pants_log_path(Path(global_bootstrap_options.pants_workdir)))
     safe_mkdir_for(deprecated_log_path)
     safe_mkdir_for(log_path)
     # NB: We append to the deprecated log location with a deprecated conditional that never
@@ -180,6 +181,11 @@ def initialize_stdio(global_bootstrap_options: OptionValueContainer) -> Iterator
     finally:
         sys.stdin, sys.stdout, sys.stderr = original_stdin, original_stdout, original_stderr
         sys.__stdin__, sys.__stdout__, sys.__stderr__ = sys.stdin, sys.stdout, sys.stderr
+
+
+def pants_log_path(workdir: Path) -> Path:
+    """Given the path of the workdir, returns the `pants.log` path."""
+    return workdir / "pants.log"
 
 
 def _get_log_levels_by_target(


### PR DESCRIPTION
### Problem

`pantsd` has closed the file handles associated with `sys.std*` (fds "0, 1, 2") since its early inception, and until #11536 it allowed exactly one client at a time in order to redirect those precise fd numbers to the client socket (via nailgun).

It's likely that:
1. before #11536, between the closing of stdio and its replacement when a client connected, any attempt to interact with `sys.std*` or Rust's stdio file handles would crash.
2. after #11536, interactions with `sys.std*` or Rust's stdio file handles at _any_ time would crash.

### Solution

Rather than closing `sys.std*` in `pantsd`, replace them with valid file handles as a backstop against code that has-not/cannot be updated to avoid touching them (such as Rust panic handlers). In the case of `stdout`/`stderr`, redirect them to append to the `pants.log`.

### Result

Given what was reported on https://github.com/tokio-rs/tokio/issues/3499, it's likely that this fixes #11364 by replacing the "panicked while processing panic" message with an actual panic message rendered in the `pants.log` (for which we can open a new ticket). 

[ci skip-rust]
[ci skip-build-wheels]