### PR TITLE
upgrade lexical-core to fix a bug in recent rustc version

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1452,13 +1452,13 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lexical-core"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
  "arrayvec",
  "bitflags",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "ryu",
  "static_assertions",
 ]


### PR DESCRIPTION
Upgrade the `lexical-core` crate to version v0.7.6 (from v0.7.4) so we get the fix from v0.7.5 that is blocking the upgrade to Rust v1.53.0. See https://github.com/pantsbuild/pants/pull/12221#issuecomment-863405175 for the particular error. 

[ci skip-build-wheels]