### PR TITLE
[internal] Add a benchmark for Snapshot capture

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -153,7 +153,7 @@ jobs:
 
         ./cargo test --all --tests -- --nocapture
 
-        ./cargo build --benches
+        ./cargo check --benches
 
         '
     strategy:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -153,7 +153,7 @@ jobs:
 
         ./cargo test --all --tests -- --nocapture
 
-        ./cargo build --benches
+        ./cargo check --benches
 
         '
     strategy:

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -303,7 +303,7 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
                         sudo apt-get install -y pkg-config fuse libfuse-dev
                         ./build-support/bin/check_rust_pre_commit.sh
                         ./cargo test --all --tests -- --nocapture
-                        ./cargo build --benches
+                        ./cargo check --benches
                         """
                     ),
                     "if": DONT_SKIP_RUST,


### PR DESCRIPTION
Refactor the test harness to allow for creating larger files (without allocating their full contents in memory), and add benchmarks for a series of file counts, sizes, and repetitions.

Preparation for #12563.

[ci skip-build-wheels]