### PR TITLE
add retries with exponential back-off for remote cache

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1041,6 +1041,7 @@ dependencies = [
  "futures",
  "prost",
  "prost-types",
+ "rand 0.8.2",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1039,6 +1039,7 @@ version = "0.0.1"
 dependencies = [
  "bytes 1.0.1",
  "futures",
+ "parking_lot",
  "prost",
  "prost-types",
  "rand 0.8.2",

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -368,10 +368,14 @@ impl ByteStore {
     let result_future = async move {
       let store2 = store.clone();
       let client = store2.cas_client.as_ref().clone();
-      let response = retry_call(client, move |mut client| {
-        let request = request.clone();
-        async move { client.find_missing_blobs(request).await }
-      }, status_is_retryable)
+      let response = retry_call(
+        client,
+        move |mut client| {
+          let request = request.clone();
+          async move { client.find_missing_blobs(request).await }
+        },
+        status_is_retryable,
+      )
       .await
       .map_err(status_to_str)?;
 

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -9,9 +9,9 @@ use bazel_protos::gen::build::bazel::remote::execution::v2 as remexec;
 use bazel_protos::gen::google::bytestream::byte_stream_client::ByteStreamClient;
 use bazel_protos::{self};
 use bytes::{Bytes, BytesMut};
-use futures::future::TryFutureExt;
 use futures::Future;
 use futures::StreamExt;
+use grpc_util::retry::retry_call;
 use grpc_util::{headers_to_interceptor_fn, status_to_str};
 use hashing::Digest;
 use log::Level;
@@ -367,12 +367,13 @@ impl ByteStore {
     };
     let result_future = async move {
       let store2 = store.clone();
-      let mut client = store2.cas_client.as_ref().clone();
-      let request = request.clone();
-      let response = client
-        .find_missing_blobs(request)
-        .map_err(status_to_str)
-        .await?;
+      let client = store2.cas_client.as_ref().clone();
+      let response = retry_call(client, move |mut client| {
+        let request = request.clone();
+        async move { client.find_missing_blobs(request).await }
+      })
+      .await
+      .map_err(status_to_str)?;
 
       response
         .into_inner()

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -11,7 +11,7 @@ use bazel_protos::{self};
 use bytes::{Bytes, BytesMut};
 use futures::Future;
 use futures::StreamExt;
-use grpc_util::retry::retry_call;
+use grpc_util::retry::{retry_call, status_is_retryable};
 use grpc_util::{headers_to_interceptor_fn, status_to_str};
 use hashing::Digest;
 use log::Level;
@@ -371,7 +371,7 @@ impl ByteStore {
       let response = retry_call(client, move |mut client| {
         let request = request.clone();
         async move { client.find_missing_blobs(request).await }
-      })
+      }, status_is_retryable)
       .await
       .map_err(status_to_str)?;
 

--- a/src/rust/engine/grpc_util/Cargo.toml
+++ b/src/rust/engine/grpc_util/Cargo.toml
@@ -10,6 +10,7 @@ bytes = "1.0"
 futures = "0.3"
 rustls-native-certs = "0.5"
 prost = "0.7"
+rand = "0.8"
 tokio = { version = "1.4", features = ["net", "process", "rt-multi-thread", "sync", "time"] }
 tokio-rustls = "0.22"
 tokio-util = { version = "0.6", features = ["codec"] }

--- a/src/rust/engine/grpc_util/Cargo.toml
+++ b/src/rust/engine/grpc_util/Cargo.toml
@@ -17,4 +17,5 @@ tokio-util = { version = "0.6", features = ["codec"] }
 tonic = { version = "0.4", features = ["transport", "codegen", "tls", "tls-roots", "prost"] }
 
 [dev-dependencies]
+parking_lot = "0.11"
 prost-types = "0.7"

--- a/src/rust/engine/grpc_util/src/lib.rs
+++ b/src/rust/engine/grpc_util/src/lib.rs
@@ -36,6 +36,7 @@ use tonic::metadata::{AsciiMetadataKey, AsciiMetadataValue, KeyAndValueRef, Meta
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
 
 pub mod prost;
+pub mod retry;
 
 /// Create a Tonic `Endpoint` from a string containing a schema and IP address/name.
 pub fn create_endpoint(

--- a/src/rust/engine/grpc_util/src/retry.rs
+++ b/src/rust/engine/grpc_util/src/retry.rs
@@ -1,0 +1,63 @@
+// Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+use std::time::Duration;
+
+use futures::Future;
+use rand::{thread_rng, Rng};
+use tonic::{Code, Response, Status};
+
+fn is_retryable(status: &Status) -> bool {
+  matches!(
+    status.code(),
+    Code::Aborted
+      | Code::Cancelled
+      | Code::Internal
+      | Code::ResourceExhausted
+      | Code::Unavailable
+      | Code::Unknown
+  )
+}
+
+/// Retry a gRPC client operation using exponential back-off to delay between attempts.
+#[inline]
+pub async fn retry_call<T, C, F, Fut>(client: C, f: F) -> Result<Response<T>, Status>
+where
+  C: Clone,
+  F: Fn(C) -> Fut,
+  Fut: Future<Output = Result<Response<T>, Status>>,
+{
+  const INTERVAL_DURATION: Duration = Duration::from_millis(10);
+  const MAX_RETRIES: u32 = 3;
+  const MAX_BACKOFF_DURATION: Duration = Duration::from_secs(5);
+
+  let mut last_error: Option<Status> = None;
+
+  let mut num_retries = 0;
+  while num_retries < MAX_RETRIES {
+    // Delay before the next send attempt if this is a retry.
+    if num_retries > 0 {
+      let multiplier = thread_rng().gen_range(0..2_u32.pow(num_retries) + 1);
+      let sleep_time = INTERVAL_DURATION * multiplier;
+      let sleep_time = sleep_time.min(MAX_BACKOFF_DURATION);
+      tokio::time::sleep(sleep_time).await;
+    }
+
+    let client2 = client.clone();
+    let result_fut = f(client2);
+    match result_fut.await {
+      Ok(r) => return Ok(r),
+      Err(status) => {
+        if is_retryable(&status) {
+          last_error = Some(status);
+        } else {
+          return Err(status);
+        }
+      }
+    }
+
+    num_retries += 1
+  }
+
+  Err(last_error.take().unwrap())
+}

--- a/src/rust/engine/grpc_util/src/retry.rs
+++ b/src/rust/engine/grpc_util/src/retry.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use futures::Future;
 use rand::{thread_rng, Rng};
-use tonic::{Code, Response, Status};
+use tonic::{Code, Status};
 
 pub fn status_is_retryable(status: &Status) -> bool {
   matches!(
@@ -21,21 +21,19 @@ pub fn status_is_retryable(status: &Status) -> bool {
 
 /// Retry a gRPC client operation using exponential back-off to delay between attempts.
 #[inline]
-pub async fn retry_call<T, E, C, F, Fut>(client: C, f: F, is_retryable: G) -> Result<Response<T>, Status>
+pub async fn retry_call<T, E, C, F, G, Fut>(client: C, f: F, is_retryable: G) -> Result<T, E>
 where
   C: Clone,
   F: Fn(C) -> Fut,
   G: Fn(&E) -> bool,
-  Fut: Future<Output = Result<Response<T>, E>>,
+  Fut: Future<Output = Result<T, E>>,
 {
-  const INTERVAL_DURATION: Duration = Duration::from_millis(10);
+  const INTERVAL_DURATION: Duration = Duration::from_millis(20);
   const MAX_RETRIES: u32 = 3;
   const MAX_BACKOFF_DURATION: Duration = Duration::from_secs(5);
 
-  let mut last_error: Option<Status> = None;
-
   let mut num_retries = 0;
-  while num_retries < MAX_RETRIES {
+  let last_error = loop {
     // Delay before the next send attempt if this is a retry.
     if num_retries > 0 {
       let multiplier = thread_rng().gen_range(0..2_u32.pow(num_retries) + 1);
@@ -46,19 +44,102 @@ where
 
     let client2 = client.clone();
     let result_fut = f(client2);
-    match result_fut.await {
+    let last_error = match result_fut.await {
       Ok(r) => return Ok(r),
-      Err(status) => {
-        if is_retryable(&status) {
-          last_error = Some(status);
+      Err(err) => {
+        if is_retryable(&err) {
+          err
         } else {
-          return Err(status);
+          return Err(err);
         }
+      }
+    };
+
+    num_retries += 1;
+
+    if num_retries >= MAX_RETRIES {
+      break last_error;
+    }
+  };
+
+  Err(last_error)
+}
+
+#[cfg(test)]
+mod tests {
+  use std::collections::VecDeque;
+  use std::sync::Arc;
+
+  use parking_lot::Mutex;
+
+  use super::retry_call;
+
+  #[derive(Clone, Debug)]
+  struct MockClient<T> {
+    values: Arc<Mutex<VecDeque<T>>>,
+  }
+
+  impl<T> MockClient<T> {
+    pub fn new(values: Vec<T>) -> Self {
+      MockClient {
+        values: Arc::new(Mutex::new(values.into())),
       }
     }
 
-    num_retries += 1
+    async fn next(&self) -> T {
+      let mut values = self.values.lock();
+      values.pop_front().unwrap()
+    }
   }
 
-  Err(last_error.unwrap())
+  #[derive(Clone, Debug, Eq, PartialEq)]
+  struct MockError(bool, &'static str);
+
+  #[tokio::test]
+  async fn retry_call_works_as_expected() {
+    let client = MockClient::new(vec![
+      Err(MockError(true, "first")),
+      Err(MockError(true, "second")),
+      Ok(3isize),
+      Ok(4isize),
+    ]);
+    let result = retry_call(
+      client.clone(),
+      |client| async move { client.next().await },
+      |err| err.0,
+    )
+    .await;
+    assert_eq!(result, Ok(3isize));
+    assert_eq!(client.values.lock().len(), 1);
+
+    let client = MockClient::new(vec![
+      Err(MockError(true, "first")),
+      Err(MockError(false, "second")),
+      Ok(3isize),
+      Ok(4isize),
+    ]);
+    let result = retry_call(
+      client.clone(),
+      |client| async move { client.next().await },
+      |err| err.0,
+    )
+    .await;
+    assert_eq!(result, Err(MockError(false, "second")));
+    assert_eq!(client.values.lock().len(), 2);
+
+    let client = MockClient::new(vec![
+      Err(MockError(true, "first")),
+      Err(MockError(true, "second")),
+      Err(MockError(true, "third")),
+      Ok(1isize),
+    ]);
+    let result = retry_call(
+      client.clone(),
+      |client| async move { client.next().await },
+      |err| err.0,
+    )
+    .await;
+    assert_eq!(result, Err(MockError(true, "third")));
+    assert_eq!(client.values.lock().len(), 1);
+  }
 }

--- a/src/rust/engine/grpc_util/src/retry.rs
+++ b/src/rust/engine/grpc_util/src/retry.rs
@@ -59,5 +59,5 @@ where
     num_retries += 1
   }
 
-  Err(last_error.take().unwrap())
+  Err(last_error.unwrap())
 }

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -1382,21 +1382,25 @@ pub async fn check_action_cache(
     .increment_counter(Metric::RemoteCacheRequests, 1);
 
   let client = action_cache_client.as_ref().clone();
-  let action_result_response = retry_call(client, move |mut client| {
-    let request = remexec::GetActionResultRequest {
-      action_digest: Some(action_digest.into()),
-      instance_name: metadata
-        .instance_name
-        .as_ref()
-        .cloned()
-        .unwrap_or_else(String::new),
-      ..remexec::GetActionResultRequest::default()
-    };
+  let action_result_response = retry_call(
+    client,
+    move |mut client| {
+      let request = remexec::GetActionResultRequest {
+        action_digest: Some(action_digest.into()),
+        instance_name: metadata
+          .instance_name
+          .as_ref()
+          .cloned()
+          .unwrap_or_else(String::new),
+        ..remexec::GetActionResultRequest::default()
+      };
 
-    let request = apply_headers(Request::new(request), &context.build_id);
+      let request = apply_headers(Request::new(request), &context.build_id);
 
-    async move { client.get_action_result(request).await }
-  }, status_is_retryable)
+      async move { client.get_action_result(request).await }
+    },
+    status_is_retryable,
+  )
   .await;
 
   match action_result_response {

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -44,7 +44,7 @@ use crate::{
   Context, FallibleProcessResultWithPlatform, MultiPlatformProcess, Platform, Process,
   ProcessCacheScope, ProcessMetadata, ProcessResultMetadata,
 };
-use grpc_util::retry::retry_call;
+use grpc_util::retry::{retry_call, status_is_retryable};
 
 // Environment variable which is exclusively used for cache key invalidation.
 // This may be not specified in an Process, and may be populated only by the
@@ -1396,7 +1396,7 @@ pub async fn check_action_cache(
     let request = apply_headers(Request::new(request), &context.build_id);
 
     async move { client.get_action_result(request).await }
-  })
+  }, status_is_retryable)
   .await;
 
   match action_result_response {

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -44,6 +44,7 @@ use crate::{
   Context, FallibleProcessResultWithPlatform, MultiPlatformProcess, Platform, Process,
   ProcessCacheScope, ProcessMetadata, ProcessResultMetadata,
 };
+use grpc_util::retry::retry_call;
 
 // Environment variable which is exclusively used for cache key invalidation.
 // This may be not specified in an Process, and may be populated only by the
@@ -1380,19 +1381,23 @@ pub async fn check_action_cache(
     .workunit_store
     .increment_counter(Metric::RemoteCacheRequests, 1);
 
-  let request = remexec::GetActionResultRequest {
-    action_digest: Some(action_digest.into()),
-    instance_name: metadata
-      .instance_name
-      .as_ref()
-      .cloned()
-      .unwrap_or_else(String::new),
-    ..remexec::GetActionResultRequest::default()
-  };
+  let client = action_cache_client.as_ref().clone();
+  let action_result_response = retry_call(client, move |mut client| {
+    let request = remexec::GetActionResultRequest {
+      action_digest: Some(action_digest.into()),
+      instance_name: metadata
+        .instance_name
+        .as_ref()
+        .cloned()
+        .unwrap_or_else(String::new),
+      ..remexec::GetActionResultRequest::default()
+    };
 
-  let mut client = action_cache_client.as_ref().clone();
-  let request = apply_headers(Request::new(request), &context.build_id);
-  let action_result_response = client.get_action_result(request).await;
+    let request = apply_headers(Request::new(request), &context.build_id);
+
+    async move { client.get_action_result(request).await }
+  })
+  .await;
 
   match action_result_response {
     Ok(action_result) => {

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -9,8 +9,7 @@ use bazel_protos::gen::build::bazel::remote::execution::v2 as remexec;
 use bazel_protos::require_digest;
 use fs::RelativePath;
 use futures::FutureExt;
-use grpc_util::headers_to_interceptor_fn;
-use grpc_util::status_to_str;
+use grpc_util::{headers_to_interceptor_fn, retry::retry_call, status_to_str};
 use hashing::Digest;
 use parking_lot::Mutex;
 use remexec::action_cache_client::ActionCacheClient;
@@ -371,22 +370,27 @@ impl CommandRunner {
       .ensure_remote_has_recursive(digests_for_action_result)
       .await?;
 
-    let update_action_cache_request = remexec::UpdateActionResultRequest {
-      instance_name: metadata
-        .instance_name
-        .as_ref()
-        .cloned()
-        .unwrap_or_else(|| "".to_owned()),
-      action_digest: Some(action_digest.into()),
-      action_result: Some(action_result),
-      ..remexec::UpdateActionResultRequest::default()
-    };
+    let client = self.action_cache_client.as_ref().clone();
+    retry_call(client, move |mut client| {
+      let update_action_cache_request = remexec::UpdateActionResultRequest {
+        instance_name: metadata
+          .instance_name
+          .as_ref()
+          .cloned()
+          .unwrap_or_else(|| "".to_owned()),
+        action_digest: Some(action_digest.into()),
+        action_result: Some(action_result.clone()),
+        ..remexec::UpdateActionResultRequest::default()
+      };
 
-    let mut client = self.action_cache_client.as_ref().clone();
-    client
-      .update_action_result(update_action_cache_request)
-      .await
-      .map_err(status_to_str)?;
+      async move {
+        client
+          .update_action_result(update_action_cache_request)
+          .await
+      }
+    })
+    .await
+    .map_err(status_to_str)?;
 
     Ok(())
   }


### PR DESCRIPTION
## Problem

When using remote cache, transient errors returned by the remote system or local client stack (e.g, gRPC "unavailable" status) are not retried. This is not as good an experience for users of remote cache as they will see warnings about remote cache issues.

## Solution

Retry failed remote cache requests using exponential backoff. This PR introduces a helper called `retry_call` which implements the backoff logic and ports some of the remote cache/execution call sites to use it.

This PR does not port the CAS write logic since the use of streams there complicates usage of a function like `retry_call`.

Fixes https://github.com/pantsbuild/pants/issues/11373.

[ci skip-build-wheels]