### PR TITLE
[internal] Sort input requirements for `LockfileMetadata`

### DIFF
--- a/3rdparty/python/lockfiles/flake8.txt
+++ b/3rdparty/python/lockfiles/flake8.txt
@@ -4,7 +4,7 @@
 #
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {
-#   "requirements_invalidation_digest": "a6b4aeeac96728225dd3399bff5eb72a582aaa53cea7b63505fcb3cecdef5723",
+#   "requirements_invalidation_digest": "ad03d1f7b433f6ad42c1316c2df03efa0bfbfbc80f2152bf94eebe9c0355bf67",
 #   "valid_for_interpreter_constraints": [
 #     "CPython<3.10,>=3.7"
 #   ]

--- a/3rdparty/python/lockfiles/pytest.txt
+++ b/3rdparty/python/lockfiles/pytest.txt
@@ -4,7 +4,7 @@
 #
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {
-#   "requirements_invalidation_digest": "0768084ec1d13f0a8c5514291b5cffd79d8304332aa2c895369f858e3839330b",
+#   "requirements_invalidation_digest": "ac422863a6eb2322780151c7c332330b8b6c32c2ac4586b1cf6b67081c27826e",
 #   "valid_for_interpreter_constraints": [
 #     "CPython<3.10,>=3.7"
 #   ]

--- a/src/python/pants/backend/experimental/python/lockfile_metadata.py
+++ b/src/python/pants/backend/experimental/python/lockfile_metadata.py
@@ -113,7 +113,7 @@ def calculate_invalidation_digest(requirements: Iterable[str]) -> str:
     """Returns an invalidation digest for the given requirements."""
     m = hashlib.sha256()
     inputs = {
-        "requirements": list(requirements),
+        "requirements": sorted(requirements),
     }
     m.update(json.dumps(inputs).encode("utf-8"))
     return m.hexdigest()

--- a/src/python/pants/backend/experimental/python/lockfile_metadata.py
+++ b/src/python/pants/backend/experimental/python/lockfile_metadata.py
@@ -114,6 +114,8 @@ def calculate_invalidation_digest(requirements: Iterable[str]) -> str:
     """Returns an invalidation digest for the given requirements."""
     m = hashlib.sha256()
     inputs = {
+        # `FrozenOrderedSet` deduplicates while keeping ordering, which speeds up the sorting if
+        # the input was already sorted.
         "requirements": sorted(FrozenOrderedSet(requirements)),
     }
     m.update(json.dumps(inputs).encode("utf-8"))

--- a/src/python/pants/backend/experimental/python/lockfile_metadata.py
+++ b/src/python/pants/backend/experimental/python/lockfile_metadata.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Iterable, TypeVar
 
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
+from pants.util.ordered_set import FrozenOrderedSet
 
 BEGIN_LOCKFILE_HEADER = b"# --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---"
 END_LOCKFILE_HEADER = b"# --- END PANTS LOCKFILE METADATA ---"
@@ -113,7 +114,7 @@ def calculate_invalidation_digest(requirements: Iterable[str]) -> str:
     """Returns an invalidation digest for the given requirements."""
     m = hashlib.sha256()
     inputs = {
-        "requirements": sorted(requirements),
+        "requirements": sorted(FrozenOrderedSet(requirements)),
     }
     m.update(json.dumps(inputs).encode("utf-8"))
     return m.hexdigest()

--- a/src/python/pants/backend/experimental/python/lockfile_metadata_test.py
+++ b/src/python/pants/backend/experimental/python/lockfile_metadata_test.py
@@ -55,14 +55,14 @@ dave==3.1.4 \\
     assert line_by_line(result) == line_by_line(expected)
 
 
-_requirements = ["flake8-pantsbuild>=2.0,<3", "flake8-2020>=1.6.0,<1.7.0"]
-
-
 @pytest.mark.parametrize(
     "requirements,expected",
     [
         ([], "c8e8d0a6d6ec36bee3942091046d81d86e3b83b143b37a7cc714e2d022bf4f85"),
-        (_requirements, "66327c52225d2f798ffad7f092bf1b51da8a66777f3ebf654e2444d7eb1429f4"),
+        (
+            ["flake8-pantsbuild>=2.0,<3", "flake8-2020>=1.6.0,<1.7.0"],
+            "ef417e5ccadca6983fc8ec7df2c8c3e218af029a61752d38bd01926b2adb85b9",
+        ),
     ],
 )
 def test_invalidation_digest(requirements, expected) -> None:

--- a/src/python/pants/backend/experimental/python/lockfile_metadata_test.py
+++ b/src/python/pants/backend/experimental/python/lockfile_metadata_test.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import itertools
+from typing import Iterable
 
 import pytest
 
@@ -71,15 +72,15 @@ def test_invalidation_digest(requirements, expected) -> None:
     b = "flake8-2020>=1.6.0,<1.7.0"
     c = "flake8"
 
-    def assert_eq(left: list[str], right: list[str]) -> None:
+    def assert_eq(left: Iterable[str], right: Iterable[str]) -> None:
         assert calculate_invalidation_digest(left) == calculate_invalidation_digest(right)
 
-    def assert_neq(left: list[str], right: list[str]) -> None:
+    def assert_neq(left: Iterable[str], right: Iterable[str]) -> None:
         assert calculate_invalidation_digest(left) != calculate_invalidation_digest(right)
 
     for reqs in itertools.permutations([a, b, c]):
-        assert_eq(list(reqs), [a, b, c])
-        assert_neq(list(reqs), [a, b])
+        assert_eq(reqs, [a, b, c])
+        assert_neq(reqs, [a, b])
 
     assert_eq([], [])
     assert_neq([], [a])

--- a/src/python/pants/backend/experimental/python/lockfile_metadata_test.py
+++ b/src/python/pants/backend/experimental/python/lockfile_metadata_test.py
@@ -57,17 +57,7 @@ dave==3.1.4 \\
     assert line_by_line(result) == line_by_line(expected)
 
 
-@pytest.mark.parametrize(
-    "requirements,expected",
-    [
-        ([], "c8e8d0a6d6ec36bee3942091046d81d86e3b83b143b37a7cc714e2d022bf4f85"),
-        (
-            ["flake8-pantsbuild>=2.0,<3", "flake8-2020>=1.6.0,<1.7.0"],
-            "ef417e5ccadca6983fc8ec7df2c8c3e218af029a61752d38bd01926b2adb85b9",
-        ),
-    ],
-)
-def test_invalidation_digest(requirements, expected) -> None:
+def test_invalidation_digest() -> None:
     a = "flake8-pantsbuild>=2.0,<3"
     b = "flake8-2020>=1.6.0,<1.7.0"
     c = "flake8"

--- a/src/python/pants/backend/python/lint/bandit/lockfile.txt
+++ b/src/python/pants/backend/python/lint/bandit/lockfile.txt
@@ -4,7 +4,7 @@
 #
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {
-#   "requirements_invalidation_digest": "cbf22af846824c323ff23c432aee4f9bfc2fe69f5ea15ad234a1c689b24564e9",
+#   "requirements_invalidation_digest": "e70d1fe5ade6ee86ce308b1c69c525afc096c595a846c93577a177167ecce143",
 #   "valid_for_interpreter_constraints": [
 #     "CPython>=3.6"
 #   ]

--- a/src/python/pants/backend/python/lint/flake8/lockfile.txt
+++ b/src/python/pants/backend/python/lint/flake8/lockfile.txt
@@ -4,7 +4,7 @@
 #
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {
-#   "requirements_invalidation_digest": "b816a2c6e614808cbef00e8fab0cbb9dd453352f549663e3721f78a5a2caa6b6",
+#   "requirements_invalidation_digest": "18c098b561bb0965db821536ff62783bd170877ae0c1be2aaa53fa8fc927312a",
 #   "valid_for_interpreter_constraints": [
 #     "CPython>=3.6"
 #   ]

--- a/src/python/pants/backend/python/lint/yapf/lockfile.txt
+++ b/src/python/pants/backend/python/lint/yapf/lockfile.txt
@@ -4,7 +4,7 @@
 #
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {
-#   "requirements_invalidation_digest": "c9ac324ac99361e93a096930b044d0b30e906833d1c7bba7f7af8e4e36621fb8",
+#   "requirements_invalidation_digest": "badbe5481abf6b0c7b8ea24f984e0be948dfa2ecf37a18a0d348c1fb8f548168",
 #   "valid_for_interpreter_constraints": [
 #     "CPython>=3.6"
 #   ]

--- a/src/python/pants/backend/python/subsystems/pytest_lockfile.txt
+++ b/src/python/pants/backend/python/subsystems/pytest_lockfile.txt
@@ -4,7 +4,7 @@
 #
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {
-#   "requirements_invalidation_digest": "ad3adc471b0475db2819c75b2efb3bcfd1e79f33237295f27ff45158c381b6fd",
+#   "requirements_invalidation_digest": "2de88e998b660ebb313faa82bca2667ed50b2777adb6b741f25c8586ff3f067d",
 #   "valid_for_interpreter_constraints": [
 #     "CPython>=3.6"
 #   ]


### PR DESCRIPTION
This ensures that callers can't mess up the determinism of the lockfile's invalidation digest. It will also make https://github.com/pantsbuild/pants/issues/12610 more presentable for users, when we store the requirement strings in the lockfile rather than just a hash.

[ci skip-rust]
[ci skip-build-wheels]