### PR TITLE
[internal] bump timeout for docker tests to 120s, due to integration …

### DIFF
--- a/src/python/pants/backend/docker/BUILD
+++ b/src/python/pants/backend/docker/BUILD
@@ -5,4 +5,5 @@ python_library()
 
 python_tests(
     name="tests",
+    timeout=120,
 )


### PR DESCRIPTION
…tests timing out.