### PR TITLE
Change the PythonProtobufMypyPlugin option scope.

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -56,11 +56,10 @@ class PythonProtobufSubsystem(Subsystem):
 
 
 class PythonProtobufMypyPlugin(PythonToolRequirementsBase):
-    options_scope = PythonProtobufSubsystem.subscope("mypy-plugin")
-    help = (
-        "Configuration of the mypy-protobuf type stub generation plugin for the Protobuf Python "
-        "backend."
-    )
+    options_scope = "mypy-protobuf"
+    deprecated_options_scope = "python-protobuf.mypy-plugin"
+    deprecated_options_scope_removal_version = "2.8.0.dev0"
+    help = "Configuration of the mypy-protobuf type stub generation plugin."
 
     default_version = "mypy-protobuf==2.4"
 


### PR DESCRIPTION
top-level scopes are not allowed to contain dots. This is only weakly enforced however,
when calling `get_scope_info()` on the Subsystem instance. So this snuck by. 

But it will fail the validation check if, for example, calling `./pants help-all` with the
python proto backend enabled.

In any case, the name was over-elaborate, and this new name is more succinct,
more intuitive and more conventional (i.e., it is named after the tool it configures).

[ci skip-rust]

[ci skip-build-wheels]