### PR TITLE
Add support for filesystem addresses referring to directories

### DIFF
--- a/src/python/pants/backend/go/goals/tailor.py
+++ b/src/python/pants/backend/go/goals/tailor.py
@@ -78,8 +78,7 @@ async def find_putative_go_targets(
     unowned_main_package_dirs = set(main_package_dirs) - {
         # We can be confident `go_first_party_package` targets were generated, meaning that the
         # below will get us the full path to the package's directory.
-        # TODO: generalize this
-        os.path.join(pkg.address.spec_path, pkg.address.generated_name[2:]).rstrip("/")  # type: ignore[index]
+        pkg.address.filename.rstrip("/")
         for pkg in owned_main_packages
     }
     putative_targets.extend(

--- a/src/python/pants/backend/go/goals/tailor_test.py
+++ b/src/python/pants/backend/go/goals/tailor_test.py
@@ -53,7 +53,7 @@ def test_find_putative_go_targets(rule_runner: RuleRunner) -> None:
             "src/go/owned/pkg2/BUILD": "go_binary()",
             # Has a `go_binary` defined in a different directory.
             "src/go/owned/pkg3/subdir/app.go": "package main",
-            "src/go/owned/pkg3/BUILD": "go_binary(main='src/go/owned#./pkg3/subdir')",
+            "src/go/owned/pkg3/BUILD": "go_binary(main='src/go/owned/pkg3/subdir/:../../owned')",
         }
     )
     putative_targets = rule_runner.request(

--- a/src/python/pants/backend/go/goals/test_test.py
+++ b/src/python/pants/backend/go/goals/test_test.py
@@ -74,7 +74,7 @@ def test_internal_test_success(rule_runner: RuleRunner) -> None:
             ),
         }
     )
-    tgt = rule_runner.get_target(Address("foo", generated_name="./"))
+    tgt = rule_runner.get_target(Address("foo", relative_file_path=""))
     result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
     assert result.exit_code == 0
     assert result.stdout == "PASS\n"
@@ -96,7 +96,7 @@ def test_internal_test_fails(rule_runner: RuleRunner) -> None:
             ),
         }
     )
-    tgt = rule_runner.get_target(Address("foo", generated_name="./"))
+    tgt = rule_runner.get_target(Address("foo", relative_file_path=""))
     result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
     assert result.exit_code == 1
     assert "FAIL: TestAdd" in result.stdout
@@ -131,7 +131,7 @@ def test_internal_benchmark_passes(rule_runner: RuleRunner) -> None:
             ),
         }
     )
-    tgt = rule_runner.get_target(Address("foo", generated_name="./"))
+    tgt = rule_runner.get_target(Address("foo", relative_file_path=""))
     result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
     assert result.exit_code == 0
     assert result.stdout == "PASS\n"
@@ -156,7 +156,7 @@ def test_internal_example_passes(rule_runner: RuleRunner) -> None:
             ),
         }
     )
-    tgt = rule_runner.get_target(Address("foo", generated_name="./"))
+    tgt = rule_runner.get_target(Address("foo", relative_file_path=""))
     result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
     assert result.exit_code == 0
     assert result.stdout == "PASS\n"
@@ -184,7 +184,7 @@ def test_internal_test_with_test_main(rule_runner: RuleRunner) -> None:
             ),
         }
     )
-    tgt = rule_runner.get_target(Address("foo", generated_name="./"))
+    tgt = rule_runner.get_target(Address("foo", relative_file_path=""))
     result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
     assert result.exit_code == 0
     assert "foo.TestMain called" in result.stdout
@@ -219,7 +219,7 @@ def test_external_test_success(rule_runner: RuleRunner) -> None:
             ),
         }
     )
-    tgt = rule_runner.get_target(Address("foo", generated_name="./"))
+    tgt = rule_runner.get_target(Address("foo", relative_file_path=""))
     result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
     assert result.exit_code == 0
     assert result.stdout == "PASS\n"
@@ -252,7 +252,7 @@ def test_external_test_fails(rule_runner: RuleRunner) -> None:
             ),
         }
     )
