### PR TITLE
Simplify `generate_github_workflow.py`

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -452,5 +452,4 @@ jobs:
         - '3.8'
 name: Daily Extended Python Testing
 'on':
-  schedule:
-  - cron: 45 8 * * *
+- pull_request

--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -467,4 +467,5 @@ jobs:
         - '3.8'
 name: Daily Extended Python Testing
 'on':
-- pull_request
+  schedule:
+  - cron: 45 8 * * *

--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -308,6 +308,11 @@ jobs:
         ./pants lint typecheck ::
 
         '
+    - name: Upload pants.log
+      uses: actions/upload-artifact@v2
+      with:
+        name: pants-log-lint
+        path: .pants.d/pants.log
     strategy:
       matrix:
         python-version:
@@ -376,6 +381,11 @@ jobs:
       run: './pants test ::
 
         '
+    - name: Upload pants.log
+      uses: actions/upload-artifact@v2
+      with:
+        name: pants-log-python-test-linux
+        path: .pants.d/pants.log
     strategy:
       matrix:
         python-version:
@@ -446,6 +456,11 @@ jobs:
       run: './pants --tag=+platform_specific_behavior test ::
 
         '
+    - name: Upload pants.log
+      uses: actions/upload-artifact@v2
+      with:
+        name: pants-log-python-test-macos
+        path: .pants.d/pants.log
     strategy:
       matrix:
         python-version:

--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -5,8 +5,6 @@
 
 env:
   PANTS_CONFIG_FILES: +['pants.ci.toml']
-  PANTS_REMOTE_CACHE_READ: 'true'
-  PANTS_REMOTE_CACHE_WRITE: 'true'
   RUST_BACKTRACE: all
 jobs:
   bootstrap_pants_linux:
@@ -44,6 +42,13 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Tell Pants to use Python ${{ matrix.python-version }}
+      run: 'echo "PY=python${{ matrix.python-version }}" >> $GITHUB_ENV
+
+        echo "PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS=[''==${{ matrix.python-version
+        }}.*'']" >> $GITHUB_ENV
+
+        '
     - name: Cache Rust toolchain
       uses: actions/cache@v2
       with:
@@ -130,7 +135,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - 3.8.3
+        - '3.8'
   bootstrap_pants_macos:
     name: Bootstrap Pants, test Rust (macOS)
     runs-on: macos-10.15
@@ -161,6 +166,13 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Tell Pants to use Python ${{ matrix.python-version }}
+      run: 'echo "PY=python${{ matrix.python-version }}" >> $GITHUB_ENV
+
+        echo "PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS=[''==${{ matrix.python-version
+        }}.*'']" >> $GITHUB_ENV
+
+        '
     - name: Cache Rust toolchain
       uses: actions/cache@v2
       with:
@@ -231,7 +243,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - 3.8.3
+        - '3.8'
   lint_python:
     name: Lint Python and Shell
     needs: bootstrap_pants_linux
@@ -268,6 +280,13 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Tell Pants to use Python ${{ matrix.python-version }}
+      run: 'echo "PY=python${{ matrix.python-version }}" >> $GITHUB_ENV
+
+        echo "PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS=[''==${{ matrix.python-version
+        }}.*'']" >> $GITHUB_ENV
+
+        '
     - name: Cache Pants Virtualenv
       uses: actions/cache@v2
       with:
@@ -289,15 +308,10 @@ jobs:
         ./pants lint typecheck ::
 
         '
-    - name: Upload pants log
-      uses: actions/upload-artifact@v2
-      with:
-        name: pants-log-lint
-        path: .pants.d/pants.log
     strategy:
       matrix:
         python-version:
-        - 3.8.3
+        - '3.8'
   test_python_linux:
     name: Test Python (Linux)
     needs: bootstrap_pants_linux
@@ -334,6 +348,13 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Tell Pants to use Python ${{ matrix.python-version }}
+      run: 'echo "PY=python${{ matrix.python-version }}" >> $GITHUB_ENV
+
+        echo "PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS=[''==${{ matrix.python-version
+        }}.*'']" >> $GITHUB_ENV
+
+        '
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - name: Cache Pants Virtualenv
@@ -355,15 +376,10 @@ jobs:
       run: './pants test ::
 
         '
-    - name: Upload pants log
-      uses: actions/upload-artifact@v2
-      with:
-        name: pants-log-python-test-linux
-        path: .pants.d/pants.log
     strategy:
       matrix:
         python-version:
