### PR TITLE
[internal] add timeouts on some pants runs that can take a long time.

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -244,6 +244,7 @@ jobs:
       matrix:
         python-version:
         - '3.8'
+    timeout-minutes: 20
   lint_python:
     name: Lint Python and Shell
     needs: bootstrap_pants_linux
@@ -308,6 +309,7 @@ jobs:
         ./pants lint typecheck ::
 
         '
+      timeout-minutes: 20
     - name: Upload pants.log
       uses: actions/upload-artifact@v2
       with:
@@ -317,6 +319,7 @@ jobs:
       matrix:
         python-version:
         - '3.8'
+    timeout-minutes: 60
   test_python_linux:
     name: Test Python (Linux)
     needs: bootstrap_pants_linux
@@ -381,6 +384,7 @@ jobs:
       run: './pants test ::
 
         '
+      timeout-minutes: 40
     - name: Upload pants.log
       uses: actions/upload-artifact@v2
       with:
@@ -390,6 +394,7 @@ jobs:
       matrix:
         python-version:
         - '3.8'
+    timeout-minutes: 60
   test_python_macos:
     env:
       ARCHFLAGS: -arch x86_64
@@ -456,6 +461,7 @@ jobs:
       run: './pants --tag=+platform_specific_behavior test ::
 
         '
+      timeout-minutes: 40
     - name: Upload pants.log
       uses: actions/upload-artifact@v2
       with:
@@ -465,6 +471,7 @@ jobs:
       matrix:
         python-version:
         - '3.8'
+    timeout-minutes: 60
 name: Daily Extended Python Testing
 'on':
   schedule:

--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -244,7 +244,7 @@ jobs:
       matrix:
         python-version:
         - '3.8'
-    timeout-minutes: 20
+    timeout-minutes: 40
   lint_python:
     name: Lint Python and Shell
     needs: bootstrap_pants_linux
@@ -309,7 +309,6 @@ jobs:
         ./pants lint typecheck ::
 
         '
-      timeout-minutes: 20
     - name: Upload pants.log
       uses: actions/upload-artifact@v2
       with:
@@ -384,7 +383,6 @@ jobs:
       run: './pants test ::
 
         '
-      timeout-minutes: 40
     - name: Upload pants.log
       uses: actions/upload-artifact@v2
       with:
@@ -461,7 +459,6 @@ jobs:
       run: './pants --tag=+platform_specific_behavior test ::
 
         '
-      timeout-minutes: 20
     - name: Upload pants.log
       uses: actions/upload-artifact@v2
       with:
@@ -471,7 +468,7 @@ jobs:
       matrix:
         python-version:
         - '3.8'
-    timeout-minutes: 40
+    timeout-minutes: 20
 name: Daily Extended Python Testing
 'on':
   schedule:

--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -319,7 +319,7 @@ jobs:
       matrix:
         python-version:
         - '3.8'
-    timeout-minutes: 60
+    timeout-minutes: 30
   test_python_linux:
     name: Test Python (Linux)
     needs: bootstrap_pants_linux
@@ -394,7 +394,7 @@ jobs:
       matrix:
         python-version:
         - '3.8'
-    timeout-minutes: 60
+    timeout-minutes: 30
   test_python_macos:
     env:
       ARCHFLAGS: -arch x86_64
@@ -461,7 +461,7 @@ jobs:
       run: './pants --tag=+platform_specific_behavior test ::
 
         '
-      timeout-minutes: 40
+      timeout-minutes: 20
     - name: Upload pants.log
       uses: actions/upload-artifact@v2
       with:
@@ -471,7 +471,7 @@ jobs:
       matrix:
         python-version:
         - '3.8'
-    timeout-minutes: 60
+    timeout-minutes: 40
 name: Daily Extended Python Testing
 'on':
   schedule:

--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -392,7 +392,7 @@ jobs:
       matrix:
         python-version:
         - '3.8'
-    timeout-minutes: 30
+    timeout-minutes: 45
   test_python_macos:
     env:
       ARCHFLAGS: -arch x86_64

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -244,7 +244,7 @@ jobs:
       matrix:
         python-version:
         - '3.7'
