### PR TITLE
Add `[docker].env_vars` option.

### DIFF
--- a/src/python/pants/backend/docker/docker_binary.py
+++ b/src/python/pants/backend/docker/docker_binary.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Mapping
 
 from pants.engine.fs import Digest
 from pants.engine.process import (
@@ -27,7 +27,11 @@ class DockerBinary(BinaryPath):
     DEFAULT_SEARCH_PATH = SearchPath(("/usr/bin", "/bin", "/usr/local/bin"))
 
     def build_image(
-        self, tags: tuple[str, ...], digest: Digest, dockerfile: Optional[str] = None
+        self,
+        tags: tuple[str, ...],
+        digest: Digest,
+        dockerfile: str | None = None,
+        env: Mapping[str, str] | None = None,
     ) -> Process:
         args = [self.path, "build"]
         for tag in tags:
@@ -40,11 +44,12 @@ class DockerBinary(BinaryPath):
 
         return Process(
             argv=tuple(args),
-            input_digest=digest,
             description=(
                 f"Building docker image {tags[0]}"
                 + (f" +{pluralize(len(tags)-1, 'additional tag')}." if len(tags) > 1 else ".")
             ),
+            env=env,
+            input_digest=digest,
         )
 
     def push_image(self, tags: tuple[str, ...]) -> Process | None:

--- a/src/python/pants/backend/docker/docker_build.py
+++ b/src/python/pants/backend/docker/docker_build.py
@@ -15,7 +15,7 @@ from pants.backend.docker.docker_build_context import (
     DockerVersionContextValue,
 )
 from pants.backend.docker.registries import DockerRegistries
-from pants.backend.docker.subsystem import DockerOptions
+from pants.backend.docker.subsystem import DockerEnvironmentVars, DockerOptions
 from pants.backend.docker.target_types import (
     DockerImageName,
     DockerImageNameTemplate,
@@ -151,6 +151,7 @@ async def build_docker_image(
     field_set: DockerFieldSet,
     options: DockerOptions,
     docker: DockerBinary,
+    env: DockerEnvironmentVars,
 ) -> BuiltPackage:
     context = await Get(
         DockerBuildContext,
@@ -173,6 +174,7 @@ async def build_docker_image(
             tags=tags,
             digest=context.digest,
             dockerfile=field_set.dockerfile_path,
+            env=env.vars,
         ),
     )
 

--- a/src/python/pants/backend/docker/docker_build_test.py
+++ b/src/python/pants/backend/docker/docker_build_test.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from textwrap import dedent
+from typing import Callable
 
 import pytest
 
@@ -22,32 +23,54 @@ from pants.backend.docker.docker_build_context import (
     DockerVersionContextValue,
 )
 from pants.backend.docker.registries import DockerRegistries
-from pants.backend.docker.subsystem import DockerOptions
+from pants.backend.docker.subsystem import DockerEnvironmentVars, DockerOptions
+from pants.backend.docker.subsystem import rules as docker_subsystem_rules
 from pants.backend.docker.target_types import DockerImage
 from pants.core.goals.package import BuiltPackage
 from pants.engine.addresses import Address
+from pants.engine.environment import rules as environment_rules
 from pants.engine.fs import EMPTY_DIGEST, EMPTY_FILE_DIGEST
 from pants.engine.process import Process, ProcessResult
 from pants.testutil.option_util import create_subsystem
-from pants.testutil.rule_runner import MockGet, RuleRunner, run_rule_with_mocks
+from pants.testutil.rule_runner import MockGet, QueryRule, RuleRunner, run_rule_with_mocks
 from pants.util.frozendict import FrozenDict
 
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
     return RuleRunner(
-        rules=[],
+        rules=[
+            *docker_subsystem_rules(),
+            *environment_rules(),
+            QueryRule(DockerEnvironmentVars, []),
+        ],
         target_types=[DockerImage],
     )
 
 
 def assert_build(
-    rule_runner: RuleRunner, address: Address, *extra_log_lines: str, options: dict | None = None
+    rule_runner: RuleRunner,
+    address: Address,
+    *extra_log_lines: str,
+    options: dict | None = None,
+    process_assertions: Callable[[Process], None] | None = None,
 ) -> None:
     tgt = rule_runner.get_target(address)
 
     def build_context_mock(request: DockerBuildContextRequest) -> DockerBuildContext:
         return DockerBuildContext(digest=EMPTY_DIGEST, version_context=FrozenDict())
+
+    def run_process_mock(process: Process) -> ProcessResult:
+        if process_assertions:
+            process_assertions(process)
+
+        return ProcessResult(
+            stdout=b"stdout",
+            stdout_digest=EMPTY_FILE_DIGEST,
+            stderr=b"stderr",
+            stderr_digest=EMPTY_FILE_DIGEST,
+            output_digest=EMPTY_DIGEST,
+        )
 
     opts = options or {}
     opts.setdefault("registries", {})
@@ -58,9 +81,15 @@ def assert_build(
         **opts,
     )
 
+    env = rule_runner.request(DockerEnvironmentVars, [])
     result = run_rule_with_mocks(
         build_docker_image,
-        rule_args=[DockerFieldSet.create(tgt), docker_options, DockerBinary("/dummy/docker")],
+        rule_args=[
+            DockerFieldSet.create(tgt),
+            docker_options,
+            DockerBinary("/dummy/docker"),
+            env,
+        ],
         mock_gets=[
             MockGet(
                 output_type=DockerBuildContext,
@@ -70,14 +99,7 @@ def assert_build(
             MockGet(
                 output_type=ProcessResult,
                 input_type=Process,
-                # Process() generation has its own tests in test_docker_binary_build_image
-                mock=lambda _: ProcessResult(
-                    stdout=b"stdout",
-                    stdout_digest=EMPTY_FILE_DIGEST,
-                    stderr=b"stderr",
-                    stderr_digest=EMPTY_FILE_DIGEST,
-                    output_digest=EMPTY_DIGEST,
-                ),
+                mock=run_process_mock,
             ),
         ],
     )
@@ -337,3 +359,37 @@ def test_docker_run(rule_runner: RuleRunner) -> None:
     )
 
     assert result.args == ("/dummy/docker", "run", "-it", "--rm", "test:latest")
+
+
+def test_docker_build_process_environment(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files({"docker/test/BUILD": 'docker_image(name="env1", version="1.2.3")'})
+    rule_runner.set_options(
+        [],
+        env={
+            "INHERIT": "from Pants env",
+            "PANTS_DOCKER_ENV_VARS": '["VAR=value", "INHERIT"]',
+        },
+    )
+
+    def check_docker_proc(process: Process):
+        assert process.argv == (
+            "/dummy/docker",
+            "build",
+            "-t",
+            "test/env1:1.2.3",
+            "-f",
+            "docker/test/Dockerfile",
+            ".",
+        )
+        assert process.env == FrozenDict(
+            {
+                "INHERIT": "from Pants env",
+                "VAR": "value",
+            }
+        )
+
+    assert_build(
+        rule_runner,
+        Address("docker/test", target_name="env1"),
+        process_assertions=check_docker_proc,
+    )

--- a/src/python/pants/backend/docker/rules.py
+++ b/src/python/pants/backend/docker/rules.py
@@ -7,6 +7,7 @@ from pants.backend.docker.docker_build import rules as build_rules
 from pants.backend.docker.docker_build_context import rules as context_rules
 from pants.backend.docker.dockerfile_parser import rules as parser_rules
 from pants.backend.docker.publish import rules as publish_rules
+from pants.backend.docker.subsystem import rules as subsystem_rules
 
 
 def rules():
@@ -17,4 +18,5 @@ def rules():
         *dependencies_rules(),
         *parser_rules(),
         *publish_rules(),
+        *subsystem_rules(),
     ]

--- a/src/python/pants/backend/docker/subsystem.py
+++ b/src/python/pants/backend/docker/subsystem.py
@@ -3,11 +3,15 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from textwrap import dedent
 from typing import cast
 
 from pants.backend.docker.registries import DockerRegistries
+from pants.engine.environment import Environment, EnvironmentRequest
+from pants.engine.rules import Get, collect_rules, rule
 from pants.option.subsystem import Subsystem
+from pants.util.frozendict import FrozenDict
 from pants.util.memo import memoized_method
 from pants.util.strutil import bullet_list
 
@@ -66,6 +70,23 @@ class DockerOptions(Subsystem):
             default=image_name_default,
         )
 
+        register(
+            "--env-vars",
+            type=list,
+            member_type=str,
+            default=[],
+            advanced=True,
+            help=(
+                "Environment variables to set for `docker` invocations. "
+                "Entries are either strings in the form `ENV_VAR=value` to set an explicit value; "
+                "or just `ENV_VAR` to copy the value from Pants's own environment."
+            ),
+        )
+
+    @property
+    def env_vars_to_pass_to_docker(self) -> tuple[str, ...]:
+        return tuple(sorted(set(self.options.env_vars)))
+
     @property
     def default_image_name_template(self) -> str:
         return cast(str, self.options.default_image_name_template)
@@ -73,3 +94,21 @@ class DockerOptions(Subsystem):
     @memoized_method
     def registries(self) -> DockerRegistries:
         return DockerRegistries.from_dict(self.options.registries)
+
+
+@dataclass(frozen=True)
+class DockerEnvironmentVars:
+    vars: FrozenDict[str, str]
+
+
+@rule
+async def get_docker_environment(
+    docker: DockerOptions,
+) -> DockerEnvironmentVars:
+    return DockerEnvironmentVars(
+        await Get(Environment, EnvironmentRequest(docker.env_vars_to_pass_to_docker))
+    )
+
+
+def rules():
+    return collect_rules()


### PR DESCRIPTION
This is pre-work for `--build-arg` support. The build arg options may use either a `VAR=value` syntax, or the shorter `VAR` syntax which will take the value from the environment.
In order to support the latter, we introduce generic env support for the docker invocations.
