### PR TITLE
Remove deprecated `pex_binary` fields.

### DIFF
--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -7,7 +7,6 @@ from typing import Tuple
 
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (
-    PexAlwaysWriteCacheField,
     PexBinaryDefaults,
     PexEmitWarningsField,
     PexEntryPointField,
@@ -22,7 +21,6 @@ from pants.backend.python.target_types import (
     PexScriptField,
     PexShebangField,
     PexStripEnvField,
-    PexZipSafeField,
     PythonResolveField,
     ResolvedPexEntryPoint,
     ResolvePexEntryPointRequest,
@@ -58,12 +56,10 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
     script: PexScriptField
 
     output_path: OutputPathField
-    always_write_cache: PexAlwaysWriteCacheField
     emit_warnings: PexEmitWarningsField
     ignore_errors: PexIgnoreErrorsField
     inherit_path: PexInheritPathField
     shebang: PexShebangField
-    zip_safe: PexZipSafeField
     strip_env: PexStripEnvField
     platforms: PythonPlatformsField
     execution_mode: PexExecutionModeField

--- a/src/python/pants/backend/python/goals/run_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary_integration_test.py
@@ -15,9 +15,9 @@ from pants.testutil.pants_integration_test import PantsResult, run_pants, setup_
 @pytest.mark.parametrize(
     ("entry_point", "execution_mode", "include_tools"),
     [
-        ("app.py", PexExecutionMode.UNZIP, True),
-        ("app.py", PexExecutionMode.VENV, True),
-        ("app.py:main", PexExecutionMode.ZIPAPP, False),
+        ("app.py", None, True),
+        ("app.py", PexExecutionMode.VENV, False),
+        ("app.py:main", PexExecutionMode.ZIPAPP, True),
         ("app.py:main", None, False),
     ],
 )


### PR DESCRIPTION
This removes:
+ `zip_safe`: PEXes are now always zip safe.
+ `always_write_cache`: PEXes now always write all code to the cache.
+ `execution_mode="unzip"`: This is now the default execution mode.

Closes #12803

[ci skip-rust]
[ci skip-build-wheels]