### PR TITLE
Fix transitive excludes for generating setup.py

### DIFF
--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -70,6 +70,7 @@ from pants.util.docutil import docs_url
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized_property
 from pants.util.meta import frozen_after_init
+from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.strutil import ensure_text
 
 logger = logging.getLogger(__name__)
@@ -362,7 +363,10 @@ async def package_python_dist(
     field_set: PythonDistributionFieldSet,
     python_setup: PythonSetup,
 ) -> BuiltPackage:
-    transitive_targets = await Get(TransitiveTargets, TransitiveTargetsRequest([field_set.address]))
+    transitive_targets = await Get(
+        TransitiveTargets,
+        TransitiveTargetsRequest([field_set.address], include_special_cased_deps=True),
+    )
     exported_target = ExportedTarget(transitive_targets.roots[0])
     interpreter_constraints = PexInterpreterConstraints.create_from_targets(
         transitive_targets.closure, python_setup
@@ -474,12 +478,15 @@ async def determine_setup_kwargs(
 async def generate_chroot(request: SetupPyChrootRequest) -> SetupPyChroot:
     exported_target = request.exported_target
     exported_addr = exported_target.target.address
-
     owned_deps, transitive_targets = await MultiGet(
         Get(OwnedDependencies, DependencyOwner(exported_target)),
-        Get(TransitiveTargets, TransitiveTargetsRequest([exported_target.target.address])),
+        Get(
+            TransitiveTargets,
+            TransitiveTargetsRequest(
+                [exported_target.target.address], include_special_cased_deps=True
+            ),
+        ),
     )
-
     # files() targets aren't owned by a single exported target - they aren't code, so
     # we allow them to be in multiple dists. This is helpful for, e.g., embedding
     # a standard license file in a dist.
@@ -490,7 +497,6 @@ async def generate_chroot(request: SetupPyChrootRequest) -> SetupPyChroot:
         Get(SetupPySources, SetupPySourcesRequest(targets, py2=request.py2)),
         Get(ExportedTargetRequirements, DependencyOwner(exported_target)),
     )
-
     # Generate the kwargs for the setup() call. In addition to using the kwargs that are either
     # explicitly provided or generated via a user's plugin, we add additional kwargs based on the
     # resolved requirements and sources.
@@ -617,9 +623,11 @@ async def get_requirements(
     setup_py_generation: SetupPyGeneration,
 ) -> ExportedTargetRequirements:
     transitive_targets = await Get(
-        TransitiveTargets, TransitiveTargetsRequest([dep_owner.exported_target.target.address])
+        TransitiveTargets,
+        TransitiveTargetsRequest(
+            [dep_owner.exported_target.target.address], include_special_cased_deps=True
+        ),
     )
-
     ownable_tgts = [
         tgt for tgt in transitive_targets.closure if is_ownable_target(tgt, union_membership)
     ]
@@ -637,11 +645,32 @@ async def get_requirements(
     # then it's owned by an exported target ET, and so R will be in the requirements for ET, and we
     # will require ET.
     direct_deps_tgts = await MultiGet(
-        Get(Targets, DependenciesRequest(tgt.get(Dependencies))) for tgt in owned_by_us
+        Get(
+            Targets,
+            DependenciesRequest(tgt.get(Dependencies), include_special_cased_deps=True),
+        )
+        for tgt in owned_by_us
     )
+
+    transitive_excludes: FrozenOrderedSet[Target] = FrozenOrderedSet()
+
+    uneval_trans_excl = [
+        tgt.get(Dependencies).unevaluated_transitive_excludes for tgt in transitive_targets.closure
+    ]
+    if uneval_trans_excl:
+        nested_trans_excl = await MultiGet(
+            Get(Targets, UnparsedAddressInputs, unparsed) for unparsed in uneval_trans_excl
+        )
+        transitive_excludes = FrozenOrderedSet(
+            itertools.chain.from_iterable(excludes for excludes in nested_trans_excl)
+        )
+
+    direct_deps_chained = FrozenOrderedSet(itertools.chain.from_iterable(direct_deps_tgts))
+    direct_deps_with_excl = direct_deps_chained.difference(transitive_excludes)
+
     reqs = PexRequirements.create_from_requirement_fields(
         tgt[PythonRequirementsField]
-        for tgt in itertools.chain.from_iterable(direct_deps_tgts)
+        for tgt in direct_deps_with_excl
         if tgt.has_field(PythonRequirementsField)
     )
     req_strs = list(reqs)
@@ -654,7 +683,6 @@ async def get_requirements(
         f"{kwargs.name}{setup_py_generation.first_party_dependency_version(kwargs.version)}"
         for kwargs in set(kwargs_for_exported_targets_we_depend_on)
     )
-
     return ExportedTargetRequirements(req_strs)
 
 
@@ -668,7 +696,9 @@ async def get_owned_dependencies(
     """
     transitive_targets = await Get(
         TransitiveTargets,
-        TransitiveTargetsRequest([dependency_owner.exported_target.target.address]),
+        TransitiveTargetsRequest(
+            [dependency_owner.exported_target.target.address], include_special_cased_deps=True
+        ),
     )
     ownable_targets = [
         tgt for tgt in transitive_targets.closure if is_ownable_target(tgt, union_membership)


### PR DESCRIPTION
Closes #11469, and adds a test for checking whether transitive excludes are considered when generating setup.py (courtesy of @asherf).

[ci skip-rust]
[ci skip-build-wheels]