### PR TITLE
Fix assert arguments in a test: strutil_test

### DIFF
--- a/src/python/pants/util/strutil_test.py
+++ b/src/python/pants/util/strutil_test.py
@@ -28,7 +28,7 @@ def test_pluralize() -> None:
 
 def test_ensure_text() -> None:
     bytes_val = bytes(bytearray([0xE5, 0xBF, 0xAB]))
-    assert "快", ensure_text(bytes_val)
+    assert "快" == ensure_text(bytes_val)
     with pytest.raises(TypeError):
         ensure_text(45)  # type: ignore[arg-type] # intended to fail type check
 


### PR DESCRIPTION
Currently, this `assert` statement is checking that the tuple (i.e. `("快", ensure_text(bytes_val)`) is not empty. I believe the intention was to use the `assert` statement to verify that `ensure_text` function produced text.

[ci skip-build-wheels]