### PR TITLE
Don't require a kwarg for `Target` and `Field` constructors

### DIFF
--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -44,8 +44,8 @@ class PythonAwsLambdaHandlerField(StringField, AsyncFieldMixin, SecondaryOwnerMi
     )
 
     @classmethod
-    def compute_value(cls, raw_value: Optional[str], *, address: Address) -> str:
-        value = cast(str, super().compute_value(raw_value, address=address))
+    def compute_value(cls, raw_value: Optional[str], address: Address) -> str:
+        value = cast(str, super().compute_value(raw_value, address))
         if ":" not in value:
             raise InvalidFieldException(
                 f"The `{cls.alias}` field in target at {address} must end in the "
@@ -170,8 +170,8 @@ class PythonAwsLambdaRuntime(StringField):
     )
 
     @classmethod
-    def compute_value(cls, raw_value: Optional[str], *, address: Address) -> str:
-        value = cast(str, super().compute_value(raw_value, address=address))
+    def compute_value(cls, raw_value: Optional[str], address: Address) -> str:
+        value = cast(str, super().compute_value(raw_value, address))
         if not re.match(cls.PYTHON_RUNTIME_REGEX, value):
             raise InvalidFieldException(
                 f"The `{cls.alias}` field in target at {address} must be of the form pythonX.Y, "

--- a/src/python/pants/backend/awslambda/python/target_types_test.py
+++ b/src/python/pants/backend/awslambda/python/target_types_test.py
@@ -48,20 +48,20 @@ def rule_runner() -> RuleRunner:
 )
 def test_to_interpreter_version(runtime: str, expected_major: int, expected_minor: int) -> None:
     assert (expected_major, expected_minor) == PythonAwsLambdaRuntime(
-        runtime, address=Address("", target_name="t")
+        runtime, Address("", target_name="t")
     ).to_interpreter_version()
 
 
 @pytest.mark.parametrize("invalid_runtime", ("python88.99", "fooobar"))
 def test_runtime_validation(invalid_runtime: str) -> None:
     with pytest.raises(InvalidFieldException):
-        PythonAwsLambdaRuntime(invalid_runtime, address=Address("", target_name="t"))
+        PythonAwsLambdaRuntime(invalid_runtime, Address("", target_name="t"))
 
 
 @pytest.mark.parametrize("invalid_handler", ("path.to.lambda", "lambda.py"))
 def test_handler_validation(invalid_handler: str) -> None:
     with pytest.raises(InvalidFieldException):
-        PythonAwsLambdaHandlerField(invalid_handler, address=Address("", target_name="t"))
+        PythonAwsLambdaHandlerField(invalid_handler, Address("", target_name="t"))
 
 
 @pytest.mark.parametrize(
@@ -69,7 +69,7 @@ def test_handler_validation(invalid_handler: str) -> None:
     (("path.to.module:func", []), ("lambda.py:func", ["project/dir/lambda.py"])),
 )
 def test_handler_filespec(handler: str, expected: List[str]) -> None:
-    field = PythonAwsLambdaHandlerField(handler, address=Address("project/dir"))
+    field = PythonAwsLambdaHandlerField(handler, Address("project/dir"))
     assert field.filespec == {"includes": expected}
 
 
@@ -78,7 +78,7 @@ def test_resolve_handler(rule_runner: RuleRunner) -> None:
         addr = Address("src/python/project")
         rule_runner.create_file("src/python/project/lambda.py")
         rule_runner.create_file("src/python/project/f2.py")
-        field = PythonAwsLambdaHandlerField(handler, address=addr)
+        field = PythonAwsLambdaHandlerField(handler, addr)
         result = rule_runner.request(
             ResolvedPythonAwsHandler, [ResolvePythonAwsHandlerRequest(field)]
         )

