### PR TITLE
An explicit generate_setup field on python_distribution.

### DIFF
--- a/src/python/pants/backend/python/goals/setup_py_test.py
+++ b/src/python/pants/backend/python/goals/setup_py_test.py
@@ -169,8 +169,9 @@ def test_use_existing_setup_script(chroot_rule_runner) -> None:
                 dependencies=[
                     ':setup',
                 ],
+                generate_setup=False,
                 provides=setup_py(
-                    name='foo', version='1.2.3'
+                    name='foo', version='1.2.3',
                 )
             )
 

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -1037,12 +1037,13 @@ class SetupPyCommandsField(StringSequenceField):
     )
 
 
-class GenerateSetupField(BoolField):
+class GenerateSetupField(TriBoolField):
     alias = "generate_setup"
-    # Generating setup is the more aggressive thing to do, so we'd prefer that the default be False.
-    # However that would break widespread existing usage, so we'll make that change in a future
-    # deprecation cycle.
-    default = True
+    required = False
+    # The default behavior if this field is unspecified is controlled by the
+    # --generate-setup-default option in the setup-py-generation scope.
+    default = None
+
     help = (
         "Whether to generate setup information for this distribution, based on analyzing "
         "sources and dependencies. Set to False to use existing setup information, such as "

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -1037,6 +1037,19 @@ class SetupPyCommandsField(StringSequenceField):
     )
 
 
+class GenerateSetupField(BoolField):
+    alias = "generate_setup"
+    # Generating setup is the more aggressive thing to do, so we'd prefer that the default be False.
+    # However that would break widespread existing usage, so we'll make that change in a future
+    # deprecation cycle.
+    default = True
+    help = (
+        "Whether to generate setup information for this distribution, based on analyzing "
+        "sources and dependencies. Set to False to use existing setup information, such as "
+        "existing setup.py, setup.cfg, pyproject.toml files or similar."
+    )
+
+
 class PythonDistribution(Target):
     alias = "python_distribution"
     core_fields = (
@@ -1044,6 +1057,7 @@ class PythonDistribution(Target):
         PythonDistributionDependencies,
         PythonDistributionEntryPointsField,
         PythonProvidesField,
+        GenerateSetupField,
         WheelField,
         SDistField,
         WheelConfigSettingsField,

--- a/testprojects/src/python/native/BUILD
+++ b/testprojects/src/python/native/BUILD
@@ -11,10 +11,10 @@ resources(name="impl", sources=["*.c"])
 python_distribution(
     name = "dist",
     dependencies = [":impl", ":lib"],
+    generate_setup = False,
     provides = python_artifact(
         name = "native",
         version = "2.3.4",
-        setup_script='setup.py',
     ),
     sdist = False,
     wheel_config_settings = {"--global-option": ["--python-tag", "py36.py37"]}


### PR DESCRIPTION
Instead of attempting to guess user intent by the presence
of an existing setup.py.

This will give us room to use alternative existing setup files,
such as setup.cfg etc.

[ci skip-rust]

[ci skip-build-wheels]