### PR TITLE
Add mechanism for targets to opt out of field sets

### DIFF
--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -930,7 +930,7 @@ class NoApplicableTargetsException(Exception):
             target_type
             for field_set_type in field_set_types
             for target_type in field_set_type.applicable_target_types(
-                registered_target_types.types, union_membership=union_membership
+                registered_target_types.types, union_membership
             )
         }
         return cls(

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -791,14 +791,13 @@ class FieldSet(EngineAwareParameter, metaclass=ABCMeta):
         @dataclass(frozen=True)
         class FortranTestFieldSet(FieldSet):
             required_fields = (FortranSources,)
-            unconditional_opt_out = AlwaysSkipFortranTestsSentinelField
 
             sources: FortranSources
             fortran_version: FortranVersion
 
             @classmethod
             def conditional_opt_out(cls, tgt: Target) -> bool:
-                return tgt.get(MaybeSkipFortranTestsField).value is True
+                return tgt.get(MaybeSkipFortranTestsField).value
 
     This field set may then created from a `Target` through the `is_applicable()` and `create()`
     class methods:
@@ -1009,22 +1008,6 @@ class UnrecognizedTargetTypeException(Exception):
 # -----------------------------------------------------------------------------------------------
 
 T = TypeVar("T")
-
-
-class SentinelField(Field):
-    """A field used only as a marker type and not meant to be set in BUILD files.
-
-    The `alias` class property should start with `_` so that the field does not show up with the
-    help system.
-    """
-
-    help = "A private field only used as a marker."
-    value: None
-    default: ClassVar[None] = None
-
-    @classmethod
-    def compute_value(cls, raw_value: None, address: Address) -> None:
-        return None
 
 
 class ScalarField(Generic[T], Field):

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1020,7 +1020,7 @@ class SentinelField(Field):
 
     help = "A private field only used as a marker."
     value: None
-    default: None
+    default: ClassVar[None] = None
 
     @classmethod
     def compute_value(cls, raw_value: None, address: Address) -> None:

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -24,7 +24,6 @@ from pants.engine.target import (
     InvalidFieldTypeException,
     RequiredFieldMissingException,
     ScalarField,
-    SentinelField,
     SequenceField,
     Sources,
     StringField,


### PR DESCRIPTION
Users have recently requested a feature to disable linters for specific targets. This is prework to add generic support for targets to opt out of specific `FieldSet` implementations via the Target API.

There are two types of opt outs:

* Unconditional opt outs, where the target type is categorically not applicable to a particular field set.
     * For example, a user asked us to add support for running Black on BUILD files. Naively, we could create a `build_files()` target that subclasses `PythonSources`. But, we need to opt it out of most things like Flake8 and Pylint. Categorically, the target never works with those tools.
* Conditional opt outs, where some instances of the target should be used and others not.
     * This allows, for example, to expose a bool field that users can set in a BUILD file.

This nuance is important so that we can preserve our error message for when there are no applicable target types:

```
❯ ./pants package
10:25:43.23 [WARN] No files or targets specified. The `package` goal works with these target types:

  * archive
  * pex_binary
  * python_awslambda
  * python_distribution

Please specify relevant files and/or targets. Run `./pants filter --target-type=archive,pex_binary,python_awslambda,python_distribution ::` to find all applicable targets in your project.
```

This PR only adds support for conditional opt-outs and punts on the unconditional opt-outs because those may be better modeled by providing new mechanisms for opt-ins, rather than opt-outs. Plugin authors can (ab)use this new mechanism to implement unconditional opt outs, but we trust them to know what they're doing, and the worst that happens is a misleading error message.

[ci skip-rust]
[ci skip-build-wheels]