### PR TITLE
[internal] Fix inconsistent Rust file prefix on main and align pre-commit checks with CI

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -140,9 +140,7 @@ jobs:
       name: Test and Lint Rust
       run: 'sudo apt-get install -y pkg-config fuse libfuse-dev
 
-        ./cargo fmt --all -- --check
-
-        ./cargo clippy --all
+        ./build-support/bin/check_rust_pre_commit.sh
 
         ./cargo test --all --tests -- --nocapture
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -140,9 +140,7 @@ jobs:
       name: Test and Lint Rust
       run: 'sudo apt-get install -y pkg-config fuse libfuse-dev
 
-        ./cargo fmt --all -- --check
-
-        ./cargo clippy --all
+        ./build-support/bin/check_rust_pre_commit.sh
 
         ./cargo test --all --tests -- --nocapture
 

--- a/build-support/bin/check_rust_formatting.sh
+++ b/build-support/bin/check_rust_formatting.sh
@@ -2,72 +2,12 @@
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-function usage() {
-  echo "Checks formatting of rust files, optionally fixing mis-formatted files."
-  echo
-  echo "Usage: $0 (-h|-f)"
-  echo " -h    print out this help message"
-  echo " -f    instead of erroring on files with bad formatting, fix those files"
+BASE_COMMAND="${REPO_ROOT}/cargo fmt --all --"
 
-  if [[ -n "$*" ]]; then
-    echo
-    echo "$@"
-  fi
-}
-
-check="true"
-
-while getopts "hf" opt; do
-  case ${opt} in
-    h)
-      usage
-      exit 0
-      ;;
-    f)
-      check="false"
-      ;;
-    *)
-      usage "Unrecognized arguments."
-      exit 1
-      ;;
-  esac
-done
-
-cmd=(
-  "${REPO_ROOT}/cargo" fmt --all --
-)
-if [[ "${check}" == "true" ]]; then
-  cmd=("${cmd[@]}" "--check")
-fi
-
-# WONTFIX: fixing the array expansion is too difficult to be worth it. See https://github.com/koalaman/shellcheck/wiki/SC2207.
-# shellcheck disable=SC2207
-bad_files=(
-  $(
-    # Ensure generated code is present since `cargo fmt` needs to do enough parsing to follow use's
-    # and these will land in generated code.
-    echo >&2 "Ensuring generated code is present for downstream formatting checks..."
-    "${REPO_ROOT}/cargo" check -p bazel_protos
-
-    "${cmd[@]}" |
-      awk '$0 ~ /^Diff in/ {print $3}' |
-      sort -u
-    exit "${PIPESTATUS[0]}"
-  )
-)
+$BASE_COMMAND --check
 exit_code=$?
 
 if [[ ${exit_code} -ne 0 ]]; then
-  if [[ "${check}" == "true" ]]; then
-    echo >&2 "The following Rust files were incorrectly formatted, run \`$0 -f\` to reformat them:"
-    for bad_file in ${bad_files[*]}; do
-      echo >&2 "${bad_file}"
-    done
-  else
-    cat << EOF >&2
-An error occurred while checking the formatting of Rust files:
-EOF
-    cd "${NATIVE_ROOT}" && "${cmd[@]}" > /dev/null
-  fi
+  echo >&2 "Rust files incorrectly formatted, run \`${BASE_COMMAND}\` to reformat them."
   exit 1
 fi

--- a/build-support/bin/check_rust_pre_commit.sh
+++ b/build-support/bin/check_rust_pre_commit.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# NB: pre-commit runs in the context of GIT_WORK_TREE, ie: pwd == REPO_ROOT
+
+echo "* Running \`./cargo clippy --all\`"
+./cargo clippy --all || exit 1
+echo "* Checking formatting of Rust files"
+./build-support/bin/check_rust_formatting.sh || exit 1
+echo "* Checking Rust target headers"
+./build-support/bin/check_rust_target_headers.sh || exit 1

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -288,8 +288,7 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
                     "run": dedent(
                         """\
                         sudo apt-get install -y pkg-config fuse libfuse-dev
-                        ./cargo fmt --all -- --check
-                        ./cargo clippy --all
+                        ./build-support/bin/check_rust_pre_commit.sh
                         ./cargo test --all --tests -- --nocapture
                         """
                     ),

