### PR TITLE
Do not upload Action inputs for remote cache writes.

### DIFF
--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -438,29 +438,20 @@ impl CommandRunner {
   async fn update_action_cache(
     &self,
     context: &Context,
-    request: &Process,
     result: &FallibleProcessResultWithPlatform,
     metadata: &ProcessMetadata,
     command: &Command,
     action_digest: Digest,
     command_digest: Digest,
   ) -> Result<(), String> {
-    // Upload the action (and related data, i.e. the embedded command and input files).
-    // Assumption: The Action and related data has already been stored locally.
-    in_workunit!(
-      context.workunit_store.clone(),
-      "ensure_action_uploaded".to_owned(),
-      WorkunitMetadata {
-        level: Level::Trace,
-        desc: Some(format!("ensure action uploaded for {:?}", action_digest)),
-        ..WorkunitMetadata::default()
-      },
-      |_workunit| crate::remote::ensure_action_uploaded(
-        &self.store,
-        command_digest,
-        action_digest,
-        request.input_files,
-      ),
+    // Upload the Action and Command, but not the input files. See #12432.
+    // Assumption: The Action and Command have already been stored locally.
+    crate::remote::ensure_action_uploaded(
+      context,
+      &self.store,
+      command_digest,
+      action_digest,
+      None,
     )
     .await?;
 
@@ -616,7 +607,6 @@ impl crate::CommandRunner for CommandRunner {
           let write_result = command_runner
             .update_action_cache(
               &context2,
-              &request,
               &result,
               &command_runner.metadata,
               &command,

--- a/tests/python/pants_test/integration/remote_cache_integration_test.py
+++ b/tests/python/pants_test/integration/remote_cache_integration_test.py
@@ -39,7 +39,7 @@ def test_warns_on_remote_cache_errors():
 
     def write_err(i: int) -> str:
         return (
-            f'Failed to write to remote cache ({i} occurrences so far): Internal: "StubCAS is '
+            f'Failed to write to remote cache ({i} occurrences so far): InvalidArgument: "StubCAS is '
             f'configured to always fail"'
         )
 
@@ -63,7 +63,7 @@ def test_warns_on_remote_cache_errors():
 
     first_only_result = run(RemoteCacheWarningsBehavior.first_only)
     for err in [first_read_err, first_write_err]:
-        assert err in first_only_result
+        assert err in first_only_result, f"Not found in:\n{first_only_result}"
     for err in [third_read_err, third_write_err, fourth_read_err, fourth_write_err]:
         assert err not in first_only_result
 


### PR DESCRIPTION
We currently upload the input files during an action cache write, since the spec was slightly unclear about whether only the Action and Command or also their inputs needed to be uploaded. But after asking around, none of the servers appear to require inputs to be uploaded.

Fixes #12432.

[ci skip-build-wheels]