### PR TITLE
pin setuptools

### DIFF
--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -26,6 +26,7 @@ function activate_venv() {
   # place, Shellcheck will not be able to find it so we tell Shellcheck to ignore the file.
   # shellcheck source=/dev/null
   source "$(venv_dir)/bin/activate"
+  pip3 install setuptools==57.5.0
 }
 
 function remove_venv() {


### PR DESCRIPTION
setuptools version was floating during bootstrap, causing the error blow. Hence pinning it.
```
Collecting pystache==0.5.3
  Downloading pystache-0.5.3.tar.gz (74 kB)
    ERROR: Command errored out with exit status 1:
     command: /home/travis/build/pantsbuild/intellij-pants-plugin/.cache/pants/build-support/virtualenvs/Linux/pants_dev_deps.py37.venv/bin/python3 -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-8t0fiy4q/pystache_041c47aba33b439798429c5ec3c64764/setup.py'"'"'; __file__='"'"'/tmp/pip-install-8t0fiy4q/pystache_041c47aba33b439798429c5ec3c64764/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-_5f81bn4
         cwd: /tmp/pip-install-8t0fiy4q/pystache_041c47aba33b439798429c5ec3c64764/
    Complete output (3 lines):
    Warning: 'classifiers' should be a list, got type 'tuple'
    error in pystache setup command: use_2to3 is invalid.
    pystache: using: version '58.0.2' of <module 'setuptools' from '/home/travis/build/pantsbuild/intellij-pants-plugin/.cache/pants/build-support/virtualenvs/Linux/pants_dev_deps.py37.venv/lib/python3.7/site-packages/setuptools/__init__.py'>
    ----------------------------------------
WARNING: Discarding https://files.pythonhosted.org/packages/08/e6/c0345da4dbccdcd4d4054e77ba3b9064d05064564d4b9d5978d07b2aab7d/pystache-0.5.3.tar.gz#sha256=445c8663291abf11305693ecac7b9f3ff976555f5506ccc05a0353260a5a16dc (from https://pypi.org/simple/pystache/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
ERROR: Could not find a version that satisfies the requirement pystache==0.5.3 (from versions: 0.1.0, 0.2.0, 0.3.0, 0.3.1, 0.4.0, 0.4.1, 0.5.0, 0.5.1, 0.5.2, 0.5.3, 0.5.4)
ERROR: No matching distribution found for pystache==0.5.3
Failed to install requirements from /home/travis/build/pantsbuild/intellij-pants-plugin/.cache/pants/3rdparty/python/requirements.txt.
The command "./scripts/setup-ci-environment.sh" failed and exited with 1 during .
```