### PR TITLE
Apply a concurrency limit to remote cache/execution gRPC requests

### DIFF
--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -175,14 +175,17 @@ class Scheduler:
             store_chunk_bytes=execution_options.remote_store_chunk_bytes,
             store_chunk_upload_timeout=execution_options.remote_store_chunk_upload_timeout_seconds,
             store_rpc_retries=execution_options.remote_store_rpc_retries,
+            store_rpc_concurrency=execution_options.remote_store_rpc_concurrency,
             cache_warnings_behavior=execution_options.remote_cache_warnings.value,
             cache_eager_fetch=execution_options.remote_cache_eager_fetch,
+            cache_rpc_concurrency=execution_options.remote_cache_rpc_concurrency,
             execution_extra_platform_properties=tuple(
                 tuple(pair.split("=", 1))
                 for pair in execution_options.remote_execution_extra_platform_properties
             ),
             execution_headers=tuple(execution_options.remote_execution_headers.items()),
             execution_overall_deadline_secs=execution_options.remote_execution_overall_deadline_secs,
+            execution_rpc_concurrency=execution_options.remote_execution_rpc_concurrency,
         )
         py_local_store_options = PyLocalStoreOptions(
             store_dir=local_store_options.store_dir,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -149,6 +149,10 @@ class DynamicRemoteOptions:
     execution_address: str | None
     store_headers: dict[str, str]
     execution_headers: dict[str, str]
+    parallelism: int
+    store_rpc_concurrency: int
+    cache_rpc_concurrency: int
+    execution_rpc_concurrency: int
 
     @classmethod
     def disabled(cls) -> DynamicRemoteOptions:
@@ -161,6 +165,10 @@ class DynamicRemoteOptions:
             execution_address=None,
             store_headers={},
             execution_headers={},
+            parallelism=DEFAULT_EXECUTION_OPTIONS.process_execution_remote_parallelism,
+            store_rpc_concurrency=DEFAULT_EXECUTION_OPTIONS.remote_store_rpc_concurrency,
+            cache_rpc_concurrency=DEFAULT_EXECUTION_OPTIONS.remote_cache_rpc_concurrency,
+            execution_rpc_concurrency=DEFAULT_EXECUTION_OPTIONS.remote_execution_rpc_concurrency,
         )
 
     @classmethod
@@ -180,6 +188,10 @@ class DynamicRemoteOptions:
         instance_name = cast("str | None", bootstrap_options.remote_instance_name)
         execution_headers = cast("dict[str, str]", bootstrap_options.remote_execution_headers)
         store_headers = cast("dict[str, str]", bootstrap_options.remote_store_headers)
+        parallelism = cast(int, bootstrap_options.process_execution_remote_parallelism)
+        store_rpc_concurrency = cast(int, bootstrap_options.remote_store_rpc_concurrency)
+        cache_rpc_concurrency = cast(int, bootstrap_options.remote_cache_rpc_concurrency)
+        execution_rpc_concurrency = cast(int, bootstrap_options.remote_execution_rpc_concurrency)
 
         if bootstrap_options.remote_oauth_bearer_token_path:
             oauth_token = (
@@ -289,6 +301,10 @@ class DynamicRemoteOptions:
             execution_address=execution_address,
             store_headers=store_headers,
             execution_headers=execution_headers,
+            parallelism=parallelism,
+            store_rpc_concurrency=store_rpc_concurrency,
+            cache_rpc_concurrency=cache_rpc_concurrency,
+            execution_rpc_concurrency=execution_rpc_concurrency,
         )
         return opts, auth_plugin_result
 
@@ -319,14 +335,17 @@ class ExecutionOptions:
     remote_store_chunk_bytes: Any
     remote_store_chunk_upload_timeout_seconds: int
     remote_store_rpc_retries: int
+    remote_store_rpc_concurrency: int
 
     remote_cache_eager_fetch: bool
     remote_cache_warnings: RemoteCacheWarningsBehavior
