### PR TITLE
Deprecate `module_mapping` and `type_stubs_module_mapping` fields for `python_requirement` in favor of `modules` and `type_stub_modules`

### DIFF
--- a/src/python/pants/backend/python/macros/pants_requirement.py
+++ b/src/python/pants/backend/python/macros/pants_requirement.py
@@ -63,5 +63,5 @@ class PantsRequirement:
             "python_requirement",
             name=name,
             requirements=[f"{dist}=={pants_version()}"],
-            module_mapping={dist: modules},
+            modules=modules,
         )

--- a/src/python/pants/backend/python/macros/pants_requirement_test.py
+++ b/src/python/pants/backend/python/macros/pants_requirement_test.py
@@ -2,12 +2,11 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import pytest
-from packaging.utils import canonicalize_name as canonicalize_project_name
 from pkg_resources import Requirement
 
 from pants.backend.python.macros.pants_requirement import PantsRequirement
 from pants.backend.python.target_types import (
-    ModuleMappingField,
+    PythonRequirementModulesField,
     PythonRequirementsField,
     PythonRequirementTarget,
 )
@@ -15,7 +14,6 @@ from pants.base.build_environment import pants_version
 from pants.engine.addresses import Address
 from pants.engine.internals.scheduler import ExecutionError
 from pants.testutil.rule_runner import RuleRunner
-from pants.util.frozendict import FrozenDict
 
 
 @pytest.fixture
