### PR TITLE
add entry_points field on python_distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ __pycache__/
 .build.properties
 .buildcache/
 .coverage*
+.emacs.desktop
 .idea
 /.vscode/
 .cache

--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -29,9 +29,12 @@ python_distribution(
     # consumers of pantsbuild.pants are using a compatible interpreter.
     # TODO(7344): the tuple syntax for ext_modules is deprecated. Use Extension once we support it.
     ext_modules=[('native_engine', {'sources': ['pants/dummy.c']})],
-  ).with_binaries(
-    pants='src/python/pants/bin:pants',
-  )
+  ),
+  entry_points={
+    'console_scripts': {
+      'pants': 'src/python/pants/bin:pants',
+    },
+  },
 )
 
 # NB: we use this to avoid clang/gcc complaining `error: no input files` when building

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -92,8 +92,9 @@ class PythonInferSubsystem(Subsystem):
             default=True,
             type=bool,
             help=(
-                "Infer dependencies on binary targets' entry points, e.g. `pex_binary`'s "
-                "`entry_point` field and `python_awslambda`'s `handler` field."
+                "Infer dependencies on targets' entry points, e.g. `pex_binary`'s "
+                "`entry_point` field, `python_awslambda`'s `handler` field and "
+                "`python_distribution`'s `entry_points` field."
             ),
         )
 

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -623,7 +623,7 @@ async def generate_chroot(request: SetupPyChrootRequest) -> SetupPyChroot:
             "console_scripts": entry_points_from_with_binaries
         },
         f"{exported_addr} `entry_points`": entry_points_from_field,
-        f"{exported_addr} `provides.entry_points`": entry_points_from_provides,
+        f"{exported_addr}'s field `provides=setup_py(..., entry_points={...})`": entry_points_from_provides,
     }
     # Merge all collected entry points and add them to the dist's entry points.
     entry_points = merge_entry_points(*list(entry_point_sources.items()))

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -619,7 +619,7 @@ async def generate_chroot(request: SetupPyChrootRequest) -> SetupPyChroot:
 
     # Gather entry points with source description for any error messages when merging them.
     entry_point_sources = {
-        f"{exported_addr} `provides.with_binaries()`": {
+        f"{exported_addr}'s field `provides=setup_py().with_binaries()`": {
             "console_scripts": entry_points_from_with_binaries
         },
         f"{exported_addr} `entry_points`": entry_points_from_field,

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -622,7 +622,7 @@ async def generate_chroot(request: SetupPyChrootRequest) -> SetupPyChroot:
         f"{exported_addr}'s field `provides=setup_py().with_binaries()`": {
             "console_scripts": entry_points_from_with_binaries
         },
-        f"{exported_addr} `entry_points`": entry_points_from_field,
+        f"{exported_addr}'s field `entry_points`": entry_points_from_field,
         f"{exported_addr}'s field `provides=setup_py(..., entry_points={...})`": entry_points_from_provides,
     }
     # Merge all collected entry points and add them to the dist's entry points.

--- a/src/python/pants/backend/python/goals/setup_py_test.py
+++ b/src/python/pants/backend/python/goals/setup_py_test.py
@@ -416,7 +416,6 @@ def test_generate_chroot_entry_points(chroot_rule_runner: RuleRunner) -> None:
             "name": "foo",
             "version": "1.2.3",
             "plugin_demo": "hello world",
-            "package_dir": {"": "src"},
             "packages": tuple(),
             "namespace_packages": tuple(),
             "package_data": {},

--- a/src/python/pants/backend/python/goals/setup_py_test.py
+++ b/src/python/pants/backend/python/goals/setup_py_test.py
@@ -35,6 +35,7 @@ from pants.backend.python.goals.setup_py import (
     get_owned_dependencies,
     get_requirements,
     get_sources,
+    merge_entry_points,
     validate_commands,
 )
 from pants.backend.python.macros.python_artifact import PythonArtifact
@@ -214,6 +215,47 @@ def test_use_existing_setup_script(chroot_rule_runner) -> None:
     )
 
 
