### PR TITLE
Add macos workaround to build wheel step on macos.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -340,7 +340,9 @@ jobs:
         restore-keys: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-
 
           '
-    - if: github.event_name == 'push' || !contains(env.COMMIT_MESSAGE, '[ci skip-build-wheels]')
+    - env:
+        ARCHFLAGS: -arch x86_64
+      if: github.event_name == 'push' || !contains(env.COMMIT_MESSAGE, '[ci skip-build-wheels]')
       name: Build wheels and fs_util
       run: '[[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && export MODE=debug
 

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -253,7 +253,7 @@ def get_build_wheels_step(is_macos: bool) -> Step:
     if is_macos:
         # Works around bad `-arch arm64` flag embedded in Xcode 12.x Python interpreters on
         # intel machines. See: https://github.com/giampaolo/psutil/issues/1832
-        step["env"] = {"ARCHFLAGS": "-arch x86_64"}
+        step["env"] = {"ARCHFLAGS": "-arch x86_64"}  # type: ignore[assignment]
     return step
 
 


### PR DESCRIPTION
### Problem

See: https://github.com/pantsbuild/pants/pull/11733
This issue now happens during wheel build:  https://github.com/pantsbuild/pants/runs/2300092374?check_suite_focus=true#step:8:1129

### Solution

Apply the same solution that we use for running other things on macos to the build wheels job.
