### PR TITLE
Mark workunits blocked, and skip rendering completed workunits (cherrypick of #12369)

### DIFF
--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -31,7 +31,7 @@ from pants.engine.internals.engine_testutil import (
 from pants.engine.internals.scheduler import ExecutionError, SchedulerSession
 from pants.engine.internals.scheduler_test_base import SchedulerTestBase
 from pants.engine.platform import rules as platform_rules
-from pants.engine.process import MultiPlatformProcess, Process, ProcessResult
+from pants.engine.process import MultiPlatformProcess, Process, ProcessCacheScope, ProcessResult
 from pants.engine.process import rules as process_rules
 from pants.engine.rules import Get, MultiGet, rule
 from pants.engine.streaming_workunit_handler import (
@@ -609,6 +609,7 @@ class StreamingWorkunitTests(unittest.TestCase, SchedulerTestBase):
             proc = Process(
                 ["/bin/sh", "-c", "true"],
                 description="always true",
+                cache_scope=ProcessCacheScope.PER_SESSION,
             )
             _ = await Get(ProcessResult, MultiPlatformProcess({None: proc}))
             return TrueResult()
@@ -624,9 +625,9 @@ class StreamingWorkunitTests(unittest.TestCase, SchedulerTestBase):
 
         finished = list(itertools.chain.from_iterable(tracker.finished_workunit_chunks))
         workunits_with_counters = [item for item in finished if "counters" in item]
-        assert workunits_with_counters[0]["counters"]["local_execution_requests"] == 1
-        assert workunits_with_counters[1]["counters"]["local_cache_requests"] == 1
-        assert workunits_with_counters[1]["counters"]["local_cache_requests_uncached"] == 1
+        assert workunits_with_counters[0]["counters"]["local_cache_requests"] == 1
+        assert workunits_with_counters[0]["counters"]["local_cache_requests_uncached"] == 1
+        assert workunits_with_counters[1]["counters"]["local_execution_requests"] == 1
 
         assert histograms_info["version"] == 0
         assert "histograms" in histograms_info
@@ -736,7 +737,7 @@ def test_process_digests_on_streaming_workunits(
         run_tracker=run_tracker,
         callbacks=[tracker],
         report_interval_seconds=0.01,
-        max_workunit_verbosity=LogLevel.INFO,
+        max_workunit_verbosity=LogLevel.DEBUG,
         specs=Specs.empty(),
         options_bootstrapper=create_options_bootstrapper([]),
         pantsd=False,
@@ -752,9 +753,7 @@ def test_process_digests_on_streaming_workunits(
     assert tracker.finished
     finished = list(itertools.chain.from_iterable(tracker.finished_workunit_chunks))
 
-    process_workunit = next(
-        item for item in finished if item["name"] == "multi_platform_process-running"
-    )
+    process_workunit = next(item for item in finished if item["name"] == "multi_platform_process")
     assert process_workunit is not None
     stdout_digest = process_workunit["artifacts"]["stdout_digest"]
     stderr_digest = process_workunit["artifacts"]["stderr_digest"]
@@ -769,7 +768,7 @@ def test_process_digests_on_streaming_workunits(
         run_tracker=run_tracker,
         callbacks=[tracker],
         report_interval_seconds=0.01,
-        max_workunit_verbosity=LogLevel.INFO,
+        max_workunit_verbosity=LogLevel.DEBUG,
         specs=Specs.empty(),
         options_bootstrapper=create_options_bootstrapper([]),
         pantsd=False,
@@ -782,9 +781,7 @@ def test_process_digests_on_streaming_workunits(
 
     assert tracker.finished
     finished = list(itertools.chain.from_iterable(tracker.finished_workunit_chunks))
-    process_workunit = next(
-        item for item in finished if item["name"] == "multi_platform_process-running"
-    )
+    process_workunit = next(item for item in finished if item["name"] == "multi_platform_process")
 
     assert process_workunit is not None
     stdout_digest = process_workunit["artifacts"]["stdout_digest"]

--- a/src/rust/engine/async_semaphore/src/lib.rs
+++ b/src/rust/engine/async_semaphore/src/lib.rs
@@ -68,8 +68,8 @@ impl AsyncSemaphore {
   ///
   pub async fn with_acquired<F, B, O>(self, f: F) -> O
   where
-    F: FnOnce(usize) -> B + Send + 'static,
-    B: Future<Output = O> + Send + 'static,
+    F: FnOnce(usize) -> B,
+    B: Future<Output = O>,
   {
     let permit = self.acquire().await;
     let res = f(permit.id).await;

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -30,19 +30,20 @@
 #[macro_use]
 extern crate derivative;
 
-use async_trait::async_trait;
-use bazel_protos::gen::build::bazel::remote::execution::v2 as remexec;
-pub use log::Level;
-use remexec::ExecutedActionMetadata;
-use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryFrom;
 use std::path::PathBuf;
 use std::sync::Arc;
-use workunit_store::{in_workunit, UserMetadataItem, WorkunitMetadata, WorkunitStore};
+
+pub use log::Level;
 
 use async_semaphore::AsyncSemaphore;
+use async_trait::async_trait;
+use bazel_protos::gen::build::bazel::remote::execution::v2 as remexec;
 use hashing::{Digest, EMPTY_FINGERPRINT};
+use remexec::ExecutedActionMetadata;
+use serde::{Deserialize, Serialize};
+use workunit_store::{RunningWorkunit, WorkunitStore};
 
 pub mod cache;
 #[cfg(test)]
@@ -321,10 +322,6 @@ impl MultiPlatformProcess {
       .map(|(_platforms, process)| process.level)
       .unwrap_or(Level::Info)
   }
-
-  pub fn workunit_name(&self) -> String {
-    "multi_platform_process".to_string()
-  }
 }
 
 impl From<Process> for MultiPlatformProcess {
@@ -473,8 +470,9 @@ pub trait CommandRunner: Send + Sync {
   ///
   async fn run(
     &self,
-    req: MultiPlatformProcess,
     context: Context,
+    workunit: &mut RunningWorkunit,
+    req: MultiPlatformProcess,
   ) -> Result<FallibleProcessResultWithPlatform, String>;
 
   ///
@@ -530,38 +528,21 @@ impl BoundedCommandRunner {
 impl CommandRunner for BoundedCommandRunner {
   async fn run(
     &self,
-    mut req: MultiPlatformProcess,
     context: Context,
+    workunit: &mut RunningWorkunit,
+    mut req: MultiPlatformProcess,
   ) -> Result<FallibleProcessResultWithPlatform, String> {
-    let name = format!("{}-waiting", req.workunit_name());
-    let desc = req.user_facing_name();
-    let outer_metadata = WorkunitMetadata {
-      level: Level::Debug,
-      desc: Some(format!("(Waiting) {}", desc)),
-      // We don't want to display the workunit associated with processes waiting on a
-      // BoundedCommandRunner to show in the dynamic UI, so set the `blocked` flag
-      // on the workunit metadata in order to prevent this.
-      blocked: true,
-      ..WorkunitMetadata::default()
-    };
-
-    let bounded_fut = {
-      let inner = self.inner.clone();
-      let semaphore = self.inner.1.clone();
-      let context = context.clone();
-      let name = format!("{}-running", req.workunit_name());
-
-      semaphore.with_acquired(move |concurrency_id| {
+    let semaphore = self.inner.1.clone();
+    let inner = self.inner.clone();
+    let blocking_token = workunit.blocking();
+    semaphore
+      .with_acquired(|concurrency_id| {
         log::debug!(
           "Running {} under semaphore with concurrency id: {}",
-          desc,
+          req.user_facing_name(),
           concurrency_id
         );
-        let metadata = WorkunitMetadata {
-          level: req.workunit_level(),
-          desc: Some(desc),
-          ..WorkunitMetadata::default()
-        };
+        std::mem::drop(blocking_token);
 
         for (_, process) in req.0.iter_mut() {
           if let Some(ref execution_slot_env_var) = process.execution_slot_variable {
@@ -572,39 +553,9 @@ impl CommandRunner for BoundedCommandRunner {
           }
         }
 
-        in_workunit!(
-          context.workunit_store.clone(),
-          name,
-          metadata,
-          |workunit| async move {
-            let res = inner.0.run(req, context).await;
-            if let Ok(FallibleProcessResultWithPlatform {
-              stdout_digest,
-              stderr_digest,
-              exit_code,
-              ..
-            }) = res
-            {
-              workunit.update_metadata(|initial| WorkunitMetadata {
-                stdout: Some(stdout_digest),
-                stderr: Some(stderr_digest),
-                user_metadata: vec![(
-                  "exit_code".to_string(),
-                  UserMetadataItem::ImmediateId(exit_code as i64),
-                )],
-                ..initial
-              })
-            }
-            res
-          },
-        )
+        inner.0.run(context, workunit, req)
       })
-    };
-
-    in_workunit!(context.workunit_store, name, outer_metadata, |_workunit| {
-      bounded_fut
-    })
-    .await
+      .await
   }
 
   fn extract_compatible_request(&self, req: &MultiPlatformProcess) -> Option<Process> {

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -29,7 +29,7 @@ use tokio::sync::RwLock;
 use tokio::time::{timeout, Duration};
 use tokio_util::codec::{BytesCodec, FramedRead};
 use tryfuture::try_future;
-use workunit_store::{in_workunit, Level, Metric, WorkunitMetadata};
+use workunit_store::{in_workunit, Metric, RunningWorkunit, WorkunitMetadata};
 
 use crate::{
   Context, FallibleProcessResultWithPlatform, MultiPlatformProcess, NamedCaches, Platform, Process,
@@ -247,8 +247,9 @@ impl super::CommandRunner for CommandRunner {
   ///
   async fn run(
     &self,
-    req: MultiPlatformProcess,
     context: Context,
+    _workunit: &mut RunningWorkunit,
+    req: MultiPlatformProcess,
   ) -> Result<FallibleProcessResultWithPlatform, String> {
     let req = self.extract_compatible_request(&req).unwrap();
     let req_debug_repr = format!("{:#?}", req);
@@ -256,7 +257,10 @@ impl super::CommandRunner for CommandRunner {
       context.workunit_store.clone(),
       "run_local_process".to_owned(),
       WorkunitMetadata {
-        level: Level::Trace,
+        // NB: See engine::nodes::NodeKey::workunit_level for more information on why this workunit
+        // renders at the Process's level.
+        level: req.level,
+        desc: Some(req.description.clone()),
         ..WorkunitMetadata::default()
       },
       |workunit| async move {

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -915,7 +915,7 @@ async fn workunit_to_py_value(
   }
 
   match workunit.state {
-    WorkunitState::Started { start_time } => {
+    WorkunitState::Started { start_time, .. } => {
       let duration = start_time
         .duration_since(UNIX_EPOCH)
         .unwrap_or_else(|_| Duration::default());

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 use std::{self, fmt};
 
 use async_trait::async_trait;
-use futures::future::{self, FutureExt, TryFutureExt};
+use futures::future::{self, BoxFuture, FutureExt, TryFutureExt};
 use futures::stream::StreamExt;
 use url::Url;
 
@@ -39,7 +39,7 @@ use reqwest::Error;
 use std::pin::Pin;
 use store::{self, StoreFileByDigest};
 use workunit_store::{
-  in_workunit, ArtifactOutput, Level, UserMetadataItem, UserMetadataPyValue, WorkunitMetadata,
+  in_workunit, Level, RunningWorkunit, UserMetadataItem, UserMetadataPyValue, WorkunitMetadata,
 };
 
 pub type NodeResult<T> = Result<T, Failure>;
@@ -87,7 +87,11 @@ impl StoreFileByDigest<Failure> for Context {
 pub trait WrappedNode: Into<NodeKey> {
   type Item: TryFrom<NodeOutput>;
 
-  async fn run_wrapped_node(self, context: Context) -> NodeResult<Self::Item>;
+  async fn run_wrapped_node(
+    self,
+    context: Context,
+    _workunit: &mut RunningWorkunit,
+  ) -> NodeResult<Self::Item>;
 }
 
 ///
@@ -127,12 +131,12 @@ impl Select {
     Select::new(params, product, entry)
   }
 
-  async fn select_product(
+  fn select_product(
     &self,
     context: &Context,
     product: TypeId,
     caller_description: &str,
-  ) -> NodeResult<Value> {
+  ) -> BoxFuture<NodeResult<Value>> {
     let edges = context
       .core
       .rule_graph
@@ -142,33 +146,32 @@ impl Select {
           "Tried to select product {} for {} but found no edges",
           product, caller_description
         ))
-      })?;
+      });
+    let params = self.params.clone();
     let context = context.clone();
-    Select::new_from_edges(self.params.clone(), product, &edges)
-      .run_wrapped_node(context)
-      .await
+    async move {
+      let edges = edges?;
+      Select::new_from_edges(params, product, &edges)
+        .run(context)
+        .await
+    }
+    .boxed()
   }
-}
 
-// TODO: This is a Node only because it is used as a root in the graph, but it should never be
-// requested using context.get
-#[async_trait]
-impl WrappedNode for Select {
-  type Item = Value;
-
-  async fn run_wrapped_node(self, context: Context) -> NodeResult<Value> {
+  async fn run(self, context: Context) -> NodeResult<Value> {
     match &self.entry {
       &rule_graph::Entry::WithDeps(rule_graph::EntryWithDeps::Inner(ref inner)) => {
         match inner.rule() {
-          &tasks::Rule::Task(ref task) => context
-            .get(Task {
-              params: self.params.clone(),
-              product: self.product,
-              task: task.clone(),
-              entry: Arc::new(self.entry.clone()),
-            })
-            .await
-            .map(|output| output.value),
+          &tasks::Rule::Task(ref task) => {
+            context
+              .get(Task {
+                params: self.params.clone(),
+                product: self.product,
+                task: task.clone(),
+                entry: Arc::new(self.entry.clone()),
+              })
+              .await
+          }
           &Rule::Intrinsic(ref intrinsic) => {
             let intrinsic = intrinsic.clone();
             let values = future::try_join_all(
@@ -201,6 +204,26 @@ impl WrappedNode for Select {
         panic!("Not a runtime-executable entry! {:?}", self.entry)
       }
     }
+  }
+}
+
+///
+/// NB: This is a Node so that it can be used as a root in the graph, but it should otherwise
+/// never be requested as a Node using context.get. Select is a thin proxy to other Node types
+/// (which it requests using context.get), and memoizing it would be redundant.
+///
+/// Instead, use `Select::run` to run the Select logic without memoizing it.
+///
+#[async_trait]
+impl WrappedNode for Select {
+  type Item = Value;
+
+  async fn run_wrapped_node(
+    self,
+    context: Context,
+    _workunit: &mut RunningWorkunit,
+  ) -> NodeResult<Value> {
+    self.run(context).await
   }
 }
 
@@ -369,7 +392,11 @@ impl From<MultiPlatformExecuteProcess> for NodeKey {
 impl WrappedNode for MultiPlatformExecuteProcess {
   type Item = ProcessResult;
 
-  async fn run_wrapped_node(self, context: Context) -> NodeResult<ProcessResult> {
+  async fn run_wrapped_node(
+    self,
+    context: Context,
+    workunit: &mut RunningWorkunit,
+  ) -> NodeResult<ProcessResult> {
     let request = self.process;
 
     if context
@@ -386,9 +413,19 @@ impl WrappedNode for MultiPlatformExecuteProcess {
       );
 
       let res = command_runner
-        .run(request, execution_context)
+        .run(execution_context, workunit, request)
         .await
         .map_err(|e| throw(&e))?;
+
+      workunit.update_metadata(|initial| WorkunitMetadata {
+        stdout: Some(res.stdout_digest),
+        stderr: Some(res.stderr_digest),
+        user_metadata: vec![(
+          "exit_code".to_string(),
+          UserMetadataItem::ImmediateId(res.exit_code as i64),
+        )],
+        ..initial
+      });
 
       Ok(ProcessResult(res))
     } else {
@@ -416,7 +453,11 @@ pub struct LinkDest(PathBuf);
 impl WrappedNode for ReadLink {
   type Item = LinkDest;
 
-  async fn run_wrapped_node(self, context: Context) -> NodeResult<LinkDest> {
+  async fn run_wrapped_node(
+    self,
+    context: Context,
+    _workunit: &mut RunningWorkunit,
+  ) -> NodeResult<LinkDest> {
     let node = self;
     let link_dest = context
       .core
@@ -444,7 +485,11 @@ pub struct DigestFile(pub File);
 impl WrappedNode for DigestFile {
   type Item = hashing::Digest;
 
-  async fn run_wrapped_node(self, context: Context) -> NodeResult<hashing::Digest> {
+  async fn run_wrapped_node(
+    self,
+    context: Context,
+    _workunit: &mut RunningWorkunit,
+  ) -> NodeResult<hashing::Digest> {
     let content = context
       .core
       .vfs
@@ -477,7 +522,11 @@ pub struct Scandir(Dir);
 impl WrappedNode for Scandir {
   type Item = Arc<DirectoryListing>;
 
-  async fn run_wrapped_node(self, context: Context) -> NodeResult<Arc<DirectoryListing>> {
+  async fn run_wrapped_node(
+    self,
+    context: Context,
+    _workunit: &mut RunningWorkunit,
+  ) -> NodeResult<Arc<DirectoryListing>> {
     let directory_listing = context
       .core
       .vfs
@@ -549,7 +598,11 @@ impl Paths {
 impl WrappedNode for Paths {
   type Item = Arc<Vec<PathStat>>;
 
-  async fn run_wrapped_node(self, context: Context) -> NodeResult<Arc<Vec<PathStat>>> {
+  async fn run_wrapped_node(
+    self,
+    context: Context,
+    _workunit: &mut RunningWorkunit,
+  ) -> NodeResult<Arc<Vec<PathStat>>> {
     let path_globs = self.path_globs.parse().map_err(|e| throw(&e))?;
     let path_stats = Self::create(context, path_globs).await?;
     Ok(Arc::new(path_stats))
@@ -569,7 +622,11 @@ pub struct SessionValues;
 impl WrappedNode for SessionValues {
   type Item = Value;
 
-  async fn run_wrapped_node(self, context: Context) -> NodeResult<Value> {
+  async fn run_wrapped_node(
+    self,
+    context: Context,
+    _workunit: &mut RunningWorkunit,
+  ) -> NodeResult<Value> {
     Ok(context.session.session_values())
   }
 }
@@ -691,7 +748,11 @@ impl Snapshot {
 impl WrappedNode for Snapshot {
   type Item = Digest;
 
-  async fn run_wrapped_node(self, context: Context) -> NodeResult<Digest> {
+  async fn run_wrapped_node(
+    self,
+    context: Context,
+    _workunit: &mut RunningWorkunit,
+  ) -> NodeResult<Digest> {
     let path_globs = self.path_globs.parse().map_err(|e| throw(&e))?;
     let snapshot = Self::create(context, path_globs).await?;
     Ok(snapshot.digest)
@@ -892,7 +953,11 @@ impl DownloadedFile {
 impl WrappedNode for DownloadedFile {
   type Item = Digest;
 
-  async fn run_wrapped_node(self, context: Context) -> NodeResult<Digest> {
+  async fn run_wrapped_node(
+    self,
+    context: Context,
+    _workunit: &mut RunningWorkunit,
+  ) -> NodeResult<Digest> {
     let value = externs::val_for(&self.0);
     let url_str = externs::getattr_as_string(&value, "url");
 
@@ -928,10 +993,13 @@ pub struct Task {
 impl Task {
   async fn gen_get(
     context: &Context,
+    workunit: &mut RunningWorkunit,
     params: &Params,
     entry: &Arc<rule_graph::Entry<Rule>>,
     gets: Vec<externs::Get>,
   ) -> NodeResult<Vec<Value>> {
+    // While waiting for dependencies, mark the workunit for this Task blocked.
+    let _blocking_token = workunit.blocking();
     let get_futures = gets
       .into_iter()
       .map(|get| {
@@ -975,11 +1043,9 @@ impl Task {
         // The subject of the get is a new parameter that replaces an existing param of the same
         // type.
         params.put(get.input);
-        async move {
-          let entry = entry_res?;
-          Select::new(params, get.output, entry)
-            .run_wrapped_node(context.clone())
-            .await
+        match entry_res {
+          Ok(entry) => Select::new(params, get.output, entry).run(context).boxed(),
+          Err(e) => future::err(e).boxed(),
         }
       })
       .collect::<Vec<_>>();
@@ -991,7 +1057,8 @@ impl Task {
   /// it completes with a result Value.
   ///
   async fn generate(
-    context: Context,
+    context: &Context,
+    workunit: &mut RunningWorkunit,
     params: Params,
     entry: Arc<rule_graph::Entry<Rule>>,
     generator: Value,
@@ -1003,11 +1070,11 @@ impl Task {
       let entry = entry.clone();
       match externs::generator_send(&generator, &input)? {
         externs::GeneratorResponse::Get(get) => {
-          let values = Self::gen_get(&context, &params, &entry, vec![get]).await?;
+          let values = Self::gen_get(&context, workunit, &params, &entry, vec![get]).await?;
           input = values.into_iter().next().unwrap();
         }
         externs::GeneratorResponse::GetMulti(gets) => {
-          let values = Self::gen_get(&context, &params, &entry, gets).await?;
+          let values = Self::gen_get(&context, workunit, &params, &entry, gets).await?;
           input = externs::store_tuple(values);
         }
         externs::GeneratorResponse::Break(val) => {
@@ -1028,21 +1095,19 @@ impl fmt::Debug for Task {
   }
 }
 
-pub struct PythonRuleOutput {
-  value: Value,
-  new_level: Option<log::Level>,
-  message: Option<String>,
-  new_artifacts: Vec<(String, ArtifactOutput)>,
-  new_metadata: Vec<(String, Value)>,
-}
-
 #[async_trait]
 impl WrappedNode for Task {
-  type Item = PythonRuleOutput;
+  type Item = Value;
 
-  async fn run_wrapped_node(self, context: Context) -> NodeResult<PythonRuleOutput> {
+  async fn run_wrapped_node(
+    self,
+    context: Context,
+    workunit: &mut RunningWorkunit,
+  ) -> NodeResult<Value> {
     let params = self.params;
     let deps = {
+      // While waiting for dependencies, mark ourselves blocking.
+      let _blocking_token = workunit.blocking();
       let edges = &context
         .core
         .rule_graph
@@ -1054,7 +1119,7 @@ impl WrappedNode for Task {
           .clause
           .into_iter()
           .map(|type_id| {
-            Select::new_from_edges(params.clone(), type_id, edges).run_wrapped_node(context.clone())
+            Select::new_from_edges(params.clone(), type_id, edges).run(context.clone())
           })
           .collect::<Vec<_>>(),
       )
@@ -1071,7 +1136,7 @@ impl WrappedNode for Task {
     let mut result_val: Value = result_val.into();
     let mut result_type = externs::get_type_for(&result_val);
     if result_type == context.core.types.coroutine {
-      result_val = Self::generate(context.clone(), params, entry, result_val).await?;
+      result_val = Self::generate(&context, workunit, params, entry, result_val).await?;
       result_type = externs::get_type_for(&result_val);
     }
 
@@ -1088,13 +1153,26 @@ impl WrappedNode for Task {
       } else {
         (None, None, Vec::new(), Vec::new())
       };
-      Ok(PythonRuleOutput {
-        value: result_val,
-        new_level,
-        message,
-        new_artifacts,
-        new_metadata,
-      })
+      workunit.update_metadata(|mut metadata| {
+        if let Some(new_level) = new_level {
+          metadata.level = new_level;
+        }
+        metadata.message = message;
+        metadata.artifacts.extend(new_artifacts);
+        metadata
+          .user_metadata
+          .extend(new_metadata.into_iter().map(|(key, val)| {
+            let py_value_handle = UserMetadataPyValue::new();
+            let umi = UserMetadataItem::PyValue(py_value_handle.clone());
+            context.session.with_metadata_map(|map| {
+              let val = val.clone();
+              map.insert(py_value_handle.clone(), val);
+            });
+            (key, umi)
+          }));
+        metadata
+      });
+      Ok(result_val)
     } else {
       Err(throw(&format!(
         "{:?} returned a result value that did not satisfy its constraints: {:?}",
@@ -1192,6 +1270,13 @@ impl NodeKey {
   fn workunit_level(&self) -> Level {
     match self {
       NodeKey::Task(ref task) => task.task.display_info.level,
+      NodeKey::MultiPlatformExecuteProcess(..) => {
+        // NB: The Node for a Process is statically rendered at Debug (rather than at
+        // Process.level) because it is very likely to wrap a BoundedCommandRunner which
+        // will block the workunit. We don't want to render at the Process's actual level
+        // until we're certain that it has begun executing (if at all).
+        Level::Debug
+      }
       NodeKey::DownloadedFile(..) => Level::Debug,
       _ => Level::Trace,
     }
@@ -1204,7 +1289,7 @@ impl NodeKey {
   fn workunit_name(&self) -> String {
     match self {
       NodeKey::Task(ref task) => task.task.display_info.name.clone(),
-      NodeKey::MultiPlatformExecuteProcess(mp_epr) => mp_epr.process.workunit_name(),
+      NodeKey::MultiPlatformExecuteProcess(..) => "multi_platform_process".to_string(),
       NodeKey::Snapshot(..) => "snapshot".to_string(),
       NodeKey::Paths(..) => "paths".to_string(),
       NodeKey::DigestFile(..) => "digest_file".to_string(),
@@ -1228,7 +1313,10 @@ impl NodeKey {
       NodeKey::Task(ref task) => task.task.display_info.desc.as_ref().map(|s| s.to_owned()),
       NodeKey::Snapshot(ref s) => Some(format!("Snapshotting: {}", s.path_globs)),
       NodeKey::Paths(ref s) => Some(format!("Finding files: {}", s.path_globs)),
-      NodeKey::MultiPlatformExecuteProcess(mp_epr) => Some(mp_epr.process.user_facing_name()),
+      NodeKey::MultiPlatformExecuteProcess(mp_epr) => {
+        // NB: See Self::workunit_level for more information on why this is prefixed.
+        Some(format!("Scheduling: {}", mp_epr.process.user_facing_name()))
+      }
       NodeKey::DigestFile(DigestFile(File { path, .. })) => {
         Some(format!("Fingerprinting: {}", path.display()))
       }
@@ -1300,112 +1388,95 @@ impl Node for NodeKey {
       level: self.workunit_level(),
       ..WorkunitMetadata::default()
     };
-    let metadata2 = metadata.clone();
-
-    let result_future = async move {
-      let metadata = metadata2;
-      // To avoid races, we must ensure that we have installed a watch for the subject before
-      // executing the node logic. But in case of failure, we wait to see if the Node itself
-      // fails, and prefer that error message if so (because we have little control over the
-      // error messages of the watch API).
-      let maybe_watch = if let Some(path) = self.fs_subject() {
-        if let Some(watcher) = &context.core.watcher {
-          let abs_path = context.core.build_root.join(path);
-          watcher
-            .watch(abs_path)
-            .map_err(|e| Context::mk_error(&e))
-            .await
-        } else {
-          Ok(())
-        }
-      } else {
-        Ok(())
-      };
-
-      let mut level = metadata.level;
-      let mut message = None;
-      let mut artifacts = Vec::new();
-      let mut user_metadata = Vec::new();
-
-      let context2 = context.clone();
-      let mut result = match self {
-        NodeKey::DigestFile(n) => n.run_wrapped_node(context).map_ok(NodeOutput::Digest).await,
-        NodeKey::DownloadedFile(n) => n.run_wrapped_node(context).map_ok(NodeOutput::Digest).await,
-        NodeKey::MultiPlatformExecuteProcess(n) => {
-          n.run_wrapped_node(context)
-            .map_ok(|r| NodeOutput::ProcessResult(Box::new(r)))
-            .await
-        }
-        NodeKey::ReadLink(n) => {
-          n.run_wrapped_node(context)
-            .map_ok(NodeOutput::LinkDest)
-            .await
-        }
-        NodeKey::Scandir(n) => {
-          n.run_wrapped_node(context)
-            .map_ok(NodeOutput::DirectoryListing)
-            .await
-        }
-        NodeKey::Select(n) => n.run_wrapped_node(context).map_ok(NodeOutput::Value).await,
-        NodeKey::Snapshot(n) => n.run_wrapped_node(context).map_ok(NodeOutput::Digest).await,
-        NodeKey::Paths(n) => n.run_wrapped_node(context).map_ok(NodeOutput::Paths).await,
-        NodeKey::SessionValues(n) => n.run_wrapped_node(context).map_ok(NodeOutput::Value).await,
-        NodeKey::Task(n) => {
-          n.run_wrapped_node(context)
-            .map_ok(|python_rule_output| {
-              if let Some(new_level) = python_rule_output.new_level {
-                level = new_level;
-              }
-              message = python_rule_output.message;
-              artifacts = python_rule_output.new_artifacts;
-              user_metadata = python_rule_output.new_metadata;
-              NodeOutput::Value(python_rule_output.value)
-            })
-            .await
-        }
-      };
-
-      result = result.map_err(|failure| failure.with_pushed_frame(&failure_name));
-
-      // If both the Node and the watch failed, prefer the Node's error message.
-      match (&result, maybe_watch) {
-        (Ok(_), Ok(_)) => {}
-        (Err(_), _) => {}
-        (Ok(_), Err(e)) => {
-          result = Err(e);
-        }
-      }
-
-      let session = context2.session;
-      let final_metadata = WorkunitMetadata {
-        level,
-        message,
-        artifacts,
-        user_metadata: user_metadata
-          .into_iter()
-          .map(|(key, val)| {
-            let py_value_handle = UserMetadataPyValue::new();
-            let umi = UserMetadataItem::PyValue(py_value_handle.clone());
-            session.with_metadata_map(|map| {
-              let val = val.clone();
-              map.insert(py_value_handle.clone(), val);
-            });
-            (key, umi)
-          })
-          .collect(),
-        ..metadata
-      };
-      (result, final_metadata)
-    };
 
     in_workunit!(
       workunit_store_handle.store,
       workunit_name,
       metadata,
       |workunit| async move {
-        let (res, final_metadata) = result_future.await;
-        workunit.update_metadata(|_| final_metadata);
-        res
+        // To avoid races, we must ensure that we have installed a watch for the subject before
+        // executing the node logic. But in case of failure, we wait to see if the Node itself
+        // fails, and prefer that error message if so (because we have little control over the
+        // error messages of the watch API).
+        let maybe_watch = if let Some(path) = self.fs_subject() {
+          if let Some(watcher) = &context.core.watcher {
+            let abs_path = context.core.build_root.join(path);
+            watcher
+              .watch(abs_path)
+              .map_err(|e| Context::mk_error(&e))
+              .await
+          } else {
+            Ok(())
+          }
+        } else {
+          Ok(())
+        };
+
+        let mut result = match self {
+          NodeKey::DigestFile(n) => {
+            n.run_wrapped_node(context, workunit)
+              .map_ok(NodeOutput::Digest)
+              .await
+          }
+          NodeKey::DownloadedFile(n) => {
+            n.run_wrapped_node(context, workunit)
+              .map_ok(NodeOutput::Digest)
+              .await
+          }
+          NodeKey::MultiPlatformExecuteProcess(n) => {
+            n.run_wrapped_node(context, workunit)
+              .map_ok(|r| NodeOutput::ProcessResult(Box::new(r)))
+              .await
+          }
+          NodeKey::ReadLink(n) => {
+            n.run_wrapped_node(context, workunit)
+              .map_ok(NodeOutput::LinkDest)
+              .await
+          }
+          NodeKey::Scandir(n) => {
+            n.run_wrapped_node(context, workunit)
+              .map_ok(NodeOutput::DirectoryListing)
+              .await
+          }
+          NodeKey::Select(n) => {
+            n.run_wrapped_node(context, workunit)
+              .map_ok(NodeOutput::Value)
+              .await
+          }
+          NodeKey::Snapshot(n) => {
+            n.run_wrapped_node(context, workunit)
+              .map_ok(NodeOutput::Digest)
+              .await
+          }
+          NodeKey::Paths(n) => {
+            n.run_wrapped_node(context, workunit)
+              .map_ok(NodeOutput::Paths)
+              .await
+          }
+          NodeKey::SessionValues(n) => {
+            n.run_wrapped_node(context, workunit)
+              .map_ok(NodeOutput::Value)
+              .await
+          }
+          NodeKey::Task(n) => {
+            n.run_wrapped_node(context, workunit)
+              .map_ok(NodeOutput::Value)
+              .await
+          }
+        };
+
+        // If both the Node and the watch failed, prefer the Node's error message.
+        match (&result, maybe_watch) {
+          (Ok(_), Ok(_)) => {}
+          (Err(_), _) => {}
+          (Ok(_), Err(e)) => {
+            result = Err(e);
+          }
+        }
+
+        result = result.map_err(|failure| failure.with_pushed_frame(&failure_name));
+
+        result
       }
     )
     .await
@@ -1503,23 +1574,6 @@ impl NodeOutput {
       | NodeOutput::LinkDest(_)
       | NodeOutput::Paths(_)
       | NodeOutput::Value(_) => vec![],
-    }
-  }
-}
-
-impl TryFrom<NodeOutput> for PythonRuleOutput {
-  type Error = ();
-
-  fn try_from(nr: NodeOutput) -> Result<Self, ()> {
-    match nr {
-      NodeOutput::Value(v) => Ok(PythonRuleOutput {
-        value: v,
-        new_level: None,
-        message: None,
-        new_artifacts: Vec::new(),
-        new_metadata: Vec::new(),
-      }),
-      _ => Err(()),
     }
   }
 }

--- a/src/rust/engine/workunit_store/src/tests.rs
+++ b/src/rust/engine/workunit_store/src/tests.rs
@@ -1,4 +1,33 @@
-use crate::SpanId;
+use std::collections::HashSet;
+use std::sync::atomic;
+use std::time::Duration;
+
+use crate::{SpanId, WorkunitMetadata, WorkunitState, WorkunitStore};
+
+#[test]
+fn heavy_hitters_basic() {
+  let ws = create_store(vec![], vec![wu_root(0), wu(1, 0)], vec![]);
+  assert_eq!(vec!["1"], ws.heavy_hitters(1).keys().collect::<Vec<_>>());
+}
+
+#[test]
+fn straggling_workunits_basic() {
+  let ws = create_store(vec![], vec![wu_root(0), wu(1, 0)], vec![]);
+  assert_eq!(
+    vec!["1"],
+    ws.straggling_workunits(Duration::from_secs(0))
+      .into_iter()
+      .map(|(_, n)| n)
+      .collect::<Vec<_>>()
+  );
+}
+
+#[test]
+fn straggling_workunits_blocked() {
+  // Test that a blocked leaf is not eligible to be rendered.
+  let ws = create_store(vec![], vec![wu_root(0)], vec![wu(1, 0)]);
+  assert!(ws.straggling_workunits(Duration::from_secs(0)).is_empty());
+}
 
 #[test]
 fn workunit_span_id_has_16_digits_len_hex_format() {
@@ -21,4 +50,66 @@ fn hex_16_digit_string_actually_uses_input_number() {
     SpanId(0x_0123_4567_89ab_cdef).to_string(),
     "0123456789abcdef"
   );
+}
+
+fn create_store(
+  completed: Vec<AnonymousWorkunit>,
+  started: Vec<AnonymousWorkunit>,
+  blocked: Vec<AnonymousWorkunit>,
+) -> WorkunitStore {
+  let completed_ids = completed
+    .iter()
+    .map(|(span_id, _, _)| *span_id)
+    .collect::<HashSet<_>>();
+  let blocked_ids = blocked
+    .iter()
+    .map(|(span_id, _, _)| *span_id)
+    .collect::<HashSet<_>>();
+  let ws = WorkunitStore::new(true);
+
+  // Start all of completed, started, and blocked workunits.
+  let workunits = completed
+    .into_iter()
+    .chain(started.into_iter())
+    .chain(blocked.into_iter())
+    .map(|(span_id, parent_id, metadata)| {
+      ws.start_workunit(span_id, format!("{}", span_id.0), parent_id, metadata)
+    })
+    .collect::<Vec<_>>();
+
+  // Block and blocked workunits, and complete any completed workunits.
+  for mut workunit in workunits {
+    if blocked_ids.contains(&workunit.span_id) {
+      match &mut workunit.state {
+        WorkunitState::Started { blocked, .. } => blocked.store(true, atomic::Ordering::Relaxed),
+        _ => unreachable!(),
+      }
+    }
+    if completed_ids.contains(&workunit.span_id) {
+      ws.complete_workunit(workunit);
+    }
+  }
+
+  ws
+}
+
+// Used with `create_store` to quickly create a tree of anonymous workunits (with names equal to
+// their SpanIds).
+type AnonymousWorkunit = (SpanId, Option<SpanId>, WorkunitMetadata);
+
+fn wu_root(span_id: u64) -> AnonymousWorkunit {
+  wu_meta(span_id, None, WorkunitMetadata::default())
+}
+
+fn wu(span_id: u64, parent_id: u64) -> AnonymousWorkunit {
+  wu_meta(span_id, Some(parent_id), WorkunitMetadata::default())
+}
+
+fn wu_meta(
+  span_id: u64,
+  parent_id: Option<u64>,
+  mut metadata: WorkunitMetadata,
+) -> AnonymousWorkunit {
+  metadata.desc = Some(format!("{}", span_id));
+  (SpanId(span_id), parent_id.map(SpanId), metadata)
 }


### PR DESCRIPTION
Our "graph" of execution is a DAG, while the workunits (used to visualize and record traces) form a tree. Because they form a tree, workunits do not always report that they are blocked on work that they didn't start, but which some other node started (common when lots of @rules are waiting on another single @rule which only one of them started).

To fix this, we make the `blocked` property of a workunit an atomic mutable, and skip rendering the parents of blocked leaves. We use the `blocked` flag both for `Tasks` (which wait directly for memoized Nodes, and so frequently block in this way), and in `BoundedCommandRunner`, which temporarily blocks the workunit while we're acquiring the semaphore. Additionally, we skip rendering or walking through `Completed` workunits, which can happen in the case of speculation if a parent workunit completes before a child.

In order to toggle the `blocked` property on workunits, we expose the current `RunningWorkunit` in two new places: the `CommandRunner` and `WrappedNode`. In both cases, this is to allow the generic code to consume the workunit created by their callers and mark it blocked (for `Task` and `BoundedCommandRunner`).

Fixes #12349.

[ci skip-build-wheels]