### PR TITLE
Dependency inference for `pex_binary` and `python_awslambda` can disambiguate ambiguous modules based on file paths

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/protobuf_dependency_inference.py
+++ b/src/python/pants/backend/codegen/protobuf/protobuf_dependency_inference.py
@@ -122,7 +122,7 @@ async def infer_protobuf_dependencies(
                         f"{file_content.path}"
                     ),
                 )
-                maybe_disambiguated = explicitly_provided_deps.disambiguated_via_ignores(ambiguous)
+                maybe_disambiguated = explicitly_provided_deps.disambiguated(ambiguous)
                 if maybe_disambiguated:
                     result.add(maybe_disambiguated)
     return InferredDependencies(sorted(result), sibling_dependencies_inferrable=True)

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -159,7 +159,7 @@ async def infer_python_dependencies_via_imports(
             import_reference="module",
             context=f"The target {address} imports `{imp}`",
         )
-        maybe_disambiguated = explicitly_provided_deps.disambiguated_via_ignores(owners.ambiguous)
+        maybe_disambiguated = explicitly_provided_deps.disambiguated(owners.ambiguous)
         if maybe_disambiguated:
             merged_result.add(maybe_disambiguated)
 

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -227,6 +227,7 @@ class PexEntryPointField(AsyncFieldMixin, SecondaryOwnerMixin, Field):
 @dataclass(frozen=True)
 class ResolvedPexEntryPoint:
     val: Optional[EntryPoint]
+    file_name_used: bool
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/shell/dependency_inference.py
+++ b/src/python/pants/backend/shell/dependency_inference.py
@@ -192,7 +192,7 @@ async def infer_shell_dependencies(
                     import_reference="file",
                     context=f"The target {address} sources `{import_path}`",
                 )
-                maybe_disambiguated = explicitly_provided_deps.disambiguated_via_ignores(ambiguous)
+                maybe_disambiguated = explicitly_provided_deps.disambiguated(ambiguous)
                 if maybe_disambiguated:
                     result.add(maybe_disambiguated)
     return InferredDependencies(sorted(result), sibling_dependencies_inferrable=True)

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -722,7 +722,9 @@ async def determine_explicitly_provided_dependencies(
     parsed_includes = await MultiGet(Get(Address, AddressInput, ai) for ai in addresses)
     parsed_ignores = await MultiGet(Get(Address, AddressInput, ai) for ai in ignored_addresses)
     return ExplicitlyProvidedDependencies(
-        FrozenOrderedSet(sorted(parsed_includes)), FrozenOrderedSet(sorted(parsed_ignores))
+        request.field.address,
+        FrozenOrderedSet(sorted(parsed_includes)),
+        FrozenOrderedSet(sorted(parsed_ignores)),
     )
 
 

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -1338,6 +1338,7 @@ def test_explicitly_provided_dependencies(dependencies_rule_runner: RuleRunner) 
     result = dependencies_rule_runner.request(
         ExplicitlyProvidedDependencies, [DependenciesRequest(target[Dependencies])]
     )
+    assert result.address == target.address
     expected_addresses = {Address("a/b/c"), Address("files", relative_file_path="f.txt")}
     assert set(result.includes) == expected_addresses
     assert set(result.ignores) == {

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1645,7 +1645,12 @@ class ExplicitlyProvidedDependencies:
             )
             if owners_must_be_ancestors is False:
                 return not is_ignored
-            return not is_ignored and original_addr_path.is_relative_to(addr.spec_path)
+            # NB: `PurePath.is_relative_to()` was not added until Python 3.9. This emulates it.
+            try:
+                original_addr_path.relative_to(addr.spec_path)
+                return not is_ignored
+            except ValueError:
+                return False
 
         return frozenset(filter(is_valid, addresses))
 


### PR DESCRIPTION
A user has the files `root1/app.py` and `root2/app.py`. In both folders, they have a `pex_binary` with `entry_point="app.py"`. Our dep inference code complains this is ambiguous because >1 target exports the module `app`.

But we can leverage this requirement for the `pex_binary` and `python_awslambda` targets to do better than that:

> Like with the sources field, file paths are relative to the BUILD file, rather than the build root.

This assumption means that we know—when using a file name—that file must be in the current dir of the target or a subdir. That implies that all owning targets of the file must be in the current dir or an ancestor dir. We can safely ignore all candidate targets out of that tree.

[ci skip-rust]
[ci skip-build-wheels]