### PR TITLE
[internal] java: extract more consumed types from sources

### DIFF
--- a/src/python/pants/backend/java/dependency_inference/PantsJavaParserLauncher.java
+++ b/src/python/pants/backend/java/dependency_inference/PantsJavaParserLauncher.java
@@ -13,7 +13,11 @@ import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.AnnotationExpr;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.FieldAccessExpr;
+import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.Name;
+import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithType;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.Type;
@@ -156,7 +160,7 @@ public class PantsJavaParserLauncher {
                     for (Parameter param : methodDecl.getParameters()) {
                         candidateConsumedTypes.add(param.getType());
                     }
-                    System.out.println("Method type: " + methodDecl.getType());
+                    candidateConsumedTypes.addAll(methodDecl.getThrownExceptions());
                 }
                 if (node instanceof ClassOrInterfaceDeclaration) {
                     ClassOrInterfaceDeclaration classOrIntfDecl = (ClassOrInterfaceDeclaration) node;
@@ -166,6 +170,25 @@ public class PantsJavaParserLauncher {
                 if (node instanceof AnnotationExpr) {
                     AnnotationExpr annoExpr = (AnnotationExpr) node;
                     identifiers.add(annoExpr.getNameAsString());
+                }
+                if (node instanceof MethodCallExpr) {
+                    MethodCallExpr methodCallExpr = (MethodCallExpr) node;
+                    Optional<Expression> scopeExprOpt = methodCallExpr.getScope();
+                    if (scopeExprOpt.isPresent()) {
+                        Expression scope = scopeExprOpt.get();
+                        if (scope instanceof NameExpr) {
+                            NameExpr nameExpr = (NameExpr) scope;
+                            identifiers.add(nameExpr.getNameAsString());
+                        }
+                    }
+                }
+                if (node instanceof FieldAccessExpr) {
+                    FieldAccessExpr fieldAccessExpr = (FieldAccessExpr) node;
+                    Expression scope = fieldAccessExpr.getScope();
+                    if (scope instanceof NameExpr) {
+                        NameExpr nameExpr = (NameExpr) scope;
+                        identifiers.add(nameExpr.getNameAsString());
+                    }
                 }
             }
         });

--- a/src/python/pants/backend/java/dependency_inference/java_parser_test.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser_test.py
@@ -122,9 +122,12 @@ def test_simple_java_parser_analysis(rule_runner: RuleRunner) -> None:
         "org.pantsbuild.example.SimpleSource",
         "org.pantsbuild.example.Foo",
     ]
-    assert analysis.consumed_unqualified_types == [
-        "some.other.Thing",
+    assert sorted(analysis.consumed_unqualified_types) == [
         "Date",
+        "System",
+        "date",  # note: false positive on a variable identifier
+        "some",
+        "some.other.Thing",
     ]
 
 
@@ -218,7 +221,7 @@ def test_java_parser_unnamed_package(rule_runner: RuleRunner) -> None:
     assert analysis.declared_package == ""
     assert analysis.imports == []
     assert analysis.top_level_types == ["SimpleSource", "Foo"]
-    assert analysis.consumed_unqualified_types == []
+    assert analysis.consumed_unqualified_types == ["System"]
 
 
 @maybe_skip_jdk_test
@@ -251,7 +254,8 @@ def test_java_parser_consumed_unqualified_types(rule_runner: RuleRunner) -> None
                     }
 
                     @Override
-                    public int foo() {
+                    public int foo() throws AThrownException {
+                        StaticClassRef.someMethod();
                         return 2;
                     }
                 }
@@ -277,15 +281,18 @@ def test_java_parser_consumed_unqualified_types(rule_runner: RuleRunner) -> None
     assert analysis.declared_package == "org.pantsbuild.test"
     assert analysis.imports == []
     assert analysis.top_level_types == ["org.pantsbuild.test.AnImpl"]
-    assert analysis.consumed_unqualified_types == [
-        "InnerClassAnnotation",
-        "SomeInterface",
-        "FieldAnnotation",
+    assert sorted(analysis.consumed_unqualified_types) == [
+        "AThrownException",
         "ClassAnnotation",
-        "SomeThing",
-        "SomeGeneric",
-        "String",
+        "FieldAnnotation",
+        "InnerClassAnnotation",
         "Override",
         "Provided",
         "Provider",
+        "SomeGeneric",
+        "SomeInterface",
+        "SomeThing",
+        "StaticClassRef",
+        "String",
+        "provider",  # note: false positive on a variable identifier
     ]


### PR DESCRIPTION
Extract potential consumed types from method call and field access expressions plus include thrown exceptions as candidate types. This generates some false positives from variable identifiers, but would require some amount of type solving in order to exclude them, so going to not do that work now.