### PR TITLE
Ensure fmt goal is run before the lint goal. fixes #12334

### DIFF
--- a/src/python/pants/base/dependence_analysis.py
+++ b/src/python/pants/base/dependence_analysis.py
@@ -1,0 +1,112 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from collections import defaultdict
+from dataclasses import dataclass
+from operator import itemgetter
+from typing import (
+    ClassVar,
+    DefaultDict,
+    Generic,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    cast,
+)
+
+from pants.engine.goal import Goal
+from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.target import Sources, Target, Targets
+from pants.engine.unions import UnionMembership, union
+from pants.util.ordered_set import FrozenOrderedSet
+
+_S = TypeVar("_S", bound=Sources)
+
+
+@union
+@dataclass(frozen=True)
+class DependenceAnalysisRequest(Generic[_S]):
+    """A request to determine what kind of goal data dependence exists for target source fields."""
+
+    source_field_types: ClassVar[Tuple[Type[_S], ...]] = tuple()
+    targets: Targets
+
+
+@dataclass(frozen=True)
+class DependenceAnalysisResult:
+    goal: Goal
+    accesses: Targets
+    mutates: Optional[Targets] = None
+
+
+@dataclass(frozen=True)
+class DependenceAnalysis:
+    goal_dependence_order: FrozenOrderedSet[Goal]
+
+
+def update_goal(
+    goals_per_target: DefaultDict[Target, List[Goal]], goal: Goal, targets: Targets, append: bool
+) -> int:
+    """Update goals_per_target for each target, adding goal to the front or back of the list of
+    goals.
+
+    Returns the lowest index position for this goal.
+    """
+    idx = 0
+    for target in targets:
+        goals = goals_per_target[target]
+        if append and goal not in goals:
+            idx = max(idx, len(goals))
+            goals.append(goal)
+        elif not append:
+            goals.append(goal)
+    return idx
+
+
+@rule
+async def run_dependence_analysis(
+    targets: Targets, union_membership: UnionMembership
+) -> DependenceAnalysis:
+    request_types = cast(
+        "Iterable[type[DependenceAnalysisRequest]]", union_membership[DependenceAnalysisRequest]
+    )
+    requests = [
+        request_type(
+            Targets(
+                tgt
+                for tgt in targets
+                if any(tgt.has_field(fld) for fld in request_type.source_field_types)
+            )
+            if request_type.source_field_types
+            else targets
+        )
+        for request_type in request_types
+    ]
+    results = await MultiGet(
+        Get(DependenceAnalysisResult, DependenceAnalysisRequest, request) for request in requests
+    )
+
+    # Sort results based on target accesses/mutates data dependence.
+    goals_per_target: DefaultDict[Target, List[Goal]] = defaultdict(list)
+    goal_orders = sorted(
+        [
+            (update_goal(goals_per_target, result.goal, result.mutates, append=False), result.goal)
+            for result in results
+            if result.mutates
+        ]
+        + [
+            (update_goal(goals_per_target, result.goal, result.accesses, append=True), result.goal)
+            for result in results
+            if result.accesses
+        ],
+        key=itemgetter(0),
+    )
+
+    return DependenceAnalysis(FrozenOrderedSet([goal for _, goal in goal_orders]))
+
+
+def rules():
+    return collect_rules()

