### PR TITLE
`pantsd` falls back to socket usage if it cannot open a TTY. (cherrypick of #13155)

### DIFF
--- a/src/rust/engine/nailgun/src/server.rs
+++ b/src/rust/engine/nailgun/src/server.rs
@@ -28,6 +28,7 @@
 #![allow(clippy::mutex_atomic)]
 
 use std::collections::HashMap;
+use std::fs::OpenOptions;
 use std::io;
 use std::net::Ipv4Addr;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
@@ -304,8 +305,8 @@ impl RawFdNail {
   fn input(
     tty_path: Option<PathBuf>,
   ) -> Result<(Box<dyn AsRawFd + Send>, Option<impl sink::Sink<Bytes>>), io::Error> {
-    if let Some(tty_path) = tty_path {
-      Ok((Box::new(std::fs::File::open(tty_path)?), None))
+    if let Some(tty) = Self::try_open_tty(tty_path, OpenOptions::new().read(true)) {
+      Ok((Box::new(tty), None))
     } else {
       let (stdin_reader, stdin_writer) = os_pipe::pipe()?;
       let write_handle =
@@ -329,11 +330,7 @@ impl RawFdNail {
     ),
     io::Error,
   > {
-    if let Some(tty_path) = tty_path {
-      let tty = std::fs::OpenOptions::new()
-        .write(true)
-        .create(false)
-        .open(tty_path)?;
+    if let Some(tty) = Self::try_open_tty(tty_path, OpenOptions::new().write(true).create(false)) {
       Ok((stream::empty().boxed(), Box::new(tty)))
     } else {
       let (stdin_reader, stdin_writer) = os_pipe::pipe()?;
@@ -341,6 +338,23 @@ impl RawFdNail {
         File::from_std(unsafe { std::fs::File::from_raw_fd(stdin_reader.into_raw_fd()) });
       Ok((stream_for(read_handle).boxed(), Box::new(stdin_writer)))
     }
+  }
+
+  ///
+  /// Attempt to open the given TTY-path, logging any errors.
+  ///
+  fn try_open_tty(tty_path: Option<PathBuf>, open_options: &OpenOptions) -> Option<std::fs::File> {
+    let tty_path = tty_path?;
+    open_options
+      .open(&tty_path)
+      .map_err(|e| {
+        log::debug!(
+          "Failed to open TTY at {}: {:?}, falling back to socket access.",
+          tty_path.display(),
+          e
+        );
+      })
+      .ok()
   }
 
   ///


### PR DESCRIPTION
In a few different contexts, `pantsd` will not have permission to access the client's TTY (see #5664). For those cases, and any others, we should fall back to using a pipe (as we do when stdio is redirected).

Fixes #5664. Thanks to @jriddy for assistance with the investigation!

[ci skip-build-wheels]