### PR TITLE
[internal] Always upload Pants log in CI

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -56,7 +56,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/beta-2021-04-07-*
+        path: '~/.rustup/toolchains/1.52.1-*
 
           ~/.rustup/update-hashes
 
@@ -119,7 +119,8 @@ jobs:
         ./pants help subsystems
 
         '
-    - name: Upload pants.log
+    - if: always()
+      name: Upload pants.log
       uses: actions/upload-artifact@v2
       with:
         name: pants-log-bootstrap-linux
@@ -195,7 +196,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/beta-2021-04-07-*
+        path: '~/.rustup/toolchains/1.52.1-*
 
           ~/.rustup/update-hashes
 
@@ -328,7 +329,8 @@ jobs:
         ./pants lint typecheck ::
 
         '
-    - name: Upload pants.log
+    - if: always()
+      name: Upload pants.log
       uses: actions/upload-artifact@v2
       with:
         name: pants-log-lint
@@ -403,7 +405,8 @@ jobs:
       run: './pants test ::
 
         '
-    - name: Upload pants.log
+    - if: always()
+      name: Upload pants.log
       uses: actions/upload-artifact@v2
       with:
         name: pants-log-python-test-linux
@@ -480,7 +483,8 @@ jobs:
       run: './pants --tag=+platform_specific_behavior test ::
 
         '
-    - name: Upload pants.log
+    - if: always()
+      name: Upload pants.log
       uses: actions/upload-artifact@v2
       with:
         name: pants-log-python-test-macos

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,7 +56,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/beta-2021-04-07-*
+        path: '~/.rustup/toolchains/1.52.1-*
 
           ~/.rustup/update-hashes
 
@@ -119,7 +119,8 @@ jobs:
         ./pants help subsystems
 
         '
-    - name: Upload pants.log
+    - if: always()
+      name: Upload pants.log
       uses: actions/upload-artifact@v2
       with:
         name: pants-log-bootstrap-linux
@@ -194,7 +195,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/beta-2021-04-07-*
+        path: '~/.rustup/toolchains/1.52.1-*
 
           ~/.rustup/update-hashes
 
@@ -322,7 +323,8 @@ jobs:
         ./build-support/bin/release.sh -f
 
         '
-    - name: Upload pants.log
+    - if: always()
+      name: Upload pants.log
       uses: actions/upload-artifact@v2
       with:
         name: pants-log-wheels-linux
@@ -374,7 +376,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/beta-2021-04-07-*
+        path: '~/.rustup/toolchains/1.52.1-*
 
           ~/.rustup/update-hashes
 
@@ -412,7 +414,8 @@ jobs:
         ./build-support/bin/release.sh -f
 
         '
-    - name: Upload pants.log
+    - if: always()
+      name: Upload pants.log
       uses: actions/upload-artifact@v2
       with:
         name: pants-log-wheels-macos
@@ -488,7 +491,8 @@ jobs:
         ./pants lint typecheck ::
 
         '
-    - name: Upload pants.log
+    - if: always()
+      name: Upload pants.log
       uses: actions/upload-artifact@v2
       with:
         name: pants-log-lint
@@ -562,7 +566,8 @@ jobs:
       run: './pants test ::
 
         '
-    - name: Upload pants.log
+    - if: always()
+      name: Upload pants.log
       uses: actions/upload-artifact@v2
       with:
         name: pants-log-python-test-linux
@@ -638,7 +643,8 @@ jobs:
       run: './pants --tag=+platform_specific_behavior test ::
 
         '
-    - name: Upload pants.log
+    - if: always()
+      name: Upload pants.log
       uses: actions/upload-artifact@v2
       with:
         name: pants-log-python-test-macos

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -247,6 +247,7 @@ def upload_log_artifacts(name: str) -> Step:
     return {
         "name": "Upload pants.log",
         "uses": "actions/upload-artifact@v2",
+        "if": "always()",
         "with": {"name": f"pants-log-{name}", "path": ".pants.d/pants.log"},
     }
 


### PR DESCRIPTION
It's not being uploaded on CI failures, even though that is often the most useful time for the log, e.g. to debug https://github.com/pantsbuild/pants/issues/11926