### PR TITLE
[internal] flake8 integration test timeout bump

### DIFF
--- a/src/python/pants/backend/python/lint/flake8/BUILD
+++ b/src/python/pants/backend/python/lint/flake8/BUILD
@@ -8,7 +8,7 @@ python_tests(name="subsystem_test", sources=["subsystem_test.py"])
 python_tests(
     name="rules_integration_test",
     sources=["rules_integration_test.py"],
-    timeout=180,
+    timeout=240,
     # We want to make sure the default lockfile works for both macOS and Linux.
     tags=["platform_specific_behavior"],
 )


### PR DESCRIPTION
Takes slightly longer in macOS CI sometimes.