### PR TITLE
Introduce BinaryTargetDependencies.

### DIFF
--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -15,6 +15,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     AsyncFieldMixin,
+    BinaryTargetDependencies,
     Dependencies,
     DependenciesRequest,
     ExplicitlyProvidedDependencies,
@@ -117,8 +118,8 @@ async def resolve_python_aws_handler(
     return ResolvedPythonAwsHandler(f"{normalized_path}:{func}", file_name_used=True)
 
 
-class PythonAwsLambdaDependencies(Dependencies):
-    supports_transitive_excludes = True
+class PythonAwsLambdaDependencies(BinaryTargetDependencies):
+    ...
 
 
 class InjectPythonLambdaHandlerDependency(InjectDependenciesRequest):

--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -15,13 +15,13 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     AsyncFieldMixin,
-    BinaryTargetDependencies,
     Dependencies,
     DependenciesRequest,
     ExplicitlyProvidedDependencies,
     InjectDependenciesRequest,
     InjectedDependencies,
     InvalidFieldException,
+    PackageTargetDependencies,
     SecondaryOwnerMixin,
     StringField,
     Target,
@@ -118,8 +118,8 @@ async def resolve_python_aws_handler(
     return ResolvedPythonAwsHandler(f"{normalized_path}:{func}", file_name_used=True)
 
 
-class PythonAwsLambdaDependencies(BinaryTargetDependencies):
-    ...
+class PythonAwsLambdaDependencies(PackageTargetDependencies):
+    pass
 
 
 class InjectPythonLambdaHandlerDependency(InjectDependenciesRequest):

--- a/src/python/pants/backend/docker/target_types.py
+++ b/src/python/pants/backend/docker/target_types.py
@@ -3,7 +3,7 @@
 
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
-    BinaryTargetDependencies,
+    PackageTargetDependencies,
     Sources,
     StringField,
     Target,
@@ -22,8 +22,8 @@ class DockerImageVersion(StringField):
     help = "Image tag to apply to built images."
 
 
-class DockerDependencies(BinaryTargetDependencies):
-    ...
+class DockerDependencies(PackageTargetDependencies):
+    pass
 
 
 class DockerContextRoot(StringField):

--- a/src/python/pants/backend/docker/target_types.py
+++ b/src/python/pants/backend/docker/target_types.py
@@ -1,7 +1,13 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.engine.target import COMMON_TARGET_FIELDS, Dependencies, Sources, StringField, Target
+from pants.engine.target import (
+    COMMON_TARGET_FIELDS,
+    BinaryTargetDependencies,
+    Sources,
+    StringField,
+    Target,
+)
 
 
 class DockerImageSources(Sources):
@@ -16,8 +22,8 @@ class DockerImageVersion(StringField):
     help = "Image tag to apply to built images."
 
 
-class DockerDependencies(Dependencies):
-    supports_transitive_excludes = True
+class DockerDependencies(BinaryTargetDependencies):
+    ...
 
 
 class DockerContextRoot(StringField):

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -26,6 +26,7 @@ from pants.engine.addresses import Address, Addresses
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     AsyncFieldMixin,
+    BinaryTargetDependencies,
     BoolField,
     Dependencies,
     DictStringToStringSequenceField,
@@ -41,6 +42,7 @@ from pants.engine.target import (
     StringField,
     StringSequenceField,
     Target,
+    TestTargetDependencies,
     TriBoolField,
 )
 from pants.option.subsystem import Subsystem
@@ -116,8 +118,8 @@ class PexBinaryDefaults(Subsystem):
 
 
 # See `target_types_rules.py` for a dependency injection rule.
-class PexBinaryDependencies(Dependencies):
-    supports_transitive_excludes = True
+class PexBinaryDependencies(BinaryTargetDependencies):
+    ...
 
 
 class MainSpecification(ABC):
@@ -420,8 +422,8 @@ class PythonTestsSources(PythonSources):
     )
 
 
-class PythonTestsDependencies(Dependencies):
-    supports_transitive_excludes = True
+class PythonTestsDependencies(TestTargetDependencies):
+    ...
 
 
 class PythonTestsTimeout(IntField):
@@ -712,8 +714,8 @@ class PythonRequirementsFile(Target):
 
 
 # See `target_types_rules.py` for a dependency injection rule.
-class PythonDistributionDependencies(Dependencies):
-    supports_transitive_excludes = True
+class PythonDistributionDependencies(BinaryTargetDependencies):
+    ...
 
 
 class PythonProvidesField(ScalarField, ProvidesField, AsyncFieldMixin):

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -26,7 +26,6 @@ from pants.engine.addresses import Address, Addresses
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     AsyncFieldMixin,
-    BinaryTargetDependencies,
     BoolField,
     Dependencies,
     DictStringToStringSequenceField,
@@ -35,6 +34,7 @@ from pants.engine.target import (
     InvalidFieldException,
     InvalidFieldTypeException,
     NestedDictStringToStringField,
+    PackageTargetDependencies,
     ProvidesField,
     ScalarField,
     SecondaryOwnerMixin,
@@ -118,7 +118,7 @@ class PexBinaryDefaults(Subsystem):
 
 
 # See `target_types_rules.py` for a dependency injection rule.
-class PexBinaryDependencies(BinaryTargetDependencies):
+class PexBinaryDependencies(PackageTargetDependencies):
     ...
 
 
@@ -714,8 +714,8 @@ class PythonRequirementsFile(Target):
 
 
 # See `target_types_rules.py` for a dependency injection rule.
-class PythonDistributionDependencies(BinaryTargetDependencies):
-    ...
+class PythonDistributionDependencies(PackageTargetDependencies):
+    pass
 
 
 class PythonProvidesField(ScalarField, ProvidesField, AsyncFieldMixin):

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -18,6 +18,7 @@ from pants.engine.target import (
     Sources,
     StringField,
     Target,
+    TestTargetDependencies,
 )
 from pants.util.enums import match
 
@@ -75,8 +76,8 @@ class Shunit2Shell(Enum):
         return BinaryPathTest((arg,))
 
 
-class Shunit2TestsDependencies(Dependencies):
-    supports_transitive_excludes = True
+class Shunit2TestsDependencies(TestTargetDependencies):
+    ...
 
 
 class Shunit2TestsSources(ShellSources):

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1654,7 +1654,7 @@ class Dependencies(StringSequenceField, AsyncFieldMixin):
 class TestTargetDependencies(Dependencies):
     """A base class for dependencies of targets representing tests.
 
-    Test targets are in some ways like library targets (they contain sources, so they must have
+    Test targets are in some ways like library targets (they contain sources, so they must
     have their dependencies inferred) and in other ways they are like binary targets (they
     typically act as root targets for goals, and they should support transitive excludes).
     Further complicating matters: it's not clear what depending on a test target should mean:


### PR DESCRIPTION
Creates a formal distinction between library and non-library
targets, wrt how their transitive deps are handled by their
dependees.

Test targets are a weird hybrid that muddies the waters, but
this is at least now made explicit.

[ci skip-rust]

[ci skip-build-wheels]