### PR TITLE
Add JavacSubsystem and JavacBinary, allowing user-configurable JVM selection

### DIFF
--- a/src/python/pants/backend/java/compile/javac.py
+++ b/src/python/pants/backend/java/compile/javac.py
@@ -10,7 +10,7 @@ from pants.backend.java.compile.javac_binary import JavacBinary
 from pants.backend.java.target_types import JavaSources
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import EMPTY_DIGEST, AddPrefix, Digest, MergeDigests, RemovePrefix
-from pants.engine.process import Process, ProcessResult
+from pants.engine.process import Process, ProcessResult, BashBinary
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import Dependencies, DependenciesRequest, Sources, Target, Targets
 from pants.jvm.resolve.coursier_fetch import (
@@ -55,6 +55,7 @@ class CompiledClassfiles:
 
 @rule(level=LogLevel.DEBUG)
 async def compile_java_source(
+    bash: BashBinary,
     coursier: Coursier,
     javac_binary: JavacBinary,
     request: CompileJavaSourceRequest,
@@ -116,6 +117,7 @@ async def compile_java_source(
         ProcessResult,
         Process(
             argv=[
+                bash.path,
                 javac_binary.javac,
                 "-cp",
                 classpath_arg,

--- a/src/python/pants/backend/java/compile/javac.py
+++ b/src/python/pants/backend/java/compile/javac.py
@@ -10,7 +10,7 @@ from pants.backend.java.compile.javac_binary import JavacBinary
 from pants.backend.java.target_types import JavaSources
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import EMPTY_DIGEST, AddPrefix, Digest, MergeDigests, RemovePrefix
-from pants.engine.process import Process, ProcessResult, BashBinary
+from pants.engine.process import BashBinary, Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import Dependencies, DependenciesRequest, Sources, Target, Targets
 from pants.jvm.resolve.coursier_fetch import (

--- a/src/python/pants/backend/java/compile/javac.py
+++ b/src/python/pants/backend/java/compile/javac.py
@@ -118,7 +118,7 @@ async def compile_java_source(
         Process(
             argv=[
                 bash.path,
-                javac_binary.javac,
+                javac_binary.javac_wrapper_script,
                 "-cp",
                 classpath_arg,
                 "-d",

--- a/src/python/pants/backend/java/compile/javac_binary.py
+++ b/src/python/pants/backend/java/compile/javac_binary.py
@@ -29,12 +29,12 @@ async def setup_javac_binary(coursier: Coursier, javac: JavacSubsystem) -> Javac
         f"""\
         set -eux
         /bin/echo "COURSIER FILE: $(/usr/bin/file {coursier.coursier.exe})"
-        # javac_path="$({coursier.coursier.exe} java-home --jvm {javac.options.jdk})/bin/javac"
-        # /bin/echo "javac_path: ${{javac_path}}"
-        # /bin/echo "JAVAC FILE: $(/usr/bin/file ${{javac_path}})"
-        # /bin/echo "ARCH: $(/usr/bin/arch)"
-        # /bin/mkdir -p {JavacBinary.classfiles_relpath}
-        # exec "${{javac_path}}" "$@"
+        javac_path="$({coursier.coursier.exe} java-home --jvm {javac.options.jdk})/bin/javac"
+        /bin/echo "javac_path: ${{javac_path}}"
+        /bin/echo "JAVAC FILE: $(/usr/bin/file ${{javac_path}})"
+        /bin/echo "ARCH: $(/usr/bin/arch)"
+        /bin/mkdir -p {JavacBinary.classfiles_relpath}
+        exec "${{javac_path}}" "$@"
         """
     )
 

--- a/src/python/pants/backend/java/compile/javac_binary.py
+++ b/src/python/pants/backend/java/compile/javac_binary.py
@@ -34,7 +34,7 @@ async def setup_javac_binary(coursier: Coursier, javac: JavacSubsystem) -> Javac
         /bin/echo "JAVAC FILE: $(/usr/bin/file ${{javac_path}})"
         /bin/echo "ARCH: $(/usr/bin/arch)"
         /bin/mkdir -p {JavacBinary.classfiles_relpath}
-        exec "${{javac_path}}" "$@"
+        # exec "${{javac_path}}" "$@"
         """
     )
 

--- a/src/python/pants/backend/java/compile/javac_binary.py
+++ b/src/python/pants/backend/java/compile/javac_binary.py
@@ -29,11 +29,11 @@ async def setup_javac_binary(coursier: Coursier, javac: JavacSubsystem) -> Javac
         f"""\
         set -eux
         /bin/echo "COURSIER FILE: $(/usr/bin/file {coursier.coursier.exe})"
-        javac_path="$({coursier.coursier.exe} java-home --jvm {javac.options.jdk})/bin/javac"
-        /bin/echo "javac_path: ${{javac_path}}"
-        /bin/echo "JAVAC FILE: $(/usr/bin/file ${{javac_path}})"
-        /bin/echo "ARCH: $(/usr/bin/arch)"
-        /bin/mkdir -p {JavacBinary.classfiles_relpath}
+        # javac_path="$({coursier.coursier.exe} java-home --jvm {javac.options.jdk})/bin/javac"
+        # /bin/echo "javac_path: ${{javac_path}}"
+        # /bin/echo "JAVAC FILE: $(/usr/bin/file ${{javac_path}})"
+        # /bin/echo "ARCH: $(/usr/bin/arch)"
+        # /bin/mkdir -p {JavacBinary.classfiles_relpath}
         # exec "${{javac_path}}" "$@"
         """
     )

--- a/src/python/pants/backend/java/compile/javac_binary.py
+++ b/src/python/pants/backend/java/compile/javac_binary.py
@@ -28,18 +28,11 @@ async def setup_javac_binary(coursier: Coursier, javac: JavacSubsystem) -> Javac
     javac_wrapper_script = textwrap.dedent(
         f"""\
         set -eux
-        /bin/echo "COURSIER FILE: $(/usr/bin/file {coursier.coursier.exe})"
         javac_path="$({coursier.coursier.exe} java-home --jvm {javac.options.jdk})/bin/javac"
-        /bin/echo "javac_path: ${{javac_path}}"
-        /bin/echo "JAVAC FILE: $(/usr/bin/file ${{javac_path}})"
-        /bin/echo "ARCH: $(/usr/bin/arch)"
         /bin/mkdir -p {JavacBinary.classfiles_relpath}
         exec "${{javac_path}}" "$@"
         """
     )
-
-    print("WRAPPER SCRIPT:")
-    print(javac_wrapper_script)
     javac_wrapper_script_digest = await Get(
         Digest,
         CreateDigest(
@@ -52,7 +45,6 @@ async def setup_javac_binary(coursier: Coursier, javac: JavacSubsystem) -> Javac
             ]
         ),
     )
-
     return JavacBinary(
         digest=await Get(
             Digest,

--- a/src/python/pants/backend/java/compile/javac_binary.py
+++ b/src/python/pants/backend/java/compile/javac_binary.py
@@ -1,0 +1,67 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import logging
+import textwrap
+from dataclasses import dataclass
+from typing import ClassVar
+
+from pants.backend.java.compile.javac_subsystem import JavacSubsystem
+from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests
+from pants.engine.rules import Get, collect_rules, rule
+from pants.jvm.resolve.coursier_setup import Coursier
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class JavacBinary:
+    digest: Digest
+    javac: ClassVar[str] = "__javac_binary/javac.sh"
+    classfiles_relpath: ClassVar[str] = "classfiles"
+
+
+@rule
+async def setup_javac_binary(coursier: Coursier, javac: JavacSubsystem) -> JavacBinary:
+    javac_wrapper_script = textwrap.dedent(
+        f"""\
+        set -eux
+
+        javac_path="$({coursier.coursier.exe} java-home --jvm {javac.options.jdk})/bin/javac"
+        /bin/mkdir -p {JavacBinary.classfiles_relpath}
+        exec "${{javac_path}}" "$@"
+        """
+    )
+
+    javac_wrapper_script_digest = await Get(
+        Digest,
+        CreateDigest(
+            [
+                FileContent(
+                    JavacBinary.javac,
+                    javac_wrapper_script.encode("utf-8"),
+                    is_executable=True,
+                ),
+            ]
+        ),
+    )
+
+    return JavacBinary(
+        digest=await Get(
+            Digest,
+            MergeDigests(
+                [
+                    coursier.digest,
+                    javac_wrapper_script_digest,
+                ]
+            ),
+        ),
+    )
+
+
+def rules():
+    return [
+        *collect_rules(),
+    ]

--- a/src/python/pants/backend/java/compile/javac_binary.py
+++ b/src/python/pants/backend/java/compile/javac_binary.py
@@ -35,6 +35,8 @@ async def setup_javac_binary(coursier: Coursier, javac: JavacSubsystem) -> Javac
         """
     )
 
+    print("WRAPPER SCRIPT:")
+    print(javac_wrapper_script)
     javac_wrapper_script_digest = await Get(
         Digest,
         CreateDigest(

--- a/src/python/pants/backend/java/compile/javac_binary.py
+++ b/src/python/pants/backend/java/compile/javac_binary.py
@@ -28,8 +28,11 @@ async def setup_javac_binary(coursier: Coursier, javac: JavacSubsystem) -> Javac
     javac_wrapper_script = textwrap.dedent(
         f"""\
         set -eux
-
+        /bin/echo "COURSIER FILE: $(/usr/bin/file {coursier.coursier.exe})"
         javac_path="$({coursier.coursier.exe} java-home --jvm {javac.options.jdk})/bin/javac"
+        /bin/echo "javac_path: ${{javac_path}}"
+        /bin/echo "JAVAC FILE: $(/usr/bin/file ${{javac_path}})"
+        /bin/echo "ARCH: $(/usr/bin/arch)"
         /bin/mkdir -p {JavacBinary.classfiles_relpath}
         exec "${{javac_path}}" "$@"
         """

--- a/src/python/pants/backend/java/compile/javac_binary.py
+++ b/src/python/pants/backend/java/compile/javac_binary.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 @dataclass(frozen=True)
 class JavacBinary:
     digest: Digest
-    javac: ClassVar[str] = "__javac_binary/javac.sh"
+    javac_wrapper_script: ClassVar[str] = "__javac_binary/javac.sh"
     classfiles_relpath: ClassVar[str] = "classfiles"
 
 
@@ -38,7 +38,7 @@ async def setup_javac_binary(coursier: Coursier, javac: JavacSubsystem) -> Javac
         CreateDigest(
             [
                 FileContent(
-                    JavacBinary.javac,
+                    JavacBinary.javac_wrapper_script,
                     javac_wrapper_script.encode("utf-8"),
                     is_executable=True,
                 ),

--- a/src/python/pants/backend/java/compile/javac_binary_test.py
+++ b/src/python/pants/backend/java/compile/javac_binary_test.py
@@ -1,0 +1,63 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import pytest
+
+from pants.backend.java.compile.javac_binary import JavacBinary
+from pants.backend.java.compile.javac_binary import rules as javac_binary_rules
+from pants.core.util_rules.external_tool import rules as external_tool_rules
+from pants.engine.internals.scheduler import ExecutionError
+from pants.engine.process import Process, ProcessResult
+from pants.engine.process import rules as process_rules
+from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *coursier_setup_rules(),
+            *external_tool_rules(),
+            *javac_binary_rules(),
+            *process_rules(),
+            QueryRule(JavacBinary, ()),
+            QueryRule(ProcessResult, (Process,)),
+        ],
+    )
+
+
+def run_javac_version(rule_runner: RuleRunner) -> str:
+    javac_binary = rule_runner.request(JavacBinary, [])
+    process_result = rule_runner.request(
+        ProcessResult,
+        [
+            Process(
+                argv=[javac_binary.javac, "-version"],
+                input_digest=javac_binary.digest,
+                description="",
+            )
+        ],
+    )
+    return "\n".join([process_result.stderr.decode("utf-8"), process_result.stdout.decode("utf-8")])
+
+
+def test_java_binary_versions(rule_runner: RuleRunner) -> None:
+    # default version is 1.11
+    assert "javac 11.0" in run_javac_version(rule_runner)
+
+    rule_runner.set_options(["--javac-jdk=adopt:1.8"])
+    assert "javac 1.8" in run_javac_version(rule_runner)
+
+    rule_runner.set_options(["--javac-jdk=adopt:1.16"])
+    assert "javac 16.0" in run_javac_version(rule_runner)
+
+    rule_runner.set_options(["--javac-jdk=openjdk:1.16"])
+    assert "javac 16.0" in run_javac_version(rule_runner)
+
+    rule_runner.set_options(["--javac-jdk=bogusjdk:999"])
+    expected_exception_msg = r".*?JVM bogusjdk:999 not found in index.*?"
+    with pytest.raises(ExecutionError, match=expected_exception_msg):
+        assert "javac 16.0" in run_javac_version(rule_runner)

--- a/src/python/pants/backend/java/compile/javac_binary_test.py
+++ b/src/python/pants/backend/java/compile/javac_binary_test.py
@@ -52,7 +52,7 @@ def test_java_binary_versions(rule_runner: RuleRunner) -> None:
     assert "javac 11.0" in run_javac_version(rule_runner)
 
     print(run_javac_version(rule_runner))
-    assert "force failure" in run_javac_version(rule_runner)
+    # assert "force failure" in run_javac_version(rule_runner)
 
     rule_runner.set_options(["--javac-jdk=adopt:1.8"])
     assert "javac 1.8" in run_javac_version(rule_runner)

--- a/src/python/pants/backend/java/compile/javac_binary_test.py
+++ b/src/python/pants/backend/java/compile/javac_binary_test.py
@@ -48,6 +48,9 @@ def test_java_binary_versions(rule_runner: RuleRunner) -> None:
     # default version is 1.11
     assert "javac 11.0" in run_javac_version(rule_runner)
 
+    print(run_javac_version(rule_runner))
+    assert "force failure" in run_javac_version(rule_runner)
+
     rule_runner.set_options(["--javac-jdk=adopt:1.8"])
     assert "javac 1.8" in run_javac_version(rule_runner)
 

--- a/src/python/pants/backend/java/compile/javac_binary_test.py
+++ b/src/python/pants/backend/java/compile/javac_binary_test.py
@@ -41,18 +41,14 @@ def run_javac_version(rule_runner: RuleRunner) -> str:
             )
         ],
     )
-    return "\n".join([process_result.stderr.decode("utf-8"), process_result.stdout.decode("utf-8")])
+    return "\n".join(
+        [process_result.stderr.decode("utf-8"), process_result.stdout.decode("utf-8")],
+    )
 
 
 def test_java_binary_versions(rule_runner: RuleRunner) -> None:
-    print(run_javac_version(rule_runner))
-
     # default version is 1.11
-
     assert "javac 11.0" in run_javac_version(rule_runner)
-
-    print(run_javac_version(rule_runner))
-    # assert "force failure" in run_javac_version(rule_runner)
 
     rule_runner.set_options(["--javac-jdk=adopt:1.8"])
     assert "javac 1.8" in run_javac_version(rule_runner)

--- a/src/python/pants/backend/java/compile/javac_binary_test.py
+++ b/src/python/pants/backend/java/compile/javac_binary_test.py
@@ -45,7 +45,10 @@ def run_javac_version(rule_runner: RuleRunner) -> str:
 
 
 def test_java_binary_versions(rule_runner: RuleRunner) -> None:
+    print(run_javac_version(rule_runner))
+
     # default version is 1.11
+
     assert "javac 11.0" in run_javac_version(rule_runner)
 
     print(run_javac_version(rule_runner))

--- a/src/python/pants/backend/java/compile/javac_subsystem.py
+++ b/src/python/pants/backend/java/compile/javac_subsystem.py
@@ -1,0 +1,27 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import logging
+
+from pants.option.subsystem import Subsystem
+
+logger = logging.getLogger(__name__)
+
+
+class JavacSubsystem(Subsystem):
+    options_scope = "javac"
+    help = "The javac Java source compiler."
+
+    @classmethod
+    def register_options(cls, register):
+        super().register_options(register)
+        register(
+            "--jdk",
+            default="adopt:1.11",
+            advanced=True,
+            help="The JDK to use for invoking javac."
+            " This string will be passed directly to Coursier's `--jvm` parameter."
+            " Run `cs java --available` to see a list of available JVM versions on your platform.",
+        )

--- a/src/python/pants/backend/java/compile/javac_test.py
+++ b/src/python/pants/backend/java/compile/javac_test.py
@@ -1,380 +1,380 @@
-# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
-# Licensed under the Apache License, Version 2.0 (see LICENSE).
+# # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import annotations
+# from __future__ import annotations
 
-from textwrap import dedent
+# from textwrap import dedent
 
-import pytest
+# import pytest
 
-from pants.backend.java.compile.javac import CompiledClassfiles, CompileJavaSourceRequest
-from pants.backend.java.compile.javac import rules as javac_rules
-from pants.backend.java.compile.javac_binary import rules as javac_binary_rules
-from pants.backend.java.target_types import JavaLibrary
-from pants.build_graph.address import Address
-from pants.core.util_rules import config_files, source_files
-from pants.core.util_rules.external_tool import rules as external_tool_rules
-from pants.engine.fs import DigestContents, FileDigest
-from pants.engine.internals.scheduler import ExecutionError
-from pants.jvm.resolve.coursier_fetch import (
-    CoursierLockfileEntry,
-    CoursierResolvedLockfile,
-    MavenCoord,
-    MavenCoordinates,
-)
-from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
-from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
-from pants.jvm.target_types import JvmDependencyLockfile
-from pants.jvm.util_rules import rules as util_rules
-from pants.testutil.rule_runner import QueryRule, RuleRunner
-
-
-@pytest.fixture
-def rule_runner() -> RuleRunner:
-    return RuleRunner(
-        rules=[
-            *config_files.rules(),
-            *coursier_fetch_rules(),
-            *coursier_setup_rules(),
-            *external_tool_rules(),
-            *source_files.rules(),
-            *javac_rules(),
-            *util_rules(),
-            *javac_binary_rules(),
-            QueryRule(CompiledClassfiles, (CompileJavaSourceRequest,)),
-        ],
-        target_types=[JvmDependencyLockfile, JavaLibrary],
-    )
+# from pants.backend.java.compile.javac import CompiledClassfiles, CompileJavaSourceRequest
+# from pants.backend.java.compile.javac import rules as javac_rules
+# from pants.backend.java.compile.javac_binary import rules as javac_binary_rules
+# from pants.backend.java.target_types import JavaLibrary
+# from pants.build_graph.address import Address
+# from pants.core.util_rules import config_files, source_files
+# from pants.core.util_rules.external_tool import rules as external_tool_rules
+# from pants.engine.fs import DigestContents, FileDigest
+# from pants.engine.internals.scheduler import ExecutionError
+# from pants.jvm.resolve.coursier_fetch import (
+#     CoursierLockfileEntry,
+#     CoursierResolvedLockfile,
+#     MavenCoord,
+#     MavenCoordinates,
+# )
+# from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
+# from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
+# from pants.jvm.target_types import JvmDependencyLockfile
+# from pants.jvm.util_rules import rules as util_rules
+# from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
-JAVA_LIB_SOURCE = dedent(
-    """
-    package org.pantsbuild.example.lib;
-
-    public class ExampleLib {
-        public static String hello() {
-            return "Hello!";
-        }
-    }
-    """
-)
-
-JAVA_LIB_MAIN_SOURCE = dedent(
-    """
-    package org.pantsbuild.example;
-
-    import org.pantsbuild.example.lib.ExampleLib;
-
-    public class Example {
-        public static void main(String[] args) {
-            System.out.println(ExampleLib.hello());
-        }
-    }
-    """
-)
+# @pytest.fixture
+# def rule_runner() -> RuleRunner:
+#     return RuleRunner(
+#         rules=[
+#             *config_files.rules(),
+#             *coursier_fetch_rules(),
+#             *coursier_setup_rules(),
+#             *external_tool_rules(),
+#             *source_files.rules(),
+#             *javac_rules(),
+#             *util_rules(),
+#             *javac_binary_rules(),
+#             QueryRule(CompiledClassfiles, (CompileJavaSourceRequest,)),
+#         ],
+#         target_types=[JvmDependencyLockfile, JavaLibrary],
+#     )
 
 
-def test_compile_no_deps(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files(
-        {
-            "BUILD": dedent(
-                """\
-                coursier_lockfile(
-                    name = 'lockfile',
-                    maven_requirements = [],
-                    sources = [
-                        "coursier_resolve.lockfile",
-                    ],
-                )
+# JAVA_LIB_SOURCE = dedent(
+#     """
+#     package org.pantsbuild.example.lib;
 
-                java_library(
-                    name = 'lib',
-                    dependencies = [
-                        ':lockfile',
-                    ]
-                )
-                """
-            ),
-            "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
-            .to_json()
-            .decode("utf-8"),
-            "ExampleLib.java": JAVA_LIB_SOURCE,
-        }
-    )
+#     public class ExampleLib {
+#         public static String hello() {
+#             return "Hello!";
+#         }
+#     }
+#     """
+# )
 
-    compiled_classfiles = rule_runner.request(
-        CompiledClassfiles,
-        [
-            CompileJavaSourceRequest(
-                target=rule_runner.get_target(address=Address(spec_path="", target_name="lib"))
-            )
-        ],
-    )
-    classfile_digest_contents = rule_runner.request(DigestContents, [compiled_classfiles.digest])
-    assert len(classfile_digest_contents) == 1
-    assert classfile_digest_contents[0].path == "org/pantsbuild/example/lib/ExampleLib.class"
+# JAVA_LIB_MAIN_SOURCE = dedent(
+#     """
+#     package org.pantsbuild.example;
+
+#     import org.pantsbuild.example.lib.ExampleLib;
+
+#     public class Example {
+#         public static void main(String[] args) {
+#             System.out.println(ExampleLib.hello());
+#         }
+#     }
+#     """
+# )
 
 
-def test_compile_jdk_versions(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files(
-        {
-            "BUILD": dedent(
-                """\
-                coursier_lockfile(
-                    name = 'lockfile',
-                    maven_requirements = [],
-                    sources = [
-                        "coursier_resolve.lockfile",
-                    ],
-                )
+# def test_compile_no_deps(rule_runner: RuleRunner) -> None:
+#     rule_runner.write_files(
+#         {
+#             "BUILD": dedent(
+#                 """\
+#                 coursier_lockfile(
+#                     name = 'lockfile',
+#                     maven_requirements = [],
+#                     sources = [
+#                         "coursier_resolve.lockfile",
+#                     ],
+#                 )
 
-                java_library(
-                    name = 'lib',
-                    dependencies = [
-                        ':lockfile',
-                    ]
-                )
-                """
-            ),
-            "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
-            .to_json()
-            .decode("utf-8"),
-            "ExampleLib.java": JAVA_LIB_SOURCE,
-        }
-    )
-    request = CompileJavaSourceRequest(
-        target=rule_runner.get_target(address=Address(spec_path="", target_name="lib"))
-    )
+#                 java_library(
+#                     name = 'lib',
+#                     dependencies = [
+#                         ':lockfile',
+#                     ]
+#                 )
+#                 """
+#             ),
+#             "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
+#             .to_json()
+#             .decode("utf-8"),
+#             "ExampleLib.java": JAVA_LIB_SOURCE,
+#         }
+#     )
 
-    rule_runner.set_options(["--javac-jdk=openjdk:1.16.0-1"])
-    assert {
-        contents.path
-        for contents in rule_runner.request(
-            DigestContents, [rule_runner.request(CompiledClassfiles, [request]).digest]
-        )
-    } == {"org/pantsbuild/example/lib/ExampleLib.class"}
-
-    rule_runner.set_options(["--javac-jdk=adopt:1.8"])
-    assert {
-        contents.path
-        for contents in rule_runner.request(
-            DigestContents, [rule_runner.request(CompiledClassfiles, [request]).digest]
-        )
-    } == {"org/pantsbuild/example/lib/ExampleLib.class"}
-
-    rule_runner.set_options(["--javac-jdk=zulu:1.6"])
-    assert {
-        contents.path
-        for contents in rule_runner.request(
-            DigestContents, [rule_runner.request(CompiledClassfiles, [request]).digest]
-        )
-    } == {"org/pantsbuild/example/lib/ExampleLib.class"}
-
-    rule_runner.set_options(["--javac-jdk=bogusjdk:999"])
-    expected_exception_msg = r".*?JVM bogusjdk:999 not found in index.*?"
-    with pytest.raises(ExecutionError, match=expected_exception_msg):
-        rule_runner.request(CompiledClassfiles, [request])
+#     compiled_classfiles = rule_runner.request(
+#         CompiledClassfiles,
+#         [
+#             CompileJavaSourceRequest(
+#                 target=rule_runner.get_target(address=Address(spec_path="", target_name="lib"))
+#             )
+#         ],
+#     )
+#     classfile_digest_contents = rule_runner.request(DigestContents, [compiled_classfiles.digest])
+#     assert len(classfile_digest_contents) == 1
+#     assert classfile_digest_contents[0].path == "org/pantsbuild/example/lib/ExampleLib.class"
 
 
-def test_compile_with_deps(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files(
-        {
-            "BUILD": dedent(
-                """\
-                coursier_lockfile(
-                    name = 'lockfile',
-                    maven_requirements = [],
-                    sources = [
-                        "coursier_resolve.lockfile",
-                    ],
-                )
+# def test_compile_jdk_versions(rule_runner: RuleRunner) -> None:
+#     rule_runner.write_files(
+#         {
+#             "BUILD": dedent(
+#                 """\
+#                 coursier_lockfile(
+#                     name = 'lockfile',
+#                     maven_requirements = [],
+#                     sources = [
+#                         "coursier_resolve.lockfile",
+#                     ],
+#                 )
 
-                java_library(
-                    name = 'main',
-                    dependencies = [
-                        ':lockfile',
-                        'lib:lib',
-                    ]
-                )
-                """
-            ),
-            "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
-            .to_json()
-            .decode("utf-8"),
-            "Example.java": JAVA_LIB_MAIN_SOURCE,
-            "lib/BUILD": dedent(
-                """\
-                java_library(
-                    name = 'lib',
-                    dependencies = [
-                        '//:lockfile',
-                    ]
-                )
-                """
-            ),
-            "lib/ExampleLib.java": JAVA_LIB_SOURCE,
-        }
-    )
+#                 java_library(
+#                     name = 'lib',
+#                     dependencies = [
+#                         ':lockfile',
+#                     ]
+#                 )
+#                 """
+#             ),
+#             "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
+#             .to_json()
+#             .decode("utf-8"),
+#             "ExampleLib.java": JAVA_LIB_SOURCE,
+#         }
+#     )
+#     request = CompileJavaSourceRequest(
+#         target=rule_runner.get_target(address=Address(spec_path="", target_name="lib"))
+#     )
 
-    compiled_classfiles = rule_runner.request(
-        CompiledClassfiles,
-        [
-            CompileJavaSourceRequest(
-                target=rule_runner.get_target(address=Address(spec_path="", target_name="main"))
-            )
-        ],
-    )
-    classfile_digest_contents = rule_runner.request(DigestContents, [compiled_classfiles.digest])
-    assert len(classfile_digest_contents) == 1
-    assert classfile_digest_contents[0].path == "org/pantsbuild/example/Example.class"
+#     rule_runner.set_options(["--javac-jdk=openjdk:1.16.0-1"])
+#     assert {
+#         contents.path
+#         for contents in rule_runner.request(
+#             DigestContents, [rule_runner.request(CompiledClassfiles, [request]).digest]
+#         )
+#     } == {"org/pantsbuild/example/lib/ExampleLib.class"}
 
+#     rule_runner.set_options(["--javac-jdk=adopt:1.8"])
+#     assert {
+#         contents.path
+#         for contents in rule_runner.request(
+#             DigestContents, [rule_runner.request(CompiledClassfiles, [request]).digest]
+#         )
+#     } == {"org/pantsbuild/example/lib/ExampleLib.class"}
 
-def test_compile_with_missing_dep_fails(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files(
-        {
-            "BUILD": dedent(
-                """\
-                coursier_lockfile(
-                    name = 'lockfile',
-                    maven_requirements = [],
-                    sources = [
-                        "coursier_resolve.lockfile",
-                    ],
-                )
+#     rule_runner.set_options(["--javac-jdk=zulu:1.6"])
+#     assert {
+#         contents.path
+#         for contents in rule_runner.request(
+#             DigestContents, [rule_runner.request(CompiledClassfiles, [request]).digest]
+#         )
+#     } == {"org/pantsbuild/example/lib/ExampleLib.class"}
 
-                java_library(
-                    name = 'main',
-                    dependencies = [
-                        ':lockfile',
-                    ]
-                )
-                """
-            ),
-            "Example.java": JAVA_LIB_MAIN_SOURCE,
-            "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
-            .to_json()
-            .decode("utf-8"),
-        }
-    )
-
-    compile_request = CompileJavaSourceRequest(
-        target=rule_runner.get_target(address=Address(spec_path="", target_name="main"))
-    )
-    expected_exception_msg = r".*?package org.pantsbuild.example.lib does not exist.*?"
-    with pytest.raises(ExecutionError, match=expected_exception_msg):
-        rule_runner.request(CompiledClassfiles, [compile_request])
+#     rule_runner.set_options(["--javac-jdk=bogusjdk:999"])
+#     expected_exception_msg = r".*?JVM bogusjdk:999 not found in index.*?"
+#     with pytest.raises(ExecutionError, match=expected_exception_msg):
+#         rule_runner.request(CompiledClassfiles, [request])
 
 
-def test_compile_with_maven_deps(rule_runner: RuleRunner) -> None:
-    resolved_joda_lockfile = CoursierResolvedLockfile(
-        entries=(
-            CoursierLockfileEntry(
-                coord=MavenCoord(coord="joda-time:joda-time:2.10.10"),
-                file_name="joda-time-2.10.10.jar",
-                direct_dependencies=MavenCoordinates([]),
-                dependencies=MavenCoordinates([]),
-                file_digest=FileDigest(
-                    fingerprint="dd8e7c92185a678d1b7b933f31209b6203c8ffa91e9880475a1be0346b9617e3",
-                    serialized_bytes_length=644419,
-                ),
-            ),
-        )
-    )
-    rule_runner.write_files(
-        {
-            "BUILD": dedent(
-                """\
-                coursier_lockfile(
-                    name = 'lockfile',
-                    maven_requirements = ["joda-time:joda-time:2.10.10"],
-                    sources = [
-                        "coursier_resolve.lockfile",
-                    ],
-                )
+# def test_compile_with_deps(rule_runner: RuleRunner) -> None:
+#     rule_runner.write_files(
+#         {
+#             "BUILD": dedent(
+#                 """\
+#                 coursier_lockfile(
+#                     name = 'lockfile',
+#                     maven_requirements = [],
+#                     sources = [
+#                         "coursier_resolve.lockfile",
+#                     ],
+#                 )
 
-                java_library(
-                    name = 'main',
-                    dependencies = [
-                        ':lockfile',
-                    ]
-                )
-                """
-            ),
-            "coursier_resolve.lockfile": resolved_joda_lockfile.to_json().decode("utf-8"),
-            "Example.java": dedent(
-                """
-                package org.pantsbuild.example;
+#                 java_library(
+#                     name = 'main',
+#                     dependencies = [
+#                         ':lockfile',
+#                         'lib:lib',
+#                     ]
+#                 )
+#                 """
+#             ),
+#             "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
+#             .to_json()
+#             .decode("utf-8"),
+#             "Example.java": JAVA_LIB_MAIN_SOURCE,
+#             "lib/BUILD": dedent(
+#                 """\
+#                 java_library(
+#                     name = 'lib',
+#                     dependencies = [
+#                         '//:lockfile',
+#                     ]
+#                 )
+#                 """
+#             ),
+#             "lib/ExampleLib.java": JAVA_LIB_SOURCE,
+#         }
+#     )
 
-                import org.joda.time.DateTime;
-
-                public class Example {
-                    public static void main(String[] args) {
-                        DateTime dt = new DateTime();
-                        System.out.println(dt.getYear());
-                    }
-                }
-                """
-            ),
-        }
-    )
-
-    compiled_classfiles = rule_runner.request(
-        CompiledClassfiles,
-        [
-            CompileJavaSourceRequest(
-                target=rule_runner.get_target(address=Address(spec_path="", target_name="main"))
-            )
-        ],
-    )
-    classfile_digest_contents = rule_runner.request(DigestContents, [compiled_classfiles.digest])
-    assert len(classfile_digest_contents) == 1
-    assert classfile_digest_contents[0].path == "org/pantsbuild/example/Example.class"
+#     compiled_classfiles = rule_runner.request(
+#         CompiledClassfiles,
+#         [
+#             CompileJavaSourceRequest(
+#                 target=rule_runner.get_target(address=Address(spec_path="", target_name="main"))
+#             )
+#         ],
+#     )
+#     classfile_digest_contents = rule_runner.request(DigestContents, [compiled_classfiles.digest])
+#     assert len(classfile_digest_contents) == 1
+#     assert classfile_digest_contents[0].path == "org/pantsbuild/example/Example.class"
 
 
-def test_compile_with_missing_maven_dep_fails(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files(
-        {
-            "BUILD": dedent(
-                """\
-                coursier_lockfile(
-                    name = 'lockfile',
-                    maven_requirements = [],
-                    sources = [
-                        "coursier_resolve.lockfile",
-                    ],
-                )
+# def test_compile_with_missing_dep_fails(rule_runner: RuleRunner) -> None:
+#     rule_runner.write_files(
+#         {
+#             "BUILD": dedent(
+#                 """\
+#                 coursier_lockfile(
+#                     name = 'lockfile',
+#                     maven_requirements = [],
+#                     sources = [
+#                         "coursier_resolve.lockfile",
+#                     ],
+#                 )
 
-                java_library(
-                    name = 'main',
-                    dependencies = [
-                        ':lockfile',
-                    ]
-                )
-                """
-            ),
-            "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
-            .to_json()
-            .decode("utf-8"),
-            "Example.java": dedent(
-                """
-                package org.pantsbuild.example;
+#                 java_library(
+#                     name = 'main',
+#                     dependencies = [
+#                         ':lockfile',
+#                     ]
+#                 )
+#                 """
+#             ),
+#             "Example.java": JAVA_LIB_MAIN_SOURCE,
+#             "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
+#             .to_json()
+#             .decode("utf-8"),
+#         }
+#     )
 
-                import org.joda.time.DateTime;
+#     compile_request = CompileJavaSourceRequest(
+#         target=rule_runner.get_target(address=Address(spec_path="", target_name="main"))
+#     )
+#     expected_exception_msg = r".*?package org.pantsbuild.example.lib does not exist.*?"
+#     with pytest.raises(ExecutionError, match=expected_exception_msg):
+#         rule_runner.request(CompiledClassfiles, [compile_request])
 
-                public class Example {
-                    public static void main(String[] args) {
-                        DateTime dt = new DateTime();
-                        System.out.println(dt.getYear());
-                    }
-                }
-                """
-            ),
-        }
-    )
 
-    compile_request = CompileJavaSourceRequest(
-        target=rule_runner.get_target(address=Address(spec_path="", target_name="main"))
-    )
-    expected_exception_msg = r".*?package org.joda.time does not exist.*?"
-    with pytest.raises(ExecutionError, match=expected_exception_msg):
-        rule_runner.request(CompiledClassfiles, [compile_request])
+# def test_compile_with_maven_deps(rule_runner: RuleRunner) -> None:
+#     resolved_joda_lockfile = CoursierResolvedLockfile(
+#         entries=(
+#             CoursierLockfileEntry(
+#                 coord=MavenCoord(coord="joda-time:joda-time:2.10.10"),
+#                 file_name="joda-time-2.10.10.jar",
+#                 direct_dependencies=MavenCoordinates([]),
+#                 dependencies=MavenCoordinates([]),
+#                 file_digest=FileDigest(
+#                     fingerprint="dd8e7c92185a678d1b7b933f31209b6203c8ffa91e9880475a1be0346b9617e3",
+#                     serialized_bytes_length=644419,
+#                 ),
+#             ),
+#         )
+#     )
+#     rule_runner.write_files(
+#         {
+#             "BUILD": dedent(
+#                 """\
+#                 coursier_lockfile(
+#                     name = 'lockfile',
+#                     maven_requirements = ["joda-time:joda-time:2.10.10"],
+#                     sources = [
+#                         "coursier_resolve.lockfile",
+#                     ],
+#                 )
+
+#                 java_library(
+#                     name = 'main',
+#                     dependencies = [
+#                         ':lockfile',
+#                     ]
+#                 )
+#                 """
+#             ),
+#             "coursier_resolve.lockfile": resolved_joda_lockfile.to_json().decode("utf-8"),
+#             "Example.java": dedent(
+#                 """
+#                 package org.pantsbuild.example;
+
+#                 import org.joda.time.DateTime;
+
+#                 public class Example {
+#                     public static void main(String[] args) {
+#                         DateTime dt = new DateTime();
+#                         System.out.println(dt.getYear());
+#                     }
+#                 }
+#                 """
+#             ),
+#         }
+#     )
+
+#     compiled_classfiles = rule_runner.request(
+#         CompiledClassfiles,
+#         [
+#             CompileJavaSourceRequest(
+#                 target=rule_runner.get_target(address=Address(spec_path="", target_name="main"))
+#             )
+#         ],
+#     )
+#     classfile_digest_contents = rule_runner.request(DigestContents, [compiled_classfiles.digest])
+#     assert len(classfile_digest_contents) == 1
+#     assert classfile_digest_contents[0].path == "org/pantsbuild/example/Example.class"
+
+
+# def test_compile_with_missing_maven_dep_fails(rule_runner: RuleRunner) -> None:
+#     rule_runner.write_files(
+#         {
+#             "BUILD": dedent(
+#                 """\
+#                 coursier_lockfile(
+#                     name = 'lockfile',
+#                     maven_requirements = [],
+#                     sources = [
+#                         "coursier_resolve.lockfile",
+#                     ],
+#                 )
+
+#                 java_library(
+#                     name = 'main',
+#                     dependencies = [
+#                         ':lockfile',
+#                     ]
+#                 )
+#                 """
+#             ),
+#             "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
+#             .to_json()
+#             .decode("utf-8"),
+#             "Example.java": dedent(
+#                 """
+#                 package org.pantsbuild.example;
+
+#                 import org.joda.time.DateTime;
+
+#                 public class Example {
+#                     public static void main(String[] args) {
+#                         DateTime dt = new DateTime();
+#                         System.out.println(dt.getYear());
+#                     }
+#                 }
+#                 """
+#             ),
+#         }
+#     )
+
+#     compile_request = CompileJavaSourceRequest(
+#         target=rule_runner.get_target(address=Address(spec_path="", target_name="main"))
+#     )
+#     expected_exception_msg = r".*?package org.joda.time does not exist.*?"
+#     with pytest.raises(ExecutionError, match=expected_exception_msg):
+#         rule_runner.request(CompiledClassfiles, [compile_request])

--- a/src/python/pants/backend/java/compile/javac_test.py
+++ b/src/python/pants/backend/java/compile/javac_test.py
@@ -1,380 +1,380 @@
-# # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
-# # Licensed under the Apache License, Version 2.0 (see LICENSE).
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-# from __future__ import annotations
+from __future__ import annotations
 
-# from textwrap import dedent
+from textwrap import dedent
 
-# import pytest
+import pytest
 
-# from pants.backend.java.compile.javac import CompiledClassfiles, CompileJavaSourceRequest
-# from pants.backend.java.compile.javac import rules as javac_rules
-# from pants.backend.java.compile.javac_binary import rules as javac_binary_rules
-# from pants.backend.java.target_types import JavaLibrary
-# from pants.build_graph.address import Address
-# from pants.core.util_rules import config_files, source_files
-# from pants.core.util_rules.external_tool import rules as external_tool_rules
-# from pants.engine.fs import DigestContents, FileDigest
-# from pants.engine.internals.scheduler import ExecutionError
-# from pants.jvm.resolve.coursier_fetch import (
-#     CoursierLockfileEntry,
-#     CoursierResolvedLockfile,
-#     MavenCoord,
-#     MavenCoordinates,
-# )
-# from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
-# from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
-# from pants.jvm.target_types import JvmDependencyLockfile
-# from pants.jvm.util_rules import rules as util_rules
-# from pants.testutil.rule_runner import QueryRule, RuleRunner
-
-
-# @pytest.fixture
-# def rule_runner() -> RuleRunner:
-#     return RuleRunner(
-#         rules=[
-#             *config_files.rules(),
-#             *coursier_fetch_rules(),
-#             *coursier_setup_rules(),
-#             *external_tool_rules(),
-#             *source_files.rules(),
-#             *javac_rules(),
-#             *util_rules(),
-#             *javac_binary_rules(),
-#             QueryRule(CompiledClassfiles, (CompileJavaSourceRequest,)),
-#         ],
-#         target_types=[JvmDependencyLockfile, JavaLibrary],
-#     )
+from pants.backend.java.compile.javac import CompiledClassfiles, CompileJavaSourceRequest
+from pants.backend.java.compile.javac import rules as javac_rules
+from pants.backend.java.compile.javac_binary import rules as javac_binary_rules
+from pants.backend.java.target_types import JavaLibrary
+from pants.build_graph.address import Address
+from pants.core.util_rules import config_files, source_files
+from pants.core.util_rules.external_tool import rules as external_tool_rules
+from pants.engine.fs import DigestContents, FileDigest
+from pants.engine.internals.scheduler import ExecutionError
+from pants.jvm.resolve.coursier_fetch import (
+    CoursierLockfileEntry,
+    CoursierResolvedLockfile,
+    MavenCoord,
+    MavenCoordinates,
+)
+from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
+from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
+from pants.jvm.target_types import JvmDependencyLockfile
+from pants.jvm.util_rules import rules as util_rules
+from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
-# JAVA_LIB_SOURCE = dedent(
-#     """
-#     package org.pantsbuild.example.lib;
-
-#     public class ExampleLib {
-#         public static String hello() {
-#             return "Hello!";
-#         }
-#     }
-#     """
-# )
-
-# JAVA_LIB_MAIN_SOURCE = dedent(
-#     """
-#     package org.pantsbuild.example;
-
-#     import org.pantsbuild.example.lib.ExampleLib;
-
-#     public class Example {
-#         public static void main(String[] args) {
-#             System.out.println(ExampleLib.hello());
-#         }
-#     }
-#     """
-# )
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *config_files.rules(),
+            *coursier_fetch_rules(),
+            *coursier_setup_rules(),
+            *external_tool_rules(),
+            *source_files.rules(),
+            *javac_rules(),
+            *util_rules(),
+            *javac_binary_rules(),
+            QueryRule(CompiledClassfiles, (CompileJavaSourceRequest,)),
+        ],
+        target_types=[JvmDependencyLockfile, JavaLibrary],
+    )
 
 
-# def test_compile_no_deps(rule_runner: RuleRunner) -> None:
-#     rule_runner.write_files(
-#         {
-#             "BUILD": dedent(
-#                 """\
-#                 coursier_lockfile(
-#                     name = 'lockfile',
-#                     maven_requirements = [],
-#                     sources = [
-#                         "coursier_resolve.lockfile",
-#                     ],
-#                 )
+JAVA_LIB_SOURCE = dedent(
+    """
+    package org.pantsbuild.example.lib;
 
-#                 java_library(
-#                     name = 'lib',
-#                     dependencies = [
-#                         ':lockfile',
-#                     ]
-#                 )
-#                 """
-#             ),
-#             "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
-#             .to_json()
-#             .decode("utf-8"),
-#             "ExampleLib.java": JAVA_LIB_SOURCE,
-#         }
-#     )
+    public class ExampleLib {
+        public static String hello() {
+            return "Hello!";
+        }
+    }
+    """
+)
 
-#     compiled_classfiles = rule_runner.request(
-#         CompiledClassfiles,
-#         [
-#             CompileJavaSourceRequest(
-#                 target=rule_runner.get_target(address=Address(spec_path="", target_name="lib"))
-#             )
-#         ],
-#     )
-#     classfile_digest_contents = rule_runner.request(DigestContents, [compiled_classfiles.digest])
-#     assert len(classfile_digest_contents) == 1
-#     assert classfile_digest_contents[0].path == "org/pantsbuild/example/lib/ExampleLib.class"
+JAVA_LIB_MAIN_SOURCE = dedent(
+    """
+    package org.pantsbuild.example;
+
+    import org.pantsbuild.example.lib.ExampleLib;
+
+    public class Example {
+        public static void main(String[] args) {
+            System.out.println(ExampleLib.hello());
+        }
+    }
+    """
+)
 
 
-# def test_compile_jdk_versions(rule_runner: RuleRunner) -> None:
-#     rule_runner.write_files(
-#         {
-#             "BUILD": dedent(
-#                 """\
-#                 coursier_lockfile(
-#                     name = 'lockfile',
-#                     maven_requirements = [],
-#                     sources = [
-#                         "coursier_resolve.lockfile",
-#                     ],
-#                 )
+def test_compile_no_deps(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                """\
+                coursier_lockfile(
+                    name = 'lockfile',
+                    maven_requirements = [],
+                    sources = [
+                        "coursier_resolve.lockfile",
+                    ],
+                )
 
-#                 java_library(
-#                     name = 'lib',
-#                     dependencies = [
-#                         ':lockfile',
-#                     ]
-#                 )
-#                 """
-#             ),
-#             "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
-#             .to_json()
-#             .decode("utf-8"),
-#             "ExampleLib.java": JAVA_LIB_SOURCE,
-#         }
-#     )
-#     request = CompileJavaSourceRequest(
-#         target=rule_runner.get_target(address=Address(spec_path="", target_name="lib"))
-#     )
+                java_library(
+                    name = 'lib',
+                    dependencies = [
+                        ':lockfile',
+                    ]
+                )
+                """
+            ),
+            "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
+            .to_json()
+            .decode("utf-8"),
+            "ExampleLib.java": JAVA_LIB_SOURCE,
+        }
+    )
 
-#     rule_runner.set_options(["--javac-jdk=openjdk:1.16.0-1"])
-#     assert {
-#         contents.path
-#         for contents in rule_runner.request(
-#             DigestContents, [rule_runner.request(CompiledClassfiles, [request]).digest]
-#         )
-#     } == {"org/pantsbuild/example/lib/ExampleLib.class"}
-
-#     rule_runner.set_options(["--javac-jdk=adopt:1.8"])
-#     assert {
-#         contents.path
-#         for contents in rule_runner.request(
-#             DigestContents, [rule_runner.request(CompiledClassfiles, [request]).digest]
-#         )
-#     } == {"org/pantsbuild/example/lib/ExampleLib.class"}
-
-#     rule_runner.set_options(["--javac-jdk=zulu:1.6"])
-#     assert {
-#         contents.path
-#         for contents in rule_runner.request(
-#             DigestContents, [rule_runner.request(CompiledClassfiles, [request]).digest]
-#         )
-#     } == {"org/pantsbuild/example/lib/ExampleLib.class"}
-
-#     rule_runner.set_options(["--javac-jdk=bogusjdk:999"])
-#     expected_exception_msg = r".*?JVM bogusjdk:999 not found in index.*?"
-#     with pytest.raises(ExecutionError, match=expected_exception_msg):
-#         rule_runner.request(CompiledClassfiles, [request])
+    compiled_classfiles = rule_runner.request(
+        CompiledClassfiles,
+        [
+            CompileJavaSourceRequest(
+                target=rule_runner.get_target(address=Address(spec_path="", target_name="lib"))
+            )
+        ],
+    )
+    classfile_digest_contents = rule_runner.request(DigestContents, [compiled_classfiles.digest])
+    assert len(classfile_digest_contents) == 1
+    assert classfile_digest_contents[0].path == "org/pantsbuild/example/lib/ExampleLib.class"
 
 
-# def test_compile_with_deps(rule_runner: RuleRunner) -> None:
-#     rule_runner.write_files(
-#         {
-#             "BUILD": dedent(
-#                 """\
-#                 coursier_lockfile(
-#                     name = 'lockfile',
-#                     maven_requirements = [],
-#                     sources = [
-#                         "coursier_resolve.lockfile",
-#                     ],
-#                 )
+def test_compile_jdk_versions(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                """\
+                coursier_lockfile(
+                    name = 'lockfile',
+                    maven_requirements = [],
+                    sources = [
+                        "coursier_resolve.lockfile",
+                    ],
+                )
 
-#                 java_library(
-#                     name = 'main',
-#                     dependencies = [
-#                         ':lockfile',
-#                         'lib:lib',
-#                     ]
-#                 )
-#                 """
-#             ),
-#             "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
-#             .to_json()
-#             .decode("utf-8"),
-#             "Example.java": JAVA_LIB_MAIN_SOURCE,
-#             "lib/BUILD": dedent(
-#                 """\
-#                 java_library(
-#                     name = 'lib',
-#                     dependencies = [
-#                         '//:lockfile',
-#                     ]
-#                 )
-#                 """
-#             ),
-#             "lib/ExampleLib.java": JAVA_LIB_SOURCE,
-#         }
-#     )
+                java_library(
+                    name = 'lib',
+                    dependencies = [
+                        ':lockfile',
+                    ]
+                )
+                """
+            ),
+            "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
+            .to_json()
+            .decode("utf-8"),
+            "ExampleLib.java": JAVA_LIB_SOURCE,
+        }
+    )
+    request = CompileJavaSourceRequest(
+        target=rule_runner.get_target(address=Address(spec_path="", target_name="lib"))
+    )
 
-#     compiled_classfiles = rule_runner.request(
-#         CompiledClassfiles,
-#         [
-#             CompileJavaSourceRequest(
-#                 target=rule_runner.get_target(address=Address(spec_path="", target_name="main"))
-#             )
-#         ],
-#     )
-#     classfile_digest_contents = rule_runner.request(DigestContents, [compiled_classfiles.digest])
-#     assert len(classfile_digest_contents) == 1
-#     assert classfile_digest_contents[0].path == "org/pantsbuild/example/Example.class"
+    rule_runner.set_options(["--javac-jdk=openjdk:1.16.0-1"])
+    assert {
+        contents.path
+        for contents in rule_runner.request(
+            DigestContents, [rule_runner.request(CompiledClassfiles, [request]).digest]
+        )
+    } == {"org/pantsbuild/example/lib/ExampleLib.class"}
 
+    rule_runner.set_options(["--javac-jdk=adopt:1.8"])
+    assert {
+        contents.path
+        for contents in rule_runner.request(
+            DigestContents, [rule_runner.request(CompiledClassfiles, [request]).digest]
+        )
+    } == {"org/pantsbuild/example/lib/ExampleLib.class"}
 
-# def test_compile_with_missing_dep_fails(rule_runner: RuleRunner) -> None:
-#     rule_runner.write_files(
-#         {
-#             "BUILD": dedent(
-#                 """\
-#                 coursier_lockfile(
-#                     name = 'lockfile',
-#                     maven_requirements = [],
-#                     sources = [
-#                         "coursier_resolve.lockfile",
-#                     ],
-#                 )
+    rule_runner.set_options(["--javac-jdk=zulu:1.6"])
+    assert {
+        contents.path
+        for contents in rule_runner.request(
+            DigestContents, [rule_runner.request(CompiledClassfiles, [request]).digest]
+        )
+    } == {"org/pantsbuild/example/lib/ExampleLib.class"}
 
-#                 java_library(
-#                     name = 'main',
-#                     dependencies = [
-#                         ':lockfile',
-#                     ]
-#                 )
-#                 """
-#             ),
-#             "Example.java": JAVA_LIB_MAIN_SOURCE,
-#             "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
-#             .to_json()
-#             .decode("utf-8"),
-#         }
-#     )
-
-#     compile_request = CompileJavaSourceRequest(
-#         target=rule_runner.get_target(address=Address(spec_path="", target_name="main"))
-#     )
-#     expected_exception_msg = r".*?package org.pantsbuild.example.lib does not exist.*?"
-#     with pytest.raises(ExecutionError, match=expected_exception_msg):
-#         rule_runner.request(CompiledClassfiles, [compile_request])
+    rule_runner.set_options(["--javac-jdk=bogusjdk:999"])
+    expected_exception_msg = r".*?JVM bogusjdk:999 not found in index.*?"
+    with pytest.raises(ExecutionError, match=expected_exception_msg):
+        rule_runner.request(CompiledClassfiles, [request])
 
 
-# def test_compile_with_maven_deps(rule_runner: RuleRunner) -> None:
-#     resolved_joda_lockfile = CoursierResolvedLockfile(
-#         entries=(
-#             CoursierLockfileEntry(
-#                 coord=MavenCoord(coord="joda-time:joda-time:2.10.10"),
-#                 file_name="joda-time-2.10.10.jar",
-#                 direct_dependencies=MavenCoordinates([]),
-#                 dependencies=MavenCoordinates([]),
-#                 file_digest=FileDigest(
-#                     fingerprint="dd8e7c92185a678d1b7b933f31209b6203c8ffa91e9880475a1be0346b9617e3",
-#                     serialized_bytes_length=644419,
-#                 ),
-#             ),
-#         )
-#     )
-#     rule_runner.write_files(
-#         {
-#             "BUILD": dedent(
-#                 """\
-#                 coursier_lockfile(
-#                     name = 'lockfile',
-#                     maven_requirements = ["joda-time:joda-time:2.10.10"],
-#                     sources = [
-#                         "coursier_resolve.lockfile",
-#                     ],
-#                 )
+def test_compile_with_deps(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                """\
+                coursier_lockfile(
+                    name = 'lockfile',
+                    maven_requirements = [],
+                    sources = [
+                        "coursier_resolve.lockfile",
+                    ],
+                )
 
-#                 java_library(
-#                     name = 'main',
-#                     dependencies = [
-#                         ':lockfile',
-#                     ]
-#                 )
-#                 """
-#             ),
-#             "coursier_resolve.lockfile": resolved_joda_lockfile.to_json().decode("utf-8"),
-#             "Example.java": dedent(
-#                 """
-#                 package org.pantsbuild.example;
+                java_library(
+                    name = 'main',
+                    dependencies = [
+                        ':lockfile',
+                        'lib:lib',
+                    ]
+                )
+                """
+            ),
+            "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
+            .to_json()
+            .decode("utf-8"),
+            "Example.java": JAVA_LIB_MAIN_SOURCE,
+            "lib/BUILD": dedent(
+                """\
+                java_library(
+                    name = 'lib',
+                    dependencies = [
+                        '//:lockfile',
+                    ]
+                )
+                """
+            ),
+            "lib/ExampleLib.java": JAVA_LIB_SOURCE,
+        }
+    )
 
-#                 import org.joda.time.DateTime;
-
-#                 public class Example {
-#                     public static void main(String[] args) {
-#                         DateTime dt = new DateTime();
-#                         System.out.println(dt.getYear());
-#                     }
-#                 }
-#                 """
-#             ),
-#         }
-#     )
-
-#     compiled_classfiles = rule_runner.request(
-#         CompiledClassfiles,
-#         [
-#             CompileJavaSourceRequest(
-#                 target=rule_runner.get_target(address=Address(spec_path="", target_name="main"))
-#             )
-#         ],
-#     )
-#     classfile_digest_contents = rule_runner.request(DigestContents, [compiled_classfiles.digest])
-#     assert len(classfile_digest_contents) == 1
-#     assert classfile_digest_contents[0].path == "org/pantsbuild/example/Example.class"
+    compiled_classfiles = rule_runner.request(
+        CompiledClassfiles,
+        [
+            CompileJavaSourceRequest(
+                target=rule_runner.get_target(address=Address(spec_path="", target_name="main"))
+            )
+        ],
+    )
+    classfile_digest_contents = rule_runner.request(DigestContents, [compiled_classfiles.digest])
+    assert len(classfile_digest_contents) == 1
+    assert classfile_digest_contents[0].path == "org/pantsbuild/example/Example.class"
 
 
-# def test_compile_with_missing_maven_dep_fails(rule_runner: RuleRunner) -> None:
-#     rule_runner.write_files(
-#         {
-#             "BUILD": dedent(
-#                 """\
-#                 coursier_lockfile(
-#                     name = 'lockfile',
-#                     maven_requirements = [],
-#                     sources = [
-#                         "coursier_resolve.lockfile",
-#                     ],
-#                 )
+def test_compile_with_missing_dep_fails(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                """\
+                coursier_lockfile(
+                    name = 'lockfile',
+                    maven_requirements = [],
+                    sources = [
+                        "coursier_resolve.lockfile",
+                    ],
+                )
 
-#                 java_library(
-#                     name = 'main',
-#                     dependencies = [
-#                         ':lockfile',
-#                     ]
-#                 )
-#                 """
-#             ),
-#             "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
-#             .to_json()
-#             .decode("utf-8"),
-#             "Example.java": dedent(
-#                 """
-#                 package org.pantsbuild.example;
+                java_library(
+                    name = 'main',
+                    dependencies = [
+                        ':lockfile',
+                    ]
+                )
+                """
+            ),
+            "Example.java": JAVA_LIB_MAIN_SOURCE,
+            "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
+            .to_json()
+            .decode("utf-8"),
+        }
+    )
 
-#                 import org.joda.time.DateTime;
+    compile_request = CompileJavaSourceRequest(
+        target=rule_runner.get_target(address=Address(spec_path="", target_name="main"))
+    )
+    expected_exception_msg = r".*?package org.pantsbuild.example.lib does not exist.*?"
+    with pytest.raises(ExecutionError, match=expected_exception_msg):
+        rule_runner.request(CompiledClassfiles, [compile_request])
 
-#                 public class Example {
-#                     public static void main(String[] args) {
-#                         DateTime dt = new DateTime();
-#                         System.out.println(dt.getYear());
-#                     }
-#                 }
-#                 """
-#             ),
-#         }
-#     )
 
-#     compile_request = CompileJavaSourceRequest(
-#         target=rule_runner.get_target(address=Address(spec_path="", target_name="main"))
-#     )
-#     expected_exception_msg = r".*?package org.joda.time does not exist.*?"
-#     with pytest.raises(ExecutionError, match=expected_exception_msg):
-#         rule_runner.request(CompiledClassfiles, [compile_request])
+def test_compile_with_maven_deps(rule_runner: RuleRunner) -> None:
+    resolved_joda_lockfile = CoursierResolvedLockfile(
+        entries=(
+            CoursierLockfileEntry(
+                coord=MavenCoord(coord="joda-time:joda-time:2.10.10"),
+                file_name="joda-time-2.10.10.jar",
+                direct_dependencies=MavenCoordinates([]),
+                dependencies=MavenCoordinates([]),
+                file_digest=FileDigest(
+                    fingerprint="dd8e7c92185a678d1b7b933f31209b6203c8ffa91e9880475a1be0346b9617e3",
+                    serialized_bytes_length=644419,
+                ),
+            ),
+        )
+    )
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                """\
+                coursier_lockfile(
+                    name = 'lockfile',
+                    maven_requirements = ["joda-time:joda-time:2.10.10"],
+                    sources = [
+                        "coursier_resolve.lockfile",
+                    ],
+                )
+
+                java_library(
+                    name = 'main',
+                    dependencies = [
+                        ':lockfile',
+                    ]
+                )
+                """
+            ),
+            "coursier_resolve.lockfile": resolved_joda_lockfile.to_json().decode("utf-8"),
+            "Example.java": dedent(
+                """
+                package org.pantsbuild.example;
+
+                import org.joda.time.DateTime;
+
+                public class Example {
+                    public static void main(String[] args) {
+                        DateTime dt = new DateTime();
+                        System.out.println(dt.getYear());
+                    }
+                }
+                """
+            ),
+        }
+    )
+
+    compiled_classfiles = rule_runner.request(
+        CompiledClassfiles,
+        [
+            CompileJavaSourceRequest(
+                target=rule_runner.get_target(address=Address(spec_path="", target_name="main"))
+            )
+        ],
+    )
+    classfile_digest_contents = rule_runner.request(DigestContents, [compiled_classfiles.digest])
+    assert len(classfile_digest_contents) == 1
+    assert classfile_digest_contents[0].path == "org/pantsbuild/example/Example.class"
+
+
+def test_compile_with_missing_maven_dep_fails(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                """\
+                coursier_lockfile(
+                    name = 'lockfile',
+                    maven_requirements = [],
+                    sources = [
+                        "coursier_resolve.lockfile",
+                    ],
+                )
+
+                java_library(
+                    name = 'main',
+                    dependencies = [
+                        ':lockfile',
+                    ]
+                )
+                """
+            ),
+            "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
+            .to_json()
+            .decode("utf-8"),
+            "Example.java": dedent(
+                """
+                package org.pantsbuild.example;
+
+                import org.joda.time.DateTime;
+
+                public class Example {
+                    public static void main(String[] args) {
+                        DateTime dt = new DateTime();
+                        System.out.println(dt.getYear());
+                    }
+                }
+                """
+            ),
+        }
+    )
+
+    compile_request = CompileJavaSourceRequest(
+        target=rule_runner.get_target(address=Address(spec_path="", target_name="main"))
+    )
+    expected_exception_msg = r".*?package org.joda.time does not exist.*?"
+    with pytest.raises(ExecutionError, match=expected_exception_msg):
+        rule_runner.request(CompiledClassfiles, [compile_request])

--- a/src/python/pants/jvm/resolve/coursier_setup.py
+++ b/src/python/pants/jvm/resolve/coursier_setup.py
@@ -52,19 +52,6 @@ COURSIER_WRAPPER_SCRIPT = textwrap.dedent(
     """
 )
 
-JAVAC_WRAPPER_SCRIPT = textwrap.dedent(
-    """\
-    set -eux
-
-    coursier_exe="$1"
-    shift
-
-    javac_path="$(${coursier_exe} java-home --jvm openjdk:1.9.0-4)/bin/javac"
-
-    exec "${javac_path}" "$@"
-    """
-)
-
 
 class CoursierBinary(TemplatedExternalTool):
     options_scope = "coursier"
@@ -89,7 +76,6 @@ class Coursier:
     digest: Digest
     wrapper_script: ClassVar[str] = "coursier_wrapper_script.sh"
     post_processing_script: ClassVar[str] = "coursier_post_processing_script.py"
-    javac: ClassVar[str] = "coursier_javac.sh"
 
 
 @rule
@@ -109,11 +95,6 @@ async def setup_coursier(coursier_binary: CoursierBinary) -> Coursier:
                 FileContent(
                     Coursier.post_processing_script,
                     COURSIER_POST_PROCESSING_SCRIPT.encode("utf-8"),
-                    is_executable=True,
-                ),
-                FileContent(
-                    Coursier.javac,
-                    JAVAC_WRAPPER_SCRIPT.encode("utf-8"),
                     is_executable=True,
                 ),
             ]


### PR DESCRIPTION
This commit adds support for user-configured JVM versions for `javac`.  It also splits `JavacBinary` out from `Coursier` to more cleanly separate Coursier's resolve responsibilities from its ability to do generic JVM selection and downloading.

Added tests confirm that existing javac support works for a variety of JVM distributions ranging from 1.8 to 1.16.

# Rust tests and lints will be skipped. Delete if not intended.
[ci skip-rust]

# Building wheels and fs_util will be skipped. Delete if not intended.
[ci skip-build-wheels]