### PR TITLE
[internal] Increase engine build parallelism, and include arch in fingerprint.

### DIFF
--- a/build-support/bin/rust/calculate_engine_hash.sh
+++ b/build-support/bin/rust/calculate_engine_hash.sh
@@ -34,7 +34,7 @@ function calculate_current_hash() {
     (
       echo "${MODE_FLAG}"
       echo "${RUST_TOOLCHAIN_CONTENTS}"
-      uname
+      uname -mps
       python --version 2>&1
       git ls-files --cached --others --exclude-standard \
         "${NATIVE_ROOT}" \


### PR DESCRIPTION
In two commits:
* Include the `arch` in the engine fingerprint to rebuild when it changes (i.e. on M1 with rosetta)
* Build both Python extension modules in parallel