### PR TITLE
Include experimental Go backends in pantsbuild.pants (Cherry-pick of #12290)

### DIFF
--- a/src/python/pants/init/BUILD
+++ b/src/python/pants/init/BUILD
@@ -8,6 +8,8 @@ target(
   dependencies=[
     'src/python/pants/backend/awslambda/python',
     'src/python/pants/backend/codegen/protobuf/python',
+    'src/python/pants/backend/experimental/go',
+    'src/python/pants/backend/experimental/go/lint/gofmt',
     'src/python/pants/backend/project_info',
     'src/python/pants/backend/python',
     'src/python/pants/backend/python/lint/bandit',


### PR DESCRIPTION
[ci skip-rust]
[ci skip-build-wheels]