### PR TITLE
Unify kwargs for deprecation utilities

### DIFF
--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -1,6 +1,8 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import inspect
 import logging
 from functools import wraps
@@ -14,25 +16,29 @@ from pants.version import PANTS_SEMVER
 logger = logging.getLogger(__name__)
 
 
-class DeprecationApplicationError(Exception):
+class DeprecationError(Exception):
     """The base exception type thrown for any form of @deprecation application error."""
 
 
-class MissingSemanticVersionError(DeprecationApplicationError):
+class MissingSemanticVersionError(DeprecationError):
     """Indicates the required removal_version was not supplied."""
 
 
-class BadSemanticVersionError(DeprecationApplicationError):
+class BadSemanticVersionError(DeprecationError):
     """Indicates the supplied removal_version was not a valid semver string."""
 
 
-class NonDevSemanticVersionError(DeprecationApplicationError):
+class NonDevSemanticVersionError(DeprecationError):
     """Indicates the supplied removal_version was not a pre-release version."""
 
 
-class InvalidSemanticVersionOrderingError(DeprecationApplicationError):
+class InvalidSemanticVersionOrderingError(DeprecationError):
     """Indicates that multiple semantic version strings were provided in an inconsistent
     ordering."""
+
+
+class BadDecoratorNestingError(DeprecationError):
+    """Indicates the @deprecated decorator was innermost in a sequence of layered decorators."""
 
 
 class CodeRemovedError(Exception):
@@ -40,17 +46,13 @@ class CodeRemovedError(Exception):
 
     I.e., that the option/function/module with that removal_version has already been removed.
 
-    Note, the code in question may not actually have been excised from the codebase yet, but
-    it may be at any time, and no control paths access it.
+    Note that the code in question may not actually have been excised from the codebase yet, but
+    it may be at any time.
     """
 
 
-class BadDecoratorNestingError(DeprecationApplicationError):
-    """Indicates the @deprecated decorator was innermost in a sequence of layered decorators."""
-
-
-def is_deprecation_active(deprecation_start_version: Optional[str]) -> bool:
-    return deprecation_start_version is None or Version(deprecation_start_version) <= PANTS_SEMVER
+def is_deprecation_active(start_version: str | None) -> bool:
+    return start_version is None or Version(start_version) <= PANTS_SEMVER
 
 
 def get_deprecated_tense(removal_version: str) -> str:
@@ -62,85 +64,91 @@ def get_deprecated_tense(removal_version: str) -> str:
 def validate_deprecation_semver(version_string: str, version_description: str) -> Version:
     """Validates that version_string is a valid semver.
 
-    If so, returns that semver.  Raises an error otherwise.
+    If so, returns that semver. Raises an error otherwise.
 
     :param version_string: A pantsbuild.pants version which affects some deprecated entity.
     :param version_description: A string used in exception messages to describe what the
