### PR TITLE
Do not upload Action inputs for remote cache writes. (cherrypick of #12443)

### DIFF
--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -741,7 +741,6 @@ impl crate::CommandRunner for CommandRunner {
 
     // Construct the REv2 ExecuteRequest and related data for this execution request.
     let request = self.extract_compatible_request(&request).unwrap();
-    let store = self.store.clone();
     let (action, command, execute_request) = make_execute_request(&request, self.metadata.clone())?;
     let build_id = context.build_id.clone();
 
@@ -782,16 +781,12 @@ impl crate::CommandRunner for CommandRunner {
     }
 
     // Upload the action (and related data, i.e. the embedded command and input files).
-    let input_files = request.input_files;
-    in_workunit!(
-      context.workunit_store.clone(),
-      "ensure_action_uploaded".to_owned(),
-      WorkunitMetadata {
-        level: Level::Trace,
-        desc: Some(format!("ensure action uploaded for {:?}", action_digest)),
-        ..WorkunitMetadata::default()
-      },
-      |_workunit| ensure_action_uploaded(&store, command_digest, action_digest, input_files),
+    ensure_action_uploaded(
+      &context,
+      &self.store,
+      command_digest,
+      action_digest,
+      Some(request.input_files),
     )
     .await?;
 
@@ -1456,16 +1451,33 @@ pub async fn ensure_action_stored_locally(
   Ok((command_digest, action_digest))
 }
 
+///
+/// Ensure that the Action and Command (and optionally their input files, likely depending on
+/// whether we are in a remote execution context, or a pure cache-usage context) are uploaded.
+///
 pub async fn ensure_action_uploaded(
+  context: &Context,
   store: &Store,
   command_digest: Digest,
   action_digest: Digest,
-  input_files: Digest,
+  input_files: Option<Digest>,
 ) -> Result<(), String> {
-  let _ = store
-    .ensure_remote_has_recursive(vec![command_digest, action_digest, input_files])
-    .await?;
-  Ok(())
+  in_workunit!(
+    context.workunit_store.clone(),
+    "ensure_action_uploaded".to_owned(),
+    WorkunitMetadata {
+      level: Level::Trace,
+      desc: Some(format!("ensure action uploaded for {:?}", action_digest)),
+      ..WorkunitMetadata::default()
+    },
+    |_workunit| async move {
+      let mut digests = vec![command_digest, action_digest];
+      digests.extend(input_files);
+      let _ = store.ensure_remote_has_recursive(digests).await?;
+      Ok(())
+    },
+  )
+  .await
 }
 
 pub fn format_error(error: &StatusProto) -> String {

--- a/tests/python/pants_test/integration/remote_cache_integration_test.py
+++ b/tests/python/pants_test/integration/remote_cache_integration_test.py
@@ -39,7 +39,7 @@ def test_warns_on_remote_cache_errors():
 
     def write_err(i: int) -> str:
         return (
-            f'Failed to write to remote cache ({i} occurrences so far): Internal: "StubCAS is '
+            f'Failed to write to remote cache ({i} occurrences so far): InvalidArgument: "StubCAS is '
             f'configured to always fail"'
         )
 
@@ -63,7 +63,7 @@ def test_warns_on_remote_cache_errors():
 
     first_only_result = run(RemoteCacheWarningsBehavior.first_only)
     for err in [first_read_err, first_write_err]:
-        assert err in first_only_result
+        assert err in first_only_result, f"Not found in:\n{first_only_result}"
     for err in [third_read_err, third_write_err, fourth_read_err, fourth_write_err]:
         assert err not in first_only_result
 


### PR DESCRIPTION
We currently upload the input files during an action cache write, since the spec was slightly unclear about whether only the Action and Command or also their inputs needed to be uploaded. But after asking around, none of the servers appear to require inputs to be uploaded.

Fixes #12432.

[ci skip-build-wheels]