+def test_merge_entry_points() -> None:
+    sources = {
+        "src/python/foo:foo-dist `entry_points`": {
+            "console_scripts": {"foo_tool": "foo.bar.baz:Tool.main"},
+            "foo_plugins": {"qux": "foo.qux"},
+        },
+        "src/python/foo:foo-dist `provides.entry_points`": {
+            "console_scripts": {"foo_qux": "foo.baz.qux"},
+            "foo_plugins": {"foo-bar": "foo.bar:plugin"},
+        },
+        "src/python/foo:foo-dist `provides.with_binaries()`": {
+            "console_scripts": {"foo_main": "foo.qux.bin:main"},
+        },
+    }
+    expect = {
+        "console_scripts": [
+            "foo_tool=foo.bar.baz:Tool.main",
+            "foo_qux=foo.baz.qux",
+            "foo_main=foo.qux.bin:main",
+        ],
+        "foo_plugins": [
+            "qux=foo.qux",
+            "foo-bar=foo.bar:plugin",
+        ],
+    }
+    assert merge_entry_points(*list(sources.items())) == expect
+
+    conflicting_sources = {
+        "src/python/foo:foo-dist `entry_points`": {"console_scripts": {"my-tool": "ep1"}},
+        "src/python/foo:foo-dist `provides.entry_points`": {"console_scripts": {"my-tool": "ep2"}},
+    }
+
+    err_msg = (
+        "Multiple entry_points registered for console_scripts my-tool in: "
+        "src/python/foo:foo-dist `entry_points`, "
+        "src/python/foo:foo-dist `provides.entry_points`"
+    )
+    with pytest.raises(ValueError, match=err_msg):
+        merge_entry_points(*list(conflicting_sources.items()))
+
+
 def test_generate_chroot(chroot_rule_runner: RuleRunner) -> None:
     chroot_rule_runner.add_to_build_file(
         "src/python/foo/bar/baz",
@@ -305,6 +347,94 @@ def test_generate_chroot(chroot_rule_runner: RuleRunner) -> None:
             "package_data": {"foo": ("resources/js/code.js",)},
             "install_requires": ("baz==1.1.1",),
             "entry_points": {"console_scripts": ["foo_main=foo.qux.bin:main"]},
+        },
+        Address("src/python/foo", target_name="foo-dist"),
+    )
+
+
+def test_generate_chroot_entry_points(chroot_rule_runner: RuleRunner) -> None:
+    chroot_rule_runner.add_to_build_file(
+        "src/python/foo/qux",
+        textwrap.dedent(
+            """
+            python_library()
+
+            pex_binary(name="bin", entry_point="foo.qux.bin:main")
+            """
+        ),
+    )
+    chroot_rule_runner.add_to_build_file(
+        "src/python/foo",
+        textwrap.dedent(
+            """
+            python_distribution(
+                name='foo-dist',
+                entry_points={
+                    "console_scripts":{
+                        "foo_tool":"foo.bar.baz:Tool.main",
+                        "bin_tool":"//src/python/foo/qux:bin",
+                        "bin_tool2":"src/python/foo/qux:bin",
+                        "hello":":foo-bin",
+                    },
+                    "foo_plugins":{
+                        "qux":"foo.qux",
+                    },
+                },
+                provides=setup_py(
+                    name='foo', version='1.2.3',
+                    entry_points={
+                        "console_scripts":{
+                            "foo_qux":"foo.baz.qux",
+                        },
+                        "foo_plugins":[
+                            "foo-bar=foo.bar:plugin",
+                        ],
+                    },
+                ).with_binaries(
+                    foo_main='src/python/foo/qux:bin'
+                )
+            )
+
+            python_library(
+                dependencies=[
+                    'src/python/foo/qux',
+                ]
+            )
+
+            pex_binary(name="foo-bin", entry_point="foo.bin:main")
+            """
+        ),
+    )
+    assert_chroot(
+        chroot_rule_runner,
+        [
+            "setup.py",
+            "MANIFEST.in",
+        ],
+        "setup.py",
+        {
+            "name": "foo",
+            "version": "1.2.3",
+            "plugin_demo": "hello world",
+            "package_dir": {"": "src"},
+            "packages": tuple(),
+            "namespace_packages": tuple(),
+            "package_data": {},
+            "install_requires": tuple(),
+            "entry_points": {
+                "console_scripts": [
+                    "foo_main=foo.qux.bin:main",
+                    "foo_tool=foo.bar.baz:Tool.main",
+                    "bin_tool=foo.qux.bin:main",
+                    "bin_tool2=foo.qux.bin:main",
+                    "hello=foo.bin:main",
+                    "foo_qux=foo.baz.qux",
+                ],
+                "foo_plugins": [
+                    "qux=foo.qux",
+                    "foo-bar=foo.bar:plugin",
+                ],
+            },
         },
         Address("src/python/foo", target_name="foo-dist"),
     )

