### PR TITLE
[1.25.x-twtr][jvm] javac --release support, ensure dist selection reflects target platform

### DIFF
--- a/contrib/mypy/src/python/pants/contrib/mypy/register.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/register.py
@@ -10,13 +10,9 @@ class MypyStandalone(MypyTask):
     @classmethod
     def register_options(cls, register):
         super().register_options(register)
-        register("--skip", type=bool, default=False, help="Skip running mypy.")
-        register(
-            "--transitive",
-            type=bool,
-            default=False,
-            help="Whether to run mypy on transitive dependencies of the given python targets.",
-        )
+        register('--skip', type=bool, default=False, help='Skip running mypy.')
+        register('--transitive', type=bool, default=False,
+                 help='Whether to run mypy on transitive dependencies of the given python targets.')
 
 
 def register_goals():

--- a/contrib/mypy/src/python/pants/contrib/mypy/register.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/register.py
@@ -10,9 +10,13 @@ class MypyStandalone(MypyTask):
     @classmethod
     def register_options(cls, register):
         super().register_options(register)
-        register('--skip', type=bool, default=False, help='Skip running mypy.')
-        register('--transitive', type=bool, default=False,
-                 help='Whether to run mypy on transitive dependencies of the given python targets.')
+        register("--skip", type=bool, default=False, help="Skip running mypy.")
+        register(
+            "--transitive",
+            type=bool,
+            default=False,
+            help="Whether to run mypy on transitive dependencies of the given python targets.",
+        )
 
 
 def register_goals():

--- a/src/python/pants/backend/jvm/subsystems/jvm_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm_platform.py
@@ -366,8 +366,10 @@ class JvmPlatformSettings:
         self._by_default = by_default
         self._validate_source_target()
 
-    def javac_args(self, dist_home):
+    @property
+    def javac_args(self):
         # todo support release
+        # must handle release here because source/target are mutually exclusive with release
         args = [
             "-source",
             str(self.source_level),
@@ -375,14 +377,8 @@ class JvmPlatformSettings:
             str(self.target_level),
         ]
         if self.args:
-            settings_args = self.args
-            if any("$JAVA_HOME" in a for a in self.args):
-                logger.debug(
-                    'Substituting "$JAVA_HOME" with "{}" in jvm-platform args.'.format(dist_home)
-                )
-                settings_args = (a.replace("$JAVA_HOME", dist_home) for a in self.args)
-            args.extend(settings_args)
-        return args
+            args.extend(self.args)
+        return tuple(args)
 
     def _validate_source_target(self):
         if self.source_level > self.target_level:

--- a/src/python/pants/backend/jvm/subsystems/jvm_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm_platform.py
@@ -366,19 +366,23 @@ class JvmPlatformSettings:
         self._by_default = by_default
         self._validate_source_target()
 
+    def javac_source_target_args(self, distribution):
+        if distribution.version < Revision(9):
+            return [
+                "-source",
+                str(self.source_level),
+                "-target",
+                str(self.target_level),
+            ]
+        else:
+            return ["--release", str(self.release_level)]
+
     @property
-    def javac_args(self):
-        # todo support release
-        # must handle release here because source/target are mutually exclusive with release
-        args = [
-            "-source",
-            str(self.source_level),
-            "-target",
-            str(self.target_level),
-        ]
-        if self.args:
-            args.extend(self.args)
-        return tuple(args)
+    def release_level(self):
+        # NB release expects just 8 and not 1.8
+        if self.target_level.components[0] == 1:
+            return Revision(self.target_level.components[1])
+        return self.target_level
 
     def _validate_source_target(self):
         if self.source_level > self.target_level:

--- a/src/python/pants/backend/jvm/subsystems/jvm_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm_platform.py
@@ -366,6 +366,24 @@ class JvmPlatformSettings:
         self._by_default = by_default
         self._validate_source_target()
 
+    def javac_args(self, dist_home):
+        # todo support release
+        args = [
+            "-source",
+            str(self.source_level),
+            "-target",
+            str(self.target_level),
+        ]
+        if self.args:
+            settings_args = self.args
+            if any("$JAVA_HOME" in a for a in self.args):
+                logger.debug(
+                    'Substituting "$JAVA_HOME" with "{}" in jvm-platform args.'.format(dist_home)
+                )
+                settings_args = (a.replace("$JAVA_HOME", dist_home) for a in self.args)
+            args.extend(settings_args)
+        return args
+
     def _validate_source_target(self):
         if self.source_level > self.target_level:
             if self.by_default:

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
@@ -110,27 +110,7 @@ class JavacCompile(JvmCompile):
         distribution = self._local_jvm_distribution(settings)
 
         javac_args = []
