### PR TITLE
`shell_sources` and `shunit2_tests` targets now generate `shell_source` and `shunit2_test` targets

### DIFF
--- a/src/python/pants/backend/shell/register.py
+++ b/src/python/pants/backend/shell/register.py
@@ -5,13 +5,21 @@ from pants.backend.shell import dependency_inference, shell_command, shunit2_tes
 from pants.backend.shell.target_types import (
     ShellCommand,
     ShellSourcesGeneratorTarget,
+    ShellSourceTarget,
     Shunit2TestsGeneratorTarget,
+    Shunit2TestTarget,
 )
 from pants.backend.shell.target_types import rules as target_types_rules
 
 
 def target_types():
-    return [ShellCommand, ShellSourcesGeneratorTarget, Shunit2TestsGeneratorTarget]
+    return [
+        ShellCommand,
+        ShellSourcesGeneratorTarget,
+        Shunit2TestsGeneratorTarget,
+        ShellSourceTarget,
+        Shunit2TestTarget,
+    ]
 
 
 def rules():

--- a/src/python/pants/backend/shell/shunit2_test_runner_integration_test.py
+++ b/src/python/pants/backend/shell/shunit2_test_runner_integration_test.py
@@ -19,7 +19,7 @@ from pants.backend.shell.shunit2_test_runner import (
     Shunit2RunnerRequest,
 )
 from pants.backend.shell.target_types import (
-    ShellSourcesGeneratorTarget,
+    ShellSourceTarget,
     Shunit2Shell,
     Shunit2ShellField,
     Shunit2TestsGeneratorTarget,
@@ -56,7 +56,7 @@ def rule_runner() -> RuleRunner:
             QueryRule(Shunit2Runner, [Shunit2RunnerRequest]),
         ],
         target_types=[
-            ShellSourcesGeneratorTarget,
+            ShellSourceTarget,
             Shunit2TestsGeneratorTarget,
             PythonSourcesGeneratorTarget,
             PexBinary,
@@ -163,8 +163,8 @@ def test_dependencies(rule_runner: RuleRunner) -> None:
             "BUILD": dedent(
                 """\
                 shunit2_tests(name="t", dependencies=[':direct'])
-                shell_sources(name="direct", sources=['direct.sh'], dependencies=[':transitive'])
-                shell_sources(name="transitive", sources=['transitive.sh'])
+                shell_source(name="direct", source='direct.sh', dependencies=[':transitive'])
+                shell_source(name="transitive", source='transitive.sh')
                 """
             ),
         }

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -125,7 +125,7 @@ class Shunit2ShellField(StringField):
 
 
 class Shunit2TestTarget(Target):
-    alias = "shunit2_tests"  # TODO(#12954): rename to `shunit_test` when ready. Update `help` too.
+    alias = "shunit2_test"
     core_fields = (
         *COMMON_TARGET_FIELDS,
         Shunit2TestSourceField,
@@ -134,7 +134,16 @@ class Shunit2TestTarget(Target):
         Shunit2ShellField,
         RuntimePackageDependenciesField,
     )
-    help = "A test file for Bourne-based shell scripts using the shunit2 test framework."
+    help = (
+        "A single test file for Bourne-based shell scripts using the shunit2 test framework.\n\n"
+        "To use, add tests to your file per https://github.com/kward/shunit2/. Specify the shell "
+        f"to run with by either setting the field `{Shunit2ShellField.alias}` or including a "
+        f"shebang. To test the same file with multiple shells, create multiple `shunit2_tests` "
+        f"targets, one for each shell.\n\n"
+        f"Pants will automatically download the `shunit2` bash script and add "
+        f"`source ./shunit2` to your test for you. If you already have `source ./shunit2`, "
+        f"Pants will overwrite it to use the correct relative path."
+    )
 
 
 # -----------------------------------------------------------------------------------------------
@@ -156,16 +165,7 @@ class Shunit2TestsGeneratorTarget(Target):
         Shunit2ShellField,
         RuntimePackageDependenciesField,
     )
-    help = (
-        "Tests of Bourne-based shell scripts using the shUnit2 test framework.\n\n"
-        "To use, add tests to your file per https://github.com/kward/shunit2/. Specify the shell "
-        f"to run with by either setting the field `{Shunit2ShellField.alias}` or including a "
-        f"shebang. To test the same file with multiple shells, create multiple `shunit2_tests` "
-        f"targets, one for each shell.\n\n"
-        f"Pants will automatically download the `shunit2` bash script and add "
-        f"`source ./shunit2` to your test for you. If you already have `source ./shunit2`, "
-        f"Pants will overwrite it to use the correct relative path."
-    )
+    help = "Generate a `shunit2_test` target for each file in the `sources` field."
 
 
 class GenerateTargetsFromShunit2Tests(GenerateTargetsRequest):
@@ -196,12 +196,9 @@ async def generate_targets_from_shunit2_tests(
 
 
 class ShellSourceTarget(Target):
-    alias = "shell_sources"  # TODO(#12954): rename to `shell_source` when ready.
+    alias = "shell_source"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, ShellSourceField)
-    help = "A Bourne-based shell script, e.g. a Bash script."
-
-    deprecated_alias = "shell_library"
-    deprecated_alias_removal_version = "2.9.0.dev0"
+    help = "A single Bourne-based shell script, e.g. a Bash script."
 
 
 class ShellSourcesGeneratingSourcesField(ShellGeneratingSourcesBases):
@@ -211,7 +208,7 @@ class ShellSourcesGeneratingSourcesField(ShellGeneratingSourcesBases):
 class ShellSourcesGeneratorTarget(Target):
     alias = "shell_sources"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, ShellSourcesGeneratingSourcesField)
-    help = "Bourne-based shell scripts, e.g. Bash scripts."
+    help = "Generate a `shell_source` target for each file in the `sources` field."
 
     deprecated_alias = "shell_library"
     deprecated_alias_removal_version = "2.9.0.dev0"


### PR DESCRIPTION
See https://github.com/pantsbuild/pants/pull/13235 for the motivation and impact to `./pants peek` and `./pants filter --target-type`.

[ci skip-rust]
[ci skip-build-wheels]