### PR TITLE
Revert "Deprecate unused `--process-execution-local-enable-nailgun` (#11600)"

### DIFF
--- a/src/python/pants/bin/loader_integration_test.py
+++ b/src/python/pants/bin/loader_integration_test.py
@@ -54,16 +54,6 @@ def test_alternate_entrypoint_bad() -> None:
     assert "must be of the form" in pants_run.stderr
 
 
-def test_alternate_entrypoint_not_callable() -> None:
-    pants_run = run_pants(
-        command=["help"],
-        extra_env={DAEMON_ENTRYPOINT: "pants.bin.loader_integration_test:TEST_STR"},
-    )
-    pants_run.assert_failure()
-    assert "TEST_STR" in pants_run.stderr
-    assert "not callable" in pants_run.stderr
-
-
 def exercise_alternate_entrypoint_scrubbing():
     """An alternate test entrypoint for exercising scrubbing."""
     print(f"{DAEMON_ENTRYPOINT}={os.environ.get(DAEMON_ENTRYPOINT)}")

--- a/src/python/pants/bin/pants_loader.py
+++ b/src/python/pants/bin/pants_loader.py
@@ -83,12 +83,7 @@ class PantsLoader:
 
         module = importlib.import_module(module_path)
         entrypoint_fn = getattr(module, func_name)
-
-        try:
-            entrypoint_fn()
-        except TypeError:
-            print(f"{DAEMON_ENTRYPOINT} {func_name} is not callable", file=sys.stderr)
-            sys.exit(PANTS_FAILED_EXIT_CODE)
+        entrypoint_fn()
 
     @staticmethod
     def run_default_entrypoint() -> None:

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -198,6 +198,7 @@ class Scheduler:
             remote_cache_write=execution_options.remote_cache_write,
             local_cleanup=execution_options.process_execution_local_cleanup,
             local_parallelism=execution_options.process_execution_local_parallelism,
+            local_enable_nailgun=execution_options.process_execution_local_enable_nailgun,
             remote_parallelism=execution_options.process_execution_remote_parallelism,
         )
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -311,6 +311,7 @@ class ExecutionOptions:
     process_execution_local_cache: bool
     process_execution_local_cleanup: bool
     process_execution_local_parallelism: int
+    process_execution_local_enable_nailgun: bool
     process_execution_remote_parallelism: int
     process_execution_cache_namespace: str | None
 
@@ -348,6 +349,7 @@ class ExecutionOptions:
             process_execution_remote_parallelism=bootstrap_options.process_execution_remote_parallelism,
             process_execution_local_cleanup=bootstrap_options.process_execution_local_cleanup,
             process_execution_cache_namespace=bootstrap_options.process_execution_cache_namespace,
+            process_execution_local_enable_nailgun=bootstrap_options.process_execution_local_enable_nailgun,
             # Remote store setup.
             remote_store_address=dynamic_remote_options.store_address,
             remote_store_headers=dynamic_remote_options.store_headers,
@@ -420,6 +422,7 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     process_execution_cache_namespace=None,
     process_execution_local_cleanup=True,
     process_execution_local_cache=True,
+    process_execution_local_enable_nailgun=False,
     # Remote store setup.
     remote_store_address=None,
     remote_store_headers={
@@ -1021,6 +1024,13 @@ class GlobalOptions(Subsystem):
                 "Change this value to invalidate every artifact's execution, or to prevent "
                 "process cache entries from being (re)used for different usecases or users."
             ),
