### PR TITLE
Refer to Subsystem instead of Optionable.

### DIFF
--- a/src/python/pants/build_graph/build_configuration_test.py
+++ b/src/python/pants/build_graph/build_configuration_test.py
@@ -9,7 +9,6 @@ from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.goal import GoalSubsystem
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule, union
-from pants.option.optionable import Optionable
 from pants.option.subsystem import Subsystem
 from pants.util.frozendict import FrozenDict
 from pants.util.ordered_set import FrozenOrderedSet
@@ -79,11 +78,11 @@ def test_register_union_rules(bc_builder: BuildConfiguration.Builder) -> None:
 
 
 def test_validation(caplog, bc_builder: BuildConfiguration.Builder) -> None:
-    def mk_dummy_opt(_options_scope: str, goal: bool = False) -> Type[Optionable]:
-        class DummyOptionable(GoalSubsystem if goal else Subsystem):  # type: ignore[misc]
+    def mk_dummy_subsys(_options_scope: str, goal: bool = False) -> Type[Subsystem]:
+        class DummySubsystem(GoalSubsystem if goal else Subsystem):  # type: ignore[misc]
             options_scope = _options_scope
 
-        return DummyOptionable
+        return DummySubsystem
 
     def mk_dummy_tgt(_alias: str) -> Type[Target]:
         class DummyTarget(Target):
@@ -92,13 +91,13 @@ def test_validation(caplog, bc_builder: BuildConfiguration.Builder) -> None:
 
         return DummyTarget
 
