### PR TITLE
Upgrade to poetry 1.1.8

### DIFF
--- a/src/python/pants/backend/python/subsystems/poetry.py
+++ b/src/python/pants/backend/python/subsystems/poetry.py
@@ -24,7 +24,7 @@ class PoetrySubsystem(PythonToolRequirementsBase):
     options_scope = "poetry"
     help = "Used to generate lockfiles for third-party Python dependencies."
 
-    default_version = "poetry==1.1.7"
+    default_version = "poetry==1.1.8"
 
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.6"]


### PR DESCRIPTION
https://python-poetry.org/history/#118---2021-08-19

Fixed an error with repository prioritization when specifying secondary repositories. (#4241)
Fixed the detection of the system environment when the setting virtualenvs.create is deactivated. (#4330, #4407)
Fixed the evaluation of relative path dependencies. (#4246)
Fixed environment detection for Python 3.10 environments. (#4387)
Fixed an error in the evaluation of in/not in markers (python-poetry/poetry-core#189)