### PR TITLE
Handle URL requirements with constraints files.

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -304,6 +304,7 @@ async def pex_from_targets(
                         requirements=PexRequirements(all_constraints),
                         interpreter_constraints=interpreter_constraints,
                         platforms=request.platforms,
+                        additional_args=["-vvv"],
                     ),
                 )
     elif (

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -244,13 +244,25 @@ async def pex_from_targets(
         # In requirement strings, Foo_-Bar.BAZ and foo-bar-baz refer to the same project. We let
         # packaging canonicalize for us.
         # See: https://www.python.org/dev/peps/pep-0503/#normalized-names
-        exact_req_projects = {
-            canonicalize_project_name(Requirement.parse(req).project_name) for req in exact_reqs
-        }
+
+        url_reqs = set()  # E.g., 'foobar@ git+https://github.com/foo/bar.git@branch'
+        name_reqs = set()  # E.g., foobar>=1.2.3
+        name_req_projects = set()
+
+        for req_str in exact_reqs:
+            req = Requirement.parse(req_str)
+            if req.url:  # type: ignore[attr-defined]
+                url_reqs.add(req)
+            else:
+                name_reqs.add(req)
+                name_req_projects.add(canonicalize_project_name(req.project_name))
+
         constraint_file_projects = {
             canonicalize_project_name(req.project_name) for req in constraints_file_reqs
         }
-        unconstrained_projects = exact_req_projects - constraint_file_projects
+        # Constraints files must only contain name reqs, not URL reqs (those are already
+        # constrained by their very nature). See https://github.com/pypa/pip/issues/8210.
+        unconstrained_projects = name_req_projects - constraint_file_projects
         if unconstrained_projects:
             constraints_descr = (
                 f"constraints file {constraints_file.path}"
@@ -272,13 +284,24 @@ async def pex_from_targets(
                     "file does not cover all requirements."
                 )
             else:
+                # To get a full set of requirements we must add the URL requirements to the
+                # constraints file, since the latter cannot contain URL requirements.
+                # NB: We can only add the URL requirements we know about here, i.e., those that
+                #  are transitive deps of the targets in play. There may be others in the repo.
+                #  So we may end up creating a few different repository pexes, each with identical
+                #  name requirements but different subsets of URL requirements. Fortunately since
+                #  all these repository pexes will have identical pinned versions of everything,
+                #  this is not a correctness issue, only a performance one.
+                # TODO: Address this as part of providing proper lockfile support. However we
+                #  generate lockfiles, they must be able to include URL requirements.
+                all_constraints = {str(req) for req in (constraints_file_reqs | url_reqs)}
                 repository_pex = await Get(
                     Pex,
                     PexRequest(
                         description=f"Resolving {python_setup.requirement_constraints}",
                         output_filename="repository.pex",
                         internal_only=request.internal_only,
-                        requirements=PexRequirements(str(req) for req in constraints_file_reqs),
+                        requirements=PexRequirements(all_constraints),
                         interpreter_constraints=interpreter_constraints,
                         platforms=request.platforms,
                     ),

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import json
-import os
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -140,9 +139,9 @@ def test_constraints_validation(tmp_path_factory: TempPathFactory, rule_runner: 
         subprocess.check_call(["git", "commit", "-m", "initial commit"])
         subprocess.check_call(["git", "branch", "9.8.7"])
 
-    # This string won't parse as a Requirement if it contains a full path
-    # (i.e., three slashes after the `file:`) so we use a relpath.
-    url_req = f"foorl@ git+file://{os.path.relpath(foorl_dir)}@9.8.7"
+    # This string won't parse as a Requirement if it doesn't contain a netloc,
+    # so we explicitly mention localhost.
+    url_req = f"foorl@ git+file://localhost{foorl_dir.as_posix()}@9.8.7"
 
     rule_runner.add_to_build_file(
         "",

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -201,7 +201,7 @@ def test_constraints_validation(tmp_path_factory: TempPathFactory, rule_runner: 
     pex_req1_direct = get_pex_request(
         "constraints1.txt", ResolveAllConstraintsOption.NEVER, direct_deps_only=True
     )
-    assert pex_req1_direct.requirements == PexRequirements(["baz"])
+    assert pex_req1_direct.requirements == PexRequirements(["baz", url_req])
     assert pex_req1_direct.repository_pex is None
 
     pex_req2 = get_pex_request("constraints1.txt", ResolveAllConstraintsOption.ALWAYS)
@@ -217,7 +217,7 @@ def test_constraints_validation(tmp_path_factory: TempPathFactory, rule_runner: 
     pex_req2_direct = get_pex_request(
         "constraints1.txt", ResolveAllConstraintsOption.ALWAYS, direct_deps_only=True
     )
-    assert pex_req2_direct.requirements == PexRequirements(["baz"])
+    assert pex_req2_direct.requirements == PexRequirements(["baz", url_req])
     assert pex_req2_direct.repository_pex == repository_pex
 
     with pytest.raises(ExecutionError) as err:

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -182,6 +182,7 @@ def test_constraints_validation(tmp_path_factory: TempPathFactory, rule_runner: 
             output_filename="demo.pex",
             internal_only=True,
             direct_deps_only=direct_deps_only,
+            additional_args=["-vvv"],
         )
         if resolve_all:
             args.append(f"--python-setup-resolve-all-constraints={resolve_all.value}")

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import json
+import os
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -139,7 +140,9 @@ def test_constraints_validation(tmp_path_factory: TempPathFactory, rule_runner: 
         subprocess.check_call(["git", "commit", "-m", "initial commit"])
         subprocess.check_call(["git", "branch", "9.8.7"])
 
-    url_req = f"foorl@ git+file:/{foorl_dir}@9.8.7"
+    # This string won't parse as a Requirement if it contains a full path
+    # (i.e., three slashes after the `file:`) so we use a relpath.
+    url_req = f"foorl@ git+file://{os.path.relpath(foorl_dir)}@9.8.7"
 
     rule_runner.add_to_build_file(
         "",

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -182,7 +182,6 @@ def test_constraints_validation(tmp_path_factory: TempPathFactory, rule_runner: 
             output_filename="demo.pex",
             internal_only=True,
             direct_deps_only=direct_deps_only,
-            additional_args=["-vvv"],
         )
         if resolve_all:
             args.append(f"--python-setup-resolve-all-constraints={resolve_all.value}")

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -20,7 +20,7 @@ from pants.build_graph.address import Address
 from pants.engine.internals.scheduler import ExecutionError
 from pants.python.python_setup import ResolveAllConstraintsOption
 from pants.testutil.rule_runner import QueryRule, RuleRunner
-from pants.util.contextutil import environment_as, pushd
+from pants.util.contextutil import pushd
 
 
 @pytest.fixture
@@ -132,11 +132,12 @@ def test_constraints_validation(tmp_path_factory: TempPathFactory, rule_runner: 
     # Turn the project dir into a git repo, so it can be cloned.
     foorl_dir = create_project_dir(tmp_path_factory.mktemp("git"), Project("foorl", "9.8.7"))
     with pushd(str(foorl_dir)):
-        with environment_as(GIT_AUTHOR_NAME="dummy", GIT_AUTHOR_EMAIL="dummy@dummy.com"):
-            subprocess.check_call(["git", "init"])
-            subprocess.check_call(["git", "add", "--all"])
-            subprocess.check_call(["git", "commit", "-m", "initial commit"])
-            subprocess.check_call(["git", "branch", "9.8.7"])
+        subprocess.check_call(["git", "init"])
+        subprocess.check_call(["git", "config", "user.name", "dummy"])
+        subprocess.check_call(["git", "config", "user.email", "dummy@dummy.com"])
+        subprocess.check_call(["git", "add", "--all"])
+        subprocess.check_call(["git", "commit", "-m", "initial commit"])
+        subprocess.check_call(["git", "branch", "9.8.7"])
 
     url_req = f"foorl@ git+file:/{foorl_dir}@9.8.7"
 

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -20,7 +20,7 @@ from pants.build_graph.address import Address
 from pants.engine.internals.scheduler import ExecutionError
 from pants.python.python_setup import ResolveAllConstraintsOption
 from pants.testutil.rule_runner import QueryRule, RuleRunner
-from pants.util.contextutil import pushd
+from pants.util.contextutil import environment_as, pushd
 
 
 @pytest.fixture
@@ -132,10 +132,11 @@ def test_constraints_validation(tmp_path_factory: TempPathFactory, rule_runner: 
     # Turn the project dir into a git repo, so it can be cloned.
     foorl_dir = create_project_dir(tmp_path_factory.mktemp("git"), Project("foorl", "9.8.7"))
     with pushd(str(foorl_dir)):
-        subprocess.check_call(["git", "init"])
-        subprocess.check_call(["git", "add", "--all"])
-        subprocess.check_call(["git", "commit", "-m", "initial commit"])
-        subprocess.check_call(["git", "branch", "9.8.7"])
+        with environment_as(GIT_AUTHOR_NAME="dummy", GIT_AUTHOR_EMAIL="dummy@dummy.com"):
+            subprocess.check_call(["git", "init"])
+            subprocess.check_call(["git", "add", "--all"])
+            subprocess.check_call(["git", "commit", "-m", "initial commit"])
+            subprocess.check_call(["git", "branch", "9.8.7"])
 
     url_req = f"foorl@ git+file:/{foorl_dir}@9.8.7"
 


### PR DESCRIPTION
Requirements can be expressed as name requirements (e.g., foobar==x.y.x) or URL requirements
(e.g., VCS requirements such as  foobar@ git+https://github.com/foo/bar.git@branch).

But pip constraint files cannot contain URL requirements, only name requirements (e.g., foobar==x.y.x). 
Our check that the constraints file covered all the requirements did not take this into account.

This change subtracts out URL requirements before checking constraint coverage, and then adds them
back when creating the "repository pex". 

Note that using this requires some care in constructing the constraints file. For example, `pip freeze` will
not do the right thing. 

We will handle this case properly when we have a first-class feature in Pants for creating and consuming 
proper lockfiles. 

[ci skip-rust]

[ci skip-build-wheels]