### PR TITLE
[internal] Upgrade PyO3 to 14.1

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -570,16 +570,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbaabec2c953050352311293be5c6aba8e141ba19d6811862b232d6fd020484"
-dependencies = [
- "quote 1.0.8",
- "syn 1.0.67",
-]
-
-[[package]]
 name = "derivative"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1048,17 +1038,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ghost"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5bcf1bbeab73aa4cf2fde60a846858dc036163c7c33bec309f8d17de785479"
-dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.8",
- "syn 1.0.67",
-]
-
-[[package]]
 name = "glob"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1381,28 +1360,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "inventory"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0f7efb804ec95e33db9ad49e4252f049e37e8b0a4652e3cd61f7999f2eff7f"
-dependencies = [
- "ctor",
- "ghost",
- "inventory-impl",
-]
-
-[[package]]
-name = "inventory-impl"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c094e94816723ab936484666968f5b58060492e880f3c8d00489a1e244fa51"
-dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.8",
- "syn 1.0.67",
 ]
 
 [[package]]
@@ -2353,26 +2310,34 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.13.2"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4837b8e8e18a102c23f79d1e9a110b597ea3b684c95e874eb1ad88f8683109c3"
+checksum = "338f7f3701e11fd7f76508c91fbcaabc982564bcaf4d1ca7e1574ff2b4778aec"
 dependencies = [
  "cfg-if 1.0.0",
- "ctor",
  "indoc",
- "inventory",
  "libc",
  "parking_lot",
  "paste 0.1.18",
+ "pyo3-build-config",
  "pyo3-macros",
  "unindent",
 ]
 
 [[package]]
