### PR TITLE
add version_constraints option to external tool definition.

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -39,6 +39,7 @@ class PexBinary(TemplatedExternalTool):
 
     default_version = "v2.1.42"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
+    version_constraints = ">=2.1.42, <3.0"
 
     @classproperty
     def default_known_versions(cls):

--- a/src/python/pants/core/util_rules/external_tool_test.py
+++ b/src/python/pants/core/util_rules/external_tool_test.py
@@ -10,10 +10,10 @@ from pants.core.util_rules.external_tool import (
     ExternalTool,
     ExternalToolError,
     ExternalToolRequest,
-    ExternalToolVersionConstraintsViolationAction,
     TemplatedExternalTool,
     UnknownVersion,
     UnsupportedVersion,
+    UnsupportedVersionUsage,
 )
 from pants.engine.fs import DownloadFile, FileDigest
 from pants.engine.platform import Platform
@@ -144,16 +144,16 @@ def no_exception():
     [
         (
             "v1.2.3",
-            ExternalToolVersionConstraintsViolationAction.RaiseError,
+            UnsupportedVersionUsage.RaiseError,
             pytest.raises(
                 UnsupportedVersion,
-                match="Version v1.2.3 does not satisfy the version constraints foobar<3.8,>3.2.1",
+                match="foobar v1.2.3 does not satisfy the version constraints foobar<3.8,>3.2.1",
             ),
             None,
         ),
         (
             "v3.2.2",
-            ExternalToolVersionConstraintsViolationAction.RaiseError,
+            UnsupportedVersionUsage.RaiseError,
             pytest.raises(
                 UnknownVersion, match="No known version of foobar v3.2.2 for darwin found in"
             ),
@@ -161,21 +161,21 @@ def no_exception():
         ),
         (
             "v3.4.7",
-            ExternalToolVersionConstraintsViolationAction.RaiseError,
+            UnsupportedVersionUsage.RaiseError,
             no_exception(),
             None,
         ),
         (
             "v3.8.0",
-            ExternalToolVersionConstraintsViolationAction.RaiseError,
+            UnsupportedVersionUsage.RaiseError,
             pytest.raises(
-                UnsupportedVersion, match="Version v3.8.0 does not satisfy the version constraints"
+                UnsupportedVersion, match="foobar v3.8.0 does not satisfy the version constraints"
             ),
             None,
         ),
         (
             "v3.8.0",
-            ExternalToolVersionConstraintsViolationAction.LogWarning,
+            UnsupportedVersionUsage.LogWarning,
             pytest.raises(
                 UnknownVersion, match="No known version of foobar v3.8.0 for darwin found in"
             ),
@@ -188,7 +188,7 @@ def no_exception():
         ),
         (
             "v3.8.0",
-            ExternalToolVersionConstraintsViolationAction.Ignore,
+            UnsupportedVersionUsage.Allow,
             pytest.raises(
                 UnknownVersion, match="No known version of foobar v3.8.0 for darwin found in"
             ),
@@ -209,7 +209,7 @@ def test_version_constraints(caplog, version, action, assert_expectation, expect
         create_subsystem(
             ConstrainedTool,
             version=version,
-            on_version_constraints_violation=action,
+            use_unsupported_version=action,
             known_versions=ConstrainedTool.default_known_versions,
             url_template=ConstrainedTool.default_url_template,
             url_platform_mapping=ConstrainedTool.default_url_platform_mapping,

--- a/src/python/pants/core/util_rules/external_tool_test.py
+++ b/src/python/pants/core/util_rules/external_tool_test.py
@@ -1,6 +1,7 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import logging
 from contextlib import contextmanager
 
 import pytest
@@ -9,6 +10,7 @@ from pants.core.util_rules.external_tool import (
     ExternalTool,
     ExternalToolError,
     ExternalToolRequest,
+    ExternalToolVersionConstraintsViolationAction,
     TemplatedExternalTool,
     UnknownVersion,
     UnsupportedVersion,
@@ -114,13 +116,13 @@ class ConstrainedTool(TemplatedExternalTool):
     name = "foobar"
     options_scope = "foobar"
     version_constraints = ">3.2.1, <3.8"
-    default_version = "3.4.7"
+    default_version = "v3.4.7"
     default_known_versions = [
-        "3.2.0|darwin   |1102324cdaacd589e50b8b7770595f220f54e18a1d76ee3c445198f80ab865b8|123346",
-        "3.2.0|linux_ppc|39e5d64b0f31117c94651c880d0a776159e49eab42b2066219569934b936a5e7|124443",
-        "3.2.0|linux    |c0c667fb679a8221bed01bffeed1f80727c6c7827d0cbd8f162195efb12df9e4|121212",
-        "3.4.7|darwin   |9d0e18cd74b918c7b3edd0203e75569e0c8caecb1367b3be409b45e28514f5be|123321",
-        "3.4.7|linux    |a019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5|134213",
+        "v3.2.0|darwin   |1102324cdaacd589e50b8b7770595f220f54e18a1d76ee3c445198f80ab865b8|123346",
+        "v3.2.0|linux_ppc|39e5d64b0f31117c94651c880d0a776159e49eab42b2066219569934b936a5e7|124443",
+        "v3.2.0|linux    |c0c667fb679a8221bed01bffeed1f80727c6c7827d0cbd8f162195efb12df9e4|121212",
+        "v3.4.7|darwin   |9d0e18cd74b918c7b3edd0203e75569e0c8caecb1367b3be409b45e28514f5be|123321",
+        "v3.4.7|linux    |a019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5|134213",
     ]
     default_url_template = "https://foobar.org/bin/v{version}/foobar-{version}-{platform}.tgz"
     default_url_platform_mapping = {
@@ -138,36 +140,86 @@ def no_exception():
 
 
 @pytest.mark.parametrize(
-    "version, assert_expectation",
+    "version, action, assert_expectation, expect_logged",
     [
         (
-            "1.2.3",
+            "v1.2.3",
+            ExternalToolVersionConstraintsViolationAction.RaiseError,
             pytest.raises(
                 UnsupportedVersion,
-                match="Version 1.2.3 does not satisfy the version constraint foobar<3.8,>3.2.1",
+                match="Version v1.2.3 does not satisfy the version constraints foobar<3.8,>3.2.1",
             ),
+            None,
         ),
         (
-            "3.2.2",
+            "v3.2.2",
+            ExternalToolVersionConstraintsViolationAction.RaiseError,
             pytest.raises(
-                UnknownVersion, match="No known version of foobar 3.2.2 for darwin found in"
+                UnknownVersion, match="No known version of foobar v3.2.2 for darwin found in"
             ),
+            None,
         ),
-        ("3.4.7", no_exception()),
         (
-            "3.8.0",
+            "v3.4.7",
+            ExternalToolVersionConstraintsViolationAction.RaiseError,
+            no_exception(),
+            None,
+        ),
+        (
+            "v3.8.0",
+            ExternalToolVersionConstraintsViolationAction.RaiseError,
             pytest.raises(
-                UnsupportedVersion, match="Version 3.8.0 does not satisfy the version constraint"
+                UnsupportedVersion, match="Version v3.8.0 does not satisfy the version constraints"
             ),
+            None,
+        ),
+        (
+            "v3.8.0",
+            ExternalToolVersionConstraintsViolationAction.LogWarning,
+            pytest.raises(
+                UnknownVersion, match="No known version of foobar v3.8.0 for darwin found in"
+            ),
+            [
+                (
+                    logging.WARNING,
+                    "foobar v3.8.0 may not be compatible with this version of pants, as it does not satisfy the constraints foobar<3.8,>3.2.1",
+                )
+            ],
+        ),
+        (
+            "v3.8.0",
+            ExternalToolVersionConstraintsViolationAction.Ignore,
+            pytest.raises(
+                UnknownVersion, match="No known version of foobar v3.8.0 for darwin found in"
+            ),
+            [
+                (
+                    logging.DEBUG,
+                    "Ignoring constraints for version v3.8.0, does not satisfy version constraints foobar<3.8,>3.2.1",
+                )
+            ],
         ),
     ],
 )
-def test_version_constraints(version, assert_expectation) -> None:
+def test_version_constraints(caplog, version, action, assert_expectation, expect_logged) -> None:
+    caplog.set_level(logging.DEBUG)
+    caplog.clear()
+
     with assert_expectation:
         create_subsystem(
             ConstrainedTool,
             version=version,
+            on_version_constraints_violation=action,
             known_versions=ConstrainedTool.default_known_versions,
             url_template=ConstrainedTool.default_url_template,
             url_platform_mapping=ConstrainedTool.default_url_platform_mapping,
         ).get_request(Platform.darwin)
+
+    if expect_logged:
+        assert len(caplog.records) == len(expect_logged)
+        for idx, (lvl, msg) in enumerate(expect_logged):
+            log_record = caplog.records[idx]
+            assert msg in log_record.message
+            assert lvl == log_record.levelno
+    else:
+        assert not caplog.records

--- a/src/python/pants/core/util_rules/external_tool_test.py
+++ b/src/python/pants/core/util_rules/external_tool_test.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from contextlib import contextmanager
+
 import pytest
 
 from pants.core.util_rules.external_tool import (
@@ -9,6 +11,7 @@ from pants.core.util_rules.external_tool import (
     ExternalToolRequest,
     TemplatedExternalTool,
     UnknownVersion,
+    UnsupportedVersion,
 )
 from pants.engine.fs import DownloadFile, FileDigest
 from pants.engine.platform import Platform
@@ -104,4 +107,67 @@ def test_generate_request() -> None:
     with pytest.raises(UnknownVersion):
         create_subsystem(
             FooBar, version="9.9.9", known_versions=FooBar.default_known_versions
+        ).get_request(Platform.darwin)
+
+
+class ConstrainedTool(TemplatedExternalTool):
+    name = "foobar"
+    options_scope = "foobar"
+    version_constraints = ">3.2.1, <3.8"
+    default_version = "3.4.7"
+    default_known_versions = [
+        "3.2.0|darwin   |1102324cdaacd589e50b8b7770595f220f54e18a1d76ee3c445198f80ab865b8|123346",
+        "3.2.0|linux_ppc|39e5d64b0f31117c94651c880d0a776159e49eab42b2066219569934b936a5e7|124443",
+        "3.2.0|linux    |c0c667fb679a8221bed01bffeed1f80727c6c7827d0cbd8f162195efb12df9e4|121212",
+        "3.4.7|darwin   |9d0e18cd74b918c7b3edd0203e75569e0c8caecb1367b3be409b45e28514f5be|123321",
+        "3.4.7|linux    |a019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5|134213",
+    ]
+    default_url_template = "https://foobar.org/bin/v{version}/foobar-{version}-{platform}.tgz"
+    default_url_platform_mapping = {
+        "darwin": "osx-x86_64",
+        "linux": "linux-x86_64",
+    }
+
+    def generate_exe(self, plat: Platform) -> str:
+        return f"foobar-{self.version}/bin/foobar"
+
+
+@contextmanager
+def no_exception():
+    yield None
+
+
+@pytest.mark.parametrize(
+    "version, assert_expectation",
+    [
+        (
+            "1.2.3",
+            pytest.raises(
+                UnsupportedVersion,
+                match="Version 1.2.3 does not satisfy the version constraint foobar<3.8,>3.2.1",
+            ),
+        ),
+        (
+            "3.2.2",
+            pytest.raises(
+                UnknownVersion, match="No known version of foobar 3.2.2 for darwin found in"
+            ),
+        ),
+        ("3.4.7", no_exception()),
+        (
+            "3.8.0",
+            pytest.raises(
+                UnsupportedVersion, match="Version 3.8.0 does not satisfy the version constraint"
+            ),
+        ),
+    ],
+)
+def test_version_constraints(version, assert_expectation) -> None:
+    with assert_expectation:
+        create_subsystem(
+            ConstrainedTool,
+            version=version,
+            known_versions=ConstrainedTool.default_known_versions,
+            url_template=ConstrainedTool.default_url_template,
+            url_platform_mapping=ConstrainedTool.default_url_platform_mapping,
         ).get_request(Platform.darwin)

--- a/src/python/pants/core/util_rules/external_tool_test.py
+++ b/src/python/pants/core/util_rules/external_tool_test.py
@@ -144,9 +144,9 @@ class ConstrainedTool(TemplatedExternalTool):
             pytest.raises(
                 UnsupportedVersion,
                 match=re.escape(
-                    "The option [foobar].version is set to v1.2.3, which is not compatible with what this release of Pants expects: foobar<3.8,>3.2.1\n"
-                    "Please update the version to a supported value, or consider using a different Pants release if you cannot change the version.\n"
-                    "Alternatively, update [foobar].use_unsupported_version to be 'allow' or 'warning'."
+                    "The option [foobar].version is set to v1.2.3, which is not compatible with what this release of Pants expects: foobar<3.8,>3.2.1. "
+                    "Please update the version to a supported value, or consider using a different Pants release if you cannot change the version. "
+                    "Alternatively, update [foobar].use_unsupported_version to be 'warning'."
                 ),
             ),
             None,
@@ -171,9 +171,9 @@ class ConstrainedTool(TemplatedExternalTool):
             pytest.raises(
                 UnsupportedVersion,
                 match=re.escape(
-                    "The option [foobar].version is set to v3.8.0, which is not compatible with what this release of Pants expects: foobar<3.8,>3.2.1\n"
-                    "Please update the version to a supported value, or consider using a different Pants release if you cannot change the version.\n"
-                    "Alternatively, update [foobar].use_unsupported_version to be 'allow' or 'warning'."
+                    "The option [foobar].version is set to v3.8.0, which is not compatible with what this release of Pants expects: foobar<3.8,>3.2.1. "
+                    "Please update the version to a supported value, or consider using a different Pants release if you cannot change the version. "
+                    "Alternatively, update [foobar].use_unsupported_version to be 'warning'."
                 ),
             ),
             None,
@@ -188,24 +188,10 @@ class ConstrainedTool(TemplatedExternalTool):
                 (
                     logging.WARNING,
                     (
-                        "The option [foobar].version is set to v3.8.0, which is not compatible with what this release of Pants expects: foobar<3.8,>3.2.1\n"
-                        "Please update the version to a supported value, or consider using a different Pants release if you cannot change the version."
-                    ),
-                )
-            ],
-        ),
-        (
-            "v3.8.0",
-            UnsupportedVersionUsage.Allow,
-            pytest.raises(
-                UnknownVersion, match="No known version of foobar v3.8.0 for darwin found in"
-            ),
-            [
-                (
-                    logging.INFO,
-                    (
-                        "The option [foobar].version is set to v3.8.0, which is not compatible with what this release of Pants expects: foobar<3.8,>3.2.1\n"
-                        "The option [foobar].use_unsupported_version is set to 'allow'."
+                        "The option [foobar].version is set to v3.8.0, which is not compatible with what this release of Pants expects: foobar<3.8,>3.2.1. "
+                        "Please update the version to a supported value, or consider using a different Pants release if you cannot change the version. "
+                        "Alternatively, you can ignore this warning (at your own peril) by adding this to the GLOBAL section of pants.toml: "
+                        'ignore_warnings = ["The option [foobar].version is set to"].'
                     ),
                 )
             ],

--- a/src/python/pants/testutil/pytest_util.py
+++ b/src/python/pants/testutil/pytest_util.py
@@ -1,0 +1,22 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def no_exception():
+    """Useful replacement for `pytest.raises()`, when there is no exception to be expected.
+
+    When declaring parametrized tests, the test function can take a exceptions
+    expectation as input, and always use a with-block for the code under test.
+
+        @pytest.mark.parametrize('answer, expect_raises', [
+            (42, no_exception()),
+            (12, pytest.raises(WrongAnswer)),
+        ])
+        def test_search_for_the_meaning_of_life_universe_and_everything(answer, expect_raises):
+            with expect_raises:
+                computer.validate_result(answer)
+    """
+    yield None


### PR DESCRIPTION
Added initial pex version constraint >=2.1.42 <3.0

fixes #12086

Signed-off-by: Andreas Stenius <andreas.stenius@svenskaspel.se>

[ci skip-rust]