### PR TITLE
[internal] jvm: introduce `jvm_artifact` target type

### DIFF
--- a/src/python/pants/backend/java/compile/javac_test.py
+++ b/src/python/pants/backend/java/compile/javac_test.py
@@ -36,7 +36,7 @@ from pants.jvm.resolve.coursier_fetch import (
 )
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
-from pants.jvm.target_types import JvmDependencyLockfile, JvmArtifact
+from pants.jvm.target_types import JvmArtifact, JvmDependencyLockfile
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 

--- a/src/python/pants/backend/java/compile/javac_test.py
+++ b/src/python/pants/backend/java/compile/javac_test.py
@@ -24,7 +24,6 @@ from pants.core.util_rules import config_files, source_files
 from pants.core.util_rules.external_tool import rules as external_tool_rules
 from pants.engine.addresses import Addresses
 from pants.engine.fs import DigestContents, FileDigest
-from pants.engine.fs import rules as fs_rules
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.target import CoarsenedTarget, CoarsenedTargets, Targets
 from pants.jvm.goals.coursier import rules as coursier_rules
@@ -54,7 +53,6 @@ def rule_runner() -> RuleRunner:
             *util_rules(),
             *javac_binary_rules(),
             *target_types_rules(),
-            *fs_rules(),
             *coursier_rules(),
             QueryRule(CheckResults, (JavacCheckRequest,)),
             QueryRule(FallibleCompiledClassfiles, (CompileJavaSourceRequest,)),

--- a/src/python/pants/backend/java/compile/javac_test.py
+++ b/src/python/pants/backend/java/compile/javac_test.py
@@ -24,8 +24,10 @@ from pants.core.util_rules import config_files, source_files
 from pants.core.util_rules.external_tool import rules as external_tool_rules
 from pants.engine.addresses import Addresses
 from pants.engine.fs import DigestContents, FileDigest
+from pants.engine.fs import rules as fs_rules
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.target import CoarsenedTarget, CoarsenedTargets, Targets
+from pants.jvm.goals.coursier import rules as coursier_rules
 from pants.jvm.resolve.coursier_fetch import (
     Coordinate,
     Coordinates,
@@ -34,7 +36,7 @@ from pants.jvm.resolve.coursier_fetch import (
 )
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
-from pants.jvm.target_types import JvmDependencyLockfile
+from pants.jvm.target_types import JvmDependencyLockfile, JvmArtifact
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -52,12 +54,14 @@ def rule_runner() -> RuleRunner:
             *util_rules(),
             *javac_binary_rules(),
             *target_types_rules(),
+            *fs_rules(),
+            *coursier_rules(),
             QueryRule(CheckResults, (JavacCheckRequest,)),
             QueryRule(FallibleCompiledClassfiles, (CompileJavaSourceRequest,)),
             QueryRule(CompiledClassfiles, (CompileJavaSourceRequest,)),
             QueryRule(CoarsenedTargets, (Addresses,)),
         ],
-        target_types=[JvmDependencyLockfile, JavaLibrary],
+        target_types=[JvmDependencyLockfile, JavaLibrary, JvmArtifact],
         # TODO(#12293): Remove this nonhermetic hack once Coursier JVM boostrapping flakiness
         # is properly fixed in CI.
         bootstrap_args=["--javac-jdk=system"],
