### PR TITLE
[internal] Upgrade toolchain plugin to v0.8.1

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -20,7 +20,7 @@ backend_packages.add = [
 ]
 plugins = [
   "hdrhistogram",  # For use with `--stats-log`.
-  "toolchain.pants.plugin==0.8.0",
+  "toolchain.pants.plugin==0.8.1",
 ]
 
 # The invalidation globs cover the PYTHONPATH by default, but we exclude some files that are on the

--- a/pants.toml
+++ b/pants.toml
@@ -17,19 +17,10 @@ backend_packages.add = [
   "pants.backend.shell.lint.shellcheck",
   "pants.backend.shell.lint.shfmt",
   "internal_plugins.releases",
-  "toolchain.pants.auth",
-  "toolchain.pants.buildsense",
-  "toolchain.pants.common",
 ]
 plugins = [
   "hdrhistogram",  # For use with `--stats-log`.
-  # TODO: Remove the relevant `ignore_pants_warning` entry when this is bumped.
-  "toolchain.pants.plugin==0.7.0",
-]
-
-ignore_warnings = [
-  # TODO: Remove when `toolchain.pants.plugin` is bumped past `0.7.0`.
-  "DeprecationWarning: DEPRECATED: pants.core.util_rules.pants_environment",
+  "toolchain.pants.plugin==0.8.0",
 ]
 
 # The invalidation globs cover the PYTHONPATH by default, but we exclude some files that are on the


### PR DESCRIPTION
Important changes:
* Usage of auto-registration mechanism via setup.py entry_points so no need to specify backends anymore.
* Removed support for python 3.9 since pants doesn't support it yet.
* Disabled async completion due to issues w/ pants logging and not uploading data to buildsense in some cases.
* Log when attempting to load auth token from env variables (used in CI)
