### PR TITLE
Merge docker `version` field into the `image_tags` field.

### DIFF
--- a/src/python/pants/backend/docker/goals/package_image_integration_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_integration_test.py
@@ -50,7 +50,7 @@ def test_docker_build(rule_runner) -> None:
     """This test requires a running docker daemon."""
     rule_runner.write_files(
         {
-            "src/BUILD": "docker_image(name='test-image', version='1.0')",
+            "src/BUILD": "docker_image(name='test-image', image_tags=['1.0'])",
             "src/Dockerfile": "FROM python:3.8",
         }
     )

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -10,6 +10,7 @@ import pytest
 
 from pants.backend.docker.goals.package_image import (
     DockerFieldSet,
+    DockerImageTagValueError,
     DockerRepositoryNameError,
     build_docker_image,
 )
@@ -22,7 +23,6 @@ from pants.backend.docker.util_rules.docker_build_context import (
     DockerBuildContext,
     DockerBuildContextRequest,
     DockerVersionContext,
-    DockerVersionContextError,
     DockerVersionContextValue,
 )
 from pants.engine.addresses import Address
@@ -123,26 +123,26 @@ def test_build_docker_image(rule_runner: RuleRunner) -> None:
 
                 docker_image(
                   name="test1",
-                  version="1.2.3",
+                  image_tags=["1.2.3"],
                   repository="{directory}/{name}",
                 )
                 docker_image(
                   name="test2",
-                  version="1.2.3"
+                  image_tags=["1.2.3"],
                 )
                 docker_image(
                   name="test3",
-                  version="1.2.3",
+                  image_tags=["1.2.3"],
                   repository="{parent_directory}/{directory}/{name}",
                 )
                 docker_image(
                   name="test4",
-                  version="1.2.3",
+                  image_tags=["1.2.3"],
                   repository="{directory}/four/test-four",
                 )
                 docker_image(
                   name="test5",
-                  image_tags=["alpha-1.0", "alpha-1"],
+                  image_tags=["latest", "alpha-1.0", "alpha-1"],
                 )
                 docker_image(
                   name="err1",
@@ -188,7 +188,7 @@ def test_build_docker_image(rule_runner: RuleRunner) -> None:
 
     err1 = (
         r"Invalid value for the `repository` field of the `docker_image` target at "
-        r"docker/test:err1: '{bad_template}'\. Unknown key: 'bad_template'\.\n\n"
+        r"docker/test:err1: '{bad_template}'\. Unknown placeholder: 'bad_template'\.\n\n"
         r"You may only reference any of `name`, `directory` or `parent_directory`\."
     )
     with pytest.raises(DockerRepositoryNameError, match=err1):
@@ -203,15 +203,15 @@ def test_build_image_with_registries(rule_runner: RuleRunner) -> None:
         {
             "docker/test/BUILD": dedent(
                 """\
-                docker_image(name="addr1", version="1.2.3", registries=["myregistry1domain:port"])
-                docker_image(name="addr2", version="1.2.3", registries=["myregistry2domain:port"])
-                docker_image(name="addr3", version="1.2.3", registries=["myregistry3domain:port"])
-                docker_image(name="alias1", version="1.2.3", registries=["@reg1"])
-                docker_image(name="alias2", version="1.2.3", registries=["@reg2"])
-                docker_image(name="alias3", version="1.2.3", registries=["reg3"])
-                docker_image(name="unreg", version="1.2.3", registries=[])
-                docker_image(name="def", version="1.2.3")
-                docker_image(name="multi", version="1.2.3", registries=["@reg2", "@reg1"])
+                docker_image(name="addr1", image_tags=["1.2.3"], registries=["myregistry1domain:port"])
+                docker_image(name="addr2", image_tags=["1.2.3"], registries=["myregistry2domain:port"])
+                docker_image(name="addr3", image_tags=["1.2.3"], registries=["myregistry3domain:port"])
+                docker_image(name="alias1", image_tags=["1.2.3"], registries=["@reg1"])
+                docker_image(name="alias2", image_tags=["1.2.3"], registries=["@reg2"])
+                docker_image(name="alias3", image_tags=["1.2.3"], registries=["reg3"])
+                docker_image(name="unreg", image_tags=["1.2.3"], registries=[])
+                docker_image(name="def", image_tags=["1.2.3"])
+                docker_image(name="multi", image_tags=["1.2.3"], registries=["@reg2", "@reg1"])
                 """
             ),
             "docker/test/Dockerfile": "FROM python:3.8",
@@ -314,11 +314,10 @@ def test_dynamic_image_version(rule_runner: RuleRunner) -> None:
                 docker_image(name="ver_1")
                 docker_image(
                   name="ver_2",
-                  version="{baseimage.tag}-{stage2.tag}",
-                  image_tags=["beta"]
+                  image_tags=["{baseimage.tag}-{stage2.tag}", "beta"]
                 )
-                docker_image(name="err_1", version="{unknown_stage}")
-                docker_image(name="err_2", version="{stage0.unknown_value}")
+                docker_image(name="err_1", image_tags=["{unknown_stage}"])
+                docker_image(name="err_2", image_tags=["{stage0.unknown_value}"])
                 """
             ),
         }
@@ -328,25 +327,27 @@ def test_dynamic_image_version(rule_runner: RuleRunner) -> None:
     assert_tags("ver_2", "image:3.8-latest", "image:beta")
 
     err_1 = (
-        r"Invalid format string for the `version` field of the `docker_image` target at "
+        r"Invalid tag value for the `image_tags` field of the `docker_image` target at "
         r"docker/test:err_1: '{unknown_stage}'\.\n\n"
-        r"The key 'unknown_stage' is unknown\. Try with one of: baseimage, stage0, interim, "
-        r"stage2, output\."
+        r"The placeholder 'unknown_stage' is unknown\. Try with one of: baseimage, stage0, "
+        r"interim, stage2, output\."
     )
-    with pytest.raises(DockerVersionContextError, match=err_1):
+    with pytest.raises(DockerImageTagValueError, match=err_1):
         assert_tags("err_1")
 
     err_2 = (
-        r"Invalid format string for the `version` field of the `docker_image` target at "
+        r"Invalid tag value for the `image_tags` field of the `docker_image` target at "
         r"docker/test:err_2: '{stage0.unknown_value}'\.\n\n"
-        r"The key 'unknown_value' is unknown\. Try with one of: tag\."
+        r"The placeholder 'unknown_value' is unknown\. Try with one of: tag\."
     )
-    with pytest.raises(DockerVersionContextError, match=err_2):
+    with pytest.raises(DockerImageTagValueError, match=err_2):
         assert_tags("err_2")
 
 
 def test_docker_build_process_environment(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files({"docker/test/BUILD": 'docker_image(name="env1", version="1.2.3")'})
+    rule_runner.write_files(
+        {"docker/test/BUILD": 'docker_image(name="env1", image_tags=["1.2.3"])'}
+    )
     rule_runner.set_options(
         [],
         env={
@@ -380,7 +381,9 @@ def test_docker_build_process_environment(rule_runner: RuleRunner) -> None:
 
 
 def test_docker_build_args(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files({"docker/test/BUILD": 'docker_image(name="args1", version="1.2.3")'})
+    rule_runner.write_files(
+        {"docker/test/BUILD": 'docker_image(name="args1", image_tags=["1.2.3"])'}
+    )
     rule_runner.set_options(
         [],
         env={
@@ -420,7 +423,7 @@ def test_docker_build_args(rule_runner: RuleRunner) -> None:
 
 def test_docker_image_version_from_build_arg(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
-        {"docker/test/BUILD": 'docker_image(name="ver1", version="{build_args.VERSION}")'}
+        {"docker/test/BUILD": 'docker_image(name="ver1", image_tags=["{build_args.VERSION}"])'}
     )
     rule_runner.set_options(
         [],

--- a/src/python/pants/backend/docker/goals/publish_test.py
+++ b/src/python/pants/backend/docker/goals/publish_test.py
@@ -17,13 +17,13 @@ from pants.backend.docker.subsystems.docker_options import DockerOptions
 from pants.backend.docker.target_types import DockerImage
 from pants.backend.docker.util_rules import docker_binary
 from pants.backend.docker.util_rules.docker_binary import DockerBinary
+from pants.backend.docker.util_rules.docker_build_context import DockerVersionContext
 from pants.core.goals.package import BuiltPackage
 from pants.core.goals.publish import PublishPackages, PublishProcesses
 from pants.engine.addresses import Address
 from pants.engine.fs import EMPTY_DIGEST
 from pants.testutil.option_util import create_subsystem
 from pants.testutil.rule_runner import QueryRule, RuleRunner
-from pants.util.frozendict import FrozenDict
 
 
 @pytest.fixture
@@ -62,7 +62,7 @@ def build(tgt: DockerImage, options: DockerOptions):
                     fs.image_refs(
                         options.default_repository,
                         options.registries(),
-                        FrozenDict(),
+                        DockerVersionContext(),
                     ),
                 ),
             ),

--- a/src/python/pants/backend/docker/target_types.py
+++ b/src/python/pants/backend/docker/target_types.py
@@ -33,21 +33,18 @@ class DockerImageSources(MultipleSourcesField):
     help = "The Dockerfile to use when building the Docker image."
 
 
-class DockerImageVersion(StringField):
-    alias = "version"
-    default = "latest"
-    help = "Image tag to apply to built images."
-
-
-class DockerImageTags(StringSequenceField):
+class DockerImageTagsField(StringSequenceField):
     alias = "image_tags"
+    default = ("latest",)
     help = (
-        "Any tags to apply to the Docker image name, in addition to the default from the "
-        "`version` field."
+        "Any tags to apply to the Docker image name (the version is usually applied as a tag).\n\n"
+        "Each tag may use placeholders in curly braces to be interpolated. The placeholders are "
+        "derived from various sources, such as the Dockerfile FROM instructions tags and build "
+        "args.\n\nSee {doc_url('tagging-docker-images')}."
     )
 
 
-class DockerDependencies(Dependencies):
+class DockerDependenciesField(Dependencies):
     supports_transitive_excludes = True
 
 
@@ -112,10 +109,9 @@ class DockerImage(Target):
     core_fields = (
         *COMMON_TARGET_FIELDS,
         DockerBuildArgsField,
-        DockerDependencies,
+        DockerDependenciesField,
         DockerImageSources,
-        DockerImageTags,
-        DockerImageVersion,
+        DockerImageTagsField,
         DockerRegistriesField,
         DockerRepositoryField,
         DockerSkipPushField,

--- a/src/python/pants/backend/docker/util_rules/dependencies.py
+++ b/src/python/pants/backend/docker/util_rules/dependencies.py
@@ -3,7 +3,7 @@
 
 
 from pants.backend.docker.subsystems.dockerfile_parser import DockerfileInfo
-from pants.backend.docker.target_types import DockerDependencies, DockerImageSources
+from pants.backend.docker.target_types import DockerDependenciesField, DockerImageSources
 from pants.backend.python.goals.package_pex_binary import PexBinaryFieldSet
 from pants.engine.addresses import Address, Addresses, UnparsedAddressInputs
 from pants.engine.rules import Get, collect_rules, rule
@@ -17,7 +17,7 @@ from pants.engine.unions import UnionRule
 
 
 class InjectDockerDependencies(InjectDependenciesRequest):
-    inject_for = DockerDependencies
+    inject_for = DockerDependenciesField
 
 
 @rule

--- a/src/python/pants/backend/docker/util_rules/dependencies_test.py
+++ b/src/python/pants/backend/docker/util_rules/dependencies_test.py
@@ -6,7 +6,7 @@ from textwrap import dedent
 import pytest
 
 from pants.backend.docker.subsystems.dockerfile_parser import rules as parser_rules
-from pants.backend.docker.target_types import DockerDependencies, DockerImage
+from pants.backend.docker.target_types import DockerDependenciesField, DockerImage
 from pants.backend.docker.util_rules.dependencies import (
     InjectDockerDependencies,
     inject_docker_dependencies,
@@ -66,7 +66,7 @@ def test_inject_docker_dependencies(rule_runner: RuleRunner) -> None:
     tgt = rule_runner.get_target(Address("project/image/test", target_name="image"))
     injected = rule_runner.request(
         InjectedDependencies,
-        [InjectDockerDependencies(tgt[DockerDependencies])],
+        [InjectDockerDependencies(tgt[DockerDependenciesField])],
     )
     assert injected == InjectedDependencies(
         [Address("project/hello/main", target_name="main_binary")]

--- a/src/python/pants/backend/docker/util_rules/docker_build_context.py
+++ b/src/python/pants/backend/docker/util_rules/docker_build_context.py
@@ -41,7 +41,8 @@ class DockerVersionContextValue(FrozenDict[str, str]):
     def __getattr__(self, attribute: str) -> str:
         if attribute not in self:
             raise DockerVersionContextError(
-                f"The key {attribute!r} is unknown. Try with one of: " f'{", ".join(self.keys())}.'
+                f"The placeholder {attribute!r} is unknown. Try with one of: "
+                f'{", ".join(self.keys())}.'
             )
         return self[attribute]
 

--- a/testprojects/src/python/docker/BUILD
+++ b/testprojects/src/python/docker/BUILD
@@ -2,5 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 docker_image(
-    name="test-example", version="1.2.5", dependencies=["testprojects/src/python/hello/main"]
+    name="test-example", image_tags=["1.2.5"], dependencies=["testprojects/src/python/hello/main"]
 )


### PR DESCRIPTION
As the `version` field value is simply added to the values of the `image_tags` field value, we can simply get rid of the `version` field and rely only on `image_tags` for image tagging.