-    timeout-minutes: 20
+    timeout-minutes: 40
   build_wheels_linux:
     container: quay.io/pypa/manylinux2014_x86_64:latest
     name: Build wheels and fs_util (Linux)
@@ -438,7 +438,6 @@ jobs:
         ./pants lint typecheck ::
 
         '
-      timeout-minutes: 20
     - name: Upload pants.log
       uses: actions/upload-artifact@v2
       with:
@@ -513,7 +512,6 @@ jobs:
       run: './pants test ::
 
         '
-      timeout-minutes: 40
     - name: Upload pants.log
       uses: actions/upload-artifact@v2
       with:
@@ -590,7 +588,6 @@ jobs:
       run: './pants --tag=+platform_specific_behavior test ::
 
         '
-      timeout-minutes: 20
     - name: Upload pants.log
       uses: actions/upload-artifact@v2
       with:
@@ -600,7 +597,7 @@ jobs:
       matrix:
         python-version:
         - '3.7'
-    timeout-minutes: 40
+    timeout-minutes: 20
 name: Pull Request CI
 'on':
 - push

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -244,6 +244,7 @@ jobs:
       matrix:
         python-version:
         - '3.7'
+    timeout-minutes: 20
   build_wheels_linux:
     container: quay.io/pypa/manylinux2014_x86_64:latest
     name: Build wheels and fs_util (Linux)
@@ -298,6 +299,7 @@ jobs:
       if: github.event_name == 'push'
       name: Deploy to S3
       run: ./build-support/bin/deploy_to_s3.py
+    timeout-minutes: 40
   build_wheels_macos:
     name: Build wheels and fs_util (macOS)
     runs-on: macos-10.15
@@ -371,6 +373,7 @@ jobs:
       if: github.event_name == 'push'
       name: Deploy to S3
       run: ./build-support/bin/deploy_to_s3.py
+    timeout-minutes: 40
   lint_python:
     name: Lint Python and Shell
     needs: bootstrap_pants_linux
@@ -435,6 +438,7 @@ jobs:
         ./pants lint typecheck ::
 
         '
+      timeout-minutes: 20
     - name: Upload pants.log
       uses: actions/upload-artifact@v2
       with:
@@ -444,6 +448,7 @@ jobs:
       matrix:
         python-version:
         - '3.7'
+    timeout-minutes: 60
   test_python_linux:
     name: Test Python (Linux)
     needs: bootstrap_pants_linux
@@ -508,6 +513,7 @@ jobs:
       run: './pants test ::
 
         '
+      timeout-minutes: 40
     - name: Upload pants.log
       uses: actions/upload-artifact@v2
       with:
@@ -517,6 +523,7 @@ jobs:
       matrix:
         python-version:
         - '3.7'
+    timeout-minutes: 60
   test_python_macos:
     env:
       ARCHFLAGS: -arch x86_64
@@ -583,6 +590,7 @@ jobs:
       run: './pants --tag=+platform_specific_behavior test ::
 
         '
+      timeout-minutes: 40
     - name: Upload pants.log
       uses: actions/upload-artifact@v2
       with:
@@ -592,6 +600,7 @@ jobs:
       matrix:
         python-version:
         - '3.7'
+    timeout-minutes: 60
 name: Pull Request CI
 'on':
 - push

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -521,7 +521,7 @@ jobs:
       matrix:
         python-version:
         - '3.7'
-    timeout-minutes: 30
+    timeout-minutes: 45
   test_python_macos:
     env:
       ARCHFLAGS: -arch x86_64

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -299,7 +299,7 @@ jobs:
       if: github.event_name == 'push'
       name: Deploy to S3
       run: ./build-support/bin/deploy_to_s3.py
-    timeout-minutes: 40
+    timeout-minutes: 70
   build_wheels_macos:
     name: Build wheels and fs_util (macOS)
     runs-on: macos-10.15
@@ -373,7 +373,7 @@ jobs:
       if: github.event_name == 'push'
       name: Deploy to S3
       run: ./build-support/bin/deploy_to_s3.py
-    timeout-minutes: 40
+    timeout-minutes: 60
   lint_python:
     name: Lint Python and Shell
     needs: bootstrap_pants_linux
