### PR TITLE
Go: dependency inference for packages

### DIFF
--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -9,7 +9,6 @@ from pants.backend.go.pkg import ResolvedGoPackage, ResolveGoPackageRequest
 from pants.backend.go.target_types import (
     GoExternalModule,
     GoImportPath,
-    GoModuleDependencies,
     GoPackageDependencies,
     GoPackageSources,
 )
@@ -47,18 +46,14 @@ async def inject_go_package_dependencies(
         return InjectedDependencies()
 
 
-# Inject dependencies from a go_module to any referenced go_external_module targets.
-class InjectGoModuleDependenciesRequest(InjectDependenciesRequest):
-    inject_for = GoModuleDependencies
-
-
-class InferGoDependenciesRequest(InferDependenciesRequest):
+class InferGoPackageDependenciesRequest(InferDependenciesRequest):
     infer_from = GoPackageSources
 
 
 @rule
 async def infer_go_dependencies(
-    request: InferGoDependenciesRequest, goroot_imports: ResolvedImportPathsForGoLangDistribution
+    request: InferGoPackageDependenciesRequest,
+    goroot_imports: ResolvedImportPathsForGoLangDistribution,
 ) -> InferredDependencies:
     this_go_package = await Get(
         ResolvedGoPackage, ResolveGoPackageRequest(request.sources_field.address)
@@ -149,5 +144,5 @@ def rules():
         *pkg.rules(),
         *import_analysis.rules(),
         UnionRule(InjectDependenciesRequest, InjectGoPackageDependenciesRequest),
-        UnionRule(InferDependenciesRequest, InferGoDependenciesRequest),
+        UnionRule(InferDependenciesRequest, InferGoPackageDependenciesRequest),
     )

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -4,9 +4,20 @@ import logging
 
 from pants.backend.go import import_analysis, pkg
 from pants.backend.go.import_analysis import ResolvedImportPathsForGoLangDistribution
-from pants.backend.go.module import FindNearestGoModuleRequest, ResolvedOwningGoModule
+from pants.backend.go.module import (
+    FindNearestGoModuleRequest,
+    ResolvedGoModule,
+    ResolvedOwningGoModule,
+    ResolveGoModuleRequest,
+)
 from pants.backend.go.pkg import ResolvedGoPackage, ResolveGoPackageRequest
-from pants.backend.go.target_types import GoPackageDependencies, GoPackageSources
+from pants.backend.go.target_types import (
+    GoExternalModule,
+    GoImportPath,
+    GoModuleDependencies,
+    GoPackageDependencies,
+    GoPackageSources,
+)
 from pants.base.specs import AddressSpecs, MaybeEmptyDescendantAddresses, MaybeEmptySiblingAddresses
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import collect_rules, rule
@@ -22,12 +33,15 @@ from pants.engine.unions import UnionRule
 logger = logging.getLogger(__name__)
 
 
-class InjectGoModuleDependency(InjectDependenciesRequest):
+# Inject a dependency between a go_package and its owning go_module.
+class InjectGoPackageDependenciesRequest(InjectDependenciesRequest):
     inject_for = GoPackageDependencies
 
 
 @rule
-async def inject_go_module_dependency(request: InjectGoModuleDependency) -> InjectedDependencies:
+async def inject_go_package_dependencies(
+    request: InjectGoPackageDependenciesRequest,
+) -> InjectedDependencies:
     owning_go_module_result = await Get(
         ResolvedOwningGoModule,
         FindNearestGoModuleRequest(request.dependencies_field.address.spec_path),
@@ -36,6 +50,11 @@ async def inject_go_module_dependency(request: InjectGoModuleDependency) -> Inje
         return InjectedDependencies([owning_go_module_result.module_address])
     else:
         return InjectedDependencies()
+
+
+# Inject dependencies from a go_module to any referenced go_external_module targets.
+class InjectGoModuleDependenciesRequest(InjectDependenciesRequest):
+    inject_for = GoModuleDependencies
 
 
 class InferGoDependenciesRequest(InferDependenciesRequest):
@@ -67,8 +86,25 @@ async def infer_go_dependencies(
     ]
     print(f"go_package_targets={go_package_targets}")
 
+    # TODO: Use MultiGet if possible to process modules concurrently.
+    resolved_go_module = await Get(
+        ResolvedGoModule, ResolveGoModuleRequest(this_go_package.module_address)
+    )
+
+    # Find all go_external_modules in the repo and map their import paths to their address.
+    candidate_go_external_module_targets = await Get(
+        UnexpandedTargets, AddressSpecs([MaybeEmptyDescendantAddresses("")])
+    )
+    go_external_module_targets = [
+        tgt for tgt in candidate_go_external_module_targets if isinstance(tgt, GoExternalModule)
+    ]
+    third_party_import_path_to_address = {
+        tgt[GoImportPath].value: tgt.address for tgt in go_external_module_targets
+    }
+    print(f"third_party_import_path_to_address={third_party_import_path_to_address}")
+
     # Resolve all of the packages found.
-    import_path_to_pkg_address = {}
+    first_party_import_path_to_address = {}
     resolved_go_packages = await MultiGet(
         Get(ResolvedGoPackage, ResolveGoPackageRequest(tgt.address)) for tgt in go_package_targets
     )
@@ -83,25 +119,42 @@ async def infer_go_dependencies(
             )
             continue
 
-        import_path_to_pkg_address[pkg.import_path] = pkg.address
+        first_party_import_path_to_address[pkg.import_path] = pkg.address
 
-    print(f"import_path_to_pkg_address={import_path_to_pkg_address}")
+    print(f"first_party_import_path_to_address={first_party_import_path_to_address}")
 
-    # Loop through all of the imports of this package and add dependencies on other packages automatically.
+    # Loop through all of the imports of this package and add dependencies on other packages and
+    # external modules.
     inferred_dependencies = []
     for import_path in this_go_package.imports + this_go_package.test_imports:
         # Check whether the import path comes from the standard library.
         if import_path in goroot_imports.import_path_mapping:
             continue
 
-        # Otherwise check whether the import comes from other packages in this module.
-        if import_path in import_path_to_pkg_address:
-            inferred_dependencies.append(import_path_to_pkg_address[import_path])
-        else:
-            raise ValueError(
-                f"Unable to infer dependency for import path {import_path} "
-                f"in go_package at address '{this_go_package.address}'"
-            )
+        # Infer first-party dependencies to other packages in same go_module.
+        if import_path in first_party_import_path_to_address:
+            inferred_dependencies.append(first_party_import_path_to_address[import_path])
+            continue
+
+        # Infer third-party dependencies on go_external_module targets.
+        found_module_import = False
+        for module_import_path, address in third_party_import_path_to_address.items():
+            # TODO: This check naively assumes that the import path for the external module is a prefix of any package
+            # from the external module and that the import path will never overlap with another external module's
+            # import path. This may be the case, but bears investigation. One problem could be how to handle multiple
+            # major versions which have separate import paths.
+            print(f"module_import_path='{module_import_path}'\nimport_path='{import_path}'")
+            if import_path.startswith(module_import_path):
+                inferred_dependencies.append(address)
+                found_module_import = True
+
+        if found_module_import:
+            continue
+
+        raise ValueError(
+            f"Unable to infer dependency for import path '{import_path}' "
+            f"in go_package at address '{this_go_package.address}'."
+        )
 
     return InferredDependencies(inferred_dependencies, sibling_dependencies_inferrable=False)
 
@@ -111,6 +164,6 @@ def rules():
         *collect_rules(),
         *pkg.rules(),
         *import_analysis.rules(),
-        UnionRule(InjectDependenciesRequest, InjectGoModuleDependency),
+        UnionRule(InjectDependenciesRequest, InjectGoPackageDependenciesRequest),
         UnionRule(InferDependenciesRequest, InferGoDependenciesRequest),
     )

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -50,6 +50,8 @@ class InferGoPackageDependenciesRequest(InferDependenciesRequest):
     infer_from = GoPackageSources
 
 
+# TODO: Refactor this rule so as much as possible is memoized by invoking other rules. Consider
+# for example `FirstPartyPythonModuleMapping` and `ThirdPartyPythonModuleMapping`.
 @rule
 async def infer_go_dependencies(
     request: InferGoPackageDependenciesRequest,

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -1,12 +1,25 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+import logging
+
+from pants.backend.go import import_analysis, pkg
+from pants.backend.go.import_analysis import ResolvedImportPathsForGoLangDistribution
 from pants.backend.go.module import FindNearestGoModuleRequest, ResolvedOwningGoModule
-from pants.backend.go.pkg import ResolveGoPackageRequest, ResolvedGoPackage
-from pants.backend.go.target_types import GoPackageDependencies
-from pants.engine.internals.selectors import Get
+from pants.backend.go.pkg import ResolvedGoPackage, ResolveGoPackageRequest
+from pants.backend.go.target_types import GoPackageDependencies, GoPackageSources
+from pants.base.specs import AddressSpecs, MaybeEmptyDescendantAddresses, MaybeEmptySiblingAddresses
+from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import collect_rules, rule
-from pants.engine.target import InjectDependenciesRequest, InjectedDependencies
+from pants.engine.target import (
+    InferDependenciesRequest,
+    InferredDependencies,
+    InjectDependenciesRequest,
+    InjectedDependencies,
+    UnexpandedTargets,
+)
 from pants.engine.unions import UnionRule
+
+logger = logging.getLogger(__name__)
 
 
 class InjectGoModuleDependency(InjectDependenciesRequest):
@@ -15,9 +28,6 @@ class InjectGoModuleDependency(InjectDependenciesRequest):
 
 @rule
 async def inject_go_module_dependency(request: InjectGoModuleDependency) -> InjectedDependencies:
-    # Resolve the package.
-    resolved_go_package = await Get(ResolvedGoPackage, ResolveGoPackageRequest(request.dependencies_field.address.spec_path))
-
     owning_go_module_result = await Get(
         ResolvedOwningGoModule,
         FindNearestGoModuleRequest(request.dependencies_field.address.spec_path),
@@ -28,10 +38,79 @@ async def inject_go_module_dependency(request: InjectGoModuleDependency) -> Inje
         return InjectedDependencies()
 
 
+class InferGoDependenciesRequest(InferDependenciesRequest):
+    infer_from = GoPackageSources
+
+
+@rule
+async def infer_go_dependencies(
+    request: InferGoDependenciesRequest, goroot_imports: ResolvedImportPathsForGoLangDistribution
+) -> InferredDependencies:
+    this_go_package = await Get(
+        ResolvedGoPackage, ResolveGoPackageRequest(request.sources_field.address)
+    )
+    print(f"resolved_go_package={this_go_package}")
+
+    # Obtain all go_package targets under this package's go_module.
+    spec_path = this_go_package.module_address.spec_path
+    address_specs = [
+        MaybeEmptySiblingAddresses(spec_path),
+        MaybeEmptyDescendantAddresses(spec_path),
+    ]
+    candidate_targets = await Get(UnexpandedTargets, AddressSpecs(address_specs))
+    go_package_targets = [
+        tgt
+        for tgt in candidate_targets
+        if tgt.has_field(GoPackageSources)
+        and not tgt.address.is_file_target
+        and tgt.address != this_go_package.address
+    ]
+    print(f"go_package_targets={go_package_targets}")
+
+    # Resolve all of the packages found.
+    import_path_to_pkg_address = {}
+    resolved_go_packages = await MultiGet(
+        Get(ResolvedGoPackage, ResolveGoPackageRequest(tgt.address)) for tgt in go_package_targets
+    )
+    print(f"resolved_go_packages={resolved_go_packages}")
+    for pkg in resolved_go_packages:
+        # Skip packages that are not part of this package's module.
+        # TODO: This requires that all first-party code in the monorepo be part of the same go_module. Will need
+        # figure out how multiple modules in a monorepo can interact.
+        if pkg.module_address != this_go_package.module_address:
+            print(
+                f"Skipping addr={pkg.address} (mod_addr={pkg.module_address}, this_mod_addr={this_go_package.module_address})"
+            )
+            continue
+
+        import_path_to_pkg_address[pkg.import_path] = pkg.address
+
+    print(f"import_path_to_pkg_address={import_path_to_pkg_address}")
+
+    # Loop through all of the imports of this package and add dependencies on other packages automatically.
+    inferred_dependencies = []
+    for import_path in this_go_package.imports + this_go_package.test_imports:
+        # Check whether the import path comes from the standard library.
+        if import_path in goroot_imports.import_path_mapping:
+            continue
+
+        # Otherwise check whether the import comes from other packages in this module.
+        if import_path in import_path_to_pkg_address:
+            inferred_dependencies.append(import_path_to_pkg_address[import_path])
+        else:
+            raise ValueError(
+                f"Unable to infer dependency for import path {import_path} "
+                f"in go_package at address '{this_go_package.address}'"
+            )
+
+    return InferredDependencies(inferred_dependencies, sibling_dependencies_inferrable=False)
 
 
 def rules():
     return (
         *collect_rules(),
+        *pkg.rules(),
+        *import_analysis.rules(),
         UnionRule(InjectDependenciesRequest, InjectGoModuleDependency),
+        UnionRule(InferDependenciesRequest, InferGoDependenciesRequest),
     )

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -1,6 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from pants.backend.go.module import FindNearestGoModuleRequest, ResolvedOwningGoModule
+from pants.backend.go.pkg import ResolveGoPackageRequest, ResolvedGoPackage
 from pants.backend.go.target_types import GoPackageDependencies
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
@@ -14,6 +15,9 @@ class InjectGoModuleDependency(InjectDependenciesRequest):
 
 @rule
 async def inject_go_module_dependency(request: InjectGoModuleDependency) -> InjectedDependencies:
+    # Resolve the package.
+    resolved_go_package = await Get(ResolvedGoPackage, ResolveGoPackageRequest(request.dependencies_field.address.spec_path))
+
     owning_go_module_result = await Get(
         ResolvedOwningGoModule,
         FindNearestGoModuleRequest(request.dependencies_field.address.spec_path),
@@ -22,6 +26,8 @@ async def inject_go_module_dependency(request: InjectGoModuleDependency) -> Inje
         return InjectedDependencies([owning_go_module_result.module_address])
     else:
         return InjectedDependencies()
+
+
 
 
 def rules():

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -132,7 +132,7 @@ async def infer_go_dependencies(
         if found_module_import:
             continue
 
-        raise ValueError(
+        logger.debug(
             f"Unable to infer dependency for import path '{import_path}' "
             f"in go_package at address '{this_go_package.address}'."
         )

--- a/src/python/pants/backend/go/target_type_rules_test.py
+++ b/src/python/pants/backend/go/target_type_rules_test.py
@@ -5,7 +5,7 @@ import textwrap
 import pytest
 
 from pants.backend.go import module, pkg, target_type_rules
-from pants.backend.go.target_type_rules import InferGoDependenciesRequest
+from pants.backend.go.target_type_rules import InferGoPackageDependenciesRequest
 from pants.backend.go.target_types import (
     GoExternalModule,
     GoModule,
@@ -39,7 +39,7 @@ def rule_runner() -> RuleRunner:
             *target_type_rules.rules(),
             QueryRule(Addresses, (DependenciesRequest,)),
             QueryRule(UnexpandedTargets, (Addresses,)),
-            QueryRule(InferredDependencies, (InferGoDependenciesRequest,)),
+            QueryRule(InferredDependencies, (InferGoPackageDependenciesRequest,)),
         ],
         target_types=[GoPackage, GoModule, GoExternalModule],
     )
@@ -128,14 +128,14 @@ def test_go_package_dependency_inference(rule_runner: RuleRunner) -> None:
     )
     target1 = rule_runner.get_target(Address("foo/cmd"))
     inferred_deps_1 = rule_runner.request(
-        InferredDependencies, [InferGoDependenciesRequest(target1[GoPackageSources])]
+        InferredDependencies, [InferGoPackageDependenciesRequest(target1[GoPackageSources])]
     )
     assert inferred_deps_1.dependencies == FrozenOrderedSet([Address("foo/pkg")])
     assert not inferred_deps_1.sibling_dependencies_inferrable
 
     target2 = rule_runner.get_target(Address("foo/pkg"))
     inferred_deps_2 = rule_runner.request(
-        InferredDependencies, [InferGoDependenciesRequest(target2[GoPackageSources])]
+        InferredDependencies, [InferGoPackageDependenciesRequest(target2[GoPackageSources])]
     )
     assert inferred_deps_2.dependencies == FrozenOrderedSet(
         [Address("foo", target_name="github.com_google_go-cmp_0.4.0")]

--- a/src/python/pants/backend/go/target_type_rules_test.py
+++ b/src/python/pants/backend/go/target_type_rules_test.py
@@ -1,15 +1,25 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+import textwrap
+
 import pytest
 
-from pants.backend.go import module, target_type_rules
-from pants.backend.go.target_types import GoModule, GoModuleSources, GoPackage
+from pants.backend.go import module, pkg, target_type_rules
+from pants.backend.go.target_type_rules import InferGoDependenciesRequest
+from pants.backend.go.target_types import GoModule, GoModuleSources, GoPackage, GoPackageSources
 from pants.build_graph.address import Address
 from pants.core.util_rules import external_tool, source_files
 from pants.engine.addresses import Addresses
 from pants.engine.rules import QueryRule
-from pants.engine.target import Dependencies, DependenciesRequest, Target, UnexpandedTargets
+from pants.engine.target import (
+    Dependencies,
+    DependenciesRequest,
+    InferredDependencies,
+    Target,
+    UnexpandedTargets,
+)
 from pants.testutil.rule_runner import RuleRunner
+from pants.util.ordered_set import FrozenOrderedSet
 
 
 @pytest.fixture
@@ -19,9 +29,11 @@ def rule_runner() -> RuleRunner:
             *external_tool.rules(),
             *source_files.rules(),
             *module.rules(),
+            *pkg.rules(),
             *target_type_rules.rules(),
             QueryRule(Addresses, (DependenciesRequest,)),
             QueryRule(UnexpandedTargets, (Addresses,)),
+            QueryRule(InferredDependencies, (InferGoDependenciesRequest,)),
         ],
         target_types=[GoPackage, GoModule],
     )
@@ -36,20 +48,63 @@ def assert_go_module_address(rule_runner: RuleRunner, target: Target, expected_a
 
 
 def test_go_module_dependency_injection(rule_runner: RuleRunner) -> None:
-    rule_runner.add_to_build_file("foo", "go_module()")
     rule_runner.write_files(
         {
-            "foo/pkg/foo.go": "package pkg\n",
+            "foo/BUILD": "go_module()\n",
             "foo/go.mod": "module foo\n",
             "foo/go.sum": "",
+            "foo/pkg/BUILD": "go_package()\n",
+            "foo/pkg/foo.go": "package pkg\n",
+            "foo/bar/BUILD": "go_module(name='mod')\ngo_package(name='pkg')\n",
+            "foo/bar/go.mod": "module bar\n",
             "foo/bar/src.go": "package bar\n",
         }
     )
-    rule_runner.add_to_build_file("foo/pkg", "go_package()")
-    rule_runner.add_to_build_file("foo/bar", "go_module(name='mod')\ngo_package(name='pkg')\n")
 
     target = rule_runner.get_target(Address("foo/pkg", target_name="pkg"))
     assert_go_module_address(rule_runner, target, Address("foo"))
 
     target = rule_runner.get_target(Address("foo/bar", target_name="pkg"))
     assert_go_module_address(rule_runner, target, Address("foo/bar", target_name="mod"))
+
+
+def test_go_package_dependency_inference(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        (
+            {
+                "foo/BUILD": "go_module()\n",
+                "foo/go.mod": textwrap.dedent(
+                    """\
+                module go.example.com/foo
+                go 1.16"""
+                ),
+                "foo/go.sum": "",
+                "foo/pkg/BUILD": "go_package()\n",
+                "foo/pkg/foo.go": textwrap.dedent(
+                    """\
+                package pkg
+                func Grok() string {
+                    return "Hello World"
+                }"""
+                ),
+                "foo/cmd/BUILD": "go_package()\n",
+                "foo/cmd/main.go": textwrap.dedent(
+                    """\
+                package main
+                import (
+                    "fmt"
+                    "go.example.com/foo/pkg"
+                )
+                func main() {
+                    fmt.Printf("%s\n", pkg.Grok())
+                }"""
+                ),
+            }
+        )
+    )
+    target = rule_runner.get_target(Address("foo/cmd"))
+    inferred_deps = rule_runner.request(
+        InferredDependencies, [InferGoDependenciesRequest(target[GoPackageSources])]
+    )
+    assert inferred_deps.dependencies == FrozenOrderedSet([Address("foo/pkg")])
+    assert not inferred_deps.sibling_dependencies_inferrable

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -52,15 +52,11 @@ class GoModuleSources(Sources):
             raise InvalidFieldException(f"""No go.mod file was found for target {self.address}.""")
 
 
-class GoModuleDependencies(Dependencies):
-    pass
-
-
 class GoModule(Target):
     alias = "go_module"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        GoModuleDependencies,
+        Dependencies,
         GoModuleSources,
     )
     help = "First-party Go module."

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -52,11 +52,15 @@ class GoModuleSources(Sources):
             raise InvalidFieldException(f"""No go.mod file was found for target {self.address}.""")
 
 
+class GoModuleDependencies(Dependencies):
+    pass
+
+
 class GoModule(Target):
     alias = "go_module"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        Dependencies,
+        GoModuleDependencies,
         GoModuleSources,
     )
     help = "First-party Go module."


### PR DESCRIPTION
Add dependency inference for `go_package` targets as follows:
- Add a dependency on any other imported first-party `go_package` that is part of the same Go module.
- Add a dependency on the applicable `go_external_module` for any package imported from a third-party module

This PR intentionally does not solve handling dependencies on first-party code owned by a different `go_module` than the current package's owning `go_module`. It also punts on a better refactoring of the dependency inference rules until after we figure out how to handle vendored code.

Also:
- Renames `InjectGoModuleDependency` to `InjectGoPackageDependenciesRequest`. 
