### PR TITLE
Improve descriptions of the process executions for PEX_PATH composition. (cherrypick of #12736)

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -509,6 +509,7 @@ def test_build_pex_description() -> None:
     def assert_description(
         requirements: PexRequirements | Lockfile | LockfileContent,
         *,
+        pex_path_length: int = 0,
         description: str | None = None,
         expected: str,
     ) -> None:
@@ -517,6 +518,7 @@ def test_build_pex_description() -> None:
             internal_only=True,
             requirements=requirements,
             description=description,
+            pex_path=(Pex(EMPTY_DIGEST, f"{i}.pex", None, ()) for i in range(0, pex_path_length)),
         )
         assert _build_pex_description(request) == expected
 
@@ -530,14 +532,18 @@ def test_build_pex_description() -> None:
     )
 
     assert_description(PexRequirements(), expected="Building new.pex")
-    assert_description(PexRequirements(resolved_dists=resolved_dists), expected="Building new.pex")
+    assert_description(
+        PexRequirements(resolved_dists=resolved_dists),
+        pex_path_length=2,
+        expected="Composing 2 requirements to build new.pex from repo.pex",
+    )
 
     assert_description(
         PexRequirements(["req"]), expected="Building new.pex with 1 requirement: req"
     )
     assert_description(
         PexRequirements(["req"], resolved_dists=resolved_dists),
-        expected="Extracting 1 requirement to build new.pex from repo.pex: req",
+        expected="Extracting req from repo.pex",
     )
 
     assert_description(
@@ -545,20 +551,20 @@ def test_build_pex_description() -> None:
         expected="Building new.pex with 2 requirements: req1, req2",
     )
     assert_description(
-        PexRequirements(["req1", "req2"], resolved_dists=resolved_dists),
-        expected="Extracting 2 requirements to build new.pex from repo.pex: req1, req2",
+        PexRequirements(["req1"], resolved_dists=resolved_dists),
+        expected="Extracting req1 from repo.pex",
     )
 
     assert_description(
         LockfileContent(file_content=FileContent("lock.txt", b""), lockfile_hex_digest=None),
-        expected="Building new.pex from lock.txt",
+        expected="Resolving new.pex from lock.txt",
     )
 
     assert_description(
         Lockfile(
             file_path="lock.txt", file_path_description_of_origin="foo", lockfile_hex_digest=None
         ),
-        expected="Building new.pex from lock.txt",
+        expected="Resolving new.pex from lock.txt",
     )
 
 


### PR DESCRIPTION
Followup to #12675 to improve the process descriptions surrounding PEX_PATH composition.

This only meaningfully affects the output when lockfiles / constraints-file are in use. Afterwards, the output in that case looks like:
```console
$ ./pants --no-process-execution-local-cache --no-remote-cache-read test src/python/pants/util/::
16:20:12.69 [INFO] Completed: Building requirements.pex
16:20:33.47 [INFO] Completed: Resolving pytest.pex from 3rdparty/python/lockfiles/pytest.txt
16:20:36.88 [INFO] Completed: Resolving 3rdparty/python/lockfiles/user_reqs.txt
16:20:38.05 [INFO] Completed: Building pytest_runner.pex
16:20:41.32 [INFO] Completed: test - src/python/pants/util/osutil_test.py:tests succeeded.
16:20:41.96 [INFO] Completed: test - src/python/pants/util/filtering_test.py:tests succeeded.
16:20:41.96 [INFO] Completed: test - src/python/pants/util/eval_test.py:tests succeeded.
16:20:41.97 [INFO] Completed: test - src/python/pants/util/socket_test.py:tests succeeded.
16:20:42.70 [INFO] Completed: Extracting ansicolors==1.1.8 from lockfile.pex
16:20:42.72 [INFO] Completed: Extracting typing-extensions==3.7.4.3 from lockfile.pex
16:20:42.85 [INFO] Completed: Extracting packaging==21.0 from lockfile.pex
16:20:44.56 [INFO] Completed: test - src/python/pants/util/memo_test.py:tests succeeded.
16:20:44.65 [INFO] Completed: test - src/python/pants/util/enums_test.py:tests succeeded.
16:20:44.70 [INFO] Completed: Extracting pytest<6.3,>=6.0.1 from lockfile.pex
16:20:46.86 [INFO] Completed: Composing 2 requirements to build requirements.pex from lockfile.pex
16:20:47.04 [INFO] Completed: Composing 1 requirement to build requirements.pex from lockfile.pex
16:20:48.48 [INFO] Completed: Composing 1 requirement to build requirements.pex from lockfile.pex
16:20:53.01 [INFO] Completed: Building pytest_runner.pex
16:20:53.04 [INFO] Completed: Building pytest_runner.pex
16:20:55.50 [INFO] Completed: test - src/python/pants/util/docutil_test.py:tests succeeded.
16:20:55.73 [INFO] Completed: Building pytest_runner.pex
16:20:56.09 [INFO] Completed: test - src/python/pants/util/contextutil_test.py:tests succeeded.
16:20:56.09 [INFO] Completed: test - src/python/pants/util/dirutil_test.py:tests succeeded.
16:20:58.00 [INFO] Completed: test - src/python/pants/util/collections_test.py:tests succeeded.
16:20:58.27 [INFO] Completed: test - src/python/pants/util/meta_test.py:tests succeeded.
16:20:58.45 [INFO] Completed: test - src/python/pants/util/frozendict_test.py:tests succeeded.
16:20:58.52 [INFO] Completed: test - src/python/pants/util/strutil_test.py:tests succeeded.
16:20:58.56 [INFO] Completed: test - src/python/pants/util/ordered_set_test.py:tests succeeded.

✓ src/python/pants/util/collections_test.py:tests succeeded.
✓ src/python/pants/util/contextutil_test.py:tests succeeded.
✓ src/python/pants/util/dirutil_test.py:tests succeeded.
✓ src/python/pants/util/docutil_test.py:tests succeeded.
✓ src/python/pants/util/enums_test.py:tests succeeded.
✓ src/python/pants/util/eval_test.py:tests succeeded.
✓ src/python/pants/util/filtering_test.py:tests succeeded.
✓ src/python/pants/util/frozendict_test.py:tests succeeded.
✓ src/python/pants/util/memo_test.py:tests succeeded.
✓ src/python/pants/util/meta_test.py:tests succeeded.
✓ src/python/pants/util/ordered_set_test.py:tests succeeded.
✓ src/python/pants/util/osutil_test.py:tests succeeded.
✓ src/python/pants/util/socket_test.py:tests succeeded.
✓ src/python/pants/util/strutil_test.py:tests succeeded.
```

[ci skip-rust]
[ci skip-build-wheels]