### PR TITLE
[internal] Fix `go_binary`'s `main` field inference to work with generated targets

### DIFF
--- a/src/python/pants/backend/go/goals/package_binary_integration_test.py
+++ b/src/python/pants/backend/go/goals/package_binary_integration_test.py
@@ -163,8 +163,7 @@ def test_package_with_dependencies(rule_runner: RuleRunner) -> None:
             "BUILD": dedent(
                 """\
                 go_mod(name='mod')
-                # TODO: Remove `main` once it's fixed for target gen.
-                go_binary(name='bin', main='//:mod#./')
+                go_binary(name='bin')
                 """
             ),
         }

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -41,7 +41,7 @@ from pants.backend.go.util_rules.go_mod import (
 from pants.backend.go.util_rules.go_pkg import ResolvedGoPackage, ResolveGoPackageRequest
 from pants.backend.go.util_rules.import_analysis import GoStdLibImports
 from pants.base.exceptions import ResolveError
-from pants.base.specs import AddressSpecs, DescendantAddresses, SiblingAddresses
+from pants.base.specs import AddressSpecs, AscendantAddresses, DescendantAddresses
 from pants.core.goals.tailor import group_by_dir
 from pants.engine.addresses import Address, AddressInput
 from pants.engine.fs import PathGlobs, Paths
@@ -291,34 +291,40 @@ async def determine_main_pkg_for_go_binary(
         if not wrapped_specified_tgt.target.has_field(GoInternalPackageSourcesField):
             raise InvalidFieldException(
                 f"The {repr(GoBinaryMainPackageField.alias)} field in target {addr} must point to "
-                "a `go_package` target, but was the address for a "
+                "a `_go_internal_package` target, but was the address for a "
                 f"`{wrapped_specified_tgt.target.alias}` target.\n\n"
-                "Hint: consider leaving off this field so that Pants will find the `go_package` "
-                "target for you."
+                "Hint: consider leaving off this field so that Pants will find the "
+                "`_go_internal_package` target for you."
             )
         return GoBinaryMainPackage(wrapped_specified_tgt.target.address)
 
-    # TODO: fix this to account for `_go_internal_package` being generated.
-    build_dir_targets = await Get(Targets, AddressSpecs([SiblingAddresses(addr.spec_path)]))
-    internal_pkg_targets = [
-        tgt for tgt in build_dir_targets if tgt.has_field(GoInternalPackageSourcesField)
+    candidate_targets = await Get(Targets, AddressSpecs([AscendantAddresses(addr.spec_path)]))
+    relevant_pkg_targets = [
+        tgt
+        for tgt in candidate_targets
+        if (
+            tgt.has_field(GoInternalPackageSubpathField)
+            and tgt[GoInternalPackageSubpathField].full_dir_path == addr.spec_path
+        )
     ]
-    if len(internal_pkg_targets) == 1:
-        return GoBinaryMainPackage(internal_pkg_targets[0].address)
+    if len(relevant_pkg_targets) == 1:
+        return GoBinaryMainPackage(relevant_pkg_targets[0].address)
 
     wrapped_tgt = await Get(WrappedTarget, Address, addr)
     alias = wrapped_tgt.target.alias
-    if not internal_pkg_targets:
+    if not relevant_pkg_targets:
         raise ResolveError(
-            f"The `{alias}` target {addr} requires that there is a `go_package` "
-            "target in the same directory, but none were found."
+            f"The `{alias}` target {addr} requires that there is a `_go_internal_package` "
+            f"target for its directory {addr.spec_path}, but none were found.\n\n"
+            "Have you added a `go_mod` target (which will generate `_go_internal_package` targets)?"
         )
     raise ResolveError(
-        f"There are multiple `go_package` targets in the same directory of the `{alias}` "
-        f"target {addr}, so it is ambiguous what to use as the `main` package.\n\n"
+        f"There are multiple `_go_internal_package` targets for the same directory of the "
+        "`{alias}` target {addr}: {addr.spec_path}. It is ambiguous what to use as the `main` "
+        "package.\n\n"
         f"To fix, please either set the `main` field for `{addr} or remove these "
-        "`go_package` targets so that only one remains: "
-        f"{sorted(tgt.address.spec for tgt in internal_pkg_targets)}"
+        "`_go_internal_package` targets so that only one remains: "
+        f"{sorted(tgt.address.spec for tgt in relevant_pkg_targets)}"
     )
 
 

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -134,7 +134,7 @@ class GoInternalPackageDependenciesField(Dependencies):
     pass
 
 
-class GoInternalPackageSubpathField(StringField):
+class GoInternalPackageSubpathField(StringField, AsyncFieldMixin):
     alias = "subpath"
     help = (
         "The path from the owning `go.mod` to this package's directory, e.g. `subdir`.\n\n"
@@ -143,6 +143,19 @@ class GoInternalPackageSubpathField(StringField):
     )
     required = True
     value: str
+
+    @property
+    def full_dir_path(self) -> str:
+        """The full path to this package's directory, relative to the build root."""
+        # NB: Assumes that the `spec_path` points to the ancestor `go.mod`, which will be the
+        # case when `go_mod` targets generate.
+        if not self.address.is_generated_target:
+            # TODO: Make this error more eager via target validation.
+            raise AssertionError(
+                f"Target was manually created, but expected to be generated: {self.address}"
+            )
+        go_mod_path = self.address.spec_path
+        return os.path.join(go_mod_path, self.value)
 
 
 class GoInternalPackageTarget(Target):
@@ -203,9 +216,9 @@ class GoExternalPackageTarget(Target):
 class GoBinaryMainPackageField(StringField, AsyncFieldMixin):
     alias = "main"
     help = (
-        "Address of the `go_package` with the `main` for this binary.\n\n"
-        "If not specified, will default to the `go_package` in the same directory as this target's "
-        "BUILD file."
+        "Address of the `_go_internal_package` with the `main` for this binary.\n\n"
+        "If not specified, will default to the `_go_internal_package` for the same "
+        "directory as this target's BUILD file."
     )
     value: str
 


### PR DESCRIPTION
Restores support for https://github.com/pantsbuild/pants/pull/13117 post-https://github.com/pantsbuild/pants/pull/13139.

[ci skip-rust]