### PR TITLE
 Surround docs urls with brackets.

### DIFF
--- a/src/python/pants/backend/awslambda/python/rules.py
+++ b/src/python/pants/backend/awslambda/python/rules.py
@@ -40,7 +40,7 @@ from pants.engine.target import (
     targets_with_sources_types,
 )
 from pants.engine.unions import UnionMembership, UnionRule
-from pants.util.docutil import docs_url
+from pants.util.docutil import bracketed_docs_url
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
@@ -119,7 +119,7 @@ async def package_python_awslambda(
             "files targets, but Pants will not include them in the built Lambda. Filesystem APIs "
             "like `open()` are not able to load files within the binary itself; instead, they "
             "read from the current working directory."
-            f"\n\nInstead, use `resources` targets. See {docs_url('resources')}."
+            f"\n\nInstead, use `resources` targets. See {bracketed_docs_url('resources')}."
             f"\n\nFiles targets dependencies: {files_addresses}"
         )
 

--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -29,7 +29,7 @@ from pants.engine.target import (
 from pants.engine.unions import UnionRule
 from pants.source.filespec import Filespec
 from pants.source.source_root import SourceRoot, SourceRootRequest
-from pants.util.docutil import docs_url
+from pants.util.docutil import bracketed_docs_url
 
 
 class PythonAwsLambdaHandlerField(StringField, AsyncFieldMixin, SecondaryOwnerMixin):
@@ -195,7 +195,7 @@ class PythonAWSLambda(Target):
     )
     help = (
         "A self-contained Python function suitable for uploading to AWS Lambda.\n\nSee "
-        f"{docs_url('awslambda-python')}."
+        f"{bracketed_docs_url('awslambda-python')}."
     )
 
 

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -13,12 +13,14 @@ from pants.engine.unions import UnionRule
 from pants.option.custom_types import target_option
 from pants.option.ranked_value import Rank
 from pants.option.subsystem import Subsystem
-from pants.util.docutil import docs_url
+from pants.util.docutil import bracketed_docs_url
 
 
 class PythonProtobufSubsystem(Subsystem):
     options_scope = "python-protobuf"
-    help = f"Options related to the Protobuf Python backend.\n\nSee {docs_url('protobuf')}."
+    help = (
+        f"Options related to the Protobuf Python backend.\n\nSee {bracketed_docs_url('protobuf')}."
+    )
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/codegen/protobuf/target_types.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.engine.target import COMMON_TARGET_FIELDS, BoolField, Dependencies, Sources, Target
-from pants.util.docutil import docs_url
+from pants.util.docutil import bracketed_docs_url
 
 
 # NB: We subclass Dependencies so that specific backends can add dependency injection rules to
@@ -25,4 +25,4 @@ class ProtobufGrpcToggle(BoolField):
 class ProtobufLibrary(Target):
     alias = "protobuf_library"
     core_fields = (*COMMON_TARGET_FIELDS, ProtobufDependencies, ProtobufSources, ProtobufGrpcToggle)
-    help = f"Protobuf files used to generate various languages.\n\nSee {docs_url('protobuf')}."
+    help = f"Protobuf files used to generate various languages.\n\nSee {bracketed_docs_url('protobuf')}."

--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -20,7 +20,7 @@ from pants.engine.addresses import Address
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import ExplicitlyProvidedDependencies, SourcesPathsRequest, Targets
 from pants.engine.unions import UnionMembership, UnionRule, union
-from pants.util.docutil import docs_url
+from pants.util.docutil import bracketed_docs_url
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized_method
@@ -335,7 +335,7 @@ class PythonModuleOwners:
             f"with `!` or `!!` so that <=1 targets are left."
             f"\n\nAlternatively, you can remove the ambiguity by deleting/changing some of the "
             f"targets so that only 1 target exports this module. Refer to "
