### PR TITLE
Update petgraph to 0.5.1, and switch to using a FixedBitSet in walk.

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -750,12 +750,6 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
-
-[[package]]
-name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
@@ -1059,11 +1053,12 @@ dependencies = [
  "async-trait",
  "async_value",
  "env_logger",
+ "fixedbitset",
  "fnv",
  "futures",
  "log 0.4.11",
  "parking_lot",
- "petgraph 0.4.13",
+ "petgraph",
  "rand 0.8.2",
  "tokio",
 ]
@@ -1939,12 +1934,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
-name = "ordermap"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
-
-[[package]]
 name = "os_pipe"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2012,21 +2001,11 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "petgraph"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
-dependencies = [
- "fixedbitset 0.1.9",
- "ordermap",
-]
-
-[[package]]
-name = "petgraph"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
 dependencies = [
- "fixedbitset 0.2.0",
+ "fixedbitset",
  "indexmap",
 ]
 
@@ -2262,7 +2241,7 @@ dependencies = [
  "itertools 0.9.0",
  "log 0.4.11",
  "multimap",
- "petgraph 0.5.1",
+ "petgraph",
  "prost",
  "prost-types",
  "tempfile",
@@ -2700,7 +2679,7 @@ dependencies = [
  "env_logger",
  "indexmap",
  "log 0.4.11",
- "petgraph 0.4.13",
+ "petgraph",
 ]
 
 [[package]]
@@ -3840,7 +3819,7 @@ dependencies = [
  "hdrhistogram",
  "log 0.4.11",
  "parking_lot",
- "petgraph 0.4.13",
+ "petgraph",
  "rand 0.8.2",
  "strum",
  "strum_macros",

--- a/src/rust/engine/graph/Cargo.toml
+++ b/src/rust/engine/graph/Cargo.toml
@@ -10,9 +10,10 @@ async-trait = "0.1"
 async_value = { path = "../async_value" }
 fnv = "1.0.5"
 futures = "0.3"
+fixedbitset = "0.2"
 log = "0.4"
 parking_lot = "0.11"
-petgraph = "0.4.5"
+petgraph = "0.5"
 tokio = { version = "1.4", features = ["time"] }
 
 [dev-dependencies]

--- a/src/rust/engine/rule_graph/Cargo.toml
+++ b/src/rust/engine/rule_graph/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 log = "0.4"
-petgraph = "0.4.5"
+petgraph = "0.5"
 indexmap = "1.4"
 
 [dev-dependencies]

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -13,7 +13,7 @@ hdrhistogram = "7.2"
 parking_lot = "0.11"
 rand = "0.8"
 tokio = { version = "1.4", features = ["rt"] }
-petgraph = "0.4.5"
+petgraph = "0.5"
 log = "0.4"
 strum = "0.20"
 strum_macros = "0.20"


### PR DESCRIPTION
Cycle detection shows up surprisingly hot in debug mode (tight loops are much better optimized in `--release` mode). Switching to a `bitset` doesn't do anything in `--release` mode, but it's about 4% faster in debug mode.

I'll likely follow up to do further algorithmic work around cycle detection, as there seem to be some pathological cases.