### PR TITLE
Disable Toolchain BuildSense

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -628,11 +628,6 @@ jobs:
     - mkdir -p dist/deploy/pex/
     - mv dist/pants*.pex dist/deploy/pex/
     stage: Deploy Pants Pex Unstable
-notifications:
-  webhooks:
-    on_start: always
-    urls:
-    - https://webhooks.toolchain.com/travis/repo/pantsbuild/pants/
 stages:
 - if: type != cron
   name: Bootstrap Pants

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -792,12 +792,12 @@ def main() -> None:
             # Conditions are documented here: https://docs.travis-ci.com/user/conditions-v1
             "conditions": "v1",
             "env": {"global": GLOBAL_ENV_VARS},
-            "notifications": {
-                "webhooks": {
-                    "on_start": "always",
-                    "urls": ["https://webhooks.toolchain.com/travis/repo/pantsbuild/pants/"],
-                }
-            },
+            # "notifications": {
+            #     "webhooks": {
+            #         "on_start": "always",
+            #         "urls": ["https://webhooks.toolchain.com/travis/repo/pantsbuild/pants/"],
+            #     }
+            # },
             "stages": Stage.all_entries(),
             "deploy": DEPLOY_SETTINGS,
             "jobs": {

--- a/pants.toml
+++ b/pants.toml
@@ -14,13 +14,13 @@ backend_packages.add = [
   "pants.backend.python.typecheck.mypy",
   "pants.backend.python.mixed_interpreter_constraints",
   "internal_plugins.releases",
-  "toolchain.pants.auth",
-  "toolchain.pants.buildsense",
-  "toolchain.pants.common",
+#  "toolchain.pants.auth",
+#  "toolchain.pants.buildsense",
+#  "toolchain.pants.common",
 ]
 
 plugins = [
-  "toolchain.pants.plugin==0.1.0",
+#  "toolchain.pants.plugin==0.1.0",
 ]
 
 build_file_prelude_globs = ["pants-plugins/python_integration_tests_macro.py"]
@@ -141,5 +141,5 @@ interpreter_constraints = [">=3.7,<3.9"]
 [sourcefile-validation]
 config = "@build-support/regexes/config.yaml"
 
-[toolchain-setup]
-repo = "pants"
+# [toolchain-setup]
+# repo = "pants"

--- a/pants.travis-ci.toml
+++ b/pants.travis-ci.toml
@@ -8,7 +8,7 @@ dynamic_ui = false
 # now in order to smooth off rough edges locally.
 pantsd = false
 
-streaming_workunits_handlers = ["toolchain.pants.buildsense.reporter.Reporter"]
+#streaming_workunits_handlers = ["toolchain.pants.buildsense.reporter.Reporter"]
 
 [test]
 use_coverage = true
@@ -19,7 +19,7 @@ junit_xml_dir = "dist/test-results/"
 [coverage-py]
 report = ["raw", "xml"]
 
-[auth]
-from_env_var = "TOOLCHAIN_AUTH_TOKEN"
-org = "pantsbuild"
-ci_env_variables = ["TRAVIS", "TRAVIS_JOB_ID", "TRAVIS_BUILD_ID", "TRAVIS_PULL_REQUEST", "TRAVIS_BUILD_WEB_URL"]
+#[auth]
+#from_env_var = "TOOLCHAIN_AUTH_TOKEN"
+#org = "pantsbuild"
+#ci_env_variables = ["TRAVIS", "TRAVIS_JOB_ID", "TRAVIS_BUILD_ID", "TRAVIS_PULL_REQUEST", "TRAVIS_BUILD_WEB_URL"]


### PR DESCRIPTION
The plugin is failing, likely due to server changes: https://travis-ci.com/github/pantsbuild/pants/jobs/498920388#L210

Because this is an old branch, it's not worth the resources to upgrade the plugin.