--- a/src/python/pants/backend/python/macros/python_artifact.py
+++ b/src/python/pants/backend/python/macros/python_artifact.py
@@ -6,13 +6,13 @@ from typing import Any, Dict, List, Union
 
 
 def _normalize_entry_points(
-    entry_points: Dict[str, Union[List[str], Dict[str, str]]]
+    all_entry_points: Dict[str, Union[List[str], Dict[str, str]]]
 ) -> Dict[str, Dict[str, str]]:
     """Ensure any entry points are in the form Dict[str, Dict[str, str]]."""
-    if not isinstance(entry_points, collections.abc.Mapping):
+    if not isinstance(all_entry_points, collections.abc.Mapping):
         raise ValueError(
             f"The `entry_points` in `setup_py()` must be a dictionary, "
-            f"but was {entry_points!r} with type {type(entry_points).__name__}."
+            f"but was {all_entry_points!r} with type {type(all_entry_points).__name__}."
         )
 
     def _values_to_entry_points(values):
@@ -33,7 +33,9 @@ def _normalize_entry_points(
             f"but got {values!r} of type {type(values).__name__}."
         )
 
-    return {section: _values_to_entry_points(values) for section, values in entry_points.items()}
+    return {
+        category: _values_to_entry_points(values) for category, values in all_entry_points.items()
+    }
 
 
 class PythonArtifact:

--- a/src/python/pants/backend/python/macros/python_artifact_test.py
+++ b/src/python/pants/backend/python/macros/python_artifact_test.py
@@ -1,0 +1,73 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import re
+
+import pytest
+
+from pants.backend.python.macros.python_artifact import _normalize_entry_points
+from pants.testutil.pytest_util import no_exception
+
+
+@pytest.mark.parametrize(
+    "entry_points, normalized, expect",
+    [
+        (
+            dict(console_scripts=dict(foo="bar:baz")),
+            dict(console_scripts=dict(foo="bar:baz")),
+            no_exception(),
+        ),
+        (
+            dict(console_scripts=["foo=bar:baz", "barty=slouch:ing"]),
+            dict(console_scripts=dict(foo="bar:baz", barty="slouch:ing")),
+            no_exception(),
+        ),
+        (
+            dict(
+                console_scripts=["foo=bar:baz"],
+                other_plugins=["plug=this.ok"],
+                my=dict(already="norm.alize:d"),
+            ),
+            dict(
+                console_scripts=dict(foo="bar:baz"),
+                other_plugins=dict(plug="this.ok"),
+                my=dict(already="norm.alize:d"),
+            ),
+            no_exception(),
+        ),
+        (
+            ["not=ok"],
+            None,
+            pytest.raises(
+                ValueError,
+                match=re.escape(
+                    r"The `entry_points` in `setup_py()` must be a dictionary, but was ['not=ok'] with type list."
+                ),
+            ),
+        ),
+        (
+            dict(ep=["missing.name:here"]),
+            None,
+            pytest.raises(
+                ValueError,
+                match=re.escape(
+                    r"Invalid `entry_point`, expected `<name> = <entry point>`, but got 'missing.name:here'."
+                ),
+            ),
+        ),
+        (
+            dict(ep="whops = this.is.a:mistake"),
+            None,
+            pytest.raises(
+                ValueError,
+                match=re.escape(
+                    r"The values of the `entry_points` dictionary in `setup_py()` must be a list of strings "
+                    r"or a dictionary of string to string, but got 'whops = this.is.a:mistake' of type str."
+                ),
+            ),
+        ),
+    ],
+)
+def test_normalize_entry_points(entry_points, normalized, expect):
+    with expect:
+        assert _normalize_entry_points(entry_points) == normalized

