### PR TITLE
[internal] Rename Go package targets to `go_{first,third}_party_package`

### DIFF
--- a/src/python/pants/backend/experimental/go/register.py
+++ b/src/python/pants/backend/experimental/go/register.py
@@ -9,26 +9,26 @@ from pants.backend.go.lint.gofmt.rules import rules as gofmt_rules
 from pants.backend.go.subsystems import golang
 from pants.backend.go.target_types import (
     GoBinaryTarget,
-    GoExternalPackageTarget,
-    GoInternalPackageTarget,
+    GoFirstPartyPackageTarget,
     GoModTarget,
+    GoThirdPartyPackageTarget,
 )
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
     compile,
-    external_pkg,
     first_party_pkg,
     go_mod,
     import_analysis,
     link,
     sdk,
     tests_analysis,
+    third_party_pkg,
 )
 
 
 def target_types():
-    return [GoInternalPackageTarget, GoModTarget, GoExternalPackageTarget, GoBinaryTarget]
+    return [GoFirstPartyPackageTarget, GoModTarget, GoThirdPartyPackageTarget, GoBinaryTarget]
 
 
 def rules():
@@ -36,7 +36,7 @@ def rules():
         *assembly.rules(),
         *build_pkg.rules(),
         *compile.rules(),
-        *external_pkg.rules(),
+        *third_party_pkg.rules(),
         *golang.rules(),
         *import_analysis.rules(),
         *go_mod.rules(),

--- a/src/python/pants/backend/go/goals/package_binary_integration_test.py
+++ b/src/python/pants/backend/go/goals/package_binary_integration_test.py
@@ -17,12 +17,12 @@ from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
     compile,
-    external_pkg,
     first_party_pkg,
     go_mod,
     import_analysis,
     link,
     sdk,
+    third_party_pkg,
 )
 from pants.core.goals.package import BuiltPackage
 from pants.engine.addresses import Address
@@ -44,7 +44,7 @@ def rule_runner() -> RuleRunner:
             *go_mod.rules(),
             *link.rules(),
             *target_type_rules.rules(),
-            *external_pkg.rules(),
+            *third_party_pkg.rules(),
             *sdk.rules(),
             QueryRule(BuiltPackage, (GoBinaryFieldSet,)),
         ],

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -3,16 +3,16 @@
 
 from __future__ import annotations
 
-from pants.backend.go.target_types import GoInternalPackageSourcesField
+from pants.backend.go.target_types import GoFirstPartyPackageSourcesField
 from pants.core.goals.test import TestDebugRequest, TestFieldSet, TestResult
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 
 
 class GoTestFieldSet(TestFieldSet):
-    required_fields = (GoInternalPackageSourcesField,)
+    required_fields = (GoFirstPartyPackageSourcesField,)
 
-    sources: GoInternalPackageSourcesField
+    sources: GoFirstPartyPackageSourcesField
 
 
 @rule

--- a/src/python/pants/backend/go/goals/test_test.py
+++ b/src/python/pants/backend/go/goals/test_test.py
@@ -9,7 +9,7 @@ from pants.backend.go import target_type_rules
 from pants.backend.go.goals.test import GoTestFieldSet
 from pants.backend.go.goals.test import rules as test_rules
 from pants.backend.go.target_types import GoModTarget
-from pants.backend.go.util_rules import external_pkg, first_party_pkg, go_mod, sdk
+from pants.backend.go.util_rules import first_party_pkg, go_mod, sdk, third_party_pkg
 from pants.build_graph.address import Address
 from pants.core.goals.test import TestResult
 from pants.testutil.rule_runner import QueryRule, RuleRunner, engine_error
@@ -22,7 +22,7 @@ def rule_runner() -> RuleRunner:
             *test_rules(),
             *go_mod.rules(),
             *first_party_pkg.rules(),
-            *external_pkg.rules(),
+            *third_party_pkg.rules(),
             *sdk.rules(),
             *target_type_rules.rules(),
             QueryRule(TestResult, [GoTestFieldSet]),

--- a/src/python/pants/backend/go/lint/fmt.py
+++ b/src/python/pants/backend/go/lint/fmt.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass
 from typing import Iterable
 
-from pants.backend.go.target_types import GoInternalPackageSourcesField
+from pants.backend.go.target_types import GoFirstPartyPackageSourcesField
 from pants.core.goals.fmt import FmtResult, LanguageFmtResults, LanguageFmtTargets
 from pants.core.goals.style_request import StyleRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
@@ -18,7 +18,7 @@ from pants.engine.unions import UnionMembership, UnionRule, union
 # While gofmt is one of those, this is more generic and can work with other formatters.
 @dataclass(frozen=True)
 class GoLangFmtTargets(LanguageFmtTargets):
-    required_fields = (GoInternalPackageSourcesField,)
+    required_fields = (GoFirstPartyPackageSourcesField,)
 
 
 @union
