### PR TITLE
go: add go_module and go_external_module targets

### DIFF
--- a/src/python/pants/backend/experimental/go/register.py
+++ b/src/python/pants/backend/experimental/go/register.py
@@ -10,4 +10,9 @@ def target_types():
 
 
 def rules():
-    return [*build.rules(), *distribution.rules(), *import_analysis.rules(), *target_type_rules.rules()]
+    return [
+        *build.rules(),
+        *distribution.rules(),
+        *import_analysis.rules(),
+        *target_type_rules.rules(),
+    ]

--- a/src/python/pants/backend/experimental/go/register.py
+++ b/src/python/pants/backend/experimental/go/register.py
@@ -1,12 +1,12 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.go import build, distribution, import_analysis, target_type_rules
-from pants.backend.go.target_types import GoBinary, GoPackage
+from pants.backend.go import build, distribution, import_analysis, target_type_rules, target_types
+from pants.backend.go.target_types import GoBinary, GoExternalModule, GoModule, GoPackage
 
 
 def target_types():
-    return [GoBinary, GoPackage]
+    return [GoBinary, GoPackage, GoModule, GoExternalModule]
 
 
 def rules():
@@ -14,5 +14,6 @@ def rules():
         *build.rules(),
         *distribution.rules(),
         *import_analysis.rules(),
+        *target_types.rules(),
         *target_type_rules.rules(),
     ]

--- a/src/python/pants/backend/experimental/go/register.py
+++ b/src/python/pants/backend/experimental/go/register.py
@@ -1,7 +1,8 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.go import build, distribution, import_analysis, target_type_rules, target_types
+from pants.backend.go import build, distribution, import_analysis, target_type_rules
+from pants.backend.go import target_types as go_target_types
 from pants.backend.go.target_types import GoBinary, GoExternalModule, GoModule, GoPackage
 
 
@@ -14,6 +15,6 @@ def rules():
         *build.rules(),
         *distribution.rules(),
         *import_analysis.rules(),
-        *target_types.rules(),
+        *go_target_types.rules(),
         *target_type_rules.rules(),
     ]

--- a/src/python/pants/backend/experimental/go/register.py
+++ b/src/python/pants/backend/experimental/go/register.py
@@ -1,7 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.go import build, distribution, import_analysis
+from pants.backend.go import build, distribution, import_analysis, target_type_rules
 from pants.backend.go.target_types import GoBinary, GoPackage
 
 
@@ -10,4 +10,4 @@ def target_types():
 
 
 def rules():
-    return [*build.rules(), *distribution.rules(), *import_analysis.rules()]
+    return [*build.rules(), *distribution.rules(), *import_analysis.rules(), *target_type_rules.rules()]

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -2,15 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from pants.backend.go.target_types import GoModuleSources, GoPackageDependencies
 from pants.base.specs import AddressSpecs, AscendantAddresses, SiblingAddresses
-from pants.build_graph.address import Address
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
-from pants.engine.target import (
-    InjectDependenciesRequest,
-    InjectedDependencies,
-    UnexpandedTargets,
-    WrappedTarget,
-)
+from pants.engine.target import InjectDependenciesRequest, InjectedDependencies, UnexpandedTargets
 from pants.engine.unions import UnionRule
 
 

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -20,20 +20,26 @@ class InjectGoModuleDependency(InjectDependenciesRequest):
 
 @rule
 async def inject_go_module_dependency(request: InjectGoModuleDependency) -> InjectedDependencies:
-    original_tgt = await Get(WrappedTarget, Address, request.dependencies_field.address)
-    spec_path = original_tgt.target.address.spec_path
+    # Obtain unexpanded targets and ensure file targets are filtered out. Unlike Python, file targets do not
+    # make sense semantically for Go source since Go builds entire packages at a time. The filtering is
+    # accomplished by requesting `UnexpandedTargets` and also filtering on `is_file_target`.
+    spec_path = request.dependencies_field.address.spec_path
     candidate_targets = await Get(
         UnexpandedTargets,
         AddressSpecs([AscendantAddresses(spec_path), SiblingAddresses(spec_path)]),
     )
     go_module_targets = [
-        (tgt.address.spec_path, tgt)
+        tgt
         for tgt in candidate_targets
         if tgt.has_field(GoModuleSources) and not tgt.address.is_file_target
     ]
