### PR TITLE
Fix remote cache storing of `output_directories`

### DIFF
--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -101,6 +101,9 @@ impl CommandRunner {
   /// output directories to be stored as `Tree` protos that contain all of the `Directory`
   /// protos that constitute the directory tree.)
   ///
+  /// Note that the Tree does not include the directory_path as a prefix, per REAPI. This path
+  /// gets stored on the OutputDirectory proto.
+  ///
   /// If the output directory does not exist, then returns Ok(None).
   pub(crate) async fn make_tree_for_output_directory(
     root_directory_digest: Digest,
@@ -292,7 +295,7 @@ impl CommandRunner {
       action_result
         .output_directories
         .push(remexec::OutputDirectory {
-          path: String::new(),
+          path: output_directory.to_owned(),
           tree_digest: Some(tree_digest.into()),
         });
     }


### PR DESCRIPTION
We need to store the `path` in `OutputDirectory`, whereas we had it as the empty string before. This caused `Process.output_directories` to not work properly with the remote cache because we would not restore the `output_directory` prefix when loading from the cache. For example, if the user set `output_directories=('a',)`, which captured `a/b/f.ext`, then we would only store `b/f.ext` instead of `a/b/f.ext`.

Fixes https://github.com/pantsbuild/pants/pull/11856.
 
[ci skip-build-wheels]