### PR TITLE
[WIP] [internal] introduce `reusable_input_digests` API for Process

### DIFF
--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -65,6 +65,7 @@ class Process:
     use_nailgun: Digest
     execution_slot_variable: str | None
     cache_scope: ProcessCacheScope
+    reusable_input_digests: FrozenDict[str, Digest]
 
     def __init__(
         self,
@@ -83,6 +84,7 @@ class Process:
         use_nailgun: Digest = EMPTY_DIGEST,
         execution_slot_variable: str | None = None,
         cache_scope: ProcessCacheScope = ProcessCacheScope.SUCCESSFUL,
+        reusable_digests: Mapping[str, Digest] | None = None,
     ) -> None:
         """Request to run a subprocess, similar to subprocess.Popen.
 
@@ -127,6 +129,7 @@ class Process:
         self.use_nailgun = use_nailgun
         self.execution_slot_variable = execution_slot_variable
         self.cache_scope = cache_scope
+        self.reusable_input_digests = FrozenDict(reusable_digests or {})
 
 
 @frozen_after_init

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -257,6 +257,21 @@ pub struct Process {
   pub use_nailgun: Digest,
 
   pub cache_scope: ProcessCacheScope,
+
+  /// "Reusable" digests to make available in the input root.
+  ///
+  /// These digests are intended for inputs that will be reused between multiple Process
+  /// invocations.This is useful, for example, for the files used by a tool to be
+  /// invoked in the `Process`.
+  ///
+  /// The digests will be mounted at the relative path represented by the `RelativePath` keys.
+  /// The executor may choose how to make the digests available, including by just merging
+  /// the digest normally into the input root, creating a symlink to a persistent cache,
+  /// or bind mounting the directory read-only into a persistent cache.
+  ///
+  /// Assumes the build action does not modify the digest as made available. This may be
+  /// enforced by an executor, for example by bind mounting the directory read-only.
+  pub reusable_input_digests: BTreeMap<RelativePath, Digest>,
 }
 
 impl Process {
@@ -287,6 +302,7 @@ impl Process {
       use_nailgun: hashing::EMPTY_DIGEST,
       execution_slot_variable: None,
       cache_scope: ProcessCacheScope::Successful,
+      reusable_input_digests: BTreeMap::new(),
     }
   }
 
@@ -322,6 +338,14 @@ impl Process {
     append_only_caches: BTreeMap<CacheName, CacheDest>,
   ) -> Process {
     self.append_only_caches = append_only_caches;
+    self
+  }
+
+  ///
+  /// Replaces the reusable digests for this process.
+  ///
+  pub fn reusable_digests(mut self, reusable_digests: BTreeMap<RelativePath, Digest>) -> Self {
+    self.reusable_input_digests = reusable_digests;
     self
   }
 }

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -61,6 +61,7 @@ mod remote_cache_tests;
 pub mod nailgun;
 
 pub mod named_caches;
+pub mod reusable_caches;
 
 extern crate uname;
 

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -89,6 +89,7 @@ async fn make_execute_request() {
     use_nailgun: EMPTY_DIGEST,
     execution_slot_variable: None,
     cache_scope: ProcessCacheScope::Always,
+    reusable_input_digests: BTreeMap::new(),
   };
 
   let want_command = remexec::Command {
@@ -166,6 +167,7 @@ async fn make_execute_request_with_instance_name() {
     use_nailgun: EMPTY_DIGEST,
     execution_slot_variable: None,
     cache_scope: ProcessCacheScope::Always,
+    reusable_input_digests: BTreeMap::new(),
   };
 
   let want_command = remexec::Command {
@@ -256,6 +258,7 @@ async fn make_execute_request_with_cache_key_gen_version() {
     use_nailgun: EMPTY_DIGEST,
     execution_slot_variable: None,
     cache_scope: ProcessCacheScope::Always,
+    reusable_input_digests: BTreeMap::new(),
   };
 
   let mut want_command = remexec::Command {
@@ -493,6 +496,7 @@ async fn make_execute_request_with_timeout() {
     use_nailgun: EMPTY_DIGEST,
     execution_slot_variable: None,
     cache_scope: ProcessCacheScope::Always,
+    reusable_input_digests: BTreeMap::new(),
   };
 
   let want_command = remexec::Command {

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -26,6 +26,7 @@ use crate::{
   CommandRunner as CommandRunnerTrait, Context, FallibleProcessResultWithPlatform,
   MultiPlatformProcess, Platform, Process, ProcessCacheScope, ProcessMetadata,
 };
+use fs::RelativePath;
 use std::any::type_name;
 use std::io::Cursor;
 use tonic::{Code, Status};
@@ -541,6 +542,88 @@ async fn make_execute_request_with_timeout() {
         )
         .unwrap(),
         144,
+      ))
+        .into(),
+    ),
+    ..Default::default()
+  };
+
+  assert_eq!(
+    crate::remote::make_execute_request(&req, ProcessMetadata::default()),
+    Ok((want_action, want_command, want_execute_request))
+  );
+}
+
+#[tokio::test]
+async fn make_execute_request_using_reusable_input_digests() {
+  let input_directory = TestDirectory::containing_roland();
+  let req = Process {
+    argv: owned_string_vec(&["/bin/echo", "yo"]),
+    env: vec![("SOME".to_owned(), "value".to_owned())]
+      .into_iter()
+      .collect(),
+    working_directory: None,
+    input_files: EMPTY_DIGEST,
+    // Intentionally poorly sorted:
+    output_files: relative_paths(&["path/to/file.ext", "other/file.ext"]).collect(),
+    output_directories: relative_paths(&["directory/name"]).collect(),
+    timeout: None,
+    description: "some description".to_owned(),
+    level: log::Level::Info,
+    append_only_caches: BTreeMap::new(),
+    jdk_home: None,
+    platform_constraint: None,
+    use_nailgun: EMPTY_DIGEST,
+    execution_slot_variable: None,
+    cache_scope: ProcessCacheScope::Always,
+    reusable_input_digests: {
+      let mut map = BTreeMap::new();
+      map.insert(RelativePath::new("cats").unwrap(), input_directory.digest());
+      map
+    },
+  };
+
+  let want_command = remexec::Command {
+    arguments: vec!["/bin/echo".to_owned(), "yo".to_owned()],
+    environment_variables: vec![
+      remexec::command::EnvironmentVariable {
+        name: crate::remote::CACHE_KEY_TARGET_PLATFORM_ENV_VAR_NAME.to_owned(),
+        value: "none".to_owned(),
+      },
+      remexec::command::EnvironmentVariable {
+        name: "SOME".to_owned(),
+        value: "value".to_owned(),
+      },
+    ],
+    output_files: vec!["other/file.ext".to_owned(), "path/to/file.ext".to_owned()],
+    output_directories: vec!["directory/name".to_owned()],
+    platform: Some(remexec::Platform::default()),
+    ..Default::default()
+  };
+
+  let want_action = remexec::Action {
+    command_digest: Some(
+      (&Digest::new(
+        Fingerprint::from_hex_string(
+          "c426b29478ec1ddbd872fbfad63ae9151eb9196edcd1a10aa0aab3aa1b48eef8",
+        )
+        .unwrap(),
+        123,
+      ))
+        .into(),
+    ),
+    input_root_digest: Some((&input_directory.digest()).into()),
+    ..Default::default()
+  };
+
+  let want_execute_request = remexec::ExecuteRequest {
+    action_digest: Some(
+      (&Digest::new(
+        Fingerprint::from_hex_string(
+          "08ff4ee93b1f4ecabc2d1c4db2f39fe3d1e5946134bb3c4fd28ebde3adfe5f90",
+        )
+        .unwrap(),
+        140,
       ))
         .into(),
     ),

--- a/src/rust/engine/process_execution/src/reusable_caches.rs
+++ b/src/rust/engine/process_execution/src/reusable_caches.rs
@@ -1,0 +1,26 @@
+// Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+use std::collections::BTreeMap;
+
+use fs::RelativePath;
+use hashing::Digest;
+use store::{SnapshotOps, SnapshotOpsError, Store};
+
+pub async fn merge_reusable_input_digests(
+  store: &Store,
+  input_digest: Digest,
+  reusable_input_digests: BTreeMap<RelativePath, Digest>,
+) -> Result<Digest, SnapshotOpsError> {
+  let mut digests_to_merge = futures::future::try_join_all(
+    reusable_input_digests
+      .into_iter()
+      .map(|(path, digest)| store.add_prefix(digest, path))
+      .collect::<Vec<_>>(),
+  )
+  .await?;
+
+  digests_to_merge.push(input_digest);
+
+  store.merge(digests_to_merge).await
+}

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -448,6 +448,7 @@ fn make_request_from_flat_args(
     use_nailgun,
     execution_slot_variable: None,
     cache_scope: ProcessCacheScope::Always,
+    reusable_input_digests: BTreeMap::new(),
   };
 
   let metadata = ProcessMetadata {
@@ -533,6 +534,7 @@ async fn extract_request_from_action_digest(
     platform_constraint: None,
     use_nailgun: EMPTY_DIGEST,
     cache_scope: ProcessCacheScope::Always,
+    reusable_input_digests: BTreeMap::new(),
   };
 
   let metadata = ProcessMetadata {


### PR DESCRIPTION
## Motivation

While developing the Go backend for Pants, we found that the amount of time spent unpacking the Go SDK (100+ MB) into the input root dominated the execution time for each `Process` invocation at 60-70% of total execution time. This made it impractical to use a downloaded Go SDK versus using a pre-installed system-wide Go SDK. We would like to be able to eventually again download the Go SDK, but need a way to avoid the performance cost.

## Solution

Introduce the notion of a "reusable input digest" which are digests that are expected to be reused between `Process` invocations. This is a hint to a process executor that the digests are immutable and that the executor can optimize as it chooses. They are useful for tools (like the Go SDK) which will not change between `Process` invocations.

This initial implementation just merges the digests into the input root and does not implement any optimization (which will come later for the local executor).