### PR TITLE
[internal] Use fast_relpath_optional for source root calculation in local_dists.

### DIFF
--- a/src/python/pants/backend/python/util_rules/local_dists.py
+++ b/src/python/pants/backend/python/util_rules/local_dists.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import zipfile
 from dataclasses import dataclass
 from io import BytesIO
@@ -30,6 +29,7 @@ from pants.engine.fs import (
 )
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import TransitiveTargets, TransitiveTargetsRequest
+from pants.util.dirutil import fast_relpath_optional
 from pants.util.docutil import doc_url
 from pants.util.meta import frozen_after_init
 
@@ -150,10 +150,8 @@ async def build_local_dists(
     for source in request.sources.source_files.files:
         if source not in unrooted_files_set:
             for source_root in source_roots:
-                if (
-                    source.startswith(source_root)
-                    and os.path.relpath(source, source_root) in provided_files
-                ):
+                source_relpath = fast_relpath_optional(source, source_root)
+                if source_relpath is not None and source_relpath in provided_files:
                     remaining_sources.remove(source)
     remaining_sources_snapshot = await Get(
         Snapshot,


### PR DESCRIPTION
This usage of `os.path.relpath` was showing up in profiles: it's a notoriously expensive function due to its support for relativizing non-contained paths, and use of `os.getcwd` (which releases the GIL to execute a syscall, and then needs to re-acquire it).

Switch to `fast_relpath_optional`.

[ci skip-rust]
[ci skip-build-wheels]