### PR TITLE
[jvm] Ignore symbols exposed by unnamed packages.

### DIFF
--- a/src/python/pants/backend/java/dependency_inference/package_mapper.py
+++ b/src/python/pants/backend/java/dependency_inference/package_mapper.py
@@ -94,7 +94,12 @@ async def map_first_party_java_targets_to_symbols(
     dep_map = PackageRootedDependencyMap()
     for address, analysis in address_and_analysis:
         for top_level_type in analysis.top_level_types:
-            package, type_ = top_level_type.rsplit(".", maxsplit=1)
+            components = top_level_type.rsplit(".", maxsplit=1)
+            if len(components) != 2:
+                # A package without a name cannot be imported, and so does not expose any symbols.
+                # https://docs.oracle.com/javase/specs/jls/se8/html/jls-7.html#jls-7.4.2
+                continue
+            package, type_ = components
             dep_map.add_top_level_type(package=package, type_=type_, address=address)
 
     return FirstPartyJavaMappingImpl(package_rooted_dependency_map=dep_map)

--- a/src/python/pants/backend/java/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/java/dependency_inference/rules_test.py
@@ -204,6 +204,31 @@ def test_infer_java_imports_with_cycle(rule_runner: RuleRunner) -> None:
 
 
 @maybe_skip_jdk_test
+def test_infer_java_imports_unnamed_package(rule_runner: RuleRunner) -> None:
+    # A source file without a package declaration lives in the "unnamed package", and does not
+    # export any symbols.
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                """\
+                java_sources(name = 'a')
+                """
+            ),
+            "Main.java": dedent(
+                """\
+                public class Main {}
+                """
+            ),
+        }
+    )
+    target_a = rule_runner.get_target(Address("", target_name="a", relative_file_path="Main.java"))
+
+    assert rule_runner.request(
+        InferredDependencies, [InferJavaImportDependencies(target_a[JavaSourceField])]
+    ) == InferredDependencies(dependencies=[])
+
+
+@maybe_skip_jdk_test
 def test_infer_java_imports_same_target_with_cycle(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {


### PR DESCRIPTION
Symbols in the unnamed package cannot be imported: skip trying to expose their symbols.

[ci skip-rust]
[ci skip-build-wheels]