### PR TITLE
Remove the option inheritance and recursive options features.

### DIFF
--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -215,7 +215,7 @@ class RunTracker:
         scope_to_look_up = scope if scope != GLOBAL_SCOPE_CONFIG_SECTION else ""
         try:
             value = self._all_options.for_scope(
-                scope_to_look_up, inherit_from_enclosing_scope=False
+                scope_to_look_up, check_deprecations=False
             ).as_dict()
             if option is None:
                 return value

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -360,12 +360,7 @@ class HelpInfoExtracter:
             ohi = dataclasses.replace(ohi, value_history=history)
             if ohi.deprecation_active:
                 deprecated_options.append(ohi)
-            elif kwargs.get("advanced") or (
-                kwargs.get("recursive") and not kwargs.get("recursive_root")
-            ):
-                # In order to keep the regular help output uncluttered, we treat recursive
-                # options as advanced.  The concept of recursive options is not widely used
-                # and not clear to the end user, so it's best not to expose it as a concept.
+            elif kwargs.get("advanced"):
                 advanced_options.append(ohi)
             else:
                 basic_options.append(ohi)

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -221,8 +221,6 @@ def test_grouping():
     do_test({}, expected_basic=True)
     do_test({"advanced": False}, expected_basic=True)
     do_test({"advanced": True}, expected_advanced=True)
-    do_test({"recursive_root": True}, expected_basic=True)
-    do_test({"advanced": True, "recursive_root": True}, expected_advanced=True)
 
 
 def test_get_all_help_info():

--- a/src/python/pants/option/errors.py
+++ b/src/python/pants/option/errors.py
@@ -87,17 +87,6 @@ class PassthroughType(RegistrationError):
     """Options marked passthrough must be typed as a string list."""
 
 
-class RecursiveSubsystemOption(RegistrationError):
-    """Subsystem option cannot specify 'recursive'.
-
-    Subsystem options are always recursive.
-    """
-
-
-class Shadowing(RegistrationError):
-    """Option shadows an option in {outer_scope}."""
-
-
 # -----------------------------------------------------------------------
 # Flag parsing errors
 # -----------------------------------------------------------------------


### PR DESCRIPTION
This is not needed in v2, and simplifies the options handling code and tests quite a bit.
It also simplifies things for end users, who don't have to understand these concepts any more.
This should also improve invalidation, since scopes don't all inherit global scope options any more.

[ci skip-rust]

[ci skip-build-wheels]