### PR TITLE
[internal] Rename `./pants lock` to `./pants user-lock` and `./pants tool-lock` to `./pants lock`

### DIFF
--- a/build-support/bin/_generate_all_lockfiles_helper.py
+++ b/build-support/bin/_generate_all_lockfiles_helper.py
@@ -43,7 +43,7 @@ def main() -> None:
             # restore it here so that the lockfile gets generated properly.
             "--python-setup-experimental-lockfile=3rdparty/python/lockfiles/user_reqs.txt",
             "lock",
-            "tool-lock",
+            "user-lock",
             "::",
         ],
         check=True,
@@ -129,7 +129,7 @@ def main() -> None:
             f"--coverage-py-interpreter-constraints={repr(CoverageSubsystem.default_interpreter_constraints)}",
             f"--coverage-py-experimental-lockfile={CoverageSubsystem.default_lockfile_path}",
             # Run the goal.
-            "tool-lock",
+            "lock",
         ],
         check=True,
     )

--- a/src/python/pants/backend/experimental/python/lockfile.py
+++ b/src/python/pants/backend/experimental/python/lockfile.py
@@ -112,7 +112,7 @@ class PythonLockfileRequest:
             ),
             dest=subsystem.lockfile,
             description=f"Generate lockfile for {subsystem.options_scope}",
-            regenerate_command="./pants tool-lock",
+            regenerate_command="./pants lock",
         )
 
     @property
