### PR TITLE
Deprecate `--ignore-pants-warnings` in favor of `--ignore-warnings`

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -24,7 +24,7 @@ plugins = [
   "toolchain.pants.plugin==0.7.0",
 ]
 
-ignore_pants_warnings = [
+ignore_warnings = [
   # TODO: Remove when `toolchain.pants.plugin` is bumped past `0.7.0`.
   "DeprecationWarning: DEPRECATED: pants.core.util_rules.pants_environment",
 ]

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -59,7 +59,8 @@ def stdio_initialize(
     use_color: bool,
     show_target: bool,
     log_levels_by_target: dict[str, int],
-    message_regex_filters: tuple[str, ...],
+    literal_filters: tuple[str, ...],
+    regex_filters: tuple[str, ...],
     log_file: str,
 ) -> tuple[RawIOBase, TextIO, TextIO]: ...
 def stdio_thread_get_destination() -> PyStdioDestination: ...

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -442,7 +442,24 @@ class GlobalOptions(Subsystem):
             ),
         )
 
-        # TODO(#7203): make a regexp option type!
+        register(
+            "--ignore-warnings",
+            type=list,
+            member_type=str,
+            default=[],
+            daemon=True,
+            advanced=True,
+            help=(
+                "Ignore logs and warnings matching these strings.\n\n"
+                "Normally, Pants will look for literal matches from the start of the log/warning "
+                "message, but you can prefix the ignore with `$regex$` for Pants to instead treat "
+                "your string as a regex pattern. For example:\n\n"
+                "  ignore_warnings = [\n"
+                "    'The option `[isort.config]` is not configured',\n"
+                "    '$regex$DeprecationWarning: DEPRECATED:\\s*'\n"
+                "  ]"
+            ),
+        )
         register(
             "--ignore-pants-warnings",
             type=list,
@@ -453,6 +470,13 @@ class GlobalOptions(Subsystem):
             help="Regexps matching warning strings to ignore, e.g. "
             '["DEPRECATED: the option `--my-opt` will be removed"]. The regex patterns will be '
             "matched from the start of the warning string, and are case-insensitive.",
+            removal_version="2.6.0.dev0",
+            removal_hint=(
+                "Use the global option `--ignore-warnings` instead.\n\nUnlike this option, "
+                "`--ignore-warnings` uses literal string matches instead of regex patterns by "
+                "default. If you would still like to use a regex pattern, prefix the string with "
+                "`$regex$`."
+            ),
         )
 
         register(


### PR DESCRIPTION
Beyond this new name beyond shorter, it makes it much easier to work with by using literal string matching by default instead of regex patterns. Regex is tricky to get working correctly, such as an ignore with `path.to.module` in it really needing to be `path\.to\.module`, which is not obvious.

If users do really want regex, they can prefix the ignore with `$regex$`.

[ci skip-build-wheels]