### PR TITLE
Fix `./pants dependencies --transitive` when run on a target generator like `python_library`

### DIFF
--- a/src/python/pants/backend/project_info/dependees.py
+++ b/src/python/pants/backend/project_info/dependees.py
@@ -28,11 +28,11 @@ class AddressToDependees:
 @rule(desc="Map all targets to their dependees", level=LogLevel.DEBUG)
 async def map_addresses_to_dependees() -> AddressToDependees:
     # Get every target in the project so that we can iterate over them to find their dependencies.
-    all_expanded_targets, all_explicit_targets = await MultiGet(
+    with_generated_targets, without_generated_targets = await MultiGet(
         Get(Targets, AddressSpecs([DescendantAddresses("")])),
         Get(UnexpandedTargets, AddressSpecs([DescendantAddresses("")])),
     )
-    all_targets = {*all_expanded_targets, *all_explicit_targets}
+    all_targets = {*with_generated_targets, *without_generated_targets}
     dependencies_per_target = await MultiGet(
         Get(Addresses, DependenciesRequest(tgt.get(Dependencies), include_special_cased_deps=True))
         for tgt in all_targets

--- a/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints.py
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints.py
@@ -77,14 +77,14 @@ async def py_constraints(
             )
             return PyConstraintsGoal(exit_code=1)
 
-        all_expanded_targets, all_explicit_targets = await MultiGet(
+        with_generated_targets, without_generated_targets = await MultiGet(
             Get(Targets, AddressSpecs([DescendantAddresses("")])),
             Get(UnexpandedTargets, AddressSpecs([DescendantAddresses("")])),
         )
         all_python_targets = sorted(
             {
                 t
-                for t in (*all_expanded_targets, *all_explicit_targets)
+                for t in (*with_generated_targets, *without_generated_targets)
                 if t.has_field(InterpreterConstraintsField)
             },
             key=lambda tgt: cast(Address, tgt.address),

--- a/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints_test.py
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints_test.py
@@ -100,7 +100,7 @@ def test_constraints_summary(rule_runner: RuleRunner) -> None:
         Target,Constraints,Transitive Constraints,# Dependencies,# Dependees\r
         app,CPython==3.7.*,"CPython==2.7.*,==3.7.*,>=3.6 OR CPython==3.7.*,>=3.5,>=3.6",3,0\r
         lib1,CPython==2.7.* OR CPython>=3.5,CPython==2.7.* OR CPython>=3.5,0,1\r
-        lib2,CPython>=3.6,CPython>=3.6,0,0\r
+        lib2,CPython>=3.6,CPython>=3.6,2,0\r
         lib2/a.py,CPython>=3.6,CPython>=3.6,0,2\r
         lib2/b.py,CPython>=3.6,CPython>=3.6,0,2\r
         """

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -48,7 +48,7 @@ class MyPyFieldSet(FieldSet):
 
     @classmethod
     def opt_out(cls, tgt: Target) -> bool:
-        return tgt.get(SkipMyPyField).value
+        return tgt.get(SkipMyPyField).value and not tgt.address.is_file_target
 
 
 # --------------------------------------------------------------------------------------

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -273,16 +273,12 @@ async def transitive_dependency_mapping(request: _DependencyMappingRequest) -> _
     Unlike a traditional BFS algorithm, we batch each round of traversals via `MultiGet` for
     improved performance / concurrency.
     """
-    roots_as_targets: Collection[Target]
-    if request.expanded_targets:
-        roots_as_targets = await Get(Targets, Addresses(request.tt_request.roots))
-    else:
-        roots_as_targets = await Get(UnexpandedTargets, Addresses(request.tt_request.roots))
+    roots_as_targets = await Get(UnexpandedTargets, Addresses(request.tt_request.roots))
     visited: OrderedSet[Target] = OrderedSet()
     queued = FrozenOrderedSet(roots_as_targets)
-    dependency_mapping: Dict[Address, Tuple[Address, ...]] = {}
+    dependency_mapping: dict[Address, Tuple[Address, ...]] = {}
     while queued:
-        direct_dependencies: Tuple[Collection[Target], ...]
+        direct_dependencies: tuple[Collection[Target], ...]
         if request.expanded_targets:
             direct_dependencies = await MultiGet(
                 Get(

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -337,11 +337,11 @@ def test_transitive_targets_tolerates_generated_target_cycles(
         [TransitiveTargetsRequest([Address("", target_name="t2")])],
     )
     assert len(result.roots) == 1
-    assert result.roots[0].address == Address("", relative_file_path="t2.txt", target_name="t2")
+    assert result.roots[0].address == Address("", target_name="t2")
     assert [tgt.address for tgt in result.dependencies] == [
         Address("", relative_file_path="t1.txt", target_name="t1"),
-        Address("", relative_file_path="dep.txt", target_name="dep"),
         Address("", relative_file_path="t2.txt", target_name="t2"),
+        Address("", relative_file_path="dep.txt", target_name="dep"),
     ]
 
 


### PR DESCRIPTION
We were replacing target generators with their generated targets in the "roots" of TransitiveTargets, when we should be using the exact roots that were given to us.

Before:

```
❯ ./pants dependencies src/python/pants/util:tests | wc -l
      31
❯ ./pants dependencies --transitive src/python/pants/util:tests | wc -l
      22
```

After:

```
❯ ./pants dependencies src/python/pants/util:tests | wc -l
      31
❯ ./pants dependencies --transitive src/python/pants/util:tests | wc -l
      36
```

I couldn't detect any behavior change beyond the `dependencies` and `py-constraints` goals, which behave more correctly now.

[ci skip-rust]