### PR TITLE
Improve error for out-of-line Gets in @rules.

### DIFF
--- a/src/python/pants/engine/internals/scheduler_test.py
+++ b/src/python/pants/engine/internals/scheduler_test.py
@@ -187,6 +187,32 @@ def test_union_rules() -> None:
     ) in str(exc.value.args[0])
 
 
+def create_outlined_get() -> Get[int, str]:
+    return Get(int, str, "hello")
+
+
+@rule
+async def uses_outlined_get() -> int:
+    return await create_outlined_get()
+
+
+def test_outlined_get() -> None:
+    rule_runner = RuleRunner(
+        rules=[
+            uses_outlined_get,
+            QueryRule(int, []),
+        ],
+    )
+    # Fails because the creation of the `Get` was out-of-lined into a separate function.
+    with pytest.raises(ExecutionError) as exc:
+        rule_runner.request(int, [])
+    assert (
+        "Get(int, str, hello) was not detected in your @rule body at rule compile time. "
+        "Was the `Get` constructor called in a separate function, or perhaps "
+        "dynamically? If so, it must be inlined into the @rule body."
+    ) in str(exc.value.args[0])
+
+
 # -----------------------------------------------------------------------------------------------
 # Test tracebacks
 # -----------------------------------------------------------------------------------------------

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -966,7 +966,9 @@ impl Task {
                 // NB: The Python constructor for `Get()` will have already errored if
                 // `type(input) != input_type`.
                 throw(&format!(
-                  "Could not find a rule to satisfy Get({}, {}, {}).",
+                  "Get({}, {}, {}) was not detected in your @rule body at rule compile time. \
+                    Was the `Get` constructor called in a separate function, or perhaps \
+                    dynamically? If so, it must be inlined into the @rule body.",
                   get.output, get.input_type, get.input
                 ))
               }


### PR DESCRIPTION
This runtime error for a `Get` can only really mean that we failed to detect an otherwise valid `Get` at `RuleGraph` construction time: as the comment above says, type-mismatches are detected in the `Get` constructor.

[ci skip-build-wheels]