@@ -33,7 +33,7 @@ async def format_golang_targets(
     original_sources = await Get(
         SourceFiles,
         SourceFilesRequest(
-            target[GoInternalPackageSourcesField] for target in go_fmt_targets.targets
+            target[GoFirstPartyPackageSourcesField] for target in go_fmt_targets.targets
         ),
     )
     prior_formatter_result = original_sources.snapshot

--- a/src/python/pants/backend/go/lint/gofmt/rules.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules.py
@@ -12,7 +12,7 @@ from pants.backend.go.lint.gofmt.skip_field import SkipGofmtField
 from pants.backend.go.lint.gofmt.subsystem import GofmtSubsystem
 from pants.backend.go.subsystems import golang
 from pants.backend.go.subsystems.golang import GoRoot
-from pants.backend.go.target_types import GoInternalPackageSourcesField
+from pants.backend.go.target_types import GoFirstPartyPackageSourcesField
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintRequest, LintResult, LintResults
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
@@ -28,9 +28,9 @@ from pants.util.strutil import pluralize
 
 @dataclass(frozen=True)
 class GofmtFieldSet(FieldSet):
-    required_fields = (GoInternalPackageSourcesField,)
+    required_fields = (GoFirstPartyPackageSourcesField,)
 
-    sources: GoInternalPackageSourcesField
+    sources: GoFirstPartyPackageSourcesField
 
     @classmethod
     def opt_out(cls, tgt: Target) -> bool:

--- a/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
@@ -7,10 +7,12 @@ from textwrap import dedent
 
 import pytest
 
+from pants.backend.go import target_type_rules
 from pants.backend.go.lint import fmt
 from pants.backend.go.lint.gofmt.rules import GofmtFieldSet, GofmtRequest
 from pants.backend.go.lint.gofmt.rules import rules as gofmt_rules
-from pants.backend.go.target_types import GoInternalPackageTarget
+from pants.backend.go.target_types import GoModTarget
+from pants.backend.go.util_rules import first_party_pkg, go_mod, sdk, third_party_pkg
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintResult, LintResults
 from pants.core.util_rules import source_files
@@ -23,17 +25,24 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 @pytest.fixture()
 def rule_runner() -> RuleRunner:
-    return RuleRunner(
-        target_types=[GoInternalPackageTarget],
+    rule_runner = RuleRunner(
+        target_types=[GoModTarget],
         rules=[
             *fmt.rules(),
             *gofmt_rules(),
             *source_files.rules(),
+            *target_type_rules.rules(),
+            *first_party_pkg.rules(),
+            *third_party_pkg.rules(),
+            *sdk.rules(),
+            *go_mod.rules(),
             QueryRule(LintResults, (GofmtRequest,)),
             QueryRule(FmtResult, (GofmtRequest,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
     )
+    rule_runner.set_options([], env_inherit={"PATH"})
+    return rule_runner
 
 
 GOOD_FILE = dedent(
@@ -78,8 +87,11 @@ FIXED_BAD_FILE = dedent(
 )
 
 
-PKG_TGT = (
-    "_go_internal_package(name='t', sources=['*.go'], import_path='doesnt_matter', subpath='')"
+GO_MOD = dedent(
+    """\
+    module example.com/fmt
+    go 1.17
+    """
 )
 
 
@@ -113,8 +125,8 @@ def get_digest(rule_runner: RuleRunner, source_files: dict[str, str]) -> Digest:
 
 
 def test_passing(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files({"f.go": GOOD_FILE, "BUILD": PKG_TGT})
-    tgt = rule_runner.get_target(Address("", target_name="t"))
+    rule_runner.write_files({"f.go": GOOD_FILE, "go.mod": GO_MOD, "BUILD": "go_mod(name='mod')"})
+    tgt = rule_runner.get_target(Address("", target_name="mod", generated_name="./"))
     lint_results, fmt_result = run_gofmt(rule_runner, [tgt])
     assert len(lint_results) == 1
     assert lint_results[0].exit_code == 0
@@ -125,8 +137,8 @@ def test_passing(rule_runner: RuleRunner) -> None:
 
 
 def test_failing(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files({"f.go": BAD_FILE, "BUILD": PKG_TGT})
-    tgt = rule_runner.get_target(Address("", target_name="t"))
+    rule_runner.write_files({"f.go": BAD_FILE, "go.mod": GO_MOD, "BUILD": "go_mod(name='mod')"})
+    tgt = rule_runner.get_target(Address("", target_name="mod", generated_name="./"))
     lint_results, fmt_result = run_gofmt(rule_runner, [tgt])
     assert len(lint_results) == 1
     assert lint_results[0].exit_code == 1
@@ -137,8 +149,10 @@ def test_failing(rule_runner: RuleRunner) -> None:
 
 
 def test_mixed_sources(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files({"good.go": GOOD_FILE, "bad.go": BAD_FILE, "BUILD": PKG_TGT})
-    tgt = rule_runner.get_target(Address("", target_name="t"))
+    rule_runner.write_files(
+        {"good.go": GOOD_FILE, "bad.go": BAD_FILE, "go.mod": GO_MOD, "BUILD": "go_mod(name='mod')"}
+    )
+    tgt = rule_runner.get_target(Address("", target_name="mod", generated_name="./"))
     lint_results, fmt_result = run_gofmt(rule_runner, [tgt])
     assert len(lint_results) == 1
     assert lint_results[0].exit_code == 1
@@ -153,15 +167,15 @@ def test_mixed_sources(rule_runner: RuleRunner) -> None:
 def test_multiple_targets(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
+            "go.mod": GO_MOD,
+            "BUILD": "go_mod(name='mod')",
             "good/f.go": GOOD_FILE,
-            "good/BUILD": PKG_TGT,
             "bad/f.go": BAD_FILE,
-            "bad/BUILD": PKG_TGT,
         }
     )
     tgts = [
-        rule_runner.get_target(Address("good", target_name="t")),
-        rule_runner.get_target(Address("bad", target_name="t")),
+        rule_runner.get_target(Address("", target_name="mod", generated_name="./good")),
+        rule_runner.get_target(Address("", target_name="mod", generated_name="./bad")),
     ]
     lint_results, fmt_result = run_gofmt(rule_runner, tgts)
     assert len(lint_results) == 1
@@ -175,8 +189,8 @@ def test_multiple_targets(rule_runner: RuleRunner) -> None:
 
 
 def test_skip(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files({"f.go": BAD_FILE, "BUILD": PKG_TGT})
-    tgt = rule_runner.get_target(Address("", target_name="t"))
+    rule_runner.write_files({"f.go": BAD_FILE, "go.mod": GO_MOD, "BUILD": "go_mod(name='mod')"})
+    tgt = rule_runner.get_target(Address("", target_name="mod", generated_name="./"))
     lint_results, fmt_result = run_gofmt(rule_runner, [tgt], extra_args=["--gofmt-skip"])
     assert not lint_results
     assert fmt_result.skipped is True

--- a/src/python/pants/backend/go/lint/gofmt/skip_field.py
+++ b/src/python/pants/backend/go/lint/gofmt/skip_field.py
@@ -1,7 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.go.target_types import GoInternalPackageTarget
+from pants.backend.go.target_types import GoFirstPartyPackageTarget
 from pants.engine.target import BoolField
 
 
@@ -12,4 +12,4 @@ class SkipGofmtField(BoolField):
 
 
 def rules():
-    return [GoInternalPackageTarget.register_plugin_field(SkipGofmtField)]
+    return [GoFirstPartyPackageTarget.register_plugin_field(SkipGofmtField)]

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -13,25 +13,19 @@ from pants.backend.go.target_types import (
     GoBinaryMainPackage,
     GoBinaryMainPackageField,
     GoBinaryMainPackageRequest,
-    GoExternalModulePathField,
-    GoExternalModuleVersionField,
-    GoExternalPackageDependenciesField,
-    GoExternalPackageTarget,
+    GoFirstPartyPackageDependenciesField,
+    GoFirstPartyPackageSourcesField,
+    GoFirstPartyPackageSubpathField,
+    GoFirstPartyPackageTarget,
     GoImportPathField,
-    GoInternalPackageDependenciesField,
-    GoInternalPackageSourcesField,
-    GoInternalPackageSubpathField,
-    GoInternalPackageTarget,
     GoModPackageSourcesField,
     GoModTarget,
+    GoThirdPartyModulePathField,
+    GoThirdPartyModuleVersionField,
+    GoThirdPartyPackageDependenciesField,
+    GoThirdPartyPackageTarget,
 )
 from pants.backend.go.util_rules import first_party_pkg, import_analysis
-from pants.backend.go.util_rules.external_pkg import (
-    ExternalModuleInfo,
-    ExternalModuleInfoRequest,
-    ExternalPkgInfo,
-    ExternalPkgInfoRequest,
-)
 from pants.backend.go.util_rules.first_party_pkg import FirstPartyPkgInfo, FirstPartyPkgInfoRequest
 from pants.backend.go.util_rules.go_mod import (
     GoModInfo,
@@ -40,6 +34,12 @@ from pants.backend.go.util_rules.go_mod import (
     OwningGoModRequest,
 )
 from pants.backend.go.util_rules.import_analysis import GoStdLibImports
+from pants.backend.go.util_rules.third_party_pkg import (
+    ThirdPartyModuleInfo,
+    ThirdPartyModuleInfoRequest,
+    ThirdPartyPkgInfo,
+    ThirdPartyPkgInfoRequest,
+)
 from pants.base.exceptions import ResolveError
 from pants.base.specs import AddressSpecs, AscendantAddresses, DescendantAddresses
 from pants.core.goals.tailor import group_by_dir
@@ -65,14 +65,13 @@ from pants.util.logging import LogLevel
 logger = logging.getLogger(__name__)
 
 
-# Inject a dependency between an _internal_go_package and its owning go_mod.
-class InjectGoPackageDependenciesRequest(InjectDependenciesRequest):
-    inject_for = GoInternalPackageDependenciesField
+class InjectGoFirstPartyPackageDependenciesRequest(InjectDependenciesRequest):
+    inject_for = GoFirstPartyPackageDependenciesField
 
 
 @rule
 async def inject_go_package_dependencies(
-    request: InjectGoPackageDependenciesRequest,
+    request: InjectGoFirstPartyPackageDependenciesRequest,
 ) -> InjectedDependencies:
     owning_go_mod = await Get(OwningGoMod, OwningGoModRequest(request.dependencies_field.address))
     return InjectedDependencies([owning_go_mod.address])
@@ -81,7 +80,6 @@ async def inject_go_package_dependencies(
 # TODO: Figure out how to merge (or not) this with ResolvedImportPaths as a base class.
 @dataclass(frozen=True)
 class ImportPathToPackages:
-    # Maps import paths to the address of go_package or (more likely) go_external_package targets.
     mapping: FrozenDict[str, tuple[Address, ...]]
 
 
@@ -100,7 +98,7 @@ async def map_import_paths_to_packages() -> ImportPathToPackages:
 
 # TODO: Use dependency injection. This doesn't actually look at the Sources field.
 class InferGoPackageDependenciesRequest(InferDependenciesRequest):
-    infer_from = GoInternalPackageSourcesField
+    infer_from = GoFirstPartyPackageSourcesField
 
 
 @rule
@@ -128,19 +126,19 @@ async def infer_go_dependencies(
         else:
             logger.debug(
                 f"Unable to infer dependency for import path '{import_path}' "
-                f"in _go_internal_package at address '{addr}'."
+                f"in go_first_party_package at address '{addr}'."
             )
 
     return InferredDependencies(inferred_dependencies)
 
 
-class InjectGoExternalPackageDependenciesRequest(InjectDependenciesRequest):
-    inject_for = GoExternalPackageDependenciesField
+class InjectGoThirdPartyPackageDependenciesRequest(InjectDependenciesRequest):
+    inject_for = GoThirdPartyPackageDependenciesField
 
 
 @rule
-async def inject_go_external_package_dependencies(
-    request: InjectGoExternalPackageDependenciesRequest,
+async def inject_go_third_party_package_dependencies(
+    request: InjectGoThirdPartyPackageDependenciesRequest,
     std_lib_imports: GoStdLibImports,
     package_mapping: ImportPathToPackages,
 ) -> InjectedDependencies:
@@ -151,10 +149,10 @@ async def inject_go_external_package_dependencies(
     owning_go_mod = await Get(OwningGoMod, OwningGoModRequest(addr))
     go_mod_info = await Get(GoModInfo, GoModInfoRequest(owning_go_mod.address))
     pkg_info = await Get(
-        ExternalPkgInfo,
-        ExternalPkgInfoRequest(
-            module_path=tgt[GoExternalModulePathField].value,
-            version=tgt[GoExternalModuleVersionField].value,
+        ThirdPartyPkgInfo,
+        ThirdPartyPkgInfoRequest(
+            module_path=tgt[GoThirdPartyModulePathField].value,
+            version=tgt[GoThirdPartyModuleVersionField].value,
             import_path=tgt[GoImportPathField].value,
             go_mod_stripped_digest=go_mod_info.stripped_digest,
         ),
@@ -177,14 +175,14 @@ async def inject_go_external_package_dependencies(
         else:
             logger.debug(
                 f"Unable to infer dependency for import path '{import_path}' "
-                f"in _go_external_package at address '{addr}'."
+                f"in go_third_party_package at address '{addr}'."
             )
 
     return InjectedDependencies(inferred_dependencies)
 
 
 # -----------------------------------------------------------------------------------------------
-# Generate `_go_internal_package` and `_go_external_package` targets
+# Generate `go_first_party_package` and `go_third_party_package` targets
 # -----------------------------------------------------------------------------------------------
 
 
@@ -193,7 +191,10 @@ class GenerateTargetsFromGoModRequest(GenerateTargetsRequest):
 
 
 @rule(
-    desc="Generate `_go_internal_package` and `_go_external_package` targets from `go_mod` target",
+    desc=(
+        "Generate `go_first_party_package` and `go_third_party_package` targets from `go_mod` "
+        "target"
+    ),
     level=LogLevel.DEBUG,
 )
 async def generate_targets_from_go_mod(
@@ -210,8 +211,8 @@ async def generate_targets_from_go_mod(
     )
     all_module_info = await MultiGet(
         Get(
-            ExternalModuleInfo,
-            ExternalModuleInfoRequest(
+            ThirdPartyModuleInfo,
+            ThirdPartyModuleInfoRequest(
                 module_path=module_descriptor.path,
                 version=module_descriptor.version,
                 go_mod_stripped_digest=go_mod_info.stripped_digest,
@@ -223,7 +224,7 @@ async def generate_targets_from_go_mod(
     dir_to_filenames = group_by_dir(go_paths.files)
     matched_dirs = [dir for dir, filenames in dir_to_filenames.items() if filenames]
 
-    def create_internal_package_tgt(dir: str) -> GoInternalPackageTarget:
+    def create_first_party_package_tgt(dir: str) -> GoFirstPartyPackageTarget:
         go_mod_spec_path = generator_addr.spec_path
         assert dir.startswith(
             go_mod_spec_path
@@ -238,11 +239,11 @@ async def generate_targets_from_go_mod(
 
         import_path = f"{go_mod_info.import_path}/{subpath}" if subpath else go_mod_info.import_path
 
-        return GoInternalPackageTarget(
+        return GoFirstPartyPackageTarget(
             {
                 GoImportPathField.alias: import_path,
-                GoInternalPackageSubpathField.alias: subpath,
-                GoInternalPackageSourcesField.alias: tuple(
+                GoFirstPartyPackageSubpathField.alias: subpath,
+                GoFirstPartyPackageSourcesField.alias: tuple(
                     sorted(os.path.join(subpath, f) for f in dir_to_filenames[dir])
                 ),
             },
@@ -250,25 +251,25 @@ async def generate_targets_from_go_mod(
             generator_addr.create_generated(f"./{subpath}"),
         )
 
-    internal_pkgs = (create_internal_package_tgt(dir) for dir in matched_dirs)
+    first_party_pkgs = (create_first_party_package_tgt(dir) for dir in matched_dirs)
 
-    def create_external_package_tgt(pkg_info: ExternalPkgInfo) -> GoExternalPackageTarget:
-        return GoExternalPackageTarget(
+    def create_third_party_package_tgt(pkg_info: ThirdPartyPkgInfo) -> GoThirdPartyPackageTarget:
+        return GoThirdPartyPackageTarget(
             {
-                GoExternalModulePathField.alias: pkg_info.module_path,
-                GoExternalModuleVersionField.alias: pkg_info.version,
+                GoThirdPartyModulePathField.alias: pkg_info.module_path,
+                GoThirdPartyModuleVersionField.alias: pkg_info.version,
                 GoImportPathField.alias: pkg_info.import_path,
             },
             # E.g. `src/go:mod#github.com/google/uuid`.
             generator_addr.create_generated(pkg_info.import_path),
         )
 
-    external_pkgs = (
-        create_external_package_tgt(pkg_info)
+    third_party_pkgs = (
+        create_third_party_package_tgt(pkg_info)
         for module_info in all_module_info
         for pkg_info in module_info.values()
     )
-    return GeneratedTargets(request.generator, (*internal_pkgs, *external_pkgs))
+    return GeneratedTargets(request.generator, (*first_party_pkgs, *third_party_pkgs))
 
 
 # -----------------------------------------------------------------------------------------------
@@ -287,13 +288,14 @@ async def determine_main_pkg_for_go_binary(
             AddressInput,
             AddressInput.parse(request.field.value, relative_to=addr.spec_path),
         )
-        if not wrapped_specified_tgt.target.has_field(GoInternalPackageSourcesField):
+        if not wrapped_specified_tgt.target.has_field(GoFirstPartyPackageSourcesField):
             raise InvalidFieldException(
                 f"The {repr(GoBinaryMainPackageField.alias)} field in target {addr} must point to "
-                "a `_go_internal_package` target, but was the address for a "
+                "a `go_first_party_package` target, but was the address for a "
                 f"`{wrapped_specified_tgt.target.alias}` target.\n\n"
-                "Hint: consider leaving off this field so that Pants will find the "
-                "`_go_internal_package` target for you."
+                "Hint: you should normally not specify this field so that Pants will find the "
+                "`go_first_party_package` target for you. (Pants generates "
+                "`go_first_party_package` targets based on the `go_mod` target)."
             )
         return GoBinaryMainPackage(wrapped_specified_tgt.target.address)
 
@@ -302,8 +304,8 @@ async def determine_main_pkg_for_go_binary(
         tgt
         for tgt in candidate_targets
         if (
-            tgt.has_field(GoInternalPackageSubpathField)
-            and tgt[GoInternalPackageSubpathField].full_dir_path == addr.spec_path
+            tgt.has_field(GoFirstPartyPackageSubpathField)
+            and tgt[GoFirstPartyPackageSubpathField].full_dir_path == addr.spec_path
         )
     ]
     if len(relevant_pkg_targets) == 1:
@@ -313,16 +315,17 @@ async def determine_main_pkg_for_go_binary(
     alias = wrapped_tgt.target.alias
     if not relevant_pkg_targets:
         raise ResolveError(
-            f"The `{alias}` target {addr} requires that there is a `_go_internal_package` "
+            f"The `{alias}` target {addr} requires that there is a `go_first_party_package` "
             f"target for its directory {addr.spec_path}, but none were found.\n\n"
-            "Have you added a `go_mod` target (which will generate `_go_internal_package` targets)?"
+            "Have you added a `go_mod` target (which will generate `go_first_party_package` "
+            "targets)?"
         )
     raise ResolveError(
-        f"There are multiple `_go_internal_package` targets for the same directory of the "
+        f"There are multiple `go_first_party_package` targets for the same directory of the "
         "`{alias}` target {addr}: {addr.spec_path}. It is ambiguous what to use as the `main` "
         "package.\n\n"
         f"To fix, please either set the `main` field for `{addr} or remove these "
-        "`_go_internal_package` targets so that only one remains: "
+        "`go_first_party_package` targets so that only one remains: "
         f"{sorted(tgt.address.spec for tgt in relevant_pkg_targets)}"
     )
 
@@ -348,9 +351,9 @@ def rules():
         *collect_rules(),
         *first_party_pkg.rules(),
         *import_analysis.rules(),
-        UnionRule(InjectDependenciesRequest, InjectGoPackageDependenciesRequest),
+        UnionRule(InjectDependenciesRequest, InjectGoFirstPartyPackageDependenciesRequest),
         UnionRule(InferDependenciesRequest, InferGoPackageDependenciesRequest),
-        UnionRule(InjectDependenciesRequest, InjectGoExternalPackageDependenciesRequest),
+        UnionRule(InjectDependenciesRequest, InjectGoThirdPartyPackageDependenciesRequest),
         UnionRule(InjectDependenciesRequest, InjectGoBinaryMainDependencyRequest),
         UnionRule(GenerateTargetsRequest, GenerateTargetsFromGoModRequest),
     )

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -16,6 +16,7 @@ from pants.engine.target import (
     AsyncFieldMixin,
     Dependencies,
     InvalidFieldException,
+    InvalidTargetException,
     Sources,
     StringField,
     StringSequenceField,
@@ -26,17 +27,20 @@ from pants.option.global_options import FilesNotFoundBehavior
 
 class GoImportPathField(StringField):
     alias = "import_path"
-    help = "Import path in Go code to import this package."
+    help = (
+        "Import path in Go code to import this package.\n\n"
+        "This field should not be overridden; use the value from target generation."
+    )
     required = True
     value: str
 
 
 def is_first_party_package_target(tgt: Target) -> bool:
-    return tgt.has_field(GoInternalPackageSourcesField)
+    return tgt.has_field(GoFirstPartyPackageSourcesField)
 
 
 def is_third_party_package_target(tgt: Target) -> bool:
-    return tgt.has_field(GoExternalPackageDependenciesField)
+    return tgt.has_field(GoThirdPartyPackageDependenciesField)
 
 
 # -----------------------------------------------------------------------------------------------
@@ -85,10 +89,10 @@ class GoModDependenciesField(Dependencies):
 
 # TODO(#12953): generalize this?
 class GoModPackageSourcesField(StringSequenceField, AsyncFieldMixin):
-    alias = "pkg_sources"
+    alias = "package_sources"
     default = ("**/*.go", "**/*.s")
     help = (
-        "What sources to generate `_go_internal_package` targets for.\n\n"
+        "What sources to generate `go_first_party_package` targets for.\n\n"
         "Pants will generate one target per matching directory."
     )
 
@@ -120,34 +124,33 @@ class GoModTarget(Target):
         GoModPackageSourcesField,
     )
     help = (
-        "A first-party Go module corresponding to a `go.mod` file.\n\n"
-        "Generates `_go_internal_package` targets for each directory from the "
-        "`internal_pkg_sources` field, and generates `_go_external_package` targets based on "
+        "A first-party Go module (corresponding to a `go.mod` file).\n\n"
+        "Generates `go_first_party_package` targets for each directory from the "
+        "`package_sources` field, and generates `go_third_party_package` targets based on "
         "the `require` directives in your `go.mod`.\n\n"
-        "If you have external packages, make sure you have an up-to-date `go.sum`. Run "
+        "If you have third-party packages, make sure you have an up-to-date `go.sum`. Run "
         "`go mod tidy` directly to update your `go.mod` and `go.sum`."
     )
 
 
 # -----------------------------------------------------------------------------------------------
-# `_go_internal_package` target
+# `go_first_party_package` target
 # -----------------------------------------------------------------------------------------------
 
 
-class GoInternalPackageSourcesField(Sources):
+class GoFirstPartyPackageSourcesField(Sources):
     expected_file_extensions = (".go", ".s")
 
 
-class GoInternalPackageDependenciesField(Dependencies):
+class GoFirstPartyPackageDependenciesField(Dependencies):
     pass
 
 
-class GoInternalPackageSubpathField(StringField, AsyncFieldMixin):
+class GoFirstPartyPackageSubpathField(StringField, AsyncFieldMixin):
     alias = "subpath"
     help = (
         "The path from the owning `go.mod` to this package's directory, e.g. `subdir`.\n\n"
-        "Should not include a leading `./`. If the package is in the same directory as the "
-        "`go.mod`, use the empty string."
+        "This field should not be overridden; use the value from target generation."
     )
     required = True
     value: str
@@ -155,65 +158,95 @@ class GoInternalPackageSubpathField(StringField, AsyncFieldMixin):
     @property
     def full_dir_path(self) -> str:
         """The full path to this package's directory, relative to the build root."""
-        # NB: Assumes that the `spec_path` points to the ancestor `go.mod`, which will be the
-        # case when `go_mod` targets generate.
-        if not self.address.is_generated_target:
-            # TODO: Make this error more eager via target validation.
-            raise AssertionError(
-                f"Target was manually created, but expected to be generated: {self.address}"
-            )
+        # NB: The `spec_path` points to the `go_mod` target used to generate the
+        # `go_first_party_package` target.
+        assert self.address.is_generated_target
         go_mod_path = self.address.spec_path
         return os.path.join(go_mod_path, self.value)
 
 
-class GoInternalPackageTarget(Target):
-    alias = "_go_internal_package"
+class GoFirstPartyPackageTarget(Target):
+    alias = "go_first_party_package"
     core_fields = (
         *COMMON_TARGET_FIELDS,
         GoImportPathField,
-        GoInternalPackageSubpathField,
-        GoInternalPackageDependenciesField,
-        GoInternalPackageSourcesField,
+        GoFirstPartyPackageSubpathField,
+        GoFirstPartyPackageDependenciesField,
+        GoFirstPartyPackageSourcesField,
     )
-    help = "A single Go package."
+    help = (
+        "A Go package (corresponding to a directory with `.go` files).\n\n"
+        "You should not explicitly create this target in BUILD files. Instead, add a `go_mod` "
+        "target where you have your `go.mod` file, which will generate "
+        "`go_first_party_package` targets for you."
+    )
+
+    def validate(self) -> None:
+        if not self.address.is_generated_target:
+            raise InvalidTargetException(
+                f"The `{self.alias}` target type should not be manually created in BUILD "
+                f"files, but it was created for {self.address}.\n\n"
+                "Instead, add a `go_mod` target where you have your `go.mod` file, which will "
+                f"generate `{self.alias}` targets for you."
+            )
 
 
 # -----------------------------------------------------------------------------------------------
-# `_go_external_package` target
+# `go_third_party_package` target
 # -----------------------------------------------------------------------------------------------
 
 
-class GoExternalPackageDependenciesField(Dependencies):
+class GoThirdPartyPackageDependenciesField(Dependencies):
     pass
 
 
-class GoExternalModulePathField(StringField):
-    alias = "path"
+class GoThirdPartyModulePathField(StringField):
+    alias = "module_path"
     help = (
         "The module path of the third-party module this package comes from, "
-        "e.g. `github.com/google/go-cmp`."
+        "e.g. `github.com/google/go-cmp`.\n\n"
+        "This field should not be overridden; use the value from target generation."
     )
     required = True
     value: str
 
 
-class GoExternalModuleVersionField(StringField):
+class GoThirdPartyModuleVersionField(StringField):
     alias = "version"
-    help = "The version of the third-party module this package comes from, e.g. `v0.4.0`."
+    help = (
+        "The version of the third-party module this package comes from, e.g. `v0.4.0`.\n\n"
+        "This field should not be overridden; use the value from target generation."
+    )
     required = True
     value: str
 
 
-class GoExternalPackageTarget(Target):
-    alias = "_go_external_package"
+class GoThirdPartyPackageTarget(Target):
+    alias = "go_third_party_package"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        GoExternalPackageDependenciesField,
-        GoExternalModulePathField,
-        GoExternalModuleVersionField,
+        GoThirdPartyPackageDependenciesField,
+        GoThirdPartyModulePathField,
+        GoThirdPartyModuleVersionField,
         GoImportPathField,
     )
-    help = "A package from a third-party Go module."
+    help = (
+        "A package from a third-party Go module.\n\n"
+        "You should not explicitly create this target in BUILD files. Instead, add a `go_mod` "
+        "target where you have your `go.mod` file, which will generate "
+        "`go_third_party_package` targets for you.\n\n"
+        "Make sure that your `go.mod` and `go.sum` files include this package's module."
+    )
+
+    def validate(self) -> None:
+        if not self.address.is_generated_target:
+            raise InvalidTargetException(
+                f"The `{self.alias}` target type should not be manually created in BUILD "
+                f"files, but it was created for {self.address}.\n\n"
+                "Instead, add a `go_mod` target where you have your `go.mod` file, which will "
+                f"generate `{self.alias}` targets for you based on the `require` directives in "
+                f"your `go.mod`."
+            )
 
 
 # -----------------------------------------------------------------------------------------------
@@ -224,9 +257,9 @@ class GoExternalPackageTarget(Target):
 class GoBinaryMainPackageField(StringField, AsyncFieldMixin):
     alias = "main"
     help = (
-        "Address of the `_go_internal_package` with the `main` for this binary.\n\n"
-        "If not specified, will default to the `_go_internal_package` for the same "
-        "directory as this target's BUILD file."
+        "Address of the `go_first_party_package` with the `main` for this binary.\n\n"
+        "If not specified, will default to the `go_first_party_package` for the same "
+        "directory as this target's BUILD file. You should usually rely on this default."
     )
     value: str
 

--- a/src/python/pants/backend/go/util_rules/assembly_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/assembly_integration_test.py
@@ -17,12 +17,12 @@ from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
     compile,
-    external_pkg,
     first_party_pkg,
     go_mod,
     import_analysis,
     link,
     sdk,
+    third_party_pkg,
 )
 from pants.core.goals.package import BuiltPackage
 from pants.engine.addresses import Address
@@ -44,7 +44,7 @@ def rule_runner() -> RuleRunner:
             *go_mod.rules(),
             *link.rules(),
             *target_type_rules.rules(),
-            *external_pkg.rules(),
+            *third_party_pkg.rules(),
             *sdk.rules(),
             QueryRule(BuiltPackage, (GoBinaryFieldSet,)),
         ],

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -7,10 +7,10 @@ from dataclasses import dataclass
 from typing import Optional
 
 from pants.backend.go.target_types import (
-    GoExternalModulePathField,
-    GoExternalModuleVersionField,
+    GoFirstPartyPackageSubpathField,
     GoImportPathField,
-    GoInternalPackageSubpathField,
+    GoThirdPartyModulePathField,
+    GoThirdPartyModuleVersionField,
     is_first_party_package_target,
     is_third_party_package_target,
 )
@@ -21,7 +21,6 @@ from pants.backend.go.util_rules.assembly import (
     AssemblyPreCompilationRequest,
 )
 from pants.backend.go.util_rules.compile import CompiledGoSources, CompileGoSourcesRequest
-from pants.backend.go.util_rules.external_pkg import ExternalPkgInfo, ExternalPkgInfoRequest
 from pants.backend.go.util_rules.first_party_pkg import FirstPartyPkgInfo, FirstPartyPkgInfoRequest
 from pants.backend.go.util_rules.go_mod import (
     GoModInfo,
@@ -30,6 +29,7 @@ from pants.backend.go.util_rules.go_mod import (
     OwningGoModRequest,
 )
 from pants.backend.go.util_rules.import_analysis import ImportConfig, ImportConfigRequest
+from pants.backend.go.util_rules.third_party_pkg import ThirdPartyPkgInfo, ThirdPartyPkgInfoRequest
 from pants.build_graph.address import Address
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import AddPrefix, Digest, MergeDigests
@@ -68,33 +68,33 @@ async def build_go_package(request: BuildGoPackageRequest) -> BuiltGoPackage:
     original_import_path = target[GoImportPathField].value
 
     if is_first_party_package_target(target):
-        _internal_pkg_info = await Get(
+        _first_party_pkg_info = await Get(
             FirstPartyPkgInfo, FirstPartyPkgInfoRequest(address=target.address)
         )
-        source_files_digest = _internal_pkg_info.digest
-        source_files_subpath = target[GoInternalPackageSubpathField].value
-        go_files = _internal_pkg_info.go_files
-        s_files = _internal_pkg_info.s_files
+        source_files_digest = _first_party_pkg_info.digest
+        source_files_subpath = target[GoFirstPartyPackageSubpathField].value
+        go_files = _first_party_pkg_info.go_files
+        s_files = _first_party_pkg_info.s_files
 
     elif is_third_party_package_target(target):
-        _module_path = target[GoExternalModulePathField].value
+        _module_path = target[GoThirdPartyModulePathField].value
         source_files_subpath = original_import_path[len(_module_path) :]
 
         _owning_go_mod = await Get(OwningGoMod, OwningGoModRequest(target.address))
         _go_mod_info = await Get(GoModInfo, GoModInfoRequest(_owning_go_mod.address))
-        _external_pkg_info = await Get(
-            ExternalPkgInfo,
-            ExternalPkgInfoRequest(
+        _third_party_pkg_info = await Get(
+            ThirdPartyPkgInfo,
+            ThirdPartyPkgInfoRequest(
                 import_path=original_import_path,
                 module_path=_module_path,
-                version=target[GoExternalModuleVersionField].value,
+                version=target[GoThirdPartyModuleVersionField].value,
                 go_mod_stripped_digest=_go_mod_info.stripped_digest,
             ),
         )
 
-        source_files_digest = _external_pkg_info.digest
-        go_files = _external_pkg_info.go_files
-        s_files = _external_pkg_info.s_files
+        source_files_digest = _third_party_pkg_info.digest
+        go_files = _third_party_pkg_info.go_files
+        s_files = _third_party_pkg_info.s_files
 
     else:
         raise AssertionError(f"Unknown how to build target at address {request.address} with Go.")

--- a/src/python/pants/backend/go/util_rules/build_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_test.py
@@ -14,11 +14,11 @@ from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
     compile,
-    external_pkg,
     first_party_pkg,
     go_mod,
     import_analysis,
     sdk,
+    third_party_pkg,
 )
 from pants.backend.go.util_rules.build_pkg import BuildGoPackageRequest, BuiltGoPackage
 from pants.engine.addresses import Address
@@ -39,7 +39,7 @@ def rule_runner() -> RuleRunner:
             *import_analysis.rules(),
             *go_mod.rules(),
             *first_party_pkg.rules(),
-            *external_pkg.rules(),
+            *third_party_pkg.rules(),
             *target_type_rules.rules(),
             QueryRule(BuiltGoPackage, [BuildGoPackageRequest]),
         ],

--- a/src/python/pants/backend/go/util_rules/first_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg.py
@@ -8,8 +8,8 @@ import logging
 from dataclasses import dataclass
 
 from pants.backend.go.target_types import (
-    GoInternalPackageSourcesField,
-    GoInternalPackageSubpathField,
+    GoFirstPartyPackageSourcesField,
+    GoFirstPartyPackageSubpathField,
 )
 from pants.backend.go.util_rules.go_mod import (
     GoModInfo,
@@ -33,7 +33,7 @@ class FirstPartyPkgInfo:
     """All the info and digest needed to build a first-party Go package.
 
     The digest does not strip its source files. You must set `working_dir` appropriately to use the
-    `_go_internal_package` target's `subpath` field.
+    `go_first_party_package` target's `subpath` field.
     """
 
     digest: Digest
@@ -66,11 +66,11 @@ async def compute_first_party_package_info(
         Get(OwningGoMod, OwningGoModRequest(request.address)),
     )
     target = wrapped_target.target
-    subpath = target[GoInternalPackageSubpathField].value
+    subpath = target[GoFirstPartyPackageSubpathField].value
 
     go_mod_info, pkg_sources = await MultiGet(
         Get(GoModInfo, GoModInfoRequest(owning_go_mod.address)),
-        Get(HydratedSources, HydrateSourcesRequest(target[GoInternalPackageSourcesField])),
+        Get(HydratedSources, HydrateSourcesRequest(target[GoFirstPartyPackageSourcesField])),
     )
     input_digest = await Get(
         Digest, MergeDigests([pkg_sources.snapshot.digest, go_mod_info.digest])

--- a/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
@@ -9,7 +9,7 @@ import pytest
 
 from pants.backend.go import target_type_rules
 from pants.backend.go.target_types import GoModTarget
-from pants.backend.go.util_rules import external_pkg, first_party_pkg, go_mod, sdk
+from pants.backend.go.util_rules import first_party_pkg, go_mod, sdk, third_party_pkg
 from pants.backend.go.util_rules.first_party_pkg import FirstPartyPkgInfo, FirstPartyPkgInfoRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import PathGlobs, Snapshot
@@ -24,7 +24,7 @@ def rule_runner() -> RuleRunner:
             *go_mod.rules(),
             *first_party_pkg.rules(),
             *sdk.rules(),
-            *external_pkg.rules(),
+            *third_party_pkg.rules(),
             *target_type_rules.rules(),
             QueryRule(FirstPartyPkgInfo, [FirstPartyPkgInfoRequest]),
         ],


### PR DESCRIPTION
@tdyas pointed out that "internal" is a bad name because it makes Go developers think of `/internal/` in the import path, which is a common pattern.

Instead, some alpha Go users voted that they like best `first_party_package` and `third_party_package`.

This also makes those targets public by removing the `_`. We want them to show up in `./pants help` and the docs so that users understand what Pants is doing (if they so desire), and so that they know how to set the `overrides` field on `go_mod` when we add that. 

We use target validation to ensure that users never explicitly create these targets, as it's too unlikely things will break if so, like that they won't set some fields correctly or that their `go.mod` will be missing an entry.

[ci skip-rust]
[ci skip-build-wheels]