### PR TITLE
Temporarily fix a test that relies on the state of the world. (#12153)

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -587,7 +587,7 @@ def test_requirement_constraints(rule_runner: RuleRunner) -> None:
     )
     assert_direct_requirements(direct_pex_info)
     assert {
-        "certifi-2020.12.5-py2.py3-none-any.whl",
+        "certifi-2021.5.30-py2.py3-none-any.whl",
         "chardet-3.0.4-py2.py3-none-any.whl",
         "idna-2.10-py2.py3-none-any.whl",
         "requests-2.23.0-py2.py3-none-any.whl",
@@ -672,7 +672,7 @@ def test_venv_pex_resolve_info(rule_runner: RuleRunner, pex_type: type[Pex | Ven
         rule_runner, pex_type=pex_type, requirements=PexRequirements(["requests==2.23.0"])
     )["pex"]
     dists = rule_runner.request(PexResolveInfo, [venv_pex])
-    assert dists[0] == PexDistributionInfo("certifi", Version("2020.12.5"), None, ())
+    assert dists[0] == PexDistributionInfo("certifi", Version("2021.05.30"), None, ())
     assert dists[1] == PexDistributionInfo("chardet", Version("3.0.4"), None, ())
     assert dists[2] == PexDistributionInfo(
         "idna", Version("2.10"), SpecifierSet("!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"), ()


### PR DESCRIPTION
certifi published a new version, and this broke some tests of
pex resolution that assumed an earlier version would be resolved.

This is a short-term fix to get tests running, but this test
needs to be fixed to not depend on external state.

[ci skip-rust]

[ci skip-build-wheels]

(cherry picked from commit 2d62aa954145a071bf0536ca775f7f9aac0e2f0d)