### PR TITLE
Make it easier to debug RuleRunner tests.

### DIFF
--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import logging
 import multiprocessing
 import os
 import sys
@@ -52,8 +51,6 @@ from pants.util.dirutil import (
     safe_open,
 )
 from pants.util.ordered_set import FrozenOrderedSet
-
-logger = logging.getLogger(__name__)
 
 # -----------------------------------------------------------------------------------------------
 # `RuleRunner`


### PR DESCRIPTION
Depending on your familiarity with RuleRunner, getting local process execution
directories preserved could be arcane. The obvious route, using set_options,
does not work. Wrap this all up and cleanup the build root by default - it
leaked previously.

[ci skip-rust]