### PR TITLE
Register `strip_pex_env` field with pex_binary.

### DIFF
--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -375,6 +375,7 @@ class PexBinary(Target):
         PexPlatformsField,
         PexInheritPathField,
         PexZipSafeField,
+        PexStripEnvField,
         PexAlwaysWriteCacheField,
         PexIgnoreErrorsField,
         PexShebangField,

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -20,9 +20,8 @@ pex_binary(
   dependencies=[
     ':pants_loader',
   ],
-  # We depend on twitter.common libraries that trigger pex warnings for not properly declaring their
-  # dependency on setuptools (for namespace package support).
-  emit_warnings=False,
+  execution_mode="unzip",
+  strip_pex_env=False,
 )
 
 python_tests(name="tests")


### PR DESCRIPTION
Previously this was only registered in the appropriate field set.

Also update the Pants `pex_binary` target with the appropriate
`strip_pex_env` and `execution_mode` parameters.

[ci skip-rust]
[ci skip-build-wheels]