### PR TITLE
[internal] jvm/java: ensure JDK downloaded in one process

### DIFF
--- a/src/python/pants/backend/experimental/java/register.py
+++ b/src/python/pants/backend/experimental/java/register.py
@@ -2,11 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.backend.java import tailor
+from pants.backend.java import util_rules as java_util_rules
 from pants.backend.java.compile import javac, javac_binary
 from pants.backend.java.target_types import JavaLibrary, JunitTests
 from pants.backend.java.target_types import rules as target_types_rules
 from pants.backend.java.test import junit
-from pants.jvm import util_rules
+from pants.jvm import util_rules as jvm_util_rules
 from pants.jvm.goals import coursier
 from pants.jvm.resolve import coursier_fetch, coursier_setup
 from pants.jvm.target_types import JvmDependencyLockfile
@@ -25,6 +26,7 @@ def rules():
         *coursier_fetch.rules(),
         *coursier_setup.rules(),
         *tailor.rules(),
-        *util_rules.rules(),
+        *jvm_util_rules.rules(),
+        *java_util_rules.rules(),
         *target_types_rules(),
     ]

--- a/src/python/pants/backend/java/compile/javac_binary_test.py
+++ b/src/python/pants/backend/java/compile/javac_binary_test.py
@@ -7,6 +7,7 @@ import pytest
 
 from pants.backend.java.compile.javac_binary import JavacBinary
 from pants.backend.java.compile.javac_binary import rules as javac_binary_rules
+from pants.backend.java.util_rules import rules as util_rules_rules
 from pants.core.util_rules.external_tool import rules as external_tool_rules
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.process import BashBinary, Process, ProcessResult
@@ -22,6 +23,7 @@ def rule_runner() -> RuleRunner:
             *coursier_setup_rules(),
             *external_tool_rules(),
             *javac_binary_rules(),
+            *util_rules_rules(),
             *process_rules(),
             QueryRule(BashBinary, ()),
             QueryRule(JavacBinary, ()),

--- a/src/python/pants/backend/java/compile/javac_test.py
+++ b/src/python/pants/backend/java/compile/javac_test.py
@@ -7,6 +7,7 @@ from textwrap import dedent
 
 import pytest
 
