### PR TITLE
Allow Python files without a file ending (Cherry-pick of #11905)

### DIFF
--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -43,7 +43,8 @@ from pants.util.docutil import docs_url
 
 
 class PythonSources(Sources):
-    expected_file_extensions = (".py", ".pyi")
+    # Note that Python scripts often have no file ending.
+    expected_file_extensions = ("", ".py", ".pyi")
 
 
 class InterpreterConstraintsField(StringSequenceField):

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1285,7 +1285,7 @@ class Sources(StringSequenceField, AsyncFieldMixin):
                     else repr(self.expected_file_extensions[0])
                 )
                 raise InvalidFieldException(
-                    f"The {repr(self.alias)} field in target {self.address} must only contain "
+                    f"The {repr(self.alias)} field in target {self.address} can only contain "
                     f"files that end in {expected}, but it had these files: {sorted(bad_files)}."
                     f"\n\nMaybe create a `resources()` or `files()` target and include it in the "
                     f"`dependencies` field?"


### PR DESCRIPTION
[ci skip-rust]