### PR TITLE
Support multiple Docker registries per image.

### DIFF
--- a/src/python/pants/backend/docker/docker_binary_test.py
+++ b/src/python/pants/backend/docker/docker_binary_test.py
@@ -13,11 +13,12 @@ def test_docker_binary_build_image():
     dockerfile = "src/test/repo/Dockerfile"
     docker = DockerBinary(docker_path)
     digest = Digest(sha256().hexdigest(), 123)
-    tag = "test:latest"
-    build_request = docker.build_image(tag, digest, dockerfile)
+    tags = ["test:0.1.0", "test:latest"]
+    build_request = docker.build_image(tags, digest, dockerfile)
 
     assert build_request == Process(
-        argv=(docker_path, "build", "-t", tag, "-f", dockerfile, "."),
+        argv=(docker_path, "build", "-t", tags[0], "-t", tags[1], "-f", dockerfile, "."),
         input_digest=digest,
-        description=f"Building docker image {tag}",
+        description="",
     )
+    assert build_request.description == "Building docker image test:0.1.0 +1 additional tag."

--- a/src/python/pants/backend/docker/docker_build.py
+++ b/src/python/pants/backend/docker/docker_build.py
@@ -1,5 +1,6 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
 
 import logging
 import os
@@ -9,11 +10,16 @@ from pants.backend.docker.docker_binary import DockerBinary, DockerBinaryRequest
 from pants.backend.docker.docker_build_context import DockerBuildContext, DockerBuildContextRequest
 from pants.backend.docker.registries import DockerRegistries
 from pants.backend.docker.subsystem import DockerOptions
-from pants.backend.docker.target_types import DockerImageSources, DockerImageVersion, DockerRegistry
+from pants.backend.docker.target_types import (
+    DockerImageSources,
+    DockerImageVersion,
+    DockerRegistriesField,
+)
 from pants.core.goals.package import BuiltPackage, BuiltPackageArtifact, PackageFieldSet
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.unions import UnionRule
+from pants.util.strutil import bullet_list
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +29,7 @@ class DockerFieldSet(PackageFieldSet):
     required_fields = (DockerImageSources,)
 
     image_version: DockerImageVersion
-    registry: DockerRegistry
+    registries: DockerRegistriesField
     sources: DockerImageSources
 
     @property
@@ -40,11 +46,13 @@ class DockerFieldSet(PackageFieldSet):
     def image_name(self) -> str:
         return ":".join(s for s in [self.address.target_name, self.image_version.value] if s)
 
-    def image_tag(self, registries: DockerRegistries) -> str:
-        registry = registries.get(self.registry.value)
-        if registry:
-            return "/".join([registry.address, self.image_name])
-        return self.image_name
+    def image_tags(self, registries: DockerRegistries) -> tuple[str, ...]:
+        image_name = self.image_name
+        registries_options = tuple(registries.get(*(self.registries.value or [])))
+        if not registries_options:
+            return (image_name,)
+
+        return tuple("/".join([registry.address, image_name]) for registry in registries_options)
 
 
 @rule
@@ -63,22 +71,24 @@ async def build_docker_image(
         ),
     )
 
-    image_tag = field_set.image_tag(options.registries())
+    image_tags = field_set.image_tags(options.registries())
     result = await Get(
         ProcessResult,
         Process,
         docker.build_image(
-            tag=image_tag,
+            tags=image_tags,
             digest=context.digest,
             dockerfile=field_set.dockerfile_path,
         ),
     )
 
     logger.debug(
-        f"Docker build output for {image_tag}:\n"
+        f"Docker build output for {image_tags[0]}:\n"
         f"{result.stdout.decode()}\n"
         f"{result.stderr.decode()}"
     )
