### PR TITLE
[internal] java: enable cycles for file-level targets generated by `java_sources`

### DIFF
--- a/src/python/pants/backend/java/target_types.py
+++ b/src/python/pants/backend/java/target_types.py
@@ -84,7 +84,8 @@ async def generate_targets_from_junit_tests(
         request.generator,
         paths.files,
         union_membership,
-        add_dependencies_on_all_siblings=False,
+        # TODO: This should be set to False once dependency inference can infer same-package dependencies.
+        add_dependencies_on_all_siblings=True,
     )
 
 
@@ -138,7 +139,8 @@ async def generate_targets_from_java_sources(
         request.generator,
         paths.files,
         union_membership,
-        add_dependencies_on_all_siblings=False,
+        # TODO: This should be set to False once dependency inference can infer same-package dependencies.
+        add_dependencies_on_all_siblings=True,
     )
 
 


### PR DESCRIPTION
As per https://github.com/pantsbuild/pants/issues/13055, Java dependency inference does not currently infer dependencies between files in the same Java package for types defined in one file and used in another. (The dependency inference currently only looks at explicit imports.)

Switch the `java_sources` and `junit_tests` target generators to request dependencies between all sibling files. While this is not the same as enabling dependencies between files in the same package, with 1:1:1 layout of `java_sources` target generators, this should be close but over-broad.

With this fix, I am able to run `./pants check core/src::` successfully in [our test branch of the guice library](https://github.com/toolchainlabs/guice/tree/setup_pants).

These cycles are over-broad and should be removed again once https://github.com/pantsbuild/pants/issues/13055 is solved more precisely.

[ci skip-rust]

[ci skip-build-wheels]