### PR TITLE
[internal] Fix MyPy Protobuf test failing due to missing dependency (Cherry-pick of #12899)

### DIFF
--- a/src/python/pants/backend/awslambda/python/BUILD
+++ b/src/python/pants/backend/awslambda/python/BUILD
@@ -8,7 +8,7 @@ python_tests(name='target_types_test', sources=["target_types_test.py"])
 python_tests(
     name="rules_test",
     sources=["rules_test.py"],
-    timeout=200,
+    timeout=300,
     # We want to make sure the default lockfile works for both macOS and Linux.
     tags=["platform_specific_behavior"],
 )

--- a/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
@@ -317,6 +317,7 @@ def test_grpc_pre_v2_mypy_plugin(rule_runner: RuleRunner) -> None:
         extra_args=[
             "--python-protobuf-mypy-plugin",
             "--mypy-protobuf-version=mypy-protobuf==1.24",
+            "--mypy-protobuf-extra-requirements=six==1.16.0",
             "--mypy-protobuf-lockfile=<none>",
         ],
         expected_files=[

--- a/src/python/pants/backend/python/typecheck/mypy/BUILD
+++ b/src/python/pants/backend/python/typecheck/mypy/BUILD
@@ -4,7 +4,7 @@
 python_library(dependencies=[":lockfile"])
 resources(name="lockfile", sources=["lockfile.txt"])
 
-python_tests(name="subsystem_test", sources=["subsystem_test.py"])
+python_tests(name="subsystem_test", sources=["subsystem_test.py"], timeout=120)
 python_tests(
     name="rules_integration_test",
     sources=["rules_integration_test.py"],


### PR DESCRIPTION
Failure looks like:

```
E           pants.engine.internals.scheduler.ExecutionError: 1 Exception encountered:
E
E           Engine traceback:
E             in select
E             in pants.backend.codegen.protobuf.python.rules.generate_python_from_protobuf ({self.protocol_target.address.spec})
E             in pants.engine.process.fallible_to_exec_result_or_raise
E           Traceback (most recent call last):
E             File "/tmp/process-executionNwaCfx/src/python/pants/engine/process.py", line 262, in fallible_to_exec_result_or_raise
E               description.value,
E           pants.engine.process.ProcessExecutionFailure: Process 'Generating Python sources from src/protobuf/dir1.' failed with exit code 1.
E           stdout:
E
E           stderr:
E           Traceback (most recent call last):
E             File "/tmp/process-executionkoj6j8/.cache/pex_root/venvs/7a60680810e39003bff7735055fba9f05cad6eb0/44bf65ec4b573a3d710ed08dd3dbbf662b72808e/bin/protoc-gen-mypy", line 5, in <module>
E               from mypy_protobuf import main
E             File "/home/runner/.cache/pants/named_caches/pex_root/venvs/short/236b4726/lib/python3.6/site-packages/mypy_protobuf.py", line 11, in <module>
E               import six
E           ModuleNotFoundError: No module named 'six'
E           --mypy_out: protoc-gen-mypy: Plugin failed with status code 1.

src/python/pants/engine/internals/scheduler.py:508: ExecutionError
=============================== warnings summary ===============================
src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py:234
```

Note that this test is not using a lockfile becase the `[mypy-protobuf].version` is different. I thought about using one, but it makes the test setup a lot more verbose and means we couldn't cherry-pick to pre-Pants 2.7.

[ci skip-rust]
[ci skip-build-wheels]
# Conflicts:
#	src/python/pants/backend/awslambda/python/BUILD