### PR TITLE
Finesse some docgen markdown<->html issues.

### DIFF
--- a/build-support/bin/docs_templates/target_reference.md.mustache
+++ b/build-support/bin/docs_templates/target_reference.md.mustache
@@ -1,5 +1,5 @@
-{{! Mark as a paragraph to render as plain text, rather than markdown. }}
-<p>{{{description}}}</p>
+{{! Mark as a paragraph to render as plain text, rather than markdown. The spaces matter. }}
+<p> {{{description}}} </p>
 
 {{#fields}}
 ## <code>{{alias}}</code>
@@ -7,7 +7,7 @@
 <span style="color: purple">type: <code>{{type_hint}}</code></span>
 <span style="color: green">{{{default_or_required}}}</span>
 
-{{! Mark as a paragraph to render as plain text, rather than markdown. }}
-<p>{{{description}}}</p>
+{{! Mark as a paragraph to render as plain text, rather than markdown. The spaces matter. }}
+<p> {{{description}}} </p>
 
 {{/fields}}

--- a/build-support/bin/generate_docs_test.py
+++ b/build-support/bin/generate_docs_test.py
@@ -1,8 +1,12 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from generate_docs import markdown_safe
+from generate_docs import html_safe, markdown_safe
 
 
 def test_markdown_safe():
     assert "\\*A\\_B&lt;C&amp;" == markdown_safe("*A_B<C&")
+
+
+def test_html_safe():
+    assert "foo <code>bar==&#x27;baz&#x27;</code> qux" == html_safe("foo `bar=='baz'` qux")

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -566,8 +566,8 @@ class PythonRequirementsField(_RequirementSequenceField):
     alias = "requirements"
     required = True
     help = (
-        "A sequence of pip-style requirement strings, e.g. ['foo==1.8', "
-        "'bar<=3 ; python_version<'3']."
+        "A sequence of pip-style requirement strings, e.g. `['foo==1.8', "
+        "\"bar<=3 ; python_version<'3'\"]`."
     )
 
 

--- a/src/python/pants/util/docutil.py
+++ b/src/python/pants/util/docutil.py
@@ -15,7 +15,11 @@ def terminal_width(*, fallback: int = 96, padding: int = 2) -> int:
 def bracketed_docs_url(slug: str) -> str:
     """Link to the Pants docs using the current version of Pants.
 
-    Returned URL is surrounded by square brackets, to prevent linkifiers from considering any
+    Returned URL is surrounded by parentheses, to prevent linkifiers from considering any
     adjacent punctuation (such as a period at the end of a sentence) as part of the URL.
+
+    Note that this function used to use square brackets, hence the name, but it turns out
+    that those prevent any linkification at all from happening on readme.com, so we switched
+    to parens, but didn't update the name to prevent churn.
     """
-    return f"[https://www.pantsbuild.org/v{MAJOR_MINOR}/docs/{slug}]"
+    return f"(https://www.pantsbuild.org/v{MAJOR_MINOR}/docs/{slug})"


### PR DESCRIPTION
- Be more explicit about what we render in a markdown context vs an HTML context (i.e., inside `<p></p>` blocks).
- Handle backticks in HTML context correctly - our help strings often contain backticks, which we want to render as `<code></code>` blocks.
- Fix an issue with auto-linkification.

[ci skip-rust]

[ci skip-build-wheels]