### PR TITLE
Fix missing field for `tffmt` in `lint`. (cherrypick of #13355)

### DIFF
--- a/src/python/pants/backend/terraform/lint/fmt.py
+++ b/src/python/pants/backend/terraform/lint/fmt.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass
 from typing import Iterable
 
-from pants.backend.terraform.target_types import TerraformModuleSourcesField
+from pants.backend.terraform.target_types import TerraformFieldSet, TerraformModuleSourcesField
 from pants.core.goals.fmt import FmtResult, LanguageFmtResults, LanguageFmtTargets
 from pants.core.goals.style_request import StyleRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
@@ -21,7 +21,7 @@ class TerraformFmtTargets(LanguageFmtTargets):
 
 @union
 class TerraformFmtRequest(StyleRequest):
-    pass
+    field_set_type = TerraformFieldSet
 
 
 @rule


### PR DESCRIPTION
#13301 changed `TffmtRequest`'s inheritance of `StyleRequest`, but didn't add an abstract field. `mypy` didn't flag this, likely because our use of `@union` obscures the constructor call that might have triggered the error: see https://mypy.readthedocs.io/en/stable/class_basics.html#abstract-base-classes-and-multiple-inheritance. 

It's possible that #12577 would improve the situation here, but it doesn't seem worth adding heavier integration tests (which would invoke the entire `lint` and `fmt` goals) just to catch this kind of case.

[ci skip-rust]
[ci skip-build-wheels]