### PR TITLE
A proper access class for the readme.com API.

### DIFF
--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -12,7 +12,7 @@ Live run:
     ./pants run build-support/bin/generate_docs.py -- --sync --api-key=<API_KEY>
 
 where API_KEY is your readme.io API Key, found here:
-  https://dash.readme.com/project/pants/v2.3/api-key
+  https://dash.readme.com/project/pants/v2.6/api-key
 """
 
 from __future__ import annotations
@@ -32,6 +32,7 @@ from typing import Any, Dict, Iterable, Optional, cast
 import pystache
 import requests
 from common import die
+from readme_api import DocRef, ReadmeAPI
 
 from pants.help.help_info_extracter import to_help_str
 from pants.version import MAJOR_MINOR
@@ -42,6 +43,10 @@ logger = logging.getLogger(__name__)
 def main() -> None:
     logging.basicConfig(format="[%(levelname)s]: %(message)s", level=logging.INFO)
     args = create_parser().parse_args()
+
+    if args.sync and not args.api_key:
+        raise Exception("You specified --sync so you must also specify --api-key")
+
     version = determine_pants_version(args.no_prompt)
     help_info = run_pants_help_all()
     doc_urls = DocUrlMatcher().find_doc_urls(value_strs_iter(help_info))
@@ -194,7 +199,7 @@ def create_parser() -> argparse.ArgumentParser:
 
 
 def run_pants_help_all() -> Dict:
-    deactivated_backends = ["internal_plugins.releases"]
+    deactivated_backends = ["internal_plugins.releases", "pants.backend.experimental.java"]
     activated_backends = [
         "pants.backend.codegen.protobuf.python",
         "pants.backend.awslambda.python",
@@ -261,7 +266,8 @@ def rewrite_value_strs(help_info: dict, slug_to_title: dict[str, str]) -> dict:
 class ReferenceGenerator:
     def __init__(self, args: argparse.Namespace, version: str, help_info: dict) -> None:
         self._args = args
-        self._version = version
+
+        self._readme_api = ReadmeAPI(api_key=self._args.api_key, version=version)
 
         def get_tpl(name: str) -> str:
             # Note that loading relative to __name__ may not always work when __name__=='__main__'.
@@ -356,18 +362,8 @@ class ReferenceGenerator:
     def category_id(self) -> str:
         """The id of the "Reference" category on the docsite."""
         if self._category_id is None:
-            self._category_id = self._get_id("categories/reference")
+            self._category_id = self._readme_api.get_category("reference").id
         return self._category_id
-
-    def _access_readme_api(self, url_suffix: str, method: str, payload: str) -> Dict:
-        """Sends requests to the readme.io API."""
-        url = f"https://dash.readme.io/api/v1/{url_suffix}"
-        headers = {"content-type": "application/json", "x-readme-version": f"v{self._version}"}
-        response = requests.request(
-            method, url, data=payload, headers=headers, auth=(self._args.api_key, "")
-        )
-        response.raise_for_status()
-        return cast(Dict, response.json()) if response.text else {}
 
     def _create(
         self, parent_doc_id: Optional[str], slug_suffix: str, title: str, body: str
@@ -393,50 +389,12 @@ class ReferenceGenerator:
         one we want humans to see (this will not change the slug, see above).
         """
         slug = f"reference-{slug_suffix}"
-
-        logger.info(f"Creating {slug}")
-
-        # See https://docs.readme.com/developers/reference/docs#createdoc.
-        page = {
-            "title": slug,
-            "type": "basic",
-            "body": "",
-            "category": self.category_id,
-            "parentDoc": parent_doc_id,
-            "hidden": False,
-        }
-        payload = json.dumps(page)
-        self._access_readme_api("docs/", "POST", payload)
+        self._readme_api.create_doc(
+            title=slug, category=self.category_id, parentDoc=parent_doc_id, hidden=False
+        )
 
         # Placeholder page exists, now update it with the real title and body.
-        self._update(parent_doc_id, slug, title, body)
-
-    def _update(self, parent_doc_id, slug, title, body):
-        """Update an existing page."""
-
-        logger.info(f"Updating {slug}")
-
-        # See https://docs.readme.com/developers/reference/docs#updatedoc.
-        page = {
-            "title": title,
-            "type": "basic",
-            "body": body,
-            "category": self.category_id,
-            "parentDoc": parent_doc_id,
-            "hidden": False,
-        }
-        payload = json.dumps(page)
-        self._access_readme_api(f"docs/{slug}", "PUT", payload)
-
-    def _delete(self, slug: str) -> None:
-        """Delete an existing page."""
-
-        logger.warning(f"Deleting {slug}")
-        self._access_readme_api(f"docs/{slug}", "DELETE", "")
-
-    def _get_id(self, url) -> str:
-        """Returns the id of the entity at the specified readme.io API url."""
-        return cast(str, self._access_readme_api(url, "GET", "")["_id"])
+        self._readme_api.update_doc(slug=slug, title=title, category=self.category_id, body=body)
 
     def _render_target(self, alias: str) -> str:
         return cast(str, self._renderer.render("{{> target}}", self._targets_info[alias]))
