### PR TITLE
[internal] java: merge first-party and third-party dep inference loops

### DIFF
--- a/src/python/pants/backend/java/dependency_inference/artifact_mapper.py
+++ b/src/python/pants/backend/java/dependency_inference/artifact_mapper.py
@@ -1,0 +1,207 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any, Iterable, Set
+
+from pants.backend.java.dependency_inference.jvm_artifact_mappings import JVM_ARTIFACT_MAPPINGS
+from pants.backend.java.subsystems.java_infer import JavaInferSubsystem
+from pants.base.specs import AddressSpecs, MaybeEmptyDescendantAddresses
+from pants.build_graph.address import Address
+from pants.engine.internals.selectors import Get
+from pants.engine.rules import collect_rules, rule
+from pants.engine.target import UnexpandedTargets
+from pants.jvm.target_types import JvmArtifactArtifactField, JvmArtifactGroupField
+from pants.util.frozendict import FrozenDict
+from pants.util.meta import frozen_after_init
+from pants.util.ordered_set import FrozenOrderedSet
+
+
+@dataclass(frozen=True)
+class UnversionedCoordinate:
+    group: str
+    artifact: str
+
+    @classmethod
+    def from_coord_str(cls, coord: str) -> UnversionedCoordinate:
+        coordinate_parts = coord.split(":")
+        if len(coordinate_parts) != 2:
+            raise ValueError(f"Invalid coordinate specifier: {coord}")
+        return UnversionedCoordinate(group=coordinate_parts[0], artifact=coordinate_parts[1])
+
+
+@dataclass(frozen=True)
+class AvailableThirdPartyArtifacts:
+    """Maps JVM artifact coordinates (with only group and artifact set) to the `Address` of each
+    target specifying that coordinate."""
+
+    artifacts: FrozenDict[UnversionedCoordinate, FrozenOrderedSet[Address]]
+
+    def addresses_for_coordinates(
+        self, coordinates: Iterable[UnversionedCoordinate]
+    ) -> FrozenOrderedSet[Address]:
+        candidate_artifact_addresses: Set[Address] = set()
+        for coordinate in coordinates:
+            candidates = self.artifacts.get(coordinate, FrozenOrderedSet())
+            candidate_artifact_addresses.update(candidates)
+        return FrozenOrderedSet(candidate_artifact_addresses)
+
+
+class MutableTrieNode:
+    def __init__(self):
+        self.children: dict[str, MutableTrieNode] = {}
+        self.recursive: bool = False
+        self.coordinates: set[UnversionedCoordinate] = set()
+
+    def ensure_child(self, name: str) -> MutableTrieNode:
+        if name in self.children:
+            return self.children[name]
+        node = MutableTrieNode()
+        self.children[name] = node
+        return node
+
+
+@frozen_after_init
+class FrozenTrieNode:
+    def __init__(self, node: MutableTrieNode) -> None:
+        children = {}
+        for key, child in node.children.items():
+            children[key] = FrozenTrieNode(child)
+        self._children: FrozenDict[str, FrozenTrieNode] = FrozenDict(children)
+        self._recursive: bool = node.recursive
+        self._coordinates: FrozenOrderedSet[UnversionedCoordinate] = FrozenOrderedSet(
+            node.coordinates
+        )
+
+    def find_child(self, name: str) -> FrozenTrieNode | None:
+        return self._children.get(name)
+
+    @property
+    def recursive(self) -> bool:
+        return self._recursive
+
+    @property
+    def coordinates(self) -> FrozenOrderedSet[UnversionedCoordinate]:
+        return self._coordinates
+
+    def __hash__(self) -> int:
+        return hash((self._children, self._recursive, self._coordinates))
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, FrozenTrieNode):
+            return False
+        return (
+            self._children == other._children
+            and self.recursive == other.recursive
+            and self.coordinates == other.coordinates
+        )
+
+    def __repr__(self):
+        return f"FrozenTrieNode(children={repr(self._children)}, recursive={self._recursive}, coordinate={self._coordinates})"
+
+
+@dataclass(frozen=True)
+class ThirdPartyJavaPackageToArtifactMapping:
+    mapping_root: FrozenTrieNode
+
+
+@rule
+async def find_available_third_party_artifacts() -> AvailableThirdPartyArtifacts:
+    all_targets = await Get(UnexpandedTargets, AddressSpecs([MaybeEmptyDescendantAddresses("")]))
+    jvm_artifact_targets = [
+        tgt
+        for tgt in all_targets
+        if tgt.has_fields((JvmArtifactGroupField, JvmArtifactArtifactField))
+    ]
+
+    artifact_mapping: dict[UnversionedCoordinate, set[Address]] = defaultdict(set)
+    for tgt in jvm_artifact_targets:
+        group = tgt[JvmArtifactGroupField].value
+        if not group:
+            raise ValueError(
+                f"The {JvmArtifactGroupField.alias} field of target {tgt.address} must be set."
+            )
+
+        artifact = tgt[JvmArtifactArtifactField].value
+        if not artifact:
+            raise ValueError(
+                f"The {JvmArtifactArtifactField.alias} field of target {tgt.address} must be set."
+            )
+
+        key = UnversionedCoordinate(group=group, artifact=artifact)
+        artifact_mapping[key].add(tgt.address)
+
+    return AvailableThirdPartyArtifacts(
+        FrozenDict({key: FrozenOrderedSet(value) for key, value in artifact_mapping.items()})
+    )
+
+
+@rule
+async def compute_java_third_party_artifact_mapping(
+    java_infer_subsystem: JavaInferSubsystem,
+) -> ThirdPartyJavaPackageToArtifactMapping:
+    def insert(mapping: MutableTrieNode, imp: str, coordinate: UnversionedCoordinate) -> None:
+        imp_parts = imp.split(".")
+        recursive = False
+        if imp_parts[-1] == "**":
+            recursive = True
+            imp_parts = imp_parts[0:-1]
+
+        current_node = mapping
+        for imp_part in imp_parts:
+            child_node = current_node.ensure_child(imp_part)
+            current_node = child_node
+
+        current_node.coordinates.add(coordinate)
+        current_node.recursive = recursive
+
+    mapping = MutableTrieNode()
+    for imp_name, imp_action in {
+        **JVM_ARTIFACT_MAPPINGS,
+        **java_infer_subsystem.third_party_import_mapping,
+    }.items():
+        value = UnversionedCoordinate.from_coord_str(imp_action)
+        insert(mapping, imp_name, value)
+
+    return ThirdPartyJavaPackageToArtifactMapping(FrozenTrieNode(mapping))
+
+
+def find_artifact_mapping(
+    import_name: str,
+    mapping: ThirdPartyJavaPackageToArtifactMapping,
+    available_artifacts: AvailableThirdPartyArtifacts,
+) -> FrozenOrderedSet[Address]:
+    imp_parts = import_name.split(".")
+    current_node = mapping.mapping_root
+
+    found_nodes = []
+    for imp_part in imp_parts:
+        child_node_opt = current_node.find_child(imp_part)
+        if not child_node_opt:
+            break
+        found_nodes.append(child_node_opt)
+        current_node = child_node_opt
+
+    if not found_nodes:
+        return FrozenOrderedSet()
+
+    # If the length of the found nodes equals the number of parts of the package path, then there
+    # is an exact match.
+    if len(found_nodes) == len(imp_parts):
+        addresses = available_artifacts.addresses_for_coordinates(found_nodes[-1].coordinates)
+        return addresses
+
+    # Otherwise, check for the first found node (in reverse order) to match recursively, and use its coordinate.
+    for found_node in reversed(found_nodes):
+        if found_node.recursive:
+            addresses = available_artifacts.addresses_for_coordinates(found_node.coordinates)
+            return addresses
+
+    # Nothing matched so return no match.
+    return FrozenOrderedSet()
+
+
+def rules():
+    return collect_rules()