-        - 3.8.3
+        - '3.8'
   test_python_macos:
     env:
       ARCHFLAGS: -arch x86_64
@@ -402,6 +418,13 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Tell Pants to use Python ${{ matrix.python-version }}
+      run: 'echo "PY=python${{ matrix.python-version }}" >> $GITHUB_ENV
+
+        echo "PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS=[''==${{ matrix.python-version
+        }}.*'']" >> $GITHUB_ENV
+
+        '
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - name: Cache Pants Virtualenv
@@ -423,15 +446,10 @@ jobs:
       run: './pants --tag=+platform_specific_behavior test ::
 
         '
-    - name: Upload pants log
-      uses: actions/upload-artifact@v2
-      with:
-        name: pants-log-python-test-macos
-        path: .pants.d/pants.log
     strategy:
       matrix:
         python-version:
-        - 3.8.3
+        - '3.8'
 name: Daily Extended Python Testing
 'on':
   schedule:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,8 +5,6 @@
 
 env:
   PANTS_CONFIG_FILES: +['pants.ci.toml']
-  PANTS_REMOTE_CACHE_READ: 'true'
-  PANTS_REMOTE_CACHE_WRITE: 'true'
   RUST_BACKTRACE: all
 jobs:
   bootstrap_pants_linux:
@@ -44,6 +42,13 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Tell Pants to use Python ${{ matrix.python-version }}
+      run: 'echo "PY=python${{ matrix.python-version }}" >> $GITHUB_ENV
+
+        echo "PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS=[''==${{ matrix.python-version
+        }}.*'']" >> $GITHUB_ENV
+
+        '
     - name: Cache Rust toolchain
       uses: actions/cache@v2
       with:
@@ -130,7 +135,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - 3.7.10
+        - '3.7'
   bootstrap_pants_macos:
     name: Bootstrap Pants, test Rust (macOS)
     runs-on: macos-10.15
@@ -161,6 +166,13 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Tell Pants to use Python ${{ matrix.python-version }}
+      run: 'echo "PY=python${{ matrix.python-version }}" >> $GITHUB_ENV
+
+        echo "PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS=[''==${{ matrix.python-version
+        }}.*'']" >> $GITHUB_ENV
+
+        '
     - name: Cache Rust toolchain
       uses: actions/cache@v2
       with:
@@ -231,7 +243,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - 3.7.10
+        - '3.7'
   build_wheels_linux:
     container: quay.io/pypa/manylinux2014_x86_64:latest
     name: Build wheels and fs_util (Linux)
@@ -395,6 +407,13 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Tell Pants to use Python ${{ matrix.python-version }}
+      run: 'echo "PY=python${{ matrix.python-version }}" >> $GITHUB_ENV
+
+        echo "PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS=[''==${{ matrix.python-version
+        }}.*'']" >> $GITHUB_ENV
+
+        '
     - name: Cache Pants Virtualenv
       uses: actions/cache@v2
       with:
@@ -416,15 +435,10 @@ jobs:
         ./pants lint typecheck ::
 
         '
-    - name: Upload pants log
-      uses: actions/upload-artifact@v2
-      with:
-        name: pants-log-lint
-        path: .pants.d/pants.log
     strategy:
       matrix:
         python-version:
-        - 3.7.10
+        - '3.7'
   test_python_linux:
     name: Test Python (Linux)
     needs: bootstrap_pants_linux
@@ -461,6 +475,13 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Tell Pants to use Python ${{ matrix.python-version }}
+      run: 'echo "PY=python${{ matrix.python-version }}" >> $GITHUB_ENV
+
+        echo "PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS=[''==${{ matrix.python-version
+        }}.*'']" >> $GITHUB_ENV
+
+        '
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - name: Cache Pants Virtualenv
@@ -482,15 +503,10 @@ jobs:
       run: './pants test ::
 
         '
-    - name: Upload pants log
-      uses: actions/upload-artifact@v2
-      with:
-        name: pants-log-python-test-linux
-        path: .pants.d/pants.log
     strategy:
       matrix:
         python-version:
-        - 3.7.10
+        - '3.7'
   test_python_macos:
     env:
       ARCHFLAGS: -arch x86_64
@@ -529,6 +545,13 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Tell Pants to use Python ${{ matrix.python-version }}
+      run: 'echo "PY=python${{ matrix.python-version }}" >> $GITHUB_ENV
+
+        echo "PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS=[''==${{ matrix.python-version
+        }}.*'']" >> $GITHUB_ENV
+
+        '
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - name: Cache Pants Virtualenv
@@ -550,15 +573,10 @@ jobs:
       run: './pants --tag=+platform_specific_behavior test ::
 
         '
