### PR TITLE
[internal] Use the new Rust resolver

### DIFF
--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -13,6 +13,7 @@ debug = true
 codegen-units = 1
 
 [workspace]
+resolver = "2"
 # These are the packages which are built/tested when the --all flag is passed to cargo.
 #
 # We need to explicitly list these, because otherwise the standalone tools


### PR DESCRIPTION
Prework for switching to Rust 2021 edition.

```
note: Switching to Edition 2021 will enable the use of the version 2 feature resolver in Cargo.
This may cause some dependencies to be built with fewer features enabled than previously.
More information about the resolver changes may be found at https://doc.rust-lang.org/nightly/edition-guide/rust-2021/default-cargo-resolver.html
When building the following dependencies, the given features will no longer be used:

  bstr v0.2.14 removed features: default, lazy_static, regex-automata, serde, serde1, serde1-nostd, unicode
  bytes v1.1.0 (as host dependency) removed features: default, std
  either v1.6.1 (as host dependency) removed features: default, use_std
  fixedbitset v0.2.0 (as host dependency) removed features: default, std
  indexmap v1.7.0 (as host dependency) removed features: std
  itoa v0.4.7 (as host dependency) removed features: default, std
  libc v0.2.103 (as host dependency) removed features: extra_traits
  log v0.4.14 (as host dependency) removed features: std
  memchr v2.4.1 (as host dependency) removed features: use_std
  num-integer v0.1.44 removed features: default, std
  petgraph v0.5.1 (as host dependency) removed features: default, graphmap, matrix_graph, stable_graph
  prost v0.8.0 (as host dependency) removed features: default, std
  prost-types v0.8.0 (as host dependency) removed features: default, std
  rand v0.8.2 (as host dependency) removed features: small_rng
  serde v1.0.126 (as host dependency) removed features: derive, serde_derive
  tokio v1.12.0 removed features: winapi
```

[ci skip-build-wheels]