### PR TITLE
Prep 2.6.0.dev1

### DIFF
--- a/src/python/pants/notes/2.6.x.md
+++ b/src/python/pants/notes/2.6.x.md
@@ -2,86 +2,19 @@
 
 ## 2.6.0.dev1 (May 29, 2021)
 
-### New Features
-
-
 ### User API Changes
-
-
-### Plugin API Changes
-
-
-### Bug fixes
-
-
-### Performance
-
-
-### Documentation
-
-
-### Internal (put these in a PR comment for review, not the release notes)
-
---------------------------------------------------------------------
-
-
-* Prepare 2.5.1rc1 ([#12148](https://github.com/pantsbuild/pants/pull/12148))
-
-* Register `strip_pex_env` field with pex_binary. ([#12147](https://github.com/pantsbuild/pants/pull/12147))
-
-* Fix `[python-setup].resolver_jobs` default value to better recognize containers ([#12139](https://github.com/pantsbuild/pants/pull/12139))
-
-* MultiGet accepts an arbitrary number of Gets. ([#12145](https://github.com/pantsbuild/pants/pull/12145))
-
-* Fix --coverage-py-global-report for >9 test files. ([#12144](https://github.com/pantsbuild/pants/pull/12144))
-
-* [internal] Re-enable colors in CI ([#12141](https://github.com/pantsbuild/pants/pull/12141))
-
-* allow prepending args to the venv invocation ([#12137](https://github.com/pantsbuild/pants/pull/12137))
-
-* Remove `dynamic_ui` and `colors` options from `pants.ci.toml` ([#12134](https://github.com/pantsbuild/pants/pull/12134))
 
 * Allow setting `--pantsd-max-memory-usage` with `GiB`, `MiB`, and `KiB` units ([#12123](https://github.com/pantsbuild/pants/pull/12123))
 
-* add retries for reads and writes from remote CAS ([#12132](https://github.com/pantsbuild/pants/pull/12132))
-
-* Prepare 2.5.1rc0 ([#12131](https://github.com/pantsbuild/pants/pull/12131))
-
-* Improve handling of linter reports. ([#12122](https://github.com/pantsbuild/pants/pull/12122))
+* Register `strip_pex_env` field with pex_binary. ([#12147](https://github.com/pantsbuild/pants/pull/12147))
 
 * Allow overriding option default help display. ([#12128](https://github.com/pantsbuild/pants/pull/12128))
 
-* Prepare 2.4.2rc0 ([#12127](https://github.com/pantsbuild/pants/pull/12127))
+### Bug fixes
 
-* Clarify the default values for parallelism options ([#12119](https://github.com/pantsbuild/pants/pull/12119))
+* Fix `[python-setup].resolver_jobs` default value to better recognize containers ([#12139](https://github.com/pantsbuild/pants/pull/12139))
 
-* Make timeouts in tests less confusing ([#12120](https://github.com/pantsbuild/pants/pull/12120))
-
-* add retries with exponential back-off for remote cache ([#12102](https://github.com/pantsbuild/pants/pull/12102))
-
-* Rewrite error message when Pantsd is shut down during run ([#12107](https://github.com/pantsbuild/pants/pull/12107))
-
-* [internal] Turn on verbose logging in CI ([#12106](https://github.com/pantsbuild/pants/pull/12106))
-
-* [internal] Restore #12085 and skip flaky test ([#12112](https://github.com/pantsbuild/pants/pull/12112))
-
-* Fix scheduler initialization log ([#12105](https://github.com/pantsbuild/pants/pull/12105))
-
-* Revert "Use pytest tmp_path fixture (#12085)" to fix flaky test ([#12109](https://github.com/pantsbuild/pants/pull/12109))
-
-* Rename `ProcessCacheScope.NEVER` to `ProcessCacheScope.PER_SESSION` ([#12100](https://github.com/pantsbuild/pants/pull/12100))
-
-* do not add a leading slash if REAPI instance name is empty ([#12103](https://github.com/pantsbuild/pants/pull/12103))
-
-* Change Docformatter to not try to use Python 2 and Python 3.5 by default ([#12099](https://github.com/pantsbuild/pants/pull/12099))
-
-* Replace `ProcessCacheScope.PER_RESTART` with `ProcessCacheScope.PER_RESTART_ALWAYS` and `ProcessCacheScope.PER_RESTART_SUCCESSFUL` ([#12094](https://github.com/pantsbuild/pants/pull/12094))
-
-* Remove workaround for macOS failing to launch process with materialized argv0 ([#12095](https://github.com/pantsbuild/pants/pull/12095))
-
-* Fix type hints for `UnionMembership.get()` ([#12092](https://github.com/pantsbuild/pants/pull/12092))
-
-
+* Fix --coverage-py-global-report for >9 test files. ([#12144](https://github.com/pantsbuild/pants/pull/12144))
 
 ## 2.6.0.dev0 (May 19, 2021)
 

--- a/src/python/pants/notes/2.6.x.md
+++ b/src/python/pants/notes/2.6.x.md
@@ -1,5 +1,88 @@
 # 2.6.x Stable Releases
 
+## 2.6.0.dev1 (May 29, 2021)
+
+### New Features
+
+
+### User API Changes
+
+
+### Plugin API Changes
+
+
+### Bug fixes
+
+
+### Performance
+
+
+### Documentation
+
+
+### Internal (put these in a PR comment for review, not the release notes)
+
+--------------------------------------------------------------------
+
+
+* Prepare 2.5.1rc1 ([#12148](https://github.com/pantsbuild/pants/pull/12148))
+
+* Register `strip_pex_env` field with pex_binary. ([#12147](https://github.com/pantsbuild/pants/pull/12147))
+
+* Fix `[python-setup].resolver_jobs` default value to better recognize containers ([#12139](https://github.com/pantsbuild/pants/pull/12139))
+
+* MultiGet accepts an arbitrary number of Gets. ([#12145](https://github.com/pantsbuild/pants/pull/12145))
+
+* Fix --coverage-py-global-report for >9 test files. ([#12144](https://github.com/pantsbuild/pants/pull/12144))
+
+* [internal] Re-enable colors in CI ([#12141](https://github.com/pantsbuild/pants/pull/12141))
+
+* allow prepending args to the venv invocation ([#12137](https://github.com/pantsbuild/pants/pull/12137))
+
+* Remove `dynamic_ui` and `colors` options from `pants.ci.toml` ([#12134](https://github.com/pantsbuild/pants/pull/12134))
+
+* Allow setting `--pantsd-max-memory-usage` with `GiB`, `MiB`, and `KiB` units ([#12123](https://github.com/pantsbuild/pants/pull/12123))
+
+* add retries for reads and writes from remote CAS ([#12132](https://github.com/pantsbuild/pants/pull/12132))
+
+* Prepare 2.5.1rc0 ([#12131](https://github.com/pantsbuild/pants/pull/12131))
+
+* Improve handling of linter reports. ([#12122](https://github.com/pantsbuild/pants/pull/12122))
+
+* Allow overriding option default help display. ([#12128](https://github.com/pantsbuild/pants/pull/12128))
+
+* Prepare 2.4.2rc0 ([#12127](https://github.com/pantsbuild/pants/pull/12127))
+
+* Clarify the default values for parallelism options ([#12119](https://github.com/pantsbuild/pants/pull/12119))
+
+* Make timeouts in tests less confusing ([#12120](https://github.com/pantsbuild/pants/pull/12120))
+
+* add retries with exponential back-off for remote cache ([#12102](https://github.com/pantsbuild/pants/pull/12102))
+
+* Rewrite error message when Pantsd is shut down during run ([#12107](https://github.com/pantsbuild/pants/pull/12107))
+
+* [internal] Turn on verbose logging in CI ([#12106](https://github.com/pantsbuild/pants/pull/12106))
+
+* [internal] Restore #12085 and skip flaky test ([#12112](https://github.com/pantsbuild/pants/pull/12112))
+
+* Fix scheduler initialization log ([#12105](https://github.com/pantsbuild/pants/pull/12105))
+
+* Revert "Use pytest tmp_path fixture (#12085)" to fix flaky test ([#12109](https://github.com/pantsbuild/pants/pull/12109))
+
+* Rename `ProcessCacheScope.NEVER` to `ProcessCacheScope.PER_SESSION` ([#12100](https://github.com/pantsbuild/pants/pull/12100))
+
+* do not add a leading slash if REAPI instance name is empty ([#12103](https://github.com/pantsbuild/pants/pull/12103))
+
+* Change Docformatter to not try to use Python 2 and Python 3.5 by default ([#12099](https://github.com/pantsbuild/pants/pull/12099))
+
+* Replace `ProcessCacheScope.PER_RESTART` with `ProcessCacheScope.PER_RESTART_ALWAYS` and `ProcessCacheScope.PER_RESTART_SUCCESSFUL` ([#12094](https://github.com/pantsbuild/pants/pull/12094))
+
+* Remove workaround for macOS failing to launch process with materialized argv0 ([#12095](https://github.com/pantsbuild/pants/pull/12095))
+
+* Fix type hints for `UnionMembership.get()` ([#12092](https://github.com/pantsbuild/pants/pull/12092))
+
+
+
 ## 2.6.0.dev0 (May 19, 2021)
 
 ### New Features

--- a/src/python/pants/notes/2.6.x.md
+++ b/src/python/pants/notes/2.6.x.md
@@ -2,19 +2,43 @@
 
 ## 2.6.0.dev1 (May 29, 2021)
 
-### User API Changes
+### New Features
 
 * Allow setting `--pantsd-max-memory-usage` with `GiB`, `MiB`, and `KiB` units ([#12123](https://github.com/pantsbuild/pants/pull/12123))
 
 * Register `strip_pex_env` field with pex_binary. ([#12147](https://github.com/pantsbuild/pants/pull/12147))
 
-* Allow overriding option default help display. ([#12128](https://github.com/pantsbuild/pants/pull/12128))
-
-### Bug fixes
+### User API Changes
 
 * Fix `[python-setup].resolver_jobs` default value to better recognize containers ([#12139](https://github.com/pantsbuild/pants/pull/12139))
 
+* Deprecate broken [lint].reports_dir and make mechanism more flexible ([#12122](https://github.com/pantsbuild/pants/pull/12122))
+
+* Change Docformatter to not try to use Python 2 and Python 3.5 by default ([#12099](https://github.com/pantsbuild/pants/pull/12099))
+
+### Plugin API Changes
+
+* Allow overriding option default help display. ([#12128](https://github.com/pantsbuild/pants/pull/12128))
+
+* Rename `ProcessCacheScope.NEVER` to `ProcessCacheScope.PER_SESSION` ([#12100](https://github.com/pantsbuild/pants/pull/12100))
+
+* Replace `ProcessCacheScope.PER_RESTART` with `ProcessCacheScope.PER_RESTART_ALWAYS` and `ProcessCacheScope.PER_RESTART_SUCCESSFUL` ([#12094](https://github.com/pantsbuild/pants/pull/12094))
+
+### Performance
+
+* add retries for reads and writes from remote CAS ([#12132](https://github.com/pantsbuild/pants/pull/12132))
+
 * Fix --coverage-py-global-report for >9 test files. ([#12144](https://github.com/pantsbuild/pants/pull/12144))
+
+### Documentation
+
+* Clarify the default values for parallelism options ([#12119](https://github.com/pantsbuild/pants/pull/12119))
+
+* Make timeouts in tests less confusing ([#12120](https://github.com/pantsbuild/pants/pull/12120))
+
+* Rewrite error message when Pantsd is shut down during run ([#12107](https://github.com/pantsbuild/pants/pull/12107))
+
+* Fix scheduler initialization log ([#12105](https://github.com/pantsbuild/pants/pull/12105))
 
 ## 2.6.0.dev0 (May 19, 2021)
 


### PR DESCRIPTION
### Internal Changes

* Prepare 2.5.1rc1 ([#12148](https://github.com/pantsbuild/pants/pull/12148))
* MultiGet accepts an arbitrary number of Gets. ([#12145](https://github.com/pantsbuild/pants/pull/12145))
* [internal] Re-enable colors in CI ([#12141](https://github.com/pantsbuild/pants/pull/12141))
* allow prepending args to the venv invocation ([#12137](https://github.com/pantsbuild/pants/pull/12137))
* Remove `dynamic_ui` and `colors` options from `pants.ci.toml` ([#12134](https://github.com/pantsbuild/pants/pull/12134))
* Prepare 2.5.1rc0 ([#12131](https://github.com/pantsbuild/pants/pull/12131))
* Prepare 2.4.2rc0 ([#12127](https://github.com/pantsbuild/pants/pull/12127))
* [internal] Turn on verbose logging in CI ([#12106](https://github.com/pantsbuild/pants/pull/12106))
* [internal] Restore #12085 and skip flaky test ([#12112](https://github.com/pantsbuild/pants/pull/12112))
* Revert "Use pytest tmp_path fixture (#12085)" to fix flaky test ([#12109](https://github.com/pantsbuild/pants/pull/12109))
* do not add a leading slash if REAPI instance name is empty ([#12103](https://github.com/pantsbuild/pants/pull/12103))
* Remove workaround for macOS failing to launch process with materialized argv0 ([#12095](https://github.com/pantsbuild/pants/pull/12095))
* Fix type hints for `UnionMembership.get()` ([#12092](https://github.com/pantsbuild/pants/pull/12092))
