### PR TITLE
[internal] Fix Go compilation of transitive dependencies

### DIFF
--- a/src/python/pants/backend/go/goals/package_binary_integration_test.py
+++ b/src/python/pants/backend/go/goals/package_binary_integration_test.py
@@ -104,7 +104,6 @@ def test_package_simple(rule_runner: RuleRunner) -> None:
     assert result.stdout == b"Hello world!\n"
 
 
-@pytest.mark.xfail
 def test_package_with_dependencies(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {

--- a/src/python/pants/backend/go/util_rules/assembly_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/assembly_integration_test.py
@@ -113,8 +113,8 @@ def test_build_package_with_assembly(rule_runner: RuleRunner) -> None:
             "BUILD": dedent(
                 """\
                 go_mod(name="mod")
-                go_package(name="main")
-                go_binary(name="bin", main=":main")
+                go_package(name="pkg")
+                go_binary(name="bin", main=":pkg")
                 """
             ),
         }

--- a/src/python/pants/backend/go/util_rules/build_go_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_go_pkg.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
+import os.path
 from dataclasses import dataclass
 from typing import Optional
 
@@ -35,20 +36,21 @@ from pants.backend.go.util_rules.go_pkg import (
     is_first_party_package_target,
     is_third_party_package_target,
 )
-from pants.backend.go.util_rules.import_analysis import GatheredImports, GatherImportsRequest
+from pants.backend.go.util_rules.import_analysis import ImportConfig, ImportConfigRequest
 from pants.build_graph.address import Address
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.engine.addresses import Addresses
 from pants.engine.engine_aware import EngineAwareParameter
-from pants.engine.fs import Digest, MergeDigests
+from pants.engine.fs import AddPrefix, Digest, MergeDigests
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import Dependencies, DependenciesRequest, UnexpandedTargets, WrappedTarget
-from pants.util.ordered_set import FrozenOrderedSet
-from pants.util.strutil import pluralize
+from pants.engine.target import Dependencies, DependenciesRequest, Targets, WrappedTarget
+from pants.util.frozendict import FrozenDict
+from pants.util.strutil import path_safe
 
 
 @dataclass(frozen=True)
 class BuildGoPackageRequest(EngineAwareParameter):
+    """Build a package and its dependencies as `__pkg__.a` files."""
+
     address: Address
     is_main: bool = False
 
@@ -58,15 +60,17 @@ class BuildGoPackageRequest(EngineAwareParameter):
 
 @dataclass(frozen=True)
 class BuiltGoPackage:
-    import_path: str
-    object_digest: Digest
-    imports_digest: Digest
+    """A package and its dependencies compiled as `__pkg__.a` files.
+
+    The packages are arranged into `__pkgs__/{path_safe(import_path)}/__pkg__.a`.
+    """
+
+    digest: Digest
+    import_paths_to_pkg_a_files: FrozenDict[str, str]
 
 
 @rule
-async def build_target(
-    request: BuildGoPackageRequest,
-) -> BuiltGoPackage:
+async def build_go_package(request: BuildGoPackageRequest) -> BuiltGoPackage:
     wrapped_target = await Get(WrappedTarget, Address, request.address)
     target = wrapped_target.target
 
@@ -102,30 +106,33 @@ async def build_target(
         source_files_digest = module.digest
         source_files_subpath = resolved_package.import_path[len(module_path) :]
     else:
-        raise ValueError(f"Unknown how to build Go target at address {request.address}.")
+        raise AssertionError(f"Unknown how to build target at address {request.address} with Go.")
 
-    dependencies = await Get(Addresses, DependenciesRequest(field=target[Dependencies]))
-    dependencies_targets = await Get(UnexpandedTargets, Addresses(dependencies))
-    buildable_dependencies_targets = [
-        dep_tgt
-        for dep_tgt in dependencies_targets
-        if is_first_party_package_target(dep_tgt) or is_third_party_package_target(dep_tgt)
+    import_path = "main" if request.is_main else resolved_package.import_path
+
+    _all_dependencies = await Get(Targets, DependenciesRequest(target[Dependencies]))
+    _buildable_dependencies = [
+        dep
+        for dep in _all_dependencies
+        if is_first_party_package_target(dep) or is_third_party_package_target(dep)
     ]
-    built_go_deps = await MultiGet(
-        Get(BuiltGoPackage, BuildGoPackageRequest(tgt.address))
-        for tgt in buildable_dependencies_targets
+    built_deps = await MultiGet(
+        Get(BuiltGoPackage, BuildGoPackageRequest(tgt.address)) for tgt in _buildable_dependencies
     )
 
-    gathered_imports = await Get(
-        GatheredImports,
-        GatherImportsRequest(packages=FrozenOrderedSet(built_go_deps), include_stdlib=True),
+    import_paths_to_pkg_a_files: dict[str, str] = {}
+    dep_digests = []
+    for dep in built_deps:
+        import_paths_to_pkg_a_files.update(dep.import_paths_to_pkg_a_files)
+        dep_digests.append(dep.digest)
+
+    merged_deps_digest, import_config = await MultiGet(
+        Get(Digest, MergeDigests(dep_digests)),
+        Get(ImportConfig, ImportConfigRequest(FrozenDict(import_paths_to_pkg_a_files))),
     )
-
-    import_path = resolved_package.import_path
-    if request.is_main:
-        import_path = "main"
-
-    input_digest = await Get(Digest, MergeDigests([gathered_imports.digest, source_files_digest]))
+    input_digest = await Get(
+        Digest, MergeDigests([merged_deps_digest, import_config.digest, source_files_digest])
+    )
 
     assembly_digests = None
     symabis_path = None
@@ -146,27 +153,30 @@ async def build_target(
             digest=input_digest,
             sources=tuple(f"./{source_files_subpath}/{name}" for name in resolved_package.go_files),
             import_path=import_path,
-            description=f"Compile Go package with {pluralize(len(resolved_package.go_files), 'file')}.",
-            import_config_path="./importcfg",
+            description=f"Compile Go package: {import_path}",
+            import_config_path=import_config.CONFIG_PATH,
             symabis_path=symabis_path,
         ),
     )
-    output_digest = result.output_digest
-
+    compilation_digest = result.output_digest
     if assembly_digests:
         assembly_result = await Get(
             AssemblyPostCompilation,
             AssemblyPostCompilationRequest(
-                output_digest, assembly_digests, resolved_package.s_files, source_files_subpath
+                compilation_digest,
+                assembly_digests,
+                resolved_package.s_files,
+                source_files_subpath,
             ),
         )
-        output_digest = assembly_result.merged_output_digest
+        compilation_digest = assembly_result.merged_output_digest
 
-    return BuiltGoPackage(
-        import_path=import_path,
-        object_digest=output_digest,
-        imports_digest=gathered_imports.digest,
-    )
+    _path_prefix = os.path.join("__pkgs__", path_safe(import_path))
+    import_paths_to_pkg_a_files[import_path] = os.path.join(_path_prefix, "__pkg__.a")
+    _output_digest = await Get(Digest, AddPrefix(compilation_digest, _path_prefix))
+    merged_result_digest = await Get(Digest, MergeDigests([*dep_digests, _output_digest]))
+
+    return BuiltGoPackage(merged_result_digest, FrozenDict(import_paths_to_pkg_a_files))
 
 
 def rules():

--- a/src/python/pants/backend/go/util_rules/build_go_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_go_pkg.py
@@ -42,7 +42,7 @@ from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import AddPrefix, Digest, MergeDigests
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import Dependencies, DependenciesRequest, Targets, WrappedTarget
+from pants.engine.target import Dependencies, DependenciesRequest, UnexpandedTargets, WrappedTarget
 from pants.util.frozendict import FrozenDict
 from pants.util.strutil import path_safe
 
@@ -110,7 +110,9 @@ async def build_go_package(request: BuildGoPackageRequest) -> BuiltGoPackage:
 
     import_path = "main" if request.is_main else resolved_package.import_path
 
-    _all_dependencies = await Get(Targets, DependenciesRequest(target[Dependencies]))
+    # TODO: If you use `Targets` here, then we replace the direct dep on the `go_mod` with all
+    #  of its generated targets...Figure this out.
+    _all_dependencies = await Get(UnexpandedTargets, DependenciesRequest(target[Dependencies]))
     _buildable_dependencies = [
         dep
         for dep in _all_dependencies

--- a/src/python/pants/backend/go/util_rules/build_go_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/build_go_pkg_test.py
@@ -202,10 +202,10 @@ def test_build_dependencies(rule_runner: RuleRunner) -> None:
         expected_import_paths=xerrors_import_paths,
     )
 
-    quoter_import_paths = ["example.com/greeter/quoter", *xerrors_import_paths]
-    assert_built(rule_runner, Address("greeter/quoter"), expected_import_paths=quoter_import_paths)
+    quoter_import_path = "example.com/greeter/quoter"
+    assert_built(rule_runner, Address("greeter/quoter"), expected_import_paths=[quoter_import_path])
 
-    greeter_import_paths = ["example.com/greeter", *quoter_import_paths]
+    greeter_import_paths = ["example.com/greeter", quoter_import_path, *xerrors_import_paths]
     assert_built(rule_runner, Address("greeter"), expected_import_paths=greeter_import_paths)
 
     assert_built(

--- a/src/python/pants/backend/go/util_rules/build_go_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/build_go_pkg_test.py
@@ -1,6 +1,8 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import os.path
 from textwrap import dedent
 

--- a/src/python/pants/backend/go/util_rules/build_go_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/build_go_pkg_test.py
@@ -1,0 +1,213 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os.path
+from textwrap import dedent
+
+import pytest
+
+from pants.backend.go import target_type_rules
+from pants.backend.go.target_types import GoModTarget, GoPackage
+from pants.backend.go.util_rules import (
+    assembly,
+    build_go_pkg,
+    compile,
+    external_module,
+    go_mod,
+    go_pkg,
+    import_analysis,
+    sdk,
+)
+from pants.backend.go.util_rules.build_go_pkg import BuildGoPackageRequest, BuiltGoPackage
+from pants.core.util_rules import source_files
+from pants.engine.addresses import Address
+from pants.engine.fs import Snapshot
+from pants.engine.rules import QueryRule
+from pants.testutil.rule_runner import RuleRunner
+from pants.util.strutil import path_safe
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = RuleRunner(
+        rules=[
+            *source_files.rules(),
+            *sdk.rules(),
+            *assembly.rules(),
+            *build_go_pkg.rules(),
+            *compile.rules(),
+            *import_analysis.rules(),
+            *go_mod.rules(),
+            *go_pkg.rules(),
+            *external_module.rules(),
+            *target_type_rules.rules(),
+            QueryRule(BuiltGoPackage, [BuildGoPackageRequest]),
+        ],
+        target_types=[GoPackage, GoModTarget],
+    )
+    rule_runner.set_options([], env_inherit={"PATH"})
+    return rule_runner
+
+
+def assert_built(
+    rule_runner: RuleRunner, addr: Address, *, expected_import_paths: list[str]
+) -> None:
+    built_package = rule_runner.request(BuiltGoPackage, [BuildGoPackageRequest(addr)])
+    result_files = rule_runner.request(Snapshot, [built_package.digest]).files
+    expected = {
+        import_path: os.path.join("__pkgs__", path_safe(import_path), "__pkg__.a")
+        for import_path in expected_import_paths
+    }
+    assert dict(built_package.import_paths_to_pkg_a_files) == expected
+    assert sorted(result_files) == sorted(expected.values())
+
+
+def test_build_internal_pkg(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "go.mod": dedent(
+                """\
+                module example.com/greeter
+                go 1.17
+                """
+            ),
+            "greeter.go": dedent(
+                """\
+                package greeter
+
+                import "fmt"
+
+                func Hello() {
+                    fmt.Println("Hello world!")
+                }
+                """
+            ),
+            "BUILD": dedent(
+                """\
+                go_mod(name="mod")
+                go_package(name="pkg", import_path='main')
+                """
+            ),
+        }
+    )
+    assert_built(rule_runner, Address("", target_name="pkg"), expected_import_paths=["main"])
+
+
+def test_build_external_pkg(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "go.mod": dedent(
+                """\
+                module example.com/greeter
+                go 1.17
+                require github.com/google/uuid v1.3.0
+                """
+            ),
+            "go.sum": dedent(
+                """\
+                github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+                github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+                """
+            ),
+            "BUILD": "go_mod(name='mod')",
+        }
+    )
+    import_path = "github.com/google/uuid"
+    assert_built(
+        rule_runner,
+        Address("", target_name="mod", generated_name=import_path),
+        expected_import_paths=[import_path],
+    )
+
+
+def test_build_dependencies(rule_runner: RuleRunner) -> None:
+    """Check that we properly include (transitive) dependencies."""
+    rule_runner.write_files(
+        {
+            "greeter/quoter/lib.go": dedent(
+                """\
+                package quoter
+
+                import "fmt"
+
+                func Quote(s string) string {
+                    return fmt.Sprintf(">> %s <<", s)
+                }
+                """
+            ),
+            "greeter/quoter/BUILD": "go_package()",
+            "greeter/lib.go": dedent(
+                """\
+                package greeter
+
+                import (
+                    "fmt"
+                    "example.com/greeter/quoter"
+                    "golang.org/x/xerrors"
+                )
+
+                func QuotedHello() {
+                    xerrors.New("some error")
+                    fmt.Println(quoter.Quote("Hello world!"))
+                }
+                """
+            ),
+            "greeter/BUILD": "go_package()",
+            "main.go": dedent(
+                """\
+                package main
+
+                import "example.com/greeter"
+
+                func main() {
+                    greeter.QuotedHello()
+                }
+                """
+            ),
+            "go.mod": dedent(
+                """\
+                module example.com
+                go 1.17
+                require golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
+                """
+            ),
+            "go.sum": dedent(
+                """\
+                golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+                golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+                """
+            ),
+            "BUILD": dedent(
+                """\
+                go_mod(name='mod')
+                go_package(name='pkg', import_path='main')
+                """
+            ),
+        }
+    )
+
+    xerrors_internal_import_path = "golang.org/x/xerrors/internal"
+    assert_built(
+        rule_runner,
+        Address("", target_name="mod", generated_name=xerrors_internal_import_path),
+        expected_import_paths=[xerrors_internal_import_path],
+    )
+
+    xerrors_import_paths = ["golang.org/x/xerrors", xerrors_internal_import_path]
+    assert_built(
+        rule_runner,
+        Address("", target_name="mod", generated_name="golang.org/x/xerrors"),
+        expected_import_paths=xerrors_import_paths,
+    )
+
+    quoter_import_paths = ["example.com/greeter/quoter", *xerrors_import_paths]
+    assert_built(rule_runner, Address("greeter/quoter"), expected_import_paths=quoter_import_paths)
+
+    greeter_import_paths = ["example.com/greeter", *quoter_import_paths]
+    assert_built(rule_runner, Address("greeter"), expected_import_paths=greeter_import_paths)
+
+    assert_built(
+        rule_runner,
+        Address("", target_name="pkg"),
+        expected_import_paths=["main", *greeter_import_paths],
+    )

--- a/src/python/pants/backend/go/util_rules/compile_test.py
+++ b/src/python/pants/backend/go/util_rules/compile_test.py
@@ -1,62 +1,56 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import textwrap
+from __future__ import annotations
+
+from textwrap import dedent
 
 import pytest
 
-from pants.backend.go.target_types import GoModTarget, GoPackage
 from pants.backend.go.util_rules import compile, sdk
 from pants.backend.go.util_rules.compile import CompiledGoSources, CompileGoSourcesRequest
-from pants.engine.fs import CreateDigest, Digest, FileContent, Snapshot
+from pants.engine.fs import Snapshot
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
-
-SOURCE = FileContent(
-    path="foo.go",
-    content=textwrap.dedent(
-        """\
-        package foo
-        func add(a, b int) int {
-            return a + b
-        }
-        """
-    ).encode("utf-8"),
-)
 
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
     rule_runner = RuleRunner(
         rules=[
-            # *source_files.rules(),
             *sdk.rules(),
             *compile.rules(),
-            QueryRule(Digest, [CreateDigest]),
-            QueryRule(Snapshot, [Digest]),
             QueryRule(CompiledGoSources, [CompileGoSourcesRequest]),
         ],
-        target_types=[GoPackage, GoModTarget],
     )
     rule_runner.set_options([], env_inherit={"PATH"})
     return rule_runner
 
 
 def test_compile_simple_source_file(rule_runner: RuleRunner) -> None:
-    sources_digest = rule_runner.request(Digest, [CreateDigest([SOURCE])])
-
+    digest = rule_runner.make_snapshot(
+        {
+            "foo.go": dedent(
+                """\
+                package foo
+                func add(a, b int) int {
+                    return a + b
+                }
+                """
+            )
+        }
+    ).digest
     result = rule_runner.request(
         CompiledGoSources,
         [
             CompileGoSourcesRequest(
-                digest=sources_digest,
-                sources=(SOURCE.path,),
+                digest=digest,
+                sources=("foo.go",),
                 import_path="foo",
                 description="test_compile_simple_source_file",
             )
         ],
     )
-
     snapshot = rule_runner.request(Snapshot, [result.output_digest])
     assert "__pkg__.a" in snapshot.files
     assert not snapshot.dirs

--- a/src/python/pants/backend/go/util_rules/go_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/go_pkg_test.py
@@ -1,5 +1,8 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
 import textwrap
 
 import pytest

--- a/src/python/pants/backend/go/util_rules/import_analysis_test.py
+++ b/src/python/pants/backend/go/util_rules/import_analysis_test.py
@@ -3,12 +3,21 @@
 
 from __future__ import annotations
 
+import os.path
+from textwrap import dedent
+
 import pytest
 
 from pants.backend.go.util_rules import import_analysis, sdk
-from pants.backend.go.util_rules.import_analysis import GoStdLibImports
+from pants.backend.go.util_rules.import_analysis import (
+    GoStdLibImports,
+    ImportConfig,
+    ImportConfigRequest,
+)
+from pants.engine.fs import DigestContents
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
+from pants.util.frozendict import FrozenDict
 
 
 @pytest.fixture
@@ -18,6 +27,7 @@ def rule_runner() -> RuleRunner:
             *sdk.rules(),
             *import_analysis.rules(),
             QueryRule(GoStdLibImports, []),
+            QueryRule(ImportConfig, [ImportConfigRequest]),
         ],
     )
     rule_runner.set_options([], env_inherit={"PATH"})
@@ -27,3 +37,32 @@ def rule_runner() -> RuleRunner:
 def test_stdlib_package_resolution(rule_runner: RuleRunner) -> None:
     std_lib_imports = rule_runner.request(GoStdLibImports, [])
     assert "fmt" in std_lib_imports
+
+
+def test_import_config_creation(rule_runner: RuleRunner) -> None:
+    mapping = FrozenDict(
+        {
+            "some/import-path": "__pkgs__/some_import-path/__pkg__.a",
+            "another/import-path/pkg1": "__pkgs__/another_import-path_pkg1/__pkg__.a",
+            "another/import-path/pkg2": "__pkgs__/another_import-path_pkg2/__pkg__.a",
+        }
+    )
+
+    def create_config(stdlib: bool) -> str:
+        config = rule_runner.request(
+            ImportConfig, [ImportConfigRequest(mapping, include_stdlib=stdlib)]
+        )
+        digest_contents = rule_runner.request(DigestContents, [config.digest])
+        assert len(digest_contents) == 1
+        file_content = digest_contents[0]
+        assert file_content.path == os.path.normpath(ImportConfig.CONFIG_PATH)
+        return file_content.content.decode()
+
+    assert create_config(stdlib=False) == dedent(
+        """\
+        # import config
+        packagefile some/import-path=__pkgs__/some_import-path/__pkg__.a
+        packagefile another/import-path/pkg1=__pkgs__/another_import-path_pkg1/__pkg__.a
+        packagefile another/import-path/pkg2=__pkgs__/another_import-path_pkg2/__pkg__.a"""
+    )
+    assert "packagefile fmt=" in create_config(stdlib=True)

--- a/src/python/pants/backend/go/util_rules/tests_analysis_test.py
+++ b/src/python/pants/backend/go/util_rules/tests_analysis_test.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
-import textwrap
+from textwrap import dedent
 
 import pytest
 
@@ -12,7 +12,6 @@ from pants.backend.go.util_rules.tests_analysis import (
     AnalyzeTestSourcesRequest,
     GoTestCase,
 )
-from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
 from pants.util.ordered_set import FrozenOrderedSet
@@ -27,49 +26,36 @@ def rule_runner() -> RuleRunner:
             *compile.rules(),
             *link.rules(),
             *sdk.rules(),
-            # *source_files.rules(),
             QueryRule(AnalyzedTestSources, [AnalyzeTestSourcesRequest]),
-            QueryRule(Digest, [CreateDigest]),
         ],
     )
     rule_runner.set_options([], env_inherit={"PATH"})
     return rule_runner
 
 
