### PR TITLE
add retries for reads and writes from remote CAS

### DIFF
--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -40,6 +40,7 @@ impl fmt::Debug for ByteStore {
 }
 
 /// Represents an error from accessing a remote bytestore.
+#[derive(Debug)]
 pub enum ByteStoreError {
   /// gRPC error
   Grpc(Status),
@@ -53,15 +54,6 @@ impl fmt::Display for ByteStoreError {
     match self {
       ByteStoreError::Grpc(status) => fmt::Display::fmt(status, f),
       ByteStoreError::Other(msg) => fmt::Display::fmt(msg, f),
-    }
-  }
-}
-
-impl fmt::Debug for ByteStoreError {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    match self {
-      ByteStoreError::Grpc(status) => fmt::Debug::fmt(status, f),
-      ByteStoreError::Other(msg) => fmt::Debug::fmt(msg, f),
     }
   }
 }

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -317,5 +317,8 @@ pub async fn load_directory_proto_bytes(
 }
 
 async fn load_bytes(store: &ByteStore, digest: Digest) -> Result<Option<Bytes>, String> {
-  store.load_bytes_with(digest, |b| Ok(b)).await.map_err(|err| format!("{}", err))
+  store
+    .load_bytes_with(digest, |b| Ok(b))
+    .await
+    .map_err(|err| format!("{}", err))
 }

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -317,5 +317,5 @@ pub async fn load_directory_proto_bytes(
 }
 
 async fn load_bytes(store: &ByteStore, digest: Digest) -> Result<Option<Bytes>, String> {
-  store.load_bytes_with(digest, |b| Ok(b)).await
+  store.load_bytes_with(digest, |b| Ok(b)).await.map_err(|err| format!("{}", err))
 }


### PR DESCRIPTION
## Problem

When using remote cache, transient errors returned by the remote system or local client stack (e.g, gRPC "unavailable" status) are not retried. This is not as good an experience for users of remote cache as they will see warnings about remote cache issues.

## Solution

Retry failed remote cache requests using exponential backoff. This PR uses the `retry_call` helper introduced in https://github.com/pantsbuild/pants/pull/12102 to add retries to reads and writes. A new error struct `ByteStoreError` has been introduced to `load_bytes_with` and `store_bytes_source` to allow callers to access tonic::Status errors directly to decide whether to retry.

Fixes remainder of https://github.com/pantsbuild/pants/issues/11373.