### PR TITLE
Add `runtime_package_dependencies` field to `shunit2_tests`

### DIFF
--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -5,7 +5,7 @@ import itertools
 import logging
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Optional, Tuple
+from typing import Optional
 
 from pants.backend.python.goals.coverage_py import (
     CoverageConfig,
@@ -13,12 +13,7 @@ from pants.backend.python.goals.coverage_py import (
     PytestCoverageData,
 )
 from pants.backend.python.subsystems.pytest import PyTest
-from pants.backend.python.target_types import (
-    ConsoleScript,
-    PythonRuntimePackageDependencies,
-    PythonTestsSources,
-    PythonTestsTimeout,
-)
+from pants.backend.python.target_types import ConsoleScript, PythonTestsSources, PythonTestsTimeout
 from pants.backend.python.util_rules.pex import (
     Pex,
     PexInterpreterConstraints,
@@ -32,8 +27,10 @@ from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
     PythonSourceFilesRequest,
 )
-from pants.core.goals.package import BuiltPackage, PackageFieldSet
 from pants.core.goals.test import (
+    BuildPackageDependenciesRequest,
+    BuiltPackageDependencies,
+    RuntimePackageDependenciesField,
     TestDebugRequest,
     TestExtraEnv,
     TestFieldSet,
@@ -42,7 +39,6 @@ from pants.core.goals.test import (
 )
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.engine.addresses import UnparsedAddressInputs
 from pants.engine.fs import (
     AddPrefix,
     CreateDigest,
@@ -61,13 +57,7 @@ from pants.engine.process import (
     ProcessCacheScope,
 )
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import (
-    FieldSetsPerTarget,
-    FieldSetsPerTargetRequest,
-    Targets,
-    TransitiveTargets,
-    TransitiveTargetsRequest,
-)
+from pants.engine.target import TransitiveTargets, TransitiveTargetsRequest
 from pants.engine.unions import UnionRule
 from pants.option.global_options import GlobalOptions
 from pants.python.python_setup import PythonSetup
@@ -88,7 +78,7 @@ class PythonTestFieldSet(TestFieldSet):
 
     sources: PythonTestsSources
     timeout: PythonTestsTimeout
-    runtime_package_dependencies: PythonRuntimePackageDependencies
+    runtime_package_dependencies: RuntimePackageDependenciesField
 
     def is_conftest_or_type_stub(self) -> bool:
         """We skip both `conftest.py` and `.pyi` stubs, even though though they often belong to a
@@ -155,23 +145,10 @@ async def setup_pytest_for_target(
         PythonSourceFiles, PythonSourceFilesRequest(all_targets, include_files=True)
     )
 
-    # Create any assets that the test depends on through the `runtime_package_dependencies` field.
-    assets: Tuple[BuiltPackage, ...] = ()
-    unparsed_runtime_packages = (
-        request.field_set.runtime_package_dependencies.to_unparsed_address_inputs()
+    build_package_dependencies_get = Get(
+        BuiltPackageDependencies,
+        BuildPackageDependenciesRequest(request.field_set.runtime_package_dependencies),
     )
-    if unparsed_runtime_packages.values:
-        runtime_package_targets = await Get(
-            Targets, UnparsedAddressInputs, unparsed_runtime_packages
-        )
-        field_sets_per_target = await Get(
-            FieldSetsPerTarget,
-            FieldSetsPerTargetRequest(PackageFieldSet, runtime_package_targets),
-        )
-        assets = await MultiGet(
-            Get(BuiltPackage, PackageFieldSet, field_set)
-            for field_set in field_sets_per_target.field_sets
-        )
 
     # Get the file names for the test_target so that we can specify to Pytest precisely which files
     # to test, rather than using auto-discovery.
@@ -182,12 +159,14 @@ async def setup_pytest_for_target(
         requirements_pex,
         prepared_sources,
         field_set_source_files,
+        built_package_dependencies,
         extra_output_directory_digest,
     ) = await MultiGet(
         pytest_pex_get,
         requirements_pex_get,
         prepared_sources_get,
         field_set_source_files_get,
+        build_package_dependencies_get,
         extra_output_directory_digest_get,
     )
 
@@ -216,7 +195,7 @@ async def setup_pytest_for_target(
                 prepared_sources.source_files.snapshot.digest,
                 config_files.snapshot.digest,
                 extra_output_directory_digest,
-                *(binary.digest for binary in assets),
+                *(pkg.digest for pkg in built_package_dependencies),
             )
         ),
     )

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -21,7 +21,12 @@ from pants.backend.python.target_types import (
     PythonTests,
 )
 from pants.backend.python.util_rules import pex_from_targets
-from pants.core.goals.test import TestDebugRequest, TestResult, get_filtered_environment
+from pants.core.goals.test import (
+    TestDebugRequest,
+    TestResult,
+    build_runtime_package_dependencies,
+    get_filtered_environment,
+)
 from pants.core.util_rules import config_files, distdir
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents
@@ -35,6 +40,7 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner, mock_console
 def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
+            build_runtime_package_dependencies,
             create_or_update_coverage_config,
             *pytest_runner.rules(),
             *pex_from_targets.rules(),
@@ -405,7 +411,7 @@ def test_runtime_package_dependency(rule_runner: RuleRunner) -> None:
                 import subprocess
 
                 def test_embedded_binary():
-                    assert  b"Hello, test!" in subprocess.check_output(args=['./bin.pex'])
+                    assert b"Hello, test!" in subprocess.check_output(args=['./bin.pex'])
 
                     # Ensure that we didn't accidentally pull in the binary's sources. This is a
                     # special type of dependency that should not be included with the rest of the

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -18,6 +18,7 @@ from pants.backend.python.dependency_inference.default_module_mapping import DEF
 from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.core.goals.package import OutputPathField
+from pants.core.goals.test import RuntimePackageDependenciesField
 from pants.engine.addresses import Address
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
@@ -33,7 +34,6 @@ from pants.engine.target import (
     ScalarField,
     SecondaryOwnerMixin,
     Sources,
-    SpecialCasedDependencies,
     StringField,
     StringSequenceField,
     Target,
@@ -399,18 +399,6 @@ class PythonTestsDependencies(Dependencies):
     supports_transitive_excludes = True
 
 
-class PythonRuntimePackageDependencies(SpecialCasedDependencies):
-    alias = "runtime_package_dependencies"
-    help = (
-        "Addresses to targets that can be built with the `./pants package` goal and whose "
-        "resulting artifacts should be included in the test run.\n\nPants will build the artifacts "
-        "as if you had run `./pants package`. It will include the results in your test's chroot, "
-        "using the same name they would normally have, but without the `--distdir` prefix (e.g. "
-        "`dist/`).\n\nYou can include anything that can be built by `./pants package`, e.g. a "
-        "`pex_binary`, `python_awslambda`, or an `archive`."
-    )
-
-
 class PythonTestsTimeout(IntField):
     alias = "timeout"
     help = (
@@ -450,8 +438,8 @@ class PythonTests(Target):
         InterpreterConstraintsField,
         PythonTestsSources,
         PythonTestsDependencies,
-        PythonRuntimePackageDependencies,
         PythonTestsTimeout,
+        RuntimePackageDependenciesField,
     )
     help = (
         "Python tests, written in either Pytest style or unittest style.\n\nAll test util code, "

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -7,6 +7,7 @@ import re
 from enum import Enum
 from typing import Optional
 
+from pants.core.goals.test import RuntimePackageDependenciesField
 from pants.engine.addresses import Address
 from pants.engine.process import BinaryPathTest
 from pants.engine.target import (
@@ -74,6 +75,10 @@ class Shunit2Shell(Enum):
         return BinaryPathTest((arg,))
 
 
+class Shunit2TestsDependencies(Dependencies):
+    supports_transitive_excludes = True
+
+
 class Shunit2TestsSources(ShellSources):
     default = ("*_test.sh", "test_*.sh", "tests.sh")
 
@@ -106,10 +111,11 @@ class Shunit2Tests(Target):
     alias = "shunit2_tests"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        Dependencies,
+        Shunit2TestsDependencies,
         Shunit2TestsSources,
         Shunit2TestsTimeout,
         Shunit2ShellField,
+        RuntimePackageDependenciesField,
     )
     help = (
         "Tests of Bourne-based shell scripts using the shUnit2 test framework.\n\n"

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -10,17 +10,25 @@ from typing import List, Optional, Tuple, Type
 
 import pytest
 
+from pants.backend.python.goals import package_pex_binary
+from pants.backend.python.target_types import PexBinary, PythonLibrary
+from pants.backend.python.target_types_rules import rules as python_target_type_rules
+from pants.backend.python.util_rules import pex_from_targets
 from pants.core.goals.test import (
+    BuildPackageDependenciesRequest,
+    BuiltPackageDependencies,
     ConsoleCoverageReport,
     CoverageData,
     CoverageDataCollection,
     CoverageReports,
     EnrichedTestResult,
+    RuntimePackageDependenciesField,
     ShowOutput,
     Test,
     TestDebugRequest,
     TestFieldSet,
     TestSubsystem,
+    build_runtime_package_dependencies,
     run_tests,
 )
 from pants.core.util_rules.distdir import DistDir
@@ -37,6 +45,7 @@ from pants.engine.fs import (
     Digest,
     FileContent,
     MergeDigests,
+    Snapshot,
     Workspace,
 )
 from pants.engine.process import InteractiveProcess, InteractiveRunner
@@ -48,7 +57,13 @@ from pants.engine.target import (
 )
 from pants.engine.unions import UnionMembership
 from pants.testutil.option_util import create_goal_subsystem
-from pants.testutil.rule_runner import MockGet, RuleRunner, mock_console, run_rule_with_mocks
+from pants.testutil.rule_runner import (
+    MockGet,
+    QueryRule,
+    RuleRunner,
+    mock_console,
+    run_rule_with_mocks,
+)
 from pants.util.logging import LogLevel
 
 
@@ -373,3 +388,38 @@ def test_streaming_output_failure() -> None:
     assert_failure_streamed(
         output_setting=ShowOutput.NONE, expected_message="demo_test failed (exit code 1)."
     )
+
+
+def test_runtime_package_dependencies() -> None:
+    rule_runner = RuleRunner(
+        rules=[
+            build_runtime_package_dependencies,
+            *pex_from_targets.rules(),
+            *package_pex_binary.rules(),
+            *python_target_type_rules(),
+            QueryRule(BuiltPackageDependencies, [BuildPackageDependenciesRequest]),
+        ],
+        target_types=[PythonLibrary, PexBinary],
+    )
+    rule_runner.set_options(args=[], env_inherit={"PATH", "PYENV_ROOT", "HOME"})
+
+    rule_runner.write_files(
+        {
+            "src/py/main.py": "",
+            "src/py/BUILD": dedent(
+                """\
+                python_library()
+                pex_binary(name='main', entry_point='main.py')
+                """
+            ),
+        }
+    )
+    # Include an irrelevant target that cannot be built with `./pants package`.
+    input_field = RuntimePackageDependenciesField(["src/py", "src/py:main"], Address("fake"))
+    result = rule_runner.request(
+        BuiltPackageDependencies, [BuildPackageDependenciesRequest(input_field)]
+    )
+    assert len(result) == 1
+    built_package = result[0]
+    snapshot = rule_runner.request(Snapshot, [built_package.digest])
+    assert snapshot.files == ("src.py/main.pex",)

--- a/src/python/pants/core/target_types_test.py
+++ b/src/python/pants/core/target_types_test.py
@@ -6,7 +6,7 @@ import zipfile
 from io import BytesIO
 from textwrap import dedent
 
-from pants.backend.python import target_types_rules
+from pants.backend.python import target_types_rules as python_target_type_rules
 from pants.backend.python.goals import package_pex_binary
 from pants.backend.python.target_types import PexBinary
 from pants.backend.python.util_rules import pex_from_targets
@@ -160,7 +160,7 @@ def test_archive() -> None:
             *target_type_rules(),
             *pex_from_targets.rules(),
             *package_pex_binary.rules(),
-            *target_types_rules.rules(),
+            *python_target_type_rules.rules(),
             QueryRule(BuiltPackage, [ArchiveFieldSet]),
         ],
         target_types=[ArchiveTarget, Files, RelocatedFiles, PexBinary],

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -42,7 +42,6 @@ from pants.engine.target import (
     Dependencies,
     DependenciesRequest,
     ExplicitlyProvidedDependencies,
-    FieldSet,
     FieldSetsPerTarget,
     FieldSetsPerTargetRequest,
     GeneratedSources,
@@ -1023,12 +1022,9 @@ async def find_valid_field_sets_for_target_roots(
 
 @rule
 def find_valid_field_sets(
-    request: FieldSetsPerTargetRequest,
-    union_membership: UnionMembership,
+    request: FieldSetsPerTargetRequest, union_membership: UnionMembership
 ) -> FieldSetsPerTarget:
-    field_set_types: Iterable[Type[FieldSet]] = union_membership.union_rules[
-        request.field_set_superclass
-    ]
+    field_set_types = union_membership.get(request.field_set_superclass)
     return FieldSetsPerTarget(
         (
             field_set_type.create(target)


### PR DESCRIPTION
This allows you to build a package with `./pants package` and write a shell-based test to validate the artifact. 

We already had this support in Python, but folks may prefer to write these tests in Shell, especially as we add more languages and can't assume everyone will be using Pants for Python.

[ci skip-rust]
[ci skip-build-wheels]