### PR TITLE
Remove `dynamic_ui` and `colors` options from `pants.ci.toml`

### DIFF
--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -1,9 +1,4 @@
 [GLOBAL]
-# Override color support detection - we want colors and Travis supports them.
-colors = true
-# TODO: See #9924.
-dynamic_ui = false
-
 remote_cache_read = true
 remote_cache_write = true
 # We want to continue to get logs when remote caching errors.


### PR DESCRIPTION
Pants's default behavior works correctly on GitHub Actions. If it's not working for other platforms, that's a bug that we need to fix.

We want it to be feasible to have no `pants.ci.toml`. Our defaults should Just Work.

[ci skip-rust]
[ci skip-build-wheels]