### PR TITLE
Replace `ProcessCacheScope.PER_RESTART` with `ProcessCacheScope.PER_RESTART_ALWAYS` and `ProcessCacheScope.PER_RESTART_SUCCESSFUL`

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -250,10 +250,10 @@ async def find_interpreter(
                 ),
             ),
             level=LogLevel.DEBUG,
-            # NB: We want interpreter discovery to re-run fairly frequently (PER_RESTART), but
-            # not on every run of Pants (NEVER, which is effectively per-Session). See #10769 for
-            # a solution that is less of a tradeoff.
-            cache_scope=ProcessCacheScope.PER_RESTART,
+            # NB: We want interpreter discovery to re-run fairly frequently
+            # (PER_RESTART_SUCCESSFUL), but not on every run of Pants (NEVER, which is effectively
+            # per-Session). See #10769 for a solution that is less of a tradeoff.
+            cache_scope=ProcessCacheScope.PER_RESTART_SUCCESSFUL,
         ),
     )
     path, fingerprint = result.stdout.decode().strip().splitlines()

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -41,8 +41,12 @@ class ProcessCacheScope(Enum):
     ALWAYS = "always"
     # Cached in all locations, but only if the process exits successfully.
     SUCCESSFUL = "successful"
-    # Cached only in memory (i.e. memoized in pantsd), but never persistently.
-    PER_RESTART = "per_restart"
+    # Cached only in memory (i.e. memoized in pantsd), but never persistently, regardless of
+    # success vs. failure.
+    PER_RESTART_ALWAYS = "per_restart_always"
+    # Cached only in memory (i.e. memoized in pantsd), but never persistently, and only if
+    # successful.
+    PER_RESTART_SUCCESSFUL = "per_restart_successful"
     # Never cached anywhere: will run once per Session (i.e. once per run of Pants).
     NEVER = "never"
 
@@ -542,7 +546,7 @@ async def find_binary(request: BinaryPathRequest) -> BinaryPaths:
             input_digest=script_digest,
             argv=[script_path, request.binary_name],
             env={"PATH": search_path},
-            cache_scope=ProcessCacheScope.PER_RESTART,
+            cache_scope=ProcessCacheScope.PER_RESTART_SUCCESSFUL,
         ),
     )
 
@@ -558,7 +562,7 @@ async def find_binary(request: BinaryPathRequest) -> BinaryPaths:
                 description=f"Test binary {path}.",
                 level=LogLevel.DEBUG,
                 argv=[path, *request.test.args],
-                cache_scope=ProcessCacheScope.PER_RESTART,
+                cache_scope=ProcessCacheScope.PER_RESTART_SUCCESSFUL,
             ),
         )
         for path in found_paths

--- a/src/python/pants/engine/process_test.py
+++ b/src/python/pants/engine/process_test.py
@@ -152,22 +152,54 @@ def test_cache_scope_successful(rule_runner: RuleRunner) -> None:
 
 
 def test_cache_scope_per_restart() -> None:
-    process = Process(
-        argv=("/bin/bash", "-c", "echo $RANDOM"),
-        cache_scope=ProcessCacheScope.PER_RESTART,
-        description="random",
-    )
-    runner_one = new_rule_runner()
-    result_one = runner_one.request(FallibleProcessResult, [process])
-    runner_one.new_session("session one")
-    result_two = runner_one.request(FallibleProcessResult, [process])
-    # Should not re-run within the same Scheduler, even with a new Session.
-    assert result_one is result_two
+    success_argv = ("/bin/bash", "-c", "echo $RANDOM")
+    failure_argv = ("/bin/bash", "-c", "echo $RANDOM; exit 1")
 
