### PR TITLE
Remove deprecated `[pytest].junit_xml_dir` option.

### DIFF
--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -24,8 +24,6 @@ from pants.backend.python.util_rules.python_sources import (
 from pants.core.goals.test import (
     BuildPackageDependenciesRequest,
     BuiltPackageDependencies,
-    JunitXMLDir,
-    JunitXMLDirSource,
     RuntimePackageDependenciesField,
     TestDebugRequest,
     TestExtraEnv,
@@ -370,17 +368,6 @@ async def debug_python_test(field_set: PythonTestFieldSet) -> TestDebugRequest:
     )
 
 
-@union
-class PytestJunitXMLDirSource:
-    pass
-
-
-@rule
-def builtin_xml_dir_source(_: PytestJunitXMLDirSource, pytest: PyTest) -> JunitXMLDir:
-    # TODO: When this field access is removed, the entire union should be as well.
-    return JunitXMLDir(pytest.options.junit_xml_dir)
-
-
 # -----------------------------------------------------------------------------------------
 # `runtime_package_dependencies` plugin
 # -----------------------------------------------------------------------------------------
@@ -408,5 +395,4 @@ def rules():
         *collect_rules(),
         UnionRule(TestFieldSet, PythonTestFieldSet),
         UnionRule(PytestPluginSetupRequest, RuntimePackagesPluginRequest),
-        UnionRule(JunitXMLDirSource, PytestJunitXMLDirSource),
     ]

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -120,19 +120,6 @@ class PyTest(PythonToolBase):
             help="The maximum timeout (in seconds) that may be used on a `python_tests` target.",
         )
         register(
-            "--junit-xml-dir",
-            type=str,
-            metavar="<DIR>",
-            default=None,
-            advanced=True,
-            removal_version="2.9.0.dev0",
-            removal_hint="Moved to `[test] xml_dir`.",
-            help=(
-                "Specifying a directory causes Junit XML result files to be emitted under "
-                "that dir for each test run."
-            ),
-        )
-        register(
             "--junit-family",
             type=str,
             default="xunit2",

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -17,14 +17,11 @@ from pants.backend.python.target_types_rules import rules as python_target_type_
 from pants.backend.python.util_rules import pex_from_targets
 from pants.core.goals.test import (
     BuildPackageDependenciesRequest,
-    BuiltinXMLDirSource,
     BuiltPackageDependencies,
     ConsoleCoverageReport,
     CoverageData,
     CoverageDataCollection,
     CoverageReports,
-    JunitXMLDir,
-    JunitXMLDirSource,
     RuntimePackageDependenciesField,
     ShowOutput,
     Test,
@@ -154,7 +151,6 @@ def run_test_rule(
         {
             TestFieldSet: [field_set],
             CoverageDataCollection: [MockCoverageDataCollection],
-            JunitXMLDirSource: [BuiltinXMLDirSource],
         }
     )
 
@@ -178,9 +174,6 @@ def run_test_rule(
             coverage_insufficient=False, report=f"Ran coverage on {addresses}"
         )
         return CoverageReports(reports=(console_report,))
-
-    def mock_xml_dir(_: BuiltinXMLDirSource) -> JunitXMLDir:
-        return JunitXMLDir(xml_dir)
 
     with mock_console(rule_runner.options_bootstrapper) as (console, stdio_reader):
         result: Test = run_rule_with_mocks(
@@ -220,11 +213,6 @@ def run_test_rule(
                     output_type=Digest,
                     input_type=MergeDigests,
                     mock=lambda _: EMPTY_DIGEST,
-                ),
-                MockGet(
-                    output_type=JunitXMLDir,
-                    input_type=JunitXMLDirSource,
-                    mock=mock_xml_dir,
                 ),
                 MockGet(
                     output_type=CoverageReports,


### PR DESCRIPTION
[ci skip-rust]
[ci skip-build-wheels]