### PR TITLE
Plugins: Add yapf Python formatter plugin

### DIFF
--- a/src/python/pants/backend/python/lint/yapf/BUILD
+++ b/src/python/pants/backend/python/lint/yapf/BUILD
@@ -1,0 +1,5 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_library()
+python_tests(name="tests", timeout=120)

--- a/src/python/pants/backend/python/lint/yapf/register.py
+++ b/src/python/pants/backend/python/lint/yapf/register.py
@@ -1,0 +1,16 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+"""Autoformatter for Python.
+
+See https://www.pantsbuild.org/docs/python-linters-and-formatters and
+https://github.com/google/yapf .
+"""
+
+from pants.backend.python.lint import python_fmt
+from pants.backend.python.lint.yapf import rules as yapf_rules
+from pants.backend.python.lint.yapf import skip_field
+
+
+def rules():
+    return (*yapf_rules.rules(), *python_fmt.rules(), *skip_field.rules())

--- a/src/python/pants/backend/python/lint/yapf/rules.py
+++ b/src/python/pants/backend/python/lint/yapf/rules.py
@@ -4,18 +4,13 @@
 from dataclasses import dataclass
 from typing import Tuple
 
+from pants.backend.python.lint.python_fmt import PythonFmtRequest
 from pants.backend.python.lint.yapf.skip_field import SkipYapfField
 from pants.backend.python.lint.yapf.subsystem import Yapf
-from pants.backend.python.lint.python_fmt import PythonFmtRequest
 from pants.backend.python.target_types import PythonSources
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.pex import (
-    PexRequest,
-    PexRequirements,
-    VenvPex,
-    VenvPexProcess,
-)
+from pants.backend.python.util_rules.pex import PexRequest, PexRequirements, VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintRequest, LintResult, LintResults
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
@@ -58,7 +53,8 @@ class Setup:
 
 
 def generate_argv(
-    source_files: SourceFiles, yapf: Yapf, check_only: bool, inplace: bool) -> Tuple[str, ...]:
+    source_files: SourceFiles, yapf: Yapf, check_only: bool, inplace: bool
+) -> Tuple[str, ...]:
     args = [*yapf.args]
     if check_only:
         # If "--diff" is passed, yapf returns zero when no changes were necessary and
