### PR TITLE
Fix poetry_requirements handling of python. (#12278)

### DIFF
--- a/src/python/pants/backend/python/macros/poetry_requirements.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements.py
@@ -185,6 +185,11 @@ def parse_pyproject_toml(toml_contents: str, file_path: str) -> set[Requirement]
             )
         )
     dependencies = poetry_vals.get("dependencies", {})
+    # N.B.: The "python" dependency is a special dependency required by Poetry that only serves to
+    # constraint the python interpreter versions the project works with; so we skip that.
+    # See: https://python-poetry.org/docs/pyproject/#dependencies-and-dev-dependencies
+    dependencies.pop("python", None)
+
     dev_dependencies = poetry_vals.get("dev-dependencies", {})
     if not dependencies and not dev_dependencies:
         logger.warning(

--- a/src/python/pants/backend/python/macros/poetry_requirements_test.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements_test.py
@@ -183,7 +183,6 @@ def test_parse_multi_reqs() -> None:
     """
     retval = parse_pyproject_toml(toml_str, "/path/to/file")
     actual_reqs = {
-        Requirement.parse("python<4.0.0,>=3.8"),
         Requirement.parse("junk@ https://github.com/myrepo/junk.whl"),
         Requirement.parse("poetry@ git+https://github.com/python-poetry/poetry.git@v1.1.1"),
         Requirement.parse('requests<3.0.0,>=2.25.1; python_version > "2.7"'),


### PR DESCRIPTION
We now skip this entry since it is not representative of an actual
third party distribution requirement.

Fixes #12276

(cherry picked from commit 2a496aa3687defca9b75e52f832443b5baa1fb61)

[ci skip-rust]
[ci skip-build-wheels]