@@ -188,35 +188,32 @@ async def generate_lockfile(
 # --------------------------------------------------------------------------------------
 
 
-class LockSubsystem(GoalSubsystem):
-    name = "lock"
-    help = "Generate a lockfile."
+# TODO(#12314): Unify with the `lock` goal. Stop looking at specs and instead have an option like
+#  `--lock-resolves` with a list of named resolves (including tools).
+class UserLockSubsystem(GoalSubsystem):
+    name = "user-lock"
+    help = "Generate a lockfile for Python user requirements (experimental)."
 
 
-class LockGoal(Goal):
-    subsystem_cls = LockSubsystem
+class UserLockGoal(Goal):
+    subsystem_cls = UserLockSubsystem
 
 
 @goal_rule
-async def lockfile_goal(
+async def user_lock_goal(
     addresses: Addresses,
     python_setup: PythonSetup,
     workspace: Workspace,
-) -> LockGoal:
+) -> UserLockGoal:
     if python_setup.lockfile is None:
         logger.warning(
-            "You ran `./pants lock`, but `[python-setup].experimental_lockfile` is not set. Please "
-            "set this option to the path where you'd like the lockfile for your code's "
+            "You ran `./pants user-lock`, but `[python-setup].experimental_lockfile` is not set. "
+            "Please set this option to the path where you'd like the lockfile for your code's "
             "dependencies to live."
         )
-        return LockGoal(exit_code=1)
+        return UserLockGoal(exit_code=1)
 
-    # TODO(#12314): Looking at the transitive closure to generate a single lockfile will not work
-    #  when we have multiple user lockfiles supported. Ideally, `./pants lock ::` would mean
-    #  "regenerate all unique lockfiles", whereas now it means "generate a single lockfile based
-    #  on this transitive closure."
     transitive_targets = await Get(TransitiveTargets, TransitiveTargetsRequest(addresses))
-
     reqs = PexRequirements.create_from_requirement_fields(
         tgt[PythonRequirementsField]
         # NB: By looking at the dependencies, rather than the closure, we only generate for
@@ -230,7 +227,7 @@ async def lockfile_goal(
             "No third-party requirements found for the transitive closure, so a lockfile will not "
             "be generated."
         )
-        return LockGoal(exit_code=0)
+        return UserLockGoal(exit_code=0)
 
     result = await Get(
         PythonLockfile,
@@ -251,7 +248,7 @@ async def lockfile_goal(
     workspace.write_digest(result.digest)
     logger.info(f"Wrote lockfile to {result.path}")
 
-    return LockGoal(exit_code=0)
+    return UserLockGoal(exit_code=0)
 
 
 # --------------------------------------------------------------------------------------
@@ -264,31 +261,24 @@ class PythonToolLockfileSentinel:
     pass
 
 
-# TODO(#12314): Unify this goal with `lock` once we figure out how to unify the semantics,
-#  particularly w/ CLI specs. This is a separate goal only to facilitate progress.
-class ToolLockSubsystem(GoalSubsystem):
-    name = "tool-lock"
-    help = "Generate a lockfile for a Python tool."
+class LockGoalSubsystem(GoalSubsystem):
+    name = "lock"
+    help = "Generate lockfiles for Python third-party dependencies."
     required_union_implementations = (PythonToolLockfileSentinel,)
 
 
-class ToolLockGoal(Goal):
-    subsystem_cls = ToolLockSubsystem
+class LockGoal(Goal):
+    subsystem_cls = LockGoalSubsystem
 
 
 @goal_rule
-async def generate_all_tool_lockfiles(
-    workspace: Workspace,
-    union_membership: UnionMembership,
-) -> ToolLockGoal:
-    # TODO(#12314): Add logic to inspect the Specs and generate for only relevant lockfiles. For
-    #  now, we generate for all tools.
+async def lock_goal(workspace: Workspace, union_membership: UnionMembership) -> LockGoal:
     requests = await MultiGet(
         Get(PythonLockfileRequest, PythonToolLockfileSentinel, sentinel())
         for sentinel in union_membership.get(PythonToolLockfileSentinel)
     )
     if not requests:
-        return ToolLockGoal(exit_code=0)
+        return LockGoal(exit_code=0)
 
     results = await MultiGet(
         Get(PythonLockfile, PythonLockfileRequest, req)
@@ -300,7 +290,7 @@ async def generate_all_tool_lockfiles(
     for result in results:
         logger.info(f"Wrote lockfile to {result.path}")
 
-    return ToolLockGoal(exit_code=0)
+    return LockGoal(exit_code=0)
 
 
 def rules():

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -99,7 +99,7 @@ class PythonToolRequirementsBase(Subsystem):
                     "recommend this, as lockfiles are essential for reproducible builds.\n\n"
                     "To use a custom lockfile, set this option to a file path relative to the "
                     "build root, then activate the backend_package "
-                    "`pants.backend.experimental.python` and run `./pants tool-lock`.\n\n"
+                    "`pants.backend.experimental.python` and run `./pants lock`.\n\n"
                     "This option is experimental and will likely change. It does not follow the "
                     "normal deprecation cycle."
                 ),

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -122,7 +122,7 @@ class PythonSetup(Subsystem):
                 "multiple lockfiles. This option's behavior may change without the normal "
                 "deprecation cycle.\n\n"
                 "To generate a lockfile, activate the backend `pants.backend.experimental.python`"
-                "and run `./pants lock ::`.\n\n"
+                "and run `./pants user-lock ::`.\n\n"
                 "Mutually exclusive with `[python-setup].requirement_constraints`."
             ),
         )
@@ -137,7 +137,7 @@ class PythonSetup(Subsystem):
             default=None,
             help=(
                 "If set, Pants will instruct your users to run a custom command to regenerate "
-                "lockfiles, rather than running `./pants lock` and `./pants tool-lock` like normal."
+                "lockfiles, rather than running `./pants lock` like normal."
                 "\n\nThis option is experimental and it may change at any time without the normal "
                 "deprecation cycle."
             ),


### PR DESCRIPTION
We currently have separate goals for user lockfiles vs tool lockfiles because the implementations are different right now, e.g. specs being different. It's easier to keep separate while iterating. We will unify them, but are not yet ready.

We want to release tool lockfiles as stable in Pants 2.7, so it should be using the final proper name of `./pants lock` rather than `./pants tool-lock`.

## `lock` vs `resolve`

Both names have been proposed, and both are probably valid. 

I went with `lock` because it's simpler and imo more evocative of what is happening: pinning down (locking) all your deps. For me personally, `resolve` is more vague and does not imply pinning.

### Should Python be mentioned in the name?

Currently, this goal only works with Python. But it should work with other languages in the future. It's not clear if those other languages will use the same semantics as the Python goal..we may need to change things to get it be consistent. 

Even if we try to be proactive thinking about other languages, we probably need to implement their support fully before we can commit to particular semantics.

Is it worth calling this `python-lock` to future-proof so that we can implement a more generic `lock` without being constricted to the decisions we make now?

[ci skip-rust]
[ci skip-build-wheels]