### PR TITLE
Fix Python run for apps that re-exec themselves. (#12060)

### DIFF
--- a/src/python/pants/backend/python/goals/run_pex_binary.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary.py
@@ -58,7 +58,13 @@ async def create_pex_binary_run_request(
         PexRequest(
             output_filename=output_filename,
             interpreter_constraints=requirements_pex_request.interpreter_constraints,
-            additional_args=field_set.generate_additional_args(pex_binary_defaults),
+            additional_args=(
+                *field_set.generate_additional_args(pex_binary_defaults),
+                # N.B.: Since we cobble together the runtime environment via PEX_PATH and
+                # PEX_EXTRA_SYS_PATH below, it's important for any app that re-executes itself that
+                # these environment variables are not stripped.
+                "--no-strip-pex-env",
+            ),
             internal_only=True,
             # Note that the entry point file is not in the PEX itself. It's loaded by setting
             # `PEX_EXTRA_SYS_PATH`.


### PR DESCRIPTION
Previously these apps would fail to find their 1st party sources and
3rd party dependencies upon re-exec due to default `PEX*` enviornment
variable stripping.

Add a failing test and fix.

Fixes #12057

(cherry picked from commit 1577b8dfa282b6339717767272246fe80439b57e)

[ci skip-rust]
[ci skip-build-wheels]