### PR TITLE
Add Java dependency analysis types and launcher using javaparser library.

### DIFF
--- a/src/python/pants/backend/java/dependency_inference/BUILD
+++ b/src/python/pants/backend/java/dependency_inference/BUILD
@@ -1,5 +1,12 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library()
+python_library(
+	dependencies=[':java_src']
+)
 python_tests(name="tests", timeout=240)
+
+resources(
+  name='java_src',
+  sources=['*.java'],
+)

--- a/src/python/pants/backend/java/dependency_inference/PantsJavaParserLauncher.java
+++ b/src/python/pants/backend/java/dependency_inference/PantsJavaParserLauncher.java
@@ -1,0 +1,75 @@
+package org.pantsbuild.javaparser;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.javaparser.ast.body.TypeDeclaration;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.Name;
+import com.github.javaparser.ast.ImportDeclaration;
+import com.github.javaparser.ast.PackageDeclaration;
+import com.github.javaparser.StaticJavaParser;
+import java.io.File;
+import java.util.AbstractCollection;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+class Import {
+    public static Import fromImportDeclaration(ImportDeclaration imp) {
+        Import analysisImport = new Import();
+        analysisImport.name = imp.getName().toString();
+        analysisImport.isStatic = imp.isStatic();
+        analysisImport.isAsterisk = imp.isAsterisk();
+        return analysisImport;
+    }
+
+    public String name;
+    public boolean isStatic;
+    public boolean isAsterisk;
+}
+
+class CompilationUnitAnalysis {
+    public String declaredPackage;
+    public ArrayList<Import> imports;
+    public ArrayList<String> topLevelTypes;
+}
+
+
+public class PantsJavaParserLauncher {
+    public static void main(String[] args) throws Exception {
+        String analysisOutputPath = args[0];
+        String sourceToAnalyze = args[1];
+
+        CompilationUnit cu = StaticJavaParser.parse(new File(sourceToAnalyze));
+        CompilationUnitAnalysis analysis = new CompilationUnitAnalysis();
+
+        // Get the source's declare package.
+        analysis.declaredPackage = cu.getPackageDeclaration()
+            .map(PackageDeclaration::getName)
+            .map(Name::toString)
+            .orElse("");
+
+        // Get the source's imports.
+        analysis.imports = new ArrayList<Import>(
+            cu.getImports().stream()
+                .map(Import::fromImportDeclaration)
+                .collect(Collectors.toList()));
+
+        // Get the source's top level types
+        analysis.topLevelTypes = new ArrayList<String>(
+            cu.getTypes().stream()
+                .filter(TypeDeclaration::isTopLevelType)
+                .map(TypeDeclaration::getFullyQualifiedName)
+                // TODO(#12293): In Java 9+ we could just flatMap(Optional::stream),
+                // but we're not guaranteed Java 9+ yet.
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toList()));
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.writeValue(new File(analysisOutputPath), analysis);
+    }
+}