+    remote_cache_rpc_concurrency: int
 
     remote_execution_address: str | None
     remote_execution_extra_platform_properties: List[str]
     remote_execution_headers: Dict[str, str]
     remote_execution_overall_deadline_secs: int
+    remote_execution_rpc_concurrency: int
 
     @classmethod
     def from_options(
@@ -345,7 +364,7 @@ class ExecutionOptions:
             # Process execution setup.
             process_execution_local_cache=bootstrap_options.process_execution_local_cache,
             process_execution_local_parallelism=bootstrap_options.process_execution_local_parallelism,
-            process_execution_remote_parallelism=bootstrap_options.process_execution_remote_parallelism,
+            process_execution_remote_parallelism=dynamic_remote_options.parallelism,
             process_execution_local_cleanup=bootstrap_options.process_execution_local_cleanup,
             process_execution_cache_namespace=bootstrap_options.process_execution_cache_namespace,
             # Remote store setup.
@@ -354,14 +373,17 @@ class ExecutionOptions:
             remote_store_chunk_bytes=bootstrap_options.remote_store_chunk_bytes,
             remote_store_chunk_upload_timeout_seconds=bootstrap_options.remote_store_chunk_upload_timeout_seconds,
             remote_store_rpc_retries=bootstrap_options.remote_store_rpc_retries,
+            remote_store_rpc_concurrency=dynamic_remote_options.store_rpc_concurrency,
             # Remote cache setup.
             remote_cache_eager_fetch=bootstrap_options.remote_cache_eager_fetch,
             remote_cache_warnings=bootstrap_options.remote_cache_warnings,
+            remote_cache_rpc_concurrency=dynamic_remote_options.cache_rpc_concurrency,
             # Remote execution setup.
             remote_execution_address=dynamic_remote_options.execution_address,
             remote_execution_extra_platform_properties=bootstrap_options.remote_execution_extra_platform_properties,
             remote_execution_headers=dynamic_remote_options.execution_headers,
             remote_execution_overall_deadline_secs=bootstrap_options.remote_execution_overall_deadline_secs,
+            remote_execution_rpc_concurrency=dynamic_remote_options.execution_rpc_concurrency,
         )
 
 
@@ -428,9 +450,11 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     remote_store_chunk_bytes=1024 * 1024,
     remote_store_chunk_upload_timeout_seconds=60,
     remote_store_rpc_retries=2,
+    remote_store_rpc_concurrency=128,
     # Remote cache setup.
     remote_cache_eager_fetch=True,
     remote_cache_warnings=RemoteCacheWarningsBehavior.first_only,
+    remote_cache_rpc_concurrency=128,
     # Remote execution setup.
     remote_execution_address=None,
     remote_execution_extra_platform_properties=[],
@@ -438,6 +462,7 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
         "user-agent": f"pants/{VERSION}",
     },
     remote_execution_overall_deadline_secs=60 * 60,  # one hour
+    remote_execution_rpc_concurrency=128,
 )
 
 DEFAULT_LOCAL_STORE_OPTIONS = LocalStoreOptions()
@@ -1159,6 +1184,13 @@ class GlobalOptions(Subsystem):
             default=DEFAULT_EXECUTION_OPTIONS.remote_store_rpc_retries,
             help="Number of times to retry any RPC to the remote store before giving up.",
         )
+        register(
+            "--remote-store-rpc-concurrency",
+            type=int,
+            advanced=True,
+            default=DEFAULT_EXECUTION_OPTIONS.remote_store_rpc_concurrency,
+            help="The number of concurrent requests allowed to the remote store service.",
+        )
 
         register(
             "--remote-cache-warnings",
@@ -1181,6 +1213,13 @@ class GlobalOptions(Subsystem):
                 "\n\nThis may result in worse performance, but reduce the frequency of errors "
                 "encountered by reducing the surface area of when remote caching is used."
             ),
