### PR TITLE
[interal] Use `DownloadedExternalModules` when analyzing external Go packages

### DIFF
--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -195,7 +195,13 @@ async def inject_go_external_package_dependencies(
     wrapped_target = await Get(WrappedTarget, Address, request.dependencies_field.address)
     tgt = wrapped_target.target
     assert isinstance(tgt, GoExternalPackageTarget)
-    this_go_package = await Get(ResolvedGoPackage, ResolveExternalGoPackageRequest(tgt))
+
+    owning_go_mod = await Get(OwningGoMod, OwningGoModRequest(tgt.address))
+    go_mod_info = await Get(GoModInfo, GoModInfoRequest(owning_go_mod.address))
+
+    this_go_package = await Get(
+        ResolvedGoPackage, ResolveExternalGoPackageRequest(tgt, go_mod_info.stripped_digest)
+    )
 
     # Loop through all of the imports of this package and add dependencies on other packages and
     # external modules.


### PR DESCRIPTION
Like https://github.com/pantsbuild/pants/pull/13070, this makes more progress on https://github.com/pantsbuild/pants/issues/12771.

We do not yet use `DownloadedExternalModules` for the sources digest used in `go_build_pkg.py`, only for the analysis of the package. That will be fixed in a followup.

To facilitate landing this, we remove the `go-pkg-debug` goal. It seems unlikely we'd want that for production, and you can simulate it by adding logging. It can be added back if we decide it's valuable once there is less churn.

[ci skip-rust]
[ci skip-build-wheels]