### PR TITLE
Add plugin hook for setting up Pytest context

### DIFF
--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -32,7 +32,7 @@ from pants.engine.process import InteractiveRunner
 from pants.engine.rules import QueryRule as QueryRule
 from pants.engine.rules import Rule
 from pants.engine.target import Target, WrappedTarget
-from pants.engine.unions import UnionMembership
+from pants.engine.unions import UnionMembership, UnionRule
 from pants.init.engine_initializer import EngineInitializer
 from pants.init.logging import initialize_stdio, stdio_destination
 from pants.option.global_options import (
@@ -191,8 +191,8 @@ class RuleRunner:
         return os.path.join(self.build_root, ".pants.d")
 
     @property
-    def rules(self) -> FrozenOrderedSet[Rule]:
-        return self.build_config.rules
+    def rules(self) -> FrozenOrderedSet[Rule | UnionRule]:
+        return FrozenOrderedSet([*self.build_config.rules, *self.build_config.union_rules])
 
     @property
     def target_types(self) -> FrozenOrderedSet[Type[Target]]:


### PR DESCRIPTION
This new hook allows users to do things like:

- Validate that databases are running.
- Insert certain files, e.g. our `runtime_package_dependencies` feature.

In the future, we can expand it to have new capabilities like setting environment variables.

Unlike our `setup_py` kwargs plugin hook, we do allow you to run >1 plugin on the same target here. It should be safe to merge multiple plugins, and this is a useful feature.

This plugin is only implemented for Pytest, not for other test runners like `shunit2`. It seems unlikely a user would want the same setup for Pytest as other languages; and if they do, they can simply factor up a helper rule that gets used by both plugin hooks.

[ci skip-rust]
[ci skip-build-wheels]