+        )
+        register(
+            "--process-execution-local-enable-nailgun",
+            type=bool,
+            default=DEFAULT_EXECUTION_OPTIONS.process_execution_local_enable_nailgun,
+            help="Whether or not to use nailgun to run the requests that are marked as nailgunnable.",
+            advanced=True,
         )
 
         register(

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -60,6 +60,8 @@ pub mod remote_cache;
 #[cfg(test)]
 mod remote_cache_tests;
 
+pub mod nailgun;
+
 pub mod named_caches;
 
 extern crate uname;

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -1,0 +1,294 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::future::{FutureExt, TryFutureExt};
+use futures::stream::{BoxStream, StreamExt};
+use log::{debug, trace};
+use nails::execution::{self, child_channel, ChildInput, Command};
+use tokio::net::TcpStream;
+
+use crate::local::{CapturedWorkdir, ChildOutput};
+use crate::nailgun::nailgun_pool::NailgunProcessName;
+use crate::{
+  Context, FallibleProcessResultWithPlatform, MultiPlatformProcess, NamedCaches, Platform, Process,
+  ProcessCacheScope, ProcessMetadata,
+};
+
+#[cfg(test)]
+pub mod tests;
+
+pub mod nailgun_pool;
+
+mod parsed_jvm_command_lines;
+#[cfg(test)]
+mod parsed_jvm_command_lines_tests;
+
+use async_semaphore::AsyncSemaphore;
+pub use nailgun_pool::NailgunPool;
+use parsed_jvm_command_lines::ParsedJVMCommandLines;
+use std::net::SocketAddr;
+
+// Hardcoded constants for connecting to nailgun
+static NAILGUN_MAIN_CLASS: &str = "com.martiansoftware.nailgun.NGServer";
+static ARGS_TO_START_NAILGUN: [&str; 1] = [":0"];
+
+///
+/// Constructs the Process that would be used
+/// to start the nailgun servers if we needed to.
+///
+// TODO(#8481) We should calculate the input_files by deeply fingerprinting the classpath.
+fn construct_nailgun_server_request(
+  nailgun_name: &str,
+  args_for_the_jvm: Vec<String>,
+  jdk: PathBuf,
+  platform_constraint: Option<Platform>,
+) -> Process {
+  let mut full_args = args_for_the_jvm;
+  full_args.push(NAILGUN_MAIN_CLASS.to_string());
+  full_args.extend(ARGS_TO_START_NAILGUN.iter().map(|&a| a.to_string()));
+
+  Process {
+    argv: full_args,
+    env: BTreeMap::new(),
+    working_directory: None,
+    input_files: hashing::EMPTY_DIGEST,
+    output_files: BTreeSet::new(),
+    output_directories: BTreeSet::new(),
+    timeout: Some(Duration::new(1000, 0)),
+    description: format!("Start a nailgun server for {}", nailgun_name),
+    level: log::Level::Info,
+    append_only_caches: BTreeMap::new(),
+    jdk_home: Some(jdk),
+    platform_constraint,
+    is_nailgunnable: true,
+    execution_slot_variable: None,
+    cache_scope: ProcessCacheScope::PerSession,
+  }
+}
+
+fn construct_nailgun_client_request(
+  original_req: Process,
+  client_main_class: String,
+  mut client_args: Vec<String>,
+) -> Process {
+  client_args.insert(0, client_main_class);
+  Process {
+    argv: client_args,
+    jdk_home: None,
+    ..original_req
+  }
+}
+
+///
+/// A command runner that can run local requests under nailgun.
+///
+/// It should only be invoked with local requests.
+/// It will read a flag marking an `Process` as nailgunnable.
+/// If that flag is set, it will connect to a running nailgun server and run the command there.
+/// Otherwise, it will just delegate to the regular local runner.
+///
+pub struct CommandRunner {
+  inner: super::local::CommandRunner,
+  nailgun_pool: NailgunPool,
+  async_semaphore: async_semaphore::AsyncSemaphore,
+  metadata: ProcessMetadata,
+  workdir_base: PathBuf,
+  executor: task_executor::Executor,
+}
+
+impl CommandRunner {
+  pub fn new(
+    runner: crate::local::CommandRunner,
+    metadata: ProcessMetadata,
+    workdir_base: PathBuf,
+    executor: task_executor::Executor,
+  ) -> Self {
+    CommandRunner {
+      inner: runner,
+      nailgun_pool: NailgunPool::new(),
+      async_semaphore: AsyncSemaphore::new(1),
+      metadata,
+      workdir_base,
+      executor,
+    }
+  }
+
+  // Ensure that the workdir for the given nailgun name exists.
+  fn get_nailgun_workdir(&self, nailgun_name: &str) -> Result<PathBuf, String> {
+    let workdir = self.workdir_base.clone().join(nailgun_name);
+    if workdir.exists() {
+      debug!("Nailgun workdir {:?} exits. Reusing that...", &workdir);
+      Ok(workdir)
+    } else {
+      debug!("Creating nailgun workdir at {:?}", &workdir);
+      fs::safe_create_dir_all(&workdir)
+        .map_err(|err| format!("Error creating the nailgun workdir! {}", err))
+        .map(|_| workdir)
+    }
+  }
+
+  // TODO(#8527) Make this name the name of the task (in v1) or some other more intentional scope (v2).
+  //      Using the main class here is fragile, because two tasks might want to run the same main class,
+  //      but in different nailgun servers.
+  fn calculate_nailgun_name(main_class: &str) -> NailgunProcessName {
+    format!("nailgun_server_{}", main_class)
+  }
+}
+
+#[async_trait]
+impl super::CommandRunner for CommandRunner {
+  async fn run(
+    &self,
+    req: MultiPlatformProcess,
+    context: Context,
+  ) -> Result<FallibleProcessResultWithPlatform, String> {
+    let original_request = self.extract_compatible_request(&req).unwrap();
+
+    if !original_request.is_nailgunnable {
+      trace!("The request is not nailgunnable! Short-circuiting to regular process execution");
+      return self.inner.run(req, context).await;
+    }
+    debug!("Running request under nailgun:\n {:#?}", &original_request);
+
+    let executor = self.executor.clone();
+    let store = self.inner.store.clone();
+    let ParsedJVMCommandLines {
+      client_main_class, ..
+    } = ParsedJVMCommandLines::parse_command_lines(&original_request.argv)?;
+    let nailgun_name = CommandRunner::calculate_nailgun_name(&client_main_class);
+    let workdir_for_this_nailgun = self.get_nailgun_workdir(&nailgun_name)?;
+
+    self
+      .run_and_capture_workdir(
+        original_request,
+        context,
+        store,
+        executor,
+        true,
+        &workdir_for_this_nailgun,
+        Platform::current().unwrap(),
+      )
+      .await
+  }
+
+  fn extract_compatible_request(&self, req: &MultiPlatformProcess) -> Option<Process> {
+    // Request compatibility should be the same as for the local runner, so we just delegate this.
+    self.inner.extract_compatible_request(req)
+  }
+}
+
+#[async_trait]
+impl CapturedWorkdir for CommandRunner {
+  fn named_caches(&self) -> &NamedCaches {
+    self.inner.named_caches()
+  }
+
+  async fn run_in_workdir<'a, 'b, 'c>(
+    &'a self,
+    workdir_path: &'b Path,
+    req: Process,
+    context: Context,
+    _exclusive_spawn: bool,
+  ) -> Result<BoxStream<'c, Result<ChildOutput, String>>, String> {
+    // Separate argument lists, to form distinct EPRs for (1) starting the nailgun server and (2) running the client in it.
+    let ParsedJVMCommandLines {
+      nailgun_args,
+      client_args,
+      client_main_class,
+    } = ParsedJVMCommandLines::parse_command_lines(&req.argv)?;
+
+    let nailgun_name = CommandRunner::calculate_nailgun_name(&client_main_class);
+    let nailgun_name2 = nailgun_name.clone();
+    let nailgun_name3 = nailgun_name.clone();
+    let client_workdir = if let Some(working_directory) = &req.working_directory {
+      workdir_path.join(working_directory)
+    } else {
+      workdir_path.to_path_buf()
+    };
+
+    let jdk_home = req
+      .jdk_home
+      .clone()
+      .ok_or("JDK home must be specified for all nailgunnable requests.")?;
+    let nailgun_req = construct_nailgun_server_request(
+      &nailgun_name,
+      nailgun_args,
+      jdk_home,
+      req.platform_constraint,
+    );
+    trace!("Extracted nailgun request:\n {:#?}", &nailgun_req);
+
+    let nailgun_req_digest = crate::digest(
+      MultiPlatformProcess::from(nailgun_req.clone()),
+      &self.metadata,
+    );
+
+    let nailgun_pool = self.nailgun_pool.clone();
+    let req2 = req.clone();
+    let workdir_for_this_nailgun = self.get_nailgun_workdir(&nailgun_name)?;
+    let build_id = context.build_id;
+    let store = self.inner.store.clone();
+
+    let mut child = self
+      .async_semaphore
+      .clone()
+      .with_acquired(move |_id| {
+        // Get the port of a running nailgun server (or a new nailgun server if it doesn't exist)
+        nailgun_pool.connect(
+          nailgun_name.clone(),
+          nailgun_req,
+          workdir_for_this_nailgun,
+          nailgun_req_digest,
+          build_id,
+          store,
+          req.input_files,
+        )
+      })
+      .map_err(|e| format!("Failed to connect to nailgun! {}", e))
+      .inspect(move |_| debug!("Connected to nailgun instance {}", &nailgun_name3))
+      .and_then(move |nailgun_port| {
+        // Run the client request in the nailgun we have active.
+        debug!("Got nailgun port {} for {}", nailgun_port, nailgun_name2);
+        let client_req = construct_nailgun_client_request(req2, client_main_class, client_args);
+        let cmd = Command {
+          command: client_req.argv[0].clone(),
+          args: client_req.argv[1..].to_vec(),
+          env: client_req
+            .env
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect(),
+          working_dir: client_workdir,
+        };
+        trace!("Client request: {:#?}", client_req);
+        let addr: SocketAddr = format!("127.0.0.1:{:?}", nailgun_port).parse().unwrap();
+        debug!("Connecting to server at {}...", addr);
+        TcpStream::connect(addr)
+          .and_then(move |stream| {
+            nails::client::handle_connection(nails::Config::default(), stream, cmd, async {
+              let (_stdin_write, stdin_read) = child_channel::<ChildInput>();
+              stdin_read
+            })
+          })
+          .map_err(|e| format!("Error communicating with server: {}", e))
+      })
+      .await?;
+
+    let output_stream = child
+      .output_stream
+      .take()
+      .unwrap()
+      .map(|output| match output {
+        execution::ChildOutput::Stdout(bytes) => Ok(ChildOutput::Stdout(bytes)),
+        execution::ChildOutput::Stderr(bytes) => Ok(ChildOutput::Stderr(bytes)),
+      });
+    let exit_code = child
+      .wait()
+      .map_ok(ChildOutput::Exit)
+      .map_err(|e| format!("Error communicating with server: {}", e));
+
+    Ok(futures::stream::select(output_stream, exit_code.into_stream()).boxed())
+  }
+}

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -129,9 +129,8 @@ impl CommandRunner {
     }
   }
 
