### PR TITLE
Add `RuleRunner.write_files()` for more declarative tests

### DIFF
--- a/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
@@ -54,7 +54,7 @@ def test_warn_files_targets(rule_runner: RuleRunner, caplog) -> None:
             ),
             "src/py/project/__init__.py": "",
             "src/py/project/app.py": "print('hello')",
-            "src/py/pyroject/BUILD": dedent(
+            "src/py/project/BUILD": dedent(
                 """\
                 pex_binary(
                     dependencies=['assets:files', 'assets:relocated', 'assets:resources'],

--- a/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
@@ -35,36 +35,34 @@ def rule_runner() -> RuleRunner:
 
 def test_warn_files_targets(rule_runner: RuleRunner, caplog) -> None:
     rule_runner.set_options([], env_inherit={"PATH", "PYENV_ROOT", "HOME"})
-    rule_runner.create_file("assets/f.txt")
-    rule_runner.add_to_build_file(
-        "assets",
-        dedent(
-            """\
-            files(name='files', sources=['f.txt'])
-            relocated_files(
-                name='relocated',
-                files_targets=[':files'],
-                src='assets',
-                dest='new_assets',
-            )
+    rule_runner.write_files(
+        {
+            "assets/f.txt": "",
+            "assets/BUILD": dedent(
+                """\
+                files(name='files', sources=['f.txt'])
+                relocated_files(
+                    name='relocated',
+                    files_targets=[':files'],
+                    src='assets',
+                    dest='new_assets',
+                )
 
-            # Resources are fine.
-            resources(name='resources', sources=['f.txt'])
-            """
-        ),
-    )
-    rule_runner.create_file("src/py/project/__init__.py")
-    rule_runner.create_file("src/py/project/app.py", "print('hello')")
-    rule_runner.add_to_build_file(
-        "src/py/project",
-        dedent(
-            """\
-            pex_binary(
-                dependencies=['assets:files', 'assets:relocated', 'assets:resources'],
-                entry_point="none",
-            )
-            """
-        ),
+                # Resources are fine.
+                resources(name='resources', sources=['f.txt'])
+                """
+            ),
+            "src/py/project/__init__.py": "",
+            "src/py/project/app.py": "print('hello')",
+            "src/py/pyroject/BUILD": dedent(
+                """\
+                pex_binary(
+                    dependencies=['assets:files', 'assets:relocated', 'assets:resources'],
+                    entry_point="none",
+                )
+                """
+            ),
+        }
     )
     tgt = rule_runner.get_target(Address("src/py/project"))
     field_set = PexBinaryFieldSet.create(tgt)

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -1,11 +1,11 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import os
 import re
-from pathlib import PurePath
 from textwrap import dedent
-from typing import List, Mapping, Optional
 
 import pytest
 
@@ -24,8 +24,9 @@ from pants.backend.python.util_rules import pex_from_targets
 from pants.core.goals.test import TestDebugRequest, TestResult, get_filtered_environment
 from pants.core.util_rules import distdir
 from pants.engine.addresses import Address
-from pants.engine.fs import DigestContents, FileContent
+from pants.engine.fs import DigestContents
 from pants.engine.process import InteractiveRunner
+from pants.engine.target import Target
 from pants.testutil.python_interpreter_selection import skip_unless_python27_and_python3_present
 from pants.testutil.rule_runner import QueryRule, RuleRunner, mock_console
 
@@ -37,7 +38,7 @@ def rule_runner() -> RuleRunner:
             create_coverage_config,
             *pytest_runner.rules(),
             *pex_from_targets.rules(),
-            *dependency_inference_rules.rules(),  # For conftest detection.
+            *dependency_inference_rules.rules(),
             *distdir.rules(),
             *package_pex_binary.rules(),
             get_filtered_environment,
@@ -51,101 +52,21 @@ def rule_runner() -> RuleRunner:
 
 SOURCE_ROOT = "tests/python"
 PACKAGE = os.path.join(SOURCE_ROOT, "pants_test")
-GOOD_SOURCE = FileContent(f"{PACKAGE}/test_good.py", b"def test():\n  pass\n")
-GOOD_WITH_PRINT = FileContent(f"{PACKAGE}/test_good.py", b"def test():\n  print('All good!')")
-BAD_SOURCE = FileContent(f"{PACKAGE}/test_bad.py", b"def test():\n  assert False\n")
-PY3_ONLY_SOURCE = FileContent(f"{PACKAGE}/test_py3.py", b"def test() -> None:\n  pass\n")
-LIBRARY_SOURCE = FileContent(f"{PACKAGE}/library.py", b"def add_two(x):\n  return x + 2\n")
-BINARY_SOURCE = FileContent(f"{PACKAGE}/say_hello.py", b"print('Hello, test!')")
 
-
-def create_python_library(
-    rule_runner: RuleRunner,
-    source_files: List[FileContent],
-    *,
-    name: str = "library",
-    dependencies: Optional[List[str]] = None,
-) -> None:
-    for source_file in source_files:
-        rule_runner.create_file(source_file.path, source_file.content.decode())
-    source_globs = [PurePath(source_file.path).name for source_file in source_files]
-    rule_runner.add_to_build_file(
-        PACKAGE,
-        dedent(
-            f"""\
-            python_library(
-                name={repr(name)},
-                sources={source_globs},
-                dependencies={[*(dependencies or ())]},
-            )
-            """
-        ),
-    )
-    rule_runner.create_file(os.path.join(PACKAGE, "__init__.py"))
-
-
-def create_test_target(
-    rule_runner: RuleRunner,
-    source_files: List[FileContent],
-    *,
-    name: str = "tests",
-    dependencies: Optional[List[str]] = None,
-    interpreter_constraints: Optional[str] = None,
-) -> PythonTests:
-    for source_file in source_files:
-        rule_runner.create_file(source_file.path, source_file.content.decode())
-    rule_runner.add_to_build_file(
-        relpath=PACKAGE,
-        target=dedent(
-            f"""\
-            python_tests(
-              name={repr(name)},
-              dependencies={dependencies or []},
-              interpreter_constraints={[interpreter_constraints] if interpreter_constraints else []},
-            )
-            """
-        ),
-    )
-    tgt = rule_runner.get_target(Address(PACKAGE, target_name=name))
-    assert isinstance(tgt, PythonTests)
-    return tgt
-
-
-def create_pex_binary_target(rule_runner: RuleRunner, source_file: FileContent) -> None:
-    rule_runner.create_file(source_file.path, source_file.content.decode())
-    file_name = PurePath(source_file.path).name
-    rule_runner.add_to_build_file(
-        relpath=PACKAGE,
-        target=dedent(
-            f"""\
-            python_library(name='bin_lib', sources=['{file_name}'])
-            pex_binary(name='bin', entry_point='{file_name}', output_path="bin.pex")
-            """
-        ),
-    )
-
-
-def setup_thirdparty_dep(rule_runner: RuleRunner) -> None:
-    rule_runner.add_to_build_file(
-        relpath="3rdparty/python",
-        target=(
-            "python_requirement_library(name='ordered-set', requirements=['ordered-set==3.1.1'])"
-        ),
-    )
+GOOD_TEST = dedent(
+    """\
+    def test():
+        pass
+    """
+)
 
 
 def run_pytest(
     rule_runner: RuleRunner,
-    test_target: PythonTests,
+    test_target: Target,
     *,
-    passthrough_args: Optional[str] = None,
-    junit_xml_dir: Optional[str] = None,
-    use_coverage: bool = False,
-    execution_slot_var: Optional[str] = None,
-    extra_env_vars: Optional[str] = None,
-    env: Optional[Mapping[str, str]] = None,
-    config: Optional[str] = None,
-    force: bool = False,
+    extra_args: list[str] | None = None,
+    env: dict[str, str] | None = None,
 ) -> TestResult:
     # pytest-html==1.22.1 has an undeclared dep on setuptools. This, unfortunately,
     # is the most recent version of pytest-html that works with the low version of
@@ -158,24 +79,9 @@ def run_pytest(
         # pin to lower versions so that we can run Python 2 tests
         "--pytest-version=pytest>=4.6.6,<4.7",
         f"--pytest-pytest-plugins={plugins_str}",
+        *(extra_args or ()),
     ]
-    if passthrough_args:
-        args.append(f"--pytest-args='{passthrough_args}'")
-    if extra_env_vars:
-        args.append(f"--test-extra-env-vars={extra_env_vars}")
-    if junit_xml_dir:
-        args.append(f"--pytest-junit-xml-dir={junit_xml_dir}")
-    if use_coverage:
-        args.append("--test-use-coverage")
-    if execution_slot_var:
-        args.append(f"--pytest-execution-slot-var={execution_slot_var}")
-    if config:
-        rule_runner.create_file(relpath="pytest.ini", contents=config)
-        args.append("--pytest-config=pytest.ini")
-    if force:
-        args.append("--test-force")
     rule_runner.set_options(args, env=env, env_inherit={"PATH", "PYENV_ROOT", "HOME"})
-
     inputs = [PythonTestFieldSet.create(test_target)]
     test_result = rule_runner.request(TestResult, inputs)
     debug_request = rule_runner.request(TestDebugRequest, inputs)
@@ -186,231 +92,216 @@ def run_pytest(
     return test_result
 
 
-def test_single_passing_test(rule_runner: RuleRunner) -> None:
-    tgt = create_test_target(rule_runner, [GOOD_SOURCE])
+def test_passing_test(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {f"{PACKAGE}/tests.py": GOOD_TEST, f"{PACKAGE}/BUILD": "python_tests()"}
+    )
+    tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="tests.py"))
     result = run_pytest(rule_runner, tgt)
     assert result.exit_code == 0
-    assert f"{PACKAGE}/test_good.py ." in result.stdout
+    assert f"{PACKAGE}/tests.py ." in result.stdout
+
+
+def test_failing_test(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            f"{PACKAGE}/tests.py": dedent(
+                """\
+                def test():
+                    assert False
+                """
+            ),
+            f"{PACKAGE}/BUILD": "python_tests()",
+        }
+    )
+    tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="tests.py"))
+    result = run_pytest(rule_runner, tgt)
+    assert result.exit_code == 1
+    assert f"{PACKAGE}/tests.py F" in result.stdout
+
+
+def test_dependencies(rule_runner: RuleRunner) -> None:
+    """Ensure direct and transitive dependencies work."""
+    rule_runner.write_files(
+        {
+            f"{PACKAGE}/__init__.py": "",
+            f"{PACKAGE}/lib1.py": dedent(
+                """\
+                def add_one(x):
+                    return x + 1
+                """
+            ),
+            f"{PACKAGE}/lib2.py": dedent(
+                """\
+                from colors import red
+
+                def add_two(x):
+                    return x + 2
+                """
+            ),
+            f"{PACKAGE}/lib3.py": dedent(
+                """\
+                from pants_test.lib2 import add_two
+
+                def add_three(x):
+                    return add_two(x) + 1
+                """
+            ),
+            f"{PACKAGE}/tests.py": dedent(
+                """\
+                from pants_test.lib1 import add_one
+                from .lib2 import add_two
+                from pants_test.lib3 import add_three
+                from ordered_set import OrderedSet
+
+                def test():
+                    assert add_one(1) == 2
+                    assert add_two(1) == 3
+                    assert add_three(1) == 4
+                """
+            ),
+            f"{PACKAGE}/BUILD": dedent(
+                """\
+                python_tests()
+                python_library(name="lib")
+                python_requirement_library(
+                    name="reqs", requirements=["ansicolors==1.1.8", "ordered-set==3.1.1"]
+                )
+                """
+            ),
+        }
+    )
+
+    tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="tests.py"))
+    result = run_pytest(rule_runner, tgt)
+    assert result.exit_code == 0
+    assert f"{PACKAGE}/tests.py ." in result.stdout
+
+
+@skip_unless_python27_and_python3_present
+def test_uses_correct_python_version(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            f"{PACKAGE}/tests.py": dedent(
+                """\
+                def test() -> None:
+                  pass
+                """
+            ),
+            f"{PACKAGE}/BUILD": dedent(
+                """\
+                python_tests(name='py2', interpreter_constraints=['==2.7.*'])
+                python_tests(name='py3', interpreter_constraints=['>=3.6.*'])
+                """
+            ),
+        }
+    )
+    py2_tgt = rule_runner.get_target(
+        Address(PACKAGE, target_name="py2", relative_file_path="tests.py")
+    )
+    result = run_pytest(rule_runner, py2_tgt)
+    assert result.exit_code == 2
+    assert "SyntaxError: invalid syntax" in result.stdout
+
+    py3_tgt = rule_runner.get_target(
+        Address(PACKAGE, target_name="py3", relative_file_path="tests.py")
+    )
+    result = run_pytest(rule_runner, py3_tgt)
+    assert result.exit_code == 0
+    assert f"{PACKAGE}/tests.py ." in result.stdout
+
+
+def test_respects_passthrough_args(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            f"{PACKAGE}/tests.py": dedent(
+                """\
+                def test_run_me():
+                  pass
+
+                def test_ignore_me():
+                  pass
+                """
+            ),
+            f"{PACKAGE}/BUILD": "python_tests()",
+        }
+    )
+    tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="tests.py"))
+    result = run_pytest(rule_runner, tgt, extra_args=["--pytest-args='-k test_run_me'"])
+    assert result.exit_code == 0
+    assert f"{PACKAGE}/tests.py ." in result.stdout
+    assert "collected 2 items / 1 deselected / 1 selected" in result.stdout
+
+
+def test_respects_config(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "pytest.ini": dedent(
+                """\
+                [pytest]
+                addopts = -s
+                """
+            ),
+            f"{PACKAGE}/tests.py": dedent(
+                """\
+                def test():
+                    print("All good!")
+                """
+            ),
+            f"{PACKAGE}/BUILD": "python_tests()",
+        }
+    )
+    tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="tests.py"))
+    result = run_pytest(rule_runner, tgt, extra_args=["--pytest-config=pytest.ini"])
+    assert result.exit_code == 0
+    assert "All good!" in result.stdout and "Captured" not in result.stdout
 
 
 def test_force(rule_runner: RuleRunner) -> None:
-    tgt = create_test_target(rule_runner, [GOOD_SOURCE])
+    rule_runner.write_files(
+        {f"{PACKAGE}/tests.py": GOOD_TEST, f"{PACKAGE}/BUILD": "python_tests()"}
+    )
+    tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="tests.py"))
 
     # Should not receive a memoized result if force=True.
-    result_one = run_pytest(rule_runner, tgt, force=True)
-    result_two = run_pytest(rule_runner, tgt, force=True)
+    result_one = run_pytest(rule_runner, tgt, extra_args=["--test-force"])
+    result_two = run_pytest(rule_runner, tgt, extra_args=["--test-force"])
     assert result_one.exit_code == 0
     assert result_two.exit_code == 0
     assert result_one is not result_two
 
     # But should if force=False.
-    result_one = run_pytest(rule_runner, tgt, force=False)
-    result_two = run_pytest(rule_runner, tgt, force=False)
+    result_one = run_pytest(rule_runner, tgt)
+    result_two = run_pytest(rule_runner, tgt)
     assert result_one.exit_code == 0
     assert result_one is result_two
 
 
-def test_single_failing_test(rule_runner: RuleRunner) -> None:
-    tgt = create_test_target(rule_runner, [BAD_SOURCE])
-    result = run_pytest(rule_runner, tgt)
-    assert result.exit_code == 1
-    assert f"{PACKAGE}/test_bad.py F" in result.stdout
-
-
-def test_mixed_sources(rule_runner: RuleRunner) -> None:
-    tgt = create_test_target(rule_runner, [GOOD_SOURCE, BAD_SOURCE])
-    result = run_pytest(rule_runner, tgt)
-    assert result.exit_code == 1
-    assert f"{PACKAGE}/test_good.py ." in result.stdout
-    assert f"{PACKAGE}/test_bad.py F" in result.stdout
-
-
-def test_absolute_import(rule_runner: RuleRunner) -> None:
-    create_python_library(rule_runner, [LIBRARY_SOURCE])
-    source = FileContent(
-        path=f"{PACKAGE}/test_absolute_import.py",
-        content=dedent(
-            """\
-            from pants_test.library import add_two
-
-            def test():
-              assert add_two(2) == 4
-            """
-        ).encode(),
-    )
-    tgt = create_test_target(rule_runner, [source], dependencies=[":library"])
-    result = run_pytest(rule_runner, tgt)
-    assert result.exit_code == 0
-    assert f"{PACKAGE}/test_absolute_import.py ." in result.stdout
-
-
-def test_relative_import(rule_runner: RuleRunner) -> None:
-    create_python_library(rule_runner, [LIBRARY_SOURCE])
-    source = FileContent(
-        path=f"{PACKAGE}/test_relative_import.py",
-        content=dedent(
-            """\
-            from .library import add_two
-
-            def test():
-              assert add_two(2) == 4
-            """
-        ).encode(),
-    )
-    tgt = create_test_target(rule_runner, [source], dependencies=[":library"])
-    result = run_pytest(rule_runner, tgt)
-    assert result.exit_code == 0
-    assert f"{PACKAGE}/test_relative_import.py ." in result.stdout
-
-
-def test_respects_config(rule_runner: RuleRunner) -> None:
-    target = create_test_target(rule_runner, [GOOD_WITH_PRINT])
-    result = run_pytest(rule_runner, target, config="[pytest]\naddopts = -s\n")
-    assert result.exit_code == 0
-    assert "All good!" in result.stdout and "Captured" not in result.stdout
-
-
-def test_transitive_dep(rule_runner: RuleRunner) -> None:
-    create_python_library(rule_runner, [LIBRARY_SOURCE])
-    transitive_dep_fc = FileContent(
-        path=f"{PACKAGE}/transitive_dep.py",
-        content=dedent(
-            """\
-            from pants_test.library import add_two
-
-            def add_four(x):
-              return add_two(x) + 2
-            """
-        ).encode(),
-    )
-    create_python_library(
-        rule_runner, [transitive_dep_fc], name="transitive_dep", dependencies=[":library"]
-    )
-    source = FileContent(
-        path=f"{PACKAGE}/test_transitive_dep.py",
-        content=dedent(
-            """\
-            from pants_test.transitive_dep import add_four
-
-            def test():
-              assert add_four(2) == 6
-            """
-        ).encode(),
-    )
-    tgt = create_test_target(rule_runner, [source], dependencies=[":transitive_dep"])
-    result = run_pytest(rule_runner, tgt)
-    assert result.exit_code == 0
-    assert f"{PACKAGE}/test_transitive_dep.py ." in result.stdout
-
-
-def test_thirdparty_dep(rule_runner: RuleRunner) -> None:
-    setup_thirdparty_dep(rule_runner)
-    source = FileContent(
-        path=f"{PACKAGE}/test_3rdparty_dep.py",
-        content=dedent(
-            """\
-            from ordered_set import OrderedSet
-
-            def test():
-              assert OrderedSet((1, 2)) == OrderedSet([1, 2])
-            """
-        ).encode(),
-    )
-    tgt = create_test_target(rule_runner, [source], dependencies=["3rdparty/python:ordered-set"])
-    result = run_pytest(rule_runner, tgt)
-    assert result.exit_code == 0
-    assert f"{PACKAGE}/test_3rdparty_dep.py ." in result.stdout
-
-
-def test_thirdparty_transitive_dep(rule_runner: RuleRunner) -> None:
-    setup_thirdparty_dep(rule_runner)
-    library_fc = FileContent(
-        path=f"{PACKAGE}/library.py",
-        content=dedent(
-            """\
-            import string
-            from ordered_set import OrderedSet
-
-            alphabet = OrderedSet(string.ascii_lowercase)
-            """
-        ).encode(),
-    )
-    create_python_library(
-        rule_runner,
-        [library_fc],
-        dependencies=["3rdparty/python:ordered-set"],
-    )
-    source = FileContent(
-        path=f"{PACKAGE}/test_3rdparty_transitive_dep.py",
-        content=dedent(
-            """\
-            from pants_test.library import alphabet
-
-            def test():
-              assert 'a' in alphabet and 'z' in alphabet
-            """
-        ).encode(),
-    )
-    tgt = create_test_target(rule_runner, [source], dependencies=[":library"])
-    result = run_pytest(rule_runner, tgt)
-    assert result.exit_code == 0
-    assert f"{PACKAGE}/test_3rdparty_transitive_dep.py ." in result.stdout
-
-
-@skip_unless_python27_and_python3_present
-def test_uses_correct_python_version(rule_runner: RuleRunner) -> None:
-    tgt = create_test_target(
-        rule_runner, [PY3_ONLY_SOURCE], name="py2", interpreter_constraints="CPython==2.7.*"
-    )
-    py2_result = run_pytest(rule_runner, tgt)
-    assert py2_result.exit_code == 2
-    assert "SyntaxError: invalid syntax" in py2_result.stdout
-
-    tgt = create_test_target(
-        rule_runner, [PY3_ONLY_SOURCE], name="py3", interpreter_constraints="CPython>=3.6"
-    )
-    py3_result = run_pytest(rule_runner, tgt)
-    assert py3_result.exit_code == 0
-    assert f"{PACKAGE}/test_py3.py ." in py3_result.stdout
-
-
-def test_respects_passthrough_args(rule_runner: RuleRunner) -> None:
-    source = FileContent(
-        path=f"{PACKAGE}/test_config.py",
-        content=dedent(
-            """\
-            def test_run_me():
-              pass
-
-            def test_ignore_me():
-              pass
-            """
-        ).encode(),
-    )
-    tgt = create_test_target(rule_runner, [source])
-    result = run_pytest(rule_runner, tgt, passthrough_args="-k test_run_me")
-    assert result.exit_code == 0
-    assert f"{PACKAGE}/test_config.py ." in result.stdout
-    assert "collected 2 items / 1 deselected / 1 selected" in result.stdout
-
-
 def test_junit(rule_runner: RuleRunner) -> None:
-    tgt = create_test_target(rule_runner, [GOOD_SOURCE])
-    result = run_pytest(rule_runner, tgt, junit_xml_dir="dist/test-results")
+    rule_runner.write_files(
+        {f"{PACKAGE}/tests.py": GOOD_TEST, f"{PACKAGE}/BUILD": "python_tests()"}
+    )
+    tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="tests.py"))
+    result = run_pytest(rule_runner, tgt, extra_args=["--pytest-junit-xml-dir=dist/test-results"])
     assert result.exit_code == 0
-    assert f"{PACKAGE}/test_good.py ." in result.stdout
+    assert f"{PACKAGE}/tests.py ." in result.stdout
     assert result.xml_results is not None
     digest_contents = rule_runner.request(DigestContents, [result.xml_results.digest])
     file = digest_contents[0]
     assert file.path.startswith("dist/test-results")
-    assert b"pants_test.test_good" in file.content
+    assert b"pants_test.tests" in file.content
 
 
 def test_extra_output(rule_runner: RuleRunner) -> None:
-    tgt = create_test_target(rule_runner, [GOOD_SOURCE])
-    result = run_pytest(rule_runner, tgt, passthrough_args="--html=extra-output/report.html")
+    rule_runner.write_files(
+        {f"{PACKAGE}/tests.py": GOOD_TEST, f"{PACKAGE}/BUILD": "python_tests()"}
+    )
+    tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="tests.py"))
+    result = run_pytest(
+        rule_runner, tgt, extra_args=["--pytest-args='--html=extra-output/report.html'"]
+    )
     assert result.exit_code == 0
-    assert f"{PACKAGE}/test_good.py ." in result.stdout
+    assert f"{PACKAGE}/tests.py ." in result.stdout
     assert result.extra_output is not None
     digest_contents = rule_runner.request(DigestContents, [result.extra_output.digest])
     paths = {dc.path for dc in digest_contents}
@@ -418,108 +309,130 @@ def test_extra_output(rule_runner: RuleRunner) -> None:
 
 
 def test_coverage(rule_runner: RuleRunner) -> None:
-    tgt = create_test_target(rule_runner, [GOOD_SOURCE])
-    result = run_pytest(rule_runner, tgt, use_coverage=True)
+    rule_runner.write_files(
+        {f"{PACKAGE}/tests.py": GOOD_TEST, f"{PACKAGE}/BUILD": "python_tests()"}
+    )
+    tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="tests.py"))
+    result = run_pytest(rule_runner, tgt, extra_args=["--test-use-coverage"])
     assert result.exit_code == 0
-    assert f"{PACKAGE}/test_good.py ." in result.stdout
+    assert f"{PACKAGE}/tests.py ." in result.stdout
     assert result.coverage_data is not None
 
 
 def test_conftest_handling(rule_runner: RuleRunner) -> None:
     """Tests that we a) inject a dependency on conftest.py and b) skip running directly on
     conftest.py."""
-    tgt = create_test_target(rule_runner, [GOOD_SOURCE])
-
-    rule_runner.create_file(
-        f"{SOURCE_ROOT}/conftest.py", "def pytest_runtest_setup(item):\n  print('In conftest!')\n"
+    rule_runner.write_files(
+        {
+            f"{SOURCE_ROOT}/conftest.py": dedent(
+                """\
+                def pytest_runtest_setup(item):
+                    print('In conftest!')
+                """
+            ),
+            f"{SOURCE_ROOT}/BUILD": "python_tests()",
+            f"{PACKAGE}/tests.py": GOOD_TEST,
+            f"{PACKAGE}/BUILD": "python_tests()",
+        }
     )
-    rule_runner.add_to_build_file(SOURCE_ROOT, "python_tests()")
-    conftest_tgt = rule_runner.get_target(Address(SOURCE_ROOT, relative_file_path="conftest.py"))
-    assert isinstance(conftest_tgt, PythonTests)
 
-    result = run_pytest(rule_runner, tgt, passthrough_args="-s")
+    test_tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="tests.py"))
+    result = run_pytest(rule_runner, test_tgt, extra_args=["--pytest-args='-s'"])
     assert result.exit_code == 0
-    assert f"{PACKAGE}/test_good.py In conftest!\n." in result.stdout
+    assert f"{PACKAGE}/tests.py In conftest!\n." in result.stdout
 
+    conftest_tgt = rule_runner.get_target(Address(SOURCE_ROOT, relative_file_path="conftest.py"))
     result = run_pytest(rule_runner, conftest_tgt)
     assert result.exit_code is None
 
 
 def test_execution_slot_variable(rule_runner: RuleRunner) -> None:
-    source = FileContent(
-        path=f"{PACKAGE}/test_concurrency_slot.py",
-        content=dedent(
-            """\
-            import os
+    rule_runner.write_files(
+        {
+            f"{PACKAGE}/test_concurrency_slot.py": dedent(
+                """\
+                import os
 
-            def test_fail_printing_slot_env_var():
-                slot = os.getenv("SLOT")
-                print(f"Value of slot is {slot}")
-                # Deliberately fail the test so the SLOT output gets printed to stdout
-                assert 1 == 2
-            """
-        ).encode(),
+                def test_fail_printing_slot_env_var():
+                    slot = os.getenv("SLOT")
+                    print(f"Value of slot is {slot}")
+                    # Deliberately fail the test so the SLOT output gets printed to stdout
+                    assert 1 == 2
+                """
+            ),
+            f"{PACKAGE}/BUILD": "python_tests()",
+        }
     )
-    tgt = create_test_target(rule_runner, [source])
-    result = run_pytest(rule_runner, tgt, execution_slot_var="SLOT")
+    tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="test_concurrency_slot.py"))
+    result = run_pytest(rule_runner, tgt, extra_args=["--pytest-execution-slot-var=SLOT"])
     assert result.exit_code == 1
     assert re.search(r"Value of slot is \d+", result.stdout)
 
 
 def test_extra_env_vars(rule_runner: RuleRunner) -> None:
-    source = FileContent(
-        path=f"{PACKAGE}/test_extra_env_vars.py",
-        content=dedent(
-            """\
-            import os
+    rule_runner.write_files(
+        {
+            f"{PACKAGE}/test_extra_env_vars.py": dedent(
+                """\
+                import os
 
-            def test_args():
-                assert os.getenv("SOME_VAR") == "some_value"
-                assert os.getenv("OTHER_VAR") == "other_value"
-            """
-        ).encode(),
+                def test_args():
+                    assert os.getenv("SOME_VAR") == "some_value"
+                    assert os.getenv("OTHER_VAR") == "other_value"
+                """
+            ),
+            f"{PACKAGE}/BUILD": "python_tests()",
+        }
     )
-    tgt = create_test_target(rule_runner, [source])
+    tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="test_extra_env_vars.py"))
     result = run_pytest(
         rule_runner,
         tgt,
-        extra_env_vars='["SOME_VAR=some_value", "OTHER_VAR"]',
+        extra_args=['--test-extra-env-vars=["SOME_VAR=some_value", "OTHER_VAR"]'],
         env={"OTHER_VAR": "other_value"},
     )
     assert result.exit_code == 0
 
 
 def test_runtime_package_dependency(rule_runner: RuleRunner) -> None:
-    create_pex_binary_target(rule_runner, BINARY_SOURCE)
-    rule_runner.create_file(
-        f"{PACKAGE}/test_binary_call.py",
-        dedent(
-            f"""\
-            import os.path
-            import subprocess
+    rule_runner.write_files(
+        {
+            f"{PACKAGE}/say_hello.py": "print('Hello, test!')",
+            f"{PACKAGE}/test_binary_call.py": dedent(
+                f"""\
+                import os.path
+                import subprocess
 
-            def test_embedded_binary():
-                assert  b"Hello, test!" in subprocess.check_output(args=['./bin.pex'])
+                def test_embedded_binary():
+                    assert  b"Hello, test!" in subprocess.check_output(args=['./bin.pex'])
 
-                # Ensure that we didn't accidentally pull in the binary's sources. This is a
-                # special type of dependency that should not be included with the rest of the
-                # normal dependencies.
-                assert os.path.exists("{BINARY_SOURCE.path}") is False
-            """
-        ),
+                    # Ensure that we didn't accidentally pull in the binary's sources. This is a
+                    # special type of dependency that should not be included with the rest of the
+                    # normal dependencies.
+                    assert os.path.exists("{PACKAGE}/say_hello.py") is False
+                """
+            ),
+            f"{PACKAGE}/BUILD": dedent(
+                """\
+                python_library(name='bin_lib', sources=['say_hello.py'])
+                pex_binary(name='bin', entry_point='say_hello.py', output_path="bin.pex")
+                python_tests(runtime_package_dependencies=[':bin'])
+                """
+            ),
+        }
     )
-    rule_runner.add_to_build_file(PACKAGE, "python_tests(runtime_package_dependencies=[':bin'])")
     tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="test_binary_call.py"))
-    assert isinstance(tgt, PythonTests)
-    result = run_pytest(rule_runner, tgt, passthrough_args="-s")
+    result = run_pytest(rule_runner, tgt, extra_args=["--pytest-args='-s'"])
     assert result.exit_code == 0
 
 
 def test_skip_type_stubs(rule_runner: RuleRunner) -> None:
-    rule_runner.create_file(f"{PACKAGE}/test_foo.pyi", "def test_foo() -> None:\n    ...\n")
-    rule_runner.add_to_build_file(PACKAGE, "python_tests()")
+    rule_runner.write_files(
+        {
+            f"{PACKAGE}/test_foo.pyi": "def test_foo() -> None:\n    ...\n",
+            f"{PACKAGE}/BUILD": "python_tests()",
+        }
+    )
     tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="test_foo.pyi"))
-    assert isinstance(tgt, PythonTests)
-
     result = run_pytest(rule_runner, tgt)
     assert result.exit_code is None

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -299,14 +299,16 @@ class RuleRunner:
         self._invalidate_for(relpath)
         return path
 
-    def create_file(self, relpath: str, contents: bytes | str = "", mode: str = "w") -> str:
+    def create_file(
+        self, relpath: str | PurePath, contents: bytes | str = "", mode: str = "w"
+    ) -> str:
         """Writes to a file under the buildroot.
 
         :API: public
 
-        relpath:  The relative path to the file from the build root.
+        relpath: The relative path to the file from the build root.
         contents: A string containing the contents of the file - '' by default..
-        mode:     The mode to write to the file in - over-write by default.
+        mode: The mode to write to the file in - over-write by default.
         """
         path = os.path.join(self.build_root, relpath)
         with safe_open(path, mode=mode) as fp:
@@ -314,12 +316,12 @@ class RuleRunner:
         self._invalidate_for(relpath)
         return path
 
-    def create_files(self, path: str, files: Iterable[str]) -> None:
+    def create_files(self, path: str | PurePath, files: Iterable[str]) -> None:
         """Writes to a file under the buildroot with contents same as file name.
 
         :API: public
 
-         path:  The relative path to the file from the build root.
+         path: The relative path to the file from the build root.
          files: List of file names.
         """
         for f in files:
@@ -342,8 +344,19 @@ class RuleRunner:
         mode = "w" if overwrite else "a"
         return self.create_file(str(build_path), target, mode=mode)
 
+    def write_files(self, files: Mapping[str, str]) -> None:
+        """Write the files to the build root.
+
+        :API: public
+        """
+        for path, content in files.items():
+            self.create_file(path, content)
+
     def make_snapshot(self, files: Mapping[str, str | bytes]) -> Snapshot:
-        """Makes a snapshot from a map of file name to file content."""
+        """Makes a snapshot from a map of file name to file content.
+
+        :API: public
+        """
         with temporary_dir() as temp_dir:
             for file_name, content in files.items():
                 mode = "wb" if isinstance(content, bytes) else "w"
@@ -357,14 +370,17 @@ class RuleRunner:
 
         This is a convenience around `TestBase.make_snapshot`, which allows specifying the content
         for each file.
+
+        :API: public
         """
         return self.make_snapshot({fp: "" for fp in files})
 
     def get_target(self, address: Address) -> Target:
         """Find the target for a given address.
 
-        This requires that the target actually exists, i.e. that you called
-        `rule_runner.add_to_build_file()`.
+        This requires that the target actually exists, i.e. that you set up its BUILD file.
+
+        :API: public
         """
         return self.request(WrappedTarget, [address]).target
 


### PR DESCRIPTION
### Problem

Our `RuleRunner` tests are hard to follow because the setup of the project file tree is spread out across the tests. Currently, we make several calls to `.create_file()` and `.add_to_build_file()`, rather than a single batch call. This resulted in writing intermediate helper functions that made it difficult to keep track of which files and targets are being created.

### Solution

Add `RuleRunner.write_files()`, which takes `Mapping[str, str]` of files. This mirrors our integration test function `setup_tmpdir()`.

We can't use `RuleRunner.create_files()` because that name is already taken.

### Result

`package_pex_binary_integration_test.py` and `pytest_runner_integration_test.py` are both easier to follow now, and they no longer have confusing helper functions.

Over time, we can chip away at `.add_to_build_file()` and `.create_files()` (plural) in favor of this new approach. (`.create_file()` (singular) should probably still exist.)

[ci skip-rust]
[ci skip-build-wheels]