-    sorted_go_module_targets = sorted(go_module_targets, key=lambda x: x[0], reverse=True)
+
+    # Sort by address.spec_path in descending order so the nearest go_module target is sorted first.
+    sorted_go_module_targets = sorted(
+        go_module_targets, key=lambda tgt: tgt.address.spec_path, reverse=True
+    )
     if sorted_go_module_targets:
-        nearest_go_module_target = sorted_go_module_targets[0][1]
+        nearest_go_module_target = sorted_go_module_targets[0]
         return InjectedDependencies([nearest_go_module_target.address])
     else:
         # TODO: Consider eventually requiring all go_package's to associate with a go_module.

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -1,0 +1,46 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from pants.backend.go.target_types import GoModuleGoVersion, GoPackageDependencies
+from pants.base.specs import AddressSpecs, AscendantAddresses, SiblingAddresses
+from pants.build_graph.address import Address
+from pants.engine.internals.selectors import Get
+from pants.engine.rules import collect_rules, rule
+from pants.engine.target import (
+    InjectDependenciesRequest,
+    InjectedDependencies,
+    Targets,
+    WrappedTarget,
+)
+from pants.engine.unions import UnionRule
+
+
+class InjectGoModuleDependency(InjectDependenciesRequest):
+    inject_for = GoPackageDependencies
+
+
+@rule
+async def inject_go_module_dependency(request: InjectGoModuleDependency) -> InjectedDependencies:
+    original_tgt = await Get(WrappedTarget, Address, request.dependencies_field.address)
+    spec_path = original_tgt.target.address.spec_path
+    candidate_targets = await Get(
+        Targets, AddressSpecs([AscendantAddresses(spec_path), SiblingAddresses(spec_path)])
+    )
+    go_module_targets = [
+        (tgt.address.spec_path, tgt)
+        for tgt in candidate_targets
+        if tgt.has_field(GoModuleGoVersion)
+    ]
+    sorted_go_module_targets = sorted(go_module_targets, key=lambda x: x[0], reverse=True)
+    if sorted_go_module_targets:
+        nearest_go_module_target = sorted_go_module_targets[0][1]
+        return InjectedDependencies([nearest_go_module_target.address])
+    else:
+        # TODO: Consider eventually requiring all go_package's to associate with a go_module.
+        return InjectedDependencies()
+
+
+def rules():
+    return (
+        *collect_rules(),
+        UnionRule(InjectDependenciesRequest, InjectGoModuleDependency),
+    )

--- a/src/python/pants/backend/go/target_type_rules_test.py
+++ b/src/python/pants/backend/go/target_type_rules_test.py
@@ -3,11 +3,11 @@
 import pytest
 
 from pants.backend.go import target_type_rules
-from pants.backend.go.target_types import GoModule, GoModuleGoVersion, GoPackage
+from pants.backend.go.target_types import GoModule, GoModuleSources, GoPackage
 from pants.build_graph.address import Address
 from pants.engine.addresses import Addresses
 from pants.engine.rules import QueryRule
-from pants.engine.target import Dependencies, DependenciesRequest, Target, Targets
+from pants.engine.target import Dependencies, DependenciesRequest, Target, UnexpandedTargets
 from pants.testutil.rule_runner import RuleRunner
 
 
@@ -17,6 +17,7 @@ def rule_runner() -> RuleRunner:
         rules=[
             *target_type_rules.rules(),
             QueryRule(Addresses, (DependenciesRequest,)),
+            QueryRule(UnexpandedTargets, (Addresses,)),
         ],
         target_types=[GoPackage, GoModule],
     )
