### PR TITLE
[internal] go: remove unnecessary test setup options

### DIFF
--- a/src/python/pants/backend/go/goals/tailor_test.py
+++ b/src/python/pants/backend/go/goals/tailor_test.py
@@ -40,7 +40,6 @@ def rule_runner() -> RuleRunner:
         ],
         target_types=[GoPackage, GoModTarget],
     )
-    rule_runner.set_options(["--backend-packages=pants.backend.experimental.go"])
     return rule_runner
 
 

--- a/src/python/pants/backend/go/goals/test_test.py
+++ b/src/python/pants/backend/go/goals/test_test.py
@@ -21,7 +21,6 @@ def rule_runner() -> RuleRunner:
         ],
         target_types=[GoPackage, GoModTarget],
     )
-    rule_runner.set_options(["--backend-packages=pants.backend.experimental.go"])
     return rule_runner
 
 


### PR DESCRIPTION
Remove unnecessary test setup options since the go plugin is configured already as a backend for the repository.

[ci skip-rust]
[ci skip-build-wheels]