### PR TITLE
Move the `process-execution-local-cleanup` hint to a more specific location.

### DIFF
--- a/src/python/pants/backend/java/dependency_inference/java_parser.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser.py
@@ -19,6 +19,7 @@ from pants.engine.fs import AddPrefix, Digest, DigestContents, MergeDigests
 from pants.engine.process import BashBinary, FallibleProcessResult, Process, ProcessExecutionFailure
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.jvm.resolve.coursier_fetch import MaterializedClasspath, MaterializedClasspathRequest
+from pants.option.global_options import GlobalOptions
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
@@ -32,6 +33,7 @@ class FallibleJavaSourceDependencyAnalysisResult:
 @rule(level=LogLevel.DEBUG)
 async def resolve_fallible_result_to_analysis(
     fallible_result: FallibleJavaSourceDependencyAnalysisResult,
+    global_options: GlobalOptions,
 ) -> JavaSourceDependencyAnalysis:
     # TODO(#12725): Just convert directly to a ProcessResult like this:
     # result = await Get(ProcessResult, FallibleProcessResult, fallible_result.process_result)
@@ -46,6 +48,7 @@ async def resolve_fallible_result_to_analysis(
         fallible_result.process_result.stdout,
         fallible_result.process_result.stderr,
         "Java source dependency analysis failed.",
+        local_cleanup=global_options.options.process_execution_local_cleanup,
     )
 
 

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -46,6 +46,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import TransitiveTargets, TransitiveTargetsRequest
 from pants.engine.unions import UnionRule
 from pants.option.custom_types import file_option
+from pants.option.global_options import GlobalOptions
 from pants.source.source_root import AllSourceRoots
 from pants.util.docutil import git_url
 from pants.util.logging import LogLevel
@@ -476,6 +477,7 @@ async def generate_coverage_reports(
     coverage_setup: CoverageSetup,
     coverage_config: CoverageConfig,
     coverage_subsystem: CoverageSubsystem,
+    global_options: GlobalOptions,
 ) -> CoverageReports:
     """Takes all Python test results and generates a single coverage report."""
     transitive_targets = await Get(
@@ -552,6 +554,7 @@ async def generate_coverage_reports(
                 res.stdout,
                 res.stderr,
                 proc.description,
+                local_cleanup=global_options.options.process_execution_local_cleanup,
             )
 
     # In practice if one result triggers --fail-under, they all will, but no need to rely on that.


### PR DESCRIPTION
The `--no-process-execution-local-cleanup` hint is currently rendered for all exceptions, but it's relatively unlikely to be helpful for non-process-failure exceptions. Move it onto `ProcessExecutionFailure`.

[ci skip-build-wheels]