### PR TITLE
[internal] Fix analysis of Go external modules without a `go.sum`

### DIFF
--- a/src/python/pants/backend/go/goals/package_binary_integration_test.py
+++ b/src/python/pants/backend/go/goals/package_binary_integration_test.py
@@ -66,7 +66,12 @@ def build_package(rule_runner: RuleRunner, binary_target: Target) -> BuiltPackag
 def test_package_simple(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "go.mod": "module foo.example.com\n",
+            "go.mod": dedent(
+                """\
+                module foo.example.com
+                go 1.17
+                """
+            ),
             "main.go": dedent(
                 """\
                 package main
@@ -140,10 +145,11 @@ def test_package_with_dependencies(rule_runner: RuleRunner) -> None:
             "go.mod": dedent(
                 """\
                 module foo.example.com
+                go 1.17
                 require (
-                    golang.org/x/text // indirect
+                    golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c // indirect
                     rsc.io/quote v1.5.2
-                    rsc.io/sampler // indirect
+                    rsc.io/sampler v1.3.0 // indirect
                 )
                 """
             ),

--- a/src/python/pants/backend/go/util_rules/BUILD
+++ b/src/python/pants/backend/go/util_rules/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(dependencies=[":analyzer_sources"])
-python_tests(name='tests')
+python_tests(name='tests', timeout=120)
 
 resources(
   name="analyzer_sources",

--- a/src/python/pants/backend/go/util_rules/external_module_test.py
+++ b/src/python/pants/backend/go/util_rules/external_module_test.py
@@ -1,6 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import os.path
 from textwrap import dedent
 
 import pytest
@@ -46,31 +47,55 @@ def rule_runner() -> RuleRunner:
     return rule_runner
 
 
+GO_MOD = dedent(
+    """\
+    module example.com/external-module
+    go 1.17
+
+    // No dependencies, already has `go.mod`.
+    require github.com/google/uuid v1.3.0
+
+    // No dependencies, but missing `go.mod`.
+    require cloud.google.com/go v0.26.0
+
+    // Has dependencies, already has a `go.sum`.
+    require (
+        github.com/google/go-cmp v0.5.6
+        golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543  // indirect
+    )
+
+    // Has dependencies, missing `go.sum`. This causes `go list` to fail in that directory unless
+    // we add `go.sum`.
+    require (
+        rsc.io/quote v1.5.2
+        golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c // indirect
+        rsc.io/sampler v1.3.0 // indirect
+    )
+    """
+)
+
+GO_SUM = dedent(
+    """\
+    cloud.google.com/go v0.26.0 h1:e0WKqKTd5BnrG8aKH3J3h+QvEIQtSUcf2n5UZ5ZgLtQ=
+    cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+    github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+    github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+    github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+    github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+    golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c h1:qgOY6WgZOaTkIIMiVjBQcw93ERBE4m30iBm00nkL0i8=
+    golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+    golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+    golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+    rsc.io/quote v1.5.2 h1:w5fcysjrx7yqtD/aO+QwRjYZOKnaM9Uh2b40tElTs3Y=
+    rsc.io/quote v1.5.2/go.mod h1:LzX7hefJvL54yjefDEDHNONDjII0t9xZLPXsUe+TKr0=
+    rsc.io/sampler v1.3.0 h1:7uVkIFmeBqHfdjD+gZwtXXI+RODJ2Wc4O7MPEh/QiW4=
+    rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
+    """
+)
+
+
 def test_download_external_modules(rule_runner: RuleRunner) -> None:
-    input_digest = rule_runner.make_snapshot(
-        {
-            "go.mod": dedent(
-                """\
-                module example.com/external-module
-                go 1.17
-                require (
-                    // Has a `go.mod` already.
-                    github.com/google/uuid v1.3.0
-                    // Does not have a `go.mod`, should be generated.
-                    cloud.google.com/go v0.26.0
-                )
-                """
-            ),
-            "go.sum": dedent(
-                """\
-                cloud.google.com/go v0.26.0 h1:e0WKqKTd5BnrG8aKH3J3h+QvEIQtSUcf2n5UZ5ZgLtQ=
-                cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-                github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
-                github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-                """
-            ),
-        }
-    ).digest
+    input_digest = rule_runner.make_snapshot({"go.mod": GO_MOD, "go.sum": GO_SUM}).digest
     downloaded_modules = rule_runner.request(
         DownloadedExternalModules, [DownloadExternalModulesRequest(input_digest)]
     )
@@ -82,13 +107,24 @@ def test_download_external_modules(rule_runner: RuleRunner) -> None:
             fp == expected_fp for fp in all_files
         ), f"Could not find `{expected_fp}` in {sorted(all_files)}"
 
+    def module_files(module_dir: str, sample_file: str) -> list[str]:
+        module_dir = os.path.join("gopath/pkg/mod", module_dir)
+        return [
+            os.path.join(module_dir, "go.mod"),
+            os.path.join(module_dir, "go.sum"),
+            os.path.join(module_dir, sample_file),
+        ]
+
     for fp in (
         "go.mod",
         "go.sum",
-        "gopath/pkg/mod/cloud.google.com/go@v0.26.0/go.mod",
-        "gopath/pkg/mod/cloud.google.com/go@v0.26.0/bigtable/filter.go",
-        "gopath/pkg/mod/github.com/google/uuid@v1.3.0/go.mod",
-        "gopath/pkg/mod/github.com/google/uuid@v1.3.0/uuid.go",
+        *module_files("cloud.google.com/go@v0.26.0", "bigtable/filter.go"),
+        *module_files("github.com/google/uuid@v1.3.0", "uuid.go"),
+        *module_files("github.com/google/go-cmp@v0.5.6", "cmp/cmpopts/errors_go113.go"),
+        *module_files("golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c", "width/transform.go"),
+        *module_files("golang.org/x/xerrors@v0.0.0-20191204190536-9bdfabe68543", "wrap.go"),
+        *module_files("rsc.io/quote@v1.5.2", "quote.go"),
+        *module_files("rsc.io/sampler@v1.3.0", "sampler.go"),
     ):
         assert_has_file(fp)
 
@@ -206,44 +242,26 @@ def test_download_external_module_with_no_gomod(rule_runner: RuleRunner) -> None
 
 
 def test_determine_external_package_info(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files(
-        {
-            "go.mod": dedent(
-                """\
-                module example.com/external-module
-                go 1.17
-                require (
-                    github.com/google/go-cmp v0.5.6
-                    golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543  // indirect
-                )
-                """
-            ),
-            "go.sum": dedent(
-                """\
-                github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
-                github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-                golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
-                golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-                """
-            ),
-            "BUILD": "go_mod(name='mod')",
-        }
-    )
+    rule_runner.write_files({"go.mod": GO_MOD, "go.sum": GO_SUM, "BUILD": "go_mod(name='mod')"})
     input_digest = rule_runner.request(Digest, [PathGlobs(["go.mod", "go.sum"])])
-    pkg_addr = Address("", target_name="mod", generated_name="github.com/google/go-cmp/cmp/cmpopts")
-    tgt = rule_runner.get_target(pkg_addr)
-    assert isinstance(tgt, GoExternalPackageTarget)
 
-    pkg_info = rule_runner.request(
-        ResolvedGoPackage, [ResolveExternalGoPackageRequest(tgt, input_digest)]
-    )
-    assert pkg_info.address == pkg_addr
-    assert pkg_info.module_address is None
-    assert pkg_info.import_path == "github.com/google/go-cmp/cmp/cmpopts"
-    assert pkg_info.module_path == "github.com/google/go-cmp"
-    assert pkg_info.module_version == "v0.5.6"
-    assert pkg_info.package_name == "cmpopts"
-    assert pkg_info.imports == (
+    def get_pkg_info(import_path: str) -> ResolvedGoPackage:
+        pkg_addr = Address("", target_name="mod", generated_name=import_path)
+        tgt = rule_runner.get_target(pkg_addr)
+        assert isinstance(tgt, GoExternalPackageTarget)
+        result = rule_runner.request(
+            ResolvedGoPackage, [ResolveExternalGoPackageRequest(tgt, input_digest)]
+        )
+        assert result.address == pkg_addr
+        assert result.module_address is None
+        assert result.import_path == import_path
+        return result
+
+    cmp_info = get_pkg_info("github.com/google/go-cmp/cmp/cmpopts")
+    assert cmp_info.module_path == "github.com/google/go-cmp"
+    assert cmp_info.module_version == "v0.5.6"
+    assert cmp_info.package_name == "cmpopts"
+    assert cmp_info.imports == (
         "errors",
         "fmt",
         "github.com/google/go-cmp/cmp",
@@ -256,7 +274,7 @@ def test_determine_external_package_info(rule_runner: RuleRunner) -> None:
         "unicode",
         "unicode/utf8",
     )
-    assert pkg_info.test_imports == (
+    assert cmp_info.test_imports == (
         "bytes",
         "errors",
         "fmt",
@@ -270,7 +288,7 @@ def test_determine_external_package_info(rule_runner: RuleRunner) -> None:
         "testing",
         "time",
     )
-    assert pkg_info.go_files == (
+    assert cmp_info.go_files == (
         "equate.go",
         "errors_go113.go",
         "ignore.go",
@@ -278,45 +296,54 @@ def test_determine_external_package_info(rule_runner: RuleRunner) -> None:
         "struct_filter.go",
         "xform.go",
     )
-    assert pkg_info.test_go_files == ("util_test.go",)
-    assert pkg_info.xtest_go_files == ("example_test.go",)
-    assert not pkg_info.c_files
-    assert not pkg_info.cgo_files
-    assert not pkg_info.cxx_files
-    assert not pkg_info.m_files
-    assert not pkg_info.h_files
-    assert not pkg_info.s_files
-    assert not pkg_info.syso_files
+    assert cmp_info.test_go_files == ("util_test.go",)
+    assert cmp_info.xtest_go_files == ("example_test.go",)
+    assert not cmp_info.c_files
+    assert not cmp_info.cgo_files
+    assert not cmp_info.cxx_files
+    assert not cmp_info.m_files
+    assert not cmp_info.h_files
+    assert not cmp_info.s_files
+    assert not cmp_info.syso_files
+
+    # Spot check that the other modules can be analyzed.
+    for pkg in (
+        "cloud.google.com/go/bigquery",
+        "github.com/google/uuid",
+        "golang.org/x/text/collate",
+        "golang.org/x/xerrors",
+        "rsc.io/quote",
+        "rsc.io/sampler",
+    ):
+        get_pkg_info(pkg)
 
 
 def test_determine_external_module_package_import_paths(rule_runner: RuleRunner) -> None:
-    input_digest = rule_runner.make_snapshot(
-        {
-            "go.mod": dedent(
-                """\
-                module example.com/external-module
-                go 1.17
-                require (
-                    github.com/google/go-cmp v0.5.6
-                    golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543  // indirect
-                )
-                """
-            ),
-            "go.sum": dedent(
-                """\
-                github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
-                github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-                golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
-                golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-                """
-            ),
-        }
-    ).digest
-    result = rule_runner.request(
-        ExternalModulePkgImportPaths,
-        [ExternalModulePkgImportPathsRequest("github.com/google/go-cmp", "v0.5.6", input_digest)],
+    input_digest = rule_runner.make_snapshot({"go.mod": GO_MOD, "go.sum": GO_SUM}).digest
+
+    def assert_packages(
+        module_path: str, version: str, expected: list[str], *, check_subset: bool = False
+    ) -> None:
+        result = rule_runner.request(
+            ExternalModulePkgImportPaths,
+            [ExternalModulePkgImportPathsRequest(module_path, version, input_digest)],
+        )
+        if check_subset:
+            assert set(expected).issubset(result)
+        else:
+            assert list(result) == expected
+
+    assert_packages(
+        "cloud.google.com/go",
+        "v0.26.0",
+        ["cloud.google.com/go/bigquery", "cloud.google.com/go/firestore"],
+        check_subset=True,
     )
-    assert result == ExternalModulePkgImportPaths(
+    assert_packages("github.com/google/uuid", "v1.3.0", ["github.com/google/uuid"])
+
+    assert_packages(
+        "github.com/google/go-cmp",
+        "v0.5.6",
         [
             "github.com/google/go-cmp/cmp",
             "github.com/google/go-cmp/cmp/cmpopts",
@@ -328,5 +355,19 @@ def test_determine_external_module_package_import_paths(rule_runner: RuleRunner)
             "github.com/google/go-cmp/cmp/internal/teststructs/foo1",
             "github.com/google/go-cmp/cmp/internal/teststructs/foo2",
             "github.com/google/go-cmp/cmp/internal/value",
-        ]
+        ],
     )
+    assert_packages(
+        "golang.org/x/text",
+        "v0.0.0-20170915032832-14c0d48ead0c",
+        ["golang.org/x/text/cmd/gotext", "golang.org/x/text/collate"],
+        check_subset=True,
+    )
+    assert_packages(
+        "golang.org/x/xerrors",
+        "v0.0.0-20191204190536-9bdfabe68543",
+        ["golang.org/x/xerrors", "golang.org/x/xerrors/internal"],
+    )
+
+    assert_packages("rsc.io/quote", "v1.5.2", ["rsc.io/quote", "rsc.io/quote/buggy"])
+    assert_packages("rsc.io/sampler", "v1.3.0", ["rsc.io/sampler"])

--- a/src/python/pants/backend/go/util_rules/external_module_test.py
+++ b/src/python/pants/backend/go/util_rules/external_module_test.py
@@ -1,6 +1,8 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import os.path
 from textwrap import dedent
 


### PR DESCRIPTION
Some modules already include `go.sum` when you download them, but others don't. If you don't have a `go.sum` already and that module's `go.mod` includes any `require` directives, then `go list` will error with

```
E           go: rsc.io/sampler@v1.3.0: missing go.sum entry; to add it:
E           	go mod download rsc.io/sampler
```

We can fix this by using the `go.sum` from the relevant `go_mod` target. That `go.sum` should be a superset of the module in question, and we can be confident the `go.sum` is comprehensive already because we eagerly validate that `go mod download all` did not result in changing the `go.sum` (like adding missing entries).

This PR fixes the issue and makes our `external_module.py` tests much more comprehensive so that we handle several permutations of external modules.

[ci skip-rust]
[ci skip-build-wheels]