### PR TITLE
[internal] Remove `_AbstractFieldSet`

### DIFF
--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -70,7 +70,6 @@ from pants.engine.target import (
     UnexpandedTargets,
     UnrecognizedTargetTypeException,
     WrappedTarget,
-    _AbstractFieldSet,
     generate_subtarget,
     generate_subtarget_address,
 )
@@ -924,7 +923,7 @@ class NoApplicableTargetsException(Exception):
         union_membership: UnionMembership,
         registered_target_types: RegisteredTargetTypes,
         *,
-        field_set_types: Iterable[Type[_AbstractFieldSet]],
+        field_set_types: Iterable[type[FieldSet]],
         goal_description: str,
     ) -> NoApplicableTargetsException:
         applicable_target_types = {
@@ -960,7 +959,7 @@ class AmbiguousImplementationsException(Exception):
     def __init__(
         self,
         target: Target,
-        field_sets: Iterable[_AbstractFieldSet],
+        field_sets: Iterable[FieldSet],
         *,
         goal_description: str,
     ) -> None:

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -42,6 +42,7 @@ from pants.engine.target import (
     Dependencies,
     DependenciesRequest,
     ExplicitlyProvidedDependencies,
+    FieldSet,
     FieldSetsPerTarget,
     FieldSetsPerTargetRequest,
     GeneratedSources,


### PR DESCRIPTION
This is leftover from when we had `FieldSet` and `FieldSetWithOrigin`. There is no need anymore for the extra boilerplate.

[ci skip-rust]
[ci skip-build-wheels]