### PR TITLE
Bootstrap fewer JVM versions in Coursier/javac tests to hopefully reduce CI flakiness

### DIFF
--- a/src/python/pants/backend/java/compile/javac_binary_test.py
+++ b/src/python/pants/backend/java/compile/javac_binary_test.py
@@ -59,12 +59,6 @@ def test_java_binary_versions(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(["--javac-jdk=adopt:1.8"])
     assert "javac 1.8" in run_javac_version(rule_runner)
 
-    rule_runner.set_options(["--javac-jdk=adopt:1.16"])
-    assert "javac 16.0" in run_javac_version(rule_runner)
-
-    rule_runner.set_options(["--javac-jdk=openjdk:1.16"])
-    assert "javac 16.0" in run_javac_version(rule_runner)
-
     rule_runner.set_options(["--javac-jdk=bogusjdk:999"])
     expected_exception_msg = r".*?JVM bogusjdk:999 not found in index.*?"
     with pytest.raises(ExecutionError, match=expected_exception_msg):

--- a/src/python/pants/backend/java/compile/javac_test.py
+++ b/src/python/pants/backend/java/compile/javac_test.py
@@ -146,22 +146,6 @@ def test_compile_jdk_versions(rule_runner: RuleRunner) -> None:
         target=rule_runner.get_target(address=Address(spec_path="", target_name="lib"))
     )
 
-    rule_runner.set_options(["--javac-jdk=openjdk:1.16.0-1"])
-    assert {
-        contents.path
-        for contents in rule_runner.request(
-            DigestContents, [rule_runner.request(CompiledClassfiles, [request]).digest]
-        )
-    } == {"org/pantsbuild/example/lib/ExampleLib.class"}
-
-    rule_runner.set_options(["--javac-jdk=adopt:1.8"])
-    assert {
-        contents.path
-        for contents in rule_runner.request(
-            DigestContents, [rule_runner.request(CompiledClassfiles, [request]).digest]
-        )
-    } == {"org/pantsbuild/example/lib/ExampleLib.class"}
-
     rule_runner.set_options(["--javac-jdk=zulu:1.6"])
     assert {
         contents.path


### PR DESCRIPTION
See https://github.com/pantsbuild/pants/issues/12293#issuecomment-878667715 for motivation.  This commit has no functional change, and almost certainly doesn't reduce the efficacy of the existing tests in any substantial way.

[ci skip-rust]
[ci skip-build-wheels]