### PR TITLE
[internal] jvm: limit caching of JDK setup processes

### DIFF
--- a/src/python/pants/backend/java/util_rules.py
+++ b/src/python/pants/backend/java/util_rules.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from pants.backend.java.compile.javac_subsystem import JavacSubsystem
 from pants.engine.fs import Digest
 from pants.engine.internals.selectors import Get
-from pants.engine.process import FallibleProcessResult, Process, ProcessResult
+from pants.engine.process import FallibleProcessResult, Process, ProcessCacheScope, ProcessResult
 from pants.engine.rules import collect_rules, rule
 from pants.jvm.resolve.coursier_setup import Coursier
 
@@ -37,6 +37,7 @@ async def setup_jdk(coursier: Coursier, javac: JavacSubsystem) -> JdkSetup:
             ),
             input_digest=coursier.digest,
             description=f"Ensure download of JDK {coursier_jdk_option}.",
+            cache_scope=ProcessCacheScope.PER_RESTART_SUCCESSFUL,
         ),
     )
 
@@ -55,6 +56,7 @@ async def setup_jdk(coursier: Coursier, javac: JavacSubsystem) -> JdkSetup:
                 "-version",
             ),
             description=f"Extract version from JDK {coursier_jdk_option}.",
+            cache_scope=ProcessCacheScope.PER_RESTART_SUCCESSFUL,
         ),
     )
 


### PR DESCRIPTION
As per https://github.com/pantsbuild/pants/pull/12972#pullrequestreview-761563441, the `Process`es used to obtain information on the JDK should not be cached permanently especially for use of the system JVM. This was originally present in the code refactored by https://github.com/pantsbuild/pants/pull/12972 but was lost in a rebase.

[ci skip-rust]

[ci skip-build-wheels]