### PR TITLE
Use logger name in debug logs

### DIFF
--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -7,7 +7,7 @@ import logging
 import sys
 from contextlib import contextmanager
 from io import BufferedReader, TextIOWrapper
-from logging import Formatter, LogRecord, StreamHandler
+from logging import BASIC_FORMAT, Formatter, LogRecord, PercentStyle, StreamHandler
 from pathlib import PurePath
 from typing import Dict, Iterator, cast
 
@@ -40,8 +40,15 @@ class _ExceptionFormatter(Formatter):
     """Uses the `--print-stacktrace` option to decide whether to render stacktraces."""
 
     def __init__(self, print_stacktrace: bool):
+
         super().__init__(None)
         self.print_stacktrace = print_stacktrace
+        self._debug_style = PercentStyle(fmt=BASIC_FORMAT)
+
+    def formatMessage(self, record):
+        if record.levelname in {"DEBUG", "TRACE"}:
+            return self._debug_style.format(record)
+        return super().formatMessage(record)
 
     def formatException(self, exc_info):
         if self.print_stacktrace:


### PR DESCRIPTION
debug logs in pants are very noisy, which is a good thing. however it can be harder to track down specific log message or figure out where a given log message is coming from, so for debug log messages it makes sense to include the logger name (which will indicate where the log messages is coming from) as part of the output.

this change looks like this (in GH actions):
<img width="1196" alt="Screen Shot 2021-04-29 at 4 35 02 PM" src="https://user-images.githubusercontent.com/1268088/116630868-e9117500-a908-11eb-8808-528636356136.png">
