### PR TITLE
[Docs] Filter out self from list of related subsystems.

### DIFF
--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -308,7 +308,9 @@ class ReferenceGenerator:
         for goal, goal_info in help_info["name_to_goal_info"].items():
             consumed_scopes = sorted(goal_info["consumed_scopes"])
             linked_consumed_scopes = [
-                f"[{cs}]({cls._link(cs, sync=sync)})" for cs in consumed_scopes if cs
+                f"[{cs}]({cls._link(cs, sync=sync)})"
+                for cs in consumed_scopes
+                if cs and cs != goal_info.name
             ]
             comma_separated_consumed_scopes = ", ".join(linked_consumed_scopes)
             scope_to_help_info[goal][


### PR DESCRIPTION
Fix for https://pantsbuild.slack.com/archives/C0D7TNJHL/p1632299453339900

Context: get rid of the link to the current page, as in this pic, the `tailor` link under "Related Subsystems" is for the page we're already at:
![image](https://user-images.githubusercontent.com/72965/136379780-5a2aa5bb-21ca-46f9-a7ba-94ea5aa56589.png)

This is what is already done for the CLI help here:
https://github.com/pantsbuild/pants/blob/964d9d8ddc167ea498da6d05af626c1252f56687/src/python/pants/help/help_printer.py#L253
