### PR TITLE
[internal] terraform: refactor parser script into its own file

### DIFF
--- a/src/python/pants/backend/terraform/BUILD
+++ b/src/python/pants/backend/terraform/BUILD
@@ -1,7 +1,25 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library(dependencies=[":lockfile"])
+python_library(
+  sources=[
+    "*.py",
+    "!*_test.py",
+    "!dependency_inference.py",
+    "!hcl2_parser.py"
+  ],
+)
+
+python_library(
+  name="dependency_inference",
+  sources=["dependency_inference.py"],
+  dependencies=[":hcl2_parser", ":lockfile"],
+)
+
+python_library(
+  name="hcl2_parser",
+  sources=["hcl2_parser.py"],
+)
 
 resources(name="lockfile", sources=["hcl2_lockfile.txt"])
 

--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
+import pkgutil
 import textwrap
 from dataclasses import dataclass
 from pathlib import PurePath
@@ -28,65 +29,9 @@ from pants.util.docutil import git_url
 from pants.util.ordered_set import OrderedSet
 
 PARSER = FileContent(
-    "__pants_tf_parser.py",
+    "",
     textwrap.dedent(
         """\
-    from pathlib import PurePath
-    import sys
-    from typing import Set
-
-    import hcl2
-
-    # PurePath does not have the Path.resolve method which resolves ".." components, thus we need to
-    # code our own version for PurePath's.
-    def resolve_pure_path(base: PurePath, relative_path: PurePath) -> PurePath:
-        parts = list(base.parts)
-        for component in relative_path.parts:
-            if component == ".":
-                pass
-            elif component == "..":
-                if not parts:
-                    raise ValueError(f"Relative path {relative_path} escapes from path {base}.")
-                parts.pop()
-            else:
-                parts.append(component)
-
-        return PurePath(*parts)
-
-
-    def extract_module_source_paths(path: PurePath, raw_content: bytes) -> Set[str]:
-        content = raw_content.decode("utf-8")
-        parsed_content = hcl2.loads(content)
-
-        # Note: The `module` key is a list where each entry is a dict with a single entry where the key is the
-        # module name and the values are a dict for that module's actual values.
-        paths = set()
-        for wrapped_module in parsed_content.get("module", []):
-            values = list(wrapped_module.values())[
-                0
-            ]  # the module is the sole entry in `wrapped_module`
-            source = values.get("source", "")
-
-            # Local paths to modules must begin with "." or ".." as per
-            # https://www.terraform.io/docs/language/modules/sources.html#local-paths.
-            if source.startswith("./") or source.startswith("../"):
-                try:
-                    resolved_path = resolve_pure_path(path, PurePath(source))
-                    paths.add(str(resolved_path))
-                except ValueError:
-                    pass
-
-        return paths
-
-
-    paths = set()
-    for filename in sys.argv[1:]:
-        with open(filename, "rb") as f:
-            content = f.read()
-        paths |= extract_module_source_paths(PurePath(filename).parent, content)
-
-    for path in paths:
-        print(path)
     """
     ).encode("utf-8"),
     is_executable=True,
@@ -126,7 +71,22 @@ class ParserSetup:
 
 @rule
 async def setup_parser(hcl2_parser: TerraformHcl2Parser) -> ParserSetup:
-    parser_digest = await Get(Digest, CreateDigest([PARSER]))
+    parser_content = pkgutil.get_data("pants.backend.terraform", "hcl2_parser.py")
+    if not parser_content:
+        raise ValueError("Unable to find source to hcl2_parser.py wrapper script.")
+
+    parser_digest = await Get(
+        Digest,
+        CreateDigest(
+            [
+                FileContent(
+                    path="__pants_tf_parser.py",
+                    content=parser_content,
+                    is_executable=True,
+                )
+            ]
+        ),
+    )
 
     parser_pex = await Get(
         VenvPex,

--- a/src/python/pants/backend/terraform/dependency_inference_test.py
+++ b/src/python/pants/backend/terraform/dependency_inference_test.py
@@ -137,18 +137,3 @@ def test_hcl_parser_wrapper_runs(rule_runner: RuleRunner, major_minor_interprete
 
     lines = {line for line in result.stdout.decode("utf-8").splitlines() if line}
     assert lines == {"grok", "foo/hello/world"}
-
-
-# TODO: How can resolve_pure_path in the parser script be tested?
-# def test_resolve_pure_path() -> None:
-#     assert resolve_pure_path(PurePath("foo/bar/hello/world"), PurePath("../../grok")) == PurePath(
-#         "foo/bar/grok"
-#     )
-#     assert resolve_pure_path(
-#         PurePath("foo/bar/hello/world"), PurePath("../../../../grok")
-#     ) == PurePath("grok")
-#     with pytest.raises(ValueError):
-#         resolve_pure_path(PurePath("foo/bar/hello/world"), PurePath("../../../../../grok"))
-#     assert resolve_pure_path(PurePath("foo/bar/hello/world"), PurePath("./grok")) == PurePath(
-#         "foo/bar/hello/world/grok"
-#     )

--- a/src/python/pants/backend/terraform/hcl2_parser.py
+++ b/src/python/pants/backend/terraform/hcl2_parser.py
@@ -1,0 +1,70 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import sys
+from pathlib import PurePath
+from typing import Set
+
+#
+# Note: This file is used as an pex entry point in the execution sandbox.
+#
+
+
+# PurePath does not have the Path.resolve method which resolves ".." components, thus we need to
+# code our own version for PurePath's.
+def resolve_pure_path(base: PurePath, relative_path: PurePath) -> PurePath:
+    parts = list(base.parts)
+    for component in relative_path.parts:
+        if component == ".":
+            pass
+        elif component == "..":
+            if not parts:
+                raise ValueError(f"Relative path {relative_path} escapes from path {base}.")
+            parts.pop()
+        else:
+            parts.append(component)
+
+    return PurePath(*parts)
+
+
+def extract_module_source_paths(path: PurePath, raw_content: bytes) -> Set[str]:
+    # Import here so we can still test this file with pytest (since `hcl2` is not present in normal Pants venv.)
+    import hcl2  # type: ignore[import]
+
+    content = raw_content.decode("utf-8")
+    parsed_content = hcl2.loads(content)
+
+    # Note: The `module` key is a list where each entry is a dict with a single entry where the key is the
+    # module name and the values are a dict for that module's actual values.
+    paths = set()
+    for wrapped_module in parsed_content.get("module", []):
+        values = list(wrapped_module.values())[
+            0
+        ]  # the module is the sole entry in `wrapped_module`
+        source = values.get("source", "")
+
+        # Local paths to modules must begin with "." or ".." as per
+        # https://www.terraform.io/docs/language/modules/sources.html#local-paths.
+        if source.startswith("./") or source.startswith("../"):
+            try:
+                resolved_path = resolve_pure_path(path, PurePath(source))
+                paths.add(str(resolved_path))
+            except ValueError:
+                pass
+
+    return paths
+
+
+def main(args):
+    paths = set()
+    for filename in args:
+        with open(filename, "rb") as f:
+            content = f.read()
+        paths |= extract_module_source_paths(PurePath(filename).parent, content)
+
+    for path in paths:
+        print(path)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/src/python/pants/backend/terraform/hcl2_parser_test.py
+++ b/src/python/pants/backend/terraform/hcl2_parser_test.py
@@ -1,0 +1,22 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pathlib import PurePath
+
+import pytest
+
+from pants.backend.terraform.hcl2_parser import resolve_pure_path
+
+
+def test_resolve_pure_path() -> None:
+    assert resolve_pure_path(PurePath("foo/bar/hello/world"), PurePath("../../grok")) == PurePath(
+        "foo/bar/grok"
+    )
+    assert resolve_pure_path(
+        PurePath("foo/bar/hello/world"), PurePath("../../../../grok")
+    ) == PurePath("grok")
+    with pytest.raises(ValueError):
+        resolve_pure_path(PurePath("foo/bar/hello/world"), PurePath("../../../../../grok"))
+    assert resolve_pure_path(PurePath("foo/bar/hello/world"), PurePath("./grok")) == PurePath(
+        "foo/bar/hello/world/grok"
+    )


### PR DESCRIPTION
Move the parser script into its own file so that we can apply fmt/lint/check to the script's source. The Terraform plugin uses `pkgutil.get_data` to retrieve the module's source to store in the CAS and use as a PEX entry point.

The commented-out test for `resolve_pure_path` previously in `dependency_inference_test.py` can now be uncommented and placed in `hcl2_parser_test.py`.