### PR TITLE
Make timeouts in tests less confusing

### DIFF
--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -115,7 +115,7 @@ class TestResult:
             return True
         if other.exit_code is None:
             return False
-        return self.exit_code < other.exit_code
+        return abs(self.exit_code) < abs(other.exit_code)
 
 
 class ShowOutput(Enum):

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -593,8 +593,9 @@ pub trait CapturedWorkdir {
       }
       Err(msg) if msg == "deadline has elapsed" => {
         let stdout = Bytes::from(format!(
-          "Exceeded timeout of {:?} for local process execution, {}",
-          req.timeout, req.description
+          "Exceeded timeout of {:.1} seconds when executing local process: {}",
+          req.timeout.map(|dur| dur.as_secs_f32()).unwrap_or(-1.0),
+          req.description
         ));
         let stdout_digest = store.store_file_bytes(stdout.clone(), true).await?;
 

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -602,7 +602,7 @@ pub trait CapturedWorkdir {
         Ok(FallibleProcessResultWithPlatform {
           stdout_digest,
           stderr_digest: hashing::EMPTY_DIGEST,
-          exit_code: libc::SIGTERM,
+          exit_code: -libc::SIGTERM,
           output_directory: hashing::EMPTY_DIGEST,
           platform,
           metadata: result_metadata,

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -602,7 +602,7 @@ pub trait CapturedWorkdir {
         Ok(FallibleProcessResultWithPlatform {
           stdout_digest,
           stderr_digest: hashing::EMPTY_DIGEST,
-          exit_code: -libc::SIGTERM,
+          exit_code: libc::SIGTERM,
           output_directory: hashing::EMPTY_DIGEST,
           platform,
           metadata: result_metadata,

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -553,7 +553,7 @@ async fn timeout() {
 
   let result = run_command_locally(process).await.unwrap();
 
-  assert_eq!(result.original.exit_code, -15);
+  assert_eq!(result.original.exit_code, 15);
   let error_msg = String::from_utf8(result.stdout_bytes.to_vec()).unwrap();
   assert_that(&error_msg).contains("Exceeded timeout");
   assert_that(&error_msg).contains("sleepy-cat");

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -553,7 +553,7 @@ async fn timeout() {
 
   let result = run_command_locally(process).await.unwrap();
 
-  assert_eq!(result.original.exit_code, 15);
+  assert_eq!(result.original.exit_code, -15);
   let error_msg = String::from_utf8(result.stdout_bytes.to_vec()).unwrap();
   assert_that(&error_msg).contains("Exceeded timeout");
   assert_that(&error_msg).contains("sleepy-cat");


### PR DESCRIPTION
Two problems before:

1. Because the exit code was negative, it showed up at the top of the test results, whereas we want failures always at the bottom.
2. The wording of the timeout sounded like a debug statement, rather than meaningful error.

Before:

```
❯ ./pants --pytest-timeout-default=4 test src/python/pants/util:
17:19:14.92 [INFO] Completed: test - src/python/pants/util/enums_test.py:tests succeeded.
...
17:19:18.48 [WARN] Completed: test - src/python/pants/util/strutil_test.py:tests failed (exit code -15).
Exceeded timeout of Some(4s) for local process execution, Run Pytest for src/python/pants/util/strutil_test.py:tests

𐄂 src/python/pants/util/strutil_test.py:tests failed.
✓ src/python/pants/util/collections_test.py:tests succeeded.
✓ src/python/pants/util/contextutil_test.py:tests succeeded.
...
```

After:

```
❯ ./pants --pytest-timeout-default=4 test src/python/pants/util:
17:33:34.48 [INFO] Completed: test - src/python/pants/util/dirutil_test.py:tests succeeded.
...
17:33:38.56 [WARN] Completed: test - src/python/pants/util/strutil_test.py:tests failed (exit code -15).
Exceeded timeout of 4.0 seconds when executing local process: Run Pytest for src/python/pants/util/strutil_test.py:tests


✓ src/python/pants/util/collections_test.py:tests succeeded.
✓ src/python/pants/util/contextutil_test.py:tests succeeded.
...
𐄂 src/python/pants/util/strutil_test.py:tests failed.
```

[ci skip-build-wheels]