### PR TITLE
Add special casing for '--javac-jdk=system' as a temporary hack for #12293.

### DIFF
--- a/src/python/pants/backend/java/compile/javac_binary.py
+++ b/src/python/pants/backend/java/compile/javac_binary.py
@@ -10,6 +10,7 @@ from typing import ClassVar
 
 from pants.backend.java.compile.javac_subsystem import JavacSubsystem
 from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests
+from pants.engine.process import Process, ProcessCacheScope, ProcessResult
 from pants.engine.rules import Get, collect_rules, rule
 from pants.jvm.resolve.coursier_setup import Coursier
 
@@ -26,23 +27,54 @@ class JavacBinary:
 @rule
 async def setup_javac_binary(coursier: Coursier, javac: JavacSubsystem) -> JavacBinary:
     if javac.options.jdk == "system":
-        javac_wrapper_script = textwrap.dedent(
-            f"""\
-            set -eux
-            javac_path="$({coursier.coursier.exe} java-home --system-jvm)/bin/javac"
-            /bin/mkdir -p {JavacBinary.classfiles_relpath}
-            exec "${{javac_path}}" "$@"
-            """
+        process_result = await Get(
+            ProcessResult,
+            Process(
+                argv=[
+                    coursier.coursier.exe,
+                    "java",
+                    "--system-jvm",
+                    "-version",
+                ],
+                input_digest=coursier.digest,
+                description="Invoke Coursier with system-jvm to fingerprint JVM version.",
+                cache_scope=ProcessCacheScope.PER_RESTART_SUCCESSFUL,
+            ),
+        )
+        all_output = "\n".join(
+            [
+                process_result.stderr.decode("utf-8"),
+                process_result.stdout.decode("utf-8"),
+            ]
+        )
+        fingerprint_comment_lines = [
+            "pants javac script using Coursier --system-jvm.  System java -version:",
+            *filter(None, all_output.splitlines()),
+        ]
+        fingerprint_comment = "".join([f"# {line}\n" for line in fingerprint_comment_lines])
+        javac_path_line = (
+            f'javac_path="$({coursier.coursier.exe} java-home --system-jvm)/bin/javac"'
         )
     else:
-        javac_wrapper_script = textwrap.dedent(
-            f"""\
-            set -eux
-            javac_path="$({coursier.coursier.exe} java-home --jvm {javac.options.jdk})/bin/javac"
-            /bin/mkdir -p {JavacBinary.classfiles_relpath}
-            exec "${{javac_path}}" "$@"
-            """
+        fingerprint_comment = f"# pants javac script using Coursier with --jvm {javac.options.jdk}"
+        javac_path_line = (
+            f'javac_path="$({coursier.coursier.exe} java-home --jvm {javac.options.jdk})/bin/javac"'
         )
+
+    # Awkward join so multi-line `fingerprint_comment` won't confuse textwrap.dedent
+    javac_wrapper_script = "\n".join(
+        [
+            fingerprint_comment,
+            textwrap.dedent(
+                f"""\
+                set -eux
+                {javac_path_line}
+                /bin/mkdir -p {JavacBinary.classfiles_relpath}
+                exec "${{javac_path}}" "$@"
+                """
+            ),
+        ]
+    )
     javac_wrapper_script_digest = await Get(
         Digest,
         CreateDigest(

--- a/src/python/pants/backend/java/compile/javac_binary.py
+++ b/src/python/pants/backend/java/compile/javac_binary.py
@@ -25,14 +25,24 @@ class JavacBinary:
 
 @rule
 async def setup_javac_binary(coursier: Coursier, javac: JavacSubsystem) -> JavacBinary:
-    javac_wrapper_script = textwrap.dedent(
-        f"""\
-        set -eux
-        javac_path="$({coursier.coursier.exe} java-home --jvm {javac.options.jdk})/bin/javac"
-        /bin/mkdir -p {JavacBinary.classfiles_relpath}
-        exec "${{javac_path}}" "$@"
-        """
-    )
+    if javac.options.jdk == "system":
+        javac_wrapper_script = textwrap.dedent(
+            f"""\
+            set -eux
+            javac_path="$({coursier.coursier.exe} java-home --system-jvm)/bin/javac"
+            /bin/mkdir -p {JavacBinary.classfiles_relpath}
+            exec "${{javac_path}}" "$@"
+            """
+        )
+    else:
+        javac_wrapper_script = textwrap.dedent(
+            f"""\
+            set -eux
+            javac_path="$({coursier.coursier.exe} java-home --jvm {javac.options.jdk})/bin/javac"
+            /bin/mkdir -p {JavacBinary.classfiles_relpath}
+            exec "${{javac_path}}" "$@"
+            """
+        )
     javac_wrapper_script_digest = await Get(
         Digest,
         CreateDigest(

--- a/src/python/pants/backend/java/compile/javac_binary_test.py
+++ b/src/python/pants/backend/java/compile/javac_binary_test.py
@@ -27,7 +27,6 @@ def rule_runner() -> RuleRunner:
             QueryRule(JavacBinary, ()),
             QueryRule(ProcessResult, (Process,)),
         ],
-        preserve_tmpdirs=True,
     )
 
 

--- a/src/python/pants/backend/java/compile/javac_binary_test.py
+++ b/src/python/pants/backend/java/compile/javac_binary_test.py
@@ -14,9 +14,6 @@ from pants.engine.process import rules as process_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
-# TODO(#12293): Stabilize network flakiness.
-pytestmark = pytest.mark.skip
-
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
@@ -30,6 +27,7 @@ def rule_runner() -> RuleRunner:
             QueryRule(JavacBinary, ()),
             QueryRule(ProcessResult, (Process,)),
         ],
+        preserve_tmpdirs=True,
     )
 
 
@@ -55,6 +53,19 @@ def run_javac_version(rule_runner: RuleRunner) -> str:
     )
 
 
+def test_java_binary_system_version(rule_runner: RuleRunner) -> None:
+    rule_runner.set_options(["--javac-jdk=system"])
+    assert "javac" in run_javac_version(rule_runner)
+
+
+def test_java_binary_bogus_version_fails(rule_runner: RuleRunner) -> None:
+    rule_runner.set_options(["--javac-jdk=bogusjdk:999"])
+    expected_exception_msg = r".*?JVM bogusjdk:999 not found in index.*?"
+    with pytest.raises(ExecutionError, match=expected_exception_msg):
+        run_javac_version(rule_runner)
+
+
+@pytest.mark.skip(reason="#12293 Coursier JDK bootstrapping is currently flaky in CI")
 def test_java_binary_versions(rule_runner: RuleRunner) -> None:
     # default version is 1.11
     assert "javac 11.0" in run_javac_version(rule_runner)

--- a/src/python/pants/backend/java/compile/javac_subsystem.py
+++ b/src/python/pants/backend/java/compile/javac_subsystem.py
@@ -21,10 +21,12 @@ class JavacSubsystem(Subsystem):
             "--jdk",
             default="adopt:1.11",
             advanced=True,
-            help="The JDK to use for invoking javac."
-            " This string will be passed directly to Coursier's `--jvm` parameter."
-            " Run `cs java --available` to see a list of available JVM versions on your platform."
-            " If the string 'system' is passed, Coursier's `--system-jvm` option will be used"
-            " instead, but note that this can lead to inconsistent behavior since the JVM version"
-            " will be whatever happens to be found first on the system's PATH.",
+            help=(
+                "The JDK to use for invoking javac.\n\n"
+                " This string will be passed directly to Coursier's `--jvm` parameter."
+                " Run `cs java --available` to see a list of available JVM versions on your platform.\n\n"
+                " If the string 'system' is passed, Coursier's `--system-jvm` option will be used"
+                " instead, but note that this can lead to inconsistent behavior since the JVM version"
+                " will be whatever happens to be found first on the system's PATH."
+            ),
         )

