### PR TITLE
Issue forms/templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Help us make Pants better
+about: Help us find and fix bugs
 title: ''
 labels: bug
 assignees: ''
@@ -17,4 +17,4 @@ Which version of Pants are you using?
 Are you encountering the bug on MacOS, Linux, or both?
 
 **Additional info**
-Add any other information about the problem here, including attachments or links to gists.
+Add any other information about the problem here, such as attachments or links to gists, if relevant.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,20 @@
+---
+name: Bug report
+about: Help us make Pants better
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of the bug.
+
+**Pants version**
+Which version of Pants are you using?
+
+**OS**
+Are you encountering the bug on MacOS, Linux, or both?
+
+**Additional info**
+Add any other information about the problem here, including attachments or links to gists.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: The Pants Documentation Site
+    url: https://www.pantsbuild.org/
+    about: You can find a lot of useful information here.
+  - name: The Pants Community Chat
+    url: https://join.slack.com/t/pantsbuild/shared_invite/zt-d0uh0mok-RLvVosDiX6JDpvStH~bFBA
+    about: We're a friendly community, and happy to answer questions!

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest ways to improve Pants
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. E.g., I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. E.g., I'm always frustrated when [...]
+A clear and concise description of what the problem is. E.g., It would be easier if [...]
 
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.

--- a/.github/ISSUE_TEMPLATE/user_registration.yml
+++ b/.github/ISSUE_TEMPLATE/user_registration.yml
@@ -1,0 +1,54 @@
+name: User Registration
+description: Add a company or organization to the public list of Pants Users
+title: "Please add XXXXXX to the public list of Pants Users"
+labels: [user-registration]
+assignees:
+  - benjyw
+  - cczona
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping grow the Pants community by being featured on the public list of Pants Users!
+  - type: input
+    id: name
+    attributes:
+      label: "Company name"
+      description: The name of your company/organization.
+      placeholder: e.g., Acme
+    validations:
+      required: true
+  - type: input
+    id: website
+    attributes:
+      label: "Company website"
+      description: Your company's main website
+      placeholder: e.g., https://www.acme.com
+    validations:
+      required: true
+  - type: input
+    id: email
+    attributes:
+      label: Contact email
+      description: |
+        How can we contact you if we have questions about this form? We won't use your email
+        address for any other purpose.
+      placeholder: e.g., wilecoyote@acme.com
+    validations:
+      required: true
+  - type: textarea
+    id: logo
+    attributes:
+      label: Company logo
+      description: |
+        We'd love to use your company's logo on the Users Page!
+
+        Please ensure that you have the right to grant us permission to use your logo in
+        this manner before adding it.
+
+        If you're unsure, please submit this page without the logo, and revisit it later, when
+        permission has been established. The other information is still very helpful!
+      placeholder: Drag and drop a .jpg or .png image of your company logo into this box .
+      value:
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/user_registration.yml
+++ b/.github/ISSUE_TEMPLATE/user_registration.yml
@@ -1,4 +1,4 @@
-name: "Support Pants - List My Company on pantsbuild.org"
+name: "Support Pants - list my company on pantsbuild.org"
 description: Add a company or organization to the public list of Pants Users
 title: "Please add XXXXXX to the public list of Pants Users"
 labels: [user-registration]
@@ -26,16 +26,6 @@ body:
       placeholder: e.g., https://www.acme.com
     validations:
       required: true
-  - type: input
-    id: email
-    attributes:
-      label: Contact email
-      description: |
-        How can we contact you if we have questions about this form? We *won't* publish your
-        email address on the Pants Users list, or use it for any other purpose.
-      placeholder: e.g., wilecoyote@acme.com
-    validations:
-      required: true
   - type: textarea
     id: logo
     attributes:
@@ -43,12 +33,17 @@ body:
       description: |
         We'd love to use your company's logo on the Users Page!
 
-        Please ensure that you have the right to grant us permission to use your logo in
+        Please ensure that you have the right to grant us permission to use the logo in
         this manner before adding it.
 
-        If you're unsure, please submit this page without the logo, and revisit it later, when
-        permission has been established. The other information is still very helpful!
-      placeholder: Drag and drop a .jpg or .png image of your company logo into this box .
+        If you're unsure, please submit this page without the logo, and we can revisit it later,
+        if/when permission has been established. The other information is still very helpful!
+      placeholder: Drag and drop a .jpg or .png image of your company logo into this box.
       value:
     validations:
       required: false
+  - type: markdown
+    attributes:
+      value: |
+        After creating the issue, please email verify@pantsbuild.org from your company
+        email address with a link to the newly-created issue. That's it, and thanks again!

--- a/.github/ISSUE_TEMPLATE/user_registration.yml
+++ b/.github/ISSUE_TEMPLATE/user_registration.yml
@@ -1,4 +1,4 @@
-name: User Registration
+name: "Support Pants - List My Company on pantsbuild.org"
 description: Add a company or organization to the public list of Pants Users
 title: "Please add XXXXXX to the public list of Pants Users"
 labels: [user-registration]
@@ -31,8 +31,8 @@ body:
     attributes:
       label: Contact email
       description: |
-        How can we contact you if we have questions about this form? We won't use your email
-        address for any other purpose.
+        How can we contact you if we have questions about this form? We *won't* publish your
+        email address on the Pants Users list, or use it for any other purpose.
       placeholder: e.g., wilecoyote@acme.com
     validations:
       required: true


### PR DESCRIPTION
For:

  - Bug reports
  - Feature requests
  - Adding a company to a public list of users

The driving goal was the user registration template, but it made it a bit weird, when opening a new issue, to have a template for that and not for bugs and feature requests. The user would have to click on a small "open a blank issue" link to actually file a normal issue. So this change also includes the bug and feature templates. Those are purposely simple though, and based on GitHub's suggested templates. No need to make bug/feature reporters jump through form hoops.

[ci skip-rust]

[ci skip-build-wheels]