### PR TITLE
[internal] Fix MyPy Protobuf test failing due to missing dependency (Cherry-pick of #12899)

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
@@ -62,10 +62,12 @@ def assert_files_generated(
     source_roots: List[str],
     mypy: bool = False,
     mypy_plugin_version: Optional[str] = None,
+    extra_args: Optional[List[str]] = None,
 ) -> None:
     options = [
         "--backend-packages=pants.backend.codegen.protobuf.python",
         f"--source-root-patterns={repr(source_roots)}",
+        *(extra_args or ()),
     ]
     if mypy:
         options.append("--python-protobuf-mypy-plugin")
@@ -309,6 +311,7 @@ def test_grpc_pre_v2_mypy_plugin(rule_runner: RuleRunner) -> None:
         source_roots=["src/protobuf"],
         mypy=True,
         mypy_plugin_version="mypy-protobuf==1.24",
+        extra_args=["--mypy-protobuf-extra-requirements=six==1.16.0"],
         expected_files=[
             "src/protobuf/dir1/f_pb2.py",
             "src/protobuf/dir1/f_pb2.pyi",

--- a/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
@@ -311,7 +311,7 @@ def test_grpc_pre_v2_mypy_plugin(rule_runner: RuleRunner) -> None:
         source_roots=["src/protobuf"],
         mypy=True,
         mypy_plugin_version="mypy-protobuf==1.24",
-        extra_args=["--mypy-protobuf-extra-requirements=six==1.16.0"],
+        extra_args=["--python-protobuf-mypy-plugin-extra-requirements=six==1.16.0"],
         expected_files=[
             "src/protobuf/dir1/f_pb2.py",
             "src/protobuf/dir1/f_pb2.pyi",


### PR DESCRIPTION
Failure looks like:

```
E           pants.engine.internals.scheduler.ExecutionError: 1 Exception encountered:
E
E           Engine traceback:
E             in select
E             in pants.backend.codegen.protobuf.python.rules.generate_python_from_protobuf ({self.protocol_target.address.spec})
E             in pants.engine.process.fallible_to_exec_result_or_raise
E           Traceback (most recent call last):
E             File "/tmp/process-executionNwaCfx/src/python/pants/engine/process.py", line 262, in fallible_to_exec_result_or_raise
E               description.value,
E           pants.engine.process.ProcessExecutionFailure: Process 'Generating Python sources from src/protobuf/dir1.' failed with exit code 1.
E           stdout:
E
E           stderr:
E           Traceback (most recent call last):
E             File "/tmp/process-executionkoj6j8/.cache/pex_root/venvs/7a60680810e39003bff7735055fba9f05cad6eb0/44bf65ec4b573a3d710ed08dd3dbbf662b72808e/bin/protoc-gen-mypy", line 5, in <module>
E               from mypy_protobuf import main
E             File "/home/runner/.cache/pants/named_caches/pex_root/venvs/short/236b4726/lib/python3.6/site-packages/mypy_protobuf.py", line 11, in <module>
E               import six
E           ModuleNotFoundError: No module named 'six'
E           --mypy_out: protoc-gen-mypy: Plugin failed with status code 1.

src/python/pants/engine/internals/scheduler.py:508: ExecutionError
=============================== warnings summary ===============================
src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py:234
```

Note that this test is not using a lockfile becase the `[mypy-protobuf].version` is different. I thought about using one, but it makes the test setup a lot more verbose and means we couldn't cherry-pick to pre-Pants 2.7.

[ci skip-rust]
[ci skip-build-wheels]
