### PR TITLE
[internal] Refactor `go_mod.py`

### DIFF
--- a/src/python/pants/backend/experimental/go/register.py
+++ b/src/python/pants/backend/experimental/go/register.py
@@ -8,7 +8,7 @@ from pants.backend.go.lint import fmt
 from pants.backend.go.lint.gofmt import skip_field as gofmt_skip_field
 from pants.backend.go.lint.gofmt.rules import rules as gofmt_rules
 from pants.backend.go.subsystems import golang
-from pants.backend.go.target_types import GoBinary, GoExternalPackageTarget, GoModule, GoPackage
+from pants.backend.go.target_types import GoBinary, GoExternalPackageTarget, GoModTarget, GoPackage
 from pants.backend.go.util_rules import (
     assembly,
     build_go_pkg,
@@ -23,7 +23,7 @@ from pants.backend.go.util_rules import (
 
 
 def target_types():
-    return [GoBinary, GoPackage, GoModule, GoExternalPackageTarget]
+    return [GoBinary, GoPackage, GoModTarget, GoExternalPackageTarget]
 
 
 def rules():

--- a/src/python/pants/backend/go/goals/package_binary_integration_test.py
+++ b/src/python/pants/backend/go/goals/package_binary_integration_test.py
@@ -10,7 +10,7 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals import package_binary
 from pants.backend.go.goals.package_binary import GoBinaryFieldSet
-from pants.backend.go.target_types import GoBinary, GoModule, GoPackage
+from pants.backend.go.target_types import GoBinary, GoModTarget, GoPackage
 from pants.backend.go.util_rules import (
     assembly,
     build_go_pkg,
@@ -33,7 +33,7 @@ from pants.testutil.rule_runner import RuleRunner
 @pytest.fixture()
 def rule_runner() -> RuleRunner:
     rule_runner = RuleRunner(
-        target_types=[GoBinary, GoPackage, GoModule],
+        target_types=[GoBinary, GoPackage, GoModTarget],
         rules=[
             *assembly.rules(),
             *compile.rules(),

--- a/src/python/pants/backend/go/goals/tailor.py
+++ b/src/python/pants/backend/go/goals/tailor.py
@@ -4,7 +4,7 @@
 import os
 from dataclasses import dataclass
 
-from pants.backend.go.target_types import GoModule, GoPackage
+from pants.backend.go.target_types import GoModTarget, GoPackage
 from pants.core.goals.tailor import (
     AllOwnedSources,
     PutativeTarget,
@@ -61,7 +61,7 @@ async def find_putative_go_module_targets(
     for dirname, filenames in group_by_dir(unowned_go_mod_files).items():
         putative_targets.append(
             PutativeTarget.for_target_type(
-                GoModule,
+                GoModTarget,
                 dirname,
                 os.path.basename(dirname),
                 sorted(filenames),

--- a/src/python/pants/backend/go/goals/tailor_test.py
+++ b/src/python/pants/backend/go/goals/tailor_test.py
@@ -9,7 +9,7 @@ from pants.backend.go.goals.tailor import (
     PutativeGoPackageTargetsRequest,
 )
 from pants.backend.go.goals.tailor import rules as go_tailor_rules
-from pants.backend.go.target_types import GoModule, GoPackage
+from pants.backend.go.target_types import GoModTarget, GoPackage
 from pants.backend.go.util_rules import external_module, go_mod, sdk
 from pants.core.goals.tailor import (
     AllOwnedSources,
@@ -38,7 +38,7 @@ def rule_runner() -> RuleRunner:
             QueryRule(PutativeTargets, [PutativeGoPackageTargetsRequest, AllOwnedSources]),
             QueryRule(PutativeTargets, [PutativeGoModuleTargetsRequest, AllOwnedSources]),
         ],
-        target_types=[GoPackage, GoModule],
+        target_types=[GoPackage, GoModTarget],
     )
     rule_runner.set_options(["--backend-packages=pants.backend.experimental.go"])
     return rule_runner
@@ -80,5 +80,5 @@ def test_find_putative_go_module_targets(rule_runner: RuleRunner) -> None:
         ],
     )
     assert putative_targets == PutativeTargets(
-        [PutativeTarget.for_target_type(GoModule, "src/go/unowned", "unowned", ["go.mod"])]
+        [PutativeTarget.for_target_type(GoModTarget, "src/go/unowned", "unowned", ["go.mod"])]
     )

--- a/src/python/pants/backend/go/target_type_rules_test.py
+++ b/src/python/pants/backend/go/target_type_rules_test.py
@@ -14,8 +14,8 @@ from pants.backend.go.target_types import (
     GoExternalModuleVersionField,
     GoExternalPackageImportPathField,
     GoExternalPackageTarget,
-    GoModule,
-    GoModuleSources,
+    GoModSourcesField,
+    GoModTarget,
     GoPackage,
     GoPackageSources,
 )
@@ -52,7 +52,7 @@ def rule_runner() -> RuleRunner:
             QueryRule(InferredDependencies, [InferGoPackageDependenciesRequest]),
             QueryRule(GeneratedTargets, [GenerateGoExternalPackageTargetsRequest]),
         ],
-        target_types=[GoPackage, GoModule, GoExternalPackageTarget],
+        target_types=[GoPackage, GoModTarget, GoExternalPackageTarget],
     )
     rule_runner.set_options([], env_inherit={"PATH"})
     return rule_runner
@@ -61,7 +61,7 @@ def rule_runner() -> RuleRunner:
 def assert_go_module_address(rule_runner: RuleRunner, target: Target, expected_address: Address):
     addresses = rule_runner.request(Addresses, [DependenciesRequest(target[Dependencies])])
     targets = rule_runner.request(Targets, [addresses])
-    go_module_targets = [tgt for tgt in targets if tgt.has_field(GoModuleSources)]
+    go_module_targets = [tgt for tgt in targets if tgt.has_field(GoModSourcesField)]
     assert len(go_module_targets) == 1
     assert go_module_targets[0].address == expected_address
 

--- a/src/python/pants/backend/go/util_rules/assembly_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/assembly_integration_test.py
@@ -6,7 +6,7 @@ from textwrap import dedent
 import pytest
 
 from pants.backend.go import target_type_rules
-from pants.backend.go.target_types import GoExternalPackageTarget, GoModule, GoPackage
+from pants.backend.go.target_types import GoExternalPackageTarget, GoModTarget, GoPackage
 from pants.backend.go.util_rules import (
     assembly,
     build_go_pkg,
@@ -40,7 +40,7 @@ def rule_runner() -> RuleRunner:
             *target_type_rules.rules(),
             QueryRule(BuiltGoPackage, [BuildGoPackageRequest]),
         ],
-        target_types=[GoPackage, GoModule, GoExternalPackageTarget],
+        target_types=[GoPackage, GoModTarget, GoExternalPackageTarget],
     )
     rule_runner.set_options([], env_inherit={"PATH"})
     return rule_runner

--- a/src/python/pants/backend/go/util_rules/compile_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/compile_integration_test.py
@@ -5,7 +5,7 @@ import textwrap
 
 import pytest
 
-from pants.backend.go.target_types import GoModule, GoPackage
+from pants.backend.go.target_types import GoModTarget, GoPackage
 from pants.backend.go.util_rules import compile, sdk
 from pants.backend.go.util_rules.compile import CompiledGoSources, CompileGoSourcesRequest
 from pants.engine.fs import CreateDigest, Digest, FileContent, Snapshot
@@ -36,7 +36,7 @@ def rule_runner() -> RuleRunner:
             QueryRule(Snapshot, [Digest]),
             QueryRule(CompiledGoSources, [CompileGoSourcesRequest]),
         ],
-        target_types=[GoPackage, GoModule],
+        target_types=[GoPackage, GoModTarget],
     )
     rule_runner.set_options([], env_inherit={"PATH"})
     return rule_runner

--- a/src/python/pants/backend/go/util_rules/external_module.py
+++ b/src/python/pants/backend/go/util_rules/external_module.py
@@ -228,10 +228,7 @@ async def resolve_external_module_to_go_packages(
             left_go_sum_contents = fc.content
             break
 
-    go_sum_only_digest = await Get(
-        Digest, DigestSubset(request.go_sum_digest, PathGlobs(["go.sum"]))
-    )
-    go_sum_prefixed_digest = await Get(Digest, AddPrefix(go_sum_only_digest, "__sources__"))
+    go_sum_prefixed_digest = await Get(Digest, AddPrefix(request.go_sum_digest, "__sources__"))
     right_digest_contents = await Get(DigestContents, Digest, go_sum_prefixed_digest)
     right_go_sum_contents = b""
     for fc in right_digest_contents:

--- a/src/python/pants/backend/go/util_rules/external_module_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/external_module_integration_test.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from pants.backend.go.target_types import GoModule, GoPackage
+from pants.backend.go.target_types import GoModTarget, GoPackage
 from pants.backend.go.util_rules import external_module, sdk
 from pants.backend.go.util_rules.external_module import (
     DownloadedExternalModule,
@@ -33,7 +33,7 @@ def rule_runner() -> RuleRunner:
             ),
             QueryRule(DigestContents, [Digest]),
         ],
-        target_types=[GoPackage, GoModule],
+        target_types=[GoPackage, GoModTarget],
     )
     rule_runner.set_options([], env_inherit={"PATH"})
     return rule_runner

