### PR TITLE
Change `BinaryNotFoundError` constructor to be more generic

### DIFF
--- a/src/python/pants/backend/docker/docker_binary.py
+++ b/src/python/pants/backend/docker/docker_binary.py
@@ -53,7 +53,7 @@ async def find_docker(docker_request: DockerBinaryRequest) -> DockerBinary:
     paths = await Get(BinaryPaths, BinaryPathRequest, request)
     first_path = paths.first_path
     if not first_path:
-        raise BinaryNotFoundError(request, rationale="interact with the docker daemon")
+        raise BinaryNotFoundError.create(request, rationale="interact with the docker daemon")
     return DockerBinary(first_path.path, first_path.fingerprint)
 
 

--- a/src/python/pants/backend/docker/docker_binary.py
+++ b/src/python/pants/backend/docker/docker_binary.py
@@ -53,7 +53,7 @@ async def find_docker(docker_request: DockerBinaryRequest) -> DockerBinary:
     paths = await Get(BinaryPaths, BinaryPathRequest, request)
     first_path = paths.first_path
     if not first_path:
-        raise BinaryNotFoundError.create(request, rationale="interact with the docker daemon")
+        raise BinaryNotFoundError.from_request(request, rationale="interact with the docker daemon")
     return DockerBinary(first_path.path, first_path.fingerprint)
 
 

