### PR TITLE
[internal] Add job & workflow name to env variables used to request r…

### DIFF
--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -27,6 +27,7 @@ org = "pantsbuild"
 ci_env_variables = [
   "TRAVIS", "TRAVIS_JOB_ID", "TRAVIS_BUILD_ID", "TRAVIS_PULL_REQUEST", "TRAVIS_BUILD_WEB_URL",
   "GITHUB_ACTIONS", "GITHUB_RUN_ID", "GITHUB_REF", "GITHUB_EVENT_NAME", "GITHUB_SHA", "GITHUB_REPOSITORY",
+  "GITHUB_WORKFLOW", "GITHUB_JOB",  # Temporary, just to help debugging issue w/ restricted tokens on scehduled builds
 ]
 restricted_token_matches =  """{
   'GITHUB_REPOSITORY': 'pantsbuild/pants', 


### PR DESCRIPTION
…estricted access tokens.

We are still seeing restricted access tokens being requested for scheduled Github Action runs, this shouldn't happen since those runs should have a token available via repo secrets.
this will upload the values of those env variables to the server and will help determines which runs are missing that secret.