### PR TITLE
Fix bug in Python 2.7 string dep inference. (cherrypick #11900)

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/import_parser.py
+++ b/src/python/pants/backend/python/dependency_inference/import_parser.py
@@ -82,8 +82,11 @@ class AstVisitor(ast.NodeVisitor):
 # logic.
 if sys.version_info[0:2] == (2,7):
     def visit_Str(self, node):
-        val = node.s.decode("utf-8") if isinstance(node.s, bytes) else node.s
-        self.maybe_add_string_import(val)
+        try:
+            val = node.s.decode("utf8") if isinstance(node.s, bytes) else node.s
+            self.maybe_add_string_import(val)
+        except UnicodeError:
+            pass
 
     setattr(AstVisitor, 'visit_Str', visit_Str)
 

--- a/src/python/pants/backend/python/dependency_inference/import_parser_test.py
+++ b/src/python/pants/backend/python/dependency_inference/import_parser_test.py
@@ -213,6 +213,8 @@ def test_works_with_python2(rule_runner: RuleRunner) -> None:
         importlib.import_module(b"dep.from.bytes")
         importlib.import_module(u"dep.from.str")
         importlib.import_module(u"dep.from.str_狗")
+
+        b"\\xa0 a non-utf8 string, make sure we ignore it"
         """
     )
     assert_imports_parsed(


### PR DESCRIPTION
[ci skip-rust]

[ci skip-build-wheels]