### PR TITLE
[internal] Adds `JUnit` subsystem and add passthrough args option

### DIFF
--- a/src/python/pants/backend/java/subsystems/BUILD
+++ b/src/python/pants/backend/java/subsystems/BUILD
@@ -1,0 +1,5 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_library()
+python_tests(name="tests")

--- a/src/python/pants/backend/java/subsystems/junit.py
+++ b/src/python/pants/backend/java/subsystems/junit.py
@@ -1,0 +1,22 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.option.custom_types import shell_str
+from pants.option.subsystem import Subsystem
+
+
+class JUnit(Subsystem):
+    options_scope = "junit"
+    help = "The JUnit test framework (https://junit.org)"
+
+    @classmethod
+    def register_options(cls, register):
+        super().register_options(register)
+
+        register(
+            "--args",
+            type=list,
+            member_type=shell_str,
+            passthrough=True,
+            help="Arguments to pass directly to JUnit, e.g. `--disable-ansi-colors`",
+        )

--- a/src/python/pants/backend/java/test/junit.py
+++ b/src/python/pants/backend/java/test/junit.py
@@ -28,6 +28,7 @@ from pants.jvm.resolve.coursier_fetch import (
 )
 from pants.jvm.resolve.coursier_setup import Coursier
 from pants.util.logging import LogLevel
+from pants.backend.java.subsystems.junit import JUnit
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +43,7 @@ class JavaTestFieldSet(TestFieldSet):
 @rule(desc="Run JUnit", level=LogLevel.DEBUG)
 async def run_junit_test(
     coursier: Coursier,
+    junit: JUnit,
     field_set: JavaTestFieldSet,
 ) -> TestResult:
     transitive_targets = await Get(TransitiveTargets, TransitiveTargetsRequest([field_set.address]))
@@ -118,6 +120,7 @@ async def run_junit_test(
             usercp_relpath,
             "--scan-class-path",
             usercp_relpath,
+            *(junit.options.args)
         ],
         input_digest=merged_digest,
         description=f"Run JUnit 5 ConsoleLauncher against {field_set.address}",

--- a/src/python/pants/backend/java/test/junit.py
+++ b/src/python/pants/backend/java/test/junit.py
@@ -114,7 +114,7 @@ async def run_junit_test(
             usercp_relpath,
             "--scan-class-path",
             usercp_relpath,
-            *(junit.options.args),
+            *junit.options.args,
         ],
         input_digest=merged_digest,
         description=f"Run JUnit 5 ConsoleLauncher against {field_set.address}",

--- a/src/python/pants/backend/java/test/junit.py
+++ b/src/python/pants/backend/java/test/junit.py
@@ -5,6 +5,7 @@ import logging
 from dataclasses import dataclass
 
 from pants.backend.java.compile.javac import CompiledClassfiles, CompileJavaSourceRequest
+from pants.backend.java.subsystems.junit import JUnit
 from pants.backend.java.target_types import JavaTestsSources
 from pants.core.goals.test import TestDebugRequest, TestFieldSet, TestResult
 from pants.engine.addresses import Addresses
@@ -28,7 +29,6 @@ from pants.jvm.resolve.coursier_fetch import (
 )
 from pants.jvm.resolve.coursier_setup import Coursier
 from pants.util.logging import LogLevel
-from pants.backend.java.subsystems.junit import JUnit
 
 logger = logging.getLogger(__name__)
 
@@ -110,17 +110,11 @@ async def run_junit_test(
             "-cp",
             materialized_classpath.classpath_arg(),
             "org.junit.platform.console.ConsoleLauncher",
-            # TODO(12812): Make these options configurable by integration tests in `junit_test.py`.
-            # Remove these hard-coded options before general availability.
-            "--disable-ansi-colors",
-            "--details=flat",
-            "--details-theme=ascii",
-            # END TODO REMOVAL
             "--classpath",
             usercp_relpath,
             "--scan-class-path",
             usercp_relpath,
-            *(junit.options.args)
+            *(junit.options.args),
         ],
         input_digest=merged_digest,
         description=f"Run JUnit 5 ConsoleLauncher against {field_set.address}",

--- a/src/python/pants/backend/java/test/junit_test.py
+++ b/src/python/pants/backend/java/test/junit_test.py
@@ -55,7 +55,11 @@ def rule_runner() -> RuleRunner:
             QueryRule(TestResult, (JavaTestFieldSet,)),
         ],
         target_types=[JvmDependencyLockfile, JvmArtifact, JavaLibrary, JunitTests],
-        bootstrap_args=["--javac-jdk=system"],  # TODO(#12293): use a fixed JDK version.
+        bootstrap_args=[
+            "--javac-jdk=system",  # TODO(#12293): use a fixed JDK version.
+            # Makes JUnit output predictable and parseable across versions (#12933):
+            "--junit-args=['--disable-ansi-colors','--details=flat','--details-theme=ascii']",
+        ],
     )
 
 


### PR DESCRIPTION
This closes #12933 by removing the hardcoded flattification arguments that we introduced in #12909, and passes them into the integration tests where they're actually needed, by way of a new `JUnit` subsystem, which allows us to pass through extra args to JUnit.

This introduces a `java.subsystems` package, which mimics the similar structure in Pythonland, assuming this structure is good, followup work will need to include moving `javac_subsystem` over to this new package for consistency.