### PR TITLE
Retrieve RunTracker args from the OptionsBootstrapper.

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -115,7 +115,7 @@ class LocalPantsRunner:
             options_bootstrapper, env, raise_=True
         )
 
-        run_tracker = RunTracker(options)
+        run_tracker = RunTracker(options_bootstrapper.args, options)
         union_membership = UnionMembership.from_rules(build_config.union_rules)
 
         # If we're running with the daemon, we'll be handed a warmed Scheduler, which we use

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -291,7 +291,8 @@ class WorkunitTracker(WorkunitsCallback):
 def new_run_tracker() -> RunTracker:
     # NB: A RunTracker usually observes "all options" (`full_options_for_scopes`), but it only
     # actually directly consumes bootstrap options.
-    return RunTracker(create_options_bootstrapper([]).bootstrap_options)
+    ob = create_options_bootstrapper([])
+    return RunTracker(ob.args, ob.bootstrap_options)
 
 
 @pytest.fixture

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -8,13 +8,12 @@ import logging
 import os
 import platform
 import socket
-import sys
 import time
 import uuid
 from collections import OrderedDict
 from hashlib import sha256
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from pants.base.build_environment import get_buildroot
 from pants.base.exiter import PANTS_SUCCEEDED_EXIT_CODE, ExitCode
@@ -45,7 +44,7 @@ class RunTrackerOptionEncoder(CoercingOptionEncoder):
 class RunTracker:
     """Tracks and times the execution of a single Pants run."""
 
-    def __init__(self, options: Options):
+    def __init__(self, args: Tuple[str, ...], options: Options):
         """
         :API: public
         """
@@ -59,6 +58,7 @@ class RunTracker:
         millis = int((run_timestamp * 1000) % 1000)
         self.run_id = f"pants_run_{str_time}_{millis}_{run_uuid}"
 
+        self._args = args
         self._all_options = options
         info_dir = os.path.join(self._all_options.for_global_scope().pants_workdir, "run-tracker")
         self._run_info: Dict[str, Any] = {}
@@ -88,7 +88,7 @@ class RunTracker:
         self._run_start_time = run_start_time
 
         datetime = time.strftime("%A %b %d, %Y %H:%M:%S", time.localtime(run_start_time))
-        cmd_line = " ".join(["pants"] + sys.argv[1:])
+        cmd_line = " ".join(("pants",) + self._args[1:])
 
         self._run_info.update(
             {


### PR DESCRIPTION
Since #11641, `sys.argv` has not been the right way to get the args for a particular run of pants.

Explicitly pass in the args via the `OptionsBootstrapper`, and fix the test (which was actually testing its _own_ `sys.argv`).

Fixes #11930.

[ci skip-rust]
[ci skip-build-wheels]