### PR TITLE
[internal] Always use jars on the user classpath, and generalize transitive classpath building

### DIFF
--- a/src/python/pants/backend/experimental/java/register.py
+++ b/src/python/pants/backend/experimental/java/register.py
@@ -1,7 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.java import tailor
+from pants.backend.java import classpath, tailor
 from pants.backend.java import util_rules as java_util_rules
 from pants.backend.java.compile import javac
 from pants.backend.java.dependency_inference import (
@@ -40,6 +40,7 @@ def rules():
     return [
         *javac.rules(),
         *junit.rules(),
+        *classpath.rules(),
         *coursier.rules(),
         *coursier_fetch.rules(),
         *coursier_setup.rules(),

--- a/src/python/pants/backend/java/classpath.py
+++ b/src/python/pants/backend/java/classpath.py
@@ -36,8 +36,8 @@ class Classpath:
 
     content: Snapshot
 
-    def classpath_args(self, prefix: str | None = None) -> Iterator[str]:
-        """Construct the argument to be passed to `java -cp`.
+    def classpath_entries(self, prefix: str | None = None) -> Iterator[str]:
+        """Returns optionally prefixed classpath entry filenames.
 
         :param prefix: if set, will be prepended to all entries.  This is useful
             if the process working directory is not the same as the root
@@ -45,8 +45,8 @@ class Classpath:
         """
         return self._classpath(lambda _: True, prefix=prefix)
 
-    def user_classpath_args(self, prefix: str | None = None) -> Iterator[str]:
-        """Like `classpath_arg`, but returns only entries corresponding to first-party code."""
+    def user_classpath_entries(self, prefix: str | None = None) -> Iterator[str]:
+        """Like `classpath_entries`, but returns only entries corresponding to first-party code."""
         return self._classpath(lambda f: f.startswith(_USERCP_RELPATH), prefix=prefix)
 
     def _classpath(

--- a/src/python/pants/backend/java/classpath.py
+++ b/src/python/pants/backend/java/classpath.py
@@ -1,0 +1,107 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Callable, Iterator
+
+from pants.backend.java.compile.javac import CompiledClassfiles, CompileJavaSourceRequest
+from pants.engine.addresses import Addresses
+from pants.engine.fs import AddPrefix, Digest, MergeDigests, Snapshot
+from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.target import (
+    CoarsenedTargets,
+    Targets,
+    TransitiveTargets,
+    TransitiveTargetsRequest,
+)
+from pants.jvm.resolve.coursier_fetch import (
+    CoursierLockfileForTargetRequest,
+    CoursierResolvedLockfile,
+    MaterializedClasspath,
+    MaterializedClasspathRequest,
+)
+
+_USERCP_RELPATH = "__usercp"
+
+
+@dataclass(frozen=True)
+class Classpath:
+    """A transitive classpath which is sufficient to launch the target(s) it was generated for.
+
+    This classpath is guaranteed to contain only JAR files.
+    """
+
+    content: Snapshot
+
+    def classpath_args(self, prefix: str | None = None) -> Iterator[str]:
+        """Construct the argument to be passed to `java -cp`.
+
+        :param prefix: if set, will be prepended to all entries.  This is useful
+            if the process working directory is not the same as the root
+            directory for the process input `Digest`.
+        """
+        return self._classpath(lambda _: True, prefix=prefix)
+
+    def user_classpath_args(self, prefix: str | None = None) -> Iterator[str]:
+        """Like `classpath_arg`, but returns only entries corresponding to first-party code."""
+        return self._classpath(lambda f: f.startswith(_USERCP_RELPATH), prefix=prefix)
+
+    def _classpath(
+        self, predicate: Callable[[str], bool], prefix: str | None = None
+    ) -> Iterator[str]:
+        def maybe_add_prefix(file_name: str) -> str:
+            if prefix is None:
+                return file_name
+            return os.path.join(prefix, file_name)
+
+        return (
+            maybe_add_prefix(file_path) for file_path in self.content.files if predicate(file_path)
+        )
+
+
+@rule
+async def classpath(addresses: Addresses) -> Classpath:
+    transitive_targets = await Get(TransitiveTargets, TransitiveTargetsRequest(addresses))
+    coarsened_targets = await Get(
+        CoarsenedTargets, Addresses(t.address for t in transitive_targets.closure)
+    )
+
+    lockfile = await Get(
+        CoursierResolvedLockfile,
+        CoursierLockfileForTargetRequest(Targets(transitive_targets.closure)),
+    )
+    materialized_classpath = await Get(
+        MaterializedClasspath,
+        MaterializedClasspathRequest(
+            prefix="__thirdpartycp",
+            lockfiles=(lockfile,),
+        ),
+    )
+    transitive_user_classfiles = await MultiGet(
+        Get(CompiledClassfiles, CompileJavaSourceRequest(component=t)) for t in coarsened_targets
+    )
+    merged_transitive_user_classfiles_digest = await Get(
+        Digest, MergeDigests(classfiles.digest for classfiles in transitive_user_classfiles)
+    )
+    prefixed_transitive_user_classfiles_digest = await Get(
+        Digest, AddPrefix(merged_transitive_user_classfiles_digest, _USERCP_RELPATH)
+    )
+
+    return Classpath(
+        await Get(
+            Snapshot,
+            MergeDigests(
+                (
+                    prefixed_transitive_user_classfiles_digest,
+                    materialized_classpath.digest,
+                )
+            ),
+        )
+    )
+
+
+def rules():
+    return collect_rules()

--- a/src/python/pants/backend/java/compile/javac.py
+++ b/src/python/pants/backend/java/compile/javac.py
@@ -293,7 +293,6 @@ async def javac_check(request: JavacCheckRequest) -> CheckResults:
         CoarsenedTargets, Addresses(field_set.address for field_set in request.field_sets)
     )
 
-    # TODO: This should be fallible so that we exit cleanly.
     results = await MultiGet(
         Get(FallibleCompiledClassfiles, CompileJavaSourceRequest(component=t))
         for t in coarsened_targets

--- a/src/python/pants/backend/java/compile/javac.py
+++ b/src/python/pants/backend/java/compile/javac.py
@@ -225,7 +225,7 @@ async def compile_java_source(
     )
 
     classpath_arg = ":".join(
-        [*prefixed_direct_dependency_classpath.files, *materialized_classpath.classpath_args()]
+        [*prefixed_direct_dependency_classpath.files, *materialized_classpath.classpath_entries()]
     )
 
     merged_digest = await Get(

--- a/src/python/pants/backend/java/compile/javac_test.py
+++ b/src/python/pants/backend/java/compile/javac_test.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from textwrap import dedent
 
 import pytest
@@ -20,11 +21,14 @@ from pants.backend.java.target_types import JavaSourcesGeneratorTarget
 from pants.backend.java.target_types import rules as target_types_rules
 from pants.build_graph.address import Address
 from pants.core.goals.check import CheckResults
-from pants.core.util_rules import config_files, source_files
+from pants.core.util_rules import archive, config_files, source_files
+from pants.core.util_rules.archive import UnzipBinary
 from pants.core.util_rules.external_tool import rules as external_tool_rules
 from pants.engine.addresses import Addresses
-from pants.engine.fs import DigestContents, FileDigest
+from pants.engine.fs import Digest, DigestContents, FileDigest, RemovePrefix, Snapshot
 from pants.engine.internals.scheduler import ExecutionError
+from pants.engine.process import Process, ProcessResult
+from pants.engine.rules import Get, MultiGet, rule
 from pants.engine.target import CoarsenedTarget, CoarsenedTargets, Targets
 from pants.jvm.goals.coursier import rules as coursier_rules
 from pants.jvm.resolve.coursier_fetch import (
@@ -45,6 +49,9 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
+            render_classpath,
+            QueryRule(RenderedClasspath, (Digest,)),
+            *archive.rules(),
             *config_files.rules(),
             *coursier_fetch_rules(),
             *coursier_setup_rules(),
@@ -89,6 +96,43 @@ JAVA_LIB_MAIN_SOURCE = dedent(
     }
     """
 )
+
+
+@dataclass(frozen=True)
+class RenderedClasspath:
+    """The contents of a classpath, organized as a key per entry with its contained classfiles."""
+
+    content: dict[str, set[str]]
+
+
+@rule
+async def render_classpath(snapshot: Snapshot, unzip_binary: UnzipBinary) -> RenderedClasspath:
+    dest_dir = "dest"
+    process_results = await MultiGet(
+        Get(
+            ProcessResult,
+            Process(
+                argv=[
+                    unzip_binary.path,
+                    "-d",
+                    dest_dir,
+                    filename,
+                ],
+                input_digest=snapshot.digest,
+                output_directories=(dest_dir,),
+                description=f"Extract {filename}",
+            ),
+        )
+        for filename in snapshot.files
+    )
+
+    listing_snapshots = await MultiGet(
+        Get(Snapshot, RemovePrefix(pr.output_digest, dest_dir)) for pr in process_results
+    )
+
+    return RenderedClasspath(
+        {path: set(listing.files) for path, listing in zip(snapshot.files, listing_snapshots)}
+    )
 
 
 def expect_single_expanded_coarsened_target(
@@ -139,10 +183,10 @@ def test_compile_no_deps(rule_runner: RuleRunner) -> None:
         [CompileJavaSourceRequest(component=coarsened_target)],
     )
 
-    classfile_digest_contents = rule_runner.request(DigestContents, [compiled_classfiles.digest])
-    assert frozenset(content.path for content in classfile_digest_contents) == frozenset(
-        ["org/pantsbuild/example/lib/ExampleLib.class"]
-    )
+    classpath = rule_runner.request(RenderedClasspath, [compiled_classfiles.digest])
+    assert classpath.content == {
+        ".ExampleLib.java.lib.jar": {"org/pantsbuild/example/lib/ExampleLib.class"}
+    }
 
     # Additionally validate that `check` works.
     check_results = rule_runner.request(
@@ -190,12 +234,11 @@ def test_compile_jdk_versions(rule_runner: RuleRunner) -> None:
         )
     )
     rule_runner.set_options(["--javac-jdk=zulu:1.8"])
