### PR TITLE
Fix engine_pyo3/build.rs missing clippy.

### DIFF
--- a/src/rust/engine/engine_pyo3/build.rs
+++ b/src/rust/engine/engine_pyo3/build.rs
@@ -1,6 +1,32 @@
 // Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+#![deny(warnings)]
+// Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
+#![deny(
+  clippy::all,
+  clippy::default_trait_access,
+  clippy::expl_impl_clone_on_copy,
+  clippy::if_not_else,
+  clippy::needless_continue,
+  clippy::unseparated_literal_suffix,
+  // TODO: Falsely triggers for async/await:
+  //   see https://github.com/rust-lang/rust-clippy/issues/5360
+  // clippy::used_underscore_binding
+)]
+// It is often more clear to show that nothing is being moved.
+#![allow(clippy::match_ref_pats)]
+// Subjective style.
+#![allow(
+  clippy::len_without_is_empty,
+  clippy::redundant_field_names,
+  clippy::too_many_arguments
+)]
+// Default isn't as big a deal as people seem to think it is.
+#![allow(clippy::new_without_default, clippy::new_ret_no_self)]
+// Arc<Mutex> can be more clear than needing to grok Orderings:
+#![allow(clippy::mutex_atomic)]
+
 fn main() {
   // NB: The native extension only works with the Python interpreter version it was built with
   // (e.g. Python 3.7 vs 3.8).


### PR DESCRIPTION
Previously this was causing errors on unrelated rust changes:
```
$ git commit --amend
* Running
   Compiling proc-macro2 v1.0.24
   ...
    Checking process_executor v0.0.1 (/home/jsirois/dev/pantsbuild/jsirois-pants/src/rust/engine/process_executor)
    Finished dev [unoptimized + debuginfo] target(s) in 2m 02s
* Checking formatting of Rust files
Ensuring generated code is present for downstream formatting checks...
    Checking tokio-stream v0.1.5
    Checking hashing v0.0.1 (/home/jsirois/dev/pantsbuild/jsirois-pants/src/rust/engine/hashing)
   Compiling bazel_protos v0.0.1 (/home/jsirois/dev/pantsbuild/jsirois-pants/src/rust/engine/process_execution/bazel_protos)
    Checking tower v0.4.6
    Checking tonic v0.4.1
    Finished dev [unoptimized + debuginfo] target(s) in 6.17s
* Checking Rust target headers
     Ignored package  is already installed, use --force to override
Rust targets didn't have correct prefix:
/home/jsirois/dev/pantsbuild/jsirois-pants/src/rust/engine/engine_pyo3/build.rs
```

[ci skip-build-wheels]