### PR TITLE
Include the arch in the venv directory path.

### DIFF
--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -13,7 +13,8 @@ REQUIREMENTS=(
 
 # NB: We house these outside the working copy to avoid needing to gitignore them, but also to
 # dodge https://github.com/hashicorp/vagrant/issues/12057.
-venv_dir_prefix="${HOME}/.cache/pants/pants_dev_deps/$(uname)"
+platform=$(uname -mps | sed 's/ /./g')
+venv_dir_prefix="${HOME}/.cache/pants/pants_dev_deps/${platform}"
 
 function venv_dir() {
   py_venv_version=$(${PY} -c 'import sys; print("".join(map(str, sys.version_info[0:2])))')


### PR DESCRIPTION
On M1 macs, it's common to need to reconfigure the architecture of your machine in various shells: we should invalidate the venv for this case.

[ci skip-rust]
[ci skip-build-wheels]