### PR TITLE
[WIP] use tower::retry::Retry for retries

### DIFF
--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -56,7 +56,7 @@ use double_checked_cell_async::DoubleCheckedCell;
 use fs::{default_cache_path, FileContent, RelativePath};
 use futures::future::{self, BoxFuture, Either, FutureExt, TryFutureExt};
 use grpc_util::prost::MessageExt;
-use grpc_util::retry::{retry_call, status_is_retryable};
+use grpc_util::retry::{retry_call, status_code_is_retryable};
 use grpc_util::status_to_str;
 use hashing::Digest;
 use parking_lot::Mutex;
@@ -557,7 +557,7 @@ impl Store {
           remote,
           |remote| async move { remote.load_bytes_with(digest, Ok).await },
           |err| match err {
-            ByteStoreError::Grpc(status) => status_is_retryable(status),
+            ByteStoreError::Grpc(status) => status_code_is_retryable(status.code()),
             _ => false,
           },
         )
@@ -846,7 +846,7 @@ impl Store {
           .await
       },
       |err| match err {
-        ByteStoreError::Grpc(status) => status_is_retryable(status),
+        ByteStoreError::Grpc(status) => status_code_is_retryable(status.code()),
         _ => false,
       },
     )

--- a/src/rust/engine/grpc_util/Cargo.toml
+++ b/src/rust/engine/grpc_util/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { version = "1.4", features = ["net", "process", "rt-multi-thread", "syn
 tokio-rustls = "0.22"
 tokio-util = { version = "0.6", features = ["codec"] }
 tonic = { version = "0.5", features = ["transport", "codegen", "tls", "tls-roots", "prost"] }
-tower = { version = "0.4", features = ["limit"] }
+tower = { version = "0.4", features = ["limit", "retry"] }
 tower-layer = "0.3"
 tower-service = "0.3"
 webpki = "0.21"

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -21,7 +21,7 @@ use futures::FutureExt;
 use futures::{Stream, StreamExt};
 use grpc_util::headers_to_http_header_map;
 use grpc_util::prost::MessageExt;
-use grpc_util::retry::{retry_call, status_is_retryable};
+use grpc_util::retry::{retry_call, status_code_is_retryable};
 use grpc_util::{layered_service, status_to_str, LayeredService};
 use hashing::{Digest, Fingerprint};
 use log::{debug, trace, warn, Level};
@@ -1375,7 +1375,7 @@ pub async fn check_action_cache(
           let request = apply_headers(Request::new(request), &context.build_id);
           async move { client.get_action_result(request).await }
         },
-        status_is_retryable,
+        |s| status_code_is_retryable(s.code()),
       )
       .await;
 

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -11,7 +11,7 @@ use bazel_protos::require_digest;
 use fs::RelativePath;
 use futures::future::BoxFuture;
 use futures::FutureExt;
-use grpc_util::retry::status_is_retryable;
+use grpc_util::retry::status_code_is_retryable;
 use grpc_util::{
   headers_to_http_header_map, layered_service, retry::retry_call, status_to_str, LayeredService,
 };
@@ -489,7 +489,7 @@ impl CommandRunner {
             .await
         }
       },
-      status_is_retryable,
+      |s| status_code_is_retryable(s.code()),
     )
     .await
     .map_err(status_to_str)?;


### PR DESCRIPTION
Use `tower::retry::Retry` for retries instead of `retry_call`.

WIP: The types for `tower::retry::Retry` are complex and I'm going to need to get some advice.

[ci skip-build-wheels]