### PR TITLE
Add `skip_tests` field to `python_tests` to facilitate incremental adoption (Cherry-pick of #12510)

### DIFF
--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -509,3 +509,15 @@ def test_skip_type_stubs(rule_runner: RuleRunner) -> None:
     tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="test_foo.pyi"))
     result = run_pytest(rule_runner, tgt)
     assert result.exit_code is None
+
+
+def test_skip_tests_field(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            f"{PACKAGE}/test_foo.pyi": "def test_foo() -> None:\n    ...\n",
+            f"{PACKAGE}/BUILD": "python_tests(skip_tests=True)",
+        }
+    )
+    tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="test_foo.pyi"))
+    result = run_pytest(rule_runner, tgt)
+    assert result.exit_code is None

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -457,6 +457,12 @@ class PythonTestsExtraEnvVars(StringSequenceField):
     )
 
 
+class SkipPythonTestsField(BoolField):
+    alias = "skip_tests"
+    default = False
+    help = "If true, don't run this target's tests."
+
+
 class PythonTests(Target):
     alias = "python_tests"
     core_fields = (
@@ -467,6 +473,7 @@ class PythonTests(Target):
         PythonTestsTimeout,
         RuntimePackageDependenciesField,
         PythonTestsExtraEnvVars,
+        SkipPythonTestsField,
     )
     help = (
         "Python tests, written in either Pytest style or unittest style.\n\nAll test util code, "


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/12503. As explained there, it's valuable to have a `python_tests` target that you don't actually yet run tests on, such as to run linters/formatters on the code.

[ci skip-rust]
[ci skip-build-wheels]