### PR TITLE
Remove deprecated `module_mapping` and `type_stubs_module_mapping` fields

### DIFF
--- a/src/python/pants/backend/awslambda/python/target_types_test.py
+++ b/src/python/pants/backend/awslambda/python/target_types_test.py
@@ -105,7 +105,7 @@ def test_inject_handler_dependency(rule_runner: RuleRunner, caplog) -> None:
                 python_requirement(
                     name='ansicolors',
                     requirements=['ansicolors'],
-                    module_mapping={'ansicolors': ['colors']},
+                    modules=['colors'],
                 )
                 """
             ),

--- a/src/python/pants/backend/google_cloud_function/python/target_types_test.py
+++ b/src/python/pants/backend/google_cloud_function/python/target_types_test.py
@@ -111,7 +111,7 @@ def test_inject_handler_dependency(rule_runner: RuleRunner, caplog) -> None:
                 python_requirement(
                     name='ansicolors',
                     requirements=['ansicolors'],
-                    module_mapping={'ansicolors': ['colors']},
+                    modules=['colors'],
                 )
                 """
             ),

--- a/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
@@ -308,13 +308,11 @@ def test_map_third_party_modules_to_addresses(rule_runner: RuleRunner) -> None:
         *,
         modules: list[str] | None = None,
         stub_modules: list[str] | None = None,
