### PR TITLE
[internal] Add `InterpreterConstraints.flatten()` in preparation for Poetry lockfiles

### DIFF
--- a/src/python/pants/backend/python/util_rules/interpreter_constraints.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints.py
@@ -414,7 +414,8 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
                 "interpreter versions from `[python-setup].interpreter_versions_universe`.\n\n"
                 "Please either change these interpreter constraints or update the "
                 "`interpreter_versions_universe` to include the interpreters set in these "
-                "constraints."
+                "constraints. Run `./pants help-advanced pytest` for more information on the "
+                "`interpreter_versions_universe` option."
             )
 
         return valid_py27_patches, valid_py3_patches

--- a/src/python/pants/backend/python/util_rules/interpreter_constraints.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints.py
@@ -278,9 +278,9 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
             result = f"{lower_bound},{upper_bound}"
             if skipped:
                 result += "," + ",".join(f"!={v}" for v in skipped)
-            return Requirement.parse(  # type:ignore[no-any-return]
+            return Requirement.parse(  # type:ignore[no-any-return,attr-defined]
                 f"doesnt-matter{result}"
-            ).specifier  # type: ignore[attr-defined]
+            ).specifier
 
         if valid_py27_patches:
             lower_bound = _determine_lower_bound(2, 7, valid_py27_patches[0])

--- a/src/python/pants/backend/python/util_rules/interpreter_constraints.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints.py
@@ -414,7 +414,7 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
                 "interpreter versions from `[python-setup].interpreter_versions_universe`.\n\n"
                 "Please either change these interpreter constraints or update the "
                 "`interpreter_versions_universe` to include the interpreters set in these "
-                "constraints. Run `./pants help-advanced pytest` for more information on the "
+                "constraints. Run `./pants help-advanced python-setup` for more information on the "
                 "`interpreter_versions_universe` option."
             )
 

--- a/src/python/pants/backend/python/util_rules/interpreter_constraints_test.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints_test.py
@@ -10,7 +10,10 @@ import pytest
 from pkg_resources import Requirement
 
 from pants.backend.python.target_types import InterpreterConstraintsField
-from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
+from pants.backend.python.util_rules.interpreter_constraints import (
+    _EXPECTED_LAST_PATCH_VERSION,
+    InterpreterConstraints,
+)
 from pants.build_graph.address import Address
 from pants.engine.target import FieldSet
 from pants.python.python_setup import PythonSetup
@@ -281,3 +284,66 @@ def test_group_field_sets_by_constraints_with_unsorted_inputs() -> None:
             Address("src/python/c_dir/path.py", target_name="test"), "==3.6.*"
         ),
     )
