### PR TITLE
Improve cache reuse for `./pants package` when using a constraints file or lockfile (cherry-pick of #12807)

### DIFF
--- a/src/python/pants/backend/awslambda/python/rules.py
+++ b/src/python/pants/backend/awslambda/python/rules.py
@@ -71,19 +71,20 @@ async def package_python_awslambda(
     if (py_major, py_minor) == (2, 7):
         platform += "u"
 
+    additional_pex_args = (
+        # Ensure we can resolve manylinux wheels in addition to any AMI-specific wheels.
+        "--manylinux=manylinux2014",
+        # When we're executing Pex on Linux, allow a local interpreter to be resolved if
+        # available and matching the AMI platform.
+        "--resolve-local-platforms",
+    )
     pex_request = PexFromTargetsRequest(
         addresses=[field_set.address],
         internal_only=False,
-        main=None,
         output_filename=output_filename,
         platforms=PexPlatforms([platform]),
-        additional_args=[
-            # Ensure we can resolve manylinux wheels in addition to any AMI-specific wheels.
-            "--manylinux=manylinux2014",
-            # When we're executing Pex on Linux, allow a local interpreter to be resolved if
-            # available and matching the AMI platform.
-            "--resolve-local-platforms",
-        ],
+        additional_args=additional_pex_args,
+        additional_lockfile_args=additional_pex_args,
     )
 
     lambdex_request = PexRequest(

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -185,6 +185,7 @@ def test_constraints_validation(tmp_path_factory: TempPathFactory, rule_runner: 
         *,
         direct_deps_only: bool = False,
         additional_args: Iterable[str] = (),
+        additional_lockfile_args: Iterable[str] = (),
     ) -> PexRequest:
         args = ["--backend-packages=pants.backend.python"]
         request = PexFromTargetsRequest(
@@ -193,6 +194,7 @@ def test_constraints_validation(tmp_path_factory: TempPathFactory, rule_runner: 
             internal_only=True,
             direct_deps_only=direct_deps_only,
             additional_args=additional_args,
+            additional_lockfile_args=additional_lockfile_args,
         )
         if resolve_all_constraints is not None:
             args.append(f"--python-setup-resolve-all-constraints={resolve_all_constraints!r}")
@@ -205,13 +207,10 @@ def test_constraints_validation(tmp_path_factory: TempPathFactory, rule_runner: 
         assert OrderedSet(additional_args).issubset(OrderedSet(pex_request.additional_args))
         return pex_request
 
-    additional_args = ["--no-strip-pex-env"]
+    additional_args = ["--strip-pex-env"]
+    additional_lockfile_args = ["--no-strip-pex-env"]
 
-    pex_req1 = get_pex_request(
-        "constraints1.txt",
-        resolve_all_constraints=False,
-        additional_args=additional_args,
-    )
+    pex_req1 = get_pex_request("constraints1.txt", resolve_all_constraints=False)
     assert pex_req1.requirements == PexRequirements(
         ["foo-bar>=0.1.2", "bar==5.5.5", "baz", url_req], apply_constraints=True
     )
@@ -225,6 +224,7 @@ def test_constraints_validation(tmp_path_factory: TempPathFactory, rule_runner: 
         "constraints1.txt",
         resolve_all_constraints=True,
         additional_args=additional_args,
+        additional_lockfile_args=additional_lockfile_args,
     )
     pex_req2_reqs = pex_req2.requirements
     assert isinstance(pex_req2_reqs, PexRequirements)
@@ -241,6 +241,7 @@ def test_constraints_validation(tmp_path_factory: TempPathFactory, rule_runner: 
         resolve_all_constraints=True,
         direct_deps_only=True,
         additional_args=additional_args,
+        additional_lockfile_args=additional_lockfile_args,
     )
     pex_req2_reqs = pex_req2_direct.requirements
     assert isinstance(pex_req2_reqs, PexRequirements)
@@ -249,9 +250,7 @@ def test_constraints_validation(tmp_path_factory: TempPathFactory, rule_runner: 
     assert not info(rule_runner, pex_req2_reqs.resolved_dists.pex)["strip_pex_env"]
 
     pex_req3_direct = get_pex_request(
-        "constraints1.txt",
-        resolve_all_constraints=True,
-        direct_deps_only=True,
+        "constraints1.txt", resolve_all_constraints=True, direct_deps_only=True
     )
     pex_req3_reqs = pex_req3_direct.requirements
     assert isinstance(pex_req3_reqs, PexRequirements)


### PR DESCRIPTION
Improves upon the solution from https://github.com/pantsbuild/pants/pull/12076. There are some args like `--manylinux` that we need to use both with the lockfile.pex and the final `PexFromTargets`. But many others like `--strip-pex-env` are irrelevant for the lockfile.pex, and we only need to set on the final PEX.

WIth this diff:

```diff
diff --git a/build-support/bin/BUILD b/build-support/bin/BUILD
index d9751179b..2a6e76478 100644
--- a/build-support/bin/BUILD
+++ b/build-support/bin/BUILD
@@ -17,4 +17,4 @@ pex_binary(name="generate_docs", entry_point="generate_docs.py", dependencies=["
 pex_binary(name="generate_github_workflows", entry_point="generate_github_workflows.py")
 pex_binary(name="generate_user_list", entry_point="generate_user_list.py", dependencies=[":user_list_templates"])
 pex_binary(name="release_helper", entry_point="_release_helper.py")
-pex_binary(name="reversion", entry_point="reversion.py")
+pex_binary(name="reversion", entry_point="reversion.py", always_write_cache=True)
```

Before:

```
❯ ./pants --no-process-execution-local-cache --no-remote-cache-read --no-pantsd package build-support/bin:
...
23:50:18.32 [INFO] Completed: Installing 3rdparty/python/lockfiles/user_reqs.txt
23:50:18.32 [INFO] Completed: Installing 3rdparty/python/lockfiles/user_reqs.txt
```

After:

```
❯ ./pants --no-process-execution-local-cache --no-remote-cache-read --no-pantsd package build-support/bin:
...
23:49:14.07 [INFO] Completed: Installing 3rdparty/python/lockfiles/user_reqs.txt
...
```

[ci skip-rust]
[ci skip-build-wheels]