### PR TITLE
Fix remote cache writes memory exhaustion.

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1473,6 +1473,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "madvise"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e1e75c3c34c2b34cec9f127418cb35240c7ebee5de36a51437e6b382c161b86"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1495,6 +1504,16 @@ name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+
+[[package]]
+name = "memmap"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "memoffset"
@@ -2850,7 +2869,9 @@ dependencies = [
  "itertools 0.7.11",
  "lmdb",
  "log 0.4.11",
+ "madvise",
  "maplit",
+ "memmap",
  "mock",
  "num_cpus",
  "parking_lot",

--- a/src/rust/engine/fs/store/Cargo.toml
+++ b/src/rust/engine/fs/store/Cargo.toml
@@ -19,6 +19,8 @@ indexmap = "1.4"
 itertools = "0.7.2"
 lmdb = { git = "https://github.com/pantsbuild/lmdb-rs.git", rev = "06bdfbfc6348f6804127176e561843f214fc17f8" }
 log = "0.4"
+madvise = "0.1"
+memmap = "0.7"
 parking_lot = "0.11"
 prost = "0.7"
 prost-types = "0.7"

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -640,8 +640,9 @@ impl Store {
     match maybe_bytes {
       Some(bytes) => remote.store_bytes(bytes).await,
       None => Err(format!(
-        "Failed to upload digest {:?}: Not found in local store",
-        digest
+        "Failed to upload digest {entry_type:?} {digest:?}: Not found in local store.",
+        entry_type = entry_type,
+        digest = digest
       )),
     }
   }

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -640,7 +640,7 @@ impl Store {
     match maybe_bytes {
       Some(bytes) => remote.store_bytes(bytes).await,
       None => Err(format!(
-        "Failed to upload digest {entry_type:?} {digest:?}: Not found in local store.",
+        "Failed to upload {entry_type:?} {digest:?}: Not found in local store.",
         entry_type = entry_type,
         digest = digest
       )),
@@ -669,7 +669,7 @@ impl Store {
           .await?;
         match result {
           None => Err(format!(
-            "Failed to upload digest {entry_type:?} {digest:?}: Not found in local store.",
+            "Failed to upload {entry_type:?} {digest:?}: Not found in local store.",
             entry_type = entry_type,
             digest = digest
           )),

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -197,6 +197,38 @@ enum RootOrParentMetadataBuilder {
   ),
 }
 
+#[derive(Clone, Debug)]
+struct RemoteStore {
+  store: remote::ByteStore,
+  in_flight_uploads: Arc<parking_lot::Mutex<HashSet<Digest>>>,
+}
+
+impl RemoteStore {
+  fn new(store: remote::ByteStore) -> Self {
+    Self {
+      store,
+      in_flight_uploads: Arc::new(parking_lot::Mutex::new(HashSet::new())),
+    }
+  }
+
+  fn reserve_uploads(&self, candidates: HashSet<Digest>) -> HashSet<Digest> {
+    let mut active_uploads = self.in_flight_uploads.lock();
+    let to_upload = candidates
+      .difference(&active_uploads)
+      .cloned()
+      .collect::<HashSet<_>>();
+    active_uploads.extend(&to_upload);
+    to_upload
+  }
+
+  fn release_uploads(&self, uploads: HashSet<Digest>) {
+    self
+      .in_flight_uploads
+      .lock()
+      .retain(|d| !uploads.contains(d));
+  }
+}
+
 ///
 /// A content-addressed store of file contents, and Directories.
 ///
@@ -212,7 +244,7 @@ enum RootOrParentMetadataBuilder {
 #[derive(Debug, Clone)]
 pub struct Store {
   local: local::ByteStore,
-  remote: Option<remote::ByteStore>,
+  remote: Option<RemoteStore>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -291,7 +323,7 @@ impl Store {
   ) -> Result<Store, String> {
     Ok(Store {
       local: self.local,
-      remote: Some(remote::ByteStore::new(
+      remote: Some(RemoteStore::new(remote::ByteStore::new(
         cas_address,
         instance_name,
         root_ca_certs,
@@ -299,7 +331,7 @@ impl Store {
         chunk_size_bytes,
         upload_timeout,
         rpc_retries,
-      )?),
+      )?)),
     })
   }
 
@@ -480,7 +512,8 @@ impl Store {
     match (maybe_local_value, maybe_remote) {
       (Some(value_result), _) => value_result.map(|res| Some((res, LoadMetadata::Local))),
       (None, None) => Ok(None),
-      (None, Some(remote)) => {
+      (None, Some(remote_store)) => {
+        let remote = remote_store.store.clone();
         let maybe_bytes = remote.load_bytes_with(digest, Ok).await?;
 
         match maybe_bytes {
@@ -515,15 +548,15 @@ impl Store {
   ) -> BoxFuture<'static, Result<UploadSummary, String>> {
     let start_time = Instant::now();
 
-    let remote = if let Some(ref remote) = self.remote {
-      remote
+    let remote_store = if let Some(ref remote) = self.remote {
+      remote.clone()
     } else {
       return futures::future::err("Cannot ensure remote has blobs without a remote".to_owned())
         .boxed();
     };
 
     let store = self.clone();
-    let remote = remote.clone();
+    let remote = remote_store.store.clone();
     async move {
       let ingested_digests = store
         .expand_digests(digests.iter(), LocalMissingBehavior::Fetch)
@@ -536,38 +569,42 @@ impl Store {
           remote.list_missing_digests(request).await?
         };
 
-      let uploaded_digests = future::try_join_all(
-        digests_to_upload
-          .into_iter()
-          .map(|digest| {
-            let entry_type = ingested_digests[&digest];
-            let local = store.local.clone();
-            let remote = remote.clone();
-
-            async move {
-              // We need to copy the bytes into memory so that they may be used safely in an async
-              // future. While this unfortunately increases memory consumption, we prioritize
-              // being able to run `remote.store_bytes()` as async.
-              //
-              // See https://github.com/pantsbuild/pants/pull/9793 for an earlier implementation
-              // that used `Executor.block_on`, which avoided the clone but was blocking.
-              let maybe_bytes = local
-                .load_bytes_with(entry_type, digest, move |bytes| {
-                  Bytes::copy_from_slice(bytes)
-                })
-                .await?;
-              match maybe_bytes {
-                Some(bytes) => remote.store_bytes(bytes).await,
-                None => Err(format!(
-                  "Failed to upload digest {:?}: Not found in local store",
-                  digest
-                )),
+      let uploaded_digests = {
+        // Here we best-effort avoid uploading common blobs multiple times. If a blob is generated
+        // that many downstream actions depend on, we would otherwise get an expanded set of digests
+        // from each of those actions that includes the new blob. If those actions all execute in a
+        // time window smaller than the time taken to upload the blob, the effort would be
+        // duplicated leading to both wasted resources locally buffering up the blob as well as
+        // wasted effort on the remote server depending on its handling of this.
+        let to_upload = remote_store.reserve_uploads(digests_to_upload);
+        let uploaded_digests_result = future::try_join_all(
+          to_upload
+            .clone()
+            .into_iter()
+            .map(|digest| {
+              let entry_type = ingested_digests[&digest];
+              let local = store.local.clone();
+              let remote = remote.clone();
+              async move {
+                // TODO(John Sirois): Consider allowing configuration of when to buffer large blobs
+                // to disk to be independent of the remote store wire chunk size.
+                if digest.size_bytes > remote.chunk_size_bytes() {
+                  Self::store_large_blob_remote(local, remote, entry_type, digest).await
+                } else {
+                  Self::store_small_blob_remote(local, remote, entry_type, digest).await
+                }
               }
-            }
-          })
-          .collect::<Vec<_>>(),
-      )
-      .await?;
+              .map_ok(move |()| digest)
+            })
+            .collect::<Vec<_>>(),
+        )
+        .await;
+        // We release the uploads whether or not they actually succeeded. Future checks for large
+        // uploads will issue `find_missing_blobs_request`s that will eventually reconcile our
+        // accounting. In the mean-time we error on the side of at least once semantics.
+        remote_store.release_uploads(to_upload);
+        uploaded_digests_result?
+      };
 
       let ingested_file_sizes = ingested_digests.iter().map(|(digest, _)| digest.size_bytes);
       let uploaded_file_sizes = uploaded_digests.iter().map(|digest| digest.size_bytes);
@@ -581,6 +618,65 @@ impl Store {
       })
     }
     .boxed()
+  }
+
+  async fn store_small_blob_remote(
+    local: local::ByteStore,
+    remote: remote::ByteStore,
+    entry_type: EntryType,
+    digest: Digest,
+  ) -> Result<(), String> {
+    // We need to copy the bytes into memory so that they may be used safely in an async
+    // future. While this unfortunately increases memory consumption, we prioritize
+    // being able to run `remote.store_bytes()` as async.
+    //
+    // See https://github.com/pantsbuild/pants/pull/9793 for an earlier implementation
+    // that used `Executor.block_on`, which avoided the clone but was blocking.
+    let maybe_bytes = local
+      .load_bytes_with(entry_type, digest, move |bytes| {
+        Bytes::copy_from_slice(bytes)
+      })
+      .await?;
+    match maybe_bytes {
+      Some(bytes) => remote.store_bytes(bytes).await,
+      None => Err(format!(
+        "Failed to upload digest {:?}: Not found in local store",
+        digest
+      )),
+    }
+  }
+
+  async fn store_large_blob_remote(
+    local: local::ByteStore,
+    remote: remote::ByteStore,
+    entry_type: EntryType,
+    digest: Digest,
+  ) -> Result<(), String> {
+    remote
+      .store_buffered(digest, |mut buffer| async {
+        let result = local
+          .load_bytes_with(entry_type, digest, move |bytes| {
+            buffer.write_all(bytes).map_err(|e| {
+              format!(
+                "Failed to write {entry_type:?} {digest:?} to temporary buffer: {err}",
+                entry_type = entry_type,
+                digest = digest,
+                err = e
+              )
+            })
+          })
+          .await?;
+        match result {
+          None => Err(format!(
+            "Failed to upload digest {entry_type:?} {digest:?}: Not found in local store.",
+            entry_type = entry_type,
+            digest = digest
+          )),
+          Some(Err(err)) => Err(err),
+          Some(Ok(())) => Ok(()),
+        }
+      })
+      .await
   }
 
   ///
@@ -675,6 +771,7 @@ impl Store {
     };
 
     let tree_opt = remote
+      .store
       .load_bytes_with(tree_digest, |b| {
         let tree = Tree::decode(b).map_err(|e| format!("protobuf decode error: {:?}", e))?;
         Ok(tree)

--- a/src/rust/engine/fs/store/src/local.rs
+++ b/src/rust/engine/fs/store/src/local.rs
@@ -269,11 +269,11 @@ impl ByteStore {
   /// blocking, this accepts a function that views a slice rather than returning a clone of the
   /// data. The upshot is that the database is able to provide slices directly into shared memory.
   ///
-  pub async fn load_bytes_with<T: Send + 'static, F: Fn(&[u8]) -> T + Send + Sync + 'static>(
+  pub async fn load_bytes_with<T: Send + 'static, F: FnMut(&[u8]) -> T + Send + Sync + 'static>(
     &self,
     entry_type: EntryType,
     digest: Digest,
-    f: F,
+    mut f: F,
   ) -> Result<Option<T>, String> {
     if digest == EMPTY_DIGEST {
       // Avoid I/O for this case. This allows some client-provided operations (like merging

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -111,7 +111,7 @@ impl ByteStore {
     })?;
     let read_buffer = write_buffer.try_clone().map_err(|e| {
       format!(
-        "Failed to create a read handle for the temporary upload buffer for for {digest:?}: {err}",
+        "Failed to create a read handle for the temporary upload buffer for {digest:?}: {err}",
         digest = digest,
         err = e
       )

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -111,8 +111,9 @@ impl ByteStore {
     })?;
     let read_buffer = write_buffer.try_clone().map_err(|e| {
       format!(
-        "Failed to create a read handle for the temporary upload buffer for {}",
-        e
+        "Failed to create a read handle for the temporary upload buffer for for {digest:?}: {err}",
+        digest = digest,
+        err = e
       )
     })?;
     write_to_buffer(write_buffer).await?;

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -7,7 +7,7 @@ use mock::StubCAS;
 use testutil::data::{TestData, TestDirectory};
 
 use crate::remote::ByteStore;
-use crate::tests::{big_file_bytes, big_file_digest, big_file_fingerprint, new_cas};
+use crate::tests::{big_file_bytes, big_file_fingerprint, new_cas};
 use crate::MEGABYTES;
 
 #[tokio::test]
@@ -139,10 +139,7 @@ async fn write_file_one_chunk() {
   let cas = StubCAS::empty();
 
   let store = new_byte_store(&cas);
-  assert_eq!(
-    store.store_bytes(testdata.bytes()).await,
-    Ok(testdata.digest())
-  );
+  assert_eq!(store.store_bytes(testdata.bytes()).await, Ok(()));
 
   let blobs = cas.blobs.lock();
   assert_eq!(blobs.get(&testdata.fingerprint()), Some(&testdata.bytes()));
@@ -167,10 +164,7 @@ async fn write_file_multiple_chunks() {
 
   let fingerprint = big_file_fingerprint();
 
-  assert_eq!(
-    store.store_bytes(all_the_henries.clone()).await,
-    Ok(big_file_digest())
-  );
+  assert_eq!(store.store_bytes(all_the_henries.clone()).await, Ok(()));
 
   let blobs = cas.blobs.lock();
   assert_eq!(blobs.get(&fingerprint), Some(&all_the_henries));
@@ -197,10 +191,7 @@ async fn write_empty_file() {
   let cas = StubCAS::empty();
 
   let store = new_byte_store(&cas);
-  assert_eq!(
-    store.store_bytes(empty_file.bytes()).await,
-    Ok(empty_file.digest())
-  );
+  assert_eq!(store.store_bytes(empty_file.bytes()).await, Ok(()));
 
   let blobs = cas.blobs.lock();
   assert_eq!(

--- a/src/rust/engine/fs/store/src/tests.rs
+++ b/src/rust/engine/fs/store/src/tests.rs
@@ -34,10 +34,6 @@ pub fn big_file_fingerprint() -> Fingerprint {
     .unwrap()
 }
 
-pub fn big_file_digest() -> Digest {
-  Digest::new(big_file_fingerprint(), big_file_bytes().len())
-}
-
 pub fn big_file_bytes() -> Bytes {
   let mut f = File::open(
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/src/rust/engine/fs/store/src/tests.rs
+++ b/src/rust/engine/fs/store/src/tests.rs
@@ -779,7 +779,7 @@ async fn upload_missing_file_in_directory() {
   assert_eq!(
     error,
     format!(
-      "Failed to upload digest {:?}: Not found in local store",
+      "Failed to upload File {:?}: Not found in local store.",
       TestData::roland().digest()
     ),
     "Bad error message"

--- a/src/rust/engine/sharded_lmdb/src/lib.rs
+++ b/src/rust/engine/sharded_lmdb/src/lib.rs
@@ -422,11 +422,11 @@ impl ShardedLmdb {
 
   pub async fn load_bytes_with<
     T: Send + 'static,
-    F: Fn(&[u8]) -> Result<T, String> + Send + Sync + 'static,
+    F: FnMut(&[u8]) -> Result<T, String> + Send + Sync + 'static,
   >(
     &self,
     fingerprint: Fingerprint,
-    f: F,
+    mut f: F,
   ) -> Result<Option<T>, String> {
     let store = self.clone();
     let effective_key = VersionedFingerprint::new(fingerprint, ShardedLmdb::SCHEMA_VERSION);


### PR DESCRIPTION
This builds upon #12083 which halved memory consumption when uploading
blobs to the remote cache and sets an upper bound on memory consumed for
uploads via two measures:

+ Blobs larger than a certain size are buffered via disk.
+ Uploading duplicate (large) blobs is largely avoided.

The latter is achieved with a best-effort, low cost sieve. We could do
better.

With these changes, a full fresh remote cache upload of Pants via
`./pants --remote-cache-write tests ::` can now complete (previously it
was OOMKilled) and does so while consuming at least 30x less memory.

[ci skip-build-wheels]