### PR TITLE
Rename `ProcessCacheScope.NEVER` to `ProcessCacheScope.PER_SESSION`

### DIFF
--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -301,7 +301,9 @@ async def setup_pytest_for_target(
     }
 
     # Cache test runs only if they are successful, or not at all if `--test-force`.
-    cache_scope = ProcessCacheScope.NEVER if test_subsystem.force else ProcessCacheScope.SUCCESSFUL
+    cache_scope = (
+        ProcessCacheScope.PER_SESSION if test_subsystem.force else ProcessCacheScope.SUCCESSFUL
+    )
     process = await Get(
         Process,
         VenvPexProcess(

--- a/src/python/pants/backend/shell/shunit2_test_runner.py
+++ b/src/python/pants/backend/shell/shunit2_test_runner.py
@@ -225,7 +225,9 @@ async def setup_shunit2_for_target(
         if runner.shell == Shunit2Shell.zsh
         else [runner.binary_path.path, *field_set_sources.snapshot.files]
     )
-    cache_scope = ProcessCacheScope.NEVER if test_subsystem.force else ProcessCacheScope.SUCCESSFUL
+    cache_scope = (
+        ProcessCacheScope.PER_SESSION if test_subsystem.force else ProcessCacheScope.SUCCESSFUL
+    )
     process = Process(
         argv=argv,
         input_digest=input_digest,

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -47,8 +47,9 @@ class ProcessCacheScope(Enum):
     # Cached only in memory (i.e. memoized in pantsd), but never persistently, and only if
     # successful.
     PER_RESTART_SUCCESSFUL = "per_restart_successful"
-    # Never cached anywhere: will run once per Session (i.e. once per run of Pants).
-    NEVER = "never"
+    # Will run once per Session, i.e. once per run of Pants. This happens because the engine
+    # de-duplicates identical work; the process is neither memoized in memory nor cached to disk.
+    PER_SESSION = "per_session"
 
 
 @frozen_after_init

--- a/src/python/pants/engine/process_test.py
+++ b/src/python/pants/engine/process_test.py
@@ -202,17 +202,19 @@ def test_cache_scope_per_restart() -> None:
     assert run2(success_cache_failure) != success_cache_failure_res1
 
 
-def test_cache_scope_never(rule_runner: RuleRunner) -> None:
+def test_cache_scope_per_session(rule_runner: RuleRunner) -> None:
     process = Process(
         argv=("/bin/bash", "-c", "echo $RANDOM"),
-        cache_scope=ProcessCacheScope.NEVER,
+        cache_scope=ProcessCacheScope.PER_SESSION,
         description="random",
     )
     result_one = rule_runner.request(FallibleProcessResult, [process])
-    rule_runner.new_session("next attempt")
     result_two = rule_runner.request(FallibleProcessResult, [process])
+    assert result_one is result_two
+    rule_runner.new_session("next attempt")
+    result_three = rule_runner.request(FallibleProcessResult, [process])
     # Should re-run in a new Session.
-    assert result_one.stdout != result_two.stdout
+    assert result_one != result_three
 
 
 # TODO: Move to fs_test.py.

--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -63,7 +63,7 @@ async def resolve_plugins(
     # NB: We run this Process per-restart because it (intentionally) leaks named cache
     # paths in a way that invalidates the Process-cache. See the method doc.
     cache_scope = (
-        ProcessCacheScope.NEVER
+        ProcessCacheScope.PER_SESSION
         if global_options.options.plugins_force_resolve
         else ProcessCacheScope.PER_RESTART_SUCCESSFUL
     )

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -121,8 +121,9 @@ pub enum ProcessCacheScope {
   // Cached only in memory (i.e. memoized in pantsd), but never persistently, and only if
   // successful.
   PerRestartSuccessful,
-  // Never cached anywhere: will run once per Session (i.e. once per run of Pants).
-  Never,
+  // Will run once per Session, i.e. once per run of Pants. This happens because the engine
+  // de-duplicates identical work; the process is neither memoized in memory nor cached to disk.
+  PerSession,
 }
 
 impl TryFrom<String> for ProcessCacheScope {
@@ -133,7 +134,7 @@ impl TryFrom<String> for ProcessCacheScope {
       "successful" => Ok(ProcessCacheScope::Successful),
       "per_restart_always" => Ok(ProcessCacheScope::PerRestartAlways),
       "per_restart_successful" => Ok(ProcessCacheScope::PerRestartSuccessful),
-      "never" => Ok(ProcessCacheScope::Never),
+      "per_session" => Ok(ProcessCacheScope::PerSession),
       other => Err(format!("Unknown Process cache scope: {:?}", other)),
     }
   }

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -965,7 +965,7 @@ pub fn make_execute_request(
 
   if matches!(
     req.cache_scope,
-    ProcessCacheScope::Never
+    ProcessCacheScope::PerSession
       | ProcessCacheScope::PerRestartAlways
       | ProcessCacheScope::PerRestartSuccessful
   ) {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1428,7 +1428,7 @@ impl Node for NodeKey {
           ProcessCacheScope::Successful | ProcessCacheScope::PerRestartSuccessful => {
             process_result.0.exit_code == 0
           }
-          ProcessCacheScope::Never => false,
+          ProcessCacheScope::PerSession => false,
         },
         _ => true,
       },


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/12097. We already had this, turns out! Only the name didn't make it quite as clear as it could be.

[ci skip-build-wheels]