### PR TITLE
assume version 1 for older lockfiles without a `version` key

### DIFF
--- a/src/python/pants/backend/python/util_rules/lockfile_metadata.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_metadata.py
@@ -122,7 +122,8 @@ class LockfileMetadata:
                 "be decoded. " + error_suffix
             )
 
-        concrete_class = _concrete_metadata_classes[metadata["version"]]
+        version = metadata.get("version", 1)
+        concrete_class = _concrete_metadata_classes[version]
 
         return concrete_class._from_json_dict(metadata, lockfile_description, error_suffix)
 


### PR DESCRIPTION
As reported in Slack, Python lockfiles created in Pants v2.7.x do not have a `version` key in the lockfile metadata. Pants v2.8.x generates lockfiles with the `version` key in the metdata and expects the files to contain that key. It had no fallback for older lockfiles without the `version` key. This broke an upgrade for one user from v2.7.0rc2 to v2.8.0rc0. 

Solution: Pants should just assume version 1 if it does not find the `version` key in lockfile metadata.

[ci skip-rust]
