### PR TITLE
Disable remote cache in CI when building wheels and bootstrapping Pants

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -251,6 +251,9 @@ jobs:
         python-version:
         - '3.8'
   lint_python:
+    env:
+      PANTS_REMOTE_CACHE_READ: 'false'
+      PANTS_REMOTE_CACHE_WRITE: 'false'
     name: Lint Python and Shell
     needs: bootstrap_pants_linux
     runs-on: ubuntu-20.04
@@ -324,6 +327,9 @@ jobs:
         python-version:
         - '3.8'
   test_python_linux:
+    env:
+      PANTS_REMOTE_CACHE_READ: 'false'
+      PANTS_REMOTE_CACHE_WRITE: 'false'
     name: Test Python (Linux)
     needs: bootstrap_pants_linux
     runs-on: ubuntu-20.04
@@ -399,6 +405,8 @@ jobs:
   test_python_macos:
     env:
       ARCHFLAGS: -arch x86_64
+      PANTS_REMOTE_CACHE_READ: 'false'
+      PANTS_REMOTE_CACHE_WRITE: 'false'
     name: Test Python (macOS)
     needs: bootstrap_pants_macos
     runs-on: macos-10.15

--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -8,6 +8,9 @@ env:
   RUST_BACKTRACE: all
 jobs:
   bootstrap_pants_linux:
+    env:
+      PANTS_REMOTE_CACHE_READ: 'false'
+      PANTS_REMOTE_CACHE_WRITE: 'false'
     name: Bootstrap Pants, test+lint Rust (Linux)
     runs-on: ubuntu-20.04
     steps:
@@ -137,6 +140,9 @@ jobs:
         python-version:
         - '3.8'
   bootstrap_pants_macos:
+    env:
+      PANTS_REMOTE_CACHE_READ: 'false'
+      PANTS_REMOTE_CACHE_WRITE: 'false'
     name: Bootstrap Pants, test Rust (macOS)
     runs-on: macos-10.15
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,9 @@ env:
   RUST_BACKTRACE: all
 jobs:
   bootstrap_pants_linux:
+    env:
+      PANTS_REMOTE_CACHE_READ: 'false'
+      PANTS_REMOTE_CACHE_WRITE: 'false'
     name: Bootstrap Pants, test+lint Rust (Linux)
     runs-on: ubuntu-20.04
     steps:
@@ -137,6 +140,9 @@ jobs:
         python-version:
         - '3.7'
   bootstrap_pants_macos:
+    env:
+      PANTS_REMOTE_CACHE_READ: 'false'
+      PANTS_REMOTE_CACHE_WRITE: 'false'
     name: Bootstrap Pants, test Rust (macOS)
     runs-on: macos-10.15
     steps:
@@ -246,6 +252,9 @@ jobs:
         - '3.7'
   build_wheels_linux:
     container: quay.io/pypa/manylinux2014_x86_64:latest
+    env:
+      PANTS_REMOTE_CACHE_READ: 'false'
+      PANTS_REMOTE_CACHE_WRITE: 'false'
     name: Build wheels and fs_util (Linux)
     runs-on: ubuntu-20.04
     steps:
@@ -299,6 +308,9 @@ jobs:
       name: Deploy to S3
       run: ./build-support/bin/deploy_to_s3.py
   build_wheels_macos:
+    env:
+      PANTS_REMOTE_CACHE_READ: 'false'
+      PANTS_REMOTE_CACHE_WRITE: 'false'
     name: Build wheels and fs_util (macOS)
     runs-on: macos-10.15
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -250,140 +250,10 @@ jobs:
       matrix:
         python-version:
         - '3.7'
