### PR TITLE
Upgrade to Rust 1.52.0-beta3

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -56,7 +56,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.49.0-*
+        path: '~/.rustup/toolchains/beta-2021-04-07-*
 
           ~/.rustup/update-hashes
 
@@ -185,7 +185,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.49.0-*
+        path: '~/.rustup/toolchains/beta-2021-04-07-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,7 +56,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.49.0-*
+        path: '~/.rustup/toolchains/beta-2021-04-07-*
 
           ~/.rustup/update-hashes
 
@@ -184,7 +184,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.49.0-*
+        path: '~/.rustup/toolchains/beta-2021-04-07-*
 
           ~/.rustup/update-hashes
 
@@ -359,7 +359,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.49.0-*
+        path: '~/.rustup/toolchains/beta-2021-04-07-*
 
           ~/.rustup/update-hashes
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.49.0"
+channel = "beta-2021-04-07"
 components = [
   "cargo",
   "clippy",

--- a/src/rust/engine/concrete_time/src/lib.rs
+++ b/src/rust/engine/concrete_time/src/lib.rs
@@ -64,9 +64,9 @@ impl From<std::time::Duration> for Duration {
   }
 }
 
-impl Into<std::time::Duration> for Duration {
-  fn into(self) -> std::time::Duration {
-    std::time::Duration::new(self.secs, self.nanos)
+impl From<Duration> for std::time::Duration {
+  fn from(duration: Duration) -> std::time::Duration {
+    std::time::Duration::new(duration.secs, duration.nanos)
   }
 }
 

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -122,8 +122,8 @@ enum Node {
 
 #[derive(Clone, Copy, Debug)]
 pub enum BRFSEvent {
-  INIT,
-  DESTROY,
+  Init,
+  Destroy,
 }
 
 struct BuildResultFS {
@@ -413,14 +413,14 @@ impl BuildResultFS {
 //  ... created on demand and cached for the lifetime of the program.
 impl fuse::Filesystem for BuildResultFS {
   fn init(&mut self, _req: &fuse::Request) -> Result<(), libc::c_int> {
-    self.sender.send(BRFSEvent::INIT).map_err(|_| 1)
+    self.sender.send(BRFSEvent::Init).map_err(|_| 1)
   }
 
   fn destroy(&mut self, _req: &fuse::Request) {
     self
       .sender
-      .send(BRFSEvent::DESTROY)
-      .unwrap_or_else(|err| warn!("Failed to send {:?} event: {}", BRFSEvent::DESTROY, err))
+      .send(BRFSEvent::Destroy)
+      .unwrap_or_else(|err| warn!("Failed to send {:?} event: {}", BRFSEvent::Destroy, err))
   }
 
   // Used to answer stat calls
@@ -708,11 +708,9 @@ async fn main() {
   let mount_path = args.value_of("mount-path").unwrap();
   let store_path = args.value_of("local-store-path").unwrap();
 
-  let root_ca_certs = if let Some(path) = args.value_of("root-ca-cert-file") {
-    Some(std::fs::read(path).expect("Error reading root CA certs file"))
-  } else {
-    None
-  };
+  let root_ca_certs = args
+    .value_of("root-ca-cert-file")
+    .map(|path| std::fs::read(path).expect("Error reading root CA certs file"));
 
   let mut headers = BTreeMap::new();
   if let Some(oauth_path) = args.value_of("oauth-bearer-token-file") {
@@ -753,8 +751,8 @@ async fn main() {
 
   #[derive(Clone, Copy, Debug)]
   enum Sig {
-    INT,
-    TERM,
+    Int,
+    Term,
     Unmount,
   }
 
@@ -768,8 +766,8 @@ async fn main() {
     .map(move |_| Some(sig))
   }
 
-  let sigint = install_handler(SignalKind::interrupt, Sig::INT);
-  let sigterm = install_handler(SignalKind::terminate, Sig::TERM);
+  let sigint = install_handler(SignalKind::interrupt, Sig::Int);
+  let sigterm = install_handler(SignalKind::terminate, Sig::Term);
 
   match mount(mount_path, store, runtime.clone()) {
     Err(err) => {
@@ -781,8 +779,8 @@ async fn main() {
     }
     Ok((_, receiver)) => {
       match receiver.recv().unwrap() {
-        BRFSEvent::INIT => debug!("Store {} mounted at {}", store_path, mount_path),
-        BRFSEvent::DESTROY => {
+        BRFSEvent::Init => debug!("Store {} mounted at {}", store_path, mount_path),
+        BRFSEvent::Destroy => {
           warn!("Externally unmounted before we could mount.");
           return;
         }
@@ -792,8 +790,8 @@ async fn main() {
         // N.B.: In practice recv always errs and we exercise the or branch. It seems the sender
         // side thread always exits (which drops our BuildResultFS) before we get a chance to
         // complete the read.
-        match receiver.recv().unwrap_or(BRFSEvent::DESTROY) {
-          BRFSEvent::DESTROY => Some(Sig::Unmount),
+        match receiver.recv().unwrap_or(BRFSEvent::Destroy) {
+          BRFSEvent::Destroy => Some(Sig::Unmount),
           event => {
             warn!("Received unexpected event {:?}", event);
             None

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -17,7 +17,7 @@ use parking_lot::Mutex;
 
 use crate::{
   Dir, GitignoreStyleExcludes, GlobExpansionConjunction, Link, PathStat, Stat, StrictGlobMatching,
-  VFS,
+  Vfs,
 };
 
 lazy_static! {
@@ -350,7 +350,7 @@ impl PreparedPathGlobs {
 }
 
 #[async_trait]
-pub trait GlobMatching<E: Display + Send + Sync + 'static>: VFS<E> {
+pub trait GlobMatching<E: Display + Send + Sync + 'static>: Vfs<E> {
   ///
   /// Canonicalize the Link for the given Path to an underlying File or Dir. May result
   /// in None if the PathStat represents a broken Link.
@@ -380,14 +380,14 @@ pub trait GlobMatching<E: Display + Send + Sync + 'static>: VFS<E> {
   }
 }
 
-impl<E: Display + Send + Sync + 'static, T: VFS<E>> GlobMatching<E> for T {}
+impl<E: Display + Send + Sync + 'static, T: Vfs<E>> GlobMatching<E> for T {}
 
 // NB: This trait exists because `expand_single()` (and its return type) should be private, but
 // traits don't allow specifying private methods (and we don't want to use a top-level `fn` because
 // it's much more awkward than just specifying `&self`).
 // The methods of `GlobMatching` are forwarded to methods here.
 #[async_trait]
-trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: VFS<E> {
+trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: Vfs<E> {
   async fn directory_listing(
     &self,
     canonical_dir: Dir,
@@ -444,7 +444,7 @@ trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: VFS<E> {
     )
     .await?;
     // See the note above.
-    Ok(path_stats.into_iter().filter_map(|pso| pso).collect())
+    Ok(path_stats.into_iter().flatten().collect())
   }
 
   async fn expand_globs(
@@ -686,4 +686,4 @@ trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: VFS<E> {
   }
 }
 
-impl<E: Display + Send + Sync + 'static, T: VFS<E>> GlobMatchingImplementation<E> for T {}
+impl<E: Display + Send + Sync + 'static, T: Vfs<E>> GlobMatchingImplementation<E> for T {}

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -662,7 +662,7 @@ impl PosixFS {
 }
 
 #[async_trait]
-impl VFS<io::Error> for Arc<PosixFS> {
+impl Vfs<io::Error> for Arc<PosixFS> {
   async fn read_link(&self, link: &Link) -> Result<PathBuf, io::Error> {
     PosixFS::read_link(self, link).await
   }
@@ -719,7 +719,7 @@ impl PathStatGetter<io::Error> for Arc<PosixFS> {
 /// A context for filesystem operations parameterized on an error type 'E'.
 ///
 #[async_trait]
-pub trait VFS<E: Send + Sync + 'static>: Clone + Send + Sync + 'static {
+pub trait Vfs<E: Send + Sync + 'static>: Clone + Send + Sync + 'static {
   async fn read_link(&self, link: &Link) -> Result<PathBuf, E>;
   async fn scandir(&self, dir: Dir) -> Result<Arc<DirectoryListing>, E>;
   fn is_ignored(&self, stat: &Stat) -> bool;

--- a/src/rust/engine/fs/src/posixfs_tests.rs
+++ b/src/rust/engine/fs/src/posixfs_tests.rs
@@ -4,7 +4,7 @@ use testutil;
 use crate::{
   Dir, DirectoryListing, File, GitignoreStyleExcludes, GlobExpansionConjunction, GlobMatching,
   Link, PathGlobs, PathStat, PathStatGetter, PosixFS, Stat, StrictGlobMatching, SymlinkBehavior,
-  VFS,
+  Vfs,
 };
 
 use async_trait::async_trait;
@@ -467,7 +467,7 @@ async fn test_basic_gitignore_functionality() {
 }
 
 ///
-/// An in-memory implementation of VFS, useful for precisely reproducing glob matching behavior for
+/// An in-memory implementation of Vfs, useful for precisely reproducing glob matching behavior for
 /// a set of file paths.
 ///
 pub struct MemFS {
@@ -516,7 +516,7 @@ impl MemFS {
 }
 
 #[async_trait]
-impl VFS<String> for Arc<MemFS> {
+impl Vfs<String> for Arc<MemFS> {
   async fn read_link(&self, link: &Link) -> Result<PathBuf, String> {
     // The creation of a static filesystem does not allow for Links.
     Err(format!("{:?} does not exist within this filesystem.", link))

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -819,8 +819,7 @@ impl Store {
   ) -> BoxFuture<'static, Result<HashMap<Digest, EntryType>, String>> {
     self
       .walk(digest, |_, _, digest, directory| {
-        let mut digest_types = Vec::new();
-        digest_types.push((digest, EntryType::Directory));
+        let mut digest_types = vec![(digest, EntryType::Directory)];
         for file in &directory.files {
           let file_digest = try_future!(require_digest(file.digest.as_ref()));
           digest_types.push((file_digest, EntryType::File));

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -67,7 +67,8 @@ async fn load_file_grpc_error() {
     .expect_err("Want error");
   assert!(
     error.contains("StubCAS is configured to always fail"),
-    format!("Bad error message, got: {}", error)
+    "Bad error message, got: {}",
+    error
   )
 }
 
@@ -83,7 +84,8 @@ async fn load_directory_grpc_error() {
   .expect_err("Want error");
   assert!(
     error.contains("StubCAS is configured to always fail"),
-    format!("Bad error message, got: {}", error)
+    "Bad error message, got: {}",
+    error
   )
 }
 
@@ -182,7 +184,9 @@ async fn write_file_multiple_chunks() {
   for size in write_message_sizes.iter() {
     assert!(
       size <= &(10 * 1024),
-      format!("Size {} should have been <= {}", size, 10 * 1024)
+      "Size {} should have been <= {}",
+      size,
+      10 * 1024
     );
   }
 }
@@ -216,7 +220,8 @@ async fn write_file_errors() {
     .expect_err("Want error");
   assert!(
     error.contains("StubCAS is configured to always fail"),
-    format!("Bad error message, got: {}", error)
+    "Bad error message, got: {}",
+    error
   );
 }
 
@@ -238,7 +243,8 @@ async fn write_connection_error() {
     .expect_err("Want error");
   assert!(
     error.contains("dns error: failed to lookup address information"),
-    format!("Bad error message, got: {}", error)
+    "Bad error message, got: {}",
+    error
   );
 }
 
@@ -290,7 +296,8 @@ async fn list_missing_digests_error() {
     .expect_err("Want error");
   assert!(
     error.contains("StubCAS is configured to always fail"),
-    format!("Bad error message, got: {}", error)
+    "Bad error message, got: {}",
+    error
   );
 }
 

--- a/src/rust/engine/fs/store/src/snapshot.rs
+++ b/src/rust/engine/fs/store/src/snapshot.rs
@@ -319,7 +319,7 @@ pub fn osstring_as_utf8(path: OsString) -> Result<String, String> {
 // StoreFileByDigest allows a File to be saved to an underlying Store, in such a way that it can be
 // looked up by the Digest produced by the store_by_digest method.
 // It is a separate trait so that caching implementations can be written which wrap the Store (used
-// to store the bytes) and VFS (used to read the files off disk if needed).
+// to store the bytes) and Vfs (used to read the files off disk if needed).
 pub trait StoreFileByDigest<Error> {
   fn store_by_digest(&self, file: File) -> future::BoxFuture<'static, Result<Digest, Error>>;
 }

--- a/src/rust/engine/fs/store/src/snapshot_ops.rs
+++ b/src/rust/engine/fs/store/src/snapshot_ops.rs
@@ -397,7 +397,7 @@ impl IntermediateGlobbedFilesAndDirectories {
         let directory_node = cur_dir_directories.get(&directory_path).unwrap();
 
         // TODO(#9967): Figure out how to consume the existing glob matching logic that works on
-        // `VFS` instances!
+        // `Vfs` instances!
         match &path_glob {
           RestrictedPathGlob::Wildcard { wildcard } => {
             // NB: We interpret globs such that the *only* way to have a glob match the contents of

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -54,7 +54,7 @@ use tokio::time::sleep;
 
 pub use crate::node::{EntryId, Node, NodeContext, NodeError, NodeVisualizer, Stats};
 
-type FNV = BuildHasherDefault<FnvHasher>;
+type Fnv = BuildHasherDefault<FnvHasher>;
 
 type PGraph<N> = DiGraph<Entry<N>, f32, u32>;
 
@@ -175,8 +175,7 @@ impl<N: Node> InnerGraph<N> {
       .expect("There should not be any negative edge weights");
 
     let mut next = dst;
-    let mut path = Vec::new();
-    path.push(next);
+    let mut path = vec![next];
     while let Some(current) = paths[next.index()] {
       path.push(current);
       if current == src {
@@ -312,7 +311,7 @@ impl<N: Node> InnerGraph<N> {
   ///
   fn invalidate_from_roots<P: Fn(&N) -> bool>(&mut self, predicate: P) -> InvalidationResult {
     // Collect all entries that will be cleared.
-    let root_ids: HashSet<_, FNV> = self
+    let root_ids: HashSet<_, Fnv> = self
       .nodes
       .iter()
       .filter_map(|(node, &entry_id)| {
@@ -925,7 +924,7 @@ where
   graph: &'a InnerGraph<N>,
   direction: Direction,
   deque: VecDeque<EntryId>,
-  walked: HashSet<EntryId, FNV>,
+  walked: HashSet<EntryId, Fnv>,
   stop_walking_predicate: F,
 }
 

--- a/src/rust/engine/grpc_util/src/lib.rs
+++ b/src/rust/engine/grpc_util/src/lib.rs
@@ -63,7 +63,7 @@ pub fn create_tls_config(root_ca_certs: Option<Vec<u8>>) -> Result<ClientConfig,
   // Must set HTTP/2 as ALPN protocol otherwise cannot connect over TLS to gRPC servers.
   // Unfortunately, this is not a default value and, moreover, Tonic does not provide
   // any helper function to encapsulate this knowledge.
-  tls_config.set_protocols(&[Vec::from(&"h2"[..])]);
+  tls_config.set_protocols(&[Vec::from("h2")]);
 
   // Add the root store.
   match root_ca_certs {

--- a/src/rust/engine/process_execution/bazel_protos/src/verification_tests.rs
+++ b/src/rust/engine/process_execution/bazel_protos/src/verification_tests.rs
@@ -78,7 +78,8 @@ fn empty_child_name() {
   let error = verify_directory_canonical(EMPTY_DIGEST, &directory).expect_err("Want error");
   assert!(
     error.contains("A child name must not be empty"),
-    format!("Bad error message: {}", error)
+    "Bad error message: {}",
+    error
   );
 }
 
@@ -96,10 +97,7 @@ fn multiple_path_segments_in_directory() {
   };
 
   let error = verify_directory_canonical(EMPTY_DIGEST, &directory).expect_err("Want error");
-  assert!(
-    error.contains("pets/cats"),
-    format!("Bad error message: {}", error)
-  );
+  assert!(error.contains("pets/cats"), "Bad error message: {}", error);
 }
 
 #[test]
@@ -119,7 +117,8 @@ fn multiple_path_segments_in_file() {
   let error = verify_directory_canonical(EMPTY_DIGEST, &directory).expect_err("Want error");
   assert!(
     error.contains("cats/roland"),
-    format!("Bad error message: {}", error)
+    "Bad error message: {}",
+    error
   );
 }
 
@@ -146,10 +145,7 @@ fn duplicate_path_in_directory() {
   };
 
   let error = verify_directory_canonical(EMPTY_DIGEST, &directory).expect_err("Want error");
-  assert!(
-    error.contains("cats"),
-    format!("Bad error message: {}", error)
-  );
+  assert!(error.contains("cats"), "Bad error message: {}", error);
 }
 
 #[test]
@@ -177,10 +173,7 @@ fn duplicate_path_in_file() {
   };
 
   let error = verify_directory_canonical(EMPTY_DIGEST, &directory).expect_err("Want error");
-  assert!(
-    error.contains("roland"),
-    format!("Bad error message: {}", error)
-  );
+  assert!(error.contains("roland"), "Bad error message: {}", error);
 }
 
 #[test]

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -152,7 +152,7 @@ impl CommandRunner {
     let maybe_execute_response: Option<(ExecuteResponse, Platform)> = self
       .process_execution_store
       .load_bytes_with(fingerprint, move |bytes| {
-        let decoded: PlatformAndResponseBytes = bincode::deserialize(&bytes[..])
+        let decoded: PlatformAndResponseBytes = bincode::deserialize(bytes)
           .map_err(|err| format!("Could not deserialize platform and response: {}", err))?;
 
         let platform = decoded.platform;

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -409,9 +409,9 @@ impl From<ExecutedActionMetadata> for ProcessResultMetadata {
   }
 }
 
-impl Into<ExecutedActionMetadata> for ProcessResultMetadata {
-  fn into(self) -> ExecutedActionMetadata {
-    let (total_start, total_end) = match self.total_elapsed {
+impl From<ProcessResultMetadata> for ExecutedActionMetadata {
+  fn from(metadata: ProcessResultMetadata) -> ExecutedActionMetadata {
+    let (total_start, total_end) = match metadata.total_elapsed {
       Some(elapsed) => {
         // Because we do not have the precise start time, we hardcode to starting at UNIX_EPOCH. We
         // only care about accurately preserving the duration.

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -651,7 +651,7 @@ fn setup_run_sh_script(
   env: &BTreeMap<String, String>,
   working_directory: &Option<RelativePath>,
   argv: &[String],
-  workdir_path: &PathBuf,
+  workdir_path: &Path,
 ) -> Result<(), String> {
   let mut env_var_strings: Vec<String> = vec![];
   for (key, value) in env.iter() {

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -491,16 +491,14 @@ impl CommandRunner {
             ));
           };
 
-          return Ok(
-            populate_fallible_execution_result(
-              self.store.clone(),
-              action_result,
-              self.platform,
-              false,
-            )
-            .await
-            .map_err(ExecutionError::Fatal)?,
-          );
+          return populate_fallible_execution_result(
+            self.store.clone(),
+            action_result,
+            self.platform,
+            false,
+          )
+          .await
+          .map_err(ExecutionError::Fatal);
         }
 
         rpc_status

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -210,11 +210,10 @@ async fn main() {
     Store::local_only(executor.clone(), local_store_path).expect("Error making local store");
   let store = match (&args.server, &args.cas_server) {
     (_, Some(cas_server)) => {
-      let root_ca_certs = if let Some(ref path) = args.cas_root_ca_cert_file {
-        Some(std::fs::read(path).expect("Error reading root CA certs file"))
-      } else {
-        None
-      };
+      let root_ca_certs = args
+        .cas_root_ca_cert_file
+        .as_ref()
+        .map(|path| std::fs::read(path).expect("Error reading root CA certs file"));
 
       let mut headers = BTreeMap::new();
       if let Some(ref oauth_path) = args.cas_oauth_bearer_token_path {
@@ -256,11 +255,9 @@ async fn main() {
 
   let runner: Box<dyn process_execution::CommandRunner> = match args.server {
     Some(address) => {
-      let root_ca_certs = if let Some(path) = args.execution_root_ca_cert_file {
-        Some(std::fs::read(path).expect("Error reading root CA certs file"))
-      } else {
-        None
-      };
+      let root_ca_certs = args
+        .execution_root_ca_cert_file
+        .map(|path| std::fs::read(path).expect("Error reading root CA certs file"));
 
       if let Some(oauth_path) = args.execution_oauth_bearer_token_path {
         let token =

--- a/src/rust/engine/rule_graph/src/builder.rs
+++ b/src/rust/engine/rule_graph/src/builder.rs
@@ -1063,19 +1063,11 @@ impl<R: Rule> Builder<R> {
       // Finally, return a new graph with all deleted data discarded.
       Ok(graph.filter_map(
         |_node_id, node| {
-          if let Some(node) = node.inner() {
-            Some((node.node.clone(), node.in_set.clone()))
-          } else {
-            None
-          }
+          node
+            .inner()
+            .map(|node| (node.node.clone(), node.in_set.clone()))
         },
-        |_edge_id, edge| {
-          if let Some(edge) = edge.inner() {
-            Some(*edge)
-          } else {
-            None
-          }
-        },
+        |_edge_id, edge| edge.inner().copied(),
       ))
     } else {
       // Render the most specific errors.
@@ -1163,11 +1155,9 @@ impl<R: Rule> Builder<R> {
 
     let subgraph = graph.filter_map(
       |node_id, node| {
-        if let Some(errors) = errored.get(&node_id) {
-          Some(format!("{}:\n{}", node, errors.join("\n")))
-        } else {
-          None
-        }
+        errored
+          .get(&node_id)
+          .map(|errors| format!("{}:\n{}", node, errors.join("\n")))
       },
       |_, edge_weight| Some(edge_weight.clone()),
     );

--- a/src/rust/engine/rule_graph/src/lib.rs
+++ b/src/rust/engine/rule_graph/src/lib.rs
@@ -220,11 +220,11 @@ pub fn visualize_entry<R: Rule>(
       // Color "singleton" entries (with no params)!
       if e.params().is_empty() {
         Some(Palette::Olive.fmt_for_graph(display_args))
-      } else if let Some(color) = e.rule().and_then(|r| r.color()) {
-        // Color "intrinsic" entries (provided by the rust codebase)!
-        Some(color.fmt_for_graph(display_args))
       } else {
-        None
+        // Color "intrinsic" entries (provided by the rust codebase)!
+        e.rule()
+          .and_then(|r| r.color())
+          .map(|color| color.fmt_for_graph(display_args))
       }
     }
     &Entry::Param(_) => {

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -401,7 +401,7 @@ impl Core {
       // TODO: Errors in initialization should definitely be exposed as python
       // exceptions, rather than as panics.
       vfs: PosixFS::new(&build_root, ignorer, executor)
-        .map_err(|e| format!("Could not initialize VFS: {:?}", e))?,
+        .map_err(|e| format!("Could not initialize Vfs: {:?}", e))?,
       build_root,
       watcher,
       local_parallelism: exec_strategy_opts.local_parallelism,

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -15,7 +15,7 @@ use cpython::{
 };
 use smallvec::SmallVec;
 
-pub type FNV = hash::BuildHasherDefault<FnvHasher>;
+pub type Fnv = hash::BuildHasherDefault<FnvHasher>;
 
 ///
 /// Params represent a TypeId->Key map.

--- a/src/rust/engine/src/externs/interface/testutil.rs
+++ b/src/rust/engine/src/externs/interface/testutil.rs
@@ -35,7 +35,7 @@ py_class!(pub class PyStubCAS |py| {
   data server: StubCAS;
 
   @classmethod
-  def builder(cls) -> PyResult<PyStubCASBuilder> {
+  def builder(_cls) -> PyResult<PyStubCASBuilder> {
     let builder = StubCAS::builder();
     PyStubCASBuilder::create_instance(py, Arc::new(Mutex::new(Some(builder))))
   }

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -324,7 +324,7 @@ pub fn generator_send(generator: &Value, arg: &Value) -> Result<GeneratorRespons
         let get = g
           .cast_as::<PyGeneratorResponseGet>(py)
           .map_err(|e| Failure::from_py_err_with_gil(py, e.into()))?;
-        Ok(Get::new(py, get)?)
+        Get::new(py, get)
       })
       .collect::<Result<Vec<_>, _>>()?;
     Ok(GeneratorResponse::GetMulti(gets))

--- a/src/rust/engine/src/externs/stdio.rs
+++ b/src/rust/engine/src/externs/stdio.rs
@@ -34,6 +34,8 @@
   clippy::transmute_ptr_to_ptr,
   clippy::zero_ptr
 )]
+// TODO: False positive for |py| in py_class!.
+#![allow(unused_variables)]
 
 use cpython::buffer::PyBuffer;
 use cpython::{exc, py_class, PyErr, PyObject, PyResult, Python};

--- a/src/rust/engine/src/interning.rs
+++ b/src/rust/engine/src/interning.rs
@@ -8,7 +8,7 @@ use std::sync::atomic;
 use cpython::{ObjectProtocol, PyErr, PyType, Python, ToPyObject};
 use parking_lot::{Mutex, RwLock};
 
-use crate::core::{Key, Value, FNV};
+use crate::core::{Fnv, Key, Value};
 use crate::externs;
 
 ///
@@ -41,8 +41,8 @@ use crate::externs;
 ///
 #[derive(Default)]
 pub struct Interns {
-  forward_keys: Mutex<HashMap<InternKey, Key, FNV>>,
-  reverse_keys: RwLock<HashMap<Key, Value, FNV>>,
+  forward_keys: Mutex<HashMap<InternKey, Key, Fnv>>,
+  reverse_keys: RwLock<HashMap<Key, Value, Fnv>>,
   id_generator: atomic::AtomicU64,
 }
 

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -26,7 +26,7 @@ use bytes::BufMut;
 use cpython::{PyObject, Python, PythonObject};
 use fs::{
   self, Dir, DirectoryListing, File, FileContent, GlobExpansionConjunction, GlobMatching, Link,
-  PathGlobs, PathStat, PreparedPathGlobs, RelativePath, StrictGlobMatching, VFS,
+  PathGlobs, PathStat, PreparedPathGlobs, RelativePath, StrictGlobMatching, Vfs,
 };
 use process_execution::{
   self, CacheDest, CacheName, MultiPlatformProcess, Platform, Process, ProcessCacheScope,
@@ -45,7 +45,7 @@ use workunit_store::{
 pub type NodeResult<T> = Result<T, Failure>;
 
 #[async_trait]
-impl VFS<Failure> for Context {
+impl Vfs<Failure> for Context {
   async fn read_link(&self, link: &Link) -> Result<PathBuf, Failure> {
     Ok(self.get(ReadLink(link.clone())).await?.0)
   }

--- a/src/rust/engine/src/session.rs
+++ b/src/rust/engine/src/session.rs
@@ -153,8 +153,8 @@ impl Session {
     ));
 
     let handle = Arc::new(SessionHandle {
-      cancelled,
       build_id,
+      cancelled,
       display,
     });
     scheduler.core.sessions.add(&handle)?;

--- a/src/rust/engine/ui/src/console_ui.rs
+++ b/src/rust/engine/ui/src/console_ui.rs
@@ -44,7 +44,6 @@ pub struct ConsoleUI {
   local_parallelism: usize,
   // While the UI is running, there will be an Instance present.
   instance: Option<Instance>,
-  teardown_in_progress: bool,
   teardown_mpsc: (mpsc::Sender<()>, mpsc::Receiver<()>),
 }
 
@@ -54,7 +53,6 @@ impl ConsoleUI {
       workunit_store,
       local_parallelism,
       instance: None,
-      teardown_in_progress: false,
       teardown_mpsc: mpsc::channel(),
     }
   }
@@ -207,7 +205,6 @@ impl ConsoleUI {
   pub fn teardown(&mut self) -> impl Future<Output = Result<(), String>> {
     if let Some(instance) = self.instance.take() {
       let sender = self.teardown_mpsc.0.clone();
-      self.teardown_in_progress = true;
       // When the MultiProgress completes, the Term(Destination) is dropped, which will restore
       // direct access to the Console.
       instance


### PR DESCRIPTION
Rust upgrades have been blocked by a clippy bug which unfortunately missed the last release cycle. See #11631.

The relevant bugfix is available in the `1.52.0` beta series, and it seems better to temporarily be on beta than to wait 12+ weeks between upgrades.

Fixes #11631.

[ci skip-build-wheels]