### PR TITLE
docker: add plugin hook for customizing build context.

### DIFF
--- a/src/python/pants/backend/docker/docker_build_context.py
+++ b/src/python/pants/backend/docker/docker_build_context.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import logging
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from itertools import chain
 
@@ -10,7 +11,7 @@ from pants.core.goals.package import BuiltPackage, PackageFieldSet
 from pants.core.target_types import FilesSources
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
-from pants.engine.fs import Digest, MergeDigests
+from pants.engine.fs import Digest, MergeDigests, Snapshot
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     Dependencies,
@@ -18,10 +19,12 @@ from pants.engine.target import (
     FieldSetsPerTarget,
     FieldSetsPerTargetRequest,
     Sources,
+    Target,
     Targets,
     TransitiveTargets,
     TransitiveTargetsRequest,
 )
+from pants.engine.unions import UnionMembership, union
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +34,36 @@ class DockerBuildContext:
     digest: Digest
 
 
+@union
+@dataclass(frozen=True)  # type: ignore[misc]
+class DockerBuildContextPlugin(ABC):
+    """Hook to offer plugins the possibility to customize the Docker build context used when
+    building Docker images.
+
+    The snapshot is the complete context for docker_image target. A plugin may implement a rule to
+    modify that digest, and return a new DockerBuildContext.
+
+    Example rule to customize the context:
+
+        class CustomContext(DockerBuildContextPlugin):
+            is_applicable(cls, target):
+                return True
+
+        @rule
+        async def plugin_rule(request: CustomContext) -> DockerBuildContext:
+            context = await Get(...)
+            return DockerBuildContext(context)
+    """
+
+    snapshot: Snapshot
+    target: Target
+
+    @classmethod
+    @abstractmethod
+    def is_applicable(cls, target: Target) -> bool:
+        """Whether the build context plugin should be used for this target or not."""
+
+
 @dataclass(frozen=True)
 class DockerBuildContextRequest:
     address: Address
@@ -38,7 +71,9 @@ class DockerBuildContextRequest:
 
 
 @rule
-async def create_docker_build_context(request: DockerBuildContextRequest) -> DockerBuildContext:
+async def create_docker_build_context(
+    request: DockerBuildContextRequest, union_membership: UnionMembership
+) -> DockerBuildContext:
     # Get all targets to include in context.
     transitive_targets = await Get(TransitiveTargets, TransitiveTargetsRequest([request.address]))
 
@@ -92,13 +127,31 @@ async def create_docker_build_context(request: DockerBuildContextRequest) -> Doc
     embedded_pkgs_digest = [built_package.digest for built_package in embedded_pkgs]
     all_digests = (dockerfiles.snapshot.digest, sources.snapshot.digest, *embedded_pkgs_digest)
 
-    # Merge all digests to get the final docker build context.
+    # Merge all digests to get the docker build context.
     context = await Get(
-        Digest,
+        Snapshot,
         MergeDigests(d for d in all_digests if d),
     )
 
-    return DockerBuildContext(context)
+    target = transitive_targets.roots[0]
+
+    # Call plugins that may modify build context.
+    customized_contexts = await MultiGet(
+        Get(
+            DockerBuildContext,
+            DockerBuildContextPlugin,  # type: ignore[misc]
+            plugin(snapshot=context, target=target),  # type: ignore[abstract]
+        )
+        for plugin in union_membership.get(DockerBuildContextPlugin)
+        if plugin.is_applicable(target)
+    )
+
+    if not customized_contexts:
+        final_context = context.digest
+    else:
+        final_context = await Get(Digest, MergeDigests(c.digest for c in customized_contexts))
+
+    return DockerBuildContext(final_context)
 
 
 def rules():


### PR DESCRIPTION
This adds a hook for plugins to customize the Docker build context.

Example rule to customize the context:

```python
        class CustomContext(DockerBuildContextPlugin):
            is_applicable(cls, target):
                return True

        @rule
        async def plugin_rule(request: CustomContext) -> DockerBuildContext:
            context = await Get(...)
            return DockerBuildContext(context)
```

[ci skip-rust]
[ci skip-build-wheels]