### PR TITLE
Deprecate `tailor` in favor of `generate-build-files`

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/generate_build_files.py
+++ b/src/python/pants/backend/codegen/protobuf/generate_build_files.py
@@ -7,7 +7,7 @@ import os.path
 from dataclasses import dataclass
 
 from pants.backend.codegen.protobuf.target_types import ProtobufSourcesGeneratorTarget
-from pants.core.goals.tailor import (
+from pants.core.goals.generate_build_files import (
     AllOwnedSources,
     PutativeTarget,
     PutativeTargets,

--- a/src/python/pants/backend/codegen/protobuf/generate_build_files_test.py
+++ b/src/python/pants/backend/codegen/protobuf/generate_build_files_test.py
@@ -3,10 +3,10 @@
 
 import pytest
 
-from pants.backend.codegen.protobuf.tailor import PutativeProtobufTargetsRequest
-from pants.backend.codegen.protobuf.tailor import rules as tailor_rules
+from pants.backend.codegen.protobuf import generate_build_files
+from pants.backend.codegen.protobuf.generate_build_files import PutativeProtobufTargetsRequest
 from pants.backend.codegen.protobuf.target_types import ProtobufSourcesGeneratorTarget
-from pants.core.goals.tailor import (
+from pants.core.goals.generate_build_files import (
     AllOwnedSources,
     PutativeTarget,
     PutativeTargets,
@@ -20,7 +20,7 @@ from pants.testutil.rule_runner import RuleRunner
 def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
-            *tailor_rules(),
+            *generate_build_files.rules(),
             QueryRule(PutativeTargets, (PutativeProtobufTargetsRequest, AllOwnedSources)),
         ],
         target_types=[],

--- a/src/python/pants/backend/codegen/protobuf/python/register.py
+++ b/src/python/pants/backend/codegen/protobuf/python/register.py
@@ -7,8 +7,7 @@ See https://www.pantsbuild.org/docs/protobuf.
 """
 
 from pants.backend.codegen import export_codegen_goal
-from pants.backend.codegen.protobuf import protobuf_dependency_inference
-from pants.backend.codegen.protobuf import tailor as protobuf_tailor
+from pants.backend.codegen.protobuf import generate_build_files, protobuf_dependency_inference
 from pants.backend.codegen.protobuf.python import (
     additional_fields,
     python_protobuf_module_mapper,
@@ -29,7 +28,7 @@ def rules():
         *python_rules(),
         *python_protobuf_module_mapper.rules(),
         *protobuf_dependency_inference.rules(),
-        *protobuf_tailor.rules(),
+        *generate_build_files.rules(),
         *export_codegen_goal.rules(),
         *protobuf_target_rules(),
     ]

--- a/src/python/pants/backend/docker/goals/generate_build_files.py
+++ b/src/python/pants/backend/docker/goals/generate_build_files.py
@@ -7,7 +7,7 @@ import os
 from dataclasses import dataclass
 
 from pants.backend.docker.target_types import DockerImage
-from pants.core.goals.tailor import (
+from pants.core.goals.generate_build_files import (
     AllOwnedSources,
     PutativeTarget,
     PutativeTargets,

--- a/src/python/pants/backend/docker/goals/generate_build_files_test.py
+++ b/src/python/pants/backend/docker/goals/generate_build_files_test.py
@@ -1,10 +1,10 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.docker.goals.tailor import PutativeDockerTargetsRequest
-from pants.backend.docker.goals.tailor import rules as docker_tailor_rules
+from pants.backend.docker.goals import generate_build_files
+from pants.backend.docker.goals.generate_build_files import PutativeDockerTargetsRequest
 from pants.backend.docker.target_types import DockerImage
-from pants.core.goals.tailor import (
+from pants.core.goals.generate_build_files import (
     AllOwnedSources,
     PutativeTarget,
     PutativeTargets,
@@ -17,7 +17,7 @@ from pants.testutil.rule_runner import RuleRunner
 def test_find_putative_targets() -> None:
     rule_runner = RuleRunner(
         rules=[
-            *docker_tailor_rules(),
+            *generate_build_files.rules(),
             QueryRule(PutativeTargets, [PutativeDockerTargetsRequest, AllOwnedSources]),
         ],
         target_types=[DockerImage],

--- a/src/python/pants/backend/experimental/docker/register.py
+++ b/src/python/pants/backend/experimental/docker/register.py
@@ -1,17 +1,17 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.docker.goals.tailor import rules as tailor_rules
+from pants.backend.docker.goals import generate_build_files
 from pants.backend.docker.rules import rules as docker_rules
 from pants.backend.docker.target_types import DockerImage
-from pants.backend.python.util_rules.pex import rules as pex_rules
+from pants.backend.python.util_rules import pex
 
 
 def rules():
     return (
         *docker_rules(),
-        *pex_rules(),
-        *tailor_rules(),
+        *pex.rules(),
+        *generate_build_files.rules(),
     )
 
 

--- a/src/python/pants/backend/experimental/go/register.py
+++ b/src/python/pants/backend/experimental/go/register.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.backend.go import target_type_rules
-from pants.backend.go.goals import package_binary, run_binary, tailor, test
+from pants.backend.go.goals import generate_build_files, package_binary, run_binary, test
 from pants.backend.go.lint import fmt
 from pants.backend.go.lint.gofmt import skip_field as gofmt_skip_field
 from pants.backend.go.lint.gofmt.rules import rules as gofmt_rules
@@ -42,7 +42,7 @@ def rules():
         *link.rules(),
         *sdk.rules(),
         *tests_analysis.rules(),
-        *tailor.rules(),
+        *generate_build_files.rules(),
         *target_type_rules.rules(),
         *test.rules(),
         *run_binary.rules(),

--- a/src/python/pants/backend/experimental/java/register.py
+++ b/src/python/pants/backend/experimental/java/register.py
@@ -1,7 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.java import classpath, tailor
+from pants.backend.java import classpath, generate_build_files
 from pants.backend.java.compile import javac
 from pants.backend.java.dependency_inference import (
     import_parser,
@@ -53,7 +53,7 @@ def rules():
         *java_parser_launcher.rules(),
         *package_mapper.rules(),
         *dependency_inference_rules.rules(),
-        *tailor.rules(),
+        *generate_build_files.rules(),
         *jvm_util_rules.rules(),
         *jdk_rules.rules(),
         *target_types_rules(),

--- a/src/python/pants/backend/experimental/terraform/register.py
+++ b/src/python/pants/backend/experimental/terraform/register.py
@@ -1,7 +1,13 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from pants.backend.python.util_rules.pex import rules as pex_rules
-from pants.backend.terraform import dependency_inference, style, tailor, target_gen, tool
+from pants.backend.terraform import (
+    dependency_inference,
+    generate_build_files,
+    style,
+    target_gen,
+    tool,
+)
 from pants.backend.terraform.lint import fmt
 from pants.backend.terraform.lint.tffmt.tffmt import rules as tffmt_rules
 from pants.backend.terraform.lint.validate.validate import rules as validate_rules
@@ -21,7 +27,7 @@ def rules():
     return [
         *collect_rules(),
         *dependency_inference.rules(),
-        *tailor.rules(),
+        *generate_build_files.rules(),
         *target_gen.rules(),
         *target_types_rules(),
         *tool.rules(),

--- a/src/python/pants/backend/go/goals/generate_build_files.py
+++ b/src/python/pants/backend/go/goals/generate_build_files.py
@@ -15,7 +15,7 @@ from pants.backend.go.target_types import (
     GoModTarget,
 )
 from pants.base.specs import AddressSpecs, AscendantAddresses
-from pants.core.goals.tailor import (
+from pants.core.goals.generate_build_files import (
     AllOwnedSources,
     PutativeTarget,
     PutativeTargets,

--- a/src/python/pants/backend/go/goals/generate_build_files_test.py
+++ b/src/python/pants/backend/go/goals/generate_build_files_test.py
@@ -6,11 +6,11 @@ from __future__ import annotations
 import pytest
 
 from pants.backend.go import target_type_rules
-from pants.backend.go.goals.tailor import PutativeGoTargetsRequest, has_package_main
-from pants.backend.go.goals.tailor import rules as go_tailor_rules
+from pants.backend.go.goals import generate_build_files
+from pants.backend.go.goals.generate_build_files import PutativeGoTargetsRequest, has_package_main
 from pants.backend.go.target_types import GoBinaryTarget, GoModTarget
 from pants.backend.go.util_rules import first_party_pkg, go_mod, sdk, third_party_pkg
-from pants.core.goals.tailor import (
+from pants.core.goals.generate_build_files import (
     AllOwnedSources,
     PutativeTarget,
     PutativeTargets,
@@ -24,7 +24,7 @@ from pants.testutil.rule_runner import RuleRunner
 def rule_runner() -> RuleRunner:
     rule_runner = RuleRunner(
         rules=[
-            *go_tailor_rules(),
+            *generate_build_files.rules(),
             *go_mod.rules(),
             *first_party_pkg.rules(),
             *third_party_pkg.rules(),

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -36,7 +36,7 @@ from pants.backend.go.util_rules.third_party_pkg import (
 )
 from pants.base.exceptions import ResolveError
 from pants.base.specs import AddressSpecs, AscendantAddresses
-from pants.core.goals.tailor import group_by_dir
+from pants.core.goals.generate_build_files import group_by_dir
 from pants.engine.addresses import Address, AddressInput
 from pants.engine.fs import PathGlobs, Paths
 from pants.engine.rules import Get, MultiGet, collect_rules, rule

--- a/src/python/pants/backend/java/generate_build_files.py
+++ b/src/python/pants/backend/java/generate_build_files.py
@@ -12,7 +12,7 @@ from pants.backend.java.target_types import (
     JavaTestsGeneratorSourcesField,
     JunitTestsGeneratorTarget,
 )
-from pants.core.goals.tailor import (
+from pants.core.goals.generate_build_files import (
     AllOwnedSources,
     PutativeTarget,
     PutativeTargets,

--- a/src/python/pants/backend/java/generate_build_files_test.py
+++ b/src/python/pants/backend/java/generate_build_files_test.py
@@ -3,10 +3,13 @@
 
 import pytest
 
-from pants.backend.java import tailor
-from pants.backend.java.tailor import PutativeJavaTargetsRequest, classify_source_files
+from pants.backend.java import generate_build_files
+from pants.backend.java.generate_build_files import (
+    PutativeJavaTargetsRequest,
+    classify_source_files,
+)
 from pants.backend.java.target_types import JavaSourcesGeneratorTarget, JunitTestsGeneratorTarget
-from pants.core.goals.tailor import (
+from pants.core.goals.generate_build_files import (
     AllOwnedSources,
     PutativeTarget,
     PutativeTargets,
@@ -32,7 +35,7 @@ def test_classify_source_files() -> None:
 def rule_runner() -> RuleRunner:
     rule_runner = RuleRunner(
         rules=[
-            *tailor.rules(),
+            *generate_build_files.rules(),
             QueryRule(PutativeTargets, (PutativeJavaTargetsRequest, AllOwnedSources)),
         ],
         target_types=[JavaSourcesGeneratorTarget, JunitTestsGeneratorTarget],

--- a/src/python/pants/backend/python/goals/BUILD
+++ b/src/python/pants/backend/python/goals/BUILD
@@ -56,5 +56,5 @@ python_tests(
     timeout=150,
 )
 
-python_tests(name="tailor_test", sources=["tailor_test.py"])
+python_tests(name="generate_build_files_test", sources=["generate_build_files_test.py"])
 python_tests(name="publish_test", sources=["publish_test.py"])

--- a/src/python/pants/backend/python/goals/generate_build_files.py
+++ b/src/python/pants/backend/python/goals/generate_build_files.py
@@ -20,7 +20,7 @@ from pants.backend.python.target_types import (
     ResolvePexEntryPointRequest,
 )
 from pants.base.specs import AddressSpecs, AscendantAddresses
-from pants.core.goals.tailor import (
+from pants.core.goals.generate_build_files import (
     AllOwnedSources,
     PutativeTarget,
     PutativeTargets,
@@ -86,7 +86,7 @@ async def find_putative_targets(
             name = "tests" if tgt_type == PythonTestsGeneratorTarget else os.path.basename(dirname)
             kwargs = {"name": name} if tgt_type == PythonTestsGeneratorTarget else {}
             if (
-                python_setup.tailor_ignore_solitary_init_files
+                python_setup.generate_build_files_ignore_solitary_init_files
                 and tgt_type == PythonSourcesGeneratorTarget
                 and filenames == {"__init__.py"}
             ):
@@ -97,7 +97,7 @@ async def find_putative_targets(
                 )
             )
 
-    if python_setup.tailor_requirements_targets:
+    if python_setup.generate_build_files_requirements_targets:
         # Find requirements files.
         all_requirements_files_globs: PathGlobs = req.search_paths.path_globs("*requirements*.txt")
         all_requirements_files = await Get(Paths, PathGlobs, all_requirements_files_globs)
@@ -118,7 +118,7 @@ async def find_putative_targets(
                 )
             )
 
-    if python_setup.tailor_pex_binary_targets:
+    if python_setup.generate_build_files_pex_binary_targets:
         # Find binary targets.
 
         # Get all files whose content indicates that they are entry points.

--- a/src/python/pants/backend/python/goals/generate_build_files_test.py
+++ b/src/python/pants/backend/python/goals/generate_build_files_test.py
@@ -5,8 +5,8 @@ import textwrap
 import pytest
 
 from pants.backend.python import target_types_rules
-from pants.backend.python.goals import tailor
-from pants.backend.python.goals.tailor import (
+from pants.backend.python.goals import generate_build_files
+from pants.backend.python.goals.generate_build_files import (
     PutativePythonTargetsRequest,
     classify_source_files,
     is_entry_point,
@@ -16,7 +16,7 @@ from pants.backend.python.target_types import (
     PythonSourcesGeneratorTarget,
     PythonTestsGeneratorTarget,
 )
-from pants.core.goals.tailor import (
+from pants.core.goals.generate_build_files import (
     AllOwnedSources,
     PutativeTarget,
     PutativeTargets,
@@ -48,7 +48,7 @@ def test_classify_source_files() -> None:
 def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
-            *tailor.rules(),
+            *generate_build_files.rules(),
             *target_types_rules.rules(),
             QueryRule(PutativeTargets, (PutativePythonTargetsRequest, AllOwnedSources)),
         ],
@@ -57,7 +57,7 @@ def rule_runner() -> RuleRunner:
 
 
 def test_find_putative_targets(rule_runner: RuleRunner) -> None:
-    rule_runner.set_options(["--no-python-setup-tailor-ignore-solitary-init-files"])
+    rule_runner.set_options(["--no-python-setup-generate-build-files-ignore-solitary-init-files"])
     rule_runner.write_files(
         {
             "3rdparty/requirements.txt": "",

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -10,13 +10,13 @@ from pants.backend.python import target_types_rules
 from pants.backend.python.dependency_inference import rules as dependency_inference_rules
 from pants.backend.python.goals import (
     coverage_py,
+    generate_build_files,
     lockfile,
     package_pex_binary,
     pytest_runner,
     repl,
     run_pex_binary,
     setup_py,
-    tailor,
 )
 from pants.backend.python.macros.pants_requirement import PantsRequirement
 from pants.backend.python.macros.pipenv_requirements import PipenvRequirements
@@ -62,7 +62,7 @@ def rules():
     return (
         *coverage_py.rules(),
         *lockfile.rules(),
-        *tailor.rules(),
+        *generate_build_files.rules(),
         *ancestor_files.rules(),
         *local_dists.rules(),
         *python_sources.rules(),

--- a/src/python/pants/backend/shell/generate_build_files.py
+++ b/src/python/pants/backend/shell/generate_build_files.py
@@ -12,7 +12,7 @@ from pants.backend.shell.target_types import (
     Shunit2TestsGeneratorSourcesField,
     Shunit2TestsGeneratorTarget,
 )
-from pants.core.goals.tailor import (
+from pants.core.goals.generate_build_files import (
     AllOwnedSources,
     PutativeTarget,
     PutativeTargets,

--- a/src/python/pants/backend/shell/generate_build_files_test.py
+++ b/src/python/pants/backend/shell/generate_build_files_test.py
@@ -3,13 +3,16 @@
 
 import pytest
 
-from pants.backend.shell import tailor
-from pants.backend.shell.tailor import PutativeShellTargetsRequest, classify_source_files
+from pants.backend.shell import generate_build_files
+from pants.backend.shell.generate_build_files import (
+    PutativeShellTargetsRequest,
+    classify_source_files,
+)
 from pants.backend.shell.target_types import (
     ShellSourcesGeneratorTarget,
     Shunit2TestsGeneratorTarget,
 )
-from pants.core.goals.tailor import (
+from pants.core.goals.generate_build_files import (
     AllOwnedSources,
     PutativeTarget,
     PutativeTargets,
@@ -32,7 +35,7 @@ def test_classify_source_files() -> None:
 def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
-            *tailor.rules(),
+            *generate_build_files.rules(),
             QueryRule(PutativeTargets, [PutativeShellTargetsRequest, AllOwnedSources]),
         ],
         target_types=[],

--- a/src/python/pants/backend/shell/register.py
+++ b/src/python/pants/backend/shell/register.py
@@ -1,7 +1,12 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.shell import dependency_inference, shell_command, shunit2_test_runner, tailor
+from pants.backend.shell import (
+    dependency_inference,
+    generate_build_files,
+    shell_command,
+    shunit2_test_runner,
+)
 from pants.backend.shell.target_types import (
     ShellCommand,
     ShellCommandRun,
@@ -29,6 +34,6 @@ def rules():
         *dependency_inference.rules(),
         *shell_command.rules(),
         *shunit2_test_runner.rules(),
-        *tailor.rules(),
+        *generate_build_files.rules(),
         *target_types_rules(),
     ]

--- a/src/python/pants/backend/terraform/generate_build_files.py
+++ b/src/python/pants/backend/terraform/generate_build_files.py
@@ -8,7 +8,7 @@ from pathlib import PurePath
 from typing import Iterable
 
 from pants.backend.terraform.target_types import TerraformModulesGeneratorTarget
-from pants.core.goals.tailor import (
+from pants.core.goals.generate_build_files import (
     PutativeTarget,
     PutativeTargets,
     PutativeTargetsRequest,

--- a/src/python/pants/backend/terraform/generate_build_files_test.py
+++ b/src/python/pants/backend/terraform/generate_build_files_test.py
@@ -2,22 +2,24 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from pathlib import PurePath
 
-from pants.backend.terraform.tailor import (
+from pants.backend.terraform.generate_build_files import (
     PutativeTerraformTargetsRequest,
     find_disjoint_longest_common_prefixes,
 )
-from pants.backend.terraform.tailor import rules as terraform_tailor_rules
+from pants.backend.terraform.generate_build_files import (
+    rules as terraform_generate_build_files_rules,
+)
 from pants.backend.terraform.target_types import (
     TerraformModulesGeneratorTarget,
     TerraformModuleTarget,
 )
-from pants.core.goals.tailor import (
+from pants.core.goals.generate_build_files import (
     AllOwnedSources,
     PutativeTarget,
     PutativeTargets,
     PutativeTargetsSearchPaths,
 )
-from pants.core.goals.tailor import rules as core_tailor_rules
+from pants.core.goals.generate_build_files import rules as core_generate_build_files_rules
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
 
@@ -25,8 +27,8 @@ from pants.testutil.rule_runner import RuleRunner
 def test_find_putative_targets() -> None:
     rule_runner = RuleRunner(
         rules=[
-            *core_tailor_rules(),
-            *terraform_tailor_rules(),
+            *core_generate_build_files_rules(),
+            *terraform_generate_build_files_rules(),
             QueryRule(PutativeTargets, [PutativeTerraformTargetsRequest, AllOwnedSources]),
             QueryRule(AllOwnedSources, ()),
         ],

--- a/src/python/pants/backend/terraform/target_gen.py
+++ b/src/python/pants/backend/terraform/target_gen.py
@@ -10,7 +10,7 @@ from pants.backend.terraform.target_types import (
     TerraformModulesGeneratorTarget,
     TerraformModuleTarget,
 )
-from pants.core.goals.tailor import group_by_dir
+from pants.core.goals.generate_build_files import group_by_dir
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import (
     GeneratedTargets,

--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -9,12 +9,12 @@ These are always activated and cannot be disabled.
 from pants.core.goals import (
     check,
     fmt,
+    generate_build_files,
     lint,
     package,
     publish,
     repl,
     run,
-    tailor,
     test,
     update_build_files,
 )
@@ -54,7 +54,7 @@ def rules():
         *publish.rules(),
         *repl.rules(),
         *run.rules(),
-        *tailor.rules(),
+        *generate_build_files.rules(),
         *test.rules(),
         # util_rules
         *anonymous_telemetry.rules(),

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -251,8 +251,8 @@ async def addresses_from_address_specs(
         )
         raise ResolveError(
             f"No targets found for {glob_description}\n\n"
-            f"Do targets exist in those directories? Maybe run `./pants tailor` to generate "
-            f"BUILD files? See {doc_url('targets')} about targets and BUILD files."
+            f"Do targets exist in those directories? Maybe run `./pants generate-build-files`? "
+            f"See {doc_url('targets')} about targets and BUILD files."
         )
 
     return Addresses(sorted(matched_addresses))

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -589,7 +589,7 @@ def _log_or_raise_unmatched_owners(
         )
     msg = (
         f"{prefix} See {doc_url('targets')} for more information on target definitions."
-        f"\n\nYou may want to run `./pants tailor` to autogenerate your BUILD files. See "
+        f"\n\nMaybe run `./pants generate-build-files`? See "
         f"{doc_url('create-initial-build-files')}.{option_msg}"
     )
 

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -55,6 +55,7 @@ class RunTracker:
             "filedeps",
             "filter",
             "fmt",
+            "generate-build-files",
             "lint",
             "list",
             "package",
@@ -62,9 +63,9 @@ class RunTracker:
             "repl",
             "roots",
             "run",
-            "tailor",
             "test",
             "typecheck",
+            "update-build-files",
             "validate",
         )
     )

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -14,6 +14,7 @@ from typing import Iterable, List, Optional, Tuple, cast
 from pex.variables import Variables
 
 from pants.base.build_environment import get_buildroot
+from pants.base.deprecated import resolve_conflicting_options
 from pants.engine.environment import Environment
 from pants.option.custom_types import file_option
 from pants.option.subsystem import Subsystem
@@ -200,6 +201,20 @@ class PythonSetup(Subsystem):
         )
 
         register(
+            "--generate-build-files-ignore-solitary-init-files",
+            type=bool,
+            default=True,
+            advanced=True,
+            help=(
+                "When generating BUILD files, don't add a `python_sources` target if there is only "
+                "an `__init__.py` file in the folder and no other `.py` files.\n\n"
+                "This can be useful to set to `True` as `__init__.py` files often only exist as "
+                "import scaffolding, rather than true library code. Set to `False` if you commonly "
+                "have directories containing only a single `__init__.py` file with real code in "
+                "them."
+            ),
+        )
+        register(
             "--tailor-ignore-solitary-init-files",
             type=bool,
             default=True,
@@ -208,22 +223,55 @@ class PythonSetup(Subsystem):
             "those usually exist as import scaffolding rather than true library code.\n\n"
             "Set to False if you commonly have packages containing real code in "
             "`__init__.py` and there are no other .py files in the package.",
+            removal_version="2.9.0.dev0",
+            removal_hint=(
+                "Use `--generate-build-files-ignore-solitary-init-files` instead, which behaves "
+                "the same."
+            ),
         )
 
+        register(
+            "--generate-build-files-requirements-targets",
+            type=bool,
+            default=True,
+            advanced=True,
+            help=(
+                "When generating BUILD files, add python_requirements() macros for "
+                "requirements.txt files."
+            ),
+        )
         register(
             "--tailor-requirements-targets",
             type=bool,
             default=True,
             advanced=True,
             help="Tailor python_requirements() targets for requirements files.",
+            removal_version="2.9.0.dev0",
+            removal_hint=(
+                "Use `--generate-build-files-requirement-targets` instead, which behaves the same."
+            ),
         )
 
+        register(
+            "--generate-build-files-pex-binary-targets",
+            type=bool,
+            default=True,
+            advanced=True,
+            help=(
+                "When generating BUILD files, add pex_binary() targets for Python files with "
+                '`if __name__ == "__main__:" present.'
+            ),
+        )
         register(
             "--tailor-pex-binary-targets",
             type=bool,
             default=True,
             advanced=True,
             help="Tailor pex_binary() targets for Python entry point files.",
+            removal_version="2.9.0.dev0",
+            removal_hint=(
+                "Use `--generate-build-files-pex_binary-targets` instead, which behaves the same."
+            ),
         )
 
         register(
@@ -284,16 +332,46 @@ class PythonSetup(Subsystem):
         return cast(int, self.options.resolver_jobs)
 
     @property
-    def tailor_ignore_solitary_init_files(self) -> bool:
-        return cast(bool, self.options.tailor_ignore_solitary_init_files)
+    def generate_build_files_ignore_solitary_init_files(self) -> bool:
+        return cast(
+            bool,
+            resolve_conflicting_options(
+                old_option="tailor_ignore_solitary_init_files",
+                new_option="generate_build_files_ignore_solitary_init_files",
+                old_scope=self.options_scope,
+                new_scope=self.options_scope,
+                old_container=self.options,
+                new_container=self.options,
+            ),
+        )
 
     @property
-    def tailor_requirements_targets(self) -> bool:
-        return cast(bool, self.options.tailor_requirements_targets)
+    def generate_build_files_requirements_targets(self) -> bool:
+        return cast(
+            bool,
+            resolve_conflicting_options(
+                old_option="tailor_requirements_targets",
+                new_option="generate_build_files_requirements_targets",
+                old_scope=self.options_scope,
+                new_scope=self.options_scope,
+                old_container=self.options,
+                new_container=self.options,
+            ),
+        )
 
     @property
-    def tailor_pex_binary_targets(self) -> bool:
-        return cast(bool, self.options.tailor_pex_binary_targets)
+    def generate_build_files_pex_binary_targets(self) -> bool:
+        return cast(
+            bool,
+            resolve_conflicting_options(
+                old_option="tailor_pex_binary_targets",
+                new_option="generate_build_files_pex_binary_targets",
+                old_scope=self.options_scope,
+                new_scope=self.options_scope,
+                old_container=self.options,
+                new_container=self.options,
+            ),
+        )
 
     @property
     def macos_big_sur_compatibility(self) -> bool:


### PR DESCRIPTION
Now we have parity with `update-build-files`:

```
❯ ./pants help goals

Goals
-----
...
generate-build-files    Generate BUILD file targets for new source files.
...
update-build-files      Format and fix safe deprecations in BUILD files.
```

While more verbose, this new name is more self-documenting and intuitive. It says exactly what it does. It does not rely on the user not only having prior knowledge of weaving/sewing, but also being able to make a connection from sewing to programming. @williamscs has helpfully pointed out that "cute" names like `tailor` often don't work as well as intended.

[ci skip-rust]
[ci skip-build-wheels]