### PR TITLE
Stream files into the local store while capturing them

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -2930,6 +2930,7 @@ dependencies = [
  "hashing",
  "lmdb",
  "log 0.4.14",
+ "parking_lot",
  "task_executor",
  "tempfile",
  "tokio",

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -385,10 +385,11 @@ async fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
             .ok_or_else(|| format!("Tried to save file {:?} but it did not exist", path))?;
           match file {
             fs::Stat::File(f) => {
-              let digest = store::OneOffStoreFileByDigest::new(store.clone(), Arc::new(posix_fs))
-                .store_by_digest(f)
-                .await
-                .unwrap();
+              let digest =
+                store::OneOffStoreFileByDigest::new(store.clone(), Arc::new(posix_fs), false)
+                  .store_by_digest(f)
+                  .await
+                  .unwrap();
 
               let report = ensure_uploaded_to_remote(&store, store_has_remote, digest)
                 .await
@@ -458,7 +459,7 @@ async fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
 
         let snapshot = Snapshot::from_path_stats(
           store_copy.clone(),
-          store::OneOffStoreFileByDigest::new(store_copy, posix_fs),
+          store::OneOffStoreFileByDigest::new(store_copy, posix_fs, false),
           paths,
         )
         .await?;

--- a/src/rust/engine/fs/src/posixfs_tests.rs
+++ b/src/rust/engine/fs/src/posixfs_tests.rs
@@ -29,37 +29,16 @@ async fn is_executable_true() {
 }
 
 #[tokio::test]
-async fn read_file() {
+async fn file_path() {
   let dir = tempfile::TempDir::new().unwrap();
   let path = PathBuf::from("marmosets");
-  let content = "cute".as_bytes().to_vec();
-  make_file(
-    &std::fs::canonicalize(dir.path()).unwrap().join(&path),
-    &content,
-    0o600,
-  );
   let fs = new_posixfs(&dir.path());
-  let file_content = fs
-    .read_file(&File {
-      path: path.clone(),
-      is_executable: false,
-    })
-    .await
-    .unwrap();
-  assert_eq!(file_content.path, path);
-  assert_eq!(file_content.content, content);
-}
-
-#[tokio::test]
-async fn read_file_missing() {
-  let dir = tempfile::TempDir::new().unwrap();
-  new_posixfs(&dir.path())
-    .read_file(&File {
-      path: PathBuf::from("marmosets"),
-      is_executable: false,
-    })
-    .await
-    .expect_err("Expected error");
+  let expected_path = std::fs::canonicalize(dir.path()).unwrap().join(&path);
+  let actual_path = fs.file_path(&File {
+    path: path.clone(),
+    is_executable: false,
+  });
+  assert_eq!(actual_path, expected_path);
 }
 
 #[tokio::test]

--- a/src/rust/engine/fs/store/benches/store.rs
+++ b/src/rust/engine/fs/store/benches/store.rs
@@ -93,7 +93,7 @@ pub fn criterion_benchmark_snapshot_capture(c: &mut Criterion) {
     (20, 10_000_000, true, 10),
     (1, 200_000_000, true, 10),
   ] {
-    let (count, size, _immutable, captures) = params;
+    let (count, size, immutable, captures) = params;
     let storedir = TempDir::new().unwrap();
     let store = Store::local_only(executor.clone(), storedir.path()).unwrap();
     let (tempdir, path_stats) = tempdir_containing(count, size);
@@ -114,7 +114,7 @@ pub fn criterion_benchmark_snapshot_capture(c: &mut Criterion) {
             let _ = executor
               .block_on(Snapshot::digest_from_path_stats(
                 store.clone(),
-                OneOffStoreFileByDigest::new(store.clone(), posix_fs.clone()),
+                OneOffStoreFileByDigest::new(store.clone(), posix_fs.clone(), immutable),
                 path_stats.clone(),
               ))
               .unwrap();
@@ -337,7 +337,7 @@ fn snapshot(
       .unwrap();
       Snapshot::digest_from_path_stats(
         store2.clone(),
-        OneOffStoreFileByDigest::new(store2, Arc::new(posix_fs)),
+        OneOffStoreFileByDigest::new(store2, Arc::new(posix_fs), true),
         path_stats,
       )
       .await

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -39,8 +39,9 @@ mod snapshot_tests;
 pub use crate::snapshot_ops::{SnapshotOps, SnapshotOpsError, StoreWrapper, SubsetParams};
 
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fmt::Debug;
 use std::fs::OpenOptions;
-use std::io::Write;
+use std::io::{self, Read, Write};
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -359,7 +360,10 @@ impl Store {
   }
 
   ///
-  /// Store a file locally.
+  /// A convenience method for storing a file.
+  ///
+  /// NB: This method should not be used for large blobs: prefer to stream them from their source
+  /// using `store_file`.
   ///
   pub async fn store_file_bytes(
     &self,
@@ -369,6 +373,30 @@ impl Store {
     self
       .local
       .store_bytes(EntryType::File, bytes, initial_lease)
+      .await
+  }
+
+  ///
+  /// Store a file locally by streaming its contents.
+  ///
+  pub async fn store_file<F, R>(
+    &self,
+    initial_lease: bool,
+    data_is_immutable: bool,
+    data_provider: F,
+  ) -> Result<Digest, String>
+  where
+    R: Read + Debug,
+    F: Fn() -> Result<R, io::Error> + Send + 'static,
+  {
+    self
+      .local
+      .store(
+        EntryType::File,
+        initial_lease,
+        data_is_immutable,
+        data_provider,
+      )
       .await
   }
 

--- a/src/rust/engine/fs/store/src/snapshot.rs
+++ b/src/rust/engine/fs/store/src/snapshot.rs
@@ -1,7 +1,6 @@
 // Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-use std::collections::HashMap;
 use std::ffi::OsString;
 use std::fmt;
 use std::iter::Iterator;
@@ -381,22 +380,5 @@ impl StoreFileByDigest<String> for OneOffStoreFileByDigest {
       store.store_file_bytes(content.content, true).await
     };
     res.boxed()
-  }
-}
-
-#[derive(Clone)]
-pub struct StoreManyFileDigests {
-  pub hash: HashMap<PathBuf, Digest>,
-}
-
-impl StoreFileByDigest<String> for StoreManyFileDigests {
-  fn store_by_digest(&self, file: File) -> future::BoxFuture<'static, Result<Digest, String>> {
-    future::ready(self.hash.get(&file.path).copied().ok_or_else(|| {
-      format!(
-        "Could not find file {} when storing file by digest",
-        file.path.display()
-      )
-    }))
-    .boxed()
   }
 }

--- a/src/rust/engine/fs/store/src/snapshot_tests.rs
+++ b/src/rust/engine/fs/store/src/snapshot_tests.rs
@@ -36,7 +36,7 @@ pub fn setup() -> (
   let dir = tempfile::Builder::new().prefix("root").tempdir().unwrap();
   let ignorer = GitignoreStyleExcludes::create(vec![]).unwrap();
   let posix_fs = Arc::new(PosixFS::new(dir.path(), ignorer, executor).unwrap());
-  let file_saver = OneOffStoreFileByDigest::new(store.clone(), posix_fs.clone());
+  let file_saver = OneOffStoreFileByDigest::new(store.clone(), posix_fs.clone(), true);
   (store, dir, posix_fs, file_saver)
 }
 

--- a/src/rust/engine/hashing/src/lib.rs
+++ b/src/rust/engine/hashing/src/lib.rs
@@ -314,6 +314,21 @@ impl<W: Write> Write for WriterHasher<W> {
   }
 }
 
+///
+/// A Write implementation which discards its inputs.
+///
+pub struct NoopWriter;
+
+impl Write for NoopWriter {
+  fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+    Ok(buf.len())
+  }
+
+  fn flush(&mut self) -> io::Result<()> {
+    Ok(())
+  }
+}
+
 #[cfg(test)]
 mod fingerprint_tests;
 

--- a/src/rust/engine/hashing/src/lib.rs
+++ b/src/rust/engine/hashing/src/lib.rs
@@ -314,21 +314,6 @@ impl<W: Write> Write for WriterHasher<W> {
   }
 }
 
-///
-/// A Write implementation which discards its inputs.
-///
-pub struct NoopWriter;
-
-impl Write for NoopWriter {
-  fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-    Ok(buf.len())
-  }
-
-  fn flush(&mut self) -> io::Result<()> {
-    Ok(())
-  }
-}
-
 #[cfg(test)]
 mod fingerprint_tests;
 

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -117,7 +117,7 @@ impl CommandRunner {
         .await?;
       Snapshot::from_path_stats(
         store.clone(),
-        OneOffStoreFileByDigest::new(store, posix_fs),
+        OneOffStoreFileByDigest::new(store, posix_fs, true),
         path_stats,
       )
       .await

--- a/src/rust/engine/sharded_lmdb/Cargo.toml
+++ b/src/rust/engine/sharded_lmdb/Cargo.toml
@@ -15,4 +15,5 @@ task_executor = { path = "../task_executor" }
 tempfile = "3"
 
 [dev-dependencies]
+parking_lot = "0.11"
 tokio = { version = "1.4", features = ["macros"] }

--- a/src/rust/engine/sharded_lmdb/src/tests.rs
+++ b/src/rust/engine/sharded_lmdb/src/tests.rs
@@ -1,5 +1,8 @@
 use std::collections::HashMap;
 
+use bytes::{Buf, Bytes};
+use hashing::Digest;
+use parking_lot::Mutex;
 use task_executor::Executor;
 use tempfile::TempDir;
 
@@ -37,4 +40,57 @@ async fn shard_counts() {
       assert_eq!(count, 256 / shard_count as usize);
     }
   }
+}
+
+#[tokio::test]
+async fn store_immutable() {
+  let (s, _) = new_store(1);
+  let digest = s.store(true, true, || Ok(bytes(0).reader())).await.unwrap();
+  assert_eq!(digest, Digest::of_bytes(&bytes(0)));
+}
+
+#[tokio::test]
+async fn store_stable() {
+  let (s, _) = new_store(1);
+  let digest = s
+    .store(true, false, || Ok(bytes(0).reader()))
+    .await
+    .unwrap();
+  assert_eq!(digest, Digest::of_bytes(&bytes(0)));
+}
+
+#[tokio::test]
+async fn store_changing() {
+  let (s, _) = new_store(1);
+
+  // Produces Readers that change during the first two reads, but stabilize on the third and
+  // fourth.
+  let contents = Mutex::new(vec![bytes(0), bytes(1), bytes(2), bytes(2)].into_iter());
+
+  let digest = s
+    .store(true, false, move || {
+      Ok(contents.lock().next().unwrap().reader())
+    })
+    .await
+    .unwrap();
+  assert_eq!(digest, Digest::of_bytes(&bytes(2)));
+}
+
+#[tokio::test]
+async fn store_failure() {
+  let (s, _) = new_store(1);
+
+  // Produces Readers that never stabilize.
+  let contents = Mutex::new((0..100).map(|b| bytes(b)));
+
+  let result = s
+    .store(true, false, move || {
+      Ok(contents.lock().next().unwrap().reader())
+    })
+    .await;
+  assert!(result.is_err());
+}
+
+fn bytes(content: u8) -> Bytes {
+  Bytes::from(vec![content; 100])
 }

