### PR TITLE
Docstrings: improve wording for pex_binary target

### DIFF
--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -241,7 +241,9 @@ class PexPlatformsField(StringSequenceField):
     help = (
         "The platforms the built PEX should be compatible with.\n\nThis defaults to the current "
         "platform, but can be overridden to different platforms. You can give a list of multiple "
-        "platforms to create a multiplatform PEX.\n\nTo use wheels for specific "
+        "platforms to create a multiplatform PEX. A multiplatform PEX file will contain platform "
+        "specific wheels for each 3rd party dependency that has some non-Python "
+        "code that requires compilation on each target platform.\n\nTo use wheels for specific "
         "interpreter/platform tags, you can append them to the platform with hyphens like: "
         'PLATFORM-IMPL-PYVER-ABI (e.g. "linux_x86_64-cp-27-cp27mu", '
         '"macosx_10.12_x86_64-cp-36-cp36m"):\n\n  - PLATFORM: the host platform, e.g. '

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -240,15 +240,13 @@ class PexPlatformsField(StringSequenceField):
     alias = "platforms"
     help = (
         "The platforms the built PEX should be compatible with.\n\nThis defaults to the current "
-        "platform, but can be overridden to different platforms.\n\nWhen building for a foreign "
-        "platform, there must be built wheels for those platforms available, rather than sdists. "
-        "You can give a list of multiple platforms to create a multiplatform PEX. "
-        "A multiplatform PEX file will contain platform "
-        "specific wheels for each 3rd party dependency that has some non-Python "
-        "code that requires compilation on each target platform.\n\nPlatforms should be in "
-        "the format defined by PEP 425, i.e. PLATFORM-IMPL-PYVER-ABI (e.g. "
-        '"linux_x86_64-cp-27-cp27mu", "macosx_10.12_x86_64-cp-36-cp36m"):\n\n'
-        '  - PLATFORM: the host platform, e.g. '
+        "platform, but can be overridden to different platforms. There must be built wheels "
+        "available for all of the foreign platforms, rather than sdists.\n\n"
+        "You can give a list of multiple platforms to create a multiplatform PEX, "
+        "meaning that the PEX will be executable in all of the supported environments.\n\n"
+        "Platforms should be in the format defined by PEP 425, i.e. PLATFORM-IMPL-PYVER-ABI "
+        '(e.g. "linux_x86_64-cp-27-cp27mu", "macosx_10.12_x86_64-cp-36-cp36m"):\n\n'
+        "  - PLATFORM: the host platform, e.g. "
         '"linux-x86_64", "macosx-10.12-x86_64".\n  - IMPL: the Python implementation '
         'abbreviation, e.g. "cp", "pp", "jp".\n  - PYVER: a two-digit string representing '
         'the Python version, e.g. "27", "36".\n  - ABI: the ABI tag, e.g. "cp36m", '

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -240,13 +240,15 @@ class PexPlatformsField(StringSequenceField):
     alias = "platforms"
     help = (
         "The platforms the built PEX should be compatible with.\n\nThis defaults to the current "
-        "platform, but can be overridden to different platforms. You can give a list of multiple "
-        "platforms to create a multiplatform PEX. A multiplatform PEX file will contain platform "
+        "platform, but can be overridden to different platforms.\n\nWhen building for a foreign "
+        "platform, there must be built wheels for those platforms available, rather than sdists. "
+        "You can give a list of multiple platforms to create a multiplatform PEX. "
+        "A multiplatform PEX file will contain platform "
         "specific wheels for each 3rd party dependency that has some non-Python "
-        "code that requires compilation on each target platform.\n\nTo use wheels for specific "
-        "interpreter/platform tags, you can append them to the platform with hyphens like: "
-        'PLATFORM-IMPL-PYVER-ABI (e.g. "linux_x86_64-cp-27-cp27mu", '
-        '"macosx_10.12_x86_64-cp-36-cp36m"):\n\n  - PLATFORM: the host platform, e.g. '
+        "code that requires compilation on each target platform.\n\nPlatforms should be in "
+        "the format defined by PEP 425, i.e. PLATFORM-IMPL-PYVER-ABI (e.g. "
+        '"linux_x86_64-cp-27-cp27mu", "macosx_10.12_x86_64-cp-36-cp36m"):\n\n'
+        '  - PLATFORM: the host platform, e.g. '
         '"linux-x86_64", "macosx-10.12-x86_64".\n  - IMPL: the Python implementation '
         'abbreviation, e.g. "cp", "pp", "jp".\n  - PYVER: a two-digit string representing '
         'the Python version, e.g. "27", "36".\n  - ABI: the ABI tag, e.g. "cp36m", '


### PR DESCRIPTION
Extend the `pex_binary` target docstring to explain that multiplatform PEX file will contain platform specific wheels.

[ci skip-rust]

[ci skip-build-wheels]