### PR TITLE
[internal] Setup toolchain auth for build-wheels jobs too.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -282,6 +282,11 @@ jobs:
     - name: Expose Pythons
       run: echo "PATH=${PATH}:/opt/python/cp37-cp37m/bin:/opt/python/cp38-cp38/bin"
         >> $GITHUB_ENV
+    - if: github.event_name != 'pull_request'
+      name: Setup toolchain auth
+      run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
+
+        '
     - if: github.event_name == 'push' || !contains(env.COMMIT_MESSAGE, '[ci skip-build-wheels]')
       name: Build wheels and fs_util
       run: '[[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && export MODE=debug
@@ -324,6 +329,11 @@ jobs:
         echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
 
         echo "EOF" >> $GITHUB_ENV
+
+        '
+    - if: github.event_name != 'pull_request'
+      name: Setup toolchain auth
+      run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
 
         '
     - name: Expose Pythons

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -416,6 +416,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
                                 '/opt/python/cp38-cp38/bin" >> $GITHUB_ENV'
                             ),
                         },
+                        setup_toolchain_auth(),
                         build_wheels_step(is_macos=False),
                         deploy_to_s3_step,
                     ],
@@ -426,6 +427,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
                     "timeout-minutes": 60,
                     "steps": [
                         *checkout(),
+                        setup_toolchain_auth(),
                         expose_all_pythons(),
                         # NB: We only cache Rust, but not `native_engine.so` and the Pants
                         # virtualenv. This is because we must build both these things with Python


### PR DESCRIPTION
without that, the remote cache can't be used in branch (push) builds.

