### PR TITLE
Pin `GitPython==3.1.18` by default with Bandit to ensure yanked release isn't used in lockfile generation

### DIFF
--- a/src/python/pants/backend/python/lint/bandit/lockfile.txt
+++ b/src/python/pants/backend/python/lint/bandit/lockfile.txt
@@ -4,7 +4,7 @@
 #
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {
-#   "requirements_invalidation_digest": "91dc76503980fccbc9c1c91f4551db29273838cad28af5234ffcff6687ea7ff0",
+#   "requirements_invalidation_digest": "f2e4cbc0fd5ee18d6993d689a40be090b961fd7269c8d3c8b72416048e61fd58",
 #   "valid_for_interpreter_constraints": [
 #     "CPython>=3.6"
 #   ]
@@ -20,9 +20,9 @@ colorama==0.4.4; python_version >= "3.5" and python_full_version < "3.0.0" and p
 gitdb==4.0.7; python_version >= "3.6" \
     --hash=sha256:6c4cc71933456991da20917998acbe6cf4fb41eeaab7d6d67fbc05ecd4c865b0 \
     --hash=sha256:96bf5c08b157a666fec41129e6d327235284cca4c81e92109260f353ba138005
-gitpython==3.1.20; python_version >= "3.6" \
-    --hash=sha256:b1e1c269deab1b08ce65403cf14e10d2ef1f6c89e33ea7c5e5bb0222ea593b8a \
-    --hash=sha256:df0e072a200703a65387b0cfdf0466e3bab729c0458cf6b7349d0e9877636519
+gitpython==3.1.18; python_version >= "3.6" \
+    --hash=sha256:fce760879cd2aebd2991b3542876dc5c4a909b30c9d69dfc488e504a8db37ee8 \
+    --hash=sha256:b838a895977b45ab6f0cc926a9045c8d1c44e2b653c1fcc39fe91f42c6e8f05b
 importlib-metadata==4.7.1; python_version < "3.8" and python_version >= "3.6" \
     --hash=sha256:9e04bf59076a15a9b6dd9c27806e8fcdf15280ba529c6a8cc3f4d5b4875bdd61 \
     --hash=sha256:c4eb3dec5f697682e383a39701a7de11cd5c02daf8dd93534b69e3e6473f6b1b

--- a/src/python/pants/backend/python/lint/bandit/lockfile.txt
+++ b/src/python/pants/backend/python/lint/bandit/lockfile.txt
@@ -4,7 +4,7 @@
 #
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {
-#   "requirements_invalidation_digest": "f2e4cbc0fd5ee18d6993d689a40be090b961fd7269c8d3c8b72416048e61fd58",
+#   "requirements_invalidation_digest": "b18a9f4d6a8cb4aafb414e9c8108d39dca053f8910ac801c147a932cd37e0040",
 #   "valid_for_interpreter_constraints": [
 #     "CPython>=3.6"
 #   ]
@@ -59,9 +59,7 @@ pyyaml==5.4.1; python_version >= "3.5" and python_full_version < "3.0.0" or pyth
     --hash=sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10 \
     --hash=sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db \
     --hash=sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e
-setuptools==44.1.1; python_full_version == "2.7.*" or python_version >= "3.5" \
-    --hash=sha256:27a714c09253134e60a6fa68130f78c7037e5562c4f21f8f318f2ae900d152d5 \
-    --hash=sha256:c67aa55db532a0dadc4d2e20ba9961cbd3ccc84d544e9029699822542b5a476b \
+setuptools==57.4.0; python_version >= "3.6" \
     --hash=sha256:a49230977aa6cfb9d933614d2f7b79036e9945c4cdd7583163f4e920b83418d6 \
     --hash=sha256:6bac238ffdf24e8806c61440e755192470352850f3419a52f26ffe0a1a64f465
 six==1.16.0; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5" \

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -127,6 +127,8 @@ def test_uses_correct_python_version(rule_runner: RuleRunner) -> None:
     )
     py2_args = [
         "--bandit-version=bandit>=1.6.2,<1.7",
+        "--bandit-extra-requirements=['setuptools']",
+        "--bandit-lockfile=<none>",
     ]
     py2_tgt = rule_runner.get_target(Address("", target_name="py2", relative_file_path="f.py"))
     py2_result = run_bandit(rule_runner, [py2_tgt], extra_args=py2_args)

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -49,6 +49,10 @@ class Bandit(PythonToolBase):
     default_extra_requirements = [
         "setuptools<45; python_full_version == '2.7.*'",
         "setuptools; python_version >= '3.5'",
+        # GitPython 3.1.20 was yanked because it breaks Python 3.8+, but Poetry's lockfile
+        # generation still tries to use it. Upgrade this to the newest version once released or
+        # when switching away from Poetry.
+        "GitPython==3.1.18",
     ]
     default_main = ConsoleScript("bandit")
 

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -47,8 +47,7 @@ class Bandit(PythonToolBase):
     # remove `setuptools` from `default_extra_requirements`.
     default_version = "bandit>=1.7.0,<1.8"
     default_extra_requirements = [
-        "setuptools<45; python_full_version == '2.7.*'",
-        "setuptools; python_version >= '3.5'",
+        "setuptools",
         # GitPython 3.1.20 was yanked because it breaks Python 3.8+, but Poetry's lockfile
         # generation still tries to use it. Upgrade this to the newest version once released or
         # when switching away from Poetry.

--- a/src/python/pants/backend/python/lint/pylint/BUILD
+++ b/src/python/pants/backend/python/lint/pylint/BUILD
@@ -4,7 +4,7 @@
 python_library(dependencies=[":lockfile"])
 resources(name="lockfile", sources=["lockfile.txt"])
 
-python_tests(name="subsystem_test", sources=["subsystem_test.py"])
+python_tests(name="subsystem_test", sources=["subsystem_test.py"], timeout=120)
 python_tests(
     name="rules_integration_test",
     sources=["rules_integration_test.py"],


### PR DESCRIPTION
Poetry does not support yanked releases yet: https://github.com/python-poetry/poetry/issues/2453. As a result, it tries to use GitPython==3.1.20 in the generated lockfile, which results in this error when using Python 3.8+:

```
pex.environment.ResolveError: Failed to resolve requirements from PEX environment @ /private/var/folders/g7/0lj2pw4d6db67tm8m8xj0rc80000gn/T/process-executionpWU6fG/.tmp/tmpafl9tzo5.
Needed macosx_11_0_arm64-cp-39-cp39 compatible dependencies for:
 1: typing-extensions>=3.7.4.3; python_version < "3.10"
    Required by:
      GitPython 3.1.20
    But this pex had no 'typing-extensions' distributions.
```

The workaround is to pin `GitPython` to an un-yanked release.

Also this stops using a setuptools version that works with Python 2 because the default version of Bandit doesn't work with Py2 anymore.


[ci skip-rust]
[ci skip-build-wheels]