### PR TITLE
add __repr__ impl for PySnapshot

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -712,8 +712,10 @@ dependencies = [
 name = "engine_pyo3"
 version = "0.0.1"
 dependencies = [
+ "either",
  "fs",
  "hashing",
+ "itertools 0.10.1",
  "mock",
  "nailgun",
  "parking_lot",

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -665,6 +665,7 @@ dependencies = [
  "cpython",
  "crossbeam-channel 0.4.4",
  "double-checked-cell-async",
+ "either",
  "env_logger",
  "fnv",
  "fs",

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -111,6 +111,7 @@ concrete_time = { path = "concrete_time" }
 cpython = { git = "https://github.com/pantsbuild/rust-cpython", rev = "46d7eff26a705384e41eb6f7b870cd3f5f14b3bc" }
 crossbeam-channel = "0.4"
 double-checked-cell-async = "2.0"
+either = "1.6"
 fnv = "1.0.5"
 fs = { path = "fs" }
 futures = "0.3"

--- a/src/rust/engine/engine_pyo3/Cargo.toml
+++ b/src/rust/engine/engine_pyo3/Cargo.toml
@@ -18,8 +18,10 @@ extension-module = ["pyo3/extension-module"]
 default = []
 
 [dependencies]
+either = "1.6"
 fs = { path = "../fs" }
 hashing = { path = "../hashing" }
+itertools = "0.10"
 nailgun = { path = "../nailgun" }
 parking_lot = "0.11"
 pyo3 = "0.14.1"


### PR DESCRIPTION
Add a `__repr__` impl for `PySnapshot` that actually displays its fields. This will make it easier to dump a Snapshot to the log when debugging plugins. (Otherwise, callers have to manually log each of the fields individually.)

[ci skip-build-wheels]