--- a/src/python/pants/backend/go/util_rules/go_mod.py
+++ b/src/python/pants/backend/go/util_rules/go_mod.py
@@ -5,20 +5,22 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass
-from typing import List, Optional
 
 import ijson
 
-from pants.backend.go.target_types import GoModuleSources
+from pants.backend.go.target_types import GoModSourcesField
 from pants.backend.go.util_rules.sdk import GoSdkProcess
 from pants.base.specs import AddressSpecs, AscendantAddresses, MaybeEmptySiblingAddresses
 from pants.build_graph.address import Address
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.engine.fs import Digest, RemovePrefix, Snapshot
-from pants.engine.internals.selectors import Get
+from pants.engine.fs import Digest, DigestSubset, PathGlobs, RemovePrefix
 from pants.engine.process import ProcessResult
-from pants.engine.rules import collect_rules, rule
-from pants.engine.target import Target, UnexpandedTargets, WrappedTarget
+from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.target import (
+    HydratedSources,
+    HydrateSourcesRequest,
+    UnexpandedTargets,
+    WrappedTarget,
+)
 from pants.util.ordered_set import FrozenOrderedSet
 
 logger = logging.getLogger(__name__)
@@ -30,39 +32,33 @@ class ModuleDescriptor:
     version: str
 
 
