### PR TITLE
Decompose requirements pexes

### DIFF
--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -216,7 +216,7 @@ async def setup_pytest_for_target(
             interpreter_constraints=interpreter_constraints,
             main=pytest.main,
             internal_only=True,
-            pex_path=[pytest_pex, requirements_pex],
+            pex_path=Pex.pex_path_closure([pytest_pex, requirements_pex]),
         ),
     )
     config_files_get = Get(

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -13,7 +13,13 @@ from pants.backend.python.goals.coverage_py import (
 )
 from pants.backend.python.subsystems.pytest import PyTest, PythonTestFieldSet
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.pex import Pex, PexRequest, VenvPex, VenvPexProcess
+from pants.backend.python.util_rules.pex import (
+    Pex,
+    PexRequest,
+    VenvPex,
+    VenvPexProcess,
+    pex_path_closure,
+)
 from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
@@ -216,7 +222,7 @@ async def setup_pytest_for_target(
             interpreter_constraints=interpreter_constraints,
             main=pytest.main,
             internal_only=True,
-            pex_path=Pex.pex_path_closure([pytest_pex, requirements_pex]),
+            pex_path=pex_path_closure([pytest_pex, requirements_pex]),
         ),
     )
     config_files_get = Get(

--- a/src/python/pants/backend/python/goals/repl.py
+++ b/src/python/pants/backend/python/goals/repl.py
@@ -106,7 +106,9 @@ async def create_ipython_repl_request(
     chrooted_source_roots = [repl.in_chroot(sr) for sr in sources.source_roots]
     extra_env = {
         **complete_pex_env.environment_dict(python_configured=ipython_pex.python is not None),
-        "PEX_PATH": repl.in_chroot(requirements_pex_request.output_filename),
+        "PEX_PATH": ":".join(
+            repl.in_chroot(p.name) for p in Pex.pex_path_closure([requirements_pex])
+        ),
         "PEX_EXTRA_SYS_PATH": ":".join(chrooted_source_roots),
     }
 

--- a/src/python/pants/backend/python/goals/repl.py
+++ b/src/python/pants/backend/python/goals/repl.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.backend.python.subsystems.ipython import IPython
-from pants.backend.python.util_rules.pex import Pex, PexRequest
+from pants.backend.python.util_rules.pex import Pex, PexRequest, pex_path_closure
 from pants.backend.python.util_rules.pex_environment import PexEnvironment
 from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
 from pants.backend.python.util_rules.python_sources import (
@@ -106,9 +106,7 @@ async def create_ipython_repl_request(
     chrooted_source_roots = [repl.in_chroot(sr) for sr in sources.source_roots]
     extra_env = {
         **complete_pex_env.environment_dict(python_configured=ipython_pex.python is not None),
-        "PEX_PATH": ":".join(
-            repl.in_chroot(p.name) for p in Pex.pex_path_closure([requirements_pex])
-        ),
+        "PEX_PATH": ":".join(repl.in_chroot(p.name) for p in pex_path_closure([requirements_pex])),
         "PEX_EXTRA_SYS_PATH": ":".join(chrooted_source_roots),
     }
 

--- a/src/python/pants/backend/python/goals/run_pex_binary.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary.py
@@ -94,7 +94,7 @@ async def create_pex_binary_run_request(
     chrooted_source_roots = [in_chroot(sr) for sr in sources.source_roots]
     extra_env = {
         **complete_pex_env.environment_dict(python_configured=runner_pex.python is not None),
-        "PEX_PATH": in_chroot(requirements_pex_request.output_filename),
+        "PEX_PATH": ":".join(in_chroot(p.name) for p in Pex.pex_path_closure([requirements])),
         "PEX_EXTRA_SYS_PATH": ":".join(chrooted_source_roots),
     }
 

--- a/src/python/pants/backend/python/goals/run_pex_binary.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary.py
@@ -9,7 +9,7 @@ from pants.backend.python.target_types import (
     ResolvedPexEntryPoint,
     ResolvePexEntryPointRequest,
 )
-from pants.backend.python.util_rules.pex import Pex, PexRequest
+from pants.backend.python.util_rules.pex import Pex, PexRequest, pex_path_closure
 from pants.backend.python.util_rules.pex_environment import PexEnvironment
 from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
 from pants.backend.python.util_rules.python_sources import (
@@ -94,7 +94,7 @@ async def create_pex_binary_run_request(
     chrooted_source_roots = [in_chroot(sr) for sr in sources.source_roots]
     extra_env = {
         **complete_pex_env.environment_dict(python_configured=runner_pex.python is not None),
-        "PEX_PATH": ":".join(in_chroot(p.name) for p in Pex.pex_path_closure([requirements])),
+        "PEX_PATH": ":".join(in_chroot(p.name) for p in pex_path_closure([requirements])),
         "PEX_EXTRA_SYS_PATH": ":".join(chrooted_source_roots),
     }
 

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -128,7 +128,7 @@ async def pylint_lint_partition(
                 interpreter_constraints=partition.interpreter_constraints,
                 main=pylint.main,
                 internal_only=True,
-                pex_path=[pylint_pex, requirements_pex],
+                pex_path=Pex.pex_path_closure([pylint_pex, requirements_pex]),
             ),
         ),
         Get(

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -13,7 +13,13 @@ from pants.backend.python.lint.pylint.subsystem import (
 from pants.backend.python.target_types import InterpreterConstraintsField
 from pants.backend.python.util_rules import pex_from_targets
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.pex import Pex, PexRequest, VenvPex, VenvPexProcess
+from pants.backend.python.util_rules.pex import (
+    Pex,
+    PexRequest,
+    VenvPex,
+    VenvPexProcess,
+    pex_path_closure,
+)
 from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
@@ -128,7 +134,7 @@ async def pylint_lint_partition(
                 interpreter_constraints=partition.interpreter_constraints,
                 main=pylint.main,
                 internal_only=True,
-                pex_path=Pex.pex_path_closure([pylint_pex, requirements_pex]),
+                pex_path=pex_path_closure([pylint_pex, requirements_pex]),
             ),
         ),
         Get(

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -172,7 +172,7 @@ async def mypy_typecheck_partition(
         PexRequest(
             output_filename="requirements_venv.pex",
             internal_only=True,
-            pex_path=[requirements_pex],
+            pex_path=Pex.pex_path_closure([requirements_pex]),
             interpreter_constraints=partition.interpreter_constraints,
         ),
     )

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -15,7 +15,13 @@ from pants.backend.python.typecheck.mypy.subsystem import (
 )
 from pants.backend.python.util_rules import pex_from_targets
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.pex import Pex, PexRequest, VenvPex, VenvPexProcess
+from pants.backend.python.util_rules.pex import (
+    Pex,
+    PexRequest,
+    VenvPex,
+    VenvPexProcess,
+    pex_path_closure,
+)
 from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
@@ -172,7 +178,7 @@ async def mypy_typecheck_partition(
         PexRequest(
             output_filename="requirements_venv.pex",
             internal_only=True,
-            pex_path=Pex.pex_path_closure([requirements_pex]),
+            pex_path=pex_path_closure([requirements_pex]),
             interpreter_constraints=partition.interpreter_constraints,
         ),
     )

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -82,25 +82,25 @@ class LockfileContent:
 class PexRequirements:
     req_strings: FrozenOrderedSet[str]
     apply_constraints: bool
-    repository_pex: Pex | None
+    resolved_dists: ResolvedDistributions | None
 
     def __init__(
         self,
         req_strings: Iterable[str] = (),
         *,
         apply_constraints: bool = False,
-        repository_pex: Pex | None = None,
+        resolved_dists: ResolvedDistributions | None = None,
     ) -> None:
         """
         :param req_strings: The requirement strings to resolve.
         :param apply_constraints: Whether to apply any configured
             requirement_constraints while building this PEX.
-        :param repository_pex: An optional PEX to resolve requirements from via the Pex CLI
-            `--pex-repository` option.
+        :param resolved_dists: An optional ResolvedDistributions instance containing the
+            closed universe of wheels that this PEX should be built from..
         """
         self.req_strings = FrozenOrderedSet(sorted(req_strings))
         self.apply_constraints = apply_constraints
-        self.repository_pex = repository_pex
+        self.resolved_dists = resolved_dists
 
     @classmethod
     def create_from_requirement_fields(
@@ -316,13 +316,13 @@ async def build_pex(
     """Returns a PEX with the given settings."""
     argv = ["--output-file", request.output_filename, *request.additional_args]
 
-    repository_pex = (
-        request.requirements.repository_pex
+    resolved_dists = (
+        request.requirements.resolved_dists
         if isinstance(request.requirements, PexRequirements)
         else None
     )
-    if repository_pex:
-        argv.extend(["--pex-repository", repository_pex.name])
+    if resolved_dists:
+        argv.extend(["--pex-repository", resolved_dists.pex.name])
     else:
         # NB: In setting `--no-pypi`, we rely on the default value of `--python-repos-indexes`
         # including PyPI, which will override `--no-pypi` and result in using PyPI in the default
@@ -390,7 +390,7 @@ async def build_pex(
     )
 
     additional_inputs_digest = request.additional_inputs or EMPTY_DIGEST
-    repository_pex_digest = repository_pex.digest if repository_pex else EMPTY_DIGEST
+    resolved_dists_digest = resolved_dists.pex.digest if resolved_dists else EMPTY_DIGEST
     constraint_file_digest = EMPTY_DIGEST
     requirements_file_digest = EMPTY_DIGEST
 
@@ -443,7 +443,7 @@ async def build_pex(
                 additional_inputs_digest,
                 constraint_file_digest,
                 requirements_file_digest,
-                repository_pex_digest,
+                resolved_dists_digest,
                 *(pex.digest for pex in request.pex_path),
             )
         ),
@@ -548,8 +548,8 @@ def _build_pex_description(request: PexRequest) -> str:
     else:
         if not request.requirements.req_strings:
             return f"Building {request.output_filename}"
-        elif request.requirements.repository_pex:
-            repo_pex = request.requirements.repository_pex.name
+        elif request.requirements.resolved_dists:
+            repo_pex = request.requirements.resolved_dists.pex.name
             return (
                 f"Extracting {pluralize(len(request.requirements.req_strings), 'requirement')} "
                 f"to build {request.output_filename} from {repo_pex}: "
@@ -1018,6 +1018,29 @@ async def determine_pex_resolve_info(pex_pex: PexPEX, pex: Pex) -> PexResolveInf
         ),
     )
     return parse_repository_info(process_result.stdout.decode())
+
+
+@dataclass(frozen=True)
+class ResolvedDistributions:
+    """A 'repository' pex, containing the entire contents of the resolve for multiple libraries.
+
+    Generally constructed from a lockfile.
+    """
+
+    pex: Pex
+
+
+@rule
+async def resolve(request: PexRequest, platform: Platform) -> ResolvedDistributions:
+    # Build the repository PEX.
+    request = dataclasses.replace(
+        request, additional_args=[*request.additional_args, "--include-tools"]
+    )
+    pex = await Get(Pex, PexRequest, request)
+
+    # TODO: extract the graph.
+
+    return ResolvedDistributions(pex)
 
 
 def rules():

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -20,10 +20,10 @@ from pants.backend.python.target_types import (
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import (
     Lockfile,
-    Pex,
     PexPlatforms,
     PexRequest,
     PexRequirements,
+    ResolvedDistributions,
 )
 from pants.backend.python.util_rules.pex import rules as pex_rules
 from pants.backend.python.util_rules.python_sources import (
@@ -164,12 +164,12 @@ class PexFromTargetsRequest:
 
 
 @dataclass(frozen=True)
-class _ConstraintsRepositoryPex:
-    maybe_pex: Pex | None
+class _ConstraintsResolvedDistributions:
+    maybe_resolved_dists: ResolvedDistributions | None
 
 
 @dataclass(frozen=True)
-class _ConstraintsRepositoryPexRequest:
+class _ConstraintsResolvedDistributionsRequest:
     requirements: PexRequirements
     platforms: PexPlatforms
     interpreter_constraints: InterpreterConstraints
@@ -225,11 +225,11 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
     description = request.description
 
     if requirements:
-        repository_pex: Pex | None = None
+        resolved_dists: ResolvedDistributions | None = None
         if python_setup.requirement_constraints:
-            maybe_constraints_repository_pex = await Get(
-                _ConstraintsRepositoryPex,
-                _ConstraintsRepositoryPexRequest(
+            constraints_resolved_dists = await Get(
+                _ConstraintsResolvedDistributions,
+                _ConstraintsResolvedDistributionsRequest(
                     requirements,
                     request.platforms,
                     interpreter_constraints,
@@ -237,8 +237,7 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
                     request.additional_args,
                 ),
             )
-            if maybe_constraints_repository_pex.maybe_pex:
-                repository_pex = maybe_constraints_repository_pex.maybe_pex
+            resolved_dists = constraints_resolved_dists.maybe_resolved_dists
         elif (
             python_setup.resolve_all_constraints
             and python_setup.resolve_all_constraints_was_set_explicitly()
@@ -248,8 +247,8 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
                 "`[python-setup].requirement_constraints` must also be set."
             )
         elif python_setup.lockfile:
-            repository_pex = await Get(
-                Pex,
+            resolved_dists = await Get(
+                ResolvedDistributions,
                 PexRequest(
                     description=f"Resolving {python_setup.lockfile}",
                     output_filename="lockfile.pex",
@@ -268,7 +267,7 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
                     additional_args=request.additional_args,
                 ),
             )
-        requirements = dataclasses.replace(requirements, repository_pex=repository_pex)
+        requirements = dataclasses.replace(requirements, resolved_dists=resolved_dists)
 
     return PexRequest(
         output_filename=request.output_filename,
@@ -286,12 +285,12 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
 
 @rule
 async def _setup_constraints_repository_pex(
-    request: _ConstraintsRepositoryPexRequest, python_setup: PythonSetup
-) -> _ConstraintsRepositoryPex:
+    request: _ConstraintsResolvedDistributionsRequest, python_setup: PythonSetup
+) -> _ConstraintsResolvedDistributions:
     # NB: it isn't safe to resolve against the whole constraints file if
     # platforms are in use. See https://github.com/pantsbuild/pants/issues/12222.
     if not python_setup.resolve_all_constraints or request.platforms:
-        return _ConstraintsRepositoryPex(None)
+        return _ConstraintsResolvedDistributions(None)
 
     constraints_path = python_setup.requirement_constraints
     assert constraints_path is not None
@@ -337,7 +336,7 @@ async def _setup_constraints_repository_pex(
             f"entries for the following requirements: {', '.join(unconstrained_projects)}.\n\n"
             f"Ignoring `[python_setup].resolve_all_constraints` option."
         )
-        return _ConstraintsRepositoryPex(None)
+        return _ConstraintsResolvedDistributions(None)
 
     # To get a full set of requirements we must add the URL requirements to the
     # constraints file, since the latter cannot contain URL requirements.
@@ -348,8 +347,8 @@ async def _setup_constraints_repository_pex(
     #  all these repository pexes will have identical pinned versions of everything,
     #  this is not a correctness issue, only a performance one.
     all_constraints = {str(req) for req in (constraints_file_reqs | url_reqs)}
-    repository_pex = await Get(
-        Pex,
+    resolved_dists = await Get(
+        ResolvedDistributions,
         PexRequest(
             description=f"Resolving {constraints_path}",
             output_filename="repository.pex",
@@ -360,7 +359,7 @@ async def _setup_constraints_repository_pex(
             additional_args=request.additional_args,
         ),
     )
-    return _ConstraintsRepositoryPex(repository_pex)
+    return _ConstraintsResolvedDistributions(resolved_dists)
 
 
 def rules():

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -281,7 +281,6 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
         additional_inputs=request.additional_inputs,
         additional_args=request.additional_args,
         description=description,
-        apply_requirement_constraints=True,
     )
 
 
@@ -355,11 +354,10 @@ async def _setup_constraints_repository_pex(
             description=f"Resolving {constraints_path}",
             output_filename="repository.pex",
             internal_only=request.internal_only,
-            requirements=PexRequirements(all_constraints),
+            requirements=PexRequirements(all_constraints, apply_constraints=True),
             interpreter_constraints=request.interpreter_constraints,
             platforms=request.platforms,
             additional_args=request.additional_args,
-            apply_requirement_constraints=True,
         ),
     )
     return _ConstraintsRepositoryPex(repository_pex)

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -212,13 +212,13 @@ def test_constraints_validation(tmp_path_factory: TempPathFactory, rule_runner: 
         additional_args=additional_args,
     )
     assert pex_req1.requirements == PexRequirements(
-        ["foo-bar>=0.1.2", "bar==5.5.5", "baz", url_req]
+        ["foo-bar>=0.1.2", "bar==5.5.5", "baz", url_req], apply_constraints=True
     )
 
     pex_req1_direct = get_pex_request(
         "constraints1.txt", resolve_all_constraints=False, direct_deps_only=True
     )
-    assert pex_req1_direct.requirements == PexRequirements(["baz", url_req])
+    assert pex_req1_direct.requirements == PexRequirements(["baz", url_req], apply_constraints=True)
 
     pex_req2 = get_pex_request(
         "constraints1.txt",
@@ -299,4 +299,4 @@ def test_issue_12222(rule_runner: RuleRunner) -> None:
     )
     result = rule_runner.request(PexRequest, [request])
 
-    assert result.requirements == PexRequirements(["foo"])
+    assert result.requirements == PexRequirements(["foo"], apply_constraints=True)

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -107,7 +107,6 @@ def create_pex_and_get_all_data(
         sources=sources,
         additional_inputs=additional_inputs,
         additional_args=additional_pex_args,
-        apply_requirement_constraints=True,
     )
     rule_runner.set_options(
         ["--backend-packages=pants.backend.python", *additional_pants_args],
@@ -360,7 +359,7 @@ def test_requirement_constraints(rule_runner: RuleRunner) -> None:
     # Unconstrained, we should always pick the top of the range (requests 2.23.0) since the top of
     # the range is a transitive closure over universal wheels.
     direct_pex_info = create_pex_and_get_pex_info(
-        rule_runner, requirements=PexRequirements(direct_deps)
+        rule_runner, requirements=PexRequirements(direct_deps, apply_constraints=False)
     )
     assert_direct_requirements(direct_pex_info)
     assert "requests-2.23.0-py2.py3-none-any.whl" in set(direct_pex_info["distributions"].keys())
@@ -375,7 +374,7 @@ def test_requirement_constraints(rule_runner: RuleRunner) -> None:
     rule_runner.create_file("constraints.txt", "\n".join(constraints))
     constrained_pex_info = create_pex_and_get_pex_info(
         rule_runner,
-        requirements=PexRequirements(direct_deps),
+        requirements=PexRequirements(direct_deps, apply_constraints=True),
         additional_pants_args=("--python-setup-requirement-constraints=constraints.txt",),
     )
     assert_direct_requirements(constrained_pex_info)
@@ -460,7 +459,7 @@ def test_venv_pex_resolve_info(rule_runner: RuleRunner, pex_type: type[Pex | Ven
     venv_pex = create_pex_and_get_all_data(
         rule_runner,
         pex_type=pex_type,
-        requirements=PexRequirements(["requests==2.23.0"]),
+        requirements=PexRequirements(["requests==2.23.0"], apply_constraints=True),
         additional_pants_args=("--python-setup-requirement-constraints=constraints.txt",),
     )["pex"]
     dists = rule_runner.request(PexResolveInfo, [venv_pex])

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -128,7 +128,7 @@ def create_pex_and_get_all_data(
             Process,
             [
                 PexProcess(
-                    Pex(digest=pex_pex.digest, name=pex_pex.exe, python=pex.python),
+                    Pex(digest=pex_pex.digest, name=pex_pex.exe, python=pex.python, pex_path=()),
                     argv=["-m", "pex.tools", pex.name, "info"],
                     input_digest=pex.digest,
                     extra_env=dict(PEX_INTERPRETER="1"),
@@ -496,7 +496,9 @@ def test_build_pex_description() -> None:
         )
         assert _build_pex_description(request) == expected
 
-    resolved_dists = ResolvedDistributions(Pex(digest=EMPTY_DIGEST, name="repo.pex", python=None))
+    resolved_dists = ResolvedDistributions(
+        Pex(digest=EMPTY_DIGEST, name="repo.pex", python=None, pex_path=())
+    )
 
     assert_description(PexRequirements(), description="Custom!", expected="Custom!")
     assert_description(

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -28,6 +28,7 @@ from pants.backend.python.util_rules.pex import (
     PexRequest,
     PexRequirements,
     PexResolveInfo,
+    ResolvedDistributions,
     VenvPex,
     VenvPexProcess,
     _build_pex_description,
@@ -67,11 +68,12 @@ def parse_requirements(requirements: Iterable[str]) -> Iterator[ExactRequirement
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
-    return RuleRunner(
+    rule_runner = RuleRunner(
         rules=[
             *pex_rules(),
             QueryRule(Pex, (PexRequest,)),
             QueryRule(VenvPex, (PexRequest,)),
+            QueryRule(ResolvedDistributions, (PexRequest,)),
             QueryRule(Process, (PexProcess,)),
             QueryRule(Process, (VenvPexProcess,)),
             QueryRule(ProcessResult, (Process,)),
@@ -80,6 +82,11 @@ def rule_runner() -> RuleRunner:
             QueryRule(PexPEX, ()),
         ],
     )
+    rule_runner.set_options(
+        ["--backend-packages=pants.backend.python"],
+        env_inherit={"PATH", "PYENV_ROOT", "HOME"},
+    )
+    return rule_runner
 
 
 def create_pex_and_get_all_data(
@@ -489,21 +496,21 @@ def test_build_pex_description() -> None:
         )
         assert _build_pex_description(request) == expected
 
-    repo_pex = Pex(EMPTY_DIGEST, "repo.pex", None)
+    resolved_dists = ResolvedDistributions(Pex(digest=EMPTY_DIGEST, name="repo.pex", python=None))
 
     assert_description(PexRequirements(), description="Custom!", expected="Custom!")
     assert_description(
-        PexRequirements(repository_pex=repo_pex), description="Custom!", expected="Custom!"
+        PexRequirements(resolved_dists=resolved_dists), description="Custom!", expected="Custom!"
     )
 
     assert_description(PexRequirements(), expected="Building new.pex")
-    assert_description(PexRequirements(repository_pex=repo_pex), expected="Building new.pex")
+    assert_description(PexRequirements(resolved_dists=resolved_dists), expected="Building new.pex")
 
     assert_description(
         PexRequirements(["req"]), expected="Building new.pex with 1 requirement: req"
     )
     assert_description(
-        PexRequirements(["req"], repository_pex=repo_pex),
+        PexRequirements(["req"], resolved_dists=resolved_dists),
         expected="Extracting 1 requirement to build new.pex from repo.pex: req",
     )
 
@@ -512,7 +519,7 @@ def test_build_pex_description() -> None:
         expected="Building new.pex with 2 requirements: req1, req2",
     )
     assert_description(
-        PexRequirements(["req1", "req2"], repository_pex=repo_pex),
+        PexRequirements(["req1", "req2"], resolved_dists=resolved_dists),
         expected="Extracting 2 requirements to build new.pex from repo.pex: req1, req2",
     )
 

--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -51,7 +51,9 @@ async def resolve_plugins(
     `named_caches` directory), but consequently needs to disable the process cache: see the
     ProcessCacheScope reference in the body.
     """
-    requirements = PexRequirements(sorted(global_options.options.plugins))
+    # The repository's constraints are not relevant here, because this resolve is mixed
+    # into the Pants' process' path, and never into user code.
+    requirements = PexRequirements(sorted(global_options.options.plugins), apply_constraints=False)
     if not requirements:
         return ResolvedPluginDistributions()
 
@@ -72,9 +74,6 @@ async def resolve_plugins(
             python=python,
             requirements=requirements,
             interpreter_constraints=request.interpreter_constraints,
-            # The repository's constraints are not relevant here, because this resolve is mixed
-            # into the Pants' process' path, and never into user code.
-            apply_requirement_constraints=False,
             description=f"Resolving plugins: {', '.join(requirements.req_strings)}",
         ),
     )


### PR DESCRIPTION
As described in #12548 (and further clarified in https://github.com/pantsbuild/pants/issues/12548#issuecomment-906906106), when we extract subsets of a `repository.pex` (which is itself built from a lockfile or constraints file), each of the subsets is likely to be highly redundant. And because the subsets cannot be structure/content shared by the CAS, the result is an increase of storage usage proportional to the number of distinct subsets. Concretely: in some repositories, we observed a ~45X blowup of storage due to ~90 different subsets being constructed.

To fix this, this change moves to constructing each `requirements.pex` subset of a `repository.pex` from a PEX_PATH containing one PEX per root requirement. As implemented here, the storage blowup is reduced to ~4.4X, but as mentioned in #12688, these "single-requirement" PEXes are currently transitive, and it's possible that this could be fixed in the future. 

An alternative to this change would have been to remove the "subsetting" step entirely, and to directly use the entire `repository.pex` in consumers (even if they only used a small fraction of it). But that would have the disadvantage that any change to any requirement would invalidate all consumers in a repository, regardless of whether the requirement was relevant to them, and would additionally violate hermeticity by allowing, for example, `test`s to observe resources that they don't have dependencies on. 

Fixes #12548.

[ci skip-rust]