+from pants.backend.java import util_rules as java_util_rules
 from pants.backend.java.compile.javac import (
     CompiledClassfiles,
     CompileJavaSourceRequest,
@@ -54,6 +55,7 @@ def rule_runner() -> RuleRunner:
             *javac_binary_rules(),
             *target_types_rules(),
             *coursier_rules(),
+            *java_util_rules.rules(),
             QueryRule(CheckResults, (JavacCheckRequest,)),
             QueryRule(FallibleCompiledClassfiles, (CompileJavaSourceRequest,)),
             QueryRule(CompiledClassfiles, (CompileJavaSourceRequest,)),

--- a/src/python/pants/backend/java/dependency_inference/java_parser.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser.py
@@ -13,12 +13,12 @@ from pants.backend.java.dependency_inference.java_parser_launcher import (
     java_parser_artifact_requirements,
 )
 from pants.backend.java.dependency_inference.types import JavaSourceDependencyAnalysis
+from pants.backend.java.util_rules import JdkSetup
 from pants.core.util_rules.source_files import SourceFiles
 from pants.engine.fs import AddPrefix, Digest, DigestContents, MergeDigests
-from pants.engine.process import BashBinary, FallibleProcessResult, Process, ProcessExecutionFailure
+from pants.engine.process import FallibleProcessResult, Process, ProcessExecutionFailure
 from pants.engine.rules import Get, collect_rules, rule
 from pants.jvm.resolve.coursier_fetch import MaterializedClasspath, MaterializedClasspathRequest
-from pants.jvm.resolve.coursier_setup import Coursier
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
@@ -51,8 +51,7 @@ async def resolve_fallible_result_to_analysis(
 
 @rule(level=LogLevel.DEBUG)
 async def analyze_java_source_dependencies(
-    bash: BashBinary,
-    coursier: Coursier,
+    jdk_setup: JdkSetup,
     processor_classfiles: JavaParserCompiledClassfiles,
     source_files: SourceFiles,
 ) -> FallibleJavaSourceDependencyAnalysisResult:
@@ -88,7 +87,6 @@ async def analyze_java_source_dependencies(
             (
                 prefixed_processor_classfiles_digest,
                 tool_classpath.digest,
-                coursier.digest,
                 prefixed_source_files_digest,
             )
         ),
@@ -98,9 +96,7 @@ async def analyze_java_source_dependencies(
 
     proc = Process(
         argv=[
-            coursier.coursier.exe,
-            "java",
-            "--system-jvm",  # TODO(#12293): use a fixed JDK version from a subsystem.
+            f"{jdk_setup.java_home}/bin/java",
             "-cp",
             ":".join([tool_classpath.classpath_arg(), processorcp_relpath]),
             "org.pantsbuild.javaparser.PantsJavaParserLauncher",

--- a/src/python/pants/backend/java/dependency_inference/java_parser_test.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser_test.py
@@ -7,6 +7,7 @@ from textwrap import dedent
 
 import pytest
 
+from pants.backend.java import util_rules as java_util_rules
 from pants.backend.java.compile.javac import rules as javac_rules
 from pants.backend.java.compile.javac_binary import rules as javac_binary_rules
 from pants.backend.java.dependency_inference.java_parser import (
@@ -47,6 +48,7 @@ def rule_runner() -> RuleRunner:
             *javac_rules(),
             *source_files.rules(),
             *util_rules(),
+            *java_util_rules.rules(),
             QueryRule(FallibleJavaSourceDependencyAnalysisResult, (SourceFiles,)),
             QueryRule(JavaSourceDependencyAnalysis, (SourceFiles,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),

--- a/src/python/pants/backend/java/test/junit.py
+++ b/src/python/pants/backend/java/test/junit.py
@@ -123,7 +123,6 @@ async def run_junit_test(
         description=f"Run JUnit 5 ConsoleLauncher against {field_set.address}",
         level=LogLevel.DEBUG,
     )
-    print(f"PROC={proc}")
 
     process_result = await Get(
         FallibleProcessResult,

--- a/src/python/pants/backend/java/test/junit.py
+++ b/src/python/pants/backend/java/test/junit.py
@@ -7,8 +7,8 @@ from dataclasses import dataclass
 from pants.backend.java.compile.javac import CompiledClassfiles, CompileJavaSourceRequest
 from pants.backend.java.subsystems.junit import JUnit
 from pants.backend.java.target_types import JavaTestsSources
-from pants.core.goals.test import TestDebugRequest, TestFieldSet, TestResult, TestSubsystem
 from pants.backend.java.util_rules import JdkSetup
+from pants.core.goals.test import TestDebugRequest, TestFieldSet, TestResult, TestSubsystem
 from pants.engine.addresses import Addresses
 from pants.engine.fs import AddPrefix, Digest, MergeDigests
 from pants.engine.process import FallibleProcessResult, Process

--- a/src/python/pants/backend/java/test/junit_test.py
+++ b/src/python/pants/backend/java/test/junit_test.py
@@ -14,6 +14,7 @@ from pants.backend.java.target_types import JavaLibrary, JunitTests
 from pants.backend.java.target_types import rules as target_types_rules
 from pants.backend.java.test.junit import JavaTestFieldSet
 from pants.backend.java.test.junit import rules as junit_rules
+from pants.backend.java.util_rules import rules as java_util_rules
 from pants.build_graph.address import Address
 from pants.core.goals.test import TestResult
 from pants.core.util_rules import config_files, source_files
@@ -50,6 +51,7 @@ def rule_runner() -> RuleRunner:
             *junit_rules(),
             *javac_binary_rules(),
             *util_rules(),
+            *java_util_rules(),
             *target_types_rules(),
             QueryRule(CoarsenedTargets, (Addresses,)),
             QueryRule(TestResult, (JavaTestFieldSet,)),

--- a/src/python/pants/backend/java/util_rules.py
+++ b/src/python/pants/backend/java/util_rules.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from pants.backend.java.compile.javac_subsystem import JavacSubsystem
+from pants.engine.fs import Digest
 from pants.engine.internals.selectors import Get
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import collect_rules, rule
@@ -14,7 +15,8 @@ from pants.jvm.resolve.coursier_setup import Coursier
 
 @dataclass(frozen=True)
 class JdkSetup:
-    java_home: str
+    digest: Digest
+    java_home_cmd: tuple[str, ...]
     fingerprint_comment: str
 
 
@@ -69,7 +71,8 @@ async def setup_jdk(coursier: Coursier, javac: JavacSubsystem) -> JdkSetup:
     fingerprint_comment = "".join([f"# {line}\n" for line in fingerprint_comment_lines])
 
     return JdkSetup(
-        java_home=java_home,
+        digest=coursier.digest,
+        java_home_cmd=(coursier.coursier.exe, "java-home", coursier_jdk_option),
         fingerprint_comment=fingerprint_comment,
     )
 

--- a/src/python/pants/backend/java/util_rules.py
+++ b/src/python/pants/backend/java/util_rules.py
@@ -75,14 +75,5 @@ async def setup_jdk(coursier: Coursier, javac: JavacSubsystem) -> JdkSetup:
     )
 
 
-@dataclass(frozen=True)
-class JdkProcess:
-    tool: str  # "java", "javac" etc.
-    args: tuple[str, ...]
-    input_digest: Digest
-    description: str
-    cache_scope: ProcessCacheScope
-
-
 def rules():
     return collect_rules()

--- a/src/python/pants/backend/java/util_rules.py
+++ b/src/python/pants/backend/java/util_rules.py
@@ -6,9 +6,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from pants.backend.java.compile.javac_subsystem import JavacSubsystem
-from pants.engine.fs import Digest
 from pants.engine.internals.selectors import Get
-from pants.engine.process import FallibleProcessResult, Process, ProcessCacheScope, ProcessResult
+from pants.engine.process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import collect_rules, rule
 from pants.jvm.resolve.coursier_setup import Coursier
 

--- a/src/python/pants/backend/java/util_rules.py
+++ b/src/python/pants/backend/java/util_rules.py
@@ -1,0 +1,88 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pants.backend.java.compile.javac_subsystem import JavacSubsystem
+from pants.engine.fs import Digest
+from pants.engine.internals.selectors import Get
+from pants.engine.process import FallibleProcessResult, Process, ProcessCacheScope, ProcessResult
+from pants.engine.rules import collect_rules, rule
+from pants.jvm.resolve.coursier_setup import Coursier
+
+
+@dataclass(frozen=True)
+class JdkSetup:
+    java_home: str
+    fingerprint_comment: str
+
+
+@rule
+async def setup_jdk(coursier: Coursier, javac: JavacSubsystem) -> JdkSetup:
+    if javac.options.jdk == "system":
+        coursier_jdk_option = "--system-jvm"
+    else:
+        coursier_jdk_option = f"--jvm={javac.options.jdk}"
+
+    java_home_result = await Get(
+        FallibleProcessResult,
+        Process(
+            argv=(
+                coursier.coursier.exe,
+                "java-home",
+                coursier_jdk_option,
+            ),
+            input_digest=coursier.digest,
+            description=f"Ensure download of JDK {coursier_jdk_option}.",
+        ),
+    )
+
+    if java_home_result.exit_code != 0:
+        raise ValueError(
+            f"Failed to determine JAVA_HOME for JDK {javac.options.jdk}: {java_home_result.stderr.decode('utf-8')}"
+        )
+
+    java_home = java_home_result.stdout.decode("utf-8").strip()
+
+    version_result = await Get(
+        ProcessResult,
+        Process(
+            argv=(
+                f"{java_home}/bin/java",
+                "-version",
+            ),
+            description=f"Extract version from JDK {coursier_jdk_option}.",
+        ),
+    )
+
+    all_output = "\n".join(
+        [
+            version_result.stderr.decode("utf-8"),
+            version_result.stdout.decode("utf-8"),
+        ]
+    )
+    fingerprint_comment_lines = [
+        f"pants javac script using Coursier {coursier_jdk_option}.  `java -version`:",
+        *filter(None, all_output.splitlines()),
+    ]
+    fingerprint_comment = "".join([f"# {line}\n" for line in fingerprint_comment_lines])
+
+    return JdkSetup(
+        java_home=java_home,
+        fingerprint_comment=fingerprint_comment,
+    )
+
+
+@dataclass(frozen=True)
+class JdkProcess:
+    tool: str  # "java", "javac" etc.
+    args: tuple[str, ...]
+    input_digest: Digest
+    description: str
+    cache_scope: ProcessCacheScope
+
+
+def rules():
+    return collect_rules()


### PR DESCRIPTION
## Motivation

As described in https://github.com/pantsbuild/pants/issues/12293, multiple Coursier invocations were downloading the JDK and triggering [a race condition in Coursier's locking](https://github.com/coursier/coursier/issues/1815) that caused flakiness in tests.

## Solution

This PR mitigates the issue by isolating JDK download to a single `Process`. The new `JdkSetup` type provides rules with the command to obtain the location of the JDK so they may query Coursier for JAVA_HOME. This has the benefit of still downloading in remote execution, but providing some guarantee that there will be a single download.