### PR TITLE
Go: don't error for unsupported third-party sources with project introspection (Cherry-pick of #13377)

### DIFF
--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -270,6 +270,11 @@ async def setup_build_go_package_target_request(
             ),
         )
 
+        # We error if trying to _build_ a package with unsupported sources (vs. only generating the
+        # target and using in project introspection).
+        if _third_party_pkg_info.unsupported_sources_error:
+            raise _third_party_pkg_info.unsupported_sources_error
+
         subpath = _third_party_pkg_info.subpath
         digest = _third_party_pkg_info.digest
         go_file_names = _third_party_pkg_info.go_files

--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -210,19 +210,13 @@ async def extract_package_info(request: ThirdPartyPkgInfoRequest) -> ThirdPartyP
         AllThirdPartyPackages, AllThirdPartyPackagesRequest(request.go_mod_stripped_digest)
     )
     pkg_info = all_packages.import_paths_to_pkg_info.get(request.import_path)
-    if pkg_info is None:
-        raise AssertionError(
-            f"The package `{request.import_path}` was not downloaded, but Pants tried using it. "
-            "This should not happen. Please open an issue at "
-            "https://github.com/pantsbuild/pants/issues/new/choose with this error message."
-        )
-
-    # We error if trying to _use_ a package with unsupported sources (vs. only generating the
-    # target definition).
-    if pkg_info.unsupported_sources_error:
-        raise pkg_info.unsupported_sources_error
-
-    return pkg_info
+    if pkg_info:
+        return pkg_info
+    raise AssertionError(
+        f"The package `{request.import_path}` was not downloaded, but Pants tried using it. "
+        "This should not happen. Please open an issue at "
+        "https://github.com/pantsbuild/pants/issues/new/choose with this error message."
+    )
 
 
 def maybe_create_error_for_invalid_sources(

--- a/src/python/pants/backend/go/util_rules/third_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg_test.py
@@ -387,25 +387,10 @@ def test_unsupported_sources(rule_runner: RuleRunner) -> None:
             """
         ),
     )
-
-    # Nothing should error when computing `AllThirdPartyPackages`, we only create an exception to
-    # maybe raise later.
-    all_packages = rule_runner.request(
-        AllThirdPartyPackages, [AllThirdPartyPackagesRequest(digest)]
+    pkg_info = rule_runner.request(
+        ThirdPartyPkgInfo, [ThirdPartyPkgInfoRequest("golang.org/x/mobile/bind/objc", digest)]
     )
-    assert (
-        all_packages.import_paths_to_pkg_info[
-            "golang.org/x/mobile/bind/objc"
-        ].unsupported_sources_error
-        is not None
-    )
-
-    # Error when requesting the `ThirdPartyPkgInfo`.
-    with engine_error(NotImplementedError):
-        rule_runner.request(
-            ThirdPartyPkgInfo,
-            [ThirdPartyPkgInfoRequest("golang.org/x/mobile/bind/objc", digest)],
-        )
+    assert pkg_info.unsupported_sources_error is not None
 
 
 def test_determine_pkg_info_module_with_replace_directive(rule_runner: RuleRunner) -> None:


### PR DESCRIPTION
Without this, `./pants peek ::` et al will error if any packages have files like Cgo. Instead, we should only error when you are trying to _build_ one of those packages.

[ci skip-rust]
[ci skip-build-wheels]