### PR TITLE
Consume CoarsenedTargets (added in #12251) in javac for cycle resolution, including cycles created by subtargets.

### DIFF
--- a/src/python/pants/backend/java/compile/javac_test.py
+++ b/src/python/pants/backend/java/compile/javac_test.py
@@ -31,7 +31,7 @@ from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 # TODO(#12293): Stabilize network flakiness.
-# pytestmark = pytest.mark.skip
+pytestmark = pytest.mark.skip
 
 
 @pytest.fixture


### PR DESCRIPTION
Consume CoarsenedTargets (added in #12251) in javac for cycle resolution, including cycles created by subtargets.

NOTE: For initial CI and review, this commit comments out the pytest skip line in `javac_test.py` that otherwise prevents #12293 from occuring.  Before merging this PR, I will either uncomment that line again, or have already merged a temporary half-fix for #12293 that at least lets us re-enable some tests (but with caveats).

[ci skip-rust]
[ci skip-build-wheels]