@@ -24,8 +25,8 @@ def rule_runner() -> RuleRunner:
 
 def assert_go_module_address(rule_runner: RuleRunner, target: Target, expected_address: Address):
     addresses = rule_runner.request(Addresses, [DependenciesRequest(target[Dependencies])])
-    targets = rule_runner.request(Targets, [addresses])
-    go_module_targets = [tgt for tgt in targets if tgt.has_field(GoModuleGoVersion)]
+    targets = rule_runner.request(UnexpandedTargets, [addresses])
+    go_module_targets = [tgt for tgt in targets if tgt.has_field(GoModuleSources)]
     assert len(go_module_targets) == 1
     assert go_module_targets[0].address == expected_address
 

--- a/src/python/pants/backend/go/target_type_rules_test.py
+++ b/src/python/pants/backend/go/target_type_rules_test.py
@@ -1,0 +1,50 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import pytest
+
+from pants.backend.go import target_type_rules
+from pants.backend.go.target_types import GoModule, GoModuleGoVersion, GoPackage
+from pants.build_graph.address import Address
+from pants.engine.addresses import Addresses
+from pants.engine.rules import QueryRule
+from pants.engine.target import Dependencies, DependenciesRequest, Target, Targets
+from pants.testutil.rule_runner import RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *target_type_rules.rules(),
+            QueryRule(Addresses, (DependenciesRequest,)),
+        ],
+        target_types=[GoPackage, GoModule],
+    )
+
+
+def assert_go_module_address(rule_runner: RuleRunner, target: Target, expected_address: Address):
+    addresses = rule_runner.request(Addresses, [DependenciesRequest(target[Dependencies])])
+    targets = rule_runner.request(Targets, [addresses])
+    go_module_targets = [tgt for tgt in targets if tgt.has_field(GoModuleGoVersion)]
+    assert len(go_module_targets) == 1
+    assert go_module_targets[0].address == expected_address
+
+
+def test_go_module_dependency_injection(rule_runner: RuleRunner) -> None:
+    rule_runner.add_to_build_file("foo", "go_module()")
+    rule_runner.write_files(
+        {
+            "foo/pkg/foo.go": "package pkg\n",
+            "foo/go.mod": "module foo\n",
+            "foo/go.sum": "",
+            "foo/bar/src.go": "package bar\n",
+        }
+    )
+    rule_runner.add_to_build_file("foo/pkg", "go_package()")
+    rule_runner.add_to_build_file("foo/bar", "go_module(name='mod')\ngo_package(name='pkg')\n")
+
+    target = rule_runner.get_target(Address("foo/pkg", target_name="pkg"))
+    assert_go_module_address(rule_runner, target, Address("foo"))
+
+    target = rule_runner.get_target(Address("foo/bar", target_name="pkg"))
+    assert_go_module_address(rule_runner, target, Address("foo/bar", target_name="mod"))

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -42,6 +42,7 @@ class GoModule(Target):
         Dependencies,
         GoModuleSources,
     )
+    help = "First-party Go module."
 
 
 # `go_external_module`
@@ -49,10 +50,12 @@ class GoModule(Target):
 
 class GoExternalModulePath(StringField):
     alias = "path"
+    help = "Module path to a Go module"
 
 
 class GoExternalModuleVersion(StringField):
     alias = "version"
+    help = "Version of a Go module"
 
 
 class GoExternalModule(Target):
@@ -64,6 +67,7 @@ class GoExternalModule(Target):
         GoExternalModuleVersion,
         GoImportPath,
     )
+    help = "External Go module."
 
 
 # `go_binary` target

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -15,13 +15,86 @@ class GoPackageSources(GoSources):
 class GoImportPath(StringField):
     # TODO: Infer the import path from the closest ancestor `go_module` target once that target is supported.
     alias = "import_path"
-    help = "Import path in Go code to import this package."
+    help = "Import path in Go code to import this package or module."
+
+
+class GoPackageDependencies(Dependencies):
+    pass
 
 
 class GoPackage(Target):
     alias = "go_package"
