### PR TITLE
[internal] Add `Target.residence_dir` as prework to fix CLI specs for generated targets

### DIFF
--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -228,7 +228,7 @@ async def generate_targets_from_go_mod(
             # E.g. `src/go:mod#./subdir`.
             generator_addr.create_generated(f"./{subpath}"),
             union_membership,
-            resident_dir=dir,
+            residence_dir=dir,
         )
 
     first_party_pkgs = (create_first_party_package_tgt(dir) for dir in matched_dirs)
@@ -243,7 +243,7 @@ async def generate_targets_from_go_mod(
             # E.g. `src/go:mod#github.com/google/uuid`.
             generator_addr.create_generated(pkg_info.import_path),
             union_membership,
-            resident_dir=generator_addr.spec_path,
+            residence_dir=generator_addr.spec_path,
         )
 
     third_party_pkgs = (

--- a/src/python/pants/backend/go/target_type_rules_test.py
+++ b/src/python/pants/backend/go/target_type_rules_test.py
@@ -178,7 +178,7 @@ def test_generate_package_targets(rule_runner: RuleRunner) -> None:
                 GoFirstPartyPackageSourcesField.alias: tuple(sources),
             },
             Address("src/go", generated_name=f"./{rel_dir}"),
-            resident_dir=os.path.join("src/go", rel_dir).rstrip("/"),
+            residence_dir=os.path.join("src/go", rel_dir).rstrip("/"),
         )
 
     def gen_third_party_tgt(

--- a/src/python/pants/backend/terraform/target_gen.py
+++ b/src/python/pants/backend/terraform/target_gen.py
@@ -56,7 +56,7 @@ async def generate_terraform_module_targets(
             generated_target_fields,
             generator.address.create_generated(relpath_to_generator or "."),
             union_membership,
-            resident_dir=dir,
+            residence_dir=dir,
         )
 
     return GeneratedTargets(request.generator, [gen_target(dir) for dir in matched_dirs])

--- a/src/python/pants/backend/terraform/target_gen_test.py
+++ b/src/python/pants/backend/terraform/target_gen_test.py
@@ -53,12 +53,12 @@ def test_target_generation_at_build_root(rule_runner: RuleRunner) -> None:
             TerraformModuleTarget(
                 {TerraformModuleSourcesField.alias: ("src/tf/foo/versions.tf",)},
                 generator_addr.create_generated("src/tf/foo"),
-                resident_dir="src/tf/foo",
+                residence_dir="src/tf/foo",
             ),
             TerraformModuleTarget(
                 {TerraformModuleSourcesField.alias: ("src/tf/outputs.tf", "src/tf/versions.tf")},
                 generator_addr.create_generated("src/tf"),
-                resident_dir="src/tf",
+                residence_dir="src/tf",
             ),
         ],
     )
@@ -84,12 +84,12 @@ def test_target_generation_at_subdir(rule_runner: RuleRunner) -> None:
             TerraformModuleTarget(
                 {TerraformModuleSourcesField.alias: ("foo/versions.tf",)},
                 generator_addr.create_generated("foo"),
-                resident_dir="src/tf/foo",
+                residence_dir="src/tf/foo",
             ),
             TerraformModuleTarget(
                 {TerraformModuleSourcesField.alias: ("versions.tf",)},
                 generator_addr.create_generated("."),
-                resident_dir="src/tf",
+                residence_dir="src/tf",
             ),
         ],
     )

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -289,7 +289,7 @@ class Target:
     address: Address
     plugin_fields: tuple[type[Field], ...]
     field_values: FrozenDict[type[Field], Field]
