### PR TITLE
Never cancel branch builds for `main` and release branches

### DIFF
--- a/.github/workflows/cancel.yaml
+++ b/.github/workflows/cancel.yaml
@@ -14,6 +14,9 @@ jobs:
 name: Cancel
 'on':
   workflow_run:
+    branches-ignore:
+    - main
+    - 2.*.x
     types:
     - requested
     workflows:

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -351,7 +351,14 @@ def generate() -> dict[Path, str]:
             # Note that this job runs in the context of the default branch, so its token
             # has permission to cancel workflows (i.e., it is not the PR's read-only token).
             "name": "Cancel",
-            "on": {"workflow_run": {"workflows": [test_workflow_name], "types": ["requested"]}},
+            "on": {
+                "workflow_run": {
+                    "workflows": [test_workflow_name],
+                    "types": ["requested"],
+                    # Never cancel branch builds for `main` and release branches.
+                    "branches-ignore": ["main", "2.*.x"],
+                }
+            },
             "jobs": {
                 "cancel": {
                     "runs-on": "ubuntu-latest",

--- a/build-support/githooks/prepare-commit-msg
+++ b/build-support/githooks/prepare-commit-msg
@@ -16,14 +16,13 @@ MERGE_BASE="$(git_merge_base)"
 # new build.
 CHANGED_FILES="$(git diff --name-only "${MERGE_BASE}")"
 
-NUM_NON_MD_FILES=$(echo "${CHANGED_FILES})" | grep -c -v ".\md$")
-
 # Ensure that this stays in sync with `build-support/bin/rust/calculate_engine_hash.sh`.
 NUM_RUST_FILES=$(echo "${CHANGED_FILES})" | grep -c -E \
   -e "^src/rust/engine" \
   -e "^rust-toolchain" \
   -e "^build-support/bin/rust" \
-  -e "^build-support/bin/generate_travis_yml.py")
+  -e "^build-support/bin/generate_travis_yml.py" \
+  -e "^build-support/bin/generate_github_workflows.py")
 
 NUM_RELEASE_FILES=$(echo "${CHANGED_FILES})" | grep -c -E \
   -e "^src/python/pants/VERSION" \
@@ -31,7 +30,8 @@ NUM_RELEASE_FILES=$(echo "${CHANGED_FILES})" | grep -c -E \
   -e "^src/rust/engine/fs/fs_util" \
   -e "^build-support/bin/release.sh" \
   -e "^build-support/bin/packages.py" \
-  -e "^build-support/bin/generate_travis_yml.py")
+  -e "^build-support/bin/generate_travis_yml.py" \
+  -e "^build-support/bin/generate_github_workflows.py")
 
 # To avoid putting skip labels multiple times, check if the labels already exist
 # in the commit message.
@@ -41,14 +41,6 @@ grep "\[ci skip-rust\]" "${COMMIT_MSG_FILEPATH}" > /dev/null
 HAS_RUST_SKIP=$?
 grep "\[ci skip-build-wheels\]" "${COMMIT_MSG_FILEPATH}" > /dev/null
 HAS_WHEELS_SKIP=$?
-
-if [[ "${HAS_CI_SKIP}" -eq 1 ]] && [ "${NUM_NON_MD_FILES}" -eq 0 ]; then
-cat <<EOF >> "${COMMIT_MSG_FILEPATH}"
-
-# All CI will be skipped. Delete if not intended.
-[ci skip]
-EOF
-fi
 
 if [[ "${HAS_RUST_SKIP}" -eq 1 ]] && [ "${NUM_RUST_FILES}" -eq 0 ]; then
 cat <<EOF >> "${COMMIT_MSG_FILEPATH}"


### PR DESCRIPTION
Fixes up https://github.com/pantsbuild/pants/pull/11747 so that we always build for `main` and release branches, even if a newer commit lands during a CI run.