### PR TITLE
Fix "file-level dependencies" on `files` and `resources` targets to not pull in sibling files

### DIFF
--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -196,7 +196,7 @@ async def infer_terraform_module_dependencies(
     terraform_module_addresses = [
         tgt.address for tgt in candidate_targets if tgt.has_field(TerraformModuleSources)
     ]
-    return InferredDependencies(terraform_module_addresses, sibling_dependencies_inferrable=False)
+    return InferredDependencies(terraform_module_addresses)
 
 
 def rules():

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -73,8 +73,7 @@ async def generate_targets_from_files(
         request.generator,
         paths.files,
         union_membership,
-        # TODO: Set to `False`!
-        add_dependencies_on_all_siblings=True,
+        add_dependencies_on_all_siblings=False,
     )
 
 
@@ -239,8 +238,7 @@ async def generate_targets_from_resources(
         request.generator,
         paths.files,
         union_membership,
-        # TODO: Set to `False`!
-        add_dependencies_on_all_siblings=True,
+        add_dependencies_on_all_siblings=False,
     )
 
 


### PR DESCRIPTION
Before:

```
❯ ./pants dependencies src/python/pants/engine/internals/fs_test_data/tls/rsa/server.crt
src/python/pants/engine/internals/fs_test_data/fs_test.tar:../fs_test_data
src/python/pants/engine/internals/fs_test_data/tls/rsa/server.chain:../../../fs_test_data
src/python/pants/engine/internals/fs_test_data/tls/rsa/server.key:../../../fs_test_data
```

After:

```
❯ ./pants dependencies src/python/pants/engine/internals/fs_test_data/tls/rsa/server.crt
```

That is, every generated file-level target from `files()` and `resources()` automatically depended on all their sibling file-level targets from generated from its target generator.

This means that you said `dependencies=["path/to/file.ext"]`, the end result is the same as `dependencies=["path/to:all_files"]`.

[ci skip-rust]
[ci skip-build-wheels]