### PR TITLE
[internal] Refactor `gofmt` tests

### DIFF
--- a/src/python/pants/backend/go/lint/gofmt/rules.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules.py
@@ -87,7 +87,7 @@ async def setup_gofmt(setup_request: SetupRequest, goroot: GoLangDistribution) -
         argv=argv,
         input_digest=input_digest,
         output_files=source_files_snapshot.files,
-        description=f"Run gofmt on {pluralize(len(setup_request.request.field_sets), 'file')}.",
+        description=f"Run gofmt on {pluralize(len(source_files_snapshot.files), 'file')}.",
         level=LogLevel.DEBUG,
     )
 


### PR DESCRIPTION
Make them more readable by using `RuleRunner.write_files()` and `RuleRunner.get_target()`.

Also, fix our Process description to account for https://github.com/pantsbuild/pants/pull/12685. We need to calculate the # of files by looking at the snapshot, not the # of field sets, as we don't use "file targets" with Go anymore so a field set may refer to >1 source.

[ci skip-rust]
[ci skip-build-wheels]