### PR TITLE
[internal] Fix Pytest and IPython to check for stale lockfiles

### DIFF
--- a/src/python/pants/backend/experimental/python/lockfile.py
+++ b/src/python/pants/backend/experimental/python/lockfile.py
@@ -136,7 +136,7 @@ async def generate_lockfile(
         PexRequest(
             output_filename="poetry.pex",
             internal_only=True,
-            requirements=poetry_subsystem.pex_requirements(),
+            requirements=poetry_subsystem.pex_requirements(expected_lockfile_hex_digest=None),
             interpreter_constraints=poetry_subsystem.interpreter_constraints,
             main=EntryPoint(PurePath(POETRY_LAUNCHER.path).stem),
             sources=launcher_digest,

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -6,12 +6,17 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Optional
 
+from pants.backend.experimental.python.lockfile import PythonLockfileRequest
 from pants.backend.python.goals.coverage_py import (
     CoverageConfig,
     CoverageSubsystem,
     PytestCoverageData,
 )
-from pants.backend.python.subsystems.pytest import PyTest, PythonTestFieldSet
+from pants.backend.python.subsystems.pytest import (
+    PyTest,
+    PytestLockfileSentinel,
+    PythonTestFieldSet,
+)
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import Pex, PexRequest, VenvPex, VenvPexProcess
 from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
@@ -169,6 +174,11 @@ async def setup_pytest_for_target(
 
     interpreter_constraints = InterpreterConstraints.create_from_targets(all_targets, python_setup)
 
+    lockfile_hex_digest = None
+    if pytest.lockfile != "<none>":
+        lockfile_request = await Get(PythonLockfileRequest, PytestLockfileSentinel())
+        lockfile_hex_digest = lockfile_request.hex_digest
+
     requirements_pex_get = Get(
         Pex,
         PexFromTargetsRequest,
@@ -178,7 +188,7 @@ async def setup_pytest_for_target(
         Pex,
         PexRequest(
             output_filename="pytest.pex",
-            requirements=pytest.pex_requirements(),
+            requirements=pytest.pex_requirements(lockfile_hex_digest),
             interpreter_constraints=interpreter_constraints,
             internal_only=True,
         ),

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -15,6 +15,7 @@ from pants.backend.python.goals import package_pex_binary, pytest_runner
 from pants.backend.python.goals.coverage_py import create_or_update_coverage_config
 from pants.backend.python.goals.pytest_runner import PytestPluginSetup, PytestPluginSetupRequest
 from pants.backend.python.subsystems.pytest import PythonTestFieldSet
+from pants.backend.python.subsystems.pytest import rules as pytest_subsystem_rules
 from pants.backend.python.target_types import (
     PexBinary,
     PythonLibrary,
@@ -46,6 +47,7 @@ def rule_runner() -> RuleRunner:
             build_runtime_package_dependencies,
             create_or_update_coverage_config,
             *pytest_runner.rules(),
+            *pytest_subsystem_rules(),
             *pex_from_targets.rules(),
             *dependency_inference_rules.rules(),
             *distdir.rules(),

--- a/src/python/pants/backend/python/goals/repl.py
+++ b/src/python/pants/backend/python/goals/repl.py
@@ -1,7 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.python.subsystems.ipython import IPython
+from pants.backend.experimental.python.lockfile import PythonLockfileRequest
+from pants.backend.python.subsystems.ipython import IPython, IPythonLockfileSentinel
 from pants.backend.python.util_rules.pex import Pex, PexRequest
 from pants.backend.python.util_rules.pex_environment import PexEnvironment
 from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
@@ -75,12 +76,17 @@ async def create_ipython_repl_request(
         PythonSourceFiles, PythonSourceFilesRequest(repl.targets, include_files=True)
     )
 
+    lockfile_hex_digest = None
+    if ipython.lockfile != "<none>":
+        lockfile_request = await Get(PythonLockfileRequest, IPythonLockfileSentinel())
+        lockfile_hex_digest = lockfile_request.hex_digest
+
     ipython_request = Get(
         Pex,
         PexRequest(
             output_filename="ipython.pex",
             main=ipython.main,
-            requirements=ipython.pex_requirements(),
+            requirements=ipython.pex_requirements(lockfile_hex_digest),
             interpreter_constraints=requirements_pex_request.interpreter_constraints,
             internal_only=True,
         ),

--- a/src/python/pants/backend/python/subsystems/ipython.py
+++ b/src/python/pants/backend/python/subsystems/ipython.py
@@ -50,7 +50,7 @@ class IPython(PythonToolBase):
         )
 
 
-class IPythonLockfileSentinel(PythonToolLockfileSentinel):
+class IPythonLockfileSentinel:
     pass
 
 

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -243,7 +243,7 @@ class PyTest(PythonToolBase):
         )
 
 
-class PytestLockfileSentinel(PythonToolLockfileSentinel):
+class PytestLockfileSentinel:
     pass
 
 

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -117,7 +117,7 @@ class PythonToolRequirementsBase(Subsystem):
         """
         return (self.version, *self.extra_requirements)
 
-    def pex_requirements(self, expected_lockfile_hex_digest: str | None = None) -> PexRequirements:
+    def pex_requirements(self, expected_lockfile_hex_digest: str | None) -> PexRequirements:
         """The requirements to be used when installing the tool.
 
         If the tool supports lockfiles, the returned type will install from the lockfile rather than

--- a/src/python/pants/core/goals/repl_integration_test.py
+++ b/src/python/pants/core/goals/repl_integration_test.py
@@ -5,6 +5,7 @@ import pytest
 
 from pants.backend.codegen.protobuf.target_types import ProtobufLibrary
 from pants.backend.python.goals import repl as python_repl
+from pants.backend.python.subsystems.ipython import rules as ipython_subsystem_rules
 from pants.backend.python.target_types import PythonLibrary
 from pants.backend.python.util_rules import pex_from_targets
 from pants.backend.python.util_rules.pex import PexProcess
@@ -19,6 +20,7 @@ def rule_runner() -> RuleRunner:
     rule_runner = RuleRunner(
         rules=[
             *repl_rules(),
+            *ipython_subsystem_rules(),
             *python_repl.rules(),
             *pex_from_targets.rules(),
             QueryRule(Process, (PexProcess,)),


### PR DESCRIPTION
These were missed in https://github.com/pantsbuild/pants/pull/12448.

To reduce the risk of this happening again, we remove the default argument for `PythonToolBase.pex_requirements(expected_lockfile_hex_digest)`.

In the process, I realized that Pylint is not actually consuming it's lockfile at all because of how we handle first-party plugins. I'll address that in a followup that adds lockfile support to MyPy.

[ci skip-rust]
[ci skip-build-wheels]