### PR TITLE
[internal] java: recurse into subdirs for java target generators

### DIFF
--- a/src/python/pants/backend/java/target_types.py
+++ b/src/python/pants/backend/java/target_types.py
@@ -52,7 +52,7 @@ class JunitTestTarget(Target):
 
 
 class JavaTestsGeneratorSourcesField(JavaGeneratorSources):
-    default = ("*Test.java",)
+    default = ("**/*Test.java",)
 
 
 class JunitTestsGeneratorTarget(Target):
@@ -109,7 +109,7 @@ class JavaSourceTarget(Target):
 
 
 class JavaSourcesGeneratorSourcesField(JavaGeneratorSources):
-    default = ("*.java",) + tuple(f"!{pat}" for pat in JavaTestsGeneratorSourcesField.default)
+    default = ("**/*.java",) + tuple(f"!{pat}" for pat in JavaTestsGeneratorSourcesField.default)
 
 
 class JavaSourcesGeneratorTarget(Target):
@@ -117,7 +117,7 @@ class JavaSourcesGeneratorTarget(Target):
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, JavaSourcesGeneratorSourcesField)
     help = (
         "Generate a `java_source` target for each file in the `sources` field (defaults to "
-        "all files named in the directory whose names end in `.java` except for those which "
+        "all files in or under the current directory whose names end in `.java` except for those which "
         "end in `Test.java`)."
     )
 


### PR DESCRIPTION
Target generators should recurse into subdirectories to setup generated targets. Otherwise the intended boilerplate reduction does not truly take effect.

[ci skip-rust]

[ci skip-build-wheels]