### PR TITLE
Discover config files automatically for tools Pants runs

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -74,9 +74,6 @@ root_patterns = [
 requirement_constraints = "3rdparty/python/constraints.txt"
 interpreter_constraints = [">=3.7,<3.10"]
 
-[black]
-config = "pyproject.toml"
-
 [docformatter]
 args = ["--wrap-summaries=100", "--wrap-descriptions=100"]
 
@@ -89,7 +86,6 @@ extra_requirements.add = [
 
 [isort]
 version = "isort[pyproject,colors]>=5.5.1,<5.6"
-config = ["pyproject.toml"]
 
 [mypy]
 config = "build-support/mypy/mypy.ini"
@@ -170,7 +166,6 @@ extra_env_vars = [
 
 [coverage-py]
 interpreter_constraints = [">=3.7,<3.10"]
-config = "pyproject.toml"
 
 [sourcefile-validation]
 config = "@build-support/regexes/config.yaml"

--- a/src/python/pants/backend/python/goals/coverage_py_test.py
+++ b/src/python/pants/backend/python/goals/coverage_py_test.py
@@ -23,7 +23,7 @@ from pants.testutil.rule_runner import MockGet, RuleRunner, run_rule_with_mocks
 
 
 def resolve_config(path: str | None, content: str | None) -> str:
-    coverage_subsystem = create_subsystem(CoverageSubsystem, config=path)
+    coverage_subsystem = create_subsystem(CoverageSubsystem, config=path, config_discovery=True)
     resolved_config: list[str] = []
 
     def mock_find_existing_config(request: ConfigFilesRequest) -> ConfigFiles:

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -212,7 +212,7 @@ def test_uses_correct_python_version(rule_runner: RuleRunner) -> None:
     assert f"{PACKAGE}/tests.py ." in result.stdout
 
 
-def test_respects_passthrough_args(rule_runner: RuleRunner) -> None:
+def test_passthrough_args(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
             f"{PACKAGE}/tests.py": dedent(
@@ -234,7 +234,7 @@ def test_respects_passthrough_args(rule_runner: RuleRunner) -> None:
     assert "collected 2 items / 1 deselected / 1 selected" in result.stdout
 
 
-def test_respects_config(rule_runner: RuleRunner) -> None:
+def test_config_file(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
             "pytest.ini": dedent(
@@ -253,7 +253,7 @@ def test_respects_config(rule_runner: RuleRunner) -> None:
         }
     )
     tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="tests.py"))
-    result = run_pytest(rule_runner, tgt, extra_args=["--pytest-config=pytest.ini"])
+    result = run_pytest(rule_runner, tgt)
     assert result.exit_code == 0
     assert "All good!" in result.stdout and "Captured" not in result.stdout
 

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -43,7 +43,10 @@ class Bandit(PythonToolBase):
             type=file_option,
             default=None,
             advanced=True,
-            help="Path to a Bandit YAML config file.",
+            help=(
+                "Path to a Bandit YAML config file "
+                "(https://bandit.readthedocs.io/en/latest/config.html)."
+            ),
         )
 
     @property
@@ -62,4 +65,6 @@ class Bandit(PythonToolBase):
     def config_request(self) -> ConfigFilesRequest:
         # Refer to https://bandit.readthedocs.io/en/latest/config.html. Note that there are no
         # default locations for Bandit config files.
-        return ConfigFilesRequest(specified=self.config, option_name=f"{self.options_scope}.config")
+        return ConfigFilesRequest(
+            specified=self.config, specified_option_name=f"{self.options_scope}.config"
+        )

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -49,7 +49,23 @@ class Black(PythonToolBase):
             type=file_option,
             default=None,
             advanced=True,
-            help="Path to a TOML config file understood by Black.",
+            help=(
+                "Path to a TOML config file understood by Black "
+                "(https://github.com/psf/black#configuration-format).\n\n"
+                f"Setting this option will disable `[{cls.options_scope}].config_discovery`. Use "
+                f"this option if the config is located in a non-standard location."
+            ),
+        )
+        register(
+            "--config-discovery",
+            type=bool,
+            default=True,
+            advanced=True,
+            help=(
+                "If true, Pants will include any relevant pyproject.toml config files during runs."
+                f"\n\nUse `[{cls.options_scope}].config` instead if your config is in a "
+                f"non-standard location."
+            ),
         )
 
     @property
@@ -70,6 +86,7 @@ class Black(PythonToolBase):
         candidates = {os.path.join(d, "pyproject.toml"): b"[tool.black]" for d in ("", *dirs)}
         return ConfigFilesRequest(
             specified=self.config,
+            specified_option_name=f"[{self.options_scope}].config",
+            discovery=cast(bool, self.options.config_discovery),
             check_content=candidates,
-            option_name=f"[{self.options_scope}].config",
         )

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -134,19 +134,23 @@ def test_uses_correct_python_version(rule_runner: RuleRunner) -> None:
     assert batched_py3_result.stdout.strip() == ""
 
 
-def test_respects_config_file(rule_runner: RuleRunner) -> None:
+@pytest.mark.parametrize(
+    "config_path,extra_args",
+    ([".flake8", []], ["custom_config.ini", ["--flake8-config=custom_config.ini"]]),
+)
+def test_config_file(rule_runner: RuleRunner, config_path: str, extra_args: list[str]) -> None:
     rule_runner.write_files(
         {
             "f.py": BAD_FILE,
             "BUILD": "python_library(name='t')",
-            ".flake8": "[flake8]\nignore = F401\n",
+            config_path: "[flake8]\nignore = F401\n",
         }
     )
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
-    assert_success(rule_runner, tgt, extra_args=["--flake8-config=.flake8"])
+    assert_success(rule_runner, tgt, extra_args=extra_args)
 
 
-def test_respects_passthrough_args(rule_runner: RuleRunner) -> None:
+def test_passthrough_args(rule_runner: RuleRunner) -> None:
     rule_runner.write_files({"f.py": BAD_FILE, "BUILD": "python_library(name='t')"})
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
     assert_success(rule_runner, tgt, extra_args=["--flake8-args='--ignore=F401'"])

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -45,7 +45,24 @@ class Flake8(PythonToolBase):
             type=file_option,
             default=None,
             advanced=True,
-            help="Path to `.flake8` or alternative Flake8 config file.",
+            help=(
+                "Path to an INI config file understood by Flake8 "
+                "(https://flake8.pycqa.org/en/latest/user/configuration.html).\n\n"
+                f"Setting this option will disable `[{cls.options_scope}].config_discovery`. Use "
+                f"this option if the config is located in a non-standard location."
+            ),
+        )
+        register(
+            "--config-discovery",
+            type=bool,
+            default=True,
+            advanced=True,
+            help=(
+                "If true, Pants will include any relevant config files during "
+                "runs (`.flake8`, `flake8`, `setup.cfg`, and `tox.ini`)."
+                f"\n\nUse `[{cls.options_scope}].config` instead if your config is in a "
+                f"non-standard location."
+            ),
         )
 
     @property