--- a/src/python/pants/base/dependence_analysis_test.py
+++ b/src/python/pants/base/dependence_analysis_test.py
@@ -1,0 +1,186 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from textwrap import dedent
+from typing import cast
+
+from pants.backend.python.target_types import PythonLibrary, PythonSources
+from pants.base.dependence_analysis import (
+    DependenceAnalysis,
+    DependenceAnalysisRequest,
+    DependenceAnalysisResult,
+    run_dependence_analysis,
+)
+from pants.engine.addresses import Address, Addresses
+from pants.engine.goal import Goal, GoalSubsystem
+from pants.engine.rules import rule
+from pants.engine.target import Sources, Target
+from pants.engine.unions import UnionRule
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.util.ordered_set import FrozenOrderedSet
+
+
+class FortranSources(Sources):
+    expected_file_extensions = (".f90",)
+
+
+class FortranTestsSources(FortranSources):
+    default = ("*_test.f90", "test_*.f90")
+
+
+class FortranLibrarySources(FortranSources):
+    default = ("*.f90",) + tuple(f"!{pat}" for pat in FortranTestsSources.default)
+
+
+class FortranLibrary(Target):
+    alias = "fortran_library"
+    core_fields = (FortranLibrarySources,)
+
+
+def setup_dependence_analysis(da_name, da_source_field_types, rule_impl):
+    class AnalysisRequest(DependenceAnalysisRequest):
+        source_field_types = da_source_field_types
+
+    AnalysisRequest.__name__ = f"{da_name}{AnalysisRequest.__name__}"
+
+    class Subsystem(GoalSubsystem):
+        name = da_name.lower()
+
+    Subsystem.__name__ = f"{da_name}{Subsystem.__name__}"
+
+    class Test(Goal):
+        subsystem_cls = Subsystem
+
+    Test.__name__ = f"{da_name}{Test.__name__}"
+
+    @rule
+    async def analysis_rule(
+        request: AnalysisRequest,
+    ) -> DependenceAnalysisResult:
+        return cast(DependenceAnalysisResult, rule_impl(Test, request))
+
+    analysis_rule.__name__ = f"{da_name}{analysis_rule.__name__}"
+    return Test, analysis_rule, UnionRule(DependenceAnalysisRequest, AnalysisRequest)
+
+
+(
+    transform_py_goal,
+    transform_py_code_analysis_rule,
+    transform_py_union_rule,
+) = setup_dependence_analysis(
+    "TransformPy",
+    (PythonSources,),
+    lambda goal, request: DependenceAnalysisResult(
+        goal=goal,
+        accesses=request.targets,
+        mutates=request.targets,
+    ),
+)
+
+
+(
+    validate_py_goal,
+    validate_py_code_analysis_rule,
+    validate_py_union_rule,
+) = setup_dependence_analysis(
+    "ValidatePy",
+    (PythonSources,),
+    lambda goal, request: DependenceAnalysisResult(
+        goal=goal, accesses=request.targets, mutates=None
+    ),
+)
+
+
+(
+    transform_fortran_goal,
+    transform_fortran_code_analysis_rule,
+    transform_fortran_union_rule,
+) = setup_dependence_analysis(
+    "TransformFortran",
+    (FortranSources,),
+    lambda goal, request: DependenceAnalysisResult(
+        goal=goal,
+        accesses=request.targets,
+        mutates=request.targets,
+    ),
+)
+
+
+(
+    validate_fortran_goal,
+    validate_fortran_code_analysis_rule,
+    validate_fortran_union_rule,
+) = setup_dependence_analysis(
+    "ValidateFortran",
+    (FortranSources,),
+    lambda goal, request: DependenceAnalysisResult(
+        goal=goal, accesses=request.targets, mutates=None
+    ),
+)
+
+
+def test_dependence_analysis():
+    rule_runner = RuleRunner(
+        rules=[
+            run_dependence_analysis,
+            transform_py_code_analysis_rule,
+            transform_py_union_rule,
+            validate_py_code_analysis_rule,
+            validate_py_union_rule,
+            transform_fortran_code_analysis_rule,
+            transform_fortran_union_rule,
+            validate_fortran_code_analysis_rule,
+            validate_fortran_union_rule,
+            QueryRule(DependenceAnalysis, [Addresses]),
+        ],
+        target_types=[
+            FortranLibrary,
+            PythonLibrary,
+        ],
+    )
+
+    rule_runner.write_files(
+        {
+            "src/py/demo/BUILD": dedent(
+                """
+                python_library()
+                """
+            ),
+            "src/fortran/demo/BUILD": dedent(
+                """
+                fortran_library()
+                """
+            ),
+        }
+    )
+
+    def assert_analysis(addresses, goals):
+        result = rule_runner.request(DependenceAnalysis, [Addresses(addresses)])
+
+        assert result.goal_dependence_order == FrozenOrderedSet(goals)
+
+    assert_analysis(
+        [Address("src/py/demo", target_name="demo")],
+        [
+            transform_py_goal,
+            validate_py_goal,
+        ],
+    )
+
+    assert_analysis(
+        [Address("src/fortran/demo", target_name="demo")],
+        [transform_fortran_goal, validate_fortran_goal],
+    )
+
+    assert_analysis(
+        [
+            Address("src/py/demo", target_name="demo"),
+            Address("src/fortran/demo", target_name="demo"),
+        ],
+        [
+            transform_py_goal,
+            transform_fortran_goal,
+            validate_py_goal,
+            validate_fortran_goal,
+        ],
+    )

--- a/src/python/pants/base/dependence_analysis_test.py
+++ b/src/python/pants/base/dependence_analysis_test.py
@@ -11,7 +11,8 @@ from pants.base.dependence_analysis import (
     DependenceAnalysisResult,
     run_dependence_analysis,
 )
-from pants.engine.addresses import Address, Addresses
+from pants.base.specs import Specs
+from pants.base.specs_parser import SpecsParser
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.rules import rule
 from pants.engine.target import Sources, Target
@@ -131,7 +132,7 @@ def test_dependence_analysis():
             transform_fortran_union_rule,
             validate_fortran_code_analysis_rule,
             validate_fortran_union_rule,
-            QueryRule(DependenceAnalysis, [Addresses]),
+            QueryRule(DependenceAnalysis, [Specs]),
         ],
         target_types=[
             FortranLibrary,
@@ -154,13 +155,15 @@ def test_dependence_analysis():
         }
     )
 
+    parser = SpecsParser("/")
+
     def assert_analysis(addresses, goals):
-        result = rule_runner.request(DependenceAnalysis, [Addresses(addresses)])
+        result = rule_runner.request(DependenceAnalysis, [parser.parse_specs(addresses)])
 
         assert result.goal_dependence_order == FrozenOrderedSet(goals)
 
     assert_analysis(
-        [Address("src/py/demo", target_name="demo")],
+        ["src/py/demo"],
         [
             transform_py_goal,
             validate_py_goal,
@@ -168,14 +171,14 @@ def test_dependence_analysis():
     )
 
     assert_analysis(
-        [Address("src/fortran/demo", target_name="demo")],
+        ["src/fortran/demo"],
         [transform_fortran_goal, validate_fortran_goal],
     )
 
     assert_analysis(
         [
-            Address("src/py/demo", target_name="demo"),
-            Address("src/fortran/demo", target_name="demo"),
+            "src/py/demo",
+            "src/fortran/demo",
         ],
         [
             transform_py_goal,


### PR DESCRIPTION
In order to reduce surprises, ensure code formatting is performed before code linting, so that

```
./pants lint fmt ::
```

does the "right" thing on the first run.

See linked issue for motivation.

To solve this, we introduce a `DependenceAnalysis` rule, that for a given set of `Specs` returns a ordered set of goals, based on if they mutate the targets sources or not.

Initial analysis implemented for the `fmt` goal. Goals that does not provide any analysis will be run after those that report as mutating, in the order specified on the command line.

Signed-off-by: Andreas Stenius <andreas.stenius@svenskaspel.se>

# Rust tests and lints will be skipped. Delete if not intended.
[ci skip-rust]

# Building wheels and fs_util will be skipped. Delete if not intended.
[ci skip-build-wheels]