### PR TITLE
Add option for async completion of StreamingWorkunitHandlers, disabled by default in containers (cherrypick of #12392)

### DIFF
--- a/src/python/pants/base/build_environment.py
+++ b/src/python/pants/base/build_environment.py
@@ -3,6 +3,7 @@
 
 import logging
 import os
+from pathlib import Path
 from typing import Optional
 
 from pants.base.build_root import BuildRoot
@@ -34,6 +35,17 @@ def get_pants_cachedir() -> str:
 def get_default_pants_config_file() -> str:
     """Return the default location of the Pants config file."""
     return os.path.join(get_buildroot(), "pants.toml")
+
+
+def is_in_container() -> bool:
+    """Return true if this process is likely running inside of a container."""
+    # https://stackoverflow.com/a/49944991/38265 and https://github.com/containers/podman/issues/3586
+    cgroup = Path("/proc/self/cgroup")
+    return (
+        Path("/.dockerenv").exists()
+        or Path("/run/.containerenv").exists()
+        or (cgroup.exists() and "docker" in cgroup.read_text("utf-8"))
+    )
 
 
 _Git: Optional[Git] = None

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -253,7 +253,9 @@ class LocalPantsRunner:
                 options_bootstrapper=self.options_bootstrapper,
                 callbacks=self._get_workunits_callbacks(),
                 report_interval_seconds=global_options.streaming_workunits_report_interval,
-                pantsd=global_options.pantsd,
+                allow_async_completion=(
+                    global_options.pantsd and global_options.streaming_workunits_complete_async
+                ),
             )
             with streaming_reporter:
                 engine_result = PANTS_FAILED_EXIT_CODE

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -314,7 +314,7 @@ class StreamingWorkunitTests(unittest.TestCase, SchedulerTestBase):
             max_workunit_verbosity=max_workunit_verbosity,
             specs=Specs.empty(),
             options_bootstrapper=create_options_bootstrapper([]),
-            pantsd=False,
+            allow_async_completion=False,
         )
         return scheduler, tracker, handler
 
@@ -679,7 +679,7 @@ def test_more_complicated_engine_aware(rule_runner: RuleRunner, run_tracker: Run
         max_workunit_verbosity=LogLevel.TRACE,
         specs=Specs.empty(),
         options_bootstrapper=create_options_bootstrapper([]),
-        pantsd=False,
+        allow_async_completion=False,
     )
     with handler:
         input_1 = CreateDigest(
@@ -739,7 +739,7 @@ def test_process_digests_on_streaming_workunits(
         max_workunit_verbosity=LogLevel.INFO,
         specs=Specs.empty(),
         options_bootstrapper=create_options_bootstrapper([]),
-        pantsd=False,
+        allow_async_completion=False,
     )
 
     stdout_process = Process(
@@ -772,7 +772,7 @@ def test_process_digests_on_streaming_workunits(
         max_workunit_verbosity=LogLevel.INFO,
         specs=Specs.empty(),
         options_bootstrapper=create_options_bootstrapper([]),
-        pantsd=False,
+        allow_async_completion=False,
     )
     stderr_process = Process(
         argv=("/bin/bash", "-c", "1>&2 /bin/echo 'stderr output'"), description="Stderr process"
@@ -837,7 +837,7 @@ def test_context_object_on_streaming_workunits(
         max_workunit_verbosity=LogLevel.INFO,
         specs=Specs.empty(),
         options_bootstrapper=create_options_bootstrapper([]),
-        pantsd=False,
+        allow_async_completion=False,
     )
     stdout_process = Process(
         argv=("/bin/bash", "-c", "/bin/echo 'stdout output'"), description="Stdout process"
@@ -899,7 +899,7 @@ def test_streaming_workunits_expanded_specs(run_tracker: RunTracker) -> None:
         options_bootstrapper=create_options_bootstrapper(
             ["--backend-packages=pants.backend.python"]
         ),
-        pantsd=False,
+        allow_async_completion=False,
     )
     stdout_process = Process(
         argv=("/bin/bash", "-c", "/bin/echo 'stdout output'"), description="Stdout process"

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -20,6 +20,7 @@ from pants.base.build_environment import (
     get_buildroot,
     get_default_pants_config_file,
     get_pants_cachedir,
+    is_in_container,
     pants_version,
 )
 from pants.engine.environment import CompleteEnvironment
@@ -1344,6 +1345,18 @@ class GlobalOptions(Subsystem):
             default=1,
             advanced=True,
             help="Interval in seconds between when streaming workunit event receivers will be polled.",
+        )
+        register(
+            "--streaming-workunits-complete-async",
+            advanced=True,
+            type=bool,
+            default=not is_in_container(),
+            help=(
+                "True if stats recording should be allowed to complete asynchronously when `pantsd` "
+                "is enabled. When `pantsd` is disabled, stats recording is always synchronous. "
+                "To reduce data loss, this flag defaults to false inside of containers, such as "
+                "when run with Docker."
+            ),
         )
 
     @classmethod


### PR DESCRIPTION
When run inside of a container that exits as soon as the client returns, async completion of workunit handlers can lead to loss of metrics. Since async completion has significant performance benefits, we disable it conditionally based on whether it is likely that we are running inside of a container.

Fixes #11833.

[ci skip-rust]
[ci skip-build-wheels]