### PR TITLE
[internal] upgrade pyo3 crate to v0.14.5

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -706,6 +706,7 @@ dependencies = [
  "nailgun",
  "parking_lot",
  "pyo3",
+ "pyo3-build-config",
  "store",
  "task_executor",
  "workunit_store",
@@ -2364,9 +2365,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.14.1"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338f7f3701e11fd7f76508c91fbcaabc982564bcaf4d1ca7e1574ff2b4778aec"
+checksum = "35100f9347670a566a67aa623369293703322bb9db77d99d7df7313b575ae0c8"
 dependencies = [
  "cfg-if 1.0.0",
  "indoc",
@@ -2380,18 +2381,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.14.1"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb2e98cc9ccc83d4f7115c8f925e0057e88c8d324b1bc4c2db4a7270c06ac9d"
+checksum = "d12961738cacbd7f91b7c43bc25cfeeaa2698ad07a04b3be0aa88b950865738f"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "pyo3-macros"
-version = "0.14.1"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfb8671a42d0ecc4bec8cc107ae96d49292ca20cd1968e09b98af4aafd516adf"
+checksum = "fc0bc5215d704824dfddddc03f93cb572e1155c68b6761c37005e1c288808ea8"
 dependencies = [
  "pyo3-macros-backend",
  "quote 1.0.9",
@@ -2400,9 +2401,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.14.1"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9addf6dc422f05d4949cc0990195ee74fa43e3c3780cc9a1972fe9e7b68a9f48"
+checksum = "71623fc593224afaab918aa3afcaf86ed2f43d34f6afde7f3922608f253240df"
 dependencies = [
  "proc-macro2 1.0.29",
  "pyo3-build-config",

--- a/src/rust/engine/engine_pyo3/Cargo.toml
+++ b/src/rust/engine/engine_pyo3/Cargo.toml
@@ -24,8 +24,11 @@ hashing = { path = "../hashing" }
 itertools = "0.10"
 nailgun = { path = "../nailgun" }
 parking_lot = "0.11"
-pyo3 = "0.14.1"
+pyo3 = "0.14.5"
 store = { path = "../fs/store" }
 task_executor = { path = "../task_executor" }
 testutil_mock = { package = "mock", path = "../testutil/mock" }
 workunit_store = { path = "../workunit_store" }
+
+[build-dependencies]
+pyo3-build-config = "0.14.5"

--- a/src/rust/engine/engine_pyo3/build.rs
+++ b/src/rust/engine/engine_pyo3/build.rs
@@ -26,6 +26,8 @@
 #![allow(clippy::mutex_atomic)]
 
 fn main() {
+  pyo3_build_config::add_extension_module_link_args();
+
   // NB: The native extension only works with the Python interpreter version it was built with
   // (e.g. Python 3.7 vs 3.8).
   println!("cargo:rerun-if-env-changed=PY");


### PR DESCRIPTION
Upgrade the `pyo3` crate from v0.14.1 to v0.14.5.

Note: In v0.14.2, certain link arguments were removed on macOS. The `pyo3-build-config` crate is used in the `build.rs` to handle adding back the correct linker arguments. See https://pyo3.rs/v0.14.5/building_and_distribution.html#macos for details.