### PR TITLE
Upgrade to Rust 1.51.0

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.49.0"
+channel = "1.51.0"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/11631.

[ci skip-build-wheels]