### PR TITLE
Fix RuleRunner to use --process-execution-local-cleanup.

### DIFF
--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -106,7 +106,7 @@ class RuleRunner:
             print(f"Preserving rule runner temporary directories at {root_dir}.", file=sys.stderr)
             bootstrap_args.extend(
                 [
-                    "--no-process-execution-cleanup-local-dirs",
+                    "--no-process-execution-local-cleanup",
                     f"--local-execution-root-dir={root_dir}",
                 ]
             )


### PR DESCRIPTION
This was made the preferred option name in #11785.

[ci skip-rust]
[ci skip-build-wheels]