### PR TITLE
Java & Scala: Supply only dependencies to the compiler when building

### DIFF
--- a/src/python/pants/backend/java/compile/javac.py
+++ b/src/python/pants/backend/java/compile/javac.py
@@ -126,17 +126,6 @@ async def compile_java_source(
             exit_code=0,
         )
 
-    transitive_deps = [
-        t
-        for item in CoarsenedTargets(request.component.dependencies).closure()
-        for t in item.members
-    ]
-
-    jvm_artifact_deps = [
-        dep
-        for dep in transitive_deps
-        if dep.has_fields((JvmArtifactGroupField, JvmArtifactArtifactField))
-    ]
     coordinates = Coordinates(
         (
             Coordinate(
@@ -144,7 +133,9 @@ async def compile_java_source(
                 artifact=(dep[JvmArtifactArtifactField].value or ""),
                 version=(dep[JvmArtifactVersionField].value or ""),
             )
-            for dep in jvm_artifact_deps
+            for item in CoarsenedTargets(request.component.dependencies).closure()
+            for dep in item.members
+            if dep.has_fields((JvmArtifactGroupField, JvmArtifactArtifactField))
         )
     )
 

--- a/src/python/pants/backend/java/compile/javac.py
+++ b/src/python/pants/backend/java/compile/javac.py
@@ -33,7 +33,7 @@ from pants.jvm.resolve.coursier_fetch import (
     Coordinates,
     CoursierResolvedLockfile,
     CoursierResolveKey,
-    FilterDirectDependenciesRequest,
+    FilterDependenciesRequest,
     MaterializedClasspath,
     MaterializedClasspathRequest,
 )
@@ -141,7 +141,7 @@ async def compile_java_source(
 
     unfiltered_lockfile = await Get(CoursierResolvedLockfile, CoursierResolveKey, request.resolve)
     lockfile = await Get(
-        CoursierResolvedLockfile, FilterDirectDependenciesRequest(coordinates, unfiltered_lockfile)
+        CoursierResolvedLockfile, FilterDependenciesRequest(coordinates, unfiltered_lockfile)
     )
 
     dest_dir = "classfiles"

--- a/src/python/pants/backend/java/compile/javac.py
+++ b/src/python/pants/backend/java/compile/javac.py
@@ -148,14 +148,10 @@ async def compile_java_source(
         )
     )
 
-
     unfiltered_lockfile = await Get(CoursierResolvedLockfile, CoursierResolveKey, request.resolve)
     lockfile = await Get(
         CoursierResolvedLockfile, FilterDirectDependenciesRequest(coordinates, unfiltered_lockfile)
     )
-
-    #raise Exception(request.component)#, coordinates, lockfile)
-
 
     dest_dir = "classfiles"
     (
@@ -176,8 +172,6 @@ async def compile_java_source(
             CreateDigest([Directory(dest_dir)]),
         ),
     )
-
-    #raise Exception(materialized_classpath)
 
     prefixed_direct_dependency_classpath = await Get(
         Snapshot, AddPrefix(merged_direct_dependency_classpath_digest, "__usercp")

--- a/src/python/pants/backend/java/dependency_inference/BUILD
+++ b/src/python/pants/backend/java/dependency_inference/BUILD
@@ -17,6 +17,8 @@ java_sources(
     ],
     dependencies=[
         ":com.github.javaparser_javaparser-symbol-solver-core",
+        ":com.github.javaparser_javaparser-core",
+        ":com.fasterxml.jackson.core_jackson-core",
         ":com.fasterxml.jackson.core_jackson-databind",
     ],
 )
@@ -29,8 +31,22 @@ jvm_artifact(
 )
 
 jvm_artifact(
+    name="com.github.javaparser_javaparser-core",
+    group="com.github.javaparser",
+    artifact="javaparser-core",
+    version="3.23.0",
+)
+
+jvm_artifact(
     name="com.fasterxml.jackson.core_jackson-databind",
     group="com.fasterxml.jackson.core",
     artifact="jackson-databind",
+    version="2.12.4",
+)
+
+jvm_artifact(
+    name="com.fasterxml.jackson.core_jackson-core",
+    group="com.fasterxml.jackson.core",
+    artifact="jackson-core",
     version="2.12.4",
 )

--- a/src/python/pants/backend/java/dependency_inference/BUILD
+++ b/src/python/pants/backend/java/dependency_inference/BUILD
@@ -17,8 +17,6 @@ java_sources(
     ],
     dependencies=[
         ":com.github.javaparser_javaparser-symbol-solver-core",
-        ":com.github.javaparser_javaparser-core",
-        ":com.fasterxml.jackson.core_jackson-core",
         ":com.fasterxml.jackson.core_jackson-databind",
     ],
 )
