### PR TITLE
 Cherry-pick #12153 and #12062 to stabilize CI (#12164) 

### DIFF
--- a/src/python/pants/backend/python/lint/python_fmt_integration_test.py
+++ b/src/python/pants/backend/python/lint/python_fmt_integration_test.py
@@ -1,6 +1,7 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import os
 from typing import List, Optional
 
 import pytest
@@ -45,7 +46,25 @@ def run_black_and_isort(
         [
             "--backend-packages=['pants.backend.python.lint.black', 'pants.backend.python.lint.isort']",
             *(extra_args or []),
-        ]
+        ],
+        # We propagate LANG and LC_ALL to satisfy click, which black depends upon. Without this we
+        # see something like the following in CI:
+        #
+        # RuntimeError: Click will abort further execution because Python was configured to use
+        # ASCII as encoding for the environment. Consult
+        # https://click.palletsprojects.com/unicode-support/ for mitigation steps.
+        #
+        # This system supports the C.UTF-8 locale which is recommended. You might be able to
+        # resolve your issue by exporting the following environment variables:
+        #
+        #     export LC_ALL=C.UTF-8
+        #     export LANG=C.UTF-8
+        #
+        env={
+            k: v
+            for k, v in os.environ.items()
+            if k in ("PATH", "PYENV_ROOT", "HOME", "LANG", "LC_ALL")
+        },
     )
     results = rule_runner.request(LanguageFmtResults, [targets])
     return results

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -492,7 +492,7 @@ def test_requirement_constraints(rule_runner: RuleRunner) -> None:
     )
     assert_direct_requirements(direct_pex_info)
     assert {
-        "certifi-2020.12.5-py2.py3-none-any.whl",
+        "certifi-2021.5.30-py2.py3-none-any.whl",
         "chardet-3.0.4-py2.py3-none-any.whl",
         "idna-2.10-py2.py3-none-any.whl",
         "requests-2.23.0-py2.py3-none-any.whl",


### PR DESCRIPTION
+ Temporarily fix a test that relies on the state of the world. (#12153)

    certifi published a new version, and this broke some tests of
    pex resolution that assumed an earlier version would be resolved.

    This is a short-term fix to get tests running, but this test
    needs to be fixed to not depend on external state.

    (cherry picked from commit 2d62aa9)

+ Fix black tests in CI. (#12062)

    (cherry picked from commit e0927e9)

    Co-authored-by: Benjy Weinberger <benjyw@gmail.com>