### PR TITLE
[internal] Structure sharing for `CoarsenedTarget`s

### DIFF
--- a/src/python/pants/backend/java/classpath.py
+++ b/src/python/pants/backend/java/classpath.py
@@ -8,15 +8,9 @@ from dataclasses import dataclass
 from typing import Callable, Iterator
 
 from pants.backend.java.compile.javac import CompiledClassfiles, CompileJavaSourceRequest
-from pants.engine.addresses import Addresses
 from pants.engine.fs import AddPrefix, Digest, MergeDigests, Snapshot
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import (
-    CoarsenedTargets,
-    Targets,
-    TransitiveTargets,
-    TransitiveTargetsRequest,
-)
+from pants.engine.target import CoarsenedTargets, Targets
 from pants.jvm.resolve.coursier_fetch import (
     CoursierLockfileForTargetRequest,
     CoursierResolvedLockfile,
@@ -63,16 +57,10 @@ class Classpath:
 
 
 @rule
-async def classpath(addresses: Addresses) -> Classpath:
-    transitive_targets = await Get(TransitiveTargets, TransitiveTargetsRequest(addresses))
-    coarsened_targets = await Get(
-        CoarsenedTargets, Addresses(t.address for t in transitive_targets.closure)
-    )
+async def classpath(coarsened_targets: CoarsenedTargets) -> Classpath:
+    targets = Targets(t for ct in coarsened_targets.closure() for t in ct.members)
 
-    lockfile = await Get(
-        CoursierResolvedLockfile,
-        CoursierLockfileForTargetRequest(Targets(transitive_targets.closure)),
-    )
+    lockfile = await Get(CoursierResolvedLockfile, CoursierLockfileForTargetRequest(targets))
     materialized_classpath = await Get(
         MaterializedClasspath,
         MaterializedClasspathRequest(
@@ -81,7 +69,8 @@ async def classpath(addresses: Addresses) -> Classpath:
         ),
     )
     transitive_user_classfiles = await MultiGet(
-        Get(CompiledClassfiles, CompileJavaSourceRequest(component=t)) for t in coarsened_targets
+        Get(CompiledClassfiles, CompileJavaSourceRequest(component=t))
+        for t in coarsened_targets.closure()
     )
     merged_transitive_user_classfiles_digest = await Get(
         Digest, MergeDigests(classfiles.digest for classfiles in transitive_user_classfiles)

--- a/src/python/pants/backend/java/compile/javac_test.py
+++ b/src/python/pants/backend/java/compile/javac_test.py
@@ -191,7 +191,11 @@ def test_compile_no_deps(rule_runner: RuleRunner) -> None:
     # Additionally validate that `check` works.
     check_results = rule_runner.request(
         CheckResults,
-        [JavacCheckRequest([JavacCheckRequest.field_set_type.create(coarsened_target.members[0])])],
+        [
+            JavacCheckRequest(
+                [JavacCheckRequest.field_set_type.create(coarsened_target.representative)]
+            )
+        ],
     )
 
     assert len(check_results.results) == 1

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -391,14 +391,12 @@ async def coarsened_targets(addresses: Addresses) -> CoarsenedTargets:
         # For each member of the component, include the CoarsenedTarget for each of its external
         # dependencies.
         coarsened_target = CoarsenedTarget(
-            tuple(addresses_to_targets[a] for a in component),
-            tuple(
-                OrderedSet(
-                    coarsened_targets[d]
-                    for a in component
-                    for d in dependency_mapping.mapping[a]
-                    if d not in component_set
-                )
+            (addresses_to_targets[a] for a in component),
+            (
+                coarsened_targets[d]
+                for a in component
+                for d in dependency_mapping.mapping[a]
+                if d not in component_set
             ),
         )
 

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -369,27 +369,47 @@ async def coarsened_targets(addresses: Addresses) -> CoarsenedTargets:
             expanded_targets=False,
         ),
     )
+    addresses_to_targets = {
+        t.address: t for t in [*dependency_mapping.visited, *dependency_mapping.roots_as_targets]
+    }
+
+    # Because this is Tarjan's SCC (TODO: update signature to guarantee), components are returned
+    # in reverse topological order. We can thus assume when building the structure shared
+    # `CoarsenedTarget` instances that each instance will already have had its dependencies
+    # constructed.
     components = native_engine.strongly_connected_components(
         list(dependency_mapping.mapping.items())
     )
 
-    addresses_set = set(addresses)
-    addresses_to_targets = {
-        t.address: t for t in [*dependency_mapping.visited, *dependency_mapping.roots_as_targets]
-    }
-    targets = []
+    coarsened_targets: dict[Address, CoarsenedTarget] = {}
+    root_coarsened_targets = []
+    root_addresses_set = set(addresses)
     for component in components:
-        if not any(component_address in addresses_set for component_address in component):
-            continue
+        component = sorted(component)
         component_set = set(component)
-        members = tuple(
-            sorted((addresses_to_targets[a] for a in component), key=lambda t: t.address)
+
+        # For each member of the component, include the CoarsenedTarget for each of its external
+        # dependencies.
+        coarsened_target = CoarsenedTarget(
+            tuple(addresses_to_targets[a] for a in component),
+            tuple(
+                OrderedSet(
+                    coarsened_targets[d]
+                    for a in component
+                    for d in dependency_mapping.mapping[a]
+                    if d not in component_set
+                )
+            ),
         )
-        dependencies = FrozenOrderedSet(
-            [d for a in component for d in dependency_mapping.mapping[a] if d not in component_set]
-        )
-        targets.append(CoarsenedTarget(members, dependencies))
-    return CoarsenedTargets(targets)
+
+        # Add to the coarsened_targets mapping under each of the component's Addresses.
+        for address in component:
+            coarsened_targets[address] = coarsened_target
+
+        # If any of the input Addresses was a member of this component, it is a root.
+        if component_set & root_addresses_set:
+            root_coarsened_targets.append(coarsened_target)
+    return CoarsenedTargets(tuple(root_coarsened_targets))
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -372,7 +372,11 @@ def test_coarsened_targets(transitive_targets_rule_runner: RuleRunner) -> None:
             [Addresses([a])],
         )
         assert list(sorted(t.address for t in coarsened_targets[0].members)) == expected_members
-        assert list(sorted(d for d in coarsened_targets[0].dependencies)) == expected_dependencies
+        # NB: Only the direct dependencies are compared.
+        assert (
+            list(sorted(d.address for ct in coarsened_targets[0].dependencies for d in ct.members))
+            == expected_dependencies
+        )
 
     # Non-file-level targets are already validated to not have cycles, so they coarsen to
     # themselves.

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -604,19 +604,25 @@ class UnexpandedTargets(Collection[Target]):
         return self[0]
 
 
-@dataclass(frozen=True)
 class CoarsenedTarget(EngineAwareParameter):
     """A set of Targets which cyclicly reach one another, and are thus indivisible.
 
-    This class is a structure-shared DAG.
-    TODO: Memoize identity and hash for the dependencies.
+    Instances of this class form a structure-shared DAG, and so a hashcode is pre-computed for the
+    recursive portion.
     """
 
     # The members of the cycle.
-    members: Tuple[Target, ...]
+    members: FrozenOrderedSet[Target]
     # The deduped direct (not transitive) dependencies of all Targets in the cycle. Dependencies
     # between members of the cycle are excluded.
-    dependencies: Tuple[CoarsenedTarget, ...]
+    dependencies: FrozenOrderedSet[CoarsenedTarget]
+    # Pre-computed hashcode: see the class doc.
+    _hashcode: int
+
+    def __init__(self, members: Iterable[Target], dependencies: Iterable[CoarsenedTarget]) -> None:
+        self.members = FrozenOrderedSet(members)
+        self.dependencies = FrozenOrderedSet(dependencies)
+        self._hashcode = hash((self.members, self.dependencies))
 
     def debug_hint(self) -> str:
         return str(self)
@@ -627,13 +633,28 @@ class CoarsenedTarget(EngineAwareParameter):
     @property
     def representative(self) -> Target:
         """A stable "representative" target in the cycle."""
-        return self.members[0]
+        return next(iter(self.members))
+
+    def __hash__(self) -> int:
+        return self._hashcode
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, CoarsenedTarget):
+            return NotImplemented
+        return (
+            self._hashcode == other._hashcode
+            and self.members == other.members
+            and self.dependencies == other.dependencies
+        )
 
     def __str__(self) -> str:
         if len(self.members) > 1:
             others = len(self.members) - 1
-            return f"{self.members[0].address.spec} (and {others} more)"
+            return f"{self.representative.address.spec} (and {others} more)"
         return self.representative.address.spec
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({str(self)})"
 
 
 class CoarsenedTargets(Collection[CoarsenedTarget]):


### PR DESCRIPTION
Profiles in example Java repositories showed (unsurprisingly) that recursively re-computing `CoarsenedTargets` (each of which did a transitive walk, and then discarded all but the `CoarsenedTarget`s for the input root) was a bottleneck.

Unlike `Targets`, `CoarsenedTargets` are by definition acyclic, and so can share structure. This change converts `CoarsenedTarget` to a transitive DAG, and `CoarsenedTargets` to containing only the roots of the walk.

Computing `CoarsenedTargets` no longer dominates compilation in example repos.