### PR TITLE
Switch log warning rendering to yellow

### DIFF
--- a/src/python/pants/backend/project_info/list_targets.py
+++ b/src/python/pants/backend/project_info/list_targets.py
@@ -1,6 +1,7 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import logging
 from typing import Dict, cast
 
 from pants.engine.addresses import Address, Addresses
@@ -8,6 +9,8 @@ from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
 from pants.engine.rules import Get, collect_rules, goal_rule
 from pants.engine.target import DescriptionField, ProvidesField, UnexpandedTargets
+
+logger = logging.getLogger(__name__)
 
 
 class ListSubsystem(LineOriented, GoalSubsystem):
@@ -48,7 +51,7 @@ async def list_targets(
     addresses: Addresses, list_subsystem: ListSubsystem, console: Console
 ) -> List:
     if not addresses:
-        console.print_stderr(f"WARNING: No targets were matched in goal `{list_subsystem.name}`.")
+        logger.warning(f"No targets were matched in goal `{list_subsystem.name}`.")
         return List(exit_code=0)
 
     if list_subsystem.provides and list_subsystem.documented:

--- a/src/python/pants/backend/project_info/list_targets_test.py
+++ b/src/python/pants/backend/project_info/list_targets_test.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import re
 from textwrap import dedent
 
 from pants.backend.project_info.list_targets import ListSubsystem, list_targets
@@ -65,7 +66,7 @@ def test_list_normal() -> None:
 
 def test_no_targets_warns() -> None:
     _, stderr = run_goal([])
-    assert "WARNING: No targets" in stderr
+    assert re.search("WARN.* No targets", stderr)
 
 
 def test_list_documented() -> None:

--- a/src/rust/engine/logging/src/logger.rs
+++ b/src/rust/engine/logging/src/logger.rs
@@ -202,7 +202,7 @@ impl Log for PantsLogger {
         _ if !use_color => format!("[{}]", level).normal().clear(),
         Level::Info => format!("[{}]", level).normal(),
         Level::Error => format!("[{}]", level).red(),
-        Level::Warn => format!("[{}]", level).red(),
+        Level::Warn => format!("[{}]", level).yellow(),
         Level::Debug => format!("[{}]", level).green(),
         Level::Trace => format!("[{}]", level).magenta(),
       };

--- a/tests/python/pants_test/integration/list_integration_test.py
+++ b/tests/python/pants_test/integration/list_integration_test.py
@@ -1,6 +1,8 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import re
+
 from pants.testutil.pants_integration_test import run_pants
 
 
@@ -13,7 +15,7 @@ def test_list_all() -> None:
 def test_list_none() -> None:
     pants_run = run_pants(["list"])
     pants_run.assert_success()
-    assert "WARNING: No targets were matched in" in pants_run.stderr
+    assert re.search("WARN.* No targets were matched in", pants_run.stderr)
 
 
 def test_list_invalid_dir() -> None:


### PR DESCRIPTION
Switch log warning rendering to yellow, and use a real `logger.warning` in a case where highlighting the warning is useful.

When we originally [made the decision to use red for warn](https://github.com/pantsbuild/pants/pull/10278#discussion_r454713168), there was a concern that yellow didn't have enough contrast on all terminals. But our experience in using tools which use yellow (`pytest`, `git`, `rustc` etc) is that it doesn't hamper usability: if we are missing important usecases for users we will be happy to make further adjustments.

[ci skip-build-wheels]