### PR TITLE
Fix case sensitivity of `module_mapping` for `python_requirements` and `poetry_requirements` (Cherry-pick of #12980)

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -11,6 +11,10 @@ from typing import DefaultDict
 
 from packaging.utils import canonicalize_name as canonicalize_project_name
 
+from pants.backend.python.dependency_inference.default_module_mapping import (
+    DEFAULT_MODULE_MAPPING,
+    DEFAULT_TYPE_STUB_MODULE_MAPPING,
+)
 from pants.backend.python.target_types import (
     ModuleMappingField,
     PythonRequirementsField,
@@ -245,8 +249,11 @@ async def map_third_party_modules_to_addresses() -> ThirdPartyPythonModuleMappin
     for tgt in all_targets:
         if not tgt.has_field(PythonRequirementsField):
             continue
-        module_map = tgt.get(ModuleMappingField).value
-        stubs_module_map = tgt.get(TypeStubsModuleMappingField).value
+        module_map = {**DEFAULT_MODULE_MAPPING, **tgt.get(ModuleMappingField).value}
+        stubs_module_map = {
+            **DEFAULT_TYPE_STUB_MODULE_MAPPING,
+            **tgt.get(TypeStubsModuleMappingField).value,
+        }
         for req in tgt[PythonRequirementsField].value:
             # NB: We don't use `canonicalize_project_name()` for the fallback value because we
             # want to preserve `.` in the module name. See

--- a/src/python/pants/backend/python/macros/pipenv_requirements_test.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements_test.py
@@ -49,7 +49,7 @@ def test_pipfile_lock(rule_runner: RuleRunner) -> None:
     Edge cases:
     * Develop and Default requirements are used
     * If a module_mapping is given, and the project is in the map, we copy over a subset of the
-        mapping to the created target.
+        mapping to the created target. It works regardless of capitalization.
     """
     assert_pipenv_requirements(
         rule_runner,
@@ -66,7 +66,7 @@ def test_pipfile_lock(rule_runner: RuleRunner) -> None:
                 {
                     "requirements": [Requirement.parse("ansicolors>=1.18.0")],
                     "dependencies": [":Pipfile.lock"],
-                    "module_mapping": {"ansicolors": ["colors"]},
+                    "module_mapping": {"ansiCOLORS": ["colors"]},
                 },
                 Address("", target_name="ansicolors"),
             ),

--- a/src/python/pants/backend/python/macros/poetry_requirements_test.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements_test.py
@@ -419,7 +419,8 @@ def test_pyproject_toml(rule_runner: RuleRunner) -> None:
         dedent(
             """\
             poetry_requirements(
-                module_mapping={'ansicolors': ['colors']},
+                # module_mapping should work regardless of capitalization.
+                module_mapping={'ansiCOLORS': ['colors']},
                 type_stubs_module_mapping={'Django-types': ['django']},
             )
             """

--- a/src/python/pants/backend/python/macros/python_requirements_test.py
+++ b/src/python/pants/backend/python/macros/python_requirements_test.py
@@ -49,7 +49,7 @@ def test_requirements_txt(rule_runner: RuleRunner) -> None:
     Some edge cases:
     * We ignore comments and options (values that start with `--`).
     * If a module_mapping is given, and the project is in the map, we copy over a subset of the
-      mapping to the created target.
+      mapping to the created target. It works regardless of capitalization.
     * Projects get normalized thanks to Requirement.parse().
     """
     assert_python_requirements(
@@ -57,7 +57,7 @@ def test_requirements_txt(rule_runner: RuleRunner) -> None:
         dedent(
             """\
             python_requirements(
-                module_mapping={'ansicolors': ['colors']},
+                module_mapping={'ansiCOLORS': ['colors']},
                 type_stubs_module_mapping={'Django-types': ['django']},
             )
             """
@@ -126,7 +126,7 @@ def test_multiple_versions(rule_runner: RuleRunner) -> None:
 
     assert_python_requirements(
         rule_runner,
-        "python_requirements(module_mapping={'ansicolors': ['colors']})",
+        "python_requirements()",
         dedent(
             """\
             Django>=3.2

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import collections.abc
+import logging
 import os.path
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -11,7 +12,6 @@ from enum import Enum
 from textwrap import dedent
 from typing import (
     TYPE_CHECKING,
-    Any,
     ClassVar,
     Dict,
     Iterable,

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -4,21 +4,28 @@
 from __future__ import annotations
 
 import collections.abc
-import logging
 import os.path
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from textwrap import dedent
-from typing import TYPE_CHECKING, Dict, Iterable, Iterator, Optional, Tuple, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Dict,
+    Iterable,
+    Iterator,
+    Mapping,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+)
 
 from packaging.utils import canonicalize_name as canonicalize_project_name
 from pkg_resources import Requirement
 
-from pants.backend.python.dependency_inference.default_module_mapping import (
-    DEFAULT_MODULE_MAPPING,
-    DEFAULT_TYPE_STUB_MODULE_MAPPING,
-)
 from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.core.goals.package import OutputPathField
 from pants.core.goals.test import RuntimePackageDependenciesField
@@ -603,27 +610,30 @@ class PythonRequirementsField(_RequirementSequenceField):
     )
 
 
+def normalize_module_mapping(
+    mapping: Mapping[str, Iterable[str]] | None
+) -> FrozenDict[str, tuple[str, ...]]:
+    return FrozenDict({canonicalize_project_name(k): tuple(v) for k, v in (mapping or {}).items()})
+
+
 class ModuleMappingField(DictStringToStringSequenceField):
     alias = "module_mapping"
     help = (
-        "A mapping of requirement names to a list of the modules they provide.\n\nFor example, "
-        '`{"ansicolors": ["colors"]}`.\n\nAny unspecified requirements will use the requirement '
-        'name as the default module, e.g. "Django" will default to `["django"]`.\n\nThis is '
-        "used to infer dependencies."
+        "A mapping of requirement names to a list of the modules they provide.\n\n"
+        'For example, `{"ansicolors": ["colors"]}`.\n\n'
+        "Any unspecified requirements will use the requirement name as the default module, "
+        'e.g. "Django" will default to `["django"]`.\n\n'
+        "This is used to infer dependencies."
     )
-    value: FrozenDict[str, Tuple[str, ...]]
+    value: FrozenDict[str, tuple[str, ...]]
+    default: ClassVar[FrozenDict[str, tuple[str, ...]]] = FrozenDict()
 
     @classmethod
-    def compute_value(
-        cls, raw_value: Optional[Dict[str, Iterable[str]]], address: Address
+    def compute_value(  # type: ignore[override]
+        cls, raw_value: Dict[str, Iterable[str]], address: Address
     ) -> FrozenDict[str, Tuple[str, ...]]:
-        provided_mapping = super().compute_value(raw_value, address)
-        return FrozenDict(
-            {
-                **DEFAULT_MODULE_MAPPING,
-                **{canonicalize_project_name(k): v for k, v in (provided_mapping or {}).items()},
-            }
-        )
+        value_or_default = super().compute_value(raw_value, address)
+        return normalize_module_mapping(value_or_default)
 
 
 class TypeStubsModuleMappingField(DictStringToStringSequenceField):
@@ -631,25 +641,22 @@ class TypeStubsModuleMappingField(DictStringToStringSequenceField):
     help = (
         "A mapping of type-stub requirement names to a list of the modules they provide.\n\n"
         'For example, `{"types-requests": ["requests"]}`.\n\n'
-        "If the requirement is not specified _and_ it starts with `types-` or ends with `-types`, "
-        "the requirement will be treated as a type stub for the corresponding module, e.g. "
-        '"types-request" has the module "requests". Otherwise, the requirement is treated like a '
-        f"normal dependency (see the field {ModuleMappingField.alias}).\n\n"
+        "If the requirement is not specified _and_ it starts with `types-` or `stubs-`, or ends "
+        "with `-types` or `-stubs`, the requirement will be treated as a type stub for the "
+        'corresponding module, e.g. "types-request" has the module "requests". Otherwise, '
+        "the requirement is treated like a normal dependency (see the field "
+        f"{ModuleMappingField.alias}).\n\n"
         "This is used to infer dependencies for type stubs."
     )
-    value: FrozenDict[str, Tuple[str, ...]]
+    value: FrozenDict[str, tuple[str, ...]]
+    default: ClassVar[FrozenDict[str, tuple[str, ...]]] = FrozenDict()
 
     @classmethod
-    def compute_value(
-        cls, raw_value: Optional[Dict[str, Iterable[str]]], address: Address
+    def compute_value(  # type: ignore[override]
+        cls, raw_value: Dict[str, Iterable[str]], address: Address
     ) -> FrozenDict[str, Tuple[str, ...]]:
-        provided_mapping = super().compute_value(raw_value, address)
-        return FrozenDict(
-            {
-                **DEFAULT_TYPE_STUB_MODULE_MAPPING,
-                **{canonicalize_project_name(k): v for k, v in (provided_mapping or {}).items()},
-            }
-        )
+        value_or_default = super().compute_value(raw_value, address)
+        return normalize_module_mapping(value_or_default)
 
 
 class PythonRequirementLibrary(Target):

--- a/src/python/pants/backend/python/target_types_test.py
+++ b/src/python/pants/backend/python/target_types_test.py
@@ -11,7 +11,6 @@ import pytest
 from _pytest.logging import LogCaptureFixture
 from pkg_resources import Requirement
 
-from pants.backend.python import target_types_rules
 from pants.backend.python.dependency_inference.rules import import_rules
 from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.subsystems.pytest import PyTest

--- a/src/python/pants/backend/python/target_types_test.py
+++ b/src/python/pants/backend/python/target_types_test.py
@@ -11,10 +11,7 @@ import pytest
 from _pytest.logging import LogCaptureFixture
 from pkg_resources import Requirement
 
-from pants.backend.python.dependency_inference.default_module_mapping import (
-    DEFAULT_MODULE_MAPPING,
-    DEFAULT_TYPE_STUB_MODULE_MAPPING,
-)
+from pants.backend.python import target_types_rules
 from pants.backend.python.dependency_inference.rules import import_rules
 from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.subsystems.pytest import PyTest
@@ -515,7 +512,7 @@ def test_module_mapping_field(
     raw_value: Optional[Dict[str, Iterable[str]]], expected: Dict[str, Tuple[str, ...]]
 ) -> None:
     actual_value = ModuleMappingField(raw_value, Address("", target_name="tests")).value
-    assert actual_value == FrozenDict({**DEFAULT_MODULE_MAPPING, **expected})
+    assert actual_value == FrozenDict(expected)
 
 
 @pytest.mark.parametrize(
@@ -530,4 +527,4 @@ def test_type_stub_module_mapping_field(
     raw_value: Optional[Dict[str, Iterable[str]]], expected: Dict[str, Tuple[str, ...]]
 ) -> None:
     actual_value = TypeStubsModuleMappingField(raw_value, Address("", target_name="tests")).value
-    assert actual_value == FrozenDict({**DEFAULT_TYPE_STUB_MODULE_MAPPING, **expected})
+    assert actual_value == FrozenDict(expected)


### PR DESCRIPTION
@riisi found in https://github.com/pantsbuild/pants/pull/12931 that the `module_mapping` was still case-sensitive, which we had intended to fix https://github.com/pantsbuild/pants/pull/12068.

The first commit also refactors how we apply the `DEFAULT_MODULE_MAPPING` so that it's no longer stored on the `ModuleMappingField`, which makes `./pants peek` more useful. Related, we now set a default for the field so that `./pants peek --exclude-defaults` works.

[ci skip-rust]