### PR TITLE
Update the error/warning messages for stale/invalid lockfiles

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -547,7 +547,7 @@ def test_error_on_invalid_lockfile_with_path(rule_runner: RuleRunner) -> None:
 
 def test_warn_on_invalid_lockfile_with_path(rule_runner: RuleRunner, caplog) -> None:
     _run_pex_for_lockfile_test(rule_runner, True, actual="1bad", expected="900d", behavior="warn")
-    assert "Invalid lockfile provided." in caplog.text
+    assert "Invalid lockfile provided" in caplog.text
 
 
 def test_ignore_on_invalid_lockfile_with_path(rule_runner: RuleRunner, caplog) -> None:
@@ -569,7 +569,7 @@ def test_error_on_invalid_lockfile_with_content(rule_runner: RuleRunner) -> None
 
 def test_warn_on_invalid_lockfile_with_content(rule_runner: RuleRunner, caplog) -> None:
     _run_pex_for_lockfile_test(rule_runner, False, actual="1bad", expected="900d", behavior="warn")
-    assert "Invalid lockfile provided." in caplog.text
+    assert "Invalid lockfile provided" in caplog.text
 
 
 def test_no_warning_on_valid_lockfile_with_content(rule_runner: RuleRunner, caplog) -> None:


### PR DESCRIPTION
Refactors the `build_pex` rule to only have the code for erroring/warning on invalid lockfiles in the one place, and updates the corresponding exception and log messages.

I'm not 100% sold on the contents of the log message, but I'm happy enough for now. Here's a sample warning:

> ```13:09:40.67 [WARN] Invalid lockfile for PEX request `black.pex`.  If your requirements or interpreter constraints have changed, follow the instructions in the header of the lockfile to regenerate it. Otherwise, ensure your interpreter constraints are compatible with the constraints specified in the lockfile.```

Closes #12541

# Rust tests and lints will be skipped. Delete if not intended.
[ci skip-rust]

# Building wheels and fs_util will be skipped. Delete if not intended.
[ci skip-build-wheels]