### PR TITLE
Warn if config files detected but not wired up to Pants

### DIFF
--- a/src/python/pants/backend/python/goals/coverage_py_test.py
+++ b/src/python/pants/backend/python/goals/coverage_py_test.py
@@ -7,27 +7,39 @@ from typing import List, Optional
 import pytest
 
 from pants.backend.python.goals.coverage_py import CoverageSubsystem, create_coverage_config
-from pants.core.util_rules.warn_config_files_not_setup import (
-    WarnConfigFilesNotSetup,
-    WarnConfigFilesNotSetupResult,
-)
+from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.engine.fs import (
     EMPTY_DIGEST,
+    EMPTY_SNAPSHOT,
     CreateDigest,
     Digest,
     DigestContents,
     FileContent,
-    PathGlobs,
 )
 from pants.testutil.option_util import create_subsystem
-from pants.testutil.rule_runner import MockGet, run_rule_with_mocks
+from pants.testutil.rule_runner import MockGet, RuleRunner, run_rule_with_mocks
 
 
 def run_create_coverage_config_rule(coverage_config: Optional[str]) -> str:
     coverage = create_subsystem(CoverageSubsystem, config="some_file" if coverage_config else None)
     resolved_config: List[str] = []
 
-    def mock_handle_config(request: CreateDigest) -> Digest:
+    def mock_find_existing_config(request: ConfigFilesRequest) -> ConfigFiles:
+        snapshot = (
+            EMPTY_SNAPSHOT
+            if not request.specified
+            else RuleRunner().make_snapshot_of_empty_files([".coveragerc"])
+        )
+        return ConfigFiles(snapshot)
+
+    def mock_read_existing_config(_: Digest) -> DigestContents:
+        # This shouldn't be called if no config file provided.
+        assert coverage_config is not None
+        return DigestContents(
+            [FileContent(path="/dev/null/prelude", content=coverage_config.encode())]
+        )
+
+    def mock_create_final_config(request: CreateDigest) -> Digest:
         assert len(request) == 1
         assert request[0].path == ".coveragerc"
         assert isinstance(request[0], FileContent)
@@ -35,21 +47,12 @@ def run_create_coverage_config_rule(coverage_config: Optional[str]) -> str:
         resolved_config.append(request[0].content.decode())
         return EMPTY_DIGEST
 
-    def mock_read_config(_: PathGlobs) -> DigestContents:
-        # This shouldn't be called if no config file provided.
-        assert coverage_config is not None
-        return DigestContents(
-            [FileContent(path="/dev/null/prelude", content=coverage_config.encode())]
-        )
-
     mock_gets = [
-        MockGet(output_type=DigestContents, input_type=PathGlobs, mock=mock_read_config),
-        MockGet(output_type=Digest, input_type=CreateDigest, mock=mock_handle_config),
         MockGet(
-            output_type=WarnConfigFilesNotSetupResult,
-            input_type=WarnConfigFilesNotSetup,
-            mock=lambda _: WarnConfigFilesNotSetupResult(),
+            output_type=ConfigFiles, input_type=ConfigFilesRequest, mock=mock_find_existing_config
         ),
+        MockGet(output_type=DigestContents, input_type=Digest, mock=mock_read_existing_config),
+        MockGet(output_type=Digest, input_type=CreateDigest, mock=mock_create_final_config),
     ]
 
     result = run_rule_with_mocks(create_coverage_config, rule_args=[coverage], mock_gets=mock_gets)

--- a/src/python/pants/backend/python/goals/coverage_py_test.py
+++ b/src/python/pants/backend/python/goals/coverage_py_test.py
@@ -7,6 +7,10 @@ from typing import List, Optional
 import pytest
 
 from pants.backend.python.goals.coverage_py import CoverageSubsystem, create_coverage_config
+from pants.core.util_rules.warn_config_files_not_setup import (
+    WarnConfigFilesNotSetup,
+    WarnConfigFilesNotSetupResult,
+)
 from pants.engine.fs import (
     EMPTY_DIGEST,
     CreateDigest,
@@ -41,6 +45,11 @@ def run_create_coverage_config_rule(coverage_config: Optional[str]) -> str:
     mock_gets = [
         MockGet(output_type=DigestContents, input_type=PathGlobs, mock=mock_read_config),
         MockGet(output_type=Digest, input_type=CreateDigest, mock=mock_handle_config),
+        MockGet(
+            output_type=WarnConfigFilesNotSetupResult,
+            input_type=WarnConfigFilesNotSetup,
+            mock=lambda _: WarnConfigFilesNotSetupResult(),
+        ),
     ]
 
     result = run_rule_with_mocks(create_coverage_config, rule_args=[coverage], mock_gets=mock_gets)

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -22,7 +22,7 @@ from pants.backend.python.target_types import (
 )
 from pants.backend.python.util_rules import pex_from_targets
 from pants.core.goals.test import TestDebugRequest, TestResult, get_filtered_environment
-from pants.core.util_rules import distdir, warn_config_files_not_setup
+from pants.core.util_rules import config_files, distdir
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents
 from pants.engine.process import InteractiveRunner
@@ -40,7 +40,7 @@ def rule_runner() -> RuleRunner:
             *pex_from_targets.rules(),
             *dependency_inference_rules.rules(),
             *distdir.rules(),
-            *warn_config_files_not_setup.rules(),
+            *config_files.rules(),
             *package_pex_binary.rules(),
             get_filtered_environment,
             *target_types_rules.rules(),

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -22,7 +22,7 @@ from pants.backend.python.target_types import (
 )
 from pants.backend.python.util_rules import pex_from_targets
 from pants.core.goals.test import TestDebugRequest, TestResult, get_filtered_environment
-from pants.core.util_rules import distdir
+from pants.core.util_rules import distdir, warn_config_files_not_setup
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents
 from pants.engine.process import InteractiveRunner
@@ -40,6 +40,7 @@ def rule_runner() -> RuleRunner:
             *pex_from_targets.rules(),
             *dependency_inference_rules.rules(),
             *distdir.rules(),
+            *warn_config_files_not_setup.rules(),
             *package_pex_binary.rules(),
             get_filtered_environment,
             *target_types_rules.rules(),

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -15,7 +15,6 @@ from pants.backend.python.util_rules.pex import (
     VenvPexProcess,
 )
 from pants.core.goals.lint import LintReport, LintRequest, LintResult, LintResults, LintSubsystem
-from pants.core.util_rules import stripped_source_files
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, DigestSubset, GlobMatchErrorBehavior, MergeDigests, PathGlobs
 from pants.engine.process import FallibleProcessResult
@@ -73,12 +72,14 @@ async def bandit_lint_partition(
         ),
     )
 
