### PR TITLE
Deprecate unused `interpreter_constraints` field for `python_awslambda`

### DIFF
--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -33,6 +33,14 @@ from pants.source.source_root import SourceRoot, SourceRootRequest
 from pants.util.docutil import bracketed_docs_url
 
 
+class DeprecatedAwsLambdaInterpreterConstraints(InterpreterConstraintsField):
+    removal_version = "2.7.0.dev0"
+    removal_hint = (
+        "The `interpreter_constraints` field does not do anything for `python_awslambda` targets. "
+        "Use the `runtime` field instead to choose the Python interpreter."
+    )
+
+
 class PythonAwsLambdaHandlerField(StringField, AsyncFieldMixin, SecondaryOwnerMixin):
     alias = "handler"
     required = True
@@ -191,7 +199,7 @@ class PythonAWSLambda(Target):
     core_fields = (
         *COMMON_TARGET_FIELDS,
         OutputPathField,
-        InterpreterConstraintsField,
+        DeprecatedAwsLambdaInterpreterConstraints,
         PythonAwsLambdaDependencies,
         PythonAwsLambdaHandlerField,
         PythonAwsLambdaRuntime,


### PR DESCRIPTION
As found in https://github.com/pantsbuild/pants/pull/11982#discussion_r652226935, it turns out this field doesn't do anything. It was a mistake to have introduced it in the first place and a mistake to roll back its removal from 2.3.

[ci skip-build-wheels]