### PR TITLE
error if directory digest is missing when it is expected to be present

### DIFF
--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -125,7 +125,12 @@ impl CommandRunner {
       // Load the Directory proto corresponding to `current_directory_digest`.
       let current_directory = match store.load_directory(current_directory_digest).await? {
         Some((dir, _)) => dir,
-        None => return Ok(None),
+        None => {
+          return Err(format!(
+            "Directory digest {:?} was referenced in output, but was not found in store.",
+            current_directory_digest
+          ))
+        }
       };
 
       // Scan the current directory for the current path component.
@@ -202,7 +207,12 @@ impl CommandRunner {
         // Load the Directory proto corresponding to `current_directory_digest`.
         let current_directory = match store.load_directory(current_directory_digest).await? {
           Some((dir, _)) => dir,
-          None => return Ok(None),
+          None => {
+            return Err(format!(
+              "Directory digest {:?} was referenced in output, but was not found in store.",
+              current_directory_digest
+            ))
+          }
         };
 
         // Scan the current directory for the current path component.

--- a/src/rust/engine/process_execution/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_cache_tests.rs
@@ -455,8 +455,8 @@ async fn make_tree_from_directory() {
     RelativePath::new("pets/xyzzy").unwrap(),
     &store,
   )
-    .await
-    .unwrap();
+  .await
+  .unwrap();
   assert!(result.is_none());
 }
 
@@ -516,8 +516,8 @@ async fn extract_output_file() {
     RelativePath::new("cats/xyzzy").unwrap(),
     &store,
   )
-      .await
-      .unwrap();
+  .await
+  .unwrap();
   assert!(file_node_opt.is_none());
 }
 


### PR DESCRIPTION
[ci skip-build-wheels]

### Problem

Fix issue with https://github.com/pantsbuild/pants/pull/11772 where it does not error if a directory digest in the output is missing when it is in fact expected to be present because the process execution just happened.

### Solution

Error in this case.

### Result

Tests pass.