@@ -66,7 +83,8 @@ class Flake8(PythonToolBase):
         # for how Flake8 discovers config files.
         return ConfigFilesRequest(
             specified=self.config,
+            specified_option_name=f"[{self.options_scope}].config",
+            discovery=cast(bool, self.options.config_discovery),
             check_existence=["flake8", ".flake8"],
             check_content={"setup.cfg": b"[flake8]", "tox.ini": b"[flake8]"},
-            option_name=f"[{self.options_scope}].config",
         )

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -119,8 +119,7 @@ def test_multiple_targets(rule_runner: RuleRunner) -> None:
 
 
 @pytest.mark.parametrize(
-    "path,extra_args",
-    ((".isort.cfg", ["--isort-config=.isort.cfg"]), ("custom.ini", ["--isort-config=custom.ini"])),
+    "path,extra_args", ((".isort.cfg", []), ("custom.ini", ["--isort-config=custom.ini"]))
 )
 def test_config_file(rule_runner: RuleRunner, path: str, extra_args: list[str]) -> None:
     rule_runner.write_files(

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -58,9 +58,24 @@ class Isort(PythonToolBase):
             member_type=file_option,
             advanced=True,
             help=(
-                "Path to `isort.cfg` or alternative isort config file(s).\n\n"
+                "Path to config file understood by isort "
+                "(https://pycqa.github.io/isort/docs/configuration/config_files/).\n\n"
+                f"Setting this option will disable `[{cls.options_scope}].config_discovery`. Use "
+                f"this option if the config is located in a non-standard location.\n\n"
                 "If using isort 5+ and you specify only 1 config file, Pants will configure "
                 "isort's argv to point to your config file."
+            ),
+        )
+        register(
+            "--config-discovery",
+            type=bool,
+            default=True,
+            advanced=True,
+            help=(
+                "If true, Pants will include any relevant config files during "
+                "runs (`.isort.cfg`, `pyproject.toml`, `setup.cfg`, `tox.ini` and `.editorconfig`)."
+                f"\n\nUse `[{cls.options_scope}].config` instead if your config is in a "
+                f"non-standard location."
             ),
         )
 
