### PR TITLE
Error, don't warn, when `--generate-lockfiles-resolve` is set to a disabled tool lockfile

### DIFF
--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -371,7 +371,7 @@ def filter_tool_lockfile_requests(
             continue
         if resolve_specified:
             resolve = req.resolve_name
-            logger.warning(
+            raise ValueError(
                 f"You requested to generate a lockfile for {resolve} because "
                 "you included it in `--generate-lockfiles-resolve`, but "
                 f"`[{resolve}].lockfile` is set to `{req.lockfile_dest}` "

--- a/src/python/pants/backend/python/goals/lockfile_test.py
+++ b/src/python/pants/backend/python/goals/lockfile_test.py
@@ -86,7 +86,7 @@ def test_unrecognized_resolve_names_error(
     ) in str(exc.value)
 
 
-def test_filter_tool_lockfile_requests(caplog) -> None:
+def test_filter_tool_lockfile_requests() -> None:
     def create_request(name: str, lockfile_dest: str | None = None) -> PythonLockfileRequest:
         return PythonLockfileRequest(
             FrozenOrderedSet(),
@@ -104,7 +104,6 @@ def test_filter_tool_lockfile_requests(caplog) -> None:
         extra_request: PythonLockfileRequest | None,
         *,
         resolve_specified: bool,
-        expected_log: str | None,
     ) -> None:
         requests = [tool1, tool2]
         if extra_request:
@@ -113,28 +112,20 @@ def test_filter_tool_lockfile_requests(caplog) -> None:
             tool1,
             tool2,
         ]
-        if expected_log:
-            assert len(caplog.records) == 1
-            assert expected_log in caplog.text
-        else:
-            assert not caplog.records
-        caplog.clear()
 
-    assert_filtered(None, resolve_specified=False, expected_log=None)
-    assert_filtered(None, resolve_specified=True, expected_log=None)
+    assert_filtered(None, resolve_specified=False)
+    assert_filtered(None, resolve_specified=True)
 
-    assert_filtered(disabled_tool, resolve_specified=False, expected_log=None)
-    assert_filtered(
-        disabled_tool,
-        resolve_specified=True,
-        expected_log=f"`[{disabled_tool.resolve_name}].lockfile` is set to `{NO_TOOL_LOCKFILE}`",
+    assert_filtered(disabled_tool, resolve_specified=False)
+    with pytest.raises(ValueError) as exc:
+        assert_filtered(disabled_tool, resolve_specified=True)
+    assert f"`[{disabled_tool.resolve_name}].lockfile` is set to `{NO_TOOL_LOCKFILE}`" in str(
+        exc.value
     )
 
-    assert_filtered(default_tool, resolve_specified=False, expected_log=None)
-    assert_filtered(
-        default_tool,
-        resolve_specified=True,
-        expected_log=(
-            f"`[{default_tool.resolve_name}].lockfile` is set to `{DEFAULT_TOOL_LOCKFILE}`"
-        ),
+    assert_filtered(default_tool, resolve_specified=False)
+    with pytest.raises(ValueError) as exc:
+        assert_filtered(default_tool, resolve_specified=True)
+    assert f"`[{default_tool.resolve_name}].lockfile` is set to `{DEFAULT_TOOL_LOCKFILE}`" in str(
+        exc.value
     )


### PR DESCRIPTION
@stuhood pointed out that the warning was too easily missed. If you set this option to a tool that isn't configured properly, we should make it abundantly clear things aren't set up how you expect.

[ci skip-rust]
[ci skip-build-wheels]