+        )
+        register(
+            "--remote-cache-rpc-concurrency",
+            type=int,
+            advanced=True,
+            default=DEFAULT_EXECUTION_OPTIONS.remote_cache_rpc_concurrency,
+            help="The number of concurrent requests allowed to the remote cache service.",
         )
 
         register(
@@ -1220,6 +1259,13 @@ class GlobalOptions(Subsystem):
             default=DEFAULT_EXECUTION_OPTIONS.remote_execution_overall_deadline_secs,
             advanced=True,
             help="Overall timeout in seconds for each remote execution request from time of submission",
+        )
+        register(
+            "--remote-execution-rpc-concurrency",
+            type=int,
+            advanced=True,
+            default=DEFAULT_EXECUTION_OPTIONS.remote_execution_rpc_concurrency,
+            help="The number of concurrent requests allowed to the remote execution service.",
         )
 
         register(

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1083,6 +1083,7 @@ dependencies = [
  "tokio-util",
  "tonic",
  "tonic-build",
+ "tower",
 ]
 
 [[package]]

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -244,6 +244,14 @@ to this directory.",
               .required(false)
               .default_value("3")
         )
+        .arg(
+          Arg::with_name("rpc-concurrency-limit")
+              .help("Maximum concurrenct RPCs to the service.")
+              .takes_value(true)
+              .long("rpc-concurrency-limit")
+              .required(false)
+              .default_value("128")
+        )
       .get_matches(),
   ).await {
     Ok(_) => {}
@@ -316,6 +324,8 @@ async fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
             // See https://github.com/pantsbuild/pants/pull/6433 for more context.
             Duration::from_secs(30 * 60),
             value_t!(top_match.value_of("rpc-attempts"), usize).expect("Bad rpc-attempts flag"),
+            value_t!(top_match.value_of("rpc-concurrency-limit"), usize)
+              .expect("Bad rpc-concurrency-limit flag"),
           ),
           true,
         )

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -324,6 +324,7 @@ impl Store {
     chunk_size_bytes: usize,
     upload_timeout: Duration,
     rpc_retries: usize,
+    rpc_concurrency_limit: usize,
   ) -> Result<Store, String> {
     Ok(Store {
       local: self.local,
@@ -335,6 +336,7 @@ impl Store {
         chunk_size_bytes,
         upload_timeout,
         rpc_retries,
+        rpc_concurrency_limit,
       )?)),
     })
   }

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -157,6 +157,7 @@ async fn write_file_multiple_chunks() {
     10 * 1024,
     Duration::from_secs(5),
     1,
+    256,
   )
   .unwrap();
 
@@ -226,6 +227,7 @@ async fn write_connection_error() {
     10 * 1024 * 1024,
     Duration::from_secs(1),
     1,
+    256,
   )
   .unwrap();
   let error = store
@@ -301,6 +303,7 @@ fn new_byte_store(cas: &StubCAS) -> ByteStore {
     10 * MEGABYTES,
     Duration::from_secs(1),
     1,
+    256,
   )
   .unwrap()
 }

--- a/src/rust/engine/fs/store/src/tests.rs
+++ b/src/rust/engine/fs/store/src/tests.rs
@@ -103,6 +103,7 @@ fn new_store<P: AsRef<Path>>(dir: P, cas_address: &str) -> Store {
       10 * MEGABYTES,
       Duration::from_secs(1),
       1,
+      256,
     )
     .unwrap()
 }
@@ -843,6 +844,7 @@ async fn instance_name_upload() {
       10 * MEGABYTES,
       Duration::from_secs(1),
       1,
+      256,
     )
     .unwrap();
 
@@ -870,6 +872,7 @@ async fn instance_name_download() {
       10 * MEGABYTES,
       Duration::from_secs(1),
       1,
+      256,
     )
     .unwrap();
 
@@ -919,6 +922,7 @@ async fn auth_upload() {
       10 * MEGABYTES,
       Duration::from_secs(1),
       1,
+      256,
     )
     .unwrap();
 
@@ -948,6 +952,7 @@ async fn auth_download() {
       10 * MEGABYTES,
       Duration::from_secs(1),
       1,
+      256,
     )
     .unwrap();
 