@@ -448,7 +448,7 @@ jobs:
       matrix:
         python-version:
         - '3.7'
-    timeout-minutes: 60
+    timeout-minutes: 30
   test_python_linux:
     name: Test Python (Linux)
     needs: bootstrap_pants_linux
@@ -523,7 +523,7 @@ jobs:
       matrix:
         python-version:
         - '3.7'
-    timeout-minutes: 60
+    timeout-minutes: 30
   test_python_macos:
     env:
       ARCHFLAGS: -arch x86_64
@@ -590,7 +590,7 @@ jobs:
       run: './pants --tag=+platform_specific_behavior test ::
 
         '
-      timeout-minutes: 40
+      timeout-minutes: 20
     - name: Upload pants.log
       uses: actions/upload-artifact@v2
       with:
@@ -600,7 +600,7 @@ jobs:
       matrix:
         python-version:
         - '3.7'
-    timeout-minutes: 60
+    timeout-minutes: 40
 name: Pull Request CI
 'on':
 - push

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -293,7 +293,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
             "runs-on": LINUX_VERSION,
             "needs": "bootstrap_pants_linux",
             "strategy": {"matrix": {"python-version": [primary_python_version]}},
-            "timeout-minutes": 60,
+            "timeout-minutes": 30,
             "steps": [
                 *checkout(),
                 setup_toolchain_auth(),
@@ -310,7 +310,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
             "runs-on": LINUX_VERSION,
             "needs": "bootstrap_pants_linux",
             "strategy": {"matrix": {"python-version": [primary_python_version]}},
-            "timeout-minutes": 60,
+            "timeout-minutes": 30,
             "steps": [
                 *checkout(),
                 setup_toolchain_auth(),
@@ -353,7 +353,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
             "needs": "bootstrap_pants_macos",
             "strategy": {"matrix": {"python-version": [primary_python_version]}},
             "env": MACOS_ENV,
-            "timeout-minutes": 60,
+            "timeout-minutes": 40,
             "steps": [
                 *checkout(),
                 setup_toolchain_auth(),
@@ -363,7 +363,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
                 native_engine_so_download(),
                 {
                     "name": "Run Python tests",
-                    "timeout-minutes": 40,
+                    "timeout-minutes": 20,
                     "run": "./pants --tag=+platform_specific_behavior test ::\n",
                 },
                 upload_log_artifacts(name="python-test-macos"),
@@ -406,7 +406,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
                     "name": "Build wheels and fs_util (Linux)",
                     "runs-on": LINUX_VERSION,
                     "container": "quay.io/pypa/manylinux2014_x86_64:latest",
-                    "timeout-minutes": 40,
+                    "timeout-minutes": 70,
                     "steps": [
                         *checkout(),
                         install_rustup(),
@@ -425,7 +425,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
                 "build_wheels_macos": {
                     "name": "Build wheels and fs_util (macOS)",
                     "runs-on": MACOS_VERSION,
-                    "timeout-minutes": 40,
+                    "timeout-minutes": 60,
                     "steps": [
                         *checkout(),
                         expose_all_pythons(),

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -301,7 +301,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
                 expose_all_pythons(),
                 pants_virtualenv_cache(),
                 native_engine_so_download(),
-                {"name": "Run Python tests", "timeout-minutes": 40, "run": "./pants test ::\n"},
+                {"name": "Run Python tests", "run": "./pants test ::\n"},
                 upload_log_artifacts(name="python-test-linux"),
             ],
         },
@@ -319,7 +319,6 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
                 native_engine_so_download(),
                 {
                     "name": "Lint",
-                    "timeout-minutes": 20,
                     "run": "./pants validate '**'\n./pants lint typecheck ::\n",
                 },
                 upload_log_artifacts(name="lint"),
@@ -329,7 +328,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
             "name": "Bootstrap Pants, test Rust (macOS)",
             "runs-on": MACOS_VERSION,
             "strategy": {"matrix": {"python-version": [primary_python_version]}},
-            "timeout-minutes": 20,
+            "timeout-minutes": 40,
             "steps": [
                 *checkout(),
                 *setup_primary_python(),
@@ -353,7 +352,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
             "needs": "bootstrap_pants_macos",
             "strategy": {"matrix": {"python-version": [primary_python_version]}},
             "env": MACOS_ENV,
-            "timeout-minutes": 40,
+            "timeout-minutes": 20,
             "steps": [
                 *checkout(),
                 setup_toolchain_auth(),
@@ -363,7 +362,6 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
                 native_engine_so_download(),
                 {
                     "name": "Run Python tests",
-                    "timeout-minutes": 20,
                     "run": "./pants --tag=+platform_specific_behavior test ::\n",
                 },
                 upload_log_artifacts(name="python-test-macos"),

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -293,6 +293,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
             "runs-on": LINUX_VERSION,
             "needs": "bootstrap_pants_linux",
             "strategy": {"matrix": {"python-version": [primary_python_version]}},
+            "timeout-minutes": 60,
             "steps": [
                 *checkout(),
                 setup_toolchain_auth(),
@@ -300,7 +301,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
                 expose_all_pythons(),
                 pants_virtualenv_cache(),
                 native_engine_so_download(),
-                {"name": "Run Python tests", "run": "./pants test ::\n"},
+                {"name": "Run Python tests", "timeout-minutes": 40, "run": "./pants test ::\n"},
                 upload_log_artifacts(name="python-test-linux"),
             ],
         },
@@ -309,6 +310,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
             "runs-on": LINUX_VERSION,
             "needs": "bootstrap_pants_linux",
             "strategy": {"matrix": {"python-version": [primary_python_version]}},
+            "timeout-minutes": 60,
             "steps": [
                 *checkout(),
                 setup_toolchain_auth(),
@@ -317,6 +319,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
                 native_engine_so_download(),
                 {
                     "name": "Lint",
+                    "timeout-minutes": 20,
                     "run": "./pants validate '**'\n./pants lint typecheck ::\n",
                 },
                 upload_log_artifacts(name="lint"),
@@ -326,6 +329,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
             "name": "Bootstrap Pants, test Rust (macOS)",
             "runs-on": MACOS_VERSION,
             "strategy": {"matrix": {"python-version": [primary_python_version]}},
+            "timeout-minutes": 20,
             "steps": [
                 *checkout(),
                 *setup_primary_python(),
@@ -349,6 +353,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
             "needs": "bootstrap_pants_macos",
             "strategy": {"matrix": {"python-version": [primary_python_version]}},
             "env": MACOS_ENV,
+            "timeout-minutes": 60,
             "steps": [
                 *checkout(),
                 setup_toolchain_auth(),
@@ -358,6 +363,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
                 native_engine_so_download(),
                 {
                     "name": "Run Python tests",
+                    "timeout-minutes": 40,
                     "run": "./pants --tag=+platform_specific_behavior test ::\n",
                 },
                 upload_log_artifacts(name="python-test-macos"),
@@ -400,6 +406,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
                     "name": "Build wheels and fs_util (Linux)",
                     "runs-on": LINUX_VERSION,
                     "container": "quay.io/pypa/manylinux2014_x86_64:latest",
+                    "timeout-minutes": 40,
                     "steps": [
                         *checkout(),
                         install_rustup(),
@@ -418,6 +425,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
                 "build_wheels_macos": {
                     "name": "Build wheels and fs_util (macOS)",
                     "runs-on": MACOS_VERSION,
+                    "timeout-minutes": 40,
                     "steps": [
                         *checkout(),
                         expose_all_pythons(),

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -293,7 +293,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
             "runs-on": LINUX_VERSION,
             "needs": "bootstrap_pants_linux",
             "strategy": {"matrix": {"python-version": [primary_python_version]}},
-            "timeout-minutes": 30,
+            "timeout-minutes": 45,
             "steps": [
                 *checkout(),
                 setup_toolchain_auth(),


### PR DESCRIPTION
the default 6 hours timeout seems excessive.

https://github.com/pantsbuild/pants/actions/runs/731574274
https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepstimeout-minutes
<img width="1104" alt="Screen Shot 2021-04-08 at 9 40 20 PM" src="https://user-images.githubusercontent.com/1268088/114129274-1db68180-98b3-11eb-84a0-624ba9b5e044.png">
