### PR TITLE
[internal] Ensure Apple Silicon publishing is in Rust release mode

### DIFF
--- a/build-support/bin/release_helper.py
+++ b/build-support/bin/release_helper.py
@@ -647,6 +647,8 @@ def publish_apple_silicon() -> None:
     banner("Building and publishing an Apple Silicon wheel")
     if os.environ.get("USE_PY39") != "true":
         die("Must set `USE_PY39=true` when building for Apple Silicon.")
+    if os.environ.get("MODE") == "debug":
+        die("Must build Rust in release mode, not debug. Please run `unset MODE`.")
     check_clean_git_branch()
     check_pgp()
     check_roles()


### PR DESCRIPTION
I messed this up on the 2.6 branch.

It's not an issue for normal releases because those wheels are built in CI.

[ci skip-rust]