### PR TITLE
upgrade to rust v1.54.0

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.53.0"
+channel = "1.54.0"
 components = [
   "cargo",
   "clippy",

--- a/src/rust/engine/client/src/main.rs
+++ b/src/rust/engine/client/src/main.rs
@@ -125,7 +125,7 @@ fn find_pantsd(
     value = option_value.value,
     source = option_value.source
   );
-  let port = pantsd::probe(&working_dir, &metadata_dir)?;
+  let port = pantsd::probe(working_dir, &metadata_dir)?;
   let mut pantsd_settings = client::ConnectionSettings::new(port);
   pantsd_settings.timeout_limit = options_parser
     .parse_float(

--- a/src/rust/engine/client/src/options/config.rs
+++ b/src/rust/engine/client/src/options/config.rs
@@ -176,13 +176,13 @@ impl OptionsSource for Config {
           if let Some(add) = sub_table.get("add") {
             list_edits.push(ListEdit {
               action: ListEditAction::Add,
-              items: Self::extract_string_list(&*format!("{}.add", option_name), &add)?,
+              items: Self::extract_string_list(&*format!("{}.add", option_name), add)?,
             })
           }
           if let Some(remove) = sub_table.get("remove") {
             list_edits.push(ListEdit {
               action: ListEditAction::Remove,
-              items: Self::extract_string_list(&*format!("{}.remove", option_name), &remove)?,
+              items: Self::extract_string_list(&*format!("{}.remove", option_name), remove)?,
             })
           }
         } else {

--- a/src/rust/engine/client/src/options/parse.rs
+++ b/src/rust/engine/client/src/options/parse.rs
@@ -190,7 +190,7 @@ fn format_parse_error(
 }
 
 pub(crate) fn parse_string_list(value: &str) -> Result<Vec<ListEdit<String>>, ParseError> {
-  option_value_parser::string_list_edits(&value)
+  option_value_parser::string_list_edits(value)
     .map_err(|e| format_parse_error("string list", value, e))
 }
 

--- a/src/rust/engine/engine_pyo3/src/externs/interface/fs.rs
+++ b/src/rust/engine/engine_pyo3/src/externs/interface/fs.rs
@@ -80,7 +80,7 @@ fn match_path_globs(
     Ok(
       paths
         .into_iter()
-        .filter(|p| path_globs.matches(&Path::new(p)))
+        .filter(|p| path_globs.matches(Path::new(p)))
         .collect(),
     )
   })

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -347,7 +347,7 @@ async fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
             .expect("size_bytes must be a non-negative number");
           let digest = Digest::new(fingerprint, size_bytes);
           let write_result = store
-            .load_file_bytes_with(digest, |bytes| io::stdout().write_all(&bytes).unwrap())
+            .load_file_bytes_with(digest, |bytes| io::stdout().write_all(bytes).unwrap())
             .await?;
           write_result
             .ok_or_else(|| {

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -320,7 +320,7 @@ impl PreparedPathGlobs {
       })
       .collect();
 
-    let patterns = PreparedPathGlobs::parse_patterns_from_include(&include.as_slice())?;
+    let patterns = PreparedPathGlobs::parse_patterns_from_include(include.as_slice())?;
     Ok(PreparedPathGlobs {
       include,
       // An empty exclude becomes EMPTY_IGNORE.
@@ -425,7 +425,7 @@ trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: Vfs<E> {
           async move {
             // Canonicalize matched PathStats, and filter paths that are ignored by local excludes.
             // Context ("global") ignore patterns are applied during `scandir`.
-            if exclude.is_ignored(&stat) {
+            if exclude.is_ignored(stat) {
               Ok(None)
             } else {
               match stat {

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -138,7 +138,7 @@ impl DirectoryMaterializeMetadata {
       }
 
       for (dir, meta) in current.child_directories.iter() {
-        recurse(outputs, path_so_far.join(RelativePath::new(dir)?), &meta)?
+        recurse(outputs, path_so_far.join(RelativePath::new(dir)?), meta)?
       }
       Ok(())
     }
@@ -1135,7 +1135,7 @@ impl Store {
                 e
               )
             })?;
-          f.write_all(&bytes)
+          f.write_all(bytes)
             .map_err(|e| format!("Error writing file {}: {:?}", destination.display(), e))?;
           Ok(())
         })

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -76,7 +76,7 @@ impl ByteStore {
     };
 
     let endpoint =
-      grpc_util::create_endpoint(&cas_address, tls_client_config.as_ref(), &mut headers)?;
+      grpc_util::create_endpoint(cas_address, tls_client_config.as_ref(), &mut headers)?;
     let http_headers = headers_to_http_header_map(&headers)?;
     let channel = layered_service(
       tonic::transport::Channel::balance_list(vec![endpoint].into_iter()),

--- a/src/rust/engine/fs/store/src/snapshot_ops.rs
+++ b/src/rust/engine/fs/store/src/snapshot_ops.rs
@@ -366,6 +366,7 @@ impl IntermediateGlobbedFilesAndDirectories {
         RestrictedPathGlob::DirWildcard { wildcard, .. } => wildcard,
       };
 
+      // TODO(#12462): Remove allow once upstream resolves https://github.com/rust-lang/rust-clippy/issues/6066.
       #[allow(clippy::needless_collect)]
       let matching_files: Vec<PathBuf> = cur_dir_files
         .keys()
@@ -383,6 +384,7 @@ impl IntermediateGlobbedFilesAndDirectories {
         globbed_files.insert(file_path, file_node);
       }
 
+      // TODO(#12462): Remove allow once upstream resolves https://github.com/rust-lang/rust-clippy/issues/6066.
       #[allow(clippy::needless_collect)]
       let matching_directories: Vec<PathBuf> = cur_dir_directories
         .keys()

--- a/src/rust/engine/fs/store/src/snapshot_ops.rs
+++ b/src/rust/engine/fs/store/src/snapshot_ops.rs
@@ -366,6 +366,7 @@ impl IntermediateGlobbedFilesAndDirectories {
         RestrictedPathGlob::DirWildcard { wildcard, .. } => wildcard,
       };
 
+      #[allow(clippy::needless_collect)]
       let matching_files: Vec<PathBuf> = cur_dir_files
         .keys()
         .filter(|path| {
@@ -382,6 +383,7 @@ impl IntermediateGlobbedFilesAndDirectories {
         globbed_files.insert(file_path, file_node);
       }
 
+      #[allow(clippy::needless_collect)]
       let matching_directories: Vec<PathBuf> = cur_dir_directories
         .keys()
         .filter(|path| {

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -253,7 +253,7 @@ impl<N: Node> InnerGraph<N> {
           Some((i, Duration::from_nanos(-weight as u64)))
         }
       })
-      .max_by(|(_, left_duration), (_, right_duration)| left_duration.cmp(&right_duration))
+      .max_by(|(_, left_duration), (_, right_duration)| left_duration.cmp(right_duration))
     {
       let critical_path = {
         let mut next = paths[index];

--- a/src/rust/engine/grpc_util/src/lib.rs
+++ b/src/rust/engine/grpc_util/src/lib.rs
@@ -138,10 +138,10 @@ pub fn headers_to_http_header_map(headers: &BTreeMap<String, String>) -> Result<
   let http_headers = headers
     .iter()
     .map(|(key, value)| {
-      let header_name = HeaderName::from_str(&key)
-        .map_err(|err| format!("Invalid header name {}: {}", key, err))?;
+      let header_name =
+        HeaderName::from_str(key).map_err(|err| format!("Invalid header name {}: {}", key, err))?;
 
-      let header_value = HeaderValue::from_str(&value)
+      let header_value = HeaderValue::from_str(value)
         .map_err(|err| format!("Invalid header value {}: {}", value, err))?;
 
       Ok((header_name, header_value))

--- a/src/rust/engine/logging/src/logger.rs
+++ b/src/rust/engine/logging/src/logger.rs
@@ -158,7 +158,7 @@ impl Log for PantsLogger {
 
     let mut should_log = self.show_rust_3rdparty_logs.load(Ordering::SeqCst);
     if !should_log {
-      if let Some(ref module_path) = record.module_path() {
+      if let Some(module_path) = record.module_path() {
         for pants_package in super::pants_packages::PANTS_PACKAGE_NAMES {
           if &module_path.split("::").next().unwrap() == pants_package {
             should_log = true;

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -521,7 +521,7 @@ pub fn digest(req: MultiPlatformProcess, metadata: &ProcessMetadata) -> Digest {
   let mut hashes: Vec<String> = req
     .0
     .values()
-    .map(|ref process| crate::remote::make_execute_request(process, metadata.clone()).unwrap())
+    .map(|process| crate::remote::make_execute_request(process, metadata.clone()).unwrap())
     .map(|(_a, _b, er)| {
       er.action_digest
         .map(|d| d.hash)
@@ -533,7 +533,7 @@ pub fn digest(req: MultiPlatformProcess, metadata: &ProcessMetadata) -> Digest {
     hashes
       .iter()
       .fold(String::new(), |mut acc, hash| {
-        acc.push_str(&hash);
+        acc.push_str(hash);
         acc
       })
       .as_bytes(),
@@ -591,7 +591,7 @@ impl CommandRunner for BoundedCommandRunner {
   }
 
   fn extract_compatible_request(&self, req: &MultiPlatformProcess) -> Option<Process> {
-    self.inner.0.extract_compatible_request(&req)
+    self.inner.0.extract_compatible_request(req)
   }
 }
 

--- a/src/rust/engine/process_execution/src/nailgun/parsed_jvm_command_lines.rs
+++ b/src/rust/engine/process_execution/src/nailgun/parsed_jvm_command_lines.rs
@@ -86,7 +86,7 @@ impl ParsedJVMCommandLines {
   fn parse_classpath(args_to_consume: &mut Iter<String>) -> Result<(String, String), String> {
     let classpath_flag = args_to_consume
       .next()
-      .filter(|e| ParsedJVMCommandLines::is_classpath_flag(&e))
+      .filter(|e| ParsedJVMCommandLines::is_classpath_flag(e))
       .ok_or_else(|| "No classpath flag found.".to_string())
       .map(|e| e.clone())?;
 

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -139,7 +139,7 @@ impl CommandRunner {
 
     let mut execution_headers = headers.clone();
     let execution_endpoint = grpc_util::create_endpoint(
-      &execution_address,
+      execution_address,
       tls_client_config.as_ref().filter(|_| execution_use_tls),
       &mut execution_headers,
     )?;
@@ -153,7 +153,7 @@ impl CommandRunner {
 
     let mut store_headers = headers.clone();
     let store_endpoint = grpc_util::create_endpoint(
-      &store_address,
+      store_address,
       tls_client_config.as_ref().filter(|_| execution_use_tls),
       &mut store_headers,
     )?;
@@ -623,7 +623,7 @@ impl CommandRunner {
           // or status to interpret.
           let operation_stream = operation_stream_response.into_inner();
           let stream_outcome = self
-            .wait_on_operation_stream(operation_stream, &context)
+            .wait_on_operation_stream(operation_stream, context)
             .await;
 
           match stream_outcome {

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -77,7 +77,7 @@ impl CommandRunner {
     };
 
     let endpoint = grpc_util::create_endpoint(
-      &action_cache_address,
+      action_cache_address,
       tls_client_config.as_ref(),
       &mut headers,
     )?;

--- a/src/rust/engine/process_execution/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_cache_tests.rs
@@ -74,7 +74,9 @@ impl CommandRunnerTrait for MockLocalCommandRunner {
 // NB: We bundle these into a struct to ensure they share the same lifetime.
 struct StoreSetup {
   pub store: Store,
+  #[allow(dead_code)]
   pub store_temp_dir: TempDir,
+  #[allow(dead_code)]
   pub cas: StubCAS,
   pub executor: task_executor::Executor,
 }

--- a/src/rust/engine/process_execution/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_cache_tests.rs
@@ -74,10 +74,8 @@ impl CommandRunnerTrait for MockLocalCommandRunner {
 // NB: We bundle these into a struct to ensure they share the same lifetime.
 struct StoreSetup {
   pub store: Store,
-  #[allow(dead_code)]
-  pub store_temp_dir: TempDir,
-  #[allow(dead_code)]
-  pub cas: StubCAS,
+  pub _store_temp_dir: TempDir,
+  pub _cas: StubCAS,
   pub executor: task_executor::Executor,
 }
 
@@ -102,8 +100,8 @@ impl StoreSetup {
       .unwrap();
     StoreSetup {
       store,
-      store_temp_dir,
-      cas,
+      _store_temp_dir: store_temp_dir,
+      _cas: cas,
       executor,
     }
   }

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -242,7 +242,7 @@ async fn main() {
       }
 
       local_only_store.into_with_remote(
-        &cas_server,
+        cas_server,
         args.remote_instance_name.clone(),
         root_ca_certs,
         headers,

--- a/src/rust/engine/rule_graph/src/builder.rs
+++ b/src/rust/engine/rule_graph/src/builder.rs
@@ -616,7 +616,7 @@ impl<R: Rule> Builder<R> {
             .collect::<Vec<_>>(),
           dependees_by_out_set
         .keys()
-        .map(|out_set| params_str(&out_set))
+        .map(|out_set| params_str(out_set))
         .collect::<Vec<_>>(),
         )
       } else {
@@ -1027,7 +1027,7 @@ impl<R: Rule> Builder<R> {
               );
             }
             errored.entry(node_id).or_insert_with(Vec::new).push(
-              self.render_no_source_of_dependency_error(&graph, &node, dependency_key, edge_refs),
+              self.render_no_source_of_dependency_error(&graph, node, dependency_key, edge_refs),
             );
           }
           _ => {
@@ -1263,7 +1263,7 @@ impl<R: Rule> Builder<R> {
 
       let dependency_key = &edge_ref.weight().0;
       edges_by_dependency_key
-        .get_mut(&dependency_key)
+        .get_mut(dependency_key)
         .unwrap_or_else(|| {
           panic!(
             "{} did not declare a dependency {}, but had an edge for it.",
@@ -1376,7 +1376,7 @@ impl<R: Rule> Builder<R> {
           .map(|(dependency_key, dependency_id)| {
             let dependency_in_set = Self::dependency_in_set(
               node_id,
-              &dependency_key,
+              dependency_key,
               *dependency_id,
               &graph[*dependency_id].0.in_set,
             )
@@ -1444,7 +1444,7 @@ impl<R: Rule> Builder<R> {
         .iter()
         .all(|(_, dependency_id, dependency_in_set)| {
           matches!(graph[*dependency_id].0.node, Node::Param(_))
-            || !minimal_in_set.contains(&dependency_id)
+            || !minimal_in_set.contains(dependency_id)
             || dependency_in_set.difference(&out_set).next().is_none()
         });
       if !out_set_satisfiable {

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -217,7 +217,7 @@ impl Core {
       local_execution_root_dir,
       named_caches_dir,
       process_execution_metadata,
-      &exec_strategy_opts,
+      exec_strategy_opts,
     );
 
     // Possibly either add the remote execution runner or the remote cache runner.

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -307,13 +307,13 @@ impl AsRef<PyObject> for Value {
 
 impl fmt::Debug for Value {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    write!(f, "{}", externs::val_to_str(&self.as_ref()))
+    write!(f, "{}", externs::val_to_str(self.as_ref()))
   }
 }
 
 impl fmt::Display for Value {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    write!(f, "{}", externs::val_to_str(&self.as_ref()))
+    write!(f, "{}", externs::val_to_str(self.as_ref()))
   }
 }
 

--- a/src/rust/engine/src/externs/engine_aware.rs
+++ b/src/rust/engine/src/externs/engine_aware.rs
@@ -36,7 +36,7 @@ impl EngineAwareInformation for Message {
   type MaybeOutput = String;
 
   fn retrieve(_types: &Types, value: &Value) -> Option<String> {
-    let msg_val = externs::call_method(&value, "message", &[]).ok()?;
+    let msg_val = externs::call_method(value, "message", &[]).ok()?;
     let msg_val = externs::check_for_python_none(msg_val)?;
     Some(externs::val_to_str(&msg_val))
   }
@@ -48,7 +48,7 @@ impl EngineAwareInformation for Metadata {
   type MaybeOutput = Vec<(String, Value)>;
 
   fn retrieve(_types: &Types, value: &Value) -> Option<Self::MaybeOutput> {
-    let metadata_val = match externs::call_method(&value, "metadata", &[]) {
+    let metadata_val = match externs::call_method(value, "metadata", &[]) {
       Ok(value) => value,
       Err(py_err) => {
         let failure = Failure::from_py_err(py_err);
@@ -88,7 +88,7 @@ impl EngineAwareInformation for Artifacts {
   type MaybeOutput = Vec<(String, ArtifactOutput)>;
 
   fn retrieve(types: &Types, value: &Value) -> Option<Self::MaybeOutput> {
-    let artifacts_val = match externs::call_method(&value, "artifacts", &[]) {
+    let artifacts_val = match externs::call_method(value, "artifacts", &[]) {
       Ok(value) => value,
       Err(py_err) => {
         let failure = Failure::from_py_err(py_err);
@@ -115,7 +115,7 @@ impl EngineAwareInformation for Artifacts {
       };
 
       let artifact_output = if externs::get_type_for(&value) == types.file_digest {
-        match lift_file_digest(&types, &value) {
+        match lift_file_digest(types, &value) {
           Ok(digest) => ArtifactOutput::FileDigest(digest),
           Err(e) => {
             log::error!("Error in EngineAware.artifacts() implementation: {}", e);
@@ -149,7 +149,7 @@ impl EngineAwareInformation for DebugHint {
   type MaybeOutput = String;
 
   fn retrieve(_types: &Types, value: &Value) -> Option<String> {
-    externs::call_method(&value, "debug_hint", &[])
+    externs::call_method(value, "debug_hint", &[])
       .ok()
       .and_then(externs::check_for_python_none)
       .map(|val| externs::val_to_str(&val))

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1008,7 +1008,7 @@ async fn workunit_to_py_value(
     let store = core.store();
     let py_val = match digest {
       ArtifactOutput::FileDigest(digest) => {
-        crate::nodes::Snapshot::store_file_digest(&core, digest)
+        crate::nodes::Snapshot::store_file_digest(core, digest)
       }
       ArtifactOutput::Snapshot(digest) => {
         let snapshot = store::Snapshot::from_digest(store, *digest)
@@ -1135,14 +1135,14 @@ fn session_poll_workunits(
             let started = core.executor.block_on(workunits_to_py_tuple_value(
               &mut started_iter,
               &scheduler.core,
-              &session,
+              session,
             ))?;
 
             let mut completed_iter = completed.iter();
             let completed = core.executor.block_on(workunits_to_py_tuple_value(
               &mut completed_iter,
               &scheduler.core,
-              &session,
+              session,
             ))?;
 
             Ok(externs::store_tuple(vec![started, completed]).into())
@@ -1600,12 +1600,12 @@ fn capture_snapshots(
       let path_globs_and_roots = values
         .iter()
         .map(|value| {
-          let root = PathBuf::from(externs::getattr_as_string(&value, "root"));
+          let root = PathBuf::from(externs::getattr_as_string(value, "root"));
           let path_globs = nodes::Snapshot::lift_prepared_path_globs(
-            &externs::getattr(&value, "path_globs").unwrap(),
+            &externs::getattr(value, "path_globs").unwrap(),
           );
           let digest_hint = {
-            let maybe_digest: PyObject = externs::getattr(&value, "digest_hint").unwrap();
+            let maybe_digest: PyObject = externs::getattr(value, "digest_hint").unwrap();
             if maybe_digest == externs::none() {
               None
             } else {
@@ -1964,7 +1964,7 @@ where
   F: FnOnce(&Executor) -> T,
 {
   let executor = executor_ptr.executor(py);
-  f(&executor)
+  f(executor)
 }
 
 ///
@@ -1975,7 +1975,7 @@ where
   F: FnOnce(&Session) -> T,
 {
   let session = session_ptr.session(py);
-  f(&session)
+  f(session)
 }
 
 ///
@@ -1987,7 +1987,7 @@ where
 {
   let nailgun_server = nailgun_server_ptr.server(py);
   let executor = nailgun_server_ptr.executor(py);
-  f(&nailgun_server, executor)
+  f(nailgun_server, executor)
 }
 
 ///

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1007,9 +1007,7 @@ async fn workunit_to_py_value(
   for (artifact_name, digest) in workunit.metadata.artifacts.iter() {
     let store = core.store();
     let py_val = match digest {
-      ArtifactOutput::FileDigest(digest) => {
-        crate::nodes::Snapshot::store_file_digest(core, digest)
-      }
+      ArtifactOutput::FileDigest(digest) => crate::nodes::Snapshot::store_file_digest(core, digest),
       ArtifactOutput::Snapshot(digest) => {
         let snapshot = store::Snapshot::from_digest(store, *digest)
           .await

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -226,7 +226,7 @@ pub fn getattr_as_string(value: &PyObject, field: &str) -> String {
 }
 
 pub fn key_to_str(key: &Key) -> String {
-  val_to_str(&val_for(key).as_ref())
+  val_to_str(val_for(key).as_ref())
 }
 
 pub fn type_to_str(type_id: TypeId) -> String {

--- a/src/rust/engine/src/interning.rs
+++ b/src/rust/engine/src/interning.rs
@@ -75,26 +75,21 @@ impl Interns {
   pub fn key_get(&self, k: &Key) -> Value {
     // NB: We do not need to acquire+release the GIL before getting a Value for a Key, because
     // neither `Key::eq` nor `Value::clone` acquire the GIL.
-    self
-      .reverse_keys
-      .read()
-      .get(k)
-      .cloned()
-      .unwrap_or_else(|| {
-        // N.B.: This panic is effectively an assertion that `Key::new` is only ever called above in
-        // `key_insert` under an exclusive lock where it is then inserted in `reverse_keys` before
-        // exiting the lock and being returned to the caller. This ensures that all `Key`s in the
-        // wild _must_ be in `reverse_keys`. As such, the code involved in generating the panic
-        // message should be immaterial and never fire. If it does fire though, then the assertion
-        // was proven incorrect and the `Key` is not, in fact, in `reverse_keys`. Since the `Debug`
-        // impl for `Key` currently uses this very method to render the `Key` we avoid using the
-        // debug formatting for `Key` to avoid generating a panic while panicking.
-        panic!(
-          "Previously memoized object disappeared for Key {{ id: {}, type_id: {} }}!",
-          k.id(),
-          k.type_id()
-        )
-      })
+    self.reverse_keys.read().get(k).cloned().unwrap_or_else(|| {
+      // N.B.: This panic is effectively an assertion that `Key::new` is only ever called above in
+      // `key_insert` under an exclusive lock where it is then inserted in `reverse_keys` before
+      // exiting the lock and being returned to the caller. This ensures that all `Key`s in the
+      // wild _must_ be in `reverse_keys`. As such, the code involved in generating the panic
+      // message should be immaterial and never fire. If it does fire though, then the assertion
+      // was proven incorrect and the `Key` is not, in fact, in `reverse_keys`. Since the `Debug`
+      // impl for `Key` currently uses this very method to render the `Key` we avoid using the
+      // debug formatting for `Key` to avoid generating a panic while panicking.
+      panic!(
+        "Previously memoized object disappeared for Key {{ id: {}, type_id: {} }}!",
+        k.id(),
+        k.type_id()
+      )
+    })
   }
 }
 

--- a/src/rust/engine/src/interning.rs
+++ b/src/rust/engine/src/interning.rs
@@ -78,7 +78,7 @@ impl Interns {
     self
       .reverse_keys
       .read()
-      .get(&k)
+      .get(k)
       .cloned()
       .unwrap_or_else(|| {
         // N.B.: This panic is effectively an assertion that `Key::new` is only ever called above in

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -238,11 +238,11 @@ pub fn lift_directory_digest(digest: &PyObject) -> Result<hashing::Digest, Strin
 }
 
 pub fn lift_file_digest(types: &Types, digest: &PyObject) -> Result<hashing::Digest, String> {
-  if types.file_digest != externs::get_type_for(&digest) {
+  if types.file_digest != externs::get_type_for(digest) {
     return Err(format!("{} is not of type {}.", digest, types.file_digest));
   }
-  let fingerprint = externs::getattr_as_string(&digest, "fingerprint");
-  let digest_length: usize = externs::getattr(&digest, "serialized_bytes_length").unwrap();
+  let fingerprint = externs::getattr_as_string(digest, "fingerprint");
+  let digest_length: usize = externs::getattr(digest, "serialized_bytes_length").unwrap();
   Ok(hashing::Digest::new(
     hashing::Fingerprint::from_hex_string(&fingerprint)?,
     digest_length,
@@ -259,10 +259,10 @@ pub struct MultiPlatformExecuteProcess {
 
 impl MultiPlatformExecuteProcess {
   fn lift_process(value: &Value, platform_constraint: Option<Platform>) -> Result<Process, String> {
-    let env = externs::getattr_from_frozendict(&value, "env");
+    let env = externs::getattr_from_frozendict(value, "env");
 
     let working_directory = {
-      let val = externs::getattr_as_string(&value, "working_directory");
+      let val = externs::getattr_as_string(value, "working_directory");
       if val.is_empty() {
         None
       } else {
@@ -270,23 +270,23 @@ impl MultiPlatformExecuteProcess {
       }
     };
 
-    let py_digest: Value = externs::getattr(&value, "input_digest").unwrap();
+    let py_digest: Value = externs::getattr(value, "input_digest").unwrap();
     let digest =
       lift_directory_digest(&py_digest).map_err(|err| format!("Error parsing digest {}", err))?;
 
-    let output_files = externs::getattr::<Vec<String>>(&value, "output_files")
+    let output_files = externs::getattr::<Vec<String>>(value, "output_files")
       .unwrap()
       .into_iter()
       .map(RelativePath::new)
       .collect::<Result<_, _>>()?;
 
-    let output_directories = externs::getattr::<Vec<String>>(&value, "output_directories")
+    let output_directories = externs::getattr::<Vec<String>>(value, "output_directories")
       .unwrap()
       .into_iter()
       .map(RelativePath::new)
       .collect::<Result<_, _>>()?;
 
-    let timeout_in_seconds: f64 = externs::getattr(&value, "timeout_seconds").unwrap();
+    let timeout_in_seconds: f64 = externs::getattr(value, "timeout_seconds").unwrap();
 
     let timeout = if timeout_in_seconds < 0.0 {
       None
@@ -294,17 +294,17 @@ impl MultiPlatformExecuteProcess {
       Some(Duration::from_millis((timeout_in_seconds * 1000.0) as u64))
     };
 
-    let description = externs::getattr_as_string(&value, "description");
-    let py_level: PyObject = externs::getattr(&value, "level").unwrap();
+    let description = externs::getattr_as_string(value, "description");
+    let py_level: PyObject = externs::getattr(value, "level").unwrap();
     let level = externs::val_to_log_level(&py_level)?;
 
-    let append_only_caches = externs::getattr_from_frozendict(&value, "append_only_caches")
+    let append_only_caches = externs::getattr_from_frozendict(value, "append_only_caches")
       .into_iter()
       .map(|(name, dest)| Ok((CacheName::new(name)?, CacheDest::new(dest)?)))
       .collect::<Result<_, String>>()?;
 
     let jdk_home = {
-      let val = externs::getattr_as_string(&value, "jdk_home");
+      let val = externs::getattr_as_string(value, "jdk_home");
       if val.is_empty() {
         None
       } else {
@@ -312,10 +312,10 @@ impl MultiPlatformExecuteProcess {
       }
     };
 
-    let is_nailgunnable: bool = externs::getattr(&value, "is_nailgunnable").unwrap();
+    let is_nailgunnable: bool = externs::getattr(value, "is_nailgunnable").unwrap();
 
     let execution_slot_variable = {
-      let s = externs::getattr_as_string(&value, "execution_slot_variable");
+      let s = externs::getattr_as_string(value, "execution_slot_variable");
       if s.is_empty() {
         None
       } else {
@@ -324,11 +324,11 @@ impl MultiPlatformExecuteProcess {
     };
 
     let cache_scope =
-      externs::getattr_as_string(&externs::getattr(&value, "cache_scope").unwrap(), "name")
+      externs::getattr_as_string(&externs::getattr(value, "cache_scope").unwrap(), "name")
         .try_into()?;
 
     Ok(process_execution::Process {
-      argv: externs::getattr(&value, "argv").unwrap(),
+      argv: externs::getattr(value, "argv").unwrap(),
       env,
       working_directory,
       input_files: digest,
@@ -347,7 +347,7 @@ impl MultiPlatformExecuteProcess {
   }
 
   pub fn lift(value: &Value) -> Result<MultiPlatformExecuteProcess, String> {
-    let raw_constraints = externs::getattr::<Vec<Option<String>>>(&value, "platform_constraints")?;
+    let raw_constraints = externs::getattr::<Vec<Option<String>>>(value, "platform_constraints")?;
     let constraints = raw_constraints
       .into_iter()
       .map(|maybe_plat| match maybe_plat {
@@ -355,7 +355,7 @@ impl MultiPlatformExecuteProcess {
         None => Ok(None),
       })
       .collect::<Result<Vec<_>, _>>()?;
-    let processes = externs::getattr::<Vec<Value>>(&value, "processes")?;
+    let processes = externs::getattr::<Vec<Value>>(value, "processes")?;
     if constraints.len() != processes.len() {
       return Err(format!(
         "Sizes of constraint keys and processes do not match: {} vs. {}",
@@ -882,7 +882,7 @@ impl DownloadedFile {
     if url.scheme() == "file" {
       return Ok(Box::new(FileDownload::start(url.path(), file_name).await?));
     }
-    Ok(Box::new(NetDownload::start(&core, url, file_name).await?))
+    Ok(Box::new(NetDownload::start(core, url, file_name).await?))
   }
 
   async fn download(

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -283,11 +283,11 @@ impl Scheduler {
       let (result, last_observed) = context
         .core
         .graph
-        .poll(root.into(), last_observed, poll_delay, &context)
+        .poll(root.into(), last_observed, poll_delay, context)
         .await?;
       (result, Some(last_observed))
     } else {
-      let result = context.core.graph.create(root.into(), &context).await?;
+      let result = context.core.graph.create(root.into(), context).await?;
       (result, None)
     };
 
@@ -391,7 +391,7 @@ impl Scheduler {
           }
           res = &mut execution_task => {
             // Completed successfully.
-            break Ok(Self::execute_record_results(&request.roots, &session, res));
+            break Ok(Self::execute_record_results(&request.roots, session, res));
           }
         }
       };

--- a/src/rust/engine/watch/src/lib.rs
+++ b/src/rust/engine/watch/src/lib.rs
@@ -133,7 +133,7 @@ impl InvalidationWatcher {
       .expect("An InvalidationWatcher can only be started once.");
 
     InvalidationWatcher::start_background_thread(
-      Arc::downgrade(&invalidatable),
+      Arc::downgrade(invalidatable),
       ignorer,
       canonical_build_root,
       liveness_sender,

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -453,7 +453,7 @@ impl HeavyHittersData {
       ) {
         let workunit = inner.workunit_records.get(&span_id).unwrap();
         if let Some(effective_name) = workunit.metadata.desc.as_ref() {
-          let maybe_duration = Self::duration_for(now, &workunit);
+          let maybe_duration = Self::duration_for(now, workunit);
 
           res.insert(effective_name.to_string(), maybe_duration);
           if res.len() >= k {
@@ -534,7 +534,7 @@ fn first_matched_parent(
   while let Some(current_span_id) = span_id {
     let workunit = workunit_records.get(&current_span_id);
 
-    if let Some(ref workunit) = workunit {
+    if let Some(workunit) = workunit {
       // Should we continue visiting parents?
       if is_terminal(workunit) {
         break;
@@ -756,7 +756,7 @@ impl WorkunitStore {
       let mut writer = BytesMut::new().writer();
 
       serializer
-        .serialize(&histogram, &mut writer)
+        .serialize(histogram, &mut writer)
         .map_err(|err| {
           format!(
             "Failed to encode histogram for key `{}`: {}",


### PR DESCRIPTION
Upgrade to Rust v1.54.0. [Announcement](https://blog.rust-lang.org/2021/07/29/Rust-1.54.0.html)

Changes to satisfy Clippy:

- Avoid borrows with an immediate implicit dereference. 
- Allow `needless_collect` in two places since making the suggested change resulted in a borrow checker error.
- Rename two fields that are stored to allow execution of a non-trivial `Drop` impl later that would otherwise be dead code and need '#[allow(dead_code)]`.