@@ -93,7 +108,8 @@ class Isort(PythonToolBase):
 
         return ConfigFilesRequest(
             specified=self.config,
+            specified_option_name=f"[{self.options_scope}].config",
+            discovery=cast(bool, self.options.config_discovery),
             check_existence=check_existence,
             check_content=check_content,
-            option_name=f"[{self.options_scope}].config",
         )

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -149,19 +149,23 @@ def test_uses_correct_python_version(rule_runner: RuleRunner) -> None:
     assert "Your code has been rated at 10.00/10" in batched_py3_result.stdout.strip()
 
 
-def test_respects_config_file(rule_runner: RuleRunner) -> None:
+@pytest.mark.parametrize(
+    "config_path,extra_args",
+    (["pylintrc", []], ["custom_config.ini", ["--pylint-config=custom_config.ini"]]),
+)
+def test_config_file(rule_runner: RuleRunner, config_path: str, extra_args: list[str]) -> None:
     rule_runner.write_files(
         {
             f"{PACKAGE}/f.py": BAD_FILE,
             f"{PACKAGE}/BUILD": "python_library()",
-            "pylintrc": "[pylint]\ndisable = C0103",
+            config_path: "[pylint]\ndisable = C0103",
         }
     )
     tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="f.py"))
-    assert_success(rule_runner, tgt, extra_args=["--pylint-config=pylintrc"])
+    assert_success(rule_runner, tgt, extra_args=extra_args)
 
 
-def test_respects_passthrough_args(rule_runner: RuleRunner) -> None:
+def test_passthrough_args(rule_runner: RuleRunner) -> None:
     rule_runner.write_files({f"{PACKAGE}/f.py": BAD_FILE, f"{PACKAGE}/BUILD": "python_library()"})
     tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="f.py"))
     assert_success(rule_runner, tgt, extra_args=["--pylint-args='--disable=C0103'"])

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -44,7 +44,24 @@ class Pylint(PythonToolBase):
             type=file_option,
             default=None,
             advanced=True,
-            help="Path to `pylintrc` or alternative Pylint config file.",
+            help=(
+                "Path to a config file understood by Pylint "
+                "(http://pylint.pycqa.org/en/latest/user_guide/run.html#command-line-options).\n\n"
+                f"Setting this option will disable `[{cls.options_scope}].config_discovery`. Use "
+                f"this option if the config is located in a non-standard location."
+            ),
+        )
+        register(
+            "--config-discovery",
+            type=bool,
+            default=True,
+            advanced=True,
+            help=(
+                "If true, Pants will include any relevant config files during "
+                "runs (`.pylintrc`, `pylintrc`, `pyproject.toml`, and `setup.cfg`)."
+                f"\n\nUse `[{cls.options_scope}].config` instead if your config is in a "
+                f"non-standard location."
+            ),
         )
         register(
             "--source-plugins",
@@ -84,9 +101,10 @@ class Pylint(PythonToolBase):
         # how config files are discovered.
         return ConfigFilesRequest(
             specified=self.config,
+            specified_option_name=f"[{self.options_scope}].config",
+            discovery=cast(bool, self.options.config_discovery),
             check_existence=[".pylinrc", *(os.path.join(d, "pylintrc") for d in ("", *dirs))],
             check_content={"pyproject.toml": b"[tool.pylint]", "setup.cfg": b"[pylint."},
-            option_name=f"[{self.options_scope}].config",
         )
 
     @property

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -83,7 +83,10 @@ class PyTest(Subsystem):
             type=str,
             default="xunit2",
             advanced=True,
-            help="The format of the generated XML file. See https://docs.pytest.org/en/latest/reference.html#confval-junit_family.",
+            help=(
+                "The format of the generated XML file. See "
+                "https://docs.pytest.org/en/latest/reference.html#confval-junit_family."
+            ),
         )
         register(
             "--execution-slot-var",
@@ -100,15 +103,23 @@ class PyTest(Subsystem):
             type=file_option,
             default=None,
             advanced=True,
+            help="Path to pytest.ini or alternative Pytest config file.",
+            removal_version="2.6.0.dev0",
+            removal_hint=(
+                "Pants now auto-discovers config files, so there is no need to set "
+                "`[pytest].config` if `[pytest].config_discovery` is enabled (the default)."
+            ),
+        )
+        register(
+            "--config-discovery",
+            type=bool,
+            default=True,
+            advanced=True,
             help=(
-                "Path to pytest.ini or alternative Pytest config file.\n\n"
-                "Pytest will attempt to auto-discover the config file,"
-                "meaning that it should typically be an ancestor of your"
-                "tests, such as in the build root.\n\nPants will not automatically"
-                " set --rootdir for you to force Pytest to pick up your config "
-                "file, but you can manually set --rootdir in [pytest].args.\n\n"
-                "Refer to https://docs.pytest.org/en/stable/customize.html#"
-                "initialization-determining-rootdir-and-configfile."
+                "If true, Pants will include all relevant Pytest config files (e.g. `pytest.ini`) "
+                "during runs. See "
+                "https://docs.pytest.org/en/stable/customize.html#finding-the-rootdir for where "
+                "config files should be located for Pytest to discover them."
             ),
         )
 
