### PR TITLE
Warn if `[python-repos]` is set during lockfile generation (Cherry-pick of #12800)

### DIFF
--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -110,7 +110,11 @@ class PythonToolRequirementsBase(Subsystem):
                     "To use a custom lockfile, set this option to a file path relative to the "
                     f"build root, then run `./pants generate-lockfiles "
                     f"--resolve={cls.options_scope}`.\n\n"
-                    ""
+                    "Lockfile generation currently does not wire up the `[python-repos]` options. "
+                    "If lockfile generation fails, you can manually generate a lockfile, such as "
+                    "by using pip-compile or `pip freeze`. Set this option to the path to your "
+                    "manually generated lockfile. When manually maintaining lockfiles, set "
+                    "`[python-setup].invalid_lockfile_behavior = 'ignore'`."
                 ),
             )
 

--- a/src/python/pants/python/python_repos.py
+++ b/src/python/pants/python/python_repos.py
@@ -13,6 +13,8 @@ class PythonRepos(Subsystem):
         "custom cheeseshops when resolving requirements."
     )
 
+    pypi_index = "https://pypi.org/simple/"
+
     @classmethod
     def register_options(cls, register):
         super().register_options(register)
@@ -30,7 +32,7 @@ class PythonRepos(Subsystem):
             "--indexes",
             advanced=True,
             type=list,
-            default=["https://pypi.org/simple/"],
+            default=[cls.pypi_index],
             help=(
                 "URLs of code repository indexes to look for requirements. If set to an empty "
                 "list, then Pex will use no indices (meaning it will not use PyPI). The values "


### PR DESCRIPTION
[ci skip-rust]
[ci skip-build-wheels]