-    # Should re-run in a new Scheduler.
+    always_cache_success = Process(
+        success_argv, cache_scope=ProcessCacheScope.PER_RESTART_ALWAYS, description="foo"
+    )
+    always_cache_failure = Process(
+        failure_argv, cache_scope=ProcessCacheScope.PER_RESTART_ALWAYS, description="foo"
+    )
+    success_cache_success = Process(
+        success_argv, cache_scope=ProcessCacheScope.PER_RESTART_SUCCESSFUL, description="foo"
+    )
+    success_cache_failure = Process(
+        failure_argv, cache_scope=ProcessCacheScope.PER_RESTART_SUCCESSFUL, description="foo"
+    )
+
+    runner_one = new_rule_runner()
+
+    def run(process: Process) -> FallibleProcessResult:
+        return runner_one.request(FallibleProcessResult, [process])
+
+    always_cache_success_res1 = run(always_cache_success)
+    always_cache_failure_res1 = run(always_cache_failure)
+    success_cache_success_res1 = run(success_cache_success)
+    success_cache_failure_res1 = run(success_cache_failure)
+
+    runner_one.new_session("new session")
+    always_cache_success_res2 = run(always_cache_success)
+    always_cache_failure_res2 = run(always_cache_failure)
+    success_cache_success_res2 = run(success_cache_success)
+    success_cache_failure_res2 = run(success_cache_failure)
+
+    # Even with a new session, most results should be memoized.
+    assert always_cache_success_res1 is always_cache_success_res2
+    assert always_cache_failure_res1 is always_cache_failure_res2
+    assert success_cache_success_res1 is success_cache_success_res2
+    assert success_cache_failure_res1 != success_cache_failure_res2
+
+    # But a new scheduler removes all memoization. We do not cache to disk.
     runner_two = new_rule_runner()
