### PR TITLE
Fix `./pants help targets` to not include deprecated target names

### DIFF
--- a/src/python/pants/backend/scala/BUILD
+++ b/src/python/pants/backend/scala/BUILD
@@ -1,8 +1,4 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library()
-
-python_tests(
-    name="tests",
-)
+python_sources()

--- a/src/python/pants/backend/scala/compile/BUILD
+++ b/src/python/pants/backend/scala/compile/BUILD
@@ -1,5 +1,5 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library()
+python_sources()
 python_tests(name="tests", timeout=240)

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -269,7 +269,11 @@ class HelpInfoExtracter:
         name_to_target_type_info = {
             alias: TargetTypeHelpInfo.create(target_type, union_membership=union_membership)
             for alias, target_type in registered_target_types.aliases_to_types.items()
-            if not alias.startswith("_") and target_type.removal_version is None
+            if (
+                not alias.startswith("_")
+                and target_type.removal_version is None
+                and alias != target_type.deprecated_alias
+            )
         }
 
         return AllHelpInfo(


### PR DESCRIPTION
[ci skip-rust]
[ci skip-build-wheels]