### PR TITLE
Don't invalidate dependency inference when unrelated file names change

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/protobuf_dependency_inference.py
+++ b/src/python/pants/backend/codegen/protobuf/protobuf_dependency_inference.py
@@ -9,8 +9,7 @@ from dataclasses import dataclass
 from typing import DefaultDict
 
 from pants.backend.codegen.protobuf.protoc import Protoc
-from pants.backend.codegen.protobuf.target_types import ProtobufSourceField
-from pants.base.specs import AddressSpecs, DescendantAddresses
+from pants.backend.codegen.protobuf.target_types import AllProtobufTargets, ProtobufSourceField
 from pants.core.util_rules.stripped_source_files import StrippedSourceFileNames
 from pants.engine.addresses import Address
 from pants.engine.fs import Digest, DigestContents
@@ -24,7 +23,6 @@ from pants.engine.target import (
     InferDependenciesRequest,
     InferredDependencies,
     SourcesPathsRequest,
-    Targets,
     WrappedTarget,
 )
 from pants.engine.unions import UnionRule
@@ -42,9 +40,7 @@ class ProtobufMapping:
 
 
 @rule(desc="Creating map of Protobuf file names to Protobuf targets", level=LogLevel.DEBUG)
-async def map_protobuf_files() -> ProtobufMapping:
-    targets = await Get(Targets, AddressSpecs([DescendantAddresses("")]))
-    protobuf_targets = tuple(tgt for tgt in targets if tgt.has_field(ProtobufSourceField))
+async def map_protobuf_files(protobuf_targets: AllProtobufTargets) -> ProtobufMapping:
     stripped_sources_per_target = await MultiGet(
         Get(StrippedSourceFileNames, SourcesPathsRequest(tgt[ProtobufSourceField]))
         for tgt in protobuf_targets

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_module_mapper.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_module_mapper.py
@@ -4,16 +4,19 @@
 from collections import defaultdict
 from typing import DefaultDict
 
-from pants.backend.codegen.protobuf.target_types import ProtobufGrpcToggleField, ProtobufSourceField
+from pants.backend.codegen.protobuf.target_types import (
+    AllProtobufTargets,
+    ProtobufGrpcToggleField,
+    ProtobufSourceField,
+)
 from pants.backend.python.dependency_inference.module_mapper import (
     FirstPartyPythonMappingImpl,
     FirstPartyPythonMappingImplMarker,
 )
-from pants.base.specs import AddressSpecs, DescendantAddresses
 from pants.core.util_rules.stripped_source_files import StrippedSourceFileNames
 from pants.engine.addresses import Address
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import SourcesPathsRequest, Target, Targets
+from pants.engine.target import SourcesPathsRequest, Target
 from pants.engine.unions import UnionRule
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
@@ -30,10 +33,9 @@ class PythonProtobufMappingMarker(FirstPartyPythonMappingImplMarker):
 
 @rule(desc="Creating map of Protobuf targets to generated Python modules", level=LogLevel.DEBUG)
 async def map_protobuf_to_python_modules(
+    protobuf_targets: AllProtobufTargets,
     _: PythonProtobufMappingMarker,
 ) -> FirstPartyPythonMappingImpl:
-    targets = await Get(Targets, AddressSpecs([DescendantAddresses("")]))
-    protobuf_targets = tuple(tgt for tgt in targets if tgt.has_field(ProtobufSourceField))
     stripped_sources_per_target = await MultiGet(
         Get(StrippedSourceFileNames, SourcesPathsRequest(tgt[ProtobufSourceField]))
         for tgt in protobuf_targets

--- a/src/python/pants/backend/codegen/protobuf/target_types.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types.py
@@ -5,6 +5,7 @@ from pants.backend.codegen.protobuf.protoc import Protoc
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
+    AllTargets,
     BoolField,
     Dependencies,
     GeneratedTargets,
@@ -14,10 +15,12 @@ from pants.engine.target import (
     SourcesPaths,
     SourcesPathsRequest,
     Target,
+    Targets,
     generate_file_level_targets,
 )
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.util.docutil import doc_url, git_url
+from pants.util.logging import LogLevel
 
 
 # NB: We subclass Dependencies so that specific backends can add dependency injection rules to
@@ -30,6 +33,15 @@ class ProtobufGrpcToggleField(BoolField):
     alias = "grpc"
     default = False
     help = "Whether to generate gRPC code or not."
+
+
+class AllProtobufTargets(Targets):
+    pass
+
+
+@rule(desc="Find all Protobuf targets in project", level=LogLevel.DEBUG)
+def find_all_protobuf_targets(targets: AllTargets) -> AllProtobufTargets:
+    return AllProtobufTargets(tgt for tgt in targets if tgt.has_field(ProtobufSourceField))
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -34,7 +34,6 @@ from pants.backend.python.util_rules.lockfile_metadata import (
     calculate_invalidation_digest,
 )
 from pants.backend.python.util_rules.pex import PexRequest, PexRequirements, VenvPex, VenvPexProcess
-from pants.base.specs import AddressSpecs, DescendantAddresses
 from pants.engine.collection import Collection
 from pants.engine.fs import (
     CreateDigest,
@@ -47,7 +46,7 @@ from pants.engine.fs import (
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import ProcessCacheScope, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
-from pants.engine.target import TransitiveTargets, TransitiveTargetsRequest, UnexpandedTargets
+from pants.engine.target import AllTargets, TransitiveTargets, TransitiveTargetsRequest
 from pants.engine.unions import UnionMembership, union
 from pants.python.python_repos import PythonRepos
 from pants.python.python_setup import PythonSetup
@@ -269,12 +268,11 @@ class _UserLockfileRequests(Collection[PythonLockfileRequest]):
 
 @rule
 async def setup_user_lockfile_requests(
-    requested: _SpecifiedUserResolves, python_setup: PythonSetup
+    requested: _SpecifiedUserResolves, all_targets: AllTargets, python_setup: PythonSetup
 ) -> _UserLockfileRequests:
     # First, associate all resolves with their consumers.
-    all_build_targets = await Get(UnexpandedTargets, AddressSpecs([DescendantAddresses("")]))
     resolves_to_roots = defaultdict(list)
-    for tgt in all_build_targets:
+    for tgt in all_targets:
         if not tgt.has_field(PythonResolveField):
             continue
         tgt[PythonResolveField].validate(python_setup)

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -16,10 +16,9 @@ from pants.backend.python.target_types import (
     PythonSourceField,
 )
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.base.specs import AddressSpecs, DescendantAddresses
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import Get, collect_rules, rule
-from pants.engine.target import FieldSet, Target, Targets
+from pants.engine.target import AllTargets, AllTargetsRequest, FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.option.custom_types import file_option, shell_str
 from pants.python.python_setup import PythonSetup
@@ -132,7 +131,7 @@ async def setup_bandit_lockfile(
     #
     # This ORs all unique interpreter constraints. The net effect is that every possible Python
     # interpreter used will be covered.
-    all_tgts = await Get(Targets, AddressSpecs([DescendantAddresses("")]))
+    all_tgts = await Get(AllTargets, AllTargetsRequest())
     unique_constraints = {
         InterpreterConstraints.create_from_targets([tgt], python_setup)
         for tgt in all_tgts

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -11,10 +11,9 @@ from pants.backend.python.lint.black.skip_field import SkipBlackField
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.base.specs import AddressSpecs, DescendantAddresses
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import Get, collect_rules, rule
-from pants.engine.target import UnexpandedTargets
+from pants.engine.target import AllTargets, AllTargetsRequest
 from pants.engine.unions import UnionRule
 from pants.option.custom_types import file_option, shell_str
 from pants.python.python_setup import PythonSetup
@@ -122,9 +121,10 @@ async def setup_black_lockfile(
 
     constraints = black.interpreter_constraints
     if black.options.is_default("interpreter_constraints"):
-        all_build_targets = await Get(UnexpandedTargets, AddressSpecs([DescendantAddresses("")]))
+        all_tgts = await Get(AllTargets, AllTargetsRequest())
+        # TODO: fix to use `FieldSet.is_applicable()`.
         code_constraints = InterpreterConstraints.create_from_targets(
-            (tgt for tgt in all_build_targets if not tgt.get(SkipBlackField).value), python_setup
+            (tgt for tgt in all_tgts if not tgt.get(SkipBlackField).value), python_setup
         )
         if code_constraints.requires_python38_or_newer(python_setup.interpreter_universe):
             constraints = code_constraints

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -16,10 +16,9 @@ from pants.backend.python.target_types import (
     PythonSourceField,
 )
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.base.specs import AddressSpecs, DescendantAddresses
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import Get, collect_rules, rule
-from pants.engine.target import FieldSet, Target, Targets
+from pants.engine.target import AllTargets, AllTargetsRequest, FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.option.custom_types import file_option, shell_str
 from pants.python.python_setup import PythonSetup
@@ -141,7 +140,7 @@ async def setup_flake8_lockfile(
     #
     # This ORs all unique interpreter constraints. The net effect is that every possible Python
     # interpreter used will be covered.
-    all_tgts = await Get(Targets, AddressSpecs([DescendantAddresses("")]))
+    all_tgts = await Get(AllTargets, AllTargetsRequest())
     unique_constraints = {
         InterpreterConstraints.create_from_targets([tgt], python_setup)
         for tgt in all_tgts

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -23,12 +23,13 @@ from pants.backend.python.util_rules.python_sources import (
     PythonSourceFilesRequest,
     StrippedPythonSourceFiles,
 )
-from pants.base.specs import AddressSpecs, DescendantAddresses
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.addresses import Addresses, UnparsedAddressInputs
 from pants.engine.fs import EMPTY_DIGEST, AddPrefix, Digest
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
+    AllTargets,
+    AllTargetsRequest,
     Dependencies,
     DependenciesRequest,
     FieldSet,
@@ -257,7 +258,7 @@ async def setup_pylint_lockfile(
     # dependencies (which will AND across each target in the closure). Then, it ORs all unique
     # resulting interpreter constraints. The net effect is that every possible Python interpreter
     # used will be covered.
-    all_tgts = await Get(Targets, AddressSpecs([DescendantAddresses("")]))
+    all_tgts = await Get(AllTargets, AllTargetsRequest())
     relevant_targets = tuple(tgt for tgt in all_tgts if PylintFieldSet.is_applicable(tgt))
     direct_deps_per_target = await MultiGet(
         Get(Targets, DependenciesRequest(tgt.get(Dependencies))) for tgt in relevant_targets

--- a/src/python/pants/backend/python/macros/pipenv_requirements_test.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements_test.py
@@ -10,16 +10,14 @@ from pkg_resources import Requirement
 
 from pants.backend.python.macros.pipenv_requirements import PipenvRequirements
 from pants.backend.python.target_types import PythonRequirementsFile, PythonRequirementTarget
-from pants.base.specs import AddressSpecs, DescendantAddresses, FilesystemSpecs, Specs
 from pants.engine.addresses import Address
-from pants.engine.target import Targets
-from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.engine.target import AllTargets
+from pants.testutil.rule_runner import RuleRunner
 
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
     return RuleRunner(
-        rules=[QueryRule(Targets, (Specs,))],
         target_types=[PythonRequirementTarget, PythonRequirementsFile],
         context_aware_object_factories={"pipenv_requirements": PipenvRequirements},
     )
@@ -35,10 +33,7 @@ def assert_pipenv_requirements(
     pipfile_lock_relpath: str = "Pipfile.lock",
 ) -> None:
     rule_runner.write_files({"BUILD": build_file_entry, pipfile_lock_relpath: dumps(pipfile_lock)})
-    targets = rule_runner.request(
-        Targets,
-        [Specs(AddressSpecs([DescendantAddresses("")]), FilesystemSpecs([]))],
-    )
+    targets = rule_runner.request(AllTargets, [])
     assert {expected_file_dep, *expected_targets} == set(targets)
 
 

--- a/src/python/pants/backend/python/macros/poetry_requirements_test.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements_test.py
@@ -24,11 +24,10 @@ from pants.backend.python.macros.poetry_requirements import (
     parse_str_version,
 )
 from pants.backend.python.target_types import PythonRequirementsFile, PythonRequirementTarget
-from pants.base.specs import AddressSpecs, DescendantAddresses, FilesystemSpecs, Specs
 from pants.engine.addresses import Address
 from pants.engine.internals.scheduler import ExecutionError
-from pants.engine.target import Targets
-from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.engine.target import AllTargets
+from pants.testutil.rule_runner import RuleRunner
 
 
 @pytest.mark.parametrize(
@@ -384,7 +383,6 @@ def test_parse_multi_reqs() -> None:
 @pytest.fixture
 def rule_runner() -> RuleRunner:
     return RuleRunner(
-        rules=[QueryRule(Targets, (Specs,))],
         target_types=[PythonRequirementTarget, PythonRequirementsFile],
         context_aware_object_factories={"poetry_requirements": PoetryRequirements},
     )
@@ -400,10 +398,7 @@ def assert_poetry_requirements(
     pyproject_toml_relpath: str = "pyproject.toml",
 ) -> None:
     rule_runner.write_files({"BUILD": build_file_entry, pyproject_toml_relpath: pyproject_toml})
-    targets = rule_runner.request(
-        Targets,
-        [Specs(AddressSpecs([DescendantAddresses("")]), FilesystemSpecs([]))],
-    )
+    targets = rule_runner.request(AllTargets, [])
     assert {expected_file_dep, *expected_targets} == set(targets)
 
 

--- a/src/python/pants/backend/python/macros/python_requirements_test.py
+++ b/src/python/pants/backend/python/macros/python_requirements_test.py
@@ -9,17 +9,15 @@ from pkg_resources import Requirement
 
 from pants.backend.python.macros.python_requirements import PythonRequirements
 from pants.backend.python.target_types import PythonRequirementsFile, PythonRequirementTarget
-from pants.base.specs import AddressSpecs, DescendantAddresses, FilesystemSpecs, Specs
 from pants.engine.addresses import Address
 from pants.engine.internals.scheduler import ExecutionError
-from pants.engine.target import Targets
-from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.engine.target import AllTargets
+from pants.testutil.rule_runner import RuleRunner
 
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
     return RuleRunner(
-        rules=[QueryRule(Targets, (Specs,))],
         target_types=[PythonRequirementTarget, PythonRequirementsFile],
         context_aware_object_factories={"python_requirements": PythonRequirements},
     )
@@ -35,10 +33,7 @@ def assert_python_requirements(
     requirements_txt_relpath: str = "requirements.txt",
 ) -> None:
     rule_runner.write_files({"BUILD": build_file_entry, requirements_txt_relpath: requirements_txt})
-    targets = rule_runner.request(
-        Targets,
-        [Specs(AddressSpecs([DescendantAddresses("")]), FilesystemSpecs([]))],
-    )
+    targets = rule_runner.request(AllTargets, [])
     assert {expected_file_dep, *expected_targets} == set(targets)
 
 

--- a/src/python/pants/backend/python/subsystems/ipython.py
+++ b/src/python/pants/backend/python/subsystems/ipython.py
@@ -9,9 +9,8 @@ from pants.backend.python.goals.lockfile import PythonLockfileRequest, PythonToo
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript, InterpreterConstraintsField
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.base.specs import AddressSpecs, DescendantAddresses
 from pants.engine.rules import Get, collect_rules, rule
-from pants.engine.target import UnexpandedTargets
+from pants.engine.target import AllTargets, AllTargetsRequest
 from pants.engine.unions import UnionRule
 from pants.python.python_setup import PythonSetup
 from pants.util.docutil import git_url
@@ -71,12 +70,12 @@ async def setup_ipython_lockfile(
     #
     # This ORs all unique interpreter constraints. The net effect is that every possible Python
     # interpreter used will be covered.
-    all_build_targets = await Get(UnexpandedTargets, AddressSpecs([DescendantAddresses("")]))
+    all_tgts = await Get(AllTargets, AllTargetsRequest())
     unique_constraints = {
         InterpreterConstraints.create_from_compatibility_fields(
             [tgt[InterpreterConstraintsField]], python_setup
         )
-        for tgt in all_build_targets
+        for tgt in all_tgts
         if tgt.has_field(InterpreterConstraintsField)
     }
     constraints = InterpreterConstraints(itertools.chain.from_iterable(unique_constraints))

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -24,11 +24,16 @@ from pants.backend.python.target_types import (
     format_invalid_requirement_string_error,
 )
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.base.specs import AddressSpecs, DescendantAddresses
 from pants.core.goals.test import RuntimePackageDependenciesField, TestFieldSet
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import Target, Targets, TransitiveTargets, TransitiveTargetsRequest
+from pants.engine.target import (
+    AllTargets,
+    AllTargetsRequest,
+    Target,
+    TransitiveTargets,
+    TransitiveTargetsRequest,
+)
 from pants.engine.unions import UnionRule
 from pants.option.custom_types import shell_str
 from pants.python.python_setup import PythonSetup
@@ -240,7 +245,7 @@ async def setup_pytest_lockfile(
     # (which will AND across each target in the closure). Then, it ORs all unique resulting
     # interpreter constraints. The net effect is that every possible Python interpreter used will
     # be covered.
-    all_tgts = await Get(Targets, AddressSpecs([DescendantAddresses("")]))
+    all_tgts = await Get(AllTargets, AllTargetsRequest())
     transitive_targets_per_test = await MultiGet(
         Get(TransitiveTargets, TransitiveTargetsRequest([tgt.address]))
         for tgt in all_tgts

--- a/src/python/pants/backend/python/subsystems/setuptools.py
+++ b/src/python/pants/backend/python/subsystems/setuptools.py
@@ -8,10 +8,14 @@ from pants.backend.python.goals.lockfile import PythonLockfileRequest, PythonToo
 from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
 from pants.backend.python.target_types import PythonProvidesField
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.base.specs import AddressSpecs, DescendantAddresses
 from pants.core.goals.package import PackageFieldSet
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import TransitiveTargets, TransitiveTargetsRequest, UnexpandedTargets
+from pants.engine.target import (
+    AllTargets,
+    AllTargetsRequest,
+    TransitiveTargets,
+    TransitiveTargetsRequest,
+)
 from pants.engine.unions import UnionRule
 from pants.python.python_setup import PythonSetup
 from pants.util.docutil import git_url
@@ -52,10 +56,10 @@ async def setup_setuptools_lockfile(
     if not setuptools.uses_lockfile:
         return PythonLockfileRequest.from_tool(setuptools)
 
-    all_build_targets = await Get(UnexpandedTargets, AddressSpecs([DescendantAddresses("")]))
+    all_tgts = await Get(AllTargets, AllTargetsRequest())
     transitive_targets_per_python_dist = await MultiGet(
         Get(TransitiveTargets, TransitiveTargetsRequest([tgt.address]))
-        for tgt in all_build_targets
+        for tgt in all_tgts
         if PythonDistributionFieldSet.is_applicable(tgt)
     )
     unique_constraints = {

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -22,15 +22,15 @@ from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
     PythonSourceFilesRequest,
 )
-from pants.base.specs import AddressSpecs, DescendantAddresses
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.engine.addresses import Addresses, UnparsedAddressInputs
 from pants.engine.fs import EMPTY_DIGEST, Digest, DigestContents, FileContent
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
+    AllTargets,
+    AllTargetsRequest,
     FieldSet,
     Target,
-    Targets,
     TransitiveTargets,
     TransitiveTargetsRequest,
 )
@@ -295,7 +295,7 @@ async def setup_mypy_lockfile(
 
     constraints = mypy.interpreter_constraints
     if mypy.options.is_default("interpreter_constraints"):
-        all_tgts = await Get(Targets, AddressSpecs([DescendantAddresses("")]))
+        all_tgts = await Get(AllTargets, AllTargetsRequest())
         all_transitive_targets = await MultiGet(
             Get(TransitiveTargets, TransitiveTargetsRequest([tgt.address]))
             for tgt in all_tgts

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -744,6 +744,30 @@ class RegisteredTargetTypes:
         return FrozenOrderedSet(self.aliases_to_types.values())
 
 
+class AllTargets(Targets):
+    """All targets in the project.
+
+    This should generally be avoided because it is relatively expensive to compute and is
+    frequently invalidated, but it can be necessary for things like dependency inference to build
+    a global mapping of imports to targets.
+
+    You can either request via `Get(AllTargets, AllTargetsRequest)`, or as a singleton, i.e. using
+    `AllTargets` as a parameter to the `@rule`. When used as a singleton, all target generators
+    will be replaced by their generated targets.
+    """
+
+
+@dataclass(frozen=True)
+class AllTargetsRequest:
+    """Find all targets in the project.
+
+    Will always include generated targets. If `include_target_generators` is True, will also include
+    target generators rather than replacing them with their generated targets.
+    """
+
+    include_target_generators: bool = False
+
+
 # -----------------------------------------------------------------------------------------------
 # Target generation
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -33,7 +33,7 @@ from pants.engine.internals.session import SessionValues
 from pants.engine.process import InteractiveProcess, InteractiveProcessResult
 from pants.engine.rules import QueryRule as QueryRule
 from pants.engine.rules import Rule
-from pants.engine.target import Target, WrappedTarget
+from pants.engine.target import AllTargets, Target, WrappedTarget
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.init.engine_initializer import EngineInitializer
 from pants.init.logging import initialize_stdio, initialize_stdio_raw, stdio_destination
@@ -198,6 +198,7 @@ class RuleRunner:
             *(rules or ()),
             *source_root.rules(),
             QueryRule(WrappedTarget, [Address]),
+            QueryRule(AllTargets, []),
             QueryRule(UnionMembership, []),
         )
         build_config_builder = BuildConfiguration.Builder()


### PR DESCRIPTION
Before, we were invalidating dependency inference more than necessary. For example, changing a `.go` file would require us to recompute Python's module mapping because `Get(Targets, AddresSpecs([DescendentAddresess])` changed inside the rule's body, so we had to finish running the rest of the rule. 

Now, we only rerun our module mapping code if relevant target types changed.

(A secondary motivation was DRY for our `specs.py` code to facilitate upcoming changes.)

[ci skip-rust]
[ci skip-build-wheels]