### PR TITLE
Refactor BUILD file parsing.

### DIFF
--- a/src/python/pants/base/parse_context.py
+++ b/src/python/pants/base/parse_context.py
@@ -1,23 +1,14 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import threading
+from typing import Any, Mapping
+
+from typing_extensions import Protocol
 
 
-class Storage(threading.local):
-    def __init__(self, rel_path):
-        self.clear(rel_path)
-
-    def clear(self, rel_path):
-        self.rel_path = rel_path
-        self.objects_by_name = dict()
-        self.objects = []
-
-    def add(self, obj, name=None):
-        if name is not None:
-            # NB: `src/python/pants/engine/mapper.py` will detect an overwritten object later.
-            self.objects_by_name[name] = obj
-        self.objects.append(obj)
+class RelPathOracle(Protocol):
+    def rel_path(self) -> str:
+        ...
 
 
 class ParseContext:
@@ -28,42 +19,40 @@ class ParseContext:
     in its `__init__`).
     """
 
-    def __init__(self, rel_path, type_aliases):
+    def __init__(self, type_aliases: Mapping[str, Any], rel_path_oracle: RelPathOracle) -> None:
         """Create a ParseContext.
 
-        :param rel_path: The (build file) path that the parse is currently operating on: initially None.
-        :param type_aliases: A dictionary of alias name strings or alias classes to a callable
-          constructor for the alias.
+        :param type_aliases: A dictionary of BUILD file symbols.
+        :param rel_path_oracle: An oracle than can be queried for the current BUILD file path.
         """
 
         self._type_aliases = type_aliases
-        self._storage = Storage(rel_path)
+        self._rel_path_oracle = rel_path_oracle
 
-    def create_object(self, alias, *args, **kwargs):
+    def create_object(self, alias: str, *args: Any, **kwargs: Any) -> Any:
         """Constructs the type with the given alias using the given args and kwargs.
-
-        NB: aliases may be the alias' object type itself if that type is known.
 
         :API: public
 
-        :param alias: Either the type alias or the type itself.
-        :type alias: string|type
+        :param alias: The type alias.
         :param args: These pass through to the underlying callable object.
         :param kwargs: These pass through to the underlying callable object.
         :returns: The created object.
         """
         object_type = self._type_aliases.get(alias)
         if object_type is None:
-            raise KeyError("There is no type registered for alias {0}".format(alias))
+            raise KeyError(f"There is no type registered for alias {alias}")
+        if not callable(object_type):
+            raise TypeError(
+                f"Asked to call {alias} with args {args} and kwargs {kwargs} but it is not "
+                f"callable, its a {type(alias).__name__}."
+            )
         return object_type(*args, **kwargs)
 
     @property
-    def rel_path(self):
-        """Relative path from the build root to the BUILD file the context aware object is called
-        in.
+    def rel_path(self) -> str:
+        """Relative path from the build root to the BUILD file being parsed.
 
         :API: public
-
-        :rtype string
         """
-        return self._storage.rel_path
+        return self._rel_path_oracle.rel_path()

--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -1,12 +1,15 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import os.path
+import threading
 import tokenize
 from dataclasses import dataclass
 from difflib import get_close_matches
 from io import StringIO
-from typing import Any, Dict, Iterable, List, Tuple, cast
+from typing import Any, Iterable
 
 from pants.base.exceptions import MappingError
 from pants.base.parse_context import ParseContext
@@ -29,11 +32,36 @@ class UnaddressableObjectError(MappingError):
     """Indicates an un-addressable object was found at the top level."""
 
 
+class ParseState(threading.local):
+    def __init__(self):
+        self._rel_path: str | None = None
+        self._target_adapters: list[TargetAdaptor] = []
+
+    def reset(self, rel_path: str) -> None:
+        self._rel_path = rel_path
+        self._target_adapters.clear()
+
+    def add(self, target_adapter: TargetAdaptor) -> None:
+        self._target_adapters.append(target_adapter)
+
+    def rel_path(self) -> str:
+        if self._rel_path is None:
+            raise AssertionError(
+                "The BUILD file rel_path was accessed before being set. This indicates a "
+                "programming error in Pants. Please file a bug report at "
+                "https://github.com/pantsbuild/pants/issues/new."
+            )
+        return self._rel_path
+
+    def parsed_targets(self) -> list[TargetAdaptor]:
+        return list(self._target_adapters)
+
+
 class Parser:
     def __init__(
         self, *, target_type_aliases: Iterable[str], object_aliases: BuildFileAliases
     ) -> None:
