### PR TITLE
introduce `test_globs` field for go_package to identify test files 

### DIFF
--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -10,6 +10,7 @@ from pants.engine.target import (
     InvalidFieldException,
     Sources,
     StringField,
+    StringSequenceField,
     Target,
 )
 
@@ -19,7 +20,7 @@ class GoSources(Sources):
 
 
 class GoPackageSources(GoSources):
-    default = ("*.go", "!*_test.go")
+    default = ("*.go",)
 
 
 class GoImportPath(StringField):
@@ -32,9 +33,21 @@ class GoPackageDependencies(Dependencies):
     pass
 
 
+class GoTestGlobs(StringSequenceField):
+    alias = "test_globs"
+    default = ("*_test.go",)
+    help = "Sequence of globs for which files in the package are test files."
+
+
 class GoPackage(Target):
     alias = "go_package"
-    core_fields = (*COMMON_TARGET_FIELDS, GoPackageDependencies, GoPackageSources, GoImportPath)
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        GoPackageDependencies,
+        GoPackageSources,
+        GoImportPath,
+        GoTestGlobs,
+    )
     help = "A single Go package."
 
 


### PR DESCRIPTION
The current design for the Go plugin has `go_package` own all Go sources in a directory. It is still necessary to exclude test files, however, when building a `go_binary`.

This PR introduces the `test_globs` field for `go_package` as the way for the Go plugin to identify which files in a go_package are test files. It defaults to `("_*test.go",)` which should match the `go` tooling. It is a field versus hard-coded to let users override if necessary.

[ci skip-rust]

[ci skip-build-wheels]