### PR TITLE
Don't parse string imports if not enabled

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/import_parser.py
+++ b/src/python/pants/backend/python/dependency_inference/import_parser.py
@@ -7,13 +7,12 @@ from pants.backend.python.util_rules.pex import PexInterpreterConstraints
 from pants.backend.python.util_rules.pex_environment import PythonExecutable
 from pants.core.util_rules.source_files import SourceFilesRequest
 from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
+from pants.engine.collection import DeduplicatedCollection
 from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import Sources
 from pants.util.logging import LogLevel
-from pants.util.memo import memoized_property
-from pants.util.ordered_set import FrozenOrderedSet
 
 _SCRIPT = """\
 # -*- coding: utf-8 -*-
@@ -24,7 +23,7 @@ from __future__ import print_function, unicode_literals
 
 from io import open
 import ast
-import os.path
+import os
 import re
 import sys
 
@@ -35,16 +34,15 @@ STRING_IMPORT_REGEX = re.compile(r"^([a-z_][a-z_\\d]*\\.){2,}[a-zA-Z_]\\w*$", re
 class AstVisitor(ast.NodeVisitor):
     def __init__(self, package_parts):
         self._package_parts = package_parts
-        self.explicit_imports = set()
-        self.string_imports = set()
+        self.imports = set()
 
     def maybe_add_string_import(self, s):
         if STRING_IMPORT_REGEX.match(s):
-            self.string_imports.add(s)
+            self.imports.add(s)
 
     def visit_Import(self, node):
         for alias in node.names:
-            self.explicit_imports.add(alias.name)
+            self.imports.add(alias.name)
 
     def visit_ImportFrom(self, node):
         if node.level:
@@ -57,7 +55,7 @@ class AstVisitor(ast.NodeVisitor):
         else:
             abs_module = node.module
         for alias in node.names:
-            self.explicit_imports.add("{}.{}".format(abs_module, alias.name))
+            self.imports.add("{}.{}".format(abs_module, alias.name))
 
     def visit_Call(self, node):
       # Handle __import__("string_literal").  This is commonly used in __init__.py files,
@@ -71,37 +69,38 @@ class AstVisitor(ast.NodeVisitor):
           if sys.version_info[0:2] < (3, 8) and isinstance(node.args[0], ast.Str):
               arg_s = node.args[0].s
               val = arg_s.decode("utf-8") if isinstance(arg_s, bytes) else arg_s
-              self.explicit_imports.add(arg_s)
+              self.imports.add(arg_s)
               return
           elif isinstance(node.args[0], ast.Constant):
-              self.explicit_imports.add(str(node.args[0].value))
+              self.imports.add(str(node.args[0].value))
               return
       self.generic_visit(node)
 
-# String handling changes a bit depending on Python version. We dynamically add the appropriate
-# logic.
-if sys.version_info[0:2] == (2,7):
-    def visit_Str(self, node):
-        try:
-            val = node.s.decode("utf8") if isinstance(node.s, bytes) else node.s
-            self.maybe_add_string_import(val)
-        except UnicodeError:
-            pass
+if os.environ["STRING_IMPORTS"] == "y":
+    # String handling changes a bit depending on Python version. We dynamically add the appropriate
+    # logic.
+    if sys.version_info[0:2] == (2,7):
+        def visit_Str(self, node):
+            try:
+                val = node.s.decode("utf8") if isinstance(node.s, bytes) else node.s
+                self.maybe_add_string_import(val)
+            except UnicodeError:
+                pass
 
-    setattr(AstVisitor, 'visit_Str', visit_Str)
+        setattr(AstVisitor, 'visit_Str', visit_Str)
 
-elif sys.version_info[0:2] < (3, 8):
-    def visit_Str(self, node):
-        self.maybe_add_string_import(node.s)
+    elif sys.version_info[0:2] < (3, 8):
+        def visit_Str(self, node):
+            self.maybe_add_string_import(node.s)
 
-    setattr(AstVisitor, 'visit_Str', visit_Str)
+        setattr(AstVisitor, 'visit_Str', visit_Str)
 
-else:
-    def visit_Constant(self, node):
-        if isinstance(node.value, str):
-            self.maybe_add_string_import(node.value)
+    else:
+        def visit_Constant(self, node):
+            if isinstance(node.value, str):
+                self.maybe_add_string_import(node.value)
 
-    setattr(AstVisitor, 'visit_Constant', visit_Constant)
+        setattr(AstVisitor, 'visit_Constant', visit_Constant)
 
 
 def parse_file(filename):
@@ -114,8 +113,7 @@ def parse_file(filename):
 
 
 if __name__ == "__main__":
-    explicit_imports = set()
-    string_imports = set()
+    imports = set()
 
     for filename in sys.argv[1:]:
         tree = parse_file(filename)
@@ -124,41 +122,29 @@ if __name__ == "__main__":
 
         package_parts = os.path.dirname(filename).split(os.path.sep)
         visitor = AstVisitor(package_parts)
-        visitor.visit(tree)
 
-        explicit_imports.update(visitor.explicit_imports)
-        string_imports.update(visitor.string_imports)
+        visitor.visit(tree)
+        imports.update(visitor.imports)
 
     # We have to be careful to set the encoding explicitly and write raw bytes ourselves.
     # See below for where we explicitly decode.
-    buffer = sys.stdout if sys.version_info[0:2] == (2,7) else sys.stdout.buffer
-    buffer.write("\\n".join(sorted(explicit_imports)).encode("utf8"))
-    buffer.write(b"\\n--\\n")
-    buffer.write("\\n".join(sorted(string_imports)).encode("utf8"))
+    buffer = sys.stdout if sys.version_info[0:2] == (2, 7) else sys.stdout.buffer
+    buffer.write("\\n".join(sorted(imports)).encode("utf8"))
 """
 
 
