### PR TITLE
Ensure XML results recorded for both pytest and junit

### DIFF
--- a/src/python/pants/backend/java/test/junit_test.py
+++ b/src/python/pants/backend/java/test/junit_test.py
@@ -438,6 +438,7 @@ def test_jupiter_simple_success(rule_runner: RuleRunner) -> None:
     test_result = run_junit_test(rule_runner, "example-test", "SimpleTest.java")
 
     assert test_result.exit_code == 0
+    assert test_result.xml_results and test_result.xml_results.files
     assert re.search(r"Finished:\s+testHello", test_result.stdout) is not None
     assert re.search(r"1 tests successful", test_result.stdout) is not None
     assert re.search(r"1 tests found", test_result.stdout) is not None
@@ -493,6 +494,7 @@ def test_jupiter_simple_failure(rule_runner: RuleRunner) -> None:
     test_result = run_junit_test(rule_runner, "example-test", "SimpleTest.java")
 
     assert test_result.exit_code == 1
+    assert test_result.xml_results and test_result.xml_results.files
     assert (
         re.search(
             r"Finished:.*?testHello.*?Exception: org.opentest4j.AssertionFailedError: expected: <Goodbye!> but was: <Hello!>",

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -128,6 +128,7 @@ def test_passing(rule_runner: RuleRunner, major_minor_interpreter: str) -> None:
         tgt,
         extra_args=[f"--python-setup-interpreter-constraints=['=={major_minor_interpreter}.*']"],
     )
+    assert result.xml_results is not None
     assert result.exit_code == 0
     assert f"{PACKAGE}/tests.py ." in result.stdout
 
@@ -307,21 +308,6 @@ def test_force(rule_runner: RuleRunner) -> None:
     result_two = run_pytest(rule_runner, tgt)
     assert result_one.exit_code == 0
     assert result_one is result_two
-
-
-def test_junit(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files(
-        {f"{PACKAGE}/tests.py": GOOD_TEST, f"{PACKAGE}/BUILD": "python_tests()"}
-    )
-    tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="tests.py"))
-    result = run_pytest(rule_runner, tgt, extra_args=["--pytest-junit-xml-dir=dist/test-results"])
-    assert result.exit_code == 0
-    assert f"{PACKAGE}/tests.py ." in result.stdout
-    assert result.xml_results is not None
-    digest_contents = rule_runner.request(DigestContents, [result.xml_results.digest])
-    file = digest_contents[0]
-    assert file.path.startswith("dist/test-results")
-    assert b"pants_test.tests" in file.content
 
 
 def test_extra_output(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -119,8 +119,12 @@ class PyTest(PythonToolBase):
             metavar="<DIR>",
             default=None,
             advanced=True,
-            help="Specifying a directory causes Junit XML result files to be emitted under "
-            "that dir for each test run.",
+            removal_version="2.9.0.dev0",
+            removal_hint="Moved to `[test] xml_dir`.",
+            help=(
+                "Specifying a directory causes Junit XML result files to be emitted under "
+                "that dir for each test run."
+            ),
         )
         register(
             "--junit-family",
@@ -128,7 +132,7 @@ class PyTest(PythonToolBase):
             default="xunit2",
             advanced=True,
             help=(
-                "The format of the generated XML file. See "
+                "The format of generated junit XML files. See "
                 "https://docs.pytest.org/en/latest/reference.html#confval-junit_family."
             ),
         )

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -312,7 +312,7 @@ class TestSubsystem(GoalSubsystem):
             advanced=True,
             help=(
                 "Specifying a directory causes Junit XML result files to be emitted under "
-                "that dir for each test run."
+                "that dir for each test run that supports producing them."
             ),
         )
         register(


### PR DESCRIPTION
Currently, JUnit XML is only produced and attached to `TestResult`s if the `--junit-xml-dir` option is set. But the XML is cheap to generate, and adds useful information for workunit consumers.

* Lift the `--junit-xml-dir` flag onto the `[test]` scope as `--xml-dir`, and deprecate the previous location.
* Generate junit XML regardless of the `--xml-dir` flag value, but only materialize it in the workspace if the flag is set.
* Add support for capturing the junit XML produced by JUnit.