--- a/src/python/pants/backend/java/dependency_inference/rules.py
+++ b/src/python/pants/backend/java/dependency_inference/rules.py
@@ -3,16 +3,22 @@
 from __future__ import annotations
 
 import logging
-from collections import defaultdict
-from dataclasses import dataclass
-from typing import Any, Iterable, Set, cast
 
-from pants.backend.java.dependency_inference import import_parser, java_parser, package_mapper
-from pants.backend.java.dependency_inference.jvm_artifact_mappings import JVM_ARTIFACT_MAPPINGS
+from pants.backend.java.dependency_inference import (
+    artifact_mapper,
+    import_parser,
+    java_parser,
+    package_mapper,
+)
+from pants.backend.java.dependency_inference.artifact_mapper import (
+    AvailableThirdPartyArtifacts,
+    ThirdPartyJavaPackageToArtifactMapping,
+    find_artifact_mapping,
+)
 from pants.backend.java.dependency_inference.package_mapper import FirstPartyJavaPackageMapping
 from pants.backend.java.dependency_inference.types import JavaSourceDependencyAnalysis
+from pants.backend.java.subsystems.java_infer import JavaInferSubsystem
 from pants.backend.java.target_types import JavaSourceField
-from pants.base.specs import AddressSpecs, MaybeEmptyDescendantAddresses
 from pants.core.util_rules.source_files import SourceFilesRequest
 from pants.core.util_rules.source_files import rules as source_files_rules
 from pants.engine.addresses import Address