-        module_mapping: dict[str, list[str]] | None = None,
     ) -> str:
         return (
             f"python_requirement(name='{tgt_name}', requirements=['{req_str}'], "
             f"modules={modules or []},"
-            f"type_stub_modules={stub_modules or []},"
-            f"module_mapping={repr(module_mapping or {})})"
+            f"type_stub_modules={stub_modules or []})"
         )
 
     build_file = "\n\n".join(
@@ -324,11 +322,6 @@ def test_map_third_party_modules_to_addresses(rule_runner: RuleRunner) -> None:
             req("file_dist", "file_dist@ file:///path/to/dist.whl"),
             req("vcs_dist", "vcs_dist@ git+https://github.com/vcs/dist.git"),
             req("modules", "foo==1", modules=["mapped_module"]),
-            req(
-                "module_mapping_un_normalized",
-                "DiFFerent-than_Mapping",
-                module_mapping={"different_THAN-mapping": ["module_mapping_un_normalized"]},
-            ),
             # We extract the module from type stub dependencies.
             req("typed-dep1", "typed-dep1-types"),
             req("typed-dep2", "types-typed-dep2"),
@@ -367,9 +360,6 @@ def test_map_third_party_modules_to_addresses(rule_runner: RuleRunner) -> None:
                 "file_dist": (Address("", target_name="file_dist"),),
                 "looks_like_stubs": (Address("", target_name="looks_like_stubs"),),
                 "mapped_module": (Address("", target_name="modules"),),
-                "module_mapping_un_normalized": (
-                    Address("", target_name="module_mapping_un_normalized"),
-                ),
                 "req1": (Address("", target_name="req1"),),
                 "req2": (Address("", target_name="req2"), Address("", target_name="req2_types")),
                 "req3": (Address("", target_name="req3"), Address("", target_name="req3_types")),
@@ -466,10 +456,10 @@ def test_map_module_to_address(rule_runner: RuleRunner) -> None:
                 # Ambiguity within third-party, which should result in ambiguity for first-party
                 # too. These all share the module `ambiguous.f2`.
                 python_requirement(
-                    name='thirdparty3', requirements=['bar'], module_mapping={'bar': ['ambiguous.f2']}
+                    name='thirdparty3', requirements=['bar'], modules=['ambiguous.f2']
                 )
                 python_requirement(
-                    name='thirdparty4', requirements=['bar'], module_mapping={'bar': ['ambiguous.f2']}
+                    name='thirdparty4', requirements=['bar'], modules=['ambiguous.f2']
                 )
                 python_sources(name="firstparty3", sources=["f2.py"])
 
@@ -478,7 +468,7 @@ def test_map_module_to_address(rule_runner: RuleRunner) -> None:
                 python_sources(name="firstparty4", sources=["f3.py"])
                 python_sources(name="firstparty5", sources=["f3.py"])
                 python_requirement(
-                    name='thirdparty5', requirements=['baz'], module_mapping={'baz': ['ambiguous.f3']}
+                    name='thirdparty5', requirements=['baz'], modules=['ambiguous.f3']
                 )
 
                 # You can only write a first-party type stub for a third-party requirement if
@@ -486,12 +476,12 @@ def test_map_module_to_address(rule_runner: RuleRunner) -> None:
                 python_requirement(
                     name='ambiguous-stub',
                     requirements=['ambiguous-stub'],
-                    module_mapping={"ambiguous-stub": ["ambiguous.f4"]},
+                    modules=["ambiguous.f4"],
                 )
                 python_requirement(
                     name='ambiguous-stub-types',
                     requirements=['ambiguous-stub-types'],
-                    type_stubs_module_mapping={"ambiguous-stub-types": ["ambiguous.f4"]},
+                    type_stub_modules=["ambiguous.f4"],
                 )
                 python_sources(name='ambiguous-stub-1stparty', sources=['f4.pyi'])
                 """

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -13,8 +13,6 @@ from textwrap import dedent
 from typing import (
     TYPE_CHECKING,
     Any,
-    ClassVar,
-    Dict,
     Iterable,
     Iterator,
     Mapping,
@@ -900,65 +898,6 @@ def normalize_module_mapping(
     return FrozenDict({canonicalize_project_name(k): tuple(v) for k, v in (mapping or {}).items()})
 
 
-class ModuleMappingField(DictStringToStringSequenceField):
-    alias = "module_mapping"
-    help = (
-        "A mapping of requirement names to a list of the modules they provide.\n\n"
-        'For example, `{"ansicolors": ["colors"]}`.\n\n'
-        "Any unspecified requirements will use the requirement name as the default module, "
-        'e.g. "Django" will default to `["django"]`.\n\n'
-        "This is used to infer dependencies."
-    )
-    value: FrozenDict[str, tuple[str, ...]]
-    default: ClassVar[FrozenDict[str, tuple[str, ...]]] = FrozenDict()
-    removal_version = "2.9.0.dev0"
-    removal_hint = (
-        "Use the field `modules` instead, which takes a list of modules the `python_requirement` "
-        "target provides.\n\n"
-        "If this `python_requirement` target has multiple distinct 3rd-party "
-        "projects in its `requirements` field, you should split those up into one `"
-        "python_requirement` target per distinct project."
-    )
-
-    @classmethod
-    def compute_value(  # type: ignore[override]
-        cls, raw_value: Dict[str, Iterable[str]], address: Address
-    ) -> FrozenDict[str, Tuple[str, ...]]:
-        value_or_default = super().compute_value(raw_value, address)
-        return normalize_module_mapping(value_or_default)
-
-
-class TypeStubsModuleMappingField(DictStringToStringSequenceField):
-    alias = "type_stubs_module_mapping"
-    help = (
-        "A mapping of type-stub requirement names to a list of the modules they provide.\n\n"
-        'For example, `{"types-requests": ["requests"]}`.\n\n'
-        "If the requirement is not specified _and_ it starts with `types-` or `stubs-`, or ends "
-        "with `-types` or `-stubs`, the requirement will be treated as a type stub for the "
-        'corresponding module, e.g. "types-request" has the module "requests". Otherwise, '
-        "the requirement is treated like a normal dependency (see the field "
-        f"{ModuleMappingField.alias}).\n\n"
-        "This is used to infer dependencies for type stubs."
-    )
-    value: FrozenDict[str, tuple[str, ...]]
-    default: ClassVar[FrozenDict[str, tuple[str, ...]]] = FrozenDict()
-    removal_version = "2.9.0.dev0"
-    removal_hint = (
-        "Use the field `type_stub_modules` instead, which takes a list of modules the "
-        "`python_requirement` target provides type stubs for.\n\n"
-        "If this `python_requirement` target has multiple distinct 3rd-party "
-        "projects in its `requirements` field, you should split those up into one `"
-        "python_requirement` target per distinct project."
-    )
-
-    @classmethod
-    def compute_value(  # type: ignore[override]
-        cls, raw_value: Dict[str, Iterable[str]], address: Address
-    ) -> FrozenDict[str, Tuple[str, ...]]:
-        value_or_default = super().compute_value(raw_value, address)
-        return normalize_module_mapping(value_or_default)
-
-
 class PythonRequirementTarget(Target):
     alias = "python_requirement"
     core_fields = (
@@ -967,8 +906,6 @@ class PythonRequirementTarget(Target):
         PythonRequirementsField,
         PythonRequirementModulesField,
         PythonRequirementTypeStubModulesField,
-        ModuleMappingField,
-        TypeStubsModuleMappingField,
     )
     help = (
         "A Python requirement installable by pip.\n\n"


### PR DESCRIPTION
[ci skip-rust]
[ci skip-build-wheels]