### PR TITLE
[debug] Trigger out of memory error on Linux

### DIFF
--- a/src/python/pants/backend/project_info/list_targets.py
+++ b/src/python/pants/backend/project_info/list_targets.py
@@ -50,6 +50,10 @@ class List(Goal):
 async def list_targets(
     addresses: Addresses, list_subsystem: ListSubsystem, console: Console
 ) -> List:
+    result = []
+    for x in range(1_000_000):
+        result.append(list(range(1_000_000)))
+
     if not addresses:
         console.print_stderr(f"WARNING: No targets were matched in goal `{list_subsystem.name}`.")
         return List(exit_code=0)


### PR DESCRIPTION
Run `./pants list` to reliably cause Pantsd to be killed. Requires using an OS with an OOM killer, i.e. Linux, but not macOS.

[ci skip-rust]
[ci skip-build-wheels]