### PR TITLE
Remove deprecated `[grpc_python_plugin]` in favor of `[grpc-python-plugin]`

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/python/grpc_python_plugin.py
+++ b/src/python/pants/backend/codegen/protobuf/python/grpc_python_plugin.py
@@ -7,8 +7,6 @@ from pants.core.util_rules.external_tool import TemplatedExternalTool
 class GrpcPythonPlugin(TemplatedExternalTool):
     options_scope = "grpc-python-plugin"
     help = "The gRPC Protobuf plugin for Python."
-    deprecated_options_scope = "grpc_python_plugin"
-    deprecated_options_scope_removal_version = "2.8.0.dev0"
 
     default_version = "1.32.0"
     default_known_versions = [


### PR DESCRIPTION
Now we can enforce that subsystems use `-` instead of `_`. This is a useful heuristic because both targets and individual options use `_`.

[ci skip-rust]
[ci skip-build-wheels]