@@ -23,90 +29,16 @@ from pants.engine.target import (
     ExplicitlyProvidedDependencies,
     InferDependenciesRequest,
     InferredDependencies,
-    UnexpandedTargets,
     WrappedTarget,
 )
 from pants.engine.unions import UnionRule
-from pants.jvm.target_types import JvmArtifactArtifactField, JvmArtifactGroupField
-from pants.option.subsystem import Subsystem
-from pants.util.docutil import git_url
-from pants.util.frozendict import FrozenDict
-from pants.util.meta import frozen_after_init
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 
 logger = logging.getLogger(__name__)
 
 
-class JavaInferSubsystem(Subsystem):
-    options_scope = "java-infer"
-    help = "Options controlling which dependencies will be inferred for Java targets."
-
-    @classmethod
-    def register_options(cls, register):
-        super().register_options(register)
-        register(
-            "--imports",
-            default=True,
-            type=bool,
-            help=("Infer a target's dependencies by parsing import statements from sources."),
-        )
-        register(
-            "--consumed-types",
-            default=True,
-            type=bool,
-            help=("Infer a target's dependencies by parsing consumed types from sources."),
-        )
-        register(
-            "--third-party-imports",
-            default=True,
-            type=bool,
-            help="Infer a target's third-party dependencies using Java import statements.",
-        )
-        _default_package_mapping_url = git_url(
-            "src/python/pants/backend/java/dependency_inference/jvm_artifact_mappings.py"
-        )
-        register(
-            "--third-party-import-mapping",
-            type=dict,
-            help=(
-                "A dictionary mapping a Java package path to a JVM artifact coordinate (GROUP:ARTIFACT) "
-                "without the version. The package path may be made recursive to match symbols in subpackages "
-                "by adding `.**` to the end of the package path. For example, specify `{'org.junit.**': 'junit:junit'} `"
-                "to infer a dependency on junit:junit for any file importing a symbol from org.junit or its "
-                f"subpackages. Pants also supplies a default package mapping ({_default_package_mapping_url})."
-            ),
-        )
-
-    @property
-    def imports(self) -> bool:
-        return cast(bool, self.options.imports)
-
-    @property
-    def consumed_types(self) -> bool:
-        return cast(bool, self.options.consumed_types)
-
-    @property
-    def third_party_imports(self) -> bool:
-        return cast(bool, self.options.third_party_imports)
-
-    @property
-    def third_party_import_mapping(self) -> dict:
-        return cast(dict, self.options.third_party_import_mapping)
-
-
 class InferJavaSourceDependencies(InferDependenciesRequest):
     infer_from = JavaSourceField
-
-
-@dataclass(frozen=True)
-class MapThirdPartyJavaImportsToArtifactsAddressesRequest:
-    analysis: JavaSourceDependencyAnalysis
-    import_name: str
-
-
-@dataclass(frozen=True)
-class MappedThirdPartyJavaImportsToArtifactsAddresses:
-    addresses: FrozenOrderedSet[Address]
 
 
 @rule(desc="Inferring Java dependencies by analyzing imports")
