### PR TITLE
Hash the repo_id in the tag.

### DIFF
--- a/src/python/pants/goal/anonymous_telemetry.py
+++ b/src/python/pants/goal/anonymous_telemetry.py
@@ -162,7 +162,8 @@ class AnonymousTelemetryCallback(WorkunitsCallback):
                     system_tags
                     + [
                         f"pants_version:{telemetry_data.get('pants_version')}",
-                        f"repo:{repo_id}",
+                        # This is hashed, unlike the contents of the repo_id var.
+                        f"repo:{telemetry_data.get('repo_id')}",
                         f"user:{telemetry_data.get('user_id', 'UNKNOWN')}",
                         f"machine:{telemetry_data.get('machine_id', 'UNKNOWN')}",
                         f"duration:{telemetry_data.get('duration', '0')}",

--- a/src/python/pants/goal/anonymous_telemetry.py
+++ b/src/python/pants/goal/anonymous_telemetry.py
@@ -163,7 +163,7 @@ class AnonymousTelemetryCallback(WorkunitsCallback):
                     + [
                         f"pants_version:{telemetry_data.get('pants_version')}",
                         # This is hashed, unlike the contents of the repo_id var.
-                        f"repo:{telemetry_data.get('repo_id')}",
+                        f"repo:{telemetry_data.get('repo_id', 'UNKNOWN')}",
                         f"user:{telemetry_data.get('user_id', 'UNKNOWN')}",
                         f"machine:{telemetry_data.get('machine_id', 'UNKNOWN')}",
                         f"duration:{telemetry_data.get('duration', '0')}",


### PR DESCRIPTION
Previously we sent the unhashed id in the tag, but the hashed
id as a standalone field.

This is only a minor anonymity issue, since the raw repo_id
is just a UUID. But it is a uniformity issue, and it violates
our promise to users.

[ci skip-rust]

[ci skip-build-wheels]