### PR TITLE
[internal] Link to pants slack from pypi project page

### DIFF
--- a/pants-plugins/internal_plugins/releases/register.py
+++ b/pants-plugins/internal_plugins/releases/register.py
@@ -122,6 +122,8 @@ async def pants_setup_kwargs(
             "Tracker": "https://github.com/pantsbuild/pants/issues",
             "Changelog": "https://www.pantsbuild.org/docs/changelog",
             "Twitter": "https://twitter.com/pantsbuild",
+            "Slack": "https://pantsbuild.slack.com/join/shared_invite/zt-d0uh0mok-RLvVosDiX6JDpvStH~bFBA#/shared-invite/email",
+            "YouTube": "https://www.youtube.com/channel/UCCcfCbDqtqlCkFEuENsHlbQ",
         },
         license="Apache License, Version 2.0",
         zip_safe=True,


### PR DESCRIPTION
It seems that pypi can parse [Slack](https://github.com/pypa/warehouse/blob/3943226cf1168f5cead40913d42603e9d1f25010/warehouse/templates/packaging/detail.html#L46-L47) and [YouTube](https://github.com/pypa/warehouse/blob/3943226cf1168f5cead40913d42603e9d1f25010/warehouse/templates/packaging/detail.html#L56-L57), so adding making those links available from the pypi project page seems useful.