### PR TITLE
Upgrade the default mypy to a version that works with namespace packages

### DIFF
--- a/3rdparty/python/constraints.txt
+++ b/3rdparty/python/constraints.txt
@@ -11,7 +11,7 @@ freezegun==1.1.0
 humbug==0.1.9
 idna==2.10
 iniconfig==1.1.1
-mypy==0.800
+mypy==0.812
 mypy-extensions==0.4.3
 packaging==20.9
 pex==2.1.38

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -14,7 +14,7 @@ humbug==0.1.9
 #     .value_history.ranked_values[-1].value
 #   '
 #
-mypy==0.800
+mypy==0.812
 
 packaging==20.9
 pathspec==0.8.1

--- a/build-support/coverage/coveragerc
+++ b/build-support/coverage/coveragerc
@@ -1,0 +1,6 @@
+[report]
+omit =
+  # We inject this file at test time (see src/python/pants/conftest.py), and so
+  # coverage will gather stats for it, but it doesn't correspond to a real source file,
+  # so reporting will fail, unless we omit it here.
+  */src/python/pants/__init__.py

--- a/build-support/mypy/mypy.ini
+++ b/build-support/mypy/mypy.ini
@@ -11,6 +11,11 @@ plugins =
 # because our codebase has so little type coverage. As we add more types, these options should be
 # re-evaluated and made more strict where possible.
 
+# Support namespace packages
+namespace_packages = True
+explicit_package_bases = True
+mypy_path = src/python:tests/python:testprojects/src/python
+
 # Optionals
 no_implicit_optional = True
 

--- a/pants.toml
+++ b/pants.toml
@@ -171,6 +171,7 @@ extra_env_vars = [
 
 [coverage-py]
 interpreter_constraints = [">=3.7,<3.10"]
+config = "build-support/coverage/coveragerc"
 
 [sourcefile-validation]
 config = "@build-support/regexes/config.yaml"

--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -44,6 +44,11 @@ resources(
 )
 
 python_library(
+  name='conftest',
+  sources=['conftest.py'],
+)
+
+python_library(
   name='version',
   sources=['version.py'],
   dependencies = [

--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -10,11 +10,6 @@ python_library(
   ],
 )
 
-python_library(
-  name='init',
-  sources=['__init__.py'],
-)
-
 python_distribution(
   name='pants-packaged',
   dependencies=[

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -626,7 +626,7 @@ def test_source_plugin(rule_runner: RuleRunner) -> None:
             """\
             python_requirement_library(
                 name='mypy',
-                requirements=['mypy==0.800'],
+                requirements=['mypy==0.812'],
             )
 
             python_requirement_library(

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -16,7 +16,7 @@ class MyPy(PythonToolBase):
     options_scope = "mypy"
     help = "The MyPy Python type checker (http://mypy-lang.org/)."
 
-    default_version = "mypy==0.800"
+    default_version = "mypy==0.812"
     default_main = ConsoleScript("mypy")
     # See `mypy/rules.py`. We only use these default constraints in some situations. Technically,
     # MyPy only requires 3.5+, but some popular plugins like `django-stubs` require 3.6+. Because

--- a/src/python/pants/conftest.py
+++ b/src/python/pants/conftest.py
@@ -1,0 +1,30 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pathlib import Path
+
+# The top-level `pants` module must be a namespace package, because we build two dists from it
+# (pantsbuild.pants, and pantsbuild.pants.testutil) and consumers of these dists need to be
+# able to import from both.
+#
+# In fact it is an *implicit* namespace package - that is, it has no __init__.py file.
+# See https://packaging.python.org/guides/packaging-namespace-packages/ .
+#
+# Unfortunately, the presence or absence of __init__.py affects how pytest determines the
+# module names for test code. For details see
+# https://docs.pytest.org/en/stable/goodpractices.html#test-package-name .
+#
+# Usually this doesn't matter, as tests don't typically care about their own module name.
+# But we have tests (notably those in src/python/pants/engine) that create @rules and
+# expect them to have certain names. And @rule names are generated from the name of the module
+# containing the rule function...
+#
+# To allow those tests to work naturally (with expected module names relative to `src/python`)
+# we artificially create `src/python/pants/__init__.py` in the test sandbox, to force
+# pytest to determine module names relative to `src/python` (instead of `src/python/pants`).
+#
+# Note that while this makes the (implicit) namespace package into a regular package,
+# that is fine at test time. We don't consume testutil from a dist but from source, in the same
+# source root (src/python). We only need `pants` to be a namespace package in the dists we create.
+
+Path("src/python/pants/__init__.py").touch()

--- a/testprojects/src/python/python_targets/test_binary.py
+++ b/testprojects/src/python/python_targets/test_binary.py
@@ -1,6 +1,6 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from python_targets.test_library import say_test  # type: ignore[import]
+from python_targets.test_library import say_test
 
 say_test()


### PR DESCRIPTION
Also, make the top-level `pants` package an implicit namespace package, and 
set up our mypy config appropriately, to prove that this works.

For context, #11532 attempted to rely on implicit ns packages by removing the explicit 
ns package invocation, leaving an empty `__init__.py`. But implicit ns packages 
require the `__init__.py` to be omitted entirely.

See https://www.python.org/dev/peps/pep-0420/, specifically
```Namespace packages cannot contain an __init__.py```

`pants` must be a ns package for imports from pantsbuild.pants.testutil to work.

[ci skip-rust]

[ci skip-build-wheels]