### PR TITLE
[Internal] Fix type typo.

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -117,7 +117,7 @@ class PythonInferSubsystem(Subsystem):
 
     @property
     def string_imports_min_dots(self) -> int:
-        return cast(bool, self.options.string_imports_min_dots)
+        return cast(int, self.options.string_imports_min_dots)
 
     @property
     def inits(self) -> bool:


### PR DESCRIPTION
Fix copy paste bug from #13059 

Interestingly that mypy didn't catch this.. ?

# Rust tests and lints will be skipped. Delete if not intended.
[ci skip-rust]

# Building wheels and fs_util will be skipped. Delete if not intended.
[ci skip-build-wheels]