--- a/src/python/pants/backend/java/compile/javac_subsystem.py
+++ b/src/python/pants/backend/java/compile/javac_subsystem.py
@@ -23,5 +23,8 @@ class JavacSubsystem(Subsystem):
             advanced=True,
             help="The JDK to use for invoking javac."
             " This string will be passed directly to Coursier's `--jvm` parameter."
-            " Run `cs java --available` to see a list of available JVM versions on your platform.",
+            " Run `cs java --available` to see a list of available JVM versions on your platform."
+            " If the string 'system' is passed, Coursier's `--system-jvm` option will be used"
+            " instead, but note that this can lead to inconsistent behavior since the JVM version"
+            " will be whatever happens to be found first on the system's PATH.",
         )

--- a/src/python/pants/backend/java/compile/javac_test.py
+++ b/src/python/pants/backend/java/compile/javac_test.py
@@ -136,6 +136,7 @@ def test_compile_no_deps(rule_runner: RuleRunner) -> None:
     )
 
 
+@pytest.mark.skip(reason="#12293 Coursier JDK bootstrapping is currently flaky in CI")
 def test_compile_jdk_versions(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {

--- a/src/python/pants/backend/java/compile/javac_test.py
+++ b/src/python/pants/backend/java/compile/javac_test.py
@@ -30,9 +30,6 @@ from pants.jvm.target_types import JvmDependencyLockfile
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
-# TODO(#12293): Stabilize network flakiness.
-pytestmark = pytest.mark.skip
-
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
@@ -50,6 +47,9 @@ def rule_runner() -> RuleRunner:
             QueryRule(CoarsenedTargets, (Addresses,)),
         ],
         target_types=[JvmDependencyLockfile, JavaLibrary],
+        # TODO(#12293): Remove this nonhermetic hack once Coursier JVM boostrapping flakiness
+        # is properly fixed in CI.
+        bootstrap_args=["--javac-jdk=system"],
     )
 
 


### PR DESCRIPTION
This causes JavacBinary to pass the `--system-jvm` option to Coursier,
which selects whichever JDK Coursier happens to find already installed
on the system.  Long term, we shouldn't use this behavior in tests and
probably shouldn't even allow it at all since the inherent non-hermeticity
isn't properly captured in cache keys, but for now it allows testing
of Coursier-dependent backends in CI until #12293 is resolved properly.

[ci skip-rust]
[ci skip-build-wheels]