### PR TITLE
[internal] Upgrade toolchain pants plugin to 0.10.0 (#12044)

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -20,7 +20,7 @@ backend_packages.add = [
 ]
 plugins = [
   "hdrhistogram",  # For use with `--stats-log`.
-  "toolchain.pants.plugin==0.9.1",
+  "toolchain.pants.plugin==0.10.0",
 ]
 
 # The invalidation globs cover the PYTHONPATH by default, but we exclude some files that are on the


### PR DESCRIPTION
Cherry-picking to unblock cherry pick of https://github.com/pantsbuild/pants/pull/12029.