### PR TITLE
[internal] go: handle empty input from `go list` that ijson cannot handle

### DIFF
--- a/src/python/pants/backend/go/util_rules/external_module.py
+++ b/src/python/pants/backend/go/util_rules/external_module.py
@@ -322,10 +322,14 @@ async def compute_package_import_paths_from_external_module(
             ),
         ),
     )
-    return ExternalModulePkgImportPaths(
-        metadata["ImportPath"]
-        for metadata in ijson.items(json_result.stdout, "", multiple_values=True)
-    )
+
+    if json_result.stdout:
+        return ExternalModulePkgImportPaths(
+            metadata["ImportPath"]
+            for metadata in ijson.items(json_result.stdout, "", multiple_values=True)
+        )
+    else:
+        return ExternalModulePkgImportPaths()
 
 
 def rules():


### PR DESCRIPTION
Short-circuit processing of empty output  of `go list` in `compute_external_go_package_info` since `ijson` cannot handle empty input.

[ci skip-rust]

[ci skip-build-wheels]