### PR TITLE
Remove subprocess-environment allow list.

### DIFF
--- a/src/python/pants/core/util_rules/subprocess_environment.py
+++ b/src/python/pants/core/util_rules/subprocess_environment.py
@@ -9,28 +9,6 @@ from pants.engine.rules import Get, collect_rules, rule
 from pants.option.subsystem import Subsystem
 from pants.util.frozendict import FrozenDict
 
-# Names of env vars that can be set on all subprocesses via config.
-SETTABLE_ENV_VARS = (
-    # Customarily used to control i18n settings.
-    "LANG",
-    "LC_CTYPE",
-    "LC_ALL",
-    # Customarily used to control proxy settings in various processes.
-    "http_proxy",
-    "https_proxy",
-    "ftp_proxy",
-    "all_proxy",
-    "no_proxy",
-    "HTTP_PROXY",
-    "HTTPS_PROXY",
-    "FTP_PROXY",
-    "ALL_PROXY",
-    "NO_PROXY",
-    # Allow Requests to verify SSL certificates for HTTPS requests
-    # https://requests.readthedocs.io/en/master/user/advanced/#ssl-cert-verification
-    "REQUESTS_CA_BUNDLE",
-)
-
 
 # TODO: We may want to support different sets of env vars for different types of process.
 #  Can be done via scoped subsystems, possibly.  However we should only do this if there
@@ -51,8 +29,7 @@ class SubprocessEnvironment(Subsystem):
             help=(
                 "Environment variables to set for process invocations. "
                 "Entries are either strings in the form `ENV_VAR=value` to set an explicit value; "
-                "or just `ENV_VAR` to copy the value from Pants's own environment.\n\nEach ENV_VAR "
-                f"must be one of {', '.join(f'`{v}`' for v in SETTABLE_ENV_VARS)}."
+                "or just `ENV_VAR` to copy the value from Pants's own environment."
             ),
         )
 
@@ -71,12 +48,7 @@ async def get_subprocess_environment(
     subproc_env: SubprocessEnvironment,
 ) -> SubprocessEnvironmentVars:
     return SubprocessEnvironmentVars(
-        await Get(
-            Environment,
-            EnvironmentRequest(
-                subproc_env.env_vars_to_pass_to_subprocesses, allowed=SETTABLE_ENV_VARS
-            ),
-        )
+        await Get(Environment, EnvironmentRequest(subproc_env.env_vars_to_pass_to_subprocesses))
     )
 
 


### PR DESCRIPTION
Now `[subprocess-environment] env_vars` can be used to selectively
allow arbitrary environment variables to be propagated to subprocesses.

[ci skip-rust]
[ci skip-build-wheels]
