### PR TITLE
Fix case sensitivity of module_mapping for `python_requirements` and `poetry_requirements`

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -11,6 +11,10 @@ from typing import DefaultDict
 
 from packaging.utils import canonicalize_name as canonicalize_project_name
 
+from pants.backend.python.dependency_inference.default_module_mapping import (
+    DEFAULT_MODULE_MAPPING,
+    DEFAULT_TYPE_STUB_MODULE_MAPPING,
+)
 from pants.backend.python.target_types import (
     ModuleMappingField,
     PythonRequirementsField,
@@ -245,8 +249,11 @@ async def map_third_party_modules_to_addresses() -> ThirdPartyPythonModuleMappin
     for tgt in all_targets:
         if not tgt.has_field(PythonRequirementsField):
             continue
-        module_map = tgt.get(ModuleMappingField).value
-        stubs_module_map = tgt.get(TypeStubsModuleMappingField).value
+        module_map = {**DEFAULT_MODULE_MAPPING, **tgt.get(ModuleMappingField).value}
+        stubs_module_map = {
+            **DEFAULT_TYPE_STUB_MODULE_MAPPING,
+            **tgt.get(TypeStubsModuleMappingField).value,
+        }
         for req in tgt[PythonRequirementsField].value:
             # NB: We don't use `canonicalize_project_name()` for the fallback value because we
             # want to preserve `.` in the module name. See

--- a/src/python/pants/backend/python/macros/pipenv_requirements.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements.py
@@ -35,6 +35,7 @@ class PipenvRequirements:
         self,
         requirements_relpath: str = "Pipfile.lock",
         module_mapping: Optional[Mapping[str, Iterable[str]]] = None,
+        type_stubs_module_mapping: Optional[Mapping[str, Iterable[str]]] = None,
         pipfile_target: Optional[str] = None,
     ) -> None:
         """
@@ -74,16 +75,11 @@ class PipenvRequirements:
 
             parsed_req = Requirement.parse(req_str)
 
-            req_module_mapping = (
-                {parsed_req.project_name: module_mapping[parsed_req.project_name]}
-                if module_mapping and parsed_req.project_name in module_mapping
-                else None
-            )
-
             self._parse_context.create_object(
                 "python_requirement_library",
                 name=parsed_req.project_name,
                 requirements=[parsed_req],
                 dependencies=[requirements_dep],
-                module_mapping=req_module_mapping,
+                module_mapping=module_mapping or {},
+                type_stubs_module_mapping=type_stubs_module_mapping or {},
             )

--- a/src/python/pants/backend/python/macros/pipenv_requirements_test.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements_test.py
@@ -51,6 +51,10 @@ def test_pipfile_lock(rule_runner: RuleRunner) -> None:
     * If a module_mapping is given, and the project is in the map, we copy over a subset of the
         mapping to the created target.
     """
+    common_fields = {
+        "dependencies": [":Pipfile.lock"],
+        "module_mapping": {"ansicolors": ["colors"]},
+    }
     assert_pipenv_requirements(
         rule_runner,
         "pipenv_requirements(module_mapping={'ansicolors': ['colors']})",
@@ -63,11 +67,7 @@ def test_pipfile_lock(rule_runner: RuleRunner) -> None:
         ),
         expected_targets=[
             PythonRequirementLibrary(
-                {
-                    "requirements": [Requirement.parse("ansicolors>=1.18.0")],
-                    "dependencies": [":Pipfile.lock"],
-                    "module_mapping": {"ansicolors": ["colors"]},
-                },
+                {"requirements": [Requirement.parse("ansicolors>=1.18.0")], **common_fields},
                 Address("", target_name="ansicolors"),
             ),
             PythonRequirementLibrary(
@@ -75,7 +75,7 @@ def test_pipfile_lock(rule_runner: RuleRunner) -> None:
                     "requirements": [
                         Requirement.parse("cachetools==4.1.1;python_version ~= '3.5'")
                     ],
-                    "dependencies": [":Pipfile.lock"],
+                    **common_fields,
                 },
                 Address("", target_name="cachetools"),
             ),

--- a/src/python/pants/backend/python/macros/poetry_requirements.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements.py
@@ -411,22 +411,11 @@ class PoetryRequirements:
             PyProjectToml.create(self._parse_context, pyproject_toml_relpath)
         )
         for parsed_req in requirements:
