### PR TITLE
[internal] Add missing `resources` targets for default tool lockfiles

### DIFF
--- a/src/python/pants/backend/awslambda/python/BUILD
+++ b/src/python/pants/backend/awslambda/python/BUILD
@@ -1,7 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library()
+python_library(dependencies=[":lockfile"])
+resources(name="lockfile", sources=["lambdex_lockfile.txt"])
 
 python_tests(name='target_types_test', sources=["target_types_test.py"])
 python_tests(

--- a/src/python/pants/backend/codegen/protobuf/python/BUILD
+++ b/src/python/pants/backend/codegen/protobuf/python/BUILD
@@ -1,7 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library()
+python_library(dependencies=[":lockfile"])
+resources(name="lockfile", sources=["mypy_protobuf_lockfile.txt"])
 
 python_tests(
     name="python_protobuf_module_mapper_test", sources=["python_protobuf_module_mapper_test.py"]

--- a/src/python/pants/backend/python/lint/bandit/BUILD
+++ b/src/python/pants/backend/python/lint/bandit/BUILD
@@ -1,7 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library()
+python_library(dependencies=[":lockfile"])
+resources(name="lockfile", sources=["lockfile.txt"])
 
 python_tests(name="subsystem_test", sources=["subsystem_test.py"])
 python_tests(

--- a/src/python/pants/backend/python/lint/black/BUILD
+++ b/src/python/pants/backend/python/lint/black/BUILD
@@ -1,7 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library()
+python_library(dependencies=[":lockfile"])
+resources(name="lockfile", sources=["lockfile.txt"])
 
 python_tests(name="subsystem_test", sources=["subsystem_test.py"])
 python_tests(

--- a/src/python/pants/backend/python/lint/flake8/BUILD
+++ b/src/python/pants/backend/python/lint/flake8/BUILD
@@ -1,7 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library()
+python_library(dependencies=[":lockfile"])
+resources(name="lockfile", sources=["lockfile.txt"])
 
 python_tests(name="subsystem_test", sources=["subsystem_test.py"])
 python_tests(

--- a/src/python/pants/backend/python/lint/isort/BUILD
+++ b/src/python/pants/backend/python/lint/isort/BUILD
@@ -1,7 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library()
+python_library(dependencies=[":lockfile"])
+resources(name="lockfile", sources=["lockfile.txt"])
 
 python_tests(
     name="rules_integration_test",

--- a/src/python/pants/backend/python/lint/pylint/BUILD
+++ b/src/python/pants/backend/python/lint/pylint/BUILD
@@ -1,7 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library()
+python_library(dependencies=[":lockfile"])
+resources(name="lockfile", sources=["lockfile.txt"])
 
 python_tests(name="subsystem_test", sources=["subsystem_test.py"])
 python_tests(

--- a/src/python/pants/backend/python/lint/yapf/BUILD
+++ b/src/python/pants/backend/python/lint/yapf/BUILD
@@ -1,7 +1,8 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library()
+python_library(dependencies=[":lockfile"])
+resources(name="lockfile", sources=["lockfile.txt"])
 
 python_tests(
     name="rules_integration_test",

--- a/src/python/pants/backend/python/subsystems/BUILD
+++ b/src/python/pants/backend/python/subsystems/BUILD
@@ -1,5 +1,7 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library()
+python_library(dependencies=[":lockfiles"])
+resources(name="lockfiles", sources=["*_lockfile.txt"])
+
 python_tests(name="tests")

--- a/src/python/pants/backend/python/typecheck/mypy/BUILD
+++ b/src/python/pants/backend/python/typecheck/mypy/BUILD
@@ -1,7 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library()
+python_library(dependencies=[":lockfile"])
+resources(name="lockfile", sources=["lockfile.txt"])
 
 python_tests(name="subsystem_test", sources=["subsystem_test.py"])
 python_tests(


### PR DESCRIPTION
Without these, the lockfiles won't be included in pantsbuild.pants and the defaults will fail to be imported.

[ci skip-rust]
[ci skip-build-wheels]