### PR TITLE
[internal] terraform: generate terraform_module targets

### DIFF
--- a/src/python/pants/backend/experimental/terraform/register.py
+++ b/src/python/pants/backend/experimental/terraform/register.py
@@ -1,22 +1,21 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-from pants.backend.terraform import tailor
-from pants.backend.terraform import target_types as target_types_module
-from pants.backend.terraform import tool
+from pants.backend.terraform import tailor, target_gen, target_types, tool
 from pants.backend.terraform.lint import fmt
-from pants.backend.terraform.target_types import TerraformModule
+from pants.backend.terraform.target_types import TerraformModule, TerraformModules
 from pants.engine.rules import collect_rules
 
 
 def target_types():
-    return [TerraformModule]
+    return [TerraformModule, TerraformModules]
 
 
 def rules():
     return [
         *collect_rules(),
         *tailor.rules(),
-        *target_types_module.rules(),
+        *target_gen.rules(),
+        *target_types.rules(),
         *tool.rules(),
         *fmt.rules(),
     ]

--- a/src/python/pants/backend/experimental/terraform/register.py
+++ b/src/python/pants/backend/experimental/terraform/register.py
@@ -1,9 +1,9 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from pants.backend.terraform import tailor, target_gen, tool
-from pants.backend.terraform.target_types import rules as target_types_rules
 from pants.backend.terraform.lint import fmt
 from pants.backend.terraform.target_types import TerraformModule, TerraformModules
+from pants.backend.terraform.target_types import rules as target_types_rules
 from pants.engine.rules import collect_rules
 
 

--- a/src/python/pants/backend/experimental/terraform/register.py
+++ b/src/python/pants/backend/experimental/terraform/register.py
@@ -1,6 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-from pants.backend.terraform import tailor, target_gen, target_types, tool
+from pants.backend.terraform import tailor, target_gen, tool
+from pants.backend.terraform.target_types import rules as target_types_rules
 from pants.backend.terraform.lint import fmt
 from pants.backend.terraform.target_types import TerraformModule, TerraformModules
 from pants.engine.rules import collect_rules
@@ -15,7 +16,7 @@ def rules():
         *collect_rules(),
         *tailor.rules(),
         *target_gen.rules(),
-        *target_types.rules(),
+        *target_types_rules(),
         *tool.rules(),
         *fmt.rules(),
     ]

