### PR TITLE
wip: unions using protocol classes.

### DIFF
--- a/src/python/pants/engine/unions.py
+++ b/src/python/pants/engine/unions.py
@@ -3,47 +3,18 @@
 
 from __future__ import annotations
 
+from abc import ABC
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, DefaultDict, Iterable, Mapping, Protocol, Type, TypeVar, runtime_checkable
+from typing import Any, DefaultDict, Iterable, Mapping, Type, TypeVar
 
 from pants.util.frozendict import FrozenDict
 from pants.util.meta import decorated_type_checkable, frozen_after_init
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 
 
-class UnionBaseMetaclass(type):
-    # This trick with UnionBase just shows that it does NOT work well.
-    """Turn UnionBase derived classes into runtime checkable Protocol classes.
-
-    This trick fools mypy into not seeing the resulting class as being a Protocol, however.
-    """
-
-    def __new__(meta_cls, name, bases, namespace):
-        if name == "UnionBase":
-            cls = type.__new__(meta_cls, name, bases, namespace)
-        else:
-            meta_cls = type(Protocol)
-            if Protocol not in bases:
-                bases = (*bases, Protocol)
-
-            cls = runtime_checkable(
-                meta_cls.__new__(
-                    meta_cls,
-                    name,
-                    tuple(base for base in bases if base.__name__ != "UnionBase"),
-                    namespace,
-                )
-            )
-        return cls
-
-
-class UnionBase(metaclass=UnionBaseMetaclass):
-    """We require runtime checkable Protocol classes.
-
-    Deriving from this class make the user code cleaner, but does not work as regular Protocol
-    classes, as mypy fails to detect them as such.
-    """
+class UnionBase(ABC):
+    """Abstract base class for Unions."""
 
 
 @decorated_type_checkable
@@ -67,8 +38,21 @@ def union(cls):
 
 
 def is_union(input_type: type) -> bool:
-    """Return whether or not a type has been annotated with `@union`."""
-    return union.is_instance(input_type)
+    """Return whether or not a type has been annotated with `@union`, or derives from the UnionBase
+    ABC."""
+    return union.is_instance(input_type) or issubclass(input_type, UnionBase)
+
+
+def is_union_member(member, base: type) -> bool:
+    """Return whether or not a type is a union member for a given union base."""
+    if union.is_instance(base):
+        # we have no way of knowing this for old style unions
+        return True
+
+    if issubclass(base, UnionBase):
+        return issubclass(member, base)
+
+    return False
 
 
 @dataclass(frozen=True)
@@ -80,38 +64,30 @@ class UnionRule:
     union_member: Type
 
     def __post_init__(self) -> None:
-        if getattr(self.union_base, "_is_protocol", False):
-            self.__check_union_protocol()
-        else:
-            self.__check_decorated_union()
-
-    def __check_union_protocol(self):
-        if not getattr(self.union_base, "_is_runtime_protocol", False):
-            raise ValueError(
-                "The first argument, {self.union_base}, must either be decorated "
-                "with @typing.runtime_checkable in order to check the Union Protocol, "
-                "or derive from pants.engine.unions.UnionBase."
-            )
-
-        if not issubclass(self.union_member, self.union_base):
-            raise ValueError(
-                f"The second argument, {self.union_member}, must satisfy the "
-                f"union Protocol {self.union_base}."
-            )
-
-    def __check_decorated_union(self):
-        if union.is_instance(self.union_base):
+        if is_union_member(self.union_member, self.union_base):
             return
 
