### PR TITLE
Support for custom target types in tailor.

### DIFF
--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -144,6 +144,17 @@ class PutativeTarget:
     def address(self) -> Address:
         return Address(self.path, target_name=self.name)
 
+    def realias(self, new_alias: str | None) -> PutativeTarget:
+        """A copy of this object with the alias replaced to the given alias.
+
+        Returns this object if the alias is None or is identical to this objects existing alias.
+        """
+        return (
+            self
+            if (new_alias is None or new_alias == self.type_alias)
+            else dataclasses.replace(self, type_alias=new_alias)
+        )
+
     def rename(self, new_name: str) -> PutativeTarget:
         """A copy of this object with the name replaced to the given name."""
         # We assume that a rename imposes an explicit "name=" kwarg, overriding any previous
@@ -210,9 +221,24 @@ class TailorSubsystem(GoalSubsystem):
             help="The indent to use when auto-editing BUILD files.",
         )
 
+        register(
+            "--alias-mapping",
+            advanced=True,
+            type=dict,
+            member_type=str,
+            help="A mapping from standard target type to custom type to use instead. The custom "
+            "type can be a custom target type or a macro that offers compatible functionality "
+            "to the one it replaces (see https://www.pantsbuild.org/docs/macros).",
+        )
+
     @property
     def build_file_indent(self) -> str:
         return cast(str, self.options.build_file_indent)
+
+    def alias_for(self, standard_type: str) -> str | None:
+        # The get() could return None, but casting to str | None errors.
+        # This cast suffices to avoid typecheck errors.
+        return cast(str, self.options.alias_mapping.get(standard_type))
 
 
 class Tailor(Goal):
@@ -392,6 +418,9 @@ async def tailor(
         for req_type in putative_target_request_types
     )
     putative_targets = PutativeTargets.merge(putative_targets_results)
+    putative_targets = PutativeTargets(
+        pt.realias(tailor_subsystem.alias_for(pt.type_alias)) for pt in putative_targets
+    )
     fixed_names_ptgts = await Get(UniquelyNamedPutativeTargets, PutativeTargets, putative_targets)
     fixed_sources_ptgts = await MultiGet(
         Get(DisjointSourcePutativeTarget, PutativeTarget, ptgt)

--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -225,7 +225,6 @@ class TailorSubsystem(GoalSubsystem):
             "--alias-mapping",
             advanced=True,
             type=dict,
-            member_type=str,
             help="A mapping from standard target type to custom type to use instead. The custom "
             "type can be a custom target type or a macro that offers compatible functionality "
             "to the one it replaces (see https://www.pantsbuild.org/docs/macros).",

--- a/src/python/pants/core/goals/tailor_test.py
+++ b/src/python/pants/core/goals/tailor_test.py
@@ -292,7 +292,11 @@ def test_tailor_rule(rule_runner: RuleRunner) -> None:
         run_rule_with_mocks(
             tailor.tailor,
             rule_args=[
-                create_goal_subsystem(TailorSubsystem, build_file_indent="    "),
+                create_goal_subsystem(
+                    TailorSubsystem,
+                    build_file_indent="    ",
+                    alias_mapping={"fortran_library": "my_fortran_lib"},
+                ),
                 console,
                 workspace,
                 union_membership,
@@ -358,7 +362,7 @@ def test_tailor_rule(rule_runner: RuleRunner) -> None:
         stdout_str = stdio_reader.get_stdout()
 
     assert (
-        "Created src/fortran/baz/BUILD:\n  - Added fortran_library target src/fortran/baz"
+        "Created src/fortran/baz/BUILD:\n  - Added my_fortran_lib target src/fortran/baz"
         in stdout_str
     )
     assert (
@@ -366,7 +370,7 @@ def test_tailor_rule(rule_runner: RuleRunner) -> None:
         in stdout_str
     )
     assert (
-        "Updated src/fortran/conflict/BUILD:\n  - Added fortran_library target "
+        "Updated src/fortran/conflict/BUILD:\n  - Added my_fortran_lib target "
         "src/fortran/conflict:conflict0"
     ) in stdout_str
 


### PR DESCRIPTION
Allows users to override the standard types and customize the output via macros or custom types. 

[ci skip-rust]

[ci skip-build-wheels]