### PR TITLE
Clarify when we are subsetting the lockfile for 3rdparty dependencies (Cherry-pick of #12435)

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -359,24 +359,13 @@ async def build_pex(
     if request.pex_path:
         argv.extend(["--pex-path", ":".join(pex.name for pex in request.pex_path)])
 
-    description = request.description
-    if description is None:
-        if request.requirements:
-            description = (
-                f"Building {request.output_filename} with "
-                f"{pluralize(len(request.requirements), 'requirement')}: "
-                f"{', '.join(request.requirements)}"
-            )
-        else:
-            description = f"Building {request.output_filename}"
-
     process = await Get(
         Process,
         PexCliProcess(
             python=python,
             argv=argv,
             additional_input_digest=merged_digest,
-            description=description,
+            description=_build_pex_description(request),
             output_files=[request.output_filename],
         ),
     )
@@ -401,6 +390,23 @@ async def build_pex(
 
     return BuildPexResult(
         result=result, pex_filename=request.output_filename, digest=digest, python=python
+    )
+
+
+def _build_pex_description(request: PexRequest) -> str:
+    if request.description:
+        return request.description
+    if not request.requirements:
+        return f"Building {request.output_filename}"
+    if request.repository_pex:
+        return (
+            f"Extracting {pluralize(len(request.requirements), 'requirement')} "
+            f"to build {request.output_filename} from {request.repository_pex.name}: "
+            f"{', '.join(request.requirements)}"
+        )
+    return (
+        f"Building {request.output_filename} with "
+        f"{pluralize(len(request.requirements), 'requirement')}: {', '.join(request.requirements)}"
     )
 
 

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -27,10 +27,11 @@ from pants.backend.python.util_rules.pex import (
     PexResolveInfo,
     VenvPex,
     VenvPexProcess,
+    _build_pex_description,
 )
 from pants.backend.python.util_rules.pex import rules as pex_rules
 from pants.backend.python.util_rules.pex_cli import PexPEX
-from pants.engine.fs import CreateDigest, Digest, FileContent
+from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, FileContent
 from pants.engine.process import Process, ProcessResult
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -402,3 +403,49 @@ def test_venv_pex_resolve_info(rule_runner: RuleRunner, pex_type: type[Pex | Ven
     assert dists[3].version == Version("2.23.0")
     assert Requirement.parse('PySocks!=1.5.7,>=1.5.6; extra == "socks"') in dists[3].requires_dists
     assert dists[4].project_name == "urllib3"
+
+
+def test_build_pex_description() -> None:
+    def assert_description(
+        requirements: PexRequirements,
+        *,
+        use_repo_pex: bool = False,
+        description: str | None = None,
+        expected: str,
+    ) -> None:
+        repo_pex = Pex(EMPTY_DIGEST, "repo.pex", None) if use_repo_pex else None
+        request = PexRequest(
+            output_filename="new.pex",
+            internal_only=True,
+            requirements=requirements,
+            description=description,
+            repository_pex=repo_pex,
+        )
+        assert _build_pex_description(request) == expected
+
+    assert_description(PexRequirements(), description="Custom!", expected="Custom!")
+    assert_description(
+        PexRequirements(), description="Custom!", use_repo_pex=True, expected="Custom!"
+    )
+
+    assert_description(PexRequirements(), expected="Building new.pex")
+    assert_description(PexRequirements(), use_repo_pex=True, expected="Building new.pex")
+
+    assert_description(
+        PexRequirements(["req"]), expected="Building new.pex with 1 requirement: req"
+    )
+    assert_description(
+        PexRequirements(["req"]),
+        use_repo_pex=True,
+        expected="Extracting 1 requirement to build new.pex from repo.pex: req",
+    )
+
+    assert_description(
+        PexRequirements(["req1", "req2"]),
+        expected="Building new.pex with 2 requirements: req1, req2",
+    )
+    assert_description(
+        PexRequirements(["req1", "req2"]),
+        use_repo_pex=True,
+        expected="Extracting 2 requirements to build new.pex from repo.pex: req1, req2",
+    )


### PR DESCRIPTION
See https://github.com/pantsbuild/pants/pull/12435. 

This isn't a clean cherry-pick: lockfiles are not added to 2.6 yet, so we can simplify some of the code.

[ci skip-rust]
[ci skip-build-wheels]