### PR TITLE
Kill unused class.

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -281,9 +281,5 @@ class CompletePexEnvironment:
         return d
 
 
-class WorkspacePexEnvironment(CompletePexEnvironment):
-    pass
-
-
 def rules():
     return [*collect_rules(), *process.rules(), *subprocess_environment.rules()]


### PR DESCRIPTION
This was missed in #12479.

[ci skip-rust]
[ci skip-build-wheels]