### PR TITLE
[WIP] Generate lockfiles with each possible Python version

### DIFF
--- a/src/python/pants/backend/experimental/python/lockfile.py
+++ b/src/python/pants/backend/experimental/python/lockfile.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from enum import Enum
 from typing import cast
 
 from pants.backend.python.subsystems.python_tool_base import (
@@ -14,14 +15,23 @@ from pants.backend.python.subsystems.python_tool_base import (
 from pants.backend.python.target_types import ConsoleScript, PythonRequirementsField
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import PexRequest, PexRequirements, VenvPex, VenvPexProcess
+from pants.backend.python.util_rules.pex_environment import MaybePythonExecutable
 from pants.engine.addresses import Addresses
-from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests, Workspace
+from pants.engine.fs import (
+    CreateDigest,
+    Digest,
+    DigestContents,
+    FileContent,
+    MergeDigests,
+    Workspace,
+)
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
 from pants.engine.target import TransitiveTargets, TransitiveTargetsRequest
 from pants.engine.unions import UnionMembership, union
 from pants.python.python_setup import PythonSetup
+from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.strutil import pluralize
@@ -34,6 +44,11 @@ logger = logging.getLogger(__name__)
 # --------------------------------------------------------------------------------------
 
 
+class MissingInterpretersBehavior(Enum):
+    warn = "warn"
+    error = "error"
+
+
 class PipToolsSubsystem(PythonToolBase):
     options_scope = "pip-tools"
     help = "Used to generate lockfiles for third-party Python dependencies."
@@ -44,18 +59,36 @@ class PipToolsSubsystem(PythonToolBase):
     @classmethod
     def register_options(cls, register):
         super().register_options(register)
-        # TODO(#12314): How should users indicate where to save the lockfile to when we have
-        #  per-tool lockfiles and multiple user lockfiles?
+        # TODO(#12314): Find a proper home for this. This could be it, but maybe [python-setup] or
+        #  a new [python-lockfiles] are more appropriate? We keep it here for now to feature gate
+        #  it.
         register(
-            "--lockfile-dest",
-            type=str,
-            default="3rdparty/python/lockfile.txt",
-            help="The file path to be created.\n\nThis will overwrite any previous files.",
+            "--lockfile-missing-interpreters-behavior",
+            type=MissingInterpretersBehavior,
+            # TODO(#12314): Once we implement merging logic, update pantsbuild/pants to error. Even
+            #  if we keep the default at warning, we should error for Pants to ensure that our
+            #  default lockfiles we generate are always valid.
+            default=MissingInterpretersBehavior.warn,
+            help=(
+                "What to do if interpreters used by your code or tools you run are not "
+                "discoverable when generating lockfiles.\n\n"
+                "Because some Python dependencies are only needed when using a particular Python "
+                "version, Pants needs to generate a lockfile with each Python interpreter possibly "
+                "used by your interpreter constraints. Pants will then merge all the lockfiles "
+                "into a single, universal lockfile.\n\n"
+                "For example, if you set `[python-setup].interpreter_constraints` to "
+                "`['>=3.6,<3.8']`, Pants will try to generate lockfiles with Python 3.6 and 3.7, "
+                "then merge into a single lockfile.\n\n"
+                "If certain interpreters in the constraint range are missing, the lockfile may be "
+                "invalid."
+            ),
         )
 
     @property
-    def lockfile_dest(self) -> str:
-        return cast(str, self.options.lockfile_dest)
+    def missing_interpreters_behavior(self) -> MissingInterpretersBehavior:
+        return cast(
+            MissingInterpretersBehavior, self.options.lockfile_missing_interpreters_behavior
+        )
 
 
 @dataclass(frozen=True)
@@ -77,54 +110,143 @@ class PythonLockfileRequest:
             requirements=FrozenOrderedSet(subsystem.all_requirements),
             interpreter_constraints=subsystem.interpreter_constraints,
             dest=subsystem.lockfile,
-            description=f"Generate lockfile for {subsystem.options_scope}",
+            description=subsystem.options_scope,
         )
+
+
+@dataclass(frozen=True)
+class _MergeLockfilesRequest:
+    major_minor_version_to_lockfile: FrozenDict[str, FileContent]
 
 
 @rule(desc="Generate lockfile", level=LogLevel.DEBUG)
 async def generate_lockfile(
-    req: PythonLockfileRequest, pip_tools_subsystem: PipToolsSubsystem
+    req: PythonLockfileRequest, pip_tools_subsystem: PipToolsSubsystem, python_setup: PythonSetup
 ) -> PythonLockfile:
     input_requirements = await Get(
         Digest, CreateDigest([FileContent("reqs.txt", "\n".join(req.requirements).encode())])
     )
 
-    pip_compile_pex = await Get(
-        VenvPex,
-        PexRequest(
-            output_filename="pip_compile.pex",
-            internal_only=True,
-            requirements=pip_tools_subsystem.pex_requirements,
-            interpreter_constraints=req.interpreter_constraints,
-            main=pip_tools_subsystem.main,
-            description=(
-                "Building pip_compile.pex with interpreter constraints: "
-                f"{req.interpreter_constraints}"
-            ),
-        ),
+    major_minor_versions_to_ics = req.interpreter_constraints.partition_by_major_minor_versions(
+        python_setup.interpreter_universe
+    )
+    maybe_python_per_ics = await MultiGet(
+        Get(MaybePythonExecutable, InterpreterConstraints, ic)
+        for ic in major_minor_versions_to_ics.values()
     )
 
-    result = await Get(
-        ProcessResult,
-        # TODO(#12314): Figure out named_caches for pip-tools. The best would be to share
-        #  the cache between Pex and Pip. Next best is a dedicated named_cache.
-        VenvPexProcess(
-            pip_compile_pex,
-            description=req.description,
-            # TODO(#12314): Wire up all the pip options like indexes.
-            argv=[
-                "reqs.txt",
-                "--generate-hashes",
-                f"--output-file={req.dest}",
-                # NB: This allows pinning setuptools et al, which we must do. This will become
-                # the default in a future version of pip-tools.
-                "--allow-unsafe",
-            ],
-            input_digest=input_requirements,
-            output_files=(req.dest,),
-        ),
+    valid_versions_to_ics = {}
+    missing_versions_to_ics = {}
+    for major_minor, ic, maybe_python in zip(
+        major_minor_versions_to_ics.keys(),
+        major_minor_versions_to_ics.values(),
+        maybe_python_per_ics,
+    ):
+        if maybe_python.python:
+            valid_versions_to_ics[major_minor] = ic
+        else:
+            missing_versions_to_ics[major_minor] = ic
+
+    if missing_versions_to_ics:
+        if not valid_versions_to_ics:
+            raise ()
+        _handle_missing_interpreters(
+            missing_versions_to_ics,
+            pip_tools_subsystem.missing_interpreters_behavior,
+            lockfile_description=req.description,
+        )
+
+    pip_compile_pexes = await MultiGet(
+        Get(
+            VenvPex,
+            PexRequest(
+                output_filename="pip_compile.pex",
+                internal_only=True,
+                requirements=pip_tools_subsystem.pex_requirements,
+                interpreter_constraints=ic,
+                main=pip_tools_subsystem.main,
+                description=f"Build pip_compile.pex with Python {major_minor}",
+            ),
+        )
+        for major_minor, ic in valid_versions_to_ics.items()
     )
-    return PythonLockfile(result.output_digest, req.dest)
+
+    results = await MultiGet(
+        Get(
+            ProcessResult,
+            # TODO(#12314): Figure out named_caches for pip-tools. The best would be to share
+            #  the cache between Pex and Pip. Next best is a dedicated named_cache.
+            VenvPexProcess(
+                pip_compile,
+                description=f"Generate lockfile for {req.description} with Python {major_minor}",
+                # TODO(#12314): Wire up all the pip options like indexes.
+                argv=[
+                    "reqs.txt",
+                    "--generate-hashes",
+                    f"--output-file={req.dest}",
+                    # NB: This allows pinning setuptools et al, which we must do. This will become
+                    # the default in a future version of pip-tools.
+                    "--allow-unsafe",
+                ],
+                input_digest=input_requirements,
+                output_files=(req.dest,),
+            ),
+        )
+        for pip_compile, major_minor in zip(pip_compile_pexes, valid_versions_to_ics.keys())
+    )
+
+    lockfiles = await MultiGet(Get(DigestContents, Digest, res.output_digest) for res in results)
+    versions_to_lockfiles = {
+        major_minor: digest_contents[0]
+        for major_minor, digest_contents in zip(valid_versions_to_ics.keys(), lockfiles)
+    }
+    return await Get(PythonLockfile, _MergeLockfilesRequest(FrozenDict(versions_to_lockfiles)))
+
+
+@rule(desc="Merge lockfiles generated for each relevant interpreter version", level=LogLevel.DEBUG)
+async def merge_lockfiles(request: _MergeLockfilesRequest) -> PythonLockfile:
+    # TODO(#12314): Properly merge these files into a single one. A simple first step could be to
+    #  detect conflicts and warn so that the user can manually fix.
+    first_lockfile = next(iter(request.major_minor_version_to_lockfile.values()))
+    digest = await Get(Digest, CreateDigest([first_lockfile]))
+    return PythonLockfile(digest, first_lockfile.path)
+
+
+class MissingPythonInterpreters(Exception):
+    pass
+
+
+def _handle_missing_interpreters(
+    missing_versions_to_ics: dict[str, InterpreterConstraints],
+    behavior: MissingInterpretersBehavior,
+    lockfile_description: str,
+) -> None:
+    formatted_missing = "\n".join(
+        f"  * Python {major_minor} (Constraint: {ic})"
+        for major_minor, ic in missing_versions_to_ics.items()
+    )
+    warning = (
+        "Could not find Python interpreters for the following Python versions when generating a "
+        f"lockfile for {lockfile_description}:\n\n"
+        f"{formatted_missing}\n\n"
+        "Because some Python dependencies are only needed when using a particular Python version, "
+        "Pants needs to generate a lockfile with each Python interpreter possibly used by your "
+        "interpreter constraints. Pants will then merge all the lockfiles into a single, "
+        "universal lockfile.\n\n"
+        "To fix this, please either install the missing Python interpreters and ensure they're "
+        "discoverable via `[python-setup].interpreter_search_path`, or tighten your interpreter "
+        "constraints. (Tip: Pyenv can be useful to install multiple interpreter versions.)\n"
+    )
+    if behavior == MissingInterpretersBehavior.warn:
+        logger.warning(warning)
+    elif behavior == MissingInterpretersBehavior.error:
+        warning += (
+            "\nAlternatively, you can update `[pip-tools].lockfile_missing_interpreter_behavior` "
+            "to `warn`, although this risks generating invalid lockfiles.\n"
+        )
+        raise MissingPythonInterpreters(warning)
+    else:
+        raise AssertionError(f"Unhandled variant for {behavior}")
 
 
 # --------------------------------------------------------------------------------------
@@ -144,7 +266,6 @@ class LockGoal(Goal):
 @goal_rule
 async def lockfile_goal(
     addresses: Addresses,
-    pip_tools_subsystem: PipToolsSubsystem,
     python_setup: PythonSetup,
     workspace: Workspace,
 ) -> LockGoal:
@@ -197,11 +318,8 @@ async def lockfile_goal(
             #  transitive closure. When we're doing a single global lockfile, it's fine to do that,
             #  but we need to figure out how this will work with multiple resolves.
             InterpreterConstraints(python_setup.interpreter_constraints),
-            dest=pip_tools_subsystem.lockfile_dest,
-            description=(
-                f"Generate lockfile for {pluralize(len(reqs.req_strings), 'requirements')}: "
-                f"{', '.join(reqs.req_strings)}"
-            ),
+            dest=python_setup.lockfile,
+            description=pluralize(len(reqs.req_strings), "requirements"),
         ),
     )
     workspace.write_digest(result.digest)
@@ -239,22 +357,20 @@ async def generate_all_tool_lockfiles(
 ) -> ToolLockGoal:
     # TODO(#12314): Add logic to inspect the Specs and generate for only relevant lockfiles. For
     #  now, we generate for all tools.
-    requests = await MultiGet(
+    candidate_requests = await MultiGet(
         Get(PythonLockfileRequest, PythonToolLockfileSentinel, sentinel())
         for sentinel in union_membership.get(PythonToolLockfileSentinel)
     )
-    if not requests:
+    if not candidate_requests:
         return ToolLockGoal(exit_code=0)
 
-    results = await MultiGet(
-        Get(PythonLockfile, PythonLockfileRequest, req)
-        for req in requests
-        if req.dest not in {"<none>", "<default>"}
-    )
+    requests = [req for req in candidate_requests if req.dest not in {"<none>", "<default>"}]
+
+    results = await MultiGet(Get(PythonLockfile, PythonLockfileRequest, req) for req in requests)
     merged_digest = await Get(Digest, MergeDigests(res.digest for res in results))
     workspace.write_digest(merged_digest)
-    for result in results:
-        logger.info(f"Wrote lockfile to {result.path}")
+    for req, result in zip(requests, results):
+        logger.info(f"Wrote lockfile for {req.description} to {result.path}")
 
     return ToolLockGoal(exit_code=0)
 

--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -14,7 +14,13 @@ from pants.core.util_rules.subprocess_environment import SubprocessEnvironmentVa
 from pants.engine import process
 from pants.engine.engine_aware import EngineAwareReturnType
 from pants.engine.environment import Environment, EnvironmentRequest
-from pants.engine.process import BinaryPath, BinaryPathRequest, BinaryPaths, BinaryPathTest
+from pants.engine.process import (
+    BinaryPath,
+    BinaryPathRequest,
+    BinaryPaths,
+    BinaryPathTest,
+    FallibleProcessResult,
+)
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.option.global_options import GlobalOptions
 from pants.option.subsystem import Subsystem
@@ -94,6 +100,16 @@ class PexRuntimeEnvironment(Subsystem):
         if level < 0 or level > 9:
             raise ValueError("verbosity level must be between 0 and 9")
         return level
+
+
+@dataclass(frozen=True)
+class MaybePythonExecutable:
+    python: PythonExecutable | None
+    _process_result: FallibleProcessResult | None
+
+    def __post_init__(self) -> None:
+        if not self.python and not self._process_result:
+            raise ValueError("Must set either `python` or `_process_result`.")
 
 
 class PythonExecutable(BinaryPath, EngineAwareReturnType):


### PR DESCRIPTION
To *workaround https://github.com/pantsbuild/pants/issues/12200, we generate a unique lockfile for each interpreter in the constraint range. For example, with `['>=3.6', '<3.8']`, we generate with 3.6 and 3.7. Then, per https://github.com/pantsbuild/pants/pull/12362, we will be able to merge these all into a single unified lockfile thanks to environment markers like `python_version == '3.6'`.

This sets up generating a lockfile with each major-minor interpreter version:

```
18:34:43.86 [INFO] Completed: Build pip_compile.pex with Python 3.9
18:34:44.79 [INFO] Completed: Build pip_compile.pex with Python 3.8
18:34:45.97 [INFO] Completed: Generate lockfile for isort with Python 3.9
18:34:47.96 [INFO] Completed: Generate lockfile for isort with Python 3.8
```

It also warns or errors if any interpreters are missing:

> 18:34:42.07 [WARN] Could not find Python interpreters for the following Python versions when generating a lockfile for yapf:
>
>  * Python 3.6 (Constraint: CPython==3.6.*)
>  * Python 3.7 (Constraint: CPython==3.7.*)
>  * Python 3.10 (Constraint: CPython==3.10.*)
>
> Because some Python dependencies are only needed when using a particular Python version, Pants needs to generate a lockfile with each Python interpreter possibly used by your interpreter constraints. Pants will then merge all the lockfiles into a single, universal lockfile.
>
> To fix this, please either install the missing Python interpreters and ensure they're discoverable via `[python-setup].interpreter_search_path`, or tighten your interpreter constraints. (Tip: Pyenv can be useful to install multiple interpreter versions.)

However, this does not yet implement the merging - for now, we take the lowest lockfile generated (e.g. 3.6 if constraints are 3.6+).

*As explained in https://github.com/pantsbuild/pants/issues/12463, this approach of "pessessimistic generation" is fallible. It handles interpreter constraints, but not platforms. See https://github.com/pantsbuild/pants/issues/12463#issuecomment-893050850 for a failing case.

[ci skip-rust]
[ci skip-build-wheels]