### PR TITLE
[Internal] Add `git_url()` helper to `docutil.py`

### DIFF
--- a/src/python/pants/util/docutil.py
+++ b/src/python/pants/util/docutil.py
@@ -19,10 +19,5 @@ def doc_url(slug: str) -> str:
 
 
 def git_url(fp: str) -> str:
-    """Link to code in pantsbuild/pants.
-
-    Note that links will not be stable for dev releases because `main` floats. Only release
-    candidates and stable releases have stable links.
-    """
-    branch = "main" if PANTS_SEMVER.is_devrelease else f"{MAJOR_MINOR}.x"
-    return f"https://github.com/pantsbuild/pants/blob/{branch}/{fp}"
+    """Link to code in pantsbuild/pants."""
+    return f"https://github.com/pantsbuild/pants/blob/release_{PANTS_SEMVER}/{fp}"

--- a/src/python/pants/util/docutil.py
+++ b/src/python/pants/util/docutil.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import shutil
 
-from pants.version import MAJOR_MINOR
+from pants.version import MAJOR_MINOR, PANTS_SEMVER
 
 
 # NB: This is not memoized because that would cause Pants to not pick up terminal resizing when
@@ -16,3 +16,13 @@ def terminal_width(*, fallback: int = 96, padding: int = 2) -> int:
 
 def doc_url(slug: str) -> str:
     return f"https://www.pantsbuild.org/v{MAJOR_MINOR}/docs/{slug}"
+
+
+def git_url(fp: str) -> str:
+    """Link to code in pantsbuild/pants.
+
+    Note that links will not be stable for dev releases because `main` floats. Only release
+    candidates and stable releases have stable links.
+    """
+    branch = "main" if PANTS_SEMVER.is_devrelease else f"{MAJOR_MINOR}.x"
+    return f"https://github.com/pantsbuild/pants/blob/{branch}/{fp}"

--- a/src/python/pants/util/docutil_test.py
+++ b/src/python/pants/util/docutil_test.py
@@ -1,0 +1,30 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from packaging.version import Version
+
+from pants.util import docutil
+from pants.util.docutil import doc_url, git_url
+
+
+def test_doc_url(monkeypatch) -> None:
+    monkeypatch.setattr(docutil, "MAJOR_MINOR", "1.29")
+    assert doc_url("some-slug") == "https://www.pantsbuild.org/v1.29/docs/some-slug"
+
+
+def test_git_url(monkeypatch) -> None:
+    monkeypatch.setattr(docutil, "MAJOR_MINOR", "1.29")
+    monkeypatch.setattr(docutil, "PANTS_SEMVER", Version("1.29.0.dev0"))
+    assert git_url("some_file.ext") == "https://github.com/pantsbuild/pants/blob/main/some_file.ext"
+
+    monkeypatch.setattr(docutil, "PANTS_SEMVER", Version("1.29.0rc0"))
+    assert (
+        git_url("some_file.ext") == "https://github.com/pantsbuild/pants/blob/1.29.x/some_file.ext"
+    )
+
+    monkeypatch.setattr(docutil, "PANTS_SEMVER", Version("1.29.0"))
+    assert (
+        git_url("some_file.ext") == "https://github.com/pantsbuild/pants/blob/1.29.x/some_file.ext"
+    )

--- a/src/python/pants/util/docutil_test.py
+++ b/src/python/pants/util/docutil_test.py
@@ -15,16 +15,20 @@ def test_doc_url(monkeypatch) -> None:
 
 
 def test_git_url(monkeypatch) -> None:
-    monkeypatch.setattr(docutil, "MAJOR_MINOR", "1.29")
     monkeypatch.setattr(docutil, "PANTS_SEMVER", Version("1.29.0.dev0"))
-    assert git_url("some_file.ext") == "https://github.com/pantsbuild/pants/blob/main/some_file.ext"
+    assert (
+        git_url("some_file.ext")
+        == "https://github.com/pantsbuild/pants/blob/release_1.29.0.dev0/some_file.ext"
+    )
 
     monkeypatch.setattr(docutil, "PANTS_SEMVER", Version("1.29.0rc0"))
     assert (
-        git_url("some_file.ext") == "https://github.com/pantsbuild/pants/blob/1.29.x/some_file.ext"
+        git_url("some_file.ext")
+        == "https://github.com/pantsbuild/pants/blob/release_1.29.0rc0/some_file.ext"
     )
 
     monkeypatch.setattr(docutil, "PANTS_SEMVER", Version("1.29.0"))
     assert (
-        git_url("some_file.ext") == "https://github.com/pantsbuild/pants/blob/1.29.x/some_file.ext"
+        git_url("some_file.ext")
+        == "https://github.com/pantsbuild/pants/blob/release_1.29.0/some_file.ext"
     )


### PR DESCRIPTION
For per-tool lockfiles in https://github.com/pantsbuild/pants/pull/12346, we will be embedding the default lockfile as a resource. We want to allow users to see what is in the lockfile, but don't want to dump all the contents to `./pants help`. 

Instead, this new `git_url()` util will allow us to link to the URL for the text file on GitHub.

[ci skip-rust]
[ci skip-build-wheels]