--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -217,6 +217,7 @@ async def inject_python_distribution_dependencies(
             original_tgt.target[PythonDistributionEntryPoints]
         ),
     )
+
     entry_point_addresses = Addresses()
 
     if entry_points.val and python_infer_subsystem.entry_points:

--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -9,16 +9,21 @@ defined in `target_types.py`.
 
 import dataclasses
 import os.path
+from collections import defaultdict
 
 from pants.backend.python.dependency_inference.module_mapper import PythonModule, PythonModuleOwners
 from pants.backend.python.dependency_inference.rules import PythonInferSubsystem, import_rules
 from pants.backend.python.target_types import (
+    EntryPoint,
     PexBinaryDependencies,
     PexEntryPointField,
     PythonDistributionDependencies,
+    PythonDistributionEntryPoints,
     PythonProvidesField,
     ResolvedPexEntryPoint,
+    ResolvedPythonDistributionEntryPoints,
     ResolvePexEntryPointRequest,
+    ResolvePythonDistributionEntryPointsRequest,
 )
 from pants.engine.addresses import Address, Addresses, UnparsedAddressInputs
 from pants.engine.fs import GlobMatchErrorBehavior, PathGlobs, Paths
@@ -30,10 +35,12 @@ from pants.engine.target import (
     InjectDependenciesRequest,
     InjectedDependencies,
     InvalidFieldException,
+    Targets,
     WrappedTarget,
 )
 from pants.engine.unions import UnionRule
 from pants.source.source_root import SourceRoot, SourceRootRequest
+from pants.util.frozendict import FrozenDict
 
 # -----------------------------------------------------------------------------------------------
 # `pex_binary` rules
