### PR TITLE
Fix ETXTBSY for Coursier fetch.

### DIFF
--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -189,8 +189,6 @@ impl CapturedWorkdir for CommandRunner {
     workdir_path: &'b Path,
     workdir_token: Self::WorkdirToken,
     req: Process,
-    _context: Context,
-    _exclusive_spawn: bool,
   ) -> Result<BoxStream<'c, Result<ChildOutput, String>>, String> {
     let client_workdir = if let Some(working_directory) = &req.working_directory {
       workdir_path.join(working_directory)


### PR DESCRIPTION
Some of our Processes use system binaries to run scripts in the input
digest of the Process. This foiled the original ETXTBSY fix which was
only used when argv0 was a member of the input digest. Coursier fetch
was an example of this, using the system provided bash to execute a
script in the input digest which in turn executed a binary in the input
digest.

Fix this by just pessimistically assuming all Process invocations will
execute files in the input digest and always performing the mitigation.

Fixes #13424

[ci skip-build-wheels]