### PR TITLE
[internal] Rename `generate-lockfiles` to `gen-lockfiles`

### DIFF
--- a/build-support/bin/_generate_all_lockfiles_helper.py
+++ b/build-support/bin/_generate_all_lockfiles_helper.py
@@ -42,8 +42,8 @@ def main() -> None:
             # and egg problem from https://github.com/pantsbuild/pants/issues/12457. We must
             # restore it here so that the lockfile gets generated properly.
             "--python-setup-experimental-lockfile=3rdparty/python/lockfiles/user_reqs.txt",
-            "generate-lockfiles",
-            "generate-user-lockfile",
+            "gen-lockfiles",
+            "gen-user-lockfile",
             "::",
         ],
         check=True,
@@ -129,7 +129,7 @@ def main() -> None:
             f"--coverage-py-interpreter-constraints={repr(CoverageSubsystem.default_interpreter_constraints)}",
             f"--coverage-py-experimental-lockfile={CoverageSubsystem.default_lockfile_path}",
             # Run the goal.
-            "generate-lockfiles",
+            "gen-lockfiles",
         ],
         check=True,
     )

--- a/src/python/pants/backend/experimental/python/user_lockfiles.py
+++ b/src/python/pants/backend/experimental/python/user_lockfiles.py
@@ -20,10 +20,10 @@ from pants.util.strutil import pluralize
 logger = logging.getLogger(__name__)
 
 
-# TODO(#12314): Unify with the `generate-lockfiles` goal. Stop looking at specs and instead have
-#  an option like `--lock-resolves` with a list of named resolves (including tools).
+# TODO(#12314): Unify with the `gen-lockfiles` goal by using its `--resolves` option for named
+#  resolves, rather than taking CLI specs.
 class GenerateUserLockfileSubsystem(GoalSubsystem):
-    name = "generate-user-lockfile"
+    name = "gen-user-lockfile"
     help = "Generate a lockfile for Python user requirements (experimental)."
 
 
@@ -39,7 +39,7 @@ async def generate_user_lockfile_goal(
 ) -> GenerateUserLockfileGoal:
     if python_setup.lockfile is None:
         logger.warning(
-            "You ran `./pants generate-user-lockfile`, but `[python-setup].experimental_lockfile` "
+            "You ran `./pants gen-user-lockfile`, but `[python-setup].experimental_lockfile` "
             "is not set. Please set this option to the path where you'd like the lockfile for "
             "your code's dependencies to live."
         )
@@ -74,7 +74,7 @@ async def generate_user_lockfile_goal(
             ),
             # TODO(12382): Make this command actually accurate once we figure out the semantics
             #  for user lockfiles. This is currently misleading.
-            regenerate_command="./pants generate-user-lockfile ::",
+            regenerate_command="./pants gen-user-lockfile ::",
         ),
     )
     workspace.write_digest(result.digest)

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -85,7 +85,7 @@ class PythonLockfileRequest:
             ),
             dest=subsystem.lockfile,
             description=f"Generate lockfile for {subsystem.options_scope}",
-            regenerate_command="./pants generate-lockfiles",
+            regenerate_command="./pants gen-lockfiles",
         )
 
     @property
@@ -167,7 +167,7 @@ class PythonToolLockfileSentinel:
 
 
 class GenerateLockfilesSubsystem(GoalSubsystem):
-    name = "generate-lockfiles"
+    name = "gen-lockfiles"
     help = "Generate lockfiles for Python third-party dependencies."
     required_union_implementations = (PythonToolLockfileSentinel,)
 

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -99,7 +99,7 @@ class PythonToolRequirementsBase(Subsystem):
                     "recommend this, as lockfiles are essential for reproducible builds.\n\n"
                     "To use a custom lockfile, set this option to a file path relative to the "
                     "build root, then activate the backend_package "
-                    "`pants.backend.experimental.python` and run `./pants generate-lockfiles`.\n\n"
+                    "`pants.backend.experimental.python` and run `./pants gen-lockfiles`.\n\n"
                     "This option is experimental and will likely change. It does not follow the "
                     "normal deprecation cycle."
                 ),

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -123,7 +123,7 @@ class PythonSetup(Subsystem):
                 "multiple lockfiles. This option's behavior may change without the normal "
                 "deprecation cycle.\n\n"
                 "To generate a lockfile, activate the backend `pants.backend.experimental.python`"
-                "and run `./pants generate-user-lockfile ::`.\n\n"
+                "and run `./pants gen-user-lockfile ::`.\n\n"
                 "Mutually exclusive with `[python-setup].requirement_constraints`."
             ),
         )
@@ -138,7 +138,7 @@ class PythonSetup(Subsystem):
             default=None,
             help=(
                 "If set, Pants will instruct your users to run a custom command to regenerate "
-                "lockfiles, rather than running `./pants generate-lockfiles` like normal."
+                "lockfiles, rather than running `./pants gen-lockfiles` like normal."
                 "\n\nThis option is experimental and it may change at any time without the normal "
                 "deprecation cycle."
             ),


### PR DESCRIPTION
See https://github.com/pantsbuild/pants/pull/12641 for why we're using this naming scheme of `generate-lockfiles` instead of something more succinct like `lock`. tl;dr: the semantics for lockfiles will improve in Pants 2.8+, e.g. autogenerating the lockfile when necessary, and we don't want to commit to a highly generic name till that is all worked out.

Still, @benjyw pointed out in https://github.com/pantsbuild/pants/pull/12676 that `gen-lockfiles` is more concise than `generate-lockfiles` and probably does not lose much clarity. We already use the "gen" abbrevation, like `export-codegen`. Note that `gen-lockfiles` is still a verb, which we want for goal names.

[ci skip-rust]
[ci skip-build-wheels]