### PR TITLE
Fallback to `[python-setup].interpreter_constraints` for `python_distribution`s with no first-party dependencies

### DIFF
--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -362,7 +362,7 @@ async def package_python_dist(
     exported_target = ExportedTarget(transitive_targets.roots[0])
     interpreter_constraints = InterpreterConstraints.create_from_targets(
         transitive_targets.closure, python_setup
-    )
+    ) or InterpreterConstraints(python_setup.interpreter_constraints)
     chroot = await Get(
         SetupPyChroot,
         SetupPyChrootRequest(exported_target, py2=interpreter_constraints.includes_python2()),

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -665,13 +665,6 @@ class PythonDistributionDependencies(Dependencies):
     supports_transitive_excludes = True
 
 
-class PythonDistributionInterpreterConstraints(InterpreterConstraintsField):
-    help = InterpreterConstraintsField.help + (
-        "\n\nFor now, Pants will not set `python_requires` for you in the generated setup.py. "
-        "Instead, manually set it in the `provides=setup_py()` field."
-    )
-
-
 class PythonProvidesField(ScalarField, ProvidesField):
     expected_type = PythonArtifact
     expected_type_help = "setup_py(name='my-dist', **kwargs)"
@@ -680,7 +673,7 @@ class PythonProvidesField(ScalarField, ProvidesField):
     help = (
         "The setup.py kwargs for the external artifact built from this target.\n\nYou must define "
         "`name`. You can also set almost any keyword argument accepted by setup.py in the "
-        "`setup_py()` constructor: "
+        "`setup()` function: "
         "(https://packaging.python.org/guides/distributing-packages-using-setuptools/#setup-args)."
         f"\n\nSee {bracketed_docs_url('plugins-setup-py')} for how to write a plugin to "
         f"dynamically generate kwargs."
@@ -708,7 +701,6 @@ class PythonDistribution(Target):
     alias = "python_distribution"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        PythonDistributionInterpreterConstraints,
         PythonDistributionDependencies,
         PythonProvidesField,
         SetupPyCommandsField,


### PR DESCRIPTION
We use interpreter constraints with `python_distribution` targets to determine what to run `setuptools` with if `setup_py_commands` is set, along with determining if Py2 is used for how to handle namespace packages. 

Currently, the ICs can only be set via dependencies on `python_library` targets. If there are no relevant deps—e.g. an empty `python_distribution`, which is weird but legal—we use no constraints at all. This resulted in a bug where Python 2 was being used to build `setuptools>50`, which fails to build.

We fix this by simply falling back to `[python-setup].interpreter_constraints`, which is what we also do with `./pants repl` when there are no relevant targets specified. 

It's possible, but unlikely, that a user won't want to couple `[python-setup].interpreter_constraints` with setuptools, e.g. that their constraints are Py2 or Py3, but they want to use setuptools 50. We decided to not proactively plan for this because it seems unlikely—especially because it is so rare to have a distribution with no first-party deps—and we want to avoid options fatigue. If it becomes a problem, we could add an option `[setuptools].fallback_interpreter_constraints`.

### Rejected alternative: add `interpreter_constraints` to `python_distribution`

We have `interpreter_constraints` on `pex_binary` to accommodate a PEX with only third party dependencies. There, constraints are relevant.

But for `python_distribution`, if you have a dist with no first-party dependencies, the only reason the ICs matter is so that they're compatible with `[setuptools].version`, as it's only used to run setuptools and the ICs are not embedded into the distribution. If you do have first-party deps, the ICs should be updated on the relevant `python_library` code.

[ci skip-rust]