### PR TITLE
Render dynamic UI with `prodash`

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,7 +319,7 @@ version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "atty",
  "bitflags",
  "strsim",
@@ -368,21 +377,6 @@ dependencies = [
  "prost-types",
  "serde",
  "serde_derive",
-]
-
-[[package]]
-name = "console"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "regex",
- "terminal_size",
- "unicode-width",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -518,6 +512,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crosstermion"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a700b46e8d365e505990fc24a85c42b8e7d7eb3a4203a0cc922d92f4092e854"
+dependencies = [
+ "ansi_term 0.12.1",
+ "termion",
+]
+
+[[package]]
 name = "csv"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +541,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "dashmap"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "num_cpus",
 ]
 
 [[package]]
@@ -602,12 +616,6 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
-
-[[package]]
-name = "encode_unicode"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -683,7 +691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 1.3.0",
  "log",
  "regex",
  "termcolor",
@@ -1202,6 +1210,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1289,18 +1303,6 @@ checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg 1.0.1",
  "hashbrown",
-]
-
-[[package]]
-name = "indicatif"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
-dependencies = [
- "console",
- "lazy_static",
- "number_prefix",
- "regex",
 ]
 
 [[package]]
@@ -1881,10 +1883,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
+name = "numtoa"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 
 [[package]]
 name = "once_cell"
@@ -2254,6 +2256,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "prodash"
+version = "16.0.0"
+source = "git+https://github.com/stuhood/prodash?rev=stuhood/raw-messages-draft#e885594854583c5b0a3319ad41d3a5825ed7eab5"
+dependencies = [
+ "crosstermion",
+ "dashmap",
+ "humantime 2.1.0",
+ "parking_lot",
+ "unicode-width",
+ "vte",
+]
+
+[[package]]
 name = "prost"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2612,6 +2627,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_termios"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
+dependencies = [
+ "redox_syscall 0.2.10",
 ]
 
 [[package]]
@@ -3247,13 +3271,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "terminal_size"
-version = "0.1.15"
+name = "termion"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd2d183bd3fac5f5fe38ddbeb4dc9aec4a39a9d7d59e7491d900302da01cbe1"
+checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "numtoa",
+ "redox_syscall 0.2.10",
+ "redox_termios",
 ]
 
 [[package]]