-    tgt = rule_runner.get_target(Address("foo", generated_name="./"))
+    tgt = rule_runner.get_target(Address("foo", relative_file_path=""))
     result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
     assert result.exit_code == 1
     assert "FAIL: TestAdd" in result.stdout
@@ -290,7 +290,7 @@ def test_external_benchmark_passes(rule_runner: RuleRunner) -> None:
             ),
         }
     )
-    tgt = rule_runner.get_target(Address("foo", generated_name="./"))
+    tgt = rule_runner.get_target(Address("foo", relative_file_path=""))
     result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
     assert result.exit_code == 0
     assert result.stdout == "PASS\n"
@@ -324,7 +324,7 @@ def test_external_example_passes(rule_runner: RuleRunner) -> None:
             ),
         }
     )
-    tgt = rule_runner.get_target(Address("foo", generated_name="./"))
+    tgt = rule_runner.get_target(Address("foo", relative_file_path=""))
     result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
     assert result.exit_code == 0
     assert result.stdout == "PASS\n"
@@ -364,7 +364,7 @@ def test_external_test_with_test_main(rule_runner: RuleRunner) -> None:
             ),
         }
     )
-    tgt = rule_runner.get_target(Address("foo", generated_name="./"))
+    tgt = rule_runner.get_target(Address("foo", relative_file_path=""))
     result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
     assert result.exit_code == 0
     assert "foo_test.TestMain called" in result.stdout
@@ -408,7 +408,7 @@ def test_both_internal_and_external_tests_fail(rule_runner: RuleRunner) -> None:
             ),
         }
     )
-    tgt = rule_runner.get_target(Address("foo", generated_name="./"))
+    tgt = rule_runner.get_target(Address("foo", relative_file_path=""))
     result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
     assert result.exit_code == 1
     assert "FAIL: TestAddInternal" in result.stdout

--- a/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
@@ -174,8 +174,8 @@ def test_multiple_targets(rule_runner: RuleRunner) -> None:
         }
     )
     tgts = [
-        rule_runner.get_target(Address("", target_name="mod", relative_file_path="good")),
-        rule_runner.get_target(Address("", target_name="mod", relative_file_path="bad")),
+        rule_runner.get_target(Address("", target_name="mod", relative_file_path="good/")),
+        rule_runner.get_target(Address("", target_name="mod", relative_file_path="bad/")),
     ]
     lint_results, fmt_result = run_gofmt(rule_runner, tgts)
     assert len(lint_results) == 1

--- a/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
@@ -126,7 +126,7 @@ def get_digest(rule_runner: RuleRunner, source_files: dict[str, str]) -> Digest:
 
 def test_passing(rule_runner: RuleRunner) -> None:
     rule_runner.write_files({"f.go": GOOD_FILE, "go.mod": GO_MOD, "BUILD": "go_mod(name='mod')"})
-    tgt = rule_runner.get_target(Address("", target_name="mod", generated_name="./"))
+    tgt = rule_runner.get_target(Address("", target_name="mod", relative_file_path=""))
     lint_results, fmt_result = run_gofmt(rule_runner, [tgt])
     assert len(lint_results) == 1
     assert lint_results[0].exit_code == 0
@@ -138,7 +138,7 @@ def test_passing(rule_runner: RuleRunner) -> None:
 
 def test_failing(rule_runner: RuleRunner) -> None:
     rule_runner.write_files({"f.go": BAD_FILE, "go.mod": GO_MOD, "BUILD": "go_mod(name='mod')"})
-    tgt = rule_runner.get_target(Address("", target_name="mod", generated_name="./"))
+    tgt = rule_runner.get_target(Address("", target_name="mod", relative_file_path=""))
     lint_results, fmt_result = run_gofmt(rule_runner, [tgt])
     assert len(lint_results) == 1
     assert lint_results[0].exit_code == 1
@@ -152,7 +152,7 @@ def test_mixed_sources(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {"good.go": GOOD_FILE, "bad.go": BAD_FILE, "go.mod": GO_MOD, "BUILD": "go_mod(name='mod')"}
     )
