### PR TITLE
[Internal] Rewrite more tests to use `RuleRunner.write_files()`

### DIFF
--- a/src/python/pants/backend/codegen/export_codegen_goal_test.py
+++ b/src/python/pants/backend/codegen/export_codegen_goal_test.py
@@ -79,7 +79,7 @@ def test_no_codegen_targets(rule_runner: RuleRunner, caplog) -> None:
 
 
 def test_export_codegen(rule_runner: RuleRunner) -> None:
-    rule_runner.add_to_build_file("", "gen1(name='gen1')\ngen2(name='gen2')\n")
+    rule_runner.write_files({"BUILD": "gen1(name='gen1')\ngen2(name='gen2')\n"})
     result = rule_runner.run_goal_rule(ExportCodegen, args=["::"])
     assert result.exit_code == 0
     parent_dir = Path(rule_runner.build_root, "dist", "codegen")

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem_test.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem_test.py
@@ -1,8 +1,6 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from textwrap import dedent
-
 from pants.backend.codegen.protobuf.python import python_protobuf_subsystem
 from pants.backend.codegen.protobuf.python.python_protobuf_subsystem import (
     InjectPythonProtobufDependencies,
@@ -29,14 +27,8 @@ def test_inject_dependencies() -> None:
         ]
     )
     # Note that injected deps can be any target type for `--python-protobuf-runtime-dependencies`.
