### PR TITLE
Do not use `[python-setup].resolve_all_constraints` when using `platforms`

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -271,7 +271,9 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
                 f"entries for the following requirements: {', '.join(unconstrained_projects)}"
             )
 
-        if python_setup.resolve_all_constraints:
+        # NB: it isn't safe to resolve against the whole constraints file if
+        # platforms are in use. See https://github.com/pantsbuild/pants/issues/12222.
+        if python_setup.resolve_all_constraints and not request.platforms:
             if unconstrained_projects:
                 logger.warning(
                     "Ignoring `[python_setup].resolve_all_constraints` option because constraints "

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -16,7 +16,7 @@ from _pytest.tmpdir import TempPathFactory
 
 from pants.backend.python.target_types import PythonLibrary, PythonRequirementLibrary
 from pants.backend.python.util_rules import pex_from_targets
-from pants.backend.python.util_rules.pex import Pex, PexRequest, PexRequirements
+from pants.backend.python.util_rules.pex import Pex, PexPlatforms, PexRequest, PexRequirements
 from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
 from pants.build_graph.address import Address
 from pants.engine.internals.scheduler import ExecutionError
@@ -267,3 +267,34 @@ def test_constraints_validation(tmp_path_factory: TempPathFactory, rule_runner: 
 
     # Shouldn't error, as we don't explicitly set --resolve-all-constraints.
     get_pex_request(None, resolve_all_constraints=None)
+
+
+def test_issue_12222(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "constraints.txt": "foo==1.0\nbar==1.0",
+            "BUILD": dedent(
+                """
+            python_requirement_library(name="foo",requirements=["foo"])
+            python_requirement_library(name="bar",requirements=["bar"])
+            python_library(name="lib",sources=[],dependencies=[":foo"])
+            """
+            ),
+        }
+    )
+    request = PexFromTargetsRequest(
+        [Address("", target_name="lib")],
+        output_filename="demo.pex",
+        internal_only=False,
+        platforms=PexPlatforms(["some-platform-x86_64"]),
+    )
+    rule_runner.set_options(
+        [
+            "--python-setup-requirement-constraints=constraints.txt",
+            "--python-setup-resolve-all-constraints",
+        ]
+    )
+    result = rule_runner.request(PexRequest, [request])
+
+    assert result.repository_pex is None
+    assert result.requirements == PexRequirements(["foo"])


### PR DESCRIPTION
…orms` (#12268)

Closes #12222 and adds an associated test for this edge case.

[ci skip-rust]
[ci skip-build-wheels]