### PR TITLE
Existing setup.py files should be relative to the BUILD file.

### DIFF
--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -539,7 +539,8 @@ async def generate_chroot(request: SetupPyChrootRequest) -> SetupPyChroot:
                 f"{','.join(sorted(invalid_keys))}."
             )
         stripped_setup_script = await Get(
-            StrippedSourceFileNames, SourcesPaths(files=(setup_script,), dirs=())
+            StrippedSourceFileNames,
+            SourcesPaths(files=(os.path.join(target.address.spec_path, setup_script),), dirs=()),
         )
         return SetupPyChroot(
             sources.digest,

--- a/testprojects/src/python/native/BUILD
+++ b/testprojects/src/python/native/BUILD
@@ -12,7 +12,7 @@ python_distribution(
     provides = setup_py(
         name = "native",
         version = "2.3.4",
-        setup_script='testprojects/src/python/native/setup.py',
+        setup_script='setup.py',
     ),
     setup_py_commands = ["bdist_wheel",]
 )


### PR DESCRIPTION
Previously we required that setup_script= contain a path from
the repo root, which is different from how we specify sources=
and so might lead to confusion and error.

[ci skip-rust]

[ci skip-build-wheels]