### PR TITLE
Remove deprecated `protobuf_library`, `python_library`, `shell_library`, and `python_requirement_library` target aliases

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/target_types.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types.py
@@ -105,9 +105,6 @@ class ProtobufSourcesGeneratorTarget(Target):
     )
     help = "Generate a `protobuf_source` target for each file in the `sources` field."
 
-    deprecated_alias = "protobuf_library"
-    deprecated_alias_removal_version = "2.9.0.dev0"
-
 
 class GenerateTargetsFromProtobufSources(GenerateTargetsRequest):
     generate_from = ProtobufSourcesGeneratorTarget

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -766,9 +766,6 @@ class PythonSourcesGeneratorTarget(Target):
         "separate test support files vs. production files."
     )
 
-    deprecated_alias = "python_library"
-    deprecated_alias_removal_version = "2.9.0.dev0"
-
 
 # -----------------------------------------------------------------------------------------------
 # `python_requirement` target
@@ -983,9 +980,6 @@ class PythonRequirementTarget(Target):
         "\n\n"
         f"See {doc_url('python-third-party-dependencies')}."
     )
-
-    deprecated_alias = "python_requirement_library"
-    deprecated_alias_removal_version = "2.9.0.dev0"
 
     def validate(self) -> None:
         if (

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -259,9 +259,6 @@ class ShellSourcesGeneratorTarget(Target):
     )
     help = "Generate a `shell_source` target for each file in the `sources` field."
 
-    deprecated_alias = "shell_library"
-    deprecated_alias_removal_version = "2.9.0.dev0"
-
 
 class GenerateTargetsFromShellSources(GenerateTargetsRequest):
     generate_from = ShellSourcesGeneratorTarget

--- a/src/python/pants/core/goals/run_integration_test.py
+++ b/src/python/pants/core/goals/run_integration_test.py
@@ -25,7 +25,7 @@ def test_run_then_edit(use_pantsd: bool) -> None:
         ),
         "BUILD": dedent(
             f"""\
-        python_library(name='lib')
+        python_sources(name='lib')
         pex_binary(name='bin', entry_point='{slow}', restartable=True)
         """
         ),


### PR DESCRIPTION
[ci skip-rust]
[ci skip-build-wheels]