### PR TITLE
Fix a bug in unicode string dep inference. (cherrypick of #11879)

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/import_parser_test.py
+++ b/src/python/pants/backend/python/dependency_inference/import_parser_test.py
@@ -147,6 +147,7 @@ def test_imports_from_strings(rule_runner: RuleRunner) -> None:
             'a.b.c.d.e.f.g.Baz',
             'a.b_c.d._bar',
             'a.b2.c.D',
+            'a.b.c_狗',
 
             # Invalid strings
             '..a.b.c.d',
@@ -177,6 +178,7 @@ def test_imports_from_strings(rule_runner: RuleRunner) -> None:
             "a.b.c.d.e.f.g.Baz",
             "a.b_c.d._bar",
             "a.b2.c.D",
+            "a.b.c_狗",
         ],
     )
 
@@ -199,6 +201,7 @@ def test_gracefully_handle_no_sources(rule_runner: RuleRunner) -> None:
 def test_works_with_python2(rule_runner: RuleRunner) -> None:
     content = dedent(
         """\
+        # -*- coding: utf-8 -*-
         print "Python 2 lives on."
 
         import demo
@@ -209,6 +212,7 @@ def test_works_with_python2(rule_runner: RuleRunner) -> None:
 
         importlib.import_module(b"dep.from.bytes")
         importlib.import_module(u"dep.from.str")
+        importlib.import_module(u"dep.from.str_狗")
         """
     )
     assert_imports_parsed(
@@ -221,7 +225,7 @@ def test_works_with_python2(rule_runner: RuleRunner) -> None:
             "pkg_resources",
             "treat.as.a.regular.import.not.a.string.import",
         ],
-        expected_string=["dep.from.bytes", "dep.from.str"],
+        expected_string=["dep.from.bytes", "dep.from.str", "dep.from.str_狗"],
     )
 
 


### PR DESCRIPTION
The dep extraction code calls print() to emit any imports and import-like strings it finds to stdout.
print() uses a default encoding, which in some cases might be ascii, causing it to fail on
non-ascii strings.

This change replaces the naive call to print() with explicitly encoding the string as utf8 and writing
the resulting raw bytes.

[ci skip-rust]

[ci skip-build-wheels]
