### PR TITLE
[internal] Remove test cache isolation

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -114,7 +114,6 @@ extra_requirements.add = [
 ]
 lockfile = "3rdparty/python/lockfiles/pytest.txt"
 timeout_default = 60
-execution_slot_var = "EXECUTION_SLOT"
 
 [test]
 extra_env_vars = [

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -170,15 +170,6 @@ class RuleRunner:
 
         bootstrap_args = [*bootstrap_args]
 
-        # TODO: Until https://github.com/coursier/coursier/pull/2197 is resolved, we avoid concurrent
-        # use of the named caches via `[pytest] execution_slot_var`.
-        home = os.environ.get("HOME")
-        exec_slot = os.environ.get("EXECUTION_SLOT")
-        if home and exec_slot:
-            bootstrap_args.append(
-                f"--named-caches-dir={home}/.cache/pants/named_caches/tests/{exec_slot}"
-            )
-
         root_dir: Path | None = None
         if preserve_tmpdirs:
             root_dir = Path(mkdtemp(prefix="RuleRunner."))


### PR DESCRIPTION
With #13336 fixed, we should be able to remove `RuleRunner` cache directory isolation.

Thanks a lot to @patricklaw for the upstream fix in https://github.com/coursier/coursier/pull/2197, and @alexarchambault for his work getting out a new coursier release! 

[ci skip-rust]
[ci skip-build-wheels]