### PR TITLE
Initial Dockerfile parsing support

### DIFF
--- a/src/python/pants/backend/docker/dockerfile.py
+++ b/src/python/pants/backend/docker/dockerfile.py
@@ -1,0 +1,46 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import re
+from dataclasses import dataclass, fields
+from typing import Any, Dict, Generator, Optional, Tuple
+
+from pants.backend.docker.dockerfile_commands import BaseImage, Copy, DockerfileCommand, EntryPoint
+
+
+@dataclass(frozen=True)
+class Dockerfile:
+    baseimage: Optional[BaseImage] = None
+    entry_point: Optional[EntryPoint] = None
+    copy: Tuple[Copy, ...] = tuple()
+
+    @classmethod
+    def parse(cls, dockerfile_source: str) -> "Dockerfile":
+        attrs: Dict[str, Any] = {}
+        for command_line in cls._iter_command_lines(dockerfile_source):
+            cmd = DockerfileCommand.decode(command_line)
+            if cmd:
+                cmd.register(attrs)
+
+        return Dockerfile(**attrs)
+
+    def compile(self) -> str:
+        return "\n".join(self._encode_fields())
+
+    def _encode_fields(self) -> Generator[str, None, None]:
+        for fld in fields(self):
+            value = getattr(self, fld.name)
+            if value:
+                if isinstance(value, tuple):
+                    for v in value:
+                        yield v.encode()
+                else:
+                    yield value.encode()
+
+    @staticmethod
+    def _iter_command_lines(dockerfile_source: str) -> Generator[str, None, None]:
+        unwraped = re.sub(r"\\[\r\n]+", "", dockerfile_source)
+        for m in re.finditer("^.*$", unwraped, flags=re.MULTILINE):
+            line = m.group().strip()
+            if line and not line.startswith("#"):
+                yield re.sub(r" +", " ", re.sub(r"\t", " ", line))

--- a/src/python/pants/backend/docker/dockerfile.py
+++ b/src/python/pants/backend/docker/dockerfile.py
@@ -2,21 +2,52 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import re
-from dataclasses import dataclass, fields
-from typing import Collection, Generator, Tuple
+from dataclasses import dataclass, field
+from typing import Collection, Generator, List, Optional, Tuple, Type, TypeVar, Union, cast
 
-from pants.backend.docker.dockerfile_commands import DockerfileCommand
+from pants.backend.docker.dockerfile_commands import BaseImage, DockerfileCommand
+from pants.util.frozendict import FrozenDict
 from pants.util.meta import frozen_after_init
+
+T = TypeVar("T", bound=DockerfileCommand)
+
+
+class NoValue:
+    pass
+
+
+NOVALUE = NoValue()
+
+
+@dataclass(frozen=True)
+class DockerfileStage:
+    parent: "Dockerfile" = field(hash=False, repr=False)
+    index: int
 
 
 @frozen_after_init
-@dataclass
+@dataclass(unsafe_hash=True)
 class Dockerfile:
     commands: Tuple[DockerfileCommand, ...]
 
-    def __init__(self, commands: Collection[DockerfileCommand]) -> None:
+    _stage_info: Optional[DockerfileStage] = None
+    stages: Tuple["Dockerfile", ...] = field(init=False, compare=False)
+    stage: FrozenDict[str, "Dockerfile"] = field(init=False, compare=False)
+
+    def __init__(
+        self, commands: Collection[DockerfileCommand], _stage_info: Optional[DockerfileStage] = None
+    ) -> None:
         super().__init__()
         self.commands = tuple(commands)
+        self.stage = FrozenDict()
+        if _stage_info:
+            self._stage_info = _stage_info
+            self.stages = ()
+        else:
+            self._stage_info = None
+            self.stages = tuple(self._iter_stages())
+
+        self.stage = FrozenDict({cast(str, stage.stage_name): stage for stage in self.stages})
 
     @classmethod
     def parse(cls, dockerfile_source: str) -> "Dockerfile":
