### PR TITLE
[internal] Skip Java tests due to network flakiness

### DIFF
--- a/src/python/pants/backend/java/compile/javac_binary_test.py
+++ b/src/python/pants/backend/java/compile/javac_binary_test.py
@@ -15,6 +15,10 @@ from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
+# TODO(#12293): Stabilize network flakiness.
+pytestmark = pytest.mark.skip
+
+
 @pytest.fixture
 def rule_runner() -> RuleRunner:
     return RuleRunner(

--- a/src/python/pants/backend/java/compile/javac_binary_test.py
+++ b/src/python/pants/backend/java/compile/javac_binary_test.py
@@ -14,7 +14,6 @@ from pants.engine.process import rules as process_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
-
 # TODO(#12293): Stabilize network flakiness.
 pytestmark = pytest.mark.skip
 

--- a/src/python/pants/backend/java/compile/javac_test.py
+++ b/src/python/pants/backend/java/compile/javac_test.py
@@ -29,6 +29,10 @@ from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
+# TODO(#12293): Stabilize network flakiness.
+pytestmark = pytest.mark.skip
+
+
 @pytest.fixture
 def rule_runner() -> RuleRunner:
     return RuleRunner(

--- a/src/python/pants/backend/java/compile/javac_test.py
+++ b/src/python/pants/backend/java/compile/javac_test.py
@@ -28,7 +28,6 @@ from pants.jvm.target_types import JvmDependencyLockfile
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
-
 # TODO(#12293): Stabilize network flakiness.
 pytestmark = pytest.mark.skip
 


### PR DESCRIPTION
See https://github.com/pantsbuild/pants/issues/12293. These seem to be failing around 5-10% of builds in CI.

Because this backend is still experimental, there's less risk in skipping the tests. We can stabilize and re-enable before productionizing the backend.

[ci skip-rust]
[ci skip-build-wheels]