### PR TITLE
[internal] Improve performance of Go dependency inference

### DIFF
--- a/src/python/pants/backend/go/target_type_rules_test.py
+++ b/src/python/pants/backend/go/target_type_rules_test.py
@@ -22,6 +22,7 @@ from pants.backend.go.target_types import (
     GoExternalModuleVersionField,
     GoExternalPackageImportPathField,
     GoExternalPackageTarget,
+    GoImportPathsDependenciesField,
     GoModSourcesField,
     GoModTarget,
     GoPackage,
@@ -199,12 +200,15 @@ def test_generate_go_external_package_targets(rule_runner: RuleRunner) -> None:
         GeneratedTargets, [GenerateGoExternalPackageTargetsRequest(generator)]
     )
 
-    def gen_tgt(mod_path: str, version: str, import_path: str) -> GoExternalPackageTarget:
+    def gen_tgt(
+        mod_path: str, version: str, import_path: str, import_path_deps: list[str]
+    ) -> GoExternalPackageTarget:
         return GoExternalPackageTarget(
             {
                 GoExternalModulePathField.alias: mod_path,
                 GoExternalModuleVersionField.alias: version,
                 GoExternalPackageImportPathField.alias: import_path,
+                GoImportPathsDependenciesField.alias: import_path_deps,
             },
             Address("src/go", generated_name=import_path),
         )
@@ -212,40 +216,127 @@ def test_generate_go_external_package_targets(rule_runner: RuleRunner) -> None:
     expected = GeneratedTargets(
         generator,
         {
-            gen_tgt("github.com/google/uuid", "v1.2.0", "github.com/google/uuid"),
-            gen_tgt("github.com/google/go-cmp", "v0.4.0", "github.com/google/go-cmp/cmp"),
-            gen_tgt("github.com/google/go-cmp", "v0.4.0", "github.com/google/go-cmp/cmp/cmpopts"),
             gen_tgt(
-                "github.com/google/go-cmp", "v0.4.0", "github.com/google/go-cmp/cmp/internal/diff"
+                "github.com/google/uuid",
+                "v1.2.0",
+                "github.com/google/uuid",
+                [
+                    "bytes",
+                    "crypto/md5",
+                    "crypto/rand",
+                    "crypto/sha1",
+                    "database/sql/driver",
+                    "encoding/binary",
+                    "encoding/hex",
+                    "errors",
+                    "fmt",
+                    "hash",
+                    "io",
+                    "net",
+                    "os",
+                    "strings",
+                    "sync",
+                    "time",
+                ],
             ),
             gen_tgt(
-                "github.com/google/go-cmp", "v0.4.0", "github.com/google/go-cmp/cmp/internal/flags"
+                "github.com/google/go-cmp",
+                "v0.4.0",
+                "github.com/google/go-cmp/cmp",
+                [
+                    "bytes",
+                    "fmt",
+                    "github.com/google/go-cmp/cmp/internal/diff",
+                    "github.com/google/go-cmp/cmp/internal/flags",
+                    "github.com/google/go-cmp/cmp/internal/function",
+                    "github.com/google/go-cmp/cmp/internal/value",
+                    "math/rand",
+                    "reflect",
+                    "regexp",
+                    "strconv",
+                    "strings",
+                    "time",
+                    "unicode",
+                    "unicode/utf8",
+                    "unsafe",
+                ],
+            ),
+            gen_tgt(
+                "github.com/google/go-cmp",
+                "v0.4.0",
+                "github.com/google/go-cmp/cmp/cmpopts",
+                [
+                    "fmt",
+                    "github.com/google/go-cmp/cmp",
+                    "github.com/google/go-cmp/cmp/internal/function",
+                    "golang.org/x/xerrors",
+                    "math",
+                    "reflect",
+                    "sort",
+                    "strings",
+                    "time",
+                    "unicode",
+                    "unicode/utf8",
+                ],
+            ),
+            gen_tgt(
+                "github.com/google/go-cmp",
+                "v0.4.0",
+                "github.com/google/go-cmp/cmp/internal/diff",
+                [],
+            ),
+            gen_tgt(
+                "github.com/google/go-cmp",
+                "v0.4.0",
+                "github.com/google/go-cmp/cmp/internal/flags",
+                [],
             ),
             gen_tgt(
                 "github.com/google/go-cmp",
                 "v0.4.0",
                 "github.com/google/go-cmp/cmp/internal/function",
+                ["reflect", "regexp", "runtime", "strings"],
             ),
             gen_tgt(
                 "github.com/google/go-cmp",
                 "v0.4.0",
                 "github.com/google/go-cmp/cmp/internal/testprotos",
+                [],
             ),
             gen_tgt(
                 "github.com/google/go-cmp",
                 "v0.4.0",
                 "github.com/google/go-cmp/cmp/internal/teststructs",
+                ["github.com/google/go-cmp/cmp/internal/testprotos", "sync", "time"],
             ),
             gen_tgt(
-                "github.com/google/go-cmp", "v0.4.0", "github.com/google/go-cmp/cmp/internal/value"
+                "github.com/google/go-cmp",
+                "v0.4.0",
+                "github.com/google/go-cmp/cmp/internal/value",
+                ["fmt", "math", "reflect", "sort", "unsafe"],
             ),
             gen_tgt(
-                "golang.org/x/xerrors", "v0.0.0-20191204190536-9bdfabe68543", "golang.org/x/xerrors"
+                "golang.org/x/xerrors",
+                "v0.0.0-20191204190536-9bdfabe68543",
+                "golang.org/x/xerrors",
+                [
+                    "bytes",
+                    "fmt",
+                    "golang.org/x/xerrors/internal",
+                    "io",
+                    "reflect",
+                    "runtime",
+                    "strconv",
+                    "strings",
+                    "unicode",
+                    "unicode/utf8",
+                ],
             ),
             gen_tgt(
                 "golang.org/x/xerrors",
                 "v0.0.0-20191204190536-9bdfabe68543",
                 "golang.org/x/xerrors/internal",
+                [],
             ),
         },
     )

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -17,6 +17,7 @@ from pants.engine.target import (
     InvalidFieldException,
     Sources,
     StringField,
+    StringSequenceField,
     Target,
 )
 
