### PR TITLE
Remove undocumented `pants_version()` symbol from BUILD files

### DIFF
--- a/src/python/pants/build_graph/register.py
+++ b/src/python/pants/build_graph/register.py
@@ -8,7 +8,7 @@ These are always activated and cannot be disabled.
 
 import os
 
-from pants.base.build_environment import get_buildroot, pants_version
+from pants.base.build_environment import get_buildroot
 from pants.build_graph.build_file_aliases import BuildFileAliases
 
 
@@ -25,6 +25,6 @@ class BuildFilePath:
 
 def build_file_aliases():
     return BuildFileAliases(
-        objects={"get_buildroot": get_buildroot, "pants_version": pants_version},
+        objects={"get_buildroot": get_buildroot},
         context_aware_object_factories={"buildfile_path": BuildFilePath},
     )


### PR DESCRIPTION
I can't think of a reason why an end-user would ever use this in their BUILD file. Their own code shouldn't really care about what version of Pants they're using.

This gets us closer to killing `objects`.

[ci skip-rust]
[ci skip-build-wheels]