### PR TITLE
Add dependency inference for Python third-party type stubs

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -19,5 +19,16 @@ DEFAULT_MODULE_MAPPING = {
     "pyyaml": ("yaml",),
     "pymongo": ("bson", "gridfs"),
     "pytest-runner": ("ptr",),
-    "setuptools": ("easy_install", "pkg_resources"),
+    "setuptools": ("easy_install", "pkg_resources", "setuptools"),
+}
+
+DEFAULT_TYPE_STUB_MODULE_MAPPING = {
+    "djangorestframework-types": ("rest_framework",),
+    "types-enum34": ("enum34",),
+    "types-protobuf": ("google.protobuf",),
+    "types-pycrypto": ("Crypto",),
+    "types-pyopenssl": ("OpenSSL",),
+    "types-pyyaml": ("yaml",),
+    "types-python-dateutil": ("dateutil",),
+    "types-setuptools": ("easy_install", "pkg_resources", "setuptools"),
 }

--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -258,7 +258,9 @@ async def map_third_party_modules_to_addresses() -> ThirdPartyPythonModuleMappin
             in_stubs_map = proj_name in stubs_module_map
             starts_with_types = fallback_value.startswith("types_")
             ends_with_types = fallback_value.endswith("_types")
-            if starts_with_types or ends_with_types or in_stubs_map:
+            if proj_name not in module_map and (
+                in_stubs_map or starts_with_types or ends_with_types
+            ):
                 if in_stubs_map:
                     modules = stubs_module_map[proj_name]
                 else:

--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -15,6 +15,7 @@ from pants.backend.python.target_types import (
     ModuleMappingField,
     PythonRequirementsField,
     PythonSources,
+    TypeStubsModuleMappingField,
 )
 from pants.base.specs import AddressSpecs, DescendantAddresses
 from pants.core.util_rules.stripped_source_files import StrippedSourceFileNames
