### PR TITLE
[internal] `--generate-lockfiles-resolve` does not determine `PythonLockfileRequest` for unspecified tools

### DIFF
--- a/src/python/pants/backend/awslambda/python/lambdex.py
+++ b/src/python/pants/backend/awslambda/python/lambdex.py
@@ -25,8 +25,8 @@ class Lambdex(PythonToolBase):
     default_lockfile_url = git_url(default_lockfile_path)
 
 
-class LambdexLockfileSentinel:
-    pass
+class LambdexLockfileSentinel(PythonToolLockfileSentinel):
+    options_scope = Lambdex.options_scope
 
 
 @rule

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -74,8 +74,8 @@ class PythonProtobufMypyPlugin(PythonToolRequirementsBase):
     default_lockfile_url = git_url(default_lockfile_path)
 
 
-class MypyProtobufLockfileSentinel:
-    pass
+class MypyProtobufLockfileSentinel(PythonToolLockfileSentinel):
+    options_scope = PythonProtobufMypyPlugin.options_scope
 
 
 @rule

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -216,8 +216,8 @@ class CoverageSubsystem(PythonToolBase):
         return cast(bool, self.options.global_report)
 
 
-class CoveragePyLockfileSentinel:
-    pass
+class CoveragePyLockfileSentinel(PythonToolLockfileSentinel):
+    options_scope = CoverageSubsystem.options_scope
 
 
 @rule

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Iterable, Sequence, cast
+from typing import ClassVar, Iterable, Sequence, cast
 
 from pants.backend.python.subsystems.poetry import (
     POETRY_LAUNCHER,
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 
 @union
 class PythonToolLockfileSentinel:
-    pass
+    options_scope: ClassVar[str]
 
 
 class GenerateLockfilesSubsystem(GoalSubsystem):
@@ -128,6 +128,13 @@ class PythonLockfileRequest:
         rather than the option `--interpreter-constraints`, you must pass the arg
         `interpreter_constraints`.
         """
+        if not subsystem.uses_lockfile:
+            return cls(
+                FrozenOrderedSet(),
+                InterpreterConstraints(),
+                resolve_name=subsystem.options_scope,
+                lockfile_dest=subsystem.lockfile,
+            )
         return cls(
             requirements=FrozenOrderedSet((*subsystem.all_requirements, *extra_requirements)),
             interpreter_constraints=(

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -107,8 +107,8 @@ class Bandit(PythonToolBase):
         )
 
 
-class BanditLockfileSentinel:
-    pass
+class BanditLockfileSentinel(PythonToolLockfileSentinel):
+    options_scope = Bandit.options_scope
 
 
 @rule(
@@ -121,6 +121,9 @@ class BanditLockfileSentinel:
 async def setup_bandit_lockfile(
     _: BanditLockfileSentinel, bandit: Bandit, python_setup: PythonSetup
 ) -> PythonLockfileRequest:
+    if not bandit.uses_lockfile:
+        return PythonLockfileRequest.from_tool(bandit)
+
     # While Bandit will run in partitions, we need a single lockfile that works with every
     # partition.
     #

--- a/src/python/pants/backend/python/lint/bandit/subsystem_test.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem_test.py
@@ -27,7 +27,8 @@ def test_setup_lockfile_interpreter_constraints() -> None:
 
     global_constraint = "==3.9.*"
     rule_runner.set_options(
-        [], env={"PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"}
+        ["--bandit-lockfile=lockfile.txt"],
+        env={"PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"},
     )
 
     def assert_ics(build_file: str, expected: list[str]) -> None:

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -106,8 +106,8 @@ class Black(PythonToolBase):
         )
 
 
-class BlackLockfileSentinel:
-    pass
+class BlackLockfileSentinel(PythonToolLockfileSentinel):
+    options_scope = Black.options_scope
 
 
 @rule(
@@ -117,6 +117,9 @@ class BlackLockfileSentinel:
 async def setup_black_lockfile(
     _: BlackLockfileSentinel, black: Black, python_setup: PythonSetup
 ) -> PythonLockfileRequest:
+    if not black.uses_lockfile:
+        return PythonLockfileRequest.from_tool(black)
+
     constraints = black.interpreter_constraints
     if black.options.is_default("interpreter_constraints"):
         all_build_targets = await Get(UnexpandedTargets, AddressSpecs([DescendantAddresses("")]))

--- a/src/python/pants/backend/python/lint/black/subsystem_test.py
+++ b/src/python/pants/backend/python/lint/black/subsystem_test.py
@@ -27,7 +27,8 @@ def test_setup_lockfile_interpreter_constraints() -> None:
 
     global_constraint = "==3.9.*"
     rule_runner.set_options(
-        [], env={"PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"}
+        ["--black-lockfile=lockfile.txt"],
+        env={"PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"},
     )
 
     def assert_ics(build_file: str, expected: list[str]) -> None:

--- a/src/python/pants/backend/python/lint/docformatter/subsystem.py
+++ b/src/python/pants/backend/python/lint/docformatter/subsystem.py
@@ -58,8 +58,8 @@ class Docformatter(PythonToolBase):
         return tuple(self.options.args)
 
 
-class DocformatterLockfileSentinel:
-    pass
+class DocformatterLockfileSentinel(PythonToolLockfileSentinel):
+    options_scope = Docformatter.options_scope
 
 
 @rule

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -119,8 +119,8 @@ class Flake8(PythonToolBase):
         )
 
 
-class Flake8LockfileSentinel:
-    pass
+class Flake8LockfileSentinel(PythonToolLockfileSentinel):
+    options_scope = Flake8.options_scope
 
 
 @rule(
@@ -133,6 +133,9 @@ class Flake8LockfileSentinel:
 async def setup_flake8_lockfile(
     _: Flake8LockfileSentinel, flake8: Flake8, python_setup: PythonSetup
 ) -> PythonLockfileRequest:
+    if not flake8.uses_lockfile:
+        return PythonLockfileRequest.from_tool(flake8)
+
     # While Flake8 will run in partitions, we need a single lockfile that works with every
     # partition.
     #

--- a/src/python/pants/backend/python/lint/flake8/subsystem_test.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem_test.py
@@ -27,7 +27,8 @@ def test_setup_lockfile_interpreter_constraints() -> None:
 
     global_constraint = "==3.9.*"
     rule_runner.set_options(
-        [], env={"PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"}
+        ["--flake8-lockfile=lockfile.txt"],
+        env={"PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"},
     )
 
     def assert_ics(build_file: str, expected: list[str]) -> None:

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -124,8 +124,8 @@ class Isort(PythonToolBase):
         )
 
 
-class IsortLockfileSentinel:
-    pass
+class IsortLockfileSentinel(PythonToolLockfileSentinel):
+    options_scope = Isort.options_scope
 
 
 @rule

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -229,8 +229,8 @@ async def pylint_first_party_plugins(pylint: Pylint) -> PylintFirstPartyPlugins:
 # --------------------------------------------------------------------------------------
 
 
-class PylintLockfileSentinel:
-    pass
+class PylintLockfileSentinel(PythonToolLockfileSentinel):
+    options_scope = Pylint.options_scope
 
 
 @rule(
@@ -246,6 +246,9 @@ async def setup_pylint_lockfile(
     pylint: Pylint,
     python_setup: PythonSetup,
 ) -> PythonLockfileRequest:
+    if not pylint.uses_lockfile:
+        return PythonLockfileRequest.from_tool(pylint)
+
     # While Pylint will run in partitions, we need a single lockfile that works with every
     # partition. We must also consider any 3rd-party requirements used by 1st-party plugins.
     #

--- a/src/python/pants/backend/python/lint/pylint/subsystem_test.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem_test.py
@@ -108,11 +108,11 @@ def test_setup_lockfile_interpreter_constraints(rule_runner: RuleRunner) -> None
         expected_ics: list[str],
         *,
         extra_expected_requirements: list[str] | None = None,
-        args: list[str] | None = None,
+        extra_args: list[str] | None = None,
     ) -> None:
         rule_runner.write_files({"project/BUILD": build_file})
         rule_runner.set_options(
-            args or [],
+            ["--pylint-lockfile=lockfile.txt", *(extra_args or [])],
             env={"PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"},
         )
         lockfile_request = rule_runner.request(PythonLockfileRequest, [PylintLockfileSentinel()])
@@ -231,7 +231,7 @@ def test_setup_lockfile_interpreter_constraints(rule_runner: RuleRunner) -> None
             """
         ),
         ["==2.7.*,==3.6.*"],
