### PR TITLE
[internal] Add `[python-setup].experimental_resolves_to_lockfiles` and hook up to `./pants generate-lockfiles`

### DIFF
--- a/src/python/pants/backend/python/goals/lockfile_test.py
+++ b/src/python/pants/backend/python/goals/lockfile_test.py
@@ -28,11 +28,7 @@ def test_determine_tool_sentinels_to_generate() -> None:
     class Tool3(PythonToolLockfileSentinel):
         options_scope = "tool3"
 
-    all_user_resolves = {
-        "u1": "some_lockfile.txt",
-        "u2": "another_lockfile.txt",
-        "u3": "yet_another_lockfile.txt",
-    }
+    all_user_resolves = ["u1", "u2", "u3"]
 
     def assert_chosen(
         requested: list[str],
@@ -42,9 +38,7 @@ def test_determine_tool_sentinels_to_generate() -> None:
         user_resolves, tools = determine_resolves_to_generate(
             all_user_resolves, [Tool1, Tool2, Tool3], requested
         )
-        assert user_resolves == {
-            resolve: all_user_resolves[resolve] for resolve in expected_user_resolves
-        }
+        assert user_resolves == expected_user_resolves
         assert tools == expected_tools
 
     assert_chosen(

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -128,6 +128,19 @@ class PythonSetup(Subsystem):
             ),
         )
         register(
+            "--experimental-resolves-to-lockfiles",
+            advanced=True,
+            type=dict,
+            help=(
+                "A mapping of logical names to lockfile paths used in your project, e.g. "
+                "`{ default = '3rdparty/default_lockfile.txt', py2 = '3rdparty/py2.txt' }`.\n\n"
+                "To generate a lockfile, run `./pants generate-lockfiles --resolve=<name>` or "
+                "`./pants generate-lockfiles` to generate for all resolves (including tool "
+                "lockfiles).\n\n"
+                "This is highly experimental and will likely change."
+            ),
+        )
+        register(
             "--invalid-lockfile-behavior",
             advanced=True,
             type=InvalidLockfileBehavior,
@@ -219,6 +232,10 @@ class PythonSetup(Subsystem):
     @property
     def lockfile(self) -> str | None:
         return cast("str | None", self.options.experimental_lockfile)
+
+    @property
+    def resolves_to_lockfiles(self) -> dict[str, str]:
+        return cast("dict[str, str]", self.options.experimental_resolves_to_lockfiles)
 
     @property
     def invalid_lockfile_behavior(self) -> InvalidLockfileBehavior:


### PR DESCRIPTION
This option does not currently do anything..but it will be where users define their "named resolve":

```toml
[python-setup]
resolves_to_lockfiles = { default = "default_lock.txt", data-science = "ds_lock.txt" }
```

Then, users can set `resolve="data-science"` on targets.

They can generate the lockfile with `./pants generate-lockfiles --resolve='data-science'`.

--

This PR is prework to add the option and wire it up to `./pants generate-lockfiles`, including checking that the named resolve is not ambiguous with a tool's resolve name (its option scope).

[ci skip-rust]
[ci skip-build-wheels]