### PR TITLE
upgrade tempfile and rand crates

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -683,7 +683,7 @@ dependencies = [
  "num_enum",
  "parking_lot",
  "process_execution",
- "rand 0.6.5",
+ "rand 0.8.2",
  "regex",
  "reqwest",
  "rule_graph",
@@ -747,7 +747,7 @@ checksum = "0c122a393ea57648015bf06fbd3d372378992e86b9ff5a7a497b076a28c79efe"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "winapi 0.3.9",
 ]
 
@@ -825,7 +825,7 @@ dependencies = [
  "hashing",
  "parking_lot",
  "prost",
- "rand 0.6.5",
+ "rand 0.8.2",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1059,7 +1059,7 @@ dependencies = [
  "log 0.4.11",
  "parking_lot",
  "petgraph 0.4.13",
- "rand 0.6.5",
+ "rand 0.8.2",
  "tokio",
 ]
 
@@ -1897,7 +1897,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "smallvec 1.6.1",
  "winapi 0.3.9",
 ]
@@ -2112,7 +2112,7 @@ dependencies = [
  "parking_lot",
  "prost",
  "prost-types",
- "rand 0.6.5",
+ "rand 0.8.2",
  "regex",
  "serde",
  "sha2",
@@ -2290,19 +2290,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.15",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc 0.2.0",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18519b42a40024d661e1714153e9ad0c3de27cd495760ceb09710920f1098b1e"
@@ -2321,16 +2308,6 @@ checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 dependencies = [
  "autocfg 0.1.7",
  "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -2360,15 +2337,6 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.15",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
@@ -2383,15 +2351,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
 dependencies = [
  "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -2497,13 +2456,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
  "getrandom 0.1.15",
- "redox_syscall",
+ "redox_syscall 0.1.57",
 ]
 
 [[package]]
@@ -3056,14 +3024,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "rand 0.7.3",
- "redox_syscall",
+ "rand 0.8.2",
+ "redox_syscall 0.2.5",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -3741,7 +3709,7 @@ dependencies = [
  "log 0.4.11",
  "parking_lot",
  "petgraph 0.4.13",
- "rand 0.6.5",
+ "rand 0.8.2",
  "strum",
  "strum_macros",
  "tokio",

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -120,7 +120,7 @@ nailgun = { path = "nailgun" }
 num_enum = "0.4"
 parking_lot = "0.11"
 process_execution = { path = "process_execution" }
-rand = "0.6"
+rand = "0.8"
 regex = "1"
 reqwest = { version = "0.11", default_features = false, features = ["stream", "rustls-tls"] }
 rule_graph = { path = "rule_graph" }

--- a/src/rust/engine/fs/fs_util/Cargo.toml
+++ b/src/rust/engine/fs/fs_util/Cargo.toml
@@ -16,7 +16,7 @@ futures = "0.3"
 hashing = { path = "../../hashing" }
 parking_lot = "0.11"
 prost = "0.7"
-rand = "0.6"
+rand = "0.8"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"

--- a/src/rust/engine/graph/Cargo.toml
+++ b/src/rust/engine/graph/Cargo.toml
@@ -16,6 +16,6 @@ petgraph = "0.4.5"
 tokio = { version = "1.4", features = ["time"] }
 
 [dev-dependencies]
-rand = "0.6"
+rand = "0.8"
 env_logger = "0.5.4"
 tokio = { version = "1.4", features = ["macros", "rt-multi-thread", "time"] }

--- a/src/rust/engine/graph/src/tests.rs
+++ b/src/rust/engine/graph/src/tests.rs
@@ -153,7 +153,7 @@ async fn invalidate_randomly() {
       invalidations -= 1;
 
       // Invalidate a random node in the graph.
-      let candidate = rng.gen_range(0, range);
+      let candidate = rng.gen_range(0..range);
       graph2.invalidate_from_roots(|&TNode(n, _)| n == candidate);
 
       thread::sleep(sleep_per_invalidation);

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -39,7 +39,7 @@ itertools = "0.8.0"
 serde = "1.0.104"
 bincode = "1.2.1"
 double-checked-cell-async = "2.0"
-rand = "0.6"
+rand = "0.8"
 prost = "0.7"
 prost-types = "0.7"
 tonic = { version = "0.4", features = ["transport", "codegen", "tls", "tls-roots", "prost"] }

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -585,7 +585,7 @@ impl CommandRunner {
           .workunit_store
           .increment_counter(Metric::RemoteExecutionRPCRetries, 1);
 
-        let multiplier = thread_rng().gen_range(0, 2_u32.pow(num_retries) + 1);
+        let multiplier = thread_rng().gen_range(0..2_u32.pow(num_retries) + 1);
         let sleep_time = self.retry_interval_duration * multiplier;
         let sleep_time = sleep_time.min(MAX_BACKOFF_DURATION);
         debug!("delaying {:?} before retry", sleep_time);

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -11,7 +11,7 @@ concrete_time = { path = "../concrete_time" }
 hashing = { path = "../hashing" }
 hdrhistogram = "7.2"
 parking_lot = "0.11"
-rand = "0.6"
+rand = "0.8"
 tokio = { version = "1.4", features = ["rt"] }
 petgraph = "0.4.5"
 log = "0.4"


### PR DESCRIPTION
Upgrade `tempfile` and `rand` crates. Because of the `tempfile` upgrade, that is one less duplicative version of `rand` being included. (We still pick up rand v0.4 and v0.6 via transitive deps.)