### PR TITLE
deprecate `--list-provides` option.

### DIFF
--- a/src/python/pants/backend/project_info/list_targets.py
+++ b/src/python/pants/backend/project_info/list_targets.py
@@ -25,6 +25,8 @@ class ListSubsystem(LineOriented, GoalSubsystem):
             type=bool,
             default=False,
             help="List only targets that provide an artifact.",
+            removal_version="2.9.0.dev0",
+            removal_hint="Filter on python distributions instead: ./pants filter --target-type=python_distribution ::\n",
         )
         register(
             "--documented",


### PR DESCRIPTION
This is pre-work for getting rid of `python_artifact` in favour of fields directly on `python_distribution`. See #12410 

Signed-off-by: Andreas Stenius <andreas.stenius@svenskaspel.se>

[ci skip-build-wheels]