### PR TITLE
[internal] Remove unused `InterpreterConstraints.partition_by_major_minor_versions`

### DIFF
--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -126,9 +126,8 @@ async def setup_bandit_lockfile(
     # While Bandit will run in partitions, we need a single lockfile that works with every
     # partition.
     #
-    # This ORs all unique interpreter constraints. When paired with
-    # `InterpreterConstraints.partition_by_major_minor_versions`, the net effect is that every
-    # possible Python interpreter used will be covered.
+    # This ORs all unique interpreter constraints. The net effect is that every possible Python
+    # interpreter used will be covered.
     all_build_targets = await Get(UnexpandedTargets, AddressSpecs([DescendantAddresses("")]))
     unique_constraints = {
         InterpreterConstraints.create_from_targets([tgt], python_setup)

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -143,9 +143,8 @@ async def setup_flake8_lockfile(
     # While Flake8 will run in partitions, we need a single lockfile that works with every
     # partition.
     #
-    # This ORs all unique interpreter constraints. When paired with
-    # `InterpreterConstraints.partition_by_major_minor_versions`, the net effect is that every
-    # possible Python interpreter used will be covered.
+    # This ORs all unique interpreter constraints. The net effect is that every possible Python
+    # interpreter used will be covered.
     all_build_targets = await Get(UnexpandedTargets, AddressSpecs([DescendantAddresses("")]))
     unique_constraints = {
         InterpreterConstraints.create_from_targets([tgt], python_setup)

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -168,9 +168,8 @@ async def setup_pylint_lockfile(
     #
     # This first computes the constraints for each individual target, including its direct
     # dependencies (which will AND across each target in the closure). Then, it ORs all unique
-    # resulting interpreter constraints. When paired with
-    # `InterpreterConstraints.partition_by_major_minor_versions`, the net effect is that
-    # every possible Python interpreter used will be covered.
+    # resulting interpreter constraints. The net effect is that every possible Python interpreter
+    # used will be covered.
     all_build_targets = await Get(UnexpandedTargets, AddressSpecs([DescendantAddresses("")]))
     relevant_targets = tuple(tgt for tgt in all_build_targets if PylintFieldSet.is_applicable(tgt))
     direct_deps_per_target = await MultiGet(

--- a/src/python/pants/backend/python/subsystems/ipython.py
+++ b/src/python/pants/backend/python/subsystems/ipython.py
@@ -69,9 +69,8 @@ async def setup_ipython_lockfile(
     # `./pants repl py2::` and then `./pants repl py3::`. Still, even with those subsets possible,
     # we need a single lockfile that works with all possible Python interpreters in use.
     #
-    # This ORs all unique interpreter constraints. When paired with
-    # `InterpreterConstraints.partition_by_major_minor_versions`, the net effect is that
-    # every possible Python interpreter used will be covered.
+    # This ORs all unique interpreter constraints. The net effect is that every possible Python
+    # interpreter used will be covered.
     all_build_targets = await Get(UnexpandedTargets, AddressSpecs([DescendantAddresses("")]))
     unique_constraints = {
         InterpreterConstraints.create_from_compatibility_fields(

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -196,9 +196,8 @@ async def setup_pytest_lockfile(
     #
     # This first computes the constraints for each individual `python_tests` target
     # (which will AND across each target in the closure). Then, it ORs all unique resulting
-    # interpreter constraints. When paired with
-    # `InterpreterConstraints.partition_by_major_minor_versions`, the net effect is that
-    # every possible Python interpreter used will be covered.
+    # interpreter constraints. The net effect is that every possible Python interpreter used will
+    # be covered.
     all_build_targets = await Get(UnexpandedTargets, AddressSpecs([DescendantAddresses("")]))
     transitive_targets_per_test = await MultiGet(
         Get(TransitiveTargets, TransitiveTargetsRequest([tgt.address]))

--- a/src/python/pants/backend/python/util_rules/interpreter_constraints.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints.py
@@ -238,70 +238,6 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
             allowed_versions=py38_and_later, prior_version="3.7"
         )
 
-    def partition_by_major_minor_versions(
-        self, interpreter_universe: Iterable[str]
-    ) -> tuple[InterpreterConstraints, ...]:
-        """Create a distinct InterpreterConstraints value for each CPython major-minor version that
-        is compatible with the original constraints."""
-        if any(req.project_name != "CPython" for req in self):
-            raise AssertionError(
-                "This function only works with CPython interpreter constraints for now."
-            )
-
-        def all_valid_patch_versions(major_minor: str) -> list[int]:
-            return [
-                p
-                for p in range(0, _EXPECTED_LAST_PATCH_VERSION + 1)
-                for req in self
-                if req.specifier.contains(f"{major_minor}.{p}")  # type: ignore[attr-defined]
-            ]
-
-        result = []
-
-        def maybe_add_version(major_minor: str) -> None:
-            major, minor = _major_minor_to_int(major_minor)
-            next_major_minor = f"{major}.{minor + 1}"
-
-            valid_patch_versions = all_valid_patch_versions(major_minor)
-            if not valid_patch_versions:
-                return
-
-            if len(valid_patch_versions) == 1:
-                result.append(
-                    InterpreterConstraints([f"=={major_minor}.{valid_patch_versions[0]}"])
-                )
-                return
-
-            skipped_patch_versions = _not_in_contiguous_range(valid_patch_versions)
-            first_patch_supported = valid_patch_versions[0] == 0
-            last_patch_supported = valid_patch_versions[-1] == _EXPECTED_LAST_PATCH_VERSION
-            if not skipped_patch_versions and first_patch_supported and last_patch_supported:
-                constraint = f"=={major_minor}.*"
-            else:
-                min_constraint = (
-                    f">={major_minor}"
-                    if first_patch_supported
-                    else f">={major_minor}.{valid_patch_versions[0]}"
-                )
-                max_constraint = (
-                    f"<{next_major_minor}"
-                    if last_patch_supported
-                    else f"<={major_minor}.{valid_patch_versions[-1]}"
-                )
-                if skipped_patch_versions:
-                    skipped_constraints = ",".join(
-                        f"!={major_minor}.{p}" for p in skipped_patch_versions
-                    )
-                    constraint = f"{min_constraint},{max_constraint},{skipped_constraints}"
-                else:
-                    constraint = f"{min_constraint},{max_constraint}"
-
-            result.append(InterpreterConstraints([constraint]))
-
-        for major_minor in sorted(interpreter_universe, key=_major_minor_to_int):
-            maybe_add_version(major_minor)
-        return tuple(result)
-
     def __str__(self) -> str:
         return " OR ".join(str(constraint) for constraint in self)
 
@@ -311,9 +247,3 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
 
 def _major_minor_to_int(major_minor: str) -> tuple[int, int]:
     return tuple(int(x) for x in major_minor.split(".", maxsplit=1))  # type: ignore[return-value]
-
-
-def _not_in_contiguous_range(nums: list[int]) -> list[int]:
-    # Expects list to already be sorted and have 1+ elements.
-    expected = {i for i in range(nums[0], nums[-1])}
-    return sorted(expected - set(nums))


### PR DESCRIPTION
Because Poetry already robustly handles generating a single lockfile that works with all requested Python interpreters (https://github.com/pantsbuild/pants/issues/12470#issuecomment-894523184), there is no need for the "pessimistic generation" proposed in https://github.com/pantsbuild/pants/issues/12463.

[ci skip-rust]
[ci skip-build-wheels]