### PR TITLE
Properly include file dependencies in docker build context (cherrypick of #12758)

### DIFF
--- a/src/python/pants/backend/docker/docker_binary.py
+++ b/src/python/pants/backend/docker/docker_binary.py
@@ -23,13 +23,13 @@ class DockerBinary(BinaryPath):
 
     DEFAULT_SEARCH_PATH = SearchPath(("/usr/bin", "/bin", "/usr/local/bin"))
 
-    def build_image(
-        self, tag: str, digest: Digest, context_root: str, dockerfile: Optional[str] = None
-    ) -> Process:
+    def build_image(self, tag: str, digest: Digest, dockerfile: Optional[str] = None) -> Process:
         args = [self.path, "build", "-t", tag]
         if dockerfile:
             args.extend(["-f", dockerfile])
-        args.append(context_root)
+
+        # Add build context root.
+        args.append(".")
 
         return Process(
             argv=tuple(args),

--- a/src/python/pants/backend/docker/docker_binary_test.py
+++ b/src/python/pants/backend/docker/docker_binary_test.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from hashlib import sha256
-from os import path
 
 from pants.backend.docker.docker_binary import DockerBinary
 from pants.engine.fs import Digest
@@ -10,16 +9,15 @@ from pants.engine.process import Process
 
 
 def test_docker_binary_build_image():
-    source_path = "src/test/repo"
     docker_path = "/bin/docker"
-    dockerfile = path.join(source_path, "Dockerfile")
+    dockerfile = "src/test/repo/Dockerfile"
     docker = DockerBinary(docker_path)
     digest = Digest(sha256().hexdigest(), 123)
     tag = "test:latest"
-    build_request = docker.build_image(tag, digest, source_path, dockerfile)
+    build_request = docker.build_image(tag, digest, dockerfile)
 
     assert build_request == Process(
-        argv=(docker_path, "build", "-t", tag, "-f", dockerfile, source_path),
+        argv=(docker_path, "build", "-t", tag, "-f", dockerfile, "."),
         input_digest=digest,
         description=f"Building docker image {tag}",
     )

--- a/src/python/pants/backend/docker/docker_build.py
+++ b/src/python/pants/backend/docker/docker_build.py
@@ -7,11 +7,7 @@ from dataclasses import dataclass
 
 from pants.backend.docker.docker_binary import DockerBinary, DockerBinaryRequest
 from pants.backend.docker.docker_build_context import DockerBuildContext, DockerBuildContextRequest
-from pants.backend.docker.target_types import (
-    DockerContextRoot,
-    DockerImageSources,
-    DockerImageVersion,
-)
+from pants.backend.docker.target_types import DockerImageSources, DockerImageVersion
 from pants.core.goals.package import BuiltPackage, BuiltPackageArtifact, PackageFieldSet
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
@@ -24,7 +20,6 @@ logger = logging.getLogger(__name__)
 class DockerFieldSet(PackageFieldSet):
     required_fields = (DockerImageSources,)
 
-    context_root_field: DockerContextRoot
     image_version: DockerImageVersion
     sources: DockerImageSources
 
@@ -39,17 +34,6 @@ class DockerFieldSet(PackageFieldSet):
         return os.path.join(self.address.spec_path, self.dockerfile_relpath)
 
     @property
-    def context_root(self) -> str:
-        """Translates context_root from a users perspective in the BUILD file, to Dockers
-        perspective of the file system."""
-        path = self.context_root_field.value or "."
-        if os.path.isabs(path):
-            path = os.path.relpath(path, "/")
-        else:
-            path = os.path.join(self.address.spec_path, path)
-        return path
-
-    @property
     def image_tag(self) -> str:
         return ":".join(s for s in [self.address.target_name, self.image_version.value] if s)
 
@@ -61,7 +45,11 @@ async def build_docker_image(
     docker, context = await MultiGet(
         Get(DockerBinary, DockerBinaryRequest()),
         Get(
-            DockerBuildContext, DockerBuildContextRequest(field_set.address, field_set.context_root)
+            DockerBuildContext,
+            DockerBuildContextRequest(
+                address=field_set.address,
+                build_upstream_images=True,
+            ),
         ),
     )
 
@@ -69,10 +57,9 @@ async def build_docker_image(
         ProcessResult,
         Process,
         docker.build_image(
-            field_set.image_tag,
-            context.digest,
-            field_set.context_root,
-            field_set.dockerfile_path,
+            tag=field_set.image_tag,
+            digest=context.digest,
+            dockerfile=field_set.dockerfile_path,
         ),
     )
 

--- a/src/python/pants/backend/docker/docker_build_context.py
+++ b/src/python/pants/backend/docker/docker_build_context.py
@@ -3,18 +3,22 @@
 
 import logging
 from dataclasses import dataclass
+from itertools import chain
 
 from pants.backend.docker.target_types import DockerImageSources
 from pants.core.goals.package import BuiltPackage, PackageFieldSet
-from pants.core.target_types import FilesSources, ResourcesSources
+from pants.core.target_types import FilesSources
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
-from pants.engine.fs import AddPrefix, Digest, MergeDigests
+from pants.engine.fs import Digest, MergeDigests
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
+    Dependencies,
+    DependenciesRequest,
     FieldSetsPerTarget,
     FieldSetsPerTargetRequest,
     Sources,
+    Targets,
     TransitiveTargets,
     TransitiveTargetsRequest,
 )
@@ -30,19 +34,35 @@ class DockerBuildContext:
 @dataclass(frozen=True)
 class DockerBuildContextRequest:
     address: Address
-    context_root: str
+    build_upstream_images: bool = False
 
 
 @rule
 async def create_docker_build_context(request: DockerBuildContextRequest) -> DockerBuildContext:
+    # Get all targets to include in context.
     transitive_targets = await Get(TransitiveTargets, TransitiveTargetsRequest([request.address]))
 
-    # Get all sources, going into the build context.
+    # Get the Dockerfile from the root target.
+    dockerfiles_request = Get(
+        SourceFiles,
+        SourceFilesRequest(
+            sources_fields=[t.get(Sources) for t in transitive_targets.roots],
+            for_sources_types=(DockerImageSources,),
+        ),
+    )
+
+    # Get all dependencies for the root target.
+    root_dependencies = await MultiGet(
+        Get(Targets, DependenciesRequest(target.get(Dependencies)))
+        for target in transitive_targets.roots
+    )
+
+    # Get all sources from the root dependencies (i.e. files).
     sources_request = Get(
         SourceFiles,
         SourceFilesRequest(
-            sources_fields=[t.get(Sources) for t in transitive_targets.closure],
-            for_sources_types=(DockerImageSources, FilesSources, ResourcesSources),
+            sources_fields=[t.get(Sources) for t in chain(*root_dependencies)],
+            for_sources_types=(FilesSources,),
         ),
     )
 
@@ -51,37 +71,31 @@ async def create_docker_build_context(request: DockerBuildContextRequest) -> Doc
         FieldSetsPerTargetRequest(PackageFieldSet, transitive_targets.dependencies),
     )
 
-    sources, embedded_pkgs_per_target = await MultiGet(
-        sources_request, embedded_pkgs_per_target_request
+    dockerfiles, sources, embedded_pkgs_per_target = await MultiGet(
+        dockerfiles_request,
+        sources_request,
+        embedded_pkgs_per_target_request,
     )
 
     # Package binary dependencies for build context.
     embedded_pkgs = await MultiGet(
         Get(BuiltPackage, PackageFieldSet, field_set)
         for field_set in embedded_pkgs_per_target.field_sets
+        # Exclude docker images, unless build_upstream_images is true.
+        if request.build_upstream_images
+        or not isinstance(getattr(field_set, "sources", None), DockerImageSources)
     )
 
     packages_str = ", ".join(a.relpath for p in embedded_pkgs for a in p.artifacts if a.relpath)
     logger.debug(f"Packages for Docker image: {packages_str}")
 
-    embedded_pkgs_digests = tuple(built_package.digest for built_package in embedded_pkgs)
-    if request.context_root != ".":
-        # Copy packages to context root tree, unless the context root is at the project root.
-        embedded_pkgs_digests = await MultiGet(
-            Get(Digest, AddPrefix(digest, request.context_root)) for digest in embedded_pkgs_digests
-        )
+    embedded_pkgs_digest = [built_package.digest for built_package in embedded_pkgs]
+    all_digests = (dockerfiles.snapshot.digest, sources.snapshot.digest, *embedded_pkgs_digest)
 
-    # Merge build context.
+    # Merge all digests to get the final docker build context.
     context = await Get(
         Digest,
-        MergeDigests(
-            d
-            for d in (
-                sources.snapshot.digest,
-                *embedded_pkgs_digests,
-            )
-            if d
-        ),
+        MergeDigests(d for d in all_digests if d),
     )
 
     return DockerBuildContext(context)

--- a/src/python/pants/backend/docker/docker_build_context_test.py
+++ b/src/python/pants/backend/docker/docker_build_context_test.py
@@ -1,79 +1,146 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.docker.docker_build_context import (
-    DockerBuildContextRequest,
-    create_docker_build_context,
-)
+from __future__ import annotations
+
+from textwrap import dedent
+
+import pytest
+
+from pants.backend.docker.docker_build_context import DockerBuildContext, DockerBuildContextRequest
+from pants.backend.docker.rules import rules
 from pants.backend.docker.target_types import DockerImage
-from pants.backend.python.goals.package_pex_binary import PexBinaryFieldSet
-from pants.backend.python.target_types import PexBinary
-from pants.core.goals.package import BuiltPackage, PackageFieldSet
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.core.target_types import Files
+from pants.core.util_rules.source_files import rules as source_files_rules
 from pants.engine.addresses import Address
-from pants.engine.fs import EMPTY_DIGEST, EMPTY_SNAPSHOT, AddPrefix, Digest, MergeDigests
-from pants.engine.target import (
-    FieldSetsPerTarget,
-    FieldSetsPerTargetRequest,
-    TransitiveTargets,
-    TransitiveTargetsRequest,
-)
-from pants.engine.unions import UnionMembership
-from pants.testutil.rule_runner import MockGet, run_rule_with_mocks
+from pants.engine.fs import Snapshot
+from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
-def test_create_docker_build_context():
-    img = DockerImage(address=Address("src/test", target_name="image"), unhydrated_values={})
-    pex = PexBinary(
-        address=Address("src/test", target_name="bin"),
-        unhydrated_values={"entry_point": "src.test.main:main"},
-    )
-    request = DockerBuildContextRequest(
-        address=img.address,
-        context_root=".",
-    )
-
-    result = run_rule_with_mocks(
-        create_docker_build_context,
-        rule_args=[request],
-        mock_gets=[
-            MockGet(
-                output_type=TransitiveTargets,
-                input_type=TransitiveTargetsRequest,
-                mock=lambda _: TransitiveTargets([img], [pex]),
-            ),
-            MockGet(
-                output_type=SourceFiles,
-                input_type=SourceFilesRequest,
-                mock=lambda _: SourceFiles(
-                    snapshot=EMPTY_SNAPSHOT,
-                    unrooted_files=tuple(),
-                ),
-            ),
-            MockGet(
-                output_type=FieldSetsPerTarget,
-                input_type=FieldSetsPerTargetRequest,
-                mock=lambda request: FieldSetsPerTarget([[PexBinaryFieldSet.create(pex)]]),
-            ),
-            MockGet(
-                output_type=BuiltPackage,
-                input_type=PackageFieldSet,
-                mock=lambda _: BuiltPackage(EMPTY_DIGEST, []),
-            ),
-            MockGet(
-                output_type=Digest,
-                input_type=AddPrefix,
-                mock=lambda _: EMPTY_DIGEST,
-            ),
-            MockGet(
-                output_type=Digest,
-                input_type=MergeDigests,
-                mock=lambda _: EMPTY_DIGEST,
-            ),
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *rules(),
+            *source_files_rules(),
+            QueryRule(DockerBuildContext, (DockerBuildContextRequest,)),
         ],
-        # need AddPrefix here, since UnionMembership.is_member() throws when called with non
-        # registered types
-        union_membership=UnionMembership({PackageFieldSet: [PexBinaryFieldSet], AddPrefix: []}),
+        target_types=[DockerImage, Files],
     )
 
-    assert result.digest == EMPTY_DIGEST
+
+def assert_build_context(
+    rule_runner: RuleRunner,
+    address: Address,
+    expected_files: list[str],
+) -> None:
+    context = rule_runner.request(
+        DockerBuildContext,
+        [
+            DockerBuildContextRequest(
+                address=address,
+                build_upstream_images=False,
+            )
+        ],
+    )
+
+    snapshot = rule_runner.request(Snapshot, [context.digest])
+    assert sorted(expected_files) == sorted(snapshot.files)
+
+
+def test_file_dependencies(rule_runner: RuleRunner) -> None:
+    # img_A -> files_A
+    # img_A -> img_B -> files_B
+    rule_runner.add_to_build_file(
+        "src/a",
+        dedent(
+            """\
+            docker_image(name="img_A", dependencies=[":files_A", "src/b:img_B"])
+            files(name="files_A", sources=["files/**"])
+            """
+        ),
+    )
+    rule_runner.add_to_build_file(
+        "src/b",
+        dedent(
+            """\
+            docker_image(name="img_B", dependencies=[":files_B"])
+            files(name="files_B", sources=["files/**"])
+            """
+        ),
+    )
+    rule_runner.create_files("src/a", ["Dockerfile"])
+    rule_runner.create_files("src/a/files", ["a01", "a02"])
+    rule_runner.create_files("src/b", ["Dockerfile"])
+    rule_runner.create_files("src/b/files", ["b01", "b02"])
+
+    # We want files_B in build context for img_B
+    assert_build_context(
+        rule_runner,
+        Address("src/b", target_name="img_B"),
+        expected_files=["src/b/Dockerfile", "src/b/files/b01", "src/b/files/b02"],
+    )
+
+    # We want files_A in build context for img_A, but not files_B
+    assert_build_context(
+        rule_runner,
+        Address("src/a", target_name="img_A"),
+        expected_files=["src/a/Dockerfile", "src/a/files/a01", "src/a/files/a02"],
+    )
+
+    # Mixed.
+    rule_runner.add_to_build_file(
+        "src/c",
+        dedent(
+            """\
+            docker_image(name="img_C", dependencies=["src/a:files_A", "src/b:files_B"])
+            """
+        ),
+    )
+    rule_runner.create_files("src/c", ["Dockerfile"])
+
+    assert_build_context(
+        rule_runner,
+        Address("src/c", target_name="img_C"),
+        expected_files=[
+            "src/c/Dockerfile",
+            "src/a/files/a01",
+            "src/a/files/a02",
+            "src/b/files/b01",
+            "src/b/files/b02",
+        ],
+    )
+
+
+def test_files_out_of_tree(rule_runner: RuleRunner) -> None:
+    # src/a:img_A -> res/static:files
+    rule_runner.add_to_build_file(
+        "src/a",
+        dedent(
+            """\
+            docker_image(name="img_A", dependencies=["res/static:files"])
+            """
+        ),
+    )
+    rule_runner.add_to_build_file(
+        "res/static",
+        dedent(
+            """\
+            files(name="files", sources=["!BUILD", "**/*"])
+            """
+        ),
+    )
+    rule_runner.create_files("src/a", ["Dockerfile"])
+    rule_runner.create_files("res/static", ["s01", "s02"])
+    rule_runner.create_files("res/static/sub", ["s03"])
+
+    assert_build_context(
+        rule_runner,
+        Address("src/a", target_name="img_A"),
+        expected_files=[
+            "src/a/Dockerfile",
+            "res/static/s01",
+            "res/static/s02",
+            "res/static/sub/s03",
+        ],
+    )

--- a/src/python/pants/backend/docker/docker_build_test.py
+++ b/src/python/pants/backend/docker/docker_build_test.py
@@ -17,41 +17,11 @@ from pants.testutil.rule_runner import MockGet, run_rule_with_mocks
     "target_values, expected_features",
     [
         (
-            dict(),
-            dict(
-                context_root="docker/test/.",
-            ),
-        ),
-        (
             dict(
                 version="1.2.3",
             ),
             dict(
                 version="1.2.3",
-            ),
-        ),
-        (
-            dict(
-                context_root="/",
-            ),
-            dict(
-                context_root=".",
-            ),
-        ),
-        (
-            dict(
-                context_root="foo/bar",
-            ),
-            dict(
-                context_root="docker/test/foo/bar",
-            ),
-        ),
-        (
-            dict(
-                context_root="/foo/bar",
-            ),
-            dict(
-                context_root="foo/bar",
             ),
         ),
     ],
@@ -65,9 +35,6 @@ def test_build_docker_image_rule(target_values, expected_features):
     field_set = DockerFieldSet.create(image)
 
     def build_context_mock(request: DockerBuildContextRequest) -> DockerBuildContext:
-        if "context_root" in expected_features:
-            assert expected_features["context_root"] == request.context_root
-
         return DockerBuildContext(digest=EMPTY_DIGEST)
 
     result = run_rule_with_mocks(

--- a/src/python/pants/backend/docker/target_types.py
+++ b/src/python/pants/backend/docker/target_types.py
@@ -20,21 +20,10 @@ class DockerDependencies(Dependencies):
     supports_transitive_excludes = True
 
 
-class DockerContextRoot(StringField):
-    alias = "context_root"
-    default = "."
-    help = (
-        "Root directory for the Docker build context.\n\nDefault is to use the directory of the "
-        "`BUILD` file. Use '/' to use the project root, thus putting any resource from the entire "
-        "project within scope (if the target also has a dependency on it)."
-    )
-
-
 class DockerImage(Target):
     alias = "docker_image"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        DockerContextRoot,
         DockerDependencies,
         DockerImageSources,
         DockerImageVersion,


### PR DESCRIPTION
Turns out that there were quite a few corner cases uncovered wrgt targets, transitive targets and dependencies that I hadn't really come to terms with.

[ci skip-rust]
[ci skip-build-wheels]