@@ -3581,12 +3607,10 @@ checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 name = "ui"
 version = "0.0.1"
 dependencies = [
- "console",
  "futures",
- "indexmap",
- "indicatif",
  "logging",
  "parking_lot",
+ "prodash",
  "stdio",
  "task_executor",
  "uuid",
@@ -3688,6 +3712,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
+
+[[package]]
 name = "uuid"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3713,6 +3743,27 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "vte"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
+dependencies = [
+ "arrayvec",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
+dependencies = [
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+]
 
 [[package]]
 name = "walkdir"

--- a/src/rust/engine/ui/Cargo.toml
+++ b/src/rust/engine/ui/Cargo.toml
@@ -8,10 +8,9 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 path = "src/console_ui.rs"
 
 [dependencies]
-console = "0.15.0"
 futures = "0.3"
-indexmap = "1.4"
-indicatif = "0.16.2"
+# TODO: See https://github.com/Byron/prodash/pull/9.
+prodash = { git = "https://github.com/stuhood/prodash", rev = 'stuhood/raw-messages-draft', version = "16", default-features = false, features = ["progress-tree", "render-line", "render-line-termion"] }
 logging = { path = "../logging" }
 parking_lot = "0.11"
 stdio = { path = "../stdio" }

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -785,9 +785,11 @@ impl WorkunitStore {
   }
 }
 
-pub fn format_workunit_duration(duration: Duration) -> String {
-  let duration_secs: f64 = (duration.as_millis() as f64) / 1000.0;
-  format!("{:.2}s ", duration_secs)
+#[macro_export]
+macro_rules! format_workunit_duration_ms {
+  ($workunit_duration_ms:expr) => {{
+    format_args!("{:.2}s", ($workunit_duration_ms as f64) / 1000.0)
+  }};
 }
 
 ///

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -26,6 +26,7 @@
 #![allow(clippy::mutex_atomic)]
 
 use std::cell::RefCell;
+use std::cmp::Reverse;
 use std::collections::hash_map::Entry;
 use std::collections::{BinaryHeap, HashMap};
 use std::future::Future;
@@ -425,23 +426,24 @@ impl HeavyHittersData {
     }
   }
 
-  fn heavy_hitters(&self, k: usize) -> HashMap<SpanId, (String, Option<Duration>)> {
+  fn heavy_hitters(&self, k: usize) -> HashMap<SpanId, (String, SystemTime)> {
     self.refresh_store();
 
-    let now = SystemTime::now();
     let inner = self.inner.lock();
 
-    // Initialize the heap with the leaves of the running workunit graph.
-    let mut queue: BinaryHeap<(Duration, SpanId)> = inner
+    // Initialize the heap with the leaves of the running workunit graph, sorted oldest first.
+    let mut queue: BinaryHeap<(Reverse<SystemTime>, SpanId)> = inner
       .running_graph
       .externals(petgraph::Direction::Outgoing)
       .map(|entry| inner.running_graph[entry])
       .flat_map(|span_id: SpanId| {
-        let workunit: Option<&Workunit> = inner.workunit_records.get(&span_id);
-        match workunit {
-          Some(workunit) if !workunit.state.blocked() => {
-            Self::duration_for(now, workunit).map(|d| (d, span_id))
-          }
+        let workunit: &Workunit = inner.workunit_records.get(&span_id)?;
+        match workunit.state {
+          WorkunitState::Started {
+            ref blocked,
+            start_time,
+            ..
+          } if !blocked.load(atomic::Ordering::Relaxed) => Some((Reverse(start_time), span_id)),
           _ => None,
         }
       })
@@ -451,17 +453,21 @@ impl HeavyHittersData {
     let mut res = HashMap::new();
     while let Some((_dur, span_id)) = queue.pop() {
       // If the leaf is visible or has a visible parent, emit it.
-      if let Some(span_id) = first_matched_parent(
+      let parent_span_id = if let Some(span_id) = first_matched_parent(
         &inner.workunit_records,
         Some(span_id),
         |wu| wu.state.completed(),
         Self::is_visible,
       ) {
-        let workunit = inner.workunit_records.get(&span_id).unwrap();
-        if let Some(effective_name) = workunit.metadata.desc.as_ref() {
-          let maybe_duration = Self::duration_for(now, workunit);
+        span_id
+      } else {
+        continue;
+      };
 
-          res.insert(span_id, (effective_name.to_string(), maybe_duration));
+      let workunit = inner.workunit_records.get(&parent_span_id).unwrap();
+      if let Some(effective_name) = workunit.metadata.desc.as_ref() {
+        if let Some(start_time) = Self::start_time_for(workunit) {
+          res.insert(parent_span_id, (effective_name.to_string(), start_time));
           if res.len() >= k {
             break;
           }
@@ -516,11 +522,15 @@ impl HeavyHittersData {
       && matches!(workunit.state, WorkunitState::Started { .. })
   }
 
-  fn duration_for(now: SystemTime, workunit: &Workunit) -> Option<Duration> {
+  fn start_time_for(workunit: &Workunit) -> Option<SystemTime> {
     match workunit.state {
-      WorkunitState::Started { ref start_time, .. } => now.duration_since(*start_time).ok(),
+      WorkunitState::Started { start_time, .. } => Some(start_time),
       _ => None,
     }
+  }
+
+  fn duration_for(now: SystemTime, workunit: &Workunit) -> Option<Duration> {
+    now.duration_since(Self::start_time_for(workunit)?).ok()
   }
 }
 
@@ -586,9 +596,10 @@ impl WorkunitStore {
   }
 
   ///
-  /// Find the longest running leaf workunits, and return their first visible parents.
+  /// Find the longest running leaf workunits, and return the description and start time of their
+  /// first visible parents.
   ///
-  pub fn heavy_hitters(&self, k: usize) -> HashMap<SpanId, (String, Option<Duration>)> {
+  pub fn heavy_hitters(&self, k: usize) -> HashMap<SpanId, (String, SystemTime)> {
     self.heavy_hitters_data.heavy_hitters(k)
   }
 


### PR DESCRIPTION
Switches to rendering the `--dynamic-ui` with [`prodash`](https://docs.rs/prodash/16.0.0/prodash/). Although `prodash` has fewer users than `indicatif`, the documentation and internals are very solid, and the project maintainer is highly responsive. `prodash`'s conceptual model is also a much closer fit for our workunits: its core data model is a tree, which naturally allows for rendering workunit hierarchy, and dynamically adding and removing tasks.

This change would resolve #13367 by adjusting the number of swimlanes dynamically. But it would also pave a clear path to #11965 to both render task progress via gauges (to show e.g. download progress, or the expected runtime of processes), and potentially by rendering either a child workunit, or the last line of output for long-running tasks as a child of a task.

[![asciicast](https://asciinema.org/a/AQJUBDvZQz15Ef3ZQngYF34iz.svg)](https://asciinema.org/a/AQJUBDvZQz15Ef3ZQngYF34iz)