-        msg = (
-            f"The first argument must be a class annotated with @union "
-            f"(from pants.engine.unions), but was {self.union_base}."
-        )
-        if union.is_instance(self.union_member):
-            msg += (
-                "\n\nHowever, the second argument was annotated with `@union`. Did you "
-                "switch the first and second arguments to `UnionRule()`?"
+        if is_union(self.union_base):
+            msg = (
+                f"The second argument, the union member {self.union_member}, must "
+                f"inherit from the first argument, the union base {self.union_base}."
             )
+            if is_union_member(self.union_base, self.union_member):
+                msg += (
+                    "\n\nHowever, the first argument inherits from the second. "
+                    "You have switched the first and second arguments to `UnionRule()`."
+                )
+        else:
+            msg = (
+                f"The first argument must be a class either annotated with @union or inheriting "
+                f"from UnionBase (from pants.engine.unions), but was {self.union_base}."
+            )
+            if union.is_instance(self.union_member):
+                msg += (
+                    "\n\nHowever, the second argument was annotated with `@union`. Did you "
+                    "switch the first and second arguments to `UnionRule()`?"
+                )
+
         raise ValueError(msg)
 
 

--- a/src/python/pants/engine/unions_test.py
+++ b/src/python/pants/engine/unions_test.py
@@ -1,7 +1,11 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.engine.unions import UnionMembership, UnionRule, union
+from typing import Protocol, Type
+
+import pytest
+
+from pants.engine.unions import UnionMembership, UnionRule, union  # , UnionRule2
 from pants.util.ordered_set import FrozenOrderedSet
 
 
@@ -19,3 +23,56 @@ def test_union_membership_from_rules() -> None:
     assert UnionMembership.from_rules([UnionRule(Base, A), UnionRule(Base, B)]) == UnionMembership(
         {Base: FrozenOrderedSet([A, B])}
     )
+
+
+def test_unions_using_protocols() -> None:
+    class Base(Protocol):
+        def frobnicate(self) -> bool:
+            ...
+
+    class A:
+        def frobnicate(self) -> bool:
+            return False
+
+    class B:
+        def frobnicate(self) -> bool:
+            return True
+
+    class C:
+        pass
+
+    class Base2(Protocol):
+        pass
+
+    union_membership = UnionMembership.from_rules(
+        [
+            UnionRule(Base, A),
+            UnionRule(Base, B),
+            UnionRule(Base, C),
+        ]
+    )
+    assert union_membership == UnionMembership({Base: FrozenOrderedSet([A, B, C])})
+
+    assert union_membership.has_members(Base)
+    assert not union_membership.has_members(Base2)
+    assert union_membership.is_member(Base, A())
+    with pytest.raises(TypeError):
+        union_membership.is_member(Base2, A())
+
+    a: Base = A()
+    b: Base = B()
+
+    # expected type error, as C does not fulfill the Base protocol
+    c: Base = C()  # type: ignore[assignment]
+
+    assert isinstance(a, A)
+    assert isinstance(b, B)
+    assert isinstance(c, C)
+
+    T: Type[Base] = A
+    t = T()
+
+    assert isinstance(t, A)
+
+    # WIP: want typecheck to err on the following:
+    # UnionRule2(Base, C)

--- a/src/python/pants/engine/unions_test.py
+++ b/src/python/pants/engine/unions_test.py
@@ -1,7 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Protocol, runtime_checkable
+from abc import abstractmethod
+from dataclasses import dataclass
 
 import pytest
 
@@ -25,110 +26,36 @@ def test_union_membership_from_rules() -> None:
     )
 
 
-def test_unions_using_protocols() -> None:
-    # Setup different versions of Union base classes, show casing UnionBase vs Protocol (w/ and w/o
-    # @runtime_checkable).
-
-    class Base(UnionBase):
+def test_unions_using_abc() -> None:
+    class CustomUnion(UnionBase):
+        @abstractmethod
         def frobnicate(self) -> bool:
-            ...
-
-    # This will be the line to go with, using Protocol directly. The runtime_checkable decorator
-    # could be made optional, especially if using attributes, which it is not compatible with.. I
-    # was hoping for something cleaner, but maybe not too bad, considering the hackish workarounds
-    # required to make it work otherwise.
-    @runtime_checkable
-    class Base2(Protocol):
-        def some(self) -> str:
-            ...
-
-    class Base3(Protocol):
-        pass
-
-    class Base4(Protocol):
-        attr: int
-
-    # All bases of a Protocol must be protocols.. so we tripped up here, with the UnionBase.
-    class Derived(Base, Protocol):  # type: ignore[misc]
-        def gonk(self) -> None:
-            ...
-
-    class Derived2(Base2, Protocol):
-        def other(self) -> float:
-            ...
-
-    class A:
-        def frobnicate(self) -> bool:
+            # default impl
             return False
 
-    class B:
-        def some(self) -> str:
-            return "thing"
+    @dataclass
+    class Impl1(CustomUnion):
+        prop: str
+        opt: int
 
