### PR TITLE
Don't error when `dir:` and `dir::` CLI specs don't match any targets

### DIFF
--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -11,7 +11,7 @@ from pants.backend.python.subsystems.python_tool_base import PythonToolRequireme
 from pants.backend.python.target_types import EntryPoint
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.backend.terraform.target_types import TerraformModuleSourcesField
-from pants.base.specs import AddressSpecs, MaybeEmptySiblingAddresses
+from pants.base.specs import AddressSpecs, SiblingAddresses
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.internals.selectors import Get
 from pants.engine.process import Process, ProcessResult
@@ -137,7 +137,7 @@ async def infer_terraform_module_dependencies(
 
     # For each path, see if there is a `terraform_module` target at the specified spec_path.
     candidate_targets = await Get(
-        Targets, AddressSpecs([MaybeEmptySiblingAddresses(path) for path in candidate_spec_paths])
+        Targets, AddressSpecs([SiblingAddresses(path) for path in candidate_spec_paths])
     )
     # TODO: Need to either implement the standard ambiguous dependency logic or ban >1 terraform_module
     # per directory.

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -7,7 +7,7 @@ import itertools
 import os
 from abc import ABC, ABCMeta, abstractmethod
 from dataclasses import dataclass
-from typing import ClassVar, Iterable
+from typing import Iterable
 
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.engine.fs import GlobExpansionConjunction, PathGlobs
@@ -57,7 +57,6 @@ class AddressLiteralSpec(AddressSpec):
 @dataclass(frozen=True)  # type: ignore[misc]
 class AddressGlobSpec(AddressSpec, metaclass=ABCMeta):
     directory: str
-    error_if_no_matches: ClassVar[bool]
 
     def to_build_file_globs(self, build_patterns: Iterable[str]) -> set[str]:
         """Generate glob patterns matching all the BUILD files this address spec must inspect to
@@ -79,12 +78,7 @@ class AddressGlobSpec(AddressSpec, metaclass=ABCMeta):
 
 
 class SiblingAddresses(AddressGlobSpec):
-    """An AddressSpec representing all addresses residing within the given directory.
-
-    At least one such address must exist.
-    """
-
-    error_if_no_matches = True
+    """An AddressSpec representing all addresses residing within the given directory."""
 
     def __str__(self) -> str:
         return f"{self.directory}:"
@@ -93,22 +87,8 @@ class SiblingAddresses(AddressGlobSpec):
         return tgt_residence_dir == self.directory
 
 
-class MaybeEmptySiblingAddresses(SiblingAddresses):
-    """An AddressSpec representing all addresses residing within the given directory.
-
-    It is not an error if there are no such addresses.
-    """
-
-    error_if_no_matches = False
-
-
 class DescendantAddresses(AddressGlobSpec):
-    """An AddressSpec representing all addresses residing recursively under the given directory.
-
-    At least one such address must exist.
-    """
-
-    error_if_no_matches = True
+    """An AddressSpec representing all addresses residing recursively under the given directory."""
 
     def __str__(self) -> str:
         return f"{self.directory}::"
@@ -123,20 +103,9 @@ class DescendantAddresses(AddressGlobSpec):
         return fast_relpath_optional(tgt_residence_dir, self.directory) is not None
 
 
-class MaybeEmptyDescendantAddresses(DescendantAddresses):
-    """An AddressSpec representing all addresses residing recursively under the given directory.
-
-    It is not an error if there are no such addresses.
-    """
-
-    error_if_no_matches = False
-
-
 class AscendantAddresses(AddressGlobSpec):
     """An AddressSpec representing all addresses located recursively in and above the given
     directory."""
-
-    error_if_no_matches = False
 
     def __str__(self) -> str:
         return f"{self.directory}^"

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -20,7 +20,6 @@ from pants.engine.internals.target_adaptor import TargetAdaptor
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import Targets, UnexpandedTargets, WrappedTarget
 from pants.option.global_options import GlobalOptions
-from pants.util.docutil import doc_url
 from pants.util.frozendict import FrozenDict
 from pants.util.ordered_set import OrderedSet
 
@@ -226,34 +225,15 @@ async def addresses_from_address_specs(
     for tgt in (*tgts_generators_kept, *tgts_generators_replaced):
         residence_dir_to_targets[tgt.residence_dir].append(tgt)
 
-    matched_globs = set()
     for glob_spec in address_specs.globs:
         for residence_dir in residence_dir_to_targets:
             if not glob_spec.matches(residence_dir):
                 continue
-            matched_globs.add(glob_spec)
             matched_addresses.update(
                 tgt.address
                 for tgt in residence_dir_to_targets[residence_dir]
                 if filtering_disabled or specs_filter.matches(tgt)
             )
-
-    unmatched_globs = [
-        glob
-        for glob in address_specs.globs
-        if glob not in matched_globs and glob.error_if_no_matches
-    ]
-    if unmatched_globs:
-        glob_description = (
-            f"the address glob `{unmatched_globs[0]}`"
-            if len(unmatched_globs) == 1
-            else f"these address globs: {sorted(str(glob) for glob in unmatched_globs)}"
-        )
-        raise ResolveError(
-            f"No targets found for {glob_description}\n\n"
-            f"Do targets exist in those directories? Maybe run `./pants tailor` to generate "
-            f"BUILD files? See {doc_url('targets')} about targets and BUILD files."
-        )
 
     return Addresses(sorted(matched_addresses))
 

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -16,7 +16,6 @@ from pants.base.specs import (
     AddressSpecs,
     AscendantAddresses,
     DescendantAddresses,
-    MaybeEmptySiblingAddresses,
     SiblingAddresses,
 )
 from pants.build_graph.build_file_aliases import BuildFileAliases
@@ -500,33 +499,10 @@ def test_address_specs_do_not_exist(address_specs_rule_runner: RuleRunner) -> No
     assert_resolve_error([AddressLiteralSpec("real", "fake_tgt")], expected=str(did_you_mean))
     assert_resolve_error([AddressLiteralSpec("real/f.txt", "fake_tgt")], expected=str(did_you_mean))
 
-    # SiblingAddresses requires at least one match.
-    assert_resolve_error(
-        [SiblingAddresses("fake")],
-        expected="No targets found for the address glob `fake:`",
-    )
-    assert_resolve_error(
-        [SiblingAddresses("empty")], expected="No targets found for the address glob `empty:`"
-    )
-
-    # MaybeEmptySiblingAddresses does not require any matches.
-    assert not resolve_address_specs(
-        address_specs_rule_runner, [MaybeEmptySiblingAddresses("fake")]
-    )
-    assert not resolve_address_specs(
-        address_specs_rule_runner, [MaybeEmptySiblingAddresses("empty")]
-    )
-
-    # DescendantAddresses requires at least one match.
-    assert_resolve_error(
-        [DescendantAddresses("fake"), DescendantAddresses("empty")],
-        expected="No targets found for these address globs: ['empty::', 'fake::']",
-    )
-
-    # AscendantAddresses does not require any matches.
-    assert not resolve_address_specs(
-        address_specs_rule_runner, [AscendantAddresses("fake"), AscendantAddresses("empty")]
-    )
+    # Address globs do not require any matches.
+    for glob_type in (SiblingAddresses, DescendantAddresses, AscendantAddresses):
+        assert not resolve_address_specs(address_specs_rule_runner, [glob_type("fake")])
+        assert not resolve_address_specs(address_specs_rule_runner, [glob_type("empty")])
 
 
 def test_address_specs_generated_target_does_not_belong_to_generator(

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -501,8 +501,12 @@ def test_address_specs_do_not_exist(address_specs_rule_runner: RuleRunner) -> No
 
     # Address globs do not require any matches.
     for glob_type in (SiblingAddresses, DescendantAddresses, AscendantAddresses):
-        assert not resolve_address_specs(address_specs_rule_runner, [glob_type("fake")])
-        assert not resolve_address_specs(address_specs_rule_runner, [glob_type("empty")])
+        assert not resolve_address_specs(
+            address_specs_rule_runner, [glob_type("fake")]  # type: ignore[abstract]
+        )
+        assert not resolve_address_specs(
+            address_specs_rule_runner, [glob_type("empty")]  # type: ignore[abstract]
+        )
 
 
 def test_address_specs_generated_target_does_not_belong_to_generator(

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -16,9 +16,9 @@ from pants.base.exceptions import ResolveError
 from pants.base.specs import (
     AddressSpecs,
     AscendantAddresses,
+    DescendantAddresses,
     FileLiteralSpec,
     FilesystemSpecs,
-    MaybeEmptyDescendantAddresses,
     Specs,
 )
 from pants.engine.addresses import (
@@ -219,13 +219,13 @@ async def resolve_targets(
 
 @rule(desc="Find all targets in the project", level=LogLevel.DEBUG)
 async def find_all_targets(_: AllTargetsRequest) -> AllTargets:
-    tgts = await Get(Targets, AddressSpecs([MaybeEmptyDescendantAddresses("")]))
+    tgts = await Get(Targets, AddressSpecs([DescendantAddresses("")]))
     return AllTargets(tgts)
 
 
 @rule(desc="Find all targets in the project", level=LogLevel.DEBUG)
 async def find_all_unexpanded_targets(_: AllTargetsRequest) -> AllUnexpandedTargets:
-    tgts = await Get(UnexpandedTargets, AddressSpecs([MaybeEmptyDescendantAddresses("")]))
+    tgts = await Get(UnexpandedTargets, AddressSpecs([DescendantAddresses("")]))
     return AllUnexpandedTargets(tgts)
 
 


### PR DESCRIPTION
Per the [Specs Redesign proposal (pt 2)](https://docs.google.com/document/d/1WWQM-X6kHoSCKwItqf61NiKFWNSlpnTC5QNu3ul9RDk/edit#heading=h.1h4j0d5mazhu), we believe it's valuable to start having the globs `dir:` and `dir::` work with target-agnostic goals like `count-loc` and `validate`. For that to happen, we need to stop erroring when they don't match any targets. For example, `./pants tailor ::` should work even if you have no targets created at all, whereas right now it errors with:

```
❯ ./pants test src/rust/engine/cache::
pants.base.exceptions.ResolveError: No targets found for the address glob `src/rust/engine/cache::`

Do targets exist in those directories? Maybe run `./pants tailor` to generate BUILD files? See https://www.pantsbuild.org/v2.8/docs/targets about targets and BUILD files.
```

There is already a good warning if no targets match:

```
❯ ./pants test src/rust/engine/cache::
09:58:19.04 [WARN] No files or targets specified. The `test` goal works with these target types:

  * go_first_party_package
  * junit_test
  * python_test
  * shunit2_test

Please specify relevant files and/or targets. Run `./pants filter --target-type=go_first_party_package,junit_test,python_test,shunit2_test ::` to find all applicable targets in your project, or run `./pants filter --target-type=go_first_party_package,junit_test,python_test,shunit2_test :: | xargs ./pants filedeps` to find all applicable files.
```

[ci skip-rust]
[ci skip-build-wheels]