### PR TITLE
Fix parameters of a test: convert_source_to_sources_test

### DIFF
--- a/build-support/migration-support/convert_source_to_sources_test.py
+++ b/build-support/migration-support/convert_source_to_sources_test.py
@@ -14,9 +14,9 @@ from pants.util.contextutil import temporary_dir
     "line",
     [
         "sources=['foo.py'],",
-        "sources= ('foo.py', ),"
-        "sources = {'foo.py'},"
-        "sources =['*.py'],"
+        "sources= ('foo.py', ),",
+        "sources = {'foo.py'},",
+        "sources =['*.py'],",
         'sources =["!ignore.java"],',
         'sources   =    (    "!ignore.java",   )',
         '     sources=[""]',


### PR DESCRIPTION
Currently one of the parameters of the test is a long string that is syntactically correct (thanks to implicit string concatenation), however, I believe the intention was to have each of the `sources=` sample inputs to be separate parameters.

[ci skip-rust]
[ci skip-build-wheels]