### PR TITLE
Invalidate all files in the graph when file watching receives a rescan event.

### DIFF
--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -399,6 +399,16 @@ impl Invalidatable for InvalidatableGraph {
     );
     cleared + dirtied
   }
+
+  fn invalidate_all(&self, caller: &str) -> usize {
+    let InvalidationResult { cleared, dirtied } =
+      self.invalidate_from_roots(|node| node.fs_subject().is_some());
+    info!(
+      "{} invalidation: cleared {} and dirtied {} nodes for all paths",
+      caller, cleared, dirtied
+    );
+    cleared + dirtied
+  }
 }
 
 impl Deref for InvalidatableGraph {

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -15,9 +15,9 @@ use crate::nodes::{Select, Visualizer};
 use crate::session::{ObservedValueResult, Root, Session};
 
 use futures::{future, FutureExt};
-use graph::{InvalidationResult, LastObserved};
+use graph::LastObserved;
 use hashing::{Digest, EMPTY_DIGEST};
-use log::{debug, info, warn};
+use log::{debug, warn};
 use stdio::TryCloneAsFile;
 use tempfile::TempDir;
 use tokio::process;
@@ -109,15 +109,7 @@ impl Scheduler {
   /// Invalidate all filesystem dependencies in the graph.
   ///
   pub fn invalidate_all_paths(&self) -> usize {
-    let InvalidationResult { cleared, dirtied } = self
-      .core
-      .graph
-      .invalidate_from_roots(|node| node.fs_subject().is_some());
-    info!(
-      "invalidation: cleared {} and dirtied {} nodes for all paths",
-      cleared, dirtied
-    );
-    cleared + dirtied
+    self.core.graph.invalidate_all("external")
   }
 
   ///

--- a/src/rust/engine/watch/src/tests.rs
+++ b/src/rust/engine/watch/src/tests.rs
@@ -157,4 +157,8 @@ impl Invalidatable for TestInvalidatable {
     calls.push(paths.clone());
     invalidated
   }
+
+  fn invalidate_all(&self, _caller: &str) -> usize {
+    unimplemented!();
+  }
 }


### PR DESCRIPTION
### Problem

When inotify kernel buffers overflow, the `notify` crate will send a [Rescan](https://docs.rs/notify/5.0.0-pre.6/notify/event/enum.Flag.html#variant.Rescan) flagged `Event` which is intended to be a signal to purge in memory state. Pants currently does not react to that flag.

### Solution

Invalidate all files in the graph when we receive a `Rescan` flagged event.

[ci skip-build-wheels]