### PR TITLE
[internal] New `dir:generator#generated` address syntax works with command line args

### DIFF
--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -37,15 +37,27 @@ class AddressSpec(Spec, metaclass=ABCMeta):
 class AddressLiteralSpec(AddressSpec):
     """An AddressSpec for a single address.
 
-    This may be a traditional address, like `a/b/c:c`, or a file address using disambiguation
-    syntax, e.g. `a/b/c.txt:tgt`.
+    This may be one of:
+
+    * A traditional address, like `dir:lib`.
+    * A generated target address like `dir:lib#generated` or `dir#generated`.
+    * A file address using disambiguation syntax like dir/f.ext:lib` (files without a target will
+      be FilesystemSpecs).
     """
 
     path_component: str
-    target_component: str
+    target_component: str | None = None
+    generated_component: str | None = None
 
     def __str__(self) -> str:
-        return f"{self.path_component}:{self.target_component}"
+        tgt = f":{self.target_component}" if self.target_component else ""
+        generated = f"#{self.generated_component}" if self.generated_component else ""
+        return f"{self.path_component}{tgt}{generated}"
+
+    @property
+    def is_directory_shorthand(self) -> bool:
+        """Is in the format `path/to/dir`, which is shorthand for `path/to/dir:dir`."""
+        return self.target_component is None and self.generated_component is None
 
 
 class AddressGlobSpec(AddressSpec, metaclass=ABCMeta):

--- a/src/python/pants/base/specs_parser_test.py
+++ b/src/python/pants/base/specs_parser_test.py
@@ -21,9 +21,10 @@ from pants.base.specs import (
 from pants.base.specs_parser import SpecsParser
 
 
-def address_literal(directory: str, name: str | None = None) -> AddressLiteralSpec:
-    name = name if name is not None else os.path.basename(directory)
-    return AddressLiteralSpec(directory, name)
+def address_literal(
+    directory: str, name: str | None = None, generated: str | None = None
+) -> AddressLiteralSpec:
+    return AddressLiteralSpec(directory, name, generated)
 
 
 def desc(directory: str) -> DescendantAddresses:
@@ -72,6 +73,12 @@ def assert_filesystem_spec_parsed(
         ("a/b", address_literal("a/b")),
         ("a/b:b", address_literal("a/b", "b")),
         ("a/b:c", address_literal("a/b", "c")),
+        ("//a/b:c", address_literal("a/b", "c")),
+        ("//#gen", address_literal("", None, "gen")),
+        ("//:tgt#gen", address_literal("", "tgt", "gen")),
+        ("dir:tgt#gen", address_literal("dir", "tgt", "gen")),
+        ("dir#gen", address_literal("dir", None, "gen")),
+        ("//dir:tgt#gen", address_literal("dir", "tgt", "gen")),
     ],
 )
 def test_address_literal_specs(tmp_path: Path, spec: str, expected: AddressLiteralSpec) -> None:

--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -456,7 +456,7 @@ def specs_to_dirs(specs: Specs) -> tuple[str, ...]:
         *specs.address_specs.globs,
     ]
     for spec in specs.address_specs.literals:
-        if spec.target_component == os.path.basename(spec.path_component):
+        if spec.is_directory_shorthand:
             dir_specs.append(spec)
         else:
             other_specs.append(spec)