@@ -29,17 +60,7 @@ class Dockerfile:
         return Dockerfile(commands)
 
     def compile(self) -> str:
-        return "\n".join(self._encode_fields())
-
-    def _encode_fields(self) -> Generator[str, None, None]:
-        for fld in fields(self):
-            value = getattr(self, fld.name)
-            if value:
-                if isinstance(value, tuple):
-                    for v in value:
-                        yield v.encode()
-                else:
-                    yield value.encode()
+        return "\n".join(cmd.encode() for cmd in self.commands)
 
     @staticmethod
     def _iter_command_lines(dockerfile_source: str) -> Generator[str, None, None]:
@@ -48,3 +69,55 @@ class Dockerfile:
             line = m.group().strip()
             if line and not line.startswith("#"):
                 yield re.sub(r" +", " ", re.sub(r"\t", " ", line))
+
+    def _create_stage(
+        self, stage_index: int, commands: Collection[DockerfileCommand]
+    ) -> "Dockerfile":
+        return Dockerfile(commands, _stage_info=DockerfileStage(self, stage_index))
+
+    def _iter_stages(self) -> Generator["Dockerfile", None, None]:
+        command_stack: List[DockerfileCommand] = []
+        stage_index = 0
+
+        for cmd in self.commands:
+            if cmd.alias == "FROM":
+                if command_stack:
+                    yield self._create_stage(stage_index, command_stack)
+                    stage_index += 1
+
+                command_stack = []
+            command_stack.append(cmd)
+
+        yield self._create_stage(stage_index, command_stack)
+
+    def get(self, command_type: Type[T], default: Union[T, None, NoValue] = NOVALUE) -> Optional[T]:
+        for cmd in self.commands:
+            if isinstance(cmd, command_type):
+                return cmd
+
+        if isinstance(default, NoValue):
+            raise KeyError(f"Dockerfile has no {command_type} command instruction.")
+        return default
+
+    def get_all(self, command_type: Type[T]) -> Tuple[T, ...]:
+        return tuple(cmd for cmd in self.commands if isinstance(cmd, command_type))
+
+    @property
+    def parent(self) -> Optional["Dockerfile"]:
+        if self._stage_info:
+            return self._stage_info.parent
+        return None
+
+    @property
+    def stage_index(self) -> Optional[int]:
+        if self._stage_info:
+            return self._stage_info.index
+        return None
+
+    @property
+    def stage_name(self) -> Optional[str]:
+        if self._stage_info:
+            base = self.get(BaseImage, None)
+            if base:
+                return base.name or str(self.stage_index)
+        return None

