### PR TITLE
Revert "Remove the explicit `pants` namespace package. (#11532)"

### DIFF
--- a/build-support/bin/check_inits.py
+++ b/build-support/bin/check_inits.py
@@ -21,7 +21,13 @@ def main() -> None:
     files = itertools.chain.from_iterable(
         [Path().glob(f"{d}/**/__init__.py") for d in DIRS_TO_CHECK]
     )
-    non_empty_inits = [f for f in files if bool(f.read_text())]
+    root_init = Path("src/python/pants/__init__.py")
+    if '__import__("pkg_resources").declare_namespace(__name__)' not in root_init.read_text():
+        die(
+            f"{root_init} must have the line "
+            '`__import__("pkg_resources").declare_namespace(__name__)` in it.'
+        )
+    non_empty_inits = [f for f in files if bool(f.read_text()) and f != root_init]
     if non_empty_inits:
         die(
             "All `__init__.py` file should be empty, but the following had content: "

--- a/src/python/pants/__init__.py
+++ b/src/python/pants/__init__.py
@@ -1,0 +1,3 @@
+# NB: We need to declare a namespace package because we have the dists `pantsbuild.pants` and
+# `pantsbuild.pants.testutil`, which both have the module `pants`.
+__import__("pkg_resources").declare_namespace(__name__)


### PR DESCRIPTION
This reverts commit 89e4bc49bfb5f694b23f53f59dd5a024608669d7.

#11532 replaced the ns package invocation in `src/python/pants/__init__.py` with an empty file, 
hoping to rely on implicit namespace package support in Python 3.7+. 

However, implicit namespace packages are created only when `__init__.py` is omitted entirely, 
not when it exists but is empty. 

Unfortunately, we cannot easily remove that `__init__.py` because it interferes with pytest's module 
discovery algorithm (see https://docs.pytest.org/en/stable/goodpractices.html#test-package-name 
and the note immediately above it). Removing `src/python/pants/__init__.py` means that pytest
will treat `src/python/pants` as a package root, prepend it to sys.path, and import test modules
relative to it. So, for example, it will import `src/python/pants/engine/rules_test.py` as module
`engine.rules_test`, not `pants.engine.rules_test`. 

Does the name a test module sees itself as matter? Usually not. But our engine tests create fake 
`@rule`s to test with, and those take on the name of the rule function's `__module__`, so various 
engine tests would fail because the rule names aren't as currently expected by the test.  

We could fix this by simply changing what the test expects, but that seems weird. The tests would need 
comments like "# This rule name is `engine.rules_test.a_named_rule`, without the expected `pants.` prefix,
because of a quirk of pytest", and that feels like a smell.

One fix I tried was to use the new (pytest 6.0+) `--import-mode=importlib` setting, but I could not get
that to work at all with our rules tests. A separate ticket will be filed for this, as this setting will become
pytest's default in the future, so we should figure it out at some point.

So for now we go back to explicit namespace packaging, despite the performance implications, 
until we figure out a solution.  As I understand it, the performance implications are in our own repo, and
don't affect end users.

[ci skip-rust]

[ci skip-build-wheels]