### PR TITLE
[internal] Re-enable skipped JVM inference tests.

### DIFF
--- a/src/python/pants/backend/java/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/java/dependency_inference/rules_test.py
@@ -325,7 +325,7 @@ def test_infer_java_imports_same_target_with_cycle(rule_runner: RuleRunner) -> N
     ) == InferredDependencies(dependencies=[target_a.address])
 
 
-@pytest.mark.xfail(reason="https://github.com/pantsbuild/pants/issues/13056")
+@maybe_skip_jdk_test
 def test_dependencies_from_inferred_deps(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -406,7 +406,7 @@ def test_dependencies_from_inferred_deps(rule_runner: RuleRunner) -> None:
     )
 
 
-@pytest.mark.xfail(reason="https://github.com/pantsbuild/pants/issues/13056")
+@maybe_skip_jdk_test
 def test_package_private_dep(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {


### PR DESCRIPTION
Fixes #13056.

[ci skip-build-wheels]