### PR TITLE
Add pex_binary support for --no-strip-pex-env.

### DIFF
--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -19,6 +19,7 @@ from pants.backend.python.target_types import (
 from pants.backend.python.target_types import PexPlatformsField as PythonPlatformsField
 from pants.backend.python.target_types import (
     PexShebangField,
+    PexStripEnvField,
     PexZipSafeField,
     ResolvedPexEntryPoint,
     ResolvePexEntryPointRequest,
@@ -62,6 +63,7 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
     inherit_path: PexInheritPathField
     shebang: PexShebangField
     zip_safe: PexZipSafeField
+    strip_env: PexStripEnvField
     platforms: PythonPlatformsField
     execution_mode: PexExecutionModeField
     include_tools: PexIncludeToolsField
@@ -84,6 +86,8 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
             args.append(f"--python-shebang={self.shebang.value}")
         if self.zip_safe.value is False:
             args.append("--not-zip-safe")
+        if self.strip_env.value is False:
+            args.append("--no-strip-pex-env")
         if self._execution_mode is PexExecutionMode.UNZIP:
             args.append("--unzip")
         if self._execution_mode is PexExecutionMode.VENV:

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -277,6 +277,19 @@ class PexZipSafeField(BoolField):
     )
 
 
+class PexStripEnvField(BoolField):
+    alias = "strip_pex_env"
+    default = True
+    help = (
+        "Whether or not to strip the PEX runtime environment of `PEX*` environment variables.\n\n"
+        "Most applications have no need for the `PEX*` environment variables that are used to "
+        "control PEX startup; so these variables are scrubbed from the environment by Pex before "
+        "transferring control to the application by default. This prevents any subprocesses that "
+        "happen to execute other PEX files from inheriting these control knob values since most "
+        "would be undesired; e.g.: PEX_MODULE or PEX_PATH."
+    )
+
+
 class PexAlwaysWriteCacheField(BoolField):
     alias = "always_write_cache"
     default = False


### PR DESCRIPTION
Not many PEX files will need this to operate correctly, but it was an
omission brought to attention by #12057.

[ci skip-rust]
[ci skip-build-wheels]