### PR TITLE
Don't error for invalid Go third-party packages unless building them (Cherry-pick of #13405)

### DIFF
--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -309,10 +309,10 @@ async def setup_build_go_package_target_request(
             ),
         )
 
-        # We error if trying to _build_ a package with unsupported sources (vs. only generating the
-        # target and using in project introspection).
-        if _third_party_pkg_info.unsupported_sources_error:
-            raise _third_party_pkg_info.unsupported_sources_error
+        # We error if trying to _build_ a package with issues (vs. only generating the target and
+        # using in project introspection).
+        if _third_party_pkg_info.error:
+            raise _third_party_pkg_info.error
 
         subpath = _third_party_pkg_info.subpath
         digest = _third_party_pkg_info.digest

--- a/src/python/pants/backend/go/util_rules/third_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg_test.py
@@ -16,7 +16,7 @@ from pants.backend.go.util_rules.third_party_pkg import (
     ThirdPartyPkgInfo,
     ThirdPartyPkgInfoRequest,
 )
-from pants.engine.fs import Digest, Snapshot
+from pants.engine.fs import EMPTY_DIGEST, Digest, Snapshot
 from pants.engine.process import ProcessExecutionFailure
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner, engine_error
@@ -390,7 +390,7 @@ def test_unsupported_sources(rule_runner: RuleRunner) -> None:
     pkg_info = rule_runner.request(
         ThirdPartyPkgInfo, [ThirdPartyPkgInfoRequest("golang.org/x/mobile/bind/objc", digest)]
     )
-    assert pkg_info.unsupported_sources_error is not None
+    assert pkg_info.error is not None
 
 
 def test_determine_pkg_info_module_with_replace_directive(rule_runner: RuleRunner) -> None:
@@ -513,3 +513,34 @@ def test_determine_pkg_info_module_with_replace_directive(rule_runner: RuleRunne
     )
     assert pkg_info.subpath == "github.com/hashicorp/consul/api@v1.3.0"
     assert "raw.go" in pkg_info.go_files
+
+
+def test_ambiguous_package(rule_runner: RuleRunner) -> None:
+    digest = set_up_go_mod(
+        rule_runner,
+        dedent(
+            """\
+            module example.com/third-party-module
+            go 1.16
+            require github.com/ugorji/go v1.1.4
+            require github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8
+            """
+        ),
+        dedent(
+            """\
+            github.com/ugorji/go v1.1.4 h1:j4s+tAvLfL3bZyefP2SEWmhBzmuIlH/eqNuPdFPgngw=
+            github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
+            github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8 h1:3SVOIvH7Ae1KRYyQWRjXWJEA9sS/c/pjvH++55Gr648=
+            github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
+            """
+        ),
+    )
+    pkg_info = rule_runner.request(
+        ThirdPartyPkgInfo,
+        [ThirdPartyPkgInfoRequest("github.com/ugorji/go/codec", digest)],
+    )
+    assert pkg_info.error is not None
+    # This particular error is tricky because `Dir` will not have been set, which we need to
+    # determine the subpath and the digest.
+    assert pkg_info.subpath == ""
+    assert pkg_info.digest == EMPTY_DIGEST


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/13391. 

We now consistently use the philosophy implemented in https://github.com/pantsbuild/pants/pull/13377 with third-party packages for Go. So long as that package has a valid `import_path` (its unique identifier), we only error when building the package. We don't error with target generation and using it for project introspection. 

This is particularly important for Go because we generate a target for every package from third-party modules, even if it will never be used. For example, the failure from https://github.com/pantsbuild/pants/pull/13377 was for `github.com/cncf/udpa/test/build`, i.e. a test package never used by first-party code.

With this fix, both Helm and external-dns now work with `./pants list ::`. (Not sure about `check` because performance is too slow to get a result...)

[ci skip-rust]
[ci skip-build-wheels]