### PR TITLE
Allow skipping linters/formatters/typecheckers by target

### DIFF
--- a/src/python/pants/backend/experimental/go/lint/gofmt/register.py
+++ b/src/python/pants/backend/experimental/go/lint/gofmt/register.py
@@ -3,7 +3,8 @@
 
 from pants.backend.go.lint import fmt
 from pants.backend.go.lint.gofmt.rules import rules as gofmt_rules
+from pants.backend.go.lint.gofmt import skip_field
 
 
 def rules():
-    return [*fmt.rules(), *gofmt_rules()]
+    return [*fmt.rules(), *gofmt_rules(), *skip_field.rules()]

--- a/src/python/pants/backend/experimental/go/lint/gofmt/register.py
+++ b/src/python/pants/backend/experimental/go/lint/gofmt/register.py
@@ -2,8 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.backend.go.lint import fmt
-from pants.backend.go.lint.gofmt.rules import rules as gofmt_rules
 from pants.backend.go.lint.gofmt import skip_field
+from pants.backend.go.lint.gofmt.rules import rules as gofmt_rules
 
 
 def rules():

--- a/src/python/pants/backend/go/lint/gofmt/rules.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 from pants.backend.go.distribution import GoLangDistribution
 from pants.backend.go.lint.fmt import GoLangFmtRequest
+from pants.backend.go.lint.gofmt.skip_field import SkipGofmtField
 from pants.backend.go.lint.gofmt.subsystem import GofmtSubsystem
 from pants.backend.go.target_types import GoSources
 from pants.core.goals.fmt import FmtResult
@@ -17,7 +18,7 @@ from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.platform import Platform
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import collect_rules, rule
-from pants.engine.target import FieldSet
+from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
@@ -28,6 +29,10 @@ class GofmtFieldSet(FieldSet):
     required_fields = (GoSources,)
 
     sources: GoSources
+
+    @classmethod
+    def opt_out(cls, tgt: Target) -> bool:
+        return tgt.get(SkipGofmtField).value
 
 
 class GofmtRequest(GoLangFmtRequest):

--- a/src/python/pants/backend/go/lint/gofmt/skip_field.py
+++ b/src/python/pants/backend/go/lint/gofmt/skip_field.py
@@ -1,0 +1,15 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.backend.go.target_types import GoPackage
+from pants.engine.target import BoolField
+
+
+class SkipGofmtField(BoolField):
+    alias = "skip_gofmt"
+    default = False
+    help = "If true, don't run gofmt on this target's code."
+
+
+def rules():
+    return [GoPackage.register_plugin_field(SkipGofmtField)]