+
+    image_tags_string = image_tags[0] if len(image_tags) == 1 else (f"\n{bullet_list(image_tags)}")
 
     return BuiltPackage(
         result.output_digest,
@@ -86,11 +96,11 @@ async def build_docker_image(
             BuiltPackageArtifact(
                 relpath=None,
                 extra_log_lines=(
-                    f"Built docker image: {image_tag}",
+                    f"Built docker image: {image_tags_string}",
                     "To try out the image interactively:",
-                    f"    docker run -it --rm {image_tag} [entrypoint args...]",
+                    f"    docker run -it --rm {image_tags[0]} [entrypoint args...]",
                     "To push your image:",
-                    f"    docker push {image_tag}",
+                    f"    docker push {image_tags[0]}",
                     "",
                 ),
             ),

--- a/src/python/pants/backend/docker/docker_build.py
+++ b/src/python/pants/backend/docker/docker_build.py
@@ -7,7 +7,8 @@ from dataclasses import dataclass
 
 from pants.backend.docker.docker_binary import DockerBinary, DockerBinaryRequest
 from pants.backend.docker.docker_build_context import DockerBuildContext, DockerBuildContextRequest
-from pants.backend.docker.subsystem import DockerOptions, DockerRegistries
+from pants.backend.docker.registries import DockerRegistries
+from pants.backend.docker.subsystem import DockerOptions
 from pants.backend.docker.target_types import DockerImageSources, DockerImageVersion, DockerRegistry
 from pants.core.goals.package import BuiltPackage, BuiltPackageArtifact, PackageFieldSet
 from pants.engine.process import Process, ProcessResult

--- a/src/python/pants/backend/docker/registries.py
+++ b/src/python/pants/backend/docker/registries.py
@@ -1,0 +1,99 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, cast
+
+from pants.option.parser import Parser
+from pants.util.frozendict import FrozenDict
+
+DEFAULT_REGISTRY = "@<default>"
+
+
+class DockerRegistryError(ValueError):
+    pass
+
+
+class DockerRegistryOptionsNotFoundError(DockerRegistryError):
+    def __init__(self, message):
+        super().__init__(
+            f"{message}\n\n"
+            "Use the [docker].registries configuration option to define custom registries."
+        )
+
+
+@dataclass(frozen=True)
+class DockerRegistryOptions:
+    address: str
+    alias: str = ""
+    default: bool = False
+
+    @classmethod
+    def from_dict(cls, alias: str, d: dict[str, Any]) -> DockerRegistryOptions:
+        return cls(
+            alias=alias,
+            address=d["address"],
+            default=Parser.ensure_bool(d.get("default", alias == "default")),
+        )
+
+    def register(self, registries: dict[str, DockerRegistryOptions]) -> None:
+        registries[self.address] = self
+        if self.alias:
+            registries[f"@{self.alias}"] = self
+        if self.default:
+            registries[DEFAULT_REGISTRY] = self
+
+
+@dataclass(frozen=True)
+class DockerRegistries:
+    registries: FrozenDict[str, DockerRegistryOptions]
+
+    def __post_init__(self):
+        defaults = set()
+        for alias, registry in self.registries.items():
+            if registry.default:
+                defaults.add(registry)
+        if len(defaults) > 1:
+            raise DockerRegistryError(
+                "Multiple default Docker registries in the [docker].registries configuration: "
+                + ", ".join(registry.alias for registry in defaults)
+                + "."
+            )
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> DockerRegistries:
+        registries: dict[str, DockerRegistryOptions] = {}
+        for alias, options in d.items():
+            DockerRegistryOptions.from_dict(alias, options).register(registries)
+        return cls(FrozenDict(registries))
+
+    def __getitem__(self, alias_or_address: str | None) -> DockerRegistryOptions:
+        return cast(DockerRegistryOptions, self.get(alias_or_address, implicit_options=False))
+
+    def get(
+        self, alias_or_address: str | None, implicit_options: bool = True
+    ) -> DockerRegistryOptions | None:
+        if not alias_or_address:
+            return None
+
+        if alias_or_address in self.registries:
+            return self.registries[alias_or_address]
+        elif alias_or_address == DEFAULT_REGISTRY:
+            if not implicit_options:
+                raise DockerRegistryOptionsNotFoundError(
+                    "There is no default Docker registry configured."
+                )
+            else:
+                return None
+        elif alias_or_address.startswith("@"):
+            raise DockerRegistryOptionsNotFoundError(
+                f"There is no Docker registry configured with alias: {alias_or_address[1:]}."
+            )
+        elif implicit_options:
+            return DockerRegistryOptions(address=alias_or_address)
+        else:
+            raise DockerRegistryOptionsNotFoundError(
+                f"Unknown Docker registry: {alias_or_address}."
+            )

--- a/src/python/pants/backend/docker/registries_test.py
+++ b/src/python/pants/backend/docker/registries_test.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from pants.backend.docker.subsystem import (
+from pants.backend.docker.registries import (
     DEFAULT_REGISTRY,
     DockerRegistries,
     DockerRegistryError,

--- a/src/python/pants/backend/docker/subsystem.py
+++ b/src/python/pants/backend/docker/subsystem.py
@@ -3,103 +3,11 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from textwrap import dedent
-from typing import Any, cast
 
-from pants.option.parser import Parser
+from pants.backend.docker.registries import DockerRegistries
 from pants.option.subsystem import Subsystem
-from pants.util.frozendict import FrozenDict
 from pants.util.memo import memoized_method
-
-DEFAULT_REGISTRY = "@<default>"
-
-
-class DockerRegistryError(ValueError):
-    pass
-
-
-class DockerRegistryOptionsNotFoundError(DockerRegistryError):
-    def __init__(self, message):
-        super().__init__(
-            f"{message}\n\n"
-            "Use the [docker].registries configuration option to define custom registries."
-        )
-
-
-@dataclass(frozen=True)
-class DockerRegistryOptions:
-    address: str
-    alias: str = ""
-    default: bool = False
-
-    @classmethod
-    def from_dict(cls, alias: str, d: dict[str, Any]) -> DockerRegistryOptions:
-        return cls(
-            alias=alias,
-            address=d["address"],
-            default=Parser.ensure_bool(d.get("default", alias == "default")),
-        )
-
-    def register(self, registries: dict[str, DockerRegistryOptions]) -> None:
-        registries[self.address] = self
-        if self.alias:
-            registries[f"@{self.alias}"] = self
-        if self.default:
-            registries[DEFAULT_REGISTRY] = self
-
-
-@dataclass(frozen=True)
-class DockerRegistries:
-    registries: FrozenDict[str, DockerRegistryOptions]
-
-    def __post_init__(self):
-        defaults = set()
-        for alias, registry in self.registries.items():
-            if registry.default:
-                defaults.add(registry)
-        if len(defaults) > 1:
-            raise DockerRegistryError(
-                "Multiple default Docker registries in the [docker].registries configuration: "
-                + ", ".join(registry.alias for registry in defaults)
-                + "."
-            )
-
-    @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> DockerRegistries:
-        registries: dict[str, DockerRegistryOptions] = {}
-        for alias, options in d.items():
-            DockerRegistryOptions.from_dict(alias, options).register(registries)
-        return cls(FrozenDict(registries))
-
-    def __getitem__(self, alias_or_address: str | None) -> DockerRegistryOptions:
-        return cast(DockerRegistryOptions, self.get(alias_or_address, implicit_options=False))
-
-    def get(
-        self, alias_or_address: str | None, implicit_options: bool = True
-    ) -> DockerRegistryOptions | None:
-        if not alias_or_address:
-            return None
-
-        if alias_or_address in self.registries:
-            return self.registries[alias_or_address]
-        elif alias_or_address == DEFAULT_REGISTRY:
-            if not implicit_options:
-                raise DockerRegistryOptionsNotFoundError(
-                    "There is no default Docker registry configured."
-                )
-            else:
-                return None
-        elif alias_or_address.startswith("@"):
-            raise DockerRegistryOptionsNotFoundError(
-                f"There is no Docker registry configured with alias: {alias_or_address[1:]}."
-            )
-        elif implicit_options:
-            return DockerRegistryOptions(address=alias_or_address)
-        else:
-            raise DockerRegistryOptionsNotFoundError(
-                f"Unknown Docker registry: {alias_or_address}."
-            )
 
 
 class DockerOptions(Subsystem):

--- a/src/python/pants/backend/docker/subsystem.py
+++ b/src/python/pants/backend/docker/subsystem.py
@@ -32,14 +32,12 @@ class DockerOptions(Subsystem):
                 """
             )
             + (
-                "Only one registry may be declared as the default registry. If a registry value "
-                "is not provided in a `docker_image` target, the address of the default registry "
-                "will be used, if any.\n"
-                "The `docker_image.registry` may be provided with either the registry address or "
-                'the registry alias prefixed with `@`, or the empty string `""` if the image '
-                "should not be associated with a custom registry.\n"
-                "A configured registry is made default either by setting `default = true` or with "
-                'an alias of `"default"`.'
+                "If no registries are provided in a `docker_image` target, then all default "
+                "addresses will be used, if any.\n"
+                "The `docker_image.registries` may be provided with a list of registry addresses "
+                "and registry aliases prefixed with `@` to be used instead of the defaults.\n"
+                "A configured registry is marked as default either by setting `default = true` "
+                'or with an alias of `"default"`.'
             )
         )
         super().register_options(register)

--- a/src/python/pants/backend/docker/target_types.py
+++ b/src/python/pants/backend/docker/target_types.py
@@ -3,7 +3,7 @@
 
 from textwrap import dedent
 
-from pants.backend.docker.subsystem import DEFAULT_REGISTRY
+from pants.backend.docker.registries import DEFAULT_REGISTRY
 from pants.engine.target import COMMON_TARGET_FIELDS, Dependencies, Sources, StringField, Target
 
 

--- a/src/python/pants/backend/docker/target_types.py
+++ b/src/python/pants/backend/docker/target_types.py
@@ -3,8 +3,15 @@
 
 from textwrap import dedent
 
-from pants.backend.docker.registries import DEFAULT_REGISTRY
-from pants.engine.target import COMMON_TARGET_FIELDS, Dependencies, Sources, StringField, Target
+from pants.backend.docker.registries import ALL_DEFAULT_REGISTRIES
+from pants.engine.target import (
+    COMMON_TARGET_FIELDS,
+    Dependencies,
+    Sources,
+    StringField,
+    StringSequenceField,
+    Target,
+)
 
 
 class DockerImageSources(Sources):
@@ -23,14 +30,16 @@ class DockerDependencies(Dependencies):
     supports_transitive_excludes = True
 
 
-class DockerRegistry(StringField):
-    alias = "registry"
-    default = DEFAULT_REGISTRY
+class DockerRegistriesField(StringSequenceField):
+    alias = "registries"
+    default = (ALL_DEFAULT_REGISTRIES,)
     help = (
-        "Address to Docker registry to use for the built image.\n\n"
-        "This is either the domain name with optional port for your registry, or a registry alias "
-        "prefixed with `@` for a registry configuration listed in the [docker].registries "
-        "configuration section.\n"
+        "List of addresses or configured aliases to any Docker registries to use for the "
+        "built image.\n\n"
+        "The address is a domain name with optional port for your registry, and any registry "
+        "aliases are prefixed with `@` for addresses in the [docker].registries configuration "
+        "section.\n\n"
+        "By default, all configured registries with `default = true` are used.\n\n"
         + dedent(
             """\
             Example:
@@ -46,15 +55,17 @@ class DockerRegistry(StringField):
 
                 # example/BUILD
                 docker_image(
-                    registry = "@my-registry-alias" | "myregistrydomain:port" | ""
+                    registries = [
+                        "@my-registry-alias",
+                        "myregistrydomain:port",
+                    ],
                 )
 
             """
         )
         + (
-            "The above example shows three valid `registry` options: using an alias to a configured "
-            "registry, the address to a registry verbatim in the BUILD file, and last explicitly no "
-            "registry even if there is a default registry configured."
+            "The above example shows two valid `registry` options: using an alias to a configured "
+            "registry and the address to a registry verbatim in the BUILD file."
         )
     )
 
@@ -66,6 +77,6 @@ class DockerImage(Target):
         DockerDependencies,
         DockerImageSources,
         DockerImageVersion,
-        DockerRegistry,
+        DockerRegistriesField,
     )
     help = "A Docker image."


### PR DESCRIPTION
Amend the `registry` support of #13017 to support the use case of multiple registries per Docker image.

The field has thus been renamed `registry => registries`, and take a list of strings instead of a single string value.

```python
docker_image(
  registries=[
    "@my-registry",
    "other.registry:1234",
  ]
)
```
