### PR TITLE
Shifted to BuiltinGoal from HelpRequest

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -32,8 +32,8 @@ from pants.help.help_printer import HelpPrinter
 from pants.init.engine_initializer import EngineInitializer, GraphScheduler, GraphSession
 from pants.init.options_initializer import OptionsInitializer
 from pants.init.specs_calculator import calculate_specs
-from pants.option.arg_splitter import HelpRequest
 from pants.option.global_options import DynamicRemoteOptions
+from pants.option.native_goal_request import NativeGoalRequest
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.util.contextutil import maybe_profiled
@@ -198,7 +198,7 @@ class LocalPantsRunner:
     def _finish_run(self, code: ExitCode) -> None:
         """Cleans up the run tracker."""
 
-    def _print_help(self, request: HelpRequest) -> ExitCode:
+    def _print_help(self, request: NativeGoalRequest) -> ExitCode:
         global_options = self.options.for_global_scope()
 
         all_help_info = HelpInfoExtracter.get_all_help_info(

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -33,7 +33,7 @@ from pants.init.engine_initializer import EngineInitializer, GraphScheduler, Gra
 from pants.init.options_initializer import OptionsInitializer
 from pants.init.specs_calculator import calculate_specs
 from pants.option.global_options import DynamicRemoteOptions
-from pants.option.native_goal_request import NativeGoalRequest
+from pants.goal.builtin_goal import BuiltinGoal
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.util.contextutil import maybe_profiled
@@ -198,7 +198,7 @@ class LocalPantsRunner:
     def _finish_run(self, code: ExitCode) -> None:
         """Cleans up the run tracker."""
 
-    def _print_help(self, request: NativeGoalRequest) -> ExitCode:
+    def _print_help(self, request: BuiltinGoal) -> ExitCode:
         global_options = self.options.for_global_scope()
 
         all_help_info = HelpInfoExtracter.get_all_help_info(
@@ -209,7 +209,7 @@ class LocalPantsRunner:
         )
         help_printer = HelpPrinter(
             bin_name=global_options.pants_bin_name,
-            help_request=request,
+            builtin_goal=request,
             all_help_info=all_help_info,
             color=global_options.colors,
         )
@@ -225,7 +225,7 @@ class LocalPantsRunner:
 
     def _run_inner(self) -> ExitCode:
         goals = tuple(self.options.goals)
-        if self.options.help_request:
+        if self.options.builtin_goal:
             return self._print_help(self.options.help_request)
         if not goals:
             return PANTS_SUCCEEDED_EXIT_CODE

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -26,6 +26,7 @@ from pants.engine.streaming_workunit_handler import (
 )
 from pants.engine.target import RegisteredTargetTypes
 from pants.engine.unions import UnionMembership
+from pants.goal.builtin_goal import BuiltinGoal
 from pants.goal.run_tracker import RunTracker
 from pants.help.help_info_extracter import HelpInfoExtracter
 from pants.help.help_printer import HelpPrinter
@@ -33,7 +34,6 @@ from pants.init.engine_initializer import EngineInitializer, GraphScheduler, Gra
 from pants.init.options_initializer import OptionsInitializer
 from pants.init.specs_calculator import calculate_specs
 from pants.option.global_options import DynamicRemoteOptions
-from pants.goal.builtin_goal import BuiltinGoal
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.util.contextutil import maybe_profiled
@@ -226,7 +226,7 @@ class LocalPantsRunner:
     def _run_inner(self) -> ExitCode:
         goals = tuple(self.options.goals)
         if self.options.builtin_goal:
-            return self._print_help(self.options.help_request)
+            return self._print_help(self.options.builtin_goal)
         if not goals:
             return PANTS_SUCCEEDED_EXIT_CODE
 

--- a/src/python/pants/goal/builtin_goal.py
+++ b/src/python/pants/goal/builtin_goal.py
@@ -4,5 +4,5 @@
 from abc import ABC
 
 
-class NativeGoalRequest(ABC):
-    """Represents an implicit or explicit request for help by the user."""
+class BuiltinGoal(ABC):
+    """A goal built-in to pants rather than using the Plugin API."""

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -13,14 +13,8 @@ from pants.base.build_environment import pants_version
 from pants.help.help_formatter import HelpFormatter
 from pants.help.help_info_extracter import AllHelpInfo, HelpJSONEncoder
 from pants.help.maybe_color import MaybeColor
-from pants.option.arg_splitter import (
-    AllHelp,
-    HelpRequest,
-    NoGoalHelp,
-    ThingHelp,
-    UnknownGoalHelp,
-    VersionHelp,
-)
+from pants.option.arg_splitter import AllHelp, NoGoalHelp, ThingHelp, UnknownGoalHelp, VersionHelp
+from pants.option.native_goal_request import NativeGoalRequest
 from pants.option.scope import GLOBAL_SCOPE
 from pants.util.docutil import terminal_width
 from pants.util.strutil import first_paragraph, hard_wrap
@@ -33,7 +27,7 @@ class HelpPrinter(MaybeColor):
         self,
         *,
         bin_name: str,
-        help_request: HelpRequest,
+        help_request: NativeGoalRequest,
         all_help_info: AllHelpInfo,
         color: bool,
     ) -> None:

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -10,11 +10,11 @@ from typing import Dict, cast
 from typing_extensions import Literal
 
 from pants.base.build_environment import pants_version