-    assert {
-        contents.path
-        for contents in rule_runner.request(
-            DigestContents, [rule_runner.request(CompiledClassfiles, [request]).digest]
-        )
-    } == {"org/pantsbuild/example/lib/ExampleLib.class"}
+    compiled_classfiles = rule_runner.request(CompiledClassfiles, [request])
+    classpath = rule_runner.request(RenderedClasspath, [compiled_classfiles.digest])
+    assert classpath.content == {
+        ".ExampleLib.java.lib.jar": {"org/pantsbuild/example/lib/ExampleLib.class"}
+    }
 
     rule_runner.set_options(["--javac-jdk=bogusjdk:999"])
     expected_exception_msg = r".*?JVM bogusjdk:999 not found in index.*?"
@@ -346,15 +389,15 @@ def test_compile_with_cycle(rule_runner: RuleRunner) -> None:
     request = CompileJavaSourceRequest(component=coarsened_target)
 
     compiled_classfiles = rule_runner.request(CompiledClassfiles, [request])
-    classfile_digest_contents = rule_runner.request(DigestContents, [compiled_classfiles.digest])
-    assert frozenset(content.path for content in classfile_digest_contents) == frozenset(
-        [
+    classpath = rule_runner.request(RenderedClasspath, [compiled_classfiles.digest])
+    assert classpath.content == {
+        "a.A.java.jar": {
             "org/pantsbuild/a/A.class",
             "org/pantsbuild/a/C.class",
             "org/pantsbuild/b/B.class",
             "org/pantsbuild/b/C.class",
-        ]
-    )
+        }
+    }
 
 
 @maybe_skip_jdk_test
