### PR TITLE
Reduce # of resolves when packaging `pex_binary` and `python_awslambda` targets

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -18,13 +18,7 @@ from pants.backend.python.target_types import (
     parse_requirements_file,
 )
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.pex import (
-    Pex,
-    PexPlatforms,
-    PexRequest,
-    PexRequirements,
-    TwoStepPexRequest,
-)
+from pants.backend.python.util_rules.pex import Pex, PexPlatforms, PexRequest, PexRequirements
 from pants.backend.python.util_rules.pex import rules as pex_rules
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFilesRequest,
@@ -161,21 +155,6 @@ class PexFromTargetsRequest:
             internal_only=internal_only,
             direct_deps_only=direct_deps_only,
         )
-
-
-@dataclass(frozen=True)
-class TwoStepPexFromTargetsRequest:
-    """Request to create a PEX from the closure of a set of targets, in two steps.
-
-    First we create a requirements-only pex. Then we create the full pex on top of that
-    requirements pex, instead of having the full pex directly resolve its requirements.
-
-    This allows us to re-use the requirements-only pex when no requirements have changed (which is
-    the overwhelmingly common case), thus avoiding spurious re-resolves of the same requirements
-    over and over again.
-    """
-
-    pex_from_targets_request: PexFromTargetsRequest
 
 
 @rule(level=LogLevel.DEBUG)
@@ -347,12 +326,6 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
         additional_args=request.additional_args,
         description=description,
     )
-
-
-@rule
-async def two_step_pex_from_targets(req: TwoStepPexFromTargetsRequest) -> TwoStepPexRequest:
-    pex_request = await Get(PexRequest, PexFromTargetsRequest, req.pex_from_targets_request)
-    return TwoStepPexRequest(pex_request=pex_request)
 
 
 def rules():


### PR DESCRIPTION
We already use repository PEXes when `[python-setup].resolve_all_constraints` or experimental lockfile are set, thanks to code in `pex_from_targets.py`. Those benefit from using the same repository PEX as the rest of the codebase, e.g. when using MyPy or Pytest.

However, we were ignoring this repository pex with `python_awslambda` and `pex_binary` and resolving more granular repository PEXes after having already resolved the global one. Iiuc, those more granular ones are not coming from the global one. This is wasted work. 

While a `TwoStepPex` could be useful in those two callsites if you are not using constraints/lockfiles, we strongly encourage using lockfiles. 

Removing `TwoStepPex` allows us to remove complexity in a hairy part of the codebase, especially as we add new complexity for lockfile support.

[ci skip-rust]
[ci skip-build-wheels]