-  // TODO(#8527) Make this name the name of the task (in v1) or some other more intentional scope (v2).
-  //      Using the main class here is fragile, because two tasks might want to run the same main class,
-  //      but in different nailgun servers.
+  // TODO(#8527) Make this a more intentional scope (v2). Using the main class here is fragile,
+  // because two tasks might want to run the same main class with different input digests.
   fn calculate_nailgun_name(main_class: &str) -> NailgunProcessName {
     format!("nailgun_server_{}", main_class)
   }

--- a/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
@@ -1,0 +1,364 @@
+// Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+use std::collections::HashMap;
+use std::fs::{read_link, remove_file};
+use std::io;
+use std::io::BufRead;
+use std::os::unix::fs::symlink;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+
+use futures::future::BoxFuture;
+use futures::{FutureExt, TryFutureExt};
+use hashing::{Digest, Fingerprint};
+use lazy_static::lazy_static;
+use log::{debug, info};
+use parking_lot::Mutex;
+use regex::Regex;
+use sha2::{Digest as Sha256Digest, Sha256};
+use store::Store;
+use tryfuture::try_future;
+
+use crate::Process;
+
+lazy_static! {
+  static ref NAILGUN_PORT_REGEX: Regex = Regex::new(r".*\s+port\s+(\d+)\.$").unwrap();
+}
+
+pub type NailgunProcessName = String;
+type NailgunProcessMap = HashMap<NailgunProcessName, NailgunProcess>;
+pub type Port = usize;
+
+#[derive(Clone)]
+pub struct NailgunPool {
+  processes: Arc<Mutex<NailgunProcessMap>>,
+}
+
+impl NailgunPool {
+  pub fn new() -> Self {
+    NailgunPool {
+      processes: Arc::new(Mutex::new(NailgunProcessMap::new())),
+    }
+  }
+
+  // TODO(#8481) When we correctly set the input_files field of the nailgun EPR, we won't need to pass it here as an argument.
+  pub fn materialize_workdir_for_server(
+    store: Store,
+    workdir_for_server: PathBuf,
+    requested_jdk_home: PathBuf,
+    input_files: Digest,
+  ) -> BoxFuture<'static, Result<(), String>> {
+    // Materialize the directory for running the nailgun server, if we need to.
+    let workdir_for_server2 = workdir_for_server.clone();
+
+    // TODO(#8481) This materializes the input files in the client req, which is a superset of the files we need (we only need the classpath, not the input files)
+    store.materialize_directory(workdir_for_server.clone(), input_files)
+    .and_then(move |_metadata| async move {
+      let jdk_home_in_workdir = &workdir_for_server.join(".jdk");
+      let jdk_home_in_workdir2 = jdk_home_in_workdir.clone();
+      let jdk_home_in_workdir3 = jdk_home_in_workdir.clone();
+      if jdk_home_in_workdir.exists() {
+        let maybe_existing_jdk = read_link(jdk_home_in_workdir).map_err(|e| format!("{}", e));
+        let maybe_existing_jdk2 = maybe_existing_jdk.clone();
+        if maybe_existing_jdk.is_err() || (maybe_existing_jdk.is_ok() && maybe_existing_jdk.unwrap() != requested_jdk_home) {
+          remove_file(jdk_home_in_workdir2)
+              .map_err(|err| format!(
+                "Error removing existing (but incorrect) jdk symlink. We wanted it to point to {:?}, but it pointed to {:?}. {}",
+                &requested_jdk_home, &maybe_existing_jdk2, err
+              ))
+              .and_then(|_| {
+                symlink(requested_jdk_home, jdk_home_in_workdir3)
+                    .map_err(|err| format!("Error overwriting symlink for local execution in workdir {:?}: {:?}", &workdir_for_server, err))
+              })
+        } else {
+          debug!("JDK home for Nailgun already exists in {:?}. Using that one.", &workdir_for_server);
+          Ok(())
+        }
+      } else {
+        symlink(requested_jdk_home, jdk_home_in_workdir)
+            .map_err(|err| format!("Error making new symlink for local execution in workdir {:?}: {:?}", &workdir_for_server, err))
+      }
+    })
+    .inspect(move |_| debug!("Materialized directory {:?} before connecting to nailgun server.", &workdir_for_server2))
+    .boxed()
+  }
+
+  ///
+  /// Given a `NailgunProcessName` and a `Process` configuration,
+  /// return a port of a nailgun server running under that name and configuration.
+  ///
+  /// If the server is not running, or if it's running with a different configuration,
+  /// this code will start a new server as a side effect.
+  ///
+  pub fn connect(
+    &self,
+    name: NailgunProcessName,
+    startup_options: Process,
+    workdir_path: PathBuf,
+    nailgun_req_digest: Digest,
+    build_id_requesting_connection: String,
+    store: Store,
+    input_files: Digest,
+  ) -> BoxFuture<'static, Result<Port, String>> {
+    let processes = self.processes.clone();
+
+    let jdk_path = try_future!(startup_options.jdk_home.clone().ok_or_else(|| {
+      format!(
+        "jdk_home is not set for nailgun server startup request {:#?}",
+        &startup_options
+      )
+    }));
+    let requested_server_fingerprint = try_future!(NailgunProcessFingerprint::new(
+      nailgun_req_digest,
+      jdk_path.clone()
+    ));
+
+    Self::materialize_workdir_for_server(
+      store, workdir_path.clone(), jdk_path, input_files
+    ).and_then(move |_| async move {
+      debug!("Locking nailgun process pool so that only one can be connecting at a time.");
+      let mut processes = processes.lock();
+      debug!("Locked!");
+      let connection_result = if let Some(process) = processes.get_mut(&name) {
+        // Clone some fields that we need for later
+        let (process_name, process_fingerprint, process_port, build_id_that_started_the_server) = (
+          process.name.clone(),
+          process.fingerprint.clone(),
+          process.port,
+          process.build_id.clone(),
+        );
+
+        debug!(
+          "Checking if nailgun server {} is still alive at port {}...",
+          &process_name, process_port
+        );
+
+        // If the process is in the map, check if it's alive using the handle.
+        let status = {
+          process
+              .handle
+              .lock()
+              .try_wait()
+              .map_err(|e| format!("Error getting the process status! {}", e))
+        };
+        match status {
+          Ok(None) => {
+            // Process hasn't exited yet
+            debug!(
+              "Found nailgun process {}, with fingerprint {:?}",
+              &name, process_fingerprint
+            );
+            if requested_server_fingerprint == process_fingerprint {
+              debug!("The fingerprint of the running nailgun {:?} matches the requested fingerprint {:?}. Connecting to existing server.",
+                     requested_server_fingerprint, process_fingerprint);
+              Ok(process_port)
+            } else {
+              // The running process doesn't coincide with the options we want.
+              if build_id_that_started_the_server == build_id_requesting_connection {
+                Err(format!(
+                  "Trying to change the JVM options for a running nailgun server that was started this run, with name {}.\
+                    There is exactly one nailgun server per task, so it shouldn't be possible to change the options of a nailgun server mid-run.\
+                    This might be a problem with how we calculate the keys of nailgun servers (https://github.com/pantsbuild/pants/issues/8527).",
+                  &name)
+                )
+              } else {
+                // Restart it.
+                // Since the stored server was started in a different pants run,
+                // no client will be running on that server.
+                debug!(
+                  "The options for server process {} are different to the startup_options, \
+                 and the original process was started in a different pants run.\n\
+                 Startup Options: {:?}\n Process Cmd: {:?}",
+                  &process_name, startup_options, process_fingerprint
+                );
+                debug!("Restarting the server...");
+                Self::start_new_nailgun(
+                  &mut *processes,
+                  name,
+                  startup_options,
+                  &workdir_path,
+                  requested_server_fingerprint,
+                  build_id_requesting_connection,
+                )
+              }
+            }
+          }
+          Ok(_) => {
+            // The process has exited with some exit code
+            debug!("The requested nailgun server was not running anymore. Restarting process...");
+            Self::start_new_nailgun(
+              &mut *processes,
+              name,
+              startup_options,
+              &workdir_path,
+              requested_server_fingerprint,
+              build_id_requesting_connection,
+            )
+          }
+          Err(e) => Err(e),
+        }
+      } else {
+        // We don't have a running nailgun registered in the map.
+        debug!(
+          "No nailgun server is running with name {}. Starting one...",
+          &name
+        );
+        Self::start_new_nailgun(
+          &mut *processes,
+          name,
+          startup_options,
+          &workdir_path,
+          requested_server_fingerprint,
+          build_id_requesting_connection,
+        )
+      };
+      debug!("Unlocking nailgun process pool.");
+      connection_result
+    })
+    .boxed()
+  }
+
+  //
+  // This is a blocking method that is being called under the NailgunProcessMap's lock (see #8543)
+  //
+  fn start_new_nailgun(
+    processes: &mut NailgunProcessMap,
+    name: String,
+    startup_options: Process,
+    workdir_path: &Path,
+    nailgun_server_fingerprint: NailgunProcessFingerprint,
+    build_id: String,
+  ) -> Result<Port, String> {
+    debug!(
+      "Starting new nailgun server for {}, with options {:?}",
+      &name, &startup_options
+    );
+    NailgunProcess::start_new(
+      name.clone(),
+      startup_options,
+      workdir_path,
+      nailgun_server_fingerprint,
+      build_id,
+    )
+    .map(move |process| {
+      let port = process.port;
+      processes.insert(name.clone(), process);
+      port
+    })
+  }
+}
+
+/// Representation of a running nailgun server.
+#[derive(Debug)]
+pub struct NailgunProcess {
+  pub name: NailgunProcessName,
+  pub fingerprint: NailgunProcessFingerprint,
+  pub build_id: String,
+  pub port: Port,
+  pub handle: Arc<Mutex<std::process::Child>>,
+}
+
+fn read_port(child: &mut std::process::Child) -> Result<Port, String> {
+  let stdout = child
+    .stdout
+    .as_mut()
+    .ok_or_else(|| "No Stdout found!".to_string());
+  stdout.and_then(|stdout| {
+    let reader = io::BufReader::new(stdout);
+    let line = reader
+      .lines()
+      .next()
+      .ok_or("There is no line ready in the child's output")?
+      .map_err(|err| format!("{}", err))?;
+    let port = &NAILGUN_PORT_REGEX
+      .captures_iter(&line)
+      .next()
+      .ok_or("Output for nailgun server didn't match the regex!")?[1];
+    port
+      .parse::<Port>()
+      .map_err(|e| format!("Error parsing port {}! {}", &port, e))
+  })
+}
+
+impl NailgunProcess {
+  fn start_new(
+    name: NailgunProcessName,
+    startup_options: Process,
+    workdir_path: &Path,
+    nailgun_server_fingerprint: NailgunProcessFingerprint,
+    build_id: String,
+  ) -> Result<NailgunProcess, String> {
+    let cmd = startup_options.argv[0].clone();
+    // TODO: This is an expensive operation, and thus we info! it.
+    //       If it becomes annoying, we can downgrade the logging to just debug!
+    info!(
+      "Starting new nailgun server with cmd: {:?}, args {:?}, in cwd {:?}",
+      cmd,
+      &startup_options.argv[1..],
+      &workdir_path
+    );
+    let handle = std::process::Command::new(&cmd)
+      .args(&startup_options.argv[1..])
+      .stdout(Stdio::piped())
+      .stderr(Stdio::piped())
+      .current_dir(&workdir_path)
+      .spawn();
+    handle
+      .map_err(|e| {
+        format!(
+          "Failed to create child handle with cmd: {} options {:#?}: {}",
+          &cmd, &startup_options, e
+        )
+      })
+      .and_then(|mut child| {
+        let port = read_port(&mut child);
+        port.map(|port| (child, port))
+      })
+      .map(|(child, port)| {
+        debug!(
+          "Created nailgun server process with pid {} and port {}",
+          child.id(),
+          port
+        );
+        NailgunProcess {
+          port,
+          fingerprint: nailgun_server_fingerprint,
+          name,
+          handle: Arc::new(Mutex::new(child)),
+          build_id,
+        }
+      })
+  }
+}
+
+impl Drop for NailgunProcess {
+  fn drop(&mut self) {
+    debug!("Exiting nailgun server process {:?}", self);
+    let _ = self.handle.lock().kill();
+  }
+}
+
+/// The fingerprint of an nailgun server process.
+///
+/// This is calculated by hashing together:
+///   - The jvm options and classpath used to create the server
+///   - The path to the jdk
+#[derive(Clone, Hash, PartialEq, Eq, Debug)]
+pub struct NailgunProcessFingerprint(pub Fingerprint);
+
+impl NailgunProcessFingerprint {
+  pub fn new(nailgun_server_req_digest: Digest, jdk_path: PathBuf) -> Result<Self, String> {
+    let jdk_realpath = jdk_path
+      .canonicalize()
+      .map_err(|err| format!("Error getting the realpath of the jdk home: {}", err))?;
+
+    let mut hasher = Sha256::default();
+    hasher.update(nailgun_server_req_digest.hash);
+    hasher.update(jdk_realpath.to_string_lossy().as_bytes());
+    Ok(NailgunProcessFingerprint(Fingerprint::from_bytes(
+      hasher.finalize(),
+    )))
+  }
+}

