### PR TITLE
[internal] Remove `OwningGoMod` thanks to target generation

### DIFF
--- a/src/python/pants/backend/go/target_type_rules_test.py
+++ b/src/python/pants/backend/go/target_type_rules_test.py
@@ -70,27 +70,6 @@ def rule_runner() -> RuleRunner:
     return rule_runner
 
 
-def test_go_package_dependency_injection(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files(
-        {
-            "dir1/go.mod": "module foo",
-            "dir1/BUILD": "go_mod()",
-            "dir1/pkg/foo.go": "package pkg",
-            "dir2/bar/go.mod": "module bar",
-            "dir2/bar/src.go": "package bar",
-            "dir2/bar/BUILD": "go_mod()",
-        }
-    )
-
-    def assert_go_mod(pkg: Address, go_mod: Address) -> None:
-        tgt = rule_runner.get_target(pkg)
-        deps = rule_runner.request(Addresses, [DependenciesRequest(tgt[Dependencies])])
-        assert set(deps) == {go_mod}
-
-    assert_go_mod(Address("dir1", generated_name="./pkg"), Address("dir1"))
-    assert_go_mod(Address("dir2/bar", generated_name="./"), Address("dir2/bar"))
-
-
 def test_go_package_dependency_inference(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         (

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -22,12 +22,7 @@ from pants.backend.go.util_rules.assembly import (
 )
 from pants.backend.go.util_rules.compile import CompiledGoSources, CompileGoSourcesRequest
 from pants.backend.go.util_rules.first_party_pkg import FirstPartyPkgInfo, FirstPartyPkgInfoRequest
-from pants.backend.go.util_rules.go_mod import (
-    GoModInfo,
-    GoModInfoRequest,
-    OwningGoMod,
-    OwningGoModRequest,
-)
+from pants.backend.go.util_rules.go_mod import GoModInfo, GoModInfoRequest
 from pants.backend.go.util_rules.import_analysis import ImportConfig, ImportConfigRequest
 from pants.backend.go.util_rules.third_party_pkg import ThirdPartyPkgInfo, ThirdPartyPkgInfoRequest
 from pants.build_graph.address import Address
@@ -82,8 +77,8 @@ async def build_go_package(request: BuildGoPackageRequest) -> BuiltGoPackage:
         _module_path = target[GoThirdPartyModulePathField].value
         source_files_subpath = original_import_path[len(_module_path) :]
 
-        _owning_go_mod = await Get(OwningGoMod, OwningGoModRequest(target.address))
-        _go_mod_info = await Get(GoModInfo, GoModInfoRequest(_owning_go_mod.address))
+        _go_mod_address = target.address.maybe_convert_to_target_generator()
+        _go_mod_info = await Get(GoModInfo, GoModInfoRequest(_go_mod_address))
         _third_party_pkg_info = await Get(
             ThirdPartyPkgInfo,
             ThirdPartyPkgInfoRequest(

--- a/src/python/pants/backend/go/util_rules/first_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg.py
@@ -11,12 +11,7 @@ from pants.backend.go.target_types import (
     GoFirstPartyPackageSourcesField,
     GoFirstPartyPackageSubpathField,
 )
-from pants.backend.go.util_rules.go_mod import (
-    GoModInfo,
-    GoModInfoRequest,
-    OwningGoMod,
-    OwningGoModRequest,
-)
+from pants.backend.go.util_rules.go_mod import GoModInfo, GoModInfoRequest
 from pants.backend.go.util_rules.sdk import GoSdkProcess
 from pants.build_graph.address import Address
 from pants.engine.engine_aware import EngineAwareParameter
@@ -61,16 +56,16 @@ class FirstPartyPkgInfoRequest(EngineAwareParameter):
 async def compute_first_party_package_info(
     request: FirstPartyPkgInfoRequest,
 ) -> FirstPartyPkgInfo:
-    wrapped_target, owning_go_mod = await MultiGet(
+    go_mod_address = request.address.maybe_convert_to_target_generator()
+    wrapped_target, go_mod_info = await MultiGet(
         Get(WrappedTarget, Address, request.address),
-        Get(OwningGoMod, OwningGoModRequest(request.address)),
+        Get(GoModInfo, GoModInfoRequest(go_mod_address)),
     )
     target = wrapped_target.target
     subpath = target[GoFirstPartyPackageSubpathField].value
 
-    go_mod_info, pkg_sources = await MultiGet(
-        Get(GoModInfo, GoModInfoRequest(owning_go_mod.address)),
-        Get(HydratedSources, HydrateSourcesRequest(target[GoFirstPartyPackageSourcesField])),
+    pkg_sources = await Get(
+        HydratedSources, HydrateSourcesRequest(target[GoFirstPartyPackageSourcesField])
     )
     input_digest = await Get(
         Digest, MergeDigests([pkg_sources.snapshot.digest, go_mod_info.digest])
@@ -81,8 +76,8 @@ async def compute_first_party_package_info(
         GoSdkProcess(
             input_digest=input_digest,
             command=("list", "-json", f"./{subpath}"),
-            description=f"Determine metadata for {target.address}",
-            working_dir=owning_go_mod.address.spec_path,
+            description=f"Determine metadata for {request.address}",
+            working_dir=request.address.spec_path,
         ),
     )
     metadata = json.loads(result.stdout)


### PR DESCRIPTION
We eagerly validate that `go_{first,third}_party_package` targets are only created via target generation, so we can simply call `address.maybe_convert_to_target_generator()` to get the original `go_mod` target. 

This simplifies the code and improves performance by no longer needing to do `AddressSpecs([AscendantAddresses(request.address.spec_path)])`.

[ci skip-rust]
[ci skip-build-wheels]