--- a/src/rust/engine/grpc_util/Cargo.toml
+++ b/src/rust/engine/grpc_util/Cargo.toml
@@ -17,6 +17,7 @@ tokio = { version = "1.4", features = ["net", "process", "rt-multi-thread", "syn
 tokio-rustls = "0.22"
 tokio-util = { version = "0.6", features = ["codec"] }
 tonic = { version = "0.4", features = ["transport", "codegen", "tls", "tls-roots", "prost"] }
+tower = { version = "0.4", features = ["limit"] }
 
 [dev-dependencies]
 async-trait = "0.1"

--- a/src/rust/engine/grpc_util/src/lib.rs
+++ b/src/rust/engine/grpc_util/src/lib.rs
@@ -48,10 +48,9 @@ pub mod retry;
 // diverge in which layers they use, we should instead use a Box<dyn Service<..>>.
 pub type LayeredService = ConcurrencyLimit<Channel>;
 
-pub fn layered_service(channel: Channel) -> LayeredService {
+pub fn layered_service(channel: Channel, concurrency_limit: usize) -> LayeredService {
   ServiceBuilder::new()
-    // TODO
-    .concurrency_limit(100)
+    .concurrency_limit(concurrency_limit)
     .service(channel)
 }
 

--- a/src/rust/engine/grpc_util/src/lib.rs
+++ b/src/rust/engine/grpc_util/src/lib.rs
@@ -36,10 +36,24 @@ use http::header::USER_AGENT;
 use tokio_rustls::rustls::ClientConfig;
 use tonic::metadata::{AsciiMetadataKey, AsciiMetadataValue, KeyAndValueRef, MetadataMap};
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
+use tower::limit::ConcurrencyLimit;
+use tower::ServiceBuilder;
 
 pub mod hyper;
 pub mod prost;
 pub mod retry;
+
+// NB: Rather than boxing our tower/tonic services, we define a type alias that fully defines the
+// Service layers that we use universally. If this type becomes unwieldy, or our various Services
+// diverge in which layers they use, we should instead use a Box<dyn Service<..>>.
+pub type LayeredService = ConcurrencyLimit<Channel>;
+
+pub fn layered_service(channel: Channel) -> LayeredService {
+  ServiceBuilder::new()
+    // TODO
+    .concurrency_limit(100)
+    .service(channel)
+}
 
 /// Create a Tonic `Endpoint` from a string containing a schema and IP address/name.
 pub fn create_endpoint(

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -66,6 +66,7 @@ impl CommandRunner {
     cache_write: bool,
     warnings_behavior: RemoteCacheWarningsBehavior,
     eager_fetch: bool,
+    concurrency_limit: usize,
   ) -> Result<Self, String> {
     let tls_client_config = if action_cache_address.starts_with("https://") {
       Some(grpc_util::create_tls_config(root_ca_certs)?)
@@ -78,9 +79,10 @@ impl CommandRunner {
       tls_client_config.as_ref(),
       &mut headers,
     )?;
-    let channel = layered_service(tonic::transport::Channel::balance_list(
-      vec![endpoint].into_iter(),
-    ));
+    let channel = layered_service(
+      tonic::transport::Channel::balance_list(vec![endpoint].into_iter()),
+      concurrency_limit,
+    );
     let action_cache_client = Arc::new(if headers.is_empty() {
       ActionCacheClient::new(channel)
     } else {

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -10,13 +10,14 @@ use bazel_protos::require_digest;
 use fs::RelativePath;
 use futures::future::BoxFuture;
 use futures::FutureExt;
-use grpc_util::{headers_to_interceptor_fn, retry::retry_call, status_to_str};
+use grpc_util::{
+  headers_to_interceptor_fn, layered_service, retry::retry_call, status_to_str, LayeredService,
+};
 use hashing::Digest;
 use parking_lot::Mutex;
 use remexec::action_cache_client::ActionCacheClient;
 use remexec::{ActionResult, Command, FileNode, Tree};
 use store::Store;
-use tonic::transport::Channel;
 use workunit_store::{in_workunit, Level, Metric, ObservationMetric, WorkunitMetadata};
 
 use crate::remote::make_execute_request;
@@ -40,7 +41,7 @@ pub struct CommandRunner {
   metadata: ProcessMetadata,
   executor: task_executor::Executor,
   store: Store,
-  action_cache_client: Arc<ActionCacheClient<Channel>>,
+  action_cache_client: Arc<ActionCacheClient<LayeredService>>,
   headers: BTreeMap<String, String>,
   platform: Platform,
   cache_read: bool,
@@ -77,7 +78,9 @@ impl CommandRunner {
       tls_client_config.as_ref(),
       &mut headers,
     )?;
-    let channel = tonic::transport::Channel::balance_list(vec![endpoint].into_iter());
+    let channel = layered_service(tonic::transport::Channel::balance_list(
+      vec![endpoint].into_iter(),
+    ));
     let action_cache_client = Arc::new(if headers.is_empty() {
       ActionCacheClient::new(channel)
     } else {

--- a/src/rust/engine/process_execution/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_cache_tests.rs
@@ -94,6 +94,7 @@ impl StoreSetup {
         10 * 1024 * 1024,
         Duration::from_secs(1),
         1,
+        256,
       )
       .unwrap();
     StoreSetup {
@@ -140,6 +141,7 @@ fn create_cached_runner(
       true,
       RemoteCacheWarningsBehavior::FirstOnly,
       eager_fetch,
+      256,
     )
     .expect("caching command runner"),
   );
@@ -587,6 +589,7 @@ async fn make_action_result_basic() {
     true,
     RemoteCacheWarningsBehavior::FirstOnly,
     false,
+    256,
   )
   .expect("caching command runner");
 

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -31,6 +31,9 @@ use tonic::{Code, Status};
 
 const OVERALL_DEADLINE_SECS: Duration = Duration::from_secs(10 * 60);
 const RETRY_INTERVAL: Duration = Duration::from_micros(0);
+const STORE_CONCURRENCY_LIMIT: usize = 256;
+const EXEC_CONCURRENCY_LIMIT: usize = 256;
+const CACHE_CONCURRENCY_LIMIT: usize = 256;
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct RemoteTestResult {
@@ -866,6 +869,7 @@ async fn sends_headers() {
       10 * 1024 * 1024,
       Duration::from_secs(1),
       1,
+      STORE_CONCURRENCY_LIMIT,
     )
     .unwrap();
 
@@ -882,6 +886,8 @@ async fn sends_headers() {
     Platform::Linux,
     OVERALL_DEADLINE_SECS,
     RETRY_INTERVAL,
+    EXEC_CONCURRENCY_LIMIT,
+    CACHE_CONCURRENCY_LIMIT,
   )
   .unwrap();
   let context = Context {
@@ -1061,6 +1067,7 @@ async fn ensure_inline_stdio_is_stored() {
       10 * 1024 * 1024,
       Duration::from_secs(1),
       1,
+      STORE_CONCURRENCY_LIMIT,
     )
     .unwrap();
 
@@ -1074,6 +1081,8 @@ async fn ensure_inline_stdio_is_stored() {
     Platform::Linux,
     OVERALL_DEADLINE_SECS,
     RETRY_INTERVAL,
+    EXEC_CONCURRENCY_LIMIT,
+    CACHE_CONCURRENCY_LIMIT,
   )
   .unwrap();
 
@@ -1438,6 +1447,7 @@ async fn execute_missing_file_uploads_if_known() {
       10 * 1024 * 1024,
       Duration::from_secs(1),
       1,
+      STORE_CONCURRENCY_LIMIT,
     )
     .unwrap();
   store
@@ -1458,6 +1468,8 @@ async fn execute_missing_file_uploads_if_known() {
     Platform::Linux,
     OVERALL_DEADLINE_SECS,
     RETRY_INTERVAL,
+    EXEC_CONCURRENCY_LIMIT,
+    CACHE_CONCURRENCY_LIMIT,
   )
   .unwrap();
 
@@ -1513,6 +1525,7 @@ async fn execute_missing_file_errors_if_unknown() {
       10 * 1024 * 1024,
       Duration::from_secs(1),
       1,
+      STORE_CONCURRENCY_LIMIT,
     )
     .unwrap();
 
@@ -1526,6 +1539,8 @@ async fn execute_missing_file_errors_if_unknown() {
     Platform::Linux,
     OVERALL_DEADLINE_SECS,
     RETRY_INTERVAL,
+    EXEC_CONCURRENCY_LIMIT,
+    CACHE_CONCURRENCY_LIMIT,
   )
   .unwrap();
 
@@ -2225,6 +2240,8 @@ fn create_command_runner(
     platform,
     OVERALL_DEADLINE_SECS,
     RETRY_INTERVAL,
+    EXEC_CONCURRENCY_LIMIT,
+    CACHE_CONCURRENCY_LIMIT,
   )
   .expect("Failed to make command runner");
   (command_runner, store)
@@ -2274,6 +2291,7 @@ pub(crate) fn make_store(
       10 * 1024 * 1024,
       Duration::from_secs(1),
       1,
+      STORE_CONCURRENCY_LIMIT,
     )
     .unwrap()
 }

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -168,6 +168,22 @@ struct Opt {
   #[structopt(long, default_value = "3145728")]
   upload_chunk_bytes: usize,
 
+  /// Number of retries per request to the store service.
+  #[structopt(long, default_value = "3")]
+  store_rpc_retries: usize,
+
+  /// Number of concurrent requests to the store service.
+  #[structopt(long, default_value = "128")]
+  store_rpc_concurrency: usize,
+
+  /// Number of concurrent requests to the execution service.
+  #[structopt(long, default_value = "128")]
+  execution_rpc_concurrency: usize,
+
+  /// Number of concurrent requests to the cache service.
+  #[structopt(long, default_value = "128")]
+  cache_rpc_concurrency: usize,
+
   /// Whether or not to enable running the process through a Nailgun server.
   /// This will likely start a new Nailgun server as a side effect.
   #[structopt(long)]
@@ -232,8 +248,8 @@ async fn main() {
         headers,
         args.upload_chunk_bytes,
         Duration::from_secs(30),
-        // TODO: Take a command line arg.
-        3,
+        args.store_rpc_retries,
+        args.store_rpc_concurrency,
       )
     }
     (None, None) => Ok(local_only_store),
@@ -280,6 +296,8 @@ async fn main() {
             Platform::Linux,
             Duration::from_secs(args.overall_deadline_secs),
             Duration::from_millis(100),
+            args.execution_rpc_concurrency,
+            args.cache_rpc_concurrency,
           )
           .expect("Failed to make command runner"),
         )

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -78,11 +78,14 @@ pub struct RemotingOptions {
   pub store_chunk_bytes: usize,
   pub store_chunk_upload_timeout: Duration,
   pub store_rpc_retries: usize,
+  pub store_rpc_concurrency: usize,
   pub cache_warnings_behavior: RemoteCacheWarningsBehavior,
   pub cache_eager_fetch: bool,
+  pub cache_rpc_concurrency: usize,
   pub execution_extra_platform_properties: Vec<(String, String)>,
   pub execution_headers: BTreeMap<String, String>,
   pub execution_overall_deadline: Duration,
+  pub execution_rpc_concurrency: usize,
 }
 
 #[derive(Clone, Debug)]
@@ -142,6 +145,7 @@ impl Core {
         remoting_opts.store_chunk_bytes,
         remoting_opts.store_chunk_upload_timeout,
         remoting_opts.store_rpc_retries,
+        remoting_opts.store_rpc_concurrency,
       )
     } else {
       Ok(local_only)
@@ -200,6 +204,8 @@ impl Core {
             Platform::Linux,
             remoting_opts.execution_overall_deadline,
             Duration::from_millis(100),
+            remoting_opts.execution_rpc_concurrency,
+            remoting_opts.cache_rpc_concurrency,
           )?),
           exec_strategy_opts.remote_parallelism,
         ))
@@ -217,6 +223,7 @@ impl Core {
           exec_strategy_opts.remote_cache_write,
           remoting_opts.cache_warnings_behavior,
           remoting_opts.cache_eager_fetch,
+          remoting_opts.cache_rpc_concurrency,
         )?)
       } else {
         local_command_runner

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -507,8 +507,8 @@ py_class!(class PyExecutionStrategyOptions |py| {
 
   def __new__(
     _cls,
-    local_parallelism: u64,
-    remote_parallelism: u64,
+    local_parallelism: usize,
+    remote_parallelism: usize,
     local_cleanup: bool,
     local_cache: bool,
     remote_cache_read: bool,
@@ -516,8 +516,8 @@ py_class!(class PyExecutionStrategyOptions |py| {
   ) -> CPyResult<Self> {
     Self::create_instance(py,
       ExecutionStrategyOptions {
-        local_parallelism: local_parallelism as usize,
-        remote_parallelism: remote_parallelism as usize,
+        local_parallelism,
+        remote_parallelism,
         local_cleanup,
         local_cache,
         remote_cache_read,
@@ -540,14 +540,17 @@ py_class!(class PyRemotingOptions |py| {
     instance_name: Option<String>,
     root_ca_certs_path: Option<String>,
     store_headers: Vec<(String, String)>,
-    store_chunk_bytes: u64,
+    store_chunk_bytes: usize,
     store_chunk_upload_timeout: u64,
-    store_rpc_retries: u64,
+    store_rpc_retries: usize,
+    store_rpc_concurrency: usize,
     cache_warnings_behavior: String,
     cache_eager_fetch: bool,
+    cache_rpc_concurrency: usize,
     execution_extra_platform_properties: Vec<(String, String)>,
     execution_headers: Vec<(String, String)>,
-    execution_overall_deadline_secs: u64
+    execution_overall_deadline_secs: u64,
+    execution_rpc_concurrency: usize,
   ) -> CPyResult<Self> {
     Self::create_instance(py,
       RemotingOptions {
@@ -558,14 +561,17 @@ py_class!(class PyRemotingOptions |py| {
         instance_name,
         root_ca_certs_path: root_ca_certs_path.map(PathBuf::from),
         store_headers: store_headers.into_iter().collect(),
-        store_chunk_bytes: store_chunk_bytes as usize,
+        store_chunk_bytes,
         store_chunk_upload_timeout: Duration::from_secs(store_chunk_upload_timeout),
-        store_rpc_retries: store_rpc_retries as usize,
+        store_rpc_retries,
+        store_rpc_concurrency,
         cache_warnings_behavior: RemoteCacheWarningsBehavior::from_str(&cache_warnings_behavior).unwrap(),
         cache_eager_fetch,
+        cache_rpc_concurrency,
         execution_extra_platform_properties,
         execution_headers: execution_headers.into_iter().collect(),
         execution_overall_deadline: Duration::from_secs(execution_overall_deadline_secs),
+        execution_rpc_concurrency,
       }
     )
   }


### PR DESCRIPTION
### Problem

We currently apply concurrency limits to process invokes via `BoundedCommandRunner`s wrapped around local and remote execution. But we should not bound the concurrency of the `remote_cache::CommandRunner`, and arguably the bound on the `remote::CommandRunner` should be removed in favor of letting the remote execution service build a deeper queue on its own. The `local::CommandRunner` bound is appropriately applied.

We _do_ need limits on concurrent requests to the remote services though: in flight requests (rather than simply being inside of the relevant `CommandRunner`) are what apply load (with the exception of the remote execution service, but see above).

### Solution

Add independent gRPC-level concurrency limits to each backend service. Because they are part of the `DynamicRemoteOptions`, they can also be set dynamically by an auth plugin based on backend load.

### Result

Likely sufficient to fix #12191: will close it for now and re-open if necessary. We do not have metrics support for "gauges" yet (opened #12255), but we should likely have a metric to monitor the number of permits available.



