### PR TITLE
Deprecate `requirements_relpath` and `pyproject_toml_relpath` in favor of `source` for `python_requirements` and `poetry_requirements`

### DIFF
--- a/src/python/pants/backend/python/macros/pipenv_requirements.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements.py
@@ -61,7 +61,7 @@ class PipenvRequirements:
                 f"macro in the BUILD file at {self._parse_context.rel_path}. Use one, preferably "
                 "`source`."
             )
-        if requirements_relpath:
+        if requirements_relpath is not None:
             warn_or_error(
                 "2.9.0.dev0",
                 "the `requirements_relpath` argument for `pipenv_requirements()`",
@@ -72,7 +72,7 @@ class PipenvRequirements:
                 ),
             )
             source = requirements_relpath
-        if not source:
+        if source is None:
             source = "Pipfile.lock"
 
         requirements_path = Path(get_buildroot(), self._parse_context.rel_path, source)

--- a/src/python/pants/backend/python/macros/pipenv_requirements_test.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements_test.py
@@ -122,14 +122,15 @@ def test_properly_creates_extras_requirements(rule_runner: RuleRunner) -> None:
     )
 
 
-def test_supply_python_requirements_file(rule_runner: RuleRunner) -> None:
+@pytest.mark.parametrize("source_arg", ("source", "requirements_relpath"))
+def test_supply_python_requirements_file(source_arg: str, rule_runner: RuleRunner) -> None:
     """This tests that we can supply our own `_python_requirements_file`."""
     assert_pipenv_requirements(
         rule_runner,
         dedent(
-            """
+            f"""
             pipenv_requirements(
-                source='custom/pipfile/Pipfile.lock',
+                {source_arg}='custom/pipfile/Pipfile.lock',
                 pipfile_target='//:custom_pipfile_target'
             )
 

--- a/src/python/pants/backend/python/macros/poetry_requirements.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements.py
@@ -406,7 +406,7 @@ class PoetryRequirements:
                 f"macro in the BUILD file at {self._parse_context.rel_path}. Use one, preferably "
                 "`source`."
             )
-        if pyproject_toml_relpath:
+        if pyproject_toml_relpath is not None:
             warn_or_error(
                 "2.9.0.dev0",
                 "the `pyproject_toml_relpath` argument for `poetry_requirements()`",
@@ -417,7 +417,7 @@ class PoetryRequirements:
                 ),
             )
             source = pyproject_toml_relpath
-        if not source:
+        if source is None:
             source = "pyproject.toml"
 
         req_file_tgt = self._parse_context.create_object(

--- a/src/python/pants/backend/python/macros/poetry_requirements_test.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements_test.py
@@ -474,10 +474,11 @@ def test_pyproject_toml(rule_runner: RuleRunner) -> None:
     )
 
 
-def test_source_override(rule_runner: RuleRunner) -> None:
+@pytest.mark.parametrize("source_arg", ("source", "pyproject_toml_relpath"))
+def test_source_override(source_arg: str, rule_runner: RuleRunner) -> None:
     assert_poetry_requirements(
         rule_runner,
-        "poetry_requirements(source='subdir/pyproject.toml')",
+        f"poetry_requirements({source_arg}='subdir/pyproject.toml')",
         dedent(
             """\
             [tool.poetry.dependencies]

--- a/src/python/pants/backend/python/macros/python_requirements.py
+++ b/src/python/pants/backend/python/macros/python_requirements.py
@@ -72,7 +72,7 @@ class PythonRequirements:
                 f"macro in the BUILD file at {self._parse_context.rel_path}. Use one, preferably "
                 "`source`."
             )
-        if requirements_relpath:
+        if requirements_relpath is not None:
             warn_or_error(
                 "2.9.0.dev0",
                 "the `requirements_relpath` argument for `python_requirements()`",
@@ -83,7 +83,7 @@ class PythonRequirements:
                 ),
             )
             source = requirements_relpath
-        if not source:
+        if source is None:
             source = "requirements.txt"
 
         req_file_tgt = self._parse_context.create_object(

--- a/src/python/pants/backend/python/macros/python_requirements_test.py
+++ b/src/python/pants/backend/python/macros/python_requirements_test.py
@@ -195,10 +195,11 @@ def test_invalid_req(rule_runner: RuleRunner) -> None:
     assert "It looks like you're trying to use a pip VCS-style requirement?" in str(exc.value)
 
 
-def test_source_override(rule_runner: RuleRunner) -> None:
+@pytest.mark.parametrize("source_arg", ("source", "requirements_relpath"))
+def test_source_override(source_arg: str, rule_runner: RuleRunner) -> None:
     assert_python_requirements(
         rule_runner,
-        "python_requirements(source='subdir/requirements.txt')",
+        f"python_requirements({source_arg}='subdir/requirements.txt')",
         "ansicolors>=1.18.0",
         requirements_txt_relpath="subdir/requirements.txt",
         expected_file_dep=PythonRequirementsFile(


### PR DESCRIPTION
`source` is more consistent with the new names we'll be introducing post-https://github.com/pantsbuild/pants/pull/13202 for file-based targets like `docker_image` and `file`. Also less verbose.

A followup will add this to `./pants mend` to auto-fix BUILD files for users.

[ci skip-rust]