### PR TITLE
[internal] Refactor `go/util_rules/external_module.py`

### DIFF
--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -20,8 +20,8 @@ from pants.backend.go.target_types import (
 )
 from pants.backend.go.util_rules import go_pkg, import_analysis
 from pants.backend.go.util_rules.external_module import (
-    ResolveExternalGoModuleToPackagesRequest,
-    ResolveExternalGoModuleToPackagesResult,
+    PackagesFromExternalModule,
+    PackagesFromExternalModuleRequest,
     ResolveExternalGoPackageRequest,
 )
 from pants.backend.go.util_rules.go_mod import (
@@ -239,9 +239,9 @@ async def generate_go_external_package_targets(
     go_mod_info = await Get(GoModInfo, GoModInfoRequest(generator_addr))
     all_resolved_packages = await MultiGet(
         Get(
-            ResolveExternalGoModuleToPackagesResult,
-            ResolveExternalGoModuleToPackagesRequest(
-                path=module_descriptor.path,
+            PackagesFromExternalModule,
+            PackagesFromExternalModuleRequest(
+                module_path=module_descriptor.path,
                 version=module_descriptor.version,
                 go_sum_digest=go_mod_info.go_sum_stripped_digest,
             ),
@@ -266,11 +266,7 @@ async def generate_go_external_package_targets(
 
     return GeneratedTargets(
         request.generator,
-        (
-            create_tgt(pkg)
-            for resolved_pkgs in all_resolved_packages
-            for pkg in resolved_pkgs.packages
-        ),
+        (create_tgt(pkg) for resolved_pkgs in all_resolved_packages for pkg in resolved_pkgs),
     )
 
 

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -49,6 +49,7 @@ from pants.engine.target import (
     InjectDependenciesRequest,
     InjectedDependencies,
     Targets,
+    WrappedTarget,
 )
 from pants.engine.unions import UnionRule
 from pants.util.frozendict import FrozenDict
@@ -190,9 +191,10 @@ async def inject_go_external_package_dependencies(
     std_lib_imports: GoStdLibImports,
     package_mapping: GoImportPathToPackageMapping,
 ) -> InjectedDependencies:
-    this_go_package = await Get(
-        ResolvedGoPackage, ResolveExternalGoPackageRequest(request.dependencies_field.address)
-    )
+    wrapped_target = await Get(WrappedTarget, Address, request.dependencies_field.address)
+    tgt = wrapped_target.target
+    assert isinstance(tgt, GoExternalPackageTarget)
+    this_go_package = await Get(ResolvedGoPackage, ResolveExternalGoPackageRequest(tgt))
 
     # Loop through all of the imports of this package and add dependencies on other packages and
     # external modules.

--- a/src/python/pants/backend/go/util_rules/build_go_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_go_pkg.py
@@ -8,6 +8,7 @@ from typing import Optional
 from pants.backend.go.target_types import (
     GoExternalModulePathField,
     GoExternalModuleVersionField,
+    GoExternalPackageTarget,
     GoPackageSources,
 )
 from pants.backend.go.util_rules.assembly import (
@@ -74,6 +75,7 @@ async def build_target(
         source_files_digest = source_files.snapshot.digest
         source_files_subpath = target.address.spec_path
     elif is_third_party_package_target(target):
+        assert isinstance(target, GoExternalPackageTarget)
         module_path = target[GoExternalModulePathField].value
         module, resolved_package = await MultiGet(
             Get(
@@ -83,7 +85,7 @@ async def build_target(
                     version=target[GoExternalModuleVersionField].value,
                 ),
             ),
-            Get(ResolvedGoPackage, ResolveExternalGoPackageRequest(address=request.address)),
+            Get(ResolvedGoPackage, ResolveExternalGoPackageRequest(target)),
         )
 
         source_files_digest = module.digest

--- a/src/python/pants/backend/go/util_rules/external_module.py
+++ b/src/python/pants/backend/go/util_rules/external_module.py
@@ -22,8 +22,10 @@ from pants.engine.fs import (
     CreateDigest,
     Digest,
     DigestContents,
+    DigestEntries,
     DigestSubset,
     FileContent,
+    FileEntry,
     GlobExpansionConjunction,
     MergeDigests,
     PathGlobs,
@@ -34,6 +36,7 @@ from pants.engine.process import ProcessResult
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import WrappedTarget
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
+from pants.util.strutil import strip_v2_chroot_path
 
 
 @dataclass(frozen=True)
@@ -47,18 +50,13 @@ class DownloadedExternalModule:
     path: str
     version: str
     digest: Digest
-    sum: str
-    go_mod_sum: str
-
-    def to_go_sum_lines(self):
-        return f"{self.path} {self.version} {self.sum}\n{self.path} {self.version}/go.mod {self.go_mod_sum}\n"
 
 
 @rule
 async def download_external_module(
     request: DownloadExternalModuleRequest,
 ) -> DownloadedExternalModule:
-    result = await Get(
+    download_result = await Get(
         ProcessResult,
         GoSdkProcess(
             input_digest=EMPTY_DIGEST,
@@ -68,82 +66,74 @@ async def download_external_module(
         ),
     )
 
-    # Decode the module metadata.
-    metadata = json.loads(result.stdout)
+    metadata = json.loads(download_result.stdout)
 
-    # Find the path within the digest where the source was downloaded. The path will have a sandbox-specific
-    # prefix that we need to strip down to the `gopath` path component.
-    absolute_source_path = metadata["Dir"]
-    gopath_index = absolute_source_path.index("gopath/")
-    source_path = absolute_source_path[gopath_index:]
-
-    source_digest = await Get(
+    _download_path = strip_v2_chroot_path(metadata["Dir"])
+    _download_digest_unstripped = await Get(
         Digest,
         DigestSubset(
-            result.output_digest,
+            download_result.output_digest,
             PathGlobs(
-                [f"{source_path}/**"],
+                [f"{_download_path}/**"],
                 glob_match_error_behavior=GlobMatchErrorBehavior.error,
-                description_of_origin=f"the DownloadExternalModuleRequest for {request.path}@{request.version}",
+                description_of_origin=(
+                    f"the DownloadExternalModuleRequest for {request.path}@{request.version}"
+                ),
             ),
         ),
     )
+    download_snapshot = await Get(
+        Snapshot, RemovePrefix(_download_digest_unstripped, _download_path)
+    )
 
-    source_snapshot_stripped = await Get(Snapshot, RemovePrefix(source_digest, source_path))
-    if "go.mod" not in source_snapshot_stripped.files:
-        # There was no go.mod in the downloaded source. Use the generated go.mod from the go tooling which
-        # was returned in the module metadata.
-        go_mod_absolute_path = metadata.get("GoMod")
-        if not go_mod_absolute_path:
-            raise ValueError(
-                f"No go.mod was provided in download of Go external module {request.path}@{request.version}, "
-                "and the module metadata did not identify a generated go.mod file to use instead."
-            )
-        gopath_index = go_mod_absolute_path.index("gopath/")
-        go_mod_path = go_mod_absolute_path[gopath_index:]
-        go_mod_digest = await Get(
-            Digest,
-            DigestSubset(
-                result.output_digest,
-                PathGlobs(
-                    [f"{go_mod_path}"],
-                    glob_match_error_behavior=GlobMatchErrorBehavior.error,
-                    description_of_origin=f"the DownloadExternalModuleRequest for {request.path}@{request.version}",
+    if "go.mod" in download_snapshot.files:
+        return DownloadedExternalModule(
+            path=request.path,
+            version=request.version,
+            digest=download_snapshot.digest,
+        )
+
+    # Else, there was no go.mod in the downloaded source. Use the generated go.mod from the Go
+    # tooling.
+    if "GoMod" not in metadata:
+        raise AssertionError(
+            "No go.mod was provided in download of Go external module "
+            f"{request.path}@{request.version}, and the module metadata did not identify a "
+            "generated go.mod file to use instead.\n\n"
+            "Please open a bug at https://github.com/pantsbuild/pants/issues/new/choose with the "
+            "above information."
+        )
+
+    _go_mod_path = strip_v2_chroot_path(metadata["GoMod"])
+    _go_mod_digest_unstripped = await Get(
+        Digest,
+        DigestSubset(
+            download_result.output_digest,
+            PathGlobs(
+                [f"{_go_mod_path}"],
+                glob_match_error_behavior=GlobMatchErrorBehavior.error,
+                description_of_origin=(
+                    f"the DownloadExternalModuleRequest for {request.path}@{request.version}"
                 ),
             ),
-        )
-        go_mod_digest_stripped = await Get(
-            Digest, RemovePrefix(go_mod_digest, os.path.dirname(go_mod_path))
-        )
+        ),
+    )
+    original_go_mod_digest = await Get(
+        Digest, RemovePrefix(_go_mod_digest_unstripped, os.path.dirname(_go_mod_path))
+    )
 
-        # There should now be one file in the digest. Create a digest where that file is named go.mod
-        # and then merge it into the sources.
-        contents = await Get(DigestContents, Digest, go_mod_digest_stripped)
-        assert len(contents) == 1
-        go_mod_only_digest = await Get(
-            Digest,
-            CreateDigest(
-                [
-                    FileContent(
-                        path="go.mod",
-                        content=contents[0].content,
-                    )
-                ]
-            ),
-        )
-        source_digest_final = await Get(
-            Digest, MergeDigests([go_mod_only_digest, source_snapshot_stripped.digest])
-        )
-    else:
-        # If the module download has a go.mod, then just use the sources as is.
-        source_digest_final = source_snapshot_stripped.digest
+    # Rename the `.mod` file to the standard `go.mod` name.
+    entries = await Get(DigestEntries, Digest, original_go_mod_digest)
+    assert len(entries) == 1
+    file_entry = entries[0]
+    assert isinstance(file_entry, FileEntry)
+    go_mod_digest = await Get(Digest, CreateDigest([FileEntry("go.mod", file_entry.file_digest)]))
 
+    result_digest = await Get(Digest, MergeDigests([go_mod_digest, download_snapshot.digest]))
     return DownloadedExternalModule(
         path=request.path,
         version=request.version,
-        digest=source_digest_final,
-        sum=metadata["Sum"],
-        go_mod_sum=metadata["GoModSum"],
+        digest=result_digest,
     )
 
 

--- a/src/python/pants/backend/go/util_rules/external_module_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/external_module_integration_test.py
@@ -3,7 +3,6 @@
 
 import pytest
 
-from pants.backend.go.target_types import GoModTarget, GoPackage
 from pants.backend.go.util_rules import external_module, sdk
 from pants.backend.go.util_rules.external_module import (
     DownloadedExternalModule,
@@ -11,9 +10,7 @@ from pants.backend.go.util_rules.external_module import (
     ResolveExternalGoModuleToPackagesRequest,
     ResolveExternalGoModuleToPackagesResult,
 )
-from pants.core.util_rules import external_tool, source_files
-from pants.engine import fs
-from pants.engine.fs import EMPTY_DIGEST, Digest, DigestContents
+from pants.engine.fs import EMPTY_DIGEST, Snapshot
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
 
@@ -22,18 +19,13 @@ from pants.testutil.rule_runner import RuleRunner
 def rule_runner() -> RuleRunner:
     rule_runner = RuleRunner(
         rules=[
-            *external_tool.rules(),
-            *source_files.rules(),
-            *fs.rules(),
             *sdk.rules(),
             *external_module.rules(),
             QueryRule(DownloadedExternalModule, [DownloadExternalModuleRequest]),
             QueryRule(
                 ResolveExternalGoModuleToPackagesResult, [ResolveExternalGoModuleToPackagesRequest]
             ),
-            QueryRule(DigestContents, [Digest]),
         ],
-        target_types=[GoPackage, GoModTarget],
     )
     rule_runner.set_options([], env_inherit={"PATH"})
     return rule_runner
@@ -42,35 +34,35 @@ def rule_runner() -> RuleRunner:
 def test_download_external_module(rule_runner: RuleRunner) -> None:
     downloaded_module = rule_runner.request(
         DownloadedExternalModule,
-        [DownloadExternalModuleRequest(path="github.com/google/uuid", version="v1.3.0")],
+        [DownloadExternalModuleRequest("github.com/google/uuid", "v1.3.0")],
     )
     assert downloaded_module.path == "github.com/google/uuid"
     assert downloaded_module.version == "v1.3.0"
 
-    digest_contents = rule_runner.request(DigestContents, [downloaded_module.digest])
-    found_uuid_go_file = False
-    for file_content in digest_contents:
-        if file_content.path == "uuid.go":
-            found_uuid_go_file = True
-            break
-    assert found_uuid_go_file
+    snapshot = rule_runner.request(Snapshot, [downloaded_module.digest])
+    assert any(
+        fp == "uuid.go" for fp in snapshot.files
+    ), f"Could not find `uuid.go` in {snapshot.files}"
+    assert any(
+        fp == "go.mod" for fp in snapshot.files
+    ), f"Could not find `go.mod` in {snapshot.files}"
 
 
 def test_download_external_module_with_no_gomod(rule_runner: RuleRunner) -> None:
     downloaded_module = rule_runner.request(
         DownloadedExternalModule,
-        [DownloadExternalModuleRequest(path="cloud.google.com/go", version="v0.26.0")],
+        [DownloadExternalModuleRequest("cloud.google.com/go", "v0.26.0")],
     )
     assert downloaded_module.path == "cloud.google.com/go"
     assert downloaded_module.version == "v0.26.0"
 
-    digest_contents = rule_runner.request(DigestContents, [downloaded_module.digest])
-    found_go_mod = False
-    for file_content in digest_contents:
-        if file_content.path == "go.mod":
-            found_go_mod = True
-            break
-    assert found_go_mod
+    snapshot = rule_runner.request(Snapshot, [downloaded_module.digest])
+    assert any(
+        fp == "bigtable/filter.go" for fp in snapshot.files
+    ), f"Could not find `bigtable/filter.go` in {snapshot.files}"
+    assert any(
+        fp == "go.mod" for fp in snapshot.files
+    ), f"Could not find `go.mod` in {snapshot.files}"
 
 
 def test_resolve_packages_of_go_external_module(rule_runner: RuleRunner) -> None:


### PR DESCRIPTION
* Rename `ResolveExternalGoModuleToPackagesResult` to `PackagesFromExternalModule`
* Store a `GoExternalPackageTarget` instead of `Address` on `ResolveExternalGoPackageRequest`. This breaks the Target API's extensibility, but improves clarity with the type system of what is happening. This is not the final factoring.
* Use `DigestEntries` instead of `DigestContents` for better performance renaming the `go.mod` file
* Remove unused fields `sum` and `go_mod_sum` from `DownloadedExternalModule`
* Use the helper `strip_v2_chroot_path()`
