### PR TITLE
Fix documentation for `file:` URLs, and add an assist for malformed URLs

### DIFF
--- a/src/python/pants/core/util_rules/external_tool.py
+++ b/src/python/pants/core/util_rules/external_tool.py
@@ -18,6 +18,7 @@ from pants.engine.fs import Digest, DownloadFile, FileDigest
 from pants.engine.platform import Platform
 from pants.engine.rules import Get, collect_rules, rule
 from pants.option.subsystem import Subsystem
+from pants.util.docutil import doc_url
 from pants.util.logging import LogLevel
 from pants.util.meta import classproperty
 
@@ -294,8 +295,9 @@ class TemplatedExternalTool(ExternalTool):
             help=(
                 "URL to download the tool, either as a single binary file or a compressed file "
                 "(e.g. zip file). You can change this to point to your own hosted file, e.g. to "
-                "work with proxies or for access via the filesystem through a `file:$path` URL (e.g. "
-                "`file:/this/is/absolute` or `file:this/is/relative`).\n\n"
+                "work with proxies or for access via the filesystem through a `file:$abspath` URL (e.g. "
+                "`file:/this/is/absolute`, possibly by [templating the buildroot in a "
+                f"config file]({doc_url('options#config-file-entries')})).\n\n"
                 "Use `{version}` to have the value from --version substituted, and `{platform}` to "
                 "have a value from --url-platform-mapping substituted in, depending on the "
                 "current platform. For example, "

--- a/src/python/pants/engine/fs_test.py
+++ b/src/python/pants/engine/fs_test.py
@@ -868,16 +868,11 @@ def test_download_wrong_digest(downloads_rule_runner: RuleRunner) -> None:
 
 def test_download_file(downloads_rule_runner: RuleRunner) -> None:
     with temporary_dir() as temp_dir:
-        roland_abs = Path(temp_dir, "roland")
-        roland_abs.write_text("European Burmese")
+        roland = Path(temp_dir, "roland")
+        roland.write_text("European Burmese")
         snapshot = downloads_rule_runner.request(
             Snapshot,
-            [DownloadFile(f"file:{roland_abs}", ROLAND_FILE_DIGEST)],
-        )
-        roland_rel = os.path.relpath(roland_abs)
-        snapshot = downloads_rule_runner.request(
-            Snapshot,
-            [DownloadFile(f"file:{roland_rel}", ROLAND_FILE_DIGEST)],
+            [DownloadFile(f"file:{roland}", ROLAND_FILE_DIGEST)],
         )
 
     assert snapshot.files == ("roland",)

--- a/src/rust/engine/src/downloads.rs
+++ b/src/rust/engine/src/downloads.rs
@@ -100,12 +100,14 @@ async fn start_download(
   file_name: String,
 ) -> Result<Box<dyn StreamingDownload>, String> {
   if url.scheme() == "file" {
-    if url.has_host() {
+    if let Some(host) = url.host_str() {
       return Err(format!(
         "The file Url `{}` has a host component. Instead, use `file:$path`, \
-        which in this case is likely to be: `file:{}`.",
+        which in this case might be either `file:{}{}` or `file:{}`.",
         url,
-        url.path()
+        host,
+        url.path(),
+        url.path(),
       ));
     }
     return Ok(Box::new(FileDownload::start(url.path(), file_name).await?));


### PR DESCRIPTION
Fix documentation for `file:` URLs, and add an assist if the URL contains a hostname.

Fixes #13054.

[ci skip-build-wheels]