### PR TITLE
Add skimage module mapping

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -19,6 +19,7 @@ DEFAULT_MODULE_MAPPING = {
     "pyyaml": ("yaml",),
     "pymongo": ("bson", "gridfs"),
     "pytest-runner": ("ptr",),
+    "scikit-image": ("skimage",),
     "setuptools": ("easy_install", "pkg_resources", "setuptools"),
 }
 


### PR DESCRIPTION
If you `import skimage` that means you need to `pip install scikit-image`.   Add the appropriate mapping to make this jump automatically.