### PR TITLE
Release Pants with Python 3.9

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -4,7 +4,7 @@
 
 
 env:
-  PANTS_CONFIG_FILES: +['pants.ci.toml']
+  PANTS_CONFIG_FILES: +['pants.ci.toml', 'pants.no-buildsense.toml']
   RUST_BACKTRACE: all
 jobs:
   bootstrap_pants_linux:
@@ -139,6 +139,7 @@ jobs:
       matrix:
         python-version:
         - '3.8'
+        - '3.9'
     timeout-minutes: 40
   bootstrap_pants_macos:
     env:
@@ -251,6 +252,7 @@ jobs:
       matrix:
         python-version:
         - '3.8'
+        - '3.9'
     timeout-minutes: 40
   lint_python:
     name: Lint Python and Shell
@@ -325,6 +327,7 @@ jobs:
       matrix:
         python-version:
         - '3.8'
+        - '3.9'
     timeout-minutes: 30
   test_python_linux:
     name: Test Python (Linux)
@@ -399,6 +402,7 @@ jobs:
       matrix:
         python-version:
         - '3.8'
+        - '3.9'
     timeout-minutes: 60
   test_python_macos:
     env:
@@ -475,8 +479,8 @@ jobs:
       matrix:
         python-version:
         - '3.8'
+        - '3.9'
     timeout-minutes: 20
 name: Daily Extended Python Testing
 'on':
-  schedule:
-  - cron: 45 8 * * *
+- pull_request

--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -483,4 +483,5 @@ jobs:
     timeout-minutes: 20
 name: Daily Extended Python Testing
 'on':
-- pull_request
+  schedule:
+  - cron: 45 8 * * *

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -290,20 +290,24 @@ jobs:
 
         '
     - name: Expose Pythons
-      run: echo "PATH=${PATH}:/opt/python/cp37-cp37m/bin:/opt/python/cp38-cp38/bin"
+      run: echo "PATH=${PATH}:/opt/python/cp37-cp37m/bin:/opt/python/cp38-cp38/bin:/opt/python/cp39-cp39/bin"
         >> $GITHUB_ENV
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
 
         '
-    - if: github.event_name == 'push' || !contains(env.COMMIT_MESSAGE, '[ci skip-build-wheels]')
+    - env:
+        PANTS_CONFIG_FILES: +['pants.ci.toml', 'pants.no-buildsense.toml']
+      if: github.event_name == 'push' || !contains(env.COMMIT_MESSAGE, '[ci skip-build-wheels]')
       name: Build wheels and fs_util
       run: '[[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && export MODE=debug
 
         ./build-support/bin/release.sh -n
 
         USE_PY38=true ./build-support/bin/release.sh -n
+
+        USE_PY39=true ./build-support/bin/release.sh -n
 
         ./build-support/bin/release.sh -f
 
@@ -379,6 +383,7 @@ jobs:
           '
     - env:
         ARCHFLAGS: -arch x86_64
+        PANTS_CONFIG_FILES: +['pants.ci.toml', 'pants.no-buildsense.toml']
       if: github.event_name == 'push' || !contains(env.COMMIT_MESSAGE, '[ci skip-build-wheels]')
       name: Build wheels and fs_util
       run: '[[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && export MODE=debug
@@ -386,6 +391,8 @@ jobs:
         ./build-support/bin/release.sh -n
 
         USE_PY38=true ./build-support/bin/release.sh -n
+
+        USE_PY39=true ./build-support/bin/release.sh -n
 
         ./build-support/bin/release.sh -f
 

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -497,8 +497,7 @@ def generate() -> dict[Path, str]:
         {
             "name": "Daily Extended Python Testing",
             # 08:45 UTC / 12:45AM PST, 1:45AM PDT: arbitrary time after hours.
-            # "on": {"schedule": [{"cron": "45 8 * * *"}]},
-            "on": ["pull_request"],
+            "on": {"schedule": [{"cron": "45 8 * * *"}]},
             "jobs": test_workflow_jobs([PYTHON38_VERSION, PYTHON39_VERSION], cron=True),
             "env": global_env(disable_buildsense=True),
         },

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -130,9 +130,9 @@ def pants_virtualenv_cache() -> Step:
 def global_env(*, disable_buildsense: bool = False) -> Env:
     return {
         "PANTS_CONFIG_FILES": (
-            "+['pants.ci.toml']"
-            if not disable_buildsense
-            else "+['pants.ci.toml', 'pants.no-buildsense.toml']"
+            "+['pants.ci.toml', 'pants.no-buildsense.toml']"
+            if disable_buildsense
+            else "+['pants.ci.toml']"
         ),
         "RUST_BACKTRACE": "all",
     }

