### PR TITLE
[internal] go: add stub implementation of `test` goal

### DIFF
--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -1,0 +1,28 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from pants.backend.go.target_types import GoPackageSources
+from pants.core.goals.test import TestDebugRequest, TestFieldSet, TestResult
+from pants.engine.rules import collect_rules, rule
+from pants.engine.unions import UnionRule
+
+
+class GoTestFieldSet(TestFieldSet):
+    required_fields = (GoPackageSources,)
+    sources: GoPackageSources
+
+
+@rule
+async def run_go_tests(field_set: GoTestFieldSet) -> TestResult:
+    raise NotImplementedError("This is a stub.")
+
+
+@rule
+async def generate_go_tests_debug_request(field_set: GoTestFieldSet) -> TestDebugRequest:
+    raise NotImplementedError("This is a stub.")
+
+
+def rules():
+    return [
+        *collect_rules(),
+        UnionRule(TestFieldSet, GoTestFieldSet),
+    ]

--- a/src/python/pants/backend/go/goals/test_test.py
+++ b/src/python/pants/backend/go/goals/test_test.py
@@ -1,0 +1,42 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import pytest
+
+from pants.backend.go.goals.test import GoTestFieldSet
+from pants.backend.go.goals.test import rules as test_rules
+from pants.backend.go.target_types import GoModTarget, GoPackage
+from pants.build_graph.address import Address
+from pants.core.goals.test import TestResult
+from pants.engine.internals.scheduler import ExecutionError
+from pants.engine.rules import QueryRule
+from pants.testutil.rule_runner import RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = RuleRunner(
+        rules=[
+            *test_rules(),
+            QueryRule(TestResult, [GoTestFieldSet]),
+        ],
+        target_types=[GoPackage, GoModTarget],
+    )
+    rule_runner.set_options(["--backend-packages=pants.backend.experimental.go"])
+    return rule_runner
+
+
+def test_stub_is_a_stub(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "foo/BUILD": "go_mod()\ngo_package(name='lib')\n",
+            "foo/go.mod": "module foo\n",
+            "foo/go.sum": "",
+            "foo/bar_test.go": "package foo\n",
+        }
+    )
+
+    with pytest.raises(ExecutionError) as exc_info:
+        tgt = rule_runner.get_target(Address("foo", target_name="lib"))
+        rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
+
+    assert "NotImplementedError: This is a stub." in str(exc_info.value)


### PR DESCRIPTION
Add a stub implementation of the `test` goal for Go packages. This will allow writing failing tests (marked with pytest `xfail`) for Go tests to use while implementing Go tests support.

[ci skip-rust]

[ci skip-build-wheels]