### PR TITLE
Adds `--[no-]watch-filesystem` switch

### DIFF
--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -104,6 +104,7 @@ def scheduler_create(
     ca_certs_path: str | None,
     ignore_patterns: Sequence[str],
     use_gitignore: bool,
+    watch_filesystem: bool,
     remoting_options: PyRemotingOptions,
     local_store_options: PyLocalStoreOptions,
     exec_strategy_opts: PyExecutionStrategyOptions,

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -116,6 +116,7 @@ class Scheduler:
         include_trace_on_error: bool = True,
         visualize_to_dir: Optional[str] = None,
         validate_reachability: bool = True,
+        watch_filesystem: bool = True,
     ) -> None:
         """
         :param ignore_patterns: A list of gitignore-style file patterns for pants to ignore.
@@ -132,6 +133,7 @@ class Scheduler:
         :param validate_reachability: True to assert that all rules in an otherwise successfully
           constructed rule graph are reachable: if a graph cannot be successfully constructed, it
           is always a fatal error.
+        :param watch_filesystem: False if filesystem watching should be disabled.
         """
         self.include_trace_on_error = include_trace_on_error
         self._visualize_to_dir = visualize_to_dir
@@ -199,9 +201,6 @@ class Scheduler:
             remote_parallelism=execution_options.process_execution_remote_parallelism,
         )
 
-
-        # watch filesystem config here!
-
         self._py_scheduler = native_engine.scheduler_create(
             executor,
             tasks,
@@ -212,7 +211,7 @@ class Scheduler:
             ca_certs_path,
             ignore_patterns,
             use_gitignore,
-            True,  # watch_filesystem
+            watch_filesystem,
             remoting_options,
             py_local_store_options,
             exec_stategy_opts,

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -199,6 +199,9 @@ class Scheduler:
             remote_parallelism=execution_options.process_execution_remote_parallelism,
         )
 
+
+        # watch filesystem config here!
+
         self._py_scheduler = native_engine.scheduler_create(
             executor,
             tasks,
@@ -209,6 +212,7 @@ class Scheduler:
             ca_certs_path,
             ignore_patterns,
             use_gitignore,
+            True,  # watch_filesystem
             remoting_options,
             py_local_store_options,
             exec_stategy_opts,

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -208,7 +208,7 @@ class EngineInitializer:
         build_root: Optional[str] = None,
         include_trace_on_error: bool = True,
         native_engine_visualize_to: Optional[str] = None,
-        watch_filesystem: bool = True, 
+        watch_filesystem: bool = True,
     ) -> GraphScheduler:
         build_root = build_root or get_buildroot()
 

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -190,6 +190,7 @@ class EngineInitializer:
             build_root=build_root,
             include_trace_on_error=bootstrap_options.print_stacktrace,
             native_engine_visualize_to=bootstrap_options.native_engine_visualize_to,
+            watch_filesystem=bootstrap_options.watch_filesystem,
         )
 
     @staticmethod
@@ -207,6 +208,7 @@ class EngineInitializer:
         build_root: Optional[str] = None,
         include_trace_on_error: bool = True,
         native_engine_visualize_to: Optional[str] = None,
+        watch_filesystem: bool = True, 
     ) -> GraphScheduler:
         build_root = build_root or get_buildroot()
 
@@ -292,6 +294,7 @@ class EngineInitializer:
             local_store_options=local_store_options,
             include_trace_on_error=include_trace_on_error,
             visualize_to_dir=native_engine_visualize_to,
+            watch_filesystem=watch_filesystem,
         )
 
         return GraphScheduler(scheduler, goal_map)

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1217,6 +1217,15 @@ class GlobalOptions(Subsystem):
             help="Overall timeout in seconds for each remote execution request from time of submission",
         )
 
+        register(
+            "--watch-filesystem",
+            type=bool,
+            default=True,
+            advanced=True,
+            help="Set to False if Pants should not watch the filesystem for changes. `pantsd` may not be enabled."
+        )
+
+
     @classmethod
     def register_options(cls, register):
         """Register options not tied to any particular task or subsystem."""
@@ -1380,6 +1389,12 @@ class GlobalOptions(Subsystem):
             raise OptionsError(
                 "The `--remote-cache-write` option requires also setting "
                 "`--remote-store-address` or to work properly."
+            )
+
+        if not opts.watch_filesystem and (opts.pantsd or opts.loop):
+            raise OptionsError(
+                "The `--no-watch-filesystem` option may not be set if "
+                "`--pantsd` or `--loop` is set."
             )
 
         def validate_remote_address(opt_name: str) -> None:

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1222,7 +1222,8 @@ class GlobalOptions(Subsystem):
             type=bool,
             default=True,
             advanced=True,
