### PR TITLE
Fix UI rendering when multiple tasks have the same label

### DIFF
--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -420,7 +420,7 @@ impl HeavyHittersData {
     }
   }
 
-  fn heavy_hitters(&self, k: usize) -> HashMap<String, Option<Duration>> {
+  fn heavy_hitters(&self, k: usize) -> HashMap<SpanId, (String, Option<Duration>)> {
     self.refresh_store();
 
     let now = SystemTime::now();
@@ -456,7 +456,7 @@ impl HeavyHittersData {
         if let Some(effective_name) = workunit.metadata.desc.as_ref() {
           let maybe_duration = Self::duration_for(now, workunit);
 
-          res.insert(effective_name.to_string(), maybe_duration);
+          res.insert(span_id, (effective_name.to_string(), maybe_duration));
           if res.len() >= k {
             break;
           }
@@ -583,7 +583,7 @@ impl WorkunitStore {
   ///
   /// Find the longest running leaf workunits, and return their first visible parents.
   ///
-  pub fn heavy_hitters(&self, k: usize) -> HashMap<String, Option<Duration>> {
+  pub fn heavy_hitters(&self, k: usize) -> HashMap<SpanId, (String, Option<Duration>)> {
     self.heavy_hitters_data.heavy_hitters(k)
   }
 

--- a/src/rust/engine/workunit_store/src/tests.rs
+++ b/src/rust/engine/workunit_store/src/tests.rs
@@ -7,7 +7,10 @@ use crate::{SpanId, WorkunitMetadata, WorkunitState, WorkunitStore};
 #[test]
 fn heavy_hitters_basic() {
   let ws = create_store(vec![], vec![wu_root(0), wu(1, 0)], vec![]);
-  assert_eq!(vec!["1"], ws.heavy_hitters(1).keys().collect::<Vec<_>>());
+  assert_eq!(
+    vec![SpanId(1)],
+    ws.heavy_hitters(1).keys().cloned().collect::<Vec<_>>()
+  );
 }
 
 #[test]


### PR DESCRIPTION
The `heavy_hitters` computed by the workunit store were keyed by their `String` label. But this meant that all workunits with the same label were rendered only once in the UI, which wasn't accurate/useful. Secondarily, it's less efficient to be tracking workunits by a `String` key rather than by a `u64`.

[ci skip-build-wheels]