--- a/build-support/bin/packages.py
+++ b/build-support/bin/packages.py
@@ -431,10 +431,10 @@ def check_prebuilt_wheels(check_dir: str) -> None:
         if not local_files:
             missing_packages.append(package.name)
             continue
-        if is_cross_platform(local_files) and len(local_files) != 4:
+        if is_cross_platform(local_files) and len(local_files) != 6:
             formatted_local_files = ", ".join(f.name for f in local_files)
             missing_packages.append(
-                f"{package.name} (expected 4 wheels, {{macosx, linux}} x {{cp37m, cp38}}, "
+                f"{package.name} (expected 6 wheels, {{macosx, linux}} x {{cp37m, cp38, cp39}}, "
                 f"but found {formatted_local_files})"
             )
     if missing_packages:

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -26,6 +26,9 @@ source "${ROOT}/build-support/common.sh"
 if [[ "${USE_PY38:-false}" == "true" ]]; then
   default_python=python3.8
   interpreter_constraint="==3.8.*"
+elif [[ "${USE_PY39:-false}" == "true" ]]; then
+  default_python=python3.9
+  interpreter_constraint="==3.9.*"
 else
   default_python=python3.7
   interpreter_constraint="==3.7.*"
@@ -36,8 +39,8 @@ if ! command -v "${PY}" > /dev/null; then
   die "Python interpreter ${PY} not discoverable on your PATH."
 fi
 py_major_minor=$(${PY} -c 'import sys; print(".".join(map(str, sys.version_info[0:2])))')
-if [[ "${py_major_minor}" != "3.7" && "${py_major_minor}" != "3.8" ]]; then
-  die "Invalid interpreter. The release script requires Python 3.7 or 3.8 (you are using ${py_major_minor})."
+if [[ "${py_major_minor}" != "3.7" && "${py_major_minor}" != "3.8" && "${py_major_minor}" != "3.9" ]]; then
+  die "Invalid interpreter. The release script requires Python 3.7, 3.8, or 3.9 (you are using ${py_major_minor})."
 fi
 
 # This influences what setuptools is run with, which determines the interpreter used for building
@@ -308,7 +311,7 @@ function build_pex() {
       ;;
     fetch)
       local distribution_target_flags=()
-      abis=("cp-37-m" "cp-38-cp38")
+      abis=("cp-37-m" "cp-38-cp38" "cp-39-cp39")
       for platform in "${linux_platform_noabi}" "${osx_platform_noabi}"; do
         for abi in "${abis[@]}"; do
           distribution_target_flags=("${distribution_target_flags[@]}" "--platform=${platform}-${abi}")

