### PR TITLE
Load Toolchain auth token from secrets when building branches

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -93,7 +93,7 @@ jobs:
       run: 'echo ''PANTS_CONFIG_FILES=+["${{ github.workspace }}/pants.ci.toml", "${{
         github.workspace }}/pants.remote-cache.toml"]'' >> ${GITHUB_ENV}
 
-        '
+        echo ''TOOLCHAIN_AUTH_TOKEN={{ secrets.TOOLCHAIN_AUTH_TOKEN }} >> ${GITHUB_ENV}'
     - name: Bootstrap Pants
       run: './pants --version
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -93,7 +93,7 @@ jobs:
       run: 'echo ''PANTS_CONFIG_FILES=+["${{ github.workspace }}/pants.ci.toml", "${{
         github.workspace }}/pants.remote-cache.toml"]'' >> ${GITHUB_ENV}
 
-        '
+        echo ''TOOLCHAIN_AUTH_TOKEN={{ secrets.TOOLCHAIN_AUTH_TOKEN }} >> ${GITHUB_ENV}'
     - name: Bootstrap Pants
       run: './pants --version
 

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -168,7 +168,8 @@ def test_workflow_jobs(python_versions: Sequence[str]) -> Jobs:
                 *bootstrap_caches(),
                 {
                     "name": "Set env vars",
-                    "run": 'echo \'PANTS_CONFIG_FILES=+["${{ github.workspace }}/pants.ci.toml", "${{ github.workspace }}/pants.remote-cache.toml"]\' >> ${GITHUB_ENV}\n',
+                    "run": 'echo \'PANTS_CONFIG_FILES=+["${{ github.workspace }}/pants.ci.toml", "${{ github.workspace }}/pants.remote-cache.toml"]\' >> ${GITHUB_ENV}\n'
+                    "echo 'TOOLCHAIN_AUTH_TOKEN={{ secrets.TOOLCHAIN_AUTH_TOKEN }} >> ${GITHUB_ENV}",
                 },
                 {"name": "Bootstrap Pants", "run": "./pants --version\n"},
                 {


### PR DESCRIPTION
This will allow the toolchain plugin to auth to toolchain service when running non branch PRs