### PR TITLE
Add `TriBoolField` field template

### DIFF
--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -37,6 +37,7 @@ from pants.engine.target import (
     StringField,
     StringSequenceField,
     Target,
+    TriBoolField,
 )
 from pants.option.subsystem import Subsystem
 from pants.python.python_setup import PythonSetup
@@ -269,7 +270,6 @@ class PexInheritPathField(StringField):
 class PexZipSafeField(BoolField):
     alias = "zip_safe"
     default = True
-    value: bool
     help = (
         "Whether or not this binary is safe to run in compacted (zip-file) form.\n\nIf the PEX is "
         "not zip safe, it will be written to disk prior to execution. You may need to mark "
@@ -280,7 +280,6 @@ class PexZipSafeField(BoolField):
 class PexAlwaysWriteCacheField(BoolField):
     alias = "always_write_cache"
     default = False
-    value: bool
     help = (
         "Whether PEX should always write the .deps cache of the .pex file to disk or not. This "
         "can use less memory in RAM-constrained environments."
@@ -290,7 +289,6 @@ class PexAlwaysWriteCacheField(BoolField):
 class PexIgnoreErrorsField(BoolField):
     alias = "ignore_errors"
     default = False
-    value: bool
     help = "Should PEX ignore when it cannot resolve dependencies?"
 
 
@@ -304,7 +302,7 @@ class PexShebangField(StringField):
     )
 
 
-class PexEmitWarningsField(BoolField):
+class PexEmitWarningsField(TriBoolField):
     alias = "emit_warnings"
     help = (
         "Whether or not to emit PEX warnings at runtime.\n\nThe default is determined by the "
@@ -345,7 +343,6 @@ class PexExecutionModeField(StringField):
 class PexIncludeToolsField(BoolField):
     alias = "include_tools"
     default = False
-    value: bool
     help = (
         "Whether to include Pex tools in the PEX bootstrap code.\n\nWith tools included, the "
         "generated PEX file can be executed with `PEX_TOOLS=1 <pex file> --help` to gain access "

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1037,7 +1037,7 @@ class BoolField(Field):
     default: ClassVar[bool]
 
     @classmethod
-    def compute_value(cls, raw_value: bool, address: Address) -> bool:
+    def compute_value(cls, raw_value: bool, address: Address) -> bool:  # type: ignore[override]
         value_or_default = super().compute_value(raw_value, address)
         if not isinstance(value_or_default, bool):
             raise InvalidFieldTypeException(


### PR DESCRIPTION
Cherry-picked from https://github.com/pantsbuild/pants/pull/10932 (credit to @cosmicexplorer!). The vast majority of `BoolField`s are meant to be binary: `True` or `False`. But they were really trinary because they included `None`, which made the type hint harder to work with and made the `./pants help` message include `| None`.

[ci skip-rust]
[ci skip-build-wheels]