### PR TITLE
Update iSort link

### DIFF
--- a/src/python/pants/backend/python/lint/isort/register.py
+++ b/src/python/pants/backend/python/lint/isort/register.py
@@ -4,7 +4,7 @@
 """Autoformatter for Python import statements.
 
 See https://www.pantsbuild.org/docs/python-linters-and-formatters and
-https://timothycrosley.github.io/isort/.
+https://pycqa.github.io/isort/.
 """
 
 from pants.backend.python.lint import python_fmt

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -18,7 +18,7 @@ from pants.util.docutil import git_url
 
 class Isort(PythonToolBase):
     options_scope = "isort"
-    help = "The Python import sorter tool (https://timothycrosley.github.io/isort/)."
+    help = "The Python import sorter tool (https://pycqa.github.io/isort/)."
 
     default_version = "isort[pyproject,colors]>=5.9.3,<6.0"
     default_main = ConsoleScript("isort")


### PR DESCRIPTION
the old link: https://timothycrosley.github.io/isort/ now redirects to https://pycqa.github.io/isort/ so we might as well use that.
