### PR TITLE
Remove `tffmt` from `lint` so that it runs only in `check`

### DIFF
--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
@@ -8,7 +8,7 @@ from pants.backend.terraform.style import StyleSetup, StyleSetupRequest
 from pants.backend.terraform.tool import TerraformProcess
 from pants.backend.terraform.tool import rules as tool_rules
 from pants.core.goals.fmt import FmtResult
-from pants.core.goals.lint import LintRequest, LintResult, LintResults
+from pants.core.goals.lint import LintResult, LintResults
 from pants.core.util_rules import external_tool
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.internals.selectors import Get, MultiGet
@@ -102,6 +102,5 @@ def rules():
         *collect_rules(),
         *external_tool.rules(),
         *tool_rules(),
-        UnionRule(LintRequest, TffmtRequest),
         UnionRule(TerraformFmtRequest, TffmtRequest),
     ]


### PR DESCRIPTION
#13301 moved `tffmt` to the `check` goal, but did not actually remove it from `lint`.

[ci skip-rust]
[ci skip-build-wheels]