### PR TITLE
[internal] Remove spurious `python_tests` directive

### DIFF
--- a/src/python/pants/backend/java/subsystems/BUILD
+++ b/src/python/pants/backend/java/subsystems/BUILD
@@ -2,4 +2,3 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library()
-python_tests(name="tests")


### PR DESCRIPTION
These can be removed if/when the `junit` subsystem itself has tests