### PR TITLE
go: analyze package metadata

### DIFF
--- a/src/python/pants/backend/experimental/go/register.py
+++ b/src/python/pants/backend/experimental/go/register.py
@@ -1,7 +1,15 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.go import build, distribution, import_analysis, module, tailor, target_type_rules, pkg
+from pants.backend.go import (
+    build,
+    distribution,
+    import_analysis,
+    module,
+    pkg,
+    tailor,
+    target_type_rules,
+)
 from pants.backend.go import target_types as go_target_types
 from pants.backend.go.target_types import GoBinary, GoExternalModule, GoModule, GoPackage
 

--- a/src/python/pants/backend/experimental/go/register.py
+++ b/src/python/pants/backend/experimental/go/register.py
@@ -1,7 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.go import build, distribution, import_analysis, module, tailor, target_type_rules
+from pants.backend.go import build, distribution, import_analysis, module, tailor, target_type_rules, pkg
 from pants.backend.go import target_types as go_target_types
 from pants.backend.go.target_types import GoBinary, GoExternalModule, GoModule, GoPackage
 
@@ -17,6 +17,7 @@ def rules():
         *go_target_types.rules(),
         *import_analysis.rules(),
         *module.rules(),
+        *pkg.rules(),
         *tailor.rules(),
         *target_type_rules.rules(),
     ]

--- a/src/python/pants/backend/go/build.py
+++ b/src/python/pants/backend/go/build.py
@@ -36,7 +36,7 @@ from pants.util.logging import LogLevel
 from pants.util.ordered_set import OrderedSet
 from pants.util.strutil import pluralize
 
