### PR TITLE
Reduce verbosity of warnings when remote caching has errors

### DIFF
--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -24,6 +24,14 @@ use crate::{
   ProcessMetadata,
 };
 
+/// Every n times, log a particular remote cache error at warning level instead of debug level. We
+/// don't log at warn level every time to avoid flooding the console.
+///
+/// Every 5 times is arbitrary and can be changed. It's based on running the `lint` goal with a
+/// fake store address resulting in 5 read errors and 18 write errors; 5 seems like a
+/// reasonable increment.
+const LOG_ERRORS_INCREMENT: usize = 5;
+
 /// This `CommandRunner` implementation caches results remotely using the Action Cache service
 /// of the Remote Execution API.
 ///
@@ -468,7 +476,7 @@ impl crate::CommandRunner for CommandRunner {
               "Failed to read from remote cache ({} occurrences so far): {}",
               err_count, err
             );
-            if err_count == 1 || err_count % 5 == 0 {
+            if err_count == 1 || err_count % LOG_ERRORS_INCREMENT == 0 {
               log::warn!("{}", log_msg);
             } else {
               log::debug!("{}", log_msg);
@@ -547,7 +555,7 @@ impl crate::CommandRunner for CommandRunner {
             "Failed to write to remote cache ({} occurrences so far): {}",
             err_count, err
           );
-          if err_count == 1 || err_count % 5 == 0 {
+          if err_count == 1 || err_count % LOG_ERRORS_INCREMENT == 0 {
             log::warn!("{}", log_msg);
           } else {
             log::debug!("{}", log_msg);

--- a/tests/python/pants_test/integration/remote_cache_integration_test.py
+++ b/tests/python/pants_test/integration/remote_cache_integration_test.py
@@ -35,10 +35,15 @@ def test_warns_on_remote_cache_errors():
     )
 
     pants_run.assert_success()
-    assert "Failed to read from remote cache: Unimplemented" in pants_run.stderr
+    assert (
+        "Failed to read from remote cache (1 occurrences so far): Unimplemented" in pants_run.stderr
+    )
     assert (
         re.search(
-            "Failed to write to remote cache:.*StubCAS is configured to always fail",
+            (
+                r"Failed to write to remote cache \(1 occurrences so far\):.*StubCAS is configured "
+                r"to always fail"
+            ),
             pants_run.stderr,
             re.MULTILINE,
         )


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/11494. We still always log errors, but only at the warn level for the 1st instance of a particular error, and then every 5 times after that. Otherwise, we use the debug level.

For example:

```
❯ ./pants --remote-cache-read --remote-cache-write --remote-store-address='grpcs://fake.com' lint src/python/pants/util/strutil.py --no-process-execution-use-local-cache
18:35:59.93 [WARN] Failed to write to remote cache (1 occurrences so far): Error from server in response to find_missing_blobs_request: Status { code: Internal, message: "Unexpected compression flag: 60, while receiving response with status: 404 Not Found" }
18:36:00.72 [WARN] Failed to write to remote cache (5 occurrences so far): Error from server in response to find_missing_blobs_request: Status { code: Internal, message: "Unexpected compression flag: 60, while receiving response with status: 404 Not Found" }
18:36:01.10 [INFO] Completed: Building docformatter.pex with 1 requirement: docformatter>=1.3.1,<1.4
18:36:01.20 [INFO] Completed: lint - Docformatter succeeded.
18:36:01.24 [WARN] Failed to write to remote cache (10 occurrences so far): Error from server in response to find_missing_blobs_request: Status { code: Internal, message: "Unexpected compression flag: 60, while receiving response with status: 404 Not Found" }
```

This intentionally does not add an option to control this behavior, instead trying to reach a sensible default that balances the desire for logs to know when things aren't working with not wanting to crowd the console. Pants arguably has options fatigue, and adding an option here would add lots of complexity (including wiring over FFI).

Note that for simplicity of the implementation, this does not log at warn level the final count of errors, as we do not know what the final call to `run()` will be. Users can use `-ldebug` if they care about this, especially with `--log-levels-by-target`.

[ci skip-build-wheels]