### PR TITLE
Use `--layout=packed` for all monolithic resolves. (cherrypick of #13400)

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -354,7 +354,11 @@ async def _setup_constraints_repository_pex(
             description=f"Resolving {constraints_path}",
             output_filename="repository.pex",
             internal_only=request.internal_only,
-            requirements=PexRequirements(all_constraints),
+            requirements=PexRequirements(
+                all_constraints,
+                # TODO: See PexRequirements docs.
+                is_all_constraints_resolve=True,
+            ),
             interpreter_constraints=request.interpreter_constraints,
             platforms=request.platforms,
             additional_args=request.additional_lockfile_args,

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -412,6 +412,22 @@ def test_resolves_dependencies(rule_runner: RuleRunner) -> None:
     )
 
 
+@pytest.mark.parametrize("is_all_constraints_resolve", [True, False])
+@pytest.mark.parametrize("internal_only", [True, False])
+def test_use_packed_pex_requirements(
+    rule_runner: RuleRunner, is_all_constraints_resolve: bool, internal_only: bool
+) -> None:
+    requirements = PexRequirements(
+        ["six==1.12.0"], is_all_constraints_resolve=is_all_constraints_resolve
+    )
+    pex_data = create_pex_and_get_all_data(
+        rule_runner, requirements=requirements, internal_only=internal_only
+    )
+    # If this is either internal_only, or an all_constraints resolve, we should use packed.
+    should_use_packed = is_all_constraints_resolve or internal_only
+    assert (not pex_data.is_zipapp) == should_use_packed
+
+
 def test_requirement_constraints(rule_runner: RuleRunner) -> None:
     direct_deps = ["requests>=1.0.0,<=2.23.0"]
 


### PR DESCRIPTION
As described in #13398, we should use `--layout=packed` for all monolithic resolves (lockfiles, all_constraints, etc), in addition to for `internal_only` resolves.

Note that this is _not_ sufficient to allow for cache reuse across internal PEXes (i.e. those created for tests) and external PEXes (`pex_binary`), because the `repository.pex` is constructed with other differing arguments.

Fixes #13398.

[ci skip-rust]
[ci skip-build-wheels]