--- a/src/rust/engine/process_execution/src/nailgun/parsed_jvm_command_lines.rs
+++ b/src/rust/engine/process_execution/src/nailgun/parsed_jvm_command_lines.rs
@@ -1,0 +1,130 @@
+use itertools::Itertools;
+use std::slice::Iter;
+
+/// Represents the result of parsing the args of a nailgunnable Process
+/// TODO(#8481) We may want to split the classpath by the ":", and store it as a Vec<String>
+///         to allow for deep fingerprinting.
+#[derive(PartialEq, Eq, Debug)]
+pub struct ParsedJVMCommandLines {
+  pub nailgun_args: Vec<String>,
+  pub client_args: Vec<String>,
+  pub client_main_class: String,
+}
+
+impl ParsedJVMCommandLines {
+  ///
+  /// Given a list of args that one would likely pass to a java call,
+  /// we automatically split it to generate two argument lists:
+  ///  - nailgun arguments: The list of arguments needed to start the nailgun server.
+  ///    These arguments include everything in the arg list up to (but not including) the main class.
+  ///    These arguments represent roughly JVM options (-Xmx...), and the classpath (-cp ...).
+  ///
+  ///  - client arguments: The list of arguments that will be used to run the jvm program under nailgun.
+  ///    These arguments can be thought of as "passthrough args" that are sent to the jvm via the nailgun client.
+  ///    These arguments include everything starting from the main class.
+  ///
+  /// We assume that:
+  ///  - Every args list has a main class.
+  ///  - There is exactly one argument that doesn't begin with a `-` in the command line before the main class,
+  ///    and it's the value of the classpath (i.e. `-cp scala-library.jar`).
+  ///
+  /// We think these assumptions are valid as per: https://github.com/pantsbuild/pants/issues/8387
+  ///
+  pub fn parse_command_lines(args: &[String]) -> Result<ParsedJVMCommandLines, String> {
+    let mut args_to_consume = args.iter();
+
+    let jdk = Self::parse_jdk(&mut args_to_consume)?;
+    let nailgun_args_before_classpath =
+      Self::parse_jvm_args_that_are_not_classpath(&mut args_to_consume)?;
+    let (classpath_flag, classpath_value) = Self::parse_classpath(&mut args_to_consume)?;
+    let nailgun_args_after_classpath =
+      Self::parse_jvm_args_that_are_not_classpath(&mut args_to_consume)?;
+    let main_class = Self::parse_main_class(&mut args_to_consume)?;
+    let client_args = Self::parse_to_end(&mut args_to_consume)?;
+
+    if args_to_consume.clone().peekable().peek().is_some() {
+      return Err(format!(
+        "Malformed command line: There are still arguments to consume: {:?}",
+        &args_to_consume
+      ));
+    }
+
+    let mut nailgun_args = vec![jdk];
+    nailgun_args.extend(nailgun_args_before_classpath);
+    nailgun_args.push(classpath_flag);
+    nailgun_args.push(classpath_value);
+    nailgun_args.extend(nailgun_args_after_classpath);
+
+    Ok(ParsedJVMCommandLines {
+      nailgun_args,
+      client_args,
+      client_main_class: main_class,
+    })
+  }
+
+  fn parse_jdk(args_to_consume: &mut Iter<String>) -> Result<String, String> {
+    args_to_consume
+      .next()
+      .filter(|&e| e == ".jdk/bin/java")
+      .ok_or_else(|| "Every command line must start with a call to the jdk.".to_string())
+      .map(|e| e.clone())
+  }
+
+  fn parse_jvm_args_that_are_not_classpath(
+    args_to_consume: &mut Iter<String>,
+  ) -> Result<Vec<String>, String> {
+    Ok(
+      args_to_consume
+        .take_while_ref(|elem| {
+          ParsedJVMCommandLines::is_flag(elem) && !ParsedJVMCommandLines::is_classpath_flag(elem)
+        })
+        .cloned()
+        .collect(),
+    )
+  }
+
+  fn parse_classpath(args_to_consume: &mut Iter<String>) -> Result<(String, String), String> {
+    let classpath_flag = args_to_consume
+      .next()
+      .filter(|e| ParsedJVMCommandLines::is_classpath_flag(&e))
+      .ok_or_else(|| "No classpath flag found.".to_string())
+      .map(|e| e.clone())?;
+
+    let classpath_value = args_to_consume
+      .next()
+      .ok_or_else(|| "No classpath value found!".to_string())
+      .and_then(|elem| {
+        if ParsedJVMCommandLines::is_flag(elem) {
+          Err(format!(
+            "Classpath value has incorrect formatting {}.",
+            elem
+          ))
+        } else {
+          Ok(elem)
+        }
+      })?
+      .clone();
+
+    Ok((classpath_flag, classpath_value))
+  }
+
+  fn parse_main_class(args_to_consume: &mut Iter<String>) -> Result<String, String> {
+    args_to_consume
+      .next()
+      .filter(|e| !ParsedJVMCommandLines::is_flag(e))
+      .ok_or_else(|| "No main class provided.".to_string())
+      .map(|e| e.clone())
+  }
+
+  fn parse_to_end(args_to_consume: &mut Iter<String>) -> Result<Vec<String>, String> {
+    Ok(args_to_consume.cloned().collect())
+  }
+
+  fn is_flag(arg: &str) -> bool {
+    arg.starts_with('-') || arg.starts_with('@')
+  }
+
+  fn is_classpath_flag(arg: &str) -> bool {
+    arg == "-cp" || arg == "-classpath"
+  }
+}