@@ -114,6 +46,8 @@ async def infer_java_dependencies_via_imports(
     request: InferJavaSourceDependencies,
     java_infer_subsystem: JavaInferSubsystem,
     first_party_dep_map: FirstPartyJavaPackageMapping,
+    third_party_artifact_mapping: ThirdPartyJavaPackageToArtifactMapping,
+    available_artifacts: AvailableThirdPartyArtifacts,
 ) -> InferredDependencies:
     if (
         not java_infer_subsystem.imports
@@ -146,11 +80,9 @@ async def infer_java_dependencies_via_imports(
         first_party_matches = dep_map.addresses_for_type(typ)
         third_party_matches: FrozenOrderedSet[Address] = FrozenOrderedSet()
         if java_infer_subsystem.third_party_imports:
-            mapped_third_party_addresses = await Get(
-                MappedThirdPartyJavaImportsToArtifactsAddresses,
-                MapThirdPartyJavaImportsToArtifactsAddressesRequest(analysis, typ),
+            third_party_matches = find_artifact_mapping(
+                typ, third_party_artifact_mapping, available_artifacts
             )
-            third_party_matches = mapped_third_party_addresses.addresses
         matches = first_party_matches.union(third_party_matches)
         if not matches:
             continue
@@ -168,199 +100,10 @@ async def infer_java_dependencies_via_imports(
     return InferredDependencies(dependencies)
 
 
-# -----------------------------------------------------------------------------------------------
-# Third-party package dependency inference
-# -----------------------------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class UnversionedCoordinate:
-    group: str
-    artifact: str
-
-    @classmethod
-    def from_coord_str(cls, coord: str) -> UnversionedCoordinate:
-        coordinate_parts = coord.split(":")
-        if len(coordinate_parts) != 2:
-            raise ValueError(f"Invalid coordinate specifier: {coord}")
-        return UnversionedCoordinate(group=coordinate_parts[0], artifact=coordinate_parts[1])
-
-
-@dataclass(frozen=True)
-class AvailableThirdPartyArtifacts:
-    """Maps JVM artifact coordinates (with only group and artifact set) to the `Address` of each
-    target specifying that coordinate."""
-
-    artifacts: FrozenDict[UnversionedCoordinate, FrozenOrderedSet[Address]]
-
-    def addresses_for_coordinates(
-        self, coordinates: Iterable[UnversionedCoordinate]
-    ) -> FrozenOrderedSet[Address]:
-        candidate_artifact_addresses: Set[Address] = set()
-        for coordinate in coordinates:
-            candidates = self.artifacts.get(coordinate, FrozenOrderedSet())
-            candidate_artifact_addresses.update(candidates)
-        return FrozenOrderedSet(candidate_artifact_addresses)
-
-
-class MutableTrieNode:
-    def __init__(self):
-        self.children: dict[str, MutableTrieNode] = {}
-        self.recursive: bool = False
-        self.coordinates: set[UnversionedCoordinate] = set()
-
-    def ensure_child(self, name: str) -> MutableTrieNode:
-        if name in self.children:
-            return self.children[name]
-        node = MutableTrieNode()
-        self.children[name] = node
-        return node
-
-
-@frozen_after_init
-class FrozenTrieNode:
-    def __init__(self, node: MutableTrieNode) -> None:
-        children = {}
-        for key, child in node.children.items():
-            children[key] = FrozenTrieNode(child)
-        self._children: FrozenDict[str, FrozenTrieNode] = FrozenDict(children)
-        self._recursive: bool = node.recursive
-        self._coordinates: FrozenOrderedSet[UnversionedCoordinate] = FrozenOrderedSet(
-            node.coordinates
-        )
-
-    def find_child(self, name: str) -> FrozenTrieNode | None:
-        return self._children.get(name)
-
-    @property
-    def recursive(self) -> bool:
-        return self._recursive
-
-    @property
-    def coordinates(self) -> FrozenOrderedSet[UnversionedCoordinate]:
-        return self._coordinates
-
-    def __hash__(self) -> int:
-        return hash((self._children, self._recursive, self._coordinates))
-
-    def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, FrozenTrieNode):
-            return False
-        return (
-            self._children == other._children
-            and self.recursive == other.recursive
-            and self.coordinates == other.coordinates
-        )
-
-    def __repr__(self):
-        return f"FrozenTrieNode(children={repr(self._children)}, recursive={self._recursive}, coordinate={self._coordinates})"
-
-
-@dataclass(frozen=True)
-class ThirdPartyJavaPackageToArtifactMapping:
-    mapping_root: FrozenTrieNode
-
-
-@rule
-async def find_available_third_party_artifacts() -> AvailableThirdPartyArtifacts:
-    all_targets = await Get(UnexpandedTargets, AddressSpecs([MaybeEmptyDescendantAddresses("")]))
-    jvm_artifact_targets = [
-        tgt
-        for tgt in all_targets
-        if tgt.has_fields((JvmArtifactGroupField, JvmArtifactArtifactField))
-    ]
-
-    artifact_mapping: dict[UnversionedCoordinate, set[Address]] = defaultdict(set)
-    for tgt in jvm_artifact_targets:
-        group = tgt[JvmArtifactGroupField].value
-        if not group:
-            raise ValueError(
-                f"The {JvmArtifactGroupField.alias} field of target {tgt.address} must be set."
-            )
-
-        artifact = tgt[JvmArtifactArtifactField].value
-        if not artifact:
-            raise ValueError(
-                f"The {JvmArtifactArtifactField.alias} field of target {tgt.address} must be set."
-            )
-
-        key = UnversionedCoordinate(group=group, artifact=artifact)
-        artifact_mapping[key].add(tgt.address)
-
-    return AvailableThirdPartyArtifacts(
-        FrozenDict({key: FrozenOrderedSet(value) for key, value in artifact_mapping.items()})
-    )
-
-
-@rule
-async def compute_java_third_party_artifact_mapping(
-    java_infer_subsystem: JavaInferSubsystem,
-) -> ThirdPartyJavaPackageToArtifactMapping:
-    def insert(mapping: MutableTrieNode, imp: str, coordinate: UnversionedCoordinate) -> None:
-        imp_parts = imp.split(".")
-        recursive = False
-        if imp_parts[-1] == "**":
-            recursive = True
-            imp_parts = imp_parts[0:-1]
-
-        current_node = mapping
-        for imp_part in imp_parts:
-            child_node = current_node.ensure_child(imp_part)
-            current_node = child_node
-
-        current_node.coordinates.add(coordinate)
-        current_node.recursive = recursive
-
-    mapping = MutableTrieNode()
-    for imp_name, imp_action in {
-        **JVM_ARTIFACT_MAPPINGS,
-        **java_infer_subsystem.third_party_import_mapping,
-    }.items():
-        value = UnversionedCoordinate.from_coord_str(imp_action)
-        insert(mapping, imp_name, value)
-
-    return ThirdPartyJavaPackageToArtifactMapping(FrozenTrieNode(mapping))
-
-
-@rule
-async def find_artifact_mapping(
-    request: MapThirdPartyJavaImportsToArtifactsAddressesRequest,
-    mapping: ThirdPartyJavaPackageToArtifactMapping,
-    available_artifacts: AvailableThirdPartyArtifacts,
-) -> MappedThirdPartyJavaImportsToArtifactsAddresses:
-    imp_parts = request.import_name.split(".")
-    current_node = mapping.mapping_root
-
-    found_nodes = []
-    for imp_part in imp_parts:
-        child_node_opt = current_node.find_child(imp_part)
-        if not child_node_opt:
-            break
-        found_nodes.append(child_node_opt)
-        current_node = child_node_opt
-
-    if not found_nodes:
-        return MappedThirdPartyJavaImportsToArtifactsAddresses(FrozenOrderedSet())
-
-    # If the length of the found nodes equals the number of parts of the package path, then there
-    # is an exact match.
-    if len(found_nodes) == len(imp_parts):
-        addresses = available_artifacts.addresses_for_coordinates(found_nodes[-1].coordinates)
-        return MappedThirdPartyJavaImportsToArtifactsAddresses(FrozenOrderedSet(addresses))
-
-    # Otherwise, check for the first found node (in reverse order) to match recursively, and use its coordinate.
-    for found_node in reversed(found_nodes):
-        if found_node.recursive:
-            addresses = available_artifacts.addresses_for_coordinates(found_node.coordinates)
-            return MappedThirdPartyJavaImportsToArtifactsAddresses(addresses)
-
-    # Nothing matched so return no match.
-    return MappedThirdPartyJavaImportsToArtifactsAddresses(FrozenOrderedSet())
-
-
 def rules():
     return [
         *collect_rules(),
+        *artifact_mapper.rules(),
         *java_parser.rules(),
         *import_parser.rules(),
         *package_mapper.rules(),

--- a/src/python/pants/backend/java/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/java/dependency_inference/rules_test.py
@@ -6,17 +6,17 @@ from textwrap import dedent
 import pytest
 
 from pants.backend.java.compile.javac import rules as javac_rules
-from pants.backend.java.dependency_inference.java_parser import rules as java_parser_rules
-from pants.backend.java.dependency_inference.java_parser_launcher import (
-    rules as java_parser_launcher_rules,
-)
-from pants.backend.java.dependency_inference.rules import (
+from pants.backend.java.dependency_inference.artifact_mapper import (
     FrozenTrieNode,
-    InferJavaSourceDependencies,
     MutableTrieNode,
     ThirdPartyJavaPackageToArtifactMapping,
     UnversionedCoordinate,
 )
+from pants.backend.java.dependency_inference.java_parser import rules as java_parser_rules
+from pants.backend.java.dependency_inference.java_parser_launcher import (
+    rules as java_parser_launcher_rules,
+)
+from pants.backend.java.dependency_inference.rules import InferJavaSourceDependencies
 from pants.backend.java.dependency_inference.rules import rules as dep_inference_rules
 from pants.backend.java.target_types import (
     JavaSourceField,

--- a/src/python/pants/backend/java/subsystems/java_infer.py
+++ b/src/python/pants/backend/java/subsystems/java_infer.py
@@ -1,0 +1,63 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from typing import cast
+
+from pants.option.subsystem import Subsystem
+from pants.util.docutil import git_url
+
+
+class JavaInferSubsystem(Subsystem):
+    options_scope = "java-infer"
+    help = "Options controlling which dependencies will be inferred for Java targets."
+
+    @classmethod
+    def register_options(cls, register):
+        super().register_options(register)
+        register(
+            "--imports",
+            default=True,
+            type=bool,
+            help=("Infer a target's dependencies by parsing import statements from sources."),
+        )
+        register(
+            "--consumed-types",
+            default=True,
+            type=bool,
+            help=("Infer a target's dependencies by parsing consumed types from sources."),
+        )
+        register(
+            "--third-party-imports",
+            default=True,
+            type=bool,
+            help="Infer a target's third-party dependencies using Java import statements.",
+        )
+        _default_package_mapping_url = git_url(
+            "src/python/pants/backend/java/dependency_inference/jvm_artifact_mappings.py"
+        )
+        register(
+            "--third-party-import-mapping",
+            type=dict,
+            help=(
+                "A dictionary mapping a Java package path to a JVM artifact coordinate (GROUP:ARTIFACT) "
+                "without the version. The package path may be made recursive to match symbols in subpackages "
+                "by adding `.**` to the end of the package path. For example, specify `{'org.junit.**': 'junit:junit'} `"
+                "to infer a dependency on junit:junit for any file importing a symbol from org.junit or its "
+                f"subpackages. Pants also supplies a default package mapping ({_default_package_mapping_url})."
+            ),
+        )
+
+    @property
+    def imports(self) -> bool:
+        return cast(bool, self.options.imports)
+
+    @property
+    def consumed_types(self) -> bool:
+        return cast(bool, self.options.consumed_types)
+
+    @property
+    def third_party_imports(self) -> bool:
+        return cast(bool, self.options.third_party_imports)
+
+    @property
+    def third_party_import_mapping(self) -> dict:
+        return cast(dict, self.options.third_party_import_mapping)


### PR DESCRIPTION
Merge the first-party and third-party dependency inference loops into a single loop so the ambiguity checking works properly.

[ci skip-rust]