### PR TITLE
[internal] Refactor `module_mapper_test.py`

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
@@ -284,7 +284,9 @@ def test_map_first_party_modules_to_addresses(rule_runner: RuleRunner) -> None:
 
 
 def test_map_third_party_modules_to_addresses(rule_runner: RuleRunner) -> None:
-    def req(tgt_name: str, req_str: str, *, module_mapping: dict[str, str] | None = None) -> str:
+    def req(
+        tgt_name: str, req_str: str, *, module_mapping: dict[str, list[str]] | None = None
+    ) -> str:
         return (
             f"python_requirement_library(name='{tgt_name}', requirements=['{req_str}'], "
             f"module_mapping={repr(module_mapping or {})})"


### PR DESCRIPTION
Changes to `test_map_third_party_modules_to_addresses`:
- Use one target per requirement for clarity.
- Rename targets/reqs to describe what they are testing, rather than fake project names.
- DRY

Changes to `test_map_module_to_address`:
- Use `RuleRunner.write_files({})` to consolidate all test setup into a single place, rather than mutating state along the way. This makes the tests easier to follow.
- Rename some targets/reqs for clarity.

`dependency_inference/rules.py` could use a refactor too, but this punts on that.

[ci skip-rust]
[ci skip-build-wheels]