### PR TITLE
[internal] upgrade to Rust v1.56.1

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -52,7 +52,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.56.0-*
+        path: '~/.rustup/toolchains/1.56.1-*
 
           ~/.rustup/update-hashes
 
@@ -207,7 +207,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.56.0-*
+        path: '~/.rustup/toolchains/1.56.1-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,7 +52,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.56.0-*
+        path: '~/.rustup/toolchains/1.56.1-*
 
           ~/.rustup/update-hashes
 
@@ -206,7 +206,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.56.0-*
+        path: '~/.rustup/toolchains/1.56.1-*
 
           ~/.rustup/update-hashes
 
@@ -407,7 +407,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.56.0-*
+        path: '~/.rustup/toolchains/1.56.1-*
 
           ~/.rustup/update-hashes
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.56.0"
+channel = "1.56.1"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
Upgrade to Rust v1.56.1 which includes lints to detect a security issue with Unicode encoding. See https://blog.rust-lang.org/2021/11/01/Rust-1.56.1.html for details.