### PR TITLE
Remove `TestResult.skip()` in favor of `TestFieldSet.opt_out()`

### DIFF
--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -4,7 +4,6 @@
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from pathlib import PurePath
 from typing import Optional
 
 from pants.backend.python.goals.coverage_py import (
@@ -12,13 +11,7 @@ from pants.backend.python.goals.coverage_py import (
     CoverageSubsystem,
     PytestCoverageData,
 )
-from pants.backend.python.subsystems.pytest import PyTest
-from pants.backend.python.target_types import (
-    PythonTestsExtraEnvVars,
-    PythonTestsSources,
-    PythonTestsTimeout,
-    SkipPythonTestsField,
-)
+from pants.backend.python.subsystems.pytest import PyTest, PythonTestFieldSet
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import Pex, PexRequest, VenvPex, VenvPexProcess
 from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
@@ -67,27 +60,6 @@ from pants.python.python_setup import PythonSetup
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger()
-
-
-@dataclass(frozen=True)
-class PythonTestFieldSet(TestFieldSet):
-    required_fields = (PythonTestsSources,)
-
-    sources: PythonTestsSources
-    timeout: PythonTestsTimeout
-    runtime_package_dependencies: RuntimePackageDependenciesField
-    extra_env_vars: PythonTestsExtraEnvVars
-    skip_tests: SkipPythonTestsField
-
-    def should_skip(self) -> bool:
-        """Check if the target was set to be skipped, or it's `conftest.py` or a type stub."""
-        if self.skip_tests.value:
-            return True
-        # Defend against it being a BUILD target, which should never happen in production.
-        if not self.address.is_file_target:
-            return False
-        file_name = PurePath(self.address.filename)
-        return file_name.name == "conftest.py" or file_name.suffix == ".pyi"
 
 
 # -----------------------------------------------------------------------------------------
@@ -334,9 +306,6 @@ async def setup_pytest_for_target(
 async def run_python_test(
     field_set: PythonTestFieldSet, test_subsystem: TestSubsystem, pytest: PyTest
 ) -> TestResult:
-    if field_set.should_skip():
-        return TestResult.skip(field_set.address)
-
     setup = await Get(TestSetup, TestSetupRequest(field_set, is_debug=False))
     result = await Get(FallibleProcessResult, Process, setup.process)
 
@@ -380,8 +349,6 @@ async def run_python_test(
 
 @rule(desc="Set up Pytest to run interactively", level=LogLevel.DEBUG)
 async def debug_python_test(field_set: PythonTestFieldSet) -> TestDebugRequest:
-    if field_set.should_skip():
-        return TestDebugRequest(None)
     setup = await Get(TestSetup, TestSetupRequest(field_set, is_debug=True))
     return TestDebugRequest(
         InteractiveProcess.from_process(setup.process, forward_signals_to_process=False)

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -329,9 +329,8 @@ def test_coverage(rule_runner: RuleRunner) -> None:
     assert result.coverage_data is not None
 
 
-def test_conftest_handling(rule_runner: RuleRunner) -> None:
-    """Tests that we a) inject a dependency on conftest.py and b) skip running directly on
-    conftest.py."""
+def test_conftest_dependency_injection(rule_runner: RuleRunner) -> None:
+    # See `test_skip_tests` for a test that we properly skip running on conftest.py.
     rule_runner.write_files(
         {
             f"{SOURCE_ROOT}/conftest.py": dedent(
@@ -345,15 +344,10 @@ def test_conftest_handling(rule_runner: RuleRunner) -> None:
             f"{PACKAGE}/BUILD": "python_tests()",
         }
     )
-
-    test_tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="tests.py"))
-    result = run_pytest(rule_runner, test_tgt, extra_args=["--pytest-args='-s'"])
+    tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="tests.py"))
+    result = run_pytest(rule_runner, tgt, extra_args=["--pytest-args='-s'"])
     assert result.exit_code == 0
     assert f"{PACKAGE}/tests.py In conftest!\n." in result.stdout
-
-    conftest_tgt = rule_runner.get_target(Address(SOURCE_ROOT, relative_file_path="conftest.py"))
-    result = run_pytest(rule_runner, conftest_tgt)
-    assert result.exit_code is None
 
 
 def test_execution_slot_variable(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/python/subsystems/pytest_test.py
+++ b/src/python/pants/backend/python/subsystems/pytest_test.py
@@ -42,6 +42,17 @@ def test_setup_lockfile_interpreter_constraints() -> None:
     # Only care about `python_tests` and their transitive deps, not unused `python_library`s.
     assert_ics("python_library(interpreter_constraints=['==2.7.*'])", [global_constraint])
 
+    # Ignore targets that are skipped.
+    assert_ics(
+        dedent(
+            """\
+            python_tests(name='a', interpreter_constraints=['==2.7.*'])
+            python_tests(name='b', interpreter_constraints=['==3.5.*'], skip_tests=True)
+            """
+        ),
+        ["==2.7.*"],
+    )
+
     # If there are multiple distinct ICs in the repo, we OR them because the lockfile needs to be
     # compatible with every target.
     assert_ics(

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -23,7 +23,7 @@ from pants.engine.console import Console
 from pants.engine.desktop import OpenFiles, OpenFilesRequest
 from pants.engine.engine_aware import EngineAwareReturnType
 from pants.engine.environment import CompleteEnvironment
-from pants.engine.fs import EMPTY_FILE_DIGEST, Digest, FileDigest, MergeDigests, Snapshot, Workspace
+from pants.engine.fs import Digest, FileDigest, MergeDigests, Snapshot, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import FallibleProcessResult, InteractiveProcess, InteractiveRunner
 from pants.engine.rules import Get, MultiGet, _uncacheable_rule, collect_rules, goal_rule, rule
@@ -47,7 +47,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class TestResult:
-    exit_code: Optional[int]
+    exit_code: int
     stdout: str
     stdout_digest: FileDigest
     stderr: str
@@ -60,17 +60,6 @@ class TestResult:
 
     # Prevent this class from being detected by pytest as a test class.
     __test__ = False
-
-    @classmethod
-    def skip(cls, address: Address) -> TestResult:
-        return cls(
-            exit_code=None,
-            stdout="",
-            stderr="",
-            stdout_digest=EMPTY_FILE_DIGEST,
-            stderr_digest=EMPTY_FILE_DIGEST,
-            address=address,
-        )
 
     @classmethod
     def from_fallible_process_result(
@@ -94,27 +83,13 @@ class TestResult:
             extra_output=extra_output,
         )
 
-    @property
-    def skipped(self) -> bool:
-        return (
-            self.exit_code is None
-            and not self.stdout
-            and not self.stderr
-            and not self.coverage_data
-            and not self.xml_results
-        )
-
     def __lt__(self, other: Union[Any, EnrichedTestResult]) -> bool:
-        """We sort first by status (skipped vs failed vs succeeded), then alphanumerically within
-        each group."""
+        """We sort first by status (failed vs succeeded), then alphanumerically within each
+        group."""
         if not isinstance(other, EnrichedTestResult):
             return NotImplemented
         if self.exit_code == other.exit_code:
             return self.address.spec < other.address.spec
-        if self.exit_code is None:
-            return True
-        if other.exit_code is None:
-            return False
         return abs(self.exit_code) < abs(other.exit_code)
 
 
@@ -146,13 +121,9 @@ class EnrichedTestResult(TestResult, EngineAwareReturnType):
         return output
 
     def level(self) -> LogLevel:
-        if self.skipped:
-            return LogLevel.DEBUG
         return LogLevel.INFO if self.exit_code == 0 else LogLevel.WARN
 
     def message(self) -> str:
-        if self.skipped:
-            return f"{self.address} skipped."
         status = "succeeded" if self.exit_code == 0 else f"failed (exit code {self.exit_code})"
         message = f"{self.address} {status}."
         if self.output_setting == ShowOutput.NONE or (
@@ -174,7 +145,7 @@ class EnrichedTestResult(TestResult, EngineAwareReturnType):
 
 @dataclass(frozen=True)
 class TestDebugRequest:
-    process: Optional[InteractiveProcess]
+    process: InteractiveProcess
 
     # Prevent this class from being detected by pytest as a test class.
     __test__ = False
@@ -393,8 +364,6 @@ async def run_tests(
         )
         exit_code = 0
         for debug_request in debug_requests:
-            if debug_request.process is None:
-                continue
             debug_result = interactive_runner.run(debug_request.process)
             if debug_result.exit_code != 0:
                 exit_code = debug_result.exit_code
@@ -421,15 +390,13 @@ async def run_tests(
     if results:
         console.print_stderr("")
     for result in sorted(results):
-        if result.skipped:
-            continue
         if result.exit_code == 0:
             sigil = console.green("✓")
             status = "succeeded"
         else:
             sigil = console.red("𐄂")
             status = "failed"
-            exit_code = cast(int, result.exit_code)
+            exit_code = result.exit_code
         console.print_stderr(f"{sigil} {result.address} {status}.")
         if result.extra_output and result.extra_output.files:
             workspace.write_digest(

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -321,7 +321,7 @@ def sort_results() -> None:
 
 def assert_streaming_output(
     *,
-    exit_code: Optional[int],
+    exit_code: int,
     stdout: str = "stdout",
     stderr: str = "stderr",
     output_setting: ShowOutput = ShowOutput.ALL,
@@ -339,16 +339,6 @@ def assert_streaming_output(
     )
     assert result.level() == expected_level
     assert result.message() == expected_message
-
-
-def test_streaming_output_skip() -> None:
-    assert_streaming_output(
-        exit_code=None,
-        stdout="",
-        stderr="",
-        expected_level=LogLevel.DEBUG,
-        expected_message="demo_test skipped.",
-    )
 
 
 def test_streaming_output_success() -> None:


### PR DESCRIPTION
This is a more standard way now of skipping out on running against a target that would normally be used.

This also fixes our Pytest lockfile generation to respect the field `skip_tests=True`.

[ci skip-rust]
[ci skip-build-wheels]