### PR TITLE
allow prepending args to the venv invocation

### DIFF
--- a/pants
+++ b/pants
@@ -46,8 +46,6 @@ function exec_pants_bare() {
   activate_pants_venv 1>&2
   bootstrap_native_code 1>&2
 
-  # Because the venv has been activated, we simply say `python` and it will use the venv's version. We cannot use
-  # `${PY}` because it could use the wrong interpreter if the value is an absolute path.
   PYTHONPATH="${PANTS_SRCPATH}:${PYTHONPATH}" RUNNING_PANTS_FROM_SOURCES=1 \
     exec ${PANTS_PREPEND_ARGS:-} "$(venv_dir)/bin/python" "${PANTS_EXE}" "$@"
 }

--- a/pants
+++ b/pants
@@ -49,7 +49,7 @@ function exec_pants_bare() {
   # Because the venv has been activated, we simply say `python` and it will use the venv's version. We cannot use
   # `${PY}` because it could use the wrong interpreter if the value is an absolute path.
   PYTHONPATH="${PANTS_SRCPATH}:${PYTHONPATH}" RUNNING_PANTS_FROM_SOURCES=1 \
-    exec python "${PANTS_EXE}" "$@"
+    exec ${PANTS_PREPEND_ARGS:-} "$(venv_dir)/bin/python" "${PANTS_EXE}" "$@"
 }
 
 exec_pants_bare "$@"

--- a/pants
+++ b/pants
@@ -46,6 +46,7 @@ function exec_pants_bare() {
   activate_pants_venv 1>&2
   bootstrap_native_code 1>&2
 
+  # shellcheck disable=SC2086
   PYTHONPATH="${PANTS_SRCPATH}:${PYTHONPATH}" RUNNING_PANTS_FROM_SOURCES=1 \
     exec ${PANTS_PREPEND_ARGS:-} "$(venv_dir)/bin/python" "${PANTS_EXE}" "$@"
 }


### PR DESCRIPTION
I need to prepend a profiler command so that pants is invoked under the profiler (e.g., `heaptrack` or `valgrind`).  This PR modifies the `./pants` script so that the caller can set `PANTS_PREPEND_ARGS` so that the profiler is directly invoked instead of pants (which runs under control of the profiler). It also uses the full path to the venv python interpreter (which had confused `heaptrack` since `heaptrack` doesn't scan the PATH).

Examples:

```
PANTS_PREPEND_ARGS="/usr/local/bin/heaptrack" ./pants --no-pantsd typecheck src/python/pants/backend/go::
```

I plan on writing up how to do this, and it seems silly to make users of those (coming) docs to have to patch `./pants` each time.

[ci skip-rust]

[ci skip-build-wheels]