### PR TITLE
[internal] Add`InterpreterConstraints.contains()` for lockfile validation

### DIFF
--- a/src/python/pants/backend/python/util_rules/interpreter_constraints.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints.py
@@ -259,6 +259,61 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
             return "*"
         return " || ".join(specifiers)
 
+    def enumerate_python_versions(
+        self, interpreter_universe: Iterable[str]
+    ) -> set[tuple[int, int, int]]:
+        """Return a set of all plausible (major, minor, patch) tuples for all Python 2.7/3.x in the
+        specified interpreter universe that matches this set of interpreter constraints.
+
+        This also validates our assumptions around the `interpreter_universe`:
+
+        - Python 2.7 is the only Python 2 version in the universe, if at all.
+        - Python 3 is the last major release of Python, which the core devs have committed to in
+          public several times.
+        """
+        if not self:
+            return set()
+
+        minors = []
+        for major_minor in interpreter_universe:
+            major, minor = _major_minor_to_int(major_minor)
+            if major == 2:
+                if minor != 7:
+                    raise AssertionError(
+                        "Unexpected value in `[python-setup].interpreter_versions_universe`: "
+                        f"{major_minor}. Expected the only Python 2 value to be '2.7', given that "
+                        f"all other versions are unmaintained or do not exist."
+                    )
+                minors.append((2, minor))
+            elif major == 3:
+                minors.append((3, minor))
+            else:
+                raise AssertionError(
+                    "Unexpected value in `[python-setup].interpreter_versions_universe`: "
+                    f"{major_minor}. Expected to only include '2.7' and/or Python 3 versions, "
+                    "given that Python 3 will be the last major Python version. Please open an "
+                    "issue at https://github.com/pantsbuild/pants/issues/new if this is no longer "
+                    "true."
+                )
+
+        valid_patches = set(
+            (major, minor, patch)
+            for (major, minor) in sorted(minors)
+            for patch in self._valid_patch_versions(major, minor)
+        )
+
+        if not valid_patches:
+            raise ValueError(
+                f"The interpreter constraints `{self}` are not compatible with any of the "
+                "interpreter versions from `[python-setup].interpreter_versions_universe`.\n\n"
+                "Please either change these interpreter constraints or update the "
+                "`interpreter_versions_universe` to include the interpreters set in these "
+                "constraints. Run `./pants help-advanced python-setup` for more information on the "
+                "`interpreter_versions_universe` option."
+            )
+
+        return valid_patches
+
 
 def _major_minor_to_int(major_minor: str) -> tuple[int, int]:
     return tuple(int(x) for x in major_minor.split(".", maxsplit=1))  # type: ignore[return-value]

--- a/src/python/pants/backend/python/util_rules/interpreter_constraints.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints.py
@@ -314,6 +314,16 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
 
         return valid_patches
 
+    def contains(self, other: InterpreterConstraints, universe: Iterable[str]) -> bool:
+        """Returns True if the `InterpreterConstraints` specified in `other` is a subset of these
+        `InterpreterConstraints`.
+
+        This is restricted to the set of minor Python versions specified in `universe`.
+        """
+        this = self.enumerate_python_versions(universe)
+        that = other.enumerate_python_versions(universe)
+        return this.issuperset(that)
+
 
 def _major_minor_to_int(major_minor: str) -> tuple[int, int]:
     return tuple(int(x) for x in major_minor.split(".", maxsplit=1))  # type: ignore[return-value]

--- a/src/python/pants/backend/python/util_rules/interpreter_constraints_test.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints_test.py
@@ -353,38 +353,48 @@ def test_enumerate_python_versions_invalid_universe(version: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "narrower,wider,matches",
+    "candidate,target,matches",
     (
-        ([">=3.5.5"], [">=3.5, <=3.6"], False),  # User ICs contain versions in the 3.6 range
-        ([">=3.5.5, <=3.5.10"], [">=3.5, <=3.6"], True),
+        ([">=3.5,<=3.6"], [">=3.5.5"], False),  # Target ICs contain versions in the 3.6 range
+        ([">=3.5,<=3.6"], [">=3.5.5,<=3.5.10"], True),
         (
-            [">=3.5.5, <=3.5.10"],
             [">=3.5", "<=3.6"],
+            [">=3.5.5,<=3.5.10"],
             True,
-        ),  # User ICs match each of the actual ICs individually
+        ),  # Target ICs match each of the actual ICs individually
         (
-            [">=3.5.5, <=3.5.10"],
             [">=3.5", "<=3.5.4"],
+            [">=3.5.5,<=3.5.10"],
             True,
-        ),  # User ICs do not match one of the individual ICs
-        (["==3.5.*, !=3.5.10"], [">=3.5, <=3.6"], True),
+        ),  # Target ICs do not match any candidate ICs
+        ([">=3.5,<=3.6"], ["==3.5.*,!=3.5.10"], True),
         (
+            [">=3.5,<=3.6, !=3.5.10"],
             ["==3.5.*"],
-            [">=3.5, <=3.6, !=3.5.10"],
             False,
-        ),  # Excluded IC from expected range is valid for user ICs
-        ([">=3.5, <=3.6", ">= 3.8"], [">=3.5"], True),
+        ),  # Excluded IC from candidate range is valid for target ICs
+        ([">=3.5"], [">=3.5,<=3.6", ">= 3.8"], True),
         (
-            [">=3.5, <=3.6", ">= 3.8"],
-            [">=3.5, !=3.7.10"],
+            [">=3.5,!=3.7.10"],
+            [">=3.5,<=3.6", ">= 3.8"],
             True,
-        ),  # Excluded version from expected ICs is not in a range specified
+        ),  # Excluded version from candidate ICs is not in a range specified by target ICs
+        (
+            [">=3.5,<=3.6", ">= 3.8"],
+            [">=3.9"],
+            True,
+        ),  # matches only one of the candidate specifications
+        (
+            ["<3.6", ">=3.6"],
+            [">=3.5"],
+            True,
+        ),  # target matches a weirdly specified non-disjoint IC list
     ),
 )
-def test_contains(narrower, wider, matches) -> None:
+def test_contains(candidate, target, matches) -> None:
     assert (
-        InterpreterConstraints(wider).contains(
-            InterpreterConstraints(narrower), ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        InterpreterConstraints(candidate).contains(
+            InterpreterConstraints(target), ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
         )
         == matches
     )

--- a/src/python/pants/backend/python/util_rules/interpreter_constraints_test.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints_test.py
@@ -313,9 +313,9 @@ def patches(major, minor, unqualified_patches):
 @pytest.mark.parametrize(
     "constraints,expected",
     (
-        (["==2.7.15"], patches(2, 7, {15})),
+        (["==2.7.15"], {(2, 7, 15)}),
         (["==2.7.*"], patches(2, 7, _ALL_PATCHES)),
-        (["==3.6.15", "==3.7.15"], patches(3, 6, {15}) | patches(3, 7, {15})),
+        (["==3.6.15", "==3.7.15"], {(3, 6, 15), (3, 7, 15)}),
         (["==3.6.*", "==3.7.*"], patches(3, 6, _ALL_PATCHES) | patches(3, 7, _ALL_PATCHES)),
         (
             ["==2.7.1", ">=3.6.15"],


### PR DESCRIPTION
This adds two methods to `InterpreterConstraints`:

* `enumerate_python_versions` produces a set of plausibly valid Python interpreter versions that match the given `InterpreterConstraints` (within a given universe of minor versions)
* `contains` checks whether the plausible versions specified by `InterpreterConstraints` contains all of the plausible versions specified by another `InterpreterConstraints`.

This contains some of the work done in #12566.