-                                `version_string` represents.
-    :raises DeprecationApplicationError: if the version_string parameter is invalid.
+        `version_string` represents.
+    :raises DeprecationError: if the version_string parameter is invalid.
     """
     if version_string is None:
-        raise MissingSemanticVersionError("The {} must be provided.".format(version_description))
+        raise MissingSemanticVersionError(f"The {version_string} must be provided.")
     if not isinstance(version_string, str):
         raise BadSemanticVersionError(
-            "The {} must be a version string.".format(version_description)
+            f"The {version_description} must be a version string but was {version_string} with "
+            f"type {type(version_description)}."
         )
+
     try:
-        # NB: packaging will see versions like 1.a.0 as 1a0, and are "valid"
-        # We explicitly want our versions to be of the form x.y.z.
         v = Version(version_string)
-        if len(v.base_version.split(".")) != 3:
-            raise BadSemanticVersionError(
-                "The given {} is not a valid version: "
-                "{}".format(version_description, version_string)
-            )
-        if not v.is_prerelease:
-            raise NonDevSemanticVersionError(
-                "The given {} is not a dev version: {}\n"
-                "Features should generally be removed in the first `dev` release "
-                "of a release cycle.".format(version_description, version_string)
-            )
-        return v
     except InvalidVersion as e:
         raise BadSemanticVersionError(
-            "The given {} {} is not a valid version: "
-            "{}".format(version_description, version_string, e)
+            f"The given {version_description} {version_string} is not a valid version: "
+            f"{repr(e)}"
         )
 
+    # NB: packaging.Version will see versions like 1.a.0 as 1a0 and as "valid".
+    # We explicitly want our versions to be of the form x.y.z.
+    if len(v.base_version.split(".")) != 3:
+        raise BadSemanticVersionError(
+            f"The given {version_description} is not a valid version: "
+            f"{version_description}. Expecting the format `x.y.z.dev0`"
+        )
+    if not v.is_prerelease:
+        raise NonDevSemanticVersionError(
+            f"The given {version_description} is not a dev version: {version_string}\n"
+            "Features should generally be removed in the first `dev` release of a release "
+            "cycle."
+        )
+    return v
 
-# TODO: propagate `deprecation_start_version` to other methods in this file!
+
 def warn_or_error(
     removal_version: str,
-    deprecated_entity_description: str,
+    entity: str,
     hint: Optional[str] = None,
-    deprecation_start_version: Optional[str] = None,
+    *,
+    start_version: str | None = None,
     print_warning: bool = True,
 ) -> None:
-    """Check the removal_version against the current pants version.
+    """Check the removal_version against the current Pants version.
 
-    Issues a warning if the removal version is > current pants version, or an error otherwise.
+    When choosing a removal version, there is a natural tension between the code-base, which benefits
+    from short deprecation cycles, and the user-base which may prefer to deal with deprecations less
+    frequently. As a rule of thumb, if the hint message can fully convey corrective action
+    succinctly and you judge the impact to be on the small side (effects custom tasks as opposed to
+    effecting BUILD files), lean towards the next release version as the removal version; otherwise,
+    consider initiating a discussion to win consensus on a reasonable removal version.
+
+    Issues a warning if the removal version is > current Pants version or an error otherwise.
 
     :param removal_version: The pantsbuild.pants version at which the deprecated entity will
-                            be/was removed.
-    :param deprecated_entity_description: A short description of the deprecated entity, that
-                                          we can embed in warning/error messages.
-    :param hint: A message describing how to migrate from the removed entity.
-    :param deprecation_start_version: The pantsbuild.pants version at which the entity will
-                                      begin to display a deprecation warning. This must be less
-                                      than the `removal_version`. If not provided, the
-                                      deprecation warning is always displayed.
+        be/was removed.
+    :param entity: A short description of the deprecated entity, e.g. "using an INI config file".
+    :param hint: How to migrate.
+    :param start_version: The pantsbuild.pants version at which the entity will
+        begin to display a deprecation warning. This must be less than the `removal_version`. If
+        not provided, the deprecation warning is always displayed.
     :param print_warning: Whether to print a warning for deprecations *before* their removal.
-                          If this flag is off, an exception will still be raised for options
-                          past their deprecation date.
-    :raises DeprecationApplicationError: if the removal_version parameter is invalid.
+        If this flag is off, an exception will still be raised for options past their deprecation
+        date.
+    :raises DeprecationError: if the removal_version parameter is invalid.
     :raises CodeRemovedError: if the current version is later than the version marked for removal.
     """
     removal_semver = validate_deprecation_semver(removal_version, "removal version")
-    if deprecation_start_version:
-        deprecation_start_semver = validate_deprecation_semver(
-            deprecation_start_version, "deprecation start version"
-        )
-        if deprecation_start_semver >= removal_semver:
+    if start_version:
+        start_semver = validate_deprecation_semver(start_version, "deprecation start version")
+        if start_semver >= removal_semver:
             raise InvalidSemanticVersionOrderingError(
-                f"The deprecation start version {deprecation_start_version} must be less than "
+                f"The deprecation start version {start_version} must be less than "
                 f"the end version {removal_version}."
             )
