### PR TITLE
[internal] Enable buildsense for cron jobs

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -4,7 +4,7 @@
 
 
 env:
-  PANTS_CONFIG_FILES: +['pants.ci.toml', 'pants.no-buildsense.toml']
+  PANTS_CONFIG_FILES: +['pants.ci.toml']
   RUST_BACKTRACE: all
 jobs:
   bootstrap_pants_linux:

--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -480,7 +480,7 @@ jobs:
         python-version:
         - '3.8'
         - '3.9'
-    timeout-minutes: 20
+    timeout-minutes: 40
 name: Daily Extended Python Testing
 'on':
   schedule:

--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -482,4 +482,6 @@ jobs:
         - '3.9'
     timeout-minutes: 40
 name: Daily Extended Python Testing
-on: pull_request
+'on':
+  schedule:
+  - cron: 45 8 * * *

--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -482,6 +482,4 @@ jobs:
         - '3.9'
     timeout-minutes: 40
 name: Daily Extended Python Testing
-'on':
-  schedule:
-  - cron: 45 8 * * *
+on: pull_request

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -298,7 +298,7 @@ jobs:
 
         '
     - env:
-        PANTS_CONFIG_FILES: +['pants.ci.toml', 'pants.no-buildsense.toml']
+        PANTS_CONFIG_FILES: +['pants.ci.toml']
       if: github.event_name == 'push' || !contains(env.COMMIT_MESSAGE, '[ci skip-build-wheels]')
       name: Build wheels and fs_util
       run: '[[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && export MODE=debug
@@ -383,7 +383,7 @@ jobs:
           '
     - env:
         ARCHFLAGS: -arch x86_64
-        PANTS_CONFIG_FILES: +['pants.ci.toml', 'pants.no-buildsense.toml']
+        PANTS_CONFIG_FILES: +['pants.ci.toml']
       if: github.event_name == 'push' || !contains(env.COMMIT_MESSAGE, '[ci skip-build-wheels]')
       name: Build wheels and fs_util
       run: '[[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && export MODE=debug

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -627,7 +627,7 @@ jobs:
       matrix:
         python-version:
         - '3.7'
-    timeout-minutes: 20
+    timeout-minutes: 40
 name: Pull Request CI
 'on':
 - push

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -358,7 +358,7 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
             "needs": "bootstrap_pants_macos",
             "strategy": {"matrix": {"python-version": python_versions}},
             "env": MACOS_ENV,
-            "timeout-minutes": 20,
+            "timeout-minutes": 40,
             "steps": [
                 *checkout(),
                 setup_toolchain_auth(),

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -391,7 +391,7 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
                     """
                 ),
                 "if": DONT_SKIP_WHEELS,
-                "env": {"PANTS_CONFIG_FILES": "+['pants.ci.toml', 'pants.no-buildsense.toml']"},
+                "env": {"PANTS_CONFIG_FILES": "+['pants.ci.toml']"},
             }
             if is_macos:
                 step["env"].update(MACOS_ENV)  # type: ignore[attr-defined]

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -127,13 +127,9 @@ def pants_virtualenv_cache() -> Step:
     }
 
 
-def global_env(*, disable_buildsense: bool = False) -> Env:
+def global_env() -> Env:
     return {
-        "PANTS_CONFIG_FILES": (
-            "+['pants.ci.toml', 'pants.no-buildsense.toml']"
-            if disable_buildsense
-            else "+['pants.ci.toml']"
-        ),
+        "PANTS_CONFIG_FILES": "+['pants.ci.toml']",
         "RUST_BACKTRACE": "all",
     }
 
@@ -499,7 +495,7 @@ def generate() -> dict[Path, str]:
             # 08:45 UTC / 12:45AM PST, 1:45AM PDT: arbitrary time after hours.
             "on": {"schedule": [{"cron": "45 8 * * *"}]},
             "jobs": test_workflow_jobs([PYTHON38_VERSION, PYTHON39_VERSION], cron=True),
-            "env": global_env(disable_buildsense=True),
+            "env": global_env(),
         },
         Dumper=NoAliasDumper,
     )

--- a/pants.no-buildsense.toml
+++ b/pants.no-buildsense.toml
@@ -1,7 +1,0 @@
-[GLOBAL]
-verify_config = false
-
-plugins = ["hdrhistogram"]
-
-remote_cache_read = false
-remote_cache_write = false


### PR DESCRIPTION
The new version of the  toolchain plugin works just fine under 3.9 (since the plugin no longer depends on pants)