-    tgt = rule_runner.get_target(Address("", target_name="mod", generated_name="./"))
+    tgt = rule_runner.get_target(Address("", target_name="mod", relative_file_path=""))
     lint_results, fmt_result = run_gofmt(rule_runner, [tgt])
     assert len(lint_results) == 1
     assert lint_results[0].exit_code == 1
@@ -174,8 +174,8 @@ def test_multiple_targets(rule_runner: RuleRunner) -> None:
         }
     )
     tgts = [
-        rule_runner.get_target(Address("", target_name="mod", generated_name="./good")),
-        rule_runner.get_target(Address("", target_name="mod", generated_name="./bad")),
+        rule_runner.get_target(Address("", target_name="mod", relative_file_path="good")),
+        rule_runner.get_target(Address("", target_name="mod", relative_file_path="bad")),
     ]
     lint_results, fmt_result = run_gofmt(rule_runner, tgts)
     assert len(lint_results) == 1
@@ -190,7 +190,7 @@ def test_multiple_targets(rule_runner: RuleRunner) -> None:
 
 def test_skip(rule_runner: RuleRunner) -> None:
     rule_runner.write_files({"f.go": BAD_FILE, "go.mod": GO_MOD, "BUILD": "go_mod(name='mod')"})
-    tgt = rule_runner.get_target(Address("", target_name="mod", generated_name="./"))
+    tgt = rule_runner.get_target(Address("", target_name="mod", relative_file_path=""))
     lint_results, fmt_result = run_gofmt(rule_runner, [tgt], extra_args=["--gofmt-skip"])
     assert not lint_results
     assert fmt_result.skipped is True

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -223,8 +223,8 @@ async def generate_targets_from_go_mod(
                     sorted(os.path.join(subpath, f) for f in dir_to_filenames[dir])
                 ),
             },
-            # E.g. `src/go:mod#./subdir`.
-            generator_addr.create_generated(f"./{subpath}"),
+            # E.g. `src/go/subdir:../mod`.
+            generator_addr.create_filesystem(subpath),
         )
 
     first_party_pkgs = (create_first_party_package_tgt(dir) for dir in matched_dirs)

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -223,8 +223,8 @@ async def generate_targets_from_go_mod(
                     sorted(os.path.join(subpath, f) for f in dir_to_filenames[dir])
                 ),
             },
-            # E.g. `src/go/subdir:../mod`.
-            generator_addr.create_filesystem(subpath),
+            # E.g. `src/go/subdir/:../mod`.
+            generator_addr.create_filesystem(f"{subpath}/" if subpath else subpath),
         )
 
     first_party_pkgs = (create_first_party_package_tgt(dir) for dir in matched_dirs)

