### PR TITLE
[internal] java: fix version in test

### DIFF
--- a/src/python/pants/backend/java/compile/javac_test.py
+++ b/src/python/pants/backend/java/compile/javac_test.py
@@ -189,7 +189,7 @@ def test_compile_jdk_versions(rule_runner: RuleRunner) -> None:
             rule_runner, Address(spec_path="", target_name="lib")
         )
     )
-    rule_runner.set_options(["--javac-jdk=zulu:1.6"])
+    rule_runner.set_options(["--javac-jdk=zulu:1.8"])
     assert {
         contents.path
         for contents in rule_runner.request(


### PR DESCRIPTION
As per https://github.com/pantsbuild/pants/issues/13056, fix a failing test that relies on trying to install an older "zulu" JDK version that does not exist on all platforms.

[ci skip-rust]

[ci skip-build-wheels]