### PR TITLE
do not add a leading slash if REAPI instance name is empty

### DIFF
--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -166,9 +166,11 @@ impl ByteStore {
     ByteSource: Fn(Range<usize>) -> Bytes + Send + Sync + 'static,
   {
     let len = digest.size_bytes;
+    let instance_name = self.instance_name.clone().unwrap_or_default();
     let resource_name = format!(
-      "{}/uploads/{}/blobs/{}/{}",
-      self.instance_name.clone().unwrap_or_default(),
+      "{}{}uploads/{}/blobs/{}/{}",
+      &instance_name,
+      if instance_name.is_empty() { "" } else { "/" },
       uuid::Uuid::new_v4(),
       digest.hash,
       digest.size_bytes,
@@ -245,9 +247,11 @@ impl ByteStore {
     f: F,
   ) -> Result<Option<T>, String> {
     let store = self.clone();
+    let instance_name = store.instance_name.clone().unwrap_or_default();
     let resource_name = format!(
-      "{}/blobs/{}/{}",
-      store.instance_name.clone().unwrap_or_default(),
+      "{}{}blobs/{}/{}",
+      &instance_name,
+      if instance_name.is_empty() { "" } else { "/" },
       digest.hash,
       digest.size_bytes
     );


### PR DESCRIPTION
## Problem

The Remote Execution API requires that resource names used with the `Read` and `Write` methods of the `Bytestream` gRPC service must not begin with a leading slash if the REAPI instance name is empty.

> `instance_name` is an identifier, possibly containing multiple path segments, used to distinguish between the various instances on the server, in a manner defined by the server. If it is the empty path, the leading slash is omitted

https://github.com/pantsbuild/pants/blob/bc7fbd3905a96540a0e0d5a10dc5560d14968ff8/src/rust/engine/process_execution/bazel_protos/protos/bazelbuild_remote-apis/build/bazel/remote/execution/v2/remote_execution.proto#L210-L214

## Solution

Do not add a leading slash if the REAPI instance name is empty. Update the `StubCAS` test mock to better parse resource names.

[ci skip-build-wheels]