### PR TITLE
[internal] jvm: split Coordinate into fields for each coordinate component

### DIFF
--- a/src/python/pants/backend/java/compile/javac_test.py
+++ b/src/python/pants/backend/java/compile/javac_test.py
@@ -623,7 +623,7 @@ def test_compile_with_maven_deps(rule_runner: RuleRunner) -> None:
     resolved_joda_lockfile = CoursierResolvedLockfile(
         entries=(
             CoursierLockfileEntry(
-                coord=Coordinate(coord="joda-time:joda-time:2.10.10"),
+                coord=Coordinate(group="joda-time", artifact="joda-time", version="2.10.10"),
                 file_name="joda-time-2.10.10.jar",
                 direct_dependencies=Coordinates([]),
                 dependencies=Coordinates([]),

--- a/src/python/pants/backend/java/test/junit.py
+++ b/src/python/pants/backend/java/test/junit.py
@@ -19,11 +19,12 @@ from pants.engine.target import (
 )
 from pants.engine.unions import UnionRule
 from pants.jvm.resolve.coursier_fetch import (
+    ArtifactRequirements,
+    Coordinate,
     CoursierLockfileForTargetRequest,
     CoursierResolvedLockfile,
     MaterializedClasspath,
     MaterializedClasspathRequest,
-    MavenRequirements,
 )
 from pants.jvm.resolve.coursier_setup import Coursier
 from pants.util.logging import LogLevel
@@ -56,14 +57,25 @@ async def run_junit_test(
         MaterializedClasspathRequest(
             prefix="__thirdpartycp",
             lockfiles=(lockfile,),
-            maven_requirements=(
-                MavenRequirements.create_from_maven_coordinates_fields(
-                    fields=(),
-                    additional_requirements=[
-                        "org.junit.platform:junit-platform-console:1.7.2",
-                        "org.junit.jupiter:junit-jupiter-engine:5.7.2",
-                        "org.junit.vintage:junit-vintage-engine:5.7.2",
-                    ],
+            artifact_requirements=(
+                ArtifactRequirements(
+                    [
+                        Coordinate(
+                            group="org.junit.platform",
+                            artifact="junit-platform-console",
+                            version="1.7.2",
+                        ),
+                        Coordinate(
+                            group="org.junit.jupiter",
+                            artifact="junit-jupiter-engine",
+                            version="5.7.2",
+                        ),
+                        Coordinate(
+                            group="org.junit.vintage",
+                            artifact="junit-vintage-engine",
+                            version="5.7.2",
+                        ),
+                    ]
                 ),
             ),
         ),

--- a/src/python/pants/backend/java/test/junit_test.py
+++ b/src/python/pants/backend/java/test/junit_test.py
@@ -76,17 +76,21 @@ def rule_runner() -> RuleRunner:
 JUNIT4_RESOLVED_LOCKFILE = CoursierResolvedLockfile(
     entries=(
         CoursierLockfileEntry(
-            coord=Coordinate(coord="junit:junit:4.13.2"),
+            coord=Coordinate(group="junit", artifact="junit", version="4.13.2"),
             file_name="junit-4.13.2.jar",
-            direct_dependencies=Coordinates([Coordinate(coord="org.hamcrest:hamcrest-core:1.3")]),
-            dependencies=Coordinates([Coordinate(coord="org.hamcrest:hamcrest-core:1.3")]),
+            direct_dependencies=Coordinates(
+                [Coordinate(group="org.hamcrest", artifact="hamcrest-core", version="1.3")]
+            ),
+            dependencies=Coordinates(
+                [Coordinate(group="org.hamcrest", artifact="hamcrest-core", version="1.3")]
+            ),
             file_digest=FileDigest(
                 fingerprint="8e495b634469d64fb8acfa3495a065cbacc8a0fff55ce1e31007be4c16dc57d3",
                 serialized_bytes_length=384581,
             ),
         ),
         CoursierLockfileEntry(
-            coord=Coordinate(coord="org.hamcrest:hamcrest-core:1.3"),
+            coord=Coordinate(group="org.hamcrest", artifact="hamcrest-core", version="1.3"),
             file_name="hamcrest-core-1.3.jar",
             direct_dependencies=Coordinates([]),
             dependencies=Coordinates([]),
@@ -296,7 +300,7 @@ def test_vintage_success_with_dep(rule_runner: RuleRunner) -> None:
 JUNIT5_RESOLVED_LOCKFILE = CoursierResolvedLockfile(
     entries=(
         CoursierLockfileEntry(
-            coord=Coordinate(coord="org.apiguardian:apiguardian-api:1.1.0"),
+            coord=Coordinate(group="org.apiguardian", artifact="apiguardian-api", version="1.1.0"),
             file_name="apiguardian-api-1.1.0.jar",
             direct_dependencies=Coordinates([]),
             dependencies=Coordinates([]),
@@ -306,20 +310,34 @@ JUNIT5_RESOLVED_LOCKFILE = CoursierResolvedLockfile(
             ),
         ),
         CoursierLockfileEntry(
-            coord=Coordinate(coord="org.junit.jupiter:junit-jupiter-api:5.7.2"),
+            coord=Coordinate(
+                group="org.junit.jupiter", artifact="junit-jupiter-api", version="5.7.2"
+            ),
             file_name="junit-jupiter-api-5.7.2.jar",
             direct_dependencies=Coordinates(
                 [
-                    Coordinate(coord="org.apiguardian:apiguardian-api:1.1.0"),
-                    Coordinate(coord="org.junit.platform:junit-platform-commons:1.7.2"),
-                    Coordinate(coord="org.opentest4j:opentest4j:1.2.0"),
+                    Coordinate(
+                        group="org.apiguardian", artifact="apiguardian-api", version="1.1.0"
+                    ),
+                    Coordinate(
+                        group="org.junit.platform",
+                        artifact="junit-platform-commons",
+                        version="1.7.2",
+                    ),
+                    Coordinate(group="org.opentest4j", artifact="opentest4j", version="1.2.0"),
                 ]
             ),
             dependencies=Coordinates(
                 [
-                    Coordinate(coord="org.apiguardian:apiguardian-api:1.1.0"),
-                    Coordinate(coord="org.junit.platform:junit-platform-commons:1.7.2"),
-                    Coordinate(coord="org.opentest4j:opentest4j:1.2.0"),
+                    Coordinate(
+                        group="org.apiguardian", artifact="apiguardian-api", version="1.1.0"
+                    ),
+                    Coordinate(
+                        group="org.junit.platform",
+                        artifact="junit-platform-commons",
+                        version="1.7.2",
+                    ),
+                    Coordinate(group="org.opentest4j", artifact="opentest4j", version="1.2.0"),
                 ]
             ),
             file_digest=FileDigest(
@@ -328,19 +346,23 @@ JUNIT5_RESOLVED_LOCKFILE = CoursierResolvedLockfile(
             ),
         ),
         CoursierLockfileEntry(
-            coord=Coordinate(coord="org.junit.platform:junit-platform-commons:1.7.2"),
+            coord=Coordinate(
+                group="org.junit.platform", artifact="junit-platform-commons", version="1.7.2"
+            ),
             file_name="junit-platform-commons-1.7.2.jar",
             direct_dependencies=Coordinates(
-                [Coordinate(coord="org.apiguardian:apiguardian-api:1.1.0")]
+                [Coordinate(group="org.apiguardian", artifact="apiguardian-api", version="1.1.0")]
             ),
-            dependencies=Coordinates([Coordinate(coord="org.apiguardian:apiguardian-api:1.1.0")]),
+            dependencies=Coordinates(
+                [Coordinate(group="org.apiguardian", artifact="apiguardian-api", version="1.1.0")]
+            ),
             file_digest=FileDigest(
                 fingerprint="738d0df021a0611fff5d277634e890cc91858fa72227cf0bcf36232a7caf014c",
                 serialized_bytes_length=100008,
             ),
         ),
         CoursierLockfileEntry(
-            coord=Coordinate(coord="org.opentest4j:opentest4j:1.2.0"),
+            coord=Coordinate(group="org.opentest4j", artifact="opentest4j", version="1.2.0"),
             file_name="opentest4j-1.2.0.jar",
             direct_dependencies=Coordinates([]),
             dependencies=Coordinates([]),
@@ -370,8 +392,8 @@ def test_jupiter_simple_success(rule_runner: RuleRunner) -> None:
                 )
 
                 junit_tests(
-                    name='example-test',
-                    dependencies= [':lockfile'],
+                    name = 'example-test',
+                    dependencies = [':lockfile'],
                 )
                 """
             ),
@@ -476,7 +498,9 @@ def test_jupiter_success_with_dep(rule_runner: RuleRunner) -> None:
                 """\
                 coursier_lockfile(
                     name = 'lockfile',
-                    maven_requirements = ['org.junit.jupiter:junit-jupiter-api:5.7.2'],
+                    maven_requirements = [
+                        'org.junit.jupiter:junit-jupiter-api:5.7.2',
+                    ],
                     sources = [
                         "coursier_resolve.lockfile",
                     ],
@@ -608,6 +632,8 @@ def test_vintage_and_jupiter_simple_success(rule_runner: RuleRunner) -> None:
         ],
     )
     assert test_result.exit_code == 0
+    # TODO: Once support for parsing junit.xml is implemented, use that to determine status so we can remove the
+    #  hack to use ASCII test output in the `run_junit_test` rule.
     assert re.search(r"Finished:\s+testHello", test_result.stdout) is not None
     assert re.search(r"Finished:\s+testGoodbye", test_result.stdout) is not None
     assert re.search(r"2 tests successful", test_result.stdout) is not None

--- a/src/python/pants/jvm/goals/coursier.py
+++ b/src/python/pants/jvm/goals/coursier.py
@@ -21,7 +21,7 @@ from pants.engine.fs import (
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
 from pants.engine.target import Sources, Target, Targets
-from pants.jvm.resolve.coursier_fetch import CoursierResolvedLockfile, MavenRequirements
+from pants.jvm.resolve.coursier_fetch import ArtifactRequirements, CoursierResolvedLockfile
 from pants.jvm.target_types import JvmLockfileSources, MavenRequirementsField
 
 
@@ -58,8 +58,8 @@ async def coursier_generate_lockfile(
 ) -> CoursierGenerateLockfileResult:
     resolved_lockfile = await Get(
         CoursierResolvedLockfile,
-        MavenRequirements,
-        MavenRequirements.create_from_maven_coordinates_fields(
+        ArtifactRequirements,
+        ArtifactRequirements.create_from_maven_coordinates_fields(
             fields=(request.target[MavenRequirementsField],),
         ),
     )

--- a/src/python/pants/jvm/goals/coursier_integration_test.py
+++ b/src/python/pants/jvm/goals/coursier_integration_test.py
@@ -25,6 +25,12 @@ from pants.jvm.target_types import JvmDependencyLockfile
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import RuleRunner
 
+HAMCREST_COORD = Coordinate(
+    group="org.hamcrest",
+    artifact="hamcrest-core",
+    version="1.3",
+)
+
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
@@ -64,7 +70,7 @@ def test_coursier_resolve_creates_missing_lockfile(rule_runner: RuleRunner) -> N
     expected_lockfile = CoursierResolvedLockfile(
         entries=(
             CoursierLockfileEntry(
-                coord=Coordinate(coord="org.hamcrest:hamcrest-core:1.3"),
+                coord=HAMCREST_COORD,
                 file_name="hamcrest-core-1.3.jar",
                 direct_dependencies=Coordinates([]),
                 dependencies=Coordinates([]),
@@ -85,7 +91,7 @@ def test_coursier_resolve_noop_does_not_touch_lockfile(rule_runner: RuleRunner) 
     expected_lockfile = CoursierResolvedLockfile(
         entries=(
             CoursierLockfileEntry(
-                coord=Coordinate(coord="org.hamcrest:hamcrest-core:1.3"),
+                coord=HAMCREST_COORD,
                 file_name="hamcrest-core-1.3.jar",
                 direct_dependencies=Coordinates([]),
                 dependencies=Coordinates([]),
@@ -141,7 +147,7 @@ def test_coursier_resolve_updates_lockfile(rule_runner: RuleRunner) -> None:
     expected_lockfile = CoursierResolvedLockfile(
         entries=(
             CoursierLockfileEntry(
-                coord=Coordinate(coord="org.hamcrest:hamcrest-core:1.3"),
+                coord=HAMCREST_COORD,
                 file_name="hamcrest-core-1.3.jar",
                 direct_dependencies=Coordinates([]),
                 dependencies=Coordinates([]),
@@ -180,7 +186,7 @@ def test_coursier_resolve_updates_bogus_lockfile(rule_runner: RuleRunner) -> Non
     expected_lockfile = CoursierResolvedLockfile(
         entries=(
             CoursierLockfileEntry(
-                coord=Coordinate(coord="org.hamcrest:hamcrest-core:1.3"),
+                coord=HAMCREST_COORD,
                 file_name="hamcrest-core-1.3.jar",
                 direct_dependencies=Coordinates([]),
                 dependencies=Coordinates([]),

--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -10,11 +10,11 @@ from pants.core.util_rules.external_tool import rules as external_tool_rules
 from pants.engine.fs import FileDigest
 from pants.engine.internals.scheduler import ExecutionError
 from pants.jvm.resolve.coursier_fetch import (
+    ArtifactRequirements,
     Coordinate,
     Coordinates,
     CoursierLockfileEntry,
     CoursierResolvedLockfile,
-    MavenRequirements,
     ResolvedClasspathEntry,
 )
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
@@ -23,6 +23,12 @@ from pants.jvm.target_types import JvmDependencyLockfile
 from pants.jvm.util_rules import ExtractFileDigest
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+HAMCREST_COORD = Coordinate(
+    group="org.hamcrest",
+    artifact="hamcrest-core",
+    version="1.3",
+)
 
 
 @pytest.fixture
@@ -35,7 +41,7 @@ def rule_runner() -> RuleRunner:
             *external_tool_rules(),
             *source_files.rules(),
             *util_rules(),
-            QueryRule(CoursierResolvedLockfile, (MavenRequirements,)),
+            QueryRule(CoursierResolvedLockfile, (ArtifactRequirements,)),
             QueryRule(ResolvedClasspathEntry, (CoursierLockfileEntry,)),
             QueryRule(FileDigest, (ExtractFileDigest,)),
         ],
@@ -46,11 +52,7 @@ def rule_runner() -> RuleRunner:
 def test_empty_resolve(rule_runner: RuleRunner) -> None:
     resolved_lockfile = rule_runner.request(
         CoursierResolvedLockfile,
-        [
-            MavenRequirements.create_from_maven_coordinates_fields(
-                fields=(),
-            )
-        ],
+        [ArtifactRequirements([])],
     )
     assert resolved_lockfile == CoursierResolvedLockfile(entries=())
 
@@ -61,17 +63,12 @@ def test_empty_resolve(rule_runner: RuleRunner) -> None:
 def test_resolve_with_no_deps(rule_runner: RuleRunner) -> None:
     resolved_lockfile = rule_runner.request(
         CoursierResolvedLockfile,
-        [
-            MavenRequirements.create_from_maven_coordinates_fields(
-                fields=(),
-                additional_requirements=["org.hamcrest:hamcrest-core:1.3"],
-            )
-        ],
+        [ArtifactRequirements([HAMCREST_COORD])],
     )
     assert resolved_lockfile == CoursierResolvedLockfile(
         entries=(
             CoursierLockfileEntry(
-                coord=Coordinate(coord="org.hamcrest:hamcrest-core:1.3"),
+                coord=HAMCREST_COORD,
                 file_name="hamcrest-core-1.3.jar",
                 direct_dependencies=Coordinates([]),
                 dependencies=Coordinates([]),
@@ -85,32 +82,28 @@ def test_resolve_with_no_deps(rule_runner: RuleRunner) -> None:
 
 
 def test_resolve_with_transitive_deps(rule_runner: RuleRunner) -> None:
+    junit_coord = Coordinate(group="junit", artifact="junit", version="4.13.2")
     resolved_lockfile = rule_runner.request(
         CoursierResolvedLockfile,
         [
-            MavenRequirements.create_from_maven_coordinates_fields(
-                fields=(),
-                additional_requirements=["junit:junit:4.13.2"],
-            )
+            ArtifactRequirements([junit_coord]),
         ],
     )
 
     assert resolved_lockfile == CoursierResolvedLockfile(
         entries=(
             CoursierLockfileEntry(
-                coord=Coordinate(coord="junit:junit:4.13.2"),
+                coord=junit_coord,
                 file_name="junit-4.13.2.jar",
-                direct_dependencies=Coordinates(
-                    [Coordinate(coord="org.hamcrest:hamcrest-core:1.3")]
-                ),
-                dependencies=Coordinates([Coordinate(coord="org.hamcrest:hamcrest-core:1.3")]),
+                direct_dependencies=Coordinates([HAMCREST_COORD]),
+                dependencies=Coordinates([HAMCREST_COORD]),
                 file_digest=FileDigest(
                     fingerprint="8e495b634469d64fb8acfa3495a065cbacc8a0fff55ce1e31007be4c16dc57d3",
                     serialized_bytes_length=384581,
                 ),
             ),
             CoursierLockfileEntry(
-                coord=Coordinate(coord="org.hamcrest:hamcrest-core:1.3"),
+                coord=HAMCREST_COORD,
                 file_name="hamcrest-core-1.3.jar",
                 direct_dependencies=Coordinates([]),
                 dependencies=Coordinates([]),
@@ -127,21 +120,18 @@ def test_resolve_with_inexact_coord(rule_runner: RuleRunner) -> None:
     resolved_lockfile = rule_runner.request(
         CoursierResolvedLockfile,
         [
-            MavenRequirements.create_from_maven_coordinates_fields(
-                fields=(),
-                # Note the open-ended coordinate here.  We will still resolve this for the user, but the result
-                # will be exact and pinned.  As noted above, this is an especially brittle unit test, but version
-                # 4.8 was chosen because it has multiple patch versions and no new versions have been uploaded
-                # to 4.8.x in over a decade.
-                additional_requirements=["junit:junit:4.8+"],
-            )
+            # Note the open-ended coordinate here.  We will still resolve this for the user, but the result
+            # will be exact and pinned.  As noted above, this is an especially brittle unit test, but version
+            # 4.8 was chosen because it has multiple patch versions and no new versions have been uploaded
+            # to 4.8.x in over a decade.
+            ArtifactRequirements([Coordinate(group="junit", artifact="junit", version="4.8+")]),
         ],
     )
 
     assert resolved_lockfile == CoursierResolvedLockfile(
         entries=(
             CoursierLockfileEntry(
-                coord=Coordinate(coord="junit:junit:4.8.2"),
+                coord=Coordinate(group="junit", artifact="junit", version="4.8.2"),
                 file_name="junit-4.8.2.jar",
                 direct_dependencies=Coordinates([]),
                 dependencies=Coordinates([]),
@@ -160,7 +150,7 @@ def test_fetch_one_coord_with_no_deps(rule_runner: RuleRunner) -> None:
         ResolvedClasspathEntry,
         [
             CoursierLockfileEntry(
-                coord=Coordinate(coord="org.hamcrest:hamcrest-core:1.3"),
+                coord=HAMCREST_COORD,
                 file_name="hamcrest-core-1.3.jar",
                 direct_dependencies=Coordinates([]),
                 dependencies=Coordinates([]),
@@ -171,7 +161,7 @@ def test_fetch_one_coord_with_no_deps(rule_runner: RuleRunner) -> None:
             )
         ],
     )
-    assert classpath_entry.coord == Coordinate(coord="org.hamcrest:hamcrest-core:1.3")
+    assert classpath_entry.coord == HAMCREST_COORD
     assert classpath_entry.file_name == "hamcrest-core-1.3.jar"
     file_digest = rule_runner.request(
         FileDigest, [ExtractFileDigest(classpath_entry.digest, "hamcrest-core-1.3.jar")]
@@ -183,17 +173,15 @@ def test_fetch_one_coord_with_no_deps(rule_runner: RuleRunner) -> None:
 
 
 def test_fetch_one_coord_with_transitive_deps(rule_runner: RuleRunner) -> None:
-
+    junit_coord = Coordinate(group="junit", artifact="junit", version="4.13.2")
     classpath_entry = rule_runner.request(
         ResolvedClasspathEntry,
         [
             CoursierLockfileEntry(
-                coord=Coordinate(coord="junit:junit:4.13.2"),
+                coord=junit_coord,
                 file_name="junit-4.13.2.jar",
-                direct_dependencies=Coordinates(
-                    [Coordinate(coord="org.hamcrest:hamcrest-core:1.3")]
-                ),
-                dependencies=Coordinates([Coordinate(coord="org.hamcrest:hamcrest-core:1.3")]),
+                direct_dependencies=Coordinates([HAMCREST_COORD]),
+                dependencies=Coordinates([HAMCREST_COORD]),
                 file_digest=FileDigest(
                     fingerprint="8e495b634469d64fb8acfa3495a065cbacc8a0fff55ce1e31007be4c16dc57d3",
                     serialized_bytes_length=384581,
@@ -201,7 +189,7 @@ def test_fetch_one_coord_with_transitive_deps(rule_runner: RuleRunner) -> None:
             )
         ],
     )
-    assert classpath_entry.coord == Coordinate(coord="junit:junit:4.13.2")
+    assert classpath_entry.coord == junit_coord
     assert classpath_entry.file_name == "junit-4.13.2.jar"
     file_digest = rule_runner.request(
         FileDigest, [ExtractFileDigest(classpath_entry.digest, "junit-4.13.2.jar")]
@@ -219,7 +207,7 @@ def test_fetch_one_coord_with_bad_fingerprint(rule_runner: RuleRunner) -> None:
         r"did not match.*?ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     )
     lockfile_entry = CoursierLockfileEntry(
-        coord=Coordinate(coord="org.hamcrest:hamcrest-core:1.3"),
+        coord=HAMCREST_COORD,
         file_name="hamcrest-core-1.3.jar",
         direct_dependencies=Coordinates([]),
         dependencies=Coordinates([]),
@@ -241,7 +229,7 @@ def test_fetch_one_coord_with_bad_length(rule_runner: RuleRunner) -> None:
         r"serialized_bytes_length=1\).*?"
     )
     lockfile_entry = CoursierLockfileEntry(
-        coord=Coordinate(coord="org.hamcrest:hamcrest-core:1.3"),
+        coord=HAMCREST_COORD,
         file_name="hamcrest-core-1.3.jar",
         direct_dependencies=Coordinates([]),
         dependencies=Coordinates([]),
@@ -268,7 +256,7 @@ def test_fetch_one_coord_with_mismatched_coord(rule_runner: RuleRunner) -> None:
         r'does not match requested coord.*?"org.hamcrest:hamcrest-core:1.3\+".*?'
     )
     lockfile_entry = CoursierLockfileEntry(
-        coord=Coordinate(coord="org.hamcrest:hamcrest-core:1.3+"),
+        coord=Coordinate(group="org.hamcrest", artifact="hamcrest-core", version="1.3+"),
         file_name="hamcrest-core-1.3.jar",
         direct_dependencies=Coordinates([]),
         dependencies=Coordinates([]),


### PR DESCRIPTION
Introduce separate fields in `Coordinate` for each component of the artifact's coordinate (i.e., group, artifact, version, and packaging). This does not change the user-visible side of specifying artifacts which will be made in a separate PR.

This PR was split from #12897.

[ci skip-rust]

[ci skip-build-wheels]