### PR TITLE
Remove `Enriched*Result` classes in favor of `EngineAwareReturnType.cacheable`

### DIFF
--- a/src/python/pants/backend/go/lint/fmt.py
+++ b/src/python/pants/backend/go/lint/fmt.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Iterable
 
 from pants.backend.go.target_types import GoSources
-from pants.core.goals.fmt import EnrichedFmtResult, LanguageFmtResults, LanguageFmtTargets
+from pants.core.goals.fmt import FmtResult, LanguageFmtResults, LanguageFmtTargets
 from pants.core.goals.style_request import StyleRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, Snapshot
@@ -49,7 +49,7 @@ async def format_golang_targets(
         )
         if not request.field_sets:
             continue
-        result = await Get(EnrichedFmtResult, GoLangFmtRequest, request)
+        result = await Get(FmtResult, GoLangFmtRequest, request)
         results.append(result)
         if result.did_change:
             prior_formatter_result = await Get(Snapshot, Digest, result.output)

--- a/src/python/pants/backend/java/test/junit.py
+++ b/src/python/pants/backend/java/test/junit.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from pants.backend.java.compile.javac import CompiledClassfiles, CompileJavaSourceRequest
 from pants.backend.java.subsystems.junit import JUnit
 from pants.backend.java.target_types import JavaTestsSources
-from pants.core.goals.test import TestDebugRequest, TestFieldSet, TestResult
+from pants.core.goals.test import TestDebugRequest, TestFieldSet, TestResult, TestSubsystem
 from pants.engine.addresses import Addresses
 from pants.engine.fs import AddPrefix, Digest, MergeDigests
 from pants.engine.process import FallibleProcessResult, Process
@@ -44,6 +44,7 @@ class JavaTestFieldSet(TestFieldSet):
 async def run_junit_test(
     coursier: Coursier,
     junit: JUnit,
+    test_subsystem: TestSubsystem,
     field_set: JavaTestFieldSet,
 ) -> TestResult:
     transitive_targets = await Get(TransitiveTargets, TransitiveTargetsRequest([field_set.address]))