-        args=["--pylint-source-plugins=project:plugin"],
+        extra_args=["--pylint-source-plugins=project:plugin"],
     )
     assert_lockfile_request(
         dedent(
@@ -260,6 +260,6 @@ def test_setup_lockfile_interpreter_constraints(rule_runner: RuleRunner) -> None
             """
         ),
         ["==2.7.*,==3.6.*", "==3.6.*"],
-        args=["--pylint-source-plugins=project"],
+        extra_args=["--pylint-source-plugins=project"],
         extra_expected_requirements=["ansicolors"],
     )

--- a/src/python/pants/backend/python/lint/yapf/subsystem.py
+++ b/src/python/pants/backend/python/lint/yapf/subsystem.py
@@ -116,8 +116,8 @@ class Yapf(PythonToolBase):
         )
 
 
-class YapfLockfileSentinel:
-    pass
+class YapfLockfileSentinel(PythonToolLockfileSentinel):
+    options_scope = Yapf.options_scope
 
 
 @rule

--- a/src/python/pants/backend/python/subsystems/ipython.py
+++ b/src/python/pants/backend/python/subsystems/ipython.py
@@ -47,8 +47,8 @@ class IPython(PythonToolBase):
         )
 
 
-class IPythonLockfileSentinel:
-    pass
+class IPythonLockfileSentinel(PythonToolLockfileSentinel):
+    options_scope = IPython.options_scope
 
 
 @rule(
@@ -61,6 +61,9 @@ class IPythonLockfileSentinel:
 async def setup_ipython_lockfile(
     _: IPythonLockfileSentinel, ipython: IPython, python_setup: PythonSetup
 ) -> PythonLockfileRequest:
+    if not ipython.uses_lockfile:
+        return PythonLockfileRequest.from_tool(ipython)
+
     # IPython is often run against the whole repo (`./pants repl ::`), but it is possible to run
     # on subsets of the codebase with disjoint interpreter constraints, such as
     # `./pants repl py2::` and then `./pants repl py3::`. Still, even with those subsets possible,

--- a/src/python/pants/backend/python/subsystems/ipython_test.py
+++ b/src/python/pants/backend/python/subsystems/ipython_test.py
@@ -22,7 +22,8 @@ def test_setup_lockfile_interpreter_constraints() -> None:
 
     global_constraint = "==3.9.*"
     rule_runner.set_options(
-        [], env={"PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"}
+        ["--ipython-lockfile=lockfile.txt"],
+        env={"PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"},
     )
 
     def assert_ics(build_file: str, expected: list[str]) -> None:

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -240,8 +240,8 @@ class PyTest(PythonToolBase):
         )
 
 
-class PytestLockfileSentinel:
-    pass
+class PytestLockfileSentinel(PythonToolLockfileSentinel):
+    options_scope = PyTest.options_scope
 
 
 @rule(
@@ -254,6 +254,9 @@ class PytestLockfileSentinel:
 async def setup_pytest_lockfile(
     _: PytestLockfileSentinel, pytest: PyTest, python_setup: PythonSetup
 ) -> PythonLockfileRequest:
+    if not pytest.uses_lockfile:
+        return PythonLockfileRequest.from_tool(pytest)
+
     # Even though we run each python_tests target in isolation, we need a single lockfile that
     # works with them all (and their transitive deps).
     #

--- a/src/python/pants/backend/python/subsystems/pytest_test.py
+++ b/src/python/pants/backend/python/subsystems/pytest_test.py
@@ -26,7 +26,8 @@ def test_setup_lockfile_interpreter_constraints() -> None:
 
     global_constraint = "==3.9.*"
     rule_runner.set_options(
-        [], env={"PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"}
+        ["--pytest-lockfile=lockfile.txt"],
+        env={"PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"},
     )
 
     def assert_ics(build_file: str, expected: list[str]) -> None:

--- a/src/python/pants/backend/python/subsystems/setuptools.py
+++ b/src/python/pants/backend/python/subsystems/setuptools.py
@@ -38,8 +38,8 @@ class Setuptools(PythonToolRequirementsBase):
     default_lockfile_url = git_url(default_lockfile_path)
 
 
-class SetuptoolsLockfileSentinel:
-    pass
+class SetuptoolsLockfileSentinel(PythonToolLockfileSentinel):
+    options_scope = Setuptools.options_scope
 
 
 @rule(
@@ -49,6 +49,9 @@ class SetuptoolsLockfileSentinel:
 async def setup_setuptools_lockfile(
     _: SetuptoolsLockfileSentinel, setuptools: Setuptools, python_setup: PythonSetup
 ) -> PythonLockfileRequest:
+    if not setuptools.uses_lockfile:
+        return PythonLockfileRequest.from_tool(setuptools)
+
     all_build_targets = await Get(UnexpandedTargets, AddressSpecs([DescendantAddresses("")]))
     transitive_targets_per_python_dist = await MultiGet(
         Get(TransitiveTargets, TransitiveTargetsRequest([tgt.address]))

--- a/src/python/pants/backend/python/subsystems/setuptools_test.py
+++ b/src/python/pants/backend/python/subsystems/setuptools_test.py
@@ -26,7 +26,8 @@ def test_setup_lockfile_interpreter_constraints() -> None:
 
     global_constraint = "==3.9.*"
     rule_runner.set_options(
-        [], env={"PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"}
+        ["--setuptools-lockfile=lockfile.txt"],
+        env={"PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"},
     )
 
     def assert_ics(build_file: str, expected: list[str]) -> None:

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -252,8 +252,8 @@ async def mypy_first_party_plugins(mypy: MyPy) -> MyPyFirstPartyPlugins:
 # --------------------------------------------------------------------------------------
 
 
-class MyPyLockfileSentinel:
-    pass
+class MyPyLockfileSentinel(PythonToolLockfileSentinel):
+    options_scope = MyPy.options_scope
 
 
 @rule(
@@ -266,6 +266,9 @@ async def setup_mypy_lockfile(
     mypy: MyPy,
     python_setup: PythonSetup,
 ) -> PythonLockfileRequest:
+    if not mypy.uses_lockfile:
+        return PythonLockfileRequest.from_tool(mypy)
+
     constraints = mypy.interpreter_constraints
     if mypy.options.is_default("interpreter_constraints"):
         all_build_targets = await Get(UnexpandedTargets, AddressSpecs([DescendantAddresses("")]))

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem_test.py
@@ -146,11 +146,11 @@ def test_setup_lockfile_interpreter_constraints(rule_runner: RuleRunner) -> None
         expected_ics: list[str],
         *,
         extra_expected_requirements: list[str] | None = None,
-        args: list[str] | None = None,
+        extra_args: list[str] | None = None,
     ) -> None:
         rule_runner.write_files({"project/BUILD": build_file})
         rule_runner.set_options(
-            args or [],
+            ["--mypy-lockfile=lockfile.txt", *(extra_args or [])],
             env={"PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"},
         )
         lockfile_request = rule_runner.request(PythonLockfileRequest, [MyPyLockfileSentinel()])
@@ -244,6 +244,6 @@ def test_setup_lockfile_interpreter_constraints(rule_runner: RuleRunner) -> None
             """
         ),
         MyPy.default_interpreter_constraints,
-        args=["--mypy-source-plugins=project"],
+        extra_args=["--mypy-source-plugins=project"],
         extra_expected_requirements=["ansicolors"],
     )


### PR DESCRIPTION
Improves https://github.com/pantsbuild/pants/pull/12676. Now when `--resolve` is specified, we don't waste time determining the `PythonLockfileRequest` for other tools, which can be quite slow because it requires scanning the repo to determine interpreter constraints.

We also now early return in our `PythonToolLockfileSentinel -> PythonLockfileRequest` rules when lockfiles are disabled for that tool.