-    resident_dir: str
+    residence_dir: str
 
     @final
     def __init__(
@@ -301,7 +301,7 @@ class Target:
         # rarely directly instantiate Targets and should instead use the engine to request them.
         union_membership: UnionMembership | None = None,
         *,
-        resident_dir: str | None = None,
+        residence_dir: str | None = None,
     ) -> None:
         """Create a target.
 
@@ -309,7 +309,7 @@ class Target:
             fields will either use their default or error if required=True.
         :param address: How to uniquely identify this target.
         :param union_membership: Used to determine plugin fields. This must be set in production!
-        :param resident_dir: Where this target "lives". If unspecified, will be the `spec_path`
+        :param residence_dir: Where this target "lives". If unspecified, will be the `spec_path`
             of the `address`, i.e. where the target was either explicitly defined or where its
             target generator was explicitly defined. Target generators can, however, set this to
             the directory where the generated target provides metadata for. For example, a
@@ -337,7 +337,7 @@ class Target:
         self.address = address
         self.plugin_fields = self._find_plugin_fields(union_membership or UnionMembership({}))
 
-        self.resident_dir = resident_dir if resident_dir is not None else address.spec_path
+        self.residence_dir = residence_dir if residence_dir is not None else address.spec_path
 
         field_values = {}
         aliases_to_field_types = {field_type.alias: field_type for field_type in self.field_types}
@@ -384,7 +384,7 @@ class Target:
             f"{self.__class__}("
             f"address={self.address}, "
             f"alias={repr(self.alias)}, "
-            f"resident_dir={repr(self.resident_dir)}, "
+            f"residence_dir={repr(self.residence_dir)}, "
             f"{fields})"
         )
 
@@ -394,15 +394,15 @@ class Target:
         return f"{self.alias}({address}{fields})"
 
     def __hash__(self) -> int:
-        return hash((self.__class__, self.address, self.resident_dir, self.field_values))
+        return hash((self.__class__, self.address, self.residence_dir, self.field_values))
 
     def __eq__(self, other: Union[Target, Any]) -> bool:
         if not isinstance(other, Target):
             return NotImplemented
-        return (self.__class__, self.address, self.resident_dir, self.field_values) == (
+        return (self.__class__, self.address, self.residence_dir, self.field_values) == (
             other.__class__,
             other.address,
-            other.resident_dir,
+            other.residence_dir,
             other.field_values,
         )
 
@@ -898,7 +898,7 @@ def generate_file_level_targets(
             generated_target_fields,
             address,
             union_membership,
-            resident_dir=os.path.dirname(full_fp),
+            residence_dir=os.path.dirname(full_fp),
         )
 
     return GeneratedTargets(

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -429,10 +429,10 @@ def test_target_validate() -> None:
         FortranTarget({FortranVersion.alias: "bad"}, Address("", target_name="t"))
 
 
-def test_target_resident_dir() -> None:
-    assert FortranTarget({}, Address("some_dir/subdir")).resident_dir == "some_dir/subdir"
+def test_target_residence_dir() -> None:
+    assert FortranTarget({}, Address("some_dir/subdir")).residence_dir == "some_dir/subdir"
     assert (
-        FortranTarget({}, Address("some_dir/subdir"), resident_dir="another_dir").resident_dir
+        FortranTarget({}, Address("some_dir/subdir"), residence_dir="another_dir").residence_dir
         == "another_dir"
     )
 
@@ -476,12 +476,12 @@ def test_generate_file_level_targets() -> None:
             MockGenerated(
                 {MultipleSourcesField.alias: ["f1.ext"], Tags.alias: ["tag"]},
                 Address("demo", relative_file_path="f1.ext"),
-                resident_dir="demo",
+                residence_dir="demo",
             ),
             MockGenerated(
                 {MultipleSourcesField.alias: ["f2.ext"], Tags.alias: ["tag"]},
                 Address("demo", relative_file_path="f2.ext"),
-                resident_dir="demo",
+                residence_dir="demo",
             ),
         ],
     )
@@ -497,7 +497,7 @@ def test_generate_file_level_targets() -> None:
                     Tags.alias: ["tag"],
                 },
                 Address("demo", relative_file_path="f1.ext"),
-                resident_dir="demo",
+                residence_dir="demo",
             ),
             MockGenerated(
                 {
@@ -506,7 +506,7 @@ def test_generate_file_level_targets() -> None:
                     Tags.alias: ["tag"],
                 },
                 Address("demo", relative_file_path="f2.ext"),
-                resident_dir="demo",
+                residence_dir="demo",
             ),
         ],
     )
@@ -521,7 +521,7 @@ def test_generate_file_level_targets() -> None:
             MockGenerated(
                 {MultipleSourcesField.alias: ["subdir/demo.f95"]},
                 Address("src/fortran", target_name="demo", relative_file_path="subdir/demo.f95"),
-                resident_dir="src/fortran/subdir",
+                residence_dir="src/fortran/subdir",
             )
         ],
     )
@@ -533,7 +533,7 @@ def test_generate_file_level_targets() -> None:
             MockGenerated(
                 {MultipleSourcesField.alias: ["subdir/demo.f95"]},
                 Address("src/fortran", target_name="demo", generated_name="subdir/demo.f95"),
-                resident_dir="src/fortran/subdir",
+                residence_dir="src/fortran/subdir",
             )
         ],
     )


### PR DESCRIPTION
Generated targets behave weirdly with address specs. If you have a `go_mod` target generator `src/go`, you would expect `./pants test src/go/dir::` to run all tests in `dir` and below. But Pants won't do anything! This is because the generated targets technically live in `src/go`, where their target generator is.

It's important that we continue to keep the address's `spec_path` as the target generator's. That allows us to determine how to generate the target in `Address -> WrappedTarget` without having to resort to `Specs` code.

Instead, this PR adds a `residence_dir` property on `Target`, with a default of its address's `spec_path`. This allows generated targets to express their relationship with subdirectories, while keeping their address at the target generator. In a followup, we can use this to update our `Specs -> Addresses` codepath to better handle specs for generated targets.

Why `residence_dir` instead of `residence_file` or `residence_dirs`? CLI specs already work well with file arguments, thanks to our ownership code (we find the "owners" of a file). The only other way to address a specific file is to use a literal address spec for a file-based target like `python_source`, which already works well. What is broken is the `:` and `::` specs, which are directory based. This field allows us to determine if a target "resides" in the directory.

[ci skip-rust]
[ci skip-build-wheels]