### PR TITLE
The `pex_binary` "venv" mode now sees bin scripts.

### DIFF
--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -88,7 +88,7 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
         if self._execution_mode is PexExecutionMode.UNZIP:
             args.append("--unzip")
         if self._execution_mode is PexExecutionMode.VENV:
-            args.append("--venv")
+            args.extend(("--venv", "prepend"))
         if self.include_tools.value is True:
             args.append("--include-tools")
         return tuple(args)

--- a/src/python/pants/backend/python/goals/run_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary_integration_test.py
@@ -90,6 +90,9 @@ def test_run_sample_script(
         pex_info = json.loads(result.stdout)
         assert (execution_mode is PexExecutionMode.UNZIP) == pex_info["unzip"]
         assert (execution_mode is PexExecutionMode.VENV) == pex_info["venv"]
+        assert ("prepend" if execution_mode is PexExecutionMode.VENV else "false") == pex_info[
+            "venv_bin_path"
+        ]
         assert pex_info["strip_pex_env"] is False
 
 


### PR DESCRIPTION
Setting a `pex_binary` target's `execution_mode` to `"venv"` now
configures all of the PEX's thirdy party dependencies' scripts to be
pre-pended to the `$PATH` of the PEX and any subprocesses launched by
it. This is how standard venv activation works and it permits a wider
range of PEXes to work out of the box.

Fixes #12651

[ci skip-rust]
[ci skip-build-wheels]