### PR TITLE
JVM: Select Coursier resolves before compiling 

### DIFF
--- a/src/python/pants/backend/java/compile/javac.py
+++ b/src/python/pants/backend/java/compile/javac.py
@@ -239,16 +239,15 @@ async def javac_check(request: JavacCheckRequest) -> CheckResults:
         CoarsenedTargets, Addresses(field_set.address for field_set in request.field_sets)
     )
 
-    resolves = await MultiGet(
-        Get(CoursierResolveKey, Targets(t.members)) for t in coarsened_targets
-    )
+    targets_for_resolve = Targets(t for ct in coarsened_targets.closure() for t in ct.members)
+    resolve = await Get(CoursierResolveKey, Targets, targets_for_resolve)
 
     results = await MultiGet(
         Get(
             FallibleCompiledClassfiles,
             CompileJavaSourceRequest(component=target, resolve=resolve),
         )
-        for target, resolve in zip(coarsened_targets, resolves)
+        for target in coarsened_targets
     )
 
     # NB: We don't pass stdout/stderr as it will have already been rendered as streaming.

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -580,7 +580,6 @@ async def get_coursier_lockfile_for_resolve(
 async def get_coursier_lockfile_for_target(
     request: CoursierLockfileForTargetRequest,
 ) -> CoursierResolvedLockfile:
-
     coursier_resolve = await Get(CoursierResolveKey, Targets, request.targets)
     lockfile = await Get(CoursierResolvedLockfile, CoursierResolveKey, coursier_resolve)
     return lockfile

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -566,16 +566,24 @@ class CoursierLockfileForTargetRequest:
 
 
 @rule
-async def get_coursier_lockfile_for_target(
-    request: CoursierLockfileForTargetRequest,
+async def get_coursier_lockfile_for_resolve(
+    coursier_resolve: CoursierResolve,
 ) -> CoursierResolvedLockfile:
-
-    coursier_resolve = await Get(CoursierResolve, Targets, request.targets)
 
     lockfile_digest_contents = await Get(DigestContents, Digest, coursier_resolve.digest)
     lockfile_contents = lockfile_digest_contents[0].content
 
     return CoursierResolvedLockfile.from_json_dict(json.loads(lockfile_contents))
+
+
+@rule
+async def get_coursier_lockfile_for_target(
+    request: CoursierLockfileForTargetRequest,
+) -> CoursierResolvedLockfile:
+
+    coursier_resolve = await Get(CoursierResolve, Targets, request.targets)
+    lockfile = await Get(CoursierResolvedLockfile, CoursierResolve, coursier_resolve)
+    return lockfile
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -581,8 +581,7 @@ async def get_coursier_lockfile_for_target(
     request: CoursierLockfileForTargetRequest,
 ) -> CoursierResolvedLockfile:
     coursier_resolve = await Get(CoursierResolveKey, Targets, request.targets)
-    lockfile = await Get(CoursierResolvedLockfile, CoursierResolveKey, coursier_resolve)
-    return lockfile
+    return await Get(CoursierResolvedLockfile, CoursierResolveKey, coursier_resolve)
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -448,7 +448,7 @@ async def load_coursier_lockfile_from_source(
 
 
 @dataclass(frozen=True)
-class CoursierResolve:
+class CoursierResolveKey:
     name: str
     path: str
     digest: Digest
@@ -459,7 +459,7 @@ async def select_coursier_resolve_for_targets(
     targets: Targets,
     jvm: JvmSubsystem,
     coursier: Coursier,
-) -> CoursierResolve:
+) -> CoursierResolveKey:
     """Determine the lockfile that applies for given JVM targets and resolve configuration.
 
     This walks the target's transitive dependencies to find the set of resolve names that are
@@ -557,7 +557,7 @@ async def select_coursier_resolve_for_targets(
     )
     resolve_digest = await Get(Digest, PathGlobs, lockfile_source)
 
-    return CoursierResolve(resolve_name, resolve_path, resolve_digest)
+    return CoursierResolveKey(resolve_name, resolve_path, resolve_digest)
 
 
 @dataclass(frozen=True)
@@ -567,7 +567,7 @@ class CoursierLockfileForTargetRequest:
 
 @rule
 async def get_coursier_lockfile_for_resolve(
-    coursier_resolve: CoursierResolve,
+    coursier_resolve: CoursierResolveKey,
 ) -> CoursierResolvedLockfile:
 
     lockfile_digest_contents = await Get(DigestContents, Digest, coursier_resolve.digest)
@@ -581,8 +581,8 @@ async def get_coursier_lockfile_for_target(
     request: CoursierLockfileForTargetRequest,
 ) -> CoursierResolvedLockfile:
 
-    coursier_resolve = await Get(CoursierResolve, Targets, request.targets)
-    lockfile = await Get(CoursierResolvedLockfile, CoursierResolve, coursier_resolve)
+    coursier_resolve = await Get(CoursierResolveKey, Targets, request.targets)
+    lockfile = await Get(CoursierResolvedLockfile, CoursierResolveKey, coursier_resolve)
     return lockfile
 
 

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -504,8 +504,9 @@ async def select_coursier_resolve_for_targets(
     if not compatible_resolves:
         raise CoursierError(
             "There are no resolve names that are compatible with all of the targets in this build. "
-            "At least one resolve must be compatible with every target -- including dependencies "
-            "and transitive dependencies in order to complete the build."
+            f"The targets are {targets}.  At least one resolve must be compatible with every "
+            "target -- including dependencies and transitive dependencies in order to complete the "
+            "build."
         )
 
     available_resolves = jvm.options.resolves


### PR DESCRIPTION
Resolves #13324

Currently `javac` and `scalac` rules select the resolve to use with every compilation step. This moves resolve calculation to only before all the compile processes are done. This should save a whole bunch of graph walking.