### PR TITLE
Change Docformatter to not try to use Python 2 and Python 3.5 by default (Cherry-pick of #12099)

### DIFF
--- a/src/python/pants/backend/python/lint/docformatter/subsystem.py
+++ b/src/python/pants/backend/python/lint/docformatter/subsystem.py
@@ -12,10 +12,10 @@ class Docformatter(PythonToolBase):
     options_scope = "docformatter"
     help = "The Python docformatter tool (https://github.com/myint/docformatter)."
 
-    default_version = "docformatter>=1.3.1,<1.4"
+    default_version = "docformatter>=1.4,<1.5"
     default_main = ConsoleScript("docformatter")
     register_interpreter_constraints = True
-    default_interpreter_constraints = ["CPython==2.7.*", "CPython>=3.4,<3.9"]
+    default_interpreter_constraints = ["CPython>=3.6"]
 
     @classmethod
     def register_options(cls, register):


### PR DESCRIPTION
[ci skip-rust]
[ci skip-build-wheels]