### PR TITLE
[WIP] Add target generation: macros that can use the Rules API

### DIFF
--- a/3rdparty/python/BUILD
+++ b/3rdparty/python/BUILD
@@ -4,6 +4,8 @@
 # See requirements.txt in this directory to change deps.
 python_requirements()
 
+python_requirements_new(name="new_requirements")
+
 # Useful when using IntelliJ/PyCharm remote debugging. Importing `pydevd_pycharm` at
 # the breakpoint will cause dep inference to add this dep on the remote debugger client.
 python_requirement_library(

--- a/src/python/pants/backend/python/macros/python_requirements_new.py
+++ b/src/python/pants/backend/python/macros/python_requirements_new.py
@@ -1,0 +1,131 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import itertools
+import logging
+import os.path
+from dataclasses import dataclass
+from typing import ClassVar, TypeVar
+
+from pants.backend.python.target_types import (
+    ModuleMappingField,
+    PythonRequirementLibrary,
+    PythonRequirementsField,
+    PythonRequirementsMacro,
+    PythonRequirementsRelpath,
+    TypeStubsModuleMappingField,
+    parse_requirements_file,
+)
+from pants.base.specs import AddressSpecs, DescendantAddresses
+from pants.engine.addresses import Address
+from pants.engine.collection import Collection
+from pants.engine.fs import DigestContents, GlobMatchErrorBehavior, PathGlobs
+from pants.engine.goal import Goal, GoalSubsystem
+from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
+from pants.engine.target import Target, UnexpandedTargets, WrappedTarget
+from pants.engine.unions import UnionMembership, UnionRule, union
+
+logger = logging.getLogger(__name__)
+
+
+_T = TypeVar("_T", bound=Target)
+
+
+@union
+@dataclass(frozen=True)
+class GenerateTargetsRequest:
+    target_class: ClassVar[type[_T]]
+    target: _T
+
+
+class GeneratePythonRequirementLibrariesFromPythonRequirements(GenerateTargetsRequest):
+    target_class = PythonRequirementsMacro
+
+
+class GeneratedTargets(Collection[Target]):
+    pass
+
+
+@rule
+async def generate_python_requirement_libraries_from_requirements_file(
+    request: GeneratePythonRequirementLibrariesFromPythonRequirements,
+) -> GeneratedTargets:
+    relpath = os.path.join(
+        request.target.address.spec_path, request.target[PythonRequirementsRelpath].value
+    )
+    digest_contents = await Get(
+        DigestContents,
+        PathGlobs(
+            [relpath],
+            glob_match_error_behavior=GlobMatchErrorBehavior.error,
+            description_of_origin=f"{request.target}'s field `{PythonRequirementsRelpath.alias}`",
+        ),
+    )
+    requirements = parse_requirements_file(digest_contents[0].content.decode(), rel_path=relpath)
+    grouped_requirements = itertools.groupby(
+        requirements, lambda parsed_req: parsed_req.project_name
+    )
+    result = []
+    module_mapping = {}
+    type_stubs_module_mapping = {}
+    for project_name, parsed_reqs in grouped_requirements:
+        req_module_mapping = (
+            {project_name: module_mapping[project_name]}
+            if module_mapping and project_name in module_mapping
+            else None
+        )
+        stubs_module_mapping = (
+            {project_name: type_stubs_module_mapping[project_name]}
+            if type_stubs_module_mapping and project_name in type_stubs_module_mapping
+            else None
+        )
+        generated_tgt = PythonRequirementLibrary(
+            {
+                PythonRequirementsField.alias: list(parsed_reqs),
+                ModuleMappingField.alias: req_module_mapping,
+                TypeStubsModuleMappingField.alias: stubs_module_mapping,
+            },
+            Address(request.target.address.spec_path, target_name=project_name),
+        )
+        result.append(generated_tgt)
+
+    return GeneratedTargets(result)
+
+
+class TargetGenSubsystem(GoalSubsystem):
+    name = "target-gen"
+    help = "Foo"
+    required_union_implementations = (GenerateTargetsRequest,)
+
+
+class TargetGen(Goal):
+    subsystem_cls = TargetGenSubsystem
+
+
+@goal_rule
+async def gen_targets(union_membership: UnionMembership) -> TargetGen:
+    target_types_to_generate_requests = {
+        request_cls.target_class: request_cls
+        for request_cls in union_membership[GenerateTargetsRequest]
+    }
+
+    all_build_targets = await Get(UnexpandedTargets, AddressSpecs([DescendantAddresses("")]))
+    generate_requests = []
+    for tgt in all_build_targets:
+        tgt_type = type(tgt)
+        if tgt_type not in target_types_to_generate_requests:
+            continue
+        generate_requests.append(target_types_to_generate_requests[tgt_type](tgt))
+
+    all_generated = await MultiGet(
+        Get(GeneratedTargets, GenerateTargetsRequest, request) for request in generate_requests
+    )
+    logger.error([tgt.address.spec for generated in all_generated for tgt in generated])
+    return TargetGen(exit_code=0)
+
+
+def rules():
+    return (
+        *collect_rules(),
+        UnionRule(GenerateTargetsRequest, GeneratePythonRequirementLibrariesFromPythonRequirements),
+    )

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -18,6 +18,7 @@ from pants.backend.python.goals import (
     setup_py,
     tailor,
 )
+from pants.backend.python.macros import python_requirements_new
 from pants.backend.python.macros.pants_requirement import PantsRequirement
 from pants.backend.python.macros.pipenv_requirements import PipenvRequirements
 from pants.backend.python.macros.poetry_requirements import PoetryRequirements
@@ -30,6 +31,7 @@ from pants.backend.python.target_types import (
     PythonLibrary,
     PythonRequirementLibrary,
     PythonRequirementsFile,
+    PythonRequirementsMacro,
     PythonTests,
 )
 from pants.backend.python.util_rules import (
@@ -77,6 +79,7 @@ def rules():
         *setuptools.rules(),
         *ipython.rules(),
         *pytest.rules(),
+        *python_requirements_new.rules(),
     )
 
 
@@ -87,5 +90,6 @@ def target_types():
         PythonLibrary,
         PythonRequirementLibrary,
         PythonRequirementsFile,
+        PythonRequirementsMacro,
         PythonTests,
     ]

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -727,6 +727,54 @@ class PythonRequirementLibrary(Target):
 
 
 # -----------------------------------------------------------------------------------------------
