### PR TITLE
Fix misleading docs for `[mypy].skip`

### DIFF
--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -30,7 +30,7 @@ class MyPy(PythonToolBase):
             "--skip",
             type=bool,
             default=False,
-            help=f"Don't use MyPy when running `{register.bootstrap.pants_bin_name} lint`.",
+            help=f"Don't use MyPy when running `{register.bootstrap.pants_bin_name} typecheck`.",
         )
         register(
             "--args",


### PR DESCRIPTION
MyPy used to run under `lint`, until we added `typecheck`.

[ci skip-rust]
[ci skip-build-wheels]