--- a/src/python/pants/core/goals/tailor_test.py
+++ b/src/python/pants/core/goals/tailor_test.py
@@ -316,16 +316,13 @@ def test_group_by_dir() -> None:
 def test_specs_to_dirs() -> None:
     assert specs_to_dirs(Specs(AddressSpecs([]), FilesystemSpecs([]))) == ("",)
     assert specs_to_dirs(
-        Specs(AddressSpecs([AddressLiteralSpec("src/python/foo", "foo")]), FilesystemSpecs([]))
+        Specs(AddressSpecs([AddressLiteralSpec("src/python/foo")]), FilesystemSpecs([]))
     ) == ("src/python/foo",)
     assert (
         specs_to_dirs(
             Specs(
                 AddressSpecs(
-                    [
-                        AddressLiteralSpec("src/python/foo", "foo"),
-                        AddressLiteralSpec("src/python/bar", "bar"),
-                    ]
+                    [AddressLiteralSpec("src/python/foo"), AddressLiteralSpec("src/python/bar")]
                 ),
                 FilesystemSpecs([]),
             )
@@ -340,8 +337,20 @@ def test_specs_to_dirs() -> None:
 
     with pytest.raises(ValueError):
         specs_to_dirs(
+            Specs(AddressSpecs([AddressLiteralSpec("src/python/bar", "tgt")]), FilesystemSpecs([]))
+        )
+
+    with pytest.raises(ValueError):
+        specs_to_dirs(
             Specs(
-                AddressSpecs([AddressLiteralSpec("src/python/bar", "notbar")]), FilesystemSpecs([])
+                AddressSpecs(
+                    [
+                        AddressLiteralSpec(
+                            "src/python/bar", target_component=None, generated_component="gen"
+                        )
+                    ]
+                ),
+                FilesystemSpecs([]),
             )
         )
 

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -162,10 +162,13 @@ async def addresses_from_address_specs(
     matched_addresses: OrderedSet[Address] = OrderedSet()
     filtering_disabled = address_specs.filter_by_global_options is False
 
-    # First convert all `AddressLiteralSpec`s. Some of the resulting addresses may be file
+    # First convert all `AddressLiteralSpec`s. Some of the resulting addresses may be generated
     # addresses. This will raise an exception if any of the addresses are not valid.
     literal_addresses = await MultiGet(
-        Get(Address, AddressInput(spec.path_component, spec.target_component))
+        Get(
+            Address,
+            AddressInput(spec.path_component, spec.target_component, spec.generated_component),
+        )
         for spec in address_specs.literals
     )
     literal_target_adaptors = await MultiGet(
@@ -204,6 +207,7 @@ async def addresses_from_address_specs(
         matched_addresses.update(
             addr
             for (addr, tgt) in addr_target_pairs_for_spec
+            # TODO(#11123): handle the edge case if a generated target's `tags` != its generator's.
             if filtering_disabled or specs_filter.matches(addr, tgt)
         )
 

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -119,12 +119,12 @@ class MockTgt(Target):
 
 class MockGeneratedTarget(Target):
     alias = "generated"
-    core_fields = (Dependencies, Sources)
+    core_fields = (Dependencies, Sources, Tags)
 
 
 class MockTargetGenerator(Target):
     alias = "generator"
-    core_fields = (Dependencies, Sources)
+    core_fields = (Dependencies, Sources, Tags)
 
 
 class MockGenerateTargetsRequest(GenerateTargetsRequest):
@@ -134,7 +134,21 @@ class MockGenerateTargetsRequest(GenerateTargetsRequest):
 @rule
 async def generate_mock_generated_target(request: MockGenerateTargetsRequest) -> GeneratedTargets:
     paths = await Get(SourcesPaths, SourcesPathsRequest(request.generator[Sources]))
-    return generate_file_level_targets(MockGeneratedTarget, request.generator, paths.files, None)
+    # Generate using both "file address" and "generated target" syntax.
+    return GeneratedTargets(
+        [
+            *generate_file_level_targets(
+                MockGeneratedTarget, request.generator, paths.files, None
+            ).values(),
+            *generate_file_level_targets(
+                MockGeneratedTarget,
+                request.generator,
+                paths.files,
+                None,
+                use_generated_address_syntax=True,
+            ).values(),
+        ]
+    )
 
 
 def test_resolve_address() -> None:
@@ -264,16 +278,19 @@ def test_address_specs_deduplication(address_specs_rule_runner: RuleRunner) -> N
     address_specs_rule_runner.write_files(
         {"demo/f.txt": "", "demo/BUILD": "mock_tgt(sources=['f.txt'])"}
     )
-    # We also include a file address to ensure that that is included in the result.
     specs = [
-        AddressLiteralSpec("demo", "demo"),
-        AddressLiteralSpec("demo/f.txt", "demo"),
+        AddressLiteralSpec("demo"),
         SiblingAddresses("demo"),
         DescendantAddresses("demo"),
         AscendantAddresses("demo"),
+        # We also include a generated target and file address to ensure that that is included in
+        # the result.
+        AddressLiteralSpec("demo", None, "gen"),
+        AddressLiteralSpec("demo/f.txt"),
     ]
     assert resolve_address_specs(address_specs_rule_runner, specs) == {
         Address("demo"),
+        Address("demo", generated_name="gen"),
         Address("demo", relative_file_path="f.txt"),
     }
 
@@ -285,9 +302,9 @@ def test_address_specs_filter_by_tag(address_specs_rule_runner: RuleRunner) -> N
             "demo/f.txt": "",
             "demo/BUILD": dedent(
                 """\
-                mock_tgt(name="a", sources=["f.txt"])
-                mock_tgt(name="b", sources=["f.txt"], tags=["integration"])
-                mock_tgt(name="c", sources=["f.txt"], tags=["ignore"])
+                generator(name="a", sources=["f.txt"])
+                generator(name="b", sources=["f.txt"], tags=["integration"])
+                generator(name="c", sources=["f.txt"], tags=["ignore"])
                 """
             ),
         }
@@ -296,8 +313,8 @@ def test_address_specs_filter_by_tag(address_specs_rule_runner: RuleRunner) -> N
         Address("demo", target_name="b")
     }
 
-    # The same filtering should work when given literal addresses, including file addresses.
-    # For file addresses, we look up the `tags` field of the original BUILD target.
+    # The same filtering should work when given literal addresses, including generated targets and
+    # file addresses.
     literals_result = resolve_address_specs(
         address_specs_rule_runner,
         [
@@ -306,12 +323,15 @@ def test_address_specs_filter_by_tag(address_specs_rule_runner: RuleRunner) -> N
             AddressLiteralSpec("demo", "c"),
             AddressLiteralSpec("demo/f.txt", "a"),
             AddressLiteralSpec("demo/f.txt", "b"),
-            AddressLiteralSpec("demo/f.txt", "c"),
+            AddressLiteralSpec("demo", "a", "f.txt"),
+            AddressLiteralSpec("demo", "b", "f.txt"),
+            AddressLiteralSpec("demo", "c", "f.txt"),
         ],
     )
     assert literals_result == {
-        Address("demo", relative_file_path="f.txt", target_name="b"),
         Address("demo", target_name="b"),
+        Address("demo", target_name="b", generated_name="f.txt"),
+        Address("demo", target_name="b", relative_file_path="f.txt"),
     }
 
 
@@ -333,21 +353,24 @@ def test_address_specs_filter_by_exclude_pattern(address_specs_rule_runner: Rule
         Address("demo", target_name="not_me")
     }
 
-    # The same filtering should work when given literal addresses, including file addresses.
-    # The filtering will operate against the normalized Address.spec.
+    # The same filtering should work when given literal addresses, including generated targets and
+    # file addresses.
     literals_result = resolve_address_specs(
         address_specs_rule_runner,
         [
             AddressLiteralSpec("demo", "exclude_me"),
             AddressLiteralSpec("demo", "not_me"),
+            AddressLiteralSpec("demo", "exclude_me", "f.txt"),
+            AddressLiteralSpec("demo", "not_me", "f.txt"),
             AddressLiteralSpec("demo/f.txt", "exclude_me"),
             AddressLiteralSpec("demo/f.txt", "not_me"),
         ],
     )
 
     assert literals_result == {
-        Address("demo", relative_file_path="f.txt", target_name="not_me"),
         Address("demo", target_name="not_me"),
+        Address("demo", target_name="not_me", relative_file_path="f.txt"),
+        Address("demo", target_name="not_me", generated_name="f.txt"),
     }
 
 

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -724,6 +724,8 @@ def generate_file_level_targets(
     paths: Iterable[str],
     # NB: Should only ever be set to `None` in tests.
     union_membership: UnionMembership | None,
+    *,
+    use_generated_address_syntax: bool = False,
 ) -> GeneratedTargets:
     """Generate one new target for each path, using the same fields as the generator target except
     for the `sources` field only referring to the path and using a new address."""
@@ -751,15 +753,20 @@ def generate_file_level_targets(
                 value = field.value
             generated_target_fields[field.alias] = value
 
-        return generated_target_cls(
-            generated_target_fields,
+        address = (
             Address(
                 generator.address.spec_path,
                 target_name=generator.address.target_name,
+                generated_name=relativized_file_name,
+            )
+            if use_generated_address_syntax
+            else Address(
+                generator.address.spec_path,
+                target_name=generator.address.target_name,
                 relative_file_path=relativized_file_name,
-            ),
-            union_membership,
+            )
         )
+        return generated_target_cls(generated_target_fields, address, union_membership)
 
     return GeneratedTargets(gen_tgt(fp) for fp in paths)
 

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -441,8 +441,16 @@ def test_generate_file_level_targets() -> None:
         alias = "generated"
         core_fields = (Dependencies, Tags, Sources)
 
-    def generate(generator: Target, files: List[str]) -> GeneratedTargets:
-        return generate_file_level_targets(MockGenerated, generator, files, None)
+    def generate(
+        generator: Target, files: List[str], *, use_generated_addr_syntax: bool = False
+    ) -> GeneratedTargets:
+        return generate_file_level_targets(
+            MockGenerated,
+            generator,
+            files,
+            None,
+            use_generated_address_syntax=use_generated_addr_syntax,
+        )
 
     tgt = MockGenerator({Sources.alias: ["f1.ext", "f2.ext"], Tags.alias: ["tag"]}, Address("demo"))
     assert generate(tgt, ["demo/f1.ext", "demo/f2.ext"]) == GeneratedTargets(
@@ -466,6 +474,16 @@ def test_generate_file_level_targets() -> None:
             MockGenerated(
                 {Sources.alias: ["subdir/demo.f95"]},
                 Address("src/fortran", target_name="demo", relative_file_path="subdir/demo.f95"),
+            )
+        ]
+    )
+    assert generate(
+        subdir_tgt, ["src/fortran/subdir/demo.f95"], use_generated_addr_syntax=True
+    ) == GeneratedTargets(
+        [
+            MockGenerated(
+                {Sources.alias: ["subdir/demo.f95"]},
+                Address("src/fortran", target_name="demo", generated_name="subdir/demo.f95"),
             )
         ]
     )

--- a/src/python/pants/init/specs_calculator.py
+++ b/src/python/pants/init/specs_calculator.py
@@ -72,9 +72,8 @@ def calculate_specs(
         address_specs.append(
             AddressLiteralSpec(
                 path_component=address_input.path_component,
-                # NB: AddressInput.target_component may be None, but AddressLiteralSpec expects a
-                # string.
-                target_component=address_input.target_component or address.target_name,
+                target_component=address_input.target_component,
+                generated_component=address_input.generated_component,
             )
         )
     return Specs(AddressSpecs(address_specs, filter_by_global_options=True), FilesystemSpecs([]))


### PR DESCRIPTION

[ci skip-rust]
[ci skip-build-wheels]