### PR TITLE
[internal] Record metadata on engine-aware params

### DIFF
--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Sequence
+from typing import Any, Sequence
 
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.util.dirutil import fast_relpath, longest_dir_prefix
@@ -419,6 +419,9 @@ class Address(EngineAwareParameter):
 
     def debug_hint(self) -> str:
         return self.spec
+
+    def metadata(self) -> dict[str, Any]:
+        return {"address": self.spec}
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/core/goals/style_request.py
+++ b/src/python/pants/core/goals/style_request.py
@@ -7,12 +7,13 @@ import logging
 import os.path
 from abc import ABCMeta
 from dataclasses import dataclass
-from typing import Callable, ClassVar, Generic, Iterable, Optional, Sequence, Type, TypeVar
+from typing import Any, Callable, ClassVar, Generic, Iterable, Optional, Sequence, Type, TypeVar
 
 from typing_extensions import Protocol
 
 from pants.core.util_rules.distdir import DistDir
 from pants.engine.collection import Collection
+from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import EMPTY_DIGEST, Digest, Snapshot, Workspace
 from pants.engine.target import FieldSet
 from pants.util.meta import frozen_after_init
@@ -25,7 +26,7 @@ _FS = TypeVar("_FS", bound=FieldSet)
 
 @frozen_after_init
 @dataclass(unsafe_hash=True)
-class StyleRequest(Generic[_FS], metaclass=ABCMeta):
+class StyleRequest(Generic[_FS], EngineAwareParameter, metaclass=ABCMeta):
     """A request to style or lint a collection of `FieldSet`s.
 
     Should be subclassed for a particular style engine in order to support autoformatting or
@@ -45,6 +46,9 @@ class StyleRequest(Generic[_FS], metaclass=ABCMeta):
     ) -> None:
         self.field_sets = Collection[_FS](field_sets)
         self.prior_formatter_result = prior_formatter_result
+
+    def metadata(self) -> dict[str, Any]:
+        return {"addresses": [fs.address.spec for fs in self.field_sets]}
 
 
 class _ResultWithReport(Protocol):

--- a/src/python/pants/engine/engine_aware.py
+++ b/src/python/pants/engine/engine_aware.py
@@ -23,6 +23,15 @@ class EngineAwareParameter(ABC):
         the annotated type as a parameter."""
         return None
 
+    def metadata(self) -> dict[str, Any] | None:
+        """If implemented, adds arbitrary key-value pairs to the `metadata` entry of the `@rule`.
+
+        If multiple Params to a `@rule` have metadata, the metadata will be merged in a
+        deterministic but unspecified order.
+        """
+
+        return None
+
 
 class EngineAwareReturnType(ABC):
     """A marker class for types that are returned by rules to allow sending additional metadata to
@@ -68,7 +77,10 @@ class EngineAwareReturnType(ABC):
         return None
 
     def metadata(self) -> dict[str, Any] | None:
-        """If implemented, adds arbitrary key-value pairs to the `metadata` entry of the `@rule`
-        workunit."""
+        """If implemented, adds arbitrary key-value pairs to the `metadata` entry of the `@rule`.
+
+        If a @rule has `metadata` supplied by `EngineAwareParameter`s, the data will be merged, with
+        only colliding keys overwritten.
+        """
 
         return None

--- a/src/python/pants/engine/engine_aware.py
+++ b/src/python/pants/engine/engine_aware.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import Any, Optional
+from typing import Any
 
 from pants.engine.fs import FileDigest, Snapshot
 from pants.util.logging import LogLevel
@@ -18,7 +18,7 @@ class EngineAwareParameter(ABC):
     will do nothing; otherwise, it will use the additional metadata provided.
     """
 
-    def debug_hint(self) -> Optional[str]:
+    def debug_hint(self) -> str | None:
         """If implemented, this string will be shown in `@rule` debug contexts if that rule takes
         the annotated type as a parameter."""
         return None

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -618,6 +618,9 @@ class CoarsenedTarget(EngineAwareParameter):
     def debug_hint(self) -> str:
         return str(self)
 
+    def metadata(self) -> Dict[str, Any]:
+        return {"addresses": [t.address.spec for t in self.members]}
+
     def __str__(self) -> str:
         if len(self.members) > 1:
             others = len(self.members) - 1
@@ -926,6 +929,9 @@ class FieldSet(EngineAwareParameter, metaclass=ABCMeta):
 
     def debug_hint(self) -> str:
         return self.address.spec
+
+    def metadata(self) -> Dict[str, Any]:
+        return {"address": self.address.spec}
 
     def __repr__(self) -> str:
         # We use a short repr() because this often shows up in stack traces. We don't need any of
@@ -1560,7 +1566,7 @@ class HydratedSources:
 
 @union
 @dataclass(frozen=True)
-class GenerateSourcesRequest(EngineAwareParameter):
+class GenerateSourcesRequest:
     """A request to go from protocol sources -> a particular language.
 
     This should be subclassed for each distinct codegen implementation. The subclasses must define
@@ -1592,9 +1598,6 @@ class GenerateSourcesRequest(EngineAwareParameter):
 
     input: ClassVar[Type[Sources]]
     output: ClassVar[Type[Sources]]
-
-    def debug_hint(self) -> str:
-        return "{self.protocol_target.address.spec}"
 
 
 @dataclass(frozen=True)

--- a/src/rust/engine/src/session.rs
+++ b/src/rust/engine/src/session.rs
@@ -229,7 +229,7 @@ impl Session {
 
   pub fn with_metadata_map<F, T>(&self, f: F) -> T
   where
-    F: Fn(&mut HashMap<UserMetadataPyValue, Value>) -> T,
+    F: FnOnce(&mut HashMap<UserMetadataPyValue, Value>) -> T,
   {
     f(&mut self.state.workunit_metadata_map.write())
   }


### PR DESCRIPTION
To allow workunit consumers to display rich information about results, we should include the addresses that the tools have operated on in their workunit `metadata`.

To do this, add support for initializing the `user_metadata` for a workunit with `metadata` from its `EngineAwareParameter`-typed `Param`s, and then apply `metadata` to any types relevant to `check`/`fmt`/`lint`/`test`.

[ci skip-rust]
[ci skip-build-wheels]