### PR TITLE
[internal] terraform: fix target generation for API change

### DIFF
--- a/src/python/pants/backend/terraform/target_gen.py
+++ b/src/python/pants/backend/terraform/target_gen.py
@@ -59,7 +59,9 @@ async def generate_terraform_module_targets(
             ),
         )
 
-    return GeneratedTargets(gen_target(dir) for dir in dirs_with_terraform_files)
+    return GeneratedTargets(
+        request.generator, [gen_target(dir) for dir in dirs_with_terraform_files]
+    )
 
 
 def rules():

--- a/src/python/pants/backend/terraform/target_gen_test.py
+++ b/src/python/pants/backend/terraform/target_gen_test.py
@@ -47,6 +47,7 @@ def test_target_generation(rule_runner: RuleRunner) -> None:
         GeneratedTargets, [GenerateTerraformModuleTargetsRequest(generator)]
     )
     assert targets == GeneratedTargets(
+        generator,
         [
             TerraformModule(
                 {
@@ -63,5 +64,5 @@ def test_target_generation(rule_runner: RuleRunner) -> None:
                 },
                 Address("", target_name="tf_mods", generated_name="src/tf"),
             ),
-        ]
+        ],
     )


### PR DESCRIPTION
The API changed between when https://github.com/pantsbuild/pants/pull/12910 was approved and when I landed it (without rebasing). Fix the target_gen rule for the API change.

[ci skip-rust]

[ci skip-build-wheels]