### PR TITLE
[internal] Simplify PEX setup for `./pants run`

### DIFF
--- a/src/python/pants/backend/python/goals/run_pex_binary.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary.py
@@ -9,7 +9,7 @@ from pants.backend.python.target_types import (
     ResolvedPexEntryPoint,
     ResolvePexEntryPointRequest,
 )
-from pants.backend.python.util_rules.pex import Pex, PexRequest
+from pants.backend.python.util_rules.pex import Pex
 from pants.backend.python.util_rules.pex_environment import PexEnvironment
 from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
 from pants.backend.python.util_rules.python_sources import (
@@ -40,67 +40,45 @@ async def create_pex_binary_run_request(
         Get(TransitiveTargets, TransitiveTargetsRequest([field_set.address])),
     )
 
-    # Note that we get an intermediate PexRequest here (instead of going straight to a Pex)
-    # so that we can get the interpreter constraints for use in runner_pex_request.
-    requirements_pex_request = await Get(
-        PexRequest,
-        PexFromTargetsRequest,
-        PexFromTargetsRequest.for_requirements(
-            [field_set.address],
-            internal_only=True,
-            resolve_and_lockfile=field_set.resolve.resolve_and_lockfile(python_setup),
-        ),
-    )
-
-    requirements_request = Get(Pex, PexRequest, requirements_pex_request)
-
-    sources_request = Get(
-        PythonSourceFiles, PythonSourceFilesRequest(transitive_targets.closure, include_files=True)
-    )
-
-    output_filename = f"{field_set.address.target_name}.pex"
-    runner_pex_request = Get(
+    pex_get = Get(
         Pex,
-        PexRequest(
-            output_filename=output_filename,
-            interpreter_constraints=requirements_pex_request.interpreter_constraints,
-            additional_args=(
-                *field_set.generate_additional_args(pex_binary_defaults),
-                # N.B.: Since we cobble together the runtime environment via PEX_PATH and
-                # PEX_EXTRA_SYS_PATH below, it's important for any app that re-executes itself that
-                # these environment variables are not stripped.
-                "--no-strip-pex-env",
-            ),
+        PexFromTargetsRequest(
+            [field_set.address],
+            output_filename=f"{field_set.address.target_name}.pex",
             internal_only=True,
-            # Note that the entry point file is not in the PEX itself. It's loaded by setting
-            # `PEX_EXTRA_SYS_PATH`.
+            include_source_files=False,
+            # Note that the file for first-party entry points is not in the PEX itself. In that
+            # case, it's loaded by setting `PEX_EXTRA_SYS_PATH`.
             # TODO(John Sirois): Support ConsoleScript in PexBinary targets:
             #  https://github.com/pantsbuild/pants/issues/11619
             main=entry_point.val,
+            resolve_and_lockfile=field_set.resolve.resolve_and_lockfile(python_setup),
+            additional_args=(
+                *field_set.generate_additional_args(pex_binary_defaults),
+                # N.B.: Since we cobble together the runtime environment via PEX_EXTRA_SYS_PATH
+                # below, it's important for any app that re-executes itself that these environment
+                # variables are not stripped.
+                "--no-strip-pex-env",
+            ),
         ),
     )
-
-    requirements, sources, runner_pex = await MultiGet(
-        requirements_request, sources_request, runner_pex_request
+    sources_get = Get(
+        PythonSourceFiles, PythonSourceFilesRequest(transitive_targets.closure, include_files=True)
     )
-
+    pex, sources = await MultiGet(pex_get, sources_get)
     merged_digest = await Get(
-        Digest,
-        MergeDigests(
-            [requirements.digest, sources.source_files.snapshot.digest, runner_pex.digest]
-        ),
+        Digest, MergeDigests([pex.digest, sources.source_files.snapshot.digest])
     )
 
     def in_chroot(relpath: str) -> str:
         return os.path.join("{chroot}", relpath)
 
     complete_pex_env = pex_env.in_workspace()
-    args = complete_pex_env.create_argv(in_chroot(runner_pex.name), python=runner_pex.python)
+    args = complete_pex_env.create_argv(in_chroot(pex.name), python=pex.python)
 
     chrooted_source_roots = [in_chroot(sr) for sr in sources.source_roots]
     extra_env = {
-        **complete_pex_env.environment_dict(python_configured=runner_pex.python is not None),
-        "PEX_PATH": in_chroot(requirements_pex_request.output_filename),
+        **complete_pex_env.environment_dict(python_configured=pex.python is not None),
         "PEX_EXTRA_SYS_PATH": ":".join(chrooted_source_roots),
     }
 


### PR DESCRIPTION
To implement https://github.com/pantsbuild/pants/issues/11619, we need to set `--console-script` on the requirements PEX, not the runner PEX. It does not work to set on the runner PEX because it will not have any distributions available. 

In trying to fix that, I realized it is useful to simplify no longer having a requirements PEX vs. runner PEX. Originally, we split this so that the requirements PEX shared the cache between goals like `test` and `lint`. That is less relevant now that we first resolve from the constraints/lockfile, then extract the subset of deps - most of the heavy lifting will already be shared.

*https://github.com/pantsbuild/pants/pull/12806 was necessary to land before for this to work. Otherwise, the lockfile.pex would have much less reuse because of setting `additional_args` on the `PexFromTargetsRequest`.

[ci skip-rust]
[ci skip-build-wheels]