### PR TITLE
Adds support for Poetry group dependencies

### DIFF
--- a/src/python/pants/backend/python/macros/poetry_requirements.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements.py
@@ -8,7 +8,7 @@ import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path, PurePath
-from typing import Any, Iterable, Iterator, List, Mapping, Optional, Sequence, cast
+from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Sequence, cast
 
 import toml
 from packaging.version import InvalidVersion, Version
@@ -331,16 +331,16 @@ def parse_pyproject_toml(pyproject_toml: PyProjectToml) -> set[Requirement]:
     dependencies.pop("python", None)
 
     groups = poetry_vals.get("group", {})
-    group_deps = {}
+    group_deps: Dict[str, PyprojectAttr] = {}
 
     for group in groups.values():
-        group_deps.update(**group.get("dependencies", {}))
+        group_deps.update(group.get("dependencies", {}))
 
     dev_dependencies = poetry_vals.get("dev-dependencies", {})
     if not dependencies and not dev_dependencies and not group_deps:
         logger.warning(
-            "No requirements defined in any Poetry dependency groups, poetry.tools.dependencies and "
-            f"poetry.tools.dev-dependencies in {pyproject_toml.toml_relpath}, which is loaded "
+            "No requirements defined in any Poetry dependency groups, tool.poetry.dependencies and "
+            f"tool.poetry.dev-dependencies in {pyproject_toml.toml_relpath}, which is loaded "
             "by Pants from a poetry_requirements macro. Did you mean to populate these "
             "with requirements?"
         )

--- a/src/python/pants/backend/python/macros/poetry_requirements.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements.py
@@ -330,10 +330,16 @@ def parse_pyproject_toml(pyproject_toml: PyProjectToml) -> set[Requirement]:
     # See: https://python-poetry.org/docs/pyproject/#dependencies-and-dev-dependencies
     dependencies.pop("python", None)
 
+    groups = poetry_vals.get("group", {})
+    group_deps = {}
+
+    for group in groups.values():
+        group_deps.update(**group.get("dependencies", {}))
+
     dev_dependencies = poetry_vals.get("dev-dependencies", {})
-    if not dependencies and not dev_dependencies:
+    if not dependencies and not dev_dependencies and not group_deps:
         logger.warning(
-            "No requirements defined in poetry.tools.dependencies and "
+            "No requirements defined in any Poetry dependency groups, poetry.tools.dependencies and "
             f"poetry.tools.dev-dependencies in {pyproject_toml.toml_relpath}, which is loaded "
             "by Pants from a poetry_requirements macro. Did you mean to populate these "
             "with requirements?"
@@ -342,7 +348,7 @@ def parse_pyproject_toml(pyproject_toml: PyProjectToml) -> set[Requirement]:
     return set(
         itertools.chain.from_iterable(
             parse_single_dependency(proj, attr, pyproject_toml)
-            for proj, attr in {**dependencies, **dev_dependencies}.items()
+            for proj, attr in {**dependencies, **dev_dependencies, **group_deps}.items()
         )
     )
 

--- a/src/python/pants/backend/python/macros/poetry_requirements_test.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements_test.py
@@ -349,6 +349,12 @@ def test_parse_multi_reqs() -> None:
     python = "3.6"
     markers = "platform_python_implementation == 'CPython'"
 
+    [tool.poetry.group.mygroup.dependencies]
+    myrequirement = "1.2.3"
+
+    [tool.poetry.group.mygroup2.dependencies]
+    myrequirement2 = "1.2.3"
+
     [tool.poetry.dev-dependencies]
     isort = ">=5.5.1,<5.6"
 
@@ -360,6 +366,8 @@ def test_parse_multi_reqs() -> None:
     retval = parse_pyproject_toml(pyproject_toml)
     actual_reqs = {
         Requirement.parse("junk[security]@ https://github.com/myrepo/junk.whl"),
+        Requirement.parse("myrequirement==1.2.3"),
+        Requirement.parse("myrequirement2==1.2.3"),
         Requirement.parse("poetry@ git+https://github.com/python-poetry/poetry.git@v1.1.1"),
         Requirement.parse('requests[security, random]<3.0.0,>=2.25.1; python_version > "2.7"'),
         Requirement.parse('foo>=1.9; python_version >= "2.7" and python_version < "3.0"'),


### PR DESCRIPTION
Adds support for [newly-introduced Poetry groups](https://python-poetry.org/blog/announcing-poetry-1.2.0a2/#dependency-groups) and updates test cases to handle.


[ci skip-rust]

[ci skip-build-wheels]