### PR TITLE
Tailor pex_binary targets for entry points.

### DIFF
--- a/src/python/pants/backend/python/goals/tailor.py
+++ b/src/python/pants/backend/python/goals/tailor.py
@@ -4,10 +4,22 @@
 from __future__ import annotations
 
 import os
+import re
 from dataclasses import dataclass
+from pathlib import PurePath
 from typing import Iterable
 
-from pants.backend.python.target_types import PythonLibrary, PythonTests, PythonTestsSources
+from pants.backend.python.dependency_inference.module_mapper import PythonModule
+from pants.backend.python.target_types import (
+    PexBinary,
+    PexEntryPointField,
+    PythonLibrary,
+    PythonTests,
+    PythonTestsSources,
+    ResolvedPexEntryPoint,
+    ResolvePexEntryPointRequest,
+)
+from pants.base.specs import AddressSpecs, AscendantAddresses
 from pants.core.goals.tailor import (
     AllOwnedSources,
     PutativeTarget,
@@ -15,13 +27,14 @@ from pants.core.goals.tailor import (
     PutativeTargetsRequest,
     group_by_dir,
 )
-from pants.engine.fs import PathGlobs, Paths
-from pants.engine.internals.selectors import Get
+from pants.engine.fs import DigestContents, PathGlobs, Paths
+from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import collect_rules, rule
-from pants.engine.target import Target
+from pants.engine.target import Target, UnexpandedTargets
 from pants.engine.unions import UnionRule
 from pants.python.python_setup import PythonSetup
 from pants.source.filespec import Filespec, matches_filespec
+from pants.source.source_root import SourceRootsRequest, SourceRootsResult
 from pants.util.logging import LogLevel
 
 
@@ -41,13 +54,30 @@ def classify_source_files(paths: Iterable[str]) -> dict[type[Target], set[str]]:
     return {PythonTests: test_files, PythonLibrary: library_files}
 
 
+# The order "__main__" == __name__ would also technically work, but is very
+# non-idiomatic, so we ignore it.
+_entry_point_re = re.compile(rb"^if __name__ +== +['\"]__main__['\"]: *(#.*)?$", re.MULTILINE)
+
+
+def is_entry_point(content: bytes) -> bool:
+    # Identify files that look like entry points.  We use a regex for speed, as it will catch
+    # almost all correct cases in practice, with extremely rare false positives (we will only
+    # have a false positive if the matching code is in a multiline string indented all the way
+    # to the left). Looking at the ast would be more correct, technically, but also more laborious,
+    # trickier to implement correctly for different interpreter versions, and much slower.
+    return _entry_point_re.search(content) is not None
+
+
 @rule(level=LogLevel.DEBUG, desc="Determine candidate Python targets to create")
 async def find_putative_targets(
     req: PutativePythonTargetsRequest,
     all_owned_sources: AllOwnedSources,
     python_setup: PythonSetup,
 ) -> PutativeTargets:
-    all_py_files = await Get(Paths, PathGlobs, req.search_paths.path_globs("*.py"))
+    # Find library/test targets.
+
+    all_py_files_globs: PathGlobs = req.search_paths.path_globs("*.py")
+    all_py_files = await Get(Paths, PathGlobs, all_py_files_globs)
     unowned_py_files = set(all_py_files.files) - set(all_owned_sources)
     classified_unowned_py_files = classify_source_files(unowned_py_files)
     pts = []
@@ -66,6 +96,62 @@ async def find_putative_targets(
                     tgt_type, dirname, name, sorted(filenames), kwargs=kwargs
                 )
             )
+
+    if python_setup.tailor_pex_binary_targets:
+        # Find binary targets.
+
+        # Get all files whose content indicates that they are entry points.
+        digest_contents = await Get(DigestContents, PathGlobs, all_py_files_globs)
+        entry_points = [
+            file_content.path
+            for file_content in digest_contents
+            if is_entry_point(file_content.content)
+        ]
+
+        # Get the modules for these entry points.
+        src_roots = await Get(
+            SourceRootsResult, SourceRootsRequest, SourceRootsRequest.for_files(entry_points)
+        )
+        module_to_entry_point = {}
+        for entry_point in entry_points:
+            entry_point_path = PurePath(entry_point)
+            src_root = src_roots.path_to_root[entry_point_path]
+            stripped_entry_point = entry_point_path.relative_to(src_root.path)
+            module = PythonModule.create_from_stripped_path(stripped_entry_point)
+            module_to_entry_point[module.module] = entry_point
+
+        # Get existing binary targets for these entry points.
+        entry_point_dirs = {os.path.dirname(entry_point) for entry_point in entry_points}
+        possible_existing_binary_targets = await Get(
+            UnexpandedTargets, AddressSpecs(AscendantAddresses(d) for d in entry_point_dirs)
+        )
+        possible_existing_binary_entry_points = await MultiGet(
+            Get(ResolvedPexEntryPoint, ResolvePexEntryPointRequest(t[PexEntryPointField]))
+            for t in possible_existing_binary_targets
+            if t.has_field(PexEntryPointField)
+        )
+        possible_existing_entry_point_modules = {
+            rep.val.module for rep in possible_existing_binary_entry_points if rep.val
+        }
+        unowned_entry_point_modules = (
+            module_to_entry_point.keys() - possible_existing_entry_point_modules
+        )
+
+        # Generate new targets for entry points that don't already have one.
+        for entry_point_module in unowned_entry_point_modules:
+            entry_point = module_to_entry_point[entry_point_module]
+            path, fname = os.path.split(entry_point)
+            name = os.path.splitext(fname)[0]
+            pts.append(
+                PutativeTarget.for_target_type(
+                    target_type=PexBinary,
+                    path=path,
+                    name=name,
+                    triggering_sources=tuple(),
+                    kwargs={"name": name, "entry_point": fname},
+                )
+            )
+
     return PutativeTargets(pts)
 
 

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -166,6 +166,14 @@ class PythonSetup(Subsystem):
             "__init__.py and there are no other .py files in the package.",
         )
 
+        register(
+            "--tailor-pex-binary-targets",
+            type=bool,
+            default=True,
+            advanced=True,
+            help="Tailor pex_binary() targets for Python entry point files.",
+        )
+
     @property
     def interpreter_constraints(self) -> Tuple[str, ...]:
         return tuple(self.options.interpreter_constraints)
@@ -208,6 +216,10 @@ class PythonSetup(Subsystem):
     @property
     def tailor_ignore_solitary_init_files(self) -> bool:
         return cast(bool, self.options.tailor_ignore_solitary_init_files)
+
+    @property
+    def tailor_pex_binary_targets(self) -> bool:
+        return cast(bool, self.options.tailor_pex_binary_targets)
 
     @property
     def scratch_dir(self):


### PR DESCRIPTION
A .py file with the `if __name__ == "__main__"` stanza is considered an entry point. 
We generate pex_binary targets for all entry points that don't already have one. 

There is an option to serve as an escape hatch if this behavior is undesirable to some.

[ci skip-rust]

[ci skip-build-wheels]