--- a/src/python/pants/backend/project_info/filter_targets_test.py
+++ b/src/python/pants/backend/project_info/filter_targets_test.py
@@ -68,7 +68,7 @@ def run_goal(
 
 def test_no_filters_provided() -> None:
     # `filter` behaves like `list` when there are no specified filters.
-    targets = [MockTarget({}, address=Address("", target_name=name)) for name in ("t3", "t2", "t1")]
+    targets = [MockTarget({}, Address("", target_name=name)) for name in ("t3", "t2", "t1")]
     assert run_goal(targets) == dedent(
         """\
         //:t1
@@ -87,10 +87,8 @@ def test_filter_by_target_type() -> None:
         alias = "smalltalk"
         core_fields = ()
 
-    fortran_targets = [Fortran({}, address=Address("", target_name=name)) for name in ("f1", "f2")]
-    smalltalk_targets = [
-        Smalltalk({}, address=Address("", target_name=name)) for name in ("s1", "s2")
-    ]
+    fortran_targets = [Fortran({}, Address("", target_name=name)) for name in ("f1", "f2")]
+    smalltalk_targets = [Smalltalk({}, Address("", target_name=name)) for name in ("s1", "s2")]
     targets = [*fortran_targets, *smalltalk_targets]
 
     assert run_goal(targets, target_type=["fortran"]).strip() == "//:f1\n//:f2"
@@ -115,7 +113,7 @@ def test_filter_by_target_type() -> None:
 
 def test_filter_by_address_regex() -> None:
     targets = [
-        MockTarget({}, address=addr)
+        MockTarget({}, addr)
         for addr in (
             Address("dir1", target_name="lib"),
             Address("dir2", target_name="lib"),
@@ -137,10 +135,10 @@ def test_filter_by_address_regex() -> None:
 
 def test_filter_by_tag_regex() -> None:
     targets = [
-        MockTarget({"tags": ["tag1"]}, address=Address("", target_name="t1")),
-        MockTarget({"tags": ["tag2"]}, address=Address("", target_name="t2")),
-        MockTarget({"tags": ["tag1", "tag2"]}, address=Address("", target_name="both")),
-        MockTarget({}, address=Address("", target_name="no_tags")),
+        MockTarget({"tags": ["tag1"]}, Address("", target_name="t1")),
+        MockTarget({"tags": ["tag2"]}, Address("", target_name="t2")),
+        MockTarget({"tags": ["tag1", "tag2"]}, Address("", target_name="both")),
+        MockTarget({}, Address("", target_name="no_tags")),
     ]
     assert run_goal(targets, tag_regex=[r"t.?g2$"]).strip() == "//:both\n//:t2"
     assert run_goal(targets, tag_regex=["+tag1"]).strip() == "//:both\n//:t1"
@@ -157,8 +155,8 @@ def test_filter_by_tag_regex() -> None:
 
 def test_filter_by_granularity() -> None:
     targets = [
-        MockTarget({}, address=Address("p1")),
-        MockTarget({}, address=Address("p1", relative_file_path="file.txt")),
+        MockTarget({}, Address("p1")),
+        MockTarget({}, Address("p1", relative_file_path="file.txt")),
     ]
     assert run_goal(targets, granularity=TargetGranularity.all_targets).strip() == "p1\np1/file.txt"
     assert run_goal(targets, granularity=TargetGranularity.build_targets).strip() == "p1"

--- a/src/python/pants/backend/project_info/list_targets_test.py
+++ b/src/python/pants/backend/project_info/list_targets_test.py
@@ -54,9 +54,7 @@ def run_goal(
 def test_list_normal() -> None:
     # Note that these are unsorted.
     target_names = ("t3", "t2", "t1")
-    stdout, _ = run_goal(
-        [MockTarget({}, address=Address("", target_name=name)) for name in target_names]
-    )
+    stdout, _ = run_goal([MockTarget({}, Address("", target_name=name)) for name in target_names])
     assert stdout == dedent(
         """\
         //:t1
@@ -76,9 +74,9 @@ def test_list_documented() -> None:
         [
             MockTarget(
                 {DescriptionField.alias: "Description of a target.\n\tThis target is the best."},
-                address=Address("", target_name="described"),
+                Address("", target_name="described"),
             ),
-            MockTarget({}, address=Address("", target_name="not_described")),
+            MockTarget({}, Address("", target_name="not_described")),
         ],
         show_documented=True,
     )
@@ -94,10 +92,8 @@ def test_list_documented() -> None:
 def test_list_provides() -> None:
     sample_artifact = PythonArtifact(name="project.demo")
     targets = [
-        MockTarget(
-            {ProvidesField.alias: sample_artifact}, address=Address("", target_name="provided")
-        ),
-        MockTarget({}, address=Address("", target_name="not_provided")),
+        MockTarget({ProvidesField.alias: sample_artifact}, Address("", target_name="provided")),
+        MockTarget({}, Address("", target_name="not_provided")),
     ]
     stdout, _ = run_goal(targets, show_provides=True)
     assert stdout.strip() == f"//:provided {sample_artifact}"

--- a/src/python/pants/backend/python/macros/pipenv_requirements_test.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements_test.py
@@ -61,7 +61,7 @@ def test_pipfile_lock(rule_runner: RuleRunner) -> None:
             "develop": {"cachetools": {"markers": "python_version ~= '3.5'", "version": "==4.1.1"}},
         },
         expected_file_dep=PythonRequirementsFile(
-            {"sources": ["Pipfile.lock"]}, address=Address("", target_name="Pipfile.lock")
+            {"sources": ["Pipfile.lock"]}, Address("", target_name="Pipfile.lock")
         ),
         expected_targets=[
             PythonRequirementLibrary(
@@ -70,7 +70,7 @@ def test_pipfile_lock(rule_runner: RuleRunner) -> None:
                     "dependencies": [":Pipfile.lock"],
                     "module_mapping": {"ansicolors": ["colors"]},
                 },
-                address=Address("", target_name="ansicolors"),
+                Address("", target_name="ansicolors"),
             ),
             PythonRequirementLibrary(
                 {
@@ -79,7 +79,7 @@ def test_pipfile_lock(rule_runner: RuleRunner) -> None:
                     ],
                     "dependencies": [":Pipfile.lock"],
                 },
-                address=Address("", target_name="cachetools"),
+                Address("", target_name="cachetools"),
             ),
         ],
     )
@@ -101,7 +101,7 @@ def test_properly_creates_extras_requirements(rule_runner: RuleRunner) -> None:
             },
         },
         expected_file_dep=PythonRequirementsFile(
-            {"sources": ["Pipfile.lock"]}, address=Address("", target_name="Pipfile.lock")
+            {"sources": ["Pipfile.lock"]}, Address("", target_name="Pipfile.lock")
         ),
         expected_targets=[
             PythonRequirementLibrary(
@@ -109,7 +109,7 @@ def test_properly_creates_extras_requirements(rule_runner: RuleRunner) -> None:
                     "requirements": [Requirement.parse("ansicolors[neon]>=1.18.0")],
                     "dependencies": [":Pipfile.lock"],
                 },
-                address=Address("", target_name="ansicolors"),
+                Address("", target_name="ansicolors"),
             ),
             PythonRequirementLibrary(
                 {
@@ -118,7 +118,7 @@ def test_properly_creates_extras_requirements(rule_runner: RuleRunner) -> None:
                     ],
                     "dependencies": [":Pipfile.lock"],
                 },
-                address=Address("", target_name="cachetools"),
+                Address("", target_name="cachetools"),
             ),
         ],
     )
@@ -144,7 +144,7 @@ def test_supply_python_requirements_file(rule_runner: RuleRunner) -> None:
         {"default": {"ansicolors": {"version": ">=1.18.0"}}},
         expected_file_dep=PythonRequirementsFile(
             {"sources": ["custom/pipfile/Pipfile.lock"]},
-            address=Address("", target_name="custom_pipfile_target"),
+            Address("", target_name="custom_pipfile_target"),
         ),
         expected_targets=[
             PythonRequirementLibrary(
@@ -152,7 +152,7 @@ def test_supply_python_requirements_file(rule_runner: RuleRunner) -> None:
                     "requirements": [Requirement.parse("ansicolors>=1.18.0")],
                     "dependencies": ["//:custom_pipfile_target"],
                 },
-                address=Address("", target_name="ansicolors"),
+                Address("", target_name="ansicolors"),
             ),
         ],
         pipfile_lock_relpath="custom/pipfile/Pipfile.lock",

--- a/src/python/pants/backend/python/macros/python_requirements_test.py
+++ b/src/python/pants/backend/python/macros/python_requirements_test.py
@@ -68,7 +68,7 @@ def test_requirements_txt(rule_runner: RuleRunner) -> None:
         ),
         expected_file_dep=PythonRequirementsFile(
             {"sources": ["requirements.txt"]},
-            address=Address("", target_name="requirements.txt"),
+            Address("", target_name="requirements.txt"),
         ),
         expected_targets=[
             PythonRequirementLibrary(
@@ -77,28 +77,28 @@ def test_requirements_txt(rule_runner: RuleRunner) -> None:
                     "requirements": [Requirement.parse("ansicolors>=1.18.0")],
                     "module_mapping": {"ansicolors": ["colors"]},
                 },
-                address=Address("", target_name="ansicolors"),
+                Address("", target_name="ansicolors"),
             ),
             PythonRequirementLibrary(
                 {
                     "dependencies": [":requirements.txt"],
                     "requirements": [Requirement.parse("Django==3.2 ; python_version>'3'")],
                 },
-                address=Address("", target_name="Django"),
+                Address("", target_name="Django"),
             ),
             PythonRequirementLibrary(
                 {
                     "dependencies": [":requirements.txt"],
                     "requirements": [Requirement.parse("Un_Normalized_PROJECT")],
                 },
-                address=Address("", target_name="Un-Normalized-PROJECT"),
+                Address("", target_name="Un-Normalized-PROJECT"),
             ),
             PythonRequirementLibrary(
                 {
                     "dependencies": [":requirements.txt"],
                     "requirements": [Requirement.parse("pip@ git+https://github.com/pypa/pip.git")],
                 },
-                address=Address("", target_name="pip"),
+                Address("", target_name="pip"),
             ),
         ],
     )
