### PR TITLE
[internal] Fix setup.py path in test.

### DIFF
--- a/src/python/pants/backend/python/goals/setup_py_test.py
+++ b/src/python/pants/backend/python/goals/setup_py_test.py
@@ -163,7 +163,7 @@ def test_use_existing_setup_script(chroot_rule_runner) -> None:
                     ':foo',
                 ],
                 provides=setup_py(
-                    setup_script='src/python/foo/setup.py',
+                    setup_script='setup.py',
                     name='foo', version='1.2.3'
                 )
             )


### PR DESCRIPTION
The path is supposed to be relative to the BUILD file, but was
specified relative to the buildroot.

This test passed because src/python/foo/src/python/foo/setup.py
becomes foo/setup.py after stripping source roots (because
src/python/foo/src/python/ is recognized as a source root).
But that was still a bad example for any readers.

[ci skip-rust]

[ci skip-build-wheels]