### PR TITLE
fs_util can use mTLS and ignore certificates

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -202,6 +202,7 @@ dependencies = [
  "errno",
  "fuse",
  "futures",
+ "grpc_util",
  "hashing",
  "libc",
  "log 0.4.14",
@@ -670,6 +671,7 @@ dependencies = [
  "futures",
  "futures-core",
  "graph",
+ "grpc_util",
  "hashing",
  "indexmap",
  "itertools 0.10.1",
@@ -1090,7 +1092,9 @@ dependencies = [
  "prost-build",
  "prost-types",
  "rand 0.8.2",
+ "rustls",
  "rustls-native-certs",
+ "rustls-pemfile",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -1099,6 +1103,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "webpki",
 ]
 
 [[package]]
@@ -2243,6 +2248,7 @@ dependencies = [
  "env_logger",
  "fs",
  "futures",
+ "grpc_util",
  "hashing",
  "log 0.4.14",
  "process_execution",
@@ -2763,6 +2769,15 @@ dependencies = [
  "rustls",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
+dependencies = [
+ "base64",
 ]
 
 [[package]]

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -116,6 +116,7 @@ fs = { path = "fs" }
 futures = "0.3"
 futures-core = "^0.3.0"
 graph = { path = "graph" }
+grpc_util = { path = "grpc_util" }
 hashing = { path = "hashing" }
 indexmap = "1.4"
 itertools = "0.10"

--- a/src/rust/engine/fs/brfs/Cargo.toml
+++ b/src/rust/engine/fs/brfs/Cargo.toml
@@ -13,6 +13,7 @@ env_logger = "0.5.4"
 errno = "0.2.3"
 fuse = "0.3.1"
 futures = "0.3"
+grpc_util = { path = "../../grpc_util" }
 hashing = { path = "../../hashing" }
 libc = "0.2.39"
 log = "0.4.1"

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -39,6 +39,7 @@ use bazel_protos::gen::build::bazel::remote::execution::v2 as remexec;
 use bazel_protos::require_digest;
 use clap::{value_t, App, Arg};
 use futures::future::FutureExt;
+use grpc_util::tls;
 use hashing::{Digest, Fingerprint};
 use log::{debug, error, warn};
 use parking_lot::Mutex;
@@ -756,7 +757,7 @@ async fn main() {
       .into_with_remote(
         address,
         args.value_of("remote-instance-name").map(str::to_owned),
-        root_ca_certs,
+        tls::Config::new_without_mtls(root_ca_certs),
         headers,
         4 * 1024 * 1024,
         std::time::Duration::from_secs(5 * 60),

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -321,7 +321,7 @@ impl Store {
     self,
     cas_address: &str,
     instance_name: Option<String>,
-    root_ca_certs: Option<Vec<u8>>,
+    tls_config: grpc_util::tls::Config,
     headers: BTreeMap<String, String>,
     chunk_size_bytes: usize,
     upload_timeout: Duration,
@@ -335,7 +335,7 @@ impl Store {
       remote: Some(RemoteStore::new(remote::ByteStore::new(
         cas_address,
         instance_name,
-        root_ca_certs,
+        tls_config,
         headers,
         chunk_size_bytes,
         upload_timeout,

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -70,7 +70,7 @@ impl ByteStore {
   pub fn new(
     cas_address: &str,
     instance_name: Option<String>,
-    root_ca_certs: Option<Vec<u8>>,
+    tls_config: grpc_util::tls::Config,
     mut headers: BTreeMap<String, String>,
     chunk_size_bytes: usize,
     upload_timeout: Duration,
@@ -80,7 +80,7 @@ impl ByteStore {
     batch_api_size_limit: usize,
   ) -> Result<ByteStore, String> {
     let tls_client_config = if cas_address.starts_with("https://") {
-      Some(grpc_util::create_tls_config(root_ca_certs)?)
+      Some(tls_config.try_into()?)
     } else {
       None
     };
@@ -512,7 +512,7 @@ impl ByteStore {
     }
   }
 
-  pub(super) fn find_missing_blobs_request<'a, Digests: Iterator<Item = &'a Digest>>(
+  pub fn find_missing_blobs_request<'a, Digests: Iterator<Item = &'a Digest>>(
     &self,
     digests: Digests,
   ) -> remexec::FindMissingBlobsRequest {

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::time::Duration;
 
 use bytes::Bytes;
+use grpc_util::tls;
 use hashing::Digest;
 use mock::StubCAS;
 use testutil::data::{TestData, TestDirectory};
@@ -152,7 +153,7 @@ async fn write_file_multiple_chunks() {
   let store = ByteStore::new(
     &cas.address(),
     None,
-    None,
+    tls::Config::default(),
     BTreeMap::new(),
     10 * 1024,
     Duration::from_secs(5),
@@ -224,7 +225,7 @@ async fn write_connection_error() {
   let store = ByteStore::new(
     "http://doesnotexist.example",
     None,
-    None,
+    tls::Config::default(),
     BTreeMap::new(),
     10 * 1024 * 1024,
     Duration::from_secs(1),
@@ -302,7 +303,7 @@ fn new_byte_store(cas: &StubCAS) -> ByteStore {
   ByteStore::new(
     &cas.address(),
     None,
-    None,
+    tls::Config::default(),
     BTreeMap::new(),
     10 * MEGABYTES,
     Duration::from_secs(1),

--- a/src/rust/engine/fs/store/src/tests.rs
+++ b/src/rust/engine/fs/store/src/tests.rs
@@ -11,6 +11,7 @@ use bazel_protos::gen::build::bazel::remote::execution::v2 as remexec;
 use bytes::{Bytes, BytesMut};
 use fs::RelativePath;
 use grpc_util::prost::MessageExt;
+use grpc_util::tls;
 use hashing::{Digest, Fingerprint};
 use maplit::btreemap;
 use mock::StubCAS;
@@ -100,7 +101,7 @@ fn new_store<P: AsRef<Path>>(dir: P, cas_address: &str) -> Store {
     .into_with_remote(
       cas_address,
       None,
-      None,
+      tls::Config::default(),
       BTreeMap::new(),
       10 * MEGABYTES,
       Duration::from_secs(1),
@@ -843,7 +844,7 @@ async fn instance_name_upload() {
     .into_with_remote(
       &cas.address(),
       Some("dark-tower".to_owned()),
-      None,
+      tls::Config::default(),
       BTreeMap::new(),
       10 * MEGABYTES,
       Duration::from_secs(1),
@@ -873,7 +874,7 @@ async fn instance_name_download() {
     .into_with_remote(
       &cas.address(),
       Some("dark-tower".to_owned()),
-      None,
+      tls::Config::default(),
       BTreeMap::new(),
       10 * MEGABYTES,
       Duration::from_secs(1),
@@ -925,7 +926,7 @@ async fn auth_upload() {
     .into_with_remote(
       &cas.address(),
       None,
-      None,
+      tls::Config::default(),
       headers,
       10 * MEGABYTES,
       Duration::from_secs(1),
@@ -957,7 +958,7 @@ async fn auth_download() {
     .into_with_remote(
       &cas.address(),
       None,
-      None,
+      tls::Config::default(),
       headers,
       10 * MEGABYTES,
       Duration::from_secs(1),

--- a/src/rust/engine/grpc_util/Cargo.toml
+++ b/src/rust/engine/grpc_util/Cargo.toml
@@ -15,6 +15,8 @@ itertools = "0.10"
 rustls-native-certs = "0.5"
 prost = "0.8"
 rand = "0.8"
+rustls = { version = "0.19", features = ["dangerous_configuration"] }
+rustls-pemfile = "0.2"
 tokio = { version = "1.4", features = ["net", "process", "rt-multi-thread", "sync", "time"] }
 tokio-rustls = "0.22"
 tokio-util = { version = "0.6", features = ["codec"] }
@@ -22,6 +24,7 @@ tonic = { version = "0.5", features = ["transport", "codegen", "tls", "tls-roots
 tower = { version = "0.4", features = ["limit"] }
 tower-layer = "0.3"
 tower-service = "0.3"
+webpki = "0.21"
 
 [dev-dependencies]
 async-trait = "0.1"

--- a/src/rust/engine/grpc_util/src/tls.rs
+++ b/src/rust/engine/grpc_util/src/tls.rs
@@ -1,0 +1,137 @@
+use rustls::{ClientConfig, RootCertStore, ServerCertVerified, ServerCertVerifier, TLSError};
+use std::convert::TryFrom;
+use std::sync::Arc;
+use webpki::DNSNameRef;
+
+#[derive(Default)]
+pub struct Config {
+  pub root_ca_certs: Option<Vec<u8>>,
+  pub mtls: Option<MtlsConfig>,
+  pub certificate_check: CertificateCheck,
+}
+
+impl Config {
+  pub fn new_without_mtls(root_ca_certs: Option<Vec<u8>>) -> Self {
+    Self {
+      root_ca_certs,
+      mtls: None,
+      certificate_check: CertificateCheck::Enabled,
+    }
+  }
+}
+
+impl TryFrom<Config> for ClientConfig {
+  type Error = String;
+
+  /// Create a rust-tls `ClientConfig` from root CA certs, falling back to the rust-tls-native-certs
+  /// crate if specific root CA certs were not given.
+  fn try_from(config: Config) -> Result<Self, Self::Error> {
+    let mut tls_config = ClientConfig::new();
+
+    // Must set HTTP/2 as ALPN protocol otherwise cannot connect over TLS to gRPC servers.
+    // Unfortunately, this is not a default value and, moreover, Tonic does not provide
+    // any helper function to encapsulate this knowledge.
+    tls_config.set_protocols(&[Vec::from("h2")]);
+
+    // Add the root store.
+    match config.root_ca_certs {
+      Some(pem_bytes) => {
+        let mut reader = std::io::Cursor::new(pem_bytes);
+        tls_config
+          .root_store
+          .add_pem_file(&mut reader)
+          .map_err(|_| {
+            "Unexpected state when adding PEM file from `--remote-ca-certs-path`. Please \
+          check that it points to a valid file."
+              .to_owned()
+          })?;
+      }
+      None => {
+        tls_config.root_store =
+          rustls_native_certs::load_native_certs().map_err(|(_maybe_store, e)| {
+            format!(
+              "Could not discover root CA cert files to use TLS with remote caching and remote \
+            execution. Consider setting `--remote-ca-certs-path` instead to explicitly point to \
+            the correct PEM file.\n\n{}",
+              e
+            )
+          })?;
+      }
+    }
+
+    if let Some(MtlsConfig { key, cert_chain }) = config.mtls {
+      tls_config
+        .set_single_client_cert(
+          cert_chain_from_pem_bytes(cert_chain)?,
+          der_key_from_pem_bytes(key)?,
+        )
+        .map_err(|err| format!("Error creating MTLS config: {:?}", err))?;
+    }
+
+    if let CertificateCheck::DangerouslyDisabled = config.certificate_check {
+      tls_config
+        .dangerous()
+        .set_certificate_verifier(Arc::new(NoVerifier));
+    }
+
+    Ok(tls_config)
+  }
+}
+
+pub struct MtlsConfig {
+  /// PEM bytes of the private key used for MTLS.
+  pub key: Vec<u8>,
+  /// PEM bytes of the certificate used for MTLS.
+  pub cert_chain: Vec<u8>,
+}
+
+pub enum CertificateCheck {
+  Enabled,
+  DangerouslyDisabled,
+}
+
+impl Default for CertificateCheck {
+  fn default() -> Self {
+    Self::Enabled
+  }
+}
+
+struct NoVerifier;
+
+impl ServerCertVerifier for NoVerifier {
+  fn verify_server_cert(
+    &self,
+    _roots: &RootCertStore,
+    _presented_certs: &[rustls::Certificate],
+    _dns_name: DNSNameRef,
+    _ocsp_response: &[u8],
+  ) -> Result<ServerCertVerified, TLSError> {
+    Ok(ServerCertVerified::assertion())
+  }
+}
+
+fn cert_chain_from_pem_bytes(cert_chain: Vec<u8>) -> Result<Vec<rustls::Certificate>, String> {
+  rustls_pemfile::certs(&mut cert_chain.as_slice())
+    .and_then(|certs| {
+      certs
+        .into_iter()
+        .map(|cert| Ok(rustls::Certificate(cert)))
+        .collect::<Result<Vec<_>, _>>()
+    })
+    .map_err(|err| format!("Failed to parse certificates from PEM file {:?}", err))
+}
+
+fn der_key_from_pem_bytes(pem_bytes: Vec<u8>) -> Result<rustls::PrivateKey, String> {
+  let key = rustls_pemfile::read_one(&mut pem_bytes.as_slice())
+    .map_err(|err| format!("Failed to read PEM file: {:?}", err))?
+    .ok_or_else(|| "No private key found in PEM file".to_owned())?;
+  use rustls_pemfile::Item;
+  let key = match key {
+    Item::RSAKey(bytes) => bytes,
+    Item::PKCS8Key(bytes) => bytes,
+    Item::X509Certificate(_) => {
+      return Err("Found certificate in PEM file but expected private key".to_owned())
+    }
+  };
+  Ok(rustls::PrivateKey(key))
+}

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -133,7 +133,7 @@ impl CommandRunner {
     let store_use_tls = store_address.starts_with("https://");
 
     let tls_client_config = if execution_use_tls || store_use_tls {
-      Some(grpc_util::create_tls_config(root_ca_certs)?)
+      Some(grpc_util::tls::Config::new_without_mtls(root_ca_certs).try_into()?)
     } else {
       None
     };

--- a/src/rust/engine/process_execution/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_cache_tests.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use bazel_protos::gen::build::bazel::remote::execution::v2 as remexec;
 use fs::RelativePath;
+use grpc_util::tls;
 use hashing::{Digest, EMPTY_DIGEST};
 use maplit::hashset;
 use mock::{StubActionCache, StubCAS};
@@ -90,7 +91,7 @@ impl StoreSetup {
       .into_with_remote(
         &cas.address(),
         None,
-        None,
+        tls::Config::default(),
         BTreeMap::new(),
         10 * 1024 * 1024,
         Duration::from_secs(1),

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -7,6 +7,7 @@ use bazel_protos::gen::build::bazel::remote::execution::v2 as remexec;
 use bazel_protos::gen::google::longrunning::Operation;
 use bytes::Bytes;
 use grpc_util::prost::MessageExt;
+use grpc_util::tls;
 use hashing::{Digest, Fingerprint, EMPTY_DIGEST};
 use maplit::{btreemap, hashset};
 use mock::execution_server::{ExpectedAPICall, MockOperation};
@@ -865,7 +866,7 @@ async fn sends_headers() {
     .into_with_remote(
       &cas.address(),
       None,
-      None,
+      tls::Config::default(),
       BTreeMap::new(),
       10 * 1024 * 1024,
       Duration::from_secs(1),
@@ -1066,7 +1067,7 @@ async fn ensure_inline_stdio_is_stored() {
     .into_with_remote(
       &cas.address(),
       None,
-      None,
+      tls::Config::default(),
       BTreeMap::new(),
       10 * 1024 * 1024,
       Duration::from_secs(1),
@@ -1448,7 +1449,7 @@ async fn execute_missing_file_uploads_if_known() {
     .into_with_remote(
       &cas.address(),
       None,
-      None,
+      tls::Config::default(),
       BTreeMap::new(),
       10 * 1024 * 1024,
       Duration::from_secs(1),
@@ -1529,7 +1530,7 @@ async fn execute_missing_file_errors_if_unknown() {
     .into_with_remote(
       &cas.address(),
       None,
-      None,
+      tls::Config::default(),
       BTreeMap::new(),
       10 * 1024 * 1024,
       Duration::from_secs(1),
@@ -2276,7 +2277,7 @@ pub(crate) fn make_store(
     .into_with_remote(
       &cas.address(),
       None,
-      None,
+      tls::Config::default(),
       BTreeMap::new(),
       10 * 1024 * 1024,
       Duration::from_secs(1),

--- a/src/rust/engine/process_executor/Cargo.toml
+++ b/src/rust/engine/process_executor/Cargo.toml
@@ -12,6 +12,7 @@ dirs-next = "2"
 env_logger = "0.5.4"
 fs = { path = "../fs" }
 futures = "0.3"
+grpc_util = { path = "../grpc_util" }
 hashing = { path = "../hashing" }
 log = "0.4"
 process_execution = { path = "../process_execution" }

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -248,7 +248,7 @@ async fn main() {
       local_only_store.into_with_remote(
         cas_server,
         args.remote_instance_name.clone(),
-        root_ca_certs,
+        grpc_util::tls::Config::new_without_mtls(root_ca_certs),
         headers,
         args.upload_chunk_bytes,
         Duration::from_secs(30),

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -145,7 +145,7 @@ impl Core {
       local_only.into_with_remote(
         remote_store_address,
         remoting_opts.instance_name.clone(),
-        root_ca_certs.clone(),
+        grpc_util::tls::Config::new_without_mtls(root_ca_certs.clone()),
         remoting_opts.store_headers.clone(),
         remoting_opts.store_chunk_bytes,
         remoting_opts.store_chunk_upload_timeout,


### PR DESCRIPTION
This sets up the infrastructure for these to be configured for all gRPC
connections, but doesn't wire them up other than for fs_util.