### PR TITLE
[WIP] Add `[python-setup].disable_mixed_interpreter_constraints` to improve performance in repos with a single Python constraint

### DIFF
--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -111,6 +111,15 @@ async def bandit_lint(
     if bandit.skip:
         return LintResults([], linter_name="Bandit")
 
+    if python_setup.disable_mixed_interpreter_constraints:
+        result = await Get(
+            LintResult,
+            BanditPartition(
+                request.field_sets, InterpreterConstraints(python_setup.interpreter_constraints)
+            ),
+        )
+        return LintResults([result], linter_name="Bandit")
+
     # NB: Bandit output depends upon which Python interpreter version it's run with
     # ( https://github.com/PyCQA/bandit#under-which-version-of-python-should-i-install-bandit). We
     # batch targets by their constraints to ensure, for example, that all Python 2 targets run

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -109,16 +109,15 @@ def test_uses_correct_python_version(rule_runner: RuleRunner) -> None:
             ),
         }
     )
-    py2_args = [
-        "--bandit-version=bandit>=1.6.2,<1.7",
-    ]
+    py2_args = ["--bandit-version=bandit>=1.6.2,<1.7"]
     py2_tgt = rule_runner.get_target(Address("", target_name="py2", relative_file_path="f.py"))
+    py3_tgt = rule_runner.get_target(Address("", target_name="py3", relative_file_path="f.py"))
+
     py2_result = run_bandit(rule_runner, [py2_tgt], extra_args=py2_args)
     assert len(py2_result) == 1
     assert py2_result[0].exit_code == 0
     assert "f.py (syntax error while parsing AST from file)" in py2_result[0].stdout
 
-    py3_tgt = rule_runner.get_target(Address("", target_name="py3", relative_file_path="f.py"))
     py3_result = run_bandit(rule_runner, [py3_tgt], extra_args=py2_args)
     assert len(py3_result) == 1
     assert py3_result[0].exit_code == 0
@@ -139,6 +138,17 @@ def test_uses_correct_python_version(rule_runner: RuleRunner) -> None:
     assert batched_py3_result.exit_code == 0
     assert batched_py3_result.partition_description == "['CPython>=3.6']"
     assert "No issues identified." in batched_py3_result.stdout
