### PR TITLE
Add `engine_error()` context manager for testing plugin exceptions

### DIFF
--- a/src/python/pants/backend/awslambda/python/target_types_test.py
+++ b/src/python/pants/backend/awslambda/python/target_types_test.py
@@ -20,7 +20,7 @@ from pants.backend.python.target_types import PythonLibrary, PythonRequirementLi
 from pants.backend.python.target_types_rules import rules as python_target_types_rules
 from pants.build_graph.address import Address
 from pants.engine.target import InjectedDependencies, InvalidFieldException
-from pants.testutil.rule_runner import EngineErrorTrap, QueryRule, RuleRunner
+from pants.testutil.rule_runner import QueryRule, RuleRunner, engine_error
 
 
 @pytest.fixture
@@ -90,10 +90,10 @@ def test_resolve_handler(rule_runner: RuleRunner) -> None:
     assert_resolved("path.to.lambda:func", expected="path.to.lambda:func", is_file=False)
     assert_resolved("lambda.py:func", expected="project.lambda:func", is_file=True)
 
-    with EngineErrorTrap(contains="Unmatched glob"):
+    with engine_error(contains="Unmatched glob"):
         assert_resolved("doesnt_exist.py:func", expected="doesnt matter", is_file=True)
     # Resolving >1 file is an error.
-    with EngineErrorTrap(InvalidFieldException):
+    with engine_error(InvalidFieldException):
         assert_resolved("*.py:func", expected="doesnt matter", is_file=True)
 
 

--- a/src/python/pants/backend/awslambda/python/target_types_test.py
+++ b/src/python/pants/backend/awslambda/python/target_types_test.py
@@ -90,13 +90,11 @@ def test_resolve_handler(rule_runner: RuleRunner) -> None:
     assert_resolved("path.to.lambda:func", expected="path.to.lambda:func", is_file=False)
     assert_resolved("lambda.py:func", expected="project.lambda:func", is_file=True)
 
-    with EngineErrorTrap() as trap:
+    with EngineErrorTrap(contains="Unmatched glob"):
         assert_resolved("doesnt_exist.py:func", expected="doesnt matter", is_file=True)
-    assert "Unmatched glob" in str(trap.e)
     # Resolving >1 file is an error.
-    with EngineErrorTrap() as trap:
+    with EngineErrorTrap(InvalidFieldException):
         assert_resolved("*.py:func", expected="doesnt matter", is_file=True)
-    assert isinstance(trap.e, InvalidFieldException)
 
 
 def test_inject_handler_dependency(rule_runner: RuleRunner, caplog) -> None:

--- a/src/python/pants/backend/go/util_rules/external_module_test.py
+++ b/src/python/pants/backend/go/util_rules/external_module_test.py
@@ -126,13 +126,13 @@ def test_download_modules(rule_runner: RuleRunner) -> None:
 
 def test_download_modules_missing_module(rule_runner: RuleRunner) -> None:
     input_digest = rule_runner.make_snapshot({"go.mod": GO_MOD, "go.sum": GO_SUM}).digest
-    with EngineErrorTrap() as trap:
+    with EngineErrorTrap(
+        AssertionError, contains="The module some_project.org/project@v1.1 was not downloaded"
+    ):
         rule_runner.request(
             DownloadedModule,
             [DownloadedModuleRequest("some_project.org/project", "v1.1", input_digest)],
         )
-    assert isinstance(trap.e, AssertionError)
-    assert "The module some_project.org/project@v1.1 was not downloaded" in str(trap.e)
 
 
 def test_download_modules_invalid_go_sum(rule_runner: RuleRunner) -> None:
@@ -153,10 +153,8 @@ def test_download_modules_invalid_go_sum(rule_runner: RuleRunner) -> None:
             ),
         }
     ).digest
-    with EngineErrorTrap() as trap:
+    with EngineErrorTrap(ProcessExecutionFailure, contains="SECURITY ERROR"):
         rule_runner.request(AllDownloadedModules, [AllDownloadedModulesRequest(input_digest)])
