### PR TITLE
Fixes incorrectly-ordered sorting of requirement components in `InterpreterConstraints` constructor

### DIFF
--- a/src/python/pants/backend/python/util_rules/interpreter_constraints.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints.py
@@ -45,9 +45,9 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
         # #12578 `parse_constraint` will sort the requirement's component constraints into a stable form.
         # We need to sort the component constraints for each requirement _before_ sorting the entire list
         # for the ordering to be correct.
-        parsed_constraints = [
+        parsed_constraints = (
             i if isinstance(i, Requirement) else self.parse_constraint(i) for i in constraints
-        ]
+        )
         super().__init__(sorted(parsed_constraints, key=lambda c: str(c)))
 
     def __str__(self) -> str:

--- a/src/python/pants/backend/python/util_rules/interpreter_constraints_test.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints_test.py
@@ -402,7 +402,7 @@ def test_contains(candidate, target, matches) -> None:
 
 def test_constraints_are_correctly_sorted_at_construction() -> None:
     # #12578: This list itself is out of order, and `CPython>=3.6,<4,!=3.7.*` is specified with out-of-order component requirements.
-    # This test verifie
+    # This test verifies that the list is fully sorted after the first call to `InterpreterConstraints()`
     inputs = ["CPython==2.7.*", "PyPy", "CPython>=3.6,<4,!=3.7.*"]
     a = InterpreterConstraints(inputs)
     a_str = [str(i) for i in a]

--- a/src/python/pants/backend/python/util_rules/interpreter_constraints_test.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints_test.py
@@ -401,8 +401,9 @@ def test_contains(candidate, target, matches) -> None:
 
 
 def test_constraints_are_correctly_sorted_at_construction() -> None:
-    # #12578: This list itself is out of order, and `CPython>=3.6,<4,!=3.7.*` is specified with out-of-order component requirements.
-    # This test verifies that the list is fully sorted after the first call to `InterpreterConstraints()`
+    # #12578: This list itself is out of order, and `CPython>=3.6,<4,!=3.7.*` is specified with 
+    # out-of-order component requirements. This test verifies that the list is fully sorted after 
+    # the first call to `InterpreterConstraints()`
     inputs = ["CPython==2.7.*", "PyPy", "CPython>=3.6,<4,!=3.7.*"]
     a = InterpreterConstraints(inputs)
     a_str = [str(i) for i in a]

--- a/src/python/pants/backend/python/util_rules/interpreter_constraints_test.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints_test.py
@@ -293,7 +293,7 @@ _SKIPPED_PY3 = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
     "constraints,expected",
     (
         (["==2.7.*"], "==2.7.*"),
-        (["==2.7.*", ">=3.6,!=3.6.1"], "==2.7.* || !=3.6.1,>=3.6"),
+        (["==2.7.*", ">=3.6,!=3.6.1"], "!=3.6.1,>=3.6 || ==2.7.*"),
         ([], "*"),
         # If any of the constraints are unconstrained (e.g. `CPython`), use a wildcard.
         (["==2.7", ""], "*"),
@@ -398,3 +398,13 @@ def test_contains(candidate, target, matches) -> None:
         )
         == matches
     )
+
+
+def test_constraints_are_correctly_sorted_at_construction() -> None:
+    # #12578: This list itself is out of order, and `CPython>=3.6,<4,!=3.7.*` is specified with out-of-order component requirements.
+    # This test verifie
+    inputs = ["CPython==2.7.*", "PyPy", "CPython>=3.6,<4,!=3.7.*"]
+    a = InterpreterConstraints(inputs)
+    a_str = [str(i) for i in a]
+    b = InterpreterConstraints(a_str)
+    assert a == b

--- a/src/python/pants/backend/python/util_rules/interpreter_constraints_test.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints_test.py
@@ -401,8 +401,8 @@ def test_contains(candidate, target, matches) -> None:
 
 
 def test_constraints_are_correctly_sorted_at_construction() -> None:
-    # #12578: This list itself is out of order, and `CPython>=3.6,<4,!=3.7.*` is specified with 
-    # out-of-order component requirements. This test verifies that the list is fully sorted after 
+    # #12578: This list itself is out of order, and `CPython>=3.6,<4,!=3.7.*` is specified with
+    # out-of-order component requirements. This test verifies that the list is fully sorted after
     # the first call to `InterpreterConstraints()`
     inputs = ["CPython==2.7.*", "PyPy", "CPython>=3.6,<4,!=3.7.*"]
     a = InterpreterConstraints(inputs)


### PR DESCRIPTION
Fixes #12578.

# Rust tests and lints will be skipped. Delete if not intended.
[ci skip-rust]