### PR TITLE
[internal] Infer `main` field for `go_binary`

### DIFF
--- a/src/python/pants/backend/experimental/go/register.py
+++ b/src/python/pants/backend/experimental/go/register.py
@@ -2,13 +2,17 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.backend.go import target_type_rules
-from pants.backend.go import target_types as go_target_types
 from pants.backend.go.goals import custom_goals, package_binary, tailor
 from pants.backend.go.lint import fmt
 from pants.backend.go.lint.gofmt import skip_field as gofmt_skip_field
 from pants.backend.go.lint.gofmt.rules import rules as gofmt_rules
 from pants.backend.go.subsystems import golang
-from pants.backend.go.target_types import GoBinary, GoExternalPackageTarget, GoModTarget, GoPackage
+from pants.backend.go.target_types import (
+    GoBinaryTarget,
+    GoExternalPackageTarget,
+    GoModTarget,
+    GoPackage,
+)
 from pants.backend.go.util_rules import (
     assembly,
     build_go_pkg,
@@ -24,7 +28,7 @@ from pants.backend.go.util_rules import (
 
 
 def target_types():
-    return [GoBinary, GoPackage, GoModTarget, GoExternalPackageTarget]
+    return [GoModTarget, GoPackage, GoExternalPackageTarget, GoBinaryTarget]
 
 
 def rules():
@@ -34,7 +38,6 @@ def rules():
         *compile.rules(),
         *external_module.rules(),
         *golang.rules(),
-        *go_target_types.rules(),
         *import_analysis.rules(),
         *go_mod.rules(),
         *go_pkg.rules(),

--- a/src/python/pants/backend/go/goals/package_binary_integration_test.py
+++ b/src/python/pants/backend/go/goals/package_binary_integration_test.py
@@ -12,7 +12,7 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals import package_binary
 from pants.backend.go.goals.package_binary import GoBinaryFieldSet
-from pants.backend.go.target_types import GoBinary, GoModTarget, GoPackage
+from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackage
 from pants.backend.go.util_rules import (
     assembly,
     build_go_pkg,
@@ -50,7 +50,7 @@ def rule_runner() -> RuleRunner:
             *sdk.rules(),
             QueryRule(BuiltPackage, (GoBinaryFieldSet,)),
         ],
-        target_types=[GoBinary, GoPackage, GoModTarget],
+        target_types=[GoBinaryTarget, GoPackage, GoModTarget],
     )
     rule_runner.set_options([], env_inherit={"PATH"})
     return rule_runner
@@ -88,8 +88,8 @@ def test_package_simple(rule_runner: RuleRunner) -> None:
             "BUILD": dedent(
                 """\
                 go_mod(name='mod')
-                go_package(name='main')
-                go_binary(name='bin', main=':main')
+                go_package(name='pkg')
+                go_binary(name='bin')
                 """
             ),
         }
@@ -165,8 +165,8 @@ def test_package_with_dependencies(rule_runner: RuleRunner) -> None:
             "BUILD": dedent(
                 """\
                 go_mod(name='mod')
-                go_package(name='main')
-                go_binary(name='bin', main=':main')
+                go_package(name='pkg')
+                go_binary(name='bin')
                 """
             ),
         }

--- a/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
@@ -10,7 +10,7 @@ import pytest
 from pants.backend.go.lint import fmt
 from pants.backend.go.lint.gofmt.rules import GofmtFieldSet, GofmtRequest
 from pants.backend.go.lint.gofmt.rules import rules as gofmt_rules
-from pants.backend.go.target_types import GoBinary, GoPackage
+from pants.backend.go.target_types import GoBinaryTarget, GoPackage
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintResult, LintResults
 from pants.core.util_rules import source_files
