### PR TITLE
Fix `module_mapping` to work regardless of capitalization and `-` vs …`_` (Cherry-pick of #12068)

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -1,28 +1,23 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-# notice: using sets here to ensure the mapping is hashable
+# NB: The project names must follow the naming scheme at
+#  https://www.python.org/dev/peps/pep-0503/#normalized-names.
 DEFAULT_MODULE_MAPPING = {
     "ansicolors": ("colors",),
+    "apache-airflow": ("airflow",),
     "attrs": ("attr",),
     "beautifulsoup4": ("bs4",),
     "djangorestframework": ("rest_framework",),
     "enum34": ("enum",),
-    "paho_mqtt": ("paho",),
+    "paho-mqtt": ("paho",),
     "protobuf": ("google.protobuf",),
     "pycrypto": ("Crypto",),
     "pyopenssl": ("OpenSSL",),
     "python-dateutil": ("dateutil",),
     "python-jose": ("jose",),
-    "PyYAML": ("yaml",),
-    "pymongo": (
-        "bson",
-        "gridfs",
-    ),
-    "pytest_runner": ("ptr",),
-    "python_dateutil": ("dateutil",),
-    "setuptools": (
-        "easy_install",
-        "pkg_resources",
-    ),
+    "pyyaml": ("yaml",),
+    "pymongo": ("bson", "gridfs"),
+    "pytest-runner": ("ptr",),
+    "setuptools": ("easy_install", "pkg_resources"),
 }

--- a/src/python/pants/backend/python/macros/pants_requirement_test.py
+++ b/src/python/pants/backend/python/macros/pants_requirement_test.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import pytest
+from packaging.utils import canonicalize_name as canonicalize_project_name
 from pkg_resources import Requirement
 
 from pants.backend.python.macros.pants_requirement import PantsRequirement
@@ -39,9 +40,9 @@ def assert_pants_requirement(
     assert target[PythonRequirementsField].value == (
         Requirement.parse(f"{expected_dist}=={pants_version()}"),
     )
-    actual_value = target[ModuleMappingField].value
-    assert isinstance(actual_value, FrozenDict)
-    assert actual_value.get(expected_dist) == (expected_module,)
+    module_mapping = target[ModuleMappingField].value
+    assert isinstance(module_mapping, FrozenDict)
+    assert module_mapping.get(canonicalize_project_name(expected_dist)) == (expected_module,)
 
 
 def test_target_name(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/python/target_types_test.py
+++ b/src/python/pants/backend/python/target_types_test.py
@@ -373,12 +373,12 @@ def test_python_distribution_dependency_injection() -> None:
     ["raw_value", "expected"],
     (
         (None, {}),
-        ({"new_dist": ["new_module"]}, {"new_dist": ("new_module",)}),
-        ({"PyYAML": ["custom_yaml"]}, {"PyYAML": ("custom_yaml",)}),
+        ({"new-dist": ["new_module"]}, {"new-dist": ("new_module",)}),
+        ({"PyYAML": ["custom_yaml"]}, {"pyyaml": ("custom_yaml",)}),
     ),
 )
 def test_module_mapping_field(
-    raw_value: Optional[Dict[str, Iterable[str]]], expected: Dict[str, Tuple[str]]
+    raw_value: Optional[Dict[str, Iterable[str]]], expected: Dict[str, Tuple[str, ...]]
 ) -> None:
     merged = dict(DEFAULT_MODULE_MAPPING)
     merged.update(expected)


### PR DESCRIPTION
[ci skip-rust]
[ci skip-build-wheels]