### PR TITLE
Stream files into the local store while capturing them (cherrypick of #12563)

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -2889,6 +2889,7 @@ dependencies = [
  "hashing",
  "lmdb",
  "log 0.4.11",
+ "parking_lot",
  "task_executor",
  "tempfile",
  "tokio",

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -365,10 +365,11 @@ async fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
             .ok_or_else(|| format!("Tried to save file {:?} but it did not exist", path))?;
           match file {
             fs::Stat::File(f) => {
-              let digest = store::OneOffStoreFileByDigest::new(store.clone(), Arc::new(posix_fs))
-                .store_by_digest(f)
-                .await
-                .unwrap();
+              let digest =
+                store::OneOffStoreFileByDigest::new(store.clone(), Arc::new(posix_fs), false)
+                  .store_by_digest(f)
+                  .await
+                  .unwrap();
 
               let report = ensure_uploaded_to_remote(&store, store_has_remote, digest)
                 .await
@@ -438,7 +439,7 @@ async fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
 
         let snapshot = Snapshot::from_path_stats(
           store_copy.clone(),
-          store::OneOffStoreFileByDigest::new(store_copy, posix_fs),
+          store::OneOffStoreFileByDigest::new(store_copy, posix_fs, false),
           paths,
         )
         .await?;

--- a/src/rust/engine/fs/src/posixfs_tests.rs
+++ b/src/rust/engine/fs/src/posixfs_tests.rs
@@ -29,37 +29,16 @@ async fn is_executable_true() {
 }
 
 #[tokio::test]
-async fn read_file() {
+async fn file_path() {
   let dir = tempfile::TempDir::new().unwrap();
   let path = PathBuf::from("marmosets");
-  let content = "cute".as_bytes().to_vec();
-  make_file(
-    &std::fs::canonicalize(dir.path()).unwrap().join(&path),
-    &content,
-    0o600,
-  );
   let fs = new_posixfs(&dir.path());
-  let file_content = fs
-    .read_file(&File {
-      path: path.clone(),
-      is_executable: false,
-    })
-    .await
-    .unwrap();
-  assert_eq!(file_content.path, path);
-  assert_eq!(file_content.content, content);
-}
-
-#[tokio::test]
-async fn read_file_missing() {
-  let dir = tempfile::TempDir::new().unwrap();
-  new_posixfs(&dir.path())
-    .read_file(&File {
-      path: PathBuf::from("marmosets"),
-      is_executable: false,
-    })
-    .await
-    .expect_err("Expected error");
+  let expected_path = std::fs::canonicalize(dir.path()).unwrap().join(&path);
+  let actual_path = fs.file_path(&File {
+    path: path.clone(),
+    is_executable: false,
+  });
+  assert_eq!(actual_path, expected_path);
 }
 
 #[tokio::test]

--- a/src/rust/engine/fs/store/src/snapshot.rs
+++ b/src/rust/engine/fs/store/src/snapshot.rs
@@ -1,11 +1,10 @@
 // Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-use std::collections::HashMap;
 use std::ffi::OsString;
 use std::fmt;
 use std::iter::Iterator;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 
 use bazel_protos::gen::build::bazel::remote::execution::v2 as remexec;
@@ -270,7 +269,7 @@ impl Snapshot {
         .map_err(|err| format!("Error expanding globs: {}", err))?;
       Snapshot::from_path_stats(
         store.clone(),
-        OneOffStoreFileByDigest::new(store, posix_fs),
+        OneOffStoreFileByDigest::new(store, posix_fs, true),
         path_stats,
       )
       .await
@@ -325,17 +324,23 @@ pub trait StoreFileByDigest<Error> {
 }
 
 ///
-/// A StoreFileByDigest which reads with a PosixFS and writes to a Store, with no caching.
+/// A StoreFileByDigest which reads immutable files with a PosixFS and writes to a Store, with no
+/// caching.
 ///
 #[derive(Clone)]
 pub struct OneOffStoreFileByDigest {
   store: Store,
   posix_fs: Arc<PosixFS>,
+  immutable: bool,
 }
 
 impl OneOffStoreFileByDigest {
-  pub fn new(store: Store, posix_fs: Arc<PosixFS>) -> OneOffStoreFileByDigest {
-    OneOffStoreFileByDigest { store, posix_fs }
+  pub fn new(store: Store, posix_fs: Arc<PosixFS>, immutable: bool) -> OneOffStoreFileByDigest {
+    OneOffStoreFileByDigest {
+      store,
+      posix_fs,
+      immutable,
+    }
   }
 }
 
@@ -343,30 +348,13 @@ impl StoreFileByDigest<String> for OneOffStoreFileByDigest {
   fn store_by_digest(&self, file: File) -> future::BoxFuture<'static, Result<Digest, String>> {
     let store = self.store.clone();
     let posix_fs = self.posix_fs.clone();
+    let immutable = self.immutable;
     let res = async move {
-      let content = posix_fs
-        .read_file(&file)
+      let path = posix_fs.file_path(&file);
+      store
+        .store_file(true, immutable, move || std::fs::File::open(&path))
         .await
-        .map_err(move |err| format!("Error reading file {:?}: {:?}", file, err))?;
-      store.store_file_bytes(content.content, true).await
     };
     res.boxed()
-  }
-}
-
-#[derive(Clone)]
-pub struct StoreManyFileDigests {
-  pub hash: HashMap<PathBuf, Digest>,
-}
-
-impl StoreFileByDigest<String> for StoreManyFileDigests {
-  fn store_by_digest(&self, file: File) -> future::BoxFuture<'static, Result<Digest, String>> {
-    future::ready(self.hash.get(&file.path).copied().ok_or_else(|| {
-      format!(
-        "Could not find file {} when storing file by digest",
-        file.path.display()
-      )
-    }))
-    .boxed()
   }
 }

--- a/src/rust/engine/fs/store/src/snapshot_tests.rs
+++ b/src/rust/engine/fs/store/src/snapshot_tests.rs
@@ -36,7 +36,7 @@ pub fn setup() -> (
   let dir = tempfile::Builder::new().prefix("root").tempdir().unwrap();
   let ignorer = GitignoreStyleExcludes::create(vec![]).unwrap();
   let posix_fs = Arc::new(PosixFS::new(dir.path(), ignorer, executor).unwrap());
-  let file_saver = OneOffStoreFileByDigest::new(store.clone(), posix_fs.clone());
+  let file_saver = OneOffStoreFileByDigest::new(store.clone(), posix_fs.clone(), true);
   (store, dir, posix_fs, file_saver)
 }
 

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -117,7 +117,7 @@ impl CommandRunner {
         .await?;
       Snapshot::from_path_stats(
         store.clone(),
-        OneOffStoreFileByDigest::new(store, posix_fs),
+        OneOffStoreFileByDigest::new(store, posix_fs, true),
         path_stats,
       )
       .await

--- a/src/rust/engine/sharded_lmdb/Cargo.toml
+++ b/src/rust/engine/sharded_lmdb/Cargo.toml
@@ -15,4 +15,5 @@ task_executor = { path = "../task_executor" }
 tempfile = "3"
 
 [dev-dependencies]
+parking_lot = "0.11"
 tokio = { version = "1.4", features = ["macros"] }

--- a/src/rust/engine/sharded_lmdb/src/lib.rs
+++ b/src/rust/engine/sharded_lmdb/src/lib.rs
@@ -27,18 +27,21 @@
 // Arc<Mutex> can be more clear than needing to grok Orderings:
 #![allow(clippy::mutex_atomic)]
 
-use bytes::Bytes;
-use hashing::{Fingerprint, FINGERPRINT_SIZE};
+use std::collections::HashMap;
+use std::fmt;
+use std::fmt::Debug;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{self, Duration};
+
+use bytes::{BufMut, Bytes};
+use hashing::{Digest, Fingerprint, WriterHasher, FINGERPRINT_SIZE};
 use lmdb::{
   self, Database, DatabaseFlags, Environment, EnvironmentCopyFlags, EnvironmentFlags,
   RwTransaction, Transaction, WriteFlags,
 };
 use log::trace;
-use std::collections::HashMap;
-use std::fmt;
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
-use std::time::{self, Duration};
 use tempfile::TempDir;
 
 ///
@@ -378,6 +381,120 @@ impl ShardedLmdb {
       .await
   }
 
+  ///
+  /// Stores the given Read instance under its computed digest. This method performs two passes
+  /// over the source to 1) hash it, 2) store it. If !data_is_immutable, the second pass will
+  /// re-hash the data to confirm that it hasn't changed.
+  ///
+  /// If the Read instance gets longer between Reads, we will not detect that here, but any
+  /// captured data will still be valid.
+  ///
+  pub async fn store<F, R>(
+    &self,
+    initial_lease: bool,
+    data_is_immutable: bool,
+    data_provider: F,
+  ) -> Result<Digest, String>
+  where
+    R: Read + Debug,
+    F: Fn() -> Result<R, io::Error> + Send + 'static,
+  {
+    let store = self.clone();
+    self
+      .executor
+      .spawn_blocking(move || {
+        let mut attempts = 0;
+        loop {
+          // First pass: compute the Digest.
+          let digest = {
+            let mut read = data_provider().map_err(|e| format!("Failed to read: {}", e))?;
+            let mut hasher = WriterHasher::new(io::sink());
+            let _ = io::copy(&mut read, &mut hasher)
+              .map_err(|e| format!("Failed to read from {:?}: {}", read, e))?;
+            hasher.finish().0
+          };
+
+          let effective_key = VersionedFingerprint::new(digest.hash, ShardedLmdb::SCHEMA_VERSION);
+          let (env, db, lease_database) = store.get(&digest.hash);
+          let put_res: Result<(), StoreError> = env
+            .begin_rw_txn()
+            .map_err(StoreError::Lmdb)
+            .and_then(|mut txn| {
+              // Second pass: copy into the reserved memory.
+              let mut writer = txn
+                .reserve(
+                  db,
+                  &effective_key,
+                  digest.size_bytes,
+                  WriteFlags::NO_OVERWRITE,
+                )?
+                .writer();
+              let mut read = data_provider().map_err(|e| format!("Failed to read: {}", e))?;
+              let should_retry = if data_is_immutable {
+                // Trust that the data hasn't changed, and only validate its length.
+                let copied = io::copy(&mut read, &mut writer).map_err(|e| {
+                  format!(
+                    "Failed to copy from {:?} or store in {:?}: {:?}",
+                    read, env, e
+                  )
+                })?;
+
+                // Should retry if the file got shorter between reads.
+                copied as usize != digest.size_bytes
+              } else {
+                // Confirm that the data hasn't changed.
+                let mut hasher = WriterHasher::new(writer);
+                let _ = io::copy(&mut read, &mut hasher).map_err(|e| {
+                  format!(
+                    "Failed to copy from {:?} or store in {:?}: {:?}",
+                    read, env, e
+                  )
+                })?;
+
+                // Should retry if the Digest changed between reads.
+                digest != hasher.finish().0
+              };
+
+              if should_retry {
+                let msg = format!("Input {:?} changed while reading.", read);
+                log::debug!("{}", msg);
+                return Err(StoreError::Retry(msg));
+              }
+
+              if initial_lease {
+                store.lease_inner(
+                  lease_database,
+                  &effective_key,
+                  store.lease_until_secs_since_epoch(),
+                  &mut txn,
+                )?;
+              }
+              txn.commit()?;
+              Ok(())
+            });
+
+          match put_res {
+            Ok(()) => return Ok(digest),
+            Err(StoreError::Retry(msg)) => {
+              // Input changed during reading: maybe retry.
+              if attempts > 10 {
+                return Err(msg);
+              } else {
+                attempts += 1;
+                continue;
+              }
+            }
+            Err(StoreError::Lmdb(lmdb::Error::KeyExist)) => return Ok(digest),
+            Err(StoreError::Lmdb(err)) => {
+              return Err(format!("Error storing {:?}: {}", digest, err))
+            }
+            Err(StoreError::Io(err)) => return Err(format!("Error storing {:?}: {}", digest, err)),
+          };
+        }
+      })
+      .await
+  }
+
   pub async fn lease(&self, fingerprint: Fingerprint) -> Result<(), lmdb::Error> {
     let store = self.clone();
     self
@@ -481,6 +598,24 @@ impl ShardedLmdb {
       std::mem::drop(new_dir);
     }
     Ok(())
+  }
+}
+
+enum StoreError {
+  Lmdb(lmdb::Error),
+  Io(String),
+  Retry(String),
+}
+
+impl From<lmdb::Error> for StoreError {
+  fn from(err: lmdb::Error) -> Self {
+    Self::Lmdb(err)
+  }
+}
+
+impl From<String> for StoreError {
+  fn from(err: String) -> Self {
+    Self::Io(err)
   }
 }
 

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -523,16 +523,11 @@ impl WrappedNode for DigestFile {
     context: Context,
     _workunit: &mut RunningWorkunit,
   ) -> NodeResult<hashing::Digest> {
-    let content = context
-      .core
-      .vfs
-      .read_file(&self.0)
-      .map_err(|e| throw(&format!("{}", e)))
-      .await?;
+    let path = context.core.vfs.file_path(&self.0);
     context
       .core
       .store()
-      .store_file_bytes(content.content, true)
+      .store_file(true, false, move || std::fs::File::open(&path))
       .map_err(|e| throw(&e))
       .await
   }


### PR DESCRIPTION
A private repository experienced OOM issues in CI with a large number of tests. Allocation profiling highlighted that a large batch of `32MB`/`64MB` allocations was occurring around the same time, all caused by the fact that `PosixFS::read_file` slurps an entire file into memory as `FileContent`. Because local process execution uses `PosixFS::read_file` to capture sandbox outputs, a bunch of processes finishing at once could lead to memory usage spikes.

To fix that, this change removes `PosixFS::read_file` (which was only ever used to digest files), and replaces it with `{Store,local::ByteStore,ShardedLmdb}::store*` methods which make two-ish passes over a `Read` instance in order to digest and capture it.

The methods take an `immutable_data` parameter so that callers can indicate that they know that data will not change, which allows for avoiding hashing it on the second pass. Captures from process sandboxes are treated as immutable, while memoized captures from the workspace are not.

----

```
snapshot_capture/snapshot_capture((100, 100, false, 100))
                        time:   [1.8909 s 1.9000 s 1.9109 s]
                        change: [-27.459% -25.841% -24.085%] (p = 0.00 < 0.05)
                        Performance has improved.
snapshot_capture/snapshot_capture((20, 10000000, true, 10))
                        time:   [1.2539 s 1.2655 s 1.2782 s]
                        change: [-62.138% -61.318% -60.505%] (p = 0.00 < 0.05)
                        Performance has improved.
snapshot_capture/snapshot_capture((1, 200000000, true, 10))
                        time:   [3.5281 s 3.5773 s 3.6299 s]
                        change: [-13.420% -11.985% -10.434%] (p = 0.00 < 0.05)
                        Performance has improved.
```