### PR TITLE
add counters for blob bytes uploaded/downloaded to/from CAS (cherrypick of #12471)

### DIFF
--- a/src/rust/engine/workunit_store/src/metrics.rs
+++ b/src/rust/engine/workunit_store/src/metrics.rs
@@ -73,6 +73,10 @@ pub enum Metric {
   RemoteExecutionSuccess,
   RemoteExecutionTimeouts,
   RemoteStoreMissingDigest,
+  /// Total number of bytes of blobs downloaded from a remote CAS.
+  RemoteStoreBlobBytesDownloaded,
+  /// Total number of bytes of blobs uploaded to a remote CAS.
+  RemoteStoreBlobBytesUploaded,
 }
 
 impl Metric {


### PR DESCRIPTION
Add counters to track the number of bytes uploaded to, or downloaded from, a remote CAS for blobs.

[ci skip-build-wheels]