-        def frobnicate(self) -> bool:
-            return True
-
-    class C:
-        def some(self) -> str:
-            return "thing"
-
-    class D(A, C):
-        def gonk(self) -> None:
-            return None
-
-        def other(self) -> float:
-            return 1.2
+        # mypy catches the following mistake (wrong ret type: bool -> str)
+        def frobnicate(self) -> str:  # type: ignore[override]
+            return self.prop * self.opt
 
     union_membership = UnionMembership.from_rules(
         [
-            UnionRule(Base, A),
-            UnionRule(Base, B),
-            UnionRule(Base2, B),
-            UnionRule(Base2, C),
-            UnionRule(Derived, D),
-            UnionRule(Derived2, D),
+            UnionRule(CustomUnion, Impl1),
         ]
     )
+
     assert union_membership == UnionMembership(
         {
-            Base: FrozenOrderedSet([A, B]),
-            Base2: FrozenOrderedSet([B, C]),
-            Derived: FrozenOrderedSet([D]),
-            Derived2: FrozenOrderedSet([D]),
+            CustomUnion: FrozenOrderedSet([Impl1]),
         }
     )
 
-    assert union_membership.has_members(Base)
-    assert not union_membership.has_members(UnionBase)
-    assert union_membership.is_member(Base, A())
-    assert not union_membership.is_member(Base2, A())
-    with pytest.raises(TypeError):
-        union_membership.is_member(UnionBase, A())
-
-    # wanted typecheck to err on the following, but didn't manage that, so settled to have a runtime
-    # check instead.
-    with pytest.raises(ValueError):
-        # Not OK - C does not fulfill the Base protocol
-        UnionRule(Base, C)
+    a = Impl1("val", 2)
+    assert a.frobnicate() == "valval"
 
     with pytest.raises(ValueError):
-        # Not OK - Base3 is not runtime checkable
-        UnionRule(Base3, C)
-
-    # Type check tests, with UnionBase vs clean Protocol classes
-
-    # mypy does not pick up our trick to turn Base into a Protocol, so this is not OK
-    a: Base = A()  # type: ignore[assignment]
-
-    # Base2 and Base3 are both explicitly Protocols, so this is OK
-    b: Base2 = B()
-    c: Base3 = C()
-
-    # C does not fulfill Base4, so this is not OK
-    d: Base4 = C()  # type: ignore[assignment]
-    # error: Incompatible types in
-    # assignment (expression has type "C", variable has type "Base4")  [assignment]
-    #    d: Base4 = C()
-    #               ^
-
-    assert a and b and c and d
+        UnionRule(Impl1, CustomUnion)

--- a/src/python/pants/engine/unions_test.py
+++ b/src/python/pants/engine/unions_test.py
@@ -1,11 +1,11 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Protocol, Type
+from typing import Protocol, runtime_checkable
 
 import pytest
 
-from pants.engine.unions import UnionMembership, UnionRule, union  # , UnionRule2
+from pants.engine.unions import UnionBase, UnionMembership, UnionRule, union
 from pants.util.ordered_set import FrozenOrderedSet
 
 
@@ -26,8 +26,35 @@ def test_union_membership_from_rules() -> None:
 
 
 def test_unions_using_protocols() -> None:
-    class Base(Protocol):
+    # Setup different versions of Union base classes, show casing UnionBase vs Protocol (w/ and w/o
+    # @runtime_checkable).
+
+    class Base(UnionBase):
         def frobnicate(self) -> bool:
+            ...
+
+    # This will be the line to go with, using Protocol directly. The runtime_checkable decorator
+    # could be made optional, especially if using attributes, which it is not compatible with.. I
+    # was hoping for something cleaner, but maybe not too bad, considering the hackish workarounds
+    # required to make it work otherwise.
+    @runtime_checkable
+    class Base2(Protocol):
+        def some(self) -> str:
+            ...
+
+    class Base3(Protocol):
+        pass
+
+    class Base4(Protocol):
+        attr: int
+
+    # All bases of a Protocol must be protocols.. so we tripped up here, with the UnionBase.
+    class Derived(Base, Protocol):  # type: ignore[misc]
+        def gonk(self) -> None:
+            ...
+
+    class Derived2(Base2, Protocol):
+        def other(self) -> float:
             ...
 
     class A:
@@ -35,44 +62,73 @@ def test_unions_using_protocols() -> None:
             return False
 
     class B:
+        def some(self) -> str:
+            return "thing"
+
         def frobnicate(self) -> bool:
             return True
 
     class C:
-        pass
+        def some(self) -> str:
+            return "thing"
 
