### PR TITLE
[internal] Error when using `cgo` files

### DIFF
--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -93,7 +93,11 @@ class GoModPackageSourcesField(StringSequenceField, AsyncFieldMixin):
     default = ("**/*.go", "**/*.s")
     help = (
         "What sources to generate `go_first_party_package` targets for.\n\n"
-        "Pants will generate one target per matching directory."
+        "Pants will generate one target per matching directory.\n\n"
+        "Pants does not yet support some file types like `.c` and `.h` files, along with cgo "
+        "files. If you need to use these files, please open a feature request at "
+        "https://github.com/pantsbuild/pants/issues/new/choose so that we know to "
+        "prioritize adding support."
     )
 
     def _prefix_glob_with_address(self, glob: str) -> str:

--- a/src/python/pants/backend/go/util_rules/first_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg.py
@@ -86,6 +86,15 @@ async def compute_first_party_package_info(
         ),
     )
     metadata = json.loads(result.stdout)
+
+    if "CgoFiles" in metadata:
+        raise NotImplementedError(
+            f"The first-party package {request.address} includes `CgoFiles`, which Pants does "
+            "not yet support. Please open a feature request at "
+            "https://github.com/pantsbuild/pants/issues/new/choose so that we know to "
+            "prioritize adding support."
+        )
+
     return FirstPartyPkgInfo(
         digest=pkg_sources.snapshot.digest,
         imports=tuple(metadata.get("Imports", [])),


### PR DESCRIPTION
Cgo files are `.go` files that use C: https://pkg.go.dev/cmd/cgo. We do not have the infrastructure to support them yet, so we instead want to eagerly redirect users to file a feature request. 

Note that users cannot use other file types like `.h` and `.m` files already because the Sources field bans them. Only cgo files are possible because they end in `.go`.

[ci skip-rust]
[ci skip-build-wheels]