### PR TITLE
[internal] CI: include java in release test

### DIFF
--- a/build-support/bin/_release_helper.py
+++ b/build-support/bin/_release_helper.py
@@ -189,6 +189,7 @@ def validate_pants_pkg(version: str, venv_dir: Path, extra_pip_args: list[str]) 
                         "'pants.backend.awslambda.python', "
                         "'pants.backend.python', "
                         "'pants.backend.shell', "
+                        "'pants.backend.experimental.java', "
                         "'internal_plugins.releases'"
                         "]"
                     ),


### PR DESCRIPTION
CI is broken after https://github.com/pantsbuild/pants/pull/13173 which introduced a `java_sources` for the Java plugin. That PR was marked "skip-wheels", so the release step being broken did not occur until it was on `main`.

[ci skip-rust]