-    assert isinstance(trap.e, ProcessExecutionFailure)
-    assert "SECURITY ERROR" in str(trap.e)
 
 
 def test_download_modules_missing_go_sum(rule_runner: RuleRunner) -> None:
@@ -178,9 +176,8 @@ def test_download_modules_missing_go_sum(rule_runner: RuleRunner) -> None:
             ),
         }
     ).digest
-    with EngineErrorTrap() as trap:
+    with EngineErrorTrap(contains="`go.mod` and/or `go.sum` changed!"):
         rule_runner.request(AllDownloadedModules, [AllDownloadedModulesRequest(input_digest)])
-    assert "`go.mod` and/or `go.sum` changed!" in str(trap.e)
 
 
 def test_determine_external_package_info(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/go/util_rules/external_module_test.py
+++ b/src/python/pants/backend/go/util_rules/external_module_test.py
@@ -22,10 +22,9 @@ from pants.backend.go.util_rules.external_module import (
 from pants.backend.go.util_rules.go_pkg import ResolvedGoPackage
 from pants.engine.addresses import Address
 from pants.engine.fs import Digest, PathGlobs, Snapshot
-from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.process import ProcessExecutionFailure
 from pants.engine.rules import QueryRule
-from pants.testutil.rule_runner import RuleRunner
+from pants.testutil.rule_runner import EngineErrorTrap, RuleRunner
 
 
 @pytest.fixture
@@ -127,16 +126,13 @@ def test_download_modules(rule_runner: RuleRunner) -> None:
 
 def test_download_modules_missing_module(rule_runner: RuleRunner) -> None:
     input_digest = rule_runner.make_snapshot({"go.mod": GO_MOD, "go.sum": GO_SUM}).digest
-    with pytest.raises(ExecutionError) as exc:
+    with EngineErrorTrap() as trap:
         rule_runner.request(
             DownloadedModule,
             [DownloadedModuleRequest("some_project.org/project", "v1.1", input_digest)],
         )
-    underlying_exception = exc.value.wrapped_exceptions[0]
-    assert isinstance(underlying_exception, AssertionError)
-    assert "The module some_project.org/project@v1.1 was not downloaded" in str(
-        underlying_exception
-    )
+    assert isinstance(trap.e, AssertionError)
+    assert "The module some_project.org/project@v1.1 was not downloaded" in str(trap.e)
 
 
 def test_download_modules_invalid_go_sum(rule_runner: RuleRunner) -> None:
@@ -157,11 +153,10 @@ def test_download_modules_invalid_go_sum(rule_runner: RuleRunner) -> None:
             ),
         }
     ).digest
-    with pytest.raises(ExecutionError) as exc:
+    with EngineErrorTrap() as trap:
         rule_runner.request(AllDownloadedModules, [AllDownloadedModulesRequest(input_digest)])
-    underlying_exception = exc.value.wrapped_exceptions[0]
-    assert isinstance(underlying_exception, ProcessExecutionFailure)
-    assert "SECURITY ERROR" in str(underlying_exception)
+    assert isinstance(trap.e, ProcessExecutionFailure)
+    assert "SECURITY ERROR" in str(trap.e)
 
 
 def test_download_modules_missing_go_sum(rule_runner: RuleRunner) -> None:
@@ -183,10 +178,9 @@ def test_download_modules_missing_go_sum(rule_runner: RuleRunner) -> None:
             ),
         }
     ).digest
-    with pytest.raises(ExecutionError) as exc:
+    with EngineErrorTrap() as trap:
         rule_runner.request(AllDownloadedModules, [AllDownloadedModulesRequest(input_digest)])
