### PR TITLE
[internal] [#12811] Use `DigestEntries` to skip inflating JARs when resolving Coursier lockfiles

### DIFF
--- a/src/python/pants/jvm/util_rules.py
+++ b/src/python/pants/jvm/util_rules.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from pants.engine.fs import Digest, DigestEntries, DigestSubset, FileDigest, PathGlobs
+from pants.engine.fs import Digest, DigestEntries, DigestSubset, FileDigest, FileEntry, PathGlobs
 from pants.engine.rules import Get, collect_rules, rule
 
 
@@ -27,6 +27,11 @@ async def digest_to_file_digest(request: ExtractFileDigest) -> FileDigest:
         )
 
     file_info = digest_entries[0]
+    if not isinstance(file_info, FileEntry):
+        raise Exception(
+            f"ExtractFileDigest: '{request.file_path}' referred to a directory and not a file."
+        )
+
     return file_info.file_digest
 
 

--- a/src/python/pants/jvm/util_rules.py
+++ b/src/python/pants/jvm/util_rules.py
@@ -3,10 +3,9 @@
 
 from __future__ import annotations
 
-import hashlib
 from dataclasses import dataclass
 
-from pants.engine.fs import Digest, DigestContents, DigestSubset, FileDigest, PathGlobs
+from pants.engine.fs import Digest, DigestEntries, DigestSubset, FileDigest, PathGlobs
 from pants.engine.rules import Get, collect_rules, rule
 
 
@@ -18,23 +17,17 @@ class ExtractFileDigest:
 
 @rule
 async def digest_to_file_digest(request: ExtractFileDigest) -> FileDigest:
-    """TODO(#11806): This is just a workaround; this extraction should be provided directly by the engine."""
-
     digest = await Get(Digest, DigestSubset(request.digest, PathGlobs([request.file_path])))
-    digest_contents = await Get(DigestContents, Digest, digest)
-    if len(digest_contents) == 0:
+    digest_entries = await Get(DigestEntries, Digest, digest)
+    if len(digest_entries) == 0:
         raise Exception(f"ExtractFileDigest: '{request.file_path}' not found in {request.digest}.")
-    elif len(digest_contents) > 1:
+    elif len(digest_entries) > 1:
         raise Exception(
             f"ExtractFileDigest: Unexpected error: '{request.file_path}' found multiple times in {request.digest}"
         )
 
-    file_content = digest_contents[0]
-    hasher = hashlib.sha256()
-    hasher.update(file_content.content)
-    return FileDigest(
-        fingerprint=hasher.hexdigest(), serialized_bytes_length=len(file_content.content)
-    )
+    file_info = digest_entries[0]
+    return file_info.file_digest
 
 
 def rules():

--- a/src/python/pants/jvm/util_rules.py
+++ b/src/python/pants/jvm/util_rules.py
@@ -5,7 +5,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from pants.engine.fs import Digest, DigestEntries, DigestSubset, FileDigest, FileEntry, PathGlobs
+from pants.engine.fs import (
+    Digest,
+    DigestEntries,
+    DigestSubset,
+    Directory,
+    FileDigest,
+    FileEntry,
+    PathGlobs,
+)
 from pants.engine.rules import Get, collect_rules, rule
 
 
@@ -19,7 +27,10 @@ class ExtractFileDigest:
 async def digest_to_file_digest(request: ExtractFileDigest) -> FileDigest:
     digest = await Get(Digest, DigestSubset(request.digest, PathGlobs([request.file_path])))
     digest_entries = await Get(DigestEntries, Digest, digest)
-    if len(digest_entries) == 0:
+
+    if len(digest_entries) == 0 or (
+        len(digest_entries) == 1 and digest_entries[0] == Directory("")
+    ):
         raise Exception(f"ExtractFileDigest: '{request.file_path}' not found in {request.digest}.")
     elif len(digest_entries) > 1:
         raise Exception(


### PR DESCRIPTION
This replaces manually calculating the fingerprint and length of a JAR file with intrinsics that already do this for us. 