### PR TITLE
[internal] Bump timeouts due to flakes

### DIFF
--- a/src/python/pants/backend/python/lint/docformatter/BUILD
+++ b/src/python/pants/backend/python/lint/docformatter/BUILD
@@ -7,7 +7,7 @@ resources(name="lockfile", sources=["lockfile.txt"])
 python_tests(
     name="rules_integration_test",
     sources=["rules_integration_test.py"],
-    timeout=180,
+    timeout=240,
     # We want to make sure the default lockfile works for both macOS and Linux.
     tags=["platform_specific_behavior"],
 )

--- a/src/python/pants/backend/python/util_rules/BUILD
+++ b/src/python/pants/backend/python/util_rules/BUILD
@@ -9,5 +9,5 @@ python_tests(
     # We shell out to pex in tests; so we have a dependency, but not an explicit import.
     "3rdparty/python:pex",
   ],
-  timeout=120,
+  timeout=300,
 )


### PR DESCRIPTION
Timed out on `main`.

[ci skip-rust]
[ci skip-build-wheels]