### PR TITLE
Adds ability to generate lockfiles cleanly on MacOS-upon-ARM

### DIFF
--- a/build-support/bin/generate_all_lockfiles.sh
+++ b/build-support/bin/generate_all_lockfiles.sh
@@ -4,9 +4,21 @@
 
 set -euo pipefail
 
+source `dirname $0`/../common.sh
+
 # To solve the chicken and egg problem of https://github.com/pantsbuild/pants/issues/12457, we
 # temporarily disable the lockfile. This means that `./pants run` will ignore the lockfile. While
 # the script is then running, it will set the option again to generate the lockfile where we want.
 export PANTS_PYTHON_SETUP_EXPERIMENTAL_LOCKFILE=""
 
-exec ./pants run build-support/bin/_generate_all_lockfiles_helper.py
+if is_macos_arm
+then
+    # Generate the lockfiles with the correct notated interpreter constraints, but make
+    # Pants execute with a version of Python that actually runs on MacOS ARM
+    unset PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS
+    MAYBE_INTERPRETER_CONSTRAINTS=--python-setup-interpreter-constraints=[\'==3.9.*\']
+else
+    MAYBE_INTERPRETER_CONSTRAINTS=
+fi
+
+exec ./pants run build-support/bin/_generate_all_lockfiles_helper.py $MAYBE_INTERPRETER_CONSTRAINTS

--- a/build-support/bin/generate_all_lockfiles.sh
+++ b/build-support/bin/generate_all_lockfiles.sh
@@ -4,21 +4,20 @@
 
 set -euo pipefail
 
-source `dirname $0`/../common.sh
+source $(dirname $0)/../common.sh
 
 # To solve the chicken and egg problem of https://github.com/pantsbuild/pants/issues/12457, we
 # temporarily disable the lockfile. This means that `./pants run` will ignore the lockfile. While
 # the script is then running, it will set the option again to generate the lockfile where we want.
 export PANTS_PYTHON_SETUP_EXPERIMENTAL_LOCKFILE=""
 
-if is_macos_arm
-then
-    # Generate the lockfiles with the correct notated interpreter constraints, but make
-    # Pants execute with a version of Python that actually runs on MacOS ARM
-    unset PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS
-    MAYBE_INTERPRETER_CONSTRAINTS=--python-setup-interpreter-constraints=[\'==3.9.*\']
+if is_macos_arm; then
+  # Generate the lockfiles with the correct notated interpreter constraints, but make
+  # Pants execute with a version of Python that actually runs on MacOS ARM
+  unset PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS
+  MAYBE_INTERPRETER_CONSTRAINTS=--python-setup-interpreter-constraints=[\'==3.9.*\']
 else
-    MAYBE_INTERPRETER_CONSTRAINTS=
+  MAYBE_INTERPRETER_CONSTRAINTS=
 fi
 
 exec ./pants run build-support/bin/_generate_all_lockfiles_helper.py $MAYBE_INTERPRETER_CONSTRAINTS

--- a/build-support/bin/generate_all_lockfiles.sh
+++ b/build-support/bin/generate_all_lockfiles.sh
@@ -4,7 +4,11 @@
 
 set -euo pipefail
 
-source $(dirname $0)/../common.sh
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT" || exit 1
+
+# shellcheck source=build-support/common.sh
+source "${REPO_ROOT}/build-support/common.sh"
 
 # To solve the chicken and egg problem of https://github.com/pantsbuild/pants/issues/12457, we
 # temporarily disable the lockfile. This means that `./pants run` will ignore the lockfile. While
@@ -15,9 +19,7 @@ if is_macos_arm; then
   # Generate the lockfiles with the correct notated interpreter constraints, but make
   # Pants execute with a version of Python that actually runs on MacOS ARM
   unset PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS
-  MAYBE_INTERPRETER_CONSTRAINTS=--python-setup-interpreter-constraints=[\'==3.9.*\']
+  exec ./pants run build-support/bin/_generate_all_lockfiles_helper.py --python-setup-interpreter-constraints="['==3.9.*']"
 else
-  MAYBE_INTERPRETER_CONSTRAINTS=
+  exec ./pants run build-support/bin/_generate_all_lockfiles_helper.py
 fi
-
-exec ./pants run build-support/bin/_generate_all_lockfiles_helper.py $MAYBE_INTERPRETER_CONSTRAINTS

--- a/build-support/common.sh
+++ b/build-support/common.sh
@@ -65,3 +65,7 @@ function determine_python() {
     echo "${interpreter_path}" && return 0
   done
 }
+
+function is_macos_arm() {
+  [[ `uname -sm` == "Darwin arm64" ]]
+}

--- a/build-support/common.sh
+++ b/build-support/common.sh
@@ -67,5 +67,5 @@ function determine_python() {
 }
 
 function is_macos_arm() {
-  [[ `uname -sm` == "Darwin arm64" ]]
+  [[ $(uname -sm) == "Darwin arm64" ]]
 }


### PR DESCRIPTION
Adds `is_macos_arm` to `common.sh` and uses it in `generate_all_lockfiles.sh`

# Rust tests and lints will be skipped. Delete if not intended.
[ci skip-rust]

# Building wheels and fs_util will be skipped. Delete if not intended.
[ci skip-build-wheels]