### PR TITLE
Deprecate unused `interpreter_constraints` field for `python_awslambda` (Cherry-pick of #12208)

### DIFF
--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -46,6 +46,14 @@ class PythonAwsLambdaSources(PythonSources):
     )
 
 
+class DeprecatedAwsLambdaInterpreterConstraints(InterpreterConstraintsField):
+    deprecated_removal_version = "2.7.0.dev0"
+    deprecated_removal_hint = (
+        "The `interpreter_constraints` field does not do anything for `python_awslambda` targets. "
+        "Use the `runtime` field instead to choose the Python interpreter."
+    )
+
+
 class PythonAwsLambdaHandlerField(StringField, AsyncFieldMixin, SecondaryOwnerMixin):
     alias = "handler"
     required = True
@@ -190,7 +198,7 @@ class PythonAWSLambda(Target):
         *COMMON_TARGET_FIELDS,
         PythonAwsLambdaSources,
         OutputPathField,
-        InterpreterConstraintsField,
+        DeprecatedAwsLambdaInterpreterConstraints,
         PythonAwsLambdaDependencies,
         PythonAwsLambdaHandlerField,
         PythonAwsLambdaRuntime,


### PR DESCRIPTION
As found in https://github.com/pantsbuild/pants/pull/11982#discussion_r652226935, it turns out this field doesn't do anything. It was a mistake to have introduced it in the first place and a mistake to roll back its removal from 2.3.

[ci skip-rust]
[ci skip-build-wheels]