### PR TITLE
Ban `#` in an address's target name

### DIFF
--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -12,9 +12,9 @@ from pants.engine.engine_aware import EngineAwareParameter
 from pants.util.dirutil import fast_relpath, longest_dir_prefix
 from pants.util.strutil import strip_prefix
 
-# `:` is used as a delimiter already. Others are reserved for possible future needs.
-BANNED_CHARS_IN_TARGET_NAME = frozenset(r":!@?/\=")
-BANNED_CHARS_IN_GENERATED_NAME = frozenset(r":!@?=")
+# `:` and `#` used as delimiters already. Others are reserved for possible future needs.
+BANNED_CHARS_IN_TARGET_NAME = frozenset(r":#!@?/\=")
+BANNED_CHARS_IN_GENERATED_NAME = frozenset(r":#!@?=")
 
 
 class InvalidSpecPath(ValueError):

--- a/src/python/pants/build_graph/address_test.py
+++ b/src/python/pants/build_graph/address_test.py
@@ -91,14 +91,28 @@ def test_address_input_parse_bad_path_component(spec: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "spec", ["", "a:", "a::", "//", "//:", "//:@t", "//:!t", "//:?", "//:=", r"a:b\c", "a:b/c"]
+    "spec",
+    [
+        "",
+        "a:",
+        "a::",
+        "//",
+        "//:",
+        "//:@t",
+        "//:!t",
+        "//:?",
+        "//:=",
+        r"a:b\c",
+        "a:b/c",
+        "a:my#tgt#generated",
+    ],
 )
 def test_address_bad_target_component(spec: str) -> None:
     with pytest.raises(InvalidTargetName):
         AddressInput.parse(spec).dir_to_address()
 
 
-@pytest.mark.parametrize("spec", ["//:t#gen@", "//:t#gen!", "//:t#gen?", "//:t#gen="])
+@pytest.mark.parametrize("spec", ["//:t#gen@", "//:t#gen!", "//:t#gen?", "//:t#gen=", "//:t#gen#"])
 def test_address_generated_name(spec: str) -> None:
     with pytest.raises(InvalidTargetName):
         AddressInput.parse(spec).dir_to_address()


### PR DESCRIPTION
Now reserved for generated target syntax: `dir:generator#generated`.

This is technically a breaking change, but I see no way to gracefully deprecate this. It seems pretty unlikely to use `#` in a target name, and there are alternatives people can switch to.

[ci skip-rust]
[ci skip-build-wheels]