### PR TITLE
Deprecate `--pants-supportdir`, rename `--engine-visualize-to`, and fix help for `--loop`. (#12558)

### DIFF
--- a/src/python/pants/engine/internals/scheduler_integration_test.py
+++ b/src/python/pants/engine/internals/scheduler_integration_test.py
@@ -9,13 +9,13 @@ from pants.util.contextutil import temporary_dir
 
 
 def test_visualize_to():
-    # Tests usage of the `--native-engine-visualize-to=` option, which triggers background
+    # Tests usage of the `--engine-visualize-to=` option, which triggers background
     # visualization of the graph. There are unit tests confirming the content of the rendered
     # results.
     with temporary_dir(root_dir=os.getcwd()) as destdir:
         run_pants(
             [
-                f"--native-engine-visualize-to={destdir}",
+                f"--engine-visualize-to={destdir}",
                 "--backend-packages=pants.backend.python",
                 "list",
                 "testprojects/src/python/hello/greet",

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -177,6 +177,7 @@ class EngineInitializer:
         executor = executor or GlobalOptions.create_py_executor(bootstrap_options)
         execution_options = ExecutionOptions.from_options(bootstrap_options, dynamic_remote_options)
         local_store_options = LocalStoreOptions.from_options(bootstrap_options)
+        engine_visualize_to = GlobalOptions.compute_engine_visualize_to(bootstrap_options)
         return EngineInitializer.setup_graph_extended(
             build_configuration,
             execution_options,
@@ -189,7 +190,7 @@ class EngineInitializer:
             ca_certs_path=bootstrap_options.ca_certs_path,
             build_root=build_root,
             include_trace_on_error=bootstrap_options.print_stacktrace,
-            native_engine_visualize_to=bootstrap_options.native_engine_visualize_to,
+            engine_visualize_to=engine_visualize_to,
             watch_filesystem=bootstrap_options.watch_filesystem,
         )
 
@@ -207,7 +208,7 @@ class EngineInitializer:
         ca_certs_path: Optional[str] = None,
         build_root: Optional[str] = None,
         include_trace_on_error: bool = True,
-        native_engine_visualize_to: Optional[str] = None,
+        engine_visualize_to: Optional[str] = None,
         watch_filesystem: bool = True,
     ) -> GraphScheduler:
         build_root_path = build_root or get_buildroot()
@@ -294,7 +295,7 @@ class EngineInitializer:
             execution_options=execution_options,
             local_store_options=local_store_options,
             include_trace_on_error=include_trace_on_error,
-            visualize_to_dir=native_engine_visualize_to,
+            visualize_to_dir=engine_visualize_to,
             watch_filesystem=watch_filesystem,
         )
 

--- a/src/python/pants/option/config.py
+++ b/src/python/pants/option/config.py
@@ -407,16 +407,13 @@ class _ConfigValues:
 
     def has_option(self, section: str, option: str) -> bool:
         try:
-            self._get_value(section, option, allow_default=False)
+            self.get_value(section, option)
         except (configparser.NoSectionError, configparser.NoOptionError):
             return False
         else:
             return True
 
     def get_value(self, section: str, option: str) -> str | None:
-        return self._get_value(section, option)
-
-    def _get_value(self, section: str, option: str, *, allow_default: bool = True) -> str | None:
         section_values = self._find_section_values(section)
         if section_values is None:
             raise configparser.NoSectionError(section)
@@ -427,9 +424,8 @@ class _ConfigValues:
             section_values=section_values,
         )
         if option not in section_values:
-            if not allow_default or option not in self.defaults:
+            if option not in self.defaults:
                 raise configparser.NoOptionError(option, section)
-            self._maybe_deprecated_default(option)
             return stringify(raw_value=self.defaults[option])
         option_value = section_values[option]
         # Handle the special `my_list_option.add` and `my_list_option.remove` syntax.

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1545,7 +1545,7 @@ class GlobalOptions(Subsystem):
     def compute_engine_visualize_to(bootstrap_options: OptionValueContainer) -> str | None:
         result = resolve_conflicting_options(
             old_option="native_engine_visualize_to",
-            new_option="native_engine_visualize_to",
+            new_option="engine_visualize_to",
             old_scope="",
             new_scope="",
             old_container=bootstrap_options,

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -171,7 +171,7 @@ class RuleRunner:
             executor=_EXECUTOR,
             execution_options=ExecutionOptions.from_options(global_options, dynamic_remote_options),
             ca_certs_path=ca_certs_path,
-            native_engine_visualize_to=None,
+            engine_visualize_to=None,
         ).new_session(
             build_id="buildid_for_test",
             session_values=SessionValues(


### PR DESCRIPTION
* Fix wording of the `--loop` option, which is stable now.
* Rename `--native-engine-visualize-to` to `--engine-visualize-to` (could potentially be shortened further, but the "native" bit stood out).
* Prepare to remove `--pants-supportdir` by deprecating templating of that value into `pants.toml`.

[ci skip-rust]
[ci skip-build-wheels]