@@ -109,7 +113,7 @@ def test_compile_no_deps(rule_runner: RuleRunner) -> None:
                 """\
                 coursier_lockfile(
                     name = 'lockfile',
-                    maven_requirements = [],
+                    requirements = [],
                     sources = [
                         "coursier_resolve.lockfile",
                     ],
@@ -162,7 +166,7 @@ def test_compile_jdk_versions(rule_runner: RuleRunner) -> None:
                 """\
                 coursier_lockfile(
                     name = 'lockfile',
-                    maven_requirements = [],
+                    requirements = [],
                     sources = [
                         "coursier_resolve.lockfile",
                     ],
@@ -209,7 +213,7 @@ def test_compile_multiple_source_files(rule_runner: RuleRunner) -> None:
                 """\
                 coursier_lockfile(
                     name = 'lockfile',
-                    maven_requirements = [],
+                    requirements = [],
                     sources = [
                         "coursier_resolve.lockfile",
                     ],
@@ -286,7 +290,7 @@ def test_compile_with_cycle(rule_runner: RuleRunner) -> None:
                 """\
                 coursier_lockfile(
                     name = 'lockfile',
-                    maven_requirements = [],
+                    requirements = [],
                     sources = [
                         "coursier_resolve.lockfile",
                     ],
@@ -364,7 +368,7 @@ def test_compile_with_transitive_cycle(rule_runner: RuleRunner) -> None:
                 """\
                 coursier_lockfile(
                     name = 'lockfile',
-                    maven_requirements = [],
+                    requirements = [],
                     sources = [
                         "coursier_resolve.lockfile",
                     ],
@@ -456,7 +460,7 @@ def test_compile_with_transitive_multiple_sources(rule_runner: RuleRunner) -> No
                 """\
                 coursier_lockfile(
                     name = 'lockfile',
-                    maven_requirements = [],
+                    requirements = [],
                     sources = [
                         "coursier_resolve.lockfile",
                     ],
@@ -535,7 +539,7 @@ def test_compile_with_deps(rule_runner: RuleRunner) -> None:
                 """\
                 coursier_lockfile(
                     name = 'lockfile',
-                    maven_requirements = [],
+                    requirements = [],
                     sources = [
                         "coursier_resolve.lockfile",
                     ],
@@ -589,7 +593,7 @@ def test_compile_with_missing_dep_fails(rule_runner: RuleRunner) -> None:
                 """\
                 coursier_lockfile(
                     name = 'lockfile',
-                    maven_requirements = [],
+                    requirements = [],
                     sources = [
                         "coursier_resolve.lockfile",
                     ],
@@ -638,9 +642,15 @@ def test_compile_with_maven_deps(rule_runner: RuleRunner) -> None:
         {
             "BUILD": dedent(
                 """\
+                jvm_artifact(
+                    name = "joda-time_joda-time",
+                    group = "joda-time",
+                    artifact = "joda-time",
+                    version = "2.10.10",
+                )
                 coursier_lockfile(
                     name = 'lockfile',
-                    maven_requirements = ["joda-time:joda-time:2.10.10"],
+                    requirements = [":joda-time_joda-time"],
                     sources = [
                         "coursier_resolve.lockfile",
                     ],
@@ -689,7 +699,7 @@ def test_compile_with_missing_maven_dep_fails(rule_runner: RuleRunner) -> None:
                 """\
                 coursier_lockfile(
                     name = 'lockfile',
-                    maven_requirements = [],
+                    requirements = [],
                     sources = [
                         "coursier_resolve.lockfile",
                     ],

--- a/src/python/pants/backend/java/test/junit.py
+++ b/src/python/pants/backend/java/test/junit.py
@@ -21,6 +21,7 @@ from pants.engine.unions import UnionRule
 from pants.jvm.resolve.coursier_fetch import (
     ArtifactRequirements,
     Coordinate,
+    Coordinates,
     CoursierLockfileForTargetRequest,
     CoursierResolvedLockfile,
     MaterializedClasspath,

--- a/src/python/pants/backend/java/test/junit.py
+++ b/src/python/pants/backend/java/test/junit.py
@@ -21,7 +21,6 @@ from pants.engine.unions import UnionRule
 from pants.jvm.resolve.coursier_fetch import (
     ArtifactRequirements,
     Coordinate,
-    Coordinates,
     CoursierLockfileForTargetRequest,
     CoursierResolvedLockfile,
     MaterializedClasspath,

--- a/src/python/pants/backend/java/test/junit_test.py
+++ b/src/python/pants/backend/java/test/junit_test.py
@@ -29,7 +29,7 @@ from pants.jvm.resolve.coursier_fetch import (
 )
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
-from pants.jvm.target_types import JvmDependencyLockfile, JvmArtifact
+from pants.jvm.target_types import JvmArtifact, JvmDependencyLockfile
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 

--- a/src/python/pants/backend/java/test/junit_test.py
+++ b/src/python/pants/backend/java/test/junit_test.py
@@ -29,7 +29,7 @@ from pants.jvm.resolve.coursier_fetch import (
 )
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
-from pants.jvm.target_types import JvmDependencyLockfile
+from pants.jvm.target_types import JvmDependencyLockfile, JvmArtifact
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -54,7 +54,7 @@ def rule_runner() -> RuleRunner:
             QueryRule(CoarsenedTargets, (Addresses,)),
             QueryRule(TestResult, (JavaTestFieldSet,)),
         ],
-        target_types=[JvmDependencyLockfile, JavaLibrary, JunitTests],
+        target_types=[JvmDependencyLockfile, JvmArtifact, JavaLibrary, JunitTests],
         bootstrap_args=["--javac-jdk=system"],  # TODO(#12293): use a fixed JDK version.
     )
 
@@ -109,9 +109,15 @@ def test_vintage_simple_success(rule_runner: RuleRunner) -> None:
             "coursier_resolve.lockfile": JUNIT4_RESOLVED_LOCKFILE.to_json().decode("utf-8"),
             "BUILD": dedent(
                 """\
+                jvm_artifact(
+                  name = 'junit_junit',
+                  group = 'junit',
+                  artifact = 'junit',
+                  version = '4.13.2',
+                )
                 coursier_lockfile(
                     name = 'lockfile',
-                    maven_requirements = ['junit:junit:4.13.2'],
+                    requirements = [':junit_junit'],
                     sources = [
                         "coursier_resolve.lockfile",
                     ],
@@ -159,9 +165,15 @@ def test_vintage_simple_failure(rule_runner: RuleRunner) -> None:
             "coursier_resolve.lockfile": JUNIT4_RESOLVED_LOCKFILE.to_json().decode("utf-8"),
             "BUILD": dedent(
                 """\
+                jvm_artifact(
+                  name = 'junit_junit',
+                  group = 'junit',
+                  artifact = 'junit',
+                  version = '4.13.2',
+                )
                 coursier_lockfile(
                     name = 'lockfile',
-                    maven_requirements = ['junit:junit:4.13.2'],
+                    requirements = [':junit_junit'],
                     sources = [
                         "coursier_resolve.lockfile",
                     ],
@@ -218,9 +230,15 @@ def test_vintage_success_with_dep(rule_runner: RuleRunner) -> None:
             "coursier_resolve.lockfile": JUNIT4_RESOLVED_LOCKFILE.to_json().decode("utf-8"),
             "BUILD": dedent(
                 """\
+                jvm_artifact(
+                  name = 'junit_junit',
+                  group = 'junit',
+                  artifact = 'junit',
+                  version = '4.13.2',
+                )
                 coursier_lockfile(
                     name = 'lockfile',
-                    maven_requirements = ['junit:junit:4.13.2'],
+                    requirements = [':junit_junit'],
                     sources = [
                         "coursier_resolve.lockfile",
                     ],
@@ -381,10 +399,16 @@ def test_jupiter_simple_success(rule_runner: RuleRunner) -> None:
             "coursier_resolve.lockfile": JUNIT5_RESOLVED_LOCKFILE.to_json().decode("utf-8"),
             "BUILD": dedent(
                 """\
+                jvm_artifact(
+                  name='org.junit.jupiter_junit-jupiter-api',
+                  group='org.junit.jupiter',
+                  artifact='junit-jupiter-api',
+                  version='5.7.2',
+                )
                 coursier_lockfile(
                     name = 'lockfile',
-                    maven_requirements = [
-                        'org.junit.jupiter:junit-jupiter-api:5.7.2',
+                    requirements = [
+                        ':org.junit.jupiter_junit-jupiter-api',
                     ],
                     sources = [
                         "coursier_resolve.lockfile",
@@ -435,10 +459,16 @@ def test_jupiter_simple_failure(rule_runner: RuleRunner) -> None:
             "coursier_resolve.lockfile": JUNIT5_RESOLVED_LOCKFILE.to_json().decode("utf-8"),
             "BUILD": dedent(
                 """\
+                jvm_artifact(
+                  name='org.junit.jupiter_junit-jupiter-api',
+                  group='org.junit.jupiter',
+                  artifact='junit-jupiter-api',
+                  version='5.7.2',
+                )
                 coursier_lockfile(
                     name = 'lockfile',
-                    maven_requirements = [
-                        'org.junit.jupiter:junit-jupiter-api:5.7.2',
+                    requirements = [
+                        ':org.junit.jupiter_junit-jupiter-api',
                     ],
                     sources = [
                         "coursier_resolve.lockfile",
@@ -496,10 +526,16 @@ def test_jupiter_success_with_dep(rule_runner: RuleRunner) -> None:
             "coursier_resolve.lockfile": JUNIT5_RESOLVED_LOCKFILE.to_json().decode("utf-8"),
             "BUILD": dedent(
                 """\
+                jvm_artifact(
+                  name='org.junit.jupiter_junit-jupiter-api',
+                  group='org.junit.jupiter',
+                  artifact='junit-jupiter-api',
+                  version='5.7.2',
+                )
                 coursier_lockfile(
                     name = 'lockfile',
-                    maven_requirements = [
-                        'org.junit.jupiter:junit-jupiter-api:5.7.2',
+                    requirements = [
+                        ':org.junit.jupiter_junit-jupiter-api',
                     ],
                     sources = [
                         "coursier_resolve.lockfile",
@@ -575,11 +611,23 @@ def test_vintage_and_jupiter_simple_success(rule_runner: RuleRunner) -> None:
             "coursier_resolve.lockfile": combined_lockfile.to_json().decode("utf-8"),
             "BUILD": dedent(
                 """\
+                jvm_artifact(
+                  name='junit_junit',
+                  group='junit',
+                  artifact='junit',
+                  version='4.13.2',
+                )
+                jvm_artifact(
+                  name='org.junit.jupiter_junit-jupiter-api',
+                  group='org.junit.jupiter',
+                  artifact='junit-jupiter-api',
+                  version='5.7.2',
+                )
                 coursier_lockfile(
                     name = 'lockfile',
-                    maven_requirements = [
-                        'junit:junit:4.13.2',
-                        'org.junit.jupiter:junit-jupiter-api:5.7.2',
+                    requirements = [
+                        ':junit_junit',
+                        ':org.junit.jupiter_junit-jupiter-api',
                     ],
                     sources = [
                         "coursier_resolve.lockfile",

--- a/src/python/pants/jvm/goals/coursier.py
+++ b/src/python/pants/jvm/goals/coursier.py
@@ -21,7 +21,7 @@ from pants.engine.fs import (
 )
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
-from pants.engine.target import InvalidTargetException, Sources, Target, Targets, UnexpandedTargets
+from pants.engine.target import InvalidTargetException, Sources, Target, Targets
 from pants.jvm.resolve.coursier_fetch import (
     ArtifactRequirements,
     Coordinate,
@@ -85,7 +85,7 @@ async def gather_artifact_requirements(
     requirements_addresses = await Get(
         Addresses, UnparsedAddressInputs, request.requirements.to_unparsed_address_inputs()
     )
-    requirements_targets = await Get(UnexpandedTargets, Addresses, requirements_addresses)
+    requirements_targets = await Get(Targets, Addresses, requirements_addresses)
 
     return ArtifactRequirements(from_target(tgt) for tgt in requirements_targets)
 

--- a/src/python/pants/jvm/goals/coursier.py
+++ b/src/python/pants/jvm/goals/coursier.py
@@ -21,7 +21,7 @@ from pants.engine.fs import (
 )
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
-from pants.engine.target import Sources, Target, Targets, UnexpandedTargets
+from pants.engine.target import InvalidTargetException, Sources, Target, Targets, UnexpandedTargets
 from pants.jvm.resolve.coursier_fetch import (
     ArtifactRequirements,
     Coordinate,
@@ -60,15 +60,21 @@ async def gather_artifact_requirements(
     def from_target(tgt: Target) -> Coordinate:
         group = tgt[JvmArtifactGroupField].value
         if not group:
-            raise ValueError("A group field must not be blank.")
+            raise InvalidTargetException(
+                f"The `group` field of {tgt.alias} target {tgt.address} must be set."
+            )
 
         artifact = tgt[JvmArtifactArtifactField].value
         if not artifact:
-            raise ValueError("A artifact field must not be blank.")
+            raise InvalidTargetException(
+                f"The `artifact` field of {tgt.alias} target {tgt.address} must be set."
+            )
 
         version = tgt[JvmArtifactVersionField].value
         if not version:
-            raise ValueError("A version field must not be blank.")
+            raise InvalidTargetException(
+                f"The `version` field of {tgt.alias} target {tgt.address} must be set."
+            )
 
         return Coordinate(
             group=group,

--- a/src/python/pants/jvm/goals/coursier_integration_test.py
+++ b/src/python/pants/jvm/goals/coursier_integration_test.py
@@ -21,7 +21,7 @@ from pants.jvm.resolve.coursier_fetch import (
 )
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
-from pants.jvm.target_types import JvmDependencyLockfile
+from pants.jvm.target_types import JvmArtifact, JvmDependencyLockfile
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import RuleRunner
 
@@ -45,7 +45,7 @@ def rule_runner() -> RuleRunner:
             *source_files.rules(),
             *util_rules(),
         ],
-        target_types=[JvmDependencyLockfile],
+        target_types=[JvmDependencyLockfile, JvmArtifact],
     )
 
 
@@ -54,10 +54,16 @@ def test_coursier_resolve_creates_missing_lockfile(rule_runner: RuleRunner) -> N
         {
             "BUILD": dedent(
                 """\
+                jvm_artifact(
+                    name = 'org.hamcrest_hamcrest-core',
+                    group = 'org.hamcrest',
+                    artifact = 'hamcrest-core',
+                    version = "1.3",
+                )
                 coursier_lockfile(
                     name = 'example-lockfile',
-                    maven_requirements = [
-                        'org.hamcrest:hamcrest-core:1.3',
+                    requirements = [
+                        ':org.hamcrest_hamcrest-core',
                     ],
                 )
                 """
@@ -106,10 +112,16 @@ def test_coursier_resolve_noop_does_not_touch_lockfile(rule_runner: RuleRunner) 
         {
             "BUILD": dedent(
                 """\
+                jvm_artifact(
+                    name = 'org.hamcrest_hamcrest-core',
+                    group = 'org.hamcrest',
+                    artifact = 'hamcrest-core',
+                    version = "1.3",
+                )
                 coursier_lockfile(
                     name = 'example-lockfile',
-                    maven_requirements = [
-                        'org.hamcrest:hamcrest-core:1.3',
+                    requirements = [
+                        ':org.hamcrest_hamcrest-core',
                     ],
                     sources = [
                         "coursier_resolve.lockfile",
@@ -130,10 +142,16 @@ def test_coursier_resolve_updates_lockfile(rule_runner: RuleRunner) -> None:
         {
             "BUILD": dedent(
                 """\
+                jvm_artifact(
+                    name = 'org.hamcrest_hamcrest-core',
+                    group = 'org.hamcrest',
+                    artifact = 'hamcrest-core',
+                    version = "1.3",
+                )
                 coursier_lockfile(
                     name = 'example-lockfile',
-                    maven_requirements = [
-                        'org.hamcrest:hamcrest-core:1.3',
+                    requirements = [
+                        ':org.hamcrest_hamcrest-core',
                     ],
                 )
                 """
@@ -169,10 +187,16 @@ def test_coursier_resolve_updates_bogus_lockfile(rule_runner: RuleRunner) -> Non
         {
             "BUILD": dedent(
                 """\
+                jvm_artifact(
+                    name = 'org.hamcrest_hamcrest-core',
+                    group = 'org.hamcrest',
+                    artifact = 'hamcrest-core',
+                    version = "1.3",
+                )
                 coursier_lockfile(
                     name = 'example-lockfile',
-                    maven_requirements = [
-                        'org.hamcrest:hamcrest-core:1.3',
+                    requirements = [
+                        ':org.hamcrest_hamcrest-core',
                     ],
                 )
                 """

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -26,7 +26,7 @@ from pants.engine.process import BashBinary, Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import Targets, TransitiveTargets, TransitiveTargetsRequest
 from pants.jvm.resolve.coursier_setup import Coursier
-from pants.jvm.target_types import JvmLockfileSources, MavenRequirementsField
+from pants.jvm.target_types import JvmLockfileSources, JvmRequirementsField
 from pants.jvm.util_rules import ExtractFileDigest
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
@@ -79,7 +79,7 @@ class Coordinate:
 
 
 class Coordinates(DeduplicatedCollection[Coordinate]):
-    """An ordered list of Coordinate."""
+    """An ordered list of `Coordinate`s."""
 
 
 # TODO: Consider whether to carry classpath scope in some fashion via ArtifactRequirements.
@@ -89,7 +89,7 @@ class ArtifactRequirements(DeduplicatedCollection[Coordinate]):
     @classmethod
     def create_from_maven_coordinates_fields(
         cls,
-        fields: Iterable[MavenRequirementsField],
+        fields: Iterable[JvmRequirementsField],
         *,
         additional_requirements: Iterable[Coordinate] = (),
     ) -> ArtifactRequirements:

--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -19,7 +19,7 @@ from pants.jvm.resolve.coursier_fetch import (
 )
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
-from pants.jvm.target_types import JvmDependencyLockfile
+from pants.jvm.target_types import JvmArtifact, JvmDependencyLockfile
 from pants.jvm.util_rules import ExtractFileDigest
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import QueryRule, RuleRunner
@@ -45,7 +45,7 @@ def rule_runner() -> RuleRunner:
             QueryRule(ResolvedClasspathEntry, (CoursierLockfileEntry,)),
             QueryRule(FileDigest, (ExtractFileDigest,)),
         ],
-        target_types=[JvmDependencyLockfile],
+        target_types=[JvmDependencyLockfile, JvmArtifact],
     )
 
 

--- a/src/python/pants/jvm/target_types.py
+++ b/src/python/pants/jvm/target_types.py
@@ -3,14 +3,62 @@
 
 from __future__ import annotations
 
-from pants.engine.target import COMMON_TARGET_FIELDS, Sources, StringSequenceField, Target
+from pants.engine.target import (
+    COMMON_TARGET_FIELDS,
+    Sources,
+    SpecialCasedDependencies,
+    StringField,
+    Target,
+)
 
 
-class MavenRequirementsField(StringSequenceField):
-    alias = "maven_requirements"
+class JvmArtifactGroupField(StringField):
+    alias = "group"
     help = (
-        "A sequence of Maven coordinate strings, e.g. ['org.scala-lang:scala-compiler:2.12.0', "
-        "'org.scala-lang:scala-library:2.12.0']."
+        "The 'group' part of a Maven-compatible coordinate to a third-party jar artifact. For the jar coordinate "
+        "com.google.guava:guava:30.1.1-jre, the group is 'com.google.guava'."
+    )
+    required = True
+
+
+class JvmArtifactArtifactField(StringField):
+    alias = "artifact"
+    required = True
+    help = (
+        "The 'artifact' part of a Maven-compatible coordinate to a third-party jar artifact. For the jar coordinate "
+        "com.google.guava:guava:30.1.1-jre, the artifact is 'guava'."
+    )
+
+
+class JvmArtifactVersionField(StringField):
+    alias = "version"
+    required = True
+    help = (
+        "The 'version' part of a Maven-compatible coordinate to a third-party jar artifact. For the jar coordinate "
+        "com.google.guava:guava:30.1.1-jre, the version is '30.1.1-jre'."
+    )
+
+
+class JvmArtifact(Target):
+    alias = "jvm_artifact"
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        JvmArtifactGroupField,
+        JvmArtifactArtifactField,
+        JvmArtifactVersionField,
+    )
+    help = (
+        "Represents a third-party JVM artifact as identified by its Maven-compatible coordinate, "
+        "that is, its `group`, `artifact`, and `version` components."
+    )
+
+
+class JvmRequirementsField(SpecialCasedDependencies):
+    alias = "requirements"
+    required = True
+    help = (
+        "A sequence of addresses to targets compatible with `jvm_artifact` that specify the coordinates for "
+        "third-party JVM dependencies."
     )
 
 
@@ -31,5 +79,5 @@ class JvmLockfileSources(Sources):
 
 class JvmDependencyLockfile(Target):
     alias = "coursier_lockfile"
-    core_fields = (*COMMON_TARGET_FIELDS, JvmLockfileSources, MavenRequirementsField)
-    help = "A Coursier lockfile along with the Maven-style requirements used to regenerate the lockfile."
+    core_fields = (*COMMON_TARGET_FIELDS, JvmLockfileSources, JvmRequirementsField)
+    help = "A Coursier lockfile along with references to the artifacts to use for the lockfile."


### PR DESCRIPTION
Introduces the `jvm_artifact` target type to represent JVM third-party jar artifacts. The `coursier_lockfile` target type now takes a `requirements` field which is a list of addresses to `jvm_artifact` targets. Future work for named resolves may remove `coursier_lockfile`, but for now this PR just updates the data model to support the future work on https://github.com/pantsbuild/pants/issues/12784 (JVM named resolves) and https://github.com/pantsbuild/pants/issues/12794 (typed classpaths)

This PR sets up creating a future `scala_artifact` target type for Scala support. (`scala_artifact` would just use the Target API to override the `artifact` field with a version that appends the Scala version suffix.)