### PR TITLE
Register subsystems and target types by backend/plugin.

### DIFF
--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, DefaultDict, Dict, Set, Type
+from typing import Any, DefaultDict, Dict, List, Set, Tuple, Type
 
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.goal import GoalSubsystem
@@ -18,6 +18,7 @@ from pants.engine.unions import UnionRule
 from pants.option.global_options import GlobalOptions
 from pants.option.scope import normalize_scope
 from pants.option.subsystem import Subsystem
+from pants.util.frozendict import FrozenDict
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 from pants.vcs.changed import Changed
 
@@ -30,7 +31,7 @@ _RESERVED_NAMES = {"global", "targets", "goals"}
 
 
 # Subsystems used outside of any rule.
-_GLOBAL_SUBSYSTEMS: FrozenOrderedSet[Type[Subsystem]] = FrozenOrderedSet({GlobalOptions, Changed})
+_GLOBAL_SUBSYSTEMS: Set[Type[Subsystem]] = {GlobalOptions, Changed}
 
 
 @dataclass(frozen=True)
@@ -38,16 +39,26 @@ class BuildConfiguration:
     """Stores the types and helper functions exposed to BUILD files."""
 
     registered_aliases: BuildFileAliases
-    subsystems: FrozenOrderedSet[Type[Subsystem]]
+    subsystem_to_providers: FrozenDict[Type[Subsystem], Tuple[str, ...]]
+    target_type_to_providers: FrozenDict[Type[Target], Tuple[str, ...]]
     rules: FrozenOrderedSet[Rule]
     union_rules: FrozenOrderedSet[UnionRule]
-    target_types: FrozenOrderedSet[Type[Target]]
     allow_unknown_options: bool
 
     @property
-    def all_subsystems(self) -> FrozenOrderedSet[Type[Subsystem]]:
+    def all_subsystems(self) -> Tuple[Type[Subsystem], ...]:
         """Return all subsystems in the system: global and those registered via rule usage."""
-        return _GLOBAL_SUBSYSTEMS | self.subsystems
+        # Sort by options_scope, for consistency.
+        return tuple(
+            sorted(
+                _GLOBAL_SUBSYSTEMS | self.subsystem_to_providers.keys(),
+                key=lambda x: x.options_scope,
+            )
+        )
+
+    @property
+    def target_types(self) -> Tuple[Type[Target], ...]:
+        return tuple(sorted(self.target_type_to_providers.keys(), key=lambda x: x.alias))
 
     def __post_init__(self) -> None:
         class Category(Enum):
@@ -89,10 +100,14 @@ class BuildConfiguration:
     class Builder:
         _exposed_object_by_alias: Dict[Any, Any] = field(default_factory=dict)
         _exposed_context_aware_object_factory_by_alias: Dict[Any, Any] = field(default_factory=dict)
-        _subsystems: OrderedSet = field(default_factory=OrderedSet)
+        _subsystem_to_providers: Dict[Type[Subsystem], List[str]] = field(
+            default_factory=lambda: defaultdict(list)
+        )
+        _target_type_to_providers: Dict[Type[Target], List[str]] = field(
+            default_factory=lambda: defaultdict(list)
+        )
         _rules: OrderedSet = field(default_factory=OrderedSet)
         _union_rules: OrderedSet = field(default_factory=OrderedSet)
-        _target_types: OrderedSet[Type[Target]] = field(default_factory=OrderedSet)
         _allow_unknown_options: bool = False
 
         def registered_aliases(self) -> BuildFileAliases:
@@ -150,7 +165,9 @@ class BuildConfiguration:
                 alias
             ] = context_aware_object_factory
 
-        def register_subsystems(self, subsystems: Iterable[Type[Subsystem]]):
+        def register_subsystems(
+            self, plugin_or_backend: str, subsystems: Iterable[Type[Subsystem]]
+        ):
             """Registers the given subsystem types."""
             if not isinstance(subsystems, Iterable):
                 raise TypeError("The subsystems must be an iterable, given {}".format(subsystems))
@@ -167,15 +184,11 @@ class BuildConfiguration:
                     "subclasses:\n\t{}".format("\n\t".join(str(i) for i in invalid_subsystems))
                 )
 
-            self._subsystems.update(subsystems)
+            for subsystem in subsystems:
+                self._subsystem_to_providers[subsystem].append(plugin_or_backend)
 
