### PR TITLE
[internal] Upload pants logs and make them available as artifacts

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -289,6 +289,11 @@ jobs:
         ./pants lint typecheck ::
 
         '
+    - name: Upload pants log
+      uses: actions/upload-artifact@v2
+      with:
+        name: pants-log-python-lint
+        path: .pants.d/pants.log
     strategy:
       matrix:
         python-version:
@@ -350,6 +355,11 @@ jobs:
       run: './pants test ::
 
         '
+    - name: Upload pants log
+      uses: actions/upload-artifact@v2
+      with:
+        name: pants-log-python-test-linux
+        path: .pants.d/pants.log
     strategy:
       matrix:
         python-version:
@@ -413,6 +423,11 @@ jobs:
       run: './pants --tag=+platform_specific_behavior test ::
 
         '
+    - name: Upload pants log
+      uses: actions/upload-artifact@v2
+      with:
+        name: pants-log-python-test-macos
+        path: .pants.d/pants.log
     strategy:
       matrix:
         python-version:

--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -292,7 +292,7 @@ jobs:
     - name: Upload pants log
       uses: actions/upload-artifact@v2
       with:
-        name: pants-log-python-lint
+        name: pants-log-lint
         path: .pants.d/pants.log
     strategy:
       matrix:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -417,7 +417,7 @@ jobs:
     - name: Upload pants log
       uses: actions/upload-artifact@v2
       with:
-        name: pants-log-python-lint
+        name: pants-log-lint
         path: .pants.d/pants.log
     strategy:
       matrix:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -414,6 +414,11 @@ jobs:
         ./pants lint typecheck ::
 
         '
+    - name: Upload pants log
+      uses: actions/upload-artifact@v2
+      with:
+        name: pants-log-python-lint
+        path: .pants.d/pants.log
     strategy:
       matrix:
         python-version:
@@ -475,6 +480,11 @@ jobs:
       run: './pants test ::
 
         '
+    - name: Upload pants log
+      uses: actions/upload-artifact@v2
+      with:
+        name: pants-log-python-test-linux
+        path: .pants.d/pants.log
     strategy:
       matrix:
         python-version:
@@ -538,6 +548,11 @@ jobs:
       run: './pants --tag=+platform_specific_behavior test ::
 
         '
+    - name: Upload pants log
+      uses: actions/upload-artifact@v2
+      with:
+        name: pants-log-python-test-macos
+        path: .pants.d/pants.log
     strategy:
       matrix:
         python-version:

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -288,7 +288,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
                 *pants_virtualenv_cache(),
                 *native_engine_so_download(),
                 {"name": "Run Python tests", "run": "./pants test ::\n"},
-                *upload_log_artifacts(name="python-test-linux"),
+                upload_log_artifacts(name="python-test-linux"),
             ],
         },
         "lint_python": {
@@ -306,7 +306,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
                     "name": "Lint",
                     "run": "./pants validate '**'\n./pants lint typecheck ::\n",
                 },
-                *upload_log_artifacts(name="python-lint"),
+                upload_log_artifacts(name="lint"),
             ],
         },
         "bootstrap_pants_macos": {
@@ -349,7 +349,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
                     "name": "Run Python tests",
                     "run": "./pants --tag=+platform_specific_behavior test ::\n",
                 },
-                *upload_log_artifacts(name="python-test-macos"),
+                upload_log_artifacts(name="python-test-macos"),
             ],
         },
     }
@@ -417,14 +417,12 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
     return jobs
 
 
-def upload_log_artifacts(name: str) -> Sequence[Step]:
-    return [
-        {
-            "name": "Upload pants log",
-            "uses": "actions/upload-artifact@v2",
-            "with": {"name": f"pants-log-{name}", "path": ".pants.d/pants.log"},
-        }
-    ]
+def upload_log_artifacts(name: str) -> Step:
+    return {
+        "name": "Upload pants log",
+        "uses": "actions/upload-artifact@v2",
+        "with": {"name": f"pants-log-{name}", "path": ".pants.d/pants.log"},
+    }
 
 
 # ----------------------------------------------------------------------

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -288,6 +288,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
                 *pants_virtualenv_cache(),
                 *native_engine_so_download(),
                 {"name": "Run Python tests", "run": "./pants test ::\n"},
+                *upload_log_artifacts(name="python-test-linux"),
             ],
         },
         "lint_python": {
@@ -305,6 +306,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
                     "name": "Lint",
                     "run": "./pants validate '**'\n./pants lint typecheck ::\n",
                 },
+                *upload_log_artifacts(name="python-lint"),
             ],
         },
         "bootstrap_pants_macos": {
@@ -347,6 +349,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
                     "name": "Run Python tests",
                     "run": "./pants --tag=+platform_specific_behavior test ::\n",
                 },
+                *upload_log_artifacts(name="python-test-macos"),
             ],
         },
     }
@@ -412,6 +415,16 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
             }
         )
     return jobs
+
+
+def upload_log_artifacts(name: str) -> Sequence[Step]:
+    return [
+        {
+            "name": "Upload pants log",
+            "uses": "actions/upload-artifact@v2",
+            "with": {"name": f"pants-log-{name}", "path": ".pants.d/pants.log"},
+        }
+    ]
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Relevant GH docs: 
https://github.com/actions/upload-artifact
https://docs.github.com/en/actions/guides/storing-workflow-data-as-artifacts


### Problem

Some of the pants logs messages don't go into stdout/stderr and as a result they don't show up anywhere
### Solution

capture the pants logs from various runs and make them available as build artifacts.

### Result

Ability to look into those logs when needed (when things go sideways)