@@ -31,22 +29,8 @@ jvm_artifact(
 )
 
 jvm_artifact(
-    name="com.github.javaparser_javaparser-core",
-    group="com.github.javaparser",
-    artifact="javaparser-core",
-    version="3.23.0",
-)
-
-jvm_artifact(
     name="com.fasterxml.jackson.core_jackson-databind",
     group="com.fasterxml.jackson.core",
     artifact="jackson-databind",
-    version="2.12.4",
-)
-
-jvm_artifact(
-    name="com.fasterxml.jackson.core_jackson-core",
-    group="com.fasterxml.jackson.core",
-    artifact="jackson-core",
     version="2.12.4",
 )

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -317,15 +317,15 @@ async def coursier_resolve_lockfile(
 
 
 @dataclass(frozen=True)
-class FilterDirectDependenciesRequest:
+class FilterDependenciesRequest:
     direct_dependencies: Coordinates
     lockfile: CoursierResolvedLockfile
     transitive: bool = True
 
 
 @rule
-async def filter_for_direct_dependencies(
-    request: FilterDirectDependenciesRequest,
+async def filter_for_dependencies(
+    request: FilterDependenciesRequest,
 ) -> CoursierResolvedLockfile:
     """Returns a filtered version of the input lockfile that only contains the direct dependencies
     of a given target.

--- a/src/python/pants/jvm/resolve/coursier_fetch_filter_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_filter_test.py
@@ -104,13 +104,9 @@ def test_filter_transitive_includes_transitive_deps(
     rule_runner: RuleRunner, lockfile: CoursierResolvedLockfile
 ) -> None:
     filtered = filter(rule_runner, [coord2], lockfile, True)
-    assert sorted(filtered, key=lambda i: i.artifact) == [
-        coord1,
-        coord2,
-        coord3,
-        coord4,
-        coord5,
-    ]  # Entries should only appear once.
+    assert set(filtered) == {coord1, coord2, coord3, coord4, coord5}
+    # Entries should only appear once.
+    assert len(filtered) == 5
 
 
 def filter(rule_runner, coordinates, lockfile, transitive) -> Sequence[Coordinate]:

--- a/src/python/pants/jvm/resolve/coursier_fetch_filter_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_filter_test.py
@@ -1,0 +1,121 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from typing import DefaultDict, Sequence
+from unittest import mock
+
+import pytest
+
+from pants.core.util_rules.external_tool import rules as external_tool_rules
+from pants.jvm.resolve.coursier_fetch import (
+    Coordinate,
+    Coordinates,
+    CoursierLockfileEntry,
+    CoursierResolvedLockfile,
+    FilterDependenciesRequest,
+)
+from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
+from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
+from pants.jvm.util_rules import rules as util_rules
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = RuleRunner(
+        rules=[
+            *coursier_fetch_rules(),
+            *coursier_setup_rules(),
+            *external_tool_rules(),
+            *util_rules(),
+            QueryRule(CoursierResolvedLockfile, (FilterDependenciesRequest,)),
+        ],
+    )
+    return rule_runner
+
+
+coord1 = Coordinate("test", "art1", "1.0.0")
+coord2 = Coordinate("test", "art2", "1.0.0")
+coord3 = Coordinate("test", "art3", "1.0.0")
+coord4 = Coordinate("test", "art4", "1.0.0")
+coord5 = Coordinate("test", "art5", "1.0.0")
+
+
+# No depedencies (coord1)
+# 1 direct dependency, more transitive dependencies (coord2)
+# 1 where direct dependencies provide no transitive dependencies (coord 4)
+# 1 where direct dependencies provide repeated dependencies (coord5)
+direct: dict[Coordinate, set[Coordinate]] = {
+    coord1: set(),
+    coord2: {
+        coord3,
+    },  # 1, 2, 3, 4, 5
+    coord3: {coord1, coord4, coord5},  # 1, 3, 4, 5
+    coord4: {
+        coord1,
+    },  # 1, 4
+    coord5: {coord1, coord4},  # 1, 4, 5
+}
+
+
+@pytest.fixture
+def lockfile() -> CoursierResolvedLockfile:
+
+    # Calculate transitive deps
+    transitive_ = {(i, k) for i, j in direct.items() for k in j}
+    while True:
+        old_len = len(transitive_)
+        transitive_ |= {(i, k) for i, j in transitive_ for k in direct[j]}
+        if old_len == len(transitive_):
+            break
+    transitive = DefaultDict(set)
+    for (i, j) in transitive_:
+        transitive[i].add(j)
+
+    entries = (
+        CoursierLockfileEntry(
+            coord=coord,
+            file_name=f"{coord.artifact}.jar",
+            direct_dependencies=Coordinates(direct[coord]),
+            dependencies=Coordinates(transitive[coord]),
+            file_digest=mock.Mock(),
+        )
+        for coord in direct
+    )
+
+    return CoursierResolvedLockfile(entries=tuple(entries))
+
+
+def test_no_deps(rule_runner: RuleRunner, lockfile: CoursierResolvedLockfile) -> None:
+    filtered = filter(rule_runner, [coord1], lockfile, False)
+    assert filtered == [coord1]
+
+
+def test_filter_non_transitive_ignores_deps(
+    rule_runner: RuleRunner, lockfile: CoursierResolvedLockfile
+) -> None:
+    filtered = filter(rule_runner, [coord2], lockfile, False)
+    assert filtered == [coord2]
+
+
+def test_filter_transitive_includes_transitive_deps(
+    rule_runner: RuleRunner, lockfile: CoursierResolvedLockfile
+) -> None:
+    filtered = filter(rule_runner, [coord2], lockfile, True)
+    assert sorted(filtered, key=lambda i: i.artifact) == [
+        coord1,
+        coord2,
+        coord3,
+        coord4,
+        coord5,
+    ]  # Entries should only appear once.
+
+
+def filter(rule_runner, coordinates, lockfile, transitive) -> Sequence[Coordinate]:
+    filtered = rule_runner.request(
+        CoursierResolvedLockfile,
+        [FilterDependenciesRequest(Coordinates(coordinates), lockfile, transitive)],
+    )
+    return list(i.coord for i in filtered.entries)


### PR DESCRIPTION
Adds `FilterDependenciesRequest`, which takes a Coursier lockfile and a set of coordinates, and returns a cut-down version of that lockfile that contains only the specified coordinates, and if `transitive` is set, the transitive dependencies of those coordinates. This means that targets can share a resolve, but only the artifacts needed to build a given target are supplied to the compiler. This should improve build performance.

nb. `transitive` is set to `True` by default until configuration is added.

This resolves #13366.