### PR TITLE
[internal] Make `go_package` `sources` field private

### DIFF
--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -20,6 +20,7 @@ class GoSources(Sources):
 
 
 class GoPackageSources(GoSources):
+    alias = "_sources"
     default = ("*.go",)
 
 


### PR DESCRIPTION
As discussed in https://github.com/pantsbuild/pants/pull/12685#issuecomment-916181137, the user should not be changing the `sources` field. We assume that you have one `go_package` target per directory, and that the target owns all Go files. 

It's convenient to still use a `Sources` field because it integrates automatically with things like file arguments, but it should be an internal implementation detail.

This change means sources won't show up in `./pants help` anymore.

[ci skip-rust]
[ci skip-build-wheels]