### PR TITLE
[internal] Manually fix Black lockfile to handle interpreter constraints

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -83,8 +83,7 @@ experimental_lockfile = "src/python/pants/backend/codegen/protobuf/python/mypy_p
 experimental_lockfile = "src/python/pants/backend/awslambda/python/lambdex_lockfile.txt"
 
 [black]
-# TODO(#12200): Figure out how to get this lockfile to work with multiple interpreters.
-# experimental_lockfile = "src/python/pants/backend/python/lint/black/lockfile.txt"
+experimental_lockfile = "src/python/pants/backend/python/lint/black/lockfile.txt"
 
 [docformatter]
 args = ["--wrap-summaries=100", "--wrap-descriptions=100"]

--- a/src/python/pants/backend/python/lint/black/lockfile.txt
+++ b/src/python/pants/backend/python/lint/black/lockfile.txt
@@ -16,11 +16,11 @@ click==8.0.1 \
     --hash=sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a \
     --hash=sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6
     # via black
-dataclasses==0.8 \
+dataclasses==0.8 ; python_version == '3.6' \
     --hash=sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf \
     --hash=sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97
     # via black
-importlib-metadata==4.6.1 \
+importlib-metadata==4.6.1 ; python_version == '3.6' or python_version == '3.7' \
     --hash=sha256:079ada16b7fc30dfbb5d13399a5113110dab1aa7c2bc62f66af75f0b717c8cac \
     --hash=sha256:9f55f560e116f8643ecf2922d9cd3e1c7e8d52e683178fecd9d08f6aa357e11e
     # via click
@@ -79,7 +79,7 @@ toml==0.10.2 \
     --hash=sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b \
     --hash=sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f
     # via black
-typed-ast==1.4.3 \
+typed-ast==1.4.3 ; python_version == '3.6' or python_version == '3.7' \
     --hash=sha256:01ae5f73431d21eead5015997ab41afa53aa1fbe252f9da060be5dad2c730ace \
     --hash=sha256:067a74454df670dcaa4e59349a2e5c81e567d8d65458d480a5b3dfecec08c5ff \
     --hash=sha256:0fb71b8c643187d7492c1f8352f2c15b4c4af3f6338f21681d3681b3dc31a266 \
@@ -111,14 +111,14 @@ typed-ast==1.4.3 \
     --hash=sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f \
     --hash=sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65
     # via black
-typing-extensions==3.10.0.0 \
+typing-extensions==3.10.0.0 ; python_version == '3.6' or python_version == '3.7' \
     --hash=sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497 \
     --hash=sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342 \
     --hash=sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84
     # via
     #   black
     #   importlib-metadata
-zipp==3.5.0 \
+zipp==3.5.0 ; python_version == '3.6' or python_version == '3.7' \
     --hash=sha256:957cfda87797e389580cb8b9e3870841ca991e2125350677b2ca83a0e99390a3 \
     --hash=sha256:f5812b1e007e48cff63449a5e9f4e7ebea716b4111f9c4f9a645f91d579bf0c4
     # via importlib-metadata


### PR DESCRIPTION
As explained in https://github.com/pantsbuild/pants/pull/12362. 

https://github.com/pantsbuild/pants/pull/12362 showed three different formats for how to handle conflicting interpreter constraints. We all agreed to liking format 3 the most: a unified lockfile that uses environment markers to make the lockfile safe for every interpreter in the range.

This lockfile was manually created. In followups, we will automate the generation of this merged lockfile. (Nothing will need to change on the consumption-side, only generation.)

[ci skip-rust]
[ci skip-build-wheels]