### PR TITLE
Fix a markdown issue in a help string.

### DIFF
--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -204,7 +204,7 @@ class PexEntryPointField(AsyncFieldMixin, SecondaryOwnerMixin, Field):
         "shorthand to specify a file name, using the same syntax as the `sources` field:\n\n  1) "
         "'app.py', Pants will convert into the module `path.to.app`;\n  2) 'app.py:func', Pants "
         "will convert into `path.to.app:func`.\n\nYou must use the file name shorthand for file "
-        "arguments to work with this target.\n\nTo leave off an entry point, set to '<none>'."
+        "arguments to work with this target.\n\nTo leave off an entry point, set to `<none>`."
     )
     required = True
     value: EntryPoint


### PR DESCRIPTION
This rendered as an unknown HTML tag instead of a literal string.
After this change, it renders as desired.

[ci skip-rust]

[ci skip-build-wheels]