### PR TITLE
Temporarily disable Shell dep inference + internal Shellcheck usage

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -14,7 +14,7 @@ backend_packages.add = [
   "pants.backend.python.typecheck.mypy",
   "pants.backend.python.mixed_interpreter_constraints",
   "pants.backend.shell",
-  "pants.backend.shell.lint.shellcheck",
+#  "pants.backend.shell.lint.shellcheck",
   "pants.backend.shell.lint.shfmt",
   "internal_plugins.releases",
 ]
@@ -90,8 +90,8 @@ config = ["pyproject.toml"]
 config = "build-support/mypy/mypy.ini"
 source_plugins = ["pants-plugins/mypy_plugins"]
 
-[shellcheck]
-args = ["--external-sources"]
+#[shellcheck]
+#args = ["--external-sources"]
 
 [shfmt]
 # See https://github.com/mvdan/sh/blob/master/cmd/shfmt/shfmt.1.scd#printer-flags.

--- a/pants.toml
+++ b/pants.toml
@@ -14,7 +14,6 @@ backend_packages.add = [
   "pants.backend.python.typecheck.mypy",
   "pants.backend.python.mixed_interpreter_constraints",
   "pants.backend.shell",
-#  "pants.backend.shell.lint.shellcheck",
   "pants.backend.shell.lint.shfmt",
   "internal_plugins.releases",
 ]
@@ -89,9 +88,6 @@ config = ["pyproject.toml"]
 [mypy]
 config = "build-support/mypy/mypy.ini"
 source_plugins = ["pants-plugins/mypy_plugins"]
-
-#[shellcheck]
-#args = ["--external-sources"]
 
 [shfmt]
 # See https://github.com/mvdan/sh/blob/master/cmd/shfmt/shfmt.1.scd#printer-flags.

--- a/src/python/pants/backend/shell/register.py
+++ b/src/python/pants/backend/shell/register.py
@@ -10,7 +10,4 @@ def target_types():
 
 
 def rules():
-    # TODO: Restore Shell dep inference once Tar extraction is not flaky in CI, as the
-    #  implementation uses Shellcheck.
-    # return [*dependency_inference.rules(), *tailor.rules(), *shunit2_test_runner.rules()]
     return [*tailor.rules(), *shunit2_test_runner.rules()]

--- a/src/python/pants/backend/shell/register.py
+++ b/src/python/pants/backend/shell/register.py
@@ -1,7 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.shell import dependency_inference, shunit2_test_runner, tailor
+from pants.backend.shell import shunit2_test_runner, tailor
 from pants.backend.shell.target_types import ShellLibrary, Shunit2Tests
 
 
@@ -10,4 +10,7 @@ def target_types():
 
 
 def rules():
-    return [*dependency_inference.rules(), *tailor.rules(), *shunit2_test_runner.rules()]
+    # TODO: Restore Shell dep inference once Tar extraction is not flaky in CI, as the
+    #  implementation uses Shellcheck.
+    # return [*dependency_inference.rules(), *tailor.rules(), *shunit2_test_runner.rules()]
+    return [*tailor.rules(), *shunit2_test_runner.rules()]


### PR DESCRIPTION
Extracting the Tar file for Shellcheck has been flaky: https://github.com/pantsbuild/pants/pull/11856. Until we can figure that out, we need to stabilize CI.