### PR TITLE
Fix --coverage-py-global-report for >9 test files. (#12144)

### DIFF
--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -408,18 +408,16 @@ async def merge_coverage_data(
                 level=LogLevel.DEBUG,
             ),
         )
-        coverage_digests = await MultiGet(
+        coverage_digest_gets.append(
             Get(
                 Digest, AddPrefix(digest=result.output_digest, prefix=str(global_coverage_base_dir))
-            ),
-            *coverage_digest_gets,
+            )
         )
         coverage_data_file_paths.append(str(global_coverage_base_dir / ".coverage"))
-        input_digest = await Get(Digest, MergeDigests(coverage_digests))
     else:
         extra_sources_digest = EMPTY_DIGEST
-        input_digest = await Get(Digest, MergeDigests(await MultiGet(coverage_digest_gets)))
 
+    input_digest = await Get(Digest, MergeDigests(await MultiGet(coverage_digest_gets)))
     result = await Get(
         ProcessResult,
         VenvPexProcess(


### PR DESCRIPTION
There is a type-checking / signature hole in MultiGet that let this
sneak through our last line of defense but that may or may not be
fixable. This fix instead targets the MultiGet use site in
`coverage_py.py`.

Fixes #12143

(cherry picked from commit 223158bd34a416a62078bb31754610e59c3a199e)

[ci skip-rust]
[ci skip-build-wheels]