### PR TITLE
More robust support for Poetry dependency attributes (`markers`, and`extras`)

### DIFF
--- a/src/python/pants/backend/python/macros/poetry_requirements.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements.py
@@ -8,7 +8,7 @@ import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path, PurePath
-from typing import Any, Iterable, Iterator, List, Mapping, Optional, Sequence, Union, cast
+from typing import Any, Iterable, Iterator, List, Mapping, Optional, Sequence, cast
 
 import toml
 from packaging.version import InvalidVersion, Version
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 PyprojectAttr = TypedDict(
     "PyprojectAttr",
     {
-        "extras": Union[List[str], str],
+        "extras": List[str],
         "git": str,
         "rev": str,
         "branch": str,
@@ -232,8 +232,6 @@ def handle_dict_attr(
     extras_lookup = attributes.get("extras")
     if isinstance(extras_lookup, list):
         extras_str = f"[{','.join(extras_lookup)}]"
-    elif isinstance(extras_lookup, str):
-        extras_str = f"{extras_lookup}"
     else:
         extras_str = ""
 
@@ -280,9 +278,6 @@ def parse_single_dependency(
     pyproject_toml: PyProjectToml,
 ) -> Iterator[Requirement]:
 
-    # TODO(Liam Wilson): Type hints are a bit of a mess at the moment; I think the best way to
-    # clean this up is a TypedDict for the attributes argument; almost everything else loses a
-    # decent amount of information.
     if isinstance(attributes, str):
         # E.g. `foo = "~1.1~'.
         yield Requirement.parse(

--- a/src/python/pants/backend/python/macros/poetry_requirements.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements.py
@@ -211,16 +211,23 @@ def add_markers(base: str, attributes: PyprojectAttr, fp) -> str:
     # markers, we evaluate them as one whole, and then AND with the new marker for the Python constraint.
     # E.g. (marker1 AND marker2 OR marker3...) AND (python_version)
     # rather than (marker1 AND marker2 OR marker3 AND python_version)
-    return (
-        f"{base}"
-        f"{';' if len(markers_lookup) > 0 else ''}"
-        f"{'(' if (' and ' in markers_lookup or ' or ' in markers_lookup) else ''}"
-        f"{markers_lookup}"
-        f"{';' if python_lookup and not markers_lookup else ''}"
-        f"{')' if (' and ' in markers_lookup or ' or ' in markers_lookup) else ''}"
-        f"{' and ' if python_lookup and markers_lookup else ''}"
-        f"{python_lookup}"
-    )
+    if not markers_lookup and not python_lookup:
+        return base
+
+    result = base
+    if markers_lookup or python_lookup:
+        result += ";"
+        result += "("
+    if markers_lookup:
+        result += markers_lookup
+        result += ")"
+    if python_lookup and markers_lookup:
+        result += " and ("
+    if python_lookup:
+        result += python_lookup
+        result += ")"
+
+    return result
 
 
 def handle_dict_attr(

--- a/src/python/pants/backend/python/macros/poetry_requirements.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 PyprojectAttr = TypedDict(
     "PyprojectAttr",
     {
-        "extras": Union[List[str],str],
+        "extras": Union[List[str], str],
         "git": str,
         "rev": str,
         "branch": str,
@@ -230,9 +230,9 @@ def handle_dict_attr(
     fp = str(pyproject_toml.toml_relpath)
 
     extras_lookup = attributes.get("extras")
-    if type(extras_lookup) == list:
+    if isinstance(extras_lookup, list):
         extras_str = f"[{','.join(extras_lookup)}]"
-    elif type(extras_lookup) == str:
+    elif isinstance(extras_lookup, str):
         extras_str = f"{extras_lookup}"
     else:
         extras_str = ""
@@ -296,7 +296,7 @@ def parse_single_dependency(
     elif isinstance(attributes, dict):
         # E.g. `foo = {version = "~1.1"}`.
         pyproject_attr = cast(PyprojectAttr, attributes)
-        req_str = handle_dict_attr(proj_name,pyproject_attr, pyproject_toml)
+        req_str = handle_dict_attr(proj_name, pyproject_attr, pyproject_toml)
         if req_str:
             yield Requirement.parse(req_str)
     elif isinstance(attributes, list):

--- a/src/python/pants/backend/python/macros/poetry_requirements_test.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements_test.py
@@ -14,6 +14,7 @@ from pkg_resources import Requirement
 from pants.backend.python.macros.poetry_requirements import (
     PoetryRequirements,
     PyProjectToml,
+    add_markers,
     get_max_caret,
     get_max_tilde,
     handle_dict_attr,
@@ -84,6 +85,62 @@ def test_handle_str(test, exp) -> None:
     assert parse_str_version("foo", test, "") == f"foo {exp}"
 
 
+def test_add_markers() -> None:
+    # case with just mark
+    attr_mark = {"python": "3.6", "markers": "platform_python_implementation == 'CPython'"}
+    assert (
+        add_markers("foo==1.0.0", attr_adv_mark, "somepath")
+        == "foo==1.0.0;platform_python_implementation == 'CPython' and python_version == '3.6'"
+    )
+
+    # case with just py
+    attr_py = {"python": "3.6", "markers": "platform_python_implementation == 'CPython'"}
+    assert (
+        add_markers("foo==1.0.0", attr_adv_py, "somepath")
+        == "foo==1.0.0;platform_python_implementation == 'CPython' and python_version == '3.6'"
+    )
+
+    # case with just advanced mark
+    attr_adv_mark = {"python": "3.6", "markers": "platform_python_implementation == 'CPython'"}
+    assert (
+        add_markers("foo==1.0.0", attr_adv_mark, "somepath")
+        == "foo==1.0.0;platform_python_implementation == 'CPython' and python_version == '3.6'"
+    )
+
+    # case with just py
+    attr_adv_py = {"python": "3.6", "markers": "platform_python_implementation == 'CPython'"}
+    assert (
+        add_markers("foo==1.0.0", attr_adv_py, "somepath")
+        == "foo==1.0.0;platform_python_implementation == 'CPython' and python_version == '3.6'"
+    )
+
+    # case with basic mark basic py
+    attr_basic_both = {"python": "3.6", "markers": "platform_python_implementation == 'CPython'"}
+    assert (
+        add_markers("foo==1.0.0", attr_basic_both, "somepath")
+        == "foo==1.0.0;platform_python_implementation == 'CPython' and python_version == '3.6'"
+    )
+    # case with adv py basic mark
+    attr_adv_py_both = {"python": "3.6", "markers": "platform_python_implementation == 'CPython'"}
+    assert (
+        add_markers("foo==1.0.0", attr_adv_py_both, "somepath")
+        == "foo==1.0.0;platform_python_implementation == 'CPython' and python_version == '3.6'"
+    )
+
+    # case with multi mark simple py
+    attr_adv_mark_both = {"python": "3.6", "markers": "platform_python_implementation == 'CPython'"}
+    assert (
+        add_markers("foo==1.0.0", attr_adv_mark_both, "somepath")
+        == "foo==1.0.0;platform_python_implementation == 'CPython' and python_version == '3.6'"
+    )
+    # adv py adv mark
+    attr_adv_both = {"python": "3.6", "markers": "platform_python_implementation == 'CPython'"}
+    assert (
+        add_markers("foo==1.0.0", attr_adv_both, "somepath")
+        == "foo==1.0.0;platform_python_implementation == 'CPython' and python_version == '3.6'"
+    )
+
+
 def create_pyproject_toml(
     build_root: PurePath | str = ".",
     toml_relpath: PurePath | str = "pyproject.toml",
@@ -113,6 +170,14 @@ def test_handle_git(empty_pyproject_toml: PyProjectToml) -> None:
     assert_git({"branch": "main"}, "@main")
     assert_git({"tag": "v1.1.1"}, "@v1.1.1")
     assert_git({"rev": "1a2b3c4d"}, "#1a2b3c4d")
+    assert_git(
+        {
+            "branch": "main",
+            "markers": "platform_python_implementation == 'CPython'",
+            "python": "3.6",
+        },
+        "@main;platform_python_implementation == 'CPython' and python_version == '3.6'",
+    )
 
 
 def test_handle_path_arg(tmp_path: Path) -> None:


### PR DESCRIPTION
Addresses #12318 and #12319-- in general, adding support for handling these flags when using a `poetry_requirement`.

#12327/#12328 currently blocked; likely unblocked post-lockfile redesign (#12314)

[ci skip-rust]
[ci skip-build-wheels]