### PR TITLE
Add a __repr__ implementation to Digest.

### DIFF
--- a/src/python/pants/engine/fs_test.py
+++ b/src/python/pants/engine/fs_test.py
@@ -1003,3 +1003,27 @@ def test_invalidated_after_new_child(rule_runner: RuleRunner) -> None:
         )
 
     assert try_with_backoff(is_changed_snapshot)
+
+
+# -----------------------------------------------------------------------------------------------
+# Comparison and representation of Digests
+# -----------------------------------------------------------------------------------------------
+
+
+def test_digest_repr() -> None:
+    assert (
+        str(Digest("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 1))
+        == "Digest('ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff', 1)"
+    )
+
+
+def test_digest_equality() -> None:
+    assert Digest("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 1) == Digest(
+        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 1
+    )
+    assert Digest("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 1) != Digest(
+        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 1000
+    )
+    assert Digest("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 1) != Digest(
+        "0000000000000000000000000000000000000000000000000000000000000000", 1
+    )

--- a/src/rust/engine/src/externs/fs.rs
+++ b/src/rust/engine/src/externs/fs.rs
@@ -99,6 +99,10 @@ py_class!(pub class PyDigest |py| {
     def __hash__(&self) -> PyResult<u64> {
       Ok(self.digest(py).hash.prefix_hash())
     }
+
+    def __repr__(&self) -> PyResult<String> {
+      Ok(format!("Digest('{}', {})", self.digest(py).hash.to_hex(), self.digest(py).size_bytes))
+    }
 });
 
 pub fn to_py_snapshot(snapshot: Snapshot) -> PyResult<PySnapshot> {


### PR DESCRIPTION
### Problem
When printing or logging a `Digest` in Python, the output is unreadable (reference to an object in memory).

### Solution

Add a `__repr__` implementation to `Digest` in the Rust implementation.

### Result

When naively printing a `Digest`, e.g. `print(digest)`:

Before:
`<pants.engine.internals.native_engine.PyDigest object at 0x7f081b7ebea0>`

After:
`Digest('8e495b634469d64fb8acfa3495a065cbacc8a0fff55ce1e31007be4c16dc57d3', 12345)`

Where the latter is a well behaved Python `__repr__` in the sense that the string is valid Python which constructs the exact same object if evaluated.
