### PR TITLE
Add `overrides` to `python_requirements` and `poetry_requirements` (Cherry-pick of #13458)

### DIFF
--- a/src/python/pants/backend/python/macros/caof_utils.py
+++ b/src/python/pants/backend/python/macros/caof_utils.py
@@ -1,0 +1,51 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Tuple, Union
+
+from packaging.utils import canonicalize_name as canonicalize_project_name
+
+from pants.engine.target import InvalidFieldException
+from pants.util.collections import ensure_str_list
+
+OVERRIDES_TYPE = Optional[Dict[Union[str, Tuple[str, ...]], Dict[str, Any]]]
+
+
+def flatten_overrides_to_dependency_field(
+    overrides_value: OVERRIDES_TYPE, *, macro_name: str, build_file_dir: str
+) -> dict[str, list[str]]:
+    """Flatten `overrides` by ensuring that only `dependencies` is specified."""
+
+    result: dict[str, list[str]] = {}
+    for maybe_key_or_keys, override in (overrides_value or {}).items():
+        keys = (maybe_key_or_keys,) if isinstance(maybe_key_or_keys, str) else maybe_key_or_keys
+        for _raw_key in keys:
+            key = canonicalize_project_name(_raw_key)
+            for field, value in override.items():
+                if field != "dependencies":
+                    raise InvalidFieldException(
+                        "Can only specify the `dependencies` field (for now) in the `overrides` "
+                        f"field of the {macro_name} macro in the BUILD file in {build_file_dir} "
+                        f"for the key `{key}`, but you specified `{field}`."
+                    )
+                if key in result:
+                    raise InvalidFieldException(
+                        f"Conflicting overrides in the `overrides` field of "
+                        f"the {macro_name} macro in the BUILD file in {build_file_dir} for the key "
+                        f"`{key}` for the field `{field}`. You cannot specify the same field name "
+                        "multiple times for the same key.\n\n"
+                        f"(One override sets the field to `{repr(result[key])}` "
+                        f"but another sets to `{repr(value)}`.)"
+                    )
+                try:
+                    normalized_value = ensure_str_list(value)
+                except ValueError:
+                    raise InvalidFieldException(
+                        f"The 'overrides' field in the {macro_name} macro in the BUILD file in "
+                        f"{build_file_dir} must be `dict[str | tuple[str, ...], dict[str, Any]]`, "
+                        f"but was `{repr(value)}` with type `{type(value).__name__}`."
+                    )
+                result[key] = normalized_value
+    return result

--- a/src/python/pants/backend/python/macros/caof_utils_test.py
+++ b/src/python/pants/backend/python/macros/caof_utils_test.py
@@ -1,0 +1,48 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import pytest
+
+from pants.backend.python.macros.caof_utils import flatten_overrides_to_dependency_field
+from pants.engine.target import InvalidFieldException
+
+
+def test_flatten_overrides_to_dependency_field() -> None:
+    result = flatten_overrides_to_dependency_field(
+        {
+            "d1": {"dependencies": ["a"]},
+            ("d2", "d3"): {"dependencies": {"b"}},
+            ("UnNormalized_proj"): {"dependencies": {"c"}},
+        },
+        macro_name="macro",
+        build_file_dir="dir",
+    )
+    assert result == {"d1": ["a"], "d2": ["b"], "d3": ["b"], "unnormalized-proj": ["c"]}
+
+
+def test_flatten_overrides_same_key() -> None:
+    # Invalid to specify same key multiple times.
+    with pytest.raises(InvalidFieldException):
+        flatten_overrides_to_dependency_field(
+            {"d1": {"dependencies": []}, ("d1", "d2"): {"dependencies": []}},
+            macro_name="macro",
+            build_file_dir="dir",
+        )
+
+
+def test_flatten_overrides_only_dependencies_field() -> None:
+    # Invalid to specify same key multiple times.
+    with pytest.raises(InvalidFieldException):
+        flatten_overrides_to_dependency_field(
+            {"d": {"tags": []}}, macro_name="macro", build_file_dir="dir"
+        )
+
+
+def test_flatten_overrides_basic_data_validation() -> None:
+    # Invalid to specify same key multiple times.
+    with pytest.raises(InvalidFieldException):
+        flatten_overrides_to_dependency_field(
+            {"d": {"dependencies": 1}}, macro_name="macro", build_file_dir="dir"
+        )

--- a/src/python/pants/backend/python/macros/pipenv_requirements.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements.py
@@ -10,6 +10,10 @@ from typing import Iterable, Mapping
 from packaging.utils import canonicalize_name as canonicalize_project_name
 from pkg_resources import Requirement
 
+from pants.backend.python.macros.caof_utils import (
+    OVERRIDES_TYPE,
+    flatten_overrides_to_dependency_field,
+)
 from pants.backend.python.target_types import normalize_module_mapping
 from pants.base.build_environment import get_buildroot
 from pants.base.deprecated import warn_or_error
@@ -44,6 +48,7 @@ class PipenvRequirements:
         module_mapping: Mapping[str, Iterable[str]] | None = None,
         type_stubs_module_mapping: Mapping[str, Iterable[str]] | None = None,
         pipfile_target: str | None = None,
+        overrides: OVERRIDES_TYPE = None,
     ) -> None:
         """
         :param requirements_relpath: The relpath from this BUILD file to the requirements file.
@@ -92,6 +97,10 @@ class PipenvRequirements:
         normalized_module_mapping = normalize_module_mapping(module_mapping)
         normalized_type_stubs_module_mapping = normalize_module_mapping(type_stubs_module_mapping)
 
+        dependencies_overrides = flatten_overrides_to_dependency_field(
+            overrides, macro_name="python_requirements", build_file_dir=self._parse_context.rel_path
+        )
+
         requirements = {**lock_info.get("default", {}), **lock_info.get("develop", {})}
         for req, info in requirements.items():
             extras = [x for x in info.get("extras", [])]
@@ -106,7 +115,10 @@ class PipenvRequirements:
                 "python_requirement",
                 name=parsed_req.project_name,
                 requirements=[parsed_req],
-                dependencies=[requirements_dep],
+                dependencies=[
+                    requirements_dep,
+                    *dependencies_overrides.get(normalized_proj_name, []),
+                ],
                 modules=normalized_module_mapping.get(normalized_proj_name),
                 type_stub_modules=normalized_type_stubs_module_mapping.get(normalized_proj_name),
             )


### PR DESCRIPTION
A common problem with Python requirements is undeclared dependencies, e.g. needing `setuptools` to build. Before, you would have to give up on the `python_requirements` macro and use a `python_requirement` target inline withthe `dependencies` field set.

Now, there's a convenient solution:

```python
python_requirements(
   overrides={"ansicolors": {"dependencies": [":setuptools"]}},
)
```

This emulates the same `overrides` field we added to `python_sources`, `python_tests`, `files`, etc. Unlike those, this for now only works with the `dependencies` field to keep things simple. But once we do https://github.com/pantsbuild/pants/issues/12915, we can make this more full-fledged.

[ci skip-rust]
[ci skip-build-wheels]