### PR TITLE
Add addresses to engine aware return types

### DIFF
--- a/src/python/pants/backend/docker/lint/hadolint/rules.py
+++ b/src/python/pants/backend/docker/lint/hadolint/rules.py
@@ -82,7 +82,12 @@ async def run_hadolint(request: HadolintRequest, hadolint: Hadolint) -> LintResu
         ),
     )
     return LintResults(
-        [LintResult.from_fallible_process_result(process_result)], linter_name="hadolint"
+        [
+            LintResult.from_fallible_process_result(
+                process_result, (fs.address for fs in request.field_sets)
+            )
+        ],
+        linter_name="hadolint",
     )
 
 

--- a/src/python/pants/backend/experimental/terraform/register.py
+++ b/src/python/pants/backend/experimental/terraform/register.py
@@ -1,7 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from pants.backend.python.util_rules.pex import rules as pex_rules
-from pants.backend.terraform import dependency_inference, tailor, target_gen, tool
+from pants.backend.terraform import dependency_inference, style, tailor, target_gen, tool
 from pants.backend.terraform.lint import fmt
 from pants.backend.terraform.lint.tffmt.tffmt import rules as tffmt_rules
 from pants.backend.terraform.lint.validate.validate import rules as validate_rules
@@ -23,6 +23,7 @@ def rules():
         *target_types_rules(),
         *tool.rules(),
         *fmt.rules(),
+        *style.rules(),
         *pex_rules(),
         *tffmt_rules(),
         *validate_rules(),

--- a/src/python/pants/backend/go/lint/gofmt/rules.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules.py
@@ -97,7 +97,9 @@ async def gofmt_lint(request: GofmtRequest, gofmt: GofmtSubsystem) -> LintResult
         return LintResults([], linter_name="gofmt")
     setup = await Get(Setup, SetupRequest(request, check_only=True))
     result = await Get(FallibleProcessResult, Process, setup.process)
-    lint_result = LintResult.from_fallible_process_result(result)
+    lint_result = LintResult.from_fallible_process_result(
+        result, (fs.address for fs in request.field_sets)
+    )
     if lint_result.exit_code == 0 and lint_result.stdout.strip() != "":
         # Note: gofmt returns success even if it would have reformatted the files.
         # When this occurs, convert the LintResult into a failure.

--- a/src/python/pants/backend/go/lint/gofmt/rules.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules.py
@@ -83,11 +83,11 @@ async def setup_gofmt(setup_request: SetupRequest, goroot: GoRoot) -> Setup:
 @rule(desc="Format with gofmt")
 async def gofmt_fmt(request: GofmtRequest, gofmt: GofmtSubsystem) -> FmtResult:
     if gofmt.options.skip:
-        return FmtResult.skip(formatter_name="gofmt")
+        return FmtResult.skip(request.field_sets, formatter_name="gofmt")
     setup = await Get(Setup, SetupRequest(request, check_only=False))
     result = await Get(ProcessResult, Process, setup.process)
     return FmtResult.from_process_result(
-        result, original_digest=setup.original_digest, formatter_name="gofmt"
+        result, request.field_sets, original_digest=setup.original_digest, formatter_name="gofmt"
     )
 
 

--- a/src/python/pants/backend/java/compile/javac.py
+++ b/src/python/pants/backend/java/compile/javac.py
@@ -306,6 +306,7 @@ async def javac_check(request: JavacCheckRequest) -> CheckResults:
                 result.exit_code,
                 stdout="",
                 stderr="",
+                addresses=tuple(t.address for t in coarsened_target.members),
                 partition_description=str(coarsened_target),
             )
             for result, coarsened_target in zip(results, coarsened_targets)

--- a/src/python/pants/backend/python/lint/autoflake/rules.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules.py
@@ -106,11 +106,12 @@ async def setup_autoflake(setup_request: SetupRequest, autoflake: Autoflake) -> 
 @rule(desc="Format with Autoflake", level=LogLevel.DEBUG)
 async def autoflake_fmt(field_sets: AutoflakeRequest, autoflake: Autoflake) -> FmtResult:
     if autoflake.skip:
