### PR TITLE
Upgrade to Lambdex 0.1.5.

### DIFF
--- a/src/python/pants/backend/awslambda/python/lambdex.py
+++ b/src/python/pants/backend/awslambda/python/lambdex.py
@@ -16,7 +16,7 @@ class Lambdex(PythonToolBase):
     options_scope = "lambdex"
     help = "A tool for turning .pex files into AWS Lambdas (https://github.com/wickman/lambdex)."
 
-    default_version = "lambdex==0.1.4"
+    default_version = "lambdex==0.1.5"
     default_main = ConsoleScript("lambdex")
 
     register_interpreter_constraints = True

--- a/src/python/pants/backend/awslambda/python/lambdex_lockfile.txt
+++ b/src/python/pants/backend/awslambda/python/lambdex_lockfile.txt
@@ -6,9 +6,9 @@
 #
 #    pip-compile --allow-unsafe --generate-hashes --output-file=src/python/pants/backend/awslambda/python/lambdex_lockfile.txt reqs.txt
 #
-lambdex==0.1.4 \
-    --hash=sha256:189e3f7aa492fd3653a6dcafb7bb493d2fa60a32f6ab8122c2ee53feb97967cc \
-    --hash=sha256:51e4e92a20cf1472e560b7b5a927286308d9e6252261a79d94b8549a3ba39bd3
+lambdex==0.1.5 \
+    --hash=sha256:29820f36a118ef38f7730c59da7920f3009cadb5651a3779a958f8797013c88b \
+    --hash=sha256:fad0d3bbeeabd9d6d9f9eaee2ac96c18c3300f880563d130e06b873db450f26f
     # via -r reqs.txt
 pex==2.1.44 \
     --hash=sha256:2916e8f76e3e00b958572f42fb3ecf7fc0a19a378f73028067a4724be39193a6 \


### PR DESCRIPTION
This picks up support for `LAMBDEX_ENTRY_POINT`:
  https://github.com/pantsbuild/lambdex/blob/main/CHANGES.md#015

[ci skip-rust]
[ci skip-build-wheels]