### PR TITLE
Handle a quirk when building on MacOS Big Sur.

### DIFF
--- a/build-support/common.sh
+++ b/build-support/common.sh
@@ -69,3 +69,7 @@ function determine_python() {
 function is_macos_arm() {
   [[ $(uname -sm) == "Darwin arm64" ]]
 }
+
+function is_macos_big_sur() {
+  [[ $(uname) == "Darwin" && $(sw_vers -productVersion) = 11\.* ]]
+}

--- a/cargo
+++ b/cargo
@@ -11,6 +11,17 @@ PY="$(determine_python)"
 export PY
 export PYO3_PYTHON="${PY}"
 export PYTHON_SYS_EXECUTABLE="${PY}" # Consumed by the cpython crate.
+if is_macos_big_sur; then
+  # With Big Sur, MacOS changed its versioning scheme from 10.X to 11.X. A pantsbuild.pants
+  # wheel built on Big Sur will declare its platform (in its name) as macosx_11_0. Unfortunately
+  # pip does not yet recognize that as a compatible platform for Big Sur.
+  # Fortunately, Big Sur may also be identified as 10.16, for backwards compatibility with the old
+  # versioning scheme. Setting MACOSX_DEPLOYMENT_TARGET=10.16 when building the wheel will cause
+  # that wheel to declare its platform as macosx_10_16, which pip will then happily install.
+  # However, in order to build the wheel as macosx_10_16 we must also build the native code for
+  # that platform string, hence this setting here.
+  export MACOSX_DEPLOYMENT_TARGET=10.16
+fi
 
 if ! command -v rustup &> /dev/null; then
   die "Please install Rustup and ensure \`rustup\` is on your PATH (usually by adding ~/.cargo/bin). See https://rustup.rs."

--- a/pants.toml
+++ b/pants.toml
@@ -74,6 +74,7 @@ root_patterns = [
 [python-setup]
 experimental_lockfile = "3rdparty/python/lockfiles/user_reqs.txt"
 interpreter_constraints = [">=3.7,<3.10"]
+macos_big_sur_compatibility = true
 
 [docformatter]
 args = ["--wrap-summaries=100", "--wrap-descriptions=100"]

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -216,6 +216,16 @@ class PythonSetup(Subsystem):
             help="Tailor pex_binary() targets for Python entry point files.",
         )
 
+        register(
+            "--macos-big-sur-compatibility",
+            type=bool,
+            default=False,
+            help="If set, and if running on MacOS Big Sur, use macosx_10_16 as the platform "
+            "when building wheels. Otherwise, the default of macosx_11_0 will be used. "
+            "This may be required for pip to be able to install the resulting distribution "
+            "on Big Sur.",
+        )
+
     @property
     def interpreter_constraints(self) -> Tuple[str, ...]:
         return tuple(self.options.interpreter_constraints)
@@ -270,6 +280,10 @@ class PythonSetup(Subsystem):
     @property
     def tailor_pex_binary_targets(self) -> bool:
         return cast(bool, self.options.tailor_pex_binary_targets)
+
+    @property
+    def macos_big_sur_compatibility(self) -> bool:
+        return cast(bool, self.options.macos_big_sur_compatibility)
 
     @property
     def scratch_dir(self):

--- a/src/python/pants/util/osutil.py
+++ b/src/python/pants/util/osutil.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import errno
 import logging
 import os
+import platform
 import posix
 from functools import reduce
 from typing import Optional
@@ -93,6 +94,10 @@ def get_normalized_os_name() -> str:
 
 def get_normalized_arch_name() -> str:
     return normalize_arch_name(get_arch_name())
+
+
+def is_macos_big_sur() -> bool:
+    return hasattr(platform, "mac_ver") and platform.mac_ver()[0].startswith("11.")
 
 
 def _values(aliases: dict[str, set[str]]) -> set[str]:


### PR DESCRIPTION
Adds an option to set the Big Sur platform to "10.16" instead of the new scheme of "11.0", 
when building dists. This may be required for pip to be able to install the resulting dists. 

Also ensures that this will work for our own wheels, by setting this when building the native code
(otherwise setup.py will warn that the native code platform is incompatible, and ignore the 10.16 setting).

[ci skip-rust]

[ci skip-build-wheels]