### PR TITLE
[internal] Refactor Pylint first-party plugins

### DIFF
--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -5,8 +5,12 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Iterable, List, Tuple
 
-from pants.backend.python.lint.pylint.subsystem import Pylint, PylintFieldSet
-from pants.backend.python.target_types import InterpreterConstraintsField, PythonRequirementsField
+from pants.backend.python.lint.pylint.subsystem import (
+    Pylint,
+    PylintFieldSet,
+    PylintFirstPartyPlugins,
+)
+from pants.backend.python.target_types import InterpreterConstraintsField
 from pants.backend.python.util_rules import pex_from_targets
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import (
@@ -20,22 +24,15 @@ from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsReque
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
     PythonSourceFilesRequest,
-    StrippedPythonSourceFiles,
 )
 from pants.core.goals.lint import LintRequest, LintResult, LintResults
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.engine.addresses import Addresses, UnparsedAddressInputs
-from pants.engine.fs import EMPTY_DIGEST, AddPrefix, Digest, MergeDigests
+from pants.engine.addresses import Addresses
+from pants.engine.fs import Digest, MergeDigests
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import (
-    DependenciesRequest,
-    Target,
-    Targets,
-    TransitiveTargets,
-    TransitiveTargetsRequest,
-)
+from pants.engine.target import DependenciesRequest, Target, Targets
 from pants.engine.unions import UnionRule
 from pants.python.python_setup import PythonSetup
 from pants.util.logging import LogLevel
@@ -55,13 +52,11 @@ class PylintPartition:
     field_sets: Tuple[PylintFieldSet, ...]
     targets_with_dependencies: Targets
     interpreter_constraints: InterpreterConstraints
-    plugin_targets: Targets
 
     def __init__(
         self,
         target_setups: Iterable[PylintTargetSetup],
         interpreter_constraints: InterpreterConstraints,
-        plugin_targets: Iterable[Target],
     ) -> None:
         field_sets = []
         targets_with_deps: List[Target] = []
@@ -72,7 +67,6 @@ class PylintPartition:
         self.field_sets = tuple(field_sets)
         self.targets_with_dependencies = Targets(targets_with_deps)
         self.interpreter_constraints = interpreter_constraints
-        self.plugin_targets = Targets(plugin_targets)
 
 
 class PylintRequest(LintRequest):
@@ -89,7 +83,9 @@ def generate_argv(source_files: SourceFiles, pylint: Pylint) -> Tuple[str, ...]:
 
 
 @rule(level=LogLevel.DEBUG)
-async def pylint_lint_partition(partition: PylintPartition, pylint: Pylint) -> LintResult:
+async def pylint_lint_partition(
+    partition: PylintPartition, pylint: Pylint, first_party_plugins: PylintFirstPartyPlugins
+) -> LintResult:
     requirements_pex_get = Get(
         Pex,
         PexFromTargetsRequest,
@@ -104,26 +100,18 @@ async def pylint_lint_partition(partition: PylintPartition, pylint: Pylint) -> L
         ),
     )
 
-    plugin_requirements = PexRequirements.create_from_requirement_fields(
-        plugin_tgt[PythonRequirementsField]
-        for plugin_tgt in partition.plugin_targets
-        if plugin_tgt.has_field(PythonRequirementsField)
-    )
     pylint_pex_get = Get(
         Pex,
         PexRequest(
             output_filename="pylint.pex",
             internal_only=True,
             requirements=PexRequirements(
-                [*pylint.all_requirements, *plugin_requirements.req_strings]
+                [*pylint.all_requirements, *first_party_plugins.requirement_strings]
             ),
             interpreter_constraints=partition.interpreter_constraints,
         ),
     )
 
-    prepare_plugin_sources_get = Get(
-        StrippedPythonSourceFiles, PythonSourceFilesRequest(partition.plugin_targets)
-    )
     prepare_python_sources_get = Get(
         PythonSourceFiles, PythonSourceFilesRequest(partition.targets_with_dependencies)
     )
@@ -131,16 +119,9 @@ async def pylint_lint_partition(partition: PylintPartition, pylint: Pylint) -> L
         SourceFiles, SourceFilesRequest(field_set.sources for field_set in partition.field_sets)
     )
 
-    (
-        pylint_pex,
-        requirements_pex,
-        prepared_plugin_sources,
-        prepared_python_sources,
-        field_set_sources,
-    ) = await MultiGet(
+    pylint_pex, requirements_pex, prepared_python_sources, field_set_sources = await MultiGet(
         pylint_pex_get,
         requirements_pex_get,
-        prepare_plugin_sources_get,
         prepare_python_sources_get,
         field_set_sources_get,
     )
@@ -161,30 +142,16 @@ async def pylint_lint_partition(partition: PylintPartition, pylint: Pylint) -> L
         ),
     )
 
-    prefixed_plugin_sources = (
-        await Get(
-            Digest,
-            AddPrefix(prepared_plugin_sources.stripped_source_files.snapshot.digest, "__plugins"),
-        )
-        if pylint.source_plugins
-        else EMPTY_DIGEST
-    )
-
     pythonpath = list(prepared_python_sources.source_roots)
