### PR TITLE
Go: refactor Go SDK invocation into common rule

### DIFF
--- a/src/python/pants/backend/experimental/go/register.py
+++ b/src/python/pants/backend/experimental/go/register.py
@@ -7,6 +7,7 @@ from pants.backend.go import (
     import_analysis,
     module,
     pkg,
+    sdk,
     tailor,
     target_type_rules,
 )
@@ -26,6 +27,7 @@ def rules():
         *import_analysis.rules(),
         *module.rules(),
         *pkg.rules(),
+        *sdk.rules(),
         *tailor.rules(),
         *target_type_rules.rules(),
     ]

--- a/src/python/pants/backend/go/build.py
+++ b/src/python/pants/backend/go/build.py
@@ -7,7 +7,7 @@ from pathlib import PurePath
 from typing import Dict, List, Tuple
 
 from pants.backend.go.import_analysis import ResolvedImportPathsForGoLangDistribution
-from pants.backend.go.sdk import InvokeGoSdkRequest
+from pants.backend.go.sdk import SetupGoSdkProcess
 from pants.backend.go.target_types import GoBinaryMainAddress, GoBinaryName, GoImportPath, GoSources
 from pants.build_graph.address import Address, AddressInput
 from pants.core.goals.package import (
@@ -147,7 +147,7 @@ async def build_target(
 
     result = await Get(
         ProcessResult,
-        InvokeGoSdkRequest(
+        SetupGoSdkProcess(
             digest=input_digest,
             command=(
                 "tool",
@@ -247,7 +247,7 @@ async def package_go_binary(
 
     result = await Get(
         ProcessResult,
-        InvokeGoSdkRequest(
+        SetupGoSdkProcess(
             digest=input_digest,
             command=(
                 "tool",

--- a/src/python/pants/backend/go/build.py
+++ b/src/python/pants/backend/go/build.py
@@ -7,7 +7,7 @@ from pathlib import PurePath
 from typing import Dict, List, Tuple
 
 from pants.backend.go.import_analysis import ResolvedImportPathsForGoLangDistribution
-from pants.backend.go.sdk import SetupGoSdkProcess
+from pants.backend.go.sdk import GoSdkProcess
 from pants.backend.go.target_types import GoBinaryMainAddress, GoBinaryName, GoImportPath, GoSources
 from pants.build_graph.address import Address, AddressInput
 from pants.core.goals.package import (
@@ -147,7 +147,7 @@ async def build_target(
 
     result = await Get(
         ProcessResult,
-        SetupGoSdkProcess(
+        GoSdkProcess(
             digest=input_digest,
             command=(
                 "tool",
@@ -247,7 +247,7 @@ async def package_go_binary(
 
     result = await Get(
         ProcessResult,
-        SetupGoSdkProcess(
+        GoSdkProcess(
             digest=input_digest,
             command=(
                 "tool",

--- a/src/python/pants/backend/go/build.py
+++ b/src/python/pants/backend/go/build.py
@@ -148,7 +148,7 @@ async def build_target(
     result = await Get(
         ProcessResult,
         GoSdkProcess(
-            digest=input_digest,
+            input_digest=input_digest,
             command=(
                 "tool",
                 "compile",
@@ -248,7 +248,7 @@ async def package_go_binary(
     result = await Get(
         ProcessResult,
         GoSdkProcess(
-            digest=input_digest,
+            input_digest=input_digest,
             command=(
                 "tool",
                 "link",

--- a/src/python/pants/backend/go/build_integration_test.py
+++ b/src/python/pants/backend/go/build_integration_test.py
@@ -5,7 +5,7 @@ from typing import Iterable, List
 
 import pytest
 
-from pants.backend.go import build, import_analysis
+from pants.backend.go import build, import_analysis, sdk
 from pants.backend.go.build import GoBinaryFieldSet
 from pants.backend.go.target_types import GoBinary, GoPackage
 from pants.build_graph.address import Address
@@ -26,6 +26,7 @@ def rule_runner() -> RuleRunner:
             *source_files.rules(),
             *import_analysis.rules(),
             *build.rules(),
+            *sdk.rules(),
             QueryRule(BuiltPackage, (GoBinaryFieldSet,)),
         ],
     )

--- a/src/python/pants/backend/go/module.py
+++ b/src/python/pants/backend/go/module.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Tuple
 
 import ijson
 
-from pants.backend.go.sdk import SetupGoSdkProcess
+from pants.backend.go.sdk import GoSdkProcess
 from pants.backend.go.target_types import GoModuleSources
 from pants.base.specs import AddressSpecs, AscendantAddresses, MaybeEmptySiblingAddresses
 from pants.build_graph.address import Address
@@ -110,7 +110,7 @@ async def resolve_go_module(
 
     result = await Get(
         ProcessResult,
-        SetupGoSdkProcess(
+        GoSdkProcess(
             digest=flattened_sources_snapshot.digest,
             command=("mod", "download", "-json", "all"),
             description="Resolve go_module metadata.",

--- a/src/python/pants/backend/go/module.py
+++ b/src/python/pants/backend/go/module.py
@@ -1,36 +1,22 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 import logging
-import textwrap
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
 import ijson
 
-from pants.backend.go.distribution import GoLangDistribution
+from pants.backend.go.sdk import InvokeGoSdkRequest, InvokeGoSdkResult
 from pants.backend.go.target_types import GoModuleSources
 from pants.base.specs import AddressSpecs, AscendantAddresses, MaybeEmptySiblingAddresses
 from pants.build_graph.address import Address
-from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Addresses
-from pants.engine.fs import (
-    CreateDigest,
-    Digest,
-    DigestContents,
-    FileContent,
-    MergeDigests,
-    RemovePrefix,
-    Snapshot,
-    Workspace,
-)
+from pants.engine.fs import Digest, DigestContents, RemovePrefix, Snapshot, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.internals.selectors import Get
-from pants.engine.platform import Platform
-from pants.engine.process import BashBinary, Process, ProcessResult
 from pants.engine.rules import collect_rules, goal_rule, rule
 from pants.engine.target import Target, UnexpandedTargets
-from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
 
 logger = logging.getLogger(__name__)
@@ -108,16 +94,7 @@ def parse_module_descriptors(raw_json: bytes) -> List[ModuleDescriptor]:
 @rule
 async def resolve_go_module(
     request: ResolveGoModuleRequest,
-    goroot: GoLangDistribution,
-    platform: Platform,
-    bash: BashBinary,
 ) -> ResolvedGoModule:
-    downloaded_goroot = await Get(
-        DownloadedExternalTool,
-        ExternalToolRequest,
-        goroot.get_request(platform),
-    )
-
     targets = await Get(UnexpandedTargets, Addresses([request.address]))
     if not targets:
         raise AssertionError(f"Address `{request.address}` did not resolve to any targets.")
@@ -130,45 +107,14 @@ async def resolve_go_module(
         Snapshot, RemovePrefix(sources.snapshot.digest, request.address.spec_path)
     )
 
-    # Note: The `go` tool requires GOPATH to be an absolute path which can only be resolved from within the
-    # execution sandbox. Thus, this code uses a bash script to be able to resolve that path.
-    # TODO: Merge all duplicate versions of this script into a single script and invoke rule.
-    analyze_script_digest = await Get(
-        Digest,
-        CreateDigest(
-            [
-                FileContent(
-                    "analyze.sh",
-                    textwrap.dedent(
-                        """\
-                export GOROOT="./go"
-                export GOPATH="$(/bin/pwd)/gopath"
-                export GOCACHE="$(/bin/pwd)/cache"
-                mkdir -p "$GOPATH" "$GOCACHE"
-                exec ./go/bin/go mod download -json all
-                """
-                    ).encode("utf-8"),
-                )
-            ]
-        ),
-    )
-
-    input_root_digest = await Get(
-        Digest,
-        MergeDigests(
-            [flattened_sources_snapshot.digest, downloaded_goroot.digest, analyze_script_digest]
-        ),
-    )
-
-    process = Process(
-        argv=[bash.path, "./analyze.sh"],
-        input_digest=input_root_digest,
+    invoke_request = InvokeGoSdkRequest(
+        digest=flattened_sources_snapshot.digest,
+        command=("mod", "download", "-json", "all"),
         description="Resolve go_module metadata.",
-        output_files=["go.mod", "go.sum"],
-        level=LogLevel.DEBUG,
+        output_files=("go.mod", "go.sum"),
     )
 
-    result = await Get(ProcessResult, Process, process)
+    invoke_result = await Get(InvokeGoSdkResult, InvokeGoSdkRequest, invoke_request)
 
     # Parse the go.mod for the module path and minimum Go version.
     module_path = None
@@ -185,8 +131,8 @@ async def resolve_go_module(
         target=target,
         import_path=module_path,
         minimum_go_version=minimum_go_version,
-        modules=FrozenOrderedSet(parse_module_descriptors(result.stdout)),
-        digest=result.output_digest,
+        modules=FrozenOrderedSet(parse_module_descriptors(invoke_result.result.stdout)),
+        digest=invoke_result.result.output_digest,
     )
 
 

--- a/src/python/pants/backend/go/module.py
+++ b/src/python/pants/backend/go/module.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Tuple
 
 import ijson
 
-from pants.backend.go.sdk import InvokeGoSdkRequest
+from pants.backend.go.sdk import SetupGoSdkProcess
 from pants.backend.go.target_types import GoModuleSources
 from pants.base.specs import AddressSpecs, AscendantAddresses, MaybeEmptySiblingAddresses
 from pants.build_graph.address import Address
@@ -110,7 +110,7 @@ async def resolve_go_module(
 
     result = await Get(
         ProcessResult,
-        InvokeGoSdkRequest(
+        SetupGoSdkProcess(
             digest=flattened_sources_snapshot.digest,
             command=("mod", "download", "-json", "all"),
             description="Resolve go_module metadata.",

--- a/src/python/pants/backend/go/module.py
+++ b/src/python/pants/backend/go/module.py
@@ -111,7 +111,7 @@ async def resolve_go_module(
     result = await Get(
         ProcessResult,
         GoSdkProcess(
-            digest=flattened_sources_snapshot.digest,
+            input_digest=flattened_sources_snapshot.digest,
             command=("mod", "download", "-json", "all"),
             description="Resolve go_module metadata.",
             output_files=("go.mod", "go.sum"),

--- a/src/python/pants/backend/go/module_integration_test.py
+++ b/src/python/pants/backend/go/module_integration_test.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 import pytest
 
-from pants.backend.go import module
+from pants.backend.go import module, sdk
 from pants.backend.go.module import ResolvedGoModule, ResolveGoModuleRequest
 from pants.backend.go.target_types import GoExternalModule, GoModule, GoPackage
 from pants.build_graph.address import Address
@@ -17,6 +17,7 @@ def rule_runner() -> RuleRunner:
         rules=[
             *external_tool.rules(),
             *source_files.rules(),
+            *sdk.rules(),
             *module.rules(),
             QueryRule(ResolvedGoModule, [ResolveGoModuleRequest]),
         ],

--- a/src/python/pants/backend/go/pkg.py
+++ b/src/python/pants/backend/go/pkg.py
@@ -11,7 +11,7 @@ from pants.backend.go.module import (
     ResolvedOwningGoModule,
     ResolveGoModuleRequest,
 )
-from pants.backend.go.sdk import InvokeGoSdkRequest
+from pants.backend.go.sdk import SetupGoSdkProcess
 from pants.backend.go.target_types import GoImportPath, GoModuleSources, GoPackageSources
 from pants.build_graph.address import Address
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
@@ -142,7 +142,7 @@ async def resolve_go_package(
 
     result = await Get(
         ProcessResult,
-        InvokeGoSdkRequest(
+        SetupGoSdkProcess(
             digest=sources.snapshot.digest,
             command=("list", "-json", f"./{spec_subpath}"),
             description="Resolve go_package metadata.",

--- a/src/python/pants/backend/go/pkg.py
+++ b/src/python/pants/backend/go/pkg.py
@@ -11,7 +11,7 @@ from pants.backend.go.module import (
     ResolvedOwningGoModule,
     ResolveGoModuleRequest,
 )
-from pants.backend.go.sdk import SetupGoSdkProcess
+from pants.backend.go.sdk import GoSdkProcess
 from pants.backend.go.target_types import GoImportPath, GoModuleSources, GoPackageSources
 from pants.build_graph.address import Address
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
@@ -142,7 +142,7 @@ async def resolve_go_package(
 
     result = await Get(
         ProcessResult,
-        SetupGoSdkProcess(
+        GoSdkProcess(
             digest=sources.snapshot.digest,
             command=("list", "-json", f"./{spec_subpath}"),
             description="Resolve go_package metadata.",

--- a/src/python/pants/backend/go/pkg.py
+++ b/src/python/pants/backend/go/pkg.py
@@ -142,7 +142,7 @@ async def resolve_go_package(
 
     invoke_request = InvokeGoSdkRequest(
         digest=sources.snapshot.digest,
-        command=("${GOROOT}/bin/go", "list", "-json", f"./{spec_subpath}"),
+        command=("list", "-json", f"./{spec_subpath}"),
         description="Resolve go_package metadata.",
         working_dir=resolved_go_module.target.address.spec_path,
     )

--- a/src/python/pants/backend/go/pkg.py
+++ b/src/python/pants/backend/go/pkg.py
@@ -143,7 +143,7 @@ async def resolve_go_package(
     result = await Get(
         ProcessResult,
         GoSdkProcess(
-            digest=sources.snapshot.digest,
+            input_digest=sources.snapshot.digest,
             command=("list", "-json", f"./{spec_subpath}"),
             description="Resolve go_package metadata.",
             working_dir=resolved_go_module.target.address.spec_path,

--- a/src/python/pants/backend/go/pkg_integration_test.py
+++ b/src/python/pants/backend/go/pkg_integration_test.py
@@ -4,7 +4,7 @@ import textwrap
 
 import pytest
 
-from pants.backend.go import module, pkg
+from pants.backend.go import module, pkg, sdk
 from pants.backend.go.pkg import ResolvedGoPackage, ResolveGoPackageRequest
 from pants.backend.go.target_types import GoExternalModule, GoModule, GoPackage
 from pants.build_graph.address import Address
@@ -21,6 +21,7 @@ def rule_runner() -> RuleRunner:
             *source_files.rules(),
             *module.rules(),
             *pkg.rules(),
+            *sdk.rules(),
             QueryRule(ResolvedGoPackage, [ResolveGoPackageRequest]),
         ],
         target_types=[GoPackage, GoModule, GoExternalModule],

--- a/src/python/pants/backend/go/sdk.py
+++ b/src/python/pants/backend/go/sdk.py
@@ -16,7 +16,7 @@ from pants.util.logging import LogLevel
 
 
 @dataclass(frozen=True)
-class InvokeGoSdkRequest:
+class SetupGoSdkProcess:
     digest: Digest
     command: Tuple[str, ...]
     description: str
@@ -27,7 +27,7 @@ class InvokeGoSdkRequest:
 
 @rule
 async def setup_go_sdk_command(
-    request: InvokeGoSdkRequest,
+    request: SetupGoSdkProcess,
     goroot: GoLangDistribution,
     bash: BashBinary,
 ) -> Process:

--- a/src/python/pants/backend/go/sdk.py
+++ b/src/python/pants/backend/go/sdk.py
@@ -1,0 +1,87 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import textwrap
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+from pants.backend.go.distribution import GoLangDistribution
+from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
+from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests
+from pants.engine.internals.selectors import Get
+from pants.engine.platform import Platform
+from pants.engine.process import BashBinary, Process, ProcessResult
+from pants.engine.rules import collect_rules, rule
+from pants.util.logging import LogLevel
+
+
+@dataclass(frozen=True)
+class InvokeGoSdkRequest:
+    digest: Digest
+    command: Tuple[str, ...]
+    description: str
+    working_dir: Optional[str] = None
+    output_files: Tuple[str, ...] = ()
+    output_directories: Tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class InvokeGoSdkResult:
+    result: ProcessResult
+
+
+@rule
+async def invoke_go_sdk(
+    request: InvokeGoSdkRequest,
+    goroot: GoLangDistribution,
+    bash: BashBinary,
+) -> InvokeGoSdkResult:
+    downloaded_goroot = await Get(
+        DownloadedExternalTool,
+        ExternalToolRequest,
+        goroot.get_request(Platform.current),
+    )
+
+    working_dir_cmd = f"cd '{request.working_dir}'" if request.working_dir else ""
+
+    script_digest = await Get(
+        Digest,
+        CreateDigest(
+            [
+                FileContent(
+                    "__pants__.sh",
+                    textwrap.dedent(
+                        f"""\
+                export GOROOT="$(/bin/pwd)/go"
+                export GOPATH="$(/bin/pwd)/gopath"
+                export GOCACHE="$(/bin/pwd)/cache"
+                /bin/mkdir -p "$GOPATH" "$GOCACHE"
+                {working_dir_cmd}
+                exec {' '.join(request.command)}
+                """
+                    ).encode("utf-8"),
+                )
+            ]
+        ),
+    )
+
+    input_root_digest = await Get(
+        Digest,
+        MergeDigests([downloaded_goroot.digest, script_digest, request.digest]),
+    )
+
+    process = Process(
+        argv=[bash.path, "__pants__.sh"],
+        input_digest=input_root_digest,
+        description=request.description,
+        output_files=request.output_files,
+        output_directories=request.output_directories,
+        level=LogLevel.DEBUG,
+    )
+
+    result = await Get(ProcessResult, Process, process)
+
+    return InvokeGoSdkResult(result=result)
+
+
+def rules():
+    return collect_rules()

--- a/src/python/pants/backend/go/sdk.py
+++ b/src/python/pants/backend/go/sdk.py
@@ -1,16 +1,13 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+import shlex
 import textwrap
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
-from pants.backend.go import distribution
 from pants.backend.go.distribution import GoLangDistribution
-from pants.core.util_rules import external_tool, source_files
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
-from pants.engine import process
 from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests
-from pants.engine.internals import build_files
 from pants.engine.internals.selectors import Get
 from pants.engine.platform import Platform
 from pants.engine.process import BashBinary, Process, ProcessResult
@@ -62,7 +59,7 @@ async def invoke_go_sdk_command(
                 export GOCACHE="$(/bin/pwd)/cache"
                 /bin/mkdir -p "$GOPATH" "$GOCACHE"
                 {working_dir_cmd}
-                exec {' '.join(request.command)}
+                exec "${{GOROOT}}/bin/go" {' '.join(shlex.quote(arg) for arg in request.command)}
                 """
                     ).encode("utf-8"),
                 )

--- a/src/python/pants/backend/go/sdk.py
+++ b/src/python/pants/backend/go/sdk.py
@@ -17,7 +17,7 @@ from pants.util.logging import LogLevel
 
 @dataclass(frozen=True)
 class GoSdkProcess:
-    digest: Digest
+    input_digest: Digest
     command: Tuple[str, ...]
     description: str
     working_dir: Optional[str] = None
@@ -64,7 +64,7 @@ async def setup_go_sdk_command(
 
     input_root_digest = await Get(
         Digest,
-        MergeDigests([downloaded_goroot.digest, script_digest, request.digest]),
+        MergeDigests([downloaded_goroot.digest, script_digest, request.input_digest]),
     )
 
     return Process(

--- a/src/python/pants/backend/go/sdk.py
+++ b/src/python/pants/backend/go/sdk.py
@@ -16,7 +16,7 @@ from pants.util.logging import LogLevel
 
 
 @dataclass(frozen=True)
-class SetupGoSdkProcess:
+class GoSdkProcess:
     digest: Digest
     command: Tuple[str, ...]
     description: str
@@ -27,7 +27,7 @@ class SetupGoSdkProcess:
 
 @rule
 async def setup_go_sdk_command(
-    request: SetupGoSdkProcess,
+    request: GoSdkProcess,
     goroot: GoLangDistribution,
     bash: BashBinary,
 ) -> Process:

--- a/src/python/pants/backend/go/tailor_test.py
+++ b/src/python/pants/backend/go/tailor_test.py
@@ -4,7 +4,7 @@ import textwrap
 
 import pytest
 
-from pants.backend.go import module, target_type_rules
+from pants.backend.go import module, sdk, target_type_rules
 from pants.backend.go.tailor import (
     PutativeGoExternalModuleTargetsRequest,
     PutativeGoModuleTargetsRequest,
@@ -33,6 +33,7 @@ def rule_runner() -> RuleRunner:
             *external_tool.rules(),
             *source_files.rules(),
             *module.rules(),
+            *sdk.rules(),
             *target_type_rules.rules(),
             QueryRule(PutativeTargets, [PutativeGoPackageTargetsRequest, AllOwnedSources]),
             QueryRule(PutativeTargets, [PutativeGoModuleTargetsRequest, AllOwnedSources]),

--- a/src/python/pants/backend/go/target_type_rules_test.py
+++ b/src/python/pants/backend/go/target_type_rules_test.py
@@ -4,7 +4,7 @@ import textwrap
 
 import pytest
 
-from pants.backend.go import module, pkg, target_type_rules
+from pants.backend.go import module, pkg, sdk, target_type_rules
 from pants.backend.go.target_type_rules import InferGoPackageDependenciesRequest
 from pants.backend.go.target_types import (
     GoExternalModule,
@@ -36,6 +36,7 @@ def rule_runner() -> RuleRunner:
             *source_files.rules(),
             *module.rules(),
             *pkg.rules(),
+            *sdk.rules(),
             *target_type_rules.rules(),
             QueryRule(Addresses, (DependenciesRequest,)),
             QueryRule(UnexpandedTargets, (Addresses,)),


### PR DESCRIPTION
Introduce `GoSdkProcess` type and a rule to invoke the Go SDK using it. Then refactor invocations of the Go SDK to use this common type. This removes the duplication of the setup code needed to invoke the Go SDK.

Caveat: The `import_analysis` module is not ported because it wants to know the digest of the Go SDK. Will port that module in a subsequent PR.