### PR TITLE
Add a --closed option to the dependencies goal.

### DIFF
--- a/src/python/pants/backend/project_info/dependees.py
+++ b/src/python/pants/backend/project_info/dependees.py
@@ -106,7 +106,7 @@ class DependeesSubsystem(LineOriented, GoalSubsystem):
             "--transitive",
             default=False,
             type=bool,
-            help="List all transitive dependees, instead of only direct dependees.",
+            help="List all transitive dependees. If unspecified, list direct dependees only.",
         )
         register(
             "--closed",
@@ -118,6 +118,8 @@ class DependeesSubsystem(LineOriented, GoalSubsystem):
             "--output-format",
             type=DependeesOutputFormat,
             default=DependeesOutputFormat.text,
+            removal_version="2.9.0.dev0",
+            removal_hint="Use the `peek` goal for structured output, including dependencies.",
             help=(
                 "Use `text` for a flattened list of target addresses; use `json` for each key to be "
                 "the address of one of the specified targets, with its value being "
@@ -146,6 +148,7 @@ class DependeesGoal(Goal):
 async def dependees_goal(
     specified_addresses: Addresses, dependees_subsystem: DependeesSubsystem, console: Console
 ) -> DependeesGoal:
+    # TODO: Delte this entire conditional in 2.9.0.dev0.
     if dependees_subsystem.output_format == DependeesOutputFormat.json:
         dependees_per_target = await MultiGet(
             Get(

--- a/src/python/pants/backend/project_info/dependencies.py
+++ b/src/python/pants/backend/project_info/dependencies.py
@@ -42,6 +42,12 @@ class DependenciesSubsystem(LineOriented, GoalSubsystem):
             ),
         )
         register(
+            "--closed",
+            type=bool,
+            default=False,
+            help="Include the input targets in the output, along with the dependencies.",
+        )
+        register(
             "--type",
             type=DependencyType,
             default=DependencyType.SOURCE,
@@ -61,6 +67,10 @@ class DependenciesSubsystem(LineOriented, GoalSubsystem):
     @property
     def transitive(self) -> bool:
         return cast(bool, self.options.transitive)
+
+    @property
+    def closed(self) -> bool:
+        return cast(bool, self.options.closed)
 
     @property
     def type(self) -> DependencyType:
@@ -100,7 +110,7 @@ async def dependencies(
         DependencyType.SOURCE_AND_THIRD_PARTY,
     ]
 
-    address_strings = set()
+    address_strings = {addr.spec for addr in addresses} if dependencies_subsystem.closed else set()
     third_party_requirements: Set[str] = set()
     for tgt in targets:
         if include_source:


### PR DESCRIPTION
Also deprecates the --output-format option on the dependees goal.

Once this deprecation is complete, the two goals will be mutually
consistent.

[ci skip-rust]

[ci skip-build-wheels]