### PR TITLE
Remove the `rationale` field from BashBinaryRequest.

### DIFF
--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -477,7 +477,6 @@ class BashBinary(BinaryPath):
 
 @dataclass(frozen=True)
 class BashBinaryRequest:
-    rationale: str
     search_path: SearchPath = BashBinary.DEFAULT_SEARCH_PATH
 
 
@@ -491,14 +490,14 @@ async def find_bash(bash_request: BashBinaryRequest) -> BashBinary:
     paths = await Get(BinaryPaths, BinaryPathRequest, request)
     first_path = paths.first_path
     if not first_path:
-        raise BinaryNotFoundError(request, rationale=bash_request.rationale)
+        raise BinaryNotFoundError(request)
     return BashBinary(first_path.path, first_path.fingerprint)
 
 
 @rule
 async def get_bash() -> BashBinary:
     # Expose bash to external consumers.
-    return await Get(BashBinary, BashBinaryRequest(rationale="execute bash scripts"))
+    return await Get(BashBinary, BashBinaryRequest())
 
 
 @rule
@@ -511,9 +510,7 @@ async def find_binary(request: BinaryPathRequest) -> BinaryPaths:
     if request.binary_name == "bash":
         shebang = "#!/usr/bin/env bash"
     else:
-        bash = await Get(
-            BashBinary, BashBinaryRequest(rationale="use it to locate other executables")
-        )
+        bash = await Get(BashBinary, BashBinaryRequest())
         shebang = f"#!{bash.path}"
 
     # Note: the backslash after the """ marker ensures that the shebang is at the start of the


### PR DESCRIPTION
It exists only to provide slightly more context for an error
message. But this context isn't actionable (the rationale doesn't
affect how you fix the error). And the downside is that the
rationale affects the cache key, so we have to re-find bash
for every rationale, which is superfluous extra work.

Right now there are only two rationales, so the work is only
done twice instead of once (and the underlying process is still cached
so the extra work is just in-process). But this field models "bad behavior": 
If in the future someone, naively, makes the rationale a dynamic
message, here or in some similar case that they cargo-culted from here, 
then the rule will thrash. Better to remove this landmine preemptively.

[ci skip-rust]

[ci skip-build-wheels]