### PR TITLE
[internal] Upgrade toolchain pants plugin to 0.11.0

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -20,7 +20,7 @@ backend_packages.add = [
 ]
 plugins = [
   "hdrhistogram",  # For use with `--stats-log`.
-  "toolchain.pants.plugin==0.10.0",
+  "toolchain.pants.plugin==0.11.0",
 ]
 
 # The invalidation globs cover the PYTHONPATH by default, but we exclude some files that are on the


### PR DESCRIPTION
* Added support for new remoting auth plugin APIs introdced in https://github.com/pantsbuild/pants/pull/12029