### PR TITLE
Fix rendering of the ABOUT file

### DIFF
--- a/pants-plugins/internal_plugins/releases/register.py
+++ b/pants-plugins/internal_plugins/releases/register.py
@@ -98,12 +98,12 @@ async def pants_setup_kwargs(
     ]
     kwargs["classifiers"] = [*standard_classifiers, *kwargs.get("classifiers", [])]
 
-    # Determine the long description by reading from ABOUT.rst and the release notes.
+    # Determine the long description by reading from ABOUT.md and the release notes.
     notes_file = pants_releases.notes_file_for_version(PANTS_SEMVER)
     digest_contents = await Get(
         DigestContents,
         PathGlobs(
-            ["src/python/pants/ABOUT.rst", notes_file],
+            ["src/python/pants/ABOUT.md", notes_file],
             description_of_origin="Pants release files",
             glob_match_error_behavior=GlobMatchErrorBehavior.error,
         ),

--- a/src/python/pants/ABOUT.md
+++ b/src/python/pants/ABOUT.md
@@ -1,0 +1,4 @@
+Pants is an Apache2 licensed build tool written in Python and Rust.
+
+The latest documentation can be found at [pantsbuild.org](https://www.pantsbuild.org/).
+

--- a/src/python/pants/ABOUT.rst
+++ b/src/python/pants/ABOUT.rst
@@ -1,4 +1,0 @@
-Pants is an Apache2 licensed build tool written in Python.
-
-The latest documentation can be found at `pantsbuild <https://www.pantsbuild.org/>`_.
-


### PR DESCRIPTION
Fix rendering of the `ABOUT` file, which is `rst`, but is being concatenated onto the relevant notes `md` file.

See, for example: ﻿﻿https://pypi.org/project/pantsbuild.pants/2.7.0rc1/

[ci skip-rust]