### PR TITLE
Fix UI rendering when a workunit has completed children but no running children (cherrypick of #12748)

### DIFF
--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -29,7 +29,7 @@ use tokio::sync::RwLock;
 use tokio::time::{timeout, Duration};
 use tokio_util::codec::{BytesCodec, FramedRead};
 use tryfuture::try_future;
-use workunit_store::{in_workunit, Metric, RunningWorkunit, WorkunitMetadata};
+use workunit_store::{in_workunit, Level, Metric, RunningWorkunit, WorkunitMetadata};
 
 use crate::{
   Context, FallibleProcessResultWithPlatform, MultiPlatformProcess, NamedCaches, Platform, Process,
@@ -457,9 +457,24 @@ pub trait CapturedWorkdir {
     // Start with async materialization of input snapshots, followed by synchronous materialization
     // of other configured inputs. Note that we don't do this in parallel, as that might cause
     // non-determinism when paths overlap.
-    let sandbox = store
-      .materialize_directory(workdir_path.clone(), req.input_files)
-      .await?;
+    let store2 = store.clone();
+    let workdir_path_2 = workdir_path.clone();
+    let input_files = req.input_files;
+    let sandbox = in_workunit!(
+      context.workunit_store.clone(),
+      "setup_sandbox".to_owned(),
+      WorkunitMetadata {
+        level: Level::Trace,
+        ..WorkunitMetadata::default()
+      },
+      |_workunit| async move {
+        store2
+          .materialize_directory(workdir_path_2, input_files)
+          .await
+      },
+    )
+    .await?;
+
     let workdir_path2 = workdir_path.clone();
     let output_file_paths = req.output_files.clone();
     let output_dir_paths = req.output_directories.clone();

--- a/src/rust/engine/workunit_store/src/tests.rs
+++ b/src/rust/engine/workunit_store/src/tests.rs
@@ -6,13 +6,23 @@ use crate::{SpanId, WorkunitMetadata, WorkunitState, WorkunitStore};
 
 #[test]
 fn heavy_hitters_basic() {
-  let ws = create_store(vec![], vec![wu_root(0), wu(1, 0)], vec![]);
+  let ws = create_store(vec![wu_root(0), wu(1, 0)], vec![], vec![]);
   assert_eq!(vec!["1"], ws.heavy_hitters(1).keys().collect::<Vec<_>>());
 }
 
 #[test]
+fn heavy_hitters_only_running() {
+  // A completed child should not prevent a parent from being rendered.
+  let ws = create_store(vec![wu_root(0), wu(1, 0)], vec![], vec![wu(2, 1)]);
+  assert_eq!(
+    vec!["1"],
+    ws.heavy_hitters(1).keys().cloned().collect::<Vec<_>>()
+  );
+}
+
+#[test]
 fn straggling_workunits_basic() {
-  let ws = create_store(vec![], vec![wu_root(0), wu(1, 0)], vec![]);
+  let ws = create_store(vec![wu_root(0), wu(1, 0)], vec![], vec![]);
   assert_eq!(
     vec!["1"],
     ws.straggling_workunits(Duration::from_secs(0))
@@ -25,7 +35,7 @@ fn straggling_workunits_basic() {
 #[test]
 fn straggling_workunits_blocked() {
   // Test that a blocked leaf is not eligible to be rendered.
-  let ws = create_store(vec![], vec![wu_root(0)], vec![wu(1, 0)]);
+  let ws = create_store(vec![wu_root(0)], vec![wu(1, 0)], vec![]);
   assert!(ws.straggling_workunits(Duration::from_secs(0)).is_empty());
 }
 
@@ -53,9 +63,9 @@ fn hex_16_digit_string_actually_uses_input_number() {
 }
 
 fn create_store(
-  completed: Vec<AnonymousWorkunit>,
   started: Vec<AnonymousWorkunit>,
   blocked: Vec<AnonymousWorkunit>,
+  completed: Vec<AnonymousWorkunit>,
 ) -> WorkunitStore {
   let completed_ids = completed
     .iter()
@@ -67,12 +77,21 @@ fn create_store(
     .collect::<HashSet<_>>();
   let ws = WorkunitStore::new(true);
 
-  // Start all of completed, started, and blocked workunits.
-  let workunits = completed
+  // Collect and sort by SpanId.
+  let mut all = started
     .into_iter()
-    .chain(started.into_iter())
     .chain(blocked.into_iter())
+    .chain(completed.into_iter())
+    .collect::<Vec<_>>();
+  all.sort_by(|a, b| a.0.cmp(&b.0));
+
+  // Start all workunits in SpanId order.
+  let workunits = all
+    .into_iter()
     .map(|(span_id, parent_id, metadata)| {
+      if let Some(parent_id) = parent_id {
+        assert!(span_id > parent_id);
+      }
       ws.start_workunit(span_id, format!("{}", span_id.0), parent_id, metadata)
     })
     .collect::<Vec<_>>();


### PR DESCRIPTION
As observed in #12732: when a running workunit had completed children but no running children, it would not be rendered, since it was not a leaf of the workunit graph.

It's possible that we never noticed this before because we tend to create "complete" trees of workunits: i.e. that most of the time below one workunit is taken up by other workunits, rather than having a child cover only a portion of parent's time (as in #12721). But this couldn't always have been the case: after a parent's children complete, it will always run for some amount of time before completing itself: this likely caused flickering in the UI.

This change filters the graph that we maintain for UI purposes to contain only running (Started but not Completed) workunits. In order to remove workunits from the graph when they complete without affecting node ids, we switch to using `StableGraph`. With that bug fixed, also restores the workunit added by #12721.

[ci skip-build-wheels]