@@ -106,9 +106,7 @@ def test_requirements_txt(rule_runner: RuleRunner) -> None:
 
 def test_invalid_req(rule_runner: RuleRunner) -> None:
     """Test that we give a nice error message."""
-    fake_file_tgt = PythonRequirementsFile(
-        {"sources": ["doesnt matter"]}, address=Address("doesnt_matter")
-    )
+    fake_file_tgt = PythonRequirementsFile({"sources": ["doesnt matter"]}, Address("doesnt_matter"))
     with pytest.raises(ExecutionError) as exc:
         assert_python_requirements(
             rule_runner,
@@ -141,7 +139,7 @@ def test_relpath_override(rule_runner: RuleRunner) -> None:
         requirements_txt_relpath="subdir/requirements.txt",
         expected_file_dep=PythonRequirementsFile(
             {"sources": ["subdir/requirements.txt"]},
-            address=Address("", target_name="subdir_requirements.txt"),
+            Address("", target_name="subdir_requirements.txt"),
         ),
         expected_targets=[
             PythonRequirementLibrary(
@@ -149,7 +147,7 @@ def test_relpath_override(rule_runner: RuleRunner) -> None:
                     "dependencies": [":subdir_requirements.txt"],
                     "requirements": [Requirement.parse("ansicolors>=1.18.0")],
                 },
-                address=Address("", target_name="ansicolors"),
+                Address("", target_name="ansicolors"),
             ),
         ],
     )

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -200,8 +200,8 @@ class PexEntryPointField(AsyncFieldMixin, SecondaryOwnerMixin, Field):
     value: EntryPoint
 
     @classmethod
-    def compute_value(cls, raw_value: Optional[str], *, address: Address) -> EntryPoint:
-        value = super().compute_value(raw_value, address=address)
+    def compute_value(cls, raw_value: Optional[str], address: Address) -> EntryPoint:
+        value = super().compute_value(raw_value, address)
         if not isinstance(value, str):
             raise InvalidFieldTypeException(address, cls.alias, value, expected_type="a string")
         try:
@@ -259,11 +259,11 @@ class PexInheritPathField(StringField):
     # TODO(#9388): deprecate allowing this to be a `bool`.
     @classmethod
     def compute_value(
-        cls, raw_value: Optional[Union[str, bool]], *, address: Address
+        cls, raw_value: Optional[Union[str, bool]], address: Address
     ) -> Optional[str]:
         if isinstance(raw_value, bool):
             return "prefer" if raw_value else "false"
-        return super().compute_value(raw_value, address=address)
+        return super().compute_value(raw_value, address)
 
 
 class PexZipSafeField(BoolField):
@@ -419,8 +419,8 @@ class PythonTestsTimeout(IntField):
     )
 
     @classmethod
-    def compute_value(cls, raw_value: Optional[int], *, address: Address) -> Optional[int]:
-        value = super().compute_value(raw_value, address=address)
+    def compute_value(cls, raw_value: Optional[int], address: Address) -> Optional[int]:
+        value = super().compute_value(raw_value, address)
         if value is not None and value < 1:
             raise InvalidFieldException(
                 f"The value for the `timeout` field in target {address} must be > 0, but was "
@@ -525,9 +525,9 @@ class _RequirementSequenceField(Field):
 
     @classmethod
     def compute_value(
-        cls, raw_value: Optional[Iterable[str]], *, address: Address
+        cls, raw_value: Optional[Iterable[str]], address: Address
     ) -> Tuple[Requirement, ...]:
-        value = super().compute_value(raw_value, address=address)
+        value = super().compute_value(raw_value, address)
         if value is None:
             return ()
         invalid_type_error = InvalidFieldTypeException(
@@ -584,9 +584,9 @@ class ModuleMappingField(DictStringToStringSequenceField):
 
     @classmethod
     def compute_value(
-        cls, raw_value: Optional[Dict[str, Iterable[str]]], *, address: Address
+        cls, raw_value: Optional[Dict[str, Iterable[str]]], address: Address
     ) -> FrozenDict[str, Tuple[str, ...]]:
-        provided_mapping = super().compute_value(raw_value, address=address)
+        provided_mapping = super().compute_value(raw_value, address)
         return FrozenDict({**DEFAULT_MODULE_MAPPING, **(provided_mapping or {})})
 
 
@@ -676,10 +676,8 @@ class PythonProvidesField(ScalarField, ProvidesField):
     )
 
     @classmethod
-    def compute_value(
-        cls, raw_value: Optional[PythonArtifact], *, address: Address
-    ) -> PythonArtifact:
-        return cast(PythonArtifact, super().compute_value(raw_value, address=address))
+    def compute_value(cls, raw_value: Optional[PythonArtifact], address: Address) -> PythonArtifact:
+        return cast(PythonArtifact, super().compute_value(raw_value, address))
 
 
 class SetupPyCommandsField(StringSequenceField):

--- a/src/python/pants/backend/python/target_types_test.py
+++ b/src/python/pants/backend/python/target_types_test.py
@@ -54,10 +54,10 @@ from pants.util.frozendict import FrozenDict
 
 def test_timeout_validation() -> None:
     with pytest.raises(InvalidFieldException):
-        PythonTestsTimeout(-100, address=Address("", target_name="tests"))
+        PythonTestsTimeout(-100, Address("", target_name="tests"))
     with pytest.raises(InvalidFieldException):
-        PythonTestsTimeout(0, address=Address("", target_name="tests"))
-    assert PythonTestsTimeout(5, address=Address("", target_name="tests")).value == 5
+        PythonTestsTimeout(0, Address("", target_name="tests"))
+    assert PythonTestsTimeout(5, Address("", target_name="tests")).value == 5
 
 
 def test_timeout_calculation() -> None:
@@ -69,7 +69,7 @@ def test_timeout_calculation() -> None:
         global_max: Optional[int] = None,
         timeouts_enabled: bool = True,
     ) -> None:
-        field = PythonTestsTimeout(field_value, address=Address("", target_name="tests"))
+        field = PythonTestsTimeout(field_value, Address("", target_name="tests"))
         pytest = create_subsystem(
             PyTest,
             timeouts=timeouts_enabled,
@@ -97,7 +97,7 @@ def test_timeout_calculation() -> None:
     ),
 )
 def test_entry_point_filespec(entry_point: Optional[str], expected: List[str]) -> None:
-    field = PexEntryPointField(entry_point, address=Address("project/dir"))
+    field = PexEntryPointField(entry_point, Address("project/dir"))
     assert field.filespec == {"includes": expected}
 
 
