### PR TITLE
[internal] Rename `go_module` target to `go_mod`

### DIFF
--- a/src/python/pants/backend/go/goals/package_binary_integration_test.py
+++ b/src/python/pants/backend/go/goals/package_binary_integration_test.py
@@ -82,7 +82,7 @@ def test_package_simple(rule_runner: RuleRunner) -> None:
             ),
             "BUILD": dedent(
                 """\
-                go_module(name='go_mod')
+                go_mod(name='mod')
                 go_package(name='main')
                 go_binary(name='bin', main=':main')
                 """
@@ -133,7 +133,7 @@ def test_package_with_dependency(rule_runner: RuleRunner) -> None:
             "go.mod": "module foo.example.com\n",
             "BUILD": dedent(
                 """\
-                go_module(name='go_mod')
+                go_mod(name='mod')
                 go_package(name='main')
                 go_binary(name='bin', main=':main')
                 """

--- a/src/python/pants/backend/go/goals/tailor.py
+++ b/src/python/pants/backend/go/goals/tailor.py
@@ -50,8 +50,8 @@ class PutativeGoModuleTargetsRequest(PutativeTargetsRequest):
     pass
 
 
-@rule(level=LogLevel.DEBUG, desc="Determine candidate Go `go_module` targets to create")
-async def find_putative_go_module_targets(
+@rule(level=LogLevel.DEBUG, desc="Determine candidate `go_mod` targets to create")
+async def find_putative_go_mod_targets(
     request: PutativeGoModuleTargetsRequest, all_owned_sources: AllOwnedSources
 ) -> PutativeTargets:
     all_go_mod_files = await Get(Paths, PathGlobs, request.search_paths.path_globs("go.mod"))

--- a/src/python/pants/backend/go/goals/tailor_test.py
+++ b/src/python/pants/backend/go/goals/tailor_test.py
@@ -64,10 +64,10 @@ def test_find_putative_go_package_targets(rule_runner: RuleRunner) -> None:
     )
 
 
-def test_find_putative_go_module_targets(rule_runner: RuleRunner) -> None:
+def test_find_putative_go_mod_targets(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "src/go/owned/BUILD": "go_module()\n",
+            "src/go/owned/BUILD": "go_mod()\n",
             "src/go/owned/go.mod": "module example.com/src/go/owned\n",
             "src/go/unowned/go.mod": "module example.com/src/go/unowned\n",
         }

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -58,7 +58,7 @@ from pants.util.logging import LogLevel
 logger = logging.getLogger(__name__)
 
 
-# Inject a dependency between a go_package and its owning go_module.
+# Inject a dependency between a go_package and its owning go_mod.
 class InjectGoPackageDependenciesRequest(InjectDependenciesRequest):
     inject_for = GoPackageDependencies
 
@@ -115,7 +115,7 @@ async def infer_go_dependencies(
         ResolvedGoPackage, ResolveGoPackageRequest(request.sources_field.address)
     )
 
-    # Obtain all go_package targets under this package's go_module.
+    # Obtain all go_package targets under this package's go_mod.
     assert this_go_package.module_address is not None
     spec_path = this_go_package.module_address.spec_path
     address_specs = [
@@ -136,7 +136,7 @@ async def infer_go_dependencies(
     )
     for first_party_go_package in first_party_go_packages:
         # Skip packages that are not part of this package's module.
-        # TODO: This requires that all first-party code in the monorepo be part of the same go_module. Will need
+        # TODO: This requires that all first-party code in the monorepo be part of the same go_mod. Will need
         # figure out how multiple modules in a monorepo can interact.
         if first_party_go_package.module_address != this_go_package.module_address:
             continue
@@ -154,7 +154,7 @@ async def infer_go_dependencies(
         if import_path in std_lib_imports:
             continue
 
-        # Infer first-party dependencies to other packages in same go_module.
+        # Infer first-party dependencies to other packages in same go_mod.
         if import_path in first_party_import_path_to_address:
             inferred_dependencies.append(first_party_import_path_to_address[import_path])
             continue

--- a/src/python/pants/backend/go/target_type_rules_test.py
+++ b/src/python/pants/backend/go/target_type_rules_test.py
@@ -58,40 +58,40 @@ def rule_runner() -> RuleRunner:
     return rule_runner
 
 
-def assert_go_module_address(rule_runner: RuleRunner, target: Target, expected_address: Address):
+def assert_go_mod_address(rule_runner: RuleRunner, target: Target, expected_address: Address):
     addresses = rule_runner.request(Addresses, [DependenciesRequest(target[Dependencies])])
     targets = rule_runner.request(Targets, [addresses])
-    go_module_targets = [tgt for tgt in targets if tgt.has_field(GoModSourcesField)]
-    assert len(go_module_targets) == 1
-    assert go_module_targets[0].address == expected_address
+    go_mod_targets = [tgt for tgt in targets if tgt.has_field(GoModSourcesField)]
+    assert len(go_mod_targets) == 1
+    assert go_mod_targets[0].address == expected_address
 
 
 def test_go_package_dependency_injection(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "foo/BUILD": "go_module()\n",
+            "foo/BUILD": "go_mod()\n",
             "foo/go.mod": "module foo\n",
             "foo/go.sum": "",
             "foo/pkg/BUILD": "go_package()\n",
             "foo/pkg/foo.go": "package pkg\n",
-            "foo/bar/BUILD": "go_module(name='mod')\ngo_package(name='pkg')\n",
+            "foo/bar/BUILD": "go_mod()\ngo_package(name='pkg')\n",
             "foo/bar/go.mod": "module bar\n",
             "foo/bar/src.go": "package bar\n",
         }
     )
 
     target = rule_runner.get_target(Address("foo/pkg", target_name="pkg"))
-    assert_go_module_address(rule_runner, target, Address("foo"))
+    assert_go_mod_address(rule_runner, target, Address("foo"))
 
     target = rule_runner.get_target(Address("foo/bar", target_name="pkg"))
-    assert_go_module_address(rule_runner, target, Address("foo/bar", target_name="mod"))
+    assert_go_mod_address(rule_runner, target, Address("foo/bar"))
 
 
 def test_go_package_dependency_inference(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         (
             {
-                "foo/BUILD": "go_module()",
+                "foo/BUILD": "go_mod()",
                 "foo/go.mod": textwrap.dedent(
                     """\
                     module go.example.com/foo
@@ -157,7 +157,7 @@ def test_go_package_dependency_inference(rule_runner: RuleRunner) -> None:
 def test_generate_go_external_package_targets(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "src/go/BUILD": "go_module()\n",
+            "src/go/BUILD": "go_mod()\n",
             "src/go/go.mod": textwrap.dedent(
                 """\
                 module example.com/src/go

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -44,7 +44,7 @@ class GoPackage(Target):
 
 
 # -----------------------------------------------------------------------------------------------
-# `go_module` target
+# `go_mod` target
 # -----------------------------------------------------------------------------------------------
 
 
@@ -83,13 +83,13 @@ class GoModSourcesField(Sources):
 
 
 class GoModTarget(Target):
-    alias = "go_module"
+    alias = "go_mod"
     core_fields = (
         *COMMON_TARGET_FIELDS,
         Dependencies,
         GoModSourcesField,
     )
-    help = "First-party Go module."
+    help = "A first-party Go module corresponding to a `go.mod` file."
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/backend/go/util_rules/assembly_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/assembly_integration_test.py
@@ -95,7 +95,7 @@ def test_build_package_with_assembly(rule_runner: RuleRunner) -> None:
             ),
             "BUILD": dedent(
                 """\
-                go_module(name="mod")
+                go_mod(name="mod")
                 go_package(name="main")
                 """
             ),

--- a/src/python/pants/backend/go/util_rules/go_mod.py
+++ b/src/python/pants/backend/go/util_rules/go_mod.py
@@ -71,7 +71,7 @@ def parse_module_descriptors(raw_json: bytes) -> list[ModuleDescriptor]:
 
 
 @rule
-async def resolve_go_module(
+async def determine_go_mod_info(
     request: GoModInfoRequest,
 ) -> GoModInfo:
     wrapped_target = await Get(WrappedTarget, Address, request.address)
@@ -127,24 +127,24 @@ class OwningGoMod:
 
 
 @rule
-async def find_nearest_go_module(request: OwningGoModRequest) -> OwningGoMod:
+async def find_nearest_go_mod(request: OwningGoModRequest) -> OwningGoMod:
     candidate_targets = await Get(
         UnexpandedTargets, AddressSpecs([AscendantAddresses(request.address.spec_path)])
     )
-    # Sort by address.spec_path in descending order so the nearest go_module target is sorted first.
-    go_module_targets = sorted(
+    # Sort by address.spec_path in descending order so the nearest go_mod target is sorted first.
+    go_mod_targets = sorted(
         (tgt for tgt in candidate_targets if tgt.has_field(GoModSourcesField)),
         key=lambda tgt: tgt.address.spec_path,
         reverse=True,
     )
-    if not go_module_targets:
+    if not go_mod_targets:
         raise Exception(
-            f"The target {request.address} does not have any `go_module` target in any ancestor "
+            f"The target {request.address} does not have any `go_mod` target in any ancestor "
             "BUILD files. To fix, please make sure your project has a `go.mod` file and add a "
-            "`go_module` target (you can run `./pants tailor` to do this)."
+            "`go_mod` target (you can run `./pants tailor` to do this)."
         )
-    nearest_go_module_target = go_module_targets[0]
-    return OwningGoMod(nearest_go_module_target.address)
+    nearest_go_mod_target = go_mod_targets[0]
+    return OwningGoMod(nearest_go_mod_target.address)
 
 
 def rules():

--- a/src/python/pants/backend/go/util_rules/go_mod_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/go_mod_integration_test.py
@@ -65,18 +65,18 @@ def test_go_mod_info(rule_runner: RuleRunner) -> None:
             "foo/main.go": "package main\nfunc main() { }\n",
             "foo/BUILD": dedent(
                 """\
-                go_module(name='mod')
+                go_mod(name='mod')
                 go_package(name='pkg')
                 """
             ),
         }
     )
-    resolved_go_module = rule_runner.request(
+    go_mod_info = rule_runner.request(
         GoModInfo, [GoModInfoRequest(Address("foo", target_name="mod"))]
     )
-    assert resolved_go_module.import_path == "go.example.com/foo"
-    assert resolved_go_module.modules
+    assert go_mod_info.import_path == "go.example.com/foo"
+    assert go_mod_info.modules
     assert any(
         module_descriptor.path == "github.com/golang/protobuf"
-        for module_descriptor in resolved_go_module.modules
+        for module_descriptor in go_mod_info.modules
     )

--- a/src/python/pants/backend/go/util_rules/go_pkg.py
+++ b/src/python/pants/backend/go/util_rules/go_pkg.py
@@ -35,10 +35,10 @@ class ResolvedGoPackage:
     # Address of the `go_package` target (if any).
     address: Address | None
 
-    # Import path of this package. The import path will be inferred from an owning `go_module` if present.
+    # Import path of this package. The import path will be inferred from an owning `go_mod` if present.
     import_path: str
 
-    # Address of the owning `go_module` if present. The owning `go_module` is the nearest go_module at the same
+    # Address of the owning `go_mod` if present. The owning `go_mod` is the nearest go_mod at the same
     # or higher level of the source tree.
     module_address: Address | None
 
@@ -109,7 +109,7 @@ class ResolvedGoPackage:
         # TODO: Raise an exception on errors. They are only emitted as warnings for now because the `go` tool is
         # flagging missing first-party code as a dependency error. But we want dependency inference and won't know
         # what the dependency actually is unless we first resolve the package with that dependency. So circular
-        # reasoning. We may need to hydrate the sources for all go_package targets that share a `go_module`.
+        # reasoning. We may need to hydrate the sources for all go_package targets that share a `go_mod`.
         if metadata.get("Incomplete"):
             error_dict = metadata.get("Error", {})
             if error_dict:
@@ -214,9 +214,9 @@ async def resolve_go_package(
         # Use any explicit import path set on the `go_package` target.
         import_path = import_path_field.value
     else:
-        # Otherwise infer the import path from the owning `go_module` target. The inferred import
+        # Otherwise infer the import path from the owning `go_mod` target. The inferred import
         # path will be the module's import path plus any subdirectories in the spec_path
-        # between the go_module and go_package target.
+        # between the go_mod and go_package target.
         import_path = f"{go_mod_info.import_path}/"
         if spec_subpath.startswith("/"):
             import_path += spec_subpath[1:]

--- a/src/python/pants/backend/go/util_rules/go_pkg_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/go_pkg_integration_test.py
@@ -29,10 +29,10 @@ def rule_runner() -> RuleRunner:
     return rule_runner
 
 
-def test_resolve_go_module(rule_runner: RuleRunner) -> None:
+def test_resolve_go_package(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "foo/BUILD": "go_module()\n",
+            "foo/BUILD": "go_mod()\n",
             "foo/go.mod": textwrap.dedent(
                 """\
                 module go.example.com/foo

--- a/testprojects/src/go/BUILD
+++ b/testprojects/src/go/BUILD
@@ -1,4 +1,4 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-go_module()
 
+go_mod()


### PR DESCRIPTION
A "module" is a generic concept in Go, and includes "external modules" like `github.com/google/uuid`. 

In contrast, our `go_module` target is specifically for first-party Go modules that are represented with a `go.mod` file. This change is meant to make more clear that connection, that the `go_mod` target should be used whenever you have a `go.mod` file. 

[ci skip-rust]
[ci skip-build-wheels]