@@ -444,10 +487,8 @@ def test_compile_with_transitive_cycle(rule_runner: RuleRunner) -> None:
             )
         ],
     )
-    classfile_digest_contents = rule_runner.request(DigestContents, [compiled_classfiles.digest])
-    assert frozenset(content.path for content in classfile_digest_contents) == frozenset(
-        ["org/pantsbuild/main/Main.class"]
-    )
+    classpath = rule_runner.request(RenderedClasspath, [compiled_classfiles.digest])
+    assert classpath.content == {".Main.java.main.jar": {"org/pantsbuild/main/Main.class"}}
 
 
 @pytest.mark.xfail(reason="https://github.com/pantsbuild/pants/issues/13056")
@@ -583,9 +624,8 @@ def test_compile_with_deps(rule_runner: RuleRunner) -> None:
             )
         ],
     )
-    classfile_digest_contents = rule_runner.request(DigestContents, [compiled_classfiles.digest])
-    assert len(classfile_digest_contents) == 1
-    assert classfile_digest_contents[0].path == "org/pantsbuild/example/Example.class"
+    classpath = rule_runner.request(RenderedClasspath, [compiled_classfiles.digest])
+    assert classpath.content == {".Example.java.main.jar": {"org/pantsbuild/example/Example.class"}}
 
 
 @maybe_skip_jdk_test
