### PR TITLE
Fix shfmt/desktop use of `Platform` enum.

### DIFF
--- a/src/python/pants/backend/shell/lint/shfmt/subsystem.py
+++ b/src/python/pants/backend/shell/lint/shfmt/subsystem.py
@@ -59,8 +59,8 @@ class Shfmt(TemplatedExternalTool):
         )
 
     def generate_exe(self, plat: Platform) -> str:
-        plat_str = "linux" if plat == Platform.linux else "darwin"
-        return f"./shfmt_{self.version}_{plat_str}_amd64"
+        plat_str = self.default_url_platform_mapping[plat.value]
+        return f"./shfmt_{self.version}_{plat_str}"
 
     @property
     def skip(self) -> bool:

--- a/src/python/pants/engine/desktop.py
+++ b/src/python/pants/engine/desktop.py
@@ -37,7 +37,7 @@ async def find_open_program(
     plat: Platform,
     complete_env: CompleteEnvironment,
 ) -> OpenFiles:
-    open_program_name = "open" if plat == Platform.darwin else "xdg-open"
+    open_program_name = "open" if plat.is_macos else "xdg-open"
     open_program_paths = await Get(
         BinaryPaths,
         BinaryPathRequest(binary_name=open_program_name, search_path=("/bin", "/usr/bin")),
@@ -52,7 +52,7 @@ async def find_open_program(
         logger.error(error)
         return OpenFiles(())
 
-    if plat == Platform.darwin:
+    if plat.is_macos:
         processes = [
             InteractiveProcess(
                 argv=(open_program_paths.first_path.path, *(str(f) for f in request.files)),

--- a/src/python/pants/engine/platform.py
+++ b/src/python/pants/engine/platform.py
@@ -41,6 +41,10 @@ class Platform(Enum):
         Platform.deprecated_due_to_no_architecture()
         return Platform.macos_x86_64
 
+    @property
+    def is_macos(self) -> bool:
+        return self in [Platform.macos_arm64, Platform.macos_x86_64]
+
     def matches(self, value):
         """Returns true if the provided value is the value for this platform, or if the provided
         value is the value for the deprecated platform symbol from before we qualified based on


### PR DESCRIPTION
Closes #12476

# Rust tests and lints will be skipped. Delete if not intended.
[ci skip-rust]

# Building wheels and fs_util will be skipped. Delete if not intended.
[ci skip-build-wheels]