--- a/src/rust/engine/process_execution/src/nailgun/parsed_jvm_command_lines_tests.rs
+++ b/src/rust/engine/process_execution/src/nailgun/parsed_jvm_command_lines_tests.rs
@@ -1,0 +1,203 @@
+use crate::nailgun::parsed_jvm_command_lines::ParsedJVMCommandLines;
+
+// TODO we should be able to use https://docs.rs/crate/derive_builder/0.8.0
+#[derive(Debug)]
+struct CLIBuilder {
+  jdk: Option<String>,
+  args_before_classpath: Vec<String>,
+  classpath_flag: Option<String>,
+  classpath_value: Option<String>,
+  args_after_classpath: Vec<String>,
+  main_class: Option<String>,
+  client_args: Vec<String>,
+}
+
+impl CLIBuilder {
+  pub fn empty() -> CLIBuilder {
+    CLIBuilder {
+      jdk: None,
+      args_before_classpath: vec![],
+      classpath_flag: None,
+      classpath_value: None,
+      args_after_classpath: vec![],
+      main_class: None,
+      client_args: vec![],
+    }
+  }
+
+  pub fn build(&self) -> CLIBuilder {
+    CLIBuilder {
+      jdk: self.jdk.clone(),
+      args_before_classpath: self.args_before_classpath.clone(),
+      classpath_flag: self.classpath_flag.clone(),
+      classpath_value: self.classpath_value.clone(),
+      args_after_classpath: self.args_after_classpath.clone(),
+      main_class: self.main_class.clone(),
+      client_args: self.client_args.clone(),
+    }
+  }
+
+  pub fn with_jdk(&mut self) -> &mut CLIBuilder {
+    self.jdk = Some(".jdk/bin/java".to_string());
+    self
+  }
+
+  pub fn with_nailgun_args(&mut self) -> &mut CLIBuilder {
+    self.args_before_classpath = vec!["-Xmx4g".to_string()];
+    self.args_after_classpath = vec!["-Xmx4g".to_string()];
+    self
+  }
+
+  pub fn with_classpath(&mut self) -> &mut CLIBuilder {
+    self.with_classpath_flag().with_classpath_value()
+  }
+
+  pub fn with_classpath_flag(&mut self) -> &mut CLIBuilder {
+    self.classpath_flag = Some("-cp".to_string());
+    self
+  }
+
+  pub fn with_classpath_value(&mut self) -> &mut CLIBuilder {
+    self.classpath_value = Some("scala-compiler.jar:scala-library.jar".to_string());
+    self
+  }
+
+  pub fn with_main_class(&mut self) -> &mut CLIBuilder {
+    self.main_class = Some("org.pantsbuild.zinc.compiler.Main".to_string());
+    self
+  }
+
+  pub fn with_client_args(&mut self) -> &mut CLIBuilder {
+    self.client_args = vec!["-some-arg-for-zinc".to_string(), "@argfile".to_string()];
+    self
+  }
+
+  pub fn with_everything() -> CLIBuilder {
+    CLIBuilder::empty()
+      .with_jdk()
+      .with_nailgun_args()
+      .with_classpath()
+      .with_main_class()
+      .with_client_args()
+      .build()
+  }
+
+  pub fn render_to_full_cli(&self) -> Vec<String> {
+    let mut cli = vec![];
+    cli.extend(self.jdk.clone());
+    cli.extend(self.args_before_classpath.clone());
+    cli.extend(self.classpath_flag.clone());
+    cli.extend(self.classpath_value.clone());
+    cli.extend(self.args_after_classpath.clone());
+    cli.extend(self.main_class.clone());
+    cli.extend(self.client_args.clone());
+    cli
+  }
+
+  pub fn render_to_parsed_args(&self) -> ParsedJVMCommandLines {
+    let mut nailgun_args: Vec<String> = self.jdk.iter().map(|e| e.clone()).collect();
+    nailgun_args.extend(self.args_before_classpath.clone());
+    nailgun_args.extend(self.classpath_flag.clone());
+    nailgun_args.extend(self.classpath_value.clone());
+    nailgun_args.extend(self.args_after_classpath.clone());
+    ParsedJVMCommandLines {
+      nailgun_args: nailgun_args,
+      client_args: self.client_args.clone(),
+      client_main_class: self.main_class.clone().unwrap(),
+    }
+  }
+}
+
+#[test]
+fn parses_correctly_formatted_cli() {
+  let correctly_formatted_cli = CLIBuilder::with_everything();
+
+  let parse_result =
+    ParsedJVMCommandLines::parse_command_lines(&correctly_formatted_cli.render_to_full_cli());
+
+  assert_eq!(
+    parse_result,
+    Ok(correctly_formatted_cli.render_to_parsed_args())
+  )
+}
+
+#[test]
+fn parses_cli_without_jvm_args() {
+  let cli_without_jvm_args = CLIBuilder::empty()
+    .with_jdk()
+    .with_classpath()
+    .with_main_class()
+    .with_client_args()
+    .build();
+
+  let parse_result =
+    ParsedJVMCommandLines::parse_command_lines(&cli_without_jvm_args.render_to_full_cli());
+
+  assert_eq!(
+    parse_result,
+    Ok(cli_without_jvm_args.render_to_parsed_args())
+  )
+}
+
+#[test]
+fn fails_to_parse_cli_without_jdk() {
+  let cli_without_jdk = CLIBuilder::empty()
+    .with_nailgun_args()
+    .with_main_class()
+    .build();
+
+  let parse_result =
+    ParsedJVMCommandLines::parse_command_lines(&cli_without_jdk.render_to_full_cli());
+
+  assert_eq!(
+    parse_result,
+    Err("Every command line must start with a call to the jdk.".to_string())
+  )
+}
+
+#[test]
+fn fails_to_parse_cli_without_main_class() {
+  let cli_without_main_class = CLIBuilder::empty()
+    .with_jdk()
+    .with_classpath()
+    .with_client_args()
+    .build();
+
+  let parse_result =
+    ParsedJVMCommandLines::parse_command_lines(&cli_without_main_class.render_to_full_cli());
+
+  assert_eq!(parse_result, Err("No main class provided.".to_string()))
+}
+
+#[test]
+fn fails_to_parse_cli_without_classpath() {
+  let cli_without_classpath = CLIBuilder::empty()
+    .with_jdk()
+    .with_nailgun_args()
+    .with_main_class()
+    .with_client_args()
+    .build();
+
+  let parse_result =
+    ParsedJVMCommandLines::parse_command_lines(&cli_without_classpath.render_to_full_cli());
+
+  assert_eq!(parse_result, Err("No classpath flag found.".to_string()))
+}
+
+#[test]
+fn fails_to_parse_cli_without_classpath_value() {
+  let cli_without_classpath_value = CLIBuilder::empty()
+    .with_jdk()
+    .with_classpath_flag()
+    .with_nailgun_args()
+    .with_main_class()
+    .build();
+
+  let parse_result =
+    ParsedJVMCommandLines::parse_command_lines(&cli_without_classpath_value.render_to_full_cli());
+
+  assert_eq!(
+    parse_result,
+    Err("Classpath value has incorrect formatting -Xmx4g.".to_string())
+  )
+}

