### PR TITLE
Add back `interpreter_constraints` field to `pex_binary`

### DIFF
--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -358,6 +358,7 @@ class PexBinary(Target):
     core_fields = (
         *COMMON_TARGET_FIELDS,
         OutputPathField,
+        InterpreterConstraintsField,
         PexBinaryDependencies,
         PexEntryPointField,
         PexPlatformsField,


### PR DESCRIPTION
This should not have been deprecated in 2.2.x - that was a mistake. Even though `pex_binary` no longer has a `sources` field, it is still sensible to want to change the interpreter constraints for a binary. For example, it is totally valid to have a `pex_binary` with no first party code and only 3rd party reqs, and to want to set the constraints for that.

[ci skip-rust]
[ci skip-build-wheels]