### PR TITLE
[internal] Hotfix release.sh breaking when building with Python 3.8

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -8,6 +8,7 @@ source "build-support/common.sh"
 
 if [[ "${USE_PY38:-false}" == "true" ]]; then
   default_python=python3.8
+  interpreter_constraint="==3.8.*"
 elif [[ "${USE_PY39:-false}" == "true" ]]; then
   default_python=python3.9
   interpreter_constraint="==3.9.*"

--- a/build-support/githooks/prepare-commit-msg
+++ b/build-support/githooks/prepare-commit-msg
@@ -27,7 +27,8 @@ NUM_RELEASE_FILES=$(echo "${CHANGED_FILES})" | grep -c -E \
   -e "^src/python/pants/VERSION" \
   -e "^src/python/pants/notes" \
   -e "^src/rust/engine/fs/fs_util" \
-  -e "^build-support/bin/release.py" \
+  -e "^build-support/bin/release.sh" \
+  -e "^build-support/bin/release_helper.py" \
   -e "^build-support/bin/generate_github_workflows.py")
 
 # To avoid putting skip labels multiple times, check if the labels already exist


### PR DESCRIPTION
I left off setting `interpreter_constraint`, which resulted in using an invalid Python version to build the Pants distribution. https://github.com/pantsbuild/pants/runs/2740478603#step:9:1179

This slipped through because `[ci skip-build-wheels]` was in the PR https://github.com/pantsbuild/pants/pull/12017 due to the pre-commit hook. This PR fixes the pre-commit hook to avoid that specific situation from happening.

[ci skip-rust]