### PR TITLE
[internal] go: refactor link step into separate rule

### DIFF
--- a/src/python/pants/backend/experimental/go/register.py
+++ b/src/python/pants/backend/experimental/go/register.py
@@ -13,6 +13,7 @@ from pants.backend.go.util_rules import (
     go_mod,
     go_pkg,
     import_analysis,
+    link,
     sdk,
 )
 
@@ -31,6 +32,7 @@ def rules():
         *import_analysis.rules(),
         *go_mod.rules(),
         *go_pkg.rules(),
+        *link.rules(),
         *sdk.rules(),
         *tailor.rules(),
         *target_type_rules.rules(),

--- a/src/python/pants/backend/go/goals/package_binary_integration_test.py
+++ b/src/python/pants/backend/go/goals/package_binary_integration_test.py
@@ -18,6 +18,7 @@ from pants.backend.go.util_rules import (
     go_mod,
     go_pkg,
     import_analysis,
+    link,
     sdk,
 )
 from pants.build_graph.address import Address
@@ -40,6 +41,7 @@ def rule_runner() -> RuleRunner:
             *build_go_pkg.rules(),
             *go_pkg.rules(),
             *go_mod.rules(),
+            *link.rules(),
             *target_type_rules.rules(),
             *external_module.rules(),
             *sdk.rules(),

--- a/src/python/pants/backend/go/util_rules/link.py
+++ b/src/python/pants/backend/go/util_rules/link.py
@@ -1,0 +1,59 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pants.backend.go.util_rules.sdk import GoSdkProcess
+from pants.engine.fs import Digest
+from pants.engine.process import ProcessResult
+from pants.engine.rules import Get, collect_rules, rule
+
+
+@dataclass(frozen=True)
+class LinkGoBinaryRequest:
+    """Link a Go binary from package archives and an import configuration."""
+
+    input_digest: Digest
+    archives: tuple[str, ...]
+    import_config_path: str
+    output_filename: str
+    description: str
+
+
+@dataclass(frozen=True)
+class LinkedGoBinary:
+    """A linked Go binary stored in a `Digest`."""
+
+    output_digest: Digest
+    output_filename: str
+
+
+@rule
+async def link_go_binary(request: LinkGoBinaryRequest) -> LinkedGoBinary:
+    result = await Get(
+        ProcessResult,
+        GoSdkProcess(
+            input_digest=request.input_digest,
+            command=(
+                "tool",
+                "link",
+                "-importcfg",
+                request.import_config_path,
+                "-o",
+                request.output_filename,
+                "-buildmode=exe",  # seen in `go build -x` output
+                *request.archives,
+            ),
+            description="Link Go binary.",
+            output_files=(request.output_filename,),
+        ),
+    )
+
+    return LinkedGoBinary(
+        output_digest=result.output_digest, output_filename=request.output_filename
+    )
+
+
+def rules():
+    return collect_rules()


### PR DESCRIPTION
Refactor the logic that links Go binaries into a separate rule and associated types `LinkGoBinaryRequest` and `LinkedGoBinary`. The motibation of this PR is similar to https://github.com/pantsbuild/pants/pull/13019: It allows building internal plugin wrapper binaries and `./pants package` to reuse the same logic.
[ci skip-rust]

[ci skip-build-wheels]