### PR TITLE
Remove deprecated `requirements_relpath` kwarg from `python_requirements` macro

### DIFF
--- a/src/python/pants/backend/python/macros/pipenv_requirements_test.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements_test.py
@@ -119,15 +119,14 @@ def test_properly_creates_extras_requirements(rule_runner: RuleRunner) -> None:
     )
 
 
-@pytest.mark.parametrize("source_arg", ("source", "requirements_relpath"))
-def test_supply_python_requirements_file(source_arg: str, rule_runner: RuleRunner) -> None:
+def test_supply_python_requirements_file(rule_runner: RuleRunner) -> None:
     """This tests that we can supply our own `_python_requirements_file`."""
     assert_pipenv_requirements(
         rule_runner,
         dedent(
-            f"""
+            """
             pipenv_requirements(
-                {source_arg}='custom/pipfile/Pipfile.lock',
+                source='custom/pipfile/Pipfile.lock',
                 pipfile_target='//:custom_pipfile_target'
             )
 

--- a/src/python/pants/backend/python/macros/poetry_requirements.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements.py
@@ -18,7 +18,6 @@ from typing_extensions import TypedDict
 
 from pants.backend.python.pip_requirement import PipRequirement
 from pants.backend.python.target_types import normalize_module_mapping
-from pants.base.deprecated import warn_or_error
 from pants.base.parse_context import ParseContext
 
 logger = logging.getLogger(__name__)
@@ -391,40 +390,17 @@ class PoetryRequirements:
 
     def __call__(
         self,
-        pyproject_toml_relpath: str | None = None,
         *,
-        source: str | None = None,
+        source: str = "pyproject.toml",
         module_mapping: Mapping[str, Iterable[str]] | None = None,
         type_stubs_module_mapping: Mapping[str, Iterable[str]] | None = None,
     ) -> None:
         """
-        :param pyproject_toml_relpath: The relpath from this BUILD file to the requirements file.
-            Defaults to a `requirements.txt` file sibling to the BUILD file.
         :param module_mapping: a mapping of requirement names to a list of the modules they provide.
             For example, `{"ansicolors": ["colors"]}`. Any unspecified requirements will use the
             requirement name as the default module, e.g. "Django" will default to
             `modules=["django"]`.
         """
-        if pyproject_toml_relpath and source:
-            raise ValueError(
-                "Specified both `pyproject_toml_relpath` and `source` in the `poetry_requirements` "
-                f"macro in the BUILD file at {self._parse_context.rel_path}. Use one, preferably "
-                "`source`."
-            )
-        if pyproject_toml_relpath is not None:
-            warn_or_error(
-                "2.9.0.dev0",
-                "the `pyproject_toml_relpath` argument for `poetry_requirements()`",
-                (
-                    "Use the `source` argument instead of `pyproject_toml_relpath` for the "
-                    f"`poetry_requirements` macro in the BUILD file at "
-                    f"{self._parse_context.rel_path}. `source` behaves the same."
-                ),
-            )
-            source = pyproject_toml_relpath
-        if source is None:
-            source = "pyproject.toml"
-
         req_file_tgt = self._parse_context.create_object(
             "_python_requirements_file",
             name=source.replace(os.path.sep, "_"),

--- a/src/python/pants/backend/python/macros/poetry_requirements_test.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements_test.py
@@ -477,11 +477,10 @@ def test_pyproject_toml(rule_runner: RuleRunner) -> None:
     )
 
 
-@pytest.mark.parametrize("source_arg", ("source", "pyproject_toml_relpath"))
-def test_source_override(source_arg: str, rule_runner: RuleRunner) -> None:
+def test_source_override(rule_runner: RuleRunner) -> None:
     assert_poetry_requirements(
         rule_runner,
-        f"poetry_requirements({source_arg}='subdir/pyproject.toml')",
+        "poetry_requirements(source='subdir/pyproject.toml')",
         dedent(
             """\
             [tool.poetry.dependencies]

--- a/src/python/pants/backend/python/macros/python_requirements.py
+++ b/src/python/pants/backend/python/macros/python_requirements.py
@@ -12,7 +12,6 @@ from packaging.utils import canonicalize_name as canonicalize_project_name
 
 from pants.backend.python.target_types import normalize_module_mapping, parse_requirements_file
 from pants.base.build_environment import get_buildroot
-from pants.base.deprecated import warn_or_error
 
 
 class PythonRequirements:
@@ -52,40 +51,17 @@ class PythonRequirements:
 
     def __call__(
         self,
-        requirements_relpath: str | None = None,
         *,
-        source: str | None = None,
+        source: str = "requirements.txt",
         module_mapping: Mapping[str, Iterable[str]] | None = None,
         type_stubs_module_mapping: Mapping[str, Iterable[str]] | None = None,
     ) -> None:
         """
-        :param requirements_relpath: The relpath from this BUILD file to the requirements file.
-            Defaults to a `requirements.txt` file sibling to the BUILD file.
         :param module_mapping: a mapping of requirement names to a list of the modules they provide.
             For example, `{"ansicolors": ["colors"]}`. Any unspecified requirements will use the
             requirement name as the default module, e.g. "Django" will default to
             `modules=["django"]`.
         """
-        if requirements_relpath and source:
-            raise ValueError(
-                "Specified both `requirements_relpath` and `source` in the `python_requirements` "
-                f"macro in the BUILD file at {self._parse_context.rel_path}. Use one, preferably "
-                "`source`."
-            )
-        if requirements_relpath is not None:
-            warn_or_error(
-                "2.9.0.dev0",
-                "the `requirements_relpath` argument for `python_requirements()`",
-                (
-                    "Use the `source` argument instead of `requirements_relpath` for the "
-                    f"`python_requirements` macro in the BUILD file at "
-                    f"{self._parse_context.rel_path}. `source` behaves the same."
-                ),
-            )
-            source = requirements_relpath
-        if source is None:
-            source = "requirements.txt"
-
         req_file_tgt = self._parse_context.create_object(
             "_python_requirements_file",
             name=source.replace(os.path.sep, "_"),

--- a/src/python/pants/backend/python/macros/python_requirements_test.py
+++ b/src/python/pants/backend/python/macros/python_requirements_test.py
@@ -192,11 +192,10 @@ def test_invalid_req(rule_runner: RuleRunner) -> None:
     assert "It looks like you're trying to use a pip VCS-style requirement?" in str(exc.value)
 
 
-@pytest.mark.parametrize("source_arg", ("source", "requirements_relpath"))
-def test_source_override(source_arg: str, rule_runner: RuleRunner) -> None:
+def test_source_override(rule_runner: RuleRunner) -> None:
     assert_python_requirements(
         rule_runner,
-        f"python_requirements({source_arg}='subdir/requirements.txt')",
+        "python_requirements(source='subdir/requirements.txt')",
         "ansicolors>=1.18.0",
         requirements_txt_relpath="subdir/requirements.txt",
         expected_file_dep=PythonRequirementsFile(


### PR DESCRIPTION
[ci skip-rust]
[ci skip-build-wheels]