@@ -141,7 +152,8 @@ class PyTest(Subsystem):
 
         return ConfigFilesRequest(
             specified=cast("str | None", self.options.config),
+            specified_option_name=f"[{self.options_scope}].config",
+            discovery=cast(bool, self.options.config_discovery),
             check_existence=check_existence,
             check_content=check_content,
-            option_name=f"[{self.options_scope}].config",
         )

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 from pathlib import PurePath
 from textwrap import dedent
 from typing import List, Optional, Sequence

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -45,8 +45,26 @@ class MyPy(PythonToolBase):
         register(
             "--config",
             type=file_option,
+            default=None,
             advanced=True,
-            help="Path to `mypy.ini` or alternative MyPy config file",
+            help=(
+                "Path to a config file understood by MyPy "
+                "(https://mypy.readthedocs.io/en/stable/config_file.html).\n\n"
+                f"Setting this option will disable `[{cls.options_scope}].config_discovery`. Use "
+                f"this option if the config is located in a non-standard location."
+            ),
+        )
+        register(
+            "--config-discovery",
+            type=bool,
+            default=True,
+            advanced=True,
+            help=(
+                "If true, Pants will include any relevant config files during "
+                "runs (`mypy.ini`, `.mypy.ini`, and `setup.cfg`)."
+                f"\n\nUse `[{cls.options_scope}].config` instead if your config is in a "
+                f"non-standard location."
+            ),
         )
         register(
             "--source-plugins",
@@ -79,9 +97,10 @@ class MyPy(PythonToolBase):
         # Refer to https://mypy.readthedocs.io/en/stable/config_file.html.
         return ConfigFilesRequest(
             specified=self.config,
+            specified_option_name=f"{self.options_scope}.config",
+            discovery=cast(bool, self.options.config_discovery),
             check_existence=["mypy.ini", ".mypy.ini"],
             check_content={"setup.cfg": b"[mypy"},
-            option_name=f"{self.options_scope}.config",
         )
 
     @property

--- a/src/python/pants/backend/shell/lint/shellcheck/subsystem.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/subsystem.py
@@ -9,7 +9,7 @@ from typing import Iterable, cast
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.core.util_rules.external_tool import TemplatedExternalTool
 from pants.engine.platform import Platform
-from pants.option.custom_types import file_option, shell_str
+from pants.option.custom_types import shell_str
 
 
 class Shellcheck(TemplatedExternalTool):
@@ -47,7 +47,8 @@ class Shellcheck(TemplatedExternalTool):
         )
         register(
             "--config-discovery",
-            type=file_option,
+            type=bool,
+            default=True,
             advanced=True,
             help=(
                 "If true, Pants will include all relevant `.shellcheckrc` and `shellcheckrc` files "

--- a/src/python/pants/backend/shell/lint/shellcheck/subsystem.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/subsystem.py
@@ -46,13 +46,13 @@ class Shellcheck(TemplatedExternalTool):
             ),
         )
         register(
-            "--config",
+            "--config-discovery",
             type=file_option,
             advanced=True,
             help=(
-                "Path to `.shellcheckrc` file.\n\nBecause Shellcheck does not have a config file "
-                "option, you must locate this file somewhere Shellcheck can auto-discover it, "
-                "usually in your build root. See https://www.mankier.com/1/shellcheck#RC_Files."
+                "If true, Pants will include all relevant `.shellcheckrc` and `shellcheckrc` files "
+                "during runs. See https://www.mankier.com/1/shellcheck#RC_Files for where these "
+                "can be located."
             ),
         )
 