--- a/src/python/pants/backend/python/lint/bandit/register.py
+++ b/src/python/pants/backend/python/lint/bandit/register.py
@@ -8,7 +8,8 @@ https://bandit.readthedocs.io/en/latest/.
 """
 
 from pants.backend.python.lint.bandit import rules as bandit_rules
+from pants.backend.python.lint.bandit import skip_field
 
 
 def rules():
-    return bandit_rules.rules()
+    return (*bandit_rules.rules(), *skip_field.rules())

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -4,6 +4,7 @@
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
+from pants.backend.python.lint.bandit.skip_field import SkipBanditField
 from pants.backend.python.lint.bandit.subsystem import Bandit
 from pants.backend.python.target_types import InterpreterConstraintsField, PythonSources
 from pants.backend.python.util_rules import pex
@@ -20,7 +21,7 @@ from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, DigestSubset, GlobMatchErrorBehavior, MergeDigests, PathGlobs
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import FieldSet
+from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.python.python_setup import PythonSetup
 from pants.util.logging import LogLevel
@@ -33,6 +34,10 @@ class BanditFieldSet(FieldSet):
 
     sources: PythonSources
     interpreter_constraints: InterpreterConstraintsField
+
+    @classmethod
+    def opt_out(cls, tgt: Target) -> bool:
+        return tgt.get(SkipBanditField).value
 
 
 class BanditRequest(LintRequest):

--- a/src/python/pants/backend/python/lint/bandit/skip_field.py
+++ b/src/python/pants/backend/python/lint/bandit/skip_field.py
@@ -1,0 +1,18 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.backend.python.target_types import PythonLibrary, PythonTests
+from pants.engine.target import BoolField
+
+
+class SkipBanditField(BoolField):
+    alias = "skip_bandit"
+    default = False
+    help = "If true, don't run Bandit on this target's code."
+
+
+def rules():
+    return [
+        PythonLibrary.register_plugin_field(SkipBanditField),
+        PythonTests.register_plugin_field(SkipBanditField),
+    ]

--- a/src/python/pants/backend/python/lint/black/register.py
+++ b/src/python/pants/backend/python/lint/black/register.py
@@ -9,7 +9,8 @@ https://black.readthedocs.io/en/stable/.
 
 from pants.backend.python.lint import python_fmt
 from pants.backend.python.lint.black import rules as black_rules
+from pants.backend.python.lint.black import skip_field
 
 
 def rules():
-    return (*black_rules.rules(), *python_fmt.rules())
+    return (*black_rules.rules(), *python_fmt.rules(), *skip_field.rules())

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -4,6 +4,7 @@
 from dataclasses import dataclass
 from typing import Tuple
 
+from pants.backend.python.lint.black.skip_field import SkipBlackField
 from pants.backend.python.lint.black.subsystem import Black
 from pants.backend.python.lint.python_fmt import PythonFmtRequest
 from pants.backend.python.target_types import InterpreterConstraintsField, PythonSources
@@ -22,7 +23,7 @@ from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import FieldSet
+from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.python.python_setup import PythonSetup
 from pants.util.logging import LogLevel
@@ -35,6 +36,10 @@ class BlackFieldSet(FieldSet):
 
     sources: PythonSources
     interpreter_constraints: InterpreterConstraintsField
+
+    @classmethod
+    def opt_out(cls, tgt: Target) -> bool:
+        return tgt.get(SkipBlackField).value
 
 
 class BlackRequest(PythonFmtRequest, LintRequest):

--- a/src/python/pants/backend/python/lint/black/skip_field.py
+++ b/src/python/pants/backend/python/lint/black/skip_field.py
@@ -1,0 +1,18 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.backend.python.target_types import PythonLibrary, PythonTests
+from pants.engine.target import BoolField
+
+
+class SkipBlackField(BoolField):
+    alias = "skip_black"
+    default = False
+    help = "If true, don't run Black on this target's code."
+
+
+def rules():
+    return [
+        PythonLibrary.register_plugin_field(SkipBlackField),
+        PythonTests.register_plugin_field(SkipBlackField),
+    ]

--- a/src/python/pants/backend/python/lint/docformatter/register.py
+++ b/src/python/pants/backend/python/lint/docformatter/register.py
@@ -8,8 +8,9 @@ https://github.com/myint/docformatter.
 """
 
 from pants.backend.python.lint import python_fmt
+from pants.backend.python.lint.docformatter import skip_field
 from pants.backend.python.lint.docformatter.rules import rules as docformatter_rules
 
 
 def rules():
-    return (*docformatter_rules(), *python_fmt.rules())
+    return (*docformatter_rules(), *python_fmt.rules(), *skip_field.rules())

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -4,6 +4,7 @@
 from dataclasses import dataclass
 from typing import Tuple
 
+from pants.backend.python.lint.docformatter.skip_field import SkipDocformatterField
 from pants.backend.python.lint.docformatter.subsystem import Docformatter
 from pants.backend.python.lint.python_fmt import PythonFmtRequest
 from pants.backend.python.target_types import PythonSources
@@ -21,7 +22,7 @@ from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import FieldSet
+from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
@@ -32,6 +33,10 @@ class DocformatterFieldSet(FieldSet):
     required_fields = (PythonSources,)
 
     sources: PythonSources
