### PR TITLE
[internal] Upgrade to `toolchain.pants.plugin==0.14.0`.

### DIFF
--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -202,7 +202,7 @@ def run_pants_help_all() -> Dict:
         "pants.backend.python.lint.pylint",
         "pants.backend.python.lint.yapf",
     ]
-    deactivated_plugins = ["toolchain.pants.plugin==0.13.1"]
+    deactivated_plugins = ["toolchain.pants.plugin==0.14.0"]
     argv = [
         "./pants",
         "--concurrent",

--- a/pants.toml
+++ b/pants.toml
@@ -21,7 +21,7 @@ backend_packages.add = [
 plugins = [
   "hdrhistogram",  # For use with `--stats-log`.
   # NOTE: Keep this version in sync with `generate_docs.py`!
-  "toolchain.pants.plugin==0.13.1",
+  "toolchain.pants.plugin==0.14.0",
 ]
 
 # The invalidation globs cover the PYTHONPATH by default, but we exclude some files that are on the


### PR DESCRIPTION
See https://docs.toolchain.com/docs/toolchain-pants-plugin-changelog for more information.

[ci skip-rust]
[ci skip-build-wheels]