@@ -24,7 +24,7 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 @pytest.fixture()
 def rule_runner() -> RuleRunner:
     return RuleRunner(
-        target_types=[GoBinary, GoPackage],
+        target_types=[GoBinaryTarget, GoPackage],
         rules=[
             *fmt.rules(),
             *gofmt_rules(),

--- a/src/python/pants/backend/go/target_type_rules_test.py
+++ b/src/python/pants/backend/go/target_type_rules_test.py
@@ -1,6 +1,9 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-import textwrap
+
+from __future__ import annotations
+
+from textwrap import dedent
 
 import pytest
 
@@ -8,8 +11,13 @@ from pants.backend.go import target_type_rules
 from pants.backend.go.target_type_rules import (
     GenerateGoExternalPackageTargetsRequest,
     InferGoPackageDependenciesRequest,
+    InjectGoBinaryMainDependencyRequest,
 )
 from pants.backend.go.target_types import (
+    GoBinaryMainPackage,
+    GoBinaryMainPackageField,
+    GoBinaryMainPackageRequest,
+    GoBinaryTarget,
     GoExternalModulePathField,
     GoExternalModuleVersionField,
     GoExternalPackageImportPathField,
@@ -20,7 +28,9 @@ from pants.backend.go.target_types import (
     GoPackageSources,
 )
 from pants.backend.go.util_rules import external_module, go_mod, go_pkg, sdk
+from pants.base.exceptions import ResolveError
 from pants.build_graph.address import Address
+from pants.core.target_types import GenericTarget
 from pants.engine.addresses import Addresses
 from pants.engine.rules import QueryRule
 from pants.engine.target import (
@@ -28,10 +38,12 @@ from pants.engine.target import (
     DependenciesRequest,
     GeneratedTargets,
     InferredDependencies,
+    InjectedDependencies,
+    InvalidFieldException,
     Target,
     Targets,
 )
-from pants.testutil.rule_runner import RuleRunner
+from pants.testutil.rule_runner import RuleRunner, engine_error
 from pants.util.ordered_set import FrozenOrderedSet
 
 
@@ -45,8 +57,16 @@ def rule_runner() -> RuleRunner:
             *sdk.rules(),
             *target_type_rules.rules(),
             QueryRule(Addresses, [DependenciesRequest]),
+            QueryRule(GoBinaryMainPackage, [GoBinaryMainPackageRequest]),
+            QueryRule(InjectedDependencies, [InjectGoBinaryMainDependencyRequest]),
         ],
-        target_types=[GoPackage, GoModTarget, GoExternalPackageTarget],
+        target_types=[
+            GoPackage,
+            GoModTarget,
+            GoExternalPackageTarget,
+            GoBinaryTarget,
+            GenericTarget,
+        ],
     )
     rule_runner.set_options([], env_inherit={"PATH"})
     return rule_runner
@@ -86,7 +106,7 @@ def test_go_package_dependency_inference(rule_runner: RuleRunner) -> None:
         (
             {
                 "foo/BUILD": "go_mod()",
-                "foo/go.mod": textwrap.dedent(
+                "foo/go.mod": dedent(
                     """\
                     module go.example.com/foo
                     go 1.17
@@ -94,7 +114,7 @@ def test_go_package_dependency_inference(rule_runner: RuleRunner) -> None:
                     require github.com/google/go-cmp v0.4.0
                     """
                 ),
-                "foo/go.sum": textwrap.dedent(
+                "foo/go.sum": dedent(
                     """\
                     github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
                     github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -103,7 +123,7 @@ def test_go_package_dependency_inference(rule_runner: RuleRunner) -> None:
                     """
                 ),
                 "foo/pkg/BUILD": "go_package()\n",
-                "foo/pkg/foo.go": textwrap.dedent(
+                "foo/pkg/foo.go": dedent(
                     """\
                     package pkg
                     import "github.com/google/go-cmp/cmp"
@@ -113,7 +133,7 @@ def test_go_package_dependency_inference(rule_runner: RuleRunner) -> None:
                     """
                 ),
                 "foo/cmd/BUILD": "go_package()\n",
-                "foo/cmd/main.go": textwrap.dedent(
+                "foo/cmd/main.go": dedent(
                     """\
                     package main
                     import (
@@ -151,7 +171,7 @@ def test_generate_go_external_package_targets(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
             "src/go/BUILD": "go_mod()\n",
-            "src/go/go.mod": textwrap.dedent(
+            "src/go/go.mod": dedent(
                 """\
                 module example.com/src/go
                 go 1.17
@@ -162,7 +182,7 @@ def test_generate_go_external_package_targets(rule_runner: RuleRunner) -> None:
                 )
                 """
             ),
-            "src/go/go.sum": textwrap.dedent(
+            "src/go/go.sum": dedent(
                 """\
                 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
                 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -231,3 +251,62 @@ def test_generate_go_external_package_targets(rule_runner: RuleRunner) -> None:
     )
     assert list(generated.keys()) == list(expected.keys())
     assert generated == expected
+
+
+# -----------------------------------------------------------------------------------------------
+# The `main` field for `go_binary`
+# -----------------------------------------------------------------------------------------------
+
+
+def test_determine_main_pkg_for_go_binary(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "explicit/BUILD": dedent(
+                """\
+                go_package(name='pkg', sources=[])
+                go_binary(main=':pkg')
+                """
+            ),
+            "inferred/BUILD": dedent(
+                """\
+                go_package(name='pkg', sources=[])
+                go_binary()
+                """
+            ),
+            "ambiguous/BUILD": dedent(
+                """\
+                go_package(name='pkg1', sources=[])
+                go_package(name='pkg2', sources=[])
+                go_binary()
+                """
+            ),
+            "missing/BUILD": "go_binary()",
+            "explicit_wrong_type/BUILD": dedent(
+                """\
+                target(name='dep')
+                go_binary(main=':dep')
+                """
+            ),
+        }
+    )
+
+    def get_main(addr: Address) -> Address:
+        tgt = rule_runner.get_target(addr)
+        main_addr = rule_runner.request(
+            GoBinaryMainPackage, [GoBinaryMainPackageRequest(tgt[GoBinaryMainPackageField])]
+        ).address
+        injected_addresses = rule_runner.request(
+            InjectedDependencies, [InjectGoBinaryMainDependencyRequest(tgt[Dependencies])]
+        )
+        assert [main_addr] == list(injected_addresses)
+        return main_addr
+
+    assert get_main(Address("explicit")) == Address("explicit", target_name="pkg")
+    assert get_main(Address("inferred")) == Address("inferred", target_name="pkg")
+
+    with engine_error(ResolveError, contains="none were found"):
+        get_main(Address("missing"))
+    with engine_error(ResolveError, contains="There are multiple `go_package` targets"):
+        get_main(Address("ambiguous"))
+    with engine_error(InvalidFieldException, contains="must point to a `go_package` target"):
+        get_main(Address("explicit_wrong_type"))

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -150,7 +150,7 @@ class GoBinaryMainPackageField(StringField, AsyncFieldMixin):
     alias = "main"
     help = (
         "Address of the `go_package` with the `main` for this binary.\n\n"
-        "If left off, will default to the `go_package` in the same directory as this target's "
+        "If not specified, will default to the `go_package` in the same directory as this target's "
         "BUILD file."
     )
     value: str

--- a/src/python/pants/backend/go/util_rules/assembly_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/assembly_integration_test.py
@@ -12,7 +12,7 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals import package_binary
 from pants.backend.go.goals.package_binary import GoBinaryFieldSet
-from pants.backend.go.target_types import GoBinary, GoModTarget, GoPackage
+from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackage
 from pants.backend.go.util_rules import (
     assembly,
     build_go_pkg,
@@ -50,7 +50,7 @@ def rule_runner() -> RuleRunner:
             *sdk.rules(),
             QueryRule(BuiltPackage, (GoBinaryFieldSet,)),
         ],
-        target_types=[GoBinary, GoPackage, GoModTarget],
+        target_types=[GoBinaryTarget, GoPackage, GoModTarget],
     )
     rule_runner.set_options([], env_inherit={"PATH"})
     return rule_runner
@@ -114,7 +114,7 @@ def test_build_package_with_assembly(rule_runner: RuleRunner) -> None:
                 """\
                 go_mod(name="mod")
                 go_package(name="pkg")
-                go_binary(name="bin", main=":pkg")
+                go_binary(name="bin")
                 """
             ),
         }

--- a/testprojects/src/go/pants_test/BUILD
+++ b/testprojects/src/go/pants_test/BUILD
@@ -2,8 +2,4 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 go_package()
-
-go_binary(
-    name="bin",
-    main=":pants_test",
-)
+go_binary(name="bin")


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/13115. 

For now, we allow you to still explicitly set the field, which gives an escape valve if >1 `go_package` exist for the same directory.