@@ -40,9 +38,7 @@ def assert_pants_requirement(
     assert target[PythonRequirementsField].value == (
         Requirement.parse(f"{expected_dist}=={pants_version()}"),
     )
-    module_mapping = target[ModuleMappingField].value
-    assert isinstance(module_mapping, FrozenDict)
-    assert module_mapping.get(canonicalize_project_name(expected_dist)) == (expected_module,)
+    assert target[PythonRequirementModulesField].value == (expected_module,)
 
 
 def test_target_name(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/python/macros/pipenv_requirements.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements.py
@@ -79,24 +79,12 @@ class PipenvRequirements:
                 req_str += f";{info['markers']}"
 
             parsed_req = Requirement.parse(req_str)
-
             normalized_proj_name = canonicalize_project_name(parsed_req.project_name)
-            req_module_mapping = (
-                {normalized_proj_name: normalized_module_mapping[normalized_proj_name]}
-                if normalized_proj_name in normalized_module_mapping
-                else {}
-            )
-            req_stubs_mapping = (
-                {normalized_proj_name: normalized_type_stubs_module_mapping[normalized_proj_name]}
-                if normalized_proj_name in normalized_type_stubs_module_mapping
-                else {}
-            )
-
             self._parse_context.create_object(
                 "python_requirement",
                 name=parsed_req.project_name,
                 requirements=[parsed_req],
                 dependencies=[requirements_dep],
-                module_mapping=req_module_mapping,
-                type_stubs_module_mapping=req_stubs_mapping,
+                modules=normalized_module_mapping.get(normalized_proj_name),
+                type_stub_modules=normalized_type_stubs_module_mapping.get(normalized_proj_name),
             )

--- a/src/python/pants/backend/python/macros/pipenv_requirements_test.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements_test.py
@@ -48,12 +48,12 @@ def test_pipfile_lock(rule_runner: RuleRunner) -> None:
 
     Edge cases:
     * Develop and Default requirements are used
-    * If a module_mapping is given, and the project is in the map, we copy over a subset of the
-        mapping to the created target. It works regardless of capitalization.
+    * If a module_mapping is given, and the project is in the map, we set `modules`. It
+      works regardless of capitalization.
     """
     assert_pipenv_requirements(
         rule_runner,
-        "pipenv_requirements(module_mapping={'ansicolors': ['colors']})",
+        "pipenv_requirements(module_mapping={'ANSIcolors': ['colors']})",
         {
             "default": {"ansicolors": {"version": ">=1.18.0"}},
             "develop": {"cachetools": {"markers": "python_version ~= '3.5'", "version": "==4.1.1"}},
@@ -66,7 +66,7 @@ def test_pipfile_lock(rule_runner: RuleRunner) -> None:
                 {
                     "requirements": [Requirement.parse("ansicolors>=1.18.0")],
                     "dependencies": [":Pipfile.lock"],
-                    "module_mapping": {"ansiCOLORS": ["colors"]},
+                    "modules": ["colors"],
                 },
                 Address("", target_name="ansicolors"),
             ),

--- a/src/python/pants/backend/python/macros/poetry_requirements.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements.py
@@ -413,22 +413,11 @@ class PoetryRequirements:
         )
         for parsed_req in requirements:
             normalized_proj_name = canonicalize_project_name(parsed_req.project_name)
-            req_module_mapping = (
-                {normalized_proj_name: normalized_module_mapping[normalized_proj_name]}
-                if normalized_proj_name in normalized_module_mapping
-                else {}
-            )
-            req_stubs_mapping = (
-                {normalized_proj_name: normalized_type_stubs_module_mapping[normalized_proj_name]}
-                if normalized_proj_name in normalized_type_stubs_module_mapping
-                else {}
-            )
-
             self._parse_context.create_object(
                 "python_requirement",
                 name=parsed_req.project_name,
                 requirements=[parsed_req],
-                module_mapping=req_module_mapping,
-                type_stubs_module_mapping=req_stubs_mapping,
+                modules=normalized_module_mapping.get(normalized_proj_name),
+                type_stub_modules=normalized_type_stubs_module_mapping.get(normalized_proj_name),
                 dependencies=[requirements_dep],
             )

--- a/src/python/pants/backend/python/macros/poetry_requirements_test.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements_test.py
@@ -444,7 +444,7 @@ def test_pyproject_toml(rule_runner: RuleRunner) -> None:
                 {
                     "dependencies": [":pyproject.toml"],
                     "requirements": [Requirement.parse("ansicolors>=1.18.0")],
-                    "module_mapping": {"ansicolors": ["colors"]},
+                    "modules": ["colors"],
                 },
                 address=Address("", target_name="ansicolors"),
             ),
@@ -459,7 +459,7 @@ def test_pyproject_toml(rule_runner: RuleRunner) -> None:
                 {
                     "dependencies": [":pyproject.toml"],
                     "requirements": [Requirement.parse("Django-types==2")],
-                    "type_stubs_module_mapping": {"Django-types": ["django"]},
+                    "type_stub_modules": ["django"],
                 },
                 address=Address("", target_name="Django-types"),
             ),

--- a/src/python/pants/backend/python/macros/python_requirements.py
+++ b/src/python/pants/backend/python/macros/python_requirements.py
@@ -81,21 +81,11 @@ class PythonRequirements:
 
         for project_name, parsed_reqs_ in grouped_requirements:
             normalized_proj_name = canonicalize_project_name(project_name)
-            req_module_mapping = (
-                {normalized_proj_name: normalized_module_mapping[normalized_proj_name]}
-                if normalized_proj_name in normalized_module_mapping
-                else {}
-            )
-            req_stubs_mapping = (
-                {normalized_proj_name: normalized_type_stubs_module_mapping[normalized_proj_name]}
-                if normalized_proj_name in normalized_type_stubs_module_mapping
-                else {}
-            )
             self._parse_context.create_object(
                 "python_requirement",
                 name=project_name,
                 requirements=list(parsed_reqs_),
-                module_mapping=req_module_mapping,
-                type_stubs_module_mapping=req_stubs_mapping,
+                modules=normalized_module_mapping.get(normalized_proj_name),
+                type_stub_modules=normalized_type_stubs_module_mapping.get(normalized_proj_name),
                 dependencies=[requirements_dep],
             )

--- a/src/python/pants/backend/python/macros/python_requirements_test.py
+++ b/src/python/pants/backend/python/macros/python_requirements_test.py
@@ -82,7 +82,7 @@ def test_requirements_txt(rule_runner: RuleRunner) -> None:
                 {
                     "dependencies": [":requirements.txt"],
                     "requirements": [Requirement.parse("ansicolors>=1.18.0")],
-                    "module_mapping": {"ansicolors": ["colors"]},
+                    "modules": ["colors"],
                 },
                 Address("", target_name="ansicolors"),
             ),
@@ -97,7 +97,7 @@ def test_requirements_txt(rule_runner: RuleRunner) -> None:
                 {
                     "dependencies": [":requirements.txt"],
                     "requirements": [Requirement.parse("Django-types")],
-                    "type_stubs_module_mapping": {"Django-types": ["django"]},
+                    "type_stub_modules": ["django"],
                 },
                 Address("", target_name="Django-types"),
             ),

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -744,6 +744,41 @@ class PythonRequirementsField(_RequirementSequenceField):
     )
 
 
+_default_module_mapping_url = git_url(
+    "src/python/pants/backend/python/dependency_inference/default_module_mapping.py"
+)
+
+
+class PythonRequirementModulesField(StringSequenceField):
+    alias = "modules"
+    help = (
+        "The modules this requirement provides (used for dependency inference).\n\n"
+        'For example, the requirement `setuptools` provides `["setuptools", "pkg_resources", '
+        '"easy_install"]`.\n\n'
+        "Usually you can leave this field off. If unspecified, Pants will first look at the "
+        f"default module mapping ({_default_module_mapping_url}), and then will default to "
+        "the normalized project name. For example, the requirement `Django` would default to "
+        "the module `django`.\n\n"
+        "Mutually exclusive with the `type_stub_modules` field."
+    )
+
+
+class PythonRequirementTypeStubModulesField(StringSequenceField):
+    alias = "type_stub_modules"
+    help = (
+        "The modules this requirement provides if the requirement is a type stub (used for "
+        "dependency inference).\n\n"
+        'For example, the requirement `types-requests` provides `["requests"]`.\n\n'
+        "Usually you can leave this field off. If unspecified, Pants will first look at the "
+        f"default module mapping ({_default_module_mapping_url}). If not found _and_ the "
+        "requirement name starts with `types-` or `stubs-`, or ends with `-types` or `-stubs`, "
+        "will default to that requirement name without the prefix/suffix. For example, "
+        "`types-requests` would default to `requests`. Otherwise, will be treated like a normal "
+        "requirement (see the `modules` field).\n\n"
+        "Mutually exclusive with the `modules` field."
+    )
+
+
 def normalize_module_mapping(
     mapping: Mapping[str, Iterable[str]] | None
 ) -> FrozenDict[str, tuple[str, ...]]:
@@ -761,6 +796,14 @@ class ModuleMappingField(DictStringToStringSequenceField):
     )
     value: FrozenDict[str, tuple[str, ...]]
     default: ClassVar[FrozenDict[str, tuple[str, ...]]] = FrozenDict()
+    removal_version = "2.9.0.dev0"
+    removal_hint = (
+        "Use the field `modules` instead, which takes a list of modules the `python_requirement` "
+        "target provides.\n\n"
+        "If this `python_requirement` target has multiple distinct 3rd-party "
+        "projects in its `requirements` field, you should split those up into one `"
+        "python_requirement` target per distinct project."
+    )
 
     @classmethod
     def compute_value(  # type: ignore[override]
@@ -784,6 +827,14 @@ class TypeStubsModuleMappingField(DictStringToStringSequenceField):
     )
     value: FrozenDict[str, tuple[str, ...]]
     default: ClassVar[FrozenDict[str, tuple[str, ...]]] = FrozenDict()
+    removal_version = "2.9.0.dev0"
+    removal_hint = (
+        "Use the field `type_stub_modules` instead, which takes a list of modules the "
+        "`python_requirement` target provides type stubs for.\n\n"
+        "If this `python_requirement` target has multiple distinct 3rd-party "
+        "projects in its `requirements` field, you should split those up into one `"
+        "python_requirement` target per distinct project."
+    )
 
     @classmethod
     def compute_value(  # type: ignore[override]
@@ -799,6 +850,8 @@ class PythonRequirementTarget(Target):
         *COMMON_TARGET_FIELDS,
         Dependencies,
         PythonRequirementsField,
+        PythonRequirementModulesField,
+        PythonRequirementTypeStubModulesField,
         ModuleMappingField,
         TypeStubsModuleMappingField,
     )
@@ -821,6 +874,18 @@ class PythonRequirementTarget(Target):
         f"{git_url('build-support/migration-support/rename_targets_pants28.py')}, then run "
         "`python3 rename_targets_pants28.py --help` for instructions."
     )
+
+    def validate(self) -> None:
+        if (
+            self[PythonRequirementModulesField].value
+            and self[PythonRequirementTypeStubModulesField].value
+        ):
+            raise InvalidTargetException(
+                f"The `{self.alias}` target {self.address} cannot set both the "
+                f"`{self[PythonRequirementModulesField].alias}` and "
+                f"`{self[PythonRequirementTypeStubModulesField].alias}` fields at the same time. "
+                "To fix, please remove one."
+            )
 
 
 # -----------------------------------------------------------------------------------------------


### PR DESCRIPTION
As articulated in https://github.com/pantsbuild/pants/pull/13133, a `python_requirement` target is meant to represent a single distinct third-party project. Even though we let you put multiple `requirements` strings, that's only to accommodate `Django==2 ; sys_version<3 && Django==3 ; sys_version>3`.

Given that, having a `module_mapping` dict field is overly verbose. A `python_requirement` should only have one `project_name`, i.e. it should be a dict with only a single key.

Fixing this simplifies the target and strengthens the conceptual model.

[ci skip-rust]
[ci skip-build-wheels]