-    rule_runner.add_to_build_file(
-        "protos",
-        dedent(
-            """\
-            protobuf_library()
-            files(name="injected_dep", sources=[])
-            """
-        ),
+    rule_runner.write_files(
+        {"protos/BUILD": "protobuf_library()\nfiles(name='injected_dep', sources=[])"}
     )
     tgt = rule_runner.get_target(Address("protos"))
     injected = rule_runner.request(

--- a/src/python/pants/backend/python/dependency_inference/import_parser_test.py
+++ b/src/python/pants/backend/python/dependency_inference/import_parser_test.py
@@ -94,7 +94,7 @@ def test_normal_imports(rule_runner: RuleRunner) -> None:
     )
     # We create a second file, in addition to what `assert_imports_parsed` does, to ensure we can
     # handle multiple files belonging to the same target.
-    rule_runner.create_file("project/f2.py", "import second_import")
+    rule_runner.write_files({"project/f2.py": "import second_import"})
     assert_imports_parsed(
         rule_runner,
         content,

--- a/src/python/pants/backend/python/macros/pipenv_requirements_test.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements_test.py
@@ -34,13 +34,11 @@ def assert_pipenv_requirements(
     expected_targets: Iterable[PythonRequirementLibrary],
     pipfile_lock_relpath: str = "Pipfile.lock",
 ) -> None:
-    rule_runner.add_to_build_file("", f"{build_file_entry}\n")
-    rule_runner.create_file(pipfile_lock_relpath, dumps(pipfile_lock))
+    rule_runner.write_files({"BUILD": build_file_entry, pipfile_lock_relpath: dumps(pipfile_lock)})
     targets = rule_runner.request(
         Targets,
         [Specs(AddressSpecs([DescendantAddresses("")]), FilesystemSpecs([]))],
     )
-
     assert {expected_file_dep, *expected_targets} == set(targets)
 
 

--- a/src/python/pants/backend/python/macros/poetry_requirements_test.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements_test.py
@@ -391,8 +391,7 @@ def assert_poetry_requirements(
     expected_targets: Iterable[PythonRequirementLibrary],
     pyproject_toml_relpath: str = "pyproject.toml",
 ) -> None:
-    rule_runner.add_to_build_file("", f"{build_file_entry}\n")
-    rule_runner.create_file(pyproject_toml_relpath, pyproject_toml)
+    rule_runner.write_files({"BUILD": build_file_entry, pyproject_toml_relpath: pyproject_toml})
     targets = rule_runner.request(
         Targets,
         [Specs(AddressSpecs([DescendantAddresses("")]), FilesystemSpecs([]))],

--- a/src/python/pants/backend/python/macros/python_requirements_test.py
+++ b/src/python/pants/backend/python/macros/python_requirements_test.py
@@ -34,13 +34,11 @@ def assert_python_requirements(
     expected_targets: Iterable[PythonRequirementLibrary],
     requirements_txt_relpath: str = "requirements.txt",
 ) -> None:
-    rule_runner.add_to_build_file("", f"{build_file_entry}\n")
-    rule_runner.create_file(requirements_txt_relpath, requirements_txt)
+    rule_runner.write_files({"BUILD": build_file_entry, requirements_txt_relpath: requirements_txt})
     targets = rule_runner.request(
         Targets,
         [Specs(AddressSpecs([DescendantAddresses("")]), FilesystemSpecs([]))],
     )
-
     assert {expected_file_dep, *expected_targets} == set(targets)
 
 

--- a/src/python/pants/core/goals/tailor_test.py
+++ b/src/python/pants/core/goals/tailor_test.py
@@ -118,17 +118,15 @@ def test_make_content_str() -> None:
 
 
 def test_rename_conflicting_targets(rule_runner: RuleRunner) -> None:
-    dir_structure = {
-        "src/fortran/foo/BUILD": "fortran_library(sources=['bar1.f90'])\n"
-        "fortran_library(name='foo0', sources=['bar2.f90'])",
-        "src/fortran/foo/bar1.f90": "",
-        "src/fortran/foo/bar2.f90": "",
-        "src/fortran/foo/bar3.f90": "",
-    }
-
-    for path, content in dir_structure.items():
-        rule_runner.create_file(path, content)
-
+    rule_runner.write_files(
+        {
+            "src/fortran/foo/BUILD": "fortran_library(sources=['bar1.f90'])\n"
+            "fortran_library(name='foo0', sources=['bar2.f90'])",
+            "src/fortran/foo/bar1.f90": "",
+            "src/fortran/foo/bar2.f90": "",
+            "src/fortran/foo/bar3.f90": "",
+        }
+    )
     ptgt = PutativeTarget(
         "src/fortran/foo", "foo", "fortran_library", ["bar3.f90"], FortranLibrarySources.default
     )
@@ -152,7 +150,7 @@ def test_rename_conflicting_targets(rule_runner: RuleRunner) -> None:
 
 
 def test_root_targets_are_explicitly_named(rule_runner: RuleRunner) -> None:
-    rule_runner.create_file("foo.f90", "")
+    rule_runner.write_files({"foo.f90": ""})
     ptgt = PutativeTarget("", "", "fortran_library", ["foo.f90"], FortranLibrarySources.default)
     unpts = rule_runner.request(UniquelyNamedPutativeTargets, [PutativeTargets([ptgt])])
     ptgts = unpts.putative_targets
@@ -174,17 +172,15 @@ def test_root_targets_are_explicitly_named(rule_runner: RuleRunner) -> None:
 
 
 def test_restrict_conflicting_sources(rule_runner: RuleRunner) -> None:
-    dir_structure = {
-        "src/fortran/foo/BUILD": "fortran_library(sources=['bar/baz1.f90'])",
-        "src/fortran/foo/bar/BUILD": "fortran_library(sources=['baz2.f90'])",
-        "src/fortran/foo/bar/baz1.f90": "",
-        "src/fortran/foo/bar/baz2.f90": "",
-        "src/fortran/foo/bar/baz3.f90": "",
-    }
-
-    for path, content in dir_structure.items():
-        rule_runner.create_file(path, content)
-
+    rule_runner.write_files(
+        {
+            "src/fortran/foo/BUILD": "fortran_library(sources=['bar/baz1.f90'])",
+            "src/fortran/foo/bar/BUILD": "fortran_library(sources=['baz2.f90'])",
+            "src/fortran/foo/bar/baz1.f90": "",
+            "src/fortran/foo/bar/baz2.f90": "",
+            "src/fortran/foo/bar/baz3.f90": "",
+        }
+    )
     ptgt = PutativeTarget(
         "src/fortran/foo/bar",
         "bar0",
@@ -204,7 +200,7 @@ def test_restrict_conflicting_sources(rule_runner: RuleRunner) -> None:
 
 
 def test_edit_build_files(rule_runner: RuleRunner) -> None:
-    rule_runner.create_file("src/fortran/foo/BUILD", 'fortran_library(sources=["bar1.f90"])')
+    rule_runner.write_files({"src/fortran/foo/BUILD": 'fortran_library(sources=["bar1.f90"])'})
     rule_runner.create_dir("src/fortran/baz/BUILD")  # NB: A directory, not a file.
     req = EditBuildFilesRequest(
         PutativeTargets(
@@ -423,16 +419,17 @@ def test_tailor_rule(rule_runner: RuleRunner) -> None:
 
 
 def test_all_owned_sources(rule_runner: RuleRunner) -> None:
-    for path in [
-        "dir/a.f90",
-        "dir/b.f90",
-        "dir/a_test.f90",
-        "dir/unowned.txt",
-        "unowned.txt",
-        "unowned.f90",
-    ]:
-        rule_runner.create_file(path)
-    rule_runner.add_to_build_file("dir", "fortran_library()\nfortran_tests(name='tests')")
+    rule_runner.write_files(
+        {
+            "dir/a.f90": "",
+            "dir/b.f90": "",
+            "dir/a_test.f90": "",
+            "dir/unowned.txt": "",
+            "dir/BUILD": "fortran_library()\nfortran_tests(name='tests')",
+            "unowned.txt": "",
+            "unowned.f90": "",
+        }
+    )
     assert rule_runner.request(AllOwnedSources, []) == AllOwnedSources(
         ["dir/a.f90", "dir/b.f90", "dir/a_test.f90"]
     )

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -307,8 +307,6 @@ class RuleRunner:
     ) -> str:
         """Writes to a file under the buildroot.
 
-        :API: public
-
         relpath: The relative path to the file from the build root.
         contents: A string containing the contents of the file - '' by default..
         mode: The mode to write to the file in - over-write by default.
@@ -322,10 +320,8 @@ class RuleRunner:
     def create_files(self, path: str | PurePath, files: Iterable[str]) -> None:
         """Writes to a file under the buildroot with contents same as file name.
 
-        :API: public
-
-         path: The relative path to the file from the build root.
-         files: List of file names.
+        path: The relative path to the file from the build root.
+        files: List of file names.
         """
         for f in files:
             self.create_file(os.path.join(path, f), contents=f)
@@ -334,8 +330,6 @@ class RuleRunner:
         self, relpath: str | PurePath, target: str, *, overwrite: bool = False
     ) -> str:
         """Adds the given target specification to the BUILD file at relpath.
-
-        :API: public
 
         relpath: The relative path to the BUILD file from the build root.
         target:  A string containing the target definition as it would appear in a BUILD file.


### PR DESCRIPTION
More progress to deprecating `RuleRunner.create_file()` and `.add_to_build_file()` in favor of the more declarative, batched `.write_files()`.

[ci skip-rust]
[ci skip-build-wheels]