### PR TITLE
Remove deprecated `[pytest].config` in favor of `[pytest].config_discovery`

### DIFF
--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -7,7 +7,7 @@ import os.path
 from typing import Iterable, cast
 
 from pants.core.util_rules.config_files import ConfigFilesRequest
-from pants.option.custom_types import file_option, shell_str
+from pants.option.custom_types import shell_str
 from pants.option.subsystem import Subsystem
 
 
@@ -99,18 +99,6 @@ class PyTest(Subsystem):
             ),
         )
         register(
-            "--config",
-            type=file_option,
-            default=None,
-            advanced=True,
-            help="Path to pytest.ini or alternative Pytest config file.",
-            removal_version="2.6.0.dev0",
-            removal_hint=(
-                "Pants now auto-discovers config files, so there is no need to set "
-                "`[pytest].config` if `[pytest].config_discovery` is enabled (the default)."
-            ),
-        )
-        register(
             "--config-discovery",
             type=bool,
             default=True,
@@ -151,8 +139,6 @@ class PyTest(Subsystem):
             check_content[os.path.join(d, "setup.cfg")] = b"[tool:pytest]"
 
         return ConfigFilesRequest(
-            specified=cast("str | None", self.options.config),
-            specified_option_name=f"[{self.options_scope}].config",
             discovery=cast(bool, self.options.config_discovery),
             check_existence=check_existence,
             check_content=check_content,


### PR DESCRIPTION
Because Pytest does not have a `--config`/`--rcfile` option to support custom config locations, it is misleading for us to have a `--config` option, which is now only intended for custom file locations thanks to config discovery.

[ci skip-build-wheels]