### PR TITLE
Allow Python files without a file ending (Cherry-pick of #11905)

### DIFF
--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -52,7 +52,8 @@ logger = logging.getLogger(__name__)
 
 
 class PythonSources(Sources):
-    expected_file_extensions = (".py", ".pyi")
+    # Note that Python scripts often have no file ending.
+    expected_file_extensions = ("", ".py", ".pyi")
 
 
 class InterpreterConstraintsField(StringSequenceField):

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -964,21 +964,24 @@ def test_sources_default_globs(sources_rule_runner: RuleRunner) -> None:
 
 def test_sources_expected_file_extensions(sources_rule_runner: RuleRunner) -> None:
     class ExpectedExtensionsSources(Sources):
-        expected_file_extensions = (".f95", ".f03")
+        expected_file_extensions = (".f95", ".f03", "")
 
     addr = Address("src/fortran", target_name="lib")
-    sources_rule_runner.create_files("src/fortran", files=["s.f95", "s.f03", "s.f08"])
-    sources = ExpectedExtensionsSources(["s.f*"], address=addr)
+    sources_rule_runner.create_files("src/fortran", ["s.f95", "s.f03", "s.f08", "s"])
+
+    def get_sources(srcs: Iterable[str]) -> Tuple[str, ...]:
+        return sources_rule_runner.request(
+            HydratedSources, [HydrateSourcesRequest(ExpectedExtensionsSources(srcs, address=addr))]
+        ).snapshot.files
+
     with pytest.raises(ExecutionError) as exc:
-        sources_rule_runner.request(HydratedSources, [HydrateSourcesRequest(sources)])
-    assert "s.f08" in str(exc.value)
+        get_sources(["s.f*"])
+    assert "['src/fortran/s.f08']" in str(exc.value)
     assert str(addr) in str(exc.value)
 
     # Also check that we support valid sources
-    valid_sources = ExpectedExtensionsSources(["s.f95"], address=addr)
-    assert sources_rule_runner.request(
-        HydratedSources, [HydrateSourcesRequest(valid_sources)]
-    ).snapshot.files == ("src/fortran/s.f95",)
+    assert get_sources(["s.f95"]) == ("src/fortran/s.f95",)
+    assert get_sources(["s"]) == ("src/fortran/s",)
 
 
 def test_sources_expected_num_files(sources_rule_runner: RuleRunner) -> None:

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1242,7 +1242,7 @@ class Sources(StringSequenceField, AsyncFieldMixin):
                     else repr(self.expected_file_extensions[0])
                 )
                 raise InvalidFieldException(
-                    f"The {repr(self.alias)} field in target {self.address} must only contain "
+                    f"The {repr(self.alias)} field in target {self.address} can only contain "
                     f"files that end in {expected}, but it had these files: {sorted(bad_files)}."
                     f"\n\nMaybe create a `resources()` or `files()` target and include it in the "
                     f"`dependencies` field?"


### PR DESCRIPTION
[ci skip-rust]
