### PR TITLE
Remove `entry_point=<none>` for `pex_binary` in favor of leaving off the field

### DIFF
--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -291,16 +291,6 @@ class PexEntryPointField(AsyncFieldMixin, SecondaryOwnerMixin, Field):
             return None
         if not isinstance(value, str):
             raise InvalidFieldTypeException(address, cls.alias, value, expected_type="a string")
-        if value in {"<none>", "<None>"}:
-            warn_or_error(
-                "2.9.0.dev0",
-                "using `<none>` for the `entry_point` field",
-                (
-                    "Rather than setting `entry_point='<none>' for the pex_binary target "
-                    f"{address}, simply leave off the field."
-                ),
-            )
-            return None
         try:
             return EntryPoint.parse(value, provenance=f"for {address}")
         except ValueError as e:

--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -383,9 +383,8 @@ async def resolve_python_distribution_entry_points(
             entry_point = binary_entry_point_by_address[owner].val
             if entry_point is None:
                 logger.warning(
-                    f"The entry point {name} in {category} references a pex binary {ref}, "
-                    "which has set its entry point to '<none>'. "
-                    "Skipping this entry because '<none>' is not valid as an entry point."
+                    f"The entry point {name} in {category} references a pex_binary target {ref} "
+                    "which does not set `entry_point`. Skipping."
                 )
                 continue
         else:

--- a/src/python/pants/backend/python/target_types_test.py
+++ b/src/python/pants/backend/python/target_types_test.py
@@ -116,7 +116,6 @@ def test_timeout_calculation() -> None:
 @pytest.mark.parametrize(
     ["entry_point", "expected"],
     (
-        ("<none>", []),
         ("path.to.module", []),
         ("path.to.module:func", []),
         ("lambda.py", ["project/dir/lambda.py"]),
@@ -185,10 +184,6 @@ def test_resolve_pex_binary_entry_point() -> None:
         expected=EntryPoint(module="project.app", function="func"),
         is_file=True,
     )
-
-    # We special case the strings `<none>` and `<None>`.
-    assert_resolved(entry_point="<none>", expected=None, is_file=False)
-    assert_resolved(entry_point="<None>", expected=None, is_file=False)
 
     with pytest.raises(ExecutionError):
         assert_resolved(


### PR DESCRIPTION

[ci skip-rust]
[ci skip-build-wheels]