### PR TITLE
[internal] Port `match_path_globs` to PyO3

### DIFF
--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -8,7 +8,6 @@ from typing import Any, Sequence, TextIO
 
 from typing_extensions import Protocol
 
-from pants.engine.fs import PathGlobs
 from pants.engine.internals.scheduler import Workunit, _PathGlobsAndRootCollection
 from pants.engine.internals.session import SessionValues
 from pants.engine.process import InteractiveProcess, InteractiveProcessResult
@@ -30,7 +29,6 @@ class RawFdRunner(Protocol):
         stderr_fileno: int,
     ) -> int: ...
 
-def match_path_globs(path_globs: PathGlobs, paths: tuple[str, ...]) -> str: ...
 def capture_snapshots(
     scheduler: PyScheduler,
     session: PySession,

--- a/src/python/pants/engine/internals/native_engine_pyo3.pyi
+++ b/src/python/pants/engine/internals/native_engine_pyo3.pyi
@@ -3,9 +3,13 @@
 
 from __future__ import annotations
 
+from pants.engine.fs import PathGlobs
+
 # TODO: black and flake8 disagree about the content of this file:
 #   see https://github.com/psf/black/issues/1548
 # flake8: noqa: E302
+
+def match_path_globs(path_globs: PathGlobs, paths: tuple[str, ...]) -> str: ...
 
 class PyNailgunClient:
     def __init__(self, port: int, executor: PyExecutor) -> None: ...

--- a/src/python/pants/source/filespec.py
+++ b/src/python/pants/source/filespec.py
@@ -8,7 +8,7 @@ from typing import Iterable
 from typing_extensions import TypedDict
 
 from pants.engine.fs import PathGlobs
-from pants.engine.internals import native_engine
+from pants.engine.internals import native_engine_pyo3 as native_engine
 
 
 class _IncludesDict(TypedDict, total=True):

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -694,6 +694,7 @@ dependencies = [
 name = "engine_pyo3"
 version = "0.0.1"
 dependencies = [
+ "fs",
  "hashing",
  "mock",
  "nailgun",

--- a/src/rust/engine/engine_pyo3/Cargo.toml
+++ b/src/rust/engine/engine_pyo3/Cargo.toml
@@ -18,6 +18,7 @@ extension-module = ["pyo3/extension-module"]
 default = []
 
 [dependencies]
+fs = { path = "../fs" }
 hashing = { path = "../hashing" }
 nailgun = { path = "../nailgun" }
 parking_lot = "0.11"

--- a/src/rust/engine/engine_pyo3/src/externs/interface.rs
+++ b/src/rust/engine/engine_pyo3/src/externs/interface.rs
@@ -4,11 +4,13 @@
 use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
 
+mod fs;
 mod nailgun;
 mod testutil;
 
 #[pymodule]
 fn native_engine_pyo3(py: Python, m: &PyModule) -> PyResult<()> {
+  self::fs::register(m)?;
   self::nailgun::register(py, m)?;
   self::testutil::register(m)?;
 

--- a/src/rust/engine/engine_pyo3/src/externs/interface/fs.rs
+++ b/src/rust/engine/engine_pyo3/src/externs/interface/fs.rs
@@ -1,0 +1,74 @@
+// Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+use std::path::PathBuf;
+
+use fs::{GlobExpansionConjunction, PathGlobs, PreparedPathGlobs, StrictGlobMatching};
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::wrap_pyfunction;
+
+pub(crate) fn register(m: &PyModule) -> PyResult<()> {
+  m.add_function(wrap_pyfunction!(match_path_globs, m)?)?;
+  Ok(())
+}
+
+struct PyPathGlobs(PathGlobs);
+
+impl PyPathGlobs {
+  fn parse(self) -> PyResult<PreparedPathGlobs> {
+    self.0.clone().parse().map_err(|e| {
+      PyValueError::new_err(format!(
+        "Failed to parse PathGlobs: {:?}\n\nError: {}",
+        self.0, e
+      ))
+    })
+  }
+}
+
+impl<'source> FromPyObject<'source> for PyPathGlobs {
+  fn extract(obj: &'source PyAny) -> PyResult<Self> {
+    let globs: Vec<String> = obj.getattr("globs")?.extract()?;
+
+    let description_of_origin_field: String = obj.getattr("description_of_origin")?.extract()?;
+    let description_of_origin = if description_of_origin_field.is_empty() {
+      None
+    } else {
+      Some(description_of_origin_field)
+    };
+
+    let match_behavior_str: &str = obj
+      .getattr("glob_match_error_behavior")?
+      .getattr("value")?
+      .extract()?;
+    let match_behavior = StrictGlobMatching::create(match_behavior_str, description_of_origin)
+      .map_err(PyValueError::new_err)?;
+
+    let conjunction_str: &str = obj.getattr("conjunction")?.getattr("value")?.extract()?;
+    let conjunction =
+      GlobExpansionConjunction::create(conjunction_str).map_err(PyValueError::new_err)?;
+
+    Ok(PyPathGlobs(PathGlobs::new(
+      globs,
+      match_behavior,
+      conjunction,
+    )))
+  }
+}
+
+#[pyfunction]
+fn match_path_globs(
+  py_path_globs: PyPathGlobs,
+  paths: Vec<String>,
+  py: Python,
+) -> PyResult<Vec<String>> {
+  py.allow_threads(|| {
+    let path_globs = py_path_globs.parse()?;
+    Ok(
+      paths
+        .into_iter()
+        .filter(|p| path_globs.matches(&PathBuf::from(p)))
+        .collect(),
+    )
+  })
+}

--- a/src/rust/engine/engine_pyo3/src/externs/interface/fs.rs
+++ b/src/rust/engine/engine_pyo3/src/externs/interface/fs.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-use std::path::PathBuf;
+use std::path::Path;
 
 use fs::{GlobExpansionConjunction, PathGlobs, PreparedPathGlobs, StrictGlobMatching};
 use pyo3::exceptions::PyValueError;
@@ -67,7 +67,7 @@ fn match_path_globs(
     Ok(
       paths
         .into_iter()
-        .filter(|p| path_globs.matches(&PathBuf::from(p)))
+        .filter(|p| path_globs.matches(&Path::new(p)))
         .collect(),
     )
   })

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -156,11 +156,6 @@ py_module_initializer!(native_engine, |py, m| {
 
   m.add(
     py,
-    "match_path_globs",
-    py_fn!(py, match_path_globs(a: PyObject, b: Vec<String>)),
-  )?;
-  m.add(
-    py,
     "write_digest",
     py_fn!(
       py,
@@ -1543,35 +1538,6 @@ fn lease_files_in_graph(
       .map(|()| None)
     })
   })
-}
-
-fn match_path_globs(
-  py: Python,
-  path_globs: PyObject,
-  paths: Vec<String>,
-) -> CPyResult<Vec<String>> {
-  let matches = py
-    .allow_threads(|| {
-      let path_globs = nodes::Snapshot::lift_prepared_path_globs(&path_globs.into())?;
-
-      Ok(
-        paths
-          .into_iter()
-          .map(PathBuf::from)
-          .filter(|pb| path_globs.matches(pb.as_ref()))
-          .collect::<Vec<_>>(),
-      )
-    })
-    .map_err(|e: String| PyErr::new::<exc::ValueError, _>(py, (e,)))?;
-
-  matches
-    .into_iter()
-    .map(|pb| {
-      pb.into_os_string().into_string().map_err(|s| {
-        PyErr::new::<exc::Exception, _>(py, (format!("Could not decode {:?} as a string.", s),))
-      })
-    })
-    .collect::<Result<Vec<_>, _>>()
 }
 
 fn capture_snapshots(


### PR DESCRIPTION
This shows how we can convert types defined in Python into Rust, e.g. `PathGlobs`. 

Whereas we used to use a free function to do the conversion and asked for `PyObject` in the FFI function, now we implement the trait `FromPyObject` on a wrapper type `PyPathGlobs` so that we can request it directly in the function signature. This is more idiomatic and makes the `#[pyfunction]` more clear what it does.

We also now directly use PyO3's `.getattr()` and `.extract()` at callsites, rather than using our custom `getattr()` functions that wrapped those with Rust-Cpython. This removes a layer of indirection and doesn't noticeably increase boilerplate at callsites - it in fact reduces some because it's easier to chain `.getattr()` multiple times.

At least for now, we don't use `Value`, which is an `Arc` around a Rust-CPython `PyObject`. We were using that because cloning with Rust-CPython requires the GIL. Here, we're able to clone w/o requiring the GIL (in `PyPathGlobs.parse()`), so I went with a simpler implementation. Some benefits of avoiding `Value` are a) better type safety and b) avoiding a lock. We may end up needing `Value` at the end of the day, but we can add this back.

### Benchmark

PyO3 does have slightly worse performance with this diff:

```diff
diff --git a/src/python/pants/bin/pants_loader.py b/src/python/pants/bin/pants_loader.py
index 10c8b406b..ec9ef50bf 100644
--- a/src/python/pants/bin/pants_loader.py
+++ b/src/python/pants/bin/pants_loader.py
@@ -126,4 +126,8 @@ def main() -> None:


 if __name__ == "__main__":
-    main()
+    from pants.engine.internals.native_engine import match_path_globs
+    from pants.engine.fs import PathGlobs
+
+    x = match_path_globs(PathGlobs(["**/*.txt"]), tuple(f"foo/{i}.txt" for i in range(1_000_000)))
+    # main()
```

Before:

```
❯ hyperfine --warmup 1 --runs=100 './pants'
Benchmark #1: ./pants
  Time (mean ± σ):     712.3 ms ±   4.6 ms    [User: 587.7 ms, System: 103.3 ms]
  Range (min … max):   701.0 ms … 722.9 ms    100 runs

```

After:

```
❯ hyperfine --warmup 1 --runs=100 './pants'
Benchmark #1: ./pants
  Time (mean ± σ):     732.7 ms ±   8.0 ms    [User: 610.8 ms, System: 100.2 ms]
  Range (min … max):   720.5 ms … 778.0 ms    100 runs
```

Another `after` benchmark run with fewer apps on my machine shows `726.1 ms ±   4.9 ms    [User: 610.0 ms, System: 94.8 ms]`. Note that User is still the same, and only System changes. So this seems to be an actual slowdown.

I am not yet sure why, but can profile if this is concerning.

[ci skip-build-wheels]