### PR TITLE
Don't invalidate the scheduler when piping output. (cherrypick of #13028)

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -559,17 +559,6 @@ class GlobalOptions(Subsystem):
         )
 
         register(
-            "--colors",
-            type=bool,
-            default=sys.stdout.isatty(),
-            help=(
-                "Whether Pants should use colors in output or not. This may also impact whether "
-                "some tools Pants runs use color.\n\nWhen unset, this value defaults based on "
-                "whether the output destination supports color."
-            ),
-        )
-
-        register(
             "--ignore-warnings",
             type=list,
             member_type=str,
@@ -1314,6 +1303,16 @@ class GlobalOptions(Subsystem):
         # global-scope options, for convenience.
         cls.register_bootstrap_options(register)
 
+        register(
+            "--colors",
+            type=bool,
+            default=sys.stdout.isatty(),
+            help=(
+                "Whether Pants should use colors in output or not. This may also impact whether "
+                "some tools Pants runs use color.\n\nWhen unset, this value defaults based on "
+                "whether the output destination supports color."
+            ),
+        )
         register(
             "--dynamic-ui",
             type=bool,

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -509,6 +509,13 @@ def mock_console(
     stdin_content: bytes | str | None = None,
 ) -> Iterator[Tuple[Console, StdioReader]]:
     global_bootstrap_options = options_bootstrapper.bootstrap_options.for_global_scope()
+    colors = (
+        options_bootstrapper.full_options_for_scopes(
+            [GlobalOptions.get_scope_info()], allow_unknown_options=True
+        )
+        .for_global_scope()
+        .colors
+    )
 
     @contextmanager
     def stdin_context():
@@ -530,7 +537,7 @@ def mock_console(
         # NB: We yield a Console without overriding the destination argument, because we have
         # already done a sys.std* level replacement. The replacement is necessary in order for
         # InteractiveProcess to have native file handles to interact with.
-        yield Console(use_colors=global_bootstrap_options.colors), StdioReader(
+        yield Console(use_colors=colors), StdioReader(
             _stdout=Path(stdout.name), _stderr=Path(stderr.name)
         )
 


### PR DESCRIPTION
Since #12585, `--colors` has not needed to be a bootstrap option. Moving it out of bootstrap to the global options avoids invalidating the `Scheduler` when piping output.

[ci skip-rust]