--- a/src/python/pants/backend/java/dependency_inference/java_parser.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser.py
@@ -1,0 +1,135 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import json
+import logging
+import os.path
+from dataclasses import dataclass
+
+from pants.backend.java.dependency_inference.java_parser_launcher import (
+    JavaParserCompiledClassfiles,
+    java_parser_artifact_requirements,
+)
+from pants.backend.java.dependency_inference.types import JavaSourceDependencyAnalysis
+from pants.core.util_rules.source_files import SourceFiles
+from pants.engine.fs import AddPrefix, Digest, DigestContents, MergeDigests
+from pants.engine.process import BashBinary, FallibleProcessResult, Process, ProcessExecutionFailure
+from pants.engine.rules import Get, collect_rules, rule
+from pants.jvm.resolve.coursier_fetch import MaterializedClasspath, MaterializedClasspathRequest
+from pants.jvm.resolve.coursier_setup import Coursier
+from pants.util.logging import LogLevel
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class FallibleJavaSourceDependencyAnalysisResult:
+    process_result: FallibleProcessResult
+    analysis: JavaSourceDependencyAnalysis | None = None
+
+
+@rule(level=LogLevel.DEBUG)
+async def resolve_fallible_result_to_analysis(
+    fallible_result: FallibleJavaSourceDependencyAnalysisResult,
+) -> JavaSourceDependencyAnalysis:
+    # For whatever reason this doesn't work despite there being a rule that ostensibly
+    # does this conversion automatically.
+    # result = await Get(ProcessResult, FallibleProcessResult, fallible_result.process_result)
+    if fallible_result.process_result.exit_code == 0:
+        return fallible_result.analysis
+    raise ProcessExecutionFailure(
+        fallible_result.process_result.exit_code,
+        fallible_result.process_result.stdout,
+        fallible_result.process_result.stderr,
+        "Java source dependency analysis failed.",
+    )
+
+
+@rule(level=LogLevel.DEBUG)
+async def analyze_java_source_dependencies(
+    bash: BashBinary,
+    coursier: Coursier,
+    processor_classfiles: JavaParserCompiledClassfiles,
+    source_files: SourceFiles,
+) -> FallibleJavaSourceDependencyAnalysisResult:
+    if len(source_files.snapshot.files) > 1:
+        raise ValueError(
+            f"parse_java_package expects sources with exactly 1 source file, but found {len(source_files.snapshot.files)}."
+        )
+    elif len(source_files.snapshot.files) == 0:
+        raise ValueError(
+            "parse_java_package expects sources with exactly 1 source file, but found none."
+        )
+    source_prefix = "__source_to_analyze"
+    source_path = os.path.join(source_prefix, source_files.snapshot.files[0])
+    processorcp_relpath = "__processorcp"
+
+    tool_classpath = await Get(
+        MaterializedClasspath,
+        MaterializedClasspathRequest(
+            prefix="__toolcp",
+            artifact_requirements=(java_parser_artifact_requirements(),),
+        ),
+    )
+    prefixed_processor_classfiles_digest = await Get(
+        Digest, AddPrefix(processor_classfiles.digest, processorcp_relpath)
+    )
+    prefixed_source_files_digest = await Get(
+        Digest, AddPrefix(source_files.snapshot.digest, source_prefix)
+    )
+
+    merged_digest = await Get(
+        Digest,
+        MergeDigests(
+            (
+                prefixed_processor_classfiles_digest,
+                tool_classpath.digest,
+                coursier.digest,
+                prefixed_source_files_digest,
+            )
+        ),
+    )
+
+    analysis_output_path = "__source_analysis.json"
+
+    proc = Process(
+        argv=[
+            coursier.coursier.exe,
+            "java",
+            "--system-jvm",  # TODO(#12293): use a fixed JDK version from a subsystem.
+            "-cp",
+            ":".join([tool_classpath.classpath_arg(), processorcp_relpath]),
+            "org.pantsbuild.javaparser.PantsJavaParserLauncher",
+            analysis_output_path,
+            source_path,
+        ],
+        input_digest=merged_digest,
+        output_files=(analysis_output_path,),
+        description="Run Spoon analysis against Java source",
+        level=LogLevel.DEBUG,
+    )
+
+    process_result = await Get(
+        FallibleProcessResult,
+        Process,
+        proc,
+    )
+
+    if process_result.exit_code != 0:
+        return FallibleJavaSourceDependencyAnalysisResult(process_result=process_result)
+
+    analysis_contents = await Get(DigestContents, Digest, process_result.output_digest)
+    analysis = json.loads(analysis_contents[0].content)
+
+    return FallibleJavaSourceDependencyAnalysisResult(
+        process_result=process_result,
+        analysis=JavaSourceDependencyAnalysis.from_json_dict(analysis),
+    )
+
+
+def rules():
+    return [
+        *collect_rules(),
+    ]

--- a/src/python/pants/backend/java/dependency_inference/java_parser.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser.py
@@ -33,8 +33,7 @@ class FallibleJavaSourceDependencyAnalysisResult:
 async def resolve_fallible_result_to_analysis(
     fallible_result: FallibleJavaSourceDependencyAnalysisResult,
 ) -> JavaSourceDependencyAnalysis:
