### PR TITLE
[internal] add links to changelog and twitter in pants pypi project page

### DIFF
--- a/pants-plugins/internal_plugins/releases/register.py
+++ b/pants-plugins/internal_plugins/releases/register.py
@@ -120,6 +120,8 @@ async def pants_setup_kwargs(
             "Documentation": "https://www.pantsbuild.org/",
             "Source": "https://github.com/pantsbuild/pants",
             "Tracker": "https://github.com/pantsbuild/pants/issues",
+            "Changelog": "https://www.pantsbuild.org/docs/changelog",
+            "Twitter": "https://twitter.com/pantsbuild",
         },
         license="Apache License, Version 2.0",
         zip_safe=True,


### PR DESCRIPTION
those links makes the project page more useful and both are supported by pypi and used by other projects.
https://pypi.org/project/pytest/
<img width="702" alt="Screen Shot 2021-08-24 at 8 53 06 AM" src="https://user-images.githubusercontent.com/1268088/130649144-56adf0f6-b833-406e-b0ed-722a28c253a9.png">
