### PR TITLE
rule runner breaks if there are not defined, which can happen due to how pants isolates test env

### DIFF
--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -129,7 +129,7 @@ class RuleRunner:
         exec_slot = os.environ.get("EXECUTION_SLOT")
         if home and exec_slot:
             bootstrap_args.append(
-                "--named-caches-dir=" f"{home}/.cache/pants/named_caches/tests/{exec_slot}"
+                f"--named-caches-dir={home}/.cache/pants/named_caches/tests/{exec_slot}"
             )
 
         root_dir: Path | None = None

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -125,10 +125,12 @@ class RuleRunner:
 
         # TODO: Until https://github.com/coursier/coursier/pull/2197 is resolved, we avoid concurrent
         # use of the named caches via `[pytest] execution_slot_var`.
-        bootstrap_args.append(
-            "--named-caches-dir="
-            f"{os.environ['HOME']}/.cache/pants/named_caches/tests/{os.environ['EXECUTION_SLOT']}"
-        )
+        home = os.environ.get("HOME")
+        exec_slot = os.environ.get("EXECUTION_SLOT")
+        if home and exec_slot:
+            bootstrap_args.append(
+                "--named-caches-dir=" f"{home}/.cache/pants/named_caches/tests/{exec_slot}"
+            )
 
         root_dir: Path | None = None
         if preserve_tmpdirs:


### PR DESCRIPTION
private link: https://app.circleci.com/pipelines/github/toolchainlabs/toolchain/37523/workflows/8b9bf63f-aaf9-4cb3-8945-f2aacce8cbc1/jobs/122624/tests#failed-test-0
<img width="794" alt="Screen Shot 2021-10-02 at 4 55 24 PM" src="https://user-images.githubusercontent.com/1268088/135734732-a6708af4-177c-40c6-956b-6cf60fbf4117.png">



also tried to add those env variables to `[subprocess-environment].env_vars` but it didn't seem to help.
related to https://github.com/pantsbuild/pants/pull/13046
@stuhood 