--- a/src/python/pants/backend/terraform/target_gen.py
+++ b/src/python/pants/backend/terraform/target_gen.py
@@ -53,15 +53,10 @@ async def generate_terraform_module_targets(
             generated_target_fields[field.alias] = value
         return TerraformModule(
             generated_target_fields,
-            # TODO(12891): Make this be:
-            #   Address(
-            #       request.generator.address.spec_path,
-            #       target_name=request.generator.target_name,
-            #       generated_name=dir
-            #   )
             Address(
-                dir,
-                target_name="tf_mod",
+                request.generator.address.spec_path,
+                target_name=request.generator.address.target_name,
+                generated_name=dir,
             ),
         )
 

--- a/src/python/pants/backend/terraform/target_gen.py
+++ b/src/python/pants/backend/terraform/target_gen.py
@@ -1,6 +1,6 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-from typing import Optional
+from __future__ import annotations
 
 from pants.backend.terraform.target_types import (
     TerraformModule,
@@ -44,7 +44,7 @@ async def generate_terraform_module_targets(
     def gen_target(dir: str) -> Target:
         generated_target_fields = {}
         for field in request.generator.field_values.values():
-            value: Optional[ImmutableValue]
+            value: ImmutableValue | None
             if isinstance(field, Sources):
                 value = tuple(dir_to_filenames[dir])
             else:

--- a/src/python/pants/backend/terraform/target_gen.py
+++ b/src/python/pants/backend/terraform/target_gen.py
@@ -46,7 +46,6 @@ async def generate_terraform_module_targets(
         for field in request.generator.field_values.values():
             value: ImmutableValue | None
             if isinstance(field, Sources):
-                # TODO: Should this just use a glob if all of the filenames match the default *.tf glob?
                 value = tuple(sorted(dir_to_filenames[dir]))
             else:
                 value = field.value

--- a/src/python/pants/backend/terraform/target_gen.py
+++ b/src/python/pants/backend/terraform/target_gen.py
@@ -46,7 +46,8 @@ async def generate_terraform_module_targets(
         for field in request.generator.field_values.values():
             value: ImmutableValue | None
             if isinstance(field, Sources):
-                value = tuple(dir_to_filenames[dir])
+                # TODO: Should this just use a glob if all of the filenames match the default *.tf glob?
+                value = tuple(sorted(dir_to_filenames[dir]))
             else:
                 value = field.value
             generated_target_fields[field.alias] = value

--- a/src/python/pants/backend/terraform/target_gen.py
+++ b/src/python/pants/backend/terraform/target_gen.py
@@ -1,0 +1,70 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from typing import Optional
+
+from pants.backend.terraform.target_types import (
+    TerraformModule,
+    TerraformModules,
+    TerraformModulesSources,
+)
+from pants.build_graph.address import Address
+from pants.core.goals.tailor import group_by_dir
+from pants.engine.internals.selectors import Get
+from pants.engine.rules import collect_rules, rule
+from pants.engine.target import (
+    GeneratedTargets,
+    GenerateTargetsRequest,
+    HydratedSources,
+    HydrateSourcesRequest,
+    ImmutableValue,
+    Sources,
+    Target,
+)
+from pants.engine.unions import UnionRule
+
+
+class GenerateTerraformModuleTargetsRequest(GenerateTargetsRequest):
+    generate_from = TerraformModules
+
+
+@rule
+async def generate_terraform_module_targets(
+    request: GenerateTerraformModuleTargetsRequest,
+) -> GeneratedTargets:
+    # Hydrate the sources referenced by the generator.
+    sources = await Get(
+        HydratedSources, HydrateSourcesRequest(request.generator.get(TerraformModulesSources))
+    )
+
+    # Group the sources by directory and find which directories have Terraform files present.
+    dir_to_filenames = group_by_dir(sources.snapshot.files)
+    dirs_with_terraform_files = []
+    for dir, filenames in dir_to_filenames.items():
+        if any(filename.endswith(".tf") for filename in filenames):
+            dirs_with_terraform_files.append(dir)
+
+    def gen_target(dir: str) -> Target:
+        generated_target_fields = {}
+        for field in request.generator.field_values.values():
+            value: Optional[ImmutableValue]
+            if isinstance(field, Sources):
+                value = tuple(dir_to_filenames[dir])
+            else:
+                value = field.value
+            generated_target_fields[field.alias] = value
+        return TerraformModule(
+            generated_target_fields,
+            Address(
+                dir,
+                target_name="tf_mod",
+            ),
+        )
+
+    return GeneratedTargets(gen_target(dir) for dir in dirs_with_terraform_files)
+
+
+def rules():
+    return [
+        *collect_rules(),
+        UnionRule(GenerateTargetsRequest, GenerateTerraformModuleTargetsRequest),
+    ]

--- a/src/python/pants/backend/terraform/target_gen_test.py
+++ b/src/python/pants/backend/terraform/target_gen_test.py
@@ -1,7 +1,5 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-import textwrap
-
 import pytest
 
 from pants.backend.terraform import target_gen
@@ -36,32 +34,10 @@ def rule_runner() -> RuleRunner:
 def test_target_generation(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "BUILD": textwrap.dedent(
-                """\
-        terraform_modules(name="tf_mods")
-        """
-            ),
-            "src/tf/versions.tf": textwrap.dedent(
-                """\
-        terraform {
-          required_version = ">= 1.0"
-        }
-        """
-            ),
-            "src/tf/outputs.tf": textwrap.dedent(
-                """\
-        output "foo" {
-          value = 'foo'
-        }
-        """
-            ),
-            "src/tf/foo/versions.tf": textwrap.dedent(
-                """\
-        terraform {
-          required_version = ">= 1.0"
-        }
-        """
-            ),
+            "BUILD": "terraform_modules(name='tf_mods')\n",
+            "src/tf/versions.tf": "",
+            "src/tf/outputs.tf": "",
+            "src/tf/foo/versions.tf": "",
             "src/tf/not-terraform/README.md": "This should not trigger target generation.",
         }
     )

--- a/src/python/pants/backend/terraform/target_gen_test.py
+++ b/src/python/pants/backend/terraform/target_gen_test.py
@@ -52,7 +52,7 @@ def test_target_generation(rule_runner: RuleRunner) -> None:
                 {
                     TerraformModuleSources.alias: ("versions.tf",),
                 },
-                Address("src/tf/foo", target_name="tf_mod"),
+                Address("", target_name="tf_mods", generated_name="src/tf/foo"),
             ),
             TerraformModule(
                 {
@@ -61,7 +61,7 @@ def test_target_generation(rule_runner: RuleRunner) -> None:
                         "versions.tf",
                     ),
                 },
-                Address("src/tf", target_name="tf_mod"),
+                Address("", target_name="tf_mods", generated_name="src/tf"),
             ),
         ]
     )

