### PR TITLE
Remove redundant cache lookup debug logging

### DIFF
--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -125,13 +125,6 @@ impl crate::CommandRunner for CommandRunner {
     .await;
 
     if let Ok(result) = cache_read_result {
-      workunit.update_metadata(|initial| WorkunitMetadata {
-        desc: initial
-          .desc
-          .as_ref()
-          .map(|desc| format!("Hit local cache: {}", desc)),
-        ..initial
-      });
       return Ok(result);
     }
 


### PR DESCRIPTION
The cache lookup workunit (a few lines up) already mutates itself to report the hit, so additionally reporting the hit on the parent workunit is redundant, and looks like:
```
15:30:10.02 [DEBUG] Completed: Hit: Local cache lookup: Determine Python imports for src/python/pants/engine/internals/mapper_test.py:tests
15:30:10.03 [DEBUG] Completed: Hit local cache: Scheduling: Determine Python imports for src/python/pants/engine/internals/mapper_test.py:tests
```