### PR TITLE
[internal] Bump CI token expiration threshold.

### DIFF
--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -22,6 +22,8 @@ report = ["raw", "xml"]
 [auth]
 from_env_var = "TOOLCHAIN_AUTH_TOKEN"
 org = "pantsbuild"
+# CI runs occasionally hit the 30 minute mark.
+token_expiration_threshold = 40
 ci_env_variables = [
   "GITHUB_ACTIONS", "GITHUB_RUN_ID", "GITHUB_REF", "GITHUB_EVENT_NAME", "GITHUB_SHA", "GITHUB_REPOSITORY",
   "GITHUB_WORKFLOW","GITHUB_JOB",  # temporary, for debugging issues w/ restricted tokens.


### PR DESCRIPTION
Long CI runs can hit the 30 minute default expiration, which reduces the effectiveness of the cache.

[ci skip-build-wheels]