### PR TITLE
[internal] jvm: skip JDK tests unless env var set

### DIFF
--- a/src/python/pants/backend/java/compile/javac_binary_test.py
+++ b/src/python/pants/backend/java/compile/javac_binary_test.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-import os
-
 import pytest
 
 from pants.backend.java.compile.javac_binary import JavacBinary
@@ -15,6 +13,7 @@ from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.process import BashBinary, Process, ProcessResult
 from pants.engine.process import rules as process_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
+from pants.jvm.testutil import maybe_skip_jdk_test
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
@@ -56,13 +55,13 @@ def run_javac_version(rule_runner: RuleRunner) -> str:
     )
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_java_binary_system_version(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(["--javac-jdk=system"])
     assert "javac" in run_javac_version(rule_runner)
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_java_binary_bogus_version_fails(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(["--javac-jdk=bogusjdk:999"])
     expected_exception_msg = r".*?JVM bogusjdk:999 not found in index.*?"
@@ -70,7 +69,7 @@ def test_java_binary_bogus_version_fails(rule_runner: RuleRunner) -> None:
         run_javac_version(rule_runner)
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 @pytest.mark.skip(reason="#12293 Coursier JDK bootstrapping is currently flaky in CI")
 def test_java_binary_versions(rule_runner: RuleRunner) -> None:
     # default version is 1.11

--- a/src/python/pants/backend/java/compile/javac_binary_test.py
+++ b/src/python/pants/backend/java/compile/javac_binary_test.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from pants.backend.java.compile.javac_binary import JavacBinary
@@ -54,11 +56,13 @@ def run_javac_version(rule_runner: RuleRunner) -> str:
     )
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_java_binary_system_version(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(["--javac-jdk=system"])
     assert "javac" in run_javac_version(rule_runner)
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_java_binary_bogus_version_fails(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(["--javac-jdk=bogusjdk:999"])
     expected_exception_msg = r".*?JVM bogusjdk:999 not found in index.*?"
@@ -66,6 +70,7 @@ def test_java_binary_bogus_version_fails(rule_runner: RuleRunner) -> None:
         run_javac_version(rule_runner)
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 @pytest.mark.skip(reason="#12293 Coursier JDK bootstrapping is currently flaky in CI")
 def test_java_binary_versions(rule_runner: RuleRunner) -> None:
     # default version is 1.11

--- a/src/python/pants/backend/java/compile/javac_test.py
+++ b/src/python/pants/backend/java/compile/javac_test.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 from textwrap import dedent
 
 import pytest
@@ -106,6 +107,7 @@ def expect_single_expanded_coarsened_target(
     return coarsened_targets[0]
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_compile_no_deps(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -158,6 +160,7 @@ def test_compile_no_deps(rule_runner: RuleRunner) -> None:
     assert check_result.partition_description == str(coarsened_target)
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 @pytest.mark.skip(reason="#12293 Coursier JDK bootstrapping is currently flaky in CI")
 def test_compile_jdk_versions(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
@@ -206,6 +209,7 @@ def test_compile_jdk_versions(rule_runner: RuleRunner) -> None:
         rule_runner.request(CompiledClassfiles, [request])
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_compile_multiple_source_files(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -268,6 +272,7 @@ def test_compile_multiple_source_files(rule_runner: RuleRunner) -> None:
     )
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_compile_with_cycle(rule_runner: RuleRunner) -> None:
     """Test that javac can handle source-level cycles--even across build target boundaries--via
     graph coarsening.
@@ -358,6 +363,7 @@ def test_compile_with_cycle(rule_runner: RuleRunner) -> None:
     )
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_compile_with_transitive_cycle(rule_runner: RuleRunner) -> None:
     """Like test_compile_with_cycle, but the cycle occurs as a transitive dep of the requested
     target."""
@@ -450,6 +456,7 @@ def test_compile_with_transitive_cycle(rule_runner: RuleRunner) -> None:
     )
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_compile_with_transitive_multiple_sources(rule_runner: RuleRunner) -> None:
     """Like test_compile_with_transitive_cycle, but the cycle occurs via subtarget source expansion
     rather than explicitly."""
@@ -532,6 +539,7 @@ def test_compile_with_transitive_multiple_sources(rule_runner: RuleRunner) -> No
     )
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_compile_with_deps(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -586,6 +594,7 @@ def test_compile_with_deps(rule_runner: RuleRunner) -> None:
     assert classfile_digest_contents[0].path == "org/pantsbuild/example/Example.class"
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_compile_with_missing_dep_fails(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -623,6 +632,7 @@ def test_compile_with_missing_dep_fails(rule_runner: RuleRunner) -> None:
     assert "package org.pantsbuild.example.lib does not exist" in fallible_result.stderr
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_compile_with_maven_deps(rule_runner: RuleRunner) -> None:
     resolved_joda_lockfile = CoursierResolvedLockfile(
         entries=(
@@ -692,6 +702,7 @@ def test_compile_with_maven_deps(rule_runner: RuleRunner) -> None:
     assert classfile_digest_contents[0].path == "org/pantsbuild/example/Example.class"
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_compile_with_missing_maven_dep_fails(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {

--- a/src/python/pants/backend/java/compile/javac_test.py
+++ b/src/python/pants/backend/java/compile/javac_test.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import os
 from textwrap import dedent
 
 import pytest
@@ -38,6 +37,7 @@ from pants.jvm.resolve.coursier_fetch import (
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.jvm.target_types import JvmArtifact, JvmDependencyLockfile
+from pants.jvm.testutil import maybe_skip_jdk_test
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -107,7 +107,7 @@ def expect_single_expanded_coarsened_target(
     return coarsened_targets[0]
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_compile_no_deps(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -160,7 +160,7 @@ def test_compile_no_deps(rule_runner: RuleRunner) -> None:
     assert check_result.partition_description == str(coarsened_target)
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 @pytest.mark.skip(reason="#12293 Coursier JDK bootstrapping is currently flaky in CI")
 def test_compile_jdk_versions(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
@@ -209,7 +209,7 @@ def test_compile_jdk_versions(rule_runner: RuleRunner) -> None:
         rule_runner.request(CompiledClassfiles, [request])
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_compile_multiple_source_files(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -272,7 +272,7 @@ def test_compile_multiple_source_files(rule_runner: RuleRunner) -> None:
     )
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_compile_with_cycle(rule_runner: RuleRunner) -> None:
     """Test that javac can handle source-level cycles--even across build target boundaries--via
     graph coarsening.
@@ -363,7 +363,7 @@ def test_compile_with_cycle(rule_runner: RuleRunner) -> None:
     )
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_compile_with_transitive_cycle(rule_runner: RuleRunner) -> None:
     """Like test_compile_with_cycle, but the cycle occurs as a transitive dep of the requested
     target."""
@@ -456,7 +456,7 @@ def test_compile_with_transitive_cycle(rule_runner: RuleRunner) -> None:
     )
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_compile_with_transitive_multiple_sources(rule_runner: RuleRunner) -> None:
     """Like test_compile_with_transitive_cycle, but the cycle occurs via subtarget source expansion
     rather than explicitly."""
@@ -539,7 +539,7 @@ def test_compile_with_transitive_multiple_sources(rule_runner: RuleRunner) -> No
     )
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_compile_with_deps(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -594,7 +594,7 @@ def test_compile_with_deps(rule_runner: RuleRunner) -> None:
     assert classfile_digest_contents[0].path == "org/pantsbuild/example/Example.class"
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_compile_with_missing_dep_fails(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -632,7 +632,7 @@ def test_compile_with_missing_dep_fails(rule_runner: RuleRunner) -> None:
     assert "package org.pantsbuild.example.lib does not exist" in fallible_result.stderr
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_compile_with_maven_deps(rule_runner: RuleRunner) -> None:
     resolved_joda_lockfile = CoursierResolvedLockfile(
         entries=(
@@ -702,7 +702,7 @@ def test_compile_with_maven_deps(rule_runner: RuleRunner) -> None:
     assert classfile_digest_contents[0].path == "org/pantsbuild/example/Example.class"
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_compile_with_missing_maven_dep_fails(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {

--- a/src/python/pants/backend/java/dependency_inference/java_parser_test.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser_test.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import os
 from textwrap import dedent
 
 import pytest
@@ -31,6 +30,7 @@ from pants.jvm.resolve.coursier_fetch import CoursierResolvedLockfile
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.jvm.target_types import JvmDependencyLockfile
+from pants.jvm.testutil import maybe_skip_jdk_test
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -59,7 +59,7 @@ def rule_runner() -> RuleRunner:
     )
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_simple_java_parser_analysis(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -140,7 +140,7 @@ def test_simple_java_parser_analysis(rule_runner: RuleRunner) -> None:
     ]
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_java_parser_fallible_error(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -199,7 +199,7 @@ def test_java_parser_fallible_error(rule_runner: RuleRunner) -> None:
     assert isinstance(exc_info.value.wrapped_exceptions[0], ProcessExecutionFailure)
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_java_parser_unnamed_package(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {

--- a/src/python/pants/backend/java/dependency_inference/java_parser_test.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser_test.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 from textwrap import dedent
 
 import pytest
@@ -58,6 +59,7 @@ def rule_runner() -> RuleRunner:
     )
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_simple_java_parser_analysis(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -138,6 +140,7 @@ def test_simple_java_parser_analysis(rule_runner: RuleRunner) -> None:
     ]
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_java_parser_fallible_error(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -196,6 +199,7 @@ def test_java_parser_fallible_error(rule_runner: RuleRunner) -> None:
     assert isinstance(exc_info.value.wrapped_exceptions[0], ProcessExecutionFailure)
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_java_parser_unnamed_package(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {

--- a/src/python/pants/backend/java/test/junit_test.py
+++ b/src/python/pants/backend/java/test/junit_test.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import os
 import re
 from textwrap import dedent
 
@@ -32,6 +31,7 @@ from pants.jvm.resolve.coursier_fetch import (
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.jvm.target_types import JvmArtifact, JvmDependencyLockfile
+from pants.jvm.testutil import maybe_skip_jdk_test
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -115,7 +115,7 @@ JUNIT4_RESOLVED_LOCKFILE = CoursierResolvedLockfile(
 )
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_vintage_simple_success(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -166,7 +166,7 @@ def test_vintage_simple_success(rule_runner: RuleRunner) -> None:
     assert re.search(r"1 tests found", test_result.stdout) is not None
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_vintage_simple_failure(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -226,7 +226,7 @@ def test_vintage_simple_failure(rule_runner: RuleRunner) -> None:
     assert re.search(r"1 tests found", test_result.stdout) is not None
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_vintage_success_with_dep(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -390,7 +390,7 @@ JUNIT5_RESOLVED_LOCKFILE = CoursierResolvedLockfile(
 )
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_jupiter_simple_success(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -445,7 +445,7 @@ def test_jupiter_simple_success(rule_runner: RuleRunner) -> None:
     assert re.search(r"1 tests found", test_result.stdout) is not None
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_jupiter_simple_failure(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -507,7 +507,7 @@ def test_jupiter_simple_failure(rule_runner: RuleRunner) -> None:
     assert re.search(r"1 tests found", test_result.stdout) is not None
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_jupiter_success_with_dep(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -584,7 +584,7 @@ def test_jupiter_success_with_dep(rule_runner: RuleRunner) -> None:
     assert re.search(r"1 tests found", test_result.stdout) is not None
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_vintage_and_jupiter_simple_success(rule_runner: RuleRunner) -> None:
     combined_lockfile = CoursierResolvedLockfile(
         entries=(*JUNIT4_RESOLVED_LOCKFILE.entries, *JUNIT5_RESOLVED_LOCKFILE.entries)

--- a/src/python/pants/backend/java/test/junit_test.py
+++ b/src/python/pants/backend/java/test/junit_test.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 from textwrap import dedent
 
@@ -114,6 +115,7 @@ JUNIT4_RESOLVED_LOCKFILE = CoursierResolvedLockfile(
 )
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_vintage_simple_success(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -164,6 +166,7 @@ def test_vintage_simple_success(rule_runner: RuleRunner) -> None:
     assert re.search(r"1 tests found", test_result.stdout) is not None
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_vintage_simple_failure(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -223,6 +226,7 @@ def test_vintage_simple_failure(rule_runner: RuleRunner) -> None:
     assert re.search(r"1 tests found", test_result.stdout) is not None
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_vintage_success_with_dep(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -386,6 +390,7 @@ JUNIT5_RESOLVED_LOCKFILE = CoursierResolvedLockfile(
 )
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_jupiter_simple_success(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -440,6 +445,7 @@ def test_jupiter_simple_success(rule_runner: RuleRunner) -> None:
     assert re.search(r"1 tests found", test_result.stdout) is not None
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_jupiter_simple_failure(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -501,6 +507,7 @@ def test_jupiter_simple_failure(rule_runner: RuleRunner) -> None:
     assert re.search(r"1 tests found", test_result.stdout) is not None
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_jupiter_success_with_dep(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -577,6 +584,7 @@ def test_jupiter_success_with_dep(rule_runner: RuleRunner) -> None:
     assert re.search(r"1 tests found", test_result.stdout) is not None
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_vintage_and_jupiter_simple_success(rule_runner: RuleRunner) -> None:
     combined_lockfile = CoursierResolvedLockfile(
         entries=(*JUNIT4_RESOLVED_LOCKFILE.entries, *JUNIT5_RESOLVED_LOCKFILE.entries)

--- a/src/python/pants/jvm/goals/coursier_integration_test.py
+++ b/src/python/pants/jvm/goals/coursier_integration_test.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from textwrap import dedent
 
@@ -23,6 +22,7 @@ from pants.jvm.resolve.coursier_fetch import (
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.jvm.target_types import JvmArtifact, JvmDependencyLockfile
+from pants.jvm.testutil import maybe_skip_jdk_test
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import RuleRunner
 
@@ -50,7 +50,7 @@ def rule_runner() -> RuleRunner:
     )
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_coursier_resolve_creates_missing_lockfile(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -95,7 +95,7 @@ def test_coursier_resolve_creates_missing_lockfile(rule_runner: RuleRunner) -> N
     )
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_coursier_resolve_noop_does_not_touch_lockfile(rule_runner: RuleRunner) -> None:
     expected_lockfile = CoursierResolvedLockfile(
         entries=(
@@ -140,7 +140,7 @@ def test_coursier_resolve_noop_does_not_touch_lockfile(rule_runner: RuleRunner) 
     assert result.stderr == ""
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_coursier_resolve_updates_lockfile(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -186,7 +186,7 @@ def test_coursier_resolve_updates_lockfile(rule_runner: RuleRunner) -> None:
     )
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_coursier_resolve_updates_bogus_lockfile(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {

--- a/src/python/pants/jvm/goals/coursier_integration_test.py
+++ b/src/python/pants/jvm/goals/coursier_integration_test.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from textwrap import dedent
 
@@ -49,6 +50,7 @@ def rule_runner() -> RuleRunner:
     )
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_coursier_resolve_creates_missing_lockfile(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -93,6 +95,7 @@ def test_coursier_resolve_creates_missing_lockfile(rule_runner: RuleRunner) -> N
     )
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_coursier_resolve_noop_does_not_touch_lockfile(rule_runner: RuleRunner) -> None:
     expected_lockfile = CoursierResolvedLockfile(
         entries=(
@@ -137,6 +140,7 @@ def test_coursier_resolve_noop_does_not_touch_lockfile(rule_runner: RuleRunner) 
     assert result.stderr == ""
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_coursier_resolve_updates_lockfile(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -182,6 +186,7 @@ def test_coursier_resolve_updates_lockfile(rule_runner: RuleRunner) -> None:
     )
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_coursier_resolve_updates_bogus_lockfile(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {

--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from pants.core.util_rules import config_files, source_files
@@ -49,6 +51,7 @@ def rule_runner() -> RuleRunner:
     )
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_empty_resolve(rule_runner: RuleRunner) -> None:
     resolved_lockfile = rule_runner.request(
         CoursierResolvedLockfile,
@@ -60,6 +63,7 @@ def test_empty_resolve(rule_runner: RuleRunner) -> None:
 # TODO(#11928): Make all of these tests more hermetic and not dependent on having a network connection.
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_resolve_with_no_deps(rule_runner: RuleRunner) -> None:
     resolved_lockfile = rule_runner.request(
         CoursierResolvedLockfile,
@@ -81,6 +85,7 @@ def test_resolve_with_no_deps(rule_runner: RuleRunner) -> None:
     )
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_resolve_with_transitive_deps(rule_runner: RuleRunner) -> None:
     junit_coord = Coordinate(group="junit", artifact="junit", version="4.13.2")
     resolved_lockfile = rule_runner.request(
@@ -116,6 +121,7 @@ def test_resolve_with_transitive_deps(rule_runner: RuleRunner) -> None:
     )
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_resolve_with_inexact_coord(rule_runner: RuleRunner) -> None:
     resolved_lockfile = rule_runner.request(
         CoursierResolvedLockfile,
@@ -144,6 +150,7 @@ def test_resolve_with_inexact_coord(rule_runner: RuleRunner) -> None:
     )
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_fetch_one_coord_with_no_deps(rule_runner: RuleRunner) -> None:
 
     classpath_entry = rule_runner.request(
@@ -172,6 +179,7 @@ def test_fetch_one_coord_with_no_deps(rule_runner: RuleRunner) -> None:
     )
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_fetch_one_coord_with_transitive_deps(rule_runner: RuleRunner) -> None:
     junit_coord = Coordinate(group="junit", artifact="junit", version="4.13.2")
     classpath_entry = rule_runner.request(
@@ -200,6 +208,7 @@ def test_fetch_one_coord_with_transitive_deps(rule_runner: RuleRunner) -> None:
     )
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_fetch_one_coord_with_bad_fingerprint(rule_runner: RuleRunner) -> None:
     expected_exception_msg = (
         r".*?CoursierError:.*?Coursier fetch for .*?hamcrest.*? succeeded.*?"
@@ -220,6 +229,7 @@ def test_fetch_one_coord_with_bad_fingerprint(rule_runner: RuleRunner) -> None:
         rule_runner.request(ResolvedClasspathEntry, [lockfile_entry])
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_fetch_one_coord_with_bad_length(rule_runner: RuleRunner) -> None:
     expected_exception_msg = (
         r".*?CoursierError:.*?Coursier fetch for .*?hamcrest.*? succeeded.*?"
@@ -242,6 +252,7 @@ def test_fetch_one_coord_with_bad_length(rule_runner: RuleRunner) -> None:
         rule_runner.request(ResolvedClasspathEntry, [lockfile_entry])
 
 
+@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
 def test_fetch_one_coord_with_mismatched_coord(rule_runner: RuleRunner) -> None:
     """This test demonstrates that fetch_one_coord is picky about inexact coordinates.
 

--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-import os
-
 import pytest
 
 from pants.core.util_rules import config_files, source_files
@@ -22,6 +20,7 @@ from pants.jvm.resolve.coursier_fetch import (
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.jvm.target_types import JvmArtifact, JvmDependencyLockfile
+from pants.jvm.testutil import maybe_skip_jdk_test
 from pants.jvm.util_rules import ExtractFileDigest
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import QueryRule, RuleRunner
@@ -51,7 +50,7 @@ def rule_runner() -> RuleRunner:
     )
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_empty_resolve(rule_runner: RuleRunner) -> None:
     resolved_lockfile = rule_runner.request(
         CoursierResolvedLockfile,
@@ -63,7 +62,7 @@ def test_empty_resolve(rule_runner: RuleRunner) -> None:
 # TODO(#11928): Make all of these tests more hermetic and not dependent on having a network connection.
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_resolve_with_no_deps(rule_runner: RuleRunner) -> None:
     resolved_lockfile = rule_runner.request(
         CoursierResolvedLockfile,
@@ -85,7 +84,7 @@ def test_resolve_with_no_deps(rule_runner: RuleRunner) -> None:
     )
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_resolve_with_transitive_deps(rule_runner: RuleRunner) -> None:
     junit_coord = Coordinate(group="junit", artifact="junit", version="4.13.2")
     resolved_lockfile = rule_runner.request(
@@ -121,7 +120,7 @@ def test_resolve_with_transitive_deps(rule_runner: RuleRunner) -> None:
     )
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_resolve_with_inexact_coord(rule_runner: RuleRunner) -> None:
     resolved_lockfile = rule_runner.request(
         CoursierResolvedLockfile,
@@ -150,7 +149,7 @@ def test_resolve_with_inexact_coord(rule_runner: RuleRunner) -> None:
     )
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_fetch_one_coord_with_no_deps(rule_runner: RuleRunner) -> None:
 
     classpath_entry = rule_runner.request(
@@ -179,7 +178,7 @@ def test_fetch_one_coord_with_no_deps(rule_runner: RuleRunner) -> None:
     )
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_fetch_one_coord_with_transitive_deps(rule_runner: RuleRunner) -> None:
     junit_coord = Coordinate(group="junit", artifact="junit", version="4.13.2")
     classpath_entry = rule_runner.request(
@@ -208,7 +207,7 @@ def test_fetch_one_coord_with_transitive_deps(rule_runner: RuleRunner) -> None:
     )
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_fetch_one_coord_with_bad_fingerprint(rule_runner: RuleRunner) -> None:
     expected_exception_msg = (
         r".*?CoursierError:.*?Coursier fetch for .*?hamcrest.*? succeeded.*?"
@@ -229,7 +228,7 @@ def test_fetch_one_coord_with_bad_fingerprint(rule_runner: RuleRunner) -> None:
         rule_runner.request(ResolvedClasspathEntry, [lockfile_entry])
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_fetch_one_coord_with_bad_length(rule_runner: RuleRunner) -> None:
     expected_exception_msg = (
         r".*?CoursierError:.*?Coursier fetch for .*?hamcrest.*? succeeded.*?"
@@ -252,7 +251,7 @@ def test_fetch_one_coord_with_bad_length(rule_runner: RuleRunner) -> None:
         rule_runner.request(ResolvedClasspathEntry, [lockfile_entry])
 
 
-@pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")
+@maybe_skip_jdk_test
 def test_fetch_one_coord_with_mismatched_coord(rule_runner: RuleRunner) -> None:
     """This test demonstrates that fetch_one_coord is picky about inexact coordinates.
 

--- a/src/python/pants/jvm/testutil.py
+++ b/src/python/pants/jvm/testutil.py
@@ -1,0 +1,12 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+
+import pytest
+
+
+def maybe_skip_jdk_test(func):
+    return pytest.mark.skipif("PANTS_RUN_JDK_TESTS" not in os.environ, reason="Skip JDK tests")(
+        func
+    )


### PR DESCRIPTION
Due to flakiness, skip JDK tests unless `PANTS_RUN_JDK_TESTS` environment variable is set.

[ci skip-rust]

[ci skip-build-wheels]