### PR TITLE
Reintroduce structure-sharing for BUILD dependencies

### DIFF
--- a/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints_test.py
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints_test.py
@@ -66,12 +66,12 @@ def test_render_constraints(rule_runner: RuleRunner) -> None:
         CPython==3.7.*
           app
 
+        CPython==2.7.* OR CPython>=3.5
+          lib1
+
         CPython>=3.6
           lib2/a.py
           lib2/b.py
-
-        CPython==2.7.* OR CPython>=3.5
-          lib1
         """
     )
 

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -182,7 +182,7 @@ class _TransitiveTargetRequest(EngineAwareParameter):
     address: Address
     include_special_cased_deps: bool
 
-    def debug_hint(self) -> Optional[str]:
+    def debug_hint(self) -> str | None:
         return str(self.address)
 
 
@@ -194,8 +194,8 @@ class _TransitiveTarget:
     """
 
     root: Target
-    build_dependencies: Tuple["_TransitiveTarget", ...]
-    file_dependencies: Tuple[Address, ...]
+    build_dependencies: tuple[_TransitiveTarget, ...]
+    file_dependencies: tuple[Address, ...]
 
 
 @rule

--- a/src/rust/engine/src/externs/engine_aware.rs
+++ b/src/rust/engine/src/externs/engine_aware.rs
@@ -10,20 +10,10 @@ use crate::Types;
 use cpython::{PyDict, PyString, Python};
 use workunit_store::{ArtifactOutput, Level};
 
-// TODO all `retrieve` implementations should add a check that the `Value` actually subclasses
-// `EngineAware`
-
-pub trait EngineAwareInformation {
-  type MaybeOutput;
-  fn retrieve(types: &Types, value: &Value) -> Option<Self::MaybeOutput>;
-}
-
 pub struct EngineAwareLevel {}
 
-impl EngineAwareInformation for EngineAwareLevel {
-  type MaybeOutput = Level;
-
-  fn retrieve(_types: &Types, value: &Value) -> Option<Level> {
+impl EngineAwareLevel {
+  pub fn retrieve(value: &Value) -> Option<Level> {
     let new_level_val = externs::call_method(value.as_ref(), "level", &[]).ok()?;
     let new_level_val = externs::check_for_python_none(new_level_val)?;
     externs::val_to_log_level(&new_level_val).ok()
@@ -32,10 +22,8 @@ impl EngineAwareInformation for EngineAwareLevel {
 
 pub struct Message {}
 
-impl EngineAwareInformation for Message {
-  type MaybeOutput = String;
-
-  fn retrieve(_types: &Types, value: &Value) -> Option<String> {
+impl Message {
+  pub fn retrieve(value: &Value) -> Option<String> {
     let msg_val = externs::call_method(value, "message", &[]).ok()?;
     let msg_val = externs::check_for_python_none(msg_val)?;
     Some(externs::val_to_str(&msg_val))
@@ -44,10 +32,8 @@ impl EngineAwareInformation for Message {
 
 pub struct Metadata;
 
-impl EngineAwareInformation for Metadata {
-  type MaybeOutput = Vec<(String, Value)>;
-
-  fn retrieve(_types: &Types, value: &Value) -> Option<Self::MaybeOutput> {
+impl Metadata {
+  pub fn retrieve(value: &Value) -> Option<Vec<(String, Value)>> {
     let metadata_val = match externs::call_method(value, "metadata", &[]) {
       Ok(value) => value,
       Err(py_err) => {
@@ -84,10 +70,8 @@ impl EngineAwareInformation for Metadata {
 
 pub struct Artifacts {}
 
-impl EngineAwareInformation for Artifacts {
-  type MaybeOutput = Vec<(String, ArtifactOutput)>;
-
-  fn retrieve(types: &Types, value: &Value) -> Option<Self::MaybeOutput> {
+impl Artifacts {
+  pub fn retrieve(types: &Types, value: &Value) -> Option<Vec<(String, ArtifactOutput)>> {
     let artifacts_val = match externs::call_method(value, "artifacts", &[]) {
       Ok(value) => value,
       Err(py_err) => {
@@ -145,10 +129,8 @@ impl EngineAwareInformation for Artifacts {
 
 pub struct DebugHint {}
 
-impl EngineAwareInformation for DebugHint {
-  type MaybeOutput = String;
-
-  fn retrieve(_types: &Types, value: &Value) -> Option<String> {
+impl DebugHint {
+  pub fn retrieve(value: &Value) -> Option<String> {
     externs::call_method(value, "debug_hint", &[])
       .ok()
       .and_then(externs::check_for_python_none)


### PR DESCRIPTION
As described in #11270, when we introduced cycle tolerance, we also removed the structure-sharing behind `TransitiveTargets` computation.

This change reintroduces structure-sharing for BUILD dependencies, while continuing to iterate for file dependencies. This allows us to reuse all cycle detection work executed by the rust Graph (since BUILD dependencies end up encoded as recursive rule invokes for the `transitive_target` `@rule`), and remove Python-side cycle detection.

For `typecheck ::` (which computes `TransitiveTargets` for every target), this is about 10% faster.
```
master:
    $ hyperfine -w 1 -p 'rm -Rf .pids; sleep 2; ./pants help' './pants typecheck ::'
    Benchmark #1: ./pants typecheck ::
      Time (mean ± σ):     19.187 s ±  0.381 s    [User: 160.4 ms, System: 176.3 ms]
      Range (min … max):   18.239 s … 19.623 s    10 runs

branch:
    $ hyperfine -w 1 -p 'rm -Rf .pids; sleep 2; ./pants help' './pants typecheck ::'
    Benchmark #1: ./pants typecheck ::
      Time (mean ± σ):     21.353 s ±  1.096 s    [User: 166.6 ms, System: 182.7 ms]
      Range (min … max):   18.658 s … 22.423 s    10 runs
```

Fixes #11270.

[ci skip-build-wheels]