### PR TITLE
Add `ExplicitlyProvidedDependencies` type

### DIFF
--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1574,6 +1574,25 @@ class DependenciesRequest(EngineAwareParameter):
         return self.field.address.spec
 
 
+@dataclass(frozen=True)
+class ExplicitlyProvidedDependencies:
+    """The literal addresses from a BUILD file `dependencies` field.
+
+    Almost always, you should use `await Get(Addresses, DependenciesRequest)` instead, which will
+    consider dependency injection and inference and apply ignores. However, this type can be
+    useful particularly within inference/injection rules to see if a user already explicitly
+    provided a dependency.
+
+    Resolve using `await Get(ExplicitlyProvidedDependencies, DependenciesRequest)`.
+
+    Note that the `includes` are not filtered based on the `ignores`: this type preserves exactly
+    what was in the BUILD file.
+    """
+
+    includes: FrozenOrderedSet[Address]
+    ignored: FrozenOrderedSet[Address]
+
+
 @union
 @dataclass(frozen=True)
 class InjectDependenciesRequest(EngineAwareParameter, ABC):


### PR DESCRIPTION
We want to add a warning to dependency inference when we detect ambiguous modules so cannot infer, but to turn off this warning if the user had provided an explicit dependency that would fix the ambiguity. This requires that we can access the explicitly provided dependencies within the BUILD file, though, which requires parsing raw strings into well-formed `Address` objects.

[ci skip-rust]
[ci skip-build-wheels]