### PR TITLE
Improve handling of linter reports.

### DIFF
--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -216,6 +216,7 @@ async def setup_pytest_for_target(
         ),
     )
 
+    # Ensure that the empty extra output dir exists.
     extra_output_directory_digest_get = Get(Digest, CreateDigest([Directory(_EXTRA_OUTPUT_DIR)]))
 
     prepared_sources_get = Get(

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Tuple
 
 from pants.backend.python.lint.bandit.skip_field import SkipBanditField
 from pants.backend.python.lint.bandit.subsystem import Bandit
@@ -10,10 +10,26 @@ from pants.backend.python.target_types import InterpreterConstraintsField, Pytho
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import PexRequest, PexRequirements, VenvPex, VenvPexProcess
-from pants.core.goals.lint import LintReport, LintRequest, LintResult, LintResults, LintSubsystem
+from pants.core.goals.lint import (
+    LINTER_REPORT_DIR,
+    LintReport,
+    LintRequest,
+    LintResult,
+    LintResults,
+    LintSubsystem,
+)
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.engine.fs import Digest, DigestSubset, GlobMatchErrorBehavior, MergeDigests, PathGlobs
+from pants.engine.fs import (
+    CreateDigest,
+    Digest,
+    DigestSubset,
+    Directory,
+    MergeDigests,
+    PathGlobs,
+    RemovePrefix,
+    Snapshot,
+)
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import FieldSet, Target
@@ -45,14 +61,10 @@ class BanditPartition:
     interpreter_constraints: InterpreterConstraints
 
 
-def generate_argv(
-    source_files: SourceFiles, bandit: Bandit, *, report_file_name: Optional[str]
-) -> Tuple[str, ...]:
+def generate_argv(source_files: SourceFiles, bandit: Bandit) -> Tuple[str, ...]:
     args = []
     if bandit.config is not None:
         args.append(f"--config={bandit.config}")
-    if report_file_name:
-        args.append(f"--output={report_file_name}")
     args.extend(bandit.args)
     args.extend(source_files.files)
     return tuple(args)
@@ -77,43 +89,41 @@ async def bandit_lint_partition(
     source_files_get = Get(
         SourceFiles, SourceFilesRequest(field_set.sources for field_set in partition.field_sets)
     )
+    # Ensure that the empty report dir exists.
+    report_directory_digest_get = Get(Digest, CreateDigest([Directory(LINTER_REPORT_DIR)]))
 
-    bandit_pex, config_files, source_files = await MultiGet(
-        bandit_pex_get, config_files_get, source_files_get
+    bandit_pex, config_files, report_directory, source_files = await MultiGet(
+        bandit_pex_get, config_files_get, report_directory_digest_get, source_files_get
     )
 
     input_digest = await Get(
-        Digest, MergeDigests((source_files.snapshot.digest, config_files.snapshot.digest))
+        Digest,
+        MergeDigests(
+            (source_files.snapshot.digest, config_files.snapshot.digest, report_directory)
+        ),
     )
-
-    report_file_name = "bandit_report.txt" if lint_subsystem.reports_dir else None
 
     result = await Get(
         FallibleProcessResult,
         VenvPexProcess(
             bandit_pex,
-            argv=generate_argv(source_files, bandit, report_file_name=report_file_name),
+            argv=generate_argv(source_files, bandit),
             input_digest=input_digest,
             description=f"Run Bandit on {pluralize(len(partition.field_sets), 'file')}.",
-            output_files=(report_file_name,) if report_file_name else None,
+            output_directories=(LINTER_REPORT_DIR,),
             level=LogLevel.DEBUG,
         ),
     )
 
-    report = None
-    if report_file_name:
-        report_digest = await Get(
-            Digest,
-            DigestSubset(
-                result.output_digest,
-                PathGlobs(
-                    [report_file_name],
-                    glob_match_error_behavior=GlobMatchErrorBehavior.warn,
-                    description_of_origin="Bandit report file",
-                ),
-            ),
+    report: LintReport | None = None
+    report_snapshot = await Get(
+        Snapshot, DigestSubset(result.output_digest, PathGlobs([f"{LINTER_REPORT_DIR}/**"]))
+    )
+    if report_snapshot.files:
+        report_snapshot = await Get(
+            Snapshot, RemovePrefix(report_snapshot.digest, LINTER_REPORT_DIR)
         )
-        report = LintReport(report_file_name, report_digest)
+        report = LintReport(report_snapshot.digest)
 
     return LintResult.from_fallible_process_result(
         result,

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -184,7 +184,9 @@ def test_3rdparty_plugin(rule_runner: RuleRunner) -> None:
 def test_report_file(rule_runner: RuleRunner) -> None:
     rule_runner.write_files({"f.py": BAD_FILE, "BUILD": "python_library(name='t')"})
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
-    result = run_bandit(rule_runner, [tgt], extra_args=["--lint-reports-dir='.'"])
+    result = run_bandit(
+        rule_runner, [tgt], extra_args=["--bandit-args='--output=reports/output.txt'"]
+    )
     assert len(result) == 1
     assert result[0].exit_code == 1
     assert result[0].stdout.strip() == ""

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -16,8 +16,11 @@ class Bandit(PythonToolBase):
     help = "A tool for finding security issues in Python code (https://bandit.readthedocs.io)."
 
     default_version = "bandit>=1.6.2,<1.7"
-    # `setuptools<45` is for Python 2 support. `stevedore` is because the 3.0 release breaks Bandit.
-    default_extra_requirements = ["setuptools<45", "stevedore<3"]
+    default_extra_requirements = [
+        "setuptools<45; python_full_version == '2.7.*'",
+        "setuptools; python_version > '2.7'",
+        "stevedore<3",  # stevedore 3.0 breaks Bandit.
+    ]
     default_main = ConsoleScript("bandit")
 
     @classmethod

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Tuple
 
 from pants.backend.python.lint.flake8.skip_field import SkipFlake8Field
 from pants.backend.python.lint.flake8.subsystem import Flake8
@@ -10,10 +10,25 @@ from pants.backend.python.target_types import InterpreterConstraintsField, Pytho
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import PexRequest, PexRequirements, VenvPex, VenvPexProcess
-from pants.core.goals.lint import LintReport, LintRequest, LintResult, LintResults, LintSubsystem
+from pants.core.goals.lint import (
+    LINTER_REPORT_DIR,
+    LintReport,
+    LintRequest,
+    LintResult,
+    LintResults,
+)
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.engine.fs import Digest, DigestSubset, GlobMatchErrorBehavior, MergeDigests, PathGlobs
+from pants.engine.fs import (
+    CreateDigest,
+    Digest,
+    DigestSubset,
+    Directory,
+    MergeDigests,
+    PathGlobs,
+    RemovePrefix,
+    Snapshot,
+)
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import FieldSet, Target
@@ -45,23 +60,17 @@ class Flake8Partition:
     interpreter_constraints: InterpreterConstraints
 
 
-def generate_argv(
-    source_files: SourceFiles, flake8: Flake8, *, report_file_name: Optional[str]
-) -> Tuple[str, ...]:
+def generate_argv(source_files: SourceFiles, flake8: Flake8) -> Tuple[str, ...]:
     args = []
     if flake8.config:
         args.append(f"--config={flake8.config}")
-    if report_file_name:
-        args.append(f"--output-file={report_file_name}")
     args.extend(flake8.args)
     args.extend(source_files.files)
     return tuple(args)
 
 
 @rule(level=LogLevel.DEBUG)
-async def flake8_lint_partition(
-    partition: Flake8Partition, flake8: Flake8, lint_subsystem: LintSubsystem
-) -> LintResult:
+async def flake8_lint_partition(partition: Flake8Partition, flake8: Flake8) -> LintResult:
     flake8_pex_get = Get(
         VenvPex,
         PexRequest(
@@ -76,42 +85,40 @@ async def flake8_lint_partition(
     source_files_get = Get(
         SourceFiles, SourceFilesRequest(field_set.sources for field_set in partition.field_sets)
     )
-    flake8_pex, config_files, source_files = await MultiGet(
-        flake8_pex_get, config_files_get, source_files_get
+    # Ensure that the empty report dir exists.
+    report_directory_digest_get = Get(Digest, CreateDigest([Directory(LINTER_REPORT_DIR)]))
+    flake8_pex, config_files, report_directory, source_files = await MultiGet(
+        flake8_pex_get, config_files_get, report_directory_digest_get, source_files_get
     )
 
     input_digest = await Get(
-        Digest, MergeDigests((source_files.snapshot.digest, config_files.snapshot.digest))
+        Digest,
+        MergeDigests(
+            (source_files.snapshot.digest, config_files.snapshot.digest, report_directory)
+        ),
     )
-
-    report_file_name = "flake8_report.txt" if lint_subsystem.reports_dir else None
 
     result = await Get(
         FallibleProcessResult,
         VenvPexProcess(
             flake8_pex,
-            argv=generate_argv(source_files, flake8, report_file_name=report_file_name),
+            argv=generate_argv(source_files, flake8),
             input_digest=input_digest,
-            output_files=(report_file_name,) if report_file_name else None,
+            output_directories=(LINTER_REPORT_DIR,),
             description=f"Run Flake8 on {pluralize(len(partition.field_sets), 'file')}.",
             level=LogLevel.DEBUG,
         ),
     )
 
-    report = None
-    if report_file_name:
-        report_digest = await Get(
-            Digest,
-            DigestSubset(
-                result.output_digest,
-                PathGlobs(
-                    [report_file_name],
-                    glob_match_error_behavior=GlobMatchErrorBehavior.warn,
-                    description_of_origin="Flake8 report file",
-                ),
-            ),
+    report: LintReport | None = None
+    report_snapshot = await Get(
+        Snapshot, DigestSubset(result.output_digest, PathGlobs([f"{LINTER_REPORT_DIR}/**"]))
+    )
+    if report_snapshot.files:
+        report_snapshot = await Get(
+            Snapshot, RemovePrefix(report_snapshot.digest, LINTER_REPORT_DIR)
         )
-        report = LintReport(report_file_name, report_digest)
+        report = LintReport(report_snapshot.digest)
 
     return LintResult.from_fallible_process_result(
         result,

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -179,7 +179,9 @@ def test_3rdparty_plugin(rule_runner: RuleRunner) -> None:
 def test_report_file(rule_runner: RuleRunner) -> None:
     rule_runner.write_files({"f.py": BAD_FILE, "BUILD": "python_library(name='t')"})
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
-    result = run_flake8(rule_runner, [tgt], extra_args=["--lint-reports-dir='.'"])
+    result = run_flake8(
+        rule_runner, [tgt], extra_args=["--flake8-args='--output-file=reports/foo.txt'"]
+    )
     assert len(result) == 1
     assert result[0].exit_code == 1
     assert result[0].stdout.strip() == ""

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -15,7 +15,7 @@ class Flake8(PythonToolBase):
     options_scope = "flake8"
     help = "The Flake8 Python linter (https://flake8.pycqa.org/)."
 
-    default_version = "flake8>=3.7.9,<3.9"
+    default_version = "flake8>=3.9.2,<4.0"
     default_extra_requirements = [
         "setuptools<45; python_full_version == '2.7.*'",
         "setuptools; python_version > '2.7'",

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -97,10 +97,6 @@ class LintResults:
     def exit_code(self) -> int:
         return next((result.exit_code for result in self.results if result.exit_code != 0), 0)
 
-    # @memoized_property
-    # def reports(self) -> Tuple[LintReport, ...]:
-    #     return tuple(result.report for result in self.results if result.report)
-
 
 class EnrichedLintResults(LintResults, EngineAwareReturnType):
     """`LintResults` that are enriched for the sake of logging results as they come in.
@@ -157,7 +153,7 @@ class LintRequest(StyleRequest):
 
 # If a user wants linter reports to show up in dist/ they must ensure that the reports
 # are written under this directory. E.g.,
-# ./pants lint <target> -- --output=reports/report.html
+# ./pants --flake8-args="--output-file=reports/report.txt" lint <target>
 LINTER_REPORT_DIR = "reports"
 
 
@@ -196,8 +192,8 @@ class LintSubsystem(GoalSubsystem):
                 "into this directory."
             ),
             removal_version="2.7.0.dev0",
-            removal_hint=f"Edit the linter's config to cause it to write reports under "
-            f"{LINTER_REPORT_DIR} .",
+            removal_hint=f"Edit the config file for the linter in question, or set its args via "
+            f"Pants options, to cause it to write reports under f{LINTER_REPORT_DIR} .",
         )
 
     @property

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from abc import ABCMeta, abstractmethod
+from pathlib import Path
 from textwrap import dedent
 from typing import ClassVar, Iterable, List, Optional, Tuple, Type
 
@@ -15,12 +16,13 @@ from pants.core.goals.lint import (
     LintSubsystem,
     lint,
 )
+from pants.core.util_rules.distdir import DistDir
 from pants.core.util_rules.filter_empty_sources import (
     FieldSetsWithSources,
     FieldSetsWithSourcesRequest,
 )
 from pants.engine.addresses import Address
-from pants.engine.fs import EMPTY_DIGEST, Digest, MergeDigests, Workspace
+from pants.engine.fs import Workspace
 from pants.engine.target import FieldSet, Sources, Target, Targets
 from pants.engine.unions import UnionMembership
 from pants.testutil.option_util import create_goal_subsystem
@@ -138,6 +140,7 @@ def run_lint_rule(
                     LintSubsystem, per_file_caching=per_file_caching, per_target_caching=False
                 ),
                 union_membership,
+                DistDir(relpath=Path("dist")),
             ],
             mock_gets=[
                 MockGet(
@@ -152,7 +155,6 @@ def run_lint_rule(
                         field_sets if include_sources else ()
                     ),
                 ),
-                MockGet(output_type=Digest, input_type=MergeDigests, mock=lambda _: EMPTY_DIGEST),
             ],
             union_membership=union_membership,
         )

--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -161,3 +161,18 @@ def first_paragraph(s: str) -> str:
         (i for i, line in enumerate(lines) if line.strip() == ""), len(lines)
     )
     return " ".join(lines[:first_blank_line_index])
+
+
+# This is more conservative that it necessarily need be. In practice POSIX filesystems
+# support any printable character except the path separator (forward slash), but it's
+# better to be over-cautious.
+
+# TODO: <> may not be safe in Windows paths. When we support Windows we will probably
+#  want to detect that here and be more restrictive on that platform. But we do want
+#  to support <> where possible, because they appear in target partition descriptions
+#  (e.g., "CPython>=2.7,<3") and those are sometimes converted to paths.
+_non_path_safe_re = re.compile(r"[^a-zA-Z0-9_\-.()<>,= ]")
+
+
+def path_safe(s: str) -> str:
+    return _non_path_safe_re.sub("_", s)

--- a/src/python/pants/util/strutil_test.py
+++ b/src/python/pants/util/strutil_test.py
@@ -1,50 +1,53 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import unittest
 from textwrap import dedent
+
+import pytest
 
 from pants.util.strutil import (
     ensure_binary,
     ensure_text,
     first_paragraph,
     hard_wrap,
+    path_safe,
     pluralize,
     strip_prefix,
     strip_v2_chroot_path,
 )
 
 
-# TODO(Eric Ayers): Backfill tests for other methods in strutil.py
-class StrutilTest(unittest.TestCase):
-    def test_pluralize(self) -> None:
-        self.assertEqual("1 bat", pluralize(1, "bat"))
-        self.assertEqual("1 boss", pluralize(1, "boss"))
-        self.assertEqual("2 bats", pluralize(2, "bat"))
-        self.assertEqual("2 bosses", pluralize(2, "boss"))
-        self.assertEqual("0 bats", pluralize(0, "bat"))
-        self.assertEqual("0 bosses", pluralize(0, "boss"))
+def test_pluralize() -> None:
+    assert "1 bat" == pluralize(1, "bat")
+    assert "1 boss" == pluralize(1, "boss")
+    assert "2 bats" == pluralize(2, "bat")
+    assert "2 bosses" == pluralize(2, "boss")
+    assert "0 bats" == pluralize(0, "bat")
+    assert "0 bosses" == pluralize(0, "boss")
 
-    def test_ensure_text(self) -> None:
-        bytes_val = bytes(bytearray([0xE5, 0xBF, 0xAB]))
-        self.assertEqual("快", ensure_text(bytes_val))
-        with self.assertRaises(TypeError):
-            ensure_text(45)  # type: ignore[arg-type] # intended to fail type check
 
-    def test_ensure_binary(self) -> None:
-        unicode_val = "快"
-        self.assertEqual(bytearray([0xE5, 0xBF, 0xAB]), ensure_binary(unicode_val))
-        with self.assertRaises(TypeError):
-            ensure_binary(45)  # type: ignore[arg-type] # intended to fail type check
+def test_ensure_text() -> None:
+    bytes_val = bytes(bytearray([0xE5, 0xBF, 0xAB]))
+    assert "快", ensure_text(bytes_val)
+    with pytest.raises(TypeError):
+        ensure_text(45)  # type: ignore[arg-type] # intended to fail type check
 
-    def test_strip_prefix(self) -> None:
-        self.assertEqual("testString", strip_prefix("testString", "//"))
-        self.assertEqual("/testString", strip_prefix("/testString", "//"))
-        self.assertEqual("testString", strip_prefix("//testString", "//"))
-        self.assertEqual("/testString", strip_prefix("///testString", "//"))
-        self.assertEqual("//testString", strip_prefix("////testString", "//"))
-        self.assertEqual("test//String", strip_prefix("test//String", "//"))
-        self.assertEqual("testString//", strip_prefix("testString//", "//"))
+
+def test_ensure_binary() -> None:
+    unicode_val = "快"
+    assert bytearray([0xE5, 0xBF, 0xAB]) == ensure_binary(unicode_val)
+    with pytest.raises(TypeError):
+        ensure_binary(45)  # type: ignore[arg-type] # intended to fail type check
+
+
+def test_strip_prefix() -> None:
+    assert "testString" == strip_prefix("testString", "//")
+    assert "/testString" == strip_prefix("/testString", "//")
+    assert "testString" == strip_prefix("//testString", "//")
+    assert "/testString" == strip_prefix("///testString", "//")
+    assert "//testString" == strip_prefix("////testString", "//")
+    assert "test//String" == strip_prefix("test//String", "//")
+    assert "testString//" == strip_prefix("testString//", "//")
 
 
 def test_strip_chroot_path() -> None:
@@ -130,3 +133,9 @@ def test_first_paragraph() -> None:
         == "Hello! I'm spread out over multiple    lines."
     )
     assert first_paragraph("Only one paragraph.") == "Only one paragraph."
+
+
+def test_path_safe() -> None:
+    assert "abcDEF123" == path_safe("abcDEF123")
+    assert "CPython>=2.7,<3 (fun times)" == path_safe("CPython>=2.7,<3 (fun times)")
+    assert "foo bar_ baz_" == path_safe("foo bar! baz@")


### PR DESCRIPTION
Previously we tried to directly control linter report file output options, which led to several problems:
- We hard-coded report file names, including a .txt suffix, which doesn't play well with linters like Bandit that have several possible output formats.
- We assumed reports were a single file.
- We only supported a single report per linter, even if there were partitions.

This change modifies how we handle linter report files, bringing it inline with how we handle PyTest plugin custom output.
- Now all the user has to do to get a report is request it using the linter's standard args or config, and the only constraint is that those must go into a reldir named `reports/`, so that we know to capture it out of the sandbox.
- We capture whatever is in that dir, no matter how many files.
- We output whatever reports we find to dist/ , under a directory that is per-partition, so multiple lint runs can emit reports.

The only caveat is that it's not obvious to the user that they must configure their reports must go under `reports/`. So we must document this clearly. In the future we could potentially attempt to detect this case and warn by heuristically analyzing the args and/or config. But that also might be overkill so we don't do it yet.

[ci skip-rust]

[ci skip-build-wheels]