+from pants.goal.builtin_goal import BuiltinGoal
 from pants.help.help_formatter import HelpFormatter
 from pants.help.help_info_extracter import AllHelpInfo, HelpJSONEncoder
 from pants.help.maybe_color import MaybeColor
 from pants.option.arg_splitter import AllHelp, NoGoalHelp, ThingHelp, UnknownGoalHelp, VersionHelp
-from pants.goal.builtin_goal import BuiltinGoal
 from pants.option.scope import GLOBAL_SCOPE
 from pants.util.docutil import terminal_width
 from pants.util.strutil import first_paragraph, hard_wrap

--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -3,11 +3,11 @@
 
 import dataclasses
 import os.path
-from abc import ABC
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
+from pants.option.native_goal_request import NativeGoalRequest
 from pants.option.scope import GLOBAL_SCOPE, ScopeInfo
 from pants.util.ordered_set import OrderedSet
 
@@ -26,34 +26,30 @@ class SplitArgs:
     passthru: List[str]  # Any remaining args specified after a -- separator.
 
 
-class HelpRequest(ABC):
-    """Represents an implicit or explicit request for help by the user."""
-
-
 @dataclass(frozen=True)
-class ThingHelp(HelpRequest):
+class ThingHelp(NativeGoalRequest):
     """The user requested help on one or more things: e.g., an options scope or a target type."""
 
     advanced: bool = False
     things: Tuple[str, ...] = ()
 
 
-class VersionHelp(HelpRequest):
+class VersionHelp(NativeGoalRequest):
     """The user asked for the version of this instance of pants."""
 
 
-class AllHelp(HelpRequest):
+class AllHelp(NativeGoalRequest):
     """The user requested a dump of all help info."""
 
 
 @dataclass(frozen=True)
-class UnknownGoalHelp(HelpRequest):
+class UnknownGoalHelp(NativeGoalRequest):
     """The user specified an unknown goal (or task)."""
 
     unknown_goals: Tuple[str, ...]
 
 
-class NoGoalHelp(HelpRequest):
+class NoGoalHelp(NativeGoalRequest):
     """The user specified no goals."""
 
 
@@ -94,7 +90,7 @@ class ArgSplitter:
             str
         ] = []  # In reverse order, for efficient popping off the end.
         self._help_request: Optional[
-            HelpRequest
+            NativeGoalRequest
         ] = None  # Will be set if we encounter any help flags.
 
         # For convenience, and for historical reasons, we allow --scope-flag-name anywhere on the
@@ -113,7 +109,7 @@ class ArgSplitter:
         ]
 
     @property
