### PR TITLE
Minor cleanups for the autoflake linter / formatter

### DIFF
--- a/src/python/pants/core/util_rules/external_tool.py
+++ b/src/python/pants/core/util_rules/external_tool.py
@@ -187,7 +187,6 @@ class ExternalTool(Subsystem, metaclass=ABCMeta):
         Implementations should raise ExternalToolError if they cannot resolve the arguments
         to a URL. The raised exception need not have a message - a sensible one will be generated.
         """
-        pass
 
     def generate_exe(self, plat: Platform) -> str:
         """Returns the path to the tool executable.


### PR DESCRIPTION
Add the `UnionRule` to enable the autoflake linter, align linter/formatter names, and strip noisy successful output (which would otherwise render once per file).

[ci skip-rust]
[ci skip-build-wheels]