### PR TITLE
[internal] Stop using `go.sum` when generating `_go_external_package` targets

### DIFF
--- a/src/python/pants/backend/go/util_rules/external_module.py
+++ b/src/python/pants/backend/go/util_rules/external_module.py
@@ -205,7 +205,8 @@ async def compute_package_import_paths_from_external_module(
         ProcessResult,
         GoSdkProcess(
             input_digest=downloaded_module.digest,
-            command=("list", "-json", "./..."),
+            # "-find" skips determining dependencies and imports for each package.
+            command=("list", "-find", "-json", "./..."),
             description=(
                 "Determine import paths in Go external module "
                 f"{request.module_path}@{request.version}"

--- a/src/python/pants/backend/go/util_rules/external_module.py
+++ b/src/python/pants/backend/go/util_rules/external_module.py
@@ -178,8 +178,7 @@ async def resolve_external_go_package(
 class ExternalModulePkgImportPathsRequest:
     """Request the import paths for all packages belonging to an external Go module.
 
-    The `go_sum_digest` must have a `go.sum` file that includes the module and its dependencies,
-    else the user will get a `missing go.sum entry` error.
+    The `go_sum_digest` must have a `go.sum` file that includes the module.
     """
 
     module_path: str

--- a/src/python/pants/backend/go/util_rules/import_analysis.py
+++ b/src/python/pants/backend/go/util_rules/import_analysis.py
@@ -39,7 +39,8 @@ async def determine_go_std_lib_imports() -> GoStdLibImports:
     list_result = await Get(
         ProcessResult,
         GoSdkProcess(
-            command=("list", "-json", "std"),
+            # "-find" skips determining dependencies and imports for each package.
+            command=("list", "-find", "-json", "std"),
             description="Ask Go for its available import paths",
         ),
     )


### PR DESCRIPTION
To create `_go_external_package` targets, all we need is the package import paths for an external module. We don't need any extra metadata like a package's dependencies and imports. We can find that by using `go list -find`, rather than `go list`.

By simplifying that, we no longer need to worry about having `go.sum` present when running `go list` to avoid `missing go.sum entry` errors. We can remove our hacky code that was merging the `go.sum` from disk (`go_mod` target) and any `go.sum` files that were created on-the-fly in the `DownloadedExternalModule` rule.

--

Related, we now pass the `go_sum_digest` to the call to `DownloadedExternalModule` so that it uses the `go.sum` from disk. This means we don't dynamically generate a `go.sum` on-the-fly, which is important for correctness: we should be using the lockfile the user intended for us to consume.

[ci skip-rust]
[ci skip-build-wheels]