### PR TITLE
[internal] go: refactor compilation into separate rule

### DIFF
--- a/src/python/pants/backend/experimental/go/register.py
+++ b/src/python/pants/backend/experimental/go/register.py
@@ -8,6 +8,7 @@ from pants.backend.go.subsystems import golang
 from pants.backend.go.target_types import GoBinary, GoExternalPackageTarget, GoModule, GoPackage
 from pants.backend.go.util_rules import (
     assembly,
+    compile,
     build_go_pkg,
     external_module,
     go_mod,
@@ -25,6 +26,7 @@ def rules():
     return [
         *assembly.rules(),
         *build_go_pkg.rules(),
+        *compile.rules(),
         *external_module.rules(),
         *golang.rules(),
         *go_target_types.rules(),

--- a/src/python/pants/backend/experimental/go/register.py
+++ b/src/python/pants/backend/experimental/go/register.py
@@ -8,8 +8,8 @@ from pants.backend.go.subsystems import golang
 from pants.backend.go.target_types import GoBinary, GoExternalPackageTarget, GoModule, GoPackage
 from pants.backend.go.util_rules import (
     assembly,
-    compile,
     build_go_pkg,
+    compile,
     external_module,
     go_mod,
     go_pkg,

--- a/src/python/pants/backend/go/goals/package_binary_integration_test.py
+++ b/src/python/pants/backend/go/goals/package_binary_integration_test.py
@@ -14,6 +14,7 @@ from pants.backend.go.target_types import GoBinary, GoModule, GoPackage
 from pants.backend.go.util_rules import (
     assembly,
     build_go_pkg,
+    compile,
     external_module,
     go_mod,
     go_pkg,
@@ -34,6 +35,7 @@ def rule_runner() -> RuleRunner:
         target_types=[GoBinary, GoPackage, GoModule],
         rules=[
             *assembly.rules(),
+            *compile.rules(),
             *source_files.rules(),
             *import_analysis.rules(),
             *package_binary.rules(),

--- a/src/python/pants/backend/go/util_rules/assembly_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/assembly_integration_test.py
@@ -10,6 +10,7 @@ from pants.backend.go.target_types import GoExternalPackageTarget, GoModule, GoP
 from pants.backend.go.util_rules import (
     assembly,
     build_go_pkg,
+    compile,
     external_module,
     go_mod,
     go_pkg,
@@ -31,6 +32,7 @@ def rule_runner() -> RuleRunner:
             *sdk.rules(),
             *assembly.rules(),
             *build_go_pkg.rules(),
+            *compile.rules(),
             *import_analysis.rules(),
             *go_mod.rules(),
             *go_pkg.rules(),

--- a/src/python/pants/backend/go/util_rules/compile.py
+++ b/src/python/pants/backend/go/util_rules/compile.py
@@ -1,0 +1,77 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pants.backend.go.util_rules.sdk import GoSdkProcess
+from pants.engine.fs import Digest
+from pants.engine.process import ProcessResult
+from pants.engine.rules import Get, collect_rules, rule
+
+
+@dataclass(frozen=True)
+class CompileGoSourcesRequest:
+    """Compile Go sources into the package archive __pkg__.a."""
+
+    # The `Digest` containing the input Go source files and input packages.
+    digest: Digest
+
+    # Paths to each source file to compile.
+    sources: tuple[str, ...]
+
+    # The import path for the package being compiled.
+    import_path: str
+
+    # Description to use for the compilation.
+    description: str
+
+    # Import configuration
+    import_config_path: str | None = None
+
+    # Optional symabis file to use.
+    symabis_path: str | None = None
+
+
+@dataclass(frozen=True)
+class CompiledGoSources:
+    """Output from compiling Go sources.
+
+    The package archive is called __pkg__.a.
+    """
+
+    output_digest: Digest
+
+
+@rule
+async def compile_go_sources(request: CompileGoSourcesRequest) -> CompiledGoSources:
+    args = [
+        "tool",
+        "compile",
+        "-p",
+        request.import_path,
+    ]
+
+    if request.import_config_path:
+        args.extend(["-importcfg", request.import_config_path])
+
+    if request.symabis_path:
+        args.extend(["-symabis", request.symabis_path])
+
+    args.extend(["-pack", "-o", "__pkg__.a", "--", *request.sources])
+
+    result = await Get(
+        ProcessResult,
+        GoSdkProcess(
+            input_digest=request.digest,
+            command=tuple(args),
+            description=request.description,
+            output_files=("__pkg__.a",),
+        ),
+    )
+
+    return CompiledGoSources(output_digest=result.output_digest)
+
+
+def rules():
+    return collect_rules()

--- a/src/python/pants/backend/go/util_rules/compile_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/compile_integration_test.py
@@ -1,0 +1,62 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import textwrap
+
+import pytest
+
+from pants.backend.go.target_types import GoModule, GoPackage
+from pants.backend.go.util_rules import compile, sdk
+from pants.backend.go.util_rules.compile import CompiledGoSources, CompileGoSourcesRequest
+from pants.engine.fs import CreateDigest, Digest, FileContent, Snapshot
+from pants.engine.rules import QueryRule
+from pants.testutil.rule_runner import RuleRunner
+
+SOURCE = FileContent(
+    path="foo.go",
+    content=textwrap.dedent(
+        """\
+    package foo
+    func add(a, b int) int {
+        return a + b
+    }
+    """
+    ).encode("utf-8"),
+)
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = RuleRunner(
+        rules=[
+            # *source_files.rules(),
+            *sdk.rules(),
+            *compile.rules(),
+            QueryRule(Digest, [CreateDigest]),
+            QueryRule(Snapshot, [Digest]),
+            QueryRule(CompiledGoSources, [CompileGoSourcesRequest]),
+        ],
+        target_types=[GoPackage, GoModule],
+    )
+    rule_runner.set_options([], env_inherit={"PATH"})
+    return rule_runner
+
+
+def test_compile_simple_source_file(rule_runner: RuleRunner) -> None:
+    sources_digest = rule_runner.request(Digest, [CreateDigest([SOURCE])])
+
+    result = rule_runner.request(
+        CompiledGoSources,
+        [
+            CompileGoSourcesRequest(
+                digest=sources_digest,
+                sources=(SOURCE.path,),
+                import_path="foo",
+                description="test_compile_simple_source_file",
+            )
+        ],
+    )
+
+    snapshot = rule_runner.request(Snapshot, [result.output_digest])
+    assert "__pkg__.a" in snapshot.files
+    assert not snapshot.dirs


### PR DESCRIPTION
Refactor invocation of the Go compiler into a separate rule with associated `CompileGoSourcesRequest` and `CompiledGoSources` types.

The motivation for this change is for test binary support where it will be useful to invoke the compiler once for non-test sources and again for test sources. With this change, the code won't duplicate compiler invocation logic.