### PR TITLE
Suggest `-ldebug` and `--no-process-execution-local-cleanup` in exception messages

### DIFF
--- a/src/python/pants/util/docutil.py
+++ b/src/python/pants/util/docutil.py
@@ -22,4 +22,13 @@ def bracketed_docs_url(slug: str) -> str:
     that those prevent any linkification at all from happening on readme.com, so we switched
     to parens, but didn't update the name to prevent churn.
     """
-    return f"(https://www.pantsbuild.org/v{MAJOR_MINOR}/docs/{slug})"
+    return f"({unbracketed_docs_url(slug)})"
+
+
+def unbracketed_docs_url(slug: str) -> str:
+    """Link to the Pants docs using the current version of Pants.
+
+    Returned URL is _not_ surrounded by parentheses. This should only be used in error messages. Use
+    `bracketed_docs_url` for help messages so that linkifiers work correctly.
+    """
+    return f"https://www.pantsbuild.org/v{MAJOR_MINOR}/docs/{slug}"


### PR DESCRIPTION
We already recommend both these options in our docs: https://www.pantsbuild.org/docs/troubleshooting#debug-tip-enable-stack-traces-and-increase-logging. But it's not enough to expect people to find that docs page, we should give the recommendation in the message too.

`--no-process-execution-local-cleanup` will become particularly important with https://github.com/pantsbuild/pants/issues/12090, where we will no longer be able to put the requirements installed by Pex directly in the argv and users will need to inspect the generated requirements.txt file to see what was installed.

Examples:

> (Use --print-stacktrace for more error details and/or --no-process-execution-local-cleanup to inspect chroots and/or -ldebug for more logs. See https://www.pantsbuild.org/v2.6/docs/troubleshooting for common issues. Consider reaching out for help: https://www.pantsbuild.org/v2.6/docs/getting-help.)

> (Use --print-stacktrace for more error details and/or -ldebug for more logs. See https://www.pantsbuild.org/v2.6/docs/troubleshooting for common issues. Consider reaching out for help: https://www.pantsbuild.org/v2.6/docs/getting-help.)

> (See https://www.pantsbuild.org/v2.6/docs/troubleshooting for common issues. Consider reaching out for help: https://www.pantsbuild.org/v2.6/docs/getting-help.)

[ci skip-rust]
[ci skip-build-wheels]