### PR TITLE
Deprecate `--process-execution-use-local-cache` in favor of `--process-execution-local-cache`

### DIFF
--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -180,7 +180,7 @@ class Scheduler:
             local_parallelism=execution_options.process_execution_local_parallelism,
             remote_parallelism=execution_options.process_execution_remote_parallelism,
             cleanup_local_dirs=execution_options.process_execution_cleanup_local_dirs,
-            use_local_cache=execution_options.process_execution_use_local_cache,
+            local_cache=execution_options.process_execution_local_cache,
             remote_cache_read=execution_options.remote_cache_read,
             remote_cache_write=execution_options.remote_cache_write,
         )

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -21,6 +21,7 @@ from pants.base.build_environment import (
     get_pants_cachedir,
     pants_version,
 )
+from pants.base.deprecated import resolve_conflicting_options
 from pants.engine.environment import CompleteEnvironment
 from pants.engine.internals.native_engine import PyExecutor
 from pants.option.custom_types import dir_option
@@ -113,11 +114,11 @@ class ExecutionOptions:
     remote_instance_name: Optional[str]
     remote_ca_certs_path: Optional[str]
 
+    process_execution_local_cache: bool
     process_execution_local_parallelism: int
     process_execution_remote_parallelism: int
     process_execution_cache_namespace: Optional[str]
     process_execution_cleanup_local_dirs: bool
-    process_execution_use_local_cache: bool
 
     remote_store_address: str | None
     remote_store_headers: dict[str, str]
@@ -230,10 +231,17 @@ class ExecutionOptions:
             remote_instance_name=remote_instance_name,
             remote_ca_certs_path=bootstrap_options.remote_ca_certs_path,
             # Process execution setup.
+            process_execution_local_cache=resolve_conflicting_options(
+                old_option="process_execution_use_local_cache",
+                new_option="process_execution_local_cache",
+                old_scope=GLOBAL_SCOPE,
+                new_scope=GLOBAL_SCOPE,
+                old_container=bootstrap_options,
+                new_container=bootstrap_options,
+            ),
             process_execution_local_parallelism=bootstrap_options.process_execution_local_parallelism,
             process_execution_remote_parallelism=bootstrap_options.process_execution_remote_parallelism,
             process_execution_cleanup_local_dirs=bootstrap_options.process_execution_cleanup_local_dirs,
-            process_execution_use_local_cache=bootstrap_options.process_execution_use_local_cache,
             process_execution_cache_namespace=bootstrap_options.process_execution_cache_namespace,
             # Remote store setup.
             remote_store_address=remote_store_address,
@@ -269,7 +277,7 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     process_execution_remote_parallelism=128,
     process_execution_cache_namespace=None,
     process_execution_cleanup_local_dirs=True,
-    process_execution_use_local_cache=True,
+    process_execution_local_cache=True,
     # Remote store setup.
     remote_store_address=None,
     remote_store_headers={},
@@ -734,11 +742,22 @@ class GlobalOptions(Subsystem):
             default=tempfile.gettempdir(),
         )
         register(
-            "--process-execution-use-local-cache",
+            "--process-execution-local-cache",
             type=bool,
-            default=True,
+            default=DEFAULT_EXECUTION_OPTIONS.process_execution_local_cache,
             advanced=True,
             help="Whether to keep process executions in a local cache persisted to disk.",
+        )
+        register(
+            "--process-execution-use-local-cache",
+            type=bool,
+            default=DEFAULT_EXECUTION_OPTIONS.process_execution_local_cache,
+            advanced=True,
+            help="Whether to keep process executions in a local cache persisted to disk.",
+            removal_version="2.5.0.dev0",
+            removal_hint=(
+                "Use the shorter `--process-execution-local-cache`, which behaves the same."
+            )
         )
         register(
             "--process-execution-cleanup-local-dirs",

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -757,7 +757,7 @@ class GlobalOptions(Subsystem):
             removal_version="2.5.0.dev0",
             removal_hint=(
                 "Use the shorter `--process-execution-local-cache`, which behaves the same."
-            )
+            ),
         )
         register(
             "--process-execution-cleanup-local-dirs",

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -88,7 +88,7 @@ pub struct ExecutionStrategyOptions {
   pub local_parallelism: usize,
   pub remote_parallelism: usize,
   pub cleanup_local_dirs: bool,
-  pub use_local_cache: bool,
+  pub local_cache: bool,
   pub remote_cache_read: bool,
   pub remote_cache_write: bool,
 }
@@ -196,7 +196,7 @@ impl Core {
       };
 
     // Possibly use the local cache runner, regardless of remote execution/caching.
-    let maybe_local_cached_command_runner = if exec_strategy_opts.use_local_cache {
+    let maybe_local_cached_command_runner = if exec_strategy_opts.local_cache {
       let process_execution_store = ShardedLmdb::new(
         local_store_dir.join("processes"),
         2 * DEFAULT_LOCAL_STORE_GC_TARGET_BYTES,

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -524,7 +524,7 @@ py_class!(class PyExecutionStrategyOptions |py| {
     local_parallelism: u64,
     remote_parallelism: u64,
     cleanup_local_dirs: bool,
-    use_local_cache: bool,
+    local_cache: bool,
     remote_cache_read: bool,
     remote_cache_write: bool
   ) -> CPyResult<Self> {
@@ -533,7 +533,7 @@ py_class!(class PyExecutionStrategyOptions |py| {
         local_parallelism: local_parallelism as usize,
         remote_parallelism: remote_parallelism as usize,
         cleanup_local_dirs,
-        use_local_cache,
+        local_cache,
         remote_cache_read,
         remote_cache_write,
       }


### PR DESCRIPTION
This is shorter and aligns with `--remote-execution`, `--remote-cache-read`, and `--remote-cache-write`.

The even shorter `--local-cache` was considered but rejected for now to keep the namespacing of `--process-execution`.

[ci skip-rust]
[ci skip-build-wheels]