### PR TITLE
[internal] Add `experimental_resolve` to `python_tests`

### DIFF
--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -178,7 +178,11 @@ async def setup_pytest_for_target(
     requirements_pex_get = Get(
         Pex,
         PexFromTargetsRequest,
-        PexFromTargetsRequest.for_requirements([request.field_set.address], internal_only=True),
+        PexFromTargetsRequest.for_requirements(
+            [request.field_set.address],
+            internal_only=True,
+            resolve_and_lockfile=request.field_set.resolve.resolve_and_lockfile(python_setup),
+        ),
     )
     pytest_pex_get = Get(
         Pex,

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -16,6 +16,7 @@ from pants.backend.python.goals.lockfile import PythonLockfileRequest, PythonToo
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import (
     ConsoleScript,
+    PythonResolveField,
     PythonTestsExtraEnvVars,
     PythonTestsSources,
     PythonTestsTimeout,
@@ -49,6 +50,7 @@ class PythonTestFieldSet(TestFieldSet):
     timeout: PythonTestsTimeout
     runtime_package_dependencies: RuntimePackageDependenciesField
     extra_env_vars: PythonTestsExtraEnvVars
+    resolve: PythonResolveField
 
     @classmethod
     def opt_out(cls, tgt: Target) -> bool:

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -532,6 +532,7 @@ class PythonTests(Target):
     core_fields = (
         *COMMON_TARGET_FIELDS,
         InterpreterConstraintsField,
+        PythonResolveField,
         PythonTestsSources,
         PythonTestsDependencies,
         PythonTestsTimeout,


### PR DESCRIPTION
As explained in https://github.com/pantsbuild/pants/pull/12734, this allows you to set the resolve when running a specific test target.

The resolve will not yet be consumed when running Pylint and MyPy on the `python_tests` code, which is blocked by implementing https://github.com/pantsbuild/pants/issues/12714.

[ci skip-rust]
[ci skip-build-wheels]