+
+    @classmethod
+    def opt_out(cls, tgt: Target) -> bool:
+        return tgt.get(SkipDocformatterField).value
 
 
 class DocformatterRequest(PythonFmtRequest, LintRequest):

--- a/src/python/pants/backend/python/lint/docformatter/skip_field.py
+++ b/src/python/pants/backend/python/lint/docformatter/skip_field.py
@@ -1,0 +1,18 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.backend.python.target_types import PythonLibrary, PythonTests
+from pants.engine.target import BoolField
+
+
+class SkipDocformatterField(BoolField):
+    alias = "skip_docformatter"
+    default = False
+    help = "If true, don't run Docformatter on this target's code."
+
+
+def rules():
+    return [
+        PythonLibrary.register_plugin_field(SkipDocformatterField),
+        PythonTests.register_plugin_field(SkipDocformatterField),
+    ]

--- a/src/python/pants/backend/python/lint/flake8/register.py
+++ b/src/python/pants/backend/python/lint/flake8/register.py
@@ -8,7 +8,8 @@ https://flake8.pycqa.org/en/latest/.
 """
 
 from pants.backend.python.lint.flake8 import rules as flake8_rules
+from pants.backend.python.lint.flake8 import skip_field
 
 
 def rules():
-    return flake8_rules.rules()
+    return (*flake8_rules.rules(), *skip_field.rules())

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -4,6 +4,7 @@
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
+from pants.backend.python.lint.flake8.skip_field import SkipFlake8Field
 from pants.backend.python.lint.flake8.subsystem import Flake8
 from pants.backend.python.target_types import InterpreterConstraintsField, PythonSources
 from pants.backend.python.util_rules import pex
@@ -20,7 +21,7 @@ from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, DigestSubset, GlobMatchErrorBehavior, MergeDigests, PathGlobs
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import FieldSet
+from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.python.python_setup import PythonSetup
 from pants.util.logging import LogLevel
@@ -33,6 +34,10 @@ class Flake8FieldSet(FieldSet):
 
     sources: PythonSources
     interpreter_constraints: InterpreterConstraintsField
+
+    @classmethod
+    def opt_out(cls, tgt: Target) -> bool:
+        return tgt.get(SkipFlake8Field).value
 
 
 class Flake8Request(LintRequest):

--- a/src/python/pants/backend/python/lint/flake8/skip_field.py
+++ b/src/python/pants/backend/python/lint/flake8/skip_field.py
@@ -1,0 +1,18 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.backend.python.target_types import PythonLibrary, PythonTests
+from pants.engine.target import BoolField
+
+
+class SkipFlake8Field(BoolField):
+    alias = "skip_flake8"
+    default = False
+    help = "If true, don't run Flake8 on this target's code."
+
+
+def rules():
+    return [
+        PythonLibrary.register_plugin_field(SkipFlake8Field),
+        PythonTests.register_plugin_field(SkipFlake8Field),
+    ]

--- a/src/python/pants/backend/python/lint/isort/register.py
+++ b/src/python/pants/backend/python/lint/isort/register.py
@@ -9,7 +9,8 @@ https://timothycrosley.github.io/isort/.
 
 from pants.backend.python.lint import python_fmt
 from pants.backend.python.lint.isort import rules as isort_rules
+from pants.backend.python.lint.isort import skip_field
 
 
 def rules():
-    return (*isort_rules.rules(), *python_fmt.rules())
+    return (*isort_rules.rules(), *python_fmt.rules(), *skip_field.rules())

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -4,6 +4,7 @@
 from dataclasses import dataclass
 from typing import Tuple
 
+from pants.backend.python.lint.isort.skip_field import SkipIsortField
 from pants.backend.python.lint.isort.subsystem import Isort
 from pants.backend.python.lint.python_fmt import PythonFmtRequest
 from pants.backend.python.target_types import PythonSources
@@ -23,7 +24,7 @@ from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import FieldSet
+from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
@@ -34,6 +35,10 @@ class IsortFieldSet(FieldSet):
     required_fields = (PythonSources,)
 
     sources: PythonSources
+
+    @classmethod
+    def opt_out(cls, tgt: Target) -> bool:
+        return tgt.get(SkipIsortField).value
 
 
 class IsortRequest(PythonFmtRequest, LintRequest):

--- a/src/python/pants/backend/python/lint/isort/skip_field.py
+++ b/src/python/pants/backend/python/lint/isort/skip_field.py
@@ -1,0 +1,18 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.backend.python.target_types import PythonLibrary, PythonTests
+from pants.engine.target import BoolField
+
+
+class SkipIsortField(BoolField):
+    alias = "skip_isort"
+    default = False
+    help = "If true, don't run isort on this target's code."
+
+
+def rules():
+    return [
+        PythonLibrary.register_plugin_field(SkipIsortField),
+        PythonTests.register_plugin_field(SkipIsortField),
+    ]

--- a/src/python/pants/backend/python/lint/pylint/register.py
+++ b/src/python/pants/backend/python/lint/pylint/register.py
@@ -7,7 +7,8 @@ See https://www.pantsbuild.org/docs/python-linters-and-formatters and https://ww
 """
 
 from pants.backend.python.lint.pylint import rules as pylint_rules
