### PR TITLE
Resolve plugins using the PEX --python option. (cherrypick of #12500)

### DIFF
--- a/tests/python/pants_test/init/BUILD
+++ b/tests/python/pants_test/init/BUILD
@@ -3,7 +3,7 @@
 
 python_tests(
   name='tests',
-  timeout = 270,
+  timeout = 360,
   dependencies=[
     # Used by `test_options_initializer`.
     '//:build_root',

--- a/tests/python/pants_test/init/test_plugin_resolver.py
+++ b/tests/python/pants_test/init/test_plugin_resolver.py
@@ -3,6 +3,7 @@
 
 import os
 import shutil
+import sys
 from contextlib import contextmanager
 from pathlib import Path, PurePath
 from textwrap import dedent
@@ -127,10 +128,14 @@ def plugin_resolution(
             with temporary_dir() as new_chroot:
                 yield new_chroot, True
 
+    # Default to resolving with whatever we're currently running with.
     interpreter_constraints = (
         PexInterpreterConstraints([f"=={interpreter.identity.version_str}"])
         if interpreter
-        else PexInterpreterConstraints([">=3.7"])
+        else None
+    )
+    artifact_interpreter_constraints = interpreter_constraints or PexInterpreterConstraints(
+        [f"=={'.'.join(map(str, sys.version_info[:3]))}"]
     )
 
     with provide_chroot(chroot) as (root_dir, create_artifacts):
@@ -154,7 +159,7 @@ def plugin_resolution(
                     _run_setup_py(
                         rule_runner,
                         plugin,
-                        interpreter_constraints,
+                        artifact_interpreter_constraints,
                         version,
                         setup_py_args,
                         repo_dir,


### PR DESCRIPTION
As described in #12361, when Pants is running under a Python (generally selected by the `pants` script) which is not part of the `interpreter_search_path`, plugin resolution will fail to find an exact match.

Resolve Pants plugins using the PEX `--python` option to ensure that they are located regardless of the `--python-path`.

Fixes #12361 and the repro described there.

[ci skip-rust]
[ci skip-build-wheels]