### PR TITLE
Update some deps to keep 1.30.x building.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -25,13 +25,13 @@ pex==2.1.24
 psutil==5.7.0
 Pygments==2.6.1
 pystache==0.5.4
-python-Levenshtein==0.12.0
+python-Levenshtein==0.12.1
 pywatchman==1.4.1
 PyYAML>=5.3.1,<5.4
 py_zipkin==0.20.0
 requests[security]>=2.20.1
 responses==0.10.14
-setproctitle==1.1.10
+setproctitle==1.2.2
 setuptools==44.0.0
 toml==0.10.1
 typed-ast>=1.4.1,<1.5

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -684,6 +684,7 @@ dependencies = [
  "indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "logging 0.0.1",
  "nailgun 0.0.1",
@@ -1065,7 +1066,7 @@ dependencies = [
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
- "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1364,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.0.25"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3658,7 +3659,7 @@ dependencies = [
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)" = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
-"checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
+"checksum libz-sys 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
 "checksum lmdb 0.8.0 (git+https://github.com/pantsbuild/lmdb-rs.git?rev=06bdfbfc6348f6804127176e561843f214fc17f8)" = "<none>"
 "checksum lmdb-sys 0.8.0 (git+https://github.com/pantsbuild/lmdb-rs.git?rev=06bdfbfc6348f6804127176e561843f214fc17f8)" = "<none>"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -111,6 +111,7 @@ hashing = { path = "hashing" }
 indexmap = "1.0.2"
 itertools = "0.8.2"
 lazy_static = "1"
+libz-sys = "1.1.2"
 log = "0.4"
 logging = { path = "logging" }
 nailgun = { path = "nailgun" }

--- a/tests/python/pants_test/backend/jvm/subsystems/BUILD
+++ b/tests/python/pants_test/backend/jvm/subsystems/BUILD
@@ -60,7 +60,7 @@ python_tests(
     'testprojects/src/scala/org/pantsbuild/testproject:custom_scala_platform_directory',
   ],
   tags = {'integration', 'partially_type_checked'},
-  timeout=900,
+  timeout=1500,
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/project_info/tasks/test_export.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export.py
@@ -67,7 +67,7 @@ class ExportTest(ConsoleTaskTestBase):
         )
 
         # NB: `test_has_python_requirements` will attempt to inject every possible scala compiler target
-        # spec, for versions 2.10, 2.11, 2.12, and custom, and will error out if they are not
+        # spec, for versions 2.10, 2.11, 2.12, 2.13, and custom, and will error out if they are not
         # available. This isn't a problem when running pants on the command line, but in unit testing
         # there's probably some task or subsystem that needs to be initialized to avoid this.
         for empty_target in [
@@ -77,7 +77,7 @@ class ExportTest(ConsoleTaskTestBase):
             "scala-reflect",
             "scalastyle",
         ]:
-            for unused_scala_version in ["2_10", "2_11"]:
+            for unused_scala_version in ["2_10", "2_11", "2_13"]:
                 self.make_target(
                     f":{empty_target}_{unused_scala_version}", Target,
                 )


### PR DESCRIPTION
- Update libz-sys dependency version, as required to build
  on recent osx versions.
- Update setproctitle to a version that works with non-system
  Pythons on recent osx versions.
- Update Python-Levenshtein, as the previous version was yanked
  from pypi due to a security vulnerability.

[ci skip-jvm-tests]
