### PR TITLE
[internal] use `is_union()` rather than `union.is_instance()`.

### DIFF
--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -56,7 +56,7 @@ from pants.engine.process import (
     MultiPlatformProcess,
 )
 from pants.engine.rules import Rule, RuleIndex, TaskRule
-from pants.engine.unions import UnionMembership, union
+from pants.engine.unions import UnionMembership, is_union
 from pants.option.global_options import (
     LOCAL_STORE_LEASE_TIME_SECS,
     ExecutionOptions,
@@ -657,7 +657,7 @@ def register_rules(rule_index: RuleIndex, union_membership: UnionMembership) -> 
             native_engine.tasks_add_get(tasks, product, subject)
 
         for the_get in rule.input_gets:
-            if union.is_instance(the_get.input_type):
+            if is_union(the_get.input_type):
                 # If the registered subject type is a union, add Get edges to all registered
                 # union members.
                 for union_member in union_membership.get(the_get.input_type):

--- a/src/python/pants/engine/internals/selectors.py
+++ b/src/python/pants/engine/internals/selectors.py
@@ -29,7 +29,7 @@ from pants.engine.internals.native_engine import (
     PyGeneratorResponseGet,
     PyGeneratorResponseGetMulti,
 )
-from pants.engine.unions import union
+from pants.engine.unions import is_union
 from pants.util.meta import frozen_after_init
 
 _Output = TypeVar("_Output")
@@ -202,7 +202,7 @@ class Get(GetConstraints, Generic[_Output, _Input]):
         # If the input_type is not annotated with `@union`, then we validate that the input is
         # exactly the same type as the input_type. (Why not check unions? We don't have access to
         # `UnionMembership` to know if it's a valid union member. The engine will check that.)
-        if not union.is_instance(self.input_type) and type(input_) != self.input_type:
+        if not is_union(self.input_type) and type(input_) != self.input_type:
             # We can assume we're using the longhand form because the shorthand form guarantees
             # that the `input_type` is the same as `input`.
             raise TypeError(


### PR DESCRIPTION
prep work for #12577

Signed-off-by: Andreas Stenius <andreas.stenius@svenskaspel.se>

# Rust tests and lints will be skipped. Delete if not intended.
[ci skip-rust]

# Building wheels and fs_util will be skipped. Delete if not intended.
[ci skip-build-wheels]