### PR TITLE
upgrade to rust v1.55.0

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -57,7 +57,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.54.0-*
+        path: '~/.rustup/toolchains/1.55.0-*
 
           ~/.rustup/update-hashes
 
@@ -212,7 +212,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.54.0-*
+        path: '~/.rustup/toolchains/1.55.0-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,7 +57,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.54.0-*
+        path: '~/.rustup/toolchains/1.55.0-*
 
           ~/.rustup/update-hashes
 
@@ -211,7 +211,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.54.0-*
+        path: '~/.rustup/toolchains/1.55.0-*
 
           ~/.rustup/update-hashes
 
@@ -407,7 +407,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.54.0-*
+        path: '~/.rustup/toolchains/1.55.0-*
 
           ~/.rustup/update-hashes
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.54.0"
+channel = "1.55.0"
 components = [
   "cargo",
   "clippy",

--- a/src/rust/engine/grpc_util/src/lib.rs
+++ b/src/rust/engine/grpc_util/src/lib.rs
@@ -97,7 +97,7 @@ pub fn create_endpoint(
 }
 
 pub fn headers_to_http_header_map(headers: &BTreeMap<String, String>) -> Result<HeaderMap, String> {
-  let http_headers = headers
+  let (http_headers, errors): (Vec<(HeaderName, HeaderValue)>, Vec<String>) = headers
     .iter()
     .map(|(key, value)| {
       let header_name =
@@ -108,10 +108,6 @@ pub fn headers_to_http_header_map(headers: &BTreeMap<String, String>) -> Result<
 
       Ok((header_name, header_value))
     })
-    .collect::<Vec<Result<(HeaderName, HeaderValue), String>>>();
-
-  let (http_headers, errors): (Vec<(HeaderName, HeaderValue)>, Vec<String>) = http_headers
-    .into_iter()
     .partition_map(|result| match result {
       Ok(v) => Either::Left(v),
       Err(err) => Either::Right(err),


### PR DESCRIPTION
Upgrade to Rust v1.55.0.

[Changes](https://blog.rust-lang.org/2021/09/09/Rust-1.55.0.html):
- Cargo deduplicates compiler errors
- Faster, more correct float parsing
- `std::io::ErrorKind` variants updated
- Open range patterns added