### PR TITLE
[internal] Add `output_path` field to `go_binary` instead of `binary_name` field

### DIFF
--- a/src/python/pants/backend/go/build_integration_test.py
+++ b/src/python/pants/backend/go/build_integration_test.py
@@ -62,7 +62,7 @@ def test_package_simple(rule_runner: RuleRunner) -> None:
                 """\
                 go_module(name='go_mod')
                 go_package(name='main')
-                go_binary(name='bin', binary_name='foo', main=':main')
+                go_binary(name='bin', main=':main')
                 """
             ),
         }
@@ -70,7 +70,7 @@ def test_package_simple(rule_runner: RuleRunner) -> None:
     binary_tgt = rule_runner.get_target(Address("", target_name="bin"))
     built_package = build_package(rule_runner, binary_tgt)
     assert len(built_package.artifacts) == 1
-    assert built_package.artifacts[0].relpath == "foo"
+    assert built_package.artifacts[0].relpath == "bin"
 
 
 def test_package_with_dependency(rule_runner: RuleRunner) -> None:
@@ -109,7 +109,7 @@ def test_package_with_dependency(rule_runner: RuleRunner) -> None:
                 """\
                 go_module(name='go_mod')
                 go_package(name='main')
-                go_binary(name='bin', binary_name='foo', main=':main')
+                go_binary(name='bin', main=':main')
                 """
             ),
         }
@@ -117,4 +117,4 @@ def test_package_with_dependency(rule_runner: RuleRunner) -> None:
     binary_tgt = rule_runner.get_target(Address("", target_name="bin"))
     built_package = build_package(rule_runner, binary_tgt)
     assert len(built_package.artifacts) == 1
-    assert built_package.artifacts[0].relpath == "foo"
+    assert built_package.artifacts[0].relpath == "bin"

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -3,6 +3,7 @@
 import os
 from typing import Sequence
 
+from pants.core.goals.package import OutputPathField
 from pants.engine.rules import collect_rules
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
@@ -121,22 +122,15 @@ class GoExtModPackage(Target):
 # -----------------------------------------------------------------------------------------------
 
 
-class GoBinaryName(StringField):
-    alias = "binary_name"
-    required = True
-    help = "Name of the Go binary to output."
-
-
 class GoBinaryMainAddress(StringField):
     alias = "main"
     required = True
     help = "Address of the main Go package for this binary."
 
 
-# TODO(11911): This should register `OutputPathField` instead of `GoBinaryName`. (And then update build.py.)
 class GoBinary(Target):
     alias = "go_binary"
-    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, GoBinaryName, GoBinaryMainAddress)
+    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, OutputPathField, GoBinaryMainAddress)
     help = "A Go binary."
 
 


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/11911.

[ci skip-rust]
[ci skip-build-wheels]