@@ -75,7 +75,5 @@ class Shellcheck(TemplatedExternalTool):
             candidates.append(os.path.join(d, ".shellcheckrc"))
             candidates.append(os.path.join(d, "shellcheckrc"))
         return ConfigFilesRequest(
-            specified=cast("str | None", self.options.config),
-            check_existence=candidates,
-            option_name=f"[{self.options_scope}].config",
+            discovery=cast(bool, self.options.config_discovery), check_existence=candidates
         )

--- a/src/python/pants/backend/shell/lint/shfmt/subsystem.py
+++ b/src/python/pants/backend/shell/lint/shfmt/subsystem.py
@@ -9,7 +9,7 @@ from typing import Iterable, cast
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.core.util_rules.external_tool import TemplatedExternalTool
 from pants.engine.platform import Platform
-from pants.option.custom_types import file_option, shell_str
+from pants.option.custom_types import shell_str
 
 
 class Shfmt(TemplatedExternalTool):
@@ -43,13 +43,13 @@ class Shfmt(TemplatedExternalTool):
             help="Arguments to pass directly to shfmt, e.g. `--shfmt-args='-i 2'`.'",
         )
         register(
-            "--config",
-            type=file_option,
+            "--config-discovery",
+            type=bool,
+            default=True,
             advanced=True,
             help=(
-                "Path to `.editorconfig` file.\n\nBecause shfmt does not have a config file "
-                "option, you must locate this file somewhere shfmt can auto-discover it, usually "
-                "in your build root. See https://editorconfig.org."
+                "If true, Pants will include all relevant `.editorconfig` files during runs. "
+                "See https://editorconfig.org."
             ),
         )
 
@@ -69,7 +69,6 @@ class Shfmt(TemplatedExternalTool):
         # Refer to https://editorconfig.org/#file-location for how config files are discovered.
         candidates = (os.path.join(d, ".editorconfig") for d in ("", *dirs))
         return ConfigFilesRequest(
-            specified=cast("str | None", self.options.config),
+            discovery=cast(bool, self.options.config_discovery),
             check_content={fp: b"[*.sh]" for fp in candidates},
-            option_name=f"[{self.options_scope}].config",
         )

--- a/src/python/pants/core/util_rules/config_files.py
+++ b/src/python/pants/core/util_rules/config_files.py
@@ -50,7 +50,7 @@ class ConfigFilesRequest:
         self,
         *,
         specified: str | Iterable[str] | None = None,
-        specified_option_name: str = None,
+        specified_option_name: str | None = None,
         discovery: bool = False,
         check_existence: Iterable[str] = (),
         check_content: Mapping[str, bytes] = FrozenDict(),

--- a/src/python/pants/core/util_rules/config_files.py
+++ b/src/python/pants/core/util_rules/config_files.py
@@ -12,10 +12,9 @@ from pants.engine.fs import (
     DigestContents,
     GlobMatchErrorBehavior,
     PathGlobs,
-    Paths,
     Snapshot,
 )
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.rules import Get, collect_rules, rule
 from pants.util.collections import ensure_str_list
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
@@ -34,77 +33,59 @@ class ConfigFiles:
 @frozen_after_init
 @dataclass(unsafe_hash=True)
 class ConfigFilesRequest:
