### PR TITLE
`OutputPathField.value_or_default()` no longer has an `Address` argument

### DIFF
--- a/src/python/pants/backend/awslambda/python/rules.py
+++ b/src/python/pants/backend/awslambda/python/rules.py
@@ -55,7 +55,6 @@ async def package_python_awslambda(
     field_set: PythonAwsLambdaFieldSet, lambdex: Lambdex, union_membership: UnionMembership
 ) -> BuiltPackage:
     output_filename = field_set.output_path.value_or_default(
-        field_set.address,
         # Lambdas typically use the .zip suffix, so we use that instead of .pex.
         file_ending="zip",
     )

--- a/src/python/pants/backend/debian/rules.py
+++ b/src/python/pants/backend/debian/rules.py
@@ -43,7 +43,7 @@ async def package_debian_package(field_set: DebianPackageFieldSet) -> BuiltPacka
     if not dpkg_deb_path.first_path:
         raise EnvironmentError("Could not find the `touch` program on search paths ")
 
-    output_filename = field_set.output_path.value_or_default(field_set.address, file_ending="deb")
+    output_filename = field_set.output_path.value_or_default(file_ending="deb")
 
     # TODO(alexey): add Debian packaging logic
     result = await Get(

--- a/src/python/pants/backend/google_cloud_function/python/rules.py
+++ b/src/python/pants/backend/google_cloud_function/python/rules.py
@@ -59,7 +59,6 @@ async def package_python_google_cloud_function(
     union_membership: UnionMembership,
 ) -> BuiltPackage:
     output_filename = field_set.output_path.value_or_default(
-        field_set.address,
         # Cloud Functions typically use the .zip suffix, so we use that instead of .pex.
         file_ending="zip",
     )

--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -120,7 +120,7 @@ async def package_pex_binary(
             f"\n\nFiles targets dependencies: {files_addresses}"
         )
 
-    output_filename = field_set.output_path.value_or_default(field_set.address, file_ending="pex")
+    output_filename = field_set.output_path.value_or_default(file_ending="pex")
     pex = await Get(
         Pex,
         PexFromTargetsRequest(

--- a/src/python/pants/core/goals/package.py
+++ b/src/python/pants/core/goals/package.py
@@ -8,11 +8,11 @@ from dataclasses import dataclass
 from typing import Optional, Tuple
 
 from pants.core.util_rules.distdir import DistDir
-from pants.engine.addresses import Address
 from pants.engine.fs import Digest, MergeDigests, Snapshot, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
 from pants.engine.target import (
+    AsyncFieldMixin,
     FieldSet,
     NoApplicableTargetsBehavior,
     StringField,
@@ -46,7 +46,7 @@ class BuiltPackage:
     artifacts: Tuple[BuiltPackageArtifact, ...]
 
 
-class OutputPathField(StringField):
+class OutputPathField(StringField, AsyncFieldMixin):
     alias = "output_path"
     help = (
         "Where the built asset should be located.\n\nIf undefined, this will use the path to the "
@@ -56,10 +56,10 @@ class OutputPathField(StringField):
         "collisions with other package targets you may have."
     )
 
-    def value_or_default(self, address: Address, *, file_ending: str) -> str:
+    def value_or_default(self, *, file_ending: str) -> str:
         assert not file_ending.startswith("."), "`file_ending` should not start with `.`"
         return self.value or os.path.join(
-            address.spec_path.replace(os.sep, "."), f"{address.target_name}.{file_ending}"
+            self.address.spec_path.replace(os.sep, "."), f"{self.address.target_name}.{file_ending}"
         )
 
 

--- a/src/python/pants/core/goals/package.py
+++ b/src/python/pants/core/goals/package.py
@@ -1,6 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import logging
 import os
 from abc import ABCMeta
@@ -56,11 +58,15 @@ class OutputPathField(StringField, AsyncFieldMixin):
         "collisions with other package targets you may have."
     )
 
-    def value_or_default(self, *, file_ending: str) -> str:
-        assert not file_ending.startswith("."), "`file_ending` should not start with `.`"
-        return self.value or os.path.join(
-            self.address.spec_path.replace(os.sep, "."), f"{self.address.target_name}.{file_ending}"
-        )
+    def value_or_default(self, *, file_ending: str | None) -> str:
+        if self.value:
+            return self.value
+        if file_ending is None:
+            file_name = self.address.target_name
+        else:
+            assert not file_ending.startswith("."), "`file_ending` should not start with `.`"
+            file_name = f"{self.address.target_name}.{file_ending}"
+        return os.path.join(self.address.spec_path.replace(os.sep, "."), file_name)
 
 
 class PackageSubsystem(GoalSubsystem):

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -311,7 +311,7 @@ async def package_archive_target(field_set: ArchiveFieldSet) -> BuiltPackage:
     )
 
     output_filename = field_set.output_path.value_or_default(
-        field_set.address, file_ending=field_set.format_field.value
+        file_ending=field_set.format_field.value
     )
     archive = await Get(
         Digest,


### PR DESCRIPTION
I think we only didn't do this earlier because `AsyncFieldMixin` did not exist and it was awkward to store an `Address` on a `Field` - you had to subclass `AsyncField`.

Also allow setting `file_ending=None`, which is useful for Go and Rust where the built binaries often have no extension.

[ci skip-rust]
[ci skip-build-wheels]