### PR TITLE
Fix the goal deprecation message to refer to the previous name.

### DIFF
--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -204,12 +204,16 @@ class ArgSplitter:
 
         for goal in goals:
             si = self._known_goal_scopes[goal]
-            if si.deprecated_scope and goal == si.deprecated_scope:
-                assert si.deprecated_scope_removal_version
+            if (
+                si.deprecated_scope
+                and goal == si.deprecated_scope
+                and si.subsystem_cls
+                and si.deprecated_scope_removal_version
+            ):
                 warn_or_error(
                     si.deprecated_scope_removal_version,
                     f"the {si.deprecated_scope} goal",
-                    f"The {si.deprecated_scope} goal was renamed to {si.scope}",
+                    f"The {si.deprecated_scope} goal was renamed to {si.subsystem_cls.options_scope}",
                 )
 
         if isinstance(self._help_request, ThingHelp):


### PR DESCRIPTION
The `ScopeInfo` matched in this case had both the deprecated and current scope set to the same value. Use the current scope name retrieved from the `Subsystem` class instead.

It still renders twice (we are split multiple times), but at least it's correct:
```
20:31:47.60 [WARN] DEPRECATED: the typecheck goal will be removed in version 2.10.0.dev0.

The typecheck goal was renamed to check
```