### PR TITLE
[internal] Bump timeout for flaky test (Cherry-pick of #12799)

### DIFF
--- a/src/python/pants/backend/python/goals/BUILD
+++ b/src/python/pants/backend/python/goals/BUILD
@@ -34,7 +34,7 @@ python_tests(
     sources=["repl_integration_test.py"],
     # We want to make sure the default lockfile works for both macOS and Linux.
     tags=["platform_specific_behavior"],
-    timeout=120,
+    timeout=240,
 )
 
 python_tests(


### PR DESCRIPTION
Timed out on macOS, which I think has network contention due to most the tests resolving third party Python dependencies to test our lockfile support.

[ci skip-rust]
[ci skip-build-wheels]