-        return FmtResult.skip(formatter_name="Autoflake")
+        return FmtResult.skip(field_sets.field_sets, formatter_name="Autoflake")
     setup = await Get(Setup, SetupRequest(field_sets, check_only=False))
     result = await Get(ProcessResult, Process, setup.process)
     return FmtResult.from_process_result(
         result,
+        field_sets.field_sets,
         original_digest=setup.original_digest,
         formatter_name="Autoflake",
         strip_chroot_path=True,

--- a/src/python/pants/backend/python/lint/autoflake/rules.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules.py
@@ -124,7 +124,11 @@ async def autoflake_lint(request: AutoflakeRequest, autoflake: Autoflake) -> Lin
     setup = await Get(Setup, SetupRequest(request, check_only=True))
     result = await Get(FallibleProcessResult, Process, setup.process)
     return LintResults(
-        [LintResult.from_fallible_process_result(result, strip_chroot_path=True)],
+        [
+            LintResult.from_fallible_process_result(
+                result, (fs.address for fs in request.field_sets), strip_chroot_path=True
+            )
+        ],
         linter_name="autoflake",
     )
 

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -85,6 +85,7 @@ async def bandit_lint_partition(partition: BanditPartition, bandit: Bandit) -> L
     report = await Get(Digest, RemovePrefix(result.output_digest, REPORT_DIR))
     return LintResult.from_fallible_process_result(
         result,
+        (fs.address for fs in partition.field_sets),
         partition_description=str(sorted(str(c) for c in partition.interpreter_constraints)),
         report=report,
     )

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -153,7 +153,11 @@ async def black_lint(field_sets: BlackRequest, black: Black) -> LintResults:
     setup = await Get(Setup, SetupRequest(field_sets, check_only=True))
     result = await Get(FallibleProcessResult, Process, setup.process)
     return LintResults(
-        [LintResult.from_fallible_process_result(result, strip_chroot_path=True)],
+        [
+            LintResult.from_fallible_process_result(
+                result, (fs.address for fs in field_sets.field_sets), strip_chroot_path=True
+            )
+        ],
         linter_name="Black",
     )
 

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -135,11 +135,12 @@ async def setup_black(
 @rule(desc="Format with Black", level=LogLevel.DEBUG)
 async def black_fmt(field_sets: BlackRequest, black: Black) -> FmtResult:
     if black.skip:
-        return FmtResult.skip(formatter_name="Black")
+        return FmtResult.skip(field_sets.field_sets, formatter_name="Black")
     setup = await Get(Setup, SetupRequest(field_sets, check_only=False))
     result = await Get(ProcessResult, Process, setup.process)
     return FmtResult.from_process_result(
         result,
+        field_sets.field_sets,
         original_digest=setup.original_digest,
         formatter_name="Black",
         strip_chroot_path=True,

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -103,11 +103,14 @@ async def setup_docformatter(setup_request: SetupRequest, docformatter: Docforma
 @rule(desc="Format with docformatter", level=LogLevel.DEBUG)
 async def docformatter_fmt(request: DocformatterRequest, docformatter: Docformatter) -> FmtResult:
     if docformatter.skip:
-        return FmtResult.skip(formatter_name="Docformatter")
+        return FmtResult.skip(request.field_sets, formatter_name="Docformatter")
     setup = await Get(Setup, SetupRequest(request, check_only=False))
     result = await Get(ProcessResult, Process, setup.process)
     return FmtResult.from_process_result(
-        result, original_digest=setup.original_digest, formatter_name="Docformatter"
+        result,
+        request.field_sets,
+        original_digest=setup.original_digest,
+        formatter_name="Docformatter",
     )
 
 

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -120,7 +120,12 @@ async def docformatter_lint(
     setup = await Get(Setup, SetupRequest(request, check_only=True))
     result = await Get(FallibleProcessResult, Process, setup.process)
     return LintResults(
-        [LintResult.from_fallible_process_result(result)], linter_name="Docformatter"
+        [
+            LintResult.from_fallible_process_result(
+                result, (fs.address for fs in request.field_sets)
+            )
+        ],
+        linter_name="Docformatter",
     )
 
 

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -82,6 +82,7 @@ async def flake8_lint_partition(partition: Flake8Partition, flake8: Flake8) -> L
     report = await Get(Digest, RemovePrefix(result.output_digest, REPORT_DIR))
     return LintResult.from_fallible_process_result(
         result,
+        (fs.address for fs in partition.field_sets),
         partition_description=str(sorted(str(c) for c in partition.interpreter_constraints)),
         report=report,
     )

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -153,7 +153,13 @@ async def isort_lint(request: IsortRequest, isort: Isort) -> LintResults:
     setup = await Get(Setup, SetupRequest(request, check_only=True))
     result = await Get(FallibleProcessResult, Process, setup.process)
     return LintResults(
-        [LintResult.from_fallible_process_result(result, strip_chroot_path=True)],
+        [
+            LintResult.from_fallible_process_result(
+                result,
+                (fs.address for fs in request.field_sets),
+                strip_chroot_path=True,
+            )
+        ],
         linter_name="isort",
     )
 

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -135,11 +135,12 @@ async def setup_isort(setup_request: SetupRequest, isort: Isort) -> Setup:
 @rule(desc="Format with isort", level=LogLevel.DEBUG)
 async def isort_fmt(request: IsortRequest, isort: Isort) -> FmtResult:
     if isort.skip:
-        return FmtResult.skip(formatter_name="isort")
+        return FmtResult.skip(request.field_sets, formatter_name="isort")
     setup = await Get(Setup, SetupRequest(request, check_only=False))
     result = await Get(ProcessResult, Process, setup.process)
     return FmtResult.from_process_result(
         result,
+        request.field_sets,
         original_digest=setup.original_digest,
         formatter_name="isort",
         strip_chroot_path=True,

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -163,7 +163,9 @@ async def pylint_lint_partition(
         ),
     )
     return LintResult.from_fallible_process_result(
-        result, partition_description=str(sorted(str(c) for c in partition.interpreter_constraints))
+        result,
+        (fs.address for fs in partition.field_sets),
+        partition_description=str(sorted(str(c) for c in partition.interpreter_constraints)),
     )
 
 

--- a/src/python/pants/backend/python/lint/yapf/rules.py
+++ b/src/python/pants/backend/python/lint/yapf/rules.py
@@ -118,11 +118,12 @@ async def setup_yapf(setup_request: SetupRequest, yapf: Yapf) -> Setup:
 @rule(desc="Format with yapf", level=LogLevel.DEBUG)
 async def yapf_fmt(request: YapfRequest, yapf: Yapf) -> FmtResult:
     if yapf.skip:
-        return FmtResult.skip(formatter_name="yapf")
+        return FmtResult.skip(request.field_sets, formatter_name="yapf")
     setup = await Get(Setup, SetupRequest(request, check_only=False))
     result = await Get(ProcessResult, Process, setup.process)
     return FmtResult.from_process_result(
         result,
+        request.field_sets,
         original_digest=setup.original_digest,
         formatter_name="yapf",
     )

--- a/src/python/pants/backend/python/lint/yapf/rules.py
+++ b/src/python/pants/backend/python/lint/yapf/rules.py
@@ -135,7 +135,11 @@ async def yapf_lint(request: YapfRequest, yapf: Yapf) -> LintResults:
     setup = await Get(Setup, SetupRequest(request, check_only=True))
     result = await Get(FallibleProcessResult, Process, setup.process)
     return LintResults(
-        [LintResult.from_fallible_process_result(result)],
+        [
+            LintResult.from_fallible_process_result(
+                result, (fs.address for fs in request.field_sets)
+            )
+        ],
         linter_name="yapf",
     )
 

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -219,6 +219,7 @@ async def mypy_typecheck_partition(
     report = await Get(Digest, RemovePrefix(result.output_digest, REPORT_DIR))
     return CheckResult.from_fallible_process_result(
         result,
+        addresses=tuple(t.address for t in partition.root_targets),
         partition_description=str(sorted(str(c) for c in partition.interpreter_constraints)),
         report=report,
     )

--- a/src/python/pants/backend/shell/lint/shellcheck/rules.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/rules.py
@@ -104,7 +104,9 @@ async def run_shellcheck(request: ShellcheckRequest, shellcheck: Shellcheck) -> 
             level=LogLevel.DEBUG,
         ),
     )
-    result = LintResult.from_fallible_process_result(process_result)
+    result = LintResult.from_fallible_process_result(
+        process_result, (fs.address for fs in request.field_sets)
+    )
     return LintResults([result], linter_name="Shellcheck")
 
 

--- a/src/python/pants/backend/shell/lint/shfmt/rules.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules.py
@@ -98,11 +98,11 @@ async def setup_shfmt(setup_request: SetupRequest, shfmt: Shfmt) -> Setup:
 @rule(desc="Format with shfmt", level=LogLevel.DEBUG)
 async def shfmt_fmt(request: ShfmtRequest, shfmt: Shfmt) -> FmtResult:
     if shfmt.skip:
-        return FmtResult.skip(formatter_name="shfmt")
+        return FmtResult.skip(request.field_sets, formatter_name="shfmt")
     setup = await Get(Setup, SetupRequest(request, check_only=False))
     result = await Get(ProcessResult, Process, setup.process)
     return FmtResult.from_process_result(
-        result, original_digest=setup.original_digest, formatter_name="shfmt"
+        result, request.field_sets, original_digest=setup.original_digest, formatter_name="shfmt"
     )
 
 

--- a/src/python/pants/backend/shell/lint/shfmt/rules.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules.py
@@ -112,7 +112,14 @@ async def shfmt_lint(request: ShfmtRequest, shfmt: Shfmt) -> LintResults:
         return LintResults([], linter_name="shfmt")
     setup = await Get(Setup, SetupRequest(request, check_only=True))
     result = await Get(FallibleProcessResult, Process, setup.process)
-    return LintResults([LintResult.from_fallible_process_result(result)], linter_name="shfmt")
+    return LintResults(
+        [
+            LintResult.from_fallible_process_result(
+                result, (fs.address for fs in request.field_sets)
+            )
+        ],
+        linter_name="shfmt",
+    )
 
 
 def rules():

--- a/src/python/pants/backend/terraform/lint/fmt.py
+++ b/src/python/pants/backend/terraform/lint/fmt.py
@@ -4,9 +4,9 @@
 from dataclasses import dataclass
 from typing import Iterable
 
+from pants.backend.terraform.style import StyleRequest
 from pants.backend.terraform.target_types import TerraformSources
 from pants.core.goals.fmt import FmtResult, LanguageFmtResults, LanguageFmtTargets
-from pants.core.goals.style_request import StyleRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, Snapshot
 from pants.engine.internals.selectors import Get

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
@@ -49,7 +49,7 @@ class TffmtRequest(TerraformFmtRequest):
 @rule(desc="Format with `terraform fmt`")
 async def tffmt_fmt(request: TffmtRequest, tffmt: TfFmtSubsystem) -> FmtResult:
     if tffmt.options.skip:
-        return FmtResult.skip(formatter_name="tffmt")
+        return FmtResult.skip(request.field_sets, formatter_name="tffmt")
     setup = await Get(StyleSetup, StyleSetupRequest(request, ("fmt",)))
     results = await MultiGet(
         Get(ProcessResult, TerraformProcess, process)
@@ -83,6 +83,7 @@ async def tffmt_fmt(request: TffmtRequest, tffmt: TfFmtSubsystem) -> FmtResult:
         stdout=stdout_content,
         stderr=stderr_content,
         formatter_name="tffmt",
+        addresses=tuple(fs.address for fs in request.field_sets),
     )
     return fmt_result
 

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
@@ -4,29 +4,22 @@
 from __future__ import annotations
 
 import logging
-import os
 import textwrap
-from collections import defaultdict
-from dataclasses import dataclass
 
 from pants.backend.terraform.lint.fmt import TerraformFmtRequest
-from pants.backend.terraform.target_types import TerraformSources
+from pants.backend.terraform.style import StyleSetup, StyleSetupRequest
 from pants.backend.terraform.tool import TerraformProcess
 from pants.backend.terraform.tool import rules as tool_rules
-from pants.build_graph.address import Address
 from pants.core.goals.fmt import FmtResult
-from pants.core.goals.lint import LintResult, LintResults
+from pants.core.goals.lint import LintRequest, LintResult, LintResults
 from pants.core.util_rules import external_tool
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.engine.fs import Digest, MergeDigests, Snapshot
+from pants.engine.fs import Digest, MergeDigests
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.process import FallibleProcessResult, ProcessResult
 from pants.engine.rules import collect_rules, rule
-from pants.engine.target import FieldSet
 from pants.engine.unions import UnionRule
 from pants.option.subsystem import Subsystem
 from pants.util.logging import LogLevel
-from pants.util.strutil import pluralize
 
 logger = logging.getLogger(__name__)
 
@@ -49,91 +42,18 @@ class TfFmtSubsystem(Subsystem):
         )
 
 
-@dataclass(frozen=True)
-class TffmtFieldSet(FieldSet):
-    required_fields = (TerraformSources,)
-
-    sources: TerraformSources
-
-
 class TffmtRequest(TerraformFmtRequest):
-    field_set_type = TffmtFieldSet
-
-
-@dataclass(frozen=True)
-class SetupRequest:
-    request: TffmtRequest
-    check_only: bool
-
-
-@dataclass(frozen=True)
-class Setup:
-    directory_to_process: dict[str, tuple[TerraformProcess, tuple[Address, ...]]]
-    original_digest: Digest
-
-
-@rule(level=LogLevel.DEBUG)
-async def setup_terraform_fmt(setup_request: SetupRequest) -> Setup:
-    source_files_by_field_set = await MultiGet(
-        Get(
-            SourceFiles,
-            SourceFilesRequest([field_set.sources]),
-        )
-        for field_set in setup_request.request.field_sets
-    )
-
-    source_files_snapshot = (
-        await Get(Snapshot, MergeDigests(sfs.snapshot.digest for sfs in source_files_by_field_set))
-        if setup_request.request.prior_formatter_result is None
-        else setup_request.request.prior_formatter_result
-    )
-
-    # `terraform fmt` operates on a directory-by-directory basis. First determine the directories in
-    # the snapshot. This does not use `source_files_snapshot.dirs` because that will be empty if the files
-    # are in a single directory.
-    directories = defaultdict(list)
-    for source_files, field_set in zip(source_files_by_field_set, setup_request.request.field_sets):
-        for file in source_files.snapshot.files:
-            directory = os.path.dirname(file)
-            if directory == "":
-                directory = "."
-            directories[directory].append((file, field_set.address))
-
-    # Then create a process for each directory.
-    directory_to_process = {}
-    for directory, files_and_addresses_in_directory in directories.items():
-        args = [
-            "fmt",
-        ]
-        if setup_request.check_only:
-            args.append("-check")
-        args.append(directory)
-
-        files_in_directory = tuple(f for f, _ in files_and_addresses_in_directory)
-        addresses = tuple(a for _, a in files_and_addresses_in_directory)
-
-        process = TerraformProcess(
-            args=tuple(args),
-            input_digest=source_files_snapshot.digest,
-            output_files=files_in_directory,
-            description=f"Run `terraform fmt` on {pluralize(len(files_in_directory), 'file')}.",
-        )
-
-        directory_to_process[directory] = (process, addresses)
-
-    return Setup(
-        directory_to_process=directory_to_process, original_digest=source_files_snapshot.digest
-    )
+    pass
 
 
 @rule(desc="Format with `terraform fmt`")
 async def tffmt_fmt(request: TffmtRequest, tffmt: TfFmtSubsystem) -> FmtResult:
     if tffmt.options.skip:
         return FmtResult.skip(formatter_name="tffmt")
-    setup = await Get(Setup, SetupRequest(request, check_only=False))
+    setup = await Get(StyleSetup, StyleSetupRequest(request, ("fmt",)))
     results = await MultiGet(
         Get(ProcessResult, TerraformProcess, process)
-        for process in setup.directory_to_process.values()
+        for _, (process, _) in setup.directory_to_process.items()
     )
 
     def format(directory, output):
@@ -171,10 +91,10 @@ async def tffmt_fmt(request: TffmtRequest, tffmt: TfFmtSubsystem) -> FmtResult:
 async def tffmt_lint(request: TffmtRequest, tffmt: TfFmtSubsystem) -> LintResults:
     if tffmt.options.skip:
         return LintResults([], linter_name="tffmt")
-    setup = await Get(Setup, SetupRequest(request, check_only=True))
+    setup = await Get(StyleSetup, StyleSetupRequest(request, ("fmt", "-check")))
     results = await MultiGet(
         Get(FallibleProcessResult, TerraformProcess, process)
-        for directory, (process, _) in setup.directory_to_process.items()
+        for _, (process, _) in setup.directory_to_process.items()
     )
     lint_results = [
         LintResult.from_fallible_process_result(result, addresses)
@@ -188,5 +108,6 @@ def rules():
         *collect_rules(),
         *external_tool.rules(),
         *tool_rules(),
+        UnionRule(LintRequest, TffmtRequest),
         UnionRule(TerraformFmtRequest, TffmtRequest),
     ]

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
@@ -1,21 +1,24 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
 import logging
 import os
 import textwrap
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Dict
 
 from pants.backend.terraform.lint.fmt import TerraformFmtRequest
 from pants.backend.terraform.target_types import TerraformSources
 from pants.backend.terraform.tool import TerraformProcess
 from pants.backend.terraform.tool import rules as tool_rules
+from pants.build_graph.address import Address
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintResult, LintResults
 from pants.core.util_rules import external_tool
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.engine.fs import Digest, MergeDigests
+from pants.engine.fs import Digest, MergeDigests, Snapshot
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.process import FallibleProcessResult, ProcessResult
 from pants.engine.rules import collect_rules, rule
@@ -65,19 +68,22 @@ class SetupRequest:
 
 @dataclass(frozen=True)
 class Setup:
-    directory_to_process: Dict[str, TerraformProcess]
+    directory_to_process: dict[str, tuple[TerraformProcess, tuple[Address, ...]]]
     original_digest: Digest
 
 
 @rule(level=LogLevel.DEBUG)
 async def setup_terraform_fmt(setup_request: SetupRequest) -> Setup:
-    source_files = await Get(
-        SourceFiles,
-        SourceFilesRequest(field_set.sources for field_set in setup_request.request.field_sets),
+    source_files_by_field_set = await MultiGet(
+        Get(
+            SourceFiles,
+            SourceFilesRequest([field_set.sources]),
+        )
+        for field_set in setup_request.request.field_sets
     )
 
     source_files_snapshot = (
-        source_files.snapshot
+        await Get(Snapshot, MergeDigests(sfs.snapshot.digest for sfs in source_files_by_field_set))
         if setup_request.request.prior_formatter_result is None
         else setup_request.request.prior_formatter_result
     )
@@ -86,15 +92,16 @@ async def setup_terraform_fmt(setup_request: SetupRequest) -> Setup:
     # the snapshot. This does not use `source_files_snapshot.dirs` because that will be empty if the files
     # are in a single directory.
     directories = defaultdict(list)
-    for file in source_files.snapshot.files:
-        directory = os.path.dirname(file)
-        if directory == "":
-            directory = "."
-        directories[directory].append(file)
+    for source_files, field_set in zip(source_files_by_field_set, setup_request.request.field_sets):
+        for file in source_files.snapshot.files:
+            directory = os.path.dirname(file)
+            if directory == "":
+                directory = "."
+            directories[directory].append((file, field_set.address))
 
     # Then create a process for each directory.
     directory_to_process = {}
-    for directory, files_in_directory in directories.items():
+    for directory, files_and_addresses_in_directory in directories.items():
         args = [
             "fmt",
         ]
@@ -102,14 +109,17 @@ async def setup_terraform_fmt(setup_request: SetupRequest) -> Setup:
             args.append("-check")
         args.append(directory)
 
+        files_in_directory = tuple(f for f, _ in files_and_addresses_in_directory)
+        addresses = tuple(a for _, a in files_and_addresses_in_directory)
+
         process = TerraformProcess(
             args=tuple(args),
             input_digest=source_files_snapshot.digest,
-            output_files=tuple(files_in_directory),
+            output_files=files_in_directory,
             description=f"Run `terraform fmt` on {pluralize(len(files_in_directory), 'file')}.",
         )
 
-        directory_to_process[directory] = process
+        directory_to_process[directory] = (process, addresses)
 
     return Setup(
         directory_to_process=directory_to_process, original_digest=source_files_snapshot.digest
@@ -164,9 +174,12 @@ async def tffmt_lint(request: TffmtRequest, tffmt: TfFmtSubsystem) -> LintResult
     setup = await Get(Setup, SetupRequest(request, check_only=True))
     results = await MultiGet(
         Get(FallibleProcessResult, TerraformProcess, process)
-        for directory, process in setup.directory_to_process.items()
+        for directory, (process, _) in setup.directory_to_process.items()
     )
-    lint_results = [LintResult.from_fallible_process_result(result) for result in results]
+    lint_results = [
+        LintResult.from_fallible_process_result(result, addresses)
+        for (result, (_, addresses)) in zip(results, setup.directory_to_process.values())
+    ]
     return LintResults(lint_results, linter_name="tffmt")
 
 

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt_integration_test.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt_integration_test.py
@@ -5,11 +5,11 @@ from typing import List, Sequence, Tuple
 
 import pytest
 
-from pants.backend.terraform import tool
+from pants.backend.terraform import style, tool
 from pants.backend.terraform.lint import fmt
 from pants.backend.terraform.lint.tffmt import tffmt
-from pants.backend.terraform.lint.tffmt.tffmt import TffmtFieldSet, TffmtRequest
-from pants.backend.terraform.target_types import TerraformModule
+from pants.backend.terraform.lint.tffmt.tffmt import TffmtRequest
+from pants.backend.terraform.target_types import TerraformFieldSet, TerraformModule
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintResult, LintResults
 from pants.core.util_rules import external_tool, source_files
@@ -29,6 +29,7 @@ def rule_runner() -> RuleRunner:
             *fmt.rules(),
             *tffmt.rules(),
             *tool.rules(),
+            *style.rules(),
             *source_files.rules(),
             QueryRule(LintResults, (TffmtRequest,)),
             QueryRule(FmtResult, (TffmtRequest,)),
@@ -104,7 +105,7 @@ def run_tffmt(
     if skip:
         args.append("--terraform-fmt-skip")
     rule_runner.set_options(args)
-    field_sets = [TffmtFieldSet.create(tgt) for tgt in targets]
+    field_sets = [TerraformFieldSet.create(tgt) for tgt in targets]
     lint_results = rule_runner.request(LintResults, [TffmtRequest(field_sets)])
     input_sources = rule_runner.request(
         SourceFiles,

--- a/src/python/pants/backend/terraform/lint/validate/validate.py
+++ b/src/python/pants/backend/terraform/lint/validate/validate.py
@@ -1,23 +1,17 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-import os
-from collections import defaultdict
-from dataclasses import dataclass
 
-from pants.backend.terraform.target_types import TerraformSources
+from pants.backend.terraform.style import StyleRequest, StyleSetup, StyleSetupRequest
 from pants.backend.terraform.tool import TerraformProcess
 from pants.backend.terraform.tool import rules as tool_rules
 from pants.core.goals.lint import LintRequest, LintResult, LintResults
 from pants.core.util_rules import external_tool
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import SubsystemRule, collect_rules, rule
-from pants.engine.target import FieldSet
 from pants.engine.unions import UnionRule
 from pants.option.subsystem import Subsystem
 from pants.util.logging import LogLevel
-from pants.util.strutil import pluralize
 
 
 class TerraformValidateSubsystem(Subsystem):
@@ -37,15 +31,8 @@ class TerraformValidateSubsystem(Subsystem):
         )
 
 
-@dataclass(frozen=True)
-class ValidateFieldSet(FieldSet):
-    required_fields = (TerraformSources,)
-
-    sources: TerraformSources
-
-
-class ValidateRequest(LintRequest):
-    field_set_type = ValidateFieldSet
+class ValidateRequest(StyleRequest):
+    pass
 
 
 @rule(desc="Lint with `terraform validate`", level=LogLevel.DEBUG)
@@ -55,53 +42,18 @@ async def run_terraform_validate(
     if subsystem.options.skip:
         return LintResults([], linter_name="terraform validate")
 
-    sources_files = await Get(
-        SourceFiles,
-        SourceFilesRequest(field_set.sources for field_set in request.field_sets),
-    )
-
-    # `terraform validate` operates on a directory-by-directory basis. First determine the directories in
-    # the snapshot. This does not use `source_files_snapshot.dirs` because that will be empty if the files
-    # are in a single directory.
-    directories = defaultdict(list)
-    for file in sources_files.snapshot.files:
-        directory = os.path.dirname(file)
-        if directory == "":
-            directory = "."
-        directories[directory].append(file)
-
-    # Then create a process for each directory.
-    directory_to_process = {}
-    for directory, files_in_directory in directories.items():
-        args = [
-            "validate",
-            directory,
-        ]
-        args = [arg for arg in args if arg]
-
-        process = TerraformProcess(
-            args=tuple(args),
-            input_digest=sources_files.snapshot.digest,
-            output_files=tuple(files_in_directory),
-            description=f"Run `terraform validate` on {pluralize(len(files_in_directory), 'file')}.",
-        )
-
-        directory_to_process[directory] = process
-
+    setup = await Get(StyleSetup, StyleSetupRequest(request, ("validate",)))
     results = await MultiGet(
         Get(FallibleProcessResult, TerraformProcess, process)
-        for process in directory_to_process.values()
+        for _, (process, _) in setup.directory_to_process.items()
     )
-
     lint_results = []
-    for directory, result in zip(directory_to_process.keys(), results):
-        lint_result = LintResult(
-            exit_code=result.exit_code,
-            stdout=result.stdout.decode(),
-            stderr=result.stderr.decode(),
-            partition_description=f"`terraform validate` on `{directory}`",
+    for (directory, (_, addresses)), result in zip(setup.directory_to_process.items(), results):
+        lint_results.append(
+            LintResult.from_fallible_process_result(
+                result, addresses, partition_description=f"`terraform validate` on `{directory}`"
+            )
         )
-        lint_results.append(lint_result)
 
     return LintResults(lint_results, linter_name="terraform validate")
 

--- a/src/python/pants/backend/terraform/lint/validate/validate_integration_test.py
+++ b/src/python/pants/backend/terraform/lint/validate/validate_integration_test.py
@@ -5,11 +5,11 @@ from typing import List, Sequence
 
 import pytest
 
-from pants.backend.terraform import tool
+from pants.backend.terraform import style, tool
 from pants.backend.terraform.lint import fmt
 from pants.backend.terraform.lint.validate import validate
-from pants.backend.terraform.lint.validate.validate import ValidateFieldSet, ValidateRequest
-from pants.backend.terraform.target_types import TerraformModule
+from pants.backend.terraform.lint.validate.validate import ValidateRequest
+from pants.backend.terraform.target_types import TerraformFieldSet, TerraformModule
 from pants.core.goals.lint import LintResult, LintResults
 from pants.core.util_rules import external_tool, source_files
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
@@ -28,6 +28,7 @@ def rule_runner() -> RuleRunner:
             *fmt.rules(),
             *validate.rules(),
             *tool.rules(),
+            *style.rules(),
             *source_files.rules(),
             QueryRule(LintResults, (ValidateRequest,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
@@ -85,7 +86,7 @@ def run_terraform_validate(
     if skip:
         args.append("--terraform-validate-skip")
     rule_runner.set_options(args)
-    field_sets = [ValidateFieldSet.create(tgt) for tgt in targets]
+    field_sets = [TerraformFieldSet.create(tgt) for tgt in targets]
     lint_results = rule_runner.request(LintResults, [ValidateRequest(field_sets)])
     return lint_results.results
 

--- a/src/python/pants/backend/terraform/style.py
+++ b/src/python/pants/backend/terraform/style.py
@@ -1,0 +1,91 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import os
+from collections import defaultdict
+from dataclasses import dataclass
+
+from pants.backend.terraform.target_types import TerraformFieldSet
+from pants.backend.terraform.tool import TerraformProcess
+from pants.build_graph.address import Address
+from pants.core.goals import style_request
+from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.engine.fs import Digest, MergeDigests, Snapshot
+from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.rules import collect_rules, rule
+from pants.util.logging import LogLevel
+from pants.util.strutil import pluralize
+
+
+class StyleRequest(style_request.StyleRequest):
+    field_set_type = TerraformFieldSet
+
+
+@dataclass(frozen=True)
+class StyleSetupRequest:
+    request: StyleRequest
+    args: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class StyleSetup:
+    directory_to_process: dict[str, tuple[TerraformProcess, tuple[Address, ...]]]
+    original_digest: Digest
+
+
+@rule(level=LogLevel.DEBUG)
+async def setup_terraform_style(setup_request: StyleSetupRequest) -> StyleSetup:
+    source_files_by_field_set = await MultiGet(
+        Get(
+            SourceFiles,
+            SourceFilesRequest([field_set.sources]),
+        )
+        for field_set in setup_request.request.field_sets
+    )
+
+    source_files_snapshot = (
+        await Get(Snapshot, MergeDigests(sfs.snapshot.digest for sfs in source_files_by_field_set))
+        if setup_request.request.prior_formatter_result is None
+        else setup_request.request.prior_formatter_result
+    )
+
+    # `terraform fmt` operates on a directory-by-directory basis. First determine the directories in
+    # the snapshot. This does not use `source_files_snapshot.dirs` because that will be empty if the files
+    # are in a single directory.
+    directories = defaultdict(list)
+    for source_files, field_set in zip(source_files_by_field_set, setup_request.request.field_sets):
+        for file in source_files.snapshot.files:
+            directory = os.path.dirname(file)
+            if directory == "":
+                directory = "."
+            directories[directory].append((file, field_set.address))
+
+    # Then create a process for each directory.
+    directory_to_process = {}
+    for directory, files_and_addresses_in_directory in directories.items():
+        args = list(setup_request.args)
+        args.append(directory)
+
+        files_in_directory = tuple(f for f, _ in files_and_addresses_in_directory)
+        addresses = tuple(a for _, a in files_and_addresses_in_directory)
+
+        process = TerraformProcess(
+            args=tuple(args),
+            input_digest=source_files_snapshot.digest,
+            output_files=files_in_directory,
+            description=f"Run `terraform fmt` on {pluralize(len(files_in_directory), 'file')}.",
+        )
+
+        directory_to_process[directory] = (process, addresses)
+
+    return StyleSetup(
+        directory_to_process=directory_to_process, original_digest=source_files_snapshot.digest
+    )
+
+
+def rules():
+    return [
+        *collect_rules(),
+    ]

--- a/src/python/pants/backend/terraform/target_types.py
+++ b/src/python/pants/backend/terraform/target_types.py
@@ -1,11 +1,20 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+from dataclasses import dataclass
+
 from pants.engine.rules import collect_rules
-from pants.engine.target import COMMON_TARGET_FIELDS, Dependencies, Sources, Target
+from pants.engine.target import COMMON_TARGET_FIELDS, Dependencies, FieldSet, Sources, Target
 
 
 class TerraformSources(Sources):
     expected_file_extensions = (".tf",)
+
+
+@dataclass(frozen=True)
+class TerraformFieldSet(FieldSet):
+    required_fields = (TerraformSources,)
+
+    sources: TerraformSources
 
 
 class TerraformModuleSources(TerraformSources):

--- a/src/python/pants/core/goals/check_test.py
+++ b/src/python/pants/core/goals/check_test.py
@@ -41,13 +41,14 @@ class MockCheckRequest(CheckRequest, metaclass=ABCMeta):
 
     @property
     def check_results(self) -> CheckResults:
-        addresses = [config.address for config in self.field_sets]
+        addresses = tuple(config.address for config in self.field_sets)
         return CheckResults(
             [
                 CheckResult(
                     self.exit_code(addresses),
                     "",
                     "",
+                    addresses,
                 )
             ],
             checker_name=self.checker_name,
@@ -196,7 +197,9 @@ def test_streaming_output_skip() -> None:
 
 
 def test_streaming_output_success() -> None:
-    results = CheckResults([CheckResult(0, "stdout", "stderr")], checker_name="typechecker")
+    results = CheckResults(
+        [CheckResult(0, "stdout", "stderr", tuple())], checker_name="typechecker"
+    )
     assert results.level() == LogLevel.INFO
     assert results.message() == dedent(
         """\
@@ -209,7 +212,9 @@ def test_streaming_output_success() -> None:
 
 
 def test_streaming_output_failure() -> None:
-    results = CheckResults([CheckResult(18, "stdout", "stderr")], checker_name="typechecker")
+    results = CheckResults(
+        [CheckResult(18, "stdout", "stderr", tuple())], checker_name="typechecker"
+    )
     assert results.level() == LogLevel.ERROR
     assert results.message() == dedent(
         """\
@@ -224,8 +229,8 @@ def test_streaming_output_failure() -> None:
 def test_streaming_output_partitions() -> None:
     results = CheckResults(
         [
-            CheckResult(21, "", "", partition_description="ghc8.1"),
-            CheckResult(0, "stdout", "stderr", partition_description="ghc9.2"),
+            CheckResult(21, "", "", tuple(), partition_description="ghc8.1"),
+            CheckResult(0, "stdout", "stderr", tuple(), partition_description="ghc9.2"),
         ],
         checker_name="typechecker",
     )

--- a/src/python/pants/core/goals/fmt_test.py
+++ b/src/python/pants/core/goals/fmt_test.py
@@ -73,6 +73,7 @@ class FortranTargets(MockLanguageTargets):
                     stdout="",
                     stderr="",
                     formatter_name="FortranConditionallyDidChange",
+                    addresses=tuple(),
                 ),
             ),
             input=EMPTY_DIGEST,
@@ -92,8 +93,9 @@ class SmalltalkTargets(MockLanguageTargets):
                     stdout="",
                     stderr="",
                     formatter_name="SmalltalkDidNotChange",
+                    addresses=tuple(),
                 ),
-                FmtResult.skip(formatter_name="SmalltalkSkipped"),
+                FmtResult.skip([], formatter_name="SmalltalkSkipped"),
             ),
             input=EMPTY_DIGEST,
             output=result_digest,
@@ -114,6 +116,7 @@ class InvalidTargets(MockLanguageTargets):
                     stdout="",
                     stderr="",
                     formatter_name="InvalidFormatter",
+                    addresses=tuple(),
                 ),
             ),
             input=EMPTY_DIGEST,
@@ -284,7 +287,7 @@ def test_summary(rule_runner: RuleRunner) -> None:
 
 
 def test_streaming_output_skip() -> None:
-    result = FmtResult.skip(formatter_name="formatter")
+    result = FmtResult.skip([], formatter_name="formatter")
     assert result.level() == LogLevel.DEBUG
     assert result.message() == "formatter skipped."
 
@@ -297,6 +300,7 @@ def test_streaming_output_changed() -> None:
         stdout="stdout",
         stderr="stderr",
         formatter_name="formatter",
+        addresses=tuple(),
     )
     assert result.level() == LogLevel.WARN
     assert result.message() == dedent(
@@ -316,6 +320,7 @@ def test_streaming_output_not_changed() -> None:
         stdout="stdout",
         stderr="stderr",
         formatter_name="formatter",
+        addresses=tuple(),
     )
     assert result.level() == LogLevel.INFO
     assert result.message() == dedent(

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -43,9 +43,9 @@ class MockLintRequest(LintRequest, metaclass=ABCMeta):
 
     @property
     def lint_results(self) -> LintResults:
-        addresses = [config.address for config in self.field_sets]
+        addresses = tuple(config.address for config in self.field_sets)
         return LintResults(
-            [LintResult(self.exit_code(addresses), "", "")], linter_name=self.linter_name
+            [LintResult(self.exit_code(addresses), "", "", addresses)], linter_name=self.linter_name
         )
 
 
@@ -228,7 +228,7 @@ def test_streaming_output_skip() -> None:
 
 
 def test_streaming_output_success() -> None:
-    results = LintResults([LintResult(0, "stdout", "stderr")], linter_name="linter")
+    results = LintResults([LintResult(0, "stdout", "stderr", tuple())], linter_name="linter")
     assert results.level() == LogLevel.INFO
     assert results.message() == dedent(
         """\
@@ -241,7 +241,7 @@ def test_streaming_output_success() -> None:
 
 
 def test_streaming_output_failure() -> None:
-    results = LintResults([LintResult(18, "stdout", "stderr")], linter_name="linter")
+    results = LintResults([LintResult(18, "stdout", "stderr", tuple())], linter_name="linter")
     assert results.level() == LogLevel.ERROR
     assert results.message() == dedent(
         """\
@@ -256,8 +256,8 @@ def test_streaming_output_failure() -> None:
 def test_streaming_output_partitions() -> None:
     results = LintResults(
         [
-            LintResult(21, "", "", partition_description="ghc8.1"),
-            LintResult(0, "stdout", "stderr", partition_description="ghc9.2"),
+            LintResult(21, "", "", tuple(), partition_description="ghc8.1"),
+            LintResult(0, "stdout", "stderr", tuple(), partition_description="ghc9.2"),
         ],
         linter_name="linter",
     )

--- a/src/python/pants/core/goals/style_request_test.py
+++ b/src/python/pants/core/goals/style_request_test.py
@@ -14,24 +14,24 @@ def test_write_reports() -> None:
     rule_runner = RuleRunner()
     report_digest = rule_runner.make_snapshot_of_empty_files(["r.txt"]).digest
     no_results = CheckResults([], checker_name="none")
-    _empty_result = CheckResult(0, "", "", report=EMPTY_DIGEST)
+    _empty_result = CheckResult(0, "", "", tuple(), report=EMPTY_DIGEST)
     empty_results = CheckResults([_empty_result], checker_name="empty")
-    _single_result = CheckResult(0, "", "", report=report_digest)
+    _single_result = CheckResult(0, "", "", tuple(), report=report_digest)
     single_results = CheckResults([_single_result], checker_name="single")
     duplicate_results = CheckResults(
         [_single_result, _single_result, _empty_result], checker_name="duplicate"
     )
     partition_results = CheckResults(
         [
-            CheckResult(0, "", "", report=report_digest, partition_description="p1"),
-            CheckResult(0, "", "", report=report_digest, partition_description="p2"),
+            CheckResult(0, "", "", tuple(), report=report_digest, partition_description="p1"),
+            CheckResult(0, "", "", tuple(), report=report_digest, partition_description="p2"),
         ],
         checker_name="partition",
     )
     partition_duplicate_results = CheckResults(
         [
-            CheckResult(0, "", "", report=report_digest, partition_description="p"),
-            CheckResult(0, "", "", report=report_digest, partition_description="p"),
+            CheckResult(0, "", "", tuple(), report=report_digest, partition_description="p"),
+            CheckResult(0, "", "", tuple(), report=report_digest, partition_description="p"),
         ],
         checker_name="partition_duplicate",
     )


### PR DESCRIPTION
To allow workunit consumers to display rich information about results, we should include the addresses that the tools have operated on in their result types as `EngineAwareReturnType.metadata`.

Adds addresses to `CheckResult`, `FmtResult`, and `LintResult`. Additionally, unifies the setup for Terraform linting/formatting to remove redundancy.

[ci skip-rust]
[ci skip-build-wheels]