### PR TITLE
run mypy only on the files specified in the target

### DIFF
--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -49,7 +49,7 @@ class MyPyFieldSet(FieldSet):
 
 @dataclass(frozen=True)
 class MyPyPartition:
-    field_set_addresses: FrozenOrderedSet[Address]
+    root_targets: FrozenOrderedSet[Target]
     closure: FrozenOrderedSet[Target]
     interpreter_constraints: PexInterpreterConstraints
     python_version_already_configured: bool
@@ -159,17 +159,19 @@ async def mypy_typecheck_partition(partition: MyPyPartition, mypy: MyPy) -> Type
     plugin_sources_get = Get(
         PythonSourceFiles, PythonSourceFilesRequest(plugin_transitive_targets.closure)
     )
-    typechecked_sources_get = Get(PythonSourceFiles, PythonSourceFilesRequest(partition.closure))
+    closure_sources_get = Get(PythonSourceFiles, PythonSourceFilesRequest(partition.closure))
+    roots_sources_get = Get(PythonSourceFiles, PythonSourceFilesRequest(partition.root_targets))
 
     requirements_pex_get = Get(
         Pex,
         PexFromTargetsRequest,
         PexFromTargetsRequest.for_requirements(
-            (addr for addr in partition.field_set_addresses),
+            (tgt.address for tgt in partition.root_targets),
             hardcoded_interpreter_constraints=partition.interpreter_constraints,
             internal_only=True,
         ),
     )
+
     # TODO(John Sirois): Scope the extra requirements to the partition.
     #  Right now we just use a global set of extra requirements and these might not be compatible
     #  with all partitions. See: https://github.com/pantsbuild/pants/issues/11556
@@ -197,25 +199,25 @@ async def mypy_typecheck_partition(partition: MyPyPartition, mypy: MyPy) -> Type
 
     (
         plugin_sources,
-        typechecked_sources,
+        closure_sources,
+        roots_sources,
         mypy_pex,
         requirements_pex,
         mypy_extra_requirements_pex,
         config_files,
     ) = await MultiGet(
         plugin_sources_get,
-        typechecked_sources_get,
+        closure_sources_get,
+        roots_sources_get,
         mypy_pex_get,
         requirements_pex_get,
         mypy_extra_requirements_pex_get,
         config_files_get,
     )
 
-    typechecked_srcs_snapshot = typechecked_sources.source_files.snapshot
+    typechecked_srcs_snapshot = roots_sources.source_files.snapshot
     file_list_path = "__files.txt"
-    python_files = "\n".join(
-        determine_python_files(typechecked_sources.source_files.snapshot.files)
-    )
+    python_files = "\n".join(determine_python_files(roots_sources.source_files.snapshot.files))
     file_list_digest_request = Get(
         Digest,
         CreateDigest([FileContent(file_list_path, python_files.encode())]),
@@ -241,7 +243,7 @@ async def mypy_typecheck_partition(partition: MyPyPartition, mypy: MyPy) -> Type
             [
                 file_list_digest,
                 plugin_sources.source_files.snapshot.digest,
-                typechecked_srcs_snapshot.digest,
+                closure_sources.source_files.snapshot.digest,
                 typechecked_venv_pex.digest,
                 config_files.snapshot.digest,
             ]
@@ -249,10 +251,11 @@ async def mypy_typecheck_partition(partition: MyPyPartition, mypy: MyPy) -> Type
     )
 
     all_used_source_roots = sorted(
-        set(itertools.chain(plugin_sources.source_roots, typechecked_sources.source_roots))
+        set(itertools.chain(plugin_sources.source_roots, closure_sources.source_roots))
     )
     env = {
         "PEX_EXTRA_SYS_PATH": ":".join(all_used_source_roots),
+        "MYPYPATH": ":".join(all_used_source_roots),
     }
 
     result = await Get(
@@ -315,10 +318,10 @@ async def mypy_typecheck(
     for interpreter_constraints, all_transitive_targets in sorted(
         interpreter_constraints_to_transitive_targets.items()
     ):
-        combined_roots: OrderedSet[Address] = OrderedSet()
+        combined_roots: OrderedSet[Target] = OrderedSet()
         combined_closure: OrderedSet[Target] = OrderedSet()
         for transitive_targets in all_transitive_targets:
-            combined_roots.update(tgt.address for tgt in transitive_targets.roots)
+            combined_roots.update(transitive_targets.roots)
             combined_closure.update(transitive_targets.closure)
         partitions.append(
             MyPyPartition(

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -25,7 +25,7 @@ from pants.backend.python.util_rules.python_sources import (
 )
 from pants.core.goals.typecheck import TypecheckRequest, TypecheckResult, TypecheckResults
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
-from pants.engine.addresses import Address, Addresses, UnparsedAddressInputs
+from pants.engine.addresses import Addresses, UnparsedAddressInputs
 from pants.engine.fs import CreateDigest, Digest, DigestContents, FileContent, MergeDigests
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -859,7 +859,7 @@ def test_run_mypy_only_on_specified_files(rule_runner: RuleRunner) -> None:
     )
 
     # create a library that does NOT pass mypy checks
-    bad_target = make_target(
+    make_target(
         rule_runner=rule_runner,
         source_files=[BAD_SOURCE],
         name="bad",

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -96,7 +96,7 @@ def make_target(
     package: Optional[str] = None,
     name: str = "target",
     interpreter_constraints: Optional[str] = None,
-    dependencies: Optional[List[str]] = None
+    dependencies: Optional[List[str]] = None,
 ) -> Target:
     if not package:
         package = PACKAGE


### PR DESCRIPTION
[ci skip-rust]

Run mypy only on the files specified by the target instead of running it on _all_ transitive dependencies (see #11553 ).

I tried to follow the steps described in #11553 but I had to add the env var `MYPYPATH` containing all the source roots because mypy was not able to find the stub files (test `test_type_stubs`).