### PR TITLE
Parse SSH git requirements in poetry config.

### DIFF
--- a/src/python/pants/backend/python/macros/poetry_requirements.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import itertools
 import logging
 import os
+import urllib.parse
 from dataclasses import dataclass
 from pathlib import Path, PurePath
 from typing import Any, Iterable, Iterator, Mapping, Sequence, cast
@@ -239,6 +240,10 @@ def handle_dict_attr(
 
     git_lookup = attributes.get("git")
     if git_lookup is not None:
+        # If no URL scheme (e.g., `{git = "git@github.com:foo/bar.git"}`) we assume ssh,
+        # i.e., we convert to git+ssh://git@github.com/foo/bar.git.
+        if not urllib.parse.urlsplit(git_lookup).scheme:
+            git_lookup = f"ssh://{git_lookup.replace(':', '/', 1)}"
         rev_lookup = produce_match("#", attributes.get("rev"))
         branch_lookup = produce_match("@", attributes.get("branch"))
         tag_lookup = produce_match("@", attributes.get("tag"))

--- a/src/python/pants/backend/python/macros/poetry_requirements_test.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements_test.py
@@ -191,6 +191,14 @@ def test_handle_git(empty_pyproject_toml: PyProjectToml) -> None:
     )
 
 
+def test_handle_git_ssh(empty_pyproject_toml: PyProjectToml) -> None:
+    attr = PyprojectAttr({"git": "git@github.com:requests/requests.git"})
+    assert (
+        handle_dict_attr("requests", attr, empty_pyproject_toml)
+        == "requests @ git+ssh://git@github.com/requests/requests.git"
+    )
+
+
 def test_handle_path_arg(tmp_path: Path) -> None:
     build_root = tmp_path / "build_root"
 


### PR DESCRIPTION
Reqs of the form `git@github.com:foo/bar.git` must be rewritten to
`ssh://git@github.com/foo/bar.git` to become valid PEP 440 requirements.

[ci skip-rust]

[ci skip-build-wheels]