-            f"{docs_url('troubleshooting#import-errors-and-missing-dependencies')}."
+            f"{bracketed_docs_url('troubleshooting#import-errors-and-missing-dependencies')}."
         )
 
     def disambiguated_via_ignores(

--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -44,7 +44,7 @@ from pants.engine.target import (
     targets_with_sources_types,
 )
 from pants.engine.unions import UnionMembership, UnionRule
-from pants.util.docutil import docs_url
+from pants.util.docutil import bracketed_docs_url
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized_property
 
@@ -133,7 +133,7 @@ async def package_pex_binary(
             "are not able to load files within the binary itself; instead, they read from the "
             "current working directory."
             "\n\nInstead, use `resources` targets or wrap this `pex_binary` in an `archive`. See "
-            f"{docs_url('resources')}."
+            f"{bracketed_docs_url('resources')}."
             f"\n\nFiles targets dependencies: {files_addresses}"
         )
 

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -66,7 +66,7 @@ from pants.engine.target import (
 from pants.engine.unions import UnionMembership, UnionRule, union
 from pants.option.subsystem import Subsystem
 from pants.python.python_setup import PythonSetup
-from pants.util.docutil import docs_url
+from pants.util.docutil import bracketed_docs_url
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized_property
 from pants.util.meta import frozen_after_init
@@ -92,7 +92,7 @@ class OwnershipError(Exception):
 
     def __init__(self, msg: str):
         super().__init__(
-            f"{msg} See {docs_url('python-distributions')} for "
+            f"{msg} See {bracketed_docs_url('python-distributions')} for "
             f"how python_library targets are mapped to distributions."
         )
 

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -9,7 +9,7 @@ from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
 from pants.engine.addresses import UnparsedAddressInputs
 from pants.option.custom_types import file_option, shell_str, target_option
-from pants.util.docutil import docs_url
+from pants.util.docutil import bracketed_docs_url
 
 
 class Pylint(PythonToolBase):
@@ -55,7 +55,7 @@ class Pylint(PythonToolBase):
                 "example, if your plugin is at `build-support/pylint/custom_plugin.py`, add "
                 "'build-support/pylint' to `[source].root_patterns` in `pants.toml`. This is "
                 "necessary for Pants to know how to tell Pylint to discover your plugin. See "
-                f"{docs_url('source-roots')}\n\nYou must also set `load-plugins=$module_name` in "
+                f"{bracketed_docs_url('source-roots')}\n\nYou must also set `load-plugins=$module_name` in "
                 "your Pylint config file, and set the `[pylint].config` option in `pants.toml`."
                 "\n\nWhile your plugin's code can depend on other first-party code and third-party "
                 "requirements, all first-party dependencies of the plugin must live in the same "

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -41,7 +41,7 @@ from pants.engine.target import (
 from pants.option.subsystem import Subsystem
 from pants.python.python_setup import PythonSetup
 from pants.source.filespec import Filespec
-from pants.util.docutil import docs_url
+from pants.util.docutil import bracketed_docs_url
 from pants.util.frozendict import FrozenDict
 
 logger = logging.getLogger(__name__)
@@ -64,7 +64,7 @@ class InterpreterConstraintsField(StringSequenceField):
         "more than one element to OR the constraints, e.g. `['PyPy==3.7.*', 'CPython==3.7.*']` "
         "means either PyPy 3.7 _or_ CPython 3.7.\n\nIf the field is not set, it will default to "
         "the option `[python-setup].interpreter_constraints`.\n\nSee "
-        f"{docs_url('python-interpreter-compatibility')}."
+        f"{bracketed_docs_url('python-interpreter-compatibility')}."
     )
 
     def value_or_global_default(self, python_setup: PythonSetup) -> Tuple[str, ...]:
@@ -387,7 +387,7 @@ class PexBinary(Target):
     help = (
         "A Python target that can be converted into an executable PEX file.\n\nPEX files are "
         "self-contained executable files that contain a complete Python environment capable of "
-        f"running the target. For more information, see {docs_url('pex-files')}."
+        f"running the target. For more information, see {bracketed_docs_url('pex-files')}."
     )
 
 
@@ -469,7 +469,7 @@ class PythonTests(Target):
     help = (
         "Python tests, written in either Pytest style or unittest style.\n\nAll test util code, "
         "other than `conftest.py`, should go into a dedicated `python_library()` target and then "
-        f"be included in the `dependencies` field.\n\nSee {docs_url('python-test-goal')}."
+        f"be included in the `dependencies` field.\n\nSee {bracketed_docs_url('python-test-goal')}."
     )
 
 
@@ -611,7 +611,7 @@ class PythonRequirementLibrary(Target):
         "Python requirements inline in a BUILD file. If you have a `requirements.txt` file "
         "already, you can instead use the macro `python_requirements()` to convert each "
         "requirement into a `python_requirement_library()` target automatically.\n\nSee "
-        f"{docs_url('python-third-party-dependencies')}."
+        f"{bracketed_docs_url('python-third-party-dependencies')}."
     )
 
 
@@ -685,7 +685,7 @@ class PythonProvidesField(ScalarField, ProvidesField):
     required = True
     help = (
         "The setup.py kwargs for the external artifact built from this target.\n\nSee "
-        f"{docs_url('python-distributions')}."
+        f"{bracketed_docs_url('python-distributions')}."
     )
 
     @classmethod
@@ -705,7 +705,7 @@ class SetupPyCommandsField(StringSequenceField):
         "The runtime commands to invoke setup.py with to create the distribution, e.g. "
         '["bdist_wheel", "--python-tag=py36.py37", "sdist"].\n\nIf empty or unspecified, '
         "will just create a chroot with a setup() function.\n\nSee "
-        f"{docs_url('python-distributions')}."
+        f"{bracketed_docs_url('python-distributions')}."
     )
 
 

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -40,7 +40,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import FieldSet, Target, TransitiveTargets, TransitiveTargetsRequest
 from pants.engine.unions import UnionRule
 from pants.python.python_setup import PythonSetup
