### PR TITLE
[internal] terraform: update tailor to use terraform_modules generator

### DIFF
--- a/src/python/pants/backend/terraform/BUILD
+++ b/src/python/pants/backend/terraform/BUILD
@@ -5,7 +5,7 @@ python_library(dependencies=[":lockfile"])
 
 resources(name="lockfile", sources=["hcl2_lockfile.txt"])
 
-python_tests(name='tests', sources=["!dependency_inference_test.py"])
+python_tests(name='tests', sources=["*_test.py", "!dependency_inference_test.py"])
 python_tests(
   name="dependency_inference_test",
   sources=["dependency_inference_test.py"],

--- a/src/python/pants/backend/terraform/tailor.py
+++ b/src/python/pants/backend/terraform/tailor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import PurePath
+from typing import Iterable
 
 from pants.backend.terraform.target_types import TerraformModules
 from pants.core.goals.tailor import (
@@ -20,7 +21,7 @@ from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 
 
-def longest_common_prefix(x, y):
+def longest_common_prefix(x: tuple[str, ...], y: tuple[str, ...]) -> tuple[str, ...]:
     """Find the longest common prefix between two sequences."""
 
     i = j = 0
@@ -33,7 +34,9 @@ def longest_common_prefix(x, y):
     return x[:i]
 
 
-def find_disjoint_longest_common_prefixes(raw_values):
+def find_disjoint_longest_common_prefixes(
+    raw_values: Iterable[tuple[str, ...]]
+) -> set[tuple[str, ...]]:
     values = sorted(raw_values)
 
     if len(values) == 0:
@@ -59,7 +62,7 @@ def find_disjoint_longest_common_prefixes(raw_values):
             current_prefix = values[i]
         i += 1
 
-    # Recod any prefix from the last run of items.
+    # Record any prefix from the last run of items.
     if current_prefix:
         prefixes.add(current_prefix)
 

--- a/src/python/pants/backend/terraform/tailor.py
+++ b/src/python/pants/backend/terraform/tailor.py
@@ -3,16 +3,67 @@
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
+from pathlib import PurePath
 
 from pants.backend.terraform.target_types import TerraformModules
-from pants.core.goals.tailor import PutativeTarget, PutativeTargets, PutativeTargetsRequest
+from pants.core.goals.tailor import (
+    PutativeTarget,
+    PutativeTargets,
+    PutativeTargetsRequest,
+    group_by_dir,
+)
 from pants.engine.fs import PathGlobs, Paths
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
+
+
+def longest_common_prefix(x, y):
+    """Find the longest common prefix between two sequences."""
+
+    i = j = 0
+    while i < len(x) and j < len(y):
+        if x[i] != y[j]:
+            break
+        i = i + 1
+        j = j + 1
+
+    return x[:i]
+
+
+def find_disjoint_longest_common_prefixes(raw_values):
+    values = sorted(raw_values)
+
+    if len(values) == 0:
+        return set()
+    elif len(values) == 1:
+        return set(values)
+
+    prefixes = set()
+    current_prefix = values[0]
+
+    i = 1
+    while i < len(values):
+        potential_prefix = longest_common_prefix(current_prefix, values[i])
+        if potential_prefix:
+            # If this item still has any common prefix with the current run of items, then
+            # update the prefix to this potential prefix.
+            current_prefix = potential_prefix
+        else:
+            # If there is no common prefix between this item and the current run of items, then
+            # this run of items with a common prefix has ended. Record the current prefix and make
+            # the current item be the next current prefix.
+            prefixes.add(current_prefix)
+            current_prefix = values[i]
+        i += 1
+
+    # Recod any prefix from the last run of items.
+    if current_prefix:
+        prefixes.add(current_prefix)
+
+    return prefixes
 
 
 @dataclass(frozen=True)
@@ -21,20 +72,28 @@ class PutativeTerraformTargetsRequest(PutativeTargetsRequest):
 
 
 @rule(level=LogLevel.DEBUG, desc="Determine candidate Terraform targets to create")
-async def find_putative_targets(request: PutativeTerraformTargetsRequest) -> PutativeTargets:
-    putative_targets = []
-
+async def find_putative_terrform_modules_targets(
+    request: PutativeTerraformTargetsRequest,
+) -> PutativeTargets:
     all_terraform_files = await Get(Paths, PathGlobs, request.search_paths.path_globs("*.tf"))
-    if all_terraform_files:
-        # Add a terraform_modules() top-level generator target if any Terraform files are present.
-        putative_targets.append(
-            PutativeTarget.for_target_type(
-                TerraformModules,
-                "",
-                "tf_mods",
-                [os.path.join(search_path, "**/*.tf") for search_path in request.search_paths.dirs],
-            )
+    directory_to_files = {
+        dir: files
+        for dir, files in group_by_dir(all_terraform_files.files).items()
+        if any(file.endswith(".tf") for file in files)
+    }
+    prefixes = find_disjoint_longest_common_prefixes(
+        [PurePath(dir).parts for dir in directory_to_files.keys()]
+    )
+
+    putative_targets = [
+        PutativeTarget.for_target_type(
+            TerraformModules,
+            str(PurePath(*dir_parts)),
+            "tf_mods",
+            [str(PurePath(*dir_parts).joinpath("**/*.tf"))],
         )
+        for dir_parts in prefixes
+    ]
 
     return PutativeTargets(putative_targets)
 

--- a/src/python/pants/backend/terraform/tailor.py
+++ b/src/python/pants/backend/terraform/tailor.py
@@ -6,14 +6,8 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 
-from pants.backend.terraform.target_types import TerraformModule
-from pants.core.goals.tailor import (
-    AllOwnedSources,
-    PutativeTarget,
-    PutativeTargets,
-    PutativeTargetsRequest,
-    group_by_dir,
-)
+from pants.backend.terraform.target_types import TerraformModules
+from pants.core.goals.tailor import PutativeTarget, PutativeTargets, PutativeTargetsRequest
 from pants.engine.fs import PathGlobs, Paths
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
@@ -27,20 +21,18 @@ class PutativeTerraformTargetsRequest(PutativeTargetsRequest):
 
 
 @rule(level=LogLevel.DEBUG, desc="Determine candidate Terraform targets to create")
-async def find_putative_targets(
-    request: PutativeTerraformTargetsRequest, all_owned_sources: AllOwnedSources
-) -> PutativeTargets:
-    all_terraform_files = await Get(Paths, PathGlobs, request.search_paths.path_globs("*.tf"))
-    unowned_terraform_files = set(all_terraform_files.files) - set(all_owned_sources)
-
+async def find_putative_targets(request: PutativeTerraformTargetsRequest) -> PutativeTargets:
     putative_targets = []
-    for dirname, filenames in group_by_dir(unowned_terraform_files).items():
+
+    all_terraform_files = await Get(Paths, PathGlobs, request.search_paths.path_globs("*.tf"))
+    if all_terraform_files:
+        # Add a terraform_modules() top-level generator target if any Terraform files are present.
         putative_targets.append(
             PutativeTarget.for_target_type(
-                TerraformModule,
-                dirname,
-                os.path.basename(dirname),
-                sorted(filenames),
+                TerraformModules,
+                "",
+                "tf_mods",
+                [os.path.join(search_path, "**/*.tf") for search_path in request.search_paths.dirs],
             )
         )
 

--- a/src/python/pants/backend/terraform/tailor_test.py
+++ b/src/python/pants/backend/terraform/tailor_test.py
@@ -3,7 +3,7 @@
 
 from pants.backend.terraform.tailor import PutativeTerraformTargetsRequest
 from pants.backend.terraform.tailor import rules as terraform_tailor_rules
-from pants.backend.terraform.target_types import TerraformModule
+from pants.backend.terraform.target_types import TerraformModule, TerraformModules
 from pants.core.goals.tailor import (
     AllOwnedSources,
     PutativeTarget,
@@ -25,6 +25,7 @@ def test_find_putative_targets() -> None:
         ],
         target_types=[
             TerraformModule,
+            TerraformModules,
         ],
     )
     rule_runner.write_files(
@@ -56,30 +57,10 @@ def test_find_putative_targets() -> None:
         PutativeTargets(
             [
                 PutativeTarget.for_target_type(
-                    TerraformModule,
-                    "src/terraform",
-                    "terraform",
-                    [
-                        "root.tf",
-                    ],
-                ),
-                PutativeTarget.for_target_type(
-                    TerraformModule,
-                    "src/terraform/owned-module",
-                    "owned-module",
-                    [
-                        "foo.tf",
-                        "main.tf",
-                    ],
-                ),
-                PutativeTarget.for_target_type(
-                    TerraformModule,
-                    "src/terraform/unowned-module",
-                    "unowned-module",
-                    [
-                        "bar.tf",
-                        "main.tf",
-                    ],
+                    TerraformModules,
+                    "",
+                    "tf_mods",
+                    ("src/**/*.tf",),
                 ),
             ]
         )

--- a/src/python/pants/backend/terraform/target_gen_test.py
+++ b/src/python/pants/backend/terraform/target_gen_test.py
@@ -9,8 +9,8 @@ from pants.backend.terraform.target_types import (
     TerraformModules,
     TerraformModuleSources,
 )
-from pants.engine.addresses import Address
 from pants.core.util_rules import external_tool, source_files
+from pants.engine.addresses import Address
 from pants.engine.rules import QueryRule
 from pants.engine.target import GeneratedTargets
 from pants.testutil.rule_runner import RuleRunner
@@ -63,7 +63,7 @@ def test_target_generation(rule_runner: RuleRunner) -> None:
                         "versions.tf",
                     ),
                 },
-                generator_addr.create_generated("src/tf/")
+                generator_addr.create_generated("src/tf/"),
             ),
         ],
     )

--- a/src/python/pants/backend/terraform/target_gen_test.py
+++ b/src/python/pants/backend/terraform/target_gen_test.py
@@ -63,7 +63,7 @@ def test_target_generation(rule_runner: RuleRunner) -> None:
                         "versions.tf",
                     ),
                 },
-                generator_addr.create_generated("src/tf/"),
+                generator_addr.create_generated("src/tf"),
             ),
         ],
     )


### PR DESCRIPTION
Update the Terraform plugin's tailor support to use the `terraform_modules` generator instead of generating individual `terraform_module` targets.

[ci skip-rust]

[ci skip-build-wheels]