### PR TITLE
[internal] Bump isort integration test timeout

### DIFF
--- a/src/python/pants/backend/python/lint/isort/BUILD
+++ b/src/python/pants/backend/python/lint/isort/BUILD
@@ -7,7 +7,7 @@ resources(name="lockfile", sources=["lockfile.txt"])
 python_tests(
     name="rules_integration_test",
     sources=["rules_integration_test.py"],
-    timeout=120,
+    timeout=180,
     # We want to make sure the default lockfile works for both macOS and Linux.
     tags=["platform_specific_behavior"],
 )


### PR DESCRIPTION
Occasionally flakes on the macOS shard.

[ci skip-rust]
[ci skip-build-wheels]