-    underlying_exception = exc.value.wrapped_exceptions[0]
-    assert "`go.mod` and/or `go.sum` changed!" in str(underlying_exception)
+    assert "`go.mod` and/or `go.sum` changed!" in str(trap.e)
 
 
 def test_determine_external_package_info(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/go/util_rules/external_module_test.py
+++ b/src/python/pants/backend/go/util_rules/external_module_test.py
@@ -24,7 +24,7 @@ from pants.engine.addresses import Address
 from pants.engine.fs import Digest, PathGlobs, Snapshot
 from pants.engine.process import ProcessExecutionFailure
 from pants.engine.rules import QueryRule
-from pants.testutil.rule_runner import EngineErrorTrap, RuleRunner
+from pants.testutil.rule_runner import RuleRunner, engine_error
 
 
 @pytest.fixture
@@ -126,7 +126,7 @@ def test_download_modules(rule_runner: RuleRunner) -> None:
 
 def test_download_modules_missing_module(rule_runner: RuleRunner) -> None:
     input_digest = rule_runner.make_snapshot({"go.mod": GO_MOD, "go.sum": GO_SUM}).digest
-    with EngineErrorTrap(
+    with engine_error(
         AssertionError, contains="The module some_project.org/project@v1.1 was not downloaded"
     ):
         rule_runner.request(
@@ -153,7 +153,7 @@ def test_download_modules_invalid_go_sum(rule_runner: RuleRunner) -> None:
             ),
         }
     ).digest
-    with EngineErrorTrap(ProcessExecutionFailure, contains="SECURITY ERROR"):
+    with engine_error(ProcessExecutionFailure, contains="SECURITY ERROR"):
         rule_runner.request(AllDownloadedModules, [AllDownloadedModulesRequest(input_digest)])
 
 
@@ -176,7 +176,7 @@ def test_download_modules_missing_go_sum(rule_runner: RuleRunner) -> None:
             ),
         }
     ).digest
-    with EngineErrorTrap(contains="`go.mod` and/or `go.sum` changed!"):
+    with engine_error(contains="`go.mod` and/or `go.sum` changed!"):
         rule_runner.request(AllDownloadedModules, [AllDownloadedModulesRequest(input_digest)])
 
 

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -87,32 +87,31 @@ def engine_error(
         with engine_error(ValueError, contains="foo"):
             rule_runner.request(OutputType, [input])
 
-    Will raise AssertionError if no ExecutionError occurred. Will not catch any other exception
-    types.
+    Will raise AssertionError if no ExecutionError occurred.
     """
     try:
         yield
-    except ExecutionError as e:
-        if not len(e.wrapped_exceptions) == 1:
-            formatted_errors = "\n\n".join(repr(e) for e in e.wrapped_exceptions)
+    except ExecutionError as exec_error:
+        if not len(exec_error.wrapped_exceptions) == 1:
+            formatted_errors = "\n\n".join(repr(e) for e in exec_error.wrapped_exceptions)
             raise ValueError(
                 "Multiple underlying exceptions, but this helper function expected only one. "
                 "Use `with pytest.raises(ExecutionError) as exc` directly and inspect "
                 "`exc.value.wrapped_exceptions`.\n\n"
                 f"Errors: {formatted_errors}"
             )
-        underlying = e.wrapped_exceptions[0]
+        underlying = exec_error.wrapped_exceptions[0]
         if not isinstance(underlying, expected_underlying_exception):
             raise AssertionError(
                 "ExecutionError occurred as expected, but the underlying exception had type "
                 f"{type(underlying)} rather than the expected type "
                 f"{expected_underlying_exception}."
             )
-        if contains is not None and contains not in str(e):
+        if contains is not None and contains not in str(underlying):
             raise AssertionError(
                 "Expected value not found in exception.\n"
                 f"expected: {contains}\n\n"
-                f"exception: {e}"
+                f"exception: {underlying}"
             )
 
 


### PR DESCRIPTION
This makes it much easier to test that we raise the appropriate exceptions in rule code.

Thanks to @chrisjrn for co-developing this.

[ci skip-rust]
[ci skip-build-wheels]