### PR TITLE
Tell isort to use the config file at `[isort].config` when safe to do so

### DIFF
--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -45,10 +45,23 @@ class Isort(PythonToolBase):
         )
         register(
             "--config",
+            # TODO: Figure out how to deprecate this being a list in favor of a single string.
+            #  Thanks to config autodiscovery, this option should only be used because you want
+            #  Pants to explicitly set `--settings`, which only works w/ 1 config file.
+            #  isort 4 users should instead use autodiscovery to support multiple config files.
+            #  Deprecating this could be tricky, but should be possible thanks to the implicit
+            #  add syntax.
+            #
+            #  When deprecating, also deprecate the user manually setting `--settings` with
+            #  `[isort].args`.
             type=list,
             member_type=file_option,
             advanced=True,
-            help="Path to `isort.cfg` or alternative isort config file(s).",
+            help=(
+                "Path to `isort.cfg` or alternative isort config file(s).\n\n"
+                "If using isort 5+ and you specify only 1 config file, Pants will configure "
+                "isort's argv to point to your config file."
+            ),
         )
 
     @property


### PR DESCRIPTION
Builds off of https://github.com/pantsbuild/pants/pull/11585.

Pants's isort config support is a bit of a mess right now, in part because of changes made in isort 5. isort 5 no longer supports multiple config files and now uses "first one wins". Meanwhile, isort 4 merges multiple config files. Likewise, only isort 5 has an explicit `--settings` option to point to non-standard config file locations.

Before this PR, users had to manually set `[isort].args` if their config was not auto-discoverable by isort. Now, Pants will do that when safe, just as it does with all other `[tool].config` options.

### FYI: where we want to end up

Soon, we'll add auto-discovery of config files. When that lands, `[tool].config`'s intended semantics will be to support using a config file in a custom location: Pants will add the file to the chroot _and_ instruct the tool to use it. Otherwise, you should use `[tool].config_discovery` and rely on Pants's + the tool's auto-discovery.

That is, we want it to be that `[isort].config` _always_ results in telling isort to use `--settings`. That means `[isort].config` should be a single `str` option, rather than `list[str]`. If you need multiple config files, you would rely on config autodiscovery.

[ci skip-rust]
[ci skip-build-wheels]