+# `python_requirements` macro
+# -----------------------------------------------------------------------------------------------
+
+
+class PythonRequirementsRelpath(StringField):
+    alias = "requirements_relpath"
+    default = "requirements.txt"
+    help = (
+        "The relpath from this BUILD file to the requirements file.\n\n"
+        "Defaults to a `requirements.txt` file sibling to the BUILD file."
+    )
+    value: str
+
+
+class PythonRequirementsModuleMapping(DictStringToStringSequenceField):
+    alias = "module_mapping"
+    help = (
+        "A mapping of requirement names to a list of the modules they provide."
+        "\n\nFor example, `{'ansicolors': ['colors']}`.\n\n"
+        "Any unspecified requirements will use the requirement name as the default module, e.g. "
+        "'Django' will default to `modules=['django']`."
+    )
+
+
+class PythonRequirementsTypeStubsModuleMapping(DictStringToStringSequenceField):
+    alias = "type_stubs_module_mapping"
+    help = (
+        "A mapping of requirement names for type-stub dependencies to a list of the modules they "
+        "provide type stubs for."
+        "\n\nFor example, `{'types-pillow': ['PIL']}`.\n\n"
+        "Any unspecified requirements that start with `types-` or `stubs-`, or end with "
+        "`-types` or `-stubs`, will default to the project name without the prefix/suffix. For "
+        "example, `types-requests` defaults to `requests`. "
+    )
+
+
+class PythonRequirementsMacro(Target):
+    alias = "python_requirements_new"
+    help = "Macro to convert `requirements.txt` into `python_requirement_library` targets."
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        PythonRequirementsRelpath,
+        PythonRequirementsModuleMapping,
+        PythonRequirementsTypeStubsModuleMapping,
+    )
+
+
+# -----------------------------------------------------------------------------------------------
 # `_python_requirements_file` target
 # -----------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/7022. "Context aware object factories" can now be replaced by "target generation". 

## User experience

Users are agnostic to whether a target was generated vs. defined in a BUILD file. `./pants list ::` shows everything.

However, to facilitate transparency, a followup will add a `derived_from` property to `Target` and include it in `./pants peek`'s JSON.

## Generating from a target

Target generation generates 0-n targets from a single target. That base target uses the Target API like normal, meaning that `python_requirements` will no longer be some special type but just a normal target. 

It's plausible that we will eventually want to remove this requirement and allow generating a target from nothing, like `./pants tailor` but entirely in-memory.
