### PR TITLE
tailor: work-around targets that do not have a `sources` field

### DIFF
--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -123,8 +123,12 @@ class PutativeTarget:
     ):
         explicit_sources = (kwargs or {}).get("sources")
         default_sources = default_sources_for_target_type(target_type)
-        if (explicit_sources or triggering_sources) and default_sources is None:
-            raise ValueError(f"Target type {target_type.__name__} does not have a sources field.")
+        if (explicit_sources or triggering_sources) and not default_sources:
+            raise ValueError(
+                f"A target of type {target_type.__name__} was proposed at "
+                f"address {path}:{name} with explicit sources {', '.join(explicit_sources or triggering_sources)}, "
+                "but this target type does not have a `sources` field."
+            )
         owned_sources = explicit_sources or default_sources or tuple()
         return cls(
             path,

--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -82,11 +82,15 @@ class PutativeTarget:
 
     # The sources that triggered creating of this putative target.
     # The putative target will own these sources, but may also glob over other sources.
+    # If the putative target does not have a `sources` field, then this value must be the
+    # empty tuple.
     triggering_sources: Tuple[str, ...]
 
     # The globs of sources owned by this target.
     # If kwargs contains an explicit sources key, it should be identical to this value.
     # Otherwise, this field should contain the default globs that the target type will apply.
+    # If the putative target does not have a `sources` field, then this value must be the
+    # empty tuple.
     # TODO: If target_type is a regular target (and not a macro) we can derive the default
     #  source globs for that type from BuildConfiguration.  However that is fiddly and not
     #  a high priority.

--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -121,11 +121,11 @@ class PutativeTarget:
         comments: Iterable[str] = tuple(),
         build_file_name: str = "BUILD",
     ):
-        maybe_owned_sources = (kwargs or {}).get("sources")
+        explicit_sources = (kwargs or {}).get("sources")
         default_sources = default_sources_for_target_type(target_type)
-        if (maybe_owned_sources or triggering_sources) and default_sources is None:
+        if (explicit_sources or triggering_sources) and default_sources is None:
             raise ValueError(f"Target type {target_type.__name__} does not have a sources field.")
-        owned_sources = maybe_owned_sources or default_sources or tuple()
+        owned_sources = explicit_sources or default_sources or tuple()
         return cls(
             path,
             name,

--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -122,6 +122,11 @@ class PutativeTarget:
         build_file_name: str = "BUILD",
     ):
         explicit_sources = (kwargs or {}).get("sources")
+        if explicit_sources is not None and not isinstance(explicit_sources, tuple):
+            raise TypeError(
+                "Explicit sources passed to PutativeTarget.for_target_type must be a Tuple[str]."
+            )
+
         default_sources = default_sources_for_target_type(target_type)
         if (explicit_sources or triggering_sources) and not default_sources:
             raise ValueError(
@@ -135,7 +140,7 @@ class PutativeTarget:
             name,
             target_type.alias,
             triggering_sources,
-            owned_sources,  # type: ignore[arg-type]
+            owned_sources,
             kwargs=kwargs,
             comments=comments,
             build_file_name=build_file_name,

--- a/src/python/pants/core/goals/tailor_test.py
+++ b/src/python/pants/core/goals/tailor_test.py
@@ -66,6 +66,8 @@ class FortranTests(Target):
     core_fields = (FortranTestsSources,)
 
 
+# This target intentionally has no `sources` field in order to test how `tailor` interacts with targets that
+# have no sources. An example of this type of target is `GoExternalModule`.
 class FortranModule(Target):
     alias = "fortran_module"
     core_fields = ()

--- a/src/python/pants/core/goals/tailor_test.py
+++ b/src/python/pants/core/goals/tailor_test.py
@@ -465,3 +465,11 @@ def test_target_type_with_no_sources_field(rule_runner: RuleRunner) -> None:
     assert putative_targets == PutativeTargets(
         [PutativeTarget.for_target_type(FortranModule, "dir", "dir", [])]
     )
+
+    with pytest.raises(ValueError) as excinfo:
+        _ = PutativeTarget.for_target_type(FortranModule, "dir", "dir", ["a.f90"])
+    expected_msg = (
+        "A target of type FortranModule was proposed at address dir:dir with explicit sources a.f90, "
+        "but this target type does not have a `sources` field."
+    )
+    assert str(excinfo.value) == expected_msg

--- a/src/python/pants/core/goals/tailor_test.py
+++ b/src/python/pants/core/goals/tailor_test.py
@@ -65,6 +65,11 @@ class FortranTests(Target):
     core_fields = (FortranTestsSources,)
 
 
+class FortranModule(Target):
+    alias = "fortran_module"
+    core_fields = tuple()
+
+
 @pytest.fixture
 def rule_runner() -> RuleRunner:
     return RuleRunner(
@@ -83,6 +88,7 @@ def rule_runner() -> RuleRunner:
 def test_default_sources_for_target_type() -> None:
     assert default_sources_for_target_type(FortranLibrary) == FortranLibrarySources.default
     assert default_sources_for_target_type(FortranTests) == FortranTestsSources.default
+    assert default_sources_for_target_type(FortranModule) == tuple()
 
 
 def test_make_content_str() -> None:


### PR DESCRIPTION
## Problem

`./pants tailor` currently assumes that all targets on which it operates will have a `sources` field. As part of the Go plugin's tailor support in https://github.com/pantsbuild/pants/pull/12406, I would like `tailor` to infer `go_external_module` targets which do not have a `sources` field from the dependencies of `go_module` targets.

Attempting to add a `GoExternalModule` target as a `PutativeTarget` caused invocation of `tailor` to raise an exception in `default_sources_for_target_type` because that function could not find a `sources` field.

## Solution 

Work-around the issue by teaching `tailor` to ignore the lack of a `sources` field if there are no owned sources or triggering sources for the `PutativeTarget`. The exception is now raised in `PutativeTarget.for_target_type` if there are any such sources. `default_sources_for_target_type` just returns an empty tuple if it could not find a `sources` field.

This is just a work-around and is not intended as a longer term solution for `tailor` to support target types without `sources`.

[ci skip-rust]

[ci skip-build-wheels]