### PR TITLE
Fix dependency inference to be ambiguous when >1 type stub for same module

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -181,11 +181,11 @@ async def map_first_party_python_targets_to_modules(
             if module in modules_to_addresses:
                 # We check if one of the targets is an implementation (.py file) and the other is
                 # a type stub (.pyi file), which we allow. Otherwise, we have ambiguity.
-                either_targets_are_type_stubs = len(modules_to_addresses[module]) == 1 and (
-                    tgt.address.filename.endswith(".pyi")
-                    or modules_to_addresses[module][0].filename.endswith(".pyi")
-                )
-                if either_targets_are_type_stubs:
+                prior_is_type_stub = len(
+                    modules_to_addresses[module]
+                ) == 1 and modules_to_addresses[module][0].filename.endswith(".pyi")
+                current_is_type_stub = tgt.address.filename.endswith(".pyi")
+                if prior_is_type_stub ^ current_is_type_stub:
                     modules_to_addresses[module].append(tgt.address)
                 else:
                     modules_with_multiple_implementations[module].update(


### PR DESCRIPTION
We allow for you to have 1 type stub (.pyi file) and 1 implementation (.py file) for the same module. But that code was faulty that it also was allowing 2 .pyi files for the same module.

[ci skip-rust]
[ci skip-build-wheels]