### PR TITLE
[internal] add registration function for java rules

### DIFF
--- a/src/python/pants/backend/experimental/java/BUILD
+++ b/src/python/pants/backend/experimental/java/BUILD
@@ -1,0 +1,4 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_library()

--- a/src/python/pants/backend/experimental/java/register.py
+++ b/src/python/pants/backend/experimental/java/register.py
@@ -1,0 +1,25 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from pants.backend.java.compile import javac, javac_binary
+from pants.backend.java.target_types import JavaLibrary, JunitTests
+from pants.backend.java.test import junit
+from pants.jvm import util_rules
+from pants.jvm.goals import coursier
+from pants.jvm.resolve import coursier_fetch, coursier_setup
+from pants.jvm.target_types import JvmDependencyLockfile
+
+
+def target_types():
+    return [JavaLibrary, JunitTests, JvmDependencyLockfile]
+
+
+def rules():
+    return [
+        *javac.rules(),
+        *javac_binary.rules(),
+        *junit.rules(),
+        *coursier.rules(),
+        *coursier_fetch.rules(),
+        *coursier_setup.rules(),
+        *util_rules.rules(),
+    ]

--- a/src/python/pants/backend/java/test/junit.py
+++ b/src/python/pants/backend/java/test/junit.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 from pants.backend.java.compile.javac import CompiledClassfiles, CompileJavaSourceRequest
 from pants.backend.java.target_types import JavaTestsSources
-from pants.core.goals.test import TestFieldSet, TestResult
+from pants.core.goals.test import TestDebugRequest, TestFieldSet, TestResult
 from pants.engine.addresses import Addresses
 from pants.engine.fs import AddPrefix, Digest, MergeDigests
 from pants.engine.process import FallibleProcessResult, Process
@@ -116,6 +116,12 @@ async def run_junit_test(
         process_result,
         address=field_set.address,
     )
+
+
+# Required by standard test rules. Do nothing for now.
+@rule(level=LogLevel.DEBUG)
+async def setup_junit_debug_request(_field_set: JavaTestFieldSet) -> TestDebugRequest:
+    raise NotImplementedError("TestDebugResult is not implemented for JUnit (yet?).")
 
 
 def rules():


### PR DESCRIPTION
This adds a registration function under `pants.backend.experimental.java` to register the still-under-active-development Java/JVM rules. This allows me to use the rules in end-to-end testing outside of integration tests.

[ci skip-rust]

[ci skip-build-wheels]