--- a/build-support/common.sh
+++ b/build-support/common.sh
@@ -77,7 +77,7 @@ function determine_python() {
     echo "${PY}"
     return 0
   fi
-  for version in '3.7' '3.8'; do
+  for version in '3.7' '3.8' '3.9'; do
     local interpreter_path
     interpreter_path="$(command -v "python${version}")"
     if [[ -z "${interpreter_path}" ]]; then

--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -29,7 +29,7 @@ function activate_venv() {
 
 function create_venv() {
   rm -rf "$(venv_dir)"
-  "${PY}" -m venv "$(venv_dir)"
+  "${PY}" -m venv "$(venv_dir)" && "$(venv_dir)/bin/pip" install wheel
 }
 
 function ensure_gcc() {

--- a/pants.no-buildsense.toml
+++ b/pants.no-buildsense.toml
@@ -1,0 +1,7 @@
+[GLOBAL]
+verify_config = false
+
+plugins = ["hdrhistogram"]
+
+remote_cache_read = false
+remote_cache_write = false

--- a/pants.toml
+++ b/pants.toml
@@ -73,7 +73,7 @@ root_patterns = [
 [python-setup]
 requirement_constraints = "3rdparty/python/constraints.txt"
 resolve_all_constraints = "nondeployables"
-interpreter_constraints = [">=3.7,<3.9"]
+interpreter_constraints = [">=3.7,<3.10"]
 
 [black]
 config = "pyproject.toml"
@@ -170,7 +170,7 @@ extra_env_vars = [
 ]
 
 [coverage-py]
-interpreter_constraints = [">=3.7,<3.9"]
+interpreter_constraints = [">=3.7,<3.10"]
 
 [sourcefile-validation]
 config = "@build-support/regexes/config.yaml"

--- a/src/python/pants/option/optionable_test.py
+++ b/src/python/pants/option/optionable_test.py
@@ -13,7 +13,9 @@ class OptionableTest(unittest.TestCase):
 
         with self.assertRaises(TypeError) as cm:
             NoScope()  # type: ignore[abstract]
-        assert ("with abstract methods options_scope") in str(cm.exception)
+        assert "with abstract methods options_scope" in str(
+            cm.exception
+        ) or "with abstract method options_scope" in str(cm.exception)
 
         class StringScope(Optionable):
             options_scope = "good"

--- a/src/python/pants/testutil/BUILD
+++ b/src/python/pants/testutil/BUILD
@@ -8,7 +8,7 @@ python_distribution(
     ':pants_integration_test',
     ':rule_runner',
   ],
-  setup_py_commands=["bdist_wheel", "--python-tag", "py37.py38", "sdist"],
+  setup_py_commands=["bdist_wheel", "--python-tag", "py37.py38.py39", "sdist"],
   provides=setup_py(
     name='pantsbuild.pants.testutil',
     description='Test support for writing Pants plugins.',

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -408,8 +408,7 @@ checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 [[package]]
 name = "cpython"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f11357af68648b6a227e7e2384d439cec8595de65970f45e3f7f4b2600be472"
+source = "git+https://github.com/pantsbuild/rust-cpython?rev=46d7eff26a705384e41eb6f7b870cd3f5f14b3bc#46d7eff26a705384e41eb6f7b870cd3f5f14b3bc"
 dependencies = [
  "libc",
  "num-traits",
@@ -1880,22 +1879,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "0.1.18"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880"
-dependencies = [
- "paste-impl",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "paste-impl"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
-dependencies = [
- "proc-macro-hack",
-]
+checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
 
 [[package]]
 name = "percent-encoding"
@@ -2197,8 +2183,7 @@ dependencies = [
 [[package]]
 name = "python3-sys"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b29b99c6868eb02beb3bf6ed025c8bcdf02efc149b8e80347d3e5d059a806db"
+source = "git+https://github.com/pantsbuild/rust-cpython?rev=46d7eff26a705384e41eb6f7b870cd3f5f14b3bc#46d7eff26a705384e41eb6f7b870cd3f5f14b3bc"
 dependencies = [
  "libc",
  "regex",

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -102,7 +102,8 @@ async_semaphore = { path = "async_semaphore" }
 async-trait = "0.1"
 bytes = "1.0"
 concrete_time = { path = "concrete_time" }
-cpython = "0.5"
+# TODO: Go back to upstream once https://github.com/dgrunwald/rust-cpython/pull/261 lands.
+cpython = { git = "https://github.com/pantsbuild/rust-cpython", rev = "46d7eff26a705384e41eb6f7b870cd3f5f14b3bc" }
 crossbeam-channel = "0.4"
 fnv = "1.0.5"
 fs = { path = "fs" }


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/11309.

To avoid a segfault, we must use a patch of rust-cpython so that Rust compilations are invalidated when changing between 3.7 and 3.9. https://github.com/dgrunwald/rust-cpython/pull/261