### PR TITLE
Fix default coverage collection.

### DIFF
--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -122,11 +122,12 @@ class CoverageSubsystem(PythonToolBase):
             member_type=str,
             default=None,
             help=(
-                "A list of Python modules to use in the coverage report, e.g. "
-                "`['helloworld_test', 'helloworld.util.dirutil'].\n\nThe modules are recursive: "
-                "any submodules will be included.\n\nIf you leave this off, the coverage report "
-                "will include every file in the transitive closure of the address/file arguments; "
-                "for example, `test ::` will include every Python file in your project, whereas "
+                "A list of Python modules or filesystem paths to use in the coverage report, e.g. "
+                "`['helloworld_test', 'helloworld/util/dirutil'].\n\nBoth modules and directory "
+                "paths are recursive: any submodules or child paths, respectively, will be "
+                "included.\n\nIf you leave this off, the coverage report will include every file "
+                "in the transitive closure of the address/file arguments; for example, `test ::` "
+                "will include every Python file in your project, whereas "
                 "`test project/app_test.py` will include `app_test.py` and any of its transitive "
                 "dependencies."
             ),

--- a/src/python/pants/backend/python/goals/coverage_py_integration_test.py
+++ b/src/python/pants/backend/python/goals/coverage_py_integration_test.py
@@ -282,7 +282,6 @@ def test_default_coverage_issues_12390() -> None:
         result = run_pants(command)
         result.assert_success()
 
-    print(result.stderr)
     assert (
         dedent(
             f"""\

--- a/src/python/pants/backend/python/goals/coverage_py_integration_test.py
+++ b/src/python/pants/backend/python/goals/coverage_py_integration_test.py
@@ -140,13 +140,14 @@ def test_coverage() -> None:
             {tmpdir}/src/python/project/__init__.py                        0      0   100%
             {tmpdir}/src/python/project/lib.py                             6      0   100%
             {tmpdir}/src/python/project/lib_test.py                        3      0   100%
+            {tmpdir}/src/python/project/random.py                          2      2     0%
             {tmpdir}/tests/python/project_test/__init__.py                 0      0   100%
             {tmpdir}/tests/python/project_test/no_src/__init__.py          0      0   100%
             {tmpdir}/tests/python/project_test/no_src/test_no_src.py       2      0   100%
             {tmpdir}/tests/python/project_test/test_arithmetic.py          3      0   100%
             {tmpdir}/tests/python/project_test/test_multiply.py            3      0   100%
             ---------------------------------------------------------------------------------
-            TOTAL                                                            17      0   100%
+            TOTAL                                                            19      2    89%
             """
         )
         in result.stderr


### PR DESCRIPTION
Previously, the combination of collecting relative_paths and passing
`--cov=.` to pytest-cov could lead to coverage collection of invalid
paths (namely: "(builtin)") which would cause coverage report generation
to fail. Fix this by restricting coverage to the source roots of the
code under test. This also solves a regression introduced by #10165.

Fixes #12390

[ci skip-rust]
[ci skip-build-wheels]