### PR TITLE
Allow Targets to validate after construction

### DIFF
--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -34,6 +34,7 @@ from pants.engine.target import (
     IntField,
     InvalidFieldException,
     InvalidFieldTypeException,
+    InvalidTargetException,
     NestedDictStringToStringField,
     ProvidesField,
     ScalarField,
@@ -520,6 +521,14 @@ class PexBinary(Target):
         "self-contained executable files that contain a complete Python environment capable of "
         f"running the target. For more information, see {doc_url('pex-files')}."
     )
+
+    def validate(self) -> None:
+        if self[PexEntryPointField].value is not None and self[PexScriptField].value is not None:
+            raise InvalidTargetException(
+                f"The `{self.alias}` target {self.address} cannot set both the "
+                f"`{self[PexEntryPointField].alias}` and `{self[PexScriptField].alias}` fields at "
+                "the same time. To fix, please remove one."
+            )
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -333,6 +333,8 @@ class Target:
             )
         )
 
+        self.validate()
+
     @final
     @property
     def field_types(self) -> Tuple[Type[Field], ...]:
@@ -557,6 +559,9 @@ class Target:
         citizen. Plugins can use this new field like any other.
         """
         return UnionRule(cls._plugin_field_cls, field)
+
+    def validate(self) -> None:
+        """Validate the target, such as checking for mutually exclusive fields."""
 
 
 @dataclass(frozen=True)
@@ -954,6 +959,15 @@ class FieldSetsPerTargetRequest(Generic[_FS]):
 # -----------------------------------------------------------------------------------------------
 # Exception messages
 # -----------------------------------------------------------------------------------------------
+
+
+class InvalidTargetException(Exception):
+    """Use when there's an issue with the target, e.g. mutually exclusive fields set.
+
+    Suggested template:
+
+         f"The `{repr(alias)}` target {address} ..."
+    """
 
 
 class InvalidFieldException(Exception):

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -22,6 +22,7 @@ from pants.engine.target import (
     InvalidFieldChoiceException,
     InvalidFieldException,
     InvalidFieldTypeException,
+    InvalidTargetException,
     NestedDictStringToStringField,
     RequiredFieldMissingException,
     ScalarField,
@@ -77,6 +78,10 @@ class UnrelatedField(BoolField):
 class FortranTarget(Target):
     alias = "fortran"
     core_fields = (FortranExtensions, FortranVersion)
+
+    def validate(self) -> None:
+        if self[FortranVersion].value == "bad":
+            raise InvalidTargetException("Bad!")
 
 
 def test_field_and_target_eq() -> None:
@@ -415,6 +420,11 @@ def test_async_field_mixin() -> None:
     subclass = Subclass(None, addr)
     assert field != subclass
     assert hash(field) != hash(subclass)
+
+
+def test_target_validate() -> None:
+    with pytest.raises(InvalidTargetException):
+        FortranTarget({FortranVersion.alias: "bad"}, Address("", target_name="t"))
 
 
 # -----------------------------------------------------------------------------------------------


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/9561, and applies this new mechanism to validate that a `pex_binary` does not set both `script` and `entry_point`.

At first, I considered a more constrained solution like plugin authors indicating which fields are mutually exclusive. Instead, this is more flexible.

[ci skip-rust]
[ci skip-build-wheels]