### PR TITLE
Fixes to interpreter constraint computation.

### DIFF
--- a/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints.py
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints.py
@@ -140,18 +140,6 @@ async def py_constraints(
         transitive_targets.closure, python_setup
     )
 
-    if not final_constraints:
-        target_types_with_constraints = sorted(
-            tgt_type.alias
-            for tgt_type in registered_target_types.types
-            if tgt_type.class_has_field(InterpreterConstraintsField, union_membership)
-        )
-        logger.warning(
-            "No Python files/targets matched for the `py-constraints` goal. All target types with "
-            f"Python interpreter constraints: {', '.join(target_types_with_constraints)}"
-        )
-        return PyConstraintsGoal(exit_code=0)
-
     constraints_to_addresses = defaultdict(set)
     for tgt in transitive_targets.closure:
         constraints = InterpreterConstraints.create_from_targets([tgt], python_setup)

--- a/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints_test.py
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints_test.py
@@ -60,18 +60,6 @@ def run_goal(rule_runner: RuleRunner, args: list[str]) -> GoalRuleResult:
     )
 
 
-def test_no_matches(rule_runner: RuleRunner, caplog) -> None:
-    rule_runner.write_files({"f.txt": "", "BUILD": "file(name='tgt', source='f.txt')"})
-    result = run_goal(rule_runner, ["f.txt"])
-    assert result.exit_code == 0
-    print(caplog.records)
-    assert len(caplog.records) == 1
-    assert (
-        "No Python files/targets matched for the `py-constraints` goal. All target types with "
-        "Python interpreter constraints: python_sources, python_tests"
-    ) in caplog.text
-
-
 def test_render_constraints(rule_runner: RuleRunner) -> None:
     write_files(rule_runner)
     result = run_goal(rule_runner, ["app:app"])

--- a/src/python/pants/backend/python/util_rules/interpreter_constraints.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints.py
@@ -35,12 +35,18 @@ class FieldSetWithInterpreterConstraints(Protocol):
 _FS = TypeVar("_FS", bound=FieldSetWithInterpreterConstraints)
 
 
-# The current maxes are 2.7.18 and 3.6.13.
-_EXPECTED_LAST_PATCH_VERSION = 18
+# The current maxes are 2.7.18 and 3.6.15.  We go much higher, for safety.
+_PATCH_VERSION_UPPER_BOUND = 30
 
 
 # Normally we would subclass `DeduplicatedCollection`, but we want a custom constructor.
 class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter):
+    @classmethod
+    def for_fixed_python_version(
+        cls, cpython_version_str: str, interpreter_type: str = "CPython"
+    ) -> InterpreterConstraints:
+        return cls([f"{interpreter_type}=={cpython_version_str}"])
+
     def __init__(self, constraints: Iterable[str | Requirement] = ()) -> None:
         # #12578 `parse_constraint` will sort the requirement's component constraints into a stable form.
         # We need to sort the component constraints for each requirement _before_ sorting the entire list
@@ -154,6 +160,9 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
         constraint_sets = {field.value_or_global_default(python_setup) for field in fields}
         # This will OR within each field and AND across fields.
         merged_constraints = cls.merge_constraint_sets(constraint_sets)
+        if not merged_constraints:
+            # There were no applicable fields, so the only constraint is the global one.
+            return InterpreterConstraints(python_setup.interpreter_constraints)
         return InterpreterConstraints(merged_constraints)
 
     @classmethod
@@ -180,7 +189,7 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
         return args
 
     def _valid_patch_versions(self, major: int, minor: int) -> Iterator[int]:
-        for p in range(0, _EXPECTED_LAST_PATCH_VERSION + 1):
+        for p in range(0, _PATCH_VERSION_UPPER_BOUND + 1):
             for req in self:
                 if req.specifier.contains(f"{major}.{minor}.{p}"):  # type: ignore[attr-defined]
                     yield p
