### PR TITLE
Always include interpreter constraints in PEXes.

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -363,6 +363,7 @@ jobs:
         - 3.8.3
   test_python_macos:
     env:
+      ARCHFLAGS: -arch x86_64
       PANTS_CONFIG_FILES: +['pants.ci.toml', 'pants.remote-cache.toml']
     name: Test Python (MacOS)
     needs: bootstrap_pants_macos

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -363,6 +363,7 @@ jobs:
         - 3.7.10
   test_python_macos:
     env:
+      ARCHFLAGS: -arch x86_64
       PANTS_CONFIG_FILES: +['pants.ci.toml', 'pants.remote-cache.toml']
     name: Test Python (MacOS)
     needs: bootstrap_pants_macos

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -239,7 +239,12 @@ def test_workflow_jobs(python_versions: Sequence[str]) -> Jobs:
             "runs-on": "macos-10.15",
             "needs": "bootstrap_pants_macos",
             "strategy": {"matrix": {"python-version": python_versions}},
-            "env": {**pants_config_files()},
+            "env": {
+                # Works around bad `-arch arm64` flag embedded in Xcode 12.x Python interpreters on
+                # intel machines. See: https://github.com/giampaolo/psutil/issues/1832
+                "ARCHFLAGS": "-arch x86_64",
+                **pants_config_files(),
+            },
             "steps": [
                 {"name": "Check out code", "uses": "actions/checkout@v2"},
                 *setup_primary_python(),

--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -26,3 +26,10 @@ ci_env_variables = [
 
 [buildsense]
 enable = true
+
+[subprocess-environment]
+env_vars.add = [
+  # Works around bad `-arch arm64` flag embedded in Xcode 12.x Python interpreters on intel
+  # machines. See: https://github.com/giampaolo/psutil/issues/1832
+  "ARCHFLAGS",
+]

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -583,16 +583,14 @@ async def build_pex(
         #  constraints.
         argv.extend(request.platforms.generate_pex_arg_list())
     else:
+        argv.extend(request.interpreter_constraints.generate_pex_arg_list())
         # NB: If it's an internal_only PEX, we do our own lookup of the interpreter based on the
         # interpreter constraints, and then will run the PEX with that specific interpreter. We
         # will have already validated that there were no platforms.
-        # Otherwise, we let Pex resolve the constraints.
         if request.internal_only:
             python = await Get(
                 PythonExecutable, PexInterpreterConstraints, request.interpreter_constraints
             )
-        else:
-            argv.extend(request.interpreter_constraints.generate_pex_arg_list())
 
     argv.append("--no-emit-warnings")
 


### PR DESCRIPTION
Previously we left them off for internal only PEXes. Leaving them does
no harm since PEX uses the current interpreter if it matches constraints
and it aids in the debugability of process chroots.

[ci skip-rust]
[ci skip-build-wheels]