### PR TITLE
Add `skip_tests` field to `python_tests` to facilitate incremental migration

### DIFF
--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -17,6 +17,7 @@ from pants.backend.python.target_types import (
     PythonTestsExtraEnvVars,
     PythonTestsSources,
     PythonTestsTimeout,
+    SkipPythonTestsField,
 )
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import Pex, PexRequest, VenvPex, VenvPexProcess
@@ -76,10 +77,13 @@ class PythonTestFieldSet(TestFieldSet):
     timeout: PythonTestsTimeout
     runtime_package_dependencies: RuntimePackageDependenciesField
     extra_env_vars: PythonTestsExtraEnvVars
+    skip_tests: SkipPythonTestsField
 
-    def is_conftest_or_type_stub(self) -> bool:
-        """We skip both `conftest.py` and `.pyi` stubs, even though though they often belong to a
-        `python_tests` target, because neither contain any tests to run on."""
+    def should_skip(self) -> bool:
+        """Check if the target was set to be skipped, or it's `conftest.py` or a type stub."""
+        if self.skip_tests.value:
+            return True
+        # Defend against it being a BUILD target, which should never happen in production.
         if not self.address.is_file_target:
             return False
         file_name = PurePath(self.address.filename)
@@ -330,7 +334,7 @@ async def setup_pytest_for_target(
 async def run_python_test(
     field_set: PythonTestFieldSet, test_subsystem: TestSubsystem, pytest: PyTest
 ) -> TestResult:
-    if field_set.is_conftest_or_type_stub():
+    if field_set.should_skip():
         return TestResult.skip(field_set.address)
 
     setup = await Get(TestSetup, TestSetupRequest(field_set, is_debug=False))
@@ -376,7 +380,7 @@ async def run_python_test(
 
 @rule(desc="Set up Pytest to run interactively", level=LogLevel.DEBUG)
 async def debug_python_test(field_set: PythonTestFieldSet) -> TestDebugRequest:
-    if field_set.is_conftest_or_type_stub():
+    if field_set.should_skip():
         return TestDebugRequest(None)
     setup = await Get(TestSetup, TestSetupRequest(field_set, is_debug=True))
     return TestDebugRequest(

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -509,3 +509,15 @@ def test_skip_type_stubs(rule_runner: RuleRunner) -> None:
     tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="test_foo.pyi"))
     result = run_pytest(rule_runner, tgt)
     assert result.exit_code is None
+
+
+def test_skip_tests_field(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            f"{PACKAGE}/test_foo.pyi": "def test_foo() -> None:\n    ...\n",
+            f"{PACKAGE}/BUILD": "python_tests(skip_tests=True)",
+        }
+    )
+    tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="test_foo.pyi"))
+    result = run_pytest(rule_runner, tgt)
+    assert result.exit_code is None

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -466,6 +466,12 @@ class PythonTestsExtraEnvVars(StringSequenceField):
     )
 
 
+class SkipPythonTestsField(BoolField):
+    alias = "skip_tests"
+    default = False
+    help = "If true, don't run this target's tests."
+
+
 class PythonTests(Target):
     alias = "python_tests"
     core_fields = (
@@ -476,6 +482,7 @@ class PythonTests(Target):
         PythonTestsTimeout,
         RuntimePackageDependenciesField,
         PythonTestsExtraEnvVars,
+        SkipPythonTestsField,
     )
     help = (
         "Python tests, written in either Pytest style or unittest style.\n\nAll test util code, "


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/12503. As explained there, it's valuable to have a `python_tests` target that you don't actually yet run tests on, such as to run linters/formatters on the code.

[ci skip-rust]
[ci skip-build-wheels]