### PR TITLE
[internal] Disable Go downloads for almost all processes

### DIFF
--- a/src/python/pants/backend/go/util_rules/sdk.py
+++ b/src/python/pants/backend/go/util_rules/sdk.py
@@ -39,10 +39,15 @@ class GoSdkProcess:
         working_dir: str | None = None,
         output_files: Iterable[str] = (),
         output_directories: Iterable[str] = (),
+        allow_downloads: bool = False,
     ) -> None:
         self.command = tuple(command)
         self.description = description
-        self.env = FrozenDict(env or {})
+        self.env = (
+            FrozenDict(env or {})
+            if allow_downloads
+            else FrozenDict({**(env or {}), "GOPROXY": "off"})
+        )
         self.input_digest = input_digest
         self.working_dir = working_dir
         self.output_files = tuple(output_files)

--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -97,6 +97,7 @@ async def download_third_party_modules(
             description="Download all third-party Go modules",
             output_files=("go.mod", "go.sum"),
             output_directories=("gopath",),
+            allow_downloads=True,
         ),
     )
 
@@ -272,7 +273,6 @@ async def compute_third_party_module_metadata(
         GoSdkProcess(
             input_digest=downloaded_module.digest,
             command=("list", "-mod=readonly", "-json", "./..."),
-            env={"GOPROXY": "off"},
             description=(
                 "Determine metadata for Go third-party module "
                 f"{request.module_path}@{request.version}"


### PR DESCRIPTION
This allows us to be more confident we are only downloading in one place: the `go mod download all` rule. Among other benefits, this is important for performance, that we don't redownload the same thing multiple times.

[ci skip-rust]
[ci skip-build-wheels]