-        def register_rules(self, rules):
-            """Registers the given rules.
-
-            param rules: The rules to register.
-            :type rules: :class:`collections.Iterable` containing
-                         :class:`pants.engine.rules.Rule` instances.
-            """
+        def register_rules(self, plugin_or_backend: str, rules: Iterable[Rule | UnionRule]):
+            """Registers the given rules."""
             if not isinstance(rules, Iterable):
                 raise TypeError("The rules must be an iterable, given {!r}".format(rules))
 
@@ -185,14 +198,21 @@ class BuildConfiguration:
             self._rules.update(rule_index.queries)
             self._union_rules.update(rule_index.union_rules)
             self.register_subsystems(
-                rule.output_type for rule in self._rules if issubclass(rule.output_type, Subsystem)
+                plugin_or_backend,
+                (
+                    rule.output_type
+                    for rule in self._rules
+                    if issubclass(rule.output_type, Subsystem)
+                ),
             )
 
         # NB: We expect the parameter to be Iterable[Type[Target]], but we can't be confident in
         # this because we pass whatever people put in their `register.py`s to this function;
         # I.e., this is an impure function that reads from the outside world. So, we use the type
         # hint `Any` and perform runtime type checking.
-        def register_target_types(self, target_types: Iterable[Type[Target]] | Any) -> None:
+        def register_target_types(
+            self, plugin_or_backend: str, target_types: Iterable[Type[Target]] | Any
+        ) -> None:
             """Registers the given target types."""
             if not isinstance(target_types, Iterable):
                 raise TypeError(
@@ -209,7 +229,8 @@ class BuildConfiguration:
                     "Every element of the entrypoint `target_types` must be a subclass of "
                     f"{Target.__name__}. Bad elements: {bad_elements}."
                 )
