### PR TITLE
digest subset should not short-circuit when there are ignores involved.

### DIFF
--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -311,16 +311,25 @@ impl GitignoreStyleExcludes {
     }
   }
 
-  pub fn has_ignored_paths(&self, path: &Path) -> bool {
+  ///
+  /// Find out if a path has any ignore patterns for files/paths in its tree.
+  ///
+  /// Used by the IntermediateGlobbedFilesAndDirectories in snapshot_ops.rs,
+  /// to check if it mayoptimize the snapshot subset operation on this tree,
+  /// or need to check for excluded files/directories.
+  ///
+  pub fn maybe_is_parent_of_ignored_path(&self, path: &Path) -> bool {
     match path.to_str() {
-      None => return false,
+      None => true,
       Some(s) => {
         for pattern in self.exclude_patterns().iter() {
-          if pattern.starts_with(s) {
+          if pattern.starts_with(s) || s.starts_with(pattern) {
+            // In case the pattern is shorter than path, we are inside a ignored tree, so both
+            // parent and child of ignored paths.
             return true;
           }
         }
-        return false;
+        false
       }
     }
   }

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -310,6 +310,20 @@ impl GitignoreStyleExcludes {
       ::ignore::Match::Ignore(_) => true,
     }
   }
+
+  pub fn has_ignored_paths(&self, path: &Path) -> bool {
+    match path.to_str() {
+      None => return false,
+      Some(s) => {
+        for pattern in self.exclude_patterns().iter() {
+          if pattern.starts_with(s) {
+            return true;
+          }
+        }
+        return false;
+      }
+    }
+  }
 }
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -315,7 +315,7 @@ impl GitignoreStyleExcludes {
   /// Find out if a path has any ignore patterns for files/paths in its tree.
   ///
   /// Used by the IntermediateGlobbedFilesAndDirectories in snapshot_ops.rs,
-  /// to check if it mayoptimize the snapshot subset operation on this tree,
+  /// to check if it may optimize the snapshot subset operation on this tree,
   /// or need to check for excluded files/directories.
   ///
   pub fn maybe_is_parent_of_ignored_path(&self, path: &Path) -> bool {

--- a/src/rust/engine/fs/store/src/snapshot_ops.rs
+++ b/src/rust/engine/fs/store/src/snapshot_ops.rs
@@ -408,7 +408,7 @@ impl IntermediateGlobbedFilesAndDirectories {
             // a whole directory is to end in '/**' or '/**/*'.
 
             if exclude.maybe_is_parent_of_ignored_path(&directory_path) {
-              // leave this directory in todo_directories, so we process ignore patterns correctly..
+              // Leave this directory in todo_directories, so we process ignore patterns correctly.
               continue;
             }
 

--- a/src/rust/engine/fs/store/src/snapshot_ops.rs
+++ b/src/rust/engine/fs/store/src/snapshot_ops.rs
@@ -425,17 +425,19 @@ impl IntermediateGlobbedFilesAndDirectories {
             if (*wildcard == *DOUBLE_STAR_GLOB) || (*wildcard == *SINGLE_STAR_GLOB) {
               // Here we short-circuit all cases which would swallow up a directory without
               // subsetting it or needing to perform any further recursive work.
+              let has_ignores = exclude.has_ignored_paths(&directory_path);
+
               let short_circuit: bool = match &remainder[..] {
-                [] => true,
+                [] => !has_ignores,
                 // NB: Very often, /**/* is seen ending zsh-style globs, which means the same as
                 // ending in /**. Because we want to *avoid* recursing and just use the subdirectory
                 // as-is for /**/* and /**, we `continue` here in both cases.
-                [single_glob] if *single_glob == *SINGLE_STAR_GLOB => true,
-                [double_glob] if *double_glob == *DOUBLE_STAR_GLOB => true,
+                [single_glob] if *single_glob == *SINGLE_STAR_GLOB => !has_ignores,
+                [double_glob] if *double_glob == *DOUBLE_STAR_GLOB => !has_ignores,
                 [double_glob, single_glob]
                   if *double_glob == *DOUBLE_STAR_GLOB && *single_glob == *SINGLE_STAR_GLOB =>
                 {
-                  true
+                  !has_ignores
                 }
                 _ => false,
               };

--- a/src/rust/engine/fs/store/src/snapshot_ops_tests.rs
+++ b/src/rust/engine/fs/store/src/snapshot_ops_tests.rs
@@ -95,7 +95,7 @@ async fn subset_single_files() {
 async fn subset_recursive_wildcard() {
   let (store, tempdir, posix_fs, digester) = setup();
 
-  let (merged_digest, _, _) = get_duplicate_rolands(
+  let (merged_digest, snapshot1, _) = get_duplicate_rolands(
     store.clone(),
     store.clone(),
     tempdir.path(),
@@ -120,6 +120,24 @@ async fn subset_recursive_wildcard() {
     .await
     .unwrap();
   assert_eq!(merged_digest, subset_roland2);
+
+  // ** should not include explicitly excluded files
+  let subset_params3 = make_subset_params(&["!subdir/roland2", "subdir/**"]);
+  let subset_roland3 = store
+    .clone()
+    .subset(merged_digest, subset_params3)
+    .await
+    .unwrap();
+  assert_eq!(subset_roland3, snapshot1.digest);
+
+  // ** should not include explicitly excluded files
+  let subset_params4 = make_subset_params(&["!subdir/roland2", "**"]);
+  let subset_roland4 = store
+    .clone()
+    .subset(merged_digest, subset_params4)
+    .await
+    .unwrap();
+  assert_eq!(subset_roland4, snapshot1.digest);
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
From slack thread: https://pantsbuild.slack.com/archives/C0D7TNJHL/p1629826664300300

Fixes #12661.