### PR TITLE
Warn when dependency inference is not used due to ambiguity from >1 target exporting the same Python module

### DIFF
--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -140,6 +140,16 @@ async def inject_lambda_handler_dependency(
     )
     module, _, _func = handler.val.partition(":")
     owners = await Get(PythonModuleOwners, PythonModule(module))
+    address = original_tgt.target.address
+    owners.maybe_warn_of_ambiguity(
+        explicitly_provided_deps,
+        address,
+        context=(
+            f"The python_awslambda target {address} has the field "
+            f"`handler={repr(original_tgt.target[PythonAwsLambdaHandlerField].value)}`, which maps "
+            f"to the Python module `{module}`"
+        ),
+    )
     maybe_disambiguated = owners.disambiguated_via_ignores(explicitly_provided_deps)
     unambiguous_owners = owners.unambiguous or (
         (maybe_disambiguated,) if maybe_disambiguated else ()

--- a/src/python/pants/backend/awslambda/python/target_types_test.py
+++ b/src/python/pants/backend/awslambda/python/target_types_test.py
@@ -94,7 +94,7 @@ def test_resolve_handler(rule_runner: RuleRunner) -> None:
         assert_resolved("*.py:func", expected="doesnt matter")
 
 
-def test_inject_handler_dependency(rule_runner: RuleRunner) -> None:
+def test_inject_handler_dependency(rule_runner: RuleRunner, caplog) -> None:
     rule_runner.add_to_build_file(
         "",
         dedent(
@@ -148,24 +148,49 @@ def test_inject_handler_dependency(rule_runner: RuleRunner) -> None:
     assert_injected(Address("project", target_name="first_party"), expected=None)
     rule_runner.set_options([])
 
-    # Test that ignores can disambiguate an otherwise ambiguous handler.
+    # Warn if there's ambiguity, meaning we cannot infer.
+    caplog.clear()
     rule_runner.create_file("project/ambiguous.py")
     rule_runner.add_to_build_file(
         "project",
         dedent(
             """\
-            python_library(name="ambiguous1", sources=["ambiguous.py"])
-            python_library(name="ambiguous2", sources=["ambiguous.py"])
+            python_library(name="dep1", sources=["ambiguous.py"])
+            python_library(name="dep2", sources=["ambiguous.py"])
+            python_awslambda(
+                name="ambiguous",
+                handler='ambiguous.py:func',
+                runtime='python3.7',
+            )
+            """
+        ),
+    )
+    assert_injected(Address("project", target_name="ambiguous"), expected=None)
+    assert len(caplog.records) == 1
+    assert (
+        "project:ambiguous has the field `handler='ambiguous.py:func'`, which maps to the Python "
+        "module `project.ambiguous`"
+    ) in caplog.text
+    assert "['project/ambiguous.py:dep1', 'project/ambiguous.py:dep2']" in caplog.text
+
+    # Test that ignores can disambiguate an otherwise ambiguous handler. Ensure we don't log a
+    # warning about ambiguity.
+    caplog.clear()
+    rule_runner.add_to_build_file(
+        "project",
+        dedent(
+            """\
             python_awslambda(
                 name="disambiguated",
                 handler='ambiguous.py:func',
                 runtime='python3.7',
-                dependencies=["!./ambiguous.py:ambiguous2"],
+                dependencies=["!./ambiguous.py:dep2"],
             )
             """
         ),
     )
     assert_injected(
         Address("project", target_name="disambiguated"),
-        expected=Address("project", target_name="ambiguous1", relative_file_path="ambiguous.py"),
+        expected=Address("project", target_name="dep1", relative_file_path="ambiguous.py"),
     )
+    assert not caplog.records

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -34,7 +34,6 @@ from pants.engine.unions import UnionRule
 from pants.option.global_options import OwnersNotFoundBehavior
 from pants.option.subsystem import Subsystem
 from pants.python.python_setup import PythonSetup
-from pants.util.docutil import docs_url
 
 logger = logging.getLogger(__name__)
 

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import itertools
+import logging
 from typing import cast
 
 from pants.backend.python.dependency_inference import import_parser, module_mapper
@@ -33,6 +34,9 @@ from pants.engine.unions import UnionRule
 from pants.option.global_options import OwnersNotFoundBehavior
 from pants.option.subsystem import Subsystem
 from pants.python.python_setup import PythonSetup
+from pants.util.docutil import docs_url
+
+logger = logging.getLogger(__name__)
 
 
 class PythonInferSubsystem(Subsystem):
@@ -155,8 +159,14 @@ async def infer_python_dependencies_via_imports(
         for imported_module in relevant_imports
     )
     merged_result: set[Address] = set()
-    for owners in owners_per_import:
+    for owners, imp in zip(owners_per_import, relevant_imports):
         merged_result.update(owners.unambiguous)
+        address = wrapped_tgt.target.address
+        owners.maybe_warn_of_ambiguity(
+            explicitly_provided_deps,
+            address,
+            context=f"The target {address} imports `{imp}`",
+        )
         maybe_disambiguated = owners.disambiguated_via_ignores(explicitly_provided_deps)
         if maybe_disambiguated:
             merged_result.add(maybe_disambiguated)

--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -112,6 +112,16 @@ async def inject_pex_binary_entry_point_dependency(
     if entry_point.val is None:
         return InjectedDependencies()
     owners = await Get(PythonModuleOwners, PythonModule(entry_point.val.module))
+    address = original_tgt.target.address
+    owners.maybe_warn_of_ambiguity(
+        explicitly_provided_deps,
+        address,
+        context=(
+            f"The pex_binary target {address} has the field "
+            f"`entry_point={repr(original_tgt.target[PexEntryPointField].value.spec)}`, which "
+            f"maps to the Python module `{entry_point.val.module}`"
+        ),
+    )
     maybe_disambiguated = owners.disambiguated_via_ignores(explicitly_provided_deps)
     unambiguous_owners = owners.unambiguous or (
         (maybe_disambiguated,) if maybe_disambiguated else ()


### PR DESCRIPTION
This is one of our most common gotchas.

Note that users can disable this warning either by explicitly including one of the ambiguous targets, or by using `!` ignores so that <=1 targets remain.

Example:

> The target build-support/bin/reversion_test.py:tests imports `reversion.reversion`, but Pants cannot safely infer a dependency because >1 target exports this module, so it is ambiguous which to use: ['build-support/bin/reversion.py', 'build-support/bin/reversion.py:lib2'].
> 
> Please explicitly include the dependency you want in the `dependencies` field of build-support/bin/reversion_test.py:tests, or ignore the ones you do not want by prefixing with `!` or `!!` so that <=1 targets are left.
> 
> Alternatively, you can remove the ambiguity by deleting/changing some of the targets so that only 1 target exports this module. Refer to https://www.pantsbuild.org/v2.4/docs/troubleshooting#import-errors-and-missing-dependencies.

[ci skip-rust]
[ci skip-build-wheels]