### PR TITLE
Fix constraints resolves to pass additional args. (#12076)

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -301,7 +301,7 @@ async def pex_from_targets(
                         requirements=PexRequirements(all_constraints),
                         interpreter_constraints=interpreter_constraints,
                         platforms=request.platforms,
-                        additional_args=["-vvv"],
+                        additional_args=request.additional_args,
                     ),
                 )
     elif (


### PR DESCRIPTION
This was missed when landing subset resolves and affects proper handling
of Python awslambda resolves for one.

Fixes #12075

(cherry picked from commit 722cd8ad5ce3206a7fcc4afae2af10408548846b)

[ci skip-rust]
[ci skip-build-wheels]