### PR TITLE
Upgrade to Pex 2.1.50.

### DIFF
--- a/3rdparty/python/lockfiles/user_reqs.txt
+++ b/3rdparty/python/lockfiles/user_reqs.txt
@@ -16,7 +16,7 @@
 #     "humbug==0.2.6",
 #     "ijson==3.1.4",
 #     "packaging==21.0",
-#     "pex==2.1.48",
+#     "pex==2.1.50",
 #     "psutil==5.8.0",
 #     "pystache==0.5.4",
 #     "pytest<6.3,>=6.0.1",
@@ -46,9 +46,9 @@ attrs==21.2.0; python_version >= "3.6" and python_full_version < "3.0.0" or pyth
 certifi==2021.5.30; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" \
     --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8 \
     --hash=sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee
-charset-normalizer==2.0.4; python_full_version >= "3.6.0" and python_version >= "3" \
-    --hash=sha256:f23667ebe1084be45f6ae0538e4a5a865206544097e4e8bbcacf42cd02a348f3 \
-    --hash=sha256:0c8911edd15d19223366a194a513099a302055a962bca2cec0f54b8b63175d8b
+charset-normalizer==2.0.5; python_full_version >= "3.6.0" and python_version >= "3" \
+    --hash=sha256:7098e7e862f6370a2a8d1a6398cd359815c45d12626267652c3f13dec58e2367 \
+    --hash=sha256:fa471a601dfea0f492e4f4fca035cd82155e65dc45c9b83bf4322dfab63755dd
 colorama==0.4.4; python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.5.0" \
     --hash=sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2 \
     --hash=sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b
@@ -135,9 +135,9 @@ iniconfig==1.1.1; python_version >= "3.6" \
 packaging==21.0; python_version >= "3.6" \
     --hash=sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14 \
     --hash=sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7
-pex==2.1.49; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0" and python_version < "3.10") \
-    --hash=sha256:da3bb92e82906f805c9207d91f2688635028e3900cf1f4a6014c2aa95535d925 \
-    --hash=sha256:af536388eeede93111d8ef0af4a80cbb3d847c1a1470c6f34f3abe83deac1b91
+pex==2.1.50; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0" and python_version < "3.10") \
+    --hash=sha256:fee2e419f3439afd370c2770c82d148a277a980ebd3ebe7b35c5f4d10ef03a57 \
+    --hash=sha256:c67365b26060452631c0083a0f5d50af3cba9287b84b2c157404c959cb4bb74d
 pluggy==1.0.0; python_version >= "3.6" \
     --hash=sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3 \
     --hash=sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -8,7 +8,7 @@ humbug==0.2.6
 
 ijson==3.1.4
 packaging==21.0
-pex==2.1.49
+pex==2.1.50
 psutil==5.8.0
 pystache==0.5.4
 # This should be kept in sync with `pytest.py`.

--- a/src/python/pants/backend/python/subsystems/lambdex_lockfile.txt
+++ b/src/python/pants/backend/python/subsystems/lambdex_lockfile.txt
@@ -17,6 +17,6 @@
 lambdex==0.1.6; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0" and python_version < "3.10") \
     --hash=sha256:cb685b106617fbd1afd26d6e9472b2e0c99df8574c6d358aee4e6c13aeef8eb1 \
     --hash=sha256:6d1a95c8a31baa703edece8e36a705045b0203c7e886812c27a4dd945aa694e0
-pex==2.1.49; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "3.10" \
-    --hash=sha256:da3bb92e82906f805c9207d91f2688635028e3900cf1f4a6014c2aa95535d925 \
-    --hash=sha256:af536388eeede93111d8ef0af4a80cbb3d847c1a1470c6f34f3abe83deac1b91
+pex==2.1.50; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "3.10" \
+    --hash=sha256:fee2e419f3439afd370c2770c82d148a277a980ebd3ebe7b35c5f4d10ef03a57 \
+    --hash=sha256:c67365b26060452631c0083a0f5d50af3cba9287b84b2c157404c959cb4bb74d

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -37,9 +37,9 @@ class PexBinary(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."
 
-    default_version = "v2.1.49"
+    default_version = "v2.1.50"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.1.49,<3.0"
+    version_constraints = ">=2.1.50,<3.0"
 
     @classproperty
     def default_known_versions(cls):
@@ -48,8 +48,8 @@ class PexBinary(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "6fbee0df046793b555f5225490081ae44893c75d51024e7e976d4427bf914527",
-                    "3640830",
+                    "a7178d3973570f3b8b6d00345c3608dc9d7ad5b291061103e70062f53bff11a2",
+                    "3641023",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64"]


### PR DESCRIPTION
This fixes a bug executing PEX zipapps that do not have the execute bit
set, which is the case for the Pex PEX we download and run in the
release script.

[ci skip-rust]
[ci skip-build-wheels]