### PR TITLE
[internal] terraform: add `TerraformProcess` to consolidate invoking terraform

### DIFF
--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
@@ -9,16 +9,14 @@ from typing import Dict
 
 from pants.backend.terraform.lint.fmt import TerraformFmtRequest
 from pants.backend.terraform.target_types import TerraformSources
-from pants.backend.terraform.tool import TerraformTool
+from pants.backend.terraform.tool import TerraformProcess
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintResult, LintResults
 from pants.core.util_rules import external_tool
-from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.platform import Platform
-from pants.engine.process import FallibleProcessResult, Process, ProcessResult
+from pants.engine.process import FallibleProcessResult, ProcessResult
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import FieldSet
 from pants.engine.unions import UnionRule
@@ -66,36 +64,21 @@ class SetupRequest:
 
 @dataclass(frozen=True)
 class Setup:
-    directory_to_process: Dict[str, Process]
+    directory_to_process: Dict[str, TerraformProcess]
     original_digest: Digest
 
 
 @rule(level=LogLevel.DEBUG)
-async def setup_terraform_fmt(setup_request: SetupRequest, terraform: TerraformTool) -> Setup:
-    download_terraform_request = Get(
-        DownloadedExternalTool,
-        ExternalToolRequest,
-        terraform.get_request(Platform.current),
-    )
-
-    source_files_request = Get(
+async def setup_terraform_fmt(setup_request: SetupRequest) -> Setup:
+    source_files = await Get(
         SourceFiles,
         SourceFilesRequest(field_set.sources for field_set in setup_request.request.field_sets),
-    )
-
-    downloaded_terraform, source_files = await MultiGet(
-        download_terraform_request, source_files_request
     )
 
     source_files_snapshot = (
         source_files.snapshot
         if setup_request.request.prior_formatter_result is None
         else setup_request.request.prior_formatter_result
-    )
-
-    input_digest = await Get(
-        Digest,
-        MergeDigests((source_files_snapshot.digest, downloaded_terraform.digest)),
     )
 
     # `terraform fmt` operates on a directory-by-directory basis. First determine the directories in
@@ -112,19 +95,17 @@ async def setup_terraform_fmt(setup_request: SetupRequest, terraform: TerraformT
     directory_to_process = {}
     for directory, files_in_directory in directories.items():
         args = [
-            "./terraform",
             "fmt",
         ]
         if setup_request.check_only:
             args.append("-check")
         args.append(directory)
 
-        process = Process(
-            argv=args,
-            input_digest=input_digest,
-            output_files=files_in_directory,
+        process = TerraformProcess(
+            args=tuple(args),
+            input_digest=source_files_snapshot.digest,
+            output_files=tuple(files_in_directory),
             description=f"Run `terraform fmt` on {pluralize(len(files_in_directory), 'file')}.",
-            level=LogLevel.DEBUG,
         )
 
         directory_to_process[directory] = process
@@ -140,7 +121,8 @@ async def tffmt_fmt(request: TffmtRequest, tffmt: TfFmtSubsystem) -> FmtResult:
         return FmtResult.skip(formatter_name="tffmt")
     setup = await Get(Setup, SetupRequest(request, check_only=False))
     results = await MultiGet(
-        Get(ProcessResult, Process, process) for process in setup.directory_to_process.values()
+        Get(ProcessResult, TerraformProcess, process)
+        for process in setup.directory_to_process.values()
     )
 
     def format(directory, output):
@@ -180,7 +162,7 @@ async def tffmt_lint(request: TffmtRequest, tffmt: TfFmtSubsystem) -> LintResult
         return LintResults([], linter_name="tffmt")
     setup = await Get(Setup, SetupRequest(request, check_only=True))
     results = await MultiGet(
-        Get(FallibleProcessResult, Process, process)
+        Get(FallibleProcessResult, TerraformProcess, process)
         for directory, process in setup.directory_to_process.items()
     )
     lint_results = [LintResult.from_fallible_process_result(result) for result in results]

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
@@ -10,6 +10,7 @@ from typing import Dict
 from pants.backend.terraform.lint.fmt import TerraformFmtRequest
 from pants.backend.terraform.target_types import TerraformSources
 from pants.backend.terraform.tool import TerraformProcess
+from pants.backend.terraform.tool import rules as tool_rules
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintResult, LintResults
 from pants.core.util_rules import external_tool
@@ -173,5 +174,6 @@ def rules():
     return [
         *collect_rules(),
         *external_tool.rules(),
+        *tool_rules(),
         UnionRule(TerraformFmtRequest, TffmtRequest),
     ]

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt_integration_test.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt_integration_test.py
@@ -97,7 +97,10 @@ def run_tffmt(
     *,
     skip: bool = False,
 ) -> Tuple[Sequence[LintResult], FmtResult]:
-    args = ["--backend-packages=pants.backend.experimental.terraform.lint.tffmt"]
+    args = [
+        "--backend-packages=pants.backend.experimental.terraform",
+        "--backend-packages=pants.backend.experimental.terraform.lint.tffmt",
+    ]
     if skip:
         args.append("--terraform-fmt-skip")
     rule_runner.set_options(args)

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt_integration_test.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt_integration_test.py
@@ -5,6 +5,7 @@ from typing import List, Sequence, Tuple
 
 import pytest
 
+from pants.backend.terraform import tool
 from pants.backend.terraform.lint import fmt
 from pants.backend.terraform.lint.tffmt import tffmt
 from pants.backend.terraform.lint.tffmt.tffmt import TffmtFieldSet, TffmtRequest
@@ -27,6 +28,7 @@ def rule_runner() -> RuleRunner:
             *external_tool.rules(),
             *fmt.rules(),
             *tffmt.rules(),
+            *tool.rules(),
             *source_files.rules(),
             QueryRule(LintResults, (TffmtRequest,)),
             QueryRule(FmtResult, (TffmtRequest,)),

--- a/src/python/pants/backend/terraform/lint/validate/validate.py
+++ b/src/python/pants/backend/terraform/lint/validate/validate.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 from pants.backend.terraform.target_types import TerraformSources
 from pants.backend.terraform.tool import TerraformProcess
+from pants.backend.terraform.tool import rules as tool_rules
 from pants.core.goals.lint import LintRequest, LintResult, LintResults
 from pants.core.util_rules import external_tool
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
@@ -109,6 +110,7 @@ def rules():
     return [
         *collect_rules(),
         *external_tool.rules(),
+        *tool_rules(),
         UnionRule(LintRequest, ValidateRequest),
         SubsystemRule(TerraformValidateSubsystem),
     ]

--- a/src/python/pants/backend/terraform/lint/validate/validate.py
+++ b/src/python/pants/backend/terraform/lint/validate/validate.py
@@ -5,15 +5,12 @@ from collections import defaultdict
 from dataclasses import dataclass
 
 from pants.backend.terraform.target_types import TerraformSources
-from pants.backend.terraform.tool import TerraformTool
+from pants.backend.terraform.tool import TerraformProcess
 from pants.core.goals.lint import LintRequest, LintResult, LintResults
 from pants.core.util_rules import external_tool
-from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.engine.fs import Digest, MergeDigests
 from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.platform import Platform
-from pants.engine.process import FallibleProcessResult, Process
+from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import SubsystemRule, collect_rules, rule
 from pants.engine.target import FieldSet
 from pants.engine.unions import UnionRule
@@ -52,34 +49,21 @@ class ValidateRequest(LintRequest):
 
 @rule(desc="Lint with `terraform validate`", level=LogLevel.DEBUG)
 async def run_terraform_validate(
-    request: ValidateRequest, terraform: TerraformTool, subsystem: TerraformValidateSubsystem
+    request: ValidateRequest, subsystem: TerraformValidateSubsystem
 ) -> LintResults:
     if subsystem.options.skip:
         return LintResults([], linter_name="terraform validate")
 
-    download_terraform_request = Get(
-        DownloadedExternalTool,
-        ExternalToolRequest,
-        terraform.get_request(Platform.current),
-    )
-
-    sources_request = Get(
+    sources_files = await Get(
         SourceFiles,
         SourceFilesRequest(field_set.sources for field_set in request.field_sets),
-    )
-
-    downloaded_terraform, source_files = await MultiGet(download_terraform_request, sources_request)
-
-    input_digest = await Get(
-        Digest,
-        MergeDigests((source_files.snapshot.digest, downloaded_terraform.digest)),
     )
 
     # `terraform validate` operates on a directory-by-directory basis. First determine the directories in
     # the snapshot. This does not use `source_files_snapshot.dirs` because that will be empty if the files
     # are in a single directory.
     directories = defaultdict(list)
-    for file in source_files.snapshot.files:
+    for file in sources_files.snapshot.files:
         directory = os.path.dirname(file)
         if directory == "":
             directory = "."
@@ -89,24 +73,23 @@ async def run_terraform_validate(
     directory_to_process = {}
     for directory, files_in_directory in directories.items():
         args = [
-            "./terraform",
             "validate",
             directory,
         ]
         args = [arg for arg in args if arg]
 
-        process = Process(
-            argv=args,
-            input_digest=input_digest,
-            output_files=files_in_directory,
+        process = TerraformProcess(
+            args=tuple(args),
+            input_digest=sources_files.snapshot.digest,
+            output_files=tuple(files_in_directory),
             description=f"Run `terraform validate` on {pluralize(len(files_in_directory), 'file')}.",
-            level=LogLevel.DEBUG,
         )
 
         directory_to_process[directory] = process
 
     results = await MultiGet(
-        Get(FallibleProcessResult, Process, process) for process in directory_to_process.values()
+        Get(FallibleProcessResult, TerraformProcess, process)
+        for process in directory_to_process.values()
     )
 
     lint_results = []

--- a/src/python/pants/backend/terraform/lint/validate/validate_integration_test.py
+++ b/src/python/pants/backend/terraform/lint/validate/validate_integration_test.py
@@ -5,6 +5,7 @@ from typing import List, Sequence
 
 import pytest
 
+from pants.backend.terraform import tool
 from pants.backend.terraform.lint import fmt
 from pants.backend.terraform.lint.validate import validate
 from pants.backend.terraform.lint.validate.validate import ValidateFieldSet, ValidateRequest
@@ -26,6 +27,7 @@ def rule_runner() -> RuleRunner:
             *external_tool.rules(),
             *fmt.rules(),
             *validate.rules(),
+            *tool.rules(),
             *source_files.rules(),
             QueryRule(LintResults, (ValidateRequest,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),

--- a/src/python/pants/backend/terraform/lint/validate/validate_integration_test.py
+++ b/src/python/pants/backend/terraform/lint/validate/validate_integration_test.py
@@ -86,7 +86,10 @@ def run_terraform_validate(
     *,
     skip: bool = False,
 ) -> Sequence[LintResult]:
-    args = ["--backend-packages=pants.backend.experimental.terraform.lint.validate"]
+    args = [
+        "--backend-packages=pants.backend.experimental.terraform",
+        "--backend-packages=pants.backend.experimental.terraform.lint.validate",
+    ]
     if skip:
         args.append("--terraform-validate-skip")
     rule_runner.set_options(args)

--- a/src/python/pants/backend/terraform/tool.py
+++ b/src/python/pants/backend/terraform/tool.py
@@ -52,7 +52,7 @@ class TerraformProcess:
     output_files: tuple[str, ...] = ()
 
 
-@rule(level=LogLevel.DEBUG)
+@rule
 async def setup_terraform_process(request: TerraformProcess, terraform: TerraformTool) -> Process:
     downloaded_terraform = await Get(
         DownloadedExternalTool,

--- a/src/python/pants/backend/terraform/tool.py
+++ b/src/python/pants/backend/terraform/tool.py
@@ -1,8 +1,20 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
 
-from pants.core.util_rules.external_tool import TemplatedExternalTool
-from pants.engine.rules import collect_rules
+from dataclasses import dataclass
+
+from pants.core.util_rules.external_tool import (
+    DownloadedExternalTool,
+    ExternalToolRequest,
+    TemplatedExternalTool,
+)
+from pants.engine.fs import EMPTY_DIGEST, Digest, MergeDigests
+from pants.engine.internals.selectors import Get
+from pants.engine.platform import Platform
+from pants.engine.process import Process
+from pants.engine.rules import collect_rules, rule
+from pants.util.logging import LogLevel
 from pants.util.meta import classproperty
 
 
@@ -28,6 +40,38 @@ class TerraformTool(TemplatedExternalTool):
             "0.14.5|macos_x86_64|363d0e0c5c4cb4e69f5f2c7f64f9bf01ab73af0801665d577441521a24313a07|34341379",
             "0.14.5|linux_x86_64|2899f47860b7752e31872e4d57b1c03c99de154f12f0fc84965e231bc50f312f|33542124",
         ]
+
+
+@dataclass(frozen=True)
+class TerraformProcess:
+    """A request to invoke Terraform."""
+
+    args: tuple[str, ...]
+    description: str
+    input_digest: Digest = EMPTY_DIGEST
+    output_files: tuple[str, ...] = ()
+
+
+@rule(level=LogLevel.DEBUG)
+async def setup_terraform_process(request: TerraformProcess, terraform: TerraformTool) -> Process:
+    downloaded_terraform = await Get(
+        DownloadedExternalTool,
+        ExternalToolRequest,
+        terraform.get_request(Platform.current),
+    )
+
+    input_digest = await Get(
+        Digest,
+        MergeDigests((request.input_digest, downloaded_terraform.digest)),
+    )
+
+    return Process(
+        argv=("./terraform",) + request.args,
+        input_digest=input_digest,
+        output_files=request.output_files,
+        description=request.description,
+        level=LogLevel.DEBUG,
+    )
 
 
 def rules():


### PR DESCRIPTION
Refactor knowledge of how to invoke Terraform into the `TerraformProcess` type which converts to `Process` via a new rule.

[ci skip-rust]

[ci skip-build-wheels]