-# TODO: Add class docstring with info on the fields.
 @dataclass(frozen=True)
-class ResolvedGoModule:
-    # The go_module target.
-    target: Target
-
-    # Import path of the Go module. Inferred from the import path in the go.mod file.
+class GoModInfo:
+    # Import path of the Go module, based on the `module` in `go.mod`.
     import_path: str
-
-    # Minimum Go version of the module from `go` statement in go.mod.
-    minimum_go_version: Optional[str]
 
     # Modules referenced by this go.mod with resolved versions.
     modules: FrozenOrderedSet[ModuleDescriptor]
 
-    # Digest containing go.mod and updated go.sum.
+    # Digest containing the full paths to `go.mod` and `go.sum`.
     digest: Digest
+
+    # Digest containing only the `go.sum` with no leading directory prefix.
+    go_sum_stripped_digest: Digest
 
 
 @dataclass(frozen=True)
-class ResolveGoModuleRequest:
+class GoModInfoRequest:
     address: Address
 
 
-# Parse the output of `go mod download` into a list of module descriptors.
-def parse_module_descriptors(raw_json: bytes) -> List[ModuleDescriptor]:
-    # `ijson` cannot handle empty input so short-circuit if there is no data.
-    if len(raw_json) == 0:
+def parse_module_descriptors(raw_json: bytes) -> list[ModuleDescriptor]:
+    """Parse the JSON output of `go list -m`."""
+    if not raw_json:
         return []
 
     module_descriptors = []
     for raw_module_descriptor in ijson.items(raw_json, "", multiple_values=True):
-        # Skip listing the main module.
         if raw_module_descriptor.get("Main", False):
             continue
 
@@ -76,69 +72,67 @@ def parse_module_descriptors(raw_json: bytes) -> List[ModuleDescriptor]:
 
 @rule
 async def resolve_go_module(
-    request: ResolveGoModuleRequest,
-) -> ResolvedGoModule:
+    request: GoModInfoRequest,
+) -> GoModInfo:
     wrapped_target = await Get(WrappedTarget, Address, request.address)
-    target = wrapped_target.target
+    sources_field = wrapped_target.target[GoModSourcesField]
 