@@ -213,12 +214,16 @@ async def map_first_party_python_targets_to_modules(
 
 @dataclass(frozen=True)
 class ThirdPartyPythonModuleMapping:
-    mapping: FrozenDict[str, Address]
+    mapping: FrozenDict[str, tuple[Address, ...]]
     ambiguous_modules: FrozenDict[str, tuple[Address, ...]]
 
-    def address_for_module(self, module: str) -> tuple[Address | None, tuple[Address, ...]]:
-        """Return the unambiguous owner (if any) and all ambiguous addresses."""
-        unambiguous = self.mapping.get(module)
+    def addresses_for_module(self, module: str) -> tuple[tuple[Address, ...], tuple[Address, ...]]:
+        """Return all unambiguous and ambiguous addresses.
+
+        The unambiguous addresses should be 0-2, but not more. We only expect 2 if there is both an
+        implementation and type stub with the same module name.
+        """
+        unambiguous = self.mapping.get(module, ())
         ambiguous = self.ambiguous_modules.get(module, ())
         if unambiguous or ambiguous:
             return unambiguous, ambiguous
@@ -226,40 +231,77 @@ class ThirdPartyPythonModuleMapping:
         # If the module is not found, recursively try the ancestor modules, if any. For example,
         # pants.task.task.Task -> pants.task.task -> pants.task -> pants
         if "." not in module:
-            return None, ()
+            return (), ()
         parent_module = module.rsplit(".", maxsplit=1)[0]
-        return self.address_for_module(parent_module)
+        return self.addresses_for_module(parent_module)
 
 
 @rule(desc="Creating map of third party targets to Python modules", level=LogLevel.DEBUG)
 async def map_third_party_modules_to_addresses() -> ThirdPartyPythonModuleMapping:
     all_targets = await Get(Targets, AddressSpecs([DescendantAddresses("")]))
     modules_to_addresses: dict[str, Address] = {}
+    modules_to_stub_addresses: dict[str, Address] = {}
     modules_with_multiple_owners: DefaultDict[str, set[Address]] = defaultdict(set)
     for tgt in all_targets:
         if not tgt.has_field(PythonRequirementsField):
             continue
         module_map = tgt.get(ModuleMappingField).value
+        stubs_module_map = tgt.get(TypeStubsModuleMappingField).value
         for req in tgt[PythonRequirementsField].value:
-            modules = module_map.get(
-                # NB: We only use `canonicalize_project_name()` for the key, but not the fallback
-                # value, because we want to preserve `.` in the module name. See
-                # https://www.python.org/dev/peps/pep-0503/#normalized-names.
-                canonicalize_project_name(req.project_name),
-                [req.project_name.lower().replace("-", "_")],
-            )
-            for module in modules:
-                if module in modules_to_addresses:
-                    modules_with_multiple_owners[module].update(
-                        {modules_to_addresses[module], tgt.address}
-                    )
+            # NB: We don't use `canonicalize_project_name()` for the fallback value because we
+            # want to preserve `.` in the module name. See
+            # https://www.python.org/dev/peps/pep-0503/#normalized-names.
+            proj_name = canonicalize_project_name(req.project_name)
+            fallback_value = req.project_name.strip().lower().replace("-", "_")
+
+            # Handle if it's a type stub.
+            in_stubs_map = proj_name in stubs_module_map
+            starts_with_types = fallback_value.startswith("types_")
+            ends_with_types = fallback_value.endswith("_types")
+            if starts_with_types or ends_with_types or in_stubs_map:
+                if in_stubs_map:
+                    modules = stubs_module_map[proj_name]
                 else:
-                    modules_to_addresses[module] = tgt.address
+                    modules = (fallback_value[6:] if starts_with_types else fallback_value[:-6],)
+
+                for module in modules:
+                    if module in modules_with_multiple_owners:
+                        modules_with_multiple_owners[module].add(tgt.address)
+                    elif module in modules_to_stub_addresses:
+                        modules_with_multiple_owners[module].update(
+                            {modules_to_stub_addresses[module], tgt.address}
+                        )
+                    else:
+                        modules_to_stub_addresses[module] = tgt.address
+
+            # Else it's a normal requirement.
+            else:
+                modules = module_map.get(proj_name, (fallback_value,))
+                for module in modules:
+                    if module in modules_with_multiple_owners:
+                        modules_with_multiple_owners[module].add(tgt.address)
+                    elif module in modules_to_addresses:
+                        modules_with_multiple_owners[module].update(
+                            {modules_to_addresses[module], tgt.address}
+                        )
+                    else:
+                        modules_to_addresses[module] = tgt.address
+
     # Remove modules with ambiguous owners.
     for module in modules_with_multiple_owners:
-        modules_to_addresses.pop(module)
+        if module in modules_to_addresses:
+            modules_to_addresses.pop(module)
+        if module in modules_to_stub_addresses:
+            modules_to_stub_addresses.pop(module)
+
+    merged_mapping: DefaultDict[str, list[Address]] = defaultdict(list)
+    for k, v in modules_to_addresses.items():
+        merged_mapping[k].append(v)
+    for k, v in modules_to_stub_addresses.items():
+        merged_mapping[k].append(v)
+
     return ThirdPartyPythonModuleMapping(
-        mapping=FrozenDict(sorted(modules_to_addresses.items())),
+        mapping=FrozenDict((k, tuple(sorted(v))) for k, v in sorted(merged_mapping.items())),
         ambiguous_modules=FrozenDict(
             (k, tuple(sorted(v))) for k, v in sorted(modules_with_multiple_owners.items())
         ),
@@ -297,7 +339,7 @@ async def map_module_to_address(
     first_party_mapping: FirstPartyPythonModuleMapping,
     third_party_mapping: ThirdPartyPythonModuleMapping,
 ) -> PythonModuleOwners:
-    third_party_address, third_party_ambiguous = third_party_mapping.address_for_module(
+    third_party_addresses, third_party_ambiguous = third_party_mapping.addresses_for_module(
         module.module
     )
     first_party_addresses, first_party_ambiguous = first_party_mapping.addresses_for_module(
@@ -308,26 +350,29 @@ async def map_module_to_address(
     # that even if there's ambiguity purely within either third-party or first-party, all targets
     # with that module become ambiguous.
     if third_party_ambiguous or first_party_ambiguous:
-        ambiguous = {*third_party_ambiguous, *first_party_ambiguous, *first_party_addresses}
-        if third_party_address:
-            ambiguous.add(third_party_address)
+        ambiguous = {
+            *first_party_ambiguous,
+            *first_party_addresses,
+            *third_party_ambiguous,
+            *third_party_addresses,
+        }
         return PythonModuleOwners((), ambiguous=tuple(sorted(ambiguous)))
 
     # It's possible for a user to write type stubs (`.pyi` files) for their third-party
     # dependencies. We check if that happened, but we're strict in validating that there is only a
     # single third party address and a single first-party address referring to a `.pyi` file;
     # otherwise, we have ambiguous implementations.
-    if third_party_address and not first_party_addresses:
-        return PythonModuleOwners((third_party_address,))
+    if third_party_addresses and not first_party_addresses:
+        return PythonModuleOwners(third_party_addresses)
     first_party_is_type_stub = len(first_party_addresses) == 1 and first_party_addresses[
         0
     ].filename.endswith(".pyi")
-    if third_party_address and first_party_is_type_stub:
-        return PythonModuleOwners((third_party_address, *first_party_addresses))
+    if len(third_party_addresses) == 1 and first_party_is_type_stub:
+        return PythonModuleOwners((*third_party_addresses, *first_party_addresses))
     # Else, we have ambiguity between the third-party and first-party addresses.
-    if third_party_address and first_party_addresses:
+    if third_party_addresses and first_party_addresses:
         return PythonModuleOwners(
-            (), ambiguous=tuple(sorted((third_party_address, *first_party_addresses)))
+            (), ambiguous=tuple(sorted((*third_party_addresses, *first_party_addresses)))
         )
 
     # We're done with looking at third-party addresses, and now solely look at first-party, which

--- a/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
@@ -336,6 +336,12 @@ def test_map_third_party_modules_to_addresses(rule_runner: RuleRunner) -> None:
             req("ambiguous_again_stubs_t1", "ambiguous-again-stubs-types==1.2"),
             req("ambiguous_again_stubs_t2", "types-ambiguous-again-stubs==1.3"),
             req("ambiguous_again_stubs_t3", "ambiguous-again-stubs==1.3"),
+            # Only assume it's a type stubs dep if we are certain it's not an implementation.
+            req(
+                "looks_like_stubs",
+                "looks-like-stubs-types",
+                module_mapping={"looks-like-stubs-types": ["looks_like_stubs"]},
+            ),
         ]
     )
     rule_runner.write_files({"BUILD": build_file})
@@ -344,6 +350,7 @@ def test_map_third_party_modules_to_addresses(rule_runner: RuleRunner) -> None:
         mapping=FrozenDict(
             {
                 "file_dist": (Address("", target_name="file_dist"),),
+                "looks_like_stubs": (Address("", target_name="looks_like_stubs"),),
                 "mapped_module": (Address("", target_name="module_mapping"),),
                 "module_mapping_un_normalized": (
                     Address("", target_name="module_mapping_un_normalized"),

--- a/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
@@ -11,7 +11,10 @@ from packaging.utils import canonicalize_name as canonicalize_project_name
 
 from pants.backend.codegen.protobuf.python import python_protobuf_module_mapper
 from pants.backend.codegen.protobuf.target_types import ProtobufLibrary
-from pants.backend.python.dependency_inference.default_module_mapping import DEFAULT_MODULE_MAPPING
+from pants.backend.python.dependency_inference.default_module_mapping import (
+    DEFAULT_MODULE_MAPPING,
+    DEFAULT_TYPE_STUB_MODULE_MAPPING,
+)
 from pants.backend.python.dependency_inference.module_mapper import (
     FirstPartyPythonModuleMapping,
     PythonModule,
@@ -31,6 +34,10 @@ def test_default_module_mapping_is_normalized() -> None:
         assert k == canonicalize_project_name(
             k
         ), "Please update `DEFAULT_MODULE_MAPPING` to use canonical project names"
+    for k in DEFAULT_TYPE_STUB_MODULE_MAPPING:
+        assert k == canonicalize_project_name(
+            k
+        ), "Please update `DEFAULT_TYPE_STUB_MODULE_MAPPING` to use canonical project names"
 
 
 @pytest.mark.parametrize(

--- a/src/python/pants/backend/python/macros/poetry_requirements.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements.py
@@ -245,6 +245,7 @@ class PoetryRequirements:
         pyproject_toml_relpath: str = "pyproject.toml",
         *,
         module_mapping: Optional[Mapping[str, Iterable[str]]] = None,
+        type_stubs_module_mapping: Optional[Mapping[str, Iterable[str]]] = None,
     ) -> None:
         """
         :param pyproject_toml_relpath: The relpath from this BUILD file to the requirements file.
@@ -266,9 +267,15 @@ class PoetryRequirements:
             req_file.read_text(), str(req_file.relative_to(get_buildroot()))
         )
         for parsed_req in requirements:
+            proj_name = parsed_req.project_name
             req_module_mapping = (
-                {parsed_req.project_name: module_mapping[parsed_req.project_name]}
-                if module_mapping and parsed_req.project_name in module_mapping
+                {proj_name: module_mapping[proj_name]}
+                if module_mapping and proj_name in module_mapping
+                else None
+            )
+            stubs_module_mapping = (
+                {proj_name: type_stubs_module_mapping[proj_name]}
+                if type_stubs_module_mapping and proj_name in type_stubs_module_mapping
                 else None
             )
             self._parse_context.create_object(
@@ -276,5 +283,6 @@ class PoetryRequirements:
                 name=parsed_req.project_name,
                 requirements=[parsed_req],
                 module_mapping=req_module_mapping,
+                type_stubs_module_mapping=stubs_module_mapping,
                 dependencies=[requirements_dep],
             )

--- a/src/python/pants/backend/python/macros/poetry_requirements_test.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements_test.py
@@ -233,11 +233,19 @@ def test_pyproject_toml(rule_runner: RuleRunner) -> None:
     """
     assert_poetry_requirements(
         rule_runner,
-        "poetry_requirements(module_mapping={'ansicolors': ['colors']})",
+        dedent(
+            """\
+            poetry_requirements(
+                module_mapping={'ansicolors': ['colors']},
+                type_stubs_module_mapping={'Django-types': ['django']},
+            )
+            """
+        ),
         dedent(
             """\
             [tool.poetry.dependencies]
             Django = {version = "3.2", python = "3"}
+            Django-types = "2"
             Un-Normalized-PROJECT = "1.0.0"
             [tool.poetry.dev-dependencies]
             ansicolors = ">=1.18.0"
@@ -262,6 +270,14 @@ def test_pyproject_toml(rule_runner: RuleRunner) -> None:
                     "requirements": [Requirement.parse("Django==3.2 ; python_version == '3'")],
                 },
                 address=Address("", target_name="Django"),
+            ),
+            PythonRequirementLibrary(
+                {
+                    "dependencies": [":pyproject.toml"],
+                    "requirements": [Requirement.parse("Django-types==2")],
+                    "type_stubs_module_mapping": {"Django-types": ["django"]},
+                },
+                address=Address("", target_name="Django-types"),
             ),
             PythonRequirementLibrary(
                 {

--- a/src/python/pants/backend/python/macros/python_requirements.py
+++ b/src/python/pants/backend/python/macros/python_requirements.py
@@ -50,6 +50,7 @@ class PythonRequirements:
         requirements_relpath: str = "requirements.txt",
         *,
         module_mapping: Optional[Mapping[str, Iterable[str]]] = None,
+        type_stubs_module_mapping: Optional[Mapping[str, Iterable[str]]] = None,
     ) -> None:
         """
         :param requirements_relpath: The relpath from this BUILD file to the requirements file.
@@ -80,10 +81,16 @@ class PythonRequirements:
                 if module_mapping and project_name in module_mapping
                 else None
             )
+            stubs_module_mapping = (
+                {project_name: type_stubs_module_mapping[project_name]}
+                if type_stubs_module_mapping and project_name in type_stubs_module_mapping
+                else None
+            )
             self._parse_context.create_object(
                 "python_requirement_library",
                 name=project_name,
                 requirements=parsed_reqs,
                 module_mapping=req_module_mapping,
+                type_stubs_module_mapping=stubs_module_mapping,
                 dependencies=[requirements_dep],
             )

--- a/src/python/pants/backend/python/macros/python_requirements_test.py
+++ b/src/python/pants/backend/python/macros/python_requirements_test.py
@@ -56,13 +56,21 @@ def test_requirements_txt(rule_runner: RuleRunner) -> None:
     """
     assert_python_requirements(
         rule_runner,
-        "python_requirements(module_mapping={'ansicolors': ['colors']})",
+        dedent(
+            """\
+            python_requirements(
+                module_mapping={'ansicolors': ['colors']},
+                type_stubs_module_mapping={'Django-types': ['django']},
+            )
+            """
+        ),
         dedent(
             """\
             # Comment.
             --find-links=https://duckduckgo.com
             ansicolors>=1.18.0
             Django==3.2 ; python_version>'3'
+            Django-types
             Un-Normalized-PROJECT  # Inline comment.
             pip@ git+https://github.com/pypa/pip.git
             """
@@ -86,6 +94,14 @@ def test_requirements_txt(rule_runner: RuleRunner) -> None:
                     "requirements": [Requirement.parse("Django==3.2 ; python_version>'3'")],
                 },
                 Address("", target_name="Django"),
+            ),
+            PythonRequirementLibrary(
+                {
+                    "dependencies": [":requirements.txt"],
+                    "requirements": [Requirement.parse("Django-types")],
+                    "type_stubs_module_mapping": {"Django-types": ["django"]},
+                },
+                Address("", target_name="Django-types"),
             ),
             PythonRequirementLibrary(
                 {

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -15,7 +15,10 @@ from typing import Dict, Iterable, Iterator, Optional, Tuple, Union, cast
 from packaging.utils import canonicalize_name as canonicalize_project_name
 from pkg_resources import Requirement
 
-from pants.backend.python.dependency_inference.default_module_mapping import DEFAULT_MODULE_MAPPING
+from pants.backend.python.dependency_inference.default_module_mapping import (
+    DEFAULT_MODULE_MAPPING,
+    DEFAULT_TYPE_STUB_MODULE_MAPPING,
+)
 from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.core.goals.package import OutputPathField
@@ -626,7 +629,10 @@ class TypeStubsModuleMappingField(DictStringToStringSequenceField):
     ) -> FrozenDict[str, Tuple[str, ...]]:
         provided_mapping = super().compute_value(raw_value, address)
         return FrozenDict(
-            {canonicalize_project_name(k): v for k, v in (provided_mapping or {}).items()}
+            {
+                **DEFAULT_TYPE_STUB_MODULE_MAPPING,
+                **{canonicalize_project_name(k): v for k, v in (provided_mapping or {}).items()},
+            }
         )
 
 

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -607,9 +607,36 @@ class ModuleMappingField(DictStringToStringSequenceField):
         )
 
 
+class TypeStubsModuleMappingField(DictStringToStringSequenceField):
+    alias = "type_stubs_module_mapping"
+    help = (
+        "A mapping of type-stub requirement names to a list of the modules they provide.\n\n"
+        'For example, `{"types-requests": ["requests"]}`. Any unspecified requirements will use '
+        'the requirement name without `types` as the default module, e.g. "types-requests" will '
+        'default to `["requests"]`.\n\n'
+        "This is used to infer dependencies for type stubs."
+    )
+    value: FrozenDict[str, Tuple[str, ...]]
+
+    @classmethod
+    def compute_value(
+        cls, raw_value: Optional[Dict[str, Iterable[str]]], address: Address
+    ) -> FrozenDict[str, Tuple[str, ...]]:
+        provided_mapping = super().compute_value(raw_value, address)
+        return FrozenDict(
+            {canonicalize_project_name(k): v for k, v in (provided_mapping or {}).items()}
+        )
+
+
 class PythonRequirementLibrary(Target):
     alias = "python_requirement_library"
-    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, PythonRequirementsField, ModuleMappingField)
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        Dependencies,
+        PythonRequirementsField,
+        ModuleMappingField,
+        TypeStubsModuleMappingField,
+    )
     help = (
         "Python requirements installable by pip.\n\nThis target is useful when you want to declare "
         "Python requirements inline in a BUILD file. If you have a `requirements.txt` file "

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -588,7 +588,7 @@ class ModuleMappingField(DictStringToStringSequenceField):
     alias = "module_mapping"
     help = (
         "A mapping of requirement names to a list of the modules they provide.\n\nFor example, "
-        '`{"ansicolors": ["colors"]}`. Any unspecified requirements will use the requirement '
+        '`{"ansicolors": ["colors"]}`.\n\nAny unspecified requirements will use the requirement '
         'name as the default module, e.g. "Django" will default to `["django"]`.\n\nThis is '
         "used to infer dependencies."
     )
@@ -611,9 +611,11 @@ class TypeStubsModuleMappingField(DictStringToStringSequenceField):
     alias = "type_stubs_module_mapping"
     help = (
         "A mapping of type-stub requirement names to a list of the modules they provide.\n\n"
-        'For example, `{"types-requests": ["requests"]}`. Any unspecified requirements will use '
-        'the requirement name without `types` as the default module, e.g. "types-requests" will '
-        'default to `["requests"]`.\n\n'
+        'For example, `{"types-requests": ["requests"]}`.\n\n'
+        "If the requirement is not specified _and_ it starts with `types-` or ends with `-types`, "
+        "the requirement will be treated as a type stub for the corresponding module, e.g. "
+        '"types-request" has the module "requests". Otherwise, the requirement is treated like a '
+        f"normal dependency (see the field {ModuleMappingField.alias}).\n\n"
         "This is used to infer dependencies for type stubs."
     )
     value: FrozenDict[str, Tuple[str, ...]]


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/12048.

While you could technically use third party type stubs before, it was not ergonomic. If you also had the implementation, e.g. Django-types and Django, then dependency inference would fail due to ambiguity. 

We now:

- Add a `type_stubs_module_mapping` field for users to teach Pants what is a type stub.
- Fallback to assuming `types-foo` and `foo-types` are type stubs and export the module `foo`.
- Allow 1 type stub and 1 normal dependency.
- Wire up to `python_requirements` and `poetry_requirements` macros.

This change is particularly important for MyPy 0.900+ to work, as typeshed is no longer shipped with MyPy. https://mypy-lang.blogspot.com/2021/06/mypy-0900-released.html

[ci skip-rust]
[ci skip-build-wheels]