### PR TITLE
Fold OptionableFactory and Subsystem into Optionable 

### DIFF
--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -199,9 +199,9 @@ class PythonToolBase(PythonToolRequirementsBase):
         is_default_entry_point = self.options.is_default("entry_point")
         if not is_default_console_script and not is_default_entry_point:
             raise OptionsError(
-                f"Both [{self.scope}].console-script={self.options.console_script} and "
-                f"[{self.scope}].entry-point={self.options.entry_point} are configured but these "
-                f"options are mutually exclusive. Please pick one."
+                f"Both [{self.options_scope}].console-script={self.options.console_script} and "
+                f"[{self.options_scope}].entry-point={self.options.entry_point} are configured "
+                f"but these options are mutually exclusive. Please pick one."
             )
         if not is_default_console_script:
             return ConsoleScript(cast(str, self.options.console_script))

--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, DefaultDict, Dict, Set, Type, cast
+from typing import Any, DefaultDict, Dict, Set, Type
 
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.goal import GoalSubsystem
@@ -61,7 +61,7 @@ class BuildConfiguration:
         normalized_to_orig_name: Dict[str, str] = {}
 
         for opt in self.all_optionables:
-            scope = cast(str, opt.options_scope)
+            scope = opt.options_scope
             normalized_scope = normalize_scope(scope)
             name_to_categories[normalized_scope].add(
                 Category.goal if issubclass(opt, GoalSubsystem) else Category.subsystem

--- a/src/python/pants/engine/goal.py
+++ b/src/python/pants/engine/goal.py
@@ -49,7 +49,7 @@ class GoalSubsystem(Subsystem):
         for its options."""
 
     @classproperty
-    def options_scope(cls) -> str:  # type: ignore[override]
+    def options_scope(cls) -> str:
         return cast(str, cls.name)
 
 

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -31,7 +31,7 @@ from pants.engine.internals.selectors import GetConstraints
 from pants.engine.internals.selectors import MultiGet as MultiGet  # noqa: F401
 from pants.engine.internals.side_effects import side_effecting as side_effecting  # noqa: F401
 from pants.engine.unions import UnionRule
-from pants.option.optionable import OptionableFactory
+from pants.option.optionable import Optionable
 from pants.util.collections import assert_single_element
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized
@@ -76,7 +76,7 @@ class _RuleVisitor(ast.NodeVisitor):
 # We could refactor this to be a class with __call__() defined, but we would lose the `@memoized`
 # decorator.
 @memoized
-def SubsystemRule(optionable_factory: Type[OptionableFactory]) -> TaskRule:
+def SubsystemRule(optionable_factory: Type[Optionable]) -> TaskRule:
     """Returns a TaskRule that constructs an instance of the subsystem."""
     return TaskRule(**optionable_factory.signature())
 
@@ -371,7 +371,7 @@ def collect_rules(*namespaces: Union[ModuleType, Mapping[str, Any]]) -> Iterable
                 rule = getattr(item, "rule", None)
                 if isinstance(rule, TaskRule):
                     for input in rule.input_selectors:
-                        if issubclass(input, OptionableFactory):
+                        if issubclass(input, Optionable):
                             yield SubsystemRule(input)
                     if issubclass(rule.output_type, Goal):
                         yield SubsystemRule(rule.output_type.subsystem_cls)

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -87,7 +87,7 @@ class GraphSession:
             return tuple()
         consumed_types = self.goal_consumed_types(goal_product)
         return tuple(
-            sorted({typ.options_scope for typ in consumed_types if issubclass(typ, Subsystem)})  # type: ignore[misc]
+            sorted({typ.options_scope for typ in consumed_types if issubclass(typ, Subsystem)})
         )
 
     def goal_consumed_types(self, goal_product: type) -> set[type]:

--- a/src/python/pants/option/optionable_test.py
+++ b/src/python/pants/option/optionable_test.py
@@ -3,6 +3,8 @@
 
 import unittest
 
+from pants.option.errors import OptionsError
+from pants.option.option_value_container import OptionValueContainer
 from pants.option.optionable import Optionable
 
 
@@ -11,11 +13,13 @@ class OptionableTest(unittest.TestCase):
         class NoScope(Optionable):
             pass
 
-        with self.assertRaises(TypeError) as cm:
-            NoScope()  # type: ignore[abstract]
-        assert "with abstract methods options_scope" in str(
-            cm.exception
-        ) or "with abstract method options_scope" in str(cm.exception)
+        with self.assertRaises(OptionsError) as cm:
+            NoScope.get_scope_info()
+        assert "NoScope must set options_scope" in str(cm.exception)
+
+        with self.assertRaises(OptionsError) as cm:
+            NoScope(OptionValueContainer({}))
+        assert "NoScope must set options_scope" in str(cm.exception)
 
         class StringScope(Optionable):
             options_scope = "good"

--- a/src/python/pants/option/subsystem.py
+++ b/src/python/pants/option/subsystem.py
@@ -3,11 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Any, ClassVar, cast
-
-from pants.option.option_value_container import OptionValueContainer
 from pants.option.optionable import Optionable
-from pants.option.scope import ScopeInfo
 
 
 # TODO: Unite Optionable and Subsytem, since we no longer have any othe subtypes of
@@ -24,23 +20,3 @@ class Subsystem(Optionable):
 
     :API: public
     """
-
-    scope: str
-    options: OptionValueContainer
-
-    help: ClassVar[str]
-
-    @classmethod
-    def get_scope_info(cls) -> ScopeInfo:
-        cls.validate_scope_name_component(cast(str, cls.options_scope))
-        return super().get_scope_info()
-
-    def __init__(self, scope: str, options: OptionValueContainer) -> None:
-        super().__init__()
-        self.scope = scope
-        self.options = options
-
-    def __eq__(self, other: Any) -> bool:
-        if type(self) != type(other):
-            return False
-        return bool(self.scope == other.scope and self.options == other.options)

--- a/src/python/pants/testutil/option_util.py
+++ b/src/python/pants/testutil/option_util.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable, Mapping, Type, TypeVar, cast
+from typing import Iterable, Mapping, Type, TypeVar
 
 from pants.engine.goal import GoalSubsystem
 from pants.option.option_value_container import OptionValueContainer, OptionValueContainerBuilder
@@ -48,7 +48,6 @@ def create_goal_subsystem(
     :param options: The option values to populate the new goal subsystem instance with.
     """
     return goal_subsystem_type(
-        scope=goal_subsystem_type.name,
         options=create_option_value_container(default_rank, **options),
     )
 
@@ -65,8 +64,6 @@ def create_subsystem(
     :param default_rank: The rank to assign any raw option values passed.
     :param options: The option values to populate the new subsystem instance with.
     """
-    options_scope = cast(str, subsystem_type.options_scope)
     return subsystem_type(
-        scope=options_scope,
         options=create_option_value_container(default_rank, **options),
     )


### PR DESCRIPTION
- Optionable was the only subtype of OptionableFactory, so now the latter is merged into Optionable.
- Subsystem was the only subtype of Optionable, so its trivial functionality is merged into Optionable.

Subsystem remains as an alias of Optionable. To keep this change easy to review, we will wait for a followup
change to move the Optionable code into Subsystem and get rid of the Optionable name entirely. 