### PR TITLE
[internal] Add a `@logging` decorator for tests

### DIFF
--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -35,7 +35,7 @@ from pants.engine.rules import Rule
 from pants.engine.target import Target, WrappedTarget
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.init.engine_initializer import EngineInitializer
-from pants.init.logging import initialize_stdio, stdio_destination
+from pants.init.logging import initialize_stdio, initialize_stdio_raw, stdio_destination
 from pants.option.global_options import (
     DynamicRemoteOptions,
     ExecutionOptions,
@@ -54,7 +54,24 @@ from pants.util.dirutil import (
     safe_mkdtemp,
     safe_open,
 )
+from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
+
+
+def logging(func):
+    """A decorator that enables logging (optionally at the given level)."""
+
+    def wrapper(*args, **kwargs):
+        stdout_fileno, stderr_fileno = sys.stdout.fileno(), sys.stderr.fileno()
+        with temporary_dir() as tempdir, initialize_stdio_raw(
+            LogLevel.INFO, False, False, {}, True, [], tempdir
+        ), stdin_context() as stdin, stdio_destination(
+            stdin.fileno(), stdout_fileno, stderr_fileno
+        ):
+            return func(*args, **kwargs)
+
+    return wrapper
+
 
 # -----------------------------------------------------------------------------------------------
 # `RuleRunner`
@@ -529,6 +546,17 @@ def run_rule_with_mocks(
 
 
 @contextmanager
+def stdin_context(content: bytes | str | None = None):
+    if content is None:
+        yield open("/dev/null", "r")
+    else:
+        with temporary_file(binary_mode=isinstance(content, bytes)) as stdin_file:
+            stdin_file.write(content)
+            stdin_file.close()
+            yield open(stdin_file.name, "r")
+
+
+@contextmanager
 def mock_console(
     options_bootstrapper: OptionsBootstrapper,
     *,
@@ -543,19 +571,11 @@ def mock_console(
         .colors
     )
 
-    @contextmanager
-    def stdin_context():
-        if stdin_content is None:
-            yield open("/dev/null", "r")
-        else:
-            with temporary_file(binary_mode=isinstance(stdin_content, bytes)) as stdin_file:
-                stdin_file.write(stdin_content)
-                stdin_file.close()
-                yield open(stdin_file.name, "r")
-
-    with initialize_stdio(global_bootstrap_options), stdin_context() as stdin, temporary_file(
+    with initialize_stdio(global_bootstrap_options), stdin_context(
+        stdin_content
+    ) as stdin, temporary_file(binary_mode=False) as stdout, temporary_file(
         binary_mode=False
-    ) as stdout, temporary_file(binary_mode=False) as stderr, stdio_destination(
+    ) as stderr, stdio_destination(
         stdin_fileno=stdin.fileno(),
         stdout_fileno=stdout.fileno(),
         stderr_fileno=stderr.fileno(),


### PR DESCRIPTION
Logging is not otherwise enabled by default in unit tests, so add a decorator to temporarily enable it.

[ci skip-rust]
[ci skip-build-wheels]