### PR TITLE
Improve a couple of log messages.

### DIFF
--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -60,8 +60,8 @@ class _ExceptionFormatter(Formatter):
         )
 
         return (
-            f"{stacktrace}\n\n({debug_instructions}See {doc_url('troubleshooting')} for common issues. "
-            f"Consider reaching out for help: {doc_url('getting-help')}.)"
+            f"{stacktrace}\n\n{debug_instructions}\nSee {doc_url('troubleshooting')} for common "
+            f"issues.\nConsider reaching out for help: {doc_url('getting-help')}\n"
         )
 
 

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -284,8 +284,9 @@ impl super::CommandRunner for CommandRunner {
             // that the temporary directory will no longer be automatically deleted when dropped.
             let preserved_path = workdir.into_path();
             info!(
-              "preserving local process execution dir `{:?}` for {:?}",
-              preserved_path, req.description
+              "Preserving local process execution dir {} for {:?}",
+              preserved_path.display(),
+              req.description
             );
             (preserved_path, None)
           }


### PR DESCRIPTION

- Our log messages are usually capitalized, so the preserving local process dir one should be too.
- backtick-double-quote-path is much harder to select and copy than just the raw path string.
- The dot at the end of the getting-help URL might be selected and copied, which would be wrong.

[ci skip-build-wheels]