### PR TITLE
Revert deprecation of `interpreter_constraints` field for `pex_binary` and `python_awslambda`

### DIFF
--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -184,23 +184,13 @@ class PythonAwsLambdaRuntime(StringField):
         return int(mo.group("major")), int(mo.group("minor"))
 
 
-class DeprecatedAwsLambdaInterpreterConstraints(InterpreterConstraintsField):
-    deprecated_removal_version = "2.3.0.dev0"
-    deprecated_removal_hint = (
-        "Because the `sources` field will be removed from `python_awslambda` targets, it no longer "
-        "makes sense to also have an `interpreter_constraints` field. Instead, set the "
-        "`interpreter_constraints` field on the `python_library` target containing the lambda's "
-        "handler code."
-    )
-
-
 class PythonAWSLambda(Target):
     alias = "python_awslambda"
     core_fields = (
         *COMMON_TARGET_FIELDS,
         PythonAwsLambdaSources,
-        DeprecatedAwsLambdaInterpreterConstraints,
         OutputPathField,
+        InterpreterConstraintsField,
         PythonAwsLambdaDependencies,
         PythonAwsLambdaHandlerField,
         PythonAwsLambdaRuntime,

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -236,23 +236,13 @@ class PexEmitWarningsField(BoolField):
         return self.value
 
 
-class DeprecatedPexBinaryInterpreterConstraints(InterpreterConstraintsField):
-    deprecated_removal_version = "2.3.0.dev0"
-    deprecated_removal_hint = (
-        "Because the `sources` field will be removed from `pex_binary` targets, it no longer makes "
-        "sense to also have an `interpreter_constraints` field. Instead, set the "
-        "`interpreter_constraints` field on the `python_library` target containing the binary's "
-        "entry point."
-    )
-
-
 class PexBinary(Target):
     alias = "pex_binary"
     core_fields = (
         *COMMON_TARGET_FIELDS,
         OutputPathField,
-        DeprecatedPexBinaryInterpreterConstraints,
         DeprecatedPexBinarySources,
+        InterpreterConstraintsField,
         PexBinaryDependencies,
         PexEntryPointField,
         PexPlatformsField,


### PR DESCRIPTION
[ci skip-rust]
[ci skip-build-wheels]