### PR TITLE
add JDK to GitHub Actions CI

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -393,6 +393,11 @@ jobs:
         echo "EOF" >> $GITHUB_ENV
 
         '
+    - name: Install AdoptJDK
+      uses: actions/setup-java@v2
+      with:
+        distribution: adopt
+        java-version: '11'
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
@@ -471,6 +476,11 @@ jobs:
         echo "EOF" >> $GITHUB_ENV
 
         '
+    - name: Install AdoptJDK
+      uses: actions/setup-java@v2
+      with:
+        distribution: adopt
+        java-version: '11'
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -567,6 +567,11 @@ jobs:
         echo "EOF" >> $GITHUB_ENV
 
         '
+    - name: Install AdoptJDK
+      uses: actions/setup-java@v2
+      with:
+        distribution: adopt
+        java-version: '11'
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
@@ -644,6 +649,11 @@ jobs:
         echo "EOF" >> $GITHUB_ENV
 
         '
+    - name: Install AdoptJDK
+      uses: actions/setup-java@v2
+      with:
+        distribution: adopt
+        java-version: '11'
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -178,6 +178,17 @@ def rust_caches() -> Sequence[Step]:
     ]
 
 
+def install_jdk() -> Step:
+    return {
+        "name": "Install AdoptJDK",
+        "uses": "actions/setup-java@v2",
+        "with": {
+            "distribution": "adopt",
+            "java-version": "11",
+        },
+    }
+
+
 def bootstrap_caches() -> Sequence[Step]:
     return [
         *rust_caches(),
@@ -319,6 +330,7 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
             "if": IS_PANTS_OWNER,
             "steps": [
                 *checkout(),
+                install_jdk(),
                 setup_toolchain_auth(),
                 *setup_primary_python(),
                 expose_all_pythons(),
@@ -383,6 +395,7 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
             "if": IS_PANTS_OWNER,
             "steps": [
                 *checkout(),
+                install_jdk(),
                 setup_toolchain_auth(),
                 *setup_primary_python(),
                 expose_all_pythons(),


### PR DESCRIPTION
Add the JDK to the GitHub Actions CI so there is always a "system" JDK for Coursier to find. This supports JVM plugin testing.