@@ -105,15 +105,15 @@ def test_entry_point_validation(caplog: LogCaptureFixture) -> None:
     addr = Address("src/python/project")
 
     with pytest.raises(InvalidFieldException):
-        PexEntryPointField(" ", address=addr)
+        PexEntryPointField(" ", addr)
     with pytest.raises(InvalidFieldException):
-        PexEntryPointField("modue:func:who_knows_what_this_is", address=addr)
+        PexEntryPointField("modue:func:who_knows_what_this_is", addr)
     with pytest.raises(InvalidFieldException):
-        PexEntryPointField(":func", address=addr)
+        PexEntryPointField(":func", addr)
 
     ep = "custom.entry_point:"
     with caplog.at_level(logging.WARNING):
-        assert EntryPoint("custom.entry_point") == PexEntryPointField(ep, address=addr).value
+        assert EntryPoint("custom.entry_point") == PexEntryPointField(ep, addr).value
 
     assert len(caplog.record_tuples) == 1
     _, levelno, message = caplog.record_tuples[0]
@@ -134,7 +134,7 @@ def test_resolve_pex_binary_entry_point() -> None:
         addr = Address("src/python/project")
         rule_runner.create_file("src/python/project/app.py")
         rule_runner.create_file("src/python/project/f2.py")
-        ep_field = PexEntryPointField(entry_point, address=addr)
+        ep_field = PexEntryPointField(entry_point, addr)
         result = rule_runner.request(ResolvedPexEntryPoint, [ResolvePexEntryPointRequest(ep_field)])
         assert result.val == expected
 
@@ -294,20 +294,20 @@ def test_requirements_and_constraints_fields(field: type[Field]) -> None:
     )
     parsed_value = tuple(Requirement.parse(v) for v in raw_value)
 
-    assert field(raw_value, address=Address("demo")).value == parsed_value
+    assert field(raw_value, Address("demo")).value == parsed_value
 
     # Macros can pass pre-parsed Requirement objects.
-    assert field(parsed_value, address=Address("demo")).value == parsed_value
+    assert field(parsed_value, Address("demo")).value == parsed_value
 
     # Reject invalid types.
     with pytest.raises(InvalidFieldTypeException):
-        field("sneaky_str", address=Address("demo"))
+        field("sneaky_str", Address("demo"))
     with pytest.raises(InvalidFieldTypeException):
-        field([1, 2], address=Address("demo"))
+        field([1, 2], Address("demo"))
 
     # Give a nice error message if the requirement can't be parsed.
     with pytest.raises(InvalidFieldException) as exc:
-        field(["not valid! === 3.1"], address=Address("demo"))
+        field(["not valid! === 3.1"], Address("demo"))
     assert (
         f"Invalid requirement 'not valid! === 3.1' in the '{field.alias}' field for the "
         "target demo:"
@@ -315,7 +315,7 @@ def test_requirements_and_constraints_fields(field: type[Field]) -> None:
 
     # Give a nice error message if it looks like they're trying to use pip VCS-style requirements.
     with pytest.raises(InvalidFieldException) as exc:
-        field(["git+https://github.com/pypa/pip.git#egg=pip"], address=Address("demo"))
+        field(["git+https://github.com/pypa/pip.git#egg=pip"], Address("demo"))
     assert "It looks like you're trying to use a pip VCS-style requirement?" in str(exc.value)
 
 
@@ -382,5 +382,5 @@ def test_module_mapping_field(
 ) -> None:
     merged = dict(DEFAULT_MODULE_MAPPING)
     merged.update(expected)
-    actual_value = ModuleMappingField(raw_value, address=Address("", target_name="tests")).value
+    actual_value = ModuleMappingField(raw_value, Address("", target_name="tests")).value
     assert actual_value == FrozenDict(merged)

--- a/src/python/pants/backend/python/util_rules/python_sources_test.py
+++ b/src/python/pants/backend/python/util_rules/python_sources_test.py
@@ -57,7 +57,7 @@ def create_target(
 ) -> Target:
     rule_runner.write_files({os.path.join(parent_directory, f): "" for f in files})
     address = Address(parent_directory, target_name="target")
-    return target_cls({Sources.alias: files}, address=address)
+    return target_cls({Sources.alias: files}, address)
 
 
 def get_stripped_sources(
@@ -218,8 +218,8 @@ def test_python_protobuf(rule_runner: RuleRunner) -> None:
         }
     )
     targets = [
-        ProtobufLibrary({}, address=Address("src/protobuf/dir")),
-        ProtobufLibrary({}, address=Address("src/protobuf/other_dir")),
+        ProtobufLibrary({}, Address("src/protobuf/dir")),
+        ProtobufLibrary({}, Address("src/protobuf/other_dir")),
     ]
     backend_args = ["--backend-packages=pants.backend.codegen.protobuf.python"]
 

--- a/src/python/pants/backend/shell/shunit2_test_runner_integration_test.py
+++ b/src/python/pants/backend/shell/shunit2_test_runner_integration_test.py
@@ -224,13 +224,13 @@ def test_determine_shell_runner(rule_runner: RuleRunner) -> None:
 
     # If `shell` field is not set, read the shebang.
     result = rule_runner.request(
-        Shunit2Runner, [Shunit2RunnerRequest(addr, fc, Shunit2ShellField(None, address=addr))]
+        Shunit2Runner, [Shunit2RunnerRequest(addr, fc, Shunit2ShellField(None, addr))]
     )
     assert result.shell == Shunit2Shell.sh
 
     # The `shell` field overrides the shebang.
     result = rule_runner.request(
-        Shunit2Runner, [Shunit2RunnerRequest(addr, fc, Shunit2ShellField("bash", address=addr))]
+        Shunit2Runner, [Shunit2RunnerRequest(addr, fc, Shunit2ShellField("bash", addr))]
     )
     assert result.shell == Shunit2Shell.bash
 
@@ -240,7 +240,7 @@ def test_determine_shell_runner(rule_runner: RuleRunner) -> None:
             Shunit2Runner,
             [
                 Shunit2RunnerRequest(
-                    addr, FileContent("tests.sh", b""), Shunit2ShellField(None, address=addr)
+                    addr, FileContent("tests.sh", b""), Shunit2ShellField(None, addr)
                 )
             ],
         )

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -86,8 +86,8 @@ class Shunit2TestsTimeout(IntField):
     )
 
     @classmethod
