### PR TITLE
[internal] Test that default IPython lockfile works for all Python interpreters and macOS (Cherry-pick of #12791)

### DIFF
--- a/src/python/pants/backend/python/goals/BUILD
+++ b/src/python/pants/backend/python/goals/BUILD
@@ -30,6 +30,14 @@ python_tests(
 )
 
 python_tests(
+    name="repl_integration",
+    sources=["repl_integration_test.py"],
+    # We want to make sure the default lockfile works for both macOS and Linux.
+    tags=["platform_specific_behavior"],
+    timeout=120,
+)
+
+python_tests(
     name="run_pex_binary_integration",
     sources=["run_pex_binary_integration_test.py"],
     timeout=200,

--- a/src/python/pants/backend/python/goals/repl_integration_test.py
+++ b/src/python/pants/backend/python/goals/repl_integration_test.py
@@ -1,5 +1,7 @@
-# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
 
 import pytest
 
@@ -12,7 +14,9 @@ from pants.backend.python.util_rules.pex import PexProcess
 from pants.core.goals.repl import Repl
 from pants.core.goals.repl import rules as repl_rules
 from pants.engine.process import Process
-from pants.testutil.rule_runner import QueryRule, RuleRunner, mock_console
+from pants.python.python_setup import PythonSetup
+from pants.testutil.python_interpreter_selection import all_major_minor_python_versions
+from pants.testutil.rule_runner import GoalRuleResult, QueryRule, RuleRunner, mock_console
 
 
 @pytest.fixture
@@ -39,44 +43,40 @@ def rule_runner() -> RuleRunner:
     return rule_runner
 
 
-def test_repl_with_targets(rule_runner: RuleRunner) -> None:
+def run_repl(rule_runner: RuleRunner, *, extra_args: list[str] | None = None) -> GoalRuleResult:
     # TODO(#9108): Expand `mock_console` to allow for providing input for the repl to verify
     # that, e.g., the generated protobuf code is available. Right now this test prepares for
     # that by including generated code, but cannot actually verify it.
     with mock_console(rule_runner.options_bootstrapper):
-        result = rule_runner.run_goal_rule(
+        return rule_runner.run_goal_rule(
             Repl,
             global_args=[
                 "--backend-packages=pants.backend.python",
                 "--backend-packages=pants.backend.codegen.protobuf.python",
+                *(extra_args or ()),
             ],
             args=["src/python/lib.py"],
             env_inherit={"PATH", "PYENV_ROOT", "HOME"},
         )
-    assert result.exit_code == 0
 
 
-def test_repl_ipython(rule_runner: RuleRunner) -> None:
-    with mock_console(rule_runner.options_bootstrapper):
-        result = rule_runner.run_goal_rule(
-            Repl,
-            global_args=[
-                "--backend-packages=pants.backend.python",
-                "--backend-packages=pants.backend.codegen.protobuf.python",
+def test_default_repl(rule_runner: RuleRunner) -> None:
+    assert run_repl(rule_runner).exit_code == 0
+
+
+@pytest.mark.platform_specific_behavior
+@pytest.mark.parametrize(
+    "major_minor_interpreter",
+    all_major_minor_python_versions(PythonSetup.default_interpreter_constraints),
+)
+def test_ipython(rule_runner: RuleRunner, major_minor_interpreter: str) -> None:
+    assert (
+        run_repl(
+            rule_runner,
+            extra_args=[
+                "--repl-shell=ipython",
+                f"--python-setup-interpreter-constraints=['=={major_minor_interpreter}.*']",
             ],
-            args=["--shell=ipython", "src/python/lib.py"],
-            env_inherit={"PATH", "PYENV_ROOT", "HOME"},
-        )
-    assert result.exit_code == 0
-
-
-def test_repl_bogus_repl_name(rule_runner: RuleRunner) -> None:
-    with mock_console(rule_runner.options_bootstrapper):
-        result = rule_runner.run_goal_rule(
-            Repl,
-            global_args=["--backend-packages=pants.backend.python"],
-            args=["--shell=bogus-repl", "src/python/lib.py"],
-            env_inherit={"PATH", "PYENV_ROOT", "HOME"},
-        )
-    assert result.exit_code == -1
-    assert "'bogus-repl' is not a registered REPL. Available REPLs" in result.stderr
+        ).exit_code
+        == 0
+    )

--- a/src/python/pants/core/goals/repl_test.py
+++ b/src/python/pants/core/goals/repl_test.py
@@ -1,0 +1,41 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import pytest
+
+from pants.core.goals.repl import Repl, ReplImplementation, ReplRequest
+from pants.core.goals.repl import rules as repl_rules
+from pants.engine.fs import CreateDigest, Digest, FileContent
+from pants.engine.rules import Get, rule
+from pants.engine.unions import UnionRule
+from pants.testutil.rule_runner import RuleRunner, mock_console
+
+
+class MockRepl(ReplImplementation):
+    name = "mock"
+
+
+@rule
+async def create_mock_repl_request(repl: MockRepl) -> ReplRequest:
+    digest = await Get(Digest, CreateDigest([FileContent("repl.sh", b"exit 0")]))
+    return ReplRequest(digest=digest, args=("/bin/bash", repl.in_chroot("repl.sh")))
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=(*repl_rules(), create_mock_repl_request, UnionRule(ReplImplementation, MockRepl)),
+    )
+
+
+def test_valid_repl(rule_runner: RuleRunner) -> None:
+    with mock_console(rule_runner.options_bootstrapper):
+        result = rule_runner.run_goal_rule(Repl, args=[f"--shell={MockRepl.name}"])
+    assert result.exit_code == 0
+
+
+def test_unrecognized_repl(rule_runner: RuleRunner) -> None:
+    with mock_console(rule_runner.options_bootstrapper):
+        result = rule_runner.run_goal_rule(Repl, args=["--shell=bogus-repl"])
+    assert result.exit_code == -1
+    assert "'bogus-repl' is not a registered REPL. Available REPLs" in result.stderr


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/12657.

To land this, we move our tests of Python REPLs to `backend/python` instead of `core/goals`, and add a new more generic test for `core/goals`.

[ci skip-rust]
[ci skip-build-wheels]