### PR TITLE
Add `cacheable` flag to `EngineAwareReturnType`

### DIFF
--- a/src/python/pants/engine/engine_aware.py
+++ b/src/python/pants/engine/engine_aware.py
@@ -51,6 +51,14 @@ class EngineAwareReturnType(ABC):
         """
         return None
 
+    def cacheable(self) -> bool:
+        """Allows a return type to be conditionally marked uncacheable.
+
+        An uncacheable value is recomputed in each Session: this can be useful if the level or
+        message should be rendered as sideeffects in each Session.
+        """
+        return True
+
     def artifacts(self) -> dict[str, FileDigest | Snapshot] | None:
         """If implemented, this sets the `artifacts` entry for the workunit of any `@rule`'s that
         return the annotated type.

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -70,8 +70,8 @@ def teardown_dynamic_ui(scheduler: PyScheduler, session: PySession) -> None: ...
 def tasks_task_begin(
     tasks: PyTasks,
     func: Any,
-    output_type: type,
-    can_modify_workunit: bool,
+    return_type: type,
+    engine_aware_return_type: bool,
     cacheable: bool,
     name: str,
     desc: str,

--- a/src/rust/engine/engine_pyo3/src/lib.rs
+++ b/src/rust/engine/engine_pyo3/src/lib.rs
@@ -30,6 +30,5 @@
 // just the one minor call as unsafe, than to mark the whole function as unsafe which may hide
 // other unsafeness.
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
-#![type_length_limit = "43757804"]
 
 mod externs;

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1253,7 +1253,7 @@ fn tasks_task_begin(
   tasks_ptr: PyTasks,
   func: PyObject,
   output_type: PyType,
-  can_modify_workunit: bool,
+  engine_aware_return_type: bool,
   cacheable: bool,
   name: String,
   desc: String,
@@ -1268,7 +1268,7 @@ fn tasks_task_begin(
     tasks.task_begin(
       func,
       output_type,
-      can_modify_workunit,
+      engine_aware_return_type,
       cacheable,
       name,
       if desc.is_empty() { None } else { Some(desc) },

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -145,7 +145,7 @@ impl fmt::Display for Rule {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Task {
   pub product: TypeId,
-  pub can_modify_workunit: bool,
+  pub engine_aware_return_type: bool,
   pub clause: Vec<TypeId>,
   pub gets: Vec<Get>,
   pub func: Function,
@@ -216,8 +216,8 @@ impl Tasks {
   pub fn task_begin(
     &mut self,
     func: Function,
-    product: TypeId,
-    can_modify_workunit: bool,
+    return_type: TypeId,
+    engine_aware_return_type: bool,
     cacheable: bool,
     name: String,
     desc: Option<String>,
@@ -230,8 +230,8 @@ impl Tasks {
 
     self.preparing = Some(Task {
       cacheable,
-      product,
-      can_modify_workunit,
+      product: return_type,
+      engine_aware_return_type,
       clause: Vec::new(),
       gets: Vec::new(),
       func,


### PR DESCRIPTION
Add a `cacheable` flag to `EngineAwareReturnType` to ease forcing the sideeffects of `EngineAware` types. #12859 will use this to force re-rendering of failed (but not successful) compile outputs. Additionally: clarify the meaning of "can_modify_workunit" by renaming it to `engine_aware_return_type`, and remove redundancy of `impl`s.

[ci skip-build-wheels]