### PR TITLE
Add `[tailor].ignore_paths` and `[tailor].ignore_adding_targets`

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -51,7 +51,7 @@ pants_ignore.add = [
 
 build_ignore.add = [
   # Disable Go targets by default so Pants developers do not need Go installed.
-  "/testprojects/src/go/**",
+  "testprojects/src/go/**",
 ]
 
 # NB: Users must still set `--remote-cache-{read,write}` to enable the remote cache.
@@ -79,6 +79,17 @@ root_patterns = [
   "/build-support/bin",
   "/build-support/migration-support",
   "/pants-plugins",
+]
+
+[tailor]
+ignore_paths = ["build-support/migration-support/BUILD"]
+ignore_adding_targets = [
+  "src/python/pants:__main__",
+  "src/python/pants/backend/docker/subsystems:dockerfile_wrapper_script",
+  "src/python/pants/backend/go/goals:bin",
+  "src/python/pants/backend/go/util_rules:bin",
+  "src/python/pants/backend/python/dependency_inference:import_parser",
+  "src/python/pants/backend/terraform:hcl2_parser0",
 ]
 
 [python]


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/12911. Note that this allows us to have both coarse-grained ignores, which are convenient, and extremely precise ignores.

This also hooks up `[GLOBAL].build_ignore` to `tailor`, which was an oversight to not do.

[ci skip-rust]
[ci skip-build-wheels]