+
+    # Finally, disable mixed interpreter constraints, meaning we should only disable batching and
+    # use the global constraints.
+    no_mixed_ics_result = run_bandit(
+        rule_runner,
+        [py2_tgt, py3_tgt],
+        extra_args=["--python-setup-disable-mixed-interpreter-constraints"],
+    )
+    assert len(no_mixed_ics_result) == 1
+    assert no_mixed_ics_result[0].exit_code == 0
+    assert "No issues identified." in py3_result[0].stdout
 
 
 def test_respects_config_file(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -103,15 +103,19 @@ class BanditLockfileSentinel(PythonToolLockfileSentinel):
 async def setup_bandit_lockfile(
     _: BanditLockfileSentinel, bandit: Bandit, python_setup: PythonSetup
 ) -> PythonLockfileRequest:
-    all_build_targets = await Get(UnexpandedTargets, AddressSpecs([DescendantAddresses("")]))
-    unique_constraints = {
-        InterpreterConstraints.create_from_compatibility_fields(
-            [tgt[InterpreterConstraintsField]], python_setup
-        )
-        for tgt in all_build_targets
-        if tgt.has_field(InterpreterConstraintsField) and not tgt.get(SkipBanditField).value
-    }
-    constraints = InterpreterConstraints(itertools.chain.from_iterable(unique_constraints))
+    if python_setup.disable_mixed_interpreter_constraints:
+        constraints = InterpreterConstraints(python_setup.interpreter_constraints)
+    else:
+        all_build_targets = await Get(UnexpandedTargets, AddressSpecs([DescendantAddresses("")]))
+        unique_constraints = {
+            InterpreterConstraints.create_from_compatibility_fields(
+                [tgt[InterpreterConstraintsField]], python_setup
+            )
+            for tgt in all_build_targets
+            if tgt.has_field(InterpreterConstraintsField) and not tgt.get(SkipBanditField).value
+        }
+        constraints = InterpreterConstraints(itertools.chain.from_iterable(unique_constraints))
+
     return PythonLockfileRequest.from_tool(
         bandit, constraints or InterpreterConstraints(python_setup.interpreter_constraints)
     )

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -73,10 +73,13 @@ async def setup_black(
     # when relevant. We only do this if if <3.8 can't be used, as we don't want a loose requirement
     # like `>=3.6` to result in requiring Python 3.8, which would error if 3.8 is not installed on
     # the machine.
-    all_interpreter_constraints = InterpreterConstraints.create_from_compatibility_fields(
-        (field_set.interpreter_constraints for field_set in setup_request.request.field_sets),
-        python_setup,
-    )
+    if python_setup.disable_mixed_interpreter_constraints:
+        all_interpreter_constraints = InterpreterConstraints(python_setup.interpreter_constraints)
+    else:
+        all_interpreter_constraints = InterpreterConstraints.create_from_compatibility_fields(
+            (field_set.interpreter_constraints for field_set in setup_request.request.field_sets),
+            python_setup,
+        )
     tool_interpreter_constraints = (
         all_interpreter_constraints
         if (

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -123,10 +123,16 @@ async def setup_black_lockfile(
 ) -> PythonLockfileRequest:
     constraints = black.interpreter_constraints
     if black.options.is_default("interpreter_constraints"):
-        all_build_targets = await Get(UnexpandedTargets, AddressSpecs([DescendantAddresses("")]))
-        code_constraints = InterpreterConstraints.create_from_targets(
-            (tgt for tgt in all_build_targets if not tgt.get(SkipBlackField).value), python_setup
-        )
+        if python_setup.disable_mixed_interpreter_constraints:
+            code_constraints = InterpreterConstraints(python_setup.interpreter_constraints)
+        else:
+            all_build_targets = await Get(
+                UnexpandedTargets, AddressSpecs([DescendantAddresses("")])
+            )
+            code_constraints = InterpreterConstraints.create_from_targets(
+                (tgt for tgt in all_build_targets if not tgt.get(SkipBlackField).value),
+                python_setup,
+            )
         if code_constraints.requires_python38_or_newer(python_setup.interpreter_universe):
             constraints = code_constraints
 

--- a/src/python/pants/backend/python/lint/black/subsystem_test.py
+++ b/src/python/pants/backend/python/lint/black/subsystem_test.py
@@ -26,11 +26,14 @@ def test_setup_lockfile_interpreter_constraints() -> None:
     )
 
     global_constraint = "==3.9.*"
-    rule_runner.set_options(
-        [], env={"PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"}
-    )
 
-    def assert_ics(build_file: str, expected: list[str]) -> None:
+    def assert_ics(
+        build_file: str, expected: list[str], *, disable_mixed_ics: bool = False
+    ) -> None:
+        rule_runner.set_options(
+            [f"--python-setup-disable-mixed-interpreter-constraints={disable_mixed_ics}"],
+            env={"PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"},
+        )
         rule_runner.write_files({"project/BUILD": build_file})
         lockfile_request = rule_runner.request(PythonLockfileRequest, [BlackLockfileSentinel()])
         assert lockfile_request.interpreter_constraints == InterpreterConstraints(expected)
@@ -74,4 +77,11 @@ def test_setup_lockfile_interpreter_constraints() -> None:
             """
         ),
         ["==3.8.*"],
+    )
+
+    # If mixed interpreter constraints are disabled, simply look at the global ICs.
+    assert_ics(
+        "python_library(interpreter_constraints=['==2.7.*'])",
+        [global_constraint],
+        disable_mixed_ics=True,
     )

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -109,6 +109,15 @@ async def flake8_lint(
     if flake8.skip:
         return LintResults([], linter_name="Flake8")
 
+    if python_setup.disable_mixed_interpreter_constraints:
+        result = await Get(
+            LintResult,
+            Flake8Partition(
+                request.field_sets, InterpreterConstraints(python_setup.interpreter_constraints)
+            ),
+        )
+        return LintResults([result], linter_name="flake8")
+
     # NB: Flake8 output depends upon which Python interpreter version it's run with
     # (http://flake8.pycqa.org/en/latest/user/invocation.html). We batch targets by their
     # constraints to ensure, for example, that all Python 2 targets run together and all Python 3

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -107,12 +107,13 @@ def test_uses_correct_python_version(rule_runner: RuleRunner) -> None:
         }
     )
     py2_tgt = rule_runner.get_target(Address("", target_name="py2", relative_file_path="f.py"))
+    py3_tgt = rule_runner.get_target(Address("", target_name="py3", relative_file_path="f.py"))
+
     py2_result = run_flake8(rule_runner, [py2_tgt])
     assert len(py2_result) == 1
     assert py2_result[0].exit_code == 1
     assert "f.py:1:8: E999 SyntaxError" in py2_result[0].stdout
 
-    py3_tgt = rule_runner.get_target(Address("", target_name="py3", relative_file_path="f.py"))
     py3_result = run_flake8(rule_runner, [py3_tgt])
     assert len(py3_result) == 1
     assert py3_result[0].exit_code == 0
@@ -132,6 +133,17 @@ def test_uses_correct_python_version(rule_runner: RuleRunner) -> None:
     assert batched_py3_result.exit_code == 0
     assert batched_py3_result.partition_description == "['CPython>=3.6']"
     assert batched_py3_result.stdout.strip() == ""
+
+    # Finally, disable mixed interpreter constraints, meaning we should only disable batching and
+    # use the global constraints.
+    no_mixed_ics_result = run_flake8(
+        rule_runner,
+        [py2_tgt, py3_tgt],
+        extra_args=["--python-setup-disable-mixed-interpreter-constraints"],
+    )
+    assert len(no_mixed_ics_result) == 1
+    assert no_mixed_ics_result[0].exit_code == 0
+    assert no_mixed_ics_result[0].stdout.strip() == ""
 
 
 @pytest.mark.parametrize(

--- a/src/python/pants/backend/python/lint/flake8/subsystem_test.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem_test.py
@@ -30,7 +30,13 @@ def test_setup_lockfile_interpreter_constraints() -> None:
         [], env={"PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"}
     )
 
-    def assert_ics(build_file: str, expected: list[str]) -> None:
+    def assert_ics(
+        build_file: str, expected: list[str], *, disable_mixed_ics: bool = False
+    ) -> None:
+        rule_runner.set_options(
+            [f"--python-setup-disable-mixed-interpreter-constraints={disable_mixed_ics}"],
+            env={"PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"},
+        )
         rule_runner.write_files({"project/BUILD": build_file})
         lockfile_request = rule_runner.request(PythonLockfileRequest, [Flake8LockfileSentinel()])
         assert lockfile_request.interpreter_constraints == InterpreterConstraints(expected)
@@ -84,4 +90,11 @@ def test_setup_lockfile_interpreter_constraints() -> None:
             """
         ),
         ["==2.7.*", global_constraint, ">=3.6"],
+    )
+
+    # If mixed interpreter constraints are disabled, simply look at the global ICs.
+    assert_ics(
+        "python_library(interpreter_constraints=['==2.7.*'])",
+        [global_constraint],
+        disable_mixed_ics=True,
     )

--- a/src/python/pants/backend/python/subsystems/setuptools_test.py
+++ b/src/python/pants/backend/python/subsystems/setuptools_test.py
@@ -25,11 +25,14 @@ def test_setup_lockfile_interpreter_constraints() -> None:
     )
 
     global_constraint = "==3.9.*"
