### PR TITLE
Introduce new `typed` field for `python_library` and `python_distribution`

### DIFF
--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -12,6 +12,7 @@ python_library(
 
 python_distribution(
   name='pants-packaged',
+  typed='yes',
   dependencies=[
     ':dummy_c',
     ':entry_point',

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -655,8 +655,7 @@ def missing_py_typed_files(typed: Optional[bool], targets: Targets) -> Tuple[Fil
 async def get_sources(request: SetupPySourcesRequest) -> SetupPySources:
     # Create any py.typed files, if required.
     missing_py_typed = missing_py_typed_files(request.typed, request.targets)
-    py_typed_digest = await Get(Digest, CreateDigest(missing_py_typed))
-    py_typed_files = await Get(Snapshot, Digest, py_typed_digest)
+    py_typed_files = await Get(Snapshot, CreateDigest(missing_py_typed))
     py_typed_stripped = await Get(StrippedSourceFiles, SourceFiles(py_typed_files, ()))
 
     python_sources_request = PythonSourceFilesRequest(

--- a/src/python/pants/backend/python/subsystems/setuptools.py
+++ b/src/python/pants/backend/python/subsystems/setuptools.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 from pants.backend.python.goals.lockfile import PythonLockfileRequest, PythonToolLockfileSentinel
 from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
-from pants.backend.python.target_types import PythonProvidesField
+from pants.backend.python.target_types import PythonProvidesField, PythonTypedField
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.base.specs import AddressSpecs, DescendantAddresses
 from pants.core.goals.package import PackageFieldSet
@@ -23,6 +23,7 @@ class PythonDistributionFieldSet(PackageFieldSet):
     required_fields = (PythonProvidesField,)
 
     provides: PythonProvidesField
+    typed: PythonTypedField
 
 
 class Setuptools(PythonToolRequirementsBase):

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -86,6 +86,25 @@ class InterpreterConstraintsField(StringSequenceField):
         return python_setup.compatibility_or_constraints(self.value)
 
 
+class PythonTyped(Enum):
+    YES = "yes"
+    NO = "no"
+    PARTIAL = "partial"
+
+
+class PythonTypedField(StringField):
+    alias = "typed"
+    valid_choices = PythonTyped
+    expected_type = str
+    default = None
+    help = (
+        "Whether to mark this target as typed, partially typed, or not typed. (PEP-561)\n"
+        "When marked as typed, it applies recursively to all sub modules as well.\n"
+        "\n"
+        "Notice: that 'partial' MUST be applied to a top-level library."
+    )
+
+
 # -----------------------------------------------------------------------------------------------
 # `pex_binary` target
 # -----------------------------------------------------------------------------------------------
@@ -507,6 +526,7 @@ class PythonLibrary(Target):
         InterpreterConstraintsField,
         Dependencies,
         PythonLibrarySources,
+        PythonTypedField,
     )
     help = (
         "Python source code.\n\nA `python_library` does not necessarily correspond to a "
@@ -855,6 +875,7 @@ class PythonDistribution(Target):
         PythonDistributionDependencies,
         PythonDistributionEntryPointsField,
         PythonProvidesField,
+        PythonTypedField,
         SetupPyCommandsField,
     )
     help = (

--- a/src/python/pants/testutil/BUILD
+++ b/src/python/pants/testutil/BUILD
@@ -3,6 +3,7 @@
 
 python_distribution(
   name='testutil_wheel',
+  typed='yes',
   dependencies=[
     ':testutil',
     ':pants_integration_test',

--- a/tests/python/pants_test/integration/BUILD
+++ b/tests/python/pants_test/integration/BUILD
@@ -57,3 +57,10 @@ python_tests(
   ],
   timeout = 180,
 )
+
+python_tests(
+  name = 'pep_561_integration',
+  sources = ['pep_561_integration_test.py'],
+  timeout = 180,
+  runtime_package_dependencies=['src/python/pants/testutil:testutil_wheel'],
+)

--- a/tests/python/pants_test/integration/pep_561_integration_test.py
+++ b/tests/python/pants_test/integration/pep_561_integration_test.py
@@ -1,0 +1,81 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from glob import glob
+from textwrap import dedent
+
+from pants.base.build_environment import get_buildroot
+from pants.testutil.pants_integration_test import PantsResult, run_pants, setup_tmpdir
+
+
+def typecheck_file(filename: str) -> PantsResult:
+    return run_pants(
+        [
+            "--backend-packages=["
+            "'pants.backend.python',"
+            "'pants.backend.python.typecheck.mypy'"
+            "]",
+            "typecheck",
+            filename,
+        ]
+    )
+
+
+def test_typecheck_works() -> None:
+    project = {
+        "proj1/BUILD": "python_library()",
+        "proj1/ok.py": dedent(
+            """\
+            def dummy() -> int:
+                return 42
+            """
+        ),
+        "proj1/err.py": dedent(
+            """\
+            def dummy() -> int:
+                return "not an int"
+            """
+        ),
+    }
+
+    with setup_tmpdir(project) as tmpdir:
+        ok_result = typecheck_file(f"{tmpdir}/proj1/ok.py")
+        err_result = typecheck_file(f"{tmpdir}/proj1/err.py")
+
+    ok_result.assert_success()
+    err_result.assert_failure()
+
+
+def test_type_stubs() -> None:
+    wheel = glob(f"{get_buildroot()}/pantsbuild.pants.testutil-*.whl")[0]
+    project = {
+        "proj1/BUILD": dedent(
+            f"""\
+            python_requirement_library(
+                name="pants",
+                requirements=["Pants @ file://{wheel}"],
+            )
+            python_library()
+            """
+        ),
+        "proj1/ok.py": dedent(
+            """\
+            from pants.testutil.option_util import create_subsystem
+            """
+        ),
+        "proj1/err.py": dedent(
+            """\
+            from pants.testutil.option_util import create_subsystem
+
+            def dummy() -> None:
+                create_subsystem()
+            """
+        ),
+    }
+
+    with setup_tmpdir(project) as tmpdir:
+        ok_result = typecheck_file(f"{tmpdir}/proj1/ok.py")
+        err_result = typecheck_file(f"{tmpdir}/proj1/err.py")
+
+    ok_result.assert_success()
+    err_result.assert_failure()

--- a/tests/python/pants_test/integration/pep_561_integration_test.py
+++ b/tests/python/pants_test/integration/pep_561_integration_test.py
@@ -1,10 +1,10 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import os
 from glob import glob
 from textwrap import dedent
 
-from pants.base.build_environment import get_buildroot
 from pants.testutil.pants_integration_test import PantsResult, run_pants, setup_tmpdir
 
 
@@ -49,7 +49,7 @@ def test_typecheck_works() -> None:
 
 
 def test_type_stubs() -> None:
-    wheel = glob(f"{get_buildroot()}/pantsbuild.pants.testutil-*.whl")[0]
+    wheel = glob(f"{os.getcwd()}/pantsbuild.pants.testutil-*.whl")[0]
     project = {
         "proj1/BUILD": dedent(
             f"""\

--- a/tests/python/pants_test/integration/pep_561_integration_test.py
+++ b/tests/python/pants_test/integration/pep_561_integration_test.py
@@ -60,6 +60,7 @@ def test_type_stubs() -> None:
         ),
         "proj1/ok.py": dedent(
             """\
+            # import should be ok
             from pants.testutil.option_util import create_subsystem
             """
         ),
@@ -68,6 +69,7 @@ def test_type_stubs() -> None:
             from pants.testutil.option_util import create_subsystem
 
             def dummy() -> None:
+                # wrong args should not be ok
                 create_subsystem()
             """
         ),

--- a/tests/python/pants_test/integration/pep_561_integration_test.py
+++ b/tests/python/pants_test/integration/pep_561_integration_test.py
@@ -17,7 +17,9 @@ def typecheck_file(filename: str) -> PantsResult:
             "]",
             "typecheck",
             filename,
-        ]
+        ],
+        # match the setup_py_commands --python-tag of src/python/pants/testutil:testutil_wheel
+        config={"python-setup": {"interpreter_constraints": ["CPython>=3.7<=3.9"]}},
     )
 
 


### PR DESCRIPTION
To allow packages to be PEP-561 compliant, allow them to specify `typed="yes"` which will inject a `py.typed` file in the package.

Setting `typed` on a distribution overrides any provided values on libraries. On libraries, `type="partial"` is also supported.

Integration tests verify that the injected `py.typed` file has desired effect, when used on the `pantsbuild.pants.testutil` dist.

Closes #10944 Supersedes #12330 
