### PR TITLE
pyenv should fall back to $HOME/.pyenv

### DIFF
--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -504,5 +504,5 @@ def get_pyenv_root(env: Environment) -> str | None:
         return from_env
     home_from_env = env.get("HOME")
     if home_from_env:
-        return os.path.join(home_from_env, ".cache")
+        return os.path.join(home_from_env, ".pyenv")
     return None

--- a/src/python/pants/python/python_setup_test.py
+++ b/src/python/pants/python/python_setup_test.py
@@ -116,7 +116,7 @@ def rule_runner() -> RuleRunner:
 
 def test_get_pyenv_root() -> None:
     home = "/♡"
-    default_root = f"{home}/.cache"
+    default_root = f"{home}/.pyenv"
     explicit_root = f"{home}/explicit"
 
     assert explicit_root == get_pyenv_root(Environment({"PYENV_ROOT": explicit_root}))


### PR DESCRIPTION
Fixes #12526

[ci skip-rust]
[ci skip-build-wheels]