### PR TITLE
[internal] Fix Pylint lockfile to actually be wired up

### DIFF
--- a/src/python/pants/backend/experimental/python/lockfile.py
+++ b/src/python/pants/backend/experimental/python/lockfile.py
@@ -7,6 +7,7 @@ import logging
 from dataclasses import dataclass
 from pathlib import PurePath
 from textwrap import dedent
+from typing import Iterable
 
 from pants.backend.experimental.python.lockfile_metadata import (
     calculate_invalidation_digest,
@@ -92,6 +93,8 @@ class PythonLockfileRequest:
         cls,
         subsystem: PythonToolRequirementsBase,
         interpreter_constraints: InterpreterConstraints | None = None,
+        *,
+        extra_requirements: Iterable[str] = (),
     ) -> PythonLockfileRequest:
         """Create a request for a dedicated lockfile for the tool.
 
@@ -100,7 +103,7 @@ class PythonLockfileRequest:
         `interpreter_constraints`.
         """
         return cls(
-            requirements=FrozenOrderedSet(subsystem.all_requirements),
+            requirements=FrozenOrderedSet((*subsystem.all_requirements, *extra_requirements)),
             interpreter_constraints=(
                 interpreter_constraints
                 if interpreter_constraints is not None

--- a/src/python/pants/backend/python/lint/pylint/subsystem_test.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem_test.py
@@ -10,6 +10,7 @@ import pytest
 from pants.backend.experimental.python.lockfile import PythonLockfileRequest
 from pants.backend.python.lint.pylint import skip_field
 from pants.backend.python.lint.pylint.subsystem import (
+    Pylint,
     PylintFirstPartyPlugins,
     PylintLockfileSentinel,
 )
@@ -101,26 +102,40 @@ def test_first_party_plugins(rule_runner: RuleRunner) -> None:
 
 def test_setup_lockfile_interpreter_constraints(rule_runner: RuleRunner) -> None:
     global_constraint = "==3.9.*"
-    rule_runner.set_options(
-        [], env={"PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"}
-    )
 
-    def assert_ics(build_file: str, expected: list[str]) -> None:
+    def assert_lockfile_requst(
+        build_file: str,
+        expected_ics: list[str],
+        *,
+        extra_expected_requirements: list[str] | None = None,
+        args: list[str] | None = None,
+    ) -> None:
         rule_runner.write_files({"project/BUILD": build_file})
+        rule_runner.set_options(
+            args or [],
+            env={"PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"},
+        )
         lockfile_request = rule_runner.request(PythonLockfileRequest, [PylintLockfileSentinel()])
-        assert lockfile_request.interpreter_constraints == InterpreterConstraints(expected)
+        assert lockfile_request.interpreter_constraints == InterpreterConstraints(expected_ics)
+        assert lockfile_request.requirements == FrozenOrderedSet(
+            [
+                Pylint.default_version,
+                *Pylint.default_extra_requirements,
+                *(extra_expected_requirements or ()),
+            ]
+        )
 
-    assert_ics("python_library()", [global_constraint])
-    assert_ics("python_library(interpreter_constraints=['==2.7.*'])", ["==2.7.*"])
-    assert_ics(
+    assert_lockfile_requst("python_library()", [global_constraint])
+    assert_lockfile_requst("python_library(interpreter_constraints=['==2.7.*'])", ["==2.7.*"])
+    assert_lockfile_requst(
         "python_library(interpreter_constraints=['==2.7.*', '==3.5.*'])", ["==2.7.*", "==3.5.*"]
     )
 
     # If no Python targets in repo, fall back to global python-setup constraints.
-    assert_ics("target()", [global_constraint])
+    assert_lockfile_requst("target()", [global_constraint])
 
     # Ignore targets that are skipped.
-    assert_ics(
+    assert_lockfile_requst(
         dedent(
             """\
             python_library(name='a', interpreter_constraints=['==2.7.*'])
@@ -132,7 +147,7 @@ def test_setup_lockfile_interpreter_constraints(rule_runner: RuleRunner) -> None
 
     # If there are multiple distinct ICs in the repo, we OR them because the lockfile needs to be
     # compatible with every target.
-    assert_ics(
+    assert_lockfile_requst(
         dedent(
             """\
             python_library(name='a', interpreter_constraints=['==2.7.*'])
@@ -141,7 +156,7 @@ def test_setup_lockfile_interpreter_constraints(rule_runner: RuleRunner) -> None
         ),
         ["==2.7.*", "==3.5.*"],
     )
-    assert_ics(
+    assert_lockfile_requst(
         dedent(
             """\
             python_library(name='a', interpreter_constraints=['==2.7.*', '==3.5.*'])
@@ -150,7 +165,7 @@ def test_setup_lockfile_interpreter_constraints(rule_runner: RuleRunner) -> None
         ),
         ["==2.7.*", "==3.5.*", ">=3.5"],
     )
-    assert_ics(
+    assert_lockfile_requst(
         dedent(
             """\
             python_library(name='a')
@@ -163,7 +178,7 @@ def test_setup_lockfile_interpreter_constraints(rule_runner: RuleRunner) -> None
 
     # Also consider direct deps (but not transitive). They should be ANDed within each target's
     # closure like normal, but then ORed across each closure.
-    assert_ics(
+    assert_lockfile_requst(
         dedent(
             """\
             python_library(
@@ -180,7 +195,7 @@ def test_setup_lockfile_interpreter_constraints(rule_runner: RuleRunner) -> None
         ),
         ["==2.7.*", "==2.7.*,==3.6.*"],
     )
-    assert_ics(
+    assert_lockfile_requst(
         dedent(
             """\
             python_library(
@@ -195,4 +210,56 @@ def test_setup_lockfile_interpreter_constraints(rule_runner: RuleRunner) -> None
             """
         ),
         ["==2.7.*", "==2.7.*,==3.6.*", ">=3.7,==3.8.*"],
+    )
+
+    # Check that source_plugins are included, even if they aren't linted directly. Plugins
+    # consider transitive deps.
+    assert_lockfile_requst(
+        dedent(
+            """\
+            python_library(
+                name="lib",
+                sources=[],
+                interpreter_constraints=['==3.6.*'],
+            )
+            python_library(
+                name="plugin",
+                sources=[],
+                interpreter_constraints=['==2.7.*'],
+                skip_pylint=True,
+            )
+            """
+        ),
+        ["==2.7.*,==3.6.*"],
+        args=["--pylint-source-plugins=project:plugin"],
+    )
+    assert_lockfile_requst(
+        dedent(
+            """\
+            python_library(
+                sources=[],
+                dependencies=[":direct_dep"],
+                interpreter_constraints=['==3.6.*'],
+                skip_pylint=True,
+            )
+            python_library(
+                name="direct_dep",
+                sources=[],
+                dependencies=[":transitive_dep"],
+                interpreter_constraints=['==3.6.*'],
+                skip_pylint=True,
+            )
+            python_library(
+                name="transitive_dep",
+                sources=[],
+                dependencies=[":thirdparty"],
+                interpreter_constraints=['==2.7.*', '==3.6.*'],
+                skip_pylint=True,
+            )
+            python_requirement_library(name="thirdparty", requirements=["ansicolors"])
+            """
+        ),
+        ["==2.7.*,==3.6.*", "==3.6.*"],
+        args=["--pylint-source-plugins=project"],
+        extra_expected_requirements=["ansicolors"],
     )

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import importlib.resources
-from typing import ClassVar, Sequence, cast
+from typing import ClassVar, Iterable, Sequence, cast
 
 from pants.backend.python.target_types import ConsoleScript, EntryPoint, MainSpecification
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
@@ -117,14 +117,19 @@ class PythonToolRequirementsBase(Subsystem):
         """
         return (self.version, *self.extra_requirements)
 
-    def pex_requirements(self, expected_lockfile_hex_digest: str | None) -> PexRequirements:
+    def pex_requirements(
+        self,
+        expected_lockfile_hex_digest: str | None,
+        *,
+        extra_requirements: Iterable[str] = (),
+    ) -> PexRequirements:
         """The requirements to be used when installing the tool.
 
         If the tool supports lockfiles, the returned type will install from the lockfile rather than
         `all_requirements`.
         """
         if not self.register_lockfile or self.lockfile == "<none>":
-            return PexRequirements(self.all_requirements)
+            return PexRequirements((*self.all_requirements, *extra_requirements))
         if self.lockfile == "<default>":
             assert self.default_lockfile_resource is not None
             return PexRequirements(


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/12491 did not properly add lockfiles to Pylint. The option was registered, but not being consumed.

This was trickier to implement than other tool lockfiles because we must consider `[pylint].source_plugins`, whose requirement strings and interpreter constraints must be considered. 

[ci skip-rust]
[ci skip-build-wheels]