### PR TITLE
Allow overriding option default help display.

### DIFF
--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -190,7 +190,8 @@ class ReferenceGenerator:
             if default_help_repr is None:
                 default_str = to_help_str(option_data["default"])
             else:
-                default_str = default_help_repr
+                # It should already be a string, but might as well be safe.
+                default_str = to_help_str(default_help_repr)
             escaped_default_str = markdown_safe(default_str)
             if "\n" in default_str:
                 option_data["marked_up_default"] = f"<pre>{escaped_default_str}</pre>"

--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -186,7 +186,11 @@ class ReferenceGenerator:
         def munge_option(option_data):
             # Munge the default so we can display it nicely when it's multiline, while
             # still displaying it inline if it's not.
-            default_str = to_help_str(option_data["default"])
+            default_help_repr = option_data.get("default_help_repr")
+            if default_help_repr is None:
+                default_str = to_help_str(option_data["default"])
+            else:
+                default_str = default_help_repr
             escaped_default_str = markdown_safe(default_str)
             if "\n" in default_str:
                 option_data["marked_up_default"] = f"<pre>{escaped_default_str}</pre>"

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -280,15 +280,12 @@ class HelpInfoExtracter:
 
     @staticmethod
     def compute_default(**kwargs) -> Any:
-        """Compute the default val for help display for an option registered with these kwargs.
-
-        Returns a pair (default, stringified default suitable for display).
-        """
+        """Compute the default val for help display for an option registered with these kwargs."""
         # If the kwargs already determine a string representation of the default for use in help
         # messages, use that.
         default_help_repr = kwargs.get("default_help_repr")
         if default_help_repr is not None:
-            return default_help_repr
+            return str(default_help_repr)  # Should already be a string, but might as well be safe.
 
         ranked_default = kwargs.get("default")
         fallback: Any = None

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -284,6 +284,12 @@ class HelpInfoExtracter:
 
         Returns a pair (default, stringified default suitable for display).
         """
+        # If the kwargs already determine a string representation of the default for use in help
+        # messages, use that.
+        default_help_repr = kwargs.get("default_help_repr")
+        if default_help_repr is not None:
+            return default_help_repr
+
         ranked_default = kwargs.get("default")
         fallback: Any = None
         if is_list_option(kwargs):

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -127,6 +127,7 @@ def test_default() -> None:
     do_test(["--foo"], {}, "None")
     do_test(["--foo"], {"type": int}, "None")
     do_test(["--foo"], {"type": int, "default": 42}, "42")
+    do_test(["--foo"], {"type": int, "default": 65536, "default_help_repr": "64KiB"}, "64KiB")
     do_test(["--foo"], {"type": list}, "[]")
     do_test(["--foo"], {"type": dict}, "{}")
     do_test(["--foo"], {"type": LogLevel}, "None")

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -838,12 +838,12 @@ class GlobalOptions(Subsystem):
             rule_threads_core,
             type=int,
             default=max(2, _CPU_COUNT // 2),
+            default_help_repr="max(2, #cores/2)",
             advanced=True,
             help=(
                 "The number of threads to keep active and ready to execute `@rule` logic (see "
                 f"also: `{rule_threads_max}`).\n\nValues less than 2 are not currently supported. "
-                "\n\nDefaults to half the number of cores on your machine.\n\nThis value is "
-                "independent of the number of processes that may be spawned in "
+                "\n\nThis value is independent of the number of processes that may be spawned in "
                 f"parallel locally (controlled by `{process_execution_local_parallelism}`)."
             ),
         )
@@ -989,12 +989,12 @@ class GlobalOptions(Subsystem):
             process_execution_local_parallelism,
             type=int,
             default=DEFAULT_EXECUTION_OPTIONS.process_execution_local_parallelism,
+            default_help_repr="#cores",
             advanced=True,
             help=(
                 "Number of concurrent processes that may be executed locally.\n\n"
-                "Defaults to the number of cores on your machine.\n\nThis value is independent of "
-                "the number of threads that may be used to execute the logic in `@rules` "
-                f"(controlled by `{rule_threads_core}`)."
+                "This value is independent of the number of threads that may be used to "
+                f"execute the logic in `@rules` (controlled by `{rule_threads_core}`)."
             ),
         )
         register(

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -443,6 +443,7 @@ class Parser:
         "choices",
         "dest",
         "default",
+        "default_help_repr",
         "implicit_value",
         "metavar",
         "help",


### PR DESCRIPTION
In rare cases we may want the help to show some string
explaining the default value, instead of showing the actual value.

For example, a more instructive help would explain that the default
for --process-execution-local-parallelism is "#cores" and not
whatever the number of cores is on the machine generating the help
(which in the case of the docsite is the releaser's machine, which
is really not useful to the reader).

This change supports this functionality. It is intended to be used
sparingly.  But another place where this could be employed is when
int values take on units (e.g., "512MiB"). We'd want to display
the default as a string including the units, and not as the
underlying raw int (e.g, 537395200).

[ci skip-rust]

[ci skip-build-wheels]