### PR TITLE
Support `[coverage.py]` config files using `pyproject.toml`, `setup.cfg`, and `tox.ini`

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -9,4 +9,3 @@ files(name='build_root', sources=["BUILD_ROOT"])
 
 files(name='gitignore', sources=['.gitignore'])
 files(name='pants_toml', sources=['pants.toml'])
-files(name='pyproject', sources=['pyproject.toml'])

--- a/build-support/coverage/coveragerc
+++ b/build-support/coverage/coveragerc
@@ -1,6 +1,0 @@
-[report]
-omit =
-  # We inject this file at test time (see src/python/pants/conftest.py), and so
-  # coverage will gather stats for it, but it doesn't correspond to a real source file,
-  # so reporting will fail, unless we omit it here.
-  */src/python/pants/__init__.py

--- a/pants.toml
+++ b/pants.toml
@@ -169,8 +169,8 @@ extra_env_vars = [
 ]
 
 [coverage-py]
-interpreter_constraints = [">=3.7,<3.10"]
-config = "build-support/coverage/coveragerc"
+interpreter_constraints = [">=3.9,<3.10"]
+config = "pyproject.toml"
 
 [sourcefile-validation]
 config = "@build-support/regexes/config.yaml"

--- a/pants.toml
+++ b/pants.toml
@@ -169,7 +169,7 @@ extra_env_vars = [
 ]
 
 [coverage-py]
-interpreter_constraints = [">=3.9,<3.10"]
+interpreter_constraints = [">=3.7,<3.10"]
 config = "pyproject.toml"
 
 [sourcefile-validation]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,14 @@ exclude = '''
 )/
 '''
 
-
 [tool.isort]
 profile = "black"
 line_length = 100
 color_output = true
 known_first_party = ["internal_plugins", "pants", "pants_test"]
+
+[tool.coverage.report]
+# We inject this file at test time (see src/python/pants/conftest.py), and so
+# coverage will gather stats for it, but it doesn't correspond to a real source file,
+# so reporting will fail, unless we omit it here.
+omit = ["src/python/pants/__init__.py"]

--- a/src/python/pants/backend/python/goals/coverage_py_test.py
+++ b/src/python/pants/backend/python/goals/coverage_py_test.py
@@ -27,15 +27,16 @@ def resolve_config(path: str | None, content: str | None) -> str:
     resolved_config: list[str] = []
 
     def mock_find_existing_config(request: ConfigFilesRequest) -> ConfigFiles:
-        snapshot = (
-            EMPTY_SNAPSHOT
-            if not request.specified
-            else RuleRunner().make_snapshot_of_empty_files([path])
-        )
+        if request.specified:
+            assert path is not None
+            snapshot = RuleRunner().make_snapshot_of_empty_files([path])
+        else:
+            snapshot = EMPTY_SNAPSHOT
         return ConfigFiles(snapshot)
 
     def mock_read_existing_config(_: Digest) -> DigestContents:
         # This shouldn't be called if no config file provided.
+        assert path is not None
         assert content is not None
         return DigestContents([FileContent(path, content.encode())])
 

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -238,6 +238,7 @@ async def setup_pytest_for_target(
         cov_paths = coverage_subsystem.filter if coverage_subsystem.filter else (".",)
         coverage_args = [
             "--cov-report=",  # Turn off output.
+            f"--cov-config={coverage_config.path}",
             *itertools.chain.from_iterable(["--cov", cov_path] for cov_path in cov_paths),
         ]
 

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -12,7 +12,7 @@ import pytest
 from pants.backend.python import target_types_rules
 from pants.backend.python.dependency_inference import rules as dependency_inference_rules
 from pants.backend.python.goals import package_pex_binary, pytest_runner
-from pants.backend.python.goals.coverage_py import create_coverage_config
+from pants.backend.python.goals.coverage_py import create_or_update_coverage_config
 from pants.backend.python.goals.pytest_runner import PythonTestFieldSet
 from pants.backend.python.target_types import (
     PexBinary,
@@ -35,7 +35,7 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner, mock_console
 def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
-            create_coverage_config,
+            create_or_update_coverage_config,
             *pytest_runner.rules(),
             *pex_from_targets.rules(),
             *dependency_inference_rules.rules(),

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -38,6 +38,8 @@ class PyTest(Subsystem):
             "--pytest-plugins",
             type=list,
             advanced=True,
+            # TODO: When updating pytest-cov to 2.12+, update the help message for
+            #  `[coverage-py].config` to not mention installing TOML.
             default=["pytest-cov>=2.10.1,<2.12"],
             help=(
                 "Requirement strings for any plugins or additional requirements you'd like to use."

--- a/src/python/pants/core/goals/BUILD
+++ b/src/python/pants/core/goals/BUILD
@@ -8,6 +8,6 @@ python_tests(name="tests", sources=['*_test.py', '!*_integration_test.py'])
 python_tests(
   name="integration",
   sources=["*_integration_test.py"],
-  dependencies=['testprojects/src/python:hello_directory', '//:pyproject'],
+  dependencies=['testprojects/src/python:hello_directory'],
   timeout=240,
 )


### PR DESCRIPTION
Before this, we only supported `.coveragerc` files. Now we fully support what the tool supports.

We also no longer error if the user had set `relative_files = false` - we instead overwrite it.

[ci skip-rust]
[ci skip-build-wheels]