--- a/src/rust/engine/sharded_lmdb/src/tests.rs
+++ b/src/rust/engine/sharded_lmdb/src/tests.rs
@@ -25,7 +25,7 @@ fn new_store(shard_count: u8) -> (ShardedLmdb, TempDir) {
 async fn shard_counts() {
   let shard_counts = vec![1, 2, 4, 8, 16, 32, 64, 128];
   for shard_count in shard_counts {
-    let (s, _) = new_store(shard_count);
+    let (s, _tempdir) = new_store(shard_count);
     assert_eq!(s.all_lmdbs().len(), shard_count as usize);
 
     // Confirm that each database gets an even share.
@@ -44,14 +44,14 @@ async fn shard_counts() {
 
 #[tokio::test]
 async fn store_immutable() {
-  let (s, _) = new_store(1);
+  let (s, _tempdir) = new_store(1);
   let digest = s.store(true, true, || Ok(bytes(0).reader())).await.unwrap();
   assert_eq!(digest, Digest::of_bytes(&bytes(0)));
 }
 
 #[tokio::test]
 async fn store_stable() {
-  let (s, _) = new_store(1);
+  let (s, _tempdir) = new_store(1);
   let digest = s
     .store(true, false, || Ok(bytes(0).reader()))
     .await
@@ -61,7 +61,7 @@ async fn store_stable() {
 
 #[tokio::test]
 async fn store_changing() {
-  let (s, _) = new_store(1);
+  let (s, _tempdir) = new_store(1);
 
   // Produces Readers that change during the first two reads, but stabilize on the third and
   // fourth.
@@ -78,7 +78,7 @@ async fn store_changing() {
 
 #[tokio::test]
 async fn store_failure() {
-  let (s, _) = new_store(1);
+  let (s, _tempdir) = new_store(1);
 
   // Produces Readers that never stabilize.
   let contents = Mutex::new((0..100).map(|b| bytes(b)));

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -523,16 +523,11 @@ impl WrappedNode for DigestFile {
     context: Context,
     _workunit: &mut RunningWorkunit,
   ) -> NodeResult<hashing::Digest> {
-    let content = context
-      .core
-      .vfs
-      .read_file(&self.0)
-      .map_err(|e| throw(&format!("{}", e)))
-      .await?;
+    let path = context.core.vfs.file_path(&self.0);
     context
       .core
       .store()
-      .store_file_bytes(content.content, true)
+      .store_file(true, false, move || std::fs::File::open(&path))
       .map_err(|e| throw(&e))
       .await
   }


### PR DESCRIPTION
A private repository experienced OOM issues in CI with a large number of tests. Allocation profiling highlighted that a large batch of `32MB`/`64MB` allocations was occurring around the same time, all caused by the fact that `PosixFS::read_file` slurps an entire file into memory as `FileContent`. Because local process execution uses `PosixFS::read_file` to capture sandbox outputs, a bunch of processes finishing at once could lead to memory usage spikes.

To fix that, this change removes `PosixFS::read_file` (which was only ever used to digest files), and replaces it with `{Store,local::ByteStore,ShardedLmdb}::store*` methods which make two-ish passes over a `Read` instance in order to digest and capture it.

The methods take an `immutable_data` parameter so that callers can indicate that they know that data will not change, which allows for avoiding hashing it on the second pass. Captures from process sandboxes are treated as immutable, while memoized captures from the workspace are not.

----

#12569 adds relevant benchmarks. Profiling allocation during those benchmarks shows peak memory usage of `945MB` on `main`, and `362MB` on the branch. Additionally, the benchmarks all run faster (likely due to reduced allocation):

```
snapshot_capture/snapshot_capture((100, 100, false, 100))
                        time:   [1.8909 s 1.9000 s 1.9109 s]
                        change: [-27.459% -25.841% -24.085%] (p = 0.00 < 0.05)
                        Performance has improved.
snapshot_capture/snapshot_capture((20, 10000000, true, 10))
                        time:   [1.2539 s 1.2655 s 1.2782 s]
                        change: [-62.138% -61.318% -60.505%] (p = 0.00 < 0.05)
                        Performance has improved.
snapshot_capture/snapshot_capture((1, 200000000, true, 10))
                        time:   [3.5281 s 3.5773 s 3.6299 s]
                        change: [-13.420% -11.985% -10.434%] (p = 0.00 < 0.05)
                        Performance has improved.
```