### PR TITLE
[internal] Refactor build_integration_test.py

### DIFF
--- a/src/python/pants/backend/go/build_integration_test.py
+++ b/src/python/pants/backend/go/build_integration_test.py
@@ -1,7 +1,9 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-import textwrap
-from typing import Iterable, List
+
+from __future__ import annotations
+
+from textwrap import dedent
 
 import pytest
 
@@ -11,7 +13,6 @@ from pants.backend.go.target_types import GoBinary, GoModule, GoPackage
 from pants.build_graph.address import Address
 from pants.core.goals.package import BuiltPackage
 from pants.core.util_rules import external_tool, source_files
-from pants.engine.fs import FileContent
 from pants.engine.rules import QueryRule
 from pants.engine.target import Target
 from pants.testutil.rule_runner import RuleRunner
@@ -35,116 +36,85 @@ def rule_runner() -> RuleRunner:
     )
 
 
-MAIN_SOURCE = FileContent(
-    "main.go",
-    textwrap.dedent(
-        """\
-    package main
-
-    import (
-    \t"fmt"
-    )
-
-    func main() {
-    \tfmt.Println("Hello world!")
-    }
-    """
-    ).encode("utf-8"),
-)
-
-LIB_SOURCE = FileContent(
-    "lib.go",
-    textwrap.dedent(
-        """\
-    package lib
-
-    import (
-    \t"fmt"
-    )
-
-    func Quote(s string) string {
-    \treturn fmt.Sprintf(">> %s <<", s)
-    }
-    """
-    ).encode("utf-8"),
-)
-
-MAIN_USING_LIB_SOURCE = FileContent(
-    "main.go",
-    textwrap.dedent(
-        """\
-    package main
-
-    import (
-    \t"fmt"
-    \t"example.com/lib"
-    )
-
-    func main() {
-    \tfmt.Println(lib.Quote("Hello world!"))
-    }
-    """
-    ).encode("utf-8"),
-)
+def build_package(rule_runner: RuleRunner, binary_target: Target) -> BuiltPackage:
+    field_set = GoBinaryFieldSet.create(binary_target)
+    return rule_runner.request(BuiltPackage, [field_set])
 
 
-def make_target(
-    rule_runner: RuleRunner,
-    source_files: List[FileContent],
-    *,
-    import_path: str,
-    dependencies: Iterable[Address] = (),
-    target_name: str = "target",
-) -> Target:
-    for source_file in source_files:
-        rule_runner.create_file(f"{source_file.path}", source_file.content.decode())
-    source_files_str = ", ".join(f'"{sf.path}"' for sf in source_files)
-    deps_str = ", ".join(f'"{addr.spec}"' for addr in dependencies)
-    rule_runner.add_to_build_file(
-        "",
-        f"go_package(name='{target_name}', import_path='{import_path}', sources=[{source_files_str}], dependencies=[{deps_str}])\n",
-    )
-    return rule_runner.get_target(Address("", target_name=target_name))
-
-
-def build_package(
-    rule_runner: RuleRunner,
-    main_target: Target,
-) -> BuiltPackage:
-    args = ["--backend-packages=pants.backend.go"]
-    rule_runner.set_options(args)
-    rule_runner.add_to_build_file(
-        "", f"go_binary(name='bin', binary_name='foo', main='{main_target.address.spec}')\n"
-    )
-    go_binary_target = rule_runner.get_target(Address("", target_name="bin"))
-    built_package = rule_runner.request(BuiltPackage, (GoBinaryFieldSet.create(go_binary_target),))
-    return built_package
-
-
-def test_package_one_target(rule_runner: RuleRunner) -> None:
+def test_package_simple(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
-        {"BUILD": "go_module(name='root')\n", "go.mod": "module foo.example.com\n"}
+        {
+            "go.mod": "module foo.example.com\n",
+            "BUILD": "go_module(name='root')\n",
+            "project/main.go": dedent(
+                """\
+                package main
+
+                import (
+                \t"fmt"
+                )
+
+                func main() {
+                \tfmt.Println("Hello world!")
+                }
+                """
+            ),
+            "project/BUILD": dedent(
+                """\
+                go_package(name='main', import_path='main')
+                go_binary(name='bin', binary_name='foo', main=':main')
+                """
+            ),
+        }
     )