-    - name: Upload pants log
-      uses: actions/upload-artifact@v2
-      with:
-        name: pants-log-python-test-macos
-        path: .pants.d/pants.log
     strategy:
       matrix:
         python-version:
-        - 3.7.10
+        - '3.7'
 name: Pull Request CI
 'on':
 - push

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -435,6 +435,11 @@ jobs:
         ./pants lint typecheck ::
 
         '
+    - name: Upload pants.log
+      uses: actions/upload-artifact@v2
+      with:
+        name: pants-log-lint
+        path: .pants.d/pants.log
     strategy:
       matrix:
         python-version:
@@ -503,6 +508,11 @@ jobs:
       run: './pants test ::
 
         '
+    - name: Upload pants.log
+      uses: actions/upload-artifact@v2
+      with:
+        name: pants-log-python-test-linux
+        path: .pants.d/pants.log
     strategy:
       matrix:
         python-version:
@@ -573,6 +583,11 @@ jobs:
       run: './pants --tag=+platform_specific_behavior test ::
 
         '
+    - name: Upload pants.log
+      uses: actions/upload-artifact@v2
+      with:
+        name: pants-log-python-test-macos
+        path: .pants.d/pants.log
     strategy:
       matrix:
         python-version:

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -474,8 +474,7 @@ def generate() -> dict[Path, str]:
         {
             "name": "Daily Extended Python Testing",
             # 08:45 UTC / 12:45AM PST, 1:45AM PDT: arbitrary time after hours.
-            # "on": {"schedule": [{"cron": "45 8 * * *"}]},
-            "on": ["pull_request"],
+            "on": {"schedule": [{"cron": "45 8 * * *"}]},
             "jobs": test_workflow_jobs(PYTHON38_VERSION, cron=True),
             "env": global_env(),
         },

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -240,6 +240,14 @@ def expose_all_pythons() -> Step:
     }
 
 
+def upload_log_artifacts(name: str) -> Step:
+    return {
+        "name": "Upload pants.log",
+        "uses": "actions/upload-artifact@v2",
+        "with": {"name": f"pants-log-{name}", "path": ".pants.d/pants.log"},
+    }
+
+
 def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
     jobs = {
         "bootstrap_pants_linux": {
@@ -293,6 +301,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
                 pants_virtualenv_cache(),
                 native_engine_so_download(),
                 {"name": "Run Python tests", "run": "./pants test ::\n"},
+                upload_log_artifacts(name="python-test-linux"),
             ],
         },
         "lint_python": {
@@ -310,6 +319,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
                     "name": "Lint",
                     "run": "./pants validate '**'\n./pants lint typecheck ::\n",
                 },
+                upload_log_artifacts(name="lint"),
             ],
         },
         "bootstrap_pants_macos": {
@@ -350,6 +360,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
                     "name": "Run Python tests",
                     "run": "./pants --tag=+platform_specific_behavior test ::\n",
                 },
+                upload_log_artifacts(name="python-test-macos"),
             ],
         },
     }

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -463,7 +463,8 @@ def generate() -> dict[Path, str]:
         {
             "name": "Daily Extended Python Testing",
             # 08:45 UTC / 12:45AM PST, 1:45AM PDT: arbitrary time after hours.
-            "on": {"schedule": [{"cron": "45 8 * * *"}]},
+            # "on": {"schedule": [{"cron": "45 8 * * *"}]},
+            "on": ["pull_request"],
             "jobs": test_workflow_jobs(PYTHON38_VERSION, cron=True),
             "env": global_env(),
         },

--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -4,6 +4,8 @@ colors = true
 # TODO: See #9924.
 dynamic_ui = false
 
+remote_cache_read = true
+remote_cache_write = true
 # We want to continue to get logs when remote caching errors.
 remote_cache_warnings = "backoff"
 


### PR DESCRIPTION
Prework for https://github.com/pantsbuild/pants/pull/11858.

* Set remote cache options in `pants.ci.toml` instead of via env var.
* Directly return a `Step` instead of `Sequence[Step]` where possible.
* Use loose Python versions rather than patch versions.
* Factor up setting `ARCHFLAGS` on macOS.

This also adds a new step to explicitly set `$PY` and `[python-setup].interpreter_constraints`, which was necessary in https://github.com/pantsbuild/pants/pull/11858 to get the cron job to consistently use the correct Python.