-    rule_runner.set_options(
-        [], env={"PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"}
-    )
 
-    def assert_ics(build_file: str, expected: list[str]) -> None:
+    def assert_ics(
+        build_file: str, expected: list[str], *, disable_mixed_ics: bool = False
+    ) -> None:
+        rule_runner.set_options(
+            [f"--python-setup-disable-mixed-interpreter-constraints={disable_mixed_ics}"],
+            env={"PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"},
+        )
         rule_runner.write_files({"project/BUILD": build_file})
         lockfile_request = rule_runner.request(
             PythonLockfileRequest, [SetuptoolsLockfileSentinel()]
@@ -150,4 +153,20 @@ def test_setup_lockfile_interpreter_constraints() -> None:
             """
         ),
         ["==2.7.*", global_constraint, ">=3.6"],
+    )
+
+    # If mixed interpreter constraints are disabled, simply look at the global ICs.
+    assert_ics(
+        dedent(
+            """\
+            python_library(name="lib", interpreter_constraints=["==2.7.*"])
+            python_distribution(
+                name="dist",
+                dependencies=[":lib"],
+                provides=setup_py(name="dist"),
+            )
+            """
+        ),
+        [global_constraint],
+        disable_mixed_ics=True,
     )


### PR DESCRIPTION
We have code to robustly handle mixed interpreter constraints, such as partitioning Flake8 and Bandit based on interpreter constraints. This is a neat feature, but not used by everyone.

Regardless of how much we optimize those code paths, fundamentally, we are doing more work than is necessary. Given how important performance is to Pants users, that's not ideal.

--

Soon, the `interpreter_constraints` field will only be registered if you activate the backend `pants.backend.python.mixed_interpreter_constraints`. This makes sense: you're opting into that advanced functionality so get access to the new field and the `py-constraints` goal. Otherwise, you can only set via `[python-setup].interpreter_constraints`.

To handle that deprecation, two parts:

1. (In a followup PR), deprecate using `interpreter_constraints` field if the backend `pants.backend.python.mixed_interpreter_constraints` is not activated.
2. (Here), add `--disable-mixed-interpreter-constraints` to allow getting the performance boost right away.

`--disable-mixed-interpreter-constraints` is temporary and will be removed once we switch the `interpreter_constraints` field to only be registered if the backend is activated.

[ci skip-build-wheels]