### PR TITLE
Make the number of LMDB store shards configurable

### DIFF
--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -187,6 +187,7 @@ class Scheduler:
             files_max_size_bytes=local_store_options.files_max_size_bytes,
             directories_max_size_bytes=local_store_options.directories_max_size_bytes,
             lease_time_millis=LOCAL_STORE_LEASE_TIME_SECS * 1000,
+            shard_count=local_store_options.shard_count,
         )
         exec_stategy_opts = PyExecutionStrategyOptions(
             local_parallelism=execution_options.process_execution_local_parallelism,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -785,14 +785,16 @@ class GlobalOptions(Subsystem):
             type=int,
             advanced=True,
             help=(
-                "The number of LMDB shards created for the local store."
+                "The number of LMDB shards created for the local store. This setting also impacts "
+                f"the maximum size of stored files: see `{local_store_files_max_size_bytes_flag}` "
+                "for more information."
                 "\n\n"
                 "Because LMDB allows only one simultaneous writer per database, the store is split "
                 "into multiple shards to allow for more concurrent writers. The faster your disks "
                 "are, the fewer shards you are likely to need for performance."
                 "\n\n"
-                "The shard count also impacts the maximum size of stored files: see "
-                f"`{local_store_files_max_size_bytes_flag}` for more information."
+                "NB: After changing this value, you will likely want to manually clear the "
+                f"`{local_store_dir_flag}` directory to clear the space used by old shard layouts."
             ),
             default=DEFAULT_LOCAL_STORE_OPTIONS.shard_count,
         )

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -2763,6 +2763,7 @@ dependencies = [
  "log 0.4.11",
  "task_executor",
  "tempfile",
+ "tokio",
 ]
 
 [[package]]

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -78,6 +78,7 @@ pub struct LocalOptions {
   pub files_max_size_bytes: usize,
   pub directories_max_size_bytes: usize,
   pub lease_time: Duration,
+  pub shard_count: u8,
 }
 
 ///
@@ -90,6 +91,7 @@ impl Default for LocalOptions {
       files_max_size_bytes: 16 * 4 * GIGABYTES,
       directories_max_size_bytes: 2 * 4 * GIGABYTES,
       lease_time: DEFAULT_LEASE_TIME,
+      shard_count: 16,
     }
   }
 }

