### PR TITLE
[internal] Validate that generated addresses are well-formed

### DIFF
--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -136,6 +136,7 @@ async def generate_mock_generated_target(request: MockGenerateTargetsRequest) ->
     paths = await Get(SourcesPaths, SourcesPathsRequest(request.generator[Sources]))
     # Generate using both "file address" and "generated target" syntax.
     return GeneratedTargets(
+        request.generator,
         [
             *generate_file_level_targets(
                 MockGeneratedTarget, request.generator, paths.files, None
@@ -147,7 +148,7 @@ async def generate_mock_generated_target(request: MockGenerateTargetsRequest) ->
                 None,
                 use_generated_address_syntax=True,
             ).values(),
-        ]
+        ],
     )
 
 

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -714,20 +714,20 @@ class GeneratedTargets(FrozenDict[Address, Target]):
         mapping = {}
         for tgt in generated_targets:
             if tgt.address.spec_path != expected_spec_path:
-                raise ValueError(
+                raise InvalidGeneratedTargetException(
                     "All generated targets must have the same `Address.spec_path` as their "
                     f"target generator. Expected {generator.address.spec_path}, but got "
                     f"{tgt.address.spec_path} for target generated from {generator.address}: {tgt}"
                 )
             if tgt.address.target_name != expected_tgt_name:
-                raise ValueError(
+                raise InvalidGeneratedTargetException(
                     "All generated targets must have the same `Address.target_name` as their "
                     f"target generator. Expected {generator.address.target_name}, but got "
                     f"{tgt.address.target_name} for target generated from {generator.address}: "
                     f"{tgt}"
                 )
             if not tgt.address.is_generated_target:
-                raise ValueError(
+                raise InvalidGeneratedTargetException(
                     "All generated targets must set `Address.generator_name` or "
                     "`Address.relative_file_path`. Invalid for target generated from "
                     f"{generator.address}: {tgt}"
@@ -997,6 +997,10 @@ class InvalidTargetException(Exception):
 
          f"The `{repr(alias)}` target {address} ..."
     """
+
+
+class InvalidGeneratedTargetException(InvalidTargetException):
+    pass
 
 
 class InvalidFieldException(Exception):

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -708,8 +708,32 @@ class GenerateTargetsRequest(Generic[_Tgt]):
 class GeneratedTargets(FrozenDict[Address, Target]):
     """A mapping of the address of generated targets to the targets themselves."""
 
-    def __init__(self, generated_targets: Iterable[Target]) -> None:
-        super().__init__({tgt.address: tgt for tgt in generated_targets})
+    def __init__(self, generator: Target, generated_targets: Iterable[Target]) -> None:
+        expected_spec_path = generator.address.spec_path
+        expected_tgt_name = generator.address.target_name
+        mapping = {}
+        for tgt in generated_targets:
+            if tgt.address.spec_path != expected_spec_path:
+                raise ValueError(
+                    "All generated targets must have the same `Address.spec_path` as their "
+                    f"target generator. Expected {generator.address.spec_path}, but got "
+                    f"{tgt.address.spec_path} for target generated from {generator.address}: {tgt}"
+                )
+            if tgt.address.target_name != expected_tgt_name:
+                raise ValueError(
+                    "All generated targets must have the same `Address.target_name` as their "
+                    f"target generator. Expected {generator.address.target_name}, but got "
+                    f"{tgt.address.target_name} for target generated from {generator.address}: "
+                    f"{tgt}"
+                )
+            if not tgt.address.is_generated_target:
+                raise ValueError(
+                    "All generated targets must set `Address.generator_name` or "
+                    "`Address.relative_file_path`. Invalid for target generated from "
+                    f"{generator.address}: {tgt}"
+                )
+            mapping[tgt.address] = tgt
+        super().__init__(mapping)
 
 
 class TargetTypesToGenerateTargetsRequests(FrozenDict[Type[Target], Type[GenerateTargetsRequest]]):
@@ -768,7 +792,7 @@ def generate_file_level_targets(
         )
         return generated_target_cls(generated_target_fields, address, union_membership)
 
-    return GeneratedTargets(gen_tgt(fp) for fp in paths)
+    return GeneratedTargets(generator, (gen_tgt(fp) for fp in paths))
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -454,6 +454,7 @@ def test_generate_file_level_targets() -> None:
 
     tgt = MockGenerator({Sources.alias: ["f1.ext", "f2.ext"], Tags.alias: ["tag"]}, Address("demo"))
     assert generate(tgt, ["demo/f1.ext", "demo/f2.ext"]) == GeneratedTargets(
+        tgt,
         [
             MockGenerated(
                 {Sources.alias: ["f1.ext"], Tags.alias: ["tag"]},
@@ -463,29 +464,31 @@ def test_generate_file_level_targets() -> None:
                 {Sources.alias: ["f2.ext"], Tags.alias: ["tag"]},
                 Address("demo", relative_file_path="f2.ext"),
             ),
-        ]
+        ],
     )
 
     subdir_tgt = MockGenerator(
         {Sources.alias: ["demo.f95", "subdir/demo.f95"]}, Address("src/fortran", target_name="demo")
     )
     assert generate(subdir_tgt, ["src/fortran/subdir/demo.f95"]) == GeneratedTargets(
+        subdir_tgt,
         [
             MockGenerated(
                 {Sources.alias: ["subdir/demo.f95"]},
                 Address("src/fortran", target_name="demo", relative_file_path="subdir/demo.f95"),
             )
-        ]
+        ],
     )
     assert generate(
         subdir_tgt, ["src/fortran/subdir/demo.f95"], use_generated_addr_syntax=True
     ) == GeneratedTargets(
+        subdir_tgt,
         [
             MockGenerated(
                 {Sources.alias: ["subdir/demo.f95"]},
                 Address("src/fortran", target_name="demo", generated_name="subdir/demo.f95"),
             )
-        ]
+        ],
     )
 
     # The file path must match the filespec of the generator target's Sources field.
@@ -503,6 +506,58 @@ def test_generate_file_level_targets() -> None:
     with pytest.raises(AssertionError) as exc:
         generate(missing_fields_tgt, ["fake.txt"])
     assert "does not have both a `dependencies` and `sources` field" in str(exc.value)
+
+
+def test_generated_targets_address_validation() -> None:
+    """Ensure that all addresses are well formed."""
+
+    class MockTarget(Target):
+        alias = "tgt"
+        core_fields = ()
+
+    generator = MockTarget({}, Address("dir", target_name="generator"))
+    with pytest.raises(ValueError):
+        GeneratedTargets(
+            generator,
+            [
+                MockTarget(
+                    {}, Address("a_different_dir", target_name="generator", generated_name="gen")
+                )
+            ],
+        )
+    with pytest.raises(ValueError):
+        GeneratedTargets(
+            generator,
+            [
+                MockTarget(
+                    {}, Address("dir", target_name="a_different_generator", generated_name="gen")
+                )
+            ],
+        )
+    with pytest.raises(ValueError):
+        GeneratedTargets(
+            generator,
+            [
+                MockTarget(
+                    {},
+                    Address(
+                        "dir",
+                        target_name="a_different_generator",
+                        generated_name=None,
+                        relative_file_path=None,
+                    ),
+                )
+            ],
+        )
+
+    # These are fine.
+    GeneratedTargets(
+        generator,
+        [
+            MockTarget({}, Address("dir", target_name="generator", generated_name="gen")),
+            MockTarget({}, Address("dir", target_name="generator", relative_file_path="gen")),
+        ],
+    )
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -23,6 +23,7 @@ from pants.engine.target import (
     InvalidFieldChoiceException,
     InvalidFieldException,
     InvalidFieldTypeException,
+    InvalidGeneratedTargetException,
     InvalidTargetException,
     NestedDictStringToStringField,
     RequiredFieldMissingException,
@@ -516,7 +517,7 @@ def test_generated_targets_address_validation() -> None:
         core_fields = ()
 
     generator = MockTarget({}, Address("dir", target_name="generator"))
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidGeneratedTargetException):
         GeneratedTargets(
             generator,
             [
@@ -525,7 +526,7 @@ def test_generated_targets_address_validation() -> None:
                 )
             ],
         )
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidGeneratedTargetException):
         GeneratedTargets(
             generator,
             [
@@ -534,7 +535,7 @@ def test_generated_targets_address_validation() -> None:
                 )
             ],
         )
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidGeneratedTargetException):
         GeneratedTargets(
             generator,
             [


### PR DESCRIPTION
Things will not work correctly if you generate a bad Address. This catches that issue eagerly.

[ci skip-rust]
[ci skip-build-wheels]