### PR TITLE
[internal] Increase test timeout for python mac os tests.

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -480,7 +480,7 @@ jobs:
         python-version:
         - '3.8'
         - '3.9'
-    timeout-minutes: 20
+    timeout-minutes: 40
 name: Daily Extended Python Testing
 'on':
   schedule:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -627,7 +627,7 @@ jobs:
       matrix:
         python-version:
         - '3.7'
-    timeout-minutes: 20
+    timeout-minutes: 40
 name: Pull Request CI
 'on':
 - push

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -362,7 +362,7 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
             "needs": "bootstrap_pants_macos",
             "strategy": {"matrix": {"python-version": python_versions}},
             "env": MACOS_ENV,
-            "timeout-minutes": 20,
+            "timeout-minutes": 40,
             "steps": [
                 *checkout(),
                 setup_toolchain_auth(),


### PR DESCRIPTION
The purpose of those timeouts is to server as a stop gap for things going totally wrong.
so I think it does't make a lot of sense to keep timeouts so tight.
this one failed so I am extending (doubling it).

It makes more sense to have more aggressive timeouts at the BUILD/target level rather than at the CI level.
https://github.com/pantsbuild/pants/pull/12015/checks?check_run_id=2511516760

<img width="1341" alt="Screen Shot 2021-05-05 at 11 54 10 AM" src="https://user-images.githubusercontent.com/1268088/117194170-9caab700-ad98-11eb-9c64-01d886888fe0.png">
