### PR TITLE
[internal] increase timeout for coverage_py_integration test from 210 to 480 seconds.

### DIFF
--- a/src/python/pants/backend/python/goals/BUILD
+++ b/src/python/pants/backend/python/goals/BUILD
@@ -8,7 +8,7 @@ python_tests(
   sources=["coverage_py_integration_test.py"],
   # We want to make sure the default lockfile works for both macOS and Linux.
   tags=["platform_specific_behavior"],
-  timeout=210,
+  timeout=480,
 )
 
 python_tests(name="coverage_py_test", sources=["coverage_py_test.py"], timeout=20)


### PR DESCRIPTION


See: https://github.com/pantsbuild/pants/runs/3474839116#step:11:412