### PR TITLE
[internal] Use `DownloadedExternalModules` during Go target generation

### DIFF
--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -244,7 +244,7 @@ async def generate_go_external_package_targets(
             ExternalModulePkgImportPathsRequest(
                 module_path=module_descriptor.path,
                 version=module_descriptor.version,
-                go_sum_digest=go_mod_info.go_sum_stripped_digest,
+                go_mod_stripped_digest=go_mod_info.stripped_digest,
             ),
         )
         for module_descriptor in go_mod_info.modules

--- a/src/python/pants/backend/go/target_type_rules_test.py
+++ b/src/python/pants/backend/go/target_type_rules_test.py
@@ -91,13 +91,12 @@ def test_go_package_dependency_inference(rule_runner: RuleRunner) -> None:
                     module go.example.com/foo
                     go 1.17
 
-                    require (
-                        github.com/google/go-cmp v0.4.0
-                    )
+                    require github.com/google/go-cmp v0.4.0
                     """
                 ),
                 "foo/go.sum": textwrap.dedent(
                     """\
+                    github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
                     github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
                     golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
                     golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -165,6 +164,7 @@ def test_generate_go_external_package_targets(rule_runner: RuleRunner) -> None:
             ),
             "src/go/go.sum": textwrap.dedent(
                 """\
+                github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
                 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
                 github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
                 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/src/python/pants/backend/go/util_rules/external_module_test.py
+++ b/src/python/pants/backend/go/util_rules/external_module_test.py
@@ -286,8 +286,18 @@ def test_determine_external_package_info(rule_runner: RuleRunner) -> None:
 
 
 def test_determine_external_module_package_import_paths(rule_runner: RuleRunner) -> None:
-    go_sum_digest = rule_runner.make_snapshot(
+    input_digest = rule_runner.make_snapshot(
         {
+            "go.mod": dedent(
+                """\
+                module example.com/external-module
+                go 1.17
+                require (
+                    github.com/google/go-cmp v0.5.6
+                    golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543  // indirect
+                )
+                """
+            ),
             "go.sum": dedent(
                 """\
                 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
@@ -295,12 +305,12 @@ def test_determine_external_module_package_import_paths(rule_runner: RuleRunner)
                 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
                 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
                 """
-            )
+            ),
         }
     ).digest
     result = rule_runner.request(
         ExternalModulePkgImportPaths,
-        [ExternalModulePkgImportPathsRequest("github.com/google/go-cmp", "v0.5.6", go_sum_digest)],
+        [ExternalModulePkgImportPathsRequest("github.com/google/go-cmp", "v0.5.6", input_digest)],
     )
     assert result == ExternalModulePkgImportPaths(
         [

--- a/src/python/pants/backend/go/util_rules/go_mod.py
+++ b/src/python/pants/backend/go/util_rules/go_mod.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from dataclasses import dataclass
 
 import ijson
@@ -12,7 +13,8 @@ from pants.backend.go.target_types import GoModSourcesField
 from pants.backend.go.util_rules.sdk import GoSdkProcess
 from pants.base.specs import AddressSpecs, AscendantAddresses
 from pants.build_graph.address import Address
-from pants.engine.fs import Digest, DigestSubset, PathGlobs, RemovePrefix
+from pants.engine.engine_aware import EngineAwareParameter
+from pants.engine.fs import Digest, RemovePrefix
 from pants.engine.process import ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
@@ -43,13 +45,16 @@ class GoModInfo:
     # Digest containing the full paths to `go.mod` and `go.sum`.
     digest: Digest
 
-    # Digest containing only the `go.sum` with no leading directory prefix.
-    go_sum_stripped_digest: Digest
+    # Digest containing `go.mod` and `go.sum` with no path prefixes.
+    stripped_digest: Digest
 
 
 @dataclass(frozen=True)
-class GoModInfoRequest:
+class GoModInfoRequest(EngineAwareParameter):
     address: Address
+
+    def debug_hint(self) -> str:
+        return self.address.spec
 
 
 def parse_module_descriptors(raw_json: bytes) -> list[ModuleDescriptor]:
@@ -76,33 +81,35 @@ async def determine_go_mod_info(
 ) -> GoModInfo:
     wrapped_target = await Get(WrappedTarget, Address, request.address)
     sources_field = wrapped_target.target[GoModSourcesField]
+    go_mod_path = sources_field.go_mod_path
+    go_mod_dir = os.path.dirname(go_mod_path)
 
     # Get the `go.mod` (and `go.sum`) and strip so the file has no directory prefix.
     hydrated_sources = await Get(HydratedSources, HydrateSourcesRequest(sources_field))
-    sources_without_prefix = await Get(
-        Digest, RemovePrefix(hydrated_sources.snapshot.digest, request.address.spec_path)
-    )
-    go_sum_digest_get = Get(Digest, DigestSubset(sources_without_prefix, PathGlobs(["go.sum"])))
+    sources_digest = hydrated_sources.snapshot.digest
 
     mod_json_get = Get(
         ProcessResult,
         GoSdkProcess(
             command=("mod", "edit", "-json"),
-            input_digest=sources_without_prefix,
-            description=f"Parse {sources_field.go_mod_path}",
+            input_digest=sources_digest,
+            working_dir=go_mod_dir,
+            description=f"Parse {go_mod_path}",
         ),
     )
     list_modules_get = Get(
         ProcessResult,
         GoSdkProcess(
-            input_digest=sources_without_prefix,
             command=("list", "-m", "-json", "all"),
-            description=f"List modules in {sources_field.go_mod_path}",
+            input_digest=sources_digest,
+            working_dir=go_mod_dir,
+            description=f"List modules in {go_mod_path}",
         ),
     )
 
-    mod_json, list_modules, go_sum_digest = await MultiGet(
-        mod_json_get, list_modules_get, go_sum_digest_get
+    stripped_source_get = Get(Digest, RemovePrefix(sources_digest, go_mod_dir))
+    mod_json, list_modules, stripped_sources = await MultiGet(
+        mod_json_get, list_modules_get, stripped_source_get
     )
 
     module_metadata = json.loads(mod_json.stdout)
@@ -110,8 +117,8 @@ async def determine_go_mod_info(
     return GoModInfo(
         import_path=module_metadata["Module"]["Path"],
         modules=FrozenOrderedSet(modules),
-        digest=hydrated_sources.snapshot.digest,
-        go_sum_stripped_digest=go_sum_digest,
+        digest=sources_digest,
+        stripped_digest=stripped_sources,
     )
 
 
@@ -122,8 +129,11 @@ class OwningGoModRequest:
 
 
 @dataclass(frozen=True)
-class OwningGoMod:
+class OwningGoMod(EngineAwareParameter):
     address: Address
+
+    def debug_hint(self) -> str:
+        return self.address.spec
 
 
 @rule


### PR DESCRIPTION
Next part of https://github.com/pantsbuild/pants/issues/12771 and builds off of https://github.com/pantsbuild/pants/pull/13068.

When generating targets, we use `go list` to determine what packages belong to each external module. Now, we use the result of `go mod download all`, rather than possibly downloading that module again. We can be confident no downloads are happening by setting `GOPROXY=off` and `-mod=readonly.`

[ci skip-rust]
[ci skip-build-wheels]