### PR TITLE
upgrade to Rust v1.52.1

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.52.0"
+channel = "1.52.1"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
Upgrade to Rust v1.52.1 which works "around a bug in incremental compilation which was made into a compiler error in 1.52.0." https://blog.rust-lang.org/2021/05/10/Rust-1.52.1.html