+from pants.backend.python.lint.pylint import skip_field
 
 
 def rules():
-    return pylint_rules.rules()
+    return (*pylint_rules.rules(), *skip_field.rules())

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Iterable, List, Tuple
 
+from pants.backend.python.lint.pylint.skip_field import SkipPylintField
 from pants.backend.python.lint.pylint.subsystem import Pylint
 from pants.backend.python.target_types import (
     InterpreterConstraintsField,
@@ -55,6 +56,10 @@ class PylintFieldSet(FieldSet):
 
     sources: PythonSources
     dependencies: Dependencies
+
+    @classmethod
+    def opt_out(cls, tgt: Target) -> bool:
+        return tgt.get(SkipPylintField).value
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/lint/pylint/skip_field.py
+++ b/src/python/pants/backend/python/lint/pylint/skip_field.py
@@ -1,0 +1,18 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.backend.python.target_types import PythonLibrary, PythonTests
+from pants.engine.target import BoolField
+
+
+class SkipPylintField(BoolField):
+    alias = "skip_pylint"
+    default = False
+    help = "If true, don't run Pylint on this target's code."
+
+
+def rules():
+    return [
+        PythonLibrary.register_plugin_field(SkipPylintField),
+        PythonTests.register_plugin_field(SkipPylintField),
+    ]

--- a/src/python/pants/backend/python/typecheck/mypy/register.py
+++ b/src/python/pants/backend/python/typecheck/mypy/register.py
@@ -8,7 +8,8 @@ https://mypy.readthedocs.io/en/stable/.
 """
 
 from pants.backend.python.typecheck.mypy import rules as mypy_rules
+from pants.backend.python.typecheck.mypy import skip_field
 
 
 def rules():
-    return mypy_rules.rules()
+    return (*mypy_rules.rules(), *skip_field.rules())

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Iterable, Optional, Tuple
 
 from pants.backend.python.target_types import PythonRequirementsField, PythonSources
+from pants.backend.python.typecheck.mypy.skip_field import SkipMyPyField
 from pants.backend.python.typecheck.mypy.subsystem import MyPy
 from pants.backend.python.util_rules import pex_from_targets
 from pants.backend.python.util_rules.pex import (
@@ -46,6 +47,10 @@ class MyPyFieldSet(FieldSet):
     required_fields = (PythonSources,)
 
     sources: PythonSources
+
+    @classmethod
+    def opt_out(cls, tgt: Target) -> bool:
+        return tgt.get(SkipMyPyField).value
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/typecheck/mypy/skip_field.py
+++ b/src/python/pants/backend/python/typecheck/mypy/skip_field.py
@@ -1,0 +1,18 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.backend.python.target_types import PythonLibrary, PythonTests
+from pants.engine.target import BoolField
+
+
+class SkipMyPyField(BoolField):
+    alias = "skip_mypy"
+    default = False
+    help = "If true, don't run MyPy on this target's code."
+
+
+def rules():
+    return [
+        PythonLibrary.register_plugin_field(SkipMyPyField),
+        PythonTests.register_plugin_field(SkipMyPyField),
+    ]

--- a/src/python/pants/backend/shell/lint/shellcheck/register.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/register.py
@@ -1,8 +1,9 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from pants.backend.shell.lint.shellcheck import skip_field
 from pants.backend.shell.lint.shellcheck.rules import rules as shellcheck_rules
 
 
 def rules():
-    return shellcheck_rules()
+    return (*shellcheck_rules(), *skip_field.rules())

--- a/src/python/pants/backend/shell/lint/shellcheck/rules.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/rules.py
@@ -3,6 +3,7 @@
 
 from dataclasses import dataclass
 
+from pants.backend.shell.lint.shellcheck.skip_field import SkipShellcheckField
 from pants.backend.shell.lint.shellcheck.subsystem import Shellcheck
 from pants.backend.shell.target_types import ShellSources
 from pants.core.goals.lint import LintRequest, LintResult, LintResults
@@ -13,7 +14,14 @@ from pants.engine.fs import Digest, MergeDigests
 from pants.engine.platform import Platform
 from pants.engine.process import FallibleProcessResult, Process
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import Dependencies, DependenciesRequest, FieldSet, Sources, Targets
+from pants.engine.target import (
+    Dependencies,
+    DependenciesRequest,
+    FieldSet,
+    Sources,
+    Target,
+    Targets,
+)
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
@@ -25,6 +33,10 @@ class ShellcheckFieldSet(FieldSet):
 
     sources: ShellSources
     dependencies: Dependencies
+
+    @classmethod
+    def opt_out(cls, tgt: Target) -> bool:
+        return tgt.get(SkipShellcheckField).value
 
 
 class ShellcheckRequest(LintRequest):

--- a/src/python/pants/backend/shell/lint/shellcheck/skip_field.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/skip_field.py
@@ -1,0 +1,18 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.backend.shell.target_types import ShellLibrary, Shunit2Tests
+from pants.engine.target import BoolField
+
+
+class SkipShellcheckField(BoolField):
+    alias = "skip_shellcheck"
+    default = False
+    help = "If true, don't run Shellcheck on this target's code."
+
+
+def rules():
+    return [
+        ShellLibrary.register_plugin_field(SkipShellcheckField),
+        Shunit2Tests.register_plugin_field(SkipShellcheckField),
+    ]

--- a/src/python/pants/backend/shell/lint/shfmt/register.py
+++ b/src/python/pants/backend/shell/lint/shfmt/register.py
@@ -2,8 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.backend.shell.lint import shell_fmt
+from pants.backend.shell.lint.shfmt import skip_field
 from pants.backend.shell.lint.shfmt.rules import rules as shfmt_rules
 
 
 def rules():
-    return [*shfmt_rules(), *shell_fmt.rules()]
+    return [*shfmt_rules(), *shell_fmt.rules(), *skip_field.rules()]

--- a/src/python/pants/backend/shell/lint/shfmt/rules.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules.py
@@ -4,6 +4,7 @@
 from dataclasses import dataclass
 
 from pants.backend.shell.lint.shell_fmt import ShellFmtRequest
+from pants.backend.shell.lint.shfmt.skip_field import SkipShfmtField
 from pants.backend.shell.lint.shfmt.subsystem import Shfmt
 from pants.backend.shell.target_types import ShellSources
 from pants.core.goals.fmt import FmtResult
@@ -15,7 +16,7 @@ from pants.engine.fs import Digest, MergeDigests
 from pants.engine.platform import Platform
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import FieldSet
+from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
@@ -26,6 +27,10 @@ class ShfmtFieldSet(FieldSet):
     required_fields = (ShellSources,)
 
     sources: ShellSources
+
+    @classmethod
+    def opt_out(cls, tgt: Target) -> bool:
+        return tgt.get(SkipShfmtField).value
 
 
 class ShfmtRequest(ShellFmtRequest, LintRequest):

--- a/src/python/pants/backend/shell/lint/shfmt/skip_field.py
+++ b/src/python/pants/backend/shell/lint/shfmt/skip_field.py
@@ -1,0 +1,18 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.backend.shell.target_types import ShellLibrary, Shunit2Tests
+from pants.engine.target import BoolField
+
+
+class SkipShfmtField(BoolField):
+    alias = "skip_shfmt"
+    default = False
+    help = "If true, don't run shfmt on this target's code."
+
+
+def rules():
+    return [
+        ShellLibrary.register_plugin_field(SkipShfmtField),
+        Shunit2Tests.register_plugin_field(SkipShfmtField),
+    ]

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -783,7 +783,7 @@ class FieldSet(EngineAwareParameter, metaclass=ABCMeta):
 
     Subclasses must set `@dataclass(frozen=True)` for their declared fields to be recognized.
 
-    You can optionally set implement the classmethod `conditional_opt_out` so that targets have a
+    You can optionally set implement the classmethod `opt_out` so that targets have a
     mechanism to not match with the FieldSet even if they have the `required_fields` registered.
 
     For example:
@@ -796,7 +796,7 @@ class FieldSet(EngineAwareParameter, metaclass=ABCMeta):
             fortran_version: FortranVersion
 
             @classmethod
-            def conditional_opt_out(cls, tgt: Target) -> bool:
+            def opt_out(cls, tgt: Target) -> bool:
                 return tgt.get(MaybeSkipFortranTestsField).value
 
     This field set may then created from a `Target` through the `is_applicable()` and `create()`

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -510,7 +510,7 @@ def test_field_set() -> None:
         core_fields = ()
 
     class OptOutTarget(Target):
-        alias = "conditional_opt_out_tgt"
+        alias = "opt_out_tgt"
         core_fields = (RequiredField, OptOutField)
 
     @dataclass(frozen=True)
@@ -565,10 +565,10 @@ def test_field_set() -> None:
 
     # It is possible to create a target that should be opted out of; the caller must call
     # `.is_applicable()` first.
-    unconditional_opt_out_fs = RequiredFieldSet.create(opt_out_tgt)
-    assert unconditional_opt_out_fs.address == opt_out_addr
-    assert unconditional_opt_out_fs.required.value == "configured"
-    assert unconditional_opt_out_fs.optional.value == OptionalField.default
+    opt_out_fs = RequiredFieldSet.create(opt_out_tgt)
+    assert opt_out_fs.address == opt_out_addr
+    assert opt_out_fs.required.value == "configured"
+    assert opt_out_fs.optional.value == OptionalField.default
     assert isinstance(required_fs.required_fields, tuple)
 
     assert OptionalFieldSet.create(optional_tgt).optional.value == "configured"


### PR DESCRIPTION
This allows users to do something like:

```python
python_library(skip_flake8=True)
```

This is much more ergonomic than requiring the user to implement tags because they can still run `./pants lint ::` without needing to remember to filter by tag.

We use plugin fields to pull this off. When the user activates a new tool's backend, we add a small `BoolField` to the relevant targets.

```
./pants help python_library
...
skip_black
    type: bool
    default: False
    If true, don't run Black on this target's code.

skip_docformatter
    type: bool
    default: False
    If true, don't run Docformatter on this target's code.
...
```

--

We do not (yet) implement this for test runners and package implementations because those target types are very strongly linked to the specific implementations. There does not seem to be a strong need for:

```python
pex_binary(..., skip=True)
python_tests(skip=True)
```

We can add those easily, though, if a user articulates why it would be helpful for their repo.

[ci skip-rust]
[ci skip-build-wheels]