-        self._symbols, self._parse_context = self._generate_symbols(
+        self._symbols, self._parse_state = self._generate_symbols(
             target_type_aliases, object_aliases
         )
 
@@ -41,48 +69,43 @@ class Parser:
     def _generate_symbols(
         target_type_aliases: Iterable[str],
         object_aliases: BuildFileAliases,
-    ) -> Tuple[Dict[str, Any], ParseContext]:
-        symbols: Dict[str, Any] = {}
-
-        # Compute "per path" symbols.  For performance, we use the same ParseContext, which we
-        # mutate to set the rel_path appropriately before it's actually used. This allows this
-        # method to reuse the same symbols for all parses. Meanwhile, we set the rel_path to None,
-        # so that we get a loud error if anything tries to use it before it's set.
-        # TODO: See https://github.com/pantsbuild/pants/issues/3561
-        parse_context = ParseContext(rel_path=None, type_aliases=symbols)
+    ) -> tuple[dict[str, Any], ParseState]:
+        # N.B.: We re-use the thread local ParseState across symbols for performance reasons.
+        # This allows a single construction of all symbols here that can be re-used for each BUILD
+        # file parse with a reset of the ParseState for the calling thread.
+        parse_state = ParseState()
 
         class Registrar:
-            def __init__(self, parse_context: ParseContext, type_alias: str):
-                self._parse_context = parse_context
+            def __init__(self, type_alias: str) -> None:
                 self._type_alias = type_alias
 
-            def __call__(self, *args, **kwargs):
+            def __call__(self, **kwargs: Any) -> TargetAdaptor:
                 # Target names default to the name of the directory their BUILD file is in
                 # (as long as it's not the root directory).
                 if "name" not in kwargs:
-                    dirname = os.path.basename(self._parse_context.rel_path)
+                    dirname = os.path.basename(parse_state.rel_path())
                     if not dirname:
                         raise UnaddressableObjectError(
                             "Targets in root-level BUILD files must be named explicitly."
                         )
                     kwargs["name"] = dirname
-                kwargs.setdefault("type_alias", self._type_alias)
-                target_adaptor = TargetAdaptor(**kwargs)
-                self._parse_context._storage.add(target_adaptor)
+                target_adaptor = TargetAdaptor(self._type_alias, **kwargs)
+                parse_state.add(target_adaptor)
                 return target_adaptor
 
-        symbols.update({alias: Registrar(parse_context, alias) for alias in target_type_aliases})
-        symbols.update(object_aliases.objects)
+        symbols: dict[str, Any] = dict(object_aliases.objects)
+        symbols.update((alias, Registrar(alias)) for alias in target_type_aliases)
+
+        parse_context = ParseContext(type_aliases=symbols, rel_path_oracle=parse_state)
         for alias, object_factory in object_aliases.context_aware_object_factories.items():
             symbols[alias] = object_factory(parse_context)
 
-        return symbols, parse_context
+        return symbols, parse_state
 
     def parse(
         self, filepath: str, build_file_content: str, extra_symbols: BuildFilePreludeSymbols
-    ) -> List[TargetAdaptor]:
-        # Mutate the parse context with the new path.
-        self._parse_context._storage.clear(os.path.dirname(filepath))
+    ) -> list[TargetAdaptor]:
+        self._parse_state.reset(rel_path=os.path.dirname(filepath))
 
         # We update the known symbols with Build File Preludes. This is subtle code; functions have
         # their own globals set on __globals__ which they derive from the environment where they
@@ -124,7 +147,7 @@ class Parser:
 
         error_on_imports(build_file_content, filepath)
 
-        return cast(List[TargetAdaptor], list(self._parse_context._storage.objects))
+        return self._parse_state.parsed_targets()
 
 
 def error_on_imports(build_file_content: str, filepath: str) -> None:


### PR DESCRIPTION
Move to parse state storage from ParseContext to parser where it
belongs. This removes some unused cruft and cleans up the conceptual
model a bit. It also allows for adding typing annotations without
untoward dependencies.

[ci skip-rust]
[ci skip-build-wheels]