### PR TITLE
Add PackageRootedDependencyMap for mapping inferred Java dependencies

### DIFF
--- a/src/python/pants/backend/java/dependency_inference/BUILD
+++ b/src/python/pants/backend/java/dependency_inference/BUILD
@@ -1,0 +1,5 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_library()
+python_tests(name="tests", timeout=240)

--- a/src/python/pants/backend/java/dependency_inference/package_prefix_tree.py
+++ b/src/python/pants/backend/java/dependency_inference/package_prefix_tree.py
@@ -1,0 +1,93 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import FrozenSet, Set
+
+from pants.engine.addresses import Address
+
+
+class PackageRootedDependencyMap:
+    """A utility class for mapping Java FQTs and packages to owning source Addresses.
+
+    This class treats Java packages as logically opaque strings, ignoring the
+    apparent hierarchy (which is itself misleading).  For example, the packages
+    "org.pantsbuild" and "org.pantsbuild.foo" are treated as completely unrelated
+    packages by this mapping implementation.
+
+    We keep track of two things:
+        * Which Address provides a fully qualified symbol
+        * The set of Addresses that provide a given package
+    """
+
+    class ConflictingTypeOwnershipError(Exception):
+        """Raised when a Java FQT appears to be provided by more than one Address."""
+
+    def __init__(self):
+        self._type_map: dict[str, Address] = {}
+        self._package_map: dict[str, Set[Address]] = defaultdict(set)
+
+    def add_top_level_type(self, package: str, type_: str, address: Address):
+        """Declare a single Address as the provider of a top level type.
+
+        Raises ConflictingTypeOwnershipError if another address is already the provider
+        of the passed FQT.
+
+        This method also associates the address with the type's package, and there can
+        be more than one address associated with a given package.
+        """
+        fqt = ".".join([package, type_])
+        if fqt in self._type_map and self._type_map[fqt] != address:
+            raise PackageRootedDependencyMap.ConflictingTypeOwnershipError(
+                f"Attempted register '{address}' as provider of fully qualified type"
+                f" '{fqt}', but it is already provided by '{self._type_map[fqt]}'"
+            )
+        self._type_map[fqt] = address
+        self._package_map[package].add(address)
+
+    def add_package(self, package: str, address: Address):
+        """Add an address as one of the providers of a package."""
+        self._package_map[package].add(address)
+
+    def addresses_for_symbol(self, symbol: str) -> FrozenSet[Address]:
+        """Returns the set of addresses that provide the passed symbol.
+
+        `symbol` should be a fully qualified Java type (FQT) (e.g. `foo.bar.Thing`),
+        or a Java package (e.g. `foo.bar`).
+
+        We first check if the symbol has an exact matching provider address for the FQT.
+        If it does, only that address is returned.  We then check if the symbol is
+        actually a package, in which case we return the set of addresses that provide
+        that package.
+
+        We then chop off the rightmost part of the symbol (e.g. `foo.bar.Thing` becomes
+        `foo.bar`) and repeat the above process until there is nothing left.  If nothing
+        is found, an empty set is returned.
+        """
+        parts = symbol.split(".")
+        for num_parts in range(len(parts), 0, -1):
+            prefix = ".".join(parts[:num_parts])
+            if prefix in self._type_map:
+                return frozenset([self._type_map[prefix]])
+            if prefix in self._package_map:
+                return frozenset(self._package_map[prefix])
+        return frozenset()
+
+    def merge(self, other: PackageRootedDependencyMap):
+        """Merge 'other' into this dependency map.
+
+        Raises ConflictingTypeOwnershipError if 'other' has an FQT mapped to an address that
+        conflicts with this dep map.
+        """
+
+        for type_, address in other._type_map.items():
+            if type_ in self._type_map and self._type_map[type_] != address:
+                raise PackageRootedDependencyMap.ConflictingTypeOwnershipError(
+                    'Conflicting ownership of FQT "{type_}": both {self._type_map[type_]}'
+                    " and {address} appear to provide this type."
+                )
+            self._type_map[type_] = address
+        for package, addresses in other._package_map.items():
+            self._package_map[package] |= addresses