@@ -143,29 +150,123 @@ async def inject_pex_binary_entry_point_dependency(
 # -----------------------------------------------------------------------------------------------
 
 
+@rule(desc="Determining the entry points for a `python_distribution` target")
+async def resolve_python_distribution_entry_points(
+    request: ResolvePythonDistributionEntryPointsRequest,
+) -> ResolvedPythonDistributionEntryPoints:
+    field_value = request.entry_points_field.value
+    if field_value is None:
+        return ResolvedPythonDistributionEntryPoints(None)
+
+    address = request.entry_points_field.address
+    entry_points: dict[str, dict[str, EntryPoint]] = defaultdict(dict)
+
+    for section, values in field_value.items():
+        for name, ref in values.items():
+            if ref.startswith(":") or "/" in ref:
+                targets = await Get(Targets, UnparsedAddressInputs([ref], owning_address=address))
+                if not targets:
+                    raise InvalidFieldException(
+                        f'The "entry_points" target address {repr(ref)} does not resolve to any known target.'
+                    )
+
+                for target in targets:
+                    if target.has_field(PexEntryPointField):
+                        binary_entry_point = await Get(
+                            ResolvedPexEntryPoint,
+                            ResolvePexEntryPointRequest(target[PexEntryPointField]),
+                        )
+                        ep = binary_entry_point.val
+                        break
+                else:
+                    raise InvalidFieldException(
+                        f'The "entry_points" target address {repr(ref)} does not resolve to a pex_binary() target, but:'
+                        + ", ".join(str(t) for t in targets)
+                    )
+            else:
+                ep = EntryPoint.parse(ref, f"{name} for {address} {section}")
+
+            if ep is not None:
+                entry_points[section][name] = ep
+
+    return ResolvedPythonDistributionEntryPoints(
+        FrozenDict({key: FrozenDict(value) for key, value in entry_points.items()})
+    )
+
+
 class InjectPythonDistributionDependencies(InjectDependenciesRequest):
     inject_for = PythonDistributionDependencies
 
 
 @rule
 async def inject_python_distribution_dependencies(
-    request: InjectPythonDistributionDependencies,
+    request: InjectPythonDistributionDependencies, python_infer_subsystem: PythonInferSubsystem
 ) -> InjectedDependencies:
-    """Inject any `.with_binaries()` values, as it would be redundant to have to include in the
-    `dependencies` field."""
+    """Inject dependencies that we can infer from entry points in the distribution.
+
+    Inject module owners referred to from `entry_points`.
+
+    Inject any `.with_binaries()` values, as it would be redundant to have to
+    include in the `dependencies` field.
+    """
     original_tgt = await Get(WrappedTarget, Address, request.dependencies_field.address)
-    with_binaries = original_tgt.target[PythonProvidesField].value.binaries
-    if not with_binaries:
-        return InjectedDependencies()
-    # Note that we don't validate that these are all `pex_binary` targets; we don't care about
-    # that here. `setup_py.py` will do that validation.
-    addresses = await Get(
-        Addresses,
-        UnparsedAddressInputs(
-            with_binaries.values(), owning_address=request.dependencies_field.address
+
+    entry_points = await Get(
+        ResolvedPythonDistributionEntryPoints,
+        ResolvePythonDistributionEntryPointsRequest(
+            original_tgt.target[PythonDistributionEntryPoints]
         ),
     )
-    return InjectedDependencies(addresses)
+    entry_point_addresses = Addresses()
+
+    if entry_points.val and python_infer_subsystem.entry_points:
+        address = original_tgt.target.address
+        explicitly_provided_deps = await Get(
+            ExplicitlyProvidedDependencies, DependenciesRequest(original_tgt.target[Dependencies])
+        )
+        all_entry_points = [
+            (key, name, entry_point)
+            for key, section in entry_points.val.items()
+            for name, entry_point in section.items()
+        ]
+        all_owners = await MultiGet(
+            Get(PythonModuleOwners, PythonModule(entry_point.module))
+            for _, _, entry_point in all_entry_points
+        )
+        for (key, name, entry_point), owners in zip(all_entry_points, all_owners):
+            field_str = repr({key: {name: entry_point.spec}})
+            explicitly_provided_deps.maybe_warn_of_ambiguous_dependency_inference(
+                owners.ambiguous,
+                address,
+                import_reference="module",
+                context=(
+                    f"The distribution target {address} has the field "
+                    f"`entry_points={field_str}`"
+                ),
+            )
+            maybe_disambiguated = explicitly_provided_deps.disambiguated_via_ignores(
+                owners.ambiguous
+            )
+            unambiguous_owners = Addresses(
+                owners.unambiguous
+                or ((maybe_disambiguated,) if maybe_disambiguated else Addresses())
+            )
+            entry_point_addresses += unambiguous_owners  # type: ignore[assignment]
+
+    with_binaries = original_tgt.target[PythonProvidesField].value.binaries
+    if not with_binaries:
+        pex_addresses = Addresses()
+    else:
+        # Note that we don't validate that these are all `pex_binary` targets; we don't care about
+        # that here. `setup_py.py` will do that validation.
+        pex_addresses = await Get(
+            Addresses,
+            UnparsedAddressInputs(
+                with_binaries.values(), owning_address=request.dependencies_field.address
+            ),
+        )
+
+    return InjectedDependencies(entry_point_addresses + pex_addresses)
 
 
 def rules():

--- a/src/python/pants/backend/python/target_types_test.py
+++ b/src/python/pants/backend/python/target_types_test.py
@@ -419,6 +419,16 @@ def test_inject_python_distribution_dependencies() -> None:
                     }
                 },
             )
