### PR TITLE
[internal] Stop setting `import_path="main"` for Go packages

### DIFF
--- a/src/python/pants/backend/go/util_rules/build_go_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/build_go_pkg_test.py
@@ -87,12 +87,14 @@ def test_build_internal_pkg(rule_runner: RuleRunner) -> None:
             "BUILD": dedent(
                 """\
                 go_mod(name="mod")
-                go_package(name="pkg", import_path='main')
+                go_package(name="pkg")
                 """
             ),
         }
     )
-    assert_built(rule_runner, Address("", target_name="pkg"), expected_import_paths=["main"])
+    assert_built(
+        rule_runner, Address("", target_name="pkg"), expected_import_paths=["example.com/greeter"]
+    )
 
 
 def test_build_external_pkg(rule_runner: RuleRunner) -> None:
@@ -144,7 +146,7 @@ def test_build_dependencies(rule_runner: RuleRunner) -> None:
 
                 import (
                     "fmt"
-                    "example.com/greeter/quoter"
+                    "example.com/project/greeter/quoter"
                     "golang.org/x/xerrors"
                 )
 
@@ -159,7 +161,7 @@ def test_build_dependencies(rule_runner: RuleRunner) -> None:
                 """\
                 package main
 
-                import "example.com/greeter"
+                import "example.com/project/greeter"
 
                 func main() {
                     greeter.QuotedHello()
@@ -168,7 +170,7 @@ def test_build_dependencies(rule_runner: RuleRunner) -> None:
             ),
             "go.mod": dedent(
                 """\
-                module example.com
+                module example.com/project
                 go 1.17
                 require golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
                 """
@@ -182,7 +184,7 @@ def test_build_dependencies(rule_runner: RuleRunner) -> None:
             "BUILD": dedent(
                 """\
                 go_mod(name='mod')
-                go_package(name='pkg', import_path='main')
+                go_package(name='pkg')
                 """
             ),
         }
@@ -202,14 +204,18 @@ def test_build_dependencies(rule_runner: RuleRunner) -> None:
         expected_import_paths=xerrors_import_paths,
     )
 
-    quoter_import_path = "example.com/greeter/quoter"
+    quoter_import_path = "example.com/project/greeter/quoter"
     assert_built(rule_runner, Address("greeter/quoter"), expected_import_paths=[quoter_import_path])
 
-    greeter_import_paths = ["example.com/greeter", quoter_import_path, *xerrors_import_paths]
+    greeter_import_paths = [
+        "example.com/project/greeter",
+        quoter_import_path,
+        *xerrors_import_paths,
+    ]
     assert_built(rule_runner, Address("greeter"), expected_import_paths=greeter_import_paths)
 
     assert_built(
         rule_runner,
         Address("", target_name="pkg"),
-        expected_import_paths=["main", *greeter_import_paths],
+        expected_import_paths=["example.com/project", *greeter_import_paths],
     )

--- a/src/python/pants/backend/go/util_rules/go_pkg.py
+++ b/src/python/pants/backend/go/util_rules/go_pkg.py
@@ -199,6 +199,7 @@ async def resolve_go_package(
     go_mod_spec_path = owning_go_mod.address.spec_path
     assert request.address.spec_path.startswith(go_mod_spec_path)
     spec_subpath = request.address.spec_path[len(go_mod_spec_path) :]
+    print(request.address.spec_path, go_mod_spec_path, spec_subpath)
 
     go_mod_info, pkg_sources = await MultiGet(
         Get(GoModInfo, GoModInfoRequest(owning_go_mod.address)),
@@ -217,11 +218,9 @@ async def resolve_go_package(
         # Otherwise infer the import path from the owning `go_mod` target. The inferred import
         # path will be the module's import path plus any subdirectories in the spec_path
         # between the go_mod and go_package target.
-        import_path = f"{go_mod_info.import_path}/"
-        if spec_subpath.startswith("/"):
-            import_path += spec_subpath[1:]
-        else:
-            import_path += spec_subpath
+        import_path = f"{go_mod_info.import_path}"
+        if spec_subpath:
+            import_path += spec_subpath if spec_subpath.startswith("/") else f"/{spec_subpath}"
 
     result = await Get(
         ProcessResult,

--- a/testprojects/src/go/pants_test/BUILD
+++ b/testprojects/src/go/pants_test/BUILD
@@ -2,8 +2,4 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 go_package()
-
-go_binary(
-    name="bin",
-    main=":pants_test",
-)
+go_binary(name="bin", main=":pants_test")

--- a/testprojects/src/go/pants_test/bar/BUILD
+++ b/testprojects/src/go/pants_test/bar/BUILD
@@ -1,7 +1,5 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-go_package(
-    import_path="github.com/toolchainlabs/toolchain/src/go/src/toolchain/pants_test/bar",
-)
+go_package()
 

--- a/testprojects/src/go/pants_test/bar/bar.go
+++ b/testprojects/src/go/pants_test/bar/bar.go
@@ -1,5 +1,11 @@
 package bar
 
+import "github.com/google/uuid"
+
+func GenUuid() string {
+    return uuid.NewString()
+}
+
 func Quote(s string) string {
 	return ">> " + s + " <<"
 }

--- a/testprojects/src/go/pants_test/foo.go
+++ b/testprojects/src/go/pants_test/foo.go
@@ -3,8 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
-
-	"github.com/toolchainlabs/toolchain/src/go/src/toolchain/pants_test/bar"
+	"github.com/pantsbuild/pants/testprojects/src/go/pants_test/bar"
 )
 
 func main() {


### PR DESCRIPTION
Given a project with `module = example.com/foo` in `go.mod`, and `hello.go` with `package main` in it, `go list -json` will report the `ImportPath` as `example.com/foo`, _not_ `main`. So it was wrong for us to be overriding the `import_path` to be `main`.

This is important for dependency inference to work properly when there are multiple `go.mod`s in the project. Dependency inference maps import paths to targets, and we'd have ambiguity if there were multiple `main` import paths.

This also fixes our calculation of `import_path` to not include a `/` suffix when the `package` is in the same directory as the `go.mod`, i.e. we should use `example.com/foo`, not `example.com/foo/`.

[ci skip-rust]
[ci skip-build-wheels]