### PR TITLE
Resolve plugins using the PEX `--python` option

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -140,6 +140,7 @@ class PexPlatforms(DeduplicatedCollection[str]):
 class PexRequest(EngineAwareParameter):
     output_filename: str
     internal_only: bool
+    python: PythonExecutable | None
     requirements: PexRequirements
     interpreter_constraints: InterpreterConstraints
     platforms: PexPlatforms
@@ -157,6 +158,7 @@ class PexRequest(EngineAwareParameter):
         *,
         output_filename: str,
         internal_only: bool,
+        python: PythonExecutable | None = None,
         requirements: PexRequirements = PexRequirements(),
         interpreter_constraints=InterpreterConstraints(),
         platforms=PexPlatforms(),
@@ -177,6 +179,8 @@ class PexRequest(EngineAwareParameter):
             to end users, such as with the `binary` goal. Typically, instead, the user never
             directly uses the Pex, e.g. with `lint` and `test`. If True, we will use a Pex setting
             that results in faster build time but compatibility with fewer interpreters at runtime.
+        :param python: A particular PythonExecutable to use, which must match any relevant
+            interpreter_constraints.
         :param requirements: The requirements to install.
         :param interpreter_constraints: Any constraints on which Python versions may be used.
         :param platforms: Which platforms should be supported. Setting this value will cause
@@ -198,6 +202,7 @@ class PexRequest(EngineAwareParameter):
         """
         self.output_filename = output_filename
         self.internal_only = internal_only
+        self.python = python
         self.requirements = requirements
         self.interpreter_constraints = interpreter_constraints
         self.platforms = platforms
@@ -217,6 +222,16 @@ class PexRequest(EngineAwareParameter):
                 "Internal only PEXes can only constrain interpreters with interpreter_constraints."
                 f"Given platform constraints {self.platforms} for internal only pex request: "
                 f"{self}."
+            )
+        if self.python and self.platforms:
+            raise ValueError(
+                "Only one of platforms or a specific interpreter may be set. Got "
+                f"both {self.platforms} and {self.python}."
+            )
+        if self.python and self.interpreter_constraints:
+            raise ValueError(
+                "Only one of interpreter_constraints or a specific interpreter may be set. Got "
+                f"both {self.interpreter_constraints} and {self.python}."
             )
 
     def debug_hint(self) -> str:
@@ -342,15 +357,22 @@ async def build_pex(
         # TODO(#9560): consider validating that these platforms are valid with the interpreter
         #  constraints.
         argv.extend(request.platforms.generate_pex_arg_list())
-    else:
-        argv.extend(request.interpreter_constraints.generate_pex_arg_list())
+    elif request.python:
+        python = request.python
+    elif request.internal_only:
         # NB: If it's an internal_only PEX, we do our own lookup of the interpreter based on the
         # interpreter constraints, and then will run the PEX with that specific interpreter. We
         # will have already validated that there were no platforms.
-        if request.internal_only:
-            python = await Get(
-                PythonExecutable, InterpreterConstraints, request.interpreter_constraints
-            )
+        python = await Get(
+            PythonExecutable, InterpreterConstraints, request.interpreter_constraints
+        )
+    else:
+        # `--interpreter-constraint` options are mutually exclusive with the `--python` option,
+        # so we only specify them if we have not already located a concrete Python.
+        argv.extend(request.interpreter_constraints.generate_pex_arg_list())
+
+    if python:
+        argv.extend(["--python", python.path])
 
     argv.append("--no-emit-warnings")
 

--- a/tests/python/pants_test/init/BUILD
+++ b/tests/python/pants_test/init/BUILD
@@ -3,7 +3,7 @@
 
 python_tests(
   name='tests',
-  timeout = 270,
+  timeout = 360,
   dependencies=[
     # Used by `test_options_initializer`.
     '//:build_root',

--- a/tests/python/pants_test/init/test_plugin_resolver.py
+++ b/tests/python/pants_test/init/test_plugin_resolver.py
@@ -3,6 +3,7 @@
 
 import os
 import shutil
+import sys
 from contextlib import contextmanager
 from pathlib import Path, PurePath
 from textwrap import dedent
@@ -122,10 +123,12 @@ def plugin_resolution(
             with temporary_dir() as new_chroot:
                 yield new_chroot, True
 
+    # Default to resolving with whatever we're currently running with.
     interpreter_constraints = (
-        InterpreterConstraints([f"=={interpreter.identity.version_str}"])
-        if interpreter
-        else InterpreterConstraints([">=3.7"])
+        InterpreterConstraints([f"=={interpreter.identity.version_str}"]) if interpreter else None
+    )
+    artifact_interpreter_constraints = interpreter_constraints or InterpreterConstraints(
+        [f"=={'.'.join(map(str, sys.version_info[:3]))}"]
     )
 
     with provide_chroot(chroot) as (root_dir, create_artifacts):
@@ -149,7 +152,7 @@ def plugin_resolution(
                     _run_setup_py(
                         rule_runner,
                         plugin,
-                        interpreter_constraints,
+                        artifact_interpreter_constraints,
                         version,
                         setup_py_args,
                         repo_dir,


### PR DESCRIPTION
As described in #12361, when Pants is running under a Python (generally selected by the `pants` script) which is not part of the `interpreter_search_path`, plugin resolution will fail to find an exact match.

Resolve Pants plugins using the PEX `--python` option to ensure that they are located regardless of the `--python-path`.

Fixes #12361 and the repro described there.

[ci skip-rust]
[ci skip-build-wheels]