### PR TITLE
Fix asdf directory lookup.

### DIFF
--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -328,7 +328,7 @@ class PythonSetup(Subsystem):
         :param bool asdf_local: If True, only use the interpreter specified by
                                 '.tool-versions' file under `build_root`.
         """
-        asdf_dir = get_asdf_dir(env)
+        asdf_dir = get_asdf_data_dir(env)
         if not asdf_dir:
             return []
 
@@ -487,14 +487,29 @@ class PythonSetup(Subsystem):
         return paths
 
 
-def get_asdf_dir(env: Environment) -> PurePath | None:
-    """See https://asdf-vm.com/#/core-configuration?id=environment-variables."""
-    asdf_dir = env.get("ASDF_DIR", env.get("ASDF_DATA_DIR"))
-    if not asdf_dir:
+def get_asdf_data_dir(env: Environment) -> PurePath | None:
+    """Returns the location of asdf's installed tool versions.
+
+    See https://asdf-vm.com/manage/configuration.html#environment-variables.
+
+    `ASDF_DATA_DIR` is an environment variable that can be set to override the directory
+    in which the plugins, installs, and shims are installed.
+
+    `ASDF_DIR` is another environment variable that can be set, but we ignore it since
+    that location only specifies where the asdf tool itself is installed, not the managed versions.
+
+    Per the documentation, if `ASDF_DATA_DIR` is not specified, the tool will fall back to
+    `$HOME/.asdf`, so we do that as well.
+
+    :param env: The environment to use to look up asdf.
+    :return: Path to the data directory, or None if it couldn't be found in the environment.
+    """
+    asdf_data_dir = env.get("ASDF_DATA_DIR")
+    if not asdf_data_dir:
         home = env.get("HOME")
         if home:
             return PurePath(home) / ".asdf"
-    return PurePath(asdf_dir) if asdf_dir else None
+    return PurePath(asdf_data_dir) if asdf_data_dir else None
 
 
 def get_pyenv_root(env: Environment) -> str | None:

--- a/src/python/pants/python/python_setup_test.py
+++ b/src/python/pants/python/python_setup_test.py
@@ -10,7 +10,7 @@ import pytest
 
 from pants.base.build_environment import get_pants_cachedir
 from pants.engine.environment import Environment
-from pants.python.python_setup import PythonSetup, get_asdf_dir, get_pyenv_root
+from pants.python.python_setup import PythonSetup, get_asdf_data_dir, get_pyenv_root
 from pants.testutil.rule_runner import RuleRunner
 from pants.util.contextutil import environment_as, temporary_dir
 from pants.util.dirutil import safe_mkdir_for
@@ -146,9 +146,9 @@ def test_get_asdf_dir() -> None:
     default_root = home / ".asdf"
     explicit_root = home / "explicit"
 
-    assert explicit_root == get_asdf_dir(Environment({"ASDF_DIR": f"{explicit_root}"}))
-    assert default_root == get_asdf_dir(Environment({"HOME": f"{home}"}))
-    assert get_asdf_dir(Environment({})) is None
+    assert explicit_root == get_asdf_data_dir(Environment({"ASDF_DATA_DIR": f"{explicit_root}"}))
+    assert default_root == get_asdf_data_dir(Environment({"HOME": f"{home}"}))
+    assert get_asdf_data_dir(Environment({})) is None
 
 
 def test_get_asdf_paths(rule_runner: RuleRunner) -> None:
@@ -178,13 +178,13 @@ def test_get_asdf_paths(rule_runner: RuleRunner) -> None:
         expected_asdf_local_paths,
     ):
         # Check the "all installed" fallback
-        all_paths = PythonSetup.get_asdf_paths(Environment({"ASDF_DIR": asdf_dir}))
+        all_paths = PythonSetup.get_asdf_paths(Environment({"ASDF_DATA_DIR": asdf_dir}))
 
         home_paths = PythonSetup.get_asdf_paths(
-            Environment({"HOME": home_dir, "ASDF_DIR": asdf_dir})
+            Environment({"HOME": home_dir, "ASDF_DATA_DIR": asdf_dir})
         )
         local_paths = PythonSetup.get_asdf_paths(
-            Environment({"HOME": home_dir, "ASDF_DIR": asdf_dir}), asdf_local=True
+            Environment({"HOME": home_dir, "ASDF_DATA_DIR": asdf_dir}), asdf_local=True
         )
 
         # The order the filesystem returns the "installed" folders is arbitrary
@@ -243,7 +243,7 @@ def test_expand_interpreter_search_paths(rule_runner: RuleRunner) -> None:
                     "HOME": home_dir,
                     "PATH": "/env/path1:/env/path2",
                     "PYENV_ROOT": pyenv_root,
-                    "ASDF_DIR": asdf_dir,
+                    "ASDF_DATA_DIR": asdf_dir,
                 }
             )
             expanded_paths = PythonSetup.expand_interpreter_search_paths(


### PR DESCRIPTION
Should use data directory where tool versions are installed (like Python), not the directory where the asdf binary lives.

Fixes #12496

[ci skip-rust]
[ci skip-build-wheels]