### PR TITLE
Prepare 2.5.0 for real this time

### DIFF
--- a/src/python/pants/notes/2.5.x.md
+++ b/src/python/pants/notes/2.5.x.md
@@ -2,6 +2,10 @@
 
 See https://www.pantsbuild.org/v2.5/docs/release-notes-2-5 for an overview of the changes in this release series.
 
+## 2.5.0 (May 15, 2021)
+
+The first stable release of the `2.5.x` series, with no changes since the previous `rc`.
+
 ## 2.5.0rc3 (May 14, 2021)
 
 ### Bug fixes


### PR DESCRIPTION
We aborted the previous stable release because new bugs were found.

[ci skip-rust]