### PR TITLE
Revert the constraints computation part of #13465.

### DIFF
--- a/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints.py
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints.py
@@ -140,6 +140,18 @@ async def py_constraints(
         transitive_targets.closure, python_setup
     )
 
+    if not final_constraints:
+        target_types_with_constraints = sorted(
+            tgt_type.alias
+            for tgt_type in registered_target_types.types
+            if tgt_type.class_has_field(InterpreterConstraintsField, union_membership)
+        )
+        logger.warning(
+            "No Python files/targets matched for the `py-constraints` goal. All target types with "
+            f"Python interpreter constraints: {', '.join(target_types_with_constraints)}"
+        )
+        return PyConstraintsGoal(exit_code=0)
+
     constraints_to_addresses = defaultdict(set)
     for tgt in transitive_targets.closure:
         constraints = InterpreterConstraints.create_from_targets([tgt], python_setup)

--- a/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints_test.py
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints_test.py
@@ -60,6 +60,18 @@ def run_goal(rule_runner: RuleRunner, args: list[str]) -> GoalRuleResult:
     )
 
 
+def test_no_matches(rule_runner: RuleRunner, caplog) -> None:
+    rule_runner.write_files({"f.txt": "", "BUILD": "file(name='tgt', source='f.txt')"})
+    result = run_goal(rule_runner, ["f.txt"])
+    assert result.exit_code == 0
+    print(caplog.records)
+    assert len(caplog.records) == 1
+    assert (
+        "No Python files/targets matched for the `py-constraints` goal. All target types with "
+        "Python interpreter constraints: python_sources, python_tests"
+    ) in caplog.text
+
+
 def test_render_constraints(rule_runner: RuleRunner) -> None:
     write_files(rule_runner)
     result = run_goal(rule_runner, ["app:app"])

--- a/src/python/pants/backend/python/util_rules/interpreter_constraints.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints.py
@@ -160,9 +160,6 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
         constraint_sets = {field.value_or_global_default(python_setup) for field in fields}
         # This will OR within each field and AND across fields.
         merged_constraints = cls.merge_constraint_sets(constraint_sets)
-        if not merged_constraints:
-            # There were no applicable fields, so the only constraint is the global one.
-            return InterpreterConstraints(python_setup.interpreter_constraints)
         return InterpreterConstraints(merged_constraints)
 
     @classmethod


### PR DESCRIPTION
We now one again allow empty constraints if no applicable
fields were found. Consumers of the empty constraints can
fall back to the global ones if needed.

[ci skip-rust]

[ci skip-build-wheels]