-def make_digest(rule_runner: RuleRunner, data: dict[str, str]) -> Digest:
-    file_contents = [FileContent(path=k, content=v.encode("utf-8")) for k, v in data.items()]
-    return rule_runner.request(Digest, [CreateDigest(file_contents)])
-
-
 def test_basic_test_analysis(rule_runner: RuleRunner) -> None:
-    input_digest = make_digest(
-        rule_runner,
+    input_digest = rule_runner.make_snapshot(
         {
-            "foo_test.go": textwrap.dedent(
+            "foo_test.go": dedent(
                 """
-            package foo
+                package foo
 
-            func TestThisIsATest(t *testing.T) {
-            }
+                func TestThisIsATest(t *testing.T) {
+                }
 
-            func TestNotATest() {
-            }
+                func TestNotATest() {
+                }
 
-            func Test(t *testing.T) {
-            }
-            """
+                func Test(t *testing.T) {
+                }
+                """
             )
         },
-    )
+    ).digest
 
     metadata = rule_runner.request(
         AnalyzedTestSources,
-        [
-            AnalyzeTestSourcesRequest(
-                digest=input_digest,
-                paths=FrozenOrderedSet(["foo_test.go"]),
-            )
-        ],
+        [AnalyzeTestSourcesRequest(input_digest, FrozenOrderedSet(["foo_test.go"]))],
     )
 
     assert metadata == AnalyzedTestSources(


### PR DESCRIPTION
`BuiltGoPackage` was not properly preserving transitive dependencies, so at link time we would get errors like:

```
E           pants.engine.process.ProcessExecutionFailure: Process 'Link Go binary.' failed with exit code 1.
E           stdout:
E           cannot find package rsc.io/quote (using -importcfg)
E
E           stderr:
E           /opt/homebrew/Cellar/go/1.17/libexec/pkg/tool/darwin_arm64/link: cannot open file : open : no such file or directory
```

This fixes the issue and adds tests for `import_analysis.py` and `build_go_pkg.py`.

[ci skip-rust]
[ci skip-build-wheels]