-    """Resolve the specified config files if given, else look for candidate config files and warn if
-    they exist but are not hooked up to Pants.
+    """Resolve the specified config files if given, else look for candidate config files if
+    discovery is enabled.
 
     Files in `check_existence` only need to exist, whereas files in `check_content` both must exist
     and contain the bytes snippet in the file.
     """
 
     specified: tuple[str, ...]
+    specified_option_name: str | None
+    discovery: bool
     check_existence: tuple[str, ...]
     check_content: FrozenDict[str, bytes]
-    option_name: str
 
     def __init__(
         self,
         *,
         specified: str | Iterable[str] | None = None,
-        option_name: str,
+        specified_option_name: str = None,
+        discovery: bool = False,
         check_existence: Iterable[str] = (),
         check_content: Mapping[str, bytes] = FrozenDict(),
     ) -> None:
         self.specified = tuple(ensure_str_list(specified or (), allow_single_str=True))
+        self.specified_option_name = specified_option_name
+        self.discovery = discovery
         self.check_existence = tuple(sorted(check_existence))
         self.check_content = FrozenDict(check_content)
-        self.option_name = option_name
 
 
 @rule(desc="Find config files", level=LogLevel.DEBUG)
-async def warn_if_config_file_not_setup(request: ConfigFilesRequest) -> ConfigFiles:
+async def find_config_file(request: ConfigFilesRequest) -> ConfigFiles:
+    config_snapshot = EMPTY_SNAPSHOT
     if request.specified:
         config_snapshot = await Get(
             Snapshot,
             PathGlobs(
                 globs=request.specified,
                 glob_match_error_behavior=GlobMatchErrorBehavior.error,
-                description_of_origin=f"the option `{request.option_name}`",
+                description_of_origin=f"the option `{request.specified_option_name}`",
             ),
         )
         return ConfigFiles(config_snapshot)
-
-    # Else, warn if there are config files but they're not hooked up to Pants.
-    existence_paths, content_digest_contents = await MultiGet(
-        Get(Paths, PathGlobs(request.check_existence)),
-        Get(DigestContents, PathGlobs(request.check_content)),
-    )
-    discovered_config = sorted(
-        {
-            *existence_paths.files,
-            *(
-                file_content.path
-                for file_content in content_digest_contents
-                if request.check_content[file_content.path] in file_content.content
-            ),
-        }
-    )
-    if discovered_config:
-        detected = (
-            f"a relevant config file at {discovered_config[0]}"
-            if len(discovered_config) == 1
-            else f"relevant config files at {discovered_config}"
+    elif request.discovery:
+        check_content_digest_contents = await Get(DigestContents, PathGlobs(request.check_content))
+        valid_content_files = tuple(
+            file_content.path
+            for file_content in check_content_digest_contents
+            if request.check_content[file_content.path] in file_content.content
         )
-        warning_prefix = f"The option `{request.option_name}` is not configured"
-        logger.warning(
-            f"{warning_prefix}, but Pants detected "
-            f"{detected}. Did you mean to set the option `{request.option_name}`? Pants requires "
-            f"that you explicitly set up config files for them to be used.\n\n"
-            f"(If you do no want to use this config, you can ignore this warning by adding "
-            f'`ignore_warnings = ["{warning_prefix}"]` to `pants.toml` in the `GLOBAL` '
-            f"section.)"
+        config_snapshot = await Get(
+            Snapshot, PathGlobs((*request.check_existence, *valid_content_files))
         )
-
-    return ConfigFiles(EMPTY_SNAPSHOT)
+    return ConfigFiles(config_snapshot)
 
 
 def rules():


### PR DESCRIPTION
If a tool supports autodiscovery/autoloading of config files, Pants will now autodiscover those config files and include them in the chroot. This makes it more likely for Pants to work out-of-the-box.

### FYI: Semantics of `[tool].config` vs. `[tool].config_discovery`

Some tools have both these options, and some only one but not the other.

`[tool].config` is intended for custom config file locations. Pants will include the file in the chroot _and_ instruct the tool to load it via its option like `--config`/`--rcfile`. If the tool does not have an option like `--config` (Shellcheck, shfmt, and Pytest), then Pants should not have a `[tool].config` option.

`[tool].config_discovery` will locate the relevant files and include them in the chroot, but _will not_ change the argv for the tool, i.e. will not use its `--config/--rcfile` option. This avoids a major problem: what to do if we detect >1 config file but the tool only supports 1 config file. Each tool handles that case differently, normally using "first one wins". Pants should not attempt to disambiguate there, and it's a bad UX for us to error. Instead, we simply populate the chroot with the files and let the tool do its thing. This means that we only offer `[tool].config_discovery` if the tool knows how to automatically load those config files without changing the argv.

[ci skip-rust]
[ci skip-build-wheels]