### PR TITLE
[internal] Add `Address.create_generated()` for target generation

### DIFF
--- a/src/python/pants/backend/terraform/target_gen_test.py
+++ b/src/python/pants/backend/terraform/target_gen_test.py
@@ -9,7 +9,7 @@ from pants.backend.terraform.target_types import (
     TerraformModules,
     TerraformModuleSources,
 )
-from pants.build_graph.address import Address
+from pants.engine.addresses import Address
 from pants.core.util_rules import external_tool, source_files
 from pants.engine.rules import QueryRule
 from pants.engine.target import GeneratedTargets
@@ -42,7 +42,8 @@ def test_target_generation(rule_runner: RuleRunner) -> None:
         }
     )
 
-    generator = rule_runner.get_target(Address("", target_name="tf_mods"))
+    generator_addr = Address("", target_name="tf_mods")
+    generator = rule_runner.get_target(generator_addr)
     targets = rule_runner.request(
         GeneratedTargets, [GenerateTerraformModuleTargetsRequest(generator)]
     )
@@ -53,7 +54,7 @@ def test_target_generation(rule_runner: RuleRunner) -> None:
                 {
                     TerraformModuleSources.alias: ("versions.tf",),
                 },
-                Address("", target_name="tf_mods", generated_name="src/tf/foo"),
+                generator_addr.create_generated("src/tf/foo"),
             ),
             TerraformModule(
                 {
@@ -62,7 +63,7 @@ def test_target_generation(rule_runner: RuleRunner) -> None:
                         "versions.tf",
                     ),
                 },
-                Address("", target_name="tf_mods", generated_name="src/tf"),
+                generator_addr.create_generated("src/tf/")
             ),
         ],
     )

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -376,6 +376,13 @@ class Address(EngineAwareParameter):
             )
         return self
 
+    def create_generated(self, generated_name: str) -> Address:
+        if self.is_generated_target:
+            raise AssertionError("Cannot call ")
+        return self.__class__(
+            self.spec_path, target_name=self._target_name, generated_name=generated_name
+        )
+
     def __eq__(self, other):
         if not isinstance(other, Address):
             return False

--- a/src/python/pants/build_graph/address_test.py
+++ b/src/python/pants/build_graph/address_test.py
@@ -379,6 +379,16 @@ def test_address_maybe_convert_to_generated_target() -> None:
     assert_noops(Address("a/b", generated_name="generated"))
 
 
+def test_address_create_generated() -> None:
+    assert Address("dir", target_name="generator").create_generated("generated") == Address(
+        "dir", target_name="generator", generated_name="generated"
+    )
+    with pytest.raises(AssertionError):
+        Address("", target_name="t", relative_file_path="f.ext").create_generated("gen")
+    with pytest.raises(AssertionError):
+        Address("", target_name="t", generated_name="gen").create_generated("gen")
+
+
 @pytest.mark.parametrize(
     "addr,expected",
     [

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -718,19 +718,22 @@ class GeneratedTargets(FrozenDict[Address, Target]):
                     "All generated targets must have the same `Address.spec_path` as their "
                     f"target generator. Expected {generator.address.spec_path}, but got "
                     f"{tgt.address.spec_path} for target generated from {generator.address}: {tgt}"
+                    "\n\nConsider using `request.generator.address.create_generated()`."
                 )
             if tgt.address.target_name != expected_tgt_name:
                 raise InvalidGeneratedTargetException(
                     "All generated targets must have the same `Address.target_name` as their "
                     f"target generator. Expected {generator.address.target_name}, but got "
                     f"{tgt.address.target_name} for target generated from {generator.address}: "
-                    f"{tgt}"
+                    f"{tgt}\n\n"
+                    "Consider using `request.generator.address.create_generated()`."
                 )
             if not tgt.address.is_generated_target:
                 raise InvalidGeneratedTargetException(
                     "All generated targets must set `Address.generator_name` or "
                     "`Address.relative_file_path`. Invalid for target generated from "
-                    f"{generator.address}: {tgt}"
+                    f"{generator.address}: {tgt}\n\n"
+                    "Consider using `request.generator.address.create_generated()`."
                 )
             mapping[tgt.address] = tgt
         super().__init__(mapping)
@@ -777,11 +780,7 @@ def generate_file_level_targets(
     for fp in paths:
         relativized_fp = str(PurePath(fp).relative_to(generator.address.spec_path))
         all_generated_addresses.append(
-            Address(
-                generator.address.spec_path,
-                target_name=generator.address.target_name,
-                generated_name=relativized_fp,
-            )
+            generator.address.create_generated(relativized_fp)
             if use_generated_address_syntax
             else Address(
                 generator.address.spec_path,


### PR DESCRIPTION
I've been using this for a couple target generation rules, so I think it's worth DRYing.

[ci skip-rust]
[ci skip-build-wheels]