### PR TITLE
Stop interpolating `pants_supportdir` in `pants.toml` and deprecate the option

### DIFF
--- a/src/python/pants/option/config.py
+++ b/src/python/pants/option/config.py
@@ -18,7 +18,6 @@ import toml
 from typing_extensions import Protocol
 
 from pants.base.build_environment import get_buildroot
-from pants.base.deprecated import deprecated_conditional
 from pants.option.ranked_value import Value
 from pants.util.eval import parse_expression
 from pants.util.ordered_set import OrderedSet

--- a/src/python/pants/option/config.py
+++ b/src/python/pants/option/config.py
@@ -23,8 +23,7 @@ from pants.option.ranked_value import Value
 from pants.util.eval import parse_expression
 from pants.util.ordered_set import OrderedSet
 
-# A dict with optional override seed values for buildroot, pants_workdir, pants_supportdir and
-# pants_distdir.
+# A dict with optional override seed values for buildroot, pants_workdir, and pants_distdir.
 SeedValues = Dict[str, Value]
 
 
@@ -129,7 +128,6 @@ class Config(ABC):
             )
 
         update_seed_values("pants_workdir", default_dir=".pants.d")
-        update_seed_values("pants_supportdir", default_dir="build-support")
         update_seed_values("pants_distdir", default_dir="dist")
 
         return all_seed_values
@@ -247,7 +245,6 @@ class _ConfigValues:
             match = re.search(r"%\(([a-zA-Z_0-9]*)\)s", value)
             if not match:
                 return value
-            self._maybe_deprecated_default(match.group(1))
             return recursively_format_str(value=format_str(value))
 
         return recursively_format_str(raw_value)
@@ -360,16 +357,6 @@ class _ConfigValues:
                 if default_option not in section_values
             ),
         ]
-
-    def _maybe_deprecated_default(self, option: str) -> None:
-        matched = option == "pants_supportdir"
-        value = self.defaults[option] if matched else None
-        deprecated_conditional(
-            lambda: matched,
-            "2.8.0.dev0",
-            "The `pants_supportdir` default value in `pants.toml`",
-            hint=f"Replace use of the variable with the literal: {repr(value)}.",
-        )
 
     @property
     def defaults(self) -> dict[str, str]:

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -630,11 +630,10 @@ class GlobalOptions(Subsystem):
             "--pants-supportdir",
             advanced=True,
             metavar="<dir>",
-            deprecation_start_version="2.8.0.dev0",
             removal_version="2.9.0.dev0",
             removal_hint="Unused: this option has no necessary equivalent in v2.",
             default=os.path.join(buildroot, "build-support"),
-            help="Used only for templating in `pants.toml`.",
+            help="Does not do anything.",
         )
         register(
             "--pants-distdir",

--- a/src/python/pants/option/options_bootstrapper_test.py
+++ b/src/python/pants/option/options_bootstrapper_test.py
@@ -51,7 +51,6 @@ class OptionsBootstrapperTest(unittest.TestCase):
             env: Optional[Dict[str, str]] = None,
             args: Optional[List[str]] = None,
             workdir: Optional[str] = None,
-            supportdir: Optional[str] = None,
             distdir: Optional[str] = None,
         ) -> None:
             self.assert_bootstrap_options(
@@ -59,7 +58,6 @@ class OptionsBootstrapperTest(unittest.TestCase):
                 env=env,
                 args=args,
                 pants_workdir=workdir or os.path.join(get_buildroot(), ".pants.d"),
-                pants_supportdir=supportdir or os.path.join(get_buildroot(), "build-support"),
                 pants_distdir=distdir or os.path.join(get_buildroot(), "dist"),
             )
 
@@ -71,23 +69,16 @@ class OptionsBootstrapperTest(unittest.TestCase):
             config={"pants_workdir": "/from_config/.pants.d"},
             workdir="/from_config/.pants.d",
         )
-        assert_seed_values(
-            env={"PANTS_SUPPORTDIR": "/from_env/build-support"},
-            supportdir="/from_env/build-support",
-        )
         assert_seed_values(args=["--pants-distdir=/from_args/dist"], distdir="/from_args/dist")
 
         # Check that args > env > config.
         assert_seed_values(
             config={
                 "pants_workdir": "/from_config/.pants.d",
-                "pants_supportdir": "/from_config/build-support",
                 "pants_distdir": "/from_config/dist",
             },
-            env={"PANTS_SUPPORTDIR": "/from_env/build-support", "PANTS_DISTDIR": "/from_env/dist"},
             args=["--pants-distdir=/from_args/dist"],
             workdir="/from_config/.pants.d",
-            supportdir="/from_env/build-support",
             distdir="/from_args/dist",
         )
 
@@ -95,18 +86,15 @@ class OptionsBootstrapperTest(unittest.TestCase):
         assert_seed_values(
             config={
                 "pants_workdir": "/from_config/.pants.d",
-                "pants_supportdir": "/from_config/build-support",
                 "pants_distdir": "/from_config/dist",
                 "unrelated": "foo",
             },
             env={
-                "PANTS_SUPPORTDIR": "/from_env/build-support",
                 "PANTS_DISTDIR": "/from_env/dist",
                 "PANTS_NO_RELATIONSHIP": "foo",
             },
             args=["--pants-distdir=/from_args/dist", "--foo=bar", "--baz"],
             workdir="/from_config/.pants.d",
-            supportdir="/from_env/build-support",
             distdir="/from_args/dist",
         )
 
@@ -130,14 +118,14 @@ class OptionsBootstrapperTest(unittest.TestCase):
                     bar = "%(pants_workdir)s/baz"
 
                     [fruit]
-                    apple = "%(pants_supportdir)s/banana"
+                    apple = "%(pants_distdir)s/banana"
                     """
                 )
             )
             fp.close()
             args = ["--pants-workdir=/qux"] + self._config_path(fp.name)
             bootstrapper = OptionsBootstrapper.create(
-                env={"PANTS_SUPPORTDIR": "/pear"}, args=args, allow_pantsrc=False
+                env={"PANTS_DISTDIR": "/pear"}, args=args, allow_pantsrc=False
             )
             opts = bootstrapper.full_options_for_scopes(
                 known_scope_infos=[
@@ -156,7 +144,7 @@ class OptionsBootstrapperTest(unittest.TestCase):
         self.assertEqual("/pear/banana", opts.for_scope("fruit").apple)
 
     def test_bootstrapped_options_ignore_irrelevant_env(self) -> None:
-        included = "PANTS_SUPPORTDIR"
+        included = "PANTS_DISTDIR"
         excluded = "NON_PANTS_ENV"
         bootstrapper = OptionsBootstrapper.create(
             env={excluded: "pear", included: "banana"}, args=[], allow_pantsrc=False


### PR DESCRIPTION
[ci skip-rust]
[ci skip-build-wheels]