@@ -202,9 +211,21 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
         The constraints may also be compatible with later versions; this is the lowest version that
         still works.
         """
+        snapped = self.snap_to_minimum(interpreter_universe)
+        if snapped:
+            # We know by construction that snapped has a single requirement, and that has a single
+            # (op, version) spec whose version is "major.minor.*", so we just strip off the ".*" .
+            return next(iter(snapped)).specs[0][1][:-2]
+        return None
+
+    def snap_to_minimum(self, interpreter_universe: Iterable[str]) -> InterpreterConstraints | None:
+        """Snap to the lowest Python major.minor version that works with these constraints."""
         for major, minor in sorted(_major_minor_to_int(s) for s in interpreter_universe):
-            if self._includes_version(major, minor):
-                return f"{major}.{minor}"
+            for p in range(0, _PATCH_VERSION_UPPER_BOUND + 1):
+                for req in self:
+                    if req.specifier.contains(f"{major}.{minor}.{p}"):  # type: ignore[attr-defined]
+                        snapped = Requirement.parse(f"{req.project_name}=={major}.{minor}.*")
+                        return InterpreterConstraints([snapped])
         return None
 
     def _requires_python3_version_or_newer(
@@ -212,7 +233,7 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
     ) -> bool:
         if not self:
             return False
-        patch_versions = list(reversed(range(0, _EXPECTED_LAST_PATCH_VERSION)))
+        patch_versions = list(reversed(range(0, _PATCH_VERSION_UPPER_BOUND)))
         # We only look at the prior Python release. For example, consider Python 3.8+
         # looking at 3.7. If using something like `>=3.5`, Py37 will be included.
         # `==3.6.*,!=3.7.*,==3.8.*` is unlikely, and even that will work correctly as

--- a/src/python/pants/backend/python/util_rules/interpreter_constraints_test.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints_test.py
@@ -196,8 +196,9 @@ def test_interpreter_constraints_minimum_python_version(
     "constraints,expected",
     [
         (["CPython>=2.7"], "CPython==2.7.*"),
+        (["CPython>=2.7,!=2.7.2"], "CPython==2.7.*,!=2.7.2"),
         (["CPython>=3.7"], "CPython==3.7.*"),
-        (["CPython>=3.8.6"], "CPython==3.8.*"),
+        (["CPython>=3.8.3,!=3.8.5,!=3.9.1"], "CPython==3.8.*,!=3.8.0,!=3.8.1,!=3.8.2,!=3.8.5"),
         (["CPython==3.5.*", "CPython>=3.6"], "CPython==3.5.*"),
         (["CPython==3.7.*", "PyPy==3.6.*"], "PyPy==3.6.*"),
         (["CPython"], "CPython==2.7.*"),

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -832,7 +832,7 @@ class VenvPexRequest:
     bin_names: tuple[str, ...] = ()
 
     def __init__(self, pex_request: PexRequest, bin_names: Iterable[str] = ()) -> None:
-        """A request for a PEX that runs in a venv and optionally exposes select vanv `bin` scripts.
+        """A request for a PEX that runs in a venv and optionally exposes select venv `bin` scripts.
 
         :param pex_request: The details of the desired PEX.
         :param bin_names: The names of venv `bin` scripts to expose for execution.


### PR DESCRIPTION
When computing constraints for a target set, previously we'd return
empty constraints if the target set had no intepreter_constraints fields.
Instead, we should have been using the global constraints, so that
the behavior is continuous (each interpreter_constraints field adds
constraints, so no fields should be the least constrained). So we now
do so.

Also, implements a snap_to_minimum() function that returns constraints
representing the minimum version supported by the original constraints.
Reimplements minimum_python_version() to use this snapped version.

Also, sets a more generous upper bound for possible patch versions of
Python, since there's no harm in doing so, and risk in not doing so.

[ci skip-rust]

[ci skip-build-wheels]