-    class Base2(Protocol):
-        pass
+    class D(A, C):
+        def gonk(self) -> None:
+            return None
+
+        def other(self) -> float:
+            return 1.2
 
     union_membership = UnionMembership.from_rules(
         [
             UnionRule(Base, A),
             UnionRule(Base, B),
-            UnionRule(Base, C),
+            UnionRule(Base2, B),
+            UnionRule(Base2, C),
+            UnionRule(Derived, D),
+            UnionRule(Derived2, D),
         ]
     )
-    assert union_membership == UnionMembership({Base: FrozenOrderedSet([A, B, C])})
+    assert union_membership == UnionMembership(
+        {
+            Base: FrozenOrderedSet([A, B]),
+            Base2: FrozenOrderedSet([B, C]),
+            Derived: FrozenOrderedSet([D]),
+            Derived2: FrozenOrderedSet([D]),
+        }
+    )
 
     assert union_membership.has_members(Base)
-    assert not union_membership.has_members(Base2)
+    assert not union_membership.has_members(UnionBase)
     assert union_membership.is_member(Base, A())
+    assert not union_membership.is_member(Base2, A())
     with pytest.raises(TypeError):
-        union_membership.is_member(Base2, A())
+        union_membership.is_member(UnionBase, A())
 
-    a: Base = A()
-    b: Base = B()
+    # wanted typecheck to err on the following, but didn't manage that, so settled to have a runtime
+    # check instead.
+    with pytest.raises(ValueError):
+        # Not OK - C does not fulfill the Base protocol
+        UnionRule(Base, C)
 
-    # expected type error, as C does not fulfill the Base protocol
-    c: Base = C()  # type: ignore[assignment]
+    with pytest.raises(ValueError):
+        # Not OK - Base3 is not runtime checkable
+        UnionRule(Base3, C)
 
-    assert isinstance(a, A)
-    assert isinstance(b, B)
-    assert isinstance(c, C)
+    # Type check tests, with UnionBase vs clean Protocol classes
 
-    T: Type[Base] = A
-    t = T()
+    # mypy does not pick up our trick to turn Base into a Protocol, so this is not OK
+    a: Base = A()  # type: ignore[assignment]
 
-    assert isinstance(t, A)
+    # Base2 and Base3 are both explicitly Protocols, so this is OK
+    b: Base2 = B()
+    c: Base3 = C()
 
-    # WIP: want typecheck to err on the following:
-    # UnionRule2(Base, C)
+    # C does not fulfill Base4, so this is not OK
+    d: Base4 = C()  # type: ignore[assignment]
+    # error: Incompatible types in
+    # assignment (expression has type "C", variable has type "Base4")  [assignment]
+    #    d: Base4 = C()
+    #               ^
+
+    assert a and b and c and d


### PR DESCRIPTION
POC to re-design union rules.

From the explorations done (as shown in the current changes in this PR), ~I've landed in that going with Protocols is a feasible way forward, when used up front without any facades.~
No, Protocol classes did not really fit well when used at runtime. Attempt #2 using ABCs instead.

This could look like something like this:

```python
from pants.engine.unions import UnionBase, UnionRule

class Vehicle(UnionBase):
    """Union base for vehicle types."""
    def model(self) -> str: ...

class Truck(Vehicle):
    """Another union base, derived from the first one."""
    wheel_count(self) -> int: ...

class Volvo(Vehicle):
    """Union member."""
    def model(self) -> str: return "XC90"

class Peterbilt(Truck):
    """Another union member, for trucks."""
    def model(self) -> str: return "359"
    def wheel_count(self) -> int: return 6

def rules() ->
    return [
        UnionRule(Vehicle, Volvo),
        UnionRule(Truck, Peterbilt),
    ]
```

N.B. I'm not sure if there's a downside to that it is hard to distinguish which classes are union base types, and which are union members, that will be up to the UnioRule calls to settle. Perhaps a naming scheme here could help.

Also, what other current union quirks are there, that we'd like to resolve with a change like this..

~The `runtime_checkable` would need to be optional, in order to allow attributes on the union protocol. But without it, we can not use `issubclass()` to check if the union member satisfies the Protocol. Also, I didn't manage to get mypy to help with this either, if you find a way to get mypy to understand this, it would be great:~

```python

class Proto(Protocol):
    attr: str

class Impl:
    pass

@dataclass
class Foo(Generic[T]):
   attr1: T
   attr2: Type[T]

foo = Foo(Proto, Impl)   # mypy accepts this, as I've not found a way to force mypy to test the Protocol conformance here..
bar: Type[Proto] = Impl  # but not this, as Impl is missing the str attr.
```