+
+            python_distribution(
+                name="third_dep",
+                provides=setup_py(name="my-third"),
+                entry_points={
+                    "color-plugins":{
+                        "my-ansi-colors": "colors",
+                    }
+                }
+            )
             """
         ),
     )
@@ -432,7 +442,7 @@ def test_inject_python_distribution_dependencies() -> None:
         ),
     )
 
-    def assert_injected(address: Address, *expected: Address) -> None:
+    def assert_injected(address: Address, expected: List[Address]) -> None:
         tgt = rule_runner.get_target(address)
         injected = rule_runner.request(
             InjectedDependencies,
@@ -442,13 +452,22 @@ def test_inject_python_distribution_dependencies() -> None:
 
     assert_injected(
         Address("project", target_name="dist-a"),
-        Address("project", target_name="my_binary"),
+        [Address("project", target_name="my_binary")],
     )
 
     assert_injected(
         Address("project", target_name="dist-b"),
-        Address("project", relative_file_path="app.py", target_name="my_library"),
-        Address("who_knows", relative_file_path="module.py", target_name="random_lib"),
+        [
+            Address("project", target_name="my_binary"),
+            Address("project", relative_file_path="app.py", target_name="my_library"),
+        ],
+    )
+
+    assert_injected(
+        Address("project", target_name="third_dep"),
+        [
+            Address("", target_name="ansicolors"),
+        ],
     )
 
 

--- a/src/python/pants/backend/python/target_types_test.py
+++ b/src/python/pants/backend/python/target_types_test.py
@@ -41,7 +41,9 @@ from pants.backend.python.target_types_rules import (
     inject_pex_binary_entry_point_dependency,
     inject_python_distribution_dependencies,
     resolve_pex_entry_point,
+    resolve_python_distribution_entry_points,
 )
+from pants.backend.python.util_rules import python_sources
 from pants.engine.addresses import Address
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.target import (
@@ -368,7 +370,10 @@ def test_inject_python_distribution_dependencies() -> None:
     rule_runner = RuleRunner(
         rules=[
             inject_python_distribution_dependencies,
+            resolve_pex_entry_point,
+            resolve_python_distribution_entry_points,
             *import_rules(),
+            *python_sources.rules(),
             QueryRule(InjectedDependencies, [InjectPythonDistributionDependencies]),
         ],
         target_types=[PythonDistribution, PythonRequirementLibrary, PythonLibrary, PexBinary],

--- a/src/python/pants/backend/python/target_types_test.py
+++ b/src/python/pants/backend/python/target_types_test.py
@@ -364,35 +364,74 @@ def test_parse_requirements_file() -> None:
     }
 
 
-def test_python_distribution_dependency_injection() -> None:
+def test_inject_python_distribution_dependencies() -> None:
     rule_runner = RuleRunner(
         rules=[
             inject_python_distribution_dependencies,
+            *import_rules(),
             QueryRule(InjectedDependencies, [InjectPythonDistributionDependencies]),
         ],
-        target_types=[PythonDistribution, PexBinary],
+        target_types=[PythonDistribution, PythonRequirementLibrary, PythonLibrary, PexBinary],
         objects={"setup_py": PythonArtifact},
     )
     rule_runner.add_to_build_file(
-        "project",
+        "",
         dedent(
             """\
