### PR TITLE
[internal] Simplify `pants.toml` parsing now that subscopes are removed

### DIFF
--- a/src/python/pants/option/config.py
+++ b/src/python/pants/option/config.py
@@ -348,17 +348,17 @@ class _ConfigValues:
         section_values = self.values.get(section)
         if section_values is None:
             raise configparser.NoSectionError(section)
-        result = OrderedSet(
+        result = [
             option
             for option, option_value in section_values.items()
             if self._is_an_option(option_value)
-        )
-        result.update(
+        ]
+        result.extend(
             default_option
             for default_option in self.defaults.keys()
             if default_option not in result
         )
-        return list(result)
+        return result
 
     def _maybe_deprecated_default(self, option: str) -> None:
         matched = option == "pants_supportdir"

--- a/src/python/pants/option/config.py
+++ b/src/python/pants/option/config.py
@@ -203,57 +203,11 @@ class _ConfigValues:
     def _is_an_option(option_value: _TomlValue | dict) -> bool:
         """Determine if the value is actually an option belonging to that section.
 
-        A value that looks like an option might actually be a subscope, e.g. the option value
-        `java` belonging to the section `cache` could actually be the section `cache.java`, rather
-        than the option `--cache-java`.
-
-        We must also handle the special syntax of `my_list_option.add` and `my_list_option.remove`.
+        This handles the special syntax of `my_list_option.add` and `my_list_option.remove`.
         """
         if isinstance(option_value, dict):
             return "add" in option_value or "remove" in option_value
         return True
-
-    @classmethod
-    def _section_explicitly_defined(cls, section_values: Dict) -> bool:
-        """Determine if the section is truly a defined section, meaning that the user explicitly
-        wrote the section in their config file.
-
-        For example, the user may have explicitly defined `cache.java` but never defined `cache`.
-        Due to TOML's representation of the config as a nested dictionary, naively, it would appear
-        that `cache` was defined even though the user never explicitly added it to their config.
-        """
-        # TODO: Once we properly ban scopes with dots in them, we can get rid of this check.
-        at_least_one_option_defined = any(
-            cls._is_an_option(section_value) for section_value in section_values.values()
-        )
-        # We also check if the section was explicitly defined but has no options. We can be
-        # confident that this is not a parent scope (e.g. `cache` when `cache.java` is really what
-        # was defined) because the parent scope would store its child scope in its values, so the
-        # values would not be empty.
-        blank_section = len(section_values.values()) == 0
-        return at_least_one_option_defined or blank_section
-
-    def _find_section_values(self, section: str) -> dict | None:
-        """Find the values for a section, if any.
-
-        For example, if the config file was `{'GLOBAL': {'foo': 1}}`, this function would return
-        `{'foo': 1}` given `section='GLOBAL'`.
-        """
-
-        def recurse(mapping: Dict, *, remaining_sections: List[str]) -> dict | None:
-            if not remaining_sections:
-                return None
-            current_section = remaining_sections[0]
-            if current_section not in mapping:
-                return None
-            section_values = mapping[current_section]
-            if len(remaining_sections) > 1:
-                return recurse(section_values, remaining_sections=remaining_sections[1:])
-            if not self._section_explicitly_defined(section_values):
-                return None
-            return cast(Dict, section_values)
-
-        return recurse(mapping=self.values, remaining_sections=section.split("."))
 
     def _possibly_interpolate_value(
         self,
@@ -346,27 +300,11 @@ class _ConfigValues:
         )
 
     @property
-    def sections(self) -> List[str]:
-        sections: List[str] = []
-
-        def recurse(mapping: Dict, *, parent_section: str | None = None) -> None:
-            for section, section_values in mapping.items():
-                if not isinstance(section_values, dict):
-                    continue
-                # We filter out "DEFAULT" and also check for the special `my_list_option.add` and
-                # `my_list_option.remove` syntax.
-                if section == "DEFAULT" or "add" in section_values or "remove" in section_values:
-                    continue
-                section_name = section if not parent_section else f"{parent_section}.{section}"
-                if self._section_explicitly_defined(section_values):
-                    sections.append(section_name)
-                recurse(section_values, parent_section=section_name)
-
-        recurse(self.values)
-        return sections
+    def sections(self) -> list[str]:
+        return [scope for scope in self.values if scope != "DEFAULT"]
 
     def has_section(self, section: str) -> bool:
-        return self._find_section_values(section) is not None
+        return section in self.values
 
     def has_option(self, section: str, option: str) -> bool:
         try:
@@ -377,7 +315,7 @@ class _ConfigValues:
             return True
 
     def get_value(self, section: str, option: str) -> str | None:
-        section_values = self._find_section_values(section)
+        section_values = self.values.get(section)
         if section_values is None:
             raise configparser.NoSectionError(section)
         stringify = partial(
@@ -406,21 +344,21 @@ class _ConfigValues:
             return remove_val
         return stringify(option_value)
 
-    def options(self, section: str) -> List[str]:
-        section_values = self._find_section_values(section)
+    def options(self, section: str) -> list[str]:
+        section_values = self.values.get(section)
         if section_values is None:
             raise configparser.NoSectionError(section)
-        result = [
+        result = OrderedSet(
             option
             for option, option_value in section_values.items()
             if self._is_an_option(option_value)
-        ]
-        result.extend(
+        )
+        result.update(
             default_option
             for default_option in self.defaults.keys()
             if default_option not in result
         )
-        return result
+        return list(result)
 
     def _maybe_deprecated_default(self, option: str) -> None:
         matched = option == "pants_supportdir"
@@ -448,13 +386,13 @@ class _SingleFileConfig(Config):
     content_digest: str
     values: _ConfigValues
 
-    def configs(self) -> List["_SingleFileConfig"]:
+    def configs(self) -> list[_SingleFileConfig]:
         return [self]
 
-    def sources(self) -> List[str]:
+    def sources(self) -> list[str]:
         return [self.config_path]
 
-    def sections(self) -> List[str]:
+    def sections(self) -> list[str]:
         return self.values.sections
 
     def has_section(self, section: str) -> bool:
@@ -488,20 +426,20 @@ class _ChainedConfig(Config):
     """Config read from multiple sources."""
 
     # Config instances to chain. Later instances take precedence over earlier ones.
-    chained_configs: Tuple[_SingleFileConfig, ...]
+    chained_configs: tuple[_SingleFileConfig, ...]
 
     @property
-    def _configs(self) -> Tuple[_SingleFileConfig, ...]:
+    def _configs(self) -> tuple[_SingleFileConfig, ...]:
         return self.chained_configs
 
-    def configs(self) -> Tuple[_SingleFileConfig, ...]:
+    def configs(self) -> tuple[_SingleFileConfig, ...]:
         return self.chained_configs
 
-    def sources(self) -> List[str]:
+    def sources(self) -> list[str]:
         # NB: Present the sources in the order we were given them.
         return list(itertools.chain.from_iterable(cfg.sources() for cfg in reversed(self._configs)))
 
-    def sections(self) -> List[str]:
+    def sections(self) -> list[str]:
         ret: OrderedSet[str] = OrderedSet()
         for cfg in self._configs:
             ret.update(cfg.sections())

--- a/src/python/pants/option/config_test.py
+++ b/src/python/pants/option/config_test.py
@@ -259,6 +259,6 @@ def test_toml_serializer() -> None:
 
 def test_toml_serializer_list_add_remove() -> None:
     original_values = {"GLOBAL": {"backend_packages.add": ["added"]}}
-    assert TomlSerializer(original_values).normalize() == {
+    assert TomlSerializer(original_values).normalize() == {  # type: ignore[arg-type]
         "GLOBAL": {"backend_packages": "+['added']"}
     }

--- a/src/python/pants/option/config_test.py
+++ b/src/python/pants/option/config_test.py
@@ -249,24 +249,16 @@ def test_toml_serializer() -> None:
             "listy": ["a", "b", "c"],
             "map": {"a": 0, "b": 1},
         },
-        "cache.java": {"o": ""},
-        "inception.nested.nested-again.one-more": {"o": ""},
+        "some-subsystem": {"o": ""},
     }
     assert TomlSerializer(original_values).normalize() == {
         "GLOBAL": {**original_values["GLOBAL"], "map": "{'a': 0, 'b': 1}"},
-        "cache": {"java": {"o": ""}},
-        "inception": {"nested": {"nested-again": {"one-more": {"o": ""}}}},
+        "some-subsystem": {"o": ""},
     }
 
 
-def test_toml_serializer_add_remove() -> None:
-    original_values: Dict = {
-        "GLOBAL": {
-            "backend_packages.add": ["added"],
-        },
-    }
+def test_toml_serializer_list_add_remove() -> None:
+    original_values = {"GLOBAL": {"backend_packages.add": ["added"]}}
     assert TomlSerializer(original_values).normalize() == {
-        "GLOBAL": {
-            "backend_packages": "+['added']",
-        },
+        "GLOBAL": {"backend_packages": "+['added']"}
     }

--- a/src/python/pants/option/config_test.py
+++ b/src/python/pants/option/config_test.py
@@ -45,17 +45,6 @@ FILE_1 = ConfigFile(
         [b]
         preempt = true
 
-        [b.nested]
-        dict = '''
-        {
-          "a": 1,
-          "b": "%(answer)s",
-          "c": ["%(answer)s", "%(answer)s"],
-        }'''
-
-        [b.nested.nested-again]
-        movie = "inception"
-
         [c]
         name = "overridden_from_default"
         interpolated_from_section = "%(name)s is interpolated"
@@ -73,8 +62,6 @@ FILE_1 = ConfigFile(
     expected_options={
         "a": {"list": '["1", "2", "3", "42"]', "list2": "+[7, 8, 9]", "list3": '-["x", "y", "z"]'},
         "b": {"preempt": "True"},
-        "b.nested": {"dict": '{\n  "a": 1,\n  "b": "42",\n  "c": ["42", "42"],\n}'},
-        "b.nested.nested-again": {"movie": "inception"},
         "c": {
             "name": "overridden_from_default",
             "interpolated_from_section": "overridden_from_default is interpolated",
@@ -98,9 +85,6 @@ FILE_2 = ConfigFile(
         list.remove = [8, 9]
 
         [empty_section]
-
-        [p.child]
-        no_values_in_parent = true
         """
     ),
     default_values={},
@@ -109,7 +93,6 @@ FILE_2 = ConfigFile(
         "b": {"preempt": "False"},
         "d": {"list": "+[0, 1],-[8, 9]"},
         "empty_section": {},
-        "p.child": {"no_values_in_parent": "True"},
     },
 )
 
@@ -139,15 +122,12 @@ class ConfigTest(unittest.TestCase):
         }
 
     def test_sections(self) -> None:
-        expected_sections = list(
-            OrderedSet([*FILE_2.expected_options.keys(), *FILE_1.expected_options.keys()])
+        expected_sections = OrderedSet(
+            [*FILE_2.expected_options.keys(), *FILE_1.expected_options.keys()]
         )
-        assert self.config.sections() == expected_sections
+        assert self.config.sections() == list(expected_sections)
         for section in expected_sections:
             assert self.config.has_section(section) is True
-        # We should only look at explicitly defined sections. For example, if `cache.java` is
-        # defined but `cache` is not, then `cache` should not be included in the sections.
-        assert self.config.has_section("p") is False
 
     def test_has_option(self) -> None:
         # Check has all DEFAULT values

--- a/src/python/pants/option/options_bootstrapper_test.py
+++ b/src/python/pants/option/options_bootstrapper_test.py
@@ -183,18 +183,18 @@ class OptionsBootstrapperTest(unittest.TestCase):
             options = options_bootstrapper.full_options_for_scopes(
                 known_scope_infos=[
                     ScopeInfo(""),
-                    ScopeInfo("compile.apt"),
+                    ScopeInfo("compile_apt"),
                     ScopeInfo("fruit"),
                 ],
             )
             # So we don't choke on these on the cmd line.
             options.register("", "--pants-config-files", type=list)
             options.register("", "--config-override", type=list)
-            options.register("compile.apt", "--worker-count")
+            options.register("compile_apt", "--worker-count")
             options.register("fruit", "--apple")
 
             self.assertEqual(
-                str(expected_worker_count), options.for_scope("compile.apt").worker_count
+                str(expected_worker_count), options.for_scope("compile_apt").worker_count
             )
             self.assertEqual("red", options.for_scope("fruit").apple)
 
@@ -202,7 +202,7 @@ class OptionsBootstrapperTest(unittest.TestCase):
             fp1.write(
                 dedent(
                     """\
-                    [compile.apt]
+                    [compile_apt]
                     worker_count = 1
 
                     [fruit]
@@ -213,7 +213,7 @@ class OptionsBootstrapperTest(unittest.TestCase):
             fp2.write(
                 dedent(
                     """\
-                    [compile.apt]
+                    [compile_apt]
                     worker_count = 2
                     """
                 )


### PR DESCRIPTION
[ci skip-rust]
[ci skip-build-wheels]