### PR TITLE
Improve descriptions of the process executions for PEX_PATH composition.

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -692,26 +692,27 @@ def _build_pex_description(request: PexRequest) -> str:
     if request.description:
         return request.description
 
-    if isinstance(request.requirements, Lockfile):
-        desc_suffix = f"from {request.requirements.file_path}"
-    elif isinstance(request.requirements, LockfileContent):
-        desc_suffix = f"from {request.requirements.file_content.path}"
-    else:
-        if not request.requirements.req_strings:
-            return f"Building {request.output_filename}"
-        elif request.requirements.resolved_dists:
-            repo_pex = request.requirements.resolved_dists.pex.name
-            return (
-                f"Extracting {pluralize(len(request.requirements.req_strings), 'requirement')} "
-                f"to build {request.output_filename} from {repo_pex}: "
-                f"{', '.join(request.requirements.req_strings)}"
-            )
+    reqs = request.requirements
+    if isinstance(reqs, Lockfile):
+        return f"Resolving {request.output_filename} from {reqs.file_path}"
+    elif isinstance(reqs, LockfileContent):
+        return f"Resolving {request.output_filename} from {reqs.file_content.path}"
+    elif request.internal_only and reqs.resolved_dists:
+        repo_pex = reqs.resolved_dists.pex
+        if reqs.req_strings:
+            return f"Extracting {', '.join(reqs.req_strings)} from {repo_pex.name}"
         else:
-            desc_suffix = (
-                f"with {pluralize(len(request.requirements.req_strings), 'requirement')}: "
-                f"{', '.join(request.requirements.req_strings)}"
+            return (
+                f"Composing {pluralize(len(request.pex_path), 'requirement')} to build "
+                f"{request.output_filename} from {repo_pex.name}"
             )
-    return f"Building {request.output_filename} {desc_suffix}"
+    elif not reqs.req_strings:
+        return f"Building {request.output_filename}"
+    else:
+        return (
+            f"Building {request.output_filename} with "
+            f"{pluralize(len(reqs.req_strings), 'requirement')}: {', '.join(reqs.req_strings)}"
+        )
 
 
 @rule


### PR DESCRIPTION
Followup to #12675 to improve the process descriptions surrounding PEX_PATH composition.

This only meaningfully affects the output when lockfiles / constraints-file are in use. Afterwards, the output in that case looks like:
```
$ ./pants --no-process-execution-local-cache --no-remote-cache-read test src/python/pants/util/::
16:20:12.69 [INFO] Completed: Building requirements.pex
16:20:33.47 [INFO] Completed: Resolving pytest.pex from 3rdparty/python/lockfiles/pytest.txt
16:20:36.88 [INFO] Completed: Resolving 3rdparty/python/lockfiles/user_reqs.txt
16:20:38.05 [INFO] Completed: Building pytest_runner.pex
16:20:41.32 [INFO] Completed: test - src/python/pants/util/osutil_test.py:tests succeeded.
16:20:41.96 [INFO] Completed: test - src/python/pants/util/filtering_test.py:tests succeeded.
16:20:41.96 [INFO] Completed: test - src/python/pants/util/eval_test.py:tests succeeded.
16:20:41.97 [INFO] Completed: test - src/python/pants/util/socket_test.py:tests succeeded.
16:20:42.70 [INFO] Completed: Extracting ansicolors==1.1.8 from lockfile.pex
16:20:42.72 [INFO] Completed: Extracting typing-extensions==3.7.4.3 from lockfile.pex
16:20:42.85 [INFO] Completed: Extracting packaging==21.0 from lockfile.pex
16:20:44.56 [INFO] Completed: test - src/python/pants/util/memo_test.py:tests succeeded.
16:20:44.65 [INFO] Completed: test - src/python/pants/util/enums_test.py:tests succeeded.
16:20:44.70 [INFO] Completed: Extracting pytest<6.3,>=6.0.1 from lockfile.pex
16:20:46.86 [INFO] Completed: Composing 2 requirements to build requirements.pex from lockfile.pex
16:20:47.04 [INFO] Completed: Composing 1 requirement to build requirements.pex from lockfile.pex
16:20:48.48 [INFO] Completed: Composing 1 requirement to build requirements.pex from lockfile.pex
16:20:53.01 [INFO] Completed: Building pytest_runner.pex
16:20:53.04 [INFO] Completed: Building pytest_runner.pex
16:20:55.50 [INFO] Completed: test - src/python/pants/util/docutil_test.py:tests succeeded.
16:20:55.73 [INFO] Completed: Building pytest_runner.pex
16:20:56.09 [INFO] Completed: test - src/python/pants/util/contextutil_test.py:tests succeeded.
16:20:56.09 [INFO] Completed: test - src/python/pants/util/dirutil_test.py:tests succeeded.
16:20:58.00 [INFO] Completed: test - src/python/pants/util/collections_test.py:tests succeeded.
16:20:58.27 [INFO] Completed: test - src/python/pants/util/meta_test.py:tests succeeded.
16:20:58.45 [INFO] Completed: test - src/python/pants/util/frozendict_test.py:tests succeeded.
16:20:58.52 [INFO] Completed: test - src/python/pants/util/strutil_test.py:tests succeeded.
16:20:58.56 [INFO] Completed: test - src/python/pants/util/ordered_set_test.py:tests succeeded.

✓ src/python/pants/util/collections_test.py:tests succeeded.
✓ src/python/pants/util/contextutil_test.py:tests succeeded.
✓ src/python/pants/util/dirutil_test.py:tests succeeded.
✓ src/python/pants/util/docutil_test.py:tests succeeded.
✓ src/python/pants/util/enums_test.py:tests succeeded.
✓ src/python/pants/util/eval_test.py:tests succeeded.
✓ src/python/pants/util/filtering_test.py:tests succeeded.
✓ src/python/pants/util/frozendict_test.py:tests succeeded.
✓ src/python/pants/util/memo_test.py:tests succeeded.
✓ src/python/pants/util/meta_test.py:tests succeeded.
✓ src/python/pants/util/ordered_set_test.py:tests succeeded.
✓ src/python/pants/util/osutil_test.py:tests succeeded.
✓ src/python/pants/util/socket_test.py:tests succeeded.
✓ src/python/pants/util/strutil_test.py:tests succeeded.
```

[ci skip-rust]
[ci skip-build-wheels]