-name = "pyo3-macros"
-version = "0.13.2"
+name = "pyo3-build-config"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47f2c300ceec3e58064fd5f8f5b61230f2ffd64bde4970c81fdd0563a2db1bb"
+checksum = "dcb2e98cc9ccc83d4f7115c8f925e0057e88c8d324b1bc4c2db4a7270c06ac9d"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfb8671a42d0ecc4bec8cc107ae96d49292ca20cd1968e09b98af4aafd516adf"
 dependencies = [
  "pyo3-macros-backend",
  "quote 1.0.8",
@@ -2381,11 +2346,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.13.2"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87b097e5d84fcbe3e167f400fbedd657820a375b034c78bd852050749a575d66"
+checksum = "9addf6dc422f05d4949cc0990195ee74fa43e3c3780cc9a1972fe9e7b68a9f48"
 dependencies = [
  "proc-macro2 1.0.24",
+ "pyo3-build-config",
  "quote 1.0.8",
  "syn 1.0.67",
 ]

--- a/src/rust/engine/engine_pyo3/Cargo.toml
+++ b/src/rust/engine/engine_pyo3/Cargo.toml
@@ -21,6 +21,6 @@ default = []
 hashing = { path = "../hashing" }
 nailgun = { path = "../nailgun" }
 parking_lot = "0.11"
-pyo3 = "0.14"
+pyo3 = "0.14.1"
 task_executor = { path = "../task_executor" }
 testutil_mock = { package = "mock", path = "../testutil/mock" }

--- a/src/rust/engine/engine_pyo3/Cargo.toml
+++ b/src/rust/engine/engine_pyo3/Cargo.toml
@@ -21,10 +21,6 @@ default = []
 hashing = { path = "../hashing" }
 nailgun = { path = "../nailgun" }
 parking_lot = "0.11"
-# We must disable the `auto-initialize` feature because we do not enable `extension-module` normally
-# (see above comment in `features`), so `auto-initialize` would try to link to a static Python interpreter during
-# tests, which may fail. However, we need to then re-activate the `macros` feature. See
-# https://pyo3.rs/v0.13.2/features.html
-pyo3 = { version = "0.13", default-features = false, features = ["macros"] }
+pyo3 = "0.14"
 task_executor = { path = "../task_executor" }
 testutil_mock = { package = "mock", path = "../testutil/mock" }

--- a/src/rust/engine/engine_pyo3/build.rs
+++ b/src/rust/engine/engine_pyo3/build.rs
@@ -31,15 +31,4 @@ fn main() {
   // NB: The native extension only works with the Python interpreter version it was built with
   // (e.g. Python 3.7 vs 3.8).
   println!("cargo:rerun-if-env-changed=PY");
-
-  if cfg!(target_os = "macos") {
-    // N.B. On OSX, we force weak linking by passing the param `-undefined dynamic_lookup` to
-    // the underlying linker. This avoids "missing symbol" errors for Python symbols
-    // (e.g. `_PyImport_ImportModule`) at build time when bundling the PyO3 sources.
-    // The missing symbols will instead by dynamically resolved in the address space of the parent
-    // binary (e.g. `python`) at runtime. We do this to avoid needing to link to libpython
-    // (which would constrain us to specific versions of Python).
-    println!("cargo:rustc-cdylib-link-arg=-undefined");
-    println!("cargo:rustc-cdylib-link-arg=dynamic_lookup");
-  }
 }

--- a/src/rust/engine/engine_pyo3/src/externs/interface.rs
+++ b/src/rust/engine/engine_pyo3/src/externs/interface.rs
@@ -19,16 +19,14 @@ fn native_engine_pyo3(py: Python, m: &PyModule) -> PyResult<()> {
 
 #[pyclass]
 #[derive(Debug, Clone)]
-struct PyExecutor {
-  executor: task_executor::Executor,
-}
+struct PyExecutor(task_executor::Executor);
 
 #[pymethods]
 impl PyExecutor {
   #[new]
   fn __new__(core_threads: usize, max_threads: usize) -> PyResult<Self> {
     task_executor::Executor::global(core_threads, max_threads)
-      .map(|executor| PyExecutor { executor })
+      .map(|executor| PyExecutor(executor))
       .map_err(PyException::new_err)
   }
 }

--- a/src/rust/engine/engine_pyo3/src/externs/interface.rs
+++ b/src/rust/engine/engine_pyo3/src/externs/interface.rs
@@ -26,7 +26,7 @@ impl PyExecutor {
   #[new]
   fn __new__(core_threads: usize, max_threads: usize) -> PyResult<Self> {
     task_executor::Executor::global(core_threads, max_threads)
-      .map(|executor| PyExecutor(executor))
+      .map(PyExecutor)
       .map_err(PyException::new_err)
   }
 }

--- a/src/rust/engine/engine_pyo3/src/externs/interface/nailgun.rs
+++ b/src/rust/engine/engine_pyo3/src/externs/interface/nailgun.rs
@@ -36,7 +36,7 @@ impl PyNailgunClient {
   fn __new__(port: u16, py_executor: PyExecutor) -> Self {
     Self {
       port,
-      executor: py_executor.executor,
+      executor: py_executor.0,
     }
   }
 

--- a/src/rust/engine/engine_pyo3/src/externs/interface/testutil.rs
+++ b/src/rust/engine/engine_pyo3/src/externs/interface/testutil.rs
@@ -36,9 +36,7 @@ impl PyStubCASBuilder {
       .take()
       .ok_or_else(|| PyAssertionError::new_err("Unable to unwrap StubCASBuilder"))?;
     // NB: A Tokio runtime must be used when building StubCAS.
-    py_executor
-      .0
-      .enter(|| Ok(PyStubCAS(builder.build())))
+    py_executor.0.enter(|| Ok(PyStubCAS(builder.build())))
   }
 }
 

--- a/src/rust/engine/engine_pyo3/src/externs/interface/testutil.rs
+++ b/src/rust/engine/engine_pyo3/src/externs/interface/testutil.rs
@@ -17,52 +17,44 @@ pub(crate) fn register(m: &PyModule) -> PyResult<()> {
 }
 
 #[pyclass]
-struct PyStubCASBuilder {
-  builder: Arc<Mutex<Option<StubCASBuilder>>>,
-}
+struct PyStubCASBuilder(Arc<Mutex<Option<StubCASBuilder>>>);
 
 #[pymethods]
 impl PyStubCASBuilder {
   fn always_errors(&mut self) -> PyResult<PyStubCASBuilder> {
-    let mut builder_opt = self.builder.lock();
+    let mut builder_opt = self.0.lock();
     let builder = builder_opt
       .take()
       .ok_or_else(|| PyAssertionError::new_err("Unable to unwrap StubCASBuilder"))?;
     *builder_opt = Some(builder.always_errors());
-    Ok(PyStubCASBuilder {
-      builder: self.builder.clone(),
-    })
+    Ok(PyStubCASBuilder(self.0.clone()))
   }
 
   fn build(&mut self, py_executor: PyExecutor) -> PyResult<PyStubCAS> {
-    let mut builder_opt = self.builder.lock();
+    let mut builder_opt = self.0.lock();
     let builder = builder_opt
       .take()
       .ok_or_else(|| PyAssertionError::new_err("Unable to unwrap StubCASBuilder"))?;
     // NB: A Tokio runtime must be used when building StubCAS.
-    py_executor.executor.enter(|| {
-      Ok(PyStubCAS {
-        stub_cas: builder.build(),
-      })
-    })
+    py_executor
+      .0
+      .enter(|| Ok(PyStubCAS(builder.build())))
   }
 }
 
 #[pyclass]
-struct PyStubCAS {
-  stub_cas: StubCAS,
-}
+struct PyStubCAS(StubCAS);
 
 #[pymethods]
 impl PyStubCAS {
   #[classmethod]
   fn builder(_cls: &PyType) -> PyStubCASBuilder {
     let builder = Arc::new(Mutex::new(Some(StubCAS::builder())));
-    PyStubCASBuilder { builder }
+    PyStubCASBuilder(builder)
   }
 
   #[getter]
   fn address(&self) -> String {
-    self.stub_cas.address()
+    self.0.address()
   }
 }


### PR DESCRIPTION
This allows us to simplify setup of the dependency. 

Tuple structs are also now legal with `#[pyclass]`, so we can use the newytpe pattern via tuple structs.

See https://github.com/PyO3/pyo3/blob/main/CHANGELOG.md for the changelog.