-    sources = await Get(SourceFiles, SourceFilesRequest([target.get(GoModuleSources)]))
-    flattened_sources_snapshot = await Get(
-        Snapshot, RemovePrefix(sources.snapshot.digest, request.address.spec_path)
+    # Get the `go.mod` (and `go.sum`) and strip so the file has no directory prefix.
+    hydrated_sources = await Get(HydratedSources, HydrateSourcesRequest(sources_field))
+    sources_without_prefix = await Get(
+        Digest, RemovePrefix(hydrated_sources.snapshot.digest, request.address.spec_path)
     )
+    go_sum_digest_get = Get(Digest, DigestSubset(sources_without_prefix, PathGlobs(["go.sum"])))
 
-    # Parse the go.mod for the module path and minimum Go version.
-    parse_result = await Get(
+    mod_json_get = Get(
         ProcessResult,
         GoSdkProcess(
-            input_digest=flattened_sources_snapshot.digest,
             command=("mod", "edit", "-json"),
-            description=f"Parse go.mod for {request.address}.",
+            input_digest=sources_without_prefix,
+            description=f"Parse {sources_field.go_mod_path}",
         ),
     )
-    module_metadata = json.loads(parse_result.stdout)
-    module_path = module_metadata["Module"]["Path"]
-    minimum_go_version = module_metadata.get(
-        "Go", "1.16"
-    )  # TODO: Figure out better default if missing. Use the SDKs version versus this hard-code.
-
-    # Resolve the dependencies in the go.mod.
-    list_modules_result = await Get(
+    list_modules_get = Get(
         ProcessResult,
         GoSdkProcess(
-            input_digest=flattened_sources_snapshot.digest,
+            input_digest=sources_without_prefix,
             command=("list", "-m", "-json", "all"),
-            description=f"List modules in build of {request.address}.",
+            description=f"List modules in {sources_field.go_mod_path}",
         ),
     )
-    modules = parse_module_descriptors(list_modules_result.stdout)
 
-    return ResolvedGoModule(
-        target=target,
-        import_path=module_path,
-        minimum_go_version=minimum_go_version,
+    mod_json, list_modules, go_sum_digest = await MultiGet(
+        mod_json_get, list_modules_get, go_sum_digest_get
+    )
+
+    module_metadata = json.loads(mod_json.stdout)
+    modules = parse_module_descriptors(list_modules.stdout)
+    return GoModInfo(
+        import_path=module_metadata["Module"]["Path"],
         modules=FrozenOrderedSet(modules),
-        digest=flattened_sources_snapshot.digest,  # TODO: Is this a resolved version? Need to update for go-resolve goal?
+        digest=hydrated_sources.snapshot.digest,
+        go_sum_stripped_digest=go_sum_digest,
     )
 
 
 @dataclass(frozen=True)
-class FindNearestGoModuleRequest:
+class OwningGoModRequest:
     spec_path: str
 
 
 @dataclass(frozen=True)
-class ResolvedOwningGoModule:
-    module_address: Optional[Address]
+class OwningGoMod:
+    address: Address | None
 
 
 @rule
-async def find_nearest_go_module(request: FindNearestGoModuleRequest) -> ResolvedOwningGoModule:
+async def find_nearest_go_module(request: OwningGoModRequest) -> OwningGoMod:
     spec_path = request.spec_path
     candidate_targets = await Get(
         UnexpandedTargets,
         AddressSpecs([AscendantAddresses(spec_path), MaybeEmptySiblingAddresses(spec_path)]),
     )
-    go_module_targets = [tgt for tgt in candidate_targets if tgt.has_field(GoModuleSources)]
+    go_module_targets = [tgt for tgt in candidate_targets if tgt.has_field(GoModSourcesField)]
 
     # Sort by address.spec_path in descending order so the nearest go_module target is sorted first.
     sorted_go_module_targets = sorted(
@@ -146,10 +140,9 @@ async def find_nearest_go_module(request: FindNearestGoModuleRequest) -> Resolve
     )
     if sorted_go_module_targets:
         nearest_go_module_target = sorted_go_module_targets[0]
-        return ResolvedOwningGoModule(module_address=nearest_go_module_target.address)
-    else:
-        # TODO: Consider eventually requiring all go_package's to associate with a go_module.
-        return ResolvedOwningGoModule(module_address=None)
+        return OwningGoMod(nearest_go_module_target.address)
+    # TODO: Consider eventually requiring all go_package's to associate with a go_module.
+    return OwningGoMod(None)
 
 
 def rules():

--- a/src/python/pants/backend/go/util_rules/go_pkg_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/go_pkg_integration_test.py
@@ -4,7 +4,7 @@ import textwrap
 
 import pytest
 
-from pants.backend.go.target_types import GoModule, GoPackage
+from pants.backend.go.target_types import GoModTarget, GoPackage
 from pants.backend.go.util_rules import go_mod, go_pkg, sdk
 from pants.backend.go.util_rules.go_pkg import ResolvedGoPackage, ResolveGoPackageRequest
 from pants.build_graph.address import Address
@@ -23,7 +23,7 @@ def rule_runner() -> RuleRunner:
             *sdk.rules(),
             QueryRule(ResolvedGoPackage, [ResolveGoPackageRequest]),
         ],
-        target_types=[GoPackage, GoModule],
+        target_types=[GoPackage, GoModTarget],
     )
     rule_runner.set_options([], env_inherit={"PATH"})
     return rule_runner


### PR DESCRIPTION
* Rename `GoModule` -> `GoModTarget` to make clear it's a target.
* Rename `ResolvedGoModule` -> `GoModInfo`
* Rename `ResolvedOwningGoModule` -> `OwningGoMod`
* Validate `sources` are correct for `go_module` target
* Don't store `Target` and `minimum_go_version` on `GoModInfo` because they're not needed.
* Centralize all `Digest` setup for the `go.mod` to `GoModInfo`, rather than callers handling it.

[ci skip-rust]
[ci skip-build-wheels]