### PR TITLE
Add `--remote-cache-warnings` and make remote cache warnings less chatty

### DIFF
--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -4,6 +4,9 @@ colors = true
 # TODO: See #9924.
 dynamic_ui = false
 
+# We want to continue to get logs when remote caching errors.
+remote_cache_warnings = "backoff"
+
 [stats]
 log = true
 

--- a/pants.toml
+++ b/pants.toml
@@ -56,7 +56,7 @@ pants_ignore.add = [
 # NB: Users must still set `--remote-cache-read --remote-cache-write` to enable this all.
 remote_store_address = "grpcs://build.toolchain.com:443"
 remote_instance_name = "main"
-remote_auth_plugin = "toolchain.pants.auth.plugin:toolchain_auth_plugin"
+#remote_auth_plugin = "toolchain.pants.auth.plugin:toolchain_auth_plugin"
 
 [anonymous-telemetry]
 enabled = true

--- a/pants.toml
+++ b/pants.toml
@@ -56,7 +56,7 @@ pants_ignore.add = [
 # NB: Users must still set `--remote-cache-read --remote-cache-write` to enable this all.
 remote_store_address = "grpcs://build.toolchain.com:443"
 remote_instance_name = "main"
-#remote_auth_plugin = "toolchain.pants.auth.plugin:toolchain_auth_plugin"
+remote_auth_plugin = "toolchain.pants.auth.plugin:toolchain_auth_plugin"
 
 [anonymous-telemetry]
 enabled = true

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -173,6 +173,7 @@ class Scheduler:
             store_chunk_bytes=execution_options.remote_store_chunk_bytes,
             store_chunk_upload_timeout=execution_options.remote_store_chunk_upload_timeout_seconds,
             store_rpc_retries=execution_options.remote_store_rpc_retries,
+            cache_warnings_behavior=execution_options.remote_cache_warnings.value,
             cache_eager_fetch=execution_options.remote_cache_eager_fetch,
             execution_extra_platform_properties=tuple(
                 tuple(pair.split("=", 1))

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -85,6 +85,13 @@ class OwnersNotFoundBehavior(Enum):
 
 
 @enum.unique
+class RemoteCacheWarningsBehavior(Enum):
+    ignore = "ignore"
+    first_only = "first_only"
+    backoff = "backoff"
+
+
+@enum.unique
 class AuthPluginState(Enum):
     OK = "ok"
     UNAVAILABLE = "unavailable"
@@ -140,6 +147,7 @@ class ExecutionOptions:
     remote_store_rpc_retries: int
 
     remote_cache_eager_fetch: bool
+    remote_cache_warnings: RemoteCacheWarningsBehavior
 
     remote_execution_address: str | None
     remote_execution_extra_platform_properties: List[str]
@@ -258,6 +266,7 @@ class ExecutionOptions:
             remote_store_rpc_retries=bootstrap_options.remote_store_rpc_retries,
             # Remote cache setup.
             remote_cache_eager_fetch=bootstrap_options.remote_cache_eager_fetch,
+            remote_cache_warnings=bootstrap_options.remote_cache_warnings,
             # Remote execution setup.
             remote_execution_address=remote_execution_address,
             remote_execution_extra_platform_properties=bootstrap_options.remote_execution_extra_platform_properties,
@@ -329,6 +338,7 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     remote_store_rpc_retries=2,
     # Remote cache setup.
     remote_cache_eager_fetch=True,
+    remote_cache_warnings=RemoteCacheWarningsBehavior.first_only,
     # Remote execution setup.
     remote_execution_address=None,
     remote_execution_extra_platform_properties=[],
@@ -1051,6 +1061,17 @@ class GlobalOptions(Subsystem):
             help="Number of times to retry any RPC to the remote store before giving up.",
         )
 
+        register(
+            "--remote-cache-warnings",
+            type=RemoteCacheWarningsBehavior,
+            default=DEFAULT_EXECUTION_OPTIONS.remote_cache_warnings,
+            advanced=True,
+            help=(
+                "Whether to log remote cache failures at the `warn` log level.\n\n"
+                "All errors not logged at the `warn` level will instead be logged at the "
+                "`debug` level."
+            ),
+        )
         register(
             "--remote-cache-eager-fetch",
             type=bool,

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -2096,6 +2096,8 @@ dependencies = [
  "shell-quote",
  "spectral",
  "store",
+ "strum",
+ "strum_macros",
  "task_executor",
  "tempfile",
  "testutil",

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -215,10 +215,6 @@ async fn write_file_errors() {
     .await
     .expect_err("Want error");
   assert!(
-    error.contains("Error from server"),
-    format!("Bad error message, got: {}", error)
-  );
-  assert!(
     error.contains("StubCAS is configured to always fail"),
     format!("Bad error message, got: {}", error)
   );

--- a/src/rust/engine/grpc_util/src/lib.rs
+++ b/src/rust/engine/grpc_util/src/lib.rs
@@ -138,5 +138,5 @@ pub fn headers_to_interceptor_fn(
 }
 
 pub fn status_to_str(status: tonic::Status) -> String {
-  format!("{:?}: {:?}", status.code(), status.message(),)
+  format!("{:?}: {:?}", status.code(), status.message())
 }

--- a/src/rust/engine/grpc_util/src/lib.rs
+++ b/src/rust/engine/grpc_util/src/lib.rs
@@ -136,3 +136,7 @@ pub fn headers_to_interceptor_fn(
     Ok(req)
   })
 }
+
+pub fn status_to_str(status: tonic::Status) -> String {
+  format!("{:?}: {:?}", status.code(), status.message(),)
+}

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -42,6 +42,8 @@ double-checked-cell-async = "2.0"
 rand = "0.8"
 prost = "0.7"
 prost-types = "0.7"
+strum = "0.20"
+strum_macros = "0.20"
 tonic = { version = "0.4", features = ["transport", "codegen", "tls", "tls-roots", "prost"] }
 tryfuture = { path = "../tryfuture" }
 

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -616,5 +616,13 @@ impl From<Box<BoundedCommandRunner>> for Arc<dyn CommandRunner> {
   }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, strum_macros::EnumString)]
+#[strum(serialize_all = "snake_case")]
+pub enum RemoteCacheWarningsBehavior {
+  Ignore,
+  FirstOnly,
+  Backoff,
+}
+
 #[cfg(test)]
 mod tests;

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -410,7 +410,7 @@ impl CommandRunner {
     let log_at_warn = match self.warnings_behavior {
       RemoteCacheWarningsBehavior::Ignore => false,
       RemoteCacheWarningsBehavior::FirstOnly => err_count == 1,
-      RemoteCacheWarningsBehavior::Backoff => (err_count as f64).log2().fract() == 0.0,
+      RemoteCacheWarningsBehavior::Backoff => err_count.is_power_of_two(),
     };
     if log_at_warn {
       log::warn!("{}", log_msg);

--- a/src/rust/engine/process_execution/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_cache_tests.rs
@@ -22,6 +22,7 @@ use crate::remote::{ensure_action_stored_locally, make_execute_request};
 use crate::{
   CommandRunner as CommandRunnerTrait, Context, FallibleProcessResultWithPlatform,
   MultiPlatformProcess, Platform, Process, ProcessMetadata, ProcessResultMetadata,
+  RemoteCacheWarningsBehavior,
 };
 
 /// A mock of the local runner used for better hermeticity of the tests.
@@ -137,6 +138,7 @@ fn create_cached_runner(
       Platform::current().unwrap(),
       true,
       true,
+      RemoteCacheWarningsBehavior::FirstOnly,
       eager_fetch,
     )
     .expect("caching command runner"),

--- a/src/rust/engine/process_execution/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_cache_tests.rs
@@ -586,6 +586,7 @@ async fn make_action_result_basic() {
     Platform::current().unwrap(),
     true,
     true,
+    RemoteCacheWarningsBehavior::FirstOnly,
     false,
   )
   .expect("caching command runner");

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -23,6 +23,7 @@ use log::info;
 use parking_lot::Mutex;
 use process_execution::{
   self, BoundedCommandRunner, CommandRunner, NamedCaches, Platform, ProcessMetadata,
+  RemoteCacheWarningsBehavior,
 };
 use regex::Regex;
 use rule_graph::RuleGraph;
@@ -77,6 +78,7 @@ pub struct RemotingOptions {
   pub store_chunk_bytes: usize,
   pub store_chunk_upload_timeout: Duration,
   pub store_rpc_retries: usize,
+  pub cache_warnings_behavior: RemoteCacheWarningsBehavior,
   pub cache_eager_fetch: bool,
   pub execution_extra_platform_properties: Vec<(String, String)>,
   pub execution_headers: BTreeMap<String, String>,
@@ -213,6 +215,7 @@ impl Core {
           Platform::current()?,
           exec_strategy_opts.remote_cache_read,
           exec_strategy_opts.remote_cache_write,
+          remoting_opts.cache_warnings_behavior,
           remoting_opts.cache_eager_fetch,
         )?)
       } else {

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -49,6 +49,7 @@ use std::io;
 use std::os::unix::ffi::OsStrExt;
 use std::panic;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -65,6 +66,7 @@ use hashing::Digest;
 use log::{self, debug, error, warn, Log};
 use logging::logger::PANTS_LOGGER;
 use logging::{Logger, PythonLogLevel};
+use process_execution::RemoteCacheWarningsBehavior;
 use regex::Regex;
 use rule_graph::{self, RuleGraph};
 use std::collections::hash_map::HashMap;
@@ -560,6 +562,7 @@ py_class!(class PyRemotingOptions |py| {
     store_chunk_bytes: u64,
     store_chunk_upload_timeout: u64,
     store_rpc_retries: u64,
+    cache_warnings_behavior: String,
     cache_eager_fetch: bool,
     execution_extra_platform_properties: Vec<(String, String)>,
     execution_headers: Vec<(String, String)>,
@@ -577,6 +580,7 @@ py_class!(class PyRemotingOptions |py| {
         store_chunk_bytes: store_chunk_bytes as usize,
         store_chunk_upload_timeout: Duration::from_secs(store_chunk_upload_timeout),
         store_rpc_retries: store_rpc_retries as usize,
+        cache_warnings_behavior: RemoteCacheWarningsBehavior::from_str(&cache_warnings_behavior).unwrap(),
         cache_eager_fetch,
         execution_extra_platform_properties,
         execution_headers: execution_headers.into_iter().collect(),

--- a/tests/python/pants_test/integration/remote_cache_integration_test.py
+++ b/tests/python/pants_test/integration/remote_cache_integration_test.py
@@ -1,9 +1,8 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import re
-
 from pants.engine.internals.native_engine import PyExecutor, PyStubCAS
+from pants.option.global_options import RemoteCacheWarningsBehavior
 from pants.option.scope import GLOBAL_SCOPE_CONFIG_SECTION
 from pants.testutil.pants_integration_test import run_pants
 
@@ -14,38 +13,64 @@ def test_warns_on_remote_cache_errors():
     builder.always_errors()
     cas = builder.build(executor)
 
-    pants_run = run_pants(
-        [
-            "--backend-packages=['pants.backend.python']",
-            "--no-dynamic-ui",
-            "--level=info",
-            "package",
-            "testprojects/src/python/hello/main:main",
-        ],
-        use_pantsd=False,
-        config={
-            GLOBAL_SCOPE_CONFIG_SECTION: {
-                "remote_cache_read": True,
-                "remote_cache_write": True,
-                # NB: Our options code expects `grpc://`, which it will then convert back to
-                # `http://` before sending over FFI.
-                "remote_store_address": cas.address().replace("http://", "grpc://"),
-            }
-        },
-    )
-
-    pants_run.assert_success()
-    assert (
-        "Failed to read from remote cache (1 occurrences so far): Unimplemented" in pants_run.stderr
-    )
-    assert (
-        re.search(
-            (
-                r"Failed to write to remote cache \(1 occurrences so far\):.*StubCAS is configured "
-                r"to always fail"
-            ),
-            pants_run.stderr,
-            re.MULTILINE,
+    def run(behavior: RemoteCacheWarningsBehavior) -> str:
+        pants_run = run_pants(
+            [
+                "--backend-packages=['pants.backend.python']",
+                "--no-dynamic-ui",
+                "package",
+                "testprojects/src/python/hello/main:main",
+            ],
+            use_pantsd=False,
+            config={
+                GLOBAL_SCOPE_CONFIG_SECTION: {
+                    "remote_cache_read": True,
+                    "remote_cache_write": True,
+                    "remote_cache_warnings": behavior.value,
+                    # NB: Our options code expects `grpc://`, which it will then convert back to
+                    # `http://` before sending over FFI.
+                    "remote_store_address": cas.address().replace("http://", "grpc://"),
+                }
+            },
         )
-        is not None
-    )
+        pants_run.assert_success()
+        return pants_run.stderr
+
+    def read_err(i: int) -> str:
+        return f"Failed to read from remote cache ({i} occurrences so far): Unimplemented"
+
+    def write_err(i: int) -> str:
+        return (
+            f'Failed to write to remote cache ({i} occurrences so far): Internal: "StubCAS is '
+            f'configured to always fail"'
+        )
+
+    first_read_err = read_err(1)
+    first_write_err = write_err(1)
+    third_read_err = read_err(3)
+    third_write_err = write_err(3)
+    fourth_read_err = read_err(4)
+    fourth_write_err = write_err(4)
+
+    ignore_result = run(RemoteCacheWarningsBehavior.ignore)
+    for err in [
+        first_read_err,
+        first_write_err,
+        third_read_err,
+        third_write_err,
+        fourth_read_err,
+        fourth_write_err,
+    ]:
+        assert err not in ignore_result
+
+    first_only_result = run(RemoteCacheWarningsBehavior.first_only)
+    for err in [first_read_err, first_write_err]:
+        assert err in first_only_result
+    for err in [third_read_err, third_write_err, fourth_read_err, fourth_write_err]:
+        assert err not in first_only_result
+
+    backoff_result = run(RemoteCacheWarningsBehavior.backoff)
+    for err in [first_read_err, first_write_err, fourth_read_err, fourth_write_err]:
+        assert err in backoff_result
+    for err in [third_read_err, third_write_err]:
+        assert err not in backoff_result


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/11740 added new aggregation of remote cache logs. It was a fine start, but did not work properly for several error messages because we were dumping the headers, which included unique values like timestamps or the digest value:

> 23:16:17.28 [WARN] Failed to write to remote cache (1 occurrences so far): Error from server in response to find_missing_blobs_request: Status { code: PermissionDenied, message: "insufficient permissions", metadata: MetadataMap { headers: {"server": "awselb/2.0", "date": "Mon, 05 Apr 2021 23:16:17 GMT", "content-type": "application/grpc", "content-length": "0"} } }

Further, these headers were extremely noisy and most users don't care about them. They're now short:

> 23:16:17.28 [WARN] Failed to write to remote cache (1 occurrences so far): PermissionDenied:  "insufficient permissions"

Likewise, for most use cases, it was still too noisy to dump every increment. Our average use case should only log the very first time so that people are aware of the problem, but don't get flooded. In CI, users can set to log more frequently, which is now implemented via exponential backoff based on the exponent of 2.

[ci skip-build-wheels]