### PR TITLE
Added tags to anonymous telemetry

### DIFF
--- a/src/python/pants/goal/anonymous_telemetry.py
+++ b/src/python/pants/goal/anonymous_telemetry.py
@@ -166,6 +166,7 @@ class AnonymousTelemetryCallback(WorkunitsCallback):
                         f"user:{telemetry_data.get('user_id', 'UNKNOWN')}",
                         f"machine:{telemetry_data.get('machine_id', 'UNKNOWN')}",
                         f"duration:{telemetry_data.get('duration', '0')}",
+                        f"outcome:{telemetry_data.get('outcome', 'UNKNOWN')}",
                     ]
                     + [f"goal:{goal}" for goal in telemetry_data.get("standard_goals", [])]
                 )

--- a/src/python/pants/goal/anonymous_telemetry.py
+++ b/src/python/pants/goal/anonymous_telemetry.py
@@ -162,8 +162,12 @@ class AnonymousTelemetryCallback(WorkunitsCallback):
                     system_tags
                     + [
                         f"pants_version:{telemetry_data.get('pants_version')}",
+                        f"repo:{repo_id}",
+                        f"user:{telemetry_data.get('user_id', 'UNKNOWN')}",
+                        f"machine:{telemetry_data.get('machine_id', 'UNKNOWN')}",
+                        f"duration:{telemetry_data.get('duration', '0')}",
                     ]
-                    + [f"goal:{goal}" for goal in telemetry_data.get("goals", [])]
+                    + [f"goal:{goal}" for goal in telemetry_data.get("standard_goals", [])]
                 )
 
                 report = Report(


### PR DESCRIPTION
All tags were already present as data in the message body. No new information is being reported.

Just added this information as tags for more efficient aggregation + querying on Bugout.

Tags added to repos in this commit:
1. `repo:<repo_id>`
2. `user:<user_id>` (if defined in report body; else the tag is `user:UNKNOWN`)
3. `machine:<machine_id>` (if defined in report body; else the tag is `machine:UNKNOWN`)
4. `duration:<duration_seconds>` (if defined in report body; else the tag is `duration:0`)

Also fixed a bug where goal information was being extracted from the non-existent `"goals"` key in `telemetry_data`. Updated this to use the `"standard_goals"` key.