### PR TITLE
Fix remote cache writes to not block the Pants run

### DIFF
--- a/src/rust/engine/fs/store/src/tests.rs
+++ b/src/rust/engine/fs/store/src/tests.rs
@@ -783,7 +783,7 @@ async fn upload_missing_file_in_directory() {
   assert_eq!(
     error,
     format!(
-      "Failed to upload digest {:?}: Not found",
+      "Failed to upload digest {:?}: Not found in local store",
       TestData::roland().digest()
     ),
     "Bad error message"

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -154,12 +154,9 @@ impl CommandRunner {
       .load_bytes_with(fingerprint, move |bytes| {
         let decoded: PlatformAndResponseBytes = bincode::deserialize(bytes)
           .map_err(|err| format!("Could not deserialize platform and response: {}", err))?;
-
         let platform = decoded.platform;
-
         let execute_response = ExecuteResponse::decode(&decoded.response_bytes[..])
           .map_err(|e| format!("Invalid ExecuteResponse: {:?}", e))?;
-
         Ok((execute_response, platform))
       })
       .await?;

--- a/src/rust/engine/sharded_lmdb/src/lib.rs
+++ b/src/rust/engine/sharded_lmdb/src/lib.rs
@@ -436,8 +436,8 @@ impl ShardedLmdb {
         let (env, db, _) = store.get(&fingerprint);
         let ro_txn = env
           .begin_ro_txn()
-          .map_err(|err| format!("Failed to begin read transaction: {}", err));
-        ro_txn.and_then(|txn| match txn.get(db, &effective_key) {
+          .map_err(|err| format!("Failed to begin read transaction: {}", err))?;
+        match ro_txn.get(db, &effective_key) {
           Ok(bytes) => f(bytes).map(Some),
           Err(lmdb::Error::NotFound) => Ok(None),
           Err(err) => Err(format!(
@@ -445,7 +445,7 @@ impl ShardedLmdb {
             effective_key.to_hex(),
             err,
           )),
-        })
+        }
       })
       .await
   }


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/11908. As described there, `ensure_remote_has_recursive()` was blocking due to its call to `executor.block_on()`. This was introduced in https://github.com/pantsbuild/pants/pull/9793, which reasoned that only the spawned thread would get blocked, which would be safe - but it turns out that this blocking stops Pants from doing anything else.

This was not introduced due to the upgrade from Tokio 0.2 to 1.x, and it's plausible this never worked as intended with remote caching, given that remote caching was not available in May 2020.

Fundamentally, the issue makes sense. Reading from LMDB Store must be synchronous to be safe, which we correctly expressed, e.g. via using `Executor.spawn_blocking()`. We tried to minimize memory consumption by allowing for a callback to access a reference/slice of the bytes, rather than cloning it. However, we desire for the remote code to be async, e.g. so that it can finish in the background a la https://github.com/pantsbuild/pants/pull/11479. If it's async, it fundamentally would not be able to use a reference because that reference may no longer be valid - we need to clone the data to fully own it. 

While cloning the bytes will result in more memory consumption, it is imperative that remote caching fails gracefully. The increase in memory consumption is less offensive than #11908, i.e. that slowness in remote cache writes can slow down and even hang Pants.