### PR TITLE
[internal] Increase timeout for running pants tests under linux.

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -392,7 +392,7 @@ jobs:
       matrix:
         python-version:
         - '3.8'
-    timeout-minutes: 45
+    timeout-minutes: 60
   test_python_macos:
     env:
       ARCHFLAGS: -arch x86_64

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -521,7 +521,7 @@ jobs:
       matrix:
         python-version:
         - '3.7'
-    timeout-minutes: 45
+    timeout-minutes: 60
   test_python_macos:
     env:
       ARCHFLAGS: -arch x86_64

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -293,7 +293,7 @@ def test_workflow_jobs(primary_python_version: str, *, cron: bool) -> Jobs:
             "runs-on": LINUX_VERSION,
             "needs": "bootstrap_pants_linux",
             "strategy": {"matrix": {"python-version": [primary_python_version]}},
-            "timeout-minutes": 45,
+            "timeout-minutes": 60,
             "steps": [
                 *checkout(),
                 setup_toolchain_auth(),


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/11862/checks?check_run_id=2310172727
<img width="1329" alt="Screen Shot 2021-04-09 at 5 43 34 PM" src="https://user-images.githubusercontent.com/1268088/114252646-337f8180-995b-11eb-8a06-527aef035457.png">