-
-        if settings.args:
-            settings_args = settings.args
-            if any("$JAVA_HOME" in a for a in settings.args):
-                logger.debug(
-                    'Substituting "$JAVA_HOME" with "{}" in jvm-platform args.'.format(
-                        distribution.home
-                    )
-                )
-                settings_args = (a.replace("$JAVA_HOME", distribution.home) for a in settings.args)
-            javac_args.extend(settings_args)
-
-            javac_args.extend(
-                [
-                    # TODO: support -release
-                    "-source",
-                    str(settings.source_level),
-                    "-target",
-                    str(settings.target_level),
-                ]
-            )
+        javac_args.extend(distribution.generate_javac_args(settings))
 
         if self.execution_strategy == self.ExecutionStrategy.hermetic:
             javac_args.extend(

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
@@ -110,7 +110,8 @@ class JavacCompile(JvmCompile):
         distribution = self._local_jvm_distribution(settings)
 
         javac_args = []
-        javac_args.extend(distribution.generate_javac_args(settings))
+        javac_args.extend(settings.javac_source_target_args(distribution))
+        javac_args.extend(distribution.substitute_home(settings.args))
 
         if self.execution_strategy == self.ExecutionStrategy.hermetic:
             javac_args.extend(

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -37,7 +37,7 @@ from pants.base.worker_pool import WorkerPool
 from pants.base.workunit import WorkUnitLabel
 from pants.build_graph.target import Target
 from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, PathGlobs, PathGlobsAndRoot
-from pants.java.distribution.distribution import DistributionLocator
+from pants.java.distribution.distribution import Distribution, DistributionLocator
 from pants.option.compiler_option_sets_mixin import CompilerOptionSetsMixin
 from pants.option.ranked_value import RankedValue
 from pants.reporting.reporting_utils import items_to_report_element
@@ -495,6 +495,8 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
     def _missing_deps_finder(self):
         dep_analyzer = JvmDependencyAnalyzer(
             get_buildroot(),
+            # NB: The analyzer doesn't use the distribution for this usecase, so passing the default
+            # is fine
             self._get_jvm_distribution(),
             self.context.products.get_data("runtime_classpath"),
         )
@@ -1120,8 +1122,8 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
             underlying_libs = self._underlying.find_libs(names)
             return [self._rehome(l) for l in underlying_libs]
 
-        def generate_javac_args(self, *args):
-            return self._underlying.generate_javac_args(*args)
+        def generate_javac_args(self, settings):
+            return Distribution.substitute_java_home(settings.javac_args, self._home)
 
         def find_libs_path_globs(self, names):
             path_globs = []
@@ -1153,6 +1155,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
         def _rehome(self, l):
             return os.path.join(self._home, self._unroot_lib_path(l))
 
+    @memoized_method
     def _get_jvm_distribution(self, settings=None):
         local_distribution = self._local_jvm_distribution(settings)
         return match(

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -1155,6 +1155,10 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
         def _rehome(self, l):
             return os.path.join(self._home, self._unroot_lib_path(l))
 
+        @property
+        def version(self):
+            return self._underlying.version
+
     @memoized_method
     def _get_jvm_distribution(self, settings=None):
         local_distribution = self._local_jvm_distribution(settings)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -1122,8 +1122,8 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
             underlying_libs = self._underlying.find_libs(names)
             return [self._rehome(l) for l in underlying_libs]
 
-        def generate_javac_args(self, settings):
-            return Distribution.substitute_java_home(settings.javac_args, self._home)
+        def substitute_home(self, args):
+            return Distribution.substitute_java_home(args, self._home)
 
         def find_libs_path_globs(self, names):
             path_globs = []

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -1120,6 +1120,9 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
             underlying_libs = self._underlying.find_libs(names)
             return [self._rehome(l) for l in underlying_libs]
 
+        def generate_javac_args(self, *args):
+            return self._underlying.generate_javac_args(*args)
+
         def find_libs_path_globs(self, names):
             path_globs = []
             filenames = []
@@ -1150,12 +1153,8 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
         def _rehome(self, l):
             return os.path.join(self._home, self._unroot_lib_path(l))
 
-    def _get_jvm_distribution(self):
-        # TODO We may want to use different jvm distributions depending on what
-        # java version the target expects to be compiled against.
-        # See: https://github.com/pantsbuild/pants/issues/6416 for covering using
-        #      different jdks in remote builds.
-        local_distribution = self._local_jvm_distribution()
+    def _get_jvm_distribution(self, settings=None):
+        local_distribution = self._local_jvm_distribution(settings)
         return match(
             self.execution_strategy,
             {

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -517,7 +517,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
                         scheduler=self.context._scheduler
                     )
 
-                    distribution = self._get_jvm_distribution()
+                    distribution = self._get_jvm_distribution(target.platform)
 
                     def hermetic_digest_classpath():
                         jdk_libs_rel, jdk_libs_digest = self._jdk_libs_paths_and_digest(

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -84,6 +84,7 @@ class BaseZincCompile(JvmCompile):
         :type settings: :class:`JvmPlatformSettings`
         """
         args = list(settings.args)
+        # if source, target or release is already specified, then don't generate args for them.
         if all(a not in ("-C-source", "-C-target", "-C--release") for a in args):
             args.extend([f"-C{arg}" for arg in settings.javac_source_target_args(distribution)])
         # we could inject scala target/release here too, but I think it's unnecessary, because we

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -86,7 +86,7 @@ class BaseZincCompile(JvmCompile):
         args = list(settings.args)
         # if source, target or release is already specified, then don't generate args for them.
         if all(a not in ("-C-source", "-C-target", "-C--release") for a in args):
-            args.extend([f"-C{arg}" for arg in settings.javac_source_target_args(distribution)])
+            args.extend(f"-C{arg}" for arg in settings.javac_source_target_args(distribution))
         # we could inject scala target/release here too, but I think it's unnecessary, because we
         # can cover that in args.
         # if we did, it'd look something like

--- a/src/python/pants/java/distribution/distribution.py
+++ b/src/python/pants/java/distribution/distribution.py
@@ -111,8 +111,8 @@ class Distribution:
         """
         return self._get_version(self.java)
 
-    def generate_javac_args(self, settings):
-        return Distribution.substitute_java_home(settings.javac_args, self.home)
+    def substitute_home(self, args):
+        return Distribution.substitute_java_home(args, self.home)
 
     @staticmethod
     def substitute_java_home(args, home):

--- a/src/python/pants/java/distribution/distribution.py
+++ b/src/python/pants/java/distribution/distribution.py
@@ -111,6 +111,9 @@ class Distribution:
         """
         return self._get_version(self.java)
 
+    def generate_javac_args(self, settings):
+        return settings.javac_args(self.home)
+
     def find_libs(self, names):
         """Looks for jars in the distribution lib folder(s).
 

--- a/src/python/pants/java/distribution/distribution.py
+++ b/src/python/pants/java/distribution/distribution.py
@@ -112,7 +112,15 @@ class Distribution:
         return self._get_version(self.java)
 
     def generate_javac_args(self, settings):
-        return settings.javac_args(self.home)
+        return Distribution.substitute_java_home(settings.javac_args, self.home)
+
+    @staticmethod
+    def substitute_java_home(args, home):
+        if any("$JAVA_HOME" in a for a in args):
+            logger.debug(f'Substituting "$JAVA_HOME" with "{home}" in jvm-platform args.')
+            return (a.replace("$JAVA_HOME", home) for a in args)
+        else:
+            return args
 
     def find_libs(self, names):
         """Looks for jars in the distribution lib folder(s).

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/zinc_compile_integration_base.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/zinc_compile_integration_base.py
@@ -659,6 +659,7 @@ class BaseZincCompileIntegrationTest:
                                  sources=['A.java'])
                     jvm_binary(name='bin',
                                main='org.pantsbuild.cachetest.A',
+                               platform='seven',
                                dependencies=[':a'])
                     """
                 ),


### PR DESCRIPTION
This patch is for the 1.25.x-twtr branch to support our jdk 11 migration. It fixes an issue where jvm distributions were not selected dependent on the target platform, which meant that pants would fail to compile with 11 for an 11 requesting target if there were also targets using 8.

Additionally, JDK 9+'s javac supports `--release` which allows compilation against earlier JDK APIs from javacs for later ones. If a later JDK is being used, with this patch we'll use --release. In zinc, we'll skip adding -source -target etc if they are present in the platform's compiler args.

I haven't written many additional tests, but I checked that the jvm compile tests continue to pass locally. I think travis CI is broken for this branch, but I've also done some testing internally.

@wisechengyi, let me know if you have any questions / suggestions.