--- a/src/rust/engine/process_execution/src/nailgun/tests.rs
+++ b/src/rust/engine/process_execution/src/nailgun/tests.rs
@@ -1,0 +1,180 @@
+use std::fs::read_link;
+use std::os::unix::fs::symlink;
+use std::path::PathBuf;
+
+use hashing::EMPTY_DIGEST;
+use store::Store;
+use tempfile::TempDir;
+
+use crate::nailgun::{CommandRunner, ARGS_TO_START_NAILGUN, NAILGUN_MAIN_CLASS};
+use crate::{NamedCaches, Platform, Process, ProcessMetadata};
+
+fn mock_nailgun_runner(workdir_base: Option<PathBuf>) -> CommandRunner {
+  let store_dir = TempDir::new().unwrap();
+  let named_cache_dir = TempDir::new().unwrap();
+  let executor = task_executor::Executor::new();
+  let store = Store::local_only(executor.clone(), store_dir.path()).unwrap();
+  let local_runner = crate::local::CommandRunner::new(
+    store,
+    executor.clone(),
+    std::env::temp_dir(),
+    NamedCaches::new(named_cache_dir.path().to_owned()),
+    true,
+  );
+  let workdir_base = workdir_base.unwrap_or(std::env::temp_dir());
+
+  CommandRunner::new(
+    local_runner,
+    ProcessMetadata::default(),
+    workdir_base,
+    executor.clone(),
+  )
+}
+
+fn unique_temp_dir(base_dir: PathBuf, prefix: Option<String>) -> TempDir {
+  tempfile::Builder::new()
+    .prefix(&(prefix.unwrap_or("".to_string())))
+    .tempdir_in(&base_dir)
+    .expect("Error making tempdir for local process execution: {:?}")
+}
+
+fn mock_nailgunnable_request(jdk_home: Option<PathBuf>) -> Process {
+  let mut process = Process::new(vec![]);
+  process.jdk_home = jdk_home;
+  process.is_nailgunnable = true;
+  process.platform_constraint = Some(Platform::Darwin);
+  process
+}
+
+#[tokio::test]
+async fn get_workdir_creates_directory_if_it_doesnt_exist() {
+  let mock_workdir_base = unique_temp_dir(std::env::temp_dir(), None)
+    .path()
+    .to_owned();
+  let mock_nailgun_name = "mock_nonexistent_workdir".to_string();
+  let runner = mock_nailgun_runner(Some(mock_workdir_base.clone()));
+
+  let target_workdir = mock_workdir_base.join(mock_nailgun_name.clone());
+  assert!(!target_workdir.exists());
+  let res = runner.get_nailgun_workdir(&mock_nailgun_name);
+  assert_eq!(res, Ok(target_workdir.clone()));
+  assert!(target_workdir.exists());
+}
+
+#[tokio::test]
+async fn get_workdir_returns_the_workdir_when_it_exists() {
+  let mock_workdir_base = unique_temp_dir(std::env::temp_dir(), None)
+    .path()
+    .to_owned();
+  let mock_nailgun_name = "mock_existing_workdir".to_string();
+  let runner = mock_nailgun_runner(Some(mock_workdir_base.clone()));
+
+  let target_workdir = mock_workdir_base.join(mock_nailgun_name.clone());
+  assert!(!target_workdir.exists());
+  let creation_res = fs::safe_create_dir_all(&target_workdir);
+  assert!(creation_res.is_ok());
+  assert!(target_workdir.exists());
+
+  let res = runner.get_nailgun_workdir(&mock_nailgun_name);
+  assert_eq!(res, Ok(target_workdir.clone()));
+  assert!(target_workdir.exists());
+}
+
+#[tokio::test]
+async fn creating_nailgun_server_request_updates_the_cli() {
+  let req = super::construct_nailgun_server_request(
+    &NAILGUN_MAIN_CLASS.to_string(),
+    Vec::new(),
+    PathBuf::from(""),
+    None,
+  );
+  assert_eq!(req.argv[0], NAILGUN_MAIN_CLASS);
+  assert_eq!(req.argv[1..], ARGS_TO_START_NAILGUN);
+}
+
+#[tokio::test]
+async fn creating_nailgun_client_request_removes_jdk_home() {
+  let original_req = mock_nailgunnable_request(Some(PathBuf::from("some/path")));
+  let req = super::construct_nailgun_client_request(original_req, "".to_string(), vec![]);
+  assert_eq!(req.jdk_home, None);
+}
+
+#[tokio::test]
+async fn nailgun_name_is_the_main_class() {
+  let main_class = "my.main.class".to_string();
+  let name = super::CommandRunner::calculate_nailgun_name(&main_class);
+  assert_eq!(name, format!("nailgun_server_{}", main_class));
+}
+
+async fn materialize_with_jdk(
+  runner: &CommandRunner,
+  dir: PathBuf,
+  jdk_path: PathBuf,
+) -> Result<(), String> {
+  let materializer = super::NailgunPool::materialize_workdir_for_server(
+    runner.inner.store.clone(),
+    dir,
+    jdk_path,
+    EMPTY_DIGEST,
+  );
+  materializer.await
+}
+
+#[tokio::test]
+async fn materializing_workdir_for_server_creates_a_link_for_the_jdk() {
+  let workdir_base_tempdir = unique_temp_dir(std::env::temp_dir(), None);
+  let workdir_base = workdir_base_tempdir.path().to_owned();
+  let mock_jdk_dir = unique_temp_dir(std::env::temp_dir(), None);
+  let mock_jdk_path = mock_jdk_dir.path().to_owned();
+  let runner = mock_nailgun_runner(Some(workdir_base));
+  let nailgun_name = "mock_server".to_string();
+
+  let workdir_for_server = runner
+    .get_nailgun_workdir(&nailgun_name)
+    .expect("Error creating workdir for nailgun server");
+  println!("Workdir for server {:?}", &workdir_for_server);
+
+  // Assert that the materialization was successful
+  let materialization_result =
+    materialize_with_jdk(&runner, workdir_for_server.clone(), mock_jdk_path.clone()).await;
+  assert_eq!(materialization_result, Ok(()));
+
+  // Assert that the symlink points to the requested jdk
+  let materialized_jdk_path = workdir_for_server.join(".jdk");
+  let materialized_jdk = read_link(materialized_jdk_path);
+  assert!(materialized_jdk.is_ok());
+  assert_eq!(materialized_jdk.unwrap(), mock_jdk_path);
+}
+
+#[tokio::test]
+async fn materializing_workdir_for_server_replaces_jdk_link_if_a_different_one_is_requested() {
+  let workdir_base_tempdir = unique_temp_dir(std::env::temp_dir(), None);
+  let workdir_base = workdir_base_tempdir.path().to_owned();
+
+  let runner = mock_nailgun_runner(Some(workdir_base));
+  let nailgun_name = "mock_server".to_string();
+
+  let original_mock_jdk_dir = unique_temp_dir(std::env::temp_dir(), None);
+  let original_mock_jdk_path = original_mock_jdk_dir.path().to_owned();
+  let requested_mock_jdk_dir = unique_temp_dir(std::env::temp_dir(), None);
+  let requested_mock_jdk_path = requested_mock_jdk_dir.path().to_owned();
+
+  let workdir_for_server = runner
+    .get_nailgun_workdir(&nailgun_name)
+    .expect("Error creating workdir for nailgun server");
+  let materialized_jdk_path = workdir_for_server.join(".jdk");
+
+  // Manually create a symlink to one of the jdk files
+  let symlink_res = symlink(original_mock_jdk_path, materialized_jdk_path.clone());
+  assert!(symlink_res.is_ok());
+
+  // Trigger materialization of the nailgun server workdir
+  let materialization_result =
+    materialize_with_jdk(&runner, workdir_for_server, requested_mock_jdk_path.clone()).await;
+  assert!(materialization_result.is_ok());
+
+  // Assert that the symlink points to the requested jdk, and not the original one
+  let materialized_jdk = read_link(materialized_jdk_path);
+  assert!(materialized_jdk.is_ok());
+  assert_eq!(materialized_jdk.unwrap(), requested_mock_jdk_path);
+}

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -91,6 +91,7 @@ pub struct ExecutionStrategyOptions {
   pub remote_parallelism: usize,
   pub local_cleanup: bool,
   pub local_cache: bool,
+  pub local_enable_nailgun: bool,
   pub remote_cache_read: bool,
   pub remote_cache_write: bool,
 }