--- a/src/python/pants/backend/docker/dockerfile_commands.py
+++ b/src/python/pants/backend/docker/dockerfile_commands.py
@@ -1,0 +1,252 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import json
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, Generator, Optional, Pattern, Tuple, Type
+
+
+class DockerfileError(Exception):
+    pass
+
+
+class InvalidDockerfileCommandArgument(DockerfileError):
+    """Invalid syntax for the Dockerfile command."""
+
+
+class DockerfileCommand(ABC):
+    """Base class for dockerfile commands encoding/decoding."""
+
+    _command = "<OVERRIDE ME>"
+
+    def _append(self, attr: str, dockerfile_attrs: Dict[str, Any]) -> None:
+        dockerfile_attrs[attr] = (*dockerfile_attrs.get(attr, tuple()), self)
+
+    @classmethod
+    def _command_class(cls, command: str) -> Optional[Type["DockerfileCommand"]]:
+        for cmd_cls in cls.__subclasses__():
+            if cmd_cls._command == command:
+                return cmd_cls
+        return None
+
+    @classmethod
+    def from_arg(cls, arg: str) -> "DockerfileCommand":
+        # ignore type warning here, as we expect cls to be a subclass of DockerfileCommand..
+        return cls(**cls.decode_arg(arg))  # type: ignore[call-arg]
+
+    @classmethod
+    def decode(cls, command_line: str) -> Optional["DockerfileCommand"]:
+        """Parse a Dockerfile command."""
+        cmd, _, arg = command_line.partition(" ")
+        cmd_cls = cls._command_class(cmd)
+        if cmd_cls:
+            return cmd_cls.from_arg(arg)
+        return None
+
+    def encode(self) -> str:
+        """Convert command to string representation for a Dockerfile."""
+        return " ".join([self._command, *self.encode_arg()])
+
+    @staticmethod
+    def _decode_arg_regexp(regexp: Pattern, arg: str) -> Dict[str, Optional[str]]:
+        m = regexp.match(arg)
+        if not m:
+            raise InvalidDockerfileCommandArgument(arg)
+        return m.groupdict()
+
+    @classmethod
+    @abstractmethod
+    def decode_arg(cls, arg: str) -> Dict[str, Optional[str]]:
+        """Parse command arguments."""
+
+    @abstractmethod
+    def encode_arg(self) -> Generator[str, None, None]:
+        """Convert command arg to string(s)"""
+
+    @abstractmethod
+    def register(self, dockerfile_attrs: Dict[str, Any]) -> None:
+        """Add this command to Dockerfile attrs."""
+
+
+@dataclass(frozen=True)
+class BaseImage(DockerfileCommand):
+    """The FROM instruction initializes a new build stage and sets the Base Image for subsequent
+    instructions.
+
+        FROM [--platform=<platform>] <image> [AS <name>]
+        FROM [--platform=<platform>] <image>[:<tag>] [AS <name>]
+        FROM [--platform=<platform>] <image>[@<digest>] [AS <name>]
+
+    https://docs.docker.com/engine/reference/builder/#from
+    """
+
+    _command = "FROM"
+
+    image: str
+    name: Optional[str] = None
+    tag: Optional[str] = None
+    digest: Optional[str] = None
+    platform: Optional[str] = None
+    registry: Optional[str] = None
+
+    _arg_regexp = re.compile(
+        r"""
+        ^
+        # optional platform
+        (--platform=(?P<platform>\S+)\s+)?
+
+        # optional registry
+        ((?P<registry>\S+:[^/]+)/)?
+
+        # image
+        (?P<image>[^:@ \t\n\r\f\v]+)(
+
+          # optionally with :tag or @digest
+          (:(?P<tag>\S+)) | (@(?P<digest>\S+))
+
+        )?
+
+        # optional name
+        (\s+AS\s+(?P<name>\S+))?
+        $
+        """,
+        re.VERBOSE,
+    )
+
+    def register(self, dockerfile_attrs: Dict[str, Any]) -> None:
+        dockerfile_attrs["baseimage"] = self
+
+    def encode_arg(self) -> Generator[str, None, None]:
+        if self.platform:
+            yield f"--platform={self.platform}"
+
+        image = self.image
+        if self.registry:
+            image = "/".join([self.registry, self.image])
+        if self.digest:
+            image += f"@{self.digest}"
+        elif self.tag:
+            image += f":{self.tag}"
+
+        yield image
+
+        if self.name:
+            yield f"AS {self.name}"
+
+    @classmethod
+    def decode_arg(cls, arg: str) -> Dict[str, Optional[str]]:
+        return cls._decode_arg_regexp(cls._arg_regexp, arg)
+
+
+@dataclass(frozen=True)
+class EntryPoint(DockerfileCommand):
+    """An ENTRYPOINT allows you to configure a container that will run as an executable.
+
+        ENTRYPOINT ["executable", "param1", "param2"]  # form: exec
+        ENTRYPOINT command param1 param2               # form: shell
+
+    https://docs.docker.com/engine/reference/builder/#entrypoint
+    """
+
+    _command = "ENTRYPOINT"
+
+    class Form(Enum):
+        EXEC = "exec"
+        SHELL = "shell"
+
+    executable: str
+    arguments: Optional[Tuple[str, ...]] = None
+    form: Form = Form.EXEC
+
+    def register(self, dockerfile_attrs: Dict[str, Any]) -> None:
+        dockerfile_attrs["entry_point"] = self
+
+    def encode_arg(self) -> Generator[str, None, None]:
+        if self.form is EntryPoint.Form.EXEC:
+            yield json.dumps([self.executable, *(self.arguments or [])])
+        else:
+            yield self.executable
+            if self.arguments:
+                yield " ".join(self.arguments)
+
+    @classmethod
+    def decode_arg(cls, arg: str) -> Dict[str, Any]:
+        if arg.startswith("["):
+            form = EntryPoint.Form.EXEC
+            cmd_line = json.loads(arg)
+        else:
+            form = EntryPoint.Form.SHELL
+            cmd_line = arg.split(" ")
+        return dict(executable=cmd_line[0], arguments=tuple(cmd_line[1:]), form=form)
+
+
+@dataclass(frozen=True)
+class Copy(DockerfileCommand):
+    """The COPY instruction copies new files or directories from <src> and adds them to the
+    filesystem of the container at the path <dest>.
+
+        COPY [--chown=<user>:<group>] <src>... <dest>
+        COPY [--chown=<user>:<group>] ["<src>",... "<dest>"]
+
+        COPY --from=<name> ...
+
+    https://docs.docker.com/engine/reference/builder/#copy
+    """
+
+    _command = "COPY"
+
+    src: Tuple[str, ...]
+    dest: str
+    chown: Optional[str] = None
+    copy_from: Optional[str] = None
+
+    _arg_regexp = re.compile(
+        r"""
+        ^
+        # optional flags
+        (?:
+          (--chown=(?P<chown>\S+)\s+)
+          |
+          (--from=(?P<copy_from>\S+)\s+)
+        )*
+
+        # paths, will be post processed
+        (?P<paths>.+)
+        $
+        """,
+        re.VERBOSE,
+    )
+
+    def register(self, dockerfile_attrs: Dict[str, Any]) -> None:
+        self._append("copy", dockerfile_attrs)
+
+    def encode_arg(self) -> Generator[str, None, None]:
+        if self.copy_from:
+            yield f"--from={self.copy_from}"
+
+        if self.chown:
+            yield f"--chown={self.chown}"
+
+        paths = [*self.src, self.dest]
+        if any(" " in s for s in paths if s):
+            yield json.dumps(paths)
+        else:
+            for path in paths:
+                yield path
+
+    @classmethod
+    def decode_arg(cls, arg: str) -> Dict[str, Optional[str]]:
+        args: Dict[str, Any] = cls._decode_arg_regexp(cls._arg_regexp, arg)
+        paths_string = args.pop("paths") or ""
+        if paths_string.startswith("["):
+            paths = json.loads(paths_string)
+        else:
+            paths = paths_string.split()
+
+        if len(paths) > 1:
+            args["src"] = tuple(paths[:-1])
+            args["dest"] = paths[-1]
+        return args

