### PR TITLE
Remove deprecated .with_binaries() closes #12723.

### DIFF
--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -39,7 +39,7 @@ python_distribution(
 
 # NB: we use this to avoid clang/gcc complaining `error: no input files` when building
 # `:pants-packaged`. We don't actually need to use any meaningful file here, though, because we
-# use `with_binaries()` to link to the actual native code, so clang/gcc do not need to build any
+# use `entry_points` to link to the actual native code, so clang/gcc do not need to build any
 # native code. This is just a dummy file.
 resources(
   name="dummy_c",

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -556,7 +556,7 @@ async def generate_chroot(request: SetupPyChrootRequest) -> SetupPyChroot:
     )
 
     # Resolve entry points from python_distribution(entry_points=...) and from
-    # python_distribution(provides=setup_py(entry_points=...).with_binaries(...)
+    # python_distribution(provides=setup_py(entry_points=...)
     resolved_from_entry_points_field, resolved_from_provides_field = await MultiGet(
         Get(
             ResolvedPythonDistributionEntryPoints,

--- a/src/python/pants/backend/python/goals/setup_py_test.py
+++ b/src/python/pants/backend/python/goals/setup_py_test.py
@@ -225,15 +225,11 @@ def test_merge_entry_points() -> None:
             "console_scripts": {"foo_qux": "foo.baz.qux"},
             "foo_plugins": {"foo-bar": "foo.bar:plugin"},
         },
-        "src/python/foo:foo-dist `provides.with_binaries()`": {
-            "console_scripts": {"foo_main": "foo.qux.bin:main"},
-        },
     }
     expect = {
         "console_scripts": {
             "foo_tool": "foo.bar.baz:Tool.main",
             "foo_qux": "foo.baz.qux",
-            "foo_main": "foo.qux.bin:main",
         },
         "foo_plugins": {
             "qux": "foo.qux",
@@ -306,9 +302,12 @@ def test_generate_chroot(chroot_rule_runner: RuleRunner) -> None:
                 ],
                 provides=setup_py(
                     name='foo', version='1.2.3'
-                ).with_binaries(
-                    foo_main='src/python/foo/qux:bin'
-                )
+                ),
+                entry_points={
+                    "console_scripts":{
+                        "foo_main": "src/python/foo/qux:bin",
+                    },
+                },
             )
 
             python_library(
@@ -371,6 +370,7 @@ def test_generate_chroot_entry_points(chroot_rule_runner: RuleRunner) -> None:
                 name='foo-dist',
                 entry_points={
                     "console_scripts":{
+                        "foo_main": "src/python/foo/qux:bin",
                         "foo_tool":"foo.bar.baz:Tool.main",
                         "bin_tool":"//src/python/foo/qux:bin",
                         "bin_tool2":"src/python/foo/qux:bin",
@@ -391,8 +391,6 @@ def test_generate_chroot_entry_points(chroot_rule_runner: RuleRunner) -> None:
                             "foo-bar=foo.bar:plugin",
                         ],
                     },
-                ).with_binaries(
-                    foo_main='src/python/foo/qux:bin'
                 )
             )
 
@@ -423,13 +421,13 @@ def test_generate_chroot_entry_points(chroot_rule_runner: RuleRunner) -> None:
             "install_requires": tuple(),
             "entry_points": {
                 "console_scripts": [
+                    "foo_main = foo.qux.bin:main",
                     "foo_tool = foo.bar.baz:Tool.main",
                     "bin_tool = foo.qux.bin:main",
                     "bin_tool2 = foo.qux.bin:main",
                     "hello = foo.bin:main",
                     "foo_qux = foo.baz.qux:main",
                     "foo_bin = foo.bin:main",
-                    "foo_main = foo.qux.bin:main",
                 ],
                 "foo_plugins": [
                     "qux = foo.qux",
@@ -454,19 +452,34 @@ def test_invalid_binary(chroot_rule_runner: RuleRunner) -> None:
                 name='invalid_bin1',
                 provides=setup_py(
                     name='invalid_bin1', version='1.1.1'
-                ).with_binaries(foo=':not_a_binary')
+                ),
+                entry_points={
+                    "console_scripts":{
+                        "foo": ":not_a_binary",
+                    },
+                },
             )
             python_distribution(
                 name='invalid_bin2',
                 provides=setup_py(
                     name='invalid_bin2', version='1.1.1'
-                ).with_binaries(foo=':invalid_entrypoint_unowned1')
+                ),
+                entry_points={
+                    "console_scripts":{
+                        "foo": ":invalid_entrypoint_unowned1",
+                    },
+                },
             )
             python_distribution(
                 name='invalid_bin3',
                 provides=setup_py(
                     name='invalid_bin3', version='1.1.1'
-                ).with_binaries(foo=':invalid_entrypoint_unowned2')
+                ),
+                entry_points={
+                    "console_scripts":{
+                        "foo": ":invalid_entrypoint_unowned2",
+                    },
+                },
             )
             """
         ),
@@ -501,7 +514,12 @@ def test_binary_shorthand(chroot_rule_runner: RuleRunner) -> None:
                 name='dist',
                 provides=setup_py(
                     name='bin', version='1.1.1'
-                ).with_binaries(foo=':bin')
+                ),
+                entry_points={
+                    "console_scripts":{
+                        "foo": ":bin",
+                    },
+                },
             )
             """
         ),

