### PR TITLE
Add `[python-setup].interpreter_versions_universe` to ensure Pants works robustly with future Python interpreters

### DIFF
--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -80,7 +80,9 @@ async def setup_black(
     tool_interpreter_constraints = (
         all_interpreter_constraints
         if (
-            all_interpreter_constraints.requires_python38_or_newer()
+            all_interpreter_constraints.requires_python38_or_newer(
+                python_setup.interpreter_universe
+            )
             and black.options.is_default("interpreter_constraints")
         )
         else black.interpreter_constraints

--- a/src/python/pants/backend/python/util_rules/interpreter_constraints.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints.py
@@ -35,6 +35,10 @@ class FieldSetWithInterpreterConstraints(Protocol):
 _FS = TypeVar("_FS", bound=FieldSetWithInterpreterConstraints)
 
 
+# The current maxes are 2.7.18 and 3.6.13.
+_EXPECTED_LAST_PATCH_VERSION = 18
+
+
 # Normally we would subclass `DeduplicatedCollection`, but we want a custom constructor.
 class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter):
     def __init__(self, constraints: Iterable[str | Requirement] = ()) -> None:
@@ -166,7 +170,9 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
             args.extend(["--interpreter-constraint", str(constraint)])
         return args
 
-    def _includes_version(self, major_minor: str, last_patch: int) -> bool:
+    def _includes_version(
+        self, major_minor: str, last_patch: int = _EXPECTED_LAST_PATCH_VERSION
+    ) -> bool:
         patch_versions = list(reversed(range(0, last_patch + 1)))
         for req in self:
             if any(
@@ -181,28 +187,23 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
         This will return True even if the code works with Python 3 too, so long as at least one of
         the constraints works with Python 2.
         """
-        last_py27_patch_version = 18
-        return self._includes_version("2.7", last_patch=last_py27_patch_version)
+        return self._includes_version("2.7")
 
-    def minimum_python_version(self) -> str | None:
+    def minimum_python_version(self, interpreter_universe: Iterable[str]) -> str | None:
         """Find the lowest major.minor Python version that will work with these constraints.
 
         The constraints may also be compatible with later versions; this is the lowest version that
         still works.
         """
-        if self.includes_python2():
-            return "2.7"
-        max_expected_py3_patch_version = 15  # The current max is 3.6.12.
-        for major_minor in ("3.5", "3.6", "3.7", "3.8", "3.9", "3.10"):
-            if self._includes_version(major_minor, last_patch=max_expected_py3_patch_version):
+        for major_minor in sorted(interpreter_universe, key=_major_minor_to_int):
+            if self._includes_version(major_minor):
                 return major_minor
         return None
 
     def _requires_python3_version_or_newer(
         self, *, allowed_versions: Iterable[str], prior_version: str
     ) -> bool:
-        # Assume any 3.x release has no more than 15 releases. The max is currently 3.6.12.
-        patch_versions = list(reversed(range(0, 15)))
+        patch_versions = list(reversed(range(0, _EXPECTED_LAST_PATCH_VERSION)))
         # We only need to look at the prior Python release. For example, consider Python 3.8+
         # looking at 3.7. If using something like `>=3.5`, Py37 will be included.
         # `==3.6.*,!=3.7.*,==3.8.*` is extremely unlikely, and even that will work correctly as
@@ -223,14 +224,18 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
                 return False
         return True
 
-    def requires_python38_or_newer(self) -> bool:
+    def requires_python38_or_newer(self, interpreter_universe: Iterable[str]) -> bool:
         """Checks if the constraints are all for Python 3.8+.
 
         This will return False if Python 3.8 is allowed, but prior versions like 3.7 are also
         allowed.
         """
+
+        py38_and_later = [
+            interp for interp in interpreter_universe if _major_minor_to_int(interp) >= (3, 8)
+        ]
         return self._requires_python3_version_or_newer(
-            allowed_versions=["3.8", "3.9", "3.10"], prior_version="3.7"
+            allowed_versions=py38_and_later, prior_version="3.7"
         )
 
     def __str__(self) -> str:
@@ -238,3 +243,7 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
 
     def debug_hint(self) -> str:
         return str(self)
+
+
+def _major_minor_to_int(major_minor: str) -> tuple[int, int]:
+    return tuple(int(x) for x in major_minor.split(".", maxsplit=1))  # type: ignore[return-value]

--- a/src/python/pants/backend/python/util_rules/interpreter_constraints_test.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints_test.py
@@ -177,7 +177,11 @@ def test_interpreter_constraints_do_not_include_python2(constraints):
 def test_interpreter_constraints_minimum_python_version(
     constraints: List[str], expected: str
 ) -> None:
-    assert InterpreterConstraints(constraints).minimum_python_version() == expected
+    universe = ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
+    ics = InterpreterConstraints(constraints)
+    assert ics.minimum_python_version(universe) == expected
+    assert ics.minimum_python_version(reversed(universe)) == expected
+    assert ics.minimum_python_version(sorted(universe)) == expected
 
 
 @pytest.mark.parametrize(
@@ -194,7 +198,11 @@ def test_interpreter_constraints_minimum_python_version(
     ],
 )
 def test_interpreter_constraints_require_python38(constraints) -> None:
-    assert InterpreterConstraints(constraints).requires_python38_or_newer() is True
+    ics = InterpreterConstraints(constraints)
+    universe = ("2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11")
+    assert ics.requires_python38_or_newer(universe) is True
+    assert ics.requires_python38_or_newer(reversed(universe)) is True
+    assert ics.requires_python38_or_newer(sorted(universe)) is True
 
 
 @pytest.mark.parametrize(
@@ -211,7 +219,11 @@ def test_interpreter_constraints_require_python38(constraints) -> None:
     ],
 )
 def test_interpreter_constraints_do_not_require_python38(constraints):
-    assert InterpreterConstraints(constraints).requires_python38_or_newer() is False
+    ics = InterpreterConstraints(constraints)
+    universe = ("2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11")
+    assert ics.requires_python38_or_newer(universe) is False
+    assert ics.requires_python38_or_newer(reversed(universe)) is False
+    assert ics.requires_python38_or_newer(sorted(universe)) is False
 
 
 def test_group_field_sets_by_constraints() -> None:

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -55,7 +55,7 @@ class PythonSetup(Subsystem):
                 "This is used by Pants to robustly handle interpreter constraints, such as knowing "
                 "when generating lockfiles which Python versions to check if your code is "
                 "using.\n\n"
-                "This does not set your code's interpreter constraints. Instead, to set your "
+                "This does not control which interpreter your code will use. Instead, to set your "
                 "interpreter constraints, update `[python-setup].interpreter_constraints`, the "
                 "`interpreter_constraints` field, and relevant tool options like "
                 "`[isort].interpreter_constraints` to tell Pants which interpreters your code "

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -16,6 +16,7 @@ from pants.base.build_environment import get_buildroot
 from pants.engine.environment import Environment
 from pants.option.custom_types import file_option
 from pants.option.subsystem import Subsystem
+from pants.util.docutil import doc_url
 from pants.util.memo import memoized_method
 from pants.util.osutil import CPU_COUNT
 
@@ -41,6 +42,26 @@ class PythonSetup(Subsystem):
                 ">=2.7 AND version <3) or 'PyPy' (A pypy interpreter of any version). Multiple "
                 "constraint strings will be ORed together.\n\nThese constraints are used as the "
                 "default value for the `interpreter_constraints` field of Python targets."
+            ),
+        )
+        register(
+            "--interpreter-versions-universe",
+            advanced=True,
+            type=list,
+            default=["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"],
+            help=(
+                "All known Python major/minor interpreter versions that may be used by either "
+                "your code or tools used by your code.\n\n"
+                "This is used by Pants to robustly handle interpreter constraints, such as knowing "
+                "when generating lockfiles which Python versions to check if your code is "
+                "using.\n\n"
+                "This does not set your code's interpreter constraints. Instead, to set your "
+                "interpreter constraints, update `[python-setup].interpreter_constraints`, the "
+                "`interpreter_constraints` field, and relevant tool options like "
+                "`[isort].interpreter_constraints` to tell Pants which interpreters your code "
+                f"actually uses. See {doc_url('python-interpreter-compatibility')}.\n\n"
+                "All elements must be the minor and major Python version, e.g. '2.7' or '3.10'. Do "
+                "not include the patch version.\n\n"
             ),
         )
         register(
@@ -148,6 +169,10 @@ class PythonSetup(Subsystem):
     @property
     def interpreter_constraints(self) -> Tuple[str, ...]:
         return tuple(self.options.interpreter_constraints)
+
+    @property
+    def interpreter_universe(self) -> tuple[str, ...]:
+        return tuple(self.options.interpreter_versions_universe)
 
     @property
     def requirement_constraints(self) -> str | None:


### PR DESCRIPTION
We have some code that checks which Python versions are in use, which requires assuming which candidate interpreters exist in the universe. We do these checks for this dynamic functionality:

- Set the MyPy version for each partition (if user did not already explicitly set it).
- Install MyPy and Black w/ Py38+ if the user's code is Py38+, which is necessary because `typed-ast` is no longer offered for Py38+ to be able to parse newer Python ASTs than the current interpreter.
- (Upcoming) Partition a user's interpreter constraints into each valid Python major/minor version, e.g. `>=3.6,<3.9` into `['3.6', '3.7', '3.8']`.

@stuhood pointed out that it is very risky for us to hardcode the assumed Python versions. We know that some Pants users use a particular Pants version >1 year after its release, so it is plausible someone will be using, say, Pants 2.7 and trying to use Python 3.11 in the future.

[ci skip-rust]
[ci skip-build-wheels]