### PR TITLE
Stop using `[python-setup].requirements_constraints` when installing tools like Black and MyPy

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -174,7 +174,7 @@ class PexRequest(EngineAwareParameter):
         repository_pex: Pex | None = None,
         additional_args: Iterable[str] = (),
         pex_path: Iterable[Pex] = (),
-        apply_requirement_constraints: bool = True,
+        apply_requirement_constraints: bool = False,
         description: str | None = None,
     ) -> None:
         """A request to create a PEX from its inputs.

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -273,6 +273,7 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
         repository_pex=repository_pex,
         additional_args=request.additional_args,
         description=description,
+        apply_requirement_constraints=True,
     )
 
 
@@ -350,6 +351,7 @@ async def _setup_constraints_repository_pex(
             interpreter_constraints=request.interpreter_constraints,
             platforms=request.platforms,
             additional_args=request.additional_args,
+            apply_requirement_constraints=True,
         ),
     )
     return _ConstraintsRepositoryPex(repository_pex)

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -105,6 +105,7 @@ def create_pex_and_get_all_data(
         sources=sources,
         additional_inputs=additional_inputs,
         additional_args=additional_pex_args,
+        apply_requirement_constraints=True,
     )
     rule_runner.set_options(
         ["--backend-packages=pants.backend.python", *additional_pants_args],

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -80,11 +80,15 @@ class PythonSetup(Subsystem):
             type=file_option,
             mutually_exclusive_group="lockfile",
             help=(
-                "When resolving third-party requirements, use this "
-                "constraints file to determine which versions to use.\n\nSee "
-                "https://pip.pypa.io/en/stable/user_guide/#constraints-files for more information "
-                "on the format of constraint files and how constraints are applied in Pex and pip."
-                "\n\nMutually exclusive with `--requirement-constraints-target`."
+                "When resolving third-party requirements for your own code (vs. tools you run), "
+                "use this constraints file to determine which versions to use.\n\n"
+                "This only applies when resolving user requirements, rather than tools you run "
+                "like Black and Pytest. To constrain tools, set `[tool].lockfile`, e.g. "
+                "`[black].lockfile`.\n\n"
+                "See https://pip.pypa.io/en/stable/user_guide/#constraints-files for more "
+                "information on the format of constraint files and how constraints are applied in "
+                "Pex and pip.\n\n"
+                "Mutually exclusive with `[python-setup].experimental_lockfile`."
             ),
         )
         register(
@@ -118,7 +122,8 @@ class PythonSetup(Subsystem):
                 "multiple lockfiles. This option's behavior may change without the normal "
                 "deprecation cycle.\n\n"
                 "To generate a lockfile, activate the backend `pants.backend.experimental.python`"
-                "and run `./pants lock ::`."
+                "and run `./pants lock ::`.\n\n"
+                "Mutually exclusive with `[python-setup].requirement_constraints`."
             ),
         )
         # TODO(#12293): It's plausible this option might not exist once we figure out the semantics


### PR DESCRIPTION
It was an oversight (by me!) that `--requirement-constraints` was being used for tool installations. You may want for `black` to use a different version of `ast` than your own code is using, for example. It was bad coupling, and not documented or transparent to the user.

Instead, we have the much better feature of tool lockfiles: https://github.com/pantsbuild/pants/issues/11898, which will soon be promoted to be stable in Pants 2.7. If you want to lock down a tool, you need to use this new feature rather than the constraints file.

This is technically a breaking change, but the past was so broken that we consciously do not use a deprecation.

[ci skip-rust]
[ci skip-build-wheels]