### PR TITLE
Add `script` field to `pex_binary` for console scripts

### DIFF
--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -18,6 +18,7 @@ from pants.backend.python.target_types import (
 )
 from pants.backend.python.target_types import PexPlatformsField as PythonPlatformsField
 from pants.backend.python.target_types import (
+    PexScriptField,
     PexShebangField,
     PexStripEnvField,
     PexZipSafeField,
@@ -54,6 +55,7 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
     required_fields = (PexEntryPointField,)
 
     entry_point: PexEntryPointField
+    script: PexScriptField
 
     output_path: OutputPathField
     always_write_cache: PexAlwaysWriteCacheField
@@ -126,9 +128,7 @@ async def package_pex_binary(
         PexFromTargetsRequest(
             addresses=[field_set.address],
             internal_only=False,
-            # TODO(John Sirois): Support ConsoleScript in PexBinary targets:
-            #  https://github.com/pantsbuild/pants/issues/11619
-            main=resolved_entry_point.val,
+            main=resolved_entry_point.val or field_set.script.value,
             platforms=PexPlatforms.create_from_platforms_field(field_set.platforms),
             resolve_and_lockfile=field_set.resolve.resolve_and_lockfile(python_setup),
             output_filename=output_filename,

--- a/src/python/pants/backend/python/goals/run_pex_binary.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary.py
@@ -49,9 +49,7 @@ async def create_pex_binary_run_request(
             include_source_files=False,
             # Note that the file for first-party entry points is not in the PEX itself. In that
             # case, it's loaded by setting `PEX_EXTRA_SYS_PATH`.
-            # TODO(John Sirois): Support ConsoleScript in PexBinary targets:
-            #  https://github.com/pantsbuild/pants/issues/11619
-            main=entry_point.val,
+            main=entry_point.val or field_set.script.value,
             resolve_and_lockfile=field_set.resolve.resolve_and_lockfile(python_setup),
             additional_args=(
                 *field_set.generate_additional_args(pex_binary_defaults),


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/11619.

This will benefit from https://github.com/pantsbuild/pants/issues/9561 to ensure both `script` and `entry_point` are not set at the same time. For now, `entry_point` wins out.

This means that we no longer make `entry_point` required because it's valid to set `script` instead. So, we deprecate `entry_point="<none>"` to indicate there is no entry point - now you leave off both the `script` and `entry_point` fields.

[ci skip-rust]
[ci skip-build-wheels]