-            pex_binary(name="my_binary")
-            python_distribution(
-                name="dist",
-                provides=setup_py(
-                    name='my-dist'
-                ).with_binaries({"my_cmd": ":my_binary"})
+            python_requirement_library(
+                name='ansicolors',
+                requirements=['ansicolors'],
+                module_mapping={'ansicolors': ['colors']},
             )
             """
         ),
     )
-    tgt = rule_runner.get_target(Address("project", target_name="dist"))
-    injected = rule_runner.request(
-        InjectedDependencies,
-        [InjectPythonDistributionDependencies(tgt[PythonDistributionDependencies])],
+    rule_runner.create_file("project/app.py")
+    rule_runner.add_to_build_file(
+        "project",
+        dedent(
+            """\
+            pex_binary(name="my_binary", entry_point="who_knows.module")
+            python_distribution(
+                name="dist-a",
+                provides=setup_py(
+                    name='my-dist-a'
+                ).with_binaries({"my_cmd": ":my_binary"})
+            )
+
+            python_library(name="my_library", sources=["app.py"])
+            python_distribution(
+                name="dist-b",
+                provides=setup_py(
+                    name="my-dist-b"
+                ),
+                entry_points={
+                    "console_scripts":{
+                        "b_cmd": "project.app:main"
+                    }
+                },
+            )
+            """
+        ),
     )
-    assert injected == InjectedDependencies([Address("project", target_name="my_binary")])
+
+    def assert_injected(address: Address, *, expected: Optional[Address]) -> None:
+        tgt = rule_runner.get_target(address)
+        injected = rule_runner.request(
+            InjectedDependencies,
+            [InjectPythonDistributionDependencies(tgt[PythonDistributionDependencies])],
+        )
+        assert injected == InjectedDependencies([expected] if expected else [])
+
+    assert_injected(
+        Address("project", target_name="dist-a"),
+        expected=Address("project", target_name="my_binary"),
+    )
+
+    assert_injected(
+        Address("project", target_name="dist-b"),
+        expected=Address("project", relative_file_path="app.py", target_name="my_library"),
+    )
 
 
 @pytest.mark.parametrize(

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1211,6 +1211,35 @@ class DictStringToStringField(Field):
         return FrozenDict(value_or_default)
 
 
+class NestedDictStringToStringField(Field):
+    value: Optional[FrozenDict[str, FrozenDict[str, str]]]
+    default: ClassVar[Optional[FrozenDict[str, FrozenDict[str, str]]]] = None
+
+    @classmethod
+    def compute_value(
+        cls, raw_value: Optional[Dict[str, Dict[str, str]]], address: Address
+    ) -> Optional[FrozenDict[str, FrozenDict[str, str]]]:
+        value_or_default = super().compute_value(raw_value, address)
+        if value_or_default is None:
+            return None
+        invalid_type_exception = InvalidFieldTypeException(
+            address,
+            cls.alias,
+            raw_value,
+            expected_type="dict[str, dict[str, str]]",
+        )
+        if not isinstance(value_or_default, collections.abc.Mapping):
+            raise invalid_type_exception
+        for key, nested_value in value_or_default.items():
+            if not isinstance(key, str) or not isinstance(nested_value, collections.abc.Mapping):
+                raise invalid_type_exception
+            if not all(isinstance(k, str) and isinstance(v, str) for k, v in nested_value.items()):
+                raise invalid_type_exception
+        return FrozenDict(
+            {key: FrozenDict(nested_value) for key, nested_value in value_or_default.items()}
+        )
+
+
 class DictStringToStringSequenceField(Field):
     value: Optional[FrozenDict[str, Tuple[str, ...]]]
     default: ClassVar[Optional[FrozenDict[str, Tuple[str, ...]]]] = None


### PR DESCRIPTION
-  add new `entry_points` field for the `python_distribution()` target.
-  support dependency inference on `entry_points`.
-  support `pex_binary` targets in entry points, which will use the `entry_point` from the `pex_binary()` target.

The `entry_points` field of `python_distribution` is a `dict[str, dict[str, str]]` value (just as for `setuptools.setup()`), where the `str` value is either on the form of a regular setuptools entry_point or a pants target address. Any value that either starts with a `:` or that contains a `/` is considered a target address (for a `pex_binary`) and resolves to the binary's entry_point.

The reason for not requiring a leading `//` for target addresses on the entry_point str value, is to support the same syntax 1:1 from the entry_point value on `.with_binaries()`, to ease migration.

Example `BUILD` (from this repo)
```python
python_distribution(
  name='pants-packaged',
  ...
  provides=setup_py(
    name='pantsbuild.pants',
    ...
  ),
  entry_points={
    'console_scripts': {
      'pants': 'src/python/pants/bin:pants',
    },
  },
)
```

Example `BUILD`, before this change:
```python
... 
  provides=setup_py(
    name='pantsbuild.pants',
    ...
  ).with_binaries(
    pants='src/python/pants/bin:pants',
  )
```

fixes #11807.
fixes #11808.
closes #11880

Signed-off-by: Andreas Stenius <andreas.stenius@svenskaspel.se>

[ci skip-rust]

[ci skip-build-wheels]
