### PR TITLE
Fix `FindBinary` when `which` is discoverable on `$PATH` on macOS (Cherry-pick of #12581)

### DIFF
--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -516,14 +516,26 @@ async def find_binary(request: BinaryPathRequest) -> BinaryPaths:
         )
         shebang = f"#!{bash.path}"
 
-    # Note: the backslash after the """ marker ensures that the shebang is at the start of the
-    # script file. Many OSs will not see the shebang if there is intervening whitespace.
+    # Some subtle notes with this script:
+    #
+    #  - The backslash after the `"""` ensures that the shebang is at the start of the script file.
+    #       Many OSs will not see the shebang if there is intervening whitespace.
+    #  - We run the script with `ProcessResult` instead of `FallibleProcessResult` so that we
+    #      can catch bugs in the script itself, given an earlier silent failure.
+    #  - We do not use `set -e` like normal because it causes the line
+    #      `command which -a <bin> || true` to fail the script when using Bash 3, which macOS
+    #      uses by default.
+    #  - We set `ProcessCacheScope.PER_RESTART_SUCCESSFUL` to force re-run since any binary found
+    #      on the host system today could be gone tomorrow. Ideally we'd only do this for local
+    #      processes since all known remoting configurations include a static container image as
+    #      part of their cache key which automatically avoids this problem. See #10769 for a
+    #      solution that is less of a tradeoff.
     script_path = "./find_binary.sh"
     script_content = dedent(
         f"""\
         {shebang}
 
-        set -euox pipefail
+        set -uox pipefail
 
         if command -v which > /dev/null; then
             command which -a $1 || true
@@ -540,10 +552,6 @@ async def find_binary(request: BinaryPathRequest) -> BinaryPaths:
     search_path = create_path_env_var(request.search_path)
     result = await Get(
         ProcessResult,
-        # We use a volatile process to force re-run since any binary found on the host system today
-        # could be gone tomorrow. Ideally we'd only do this for local processes since all known
-        # remoting configurations include a static container image as part of their cache key which
-        # automatically avoids this problem. See #10769 for a solution that is less of a tradeoff.
         Process(
             description=f"Searching for `{request.binary_name}` on PATH={search_path}",
             level=LogLevel.DEBUG,

--- a/src/python/pants/engine/process_test.py
+++ b/src/python/pants/engine/process_test.py
@@ -1,7 +1,10 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import os
+import shutil
 
 import pytest
 
@@ -240,11 +243,20 @@ def test_interactive_process_cannot_have_input_files_and_workspace() -> None:
         InteractiveProcess(argv=["/bin/echo"], input_digest=mock_digest, run_in_workspace=True)
 
 
-def test_find_binary_non_existent(rule_runner: RuleRunner) -> None:
+def which_binary_path() -> str:
+    path = shutil.which("which")
+    if not path:
+        raise EnvironmentError("`which` not discoverable on your $PATH.")
+    return path
+
+
+@pytest.mark.parametrize("which_path", (None, which_binary_path()))
+def test_find_binary_non_existent(rule_runner: RuleRunner, which_path: str | None) -> None:
     with temporary_dir() as tmpdir:
-        search_path = [tmpdir]
+        if which_path:
+            os.symlink(which_path, os.path.join(tmpdir, "which"))
         binary_paths = rule_runner.request(
-            BinaryPaths, [BinaryPathRequest(binary_name="anybin", search_path=search_path)]
+            BinaryPaths, [BinaryPathRequest(binary_name="nonexistent-bin", search_path=[tmpdir])]
         )
         assert binary_paths.first_path is None
 


### PR DESCRIPTION
A user discovered that their dev was getting this because `python2` is not on their `$PATH`:

```
Traceback (most recent call last):
  File "/Users/ericarellano/code/pants/src/python/pants/engine/process.py", line 258, in fallible_to_exec_result_or_raise
    raise ProcessExecutionFailure(
pants.engine.process.ProcessExecutionFailure: Process 'Searching for `python2` ...

stderr:
+ command -v which
+ command which -a python2
+ which -a python1
```

The issue is because we were setting `-e` in the script, so `which -a python2` was failing *due to macOS using a very old version of bash that does not behave how we expected. It was early exiting, rather than using `|| true`.

Our test did not catch this because it only tested the case where `which` is not discoverable.

[ci skip-rust]
[ci skip-build-wheels]