### PR TITLE
[internal] Turn on verbose logging in CI

### DIFF
--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -16,6 +16,7 @@ log = true
 use_coverage = true
 
 [pytest]
+args = ["--no-header", "-vv"]
 junit_xml_dir = "dist/test-results/"
 
 [coverage-py]


### PR DESCRIPTION
This will help us to debug failing tests in the feature.

Note that `[test].output` is still set to the default `failed`, so this will only increase verbosity for failed tests.

[ci skip-rust]
[ci skip-build-wheels]