--- a/src/python/pants/backend/terraform/target_types.py
+++ b/src/python/pants/backend/terraform/target_types.py
@@ -28,7 +28,7 @@ class TerraformModulesSources(TerraformSources):
 class TerraformModules(Target):
     alias = "terraform_modules"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, TerraformModulesSources)
-    help = """Generate `terraform_module` targets from source globs."""
+    help = "Generate `terraform_module` targets from source globs."
 
 
 def rules():

--- a/src/python/pants/backend/terraform/target_types.py
+++ b/src/python/pants/backend/terraform/target_types.py
@@ -28,7 +28,10 @@ class TerraformModulesSources(TerraformSources):
 class TerraformModules(Target):
     alias = "terraform_modules"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, TerraformModulesSources)
-    help = "Generate `terraform_module` targets from source globs."
+    help = (
+        "Generate a `terraform_module` target for each directory from the `sources` field "
+        "where Terraform files are present."
+    )
 
 
 def rules():

--- a/src/python/pants/backend/terraform/target_types.py
+++ b/src/python/pants/backend/terraform/target_types.py
@@ -15,7 +15,11 @@ class TerraformModuleSources(TerraformSources):
 class TerraformModule(Target):
     alias = "terraform_module"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, TerraformModuleSources)
-    help = """A single Terraform module."""
+    help = (
+        "A single Terraform module corresponding to a directory.\n\n"
+        "There must only be one `terraform_module` in a directory.\n\n"
+        "Use `terraform_modules` to generate `terraform_module` targets for less boilerplate."
+    )
 
 
 class TerraformModulesSources(TerraformSources):

--- a/src/python/pants/backend/terraform/target_types.py
+++ b/src/python/pants/backend/terraform/target_types.py
@@ -18,5 +18,18 @@ class TerraformModule(Target):
     help = """A single Terraform module."""
 
 
+class TerraformModulesSources(TerraformSources):
+    # TODO: This currently only globs .tf files but not non-.tf files referenced by Terraform config. This
+    # should be updated to allow for the generated TerraformModule targets to capture all files in the diectory
+    # other than BUILD files.
+    default = ("**/*.tf",)
+
+
+class TerraformModules(Target):
+    alias = "terraform_modules"
+    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, TerraformModulesSources)
+    help = """Generate `terraform_module` targets from source globs."""
+
+
 def rules():
     return collect_rules()


### PR DESCRIPTION
Use the new target generation support to implement a `terraform_modules` generator that generates `terraform_module` targets.

Caveats:
- Does not check whether the files are already owned by a `terrform_module` target.
- Does not capture all files in the directories with Terraform targets.
- Does not implement `overrides` as per the target generation design document. 

[ci skip-build-wheels]