### PR TITLE
Split PexRequirements into three unioned types

### DIFF
--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -9,7 +9,7 @@ from typing import ClassVar, Iterable, Sequence, cast
 from pants.backend.experimental.python.lockfile_metadata import calculate_invalidation_digest
 from pants.backend.python.target_types import ConsoleScript, EntryPoint, MainSpecification
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.pex import PexRequirements
+from pants.backend.python.util_rules.pex import Lockfile, LockfileContent, PexRequirements
 from pants.engine.fs import FileContent
 from pants.option.errors import OptionsError
 from pants.option.subsystem import Subsystem
@@ -125,7 +125,7 @@ class PythonToolRequirementsBase(Subsystem):
         self,
         *,
         extra_requirements: Iterable[str] = (),
-    ) -> PexRequirements:
+    ) -> PexRequirements | Lockfile | LockfileContent:
         """The requirements to be used when installing the tool.
 
         If the tool supports lockfiles, the returned type will install from the lockfile rather than
@@ -141,14 +141,14 @@ class PythonToolRequirementsBase(Subsystem):
 
         if self.lockfile == DEFAULT_TOOL_LOCKFILE:
             assert self.default_lockfile_resource is not None
-            return PexRequirements(
+            return LockfileContent(
                 file_content=FileContent(
                     f"{self.options_scope}_default_lockfile.txt",
                     importlib.resources.read_binary(*self.default_lockfile_resource),
                 ),
                 lockfile_hex_digest=hex_digest,
             )
-        return PexRequirements(
+        return Lockfile(
             file_path=self.lockfile,
             file_path_description_of_origin=(
                 f"the option `[{self.options_scope}].experimental_lockfile`"

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -222,10 +222,10 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
         additional_requirements=request.additional_requirements,
     )
 
-    repository_pex: Pex | None = None
     description = request.description
 
     if requirements:
+        repository_pex: Pex | None = None
         if python_setup.requirement_constraints:
             maybe_constraints_repository_pex = await Get(
                 _ConstraintsRepositoryPex,
@@ -268,6 +268,7 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
                     additional_args=request.additional_args,
                 ),
             )
+        requirements = dataclasses.replace(requirements, repository_pex=repository_pex)
 
     return PexRequest(
         output_filename=request.output_filename,
@@ -278,7 +279,6 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
         main=request.main,
         sources=merged_input_digest,
         additional_inputs=request.additional_inputs,
-        repository_pex=repository_pex,
         additional_args=request.additional_args,
         description=description,
     )

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -18,7 +18,13 @@ from pants.backend.python.target_types import (
     parse_requirements_file,
 )
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.pex import Pex, PexPlatforms, PexRequest, PexRequirements
+from pants.backend.python.util_rules.pex import (
+    Lockfile,
+    Pex,
+    PexPlatforms,
+    PexRequest,
+    PexRequirements,
+)
 from pants.backend.python.util_rules.pex import rules as pex_rules
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFilesRequest,
@@ -242,18 +248,20 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
                 "`[python-setup].requirement_constraints` must also be set."
             )
         elif python_setup.lockfile:
-            # TODO(#12314): Hook up lockfile staleness check once multiple lockfiles are supported.
             repository_pex = await Get(
                 Pex,
                 PexRequest(
                     description=f"Resolving {python_setup.lockfile}",
                     output_filename="lockfile.pex",
                     internal_only=request.internal_only,
-                    requirements=PexRequirements(
+                    requirements=Lockfile(
                         file_path=python_setup.lockfile,
                         file_path_description_of_origin=(
                             "the option `[python-setup].experimental_lockfile`"
                         ),
+                        # TODO(#12314): Hook up lockfile staleness check once multiple lockfiles
+                        # are supported.
+                        lockfile_hex_digest=None,
                     ),
                     interpreter_constraints=interpreter_constraints,
                     platforms=request.platforms,

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -214,24 +214,23 @@ def test_constraints_validation(tmp_path_factory: TempPathFactory, rule_runner: 
     assert pex_req1.requirements == PexRequirements(
         ["foo-bar>=0.1.2", "bar==5.5.5", "baz", url_req]
     )
-    assert pex_req1.repository_pex is None
+
     pex_req1_direct = get_pex_request(
         "constraints1.txt", resolve_all_constraints=False, direct_deps_only=True
     )
     assert pex_req1_direct.requirements == PexRequirements(["baz", url_req])
-    assert pex_req1_direct.repository_pex is None
 
     pex_req2 = get_pex_request(
         "constraints1.txt",
         resolve_all_constraints=True,
         additional_args=additional_args,
     )
-    assert pex_req2.requirements == PexRequirements(
-        ["foo-bar>=0.1.2", "bar==5.5.5", "baz", url_req]
-    )
-    assert pex_req2.repository_pex is not None
-    assert not info(rule_runner, pex_req2.repository_pex)["strip_pex_env"]
-    repository_pex = pex_req2.repository_pex
+    pex_req2_reqs = pex_req2.requirements
+    assert isinstance(pex_req2_reqs, PexRequirements)
+    assert list(pex_req2_reqs.req_strings) == ["bar==5.5.5", "baz", "foo-bar>=0.1.2", url_req]
+    assert pex_req2_reqs.repository_pex is not None
+    assert not info(rule_runner, pex_req2_reqs.repository_pex)["strip_pex_env"]
+    repository_pex = pex_req2_reqs.repository_pex
     assert ["Foo._-BAR==1.0.0", "bar==5.5.5", "baz==2.2.2", "foorl", "qux==3.4.5"] == requirements(
         rule_runner, repository_pex
     )
@@ -242,19 +241,23 @@ def test_constraints_validation(tmp_path_factory: TempPathFactory, rule_runner: 
         direct_deps_only=True,
         additional_args=additional_args,
     )
-    assert pex_req2_direct.requirements == PexRequirements(["baz", url_req])
-    assert pex_req2_direct.repository_pex == repository_pex
-    assert not info(rule_runner, pex_req2.repository_pex)["strip_pex_env"]
+    pex_req2_reqs = pex_req2_direct.requirements
+    assert isinstance(pex_req2_reqs, PexRequirements)
+    assert list(pex_req2_reqs.req_strings) == ["baz", url_req]
+    assert pex_req2_reqs.repository_pex == repository_pex
+    assert not info(rule_runner, pex_req2_reqs.repository_pex)["strip_pex_env"]
 
     pex_req3_direct = get_pex_request(
         "constraints1.txt",
         resolve_all_constraints=True,
         direct_deps_only=True,
     )
-    assert pex_req3_direct.requirements == PexRequirements(["baz", url_req])
-    assert pex_req3_direct.repository_pex is not None
-    assert pex_req3_direct.repository_pex != repository_pex
-    assert info(rule_runner, pex_req3_direct.repository_pex)["strip_pex_env"]
+    pex_req3_reqs = pex_req3_direct.requirements
+    assert isinstance(pex_req3_reqs, PexRequirements)
+    assert list(pex_req3_reqs.req_strings) == ["baz", url_req]
+    assert pex_req3_reqs.repository_pex is not None
+    assert pex_req3_reqs.repository_pex != repository_pex
+    assert info(rule_runner, pex_req3_reqs.repository_pex)["strip_pex_env"]
 
     with pytest.raises(ExecutionError) as err:
         get_pex_request(None, resolve_all_constraints=True)
@@ -296,5 +299,4 @@ def test_issue_12222(rule_runner: RuleRunner) -> None:
     )
     result = rule_runner.request(PexRequest, [request])
 
-    assert result.repository_pex is None
     assert result.requirements == PexRequirements(["foo"])

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -86,7 +86,7 @@ def create_pex_and_get_all_data(
     rule_runner: RuleRunner,
     *,
     pex_type: type[Pex | VenvPex] = Pex,
-    requirements: PexRequirements = PexRequirements(),
+    requirements: PexRequirements | Lockfile | LockfileContent = PexRequirements(),
     main: MainSpecification | None = None,
     interpreter_constraints: InterpreterConstraints = InterpreterConstraints(),
     platforms: PexPlatforms = PexPlatforms(),
@@ -165,7 +165,7 @@ def create_pex_and_get_pex_info(
     rule_runner: RuleRunner,
     *,
     pex_type: type[Pex | VenvPex] = Pex,
-    requirements: PexRequirements = PexRequirements(),
+    requirements: PexRequirements | Lockfile | LockfileContent = PexRequirements(),
     main: MainSpecification | None = None,
     interpreter_constraints: InterpreterConstraints = InterpreterConstraints(),
     platforms: PexPlatforms = PexPlatforms(),
@@ -478,34 +478,32 @@ def test_build_pex_description() -> None:
     def assert_description(
         requirements: PexRequirements | Lockfile | LockfileContent,
         *,
-        use_repo_pex: bool = False,
         description: str | None = None,
         expected: str,
     ) -> None:
-        repo_pex = Pex(EMPTY_DIGEST, "repo.pex", None) if use_repo_pex else None
         request = PexRequest(
             output_filename="new.pex",
             internal_only=True,
             requirements=requirements,
             description=description,
-            repository_pex=repo_pex,
         )
         assert _build_pex_description(request) == expected
 
+    repo_pex = Pex(EMPTY_DIGEST, "repo.pex", None)
+
     assert_description(PexRequirements(), description="Custom!", expected="Custom!")
     assert_description(
-        PexRequirements(), description="Custom!", use_repo_pex=True, expected="Custom!"
+        PexRequirements(repository_pex=repo_pex), description="Custom!", expected="Custom!"
     )
 
     assert_description(PexRequirements(), expected="Building new.pex")
-    assert_description(PexRequirements(), use_repo_pex=True, expected="Building new.pex")
+    assert_description(PexRequirements(repository_pex=repo_pex), expected="Building new.pex")
 
     assert_description(
         PexRequirements(["req"]), expected="Building new.pex with 1 requirement: req"
     )
     assert_description(
-        PexRequirements(["req"]),
-        use_repo_pex=True,
+        PexRequirements(["req"], repository_pex=repo_pex),
         expected="Extracting 1 requirement to build new.pex from repo.pex: req",
     )
 
@@ -514,8 +512,7 @@ def test_build_pex_description() -> None:
         expected="Building new.pex with 2 requirements: req1, req2",
     )
     assert_description(
-        PexRequirements(["req1", "req2"]),
-        use_repo_pex=True,
+        PexRequirements(["req1", "req2"], repository_pex=repo_pex),
         expected="Extracting 2 requirements to build new.pex from repo.pex: req1, req2",
     )
 
@@ -523,24 +520,12 @@ def test_build_pex_description() -> None:
         LockfileContent(file_content=FileContent("lock.txt", b""), lockfile_hex_digest=None),
         expected="Building new.pex from lock.txt",
     )
-    assert_description(
-        LockfileContent(file_content=FileContent("lock.txt", b""), lockfile_hex_digest=None),
-        use_repo_pex=True,
-        expected="Extracting all requirements in lock.txt from repo.pex to build new.pex",
-    )
 
     assert_description(
         Lockfile(
             file_path="lock.txt", file_path_description_of_origin="foo", lockfile_hex_digest=None
         ),
         expected="Building new.pex from lock.txt",
-    )
-    assert_description(
-        Lockfile(
-            file_path="lock.txt", file_path_description_of_origin="foo", lockfile_hex_digest=None
-        ),
-        use_repo_pex=True,
-        expected="Extracting all requirements in lock.txt from repo.pex to build new.pex",
     )
 
 
@@ -597,19 +582,20 @@ def _run_pex_for_lockfile_test(rule_runner, use_file, actual, expected, behavior
 ansicolors==1.1.8
 """
     if use_file:
