### PR TITLE
[internal] go: add a missing space

### DIFF
--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -274,7 +274,7 @@ async def compute_third_party_module_metadata(
             command=("list", "-mod=readonly", "-json", "./..."),
             env={"GOPROXY": "off"},
             description=(
-                "Determine metadata for Go third-party module"
+                "Determine metadata for Go third-party module "
                 f"{request.module_path}@{request.version}"
             ),
         ),


### PR DESCRIPTION
Add a missing space to a process description.

[ci skip-rust]