### PR TITLE
[internal] Upgrade toolchain pants plugin to 0.10.0

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -20,7 +20,7 @@ backend_packages.add = [
 ]
 plugins = [
   "hdrhistogram",  # For use with `--stats-log`.
-  "toolchain.pants.plugin==0.9.1",
+  "toolchain.pants.plugin==0.10.0",
 ]
 
 # The invalidation globs cover the PYTHONPATH by default, but we exclude some files that are on the


### PR DESCRIPTION
* toolchain_auth_plugin (used for remote_auth_plugin) now accepts **kwargs so arguments can be added without breaking the interface.
* Fix headers handling in the remoting auth plugin to also support remote execution headers and to not override all headers set outside the plugin.
* Remove dependency on python-dateutil
* Avoid trying to load token from an environment variable unless auth.from_env_var is explicitly set



