### PR TITLE
[internal] Fix native environment scope names and config section merging

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -330,7 +330,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "sysinfo",
- "tempdir",
+ "tempfile",
  "tokio",
  "uname",
 ]
@@ -1956,7 +1956,7 @@ dependencies = [
  "log 0.4.14",
  "peg",
  "shellexpand",
- "tempdir",
+ "tempfile",
  "toml",
 ]
 
@@ -3225,16 +3225,6 @@ dependencies = [
  "stdio",
  "tokio",
  "workunit_store",
-]
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
 ]
 
 [[package]]

--- a/src/rust/engine/client/Cargo.toml
+++ b/src/rust/engine/client/Cargo.toml
@@ -25,4 +25,4 @@ tokio = { version = "1.4", features = ["rt-multi-thread", "macros", "net", "io-s
 uname = "0.1"
 
 [dev-dependencies]
-tempdir = "0.3"
+tempfile = "3"

--- a/src/rust/engine/client/src/pantsd_testing.rs
+++ b/src/rust/engine/client/src/pantsd_testing.rs
@@ -5,14 +5,14 @@ use std::fs;
 use std::process::{Command, Stdio};
 use std::str::from_utf8;
 
-use tempdir::TempDir;
+use tempfile::TempDir;
 
 use options::BuildRoot;
 
 pub(crate) fn launch_pantsd() -> (BuildRoot, TempDir) {
   let build_root = BuildRoot::find()
     .expect("Expected test to be run inside the Pants repo but no build root was detected.");
-  let pants_subprocessdir = TempDir::new("pants_subproccessdir").unwrap();
+  let pants_subprocessdir = TempDir::new().unwrap();
   let mut cmd = Command::new(build_root.join("pants"));
   cmd
     .current_dir(build_root.as_path())

--- a/src/rust/engine/options/Cargo.toml
+++ b/src/rust/engine/options/Cargo.toml
@@ -12,4 +12,4 @@ shellexpand = "2.1"
 toml = "0.5"
 
 [dev-dependencies]
-tempdir = "0.3"
+tempfile = "3"

--- a/src/rust/engine/options/src/build_root_tests.rs
+++ b/src/rust/engine/options/src/build_root_tests.rs
@@ -4,14 +4,14 @@
 use std::fs;
 use std::path::PathBuf;
 
-use tempdir::TempDir;
+use tempfile::TempDir;
 
 use crate::build_root::BuildRoot;
 use std::ops::Deref;
 
 #[test]
 fn test_find_cwd() {
-  let buildroot = TempDir::new("buildroot").unwrap();
+  let buildroot = TempDir::new().unwrap();
   let buildroot_path = buildroot.path().to_path_buf();
   let mut sentinel: Option<PathBuf> = None;
 
@@ -37,7 +37,7 @@ fn test_find_cwd() {
 
 #[test]
 fn test_find_subdir() {
-  let buildroot = TempDir::new("buildroot").unwrap();
+  let buildroot = TempDir::new().unwrap();
   let buildroot_path = buildroot.path().to_path_buf();
   let subdir = buildroot_path.join("foo").join("bar");
 

--- a/src/rust/engine/options/src/config_tests.rs
+++ b/src/rust/engine/options/src/config_tests.rs
@@ -1,0 +1,65 @@
+// Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+use std::fs::File;
+use std::io::Write;
+
+use crate::config::Config;
+use crate::{option_id, OptionId, OptionsSource};
+
+use tempfile::TempDir;
+
+fn config<I: IntoIterator<Item = &'static str>>(file_contents: I) -> Config {
+  let dir = TempDir::new().unwrap();
+  let files = file_contents
+    .into_iter()
+    .enumerate()
+    .map(|(idx, file_content)| {
+      let path = dir.path().join(format!("{}.toml", idx));
+      File::create(&path)
+        .unwrap()
+        .write_all(file_content.as_bytes())
+        .unwrap();
+      path
+    })
+    .collect::<Vec<_>>();
+  Config::merged(&files).unwrap()
+}
+
+#[test]
+fn test_display() {
+  let config = config([]);
+  assert_eq!(
+    "[GLOBAL] name".to_owned(),
+    config.display(&option_id!("name"))
+  );
+  assert_eq!(
+    "[scope] name".to_owned(),
+    config.display(&option_id!(["scope"], "name"))
+  );
+  assert_eq!(
+    "[scope] full_name".to_owned(),
+    config.display(&option_id!(-'f', ["scope"], "full", "name"))
+  );
+}
+
+#[test]
+fn test_section_overlap() {
+  // Two files with the same section should result in merged content for that section.
+  let config = config([
+    "[section]\n\
+     field1 = 'something'\n",
+    "[section]\n\
+     field2 = 'something else'\n",
+  ]);
+
+  let assert_string = |expected: &str, id: OptionId| {
+    assert_eq!(
+      expected.to_owned(),
+      config.get_string(&id).unwrap().unwrap()
+    )
+  };
+
+  assert_string("something", option_id!(["section"], "field1"));
+  assert_string("something else", option_id!(["section"], "field2"));
+}

--- a/src/rust/engine/options/src/env.rs
+++ b/src/rust/engine/options/src/env.rs
@@ -25,7 +25,7 @@ impl Env {
     let name = id.name("_", NameTransform::ToUpper);
     let mut names = vec![format!(
       "PANTS_{}_{}",
-      id.0.name().to_ascii_uppercase(),
+      id.0.name().replace("-", "_").to_ascii_uppercase(),
       name
     )];
     if id.0 == Scope::Global {

--- a/src/rust/engine/options/src/env_tests.rs
+++ b/src/rust/engine/options/src/env_tests.rs
@@ -18,17 +18,26 @@ fn env<I: IntoIterator<Item = (&'static str, &'static str)>>(vars: I) -> Env {
 #[test]
 fn test_display() {
   let env = env([]);
-  assert_eq!(
-    "PANTS_GLOBAL".to_owned(),
-    env.display(&option_id!("global"))
-  );
+  assert_eq!("PANTS_NAME".to_owned(), env.display(&option_id!("name")));
   assert_eq!(
     "PANTS_SCOPE_NAME".to_owned(),
-    env.display(&option_id!("scope", "name"))
+    env.display(&option_id!(["scope"], "name"))
   );
   assert_eq!(
     "PANTS_SCOPE_FULL_NAME".to_owned(),
-    env.display(&option_id!(-'f', "scope", "full", "name"))
+    env.display(&option_id!(-'f', ["scope"], "full", "name"))
+  );
+}
+
+#[test]
+fn test_scope() {
+  let env = env([("PANTS_PYTHON_SETUP_EXAMPLE", "true")]);
+  assert_eq!(
+    true,
+    env
+      .get_bool(&option_id!(["python-setup"], "example"))
+      .unwrap()
+      .unwrap()
   );
 }
 

--- a/src/rust/engine/options/src/lib.rs
+++ b/src/rust/engine/options/src/lib.rs
@@ -36,6 +36,9 @@ mod build_root;
 mod build_root_tests;
 
 mod config;
+#[cfg(test)]
+mod config_tests;
+
 mod env;
 #[cfg(test)]
 mod env_tests;


### PR DESCRIPTION
Fixes a few things I encountered while working #12804:
* Scopes in environment variable names are converted to underscored.
* Sections across multiple config files should be merged rather than fully overwriting one another.
* The `tempfile` crate is more widely used in our tests for some reason, so standardize.