-        elif PANTS_SEMVER < deprecation_start_semver:
+        elif PANTS_SEMVER < start_semver:
             return
 
     msg = (
-        f"DEPRECATED: {deprecated_entity_description} {get_deprecated_tense(removal_version)} "
-        f"removed in version {removal_version}."
+        f"DEPRECATED: {entity} {get_deprecated_tense(removal_version)} removed in version "
+        f"{removal_version}."
     )
     if hint:
         msg += f"\n\n{hint}"
@@ -154,71 +162,39 @@ def warn_or_error(
 def deprecated_conditional(
     predicate: Callable[[], bool],
     removal_version: str,
-    entity_description: str,
-    hint_message: Optional[str] = None,
-    deprecation_start_version: Optional[str] = None,
+    entity: str,
+    hint: str | None,
+    *,
+    start_version: Optional[str] = None,
 ) -> None:
-    """Marks a certain configuration as deprecated.
-
-    The predicate is used to determine if that configuration is deprecated. It is a function that
-    will be called, if true, then the deprecation warning will issue.
-
-    :param predicate: A function that returns True if the deprecation warning should be on.
-    :param removal_version: The pants version which will remove the deprecated functionality.
-    :param entity_description: A description of the deprecated entity.
-    :param hint_message: An optional hint pointing to alternatives to the deprecation.
-    :raises DeprecationApplicationError if the deprecation is applied improperly.
-    """
+    """Mark something as deprecated if the predicate is true."""
     validate_deprecation_semver(removal_version, "removal version")
     if predicate():
-        warn_or_error(
-            removal_version,
-            entity_description,
-            hint_message,
-            deprecation_start_version=deprecation_start_version,
-        )
+        warn_or_error(removal_version, entity, hint, start_version=start_version)
 
 
 def deprecated(
     removal_version: str,
-    hint_message: Optional[str] = None,
-    subject: Optional[str] = None,
+    hint: str | None = None,
+    *,
+    start_version: str | None = None,
 ):
-    """Marks a function or method as deprecated.
-
-    A removal version must be supplied and it must be greater than the current 'pantsbuild.pants'
-    version.
-
-    When choosing a removal version there is a natural tension between the code-base, which benefits
-    from short deprecation cycles, and the user-base which may prefer to deal with deprecations less
-    frequently.  As a rule of thumb, if the hint message can fully convey corrective action
-    succinctly and you judge the impact to be on the small side (effects custom tasks as opposed to
-    effecting BUILD files), lean towards the next release version as the removal version; otherwise,
-    consider initiating a discussion to win consensus on a reasonable removal version.
-
-    :param removal_version: The pantsbuild.pants version which will remove the deprecated
-                                function.
-    :param hint_message: An optional hint pointing to alternatives to the deprecation.
-    :param subject: The name of the subject that has been deprecated for logging clarity. Defaults
-                        to the name of the decorated function/method.
-    :raises DeprecationApplicationError if the @deprecation is applied improperly.
-    """
+    """Mark a function or method as deprecated."""
     validate_deprecation_semver(removal_version, "removal version")
 
     def decorator(func):
         if not inspect.isfunction(func):
             raise BadDecoratorNestingError(
-                "The @deprecated decorator must be applied innermost of all " "decorators."
+                "The @deprecated decorator must be applied innermost of all decorators."
             )
-
-        func_full_name = "{}.{}".format(func.__module__, func.__name__)
 
         @wraps(func)
         def wrapper(*args, **kwargs):
             warn_or_error(
                 removal_version,
-                subject or func_full_name,
-                hint_message,
+                f"{func.__module__}.{func.__name__}()",
+                hint,
+                start_version=start_version,
             )
             return func(*args, **kwargs)
 
@@ -228,26 +204,13 @@ def deprecated(
 
 
 def deprecated_module(
-    removal_version: str,
-    hint_message: Optional[str] = None,
-    *,
-    deprecation_start_version: Optional[str] = None,
+    removal_version: str, hint: str | None, *, start_version: str | None = None
 ) -> None:
-    """Marks an entire module as deprecated.
+    """Mark an entire module as deprecated.
 
-    Add a call to this at the top of the deprecated module, and it will print a warning message
-    when the module is imported.
-
-    :param removal_version: The pantsbuild.pants version which will remove the deprecated
-                            function.
-    :param hint_message: An optional hint pointing to alternatives to the deprecation.
+    Add a call to this at the top of the deprecated module.
     """
-    warn_or_error(
-        removal_version,
-        "module",
-        hint_message,
-        deprecation_start_version=deprecation_start_version,
-    )
+    warn_or_error(removal_version, "module", hint, start_version=start_version)
 
 
 # TODO: old_container and new_container are both `OptionValueContainer`, but that causes a dep

--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -106,7 +106,7 @@ def validate_deprecation_semver(version_string: str, version_description: str) -
 def warn_or_error(
     removal_version: str,
     entity: str,
-    hint: Optional[str] = None,
+    hint: str | None,
     *,
     start_version: str | None = None,
     print_warning: bool = True,

--- a/src/python/pants/base/deprecated_test.py
+++ b/src/python/pants/base/deprecated_test.py
@@ -77,12 +77,12 @@ def test_deprecated_function_invalid() -> None:
 
 def test_deprecated_conditional(caplog) -> None:
     assert not caplog.records
-    deprecated_conditional(lambda: True, FUTURE_VERSION, "deprecated entity")
+    deprecated_conditional(lambda: True, FUTURE_VERSION, "deprecated entity", None)
     assert len(caplog.records) == 1
     assert "deprecated entity" in caplog.text
 
     caplog.clear()
-    deprecated_conditional(lambda: False, FUTURE_VERSION, "deprecated entity")
+    deprecated_conditional(lambda: False, FUTURE_VERSION, "deprecated entity", None)
     assert not caplog.records
 
 
@@ -96,7 +96,7 @@ def test_deprecated_module(caplog) -> None:
 
 def test_removal_version_bad() -> None:
     with pytest.raises(BadSemanticVersionError):
-        warn_or_error("a.a.a", "dummy description")
+        warn_or_error("a.a.a", "fake description", None)
 
     with pytest.raises(BadSemanticVersionError):
 
@@ -105,7 +105,7 @@ def test_removal_version_bad() -> None:
             pass
 
     with pytest.raises(BadSemanticVersionError):
-        warn_or_error(1.0, "dummy description")  # type: ignore[arg-type]
+        warn_or_error(1.0, "fake description", None)  # type: ignore[arg-type]
 
     with pytest.raises(BadSemanticVersionError):
 
@@ -114,7 +114,7 @@ def test_removal_version_bad() -> None:
             pass
 
     with pytest.raises(BadSemanticVersionError):
-        warn_or_error("1.a.0", "dummy description")
+        warn_or_error("1.a.0", "fake description", None)
 
     with pytest.raises(BadSemanticVersionError):
 
@@ -132,7 +132,7 @@ def test_removal_version_bad() -> None:
 @unittest.mock.patch("pants.base.deprecated.PANTS_SEMVER", Version(_FAKE_CUR_VERSION))
 def test_removal_version_same() -> None:
     with pytest.raises(CodeRemovedError):
-        warn_or_error(_FAKE_CUR_VERSION, "dummy description")
+        warn_or_error(_FAKE_CUR_VERSION, "fake description", None)
 
     @deprecated(_FAKE_CUR_VERSION)
     def test_func():
@@ -144,7 +144,7 @@ def test_removal_version_same() -> None:
 
 def test_removal_version_lower() -> None:
     with pytest.raises(CodeRemovedError):
-        warn_or_error("0.0.27.dev0", "dummy description")
+        warn_or_error("0.0.27.dev0", "fake description", None)
 
     @deprecated("0.0.27.dev0")
     def test_func():
@@ -156,20 +156,29 @@ def test_removal_version_lower() -> None:
 
 def test_deprecation_start_version_validation() -> None:
     with pytest.raises(BadSemanticVersionError):
-        warn_or_error(removal_version="1.0.0.dev0", entity="dummy", start_version="1.a.0")
+        warn_or_error(
+            removal_version="1.0.0.dev0", entity="fake", hint=None, start_version="1.a.0"
+        )
 
     with pytest.raises(InvalidSemanticVersionOrderingError):
-        warn_or_error(removal_version="0.0.0.dev0", entity="dummy", start_version="1.0.0.dev0")
+        warn_or_error(
+            removal_version="0.0.0.dev0", entity="fake", hint=None, start_version="1.0.0.dev0"
+        )
 
 
 @unittest.mock.patch("pants.base.deprecated.PANTS_SEMVER", Version(_FAKE_CUR_VERSION))
 def test_deprecation_start_period(caplog) -> None:
     with pytest.raises(CodeRemovedError):
-        warn_or_error(removal_version=_FAKE_CUR_VERSION, entity="demo", start_version="1.0.0.dev0")
+        warn_or_error(
+            removal_version=_FAKE_CUR_VERSION, entity="demo", hint=None, start_version="1.0.0.dev0"
+        )
 
     caplog.clear()
     warn_or_error(
-        removal_version="999.999.999.dev999", entity="demo", start_version=_FAKE_CUR_VERSION
+        removal_version="999.999.999.dev999",
+        entity="demo",
+        hint=None,
+        start_version=_FAKE_CUR_VERSION,
     )
     assert len(caplog.records) == 1
     assert "DEPRECATED: demo will be removed in version 999.999.999.dev999." in caplog.text

--- a/src/python/pants/base/deprecated_test.py
+++ b/src/python/pants/base/deprecated_test.py
@@ -28,7 +28,7 @@ FUTURE_VERSION = "9999.9.9.dev0"
 
 
 def test_deprecated_function(caplog) -> None:
-    @deprecated(FUTURE_VERSION, hint_message="A hint!")
+    @deprecated(FUTURE_VERSION, "A hint!")
     def deprecated_function():
         return "some val"
 
@@ -88,7 +88,7 @@ def test_deprecated_conditional(caplog) -> None:
 
 def test_deprecated_module(caplog) -> None:
     assert not caplog.records
-    deprecated_module(FUTURE_VERSION, hint_message="Do not use me.")
+    deprecated_module(FUTURE_VERSION, hint="Do not use me.")
     assert len(caplog.records) == 1
     assert "module will be removed" in caplog.text
     assert "Do not use me" in caplog.text
@@ -156,34 +156,20 @@ def test_removal_version_lower() -> None:
 
 def test_deprecation_start_version_validation() -> None:
     with pytest.raises(BadSemanticVersionError):
-        warn_or_error(
-            removal_version="1.0.0.dev0",
-            deprecated_entity_description="dummy",
-            deprecation_start_version="1.a.0",
-        )
+        warn_or_error(removal_version="1.0.0.dev0", entity="dummy", start_version="1.a.0")
 
     with pytest.raises(InvalidSemanticVersionOrderingError):
-        warn_or_error(
-            removal_version="0.0.0.dev0",
-            deprecated_entity_description="dummy",
-            deprecation_start_version="1.0.0.dev0",
-        )
+        warn_or_error(removal_version="0.0.0.dev0", entity="dummy", start_version="1.0.0.dev0")
 
 
 @unittest.mock.patch("pants.base.deprecated.PANTS_SEMVER", Version(_FAKE_CUR_VERSION))
 def test_deprecation_start_period(caplog) -> None:
     with pytest.raises(CodeRemovedError):
-        warn_or_error(
-            removal_version=_FAKE_CUR_VERSION,
-            deprecated_entity_description="demo",
-            deprecation_start_version="1.0.0.dev0",
-        )
+        warn_or_error(removal_version=_FAKE_CUR_VERSION, entity="demo", start_version="1.0.0.dev0")
 
     caplog.clear()
     warn_or_error(
-        removal_version="999.999.999.dev999",
-        deprecated_entity_description="demo",
-        deprecation_start_version=_FAKE_CUR_VERSION,
+        removal_version="999.999.999.dev999", entity="demo", start_version=_FAKE_CUR_VERSION
     )
     assert len(caplog.records) == 1
     assert "DEPRECATED: demo will be removed in version 999.999.999.dev999." in caplog.text
@@ -227,6 +213,6 @@ def test_resolve_conflicting_options() -> None:
 
 
 def test_is_deprecation_active() -> None:
-    assert is_deprecation_active(deprecation_start_version=None)
-    assert is_deprecation_active(deprecation_start_version="1.0.0")
-    assert not is_deprecation_active(deprecation_start_version=FUTURE_VERSION)
+    assert is_deprecation_active(start_version=None)
+    assert is_deprecation_active(start_version="1.0.0")
+    assert not is_deprecation_active(start_version=FUTURE_VERSION)

--- a/src/python/pants/base/deprecated_test.py
+++ b/src/python/pants/base/deprecated_test.py
@@ -156,9 +156,7 @@ def test_removal_version_lower() -> None:
 
 def test_deprecation_start_version_validation() -> None:
     with pytest.raises(BadSemanticVersionError):
-        warn_or_error(
-            removal_version="1.0.0.dev0", entity="fake", hint=None, start_version="1.a.0"
-        )
+        warn_or_error(removal_version="1.0.0.dev0", entity="fake", hint=None, start_version="1.a.0")
 
     with pytest.raises(InvalidSemanticVersionOrderingError):
         warn_or_error(

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -118,8 +118,8 @@ class Field:
     required: ClassVar[bool] = False
 
     # Subclasses may define these.
-    deprecated_removal_version: ClassVar[str | None] = None
-    deprecated_removal_hint: ClassVar[str | None] = None
+    removal_version: ClassVar[str | None] = None
+    removal_hint: ClassVar[str | None] = None
 
     @final
     def __init__(self, raw_value: Optional[Any], address: Address) -> None:
@@ -143,20 +143,17 @@ class Field:
 
     @classmethod
     def _check_deprecated(cls, raw_value: Optional[Any], address: Address) -> None:
-        if not cls.deprecated_removal_version or address.is_file_target or raw_value is None:
+        if not cls.removal_version or address.is_file_target or raw_value is None:
             return
-        if not cls.deprecated_removal_hint:
+        if not cls.removal_hint:
             raise ValueError(
-                f"You specified `deprecated_removal_version` for {cls}, but not "
-                "the class property `deprecated_removal_hint`."
+                f"You specified `removal_version` for {cls}, but not the class property "
+                "`removal_hint`."
             )
         warn_or_error(
-            removal_version=cls.deprecated_removal_version,
-            deprecated_entity_description=f"the {repr(cls.alias)} field",
-            hint=(
-                f"Using the `{cls.alias}` field in the target {address}. "
-                f"{cls.deprecated_removal_hint}"
-            ),
+            cls.removal_version,
+            entity=f"the {repr(cls.alias)} field",
+            hint=(f"Using the `{cls.alias}` field in the target {address}. " f"{cls.removal_hint}"),
         )
 
     def __repr__(self) -> str:
@@ -280,8 +277,8 @@ class Target:
     help: ClassVar[str]
 
     # Subclasses may define these.
-    deprecated_removal_version: ClassVar[str | None] = None
-    deprecated_removal_hint: ClassVar[str | None] = None
+    removal_version: ClassVar[str | None] = None
+    removal_hint: ClassVar[str | None] = None
 
     # These get calculated in the constructor
     address: Address
@@ -299,18 +296,17 @@ class Target:
         # rarely directly instantiate Targets and should instead use the engine to request them.
         union_membership: UnionMembership | None = None,
     ) -> None:
-        if self.deprecated_removal_version and not address.is_file_target:
-            if not self.deprecated_removal_hint:
+        if self.removal_version and not address.is_file_target:
+            if not self.removal_hint:
                 raise ValueError(
-                    f"You specified `deprecated_removal_version` for {self.__class__}, but not "
-                    "the class property `deprecated_removal_hint`."
+                    f"You specified `removal_version` for {self.__class__}, but not "
+                    "the class property `removal_hint`."
                 )
             warn_or_error(
-                removal_version=self.deprecated_removal_version,
-                deprecated_entity_description=f"the {repr(self.alias)} target type",
+                self.removal_version,
+                entity=f"the {repr(self.alias)} target type",
                 hint=(
-                    f"Using the `{self.alias}` target type for {address}. "
-                    f"{self.deprecated_removal_hint}"
+                    f"Using the `{self.alias}` target type for {address}. " f"{self.removal_hint}"
                 ),
             )
 

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -205,7 +205,7 @@ class TargetTypeHelpInfo:
             fields=tuple(
                 TargetFieldHelpInfo.create(field)
                 for field in target_type.class_field_types(union_membership=union_membership)
-                if not field.alias.startswith("_") and field.deprecated_removal_version is None
+                if not field.alias.startswith("_") and field.removal_version is None
             ),
         )
 
@@ -269,7 +269,7 @@ class HelpInfoExtracter:
         name_to_target_type_info = {
             alias: TargetTypeHelpInfo.create(target_type, union_membership=union_membership)
             for alias, target_type in registered_target_types.aliases_to_types.items()
-            if not alias.startswith("_") and target_type.deprecated_removal_version is None
+            if not alias.startswith("_") and target_type.removal_version is None
         }
 
         return AllHelpInfo(

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -355,7 +355,7 @@ class Options:
             if explicit_keys:
                 warn_or_error(
                     removal_version=si.removal_version,
-                    deprecated_entity_description=f"scope {scope}",
+                    entity=f"scope {scope}",
                     hint=si.removal_hint,
                 )
 
@@ -381,7 +381,7 @@ class Options:
                     removal_version=self.known_scope_to_info[
                         scope
                     ].deprecated_scope_removal_version,
-                    deprecated_entity_description=f"scope {deprecated_scope}",
+                    entity=f"scope {deprecated_scope}",
                     hint=f"Use scope {scope} instead (options: {', '.join(explicit_keys)})",
                 )
 

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -431,8 +431,8 @@ class Parser:
         if removal_version is not None:
             warn_or_error(
                 removal_version=removal_version,
-                deprecated_entity_description=f"option '{dest}' in {self._scope_str()}",
-                deprecation_start_version=kwargs.get("deprecation_start_version", None),
+                entity=f"option '{dest}' in {self._scope_str()}",
+                start_version=kwargs.get("deprecation_start_version", None),
                 hint=kwargs.get("removal_hint", None),
                 print_warning=print_warning,
             )

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -50,9 +50,9 @@ class ResolveAllConstraintsOption(Enum):
             bool_value = enum_value is not cls.NEVER
             deprecated_conditional(
                 lambda: True,
-                removal_version="2.6.0.dev0",
-                entity_description="python-setup resolve_all_constraints non boolean values",
-                hint_message=f"Instead of {enum_value.value!r} use {bool_value!r}.",
+                "2.6.0.dev0",
+                entity="python-setup resolve_all_constraints non boolean values",
+                hint=f"Instead of {enum_value.value!r} use {bool_value!r}.",
             )
             return bool_value
 


### PR DESCRIPTION
Many of our deprecation utilities were using subtly different arguments, which adds a lot of unnecessary cognitive load. Likewise, some of the names were unnecessarily chatty.

[ci skip-rust]
[ci skip-build-wheels]