### PR TITLE
extract user-agent header and set it on Tonic builder correctly

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1072,11 +1072,14 @@ dependencies = [
 name = "grpc_util"
 version = "0.0.1"
 dependencies = [
+ "async-trait",
  "bytes 1.0.1",
  "futures",
+ "http",
  "hyper",
  "parking_lot",
  "prost",
+ "prost-build",
  "prost-types",
  "rand 0.8.2",
  "rustls-native-certs",
@@ -1084,6 +1087,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tonic",
+ "tonic-build",
 ]
 
 [[package]]

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -67,7 +67,7 @@ impl ByteStore {
     cas_address: &str,
     instance_name: Option<String>,
     root_ca_certs: Option<Vec<u8>>,
-    headers: BTreeMap<String, String>,
+    mut headers: BTreeMap<String, String>,
     chunk_size_bytes: usize,
     upload_timeout: Duration,
     rpc_retries: usize,
@@ -78,7 +78,8 @@ impl ByteStore {
       None
     };
 
-    let endpoint = grpc_util::create_endpoint(&cas_address, tls_client_config.as_ref())?;
+    let endpoint =
+      grpc_util::create_endpoint(&cas_address, tls_client_config.as_ref(), &mut headers)?;
     let channel = tonic::transport::Channel::balance_list(vec![endpoint].into_iter());
     let interceptor = if headers.is_empty() {
       None

--- a/src/rust/engine/grpc_util/Cargo.toml
+++ b/src/rust/engine/grpc_util/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 bytes = "1.0"
 futures = "0.3"
 hyper = "0.14"
+http = "0.2"
 rustls-native-certs = "0.5"
 prost = "0.7"
 rand = "0.8"
@@ -18,5 +19,10 @@ tokio-util = { version = "0.6", features = ["codec"] }
 tonic = { version = "0.4", features = ["transport", "codegen", "tls", "tls-roots", "prost"] }
 
 [dev-dependencies]
+async-trait = "0.1"
 parking_lot = "0.11"
 prost-types = "0.7"
+
+[build-dependencies]
+prost-build = "0.7"
+tonic-build = "0.4"

--- a/src/rust/engine/grpc_util/build.rs
+++ b/src/rust/engine/grpc_util/build.rs
@@ -1,0 +1,15 @@
+// Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+  use prost_build::Config;
+
+  let config = Config::new();
+
+  tonic_build::configure()
+    .build_client(true)
+    .build_server(true)
+    .compile_with_config(config, &["protos/test.proto"], &["protos"])?;
+
+  Ok(())
+}

--- a/src/rust/engine/grpc_util/protos/test.proto
+++ b/src/rust/engine/grpc_util/protos/test.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package test;
+
+message Input {}
+message Output {}
+
+service Test {
+    rpc Call(Input) returns (Output);
+}
+

--- a/src/rust/engine/grpc_util/src/lib.rs
+++ b/src/rust/engine/grpc_util/src/lib.rs
@@ -172,7 +172,7 @@ mod tests {
   use tonic::transport::{Channel, Server};
   use tonic::{Request, Response, Status};
 
-  use mock::tonic_util::AddrIncomingWithStream;
+  use crate::hyper::AddrIncomingWithStream;
 
   #[tokio::test]
   async fn user_agent_is_set_correctly() {

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -121,7 +121,7 @@ impl CommandRunner {
     store_address: &str,
     metadata: ProcessMetadata,
     root_ca_certs: Option<Vec<u8>>,
-    headers: BTreeMap<String, String>,
+    mut headers: BTreeMap<String, String>,
     store: Store,
     platform: Platform,
     overall_deadline: Duration,
@@ -145,6 +145,7 @@ impl CommandRunner {
     let execution_endpoint = grpc_util::create_endpoint(
       &execution_address,
       tls_client_config.as_ref().filter(|_| execution_use_tls),
+      &mut headers,
     )?;
     let execution_channel =
       tonic::transport::Channel::balance_list(vec![execution_endpoint].into_iter());
@@ -158,6 +159,7 @@ impl CommandRunner {
     let store_endpoint = grpc_util::create_endpoint(
       &store_address,
       tls_client_config.as_ref().filter(|_| execution_use_tls),
+      &mut headers,
     )?;
     let store_channel = tonic::transport::Channel::balance_list(vec![store_endpoint].into_iter());
 

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -59,7 +59,7 @@ impl CommandRunner {
     store: Store,
     action_cache_address: &str,
     root_ca_certs: Option<Vec<u8>>,
-    headers: BTreeMap<String, String>,
+    mut headers: BTreeMap<String, String>,
     platform: Platform,
     cache_read: bool,
     cache_write: bool,
@@ -72,7 +72,11 @@ impl CommandRunner {
       None
     };
 
-    let endpoint = grpc_util::create_endpoint(&action_cache_address, tls_client_config.as_ref())?;
+    let endpoint = grpc_util::create_endpoint(
+      &action_cache_address,
+      tls_client_config.as_ref(),
+      &mut headers,
+    )?;
     let channel = tonic::transport::Channel::balance_list(vec![endpoint].into_iter());
     let action_cache_client = Arc::new(if headers.is_empty() {
       ActionCacheClient::new(channel)


### PR DESCRIPTION
## Problem

The Tonic gRPC library requires that user agent headers be passed to it via the `Endpoint::user_agent`. Any `user-agent` header set as request metadata will be overwritten. See https://github.com/hyperium/tonic/blob/0c69c378fd85d754f045791a5d51b29831e4c728/tonic/src/transport/service/user_agent.rs#L43.

## Solution

Extract any `user-agent` header from passed-in headers for remote store and remote execution. Then pass the user agent to Tonic as it expects.

[ci skip-build-wheels]