--- a/src/python/pants/backend/docker/dockerfile_commands_test.py
+++ b/src/python/pants/backend/docker/dockerfile_commands_test.py
@@ -1,0 +1,93 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import pytest
+
+from pants.backend.docker.dockerfile_commands import (
+    BaseImage,
+    Copy,
+    DockerfileCommand,
+    EntryPoint,
+    InvalidDockerfileCommandArgument,
+)
+
+
+@pytest.mark.parametrize(
+    "command_line, expect",
+    [
+        ("FROM simple", BaseImage(image="simple")),
+        ("FROM repo/proj:latest", BaseImage(image="repo/proj", tag="latest")),
+        ("FROM repo/proj@12345", BaseImage(image="repo/proj", digest="12345")),
+        ("FROM repo/proj err", pytest.raises(InvalidDockerfileCommandArgument)),
+        (
+            "FROM custom.registry:443/inhouse/registry",
+            BaseImage(image="inhouse/registry", registry="custom.registry:443"),
+        ),
+        (
+            "FROM --platform=linux/amd64 custom.registry:443/full/blown:1.2.3 AS stage",
+            BaseImage(
+                image="full/blown",
+                tag="1.2.3",
+                name="stage",
+                registry="custom.registry:443",
+                platform="linux/amd64",
+            ),
+        ),
+        ("ENTRYPOINT command", EntryPoint("command", tuple(), form=EntryPoint.Form.SHELL)),
+        (
+            "ENTRYPOINT command param1 param2",
+            EntryPoint(
+                "command",
+                arguments=(
+                    "param1",
+                    "param2",
+                ),
+                form=EntryPoint.Form.SHELL,
+            ),
+        ),
+        ("""ENTRYPOINT ["command"]""", EntryPoint("command", tuple(), form=EntryPoint.Form.EXEC)),
+        (
+            """ENTRYPOINT ["command", "param1", "param2"]""",
+            EntryPoint(
+                "command",
+                arguments=(
+                    "param1",
+                    "param2",
+                ),
+                form=EntryPoint.Form.EXEC,
+            ),
+        ),
+        ("COPY foo /bar/", Copy(src=("foo",), dest="/bar/")),
+        (
+            "COPY foo bar baz quux/",
+            Copy(
+                src=(
+                    "foo",
+                    "bar",
+                    "baz",
+                ),
+                dest="quux/",
+            ),
+        ),
+        ("""COPY ["foo bar", "/foo-bar"]""", Copy(src=("foo bar",), dest="/foo-bar")),
+        (
+            "COPY --chown=bin:staff files* /somedir/",
+            Copy(src=("files*",), dest="/somedir/", chown="bin:staff"),
+        ),
+        ("COPY --from=build app /bin/", Copy(src=("app",), dest="/bin/", copy_from="build")),
+        (
+            "COPY --chown=10:20 --from=build app /bin/",
+            Copy(src=("app",), dest="/bin/", chown="10:20", copy_from="build"),
+        ),
+        (
+            "COPY --from=other/image:1.0 --chown=order:test app /bin/",
+            Copy(src=("app",), dest="/bin/", chown="order:test", copy_from="other/image:1.0"),
+        ),
+    ],
+)
+def test_decode_dockerfile_command(command_line, expect):
+    if isinstance(expect, DockerfileCommand):
+        assert expect == DockerfileCommand.decode(command_line)
+    else:
+        with expect:
+            DockerfileCommand.decode(command_line)