-    if pylint.source_plugins:
-        # NB: Pylint source plugins must be explicitly loaded via PEX_EXTRA_SYS_PATH. The value must
-        # point to the plugin's directory, rather than to a parent's directory, because
-        # `load-plugins` takes a module name rather than a path to the module; i.e. `plugin`, but
-        # not `path.to.plugin`. (This means users must have specified the parent directory as a
-        # source root.)
-        pythonpath.append("__plugins")
+    if first_party_plugins:
+        pythonpath.append(first_party_plugins.PREFIX)
 
     input_digest = await Get(
         Digest,
         MergeDigests(
             (
                 config_files.snapshot.digest,
-                prefixed_plugin_sources,
+                first_party_plugins.sources_digest,
                 prepared_python_sources.source_files.snapshot.digest,
             )
         ),
@@ -208,28 +175,19 @@ async def pylint_lint_partition(partition: PylintPartition, pylint: Pylint) -> L
 
 @rule(desc="Lint using Pylint", level=LogLevel.DEBUG)
 async def pylint_lint(
-    request: PylintRequest, pylint: Pylint, python_setup: PythonSetup
+    request: PylintRequest,
+    pylint: Pylint,
+    python_setup: PythonSetup,
+    first_party_plugins: PylintFirstPartyPlugins,
 ) -> LintResults:
     if pylint.skip:
         return LintResults([], linter_name="Pylint")
 
-    plugin_target_addresses = await Get(Addresses, UnparsedAddressInputs, pylint.source_plugins)
-    plugin_targets_request = Get(
-        TransitiveTargets, TransitiveTargetsRequest(plugin_target_addresses)
-    )
-    linted_targets_request = Get(
-        Targets, Addresses(field_set.address for field_set in request.field_sets)
-    )
-    plugin_targets, linted_targets = await MultiGet(plugin_targets_request, linted_targets_request)
-
-    plugin_targets_compatibility_fields = tuple(
-        plugin_tgt[InterpreterConstraintsField]
-        for plugin_tgt in plugin_targets.closure
-        if plugin_tgt.has_field(InterpreterConstraintsField)
-    )
-
     # Pylint needs direct dependencies in the chroot to ensure that imports are valid. However, it
     # doesn't lint those direct dependencies nor does it care about transitive dependencies.
+    linted_targets = await Get(
+        Targets, Addresses(field_set.address for field_set in request.field_sets)
+    )
     per_target_dependencies = await MultiGet(
         Get(Targets, DependenciesRequest(field_set.dependencies))
         for field_set in request.field_sets
@@ -251,7 +209,7 @@ async def pylint_lint(
                     for tgt in [tgt, *dependencies]
                     if tgt.has_field(InterpreterConstraintsField)
                 ),
-                *plugin_targets_compatibility_fields,
+                *first_party_plugins.interpreter_constraints_fields,
             ),
             python_setup,
         )
@@ -261,7 +219,6 @@ async def pylint_lint(
         PylintPartition(
             tuple(sorted(target_setups, key=lambda tgt_setup: tgt_setup.field_set.address)),
             interpreter_constraints,
-            Targets(plugin_targets.closure),
         )
         for interpreter_constraints, target_setups in sorted(
             interpreter_constraints_to_target_setup.items()

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -7,10 +7,10 @@ from textwrap import dedent
 
 import pytest
 
+from pants.backend.python.lint.pylint import subsystem
 from pants.backend.python.lint.pylint.rules import PylintRequest
 from pants.backend.python.lint.pylint.rules import rules as pylint_rules
 from pants.backend.python.lint.pylint.subsystem import PylintFieldSet
-from pants.backend.python.lint.pylint import subsystem
 from pants.backend.python.target_types import PythonLibrary, PythonRequirementLibrary
 from pants.core.goals.lint import LintResult, LintResults
 from pants.core.util_rules import config_files

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -10,6 +10,7 @@ import pytest
 from pants.backend.python.lint.pylint.rules import PylintRequest
 from pants.backend.python.lint.pylint.rules import rules as pylint_rules
 from pants.backend.python.lint.pylint.subsystem import PylintFieldSet
+from pants.backend.python.lint.pylint import subsystem
 from pants.backend.python.target_types import PythonLibrary, PythonRequirementLibrary
 from pants.core.goals.lint import LintResult, LintResults
 from pants.core.util_rules import config_files
@@ -24,8 +25,9 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *pylint_rules(),
-            QueryRule(LintResults, [PylintRequest]),
+            *subsystem.rules(),
             *config_files.rules(),
+            QueryRule(LintResults, [PylintRequest]),
         ],
         target_types=[PythonLibrary, PythonRequirementLibrary],
     )


### PR DESCRIPTION
This extracts out all the Pylint first-party plugin code into a dedicated rule in `pylint/subsystem.py`, which makes the code in `pylint/rules.py` much easier to work with. It also allows adding a new unit test, to complement the integration test.

Prework for fixing the lockfile for Pylint to be actually used.

[ci skip-rust]
[ci skip-build-wheels]