### PR TITLE
[internal] terraform: support consuming terraform from local path

### DIFF
--- a/src/python/pants/backend/terraform/goals/check_test.py
+++ b/src/python/pants/backend/terraform/goals/check_test.py
@@ -36,6 +36,8 @@ def rule_runner() -> RuleRunner:
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
     )
+    rule_runner.set_options([], env_inherit={"PATH"})
+    return rule_runner
 
 
 GOOD_SOURCE = FileContent(
@@ -79,9 +81,20 @@ def run_terraform_validate(
     rule_runner: RuleRunner,
     targets: List[Target],
     *,
+<<<<<<< HEAD:src/python/pants/backend/terraform/goals/check_test.py
     args: list[str] | None = None,
 ) -> Sequence[CheckResult]:
     rule_runner.set_options(args or ())
+=======
+    skip: bool = False,
+) -> Sequence[LintResult]:
+    args = [
+        "--backend-packages=pants.backend.experimental.terraform",
+    ]
+    if skip:
+        args.append("--terraform-validate-skip")
+    rule_runner.set_options(args, env_inherit={"PATH"})
+>>>>>>> 91c42fdc7 (fix tests):src/python/pants/backend/terraform/lint/validate/validate_integration_test.py
     field_sets = [TerraformFieldSet.create(tgt) for tgt in targets]
     check_results = rule_runner.request(CheckResults, [TerraformCheckRequest(field_sets)])
     return check_results.results

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt_integration_test.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt_integration_test.py
@@ -22,7 +22,7 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 @pytest.fixture()
 def rule_runner() -> RuleRunner:
