### PR TITLE
Lower the log level for scheduler init messages

### DIFF
--- a/src/python/pants/pantsd/pants_daemon_core.py
+++ b/src/python/pants/pantsd/pants_daemon_core.py
@@ -98,7 +98,7 @@ class PantsDaemonCore:
         Must be called under the lifecycle lock.
         """
         try:
-            logger.info(
+            logger.debug(
                 f"{scheduler_restart_explanation}: reinitializing scheduler..."
                 if scheduler_restart_explanation
                 else "Initializing scheduler..."
@@ -111,7 +111,7 @@ class PantsDaemonCore:
 
             self._services = self._services_constructor(bootstrap_options, self._scheduler)
             self._fingerprint = options_fingerprint
-            logger.info("Scheduler initialized.")
+            logger.debug("Scheduler initialized.")
         except Exception as e:
             self._kill_switch.set()
             self._scheduler = None

--- a/tests/python/pants_test/pantsd/pantsd_integration_test.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test.py
@@ -168,6 +168,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
                             "--remote-auth-plugin=auth_plugin.auth:auth_func",
                             "--remote-cache-read",
                             "--remote-store-address=grpc://fake",
+                            "-ldebug",
                             "help",
                         ]
                     )


### PR DESCRIPTION
As a pants user, I don't find those messages useful... they show up from time to time... I feel they are not relevant to an average pants user.

Feel free to close this PR if you disagree.