-@dataclass(frozen=True)
-class ParsedPythonImports:
+class ParsedPythonImports(DeduplicatedCollection[str]):
     """All the discovered imports from a Python source file.
 
-    Explicit imports are imports from `import x` and `from module import x` statements. String
-    imports come from strings that look like module names, such as
-    `importlib.import_module("example.subdir.Foo")`.
+    May include string imports if the request specified to include them.
     """
-
-    explicit_imports: FrozenOrderedSet[str]
-    string_imports: FrozenOrderedSet[str]
-
-    @memoized_property
-    def all_imports(self) -> FrozenOrderedSet[str]:
-        return FrozenOrderedSet(sorted([*self.explicit_imports, *self.string_imports]))
 
 
 @dataclass(frozen=True)
 class ParsePythonImportsRequest:
     sources: Sources
     interpreter_constraints: PexInterpreterConstraints
+    string_imports: bool
 
 
 @rule
@@ -181,16 +167,13 @@ async def parse_python_imports(request: ParsePythonImportsRequest) -> ParsedPyth
             ],
             input_digest=input_digest,
             description=f"Determine Python imports for {request.sources.address}",
+            env={"STRING_IMPORTS": "y" if request.string_imports else "n"},
             level=LogLevel.DEBUG,
         ),
     )
     # See above for where we explicitly encoded as utf8. Even though utf8 is the
     # default for decode(), we make that explicit here for emphasis.
-    explicit_imports, _, string_imports = process_result.stdout.decode("utf8").partition("--")
-    return ParsedPythonImports(
-        explicit_imports=FrozenOrderedSet(explicit_imports.strip().splitlines()),
-        string_imports=FrozenOrderedSet(string_imports.strip().splitlines()),
-    )
+    return ParsedPythonImports(process_result.stdout.decode("utf8").strip().splitlines())
 
 
 def rules():

--- a/src/python/pants/backend/python/dependency_inference/import_parser_test.py
+++ b/src/python/pants/backend/python/dependency_inference/import_parser_test.py
@@ -1,8 +1,9 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 from textwrap import dedent
-from typing import List, Optional
 
 import pytest
 
@@ -39,24 +40,30 @@ def rule_runner() -> RuleRunner:
 
 def assert_imports_parsed(
     rule_runner: RuleRunner,
-    content: Optional[str],
+    content: str | None,
     *,
-    expected_explicit: List[str],
-    expected_string: List[str],
+    expected: list[str],
     filename: str = "project/foo.py",
     constraints: str = ">=3.6",
-):
-    if content:
-        rule_runner.create_file(filename, content)
+    string_imports: bool = True,
+) -> None:
     rule_runner.set_options([], env_inherit={"PATH", "PYENV_ROOT", "HOME"})
-    rule_runner.add_to_build_file("project", "python_library(sources=['**/*.py'])")
+    files = {"project/BUILD": "python_library(sources=['**/*.py'])"}
+    if content is not None:
+        files[filename] = content
+    rule_runner.write_files(files)
     tgt = rule_runner.get_target(Address("project"))
     imports = rule_runner.request(
         ParsedPythonImports,
-        [ParsePythonImportsRequest(tgt[PythonSources], PexInterpreterConstraints([constraints]))],
+        [
+            ParsePythonImportsRequest(
+                tgt[PythonSources],
+                PexInterpreterConstraints([constraints]),
+                string_imports=string_imports,
+            )
+        ],
     )
-    assert set(imports.explicit_imports) == set(expected_explicit)
-    assert set(imports.string_imports) == set(expected_string)
+    assert list(imports) == sorted(expected)
 
 
 def test_normal_imports(rule_runner: RuleRunner) -> None:
@@ -91,7 +98,7 @@ def test_normal_imports(rule_runner: RuleRunner) -> None:
     assert_imports_parsed(
         rule_runner,
         content,
-        expected_explicit=[
+        expected=[
             "__future__.print_function",
             "os",
             "os.path",
@@ -106,7 +113,6 @@ def test_normal_imports(rule_runner: RuleRunner) -> None:
             "subprocess23",
             "pkg_resources",
         ],
-        expected_string=[],
     )
 
 
@@ -124,13 +130,12 @@ def test_relative_imports(rule_runner: RuleRunner, basename: str) -> None:
         rule_runner,
         content,
         filename=f"project/util/{basename}",
-        expected_explicit=[
+        expected=[
             "project.util.sibling",
             "project.util.sibling.Nibling",
             "project.util.subdir.child.Child",
             "project.parent.Parent",
         ],
-        expected_string=[],
     )
 
 
@@ -168,8 +173,7 @@ def test_imports_from_strings(rule_runner: RuleRunner) -> None:
     assert_imports_parsed(
         rule_runner,
         content,
-        expected_explicit=[],
-        expected_string=[
+        expected=[
             "a.b.d",
             "a.b2.d",
             "a.b.c.Foo",
@@ -181,20 +185,19 @@ def test_imports_from_strings(rule_runner: RuleRunner) -> None:
             "a.b.c_狗",
         ],
     )
+    assert_imports_parsed(rule_runner, content, string_imports=False, expected=[])
 
 
 def test_gracefully_handle_syntax_errors(rule_runner: RuleRunner) -> None:
-    assert_imports_parsed(rule_runner, content="x =", expected_explicit=[], expected_string=[])
+    assert_imports_parsed(rule_runner, content="x =", expected=[])
 
 
 def test_handle_unicode(rule_runner: RuleRunner) -> None:
-    assert_imports_parsed(
-        rule_runner, content="x = 'äbç'", expected_explicit=[], expected_string=[]
-    )
+    assert_imports_parsed(rule_runner, content="x = 'äbç'", expected=[])
 
 
 def test_gracefully_handle_no_sources(rule_runner: RuleRunner) -> None:
-    assert_imports_parsed(rule_runner, content=None, expected_explicit=[], expected_string=[])
+    assert_imports_parsed(rule_runner, content=None, expected=[])
 
 
 @skip_unless_python27_present
@@ -221,13 +224,15 @@ def test_works_with_python2(rule_runner: RuleRunner) -> None:
         rule_runner,
         content,
         constraints="==2.7.*",
-        expected_explicit=[
+        expected=[
             "demo",
+            "dep.from.bytes",
+            "dep.from.str",
+            "dep.from.str_狗",
             "project.demo.Demo",
             "pkg_resources",
             "treat.as.a.regular.import.not.a.string.import",
         ],
-        expected_string=["dep.from.bytes", "dep.from.str", "dep.from.str_狗"],
     )
 
 
@@ -252,13 +257,13 @@ def test_works_with_python38(rule_runner: RuleRunner) -> None:
         rule_runner,
         content,
         constraints=">=3.8",
-        expected_explicit=[
+        expected=[
             "demo",
+            "dep.from.str",
             "project.demo.Demo",
             "pkg_resources",
             "treat.as.a.regular.import.not.a.string.import",
         ],
-        expected_string=["dep.from.str"],
     )
 
 
@@ -285,11 +290,11 @@ def test_works_with_python39(rule_runner: RuleRunner) -> None:
         rule_runner,
         content,
         constraints=">=3.9",
-        expected_explicit=[
+        expected=[
             "demo",
+            "dep.from.str",
             "project.demo.Demo",
             "pkg_resources",
             "treat.as.a.regular.import.not.a.string.import",
         ],
-        expected_string=["dep.from.str"],
     )

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -139,19 +139,11 @@ async def infer_python_dependencies_via_imports(
             ParsePythonImportsRequest(
                 request.sources_field,
                 PexInterpreterConstraints.create_from_targets([wrapped_tgt.target], python_setup),
+                string_imports=python_infer_subsystem.string_imports,
             ),
         ),
     )
-
-    relevant_imports = tuple(
-        imp
-        for imp in (
-            detected_imports.all_imports
-            if python_infer_subsystem.string_imports
-            else detected_imports.explicit_imports
-        )
-        if imp not in combined_stdlib
-    )
+    relevant_imports = detected_imports - combined_stdlib
 
     owners_per_import = await MultiGet(
         Get(PythonModuleOwners, PythonModule(imported_module))


### PR DESCRIPTION
We should not be doing wasted work. If string imports won't be consumed, no need to waste time traversing the AST for these imports + decoding/encoding the detected imports.

Beyond performance, this simplifies some of the code.

### Benchmarks
Runs `multitime -n 20 ./pants --no-pantsd --no-process-execution-local-cache dependencies src/python::` 20 times.

Before:

```            
            Mean        Std.Dev.    Min         Median      Max
real        4.220       0.238       4.047       4.143       5.119
user        6.446       0.212       6.221       6.381       7.138
sys         2.916       0.081       2.783       2.903       3.155
```


After:

```
            Mean        Std.Dev.    Min         Median      Max
real        4.180       0.163       3.899       4.158       4.548
user        6.407       0.136       6.264       6.371       6.757
sys         2.856       0.061       2.710       2.855       2.991
```

Even though this benchmark does not show a huge gain, this PR does result in doing less work so it makes sense that there is a minor improvement. 

[ci skip-rust]
[ci skip-build-wheels]