-        rule_runner.write_files({"lockfile.txt": lockfile})
-        file_args = {"file_path": "lockfile.txt"}
+        file_path = "lockfile.txt"
+        rule_runner.write_files({file_path: lockfile})
+        requirements = Lockfile(
+            file_path=file_path,
+            file_path_description_of_origin="iceland",
+            lockfile_hex_digest=expected,
+        )
     else:
         content = FileContent("lockfile.txt", lockfile.encode("utf-8"))
-        file_args = {"file_content": content}
+        requirements = LockfileContent(file_content=content, lockfile_hex_digest=expected)
 
     create_pex_and_get_all_data(
         rule_runner,
-        requirements=PexRequirements(
-            **file_args,
-            file_path_description_of_origin="iceland",
-            lockfile_hex_digest=expected,
-        ),
+        requirements=requirements,
         additional_pants_args=(
             "--python-setup-experimental-lockfile=lockfile.txt",
             f"--python-setup-invalid-lockfile-behavior={behavior}",

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -19,6 +19,8 @@ from pkg_resources import Requirement
 from pants.backend.python.target_types import EntryPoint, MainSpecification
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import (
+    Lockfile,
+    LockfileContent,
     Pex,
     PexDistributionInfo,
     PexPlatforms,
@@ -474,7 +476,7 @@ def test_venv_pex_resolve_info(rule_runner: RuleRunner, pex_type: type[Pex | Ven
 
 def test_build_pex_description() -> None:
     def assert_description(
-        requirements: PexRequirements,
+        requirements: PexRequirements | Lockfile | LockfileContent,
         *,
         use_repo_pex: bool = False,
         description: str | None = None,
@@ -518,21 +520,25 @@ def test_build_pex_description() -> None:
     )
 
     assert_description(
-        PexRequirements(file_content=FileContent("lock.txt", b"")),
+        LockfileContent(file_content=FileContent("lock.txt", b""), lockfile_hex_digest=None),
         expected="Building new.pex from lock.txt",
     )
     assert_description(
-        PexRequirements(file_content=FileContent("lock.txt", b"")),
+        LockfileContent(file_content=FileContent("lock.txt", b""), lockfile_hex_digest=None),
         use_repo_pex=True,
         expected="Extracting all requirements in lock.txt from repo.pex to build new.pex",
     )
 
     assert_description(
-        PexRequirements(file_path="lock.txt", file_path_description_of_origin="foo"),
+        Lockfile(
+            file_path="lock.txt", file_path_description_of_origin="foo", lockfile_hex_digest=None
+        ),
         expected="Building new.pex from lock.txt",
     )
     assert_description(
-        PexRequirements(file_path="lock.txt", file_path_description_of_origin="foo"),
+        Lockfile(
+            file_path="lock.txt", file_path_description_of_origin="foo", lockfile_hex_digest=None
+        ),
         use_repo_pex=True,
         expected="Extracting all requirements in lock.txt from repo.pex to build new.pex",
     )


### PR DESCRIPTION
Splits out `Lockfile` and `LockfileContent` case classes, which have independent behavior from the `PexRequirements` case: they fully specify their own requirements, and don't make sense in the context of a `repository.pex`.

Prep work for #12548.

[ci skip-rust]
[ci skip-build-wheels]