--- a/src/rust/engine/fs/store/src/local.rs
+++ b/src/rust/engine/fs/store/src/local.rs
@@ -51,6 +51,7 @@ impl ByteStore {
           options.files_max_size_bytes,
           executor.clone(),
           options.lease_time,
+          options.shard_count,
         )
         .map(Arc::new),
         directory_dbs: ShardedLmdb::new(
@@ -58,6 +59,7 @@ impl ByteStore {
           options.directories_max_size_bytes,
           executor.clone(),
           options.lease_time,
+          options.shard_count,
         )
         .map(Arc::new),
         executor,

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -48,6 +48,7 @@ fn create_cached_runner(
     max_lmdb_size,
     runtime.clone(),
     DEFAULT_LEASE_TIME,
+    1,
   )
   .unwrap();
 

--- a/src/rust/engine/sharded_lmdb/Cargo.toml
+++ b/src/rust/engine/sharded_lmdb/Cargo.toml
@@ -13,3 +13,6 @@ lmdb = { git = "https://github.com/pantsbuild/lmdb-rs.git", rev = "06bdfbfc6348f
 log = "0.4"
 task_executor = { path = "../task_executor" }
 tempfile = "3"
+
+[dev-dependencies]
+tokio = { version = "1.4", features = ["macros"] }

--- a/src/rust/engine/sharded_lmdb/src/lib.rs
+++ b/src/rust/engine/sharded_lmdb/src/lib.rs
@@ -106,17 +106,16 @@ impl AsRef<[u8]> for VersionedFingerprint {
 #[derive(Debug, Clone)]
 pub struct ShardedLmdb {
   // First Database is content, second is leases.
-  lmdbs: HashMap<u8, (Arc<Environment>, Database, Database)>,
+  lmdbs: HashMap<u8, (PathBuf, Arc<Environment>, Database, Database)>,
   root_path: PathBuf,
   max_size_per_shard: usize,
   executor: task_executor::Executor,
   lease_time: Duration,
+  shard_count: u8,
+  shard_fingerprint_mask: u8,
 }
 
 impl ShardedLmdb {
-  const NUM_SHARDS: u8 = 0x10;
-  const NUM_SHARDS_SHIFT: u8 = 4;
-
   // Whenever we change the byte format of data stored in lmdb, we will
   // need to increment this schema version. This schema version will
   // be appended to the Fingerprint-derived keys to create the key
@@ -135,13 +134,36 @@ impl ShardedLmdb {
     max_size: usize,
     executor: task_executor::Executor,
     lease_time: Duration,
+    shard_count: u8,
   ) -> Result<ShardedLmdb, String> {
+    if shard_count.count_ones() != 1 {
+      return Err(format!(
+        "The shard_count must be a power of two: got {}.",
+        shard_count
+      ));
+    }
+
+    let max_size_per_shard = max_size / (shard_count as usize);
+    // We select which shard to use by masking to select only the relevant number of high order bits
+    // from the high order byte of each stored key.
+    let shard_fingerprint_mask = {
+      // Create a mask of the appropriate width.
+      let mask_width = shard_count.trailing_zeros();
+      let mut mask = 0_u8;
+      for _ in 0..mask_width {
+        mask <<= 1;
+        mask |= 1;
+      }
+      // Then move it into the high order bits.
+      mask.rotate_left(Self::shard_shift(shard_count) as u32)
+    };
+
     trace!("Initializing ShardedLmdb at root {:?}", root_path);
     let mut lmdbs = HashMap::new();
 
-    let max_size_per_shard = max_size / (Self::NUM_SHARDS as usize);
-
-    for (env, dir, fingerprint_prefix) in ShardedLmdb::envs(&root_path, max_size_per_shard)? {
+    for (env, dir, fingerprint_prefix) in
+      ShardedLmdb::envs(&root_path, max_size_per_shard, shard_count)?
+    {
       let content_database = env
         .create_db(Some("content-versioned"), DatabaseFlags::empty())
         .map_err(|e| {
@@ -162,7 +184,7 @@ impl ShardedLmdb {
 
       lmdbs.insert(
         fingerprint_prefix,
-        (Arc::new(env), content_database, lease_database),
+        (dir, Arc::new(env), content_database, lease_database),
       );
     }
 
@@ -172,23 +194,34 @@ impl ShardedLmdb {
       max_size_per_shard,
       executor,
       lease_time,
+      shard_count,
+      shard_fingerprint_mask,
     })
+  }
+
+  ///
+  /// Return the left shift value that will place the relevant portion of a byte (for the given
+  /// shard count, which is asserted in the constructor to be a power of two) into the high order
+  /// bits of a byte.
+  ///
+  fn shard_shift(shard_count: u8) -> u8 {
+    let mask_width = shard_count.trailing_zeros() as u8;
+    8 - mask_width
   }
 
   fn envs(
     root_path: &Path,
     max_size_per_shard: usize,
+    shard_count: u8,
   ) -> Result<Vec<(Environment, PathBuf, u8)>, String> {
-    let mut envs = Vec::with_capacity(Self::NUM_SHARDS as usize);
-    for b in 0x00..Self::NUM_SHARDS {
-      // NB: This shift is NUM_SHARDS dependent.
-      let fingerprint_prefix = b << Self::NUM_SHARDS_SHIFT;
-      let mut dirname = String::new();
-      fmt::Write::write_fmt(&mut dirname, format_args!("{:x}", fingerprint_prefix)).unwrap();
-      let dirname = dirname[0..1].to_owned();
-      let dir = root_path.join(dirname);
+    let shard_shift = Self::shard_shift(shard_count);
+
+    let mut envs = Vec::with_capacity(shard_count as usize);
+    for b in 0..shard_count {
+      let dir = root_path.join(format!("{:x}", b));
       fs::safe_create_dir_all(&dir)
         .map_err(|err| format!("Error making directory for store at {:?}: {:?}", dir, err))?;
+      let fingerprint_prefix = b.rotate_left(shard_shift as u32);
       envs.push((
         ShardedLmdb::make_env(&dir, max_size_per_shard)?,
         dir,
@@ -240,11 +273,23 @@ impl ShardedLmdb {
 
   // First Database is content, second is leases.
   pub fn get(&self, fingerprint: &Fingerprint) -> (Arc<Environment>, Database, Database) {
-    self.lmdbs[&(fingerprint.0[0] & 0xF0)].clone()
+    let (_, env, db1, db2) = self.get_raw(fingerprint.0[0]);
+    (env.clone(), *db1, *db2)
+  }
+
+  pub(crate) fn get_raw(
+    &self,
+    prefix_byte: u8,
+  ) -> &(PathBuf, Arc<Environment>, Database, Database) {
+    &self.lmdbs[&(prefix_byte & self.shard_fingerprint_mask)]
   }
 
   pub fn all_lmdbs(&self) -> Vec<(Arc<Environment>, Database, Database)> {
-    self.lmdbs.values().cloned().collect()
+    self
+      .lmdbs
+      .values()
+      .map(|(_, env, db1, db2)| (env.clone(), *db1, *db2))
+      .collect()
   }
 
   pub async fn remove(&self, fingerprint: Fingerprint) -> Result<bool, String> {
@@ -407,7 +452,9 @@ impl ShardedLmdb {
 
   #[allow(clippy::useless_conversion)] // False positive: https://github.com/rust-lang/rust-clippy/issues/3913
   pub fn compact(&self) -> Result<(), String> {
-    for (env, old_dir, _) in ShardedLmdb::envs(&self.root_path, self.max_size_per_shard)? {
+    for (env, old_dir, _) in
+      ShardedLmdb::envs(&self.root_path, self.max_size_per_shard, self.shard_count)?
+    {
       let new_dir = TempDir::new_in(old_dir.parent().unwrap()).expect("TODO");
       env
         .copy(new_dir.path(), EnvironmentCopyFlags::COMPACT)
@@ -436,3 +483,6 @@ impl ShardedLmdb {
     Ok(())
   }
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/rust/engine/sharded_lmdb/src/tests.rs
+++ b/src/rust/engine/sharded_lmdb/src/tests.rs
@@ -1,0 +1,40 @@
+use std::collections::HashMap;
+
+use task_executor::Executor;
+use tempfile::TempDir;
+
+use crate::{ShardedLmdb, DEFAULT_LEASE_TIME};
+
+fn new_store(shard_count: u8) -> (ShardedLmdb, TempDir) {
+  let tempdir = TempDir::new().unwrap();
+  let s = ShardedLmdb::new(
+    tempdir.path().to_owned(),
+    10_000_000,
+    Executor::new(),
+    DEFAULT_LEASE_TIME,
+    shard_count,
+  )
+  .unwrap();
+  (s, tempdir)
+}
+
+#[tokio::test]
+async fn shard_counts() {
+  let shard_counts = vec![1, 2, 4, 8, 16, 32, 64, 128];
+  for shard_count in shard_counts {
+    let (s, _) = new_store(shard_count);
+    assert_eq!(s.all_lmdbs().len(), shard_count as usize);
+
+    // Confirm that each database gets an even share.
+    let mut databases = HashMap::new();
+    for prefix_byte in 0u8..=255u8 {
+      *databases
+        .entry(s.get_raw(prefix_byte).0.clone())
+        .or_insert(0) += 1;
+    }
+    assert_eq!(databases.len(), shard_count as usize);
+    for (_, count) in databases {
+      assert_eq!(count, 256 / shard_count as usize);
+    }
+  }
+}

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -100,6 +100,7 @@ pub struct LocalStoreOptions {
   pub files_max_size_bytes: usize,
   pub directories_max_size_bytes: usize,
   pub lease_time: Duration,
+  pub shard_count: u8,
 }
 
 impl From<&LocalStoreOptions> for store::LocalOptions {
@@ -108,6 +109,7 @@ impl From<&LocalStoreOptions> for store::LocalOptions {
       files_max_size_bytes: lso.files_max_size_bytes,
       directories_max_size_bytes: lso.directories_max_size_bytes,
       lease_time: lso.lease_time,
+      shard_count: lso.shard_count,
     }
   }
 }
@@ -224,6 +226,7 @@ impl Core {
         local_store_options.process_cache_max_size_bytes,
         executor.clone(),
         local_store_options.lease_time,
+        local_store_options.shard_count,
       )
       .map_err(|err| format!("Could not initialize store for process cache: {:?}", err))?;
       Box::new(process_execution::cache::CommandRunner::new(

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -595,7 +595,12 @@ py_class!(class PyLocalStoreOptions |py| {
     files_max_size_bytes: usize,
     directories_max_size_bytes: usize,
     lease_time_millis: u64,
+    shard_count: u8,
   ) -> CPyResult<Self> {
+    if shard_count.count_ones() != 1 {
+        let err_string = format!("The local store shard count must be a power of two: got {}", shard_count);
+        return Err(PyErr::new::<exc::ValueError, _>(py, (err_string,)));
+    }
     Self::create_instance(py,
       LocalStoreOptions {
         store_dir: PathBuf::from(store_dir),
@@ -603,6 +608,7 @@ py_class!(class PyLocalStoreOptions |py| {
         files_max_size_bytes,
         directories_max_size_bytes,
         lease_time: Duration::from_millis(lease_time_millis),
+        shard_count,
       }
     )
   }


### PR DESCRIPTION
### Problem

LMDB currently uses hardcoded sharding in order to satisfy a usecase which we can no longer reproduce precisely. In order to gather real-world data about how much or little sharding is beneficial for our users, we should expose the ability to set the shard count.

### Solution

Implement support for using any small power-of-two as a shard count, and expose it as an advanced global option.

### Result

Users can experiment with various shard counts, and we can gather real-world data to potentially motivate changing the default shard count.

[ci skip-build-wheels]