### PR TITLE
[internal] Only run macOS tests in CI annotated with `@pytest.mark.platform_specific_behavior`

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -504,7 +504,7 @@ jobs:
       with:
         name: native_binaries.${{ matrix.python-version }}.${{ runner.os }}
     - name: Run Python tests
-      run: './pants --tag=+platform_specific_behavior test ::
+      run: './pants --tag=+platform_specific_behavior test :: -- -m platform_specific_behavior
 
         '
     - if: always()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -677,7 +677,7 @@ jobs:
       with:
         name: native_binaries.${{ matrix.python-version }}.${{ runner.os }}
     - name: Run Python tests
-      run: './pants --tag=+platform_specific_behavior test ::
+      run: './pants --tag=+platform_specific_behavior test :: -- -m platform_specific_behavior
 
         '
     - if: always()

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -390,7 +390,10 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
                 native_binaries_download(),
                 {
                     "name": "Run Python tests",
-                    "run": "./pants --tag=+platform_specific_behavior test ::\n",
+                    "run": (
+                        "./pants --tag=+platform_specific_behavior test :: "
+                        "-- -m platform_specific_behavior\n"
+                    ),
                 },
                 upload_log_artifacts(name="python-test-macos"),
             ],

--- a/src/python/pants/base/exception_sink_integration_test.py
+++ b/src/python/pants/base/exception_sink_integration_test.py
@@ -17,6 +17,8 @@ from pants.testutil.pants_integration_test import run_pants_with_workdir
 from pants.util.dirutil import read_file
 from pants_test.pantsd.pantsd_integration_test_base import PantsDaemonIntegrationTestBase
 
+pytestmark = pytest.mark.platform_specific_behavior
+
 
 def lifecycle_stub_cmdline() -> List[str]:
     # Load the testprojects pants-plugins to get some testing tasks and subsystems.

--- a/src/python/pants/base/exception_sink_test.py
+++ b/src/python/pants/base/exception_sink_test.py
@@ -12,6 +12,8 @@ from pants.engine.platform import Platform
 from pants.util.contextutil import temporary_dir
 from pants.util.enums import match
 
+pytestmark = pytest.mark.platform_specific_behavior
+
 
 def _gen_sink_subclass():
     # Avoid modifying global state by generating a subclass.


### PR DESCRIPTION
For https://github.com/pantsbuild/pants/issues/12601, I want to run some of our tests on macOS to make sure our default lockfiles work for both Linux and macOS. But I don't want to run _all_ the tests for each tool, like all of `mypy/rules_integration_test.py` because they can be quite slow (480s timeout!).

This change means that we will only run in CI tests for macOS where the Pants target is annotated with the tag `platform_specific_behavior` _and_ the test has a Pytest marker of `platform_specific_behavior`. You can either individually mark tests, or mark all tests in the file by setting `pytestmarker`, per https://docs.pytest.org/en/6.2.x/example/markers.html#marking-whole-classes-or-modules.

Note that if someone sets the Pants tag for a new file but forgets to set any Pytest tags, Pytest will fail complaining that no tests were selected. This should help remind people they need to set both things.
