### PR TITLE
[internal] Convert `pkg_resources.Requirement` into a Poetry `pyproject.toml` dependency

### DIFF
--- a/src/python/pants/backend/python/util_rules/poetry_conversions.py
+++ b/src/python/pants/backend/python/util_rules/poetry_conversions.py
@@ -1,0 +1,39 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from pkg_resources import Requirement
+
+
+@dataclass(frozen=True)
+class PoetryDependency:
+    name: str
+    version: str | None
+    extras: tuple[str, ...] = ()
+    markers: str | None = None
+
+    @classmethod
+    def from_requirement(cls, requirement: Requirement) -> PoetryDependency:
+        return PoetryDependency(
+            requirement.project_name,
+            version=str(requirement.specifier) or None,
+            extras=requirement.extras,
+            markers=str(requirement.marker) if requirement.marker else None,
+        )
+
+    def to_pyproject_toml_dependency(self) -> dict[str, Any]:
+        """Return a dictionary with one element of `project_name -> metadata`.
+
+        This can then be serialized using the `toml` library by being added to the
+        `[tool.poetry.dependencies]` section.
+        """
+        metadata = {"version": self.version or "*"}
+        if self.extras:
+            metadata["extras"] = self.extras
+        if self.markers:
+            metadata["markers"] = self.markers
+        return {self.name: metadata}

--- a/src/python/pants/backend/python/util_rules/poetry_conversions.py
+++ b/src/python/pants/backend/python/util_rules/poetry_conversions.py
@@ -21,7 +21,7 @@ class PoetryDependency:
         return PoetryDependency(
             requirement.project_name,
             version=str(requirement.specifier) or None,  # type: ignore[attr-defined]
-            extras=requirement.extras,
+            extras=tuple(sorted(requirement.extras)),
             markers=str(requirement.marker) if requirement.marker else None,
         )
 

--- a/src/python/pants/backend/python/util_rules/poetry_conversions_test.py
+++ b/src/python/pants/backend/python/util_rules/poetry_conversions_test.py
@@ -1,0 +1,50 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import pytest
+from pkg_resources import Requirement
+
+from pants.backend.python.util_rules.poetry_conversions import PoetryDependency
+
+
+@pytest.mark.parametrize(
+    "req_str,expected",
+    [
+        ("dep==1.0", PoetryDependency("dep", version="==1.0")),
+        ("dep>=1.0,<6,!=2.0", PoetryDependency("dep", version="!=2.0,<6,>=1.0")),
+        ("dep", PoetryDependency("dep", version=None)),
+        # Extras.
+        ("dep[extra1]", PoetryDependency("dep", version=None, extras=("extra1",))),
+        ("dep[extra1,extra2]", PoetryDependency("dep", version=None, extras=("extra2", "extra1"))),
+        # Markers.
+        (
+            "dep ; sys_platform == 'darwin'",
+            PoetryDependency("dep", version=None, markers='sys_platform == "darwin"'),
+        ),
+    ],
+)
+def test_poetry_dependency_from_requirement(req_str: str, expected: PoetryDependency) -> None:
+    req = Requirement.parse(req_str)
+    assert PoetryDependency.from_requirement(req) == expected
+
+
+@pytest.mark.parametrize(
+    "dep,expected",
+    [
+        (PoetryDependency("dep", version="==1.0"), {"dep": {"version": "==1.0"}}),
+        (PoetryDependency("dep", version=">=1.0,<6,!=2.0"), {"dep": {"version": ">=1.0,<6,!=2.0"}}),
+        (PoetryDependency("dep", version=None), {"dep": {"version": "*"}}),
+        # Extras.
+        (
+            PoetryDependency("dep", version=None, extras=("extra1", "extra2")),
+            {"dep": {"version": "*", "extras": ("extra1", "extra2")}},
+        ),
+        # Markers.
+        (
+            PoetryDependency("dep", version=None, markers='sys_platform == "darwin"'),
+            {"dep": {"version": "*", "markers": 'sys_platform == "darwin"'}},
+        ),
+    ],
+)
+def test_poetry_dependency_to_pyproject_toml(dep: PoetryDependency, expected: str) -> None:
+    assert dep.to_pyproject_toml_dependency() == expected

