### PR TITLE
[internal] java: make junit output parsing in tests more robust

### DIFF
--- a/src/python/pants/backend/java/test/junit.py
+++ b/src/python/pants/backend/java/test/junit.py
@@ -96,6 +96,12 @@ async def run_junit_test(
             "-cp",
             materialized_classpath.classpath_arg(),
             "org.junit.platform.console.ConsoleLauncher",
+            # TODO(12812): Make these options configurable by integration tests in `junit_test.py`.
+            # Remove these hard-coded options before general availability.
+            "--disable-ansi-colors",
+            "--details=flat",
+            "--details-theme=ascii",
+            # END TODO REMOVAL
             "--classpath",
             usercp_relpath,
             "--scan-class-path",

--- a/src/python/pants/backend/java/test/junit_test.py
+++ b/src/python/pants/backend/java/test/junit_test.py
@@ -33,6 +33,8 @@ from pants.jvm.target_types import JvmDependencyLockfile
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
+# TODO(12812): Switch tests to using parsed junit.xml results instead of scanning stdout strings.
+
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
@@ -144,7 +146,7 @@ def test_vintage_simple_success(rule_runner: RuleRunner) -> None:
         ],
     )
     assert test_result.exit_code == 0
-    assert re.search(r"testHello.*?\[OK\]", test_result.stdout) is not None
+    assert re.search(r"Finished:\s+testHello", test_result.stdout) is not None
     assert re.search(r"1 tests successful", test_result.stdout) is not None
     assert re.search(r"1 tests found", test_result.stdout) is not None
 
@@ -197,7 +199,12 @@ def test_vintage_simple_failure(rule_runner: RuleRunner) -> None:
     )
     assert test_result.exit_code == 1
     assert (
-        re.search(r"helloTest.*?\[X\].*?java.lang.AssertionError", test_result.stdout) is not None
+        re.search(
+            r"Finished:.*?helloTest.*?Exception: java.lang.AssertionError",
+            test_result.stdout,
+            re.DOTALL,
+        )
+        is not None
     )
     assert re.search(r"1 tests failed", test_result.stdout) is not None
     assert re.search(r"1 tests found", test_result.stdout) is not None
@@ -269,7 +276,7 @@ def test_vintage_success_with_dep(rule_runner: RuleRunner) -> None:
         ],
     )
     assert test_result.exit_code == 0
-    assert re.search(r"testHello.*?\[OK\]", test_result.stdout) is not None
+    assert re.search(r"Finished:\s+testHello", test_result.stdout) is not None
     assert re.search(r"1 tests successful", test_result.stdout) is not None
     assert re.search(r"1 tests found", test_result.stdout) is not None
 
@@ -399,7 +406,7 @@ def test_jupiter_simple_success(rule_runner: RuleRunner) -> None:
         ],
     )
     assert test_result.exit_code == 0
-    assert re.search(r"testHello.*?\[OK\]", test_result.stdout) is not None
+    assert re.search(r"Finished:\s+testHello", test_result.stdout) is not None
     assert re.search(r"1 tests successful", test_result.stdout) is not None
     assert re.search(r"1 tests found", test_result.stdout) is not None
 
@@ -455,7 +462,9 @@ def test_jupiter_simple_failure(rule_runner: RuleRunner) -> None:
     assert test_result.exit_code == 1
     assert (
         re.search(
-            r"testHello\(\).*?\[X\].*?expected: <Goodbye!> but was: <Hello!>", test_result.stdout
+            r"Finished:.*?testHello.*?Exception: org.opentest4j.AssertionFailedError: expected: <Goodbye!> but was: <Hello!>",
+            test_result.stdout,
+            re.DOTALL,
         )
         is not None
     )
@@ -532,7 +541,7 @@ def test_jupiter_success_with_dep(rule_runner: RuleRunner) -> None:
         ],
     )
     assert test_result.exit_code == 0
-    assert re.search(r"testHello.*?\[OK\]", test_result.stdout) is not None
+    assert re.search(r"Finished:\s+testHello", test_result.stdout) is not None
     assert re.search(r"1 tests successful", test_result.stdout) is not None
     assert re.search(r"1 tests found", test_result.stdout) is not None
 
@@ -603,7 +612,7 @@ def test_vintage_and_jupiter_simple_success(rule_runner: RuleRunner) -> None:
         ],
     )
     assert test_result.exit_code == 0
-    assert re.search(r"testHello.*?\[OK\]", test_result.stdout) is not None
-    assert re.search(r"testGoodbye.*?\[OK\]", test_result.stdout) is not None
+    assert re.search(r"Finished:\s+testHello", test_result.stdout) is not None
+    assert re.search(r"Finished:\s+testGoodbye", test_result.stdout) is not None
     assert re.search(r"2 tests successful", test_result.stdout) is not None
     assert re.search(r"2 tests found", test_result.stdout) is not None


### PR DESCRIPTION
When I was running the JUnit integration test, the test runner output was different than what the junit integration tests expected because JUnit saw a different terminal type on macOS than in CI/Linux and rendered the `[OK]` marker as a Unicode checkmark. The integration tests were hard-coded to look for the `[OK]` which caused them to fail.

For now, force the JUnit runner to use ASCII output and update the integration test accordingly. Add comments to note that the work-around should be removed when https://github.com/pantsbuild/pants/issues/12812 implements parsing the junit.xml.

This PR was split as pre-work from #12897.

[ci skip-rust]

[ci skip-build-wheels]