### PR TITLE
[internal] Refactor `OwningGoMod`

### DIFF
--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -66,14 +66,8 @@ class InjectGoPackageDependenciesRequest(InjectDependenciesRequest):
 async def inject_go_package_dependencies(
     request: InjectGoPackageDependenciesRequest,
 ) -> InjectedDependencies:
-    owning_go_mod = await Get(
-        OwningGoMod, OwningGoModRequest(request.dependencies_field.address.spec_path)
-    )
-    return (
-        InjectedDependencies([owning_go_mod.address])
-        if owning_go_mod.address
-        else InjectedDependencies()
-    )
+    owning_go_mod = await Get(OwningGoMod, OwningGoModRequest(request.dependencies_field.address))
+    return InjectedDependencies([owning_go_mod.address])
 
 
 # TODO: Figure out how to merge (or not) this with ResolvedImportPaths as a base class.

--- a/src/python/pants/backend/go/util_rules/go_mod.py
+++ b/src/python/pants/backend/go/util_rules/go_mod.py
@@ -10,7 +10,7 @@ import ijson
 
 from pants.backend.go.target_types import GoModSourcesField
 from pants.backend.go.util_rules.sdk import GoSdkProcess
-from pants.base.specs import AddressSpecs, AscendantAddresses, MaybeEmptySiblingAddresses
+from pants.base.specs import AddressSpecs, AscendantAddresses
 from pants.build_graph.address import Address
 from pants.engine.fs import Digest, DigestSubset, PathGlobs, RemovePrefix
 from pants.engine.process import ProcessResult
@@ -115,34 +115,36 @@ async def resolve_go_module(
     )
 
 
+# TODO: Have `go_package` have a required field associating with `go_mod` target.
 @dataclass(frozen=True)
 class OwningGoModRequest:
-    spec_path: str
+    address: Address
 
 
 @dataclass(frozen=True)
 class OwningGoMod:
-    address: Address | None
+    address: Address
 
 
 @rule
 async def find_nearest_go_module(request: OwningGoModRequest) -> OwningGoMod:
-    spec_path = request.spec_path
     candidate_targets = await Get(
-        UnexpandedTargets,
-        AddressSpecs([AscendantAddresses(spec_path), MaybeEmptySiblingAddresses(spec_path)]),
+        UnexpandedTargets, AddressSpecs([AscendantAddresses(request.address.spec_path)])
     )
-    go_module_targets = [tgt for tgt in candidate_targets if tgt.has_field(GoModSourcesField)]
-
     # Sort by address.spec_path in descending order so the nearest go_module target is sorted first.
-    sorted_go_module_targets = sorted(
-        go_module_targets, key=lambda tgt: tgt.address.spec_path, reverse=True
+    go_module_targets = sorted(
+        (tgt for tgt in candidate_targets if tgt.has_field(GoModSourcesField)),
+        key=lambda tgt: tgt.address.spec_path,
+        reverse=True,
     )
-    if sorted_go_module_targets:
-        nearest_go_module_target = sorted_go_module_targets[0]
-        return OwningGoMod(nearest_go_module_target.address)
-    # TODO: Consider eventually requiring all go_package's to associate with a go_module.
-    return OwningGoMod(None)
+    if not go_module_targets:
+        raise Exception(
+            f"The target {request.address} does not have any `go_module` target in any ancestor "
+            "BUILD files. To fix, please make sure your project has a `go.mod` file and add a "
+            "`go_module` target (you can run `./pants tailor` to do this)."
+        )
+    nearest_go_module_target = go_module_targets[0]
+    return OwningGoMod(nearest_go_module_target.address)
 
 
 def rules():

--- a/src/python/pants/backend/go/util_rules/go_pkg.py
+++ b/src/python/pants/backend/go/util_rules/go_pkg.py
@@ -192,12 +192,9 @@ async def resolve_go_package(
 ) -> ResolvedGoPackage:
     wrapped_target, owning_go_mod = await MultiGet(
         Get(WrappedTarget, Address, request.address),
-        Get(OwningGoMod, OwningGoModRequest(request.address.spec_path)),
+        Get(OwningGoMod, OwningGoModRequest(request.address)),
     )
     target = wrapped_target.target
-
-    if not owning_go_mod.address:
-        raise ValueError(f"The go_package at address {request.address} has no owning go_module.")
 
     go_mod_spec_path = owning_go_mod.address.spec_path
     assert request.address.spec_path.startswith(go_mod_spec_path)

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -183,14 +183,15 @@ class DescendantAddresses(MaybeEmptyDescendantAddresses):
 
 @dataclass(frozen=True)
 class AscendantAddresses(AddressGlobSpec):
-    """An AddressSpec representing all addresses located recursively _above_ the given directory."""
+    """An AddressSpec representing all addresses located recursively in and above the given
+    directory."""
 
     directory: str
 
     def __str__(self) -> str:
         return f"{self.directory}^"
 
-    def to_globs(self, build_patterns: Iterable[str]) -> Tuple[str, ...]:
+    def to_globs(self, build_patterns: Iterable[str]) -> tuple[str, ...]:
         return tuple(
             os.path.join(f, pattern)
             for pattern in build_patterns
@@ -198,8 +199,8 @@ class AscendantAddresses(AddressGlobSpec):
         )
 
     def matching_address_families(
-        self, address_families_dict: Mapping[str, "AddressFamily"]
-    ) -> Tuple["AddressFamily", ...]:
+        self, address_families_dict: Mapping[str, AddressFamily]
+    ) -> tuple[AddressFamily, ...]:
         return tuple(
             af
             for ns, af in address_families_dict.items()


### PR DESCRIPTION
Formalize that we expect every `go_package` to have a `go_module`.

Better modeling would be for us to add a required field to `go_package`, but that would be too much boilerplate until we have `go_module` generate `go_package` targets, which is saved for a followup.

[ci skip-rust]
[ci skip-build-wheels]