### PR TITLE
[Internal] Docker run integration test

### DIFF
--- a/src/python/pants/backend/docker/BUILD
+++ b/src/python/pants/backend/docker/BUILD
@@ -25,5 +25,5 @@ python_library(
 
 python_tests(
     name="tests",
-    timeout=120,
+    timeout=180,
 )

--- a/src/python/pants/backend/docker/docker_build.py
+++ b/src/python/pants/backend/docker/docker_build.py
@@ -26,7 +26,7 @@ from pants.backend.docker.target_types import (
     DockerRepository,
 )
 from pants.core.goals.package import BuiltPackage, BuiltPackageArtifact, PackageFieldSet
-from pants.core.goals.run import RunFieldSet, RunRequest
+from pants.core.goals.run import RunFieldSet
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.unions import UnionRule
@@ -199,21 +199,6 @@ async def build_docker_image(
     return BuiltPackage(
         result.output_digest,
         (BuiltDockerImage.create(tags),),
-    )
-
-
-@rule
-async def docker_image_run_request(field_set: DockerFieldSet, docker: DockerBinary) -> RunRequest:
-    image = await Get(BuiltPackage, PackageFieldSet, field_set)
-    return RunRequest(
-        digest=image.digest,
-        args=(
-            docker.path,
-            "run",
-            "-it",
-            "--rm",
-            cast(BuiltDockerImage, image.artifacts[0]).tags[0],
-        ),
     )
 
 

--- a/src/python/pants/backend/docker/docker_build_test.py
+++ b/src/python/pants/backend/docker/docker_build_test.py
@@ -10,11 +10,9 @@ import pytest
 
 from pants.backend.docker.docker_binary import DockerBinary
 from pants.backend.docker.docker_build import (
-    BuiltDockerImage,
     DockerFieldSet,
     DockerNameTemplateError,
     build_docker_image,
-    docker_image_run_request,
 )
 from pants.backend.docker.docker_build_context import (
     DockerBuildContext,
@@ -27,7 +25,6 @@ from pants.backend.docker.registries import DockerRegistries
 from pants.backend.docker.subsystem import DockerEnvironmentVars, DockerOptions
 from pants.backend.docker.subsystem import rules as docker_subsystem_rules
 from pants.backend.docker.target_types import DockerImage
-from pants.core.goals.package import BuiltPackage
 from pants.engine.addresses import Address
 from pants.engine.fs import EMPTY_DIGEST, EMPTY_FILE_DIGEST
 from pants.engine.process import Process, ProcessResult
@@ -345,26 +342,6 @@ def test_dynamic_image_version(rule_runner: RuleRunner) -> None:
     )
     with pytest.raises(DockerVersionContextError, match=err_2):
         assert_tags("err_2")
-
-
-def test_docker_run(rule_runner: RuleRunner) -> None:
-    rule_runner.create_file("docker/test/BUILD", "docker_image()")
-    tgt = rule_runner.get_target(Address("docker/test"))
-    result = run_rule_with_mocks(
-        docker_image_run_request,
-        rule_args=[DockerFieldSet.create(tgt), DockerBinary("/dummy/docker")],
-        mock_gets=[
-            MockGet(
-                output_type=BuiltPackage,
-                input_type=DockerFieldSet,
-                mock=lambda _: BuiltPackage(
-                    EMPTY_DIGEST, (BuiltDockerImage.create(("test:latest",)),)
-                ),
-            ),
-        ],
-    )
-
-    assert result.args == ("/dummy/docker", "run", "-it", "--rm", "test:latest")
 
 
 def test_docker_build_process_environment(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/docker/docker_run.py
+++ b/src/python/pants/backend/docker/docker_run.py
@@ -1,0 +1,37 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+import sys
+from typing import cast
+
+from pants.backend.docker.docker_binary import DockerBinary
+from pants.backend.docker.docker_build import BuiltDockerImage, DockerFieldSet
+from pants.core.goals.package import BuiltPackage, PackageFieldSet
+from pants.core.goals.run import RunRequest
+from pants.engine.rules import Get, collect_rules, rule
+
+
+@rule
+async def docker_image_run_request(field_set: DockerFieldSet, docker: DockerBinary) -> RunRequest:
+    image = await Get(BuiltPackage, PackageFieldSet, field_set)
+    return RunRequest(
+        digest=image.digest,
+        args=tuple(
+            cast(str, arg)
+            for arg in (
+                docker.path,
+                "run",
+                "-it" if sys.stdout.isatty() else False,
+                "--rm",
+                cast(BuiltDockerImage, image.artifacts[0]).tags[0],
+            )
+            if arg
+        ),
+    )
+
+
+def rules():
+    return [
+        *collect_rules(),
+    ]

--- a/src/python/pants/backend/docker/docker_run_integration_test.py
+++ b/src/python/pants/backend/docker/docker_run_integration_test.py
@@ -1,0 +1,39 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from textwrap import dedent
+
+from pants.testutil.pants_integration_test import PantsResult, run_pants, setup_tmpdir
+
+
+def run_pants_with_sources(sources: dict[str, str], *args: str) -> PantsResult:
+    with setup_tmpdir(sources) as tmpdir:
+        return run_pants(
+            [
+                "--backend-packages=pants.backend.experimental.docker",
+                "--pants-ignore=__pycache__",
+            ]
+            + [arg.format(tmpdir=tmpdir) for arg in args]
+        )
+
+
+def test_docker_run() -> None:
+    sources = {
+        "BUILD": """docker_image(name="run-image")""",
+        "Dockerfile": dedent(
+            """\
+            FROM alpine
+            CMD echo "Hello from Docker image"
+            """
+        ),
+    }
+    result = run_pants_with_sources(
+        sources,
+        "run",
+        "{tmpdir}:run-image",
+    )
+
+    assert "Hello from Docker image\n" == result.stdout
+    result.assert_success()

--- a/src/python/pants/backend/docker/rules.py
+++ b/src/python/pants/backend/docker/rules.py
@@ -5,6 +5,7 @@ from pants.backend.docker.dependencies import rules as dependencies_rules
 from pants.backend.docker.docker_binary import rules as binary_rules
 from pants.backend.docker.docker_build import rules as build_rules
 from pants.backend.docker.docker_build_context import rules as context_rules
+from pants.backend.docker.docker_run import rules as run_rules
 from pants.backend.docker.dockerfile_parser import rules as parser_rules
 from pants.backend.docker.publish import rules as publish_rules
 from pants.backend.docker.subsystem import rules as subsystem_rules
@@ -18,5 +19,6 @@ def rules():
         *dependencies_rules(),
         *parser_rules(),
         *publish_rules(),
+        *run_rules(),
         *subsystem_rules(),
     ]


### PR DESCRIPTION
Refactor the docker run (and build) integration tests to actually run pants, not just simply use the RuleRunner.