-  build_wheels_linux:
-    container: quay.io/pypa/manylinux2014_x86_64:latest
-    env:
-      PANTS_REMOTE_CACHE_READ: 'false'
-      PANTS_REMOTE_CACHE_WRITE: 'false'
-    name: Build wheels and fs_util (Linux)
-    runs-on: ubuntu-20.04
-    steps:
-    - name: Check out code
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 10
-    - if: github.event_name == 'push'
-      name: Get commit message for branch builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
-    - if: github.event_name == 'pull_request'
-      name: Get commit message for PR builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
-    - name: Install rustup
-      run: 'curl --proto ''=https'' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s --
-        -v -y --default-toolchain none
-
-        echo "PATH=${PATH}:${HOME}/.cargo/bin" >> $GITHUB_ENV
-
-        '
-    - name: Expose Pythons
-      run: echo "PATH=${PATH}:/opt/python/cp37-cp37m/bin:/opt/python/cp38-cp38/bin"
-        >> $GITHUB_ENV
-    - if: github.event_name == 'push' || !contains(env.COMMIT_MESSAGE, '[ci skip-build-wheels]')
-      name: Build wheels and fs_util
-      run: '[[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && export MODE=debug
-
-        ./build-support/bin/release.sh -n
-
-        USE_PY38=true ./build-support/bin/release.sh -n
-
-        ./build-support/bin/release.sh -f
-
-        '
-    - env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      if: github.event_name == 'push'
-      name: Deploy to S3
-      run: ./build-support/bin/deploy_to_s3.py
-  build_wheels_macos:
-    env:
-      PANTS_REMOTE_CACHE_READ: 'false'
-      PANTS_REMOTE_CACHE_WRITE: 'false'
-    name: Build wheels and fs_util (macOS)
-    runs-on: macos-10.15
-    steps:
-    - name: Check out code
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 10
-    - if: github.event_name == 'push'
-      name: Get commit message for branch builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
-    - if: github.event_name == 'pull_request'
-      name: Get commit message for PR builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
-    - name: Expose Pythons
-      uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
-    - name: Cache Rust toolchain
-      uses: actions/cache@v2
-      with:
-        key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.49.0-*
-
-          ~/.rustup/update-hashes
-
-          ~/.rustup/settings.toml
-
-          '
-    - name: Cache Cargo
-      uses: actions/cache@v2
-      with:
-        key: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
-          }}
-
-          '
-        path: '~/.cargo/registry
-
-          ~/.cargo/git
-
-          '
-        restore-keys: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-
-
-          '
-    - env:
-        ARCHFLAGS: -arch x86_64
-      if: github.event_name == 'push' || !contains(env.COMMIT_MESSAGE, '[ci skip-build-wheels]')
-      name: Build wheels and fs_util
-      run: '[[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && export MODE=debug
-
-        ./build-support/bin/release.sh -n
-
-        USE_PY38=true ./build-support/bin/release.sh -n
-
-        ./build-support/bin/release.sh -f
-
-        '
-    - env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      if: github.event_name == 'push'
-      name: Deploy to S3
-      run: ./build-support/bin/deploy_to_s3.py
   lint_python:
+    env:
+      PANTS_REMOTE_CACHE_READ: 'false'
+      PANTS_REMOTE_CACHE_WRITE: 'false'
     name: Lint Python and Shell
     needs: bootstrap_pants_linux
     runs-on: ubuntu-20.04
@@ -457,6 +327,9 @@ jobs:
         python-version:
         - '3.7'
   test_python_linux:
+    env:
+      PANTS_REMOTE_CACHE_READ: 'false'
+      PANTS_REMOTE_CACHE_WRITE: 'false'
     name: Test Python (Linux)
     needs: bootstrap_pants_linux
     runs-on: ubuntu-20.04
@@ -532,6 +405,8 @@ jobs:
   test_python_macos:
     env:
       ARCHFLAGS: -arch x86_64
+      PANTS_REMOTE_CACHE_READ: 'false'
+      PANTS_REMOTE_CACHE_WRITE: 'false'
     name: Test Python (macOS)
     needs: bootstrap_pants_macos
     runs-on: macos-10.15

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -51,6 +51,8 @@ DONT_SKIP_WHEELS = (
 )
 
 
+# NB: This overrides `pants.ci.toml`.
+DISABLE_REMOTE_CACHE_ENV = {"PANTS_REMOTE_CACHE_READ": "false", "PANTS_REMOTE_CACHE_WRITE": "false"}
 # Works around bad `-arch arm64` flag embedded in Xcode 12.x Python interpreters on
 # intel machines. See: https://github.com/giampaolo/psutil/issues/1832
 MACOS_ENV = {"ARCHFLAGS": "-arch x86_64"}
@@ -254,6 +256,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
             "name": "Bootstrap Pants, test+lint Rust (Linux)",
             "runs-on": LINUX_VERSION,
             "strategy": {"matrix": {"python-version": [primary_python_version]}},
+            "env": DISABLE_REMOTE_CACHE_ENV,
             "steps": [
                 *checkout(),
                 setup_toolchain_auth(),
@@ -326,6 +329,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
             "name": "Bootstrap Pants, test Rust (macOS)",
             "runs-on": MACOS_VERSION,
             "strategy": {"matrix": {"python-version": [primary_python_version]}},
+            "env": DISABLE_REMOTE_CACHE_ENV,
             "steps": [
                 *checkout(),
                 *setup_primary_python(),
@@ -400,6 +404,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
                     "name": "Build wheels and fs_util (Linux)",
                     "runs-on": LINUX_VERSION,
                     "container": "quay.io/pypa/manylinux2014_x86_64:latest",
+                    "env": DISABLE_REMOTE_CACHE_ENV,
                     "steps": [
                         *checkout(),
                         install_rustup(),
@@ -418,6 +423,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
                 "build_wheels_macos": {
                     "name": "Build wheels and fs_util (macOS)",
                     "runs-on": MACOS_VERSION,
+                    "env": DISABLE_REMOTE_CACHE_ENV,
                     "steps": [
                         *checkout(),
                         expose_all_pythons(),


### PR DESCRIPTION
There's no benefit to using remote caching for the bootstrap jobs because they don't run any processes. 

There is some small benefit for the build wheels jobs, but they call `./pants` dozens of times because of how often `release.sh` calls `packages.py` - this causes the Toolchain plugin to generate a new restricted auth token every time on PR builds, which quickly exhausts the max # of tokens that Toolchain grants pantsbuild/pants. The benefit is not worth this.