### PR TITLE
tailor: do not append comma to kwarg with empty tuple

### DIFF
--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -210,8 +210,8 @@ class PutativeTarget:
                 return f'"{v}"'
             if isinstance(v, tuple):
                 val_parts = [f"\n{indent*2}{fmt_val(x)}" for x in v]
-                val_str = ",".join(val_parts)
-                return f"[{val_str},\n{indent}]"
+                val_str = ",".join(val_parts) + ("," if v else "")
+                return f"[{val_str}\n{indent}]"
             return repr(v)
 
         if self.kwargs:


### PR DESCRIPTION
If an empty tuple is passed as the value of a kwarg to `PutativeTarget.for_target_type`, `tailor` will generate `[,]` in the `BUILD` file which does not parse. Fix the issue by only appending the comma when there are actually values to put into the BUILD file for the kwarg.