### PR TITLE
[go] use generated go.mod for external modules without a go.mod

### DIFF
--- a/src/python/pants/backend/go/module.py
+++ b/src/python/pants/backend/go/module.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 import json
 import logging
+import os
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
@@ -15,9 +16,12 @@ from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Addresses
 from pants.engine.fs import (
     EMPTY_DIGEST,
+    CreateDigest,
     Digest,
     DigestContents,
     DigestSubset,
+    FileContent,
+    MergeDigests,
     PathGlobs,
     RemovePrefix,
     Snapshot,
@@ -256,15 +260,65 @@ async def download_external_module(
             PathGlobs(
                 [f"{source_path}/**"],
                 glob_match_error_behavior=GlobMatchErrorBehavior.error,
-                description_of_origin=f"the DownloadExternalModuleRequest for {request.path}@{request.version}{request.path}@{request.version}",
+                description_of_origin=f"the DownloadExternalModuleRequest for {request.path}@{request.version}",
             ),
         ),
     )
 
     source_digest_stripped = await Get(Digest, RemovePrefix(source_digest, source_path))
 
+    source_snapshot = await Get(Snapshot, Digest, source_digest_stripped)
+    if "go.mod" not in source_snapshot.files:
+        # There was no go.mod in the downloaded source. Use the generated go.mod from the go tooling which
+        # was returned in the module metadata.
+        go_mod_absoloute_path = metadata.get("GoMod")
+        if not go_mod_absoloute_path:
+            raise ValueError(
+                f"No go.mod was provided in download of Go external module {request.path}@{request.version}, "
+                "and the module metadata did not identify a generated go.mod file to use instead."
+            )
+        gopath_index = go_mod_absoloute_path.index("gopath/")
+        go_mod_path = go_mod_absoloute_path[gopath_index:]
+        go_mod_digest = await Get(
+            Digest,
+            DigestSubset(
+                result.output_digest,
+                PathGlobs(
+                    [f"{go_mod_path}"],
+                    glob_match_error_behavior=GlobMatchErrorBehavior.error,
+                    description_of_origin=f"the DownloadExternalModuleRequest for {request.path}@{request.version}",
+                ),
+            ),
+        )
+        go_mod_digest_stripped = await Get(
+            Digest, RemovePrefix(go_mod_digest, os.path.dirname(go_mod_path))
+        )
+
+        # There should now be one file in the digest. Create a diges where that file is named go.mod
+        # and then merge it into the sources.
+        contents = await Get(DigestContents, Digest, go_mod_digest_stripped)
+        assert len(contents) == 1
+        go_mod_only_digest = await Get(
+            Digest,
+            CreateDigest(
+                [
+                    FileContent(
+                        path="go.mod",
+                        content=contents[0].content,
+                        is_executable=False,
+                    )
+                ]
+            ),
+        )
+        source_digest_final = await Get(
+            Digest, MergeDigests([go_mod_only_digest, source_digest_stripped])
+        )
+    else:
+        # If the module download has a go.mod, then just use the sources as is.
+        source_digest_final = source_digest_stripped
+
     return DownloadedExternalModule(
-        path=request.path, version=request.version, digest=source_digest_stripped
+        path=request.path, version=request.version, digest=source_digest_final
     )
 
 

--- a/src/python/pants/backend/go/module_integration_test.py
+++ b/src/python/pants/backend/go/module_integration_test.py
@@ -87,3 +87,25 @@ def test_download_external_module(rule_runner: RuleRunner) -> None:
             found_uuid_go_file = True
             break
     assert found_uuid_go_file
+
+
+def test_download_external_module_with_no_gomod(rule_runner: RuleRunner) -> None:
+    downloaded_module = rule_runner.request(
+        DownloadedExternalModule,
+        [
+            DownloadExternalModuleRequest(
+                path="cloud.google.com/go",
+                version="v0.26.0",
+            )
+        ],
+    )
+    assert downloaded_module.path == "cloud.google.com/go"
+    assert downloaded_module.version == "v0.26.0"
+
+    digest_contents = rule_runner.request(DigestContents, [downloaded_module.digest])
+    found_go_mod = False
+    for file_content in digest_contents:
+        if file_content.path == "go.mod":
+            found_go_mod = True
+            break
+    assert found_go_mod


### PR DESCRIPTION
While trying to get a small Go project to use the Go plugin, I found that resolving metadata for external module `cloud.google.com/go` at version `v0.26.0` did not have a `go.mod` file. The go tooling created a basic go.mod in a different directory.

Work-around this case for now by merging the generated `go.mod` into the sources digest when no `go.mod` is found in the actual sources download.

[ci skip-rust]

[ci skip-build-wheels]