### PR TITLE
[internal] Use "file addresses" internally for some `files` and `resources` targets

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -3,9 +3,6 @@
 
 shell_library(name="scripts", sources=["cargo", "pants"])
 
-# We use this to establish the build root, rather than `./pants`, because we cannot safely use the
-# latter as the sentinel filename per https://github.com/pantsbuild/pants/pull/8105.
-files(name='build_root', sources=["BUILD_ROOT"])
-
-files(name='gitignore', sources=['.gitignore'])
-files(name='pants_toml', sources=['pants.toml'])
+# We use `BUILD_ROOT` to establish the build root, rather than `./pants`, per
+# https://github.com/pantsbuild/pants/pull/8105.
+files(name="files", sources=["BUILD_ROOT", ".gitignore", "pants.toml"])

--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -5,19 +5,12 @@
 python_library(
   name='entry_point',
   sources=['__main__.py'],
-  dependencies=[
-    'src/python/pants/bin:pants_loader',
-  ],
+  dependencies=['src/python/pants/bin:pants_loader'],
 )
 
 python_distribution(
   name='pants-packaged',
-  dependencies=[
-    ':dummy_c',
-    ':entry_point',
-    ':version',
-    ':py_typed',
-  ],
+  dependencies=[':entry_point', ':resources'],
   # Because we have native code, this will cause the wheel to use whatever the ABI is for the
   # interpreter used to run setup.py, e.g. `cp36m-macosx_10_15_x86_64`.
   sdist = False,
@@ -38,15 +31,6 @@ python_distribution(
   },
 )
 
-# NB: we use this to avoid clang/gcc complaining `error: no input files` when building
-# `:pants-packaged`. We don't actually need to use any meaningful file here, though, because we
-# use `entry_points` to link to the actual native code, so clang/gcc do not need to build any
-# native code. This is just a dummy file.
-resources(
-  name="dummy_c",
-  sources=['dummy.c'],
-)
-
 python_library(
   name='conftest',
   sources=['conftest.py'],
@@ -55,17 +39,11 @@ python_library(
 python_library(
   name='version',
   sources=['version.py'],
-  dependencies = [
-    ':version-resource',
-  ],
+  dependencies=["./VERSION:resources"],
 )
 
-resources(
-  name='version-resource',
-  sources=['VERSION'],
-)
-
-resources(
-  name="py_typed",
-  sources=["py.typed"],
-)
+# NB: we use `dummy.c` to avoid clang/gcc complaining `error: no input files` when building
+# `:pants-packaged`. We don't actually need to use any meaningful file here, though, because we
+# use `entry_points` to link to the actual native code, so clang/gcc do not need to build any
+# native code. This is just a dummy file.
+resources(name="resources", sources=["VERSION", "py.typed", "dummy.c"])

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -6,9 +6,7 @@ python_library()
 python_tests(
   name="tests",
   sources=['*_test.py', '!exception_sink_test.py', '!*_integration_test.py'],
-  dependencies = [
-    '//:build_root',
-  ],
+  dependencies=["//BUILD_ROOT:files"],
 )
 
 python_tests(

--- a/src/python/pants/help/BUILD
+++ b/src/python/pants/help/BUILD
@@ -6,7 +6,7 @@ python_library()
 python_tests(
   name='tests',
   sources=['*_test.py', '!*_integration_test.py'],
-  dependencies=["//:build_root"],
+  dependencies=["//BUILD_ROOT:files"],
 )
 
 python_tests(name="integration", sources=["*_integration_test.py"], timeout=360)

--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -7,8 +7,8 @@ python_tests(
   name="tests",
   dependencies=[
     # Used by `options_bootstrapper_test` and `config_test`.
-    '//:build_root',
-    '//:pants_toml',
+    '//BUILD_ROOT:files',
+    '//pants.toml:files',
   ],
   timeout=300,
 )

--- a/src/python/pants/testutil/BUILD
+++ b/src/python/pants/testutil/BUILD
@@ -32,14 +32,14 @@ python_library(
 python_library(
   name="rule_runner",
   sources=["rule_runner.py", "test_base.py"],
-  dependencies=["//:build_root"],
+  dependencies=["//BUILD_ROOT:files"],
 )
 
 python_library(
   name = 'pants_integration_test',
   sources = ['pants_integration_test.py'],
   dependencies = [
-    '//:build_root',
+    "//BUILD_ROOT:files",
     'src/python/pants:entry_point'
   ],
 )

--- a/src/python/pants/vcs/BUILD
+++ b/src/python/pants/vcs/BUILD
@@ -14,7 +14,7 @@ python_tests(
   name='changed_integration',
   sources=['changed_integration_test.py'],
   dependencies=[
-    '//:gitignore',
+    '//.gitignore:files',
     'testprojects/src/python:python_targets_directory',
     'testprojects/src/python:sources_directory',
   ],

--- a/tests/python/pants_test/init/BUILD
+++ b/tests/python/pants_test/init/BUILD
@@ -6,7 +6,7 @@ python_tests(
   timeout = 360,
   dependencies=[
     # Used by `test_options_initializer`.
-    '//:build_root',
+    "//BUILD_ROOT:files",
   ],
 )
 

--- a/tests/python/pants_test/pantsd/BUILD
+++ b/tests/python/pants_test/pantsd/BUILD
@@ -1,10 +1,7 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_tests(
-  sources=['test_*.py'],
-  dependencies=["//:build_root"],
-)
+python_tests(sources=['test_*.py'], dependencies=["//BUILD_ROOT:files"])
 
 python_library(
   name = 'pantsd_integration_test_base',


### PR DESCRIPTION
The insight from file targets and its [target generator followup](https://docs.google.com/document/d/1HpJn2jTWf5sKob6zhe4SqHZ7KWBlX4a6OJOwnuw-IHo/edit) is that not all targets generated from the same generator necessarily need to act together as an atomic unit. You can bundle together things into a single target generator, and then callers depend on the more specific generated target to get what they need.

This applies that philosophy to two `files()` and `resources()` target internal usages. No change in functionality, but tests out this mental model.

[ci skip-rust]
[ci skip-build-wheels]