### PR TITLE
Disable Toolchain BuildSense and remote cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -276,8 +276,7 @@ jobs:
     - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain
       none
     - source ${HOME}/.cargo/env
-    - ./build-support/bin/ci.py --githooks --smoke-tests --lint --remote-cache-enabled
-      --python-version 3.7
+    - ./build-support/bin/ci.py --githooks --smoke-tests --lint --python-version 3.7
     stage: Test Pants
   - addons:
       apt:
@@ -325,8 +324,7 @@ jobs:
     - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain
       none
     - source ${HOME}/.cargo/env
-    - ./build-support/bin/ci.py --githooks --smoke-tests --lint --remote-cache-enabled
-      --python-version 3.8
+    - ./build-support/bin/ci.py --githooks --smoke-tests --lint --python-version 3.8
     stage: Test Pants (Cron)
   - before_cache:
     - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
@@ -446,7 +444,7 @@ jobs:
     - '3.7'
     script:
     - travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py
-      --unit-tests --integration-tests --remote-cache-enabled --python-version 3.7
+      --unit-tests --integration-tests --python-version 3.7
     stage: Test Pants
   - addons:
       apt:
@@ -497,7 +495,7 @@ jobs:
     - '3.7'
     script:
     - travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py
-      --unit-tests --integration-tests --remote-cache-enabled --python-version 3.8
+      --unit-tests --integration-tests --python-version 3.8
     stage: Test Pants (Cron)
   - before_cache:
     - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
@@ -929,11 +927,6 @@ jobs:
     - mkdir -p dist/deploy/pex/
     - mv dist/pants*.pex dist/deploy/pex/
     stage: Deploy Pants Pex Unstable
-notifications:
-  webhooks:
-    on_start: always
-    urls:
-    - https://webhooks.toolchain.com/travis/repo/pantsbuild/pants/
 stages:
 - if: type != cron
   name: Bootstrap Pants

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -494,7 +494,7 @@ def lint(python_version: PythonVersion) -> Dict:
             *_install_rust(),
             (
                 "./build-support/bin/ci.py --githooks --smoke-tests --lint "
-                f"--remote-cache-enabled --python-version {python_version.decimal}"
+                f"--python-version {python_version.decimal}"
             ),
         ],
     }
@@ -542,7 +542,7 @@ def python_tests(python_version: PythonVersion) -> Dict:
         "name": f"Python tests (Python {python_version.decimal})",
         "script": [
             "travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py "
-            "--unit-tests --integration-tests --remote-cache-enabled "
+            "--unit-tests --integration-tests "
             f"--python-version {python_version.decimal}"
         ],
         "after_success": ["./build-support/bin/upload_coverage.sh"],
@@ -791,12 +791,12 @@ def main() -> None:
             # Conditions are documented here: https://docs.travis-ci.com/user/conditions-v1
             "conditions": "v1",
             "env": {"global": GLOBAL_ENV_VARS},
-            "notifications": {
-                "webhooks": {
-                    "on_start": "always",
-                    "urls": ["https://webhooks.toolchain.com/travis/repo/pantsbuild/pants/"],
-                }
-            },
+            # "notifications": {
+            #     "webhooks": {
+            #         "on_start": "always",
+            #         "urls": ["https://webhooks.toolchain.com/travis/repo/pantsbuild/pants/"],
+            #     }
+            # },
             "stages": Stage.all_entries(),
             "deploy": DEPLOY_SETTINGS,
             "jobs": {

--- a/pants.toml
+++ b/pants.toml
@@ -14,13 +14,13 @@ backend_packages.add = [
   "pants.backend.python.typecheck.mypy",
   "pants.backend.python.mixed_interpreter_constraints",
   "internal_plugins.releases",
-  "toolchain.pants.auth",
-  "toolchain.pants.buildsense",
-  "toolchain.pants.common",
+#  "toolchain.pants.auth",
+#  "toolchain.pants.buildsense",
+#  "toolchain.pants.common",
 ]
 
 plugins = [
-  "toolchain.pants.plugin==0.5.0",
+#  "toolchain.pants.plugin==0.5.0",
 ]
 
 build_file_prelude_globs = ["pants-plugins/python_integration_tests_macro.py"]
@@ -142,5 +142,5 @@ interpreter_constraints = [">=3.7,<3.9"]
 [sourcefile-validation]
 config = "@build-support/regexes/config.yaml"
 
-[toolchain-setup]
-repo = "pants"
+#[toolchain-setup]
+#repo = "pants"

--- a/pants.travis-ci.toml
+++ b/pants.travis-ci.toml
@@ -13,10 +13,10 @@ junit_xml_dir = "dist/test-results/"
 [coverage-py]
 report = ["raw", "xml"]
 
-[auth]
-from_env_var = "TOOLCHAIN_AUTH_TOKEN"
-org = "pantsbuild"
-ci_env_variables = ["TRAVIS", "TRAVIS_JOB_ID", "TRAVIS_BUILD_ID", "TRAVIS_PULL_REQUEST", "TRAVIS_BUILD_WEB_URL"]
+#[auth]
+#from_env_var = "TOOLCHAIN_AUTH_TOKEN"
+#org = "pantsbuild"
+#ci_env_variables = ["TRAVIS", "TRAVIS_JOB_ID", "TRAVIS_BUILD_ID", "TRAVIS_PULL_REQUEST", "TRAVIS_BUILD_WEB_URL"]
 
-[buildsense]
-enable = true
+#[buildsense]
+#enable = true


### PR DESCRIPTION
The plugin started failing recently, likely due to a server change: https://travis-ci.com/github/pantsbuild/pants/jobs/498920252#L524

Because this is an old branch, we don't spend the energy to upgrading the plugin.