### PR TITLE
Warn if `[python-repos]` is set during lockfile generation

### DIFF
--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -371,10 +371,11 @@ def warn_python_repos(option: str) -> None:
         f"The option `[python-repos].{option}` is configured, but it does not currently work "
         "with lockfile generation. Lockfile generation will fail if the relevant requirements "
         "cannot be located on PyPI.\n\n"
-        "If lockfile generation fails, you can either disable lockfiles by setting "
-        "`[tool].lockfile = '<none>'`, e.g. setting `[black].lockfile`, or you can manually "
-        "generate lockfiles, e.g. by using pip-compile or `pip freeze`. If manually generating "
-        "lockfiles, you should set `[python-setup].invalid_lockfile_behavior = 'ignore'."
+        "If lockfile generation fails, you can disable lockfiles by setting "
+        "`[tool].lockfile = '<none>'`, e.g. setting `[black].lockfile`. You can also manually "
+        "generate a lockfile, such as by using pip-compile or `pip freeze`. Set the "
+        "`[tool].lockfile` option to the path you manually generated. When manually maintaining "
+        "lockfiles, set `[python-setup].invalid_lockfile_behavior = 'ignore'."
     )
 
 

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -110,7 +110,11 @@ class PythonToolRequirementsBase(Subsystem):
                     "To use a custom lockfile, set this option to a file path relative to the "
                     f"build root, then run `./pants generate-lockfiles "
                     f"--resolve={cls.options_scope}`.\n\n"
-                    ""
+                    "Lockfile generation currently does not wire up the `[python-repos]` options. "
+                    "If lockfile generation fails, you can set this option to a manually "
+                    "generated lockfile path, such as using pip-compile or `pip freeze` to "
+                    "generate the lockfile. When manually maintaining lockfiles, set "
+                    "`[python-setup].invalid_lockfile_behavior = 'ignore'`."
                 ),
             )
 

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -111,9 +111,9 @@ class PythonToolRequirementsBase(Subsystem):
                     f"build root, then run `./pants generate-lockfiles "
                     f"--resolve={cls.options_scope}`.\n\n"
                     "Lockfile generation currently does not wire up the `[python-repos]` options. "
-                    "If lockfile generation fails, you can set this option to a manually "
-                    "generated lockfile path, such as using pip-compile or `pip freeze` to "
-                    "generate the lockfile. When manually maintaining lockfiles, set "
+                    "If lockfile generation fails, you can manually generate a lockfile, such as "
+                    "by using pip-compile or `pip freeze`. Set this option to the path to your "
+                    "manually generated lockfile. When manually maintaining lockfiles, set "
                     "`[python-setup].invalid_lockfile_behavior = 'ignore'`."
                 ),
             )

--- a/src/python/pants/python/python_repos.py
+++ b/src/python/pants/python/python_repos.py
@@ -13,6 +13,8 @@ class PythonRepos(Subsystem):
         "custom cheeseshops when resolving requirements."
     )
 
+    pypi_index = "https://pypi.org/simple/"
+
     @classmethod
     def register_options(cls, register):
         super().register_options(register)
@@ -30,7 +32,7 @@ class PythonRepos(Subsystem):
             "--indexes",
             advanced=True,
             type=list,
-            default=["https://pypi.org/simple/"],
+            default=[cls.pypi_index],
             help=(
                 "URLs of code repository indexes to look for requirements. If set to an empty "
                 "list, then Pex will use no indices (meaning it will not use PyPI). The values "


### PR DESCRIPTION

[ci skip-rust]
[ci skip-build-wheels]