### PR TITLE
[internal] CI: Add JDK to remaining jobs

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -37,6 +37,11 @@ jobs:
         echo "EOF" >> $GITHUB_ENV
 
         '
+    - name: Install AdoptJDK
+      uses: actions/setup-java@v2
+      with:
+        distribution: adopt
+        java-version: '11'
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
@@ -192,6 +197,11 @@ jobs:
         echo "EOF" >> $GITHUB_ENV
 
         '
+    - name: Install AdoptJDK
+      uses: actions/setup-java@v2
+      with:
+        distribution: adopt
+        java-version: '11'
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
@@ -317,6 +327,11 @@ jobs:
         echo "EOF" >> $GITHUB_ENV
 
         '
+    - name: Install AdoptJDK
+      uses: actions/setup-java@v2
+      with:
+        distribution: adopt
+        java-version: '11'
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,11 @@ jobs:
         echo "EOF" >> $GITHUB_ENV
 
         '
+    - name: Install AdoptJDK
+      uses: actions/setup-java@v2
+      with:
+        distribution: adopt
+        java-version: '11'
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
@@ -191,6 +196,11 @@ jobs:
         echo "EOF" >> $GITHUB_ENV
 
         '
+    - name: Install AdoptJDK
+      uses: actions/setup-java@v2
+      with:
+        distribution: adopt
+        java-version: '11'
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
@@ -318,6 +328,11 @@ jobs:
         echo "EOF" >> $GITHUB_ENV
 
         '
+    - name: Install AdoptJDK
+      uses: actions/setup-java@v2
+      with:
+        distribution: adopt
+        java-version: '11'
     - name: Install rustup
       run: 'curl --proto ''=https'' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s --
         -v -y --default-toolchain none
@@ -396,6 +411,11 @@ jobs:
         echo "EOF" >> $GITHUB_ENV
 
         '
+    - name: Install AdoptJDK
+      uses: actions/setup-java@v2
+      with:
+        distribution: adopt
+        java-version: '11'
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
@@ -492,6 +512,11 @@ jobs:
         echo "EOF" >> $GITHUB_ENV
 
         '
+    - name: Install AdoptJDK
+      uses: actions/setup-java@v2
+      with:
+        distribution: adopt
+        java-version: '11'
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -279,6 +279,7 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
             "if": IS_PANTS_OWNER,
             "steps": [
                 *checkout(),
+                install_jdk(),
                 setup_toolchain_auth(),
                 *setup_primary_python(),
                 *bootstrap_caches(),
@@ -349,6 +350,7 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
             "if": IS_PANTS_OWNER,
             "steps": [
                 *checkout(),
+                install_jdk(),
                 setup_toolchain_auth(),
                 *setup_primary_python(),
                 pants_virtualenv_cache(),
@@ -369,6 +371,7 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
             "if": IS_PANTS_OWNER,
             "steps": [
                 *checkout(),
+                install_jdk(),
                 setup_toolchain_auth(),
                 *setup_primary_python(),
                 *bootstrap_caches(),
@@ -463,6 +466,7 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
                     "if": IS_PANTS_OWNER,
                     "steps": [
                         *checkout(),
+                        install_jdk(),
                         install_rustup(),
                         {
                             "name": "Expose Pythons",
@@ -487,6 +491,7 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
                     "if": IS_PANTS_OWNER,
                     "steps": [
                         *checkout(),
+                        install_jdk(),
                         setup_toolchain_auth(),
                         expose_all_pythons(),
                         # NB: We only cache Rust, but not `native_engine.so` and the Pants


### PR DESCRIPTION
It is unclear when the JDK will be needed during runs so make sure there is a JDK in every job except ones where it seems clear that JDK would not be needed.