### PR TITLE
[internal] Fix Go `tailor` to set `name` for `_go_external_package`

### DIFF
--- a/src/python/pants/backend/go/goals/tailor.py
+++ b/src/python/pants/backend/go/goals/tailor.py
@@ -144,10 +144,11 @@ async def find_putative_go_external_module_targets(
             assert package.module_version
             assert package.import_path.startswith(package.module_path)
             subpath = package.import_path[len(package.module_path) :].replace("/", "_")
-            ext_mod_target_name = compute_go_external_module_target_name(
+            target_name = compute_go_external_module_target_name(
                 package.module_path, package.module_version
             )
-            target_name = f"{ext_mod_target_name}-{subpath}"
+            if subpath:
+                target_name += f"-{subpath}"
 
             putative_targets.append(
                 PutativeTarget.for_target_type(
@@ -156,6 +157,7 @@ async def find_putative_go_external_module_targets(
                     target_name,
                     [],
                     kwargs={
+                        "name": target_name,
                         "path": package.module_path,
                         "version": package.module_version,
                         "import_path": package.import_path,

--- a/src/python/pants/backend/go/goals/tailor_test.py
+++ b/src/python/pants/backend/go/goals/tailor_test.py
@@ -138,12 +138,7 @@ def test_find_putative_go_external_module_targets(rule_runner: RuleRunner) -> No
         PutativeTargets,
         [
             PutativeGoExternalModuleTargetsRequest(PutativeTargetsSearchPaths(("src/",))),
-            AllOwnedSources(
-                [
-                    "src/go/go.mod",
-                    "src/go/go.sum",
-                ]
-            ),
+            AllOwnedSources(["src/go/go.mod", "src/go/go.sum"]),
         ],
     )
     assert putative_targets == PutativeTargets(
@@ -151,9 +146,10 @@ def test_find_putative_go_external_module_targets(rule_runner: RuleRunner) -> No
             PutativeTarget.for_target_type(
                 GoExternalPackageTarget,
                 "src/go",
-                "github.com_google_uuid_v1.2.0-",
+                "github.com_google_uuid_v1.2.0",
                 [],
                 kwargs={
+                    "name": "github.com_google_uuid_v1.2.0",
                     "path": "github.com/google/uuid",
                     "version": "v1.2.0",
                     "import_path": "github.com/google/uuid",


### PR DESCRIPTION
Also because `go_external_module` no longer exists, we don't have to always append `-` to the name to disambiguate between the `go_external_module` vs. `_go_external_package`.

[ci skip-rust]
[ci skip-build-wheels]