### PR TITLE
Fix `--remote-auth-plugin` and `--remote-oauth-bearer-token-path` to execute every run with Pantsd

### DIFF
--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -99,7 +99,6 @@ class DaemonPantsRunner:
         self,
         args: Tuple[str, ...],
         env: Dict[str, str],
-        working_dir: str,
         cancellation_latch: PySessionCancellationLatch,
     ) -> ExitCode:
         """Run a single daemonized run of Pants.
@@ -165,8 +164,6 @@ class DaemonPantsRunner:
                     stdout_fileno=stdout_fileno,
                     stderr_fileno=stderr_fileno,
                 ):
-                    return self.single_daemonized_run(
-                        ((command,) + args), env, working_directory.decode(), cancellation_latch
-                    )
+                    return self.single_daemonized_run(((command,) + args), env, cancellation_latch)
             finally:
                 logger.info(f"request completed: `{' '.join(args)}`")

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -76,9 +76,7 @@ class LocalPantsRunner:
     ) -> GraphSession:
         native_engine.maybe_set_panic_handler()
         if scheduler is None:
-            dynamic_execution_options = DynamicRemoteExecutionOptions.from_options(
-                options, env, local_only=False
-            )
+            dynamic_execution_options = DynamicRemoteExecutionOptions.from_options(options, env)
             bootstrap_options = options.bootstrap_option_values()
             assert bootstrap_options is not None
             scheduler = EngineInitializer.setup_graph(

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -33,6 +33,7 @@ from pants.init.engine_initializer import EngineInitializer, GraphScheduler, Gra
 from pants.init.options_initializer import OptionsInitializer
 from pants.init.specs_calculator import calculate_specs
 from pants.option.arg_splitter import HelpRequest
+from pants.option.global_options import DynamicRemoteExecutionOptions
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.util.contextutil import maybe_profiled
@@ -74,12 +75,18 @@ class LocalPantsRunner:
         cancellation_latch: Optional[PySessionCancellationLatch] = None,
     ) -> GraphSession:
         native_engine.maybe_set_panic_handler()
-        graph_scheduler_helper = scheduler or EngineInitializer.setup_graph(
-            options_bootstrapper, build_config, env
-        )
+        if scheduler is None:
+            dynamic_execution_options = DynamicRemoteExecutionOptions.from_options(
+                options, env, local_only=False
+            )
+            bootstrap_options = options.bootstrap_option_values()
+            assert bootstrap_options is not None
+            scheduler = EngineInitializer.setup_graph(
+                bootstrap_options, build_config, dynamic_execution_options
+            )
         with options_initializer.handle_unknown_flags(options_bootstrapper, env, raise_=True):
             global_options = options.for_global_scope()
-        return graph_scheduler_helper.new_session(
+        return scheduler.new_session(
             run_id,
             dynamic_ui=global_options.dynamic_ui,
             use_colors=global_options.get("colors", True),
@@ -110,7 +117,7 @@ class LocalPantsRunner:
         :param options_bootstrapper: The OptionsBootstrapper instance to reuse.
         :param scheduler: If being called from the daemon, a warmed scheduler to use.
         """
-        options_initializer = options_initializer or OptionsInitializer(options_bootstrapper, env)
+        options_initializer = options_initializer or OptionsInitializer(options_bootstrapper)
         build_config, options = options_initializer.build_config_and_options(
             options_bootstrapper, env, raise_=True
         )

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -15,7 +15,6 @@ from pants.base.specs import Specs
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.engine import desktop, environment, fs, platform, process
 from pants.engine.console import Console
-from pants.engine.environment import CompleteEnvironment
 from pants.engine.fs import PathGlobs, Snapshot, Workspace
 from pants.engine.goal import Goal
 from pants.engine.internals import build_files, graph, options_parsing
@@ -32,11 +31,12 @@ from pants.engine.unions import UnionMembership
 from pants.init import specs_calculator
 from pants.option.global_options import (
     DEFAULT_EXECUTION_OPTIONS,
+    DynamicRemoteExecutionOptions,
     ExecutionOptions,
     GlobalOptions,
     LocalStoreOptions,
 )
