### PR TITLE
[internal] fs_util: materialize_directory no longer has output

### DIFF
--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -503,9 +503,6 @@ async fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
         store
           .materialize_directory(destination, output_digest)
           .await
-          .map(|metadata| {
-            eprintln!("{}", serde_json::to_string_pretty(&metadata).unwrap());
-          })
           .map_err(|err| {
             if err.contains("not found") {
               ExitError(err, ExitCode::NotFound)
@@ -529,9 +526,6 @@ async fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
         store
           .materialize_directory(destination, digest)
           .await
-          .map(|metadata| {
-            eprintln!("{}", serde_json::to_string_pretty(&metadata).unwrap());
-          })
           .map_err(|err| {
             if err.contains("not found") {
               ExitError(err, ExitCode::NotFound)


### PR DESCRIPTION
As pointed out in https://github.com/pantsbuild/pants/pull/13303#discussion_r733160058, `Store::materialize_directory` currently returns `()` so no need to print that to the console any more.