### PR TITLE
[internal] Allow dynamically renaming macros to a different symbol

### DIFF
--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -225,7 +225,7 @@ class AstVisitor(ast.NodeVisitor):
         ):
             return
         name_keyword = next((kw for kw in node.keywords if kw.arg == "name"), None)
-        if not name_keyword:
+        if name_keyword is not None:
             return
         self.pending_renames.append(
             SymbolRename(

--- a/src/python/pants/engine/internals/parser_test.py
+++ b/src/python/pants/engine/internals/parser_test.py
@@ -115,11 +115,7 @@ def test_rewrite_macro_symbols() -> None:
         )
         + unmodified_content
     )
-    print(
-        error_on_imports_and_rewrite_caofs_to_avoid_ambiguous_symbols(
-            original, "BUILD", rename_symbols=True
-        )
-    )
+
     assert (
         error_on_imports_and_rewrite_caofs_to_avoid_ambiguous_symbols(
             original, "BUILD", rename_symbols=True

--- a/src/python/pants/engine/internals/parser_test.py
+++ b/src/python/pants/engine/internals/parser_test.py
@@ -3,10 +3,17 @@
 
 from __future__ import annotations
 
+from textwrap import dedent
+
 import pytest
 
 from pants.build_graph.build_file_aliases import BuildFileAliases
-from pants.engine.internals.parser import BuildFilePreludeSymbols, ParseError, Parser
+from pants.engine.internals.parser import (
+    BuildFilePreludeSymbols,
+    ParseError,
+    Parser,
+    error_on_imports_and_rewrite_caofs_to_avoid_ambiguous_symbols,
+)
 from pants.util.docutil import doc_url
 from pants.util.frozendict import FrozenDict
 
@@ -20,9 +27,8 @@ def test_imports_banned() -> None:
     assert "Import used in dir/BUILD at line 4" in str(exc.value)
 
 
-def test_unrecogonized_symbol() -> None:
-    def perform_test(extra_targets: list[str], dym: str) -> None:
-
+def test_unrecognized_symbol() -> None:
+    def assert_error(extra_targets: list[str], did_you_mean: str) -> None:
         parser = Parser(
             build_root="",
             target_type_aliases=["tgt", *extra_targets],
@@ -32,23 +38,97 @@ def test_unrecogonized_symbol() -> None:
             ),
         )
         prelude_symbols = BuildFilePreludeSymbols(FrozenDict({"prelude": 0}))
-        fmt_extra_sym = str(extra_targets)[1:-1] + (", ") if len(extra_targets) != 0 else ""
+
         with pytest.raises(ParseError) as exc:
             parser.parse("dir/BUILD", "fake", prelude_symbols)
+
+        fmt_extra_sym = str(extra_targets)[1:-1] + (", ") if len(extra_targets) != 0 else ""
         assert str(exc.value) == (
-            f"Name 'fake' is not defined.\n\n{dym}"
+            f"Name 'fake' is not defined.\n\n{did_you_mean}"
             "If you expect to see more symbols activated in the below list,"
             f" refer to {doc_url('enabling-backends')} for all available"
             " backends to activate.\n\n"
             f"All registered symbols: ['caof', {fmt_extra_sym}'obj', 'prelude', 'tgt']"
         )
 
-    test_targs = ["fake1", "fake2", "fake3", "fake4", "fake5"]
+    extra_targets = ["fake1", "fake2", "fake3", "fake4", "fake5"]
+    assert_error([], "")
+    assert_error(extra_targets[:1], "Did you mean fake1?\n\n")
+    assert_error(extra_targets[:2], "Did you mean fake2 or fake1?\n\n")
+    assert_error(extra_targets, "Did you mean fake5, fake4, or fake3?\n\n")
 
-    perform_test([], "")
-    dym_one = "Did you mean fake1?\n\n"
-    perform_test(test_targs[:1], dym_one)
-    dym_two = "Did you mean fake2 or fake1?\n\n"
-    perform_test(test_targs[:2], dym_two)
-    dym_many = "Did you mean fake5, fake4, or fake3?\n\n"
-    perform_test(test_targs, dym_many)
+
+def test_rewrite_macro_symbols() -> None:
+    unmodified_content = dedent(
+        """\
+        # Target generators
+        python_requirements(name="reqs")
+        python_requirements(
+            name="reqs",
+            requirements_relpath="reqs.txt",
+            module_mapping={
+                "foo": ("bar",),
+            }
+        )
+        poetry_requirements(name="gen")
+        pipenv_requirements(name="pipenv")
+        pants_requirement(name="pants")
+
+        # Other
+        x = 1 + 2
+        python_tests(sources=x, dependencies=["foo:python_requirements"])
+        """
+    )
+    original = (
+        dedent(
+            """\
+            # Macros
+            python_requirements()
+            python_requirements(
+                requirements_relpath="reqs.txt",
+                module_mapping={
+                    "foo": ("bar",),
+                }
+            )
+            poetry_requirements()
+            pipenv_requirements()
+            pants_requirement()
+            """
+        )
+        + unmodified_content
+    )
+    expected = (
+        dedent(
+            """\
+            # Macros
+            python_requirements_deprecated_macro()
+            python_requirements_deprecated_macro(
+                requirements_relpath="reqs.txt",
+                module_mapping={
+                    "foo": ("bar",),
+                }
+            )
+            poetry_requirements_deprecated_macro()
+            pipenv_requirements_deprecated_macro()
+            pants_requirement_deprecated_macro()
+            """
+        )
+        + unmodified_content
+    )
+    print(
+        error_on_imports_and_rewrite_caofs_to_avoid_ambiguous_symbols(
+            original, "BUILD", rename_symbols=True
+        )
+    )
+    assert (
+        error_on_imports_and_rewrite_caofs_to_avoid_ambiguous_symbols(
+            original, "BUILD", rename_symbols=True
+        )
+        == expected
+    )
+    assert (
+        error_on_imports_and_rewrite_caofs_to_avoid_ambiguous_symbols(
+            original, "BUILD", rename_symbols=False
+        )
+        == original
+    )


### PR DESCRIPTION
First part of https://github.com/pantsbuild/pants/issues/12915. As described there, changing our macros to be target generators is majorly disruptive because the target generator will have an address + the generated targets will have different addresses.

This PR allows us to have two conflicting implementations for macros like `python_requirements` and `poetry_requirements`: the old context-aware object factory, and the new target generator. If `name=` is set*, we use the target generator, otherwise the old macro. This means that new users will be able to use the right thing, and we can deprecate the macro for existing users.

When we add target generators, we will rename these to the deprecated symbols:

https://github.com/pantsbuild/pants/blob/528466601ee4e5bd2f5f31d8fba306b5734ea8a1/src/python/pants/backend/python/register.py#L49-L54

*I argue in https://github.com/pantsbuild/pants/issues/12286 that it's valuable to always set the `name=`, but that discussion is still pending. This heuristic does not work if we think it's important that you can leave off `name=` for `pants_requirement`, `python_requirements`, `poetry_requirements`, and `pipenv_requirements`.

[ci skip-rust]
[ci skip-build-wheels]