### PR TITLE
[internal] Use a config file to configure pants for release mode.

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -139,19 +139,7 @@ REQUIREMENTS_3RDPARTY_FILES=(
 # either pexes or venvs (as created by the `pants` script that we distribute) are
 # created outside of the buildroot.
 function execute_packaged_pants_with_internal_backends() {
-  pants \
-    --no-verify-config \
-    --no-remote-cache-read \
-    --no-remote-cache-write \
-    --no-pantsd \
-    --pythonpath="['pants-plugins']" \
-    --backend-packages="[\
-        'pants.backend.awslambda.python',\
-        'pants.backend.python',\
-        'pants.backend.shell',\
-        'internal_plugins.releases',\
-      ]" \
-    "$@"
+  pants --pants-config-files="+['pants.release.toml']" "$@"
 }
 
 function build_3rdparty_packages() {

--- a/pants.release.toml
+++ b/pants.release.toml
@@ -1,0 +1,14 @@
+[GLOBAL]
+verify_config=false
+remote_cache_read=false
+remote_cache_write=false
+pantsd=false
+
+pythonpath=["pants-plugins"]
+
+backend_packages=[
+  "pants.backend.awslambda.python",
+  "pants.backend.python",
+  "pants.backend.shell",
+  "internal_plugins.releases",
+]


### PR DESCRIPTION
I would like to be able to enable the toolchain plugin (buildsense) for the release script, at least when running in CI, so this is a cleanup to allow for that since specifying more command line params will make things less readable.
