### PR TITLE
Stop pinning `stevedore<3` by default for Bandit

### DIFF
--- a/src/python/pants/backend/python/lint/bandit/lockfile.txt
+++ b/src/python/pants/backend/python/lint/bandit/lockfile.txt
@@ -4,7 +4,7 @@
 #
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {
-#   "requirements_invalidation_digest": "e70d1fe5ade6ee86ce308b1c69c525afc096c595a846c93577a177167ecce143",
+#   "requirements_invalidation_digest": "91dc76503980fccbc9c1c91f4551db29273838cad28af5234ffcff6687ea7ff0",
 #   "valid_for_interpreter_constraints": [
 #     "CPython>=3.6"
 #   ]
@@ -23,6 +23,9 @@ gitdb==4.0.7; python_version >= "3.6" \
 gitpython==3.1.20; python_version >= "3.6" \
     --hash=sha256:b1e1c269deab1b08ce65403cf14e10d2ef1f6c89e33ea7c5e5bb0222ea593b8a \
     --hash=sha256:df0e072a200703a65387b0cfdf0466e3bab729c0458cf6b7349d0e9877636519
+importlib-metadata==4.7.1; python_version < "3.8" and python_version >= "3.6" \
+    --hash=sha256:9e04bf59076a15a9b6dd9c27806e8fcdf15280ba529c6a8cc3f4d5b4875bdd61 \
+    --hash=sha256:c4eb3dec5f697682e383a39701a7de11cd5c02daf8dd93534b69e3e6473f6b1b
 pbr==5.6.0; python_version >= "3.6" \
     --hash=sha256:c68c661ac5cc81058ac94247278eeda6d2e6aecb3e227b0387c30d277e7ef8d4 \
     --hash=sha256:42df03e7797b796625b1029c0400279c7c34fd7df24a7d7818a1abb5b38710dd
@@ -56,7 +59,7 @@ pyyaml==5.4.1; python_version >= "3.5" and python_full_version < "3.0.0" or pyth
     --hash=sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10 \
     --hash=sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db \
     --hash=sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e
-setuptools==44.1.1; python_full_version == "2.7.*" or python_version > "2.7" \
+setuptools==44.1.1; python_full_version == "2.7.*" or python_version >= "3.5" \
     --hash=sha256:27a714c09253134e60a6fa68130f78c7037e5562c4f21f8f318f2ae900d152d5 \
     --hash=sha256:c67aa55db532a0dadc4d2e20ba9961cbd3ccc84d544e9029699822542b5a476b \
     --hash=sha256:a49230977aa6cfb9d933614d2f7b79036e9945c4cdd7583163f4e920b83418d6 \
@@ -67,10 +70,13 @@ six==1.16.0; python_version >= "3.5" and python_full_version < "3.0.0" or python
 smmap==4.0.0; python_version >= "3.6" \
     --hash=sha256:a9a7479e4c572e2e775c404dcd3080c8dc49f39918c2cf74913d30c4c478e3c2 \
     --hash=sha256:7e65386bd122d45405ddf795637b7f7d2b532e7e401d46bbe3fb49b9986d5182
-stevedore==2.0.1; python_version >= "3.6" \
-    --hash=sha256:c4724f8d7b8f6be42130663855d01a9c2414d6046055b5a65ab58a0e38637688 \
-    --hash=sha256:609912b87df5ad338ff8e44d13eaad4f4170a65b79ae9cb0aa5632598994a1b7
-typing-extensions==3.10.0.0; python_version < "3.10" and python_version >= "3.6" \
+stevedore==3.4.0; python_version >= "3.6" \
+    --hash=sha256:920ce6259f0b2498aaa4545989536a27e4e4607b8318802d7ddc3a533d3d069e \
+    --hash=sha256:59b58edb7f57b11897f150475e7bc0c39c5381f0b8e3fa9f5c20ce6c89ec4aa1
+typing-extensions==3.10.0.0; python_version < "3.8" and python_version >= "3.6" \
     --hash=sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497 \
     --hash=sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84 \
     --hash=sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342
+zipp==3.5.0; python_version < "3.8" and python_version >= "3.6" \
+    --hash=sha256:957cfda87797e389580cb8b9e3870841ca991e2125350677b2ca83a0e99390a3 \
+    --hash=sha256:f5812b1e007e48cff63449a5e9f4e7ebea716b4111f9c4f9a645f91d579bf0c4

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -48,8 +48,7 @@ class Bandit(PythonToolBase):
     default_version = "bandit>=1.7.0,<1.8"
     default_extra_requirements = [
         "setuptools<45; python_full_version == '2.7.*'",
-        "setuptools; python_version > '2.7'",
-        "stevedore<3",  # stevedore 3.0 breaks Bandit.
+        "setuptools; python_version >= '3.5'",
     ]
     default_main = ConsoleScript("bandit")
 


### PR DESCRIPTION
Now that we run Bandit with a `VenvPex`, https://github.com/pantsbuild/pants/issues/10316 should not happen anymore so there is no need to pin stevedore.

[ci skip-rust]
[ci skip-build-wheels]