--- a/src/python/pants/backend/python/macros/python_artifact.py
+++ b/src/python/pants/backend/python/macros/python_artifact.py
@@ -4,8 +4,6 @@
 import collections.abc
 from typing import Any, Dict, List, Union
 
-from pants.base.deprecated import deprecated
-
 
 def _normalize_entry_points(
     all_entry_points: Dict[str, Union[List[str], Dict[str, str]]]
@@ -79,75 +77,3 @@ class PythonArtifact:
 
     def __str__(self) -> str:
         return self.name
-
-    @deprecated(
-        "2.8.0.dev0",
-        """Use `python_distribution(entry_points={"console_scripts":{...}})` instead of
-        `python_distribution(provides=setup_py().with_binaries(...))`.
-
-        The entry points field was added as a more generic mechanism than
-        `.with_binaries()`. Whereas `.with_binaries()` would only add `console_scripts` to your
-        generated `setup.py`, you can now add other types of entry points like `gui_scripts`. You
-        can also now add a setuptools entry point like `path.to.module:func`, in addition to still
-        being able to sue a Pants target address to a `pex_binary` target.
-
-        Entry points are specified as a nested dictionary, with a dictionary for each type of entry
-        point like `console_scripts` and `gui_scripts`. Each dictionary maps the entry point name to
-        either a setuptools entry point or an address to a `pex_binary` target.
-
-        Any entry point that either starts with `:` or has `/` in it, is considered a target
-        address. Use `//` as prefix for target addresses if you need to disambiguate.
-
-        To migrate, add a dictionary for `console_scripts` with the same entry point name and
-        `pex_binary` address you were using before.
-
-        Example migration, before:
-
-            pex_binary(name="binary", entry_point="app.py:main")
-
-            python_distribution(
-                name="dist",
-                provides=setup_py(...).with_binaries({'my_command': ':binary'})
-            )
-
-        after:
-
-            pex_binary(name="binary", entry_point="app.py:main")
-
-            python_distribution(
-                name="dist",
-                entry_points={'console_scripts': {'my_command': ':binary'}},
-                provides=setup_py(...),
-            )
-
-        As before, Pants will infer a dependency on the `pex_binary`. You can confirm this by
-        running
-
-            ./pants dependencies path/to:python_distribution
-
-        """,
-    )
-    def with_binaries(self, *args, **kw):
-        """Add binaries tagged to this artifact.
-
-        For example: ::
-
-          provides = setup_py(
-            name = 'my_library',
-            zip_safe = True
-          ).with_binaries(
-            my_command = ':my_library_bin'
-          )
-
-        This adds a console_script entry_point for the pex_binary target
-        pointed at by :my_library_bin.  Currently only supports
-        pex_binaries that specify entry_point explicitly instead of source.
-
-        Also can take a dictionary, e.g.
-        with_binaries({'my-command': ':my_library_bin'})
-        """
-        for arg in args:
-            if isinstance(arg, dict):
-                self._binaries.update(arg)
-        self._binaries.update(kw)
-        return self

--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -17,7 +17,7 @@ from typing import DefaultDict, Dict, Generator, Optional, Tuple, cast
 
 from pants.backend.python.dependency_inference.module_mapper import PythonModule, PythonModuleOwners
 from pants.backend.python.dependency_inference.rules import PythonInferSubsystem, import_rules
-from pants.backend.python.goals.setup_py import InvalidEntryPoint, merge_entry_points
+from pants.backend.python.goals.setup_py import InvalidEntryPoint
 from pants.backend.python.target_types import (
     EntryPoint,
     PexBinaryDependencies,
@@ -197,19 +197,7 @@ async def resolve_python_distribution_entry_points(
             _EntryPointsDictType, request.provides_field.value.kwargs.get("entry_points") or {}
         )
 
-        with_binaries = request.provides_field.value.binaries
-        if with_binaries:
-            all_entry_points = merge_entry_points(
-                (
-                    f"{address}'s field `provides=setup_py(entry_points={...})`",
-                    provides_field_value,
-                ),
-                (
-                    f"{address}'s field `provides=setup_py().with_binaries(...)",
-                    {"console_scripts": with_binaries},
-                ),
-            )
-        elif provides_field_value:
+        if provides_field_value:
             all_entry_points = provides_field_value
         else:
             return ResolvedPythonDistributionEntryPoints()

--- a/src/python/pants/backend/python/target_types_test.py
+++ b/src/python/pants/backend/python/target_types_test.py
@@ -411,7 +411,12 @@ def test_inject_python_distribution_dependencies() -> None:
                 name="dist-a",
                 provides=setup_py(
                     name='my-dist-a'
-                ).with_binaries({"my_cmd": ":my_binary"})
+                ),
+                entry_points={
+                    "console_scripts":{
+                        "my_cmd": ":my_binary",
+                    },
+                },
             )
 
             python_distribution(


### PR DESCRIPTION
Signed-off-by: Andreas Stenius <andreas.stenius@svenskaspel.se>

# Building wheels and fs_util will be skipped. Delete if not intended.
[ci skip-build-wheels]