### PR TITLE
Include experimental Go backends in pantsbuild.pants

### DIFF
--- a/src/python/pants/init/BUILD
+++ b/src/python/pants/init/BUILD
@@ -8,6 +8,8 @@ target(
   dependencies=[
     'src/python/pants/backend/awslambda/python',
     'src/python/pants/backend/codegen/protobuf/python',
+    'src/python/pants/backend/experimental/go',
+    'src/python/pants/backend/experimental/go/lint/gofmt',
     'src/python/pants/backend/project_info',
     'src/python/pants/backend/python',
     'src/python/pants/backend/python/lint/bandit',


### PR DESCRIPTION
Without this, the code is not actually bundled in the wheel.

[ci skip-rust]
[ci skip-build-wheels]