--- a/src/python/pants/backend/shell/shell_command.py
+++ b/src/python/pants/backend/shell/shell_command.py
@@ -91,7 +91,7 @@ async def run_shell_command(
         if binary.first_path:
             command_env[tool_request.binary_name] = binary.first_path.path
         else:
-            raise BinaryNotFoundError(
+            raise BinaryNotFoundError.create(
                 tool_request,
                 rationale=f"execute experimental_shell_command {shell_command.address}",
             )

--- a/src/python/pants/backend/shell/shell_command.py
+++ b/src/python/pants/backend/shell/shell_command.py
@@ -91,7 +91,7 @@ async def run_shell_command(
         if binary.first_path:
             command_env[tool_request.binary_name] = binary.first_path.path
         else:
-            raise BinaryNotFoundError.create(
+            raise BinaryNotFoundError.from_request(
                 tool_request,
                 rationale=f"execute experimental_shell_command {shell_command.address}",
             )

--- a/src/python/pants/backend/shell/shunit2_test_runner.py
+++ b/src/python/pants/backend/shell/shunit2_test_runner.py
@@ -140,7 +140,9 @@ async def determine_shunit2_shell(
     paths = await Get(BinaryPaths, BinaryPathRequest, path_request)
     first_path = paths.first_path
     if not first_path:
-        raise BinaryNotFoundError(path_request, rationale=f"run shunit2 on {request.address}")
+        raise BinaryNotFoundError.create(
+            path_request, rationale=f"run shunit2 on {request.address}"
+        )
     return Shunit2Runner(tgt_shell, first_path)
 
 

--- a/src/python/pants/backend/shell/shunit2_test_runner.py
+++ b/src/python/pants/backend/shell/shunit2_test_runner.py
@@ -140,7 +140,7 @@ async def determine_shunit2_shell(
     paths = await Get(BinaryPaths, BinaryPathRequest, path_request)
     first_path = paths.first_path
     if not first_path:
-        raise BinaryNotFoundError.create(
+        raise BinaryNotFoundError.from_request(
             path_request, rationale=f"run shunit2 on {request.address}"
         )
     return Shunit2Runner(tgt_shell, first_path)

--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -76,7 +76,7 @@ async def find_zip() -> ZipBinary:
     paths = await Get(BinaryPaths, BinaryPathRequest, request)
     first_path = paths.first_path
     if not first_path:
-        raise BinaryNotFoundError.create(request, rationale="create `.zip` archives")
+        raise BinaryNotFoundError.from_request(request, rationale="create `.zip` archives")
     return ZipBinary(first_path.path, first_path.fingerprint)
 
 
@@ -88,7 +88,9 @@ async def find_unzip() -> UnzipBinary:
     paths = await Get(BinaryPaths, BinaryPathRequest, request)
     first_path = paths.first_path
     if not first_path:
-        raise BinaryNotFoundError.create(request, rationale="download the tools Pants needs to run")
+        raise BinaryNotFoundError.from_request(
+            request, rationale="download the tools Pants needs to run"
+        )
     return UnzipBinary(first_path.path, first_path.fingerprint)
 
 
@@ -100,7 +102,9 @@ async def find_tar() -> TarBinary:
     paths = await Get(BinaryPaths, BinaryPathRequest, request)
     first_path = paths.first_path
     if not first_path:
-        raise BinaryNotFoundError.create(request, rationale="download the tools Pants needs to run")
+        raise BinaryNotFoundError.from_request(
+            request, rationale="download the tools Pants needs to run"
+        )
     return TarBinary(first_path.path, first_path.fingerprint)
 
 

--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -76,7 +76,7 @@ async def find_zip() -> ZipBinary:
     paths = await Get(BinaryPaths, BinaryPathRequest, request)
     first_path = paths.first_path
     if not first_path:
-        raise BinaryNotFoundError(request, rationale="create `.zip` archives")
+        raise BinaryNotFoundError.create(request, rationale="create `.zip` archives")
     return ZipBinary(first_path.path, first_path.fingerprint)
 
 
@@ -88,7 +88,7 @@ async def find_unzip() -> UnzipBinary:
     paths = await Get(BinaryPaths, BinaryPathRequest, request)
     first_path = paths.first_path
     if not first_path:
-        raise BinaryNotFoundError(request, rationale="download the tools Pants needs to run")
+        raise BinaryNotFoundError.create(request, rationale="download the tools Pants needs to run")
     return UnzipBinary(first_path.path, first_path.fingerprint)
 
 
@@ -100,7 +100,7 @@ async def find_tar() -> TarBinary:
     paths = await Get(BinaryPaths, BinaryPathRequest, request)
     first_path = paths.first_path
     if not first_path:
-        raise BinaryNotFoundError(request, rationale="download the tools Pants needs to run")
+        raise BinaryNotFoundError.create(request, rationale="download the tools Pants needs to run")
     return TarBinary(first_path.path, first_path.fingerprint)
 
 

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -445,7 +445,7 @@ class BinaryPaths(EngineAwareReturnType):
 
 class BinaryNotFoundError(EnvironmentError):
     @classmethod
-    def create(
+    def from_request(
         cls,
         request: BinaryPathRequest,
         *,
@@ -491,7 +491,7 @@ async def find_bash(bash_request: BashBinaryRequest) -> BashBinary:
     paths = await Get(BinaryPaths, BinaryPathRequest, request)
     first_path = paths.first_path
     if not first_path:
-        raise BinaryNotFoundError.create(request)
+        raise BinaryNotFoundError.from_request(request)
     return BashBinary(first_path.path, first_path.fingerprint)
 
 

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -444,13 +444,14 @@ class BinaryPaths(EngineAwareReturnType):
 
 
 class BinaryNotFoundError(EnvironmentError):
-    def __init__(
-        self,
+    @classmethod
+    def create(
+        cls,
         request: BinaryPathRequest,
         *,
         rationale: str | None = None,
         alternative_solution: str | None = None,
-    ) -> None:
+    ) -> BinaryNotFoundError:
         """When no binary is found via `BinaryPaths`, and it is not recoverable.
 
         :param rationale: A short description of why this binary is needed, e.g.
@@ -466,7 +467,7 @@ class BinaryNotFoundError(EnvironmentError):
         msg += f" so that Pants can {rationale}." if rationale else "."
         if alternative_solution:
             msg += f"\n\n{alternative_solution}"
-        super().__init__(msg)
+        return BinaryNotFoundError(msg)
 
 
 class BashBinary(BinaryPath):
@@ -490,7 +491,7 @@ async def find_bash(bash_request: BashBinaryRequest) -> BashBinary:
     paths = await Get(BinaryPaths, BinaryPathRequest, request)
     first_path = paths.first_path
     if not first_path:
-        raise BinaryNotFoundError(request)
+        raise BinaryNotFoundError.create(request)
     return BashBinary(first_path.path, first_path.fingerprint)
 
 


### PR DESCRIPTION
It can be nice to use free text for this error, rather than forcing you into specific phrasing. Prework for https://github.com/pantsbuild/pants/issues/12772.

[ci skip-rust]