@@ -691,9 +731,8 @@ def test_compile_with_maven_deps(rule_runner: RuleRunner) -> None:
         )
     )
     compiled_classfiles = rule_runner.request(CompiledClassfiles, [request])
-    classfile_digest_contents = rule_runner.request(DigestContents, [compiled_classfiles.digest])
-    assert len(classfile_digest_contents) == 1
-    assert classfile_digest_contents[0].path == "org/pantsbuild/example/Example.class"
+    classpath = rule_runner.request(RenderedClasspath, [compiled_classfiles.digest])
+    assert classpath.content == {".Example.java.main.jar": {"org/pantsbuild/example/Example.class"}}
 
 
 @maybe_skip_jdk_test

--- a/src/python/pants/backend/java/dependency_inference/java_parser.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser.py
@@ -113,7 +113,7 @@ async def analyze_java_source_dependencies(
         FallibleProcessResult,
         Process(
             argv=[
-                *jdk_setup.args(bash, [tool_classpath.classpath_arg(), processorcp_relpath]),
+                *jdk_setup.args(bash, [*tool_classpath.classpath_entries(), processorcp_relpath]),
                 "org.pantsbuild.javaparser.PantsJavaParserLauncher",
                 analysis_output_path,
                 source_path,

--- a/src/python/pants/backend/java/dependency_inference/java_parser_launcher.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser_launcher.py
@@ -93,7 +93,7 @@ async def build_processors(bash: BashBinary, jdk_setup: JdkSetup) -> JavaParserC
                 *jdk_setup.args(bash, [f"{jdk_setup.java_home}/lib/tools.jar"]),
                 "com.sun.tools.javac.Main",
                 "-cp",
-                materialized_classpath.classpath_arg(),
+                ":".join(materialized_classpath.classpath_entries()),
                 "-d",
                 dest_dir,
                 _LAUNCHER_BASENAME,

--- a/src/python/pants/backend/java/test/junit.py
+++ b/src/python/pants/backend/java/test/junit.py
@@ -76,14 +76,14 @@ async def run_junit_test(
     reports_dir_prefix = "__reports_dir"
     reports_dir = f"{reports_dir_prefix}/{field_set.address.path_safe_spec}"
 
-    user_classpath_arg = ":".join(classpath.user_classpath_args())
+    user_classpath_arg = ":".join(classpath.user_classpath_entries())
 
     process_result = await Get(
         FallibleProcessResult,
         Process(
             argv=[
                 *jdk_setup.args(
-                    bash, [*classpath.classpath_args(), *junit_classpath.classpath_args()]
+                    bash, [*classpath.classpath_entries(), *junit_classpath.classpath_entries()]
                 ),
                 "org.junit.platform.console.ConsoleLauncher",
                 *(("--classpath", user_classpath_arg) if user_classpath_arg else ()),

--- a/src/python/pants/backend/java/test/junit.py
+++ b/src/python/pants/backend/java/test/junit.py
@@ -4,35 +4,19 @@
 import logging
 from dataclasses import dataclass
 
-from pants.backend.java.compile.javac import CompiledClassfiles, CompileJavaSourceRequest
+from pants.backend.java.classpath import Classpath
 from pants.backend.java.subsystems.junit import JUnit
 from pants.backend.java.target_types import JavaTestSourceField
 from pants.backend.java.util_rules import JdkSetup
 from pants.core.goals.test import TestDebugRequest, TestFieldSet, TestResult, TestSubsystem
 from pants.engine.addresses import Addresses
-from pants.engine.fs import (
-    AddPrefix,
-    Digest,
-    DigestSubset,
-    MergeDigests,
-    PathGlobs,
-    RemovePrefix,
-    Snapshot,
-)
+from pants.engine.fs import Digest, DigestSubset, MergeDigests, PathGlobs, RemovePrefix, Snapshot
 from pants.engine.process import BashBinary, FallibleProcessResult, Process
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import (
-    CoarsenedTargets,
-    Targets,
-    TransitiveTargets,
-    TransitiveTargetsRequest,
-)
+from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.jvm.resolve.coursier_fetch import (
     ArtifactRequirements,
     Coordinate,
-    CoursierLockfileForTargetRequest,
-    CoursierResolvedLockfile,
     MaterializedClasspath,
     MaterializedClasspathRequest,
 )
@@ -56,20 +40,11 @@ async def run_junit_test(
     test_subsystem: TestSubsystem,
     field_set: JavaTestFieldSet,
 ) -> TestResult:
-    transitive_targets = await Get(TransitiveTargets, TransitiveTargetsRequest([field_set.address]))
-    coarsened_targets = await Get(
-        CoarsenedTargets, Addresses(t.address for t in transitive_targets.closure)
-    )
-
-    lockfile = await Get(
-        CoursierResolvedLockfile,
-        CoursierLockfileForTargetRequest(Targets(transitive_targets.closure)),
-    )
-    materialized_classpath = await Get(
+    classpath = await Get(Classpath, Addresses([field_set.address]))
+    junit_classpath = await Get(
         MaterializedClasspath,
         MaterializedClasspathRequest(
             prefix="__thirdpartycp",
-            lockfiles=(lockfile,),
             artifact_requirements=(
                 ArtifactRequirements(
                     [
@@ -93,40 +68,26 @@ async def run_junit_test(
             ),
         ),
     )
-    transitive_user_classfiles = await MultiGet(
-        Get(CompiledClassfiles, CompileJavaSourceRequest(component=t)) for t in coarsened_targets
-    )
-    merged_transitive_user_classfiles_digest = await Get(
-        Digest, MergeDigests(classfiles.digest for classfiles in transitive_user_classfiles)
-    )
-    usercp_relpath = "__usercp"
-    prefixed_transitive_user_classfiles_digest = await Get(
-        Digest, AddPrefix(merged_transitive_user_classfiles_digest, usercp_relpath)
-    )
     merged_digest = await Get(
         Digest,
-        MergeDigests(
-            (
-                prefixed_transitive_user_classfiles_digest,
-                materialized_classpath.digest,
-                jdk_setup.digest,
-            )
-        ),
+        MergeDigests((classpath.content.digest, jdk_setup.digest, junit_classpath.digest)),
     )
 
     reports_dir_prefix = "__reports_dir"
     reports_dir = f"{reports_dir_prefix}/{field_set.address.path_safe_spec}"
 
+    user_classpath_arg = ":".join(classpath.user_classpath_args())
+
     process_result = await Get(
         FallibleProcessResult,
         Process(
             argv=[
-                *jdk_setup.args(bash, [materialized_classpath.classpath_arg()]),
+                *jdk_setup.args(
+                    bash, [*classpath.classpath_args(), *junit_classpath.classpath_args()]
+                ),
                 "org.junit.platform.console.ConsoleLauncher",
-                "--classpath",
-                usercp_relpath,
-                "--scan-class-path",
-                usercp_relpath,
+                *(("--classpath", user_classpath_arg) if user_classpath_arg else ()),
+                *(("--scan-class-path", user_classpath_arg) if user_classpath_arg else ()),
                 "--reports-dir",
                 reports_dir,
                 *junit.options.args,

--- a/src/python/pants/backend/java/test/junit_test.py
+++ b/src/python/pants/backend/java/test/junit_test.py
@@ -8,6 +8,7 @@ from textwrap import dedent
 
 import pytest
 
+from pants.backend.java import classpath
 from pants.backend.java.compile.javac import rules as javac_rules
 from pants.backend.java.target_types import JavaSourcesGeneratorTarget, JunitTestsGeneratorTarget
 from pants.backend.java.target_types import rules as target_types_rules
@@ -43,6 +44,7 @@ def rule_runner() -> RuleRunner:
         preserve_tmpdirs=True,
         rules=[
             *config_files.rules(),
+            *classpath.rules(),
             *coursier_fetch_rules(),
             *coursier_setup_rules(),
             *external_tool_rules(),

--- a/src/python/pants/backend/java/util_rules.py
+++ b/src/python/pants/backend/java/util_rules.py
@@ -19,6 +19,7 @@ from pants.jvm.resolve.coursier_fetch import (
     ResolvedClasspathEntry,
 )
 from pants.jvm.resolve.coursier_setup import Coursier
+from pants.util.logging import LogLevel
 
 
 @dataclass(frozen=True)
@@ -79,6 +80,7 @@ async def setup_jdk(coursier: Coursier, javac: JavacSubsystem, bash: BashBinary)
             append_only_caches=coursier.append_only_caches,
             description=f"Ensure download of JDK {coursier_jdk_option}.",
             cache_scope=ProcessCacheScope.PER_RESTART_SUCCESSFUL,
+            level=LogLevel.DEBUG,
         ),
     )
 

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -382,7 +382,9 @@ async def coarsened_targets(addresses: Addresses) -> CoarsenedTargets:
         if not any(component_address in addresses_set for component_address in component):
             continue
         component_set = set(component)
-        members = tuple(addresses_to_targets[a] for a in component)
+        members = tuple(
+            sorted((addresses_to_targets[a] for a in component), key=lambda t: t.address)
+        )
         dependencies = FrozenOrderedSet(
             [d for a in component for d in dependency_mapping.mapping[a] if d not in component_set]
         )

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -621,11 +621,16 @@ class CoarsenedTarget(EngineAwareParameter):
     def metadata(self) -> Dict[str, Any]:
         return {"addresses": [t.address.spec for t in self.members]}
 
+    @property
+    def representative(self) -> Target:
+        """A stable "representative" target in the cycle."""
+        return self.members[0]
+
     def __str__(self) -> str:
         if len(self.members) > 1:
             others = len(self.members) - 1
             return f"{self.members[0].address.spec} (and {others} more)"
-        return self.members[0].address.spec
+        return self.representative.address.spec
 
 
 class CoarsenedTargets(Collection[CoarsenedTarget]):

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import dataclasses
+import functools
 import os
 import sys
 from contextlib import contextmanager
@@ -61,6 +62,7 @@ from pants.util.ordered_set import FrozenOrderedSet
 def logging(func):
     """A decorator that enables logging (optionally at the given level)."""
 
+    @functools.wraps(func)
     def wrapper(*args, **kwargs):
         stdout_fileno, stderr_fileno = sys.stdout.fileno(), sys.stderr.fileno()
         with temporary_dir() as tempdir, initialize_stdio_raw(


### PR DESCRIPTION
As described in #13036, Jars are faster to capture and materialize (fewer `inodes`), and have historically been significantly more performant for the JVM to load. We should have the output of JVM compilation be jars, always.

Additionally, generalize the construction of the transitive classpath needed to run an application via a `Addresses -> Classpath` `@rule`.

Fixes #13036.