### PR TITLE
Don't reject release for API token users.

### DIFF
--- a/build-support/bin/_release_helper.py
+++ b/build-support/bin/_release_helper.py
@@ -722,7 +722,11 @@ def check_roles() -> None:
     # Check that the packages we plan to publish are correctly owned.
     banner("Checking current user.")
     username = get_pypi_config("server-login", "username")
-    if username not in _expected_owners and username not in _expected_maintainers:
+    if (
+        username != "__token__"  # See: https://pypi.org/help/#apitoken
+        and username not in _expected_owners
+        and username not in _expected_maintainers
+    ):
         die(f"User {username} not authorized to publish.")
     banner("Checking package roles.")
     validator = PackageAccessValidator()


### PR DESCRIPTION
Using an API token is the right thing to do, and skipping the check
just means a first time releaser that hasn't been added to the right
PyPI roles will have to wait a bit longer to find that out with an
upload error at the end of the release process.

Fixes #12854

[ci skip-rust]
[ci skip-build-wheels]