### PR TITLE
[internal] go: remove `dependencies` field from `go_binary` target type

### DIFF
--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -149,7 +149,7 @@ class GoBinaryMainAddress(StringField):
 
 class GoBinary(Target):
     alias = "go_binary"
-    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, OutputPathField, GoBinaryMainAddress)
+    core_fields = (*COMMON_TARGET_FIELDS, OutputPathField, GoBinaryMainAddress)
     help = "A Go binary."
 
 


### PR DESCRIPTION
Remove the `dependencies` field from the `go_binary` target type since all dependencies should come through the `main` package. (And the existing `package` rule was not including `dependencies` in any event.)

[ci skip-rust]
[ci skip-build-wheels]