### PR TITLE
Fix Process output capture re: working_directory.

### DIFF
--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -7,7 +7,7 @@ import os
 from dataclasses import dataclass
 from enum import Enum
 
-from pants.engine.fs import CreateDigest, Digest, Directory, MergeDigests, RemovePrefix, Snapshot
+from pants.engine.fs import CreateDigest, Digest, Directory, MergeDigests, Snapshot
 from pants.engine.process import (
     BinaryNotFoundError,
     BinaryPath,

--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -170,10 +170,10 @@ async def maybe_extract_archive(
     digest: Digest, tar_binary: TarBinary, unzip_binary: UnzipBinary
 ) -> ExtractedArchive:
     """If digest contains a single archive file, extract it, otherwise return the input digest."""
-    output_dir = "__output"
+    extract_archive_dir = "__extract_archive_dir"
     snapshot, output_dir_digest = await MultiGet(
         Get(Snapshot, Digest, digest),
-        Get(Digest, CreateDigest([Directory(output_dir)])),
+        Get(Digest, CreateDigest([Directory(extract_archive_dir)])),
     )
     if len(snapshot.files) != 1:
         return ExtractedArchive(digest)
@@ -199,12 +199,11 @@ async def maybe_extract_archive(
             input_digest=input_digest,
             description=f"Extract {fp}",
             level=LogLevel.DEBUG,
-            output_directories=(output_dir,),
-            working_directory=output_dir,
+            output_directories=(".",),
+            working_directory=extract_archive_dir,
         ),
     )
-    strip_output_dir = await Get(Digest, RemovePrefix(result.output_digest, output_dir))
-    return ExtractedArchive(strip_output_dir)
+    return ExtractedArchive(result.output_digest)
 
 
 def rules():

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -94,21 +94,24 @@ class Process:
         that are not explicitly populated. For example, $PATH will not be defined by default, unless
         populated through the `env` parameter.
 
-        Usually, you will want to provide input files/directories via the parameter `input_digest`. The
-        process will then be able to access these paths through relative paths. If you want to give
-        multiple input digests, first merge them with `await Get(Digest, MergeDigests)`.
+        Usually, you will want to provide input files/directories via the parameter `input_digest`.
+        The process will then be able to access these paths through relative paths. If you want to
+        give multiple input digests, first merge them with `await Get(Digest, MergeDigests)`.
 
-        Often, you will want to capture the files/directories created in the process. To do this, you
-        can either set `output_files` or `output_directories`. The specified paths will then be used to
-        populate `output_digest` on the `ProcessResult`. If you want to split up this output digest
-        into multiple digests, use `await Get(Digest, DigestSubset)` on the `output_digest`.
+        Often, you will want to capture the files/directories created in the process. To do this,
+        you can either set `output_files` or `output_directories`. The specified paths should be
+        specified relative to the `working_directory`, if any, and will then be used to populate
+        `output_digest` on the `ProcessResult`. If you want to split up this output digest into
+        multiple digests, use `await Get(Digest, DigestSubset)` on the `output_digest`.
 
         To actually run the process, use `await Get(ProcessResult, Process)` or
         `await Get(FallibleProcessResult, Process)`.
 
         Example:
 
-            result = await Get(ProcessResult, Process(["/bin/echo", "hello world"], description="demo"))
+            result = await Get(
+                ProcessResult, Process(["/bin/echo", "hello world"], description="demo")
+            )
             assert result.stdout == b"hello world"
         """
         if isinstance(argv, str):


### PR DESCRIPTION
Previously our local Process output capturing did not match the REAPI
spec which led to local execution working and remote execution failing
whenever a Process execution used both `working_directory` and output
capturing.

Add a test that output capturing occurs relative to the
`working_directory` when set and fix our one combined use of
`working_directory` and output capturing in `archive.py`.

Fixes #12157

[ci skip-build-wheels]