-    target = make_target(rule_runner, [MAIN_SOURCE], import_path="main")
-    built_package = build_package(rule_runner, target)
+    binary_tgt = rule_runner.get_target(Address("project", target_name="bin"))
+    built_package = build_package(rule_runner, binary_tgt)
     assert len(built_package.artifacts) == 1
-    assert built_package.artifacts[0].relpath == "foo"
+    assert built_package.artifacts[0].relpath == "project/foo"
 
 
-def test_package_with_depenedency(rule_runner: RuleRunner) -> None:
+def test_package_with_dependency(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
-        {"BUILD": "go_module(name='root')\n", "go.mod": "module foo.example.com\n"}
+        {
+            "go.mod": "module foo.example.com\n",
+            "BUILD": "go_module(name='root')\n",
+            "project/lib/lib.go": dedent(
+                """\
+                package lib
+
+                import (
+                \t"fmt"
+                )
+
+                func Quote(s string) string {
+                \treturn fmt.Sprintf(">> %s <<", s)
+                }
+                """
+            ),
+            "project/lib/BUILD": "go_package(import_path='example.com/lib')",
+            "project/main.go": dedent(
+                """\
+                package main
+
+                import (
+                \t"fmt"
+                \t"example.com/lib"
+                )
+
+                func main() {
+                \tfmt.Println(lib.Quote("Hello world!"))
+                }
+                """
+            ),
+            "project/BUILD": dedent(
+                """\
+                go_package(name='main', import_path='main', dependencies=['project/lib'])
+                go_binary(name='bin', binary_name='foo', main=':main')
+                """
+            ),
+        }
     )
-    lib_target = make_target(
-        rule_runner, [LIB_SOURCE], import_path="example.com/lib", target_name="lib"
-    )
-    main_target = make_target(
-        rule_runner,
-        [MAIN_SOURCE],
-        import_path="main",
-        dependencies=(lib_target.address,),
-        target_name="main",
-    )
-    built_package = build_package(rule_runner, main_target)
+    binary_tgt = rule_runner.get_target(Address("project", target_name="bin"))
+    built_package = build_package(rule_runner, binary_tgt)
     assert len(built_package.artifacts) == 1
-    assert built_package.artifacts[0].relpath == "foo"
+    assert built_package.artifacts[0].relpath == "project/foo"

--- a/src/python/pants/backend/go/build_integration_test.py
+++ b/src/python/pants/backend/go/build_integration_test.py
@@ -51,11 +51,11 @@ def test_package_simple(rule_runner: RuleRunner) -> None:
                 package main
 
                 import (
-                \t"fmt"
+                    "fmt"
                 )
 
                 func main() {
-                \tfmt.Println("Hello world!")
+                    fmt.Println("Hello world!")
                 }
                 """
             ),
@@ -83,11 +83,11 @@ def test_package_with_dependency(rule_runner: RuleRunner) -> None:
                 package lib
 
                 import (
-                \t"fmt"
+                    "fmt"
                 )
 
                 func Quote(s string) string {
-                \treturn fmt.Sprintf(">> %s <<", s)
+                    return fmt.Sprintf(">> %s <<", s)
                 }
                 """
             ),
@@ -97,12 +97,12 @@ def test_package_with_dependency(rule_runner: RuleRunner) -> None:
                 package main
 
                 import (
-                \t"fmt"
-                \t"example.com/lib"
+                    "fmt"
+                    "example.com/lib"
                 )
 
                 func main() {
-                \tfmt.Println(lib.Quote("Hello world!"))
+                    fmt.Println(lib.Quote("Hello world!"))
                 }
                 """
             ),


### PR DESCRIPTION
Uses `rule_runner.write_files()` rather than `.create_file()` and `append_to_file()`. The main benefit is that all test setup is centralized, which makes them easier to follow. 

This also fixes it so that we don't have two `go_package` targets in the same directory.

[ci skip-rust]
[ci skip-build-wheels]