### PR TITLE
Embrace that help strings are markdown.

### DIFF
--- a/build-support/bin/docs_templates/options_scope_reference.md.mustache
+++ b/build-support/bin/docs_templates/options_scope_reference.md.mustache
@@ -1,8 +1,7 @@
 {{#is_goal}}```
 ./pants {{scope}} [args]
 ```{{/is_goal}}
-{{! Mark as a paragraph to render as plain text, rather than markdown. }}
-<p>{{description}}</p>
+{{{description}}}
 
 Config section: <span style="color: purple"><code>[{{scope}}{{^scope}}GLOBAL{{/scope}}]</code></span>
 

--- a/build-support/bin/docs_templates/single_option_reference.md.mustache
+++ b/build-support/bin/docs_templates/single_option_reference.md.mustache
@@ -4,14 +4,16 @@
   <code>{{env_var}}</code><br>
 </div>
 <div style="padding-left: 2em;">
-  {{#comma_separated_choices}}
-  <span style="color: green">one of: <code>{{comma_separated_choices}}</code></span><br>
-  {{/comma_separated_choices}}
-  <span style="color: green">default: {{{marked_up_default}}}</span>
-  {{! Mark both of these as paragraphs to render as plain text, rather than markdown. }}
-  {{! NB: We assume there's a removal_hint if deprecated_message is set. }}
-  {{#deprecated_message}}<p style="color: darkred">{{deprecated_message}}<br>{{removal_hint}}</p>{{/deprecated_message}}
-  <p>{{help}}</p>
+{{#comma_separated_choices}}
+<span style="color: green">one of: <code>{{comma_separated_choices}}</code></span><br>
+{{/comma_separated_choices}}
+<span style="color: green">default: {{{marked_up_default}}}</span>
+{{#deprecated_message}}<p style="color: darkred">{{deprecated_message}}<br>{{removal_hint}}</p>{{/deprecated_message}}
+<br>
+{{! NB: readme.com is finicky about when it processes markdown mingled with HTML elements.
+    The blank line here appears to ensure it. }}
+
+{{{help}}}
 </div>
 <br>
 

--- a/build-support/bin/generate_docs_test.py
+++ b/build-support/bin/generate_docs_test.py
@@ -8,20 +8,10 @@ from generate_docs import (
     DocUrlMatcher,
     DocUrlRewriter,
     get_title_from_page_content,
-    html_safe,
-    markdown_safe,
     value_strs_iter,
 )
 
 from pants.util.docutil import doc_url
-
-
-def test_markdown_safe():
-    assert "\\*A\\_B&lt;C&amp;" == markdown_safe("*A_B<C&")
-
-
-def test_html_safe():
-    assert "foo <code>bar==&#x27;baz&#x27;</code> qux" == html_safe("foo `bar=='baz'` qux")
 
 
 def test_gather_value_strs():

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -87,11 +87,11 @@ class PythonToolRequirementsBase(Subsystem):
                 advanced=True,
                 help=(
                     "Path to a lockfile used for installing the tool.\n\n"
-                    "Set to the string '<default>' to use a lockfile provided by "
+                    "Set to the string `<default>` to use a lockfile provided by "
                     "Pants, so long as you have not changed the `--version`, "
                     "`--extra-requirements`, and `--interpreter-constraints` options. See "
                     f"{cls.default_lockfile_url} for the default lockfile contents.\n\n"
-                    "Set to the string '<none>' to opt out of using a lockfile. We do not "
+                    "Set to the string `<none>` to opt out of using a lockfile. We do not "
                     "recommend this, as lockfiles are essential for reproducible builds.\n\n"
                     "To use a custom lockfile, set this option to a file path relative to the "
                     "build root, then activate the backend_package "

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -69,8 +69,8 @@ class InterpreterConstraintsField(StringSequenceField):
     alias = "interpreter_constraints"
     help = (
         "The Python interpreters this code is compatible with.\n\nEach element should be written "
-        "in pip-style format, e.g. 'CPython==2.7.*' or 'CPython>=3.6,<4'. You can leave off "
-        "`CPython` as a shorthand, e.g. '>=2.7' will be expanded to 'CPython>=2.7'.\n\nSpecify "
+        "in pip-style format, e.g. `CPython==2.7.*` or `CPython>=3.6,<4`. You can leave off "
+        "`CPython` as a shorthand, e.g. `>=2.7` will be expanded to `CPython>=2.7`.\n\nSpecify "
         "more than one element to OR the constraints, e.g. `['PyPy==3.7.*', 'CPython==3.7.*']` "
         "means either PyPy 3.7 _or_ CPython 3.7.\n\nIf the field is not set, it will default to "
         "the option `[python-setup].interpreter_constraints`.\n\n"

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -591,10 +591,10 @@ class GlobalOptions(Subsystem):
                 "Normally, Pants will look for literal matches from the start of the log/warning "
                 "message, but you can prefix the ignore with `$regex$` for Pants to instead treat "
                 "your string as a regex pattern. For example:\n\n"
-                "  ignore_warnings = [\n"
-                "    \"DEPRECATED: option 'config' in scope 'flake8' will be removed\",\n"
-                "    '$regex$:No files\\s*'\n"
-                "  ]"
+                "    ignore_warnings = [\n"
+                "        \"DEPRECATED: option 'config' in scope 'flake8' will be removed\",\n"
+                "        '$regex$:No files\\s*'\n"
+                "    ]\n"
             ),
         )
 
@@ -717,7 +717,7 @@ class GlobalOptions(Subsystem):
             # affects fingerprints.
             fingerprint=False,
             help=(
-                "Read additional specs (target addresses, files, and/or globs), one per line,"
+                "Read additional specs (target addresses, files, and/or globs), one per line, "
                 "from these files."
             ),
         )
@@ -799,7 +799,7 @@ class GlobalOptions(Subsystem):
             default=False,
             help="Enable concurrent runs of Pants. Without this enabled, Pants will "
             "start up all concurrent invocations (e.g. in other terminals) without pantsd. "
-            "Enabling this option requires parallel Pants invocations to block on the first",
+            "Enabling this option requires parallel Pants invocations to block on the first.",
         )
 
         # NB: We really don't want this option to invalidate the daemon, because different clients might have
@@ -1127,7 +1127,7 @@ class GlobalOptions(Subsystem):
             advanced=True,
             help=(
                 "Path to a PEM file containing CA certificates used for verifying secure "
-                "connections to --remote-execution-address and --remote-store-address.\n\nIf "
+                "connections to `--remote-execution-address` and `--remote-store-address`.\n\nIf "
                 "unspecified, Pants will attempt to auto-discover root CA certificates when TLS "
                 "is enabled with remote execution and caching."
             ),
@@ -1137,7 +1137,7 @@ class GlobalOptions(Subsystem):
             advanced=True,
             help=(
                 "Path to a file containing an oauth token to use for gGRPC connections to "
-                "--remote-execution-address and --remote-store-address.\n\nIf specified, Pants will "
+                "`--remote-execution-address` and `--remote-store-address`.\n\nIf specified, Pants will "
                 "add a header in the format `authorization: Bearer <token>`. You can also manually "
                 "add this header via `--remote-execution-headers` and `--remote-store-headers`, or "
                 "use `--remote-auth-plugin` to provide a plugin to dynamically set the relevant "
@@ -1165,7 +1165,7 @@ class GlobalOptions(Subsystem):
                 "`--remote-store-headers` still work.\n\n"
                 "If you return `instance_name`, Pants will replace `--remote-instance-name` "
                 "with this value.\n\n"
-                "If the returned auth state is AuthPluginState.UNAVAILABLE, Pants will disable "
+                "If the returned auth state is `AuthPluginState.UNAVAILABLE`, Pants will disable "
                 "remote caching and execution.\n\n"
                 "If Pantsd is in use, `prior_result` will be the previous "
                 "`AuthPluginResult` returned by your plugin, which allows you to reuse the result. "


### PR DESCRIPTION
Previously we sometimes wanted help strings treated as markdown and sometimes as plain text, 
depending on author convenience. Or we wanted parts of a given string treated in different ways. 
We tried various hacks to anticipate author intention, but they never worked properly, and caused 
no end of errors and edge cases and gotchas.

Now we simply accept that help strings are treated as markdown. This makes sense: We need
them to be in a format that is human-readable (for when displaying help on the CLI, or when reading
source code), and also machine-readable, for rendering by readme.com.  Markdown is such a
dual format.

This change:
- Removes the weird heuristics.
- Fixes up various help strings to conform with the new reality.

The big gotcha now is that authors of help strings must be aware of this fact. For example, you will
often want to surround things that look like markup or HTML tags, but are not, with backticks.

I have manually eyeballed a large subset of the docs generated with these changes, including
the "known offenders", and this seems like a good way to go.

A possible future change is to detect when help strings have changed, render them, and prompt
the author to manually verify that the rendered pages look good. 

[ci skip-rust]

[ci skip-build-wheels]