### PR TITLE
[internal] Add `DownloadedExternalModules` for Go

### DIFF
--- a/src/python/pants/backend/go/util_rules/external_module.py
+++ b/src/python/pants/backend/go/util_rules/external_module.py
@@ -35,6 +35,80 @@ from pants.util.strutil import strip_v2_chroot_path
 
 
 @dataclass(frozen=True)
+class DownloadedExternalModules:
+    """All downloaded modules, along with the input `go.mod` and `go.sum`."""
+
+    digest: Digest
+
+
+@dataclass(frozen=True)
+class DownloadExternalModulesRequest:
+    """Download all modules from the `go.mod`.
+
+    The `go.mod` and `go.sum` must already be up-to-date.
+    """
+
+    go_mod_stripped_digest: Digest
+
+
+@rule
+async def download_external_modules(
+    request: DownloadExternalModulesRequest,
+) -> DownloadedExternalModules:
+    download_result = await Get(
+        ProcessResult,
+        GoSdkProcess(
+            command=("mod", "download", "-json", "all"),
+            input_digest=request.go_mod_stripped_digest,
+            # TODO: make this more descriptive: point to the actual `go_mod` target or path.
+            description="Download all external Go modules",
+            output_files=("go.mod", "go.sum"),
+            output_directories=("gopath",),
+        ),
+    )
+
+    # Check that the root `go.mod` and `go.sum` did not change.
+    result_go_mod_digest = await Get(
+        Digest, DigestSubset(download_result.output_digest, PathGlobs(["go.mod", "go.sum"]))
+    )
+    if result_go_mod_digest != request.go_mod_stripped_digest:
+        # TODO: make this a more informative error.
+        raise Exception("`go.mod` and/or `go.sum` changed! Please run `go mod tidy`.")
+
+    # TODO: strip `gopath` and other paths?
+    # TODO: stop including irrelevant files like the `.zip` files.
+
+    download_snapshot = await Get(Snapshot, Digest, download_result.output_digest)
+    all_downloaded_files = set(download_snapshot.files)
+
+    # To analyze each module via `go list`, we need a `go.mod` in each module's directory. If the
+    # module does not natively use Go modules, then Go will generate a `go.mod` for us, but we
+    # need to relocate the file to the correct location.
+    module_dirs_with_go_mod = []
+    generated_go_mods_to_module_dirs = {}
+    for module_metadata in ijson.items(download_result.stdout, "", multiple_values=True):
+        download_dir = strip_v2_chroot_path(module_metadata["Dir"])
+        if f"{download_dir}/go.mod" in all_downloaded_files:
+            module_dirs_with_go_mod.append(download_dir)
+        else:
+            generated_go_mod = strip_v2_chroot_path(module_metadata["GoMod"])
+            generated_go_mods_to_module_dirs[generated_go_mod] = download_dir
+
+    digest_entries = await Get(DigestEntries, Digest, download_result.output_digest)
+    go_mod_requests = []
+    for entry in digest_entries:
+        if isinstance(entry, FileEntry) and entry.path in generated_go_mods_to_module_dirs:
+            module_dir = generated_go_mods_to_module_dirs[entry.path]
+            go_mod_requests.append(FileEntry(os.path.join(module_dir, "go.mod"), entry.file_digest))
+    generated_go_mod_digest = await Get(Digest, CreateDigest(go_mod_requests))
+
+    result_digest = await Get(
+        Digest, MergeDigests([download_result.output_digest, generated_go_mod_digest])
+    )
+    return DownloadedExternalModules(result_digest)
+
+
+@dataclass(frozen=True)
 class DownloadExternalModuleRequest:
     path: str
     version: str

--- a/src/python/pants/backend/go/util_rules/external_module.py
+++ b/src/python/pants/backend/go/util_rules/external_module.py
@@ -21,6 +21,7 @@ from pants.engine.fs import (
     EMPTY_DIGEST,
     CreateDigest,
     Digest,
+    DigestContents,
     DigestEntries,
     DigestSubset,
     FileEntry,
@@ -73,7 +74,13 @@ async def download_external_modules(
     )
     if result_go_mod_digest != request.go_mod_stripped_digest:
         # TODO: make this a more informative error.
-        raise Exception("`go.mod` and/or `go.sum` changed! Please run `go mod tidy`.")
+        contents = await Get(DigestContents, Digest, result_go_mod_digest)
+
+        raise Exception(
+            "`go.mod` and/or `go.sum` changed! Please run `go mod tidy`.\n\n"
+            f"{contents[0].content.decode()}\n\n"
+            f"{contents[1].content.decode()}\n\n"
+        )
 
     # TODO: strip `gopath` and other paths?
     # TODO: stop including irrelevant files like the `.zip` files.

--- a/src/python/pants/backend/go/util_rules/external_module_test.py
+++ b/src/python/pants/backend/go/util_rules/external_module_test.py
@@ -51,6 +51,7 @@ def test_download_external_modules(rule_runner: RuleRunner) -> None:
             "go.mod": dedent(
                 """\
                 module example.com/external-module
+                go 1.17
                 require (
                     // Has a `go.mod` already.
                     github.com/google/uuid v1.3.0


### PR DESCRIPTION
First part of https://github.com/pantsbuild/pants/issues/12771. We're re-downloading the same Go dependencies, which is substantially slowing down performance. This makes sense, when you say `go mod download module@version`, it will download all transitive deps. Because we are currently downloading one module at-a-time and not sharing a cache between those downloads, we will end up duplicating downloads.

Another problem is that we were not before respecting the `go.sum` on disk. When you say `go mod download module@version`, Go ignores the `go.mod` and `go.sum`. We need to respect the `go.sum` for security.

--

Now, we download all dependencies for each `go_mod` target all at once. (There is no reuse between `go_mod` targets.)

Followups will hook up `go_build_pkg.py` and our `ExternalModulePkgImportPaths` rule to use this.

In a followup, we can also teach Pants how to extract the relevant modules from the superset, like our Python "repository PEX" feature. This will allow us to keep precise cache keys.

[ci skip-rust]
[ci skip-build-wheels]