### PR TITLE
Check parent directories too for config files for tools Pants runs

### DIFF
--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -45,8 +45,8 @@ class BanditPartition:
     interpreter_constraints: PexInterpreterConstraints
 
 
-def generate_args(
-    *, source_files: SourceFiles, bandit: Bandit, report_file_name: Optional[str]
+def generate_argv(
+    source_files: SourceFiles, bandit: Bandit, *, report_file_name: Optional[str]
 ) -> Tuple[str, ...]:
     args = []
     if bandit.config is not None:
@@ -92,9 +92,7 @@ async def bandit_lint_partition(
         FallibleProcessResult,
         VenvPexProcess(
             bandit_pex,
-            argv=generate_args(
-                source_files=source_files, bandit=bandit, report_file_name=report_file_name
-            ),
+            argv=generate_argv(source_files, bandit, report_file_name=report_file_name),
             input_digest=input_digest,
             description=f"Run Bandit on {pluralize(len(partition.field_sets), 'file')}.",
             output_files=(report_file_name,) if report_file_name else None,

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -1,7 +1,9 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Optional, Tuple, cast
+from __future__ import annotations
+
+from typing import cast
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
@@ -11,7 +13,7 @@ from pants.option.custom_types import file_option, shell_str
 
 class Bandit(PythonToolBase):
     options_scope = "bandit"
-    help = """A tool for finding security issues in Python code (https://bandit.readthedocs.io)."""
+    help = "A tool for finding security issues in Python code (https://bandit.readthedocs.io)."
 
     default_version = "bandit>=1.6.2,<1.7"
     # `setuptools<45` is for Python 2 support. `stevedore` is because the 3.0 release breaks Bandit.
@@ -41,7 +43,7 @@ class Bandit(PythonToolBase):
             type=file_option,
             default=None,
             advanced=True,
-            help="Path to a Bandit YAML config file",
+            help="Path to a Bandit YAML config file.",
         )
 
     @property
@@ -49,14 +51,15 @@ class Bandit(PythonToolBase):
         return cast(bool, self.options.skip)
 
     @property
-    def args(self) -> Tuple[str, ...]:
+    def args(self) -> tuple[str, ...]:
         return tuple(self.options.args)
 
     @property
-    def config(self) -> Optional[str]:
-        return cast(Optional[str], self.options.config)
+    def config(self) -> str | None:
+        return cast("str | None", self.options.config)
 
     @property
     def config_request(self) -> ConfigFilesRequest:
-        # Note that there are no default locations for Bandit config files.
+        # Refer to https://bandit.readthedocs.io/en/latest/config.html. Note that there are no
+        # default locations for Bandit config files.
         return ConfigFilesRequest(specified=self.config, option_name=f"{self.options_scope}.config")

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -45,8 +45,8 @@ class Flake8Partition:
     interpreter_constraints: PexInterpreterConstraints
 
 
-def generate_args(
-    *, source_files: SourceFiles, flake8: Flake8, report_file_name: Optional[str]
+def generate_argv(
+    source_files: SourceFiles, flake8: Flake8, *, report_file_name: Optional[str]
 ) -> Tuple[str, ...]:
     args = []
     if flake8.config:
@@ -90,9 +90,7 @@ async def flake8_lint_partition(
         FallibleProcessResult,
         VenvPexProcess(
             flake8_pex,
-            argv=generate_args(
-                source_files=source_files, flake8=flake8, report_file_name=report_file_name
-            ),
+            argv=generate_argv(source_files, flake8, report_file_name=report_file_name),
             input_digest=input_digest,
             output_files=(report_file_name,) if report_file_name else None,
             description=f"Run Flake8 on {pluralize(len(partition.field_sets), 'file')}.",

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -1,7 +1,9 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Optional, Tuple, cast
+from __future__ import annotations
+
+from typing import cast
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
@@ -43,7 +45,7 @@ class Flake8(PythonToolBase):
             type=file_option,
             default=None,
             advanced=True,
-            help="Path to `.flake8` or alternative Flake8 config file",
+            help="Path to `.flake8` or alternative Flake8 config file.",
         )
 
     @property
@@ -51,15 +53,17 @@ class Flake8(PythonToolBase):
         return cast(bool, self.options.skip)
 
     @property
-    def args(self) -> Tuple[str, ...]:
+    def args(self) -> tuple[str, ...]:
         return tuple(self.options.args)
 
     @property
-    def config(self) -> Optional[str]:
-        return cast(Optional[str], self.options.config)
+    def config(self) -> str | None:
+        return cast("str | None", self.options.config)
 
     @property
     def config_request(self) -> ConfigFilesRequest:
+        # See https://flake8.pycqa.org/en/latest/user/configuration.html#configuration-locations
+        # for how Flake8 discovers config files.
         return ConfigFilesRequest(
             specified=self.config,
             check_existence=["flake8", ".flake8"],

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -51,13 +51,12 @@ class Setup:
     original_digest: Digest
 
 
-def generate_args(*, source_files: SourceFiles, isort: Isort, check_only: bool) -> Tuple[str, ...]:
+def generate_argv(source_files: SourceFiles, isort: Isort, *, check_only: bool) -> Tuple[str, ...]:
     # NB: isort auto-discovers config files. There is no way to hardcode them via command line
     # flags. So long as the files are in the Pex's input files, isort will use the config.
-    args = []
+    args = [*isort.args]
     if check_only:
         args.append("--check-only")
-    args.extend(isort.args)
     args.extend(source_files.files)
     return tuple(args)
 
@@ -74,20 +73,20 @@ async def setup_isort(setup_request: SetupRequest, isort: Isort) -> Setup:
             main=isort.main,
         ),
     )
-
-    config_files_get = Get(ConfigFiles, ConfigFilesRequest, isort.config_request)
     source_files_get = Get(
         SourceFiles,
         SourceFilesRequest(field_set.sources for field_set in setup_request.request.field_sets),
     )
+    source_files, isort_pex = await MultiGet(source_files_get, isort_pex_get)
 
-    source_files, isort_pex, config_files = await MultiGet(
-        source_files_get, isort_pex_get, config_files_get
-    )
     source_files_snapshot = (
         source_files.snapshot
         if setup_request.request.prior_formatter_result is None
         else setup_request.request.prior_formatter_result
+    )
+
+    config_files = await Get(
+        ConfigFiles, ConfigFilesRequest, isort.config_request(source_files_snapshot.dirs)
     )
 
     input_digest = await Get(
@@ -98,9 +97,7 @@ async def setup_isort(setup_request: SetupRequest, isort: Isort) -> Setup:
         Process,
         VenvPexProcess(
             isort_pex,
-            argv=generate_args(
-                source_files=source_files, isort=isort, check_only=setup_request.check_only
-            ),
+            argv=generate_argv(source_files, isort, check_only=setup_request.check_only),
             input_digest=input_digest,
             output_files=source_files_snapshot.files,
             description=f"Run isort on {pluralize(len(setup_request.request.field_sets), 'file')}.",

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -62,17 +62,16 @@ class MyPyRequest(TypecheckRequest):
 
 def generate_argv(
     mypy: MyPy,
-    *,
     typechecked_venv_pex: VenvPex,
+    *,
     file_list_path: str,
     python_version: Optional[str],
 ) -> Tuple[str, ...]:
-    args = [f"--python-executable={typechecked_venv_pex.python.argv0}"]
+    args = [f"--python-executable={typechecked_venv_pex.python.argv0}", *mypy.args]
     if mypy.config:
         args.append(f"--config-file={mypy.config}")
     if python_version:
         args.append(f"--python-version={python_version}")
-    args.extend(mypy.args)
     args.append(f"@{file_list_path}")
     return tuple(args)
 
@@ -266,7 +265,7 @@ async def mypy_typecheck_partition(partition: MyPyPartition, mypy: MyPy) -> Type
             mypy_pex,
             argv=generate_argv(
                 mypy,
-                typechecked_venv_pex=typechecked_venv_pex,
+                typechecked_venv_pex,
                 file_list_path=file_list_path,
                 python_version=python_version,
             ),

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Tuple, cast
+from typing import cast
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
@@ -67,7 +67,7 @@ class MyPy(PythonToolBase):
         return cast(bool, self.options.skip)
 
     @property
-    def args(self) -> Tuple[str, ...]:
+    def args(self) -> tuple[str, ...]:
         return tuple(self.options.args)
 
     @property
@@ -76,11 +76,12 @@ class MyPy(PythonToolBase):
 
     @property
     def config_request(self) -> ConfigFilesRequest:
+        # Refer to https://mypy.readthedocs.io/en/stable/config_file.html.
         return ConfigFilesRequest(
             specified=self.config,
             check_existence=["mypy.ini", ".mypy.ini"],
             check_content={"setup.cfg": b"[mypy"},
-            option_name="[mypy].config",
+            option_name=f"{self.options_scope}.config",
         )
 
     @property

--- a/src/python/pants/backend/shell/lint/shellcheck/rules.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/rules.py
@@ -58,15 +58,19 @@ async def run_shellcheck(request: ShellcheckRequest, shellcheck: Shellcheck) -> 
             enable_codegen=True,
         ),
     )
-    config_files_get = Get(ConfigFiles, ConfigFilesRequest, shellcheck.config_request)
 
     download_shellcheck_get = Get(
         DownloadedExternalTool, ExternalToolRequest, shellcheck.get_request(Platform.current)
     )
 
-    direct_sources, dependency_sources, downloaded_shellcheck, config_files = await MultiGet(
-        direct_sources_get, dependency_sources_get, download_shellcheck_get, config_files_get
+    direct_sources, dependency_sources, downloaded_shellcheck = await MultiGet(
+        direct_sources_get, dependency_sources_get, download_shellcheck_get
     )
+
+    config_files = await Get(
+        ConfigFiles, ConfigFilesRequest, shellcheck.config_request(direct_sources.snapshot.dirs)
+    )
+
     input_digest = await Get(
         Digest,
         MergeDigests(

--- a/src/python/pants/backend/shell/lint/shellcheck/subsystem.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/subsystem.py
@@ -3,7 +3,8 @@
 
 from __future__ import annotations
 
-from typing import cast
+import os.path
+from typing import Iterable, cast
 
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.core.util_rules.external_tool import TemplatedExternalTool
@@ -66,10 +67,15 @@ class Shellcheck(TemplatedExternalTool):
     def args(self) -> tuple[str, ...]:
         return tuple(self.options.args)
 
-    @property
-    def config_request(self) -> ConfigFilesRequest:
+    def config_request(self, dirs: Iterable[str]) -> ConfigFilesRequest:
+        # Refer to https://www.mankier.com/1/shellcheck#RC_Files for how config files are
+        # discovered.
+        candidates = []
+        for d in ("", *dirs):
+            candidates.append(os.path.join(d, ".shellcheckrc"))
+            candidates.append(os.path.join(d, "shellcheckrc"))
         return ConfigFilesRequest(
             specified=cast("str | None", self.options.config),
-            check_existence=[".shellcheckrc", "shellcheckrc"],
+            check_existence=candidates,
             option_name=f"[{self.options_scope}].config",
         )

--- a/src/python/pants/backend/shell/lint/shfmt/rules.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules.py
@@ -49,20 +49,20 @@ async def setup_shfmt(setup_request: SetupRequest, shfmt: Shfmt) -> Setup:
     download_shfmt_get = Get(
         DownloadedExternalTool, ExternalToolRequest, shfmt.get_request(Platform.current)
     )
-    config_files_get = Get(ConfigFiles, ConfigFilesRequest, shfmt.config_request)
     source_files_get = Get(
         SourceFiles,
         SourceFilesRequest(field_set.sources for field_set in setup_request.request.field_sets),
     )
-
-    downloaded_shfmt, config_files, source_files = await MultiGet(
-        download_shfmt_get, config_files_get, source_files_get
-    )
+    downloaded_shfmt, source_files = await MultiGet(download_shfmt_get, source_files_get)
 
     source_files_snapshot = (
         source_files.snapshot
         if setup_request.request.prior_formatter_result is None
         else setup_request.request.prior_formatter_result
+    )
+
+    config_files = await Get(
+        ConfigFiles, ConfigFilesRequest, shfmt.config_request(source_files_snapshot.dirs)
     )
 
     input_digest = await Get(

--- a/src/python/pants/backend/shell/lint/shfmt/subsystem.py
+++ b/src/python/pants/backend/shell/lint/shfmt/subsystem.py
@@ -3,7 +3,8 @@
 
 from __future__ import annotations
 
-from typing import cast
+import os.path
+from typing import Iterable, cast
 
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.core.util_rules.external_tool import TemplatedExternalTool
@@ -64,10 +65,11 @@ class Shfmt(TemplatedExternalTool):
     def args(self) -> tuple[str, ...]:
         return tuple(self.options.args)
 
-    @property
-    def config_request(self) -> ConfigFilesRequest:
+    def config_request(self, dirs: Iterable[str]) -> ConfigFilesRequest:
+        # Refer to https://editorconfig.org/#file-location for how config files are discovered.
+        candidates = (os.path.join(d, ".editorconfig") for d in ("", *dirs))
         return ConfigFilesRequest(
             specified=cast("str | None", self.options.config),
-            check_content={".editorconfig": b"[*.sh]"},
+            check_content={fp: b"[*.sh]" for fp in candidates},
             option_name=f"[{self.options_scope}].config",
         )


### PR DESCRIPTION
This audits each tool to make sure we are properly capturing all their config files. For now, we only warn if we detect them and they're not configured, but soon we will autodiscover them.

[ci skip-rust]
[ci skip-build-wheels]