-            self._target_types.update(target_types)
+            for target_type in target_types:
+                self._target_type_to_providers[target_type].append(plugin_or_backend)
 
         def allow_unknown_options(self, allow: bool = True) -> None:
             """Allows overriding whether Options parsing will fail for unrecognized Options.
@@ -226,9 +247,13 @@ class BuildConfiguration:
             )
             return BuildConfiguration(
                 registered_aliases=registered_aliases,
-                subsystems=FrozenOrderedSet(self._subsystems),
+                subsystem_to_providers=FrozenDict(
+                    (k, tuple(v)) for k, v in self._subsystem_to_providers.items()
+                ),
+                target_type_to_providers=FrozenDict(
+                    (k, tuple(v)) for k, v in self._target_type_to_providers.items()
+                ),
                 rules=FrozenOrderedSet(self._rules),
                 union_rules=FrozenOrderedSet(self._union_rules),
-                target_types=FrozenOrderedSet(self._target_types),
                 allow_unknown_options=self._allow_unknown_options,
             )

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -459,7 +459,7 @@ class RuleIndex:
     union_rules: FrozenOrderedSet[UnionRule]
 
     @classmethod
-    def create(cls, rule_entries: Iterable[Rule]) -> RuleIndex:
+    def create(cls, rule_entries: Iterable[Rule | UnionRule]) -> RuleIndex:
         """Creates a RuleIndex with tasks indexed by their output type."""
         rules: OrderedSet[TaskRule] = OrderedSet()
         queries: OrderedSet[QueryRule] = OrderedSet()

--- a/src/python/pants/init/extension_loader.py
+++ b/src/python/pants/init/extension_loader.py
@@ -89,13 +89,13 @@ def load_plugins(
                     raise PluginLoadOrderError(f"Plugin {plugin} must be loaded after {dep}")
         if "target_types" in entries:
             target_types = entries["target_types"].load()()
-            build_configuration.register_target_types(target_types)
+            build_configuration.register_target_types(req.key, target_types)
         if "build_file_aliases" in entries:
             aliases = entries["build_file_aliases"].load()()
             build_configuration.register_aliases(aliases)
         if "rules" in entries:
             rules = entries["rules"].load()()
-            build_configuration.register_rules(rules)
+            build_configuration.register_rules(req.key, rules)
         loaded[dist.as_requirement().key] = dist
 
 
@@ -142,10 +142,10 @@ def load_backend(build_configuration: BuildConfiguration.Builder, backend_packag
 
     target_types = invoke_entrypoint("target_types")
     if target_types:
-        build_configuration.register_target_types(target_types)
+        build_configuration.register_target_types(backend_package, target_types)
     build_file_aliases = invoke_entrypoint("build_file_aliases")
     if build_file_aliases:
         build_configuration.register_aliases(build_file_aliases)
     rules = invoke_entrypoint("rules")
     if rules:
-        build_configuration.register_rules(rules)
+        build_configuration.register_rules(backend_package, rules)

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -67,7 +67,7 @@ def create_bootstrap_scheduler(
     # To load plugins, we only need access to the Python/PEX rules.
     load_build_configuration_from_source(bc_builder, ["pants.backend.python"])
     # And to plugin-loading-specific rules.
-    bc_builder.register_rules(plugin_resolver_rules())
+    bc_builder.register_rules("_dummy_for_bootstrapping_", plugin_resolver_rules())
     # We allow unrecognized options to defer any option error handling until post-bootstrap.
     bc_builder.allow_unknown_options()
     return BootstrapScheduler(

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -135,8 +135,8 @@ class RuleRunner:
                 objects=objects, context_aware_object_factories=context_aware_object_factories
             )
         )
-        build_config_builder.register_rules(all_rules)
-        build_config_builder.register_target_types(target_types or ())
+        build_config_builder.register_rules("_dummy_for_test_", all_rules)
+        build_config_builder.register_target_types("_dummy_for_test_", target_types or ())
         self.build_config = build_config_builder.create()
 
         self.environment = CompleteEnvironment({})
@@ -195,7 +195,7 @@ class RuleRunner:
         return FrozenOrderedSet([*self.build_config.rules, *self.build_config.union_rules])
 
     @property
-    def target_types(self) -> FrozenOrderedSet[Type[Target]]:
+    def target_types(self) -> Tuple[Type[Target], ...]:
         return self.build_config.target_types
 
     @property

--- a/tests/python/pants_test/init/test_extension_loader.py
+++ b/tests/python/pants_test/init/test_extension_loader.py
@@ -31,6 +31,7 @@ from pants.init.extension_loader import (
     load_plugins,
 )
 from pants.option.subsystem import Subsystem
+from pants.util.frozendict import FrozenDict
 from pants.util.ordered_set import FrozenOrderedSet
 
 
@@ -138,7 +139,7 @@ class LoaderTest(unittest.TestCase):
         registered_aliases = build_configuration.registered_aliases
         self.assertEqual(0, len(registered_aliases.objects))
         self.assertEqual(0, len(registered_aliases.context_aware_object_factories))
-        self.assertEqual(build_configuration.subsystems, FrozenOrderedSet())
+        self.assertEqual(build_configuration.subsystem_to_providers, FrozenDict())
         self.assertEqual(0, len(build_configuration.rules))
         self.assertEqual(0, len(build_configuration.target_types))
 

--- a/tests/python/pants_test/init/test_extension_loader.py
+++ b/tests/python/pants_test/init/test_extension_loader.py
@@ -302,9 +302,7 @@ class LoaderTest(unittest.TestCase):
 
         with self.create_register(target_types=target_types) as backend_package:
             load_backend(self.bc_builder, backend_package)
-            assert self.bc_builder.create().target_types == FrozenOrderedSet(
-                [DummyTarget, DummyTarget2]
-            )
+            assert self.bc_builder.create().target_types == (DummyTarget, DummyTarget2)
 
         class PluginTarget(Target):
             alias = "plugin_tgt"
@@ -317,9 +315,7 @@ class LoaderTest(unittest.TestCase):
             self.get_mock_plugin("new-targets", "0.0.1", target_types=plugin_targets)
         )
         self.load_plugins(["new-targets"])
-        assert self.bc_builder.create().target_types == FrozenOrderedSet(
-            [DummyTarget, DummyTarget2, PluginTarget]
-        )
+        assert self.bc_builder.create().target_types == (DummyTarget, DummyTarget2, PluginTarget)
 
     def test_backend_plugin_ordering(self):
         def reg_alias():


### PR DESCRIPTION
We store, on BuildConfiguration, a map from each subsystem/
target type to the list of backends/plugins that can provide it.

A future change can use this to add this information to
help pages.

[ci skip-rust]

[ci skip-build-wheels]