-from pants.util.docutil import docs_url
+from pants.util.docutil import bracketed_docs_url
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 from pants.util.strutil import pluralize
@@ -102,7 +102,7 @@ def check_and_warn_if_python_version_configured(
         logger.warning(
             f"You set {formatted_configured}. Normally, Pants would automatically set this for you "
             "based on your code's interpreter constraints "
-            f"({docs_url('python-interpreter-compatibility')}). Instead, it will "
+            f"({bracketed_docs_url('python-interpreter-compatibility')}). Instead, it will "
             "use what you set.\n\n(Automatically setting the option allows Pants to partition your "
             "targets by their constraints, so that, for example, you can run MyPy on Python 2-only "
             "code and Python 3-only code at the same time. This feature may no longer work.)"

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -77,7 +77,7 @@ from pants.engine.target import (
 from pants.engine.unions import UnionMembership
 from pants.option.global_options import GlobalOptions, OwnersNotFoundBehavior
 from pants.source.filespec import matches_filespec
-from pants.util.docutil import docs_url
+from pants.util.docutil import bracketed_docs_url
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 
@@ -410,7 +410,7 @@ def _log_or_raise_unmatched_owners(
         msgs.append(
             f"No owning targets could be found for the file `{file_path}`.\n\nPlease check "
             f"that there is a BUILD file in `{file_path.parent}` with a target whose `sources` "
-            f"field includes `{file_path}`. See {docs_url('targets')} for more "
+            f"field includes `{file_path}`. See {bracketed_docs_url('targets')} for more "
             f"information on target definitions.{option_msg}"
         )
 

--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -12,7 +12,7 @@ from pants.base.exceptions import MappingError
 from pants.base.parse_context import ParseContext
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.internals.target_adaptor import TargetAdaptor
-from pants.util.docutil import docs_url
+from pants.util.docutil import bracketed_docs_url
 from pants.util.frozendict import FrozenDict
 
 
@@ -105,7 +105,7 @@ class Parser:
             original = e.args[0].capitalize()
             help_str = (
                 "If you expect to see more symbols activated in the below list,"
-                f" refer to {docs_url('enabling-backends')} for all available"
+                f" refer to {bracketed_docs_url('enabling-backends')} for all available"
                 " backends to activate."
             )
 
@@ -142,6 +142,6 @@ def error_on_imports(build_file_content: str, filepath: str) -> None:
         raise ParseError(
             f"Import used in {filepath} at line {lineno}. Import statements are banned in "
             "BUILD files because they can easily break Pants caching and lead to stale results. "
-            f"\n\nInstead, consider writing a macro ({docs_url('macros')}) or "
-            f"writing a plugin ({docs_url('plugins-overview')}."
+            f"\n\nInstead, consider writing a macro ({bracketed_docs_url('macros')}) or "
+            f"writing a plugin ({bracketed_docs_url('plugins-overview')}."
         )

--- a/src/python/pants/engine/internals/parser_test.py
+++ b/src/python/pants/engine/internals/parser_test.py
@@ -7,7 +7,7 @@ import pytest
 
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.internals.parser import BuildFilePreludeSymbols, ParseError, Parser
-from pants.util.docutil import docs_url
+from pants.util.docutil import bracketed_docs_url
 from pants.util.frozendict import FrozenDict
 
 
@@ -37,7 +37,7 @@ def test_unrecogonized_symbol() -> None:
         assert str(exc.value) == (
             f"Name 'fake' is not defined.\n\n{dym}"
             "If you expect to see more symbols activated in the below list,"
-            f" refer to {docs_url('enabling-backends')} for all available"
+            f" refer to {bracketed_docs_url('enabling-backends')} for all available"
             " backends to activate.\n\n"
             f"All registered symbols: ['caof', {fmt_extra_sym}'obj', 'prelude', 'tgt']"
         )

--- a/src/python/pants/goal/anonymous_telemetry.py
+++ b/src/python/pants/goal/anonymous_telemetry.py
@@ -22,14 +22,14 @@ from pants.engine.streaming_workunit_handler import (
 )
 from pants.engine.unions import UnionRule
 from pants.option.subsystem import Subsystem
-from pants.util.docutil import docs_url
+from pants.util.docutil import bracketed_docs_url
 
 logger = logging.getLogger(__name__)
 
 
 _bugout_access_token = "3ae76900-9a68-4a87-a127-7c9f179d7272"
 _bugout_journal_id = "801e9b3c-6b03-40a7-870f-5b25d326da66"
-_telemetry_docs_url = docs_url("anonymous-telemetry")
+_telemetry_docs_url = bracketed_docs_url("anonymous-telemetry")
 _telemetry_docs_referral = f"See {_telemetry_docs_url} for details"
 
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -31,7 +31,7 @@ from pants.option.options import Options
 from pants.option.scope import GLOBAL_SCOPE
 from pants.option.subsystem import Subsystem
 from pants.util.dirutil import fast_relpath_optional
-from pants.util.docutil import docs_url
+from pants.util.docutil import bracketed_docs_url
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import OrderedSet
 
@@ -487,7 +487,7 @@ class GlobalOptions(Subsystem):
             help="Use this Pants version. Note that Pants only uses this to verify that you are "
             "using the requested version, as Pants cannot dynamically change the version it "
             "is using once the program is already running.\n\nIf you use the `./pants` script from "
-            f"{docs_url('installation')}, however, changing the value in your "
+            f"{bracketed_docs_url('installation')}, however, changing the value in your "
             "`pants.toml` will cause the new version to be installed and run automatically.\n\n"
             "Run `./pants --version` to check what is being used.",
         )
@@ -1157,7 +1157,7 @@ class GlobalOptions(Subsystem):
             metavar="[+-]tag1,tag2,...",
             help=(
                 "Include only targets with these tags (optional '+' prefix) or without these "
-                f"tags ('-' prefix). See {docs_url('advanced-target-selection')}."
+                f"tags ('-' prefix). See {bracketed_docs_url('advanced-target-selection')}."
             ),
         )
         register(
@@ -1217,7 +1217,7 @@ class GlobalOptions(Subsystem):
             default=[],
             help=(
                 "Python files to evaluate and whose symbols should be exposed to all BUILD files. "
-                f"See {docs_url('macros')}."
+                f"See {bracketed_docs_url('macros')}."
             ),
         )
         register(

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -17,7 +17,7 @@ from pants.engine.fs import PathGlobs, Paths
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import Target
 from pants.option.subsystem import Subsystem
-from pants.util.docutil import docs_url
+from pants.util.docutil import bracketed_docs_url
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized_method
@@ -42,7 +42,9 @@ class SourceRootError(Exception):
     """An error related to SourceRoot computation."""
 
     def __init__(self, msg: str):
-        super().__init__(f"{msg}See {docs_url('source-roots')} for how to define source roots.")
+        super().__init__(
+            f"{msg}See {bracketed_docs_url('source-roots')} for how to define source roots."
+        )
 
 
 class InvalidSourceRootPatternError(SourceRootError):
@@ -111,7 +113,7 @@ class SourceRootConfig(Subsystem):
             "`<buildroot>/project1/src/python`. A `*` wildcard will match a single path segment, "
             "e.g., `src/*` will match `<buildroot>/src/python` and `<buildroot>/src/rust`. "
             "Use `/` to signify that the buildroot itself is a source root. "
-            f"See {docs_url('source-roots')}",
+            f"See {bracketed_docs_url('source-roots')}",
         )
         register(
             "--marker-filenames",

--- a/src/python/pants/util/docutil.py
+++ b/src/python/pants/util/docutil.py
@@ -12,6 +12,10 @@ def terminal_width(*, fallback: int = 96, padding: int = 2) -> int:
     return shutil.get_terminal_size(fallback=(fallback, 24)).columns - padding
 
 
-def docs_url(slug: str) -> str:
-    """Link to the Pants docs using the current version of Pants."""
-    return f"https://www.pantsbuild.org/v{MAJOR_MINOR}/docs/{slug}"
+def bracketed_docs_url(slug: str) -> str:
+    """Link to the Pants docs using the current version of Pants.
+
+    Returned URL is surrounded by square brackets, to prevent linkifiers from considering any
+    adjacent punctuation (such as a period at the end of a sentence) as part of the URL.
+    """
+    return f"[https://www.pantsbuild.org/v{MAJOR_MINOR}/docs/{slug}]"

--- a/src/python/pants/vcs/changed.py
+++ b/src/python/pants/vcs/changed.py
@@ -16,7 +16,7 @@ from pants.engine.internals.graph import Owners, OwnersRequest
 from pants.engine.rules import Get, collect_rules, rule
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.subsystem import Subsystem
-from pants.util.docutil import docs_url
+from pants.util.docutil import bracketed_docs_url
 from pants.vcs.git import Git
 
 
@@ -90,7 +90,7 @@ class Changed(Subsystem):
     options_scope = "changed"
     help = (
         "Tell Pants to detect what files and targets have changed from Git.\n\nSee "
-        f"{docs_url('advanced-target-selection')}."
+        f"{bracketed_docs_url('advanced-target-selection')}."
     )
 
     @classmethod

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -256,12 +256,12 @@ pub fn val_to_log_level(obj: &PyObject) -> Result<log::Level, String> {
 }
 
 /// Link to the Pants docs using the current version of Pants.
-pub fn docs_url(slug: &str) -> String {
+pub fn bracketed_docs_url(slug: &str) -> String {
   let gil = Python::acquire_gil();
   let py = gil.python();
   let docutil = py.import("pants.util.docutil").unwrap();
   docutil
-    .call(py, "docs_url", (slug,), None)
+    .call(py, "bracketed_docs_url", (slug,), None)
     .unwrap()
     .extract(py)
     .unwrap()

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -499,7 +499,7 @@ fn unmatched_globs_additional_context() -> Option<String> {
     "\n\nDo the file(s) exist? If so, check if the file(s) are in your `.gitignore` or the global \
     `pants_ignore` option, which may result in Pants not being able to see the file(s) even though \
     they exist on disk. Refer to {}.",
-    externs::docs_url("troubleshooting#pants-cannot-find-a-file-in-your-project")
+    externs::bracketed_docs_url("troubleshooting#pants-cannot-find-a-file-in-your-project")
   ))
 }
 


### PR DESCRIPTION
Auto-linkifiers may think surrounding punctuation, such as the
period at the end of a sentence, is part of the URL, and generate
a broken link. This actually happens in readme.com, and may happen elsewhere.
    
[ci skip-build-wheels]
