### PR TITLE
Skip preparation of workunit log messages which will never be rendered. (cherrypick of #12396)

### DIFF
--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -92,6 +92,9 @@ pub struct Workunit {
 
 impl Workunit {
   fn log_workunit_state(&self, canceled: bool) {
+    if !log::log_enabled!(self.metadata.level) {
+      return;
+    }
     let state = match (&self.state, canceled) {
       (_, true) => "Canceled:",
       (WorkunitState::Started { .. }, _) => "Starting:",


### PR DESCRIPTION
Based on running `hyperfine -w 2 'MODE=release ./pants --no-pantsd dependencies --transitive ::'` (which generates 19384 workunits), this saves about `1.013s` of runtime in release mode.

[ci skip-build-wheels]