### PR TITLE
Show debug level logs in dynamic UI

### DIFF
--- a/src/python/pants/backend/project_info/dependees.py
+++ b/src/python/pants/backend/project_info/dependees.py
@@ -25,7 +25,7 @@ class AddressToDependees:
     mapping: FrozenDict[Address, FrozenOrderedSet[Address]]
 
 
-@rule(level=LogLevel.DEBUG)
+@rule(desc="Map all targets to their dependees", level=LogLevel.DEBUG)
 async def map_addresses_to_dependees() -> AddressToDependees:
     # Get every target in the project so that we can iterate over them to find their dependencies.
     all_expanded_targets, all_explicit_targets = await MultiGet(

--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -239,7 +239,7 @@ class AllOwnedSources(DeduplicatedCollection[str]):
     """All files in the project already owned by targets."""
 
 
-@rule(level=LogLevel.DEBUG, desc="Determine all files already owned by targets")
+@rule(desc="Determine all files already owned by targets", level=LogLevel.DEBUG)
 async def determine_all_owned_sources() -> AllOwnedSources:
     all_tgts = await Get(UnexpandedTargets, AddressSpecs([MaybeEmptyDescendantAddresses("")]))
     all_sources_paths = await MultiGet(
@@ -343,7 +343,7 @@ def make_content_str(
     return "\n\n".join(new_content) + "\n"
 
 
-@rule(desc="Edit BUILD files with new targets")
+@rule(desc="Edit BUILD files with new targets", level=LogLevel.DEBUG)
 async def edit_build_files(req: EditBuildFilesRequest) -> EditedBuildFiles:
     ptgts_by_build_file = group_by_build_file(req.putative_targets)
     # There may be an existing *directory* whose name collides with that of a BUILD file

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -468,7 +468,7 @@ impl HeavyHittersData {
   }
 
   fn is_visible(workunit: &Workunit) -> bool {
-    workunit.metadata.level <= Level::Info && workunit.metadata.desc.is_some()
+    workunit.metadata.level <= Level::Debug && workunit.metadata.desc.is_some()
   }
 
   fn duration_for(now: SystemTime, workunit: &Workunit) -> Option<Duration> {


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/11816 resulted in the dynamic UI being empty most the time, as the vast majority of our workunits are debug or trace level. 

This system really needs to be redesigned so that log level != dynamic UI setting. There's a tension that we have lots of rules that get run frequently whereby we don't want to log them to avoid flooding the logs, but we do want to show them in the dynamic UI. Related, we want to have dynamic information in the rule's description to make them less vague. This PR punts on both of those due to lack of time right now to revisit the topic.

[ci skip-build-wheels]