--- a/src/python/pants/backend/go/util_rules/build_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_test.py
@@ -358,7 +358,7 @@ def test_build_target_with_dependencies(rule_runner: RuleRunner) -> None:
     quoter_import_path = "example.com/project/greeter/quoter"
     assert_pkg_target_built(
         rule_runner,
-        Address("", target_name="mod", relative_file_path="greeter/quoter"),
+        Address("", target_name="mod", relative_file_path="greeter/quoter/"),
         expected_import_path=quoter_import_path,
         expected_subpath="greeter/quoter",
         expected_go_file_names=["lib.go"],
@@ -369,7 +369,7 @@ def test_build_target_with_dependencies(rule_runner: RuleRunner) -> None:
     greeter_import_path = "example.com/project/greeter"
     assert_pkg_target_built(
         rule_runner,
-        Address("", target_name="mod", relative_file_path="greeter"),
+        Address("", target_name="mod", relative_file_path="greeter/"),
         expected_import_path=greeter_import_path,
         expected_subpath="greeter",
         expected_go_file_names=["lib.go"],

--- a/src/python/pants/backend/go/util_rules/build_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_test.py
@@ -208,7 +208,7 @@ def test_build_first_party_pkg_target(rule_runner: RuleRunner) -> None:
     )
     assert_pkg_target_built(
         rule_runner,
-        Address("", target_name="mod", generated_name="./"),
+        Address("", target_name="mod", relative_file_path=""),
         expected_import_path="example.com/greeter",
         expected_subpath="",
         expected_go_file_names=["greeter.go"],
@@ -358,7 +358,7 @@ def test_build_target_with_dependencies(rule_runner: RuleRunner) -> None:
     quoter_import_path = "example.com/project/greeter/quoter"
     assert_pkg_target_built(
         rule_runner,
-        Address("", target_name="mod", generated_name="./greeter/quoter"),
+        Address("", target_name="mod", relative_file_path="greeter/quoter"),
         expected_import_path=quoter_import_path,
         expected_subpath="greeter/quoter",
         expected_go_file_names=["lib.go"],
@@ -369,17 +369,17 @@ def test_build_target_with_dependencies(rule_runner: RuleRunner) -> None:
     greeter_import_path = "example.com/project/greeter"
     assert_pkg_target_built(
         rule_runner,
-        Address("", target_name="mod", generated_name="./greeter"),
+        Address("", target_name="mod", relative_file_path="greeter"),
         expected_import_path=greeter_import_path,
         expected_subpath="greeter",
         expected_go_file_names=["lib.go"],
-        expected_direct_dependency_import_paths=[quoter_import_path, xerrors_import_path],
+        expected_direct_dependency_import_paths=[xerrors_import_path, quoter_import_path],
         expected_transitive_dependency_import_paths=[xerrors_internal_import_path],
     )
 
     assert_pkg_target_built(
         rule_runner,
-        Address("", target_name="mod", generated_name="./"),
+        Address("", target_name="mod", relative_file_path=""),
         expected_import_path="example.com/project",
         expected_subpath="",
         expected_go_file_names=["main.go"],

--- a/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
@@ -86,7 +86,7 @@ def test_package_info(rule_runner: RuleRunner) -> None:
     ) -> None:
         info = rule_runner.request(
             FirstPartyPkgInfo,
-            [FirstPartyPkgInfoRequest(Address("foo", relative_file_path=subpath))],
+            [FirstPartyPkgInfoRequest(Address("foo", relative_file_path=f"{subpath}/"))],
         )
         actual_snapshot = rule_runner.request(Snapshot, [info.digest])
         expected_snapshot = rule_runner.request(Snapshot, [PathGlobs([f"foo/{subpath}/*.go"])])

--- a/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
@@ -86,7 +86,7 @@ def test_package_info(rule_runner: RuleRunner) -> None:
     ) -> None:
         info = rule_runner.request(
             FirstPartyPkgInfo,
-            [FirstPartyPkgInfoRequest(Address("foo", generated_name=f"./{subpath}"))],
+            [FirstPartyPkgInfoRequest(Address("foo", relative_file_path=subpath))],
         )
         actual_snapshot = rule_runner.request(Snapshot, [info.digest])
         expected_snapshot = rule_runner.request(Snapshot, [PathGlobs([f"foo/{subpath}/*.go"])])
@@ -152,5 +152,5 @@ def test_cgo_not_supported(rule_runner: RuleRunner) -> None:
     with engine_error(NotImplementedError):
         rule_runner.request(
             FirstPartyPkgInfo,
-            [FirstPartyPkgInfoRequest(Address("", target_name="mod", generated_name="./"))],
+            [FirstPartyPkgInfoRequest(Address("", target_name="mod", relative_file_path=""))],
         )

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -835,11 +835,7 @@ def generate_file_level_targets(
         all_generated_addresses.append(
             generator.address.create_generated(relativized_fp)
             if use_generated_address_syntax
-            else Address(
-                generator.address.spec_path,
-                target_name=generator.address.target_name,
-                relative_file_path=relativized_fp,
-            )
+            else generator.address.create_filesystem(relativized_fp)
         )
 
     all_generated_address_specs = (


### PR DESCRIPTION
Add support for having file(system) `Addresses` refer to directories, and try out using them for firstparty `go` packages.

To do this, filesystem addresses referring to directories gain a trailing slash:
```shell
# (new) Directory owned by a target inside of it (validated via a type check in AddressInput).
dir/:target
# (new) Directory owned by the default target inside of it.
dir/
# File owned by a target next to it (based on a type check in AddressInput).
file:target
# File owned by the default target in its directory.
file
# Target inside of a directory (based on a type check in AddressInput).
dir:target
```

[ci skip-rust]