### PR TITLE
Fix `skip_tool` not working with `./pants fmt` if all files are skipped (Cherry-pick of #12230)

### DIFF
--- a/src/python/pants/backend/go/lint/fmt.py
+++ b/src/python/pants/backend/go/lint/fmt.py
@@ -40,20 +40,18 @@ async def format_golang_targets(
         GoLangFmtRequest
     ]
     for fmt_request_type in fmt_request_types:
-        result = await Get(
-            EnrichedFmtResult,
-            GoLangFmtRequest,
-            fmt_request_type(
-                (
-                    fmt_request_type.field_set_type.create(target)
-                    for target in go_fmt_targets.targets
-                    if fmt_request_type.field_set_type.is_applicable(target)
-                ),
-                prior_formatter_result=prior_formatter_result,
+        request = fmt_request_type(
+            (
+                fmt_request_type.field_set_type.create(target)
+                for target in go_fmt_targets.targets
+                if fmt_request_type.field_set_type.is_applicable(target)
             ),
+            prior_formatter_result=prior_formatter_result,
         )
-        if not result.skipped:
-            results.append(result)
+        if not request.field_sets:
+            continue
+        result = await Get(EnrichedFmtResult, GoLangFmtRequest, request)
+        results.append(result)
         if result.did_change:
             prior_formatter_result = await Get(Snapshot, Digest, result.output)
     return LanguageFmtResults(

--- a/src/python/pants/backend/python/lint/python_fmt.py
+++ b/src/python/pants/backend/python/lint/python_fmt.py
@@ -35,18 +35,17 @@ async def format_python_target(
     results = []
     fmt_request_types = union_membership.union_rules[PythonFmtRequest]
     for fmt_request_type in fmt_request_types:
-        result = await Get(
-            EnrichedFmtResult,
-            PythonFmtRequest,
-            fmt_request_type(
-                (
-                    fmt_request_type.field_set_type.create(target)
-                    for target in python_fmt_targets.targets
-                    if fmt_request_type.field_set_type.is_applicable(target)
-                ),
-                prior_formatter_result=prior_formatter_result,
+        request = fmt_request_type(
+            (
+                fmt_request_type.field_set_type.create(target)
+                for target in python_fmt_targets.targets
+                if fmt_request_type.field_set_type.is_applicable(target)
             ),
+            prior_formatter_result=prior_formatter_result,
         )
+        if not request.field_sets:
+            continue
+        result = await Get(EnrichedFmtResult, PythonFmtRequest, request)
         results.append(result)
         if result.did_change:
             prior_formatter_result = await Get(Snapshot, Digest, result.output)

--- a/src/python/pants/backend/shell/lint/shell_fmt.py
+++ b/src/python/pants/backend/shell/lint/shell_fmt.py
@@ -37,18 +37,17 @@ async def format_shell_targets(
     results = []
     fmt_request_types = union_membership.union_rules[ShellFmtRequest]
     for fmt_request_type in fmt_request_types:
-        result = await Get(
-            EnrichedFmtResult,
-            ShellFmtRequest,
-            fmt_request_type(
-                (
-                    fmt_request_type.field_set_type.create(target)
-                    for target in shell_fmt_targets.targets
-                    if fmt_request_type.field_set_type.is_applicable(target)
-                ),
-                prior_formatter_result=prior_formatter_result,
+        request = fmt_request_type(
+            (
+                fmt_request_type.field_set_type.create(target)
+                for target in shell_fmt_targets.targets
+                if fmt_request_type.field_set_type.is_applicable(target)
             ),
+            prior_formatter_result=prior_formatter_result,
         )
+        if not request.field_sets:
+            continue
+        result = await Get(EnrichedFmtResult, ShellFmtRequest, request)
         results.append(result)
         if result.did_change:
             prior_formatter_result = await Get(Snapshot, Digest, result.output)


### PR DESCRIPTION
We were still invoking the formatters, but with no files to run on.

[ci skip-rust]
[ci skip-build-wheels]