### PR TITLE
[wip] Stop removing target generators from project introspection like `./pants list ::`

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -167,8 +167,10 @@ class FirstPartyPythonTargetsMappingMarker(FirstPartyPythonMappingImplMarker):
 async def map_first_party_python_targets_to_modules(
     _: FirstPartyPythonTargetsMappingMarker,
 ) -> FirstPartyPythonMappingImpl:
-    all_expanded_targets = await Get(Targets, AddressSpecs([DescendantAddresses("")]))
-    python_targets = tuple(tgt for tgt in all_expanded_targets if tgt.has_field(PythonSources))
+    all_targets = await Get(Targets, AddressSpecs([DescendantAddresses("")]))
+    python_targets = tuple(
+        tgt for tgt in all_targets if tgt.has_field(PythonSources) and tgt.address.is_file_target
+    )
     stripped_sources_per_target = await MultiGet(
         Get(StrippedSourceFileNames, SourcesPathsRequest(tgt[PythonSources]))
         for tgt in python_targets

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -36,7 +36,7 @@ class BanditFieldSet(FieldSet):
 
     @classmethod
     def opt_out(cls, tgt: Target) -> bool:
-        return tgt.get(SkipBanditField).value
+        return tgt.get(SkipBanditField).value or not tgt.address.is_file_target
 
 
 class Bandit(PythonToolBase):

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -34,7 +34,7 @@ class BlackFieldSet(FieldSet):
 
     @classmethod
     def opt_out(cls, tgt: Target) -> bool:
-        return tgt.get(SkipBlackField).value
+        return tgt.get(SkipBlackField).value or not tgt.address.is_file_target
 
 
 class BlackRequest(PythonFmtRequest, LintRequest):

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -30,7 +30,7 @@ class DocformatterFieldSet(FieldSet):
 
     @classmethod
     def opt_out(cls, tgt: Target) -> bool:
-        return tgt.get(SkipDocformatterField).value
+        return tgt.get(SkipDocformatterField).value or not tgt.address.is_file_target
 
 
 class DocformatterRequest(PythonFmtRequest, LintRequest):

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -36,7 +36,7 @@ class Flake8FieldSet(FieldSet):
 
     @classmethod
     def opt_out(cls, tgt: Target) -> bool:
-        return tgt.get(SkipFlake8Field).value
+        return tgt.get(SkipFlake8Field).value or not tgt.address.is_file_target
 
 
 class Flake8(PythonToolBase):

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -31,7 +31,7 @@ class IsortFieldSet(FieldSet):
 
     @classmethod
     def opt_out(cls, tgt: Target) -> bool:
-        return tgt.get(SkipIsortField).value
+        return tgt.get(SkipIsortField).value or not tgt.address.is_file_target
 
 
 class IsortRequest(PythonFmtRequest, LintRequest):

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -54,7 +54,7 @@ class PylintFieldSet(FieldSet):
 
     @classmethod
     def opt_out(cls, tgt: Target) -> bool:
-        return tgt.get(SkipPylintField).value
+        return tgt.get(SkipPylintField).value or not tgt.address.is_file_target
 
 
 # --------------------------------------------------------------------------------------

--- a/src/python/pants/backend/python/lint/yapf/rules.py
+++ b/src/python/pants/backend/python/lint/yapf/rules.py
@@ -31,7 +31,7 @@ class YapfFieldSet(FieldSet):
 
     @classmethod
     def opt_out(cls, tgt: Target) -> bool:
-        return tgt.get(SkipYapfField).value
+        return tgt.get(SkipYapfField).value or not tgt.address.is_file_target
 
 
 class YapfRequest(PythonFmtRequest, LintRequest):

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -54,10 +54,10 @@ class PythonTestFieldSet(TestFieldSet):
 
     @classmethod
     def opt_out(cls, tgt: Target) -> bool:
+        if not tgt.address.is_file_target:
+            return True
         if tgt.get(SkipPythonTestsField).value:
             return True
-        if not tgt.address.is_file_target:
-            return False
         file_name = PurePath(tgt.address.filename)
         return file_name.name == "conftest.py" or file_name.suffix == ".pyi"
 

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -48,7 +48,7 @@ class MyPyFieldSet(FieldSet):
 
     @classmethod
     def opt_out(cls, tgt: Target) -> bool:
-        return tgt.get(SkipMyPyField).value
+        return tgt.get(SkipMyPyField).value or not tgt.address.is_file_target
 
 
 # --------------------------------------------------------------------------------------

--- a/src/python/pants/backend/shell/lint/shellcheck/rules.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/rules.py
@@ -36,7 +36,7 @@ class ShellcheckFieldSet(FieldSet):
 
     @classmethod
     def opt_out(cls, tgt: Target) -> bool:
-        return tgt.get(SkipShellcheckField).value
+        return tgt.get(SkipShellcheckField).value or not tgt.address.is_file_target
 
 
 class ShellcheckRequest(LintRequest):

--- a/src/python/pants/backend/shell/lint/shfmt/rules.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules.py
@@ -30,7 +30,7 @@ class ShfmtFieldSet(FieldSet):
 
     @classmethod
     def opt_out(cls, tgt: Target) -> bool:
-        return tgt.get(SkipShfmtField).value
+        return tgt.get(SkipShfmtField).value or not tgt.address.is_file_target
 
 
 class ShfmtRequest(ShellFmtRequest, LintRequest):

--- a/src/python/pants/backend/shell/shunit2_test_runner.py
+++ b/src/python/pants/backend/shell/shunit2_test_runner.py
@@ -47,7 +47,7 @@ from pants.engine.process import (
     ProcessCacheScope,
 )
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import Sources, TransitiveTargets, TransitiveTargetsRequest
+from pants.engine.target import Sources, Target, TransitiveTargets, TransitiveTargetsRequest
 from pants.engine.unions import UnionRule
 from pants.option.global_options import GlobalOptions
 from pants.util.logging import LogLevel
@@ -62,6 +62,10 @@ class Shunit2FieldSet(TestFieldSet):
     timeout: Shunit2TestsTimeout
     shell: Shunit2ShellField
     runtime_package_dependencies: RuntimePackageDependenciesField
+
+    @classmethod
+    def opt_out(cls, tgt: Target) -> bool:
+        return not tgt.address.is_file_target
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
This improves upon https://github.com/pantsbuild/pants/pull/10511 to clear up some confusing semantics.

## More coherent project introspection

Now, when combined with https://github.com/pantsbuild/pants/pull/12951, `./pants list ::` will list _all_ targets in your project: normal targets (`pex_binary`), target generators (aka BUILD targets), and generated targets.

Before, `3rdparty/python:reqs` is missing:

```shell
❯ ./pants list 3rdparty/python
3rdparty/python:pydevd-pycharm
3rdparty/python:reqs#PyYAML
3rdparty/python:reqs#ansicolors
...
```

After:

```
❯ ./pants list 3rdparty/python
3rdparty/python:pydevd-pycharm
3rdparty/python:reqs
3rdparty/python:reqs#PyYAML
3rdparty/python:reqs#ansicolors
...
```

--

When you add a dependency on a target generator, that used to not show up in `./pants dependencies`. Given this BUILD file:

```python
python_library(name="lib")
python_tests(name='tests', dependencies=[":lib"])
```

Before:

```shell
❯ ./pants dependencies src/python/pants/util/strutil_test.py:tests
...
src/python/pants/util/socket.py:lib
src/python/pants/util/strutil.py:lib
```

After:

```shell
❯ ./pants dependencies src/python/pants/util/strutil_test.py:tests
...
src/python/pants/util/socket.py:lib
src/python/pants/util/strutil.py:lib
src/python/pants/util:lib
```

(Note that this is an address literal)

## Files are still the atom for file-based languages

For `fmt`, `lint`, `check`, and `test`, the relevant plugins filter out non-file-level targets using `FieldSet.opt_out()`. So, `./pants test dep:` and friends behave the exact same as before.

In the future, this filtering will be much more natural when we have `python_source`, `python_test`, et al targets. You'll operate on those atomic targets using the Target API, rather than having to think about target generators.

## Impact on file args and `--changed-since`

File args are worse than before, because `./pants list path/to/file.py` now will give you both the generated file target _and_ it's target generator. For `test`, `lint`, etc, it doesn't matter because filter out the target generator already. But for `./pants dependencies` et al, this is annoying. It means that `./pants dependencies file.ext` will find the dependencies for both the generated file-level target _and_ it's target generator.

Before:

```shell
❯ ./pants dependencies src/python/pants/util/strutil_test.py
...
src/python/pants/util/socket.py:lib
src/python/pants/util/strutil.py:lib
```

After.

```shell
❯ ./pants dependencies src/python/pants/util/strutil_test.py
...
src/python/pants/util/socket.py:lib
src/python/pants/util/socket_test.py:tests
src/python/pants/util/strutil.py:lib
src/python/pants/util/strutil_test.py:tests
src/python/pants/util:lib
```

Note that it looks like `strutil_test.py` looks like it's depending on itself, when really the file arg matched the `:tests` target generator and that _does_ indeed depend on `strutil_test.py:tests`. That's confusing.

_I think we can fix this_. When we have targets like `python_sources` (generator) vs. `python_source` (atomic target), we can use the Target API so that the `Sources` of `python_sources` is a different type such that it isn't seen as an owner. In the meantime, I think we can change the `Owners` code to filter out the target generator.

[ci skip-rust]