### PR TITLE
[internal] Go `test` and dependency inference no longer crash on compilation failures

### DIFF
--- a/src/python/pants/backend/go/target_type_rules_test.py
+++ b/src/python/pants/backend/go/target_type_rules_test.py
@@ -110,6 +110,7 @@ def test_go_package_dependency_inference(rule_runner: RuleRunner) -> None:
                         fmt.Printf("%s\n", pkg.Grok())
                     }"""
             ),
+            "foo/bad/f.go": "invalid!!!",
         }
     )
     tgt1 = rule_runner.get_target(Address("foo", generated_name="./cmd"))
@@ -126,6 +127,13 @@ def test_go_package_dependency_inference(rule_runner: RuleRunner) -> None:
     )
     assert inferred_deps2.dependencies == FrozenOrderedSet(
         [Address("foo", generated_name="github.com/google/go-cmp/cmp")]
+    )
+
+    # Compilation failures should not blow up Pants.
+    bad_tgt = rule_runner.get_target(Address("foo", generated_name="./bad"))
+    assert not rule_runner.request(
+        InferredDependencies,
+        [InferGoPackageDependenciesRequest(bad_tgt[GoFirstPartyPackageSourcesField])],
     )
 
 

--- a/src/python/pants/backend/go/util_rules/assembly.py
+++ b/src/python/pants/backend/go/util_rules/assembly.py
@@ -16,11 +16,10 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 
 @dataclass(frozen=True)
 class FallibleAssemblyPreCompilation:
-    results: tuple[FallibleProcessResult, ...]
-    output: AssemblyPreCompilation | None
-
-    def has_failures(self) -> bool:
-        return any(result.exit_code != 0 for result in self.results)
+    result: AssemblyPreCompilation | None
+    exit_code: int = 0
+    stdout: str | None = None
+    stderr: str | None = None
 
 
 @dataclass(frozen=True)
@@ -92,7 +91,10 @@ async def setup_assembly_pre_compilation(
         ),
     )
     if symabis_result.exit_code != 0:
-        return FallibleAssemblyPreCompilation((symabis_result,), None)
+        return FallibleAssemblyPreCompilation(
+            None, symabis_result.exit_code, symabis_result.stderr.decode("utf-8")
+        )
+
     merged = await Get(
         Digest,
         MergeDigests([request.compilation_input, symabis_result.output_digest]),
@@ -107,7 +109,7 @@ async def setup_assembly_pre_compilation(
                     "tool",
                     "asm",
                     "-I",
-                    str(PurePath(goroot.path, "pkg", "include")),
+                    os.path.join(goroot.path, "pkg", "include"),
                     "-o",
                     f"./{request.source_files_subpath}/{PurePath(s_file).with_suffix('.o')}",
                     f"./{request.source_files_subpath}/{s_file}",
@@ -120,9 +122,18 @@ async def setup_assembly_pre_compilation(
         )
         for s_file in request.s_files
     )
+    exit_code = max(result.exit_code for result in assembly_results)
+    if exit_code != 0:
+        stdout = "\n\n".join(
+            result.stdout.decode("utf-8") for result in assembly_results if result.stdout
+        )
+        stderr = "\n\n".join(
+            result.stderr.decode("utf-8") for result in assembly_results if result.stderr
+        )
+        return FallibleAssemblyPreCompilation(None, exit_code, stdout, stderr)
+
     return FallibleAssemblyPreCompilation(
-        tuple(assembly_results),
-        AssemblyPreCompilation(merged, tuple(result.output_digest for result in assembly_results)),
+        AssemblyPreCompilation(merged, tuple(result.output_digest for result in assembly_results))
     )
 
 

--- a/src/python/pants/backend/go/util_rules/assembly_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/assembly_integration_test.py
@@ -23,6 +23,7 @@ from pants.backend.go.util_rules import (
     sdk,
     third_party_pkg,
 )
+from pants.backend.go.util_rules.build_pkg import BuildGoPackageRequest, FallibleBuiltGoPackage
 from pants.core.goals.package import BuiltPackage
 from pants.engine.addresses import Address
 from pants.engine.rules import QueryRule
@@ -45,6 +46,7 @@ def rule_runner() -> RuleRunner:
             *third_party_pkg.rules(),
             *sdk.rules(),
             QueryRule(BuiltPackage, (GoBinaryFieldSet,)),
+            QueryRule(FallibleBuiltGoPackage, (BuildGoPackageRequest,)),
         ],
         target_types=[GoBinaryTarget, GoModTarget],
     )
@@ -123,3 +125,28 @@ def test_build_package_with_assembly(rule_runner: RuleRunner) -> None:
     result = subprocess.run([os.path.join(rule_runner.build_root, "bin")], stdout=subprocess.PIPE)
     assert result.returncode == 0
     assert result.stdout == b"3\n"
+
+
+def test_build_invalid_package(rule_runner: RuleRunner) -> None:
+    request = BuildGoPackageRequest(
+        import_path="example.com/assembly",
+        subpath="",
+        go_file_names=("add_amd64.go", "add_arm64.go"),
+        digest=rule_runner.make_snapshot(
+            {
+                "add_amd64.go": "package main\nfunc add(x, y int64) int64",
+                "add_arm64.go": "package main\nfunc add(x, y int64) int64",
+                "add_amd64.s": "INVALID!!!",
+                "add_arm64.s": "INVALID!!!",
+            }
+        ).digest,
+        s_file_names=("add_amd64.s", "add_arm64.s"),
+        direct_dependencies=(),
+    )
+    result = rule_runner.request(FallibleBuiltGoPackage, [request])
+    assert result.output is None
+    assert result.exit_code == 1
+    assert (
+        result.stdout
+        == ".//add_amd64.s:1: unexpected EOF\nasm: assembly of .//add_amd64.s failed\n"
+    )


### PR DESCRIPTION
We were erroring during `go list` if the file was invalid. That needs to be fallible.

Also `build_pkg.py` needs to handle if any dependencies failed to compile.

[ci skip-rust]
[ci skip-build-wheels]