-_logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class GoBuildSubsystem(GoalSubsystem):
@@ -139,7 +139,7 @@ async def build_target(
         input_root_digests.add(pkg_descriptor.digest)
         import_config.append(f"packagefile {pkg}={os.path.normpath(pkg_descriptor.path)}")
     import_config_content = "\n".join(import_config).encode("utf-8")
-    _logger.info(f"import_config_content={import_config_content!r}")
+    logger.info(f"import_config_content={import_config_content!r}")
     import_config_digest = await Get(
         Digest, CreateDigest([FileContent(path="./importcfg", content=import_config_content)])
     )
@@ -196,7 +196,7 @@ async def package_go_binary(
         AddressInput,
         AddressInput.parse(main_address, relative_to=field_set.address.spec_path),
     )
-    _logger.info(f"main_go_package_address={main_go_package_address}")
+    logger.info(f"main_go_package_address={main_go_package_address}")
     main_go_package_target = await Get(WrappedTarget, Address, main_go_package_address)
     main_go_package_field_set = BuildGoPackageFieldSet.create(main_go_package_target.target)
     built_main_go_package = await Get(
@@ -248,7 +248,7 @@ async def package_go_binary(
     )
 
     input_snapshot = await Get(Snapshot, Digest, input_digest)
-    _logger.info(f"input_snapshot={input_snapshot.files}")
+    logger.info(f"input_snapshot={input_snapshot.files}")
 
     output_filename_str = field_set.output_path.value
     if output_filename_str:
@@ -258,8 +258,8 @@ async def package_go_binary(
         binary_name = field_set.binary_name.value or "name-not-set"
         output_filename = PurePath(field_set.address.spec_path.replace(os.sep, ".")) / binary_name
 
-    _logger.info(f"parent={output_filename.parent}")
-    _logger.info(f"name={output_filename.name}")
+    logger.info(f"parent={output_filename.parent}")
+    logger.info(f"name={output_filename.name}")
 
     argv = [
         "./go/bin/go",
@@ -286,7 +286,7 @@ async def package_go_binary(
         Digest, AddPrefix(result.output_digest, output_filename.parent.as_posix())
     )
     ss = await Get(Snapshot, Digest, renamed_output_digest)
-    _logger.info(f"ss={ss}")
+    logger.info(f"ss={ss}")
 
     artifact = BuiltPackageArtifact(relpath=output_filename.as_posix())
     return BuiltPackage(digest=renamed_output_digest, artifacts=(artifact,))

--- a/src/python/pants/backend/go/import_analysis.py
+++ b/src/python/pants/backend/go/import_analysis.py
@@ -18,7 +18,7 @@ from pants.engine.rules import collect_rules, rule
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 
-_logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -50,7 +50,7 @@ def parse_imports_for_golang_distribution(raw_json: bytes) -> Dict[str, str]:
             if "Target" in package_descriptor and "ImportPath" in package_descriptor:
                 import_paths[package_descriptor["ImportPath"]] = package_descriptor["Target"]
         except Exception as ex:
-            _logger.error(
+            logger.error(
                 f"error while parsing package descriptor: {ex}; package_descriptor: {json.dumps(package_descriptor)}"
             )
             raise

--- a/src/python/pants/backend/go/module.py
+++ b/src/python/pants/backend/go/module.py
@@ -45,9 +45,6 @@ class ModuleDescriptor:
 
 @dataclass(frozen=True)
 class ResolvedGoModule:
-    # Address of the resolved go_module target.
-    address: Address
-
     # The go_module target.
     target: Target
 
@@ -184,7 +181,6 @@ async def resolve_go_module(
         raise ValueError("No `module` directive found in go.mod.")
 
     return ResolvedGoModule(
-        address=request.address,
         target=target,
         import_path=module_path,
         minimum_go_version=minimum_go_version,

--- a/src/python/pants/backend/go/module.py
+++ b/src/python/pants/backend/go/module.py
@@ -43,6 +43,7 @@ class ModuleDescriptor:
     module_version: str
 
 
+# TODO: Add class docstring with info on the fields.
 @dataclass(frozen=True)
 class ResolvedGoModule:
     # The go_module target.

--- a/src/python/pants/backend/go/module.py
+++ b/src/python/pants/backend/go/module.py
@@ -33,7 +33,7 @@ from pants.engine.target import Target, UnexpandedTargets
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
 
-_logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -248,9 +248,9 @@ async def run_go_resolve(targets: UnexpandedTargets, workspace: Workspace) -> Go
             resolved_go_module = await Get(ResolvedGoModule, ResolveGoModuleRequest(target.address))
             # TODO: Only update the files if they actually changed.
             workspace.write_digest(resolved_go_module.digest, path_prefix=target.address.spec_path)
-            _logger.info(f"{target.address}: Updated go.mod and go.sum.\n")
+            logger.info(f"{target.address}: Updated go.mod and go.sum.\n")
         else:
-            _logger.info(f"{target.address}: Skipping because target is not a `go_module`.\n")
+            logger.info(f"{target.address}: Skipping because target is not a `go_module`.\n")
     return GoResolveGoal(exit_code=0)
 
 

--- a/src/python/pants/backend/go/module.py
+++ b/src/python/pants/backend/go/module.py
@@ -80,6 +80,9 @@ def basic_parse_go_mod(raw_text: bytes) -> Tuple[Optional[str], Optional[str]]:
 
 # Parse the output of `go mod download` into a list of module descriptors.
 def parse_module_descriptors(raw_json: bytes) -> List[ModuleDescriptor]:
+    if len(raw_json) == 0:
+        return []
+
     module_descriptors = []
     for raw_module_descriptor in ijson.items(raw_json, "", multiple_values=True):
         module_descriptor = ModuleDescriptor(

--- a/src/python/pants/backend/go/module.py
+++ b/src/python/pants/backend/go/module.py
@@ -29,7 +29,7 @@ from pants.engine.internals.selectors import Get
 from pants.engine.platform import Platform
 from pants.engine.process import BashBinary, Process, ProcessResult
 from pants.engine.rules import collect_rules, goal_rule, rule
-from pants.engine.target import UnexpandedTargets
+from pants.engine.target import Target, UnexpandedTargets
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
 
@@ -46,6 +46,7 @@ class ModuleDescriptor:
 @dataclass(frozen=True)
 class ResolvedGoModule:
     address: Address
+    target: Target
     import_path: str
     minimum_go_version: Optional[str]
     modules: FrozenOrderedSet[ModuleDescriptor]
@@ -172,6 +173,7 @@ async def resolve_go_module(
 
     return ResolvedGoModule(
         address=request.address,
+        target=target,
         import_path=module_path,
         minimum_go_version=minimum_go_version,
         modules=FrozenOrderedSet(parse_module_descriptors(result.stdout)),

--- a/src/python/pants/backend/go/module.py
+++ b/src/python/pants/backend/go/module.py
@@ -45,11 +45,22 @@ class ModuleDescriptor:
 
 @dataclass(frozen=True)
 class ResolvedGoModule:
+    # Address of the resolved go_module target.
     address: Address
+
+    # The go_module target.
     target: Target
+
+    # Import path of the Go module. Inferred from the import path in the go.mod file.
     import_path: str
+
+    # Minimum Go version of the module from `go` statement in go.mod.
     minimum_go_version: Optional[str]
+
+    # Metadata of referenced modules.
     modules: FrozenOrderedSet[ModuleDescriptor]
+
+    # Digest containing go.mod and updated go.sum.
     digest: Digest
 
 

--- a/src/python/pants/backend/go/module.py
+++ b/src/python/pants/backend/go/module.py
@@ -92,6 +92,7 @@ def basic_parse_go_mod(raw_text: bytes) -> Tuple[Optional[str], Optional[str]]:
 
 # Parse the output of `go mod download` into a list of module descriptors.
 def parse_module_descriptors(raw_json: bytes) -> List[ModuleDescriptor]:
+    # `ijson` cannot handle empty input so short-circuit if there is no data.
     if len(raw_json) == 0:
         return []
 

--- a/src/python/pants/backend/go/module.py
+++ b/src/python/pants/backend/go/module.py
@@ -194,8 +194,8 @@ async def resolve_go_module(
 
 
 @dataclass(frozen=True)
-class FindOwningGoModuleRequest:
-    address: Address
+class FindNearestGoModuleRequest:
+    spec_path: str
 
 
 @dataclass(frozen=True)
@@ -204,11 +204,11 @@ class ResolvedOwningGoModule:
 
 
 @rule
-async def find_nearest_go_module(request: FindOwningGoModuleRequest) -> ResolvedOwningGoModule:
+async def find_nearest_go_module(request: FindNearestGoModuleRequest) -> ResolvedOwningGoModule:
     # Obtain unexpanded targets and ensure file targets are filtered out. Unlike Python, file targets do not
     # make sense semantically for Go source since Go builds entire packages at a time. The filtering is
     # accomplished by requesting `UnexpandedTargets` and also filtering on `is_file_target`.
-    spec_path = request.address.spec_path
+    spec_path = request.spec_path
     candidate_targets = await Get(
         UnexpandedTargets,
         AddressSpecs([AscendantAddresses(spec_path), MaybeEmptySiblingAddresses(spec_path)]),

--- a/src/python/pants/backend/go/pkg.py
+++ b/src/python/pants/backend/go/pkg.py
@@ -30,6 +30,7 @@ _logger = logging.getLogger(__name__)
 
 
 # A fully-resolved Go package. The metadata is obtained by invoking `go list` on the package.
+# TODO: Add class docstring with info on the fields.
 @dataclass(frozen=True)
 class ResolvedGoPackage:
     # Address of the `go_package` target. Copied from the `ResolveGoPackageRequest` for ease of access.

--- a/src/python/pants/backend/go/pkg.py
+++ b/src/python/pants/backend/go/pkg.py
@@ -26,7 +26,7 @@ from pants.engine.rules import collect_rules, rule
 from pants.engine.target import UnexpandedTargets
 from pants.util.logging import LogLevel
 
-_logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 # A fully-resolved Go package. The metadata is obtained by invoking `go list` on the package.
@@ -200,7 +200,7 @@ async def resolve_go_package(
         error_dict = metadata.get("Error", {})
         if error_dict:
             error_str = error_to_string(error_dict)
-            _logger.warning(
+            logger.warning(
                 f"Error while resolving Go package at address {request.address}: {error_str}"
             )
         # TODO: Check DepsErrors key as well.

--- a/src/python/pants/backend/go/pkg.py
+++ b/src/python/pants/backend/go/pkg.py
@@ -3,7 +3,6 @@
 import json
 import logging
 import textwrap
-import typing
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
@@ -225,31 +224,20 @@ async def resolve_go_package(
                 f"that were detected under the key '{key}': {', '.join(files)}."
             )
 
-    package_name: str = metadata["Name"]
-    imports = typing.cast(Tuple[str, ...], tuple(metadata.get("Imports", [])))
-    test_imports = typing.cast(Tuple[str, ...], tuple(metadata.get("TestImports", [])))
-    dependency_import_paths = typing.cast(Tuple[str, ...], tuple(metadata.get("Deps", [])))
-    go_files = typing.cast(Tuple[str, ...], tuple(metadata.get("GoFiles", [])))
-    cgo_files = typing.cast(Tuple[str, ...], tuple(metadata.get("CgoFiles", [])))
-    ignored_go_files = typing.cast(Tuple[str, ...], tuple(metadata.get("IgnoredGoFiles", [])))
-    ignored_other_files = typing.cast(Tuple[str, ...], tuple(metadata.get("IgnoredOtherFiles", [])))
-    test_go_files = typing.cast(Tuple[str, ...], tuple(metadata.get("TestGoFiles", [])))
-    xtest_go_files = typing.cast(Tuple[str, ...], tuple(metadata.get("XTestGoFiles", [])))
-
     return ResolvedGoPackage(
         address=request.address,
         import_path=import_path,
         module_address=owning_go_module_result.module_address,
-        package_name=package_name,
-        imports=imports,
-        test_imports=test_imports,
-        dependency_import_paths=dependency_import_paths,
-        go_files=go_files,
-        cgo_files=cgo_files,
-        ignored_go_files=ignored_go_files,
-        ignored_other_files=ignored_other_files,
-        test_go_files=test_go_files,
-        xtest_go_files=xtest_go_files,
+        package_name=metadata["Name"],
+        imports=tuple(metadata.get("Imports", [])),
+        test_imports=tuple(metadata.get("TestImports", [])),
+        dependency_import_paths=tuple(metadata.get("Deps", [])),
+        go_files=tuple(metadata.get("GoFiles", [])),
+        cgo_files=tuple(metadata.get("CgoFiles", [])),
+        ignored_go_files=tuple(metadata.get("IgnoredGoFiles", [])),
+        ignored_other_files=tuple(metadata.get("IgnoredOtherFiles", [])),
+        test_go_files=tuple(metadata.get("TestGoFiles", [])),
+        xtest_go_files=tuple(metadata.get("XTestGoFiles", [])),
     )
 
 

--- a/src/python/pants/backend/go/pkg.py
+++ b/src/python/pants/backend/go/pkg.py
@@ -1,6 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 import json
+import logging
 import textwrap
 import typing
 from dataclasses import dataclass
@@ -13,12 +14,12 @@ from pants.backend.go.module import (
     ResolvedOwningGoModule,
     ResolveGoModuleRequest,
 )
-from pants.backend.go.target_types import GoImportPath, GoModuleSources
+from pants.backend.go.target_types import GoImportPath, GoModuleSources, GoPackageSources
 from pants.build_graph.address import Address
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Addresses
-from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests, RemovePrefix, Snapshot
+from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests
 from pants.engine.internals.selectors import Get
 from pants.engine.platform import Platform
 from pants.engine.process import BashBinary, Process, ProcessResult
@@ -26,20 +27,67 @@ from pants.engine.rules import collect_rules, rule
 from pants.engine.target import UnexpandedTargets
 from pants.util.logging import LogLevel
 
+_logger = logging.getLogger(__name__)
 
+
+# A fully-resolved Go package. The metadata is obtained by invoking `go list` on the package.
 @dataclass(frozen=True)
 class ResolvedGoPackage:
+    # Address of the `go_package` target. Copied from the `ResolveGoPackageRequest` for ease of access.
     address: Address
+
+    # Import path of this package. The import path will be inferred from an owning `go_module` if present.
     import_path: str
+
+    # Address of the owning `go_module` if present. The owning `go_module` is the nearest go_module at the same
+    # or higher level of the source tree.
     module_address: Optional[Address]
+
+    # Name of the package as given by `package` directives in the source files. Obtained from `Name` key in
+    # package metadata.
     package_name: str
-    imported_import_paths: Tuple[str]
-    dependency_import_paths: Tuple[str]
+
+    # Import paths used by this package. Obtained from `Imports` key in package metadata.
+    imports: Tuple[str, ...]
+
+    # Imports from test files. Obtained from `TestImports` key in package metadata.
+    test_imports: Tuple[str, ...]
+
+    # Explicit and transitive import paths required to build the code. Obtained from `Deps` key in package metadata.
+    dependency_import_paths: Tuple[str, ...]
+
+    # .go source files (excluding CgoFiles, TestGoFiles, XTestGoFiles). Obtained from `GoFiles` key in package metadata.
+    go_files: Tuple[str, ...]
+
+    # .go source files that import "C". Obtained from `CgoFiles` key in package metadata.
+    cgo_files: Tuple[str, ...]
+
+    # .go source files ignored due to build constraints. Obtained from `IgnoredGoFiles` key in package metadata.
+    ignored_go_files: Tuple[str, ...]
+
+    # non-.go source files ignored due to build constraints. Obtained from `IgnoredOtherFiles` key in package metadata.
+    ignored_other_files: Tuple[str, ...]
+
+    # _test.go files in package. Obtained from `TestGoFiles` key in package metadata.
+    test_go_files: Tuple[str, ...]
+
+    # _test.go files outside package. Obtained from `XTestGoFiles` key in package metadata.
+    xtest_go_files: Tuple[str, ...]
 
 
 @dataclass(frozen=True)
 class ResolveGoPackageRequest:
     address: Address
+
+
+def error_to_string(d: dict) -> str:
+    pos = d.get("Pos", "")
+    if pos:
+        pos = f"{pos}: "
+
+    import_stack_items = d.get("ImportStack", [])
+    import_stack = f" (import stack: {', '.join(import_stack_items)})" if import_stack_items else ""
+    return f"{pos}{d['Err']}{import_stack}"
 
 
 @rule
@@ -68,43 +116,44 @@ async def resolve_go_package(
         ResolvedOwningGoModule, FindOwningGoModuleRequest(request.address)
     )
 
+    if not owning_go_module_result.module_address:
+        raise ValueError(f"The go_package at address {request.address} has no owning go_module.")
+    resolved_go_module = await Get(
+        ResolvedGoModule, ResolveGoModuleRequest(owning_go_module_result.module_address)
+    )
+    assert request.address.spec_path.startswith(resolved_go_module.address.spec_path)
+    spec_subpath = request.address.spec_path[len(resolved_go_module.address.spec_path) :]
+
     # Compute the import_path for this go_package.
     import_path_field = target.get(GoImportPath)
     if import_path_field and import_path_field.value:
         # Use any explicit import path set on the `go_package` target.
         import_path = import_path_field.value
-    elif owning_go_module_result.module_address:
+    else:
         # Otherwise infer the import path from the owning `go_module` target. The inferred import path will be the
         # module's import path plus any subdirectories in the spec_path between the go_module and go_package target.
-        resolved_go_module = await Get(
-            ResolvedGoModule, ResolveGoModuleRequest(owning_go_module_result.module_address)
-        )
         if not resolved_go_module.import_path:
             raise ValueError(
                 f"Unable to infer import path for the `go_package` at address {request.address} "
                 f"because the owning go_module at address {resolved_go_module.address} "
-                "does not have an import path defined."
+                "does not have an import path defined nor could one be inferred."
             )
-        assert request.address.spec_path.startswith(resolved_go_module.address.spec_path)
-        spec_path_difference = request.address.spec_path[
-            len(resolved_go_module.address.spec_path) :
-        ]
-        import_path = f"{resolved_go_module.import_path}{spec_path_difference}"
-    else:
-        raise ValueError(
-            f"Unable to infer import path for the `go_package` at address {request.address} "
-            "because no owning go_module was found (which would define an import path for the module) "
-            "and no explicit `import_path` was set on the go_package"
-        )
+        import_path = f"{resolved_go_module.import_path}{spec_subpath}"
 
-    sources = await Get(SourceFiles, SourceFilesRequest([target.get(GoModuleSources)]))
-    flattened_sources_snapshot = await Get(
-        Snapshot, RemovePrefix(sources.snapshot.digest, request.address.spec_path)
+    sources = await Get(
+        SourceFiles,
+        SourceFilesRequest(
+            [
+                target.get(GoPackageSources),
+                resolved_go_module.target.get(GoModuleSources),
+            ]
+        ),
     )
 
     # Note: The `go` tool requires GOPATH to be an absolute path which can only be resolved from within the
     # execution sandbox. Thus, this code uses a bash script to be able to resolve that path.
-    # TODO: Merge all duplicate versions of this script into a single script and invoke rule.
+    # TODO: Merge all duplicate versions of this script into a single script and add an invoke rule that will
+    # insert the desired `go` command into the boilerplate portions.
     analyze_script_digest = await Get(
         Digest,
         CreateDigest(
@@ -112,12 +161,13 @@ async def resolve_go_package(
                 FileContent(
                     "analyze.sh",
                     textwrap.dedent(
-                        """\
-                export GOROOT="./go"
+                        f"""\
+                export GOROOT="$(/bin/pwd)/go"
                 export GOPATH="$(/bin/pwd)/gopath"
                 export GOCACHE="$(/bin/pwd)/cache"
-                mkdir -p "$GOPATH" "$GOCACHE"
-                exec ./go/bin/go list -json .
+                /bin/mkdir -p "$GOPATH" "$GOCACHE"
+                cd {resolved_go_module.address.spec_path}
+                exec "${{GOROOT}}/bin/go" list -json ./{spec_subpath}
                 """
                     ).encode("utf-8"),
                 )
@@ -127,35 +177,78 @@ async def resolve_go_package(
 
     input_root_digest = await Get(
         Digest,
-        MergeDigests(
-            [flattened_sources_snapshot.digest, downloaded_goroot.digest, analyze_script_digest]
-        ),
+        MergeDigests([sources.snapshot.digest, downloaded_goroot.digest, analyze_script_digest]),
     )
 
     process = Process(
         argv=[bash.path, "./analyze.sh"],
         input_digest=input_root_digest,
         description="Resolve go_package metadata.",
-        output_files=["go.mod", "go.sum"],
         level=LogLevel.DEBUG,
     )
 
     result = await Get(ProcessResult, Process, process)
-    print(f"stdout={result.stdout}")  # type: ignore[str-bytes-safe]
-    print(f"stderr={result.stderr}")  # type: ignore[str-bytes-safe]
 
     metadata = json.loads(result.stdout)
+
+    # TODO: Raise an exception on errors. They are only emitted as warnings for now because the `go` tool is
+    # flagging missing first-party code as a dependency error. But we want dependency inference and won't know
+    # what the dependency actually is unless we first resolve the package with that dependency. So circular
+    # reasoning. We may need to hydrate the sources for all go_package targets that share a `go_module`.
+    if metadata.get("Incomplete"):
+        error_dict = metadata.get("Error", {})
+        if error_dict:
+            error_str = error_to_string(error_dict)
+            _logger.warning(
+                f"Error while resolving Go package at address {request.address}: {error_str}"
+            )
+        # TODO: Check DepsErrors key as well.
+
+    # Raise an exception if any unsupported source file keys are present in the metadata.
+    for key in (
+        "CompiledGoFiles",
+        "CFiles",
+        "CXXFiles",
+        "MFiles",
+        "HFiles",
+        "FFiles",
+        "SFiles",
+        "SwigFiles",
+        "SwigCXXFiles",
+        "SysoFiles",
+    ):
+        files = metadata.get(key, [])
+        if files:
+            raise ValueError(
+                f"The go_package at address {request.address} contains the following unsupported source files "
+                f"that were detected under the key '{key}': {', '.join(files)}."
+            )
+
     package_name: str = metadata["Name"]
-    imported_import_paths = typing.cast(Tuple[str], tuple(metadata["Imports"]))
-    dependency_import_paths = typing.cast(Tuple[str], tuple(metadata["Deps"]))
+    imports = typing.cast(Tuple[str, ...], tuple(metadata.get("Imports", [])))
+    test_imports = typing.cast(Tuple[str, ...], tuple(metadata.get("TestImports", [])))
+    dependency_import_paths = typing.cast(Tuple[str, ...], tuple(metadata.get("Deps", [])))
+    go_files = typing.cast(Tuple[str, ...], tuple(metadata.get("GoFiles", [])))
+    cgo_files = typing.cast(Tuple[str, ...], tuple(metadata.get("CgoFiles", [])))
+    ignored_go_files = typing.cast(Tuple[str, ...], tuple(metadata.get("IgnoredGoFiles", [])))
+    ignored_other_files = typing.cast(Tuple[str, ...], tuple(metadata.get("IgnoredOtherFiles", [])))
+    test_go_files = typing.cast(Tuple[str, ...], tuple(metadata.get("TestGoFiles", [])))
+    xtest_go_files = typing.cast(Tuple[str, ...], tuple(metadata.get("XTestGoFiles", [])))
 
     return ResolvedGoPackage(
         address=request.address,
         import_path=import_path,
         module_address=owning_go_module_result.module_address,
         package_name=package_name,
-        imported_import_paths=imported_import_paths,
+        imports=imports,
+        test_imports=test_imports,
         dependency_import_paths=dependency_import_paths,
+        go_files=go_files,
+        cgo_files=cgo_files,
+        ignored_go_files=ignored_go_files,
+        ignored_other_files=ignored_other_files,
+        test_go_files=test_go_files,
+        xtest_go_files=xtest_go_files,
     )
 
 

--- a/src/python/pants/backend/go/pkg.py
+++ b/src/python/pants/backend/go/pkg.py
@@ -9,7 +9,7 @@ from typing import Optional, Tuple
 
 from pants.backend.go.distribution import GoLangDistribution
 from pants.backend.go.module import (
-    FindOwningGoModuleRequest,
+    FindNearestGoModuleRequest,
     ResolvedGoModule,
     ResolvedOwningGoModule,
     ResolveGoModuleRequest,
@@ -113,7 +113,7 @@ async def resolve_go_package(
     target = targets[0]
 
     owning_go_module_result = await Get(
-        ResolvedOwningGoModule, FindOwningGoModuleRequest(request.address)
+        ResolvedOwningGoModule, FindNearestGoModuleRequest(request.address.spec_path)
     )
 
     if not owning_go_module_result.module_address:

--- a/src/python/pants/backend/go/pkg.py
+++ b/src/python/pants/backend/go/pkg.py
@@ -1,0 +1,163 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import json
+import textwrap
+import typing
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+from pants.backend.go.distribution import GoLangDistribution
+from pants.backend.go.module import (
+    FindOwningGoModuleRequest,
+    ResolvedGoModule,
+    ResolvedOwningGoModule,
+    ResolveGoModuleRequest,
+)
+from pants.backend.go.target_types import GoImportPath, GoModuleSources
+from pants.build_graph.address import Address
+from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
+from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.engine.addresses import Addresses
+from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests, RemovePrefix, Snapshot
+from pants.engine.internals.selectors import Get
+from pants.engine.platform import Platform
+from pants.engine.process import BashBinary, Process, ProcessResult
+from pants.engine.rules import collect_rules, rule
+from pants.engine.target import UnexpandedTargets
+from pants.util.logging import LogLevel
+
+
+@dataclass(frozen=True)
+class ResolvedGoPackage:
+    address: Address
+    import_path: str
+    module_address: Optional[Address]
+    package_name: str
+    imported_import_paths: Tuple[str]
+    dependency_import_paths: Tuple[str]
+
+
+@dataclass(frozen=True)
+class ResolveGoPackageRequest:
+    address: Address
+
+
+@rule
+async def resolve_go_package(
+    request: ResolveGoPackageRequest,
+    goroot: GoLangDistribution,
+    platform: Platform,
+    bash: BashBinary,
+) -> ResolvedGoPackage:
+    # TODO: Use MultiGet where applicable.
+
+    downloaded_goroot = await Get(
+        DownloadedExternalTool,
+        ExternalToolRequest,
+        goroot.get_request(platform),
+    )
+
+    targets = await Get(UnexpandedTargets, Addresses([request.address]))
+    if not targets:
+        raise AssertionError(f"Address `{request.address}` did not resolve to any targets.")
+    elif len(targets) > 1:
+        raise AssertionError(f"Address `{request.address}` resolved to multiple targets.")
+    target = targets[0]
+
+    owning_go_module_result = await Get(
+        ResolvedOwningGoModule, FindOwningGoModuleRequest(request.address)
+    )
+
+    # Compute the import_path for this go_package.
+    import_path_field = target.get(GoImportPath)
+    if import_path_field and import_path_field.value:
+        # Use any explicit import path set on the `go_package` target.
+        import_path = import_path_field.value
+    elif owning_go_module_result.module_address:
+        # Otherwise infer the import path from the owning `go_module` target. The inferred import path will be the
+        # module's import path plus any subdirectories in the spec_path between the go_module and go_package target.
+        resolved_go_module = await Get(
+            ResolvedGoModule, ResolveGoModuleRequest(owning_go_module_result.module_address)
+        )
+        if not resolved_go_module.import_path:
+            raise ValueError(
+                f"Unable to infer import path for the `go_package` at address {request.address} "
+                f"because the owning go_module at address {resolved_go_module.address} "
+                "does not have an import path defined."
+            )
+        assert request.address.spec_path.startswith(resolved_go_module.address.spec_path)
+        spec_path_difference = request.address.spec_path[
+            len(resolved_go_module.address.spec_path) :
+        ]
+        import_path = f"{resolved_go_module.import_path}{spec_path_difference}"
+    else:
+        raise ValueError(
+            f"Unable to infer import path for the `go_package` at address {request.address} "
+            "because no owning go_module was found (which would define an import path for the module) "
+            "and no explicit `import_path` was set on the go_package"
+        )
+
+    sources = await Get(SourceFiles, SourceFilesRequest([target.get(GoModuleSources)]))
+    flattened_sources_snapshot = await Get(
+        Snapshot, RemovePrefix(sources.snapshot.digest, request.address.spec_path)
+    )
+
+    # Note: The `go` tool requires GOPATH to be an absolute path which can only be resolved from within the
+    # execution sandbox. Thus, this code uses a bash script to be able to resolve that path.
+    # TODO: Merge all duplicate versions of this script into a single script and invoke rule.
+    analyze_script_digest = await Get(
+        Digest,
+        CreateDigest(
+            [
+                FileContent(
+                    "analyze.sh",
+                    textwrap.dedent(
+                        """\
+                export GOROOT="./go"
+                export GOPATH="$(/bin/pwd)/gopath"
+                export GOCACHE="$(/bin/pwd)/cache"
+                mkdir -p "$GOPATH" "$GOCACHE"
+                exec ./go/bin/go list -json .
+                """
+                    ).encode("utf-8"),
+                )
+            ]
+        ),
+    )
+
+    input_root_digest = await Get(
+        Digest,
+        MergeDigests(
+            [flattened_sources_snapshot.digest, downloaded_goroot.digest, analyze_script_digest]
+        ),
+    )
+
+    process = Process(
+        argv=[bash.path, "./analyze.sh"],
+        input_digest=input_root_digest,
+        description="Resolve go_package metadata.",
+        output_files=["go.mod", "go.sum"],
+        level=LogLevel.DEBUG,
+    )
+
+    result = await Get(ProcessResult, Process, process)
+    print(f"stdout={result.stdout}")  # type: ignore[str-bytes-safe]
+    print(f"stderr={result.stderr}")  # type: ignore[str-bytes-safe]
+
+    metadata = json.loads(result.stdout)
+    package_name: str = metadata["Name"]
+    imported_import_paths = typing.cast(Tuple[str], tuple(metadata["Imports"]))
+    dependency_import_paths = typing.cast(Tuple[str], tuple(metadata["Deps"]))
+
+    return ResolvedGoPackage(
+        address=request.address,
+        import_path=import_path,
+        module_address=owning_go_module_result.module_address,
+        package_name=package_name,
+        imported_import_paths=imported_import_paths,
+        dependency_import_paths=dependency_import_paths,
+    )
+
+
+def rules():
+    return collect_rules()

--- a/src/python/pants/backend/go/pkg_integration_test.py
+++ b/src/python/pants/backend/go/pkg_integration_test.py
@@ -1,0 +1,67 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import textwrap
+
+import pytest
+
+from pants.backend.go import module, pkg
+from pants.backend.go.pkg import ResolvedGoPackage, ResolveGoPackageRequest
+from pants.backend.go.target_types import GoExternalModule, GoModule, GoPackage
+from pants.build_graph.address import Address
+from pants.core.util_rules import external_tool, source_files
+from pants.engine.rules import QueryRule
+from pants.testutil.rule_runner import RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = RuleRunner(
+        rules=[
+            *external_tool.rules(),
+            *source_files.rules(),
+            *module.rules(),
+            *pkg.rules(),
+            QueryRule(ResolvedGoPackage, [ResolveGoPackageRequest]),
+        ],
+        target_types=[GoPackage, GoModule, GoExternalModule],
+    )
+    rule_runner.set_options(["--backend-packages=pants.backend.experimental.go"])
+    return rule_runner
+
+
+def test_resolve_go_module(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "foo/BUILD": "go_module()\n",
+            "foo/go.mod": textwrap.dedent(
+                """\
+                module go.example.com/foo
+                go 1.16"""
+            ),
+            "foo/go.sum": "",
+            "foo/pkg/BUILD": "go_package()\n",
+            "foo/pkg/foo.go": textwrap.dedent(
+                """\
+                package pkg
+                func Grok() string {
+                    return "Hello World"
+                }"""
+            ),
+            "foo/cmd/BUILD": "go_package()\n",
+            "foo/cmd/main.go": textwrap.dedent(
+                """\
+                package main
+                import (
+                    "fmt"
+                    "go.example.com/foo/pkg"
+                )
+                func main() {
+                    fmt.Printf("%s\n", pkg.Grok())
+                }"""
+            ),
+        }
+    )
+    resolved_go_package = rule_runner.request(
+        ResolvedGoPackage, [ResolveGoPackageRequest(Address("foo/cmd"))]
+    )
+    assert resolved_go_package.import_path == "go.example.com/foo/cmd"

--- a/src/python/pants/backend/go/tailor.py
+++ b/src/python/pants/backend/go/tailor.py
@@ -120,7 +120,7 @@ async def find_putative_go_external_module_targets(
             putative_targets.append(
                 PutativeTarget.for_target_type(
                     GoExternalModule,
-                    resolved_go_module.address.spec_path,
+                    resolved_go_module.target.address.spec_path,
                     compute_go_external_module_target_name(
                         module_descriptor.module_path, module_descriptor.module_version
                     ),

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -1,10 +1,10 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-from pants.backend.go.target_types import GoModuleSources, GoPackageDependencies
-from pants.base.specs import AddressSpecs, AscendantAddresses, SiblingAddresses
+from pants.backend.go.module import FindOwningGoModuleRequest, ResolvedOwningGoModule
+from pants.backend.go.target_types import GoPackageDependencies
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
-from pants.engine.target import InjectDependenciesRequest, InjectedDependencies, UnexpandedTargets
+from pants.engine.target import InjectDependenciesRequest, InjectedDependencies
 from pants.engine.unions import UnionRule
 
 
@@ -14,29 +14,12 @@ class InjectGoModuleDependency(InjectDependenciesRequest):
 
 @rule
 async def inject_go_module_dependency(request: InjectGoModuleDependency) -> InjectedDependencies:
-    # Obtain unexpanded targets and ensure file targets are filtered out. Unlike Python, file targets do not
-    # make sense semantically for Go source since Go builds entire packages at a time. The filtering is
-    # accomplished by requesting `UnexpandedTargets` and also filtering on `is_file_target`.
-    spec_path = request.dependencies_field.address.spec_path
-    candidate_targets = await Get(
-        UnexpandedTargets,
-        AddressSpecs([AscendantAddresses(spec_path), SiblingAddresses(spec_path)]),
+    owning_go_module_result = await Get(
+        ResolvedOwningGoModule, FindOwningGoModuleRequest(request.dependencies_field.address)
     )
-    go_module_targets = [
-        tgt
-        for tgt in candidate_targets
-        if tgt.has_field(GoModuleSources) and not tgt.address.is_file_target
-    ]
-
-    # Sort by address.spec_path in descending order so the nearest go_module target is sorted first.
-    sorted_go_module_targets = sorted(
-        go_module_targets, key=lambda tgt: tgt.address.spec_path, reverse=True
-    )
-    if sorted_go_module_targets:
-        nearest_go_module_target = sorted_go_module_targets[0]
-        return InjectedDependencies([nearest_go_module_target.address])
+    if owning_go_module_result.module_address:
+        return InjectedDependencies([owning_go_module_result.module_address])
     else:
-        # TODO: Consider eventually requiring all go_package's to associate with a go_module.
         return InjectedDependencies()
 
 

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -1,6 +1,6 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-from pants.backend.go.module import FindOwningGoModuleRequest, ResolvedOwningGoModule
+from pants.backend.go.module import FindNearestGoModuleRequest, ResolvedOwningGoModule
 from pants.backend.go.target_types import GoPackageDependencies
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
@@ -15,7 +15,8 @@ class InjectGoModuleDependency(InjectDependenciesRequest):
 @rule
 async def inject_go_module_dependency(request: InjectGoModuleDependency) -> InjectedDependencies:
     owning_go_module_result = await Get(
-        ResolvedOwningGoModule, FindOwningGoModuleRequest(request.dependencies_field.address)
+        ResolvedOwningGoModule,
+        FindNearestGoModuleRequest(request.dependencies_field.address.spec_path),
     )
     if owning_go_module_result.module_address:
         return InjectedDependencies([owning_go_module_result.module_address])

--- a/src/python/pants/backend/go/target_type_rules_test.py
+++ b/src/python/pants/backend/go/target_type_rules_test.py
@@ -2,9 +2,10 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 import pytest
 
-from pants.backend.go import target_type_rules
+from pants.backend.go import module, target_type_rules
 from pants.backend.go.target_types import GoModule, GoModuleSources, GoPackage
 from pants.build_graph.address import Address
+from pants.core.util_rules import external_tool, source_files
 from pants.engine.addresses import Addresses
 from pants.engine.rules import QueryRule
 from pants.engine.target import Dependencies, DependenciesRequest, Target, UnexpandedTargets
@@ -15,6 +16,9 @@ from pants.testutil.rule_runner import RuleRunner
 def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
+            *external_tool.rules(),
+            *source_files.rules(),
+            *module.rules(),
             *target_type_rules.rules(),
             QueryRule(Addresses, (DependenciesRequest,)),
             QueryRule(UnexpandedTargets, (Addresses,)),

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -19,7 +19,7 @@ class GoSources(Sources):
 
 
 class GoPackageSources(GoSources):
-    default = ("*.go", "!*_test.go")
+    default = ("*.go",)
 
 
 class GoImportPath(StringField):


### PR DESCRIPTION
Analyze package metadata and report it via `ResolvedGoPackage` type. This provides the data that will be used for dependency inference and builds of packages.

Also refactors the code that finds the owning `go_module` into its own rules via `FindNearestGoModuleRequest`.