### PR TITLE
Ensure that Tree contents are uploaded after creation.

### DIFF
--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -496,6 +496,9 @@ impl Store {
   ///
   /// Returns a structure with the summary of operations.
   ///
+  /// TODO: This method is only aware of File and Directory typed blobs: in particular, that means
+  /// it will not expand Trees to upload the files that they refer to. See #13006.
+  ///
   pub fn ensure_remote_has_recursive(
     &self,
     digests: Vec<Digest>,

--- a/src/rust/engine/process_execution/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_cache_tests.rs
@@ -426,7 +426,7 @@ async fn make_tree_from_directory() {
     .await
     .expect("Error saving directory");
 
-  let tree = crate::remote_cache::CommandRunner::make_tree_for_output_directory(
+  let (tree, file_digests) = crate::remote_cache::CommandRunner::make_tree_for_output_directory(
     directory_digest,
     RelativePath::new("pets").unwrap(),
     &store,
@@ -453,6 +453,7 @@ async fn make_tree_from_directory() {
   assert_eq!(file_node.name, "roland.ext");
   let file_digest: Digest = file_node.digest.as_ref().unwrap().try_into().unwrap();
   assert_eq!(file_digest, TestData::roland().digest());
+  assert_eq!(file_digests, vec![TestData::roland().digest()]);
 
   // Test that extracting non-existent output directories fails gracefully.
   assert!(


### PR DESCRIPTION
We currently do not upload the file `Digest`s referenced by `Tree`s, which will later cause a "missing file" to be reported during eager fetch of a cache entry.

As discussed in #13006: we should likely have native support for storing and uploading `Tree`s, but this change fixes the immediate issue in a cherry-pickable way.

[ci skip-build-wheels]