### PR TITLE
[internal] j ava: add `__repr__` and json conversion for dep inference type

### DIFF
--- a/src/python/pants/backend/java/dependency_inference/package_prefix_tree.py
+++ b/src/python/pants/backend/java/dependency_inference/package_prefix_tree.py
@@ -91,3 +91,21 @@ class PackageRootedDependencyMap:
             self._type_map[type_] = address
         for package, addresses in other._package_map.items():
             self._package_map[package] |= addresses
+
+    def to_json_dict(self):
+        return {
+            "type_map": {ty: str(addr) for ty, addr in self._type_map.items()},
+            "package_map": {
+                pkg: [str(addr) for addr in addrs] for pkg, addrs in self._package_map.items()
+            },
+        }
+
+    def __repr__(self) -> str:
+        type_map = ", ".join([f"{ty}:{addr}" for ty, addr in self._type_map.items()])
+        package_map = ", ".join(
+            [
+                f"{pkg}:{', '.join([str(addr) for addr in addrs])}"
+                for pkg, addrs in self._package_map.items()
+            ]
+        )
+        return f"PackageRootedDependencyMap(type_map={type_map}, package_map={package_map})"


### PR DESCRIPTION
Add `__repr__` and a JSON conversion for `PackageRootedDependencyMap`. This allows me to dump the mapping to disk during debugging (with code not included in this PR).

[ci skip-rust]
[ci skip-build-wheels]