### PR TITLE
Add psycopg2-binary to default module mapping

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -11,6 +11,7 @@ DEFAULT_MODULE_MAPPING = {
     "djangorestframework": ("rest_framework",),
     "enum34": ("enum",),
     "paho-mqtt": ("paho",),
+    "psycopg2-binary": ("psycopg2",),
     "protobuf": ("google.protobuf",),
     "pycrypto": ("Crypto",),
     "pyopenssl": ("OpenSSL",),


### PR DESCRIPTION
This package is extremely popular in the python ecosystem and basically if someone has a python app that talks to a postgresql db, this is the package that gets used.
so pants should include it in the default mapping.
<img width="1581" alt="Screen Shot 2021-07-13 at 2 53 22 PM" src="https://user-images.githubusercontent.com/1268088/125530223-050daefc-f3f7-4433-ac66-f0a9dd7a74d3.png">
<img width="1308" alt="Screen Shot 2021-07-13 at 2 54 06 PM" src="https://user-images.githubusercontent.com/1268088/125530297-0d300954-da51-4584-88dc-3c091710f55e.png">
https://pypistats.org/packages/psycopg2-binary
<img width="1362" alt="Screen Shot 2021-07-13 at 2 54 43 PM" src="https://user-images.githubusercontent.com/1268088/125530335-185cfcea-9443-409e-9a44-df122786db34.png">

https://snyk.io/advisor/python/psycopg2