### PR TITLE
Don't disambiguate module via `!` ignores if user already disambiguated via an include

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -282,12 +282,17 @@ class PythonModuleOwners:
                 "https://github.com/pantsbuild/pants/issues/new."
             )
 
+    def _unambiguous_via_includes(
+        self, explicitly_provided: ExplicitlyProvidedDependencies
+    ) -> bool:
+        return bool(set(self.ambiguous).intersection(explicitly_provided.includes))
+
     def disambiguated_via_ignores(
         self, explicitly_provided_deps: ExplicitlyProvidedDependencies
     ) -> Address | None:
         """If ignores in the `dependencies` field ignore all but one of the ambiguous owners, the
         remaining owner becomes unambiguous."""
-        if not self.ambiguous:
+        if not self.ambiguous or self._unambiguous_via_includes(explicitly_provided_deps):
             return None
         disambiguated = set(self.ambiguous) - explicitly_provided_deps.ignores
         return list(disambiguated)[0] if len(disambiguated) == 1 else None


### PR DESCRIPTION
If a user has already chosen which target to use for a module with >1 owning targets, then we should not attempt to further infer dependencies - it would be confusing if we end up inferring a dep different than their include, resulting in two owning targets for the same module.

Fixes an edge case from https://github.com/pantsbuild/pants/pull/11786.

[ci skip-rust]
[ci skip-build-wheels]