--- a/src/python/pants/backend/java/dependency_inference/package_prefix_tree_test.py
+++ b/src/python/pants/backend/java/dependency_inference/package_prefix_tree_test.py
@@ -1,0 +1,70 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import pytest
+
+from pants.backend.java.dependency_inference.package_prefix_tree import PackageRootedDependencyMap
+from pants.engine.addresses import Address
+
+
+def test_package_rooted_dependency_map() -> None:
+    dep_map = PackageRootedDependencyMap()
+
+    a = Address("a")
+    dep_map.add_top_level_type(package="org.pantsbuild", type_="Foo", address=a)
+    # An exact match yields the exact matching address
+    assert dep_map.addresses_for_symbol("org.pantsbuild.Foo") == frozenset([a])
+    # A miss with a package match yields all providers of the package
+    assert dep_map.addresses_for_symbol("org.pantsbuild.Bar") == frozenset([a])
+    # A miss without a package map returns nothing
+    assert dep_map.addresses_for_symbol("org.Foo") == frozenset()
+    assert dep_map.addresses_for_symbol("org.other.Foo") == frozenset()
+
+    b = Address("b")
+    dep_map.add_top_level_type(package="org.pantsbuild", type_="Baz", address=b)
+    # Again, exact matches yield exact providers
+    assert dep_map.addresses_for_symbol("org.pantsbuild.Foo") == frozenset([a])
+    assert dep_map.addresses_for_symbol("org.pantsbuild.Baz") == frozenset([b])
+    # But package-only match yields all providers of that package.
+    assert dep_map.addresses_for_symbol("org.pantsbuild.Bar") == frozenset([a, b])
+    # And total misses result in nothing.
+    assert dep_map.addresses_for_symbol("org.Foo") == frozenset()
+    assert dep_map.addresses_for_symbol("org.other.Foo") == frozenset()
+
+    c = Address("c")
+    # We can also add a package provider manually.
+    dep_map.add_package("org.pantsbuild", c)
+    # It will be included in the event of a package-only match:
+    assert dep_map.addresses_for_symbol("org.pantsbuild.Bar") == frozenset([a, b, c])
+
+    # Package matching also works if the package alone is passed as a symbol:
+    assert dep_map.addresses_for_symbol("org.pantsbuild") == frozenset([a, b, c])
+    # But note that we can't distinguish a FQT from a package:
+    assert dep_map.addresses_for_symbol("org.pantsbuild.other.package") == frozenset([a, b, c])
+
+    d = Address("d")
+    # But if we know about org.pantsbuild.other.package, the above doesn't happen:
+    dep_map.add_package("org.pantsbuild.other.package", d)
+    assert dep_map.addresses_for_symbol("org.pantsbuild.other.package") == frozenset([d])
+
+
+def test_package_rooted_dependency_map_errors() -> None:
+    dep_map = PackageRootedDependencyMap()
+    a = Address("a")
+    b = Address("b")
+
+    dep_map.add_top_level_type(package="org.pantsbuild", type_="Foo", address=a)
+    # Adding this type again is fine as long as the address is the same
+    dep_map.add_top_level_type(package="org.pantsbuild", type_="Foo", address=a)
+    # But trying to associate it to a different address is an error:
+    with pytest.raises(PackageRootedDependencyMap.ConflictingTypeOwnershipError):
+        dep_map.add_top_level_type(package="org.pantsbuild", type_="Foo", address=b)
+
+    other_map = PackageRootedDependencyMap()
+    other_map.add_top_level_type(package="org.pantsbuild", type_="Foo", address=b)
+
+    # Trying to merge in a conflict causes the same error:
+    with pytest.raises(PackageRootedDependencyMap.ConflictingTypeOwnershipError):
+        dep_map.merge(other_map)


### PR DESCRIPTION
This class is used in later PRs for collecting and mapping Java types and packages for dependency inference.

[ci skip-rust]
[ci skip-build-wheels]