### PR TITLE
Fix target generation for `terraform_modules`

### DIFF
--- a/src/python/pants/backend/experimental/terraform/register.py
+++ b/src/python/pants/backend/experimental/terraform/register.py
@@ -5,13 +5,16 @@ from pants.backend.terraform import dependency_inference, style, tailor, target_
 from pants.backend.terraform.lint import fmt
 from pants.backend.terraform.lint.tffmt.tffmt import rules as tffmt_rules
 from pants.backend.terraform.lint.validate.validate import rules as validate_rules
-from pants.backend.terraform.target_types import TerraformModule, TerraformModules
+from pants.backend.terraform.target_types import (
+    TerraformModulesGeneratorTarget,
+    TerraformModuleTarget,
+)
 from pants.backend.terraform.target_types import rules as target_types_rules
 from pants.engine.rules import collect_rules
 
 
 def target_types():
-    return [TerraformModule, TerraformModules]
+    return [TerraformModuleTarget, TerraformModulesGeneratorTarget]
 
 
 def rules():

--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -10,7 +10,7 @@ from pants.backend.python.goals.lockfile import PythonLockfileRequest, PythonToo
 from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
 from pants.backend.python.target_types import EntryPoint
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
-from pants.backend.terraform.target_types import TerraformModuleSources
+from pants.backend.terraform.target_types import TerraformModuleSourcesField
 from pants.base.specs import AddressSpecs, MaybeEmptySiblingAddresses
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.internals.selectors import Get
@@ -114,7 +114,7 @@ async def setup_process_for_parse_terraform_module_sources(
 
 
 class InferTerraformModuleDependenciesRequest(InferDependenciesRequest):
-    infer_from = TerraformModuleSources
+    infer_from = TerraformModuleSourcesField
 
 
 @rule
@@ -142,7 +142,7 @@ async def infer_terraform_module_dependencies(
     # TODO: Need to either implement the standard ambiguous dependency logic or ban >1 terraform_module
     # per directory.
     terraform_module_addresses = [
-        tgt.address for tgt in candidate_targets if tgt.has_field(TerraformModuleSources)
+        tgt.address for tgt in candidate_targets if tgt.has_field(TerraformModuleSourcesField)
     ]
     return InferredDependencies(terraform_module_addresses)
 

--- a/src/python/pants/backend/terraform/dependency_inference_test.py
+++ b/src/python/pants/backend/terraform/dependency_inference_test.py
@@ -11,7 +11,7 @@ from pants.backend.terraform.dependency_inference import (
     ParseTerraformModuleSources,
     TerraformHcl2Parser,
 )
-from pants.backend.terraform.target_types import TerraformModule
+from pants.backend.terraform.target_types import TerraformModuleTarget
 from pants.build_graph.address import Address
 from pants.core.util_rules import external_tool, source_files
 from pants.engine.process import ProcessResult
@@ -30,7 +30,7 @@ from pants.util.ordered_set import FrozenOrderedSet
 @pytest.fixture
 def rule_runner() -> RuleRunner:
     rule_runner = RuleRunner(
-        target_types=[TerraformModule],
+        target_types=[TerraformModuleTarget],
         rules=[
             *external_tool.rules(),
             *source_files.rules(),

--- a/src/python/pants/backend/terraform/lint/fmt.py
+++ b/src/python/pants/backend/terraform/lint/fmt.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Iterable
 
 from pants.backend.terraform.style import StyleRequest
-from pants.backend.terraform.target_types import TerraformSources
+from pants.backend.terraform.target_types import TerraformModuleSourcesField
 from pants.core.goals.fmt import FmtResult, LanguageFmtResults, LanguageFmtTargets
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, Snapshot
@@ -16,7 +16,7 @@ from pants.engine.unions import UnionMembership, UnionRule, union
 
 @dataclass(frozen=True)
 class TerraformFmtTargets(LanguageFmtTargets):
-    required_fields = (TerraformSources,)
+    required_fields = (TerraformModuleSourcesField,)
 
 
 @union
@@ -30,7 +30,9 @@ async def format_terraform_targets(
 ) -> LanguageFmtResults:
     original_sources = await Get(
         SourceFiles,
-        SourceFilesRequest(target[TerraformSources] for target in terraform_fmt_targets.targets),
+        SourceFilesRequest(
+            target[TerraformModuleSourcesField] for target in terraform_fmt_targets.targets
+        ),
     )
     prior_formatter_result = original_sources.snapshot
 

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt_integration_test.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt_integration_test.py
@@ -9,7 +9,7 @@ from pants.backend.terraform import style, tool
 from pants.backend.terraform.lint import fmt
 from pants.backend.terraform.lint.tffmt import tffmt
 from pants.backend.terraform.lint.tffmt.tffmt import TffmtRequest
-from pants.backend.terraform.target_types import TerraformFieldSet, TerraformModule
+from pants.backend.terraform.target_types import TerraformFieldSet, TerraformModuleTarget
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintResult, LintResults
 from pants.core.util_rules import external_tool, source_files
@@ -23,7 +23,7 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 @pytest.fixture()
 def rule_runner() -> RuleRunner:
     return RuleRunner(
-        target_types=[TerraformModule],
+        target_types=[TerraformModuleTarget],
         rules=[
             *external_tool.rules(),
             *fmt.rules(),

--- a/src/python/pants/backend/terraform/lint/validate/validate_integration_test.py
+++ b/src/python/pants/backend/terraform/lint/validate/validate_integration_test.py
@@ -9,7 +9,7 @@ from pants.backend.terraform import style, tool
 from pants.backend.terraform.lint import fmt
 from pants.backend.terraform.lint.validate import validate
 from pants.backend.terraform.lint.validate.validate import ValidateRequest
-from pants.backend.terraform.target_types import TerraformFieldSet, TerraformModule
+from pants.backend.terraform.target_types import TerraformFieldSet, TerraformModuleTarget
 from pants.core.goals.lint import LintResult, LintResults
 from pants.core.util_rules import external_tool, source_files
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
@@ -22,7 +22,7 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 @pytest.fixture()
 def rule_runner() -> RuleRunner:
     return RuleRunner(
-        target_types=[TerraformModule],
+        target_types=[TerraformModuleTarget],
         rules=[
             *external_tool.rules(),
             *fmt.rules(),

--- a/src/python/pants/backend/terraform/tailor.py
+++ b/src/python/pants/backend/terraform/tailor.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from pathlib import PurePath
 from typing import Iterable
 
-from pants.backend.terraform.target_types import TerraformModules
+from pants.backend.terraform.target_types import TerraformModulesGeneratorTarget
 from pants.core.goals.tailor import (
     PutativeTarget,
     PutativeTargets,
@@ -90,7 +90,7 @@ async def find_putative_terrform_modules_targets(
 
     putative_targets = [
         PutativeTarget.for_target_type(
-            TerraformModules,
+            TerraformModulesGeneratorTarget,
             str(PurePath(*dir_parts)),
             "tf_mods",
             [str(PurePath(*dir_parts).joinpath("**/*.tf"))],

--- a/src/python/pants/backend/terraform/tailor_test.py
+++ b/src/python/pants/backend/terraform/tailor_test.py
@@ -7,7 +7,10 @@ from pants.backend.terraform.tailor import (
     find_disjoint_longest_common_prefixes,
 )
 from pants.backend.terraform.tailor import rules as terraform_tailor_rules
-from pants.backend.terraform.target_types import TerraformModule, TerraformModules
+from pants.backend.terraform.target_types import (
+    TerraformModulesGeneratorTarget,
+    TerraformModuleTarget,
+)
 from pants.core.goals.tailor import (
     AllOwnedSources,
     PutativeTarget,
@@ -28,8 +31,8 @@ def test_find_putative_targets() -> None:
             QueryRule(AllOwnedSources, ()),
         ],
         target_types=[
-            TerraformModule,
-            TerraformModules,
+            TerraformModuleTarget,
+            TerraformModulesGeneratorTarget,
         ],
     )
     rule_runner.write_files(
@@ -65,19 +68,19 @@ def test_find_putative_targets() -> None:
         PutativeTargets(
             [
                 PutativeTarget.for_target_type(
-                    TerraformModules,
+                    TerraformModulesGeneratorTarget,
                     "prod/terraform",
                     "tf_mods",
                     ("prod/terraform/**/*.tf",),
                 ),
                 PutativeTarget.for_target_type(
-                    TerraformModules,
+                    TerraformModulesGeneratorTarget,
                     "service1/src/terraform",
                     "tf_mods",
                     ("service1/src/terraform/**/*.tf",),
                 ),
                 PutativeTarget.for_target_type(
-                    TerraformModules,
+                    TerraformModulesGeneratorTarget,
                     "service2/src/terraform",
                     "tf_mods",
                     ("service2/src/terraform/**/*.tf",),

--- a/src/python/pants/backend/terraform/target_gen.py
+++ b/src/python/pants/backend/terraform/target_gen.py
@@ -1,11 +1,14 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 from __future__ import annotations
 
+import os.path
+
 from pants.backend.terraform.target_types import (
-    TerraformModule,
-    TerraformModules,
-    TerraformModulesSources,
+    TerraformModulesGeneratingSourcesField,
+    TerraformModulesGeneratorTarget,
+    TerraformModuleTarget,
 )
 from pants.core.goals.tailor import group_by_dir
 from pants.engine.rules import Get, collect_rules, rule
@@ -22,7 +25,7 @@ from pants.engine.unions import UnionRule
 
 
 class GenerateTerraformModuleTargetsRequest(GenerateTargetsRequest):
-    generate_from = TerraformModules
+    generate_from = TerraformModulesGeneratorTarget
 
 
 @rule
@@ -31,7 +34,7 @@ async def generate_terraform_module_targets(
 ) -> GeneratedTargets:
     generator = request.generator
     sources_paths = await Get(
-        SourcesPaths, SourcesPathsRequest(generator.get(TerraformModulesSources))
+        SourcesPaths, SourcesPathsRequest(generator.get(TerraformModulesGeneratingSourcesField))
     )
 
     dir_to_filenames = group_by_dir(sources_paths.files)
@@ -45,11 +48,13 @@ async def generate_terraform_module_targets(
         for field in generator.field_values.values():
             value: ImmutableValue | None
             if isinstance(field, Sources):
-                value = tuple(sorted(dir_to_filenames[dir]))
+                value = tuple(sorted(os.path.join(dir, f) for f in dir_to_filenames[dir]))
             else:
                 value = field.value
             generated_target_fields[field.alias] = value
-        return TerraformModule(generated_target_fields, generator.address.create_generated(dir))
+        return TerraformModuleTarget(
+            generated_target_fields, generator.address.create_generated(dir)
+        )
 
     return GeneratedTargets(
         request.generator, [gen_target(dir) for dir in dirs_with_terraform_files]

--- a/src/python/pants/backend/terraform/target_gen_test.py
+++ b/src/python/pants/backend/terraform/target_gen_test.py
@@ -1,13 +1,16 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
 import pytest
 
 from pants.backend.terraform import target_gen
 from pants.backend.terraform.target_gen import GenerateTerraformModuleTargetsRequest
 from pants.backend.terraform.target_types import (
-    TerraformModule,
-    TerraformModules,
-    TerraformModuleSources,
+    TerraformModulesGeneratorTarget,
+    TerraformModuleSourcesField,
+    TerraformModuleTarget,
 )
 from pants.core.util_rules import external_tool, source_files
 from pants.engine.addresses import Address
@@ -19,7 +22,7 @@ from pants.testutil.rule_runner import RuleRunner
 @pytest.fixture
 def rule_runner() -> RuleRunner:
     rule_runner = RuleRunner(
-        target_types=[TerraformModule, TerraformModules],
+        target_types=[TerraformModuleTarget, TerraformModulesGeneratorTarget],
         rules=[
             *external_tool.rules(),
             *source_files.rules(),
@@ -50,19 +53,12 @@ def test_target_generation(rule_runner: RuleRunner) -> None:
     assert targets == GeneratedTargets(
         generator,
         [
-            TerraformModule(
-                {
-                    TerraformModuleSources.alias: ("versions.tf",),
-                },
+            TerraformModuleTarget(
+                {TerraformModuleSourcesField.alias: ("src/tf/foo/versions.tf",)},
                 generator_addr.create_generated("src/tf/foo"),
             ),
-            TerraformModule(
-                {
-                    TerraformModuleSources.alias: (
-                        "outputs.tf",
-                        "versions.tf",
-                    ),
-                },
+            TerraformModuleTarget(
+                {TerraformModuleSourcesField.alias: ("src/tf/outputs.tf", "src/tf/versions.tf")},
                 generator_addr.create_generated("src/tf"),
             ),
         ],

--- a/src/python/pants/backend/terraform/target_types.py
+++ b/src/python/pants/backend/terraform/target_types.py
@@ -1,29 +1,29 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 from pants.engine.rules import collect_rules
 from pants.engine.target import COMMON_TARGET_FIELDS, Dependencies, FieldSet, Sources, Target
 
 
-class TerraformSources(Sources):
+class TerraformModuleSourcesField(Sources):
+    default = ("*.tf",)
     expected_file_extensions = (".tf",)
 
 
 @dataclass(frozen=True)
 class TerraformFieldSet(FieldSet):
-    required_fields = (TerraformSources,)
+    required_fields = (TerraformModuleSourcesField,)
 
-    sources: TerraformSources
-
-
-class TerraformModuleSources(TerraformSources):
-    default = ("*.tf",)
+    sources: TerraformModuleSourcesField
 
 
-class TerraformModule(Target):
+class TerraformModuleTarget(Target):
     alias = "terraform_module"
-    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, TerraformModuleSources)
+    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, TerraformModuleSourcesField)
     help = (
         "A single Terraform module corresponding to a directory.\n\n"
         "There must only be one `terraform_module` in a directory.\n\n"
@@ -31,16 +31,17 @@ class TerraformModule(Target):
     )
 
 
-class TerraformModulesSources(TerraformSources):
+class TerraformModulesGeneratingSourcesField(Sources):
     # TODO: This currently only globs .tf files but not non-.tf files referenced by Terraform config. This
     # should be updated to allow for the generated TerraformModule targets to capture all files in the diectory
     # other than BUILD files.
     default = ("**/*.tf",)
+    expected_file_extensions = (".tf",)
 
 
-class TerraformModules(Target):
+class TerraformModulesGeneratorTarget(Target):
     alias = "terraform_modules"
-    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, TerraformModulesSources)
+    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, TerraformModulesGeneratingSourcesField)
     help = (
         "Generate a `terraform_module` target for each directory from the `sources` field "
         "where Terraform files are present."


### PR DESCRIPTION
Generated targets "live" in the BUILD file of their target generator. That is, the address of `prod/terraform#subdir` has the `Address.spec_path` of `prod/terraform`, _not_ `prod/terraform/subdir` like one might expect. It's only a convention that `#subdir` happens to be a directory name, it could just as easily be called `#a_generated_tgt`.

Because the spec_path is the target generator's, we weren't properly relativizing the `sources` field.

This also renames the Target and Field names to better differentiate what is the Target API vs. internal abstractions.

[ci skip-rust]
[ci skip-build-wheels]