### PR TITLE
Improve clarity of Rust filesystem test mocks

### DIFF
--- a/src/rust/engine/fs/brfs/src/tests.rs
+++ b/src/rust/engine/fs/brfs/src/tests.rs
@@ -75,7 +75,7 @@ async fn list_directory() {
     .path()
     .join("directory")
     .join(digest_to_filepath(&test_directory.digest()));
-  assert_eq!(vec!["roland"], file::list_dir(&virtual_dir));
+  assert_eq!(vec!["roland.ext"], file::list_dir(&virtual_dir));
 }
 
 #[tokio::test]
@@ -103,7 +103,7 @@ async fn read_file_from_directory() {
     .path()
     .join("directory")
     .join(digest_to_filepath(&test_directory.digest()))
-    .join("roland");
+    .join("roland.ext");
   assert_eq!(test_bytes.bytes(), file::contents(&roland));
   assert!(!file::is_executable(&roland));
 }
@@ -143,8 +143,11 @@ async fn list_recursive_directory() {
     .path()
     .join("directory")
     .join(digest_to_filepath(&recursive_directory.digest()));
-  assert_eq!(vec!["cats", "treats"], file::list_dir(&virtual_dir));
-  assert_eq!(vec!["roland"], file::list_dir(&virtual_dir.join("cats")));
+  assert_eq!(vec!["cats", "treats.ext"], file::list_dir(&virtual_dir));
+  assert_eq!(
+    vec!["roland.ext"],
+    file::list_dir(&virtual_dir.join("cats"))
+  );
 }
 
 #[tokio::test]
@@ -182,11 +185,11 @@ async fn read_file_from_recursive_directory() {
     .path()
     .join("directory")
     .join(digest_to_filepath(&recursive_directory.digest()));
-  let treats = virtual_dir.join("treats");
+  let treats = virtual_dir.join("treats.ext");
   assert_eq!(treat_bytes.bytes(), file::contents(&treats));
   assert!(!file::is_executable(&treats));
 
-  let roland = virtual_dir.join("cats").join("roland");
+  let roland = virtual_dir.join("cats").join("roland.ext");
   assert_eq!(test_bytes.bytes(), file::contents(&roland));
   assert!(!file::is_executable(&roland));
 }