@@ -493,27 +451,30 @@ class ReferenceGenerator:
 
         All pages live under the "reference" category.
 
-        There are three top-level pages under that category:
+        There are four top-level pages under that category:
         - Global options
         - The Goals parent page
         - The Subsystems parent page
+        - The Targets parent page
 
-        The individual pages for each goal/subsystem are nested under the two parent pages.
+        The individual reference pages are nested under these parent pages.
         """
         # Docs appear on the site in creation order.  If we only create new docs
         # that don't already exist then they will appear at the end, instead of in
         # alphabetical order. So we first delete all previous docs, then recreate them.
         #
+        # TODO: Instead of deleting and recreating, we can set the order explicitly.
+        #
         # Note that deleting a non-empty parent will fail, so we delete children first.
-        def do_delete(doc_to_delete):
-            for child in doc_to_delete.get("children", []):
+        def do_delete(docref: DocRef):
+            for child in docref.children:
                 do_delete(child)
-            self._delete(doc_to_delete["slug"])
+            self._readme_api.delete_doc(docref.slug)
 
-        docs = self._access_readme_api("categories/reference/docs", "GET", "")
+        docrefs = self._readme_api.get_docs_for_category("reference")
 
-        for doc in docs:
-            do_delete(doc)
+        for docref in docrefs:
+            do_delete(docref)
 
         # Partition the scopes into goals and subsystems.
         goals = {}
@@ -553,7 +514,7 @@ class ReferenceGenerator:
         )
 
         # Create the individual goal/subsystem/target docs.
-        all_goals_doc_id = self._get_id("docs/reference-all-goals")
+        all_goals_doc_id = self._readme_api.get_doc("reference-all-goals").id
         for scope, shi in sorted(goals.items()):
             self._create(
                 parent_doc_id=all_goals_doc_id,
@@ -562,7 +523,7 @@ class ReferenceGenerator:
                 body=self._render_options_body(shi),
             )
 
-        all_subsystems_doc_id = self._get_id("docs/reference-all-subsystems")
+        all_subsystems_doc_id = self._readme_api.get_doc("reference-all-subsystems").id
         for scope, shi in sorted(subsystems.items()):
             self._create(
                 parent_doc_id=all_subsystems_doc_id,
@@ -571,7 +532,7 @@ class ReferenceGenerator:
                 body=self._render_options_body(shi),
             )
 
-        all_targets_doc_id = self._get_id("docs/reference-all-targets")
+        all_targets_doc_id = self._readme_api.get_doc("reference-all-targets").id
         for alias, data in sorted(self._targets_info.items()):
             self._create(
                 parent_doc_id=all_targets_doc_id,

--- a/build-support/bin/readme_api.py
+++ b/build-support/bin/readme_api.py
@@ -1,0 +1,264 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+"""Utilities for accessing the readme.com API.
+
+Since they don't have a Python SDK.
+
+This is not a general purpose SDK: It only covers the parts we need, namely
+Categories and Docs, and within those, only the fields we care about.
+
+Note: The readme.com API is a little confusing wrt to ids and slugs.
+ You access a Category or Doc object via its slug. But those objects reference other objects by id.
+ For example, A Doc references its category via the `category` field, which contains an id.
+ There is no easy way to go directly from an id to an object: You have to enumerate all
+ the objects. The one useful exception is that when you retrieve all the Docs in a Category,
+ you get a list of reference objects, each of which includes the id *and* the slug.
+ The fields containing ids do not have an "_id" suffix, for consistency with the over-the-wire
+ field names. So assume that any reference field contains an id, unless its name is "slug".
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Type, TypeVar, Union, cast
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+_API_URL_PREFIX = "https://dash.readme.io/api/v1/"
+
+
+ApiResponse = Union[dict, list, None]
+
+
+T = TypeVar("T", bound="ReadmeEntity")  # Entity type.
+F = TypeVar("F")  # Field type.
+
+
+@dataclass(frozen=True)
+class ReadmeEntity:
+    _id: str
+
+    @property
+    def id(self):
+        return self._id
+
+    @classmethod
+    def from_api_response(cls: Type[T], data: dict) -> T:
+        init_kwargs = {}
+        for field in dataclasses.fields(cls):
+            if field.name not in data and field.default == dataclasses.MISSING:
+                raise KeyError(field.name)
+            init_kwargs[field.name] = cls.field_value_from_api_response(
+                field.name, field.type, data.get(field.name, field.default)
+            )
+        return cls(**init_kwargs)
+
+    @classmethod
+    def field_value_from_api_response(cls, field_name: str, field_type: Type[F], val: Any) -> F:
+        """Subclasses can override to handle specific fields specially."""
+        return cast(F, val)
+
+
+@dataclass(frozen=True)
+class Category(ReadmeEntity):
+    slug: str
+    title: str
+    order: int
+
+    def __str__(self):
+        return f"Category(id={self.id}, slug={self.slug}, title={self.title}, order={self.order})"
+
+
+@dataclass(frozen=True)
+class DocRef(ReadmeEntity):
+    """A reference to a doc, without its body and other details."""
+
+    slug: str
+    title: str
+    order: int
+    hidden: bool
+    children: tuple[DocRef, ...] = tuple()
+
+    @classmethod
+    def field_value_from_api_response(cls, field_name: str, field_type: Type[F], val: Any) -> F:
+        # A DocRef can have children that are themselves DocRefs. Currently readme.com only
+        # supports one level of nesting, but this code will work for any depth.
+        if field_name == "children":
+            return cast(F, tuple(cls.from_api_response(x) for x in val))
+        else:
+            return super().field_value_from_api_response(field_name, field_type, val)
+
+    def __str__(self):
+        return (
+            f"DocRef(id={self.id}, slug={self.slug}, title={self.title}, "
+            f"order={self.order}, hidden={self.hidden})"
+        )
+
+
+@dataclass(frozen=True)
+class Doc(ReadmeEntity):
+    """A full doc, including its body and other details."""
+
+    slug: str
+    title: str
+    type: str
+    version: str
+    category: str
+    hidden: bool
+    body: str
+    parentDoc: str = ""  # May be omitted in API responses if doc has no parent.
+
+    def __str__(self):
+        return (
+            f"Doc(id={self.id}, category={self.category}, slug={self.slug}, "
+            f"title={self.title}, body={self.body[:20]}...)"
+        )
+
+
+class ReadmeAPI:
+    def __init__(self, api_key: str, version: str, url_prefix: str = _API_URL_PREFIX):
+        self._api_key = api_key
+        self._version = version
+        self._url_prefix = url_prefix
+
+    def get_categories(self) -> list[Category]:
+        # https://docs.readme.com/reference/getcategories
+        logger.info("Getting categories")
+        return [Category.from_api_response(x) for x in cast(list, self._get("categories", ""))]
+
+    def get_category(self, slug: str) -> Category:
+        # https://docs.readme.com/reference/getcategory
+        logger.info(f"Getting category {slug}")
+        return Category.from_api_response(cast(dict, self._get(f"categories/{slug}", "")))
+
+    def get_docs_for_category(self, slug: str) -> list[DocRef]:
+        # https://docs.readme.com/reference/getcategorydocs
+        logger.info(f"Getting docs for category {slug}")
+        return [
+            DocRef.from_api_response(x)
+            for x in cast(list, self._get(f"categories/{slug}/docs", ""))
+        ]
+
+    def get_doc(self, slug: str) -> Doc:
+        # https://docs.readme.com/reference/getdoc
+        logger.info(f"Getting doc at slug {slug}")
+        return Doc.from_api_response(cast(dict, self._get(f"docs/{slug}", "")))
+
+    def create_doc(
+        self,
+        title: str,
+        category: str,
+        *,
+        typ: str | None = None,
+        body: str | None = None,
+        hidden: bool | None = None,
+        order: int | None = None,
+        parentDoc: str | None = None,
+    ) -> Doc:
+        logger.info(f"Creating doc with title {title}")
+        # https://docs.readme.com/reference/createdoc
+        return self._create_or_update_doc(
+            slug=None,
+            title=title,
+            category=category,
+            typ=typ,
+            body=body,
+            hidden=hidden,
+            order=order,
+            parentDoc=parentDoc,
+        )
+
+    def update_doc(
+        self,
+        slug: str,
+        title: str,
+        category: str,
+        *,
+        typ: str | None = None,
+        body: str | None = None,
+        hidden: bool | None = None,
+        order: int | None = None,
+        parentDoc: str | None = None,
+    ) -> Doc:
+        # https://docs.readme.com/reference/updatedoc
+        logger.info(f"Updating doc at slug {slug}")
+        return self._create_or_update_doc(
+            slug=slug,
+            title=title,
+            category=category,
+            typ=typ,
+            body=body,
+            hidden=hidden,
+            order=order,
+            parentDoc=parentDoc,
+        )
+
+    def delete_doc(self, slug: str) -> None:
+        # https://docs.readme.com/reference/deletedoc
+        logger.info(f"Deleting doc at slug {slug}")
+        self._delete(f"docs/{slug}", "")
+
+    def _create_or_update_doc(
+        self,
+        *,
+        slug: str | None,  # If None we create a doc, otherwise we update the doc at this slug.
+        title: str,  # Required by the API.
+        category: str,  # Required by the API.
+        typ: str | None,  # If None, the API default of "basic" will apply.
+        body: str | None,  # If None, the API default of "" will apply.
+        hidden: bool | None,  # If None, the API default of True will apply.
+        order: int | None,  # If None, the API default of 999 will apply.
+        parentDoc: str | None,  # If None, the API default of "" will apply.
+    ) -> Doc:
+        fields = {
+            "title": title,
+            "type": typ,
+            "body": body,
+            "category": category,
+            "hidden": hidden,
+            "order": order,
+            "parentDoc": parentDoc,
+        }
+        # We strip out fields that weren't provided as args, and rely on the API's defaults.
+        specified_fields = {k: v for (k, v) in fields.items() if v is not None}
+        payload = json.dumps(specified_fields)
+        if slug:
+            res = self._put(f"docs/{slug}", payload)
+        else:
+            res = self._post("docs/", payload)
+        return Doc.from_api_response(cast(dict, res))
+
+    def _get(self, endpoint: str, payload: str) -> ApiResponse:
+        return self._request("GET", endpoint, payload)
+
+    def _post(self, endpoint: str, payload: str) -> ApiResponse:
+        return self._request("POST", endpoint, payload)
+
+    def _put(self, endpoint: str, payload: str) -> ApiResponse:
+        return self._request("PUT", endpoint, payload)
+
+    def _delete(self, endpoint: str, payload: str) -> ApiResponse:
+        return self._request("DELETE", endpoint, payload)
+
+    def _request(self, method: str, endpoint: str, payload: str) -> ApiResponse:
+        """Send a request to the readme.io API."""
+        url = f"{self._url_prefix}{endpoint}"
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "x-readme-version": self._version,
+        }
+        logger.debug(f"Sending {method} request to {url}")
+        logger.debug(f"  Payload: {payload}")
+        response = requests.request(
+            method, url, data=payload, headers=headers, auth=(self._api_key, "")
+        )
+        response.raise_for_status()
+        return cast(ApiResponse, response.json()) if response.text else {}

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -68,9 +68,9 @@ class PythonInferSubsystem(Subsystem):
             default=False,
             type=bool,
             help=(
-                "Infer a target's dependencies on any __init__.py files existing for the packages "
+                "Infer a target's dependencies on any `__init__.py` files in the packages "
                 "it is located in (recursively upward in the directory structure).\n\nEven if this "
-                "is disabled, Pants will still include any ancestor __init__.py files, only they "
+                "is disabled, Pants will still include any ancestor `__init__.py` files, only they "
                 "will not be 'proper' dependencies, e.g. they will not show up in "
                 "`./pants dependencies` and their own dependencies will not be used.\n\nIf you "
                 "have empty `__init__.py` files, it's safe to leave this option off; otherwise, "

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -202,10 +202,10 @@ class PythonSetup(Subsystem):
             type=bool,
             default=True,
             advanced=True,
-            help="Don't tailor python_library targets for solitary __init__.py files, as "
+            help="Don't tailor python_library targets for solitary `__init__.py` files, as "
             "those usually exist as import scaffolding rather than true library code.\n\n"
             "Set to False if you commonly have packages containing real code in "
-            "__init__.py and there are no other .py files in the package.",
+            "`__init__.py` and there are no other .py files in the package.",
         )
 
         register(


### PR DESCRIPTION
We're currently only using the API to generate the reference docs,
and were doing so somewhat haphazardly.

But there is an increasing need for tools to sync updates across
versions, especially as we're about to make some changes
to the getting started docs. These will be easier to create with
a proper abstraction.

Note that this class only provides the parts of the API we care
about.

[ci skip-rust]

[ci skip-build-wheels]