### PR TITLE
Simplify implementation of materialize directories

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -3069,7 +3069,6 @@ dependencies = [
  "lmdb",
  "log 0.4.14",
  "madvise",
- "maplit",
  "memmap",
  "mock",
  "num_cpus",

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -195,7 +195,7 @@ impl BuildResultFS {
           .runtime
           .block_on(async move { store.load_file_bytes_with(digest, |_| ()).await })
         {
-          Ok(Some(((), _metadata))) => {
+          Ok(Some(())) => {
             let executable_inode = self.next_inode;
             self.next_inode += 1;
             let non_executable_inode = self.next_inode;
@@ -334,7 +334,7 @@ impl BuildResultFS {
             .block_on(async move { store.load_directory(digest).await });
 
           match maybe_directory {
-            Ok(Some((directory, _metadata))) => {
+            Ok(Some(directory)) => {
               let mut entries = vec![
                 ReaddirEntry {
                   inode: inode,
@@ -479,7 +479,7 @@ impl fuse::Filesystem for BuildResultFS {
                   error!("Error reading directory {:?}: {}", parent_digest, err);
                   libc::EINVAL
                 })?
-                .and_then(|(directory, _metadata)| self.node_for_digest(&directory, filename))
+                .and_then(|directory| self.node_for_digest(&directory, filename))
                 .ok_or(libc::ENOENT)
             })
             .and_then(|node| match node {

--- a/src/rust/engine/fs/store/Cargo.toml
+++ b/src/rust/engine/fs/store/Cargo.toml
@@ -33,6 +33,7 @@ sharded_lmdb = { path = "../../sharded_lmdb" }
 task_executor = { path = "../../task_executor" }
 tempfile = "3"
 tokio-rustls = "0.22"
+tokio = { version = "1.4", features = ["fs"] }
 tonic = { version = "0.5", features = ["transport", "codegen", "tls", "tls-roots", "prost"] }
 tower-service = "0.3"
 tryfuture = { path = "../../tryfuture" }

--- a/src/rust/engine/fs/store/Cargo.toml
+++ b/src/rust/engine/fs/store/Cargo.toml
@@ -41,7 +41,6 @@ workunit_store = {path = "../../workunit_store" }
 
 [dev-dependencies]
 criterion = "0.3"
-maplit = "*"
 mock = { path = "../../testutil/mock" }
 num_cpus = "1"
 testutil = { path = "../../testutil" }

--- a/src/rust/engine/fs/store/benches/store.rs
+++ b/src/rust/engine/fs/store/benches/store.rs
@@ -157,7 +157,7 @@ pub fn criterion_benchmark_merge(c: &mut Criterion) {
   let num_files: usize = 4000;
   let (store, _tempdir, digest) = snapshot(&executor, num_files, 100);
 
-  let (directory, _metadata) = executor
+  let directory = executor
     .block_on(store.load_directory(digest))
     .unwrap()
     .unwrap();

--- a/src/rust/engine/fs/store/benches/store.rs
+++ b/src/rust/engine/fs/store/benches/store.rs
@@ -55,7 +55,7 @@ pub fn criterion_benchmark_materialize(c: &mut Criterion) {
 
   let mut cgroup = c.benchmark_group("materialize_directory");
 
-  for (count, size) in vec![(100, 100), (20, 10_000_000), (1, 200_000_000)] {
+  for (count, size) in vec![(100, 100), (20, 10_000_000), (1, 200_000_000), (10000, 100)] {
     let (store, _tempdir, digest) = snapshot(&executor, count, size);
     let parent_dest = TempDir::new().unwrap();
     let parent_dest_path = parent_dest.path();

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -45,13 +45,12 @@ use std::io::{self, Read, Write};
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use bazel_protos::gen::build::bazel::remote::execution::v2 as remexec;
 use bazel_protos::require_digest;
 use bytes::Bytes;
-use concrete_time::TimeSpan;
 use double_checked_cell_async::DoubleCheckedCell;
 use fs::{default_cache_path, FileContent, RelativePath};
 use futures::future::{self, BoxFuture, Either, FutureExt, TryFutureExt};
@@ -113,94 +112,6 @@ pub struct UploadSummary {
   pub uploaded_file_bytes: usize,
   #[serde(skip)]
   pub upload_wall_time: Duration,
-}
-
-#[derive(Clone, Debug, PartialEq, Serialize)]
-pub enum LoadMetadata {
-  Local,
-  Remote(TimeSpan),
-}
-
-#[derive(Debug, PartialEq, Serialize)]
-pub struct DirectoryMaterializeMetadata {
-  pub metadata: LoadMetadata,
-  pub child_directories: BTreeMap<String, DirectoryMaterializeMetadata>,
-  pub child_files: BTreeMap<String, LoadMetadata>,
-}
-
-impl DirectoryMaterializeMetadata {
-  fn to_relative_paths(&self) -> Result<HashSet<RelativePath>, String> {
-    fn recurse(
-      outputs: &mut HashSet<RelativePath>,
-      path_so_far: RelativePath,
-      current: &DirectoryMaterializeMetadata,
-    ) -> Result<(), String> {
-      for (child, _) in current.child_files.iter() {
-        outputs.insert(path_so_far.join(RelativePath::new(child)?));
-      }
-
-      for (dir, meta) in current.child_directories.iter() {
-        recurse(outputs, path_so_far.join(RelativePath::new(dir)?), meta)?
-      }
-      Ok(())
-    }
-    let mut output_paths: HashSet<RelativePath> = HashSet::new();
-    recurse(&mut output_paths, RelativePath::empty(), self)?;
-    Ok(output_paths)
-  }
-
-  pub fn contains_file(&self, path: &RelativePath) -> bool {
-    self
-      .to_relative_paths()
-      .map_or(false, |paths| paths.contains(path))
-  }
-}
-
-#[derive(Debug)]
-struct DirectoryMaterializeMetadataBuilder {
-  pub metadata: LoadMetadata,
-  pub child_directories: Arc<Mutex<BTreeMap<String, DirectoryMaterializeMetadataBuilder>>>,
-  pub child_files: Arc<Mutex<BTreeMap<String, LoadMetadata>>>,
-}
-
-impl DirectoryMaterializeMetadataBuilder {
-  pub fn new(metadata: LoadMetadata) -> Self {
-    DirectoryMaterializeMetadataBuilder {
-      metadata,
-      child_directories: Arc::new(Mutex::new(BTreeMap::new())),
-      child_files: Arc::new(Mutex::new(BTreeMap::new())),
-    }
-  }
-}
-
-impl DirectoryMaterializeMetadataBuilder {
-  pub fn build(self) -> DirectoryMaterializeMetadata {
-    let child_directories = Arc::try_unwrap(self.child_directories)
-      .unwrap()
-      .into_inner();
-    let child_files = Arc::try_unwrap(self.child_files).unwrap().into_inner();
-    DirectoryMaterializeMetadata {
-      metadata: self.metadata,
-      child_directories: child_directories
-        .into_iter()
-        .map(|(dir, builder)| (dir, builder.build()))
-        .collect(),
-      child_files,
-    }
-  }
-}
-
-#[allow(clippy::type_complexity)]
-#[derive(Debug)]
-enum RootOrParentMetadataBuilder {
-  Root(Arc<Mutex<Option<DirectoryMaterializeMetadataBuilder>>>),
-  Parent(
-    (
-      String,
-      Arc<Mutex<BTreeMap<String, DirectoryMaterializeMetadataBuilder>>>,
-      Arc<Mutex<BTreeMap<String, LoadMetadata>>>,
-    ),
-  ),
 }
 
 #[derive(Clone, Debug)]
@@ -447,7 +358,7 @@ impl Store {
     &self,
     digest: Digest,
     f: F,
-  ) -> Result<Option<(T, LoadMetadata)>, String> {
+  ) -> Result<Option<T>, String> {
     // No transformation or verification is needed for files, so we pass in a pair of functions
     // which always succeed, whether the underlying bytes are coming from a local or remote store.
     // Unfortunately, we need to be a little verbose to do this.
@@ -486,10 +397,7 @@ impl Store {
   /// fingerprint exactly matches that which is requested. Will return an Err if it would return a
   /// non-canonical Directory.
   ///
-  pub async fn load_directory(
-    &self,
-    digest: Digest,
-  ) -> Result<Option<(remexec::Directory, LoadMetadata)>, String> {
+  pub async fn load_directory(&self, digest: Digest) -> Result<Option<remexec::Directory>, String> {
     self
       .load_bytes_with(
         EntryType::Directory,
@@ -539,17 +447,16 @@ impl Store {
     digest: Digest,
     f_local: FLocal,
     f_remote: FRemote,
-  ) -> Result<Option<(T, LoadMetadata)>, String> {
+  ) -> Result<Option<T>, String> {
     let local = self.local.clone();
     let maybe_remote = self.remote.clone();
-    let start = SystemTime::now();
     let maybe_local_value = self
       .local
       .load_bytes_with(entry_type, digest, f_local)
       .await?;
 
     match (maybe_local_value, maybe_remote) {
-      (Some(value_result), _) => value_result.map(|res| Some((res, LoadMetadata::Local))),
+      (Some(value_result), _) => value_result.map(Some),
       (None, None) => Ok(None),
       (None, Some(remote_store)) => {
         let remote = remote_store.store.clone();
@@ -572,8 +479,7 @@ impl Store {
             let value = f_remote(bytes.clone())?;
             let stored_digest = local.store_bytes(entry_type, bytes, true).await?;
             if digest == stored_digest {
-              let time_span = TimeSpan::since(&start);
-              Ok(Some((value, LoadMetadata::Remote(time_span))))
+              Ok(Some(value))
             } else {
               Err(format!(
                 "CAS gave wrong digest: expected {:?}, got {:?}",
@@ -749,9 +655,7 @@ impl Store {
     loaded_directory
       .and_then(move |directory_opt| {
         future::ready(
-          directory_opt
-            .map(|(dir, _metadata)| dir)
-            .ok_or_else(|| format!("Could not read dir with digest {:?}", dir_digest)),
+          directory_opt.ok_or_else(|| format!("Could not read dir with digest {:?}", dir_digest)),
         )
       })
       .and_then(move |directory| {
@@ -1025,46 +929,34 @@ impl Store {
     &self,
     destination: PathBuf,
     digest: Digest,
-  ) -> BoxFuture<'static, Result<DirectoryMaterializeMetadata, String>> {
-    let root = Arc::new(Mutex::new(None));
+  ) -> BoxFuture<'static, Result<(), String>> {
     self
-      .materialize_directory_helper(
-        destination,
-        RootOrParentMetadataBuilder::Root(root.clone()),
-        digest,
-      )
-      .and_then(move |()| {
-        future::ready(Ok(
-          Arc::try_unwrap(root).unwrap().into_inner().unwrap().build(),
-        ))
-      })
+      .materialize_directory_helper(destination, true, digest)
       .boxed()
   }
 
   fn materialize_directory_helper(
     &self,
     destination: PathBuf,
-    root_or_parent_metadata: RootOrParentMetadataBuilder,
+    is_root: bool,
     digest: Digest,
   ) -> BoxFuture<'static, Result<(), String>> {
     let store = self.clone();
     async move {
-      let directory_creation =
-        if let RootOrParentMetadataBuilder::Root(..) = root_or_parent_metadata {
-          let destination = destination.clone();
-          store
-            .local
-            .executor()
-            .spawn_blocking(move || fs::safe_create_dir_all(&destination))
-            .await
-        } else {
-          let destination = destination.clone();
-          store
-            .local
-            .executor()
-            .spawn_blocking(move || fs::safe_create_dir(&destination))
-            .await
-        };
+      let destination2 = destination.clone();
+      let directory_creation = if is_root {
+        store
+          .local
+          .executor()
+          .spawn_blocking(move || fs::safe_create_dir_all(&destination2))
+          .await
+      } else {
+        store
+          .local
+          .executor()
+          .spawn_blocking(move || fs::safe_create_dir(&destination2))
+          .await
+      };
       directory_creation.map_err(|e| {
         format!(
           "Failed to create directory {}: {}",
@@ -1073,31 +965,10 @@ impl Store {
         )
       })?;
 
-      let (directory, metadata) = store
+      let directory = store
         .load_directory(digest)
         .await?
         .ok_or_else(|| format!("Directory with digest {:?} not found", digest))?;
-
-      let (child_directories, child_files) = match root_or_parent_metadata {
-        RootOrParentMetadataBuilder::Root(root) => {
-          let builder = DirectoryMaterializeMetadataBuilder::new(metadata);
-          let child_directories = builder.child_directories.clone();
-          let child_files = builder.child_files.clone();
-          *root.lock() = Some(builder);
-          (child_directories, child_files)
-        }
-        RootOrParentMetadataBuilder::Parent((
-          dir_name,
-          parent_child_directories,
-          _parent_files,
-        )) => {
-          let builder = DirectoryMaterializeMetadataBuilder::new(metadata);
-          let child_directories = builder.child_directories.clone();
-          let child_files = builder.child_files.clone();
-          parent_child_directories.lock().insert(dir_name, builder);
-          (child_directories, child_files)
-        }
-      };
 
       let file_futures = directory
         .files
@@ -1106,11 +977,8 @@ impl Store {
           let store = store.clone();
           let path = destination.join(file_node.name.clone());
           let digest = try_future!(require_digest(file_node.digest.as_ref()));
-          let child_files = child_files.clone();
-          let name = file_node.name.to_owned();
           store
             .materialize_file(path, digest, file_node.is_executable)
-            .map(move |result| result.map(|metadata| child_files.lock().insert(name, metadata)))
             .boxed()
         })
         .collect::<Vec<_>>();
@@ -1122,13 +990,7 @@ impl Store {
           let path = destination.join(directory_node.name.clone());
           let digest = try_future!(require_digest(directory_node.digest.as_ref()));
 
-          let builder = RootOrParentMetadataBuilder::Parent((
-            directory_node.name.to_owned(),
-            child_directories.clone(),
-            child_files.clone(),
-          ));
-
-          store.materialize_directory_helper(path, builder, digest)
+          store.materialize_directory_helper(path, false, digest)
         })
         .collect::<Vec<_>>();
       let _ = future::try_join(
@@ -1147,7 +1009,7 @@ impl Store {
     destination: PathBuf,
     digest: Digest,
     is_executable: bool,
-  ) -> BoxFuture<'static, Result<LoadMetadata, String>> {
+  ) -> BoxFuture<'static, Result<(), String>> {
     let store = self.clone();
     let res = async move {
       let write_result = store
@@ -1174,8 +1036,8 @@ impl Store {
         })
         .await?;
       match write_result {
-        Some((Ok(()), metadata)) => Ok(metadata),
-        Some((Err(e), _metadata)) => Err(e),
+        Some(Ok(())) => Ok(()),
+        Some(Err(e)) => Err(e),
         None => Err(format!("File with digest {:?} not found", digest)),
       }
     };
@@ -1206,7 +1068,7 @@ impl Store {
                   .await?;
                 maybe_bytes
                   .ok_or_else(|| format!("Couldn't find file contents for {:?}", path))
-                  .map(|(content, _metadata)| FileContent {
+                  .map(|content| FileContent {
                     path,
                     content,
                     is_executable,
@@ -1290,7 +1152,7 @@ impl Store {
     let res = async move {
       let maybe_directory = store.load_directory(digest).await?;
       match maybe_directory {
-        Some((directory, _metadata)) => {
+        Some(directory) => {
           let result_for_directory = f(&store, &path_so_far, digest, &directory).await?;
           {
             let mut accumulator = accumulator.lock();
@@ -1339,19 +1201,11 @@ impl StoreWrapper for Store {
     digest: Digest,
     f: F,
   ) -> Result<Option<T>, String> {
-    Ok(
-      Store::load_file_bytes_with(self, digest, f)
-        .await?
-        .map(|(value, _)| value),
-    )
+    Ok(Store::load_file_bytes_with(self, digest, f).await?)
   }
 
   async fn load_directory(&self, digest: Digest) -> Result<Option<remexec::Directory>, String> {
-    Ok(
-      Store::load_directory(self, digest)
-        .await?
-        .map(|(dir, _)| dir),
-    )
+    Ok(Store::load_directory(self, digest).await?)
   }
 
   async fn load_directory_or_err(&self, digest: Digest) -> Result<remexec::Directory, String> {

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -349,6 +349,7 @@ impl ByteStore {
     digest: Digest,
     f: F,
   ) -> Result<Option<T>, ByteStoreError> {
+    let start = Instant::now();
     let store = self.clone();
     let instance_name = store.instance_name.clone().unwrap_or_default();
     let resource_name = format!(
@@ -438,6 +439,10 @@ impl ByteStore {
     };
 
     if let Some(workunit_store_handle) = workunit_store::get_workunit_store_handle() {
+      workunit_store_handle.store.record_observation(
+        ObservationMetric::RemoteStoreReadBlobTimeMicros,
+        start.elapsed().as_micros() as u64,
+      );
       in_workunit!(
         workunit_store_handle.store,
         workunit_name,

--- a/src/rust/engine/fs/store/src/snapshot.rs
+++ b/src/rust/engine/fs/store/src/snapshot.rs
@@ -220,9 +220,7 @@ impl Snapshot {
     digest: Digest,
   ) -> Result<remexec::Directory, String> {
     let maybe_dir = store.load_directory(digest).await?;
-    maybe_dir
-      .map(|(dir, _metadata)| dir)
-      .ok_or_else(|| format!("{:?} was not known", digest))
+    maybe_dir.ok_or_else(|| format!("{:?} was not known", digest))
   }
 
   ///

--- a/src/rust/engine/fs/store/src/snapshot_ops_tests.rs
+++ b/src/rust/engine/fs/store/src/snapshot_ops_tests.rs
@@ -135,11 +135,7 @@ impl StoreWrapper for LoadTrackingStore {
     digest: Digest,
     f: F,
   ) -> Result<Option<T>, String> {
-    Ok(
-      Store::load_file_bytes_with(&self.store, digest, f)
-        .await?
-        .map(|(value, _)| value),
-    )
+    Ok(Store::load_file_bytes_with(&self.store, digest, f).await?)
   }
 
   async fn load_directory(&self, digest: Digest) -> Result<Option<remexec::Directory>, String> {
@@ -148,11 +144,7 @@ impl StoreWrapper for LoadTrackingStore {
       let entry = counts.entry(digest).or_insert(0);
       *entry += 1;
     }
-    Ok(
-      Store::load_directory(&self.store, digest)
-        .await?
-        .map(|(dir, _)| dir),
-    )
+    Ok(Store::load_directory(&self.store, digest).await?)
   }
 
   async fn load_directory_or_err(&self, digest: Digest) -> Result<remexec::Directory, String> {

--- a/src/rust/engine/fs/store/src/snapshot_tests.rs
+++ b/src/rust/engine/fs/store/src/snapshot_tests.rs
@@ -272,7 +272,7 @@ async fn snapshot_merge_two_files() {
     .merge(vec![snapshot1.digest, snapshot2.digest])
     .await
     .unwrap();
-  let merged_root_directory = store.load_directory(merged).await.unwrap().unwrap().0;
+  let merged_root_directory = store.load_directory(merged).await.unwrap().unwrap();
 
   assert_eq!(merged_root_directory.files.len(), 0);
   assert_eq!(merged_root_directory.directories.len(), 1);
@@ -286,8 +286,7 @@ async fn snapshot_merge_two_files() {
     .load_directory(merged_child_dirnode_digest.unwrap())
     .await
     .unwrap()
-    .unwrap()
-    .0;
+    .unwrap();
 
   assert_eq!(merged_child_dirnode.name, common_dir_name);
   assert_eq!(

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -149,7 +149,7 @@ async fn recover_from_missing_store_contents() {
   // than just the root of the output is present when hitting the cache.
   {
     let output_dir_digest = first_result.output_directory;
-    let (output_dir, _) = store
+    let output_dir = store
       .load_directory(output_dir_digest)
       .await
       .unwrap()

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -454,17 +454,27 @@ pub trait CapturedWorkdir {
       .local_paths(&req.append_only_caches)
       .collect::<Vec<_>>();
 
+    // Capture argv0 as the executable path so that we can test whether we have created it in the
+    // sandbox.
+    let maybe_executable_path = RelativePath::new(&req.argv[0]).map(|relative_path| {
+      if let Some(working_directory) = &req.working_directory {
+        working_directory.join(relative_path)
+      } else {
+        relative_path
+      }
+    });
+
     // Start with async materialization of input snapshots, followed by synchronous materialization
     // of other configured inputs. Note that we don't do this in parallel, as that might cause
     // non-determinism when paths overlap.
-    let sandbox = store
+    store
       .materialize_directory(workdir_path.clone(), req.input_files)
       .await?;
     let workdir_path2 = workdir_path.clone();
     let output_file_paths = req.output_files.clone();
     let output_dir_paths = req.output_directories.clone();
     let maybe_jdk_home = req.jdk_home.clone();
-    executor
+    let exclusive_spawn = executor
       .spawn_blocking(move || {
         if let Some(jdk_home) = maybe_jdk_home {
           symlink(jdk_home, workdir_path2.join(".jdk"))
@@ -509,23 +519,20 @@ pub trait CapturedWorkdir {
           })?;
         }
 
-        let res: Result<_, String> = Ok(());
+        let exe_was_materialized = maybe_executable_path
+          .as_ref()
+          .map_or(false, |p| workdir_path2.join(&p).exists());
+        if exe_was_materialized {
+          debug!(
+            "Obtaining exclusive spawn lock for process since \
+                 we materialized its executable {:?}.",
+            maybe_executable_path
+          );
+        }
+        let res: Result<_, String> = Ok(exe_was_materialized);
         res
       })
       .await?;
-
-    let exclusive_spawn = RelativePath::new(&req.argv[0]).map_or(false, |relative_path| {
-      let executable_path = if let Some(working_directory) = &req.working_directory {
-        working_directory.join(relative_path)
-      } else {
-        relative_path
-      };
-      let exe_was_materialized = sandbox.contains_file(&executable_path);
-      if exe_was_materialized {
-        debug!("Obtaining exclusive spawn lock for process with argv {:?} since we materialized its executable {:?}.", &req.argv, executable_path);
-      }
-      exe_was_materialized
-    });
 
     // Spawn the process.
     // NB: We fully buffer up the `Stream` above into final `ChildResults` below and so could

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -606,16 +606,14 @@ async fn run_command_locally_in_dir(
     cleanup,
   );
   let original = runner.run(Context::default(), workunit, req.into()).await?;
-  let stdout_bytes: Vec<u8> = store
-    .load_file_bytes_with(original.stdout_digest, |bytes| bytes.into())
+  let stdout_bytes = store
+    .load_file_bytes_with(original.stdout_digest, |bytes| bytes.to_vec())
     .await?
-    .unwrap()
-    .0;
-  let stderr_bytes: Vec<u8> = store
-    .load_file_bytes_with(original.stderr_digest, |bytes| bytes.into())
+    .unwrap();
+  let stderr_bytes = store
+    .load_file_bytes_with(original.stderr_digest, |bytes| bytes.to_vec())
     .await?
-    .unwrap()
-    .0;
+    .unwrap();
   Ok(LocalTestResult {
     original,
     stdout_bytes,

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -134,7 +134,7 @@ impl CommandRunner {
 
       // Load the Directory proto corresponding to `current_directory_digest`.
       let current_directory = match store.load_directory(current_directory_digest).await? {
-        Some((dir, _)) => dir,
+        Some(dir) => dir,
         None => {
           return Err(format!(
             "Directory digest {:?} was referenced in output, but was not found in store.",
@@ -168,7 +168,7 @@ impl CommandRunner {
 
     while let Some(directory_digest) = digest_queue.pop_front() {
       let directory = match store.load_directory(directory_digest).await? {
-        Some((dir, _)) => dir,
+        Some(dir) => dir,
         None => {
           return Err(format!(
             "illegal state: directory for digest {:?} did not exist locally",
@@ -216,7 +216,7 @@ impl CommandRunner {
 
         // Load the Directory proto corresponding to `current_directory_digest`.
         let current_directory = match store.load_directory(current_directory_digest).await? {
-          Some((dir, _)) => dir,
+          Some(dir) => dir,
           None => {
             return Err(format!(
               "Directory digest {:?} was referenced in output, but was not found in store.",
@@ -244,7 +244,7 @@ impl CommandRunner {
 
     // Load the final directory.
     let directory = match store.load_directory(current_directory_digest).await? {
-      Some((dir, _)) => dir,
+      Some(dir) => dir,
       None => return Ok(None),
     };
 

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -1111,8 +1111,7 @@ async fn ensure_inline_stdio_is_stored() {
         .load_file_bytes_with(test_stdout.digest(), |v| Bytes::copy_from_slice(v))
         .await
         .unwrap()
-        .unwrap()
-        .0,
+        .unwrap(),
       test_stdout.bytes()
     );
     assert_eq!(
@@ -1120,8 +1119,7 @@ async fn ensure_inline_stdio_is_stored() {
         .load_file_bytes_with(test_stderr.digest(), |v| Bytes::copy_from_slice(v))
         .await
         .unwrap()
-        .unwrap()
-        .0,
+        .unwrap(),
       test_stderr.bytes()
     );
   }
@@ -2192,16 +2190,14 @@ pub(crate) async fn run_cmd_runner<R: crate::CommandRunner>(
   let original = command_runner
     .run(Context::default(), &mut workunit, request)
     .await?;
-  let stdout_bytes: Vec<u8> = store
-    .load_file_bytes_with(original.stdout_digest, |bytes| bytes.into())
+  let stdout_bytes = store
+    .load_file_bytes_with(original.stdout_digest, |bytes| bytes.to_vec())
     .await?
-    .unwrap()
-    .0;
-  let stderr_bytes: Vec<u8> = store
-    .load_file_bytes_with(original.stderr_digest, |bytes| bytes.into())
+    .unwrap();
+  let stderr_bytes = store
+    .load_file_bytes_with(original.stderr_digest, |bytes| bytes.to_vec())
     .await?
-    .unwrap()
-    .0;
+    .unwrap();
   Ok(RemoteTestResult {
     original,
     stdout_bytes,
@@ -2250,16 +2246,14 @@ async fn run_command_remote(
     .run(Context::default(), &mut workunit, request)
     .await?;
 
-  let stdout_bytes: Vec<u8> = store
-    .load_file_bytes_with(original.stdout_digest, |bytes| bytes.into())
+  let stdout_bytes = store
+    .load_file_bytes_with(original.stdout_digest, |bytes| bytes.to_vec())
     .await?
-    .unwrap()
-    .0;
-  let stderr_bytes: Vec<u8> = store
-    .load_file_bytes_with(original.stderr_digest, |bytes| bytes.into())
+    .unwrap();
+  let stderr_bytes = store
+    .load_file_bytes_with(original.stderr_digest, |bytes| bytes.to_vec())
     .await?
-    .unwrap()
-    .0;
+    .unwrap();
   Ok(RemoteTestResult {
     original,
     stdout_bytes,
@@ -2307,18 +2301,16 @@ async fn extract_execute_response(
     .await?;
 
   let stdout_bytes: Vec<u8> = store
-    .load_file_bytes_with(original.stdout_digest, |bytes| bytes.into())
+    .load_file_bytes_with(original.stdout_digest, |bytes| bytes.to_vec())
     .await
     .unwrap()
-    .unwrap()
-    .0;
+    .unwrap();
 
   let stderr_bytes: Vec<u8> = store
-    .load_file_bytes_with(original.stderr_digest, |bytes| bytes.into())
+    .load_file_bytes_with(original.stderr_digest, |bytes| bytes.to_vec())
     .await
     .unwrap()
-    .unwrap()
-    .0;
+    .unwrap();
 
   Ok(RemoteTestResult {
     original,

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -349,15 +349,13 @@ async fn main() {
     .load_file_bytes_with(result.stdout_digest, |bytes| bytes.to_vec())
     .await
     .unwrap()
-    .unwrap()
-    .0;
+    .unwrap();
 
   let stderr: Vec<u8> = store
     .load_file_bytes_with(result.stderr_digest, |bytes| bytes.to_vec())
     .await
     .unwrap()
-    .unwrap()
-    .0;
+    .unwrap();
 
   print!("{}", String::from_utf8(stdout).unwrap());
   eprint!("{}", String::from_utf8(stderr).unwrap());
@@ -457,7 +455,6 @@ async fn extract_request_from_action_digest(
     .load_file_bytes_with(action_digest, |bytes| Action::decode(bytes))
     .await?
     .ok_or_else(|| format!("Could not find action proto in CAS: {:?}", action_digest))?
-    .0
     .map_err(|err| {
       format!(
         "Error deserializing action proto {:?}: {:?}",
@@ -471,7 +468,6 @@ async fn extract_request_from_action_digest(
     .load_file_bytes_with(command_digest, |bytes| Command::decode(bytes))
     .await?
     .ok_or_else(|| format!("Could not find command proto in CAS: {:?}", command_digest))?
-    .0
     .map_err(|err| {
       format!(
         "Error deserializing command proto {:?}: {:?}",
@@ -581,7 +577,6 @@ async fn extract_request_from_buildbarn_url(
         })
         .await?
         .ok_or_else(|| "Couldn't fetch action result proto".to_owned())?
-        .0
         .map_err(|err| format!("Error deserializing action result proto: {:?}", err))?;
 
       require_digest(&action_result.action_digest)?

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1703,10 +1703,8 @@ fn single_file_digests_to_bytes(
         store
           .load_file_bytes_with(digest, externs::store_bytes)
           .await
-          .and_then(|maybe_bytes: Option<(Value, _)>| {
-            maybe_bytes
-              .map(|bytes_tuple| bytes_tuple.0)
-              .ok_or_else(|| format!("Error loading bytes from digest: {:?}", digest))
+          .and_then(|maybe_bytes| {
+            maybe_bytes.ok_or_else(|| format!("Error loading bytes from digest: {:?}", digest))
           })
       }
     });

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -162,23 +162,19 @@ fn multi_platform_process_request_to_process_result(
       .await
       .map_err(|s| throw(&s))?;
 
-    let stdout_bytes = maybe_stdout
-      .map(|(bytes, _load_metadata)| bytes)
-      .ok_or_else(|| {
-        throw(&format!(
-          "Bytes from stdout Digest {:?} not found in store",
-          result.stdout_digest
-        ))
-      })?;
+    let stdout_bytes = maybe_stdout.ok_or_else(|| {
+      throw(&format!(
+        "Bytes from stdout Digest {:?} not found in store",
+        result.stdout_digest
+      ))
+    })?;
 
-    let stderr_bytes = maybe_stderr
-      .map(|(bytes, _load_metadata)| bytes)
-      .ok_or_else(|| {
-        throw(&format!(
-          "Bytes from stderr Digest {:?} not found in store",
-          result.stderr_digest
-        ))
-      })?;
+    let stderr_bytes = maybe_stderr.ok_or_else(|| {
+      throw(&format!(
+        "Bytes from stderr Digest {:?} not found in store",
+        result.stderr_digest
+      ))
+    })?;
 
     let platform_name: String = result.platform.into();
     Ok(externs::unsafe_call(

--- a/src/rust/engine/workunit_store/src/metrics.rs
+++ b/src/rust/engine/workunit_store/src/metrics.rs
@@ -93,9 +93,11 @@ pub enum ObservationMetric {
   TestObservation,
   LocalProcessTimeRunMs,
   LocalStoreReadBlobSize,
+  LocalStoreReadBlobTimeMicros,
   RemoteProcessTimeRunMs,
   RemoteExecutionRPCFirstResponseTime,
   RemoteStoreTimeToFirstByte,
+  RemoteStoreReadBlobTimeMicros,
   /// The time saved (in milliseconds) thanks to a local cache hit instead of running the process
   /// directly.
   LocalCacheTimeSavedMs,


### PR DESCRIPTION
The `DirectoryMaterializeMetadata` reported by `materialize_directory` was added before we had good metrics reporting infrastructure, and was only actually reported in `fs_util` (where no users consume it any longer). Replacing `DirectoryMaterializeMetadata` with two histograms loses some fidelity, but clarifies the code and eases optimization.

After removing `DirectoryMaterializeMetadata`, also applies a small change to spawn directory creation in parallel with loading the `Directory` struct from the `Store`.

```
materialize_directory/materialize_directory(100, 100)
                        time:   [49.014 ms 49.796 ms 50.205 ms]
                        change: [-17.052% -14.766% -12.126%] (p = 0.00 < 0.05)
                        Performance has improved.
materialize_directory/materialize_directory(20, 10000000)
                        time:   [149.97 ms 153.69 ms 157.95 ms]
                        change: [-4.1772% -1.0069% +1.9043%] (p = 0.56 > 0.05)
                        No change in performance detected.
materialize_directory/materialize_directory(1, 200000000)
                        time:   [153.50 ms 154.72 ms 156.90 ms]
                        change: [-5.8662% -2.7765% +0.5632%] (p = 0.14 > 0.05)
                        No change in performance detected.
materialize_directory/materialize_directory(10000, 100)
                        time:   [5.5121 s 5.6473 s 5.7598 s]
                        change: [-18.344% -15.582% -12.832%] (p = 0.00 < 0.05)
                        Performance has improved.
```

(For posterity: I also attempted to convert the recursive `materialize_directories_helper` to iteration on `FuturesUnordered`: while possibly [slightly clearer](https://github.com/stuhood/pants/commit/9856443baf2e763224407d5f7d5e1aaef77ef17b), it was a few percentage points slower.)

[ci skip-build-wheels]