### PR TITLE
add retries for reads and writes from remote CAS (Cherry pick of #12132)

### DIFF
--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -2,6 +2,7 @@ use std::cmp::min;
 use std::collections::{BTreeMap, HashSet};
 use std::convert::TryInto;
 use std::fmt;
+use std::ops::Range;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -16,9 +17,8 @@ use grpc_util::{headers_to_interceptor_fn, status_to_str};
 use hashing::Digest;
 use log::Level;
 use remexec::content_addressable_storage_client::ContentAddressableStorageClient;
-use std::ops::Range;
 use tonic::transport::Channel;
-use tonic::{Code, Interceptor, Request};
+use tonic::{Code, Interceptor, Request, Status};
 use workunit_store::{with_workunit, ObservationMetric, WorkunitMetadata};
 
 #[derive(Clone)]
@@ -38,6 +38,27 @@ impl fmt::Debug for ByteStore {
     write!(f, "ByteStore(name={:?})", self.instance_name)
   }
 }
+
+/// Represents an error from accessing a remote bytestore.
+#[derive(Debug)]
+pub enum ByteStoreError {
+  /// gRPC error
+  Grpc(Status),
+
+  /// Other errors
+  Other(String),
+}
+
+impl fmt::Display for ByteStoreError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      ByteStoreError::Grpc(status) => fmt::Display::fmt(status, f),
+      ByteStoreError::Other(msg) => fmt::Display::fmt(msg, f),
+    }
+  }
+}
+
+impl std::error::Error for ByteStoreError {}
 
 impl ByteStore {
   // TODO: Consider extracting these options to a struct with `impl Default`, similar to
@@ -122,7 +143,7 @@ impl ByteStore {
     // could be mutated by another process. We guard against this by creating an anonymous
     // temporary file and ensuring it is written to and closed via the only other handle to it in
     // the code just above.
-    let mmap = unsafe {
+    let mmap = Arc::new(unsafe {
       let mapping = memmap::Mmap::map(&read_buffer).map_err(|e| {
         format!(
           "Failed to memory map the temporary file buffer for {digest:?}: {err}",
@@ -143,25 +164,45 @@ impl ByteStore {
         )
       }
       Ok(mapping) as Result<memmap::Mmap, String>
-    }?;
+    }?);
 
-    self
-      .store_bytes_source(digest, move |range| Bytes::copy_from_slice(&mmap[range]))
-      .await
+    retry_call(
+      mmap,
+      |mmap| self.store_bytes_source(digest, move |range| Bytes::copy_from_slice(&mmap[range])),
+      |err| match err {
+        ByteStoreError::Grpc(status) => status_is_retryable(status),
+        _ => false,
+      },
+    )
+    .await
+    .map_err(|err| match err {
+      ByteStoreError::Grpc(status) => status_to_str(status),
+      ByteStoreError::Other(msg) => msg,
+    })
   }
 
   pub async fn store_bytes(&self, bytes: Bytes) -> Result<(), String> {
     let digest = Digest::of_bytes(&bytes);
-    self
-      .store_bytes_source(digest, move |range| bytes.slice(range))
-      .await
+    retry_call(
+      bytes,
+      |bytes| self.store_bytes_source(digest, move |range| bytes.slice(range)),
+      |err| match err {
+        ByteStoreError::Grpc(status) => status_is_retryable(status),
+        _ => false,
+      },
+    )
+    .await
+    .map_err(|err| match err {
+      ByteStoreError::Grpc(status) => status_to_str(status),
+      ByteStoreError::Other(msg) => msg,
+    })
   }
 
   async fn store_bytes_source<ByteSource>(
     &self,
     digest: Digest,
     bytes: ByteSource,
-  ) -> Result<(), String>
+  ) -> Result<(), ByteStoreError>
   where
     ByteSource: Fn(Range<usize>) -> Bytes + Send + Sync + 'static,
   {
@@ -208,16 +249,16 @@ impl ByteStore {
       let response = client
         .write(Request::new(stream))
         .await
-        .map_err(status_to_str)?;
+        .map_err(ByteStoreError::Grpc)?;
 
       let response = response.into_inner();
       if response.committed_size == len as i64 {
         Ok(())
       } else {
-        Err(format!(
+        Err(ByteStoreError::Other(format!(
           "Uploading file with digest {:?}: want committed size {} but got {}",
           digest, len, response.committed_size
-        ))
+        )))
       }
     });
 
@@ -243,7 +284,7 @@ impl ByteStore {
     &self,
     digest: Digest,
     f: F,
-  ) -> Result<Option<T>, String> {
+  ) -> Result<Option<T>, ByteStoreError> {
     let store = self.clone();
     let resource_name = format!(
       "{}/blobs/{}/{}",
@@ -280,7 +321,7 @@ impl ByteStore {
         Err(status) => {
           return match status.code() {
             Code::NotFound => Ok(None),
-            _ => Err(status_to_str(status)),
+            _ => Err(ByteStoreError::Grpc(status)),
           }
         }
       };
@@ -319,13 +360,13 @@ impl ByteStore {
           if status.code() == tonic::Code::NotFound {
             None
           } else {
-            return Err(status_to_str(status));
+            return Err(ByteStoreError::Grpc(status));
           }
         }
       };
 
       match maybe_bytes {
-        Some(b) => f(b).map(Some),
+        Some(b) => f(b).map(Some).map_err(ByteStoreError::Other),
         None => Ok(None),
       }
     };

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -317,5 +317,8 @@ pub async fn load_directory_proto_bytes(
 }
 
 async fn load_bytes(store: &ByteStore, digest: Digest) -> Result<Option<Bytes>, String> {
-  store.load_bytes_with(digest, |b| Ok(b)).await
+  store
+    .load_bytes_with(digest, |b| Ok(b))
+    .await
+    .map_err(|err| format!("{}", err))
 }


### PR DESCRIPTION
## Problem

When using remote cache, transient errors returned by the remote system or local client stack (e.g, gRPC "unavailable" status) are not retried. This is not as good an experience for users of remote cache as they will see warnings about remote cache issues.

## Solution

Retry failed remote cache requests using exponential backoff. This PR uses the `retry_call` helper introduced in https://github.com/pantsbuild/pants/pull/12102 to add retries to reads and writes. A new error struct `ByteStoreError` has been introduced to `load_bytes_with` and `store_bytes_source` to allow callers to access tonic::Status errors directly to decide whether to retry.

Fixes remainder of https://github.com/pantsbuild/pants/issues/11373.