### PR TITLE
Set up pants to use the latest version of humbug

### DIFF
--- a/3rdparty/python/constraints.txt
+++ b/3rdparty/python/constraints.txt
@@ -8,7 +8,7 @@ chardet==4.0.0
 cryptography==3.4.7
 fasteners==0.16
 freezegun==1.1.0
-humbug==0.1.9
+humbug==0.2.6
 idna==2.10
 iniconfig==1.1.1
 mypy==0.812

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -4,7 +4,7 @@ freezegun==1.1.0
 
 # Note: we use humbug to report telemetry. When upgrading, ensure the new version maintains the
 # anonymity promise we make here: https://www.pantsbuild.org/docs/anonymous-telemetry
-humbug==0.1.9
+humbug==0.2.6
 
 # The MyPy requirement should be maintained in lockstep with the requirement the Pants repo uses
 # for the mypy task since it configures custom MyPy plugins. That requirement can be found via:

--- a/src/python/pants/goal/anonymous_telemetry.py
+++ b/src/python/pants/goal/anonymous_telemetry.py
@@ -10,7 +10,7 @@ import uuid
 from typing import cast
 
 from humbug.consent import HumbugConsent  # type: ignore
-from humbug.report import Modes, Report, HumbugReporter # type: ignore
+from humbug.report import Modes, Report, HumbugReporter  # type: ignore
 
 from pants.engine.internals.scheduler import Workunit
 from pants.engine.rules import collect_rules, rule

--- a/src/python/pants/goal/anonymous_telemetry.py
+++ b/src/python/pants/goal/anonymous_telemetry.py
@@ -10,7 +10,7 @@ import uuid
 from typing import cast
 
 from humbug.consent import HumbugConsent  # type: ignore
-from humbug.report import Modes, Report, HumbugReporter  # type: ignore
+from humbug.report import HumbugReporter, Modes, Report  # type: ignore
 
 from pants.engine.internals.scheduler import Workunit
 from pants.engine.rules import collect_rules, rule


### PR DESCRIPTION
Uses a new token for telemetry.

In the new setup, the journal ID is no longer necessary. In fact, we are using a new journal. Once I have approval, I will revoke the old token and remove the old journal so that no unhashed `repo_id`s are ever stored through telemetry.

Tested that revoking the token does not cause any errors when older versions of `pants` are run. Ditto deleting the journal.