### PR TITLE
Lockfile invalidation consumption

### DIFF
--- a/src/python/pants/backend/awslambda/python/lambdex.py
+++ b/src/python/pants/backend/awslambda/python/lambdex.py
@@ -28,7 +28,7 @@ class Lambdex(PythonToolBase):
     default_lockfile_url = git_url(default_lockfile_path)
 
 
-class LambdexLockfileSentinel(PythonToolLockfileSentinel):
+class LambdexLockfileSentinel:
     pass
 
 

--- a/src/python/pants/backend/awslambda/python/rules.py
+++ b/src/python/pants/backend/awslambda/python/rules.py
@@ -93,7 +93,7 @@ async def package_python_awslambda(
     lambdex_request = PexRequest(
         output_filename="lambdex.pex",
         internal_only=True,
-        requirements=lambdex.pex_requirements_with_digest(lockfile_request.hex_digest),
+        requirements=lambdex.pex_requirements(lockfile_request.hex_digest),
         interpreter_constraints=lambdex.interpreter_constraints,
         main=lambdex.main,
     )

--- a/src/python/pants/backend/awslambda/python/rules.py
+++ b/src/python/pants/backend/awslambda/python/rules.py
@@ -93,7 +93,7 @@ async def package_python_awslambda(
     lambdex_request = PexRequest(
         output_filename="lambdex.pex",
         internal_only=True,
-        requirements=lambdex.pex_requirements(lockfile_request.hex_digest),
+        requirements=lambdex.pex_requirements_with_digest(lockfile_request.hex_digest),
         interpreter_constraints=lambdex.interpreter_constraints,
         main=lambdex.main,
     )

--- a/src/python/pants/backend/awslambda/python/rules.py
+++ b/src/python/pants/backend/awslambda/python/rules.py
@@ -37,6 +37,8 @@ from pants.engine.target import (
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.util.docutil import doc_url
 from pants.util.logging import LogLevel
+from pants.backend.awslambda.python.lambdex import LambdexLockfileSentinel
+from pants.backend.experimental.python.lockfile import PythonLockfileRequest
 
 logger = logging.getLogger(__name__)
 
@@ -86,10 +88,13 @@ async def package_python_awslambda(
         ],
     )
 
+    # TODO: don't calculate if not needed
+    lockfile_request = await Get(PythonLockfileRequest, LambdexLockfileSentinel())
+
     lambdex_request = PexRequest(
         output_filename="lambdex.pex",
         internal_only=True,
-        requirements=lambdex.pex_requirements,
+        requirements=lambdex.pex_requirements(lockfile_request.hex_digest),
         interpreter_constraints=lambdex.interpreter_constraints,
         main=lambdex.main,
     )

--- a/src/python/pants/backend/awslambda/python/rules.py
+++ b/src/python/pants/backend/awslambda/python/rules.py
@@ -87,15 +87,15 @@ async def package_python_awslambda(
         ],
     )
 
-    lockfile_digest = None
+    lockfile_hex_digest = None
     if lambdex.lockfile != "<none>":
         lockfile_request = await Get(PythonLockfileRequest, LambdexLockfileSentinel())
-        lockfile_digest = lockfile_request.hex_digest
+        lockfile_hex_digest = lockfile_request.hex_digest
 
     lambdex_request = PexRequest(
         output_filename="lambdex.pex",
         internal_only=True,
-        requirements=lambdex.pex_requirements(lockfile_digest),
+        requirements=lambdex.pex_requirements(lockfile_hex_digest),
         interpreter_constraints=lambdex.interpreter_constraints,
         main=lambdex.main,
     )

--- a/src/python/pants/backend/awslambda/python/rules.py
+++ b/src/python/pants/backend/awslambda/python/rules.py
@@ -4,13 +4,14 @@
 import logging
 from dataclasses import dataclass
 
-from pants.backend.awslambda.python.lambdex import Lambdex
+from pants.backend.awslambda.python.lambdex import Lambdex, LambdexLockfileSentinel
 from pants.backend.awslambda.python.target_types import (
     PythonAwsLambdaHandlerField,
     PythonAwsLambdaRuntime,
     ResolvedPythonAwsHandler,
     ResolvePythonAwsHandlerRequest,
 )
+from pants.backend.experimental.python.lockfile import PythonLockfileRequest
 from pants.backend.python.util_rules import pex_from_targets
 from pants.backend.python.util_rules.pex import (
     Pex,
@@ -37,8 +38,6 @@ from pants.engine.target import (
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.util.docutil import doc_url
 from pants.util.logging import LogLevel
-from pants.backend.awslambda.python.lambdex import LambdexLockfileSentinel
-from pants.backend.experimental.python.lockfile import PythonLockfileRequest
 
 logger = logging.getLogger(__name__)
 

--- a/src/python/pants/backend/awslambda/python/rules.py
+++ b/src/python/pants/backend/awslambda/python/rules.py
@@ -87,13 +87,15 @@ async def package_python_awslambda(
         ],
     )
 
-    # TODO: don't calculate if not needed
-    lockfile_request = await Get(PythonLockfileRequest, LambdexLockfileSentinel())
+    lockfile_digest = None
+    if lambdex.lockfile != "<none>":
+        lockfile_request = await Get(PythonLockfileRequest, LambdexLockfileSentinel())
+        lockfile_digest = lockfile_request.hex_digest
 
     lambdex_request = PexRequest(
         output_filename="lambdex.pex",
         internal_only=True,
-        requirements=lambdex.pex_requirements(lockfile_request.hex_digest),
+        requirements=lambdex.pex_requirements(lockfile_digest),
         interpreter_constraints=lambdex.interpreter_constraints,
         main=lambdex.main,
     )

--- a/src/python/pants/backend/awslambda/python/rules_test.py
+++ b/src/python/pants/backend/awslambda/python/rules_test.py
@@ -8,6 +8,7 @@ from zipfile import ZipFile
 
 import pytest
 
+from pants.backend.awslambda.python.lambdex import rules as awslambda_python_subsystem_rules
 from pants.backend.awslambda.python.rules import PythonAwsLambdaFieldSet
 from pants.backend.awslambda.python.rules import rules as awslambda_python_rules
 from pants.backend.awslambda.python.target_types import PythonAWSLambda
@@ -26,6 +27,7 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *awslambda_python_rules(),
+            *awslambda_python_subsystem_rules(),
             *target_rules(),
             *core_target_types_rules(),
             QueryRule(BuiltPackage, (PythonAwsLambdaFieldSet,)),

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -77,7 +77,7 @@ class PythonProtobufMypyPlugin(PythonToolRequirementsBase):
     default_lockfile_url = git_url(default_lockfile_path)
 
 
-class MypyProtobufLockfileSentinel(PythonToolLockfileSentinel):
+class MypyProtobufLockfileSentinel:
     pass
 
 

--- a/src/python/pants/backend/codegen/protobuf/python/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules.py
@@ -97,7 +97,10 @@ async def generate_python_from_protobuf(
         target_stripped_sources_request,
     )
 
-    lockfile_request = await Get(PythonLockfileRequest, MypyProtobufLockfileSentinel())
+    lockfile_digest = None
+    if python_protobuf_mypy_plugin.lockfile != "<none>":
+        lockfile_request = await Get(PythonLockfileRequest, MypyProtobufLockfileSentinel())
+        lockfile_digest = lockfile_request.hex_digest
 
     protoc_gen_mypy_script = "protoc-gen-mypy"
     protoc_gen_mypy_grpc_script = "protoc-gen-mypy_grpc"
@@ -105,7 +108,7 @@ async def generate_python_from_protobuf(
     mypy_request = PexRequest(
         output_filename="mypy_protobuf.pex",
         internal_only=True,
-        requirements=python_protobuf_mypy_plugin.pex_requirements(lockfile_request.hex_digest),
+        requirements=python_protobuf_mypy_plugin.pex_requirements(lockfile_digest),
         interpreter_constraints=python_protobuf_mypy_plugin.interpreter_constraints,
     )
 

--- a/src/python/pants/backend/codegen/protobuf/python/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules.py
@@ -105,7 +105,7 @@ async def generate_python_from_protobuf(
     mypy_request = PexRequest(
         output_filename="mypy_protobuf.pex",
         internal_only=True,
-        requirements=python_protobuf_mypy_plugin.pex_requirements_with_digest(
+        requirements=python_protobuf_mypy_plugin.pex_requirements(
             lockfile_request.hex_digest
         ),
         interpreter_constraints=python_protobuf_mypy_plugin.interpreter_constraints,

--- a/src/python/pants/backend/codegen/protobuf/python/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules.py
@@ -105,9 +105,7 @@ async def generate_python_from_protobuf(
     mypy_request = PexRequest(
         output_filename="mypy_protobuf.pex",
         internal_only=True,
-        requirements=python_protobuf_mypy_plugin.pex_requirements(
-            lockfile_request.hex_digest
-        ),
+        requirements=python_protobuf_mypy_plugin.pex_requirements(lockfile_request.hex_digest),
         interpreter_constraints=python_protobuf_mypy_plugin.interpreter_constraints,
     )
 

--- a/src/python/pants/backend/codegen/protobuf/python/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules.py
@@ -97,10 +97,10 @@ async def generate_python_from_protobuf(
         target_stripped_sources_request,
     )
 
-    lockfile_digest = None
+    lockfile_hex_digest = None
     if python_protobuf_mypy_plugin.lockfile != "<none>":
         lockfile_request = await Get(PythonLockfileRequest, MypyProtobufLockfileSentinel())
-        lockfile_digest = lockfile_request.hex_digest
+        lockfile_hex_digest = lockfile_request.hex_digest
 
     protoc_gen_mypy_script = "protoc-gen-mypy"
     protoc_gen_mypy_grpc_script = "protoc-gen-mypy_grpc"
@@ -108,7 +108,7 @@ async def generate_python_from_protobuf(
     mypy_request = PexRequest(
         output_filename="mypy_protobuf.pex",
         internal_only=True,
-        requirements=python_protobuf_mypy_plugin.pex_requirements(lockfile_digest),
+        requirements=python_protobuf_mypy_plugin.pex_requirements(lockfile_hex_digest),
         interpreter_constraints=python_protobuf_mypy_plugin.interpreter_constraints,
     )
 

--- a/src/python/pants/backend/codegen/protobuf/python/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules.py
@@ -7,10 +7,12 @@ from pants.backend.codegen.protobuf.protoc import Protoc
 from pants.backend.codegen.protobuf.python.additional_fields import PythonSourceRootField
 from pants.backend.codegen.protobuf.python.grpc_python_plugin import GrpcPythonPlugin
 from pants.backend.codegen.protobuf.python.python_protobuf_subsystem import (
+    MypyProtobufLockfileSentinel,
     PythonProtobufMypyPlugin,
     PythonProtobufSubsystem,
 )
 from pants.backend.codegen.protobuf.target_types import ProtobufGrpcToggle, ProtobufSources
+from pants.backend.experimental.python.lockfile import PythonLockfileRequest
 from pants.backend.python.target_types import PythonSources
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, PexResolveInfo, VenvPex, VenvPexRequest
@@ -40,8 +42,6 @@ from pants.engine.target import (
 from pants.engine.unions import UnionRule
 from pants.source.source_root import SourceRoot, SourceRootRequest
 from pants.util.logging import LogLevel
-from pants.backend.codegen.protobuf.python.python_protobuf_subsystem import MypyProtobufLockfileSentinel
-from pants.backend.experimental.python.lockfile import PythonLockfileRequest
 
 
 class GeneratePythonFromProtobufRequest(GenerateSourcesRequest):
@@ -105,7 +105,9 @@ async def generate_python_from_protobuf(
     mypy_request = PexRequest(
         output_filename="mypy_protobuf.pex",
         internal_only=True,
-        requirements=python_protobuf_mypy_plugin.pex_requirements_with_digest(lockfile_request.hex_digest),
+        requirements=python_protobuf_mypy_plugin.pex_requirements_with_digest(
+            lockfile_request.hex_digest
+        ),
         interpreter_constraints=python_protobuf_mypy_plugin.interpreter_constraints,
     )
 

--- a/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
@@ -7,6 +7,9 @@ from typing import List, Optional
 import pytest
 
 from pants.backend.codegen.protobuf.python import additional_fields
+from pants.backend.codegen.protobuf.python.python_protobuf_subsystem import (
+    rules as protobuf_subsystem_rules,
+)
 from pants.backend.codegen.protobuf.python.rules import GeneratePythonFromProtobufRequest
 from pants.backend.codegen.protobuf.python.rules import rules as protobuf_rules
 from pants.backend.codegen.protobuf.target_types import ProtobufLibrary, ProtobufSources
@@ -45,6 +48,7 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *protobuf_rules(),
+            *protobuf_subsystem_rules(),
             *additional_fields.rules(),
             *stripped_source_files.rules(),
             QueryRule(HydratedSources, [HydrateSourcesRequest]),

--- a/src/python/pants/backend/experimental/python/lockfile.py
+++ b/src/python/pants/backend/experimental/python/lockfile.py
@@ -35,6 +35,7 @@ from pants.python.python_setup import PythonSetup
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.strutil import pluralize
+from pants.backend.experimental.python.lockfile_metadata import validated_lockfile_content
 
 logger = logging.getLogger(__name__)
 

--- a/src/python/pants/backend/experimental/python/lockfile.py
+++ b/src/python/pants/backend/experimental/python/lockfile.py
@@ -113,7 +113,7 @@ async def generate_lockfile(
         PexRequest(
             output_filename="pip_compile.pex",
             internal_only=True,
-            requirements=pip_tools_subsystem.pex_requirements,
+            requirements=pip_tools_subsystem.pex_requirements(),
             interpreter_constraints=req.interpreter_constraints,
             main=pip_tools_subsystem.main,
             description=(

--- a/src/python/pants/backend/experimental/python/lockfile.py
+++ b/src/python/pants/backend/experimental/python/lockfile.py
@@ -35,7 +35,6 @@ from pants.python.python_setup import PythonSetup
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.strutil import pluralize
-from pants.backend.experimental.python.lockfile_metadata import validated_lockfile_content
 
 logger = logging.getLogger(__name__)
 

--- a/src/python/pants/backend/experimental/python/lockfile_metadata.py
+++ b/src/python/pants/backend/experimental/python/lockfile_metadata.py
@@ -84,7 +84,4 @@ def read_lockfile_metadata(contents: bytes) -> LockfileMetadata:
             key, value = (i.strip().decode("ascii") for i in line[1:].split(b":"))
             metadata[key] = value
 
-    return LockfileMetadata(
-        invalidation_digest=metadata.get("invalidation digest")
-    )
-
+    return LockfileMetadata(invalidation_digest=metadata.get("invalidation digest"))

--- a/src/python/pants/backend/experimental/python/lockfile_metadata.py
+++ b/src/python/pants/backend/experimental/python/lockfile_metadata.py
@@ -84,4 +84,7 @@ def read_lockfile_metadata(contents: bytes) -> LockfileMetadata:
             key, value = (i.strip().decode("ascii") for i in line[1:].split(b":"))
             metadata[key] = value
 
-    return LockfileMetadata(invalidation_digest=metadata.get("invalidation digest"))
+    return LockfileMetadata(
+        invalidation_digest=metadata.get("invalidation digest")
+    )
+

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -219,7 +219,7 @@ class CoverageSubsystem(PythonToolBase):
         return cast(bool, self.options.global_report)
 
 
-class CoveragePyLockfileSentinel(PythonToolLockfileSentinel):
+class CoveragePyLockfileSentinel:
     pass
 
 
@@ -334,12 +334,16 @@ class CoverageSetup:
 
 @rule
 async def setup_coverage(coverage: CoverageSubsystem) -> CoverageSetup:
+
+    # TODO: don't calculate if not needed
+    lockfile_request = await Get(PythonLockfileRequest, CoveragePyLockfileSentinel())
+
     pex = await Get(
         VenvPex,
         PexRequest(
             output_filename="coverage.pex",
             internal_only=True,
-            requirements=coverage.pex_requirements,
+            requirements=coverage.pex_requirements_with_digest(lockfile_request.hex_digest),
             interpreter_constraints=coverage.interpreter_constraints,
             main=coverage.main,
         ),

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -334,16 +334,17 @@ class CoverageSetup:
 
 @rule
 async def setup_coverage(coverage: CoverageSubsystem) -> CoverageSetup:
-
-    # TODO: don't calculate if not needed
-    lockfile_request = await Get(PythonLockfileRequest, CoveragePyLockfileSentinel())
+    lockfile_digest = None
+    if coverage.lockfile != "<none>":
+        lockfile_request = await Get(PythonLockfileRequest, CoveragePyLockfileSentinel())
+        lockfile_digest = lockfile_request.hex_digest
 
     pex = await Get(
         VenvPex,
         PexRequest(
             output_filename="coverage.pex",
             internal_only=True,
-            requirements=coverage.pex_requirements(lockfile_request.hex_digest),
+            requirements=coverage.pex_requirements(lockfile_digest),
             interpreter_constraints=coverage.interpreter_constraints,
             main=coverage.main,
         ),

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -334,17 +334,17 @@ class CoverageSetup:
 
 @rule
 async def setup_coverage(coverage: CoverageSubsystem) -> CoverageSetup:
-    lockfile_digest = None
+    lockfile_hex_digest = None
     if coverage.lockfile != "<none>":
         lockfile_request = await Get(PythonLockfileRequest, CoveragePyLockfileSentinel())
-        lockfile_digest = lockfile_request.hex_digest
+        lockfile_hex_digest = lockfile_request.hex_digest
 
     pex = await Get(
         VenvPex,
         PexRequest(
             output_filename="coverage.pex",
             internal_only=True,
-            requirements=coverage.pex_requirements(lockfile_digest),
+            requirements=coverage.pex_requirements(lockfile_hex_digest),
             interpreter_constraints=coverage.interpreter_constraints,
             main=coverage.main,
         ),

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -343,7 +343,7 @@ async def setup_coverage(coverage: CoverageSubsystem) -> CoverageSetup:
         PexRequest(
             output_filename="coverage.pex",
             internal_only=True,
-            requirements=coverage.pex_requirements_with_digest(lockfile_request.hex_digest),
+            requirements=coverage.pex_requirements(lockfile_request.hex_digest),
             interpreter_constraints=coverage.interpreter_constraints,
             main=coverage.main,
         ),

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -206,7 +206,7 @@ async def setup_pytest_for_target(
         Pex,
         PexRequest(
             output_filename="pytest.pex",
-            requirements=pytest.pex_requirements,
+            requirements=pytest.pex_requirements(),
             interpreter_constraints=interpreter_constraints,
             internal_only=True,
         ),

--- a/src/python/pants/backend/python/goals/repl.py
+++ b/src/python/pants/backend/python/goals/repl.py
@@ -80,7 +80,7 @@ async def create_ipython_repl_request(
         PexRequest(
             output_filename="ipython.pex",
             main=ipython.main,
-            requirements=ipython.pex_requirements,
+            requirements=ipython.pex_requirements(),
             interpreter_constraints=requirements_pex_request.interpreter_constraints,
             internal_only=True,
         ),

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -420,17 +420,17 @@ async def run_setup_py(req: RunSetupPyRequest, setuptools: Setuptools) -> RunSet
     # Note that this pex has no entrypoint. We use it to run our generated setup.py, which
     # in turn imports from and invokes setuptools.
 
-    lockfile_digest = None
+    lockfile_hex_digest = None
     if setuptools.lockfile != "<none>":
         lockfile_request = await Get(PythonLockfileRequest, SetuptoolsLockfileSentinel())
-        lockfile_digest = lockfile_request.hex_digest
+        lockfile_hex_digest = lockfile_request.hex_digest
 
     setuptools_pex = await Get(
         VenvPex,
         PexRequest(
             output_filename="setuptools.pex",
             internal_only=True,
-            requirements=setuptools.pex_requirements(lockfile_digest),
+            requirements=setuptools.pex_requirements(lockfile_hex_digest),
             interpreter_constraints=req.interpreter_constraints,
         ),
     )

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -424,7 +424,7 @@ async def run_setup_py(req: RunSetupPyRequest, setuptools: Setuptools) -> RunSet
         PexRequest(
             output_filename="setuptools.pex",
             internal_only=True,
-            requirements=setuptools.pex_requirements_with_digest(lockfile_request.hex_digest),
+            requirements=setuptools.pex_requirements(lockfile_request.hex_digest),
             interpreter_constraints=req.interpreter_constraints,
         ),
     )

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -416,15 +416,17 @@ async def run_setup_py(req: RunSetupPyRequest, setuptools: Setuptools) -> RunSet
     # Note that this pex has no entrypoint. We use it to run our generated setup.py, which
     # in turn imports from and invokes setuptools.
 
-    # TODO: don't calculate if not needed
-    lockfile_request = await Get(PythonLockfileRequest, SetuptoolsLockfileSentinel())
+    lockfile_digest = None
+    if setuptools.lockfile != "<none>":
+        lockfile_request = await Get(PythonLockfileRequest, SetuptoolsLockfileSentinel())
+        lockfile_digest = lockfile_request.hex_digest
 
     setuptools_pex = await Get(
         VenvPex,
         PexRequest(
             output_filename="setuptools.pex",
             internal_only=True,
-            requirements=setuptools.pex_requirements(lockfile_request.hex_digest),
+            requirements=setuptools.pex_requirements(lockfile_digest),
             interpreter_constraints=req.interpreter_constraints,
         ),
     )

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -13,8 +13,9 @@ from dataclasses import dataclass
 from functools import partial
 from typing import Any, DefaultDict, Dict, List, Mapping, Set, Tuple, cast
 
+from pants.backend.experimental.python.lockfile import PythonLockfileRequest
 from pants.backend.python.macros.python_artifact import PythonArtifact
-from pants.backend.python.subsystems.setuptools import PythonDistributionFieldSet, Setuptools
+from pants.backend.python.subsystems.setuptools import PythonDistributionFieldSet, Setuptools, SetuptoolsLockfileSentinel
 from pants.backend.python.target_types import (
     PythonDistributionEntryPointsField,
     PythonProvidesField,
@@ -414,12 +415,16 @@ async def run_setup_py(req: RunSetupPyRequest, setuptools: Setuptools) -> RunSet
     """Run a setup.py command on a single exported target."""
     # Note that this pex has no entrypoint. We use it to run our generated setup.py, which
     # in turn imports from and invokes setuptools.
+
+    # TODO: don't calculate if not needed
+    lockfile_request = await Get(PythonLockfileRequest, SetuptoolsLockfileSentinel())
+
     setuptools_pex = await Get(
         VenvPex,
         PexRequest(
             output_filename="setuptools.pex",
             internal_only=True,
-            requirements=setuptools.pex_requirements,
+            requirements=setuptools.pex_requirements_with_digest(lockfile_request.hex_digest),
             interpreter_constraints=req.interpreter_constraints,
         ),
     )

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -15,7 +15,11 @@ from typing import Any, DefaultDict, Dict, List, Mapping, Set, Tuple, cast
 
 from pants.backend.experimental.python.lockfile import PythonLockfileRequest
 from pants.backend.python.macros.python_artifact import PythonArtifact
-from pants.backend.python.subsystems.setuptools import PythonDistributionFieldSet, Setuptools, SetuptoolsLockfileSentinel
+from pants.backend.python.subsystems.setuptools import (
+    PythonDistributionFieldSet,
+    Setuptools,
+    SetuptoolsLockfileSentinel,
+)
 from pants.backend.python.target_types import (
     PythonDistributionEntryPointsField,
     PythonProvidesField,

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -5,7 +5,11 @@ from dataclasses import dataclass
 from typing import Tuple
 
 from pants.backend.experimental.python.lockfile import PythonLockfileRequest
-from pants.backend.python.lint.bandit.subsystem import Bandit, BanditFieldSet, BanditLockfileSentinel
+from pants.backend.python.lint.bandit.subsystem import (
+    Bandit,
+    BanditFieldSet,
+    BanditLockfileSentinel,
+)
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -46,17 +46,17 @@ def generate_argv(source_files: SourceFiles, bandit: Bandit) -> Tuple[str, ...]:
 
 @rule(level=LogLevel.DEBUG)
 async def bandit_lint_partition(partition: BanditPartition, bandit: Bandit) -> LintResult:
-    lockfile_digest = None
+    lockfile_hex_digest = None
     if bandit.lockfile != "<none>":
         lockfile_request = await Get(PythonLockfileRequest, BanditLockfileSentinel())
-        lockfile_digest = lockfile_request.hex_digest
+        lockfile_hex_digest = lockfile_request.hex_digest
 
     bandit_pex_get = Get(
         VenvPex,
         PexRequest(
             output_filename="bandit.pex",
             internal_only=True,
-            requirements=bandit.pex_requirements(lockfile_digest),
+            requirements=bandit.pex_requirements(lockfile_hex_digest),
             interpreter_constraints=partition.interpreter_constraints,
             main=bandit.main,
         ),

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -50,7 +50,7 @@ async def bandit_lint_partition(partition: BanditPartition, bandit: Bandit) -> L
         PexRequest(
             output_filename="bandit.pex",
             internal_only=True,
-            requirements=bandit.pex_requirements_with_digest(lockfile_request.hex_digest),
+            requirements=bandit.pex_requirements(lockfile_request.hex_digest),
             interpreter_constraints=partition.interpreter_constraints,
             main=bandit.main,
         ),

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -10,7 +10,8 @@ import pytest
 
 from pants.backend.python.lint.bandit.rules import BanditRequest
 from pants.backend.python.lint.bandit.rules import rules as bandit_rules
-from pants.backend.python.lint.bandit.subsystem import BanditFieldSet, rules as bandit_subsystem_rules
+from pants.backend.python.lint.bandit.subsystem import BanditFieldSet
+from pants.backend.python.lint.bandit.subsystem import rules as bandit_subsystem_rules
 from pants.backend.python.target_types import PythonLibrary
 from pants.core.goals.lint import LintResult, LintResults
 from pants.core.util_rules import config_files, source_files

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -10,7 +10,7 @@ import pytest
 
 from pants.backend.python.lint.bandit.rules import BanditRequest
 from pants.backend.python.lint.bandit.rules import rules as bandit_rules
-from pants.backend.python.lint.bandit.subsystem import BanditFieldSet
+from pants.backend.python.lint.bandit.subsystem import BanditFieldSet, rules as bandit_subsystem_rules
 from pants.backend.python.target_types import PythonLibrary
 from pants.core.goals.lint import LintResult, LintResults
 from pants.core.util_rules import config_files, source_files
@@ -26,6 +26,7 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *bandit_rules(),
+            *bandit_subsystem_rules(),
             *source_files.rules(),
             *config_files.rules(),
             QueryRule(LintResults, (BanditRequest,)),

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -109,7 +109,7 @@ class Bandit(PythonToolBase):
         )
 
 
-class BanditLockfileSentinel(PythonToolLockfileSentinel):
+class BanditLockfileSentinel:
     pass
 
 

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -89,15 +89,17 @@ async def setup_black(
         else black.interpreter_constraints
     )
 
-    # TODO: don't calculate if not needed
-    lockfile_request = await Get(PythonLockfileRequest, BlackLockfileSentinel())
+    lockfile_digest = None
+    if black.lockfile != "<none>":
+        lockfile_request = await Get(PythonLockfileRequest, BlackLockfileSentinel())
+        lockfile_digest = lockfile_request.hex_digest
 
     black_pex_get = Get(
         VenvPex,
         PexRequest(
             output_filename="black.pex",
             internal_only=True,
-            requirements=black.pex_requirements(lockfile_request.hex_digest),
+            requirements=black.pex_requirements(lockfile_digest),
             interpreter_constraints=tool_interpreter_constraints,
             main=black.main,
         ),

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -97,7 +97,7 @@ async def setup_black(
         PexRequest(
             output_filename="black.pex",
             internal_only=True,
-            requirements=black.pex_requirements_with_digest(lockfile_request.hex_digest),
+            requirements=black.pex_requirements(lockfile_request.hex_digest),
             interpreter_constraints=tool_interpreter_constraints,
             main=black.main,
         ),

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -89,17 +89,17 @@ async def setup_black(
         else black.interpreter_constraints
     )
 
-    lockfile_digest = None
+    lockfile_hex_digest = None
     if black.lockfile != "<none>":
         lockfile_request = await Get(PythonLockfileRequest, BlackLockfileSentinel())
-        lockfile_digest = lockfile_request.hex_digest
+        lockfile_hex_digest = lockfile_request.hex_digest
 
     black_pex_get = Get(
         VenvPex,
         PexRequest(
             output_filename="black.pex",
             internal_only=True,
-            requirements=black.pex_requirements(lockfile_digest),
+            requirements=black.pex_requirements(lockfile_hex_digest),
             interpreter_constraints=tool_interpreter_constraints,
             main=black.main,
         ),

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -9,6 +9,7 @@ import pytest
 
 from pants.backend.python.lint.black.rules import BlackFieldSet, BlackRequest
 from pants.backend.python.lint.black.rules import rules as black_rules
+from pants.backend.python.lint.black.subsystem import rules as black_subsystem_rules
 from pants.backend.python.target_types import PythonLibrary
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintResult, LintResults
@@ -29,6 +30,7 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *black_rules(),
+            *black_subsystem_rules(),
             *source_files.rules(),
             *config_files.rules(),
             QueryRule(LintResults, (BlackRequest,)),

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -110,7 +110,7 @@ class Black(PythonToolBase):
         )
 
 
-class BlackLockfileSentinel(PythonToolLockfileSentinel):
+class BlackLockfileSentinel:
     pass
 
 

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -61,15 +61,17 @@ def generate_args(
 
 @rule(level=LogLevel.DEBUG)
 async def setup_docformatter(setup_request: SetupRequest, docformatter: Docformatter) -> Setup:
-    # TODO: don't calculate if not needed
-    lockfile_request = await Get(PythonLockfileRequest, DocformatterLockfileSentinel())
+    lockfile_digest = None
+    if docformatter.lockfile != "<none>":
+        lockfile_request = await Get(PythonLockfileRequest, DocformatterLockfileSentinel())
+        lockfile_digest = lockfile_request.hex_digest
 
     docformatter_pex_get = Get(
         VenvPex,
         PexRequest(
             output_filename="docformatter.pex",
             internal_only=True,
-            requirements=docformatter.pex_requirements(lockfile_request.hex_digest),
+            requirements=docformatter.pex_requirements(lockfile_digest),
             interpreter_constraints=docformatter.interpreter_constraints,
             main=docformatter.main,
         ),

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -61,17 +61,17 @@ def generate_args(
 
 @rule(level=LogLevel.DEBUG)
 async def setup_docformatter(setup_request: SetupRequest, docformatter: Docformatter) -> Setup:
-    lockfile_digest = None
+    lockfile_hex_digest = None
     if docformatter.lockfile != "<none>":
         lockfile_request = await Get(PythonLockfileRequest, DocformatterLockfileSentinel())
-        lockfile_digest = lockfile_request.hex_digest
+        lockfile_hex_digest = lockfile_request.hex_digest
 
     docformatter_pex_get = Get(
         VenvPex,
         PexRequest(
             output_filename="docformatter.pex",
             internal_only=True,
-            requirements=docformatter.pex_requirements(lockfile_digest),
+            requirements=docformatter.pex_requirements(lockfile_hex_digest),
             interpreter_constraints=docformatter.interpreter_constraints,
             main=docformatter.main,
         ),

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -69,7 +69,7 @@ async def setup_docformatter(setup_request: SetupRequest, docformatter: Docforma
         PexRequest(
             output_filename="docformatter.pex",
             internal_only=True,
-            requirements=docformatter.pex_requirements_with_digest(lockfile_request.hex_digest),
+            requirements=docformatter.pex_requirements(lockfile_request.hex_digest),
             interpreter_constraints=docformatter.interpreter_constraints,
             main=docformatter.main,
         ),

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -4,8 +4,12 @@
 from dataclasses import dataclass
 from typing import Tuple
 
+from pants.backend.experimental.python.lockfile import PythonLockfileRequest
 from pants.backend.python.lint.docformatter.skip_field import SkipDocformatterField
-from pants.backend.python.lint.docformatter.subsystem import Docformatter
+from pants.backend.python.lint.docformatter.subsystem import (
+    Docformatter,
+    DocformatterLockfileSentinel,
+)
 from pants.backend.python.lint.python_fmt import PythonFmtRequest
 from pants.backend.python.target_types import PythonSources
 from pants.backend.python.util_rules import pex
@@ -57,12 +61,15 @@ def generate_args(
 
 @rule(level=LogLevel.DEBUG)
 async def setup_docformatter(setup_request: SetupRequest, docformatter: Docformatter) -> Setup:
+    # TODO: don't calculate if not needed
+    lockfile_request = await Get(PythonLockfileRequest, DocformatterLockfileSentinel())
+
     docformatter_pex_get = Get(
         VenvPex,
         PexRequest(
             output_filename="docformatter.pex",
             internal_only=True,
-            requirements=docformatter.pex_requirements,
+            requirements=docformatter.pex_requirements_with_digest(lockfile_request.hex_digest),
             interpreter_constraints=docformatter.interpreter_constraints,
             main=docformatter.main,
         ),

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -7,6 +7,7 @@ import pytest
 
 from pants.backend.python.lint.docformatter.rules import DocformatterFieldSet, DocformatterRequest
 from pants.backend.python.lint.docformatter.rules import rules as docformatter_rules
+from pants.backend.python.lint.docformatter.subsystem import rules as docformatter_subsystem_rules
 from pants.backend.python.target_types import PythonLibrary
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintResult, LintResults
@@ -23,6 +24,7 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *docformatter_rules(),
+            *docformatter_subsystem_rules(),
             *source_files.rules(),
             QueryRule(LintResults, (DocformatterRequest,)),
             QueryRule(FmtResult, (DocformatterRequest,)),

--- a/src/python/pants/backend/python/lint/docformatter/subsystem.py
+++ b/src/python/pants/backend/python/lint/docformatter/subsystem.py
@@ -61,7 +61,7 @@ class Docformatter(PythonToolBase):
         return tuple(self.options.args)
 
 
-class DocformatterLockfileSentinel(PythonToolLockfileSentinel):
+class DocformatterLockfileSentinel:
     pass
 
 

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -50,7 +50,7 @@ async def flake8_lint_partition(partition: Flake8Partition, flake8: Flake8) -> L
         PexRequest(
             output_filename="flake8.pex",
             internal_only=True,
-            requirements=flake8.pex_requirements_with_digest(lockfile_request.hex_digest),
+            requirements=flake8.pex_requirements(lockfile_request.hex_digest),
             interpreter_constraints=partition.interpreter_constraints,
             main=flake8.main,
         ),

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from os import lockf
 from typing import Tuple
 
 from pants.backend.experimental.python.lockfile import PythonLockfileRequest

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -5,7 +5,11 @@ from dataclasses import dataclass
 from typing import Tuple
 
 from pants.backend.experimental.python.lockfile import PythonLockfileRequest
-from pants.backend.python.lint.flake8.subsystem import Flake8, Flake8FieldSet, Flake8LockfileSentinel
+from pants.backend.python.lint.flake8.subsystem import (
+    Flake8,
+    Flake8FieldSet,
+    Flake8LockfileSentinel,
+)
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -46,17 +46,17 @@ def generate_argv(source_files: SourceFiles, flake8: Flake8) -> Tuple[str, ...]:
 
 @rule(level=LogLevel.DEBUG)
 async def flake8_lint_partition(partition: Flake8Partition, flake8: Flake8) -> LintResult:
-    lockfile_digest = None
+    lockfile_hex_digest = None
     if flake8.lockfile != "<none>":
         lockfile_request = await Get(PythonLockfileRequest, Flake8LockfileSentinel())
-        lockfile_digest = lockfile_request.hex_digest
+        lockfile_hex_digest = lockfile_request.hex_digest
 
     flake8_pex_get = Get(
         VenvPex,
         PexRequest(
             output_filename="flake8.pex",
             internal_only=True,
-            requirements=flake8.pex_requirements(lockfile_digest),
+            requirements=flake8.pex_requirements(lockfile_hex_digest),
             interpreter_constraints=partition.interpreter_constraints,
             main=flake8.main,
         ),

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -9,7 +9,8 @@ import pytest
 
 from pants.backend.python.lint.flake8.rules import Flake8Request
 from pants.backend.python.lint.flake8.rules import rules as flake8_rules
-from pants.backend.python.lint.flake8.subsystem import Flake8FieldSet, rules as flake8_subsystem_rules
+from pants.backend.python.lint.flake8.subsystem import Flake8FieldSet
+from pants.backend.python.lint.flake8.subsystem import rules as flake8_subsystem_rules
 from pants.backend.python.target_types import PythonLibrary
 from pants.core.goals.lint import LintResult, LintResults
 from pants.core.util_rules import config_files, source_files

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -9,7 +9,7 @@ import pytest
 
 from pants.backend.python.lint.flake8.rules import Flake8Request
 from pants.backend.python.lint.flake8.rules import rules as flake8_rules
-from pants.backend.python.lint.flake8.subsystem import Flake8FieldSet
+from pants.backend.python.lint.flake8.subsystem import Flake8FieldSet, rules as flake8_subsystem_rules
 from pants.backend.python.target_types import PythonLibrary
 from pants.core.goals.lint import LintResult, LintResults
 from pants.core.util_rules import config_files, source_files
@@ -25,6 +25,7 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *flake8_rules(),
+            *flake8_subsystem_rules(),
             *source_files.rules(),
             *config_files.rules(),
             QueryRule(LintResults, [Flake8Request]),

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -126,7 +126,7 @@ class Flake8(PythonToolBase):
         )
 
 
-class Flake8LockfileSentinel(PythonToolLockfileSentinel):
+class Flake8LockfileSentinel:
     pass
 
 

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -4,8 +4,9 @@
 from dataclasses import dataclass
 from typing import Tuple
 
+from pants.backend.experimental.python.lockfile import PythonLockfileRequest
 from pants.backend.python.lint.isort.skip_field import SkipIsortField
-from pants.backend.python.lint.isort.subsystem import Isort
+from pants.backend.python.lint.isort.subsystem import Isort, IsortLockfileSentinel
 from pants.backend.python.lint.python_fmt import PythonFmtRequest
 from pants.backend.python.target_types import PythonSources
 from pants.backend.python.util_rules import pex
@@ -77,12 +78,15 @@ def generate_argv(
 
 @rule(level=LogLevel.DEBUG)
 async def setup_isort(setup_request: SetupRequest, isort: Isort) -> Setup:
+    # TODO: don't calculate if not needed
+    lockfile_request = await Get(PythonLockfileRequest, IsortLockfileSentinel())
+
     isort_pex_get = Get(
         VenvPex,
         PexRequest(
             output_filename="isort.pex",
             internal_only=True,
-            requirements=isort.pex_requirements,
+            requirements=isort.pex_requirements_with_digest(lockfile_request.hex_digest),
             interpreter_constraints=isort.interpreter_constraints,
             main=isort.main,
         ),

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -86,7 +86,7 @@ async def setup_isort(setup_request: SetupRequest, isort: Isort) -> Setup:
         PexRequest(
             output_filename="isort.pex",
             internal_only=True,
-            requirements=isort.pex_requirements_with_digest(lockfile_request.hex_digest),
+            requirements=isort.pex_requirements(lockfile_request.hex_digest),
             interpreter_constraints=isort.interpreter_constraints,
             main=isort.main,
         ),

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -78,15 +78,17 @@ def generate_argv(
 
 @rule(level=LogLevel.DEBUG)
 async def setup_isort(setup_request: SetupRequest, isort: Isort) -> Setup:
-    # TODO: don't calculate if not needed
-    lockfile_request = await Get(PythonLockfileRequest, IsortLockfileSentinel())
+    lockfile_digest = None
+    if isort.lockfile != "<none>":
+        lockfile_request = await Get(PythonLockfileRequest, IsortLockfileSentinel())
+        lockfile_digest = lockfile_request.hex_digest
 
     isort_pex_get = Get(
         VenvPex,
         PexRequest(
             output_filename="isort.pex",
             internal_only=True,
-            requirements=isort.pex_requirements(lockfile_request.hex_digest),
+            requirements=isort.pex_requirements(lockfile_digest),
             interpreter_constraints=isort.interpreter_constraints,
             main=isort.main,
         ),

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -78,17 +78,17 @@ def generate_argv(
 
 @rule(level=LogLevel.DEBUG)
 async def setup_isort(setup_request: SetupRequest, isort: Isort) -> Setup:
-    lockfile_digest = None
+    lockfile_hex_digest = None
     if isort.lockfile != "<none>":
         lockfile_request = await Get(PythonLockfileRequest, IsortLockfileSentinel())
-        lockfile_digest = lockfile_request.hex_digest
+        lockfile_hex_digest = lockfile_request.hex_digest
 
     isort_pex_get = Get(
         VenvPex,
         PexRequest(
             output_filename="isort.pex",
             internal_only=True,
-            requirements=isort.pex_requirements(lockfile_digest),
+            requirements=isort.pex_requirements(lockfile_hex_digest),
             interpreter_constraints=isort.interpreter_constraints,
             main=isort.main,
         ),

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -7,6 +7,7 @@ import pytest
 
 from pants.backend.python.lint.isort.rules import IsortFieldSet, IsortRequest
 from pants.backend.python.lint.isort.rules import rules as isort_rules
+from pants.backend.python.lint.isort.subsystem import rules as isort_subsystem_rules
 from pants.backend.python.target_types import PythonLibrary
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintResult, LintResults
@@ -23,6 +24,7 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *isort_rules(),
+            *isort_subsystem_rules(),
             *source_files.rules(),
             *config_files.rules(),
             QueryRule(LintResults, (IsortRequest,)),

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -128,7 +128,7 @@ class Isort(PythonToolBase):
         )
 
 
-class IsortLockfileSentinel(PythonToolLockfileSentinel):
+class IsortLockfileSentinel:
     pass
 
 

--- a/src/python/pants/backend/python/lint/python_fmt_integration_test.py
+++ b/src/python/pants/backend/python/lint/python_fmt_integration_test.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 import pytest
 
 from pants.backend.python.lint.black.rules import rules as black_rules
+from pants.backend.python.lint.black.subsystem import rules as black_subsystem_rules
 from pants.backend.python.lint.isort.rules import rules as isort_rules
+from pants.backend.python.lint.isort.subsystem import rules as isort_subsystem_rules
 from pants.backend.python.lint.python_fmt import PythonFmtTargets, format_python_target
 from pants.backend.python.target_types import PythonLibrary
 from pants.core.goals.fmt import LanguageFmtResults, enrich_fmt_result
@@ -28,6 +30,8 @@ def rule_runner() -> RuleRunner:
             format_python_target,
             *black_rules(),
             *isort_rules(),
+            *black_subsystem_rules(),
+            *isort_subsystem_rules(),
             *source_files.rules(),
             *config_files.rules(),
             QueryRule(LanguageFmtResults, (PythonFmtTargets,)),

--- a/src/python/pants/backend/python/lint/yapf/rules.py
+++ b/src/python/pants/backend/python/lint/yapf/rules.py
@@ -68,15 +68,17 @@ def generate_argv(source_files: SourceFiles, yapf: Yapf, check_only: bool) -> Tu
 
 @rule(level=LogLevel.DEBUG)
 async def setup_yapf(setup_request: SetupRequest, yapf: Yapf) -> Setup:
-    # TODO: don't calculate if not needed
-    lockfile_request = await Get(PythonLockfileRequest, YapfLockfileSentinel())
+    lockfile_digest = None
+    if yapf.lockfile != "<none>":
+        lockfile_request = await Get(PythonLockfileRequest, YapfLockfileSentinel())
+        lockfile_digest = lockfile_request.hex_digest
 
     yapf_pex_get = Get(
         VenvPex,
         PexRequest(
             output_filename="yapf.pex",
             internal_only=True,
-            requirements=yapf.pex_requirements(lockfile_request.hex_digest),
+            requirements=yapf.pex_requirements(lockfile_digest),
             interpreter_constraints=yapf.interpreter_constraints,
             main=yapf.main,
         ),

--- a/src/python/pants/backend/python/lint/yapf/rules.py
+++ b/src/python/pants/backend/python/lint/yapf/rules.py
@@ -76,7 +76,7 @@ async def setup_yapf(setup_request: SetupRequest, yapf: Yapf) -> Setup:
         PexRequest(
             output_filename="yapf.pex",
             internal_only=True,
-            requirements=yapf.pex_requirements_with_digest(lockfile_request.hex_digest),
+            requirements=yapf.pex_requirements(lockfile_request.hex_digest),
             interpreter_constraints=yapf.interpreter_constraints,
             main=yapf.main,
         ),

--- a/src/python/pants/backend/python/lint/yapf/rules.py
+++ b/src/python/pants/backend/python/lint/yapf/rules.py
@@ -68,17 +68,17 @@ def generate_argv(source_files: SourceFiles, yapf: Yapf, check_only: bool) -> Tu
 
 @rule(level=LogLevel.DEBUG)
 async def setup_yapf(setup_request: SetupRequest, yapf: Yapf) -> Setup:
-    lockfile_digest = None
+    lockfile_hex_digest = None
     if yapf.lockfile != "<none>":
         lockfile_request = await Get(PythonLockfileRequest, YapfLockfileSentinel())
-        lockfile_digest = lockfile_request.hex_digest
+        lockfile_hex_digest = lockfile_request.hex_digest
 
     yapf_pex_get = Get(
         VenvPex,
         PexRequest(
             output_filename="yapf.pex",
             internal_only=True,
-            requirements=yapf.pex_requirements(lockfile_digest),
+            requirements=yapf.pex_requirements(lockfile_hex_digest),
             interpreter_constraints=yapf.interpreter_constraints,
             main=yapf.main,
         ),

--- a/src/python/pants/backend/python/lint/yapf/rules.py
+++ b/src/python/pants/backend/python/lint/yapf/rules.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from os import lockf
 from typing import Tuple
 
 from pants.backend.experimental.python.lockfile import PythonLockfileRequest

--- a/src/python/pants/backend/python/lint/yapf/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/yapf/rules_integration_test.py
@@ -7,6 +7,7 @@ import pytest
 
 from pants.backend.python.lint.yapf.rules import YapfFieldSet, YapfRequest
 from pants.backend.python.lint.yapf.rules import rules as yapf_rules
+from pants.backend.python.lint.yapf.subsystem import rules as yapf_subsystem_rules
 from pants.backend.python.target_types import PythonLibrary
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintResult, LintResults
@@ -23,6 +24,7 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *yapf_rules(),
+            *yapf_subsystem_rules(),
             *source_files.rules(),
             *config_files.rules(),
             QueryRule(LintResults, (YapfRequest,)),

--- a/src/python/pants/backend/python/lint/yapf/subsystem.py
+++ b/src/python/pants/backend/python/lint/yapf/subsystem.py
@@ -119,7 +119,7 @@ class Yapf(PythonToolBase):
         )
 
 
-class YapfLockfileSentinel(PythonToolLockfileSentinel):
+class YapfLockfileSentinel:
     pass
 
 

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -133,14 +133,14 @@ class PythonToolRequirementsBase(Subsystem):
                     f"{self.options_scope}_default_lockfile.txt",
                     importlib.resources.read_binary(*self.default_lockfile_resource),
                 ),
-                is_lockfile=True,
+                lockfile_hex_digest="TODO CHANGEME",
             )
         return PexRequirements(
             file_path=self.lockfile,
             file_path_description_of_origin=(
                 f"the option `[{self.options_scope}].experimental_lockfile`"
             ),
-            is_lockfile=True,
+            lockfile_hex_digest="TODO CHANGEME",
         )
 
     def pex_requirements_with_digest(self, expected_lockfile_digest: str) -> PexRequirements:
@@ -158,7 +158,6 @@ class PythonToolRequirementsBase(Subsystem):
                     f"{self.options_scope}_default_lockfile.txt",
                     importlib.resources.read_binary(*self.default_lockfile_resource),
                 ),
-                is_lockfile=True,
                 lockfile_hex_digest=expected_lockfile_digest,
             )
         return PexRequirements(
@@ -166,7 +165,6 @@ class PythonToolRequirementsBase(Subsystem):
             file_path_description_of_origin=(
                 f"the option `[{self.options_scope}].experimental_lockfile`"
             ),
-            is_lockfile=True,
             lockfile_hex_digest=expected_lockfile_digest,
         )
 

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -143,6 +143,33 @@ class PythonToolRequirementsBase(Subsystem):
             is_lockfile=True,
         )
 
+    def pex_requirements_with_digest(self, expected_lockfile_digest: str) -> PexRequirements:
+        """The requirements to be used when installing the tool.
+
+        If the tool supports lockfiles, the returned type will install from the lockfile rather than
+        `all_requirements`.
+        """
+        if not self.register_lockfile or self.lockfile == "<none>":
+            return PexRequirements(self.all_requirements)
+        if self.lockfile == "<default>":
+            assert self.default_lockfile_resource is not None
+            return PexRequirements(
+                file_content=FileContent(
+                    f"{self.options_scope}_default_lockfile.txt",
+                    importlib.resources.read_binary(*self.default_lockfile_resource),
+                ),
+                is_lockfile=True,
+                lockfile_hex_digest=expected_lockfile_digest,
+            )
+        return PexRequirements(
+            file_path=self.lockfile,
+            file_path_description_of_origin=(
+                f"the option `[{self.options_scope}].experimental_lockfile`"
+            ),
+            is_lockfile=True,
+            lockfile_hex_digest=expected_lockfile_digest,
+        )
+
     @property
     def lockfile(self) -> str:
         """The path to a lockfile or special strings '<none>' and '<default>'.

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -117,33 +117,7 @@ class PythonToolRequirementsBase(Subsystem):
         """
         return (self.version, *self.extra_requirements)
 
-    @property
-    def pex_requirements(self) -> PexRequirements:
-        """The requirements to be used when installing the tool.
-
-        If the tool supports lockfiles, the returned type will install from the lockfile rather than
-        `all_requirements`.
-        """
-        if not self.register_lockfile or self.lockfile == "<none>":
-            return PexRequirements(self.all_requirements)
-        if self.lockfile == "<default>":
-            assert self.default_lockfile_resource is not None
-            return PexRequirements(
-                file_content=FileContent(
-                    f"{self.options_scope}_default_lockfile.txt",
-                    importlib.resources.read_binary(*self.default_lockfile_resource),
-                ),
-                lockfile_hex_digest="TODO CHANGEME",
-            )
-        return PexRequirements(
-            file_path=self.lockfile,
-            file_path_description_of_origin=(
-                f"the option `[{self.options_scope}].experimental_lockfile`"
-            ),
-            lockfile_hex_digest="TODO CHANGEME",
-        )
-
-    def pex_requirements_with_digest(self, expected_lockfile_digest: str) -> PexRequirements:
+    def pex_requirements(self, expected_lockfile_digest: str | None = None) -> PexRequirements:
         """The requirements to be used when installing the tool.
 
         If the tool supports lockfiles, the returned type will install from the lockfile rather than

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -117,7 +117,7 @@ class PythonToolRequirementsBase(Subsystem):
         """
         return (self.version, *self.extra_requirements)
 
-    def pex_requirements(self, expected_lockfile_digest: str | None = None) -> PexRequirements:
+    def pex_requirements(self, expected_lockfile_hex_digest: str | None = None) -> PexRequirements:
         """The requirements to be used when installing the tool.
 
         If the tool supports lockfiles, the returned type will install from the lockfile rather than
@@ -132,14 +132,14 @@ class PythonToolRequirementsBase(Subsystem):
                     f"{self.options_scope}_default_lockfile.txt",
                     importlib.resources.read_binary(*self.default_lockfile_resource),
                 ),
-                lockfile_hex_digest=expected_lockfile_digest,
+                lockfile_hex_digest=expected_lockfile_hex_digest,
             )
         return PexRequirements(
             file_path=self.lockfile,
             file_path_description_of_origin=(
                 f"the option `[{self.options_scope}].experimental_lockfile`"
             ),
-            lockfile_hex_digest=expected_lockfile_digest,
+            lockfile_hex_digest=expected_lockfile_hex_digest,
         )
 
     @property

--- a/src/python/pants/backend/python/subsystems/setuptools.py
+++ b/src/python/pants/backend/python/subsystems/setuptools.py
@@ -41,7 +41,7 @@ class Setuptools(PythonToolRequirementsBase):
     default_lockfile_url = git_url(default_lockfile_path)
 
 
-class SetuptoolsLockfileSentinel(PythonToolLockfileSentinel):
+class SetuptoolsLockfileSentinel:
     pass
 
 

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -8,6 +8,7 @@ from textwrap import dedent
 import pytest
 
 from pants.backend.codegen.protobuf.python.rules import rules as protobuf_rules
+from pants.backend.codegen.protobuf.python.python_protobuf_subsystem import rules as protobuf_subsystem_rules
 from pants.backend.codegen.protobuf.target_types import ProtobufLibrary
 from pants.backend.python.dependency_inference import rules as dependency_inference_rules
 from pants.backend.python.target_types import PythonLibrary, PythonRequirementLibrary
@@ -624,7 +625,7 @@ def test_source_plugin(rule_runner: RuleRunner) -> None:
 
 def test_protobuf_mypy(rule_runner: RuleRunner) -> None:
     rule_runner = RuleRunner(
-        rules=[*rule_runner.rules, *protobuf_rules()],
+        rules=[*rule_runner.rules, *protobuf_rules(), *protobuf_subsystem_rules()],
         target_types=[*rule_runner.target_types, ProtobufLibrary],
     )
     rule_runner.write_files(

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -7,8 +7,10 @@ from textwrap import dedent
 
 import pytest
 
+from pants.backend.codegen.protobuf.python.python_protobuf_subsystem import (
+    rules as protobuf_subsystem_rules,
+)
 from pants.backend.codegen.protobuf.python.rules import rules as protobuf_rules
-from pants.backend.codegen.protobuf.python.python_protobuf_subsystem import rules as protobuf_subsystem_rules
 from pants.backend.codegen.protobuf.target_types import ProtobufLibrary
 from pants.backend.python.dependency_inference import rules as dependency_inference_rules
 from pants.backend.python.target_types import PythonLibrary, PythonRequirementLibrary

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -68,7 +68,6 @@ class PexRequirements:
     file_content: FileContent | None
     file_path: str | None
     file_path_description_of_origin: str | None
-    is_lockfile: bool
     lockfile_hex_digest: str | None
 
     def __init__(
@@ -78,14 +77,12 @@ class PexRequirements:
         file_content: FileContent | None = None,
         file_path: str | None = None,
         file_path_description_of_origin: str | None = None,
-        is_lockfile: bool = False,
         lockfile_hex_digest: str | None = None,
     ) -> None:
         self.req_strings = FrozenOrderedSet(sorted(req_strings))
         self.file_content = file_content
         self.file_path = file_path
         self.file_path_description_of_origin = file_path_description_of_origin
-        self.is_lockfile = is_lockfile
         self.lockfile_hex_digest = lockfile_hex_digest
 
         if self.file_path and not self.file_path_description_of_origin:
@@ -124,6 +121,10 @@ class PexRequirements:
 
     def __bool__(self) -> bool:
         return bool(self.req_strings) or bool(self.file_path) or bool(self.file_content)
+
+    @property
+    def is_lockfile(self) -> bool:
+        return self.lockfile_hex_digest is not None
 
 
 class PexPlatforms(DeduplicatedCollection[str]):

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -37,6 +37,7 @@ from pants.engine.fs import (
     AddPrefix,
     CreateDigest,
     Digest,
+    DigestContents,
     FileContent,
     GlobMatchErrorBehavior,
     MergeDigests,
@@ -58,7 +59,6 @@ from pants.util.logging import LogLevel
 from pants.util.meta import frozen_after_init
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.strutil import pluralize
-from pants.engine.fs import DigestContents
 
 
 @frozen_after_init
@@ -428,20 +428,28 @@ async def build_pex(
         argv.extend(["--requirement", request.requirements.file_path])
 
         globs = PathGlobs(
-                [request.requirements.file_path],
-                glob_match_error_behavior=GlobMatchErrorBehavior.error,
-                description_of_origin=request.requirements.file_path_description_of_origin,
-            )
+            [request.requirements.file_path],
+            glob_match_error_behavior=GlobMatchErrorBehavior.error,
+            description_of_origin=request.requirements.file_path_description_of_origin,
+        )
 
         # use contents to invalidate here
-        requirements_file_digest_contents = await Get(DigestContents, PathGlobs, globs,)
+        requirements_file_digest_contents = await Get(
+            DigestContents,
+            PathGlobs,
+            globs,
+        )
         metadata = read_lockfile_metadata(requirements_file_digest_contents[0].content)
         if "invalidation digest" in metadata:
             invalidation = metadata["invalidation digest"]
             if invalidation != request.requirements.lockfile_hex_digest:
                 raise Exception(f"lol {invalidation} {request.requirements.lockfile_hex_digest}")
 
-        requirements_file_digest = await Get(Digest, PathGlobs, globs,)
+        requirements_file_digest = await Get(
+            Digest,
+            PathGlobs,
+            globs,
+        )
 
     elif request.requirements.file_content:
         content = request.requirements.file_content

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -443,7 +443,11 @@ async def build_pex(
         if "invalidation digest" in metadata:
             invalidation = metadata["invalidation digest"]
             if invalidation != request.requirements.lockfile_hex_digest:
-                raise Exception(f"lol {invalidation} {request.requirements.lockfile_hex_digest}")
+                if python_setup.fail_on_invalid_lockfile:
+                    raise ValueError("Invalid lockfile provided. [TODO: Improve message]")
+                else:
+                    # TODO: add warning
+                    pass
 
         requirements_file_digest = await Get(
             Digest,
@@ -462,7 +466,11 @@ async def build_pex(
         if "invalidation digest" in metadata:
             invalidation = metadata["invalidation digest"]
             if invalidation != request.requirements.lockfile_hex_digest:
-                raise Exception(f"lol {invalidation} {request.requirements.lockfile_hex_digest}")
+                if python_setup.fail_on_invalid_lockfile:
+                    raise ValueError("Invalid lockfile provided. [TODO: Improve message]")
+                else:
+                    # TODO: add warning
+                    pass
 
         requirements_file_digest = await Get(Digest, CreateDigest([content]))
     else:

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -440,14 +440,12 @@ async def build_pex(
             globs,
         )
         metadata = read_lockfile_metadata(requirements_file_digest_contents[0].content)
-        if "invalidation digest" in metadata:
-            invalidation = metadata["invalidation digest"]
-            if invalidation != request.requirements.lockfile_hex_digest:
-                if python_setup.fail_on_invalid_lockfile:
-                    raise ValueError("Invalid lockfile provided. [TODO: Improve message]")
-                else:
-                    # TODO: add warning
-                    pass
+        if metadata.invalidation_digest != request.requirements.lockfile_hex_digest:
+            if python_setup.fail_on_invalid_lockfile:
+                raise ValueError("Invalid lockfile provided. [TODO: Improve message]")
+            else:
+                # TODO: add warning
+                pass
 
         requirements_file_digest = await Get(
             Digest,
@@ -463,14 +461,12 @@ async def build_pex(
         # add option to Python setup to warn or error.
         # Pex_from_targets.py (something about not using the rule :))
         # test in pex_test.py
-        if "invalidation digest" in metadata:
-            invalidation = metadata["invalidation digest"]
-            if invalidation != request.requirements.lockfile_hex_digest:
-                if python_setup.fail_on_invalid_lockfile:
-                    raise ValueError("Invalid lockfile provided. [TODO: Improve message]")
-                else:
-                    # TODO: add warning
-                    pass
+        if metadata.invalidation_digest != request.requirements.lockfile_hex_digest:
+            if python_setup.fail_on_invalid_lockfile:
+                raise ValueError("Invalid lockfile provided. [TODO: Improve message]")
+            else:
+                # TODO: add warning
+                pass
 
         requirements_file_digest = await Get(Digest, CreateDigest([content]))
     else:

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -458,9 +458,6 @@ async def build_pex(
         argv.extend(["--requirement", content.path])
 
         metadata = read_lockfile_metadata(content.content)
-        # add option to Python setup to warn or error.
-        # Pex_from_targets.py (something about not using the rule :))
-        # test in pex_test.py
         if metadata.invalidation_digest != request.requirements.lockfile_hex_digest:
             if python_setup.fail_on_invalid_lockfile:
                 raise ValueError("Invalid lockfile provided. [TODO: Improve message]")

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -53,7 +53,7 @@ from pants.engine.process import (
 )
 from pants.engine.rules import Get, collect_rules, rule
 from pants.python.python_repos import PythonRepos
-from pants.python.python_setup import PythonSetup
+from pants.python.python_setup import InvalidLockfileBehavior, PythonSetup
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.meta import frozen_after_init
@@ -442,9 +442,9 @@ async def build_pex(
         )
         metadata = read_lockfile_metadata(requirements_file_digest_contents[0].content)
         if metadata.invalidation_digest != request.requirements.lockfile_hex_digest:
-            if python_setup.fail_on_invalid_lockfile:
+            if python_setup.invalid_lockfile_behavior == InvalidLockfileBehavior.error:
                 raise ValueError("Invalid lockfile provided. [TODO: Improve message]")
-            else:
+            elif python_setup.invalid_lockfile_behavior == InvalidLockfileBehavior.warn:
                 logger.warning("%s", "Invalid lockfile provided. [TODO: Improve message]")
 
         requirements_file_digest = await Get(
@@ -459,9 +459,9 @@ async def build_pex(
 
         metadata = read_lockfile_metadata(content.content)
         if metadata.invalidation_digest != request.requirements.lockfile_hex_digest:
-            if python_setup.fail_on_invalid_lockfile:
+            if python_setup.invalid_lockfile_behavior == InvalidLockfileBehavior.error:
                 raise ValueError("Invalid lockfile provided. [TODO: Improve message]")
-            else:
+            elif python_setup.invalid_lockfile_behavior == InvalidLockfileBehavior.warn:
                 logger.warning("%s", "Invalid lockfile provided. [TODO: Improve message]")
 
         requirements_file_digest = await Get(Digest, CreateDigest([content]))

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -445,8 +445,7 @@ async def build_pex(
             if python_setup.fail_on_invalid_lockfile:
                 raise ValueError("Invalid lockfile provided. [TODO: Improve message]")
             else:
-                # TODO: add warning
-                pass
+                logger.warning("%s", "Invalid lockfile provided. [TODO: Improve message]")
 
         requirements_file_digest = await Get(
             Digest,
@@ -463,8 +462,7 @@ async def build_pex(
             if python_setup.fail_on_invalid_lockfile:
                 raise ValueError("Invalid lockfile provided. [TODO: Improve message]")
             else:
-                # TODO: add warning
-                pass
+                logger.warning("%s", "Invalid lockfile provided. [TODO: Improve message]")
 
         requirements_file_digest = await Get(Digest, CreateDigest([content]))
     else:

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -304,7 +304,6 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
                     file_path_description_of_origin=(
                         "the option `[python-setup].experimental_lockfile`"
                     ),
-                    is_lockfile=True,
                     lockfile_hex_digest=invalidation_digest(
                         requirements.req_strings, interpreter_constraints
                     ),

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -12,7 +12,7 @@ from typing import Iterable, Tuple
 from packaging.utils import canonicalize_name as canonicalize_project_name
 from pkg_resources import Requirement
 
-from pants.backend.experimental.python.lockfile_metadata import invalidation_digest
+from pants.backend.experimental.python.lockfile_metadata import calculate_invalidation_digest
 from pants.backend.python.target_types import (
     MainSpecification,
     PythonRequirementsField,
@@ -304,7 +304,7 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
                     file_path_description_of_origin=(
                         "the option `[python-setup].experimental_lockfile`"
                     ),
-                    lockfile_hex_digest=invalidation_digest(
+                    lockfile_hex_digest=calculate_invalidation_digest(
                         requirements.req_strings, interpreter_constraints
                     ),
                 ),

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -12,6 +12,7 @@ from typing import Iterable, Tuple
 from packaging.utils import canonicalize_name as canonicalize_project_name
 from pkg_resources import Requirement
 
+from pants.backend.experimental.python.lockfile_metadata import invalidation_digest
 from pants.backend.python.target_types import (
     MainSpecification,
     PythonRequirementsField,
@@ -304,6 +305,9 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
                         "the option `[python-setup].experimental_lockfile`"
                     ),
                     is_lockfile=True,
+                    lockfile_hex_digest=invalidation_digest(
+                        requirements.req_strings, interpreter_constraints
+                    ),
                 ),
                 interpreter_constraints=interpreter_constraints,
                 platforms=request.platforms,

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -550,6 +550,11 @@ def test_warn_on_invalid_lockfile_with_path(rule_runner: RuleRunner, caplog) -> 
     assert "Invalid lockfile provided." in caplog.text
 
 
+def test_ignore_on_invalid_lockfile_with_path(rule_runner: RuleRunner, caplog) -> None:
+    _run_pex_for_lockfile_test(rule_runner, True, actual="1bad", expected="900d", behavior="ignore")
+    assert not caplog.text.strip()
+
+
 def test_no_warning_on_valid_lockfile_with_path(rule_runner: RuleRunner, caplog) -> None:
     _run_pex_for_lockfile_test(rule_runner, True, actual="900d", expected="900d", behavior="warn")
     assert not caplog.text.strip()

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -595,9 +595,6 @@ ansicolors==1.1.8
             file_path_description_of_origin="iceland",
             lockfile_hex_digest=expected,
         ),
-        interpreter_constraints=InterpreterConstraints(
-            ["CPython>=3.9"]  # TODO: Remove before merging. Needed so chrisjrn can develop on ARM
-        ),
         additional_pants_args=(
             "--python-setup-experimental-lockfile=lockfile.txt",
             f"--python-setup-invalid-lockfile-behavior={behavior}",

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -580,12 +580,10 @@ def _run_pex_for_lockfile_test(rule_runner, use_file, actual, expected, behavior
 ansicolors==1.1.8
 """
     if use_file:
-        rule_runner.create_file("lockfile.txt", lockfile)
+        rule_runner.write_files({"lockfile.txt": lockfile})
         file_args = {"file_path": "lockfile.txt"}
     else:
-        content = FileContent(
-            path="lockfile.txt", content=lockfile.encode("utf-8"), is_executable=False
-        )
+        content = FileContent("lockfile.txt", lockfile.encode("utf-8"))
         file_args = {"file_content": content}
 
     create_pex_and_get_all_data(

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -538,34 +538,60 @@ def test_build_pex_description() -> None:
     )
 
 
-def test_error_on_invalid_lockfile(rule_runner: RuleRunner, caplog) -> None:
+def test_error_on_invalid_lockfile_with_path(rule_runner: RuleRunner) -> None:
     with pytest.raises(ExecutionError):
-        _run_pex_for_lockfile_test(rule_runner, actual="1bad", expected="900d", behavior="error")
+        _run_pex_for_lockfile_test(
+            rule_runner, True, actual="1bad", expected="900d", behavior="error"
+        )
 
 
-def test_warn_on_invalid_lockfile(rule_runner: RuleRunner, caplog) -> None:
-    _run_pex_for_lockfile_test(rule_runner, actual="1bad", expected="900d", behavior="warn")
+def test_warn_on_invalid_lockfile_with_path(rule_runner: RuleRunner, caplog) -> None:
+    _run_pex_for_lockfile_test(rule_runner, True, actual="1bad", expected="900d", behavior="warn")
     assert "Invalid lockfile provided." in caplog.text
 
 
-def test_no_warning_on_valid_lockfile(rule_runner: RuleRunner, caplog) -> None:
-    _run_pex_for_lockfile_test(rule_runner, actual="900d", expected="900d", behavior="warn")
+def test_no_warning_on_valid_lockfile_with_path(rule_runner: RuleRunner, caplog) -> None:
+    _run_pex_for_lockfile_test(rule_runner, True, actual="900d", expected="900d", behavior="warn")
     assert not caplog.text.strip()
 
 
-def _run_pex_for_lockfile_test(rule_runner, actual, expected, behavior):
+def test_error_on_invalid_lockfile_with_content(rule_runner: RuleRunner) -> None:
+    with pytest.raises(ExecutionError):
+        _run_pex_for_lockfile_test(
+            rule_runner, False, actual="1bad", expected="900d", behavior="error"
+        )
+
+
+def test_warn_on_invalid_lockfile_with_content(rule_runner: RuleRunner, caplog) -> None:
+    _run_pex_for_lockfile_test(rule_runner, False, actual="1bad", expected="900d", behavior="warn")
+    assert "Invalid lockfile provided." in caplog.text
+
+
+def test_no_warning_on_valid_lockfile_with_content(rule_runner: RuleRunner, caplog) -> None:
+    _run_pex_for_lockfile_test(rule_runner, False, actual="900d", expected="900d", behavior="warn")
+    assert not caplog.text.strip()
+
+
+def _run_pex_for_lockfile_test(rule_runner, use_file, actual, expected, behavior):
     lockfile = f"""
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # invalidation digest: {actual}
 # --- END PANTS LOCKFILE METADATA ---
 ansicolors==1.1.8
 """
-    rule_runner.create_file("lockfile.txt", lockfile)
+    if use_file:
+        rule_runner.create_file("lockfile.txt", lockfile)
+        file_args = {"file_path": "lockfile.txt"}
+    else:
+        content = FileContent(
+            path="lockfile.txt", content=lockfile.encode("utf-8"), is_executable=False
+        )
+        file_args = {"file_content": content}
 
     create_pex_and_get_all_data(
         rule_runner,
         requirements=PexRequirements(
-            file_path="lockfile.txt",
+            **file_args,
             file_path_description_of_origin="iceland",
             lockfile_hex_digest=expected,
         ),

--- a/src/python/pants/backend/python/util_rules/python_sources_test.py
+++ b/src/python/pants/backend/python/util_rules/python_sources_test.py
@@ -10,6 +10,9 @@ from typing import Iterable
 import pytest
 
 from pants.backend.codegen.protobuf.python import additional_fields
+from pants.backend.codegen.protobuf.python.python_protobuf_subsystem import (
+    rules as protobuf_subsystem_rules,
+)
 from pants.backend.codegen.protobuf.python.rules import rules as protobuf_rules
 from pants.backend.codegen.protobuf.target_types import ProtobufLibrary
 from pants.backend.python.target_types import PythonSources
@@ -42,6 +45,7 @@ def rule_runner() -> RuleRunner:
             *python_sources_rules(),
             *additional_fields.rules(),
             *protobuf_rules(),
+            *protobuf_subsystem_rules(),
             QueryRule(PythonSourceFiles, [PythonSourceFilesRequest]),
             QueryRule(StrippedPythonSourceFiles, [PythonSourceFilesRequest]),
         ],

--- a/src/python/pants/engine/fs_test.py
+++ b/src/python/pants/engine/fs_test.py
@@ -119,8 +119,8 @@ FS_TAR_ALL_FILES = (
 FS_TAR_ALL_DIRS = ("a", "a/b", "c.ln", "d.ln", "d.ln/b")
 
 
-def try_with_backoff(assertion_fn: Callable[[], bool]) -> bool:
-    for i in range(4):
+def try_with_backoff(assertion_fn: Callable[[], bool], count: int = 4) -> bool:
+    for i in range(count):
         time.sleep(0.1 * i)
         if assertion_fn():
             return True
@@ -966,7 +966,7 @@ def test_invalidated_after_parent_deletion(rule_runner: RuleRunner) -> None:
     assert read_file() == "one\n"
 
     shutil.rmtree(Path(rule_runner.build_root, "a/b"))
-    assert try_with_backoff(lambda: read_file() is None)
+    assert try_with_backoff((lambda: read_file() is None), count=10)
 
 
 def test_invalidated_after_child_deletion(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -140,10 +140,11 @@ class PythonSetup(Subsystem):
             "--invalid-lockfile-behavior",
             advanced=True,
             type=InvalidLockfileBehavior,
-            default=InvalidLockfileBehavior.warn,
+            default=InvalidLockfileBehavior.error,
             help=(
                 "Set the behavior when Pants encounters a lockfile that was generated with different "
-                "requirements or interpreter constraints than those currently specified."
+                "requirements or interpreter constraints than those currently specified.\n\n"
+                "We strongly recommend setting to `error` in CI or release builds."
             ),
         )
         register(

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -138,7 +138,7 @@ class PythonSetup(Subsystem):
                 "Causes a build failure if Pants encounters a lockfile that was generated with different "
                 "requirements or interpreter constraints than those currently specified. The default behavior "
                 "is to issue a warning if such a lockfile is encountered."
-            )
+            ),
         )
         register(
             "--interpreter-search-paths",

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -130,6 +130,17 @@ class PythonSetup(Subsystem):
             ),
         )
         register(
+            "--fail-on-invalid-lockfile",
+            advanced=True,
+            type=bool,
+            default=False,
+            help=(
+                "Causes a build failure if Pants encounters a lockfile that was generated with different "
+                "requirements or interpreter constraints than those currently specified. The default behavior "
+                "is to issue a warning if such a lockfile is encountered."
+            )
+        )
+        register(
             "--interpreter-search-paths",
             advanced=True,
             type=list,
@@ -210,6 +221,10 @@ class PythonSetup(Subsystem):
     @property
     def lockfile(self) -> str | None:
         return cast("str | None", self.options.experimental_lockfile)
+
+    @property
+    def fail_on_invalid_lockfile(self) -> bool:
+        return cast(bool, self.options.fail_on_invalid_lockfile)
 
     @property
     def lockfile_custom_regeneration_command(self) -> str | None:

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -140,7 +140,7 @@ class PythonSetup(Subsystem):
             "--invalid-lockfile-behavior",
             advanced=True,
             type=InvalidLockfileBehavior,
-            default=InvalidLockfileBehavior.error,
+            default=InvalidLockfileBehavior.warn,
             help=(
                 "Set the behavior when Pants encounters a lockfile that was generated with different "
                 "requirements or interpreter constraints than those currently specified.\n\n"

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 @enum.unique
 class InvalidLockfileBehavior(enum.Enum):
     error = "error"
+    ignore = "ignore"
     warn = "warn"
 
 
@@ -140,7 +141,7 @@ class PythonSetup(Subsystem):
             "--invalid-lockfile-behavior",
             advanced=True,
             type=InvalidLockfileBehavior,
-            default=InvalidLockfileBehavior.warn,
+            default=InvalidLockfileBehavior.ignore,
             help=(
                 "Set the behavior when Pants encounters a lockfile that was generated with different "
                 "requirements or interpreter constraints than those currently specified.\n\n"
@@ -230,11 +231,8 @@ class PythonSetup(Subsystem):
         return cast("str | None", self.options.experimental_lockfile)
 
     @property
-    def fail_on_invalid_lockfile(self) -> bool:
-        return (
-            cast(InvalidLockfileBehavior, self.options.invalid_lockfile_behavior)
-            == InvalidLockfileBehavior.error
-        )
+    def invalid_lockfile_behavior(self) -> InvalidLockfileBehavior:
+        return cast(InvalidLockfileBehavior, self.options.invalid_lockfile_behavior)
 
     @property
     def lockfile_custom_regeneration_command(self) -> str | None:


### PR DESCRIPTION
Addresses #12415

This adds tools for consuming the lockfile invalidation digests that were added in #12427, both for lockfiles specified for the project, and for individual build tools.

Behavior on invalid lockfiles can be configured to either be a warning or an error.