### PR TITLE
Fix workunit visibility calculation.

### DIFF
--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -468,7 +468,7 @@ impl HeavyHittersData {
   }
 
   fn is_visible(workunit: &Workunit) -> bool {
-    workunit.metadata.level >= Level::Info && workunit.metadata.desc.is_some()
+    workunit.metadata.level <= Level::Info && workunit.metadata.desc.is_some()
   }
 
   fn duration_for(now: SystemTime, workunit: &Workunit) -> Option<Duration> {


### PR DESCRIPTION
The prior code had the sense wrong, higher is noisier.

[ci skip-build-wheels]