### PR TITLE
Fix `skip_tool` fields not working with `./pants fmt`

### DIFF
--- a/src/python/pants/backend/go/lint/fmt.py
+++ b/src/python/pants/backend/go/lint/fmt.py
@@ -47,6 +47,7 @@ async def format_golang_targets(
                 (
                     fmt_request_type.field_set_type.create(target)
                     for target in go_fmt_targets.targets
+                    if fmt_request_type.field_set_type.is_applicable(target)
                 ),
                 prior_formatter_result=prior_formatter_result,
             ),

--- a/src/python/pants/backend/python/lint/python_fmt.py
+++ b/src/python/pants/backend/python/lint/python_fmt.py
@@ -42,6 +42,7 @@ async def format_python_target(
                 (
                     fmt_request_type.field_set_type.create(target)
                     for target in python_fmt_targets.targets
+                    if fmt_request_type.field_set_type.is_applicable(target)
                 ),
                 prior_formatter_result=prior_formatter_result,
             ),

--- a/src/python/pants/backend/shell/lint/shell_fmt.py
+++ b/src/python/pants/backend/shell/lint/shell_fmt.py
@@ -44,6 +44,7 @@ async def format_shell_targets(
                 (
                     fmt_request_type.field_set_type.create(target)
                     for target in shell_fmt_targets.targets
+                    if fmt_request_type.field_set_type.is_applicable(target)
                 ),
                 prior_formatter_result=prior_formatter_result,
             ),


### PR DESCRIPTION
As discovered by @njgrisafi, `skip_black` et al only worked with `./pants lint`. This is because we weren't calling `FieldSet.is_applicable()`.

(It's unfortunate this code is duplicated across each distinct language, but that's the price we currently pay so that each language runs formatters sequentially but we run in parallel across languages.)

[ci skip-rust]