### PR TITLE
[12610] add versions to lockfiles

### DIFF
--- a/3rdparty/python/lockfiles/flake8.txt
+++ b/3rdparty/python/lockfiles/flake8.txt
@@ -4,6 +4,7 @@
 #
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {
+#   "version": 1,
 #   "requirements_invalidation_digest": "815457a1baf6226c993e5468ccdf64c69fe7214d3d9237911c762733e0130526",
 #   "valid_for_interpreter_constraints": [
 #     "CPython<3.10,>=3.7"

--- a/3rdparty/python/lockfiles/pytest.txt
+++ b/3rdparty/python/lockfiles/pytest.txt
@@ -4,6 +4,7 @@
 #
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {
+#   "version": 1,
 #   "requirements_invalidation_digest": "a2057d396be0480d2586be2da25a021149a4f96276b853dd92cc63cfc3ae8503",
 #   "valid_for_interpreter_constraints": [
 #     "CPython<3.10,>=3.7"

--- a/3rdparty/python/lockfiles/user_reqs.txt
+++ b/3rdparty/python/lockfiles/user_reqs.txt
@@ -4,6 +4,7 @@
 #
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {
+#   "version": 1,
 #   "requirements_invalidation_digest": "19770133e0608f747845bc429b61942d2f79b3cad46790962ade28db07e2b4fd",
 #   "valid_for_interpreter_constraints": [
 #     "CPython<3.10,>=3.7"

--- a/src/python/pants/backend/codegen/protobuf/python/mypy_protobuf_lockfile.txt
+++ b/src/python/pants/backend/codegen/protobuf/python/mypy_protobuf_lockfile.txt
@@ -4,6 +4,7 @@
 #
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {
+#   "version": 1,
 #   "requirements_invalidation_digest": "babed61947e74aedbe0cdbaefdaec172db6d4a9d27e12acc80be5ab623e3acdf",
 #   "valid_for_interpreter_constraints": [
 #     "CPython>=3.6"

--- a/src/python/pants/backend/python/lint/bandit/lockfile.txt
+++ b/src/python/pants/backend/python/lint/bandit/lockfile.txt
@@ -4,6 +4,7 @@
 #
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {
+#   "version": 1,
 #   "requirements_invalidation_digest": "b18a9f4d6a8cb4aafb414e9c8108d39dca053f8910ac801c147a932cd37e0040",
 #   "valid_for_interpreter_constraints": [
 #     "CPython<4,>=3.6"
@@ -59,9 +60,9 @@ pyyaml==5.4.1; python_version >= "3.5" and python_full_version < "3.0.0" or pyth
     --hash=sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10 \
     --hash=sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db \
     --hash=sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e
-setuptools==57.4.0; python_version >= "3.6" \
-    --hash=sha256:a49230977aa6cfb9d933614d2f7b79036e9945c4cdd7583163f4e920b83418d6 \
-    --hash=sha256:6bac238ffdf24e8806c61440e755192470352850f3419a52f26ffe0a1a64f465
+setuptools==58.0.3; python_version >= "3.6" \
+    --hash=sha256:1ceadf3ea9a821ef305505db995f2e21550ea62500900164278c4b23109204f3 \
+    --hash=sha256:5e4c36f55012a46c1b3e4b67a8236d1d73856a90fc7b3207d29bedb7d2bac417
 six==1.16.0; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5" \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926

--- a/src/python/pants/backend/python/lint/black/lockfile.txt
+++ b/src/python/pants/backend/python/lint/black/lockfile.txt
@@ -4,6 +4,7 @@
 #
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {
+#   "version": 1,
 #   "requirements_invalidation_digest": "1ba5f97d92f33b13e0cd56a960380fa6f616fae215d715ddd7a7ebf99795c890",
 #   "valid_for_interpreter_constraints": [
 #     "CPython>=3.6.2"

--- a/src/python/pants/backend/python/lint/docformatter/lockfile.txt
+++ b/src/python/pants/backend/python/lint/docformatter/lockfile.txt
@@ -4,6 +4,7 @@
 #
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {
+#   "version": 1,
 #   "requirements_invalidation_digest": "4ee50d37e5a334d7d496e9f7147dbbf19ee2eb0faaea33e46a553b6c692c7672",
 #   "valid_for_interpreter_constraints": [
 #     "CPython>=3.6"

--- a/src/python/pants/backend/python/lint/flake8/lockfile.txt
+++ b/src/python/pants/backend/python/lint/flake8/lockfile.txt
@@ -4,6 +4,7 @@
 #
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {
+#   "version": 1,
 #   "requirements_invalidation_digest": "ebd4b2326fca44e0d0b362def86bddc1b57e6f6d6c4f077fef5e1218286d3883",
 #   "valid_for_interpreter_constraints": [
 #     "CPython<4,>=3.6"

--- a/src/python/pants/backend/python/lint/isort/lockfile.txt
+++ b/src/python/pants/backend/python/lint/isort/lockfile.txt
@@ -4,9 +4,10 @@
 #
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {
+#   "version": 1,
 #   "requirements_invalidation_digest": "56fe21a2ac24d6f257d95eb97829e8c3cb65e2156cd987348ce837c055763302",
 #   "valid_for_interpreter_constraints": [
-#     "CPython<4,>=3.6.1"
+#     "CPython<4,>=3.7"
 #   ]
 # }
 # --- END PANTS LOCKFILE METADATA ---

--- a/src/python/pants/backend/python/lint/pylint/lockfile.txt
+++ b/src/python/pants/backend/python/lint/pylint/lockfile.txt
@@ -4,6 +4,7 @@
 #
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {
+#   "version": 1,
 #   "requirements_invalidation_digest": "b098df4cb8b4729e91282a0894f8804314269decfafe1a00d65b254074c63b8b",
 #   "valid_for_interpreter_constraints": [
 #     "CPython<4,>=3.6"

--- a/src/python/pants/backend/python/lint/yapf/lockfile.txt
+++ b/src/python/pants/backend/python/lint/yapf/lockfile.txt
@@ -4,6 +4,7 @@
 #
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {
+#   "version": 1,
 #   "requirements_invalidation_digest": "7b946efbcd8abc2a50c548b71c84b34e44eabf0430246b309d63d6200dc5715b",
 #   "valid_for_interpreter_constraints": [
 #     "CPython>=3.6"

--- a/src/python/pants/backend/python/subsystems/coverage_py_lockfile.txt
+++ b/src/python/pants/backend/python/subsystems/coverage_py_lockfile.txt
@@ -4,6 +4,7 @@
 #
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {
+#   "version": 1,
 #   "requirements_invalidation_digest": "ed5d33bbada4d1d96c7d57e100c72bdb5f26d6fed4f1e77b0e74f2ea5e43e642",
 #   "valid_for_interpreter_constraints": [
 #     "CPython<4,>=3.6"

--- a/src/python/pants/backend/python/subsystems/ipython_lockfile.txt
+++ b/src/python/pants/backend/python/subsystems/ipython_lockfile.txt
@@ -4,6 +4,7 @@
 #
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {
+#   "version": 1,
 #   "requirements_invalidation_digest": "fe82372002915f2550a0b25fea5b6f360c639252ad607a978e7e2f6cbd94c99a",
 #   "valid_for_interpreter_constraints": [
 #     "CPython<4,>=3.6"
@@ -50,9 +51,9 @@ ptyprocess==0.7.0; sys_platform != "win32" and python_version >= "3.6" \
 pygments==2.10.0; python_version >= "3.6" \
     --hash=sha256:b8e67fe6af78f492b3c4b3e2970c0624cbf08beb1e493b2c99b9fa1b67a20380 \
     --hash=sha256:f398865f7eb6874156579fdf36bc840a03cab64d1cde9e93d68f46a425ec52c6
-setuptools==57.4.0; python_version >= "3.6" \
-    --hash=sha256:a49230977aa6cfb9d933614d2f7b79036e9945c4cdd7583163f4e920b83418d6 \
-    --hash=sha256:6bac238ffdf24e8806c61440e755192470352850f3419a52f26ffe0a1a64f465
+setuptools==58.0.3; python_version >= "3.6" \
+    --hash=sha256:1ceadf3ea9a821ef305505db995f2e21550ea62500900164278c4b23109204f3 \
+    --hash=sha256:5e4c36f55012a46c1b3e4b67a8236d1d73856a90fc7b3207d29bedb7d2bac417
 six==1.16.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6" \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926

--- a/src/python/pants/backend/python/subsystems/lambdex_lockfile.txt
+++ b/src/python/pants/backend/python/subsystems/lambdex_lockfile.txt
@@ -4,6 +4,7 @@
 #
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {
+#   "version": 1,
 #   "requirements_invalidation_digest": "b3766b556f0c70fe89e235378292cb1369830e316df7ab0d4861a7dd0755f856",
 #   "valid_for_interpreter_constraints": [
 #     "CPython<3.10,>=3.6"

--- a/src/python/pants/backend/python/subsystems/pytest_lockfile.txt
+++ b/src/python/pants/backend/python/subsystems/pytest_lockfile.txt
@@ -4,6 +4,7 @@
 #
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {
+#   "version": 1,
 #   "requirements_invalidation_digest": "ac24b96fe05b827037bcb568a7578ecf36ae84929bb1409bc9dd0a89d5a2ec70",
 #   "valid_for_interpreter_constraints": [
 #     "CPython<4,>=3.6"

--- a/src/python/pants/backend/python/subsystems/setuptools_lockfile.txt
+++ b/src/python/pants/backend/python/subsystems/setuptools_lockfile.txt
@@ -4,6 +4,7 @@
 #
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {
+#   "version": 1,
 #   "requirements_invalidation_digest": "a5ec2e69360b67f3262d8ecc191c0227f09216343e97e8c9e2a34ce567b07c29",
 #   "valid_for_interpreter_constraints": [
 #     "CPython<4,>=3.6"
@@ -11,9 +12,9 @@
 # }
 # --- END PANTS LOCKFILE METADATA ---
 
-setuptools==57.4.0; python_version >= "3.6" \
-    --hash=sha256:a49230977aa6cfb9d933614d2f7b79036e9945c4cdd7583163f4e920b83418d6 \
-    --hash=sha256:6bac238ffdf24e8806c61440e755192470352850f3419a52f26ffe0a1a64f465
+setuptools==57.5.0; python_version >= "3.6" \
+    --hash=sha256:60d78588f15b048f86e35cdab73003d8b21dd45108ee61a6693881a427f22073 \
+    --hash=sha256:d9d3266d50f59c6967b9312844470babbdb26304fe740833a5f8d89829ba3a24
 wheel==0.37.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0") \
     --hash=sha256:21014b2bd93c6d0034b6ba5d35e4eb284340e09d63c59aef6fc14b0f346146fd \
     --hash=sha256:e2ef7239991699e3355d54f8e968a21bb940a1dbf34a4d226741e64462516fad

--- a/src/python/pants/backend/python/typecheck/mypy/lockfile.txt
+++ b/src/python/pants/backend/python/typecheck/mypy/lockfile.txt
@@ -4,6 +4,7 @@
 #
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {
+#   "version": 1,
 #   "requirements_invalidation_digest": "2bcd33a72af5d12ea4fcc7ada9dcaf7fa1017ba8286216e88c43ad9e1823ce75",
 #   "valid_for_interpreter_constraints": [
 #     "CPython>=3.6"

--- a/src/python/pants/backend/python/util_rules/lockfile_metadata.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_metadata.py
@@ -29,7 +29,7 @@ class LockfileMetadata:
 
     @classmethod
     def from_lockfile(
-        cls, lockfile: bytes, lockfile_scope_name: str | None = None
+        cls, lockfile: bytes, lockfile_path: str | None = None, resolve_name: str | None = None
     ) -> LockfileMetadata:
         """Parse all relevant metadata from the lockfile's header."""
         in_metadata_block = False
@@ -43,21 +43,22 @@ class LockfileMetadata:
                 metadata_lines.append(line[2:])
 
         error_suffix = "To resolve this error, you will need to regenerate the lockfile by running `./pants generate-lockfiles"
-
-        if lockfile_scope_name:
+        if resolve_name:
             error_suffix += "--resolve={tool_name}"
-
         error_suffix += "`."
 
-        lockfile_description: str = ""
-        if lockfile_scope_name:
-            lockfile_description = f"the lockfile for `{lockfile_scope_name}`"
+        if lockfile_path is not None and resolve_name is not None:
+            lockfile_description = f"the lockfile `{lockfile_path}` for `{resolve_name}`"
+        elif lockfile_path is not None:
+            lockfile_description = f"the lockfile `{lockfile_path}`"
+        elif resolve_name is not None:
+            lockfile_description = f"the lockfile for `{resolve_name}`"
         else:
-            """this lockfile."""
+            lockfile_description = "this lockfile"
 
         if not metadata_lines:
             raise InvalidLockfileError(
-                f"Could not find a pants metadata block in this {lockfile_scope_name}. {error_suffix}"
+                f"Could not find a pants metadata block in {lockfile_description}. {error_suffix}"
             )
 
         try:

--- a/src/python/pants/backend/python/util_rules/lockfile_metadata.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_metadata.py
@@ -42,7 +42,10 @@ class LockfileMetadata:
             elif in_metadata_block:
                 metadata_lines.append(line[2:])
 
-        error_suffix = "To resolve this error, you will need to regenerate the lockfile by running `./pants generate-lockfiles"
+        error_suffix = (
+            "To resolve this error, you will need to regenerate the lockfile by running "
+            "`./pants generate-lockfiles"
+        )
         if resolve_name:
             error_suffix += "--resolve={tool_name}"
         error_suffix += "`."

--- a/src/python/pants/backend/python/util_rules/lockfile_metadata.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_metadata.py
@@ -15,6 +15,7 @@ from pants.util.ordered_set import FrozenOrderedSet
 BEGIN_LOCKFILE_HEADER = b"# --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---"
 END_LOCKFILE_HEADER = b"# --- END PANTS LOCKFILE METADATA ---"
 
+LOCKFILE_VERSION = 1
 
 class InvalidLockfileError(Exception):
     pass
@@ -24,6 +25,15 @@ class InvalidLockfileError(Exception):
 class LockfileMetadata:
     requirements_invalidation_digest: str
     valid_for_interpreter_constraints: InterpreterConstraints
+
+    @staticmethod
+    def new(requirements_invalidation_digest: str, valid_for_interpreter_constraints: InterpreterConstraints) -> LockfileMetadata:
+        """Call the most recent version of the `LockfileMetadata` class to construct a concrete instance.
+        
+        This static method should be used in place of the `LockfileMetadata` constructor.
+        """
+        
+        return LockfileMetadata(requirements_invalidation_digest, valid_for_interpreter_constraints)
 
     @classmethod
     def from_lockfile(cls, lockfile: bytes) -> LockfileMetadata:
@@ -72,6 +82,7 @@ class LockfileMetadata:
 
     def add_header_to_lockfile(self, lockfile: bytes, *, regenerate_command: str) -> bytes:
         metadata_dict = {
+            "version": LOCKFILE_VERSION,
             "requirements_invalidation_digest": self.requirements_invalidation_digest,
             "valid_for_interpreter_constraints": [
                 str(ic) for ic in self.valid_for_interpreter_constraints

--- a/src/python/pants/backend/python/util_rules/lockfile_metadata_test.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_metadata_test.py
@@ -39,6 +39,7 @@ def test_add_header_to_lockfile() -> None:
 #
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {
+#   "version": 1,
 #   "requirements_invalidation_digest": "000faaafcacacaca",
 #   "valid_for_interpreter_constraints": [
 #     "CPython>=3.7"

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -483,7 +483,8 @@ async def build_pex_component(
     constraint_file_digest = EMPTY_DIGEST
     requirements_file_digest = EMPTY_DIGEST
 
-    lockfile_scope_name = (
+    # TODO(#12314): Capture the resolve name for multiple user lockfiles.
+    resolve_name = (
         request.requirements.options_scope_name
         if isinstance(request.requirements, (ToolDefaultLockfile, ToolCustomLockfile))
         else None
@@ -504,7 +505,7 @@ async def build_pex_component(
         metadata = LockfileMetadata.from_lockfile(
             requirements_file_digest_contents[0].content,
             request.requirements.file_path,
-            lockfile_scope_name,
+            resolve_name,
         )
         _validate_metadata(metadata, request, request.requirements, python_setup)
 
@@ -516,7 +517,7 @@ async def build_pex_component(
         argv.append("--no-transitive")
 
         metadata = LockfileMetadata.from_lockfile(
-            file_content.content, resolve_name=lockfile_scope_name
+            file_content.content, resolve_name=resolve_name
         )
         _validate_metadata(metadata, request, request.requirements, python_setup)
 

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -516,9 +516,7 @@ async def build_pex_component(
         argv.extend(["--requirement", file_content.path])
         argv.append("--no-transitive")
 
-        metadata = LockfileMetadata.from_lockfile(
-            file_content.content, resolve_name=resolve_name
-        )
+        metadata = LockfileMetadata.from_lockfile(file_content.content, resolve_name=resolve_name)
         _validate_metadata(metadata, request, request.requirements, python_setup)
 
         requirements_file_digest = await Get(Digest, CreateDigest([file_content]))

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -683,6 +683,7 @@ def _run_pex_for_lockfile_test(
     lockfile = f"""
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {{
+#   "version": 1,
 #   "requirements_invalidation_digest": "{actual_digest}",
 #   "valid_for_interpreter_constraints": [
 #     "{ actual_constraints }"


### PR DESCRIPTION
This adds a `version` field to lockfiles, starting at version 1, which will allow for simpler validation logic when we start updating the expected metadata in lockfile headers.

This also adds new error messages to `LockfileMetadata.from_lockfile`

Added per request by @Eric-Arellano in #12782.