### PR TITLE
[internal] Fixup fs/store/benches and add a benchmark for various materialize sizes

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -57,7 +57,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.53.0-*
+        path: '~/.rustup/toolchains/1.54.0-*
 
           ~/.rustup/update-hashes
 
@@ -206,7 +206,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.53.0-*
+        path: '~/.rustup/toolchains/1.54.0-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,7 +57,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.53.0-*
+        path: '~/.rustup/toolchains/1.54.0-*
 
           ~/.rustup/update-hashes
 
@@ -205,7 +205,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.53.0-*
+        path: '~/.rustup/toolchains/1.54.0-*
 
           ~/.rustup/update-hashes
 
@@ -401,7 +401,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.53.0-*
+        path: '~/.rustup/toolchains/1.54.0-*
 
           ~/.rustup/update-hashes
 

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -295,6 +295,7 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
                         sudo apt-get install -y pkg-config fuse libfuse-dev
                         ./build-support/bin/check_rust_pre_commit.sh
                         ./cargo test --all --tests -- --nocapture
+                        ./cargo build --benches
                         """
                     ),
                     "if": DONT_SKIP_RUST,

--- a/src/rust/engine/fs/store/benches/store.rs
+++ b/src/rust/engine/fs/store/benches/store.rs
@@ -185,9 +185,9 @@ criterion_main!(benches);
 
 ///
 /// Returns a Store (and the TempDir it is stored in) and a Digest for a nested directory
-/// containing one file per line in "all_the_henries".
+/// containing the given number of files, each with roughly the given size.
 ///
-pub fn large_snapshot(
+pub fn snapshot(
   executor: &Executor,
   max_files: usize,
   file_target_size: usize,
@@ -242,7 +242,7 @@ pub fn large_snapshot(
     .map(|mut path| {
       let store = store2.clone();
       async move {
-        // We use the path as the content as well: would be interesting to make this tunable.
+        // We use the (repeated) path as the content as well.
         let content: Bytes = {
           let base = Bytes::copy_from_slice(path.as_os_str().as_bytes());
           base.repeat(file_target_size / base.len()).into()


### PR DESCRIPTION
Get things compiling again, add CI coverage, and then add two variations to the `materialize_directory` benchmark:
```
materialize_directory/materialize_directory(100, 100)
                        time:   [52.739 ms 56.532 ms 58.393 ms]
materialize_directory/materialize_directory(20, 10000000)
                        time:   [148.33 ms 151.88 ms 154.34 ms]
materialize_directory/materialize_directory(1, 200000000)
                        time:   [145.68 ms 150.81 ms 157.88 ms]
```

[ci skip-build-wheels]