-            proj_name = parsed_req.project_name
-            req_module_mapping = (
-                {proj_name: module_mapping[proj_name]}
-                if module_mapping and proj_name in module_mapping
-                else None
-            )
-            stubs_module_mapping = (
-                {proj_name: type_stubs_module_mapping[proj_name]}
-                if type_stubs_module_mapping and proj_name in type_stubs_module_mapping
-                else None
-            )
             self._parse_context.create_object(
                 "python_requirement_library",
                 name=parsed_req.project_name,
                 requirements=[parsed_req],
-                module_mapping=req_module_mapping,
-                type_stubs_module_mapping=stubs_module_mapping,
+                module_mapping=module_mapping or {},
+                type_stubs_module_mapping=type_stubs_module_mapping or {},
                 dependencies=[requirements_dep],
             )

--- a/src/python/pants/backend/python/macros/poetry_requirements_test.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements_test.py
@@ -414,6 +414,11 @@ def test_pyproject_toml(rule_runner: RuleRunner) -> None:
     Note that this just ensures proper targets are created; see prior tests for specific parsing
     edge cases.
     """
+    common_fields = {
+        "dependencies": [":pyproject.toml"],
+        "module_mapping": {"ansicolors": ["colors"]},
+        "type_stubs_module_mapping": {"Django-types": ["django"]},
+    }
     assert_poetry_requirements(
         rule_runner,
         dedent(
@@ -440,32 +445,24 @@ def test_pyproject_toml(rule_runner: RuleRunner) -> None:
         ),
         expected_targets=[
             PythonRequirementLibrary(
-                {
-                    "dependencies": [":pyproject.toml"],
-                    "requirements": [Requirement.parse("ansicolors>=1.18.0")],
-                    "module_mapping": {"ansicolors": ["colors"]},
-                },
+                {"requirements": [Requirement.parse("ansicolors>=1.18.0")], **common_fields},
                 address=Address("", target_name="ansicolors"),
             ),
             PythonRequirementLibrary(
                 {
-                    "dependencies": [":pyproject.toml"],
                     "requirements": [Requirement.parse("Django==3.2 ; python_version == '3'")],
+                    **common_fields,
                 },
                 address=Address("", target_name="Django"),
             ),
             PythonRequirementLibrary(
-                {
-                    "dependencies": [":pyproject.toml"],
-                    "requirements": [Requirement.parse("Django-types==2")],
-                    "type_stubs_module_mapping": {"Django-types": ["django"]},
-                },
+                {"requirements": [Requirement.parse("Django-types==2")], **common_fields},
                 address=Address("", target_name="Django-types"),
             ),
             PythonRequirementLibrary(
                 {
-                    "dependencies": [":pyproject.toml"],
                     "requirements": [Requirement.parse("Un_Normalized_PROJECT == 1.0.0")],
+                    **common_fields,
                 },
                 address=Address("", target_name="Un-Normalized-PROJECT"),
             ),

--- a/src/python/pants/backend/python/macros/python_requirements.py
+++ b/src/python/pants/backend/python/macros/python_requirements.py
@@ -1,5 +1,6 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 import os
 from itertools import groupby
 from pathlib import Path
@@ -75,22 +76,11 @@ class PythonRequirements:
         grouped_requirements = groupby(requirements, lambda parsed_req: parsed_req.project_name)
 
         for project_name, parsed_reqs_ in grouped_requirements:
-            parsed_reqs = list(parsed_reqs_)
-            req_module_mapping = (
-                {project_name: module_mapping[project_name]}
-                if module_mapping and project_name in module_mapping
-                else None
-            )
-            stubs_module_mapping = (
-                {project_name: type_stubs_module_mapping[project_name]}
-                if type_stubs_module_mapping and project_name in type_stubs_module_mapping
-                else None
-            )
             self._parse_context.create_object(
                 "python_requirement_library",
                 name=project_name,
-                requirements=parsed_reqs,
-                module_mapping=req_module_mapping,
-                type_stubs_module_mapping=stubs_module_mapping,
+                requirements=list(parsed_reqs_),
+                module_mapping=module_mapping or {},
+                type_stubs_module_mapping=type_stubs_module_mapping or {},
                 dependencies=[requirements_dep],
             )

--- a/src/python/pants/backend/python/macros/python_requirements_test.py
+++ b/src/python/pants/backend/python/macros/python_requirements_test.py
@@ -52,6 +52,11 @@ def test_requirements_txt(rule_runner: RuleRunner) -> None:
       mapping to the created target.
     * Projects get normalized thanks to Requirement.parse().
     """
