### PR TITLE
Fix relocated files help display.

### DIFF
--- a/build-support/bin/docs_templates/target_reference.md.mustache
+++ b/build-support/bin/docs_templates/target_reference.md.mustache
@@ -1,5 +1,4 @@
-{{! Mark as a paragraph to render as plain text, rather than markdown. The spaces matter. }}
-<p> {{{description}}} </p>
+{{{description}}}
 
 {{#fields}}
 ## <code>{{alias}}</code>
@@ -7,7 +6,6 @@
 <span style="color: purple">type: <code>{{type_hint}}</code></span>
 <span style="color: green">{{{default_or_required}}}</span>
 
-{{! Mark as a paragraph to render as plain text, rather than markdown. The spaces matter. }}
-<p> {{{description}}} </p>
+{{{description}}}
 
 {{/fields}}

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -80,9 +80,8 @@ class RelocatedFilesSrcField(StringField):
     required = True
     help = (
         "The original prefix that you want to replace, such as `src/resources`.\n\nYou can set "
-        "this field to `"
-        "` to preserve the original path; the value in the `dest` field will "
-        "then be added to the beginning of this original path."
+        "this field to the empty string to preserve the original path; the value in the `dest` "
+        "field will then be added to the beginning of this original path."
     )
 
 
@@ -91,8 +90,8 @@ class RelocatedFilesDestField(StringField):
     required = True
     help = (
         "The new prefix that you want to add to the beginning of the path, such as `data`.\n\nYou "
-        'can set this field to "" to avoid adding any new values to the path; the value in the '
-        "`src` field will then be stripped, rather than replaced."
+        "can set this field to the empty string to avoid adding any new values to the path; the "
+        "value in the `src` field will then be stripped, rather than replaced."
     )
 
 


### PR DESCRIPTION
- Adjust for the fact that indented text is treated
  by readme.com as a blockquote, even inside `<p></p>`.
- Fix an empty string that caused a 500 error on readme.com
  (they cannot handle <code></code> with no content for some reason).

[ci skip-rust]

[ci skip-build-wheels]