### PR TITLE
[internal] Re-enable colors in CI

### DIFF
--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -1,4 +1,6 @@
 [GLOBAL]
+colors = true
+
 remote_cache_read = true
 remote_cache_write = true
 # We want to continue to get logs when remote caching errors.


### PR DESCRIPTION
Looks like our check `sys.stdout.isatty()` results in disabling colors in CI, even though they are known to work with GitHub Actions and Travis.

Fixing this robustly seems challenging, so instead (for now) we note this issue in our CI docs, given that this isn't a very problematic issue: https://www.pantsbuild.org/docs/using-pants-in-ci#configuring-pants-for-ci-pantscitoml-optional
 
[ci skip-rust]
[ci skip-build-wheels]