-    def help_request(self) -> Optional[HelpRequest]:
+    def help_request(self) -> Optional[NativeGoalRequest]:
         return self._help_request
 
     def _check_for_help_request(self, arg: str) -> bool:

--- a/src/python/pants/option/arg_splitter_test.py
+++ b/src/python/pants/option/arg_splitter_test.py
@@ -52,18 +52,18 @@ class ArgSplitterTest(unittest.TestCase):
         assert expected_scope_to_flags == split_args.scope_to_flags
         assert expected_specs == split_args.specs
         assert expected_passthru == split_args.passthru
-        assert expected_is_help == (splitter.help_request is not None)
+        assert expected_is_help == (splitter.builtin_goal is not None)
         assert expected_help_advanced == (
-            isinstance(splitter.help_request, ThingHelp) and splitter.help_request.advanced
+            isinstance(splitter.builtin_goal, ThingHelp) and splitter.builtin_goal.advanced
         )
-        assert expected_help_all == isinstance(splitter.help_request, AllHelp)
+        assert expected_help_all == isinstance(splitter.builtin_goal, AllHelp)
 
     @staticmethod
     def assert_unknown_goal(args_str: str, unknown_goals: List[str]) -> None:
         splitter = ArgSplitter(ArgSplitterTest._known_scope_infos, buildroot=os.getcwd())
         splitter.split_args(shlex.split(args_str))
-        assert isinstance(splitter.help_request, UnknownGoalHelp)
-        assert set(unknown_goals) == set(splitter.help_request.unknown_goals)
+        assert isinstance(splitter.builtin_goal, UnknownGoalHelp)
+        assert set(unknown_goals) == set(splitter.builtin_goal.unknown_goals)
 
     def test_is_spec(self) -> None:
         unambiguous_specs = [
@@ -366,7 +366,7 @@ class ArgSplitterTest(unittest.TestCase):
         def assert_version_request(args_str: str) -> None:
             splitter = ArgSplitter(ArgSplitterTest._known_scope_infos, buildroot=os.getcwd())
             splitter.split_args(shlex.split(args_str))
-            self.assertTrue(isinstance(splitter.help_request, VersionHelp))
+            self.assertTrue(isinstance(splitter.builtin_goal, VersionHelp))
 
         assert_version_request("./pants -v")
         assert_version_request("./pants -V")
@@ -383,4 +383,4 @@ class ArgSplitterTest(unittest.TestCase):
     def test_no_goal_detection(self) -> None:
         splitter = ArgSplitter(ArgSplitterTest._known_scope_infos, buildroot=os.getcwd())
         splitter.split_args(shlex.split("./pants foo/bar:baz"))
-        self.assertTrue(isinstance(splitter.help_request, NoGoalHelp))
+        self.assertTrue(isinstance(splitter.builtin_goal, NoGoalHelp))

--- a/src/python/pants/option/native_goal_request.py
+++ b/src/python/pants/option/native_goal_request.py
@@ -1,0 +1,8 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from abc import ABC
+
+
+class NativeGoalRequest(ABC):
+    """Represents an implicit or explicit request for help by the user."""

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -9,8 +9,9 @@ from typing import Dict, Iterable, List, Mapping, Optional, Sequence
 
 from pants.base.build_environment import get_buildroot
 from pants.base.deprecated import warn_or_error
-from pants.option.arg_splitter import ArgSplitter, HelpRequest
+from pants.option.arg_splitter import ArgSplitter
 from pants.option.config import Config
+from pants.option.native_goal_request import NativeGoalRequest
 from pants.option.option_util import is_list_option
 from pants.option.option_value_container import OptionValueContainer, OptionValueContainerBuilder
 from pants.option.parser import Parser
@@ -172,7 +173,7 @@ class Options:
         scope_to_flags: Dict[str, List[str]],
         specs: List[str],
         passthru: List[str],
-        help_request: Optional[HelpRequest],
+        help_request: Optional[NativeGoalRequest],
         parser_hierarchy: ParserHierarchy,
         bootstrap_option_values: Optional[OptionValueContainer],
         known_scope_to_info: Dict[str, ScopeInfo],
@@ -200,7 +201,7 @@ class Options:
         return self._frozen
 
     @property
-    def help_request(self) -> Optional[HelpRequest]:
+    def help_request(self) -> Optional[NativeGoalRequest]:
         """
         :API: public
         """

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -11,7 +11,7 @@ from pants.base.build_environment import get_buildroot
 from pants.base.deprecated import warn_or_error
 from pants.option.arg_splitter import ArgSplitter
 from pants.option.config import Config
-from pants.option.native_goal_request import NativeGoalRequest
+from pants.goal.builtin_goal import BuiltinGoal
 from pants.option.option_util import is_list_option
 from pants.option.option_value_container import OptionValueContainer, OptionValueContainerBuilder
 from pants.option.parser import Parser
@@ -151,7 +151,7 @@ class Options:
                             [line for line in [line.strip() for line in f] if line]
                         )
 
