### PR TITLE
Fix Toolchain plugin being included in generated reference docs

### DIFF
--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -194,12 +194,7 @@ def create_parser() -> argparse.ArgumentParser:
 
 
 def run_pants_help_all() -> Dict:
-    deactivated_backends = [
-        "internal_plugins.releases",
-        "toolchain.pants.auth",
-        "toolchain.pants.buildsense",
-        "toolchain.pants.common",
-    ]
+    deactivated_backends = ["internal_plugins.releases"]
     activated_backends = [
         "pants.backend.codegen.protobuf.python",
         "pants.backend.awslambda.python",
@@ -207,9 +202,11 @@ def run_pants_help_all() -> Dict:
         "pants.backend.python.lint.pylint",
         "pants.backend.python.lint.yapf",
     ]
+    deactivated_plugins = ["toolchain.pants.plugin==0.13.1"]
     argv = [
         "./pants",
         "--concurrent",
+        f"--plugins=-[{', '.join(map(repr, deactivated_plugins))}]",
         f"--backend-packages=-[{', '.join(map(repr, deactivated_backends))}]",
         f"--backend-packages=+[{', '.join(map(repr, activated_backends))}]",
         "--no-verify-config",

--- a/pants.toml
+++ b/pants.toml
@@ -20,6 +20,7 @@ backend_packages.add = [
 ]
 plugins = [
   "hdrhistogram",  # For use with `--stats-log`.
+  # NOTE: Keep this version in sync with `generate_docs.py`!
   "toolchain.pants.plugin==0.13.1",
 ]
 


### PR DESCRIPTION
A few subsystems/goals like `auth` and `toolchain-setup` started being included as of Pants 2.5 because the Toolchain plugin started activating backends by default. 

Unregistering the backends with `--backend-packages=-['foo']` does not work with plugins, and the only way to deactivate is to not install the plugin.

[ci skip-rust]