--- a/src/python/pants/backend/docker/dockerfile_test.py
+++ b/src/python/pants/backend/docker/dockerfile_test.py
@@ -6,94 +6,7 @@ from textwrap import dedent
 import pytest
 
 from pants.backend.docker.dockerfile import Dockerfile
-from pants.backend.docker.dockerfile_commands import (
-    BaseImage,
-    Copy,
-    DockerfileCommand,
-    EntryPoint,
-    InvalidDockerfileCommandArgument,
-)
-
-
-@pytest.mark.parametrize(
-    "command_line, expect",
-    [
-        ("FROM simple", BaseImage(image="simple")),
-        ("FROM repo/proj:latest", BaseImage(image="repo/proj", tag="latest")),
-        ("FROM repo/proj@12345", BaseImage(image="repo/proj", digest="12345")),
-        ("FROM repo/proj err", pytest.raises(InvalidDockerfileCommandArgument)),
-        (
-            "FROM custom.registry:443/inhouse/registry",
-            BaseImage(image="inhouse/registry", registry="custom.registry:443"),
-        ),
-        (
-            "FROM --platform=linux/amd64 custom.registry:443/full/blown:1.2.3 AS stage",
-            BaseImage(
-                image="full/blown",
-                tag="1.2.3",
-                name="stage",
-                registry="custom.registry:443",
-                platform="linux/amd64",
-            ),
-        ),
-        ("ENTRYPOINT command", EntryPoint("command", tuple(), form=EntryPoint.Form.SHELL)),
-        (
-            "ENTRYPOINT command param1 param2",
-            EntryPoint(
-                "command",
-                arguments=(
-                    "param1",
-                    "param2",
-                ),
-                form=EntryPoint.Form.SHELL,
-            ),
-        ),
-        ("""ENTRYPOINT ["command"]""", EntryPoint("command", tuple(), form=EntryPoint.Form.EXEC)),
-        (
-            """ENTRYPOINT ["command", "param1", "param2"]""",
-            EntryPoint(
-                "command",
-                arguments=(
-                    "param1",
-                    "param2",
-                ),
-                form=EntryPoint.Form.EXEC,
-            ),
-        ),
-        ("COPY foo /bar/", Copy(src=("foo",), dest="/bar/")),
-        (
-            "COPY foo bar baz quux/",
-            Copy(
-                src=(
-                    "foo",
-                    "bar",
-                    "baz",
-                ),
-                dest="quux/",
-            ),
-        ),
-        ("""COPY ["foo bar", "/foo-bar"]""", Copy(src=("foo bar",), dest="/foo-bar")),
-        (
-            "COPY --chown=bin:staff files* /somedir/",
-            Copy(src=("files*",), dest="/somedir/", chown="bin:staff"),
-        ),
-        ("COPY --from=build app /bin/", Copy(src=("app",), dest="/bin/", copy_from="build")),
-        (
-            "COPY --chown=10:20 --from=build app /bin/",
-            Copy(src=("app",), dest="/bin/", chown="10:20", copy_from="build"),
-        ),
-        (
-            "COPY --from=other/image:1.0 --chown=order:test app /bin/",
-            Copy(src=("app",), dest="/bin/", chown="order:test", copy_from="other/image:1.0"),
-        ),
-    ],
-)
-def test_decode_dockerfile_command(command_line, expect):
-    if isinstance(expect, DockerfileCommand):
-        assert expect == DockerfileCommand.decode(command_line)
-    else:
-        with expect:
-            DockerfileCommand.decode(command_line)
+from pants.backend.docker.dockerfile_commands import BaseImage, Copy, EntryPoint
 
 
 @pytest.mark.parametrize(
@@ -111,19 +24,19 @@ def test_decode_dockerfile_command(command_line, expect):
                 """
             ),
             Dockerfile(
-                baseimage=BaseImage(image="baseimage", tag="tag"),
-                entry_point=EntryPoint(
-                    executable="main",
-                    arguments=(
-                        "arg1",
-                        "arg2",
+                [
+                    BaseImage(image="baseimage", tag="tag"),
+                    EntryPoint(
+                        executable="main",
+                        arguments=(
+                            "arg1",
+                            "arg2",
+                        ),
+                        form=EntryPoint.Form.EXEC,
                     ),
-                    form=EntryPoint.Form.EXEC,
-                ),
-                copy=(
                     Copy(src=("src/path/a",), dest="dst/path/1"),
                     Copy(src=("src/path/b",), dest="dst/path/2"),
-                ),
+                ]
             ),
         ),
     ],
@@ -141,16 +54,18 @@ def test_parse_dockerfile(contents, expect):
     [
         (
             Dockerfile(
-                baseimage=BaseImage("baseimage", tag="tag"),
-                entry_point=EntryPoint(
-                    executable="main",
-                    arguments=(
-                        "arg1",
-                        "arg2",
+                [
+                    BaseImage("baseimage", tag="tag"),
+                    EntryPoint(
+                        executable="main",
+                        arguments=(
+                            "arg1",
+                            "arg2",
+                        ),
+                        form=EntryPoint.Form.EXEC,
                     ),
-                    form=EntryPoint.Form.EXEC,
-                ),
-                copy=(Copy(("source/test.txt",), "/opt/dir/", chown="1", copy_from="other"),),
+                    Copy(("source/test.txt",), "/opt/dir/", chown="1", copy_from="other"),
+                ]
             ),
             dedent(
                 """\
@@ -162,14 +77,16 @@ def test_parse_dockerfile(contents, expect):
         ),
         (
             Dockerfile(
-                entry_point=EntryPoint(
-                    executable="main",
-                    arguments=(
-                        "arg1",
-                        "arg2",
+                [
+                    EntryPoint(
+                        executable="main",
+                        arguments=(
+                            "arg1",
+                            "arg2",
+                        ),
+                        form=EntryPoint.Form.SHELL,
                     ),
-                    form=EntryPoint.Form.SHELL,
-                ),
+                ]
             ),
             dedent(
                 """\
@@ -212,7 +129,7 @@ def test_compile_dockerfile(dockerfile, expect):
         ),
     ],
 )
-def test_dockerfile_command_lines(contents, expect):
+def test_dockerfile__iter_command_lines(contents, expect):
     if isinstance(expect, list):
         assert expect == list(Dockerfile._iter_command_lines(contents))
     else:

--- a/src/python/pants/backend/docker/dockerfile_test.py
+++ b/src/python/pants/backend/docker/dockerfile_test.py
@@ -1,0 +1,220 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from textwrap import dedent
+
+import pytest
+
+from pants.backend.docker.dockerfile import Dockerfile
+from pants.backend.docker.dockerfile_commands import (
+    BaseImage,
+    Copy,
+    DockerfileCommand,
+    EntryPoint,
+    InvalidDockerfileCommandArgument,
+)
+
+
+@pytest.mark.parametrize(
+    "command_line, expect",
+    [
+        ("FROM simple", BaseImage(image="simple")),
+        ("FROM repo/proj:latest", BaseImage(image="repo/proj", tag="latest")),
+        ("FROM repo/proj@12345", BaseImage(image="repo/proj", digest="12345")),
+        ("FROM repo/proj err", pytest.raises(InvalidDockerfileCommandArgument)),
+        (
+            "FROM custom.registry:443/inhouse/registry",
+            BaseImage(image="inhouse/registry", registry="custom.registry:443"),
+        ),
+        (
+            "FROM --platform=linux/amd64 custom.registry:443/full/blown:1.2.3 AS stage",
+            BaseImage(
+                image="full/blown",
+                tag="1.2.3",
+                name="stage",
+                registry="custom.registry:443",
+                platform="linux/amd64",
+            ),
+        ),
+        ("ENTRYPOINT command", EntryPoint("command", tuple(), form=EntryPoint.Form.SHELL)),
+        (
+            "ENTRYPOINT command param1 param2",
+            EntryPoint(
+                "command",
+                arguments=(
+                    "param1",
+                    "param2",
+                ),
+                form=EntryPoint.Form.SHELL,
+            ),
+        ),
+        ("""ENTRYPOINT ["command"]""", EntryPoint("command", tuple(), form=EntryPoint.Form.EXEC)),
+        (
+            """ENTRYPOINT ["command", "param1", "param2"]""",
+            EntryPoint(
+                "command",
+                arguments=(
+                    "param1",
+                    "param2",
+                ),
+                form=EntryPoint.Form.EXEC,
+            ),
+        ),
+        ("COPY foo /bar/", Copy(src=("foo",), dest="/bar/")),
+        (
+            "COPY foo bar baz quux/",
+            Copy(
+                src=(
+                    "foo",
+                    "bar",
+                    "baz",
+                ),
+                dest="quux/",
+            ),
+        ),
+        ("""COPY ["foo bar", "/foo-bar"]""", Copy(src=("foo bar",), dest="/foo-bar")),
+        (
+            "COPY --chown=bin:staff files* /somedir/",
+            Copy(src=("files*",), dest="/somedir/", chown="bin:staff"),
+        ),
+        ("COPY --from=build app /bin/", Copy(src=("app",), dest="/bin/", copy_from="build")),
+        (
+            "COPY --chown=10:20 --from=build app /bin/",
+            Copy(src=("app",), dest="/bin/", chown="10:20", copy_from="build"),
+        ),
+        (
+            "COPY --from=other/image:1.0 --chown=order:test app /bin/",
+            Copy(src=("app",), dest="/bin/", chown="order:test", copy_from="other/image:1.0"),
+        ),
+    ],
+)
+def test_decode_dockerfile_command(command_line, expect):
+    if isinstance(expect, DockerfileCommand):
+        assert expect == DockerfileCommand.decode(command_line)
+    else:
+        with expect:
+            DockerfileCommand.decode(command_line)
+
+
+@pytest.mark.parametrize(
+    "contents, expect",
+    [
+        (
+            dedent(
+                """\
+                FROM baseimage:tag
+                ENTRYPOINT ["main", "arg1", "arg2"]
+                # ENV option=value
+                COPY src/path/a dst/path/1
+                COPY src/path/b dst/path/2
+                # RUN some command
+                """
+            ),
+            Dockerfile(
+                baseimage=BaseImage(image="baseimage", tag="tag"),
+                entry_point=EntryPoint(
+                    executable="main",
+                    arguments=(
+                        "arg1",
+                        "arg2",
+                    ),
+                    form=EntryPoint.Form.EXEC,
+                ),
+                copy=(
+                    Copy(src=("src/path/a",), dest="dst/path/1"),
+                    Copy(src=("src/path/b",), dest="dst/path/2"),
+                ),
+            ),
+        ),
+    ],
+)
+def test_parse_dockerfile(contents, expect):
+    if isinstance(expect, Dockerfile):
+        assert expect == Dockerfile.parse(contents)
+    else:
+        with expect:
+            Dockerfile.parse(contents)
+
+
+@pytest.mark.parametrize(
+    "dockerfile, expect",
+    [
+        (
+            Dockerfile(
+                baseimage=BaseImage("baseimage", tag="tag"),
+                entry_point=EntryPoint(
+                    executable="main",
+                    arguments=(
+                        "arg1",
+                        "arg2",
+                    ),
+                    form=EntryPoint.Form.EXEC,
+                ),
+                copy=(Copy(("source/test.txt",), "/opt/dir/", chown="1", copy_from="other"),),
+            ),
+            dedent(
+                """\
+                FROM baseimage:tag
+                ENTRYPOINT ["main", "arg1", "arg2"]
+                COPY --from=other --chown=1 source/test.txt /opt/dir/
+                """
+            ),
+        ),
+        (
+            Dockerfile(
+                entry_point=EntryPoint(
+                    executable="main",
+                    arguments=(
+                        "arg1",
+                        "arg2",
+                    ),
+                    form=EntryPoint.Form.SHELL,
+                ),
+            ),
+            dedent(
+                """\
+                ENTRYPOINT main arg1 arg2
+                """
+            ),
+        ),
+    ],
+)
+def test_compile_dockerfile(dockerfile, expect):
+    if isinstance(expect, str):
+        assert expect.strip() == dockerfile.compile().strip()
+    else:
+        with expect:
+            dockerfile.compile()
+
+
+@pytest.mark.parametrize(
+    "contents, expect",
+    [
+        (
+            dedent(
+                """\
+                WORKDIR /src
+                RUN command arg1 arg2\
+                    --flags=here\
+                    --on-several=lines\
+                    should work
+
+                # ignore comments
+
+                COPY this here
+            """
+            ),
+            [
+                "WORKDIR /src",
+                "RUN command arg1 arg2 --flags=here --on-several=lines should work",
+                "COPY this here",
+            ],
+        ),
+    ],
+)
+def test_dockerfile_command_lines(contents, expect):
+    if isinstance(expect, list):
+        assert expect == list(Dockerfile._iter_command_lines(contents))
+    else:
+        with expect:
+            list(Dockerfile._iter_command_lines(contents))


### PR DESCRIPTION
This is pre-work for dependency inference by inspecting Dockerfile instructions, and also lays the base work for future features involving managing Dockerfiles. It focus on parsing and a few commands useful for dep inference, so there are a lot of commands still not implemented. This will be augmented in follow up PRs as needed.