+
+
+_SKIPPED_PY3 = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
+
+
+@pytest.mark.parametrize(
+    "constraints,expected",
+    (
+        # If it's a single constraint already, simply preserve it.
+        (["==2.7.3"], "==2.7.3"),
+        ([">=3.6,<4"], ">=3.6,<4"),
+        ([">=2.7.3,<2.7.6,!=2.7.4"], ">=2.7.3,<2.7.6,!=2.7.4"),
+        # Python 2.7 only.
+        (["==2.7.13", "==2.7.14"], ">=2.7.13,<=2.7.14"),
+        (["==2.7.13", "==2.7.14", "==2.7.15"], ">=2.7.13,<=2.7.15"),
+        (["==2.7.13", ">=2.7.15,<3"], ">=2.7.13,<2.8,!=2.7.14"),
+        (["==2.7.*", ">=2.7.15,<2.8"], ">=2.7,<2.8"),
+        (["==2.7.*,!=2.7.1", ">=2.7.15,<2.8"], ">=2.7,<2.8,!=2.7.1"),
+        # Python 3, single minor version only.
+        (["==3.6.8", "==3.6.9"], ">=3.6.8,<=3.6.9"),
+        (["==3.6.13", ">=3.6.15,<3.7"], ">=3.6.13,<3.7,!=3.6.14"),
+        (["==3.6.*", ">=3.6.15,<3.7"], ">=3.6,<3.7"),
+        (["==3.6.*,!=3.6.1", ">=3.6.15,<3.7"], ">=3.6,<3.7,!=3.6.1"),
+        # Python 3, multiple versions.
+        (["==3.6.*", "==3.7.*"], ">=3.6,<3.8"),
+        ([">=3.6.2,<3.7", "==3.7.*"], ">=3.6.2,<3.8"),
+        (["==3.6.*,!=3.6.5", "==3.7.*"], ">=3.6,<3.8,!=3.6.5"),
+        (["==3.6.*", "==3.8.*"], ">=3.6,<3.9,!=3.7.*"),
+        # Python 2.7 mixed w/ Python 3.
+        (["==2.7.*", ">=3.5,<4"], f">=2.7,<3.10,{_SKIPPED_PY3}"),
+        (["==2.7.*,!=2.7.18", ">=3.5,<4"], f">=2.7,<3.10,!=2.7.18,{_SKIPPED_PY3}"),
+        (["==2.7.*", ">=3.5,<3.6"], f">=2.7,<3.6,{_SKIPPED_PY3}"),
+        (["==2.7.*", ">=3.5,<3.5.4"], f">=2.7,<=3.5.3,{_SKIPPED_PY3}"),
+        (["==2.7.*", ">=3.5.2,<3.6"], f">=2.7,<3.6,{_SKIPPED_PY3},!=3.5.0,!=3.5.1"),
+        (["==2.7.*", ">=3.5.2,<3.5.4"], f">=2.7,<=3.5.3,{_SKIPPED_PY3},!=3.5.0,!=3.5.1"),
+        (
+            ["==2.7.13", "==3.5.3"],
+            (
+                ">=2.7.13,<=3.5.3,"
+                + ",".join(f"!=2.7.{p}" for p in range(14, _EXPECTED_LAST_PATCH_VERSION + 1))
+                + f",{_SKIPPED_PY3},!=3.5.0,!=3.5.1,!=3.5.2"
+            ),
+        ),
+        (["==2.7.*", ">=3.5,<3.6.4"], f">=2.7,<=3.6.3,{_SKIPPED_PY3}"),
+        (["==2.7.*", ">=3.5.2,<3.6.4"], f">=2.7,<=3.6.3,{_SKIPPED_PY3},!=3.5.0,!=3.5.1"),
+        (["==2.7.*", ">=3.5,<3.6.4,!=3.6.0"], f">=2.7,<=3.6.3,{_SKIPPED_PY3},!=3.6.0"),
+        (["==2.7.*", "==3.5.*", "==3.8.*"], f">=2.7,<3.9,{_SKIPPED_PY3},!=3.6.*,!=3.7.*"),
+        (
+            ["==2.7.*", "==3.5.*", ">=3.7.15,<3.8", "==3.8.*"],
+            (f">=2.7,<3.9,{_SKIPPED_PY3},!=3.6.*," + ",".join(f"!=3.7.{p}" for p in range(0, 15))),
+        ),
+    ),
+)
+def test_flatten(constraints: list[str], expected: str) -> None:
+    assert InterpreterConstraints(constraints).flatten(
+        ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9"]
+    ) == Requirement.parse(f"CPython{expected}")
+
+
+@pytest.mark.parametrize("version", ["2.6", "2.8", "4.1", "1.0"])
+def test_flatten_invalid_universe(version: str) -> None:
+    with pytest.raises(AssertionError):
+        InterpreterConstraints(["==2.7.*", "==3.5.*"]).flatten([version])


### PR DESCRIPTION
## Problem

We allow ICs to be a list, where each element is ORed. For example, `['==2.7.*', '==3.6.*']` means "2.7 OR 3.6". 

However, Poetry expects the interpreter constraints to be a single constraint, and it has no notion of "OR". So, we need an automated way to convert into a format understood by Poetry.

## Algorithm strategy

Find the upper and lower bounds of the interpreter constraints, while also finding any versions to skip. With this, we can Include the entire possible range, but blocklist any skipped versions.

For example, `['==3.3.*', '==3.5.*.']` becomes `>=3.3,<3.6,!=3.4.*'`.

Where possible, we try to make the result more readable, like preferring `!=3.7.*` over `!=3.7.0,!=3.7.1,...`.