### PR TITLE
Add `[mypy].extra_type_stubs` (Cherry-pick of #13180)

### DIFF
--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -83,13 +83,9 @@ NEEDS_CONFIG_FILE = dedent(
 def run_mypy(
     rule_runner: RuleRunner, targets: list[Target], *, extra_args: list[str] | None = None
 ) -> tuple[TypecheckResult, ...]:
-    rule_runner.set_options(
-        ["--backend-packages=pants.backend.python.typecheck.mypy", *(extra_args or ())],
-        env_inherit={"PATH", "PYENV_ROOT", "HOME"},
-    )
+    rule_runner.set_options(extra_args or (), env_inherit={"PATH", "PYENV_ROOT", "HOME"})
     result = rule_runner.request(
-        TypecheckResults,
-        [MyPyRequest(MyPyFieldSet.create(tgt) for tgt in targets)],
+        TypecheckResults, [MyPyRequest(MyPyFieldSet.create(tgt) for tgt in targets)]
     )
     return result.results
 
@@ -227,18 +223,11 @@ def test_thirdparty_dependency(rule_runner: RuleRunner) -> None:
 
 
 def test_thirdparty_plugin(rule_runner: RuleRunner) -> None:
-    # NB: We install `django-stubs` both with `[mypy].extra_requirements` and a user requirement
-    # (`python_requirement_library`). This awkwardness is because its used both as a plugin and
+    # NB: We install `django-stubs` both with `[mypy].extra_requirements` and
+    # `[mypy].extra_type_stubs`. This awkwardness is because its used both as a plugin and
     # type stubs.
     rule_runner.write_files(
         {
-            "BUILD": dedent(
-                """\
-                python_requirement_library(
-                    name='django', requirements=['Django==2.2.5', 'django-stubs==1.8.0'],
-                )
-                """
-            ),
             f"{PACKAGE}/settings.py": dedent(
                 """\
                 from django.urls import URLPattern
@@ -276,6 +265,7 @@ def test_thirdparty_plugin(rule_runner: RuleRunner) -> None:
         [tgt],
         extra_args=[
             "--mypy-extra-requirements=django-stubs==1.8.0",
+            "--mypy-extra-type-stubs=django-stubs==1.8.0",
             "--mypy-version=mypy==0.812",
             "--mypy-lockfile=<none>",
         ],

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -128,6 +128,21 @@ class MyPy(PythonToolBase):
                 "`plugins` option in `mypy.ini`."
             ),
         )
+        register(
+            "--extra-type-stubs",
+            type=list,
+            member_type=str,
+            advanced=True,
+            help=(
+                "Extra type stub requirements to install when running MyPy.\n\n"
+                "Normally, type stubs can be installed as typical requirements, such as putting "
+                "them in `requirements.txt` or using a `python_requirement_library` target."
+                "Alternatively, you can use this option so that the dependencies are solely "
+                "used when running MyPy and are not runtime dependencies.\n\n"
+                "Expects a list of pip-style requirement strings, like "
+                "`['types-requests==2.25.9']`."
+            ),
+        )
 
     @property
     def skip(self) -> bool:
@@ -136,6 +151,10 @@ class MyPy(PythonToolBase):
     @property
     def args(self) -> tuple[str, ...]:
         return tuple(self.options.args)
+
+    @property
+    def extra_type_stubs(self) -> tuple[str, ...]:
+        return tuple(self.options.extra_type_stubs)
 
     @property
     def config(self) -> str | None:


### PR DESCRIPTION
Follows up on https://github.com/pantsbuild/pants/pull/12597. While that change was necessary as explained there, we've had feedback from two users that they want to retain the ability to specify type stubs via option rather than normal runtime dependencies. For example, one user wants to avoid an increase in `.pex` size (because one of the stubs incorrectly depends on MyPy).

Ideally, we should probably re-envision third-party type stubs wholesale so that our code distinguishes between normal dependencies vs. type stubs dependencies. When running MyPy, we use type stubs. When packaging, for example, we know to leave them off. But that requires design work and time to implement.

In the meantime, we can add `[mypy].extra_type_stubs`, which satisfies the different requirements:

* We don't install these into the "tool PEX", which is necessary per https://github.com/pantsbuild/pants/pull/12597.
* Type stubs continue to work when done as a normal requirement. These are "extra".

There is one weird edge: these type stubs don't have a lockfile associated with them. Those can't use the tool lockfile because we cannot tell MyPy to point into its tool lockfile (https://github.com/pantsbuild/pants/pull/12597). It would require a lot of new infrastructure to have a dedicated lockfile for `extra_type_stubs`. So, instead, if you do care about lockfiles, you should use type stubs like normal dependencies rather than using this option.

[ci skip-rust]
[ci skip-build-wheels]