### PR TITLE
Deprecate an options scope with underscores.

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/python/grpc_python_plugin.py
+++ b/src/python/pants/backend/codegen/protobuf/python/grpc_python_plugin.py
@@ -5,8 +5,10 @@ from pants.core.util_rules.external_tool import TemplatedExternalTool
 
 
 class GrpcPythonPlugin(TemplatedExternalTool):
-    options_scope = "grpc_python_plugin"
+    options_scope = "grpc-python-plugin"
     help = "The gRPC Protobuf plugin for Python."
+    deprecated_options_scope = "grpc_python_plugin"
+    deprecated_options_scope_removal_version = "2.8.0.dev0"
 
     default_version = "1.32.0"
     default_known_versions = [


### PR DESCRIPTION
So we can restore the stricter check that doesn't allow them.

[ci skip-rust]

[ci skip-build-wheels]