### PR TITLE
Release pants.pex in `--unzip` mode to workaround not loading properly

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -345,7 +345,7 @@ function build_pex() {
     -o "${dest}" \
     --no-strip-pex-env \
     --script=pants \
-    --venv \
+    --unzip \
     "${distribution_target_flags[@]}" \
     "${requirements[@]}"
 


### PR DESCRIPTION
Works around https://github.com/pantsbuild/pants/issues/11954. `--unzip` should give still good enough of performance.

[ci skip-rust]