-        help_request = splitter.help_request
+        builtin_goal = splitter.builtin_goal
 
         parser_hierarchy = ParserHierarchy(env, config, complete_known_scope_infos)
         known_scope_to_info = {s.scope: s for s in complete_known_scope_infos}
@@ -160,7 +160,7 @@ class Options:
             scope_to_flags=split_args.scope_to_flags,
             specs=split_args.specs,
             passthru=split_args.passthru,
-            help_request=help_request,
+            builtin_goal=builtin_goal,
             parser_hierarchy=parser_hierarchy,
             bootstrap_option_values=bootstrap_option_values,
             known_scope_to_info=known_scope_to_info,
@@ -173,7 +173,7 @@ class Options:
         scope_to_flags: Dict[str, List[str]],
         specs: List[str],
         passthru: List[str],
-        help_request: Optional[NativeGoalRequest],
+        builtin_goal: Optional[BuiltinGoal],
         parser_hierarchy: ParserHierarchy,
         bootstrap_option_values: Optional[OptionValueContainer],
         known_scope_to_info: Dict[str, ScopeInfo],
@@ -187,7 +187,7 @@ class Options:
         self._scope_to_flags = scope_to_flags
         self._specs = specs
         self._passthru = passthru
-        self._help_request = help_request
+        self._builtin_goal = builtin_goal
         self._parser_hierarchy = parser_hierarchy
         self._bootstrap_option_values = bootstrap_option_values
         self._known_scope_to_info = known_scope_to_info
@@ -201,11 +201,11 @@ class Options:
         return self._frozen
 
     @property
-    def help_request(self) -> Optional[NativeGoalRequest]:
+    def builtin_goal(self) -> Optional[BuiltinGoal]:
         """
         :API: public
         """
-        return self._help_request
+        return self._builtin_goal
 
     @property
     def specs(self) -> List[str]:
@@ -285,7 +285,7 @@ class Options:
             scope_to_flags=no_flags,
             specs=self._specs,
             passthru=self._passthru,
-            help_request=self._help_request,
+            builtin_goal=self._builtin_goal,
             parser_hierarchy=self._parser_hierarchy,
             bootstrap_option_values=self._bootstrap_option_values,
             known_scope_to_info=self._known_scope_to_info,

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -9,9 +9,9 @@ from typing import Dict, Iterable, List, Mapping, Optional, Sequence
 
 from pants.base.build_environment import get_buildroot
 from pants.base.deprecated import warn_or_error
+from pants.goal.builtin_goal import BuiltinGoal
 from pants.option.arg_splitter import ArgSplitter
 from pants.option.config import Config
-from pants.goal.builtin_goal import BuiltinGoal
 from pants.option.option_util import is_list_option
 from pants.option.option_value_container import OptionValueContainer, OptionValueContainerBuilder
 from pants.option.parser import Parser


### PR DESCRIPTION
1 of many towards addressing #11167: baseline work necessary to have goals outside of Pants' plugin system (i.e. `./pants gc` for garbage collection)

Still WIP pending completed refactoring of `HelpPrinter` to use a new `BuiltinGoalPrinter`
[ci skip-rust]

[ci skip-build-wheels]