### PR TITLE
Deprecate `[pytest].pytest_plugins` in favor of `[pytest].extra_requirements`

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -150,7 +150,7 @@ release_notes = """
 
 [pytest]
 args = ["--no-header"]
-pytest_plugins.add = [
+extra_requirements.add = [
   "ipdb",
   "pytest-html",
   "pytest-icdiff",

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -210,7 +210,7 @@ async def setup_pytest_for_target(
         Pex,
         PexRequest(
             output_filename="pytest.pex",
-            requirements=PexRequirements(pytest.get_requirement_strings()),
+            requirements=pytest.pex_requirements,
             interpreter_constraints=interpreter_constraints,
             internal_only=True,
         ),
@@ -246,7 +246,7 @@ async def setup_pytest_for_target(
         PexRequest(
             output_filename="pytest_runner.pex",
             interpreter_constraints=interpreter_constraints,
-            main=ConsoleScript("pytest"),
+            main=pytest.main,
             internal_only=True,
             pex_path=[pytest_pex, requirements_pex],
         ),

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -15,19 +15,12 @@ from pants.backend.python.goals.coverage_py import (
 )
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.backend.python.target_types import (
-    ConsoleScript,
     PythonTestsExtraEnvVars,
     PythonTestsSources,
     PythonTestsTimeout,
 )
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.pex import (
-    Pex,
-    PexRequest,
-    PexRequirements,
-    VenvPex,
-    VenvPexProcess,
-)
+from pants.backend.python.util_rules.pex import Pex, PexRequest, VenvPex, VenvPexProcess
 from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -84,14 +84,14 @@ def run_pytest(
     # pytest-html==1.22.1 has an undeclared dep on setuptools. This, unfortunately,
     # is the most recent version of pytest-html that works with the low version of
     # pytest that we pin to.
-    plugins = ["zipp==1.0.0", "pytest-cov>=2.8.1,<2.9", "pytest-html==1.22.1", "setuptools"]
-    plugins_str = "['" + "', '".join(plugins) + "']"
+    extra_reqs = ["zipp==1.0.0", "pytest-cov>=2.8.1,<2.9", "pytest-html==1.22.1", "setuptools"]
+    extra_reqs_str = "['" + "', '".join(extra_reqs) + "']"
     args = [
         "--backend-packages=pants.backend.python",
         f"--source-root-patterns={SOURCE_ROOT}",
         # pin to lower versions so that we can run Python 2 tests
         "--pytest-version=pytest>=4.6.6,<4.7",
-        f"--pytest-pytest-plugins={plugins_str}",
+        f"--pytest-extra-requirements={extra_reqs_str}",
         *(extra_args or ()),
     ]
     rule_runner.set_options(args, env=env, env_inherit={"PATH", "PYENV_ROOT", "HOME"})

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -10,7 +10,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from textwrap import dedent
-from typing import Dict, Iterable, Iterator, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Dict, Iterable, Iterator, Optional, Tuple, Union, cast
 
 from packaging.utils import canonicalize_name as canonicalize_project_name
 from pkg_resources import Requirement
@@ -20,7 +20,6 @@ from pants.backend.python.dependency_inference.default_module_mapping import (
     DEFAULT_TYPE_STUB_MODULE_MAPPING,
 )
 from pants.backend.python.macros.python_artifact import PythonArtifact
-from pants.backend.python.subsystems.pytest import PyTest
 from pants.core.goals.package import OutputPathField
 from pants.core.goals.test import RuntimePackageDependenciesField
 from pants.engine.addresses import Address, Addresses
@@ -51,6 +50,10 @@ from pants.util.docutil import doc_url
 from pants.util.frozendict import FrozenDict
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from pants.backend.python.subsystems.pytest import PyTest
+
 
 # -----------------------------------------------------------------------------------------------
 # Common fields


### PR DESCRIPTION
This gives the option uniformity with all other Python subsystems. 

It also allows us to use the standardized `register_lockfile` functionality in an upcoming PR.

[ci skip-rust]