@@ -130,6 +131,7 @@ async def run_junit_test(
     return TestResult.from_fallible_process_result(
         process_result,
         address=field_set.address,
+        output_setting=test_subsystem.output,
     )
 
 

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -356,6 +356,7 @@ async def run_python_test(
     return TestResult.from_fallible_process_result(
         result,
         address=field_set.address,
+        output_setting=test_subsystem.output,
         coverage_data=coverage_data,
         xml_results=xml_results_snapshot,
         extra_output=extra_output_snapshot,

--- a/src/python/pants/backend/python/lint/python_fmt.py
+++ b/src/python/pants/backend/python/lint/python_fmt.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Iterable
 
 from pants.backend.python.target_types import PythonSources
-from pants.core.goals.fmt import EnrichedFmtResult, LanguageFmtResults, LanguageFmtTargets
+from pants.core.goals.fmt import FmtResult, LanguageFmtResults, LanguageFmtTargets
 from pants.core.goals.style_request import StyleRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, Snapshot
@@ -46,7 +46,7 @@ async def format_python_target(
         )
         if not request.field_sets:
             continue
-        result = await Get(EnrichedFmtResult, PythonFmtRequest, request)
+        result = await Get(FmtResult, PythonFmtRequest, request)
         results.append(result)
         if result.did_change:
             prior_formatter_result = await Get(Snapshot, Digest, result.output)

--- a/src/python/pants/backend/python/lint/python_fmt_integration_test.py
+++ b/src/python/pants/backend/python/lint/python_fmt_integration_test.py
@@ -11,7 +11,7 @@ from pants.backend.python.lint.isort.rules import rules as isort_rules
 from pants.backend.python.lint.isort.subsystem import rules as isort_subsystem_rules
 from pants.backend.python.lint.python_fmt import PythonFmtTargets, format_python_target
 from pants.backend.python.target_types import PythonLibrary
-from pants.core.goals.fmt import LanguageFmtResults, enrich_fmt_result
+from pants.core.goals.fmt import LanguageFmtResults
 from pants.core.util_rules import config_files, source_files
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
@@ -26,7 +26,6 @@ FIXED_BAD_FILE = 'from animals import cat, dog\n\nprint("hello")\n'
 def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
-            enrich_fmt_result,
             format_python_target,
             *black_rules(),
             *isort_rules(),

--- a/src/python/pants/backend/shell/lint/shell_fmt.py
+++ b/src/python/pants/backend/shell/lint/shell_fmt.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Iterable
 
 from pants.backend.shell.target_types import ShellSources
-from pants.core.goals.fmt import EnrichedFmtResult, LanguageFmtResults, LanguageFmtTargets
+from pants.core.goals.fmt import FmtResult, LanguageFmtResults, LanguageFmtTargets
 from pants.core.goals.style_request import StyleRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, Snapshot
@@ -48,7 +48,7 @@ async def format_shell_targets(
         )
         if not request.field_sets:
             continue
-        result = await Get(EnrichedFmtResult, ShellFmtRequest, request)
+        result = await Get(FmtResult, ShellFmtRequest, request)
         results.append(result)
         if result.did_change:
             prior_formatter_result = await Get(Snapshot, Digest, result.output)

--- a/src/python/pants/backend/shell/shunit2_test_runner.py
+++ b/src/python/pants/backend/shell/shunit2_test_runner.py
@@ -241,10 +241,16 @@ async def setup_shunit2_for_target(
 
 
 @rule(desc="Run tests with Shunit2", level=LogLevel.DEBUG)
-async def run_tests_with_shunit2(field_set: Shunit2FieldSet) -> TestResult:
+async def run_tests_with_shunit2(
+    field_set: Shunit2FieldSet, test_subsystem: TestSubsystem
+) -> TestResult:
     setup = await Get(TestSetup, TestSetupRequest(field_set))
     result = await Get(FallibleProcessResult, Process, setup.process)
-    return TestResult.from_fallible_process_result(result, address=field_set.address)
+    return TestResult.from_fallible_process_result(
+        result,
+        address=field_set.address,
+        output_setting=test_subsystem.output,
+    )
 
 
 @rule(desc="Setup Shunit2 to run interactively", level=LogLevel.DEBUG)

--- a/src/python/pants/backend/terraform/lint/fmt.py
+++ b/src/python/pants/backend/terraform/lint/fmt.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Iterable
 
 from pants.backend.terraform.target_types import TerraformSources
-from pants.core.goals.fmt import EnrichedFmtResult, LanguageFmtResults, LanguageFmtTargets
+from pants.core.goals.fmt import FmtResult, LanguageFmtResults, LanguageFmtTargets
 from pants.core.goals.style_request import StyleRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, Snapshot
@@ -47,7 +47,7 @@ async def format_terraform_targets(
         )
         if not request.field_sets:
             continue
-        result = await Get(EnrichedFmtResult, TerraformFmtRequest, request)
+        result = await Get(FmtResult, TerraformFmtRequest, request)
         results.append(result)
         if result.did_change:
             prior_formatter_result = await Get(Snapshot, Digest, result.output)

--- a/src/python/pants/core/goals/fmt_test.py
+++ b/src/python/pants/core/goals/fmt_test.py
@@ -9,7 +9,6 @@ from typing import ClassVar, List, Optional, Type
 import pytest
 
 from pants.core.goals.fmt import (
-    EnrichedFmtResult,
     Fmt,
     FmtResult,
     FmtSubsystem,
@@ -285,14 +284,14 @@ def test_summary(rule_runner: RuleRunner) -> None:
 
 
 def test_streaming_output_skip() -> None:
-    result = EnrichedFmtResult.skip(formatter_name="formatter")
+    result = FmtResult.skip(formatter_name="formatter")
     assert result.level() == LogLevel.DEBUG
     assert result.message() == "formatter skipped."
 
 
 def test_streaming_output_changed() -> None:
     changed_digest = Digest(EMPTY_DIGEST.fingerprint, 2)
-    result = EnrichedFmtResult(
+    result = FmtResult(
         input=EMPTY_DIGEST,
         output=changed_digest,
         stdout="stdout",
@@ -311,7 +310,7 @@ def test_streaming_output_changed() -> None:
 
 
 def test_streaming_output_not_changed() -> None:
-    result = EnrichedFmtResult(
+    result = FmtResult(
         input=EMPTY_DIGEST,
         output=EMPTY_DIGEST,
         stdout="stdout",

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -19,7 +19,7 @@ from pants.engine.engine_aware import EngineAwareReturnType
 from pants.engine.fs import EMPTY_DIGEST, Digest, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import FallibleProcessResult
-from pants.engine.rules import Get, MultiGet, _uncacheable_rule, collect_rules, goal_rule
+from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
 from pants.engine.target import Targets
 from pants.engine.unions import UnionMembership, union
 from pants.util.logging import LogLevel
@@ -69,7 +69,7 @@ class LintResult(EngineAwareReturnType):
 
 @frozen_after_init
 @dataclass(unsafe_hash=True)
-class LintResults:
+class LintResults(EngineAwareReturnType):
     """Zero or more LintResult objects for a single linter.
 
     Typically, linters will return one result. If they no-oped, they will return zero results.
@@ -91,14 +91,6 @@ class LintResults:
     @memoized_property
     def exit_code(self) -> int:
         return next((result.exit_code for result in self.results if result.exit_code != 0), 0)
-
-
-class EnrichedLintResults(LintResults, EngineAwareReturnType):
-    """`LintResults` that are enriched for the sake of logging results as they come in.
-
-    Plugin authors only need to return `LintResults`, and a rule will upcast those into
-    `EnrichedLintResults`.
-    """
 
     def level(self) -> Optional[LogLevel]:
         if self.skipped:
@@ -136,6 +128,10 @@ class EnrichedLintResults(LintResults, EngineAwareReturnType):
                 results_msg += msg
         message += results_msg
         return message
+
+    def cacheable(self) -> bool:
+        """Is marked uncacheable to ensure that it always renders."""
+        return False
 
 
 @union
@@ -216,19 +212,19 @@ async def lint(
 
     if lint_subsystem.per_file_caching:
         all_per_file_results = await MultiGet(
-            Get(EnrichedLintResults, LintRequest, request.__class__([field_set]))
+            Get(LintResults, LintRequest, request.__class__([field_set]))
             for request in valid_requests
             for field_set in request.field_sets
         )
 
-        def key_fn(results: EnrichedLintResults):
+        def key_fn(results: LintResults):
             return results.linter_name
 
         # NB: We must pre-sort the data for itertools.groupby() to work properly.
         sorted_all_per_files_results = sorted(all_per_file_results, key=key_fn)
         # We consolidate all results for each linter into a single `LintResults`.
         all_results = tuple(
-            EnrichedLintResults(
+            LintResults(
                 itertools.chain.from_iterable(
                     per_file_results.results for per_file_results in all_linter_results
                 ),
@@ -240,7 +236,7 @@ async def lint(
         )
     else:
         all_results = await MultiGet(
-            Get(EnrichedLintResults, LintRequest, lint_request) for lint_request in valid_requests
+            Get(LintResults, LintRequest, lint_request) for lint_request in valid_requests
         )
 
     all_results = tuple(sorted(all_results, key=lambda results: results.linter_name))
@@ -273,13 +269,6 @@ async def lint(
         console.print_stderr(f"{sigil} {results.linter_name} {status}.")
 
     return Lint(exit_code)
-
-
-# NB: We mark this uncachable to ensure that the results are always streamed, even if the
-# underlying LintResults is memoized. This rule is very cheap, so there's little performance hit.
-@_uncacheable_rule(desc="lint")
-def enrich_lint_results(results: LintResults) -> EnrichedLintResults:
-    return EnrichedLintResults(results=results.results, linter_name=results.linter_name)
 
 
 def rules():

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -26,7 +26,7 @@ from pants.engine.environment import CompleteEnvironment
 from pants.engine.fs import Digest, FileDigest, MergeDigests, Snapshot, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import FallibleProcessResult, InteractiveProcess, InteractiveRunner
-from pants.engine.rules import Get, MultiGet, _uncacheable_rule, collect_rules, goal_rule, rule
+from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
 from pants.engine.target import (
     FieldSet,
     FieldSetsPerTarget,
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class TestResult:
+class TestResult(EngineAwareReturnType):
     exit_code: int
     stdout: str
     stdout_digest: FileDigest
@@ -87,31 +87,14 @@ class TestResult:
             extra_output=extra_output,
         )
 
-    def __lt__(self, other: Union[Any, EnrichedTestResult]) -> bool:
+    def __lt__(self, other: Any) -> bool:
         """We sort first by status (failed vs succeeded), then alphanumerically within each
         group."""
-        if not isinstance(other, EnrichedTestResult):
+        if not isinstance(other, TestResult):
             return NotImplemented
         if self.exit_code == other.exit_code:
             return self.address.spec < other.address.spec
         return abs(self.exit_code) < abs(other.exit_code)
-
-
-class ShowOutput(Enum):
-    """Which tests to emit detailed output for."""
-
-    ALL = "all"
-    FAILED = "failed"
-    NONE = "none"
-
-
-@dataclass(frozen=True)
-class EnrichedTestResult(TestResult, EngineAwareReturnType):
-    """A `TestResult` that is enriched for the sake of logging results as they come in.
-
-    Plugin authors only need to return `TestResult`, and a rule will upcast those into
-    `EnrichedTestResult`.
-    """
 
     def artifacts(self) -> Optional[Dict[str, Union[FileDigest, Snapshot]]]:
         output: Dict[str, Union[FileDigest, Snapshot]] = {
@@ -143,6 +126,18 @@ class EnrichedTestResult(TestResult, EngineAwareReturnType):
 
     def metadata(self) -> Dict[str, Any]:
         return {"address": self.address.spec}
+
+    def cacheable(self) -> bool:
+        """Is marked uncacheable to ensure that it always renders."""
+        return False
+
+
+class ShowOutput(Enum):
+    """Which tests to emit detailed output for."""
+
+    ALL = "all"
+    FAILED = "failed"
+    NONE = "none"
 
 
 @dataclass(frozen=True)
@@ -394,7 +389,7 @@ async def run_tests(
     )
 
     results = await MultiGet(
-        Get(EnrichedTestResult, TestFieldSet, field_set) for field_set in field_sets_with_sources
+        Get(TestResult, TestFieldSet, field_set) for field_set in field_sets_with_sources
     )
 
     # Print summary.
@@ -484,24 +479,6 @@ def get_filtered_environment(
         else FrozenDict({})
     )
     return TestExtraEnv(env)
-
-
-# NB: We mark this uncachable to ensure that the results are always streamed, even if the
-# underlying TestResult is memoized. This rule is very cheap, so there's little performance hit.
-@_uncacheable_rule(desc="test")
-def enrich_test_result(test_result: TestResult) -> EnrichedTestResult:
-    return EnrichedTestResult(
-        exit_code=test_result.exit_code,
-        stdout=test_result.stdout,
-        stdout_digest=test_result.stdout_digest,
-        stderr=test_result.stderr,
-        stderr_digest=test_result.stderr_digest,
-        address=test_result.address,
-        output_setting=test_result.output_setting,
-        coverage_data=test_result.coverage_data,
-        xml_results=test_result.xml_results,
-        extra_output=test_result.extra_output,
-    )
 
 
 # -------------------------------------------------------------------------------------------

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -21,12 +21,12 @@ from pants.core.goals.test import (
     CoverageData,
     CoverageDataCollection,
     CoverageReports,
-    EnrichedTestResult,
     RuntimePackageDependenciesField,
     ShowOutput,
     Test,
     TestDebugRequest,
     TestFieldSet,
+    TestResult,
     TestSubsystem,
     build_runtime_package_dependencies,
     run_tests,
@@ -90,8 +90,8 @@ class MockTestFieldSet(TestFieldSet, metaclass=ABCMeta):
         pass
 
     @property
-    def test_result(self) -> EnrichedTestResult:
-        return EnrichedTestResult(
+    def test_result(self) -> TestResult:
+        return TestResult(
             exit_code=self.exit_code(self.address),
             stdout="",
             stdout_digest=EMPTY_FILE_DIGEST,
@@ -193,7 +193,7 @@ def run_test_rule(
                     mock=mock_find_valid_field_sets,
                 ),
                 MockGet(
-                    output_type=EnrichedTestResult,
+                    output_type=TestResult,
                     input_type=TestFieldSet,
                     mock=lambda fs: fs.test_result,
                 ),
@@ -298,7 +298,7 @@ def test_coverage(rule_runner: RuleRunner) -> None:
 
 def sort_results() -> None:
     create_test_result = partial(
-        EnrichedTestResult,
+        TestResult,
         stdout="",
         stdout_digest=EMPTY_FILE_DIGEST,
         stderr="",
@@ -330,7 +330,7 @@ def assert_streaming_output(
     expected_level: LogLevel,
     expected_message: str,
 ) -> None:
-    result = EnrichedTestResult(
+    result = TestResult(
         exit_code=exit_code,
         stdout=stdout,
         stdout_digest=EMPTY_FILE_DIGEST,


### PR DESCRIPTION
The `Enriched*Result` classes were added in order to force re-rendering of high-level `lint`/`fmt`/`test`/`check` results, regardless of whether they had succeeded or failed. Although whether they should re-render even for successful results remains open to debate, #12877 allows for removing the "enriching" `@rule` and `Enriched*Result` wrappers by moving the specification of their cacheability directly onto the `(Lint|Fmt|Check|Test)Result` types.

When compared to the existing use of an "enriching" `@rule`, this change has the downside that the entire `@rule` body that produces a `*Result` will re-run. But because all of its inputs will be cached, this should be a trivial cost.