### PR TITLE
upgrade to Rust v1.52.0

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "beta-2021-04-07"
+channel = "1.52.0"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
Upgrade to Rust v1.52.0.

https://blog.rust-lang.org/2021/05/06/Rust-1.52.0.html

[ci skip-build-wheels]