### PR TITLE
terraform: respect search_paths in tailor support

### DIFF
--- a/src/python/pants/backend/terraform/tailor.py
+++ b/src/python/pants/backend/terraform/tailor.py
@@ -22,15 +22,15 @@ from pants.util.logging import LogLevel
 
 
 @dataclass(frozen=True)
-class PutativeTerraformTargetsRequest:
+class PutativeTerraformTargetsRequest(PutativeTargetsRequest):
     pass
 
 
 @rule(level=LogLevel.DEBUG, desc="Determine candidate Terraform targets to create")
 async def find_putative_targets(
-    _: PutativeTerraformTargetsRequest, all_owned_sources: AllOwnedSources
+    request: PutativeTerraformTargetsRequest, all_owned_sources: AllOwnedSources
 ) -> PutativeTargets:
-    all_terraform_files = await Get(Paths, PathGlobs(["**/*.tf"]))
+    all_terraform_files = await Get(Paths, PathGlobs, request.search_paths.path_globs("*.tf"))
     unowned_terraform_files = set(all_terraform_files.files) - set(all_owned_sources)
 
     putative_targets = []

--- a/src/python/pants/backend/terraform/tailor_test.py
+++ b/src/python/pants/backend/terraform/tailor_test.py
@@ -4,7 +4,12 @@
 from pants.backend.terraform.tailor import PutativeTerraformTargetsRequest
 from pants.backend.terraform.tailor import rules as terraform_tailor_rules
 from pants.backend.terraform.target_types import TerraformModule
-from pants.core.goals.tailor import AllOwnedSources, PutativeTarget, PutativeTargets
+from pants.core.goals.tailor import (
+    AllOwnedSources,
+    PutativeTarget,
+    PutativeTargets,
+    PutativeTargetsSearchPaths,
+)
 from pants.core.goals.tailor import rules as core_tailor_rules
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
@@ -37,7 +42,7 @@ def test_find_putative_targets() -> None:
     pts = rule_runner.request(
         PutativeTargets,
         [
-            PutativeTerraformTargetsRequest(),
+            PutativeTerraformTargetsRequest(PutativeTargetsSearchPaths(("src/",))),
             AllOwnedSources(
                 [
                     "src/terraform/root.tf",


### PR DESCRIPTION
`./pants tailor` can restrict its operation to specific paths requested by the user. Individual tailor rules must actually restrict themselves to those paths though. Implement this support for the experimental Terraform plugin.

[ci skip-rust]

[ci skip-build-wheels]