-    # For whatever reason this doesn't work despite there being a rule that ostensibly
-    # does this conversion automatically.
+    # TODO(#12725): Just convert directly to a ProcessResult like this:
     # result = await Get(ProcessResult, FallibleProcessResult, fallible_result.process_result)
     if fallible_result.process_result.exit_code == 0:
         analysis_contents = await Get(

--- a/src/python/pants/backend/java/dependency_inference/java_parser_launcher.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser_launcher.py
@@ -31,9 +31,8 @@ def _load_javaparser_launcher_source() -> bytes:
 
 
 def java_parser_artifact_requirements() -> ArtifactRequirements:
-    return ArtifactRequirements.create_from_maven_coordinates_fields(
-        fields=(),
-        additional_requirements=[
+    return ArtifactRequirements(
+        [
             Coordinate(
                 group="com.fasterxml.jackson.core", artifact="jackson-databind", version="2.12.4"
             ),

--- a/src/python/pants/backend/java/dependency_inference/java_parser_launcher.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser_launcher.py
@@ -1,0 +1,113 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import logging
+
+import pkg_resources
+
+from pants.backend.java.compile.javac import CompiledClassfiles
+from pants.backend.java.compile.javac_binary import JavacBinary
+from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests, RemovePrefix
+from pants.engine.process import BashBinary, Process, ProcessResult
+from pants.engine.rules import Get, collect_rules, rule
+from pants.jvm.resolve.coursier_fetch import (
+    ArtifactRequirements,
+    Coordinate,
+    MaterializedClasspath,
+    MaterializedClasspathRequest,
+)
+from pants.util.logging import LogLevel
+
+logger = logging.getLogger(__name__)
+
+
+_LAUNCHER_BASENAME = "PantsJavaParserLauncher.java"
+
+
+def _load_javaparser_launcher_source() -> bytes:
+    return pkg_resources.resource_string(__name__, _LAUNCHER_BASENAME)
+
+
+def java_parser_artifact_requirements() -> ArtifactRequirements:
+    return ArtifactRequirements.create_from_maven_coordinates_fields(
+        fields=(),
+        additional_requirements=[
+            Coordinate(
+                group="com.fasterxml.jackson.core", artifact="jackson-databind", version="2.12.4"
+            ),
+            Coordinate(
+                group="com.github.javaparser",
+                artifact="javaparser-symbol-solver-core",
+                version="3.23.0",
+            ),
+        ],
+    )
+
+
+class JavaParserCompiledClassfiles(CompiledClassfiles):
+    pass
+
+
+@rule
+async def build_processors(bash: BashBinary, javac: JavacBinary) -> JavaParserCompiledClassfiles:
+    materialized_classpath = await Get(
+        MaterializedClasspath,
+        MaterializedClasspathRequest(
+            prefix="__toolcp",
+            artifact_requirements=(java_parser_artifact_requirements(),),
+        ),
+    )
+
+    source_digest = await Get(
+        Digest,
+        CreateDigest(
+            [
+                FileContent(
+                    path=_LAUNCHER_BASENAME,
+                    content=_load_javaparser_launcher_source(),
+                )
+            ]
+        ),
+    )
+
+    merged_digest = await Get(
+        Digest,
+        MergeDigests(
+            (
+                materialized_classpath.digest,
+                javac.digest,
+                source_digest,
+            )
+        ),
+    )
+
+    process_result = await Get(
+        ProcessResult,
+        Process(
+            argv=[
+                bash.path,
+                javac.javac_wrapper_script,
+                "-cp",
+                materialized_classpath.classpath_arg(),
+                "-d",
+                "classfiles",
+                _LAUNCHER_BASENAME,
+            ],
+            input_digest=merged_digest,
+            output_directories=("classfiles",),
+            description=f"Compile {_LAUNCHER_BASENAME} import processors with javac",
+            level=LogLevel.DEBUG,
+        ),
+    )
+    stripped_classfiles_digest = await Get(
+        Digest, RemovePrefix(process_result.output_digest, "classfiles")
+    )
+    return JavaParserCompiledClassfiles(digest=stripped_classfiles_digest)
+
+
+def rules():
+    return [
+        *collect_rules(),
+    ]

--- a/src/python/pants/backend/java/dependency_inference/java_parser_test.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser_test.py
@@ -1,0 +1,254 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from textwrap import dedent
+
+import pytest
+
+from pants.backend.java.compile.javac import rules as javac_rules
+from pants.backend.java.compile.javac_binary import rules as javac_binary_rules
+from pants.backend.java.dependency_inference.java_parser import (
+    FallibleJavaSourceDependencyAnalysisResult,
+)
+from pants.backend.java.dependency_inference.java_parser import rules as java_parser_rules
+from pants.backend.java.dependency_inference.java_parser_launcher import (
+    rules as java_parser_launcher_rules,
+)
+from pants.backend.java.dependency_inference.types import JavaImport, JavaSourceDependencyAnalysis
+from pants.backend.java.target_types import JavaLibrary, JavaSources
+from pants.build_graph.address import Address
+from pants.core.util_rules import source_files
+from pants.core.util_rules.external_tool import rules as external_tool_rules
+from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.engine.internals.scheduler import ExecutionError
+from pants.engine.process import ProcessExecutionFailure
+from pants.engine.target import Sources
+from pants.jvm.resolve.coursier_fetch import CoursierResolvedLockfile
+from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
+from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
+from pants.jvm.target_types import JvmDependencyLockfile
+from pants.jvm.util_rules import rules as util_rules
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        preserve_tmpdirs=True,
+        rules=[
+            *coursier_fetch_rules(),
+            *coursier_setup_rules(),
+            *external_tool_rules(),
+            *java_parser_launcher_rules(),
+            *java_parser_rules(),
+            *javac_binary_rules(),
+            *javac_rules(),
+            *source_files.rules(),
+            *util_rules(),
+            QueryRule(FallibleJavaSourceDependencyAnalysisResult, (SourceFiles,)),
+            QueryRule(JavaSourceDependencyAnalysis, (SourceFiles,)),
+            QueryRule(SourceFiles, (SourceFilesRequest,)),
+        ],
+        target_types=[JvmDependencyLockfile, JavaLibrary],
+        bootstrap_args=["--javac-jdk=system"],  # TODO(#12293): use a fixed JDK version.
+    )
+
+
+def test_simple_java_parser_analysis(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
+            .to_json()
+            .decode("utf-8"),
+            "BUILD": dedent(
+                """\
+                coursier_lockfile(
+                    name = 'lockfile',
+                    maven_requirements = [],
+                    sources = [
+                        "coursier_resolve.lockfile",
+                    ],
+                )
+
+                java_library(
+                    name='simple-source',
+                    dependencies= [':lockfile'],
+                )
+                """
+            ),
+            "SimpleSource.java": dedent(
+                """
+                package org.pantsbuild.example;
+
+                import java.util.Date;
+                import bogus.*;
+                import static bogus.T;
+                import bogus.T.t;
+                import static bogus.Foo.*;
+
+                public class SimpleSource {
+                    public void hello() {
+                        System.out.println("hello");
+                        Date date = new Date();
+                        System.out.println("It's " + date.toString());
+                        some.qualified.ref.Foo.bar();
+                        some.other.Thing[] things = new some.other.Thing[1];
+                    }
+                }
+
+                class Foo {}
+                """
+            ),
+        }
+    )
+
+    target = rule_runner.get_target(address=Address(spec_path="", target_name="simple-source"))
+
+    source_files = rule_runner.request(
+        SourceFiles,
+        [
+            SourceFilesRequest(
+                (target.get(Sources),),
+                for_sources_types=(JavaSources,),
+                enable_codegen=True,
+            )
+        ],
+    )
+
+    fallible_result = rule_runner.request(
+        FallibleJavaSourceDependencyAnalysisResult,
+        [source_files],
+    )
+    assert fallible_result.analysis.declared_package == "org.pantsbuild.example"
+    assert fallible_result.analysis.imports == [
+        JavaImport(name="java.util.Date"),
+        JavaImport(name="bogus", is_asterisk=True),
+        JavaImport(name="bogus.T", is_static=True),
+        JavaImport(name="bogus.T.t"),
+        JavaImport(name="bogus.Foo", is_asterisk=True, is_static=True),
+    ]
+    assert fallible_result.analysis.top_level_types == [
+        "org.pantsbuild.example.SimpleSource",
+        "org.pantsbuild.example.Foo",
+    ]
+    assert (
+        rule_runner.request(JavaSourceDependencyAnalysis, [source_files])
+        == fallible_result.analysis
+    )
+
+
+def test_java_parser_fallible_error(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
+            .to_json()
+            .decode("utf-8"),
+            "BUILD": dedent(
+                """\
+                coursier_lockfile(
+                    name = 'lockfile',
+                    maven_requirements = [],
+                    sources = [
+                        "coursier_resolve.lockfile",
+                    ],
+                )
+
+                java_library(
+                    name='simple-source',
+                    dependencies= [':lockfile'],
+                )
+                """
+            ),
+            "SimpleSource.java": dedent(
+                """
+                syntax error!
+                """
+            ),
+        }
+    )
+
+    target = rule_runner.get_target(address=Address(spec_path="", target_name="simple-source"))
+
+    source_files = rule_runner.request(
+        SourceFiles,
+        [
+            SourceFilesRequest(
+                (target.get(Sources),),
+                for_sources_types=(JavaSources,),
+                enable_codegen=True,
+            )
+        ],
+    )
+
+    fallible_result = rule_runner.request(
+        FallibleJavaSourceDependencyAnalysisResult,
+        [source_files],
+    )
+    assert fallible_result.process_result.exit_code != 0
+
+    with pytest.raises(ExecutionError) as exc_info:
+        rule_runner.request(
+            JavaSourceDependencyAnalysis,
+            [source_files],
+        )
+    assert isinstance(exc_info.value.wrapped_exceptions[0], ProcessExecutionFailure)
+
+
+def test_java_parser_unnamed_package(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
+            .to_json()
+            .decode("utf-8"),
+            "BUILD": dedent(
+                """\
+                coursier_lockfile(
+                    name = 'lockfile',
+                    maven_requirements = [],
+                    sources = [
+                        "coursier_resolve.lockfile",
+                    ],
+                )
+
+                java_library(
+                    name='simple-source',
+                    dependencies= [':lockfile'],
+                )
+                """
+            ),
+            "SimpleSource.java": dedent(
+                """
+                public class SimpleSource {
+                    public void hello() {
+                        System.out.println("hello");
+                    }
+                }
+
+                class Foo {}
+                """
+            ),
+        }
+    )
+
+    target = rule_runner.get_target(address=Address(spec_path="", target_name="simple-source"))
+
+    source_files = rule_runner.request(
+        SourceFiles,
+        [
+            SourceFilesRequest(
+                (target.get(Sources),),
+                for_sources_types=(JavaSources,),
+                enable_codegen=True,
+            )
+        ],
+    )
+
+    fallible_result = rule_runner.request(
+        FallibleJavaSourceDependencyAnalysisResult,
+        [source_files],
+    )
+    assert fallible_result.analysis.declared_package == ""
+    assert fallible_result.analysis.imports == []
+    assert fallible_result.analysis.top_level_types == ["SimpleSource", "Foo"]

--- a/src/python/pants/backend/java/dependency_inference/java_parser_test.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser_test.py
@@ -117,26 +117,22 @@ def test_simple_java_parser_analysis(rule_runner: RuleRunner) -> None:
         ],
     )
 
