### PR TITLE
remove older versions of itertools crate

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -676,7 +676,7 @@ dependencies = [
  "graph",
  "hashing",
  "indexmap",
- "itertools 0.8.2",
+ "itertools 0.10.1",
  "lazy_static",
  "libc",
  "log 0.4.11",
@@ -1396,24 +1396,6 @@ name = "ipnet"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
-
-[[package]]
-name = "itertools"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -2221,7 +2203,7 @@ dependencies = [
  "futures",
  "grpc_util",
  "hashing",
- "itertools 0.8.2",
+ "itertools 0.10.1",
  "lazy_static",
  "libc",
  "log 0.4.11",
@@ -3078,7 +3060,7 @@ dependencies = [
  "http",
  "http-body",
  "indexmap",
- "itertools 0.7.11",
+ "itertools 0.10.1",
  "lmdb",
  "log 0.4.11",
  "madvise",

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -116,7 +116,7 @@ futures-core = "^0.3.0"
 graph = { path = "graph" }
 hashing = { path = "hashing" }
 indexmap = "1.4"
-itertools = "0.8.2"
+itertools = "0.10"
 lazy_static = "1"
 libc = "0.2.39"
 log = "0.4"

--- a/src/rust/engine/fs/store/Cargo.toml
+++ b/src/rust/engine/fs/store/Cargo.toml
@@ -18,7 +18,7 @@ hashing = { path = "../../hashing" }
 http = "0.2"
 http-body = "0.4"
 indexmap = "1.4"
-itertools = "0.7.2"
+itertools = "0.10"
 lmdb = { git = "https://github.com/pantsbuild/lmdb-rs.git", rev = "06bdfbfc6348f6804127176e561843f214fc17f8" }
 log = "0.4"
 madvise = "0.1"

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -35,7 +35,7 @@ workunit_store = { path = "../workunit_store" }
 regex = "1"
 lazy_static = "1"
 parking_lot = "0.11"
-itertools = "0.8.0"
+itertools = "0.10"
 serde = "1.0.104"
 bincode = "1.2.1"
 double-checked-cell-async = "2.0"


### PR DESCRIPTION
Remove some of the older versions of the `itertools` crate by bumping the version to the latest version. v0.9.x is still present as a transitive dependency but all of the Pants first-party crates use itertools 0.10.x now.

[ci skip-build-wheels]