### PR TITLE
Make remote cache warning less chatty for missing files

### DIFF
--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -648,13 +648,12 @@ impl Store {
     let result = self
       .load_bytes_with(EntryType::File, file_digest, |_| Ok(()), |_| Ok(()))
       .await?;
-    if result.is_some() {
-      Ok(())
-    } else {
-      Err(format!(
-        "File {:?} did not exist in the store.",
-        file_digest
-      ))
+    match result {
+      Some(_) => Ok(()),
+      None => {
+        log::debug!("Missing file digest from remote store: {:?}", file_digest);
+        Err("File did not exist in the remote store.".to_owned())
+      }
     }
   }
 


### PR DESCRIPTION
Because the warning had the file digest in it, our aggregation logic did not work.

```
23:47:12.14 [WARN] Failed to read from remote cache (1 occurrences so far): File Digest { hash: Fingerprint<b6862795da00928c83c322abeff8c886086cb8b98c6c250cf56b101c74eb1e1d>, size_bytes: 2030 } did not exist in the store.
23:47:12.14 [WARN] Failed to read from remote cache (1 occurrences so far): File Digest { hash: Fingerprint<8ad86e89dc8138c1d05809502f968b5d017926cb5800baf8f89712950a503d57>, size_bytes: 514 } did not exist in the store.
23:47:12.15 [WARN] Failed to read from remote cache (1 occurrences so far): File Digest { hash: Fingerprint<e49415411d5ee6ac497555b98475851675e80d53e3397685ed743f2bc4cdd629>, size_bytes: 481 } did not exist in the store.
```

However, it does seem useful to know specifically which file was missing, so we log that at the debug level.

[ci skip-build-wheels]