### PR TITLE
[internal] Replace deprecated use of `[pytest] junit_xml_dir` with `[test] xml_dir.

### DIFF
--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -11,10 +11,10 @@ log = true
 
 [test]
 use_coverage = true
+xml_dir = "dist/test-results/"
 
 [pytest]
 args = ["--no-header", "-vv"]
-junit_xml_dir = "dist/test-results/"
 
 [coverage-py]
 report = ["raw", "xml"]


### PR DESCRIPTION
[ci skip-rust]
[ci skip-build-wheels]