+    # Note that there is no standard Bandit config file path, so we do not use
+    # `WarnConfigFileNotSetup` like we do with other tools.
     config_digest_request = Get(
         Digest,
         PathGlobs(
             globs=[bandit.config] if bandit.config else [],
             glob_match_error_behavior=GlobMatchErrorBehavior.error,
-            description_of_origin="the option `--bandit-config`",
+            description_of_origin="the option `[bandit].config`",
         ),
     )
 
@@ -152,9 +153,4 @@ async def bandit_lint(
 
 
 def rules():
-    return [
-        *collect_rules(),
-        UnionRule(LintRequest, BanditRequest),
-        *pex.rules(),
-        *stripped_source_files.rules(),
-    ]
+    return [*collect_rules(), UnionRule(LintRequest, BanditRequest), *pex.rules()]

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -15,6 +15,7 @@ from pants.backend.python.util_rules.pex import (
     VenvPexProcess,
 )
 from pants.core.goals.lint import LintReport, LintRequest, LintResult, LintResults, LintSubsystem
+from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, DigestSubset, GlobMatchErrorBehavior, MergeDigests, PathGlobs
 from pants.engine.process import FallibleProcessResult
@@ -61,7 +62,7 @@ def generate_args(
 async def bandit_lint_partition(
     partition: BanditPartition, bandit: Bandit, lint_subsystem: LintSubsystem
 ) -> LintResult:
-    bandit_pex_request = Get(
+    bandit_pex_get = Get(
         VenvPex,
         PexRequest(
             output_filename="bandit.pex",
@@ -72,26 +73,18 @@ async def bandit_lint_partition(
         ),
     )
 
-    # Note that there is no standard Bandit config file path, so we do not use
-    # `WarnConfigFileNotSetup` like we do with other tools.
-    config_digest_request = Get(
-        Digest,
-        PathGlobs(
-            globs=[bandit.config] if bandit.config else [],
-            glob_match_error_behavior=GlobMatchErrorBehavior.error,
-            description_of_origin="the option `[bandit].config`",
-        ),
-    )
-
-    source_files_request = Get(
+    config_files_get = Get(ConfigFiles, ConfigFilesRequest, bandit.config_request)
+    source_files_get = Get(
         SourceFiles, SourceFilesRequest(field_set.sources for field_set in partition.field_sets)
     )
 
-    bandit_pex, config_digest, source_files = await MultiGet(
-        bandit_pex_request, config_digest_request, source_files_request
+    bandit_pex, config_files, source_files = await MultiGet(
+        bandit_pex_get, config_files_get, source_files_get
     )
 
-    input_digest = await Get(Digest, MergeDigests((source_files.snapshot.digest, config_digest)))
+    input_digest = await Get(
+        Digest, MergeDigests((source_files.snapshot.digest, config_files.snapshot.digest))
+    )
 
     report_file_name = "bandit_report.txt" if lint_subsystem.reports_dir else None
 

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -12,7 +12,7 @@ from pants.backend.python.lint.bandit.rules import BanditFieldSet, BanditRequest
 from pants.backend.python.lint.bandit.rules import rules as bandit_rules
 from pants.backend.python.target_types import PythonLibrary
 from pants.core.goals.lint import LintResult, LintResults
-from pants.core.util_rules import source_files, warn_config_files_not_setup
+from pants.core.util_rules import config_files, source_files
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents
 from pants.engine.target import Target
@@ -26,7 +26,7 @@ def rule_runner() -> RuleRunner:
         rules=[
             *bandit_rules(),
             *source_files.rules(),
-            *warn_config_files_not_setup.rules(),
+            *config_files.rules(),
             QueryRule(LintResults, (BanditRequest,)),
         ],
         target_types=[PythonLibrary],

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -12,6 +12,7 @@ from pants.backend.python.lint.bandit.rules import BanditFieldSet, BanditRequest
 from pants.backend.python.lint.bandit.rules import rules as bandit_rules
 from pants.backend.python.target_types import PythonLibrary
 from pants.core.goals.lint import LintResult, LintResults
+from pants.core.util_rules import source_files, warn_config_files_not_setup
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents
 from pants.engine.target import Target
@@ -24,6 +25,8 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *bandit_rules(),
+            *source_files.rules(),
+            *warn_config_files_not_setup.rules(),
             QueryRule(LintResults, (BanditRequest,)),
         ],
         target_types=[PythonLibrary],

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -5,6 +5,7 @@ from typing import Optional, Tuple, cast
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
+from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.option.custom_types import file_option, shell_str
 
 
@@ -54,3 +55,8 @@ class Bandit(PythonToolBase):
     @property
     def config(self) -> Optional[str]:
         return cast(Optional[str], self.options.config)
+
+    @property
+    def config_request(self) -> ConfigFilesRequest:
+        # Note that there are no default locations for Bandit config files.
+        return ConfigFilesRequest(specified=self.config, option_name=f"{self.options_scope}.config")

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -17,12 +17,9 @@ from pants.backend.python.util_rules.pex import (
 )
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintRequest, LintResult, LintResults
+from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.core.util_rules.warn_config_files_not_setup import (
-    WarnConfigFilesNotSetup,
-    WarnConfigFilesNotSetupResult,
-)
-from pants.engine.fs import Digest, GlobMatchErrorBehavior, MergeDigests, PathGlobs
+from pants.engine.fs import Digest, MergeDigests
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import FieldSet
@@ -89,7 +86,7 @@ async def setup_black(
         else PexInterpreterConstraints(black.interpreter_constraints)
     )
 
-    black_pex_request = Get(
+    black_pex_get = Get(
         VenvPex,
         PexRequest(
             output_filename="black.pex",
@@ -100,30 +97,14 @@ async def setup_black(
         ),
     )
 
-    config_digest_request = Get(
-        Digest,
-        PathGlobs(
-            globs=[black.config] if black.config else [],
-            glob_match_error_behavior=GlobMatchErrorBehavior.error,
-            description_of_origin="the option `[black].config`",
-        ),
-    )
-    if not black.config:
-        await Get(
-            WarnConfigFilesNotSetupResult,
-            WarnConfigFilesNotSetup(
-                check_content={"pyproject.toml": b"[tool.black]"},
-                option_name="[black].config",
-            ),
-        )
-
-    source_files_request = Get(
+    config_files_get = Get(ConfigFiles, ConfigFilesRequest, black.config_request)
+    source_files_get = Get(
         SourceFiles,
         SourceFilesRequest(field_set.sources for field_set in setup_request.request.field_sets),
     )
 
-    source_files, black_pex, config_digest = await MultiGet(
-        source_files_request, black_pex_request, config_digest_request
+    source_files, black_pex, config_files = await MultiGet(
+        source_files_get, black_pex_get, config_files_get
     )
     source_files_snapshot = (
         source_files.snapshot
@@ -131,7 +112,9 @@ async def setup_black(
         else setup_request.request.prior_formatter_result
     )
 
-    input_digest = await Get(Digest, MergeDigests((source_files_snapshot.digest, config_digest)))
+    input_digest = await Get(
+        Digest, MergeDigests((source_files_snapshot.digest, config_files.snapshot.digest))
+    )
 
     process = await Get(
         Process,

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -12,6 +12,7 @@ from pants.backend.python.lint.black.rules import rules as black_rules
 from pants.backend.python.target_types import PythonLibrary
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintResult, LintResults
+from pants.core.util_rules import source_files, warn_config_files_not_setup
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
@@ -28,6 +29,8 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *black_rules(),
+            *source_files.rules(),
+            *warn_config_files_not_setup.rules(),
             QueryRule(LintResults, (BlackRequest,)),
             QueryRule(FmtResult, (BlackRequest,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -12,7 +12,7 @@ from pants.backend.python.lint.black.rules import rules as black_rules
 from pants.backend.python.target_types import PythonLibrary
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintResult, LintResults
-from pants.core.util_rules import source_files, warn_config_files_not_setup
+from pants.core.util_rules import config_files, source_files
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
@@ -30,7 +30,7 @@ def rule_runner() -> RuleRunner:
         rules=[
             *black_rules(),
             *source_files.rules(),
-            *warn_config_files_not_setup.rules(),
+            *config_files.rules(),
             QueryRule(LintResults, (BlackRequest,)),
             QueryRule(FmtResult, (BlackRequest,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -5,6 +5,7 @@ from typing import Optional, Tuple, cast
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
+from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.option.custom_types import file_option, shell_str
 
 
@@ -59,3 +60,11 @@ class Black(PythonToolBase):
     @property
     def config(self) -> Optional[str]:
         return cast(Optional[str], self.options.config)
+
+    @property
+    def config_request(self) -> ConfigFilesRequest:
+        return ConfigFilesRequest(
+            specified=self.config,
+            check_content={"pyproject.toml": b"[tool.black]"},
+            option_name=f"[{self.options_scope}].config",
+        )

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -17,7 +17,6 @@ from pants.backend.python.util_rules.pex import (
 )
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintRequest, LintResult, LintResults
-from pants.core.util_rules import stripped_source_files
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
@@ -133,5 +132,4 @@ def rules():
         UnionRule(PythonFmtRequest, DocformatterRequest),
         UnionRule(LintRequest, DocformatterRequest),
         *pex.rules(),
-        *stripped_source_files.rules(),
     ]

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -10,6 +10,7 @@ from pants.backend.python.lint.docformatter.rules import rules as docformatter_r
 from pants.backend.python.target_types import PythonLibrary
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintResult, LintResults
+from pants.core.util_rules import source_files
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
@@ -22,6 +23,7 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *docformatter_rules(),
+            *source_files.rules(),
             QueryRule(LintResults, (DocformatterRequest,)),
             QueryRule(FmtResult, (DocformatterRequest,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -11,7 +11,7 @@ from pants.backend.python.lint.flake8.rules import Flake8FieldSet, Flake8Request
 from pants.backend.python.lint.flake8.rules import rules as flake8_rules
 from pants.backend.python.target_types import PythonLibrary
 from pants.core.goals.lint import LintResult, LintResults
-from pants.core.util_rules import source_files, warn_config_files_not_setup
+from pants.core.util_rules import config_files, source_files
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents
 from pants.engine.target import Target
@@ -24,9 +24,9 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *flake8_rules(),
-            QueryRule(LintResults, [Flake8Request]),
             *source_files.rules(),
-            *warn_config_files_not_setup.rules(),
+            *config_files.rules(),
+            QueryRule(LintResults, [Flake8Request]),
         ],
         target_types=[PythonLibrary],
     )

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -11,6 +11,7 @@ from pants.backend.python.lint.flake8.rules import Flake8FieldSet, Flake8Request
 from pants.backend.python.lint.flake8.rules import rules as flake8_rules
 from pants.backend.python.target_types import PythonLibrary
 from pants.core.goals.lint import LintResult, LintResults
+from pants.core.util_rules import source_files, warn_config_files_not_setup
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents
 from pants.engine.target import Target
@@ -21,7 +22,12 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 @pytest.fixture
 def rule_runner() -> RuleRunner:
     return RuleRunner(
-        rules=[*flake8_rules(), QueryRule(LintResults, (Flake8Request,))],
+        rules=[
+            *flake8_rules(),
+            QueryRule(LintResults, [Flake8Request]),
+            *source_files.rules(),
+            *warn_config_files_not_setup.rules(),
+        ],
         target_types=[PythonLibrary],
     )
 

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -5,6 +5,7 @@ from typing import Optional, Tuple, cast
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
+from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.option.custom_types import file_option, shell_str
 
 
@@ -56,3 +57,12 @@ class Flake8(PythonToolBase):
     @property
     def config(self) -> Optional[str]:
         return cast(Optional[str], self.options.config)
+
+    @property
+    def config_request(self) -> ConfigFilesRequest:
+        return ConfigFilesRequest(
+            specified=self.config,
+            check_existence=["flake8", ".flake8"],
+            check_content={"setup.cfg": b"[flake8]", "tox.ini": b"[flake8]"},
+            option_name=f"[{self.options_scope}].config",
+        )

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -10,7 +10,7 @@ from pants.backend.python.lint.isort.rules import rules as isort_rules
 from pants.backend.python.target_types import PythonLibrary
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintResult, LintResults
-from pants.core.util_rules import source_files, warn_config_files_not_setup
+from pants.core.util_rules import config_files, source_files
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
@@ -24,7 +24,7 @@ def rule_runner() -> RuleRunner:
         rules=[
             *isort_rules(),
             *source_files.rules(),
-            *warn_config_files_not_setup.rules(),
+            *config_files.rules(),
             QueryRule(LintResults, (IsortRequest,)),
             QueryRule(FmtResult, (IsortRequest,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -10,6 +10,7 @@ from pants.backend.python.lint.isort.rules import rules as isort_rules
 from pants.backend.python.target_types import PythonLibrary
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintResult, LintResults
+from pants.core.util_rules import source_files, warn_config_files_not_setup
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
@@ -22,6 +23,8 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *isort_rules(),
+            *source_files.rules(),
+            *warn_config_files_not_setup.rules(),
             QueryRule(LintResults, (IsortRequest,)),
             QueryRule(FmtResult, (IsortRequest,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -5,6 +5,7 @@ from typing import Tuple, cast
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
+from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.option.custom_types import file_option, shell_str
 
 
@@ -58,3 +59,12 @@ class Isort(PythonToolBase):
     @property
     def config(self) -> Tuple[str, ...]:
         return tuple(self.options.config)
+
+    @property
+    def config_request(self) -> ConfigFilesRequest:
+        return ConfigFilesRequest(
+            specified=self.config,
+            check_existence=[".isort.cfg"],
+            check_content={"pyproject.toml": b"[tool.isort]"},
+            option_name=f"[{self.options_scope}].config",
+        )

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -27,20 +27,10 @@ from pants.backend.python.util_rules.python_sources import (
     StrippedPythonSourceFiles,
 )
 from pants.core.goals.lint import LintRequest, LintResult, LintResults
+from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.core.util_rules.warn_config_files_not_setup import (
-    WarnConfigFilesNotSetup,
-    WarnConfigFilesNotSetupResult,
-)
 from pants.engine.addresses import Addresses, UnparsedAddressInputs
-from pants.engine.fs import (
-    EMPTY_DIGEST,
-    AddPrefix,
-    Digest,
-    GlobMatchErrorBehavior,
-    MergeDigests,
-    PathGlobs,
-)
+from pants.engine.fs import EMPTY_DIGEST, AddPrefix, Digest, MergeDigests
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
@@ -114,7 +104,7 @@ def generate_args(*, source_files: SourceFiles, pylint: Pylint) -> Tuple[str, ..
 
 @rule(level=LogLevel.DEBUG)
 async def pylint_lint_partition(partition: PylintPartition, pylint: Pylint) -> LintResult:
-    requirements_pex_request = Get(
+    requirements_pex_get = Get(
         Pex,
         PexFromTargetsRequest,
         PexFromTargetsRequest.for_requirements(
@@ -133,7 +123,7 @@ async def pylint_lint_partition(partition: PylintPartition, pylint: Pylint) -> L
         for plugin_tgt in partition.plugin_targets
         if plugin_tgt.has_field(PythonRequirementsField)
     )
-    pylint_pex_request = Get(
+    pylint_pex_get = Get(
         Pex,
         PexRequest(
             output_filename="pylint.pex",
@@ -143,48 +133,31 @@ async def pylint_lint_partition(partition: PylintPartition, pylint: Pylint) -> L
         ),
     )
 
-    config_digest_request = Get(
-        Digest,
-        PathGlobs(
-            globs=[pylint.config] if pylint.config else [],
-            glob_match_error_behavior=GlobMatchErrorBehavior.error,
-            description_of_origin="the option `[pylint].config`",
-        ),
-    )
-    if not pylint.config:
-        await Get(
-            WarnConfigFilesNotSetupResult,
-            WarnConfigFilesNotSetup(
-                check_existence=["pylintrc", ".pylinrc"],
-                check_content={"pyproject.toml": b"[tool.pylint]", "setup.cfg": b"[pylint."},
-                option_name="[pylint].config",
-            ),
-        )
-
-    prepare_plugin_sources_request = Get(
+    config_files_get = Get(ConfigFiles, ConfigFilesRequest, pylint.config_request)
+    prepare_plugin_sources_get = Get(
         StrippedPythonSourceFiles, PythonSourceFilesRequest(partition.plugin_targets)
     )
-    prepare_python_sources_request = Get(
+    prepare_python_sources_get = Get(
         PythonSourceFiles, PythonSourceFilesRequest(partition.targets_with_dependencies)
     )
-    field_set_sources_request = Get(
+    field_set_sources_get = Get(
         SourceFiles, SourceFilesRequest(field_set.sources for field_set in partition.field_sets)
     )
 
     (
         pylint_pex,
         requirements_pex,
-        config_digest,
+        config_files,
         prepared_plugin_sources,
         prepared_python_sources,
         field_set_sources,
     ) = await MultiGet(
-        pylint_pex_request,
-        requirements_pex_request,
-        config_digest_request,
-        prepare_plugin_sources_request,
-        prepare_python_sources_request,
-        field_set_sources_request,
+        pylint_pex_get,
+        requirements_pex_get,
+        config_files_get,
+        prepare_plugin_sources_get,
+        prepare_python_sources_get,
+        field_set_sources_get,
     )
 
     pylint_runner_pex = await Get(
@@ -220,7 +193,7 @@ async def pylint_lint_partition(partition: PylintPartition, pylint: Pylint) -> L
         Digest,
         MergeDigests(
             (
-                config_digest,
+                config_files.snapshot.digest,
                 prefixed_plugin_sources,
                 prepared_python_sources.source_files.snapshot.digest,
             )

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -11,6 +11,7 @@ from pants.backend.python.lint.pylint.rules import PylintFieldSet, PylintRequest
 from pants.backend.python.lint.pylint.rules import rules as pylint_rules
 from pants.backend.python.target_types import PythonLibrary, PythonRequirementLibrary
 from pants.core.goals.lint import LintResult, LintResults
+from pants.core.util_rules import warn_config_files_not_setup
 from pants.engine.addresses import Address
 from pants.engine.target import Target
 from pants.testutil.python_interpreter_selection import skip_unless_python27_and_python3_present
@@ -20,7 +21,11 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 @pytest.fixture
 def rule_runner() -> RuleRunner:
     return RuleRunner(
-        rules=[*pylint_rules(), QueryRule(LintResults, [PylintRequest])],
+        rules=[
+            *pylint_rules(),
+            QueryRule(LintResults, [PylintRequest]),
+            *warn_config_files_not_setup.rules(),
+        ],
         target_types=[PythonLibrary, PythonRequirementLibrary],
     )
 

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -11,7 +11,7 @@ from pants.backend.python.lint.pylint.rules import PylintFieldSet, PylintRequest
 from pants.backend.python.lint.pylint.rules import rules as pylint_rules
 from pants.backend.python.target_types import PythonLibrary, PythonRequirementLibrary
 from pants.core.goals.lint import LintResult, LintResults
-from pants.core.util_rules import warn_config_files_not_setup
+from pants.core.util_rules import config_files
 from pants.engine.addresses import Address
 from pants.engine.target import Target
 from pants.testutil.python_interpreter_selection import skip_unless_python27_and_python3_present
@@ -24,7 +24,7 @@ def rule_runner() -> RuleRunner:
         rules=[
             *pylint_rules(),
             QueryRule(LintResults, [PylintRequest]),
-            *warn_config_files_not_setup.rules(),
+            *config_files.rules(),
         ],
         target_types=[PythonLibrary, PythonRequirementLibrary],
     )

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -7,6 +7,7 @@ from typing import List, cast
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
+from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.addresses import UnparsedAddressInputs
 from pants.option.custom_types import file_option, shell_str, target_option
 from pants.util.docutil import bracketed_docs_url
@@ -76,6 +77,15 @@ class Pylint(PythonToolBase):
     @property
     def config(self) -> str | None:
         return cast("str | None", self.options.config)
+
+    @property
+    def config_request(self) -> ConfigFilesRequest:
+        return ConfigFilesRequest(
+            specified=self.config,
+            check_existence=["pylintrc", ".pylinrc"],
+            check_content={"pyproject.toml": b"[tool.pylint]", "setup.cfg": b"[pylint."},
+            option_name=f"[{self.options_scope}].config",
+        )
 
     @property
     def source_plugins(self) -> UnparsedAddressInputs:

--- a/src/python/pants/backend/python/lint/python_fmt_integration_test.py
+++ b/src/python/pants/backend/python/lint/python_fmt_integration_test.py
@@ -10,7 +10,7 @@ from pants.backend.python.lint.isort.rules import rules as isort_rules
 from pants.backend.python.lint.python_fmt import PythonFmtTargets, format_python_target
 from pants.backend.python.target_types import PythonLibrary
 from pants.core.goals.fmt import LanguageFmtResults, enrich_fmt_result
-from pants.core.util_rules import source_files, warn_config_files_not_setup
+from pants.core.util_rules import config_files, source_files
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.target import Target, Targets
@@ -29,7 +29,7 @@ def rule_runner() -> RuleRunner:
             *black_rules(),
             *isort_rules(),
             *source_files.rules(),
-            *warn_config_files_not_setup.rules(),
+            *config_files.rules(),
             QueryRule(LanguageFmtResults, (PythonFmtTargets,)),
         ],
         target_types=[PythonLibrary],

--- a/src/python/pants/backend/python/lint/python_fmt_integration_test.py
+++ b/src/python/pants/backend/python/lint/python_fmt_integration_test.py
@@ -10,6 +10,7 @@ from pants.backend.python.lint.isort.rules import rules as isort_rules
 from pants.backend.python.lint.python_fmt import PythonFmtTargets, format_python_target
 from pants.backend.python.target_types import PythonLibrary
 from pants.core.goals.fmt import LanguageFmtResults, enrich_fmt_result
+from pants.core.util_rules import source_files, warn_config_files_not_setup
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.target import Target, Targets
@@ -27,6 +28,8 @@ def rule_runner() -> RuleRunner:
             format_python_target,
             *black_rules(),
             *isort_rules(),
+            *source_files.rules(),
+            *warn_config_files_not_setup.rules(),
             QueryRule(LanguageFmtResults, (PythonFmtTargets,)),
         ],
         target_types=[PythonLibrary],

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -3,6 +3,7 @@
 
 from typing import Optional, Tuple, cast
 
+from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.option.custom_types import file_option, shell_str
 from pants.option.subsystem import Subsystem
 
@@ -125,3 +126,16 @@ class PyTest(Subsystem):
     @property
     def config(self) -> Optional[str]:
         return cast(Optional[str], self.options.config)
+
+    @property
+    def config_request(self) -> ConfigFilesRequest:
+        return ConfigFilesRequest(
+            specified=self.config,
+            check_existence=["pytest.ini"],
+            check_content={
+                "pyproject.toml": b"[tool.pytest.ini_options]",
+                "tox.ini": b"[pytest]",
+                "setup.cfg": b"[tool:pytest]",
+            },
+            option_name=f"[{self.options_scope}].config",
+        )

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -26,15 +26,7 @@ from pants.backend.python.util_rules.python_sources import (
 from pants.core.goals.typecheck import TypecheckRequest, TypecheckResult, TypecheckResults
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.engine.addresses import Address, Addresses, UnparsedAddressInputs
-from pants.engine.fs import (
-    CreateDigest,
-    Digest,
-    DigestContents,
-    FileContent,
-    GlobMatchErrorBehavior,
-    MergeDigests,
-    PathGlobs,
-)
+from pants.engine.fs import CreateDigest, Digest, DigestContents, FileContent, MergeDigests
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import FieldSet, Target, TransitiveTargets, TransitiveTargetsRequest
@@ -108,14 +100,6 @@ def check_and_warn_if_python_version_configured(
             "code and Python 3-only code at the same time. This feature may no longer work.)"
         )
     return bool(configured)
-
-
-def config_path_globs(mypy: MyPy) -> PathGlobs:
-    return PathGlobs(
-        globs=[mypy.config] if mypy.config else [],
-        glob_match_error_behavior=GlobMatchErrorBehavior.error,
-        description_of_origin="the option `[mypy].config`",
-    )
 
 
 def determine_python_files(files: Iterable[str]) -> Tuple[str, ...]:

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -19,7 +19,7 @@ from pants.backend.python.typecheck.mypy.rules import (
 )
 from pants.backend.python.typecheck.mypy.rules import rules as mypy_rules
 from pants.core.goals.typecheck import TypecheckResult, TypecheckResults
-from pants.core.util_rules import pants_bin, warn_config_files_not_setup
+from pants.core.util_rules import config_files, pants_bin
 from pants.engine.addresses import Address
 from pants.engine.fs import FileContent
 from pants.engine.rules import QueryRule
@@ -40,7 +40,7 @@ def rule_runner() -> RuleRunner:
             *mypy_rules(),
             *dependency_inference_rules.rules(),  # Used for import inference.
             *pants_bin.rules(),
-            *warn_config_files_not_setup.rules(),
+            *config_files.rules(),
             QueryRule(TypecheckResults, (MyPyRequest,)),
         ],
         target_types=[PythonLibrary, PythonRequirementLibrary],

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -19,6 +19,7 @@ from pants.backend.python.typecheck.mypy.rules import (
 )
 from pants.backend.python.typecheck.mypy.rules import rules as mypy_rules
 from pants.core.goals.typecheck import TypecheckResult, TypecheckResults
+from pants.core.util_rules import pants_bin, warn_config_files_not_setup
 from pants.engine.addresses import Address
 from pants.engine.fs import FileContent
 from pants.engine.rules import QueryRule
@@ -38,6 +39,8 @@ def rule_runner() -> RuleRunner:
         rules=[
             *mypy_rules(),
             *dependency_inference_rules.rules(),  # Used for import inference.
+            *pants_bin.rules(),
+            *warn_config_files_not_setup.rules(),
             QueryRule(TypecheckResults, (MyPyRequest,)),
         ],
         target_types=[PythonLibrary, PythonRequirementLibrary],

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -77,7 +77,7 @@ class MyPy(PythonToolBase):
     @property
     def config_request(self) -> ConfigFilesRequest:
         return ConfigFilesRequest(
-            specified=self.options,
+            specified=self.config,
             check_existence=["mypy.ini", ".mypy.ini"],
             check_content={"setup.cfg": b"[mypy"},
             option_name="[mypy].config",

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -7,6 +7,7 @@ from typing import Tuple, cast
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
+from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.addresses import UnparsedAddressInputs
 from pants.option.custom_types import file_option, shell_str, target_option
 
@@ -72,6 +73,15 @@ class MyPy(PythonToolBase):
     @property
     def config(self) -> str | None:
         return cast("str | None", self.options.config)
+
+    @property
+    def config_request(self) -> ConfigFilesRequest:
+        return ConfigFilesRequest(
+            specified=self.options,
+            check_existence=["mypy.ini", ".mypy.ini"],
+            check_content={"setup.cfg": b"[mypy"},
+            option_name="[mypy].config",
+        )
 
     @property
     def source_plugins(self) -> UnparsedAddressInputs:

--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -18,6 +18,7 @@ from pants.core.util_rules import (
     source_files,
     stripped_source_files,
     subprocess_environment,
+    warn_config_files_not_setup,
 )
 from pants.goal import anonymous_telemetry, stats_aggregator
 from pants.source import source_root
@@ -47,6 +48,7 @@ def rules():
         *target_type_rules(),
         *anonymous_telemetry.rules(),
         *stats_aggregator.rules(),
+        *warn_config_files_not_setup.rules(),
     ]
 
 

--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -11,6 +11,7 @@ from pants.core.target_types import ArchiveTarget, Files, GenericTarget, Relocat
 from pants.core.target_types import rules as target_type_rules
 from pants.core.util_rules import (
     archive,
+    config_files,
     distdir,
     external_tool,
     filter_empty_sources,
@@ -18,7 +19,6 @@ from pants.core.util_rules import (
     source_files,
     stripped_source_files,
     subprocess_environment,
-    warn_config_files_not_setup,
 )
 from pants.goal import anonymous_telemetry, stats_aggregator
 from pants.source import source_root
@@ -36,6 +36,7 @@ def rules():
         *typecheck.rules(),
         *tailor.rules(),
         # util_rules
+        *config_files.rules(),
         *distdir.rules(),
         *filter_empty_sources.rules(),
         *pants_bin.rules(),
@@ -48,7 +49,6 @@ def rules():
         *target_type_rules(),
         *anonymous_telemetry.rules(),
         *stats_aggregator.rules(),
-        *warn_config_files_not_setup.rules(),
     ]
 
 

--- a/src/python/pants/core/util_rules/warn_config_files_not_setup.py
+++ b/src/python/pants/core/util_rules/warn_config_files_not_setup.py
@@ -1,0 +1,89 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Iterable, Mapping
+
+from pants.engine.fs import DigestContents, PathGlobs, Paths
+from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.util.frozendict import FrozenDict
+from pants.util.logging import LogLevel
+from pants.util.meta import frozen_after_init
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class WarnConfigFilesNotSetupResult:
+    pass
+
+
+@frozen_after_init
+@dataclass(unsafe_hash=True)
+class WarnConfigFilesNotSetup:
+    """Warn if any of the specified locations are found in the build root by suggesting that the
+    user configure the corresponding option.
+
+    Files in `check_existence` only need to exist, whereas files in `check_content` both must
+    exist and contain the bytes snippet in the file.
+
+    Use with `Get(WarnConfigFilesNotSetupResult, WarnConfigFilesNotSetupResult).
+    """
+
+    check_existence: tuple[str, ...]
+    check_content: FrozenDict[str, bytes]
+    option_name: str
+
+    def __init__(
+        self,
+        *,
+        option_name: str,
+        check_existence: Iterable[str] = (),
+        check_content: Mapping[str, bytes] = FrozenDict(),
+    ) -> None:
+        self.check_existence = tuple(sorted(check_existence))
+        self.check_content = FrozenDict(check_content)
+        self.option_name = option_name
+
+
+@rule(desc="Check if config files not yet set up", level=LogLevel.DEBUG)
+async def warn_if_config_file_not_setup(
+    request: WarnConfigFilesNotSetup,
+) -> WarnConfigFilesNotSetupResult:
+    existence_paths, content_digest_contents = await MultiGet(
+        Get(Paths, PathGlobs(request.check_existence)),
+        Get(DigestContents, PathGlobs(request.check_content)),
+    )
+    discovered_config = sorted(
+        {
+            *existence_paths.files,
+            *(
+                file_content.path
+                for file_content in content_digest_contents
+                if request.check_content[file_content.path] in file_content.content
+            ),
+        }
+    )
+    if discovered_config:
+        detected = (
+            f"a relevant config file at {discovered_config[0]}"
+            if len(discovered_config) == 1
+            else f"relevant config files at {discovered_config}"
+        )
+        warning_prefix = f"The option `{request.option_name}` is not configured"
+        logger.warning(
+            f"{warning_prefix}, but Pants detected "
+            f"{detected}. Did you mean to set the option `{request.option_name}`? Pants requires "
+            f"that you explicitly set up config files for them to be used.\n\n"
+            f"(If you do no want to use this config, you can ignore this warning by adding "
+            f'`ignore_warnings = ["{warning_prefix}"]` to `pants.toml` in the `GLOBAL` '
+            f"section.)"
+        )
+    return WarnConfigFilesNotSetupResult()
+
+
+def rules():
+    return collect_rules()

--- a/src/python/pants/core/util_rules/warn_config_files_not_setup_test.py
+++ b/src/python/pants/core/util_rules/warn_config_files_not_setup_test.py
@@ -1,0 +1,54 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from pants.core.util_rules import warn_config_files_not_setup
+from pants.core.util_rules.warn_config_files_not_setup import (
+    WarnConfigFilesNotSetup,
+    WarnConfigFilesNotSetupResult,
+)
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+
+def test_warn_if_config_file_not_setup(caplog) -> None:
+    rule_runner = RuleRunner(
+        rules=[
+            *warn_config_files_not_setup.rules(),
+            QueryRule(WarnConfigFilesNotSetupResult, [WarnConfigFilesNotSetup]),
+        ],
+    )
+    rule_runner.write_files({"c1": "", "c2": "", "c3": "foo", "c4": "bar"})
+
+    def warn(existence: list[str], content: dict[str, bytes]) -> None:
+        caplog.clear()
+        rule_runner.request(
+            WarnConfigFilesNotSetupResult,
+            [
+                WarnConfigFilesNotSetup(
+                    check_existence=existence,
+                    check_content=content,
+                    option_name="[subsystem].config",
+                )
+            ],
+        )
+
+    warn(["c1", "fake"], {"c3": b"foo", "c4": b"bad"})
+    assert len(caplog.records) == 1
+    assert (
+        "The option `[subsystem].config` is not configured, but Pants detected relevant config "
+        "files at ['c1', 'c3']."
+    ) in caplog.text
+
+    warn(["c1"], {})
+    assert len(caplog.records) == 1
+    assert (
+        "The option `[subsystem].config` is not configured, but Pants detected a relevant config "
+        "file at c1."
+    ) in caplog.text
+
+    warn([], {})
+    assert not caplog.records
+
+    warn(["fake"], {"c4": b"bad"})
+    assert not caplog.records


### PR DESCRIPTION
A gotcha when setting up Pants is that you must tell Pants about config files, whereas running the underlying tools directly usually auto-detects them. We have a warning at https://www.pantsbuild.org/v2.4/docs/python-linters-and-formatters#configuring-the-tools-and-adding-plugins, but it's really easy to miss that in our docs and a runtime warning reduces the risk of confusion here.

Example warning:

> 12:55:14.71 [WARN] The option `[isort].config` is not configured, but Pants detected relevant config files at ['.isort.cfg', 'pyproject.toml']. Did you mean to set the option `[isort].config`? Pants requires that you explicitly set up config files for them to be used.
> 
> (If you do no want to use this config, you can ignore this warning by adding `ignore_warnings = ["The option `[isort].config` is not configured"]` to `pants.toml` in the `GLOBAL` section.)

To land this, we factor up a `ConfigFilesRequest -> ConfigFiles` rule, which reduces the duplication across our formatters/linters. This will be a good vehicle for us to start doing fancier things with config files, including possibly a) using auto-discovered config files, and b) warning if there are global config files in $HOME.

[ci skip-rust]
[ci skip-build-wheels]