--- a/src/python/pants/backend/python/util_rules/poetry_conversions_test.py
+++ b/src/python/pants/backend/python/util_rules/poetry_conversions_test.py
@@ -19,7 +19,7 @@ from pants.backend.python.util_rules.poetry_conversions import PoetryDependency
         ("dep", PoetryDependency("dep", version=None)),
         # Extras.
         ("dep[extra1]", PoetryDependency("dep", version=None, extras=("extra1",))),
-        ("dep[extra1,extra2]", PoetryDependency("dep", version=None, extras=("extra2", "extra1"))),
+        ("dep[extra1,extra2]", PoetryDependency("dep", version=None, extras=("extra1", "extra2"))),
         # Markers.
         (
             "dep ; sys_platform == 'darwin'",

--- a/src/python/pants/backend/python/util_rules/poetry_conversions_test.py
+++ b/src/python/pants/backend/python/util_rules/poetry_conversions_test.py
@@ -1,6 +1,10 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
+from typing import Any
+
 import pytest
 from pkg_resources import Requirement
 
@@ -29,22 +33,43 @@ def test_poetry_dependency_from_requirement(req_str: str, expected: PoetryDepend
 
 
 @pytest.mark.parametrize(
-    "dep,expected",
+    "deps,expected",
     [
-        (PoetryDependency("dep", version="==1.0"), {"dep": {"version": "==1.0"}}),
-        (PoetryDependency("dep", version=">=1.0,<6,!=2.0"), {"dep": {"version": ">=1.0,<6,!=2.0"}}),
-        (PoetryDependency("dep", version=None), {"dep": {"version": "*"}}),
+        ([PoetryDependency("dep", version="==1.0")], {"dep": {"version": "==1.0"}}),
+        (
+            [PoetryDependency("dep", version=">=1.0,<6,!=2.0")],
+            {"dep": {"version": ">=1.0,<6,!=2.0"}},
+        ),
+        ([PoetryDependency("dep", version=None)], {"dep": {"version": "*"}}),
         # Extras.
         (
-            PoetryDependency("dep", version=None, extras=("extra1", "extra2")),
+            [PoetryDependency("dep", version=None, extras=("extra1", "extra2"))],
             {"dep": {"version": "*", "extras": ("extra1", "extra2")}},
         ),
         # Markers.
         (
-            PoetryDependency("dep", version=None, markers='sys_platform == "darwin"'),
+            [PoetryDependency("dep", version=None, markers='sys_platform == "darwin"')],
             {"dep": {"version": "*", "markers": 'sys_platform == "darwin"'}},
+        ),
+        # Multiple values for the same dependency.
+        (
+            [
+                PoetryDependency("dep", version="==1.0"),
+                PoetryDependency("dep", version="==2.0"),
+                PoetryDependency("dep", version="==3.0", extras=("some-extra",)),
+            ],
+            {
+                "dep": [
+                    {"version": "==1.0"},
+                    {"version": "==2.0"},
+                    {"version": "==3.0", "extras": ("some-extra",)},
+                ]
+            },
         ),
     ],
 )
-def test_poetry_dependency_to_pyproject_toml(dep: PoetryDependency, expected: str) -> None:
-    assert dep.to_pyproject_toml_dependency() == expected
+def test_poetry_dependency_to_pyproject_toml(
+    deps: list[PoetryDependency],
+    expected: dict[str, dict[str, Any] | list[dict[str, Any]]],
+) -> None:
+    assert PoetryDependency.to_pyproject_toml_dependency(deps) == expected


### PR DESCRIPTION
Split out from https://github.com/pantsbuild/pants/pull/12549. 

This punts on PEP 440 direct references, but otherwise should support all the variants of dependencies specified in https://python-poetry.org/docs/dependency-specification, including:

- extras
- environment markers
- multiple entries for the same project

Note that we ignore Poetry's `python` attribute. Instead, we simply preserve any Python env markers like `python_version > '2.7'`.