+    common_fields = {
+        "dependencies": [":requirements.txt"],
+        "module_mapping": {"ansicolors": ["colors"]},
+        "type_stubs_module_mapping": {"Django-types": ["django"]},
+    }
     assert_python_requirements(
         rule_runner,
         dedent(
@@ -79,39 +84,28 @@ def test_requirements_txt(rule_runner: RuleRunner) -> None:
         ),
         expected_targets=[
             PythonRequirementLibrary(
-                {
-                    "dependencies": [":requirements.txt"],
-                    "requirements": [Requirement.parse("ansicolors>=1.18.0")],
-                    "module_mapping": {"ansicolors": ["colors"]},
-                },
+                {"requirements": [Requirement.parse("ansicolors>=1.18.0")], **common_fields},
                 Address("", target_name="ansicolors"),
             ),
             PythonRequirementLibrary(
                 {
-                    "dependencies": [":requirements.txt"],
                     "requirements": [Requirement.parse("Django==3.2 ; python_version>'3'")],
+                    **common_fields,
                 },
                 Address("", target_name="Django"),
             ),
             PythonRequirementLibrary(
-                {
-                    "dependencies": [":requirements.txt"],
-                    "requirements": [Requirement.parse("Django-types")],
-                    "type_stubs_module_mapping": {"Django-types": ["django"]},
-                },
+                {"requirements": [Requirement.parse("Django-types")], **common_fields},
                 Address("", target_name="Django-types"),
             ),
             PythonRequirementLibrary(
-                {
-                    "dependencies": [":requirements.txt"],
-                    "requirements": [Requirement.parse("Un_Normalized_PROJECT")],
-                },
+                {"requirements": [Requirement.parse("Un_Normalized_PROJECT")], **common_fields},
                 Address("", target_name="Un-Normalized-PROJECT"),
             ),
             PythonRequirementLibrary(
                 {
-                    "dependencies": [":requirements.txt"],
                     "requirements": [Requirement.parse("pip@ git+https://github.com/pypa/pip.git")],
+                    **common_fields,
                 },
                 Address("", target_name="pip"),
             ),
@@ -126,7 +120,7 @@ def test_multiple_versions(rule_runner: RuleRunner) -> None:
 
     assert_python_requirements(
         rule_runner,
-        "python_requirements(module_mapping={'ansicolors': ['colors']})",
+        "python_requirements()",
         dedent(
             """\
             Django>=3.2

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -10,15 +10,22 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Dict, Iterable, Iterator, Optional, Tuple, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Dict,
+    Iterable,
+    Iterator,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+)
 
 from packaging.utils import canonicalize_name as canonicalize_project_name
 from pkg_resources import Requirement
 
-from pants.backend.python.dependency_inference.default_module_mapping import (
-    DEFAULT_MODULE_MAPPING,
-    DEFAULT_TYPE_STUB_MODULE_MAPPING,
-)
 from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.base.deprecated import warn_or_error
 from pants.core.goals.package import OutputPathField
@@ -735,24 +742,23 @@ class PythonRequirementsField(_RequirementSequenceField):
 class ModuleMappingField(DictStringToStringSequenceField):
     alias = "module_mapping"
     help = (
-        "A mapping of requirement names to a list of the modules they provide.\n\nFor example, "
-        '`{"ansicolors": ["colors"]}`.\n\nAny unspecified requirements will use the requirement '
-        'name as the default module, e.g. "Django" will default to `["django"]`.\n\nThis is '
-        "used to infer dependencies."
+        "A mapping of requirement names to a list of the modules they provide.\n\n"
+        'For example, `{"ansicolors": ["colors"]}`.\n\n'
+        "Any unspecified requirements will use the requirement name as the default module, "
+        'e.g. "Django" will default to `["django"]`.\n\n'
+        "This is used to infer dependencies."
     )
-    value: FrozenDict[str, Tuple[str, ...]]
+    value: FrozenDict[str, tuple[str, ...]]
+    default: ClassVar[FrozenDict[str, tuple[str, ...]]] = FrozenDict()
 
     @classmethod
-    def compute_value(
-        cls, raw_value: Optional[Dict[str, Iterable[str]]], address: Address
+    def compute_value(  # type: ignore[override]
+        cls, raw_value: Dict[str, Iterable[str]], address: Address
     ) -> FrozenDict[str, Tuple[str, ...]]:
-        provided_mapping = super().compute_value(raw_value, address)
-        return FrozenDict(
-            {
-                **DEFAULT_MODULE_MAPPING,
-                **{canonicalize_project_name(k): v for k, v in (provided_mapping or {}).items()},
-            }
+        value_or_default = cast(
+            FrozenDict[str, tuple[str, ...]], super().compute_value(raw_value, address)
         )
+        return FrozenDict({canonicalize_project_name(k): v for k, v in value_or_default.items()})
 
 
 class TypeStubsModuleMappingField(DictStringToStringSequenceField):
@@ -760,25 +766,24 @@ class TypeStubsModuleMappingField(DictStringToStringSequenceField):
     help = (
         "A mapping of type-stub requirement names to a list of the modules they provide.\n\n"
         'For example, `{"types-requests": ["requests"]}`.\n\n'
-        "If the requirement is not specified _and_ it starts with `types-` or ends with `-types`, "
-        "the requirement will be treated as a type stub for the corresponding module, e.g. "
-        '"types-request" has the module "requests". Otherwise, the requirement is treated like a '
-        f"normal dependency (see the field {ModuleMappingField.alias}).\n\n"
+        "If the requirement is not specified _and_ it starts with `types-` or `stubs-`, or ends "
+        "with `-types` or `-stubs`, the requirement will be treated as a type stub for the "
+        'corresponding module, e.g. "types-request" has the module "requests". Otherwise, '
+        "the requirement is treated like a normal dependency (see the field "
+        f"{ModuleMappingField.alias}).\n\n"
         "This is used to infer dependencies for type stubs."
     )
-    value: FrozenDict[str, Tuple[str, ...]]
+    value: FrozenDict[str, tuple[str, ...]]
+    default: ClassVar[FrozenDict[str, tuple[str, ...]]] = FrozenDict()
 
     @classmethod
-    def compute_value(
-        cls, raw_value: Optional[Dict[str, Iterable[str]]], address: Address
+    def compute_value(  # type: ignore[override]
+        cls, raw_value: Dict[str, Iterable[str]], address: Address
     ) -> FrozenDict[str, Tuple[str, ...]]:
-        provided_mapping = super().compute_value(raw_value, address)
-        return FrozenDict(
-            {
-                **DEFAULT_TYPE_STUB_MODULE_MAPPING,
-                **{canonicalize_project_name(k): v for k, v in (provided_mapping or {}).items()},
-            }
+        value_or_default = cast(
+            FrozenDict[str, tuple[str, ...]], super().compute_value(raw_value, address)
         )
+        return FrozenDict({canonicalize_project_name(k): v for k, v in value_or_default.items()})
 
 
 class PythonRequirementLibrary(Target):

--- a/src/python/pants/backend/python/target_types_test.py
+++ b/src/python/pants/backend/python/target_types_test.py
@@ -12,10 +12,6 @@ from _pytest.logging import LogCaptureFixture
 from pkg_resources import Requirement
 
 from pants.backend.python import target_types_rules
-from pants.backend.python.dependency_inference.default_module_mapping import (
-    DEFAULT_MODULE_MAPPING,
-    DEFAULT_TYPE_STUB_MODULE_MAPPING,
-)
 from pants.backend.python.dependency_inference.rules import import_rules
 from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.subsystems.pytest import PyTest
@@ -532,7 +528,7 @@ def test_module_mapping_field(
     raw_value: Optional[Dict[str, Iterable[str]]], expected: Dict[str, Tuple[str, ...]]
 ) -> None:
     actual_value = ModuleMappingField(raw_value, Address("", target_name="tests")).value
-    assert actual_value == FrozenDict({**DEFAULT_MODULE_MAPPING, **expected})
+    assert actual_value == FrozenDict(expected)
 
 
 @pytest.mark.parametrize(
@@ -547,7 +543,7 @@ def test_type_stub_module_mapping_field(
     raw_value: Optional[Dict[str, Iterable[str]]], expected: Dict[str, Tuple[str, ...]]
 ) -> None:
     actual_value = TypeStubsModuleMappingField(raw_value, Address("", target_name="tests")).value
-    assert actual_value == FrozenDict({**DEFAULT_TYPE_STUB_MODULE_MAPPING, **expected})
+    assert actual_value == FrozenDict(expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
@riisi found in https://github.com/pantsbuild/pants/pull/12931 that the `module_mapping` was still case-sensitive, which we had intended to fix https://github.com/pantsbuild/pants/pull/12068.

The fix is to stop trying to be clever with only applying the macro's `module_mapping` arg to the relevant generated targets. Instead, we now copy it to all generated targets. The downside of that is `./pants peek` is more verbose for each generated target, and we use slightly more memory with each `Target` instance. But the code is much simpler.

The first commit also refactors how we apply the `DEFAULT_MODULE_MAPPING` so that it's no longer stored on the `ModuleMappingField`, which makes `./pants peek` more useful. Related, we now set a default for the field so that `./pants peek --exclude-defaults` works.