### PR TITLE
Pulls magic strings `<none>` and `<default>` into constants

### DIFF
--- a/src/python/pants/backend/experimental/python/lockfile.py
+++ b/src/python/pants/backend/experimental/python/lockfile.py
@@ -14,8 +14,8 @@ from pants.backend.experimental.python.lockfile_metadata import (
     lockfile_content_with_header,
 )
 from pants.backend.python.subsystems.python_tool_base import (
-    DEFAULT_LOCKFILE,
-    NO_LOCKFILE,
+    DEFAULT_TOOL_LOCKFILE,
+    NO_TOOL_LOCKFILE,
     PythonToolRequirementsBase,
 )
 from pants.backend.python.target_types import EntryPoint, PythonRequirementsField
@@ -289,7 +289,7 @@ async def generate_all_tool_lockfiles(
     results = await MultiGet(
         Get(PythonLockfile, PythonLockfileRequest, req)
         for req in requests
-        if req.dest not in {NO_LOCKFILE, DEFAULT_LOCKFILE}
+        if req.dest not in {NO_TOOL_LOCKFILE, DEFAULT_TOOL_LOCKFILE}
     )
     merged_digest = await Get(Digest, MergeDigests(res.digest for res in results))
     workspace.write_digest(merged_digest)

--- a/src/python/pants/backend/experimental/python/lockfile.py
+++ b/src/python/pants/backend/experimental/python/lockfile.py
@@ -13,7 +13,7 @@ from pants.backend.experimental.python.lockfile_metadata import (
     calculate_invalidation_digest,
     lockfile_content_with_header,
 )
-from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
+from pants.backend.python.subsystems.python_tool_base import NO_LOCKFILE, PythonToolRequirementsBase
 from pants.backend.python.target_types import EntryPoint, PythonRequirementsField
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import PexRequest, PexRequirements, VenvPex, VenvPexProcess
@@ -285,7 +285,7 @@ async def generate_all_tool_lockfiles(
     results = await MultiGet(
         Get(PythonLockfile, PythonLockfileRequest, req)
         for req in requests
-        if req.dest not in {"<none>", "<default>"}
+        if req.dest not in {NO_LOCKFILE, "<default>"}
     )
     merged_digest = await Get(Digest, MergeDigests(res.digest for res in results))
     workspace.write_digest(merged_digest)

--- a/src/python/pants/backend/experimental/python/lockfile.py
+++ b/src/python/pants/backend/experimental/python/lockfile.py
@@ -13,7 +13,11 @@ from pants.backend.experimental.python.lockfile_metadata import (
     calculate_invalidation_digest,
     lockfile_content_with_header,
 )
-from pants.backend.python.subsystems.python_tool_base import NO_LOCKFILE, PythonToolRequirementsBase
+from pants.backend.python.subsystems.python_tool_base import (
+    DEFAULT_LOCKFILE,
+    NO_LOCKFILE,
+    PythonToolRequirementsBase,
+)
 from pants.backend.python.target_types import EntryPoint, PythonRequirementsField
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import PexRequest, PexRequirements, VenvPex, VenvPexProcess
@@ -285,7 +289,7 @@ async def generate_all_tool_lockfiles(
     results = await MultiGet(
         Get(PythonLockfile, PythonLockfileRequest, req)
         for req in requests
-        if req.dest not in {NO_LOCKFILE, "<default>"}
+        if req.dest not in {NO_LOCKFILE, DEFAULT_LOCKFILE}
     )
     merged_digest = await Get(Digest, MergeDigests(res.digest for res in results))
     workspace.write_digest(merged_digest)

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -15,6 +15,8 @@ from pants.option.errors import OptionsError
 from pants.option.subsystem import Subsystem
 from pants.util.ordered_set import FrozenOrderedSet
 
+NO_LOCKFILE = "<none>"
+
 
 class PythonToolRequirementsBase(Subsystem):
     """Base class for subsystems that configure a set of requirements for a python tool."""
@@ -85,7 +87,7 @@ class PythonToolRequirementsBase(Subsystem):
             register(
                 "--experimental-lockfile",
                 type=str,
-                default="<none>",
+                default=NO_LOCKFILE,
                 advanced=True,
                 help=(
                     "Path to a lockfile used for installing the tool.\n\n"
@@ -164,7 +166,7 @@ class PythonToolRequirementsBase(Subsystem):
 
     @property
     def uses_lockfile(self) -> bool:
-        return self.register_lockfile and self.lockfile != "<none>"
+        return self.register_lockfile and self.lockfile != NO_LOCKFILE
 
     @property
     def interpreter_constraints(self) -> InterpreterConstraints:

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -15,8 +15,8 @@ from pants.option.errors import OptionsError
 from pants.option.subsystem import Subsystem
 from pants.util.ordered_set import FrozenOrderedSet
 
-DEFAULT_LOCKFILE = "<default>"
-NO_LOCKFILE = "<none>"
+DEFAULT_TOOL_LOCKFILE = "<default>"
+NO_TOOL_LOCKFILE = "<none>"
 
 
 class PythonToolRequirementsBase(Subsystem):
@@ -88,15 +88,15 @@ class PythonToolRequirementsBase(Subsystem):
             register(
                 "--experimental-lockfile",
                 type=str,
-                default=NO_LOCKFILE,
+                default=NO_TOOL_LOCKFILE,
                 advanced=True,
                 help=(
                     "Path to a lockfile used for installing the tool.\n\n"
-                    "Set to the string `<default>` to use a lockfile provided by "
+                    f"Set to the string `{DEFAULT_TOOL_LOCKFILE}` to use a lockfile provided by "
                     "Pants, so long as you have not changed the `--version`, "
                     "`--extra-requirements`, and `--interpreter-constraints` options. See "
                     f"{cls.default_lockfile_url} for the default lockfile contents.\n\n"
-                    "Set to the string `<none>` to opt out of using a lockfile. We do not "
+                    f"Set to the string `{NO_TOOL_LOCKFILE}` to opt out of using a lockfile. We do not "
                     "recommend this, as lockfiles are essential for reproducible builds.\n\n"
                     "To use a custom lockfile, set this option to a file path relative to the "
                     "build root, then activate the backend_package "
@@ -140,7 +140,7 @@ class PythonToolRequirementsBase(Subsystem):
 
         hex_digest = calculate_invalidation_digest(FrozenOrderedSet(requirements))
 
-        if self.lockfile == DEFAULT_LOCKFILE:
+        if self.lockfile == DEFAULT_TOOL_LOCKFILE:
             assert self.default_lockfile_resource is not None
             return PexRequirements(
                 file_content=FileContent(
@@ -159,7 +159,7 @@ class PythonToolRequirementsBase(Subsystem):
 
     @property
     def lockfile(self) -> str:
-        """The path to a lockfile or special strings '<none>' and '<default>'.
+        f"""The path to a lockfile or special strings '{NO_TOOL_LOCKFILE}' and '{DEFAULT_TOOL_LOCKFILE}'.
 
         This assumes you have set the class property `register_lockfile = True`.
         """
@@ -167,7 +167,7 @@ class PythonToolRequirementsBase(Subsystem):
 
     @property
     def uses_lockfile(self) -> bool:
-        return self.register_lockfile and self.lockfile != NO_LOCKFILE
+        return self.register_lockfile and self.lockfile != NO_TOOL_LOCKFILE
 
     @property
     def interpreter_constraints(self) -> InterpreterConstraints:

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -15,6 +15,7 @@ from pants.option.errors import OptionsError
 from pants.option.subsystem import Subsystem
 from pants.util.ordered_set import FrozenOrderedSet
 
+DEFAULT_LOCKFILE = "<default>"
 NO_LOCKFILE = "<none>"
 
 
@@ -139,7 +140,7 @@ class PythonToolRequirementsBase(Subsystem):
 
         hex_digest = calculate_invalidation_digest(FrozenOrderedSet(requirements))
 
-        if self.lockfile == "<default>":
+        if self.lockfile == DEFAULT_LOCKFILE:
             assert self.default_lockfile_resource is not None
             return PexRequirements(
                 file_content=FileContent(


### PR DESCRIPTION
This was probably more pressing back when we had `<none>` in 13 different places, but I figure this is still welcome.

# Rust tests and lints will be skipped. Delete if not intended.
[ci skip-rust]

# Building wheels and fs_util will be skipped. Delete if not intended.
[ci skip-build-wheels]