### PR TITLE
Support tailoring non-addressable macros.

### DIFF
--- a/src/python/pants/backend/python/goals/tailor.py
+++ b/src/python/pants/backend/python/goals/tailor.py
@@ -108,11 +108,12 @@ async def find_putative_targets(
                 PutativeTarget(
                     path=path,
                     # python_requirements is a macro and doesn't take a name argument, but the
-                    # PutativeTarget still needs a name so it can participate in de-duping logic.
+                    # PutativeTarget still needs a name for display purposes.
                     name=name,
                     type_alias="python_requirements",
                     triggering_sources=[req_file],
                     owned_sources=[req_file],
+                    addressable=False,
                     kwargs={} if name == "requirements.txt" else {"requirements_relpath": name},
                 )
             )

--- a/src/python/pants/backend/python/goals/tailor_test.py
+++ b/src/python/pants/backend/python/goals/tailor_test.py
@@ -93,6 +93,7 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
                     "python_requirements",
                     ("3rdparty/requirements-test.txt",),
                     ("3rdparty/requirements-test.txt",),
+                    addressable=False,
                     kwargs={"requirements_relpath": "requirements-test.txt"},
                 ),
                 PutativeTarget.for_target_type(

--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -76,7 +76,7 @@ class PutativeTarget:
     """A potential target to add, detected by various heuristics.
 
     This class uses the term "target" in the loose sense. It can also represent an invocation of a
-    target-genernating macro.
+    target-generating macro.
     """
 
     # Note that field order is such that the dataclass order will be by address (path+name).

--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -73,7 +73,11 @@ def default_sources_for_target_type(tgt_type: Type[Target]) -> Tuple[str, ...]:
 @frozen_after_init
 @dataclass(order=True, unsafe_hash=True)
 class PutativeTarget:
-    """A potential target to add, detected by various heuristics."""
+    """A potential target to add, detected by various heuristics.
+
+    This class uses the term "target" in the loose sense. It can also represent an invocation of a
+    target-genernating macro.
+    """
 
     # Note that field order is such that the dataclass order will be by address (path+name).
     path: str
@@ -95,6 +99,9 @@ class PutativeTarget:
     #  source globs for that type from BuildConfiguration.  However that is fiddly and not
     #  a high priority.
     owned_sources: Tuple[str, ...]
+
+    # Whether the pututative target has an address (or, e.g., is a macro with no address).
+    addressable: bool
 
     # Note that we generate the BUILD file target entry exclusively from these kwargs (plus the
     # type_alias), not from the fields above, which are broken out for other uses.
@@ -136,6 +143,7 @@ class PutativeTarget:
             target_type.alias,
             triggering_sources,
             owned_sources,
+            addressable=True,  # "Real" targets are always addressable.
             kwargs=kwargs,
             comments=comments,
         )
@@ -148,6 +156,7 @@ class PutativeTarget:
         triggering_sources: Iterable[str],
         owned_sources: Iterable[str],
         *,
+        addressable: bool = True,
         kwargs: Mapping[str, str | int | bool | Tuple[str, ...]] | None = None,
         comments: Iterable[str] = tuple(),
     ) -> None:
@@ -156,11 +165,17 @@ class PutativeTarget:
         self.type_alias = type_alias
         self.triggering_sources = tuple(triggering_sources)
         self.owned_sources = tuple(owned_sources)
+        self.addressable = addressable
         self.kwargs = FrozenDict(kwargs or {})
         self.comments = tuple(comments)
 
     @property
     def address(self) -> Address:
+        if not self.addressable:
+            raise ValueError(
+                f"Cannot compute address for non-addressable putative target of type "
+                f"{self.type_alias} at path {self.path}"
+            )
         return Address(self.path, target_name=self.name)
 
     def realias(self, new_alias: str | None) -> PutativeTarget:
@@ -336,6 +351,11 @@ async def rename_conflicting_targets(ptgts: PutativeTargets) -> UniquelyNamedPut
     existing_addrs: Set[str] = {tgt.address.spec for tgt in all_existing_tgts}
     uniquely_named_putative_targets: List[PutativeTarget] = []
     for ptgt in ptgts:
+        if not ptgt.addressable:
+            # Non-addressable PutativeTargets never have collision issues.
+            uniquely_named_putative_targets.append(ptgt)
+            continue
+
         idx = 0
         possibly_renamed_ptgt = ptgt
         # Targets in root-level BUILD files must be named explicitly.
@@ -532,7 +552,7 @@ async def tailor(
             for ptgt in ptgts:
                 console.print_stdout(
                     f"  - Added {console.green(ptgt.type_alias)} target "
-                    f"{console.cyan(ptgt.address.spec)}"
+                    f"{console.cyan(ptgt.name)}"
                 )
     return Tailor(0)
 

--- a/src/python/pants/core/goals/tailor_test.py
+++ b/src/python/pants/core/goals/tailor_test.py
@@ -193,6 +193,29 @@ def test_root_targets_are_explicitly_named(rule_runner: RuleRunner) -> None:
     )
 
 
+def test_root_macros_dont_get_named(rule_runner: RuleRunner) -> None:
+    # rule_runner.write_files({"macro_trigger.txt": ""})
+    ptgt = PutativeTarget("", "", "fortran_macro", [], [], addressable=False)
+    unpts = rule_runner.request(UniquelyNamedPutativeTargets, [PutativeTargets([ptgt])])
+    ptgts = unpts.putative_targets
+    assert (
+        PutativeTargets(
+            [
+                PutativeTarget(
+                    "",
+                    "",
+                    "fortran_macro",
+                    [],
+                    [],
+                    addressable=False,
+                    kwargs={},
+                )
+            ]
+        )
+        == ptgts
+    )
+
+
 def test_restrict_conflicting_sources(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -451,17 +474,10 @@ def test_tailor_rule(rule_runner: RuleRunner) -> None:
 
         stdout_str = stdio_reader.get_stdout()
 
+    assert "Created src/fortran/baz/BUILD:\n  - Added my_fortran_lib target baz" in stdout_str
+    assert "Updated src/fortran/foo/BUILD:\n  - Added fortran_tests target tests" in stdout_str
     assert (
-        "Created src/fortran/baz/BUILD:\n  - Added my_fortran_lib target src/fortran/baz"
-        in stdout_str
-    )
-    assert (
-        "Updated src/fortran/foo/BUILD:\n  - Added fortran_tests target src/fortran/foo:tests"
-        in stdout_str
-    )
-    assert (
-        "Updated src/fortran/conflict/BUILD:\n  - Added my_fortran_lib target "
-        "src/fortran/conflict:conflict0"
+        "Updated src/fortran/conflict/BUILD:\n  - Added my_fortran_lib target conflict0"
     ) in stdout_str
 
 

--- a/src/python/pants/engine/internals/mapper.py
+++ b/src/python/pants/engine/internals/mapper.py
@@ -43,7 +43,7 @@ class AddressMap:
         try:
             target_adaptors = parser.parse(filepath, build_file_content, extra_symbols)
         except Exception as e:
-            raise MappingError(f"Failed to parse {filepath}:\n{e}")
+            raise MappingError(f"Failed to parse ./{filepath}:\n{e}")
         name_to_target_adaptors: Dict[str, TargetAdaptor] = {}
         for target_adaptor in target_adaptors:
             name = target_adaptor.name


### PR DESCRIPTION
Previously they would participate in the disambiguation logic, and would therefore occasionally end up 
endowed with a name, even if they don't take a name kwarg. 

[ci skip-rust]

[ci skip-build-wheels]