-    result_three = runner_two.request(FallibleProcessResult, [process])
-    assert result_one.stdout != result_three.stdout
+
+    def run(process: Process) -> FallibleProcessResult:
+        return runner_two.request(FallibleProcessResult, [process])
+
+    assert run(always_cache_success) != always_cache_success_res1
+    assert run(always_cache_failure) != always_cache_failure_res1
+    assert run(success_cache_success) != success_cache_success_res1
+    assert run(success_cache_failure) != success_cache_failure_res1
 
 
 def test_cache_scope_never(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/engine/process_test.py
+++ b/src/python/pants/engine/process_test.py
@@ -170,19 +170,19 @@ def test_cache_scope_per_restart() -> None:
 
     runner_one = new_rule_runner()
 
-    def run(process: Process) -> FallibleProcessResult:
+    def run1(process: Process) -> FallibleProcessResult:
         return runner_one.request(FallibleProcessResult, [process])
 
-    always_cache_success_res1 = run(always_cache_success)
-    always_cache_failure_res1 = run(always_cache_failure)
-    success_cache_success_res1 = run(success_cache_success)
-    success_cache_failure_res1 = run(success_cache_failure)
+    always_cache_success_res1 = run1(always_cache_success)
+    always_cache_failure_res1 = run1(always_cache_failure)
+    success_cache_success_res1 = run1(success_cache_success)
+    success_cache_failure_res1 = run1(success_cache_failure)
 
     runner_one.new_session("new session")
-    always_cache_success_res2 = run(always_cache_success)
-    always_cache_failure_res2 = run(always_cache_failure)
-    success_cache_success_res2 = run(success_cache_success)
-    success_cache_failure_res2 = run(success_cache_failure)
+    always_cache_success_res2 = run1(always_cache_success)
+    always_cache_failure_res2 = run1(always_cache_failure)
+    success_cache_success_res2 = run1(success_cache_success)
+    success_cache_failure_res2 = run1(success_cache_failure)
 
     # Even with a new session, most results should be memoized.
     assert always_cache_success_res1 is always_cache_success_res2
@@ -193,13 +193,13 @@ def test_cache_scope_per_restart() -> None:
     # But a new scheduler removes all memoization. We do not cache to disk.
     runner_two = new_rule_runner()
 
-    def run(process: Process) -> FallibleProcessResult:
+    def run2(process: Process) -> FallibleProcessResult:
         return runner_two.request(FallibleProcessResult, [process])
 
-    assert run(always_cache_success) != always_cache_success_res1
-    assert run(always_cache_failure) != always_cache_failure_res1
-    assert run(success_cache_success) != success_cache_success_res1
-    assert run(success_cache_failure) != success_cache_failure_res1
+    assert run2(always_cache_success) != always_cache_success_res1
+    assert run2(always_cache_failure) != always_cache_failure_res1
+    assert run2(success_cache_success) != success_cache_success_res1
+    assert run2(success_cache_failure) != success_cache_failure_res1
 
 
 def test_cache_scope_never(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -65,7 +65,7 @@ async def resolve_plugins(
     cache_scope = (
         ProcessCacheScope.NEVER
         if global_options.options.plugins_force_resolve
-        else ProcessCacheScope.PER_RESTART
+        else ProcessCacheScope.PER_RESTART_SUCCESSFUL
     )
 
     plugins_process_result = await Get(

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -115,8 +115,12 @@ pub enum ProcessCacheScope {
   Always,
   // Cached in all locations, but only if the process exits successfully.
   Successful,
-  // Cached only in memory (i.e. memoized in pantsd), but never persistently.
-  PerRestart,
+  // Cached only in memory (i.e. memoized in pantsd), but never persistently, regardless of
+  // success vs. failure.
+  PerRestartAlways,
+  // Cached only in memory (i.e. memoized in pantsd), but never persistently, and only if
+  // successful.
+  PerRestartSuccessful,
   // Never cached anywhere: will run once per Session (i.e. once per run of Pants).
   Never,
 }
@@ -127,7 +131,8 @@ impl TryFrom<String> for ProcessCacheScope {
     match variant_candidate.to_lowercase().as_ref() {
       "always" => Ok(ProcessCacheScope::Always),
       "successful" => Ok(ProcessCacheScope::Successful),
-      "per_restart" => Ok(ProcessCacheScope::PerRestart),
+      "per_restart_always" => Ok(ProcessCacheScope::PerRestartAlways),
+      "per_restart_successful" => Ok(ProcessCacheScope::PerRestartSuccessful),
       "never" => Ok(ProcessCacheScope::Never),
       other => Err(format!("Unknown Process cache scope: {:?}", other)),
     }

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -965,7 +965,9 @@ pub fn make_execute_request(
 
   if matches!(
     req.cache_scope,
-    ProcessCacheScope::Never | ProcessCacheScope::PerRestart
+    ProcessCacheScope::Never
+      | ProcessCacheScope::PerRestartAlways
+      | ProcessCacheScope::PerRestartSuccessful
   ) {
     command
       .environment_variables

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1424,8 +1424,10 @@ impl Node for NodeKey {
     match self {
       NodeKey::MultiPlatformExecuteProcess(ref mp) => match output {
         NodeOutput::ProcessResult(ref process_result) => match mp.cache_scope {
-          ProcessCacheScope::Always | ProcessCacheScope::PerRestart => true,
-          ProcessCacheScope::Successful => process_result.0.exit_code == 0,
+          ProcessCacheScope::Always | ProcessCacheScope::PerRestartAlways => true,
+          ProcessCacheScope::Successful | ProcessCacheScope::PerRestartSuccessful => {
+            process_result.0.exit_code == 0
+          }
           ProcessCacheScope::Never => false,
         },
         _ => true,


### PR DESCRIPTION
Previously, `ProcessCacheScope.PER_RESTART` always memoized failures (but not cached to disk). 

That wasn't a problem in pantsbuild/pants because we always use `await Get(ProcessResult, Process)` instead of `Get(FallibleProcessResult, Process)`, and the error restarts Pantsd. 

But, it's valid to use a fallible process result and not want to memoize failures. For example, a user is writing a plugin to check if a database is alive before test runs. They must not cache this to disk because it's not safe to, but they also don't want to have to run the check every single distinct test run.

[ci skip-build-wheels]