### PR TITLE
Dependency inference: can disambiguate modules with multiple owners via `!` ignores

### DIFF
--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -808,7 +808,7 @@ async def resolve_dependencies(
             *itertools.chain.from_iterable(inferred),
             *special_cased,
         )
-        if addr not in explicitly_provided.ignored
+        if addr not in explicitly_provided.ignores
     }
     return Addresses(sorted(result))
 

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -1341,7 +1341,7 @@ def test_explicitly_provided_dependencies(dependencies_rule_runner: RuleRunner) 
     )
     expected_addresses = {Address("a/b/c"), Address("files", relative_file_path="f.txt")}
     assert set(result.includes) == expected_addresses
-    assert set(result.ignored) == {
+    assert set(result.ignores) == {
         *expected_addresses,
         Address("files", relative_file_path="transitive_exclude.txt"),
     }

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1590,7 +1590,7 @@ class ExplicitlyProvidedDependencies:
     """
 
     includes: FrozenOrderedSet[Address]
-    ignored: FrozenOrderedSet[Address]
+    ignores: FrozenOrderedSet[Address]
 
 
 @union


### PR DESCRIPTION
We are soon adding a warning when dependency inference fails because >1 target exports the same module. For users to silence that warning, they either must explicitly depend on one of the ambiguous modules _or_ ignore some/all of them. Why allow ignores? A user might end up wanting to ignore all of the ambiguous modules so that the module is never included.

To be consistent, because we allow ignoring all ambiguous modules to turn off dep inference for that module, ignoring all _but one_ of the ambiguous targets will disambiguate the inference. (In practice, we expect it to be more likely users will opt-in to the specific ambiguous target they want, rather than opting out of all but one.)

[ci skip-rust]
[ci skip-build-wheels]