@@ -110,7 +106,8 @@ async def setup_yapf(setup_request: SetupRequest, yapf: Yapf) -> Setup:
         VenvPexProcess(
             yapf_pex,
             argv=generate_argv(
-                source_files, yapf,
+                source_files,
+                yapf,
                 check_only=setup_request.check_only,
                 inplace=setup_request.inplace,
             ),

--- a/src/python/pants/backend/python/lint/yapf/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/yapf/rules_integration_test.py
@@ -43,7 +43,6 @@ FIXED_NEEDS_FORMATTING_FILE_INDENT2 = "def func():\n  return 42\n"
 FIXED_NEEDS_FORMATTING_FILE_INDENT4 = "def func():\n    return 42\n"
 
 
-
 def run_yapf(
     rule_runner: RuleRunner,
     targets: list[Target],
@@ -119,14 +118,17 @@ def test_multiple_targets(rule_runner: RuleRunner) -> None:
 
 
 @pytest.mark.parametrize(
-    "path,section,extra_args", (
-            (".style.yapf", "style", []),
-            ("setup.cfg", "yapf", []),
-            ("pyproject.toml", "tool.yapf", []),
-            ("custom.style", "style", ["--yapf-config=custom.style"]),
-    )
+    "path,section,extra_args",
+    (
+        (".style.yapf", "style", []),
+        ("setup.cfg", "yapf", []),
+        ("pyproject.toml", "tool.yapf", []),
+        ("custom.style", "style", ["--yapf-config=custom.style"]),
+    ),
 )
-def test_config_file(rule_runner: RuleRunner, path: str, section: str, extra_args: list[str]) -> None:
+def test_config_file(
+    rule_runner: RuleRunner, path: str, section: str, extra_args: list[str]
+) -> None:
     rule_runner.write_files(
         {
             "f.py": NEEDS_FORMATTING_FILE,
@@ -139,7 +141,9 @@ def test_config_file(rule_runner: RuleRunner, path: str, section: str, extra_arg
     assert len(lint_results) == 1
     assert lint_results[0].exit_code == 1
     assert all(msg in lint_results[0].stdout for msg in ("reformatted", "original", "f.py"))
-    assert fmt_result.output == get_digest(rule_runner, {"f.py": FIXED_NEEDS_FORMATTING_FILE_INDENT2})
+    assert fmt_result.output == get_digest(
+        rule_runner, {"f.py": FIXED_NEEDS_FORMATTING_FILE_INDENT2}
+    )
     assert fmt_result.did_change is True
 
 
@@ -149,15 +153,19 @@ def test_inline_style_overrides_config_file(rule_runner: RuleRunner) -> None:
         {
             "f.py": NEEDS_FORMATTING_FILE,
             "BUILD": "python_library(name='t', interpreter_constraints=['==3.9.*'])",
-            ".style.yapf": f"[style]\nindent_width = 8\n",
+            ".style.yapf": "[style]\nindent_width = 8\n",
         }
     )
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
-    lint_results, fmt_result = run_yapf(rule_runner, [tgt], extra_args=["--yapf-args=--style='{indent_width: 2}'"])
+    lint_results, fmt_result = run_yapf(
+        rule_runner, [tgt], extra_args=["--yapf-args=--style='{indent_width: 2}'"]
+    )
     assert len(lint_results) == 1
     assert lint_results[0].exit_code == 1
     assert all(msg in lint_results[0].stdout for msg in ("reformatted", "original", "f.py"))
-    assert fmt_result.output == get_digest(rule_runner, {"f.py": FIXED_NEEDS_FORMATTING_FILE_INDENT2})
+    assert fmt_result.output == get_digest(
+        rule_runner, {"f.py": FIXED_NEEDS_FORMATTING_FILE_INDENT2}
+    )
     assert fmt_result.did_change is True
 
 
@@ -167,16 +175,20 @@ def test_ignore_config_file(rule_runner: RuleRunner) -> None:
         {
             "f.py": NEEDS_FORMATTING_FILE,
             "BUILD": "python_library(name='t', interpreter_constraints=['==3.9.*'])",
-            ".style.yapf": f"[style]\nindent_width = 8\n",
+            ".style.yapf": "[style]\nindent_width = 8\n",
         }
     )
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
-    lint_results, fmt_result = run_yapf(rule_runner, [tgt], extra_args=["--yapf-args='--no-local-style'"])
+    lint_results, fmt_result = run_yapf(
+        rule_runner, [tgt], extra_args=["--yapf-args='--no-local-style'"]
+    )
     assert len(lint_results) == 1
     assert lint_results[0].exit_code == 1
     assert all(msg in lint_results[0].stdout for msg in ("reformatted", "original", "f.py"))
     # by default, PEP8 style is used when no config files are available
-    assert fmt_result.output == get_digest(rule_runner, {"f.py": FIXED_NEEDS_FORMATTING_FILE_INDENT4})
+    assert fmt_result.output == get_digest(
+        rule_runner, {"f.py": FIXED_NEEDS_FORMATTING_FILE_INDENT4}
+    )
     assert fmt_result.did_change is True
 
 
@@ -189,7 +201,9 @@ def test_passthrough_args(rule_runner: RuleRunner) -> None:
     assert len(lint_results) == 1
     assert lint_results[0].exit_code == 1
     assert all(msg in lint_results[0].stdout for msg in ("reformatted", "original", "f.py"))
-    assert fmt_result.output == get_digest(rule_runner, {"f.py": FIXED_NEEDS_FORMATTING_FILE_INDENT4})
+    assert fmt_result.output == get_digest(
+        rule_runner, {"f.py": FIXED_NEEDS_FORMATTING_FILE_INDENT4}
+    )
     assert fmt_result.did_change is True
 
 
@@ -202,12 +216,10 @@ def test_skip(rule_runner: RuleRunner) -> None:
     assert fmt_result.did_change is False
 
 
-@pytest.mark.parametrize(
-    "path,contents,extra_args", (
-            (".yapfignore", "d*py", []),
-    )
-)
-def test_ignore_files(rule_runner: RuleRunner, path: str, contents: str, extra_args: list[str]) -> None:
+@pytest.mark.parametrize("path,contents,extra_args", ((".yapfignore", "d*py", []),))
+def test_ignore_files(
+    rule_runner: RuleRunner, path: str, contents: str, extra_args: list[str]
+) -> None:
     """yapf should ignore files specified in the .yapfignore file."""
     rule_runner.write_files(
         {
@@ -223,7 +235,9 @@ def test_ignore_files(rule_runner: RuleRunner, path: str, contents: str, extra_a
     assert lint_results[0].exit_code == 1
     assert all(msg in lint_results[0].stdout for msg in ("reformatted", "original", "f.py"))
     assert "d.py" not in lint_results[0].stdout
-    assert fmt_result.output == get_digest(rule_runner, {"f.py": FIXED_NEEDS_FORMATTING_FILE_INDENT4})
+    assert fmt_result.output == get_digest(
+        rule_runner, {"f.py": FIXED_NEEDS_FORMATTING_FILE_INDENT4}
+    )
     assert fmt_result.did_change is True
 
 
@@ -241,5 +255,7 @@ def test_ignore_files_empty_yapfignore(rule_runner: RuleRunner) -> None:
     assert len(lint_results) == 1
     assert lint_results[0].exit_code == 1
     assert all(msg in lint_results[0].stdout for msg in ("reformatted", "original", "f.py"))
-    assert fmt_result.output == get_digest(rule_runner, {"f.py": FIXED_NEEDS_FORMATTING_FILE_INDENT4})
+    assert fmt_result.output == get_digest(
+        rule_runner, {"f.py": FIXED_NEEDS_FORMATTING_FILE_INDENT4}
+    )
     assert fmt_result.did_change is True

--- a/src/python/pants/backend/python/lint/yapf/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/yapf/rules_integration_test.py
@@ -121,8 +121,6 @@ def test_multiple_targets(rule_runner: RuleRunner) -> None:
     "path,section,extra_args",
     (
         (".style.yapf", "style", []),
-        ("setup.cfg", "yapf", []),
-        ("pyproject.toml", "tool.yapf", []),
         ("custom.style", "style", ["--yapf-config=custom.style"]),
     ),
 )
@@ -143,51 +141,6 @@ def test_config_file(
     assert all(msg in lint_results[0].stdout for msg in ("reformatted", "original", "f.py"))
     assert fmt_result.output == get_digest(
         rule_runner, {"f.py": FIXED_NEEDS_FORMATTING_FILE_INDENT2}
-    )
-    assert fmt_result.did_change is True
-
-
-def test_inline_style_overrides_config_file(rule_runner: RuleRunner) -> None:
-    """Style provided inline should have priority over the config file style section."""
-    rule_runner.write_files(
-        {
-            "f.py": NEEDS_FORMATTING_FILE,
-            "BUILD": "python_library(name='t', interpreter_constraints=['==3.9.*'])",
-            ".style.yapf": "[style]\nindent_width = 8\n",
-        }
-    )
-    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
-    lint_results, fmt_result = run_yapf(
-        rule_runner, [tgt], extra_args=["--yapf-args=--style='{indent_width: 2}'"]
-    )
-    assert len(lint_results) == 1
-    assert lint_results[0].exit_code == 1
-    assert all(msg in lint_results[0].stdout for msg in ("reformatted", "original", "f.py"))
-    assert fmt_result.output == get_digest(
-        rule_runner, {"f.py": FIXED_NEEDS_FORMATTING_FILE_INDENT2}
-    )
-    assert fmt_result.did_change is True
-
-
-def test_ignore_config_file(rule_runner: RuleRunner) -> None:
-    """Configuration file with the style should be ignored when '--no-local-style' is passed."""
-    rule_runner.write_files(
-        {
-            "f.py": NEEDS_FORMATTING_FILE,
-            "BUILD": "python_library(name='t', interpreter_constraints=['==3.9.*'])",
-            ".style.yapf": "[style]\nindent_width = 8\n",
-        }
-    )
-    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
-    lint_results, fmt_result = run_yapf(
-        rule_runner, [tgt], extra_args=["--yapf-args='--no-local-style'"]
-    )
-    assert len(lint_results) == 1
-    assert lint_results[0].exit_code == 1
-    assert all(msg in lint_results[0].stdout for msg in ("reformatted", "original", "f.py"))
-    # by default, PEP8 style is used when no config files are available
-    assert fmt_result.output == get_digest(
-        rule_runner, {"f.py": FIXED_NEEDS_FORMATTING_FILE_INDENT4}
     )
     assert fmt_result.did_change is True
 
@@ -214,48 +167,3 @@ def test_skip(rule_runner: RuleRunner) -> None:
     assert not lint_results
     assert fmt_result.skipped is True
     assert fmt_result.did_change is False
-
-
-@pytest.mark.parametrize("path,contents,extra_args", ((".yapfignore", "d*py", []),))
-def test_ignore_files(
-    rule_runner: RuleRunner, path: str, contents: str, extra_args: list[str]
-) -> None:
-    """yapf should ignore files specified in the .yapfignore file."""
-    rule_runner.write_files(
-        {
-            "f.py": NEEDS_FORMATTING_FILE,
-            "d.py": NEEDS_FORMATTING_FILE,
-            "BUILD": "python_library(name='t', interpreter_constraints=['==3.9.*'])",
-            path: contents,
-        }
-    )
-    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
-    lint_results, fmt_result = run_yapf(rule_runner, [tgt], extra_args=extra_args)
-    assert len(lint_results) == 1
-    assert lint_results[0].exit_code == 1
-    assert all(msg in lint_results[0].stdout for msg in ("reformatted", "original", "f.py"))
-    assert "d.py" not in lint_results[0].stdout
-    assert fmt_result.output == get_digest(
-        rule_runner, {"f.py": FIXED_NEEDS_FORMATTING_FILE_INDENT4}
-    )
-    assert fmt_result.did_change is True
-
-
-def test_ignore_files_empty_yapfignore(rule_runner: RuleRunner) -> None:
-    """yapf should be run on all files because the .yapfignore file is empty."""
-    rule_runner.write_files(
-        {
-            "f.py": NEEDS_FORMATTING_FILE,
-            "BUILD": "python_library(name='t', interpreter_constraints=['==3.9.*'])",
-            ".yapfignore": "",
-        }
-    )
-    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
-    lint_results, fmt_result = run_yapf(rule_runner, [tgt], extra_args=[])
-    assert len(lint_results) == 1
-    assert lint_results[0].exit_code == 1
-    assert all(msg in lint_results[0].stdout for msg in ("reformatted", "original", "f.py"))
-    assert fmt_result.output == get_digest(
-        rule_runner, {"f.py": FIXED_NEEDS_FORMATTING_FILE_INDENT4}
-    )
-    assert fmt_result.did_change is True

--- a/src/python/pants/backend/python/lint/yapf/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/yapf/rules_integration_test.py
@@ -1,0 +1,245 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import pytest
+
+from pants.backend.python.lint.yapf.rules import YapfFieldSet, YapfRequest
+from pants.backend.python.lint.yapf.rules import rules as yapf_rules
+from pants.backend.python.target_types import PythonLibrary
+from pants.core.goals.fmt import FmtResult
+from pants.core.goals.lint import LintResult, LintResults
+from pants.core.util_rules import config_files, source_files
+from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.engine.addresses import Address
+from pants.engine.fs import CreateDigest, Digest, FileContent
+from pants.engine.target import Target
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *yapf_rules(),
+            *source_files.rules(),
+            *config_files.rules(),
+            QueryRule(LintResults, (YapfRequest,)),
+            QueryRule(FmtResult, (YapfRequest,)),
+            QueryRule(SourceFiles, (SourceFilesRequest,)),
+        ],
+        target_types=[PythonLibrary],
+    )
+
+
+GOOD_FILE = "data = []\n"
+BAD_FILE = "data = {  'a':11,'b':22    }\n"
+FIXED_BAD_FILE = "data = {'a': 11, 'b': 22}\n"
+
+# Note the indentation is 6 spaces; after formatting it should become 2
+NEEDS_FORMATTING_FILE = "def func():\n      return 42\n"
+FIXED_NEEDS_FORMATTING_FILE_INDENT2 = "def func():\n  return 42\n"
+FIXED_NEEDS_FORMATTING_FILE_INDENT4 = "def func():\n    return 42\n"
+
+
+
+def run_yapf(
+    rule_runner: RuleRunner,
+    targets: list[Target],
+    *,
+    extra_args: list[str] | None = None,
+) -> tuple[tuple[LintResult, ...], FmtResult]:
+    rule_runner.set_options(
+        ["--backend-packages=pants.backend.python.lint.yapf", *(extra_args or ())],
+        env_inherit={"PATH", "PYENV_ROOT", "HOME"},
+    )
+    field_sets = [YapfFieldSet.create(tgt) for tgt in targets]
+    lint_results = rule_runner.request(LintResults, [YapfRequest(field_sets)])
+    input_sources = rule_runner.request(
+        SourceFiles,
+        [
+            SourceFilesRequest(field_set.sources for field_set in field_sets),
+        ],
+    )
+    fmt_result = rule_runner.request(
+        FmtResult,
+        [
+            YapfRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+        ],
+    )
+    return lint_results.results, fmt_result
+
+
+def get_digest(rule_runner: RuleRunner, source_files: dict[str, str]) -> Digest:
+    files = [FileContent(path, content.encode()) for path, content in source_files.items()]
+    return rule_runner.request(Digest, [CreateDigest(files)])
+
+
+def test_passing_source(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files({"f.py": GOOD_FILE, "BUILD": "python_library(name='t')"})
+    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
+    lint_results, fmt_result = run_yapf(rule_runner, [tgt])
+    assert len(lint_results) == 1
+    assert lint_results[0].exit_code == 0
+    assert lint_results[0].stderr == ""
+    assert fmt_result.output == get_digest(rule_runner, {"f.py": GOOD_FILE})
+    assert fmt_result.did_change is False
+
+
+def test_failing_source(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files({"f.py": BAD_FILE, "BUILD": "python_library(name='t')"})
+    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
+    lint_results, fmt_result = run_yapf(rule_runner, [tgt])
+    assert len(lint_results) == 1
+    assert lint_results[0].exit_code == 1
+    assert all(msg in lint_results[0].stdout for msg in ("reformatted", "original"))
+    assert fmt_result.skipped is False
+    assert fmt_result.output == get_digest(rule_runner, {"f.py": FIXED_BAD_FILE})
+    assert fmt_result.did_change is True
+
+
+def test_multiple_targets(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {"good.py": GOOD_FILE, "bad.py": BAD_FILE, "BUILD": "python_library(name='t')"}
+    )
+    tgts = [
+        rule_runner.get_target(Address("", target_name="t", relative_file_path="good.py")),
+        rule_runner.get_target(Address("", target_name="t", relative_file_path="bad.py")),
+    ]
+    lint_results, fmt_result = run_yapf(rule_runner, tgts)
+    assert len(lint_results) == 1
+    assert lint_results[0].exit_code == 1
+    assert all(msg in lint_results[0].stdout for msg in ("reformatted", "original", "bad.py"))
+    assert "good.py" not in lint_results[0].stdout
+    assert fmt_result.output == get_digest(
+        rule_runner, {"good.py": GOOD_FILE, "bad.py": FIXED_BAD_FILE}
+    )
+    assert fmt_result.did_change is True
+
+
+@pytest.mark.parametrize(
+    "path,section,extra_args", (
+            (".style.yapf", "style", []),
+            ("setup.cfg", "yapf", []),
+            ("pyproject.toml", "tool.yapf", []),
+            ("custom.style", "style", ["--yapf-config=custom.style"]),
+    )
+)
+def test_config_file(rule_runner: RuleRunner, path: str, section: str, extra_args: list[str]) -> None:
+    rule_runner.write_files(
+        {
+            "f.py": NEEDS_FORMATTING_FILE,
+            "BUILD": "python_library(name='t', interpreter_constraints=['==3.9.*'])",
+            path: f"[{section}]\nindent_width = 2\n",
+        }
+    )
+    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
+    lint_results, fmt_result = run_yapf(rule_runner, [tgt], extra_args=extra_args)
+    assert len(lint_results) == 1
+    assert lint_results[0].exit_code == 1
+    assert all(msg in lint_results[0].stdout for msg in ("reformatted", "original", "f.py"))
+    assert fmt_result.output == get_digest(rule_runner, {"f.py": FIXED_NEEDS_FORMATTING_FILE_INDENT2})
+    assert fmt_result.did_change is True
+
+
+def test_inline_style_overrides_config_file(rule_runner: RuleRunner) -> None:
+    """Style provided inline should have priority over the config file style section."""
+    rule_runner.write_files(
+        {
+            "f.py": NEEDS_FORMATTING_FILE,
+            "BUILD": "python_library(name='t', interpreter_constraints=['==3.9.*'])",
+            ".style.yapf": f"[style]\nindent_width = 8\n",
+        }
+    )
+    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
+    lint_results, fmt_result = run_yapf(rule_runner, [tgt], extra_args=["--yapf-args=--style='{indent_width: 2}'"])
+    assert len(lint_results) == 1
+    assert lint_results[0].exit_code == 1
+    assert all(msg in lint_results[0].stdout for msg in ("reformatted", "original", "f.py"))
+    assert fmt_result.output == get_digest(rule_runner, {"f.py": FIXED_NEEDS_FORMATTING_FILE_INDENT2})
+    assert fmt_result.did_change is True
+
+
+def test_ignore_config_file(rule_runner: RuleRunner) -> None:
+    """Configuration file with the style should be ignored when '--no-local-style' is passed."""
+    rule_runner.write_files(
+        {
+            "f.py": NEEDS_FORMATTING_FILE,
+            "BUILD": "python_library(name='t', interpreter_constraints=['==3.9.*'])",
+            ".style.yapf": f"[style]\nindent_width = 8\n",
+        }
+    )
+    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
+    lint_results, fmt_result = run_yapf(rule_runner, [tgt], extra_args=["--yapf-args='--no-local-style'"])
+    assert len(lint_results) == 1
+    assert lint_results[0].exit_code == 1
+    assert all(msg in lint_results[0].stdout for msg in ("reformatted", "original", "f.py"))
+    # by default, PEP8 style is used when no config files are available
+    assert fmt_result.output == get_digest(rule_runner, {"f.py": FIXED_NEEDS_FORMATTING_FILE_INDENT4})
+    assert fmt_result.did_change is True
+
+
+def test_passthrough_args(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files({"f.py": NEEDS_FORMATTING_FILE, "BUILD": "python_library(name='t')"})
+    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
+    lint_results, fmt_result = run_yapf(
+        rule_runner, [tgt], extra_args=["--yapf-args=--style='{indent_width: 4}'"]
+    )
+    assert len(lint_results) == 1
+    assert lint_results[0].exit_code == 1
+    assert all(msg in lint_results[0].stdout for msg in ("reformatted", "original", "f.py"))
+    assert fmt_result.output == get_digest(rule_runner, {"f.py": FIXED_NEEDS_FORMATTING_FILE_INDENT4})
+    assert fmt_result.did_change is True
+
+
+def test_skip(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files({"f.py": BAD_FILE, "BUILD": "python_library(name='t')"})
+    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
+    lint_results, fmt_result = run_yapf(rule_runner, [tgt], extra_args=["--yapf-skip"])
+    assert not lint_results
+    assert fmt_result.skipped is True
+    assert fmt_result.did_change is False
+
+
+@pytest.mark.parametrize(
+    "path,contents,extra_args", (
+            (".yapfignore", "d*py", []),
+    )
+)
+def test_ignore_files(rule_runner: RuleRunner, path: str, contents: str, extra_args: list[str]) -> None:
+    """yapf should ignore files specified in the .yapfignore file."""
+    rule_runner.write_files(
+        {
+            "f.py": NEEDS_FORMATTING_FILE,
+            "d.py": NEEDS_FORMATTING_FILE,
+            "BUILD": "python_library(name='t', interpreter_constraints=['==3.9.*'])",
+            path: contents,
+        }
+    )
+    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
+    lint_results, fmt_result = run_yapf(rule_runner, [tgt], extra_args=extra_args)
+    assert len(lint_results) == 1
+    assert lint_results[0].exit_code == 1
+    assert all(msg in lint_results[0].stdout for msg in ("reformatted", "original", "f.py"))
+    assert "d.py" not in lint_results[0].stdout
+    assert fmt_result.output == get_digest(rule_runner, {"f.py": FIXED_NEEDS_FORMATTING_FILE_INDENT4})
+    assert fmt_result.did_change is True
+
+
+def test_ignore_files_empty_yapfignore(rule_runner: RuleRunner) -> None:
+    """yapf should be run on all files because the .yapfignore file is empty."""
+    rule_runner.write_files(
+        {
+            "f.py": NEEDS_FORMATTING_FILE,
+            "BUILD": "python_library(name='t', interpreter_constraints=['==3.9.*'])",
+            ".yapfignore": "",
+        }
+    )
+    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
+    lint_results, fmt_result = run_yapf(rule_runner, [tgt], extra_args=[])
+    assert len(lint_results) == 1
+    assert lint_results[0].exit_code == 1
+    assert all(msg in lint_results[0].stdout for msg in ("reformatted", "original", "f.py"))
+    assert fmt_result.output == get_digest(rule_runner, {"f.py": FIXED_NEEDS_FORMATTING_FILE_INDENT4})
+    assert fmt_result.did_change is True

--- a/src/python/pants/backend/python/lint/yapf/skip_field.py
+++ b/src/python/pants/backend/python/lint/yapf/skip_field.py
@@ -1,0 +1,18 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.backend.python.target_types import PythonLibrary, PythonTests
+from pants.engine.target import BoolField
+
+
+class SkipYapfField(BoolField):
+    alias = "skip_yapf"
+    default = False
+    help = "If true, don't run yapf on this target's code."
+
+
+def rules():
+    return [
+        PythonLibrary.register_plugin_field(SkipYapfField),
+        PythonTests.register_plugin_field(SkipYapfField),
+    ]

--- a/src/python/pants/backend/python/lint/yapf/subsystem.py
+++ b/src/python/pants/backend/python/lint/yapf/subsystem.py
@@ -40,7 +40,7 @@ class Yapf(PythonToolBase):
             member_type=shell_str,
             help=(
                 "Arguments to pass directly to yapf, e.g. "
-                f'`--{cls.options_scope}-args="--no-local-style"`. '
+                f'`--{cls.options_scope}-args="--no-local-style"`.\n\n'
                 "Certain arguments, specifically `--recursive`, `--in-place`, and "
                 "`--parallel`, will be ignored because Pants takes care of finding "
                 "all the relevant files and running the formatting in parallel."
@@ -65,7 +65,7 @@ class Yapf(PythonToolBase):
             advanced=True,
             help=(
                 "If true, Pants will include any relevant config files during "
-                "runs (`.style.yapf`, `pyproject.toml`, `setup.cfg`, and `~/.config/yapf/style`)."
+                "runs (`.style.yapf`, `pyproject.toml`, and `setup.cfg`)."
                 f"\n\nUse `[{cls.options_scope}].config` instead if your config is in a "
                 f"non-standard location."
             ),
@@ -85,15 +85,15 @@ class Yapf(PythonToolBase):
 
     def config_request(self, dirs: Iterable[str]) -> ConfigFilesRequest:
         # Refer to https://github.com/google/yapf#formatting-style.
+        check_existence = []
         check_content = {}
         for d in ("", *dirs):
+            check_existence.append(os.path.join(d, ".yapfignore"))
             check_content.update(
                 {
-                    os.path.join(d, "pyproject.toml"): b"[tool.yapf]",
+                    os.path.join(d, "pyproject.toml"): b"[tool.yapf",
                     os.path.join(d, "setup.cfg"): b"[yapf]",
                     os.path.join(d, ".style.yapf"): b"[style]",
-                    "~/.config/yapf/style": b"[style]",
-                    os.path.join(d, ".yapfignore"): b"",
                 }
             )
 
@@ -101,5 +101,6 @@ class Yapf(PythonToolBase):
             specified=self.config,
             specified_option_name=f"[{self.options_scope}].config",
             discovery=cast(bool, self.options.config_discovery),
+            check_existence=check_existence,
             check_content=check_content,
         )

--- a/src/python/pants/backend/python/lint/yapf/subsystem.py
+++ b/src/python/pants/backend/python/lint/yapf/subsystem.py
@@ -1,0 +1,103 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import os.path
+from typing import Iterable, cast
+
+from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.target_types import ConsoleScript
+from pants.core.util_rules.config_files import ConfigFilesRequest
+from pants.option.custom_types import file_option, shell_str
+
+
+class Yapf(PythonToolBase):
+    options_scope = "yapf"
+    help = "A formatter for Python files (https://github.com/google/yapf)."
+
+    default_version = "yapf==0.31.0"
+    default_extra_requirements = ["setuptools", "toml"]
+    register_interpreter_constraints = True
+    default_interpreter_constraints = ["CPython>=3.6"]
+    default_main = ConsoleScript("yapf")
+
+    @classmethod
+    def register_options(cls, register):
+        super().register_options(register)
+        register(
+            "--skip",
+            type=bool,
+            default=False,
+            help=(
+                f"Don't use yapf when running `{register.bootstrap.pants_bin_name} fmt` and "
+                f"`{register.bootstrap.pants_bin_name} lint`."
+            ),
+        )
+        register(
+            "--args",
+            type=list,
+            member_type=shell_str,
+            help=(
+                "Arguments to pass directly to yapf, e.g. "
+                f'`--{cls.options_scope}-args="--no-local-style"`.'
+                "All flags except ... are ignored (because they are handled by Pants)"  # TODO(alte)
+            ),
+        )
+        register(
+            "--config",
+            type=file_option,
+            default=None,
+            advanced=True,
+            help=(
+                "Path to style file understood by yapf "
+                "(https://github.com/google/yapf#formatting-style/).\n\n"
+                f"Setting this option will disable `[{cls.options_scope}].config_discovery`. Use "
+                f"this option if the config is located in a non-standard location."
+            ),
+        )
+        register(
+            "--config-discovery",
+            type=bool,
+            default=True,
+            advanced=True,
+            help=(
+                "If true, Pants will include any relevant config files during "
+                "runs (`.style.yapf`, `pyproject.toml`, `setup.cfg`, and `~/.config/yapf/style`)."
+                f"\n\nUse `[{cls.options_scope}].config` instead if your config is in a "
+                f"non-standard location."
+            ),
+        )
+
+    @property
+    def skip(self) -> bool:
+        return cast(bool, self.options.skip)
+
+    @property
+    def args(self) -> tuple[str, ...]:
+        return tuple(self.options.args)
+
+    @property
+    def config(self) -> str | None:
+        return cast("str | None", self.options.config)
+
+    def config_request(self, dirs: Iterable[str]) -> ConfigFilesRequest:
+        # Refer to https://github.com/google/yapf#formatting-style.
+        check_content = {}
+        for d in ("", *dirs):
+            check_content.update(
+                {
+                    os.path.join(d, "pyproject.toml"): b"[tool.yapf]",
+                    os.path.join(d, "setup.cfg"): b"[yapf]",
+                    os.path.join(d, ".style.yapf"): b"[style]",
+                    "~/.config/yapf/style": b"[style]",
+                    os.path.join(d, ".yapfignore"): b"",
+                }
+            )
+
+        return ConfigFilesRequest(
+            specified=self.config,
+            specified_option_name=f"[{self.options_scope}].config",
+            discovery=cast(bool, self.options.config_discovery),
+            check_content=check_content,
+        )

--- a/src/python/pants/backend/python/lint/yapf/subsystem.py
+++ b/src/python/pants/backend/python/lint/yapf/subsystem.py
@@ -40,8 +40,10 @@ class Yapf(PythonToolBase):
             member_type=shell_str,
             help=(
                 "Arguments to pass directly to yapf, e.g. "
-                f'`--{cls.options_scope}-args="--no-local-style"`.'
-                "All flags except ... are ignored (because they are handled by Pants)"  # TODO(alte)
+                f'`--{cls.options_scope}-args="--no-local-style"`. '
+                "Certain arguments, specifically `--recursive`, `--in-place`, and "
+                "`--parallel`, will be ignored because Pants takes care of finding "
+                "all the relevant files and running the formatting in parallel."
             ),
         )
         register(

--- a/src/python/pants/init/BUILD
+++ b/src/python/pants/init/BUILD
@@ -22,6 +22,7 @@ target(
     'src/python/pants/backend/python/lint/flake8',
     'src/python/pants/backend/python/lint/isort',
     'src/python/pants/backend/python/lint/pylint',
+    'src/python/pants/backend/python/lint/yapf',
     'src/python/pants/backend/python/mixed_interpreter_constraints',
     'src/python/pants/backend/python/typecheck/mypy',
     'src/python/pants/backend/shell',


### PR DESCRIPTION
This PR adds support for [YAPF](https://github.com/google/yapf) Python formatter via a new plugin.
The `yapf` plugin code is based on the code adapted from the `isort` plugin with a few concepts borrowed from the `black` one.

Its behaviour in principle is identical to what one would expect from the `black` and `isort` -- it's used in the `lint` and `fmt` goals (unless skipped with the `--yapf-skip` flag), has support for passing a config file explicitly via the `--yapf-config` flag, and can receive the additional arguments to be passed to the `yapf` command via the `--yapf-args.` 

A few details that are either important or are specific to `yapf:`

* When run, `yapf` exits with exit code `0` if when no changes were necessary and non-zero otherwise. 
* When the `lint` rule runs, the flag `--diff` is used (corresponding to the `--check` flag for `black`) and it shows the difference between the original and formatted code in the terminal.

[ci skip-rust]

[ci skip-build-wheels]