### PR TITLE
[internal] Track side-effects in `RuleRunner.run_goal_rule` to prevent spurious restarts

### DIFF
--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -322,14 +322,14 @@ class RuleRunner:
         specs = SpecsParser(self.build_root).parse_specs(raw_specs)
 
         stdout, stderr = StringIO(), StringIO()
-        console = Console(stdout=stdout, stderr=stderr, use_colors=False)
+        console = Console(stdout=stdout, stderr=stderr, use_colors=False, session=self.scheduler)
 
         exit_code = self.scheduler.run_goal_rule(
             goal,
             Params(
                 specs,
                 console,
-                Workspace(self.scheduler, _enforce_effects=False),
+                Workspace(self.scheduler),
             ),
         )
 


### PR DESCRIPTION
Unlike `run_rule_with_mocks`, `RuleRunner.run_goal_rule` does actually run a `Goal` via the engine, and is thus subject to being restarted when its inputs have changed (see #13178). Consequently, the `Console` and `Workspace` types _do_ need to track side-effects in that context, in order to prevent the `@rule` from being restarted after its first side-effect.

This was exhibiting as test flakiness for a goal that re-writes files in the workspace (see #13383), because after writing the updated lockfile to disk, the `@rule` has changed its own inputs and is subject to restart: if the restart arrived before any `Console` output was written, the second attempt to run the rule would not find anything to do, and would thus not render any `Console` output.

Fixes #13383.

[ci skip-rust]
[ci skip-build-wheels]