### PR TITLE
Do not use `[python-setup].resolve_all_constraints` when using `platforms`

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -274,7 +274,9 @@ async def pex_from_targets(
                 f"requirements: {', '.join(unconstrained_projects)}"
             )
 
-        if python_setup.resolve_all_constraints:
+        # NB: it isn't safe to resolve against the whole constraints file if
+        # platforms are in use. See https://github.com/pantsbuild/pants/issues/12222.
+        if python_setup.resolve_all_constraints and not request.platforms:
             if unconstrained_projects:
                 logger.warning(
                     "Ignoring `[python_setup].resolve_all_constraints` option because constraints "

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -289,12 +289,7 @@ def test_issue_12222(rule_runner: RuleRunner) -> None:
         internal_only=False,
         platforms=PexPlatforms(["some-platform-x86_64"]),
     )
-    rule_runner.set_options(
-        [
-            "--python-setup-requirement-constraints=constraints.txt",
-            "--python-setup-resolve-all-constraints",
-        ]
-    )
+    rule_runner.set_options(["--python-setup-requirement-constraints=constraints.txt"])
     result = rule_runner.request(PexRequest, [request])
 
     assert result.repository_pex is None


### PR DESCRIPTION
Cherry pick of #12268 

[ci skip-rust]
[ci skip-build-wheels]