-    fallible_result = rule_runner.request(
-        FallibleJavaSourceDependencyAnalysisResult,
+    analysis = rule_runner.request(
+        JavaSourceDependencyAnalysis,
         [source_files],
     )
-    assert fallible_result.analysis.declared_package == "org.pantsbuild.example"
-    assert fallible_result.analysis.imports == [
+    assert analysis.declared_package == "org.pantsbuild.example"
+    assert analysis.imports == [
         JavaImport(name="java.util.Date"),
         JavaImport(name="bogus", is_asterisk=True),
         JavaImport(name="bogus.T", is_static=True),
         JavaImport(name="bogus.T.t"),
         JavaImport(name="bogus.Foo", is_asterisk=True, is_static=True),
     ]
-    assert fallible_result.analysis.top_level_types == [
+    assert analysis.top_level_types == [
         "org.pantsbuild.example.SimpleSource",
         "org.pantsbuild.example.Foo",
     ]
-    assert (
-        rule_runner.request(JavaSourceDependencyAnalysis, [source_files])
-        == fallible_result.analysis
-    )
 
 
 def test_java_parser_fallible_error(rule_runner: RuleRunner) -> None:
@@ -245,10 +241,7 @@ def test_java_parser_unnamed_package(rule_runner: RuleRunner) -> None:
         ],
     )
 
-    fallible_result = rule_runner.request(
-        FallibleJavaSourceDependencyAnalysisResult,
-        [source_files],
-    )
-    assert fallible_result.analysis.declared_package == ""
-    assert fallible_result.analysis.imports == []
-    assert fallible_result.analysis.top_level_types == ["SimpleSource", "Foo"]
+    analysis = rule_runner.request(JavaSourceDependencyAnalysis, [source_files])
+    assert analysis.declared_package == ""
+    assert analysis.imports == []
+    assert analysis.top_level_types == ["SimpleSource", "Foo"]

--- a/src/python/pants/backend/java/dependency_inference/java_parser_test.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser_test.py
@@ -66,7 +66,7 @@ def test_simple_java_parser_analysis(rule_runner: RuleRunner) -> None:
                 """\
                 coursier_lockfile(
                     name = 'lockfile',
-                    maven_requirements = [],
+                    requirements = [],
                     sources = [
                         "coursier_resolve.lockfile",
                     ],
@@ -145,7 +145,7 @@ def test_java_parser_fallible_error(rule_runner: RuleRunner) -> None:
                 """\
                 coursier_lockfile(
                     name = 'lockfile',
-                    maven_requirements = [],
+                    requirements = [],
                     sources = [
                         "coursier_resolve.lockfile",
                     ],
@@ -202,7 +202,7 @@ def test_java_parser_unnamed_package(rule_runner: RuleRunner) -> None:
                 """\
                 coursier_lockfile(
                     name = 'lockfile',
-                    maven_requirements = [],
+                    requirements = [],
                     sources = [
                         "coursier_resolve.lockfile",
                     ],

--- a/src/python/pants/backend/java/dependency_inference/types.py
+++ b/src/python/pants/backend/java/dependency_inference/types.py
@@ -1,0 +1,37 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+
+@dataclass(frozen=True)
+class JavaImport:
+    name: str
+    is_static: bool = False
+    is_asterisk: bool = False
+
+    @classmethod
+    def from_json_dict(cls, imp: dict[str, Any]) -> JavaImport:
+        return cls(
+            name=imp["name"],
+            is_asterisk=imp["isAsterisk"],
+            is_static=imp["isStatic"],
+        )
+
+
+@dataclass(frozen=True)
+class JavaSourceDependencyAnalysis:
+    declared_package: str
+    imports: Sequence[JavaImport]
+    top_level_types: Sequence[str]
+
+    @classmethod
+    def from_json_dict(cls, analysis: dict[str, Any]) -> JavaSourceDependencyAnalysis:
+        return cls(
+            declared_package=analysis["declaredPackage"],
+            imports=[JavaImport.from_json_dict(imp) for imp in analysis["imports"]],
+            top_level_types=analysis["topLevelTypes"],
+        )


### PR DESCRIPTION
This PR adds the core functionality for inferring from Java source:
* imports
* declared package
* top level types that could potentially be imported by other sources from the provided source

It uses the `com.github.javaparser:javaparser-symbol-solver` Java library to do the heavy lifting.  We have a custom launcher for calling into this library, and that launcher source is compiled on-the-fly by Pants (the source itself is loaded using `pkg_resources`).  This is a novel way of calling into Pants-provided JVM code that will probably act as a template for similar situations, like custom JUnit launchers.

[ci skip-rust]
[ci skip-build-wheels]
