### PR TITLE
[internal] Create `go_binary` targets with `./pants tailor`

### DIFF
--- a/src/python/pants/backend/go/goals/tailor.py
+++ b/src/python/pants/backend/go/goals/tailor.py
@@ -1,10 +1,20 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import os
+import re
 from dataclasses import dataclass
 
-from pants.backend.go.target_types import GoModTarget
+from pants.backend.go.target_types import (
+    GoBinaryMainPackage,
+    GoBinaryMainPackageField,
+    GoBinaryMainPackageRequest,
+    GoBinaryTarget,
+    GoModTarget,
+)
+from pants.base.specs import AddressSpecs, AscendantAddresses
 from pants.core.goals.tailor import (
     AllOwnedSources,
     PutativeTarget,
@@ -12,26 +22,34 @@ from pants.core.goals.tailor import (
     PutativeTargetsRequest,
     group_by_dir,
 )
-from pants.engine.fs import PathGlobs, Paths
-from pants.engine.internals.selectors import Get
-from pants.engine.rules import collect_rules, rule
+from pants.engine.fs import DigestContents, PathGlobs, Paths
+from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.target import UnexpandedTargets
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 
 
 @dataclass(frozen=True)
-class PutativeGoModuleTargetsRequest(PutativeTargetsRequest):
+class PutativeGoTargetsRequest(PutativeTargetsRequest):
     pass
 
 
-@rule(level=LogLevel.DEBUG, desc="Determine candidate `go_mod` targets to create")
-async def find_putative_go_mod_targets(
-    request: PutativeGoModuleTargetsRequest, all_owned_sources: AllOwnedSources
+_package_main_re = re.compile(rb"^package main\s*(//.*)?$", re.MULTILINE)
+
+
+def has_package_main(content: bytes) -> bool:
+    return _package_main_re.search(content) is not None
+
+
+@rule(level=LogLevel.DEBUG, desc="Determine candidate Go targets to create")
+async def find_putative_go_targets(
+    request: PutativeGoTargetsRequest, all_owned_sources: AllOwnedSources
 ) -> PutativeTargets:
+    putative_targets = []
+
+    # Add `go_mod` targets.
     all_go_mod_files = await Get(Paths, PathGlobs, request.search_paths.path_globs("go.mod"))
     unowned_go_mod_files = set(all_go_mod_files.files) - set(all_owned_sources)
-
-    putative_targets = []
     for dirname, filenames in group_by_dir(unowned_go_mod_files).items():
         putative_targets.append(
             PutativeTarget.for_target_type(
@@ -42,8 +60,41 @@ async def find_putative_go_mod_targets(
             )
         )
 
+    # Add `go_binary` targets.
+    digest_contents = await Get(DigestContents, PathGlobs, request.search_paths.path_globs("*.go"))
+    main_package_dirs = [
+        os.path.dirname(file_content.path)
+        for file_content in digest_contents
+        if has_package_main(file_content.content)
+    ]
+    existing_targets = await Get(
+        UnexpandedTargets, AddressSpecs(AscendantAddresses(d) for d in main_package_dirs)
+    )
+    owned_main_packages = await MultiGet(
+        Get(GoBinaryMainPackage, GoBinaryMainPackageRequest(t[GoBinaryMainPackageField]))
+        for t in existing_targets
+        if t.has_field(GoBinaryMainPackageField)
+    )
+    unowned_main_package_dirs = set(main_package_dirs) - {
+        # We can be confident `go_first_party_package` targets were generated, meaning that the
+        # below will get us the full path to the package's directory.
+        # TODO: generalize this
+        os.path.join(pkg.address.spec_path, pkg.address.generated_name[2:]).rstrip("/")  # type: ignore[index]
+        for pkg in owned_main_packages
+    }
+    putative_targets.extend(
+        PutativeTarget.for_target_type(
+            target_type=GoBinaryTarget,
+            path=main_pkg_dir,
+            name="bin",
+            triggering_sources=tuple(),
+            kwargs={"name": "bin"},
+        )
+        for main_pkg_dir in unowned_main_package_dirs
+    )
+
     return PutativeTargets(putative_targets)
 
 
 def rules():
-    return [*collect_rules(), UnionRule(PutativeTargetsRequest, PutativeGoModuleTargetsRequest)]
+    return [*collect_rules(), UnionRule(PutativeTargetsRequest, PutativeGoTargetsRequest)]

--- a/src/python/pants/backend/go/goals/tailor_test.py
+++ b/src/python/pants/backend/go/goals/tailor_test.py
@@ -1,11 +1,15 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import pytest
 
-from pants.backend.go.goals.tailor import PutativeGoModuleTargetsRequest
+from pants.backend.go import target_type_rules
+from pants.backend.go.goals.tailor import PutativeGoTargetsRequest, has_package_main
 from pants.backend.go.goals.tailor import rules as go_tailor_rules
-from pants.backend.go.target_types import GoModTarget
+from pants.backend.go.target_types import GoBinaryTarget, GoModTarget
+from pants.backend.go.util_rules import first_party_pkg, go_mod, sdk, third_party_pkg
 from pants.core.goals.tailor import (
     AllOwnedSources,
     PutativeTarget,
@@ -18,27 +22,44 @@ from pants.testutil.rule_runner import RuleRunner
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
-    return RuleRunner(
+    rule_runner = RuleRunner(
         rules=[
             *go_tailor_rules(),
-            QueryRule(PutativeTargets, [PutativeGoModuleTargetsRequest, AllOwnedSources]),
+            *go_mod.rules(),
+            *first_party_pkg.rules(),
+            *third_party_pkg.rules(),
+            *sdk.rules(),
+            *target_type_rules.rules(),
+            QueryRule(PutativeTargets, [PutativeGoTargetsRequest, AllOwnedSources]),
         ],
-        target_types=[GoModTarget],
+        target_types=[GoModTarget, GoBinaryTarget],
     )
+    rule_runner.set_options([], env_inherit={"PATH"})
+    return rule_runner
 
 
-def test_find_putative_go_mod_targets(rule_runner: RuleRunner) -> None:
+def test_find_putative_go_targets(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "src/go/owned/BUILD": "go_mod()\n",
-            "src/go/owned/go.mod": "module example.com/src/go/owned\n",
+            # No `go_mod`, should be created.
             "src/go/unowned/go.mod": "module example.com/src/go/unowned\n",
+            # Already has `go_mod`.
+            "src/go/owned/go.mod": "module example.com/src/go/owned\n",
+            "src/go/owned/BUILD": "go_mod()\n",
+            # Missing `go_binary()`, should be created.
+            "src/go/owned/pkg1/app.go": "package main",
+            # Already has a `go_binary()`.
+            "src/go/owned/pkg2/app.go": "package main",
+            "src/go/owned/pkg2/BUILD": "go_binary()",
+            # Has a `go_binary` defined in a different directory.
+            "src/go/owned/pkg3/subdir/app.go": "package main",
+            "src/go/owned/pkg3/BUILD": "go_binary(main='src/go/owned#./pkg3/subdir')",
         }
     )
     putative_targets = rule_runner.request(
         PutativeTargets,
         [
-            PutativeGoModuleTargetsRequest(PutativeTargetsSearchPaths(("src/",))),
+            PutativeGoTargetsRequest(PutativeTargetsSearchPaths(("src/",))),
             AllOwnedSources(["src/go/owned/go.mod"]),
         ],
     )
@@ -46,6 +67,22 @@ def test_find_putative_go_mod_targets(rule_runner: RuleRunner) -> None:
         [
             PutativeTarget.for_target_type(
                 GoModTarget, path="src/go/unowned", name="unowned", triggering_sources=["go.mod"]
-            )
+            ),
+            PutativeTarget.for_target_type(
+                GoBinaryTarget,
+                path="src/go/owned/pkg1",
+                name="bin",
+                triggering_sources=[],
+                kwargs={"name": "bin"},
+            ),
         ]
     )
+
+
+def test_has_package_main() -> None:
+    assert has_package_main(b"package main")
+    assert has_package_main(b"package main // comment 1233")
+    assert has_package_main(b"\n\npackage main\n")
+    assert not has_package_main(b"package foo")
+    assert not has_package_main(b'var = "package main"')
+    assert not has_package_main(b"   package main")

--- a/src/python/pants/backend/python/lint/pyupgrade/BUILD
+++ b/src/python/pants/backend/python/lint/pyupgrade/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library(dependencies=[":lockfile"])
+python_sources(dependencies=[":lockfile"])
 resources(name="lockfile", sources=["lockfile.txt"])
 
 python_tests(


### PR DESCRIPTION
We check for `package main`, and first confirm there aren't any `go_binary` targets already for that directory. 

Note that we simply read the file for `package main` rather than using `go list`, as it's faster and avoids needing a Go toolchain (e.g. `go.mod` to e present).

[ci skip-rust]
[ci skip-build-wheels]