### PR TITLE
[internal] go: switch test analysis to use `go` tool's code plus more tests

### DIFF
--- a/src/python/pants/backend/go/util_rules/analyze_test_sources.go
+++ b/src/python/pants/backend/go/util_rules/analyze_test_sources.go
@@ -1,26 +1,31 @@
 /* Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
  * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ *
+ * Parts adapted from Go SDK and Bazel rules_go, both under BSD-compatible licenses.
  */
 
 package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"go/ast"
+	"go/doc"
 	"go/parser"
 	"go/token"
 	"os"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
 
 //
 // Parse Go sources and extract various metadata about the tests contained therein.
-// Based in part on:
-//   * rules_go (https://github.com/bazelbuild/rules_go/blob/master/go/tools/builders/generate_test_main.go)
-//   * `go` tool (https://github.com/golang/go/blob/master/src/cmd/go/internal/load/test.go)
+// Based in part on the `go` tool (https://github.com/golang/go/blob/master/src/cmd/go/internal/load/test.go)
+// (under BSD-compatible license).
 //
-// As explained by the rules_go source:
+// As explained by the Bazel rules_go source:
 //
 // A Go test comprises three packages:
 //
@@ -32,23 +37,83 @@ import (
 //    test framework with a list of tests, benchmarks, examples, and fuzz
 //    targets read from source files.
 //
+// https://github.com/bazelbuild/rules_go/blob/master/go/tools/builders/generate_test_main.go
+//
 
-type TestCase struct {
+type TestFunc struct {
 	Package string `json:"package"`
 	Name    string `json:"name"`
+}
+
+type Example struct {
+	Package   string `json:"package"`
+	Name      string `json:"name"`
+	Output    string `json:"output"`
+	Unordered bool   `json:"unordered"`
 }
 
 // TestSourcesMetadata contains metadata about tests/benchmarks extracted from the parsed sources.
 // TODO: "Examples" and "fuzz targets" (Go 1.18+).
 type TestSourcesMetadata struct {
 	// Names of all functions in the test sources that heuristically look like test functions.
-	Tests []*TestCase `json:"tests,omit_empty"`
+	Tests []*TestFunc `json:"tests,omitempty"`
 
 	// Names of all functions in the test sources that heuristically look like benchmark functions.
-	Benchmarks []*TestCase `json:"benchmarks,omit_empty"`
+	Benchmarks []*TestFunc `json:"benchmarks,omitempty"`
+
+	// Testable examples. Extracted using "go/doc" package.
+	Examples []*Example `json:"examples,omitempty"`
 
 	// True if the sources already contain a `TestMain` function (which is the entry point for test binaries).
-	HasTestMain bool `json:"has_test_main"`
+	TestMain *TestFunc `json:"test_main,omitempty"`
+}
+
+// isTestFunc tells whether fn has the type of a testing function. arg
+// specifies the parameter type we look for: B, M or T.
+func isTestFunc(fn *ast.FuncDecl, arg string) bool {
+	if fn.Type.Results != nil && len(fn.Type.Results.List) > 0 ||
+		fn.Type.Params.List == nil ||
+		len(fn.Type.Params.List) != 1 ||
+		len(fn.Type.Params.List[0].Names) > 1 {
+		return false
+	}
+	ptr, ok := fn.Type.Params.List[0].Type.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	// We can't easily check that the type is *testing.M
+	// because we don't know how testing has been imported,
+	// but at least check that it's *M or *something.M.
+	// Same applies for B and T.
+	if name, ok := ptr.X.(*ast.Ident); ok && name.Name == arg {
+		return true
+	}
+	if sel, ok := ptr.X.(*ast.SelectorExpr); ok && sel.Sel.Name == arg {
+		return true
+	}
+	return false
+}
+
+// isTest tells whether name looks like a test (or benchmark, according to prefix).
+// It is a Test (say) if there is a character after Test that is not a lower-case letter.
+func isTest(name, prefix string) bool {
+	if !strings.HasPrefix(name, prefix) {
+		return false
+	}
+	if len(name) == len(prefix) { // "Test" is ok
+		return true
+	}
+	r, _ := utf8.DecodeRuneInString(name[len(prefix):])
+	return !unicode.IsLower(r)
+}
+
+func checkTestFunc(fileSet *token.FileSet, fn *ast.FuncDecl, arg string) error {
+	if !isTestFunc(fn, arg) {
+		name := fn.Name.String()
+		pos := fileSet.Position(fn.Pos())
+		return fmt.Errorf("%s: wrong signature for %s, must be: func %s(%s *testing.%s)", pos, name, name, strings.ToLower(arg), arg)
+	}
+	return nil
 }
 
 func processFile(fileSet *token.FileSet, filename string) (*TestSourcesMetadata, error) {
@@ -61,6 +126,19 @@ func processFile(fileSet *token.FileSet, filename string) (*TestSourcesMetadata,
 
 	pkgName := p.Name.Name
 
+	for _, e := range doc.Examples(p) {
+		if e.Output == "" && !e.EmptyOutput {
+			// Don't run examples with no output.
+			continue
+		}
+		metadata.Examples = append(metadata.Examples, &Example{
+			Name:      "Example" + e.Name,
+			Package:   pkgName,
+			Output:    e.Output,
+			Unordered: e.Unordered,
+		})
+	}
+
 	for _, decl := range p.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
 		if !ok {
@@ -70,58 +148,46 @@ func processFile(fileSet *token.FileSet, filename string) (*TestSourcesMetadata,
 			continue
 		}
 
-		// If the source has a `TestMain` function, then record that fact so that Pants knows to use the
-		// user-supplied `TestMain` instead of generating a `TestMain`.
-		if fn.Name.Name == "TestMain" {
-			metadata.HasTestMain = true
-			continue
-		}
+		// The following test/benchmark heuristic is based on the code in the `go` tool.
+		// https://github.com/golang/go/blob/94323206aee1363471a4ae3b8d40dd4ae7a5cd9c/src/cmd/go/internal/load/test.go#L626-L665
 
-		// The following test/benchmark heuristic is based on the code in Bazel's rules_go.
-		// https://github.com/bazelbuild/rules_go/blob/master/go/tools/builders/generate_test_main.go#L308-L367
-
-		// Here we check the signature of the Test* function. To be considered a test:
-
-		// 1. The function should have a single argument.
-		if len(fn.Type.Params.List) != 1 {
-			continue
-		}
-
-		// 2. The function should return nothing.
-		if fn.Type.Results != nil {
-			continue
-		}
-
-		// 3. The only parameter should have a type identified as
-		//    *<something>.T
-		starExpr, ok := fn.Type.Params.List[0].Type.(*ast.StarExpr)
-		if !ok {
-			continue
-		}
-		selExpr, ok := starExpr.X.(*ast.SelectorExpr)
-		if !ok {
-			continue
-		}
-
-		// We do not discriminate on the referenced type of the
-		// parameter being *testing.T. Instead, we assert that it
-		// should be *<something>.T. This is because the import
-		// could have been aliased as a different identifier.
-
-		if strings.HasPrefix(fn.Name.Name, "Test") {
-			if selExpr.Sel.Name != "T" {
+		name := fn.Name.String()
+		switch {
+		case name == "TestMain":
+			if isTestFunc(fn, "T") {
+				// Handle a TestMain function that is actually a test and not a true TestMain.
+				metadata.Tests = append(metadata.Tests, &TestFunc{
+					Name:    fn.Name.Name,
+					Package: pkgName,
+				})
 				continue
 			}
-			metadata.Tests = append(metadata.Tests, &TestCase{
+			err := checkTestFunc(fileSet, fn, "M")
+			if err != nil {
+				return nil, err
+			}
+			if metadata.TestMain != nil {
+				return nil, errors.New("multiple definitions of TestMain")
+			}
+			metadata.TestMain = &TestFunc{
+				Name:    fn.Name.Name,
+				Package: pkgName,
+			}
+		case isTest(name, "Test"):
+			err := checkTestFunc(fileSet, fn, "T")
+			if err != nil {
+				return nil, err
+			}
+			metadata.Tests = append(metadata.Tests, &TestFunc{
 				Name:    fn.Name.Name,
 				Package: pkgName,
 			})
-		}
-		if strings.HasPrefix(fn.Name.Name, "Benchmark") {
-			if selExpr.Sel.Name != "B" {
-				continue
+		case isTest(name, "Benchmark"):
+			err := checkTestFunc(fileSet, fn, "B")
+			if err != nil {
+				return nil, err
 			}
-			metadata.Benchmarks = append(metadata.Benchmarks, &TestCase{
+			metadata.Benchmarks = append(metadata.Benchmarks, &TestFunc{
 				Name:    fn.Name.Name,
 				Package: pkgName,
 			})
@@ -138,21 +204,26 @@ func main() {
 	for _, arg := range os.Args[1:] {
 		fileMetadata, err := processFile(fileSet, arg)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s: %s", arg, err)
+			fmt.Fprintf(os.Stderr, "%s: %s\n", arg, err)
 			os.Exit(1)
 		}
 
 		// TODO: Flag duplicate test and benchmark names.
 		allMetadata.Tests = append(allMetadata.Tests, fileMetadata.Tests...)
 		allMetadata.Benchmarks = append(allMetadata.Benchmarks, fileMetadata.Benchmarks...)
-
-		// TODO: Ensure only one TestMain function and flag duplicates.
-		allMetadata.HasTestMain = allMetadata.HasTestMain || fileMetadata.HasTestMain
+		allMetadata.Examples = append(allMetadata.Examples, fileMetadata.Examples...)
+		if fileMetadata.TestMain != nil {
+			if allMetadata.TestMain != nil {
+				fmt.Fprintf(os.Stderr, "multiple definitions of TestMain\n")
+				os.Exit(1)
+			}
+			allMetadata.TestMain = fileMetadata.TestMain
+		}
 	}
 
 	output, err := json.Marshal(&allMetadata)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to marshall JSON output: %s", err)
+		fmt.Fprintf(os.Stderr, "Unable to marshall JSON output: %s\n", err)
 		os.Exit(1)
 	}
 
@@ -162,7 +233,7 @@ func main() {
 	for amtWritten < len(output) {
 		n, err := os.Stdout.Write(output[amtWritten:])
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to write output: %s", err)
+			fmt.Fprintf(os.Stderr, "Failed to write output: %s\n", err)
 			os.Exit(1)
 		}
 		amtWritten += n

--- a/src/python/pants/backend/go/util_rules/analyze_test_sources.go
+++ b/src/python/pants/backend/go/util_rules/analyze_test_sources.go
@@ -71,7 +71,7 @@ type TestSourcesMetadata struct {
 // isTestFunc tells whether fn has the type of a testing function. arg
 // specifies the parameter type we look for: B, M or T.
 func isTestFunc(fn *ast.FuncDecl, arg string) bool {
-	if fn.Type.Results != nil && len(fn.Type.Results.List) > 0 ||
+	if (fn.Type.Results != nil && len(fn.Type.Results.List) > 0) ||
 		fn.Type.Params.List == nil ||
 		len(fn.Type.Params.List) != 1 ||
 		len(fn.Type.Params.List[0].Names) > 1 {
@@ -95,7 +95,8 @@ func isTestFunc(fn *ast.FuncDecl, arg string) bool {
 }
 
 // isTest tells whether name looks like a test (or benchmark, according to prefix).
-// It is a Test (say) if there is a character after Test that is not a lower-case letter.
+// It is a test if there is a character after Test that is not a lower-case letter.
+// This avoids, for example, Testify matching.
 func isTest(name, prefix string) bool {
 	if !strings.HasPrefix(name, prefix) {
 		return false

--- a/src/python/pants/backend/go/util_rules/tests_analysis_test.py
+++ b/src/python/pants/backend/go/util_rules/tests_analysis_test.py
@@ -10,8 +10,10 @@ from pants.backend.go.util_rules import compile, import_analysis, link, sdk, tes
 from pants.backend.go.util_rules.tests_analysis import (
     AnalyzedTestSources,
     AnalyzeTestSourcesRequest,
+    Example,
     GoTestCase,
 )
+from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
 from pants.util.ordered_set import FrozenOrderedSet
@@ -43,9 +45,6 @@ def test_basic_test_analysis(rule_runner: RuleRunner) -> None:
                 func TestThisIsATest(t *testing.T) {
                 }
 
-                func TestNotATest() {
-                }
-
                 func Test(t *testing.T) {
                 }
                 """
@@ -61,5 +60,156 @@ def test_basic_test_analysis(rule_runner: RuleRunner) -> None:
     assert metadata == AnalyzedTestSources(
         tests=FrozenOrderedSet([GoTestCase("TestThisIsATest", "foo"), GoTestCase("Test", "foo")]),
         benchmarks=FrozenOrderedSet(),
-        has_test_main=False,
+        examples=FrozenOrderedSet(),
+        test_main=None,
     )
+
+
+def test_collect_examples(rule_runner: RuleRunner) -> None:
+    input_digest = rule_runner.make_snapshot(
+        {
+            "foo_test.go": dedent(
+                """
+                package foo
+                func ExampleEmptyOutputExpected() {
+                    // Output:
+                }
+                // This does not have an `Output` comment and will be skipped.
+                func ExampleEmptyOutputAndNoOutputDirective() {
+                }
+                func ExampleSomeOutput() {
+                    fmt.Println("foo")
+                    // Output: foo
+                }
+                func ExampleAnotherOne() {
+                    fmt.Println("foo\\nbar\\n")
+                    // Output:
+                    // foo
+                    // bar
+                }
+                """
+            ),
+        },
+    ).digest
+
+    metadata = rule_runner.request(
+        AnalyzedTestSources,
+        [AnalyzeTestSourcesRequest(input_digest, FrozenOrderedSet(["foo_test.go"]))],
+    )
+
+    assert metadata == AnalyzedTestSources(
+        tests=FrozenOrderedSet(),
+        benchmarks=FrozenOrderedSet(),
+        examples=FrozenOrderedSet(
+            [
+                Example(
+                    package="foo", name="ExampleAnotherOne", output="foo\nbar\n", unordered=False
+                ),
+                Example(
+                    package="foo", name="ExampleEmptyOutputExpected", output="", unordered=False
+                ),
+                Example(package="foo", name="ExampleSomeOutput", output="foo\n", unordered=False),
+            ]
+        ),
+        test_main=None,
+    )
+
+
+def test_incorrect_signatures(rule_runner: RuleRunner) -> None:
+    test_cases = [
+        ("TestFoo(t *testing.T, a int)", "wrong signature for TestFoo"),
+        ("TestFoo()", "wrong signature for TestFoo"),
+        ("TestFoo(t *testing.B)", "wrong signature for TestFoo"),
+        ("TestFoo(t *testing.M)", "wrong signature for TestFoo"),
+        ("TestFoo(a int)", "wrong signature for TestFoo"),
+        ("BenchmarkFoo(t *testing.B, a int)", "wrong signature for BenchmarkFoo"),
+        ("BenchmarkFoo()", "wrong signature for BenchmarkFoo"),
+        ("BenchmarkFoo(t *testing.T)", "wrong signature for BenchmarkFoo"),
+        ("BenchmarkFoo(t *testing.M)", "wrong signature for BenchmarkFoo"),
+        ("BenchmarkFoo(a int)", "wrong signature for BenchmarkFoo"),
+    ]
+
+    for test_sig, err_msg in test_cases:
+        input_digest = rule_runner.make_snapshot(
+            {
+                "foo_test.go": dedent(
+                    f"""
+                    package foo
+                    func {test_sig} {{
+                    }}
+                    """
+                ),
+            },
+        ).digest
+
+        with pytest.raises(ExecutionError) as exc_info:
+            rule_runner.request(
+                AnalyzedTestSources,
+                [AnalyzeTestSourcesRequest(input_digest, FrozenOrderedSet(["foo_test.go"]))],
+            )
+        assert "" in str(exc_info.value)
+
+
+def test_duplicate_test_mains_same_file(rule_runner: RuleRunner) -> None:
+    input_digest = rule_runner.make_snapshot(
+        {
+            "foo_test.go": dedent(
+                """
+                package foo
+
+                func TestMain(m *testing.M) {
+                }
+
+                func TestMain(m *testing.M) {
+                }
+                """
+            ),
+        },
+    ).digest
+
+    with pytest.raises(ExecutionError) as exc_info:
+        rule_runner.request(
+            AnalyzedTestSources,
+            [
+                AnalyzeTestSourcesRequest(
+                    input_digest, FrozenOrderedSet(["foo_test.go", "bar_test.go"])
+                )
+            ],
+        )
+
+    assert "multiple definitions of TestMain" in str(exc_info.value)
+
+
+def test_duplicate_test_mains_different_files(rule_runner: RuleRunner) -> None:
+    input_digest = rule_runner.make_snapshot(
+        {
+            "foo_test.go": dedent(
+                """
+                package foo
+
+                func TestMain(m *testing.M) {
+                }
+                """
+            ),
+            "bar_test.go": dedent(
+                """
+                package foo
+
+                func TestMain(m *testing.M) {
+                }
+                """
+            ),
+        },
+    ).digest
+
+    with pytest.raises(ExecutionError) as exc_info:
+        rule_runner.request(
+            AnalyzedTestSources,
+            [
+                AnalyzeTestSourcesRequest(
+                    input_digest, FrozenOrderedSet(["foo_test.go", "bar_test.go"])
+                )
+            ],
+        )
+
+    assert "multiple definitions of TestMain" in str(exc_info.value)


### PR DESCRIPTION
Changes to the tests analysis code:

- Switch the test analysis code to use [the `go` tool's code](https://github.com/golang/go/blob/master/src/cmd/go/internal/load/test.go) instead of the code from Bazel rules_go.
- Analyze testable examples as well.
- Add more tests of the analysis including incorrect signatures and multiple `TestMain` functions. 

[ci skip-rust]

[ci skip-build-wheels]