-from pants.option.options_bootstrapper import OptionsBootstrapper
+from pants.option.option_value_container import OptionValueContainer
 from pants.option.subsystem import Subsystem
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.vcs.changed import rules as changed_rules
@@ -168,18 +168,16 @@ class EngineInitializer:
 
     @staticmethod
     def setup_graph(
-        options_bootstrapper: OptionsBootstrapper,
+        bootstrap_options: OptionValueContainer,
         build_configuration: BuildConfiguration,
-        env: CompleteEnvironment,
-        executor: Optional[PyExecutor] = None,
-        local_only: bool = False,
+        dynamic_execution_options: DynamicRemoteExecutionOptions,
+        executor: PyExecutor | None = None,
     ) -> GraphScheduler:
         build_root = get_buildroot()
-        bootstrap_options = options_bootstrapper.bootstrap_options.for_global_scope()
-        options = options_bootstrapper.full_options(build_configuration)
-        assert bootstrap_options is not None
         executor = executor or GlobalOptions.create_py_executor(bootstrap_options)
-        execution_options = ExecutionOptions.from_options(options, env, local_only=local_only)
+        execution_options = ExecutionOptions.from_options(
+            bootstrap_options, dynamic_execution_options
+        )
         local_store_options = LocalStoreOptions.from_options(bootstrap_options)
         return EngineInitializer.setup_graph_extended(
             build_configuration,

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -1,11 +1,13 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import dataclasses
 import logging
 import sys
 from contextlib import contextmanager
-from typing import Iterator, Optional, Tuple
+from typing import Iterator, Tuple
 
 import pkg_resources
 
@@ -22,6 +24,7 @@ from pants.init.extension_loader import (
 from pants.init.plugin_resolver import PluginResolver
 from pants.init.plugin_resolver import rules as plugin_resolver_rules
 from pants.option.errors import UnknownFlagsError
+from pants.option.global_options import DynamicRemoteExecutionOptions
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
 
@@ -58,9 +61,7 @@ def _initialize_build_configuration(
 
 
 def create_bootstrap_scheduler(
-    options_bootstrapper: OptionsBootstrapper,
-    env: CompleteEnvironment,
-    executor: Optional[PyExecutor] = None,
+    options_bootstrapper: OptionsBootstrapper, executor: PyExecutor | None = None
 ) -> BootstrapScheduler:
     bc_builder = BuildConfiguration.Builder()
     # To load plugins, we only need access to the Python/PEX rules.
@@ -71,13 +72,10 @@ def create_bootstrap_scheduler(
     bc_builder.allow_unknown_options()
     return BootstrapScheduler(
         EngineInitializer.setup_graph(
-            options_bootstrapper,
+            options_bootstrapper.bootstrap_options.for_global_scope(),
             bc_builder.create(),
-            executor=executor,
-            env=env,
-            # TODO: We set local_only to avoid invoking remote execution auth plugins. They should
-            # be loaded via rules using the bootstrap Scheduler in the future.
-            local_only=True,
+            DynamicRemoteExecutionOptions.disabled(),
+            executor,
         ).scheduler
     )
 
@@ -98,12 +96,9 @@ class OptionsInitializer:
     def __init__(
         self,
         options_bootstrapper: OptionsBootstrapper,
-        env: CompleteEnvironment,
-        executor: Optional[PyExecutor] = None,
+        executor: PyExecutor | None = None,
     ) -> None:
-        self._bootstrap_scheduler = create_bootstrap_scheduler(
-            options_bootstrapper, env, executor=executor
-        )
+        self._bootstrap_scheduler = create_bootstrap_scheduler(options_bootstrapper, executor)
         self._plugin_resolver = PluginResolver(self._bootstrap_scheduler)
 
     def build_config_and_options(

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -143,7 +143,7 @@ class DynamicRemoteExecutionOptions:
 
     @classmethod
     def from_options(
-        cls, full_options: Options, env: CompleteEnvironment, *, local_only: bool
+        cls, full_options: Options, env: CompleteEnvironment, *, local_only: bool = False
     ) -> DynamicRemoteExecutionOptions:
         if local_only:
             return DynamicRemoteExecutionOptions(

--- a/src/python/pants/option/global_options_test.py
+++ b/src/python/pants/option/global_options_test.py
@@ -11,27 +11,29 @@ import pytest
 
 from pants.base.build_environment import get_buildroot
 from pants.engine.environment import CompleteEnvironment
+from pants.engine.internals.scheduler import ExecutionError
 from pants.init.options_initializer import OptionsInitializer
-from pants.option.errors import OptionsError
-from pants.option.global_options import ExecutionOptions, GlobalOptions
+from pants.option.global_options import (
+    DynamicRemoteExecutionOptions,
+    ExecutionOptions,
+    GlobalOptions,
+)
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.util.contextutil import temporary_dir
 
 
-def create_execution_options(
+def create_dynamic_execution_options(
     *,
     initial_headers: dict[str, str],
     token_path: str | None = None,
     plugin: str | None = None,
-    remote_store_address: str = "grpc://fake.url:10",
-    remote_execution_address: str = "grpc://fake.url:10",
     local_only: bool = False,
-) -> ExecutionOptions:
+) -> DynamicRemoteExecutionOptions:
     args = [
         "--remote-cache-read",
-        f"--remote-execution-address={remote_execution_address}",
-        f"--remote-store-address={remote_store_address}",
+        "--remote-execution-address=grpc://fake.url:10",
+        "--remote-store-address=grpc://fake.url:10",
         f"--remote-store-headers={initial_headers}",
         f"--remote-execution-headers={initial_headers}",
         "--remote-instance-name=main",
@@ -42,18 +44,16 @@ def create_execution_options(
         args.append(f"--remote-auth-plugin={plugin}")
     ob = create_options_bootstrapper(args)
     env = CompleteEnvironment({})
-    _build_config, options = OptionsInitializer(ob, env).build_config_and_options(
-        ob, env, raise_=False
-    )
-    return ExecutionOptions.from_options(options, env, local_only=local_only)
+    _build_config, options = OptionsInitializer(ob).build_config_and_options(ob, env, raise_=False)
+    return DynamicRemoteExecutionOptions.from_options(options, env, local_only=local_only)
 
 
-def test_execution_options_remote_oauth_bearer_token_path() -> None:
+def test_dynamic_execution_options_remote_oauth_bearer_token_path() -> None:
     with temporary_dir() as tempdir:
         token_path = Path(tempdir, "token.txt")
         token_path.touch()
         token_path.write_text("my-token")
-        exec_options = create_execution_options(
+        exec_options = create_dynamic_execution_options(
             initial_headers={"foo": "bar"}, token_path=str(token_path)
         )
     assert exec_options.remote_store_headers == {"authorization": "Bearer my-token", "foo": "bar"}
@@ -63,60 +63,16 @@ def test_execution_options_remote_oauth_bearer_token_path() -> None:
     }
 
 
-def test_execution_options_remote_addresses() -> None:
-    # Test that we properly validate and normalize the scheme.
-    host = "fake-with-http-in-url.com:10"
-    exec_options = create_execution_options(
-        initial_headers={},
-        remote_store_address=f"grpc://{host}",
-        remote_execution_address=f"grpc://{host}",
+def test_dynamic_execution_options_local_only() -> None:
+    # Test that local_only properly disables remote execution.
+    assert (
+        create_dynamic_execution_options(initial_headers={}, local_only=True)
+        == DynamicRemoteExecutionOptions.disabled()
     )
-    assert exec_options.remote_execution_address == f"http://{host}"
-    assert exec_options.remote_store_address == f"http://{host}"
-
-    exec_options = create_execution_options(
-        initial_headers={},
-        remote_store_address=f"grpcs://{host}",
-        remote_execution_address=f"grpcs://{host}",
-    )
-    assert exec_options.remote_execution_address == f"https://{host}"
-    assert exec_options.remote_store_address == f"https://{host}"
-
-    with pytest.raises(OptionsError):
-        create_execution_options(
-            initial_headers={},
-            remote_store_address=f"http://{host}",
-            remote_execution_address=f"grpc://{host}",
-        )
-    with pytest.raises(OptionsError):
-        create_execution_options(
-            initial_headers={},
-            remote_store_address=f"grpc://{host}",
-            remote_execution_address=f"https:://{host}",
-        )
 
 
-def test_execution_options_local_only() -> None:
-    # Test that local_only properly disables remote execution. It doesn't need to prune all
-    # settings, only those which would trigger usage.
-    host = "fake-with-http-in-url.com:10"
-    exec_options = create_execution_options(
-        initial_headers={},
-        remote_store_address=f"grpc://{host}",
-        remote_execution_address=f"grpc://{host}",
-        local_only=True,
-    )
-    # Remote execution should be disabled, and the headers should still be empty, indicating that
-    # the auth plugin has not run.
-    assert not exec_options.remote_execution
-    assert not exec_options.remote_cache_read
-    assert not exec_options.remote_cache_write
-    assert exec_options.remote_store_headers == {}
-    assert exec_options.remote_execution_headers == {}
-
-
-def test_execution_options_auth_plugin() -> None:
-    def compute_exec_options(state: str) -> ExecutionOptions:
+def test_dynamic_execution_options_auth_plugin() -> None:
+    def compute_exec_options(state: str) -> DynamicRemoteExecutionOptions:
         with temporary_dir() as tempdir:
             # NB: For an unknown reason, if we use the same file name for multiple runs, the plugin
             # result gets memoized. So, we use a distinct file name.
@@ -145,7 +101,7 @@ def test_execution_options_auth_plugin() -> None:
                 )
             )
             sys.path.append(tempdir)
-            result = create_execution_options(
+            result = create_dynamic_execution_options(
                 initial_headers={"foo": "bar"}, plugin=f"auth_plugin_{state}:auth_func"
             )
             sys.path.pop()
@@ -164,6 +120,40 @@ def test_execution_options_auth_plugin() -> None:
     exec_options = compute_exec_options("UNAVAILABLE")
     assert exec_options.remote_cache_read is False
     assert exec_options.remote_instance_name == "main"
+
+
+def test_execution_options_remote_addresses() -> None:
+    # Test that we properly validate and normalize the scheme.
+
+    def create_exec_options(
+        remote_store_address: str, remote_execution_address: str
+    ) -> ExecutionOptions:
+        ob = create_options_bootstrapper(
+            [
+                f"--remote-store-address={remote_store_address}",
+                f"--remote-execution-address={remote_execution_address}",
+            ]
+        )
+        _build_config, options = OptionsInitializer(ob).build_config_and_options(
+            ob, CompleteEnvironment({}), raise_=False
+        )
+        return ExecutionOptions.from_options(
+            options.for_global_scope(), DynamicRemoteExecutionOptions.disabled()
+        )
+
+    host = "fake-with-http-in-url.com:10"
+    exec_options = create_exec_options(f"grpc://{host}", f"grpc://{host}")
+    assert exec_options.remote_execution_address == f"http://{host}"
+    assert exec_options.remote_store_address == f"http://{host}"
+
+    exec_options = create_exec_options(f"grpcs://{host}", f"grpcs://{host}")
+    assert exec_options.remote_execution_address == f"https://{host}"
+    assert exec_options.remote_store_address == f"https://{host}"
+
+    with pytest.raises(ExecutionError):
+        create_exec_options(f"http://{host}", f"grpc://{host}")
+    with pytest.raises(ExecutionError):
+        create_exec_options(f"grpc://{host}", f"https:://{host}")
 
 
 def test_invalidation_globs() -> None:

--- a/src/python/pants/pantsd/pants_daemon_core.py
+++ b/src/python/pants/pantsd/pants_daemon_core.py
@@ -122,9 +122,7 @@ class PantsDaemonCore:
         # Because these options are computed dynamically via side-effects like reading from a file,
         # they need to be re-evaluated every run. We only reinitialize the scheduler if changes
         # were made, though.
-        dynamic_execution_options = DynamicRemoteExecutionOptions.from_options(
-            options, env, local_only=False
-        )
+        dynamic_execution_options = DynamicRemoteExecutionOptions.from_options(options, env)
         exec_options_changed = dynamic_execution_options != self._prior_dynamic_exec_options
         if exec_options_changed:
             scheduler_restart_explanation = "Remote cache/execution options updated"

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -144,6 +144,9 @@ class RuleRunner:
         options = self.options_bootstrapper.full_options(self.build_config)
         global_options = self.options_bootstrapper.bootstrap_options.for_global_scope()
 
+        dynamic_execution_options = DynamicRemoteExecutionOptions.from_options(
+            options, self.environment
+        )
         local_store_options = LocalStoreOptions.from_options(global_options)
         if isolated_local_store:
             if root_dir:
@@ -153,10 +156,6 @@ class RuleRunner:
             else:
                 store_dir = safe_mkdtemp(prefix="lmdb_store.")
             local_store_options = dataclasses.replace(local_store_options, store_dir=store_dir)
-
-        dynamic_execution_options = DynamicRemoteExecutionOptions.from_options(
-            options, self.environment, local_only=False
-        )
 
         local_execution_root_dir = global_options.local_execution_root_dir
         named_caches_dir = global_options.named_caches_dir

--- a/tests/python/pants_test/init/test_options_initializer.py
+++ b/tests/python/pants_test/init/test_options_initializer.py
@@ -3,15 +3,14 @@
 
 import unittest
 
-from pants.base.exceptions import BuildConfigurationError
 from pants.engine.environment import CompleteEnvironment
+from pants.engine.internals.scheduler import ExecutionError
 from pants.init.options_initializer import OptionsInitializer
-from pants.option.errors import OptionsError
 from pants.option.options_bootstrapper import OptionsBootstrapper
 
 
 class OptionsInitializerTest(unittest.TestCase):
-    def test_invalid_version(self):
+    def test_invalid_version(self) -> None:
         options_bootstrapper = OptionsBootstrapper.create(
             env={},
             args=["--backend-packages=[]", "--pants-version=99.99.9999"],
@@ -19,17 +18,17 @@ class OptionsInitializerTest(unittest.TestCase):
         )
 
         env = CompleteEnvironment({})
-        with self.assertRaises(BuildConfigurationError):
-            OptionsInitializer(options_bootstrapper, env).build_config_and_options(
+        with self.assertRaises(ExecutionError):
+            OptionsInitializer(options_bootstrapper).build_config_and_options(
                 options_bootstrapper, env, raise_=True
             )
 
-    def test_global_options_validation(self):
+    def test_global_options_validation(self) -> None:
         # Specify an invalid combination of options.
         ob = OptionsBootstrapper.create(
             env={}, args=["--backend-packages=[]", "--remote-execution"], allow_pantsrc=False
         )
         env = CompleteEnvironment({})
-        with self.assertRaises(OptionsError) as exc:
-            OptionsInitializer(ob, env).build_config_and_options(ob, env, raise_=True)
+        with self.assertRaises(ExecutionError) as exc:
+            OptionsInitializer(ob).build_config_and_options(ob, env, raise_=True)
         self.assertIn("The `--remote-execution` option requires", str(exc.exception))

--- a/tests/python/pants_test/init/test_plugin_resolver.py
+++ b/tests/python/pants_test/init/test_plugin_resolver.py
@@ -170,7 +170,7 @@ def plugin_resolution(
         complete_env = CompleteEnvironment(
             {**{k: os.environ[k] for k in ["PATH", "HOME", "PYENV_ROOT"] if k in os.environ}, **env}
         )
-        bootstrap_scheduler = create_bootstrap_scheduler(options_bootstrapper, complete_env)
+        bootstrap_scheduler = create_bootstrap_scheduler(options_bootstrapper)
         plugin_resolver = PluginResolver(
             bootstrap_scheduler, interpreter_constraints=interpreter_constraints
         )

--- a/tests/python/pants_test/pantsd/test_pants_daemon_core.py
+++ b/tests/python/pants_test/pantsd/test_pants_daemon_core.py
@@ -8,13 +8,17 @@ from pants.pantsd.service.pants_service import PantsServices
 from pants.testutil.option_util import create_options_bootstrapper
 
 
-def test_prepare_scheduler():
+def test_prepare_scheduler() -> None:
     # A core with no services.
-    def create_services(bootstrap_options, legacy_graph_scheduler):
+    def create_services(bootstrap_options, graph_scheduler):
         return PantsServices()
 
     env = CompleteEnvironment({})
-    core = PantsDaemonCore(create_options_bootstrapper([]), env, PyExecutor(2, 4), create_services)
+    core = PantsDaemonCore(
+        create_options_bootstrapper([]),
+        PyExecutor(core_threads=2, max_threads=4),
+        create_services,
+    )
 
     first_scheduler, first_options_initializer = core.prepare(
         create_options_bootstrapper(["-ldebug"]),


### PR DESCRIPTION
As found in https://github.com/pantsbuild/pants/issues/12018, `--remote-auth-plugin` and `--remote-oauth-bearer-token-path` are both impure functions with side effects like reading from the file system. Consequently, it's necessary to rerun the two mechanisms every Pants run, even with pantsd. For example, currently we will not pick up changes made to the oauth file unless you kill Pantsd.

This PR fixes it so that we always do the correct things of re-evaluating the `DynamicRemoteExecutionOptions`. If those have changed from the prior Pantsd run, we re-initialize the scheduler.

Naively, however, this has a negative implication for the Toolchain plugin. Because Toolchain's auth logic is stateless, it generates a new short-lived token every call, which updates `--remote-store-header`. That means that this PR will cause Pantsd to be invalidated every single run, making Pantsd useless. This will be fixed in a followup by passing the prior `AuthPluginResult` to the auth plugin function + allowing the plugin to set a token expiration time, which will allow the plugin to decide if it's safe to resuse the prior token.