### PR TITLE
Upgrade to coursier `v2.0.16-169-g194ebc55c`.

### DIFF
--- a/src/python/pants/backend/java/compile/javac.py
+++ b/src/python/pants/backend/java/compile/javac.py
@@ -183,6 +183,7 @@ async def compile_java_source(
             input_digest=merged_digest,
             use_nailgun=jdk_setup.digest,
             append_only_caches=jdk_setup.append_only_caches,
+            env=jdk_setup.env,
             output_directories=(dest_dir,),
             description=f"Compile {request.component} with javac",
             level=LogLevel.DEBUG,

--- a/src/python/pants/backend/java/dependency_inference/import_parser_test.py
+++ b/src/python/pants/backend/java/dependency_inference/import_parser_test.py
@@ -29,12 +29,12 @@ from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.jvm.testutil import maybe_skip_jdk_test
 from pants.jvm.util_rules import rules as util_rules
-from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
 
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
-    return RuleRunner(
+    rule_runner = RuleRunner(
         rules=[
             *config_files.rules(),
             *coursier_fetch_rules(),
@@ -54,6 +54,8 @@ def rule_runner() -> RuleRunner:
         ],
         target_types=[JavaSourcesGeneratorTarget],
     )
+    rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    return rule_runner
 
 
 @maybe_skip_jdk_test

--- a/src/python/pants/backend/java/dependency_inference/java_parser.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser.py
@@ -122,6 +122,7 @@ async def analyze_java_source_dependencies(
             output_files=(analysis_output_path,),
             use_nailgun=tool_digest,
             append_only_caches=jdk_setup.append_only_caches,
+            env=jdk_setup.env,
             description="Run Spoon analysis against Java source",
             level=LogLevel.DEBUG,
         ),

--- a/src/python/pants/backend/java/dependency_inference/java_parser_launcher.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser_launcher.py
@@ -86,6 +86,7 @@ async def build_processors(bash: BashBinary, jdk_setup: JdkSetup) -> JavaParserC
         ),
     )
 
