### PR TITLE
Change Docformatter to not try to use Python 2 and Python 3.5 by default

### DIFF
--- a/src/python/pants/backend/python/lint/docformatter/subsystem.py
+++ b/src/python/pants/backend/python/lint/docformatter/subsystem.py
@@ -12,10 +12,10 @@ class Docformatter(PythonToolBase):
     options_scope = "docformatter"
     help = "The Python docformatter tool (https://github.com/myint/docformatter)."
 
-    default_version = "docformatter>=1.3.1,<1.4"
+    default_version = "docformatter>=1.4,<1.5"
     default_main = ConsoleScript("docformatter")
     register_interpreter_constraints = True
-    default_interpreter_constraints = ["CPython==2.7.*", "CPython>=3.4,<3.9"]
+    default_interpreter_constraints = ["CPython>=3.6"]
 
     @classmethod
     def register_options(cls, register):


### PR DESCRIPTION
It doesn't matter what interpreter you use with Docformatter thanks to it using typed-ast.

While docformatter does technically work with both 2.7 and 3.5, both those interpreters are EOL and often problematic, e.g. 2.7 often being a botched system interpreter on macOS.

Users can restore `[docformatter].interpreter_constraints` if they have a particular reason to want to install Docformatter with either version.

[ci skip-rust]
[ci skip-build-wheels]