-    def compute_value(cls, raw_value: Optional[int], *, address: Address) -> Optional[int]:
-        value = super().compute_value(raw_value, address=address)
+    def compute_value(cls, raw_value: Optional[int], address: Address) -> Optional[int]:
+        value = super().compute_value(raw_value, address)
         if value is not None and value < 1:
             raise InvalidFieldException(
                 f"The value for the `timeout` field in target {address} must be > 0, but was "

--- a/src/python/pants/core/goals/fmt_test.py
+++ b/src/python/pants/core/goals/fmt_test.py
@@ -146,7 +146,7 @@ def merged_digest(rule_runner: RuleRunner) -> Digest:
 def make_target(
     address: Optional[Address] = None, *, target_cls: Type[Target] = FortranTarget
 ) -> Target:
-    return target_cls({}, address=address or Address("", target_name="tests"))
+    return target_cls({}, address or Address("", target_name="tests"))
 
 
 def run_fmt_rule(

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -114,7 +114,7 @@ def rule_runner() -> RuleRunner:
 
 
 def make_target(address: Optional[Address] = None) -> Target:
-    return MockTarget({}, address=address or Address("", target_name="tests"))
+    return MockTarget({}, address or Address("", target_name="tests"))
 
 
 def run_lint_rule(

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -46,7 +46,7 @@ def single_target_run(
         alias = "binary"
         core_fields = ()
 
-    target = TestBinaryTarget({}, address=address)
+    target = TestBinaryTarget({}, address)
     field_set = TestRunFieldSet.create(target)
 
     with mock_console(rule_runner.options_bootstrapper) as (console, _):

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -108,7 +108,7 @@ def rule_runner() -> RuleRunner:
 def make_target(address: Optional[Address] = None) -> Target:
     if address is None:
         address = Address("", target_name="tests")
-    return MockTarget({}, address=address)
+    return MockTarget({}, address)
 
 
 def run_test_rule(

--- a/src/python/pants/core/goals/typecheck_test.py
+++ b/src/python/pants/core/goals/typecheck_test.py
@@ -113,7 +113,7 @@ class InvalidRequest(MockTypecheckRequest):
 def make_target(address: Optional[Address] = None) -> Target:
     if address is None:
         address = Address("", target_name="tests")
-    return MockTarget({}, address=address)
+    return MockTarget({}, address)
 
 
 def run_typecheck_rule(

--- a/src/python/pants/core/util_rules/filter_empty_sources_test.py
+++ b/src/python/pants/core/util_rules/filter_empty_sources_test.py
@@ -38,13 +38,11 @@ def test_filter_field_sets(rule_runner: RuleRunner) -> None:
     rule_runner.write_files({"f1.txt": ""})
     valid_addr = Address("", target_name="valid")
     valid_field_set = MockFieldSet(
-        valid_addr, Sources(["f1.txt"], address=valid_addr), Tags(None, address=valid_addr)
+        valid_addr, Sources(["f1.txt"], valid_addr), Tags(None, valid_addr)
     )
 
     empty_addr = Address("", target_name="empty")
-    empty_field_set = MockFieldSet(
-        empty_addr, Sources(None, address=empty_addr), Tags(None, address=empty_addr)
-    )
+    empty_field_set = MockFieldSet(empty_addr, Sources(None, empty_addr), Tags(None, empty_addr))
 
     result = rule_runner.request(
         FieldSetsWithSources,
@@ -63,9 +61,9 @@ def test_filter_targets(rule_runner: RuleRunner) -> None:
         core_fields = ()
 
     rule_runner.write_files({"f1.txt": ""})
-    valid_tgt = MockTarget({Sources.alias: ["f1.txt"]}, address=Address("", target_name="valid"))
-    empty_tgt = MockTarget({}, address=Address("", target_name="empty"))
-    invalid_tgt = MockTargetWithNoSourcesField({}, address=Address("", target_name="invalid"))
+    valid_tgt = MockTarget({Sources.alias: ["f1.txt"]}, Address("", target_name="valid"))
+    empty_tgt = MockTarget({}, Address("", target_name="empty"))
+    invalid_tgt = MockTargetWithNoSourcesField({}, Address("", target_name="invalid"))
 
     result = rule_runner.request(
         TargetsWithSources,

--- a/src/python/pants/core/util_rules/source_files_test.py
+++ b/src/python/pants/core/util_rules/source_files_test.py
@@ -49,7 +49,7 @@ def mock_sources_field(
 ) -> SourcesField:
     sources_field = sources_field_cls(
         sources.source_files if include_sources else [],
-        address=Address(sources.source_root, target_name="lib"),
+        Address(sources.source_root, target_name="lib"),
     )
     rule_runner.write_files({PurePath(sources.source_root, f): "" for f in sources.source_files})
     return sources_field

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -196,7 +196,7 @@ def test_build_file_address() -> None:
     rule_runner.create_file("helloworld/BUILD.ext", "mock_tgt()")
 
     def assert_bfa_resolved(address: Address) -> None:
-        expected_bfa = BuildFileAddress(rel_path="helloworld/BUILD.ext", address=address)
+        expected_bfa = BuildFileAddress(address, "helloworld/BUILD.ext")
         bfa = rule_runner.request(BuildFileAddress, [address])
         assert bfa == expected_bfa
 

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -138,7 +138,7 @@ async def resolve_target(
         raise UnrecognizedTargetTypeException(
             target_adaptor.type_alias, registered_target_types, address=address
         )
-    target = target_type(target_adaptor.kwargs, address=address, union_membership=union_membership)
+    target = target_type(target_adaptor.kwargs, address, union_membership=union_membership)
     return WrappedTarget(target)
 
 

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -603,7 +603,7 @@ def test_sequence_field() -> None:
 
         @classmethod
         def compute_value(
-            cls, raw_value: Optional[Iterable[CustomObject]], *, address: Address
+            cls, raw_value: Optional[Iterable[CustomObject]], address: Address
         ) -> Optional[Tuple[CustomObject, ...]]:
             return super().compute_value(raw_value, address)
 

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -50,10 +50,8 @@ class FortranExtensions(Field):
     default = ()
 
     @classmethod
-    def compute_value(
-        cls, raw_value: Optional[Iterable[str]], *, address: Address
-    ) -> Tuple[str, ...]:
-        value_or_default = super().compute_value(raw_value, address=address)
+    def compute_value(cls, raw_value: Optional[Iterable[str]], address: Address) -> Tuple[str, ...]:
+        value_or_default = super().compute_value(raw_value, address)
         # Add some arbitrary validation to test that hydration/validation works properly.
         bad_extensions = [
             extension for extension in value_or_default if not extension.startswith("Fortran")
@@ -82,19 +80,19 @@ class FortranTarget(Target):
 
 def test_field_and_target_eq() -> None:
     addr = Address("", target_name="tgt")
-    field = FortranVersion("dev0", address=addr)
+    field = FortranVersion("dev0", addr)
     assert field.value == "dev0"
 
-    other = FortranVersion("dev0", address=addr)
+    other = FortranVersion("dev0", addr)
     assert field == other
     assert hash(field) == hash(other)
 
-    other = FortranVersion("dev1", address=addr)
+    other = FortranVersion("dev1", addr)
     assert field != other
     assert hash(field) != hash(other)
 
     # NB: because normal `Field`s throw away the address, these are equivalent.
-    other = FortranVersion("dev0", address=Address("", target_name="other"))
+    other = FortranVersion("dev0", Address("", target_name="other"))
     assert field == other
     assert hash(field) == hash(other)
 
@@ -102,18 +100,18 @@ def test_field_and_target_eq() -> None:
     with pytest.raises(FrozenInstanceError):
         field.y = "foo"  # type: ignore[attr-defined]
 
-    tgt = FortranTarget({"version": "dev0"}, address=addr)
+    tgt = FortranTarget({"version": "dev0"}, addr)
     assert tgt.address == addr
 
-    other_tgt = FortranTarget({"version": "dev0"}, address=addr)
+    other_tgt = FortranTarget({"version": "dev0"}, addr)
     assert tgt == other_tgt
     assert hash(tgt) == hash(other_tgt)
 
-    other_tgt = FortranTarget({"version": "dev1"}, address=addr)
+    other_tgt = FortranTarget({"version": "dev1"}, addr)
     assert tgt != other_tgt
     assert hash(tgt) != hash(other_tgt)
 
-    other_tgt = FortranTarget({"version": "dev0"}, address=Address("", target_name="other"))
+    other_tgt = FortranTarget({"version": "dev0"}, Address("", target_name="other"))
     assert tgt != other_tgt
     assert hash(tgt) != hash(other_tgt)
 
@@ -125,30 +123,28 @@ def test_field_and_target_eq() -> None:
     class SubclassField(FortranVersion):
         pass
 
-    subclass_field = SubclassField("dev0", address=addr)
+    subclass_field = SubclassField("dev0", addr)
     assert field != subclass_field
     assert hash(field) != hash(subclass_field)
 
     class SubclassTarget(FortranTarget):
         pass
 
-    subclass_tgt = SubclassTarget({"version": "dev0"}, address=addr)
+    subclass_tgt = SubclassTarget({"version": "dev0"}, addr)
     assert tgt != subclass_tgt
     assert hash(tgt) != hash(subclass_tgt)
 
 
 def test_invalid_fields_rejected() -> None:
     with pytest.raises(InvalidFieldException) as exc:
-        FortranTarget({"invalid_field": True}, address=Address("", target_name="lib"))
+        FortranTarget({"invalid_field": True}, Address("", target_name="lib"))
     assert "Unrecognized field `invalid_field=True`" in str(exc)
     assert "//:lib" in str(exc)
 
 
 def test_get_field() -> None:
     extensions = ("FortranExt1",)
-    tgt = FortranTarget(
-        {FortranExtensions.alias: extensions}, address=Address("", target_name="lib")
-    )
+    tgt = FortranTarget({FortranExtensions.alias: extensions}, Address("", target_name="lib"))
 
     assert tgt[FortranExtensions].value == extensions
     assert tgt.get(FortranExtensions).value == extensions
@@ -156,7 +152,7 @@ def test_get_field() -> None:
 
     # Default field value. This happens when the field is registered on the target type, but the
     # user does not explicitly set the field in the BUILD file.
-    default_field_tgt = FortranTarget({}, address=Address("", target_name="default"))
+    default_field_tgt = FortranTarget({}, Address("", target_name="default"))
     assert default_field_tgt[FortranExtensions].value == ()
     assert default_field_tgt.get(FortranExtensions).value == ()
     assert default_field_tgt.get(FortranExtensions, default_raw_value=["FortranExt2"]).value == ()
@@ -187,7 +183,7 @@ def test_field_hydration_is_eager() -> None:
     with pytest.raises(InvalidFieldException) as exc:
         FortranTarget(
             {FortranExtensions.alias: ["FortranExt1", "DoesNotStartWithFortran"]},
-            address=Address("", target_name="bad_extension"),
+            Address("", target_name="bad_extension"),
         )
     assert "DoesNotStartWithFortran" in str(exc)
     assert "//:bad_extension" in str(exc)
@@ -195,7 +191,7 @@ def test_field_hydration_is_eager() -> None:
 
 def test_has_fields() -> None:
     empty_union_membership = UnionMembership({})
-    tgt = FortranTarget({}, address=Address("", target_name="lib"))
+    tgt = FortranTarget({}, Address("", target_name="lib"))
 
     assert tgt.field_types == (FortranExtensions, FortranVersion)
     assert FortranTarget.class_field_types(union_membership=empty_union_membership) == (
@@ -247,7 +243,7 @@ def test_add_custom_fields() -> None:
     )
     tgt_values = {CustomField.alias: True}
     tgt = FortranTarget(
-        tgt_values, address=Address("", target_name="lib"), union_membership=union_membership
+        tgt_values, Address("", target_name="lib"), union_membership=union_membership
     )
 
     assert tgt.field_types == (FortranExtensions, FortranVersion, CustomField)
@@ -268,7 +264,7 @@ def test_add_custom_fields() -> None:
     assert tgt[CustomField].value is True
 
     default_tgt = FortranTarget(
-        {}, address=Address("", target_name="default"), union_membership=union_membership
+        {}, Address("", target_name="default"), union_membership=union_membership
     )
     assert default_tgt[CustomField].value is False
 
@@ -277,7 +273,7 @@ def test_add_custom_fields() -> None:
         alias = "other_target"
         core_fields = ()
 
-    other_tgt = OtherTarget({}, address=Address("", target_name="other"))
+    other_tgt = OtherTarget({}, Address("", target_name="other"))
     assert other_tgt.plugin_fields == ()
     assert other_tgt.has_field(CustomField) is False
 
@@ -299,10 +295,10 @@ def test_override_preexisting_field_via_new_target() -> None:
 
         @classmethod
         def compute_value(
-            cls, raw_value: Optional[Iterable[str]], *, address: Address
+            cls, raw_value: Optional[Iterable[str]], address: Address
         ) -> Tuple[str, ...]:
             # Ensure that we avoid certain problematic extensions and always use some defaults.
-            specified_extensions = super().compute_value(raw_value, address=address)
+            specified_extensions = super().compute_value(raw_value, address)
             banned = [
                 extension
                 for extension in specified_extensions
@@ -322,7 +318,7 @@ def test_override_preexisting_field_via_new_target() -> None:
         )
 
     custom_tgt = CustomFortranTarget(
-        {FortranExtensions.alias: ["FortranExt1"]}, address=Address("", target_name="custom")
+        {FortranExtensions.alias: ["FortranExt1"]}, Address("", target_name="custom")
     )
 
     assert custom_tgt.has_field(FortranExtensions) is True
@@ -336,7 +332,7 @@ def test_override_preexisting_field_via_new_target() -> None:
     # Ensure that subclasses not defined on a target are not accepted. This allows us to, for
     # example, filter every target with `PythonSources` (or a subclass) and to ignore targets with
     # only `Sources`.
-    normal_tgt = FortranTarget({}, address=Address("", target_name="normal"))
+    normal_tgt = FortranTarget({}, Address("", target_name="normal"))
     assert normal_tgt.has_field(FortranExtensions) is True
     assert normal_tgt.has_field(CustomFortranExtensions) is False
 
@@ -348,7 +344,7 @@ def test_override_preexisting_field_via_new_target() -> None:
 
     # Check custom default value
     assert (
-        CustomFortranTarget({}, address=Address("", target_name="default"))[FortranExtensions].value
+        CustomFortranTarget({}, Address("", target_name="default"))[FortranExtensions].value
         == CustomFortranExtensions.default_extensions
     )
 
@@ -356,7 +352,7 @@ def test_override_preexisting_field_via_new_target() -> None:
     with pytest.raises(InvalidFieldException) as exc:
         CustomFortranTarget(
             {FortranExtensions.alias: CustomFortranExtensions.banned_extensions},
-            address=Address("", target_name="invalid"),
+            Address("", target_name="invalid"),
         )
     assert str(list(CustomFortranExtensions.banned_extensions)) in str(exc)
     assert "//:invalid" in str(exc)
@@ -374,10 +370,10 @@ def test_required_field() -> None:
     address = Address("", target_name="lib")
 
     # No errors when defined
-    RequiredTarget({"field": "present"}, address=address)
+    RequiredTarget({"field": "present"}, address)
 
     with pytest.raises(RequiredFieldMissingException) as exc:
-        RequiredTarget({}, address=address)
+        RequiredTarget({}, address)
     assert str(address) in str(exc.value)
     assert "field" in str(exc.value)
 
@@ -388,22 +384,22 @@ def test_async_field_mixin() -> None:
         default = 10
 
     addr = Address("", target_name="tgt")
-    field = ExampleField(None, address=addr)
+    field = ExampleField(None, addr)
     assert field.value == 10
     assert field.address == addr
     ExampleField.mro()  # Regression test that the mro is resolvable.
 
     # Ensure equality and __hash__ work correctly.
-    other = ExampleField(None, address=addr)
+    other = ExampleField(None, addr)
     assert field == other
     assert hash(field) == hash(other)
 
-    other = ExampleField(25, address=addr)
+    other = ExampleField(25, addr)
     assert field != other
     assert hash(field) != hash(other)
 
     # Whereas normally the address is not considered, it is considered for async fields.
-    other = ExampleField(None, address=Address("", target_name="other"))
+    other = ExampleField(None, Address("", target_name="other"))
     assert field != other
     assert hash(field) != hash(other)
 
@@ -415,7 +411,7 @@ def test_async_field_mixin() -> None:
     class Subclass(ExampleField):
         pass
 
-    subclass = Subclass(None, address=addr)
+    subclass = Subclass(None, addr)
     assert field != subclass
     assert hash(field) != hash(subclass)
 
@@ -434,7 +430,7 @@ def test_generate_subtarget() -> None:
     # different address.
     single_source_tgt = MockTarget(
         {Sources.alias: ["demo.f95"], Tags.alias: ["demo"]},
-        address=Address("src/fortran", target_name="demo"),
+        Address("src/fortran", target_name="demo"),
     )
     expected_single_source_address = Address(
         "src/fortran", relative_file_path="demo.f95", target_name="demo"
@@ -442,7 +438,7 @@ def test_generate_subtarget() -> None:
     assert generate_subtarget(
         single_source_tgt, full_file_name="src/fortran/demo.f95"
     ) == MockTarget(
-        {Sources.alias: ["demo.f95"], Tags.alias: ["demo"]}, address=expected_single_source_address
+        {Sources.alias: ["demo.f95"], Tags.alias: ["demo"]}, expected_single_source_address
     )
     assert (
         generate_subtarget_address(single_source_tgt.address, full_file_name="src/fortran/demo.f95")
@@ -451,14 +447,14 @@ def test_generate_subtarget() -> None:
 
     subdir_tgt = MockTarget(
         {Sources.alias: ["demo.f95", "subdir/demo.f95"]},
-        address=Address("src/fortran", target_name="demo"),
+        Address("src/fortran", target_name="demo"),
     )
     expected_subdir_address = Address(
         "src/fortran", relative_file_path="subdir/demo.f95", target_name="demo"
     )
     assert generate_subtarget(
         subdir_tgt, full_file_name="src/fortran/subdir/demo.f95"
-    ) == MockTarget({Sources.alias: ["subdir/demo.f95"]}, address=expected_subdir_address)
+    ) == MockTarget({Sources.alias: ["subdir/demo.f95"]}, expected_subdir_address)
     assert (
         generate_subtarget_address(subdir_tgt.address, full_file_name="src/fortran/subdir/demo.f95")
         == expected_subdir_address
@@ -474,7 +470,7 @@ def test_generate_subtarget() -> None:
         core_fields = (Tags,)
 
     missing_fields_tgt = MissingFieldsTarget(
-        {Tags.alias: ["demo"]}, address=Address("", target_name="missing_fields")
+        {Tags.alias: ["demo"]}, Address("", target_name="missing_fields")
     )
     with pytest.raises(ValueError) as exc:
         generate_subtarget(missing_fields_tgt, full_file_name="fake.txt")
@@ -514,11 +510,11 @@ def test_field_set() -> None:
         unrelated_field: UnrelatedField
 
     fortran_addr = Address("", target_name="fortran")
-    fortran_tgt = FortranTarget({}, address=fortran_addr)
+    fortran_tgt = FortranTarget({}, fortran_addr)
     unrelated_addr = Address("", target_name="unrelated")
-    unrelated_tgt = UnrelatedTarget({UnrelatedField.alias: "configured"}, address=unrelated_addr)
+    unrelated_tgt = UnrelatedTarget({UnrelatedField.alias: "configured"}, unrelated_addr)
     no_fields_addr = Address("", target_name="no_fields")
-    no_fields_tgt = NoFieldsTarget({}, address=no_fields_addr)
+    no_fields_tgt = NoFieldsTarget({}, no_fields_addr)
 
     assert FortranFieldSet.is_applicable(fortran_tgt) is True
     assert FortranFieldSet.is_applicable(unrelated_tgt) is False
@@ -554,18 +550,18 @@ def test_scalar_field() -> None:
 
         @classmethod
         def compute_value(
-            cls, raw_value: Optional[CustomObject], *, address: Address
+            cls, raw_value: Optional[CustomObject], address: Address
         ) -> Optional[CustomObject]:
-            return super().compute_value(raw_value, address=address)
+            return super().compute_value(raw_value, address)
 
     addr = Address("", target_name="example")
 
     with pytest.raises(InvalidFieldTypeException) as exc:
-        Example(1, address=addr)
+        Example(1, addr)
     assert Example.expected_type_description in str(exc.value)
 
-    assert Example(CustomObject(), address=addr).value == CustomObject()
-    assert Example(None, address=addr).value is None
+    assert Example(CustomObject(), addr).value == CustomObject()
+    assert Example(None, addr).value is None
 
 
 def test_string_field_valid_choices() -> None:
@@ -583,16 +579,16 @@ def test_string_field_valid_choices() -> None:
         default = LeafyGreens.KALE.value
 
     addr = Address("", target_name="example")
-    assert GivenStrings("spinach", address=addr).value == "spinach"
-    assert GivenEnum("spinach", address=addr).value == "spinach"
+    assert GivenStrings("spinach", addr).value == "spinach"
+    assert GivenEnum("spinach", addr).value == "spinach"
 
-    assert GivenStrings(None, address=addr).value is None
-    assert GivenEnum(None, address=addr).value == "kale"
+    assert GivenStrings(None, addr).value is None
+    assert GivenEnum(None, addr).value == "kale"
 
     with pytest.raises(InvalidFieldChoiceException):
-        GivenStrings("carrot", address=addr)
+        GivenStrings("carrot", addr)
     with pytest.raises(InvalidFieldChoiceException):
-        GivenEnum("carrot", address=addr)
+        GivenEnum("carrot", addr)
 
 
 def test_sequence_field() -> None:
@@ -609,12 +605,12 @@ def test_sequence_field() -> None:
         def compute_value(
             cls, raw_value: Optional[Iterable[CustomObject]], *, address: Address
         ) -> Optional[Tuple[CustomObject, ...]]:
-            return super().compute_value(raw_value, address=address)
+            return super().compute_value(raw_value, address)
 
     addr = Address("", target_name="example")
 
     def assert_flexible_constructor(raw_value: Iterable[CustomObject]) -> None:
-        assert Example(raw_value, address=addr).value == tuple(raw_value)
+        assert Example(raw_value, addr).value == tuple(raw_value)
 
     assert_flexible_constructor([CustomObject(), CustomObject()])
     assert_flexible_constructor((CustomObject(), CustomObject()))
@@ -622,12 +618,12 @@ def test_sequence_field() -> None:
 
     # Must be given a sequence, not a single element.
     with pytest.raises(InvalidFieldTypeException) as exc:
-        Example(CustomObject(), address=addr)
+        Example(CustomObject(), addr)
     assert Example.expected_type_description in str(exc.value)
 
     # All elements must be the expected type.
     with pytest.raises(InvalidFieldTypeException):
-        Example([CustomObject(), 1, CustomObject()], address=addr)
+        Example([CustomObject(), 1, CustomObject()], addr)
 
 
 def test_string_sequence_field() -> None:
@@ -635,12 +631,12 @@ def test_string_sequence_field() -> None:
         alias = "example"
 
     addr = Address("", target_name="example")
-    assert Example(["hello", "world"], address=addr).value == ("hello", "world")
-    assert Example(None, address=addr).value is None
+    assert Example(["hello", "world"], addr).value == ("hello", "world")
+    assert Example(None, addr).value is None
     with pytest.raises(InvalidFieldTypeException):
-        Example("strings are technically iterable...", address=addr)
+        Example("strings are technically iterable...", addr)
     with pytest.raises(InvalidFieldTypeException):
-        Example(["hello", 0, "world"], address=addr)
+        Example(["hello", 0, "world"], addr)
 
 
 def test_dict_string_to_string_field() -> None:
@@ -649,13 +645,13 @@ def test_dict_string_to_string_field() -> None:
 
     addr = Address("", target_name="example")
 
-    assert Example(None, address=addr).value is None
-    assert Example({}, address=addr).value == FrozenDict()
-    assert Example({"hello": "world"}, address=addr).value == FrozenDict({"hello": "world"})
+    assert Example(None, addr).value is None
+    assert Example({}, addr).value == FrozenDict()
+    assert Example({"hello": "world"}, addr).value == FrozenDict({"hello": "world"})
 
     def assert_invalid_type(raw_value: Any) -> None:
         with pytest.raises(InvalidFieldTypeException):
-            Example(raw_value, address=addr)
+            Example(raw_value, addr)
 
     for v in [0, object(), "hello", ["hello"], {"hello": 0}, {0: "world"}]:
         assert_invalid_type(v)
@@ -666,7 +662,7 @@ def test_dict_string_to_string_field() -> None:
         # Note that we use `FrozenDict` so that the object can be hashable.
         default = FrozenDict({"default": "val"})
 
-    assert ExampleDefault(None, address=addr).value == FrozenDict({"default": "val"})
+    assert ExampleDefault(None, addr).value == FrozenDict({"default": "val"})
 
 
 def test_dict_string_to_string_sequence_field() -> None:
@@ -676,7 +672,7 @@ def test_dict_string_to_string_sequence_field() -> None:
     addr = Address("", target_name="example")
 
     def assert_flexible_constructor(raw_value: Dict[str, Iterable[str]]) -> None:
-        assert Example(raw_value, address=addr).value == FrozenDict(
+        assert Example(raw_value, addr).value == FrozenDict(
             {k: tuple(v) for k, v in raw_value.items()}
         )
 
@@ -685,7 +681,7 @@ def test_dict_string_to_string_sequence_field() -> None:
 
     def assert_invalid_type(raw_value: Any) -> None:
         with pytest.raises(InvalidFieldTypeException):
-            Example(raw_value, address=addr)
+            Example(raw_value, addr)
 
     for v in [  # type: ignore[assignment]
         0,
@@ -703,7 +699,7 @@ def test_dict_string_to_string_sequence_field() -> None:
         # Note that we use `FrozenDict` so that the object can be hashable.
         default = FrozenDict({"default": ("val",)})
 
-    assert ExampleDefault(None, address=addr).value == FrozenDict({"default": ("val",)})
+    assert ExampleDefault(None, addr).value == FrozenDict({"default": ("val",)})
 
 
 # -----------------------------------------------------------------------------------------------
@@ -737,9 +733,9 @@ def test_targets_with_sources_types() -> None:
         input = CodegenSources
         output = Sources1
 
-    tgt1 = Tgt1({}, address=Address("tgt1"))
-    tgt2 = Tgt2({}, address=Address("tgt2"))
-    codegen_tgt = CodegenTgt({}, address=Address("codegen_tgt"))
+    tgt1 = Tgt1({}, Address("tgt1"))
+    tgt2 = Tgt2({}, Address("tgt2"))
+    codegen_tgt = CodegenTgt({}, Address("codegen_tgt"))
     result = targets_with_sources_types(
         [Sources1],
         [tgt1, tgt2, codegen_tgt],


### PR DESCRIPTION
It was a mistake that we required a kwarg for `Address` when I first wrote the Target API - the type hint makes it unambiguous already that the second arg is an `Address`.

Fixing this makes our tests less verbose.

[ci skip-rust]
[ci skip-build-wheels]