### PR TITLE
[internal] `./pants lock` uses transitive closure as inputs

### DIFF
--- a/src/python/pants/backend/experimental/python/lockfile.py
+++ b/src/python/pants/backend/experimental/python/lockfile.py
@@ -10,11 +10,12 @@ from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript, PythonRequirementsField
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import PexRequest, PexRequirements, VenvPex, VenvPexProcess
+from pants.engine.addresses import Addresses
 from pants.engine.fs import CreateDigest, Digest, FileContent, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
-from pants.engine.target import Targets
+from pants.engine.target import TransitiveTargets, TransitiveTargetsRequest
 from pants.util.strutil import pluralize
 
 logger = logging.getLogger(__name__)
@@ -53,28 +54,54 @@ class LockGoal(Goal):
     subsystem_cls = LockSubsystem
 
 
-# TODO: What should the input to `./pants lock` be when generating user lockfiles? Currently, it's
-#  the 3rd-party requirements that get used as input. Likely it should instead be all 3rd party
-#  reqs used by the transitive closure? That would better mirror generate_lockfile.sh.
 @goal_rule
 async def generate_lockfile(
-    targets: Targets, pip_tools_subsystem: PipToolsSubsystem, workspace: Workspace
+    addresses: Addresses, pip_tools_subsystem: PipToolsSubsystem, workspace: Workspace
 ) -> LockGoal:
+    # TODO: Looking at the transitive closure to generate a single lockfile will not work when we
+    #  have multiple lockfiles supported, via per-tool lockfiles and multiple user lockfiles.
+    #  Ideally, `./pants lock ::` would mean "regenerate all unique lockfiles", whereas now it
+    #  means "generate a single lockfile based on this transitive closure."
+    transitive_targets = await Get(TransitiveTargets, TransitiveTargetsRequest(addresses))
     reqs = PexRequirements.create_from_requirement_fields(
-        tgt[PythonRequirementsField] for tgt in targets if tgt.has_field(PythonRequirementsField)
+        tgt[PythonRequirementsField]
+        # NB: By looking at the dependencies, rather than the closure, we only generate for
+        # requirements that are actually used in the project.
+        #
+        # TODO: It's not totally clear to me if that is desirable. Consider requirements like
+        #  pydevd-pycharm. Should that be in the lockfile? I think this needs to be the case when
+        #  we have multiple lockfiles, though: we shouldn't look at the universe in that case,
+        #  only the relevant subset of requirements.
+        #
+        # Note that the current generate_lockfile.sh script in our docs also mixes in
+        #  `requirements.txt`, but not inlined python_requirement_library targets if they're not
+        #  in use. We don't have a way to emulate those semantics because at this point, all we
+        #  have is `python_requirement_library` targets without knowing the source.
+        for tgt in transitive_targets.dependencies
+        if tgt.has_field(PythonRequirementsField)
     )
+
+    if not reqs:
+        logger.warning(
+            "No third-party requirements found for the transitive closure, so a lockfile will not "
+            "be generated."
+        )
+        return LockGoal(exit_code=1)
 
     input_requirements_get = Get(
         Digest, CreateDigest([FileContent("requirements.in", "\n".join(reqs).encode())])
     )
+    # TODO: Figure out named_caches for pip-tools. The best would be to share the cache between
+    #  Pex and Pip. Next best is a dedicated named_cache.
     pip_compile_get = Get(
         VenvPex,
         PexRequest(
             output_filename="pip_compile.pex",
             internal_only=True,
             requirements=PexRequirements(pip_tools_subsystem.all_requirements),
-            # TODO: Figure out which interpreter constraints to use...Among other reasons, this is
-            #  tricky because python_requirement_library targets don't have interpreter constraints!
+            # TODO: Figure out which interpreter constraints to use...Likely get it from the
+            #  transitive closure. When we're doing a single global lockfile, it's fine to do that,
+            #  but we need to figure out how this will work with multiple resolves.
             interpreter_constraints=InterpreterConstraints(["CPython==3.9.*"]),
             main=pip_tools_subsystem.main,
         ),


### PR DESCRIPTION
These are _not_ the proposed final semantics for the `./pants lock` goal. The semantics will change when we have per-tool lockfiles and multiple lockfiles, likely such that `./pants lock ::` will regenerate all distinct lockfiles.

For now, this PR merely aligns `./pants lock` with the current `generate_lockfile.sh` script, so that we can run `./pants --tag=-lockfile_ignore lock ::`. The goal is to replace `generate_lockfile.sh` with this goal.

[ci skip-rust]
[ci skip-build-wheels]