-    bc_builder.register_optionables(
+    bc_builder.register_subsystems(
         (
-            mk_dummy_opt("foo"),
-            mk_dummy_opt("Bar-bar"),
-            mk_dummy_opt("baz"),
-            mk_dummy_opt("qux", goal=True),
-            mk_dummy_opt("global"),
+            mk_dummy_subsys("foo"),
+            mk_dummy_subsys("Bar-bar"),
+            mk_dummy_subsys("baz"),
+            mk_dummy_subsys("qux", goal=True),
+            mk_dummy_subsys("global"),
         )
     )
     bc_builder.register_target_types(

--- a/src/python/pants/engine/goal_test.py
+++ b/src/python/pants/engine/goal_test.py
@@ -41,6 +41,4 @@ def test_goal_scope_flag() -> None:
         name = "dummy"
 
     dummy = create_goal_subsystem(DummyGoal)
-    assert dummy.get_scope_info() == ScopeInfo(
-        scope="dummy", optionable_cls=DummyGoal, is_goal=True
-    )
+    assert dummy.get_scope_info() == ScopeInfo(scope="dummy", subsystem_cls=DummyGoal, is_goal=True)

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -31,7 +31,7 @@ from pants.engine.internals.selectors import GetConstraints
 from pants.engine.internals.selectors import MultiGet as MultiGet  # noqa: F401
 from pants.engine.internals.side_effects import side_effecting as side_effecting  # noqa: F401
 from pants.engine.unions import UnionRule
-from pants.option.optionable import Optionable
+from pants.option.subsystem import Subsystem
 from pants.util.collections import assert_single_element
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized
@@ -76,9 +76,9 @@ class _RuleVisitor(ast.NodeVisitor):
 # We could refactor this to be a class with __call__() defined, but we would lose the `@memoized`
 # decorator.
 @memoized
-def SubsystemRule(optionable_factory: Type[Optionable]) -> TaskRule:
+def SubsystemRule(subsystem: Type[Subsystem]) -> TaskRule:
     """Returns a TaskRule that constructs an instance of the subsystem."""
-    return TaskRule(**optionable_factory.signature())
+    return TaskRule(**subsystem.signature())
 
 
 def _get_starting_indent(source):
@@ -107,13 +107,10 @@ def _make_rule(
 ) -> Callable[[Callable], Callable]:
     """A @decorator that declares that a particular static function may be used as a TaskRule.
 
-    As a special case, if the output_type is a subclass of `Goal`, the `Goal.Options` for the `Goal`
-    are registered as dependency Optionables.
-
     :param rule_type: The specific decorator used to declare the rule.
     :param return_type: The return/output type for the Rule. This must be a concrete Python type.
-    :param parameter_types: A sequence of types that matches the number and order of arguments to the
-                            decorated function.
+    :param parameter_types: A sequence of types that matches the number and order of arguments to
+                            the decorated function.
     :param cacheable: Whether the results of executing the Rule should be cached as keyed by all of
                       its inputs.
     """
@@ -371,7 +368,7 @@ def collect_rules(*namespaces: Union[ModuleType, Mapping[str, Any]]) -> Iterable
                 rule = getattr(item, "rule", None)
                 if isinstance(rule, TaskRule):
                     for input in rule.input_selectors:
-                        if issubclass(input, Optionable):
+                        if issubclass(input, Subsystem):
                             yield SubsystemRule(input)
                     if issubclass(rule.output_type, Goal):
                         yield SubsystemRule(rule.output_type.subsystem_cls)

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -237,25 +237,25 @@ class HelpInfoExtracter:
         name_to_goal_info = {}
         for scope_info in sorted(options.known_scope_to_info.values(), key=lambda x: x.scope):
             options.for_scope(scope_info.scope)  # Force parsing.
-            optionable_cls = scope_info.optionable_cls
+            subsystem_cls = scope_info.subsystem_cls
             if not scope_info.description:
                 cls_name = (
-                    f"{optionable_cls.__module__}.{optionable_cls.__qualname__}"
-                    if optionable_cls
+                    f"{subsystem_cls.__module__}.{subsystem_cls.__qualname__}"
+                    if subsystem_cls
                     else ""
                 )
                 raise ValueError(
                     f"Subsystem {cls_name} with scope `{scope_info.scope}` has no description. "
                     f"Add a class property `help`."
                 )
-            is_goal = optionable_cls is not None and issubclass(optionable_cls, GoalSubsystem)
+            is_goal = subsystem_cls is not None and issubclass(subsystem_cls, GoalSubsystem)
             oshi = HelpInfoExtracter(scope_info.scope).get_option_scope_help_info(
                 scope_info.description, options.get_parser(scope_info.scope), is_goal
             )
             scope_to_help_info[oshi.scope] = oshi
 
             if is_goal:
-                goal_subsystem_cls = cast(Type[GoalSubsystem], optionable_cls)
+                goal_subsystem_cls = cast(Type[GoalSubsystem], subsystem_cls)
                 is_implemented = union_membership.has_members_for_all(
                     goal_subsystem_cls.required_union_implementations
                 )

--- a/src/python/pants/option/optionable.py
+++ b/src/python/pants/option/optionable.py
@@ -81,7 +81,7 @@ class Optionable(metaclass=ABCMeta):
     def get_scope_info(cls) -> ScopeInfo:
         """Returns a ScopeInfo instance representing this Optionable's options scope."""
         cls.validate_scope()
-        return cls.create_scope_info(scope=cls.options_scope, optionable_cls=cls)
+        return cls.create_scope_info(scope=cls.options_scope, subsystem_cls=cls)
 
     @classmethod
     def register_options(cls, register):
@@ -96,7 +96,7 @@ class Optionable(metaclass=ABCMeta):
 
         Subclasses should not generally need to override this method.
         """
-        cls.register_options(options.registration_function_for_optionable(cls))
+        cls.register_options(options.registration_function_for_subsystem(cls))
 
     def __init__(self, options: OptionValueContainer) -> None:
         self.validate_scope()

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -88,7 +88,7 @@ class Options:
             original_scopes[si.scope] = si
             ret.add(si)
             if si.deprecated_scope:
-                ret.add(ScopeInfo(si.deprecated_scope, si.optionable_cls))
+                ret.add(ScopeInfo(si.deprecated_scope, si.subsystem_cls))
                 original_scopes[si.deprecated_scope] = si
         return FrozenOrderedSet(ret)
 
@@ -253,18 +253,18 @@ class Options:
         if deprecated_scope:
             self.get_parser(deprecated_scope).register(*args, **kwargs)
 
-    def registration_function_for_optionable(self, optionable_class):
+    def registration_function_for_subsystem(self, subsystem_cls):
         """Returns a function for registering options on the given scope."""
 
         # TODO(benjy): Make this an instance of a class that implements __call__, so we can
         # docstring it, and so it's less weird than attaching properties to a function.
         def register(*args, **kwargs):
-            self.register(optionable_class.options_scope, *args, **kwargs)
+            self.register(subsystem_cls.options_scope, *args, **kwargs)
 
         # Clients can access the bootstrap option values as register.bootstrap.
         register.bootstrap = self.bootstrap_option_values()
         # Clients can access the scope as register.scope.
-        register.scope = optionable_class.options_scope
+        register.scope = subsystem_cls.options_scope
         return register
 
     def get_parser(self, scope: str) -> Parser:
@@ -299,8 +299,8 @@ class Options:
                 )
 
         # Check if we're the new name of a deprecated scope, and clone values from that scope.
-        # Note that deprecated_scope and scope share the same Optionable class, so deprecated_scope's
-        # Optionable has a deprecated_options_scope equal to deprecated_scope. Therefore we must
+        # Note that deprecated_scope and scope share the same Subsystem class, so deprecated_scope's
+        # Subsystem has a deprecated_options_scope equal to deprecated_scope. Therefore we must
         # check that scope != deprecated_scope to prevent infinite recursion.
         deprecated_scope = si.deprecated_scope
         if deprecated_scope is not None and scope != deprecated_scope:

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -16,9 +16,9 @@ from pants.build_graph.build_configuration import BuildConfiguration
 from pants.option.config import Config
 from pants.option.custom_types import ListValueComponent
 from pants.option.global_options import GlobalOptions
-from pants.option.optionable import Optionable
 from pants.option.options import Options
 from pants.option.scope import GLOBAL_SCOPE, ScopeInfo
+from pants.option.subsystem import Subsystem
 from pants.util.dirutil import read_file
 from pants.util.memo import memoized_method, memoized_property
 from pants.util.ordered_set import FrozenOrderedSet
@@ -223,12 +223,12 @@ class OptionsBootstrapper:
             allow_unknown_options=allow_unknown_options,
         )
 
-        distinct_optionable_classes: Set[Type[Optionable]] = set()
+        distinct_subsystem_classes: Set[Type[Subsystem]] = set()
         for ksi in known_scope_infos:
-            if not ksi.optionable_cls or ksi.optionable_cls in distinct_optionable_classes:
+            if not ksi.subsystem_cls or ksi.subsystem_cls in distinct_subsystem_classes:
                 continue
-            distinct_optionable_classes.add(ksi.optionable_cls)
-            ksi.optionable_cls.register_options_on_scope(options)
+            distinct_subsystem_classes.add(ksi.subsystem_cls)
+            ksi.subsystem_cls.register_options_on_scope(options)
 
         return options
 
@@ -256,7 +256,7 @@ class OptionsBootstrapper:
 
         # Parse and register options.
         known_scope_infos = [
-            optionable.get_scope_info() for optionable in build_configuration.all_optionables
+            subsystem.get_scope_info() for subsystem in build_configuration.all_subsystems
         ]
         options = self.full_options_for_scopes(
             known_scope_infos, allow_unknown_options=build_configuration.allow_unknown_options

--- a/src/python/pants/option/scope.py
+++ b/src/python/pants/option/scope.py
@@ -26,8 +26,8 @@ class ScopeInfo:
     """Information about a scope."""
 
     scope: str
-    optionable_cls: Optional[Type] = None
-    # A ScopeInfo may have a deprecated_scope (from its associated optionable_cls), which represents
+    subsystem_cls: Optional[Type] = None
+    # A ScopeInfo may have a deprecated_scope (from its associated subsystem_cls), which represents
     # a previous/deprecated name for a current/non-deprecated ScopeInfo. It may also be directly
     # deprecated via this `removal_version`, which allows for the deprecation of an entire scope.
     removal_version: Optional[str] = None
@@ -38,21 +38,21 @@ class ScopeInfo:
 
     @property
     def description(self) -> str:
-        return cast(str, getattr(self.optionable_cls, "help"))
+        return cast(str, getattr(self.subsystem_cls, "help"))
 
     @property
     def deprecated_scope(self) -> Optional[str]:
-        return cast(Optional[str], self._optionable_cls_attr("deprecated_options_scope"))
+        return cast(Optional[str], self._subsystem_cls_attr("deprecated_options_scope"))
 
     @property
     def deprecated_scope_removal_version(self) -> Optional[str]:
         return cast(
             Optional[str],
-            self._optionable_cls_attr("deprecated_options_scope_removal_version"),
+            self._subsystem_cls_attr("deprecated_options_scope_removal_version"),
         )
 
-    def _optionable_cls_attr(self, name: str, default=None):
-        return getattr(self.optionable_cls, name) if self.optionable_cls else default
+    def _subsystem_cls_attr(self, name: str, default=None):
+        return getattr(self.subsystem_cls, name) if self.subsystem_cls else default
 
 
 @dataclass(frozen=True)

--- a/tests/python/pants_test/init/test_extension_loader.py
+++ b/tests/python/pants_test/init/test_extension_loader.py
@@ -141,7 +141,7 @@ class LoaderTest(unittest.TestCase):
         registered_aliases = build_configuration.registered_aliases
         self.assertEqual(0, len(registered_aliases.objects))
         self.assertEqual(0, len(registered_aliases.context_aware_object_factories))
-        self.assertEqual(build_configuration.optionables, FrozenOrderedSet())
+        self.assertEqual(build_configuration.subsystems, FrozenOrderedSet())
         self.assertEqual(0, len(build_configuration.rules))
         self.assertEqual(0, len(build_configuration.target_types))
 
@@ -158,7 +158,7 @@ class LoaderTest(unittest.TestCase):
             registered_aliases = build_configuration.registered_aliases
             self.assertEqual(DummyObject1, registered_aliases.objects["obj1"])
             self.assertEqual(DummyObject2, registered_aliases.objects["obj2"])
-            self.assertEqual(build_configuration.optionables, FrozenOrderedSet([DummySubsystem]))
+            self.assertEqual(build_configuration.subsystems, FrozenOrderedSet([DummySubsystem]))
 
     def test_load_invalid_entrypoint(self):
         def build_file_aliases(bad_arg):
@@ -280,7 +280,7 @@ class LoaderTest(unittest.TestCase):
         registered_aliases = build_configuration.registered_aliases
         self.assertEqual(DummyObject1, registered_aliases.objects["FROMPLUGIN1"])
         self.assertEqual(DummyObject2, registered_aliases.objects["FROMPLUGIN2"])
-        self.assertEqual(build_configuration.optionables, FrozenOrderedSet([DummySubsystem]))
+        self.assertEqual(build_configuration.subsystems, FrozenOrderedSet([DummySubsystem]))
 
     def test_rules(self):
         def backend_rules():


### PR DESCRIPTION
Removes the "optionable" terminology from the codebase,
other than as a now-secret base class for Subsystem.

A future change will get rid of that last wrinkle.

[ci skip-rust]

[ci skip-build-wheels]