@@ -216,9 +219,9 @@ async fn files_are_correctly_executable() {
     .path()
     .join("directory")
     .join(digest_to_filepath(&directory.digest()));
-  assert_eq!(vec!["feed", "food"], file::list_dir(&virtual_dir));
-  assert!(file::is_executable(&virtual_dir.join("feed")));
-  assert!(!file::is_executable(&virtual_dir.join("food")));
+  assert_eq!(vec!["feed.ext", "food.ext"], file::list_dir(&virtual_dir));
+  assert!(file::is_executable(&virtual_dir.join("feed.ext")));
+  assert!(!file::is_executable(&virtual_dir.join("food.ext")));
 }
 
 pub fn digest_to_filepath(digest: &hashing::Digest) -> String {

--- a/src/rust/engine/fs/store/src/local_tests.rs
+++ b/src/rust/engine/fs/store/src/local_tests.rs
@@ -308,7 +308,7 @@ async fn garbage_collect_remove_one_of_two_directories_no_leases() {
     .await
     .expect("Error storing");
   store
-    .shrink(80, ShrinkBehavior::Fast)
+    .shrink(84, ShrinkBehavior::Fast)
     .expect("Error shrinking");
   let mut entries = Vec::new();
   entries.push(
@@ -412,13 +412,12 @@ async fn garbage_collect_fail_because_too_many_leases() {
     .store_bytes(EntryType::File, forty_chars.bytes(), true)
     .await
     .expect("Error storing");
-
   store
     .store_bytes(EntryType::File, TestData::roland().bytes(), false)
     .await
     .expect("Error storing");
 
-  assert_eq!(store.shrink(80, ShrinkBehavior::Fast), Ok(160));
+  assert_eq!(store.shrink(80, ShrinkBehavior::Fast), Ok(164));
 
   assert_eq!(
     load_bytes(&store, EntryType::File, forty_chars.digest()).await,

--- a/src/rust/engine/fs/store/src/snapshot_tests.rs
+++ b/src/rust/engine/fs/store/src/snapshot_tests.rs
@@ -456,7 +456,7 @@ async fn strip_prefix_non_matching_file() {
   let prefix = RelativePath::new(PathBuf::from("cats")).unwrap();
   let result = store.strip_prefix(dir.digest(), prefix).await;
 
-  assert_eq!(result, Err(format!("Cannot strip prefix cats from root directory (Digest with hash {:?}) - root directory contained non-matching file named: treats", dir.digest().hash).into()));
+  assert_eq!(result, Err(format!("Cannot strip prefix cats from root directory (Digest with hash {:?}) - root directory contained non-matching file named: treats.ext", dir.digest().hash).into()));
 }
 
 #[tokio::test]
@@ -492,7 +492,7 @@ async fn strip_subdir_not_in_dir() {
     .expect("Error storing directory");
   let prefix = RelativePath::new(PathBuf::from("cats/ugly")).unwrap();
   let result = store.strip_prefix(dir.digest(), prefix).await;
-  assert_eq!(result, Err(format!("Cannot strip prefix cats/ugly from root directory (Digest with hash {:?}) - subdirectory cats didn't contain a directory named ugly but did contain file named: roland", dir.digest().hash).into()));
+  assert_eq!(result, Err(format!("Cannot strip prefix cats/ugly from root directory (Digest with hash {:?}) - subdirectory cats didn't contain a directory named ugly but did contain file named: roland.ext", dir.digest().hash).into()));
 }
 
 fn make_dir_stat(root: &Path, relpath: &Path) -> PathStat {

--- a/src/rust/engine/fs/store/src/tests.rs
+++ b/src/rust/engine/fs/store/src/tests.rs
@@ -1072,17 +1072,17 @@ async fn materialize_directory() {
     .await
     .expect("Error materializing");
 
-  assert_eq!(list_dir(materialize_dir.path()), vec!["cats", "treats"]);
+  assert_eq!(list_dir(materialize_dir.path()), vec!["cats", "treats.ext"]);
   assert_eq!(
-    file_contents(&materialize_dir.path().join("treats")),
+    file_contents(&materialize_dir.path().join("treats.ext")),
     catnip.bytes()
   );
   assert_eq!(
     list_dir(&materialize_dir.path().join("cats")),
-    vec!["roland"]
+    vec!["roland.ext"]
   );
   assert_eq!(
-    file_contents(&materialize_dir.path().join("cats").join("roland")),
+    file_contents(&materialize_dir.path().join("cats").join("roland.ext")),
     roland.bytes()
   );
 }
@@ -1110,17 +1110,20 @@ async fn materialize_directory_executable() {
     .await
     .expect("Error materializing");
 
-  assert_eq!(list_dir(materialize_dir.path()), vec!["feed", "food"]);
   assert_eq!(
-    file_contents(&materialize_dir.path().join("feed")),
+    list_dir(materialize_dir.path()),
+    vec!["feed.ext", "food.ext"]
+  );
+  assert_eq!(
+    file_contents(&materialize_dir.path().join("feed.ext")),
     catnip.bytes()
   );
   assert_eq!(
-    file_contents(&materialize_dir.path().join("food")),
+    file_contents(&materialize_dir.path().join("food.ext")),
     catnip.bytes()
   );
-  assert!(is_executable(&materialize_dir.path().join("feed")));
-  assert!(!is_executable(&materialize_dir.path().join("food")));
+  assert!(is_executable(&materialize_dir.path().join("feed.ext")));
+  assert!(!is_executable(&materialize_dir.path().join("food.ext")));
 }
 
 #[tokio::test]
@@ -1171,12 +1174,12 @@ async fn contents_for_directory() {
     file_contents,
     vec![
       FileContent {
-        path: PathBuf::from("cats").join("roland"),
+        path: PathBuf::from("cats").join("roland.ext"),
         content: roland.bytes(),
         is_executable: false,
       },
       FileContent {
-        path: PathBuf::from("treats"),
+        path: PathBuf::from("treats.ext"),
         content: catnip.bytes(),
         is_executable: false,
       },
@@ -1413,7 +1416,7 @@ async fn materialize_directory_metadata_all_local() {
             metadata: local.clone(),
             child_directories: btreemap!{},
             child_files: btreemap!{
-              "roland".to_owned() => local.clone(),
+              "roland.ext".to_owned() => local.clone(),
             },
           }
         },
@@ -1472,7 +1475,7 @@ async fn materialize_directory_metadata_mixed() {
       .get("cats")
       .unwrap()
       .child_files
-      .get("roland")
+      .get("roland.ext")
       .unwrap()
   );
 }
@@ -1494,7 +1497,7 @@ async fn explicitly_overwrites_already_existing_file() {
   }
 
   let dir_to_write_to = tempfile::tempdir().unwrap();
-  let file_path: PathBuf = [dir_to_write_to.path(), Path::new("some_filename")]
+  let file_path: PathBuf = [dir_to_write_to.path(), Path::new("some_filename.ext")]
     .iter()
     .collect();
 
@@ -1504,7 +1507,7 @@ async fn explicitly_overwrites_already_existing_file() {
   assert_eq!(file_contents, b"XXX".to_vec());
 
   let cas_file = TestData::new("abc123");
-  let contents_dir = test_file_with_arbitrary_content("some_filename", &cas_file);
+  let contents_dir = test_file_with_arbitrary_content("some_filename.ext", &cas_file);
   let cas = StubCAS::builder()
     .directory(&contents_dir)
     .file(&cas_file)

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -168,9 +168,9 @@ async fn output_files_one() {
     Process::new(vec![
       find_bash(),
       "-c".to_owned(),
-      format!("echo -n {} > {}", TestData::roland().string(), "roland"),
+      format!("echo -n {} > roland.ext", TestData::roland().string()),
     ])
-    .output_files(relative_paths(&["roland"]).collect()),
+    .output_files(relative_paths(&["roland.ext"]).collect()),
   )
   .await
   .unwrap();
@@ -194,13 +194,12 @@ async fn output_dirs() {
       find_bash(),
       "-c".to_owned(),
       format!(
-        "/bin/mkdir cats && echo -n {} > {} ; echo -n {} > treats",
+        "/bin/mkdir cats && echo -n {} > cats/roland.ext ; echo -n {} > treats.ext",
         TestData::roland().string(),
-        "cats/roland",
         TestData::catnip().string()
       ),
     ])
-    .output_files(relative_paths(&["treats"]).collect())
+    .output_files(relative_paths(&["treats.ext"]).collect())
     .output_directories(relative_paths(&["cats"]).collect()),
   )
   .await
@@ -225,12 +224,12 @@ async fn output_files_many() {
       find_bash(),
       "-c".to_owned(),
       format!(
-        "echo -n {} > cats/roland ; echo -n {} > treats",
+        "echo -n {} > cats/roland.ext ; echo -n {} > treats.ext",
         TestData::roland().string(),
         TestData::catnip().string()
       ),
     ])
-    .output_files(relative_paths(&["cats/roland", "treats"]).collect()),
+    .output_files(relative_paths(&["cats/roland.ext", "treats.ext"]).collect()),
   )
   .await
   .unwrap();
@@ -254,12 +253,11 @@ async fn output_files_execution_failure() {
       find_bash(),
       "-c".to_owned(),
       format!(
-        "echo -n {} > {} ; exit 1",
-        TestData::roland().string(),
-        "roland"
+        "echo -n {} > roland.ext ; exit 1",
+        TestData::roland().string()
       ),
     ])
-    .output_files(relative_paths(&["roland"]).collect()),
+    .output_files(relative_paths(&["roland.ext"]).collect()),
   )
   .await
   .unwrap();
@@ -282,10 +280,10 @@ async fn output_files_partial_output() {
     Process::new(vec![
       find_bash(),
       "-c".to_owned(),
-      format!("echo -n {} > {}", TestData::roland().string(), "roland"),
+      format!("echo -n {} > roland.ext", TestData::roland().string()),
     ])
     .output_files(
-      relative_paths(&["roland", "susannah"])
+      relative_paths(&["roland.ext", "susannah"])
         .into_iter()
         .collect(),
     ),
@@ -311,9 +309,9 @@ async fn output_overlapping_file_and_dir() {
     Process::new(vec![
       find_bash(),
       "-c".to_owned(),
-      format!("echo -n {} > cats/roland", TestData::roland().string()),
+      format!("echo -n {} > cats/roland.ext", TestData::roland().string()),
     ])
-    .output_files(relative_paths(&["cats/roland"]).collect())
+    .output_files(relative_paths(&["cats/roland.ext"]).collect())
     .output_directories(relative_paths(&["cats"]).collect()),
   )
   .await
@@ -401,10 +399,11 @@ async fn test_directory_preservation() {
     .expect("Error saving directory");
 
   let cp = which("cp").expect("No cp on $PATH.");
-  let bash_contents = format!("echo $PWD && {} roland ..", cp.display());
+  let bash_contents = format!("echo $PWD && {} roland.ext ..", cp.display());
   let argv = vec![find_bash(), "-c".to_owned(), bash_contents.to_owned()];
 
-  let mut process = Process::new(argv.clone()).output_files(relative_paths(&["roland"]).collect());
+  let mut process =
+    Process::new(argv.clone()).output_files(relative_paths(&["roland.ext"]).collect());
   process.input_files = TestDirectory::nested().digest();
   process.working_directory = Some(RelativePath::new("cats").unwrap());
 
@@ -425,7 +424,7 @@ async fn test_directory_preservation() {
   assert_eq!(subdirs.len(), 1);
 
   // Then look for a file like e.g. `/tmp/abc1234/process-execution7zt4pH/roland`
-  let rolands_path = preserved_work_root.join(&subdirs[0]).join("roland");
+  let rolands_path = preserved_work_root.join(&subdirs[0]).join("roland.ext");
   assert!(&rolands_path.exists());
 
   // Ensure that when a directory is preserved, a __run.sh file is created with the process's
@@ -490,11 +489,11 @@ async fn all_containing_directories_for_outputs_are_created() {
         // mkdir would normally fail, since birds/ doesn't yet exist, as would echo, since cats/
         // does not exist, but we create the containing directories for all outputs before the
         // process executes.
-        "/bin/mkdir birds/falcons && echo -n {} > cats/roland",
+        "/bin/mkdir birds/falcons && echo -n {} > cats/roland.ext",
         TestData::roland().string()
       ),
     ])
-    .output_files(relative_paths(&["cats/roland"]).collect())
+    .output_files(relative_paths(&["cats/roland.ext"]).collect())
     .output_directories(relative_paths(&["birds/falcons"]).collect()),
   )
   .await
@@ -598,7 +597,7 @@ async fn working_directory() {
   .await
   .unwrap();
 
-  assert_eq!(result.stdout_bytes, "roland\n".as_bytes());
+  assert_eq!(result.stdout_bytes, "roland.ext\n".as_bytes());
   assert_eq!(result.stderr_bytes, "".as_bytes());
   assert_eq!(result.original.exit_code, 0);
   assert_eq!(result.original.output_directory, EMPTY_DIGEST);

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -355,12 +355,15 @@ async fn jdk_symlink() {
 
   let preserved_work_tmpdir = TempDir::new().unwrap();
   let roland = TestData::roland().bytes();
-  std::fs::write(preserved_work_tmpdir.path().join("roland"), roland.clone())
-    .expect("Writing temporary file");
+  std::fs::write(
+    preserved_work_tmpdir.path().join("roland.ext"),
+    roland.clone(),
+  )
+  .expect("Writing temporary file");
 
-  let mut process = Process::new(vec!["/bin/cat".to_owned(), ".jdk/roland".to_owned()]);
+  let mut process = Process::new(vec!["/bin/cat".to_owned(), ".jdk/roland.ext".to_owned()]);
   process.timeout = one_second();
-  process.description = "cat roland".to_string();
+  process.description = "cat roland.ext".to_string();
   process.jdk_home = Some(preserved_work_tmpdir.path().to_path_buf());
 
   let result = run_command_locally(process).await.unwrap();
@@ -383,7 +386,7 @@ async fn test_directory_preservation() {
   let executor = task_executor::Executor::new();
   let store = Store::local_only(executor.clone(), store_dir.path()).unwrap();
 
-  // Prepare the store to contain /cats/roland, because the EPR needs to materialize it and then run
+  // Prepare the store to contain /cats/roland.ext, because the EPR needs to materialize it and then run
   // from the ./cats directory.
   store
     .store_file_bytes(TestData::roland().bytes(), false)
@@ -423,7 +426,7 @@ async fn test_directory_preservation() {
   let subdirs = testutil::file::list_dir(&preserved_work_root);
   assert_eq!(subdirs.len(), 1);
 
-  // Then look for a file like e.g. `/tmp/abc1234/process-execution7zt4pH/roland`
+  // Then look for a file like e.g. `/tmp/abc1234/process-execution7zt4pH/roland.ext`
   let rolands_path = preserved_work_root.join(&subdirs[0]).join("roland.ext");
   assert!(&rolands_path.exists());
 
@@ -564,7 +567,7 @@ async fn working_directory() {
   let executor = task_executor::Executor::new();
   let store = Store::local_only(executor.clone(), store_dir.path()).unwrap();
 
-  // Prepare the store to contain /cats/roland, because the EPR needs to materialize it and then run
+  // Prepare the store to contain /cats/roland.ext, because the EPR needs to materialize it and then run
   // from the ./cats directory.
   store
     .store_file_bytes(TestData::roland().bytes(), false)

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -310,7 +310,6 @@ impl CommandRunner {
       };
 
       let digest = require_digest(file_node.digest.as_ref())?;
-
       digests.insert(digest);
 
       action_result.output_files.push({

--- a/src/rust/engine/process_execution/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_cache_tests.rs
@@ -438,7 +438,7 @@ async fn make_tree_from_directory() {
   assert_eq!(child_dir.files.len(), 1);
   assert_eq!(child_dir.directories.len(), 0);
   let file_node = &child_dir.files[0];
-  assert_eq!(file_node.name, "roland");
+  assert_eq!(file_node.name, "roland.ext");
   let file_digest: Digest = file_node.digest.as_ref().unwrap().try_into().unwrap();
   assert_eq!(file_digest, TestData::roland().digest());
 
@@ -483,21 +483,21 @@ async fn extract_output_file() {
 
   let file_node = crate::remote_cache::CommandRunner::extract_output_file(
     directory_digest,
-    RelativePath::new("cats/roland").unwrap(),
+    RelativePath::new("cats/roland.ext").unwrap(),
     &store,
   )
   .await
   .unwrap()
   .unwrap();
 
-  assert_eq!(file_node.name, "roland");
+  assert_eq!(file_node.name, "roland.ext");
   let file_digest: Digest = file_node.digest.unwrap().try_into().unwrap();
   assert_eq!(file_digest, TestData::roland().digest());
 
   // Extract non-existent files to make sure that Ok(None) is returned.
   let file_node_opt = crate::remote_cache::CommandRunner::extract_output_file(
     directory_digest,
-    RelativePath::new("animals").unwrap(),
+    RelativePath::new("animals.ext").unwrap(),
     &store,
   )
   .await

--- a/src/rust/engine/process_execution/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_cache_tests.rs
@@ -396,9 +396,8 @@ async fn make_tree_from_directory() {
   let executor = task_executor::Executor::new();
   let store = Store::local_only(executor.clone(), store_dir.path()).unwrap();
 
-  // Prepare the store to contain /pets/cats/roland. We will then extract varios pieces of it
+  // Prepare the store to contain /pets/cats/roland.ext. We will then extract various pieces of it
   // into Tree protos.
-
   store
     .store_file_bytes(TestData::roland().bytes(), false)
     .await
@@ -442,24 +441,27 @@ async fn make_tree_from_directory() {
   let file_digest: Digest = file_node.digest.as_ref().unwrap().try_into().unwrap();
   assert_eq!(file_digest, TestData::roland().digest());
 
-  // Test that extracting a non-existent output directory fails.
-  let result = crate::remote_cache::CommandRunner::make_tree_for_output_directory(
-    directory_digest,
-    RelativePath::new("animals").unwrap(),
-    &store,
-  )
-  .await
-  .unwrap();
-  assert!(result.is_none());
-
-  let result = crate::remote_cache::CommandRunner::make_tree_for_output_directory(
-    directory_digest,
-    RelativePath::new("pets/xyzzy").unwrap(),
-    &store,
-  )
-  .await
-  .unwrap();
-  assert!(result.is_none());
+  // Test that extracting non-existent output directories fails gracefully.
+  assert!(
+    crate::remote_cache::CommandRunner::make_tree_for_output_directory(
+      directory_digest,
+      RelativePath::new("animals").unwrap(),
+      &store,
+    )
+    .await
+    .unwrap()
+    .is_none()
+  );
+  assert!(
+    crate::remote_cache::CommandRunner::make_tree_for_output_directory(
+      directory_digest,
+      RelativePath::new("pets/xyzzy").unwrap(),
+      &store,
+    )
+    .await
+    .unwrap()
+    .is_none()
+  );
 }
 
 #[tokio::test]
@@ -543,7 +545,6 @@ async fn make_action_result_basic() {
   }
 
   WorkunitStore::setup_for_tests();
-
   let store_dir = TempDir::new().unwrap();
   let executor = task_executor::Executor::new();
   let store = Store::local_only(executor.clone(), store_dir.path()).unwrap();
@@ -552,22 +553,18 @@ async fn make_action_result_basic() {
     .store_file_bytes(TestData::roland().bytes(), false)
     .await
     .expect("Error saving file bytes");
-
   store
     .store_file_bytes(TestData::robin().bytes(), false)
     .await
     .expect("Error saving file bytes");
-
   store
     .record_directory(&TestDirectory::containing_roland().directory(), true)
     .await
     .expect("Error saving directory");
-
   store
     .record_directory(&TestDirectory::nested().directory(), true)
     .await
     .expect("Error saving directory");
-
   let directory_digest = store
     .record_directory(&TestDirectory::double_nested().directory(), true)
     .await
@@ -593,7 +590,7 @@ async fn make_action_result_basic() {
 
   let command = remexec::Command {
     arguments: vec!["this is a test".into()],
-    output_files: vec!["pets/cats/roland".into()],
+    output_files: vec!["pets/cats/roland.ext".into()],
     output_directories: vec!["pets/cats".into()],
     ..Default::default()
   };
@@ -622,9 +619,9 @@ async fn make_action_result_basic() {
 
   let actual_digests_set = digests.into_iter().collect::<HashSet<_>>();
   let expected_digests_set = hashset! {
-    TestData::roland().digest(),
-    TestData::robin().digest(),
-    TestTree::roland_at_root().digest(),
+    TestData::roland().digest(),  // stdout
+    TestData::robin().digest(),  // stderr
+    TestTree::roland_at_root().digest(),  // tree directory
   };
   assert_eq!(expected_digests_set, actual_digests_set);
 }

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -73,7 +73,7 @@ async fn make_execute_request() {
     working_directory: None,
     input_files: input_directory.digest(),
     // Intentionally poorly sorted:
-    output_files: relative_paths(&["path/to/file", "other/file"]).collect(),
+    output_files: relative_paths(&["path/to/file.ext", "other/file.ext"]).collect(),
     output_directories: relative_paths(&["directory/name"]).collect(),
     timeout: None,
     description: "some description".to_owned(),
@@ -98,7 +98,7 @@ async fn make_execute_request() {
         value: "value".to_owned(),
       },
     ],
-    output_files: vec!["other/file".to_owned(), "path/to/file".to_owned()],
+    output_files: vec!["other/file.ext".to_owned(), "path/to/file.ext".to_owned()],
     output_directories: vec!["directory/name".to_owned()],
     platform: Some(remexec::Platform::default()),
     ..Default::default()
@@ -108,10 +108,10 @@ async fn make_execute_request() {
     command_digest: Some(
       (&Digest::new(
         Fingerprint::from_hex_string(
-          "369820f9643feb39980c51fb6d35d59567256946ff3234a371cba8f4de95339c",
+          "c426b29478ec1ddbd872fbfad63ae9151eb9196edcd1a10aa0aab3aa1b48eef8",
         )
         .unwrap(),
-        115,
+        123,
       ))
         .into(),
     ),
@@ -123,7 +123,7 @@ async fn make_execute_request() {
     action_digest: Some(
       (&Digest::new(
         Fingerprint::from_hex_string(
-          "51cda3b6c18ddd47005162010e898b20faf842b3ba1a840d1a619bd962d53192",
+          "08ff4ee93b1f4ecabc2d1c4db2f39fe3d1e5946134bb3c4fd28ebde3adfe5f90",
         )
         .unwrap(),
         140,
@@ -150,7 +150,7 @@ async fn make_execute_request_with_instance_name() {
     working_directory: None,
     input_files: input_directory.digest(),
     // Intentionally poorly sorted:
-    output_files: relative_paths(&["path/to/file", "other/file"]).collect(),
+    output_files: relative_paths(&["path/to/file.ext", "other/file.ext"]).collect(),
     output_directories: relative_paths(&["directory/name"]).collect(),
     timeout: None,
     description: "some description".to_owned(),
@@ -175,7 +175,7 @@ async fn make_execute_request_with_instance_name() {
         value: "value".to_owned(),
       },
     ],
-    output_files: vec!["other/file".to_owned(), "path/to/file".to_owned()],
+    output_files: vec!["other/file.ext".to_owned(), "path/to/file.ext".to_owned()],
     output_directories: vec!["directory/name".to_owned()],
     platform: Some(remexec::Platform {
       properties: vec![remexec::platform::Property {
@@ -190,10 +190,10 @@ async fn make_execute_request_with_instance_name() {
     command_digest: Some(
       (&Digest::new(
         Fingerprint::from_hex_string(
-          "ce536af7c6334e325a99507409535d50acf05338d4cbdd031425bdaa55a87d6d",
+          "8b13668dccc1e097765f49d69a3adc16a456473a2989fd3083d34df570a9bbb6",
         )
         .unwrap(),
-        144,
+        152,
       ))
         .into(),
     ),
@@ -206,7 +206,7 @@ async fn make_execute_request_with_instance_name() {
     action_digest: Some(
       (&Digest::new(
         Fingerprint::from_hex_string(
-          "11cc69e6e2376c57a54a42db3d3dd22b2996a1527f976589d2d200623097b5c8",
+          "5e9f36c101d94b3e202e26720109c93cac5a80500aea521ea75f6080cda83fd6",
         )
         .unwrap(),
         141,
@@ -240,7 +240,7 @@ async fn make_execute_request_with_cache_key_gen_version() {
     working_directory: None,
     input_files: input_directory.digest(),
     // Intentionally poorly sorted:
-    output_files: relative_paths(&["path/to/file", "other/file"]).collect(),
+    output_files: relative_paths(&["path/to/file.ext", "other/file.ext"]).collect(),
     output_directories: relative_paths(&["directory/name"]).collect(),
     timeout: None,
     description: "some description".to_owned(),
@@ -269,7 +269,7 @@ async fn make_execute_request_with_cache_key_gen_version() {
         value: "value".to_owned(),
       },
     ],
-    output_files: vec!["other/file".to_owned(), "path/to/file".to_owned()],
+    output_files: vec!["other/file.ext".to_owned(), "path/to/file.ext".to_owned()],
     output_directories: vec!["directory/name".to_owned()],
     platform: Some(remexec::Platform::default()),
     ..Default::default()
@@ -282,10 +282,10 @@ async fn make_execute_request_with_cache_key_gen_version() {
     command_digest: Some(
       (&Digest::new(
         Fingerprint::from_hex_string(
-          "09e54a4817a36e164a0e395fac36091fd5b4aac185b8bafa90842ac4aff92a34",
+          "05f44898aa872b31e05dbcf869e3cde7ce4c6323a1eab0be219c7028a0740977",
         )
         .unwrap(),
-        152,
+        160,
       ))
         .into(),
     ),
@@ -297,7 +297,7 @@ async fn make_execute_request_with_cache_key_gen_version() {
     action_digest: Some(
       (&Digest::new(
         Fingerprint::from_hex_string(
-          "dc554a1ed77588e1bac90896dcfeba255f8178ebc01893231415841109216944",
+          "bb29e18376b3b5985191121ca36f4869bbed945b2023c0d599bd63b4eb5ade68",
         )
         .unwrap(),
         141,
@@ -362,7 +362,7 @@ async fn make_execute_request_with_jdk() {
     action_digest: Some(
       (&Digest::new(
         Fingerprint::from_hex_string(
-          "f90182cd453f36577868fc05a605ac84c19882c18bd907ff241923d98a7bca1e",
+          "636ea0e298737fc5587d815b729e366780521958ef0ee89b7b38462d242de72c",
         )
         .unwrap(),
         140,
@@ -438,7 +438,7 @@ async fn make_execute_request_with_jdk_and_extra_platform_properties() {
     action_digest: Some(
       (&Digest::new(
         Fingerprint::from_hex_string(
-          "190e7b28a9e32be6cb0beaad97d175c6882857991598de3585c91aec183b14b3",
+          "5cba7f37fe2e4c50d07d33a79d21b2bf20476509d1db6ac2b8a7a0281c7c620a",
         )
         .unwrap(),
         141,
@@ -477,7 +477,7 @@ async fn make_execute_request_with_timeout() {
     working_directory: None,
     input_files: input_directory.digest(),
     // Intentionally poorly sorted:
-    output_files: relative_paths(&["path/to/file", "other/file"]).collect(),
+    output_files: relative_paths(&["path/to/file.ext", "other/file.ext"]).collect(),
     output_directories: relative_paths(&["directory/name"]).collect(),
     timeout: one_second(),
     description: "some description".to_owned(),
@@ -502,7 +502,7 @@ async fn make_execute_request_with_timeout() {
         value: "value".to_owned(),
       },
     ],
-    output_files: vec!["other/file".to_owned(), "path/to/file".to_owned()],
+    output_files: vec!["other/file.ext".to_owned(), "path/to/file.ext".to_owned()],
     output_directories: vec!["directory/name".to_owned()],
     platform: Some(remexec::Platform::default()),
     ..Default::default()
@@ -512,10 +512,10 @@ async fn make_execute_request_with_timeout() {
     command_digest: Some(
       (&Digest::new(
         Fingerprint::from_hex_string(
-          "369820f9643feb39980c51fb6d35d59567256946ff3234a371cba8f4de95339c",
+          "c426b29478ec1ddbd872fbfad63ae9151eb9196edcd1a10aa0aab3aa1b48eef8",
         )
         .unwrap(),
-        115,
+        123,
       ))
         .into(),
     ),
@@ -528,7 +528,7 @@ async fn make_execute_request_with_timeout() {
     action_digest: Some(
       (&Digest::new(
         Fingerprint::from_hex_string(
-          "151e4bfce1244eb7ae74ed09d8759088557d9c63fbaaa5fcca662998266f4b09",
+          "b57e5ef4f0e495ac95fe948397ce59fa6783c6b23dd56a49d543aebec1f91099",
         )
         .unwrap(),
         144,
@@ -1486,7 +1486,7 @@ async fn execute_missing_file_errors_if_unknown() {
       mock::execution_server::MockExecution::new(vec![ExpectedAPICall::GetActionResult {
         action_digest: hashing::Digest::new(
           hashing::Fingerprint::from_hex_string(
-            "63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16",
+            "d1bd04c0aaa56cf24a22d392d614929e9936da64d23d4e776bdb4b19023fc9c7",
           )
           .unwrap(),
           144,
@@ -1553,7 +1553,7 @@ async fn extract_execute_response_success() {
             stdout_raw: wanted_stdout.clone(),
             stderr_raw: wanted_stderr.clone(),
             output_files: vec![remexec::OutputFile {
-              path: "cats/roland".into(),
+              path: "cats/roland.ext".into(),
               digest: Some((&TestData::roland().digest()).into()),
               is_executable: false,
               ..Default::default()
@@ -1846,7 +1846,7 @@ async fn extract_output_files_from_response_one_file() {
     result: Some(remexec::ActionResult {
       exit_code: 0,
       output_files: vec![remexec::OutputFile {
-        path: "roland".into(),
+        path: "roland.ext".into(),
         digest: Some((&TestData::roland().digest()).into()),
         is_executable: false,
         ..Default::default()
@@ -1869,13 +1869,13 @@ async fn extract_output_files_from_response_two_files_not_nested() {
       exit_code: 0,
       output_files: vec![
         remexec::OutputFile {
-          path: "roland".into(),
+          path: "roland.ext".into(),
           digest: Some((&TestData::roland().digest()).into()),
           is_executable: false,
           ..Default::default()
         },
         remexec::OutputFile {
-          path: "treats".into(),
+          path: "treats.ext".into(),
           digest: Some((&TestData::catnip().digest()).into()),
           is_executable: false,
           ..Default::default()
@@ -1899,13 +1899,13 @@ async fn extract_output_files_from_response_two_files_nested() {
       exit_code: 0,
       output_files: vec![
         remexec::OutputFile {
-          path: "cats/roland".into(),
+          path: "cats/roland.ext".into(),
           digest: Some((&TestData::roland().digest()).into()),
           is_executable: false,
           ..Default::default()
         },
         remexec::OutputFile {
-          path: "treats".into(),
+          path: "treats.ext".into(),
           digest: Some((&TestData::catnip().digest()).into()),
           is_executable: false,
           ..Default::default()
@@ -1946,15 +1946,15 @@ async fn extract_output_files_from_response_just_directory() {
 
 #[tokio::test]
 async fn extract_output_files_from_response_directories_and_files() {
-  // /catnip
-  // /pets/cats/roland
-  // /pets/dogs/robin
+  // /treats.ext
+  // /pets/cats/roland.ext
+  // /pets/dogs/robin.ext
 
   let execute_response = remexec::ExecuteResponse {
     result: Some(remexec::ActionResult {
       exit_code: 0,
       output_files: vec![remexec::OutputFile {
-        path: "treats".into(),
+        path: "treats.ext".into(),
         digest: Some((&TestData::catnip().digest()).into()),
         ..Default::default()
       }],
@@ -1977,10 +1977,10 @@ async fn extract_output_files_from_response_directories_and_files() {
     extract_output_files_from_response(&execute_response).await,
     Ok(Digest::new(
       Fingerprint::from_hex_string(
-        "639b4b84bb58a9353d49df8122e7987baf038efe54ed035e67910846c865b1e2"
+        "b5e7010d8c5ef77b383fc60ea00bdfb4743dd6fa3983033b50f218ea90124d0d"
       )
       .unwrap(),
-      159
+      163
     ))
   )
 }

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -1486,7 +1486,7 @@ async fn execute_missing_file_errors_if_unknown() {
       mock::execution_server::MockExecution::new(vec![ExpectedAPICall::GetActionResult {
         action_digest: hashing::Digest::new(
           hashing::Fingerprint::from_hex_string(
-            "d1bd04c0aaa56cf24a22d392d614929e9936da64d23d4e776bdb4b19023fc9c7",
+            "3174d44cc8d68ec5047f2da24a4db150ab0264a9d6558872081585696a98b410",
           )
           .unwrap(),
           144,
@@ -2371,7 +2371,7 @@ pub(crate) fn assert_contains(haystack: &str, needle: &str) {
 }
 
 pub(crate) fn cat_roland_request() -> MultiPlatformProcess {
-  let argv = owned_string_vec(&["/bin/cat", "roland"]);
+  let argv = owned_string_vec(&["/bin/cat", "roland.ext"]);
   let mut process = Process::new(argv);
   process.input_files = TestDirectory::containing_roland().digest();
   process.timeout = one_second();

--- a/src/rust/engine/testutil/src/data.rs
+++ b/src/rust/engine/testutil/src/data.rs
@@ -70,7 +70,7 @@ impl TestDirectory {
 
   // Directory structure:
   //
-  // /falcons/
+  // /falcons
   pub fn containing_falcons_dir() -> TestDirectory {
     let directory = remexec::Directory {
       directories: vec![remexec::DirectoryNode {
@@ -84,8 +84,8 @@ impl TestDirectory {
 
   // Directory structure:
   //
-  // birds/falcons/
-  // cats/roland
+  // birds/falcons
+  // cats/roland.ext
   pub fn nested_dir_and_file() -> TestDirectory {
     let directory = remexec::Directory {
       directories: vec![
@@ -105,8 +105,8 @@ impl TestDirectory {
 
   // Directory structure:
   //
-  // animals/birds/falcons/
-  // animals/cats/roland
+  // animals/birds/falcons
+  // animals/cats/roland.ext
   pub fn double_nested_dir_and_file() -> TestDirectory {
     let directory = remexec::Directory {
       directories: vec![remexec::DirectoryNode {
@@ -120,11 +120,11 @@ impl TestDirectory {
 
   // Directory structure:
   //
-  // /roland
+  // /roland.ext
   pub fn containing_roland() -> TestDirectory {
     let directory = remexec::Directory {
       files: vec![remexec::FileNode {
-        name: "roland".to_owned(),
+        name: "roland.ext".to_owned(),
         digest: Some((&TestData::roland().digest()).into()),
         is_executable: false,
         ..remexec::FileNode::default()
@@ -136,11 +136,11 @@ impl TestDirectory {
 
   // Directory structure:
   //
-  // /robin
+  // /robin.ext
   pub fn containing_robin() -> TestDirectory {
     let directory = remexec::Directory {
       files: vec![remexec::FileNode {
-        name: "robin".to_owned(),
+        name: "robin.ext".to_owned(),
         digest: Some((&TestData::robin().digest()).into()),
         is_executable: false,
         ..remexec::FileNode::default()
@@ -152,11 +152,11 @@ impl TestDirectory {
 
   // Directory structure:
   //
-  // /treats
+  // /treats.ext
   pub fn containing_treats() -> TestDirectory {
     let directory = remexec::Directory {
       files: vec![remexec::FileNode {
-        name: "treats".to_owned(),
+        name: "treats.ext".to_owned(),
         digest: Some((&TestData::catnip().digest()).into()),
         is_executable: false,
         ..remexec::FileNode::default()
@@ -168,7 +168,7 @@ impl TestDirectory {
 
   // Directory structure:
   //
-  // /cats/roland
+  // /cats/roland.ext
   pub fn nested() -> TestDirectory {
     let directory = remexec::Directory {
       directories: vec![remexec::DirectoryNode {
@@ -182,7 +182,7 @@ impl TestDirectory {
 
   // Directory structure:
   //
-  // /pets/cats/roland
+  // /pets/cats/roland.ext
   pub fn double_nested() -> TestDirectory {
     let directory = remexec::Directory {
       directories: vec![remexec::DirectoryNode {
@@ -196,11 +196,11 @@ impl TestDirectory {
 
   // Directory structure:
   //
-  // /dnalor
+  // /dnalor.ext
   pub fn containing_dnalor() -> TestDirectory {
     let directory = remexec::Directory {
       files: vec![remexec::FileNode {
-        name: "dnalor".to_owned(),
+        name: "dnalor.ext".to_owned(),
         digest: Some((&TestData::roland().digest()).into()),
         is_executable: false,
         ..remexec::FileNode::default()
@@ -212,11 +212,11 @@ impl TestDirectory {
 
   // Directory structure:
   //
-  // /roland
+  // /roland.ext
   pub fn containing_wrong_roland() -> TestDirectory {
     let directory = remexec::Directory {
       files: vec![remexec::FileNode {
-        name: "roland".to_owned(),
+        name: "roland.ext".to_owned(),
         digest: Some((&TestData::catnip().digest()).into()),
         is_executable: false,
         ..remexec::FileNode::default()
@@ -228,19 +228,19 @@ impl TestDirectory {
 
   // Directory structure:
   //
-  // /roland
-  // /treats
+  // /roland.ext
+  // /treats.ext
   pub fn containing_roland_and_treats() -> TestDirectory {
     let directory = remexec::Directory {
       files: vec![
         remexec::FileNode {
-          name: "roland".to_owned(),
+          name: "roland.ext".to_owned(),
           digest: Some((&TestData::roland().digest()).into()),
           is_executable: false,
           ..remexec::FileNode::default()
         },
         remexec::FileNode {
-          name: "treats".to_owned(),
+          name: "treats.ext".to_owned(),
           digest: Some((&TestData::catnip().digest()).into()),
           is_executable: false,
           ..remexec::FileNode::default()
@@ -253,8 +253,8 @@ impl TestDirectory {
 
   // Directory structure:
   //
-  // /cats/roland
-  // /treats
+  // /cats/roland.ext
+  // /treats.ext
   pub fn recursive() -> TestDirectory {
     let directory = remexec::Directory {
       directories: vec![remexec::DirectoryNode {
@@ -262,7 +262,7 @@ impl TestDirectory {
         digest: Some((&TestDirectory::containing_roland().digest()).into()),
       }],
       files: vec![remexec::FileNode {
-        name: "treats".to_owned(),
+        name: "treats.ext".to_owned(),
         digest: Some((&TestData::catnip().digest()).into()),
         ..remexec::FileNode::default()
       }],
@@ -273,19 +273,19 @@ impl TestDirectory {
 
   // Directory structure:
   //
-  // /feed (executable)
-  // /food
+  // /feed.ext (executable)
+  // /food.ext
   pub fn with_mixed_executable_files() -> TestDirectory {
     let directory = remexec::Directory {
       files: vec![
         remexec::FileNode {
-          name: "feed".to_owned(),
+          name: "feed.ext".to_owned(),
           digest: Some((&TestData::catnip().digest()).into()),
           is_executable: true,
           ..remexec::FileNode::default()
         },
         remexec::FileNode {
-          name: "food".to_owned(),
+          name: "food.ext".to_owned(),
           digest: Some((&TestData::catnip().digest()).into()),
           is_executable: false,
           ..remexec::FileNode::default()


### PR DESCRIPTION
It was not totally clear what was a file vs. a directory. Even though a file need not have an extension, using a contrived extension of `.ext` improves the readability of these tests.