### PR TITLE
Upgrade tonic to v0.5.0

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -144,9 +144,9 @@ dependencies = [
  "copy_dir",
  "dir-diff",
  "hashing",
- "prost 0.8.0",
+ "prost",
  "prost-build",
- "prost-types 0.8.0",
+ "prost-types",
  "tempfile",
  "tonic",
  "tonic-build",
@@ -367,8 +367,8 @@ name = "concrete_time"
 version = "0.0.1"
 dependencies = [
  "log 0.4.11",
- "prost 0.7.0",
- "prost-types 0.7.0",
+ "prost",
+ "prost-types",
  "serde",
  "serde_derive",
 ]
@@ -835,7 +835,7 @@ dependencies = [
  "grpc_util",
  "hashing",
  "parking_lot",
- "prost 0.7.0",
+ "prost",
  "rand 0.8.2",
  "serde",
  "serde_derive",
@@ -1080,13 +1080,15 @@ version = "0.0.1"
 dependencies = [
  "async-trait",
  "bytes 1.0.1",
+ "either",
  "futures",
  "http",
  "hyper",
+ "itertools 0.10.1",
  "parking_lot",
- "prost 0.8.0",
+ "prost",
  "prost-build",
- "prost-types 0.8.0",
+ "prost-types",
  "rand 0.8.2",
  "rustls-native-certs",
  "tokio",
@@ -1095,6 +1097,8 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -1713,8 +1717,8 @@ dependencies = [
  "hyper",
  "log 0.4.11",
  "parking_lot",
- "prost 0.8.0",
- "prost-types 0.8.0",
+ "prost",
+ "prost-types",
  "testutil",
  "tokio",
  "tonic",
@@ -2223,8 +2227,8 @@ dependencies = [
  "mock",
  "nails",
  "parking_lot",
- "prost 0.8.0",
- "prost-types 0.8.0",
+ "prost",
+ "prost-types",
  "rand 0.8.2",
  "regex",
  "serde",
@@ -2262,7 +2266,7 @@ dependencies = [
  "hashing",
  "log 0.4.11",
  "process_execution",
- "prost 0.7.0",
+ "prost",
  "shlex",
  "store",
  "structopt 0.3.20",
@@ -2273,22 +2277,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
-dependencies = [
- "bytes 1.0.1",
- "prost-derive 0.7.0",
-]
-
-[[package]]
-name = "prost"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
  "bytes 1.0.1",
- "prost-derive 0.8.0",
+ "prost-derive",
 ]
 
 [[package]]
@@ -2303,23 +2297,10 @@ dependencies = [
  "log 0.4.11",
  "multimap",
  "petgraph",
- "prost 0.8.0",
- "prost-types 0.8.0",
+ "prost",
+ "prost-types",
  "tempfile",
  "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
-dependencies = [
- "anyhow",
- "itertools 0.9.0",
- "proc-macro2 1.0.24",
- "quote 1.0.8",
- "syn 1.0.67",
 ]
 
 [[package]]
@@ -2337,22 +2318,12 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
-dependencies = [
- "bytes 1.0.1",
- "prost 0.7.0",
-]
-
-[[package]]
-name = "prost-types"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
  "bytes 1.0.1",
- "prost 0.8.0",
+ "prost",
 ]
 
 [[package]]
@@ -3102,6 +3073,8 @@ dependencies = [
  "glob",
  "grpc_util",
  "hashing",
+ "http",
+ "http-body",
  "indexmap",
  "itertools 0.7.11",
  "lmdb",
@@ -3112,8 +3085,8 @@ dependencies = [
  "mock",
  "num_cpus",
  "parking_lot",
- "prost 0.8.0",
- "prost-types 0.8.0",
+ "prost",
+ "prost-types",
  "serde",
  "serde_derive",
  "sharded_lmdb",
@@ -3123,6 +3096,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tonic",
+ "tower-service",
  "tryfuture",
  "uuid",
  "walkdir 2.3.1",
@@ -3308,7 +3282,7 @@ dependencies = [
  "fs",
  "grpc_util",
  "hashing",
- "prost 0.7.0",
+ "prost",
 ]
 
 [[package]]
@@ -3495,8 +3469,8 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project 1.0.2",
- "prost 0.8.0",
- "prost-derive 0.8.0",
+ "prost",
+ "prost-derive",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -144,9 +144,9 @@ dependencies = [
  "copy_dir",
  "dir-diff",
  "hashing",
- "prost",
+ "prost 0.8.0",
  "prost-build",
- "prost-types",
+ "prost-types 0.8.0",
  "tempfile",
  "tonic",
  "tonic-build",
@@ -367,8 +367,8 @@ name = "concrete_time"
 version = "0.0.1"
 dependencies = [
  "log 0.4.11",
- "prost",
- "prost-types",
+ "prost 0.7.0",
+ "prost-types 0.7.0",
  "serde",
  "serde_derive",
 ]
@@ -835,7 +835,7 @@ dependencies = [
  "grpc_util",
  "hashing",
  "parking_lot",
- "prost",
+ "prost 0.7.0",
  "rand 0.8.2",
  "serde",
  "serde_derive",
@@ -1084,9 +1084,9 @@ dependencies = [
  "http",
  "hyper",
  "parking_lot",
- "prost",
+ "prost 0.8.0",
  "prost-build",
- "prost-types",
+ "prost-types 0.8.0",
  "rand 0.8.2",
  "rustls-native-certs",
  "tokio",
@@ -1193,12 +1193,13 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
+checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
  "bytes 1.0.1",
  "http",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1259,6 +1260,18 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "webpki",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -1401,6 +1414,15 @@ name = "itertools"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
 dependencies = [
  "either",
 ]
@@ -1691,8 +1713,8 @@ dependencies = [
  "hyper",
  "log 0.4.11",
  "parking_lot",
- "prost",
- "prost-types",
+ "prost 0.8.0",
+ "prost-types 0.8.0",
  "testutil",
  "tokio",
  "tonic",
@@ -2201,8 +2223,8 @@ dependencies = [
  "mock",
  "nails",
  "parking_lot",
- "prost",
- "prost-types",
+ "prost 0.8.0",
+ "prost-types 0.8.0",
  "rand 0.8.2",
  "regex",
  "serde",
@@ -2240,7 +2262,7 @@ dependencies = [
  "hashing",
  "log 0.4.11",
  "process_execution",
- "prost",
+ "prost 0.7.0",
  "shlex",
  "store",
  "structopt 0.3.20",
@@ -2256,23 +2278,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
 dependencies = [
  "bytes 1.0.1",
- "prost-derive",
+ "prost-derive 0.7.0",
+]
+
+[[package]]
+name = "prost"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
+dependencies = [
+ "bytes 1.0.1",
+ "prost-derive 0.8.0",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
+checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
 dependencies = [
  "bytes 1.0.1",
  "heck",
- "itertools 0.9.0",
+ "itertools 0.10.1",
  "log 0.4.11",
  "multimap",
  "petgraph",
- "prost",
- "prost-types",
+ "prost 0.8.0",
+ "prost-types 0.8.0",
  "tempfile",
  "which",
 ]
@@ -2291,13 +2323,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.1",
+ "proc-macro2 1.0.24",
+ "quote 1.0.8",
+ "syn 1.0.67",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
 dependencies = [
  "bytes 1.0.1",
- "prost",
+ "prost 0.7.0",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
+dependencies = [
+ "bytes 1.0.1",
+ "prost 0.8.0",
 ]
 
 [[package]]
@@ -3057,8 +3112,8 @@ dependencies = [
  "mock",
  "num_cpus",
  "parking_lot",
- "prost",
- "prost-types",
+ "prost 0.8.0",
+ "prost-types 0.8.0",
  "serde",
  "serde_derive",
  "sharded_lmdb",
@@ -3253,7 +3308,7 @@ dependencies = [
  "fs",
  "grpc_util",
  "hashing",
- "prost",
+ "prost 0.7.0",
 ]
 
 [[package]]
@@ -3356,6 +3411,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3413,9 +3478,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac42cd97ac6bd2339af5bcabf105540e21e45636ec6fa6aae5e85d44db31be0"
+checksum = "b584f064fdfc50017ec39162d5aebce49912f1eb16fd128e04b7f4ce4907c7e5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3427,16 +3492,18 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-timeout",
  "percent-encoding",
  "pin-project 1.0.2",
- "prost",
- "prost-derive",
+ "prost 0.8.0",
+ "prost-derive 0.8.0",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
  "tokio-util",
  "tower",
+ "tower-layer",
  "tower-service",
  "tracing",
  "tracing-futures",
@@ -3444,9 +3511,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c695de27302f4697191dda1c7178131a8cb805463dda02864acb80fe1322fdcf"
+checksum = "d12faebbe071b06f486be82cc9318350814fdd07fcb28f3690840cd770599283"
 dependencies = [
  "proc-macro2 1.0.24",
  "prost-build",

--- a/src/rust/engine/bazel_protos/Cargo.toml
+++ b/src/rust/engine/bazel_protos/Cargo.toml
@@ -8,15 +8,15 @@ publish = false
 [dependencies]
 bytes = "1.0"
 hashing = { path = "../hashing" }
-prost = "0.7"
-prost-build = "0.7"
-prost-types = "0.7"
-tonic = { version = "0.4", features = ["transport", "codegen", "tls", "tls-roots"] }
+prost = "0.8"
+prost-build = "0.8"
+prost-types = "0.8"
+tonic = { version = "0.5", features = ["transport", "codegen", "tls", "tls-roots"] }
 
 [build-dependencies]
 copy_dir = "0.1.2"
 dir-diff = "0.3.1"
 tempfile = "3"
-prost-build = "0.7"
-tonic-build = { version = "0.4", features = ["prost"] }
+prost-build = "0.8"
+tonic-build = { version = "0.5.1", features = ["prost"] }
 walkdir = "2"

--- a/src/rust/engine/concrete_time/Cargo.toml
+++ b/src/rust/engine/concrete_time/Cargo.toml
@@ -6,8 +6,8 @@ name = "concrete_time"
 publish = false
 
 [dependencies]
-prost = "0.7"
-prost-types = "0.7"
+prost = "0.8"
+prost-types = "0.8"
 serde_derive = "1.0.98"
 serde = "1.0.98"
 log = "0.4"

--- a/src/rust/engine/fs/fs_util/Cargo.toml
+++ b/src/rust/engine/fs/fs_util/Cargo.toml
@@ -15,7 +15,7 @@ fs = { path = ".." }
 futures = "0.3"
 hashing = { path = "../../hashing" }
 parking_lot = "0.11"
-prost = "0.7"
+prost = "0.8"
 rand = "0.8"
 serde = "1.0"
 serde_json = "1.0"

--- a/src/rust/engine/fs/store/Cargo.toml
+++ b/src/rust/engine/fs/store/Cargo.toml
@@ -15,6 +15,8 @@ fs = { path = ".." }
 futures = "0.3"
 glob = "0.2.11"
 hashing = { path = "../../hashing" }
+http = "0.2"
+http-body = "0.4"
 indexmap = "1.4"
 itertools = "0.7.2"
 lmdb = { git = "https://github.com/pantsbuild/lmdb-rs.git", rev = "06bdfbfc6348f6804127176e561843f214fc17f8" }
@@ -31,6 +33,7 @@ task_executor = { path = "../../task_executor" }
 tempfile = "3"
 tokio-rustls = "0.22"
 tonic = { version = "0.5", features = ["transport", "codegen", "tls", "tls-roots", "prost"] }
+tower-service = "0.3"
 tryfuture = { path = "../../tryfuture" }
 uuid = { version = "0.7.1", features = ["v4"] }
 workunit_store = {path = "../../workunit_store" }

--- a/src/rust/engine/fs/store/Cargo.toml
+++ b/src/rust/engine/fs/store/Cargo.toml
@@ -22,15 +22,15 @@ log = "0.4"
 madvise = "0.1"
 memmap = "0.7"
 parking_lot = "0.11"
-prost = "0.7"
-prost-types = "0.7"
+prost = "0.8"
+prost-types = "0.8"
 serde = "1.0"
 serde_derive = "1.0"
 sharded_lmdb = { path = "../../sharded_lmdb" }
 task_executor = { path = "../../task_executor" }
 tempfile = "3"
 tokio-rustls = "0.22"
-tonic = { version = "0.4", features = ["transport", "codegen", "tls", "tls-roots", "prost"] }
+tonic = { version = "0.5", features = ["transport", "codegen", "tls", "tls-roots", "prost"] }
 tryfuture = { path = "../../tryfuture" }
 uuid = { version = "0.7.1", features = ["v4"] }
 workunit_store = {path = "../../workunit_store" }

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -12,9 +12,7 @@ use bytes::{Bytes, BytesMut};
 use futures::Future;
 use futures::StreamExt;
 use grpc_util::retry::{retry_call, status_is_retryable};
-use grpc_util::{
-  headers_to_interceptor_fn, identity_interceptor_fn, layered_service, status_to_str,
-};
+use grpc_util::{headers_to_http_header_map, layered_service, status_to_str, LayeredService};
 use hashing::Digest;
 use log::Level;
 use remexec::content_addressable_storage_client::ContentAddressableStorageClient;
@@ -27,11 +25,8 @@ pub struct ByteStore {
   chunk_size_bytes: usize,
   upload_timeout: Duration,
   rpc_attempts: usize,
-  interceptor: Option<Interceptor>,
-  byte_stream_client:
-    Arc<ByteStreamClient<Box<dyn tonic::client::GrpcService<tonic::body::BoxBody>>>>,
-  cas_client:
-    Arc<ContentAddressableStorageClient<Box<dyn tonic::client::GrpcService<tonic::body::BoxBody>>>>,
+  byte_stream_client: Arc<ByteStreamClient<LayeredService>>,
+  cas_client: Arc<ContentAddressableStorageClient<LayeredService>>,
 }
 
 impl fmt::Debug for ByteStore {
@@ -82,36 +77,24 @@ impl ByteStore {
 
     let endpoint =
       grpc_util::create_endpoint(&cas_address, tls_client_config.as_ref(), &mut headers)?;
+    let http_headers = headers_to_http_header_map(&headers)?;
     let channel = layered_service(
       tonic::transport::Channel::balance_list(vec![endpoint].into_iter()),
       rpc_concurrency_limit,
+      http_headers,
     );
-    let interceptor = if headers.is_empty() {
-      None
-    } else {
-      Some(Interceptor::new(headers_to_interceptor_fn(&headers)?))
-    };
 
-    let byte_stream_client = Arc::new(match interceptor.as_ref() {
-      Some(interceptor) => ByteStreamClient::with_interceptor(channel.clone(), interceptor.clone()),
-      None => ByteStreamClient::with_interceptor(channel.clone(), &identity_interceptor_fn),
-    });
+    let byte_stream_client = Arc::new(ByteStreamClient::new(channel.clone()));
 
-    let cas_client = Arc::new(match interceptor.as_ref() {
-      Some(interceptor) => {
-        ContentAddressableStorageClient::with_interceptor(channel, interceptor.clone())
-      }
-      None => ContentAddressableStorageClient::with_interceptor(channel, &identity_interceptor_fn),
-    });
+    let cas_client = Arc::new(ContentAddressableStorageClient::new(channel));
 
     Ok(ByteStore {
       instance_name,
       chunk_size_bytes,
       upload_timeout,
       rpc_attempts: rpc_retries + 1,
-      interceptor,
-      byte_stream_client: Box::new(byte_stream_client) as _,
-      cas_client: Box::new(cas_client) as _,
+      byte_stream_client,
+      cas_client,
     })
   }
 

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -235,7 +235,7 @@ async fn write_connection_error() {
     .await
     .expect_err("Want error");
   assert!(
-    error.contains("dns error: failed to lookup address information"),
+    error.contains("Unknown: \"transport error\""),
     "Bad error message, got: {}",
     error
   );

--- a/src/rust/engine/grpc_util/Cargo.toml
+++ b/src/rust/engine/grpc_util/Cargo.toml
@@ -11,19 +11,19 @@ futures = "0.3"
 hyper = "0.14"
 http = "0.2"
 rustls-native-certs = "0.5"
-prost = "0.7"
+prost = "0.8"
 rand = "0.8"
 tokio = { version = "1.4", features = ["net", "process", "rt-multi-thread", "sync", "time"] }
 tokio-rustls = "0.22"
 tokio-util = { version = "0.6", features = ["codec"] }
-tonic = { version = "0.4", features = ["transport", "codegen", "tls", "tls-roots", "prost"] }
+tonic = { version = "0.5", features = ["transport", "codegen", "tls", "tls-roots", "prost"] }
 tower = { version = "0.4", features = ["limit"] }
 
 [dev-dependencies]
 async-trait = "0.1"
 parking_lot = "0.11"
-prost-types = "0.7"
+prost-types = "0.8"
 
 [build-dependencies]
-prost-build = "0.7"
-tonic-build = "0.4"
+prost-build = "0.8"
+tonic-build = "0.5.1"

--- a/src/rust/engine/grpc_util/Cargo.toml
+++ b/src/rust/engine/grpc_util/Cargo.toml
@@ -7,9 +7,11 @@ publish = false
 
 [dependencies]
 bytes = "1.0"
+either = "1"
 futures = "0.3"
 hyper = "0.14"
 http = "0.2"
+itertools = "0.10"
 rustls-native-certs = "0.5"
 prost = "0.8"
 rand = "0.8"
@@ -18,6 +20,8 @@ tokio-rustls = "0.22"
 tokio-util = { version = "0.6", features = ["codec"] }
 tonic = { version = "0.5", features = ["transport", "codegen", "tls", "tls-roots", "prost"] }
 tower = { version = "0.4", features = ["limit"] }
+tower-layer = "0.3"
+tower-service = "0.3"
 
 [dev-dependencies]
 async-trait = "0.1"

--- a/src/rust/engine/grpc_util/src/headers.rs
+++ b/src/rust/engine/grpc_util/src/headers.rs
@@ -1,0 +1,81 @@
+// Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+use std::fmt;
+use std::task::{Context, Poll};
+
+use http::header::HeaderMap;
+use http::Request;
+use tower_layer::Layer;
+use tower_service::Service;
+
+#[derive(Debug)]
+pub struct SetRequestHeadersLayer {
+  headers: HeaderMap,
+}
+
+impl SetRequestHeadersLayer {
+  pub fn new(headers: HeaderMap) -> Self {
+    SetRequestHeadersLayer { headers }
+  }
+}
+
+impl<S> Layer<S> for SetRequestHeadersLayer {
+  type Service = SetRequestHeaders<S>;
+
+  fn layer(&self, inner: S) -> Self::Service {
+    SetRequestHeaders {
+      inner,
+      headers: self.headers.clone(),
+    }
+  }
+}
+
+#[derive(Clone)]
+pub struct SetRequestHeaders<S> {
+  inner: S,
+  headers: HeaderMap,
+}
+
+impl<S> SetRequestHeaders<S> {
+  pub fn new(inner: S, headers: HeaderMap) -> Self {
+    SetRequestHeaders { inner, headers }
+  }
+}
+
+impl<S> fmt::Debug for SetRequestHeaders<S>
+where
+  S: fmt::Debug,
+{
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.debug_struct("SetRequestHeaders")
+      .field("inner", &self.inner)
+      .field("headers", &self.headers)
+      .finish()
+  }
+}
+
+impl<ReqBody, S> Service<Request<ReqBody>> for SetRequestHeaders<S>
+where
+  S: Service<Request<ReqBody>>,
+{
+  type Response = S::Response;
+  type Error = S::Error;
+  type Future = S::Future;
+
+  #[inline]
+  fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    self.inner.poll_ready(cx)
+  }
+
+  fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
+    if !self.headers.is_empty() {
+      let headers = req.headers_mut();
+      for (header_name, header_value) in &self.headers {
+        headers.insert(header_name, header_value.clone());
+      }
+    }
+
+    self.inner.call(req)
+  }
+}

--- a/src/rust/engine/grpc_util/src/lib.rs
+++ b/src/rust/engine/grpc_util/src/lib.rs
@@ -138,10 +138,10 @@ pub fn headers_to_http_header_map(headers: &BTreeMap<String, String>) -> Result<
   let http_headers = headers
     .iter()
     .map(|(key, value)| {
-      let header_name = HeaderName::from_str(key.as_str())
+      let header_name = HeaderName::from_str(&key)
         .map_err(|err| format!("Invalid header name {}: {}", key, err))?;
 
-      let header_value = HeaderValue::from_str(value.as_str())
+      let header_value = HeaderValue::from_str(&value)
         .map_err(|err| format!("Invalid header value {}: {}", value, err))?;
 
       Ok((header_name, header_value))

--- a/src/rust/engine/grpc_util/src/lib.rs
+++ b/src/rust/engine/grpc_util/src/lib.rs
@@ -30,6 +30,7 @@
 use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
+use std::iter::FromIterator;
 use std::str::FromStr;
 
 use crate::headers::{SetRequestHeaders, SetRequestHeadersLayer};
@@ -37,7 +38,6 @@ use either::Either;
 use http::header::{HeaderName, USER_AGENT};
 use http::{HeaderMap, HeaderValue};
 use itertools::Itertools;
-use std::iter::FromIterator;
 use tokio_rustls::rustls::ClientConfig;
 use tonic::metadata::{AsciiMetadataKey, AsciiMetadataValue, KeyAndValueRef, MetadataMap};
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint};

--- a/src/rust/engine/grpc_util/src/lib.rs
+++ b/src/rust/engine/grpc_util/src/lib.rs
@@ -144,6 +144,12 @@ pub fn headers_to_metadata_map(headers: &BTreeMap<String, String>) -> Result<Met
   Ok(metadata_map)
 }
 
+pub fn identity_interceptor_fn(
+  request: tonic::Request<()>,
+) -> Result<tonic::Request<()>, tonic::Status> {
+  Ok(request)
+}
+
 pub fn headers_to_interceptor_fn(
   headers: &BTreeMap<String, String>,
 ) -> Result<

--- a/src/rust/engine/grpc_util/src/lib.rs
+++ b/src/rust/engine/grpc_util/src/lib.rs
@@ -39,7 +39,6 @@ use http::header::{HeaderName, USER_AGENT};
 use http::{HeaderMap, HeaderValue};
 use itertools::Itertools;
 use tokio_rustls::rustls::ClientConfig;
-use tonic::metadata::{AsciiMetadataKey, AsciiMetadataValue, KeyAndValueRef, MetadataMap};
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
 use tower::limit::ConcurrencyLimit;
 use tower::ServiceBuilder;
@@ -135,26 +134,6 @@ pub fn create_tls_config(root_ca_certs: Option<Vec<u8>>) -> Result<ClientConfig,
   Ok(tls_config)
 }
 
-pub fn headers_to_metadata_map(headers: &BTreeMap<String, String>) -> Result<MetadataMap, String> {
-  let mut metadata_map = MetadataMap::with_capacity(headers.len());
-  for (key, value) in headers {
-    let key_ascii = AsciiMetadataKey::from_str(key.as_str()).map_err(|_| {
-      format!(
-        "Header key `{}` must be an ASCII value (as required by gRPC).",
-        key
-      )
-    })?;
-    let value_ascii = AsciiMetadataValue::from_str(value.as_str()).map_err(|_| {
-      format!(
-        "Header value `{}` for key `{}` must be an ASCII value (as required by gRPC).",
-        value, key
-      )
-    })?;
-    metadata_map.insert(key_ascii, value_ascii);
-  }
-  Ok(metadata_map)
-}
-
 pub fn headers_to_http_header_map(headers: &BTreeMap<String, String>) -> Result<HeaderMap, String> {
   let http_headers = headers
     .iter()
@@ -181,29 +160,6 @@ pub fn headers_to_http_header_map(headers: &BTreeMap<String, String>) -> Result<
   }
 
   Ok(HeaderMap::from_iter(http_headers))
-}
-
-pub fn headers_to_interceptor_fn(
-  headers: &BTreeMap<String, String>,
-) -> Result<
-  impl Fn(tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status> + Send + Sync + 'static,
-  String,
-> {
-  let metadata_map = headers_to_metadata_map(headers)?;
-  Ok(move |mut req: tonic::Request<()>| {
-    let req_metadata = req.metadata_mut();
-    for kv_ref in metadata_map.iter() {
-      match kv_ref {
-        KeyAndValueRef::Ascii(key, value) => {
-          req_metadata.insert(key, value.clone());
-        }
-        KeyAndValueRef::Binary(key, value) => {
-          req_metadata.insert_bin(key, value.clone());
-        }
-      }
-    }
-    Ok(req)
-  })
 }
 
 pub fn status_to_str(status: tonic::Status) -> String {

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -40,11 +40,11 @@ serde = "1.0.104"
 bincode = "1.2.1"
 double-checked-cell-async = "2.0"
 rand = "0.8"
-prost = "0.7"
-prost-types = "0.7"
+prost = "0.8"
+prost-types = "0.8"
 strum = "0.20"
 strum_macros = "0.20"
-tonic = { version = "0.4", features = ["transport", "codegen", "tls", "tls-roots", "prost"] }
+tonic = { version = "0.5", features = ["transport", "codegen", "tls", "tls-roots", "prost"] }
 tryfuture = { path = "../tryfuture" }
 
 [dev-dependencies]

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -11,8 +11,7 @@ use fs::RelativePath;
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use grpc_util::{
-  headers_to_http_header_map, layered_service, retry::retry_call,
-  status_to_str, LayeredService,
+  headers_to_http_header_map, layered_service, retry::retry_call, status_to_str, LayeredService,
 };
 use hashing::Digest;
 use parking_lot::Mutex;

--- a/src/rust/engine/process_executor/Cargo.toml
+++ b/src/rust/engine/process_executor/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.3"
 hashing = { path = "../hashing" }
 log = "0.4"
 process_execution = { path = "../process_execution" }
-prost = "0.7"
+prost = "0.8"
 shlex = "0.1.1"
 store = { path = "../fs/store" }
 structopt = "0.3.20"

--- a/src/rust/engine/testutil/Cargo.toml
+++ b/src/rust/engine/testutil/Cargo.toml
@@ -12,4 +12,4 @@ bytes = "1.0"
 grpc_util = { path = "../grpc_util" }
 fs = { path = "../fs" }
 hashing = { path = "../hashing" }
-prost = "0.7" 
+prost = "0.8" 

--- a/src/rust/engine/testutil/mock/Cargo.toml
+++ b/src/rust/engine/testutil/mock/Cargo.toml
@@ -15,8 +15,8 @@ hashing = { path = "../../hashing" }
 hyper = { version = "0.14", features = ["stream", "tcp"] }
 log = "0.4"
 parking_lot = "0.11"
-prost = "0.7"
-prost-types = "0.7"
+prost = "0.8"
+prost-types = "0.8"
 testutil = { path = ".." }
 tokio = { version = "1.4", features = ["time"] }
-tonic = { version = "0.4" }
+tonic = { version = "0.5" }

--- a/src/rust/engine/testutil/mock/src/execution_server.rs
+++ b/src/rust/engine/testutil/mock/src/execution_server.rs
@@ -36,7 +36,7 @@ use tonic::{Request, Response, Status};
 /// Represents an expected API call from the REv2 client. The data carried by each enum
 /// variant are the parameters to verify and the results to return to the client.
 ///
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 #[allow(clippy::large_enum_variant)] // GetActionResult variant is larger than others
 pub enum ExpectedAPICall {
   Execute {
@@ -64,7 +64,7 @@ pub enum ExpectedAPICall {
 /// client. If the duration is not None, it represents a delay before either responding or
 /// canceling for the operation.
 ///
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct MockOperation {
   pub op: Result<Option<Operation>, Status>,
   pub duration: Option<Duration>,
@@ -182,7 +182,7 @@ impl Drop for TestServer {
             .mock_execution
             .expected_api_calls
             .lock()
-            .clone(),
+            .deref(),
         )),
         MockResponder::display_all(&self.mock_responder.received_messages.deref().lock())
       );


### PR DESCRIPTION
Upgrade the Tonic crate to v0.5.0 and Prost to v0.8.0.

Notes:

- `tonic::Interceptor` was removed. The `with_interceptor` functions now takes a `FnMut(tonic::Request<()>) -> Result<tonic::Request<()>, Status>` type for the interceptor. Moreover, `FooClient::new` and `FooClient::with_interceptor` now return different types and so the return values from each function cannot be stored in the same field any more. Also, `with_interceptor` now returns an `InterceptedService` which encodes the type of the `FnMut` into its type signature. Thus, when I tried using an "identity interceptor" function alongside the actual header interceptor function, the use of `InterceptedService` failed to compile because each closure had a different type and trying to box and/or use an `Arc` just  ended up in type hell.

  * The solution was to introduce a `SetRequestHeadersLayer` based on the `tower-http` crate and to update `layered_service` (and `LayeredService`) to always take a set of headers to apply.
  
- `tonic::Status` is no longer `Clone`. The derivations of `Clone` in `testutil/mock` for various types have been removed.

- Fixed a header setup issue in `src/rust/engine/process_execution/src/remote.rs` where user agent may not have been passed through into one of the channels because of the way in which the header map is modified in place.