### PR TITLE
Include `.gitignore` in default `pantsd_invalidation_globs`

### DIFF
--- a/src/python/pants/backend/python/macros/poetry_requirements.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements.py
@@ -356,15 +356,15 @@ class PoetryRequirements:
     For example, if pyproject.toml contains the following entries under
     poetry.tool.dependencies: `foo = ">1"` and `bar = ">2.4"`,
 
-    python_requirement_library(
-        name="foo",
-        requirements=["foo>1"],
-      )
+        python_requirement_library(
+          name="foo",
+          requirements=["foo>1"],
+        )
 
-      python_requirement_library(
-        name="bar",
-        requirements=["bar>2.4"],
-      )
+        python_requirement_library(
+          name="bar",
+          requirements=["bar>2.4"],
+        )
 
     See Poetry documentation for correct specification of pyproject.toml:
     https://python-poetry.org/docs/pyproject/
@@ -374,7 +374,7 @@ class PoetryRequirements:
     requirement. This setting is important for Pants to know how to convert your import
     statements back into your dependencies. For example:
 
-        python_requirements(
+        poetry_requirements(
           module_mapping={
             "ansicolors": ["colors"],
             "setuptools": ["pkg_resources"],

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1611,6 +1611,7 @@ class GlobalOptions(Subsystem):
             (
                 "!*.pyc",
                 "!__pycache__/",
+                ".gitignore",
                 # TODO: This is a bandaid for https://github.com/pantsbuild/pants/issues/7022:
                 # macros should be adapted to allow this dependency to be automatically detected.
                 "requirements.txt",


### PR DESCRIPTION
* Fixed copy/paste typo in doc string for PoetryRequirements. (and consistent indentation level for code blocks)
* Added `.gititgnore` to `pantsd_invalidation_globs`.