@@ -148,6 +149,40 @@ impl Core {
     }
   }
 
+  fn make_local_execution_runner(
+    store: &Store,
+    executor: &Executor,
+    local_execution_root_dir: &Path,
+    named_caches_dir: &Path,
+    process_execution_metadata: &ProcessMetadata,
+    exec_strategy_opts: &ExecutionStrategyOptions,
+  ) -> Box<dyn CommandRunner> {
+    let local_command_runner = process_execution::local::CommandRunner::new(
+      store.clone(),
+      executor.clone(),
+      local_execution_root_dir.to_path_buf(),
+      NamedCaches::new(named_caches_dir.to_path_buf()),
+      exec_strategy_opts.local_cleanup,
+    );
+
+    let maybe_nailgunnable_local_command_runner: Box<dyn process_execution::CommandRunner> =
+      if exec_strategy_opts.local_enable_nailgun {
+        Box::new(process_execution::nailgun::CommandRunner::new(
+          local_command_runner,
+          process_execution_metadata.clone(),
+          local_execution_root_dir.to_path_buf(),
+          executor.clone(),
+        ))
+      } else {
+        Box::new(local_command_runner)
+      };
+
+    Box::new(BoundedCommandRunner::new(
+      maybe_nailgunnable_local_command_runner,
+      exec_strategy_opts.local_parallelism,
+    ))
+  }
+
   fn make_command_runner(
     full_store: &Store,
     remote_store_address: &Option<String>,
@@ -171,16 +206,15 @@ impl Core {
     } else {
       full_store.clone()
     };
-    let local_command_runner = Box::new(BoundedCommandRunner::new(
-      Box::new(process_execution::local::CommandRunner::new(
-        store_for_local_runner,
-        executor.clone(),
-        local_execution_root_dir.to_path_buf(),
-        NamedCaches::new(named_caches_dir.to_path_buf()),
-        exec_strategy_opts.local_cleanup,
-      )),
-      exec_strategy_opts.local_parallelism,
-    ));
+
+    let local_command_runner = Core::make_local_execution_runner(
+      &store_for_local_runner,
+      executor,
+      local_execution_root_dir,
+      named_caches_dir,
+      process_execution_metadata,
+      &exec_strategy_opts,
+    );
 
     // Possibly either add the remote execution runner or the remote cache runner.
     // `global_options.py` already validates that both are not set at the same time.

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -511,6 +511,7 @@ py_class!(class PyExecutionStrategyOptions |py| {
     remote_parallelism: u64,
     local_cleanup: bool,
     local_cache: bool,
+    local_enable_nailgun: bool,
     remote_cache_read: bool,
     remote_cache_write: bool
   ) -> CPyResult<Self> {
@@ -520,6 +521,7 @@ py_class!(class PyExecutionStrategyOptions |py| {
         remote_parallelism: remote_parallelism as usize,
         local_cleanup,
         local_cache,
+        local_enable_nailgun,
         remote_cache_read,
         remote_cache_write,
       }


### PR DESCRIPTION
Restore native support for launching JVM processes with `nailgun`. @patricklaw will follow up to actually experiment with using this support (and will likely expose plenty of bugs in it! sorry).

This reverts commit e19336db0d3df6361e08c53b921da7c07a880045.