--- a/build-support/githooks/pre-commit
+++ b/build-support/githooks/pre-commit
@@ -21,17 +21,7 @@ MERGE_BASE="$(git_merge_base)"
 # fails in pants changed.
 if git rev-parse --verify "${MERGE_BASE}" &> /dev/null; then
   if git diff "${MERGE_BASE}" --name-only | grep '\.rs$' > /dev/null; then
-    # Clippy happens on a different Travis CI shard because of separate caching concerns.
-    # The TRAVIS env var is documented here:
-    #   https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
-    if [[ "${TRAVIS}" != "true" ]]; then
-      echo "* Running \`./cargo clippy --all\`"
-      ./cargo clippy --all || exit 1
-    fi
-    echo "* Checking formatting of Rust files"
-    ./build-support/bin/check_rust_formatting.sh || exit 1
-    echo "* Checking Rust target headers"
-    build-support/bin/check_rust_target_headers.sh || exit 1
+    ./build-support/bin/check_rust_pre_commit.sh || exit 1
   fi
 
   echo "* Checking MyPy"
@@ -40,14 +30,6 @@ if git rev-parse --verify "${MERGE_BASE}" &> /dev/null; then
   echo "* Checking linters and formatters"
   ./pants --changed-since="${MERGE_BASE}" --tag='-nolint' lint ||
     die "If there were formatting errors, run \`./pants --changed-since=$(git rev-parse --symbolic "${MERGE_BASE}") fmt\`"
-
-  if git diff "${MERGE_BASE}" --name-only | grep build-support/bin/generate_travis_yml.py > /dev/null; then
-    echo "* Checking .travis.yml generation"
-    actual_travis_yml=$(< .travis.yml)
-    expected_travis_yml=$(./pants run build-support/bin:generate_travis_yml)
-    [ "${expected_travis_yml}" == "${actual_travis_yml}" ] ||
-      die "Travis config generator changed, but .travis.yml file was not regenerated. See the header of .travis.yml for instructions."
-  fi
 
   if git diff "${MERGE_BASE}" --name-only | grep build-support/bin/generate_github_workflows.py > /dev/null; then
     echo "* Checking GitHub workflows generation"

--- a/src/rust/engine/grpc_util/build.rs
+++ b/src/rust/engine/grpc_util/build.rs
@@ -1,6 +1,32 @@
 // Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+#![deny(warnings)]
+// Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
+#![deny(
+  clippy::all,
+  clippy::default_trait_access,
+  clippy::expl_impl_clone_on_copy,
+  clippy::if_not_else,
+  clippy::needless_continue,
+  clippy::unseparated_literal_suffix,
+  // TODO: Falsely triggers for async/await:
+  //   see https://github.com/rust-lang/rust-clippy/issues/5360
+  // clippy::used_underscore_binding
+)]
+// It is often more clear to show that nothing is being moved.
+#![allow(clippy::match_ref_pats)]
+// Subjective style.
+#![allow(
+  clippy::len_without_is_empty,
+  clippy::redundant_field_names,
+  clippy::too_many_arguments
+)]
+// Default isn't as big a deal as people seem to think it is.
+#![allow(clippy::new_without_default, clippy::new_ret_no_self)]
+// Arc<Mutex> can be more clear than needing to grok Orderings:
+#![allow(clippy::mutex_atomic)]
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
   use prost_build::Config;
 


### PR DESCRIPTION
An inconsistent Rust file prefix made it on master, causing unrelated commit hook runs to fail. Fix the prefix, and adjust CI to run the same three commands as the commit hooks. Also, simplify `check_rust_formatting.sh` to recommend directly running `./cargo fmt --all` (which has seemingly worked since we moved to `prost`...?).