-    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, GoPackageSources, GoImportPath)
+    core_fields = (*COMMON_TARGET_FIELDS, GoPackageDependencies, GoPackageSources, GoImportPath)
     help = "A single Go package."
+
+
+# `go_module` target
+
+
+class GoModuleGoVersion(StringField):
+    alias = "go_version"
+    # TODO: Set default to match the active `GoLangDisribution`.
+    default = "1.16"
+
+
+# class GoModuleGoModSource(Sources):
+#     alias = "gomod"
+#     default = ["go.mod"]
+#     # TODO: This does not handle a missing go.mod file.
+#     expected_num_files = 1
+#
+#
+# class GoModuleGoSumSource(Sources):
+#     alias = "gosum"
+#     default = ["go.sum"]
+#     # TODO: This does not handle a missing go.sum file.
+#     expected_num_files = 1
+#     help = "The source file containing the go.sum file."
+#
+#
+# class GoModuleImportPathReplacements(StringSequenceField):
+#     alias = "replacements"
+#     help = (
+#         "Import path replacements where each item is in the form ORIGINAL,REPLACEMENT. "
+#         "This will be inferred from the go.mod file."
+#     )
+
+
+class GoModule(Target):
+    alias = "go_module"
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        Dependencies,
+        GoModuleGoVersion,
+        GoImportPath,
+        # GoModuleGoModSource,
+        # GoModuleGoSumSource,
+    )
+
+
+# `go_external_module`
+
+
+class GoExternalModulePath(StringField):
+    alias = "path"
+
+
+class GoExternalModuleVersion(StringField):
+    alias = "version"
+
+
+class GoExternalModule(Target):
+    alias = "go_external_module"
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        Dependencies,
+        GoExternalModulePath,
+        GoExternalModuleVersion,
+        GoImportPath,
+    )
+
+
+# `go_binary` target
 
 
 class GoBinaryName(StringField):

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -31,33 +31,8 @@ class GoPackage(Target):
 # `go_module` target
 
 
-class GoModuleGoVersion(StringField):
-    alias = "go_version"
-    # TODO: Set default to match the active `GoLangDisribution`.
-    default = "1.16"
-
-
-# class GoModuleGoModSource(Sources):
-#     alias = "gomod"
-#     default = ["go.mod"]
-#     # TODO: This does not handle a missing go.mod file.
-#     expected_num_files = 1
-#
-#
-# class GoModuleGoSumSource(Sources):
-#     alias = "gosum"
-#     default = ["go.sum"]
-#     # TODO: This does not handle a missing go.sum file.
-#     expected_num_files = 1
-#     help = "The source file containing the go.sum file."
-#
-#
-# class GoModuleImportPathReplacements(StringSequenceField):
-#     alias = "replacements"
-#     help = (
-#         "Import path replacements where each item is in the form ORIGINAL,REPLACEMENT. "
-#         "This will be inferred from the go.mod file."
-#     )
+class GoModuleSources(Sources):
+    default = ("go.mod", "go.sum")
 
 
 class GoModule(Target):
@@ -65,10 +40,7 @@ class GoModule(Target):
     core_fields = (
         *COMMON_TARGET_FIELDS,
         Dependencies,
-        GoModuleGoVersion,
-        GoImportPath,
-        # GoModuleGoModSource,
-        # GoModuleGoSumSource,
+        GoModuleSources,
     )
 
 

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -32,6 +32,7 @@ class GoPackage(Target):
 
 
 class GoModuleSources(Sources):
+    alias = "_sources"
     default = ("go.mod", "go.sum")
 
 


### PR DESCRIPTION
- Add `go_module` target which represents a first-party Go module. 
- Add `go_external_module` target which is a third-party Go module. 
- Add a rule to infer a dependency between a `go_package` and the nearest sibling or ancestor `go_module`.

Note: This PR does not include a dependency inference rule to infer the external modules listed in a `go.mod` file as dependencies of the applicable `go_module`. That will be done in a follow-up.

[ci skip-rust]

[ci skip-build-wheels]