### PR TITLE
[Internal] Teach PyO3 how to parse several of our FS types 

### DIFF
--- a/src/python/pants/engine/internals/native_engine_pyo3.pyi
+++ b/src/python/pants/engine/internals/native_engine_pyo3.pyi
@@ -5,7 +5,14 @@ from __future__ import annotations
 
 from typing import Any, Sequence
 
-from pants.engine.fs import PathGlobs
+from pants.engine.fs import (
+    AddPrefix,
+    CreateDigest,
+    DigestSubset,
+    MergeDigests,
+    PathGlobs,
+    RemovePrefix,
+)
 
 # TODO: black and flake8 disagree about the content of this file:
 #   see https://github.com/psf/black/issues/1548
@@ -22,7 +29,15 @@ class PyExecutor:
 # FS
 # ------------------------------------------------------------------------------
 
-def check_fs_python_types_load(*, path_globs: PathGlobs) -> None: ...
+def check_fs_python_types_load(
+    *,
+    path_globs: PathGlobs,
+    create_digest: CreateDigest,
+    merge_digests: MergeDigests,
+    digest_subset: DigestSubset,
+    add_prefix: AddPrefix,
+    remove_prefix: RemovePrefix,
+) -> None: ...
 def default_cache_path() -> str: ...
 
 # TODO: Really, `paths` should be `Sequence[str]`. Fix and update call sites so that we don't

--- a/src/python/pants/engine/internals/native_engine_pyo3.pyi
+++ b/src/python/pants/engine/internals/native_engine_pyo3.pyi
@@ -22,6 +22,7 @@ class PyExecutor:
 # FS
 # ------------------------------------------------------------------------------
 
+def check_fs_python_types_load(*, path_globs: PathGlobs) -> None: ...
 def default_cache_path() -> str: ...
 
 # TODO: Really, `paths` should be `Sequence[str]`. Fix and update call sites so that we don't

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -713,6 +713,7 @@ dependencies = [
 name = "engine_pyo3"
 version = "0.0.1"
 dependencies = [
+ "bytes 1.0.1",
  "fs",
  "hashing",
  "mock",

--- a/src/rust/engine/engine_pyo3/Cargo.toml
+++ b/src/rust/engine/engine_pyo3/Cargo.toml
@@ -18,6 +18,7 @@ extension-module = ["pyo3/extension-module"]
 default = []
 
 [dependencies]
+bytes = "1.0"
 fs = { path = "../fs" }
 hashing = { path = "../hashing" }
 nailgun = { path = "../nailgun" }

--- a/src/rust/engine/engine_pyo3/src/externs/interface/fs.rs
+++ b/src/rust/engine/engine_pyo3/src/externs/interface/fs.rs
@@ -240,11 +240,10 @@ impl<'source> FromPyObject<'source> for PyCreateDigest {
       let path: PathBuf = file_or_dir.getattr("path")?.extract()?;
       if file_or_dir.hasattr("content")? {
         let raw_content: Vec<u8> = file_or_dir.getattr("content")?.extract()?;
-        let content = Bytes::from(raw_content);
         let is_executable: bool = file_or_dir.getattr("is_executable")?.extract()?;
         files.push(FileContent {
           path,
-          content,
+          content: Bytes::from(raw_content),
           is_executable,
         });
       } else {

--- a/src/rust/engine/engine_pyo3/src/externs/interface/fs.rs
+++ b/src/rust/engine/engine_pyo3/src/externs/interface/fs.rs
@@ -15,12 +15,17 @@ use hashing::{Digest, Fingerprint};
 use store::Snapshot;
 
 pub(crate) fn register(m: &PyModule) -> PyResult<()> {
+  m.add_function(wrap_pyfunction!(check_fs_python_types_load, m)?)?;
   m.add_function(wrap_pyfunction!(match_path_globs, m)?)?;
   m.add_function(wrap_pyfunction!(default_cache_path, m)?)?;
   m.add_class::<PyDigest>()?;
   m.add_class::<PySnapshot>()?;
   Ok(())
 }
+
+#[pyfunction]
+#[allow(unused_variables)]
+fn check_fs_python_types_load(path_globs: PyPathGlobs) {}
 
 // -----------------------------------------------------------------------------
 // PathGlobs


### PR DESCRIPTION
With rust-cpython, our parsing code is often mixed in with our logic in `nodes.rs` and `intrinsics.rs`, such as:

https://github.com/pantsbuild/pants/blob/986e8c9c5d9ac4e776b18c4ddc3fb63ac53e5368/src/rust/engine/src/intrinsics.rs#L338-L373

Instead, with PyO3, we can implement the `FromPyObject` trait so that our parsing is encapsulated. Then, callers can either directly put the type like `PyAddPrefix` in the args of a `#[pyfunction]`, or they can call `.extract()` on a `PyAny` to convert the type.

--

These type conversions are not yet used in production, as that's blocked by migrating more of the codebase like `Scheduler`. But this makes some progress on the migration to reduce risk. 

To check for correctness, we add to Rust a `check_fs_python_types_load` function that simply takes these types as arguments, triggering the parsing code. Even after the PyO3 migration is finished, this test will be useful as a unit test of our parsing.

### Next steps in migration

There are a couple small steps to make forward progress, even though none of these actually yet switch production uses.

- Implement `FileDigest`, where we can't use "structural typing" (duck typing) and need to use "nominal typing". Specifically, check that the type is `FileDigest` and not `Digest`, given that they share the same fields but must not be mixed up.
- Implement `ToPyObject` for some types like `Paths` and `DigestContents`, which are defined in Python but meant to be instantiated from Rust.
- Refactor `nodes.rs` et al to move some of the business logic into crates like `fs/`. For example, we have a lot of logic for how to download a file in `nodes.rs`. Making the `engine/` crate (rust-cpython) smaller, it'll be easier to port to PyO3.

After that, we may want to start having the PyO3 and Rust-CPython crates use the definitions from each other, as proposed in https://github.com/pantsbuild/pants/pull/12422#pullrequestreview-715339959.