-            help="Set to False if Pants should not watch the filesystem for changes. `pantsd` may not be enabled."
+            help="Set to False if Pants should not watch the filesystem for changes. `pantsd` or `loop` "
+            "may not be enabled."
         )
 
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1223,9 +1223,8 @@ class GlobalOptions(Subsystem):
             default=True,
             advanced=True,
             help="Set to False if Pants should not watch the filesystem for changes. `pantsd` or `loop` "
-            "may not be enabled."
+            "may not be enabled.",
         )
-
 
     @classmethod
     def register_options(cls, register):

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -384,7 +384,6 @@ impl Core {
       GitignoreStyleExcludes::create_with_gitignore_file(ignore_patterns, gitignore_file)
         .map_err(|e| format!("Could not parse build ignore patterns: {:?}", e))?;
 
-    // this seems important
     let watcher = if watch_filesystem { 
       let w = InvalidationWatcher::new(executor.clone(), build_root.clone(), ignorer.clone())?; 
       w.start(&graph);

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -60,7 +60,7 @@ pub struct Core {
   pub command_runner: Box<dyn process_execution::CommandRunner>,
   pub http_client: reqwest::Client,
   pub vfs: PosixFS,
-  pub watcher: Arc<InvalidationWatcher>,
+  pub watcher: Option<Arc<InvalidationWatcher>>,
   pub build_root: PathBuf,
   pub local_parallelism: usize,
   pub sessions: Sessions,
@@ -286,6 +286,7 @@ impl Core {
     build_root: PathBuf,
     ignore_patterns: Vec<String>,
     use_gitignore: bool,
+    watch_filesystem: bool,
     local_execution_root_dir: PathBuf,
     named_caches_dir: PathBuf,
     ca_certs_path: Option<PathBuf>,
@@ -383,8 +384,14 @@ impl Core {
       GitignoreStyleExcludes::create_with_gitignore_file(ignore_patterns, gitignore_file)
         .map_err(|e| format!("Could not parse build ignore patterns: {:?}", e))?;
 
-    let watcher = InvalidationWatcher::new(executor.clone(), build_root.clone(), ignorer.clone())?;
-    watcher.start(&graph);
+    // this seems important
+    let watcher = if watch_filesystem { 
+      let w = InvalidationWatcher::new(executor.clone(), build_root.clone(), ignorer.clone())?; 
+      w.start(&graph);
+      Some(w)
+    } else { 
+      None 
+    };
 
     let sessions = Sessions::new(&executor)?;
 

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -371,6 +371,7 @@ py_module_initializer!(native_engine, |py, m| {
         ca_certs_path: Option<String>,
         ignore_patterns: Vec<String>,
         use_gitignore: bool,
+        watch_filesystem: bool,
         remoting_options: PyRemotingOptions,
         local_store_options: PyLocalStoreOptions,
         exec_strategy_opts: PyExecutionStrategyOptions
@@ -838,6 +839,7 @@ fn scheduler_create(
   ca_certs_path_buf: Option<String>,
   ignore_patterns: Vec<String>,
   use_gitignore: bool,
+  watch_filesystem: bool,
   remoting_options: PyRemotingOptions,
   local_store_options: PyLocalStoreOptions,
   exec_strategy_opts: PyExecutionStrategyOptions,
@@ -868,6 +870,7 @@ fn scheduler_create(
         PathBuf::from(build_root_buf),
         ignore_patterns,
         use_gitignore,
+        watch_filesystem,
         PathBuf::from(local_execution_root_dir_buf),
         PathBuf::from(named_caches_dir_buf),
         ca_certs_path_buf.map(PathBuf::from),

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1309,13 +1309,15 @@ impl Node for NodeKey {
       // fails, and prefer that error message if so (because we have little control over the
       // error messages of the watch API).
       let maybe_watch = if let Some(path) = self.fs_subject() {
-        let abs_path = context.core.build_root.join(path);
-        context
-          .core
-          .watcher
-          .watch(abs_path)
-          .map_err(|e| Context::mk_error(&e))
-          .await
+        if let Some(watcher) = &context.core.watcher {
+          let abs_path = context.core.build_root.join(path);
+          watcher
+            .watch(abs_path)
+            .map_err(|e| Context::mk_error(&e))
+            .await
+        } else {
+          Ok(())
+        }
       } else {
         Ok(())
       };

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -146,7 +146,11 @@ impl Scheduler {
     let core = self.core.clone();
     self.core.executor.block_on(async move {
       // Confirm that our InvalidationWatcher is still alive.
-      core.watcher.is_valid().await
+      if let Some(watcher) = &core.watcher {
+        watcher.is_valid().await
+      } else {
+        Ok(())
+      }
     })
   }
 


### PR DESCRIPTION
This should address #12059 by enabling an option to selectively disable filesystem watching, which is appropriate for one-off remote builds in cases such as preparing Docker containers.