### PR TITLE
Fix bug in remote cache client when outputs are missing

### DIFF
--- a/src/rust/engine/process_execution/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_cache_tests.rs
@@ -420,6 +420,7 @@ async fn make_tree_from_directory() {
     &store,
   )
   .await
+  .unwrap()
   .unwrap();
 
   let root_dir = tree.root.unwrap();
@@ -440,13 +441,14 @@ async fn make_tree_from_directory() {
   assert_eq!(file_digest, TestData::roland().digest());
 
   // Test that extracting a non-existent output directory fails.
-  crate::remote_cache::CommandRunner::make_tree_for_output_directory(
+  let result = crate::remote_cache::CommandRunner::make_tree_for_output_directory(
     directory_digest,
     RelativePath::new("animals").unwrap(),
     &store,
   )
   .await
-  .unwrap_err();
+  .unwrap();
+  assert!(result.is_none());
 }
 
 #[tokio::test]

--- a/src/rust/engine/process_execution/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_cache_tests.rs
@@ -449,6 +449,15 @@ async fn make_tree_from_directory() {
   .await
   .unwrap();
   assert!(result.is_none());
+
+  let result = crate::remote_cache::CommandRunner::make_tree_for_output_directory(
+    directory_digest,
+    RelativePath::new("pets/xyzzy").unwrap(),
+    &store,
+  )
+    .await
+    .unwrap();
+  assert!(result.is_none());
 }
 
 #[tokio::test]


### PR DESCRIPTION
### Problem

REAPI states that missing output directories and output files are to be silently ignored when producing an `ActionResult`. If one of them does not exist, then it will be omitted from the `ActionResult`. See https://github.com/bazelbuild/remote-apis/blob/0943dc4e70e1414735a85a3167557392c177ff45/build/bazel/remote/execution/v2/remote_execution.proto#L1010-L1016 and https://github.com/bazelbuild/remote-apis/blob/0943dc4e70e1414735a85a3167557392c177ff45/build/bazel/remote/execution/v2/remote_execution.proto#L969-L971.

Our remote cache client, however, generated an error in these cases. This caused the issue fixed in https://github.com/pantsbuild/pants/pull/11763 where optional output directories were properly missing but caused an error. This is a valid use case for process executions, especially since the process execution must still specify the output directory even when it is optional.

### Solution

Modify `make_tree_for_output_directory` and `extract_output_file` to return `Option<Tree>` and `Option<FileNode>`, respectively, to allow directories and files to be missing without error.

### Result

Updated tests to account for optional capture of directories and files.

Fixes https://github.com/pantsbuild/pants/issues/11764.
