### PR TITLE
[internal] Simplify `AllTargets` implementation

### DIFF
--- a/src/python/pants/backend/project_info/dependees.py
+++ b/src/python/pants/backend/project_info/dependees.py
@@ -10,7 +10,7 @@ from pants.engine.collection import DeduplicatedCollection
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
-from pants.engine.target import AllTargets, AllTargetsRequest, Dependencies, DependenciesRequest
+from pants.engine.target import AllUnexpandedTargets, Dependencies, DependenciesRequest
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.meta import frozen_after_init
@@ -23,8 +23,7 @@ class AddressToDependees:
 
 
 @rule(desc="Map all targets to their dependees", level=LogLevel.DEBUG)
-async def map_addresses_to_dependees() -> AddressToDependees:
-    all_targets = await Get(AllTargets, AllTargetsRequest(include_target_generators=True))
+async def map_addresses_to_dependees(all_targets: AllUnexpandedTargets) -> AddressToDependees:
     dependencies_per_target = await MultiGet(
         Get(Addresses, DependenciesRequest(tgt.get(Dependencies), include_special_cased_deps=True))
         for tgt in all_targets

--- a/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints.py
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints.py
@@ -16,8 +16,8 @@ from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, Outputting
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
 from pants.engine.target import (
-    AllTargets,
     AllTargetsRequest,
+    AllUnexpandedTargets,
     RegisteredTargetTypes,
     TransitiveTargets,
     TransitiveTargetsRequest,
@@ -77,7 +77,7 @@ async def py_constraints(
             return PyConstraintsGoal(exit_code=1)
 
         # TODO: Stop including the target generator? I don't think it's relevant for this goal.
-        all_targets = await Get(AllTargets, AllTargetsRequest(include_target_generators=True))
+        all_targets = await Get(AllUnexpandedTargets, AllTargetsRequest())
         all_python_targets = tuple(
             t for t in all_targets if t.has_field(InterpreterConstraintsField)
         )

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -44,6 +44,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     AllTargets,
     AllTargetsRequest,
+    AllUnexpandedTargets,
     CoarsenedTarget,
     CoarsenedTargets,
     Dependencies,
@@ -217,22 +218,25 @@ async def resolve_targets(
 
 
 @rule(desc="Find all targets in the project", level=LogLevel.DEBUG)
-async def find_all_targets(req: AllTargetsRequest) -> AllTargets:
-    if not req.include_target_generators:
-        tgts = await Get(Targets, AddressSpecs([MaybeEmptyDescendantAddresses("")]))
-        return AllTargets(tgts)
-    target_generators_replaced, target_generators_kep = await MultiGet(
-        Get(Targets, AddressSpecs([MaybeEmptyDescendantAddresses("")])),
-        Get(UnexpandedTargets, AddressSpecs([MaybeEmptyDescendantAddresses("")])),
-    )
-    return AllTargets(
-        sorted({*target_generators_replaced, *target_generators_kep}, key=lambda t: t.address)
-    )
+async def find_all_targets(_: AllTargetsRequest) -> AllTargets:
+    tgts = await Get(Targets, AddressSpecs([MaybeEmptyDescendantAddresses("")]))
+    return AllTargets(tgts)
+
+
+@rule(desc="Find all targets in the project", level=LogLevel.DEBUG)
+async def find_all_unexpanded_targets(_: AllTargetsRequest) -> AllUnexpandedTargets:
+    tgts = await Get(UnexpandedTargets, AddressSpecs([MaybeEmptyDescendantAddresses("")]))
+    return AllUnexpandedTargets(tgts)
 
 
 @rule
 async def find_all_targets_singleton() -> AllTargets:
     return await Get(AllTargets, AllTargetsRequest())
+
+
+@rule
+async def find_all_unexpanded_targets_singleton() -> AllUnexpandedTargets:
+    return await Get(AllUnexpandedTargets, AllTargetsRequest())
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -44,6 +44,7 @@ from pants.engine.rules import Get, MultiGet, rule
 from pants.engine.target import (
     AllTargets,
     AllTargetsRequest,
+    AllUnexpandedTargets,
     AsyncFieldMixin,
     CoarsenedTargets,
     Dependencies,
@@ -135,6 +136,7 @@ def transitive_targets_rule_runner() -> RuleRunner:
             generate_mock_generated_target,
             UnionRule(GenerateTargetsRequest, MockGenerateTargetsRequest),
             QueryRule(AllTargets, [AllTargetsRequest]),
+            QueryRule(AllUnexpandedTargets, [AllTargetsRequest]),
             QueryRule(CoarsenedTargets, [Addresses]),
             QueryRule(Targets, [DependenciesRequest]),
             QueryRule(TransitiveTargets, [TransitiveTargetsRequest]),
@@ -607,11 +609,10 @@ def test_find_all_targets(transitive_targets_rule_runner: RuleRunner) -> None:
     }
     assert {t.address for t in all_tgts} == expected
 
-    pytest.xfail("The singleton rule is being evaluated, rather than the one with the param")
-    with_generators = transitive_targets_rule_runner.request(  # type: ignore[unreachable]
-        AllTargets, [AllTargetsRequest(include_target_generators=True)]
+    all_unexpanded = transitive_targets_rule_runner.request(
+        AllUnexpandedTargets, [AllTargetsRequest()]
     )
-    assert {t.address for t in with_generators} == {*expected, Address("", target_name="generator")}
+    assert {t.address for t in all_unexpanded} == {*expected, Address("", target_name="generator")}
 
 
 def test_resolve_specs_snapshot() -> None:

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -772,16 +772,17 @@ class RegisteredTargetTypes:
         return FrozenOrderedSet(self.aliases_to_types.values())
 
 
-class AllTargets(Targets):
-    """All targets in the project.
+class AllTargets(Collection[Target]):
+    """All targets in the project, but with target generators replaced by their generated targets,
+    unlike `AllUnexpandedTargets`."""
 
-    This should generally be avoided because it is relatively expensive to compute and is
-    frequently invalidated, but it can be necessary for things like dependency inference to build
-    a global mapping of imports to targets.
 
-    You can either request via `Get(AllTargets, AllTargetsRequest)`, or as a singleton, i.e. using
-    `AllTargets` as a parameter to the `@rule`. When used as a singleton, all target generators
-    will be replaced by their generated targets.
+class AllUnexpandedTargets(Collection[Target]):
+    """All targets in the project, including generated targets.
+
+    This should generally be avoided because it is relatively expensive to compute and is frequently
+    invalidated, but it can be necessary for things like dependency inference to build a global
+    mapping of imports to targets.
     """
 
 
@@ -789,11 +790,8 @@ class AllTargets(Targets):
 class AllTargetsRequest:
     """Find all targets in the project.
 
-    Will always include generated targets. If `include_target_generators` is True, will also include
-    target generators rather than replacing them with their generated targets.
+    Use with either `AllUnexpandedTargets` or `AllTargets`.
     """
-
-    include_target_generators: bool = False
 
 
 # -----------------------------------------------------------------------------------------------


### PR DESCRIPTION
Now that address specs include generated targets (https://github.com/pantsbuild/pants/pull/13263), the implementation of `AllTargets` can be simplified.

Also updates Java dependency inference to use this rule and adds an `AllJvmArtifactTargets` type so that there's less invalidation of Java dependency inference.

[ci skip-rust]