@@ -103,7 +104,15 @@ class GoModTarget(Target):
 # -----------------------------------------------------------------------------------------------
 
 
-class GoExternalPackageDependencies(Dependencies):
+class GoImportPathsDependenciesField(StringSequenceField):
+    alias = "import_path_dependencies"
+    help = (
+        "The import paths of the package's dependencies.\n\n"
+        "(This is stored explicitly as a field to improve the performance of dependency inference.)"
+    )
+
+
+class GoExternalPackageDependenciesField(Dependencies):
     pass
 
 
@@ -133,7 +142,8 @@ class GoExternalPackageTarget(Target):
     alias = "_go_external_package"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        GoExternalPackageDependencies,
+        GoImportPathsDependenciesField,
+        GoExternalPackageDependenciesField,
         GoExternalModulePathField,
         GoExternalModuleVersionField,
         GoExternalPackageImportPathField,

--- a/src/python/pants/backend/go/util_rules/go_pkg.py
+++ b/src/python/pants/backend/go/util_rules/go_pkg.py
@@ -7,7 +7,7 @@ import logging
 from dataclasses import dataclass
 
 from pants.backend.go.target_types import (
-    GoExternalPackageDependencies,
+    GoExternalPackageDependenciesField,
     GoImportPath,
     GoPackageSources,
 )
@@ -183,7 +183,7 @@ def is_first_party_package_target(tgt: Target) -> bool:
 
 
 def is_third_party_package_target(tgt: Target) -> bool:
-    return tgt.has_field(GoExternalPackageDependencies)
+    return tgt.has_field(GoExternalPackageDependenciesField)
 
 
 @rule


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/12928#issuecomment-934805922.

This also changes our behavior to stop caring about `TestImports` for `_go_external_package` targets, given that we'll never test those.

### `dependencies` benchmark

This requires changing this line to use `Targets` so that generated targets have their dependencies resolved too:

https://github.com/pantsbuild/pants/blob/a744978d2badd06509cc6e8091c14220bed3aff6/src/python/pants/backend/project_info/dependencies.py#L94

Before (I aborted after 1 run because it was so slow): 

```
❯ hyperfine -r 5 './pants_from_sources --no-pantsd --no-process-execution-local-cache dependencies ::'
Current estimate: 344.640 s
```

After:

```
❯ /usr/bin/time ./pants_from_sources --no-pantsd --no-process-execution-local-cache dependencies ::
       27.25 real        30.56 user        24.23 sys
```

Almost all of the time was coming from here, with up to 10 seconds per package. I don't know why it's so pathologically slow - we set `GOPROXY=off` so we should be confident that nothing is being downloaded.

https://github.com/pantsbuild/pants/blob/a744978d2badd06509cc6e8091c14220bed3aff6/src/python/pants/backend/go/util_rules/external_module.py#L206-L240 

### `package` benchmark

Before:

```
❯ hyperfine -r 5 './pants_from_sources --no-pantsd --no-process-execution-local-cache package ::'
Benchmark #1: ./pants_from_sources --no-pantsd --no-process-execution-local-cache package ::
  Time (mean ± σ):     54.981 s ±  1.441 s    [User: 70.577 s, System: 81.823 s]
  Range (min … max):   53.426 s … 57.188 s    5 runs
```

After:

```
❯ hyperfine -r 5 './pants_from_sources --no-pantsd --no-process-execution-local-cache package ::'
  Time (mean ± σ):     50.658 s ±  0.700 s    [User: 66.903 s, System: 74.338 s]
  Range (min … max):   49.611 s … 51.245 s    5 runs
```


[ci skip-rust]
[ci skip-build-wheels]