### PR TITLE
[internal] Support Go `replace` for version and fix modules without packages

### DIFF
--- a/src/python/pants/backend/go/util_rules/go_mod.py
+++ b/src/python/pants/backend/go/util_rules/go_mod.py
@@ -60,12 +60,19 @@ def parse_module_descriptors(raw_json: bytes) -> list[ModuleDescriptor]:
     for raw_module_descriptor in ijson.items(raw_json, "", multiple_values=True):
         if raw_module_descriptor.get("Main", False):
             continue
-
-        module_descriptor = ModuleDescriptor(
-            path=raw_module_descriptor["Path"],
-            version=raw_module_descriptor["Version"],
-        )
-        module_descriptors.append(module_descriptor)
+        path = raw_module_descriptor["Path"]
+        if "Replace" in raw_module_descriptor:
+            if raw_module_descriptor["Replace"]["Path"] != raw_module_descriptor["Path"]:
+                raise NotImplementedError(
+                    "Pants does not yet support replace directives that change the import path. "
+                    "Please open an issue at https://github.com/pantsbuild/pants/issues/new/choose "
+                    "with this error message so that we know to prioritize adding support:\n\n"
+                    f"{raw_module_descriptor}"
+                )
+            version = raw_module_descriptor["Replace"]["Version"]
+        else:
+            version = raw_module_descriptor["Version"]
+        module_descriptors.append(ModuleDescriptor(path, version))
     return module_descriptors
 
 

--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -280,6 +280,10 @@ async def compute_third_party_module_metadata(
         ),
     )
 
+    # Some modules don't have any Go code in them, meaning they have no packages.
+    if not json_result.stdout:
+        return ThirdPartyModuleInfo()
+
     import_path_to_info = {}
     for metadata in ijson.items(json_result.stdout, "", multiple_values=True):
         import_path = metadata["ImportPath"]


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/13137. We don't yet support `replace` when it says to point to another import path, like a local directory, but we at least support changing the version used.

This also fixes that it is possible to have a module with no packages in it / no `.go` files. We should not error in that case. We simply won't generate any `go_third_party_package` targets so it's as if the module was irrelevant.

[ci skip-rust]
[ci skip-build-wheels]