### PR TITLE
Make python-setup resolve_all_constraints a bool.

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -72,7 +72,6 @@ root_patterns = [
 
 [python-setup]
 requirement_constraints = "3rdparty/python/constraints.txt"
-resolve_all_constraints = "nondeployables"
 interpreter_constraints = [">=3.7,<3.10"]
 
 [black]

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -42,7 +42,7 @@ from pants.engine.target import (
     TransitiveTargets,
     TransitiveTargetsRequest,
 )
-from pants.python.python_setup import PythonSetup, ResolveAllConstraintsOption
+from pants.python.python_setup import PythonSetup
 from pants.util.logging import LogLevel
 from pants.util.meta import frozen_after_init
 from pants.util.ordered_set import FrozenOrderedSet
@@ -274,10 +274,7 @@ async def pex_from_targets(
                 f"requirements: {', '.join(unconstrained_projects)}"
             )
 
-        if python_setup.resolve_all_constraints == ResolveAllConstraintsOption.ALWAYS or (
-            python_setup.resolve_all_constraints == ResolveAllConstraintsOption.NONDEPLOYABLES
-            and request.internal_only
-        ):
+        if python_setup.resolve_all_constraints:
             if unconstrained_projects:
                 logger.warning(
                     "Ignoring `[python_setup].resolve_all_constraints` option because constraints "
@@ -308,13 +305,12 @@ async def pex_from_targets(
                     ),
                 )
     elif (
-        python_setup.resolve_all_constraints != ResolveAllConstraintsOption.NEVER
+        python_setup.resolve_all_constraints
         and python_setup.resolve_all_constraints_was_set_explicitly()
     ):
         raise ValueError(
-            "[python-setup].resolve_all_constraints is set to "
-            f"{python_setup.resolve_all_constraints.value}, so "
-            "either [python-setup].requirement_constraints or "
+            "[python-setup].resolve_all_constraints is enabled, so either "
+            "[python-setup].requirement_constraints or "
             "[python-setup].requirement_constraints_target must also be provided."
         )
 

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -433,7 +433,7 @@ class HelpInfoExtracter:
                 scoped_arg = arg
             scoped_cmd_line_args.append(scoped_arg)
 
-            if kwargs.get("type") == bool:
+            if Parser.is_bool(kwargs):
                 if is_short_arg:
                     display_args.append(scoped_arg)
                 else:

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -50,7 +50,7 @@ class ResolveAllConstraintsOption(Enum):
             bool_value = enum_value is not cls.NEVER
             deprecated_conditional(
                 lambda: True,
-                removal_version="2.7.0.dev0",
+                removal_version="2.6.0.dev0",
                 entity_description="python-setup resolve_all_constraints non boolean values",
                 hint_message=f"Instead of {enum_value.value!r} use {bool_value!r}.",
             )

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -112,16 +112,10 @@ class PythonSetup(Subsystem):
             choices=(*(raco.value for raco in ResolveAllConstraintsOption), True, False),
             type=ResolveAllConstraintsOption.parse,
             help=(
-                "If set, and the requirements of the code being operated on are a subset of the "
-                "constraints file, then the entire constraints file will be used instead of the "
-                "subset. If unset, or any requirement of the code being operated on is not in the "
-                "constraints file, each subset will be independently resolved as needed, which is "
-                "more correct - work is only invalidated if a requirement it actually depends on "
-                "changes - but also a lot slower, due to the extra resolving. "
-                "\n\n* `never` will always use proper subsets, regardless of the goal being "
-                "run.\n* `nondeployables` will use proper subsets for `./pants package`, but "
-                "otherwise attempt to use a single resolve.\n* `always` will always attempt to use "
-                "a single resolve."
+                "If enabled, and the requirements of the code being operated on are a subset of "
+                "the constraints file, then the entire constraints file will be used instead of "
+                "the subset. If disabled, or any requirement of the code being operated on is not "
+                "in the constraints file, each subset will be independently resolved as needed."
                 "\n\nRequires [python-setup].requirement_constraints to be set."
             ),
         )

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -112,10 +112,14 @@ class PythonSetup(Subsystem):
             choices=(*(raco.value for raco in ResolveAllConstraintsOption), True, False),
             type=ResolveAllConstraintsOption.parse,
             help=(
-                "If enabled, and the requirements of the code being operated on are a subset of "
-                "the constraints file, then the entire constraints file will be used instead of "
-                "the subset. If disabled, or any requirement of the code being operated on is not "
-                "in the constraints file, each subset will be independently resolved as needed."
+                "If enabled, when resolving requirements, Pants will first resolve your entire "
+                "constraints file as a single global resolve. Then, if the code uses a subset of "
+                "your constraints file, Pants will extract the relevant requirements from that "
+                "global resolve so that only what's actually needed gets used. If disabled, Pants "
+                "will not use a global resolve and will resolve each subset of your requirements "
+                "independently."
+                "\n\nUsually this option should be enabled because it can result in far fewer "
+                "resolves."
                 "\n\nRequires [python-setup].requirement_constraints to be set."
             ),
         )


### PR DESCRIPTION
The subset resolve feature now allows resolve_all_constraints to be a
simple on/off choice indicating whether the constraints file serves as
a lock file role or not. Map the existing enum to a bool and deprecate
the enum values.

[ci skip-rust]
[ci skip-build-wheels]