### PR TITLE
Auth plugins can inspect the prior result, set an expiration, and override `--remote-{store,execution}-address`

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -33,7 +33,7 @@ from pants.init.engine_initializer import EngineInitializer, GraphScheduler, Gra
 from pants.init.options_initializer import OptionsInitializer
 from pants.init.specs_calculator import calculate_specs
 from pants.option.arg_splitter import HelpRequest
-from pants.option.global_options import DynamicRemoteExecutionOptions
+from pants.option.global_options import DynamicRemoteOptions
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.util.contextutil import maybe_profiled
@@ -76,11 +76,11 @@ class LocalPantsRunner:
     ) -> GraphSession:
         native_engine.maybe_set_panic_handler()
         if scheduler is None:
-            dynamic_execution_options = DynamicRemoteExecutionOptions.from_options(options, env)
+            dynamic_remote_options, _ = DynamicRemoteOptions.from_options(options, env)
             bootstrap_options = options.bootstrap_option_values()
             assert bootstrap_options is not None
             scheduler = EngineInitializer.setup_graph(
-                bootstrap_options, build_config, dynamic_execution_options
+                bootstrap_options, build_config, dynamic_remote_options
             )
         with options_initializer.handle_unknown_flags(options_bootstrapper, env, raise_=True):
             global_options = options.for_global_scope()

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -31,7 +31,7 @@ from pants.engine.unions import UnionMembership
 from pants.init import specs_calculator
 from pants.option.global_options import (
     DEFAULT_EXECUTION_OPTIONS,
-    DynamicRemoteExecutionOptions,
+    DynamicRemoteOptions,
     ExecutionOptions,
     GlobalOptions,
     LocalStoreOptions,
@@ -170,14 +170,12 @@ class EngineInitializer:
     def setup_graph(
         bootstrap_options: OptionValueContainer,
         build_configuration: BuildConfiguration,
-        dynamic_execution_options: DynamicRemoteExecutionOptions,
+        dynamic_remote_options: DynamicRemoteOptions,
         executor: PyExecutor | None = None,
     ) -> GraphScheduler:
         build_root = get_buildroot()
         executor = executor or GlobalOptions.create_py_executor(bootstrap_options)
-        execution_options = ExecutionOptions.from_options(
-            bootstrap_options, dynamic_execution_options
-        )
+        execution_options = ExecutionOptions.from_options(bootstrap_options, dynamic_remote_options)
         local_store_options = LocalStoreOptions.from_options(bootstrap_options)
         return EngineInitializer.setup_graph_extended(
             build_configuration,

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -24,7 +24,7 @@ from pants.init.extension_loader import (
 from pants.init.plugin_resolver import PluginResolver
 from pants.init.plugin_resolver import rules as plugin_resolver_rules
 from pants.option.errors import UnknownFlagsError
-from pants.option.global_options import DynamicRemoteExecutionOptions
+from pants.option.global_options import DynamicRemoteOptions
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
 
@@ -74,7 +74,7 @@ def create_bootstrap_scheduler(
         EngineInitializer.setup_graph(
             options_bootstrapper.bootstrap_options.for_global_scope(),
             bc_builder.create(),
-            DynamicRemoteExecutionOptions.disabled(),
+            DynamicRemoteOptions.disabled(),
             executor,
         ).scheduler
     )

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -107,14 +107,32 @@ class AuthPluginResult:
     the merge strategy if your plugin sets conflicting headers. Usually, you will want to preserve
     the `initial_store_headers` and `initial_execution_headers` passed to the plugin.
 
-    If set, the returned `instance_name` will override by `--remote-instance-name`.
+    If set, the returned `instance_name` will override by `--remote-instance-name`, `store_address`
+    will override `--remote-store-address`, and `execution_address` will override
+    `--remote-execution-address`. The store address and execution address must be prefixed with
+    `grpc://` or `grpcs://`.
     """
 
     state: AuthPluginState
     store_headers: dict[str, str]
     execution_headers: dict[str, str]
+    store_address: str | None = None
+    execution_address: str | None = None
     instance_name: str | None = None
     expiration: datetime | None = None
+
+    def __post_init__(self) -> None:
+        def assert_valid_address(addr: str | None, field_name: str) -> None:
+            valid_schemes = [f"{scheme}://" for scheme in ("grpc", "grpcs")]
+            if addr and not any(addr.startswith(scheme) for scheme in valid_schemes):
+                raise ValueError(
+                    f"Invalid `{field_name}` in `AuthPluginResult` returned from "
+                    f"`--remote-auth-plugin`. Must start with `grpc://` or `grpcs://`, but was "
+                    f"{addr}."
+                )
+
+        assert_valid_address(self.store_address, "store_address")
+        assert_valid_address(self.execution_address, "execution_address")
 
     @property
     def is_available(self) -> bool:
@@ -125,22 +143,26 @@ class AuthPluginResult:
 class DynamicRemoteOptions:
     """Options related to remote execution of processes which are computed dynamically."""
 
-    remote_execution: bool
-    remote_cache_read: bool
-    remote_cache_write: bool
-    remote_instance_name: str | None
-    remote_store_headers: dict[str, str]
-    remote_execution_headers: dict[str, str]
+    execution: bool
+    cache_read: bool
+    cache_write: bool
+    instance_name: str | None
+    store_address: str | None
+    execution_address: str | None
+    store_headers: dict[str, str]
+    execution_headers: dict[str, str]
 
     @classmethod
     def disabled(cls) -> DynamicRemoteOptions:
         return DynamicRemoteOptions(
-            remote_execution=False,
-            remote_cache_read=False,
-            remote_cache_write=False,
-            remote_instance_name=None,
-            remote_store_headers={},
-            remote_execution_headers={},
+            execution=False,
+            cache_read=False,
+            cache_write=False,
+            instance_name=None,
+            store_address=None,
+            execution_address=None,
+            store_headers={},
+            execution_headers={},
         )
 
     @classmethod
@@ -149,30 +171,17 @@ class DynamicRemoteOptions:
         full_options: Options,
         env: CompleteEnvironment,
         prior_result: AuthPluginResult | None = None,
-        *,
-        local_only: bool = False,
     ) -> tuple[DynamicRemoteOptions, AuthPluginResult | None]:
-        if local_only:
-            disabled_opts = DynamicRemoteOptions(
-                remote_execution=False,
-                remote_cache_read=False,
-                remote_cache_write=False,
-                remote_instance_name=None,
-                remote_store_headers={},
-                remote_execution_headers={},
-            )
-            return disabled_opts, None
-
         bootstrap_options = full_options.bootstrap_option_values()
         assert bootstrap_options is not None
-        remote_execution = cast(bool, bootstrap_options.remote_execution)
-        remote_cache_read = cast(bool, bootstrap_options.remote_cache_read)
-        remote_cache_write = cast(bool, bootstrap_options.remote_cache_write)
-        remote_instance_name = cast("str | None", bootstrap_options.remote_instance_name)
-        remote_execution_headers = cast(
-            "dict[str, str]", bootstrap_options.remote_execution_headers
-        )
-        remote_store_headers = cast("dict[str, str]", bootstrap_options.remote_store_headers)
+        execution = cast(bool, bootstrap_options.remote_execution)
+        cache_read = cast(bool, bootstrap_options.remote_cache_read)
+        cache_write = cast(bool, bootstrap_options.remote_cache_write)
+        store_address = cast("str | None", bootstrap_options.remote_store_address)
+        execution_address = cast("str | None", bootstrap_options.remote_execution_address)
+        instance_name = cast("str | None", bootstrap_options.remote_instance_name)
+        execution_headers = cast("dict[str, str]", bootstrap_options.remote_execution_headers)
+        store_headers = cast("dict[str, str]", bootstrap_options.remote_store_headers)
 
         if bootstrap_options.remote_oauth_bearer_token_path:
             oauth_token = (
@@ -184,14 +193,14 @@ class DynamicRemoteOptions:
                     "must not contain multiple lines."
                 )
             token_header = {"authorization": f"Bearer {oauth_token}"}
-            remote_execution_headers.update(token_header)
-            remote_store_headers.update(token_header)
+            execution_headers.update(token_header)
+            store_headers.update(token_header)
 
         auth_plugin_result: AuthPluginResult | None = None
         if (
             bootstrap_options.remote_auth_plugin
             and bootstrap_options.remote_auth_plugin.strip()
-            and (remote_execution or remote_cache_read or remote_cache_write)
+            and (execution or cache_read or cache_write)
         ):
             if ":" not in bootstrap_options.remote_auth_plugin:
                 raise OptionsError(
@@ -205,8 +214,8 @@ class DynamicRemoteOptions:
             auth_plugin_result = cast(
                 AuthPluginResult,
                 auth_plugin_func(
-                    initial_execution_headers=remote_execution_headers,
-                    initial_store_headers=remote_store_headers,
+                    initial_execution_headers=execution_headers,
+                    initial_store_headers=store_headers,
                     options=full_options,
                     env=dict(env),
                     prior_result=prior_result,
@@ -218,33 +227,70 @@ class DynamicRemoteOptions:
                     "Disabling remote caching and remote execution because authentication was not "
                     "available via the plugin from `--remote-auth-plugin`."
                 )
-                remote_execution = False
-                remote_cache_read = False
-                remote_cache_write = False
+                execution = False
+                cache_read = False
+                cache_write = False
             else:
                 logger.debug(
                     "`--remote-auth-plugin` succeeded. Remote caching/execution will be attempted."
                 )
-                remote_execution_headers = auth_plugin_result.execution_headers
-                remote_store_headers = auth_plugin_result.store_headers
+                execution_headers = auth_plugin_result.execution_headers
+                store_headers = auth_plugin_result.store_headers
+                overridden_opt_log = (
+                    "Overriding `{}` to instead be {} due to the plugin from "
+                    "`--remote-auth-plugin`."
+                )
                 if (
                     auth_plugin_result.instance_name is not None
-                    and auth_plugin_result.instance_name != remote_instance_name
+                    and auth_plugin_result.instance_name != instance_name
                 ):
                     logger.debug(
-                        f"Overriding `--remote-instance-name={repr(remote_instance_name)}` to "
-                        f"instead be {repr(auth_plugin_result.instance_name)} due to the plugin "
-                        "from `--remote-auth-plugin`."
+                        overridden_opt_log.format(
+                            f"--remote-instance-name={repr(instance_name)}",
+                            repr(auth_plugin_result.instance_name),
+                        )
                     )
-                    remote_instance_name = auth_plugin_result.instance_name
+                    instance_name = auth_plugin_result.instance_name
+                if (
+                    auth_plugin_result.store_address is not None
+                    and auth_plugin_result.store_address != store_address
+                ):
+                    logger.debug(
+                        overridden_opt_log.format(
+                            f"--remote-store-address={repr(store_address)}",
+                            repr(auth_plugin_result.store_address),
+                        )
+                    )
+                    store_address = auth_plugin_result.store_address
+                if (
+                    auth_plugin_result.execution_address is not None
+                    and auth_plugin_result.execution_address != execution_address
+                ):
+                    logger.debug(
+                        overridden_opt_log.format(
+                            f"--remote-execution-address={repr(execution_address)}",
+                            repr(auth_plugin_result.execution_address),
+                        )
+                    )
+                    execution_address = auth_plugin_result.execution_address
+
+        # NB: Tonic expects the schemes `http` and `https`, even though they are gRPC requests.
+        # We validate that users set `grpc` and `grpcs` in the options system / plugin for clarity,
+        # but then normalize to `http`/`https`.
+        execution_address = (
+            re.sub(r"^grpc", "http", execution_address) if execution_address else None
+        )
+        store_address = re.sub(r"^grpc", "http", store_address) if store_address else None
 
         opts = DynamicRemoteOptions(
-            remote_execution=remote_execution,
-            remote_cache_read=remote_cache_read,
-            remote_cache_write=remote_cache_write,
-            remote_instance_name=remote_instance_name,
-            remote_store_headers=remote_store_headers,
-            remote_execution_headers=remote_execution_headers,
+            execution=execution,
+            cache_read=cache_read,
+            cache_write=cache_write,
+            instance_name=instance_name,
+            store_address=store_address,
+            execution_address=execution_address,
+            store_headers=store_headers,
+            execution_headers=execution_headers,
         )
         return opts, auth_plugin_result
 
@@ -290,27 +336,13 @@ class ExecutionOptions:
         bootstrap_options: OptionValueContainer,
         dynamic_remote_options: DynamicRemoteOptions,
     ) -> ExecutionOptions:
-        # NB: Tonic expects the schemes `http` and `https`, even though they are gRPC requests.
-        # We validate that users set `grpc` and `grpcs` in the options system for clarity, but then
-        # normalize to `http`/`https`.
-        remote_execution_address = (
-            re.sub(r"^grpc", "http", bootstrap_options.remote_execution_address)
-            if bootstrap_options.remote_execution_address
-            else None
-        )
-        remote_store_address = (
-            re.sub(r"^grpc", "http", bootstrap_options.remote_store_address)
-            if bootstrap_options.remote_store_address
-            else None
-        )
-
         return cls(
             # Remote execution strategy.
-            remote_execution=dynamic_remote_options.remote_execution,
-            remote_cache_read=dynamic_remote_options.remote_cache_read,
-            remote_cache_write=dynamic_remote_options.remote_cache_write,
+            remote_execution=dynamic_remote_options.execution,
+            remote_cache_read=dynamic_remote_options.cache_read,
+            remote_cache_write=dynamic_remote_options.cache_write,
             # General remote setup.
-            remote_instance_name=dynamic_remote_options.remote_instance_name,
+            remote_instance_name=dynamic_remote_options.instance_name,
             remote_ca_certs_path=bootstrap_options.remote_ca_certs_path,
             # Process execution setup.
             process_execution_local_cache=bootstrap_options.process_execution_local_cache,
@@ -319,8 +351,8 @@ class ExecutionOptions:
             process_execution_local_cleanup=bootstrap_options.process_execution_local_cleanup,
             process_execution_cache_namespace=bootstrap_options.process_execution_cache_namespace,
             # Remote store setup.
-            remote_store_address=remote_store_address,
-            remote_store_headers=dynamic_remote_options.remote_store_headers,
+            remote_store_address=dynamic_remote_options.store_address,
+            remote_store_headers=dynamic_remote_options.store_headers,
             remote_store_chunk_bytes=bootstrap_options.remote_store_chunk_bytes,
             remote_store_chunk_upload_timeout_seconds=bootstrap_options.remote_store_chunk_upload_timeout_seconds,
             remote_store_rpc_retries=bootstrap_options.remote_store_rpc_retries,
@@ -328,9 +360,9 @@ class ExecutionOptions:
             remote_cache_eager_fetch=bootstrap_options.remote_cache_eager_fetch,
             remote_cache_warnings=bootstrap_options.remote_cache_warnings,
             # Remote execution setup.
-            remote_execution_address=remote_execution_address,
+            remote_execution_address=dynamic_remote_options.execution_address,
             remote_execution_extra_platform_properties=bootstrap_options.remote_execution_extra_platform_properties,
-            remote_execution_headers=dynamic_remote_options.remote_execution_headers,
+            remote_execution_headers=dynamic_remote_options.execution_headers,
             remote_execution_overall_deadline_secs=bootstrap_options.remote_execution_overall_deadline_secs,
         )
 

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -36,7 +36,7 @@ from pants.engine.unions import UnionMembership
 from pants.init.engine_initializer import EngineInitializer
 from pants.init.logging import initialize_stdio, stdio_destination
 from pants.option.global_options import (
-    DynamicRemoteExecutionOptions,
+    DynamicRemoteOptions,
     ExecutionOptions,
     GlobalOptions,
     LocalStoreOptions,
@@ -144,9 +144,7 @@ class RuleRunner:
         options = self.options_bootstrapper.full_options(self.build_config)
         global_options = self.options_bootstrapper.bootstrap_options.for_global_scope()
 
-        dynamic_execution_options = DynamicRemoteExecutionOptions.from_options(
-            options, self.environment
-        )
+        dynamic_remote_options, _ = DynamicRemoteOptions.from_options(options, self.environment)
         local_store_options = LocalStoreOptions.from_options(global_options)
         if isolated_local_store:
             if root_dir:
@@ -171,9 +169,7 @@ class RuleRunner:
             build_root=self.build_root,
             build_configuration=self.build_config,
             executor=_EXECUTOR,
-            execution_options=ExecutionOptions.from_options(
-                global_options, dynamic_execution_options
-            ),
+            execution_options=ExecutionOptions.from_options(global_options, dynamic_remote_options),
             ca_certs_path=ca_certs_path,
             native_engine_visualize_to=None,
         ).new_session(

--- a/tests/python/pants_test/pantsd/pantsd_integration_test.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test.py
@@ -4,9 +4,11 @@
 import glob
 import os
 import signal
+import sys
 import threading
 import time
 import unittest
+from pathlib import Path
 from textwrap import dedent
 from typing import List, Optional
 
@@ -99,8 +101,88 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
                 ctx.runner([f"--pantsd-invalidation-globs=ridiculous{idx}", "help"])
                 next_pid = ctx.checker.assert_started()
                 if last_pid is not None:
-                    self.assertNotEqual(last_pid, next_pid)
+                    assert last_pid != next_pid
                 last_pid = next_pid
+
+    def test_pantsd_lifecycle_invalidation_from_auth_plugin(self) -> None:
+        """If the dynamic remote options changed, we should reinitialize the scheduler but not
+        restart the daemon."""
+        plugin = dedent(
+            """\
+            from datetime import datetime
+            from pants.option.global_options import AuthPluginState, AuthPluginResult
+
+            def auth_func(
+                initial_execution_headers, initial_store_headers, options, env, prior_result
+            ):
+                # If the first run, don't change the headers, but use the `expiration` as a
+                # sentinel so that future runs know to change it.
+                if prior_result is None:
+                    return AuthPluginResult(
+                        state=AuthPluginState.OK,
+                        execution_headers=initial_execution_headers,
+                        store_headers=initial_store_headers,
+                        expiration=datetime.min,
+                    )
+
+                # If second run, still don't change the headers, but update the `expiration` as a
+                # sentinel for the next run.
+                if prior_result.expiration == datetime.min:
+                    return AuthPluginResult(
+                        state=AuthPluginState.OK,
+                        execution_headers=initial_execution_headers,
+                        store_headers=initial_store_headers,
+                        expiration=datetime.max,
+                    )
+
+                # Finally, on the third run, change the headers.
+                if prior_result.expiration == datetime.max:
+                    return AuthPluginResult(
+                        state=AuthPluginState.OK,
+                        execution_headers={"custom": "foo"},
+                        store_headers=initial_store_headers,
+                    )
+
+                # If there was a fourth run, or `prior_result` didn't preserve the `expiration`
+                # field properly, error.
+                raise AssertionError(f"Unexpected prior_result: {prior_result}")
+            """
+        )
+        with self.pantsd_successful_run_context() as ctx:
+            # This very hackily traverses up to the process's parent directory, rather than the
+            # workdir.
+            plugin_dir = Path(ctx.workdir).parent.parent / "auth_plugin"
+            plugin_dir.mkdir(parents=True, exist_ok=True)
+            (plugin_dir / "__init__.py").touch()
+            (plugin_dir / "auth.py").write_text(plugin)
+
+            def run_auth_plugin() -> tuple[str, int]:
+                sys.path.append(str(plugin_dir))
+                result = ctx.runner(
+                    [
+                        "--pythonpath=auth_plugin",
+                        "--remote-auth-plugin=auth_plugin.auth:auth_func",
+                        "--remote-cache-read",
+                        "--remote-store-address=grpc://fake",
+                        "help",
+                    ]
+                )
+                sys.path.pop()
+                return result.stderr, ctx.checker.assert_started()
+
+            first_stderr, first_pid = run_auth_plugin()
+            assert (
+                "Initializing scheduler" in first_stderr
+                or "reinitializing scheduler" in first_stderr
+            )
+
+            second_stderr, second_pid = run_auth_plugin()
+            assert "reinitializing scheduler" not in second_stderr
+            assert first_pid == second_pid
+
+            third_stderr, third_pid = run_auth_plugin()
+            assert "reinitializing scheduler" in third_stderr
+            assert second_pid == third_pid
 
     def test_pantsd_lifecycle_non_invalidation(self):
         with self.pantsd_successful_run_context() as ctx:


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/12020 results in auth plugins being executed every run of `./pants`, even when Pantsd is used. 

While correct, that is a problem for auth plugins like Toolchain's that are stateless and give back a new token every time. Getting a new token changes the `store_headers`, which changes the bootstrap options sent over FFI to Rust to create the scheduler; we must reinitialize the scheduler in this case, which is slow.

Instead, we now pass `prior_result: AuthPluginResult | None` to the auth plugin hook, which allows plugins to recycle prior results if they'd like. We also allow plugins to set `expiration` on the `AuthPluginResult`, which is particularly useful for plugins deciding to recycle a token vs. generate a new one. 

Finally, we allow the plugin to override `--remote-store-address` and `--remote-execution-address`, which isn't totally related to this PR but has been requested as a feature and is done here to reduce churn in the API.

Combined, this PR allows plugin authors to avoid the problem of invalidating Pantsd every run, while avoiding the problem that Pantsd blocked every regenerating tokens until a restart. Closes https://github.com/pantsbuild/pants/issues/12018.

[ci skip-rust]
[ci skip-build-wheels]