### PR TITLE
Support TOML tables for dict options in pants.toml

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -93,52 +93,6 @@ args = ["--external-sources"]
 # See https://github.com/mvdan/sh/blob/master/cmd/shfmt/shfmt.1.scd#printer-flags.
 args = ["-i 2", "-ci", "-sr"]
 
-[pants-releases]
-release_notes = """
-{
-  'master': 'src/python/pants/notes/master.rst',
-  '1.0.x': 'src/python/pants/notes/1.0.x.rst',
-  '1.1.x': 'src/python/pants/notes/1.1.x.rst',
-  '1.2.x': 'src/python/pants/notes/1.2.x.rst',
-  '1.3.x': 'src/python/pants/notes/1.3.x.rst',
-  '1.4.x': 'src/python/pants/notes/1.4.x.rst',
-  '1.5.x': 'src/python/pants/notes/1.5.x.rst',
-  '1.6.x': 'src/python/pants/notes/1.6.x.rst',
-  '1.7.x': 'src/python/pants/notes/1.7.x.rst',
-  '1.8.x': 'src/python/pants/notes/1.8.x.rst',
-  '1.9.x': 'src/python/pants/notes/1.9.x.rst',
-  '1.10.x': 'src/python/pants/notes/1.10.x.rst',
-  '1.11.x': 'src/python/pants/notes/1.11.x.rst',
-  '1.12.x': 'src/python/pants/notes/1.12.x.rst',
-  '1.13.x': 'src/python/pants/notes/1.13.x.rst',
-  '1.14.x': 'src/python/pants/notes/1.14.x.rst',
-  '1.15.x': 'src/python/pants/notes/1.15.x.rst',
-  '1.16.x': 'src/python/pants/notes/1.16.x.rst',
-  '1.17.x': 'src/python/pants/notes/1.17.x.rst',
-  '1.18.x': 'src/python/pants/notes/1.18.x.rst',
-  '1.19.x': 'src/python/pants/notes/1.19.x.rst',
-  '1.20.x': 'src/python/pants/notes/1.20.x.rst',
-  '1.21.x': 'src/python/pants/notes/1.21.x.rst',
-  '1.22.x': 'src/python/pants/notes/1.22.x.rst',
-  '1.23.x': 'src/python/pants/notes/1.23.x.rst',
-  '1.24.x': 'src/python/pants/notes/1.24.x.rst',
-  '1.25.x': 'src/python/pants/notes/1.25.x.rst',
-  '1.26.x': 'src/python/pants/notes/1.26.x.rst',
-  '1.27.x': 'src/python/pants/notes/1.27.x.rst',
-  '1.28.x': 'src/python/pants/notes/1.28.x.rst',
-  '1.29.x': 'src/python/pants/notes/1.29.x.rst',
-  '1.30.x': 'src/python/pants/notes/1.30.x.rst',
-  '2.0.x': 'src/python/pants/notes/2.0.x.rst',
-  '2.1.x': 'src/python/pants/notes/2.1.x.rst',
-  '2.2.x': 'src/python/pants/notes/2.2.x.md',
-  '2.3.x': 'src/python/pants/notes/2.3.x.md',
-  '2.4.x': 'src/python/pants/notes/2.4.x.md',
-  '2.5.x': 'src/python/pants/notes/2.5.x.md',
-  '2.6.x': 'src/python/pants/notes/2.6.x.md',
-  '2.7.x': 'src/python/pants/notes/2.7.x.md',
-}
-"""
-
 [pytest]
 args = ["--no-header"]
 extra_requirements.add = [
@@ -176,3 +130,45 @@ repo = "pants"
 
 [buildsense]
 enable = false
+
+[pants-releases.release_notes]
+master = "src/python/pants/notes/master.rst"
+"1.0.x" = "src/python/pants/notes/1.0.x.rst"
+"1.1.x" = "src/python/pants/notes/1.1.x.rst"
+"1.2.x" = "src/python/pants/notes/1.2.x.rst"
+"1.3.x" = "src/python/pants/notes/1.3.x.rst"
+"1.4.x" = "src/python/pants/notes/1.4.x.rst"
+"1.5.x" = "src/python/pants/notes/1.5.x.rst"
+"1.6.x" = "src/python/pants/notes/1.6.x.rst"
+"1.7.x" = "src/python/pants/notes/1.7.x.rst"
+"1.8.x" = "src/python/pants/notes/1.8.x.rst"
+"1.9.x" = "src/python/pants/notes/1.9.x.rst"
+"1.10.x" = "src/python/pants/notes/1.10.x.rst"
+"1.11.x" = "src/python/pants/notes/1.11.x.rst"
+"1.12.x" = "src/python/pants/notes/1.12.x.rst"
+"1.13.x" = "src/python/pants/notes/1.13.x.rst"
+"1.14.x" = "src/python/pants/notes/1.14.x.rst"
+"1.15.x" = "src/python/pants/notes/1.15.x.rst"
+"1.16.x" = "src/python/pants/notes/1.16.x.rst"
+"1.17.x" = "src/python/pants/notes/1.17.x.rst"
+"1.18.x" = "src/python/pants/notes/1.18.x.rst"
+"1.19.x" = "src/python/pants/notes/1.19.x.rst"
+"1.20.x" = "src/python/pants/notes/1.20.x.rst"
+"1.21.x" = "src/python/pants/notes/1.21.x.rst"
+"1.22.x" = "src/python/pants/notes/1.22.x.rst"
+"1.23.x" = "src/python/pants/notes/1.23.x.rst"
+"1.24.x" = "src/python/pants/notes/1.24.x.rst"
+"1.25.x" = "src/python/pants/notes/1.25.x.rst"
+"1.26.x" = "src/python/pants/notes/1.26.x.rst"
+"1.27.x" = "src/python/pants/notes/1.27.x.rst"
+"1.28.x" = "src/python/pants/notes/1.28.x.rst"
+"1.29.x" = "src/python/pants/notes/1.29.x.rst"
+"1.30.x" = "src/python/pants/notes/1.30.x.rst"
+"2.0.x" = "src/python/pants/notes/2.0.x.rst"
+"2.1.x" = "src/python/pants/notes/2.1.x.rst"
+"2.2.x" = "src/python/pants/notes/2.2.x.md"
+"2.3.x" = "src/python/pants/notes/2.3.x.md"
+"2.4.x" = "src/python/pants/notes/2.4.x.md"
+"2.5.x" = "src/python/pants/notes/2.5.x.md"
+"2.6.x" = "src/python/pants/notes/2.6.x.md"
+"2.7.x" = "src/python/pants/notes/2.7.x.md"

--- a/src/python/pants/option/config.py
+++ b/src/python/pants/option/config.py
@@ -332,11 +332,14 @@ class _ConfigValues:
         if not isinstance(option_value, dict):
             return stringify(option_value)
 
-        # Handle the special `my_list_option.add` and `my_list_option.remove` syntax.
-        has_add = "add" in option_value
-        has_remove = "remove" in option_value
+        # Handle dict options, along with the special `my_list_option.add` and
+        # `my_list_option.remove` syntax. We only treat `add` and `remove` as the special list
+        # syntax if the values are lists to reduce the risk of incorrectly special casing.
+        has_add = isinstance(option_value.get("add"), list)
+        has_remove = isinstance(option_value.get("remove"), list)
         if not has_add and not has_remove:
-            raise configparser.NoOptionError(option, section)
+            return stringify(option_value)
+
         add_val = stringify(option_value["add"], list_prefix="+") if has_add else None
         remove_val = stringify(option_value["remove"], list_prefix="-") if has_remove else None
         if has_add and has_remove:

--- a/src/python/pants/option/config_test.py
+++ b/src/python/pants/option/config_test.py
@@ -49,6 +49,12 @@ FILE_1 = ConfigFile(
         name = "overridden_from_default"
         interpolated_from_section = "%(name)s is interpolated"
         recursively_interpolated_from_section = "%(interpolated_from_section)s (again)"
+
+        [d.dict_val]
+        # Make sure we don't misinterpret `add` and `remove` as list options.
+        add = 0
+        remove = 0
+        nested = { nested_key = 'foo' }
         """
     ),
     default_values={
@@ -67,6 +73,7 @@ FILE_1 = ConfigFile(
             "interpolated_from_section": "overridden_from_default is interpolated",
             "recursively_interpolated_from_section": "overridden_from_default is interpolated (again)",
         },
+        "d": {"dict_val": "{'add': 0, 'remove': 0, 'nested': {'nested_key': 'foo'}"},
     },
 )
 


### PR DESCRIPTION
This is now possible:

```toml
[python-setup]
resolves_to_lockfiles = { default = "default.txt", py2 = "py2.txt" }
```

And this:

```toml
[python-setup.resolves_to_lockfiles]
default = "default.txt"
py2 = "py2.txt"
```

Even this is supported for `dict` options which really are nested dictionaries:

```toml
[subsystem.dict_option.nested_dict]
key = "foo"
```

As before, we still support directly using a string, which allows for the `+` and `-` mechanisms to still work:

```toml
[python-setup]
resolves_to_lockfiles = "+{'default': 'default.txt'}"
```