### PR TITLE
[internal] DRY rule to generate a lockfile

### DIFF
--- a/src/python/pants/backend/awslambda/python/lambdex.py
+++ b/src/python/pants/backend/awslambda/python/lambdex.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.backend.experimental.python.lockfile import (
-    PythonToolLockfileRequest,
+    PythonLockfileRequest,
     PythonToolLockfileSentinel,
 )
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
@@ -32,10 +32,8 @@ class LambdexLockfileSentinel(PythonToolLockfileSentinel):
 
 
 @rule
-def setup_lambdex_lockfile(
-    _: LambdexLockfileSentinel, lambdex: Lambdex
-) -> PythonToolLockfileRequest:
-    return PythonToolLockfileRequest.from_tool(lambdex)
+def setup_lambdex_lockfile(_: LambdexLockfileSentinel, lambdex: Lambdex) -> PythonLockfileRequest:
+    return PythonLockfileRequest.from_tool(lambdex)
 
 
 def rules():

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -5,7 +5,7 @@ from typing import cast
 
 from pants.backend.codegen.protobuf.target_types import ProtobufDependencies
 from pants.backend.experimental.python.lockfile import (
-    PythonToolLockfileRequest,
+    PythonLockfileRequest,
     PythonToolLockfileSentinel,
 )
 from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
@@ -84,8 +84,8 @@ class MypyProtobufLockfileSentinel(PythonToolLockfileSentinel):
 @rule
 def setup_bandit_lockfile(
     _: MypyProtobufLockfileSentinel, mypy_protobuf: PythonProtobufMypyPlugin
-) -> PythonToolLockfileRequest:
-    return PythonToolLockfileRequest.from_tool(mypy_protobuf)
+) -> PythonLockfileRequest:
+    return PythonLockfileRequest.from_tool(mypy_protobuf)
 
 
 class InjectPythonProtobufDependencies(InjectDependenciesRequest):

--- a/src/python/pants/backend/experimental/python/lockfile.py
+++ b/src/python/pants/backend/experimental/python/lockfile.py
@@ -66,7 +66,7 @@ class PythonLockfile:
 
 @dataclass(frozen=True)
 class PythonLockfileRequest:
-    requirements: FrozenOrderedSet[str, ...]
+    requirements: FrozenOrderedSet[str]
     interpreter_constraints: InterpreterConstraints
     dest: str
     description: str

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -13,7 +13,7 @@ from typing import List, Optional, Tuple, cast
 import toml
 
 from pants.backend.experimental.python.lockfile import (
-    PythonToolLockfileRequest,
+    PythonLockfileRequest,
     PythonToolLockfileSentinel,
 )
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
@@ -224,8 +224,8 @@ class CoveragePyLockfileSentinel(PythonToolLockfileSentinel):
 @rule
 def setup_coverage_lockfile(
     _: CoveragePyLockfileSentinel, coverage: CoverageSubsystem
-) -> PythonToolLockfileRequest:
-    return PythonToolLockfileRequest.from_tool(coverage)
+) -> PythonLockfileRequest:
+    return PythonLockfileRequest.from_tool(coverage)
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -7,7 +7,7 @@ import os.path
 from typing import Iterable, cast
 
 from pants.backend.experimental.python.lockfile import (
-    PythonToolLockfileRequest,
+    PythonLockfileRequest,
     PythonToolLockfileSentinel,
 )
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
@@ -108,8 +108,8 @@ class BlackLockfileSentinel(PythonToolLockfileSentinel):
 
 
 @rule
-def setup_black_lockfile(_: BlackLockfileSentinel, black: Black) -> PythonToolLockfileRequest:
-    return PythonToolLockfileRequest.from_tool(black)
+def setup_black_lockfile(_: BlackLockfileSentinel, black: Black) -> PythonLockfileRequest:
+    return PythonLockfileRequest.from_tool(black)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/docformatter/subsystem.py
+++ b/src/python/pants/backend/python/lint/docformatter/subsystem.py
@@ -4,7 +4,7 @@
 from typing import Tuple, cast
 
 from pants.backend.experimental.python.lockfile import (
-    PythonToolLockfileRequest,
+    PythonLockfileRequest,
     PythonToolLockfileSentinel,
 )
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
@@ -67,8 +67,8 @@ class DocformatterLockfileSentinel(PythonToolLockfileSentinel):
 @rule
 def setup_lockfile_request(
     _: DocformatterLockfileSentinel, docformatter: Docformatter
-) -> PythonToolLockfileRequest:
-    return PythonToolLockfileRequest.from_tool(docformatter)
+) -> PythonLockfileRequest:
+    return PythonLockfileRequest.from_tool(docformatter)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -7,7 +7,7 @@ import os.path
 from typing import Iterable, cast
 
 from pants.backend.experimental.python.lockfile import (
-    PythonToolLockfileRequest,
+    PythonLockfileRequest,
     PythonToolLockfileSentinel,
 )
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
@@ -132,8 +132,8 @@ class IsortLockfileSentinel(PythonToolLockfileSentinel):
 
 
 @rule
-def setup_isort_lockfile(_: IsortLockfileSentinel, isort: Isort) -> PythonToolLockfileRequest:
-    return PythonToolLockfileRequest.from_tool(isort)
+def setup_isort_lockfile(_: IsortLockfileSentinel, isort: Isort) -> PythonLockfileRequest:
+    return PythonLockfileRequest.from_tool(isort)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/yapf/subsystem.py
+++ b/src/python/pants/backend/python/lint/yapf/subsystem.py
@@ -7,7 +7,7 @@ import os.path
 from typing import Iterable, cast
 
 from pants.backend.experimental.python.lockfile import (
-    PythonToolLockfileRequest,
+    PythonLockfileRequest,
     PythonToolLockfileSentinel,
 )
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
@@ -123,8 +123,8 @@ class YapfLockfileSentinel(PythonToolLockfileSentinel):
 
 
 @rule
-def setup_yapf_lockfile(_: YapfLockfileSentinel, yapf: Yapf) -> PythonToolLockfileRequest:
-    return PythonToolLockfileRequest.from_tool(yapf)
+def setup_yapf_lockfile(_: YapfLockfileSentinel, yapf: Yapf) -> PythonLockfileRequest:
+    return PythonLockfileRequest.from_tool(yapf)
 
 
 def rules():


### PR DESCRIPTION
Soon, our lockfile generation will get much fancier to generate one lockfile per valid Python interpreter version, then merge into a single lockfile.

This is prework to use a consistent rule to generate a lockfile.

[ci skip-rust]
[ci skip-build-wheels]