### PR TITLE
[internal] Extract each downloaded Go module

### DIFF
--- a/src/python/pants/backend/go/util_rules/external_module.py
+++ b/src/python/pants/backend/go/util_rules/external_module.py
@@ -187,7 +187,7 @@ async def extract_module_from_downloaded_modules(
     if digest is None:
         raise AssertionError(
             f"The module {request.module_path}@{request.version} was not downloaded. Unless "
-            "you explicitly created an `_external_package_target`, this should not happen."
+            "you explicitly created an `_go_external_package`, this should not happen."
             "Please open an issue at https://github.com/pantsbuild/pants/issues/new/choose with "
             "this error message."
         )


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/12771.

This does not actually improve cache invalidation until we figure out https://github.com/pantsbuild/pants/issues/13093. But it does dramatically reduce the size of each sandbox, which https://github.com/pantsbuild/pants/issues/12719 identified is causing substantial slowdowns to set up.

[ci skip-rust]
[ci skip-build-wheels]