### PR TITLE
Report stderr if there is no stdout for nailgun.

### DIFF
--- a/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
@@ -236,14 +236,15 @@ fn read_port(child: &mut std::process::Child) -> Result<Port, String> {
     .stdout
     .as_mut()
     .ok_or_else(|| "No stdout found!".to_string());
-  let port_line = stdout.and_then(|stdout| {
-    let reader = io::BufReader::new(stdout);
-    reader
-      .lines()
-      .next()
-      .ok_or("There is no line ready in the child's output")?
-      .map_err(|e| e.to_string())
-  });
+  let port_line = stdout
+    .and_then(|stdout| {
+      let reader = io::BufReader::new(stdout);
+      reader
+        .lines()
+        .next()
+        .ok_or_else(|| "There is no line ready in the child's output".to_string())
+    })
+    .and_then(|res| res.map_err(|e| format!("Failed to read from stdout: {}", e)));
 
   // If we failed to read a port line and the child has exited, report that.
   if port_line.is_err() {


### PR DESCRIPTION
When `stdout` is empty, `stderr` is likely to have useful information about why that's the case. But we were bailing early for this case, rather than continuing on to poll `stderr`.

This will improve debuggability for cases like #13084.

[ci skip-build-wheels]