### PR TITLE
[internal] upgrade `tonic` crate to v0.6 and `prost` crate to v0.9

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -669,7 +669,7 @@ dependencies = [
  "nailgun",
  "num_enum",
  "parking_lot",
- "petgraph",
+ "petgraph 0.5.1",
  "process_execution",
  "protos",
  "rand 0.8.2",
@@ -768,6 +768,12 @@ name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "398ea4fabe40b9b0d885340a2a991a44c8a645624075ad966d21f88688e2b69e"
 
 [[package]]
 name = "flate2"
@@ -1061,12 +1067,12 @@ dependencies = [
  "async-trait",
  "async_value",
  "env_logger",
- "fixedbitset",
+ "fixedbitset 0.2.0",
  "fnv",
  "futures",
  "log 0.4.14",
  "parking_lot",
- "petgraph",
+ "petgraph 0.5.1",
  "rand 0.8.2",
  "task_executor",
  "tokio",
@@ -1197,9 +1203,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
+checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
 dependencies = [
  "bytes",
  "http",
@@ -1208,9 +1214,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.4.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
+checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
 
 [[package]]
 name = "httpdate"
@@ -1229,9 +1235,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.11"
+version = "0.14.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b61cf2d1aebcf6e6352c97b81dc2244ca29194be1b276f5d8ad5c6330fffb11"
+checksum = "2b91bb1f221b6ea1f1e4371216b70f40748774c2fb5971b450c07773fb92d26b"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2053,7 +2059,17 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.2.0",
+ "indexmap",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
+dependencies = [
+ "fixedbitset 0.4.0",
  "indexmap",
 ]
 
@@ -2273,9 +2289,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2283,27 +2299,29 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
+checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
 dependencies = [
  "bytes",
  "heck",
  "itertools 0.10.1",
+ "lazy_static",
  "log 0.4.14",
  "multimap",
- "petgraph",
+ "petgraph 0.6.0",
  "prost",
  "prost-types",
+ "regex",
  "tempfile",
  "which",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
 dependencies = [
  "anyhow",
  "itertools 0.10.1",
@@ -2314,9 +2332,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
+checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
  "bytes",
  "prost",
@@ -2751,7 +2769,7 @@ dependencies = [
  "env_logger",
  "indexmap",
  "log 0.4.14",
- "petgraph",
+ "petgraph 0.5.1",
 ]
 
 [[package]]
@@ -3450,9 +3468,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b584f064fdfc50017ec39162d5aebce49912f1eb16fd128e04b7f4ce4907c7e5"
+checksum = "24203b79cf2d68909da91178db3026e77054effba0c5d93deb870d3ca7b35afa"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3483,9 +3501,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d12faebbe071b06f486be82cc9318350814fdd07fcb28f3690840cd770599283"
+checksum = "88358bb1dcfeb62dcce85c63006cafb964b7be481d522b7e09589d4d1e718d2a"
 dependencies = [
  "proc-macro2 1.0.29",
  "prost-build",
@@ -3932,7 +3950,7 @@ dependencies = [
  "hdrhistogram",
  "log 0.4.14",
  "parking_lot",
- "petgraph",
+ "petgraph 0.5.1",
  "rand 0.8.2",
  "strum",
  "strum_macros",

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -108,7 +108,8 @@ default = []
 [dependencies]
 async_latch = { path = "async_latch" }
 async_semaphore = { path = "async_semaphore" }
-async-trait = "0.1"
+# Pin async-trait due to https://github.com/dtolnay/async-trait/issues/144.
+async-trait = "=0.1.42"
 protos = { path = "protos" }
 bytes = "1.0"
 cache = { path = "cache" }

--- a/src/rust/engine/concrete_time/Cargo.toml
+++ b/src/rust/engine/concrete_time/Cargo.toml
@@ -6,8 +6,8 @@ name = "concrete_time"
 publish = false
 
 [dependencies]
-prost = "0.8"
-prost-types = "0.8"
+prost = "0.9"
+prost-types = "0.9"
 serde_derive = "1.0.98"
 serde = "1.0.98"
 log = "0.4"

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -6,7 +6,8 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
 
 [dependencies]
-async-trait = "0.1"
+# Pin async-trait due to https://github.com/dtolnay/async-trait/issues/144.
+async-trait = "=0.1.42"
 bytes = "1.0"
 dirs-next = "2"
 futures = "0.3"

--- a/src/rust/engine/fs/fs_util/Cargo.toml
+++ b/src/rust/engine/fs/fs_util/Cargo.toml
@@ -15,7 +15,7 @@ fs = { path = ".." }
 futures = "0.3"
 hashing = { path = "../../hashing" }
 parking_lot = "0.11"
-prost = "0.8"
+prost = "0.9"
 rand = "0.8"
 serde = "1.0"
 serde_json = "1.0"

--- a/src/rust/engine/fs/store/Cargo.toml
+++ b/src/rust/engine/fs/store/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2018"
 
 [dependencies]
 async-stream = "0.3"
-async-trait = "0.1"
+# Pin async-trait due to https://github.com/dtolnay/async-trait/issues/144.
+async-trait = "=0.1.42"
 protos = { path = "../../protos" }
 bytes = "1.0"
 concrete_time = { path = "../../concrete_time" }

--- a/src/rust/engine/fs/store/Cargo.toml
+++ b/src/rust/engine/fs/store/Cargo.toml
@@ -25,8 +25,8 @@ log = "0.4"
 madvise = "0.1"
 memmap = "0.7"
 parking_lot = "0.11"
-prost = "0.8"
-prost-types = "0.8"
+prost = "0.9"
+prost-types = "0.9"
 serde = "1.0"
 serde_derive = "1.0"
 sharded_lmdb = { path = "../../sharded_lmdb" }
@@ -34,7 +34,7 @@ task_executor = { path = "../../task_executor" }
 tempfile = "3"
 tokio-rustls = "0.22"
 tokio = { version = "1.4", features = ["fs"] }
-tonic = { version = "0.5", features = ["transport", "codegen", "tls", "tls-roots", "prost"] }
+tonic = { version = "0.6", features = ["transport", "codegen", "tls", "tls-roots", "prost"] }
 tower-service = "0.3"
 tryfuture = { path = "../../tryfuture" }
 uuid = { version = "0.7.1", features = ["v4"] }

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -240,7 +240,7 @@ async fn write_connection_error() {
     .await
     .expect_err("Want error");
   assert!(
-    error.contains("Unknown: \"transport error\""),
+    error.contains("Unavailable: \"error trying to connect: dns error"),
     "Bad error message, got: {}",
     error
   );

--- a/src/rust/engine/graph/Cargo.toml
+++ b/src/rust/engine/graph/Cargo.toml
@@ -6,7 +6,8 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
 
 [dependencies]
-async-trait = "0.1"
+# Pin async-trait due to https://github.com/dtolnay/async-trait/issues/144.
+async-trait = "=0.1.42"
 async_value = { path = "../async_value" }
 fnv = "1.0.5"
 futures = "0.3"

--- a/src/rust/engine/grpc_util/Cargo.toml
+++ b/src/rust/engine/grpc_util/Cargo.toml
@@ -27,7 +27,8 @@ tower-service = "0.3"
 webpki = "0.21"
 
 [dev-dependencies]
-async-trait = "0.1"
+# Pin async-trait due to https://github.com/dtolnay/async-trait/issues/144.
+async-trait = "=0.1.42"
 parking_lot = "0.11"
 prost-types = "0.9"
 

--- a/src/rust/engine/grpc_util/Cargo.toml
+++ b/src/rust/engine/grpc_util/Cargo.toml
@@ -13,14 +13,14 @@ hyper = "0.14"
 http = "0.2"
 itertools = "0.10"
 rustls-native-certs = "0.5"
-prost = "0.8"
+prost = "0.9"
 rand = "0.8"
 rustls = { version = "0.19", features = ["dangerous_configuration"] }
 rustls-pemfile = "0.2"
 tokio = { version = "1.4", features = ["net", "process", "rt-multi-thread", "sync", "time"] }
 tokio-rustls = "0.22"
 tokio-util = { version = "0.6", features = ["codec"] }
-tonic = { version = "0.5", features = ["transport", "codegen", "tls", "tls-roots", "prost"] }
+tonic = { version = "0.6", features = ["transport", "codegen", "tls", "tls-roots", "prost"] }
 tower = { version = "0.4", features = ["limit"] }
 tower-layer = "0.3"
 tower-service = "0.3"
@@ -29,8 +29,8 @@ webpki = "0.21"
 [dev-dependencies]
 async-trait = "0.1"
 parking_lot = "0.11"
-prost-types = "0.8"
+prost-types = "0.9"
 
 [build-dependencies]
-prost-build = "0.8"
-tonic-build = "0.5.1"
+prost-build = "0.9"
+tonic-build = "0.6"

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -41,11 +41,11 @@ serde = "1.0.104"
 bincode = "1.2.1"
 double-checked-cell-async = "2.0"
 rand = "0.8"
-prost = "0.8"
-prost-types = "0.8"
+prost = "0.9"
+prost-types = "0.9"
 strum = "0.20"
 strum_macros = "0.20"
-tonic = { version = "0.5", features = ["transport", "codegen", "tls", "tls-roots", "prost"] }
+tonic = { version = "0.6", features = ["transport", "codegen", "tls", "tls-roots", "prost"] }
 tryfuture = { path = "../tryfuture" }
 
 [dev-dependencies]

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -6,7 +6,8 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
 
 [dependencies]
-async-trait = "0.1"
+# Pin async-trait due to https://github.com/dtolnay/async-trait/issues/144.
+async-trait = "=0.1.42"
 async-lock = "2.4"
 walkdir = "2"
 async_semaphore = { path = "../async_semaphore" }

--- a/src/rust/engine/process_executor/Cargo.toml
+++ b/src/rust/engine/process_executor/Cargo.toml
@@ -16,7 +16,7 @@ grpc_util = { path = "../grpc_util" }
 hashing = { path = "../hashing" }
 log = "0.4"
 process_execution = { path = "../process_execution" }
-prost = "0.8"
+prost = "0.9"
 shlex = "0.1.1"
 store = { path = "../fs/store" }
 structopt = "0.3.20"

--- a/src/rust/engine/protos/Cargo.toml
+++ b/src/rust/engine/protos/Cargo.toml
@@ -8,11 +8,11 @@ publish = false
 [dependencies]
 bytes = "1.0"
 hashing = { path = "../hashing" }
-prost = "0.8"
-prost-build = "0.8"
-prost-types = "0.8"
-tonic = { version = "0.5", features = ["transport", "codegen", "tls", "tls-roots"] }
+prost = "0.9"
+prost-build = "0.9"
+prost-types = "0.9"
+tonic = { version = "0.6", features = ["transport", "codegen", "tls", "tls-roots"] }
 
 [build-dependencies]
-prost-build = "0.8"
-tonic-build = { version = "0.5.1", features = ["prost"] }
+prost-build = "0.9"
+tonic-build = { version = "0.6", features = ["prost"] }

--- a/src/rust/engine/testutil/Cargo.toml
+++ b/src/rust/engine/testutil/Cargo.toml
@@ -12,4 +12,4 @@ bytes = "1.0"
 grpc_util = { path = "../grpc_util" }
 fs = { path = "../fs" }
 hashing = { path = "../hashing" }
-prost = "0.8" 
+prost = "0.9" 

--- a/src/rust/engine/testutil/mock/Cargo.toml
+++ b/src/rust/engine/testutil/mock/Cargo.toml
@@ -15,8 +15,8 @@ hashing = { path = "../../hashing" }
 hyper = { version = "0.14", features = ["stream", "tcp"] }
 log = "0.4"
 parking_lot = "0.11"
-prost = "0.8"
-prost-types = "0.8"
+prost = "0.9"
+prost-types = "0.9"
 testutil = { path = ".." }
 tokio = { version = "1.4", features = ["time"] }
-tonic = { version = "0.5" }
+tonic = { version = "0.6" }


### PR DESCRIPTION
Upgrade `tonic` to v0.6.1 and `prost` to v0.9.0.

Note: `async-trait` has been pinned to the existing v0.1.42 in the Cargo.lock due to error referenced here:  https://github.com/pantsbuild/pants/pull/12486#issuecomment-891939311. See https://github.com/dtolnay/async-trait/issues/144 for upstream discussion in `async-trait` repo.