### PR TITLE
Rename remote cache write start and finished metrics

### DIFF
--- a/src/rust/engine/workunit_store/src/metrics.rs
+++ b/src/rust/engine/workunit_store/src/metrics.rs
@@ -56,9 +56,9 @@ pub enum Metric {
   RemoteCacheRequestsCached,
   RemoteCacheRequestsUncached,
   RemoteCacheReadErrors,
+  RemoteCacheWriteAttempts,
+  RemoteCacheWriteSuccesses,
   RemoteCacheWriteErrors,
-  RemoteCacheWriteStarted,
-  RemoteCacheWriteFinished,
   RemoteCacheSpeculationLocalCompletedFirst,
   RemoteCacheSpeculationRemoteCompletedFirst,
   /// The total time saved (in milliseconds) thanks to remote cache hits instead of running the


### PR DESCRIPTION
These metrics were added in https://github.com/pantsbuild/pants/pull/11479 to track what % of writes are actually completing due to the code block being async. But the metrics are useful beyond answering that particular question, and the current names are too specific.

This also changes the "finished" metric to only record successes, whereas before it included errors too. Previously, to get successes, you had to do `remote_cache_write_finished - remote_cache_write_errors`, but now we directly store this. To get back the number "finished", you will now do `remote_cache_write_successes + remote_cache_write_errors`.

[ci skip-build-wheels]