### PR TITLE
Remove prepare-commit-msg git hook cruft.

### DIFF
--- a/build-support/githooks/prepare-commit-msg
+++ b/build-support/githooks/prepare-commit-msg
@@ -35,8 +35,6 @@ NUM_RELEASE_FILES=$(echo "${CHANGED_FILES})" | grep -c -E \
 
 # To avoid putting skip labels multiple times, check if the labels already exist
 # in the commit message.
-grep "\[ci skip\]" "${COMMIT_MSG_FILEPATH}" > /dev/null
-HAS_CI_SKIP=$?
 grep "\[ci skip-rust\]" "${COMMIT_MSG_FILEPATH}" > /dev/null
 HAS_RUST_SKIP=$?
 grep "\[ci skip-build-wheels\]" "${COMMIT_MSG_FILEPATH}" > /dev/null


### PR DESCRIPTION
Shellcheck was complaining:
```
In ./build-support/githooks/prepare-commit-msg line 39:
HAS_CI_SKIP=$?
^---------^ SC2034: HAS_CI_SKIP appears unused. Verify use (or export if used externally).
```

This appears to be leftovers from #11750.

[ci skip-rust]
[ci skip-build-wheels]