-    return RuleRunner(
+    rule_runner = RuleRunner(
         target_types=[TerraformModuleTarget],
         rules=[
             *external_tool.rules(),
@@ -36,6 +36,8 @@ def rule_runner() -> RuleRunner:
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
     )
+    rule_runner.set_options([], env_inherit={"PATH"})
+    return rule_runner
 
 
 GOOD_SOURCE = FileContent(
@@ -100,11 +102,10 @@ def run_tffmt(
 ) -> Tuple[Sequence[LintResult], FmtResult]:
     args = [
         "--backend-packages=pants.backend.experimental.terraform",
-        "--backend-packages=pants.backend.experimental.terraform.lint.tffmt",
     ]
     if skip:
         args.append("--terraform-fmt-skip")
-    rule_runner.set_options(args)
+    rule_runner.set_options(args, env_inherit={"PATH"})
     field_sets = [TerraformFieldSet.create(tgt) for tgt in targets]
     lint_results = rule_runner.request(LintResults, [TffmtRequest(field_sets)])
     input_sources = rule_runner.request(

--- a/src/python/pants/backend/terraform/tool.py
+++ b/src/python/pants/backend/terraform/tool.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 
 from pants.core.util_rules.external_tool import (
@@ -9,18 +10,26 @@ from pants.core.util_rules.external_tool import (
     ExternalToolRequest,
     TemplatedExternalTool,
 )
+from pants.engine.environment import Environment, EnvironmentRequest
 from pants.engine.fs import EMPTY_DIGEST, Digest, MergeDigests
 from pants.engine.internals.selectors import Get
 from pants.engine.platform import Platform
-from pants.engine.process import Process
+from pants.engine.process import (
+    BinaryNotFoundError,
+    BinaryPathRequest,
+    BinaryPaths,
+    BinaryPathTest,
+    Process,
+)
 from pants.engine.rules import collect_rules, rule
 from pants.option.subsystem import Subsystem
 from pants.util.logging import LogLevel
 from pants.util.meta import classproperty
+from pants.util.ordered_set import OrderedSet
 
 
 class TerraformTool(TemplatedExternalTool):
-    options_scope = "download-terraform"
+    options_scope = "terraform"
     name = "terraform"
     help = "Terraform (https://terraform.io)"
 
@@ -42,23 +51,45 @@ class TerraformTool(TemplatedExternalTool):
             "1.0.7|linux_x86_64|bc79e47649e2529049a356f9e60e06b47462bf6743534a10a4c16594f443be7b|32671441",
         ]
 
-
-class TerraformSubsystem(Subsystem):
-    options_scope = "terraform"
-    help = "Terraform-relaed options"
-
     @classmethod
     def register_options(cls, register):
         super().register_options(register)
+
         register(
             "--path",
             type=str,
             default=None,
             help=(
-                "Use this provided absolute path as the path to the `terraform` binary. "
-                "Prevents the automatic download of Terraform.",
+                "Use the provided absolute path as the path to the `terraform` binary. "
+                "Prevents the automatic download of Terraform and search of paths.",
             ),
         )
+
+        register(
+            "--search-paths",
+            type=list,
+            member_type=str,
+            default=[],
+            help=(
+                "A list of paths to search for Terraform.\n\n"
+                "Specify absolute paths to directories with the `terraform` binary, e.g. `/usr/bin`. "
+                "Earlier entries will be searched first.\n\n"
+                "The special string '<PATH>' will expand to the contents of the PATH env var."
+            ),
+        )
+
+    def search_paths(self, env: Environment) -> tuple[str, ...]:
+        def iter_path_entries():
+            for entry in self.options.search_paths:
+                if entry == "<PATH>":
+                    path = env.get("PATH")
+                    if path:
+                        for path_entry in path.split(os.pathsep):
+                            yield path_entry
+                else:
+                    yield entry
+
+        return tuple(OrderedSet(iter_path_entries()))
 
 
 @dataclass(frozen=True)
@@ -68,16 +99,44 @@ class TerraformSetup:
 
 
 @rule
-async def find_terraform(
-    tf_tool: TerraformTool, tf_subsystem: TerraformSubsystem
-) -> TerraformSetup:
-    if tf_subsystem.options.path:
-        return TerraformSetup(digest=EMPTY_DIGEST, path=tf_subsystem.options.path)
+async def find_terraform(terraform: TerraformTool) -> TerraformSetup:
+    if terraform.options.path:
+        return TerraformSetup(digest=EMPTY_DIGEST, path=terraform.options.path)
+
+    env = await Get(Environment, EnvironmentRequest(["PATH"]))
+    search_paths = terraform.search_paths(env)
+    if search_paths:
+        all_terraform_binary_paths = await Get(
+            BinaryPaths,
+            BinaryPathRequest(
+                search_path=search_paths,
+                binary_name="terraform",
+                test=BinaryPathTest(["version"]),
+            ),
+        )
+
+        if not all_terraform_binary_paths.paths:
+            raise BinaryNotFoundError(
+                "Cannot find any `terraform` binaries using the option "
+                f"`[terraform].search_paths`: {list(search_paths)}\n\n"
+                "To fix, please install one copy of Terraform and ensure "
+                "that it is discoverable via `[terraform].search_paths`."
+            )
+
+        if len(all_terraform_binary_paths.paths) > 1:
+            raise BinaryNotFoundError(
+                "Found multiple `terraform` binaries using the option "
+                f"`[terraform].search_paths`: {list(search_paths)}\n\n"
+                "To fix, please ensure that only one copy of Terraform "
+                "is discoverable via `[terraform].search_paths`."
+            )
+
+        return TerraformSetup(digest=EMPTY_DIGEST, path=all_terraform_binary_paths.paths[0])
 
     downloaded_terraform = await Get(
         DownloadedExternalTool,
         ExternalToolRequest,
-        tf_tool.get_request(Platform.current),
+        terraform.get_request(Platform.current),
     )
 
     return TerraformSetup(digest=downloaded_terraform.digest, path="./terraform")

--- a/src/python/pants/backend/terraform/tool.py
+++ b/src/python/pants/backend/terraform/tool.py
@@ -22,7 +22,6 @@ from pants.engine.process import (
     Process,
 )
 from pants.engine.rules import collect_rules, rule
-from pants.option.subsystem import Subsystem
 from pants.util.logging import LogLevel
 from pants.util.meta import classproperty
 from pants.util.ordered_set import OrderedSet
@@ -131,7 +130,7 @@ async def find_terraform(terraform: TerraformTool) -> TerraformSetup:
                 "is discoverable via `[terraform].search_paths`."
             )
 
-        return TerraformSetup(digest=EMPTY_DIGEST, path=all_terraform_binary_paths.paths[0])
+        return TerraformSetup(digest=EMPTY_DIGEST, path=all_terraform_binary_paths.paths[0].path)
 
     downloaded_terraform = await Get(
         DownloadedExternalTool,

--- a/src/python/pants/backend/terraform/tool.py
+++ b/src/python/pants/backend/terraform/tool.py
@@ -45,6 +45,7 @@ class TerraformTool(TemplatedExternalTool):
 
 class TerraformSubsystem(Subsystem):
     options_scope = "terraform"
+    help = "Terraform-relaed options"
 
     @classmethod
     def register_options(cls, register):


### PR DESCRIPTION
Allow using the `terraform` binary found at the path specified by `--terraform-path` instead of downloading Terraform from the Internet.

[ci skip-rust]

[ci skip-build-wheels]