### PR TITLE
Fix `[python-setup].resolver_jobs` default value to better recognize containers

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -34,13 +34,9 @@ from pants.util.dirutil import fast_relpath_optional
 from pants.util.docutil import bracketed_docs_url
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import OrderedSet
+from pants.util.osutil import CPU_COUNT
 
 logger = logging.getLogger(__name__)
-
-
-_CPU_COUNT = (
-    len(os.sched_getaffinity(0)) if hasattr(os, "sched_getaffinity") else os.cpu_count()
-) or 2
 
 
 # The time that leases are acquired for in the local store. Configured on the Python side
@@ -417,7 +413,7 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     remote_instance_name=None,
     remote_ca_certs_path=None,
     # Process execution setup.
-    process_execution_local_parallelism=_CPU_COUNT,
+    process_execution_local_parallelism=CPU_COUNT,
     process_execution_remote_parallelism=128,
     process_execution_cache_namespace=None,
     process_execution_local_cleanup=True,
@@ -842,7 +838,7 @@ class GlobalOptions(Subsystem):
         register(
             rule_threads_core,
             type=int,
-            default=max(2, _CPU_COUNT // 2),
+            default=max(2, CPU_COUNT // 2),
             default_help_repr="max(2, #cores/2)",
             advanced=True,
             help=(

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import logging
-import multiprocessing
 import os
 from pathlib import Path
 from typing import Iterable, List, Optional, Tuple, cast
@@ -16,6 +15,7 @@ from pants.engine.environment import Environment
 from pants.option.custom_types import file_option
 from pants.option.subsystem import Subsystem
 from pants.util.memo import memoized_method
+from pants.util.osutil import CPU_COUNT
 
 logger = logging.getLogger(__name__)
 
@@ -100,13 +100,14 @@ class PythonSetup(Subsystem):
         register(
             "--resolver-jobs",
             type=int,
-            default=multiprocessing.cpu_count() // 2,
+            default=CPU_COUNT // 2,
+            default_help_repr="#cores/2",
             advanced=True,
             help=(
-                "The maximum number of concurrent jobs to build wheels with. Because Pants "
+                "The maximum number of concurrent jobs to build wheels with.\n\nBecause Pants "
                 "can run multiple subprocesses in parallel, the maximum total parallelism will be "
                 "`--process-execution-{local,remote}-parallelism x --python-setup-resolver-jobs`. "
-                "Setting this option higher may result in better parallelism, but, if set too "
+                "\n\nSetting this option higher may result in better parallelism, but, if set too "
                 "high, may result in starvation and Out of Memory errors."
             ),
         )

--- a/src/python/pants/util/osutil.py
+++ b/src/python/pants/util/osutil.py
@@ -12,8 +12,8 @@ logger = logging.getLogger(__name__)
 
 
 # We use `sched_getaffinity()` to get the number of cores available to the process, rather than
-# the raw number of cores. This ensures that containers report their # of cores, rather than
-# the host's.
+# the raw number of cores. This sometimes helps for containers to accurately report their # of
+# cores, rather than the host's.
 CPU_COUNT = (
     len(os.sched_getaffinity(0)) if hasattr(os, "sched_getaffinity") else os.cpu_count()
 ) or 2

--- a/src/python/pants/util/osutil.py
+++ b/src/python/pants/util/osutil.py
@@ -11,6 +11,14 @@ from typing import Optional, Set
 logger = logging.getLogger(__name__)
 
 
+# We use `sched_getaffinity()` to get the number of cores available to the process, rather than
+# the raw number of cores. This ensures that containers report their # of cores, rather than
+# the host's.
+CPU_COUNT = (
+    len(os.sched_getaffinity(0)) if hasattr(os, "sched_getaffinity") else os.cpu_count()
+) or 2
+
+
 OS_ALIASES = {
     "darwin": {"macos", "darwin", "macosx", "mac os x", "mac"},
     "linux": {"linux", "linux2"},


### PR DESCRIPTION
As reported by John, on a machine with 8 cores:

```
$ python3.8 -c 'import multiprocessing, os; print(f"multiprocessing: {multiprocessing.cpu_count()} os: {os.cpu_count()} sched: {len(os.sched_getaffinity(0))}")'
multiprocessing: 8 os: 8 sched: 8
```

versus

```
$ docker run --cpuset-cpus 0 --rm python:3.8 python -c 'import multiprocessing, os; print(f"multiprocessing: {multiprocessing.cpu_count()} os: {os.cpu_count()} sched: {len(os.sched_getaffinity(0))}")'
multiprocessing: 8 os: 8 sched: 1
```

We also now explain this nuance.

[ci skip-rust]
[ci skip-build-wheels]