### PR TITLE
Expanded fields show up next to raw fields with `./pants peek`

### DIFF
--- a/src/python/pants/backend/project_info/peek.py
+++ b/src/python/pants/backend/project_info/peek.py
@@ -116,7 +116,7 @@ def _render_json(tds: Iterable[TargetData], exclude_defaults: bool = False) -> s
 
     def to_json(td: TargetData) -> dict:
         fields = {
-            (f"{k.alias}_raw" if k.alias in {"sources", "dependencies"} else k.alias): v.value
+            (f"{k.alias}_raw" if issubclass(k, (Sources, Dependencies)) else k.alias): v.value
             for k, v in td.target.field_values.items()
             if not (exclude_defaults and getattr(k, "default", nothing) == v.value)
         }

--- a/src/python/pants/backend/project_info/peek_test.py
+++ b/src/python/pants/backend/project_info/peek_test.py
@@ -140,8 +140,6 @@ from pants.testutil.rule_runner import RuleRunner
 )
 def test_render_targets_as_json(expanded_target_infos, exclude_defaults, expected_output):
     actual_output = peek._render_json(expanded_target_infos, exclude_defaults)
-    print(actual_output)
-    print(expected_output)
     assert actual_output == expected_output
 
 


### PR DESCRIPTION
Improves upon https://github.com/pantsbuild/pants/pull/12882 so that `sources` shows up next to `sources_raw`, and same with `dependencies` and `dependencies_raw`.

Also, does not assume anymore that every target type has Dependencies.

[ci skip-rust]
[ci skip-build-wheels]