+    # NB: We do not use nailgun for this process, since it is launched exactly once.
     process_result = await Get(
         ProcessResult,
         Process(
@@ -99,8 +100,8 @@ async def build_processors(bash: BashBinary, jdk_setup: JdkSetup) -> JavaParserC
                 _LAUNCHER_BASENAME,
             ],
             input_digest=merged_digest,
-            use_nailgun=jdk_setup.digest,
             append_only_caches=jdk_setup.append_only_caches,
+            env=jdk_setup.env,
             output_directories=(dest_dir,),
             description=f"Compile {_LAUNCHER_BASENAME} import processors with javac",
             level=LogLevel.DEBUG,

--- a/src/python/pants/backend/java/dependency_inference/java_parser_test.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser_test.py
@@ -30,12 +30,12 @@ from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.jvm.target_types import JvmDependencyLockfile
 from pants.jvm.testutil import maybe_skip_jdk_test
 from pants.jvm.util_rules import rules as util_rules
-from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
 
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
-    return RuleRunner(
+    rule_runner = RuleRunner(
         preserve_tmpdirs=True,
         rules=[
             *coursier_fetch_rules(),
@@ -53,6 +53,8 @@ def rule_runner() -> RuleRunner:
         ],
         target_types=[JvmDependencyLockfile, JavaSourceTarget],
     )
+    rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    return rule_runner
 
 
 @maybe_skip_jdk_test

--- a/src/python/pants/backend/java/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/java/dependency_inference/rules_test.py
@@ -34,13 +34,13 @@ from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.jvm.testutil import maybe_skip_jdk_test
 from pants.jvm.util_rules import rules as util_rules
-from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
 from pants.util.ordered_set import FrozenOrderedSet
 
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
-    return RuleRunner(
+    rule_runner = RuleRunner(
         rules=[
             *config_files.rules(),
             *coursier_fetch_rules(),
@@ -62,6 +62,8 @@ def rule_runner() -> RuleRunner:
         ],
         target_types=[JavaSourcesGeneratorTarget, JunitTestsGeneratorTarget],
     )
+    rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    return rule_runner
 
 
 @maybe_skip_jdk_test

--- a/src/python/pants/backend/java/package/deploy_jar_test.py
+++ b/src/python/pants/backend/java/package/deploy_jar_test.py
@@ -35,12 +35,12 @@ from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.jvm.target_types import JvmArtifact, JvmDependencyLockfile
 from pants.jvm.testutil import maybe_skip_jdk_test
 from pants.jvm.util_rules import rules as util_rules
-from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
 
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
-    return RuleRunner(
+    rule_runner = RuleRunner(
         rules=[
             # TODO: delete a few of these (they were copied from junit tests; not sure which
             # are needed)
@@ -76,6 +76,8 @@ def rule_runner() -> RuleRunner:
             DeployJar,
         ],
     )
+    rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    return rule_runner
 
 
 JAVA_LIB_SOURCE = dedent(
@@ -375,6 +377,7 @@ def _deploy_jar_test(rule_runner: RuleRunner, target_name: str) -> None:
                 description="Run that test jar",
                 input_digest=input_digests,
                 append_only_caches=jdk_setup.append_only_caches,
+                env=jdk_setup.env,
             )
         ],
     )

--- a/src/python/pants/backend/java/test/junit.py
+++ b/src/python/pants/backend/java/test/junit.py
@@ -95,6 +95,7 @@ async def run_junit_test(
             input_digest=merged_digest,
             output_directories=(reports_dir,),
             append_only_caches=jdk_setup.append_only_caches,
+            env=jdk_setup.env,
             description=f"Run JUnit 5 ConsoleLauncher against {field_set.address}",
             level=LogLevel.DEBUG,
         ),

--- a/src/python/pants/backend/java/test/junit_test.py
+++ b/src/python/pants/backend/java/test/junit_test.py
@@ -33,14 +33,14 @@ from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.jvm.target_types import JvmArtifact, JvmDependencyLockfile
 from pants.jvm.testutil import maybe_skip_jdk_test
 from pants.jvm.util_rules import rules as util_rules
-from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
 
 # TODO(12812): Switch tests to using parsed junit.xml results instead of scanning stdout strings.
 
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
-    return RuleRunner(
+    rule_runner = RuleRunner(
         preserve_tmpdirs=True,
         rules=[
             *config_files.rules(),
@@ -63,11 +63,13 @@ def rule_runner() -> RuleRunner:
             JavaSourcesGeneratorTarget,
             JunitTestsGeneratorTarget,
         ],
-        bootstrap_args=[
-            # Makes JUnit output predictable and parseable across versions (#12933):
-            "--junit-args=['--disable-ansi-colors','--details=flat','--details-theme=ascii']",
-        ],
     )
+    rule_runner.set_options(
+        # Makes JUnit output predictable and parseable across versions (#12933):
+        args=["--junit-args=['--disable-ansi-colors','--details=flat','--details-theme=ascii']"],
+        env_inherit=PYTHON_BOOTSTRAP_ENV,
+    )
+    return rule_runner
 
 
 # This is hard-coded to make the test somewhat more hermetic.

--- a/src/python/pants/backend/scala/compile/scalac.py
+++ b/src/python/pants/backend/scala/compile/scalac.py
@@ -210,6 +210,7 @@ async def compile_scala_source(
             description=f"Compile {request.component.members} with scalac",
             level=LogLevel.DEBUG,
             append_only_caches=jdk_setup.append_only_caches,
+            env=jdk_setup.env,
         ),
     )
     output: CompiledClassfiles | None = None

--- a/src/python/pants/backend/scala/compile/scalac_test.py
+++ b/src/python/pants/backend/scala/compile/scalac_test.py
@@ -32,12 +32,12 @@ from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.jvm.target_types import JvmArtifact, JvmDependencyLockfile
 from pants.jvm.testutil import maybe_skip_jdk_test
 from pants.jvm.util_rules import rules as util_rules
-from pants.testutil.rule_runner import QueryRule, RuleRunner, logging
+from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner, logging
 
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
-    return RuleRunner(
+    rule_runner = RuleRunner(
         rules=[
             *config_files.rules(),
             *coursier_fetch_rules(),
@@ -56,6 +56,8 @@ def rule_runner() -> RuleRunner:
         ],
         target_types=[JvmDependencyLockfile, ScalaSourcesGeneratorTarget, JvmArtifact],
     )
+    rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    return rule_runner
 
 
 SCALA_LIB_SOURCE = dedent(

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -246,6 +246,7 @@ async def coursier_resolve_lockfile(
             output_directories=("classpath",),
             output_files=(coursier_report_file_name,),
             append_only_caches=coursier.append_only_caches,
+            env=coursier.env,
             description=(
                 "Running `coursier fetch` against "
                 f"{pluralize(len(artifact_requirements), 'requirement')}: "
@@ -347,6 +348,7 @@ async def coursier_fetch_one_coord(
             output_directories=("classpath",),
             output_files=(coursier_report_file_name,),
             append_only_caches=coursier.append_only_caches,
+            env=coursier.env,
             description="Run coursier resolve",
             level=LogLevel.DEBUG,
         ),

--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -23,7 +23,7 @@ from pants.jvm.target_types import JvmArtifact, JvmDependencyLockfile
 from pants.jvm.testutil import maybe_skip_jdk_test
 from pants.jvm.util_rules import ExtractFileDigest
 from pants.jvm.util_rules import rules as util_rules
-from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
 
 HAMCREST_COORD = Coordinate(
     group="org.hamcrest",
@@ -34,7 +34,7 @@ HAMCREST_COORD = Coordinate(
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
-    return RuleRunner(
+    rule_runner = RuleRunner(
         rules=[
             *config_files.rules(),
             *coursier_fetch_rules(),
@@ -48,6 +48,8 @@ def rule_runner() -> RuleRunner:
         ],
         target_types=[JvmDependencyLockfile, JvmArtifact],
     )
+    rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    return rule_runner
 
 
 @maybe_skip_jdk_test

--- a/src/python/pants/jvm/resolve/coursier_setup.py
+++ b/src/python/pants/jvm/resolve/coursier_setup.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 import textwrap
 from dataclasses import dataclass
 from typing import ClassVar, Iterable
@@ -58,15 +59,15 @@ class CoursierBinary(TemplatedExternalTool):
     name = "coursier"
     help = "A dependency resolver for the Maven ecosystem."
 
-    default_version = "v2.0.13"
+    default_version = "v2.0.16-169-g194ebc55c"
     default_known_versions = [
-        "v2.0.13|linux_arm64 |8d428bede2d9d0e48ffad8360d49de48bd0c2c3b0e54e82e3a7665019b65e4d0|58622664",
-        "v2.0.13|linux_x86_64|1ae089789cc4b0a4d296d6852b760d7f8bf72805267a6b7571e99b681d5e13b4|59652208",
-        "v2.0.13|macos_arm64 |d74b8fe4ffc2f4e9011d7151722fc8b5ffca8a72b3bc4188c61df3326228c4ef|57625024",
-        "v2.0.13|macos_x86_64|d74b8fe4ffc2f4e9011d7151722fc8b5ffca8a72b3bc4188c61df3326228c4ef|57625024",
+        "v2.0.16-169-g194ebc55c|linux_arm64 |da38c97d55967505b8454c20a90370c518044829398b9bce8b637d194d79abb3|18114472",
+        "v2.0.16-169-g194ebc55c|linux_x86_64|4c61a634c4bd2773b4543fe0fc32210afd343692891121cddb447204b48672e8|18486946",
+        "v2.0.16-169-g194ebc55c|macos_arm64 |15bce235d223ef1d022da30b67b4c64e9228d236b876c834b64e029bbe824c6f|17957182",
+        "v2.0.16-169-g194ebc55c|macos_x86_64|15bce235d223ef1d022da30b67b4c64e9228d236b876c834b64e029bbe824c6f|17957182",
     ]
     default_url_template = (
-        "https://github.com/coursier/coursier/releases/download/{version}/cs-{platform}"
+        "https://github.com/coursier/coursier/releases/download/{version}/cs-{platform}.gz"
     )
     default_url_platform_mapping = {
         "macos_arm64": "x86_64-apple-darwin",
@@ -74,6 +75,11 @@ class CoursierBinary(TemplatedExternalTool):
         "linux_arm64": "aarch64-pc-linux",
         "linux_x86_64": "x86_64-pc-linux",
     }
+
+    def generate_exe(self, plat: Platform) -> str:
+        archive_filename = os.path.basename(self.generate_url(plat))
+        filename = os.path.splitext(archive_filename)[0]
+        return f"./{filename}"
 
 
 @dataclass(frozen=True)
@@ -88,7 +94,18 @@ class Coursier:
     cache_dir: ClassVar[str] = ".cache"
 
     def args(self, args: Iterable[str], *, wrapper: Iterable[str] = ()) -> tuple[str, ...]:
-        return tuple((*wrapper, self.coursier.exe, *args, "--cache", f"{self.cache_dir}"))
+        return tuple((*wrapper, self.coursier.exe, *args))
+
+    @property
+    def env(self) -> dict[str, str]:
+        # NB: These variables have changed a few times, and they change again on `main`. But as of
+        # `v2.0.16+73-gddc6d9cc9` they are accurate. See:
+        #  https://github.com/coursier/coursier/blob/v2.0.16+73-gddc6d9cc9/modules/paths/src/main/java/coursier/paths/CoursierPaths.java#L38-L48
+        return {
+            "COURSIER_CACHE": f"{self.cache_dir}/jdk",
+            "COURSIER_ARCHIVE_CACHE": f"{self.cache_dir}/arc",
+            "COURSIER_JVM_CACHE": f"{self.cache_dir}/v1",
+        }
 
     @property
     def append_only_caches(self) -> dict[str, str]:

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -130,6 +130,12 @@ _O = TypeVar("_O")
 _EXECUTOR = PyExecutor(core_threads=1, max_threads=3)
 
 
+# Environment variable names required for locating Python interpreters, for use with RuleRunner's
+# env_inherit arguments.
+# TODO: This is verbose and redundant: see https://github.com/pantsbuild/pants/issues/13350.
+PYTHON_BOOTSTRAP_ENV = {"PATH", "PYENV_ROOT", "HOME"}
+
+
 @dataclass(frozen=True)
 class GoalRuleResult:
     exit_code: int

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -56,6 +56,8 @@ fn construct_nailgun_server_request(
     level: log::Level::Info,
     use_nailgun: hashing::EMPTY_DIGEST,
     execution_slot_variable: None,
+    env: client_request.env,
+    append_only_caches: client_request.append_only_caches,
     ..client_request
   }
 }

--- a/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
@@ -315,6 +315,8 @@ impl NailgunProcess {
       .args(&startup_options.argv[1..])
       .stdout(Stdio::piped())
       .stderr(Stdio::piped())
+      .env_clear()
+      .envs(&startup_options.env)
       .current_dir(&workdir)
       .spawn()
       .map_err(|e| {


### PR DESCRIPTION
Upgrade to the latest coursier release to pull in https://github.com/coursier/coursier/pull/2197.

Because `coursier` is now distributed in a `.gz` file, #13335 was required. Additionally, the `--jvm-dir` flag was removed, so we move to specifying all cache locations using environment variables. Finally, fix `nailgun` server launching not propagating `env` vars to spawned servers.

Fixes #13140 and #13316.

[ci skip-build-wheels]