### PR TITLE
go: rule to download external Go modules

### DIFF
--- a/src/python/pants/backend/go/module.py
+++ b/src/python/pants/backend/go/module.py
@@ -256,10 +256,7 @@ async def download_external_module(
             PathGlobs(
                 [f"{source_path}/**"],
                 glob_match_error_behavior=GlobMatchErrorBehavior.error,
-                description_of_origin=(
-                    f"Attempted to download external Go module {request.path}@{request.version}, "
-                    "but the download was empty."
-                ),
+                description_of_origin=f"the DownloadExternalModuleRequest for {request.path}@{request.version}{request.path}@{request.version}",
             ),
         ),
     )

--- a/src/python/pants/backend/go/module_integration_test.py
+++ b/src/python/pants/backend/go/module_integration_test.py
@@ -3,10 +3,17 @@
 import pytest
 
 from pants.backend.go import module, sdk
-from pants.backend.go.module import ResolvedGoModule, ResolveGoModuleRequest
+from pants.backend.go.module import (
+    DownloadedExternalModule,
+    DownloadExternalModuleRequest,
+    ResolvedGoModule,
+    ResolveGoModuleRequest,
+)
 from pants.backend.go.target_types import GoExternalModule, GoModule, GoPackage
 from pants.build_graph.address import Address
 from pants.core.util_rules import external_tool, source_files
+from pants.engine import fs
+from pants.engine.fs import Digest, DigestContents
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
 
@@ -17,9 +24,12 @@ def rule_runner() -> RuleRunner:
         rules=[
             *external_tool.rules(),
             *source_files.rules(),
+            *fs.rules(),
             *sdk.rules(),
             *module.rules(),
             QueryRule(ResolvedGoModule, [ResolveGoModuleRequest]),
+            QueryRule(DownloadedExternalModule, [DownloadExternalModuleRequest]),
+            QueryRule(DigestContents, [Digest]),
         ],
         target_types=[GoPackage, GoModule, GoExternalModule],
     )
@@ -55,3 +65,22 @@ def test_resolve_go_module(rule_runner: RuleRunner) -> None:
         if module_descriptor.module_path == "github.com/golang/protobuf":
             found_protobuf_module = True
     assert found_protobuf_module
+
+
+def test_download_external_module(rule_runner: RuleRunner) -> None:
+    downloaded_module = rule_runner.request(
+        DownloadedExternalModule,
+        [
+            DownloadExternalModuleRequest(
+                path="github.com/google/uuid",
+                version="v1.3.0",
+            )
+        ],
+    )
+    digest_contents = rule_runner.request(DigestContents, [downloaded_module.digest])
+    found_uuid_go_file = False
+    for file_content in digest_contents:
+        if file_content.path == "uuid.go":
+            found_uuid_go_file = True
+            break
+    assert found_uuid_go_file

--- a/src/python/pants/backend/go/module_integration_test.py
+++ b/src/python/pants/backend/go/module_integration_test.py
@@ -77,6 +77,9 @@ def test_download_external_module(rule_runner: RuleRunner) -> None:
             )
         ],
     )
+    assert downloaded_module.path == "github.com/google/uuid"
+    assert downloaded_module.version == "v1.3.0"
+
     digest_contents = rule_runner.request(DigestContents, [downloaded_module.digest])
     found_uuid_go_file = False
     for file_content in digest_contents:


### PR DESCRIPTION
Add types and a rule to download the sources of external Go modules. This will be used by the support for for building third-party Go modules.

[ci skip-rust]

[ci skip-build-wheels]