### PR TITLE
Skip capture of `TRACE` workunits by default

### DIFF
--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -34,9 +34,8 @@ restricted_token_matches =  """{
   'GITHUB_REPOSITORY': 'pantsbuild/pants', 
 }"""
 
-#[buildsense]
-# TODO: Re-enable before landing once workunit format is confirmed stable.
-# enable = true
+[buildsense]
+enable = true
 
 [subprocess-environment]
 env_vars.add = [

--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -34,8 +34,9 @@ restricted_token_matches =  """{
   'GITHUB_REPOSITORY': 'pantsbuild/pants', 
 }"""
 
-[buildsense]
-enable = true
+#[buildsense]
+# TODO: Re-enable before landing once workunit format is confirmed stable.
+# enable = true
 
 [subprocess-environment]
 env_vars.add = [

--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -62,7 +62,6 @@ from pants.engine.unions import UnionMembership, UnionRule
 from pants.source.source_root import SourceRoot, SourceRootRequest
 from pants.util.docutil import doc_url
 from pants.util.frozendict import FrozenDict
-from pants.util.logging import LogLevel
 from pants.util.ordered_set import OrderedSet
 
 logger = logging.getLogger(__name__)
@@ -136,7 +135,7 @@ async def generate_targets_from_pex_binaries(
 # -----------------------------------------------------------------------------------------------
 
 
-@rule(desc="Determining the entry point for a `pex_binary` target", level=LogLevel.DEBUG)
+@rule(desc="Determining the entry point for a `pex_binary` target")
 async def resolve_pex_entry_point(request: ResolvePexEntryPointRequest) -> ResolvedPexEntryPoint:
     ep_val = request.entry_point_field.value
     if ep_val is None:
@@ -266,7 +265,7 @@ def _classify_entry_points(
             )
 
 
-@rule(desc="Determining the entry points for a `python_distribution` target", level=LogLevel.DEBUG)
+@rule(desc="Determining the entry points for a `python_distribution` target")
 async def resolve_python_distribution_entry_points(
     request: ResolvePythonDistributionEntryPointsRequest,
 ) -> ResolvedPythonDistributionEntryPoints:

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -34,6 +34,7 @@ from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.util.collections import deep_getsizeof
 from pants.util.contextutil import maybe_profiled
+from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
 
@@ -90,7 +91,10 @@ class LocalPantsRunner:
             max_workunit_level=max(
                 global_options.streaming_workunits_level,
                 global_options.level,
-                *global_options.log_levels_by_target.values(),
+                *(
+                    LogLevel[level.upper()]
+                    for level in global_options.log_levels_by_target.values()
+                ),
             ),
             session_values=SessionValues(
                 {

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -281,6 +281,7 @@ class LocalPantsRunner:
                 allow_async_completion=(
                     global_options.pantsd and global_options.streaming_workunits_complete_async
                 ),
+                max_workunit_verbosity=global_options.streaming_workunits_level,
             )
             with streaming_reporter:
                 engine_result = PANTS_FAILED_EXIT_CODE

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -87,7 +87,11 @@ class LocalPantsRunner:
             ui_use_prodash=global_options.dynamic_ui_renderer
             == DynamicUIRenderer.experimental_prodash,
             use_colors=global_options.get("colors", True),
-            max_workunit_level=max(global_options.streaming_workunits_level, global_options.level),
+            max_workunit_level=max(
+                global_options.streaming_workunits_level,
+                global_options.level,
+                *global_options.log_levels_by_target.values(),
+            ),
             session_values=SessionValues(
                 {
                     OptionsBootstrapper: options_bootstrapper,

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -87,6 +87,7 @@ class LocalPantsRunner:
             ui_use_prodash=global_options.dynamic_ui_renderer
             == DynamicUIRenderer.experimental_prodash,
             use_colors=global_options.get("colors", True),
+            max_workunit_level=max(global_options.streaming_workunits_level, global_options.level),
             session_values=SessionValues(
                 {
                     OptionsBootstrapper: options_bootstrapper,

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -344,6 +344,7 @@ class PySession:
         scheduler: PyScheduler,
         dynamic_ui: bool,
         ui_use_prodash: bool,
+        max_workunit_level: int,
         build_id: str,
         session_values: SessionValues,
         cancellation_latch: PySessionCancellationLatch,

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -308,6 +308,7 @@ class Scheduler:
         build_id: str,
         dynamic_ui: bool = False,
         ui_use_prodash: bool = False,
+        max_workunit_level: LogLevel = LogLevel.DEBUG,
         session_values: SessionValues | None = None,
         cancellation_latch: PySessionCancellationLatch | None = None,
     ) -> SchedulerSession:
@@ -318,6 +319,7 @@ class Scheduler:
                 scheduler=self.py_scheduler,
                 dynamic_ui=dynamic_ui,
                 ui_use_prodash=ui_use_prodash,
+                max_workunit_level=max_workunit_level.level,
                 build_id=build_id,
                 session_values=session_values or SessionValues(),
                 cancellation_latch=cancellation_latch or PySessionCancellationLatch(),

--- a/src/python/pants/engine/internals/scheduler_test_base.py
+++ b/src/python/pants/engine/internals/scheduler_test_base.py
@@ -10,12 +10,13 @@ from pants.engine.unions import UnionMembership
 from pants.option.global_options import DEFAULT_EXECUTION_OPTIONS, DEFAULT_LOCAL_STORE_OPTIONS
 from pants.util.contextutil import temporary_file_path
 from pants.util.dirutil import safe_mkdtemp
+from pants.util.logging import LogLevel
 
 
 class SchedulerTestBase:
-    """A mixin for classes (tests, presumably) which need to create temporary schedulers.
+    """A mixin for classes which need to create temporary schedulers.
 
-    TODO: In the medium term, this should be part of pants_test.test_base.TestBase.
+    TODO: In the medium term, this should be removed in favor of RuleRunner.
     """
 
     _executor = PyExecutor(core_threads=2, max_threads=4)
@@ -25,6 +26,7 @@ class SchedulerTestBase:
         tmp_path: Path,
         rules,
         include_trace_on_error: bool = True,
+        max_workunit_verbosity: LogLevel = LogLevel.DEBUG,
     ) -> SchedulerSession:
         """Creates a SchedulerSession for a Scheduler with the given Rules installed."""
 
@@ -49,6 +51,7 @@ class SchedulerTestBase:
         )
         return scheduler.new_session(
             build_id="buildid_for_test",
+            max_workunit_level=max_workunit_verbosity,
         )
 
     def execute(self, scheduler, product, *subjects):

--- a/src/python/pants/engine/streaming_workunit_handler.py
+++ b/src/python/pants/engine/streaming_workunit_handler.py
@@ -186,7 +186,7 @@ class StreamingWorkunitHandler:
         specs: Specs,
         report_interval_seconds: float,
         allow_async_completion: bool,
-        max_workunit_verbosity: LogLevel = LogLevel.TRACE,
+        max_workunit_verbosity: LogLevel,
     ) -> None:
         scheduler = scheduler.isolated_shallow_clone("streaming_workunit_handler_session")
         self.callbacks = callbacks

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -39,6 +39,7 @@ from pants.option.global_options import (
 )
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.subsystem import Subsystem
+from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.vcs.changed import rules as changed_rules
 
@@ -58,6 +59,7 @@ class GraphScheduler:
         dynamic_ui: bool = False,
         ui_use_prodash: bool = False,
         use_colors=True,
+        max_workunit_level: LogLevel = LogLevel.DEBUG,
         session_values: SessionValues | None = None,
         cancellation_latch: PySessionCancellationLatch | None = None,
     ) -> GraphSession:
@@ -65,6 +67,7 @@ class GraphScheduler:
             build_id,
             dynamic_ui,
             ui_use_prodash,
+            max_workunit_level=max_workunit_level,
             session_values=session_values,
             cancellation_latch=cancellation_latch,
         )

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1444,11 +1444,11 @@ class GlobalOptions(Subsystem):
         "--streaming-workunits-level",
         default=LogLevel.DEBUG,
         help=(
-            "The Level of workunits that will be reported to streaming workunit event "
+            "The level of workunits that will be reported to streaming workunit event "
             "receivers.\n\n"
-            "The filtering of workunits that occurs at higher levels is tree-aware: parent "
-            "pointers are fixed up when workunits are filtered such that the resulting workunits "
-            "always form a tree."
+            "Workunits form a tree, and even when workunits are filtered out by this setting, the "
+            "workunit tree structure will be preserved (by adjusting the parent pointers of the "
+            "remaining workunits)."
         ),
         advanced=True,
     )

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1440,6 +1440,18 @@ class GlobalOptions(Subsystem):
         help="Interval in seconds between when streaming workunit event receivers will be polled.",
         advanced=True,
     )
+    streaming_workunits_level = EnumOption(
+        "--streaming-workunits-level",
+        default=LogLevel.DEBUG,
+        help=(
+            "The Level of workunits that will be reported to streaming workunit event "
+            "receivers.\n\n"
+            "The filtering of workunits that occurs at higher levels is tree-aware: parent "
+            "pointers are fixed up when workunits are filtered such that the resulting workunits "
+            "always form a tree."
+        ),
+        advanced=True,
+    )
     streaming_workunits_complete_async = BoolOption(
         "--streaming-workunits-complete-async",
         default=not is_in_container(),

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -190,6 +190,7 @@ class RuleRunner:
         bootstrap_args: Iterable[str] = (),
         use_deprecated_python_macros: bool = False,
         extra_session_values: dict[Any, Any] | None = None,
+        max_workunit_verbosity: LogLevel = LogLevel.DEBUG,
     ) -> None:
 
         bootstrap_args = [*bootstrap_args]
@@ -272,6 +273,7 @@ class RuleRunner:
                     **(extra_session_values or {}),
                 }
             ),
+            max_workunit_level=max_workunit_verbosity,
         )
         self.scheduler = graph_session.scheduler_session
 

--- a/src/python/pants/util/logging.py
+++ b/src/python/pants/util/logging.py
@@ -5,12 +5,21 @@ from __future__ import annotations
 
 import logging
 from enum import Enum
+from functools import total_ordering
 
 # A custom log level for pants trace logging.
 TRACE = 5
 
 
+@total_ordering
 class LogLevel(Enum):
+    """Exposes an enum of the Python `logging` module's levels, with the addition of TRACE.
+
+    NB: The `logging` module uses the opposite integer ordering of levels from Rust's `log` crate,
+    but the ordering implementation of this enum inverts its comparison to make its ordering align
+    with Rust's.
+    """
+
     TRACE = ("trace", TRACE)
     DEBUG = ("debug", logging.DEBUG)
     INFO = ("info", logging.INFO)
@@ -34,3 +43,8 @@ class LogLevel(Enum):
 
     def set_level_for(self, logger: logging.Logger):
         logger.setLevel(self.level)
+
+    def __lt__(self, other):
+        if not isinstance(other, LogLevel):
+            return NotImplemented
+        return self._level > other._level

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -648,7 +648,7 @@ pub struct Context {
 impl Default for Context {
   fn default() -> Self {
     Context {
-      workunit_store: WorkunitStore::new(false),
+      workunit_store: WorkunitStore::new(false, log::Level::Debug),
       build_id: String::default(),
       run_id: RunId(0),
     }

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -651,7 +651,7 @@ pub async fn prepare_workdir(
     context.workunit_store.clone(),
     "setup_sandbox".to_owned(),
     WorkunitMetadata {
-      level: Level::Trace,
+      level: Level::Debug,
       ..WorkunitMetadata::default()
     },
     |_workunit| async move {

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -999,7 +999,7 @@ async fn sends_headers() {
   )
   .unwrap();
   let context = Context {
-    workunit_store: WorkunitStore::new(false),
+    workunit_store: WorkunitStore::new(false, log::Level::Debug),
     build_id: String::from("marmosets"),
     run_id: RunId(0),
   };

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -210,7 +210,7 @@ struct Opt {
 #[tokio::main]
 async fn main() {
   env_logger::init();
-  let workunit_store = WorkunitStore::new(false);
+  let workunit_store = WorkunitStore::new(false, log::Level::Debug);
   workunit_store.init_thread_state(None);
 
   let args = Opt::from_args();

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -354,6 +354,7 @@ impl PySession {
     scheduler: &PyScheduler,
     dynamic_ui: bool,
     ui_use_prodash: bool,
+    max_workunit_level: u64,
     build_id: String,
     session_values: PyObject,
     cancellation_latch: &PySessionCancellationLatch,
@@ -361,6 +362,9 @@ impl PySession {
   ) -> PyO3Result<Self> {
     let core = scheduler.0.core.clone();
     let cancellation_latch = cancellation_latch.0.clone();
+    let py_level: PythonLogLevel = max_workunit_level
+      .try_into()
+      .map_err(|e| PyException::new_err(format!("{e}")))?;
     // NB: Session creation interacts with the Graph, which must not be accessed while the GIL is
     // held.
     let session = py
@@ -369,6 +373,7 @@ impl PySession {
           core,
           dynamic_ui,
           ui_use_prodash,
+          py_level.into(),
           build_id,
           session_values,
           cancellation_latch,

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -848,32 +848,19 @@ pub fn _start_workunit(
 
 #[macro_export]
 macro_rules! in_workunit {
-    ($workunit_store: expr, $workunit_name: expr, $workunit_metadata: expr, |$workunit: ident| async move { $( $body:tt )* $(,)? }) => (
-      {
-        let (store_handle, mut $workunit) = $crate::_start_workunit($workunit_store, $workunit_name, $workunit_metadata);
-        $crate::scope_task_workunit_store_handle(Some(store_handle), async move {
-          let result = {
-            let $workunit = &mut $workunit;
-            async move { $( $body )* }
-          }.await;
-          $workunit.complete();
-          result
-        })
+  ($workunit_store: expr, $workunit_name: expr, $workunit_metadata: expr, |$workunit: ident| $f: expr $(,)?) => {{
+    let (store_handle, mut $workunit) =
+      $crate::_start_workunit($workunit_store, $workunit_name, $workunit_metadata);
+    $crate::scope_task_workunit_store_handle(Some(store_handle), async move {
+      let result = {
+        let $workunit = &mut $workunit;
+        $f
       }
-    );
-  ($workunit_store: expr, $workunit_name: expr, $workunit_metadata: expr, |$workunit: ident| $f: expr $(,)?) => (
-    {
-      let (store_handle, mut $workunit) = $crate::_start_workunit($workunit_store, $workunit_name, $workunit_metadata);
-      $crate::scope_task_workunit_store_handle(Some(store_handle), async move {
-          let result = {
-            let $workunit = &mut $workunit;
-            $f
-          }.await;
-          $workunit.complete();
-          result
-        })
-    }
-  );
+      .await;
+      $workunit.complete();
+      result
+    })
+  }};
 }
 
 pub struct RunningWorkunit {

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -231,6 +231,7 @@ enum StoreMsg {
 #[derive(Clone)]
 pub struct WorkunitStore {
   log_starting_workunits: bool,
+  max_level: Level,
   streaming_workunit_data: StreamingWorkunitData,
   heavy_hitters_data: HeavyHittersData,
   metrics_data: Arc<MetricsData>,
@@ -555,9 +556,10 @@ fn first_matched_parent(
 }
 
 impl WorkunitStore {
-  pub fn new(log_starting_workunits: bool) -> WorkunitStore {
+  pub fn new(log_starting_workunits: bool, max_level: Level) -> WorkunitStore {
     WorkunitStore {
       log_starting_workunits,
+      max_level,
       // TODO: Create one `StreamingWorkunitData` per subscriber, and zero if no subscribers are
       // installed.
       streaming_workunit_data: StreamingWorkunitData::new(),
@@ -571,6 +573,10 @@ impl WorkunitStore {
       store: self.clone(),
       parent_id,
     }))
+  }
+
+  pub fn max_level(&self) -> Level {
+    self.max_level
   }
 
   ///
@@ -770,7 +776,7 @@ impl WorkunitStore {
   }
 
   pub fn setup_for_tests() -> (WorkunitStore, RunningWorkunit) {
-    let store = WorkunitStore::new(false);
+    let store = WorkunitStore::new(false, Level::Debug);
     store.init_thread_state(None);
     let workunit = store.start_workunit(
       SpanId(0),
@@ -778,7 +784,7 @@ impl WorkunitStore {
       None,
       WorkunitMetadata::default(),
     );
-    (store.clone(), RunningWorkunit::new(store, workunit))
+    (store.clone(), RunningWorkunit::new(store, Some(workunit)))
   }
 }
 
@@ -835,31 +841,52 @@ pub fn expect_workunit_store_handle() -> WorkunitStoreHandle {
 /// NB: Public for macro usage: use the `in_workunit!` macro.
 ///
 pub fn _start_workunit(
-  workunit_store: WorkunitStore,
+  store_handle: &mut WorkunitStoreHandle,
   name: String,
   initial_metadata: WorkunitMetadata,
-) -> (WorkunitStoreHandle, RunningWorkunit) {
-  let mut store_handle = expect_workunit_store_handle();
+) -> RunningWorkunit {
   let span_id = SpanId::new();
   let parent_id = std::mem::replace(&mut store_handle.parent_id, Some(span_id));
-  let workunit = workunit_store.start_workunit(span_id, name, parent_id, initial_metadata);
-  (store_handle, RunningWorkunit::new(workunit_store, workunit))
+  let workunit = store_handle
+    .store
+    .start_workunit(span_id, name, parent_id, initial_metadata);
+  RunningWorkunit::new(store_handle.store.clone(), Some(workunit))
 }
 
 #[macro_export]
 macro_rules! in_workunit {
   ($workunit_store: expr, $workunit_name: expr, $workunit_metadata: expr, |$workunit: ident| $f: expr $(,)?) => {{
-    let (store_handle, mut $workunit) =
-      $crate::_start_workunit($workunit_store, $workunit_name, $workunit_metadata);
-    $crate::scope_task_workunit_store_handle(Some(store_handle), async move {
-      let result = {
-        let $workunit = &mut $workunit;
-        $f
+    // TODO: The workunit store argument is unused: remove in separate patch.
+    std::mem::drop($workunit_store);
+
+    use futures::future::FutureExt;
+    let mut store_handle = $crate::expect_workunit_store_handle();
+    // TODO: Move Level out of the metadata to allow skipping construction if disabled.
+    let workunit_metadata = $workunit_metadata;
+    if store_handle.store.max_level() >= workunit_metadata.level {
+      let mut $workunit =
+        $crate::_start_workunit(&mut store_handle, $workunit_name, workunit_metadata);
+      $crate::scope_task_workunit_store_handle(Some(store_handle), async move {
+        let result = {
+          let $workunit = &mut $workunit;
+          $f
+        }
+        .await;
+        $workunit.complete();
+        result
+      })
+      .boxed()
+    } else {
+      async move {
+        let mut $workunit = $crate::RunningWorkunit::new(store_handle.store, None);
+        {
+          let $workunit = &mut $workunit;
+          $f
+        }
+        .await
       }
-      .await;
-      $workunit.complete();
-      result
-    })
+      .boxed()
+    }
   }};
 }
 
@@ -869,11 +896,8 @@ pub struct RunningWorkunit {
 }
 
 impl RunningWorkunit {
-  fn new(store: WorkunitStore, workunit: Workunit) -> RunningWorkunit {
-    RunningWorkunit {
-      store,
-      workunit: Some(workunit),
-    }
+  pub fn new(store: WorkunitStore, workunit: Option<Workunit>) -> RunningWorkunit {
+    RunningWorkunit { store, workunit }
   }
 
   pub fn increment_counter(&mut self, counter_name: Metric, change: u64) {

--- a/src/rust/engine/workunit_store/src/tests.rs
+++ b/src/rust/engine/workunit_store/src/tests.rs
@@ -92,7 +92,7 @@ fn create_store(
     .iter()
     .map(|(span_id, _, _)| *span_id)
     .collect::<HashSet<_>>();
-  let ws = WorkunitStore::new(true);
+  let ws = WorkunitStore::new(true, log::Level::Debug);
 
   // Collect and sort by SpanId.
   let mut all = started


### PR DESCRIPTION
Currently, workunits are captured and stored (in memory, but also via any `StreamingWorkunitHandler` callbacks), regardless of their level. But in many cases, this results in tens of thousands of workunits, only a fraction of which will ever be consumed.

For some runs, the ratio between `TRACE` workunits and all other workunits (`DEBUG`, etc) is `16` to `1`... meaning that disabling `TRACE` by default results in significantly less data being captured (and less CPU usage as well).

In order to continue to support capturing finer grained details, the `WorkunitStore` is adjusted to capture only what is required by:
1. the `--dynamic-ui`, if it is enabled
2. a new `--streaming-workunits-level` option
3. the log `--level` option
4. the `--log-levels-by-target` values

Microbenchmarks show about a 5% improvement (for `hyperfine -w 2 './pants test --force --no-pytest-timeouts src/python/pants/engine/internals/engine_benchmarks_test.py'`), and an 11-15% reduction in memory usage for `./pants dependencies --transitive ::`.

[ci skip-build-wheels]