### PR TITLE
Go: improve performance of first-party package analysis (Cherry-pick of #13476)

### DIFF
--- a/src/python/pants/backend/go/goals/check_test.py
+++ b/src/python/pants/backend/go/goals/check_test.py
@@ -18,6 +18,7 @@ from pants.backend.go.util_rules import (
     first_party_pkg,
     go_mod,
     import_analysis,
+    link,
     sdk,
     third_party_pkg,
 )
@@ -36,6 +37,7 @@ def rule_runner() -> RuleRunner:
             *build_pkg.rules(),
             *build_pkg_target.rules(),
             *import_analysis.rules(),
+            *link.rules(),
             *go_mod.rules(),
             *first_party_pkg.rules(),
             *third_party_pkg.rules(),

--- a/src/python/pants/backend/go/goals/tailor_test.py
+++ b/src/python/pants/backend/go/goals/tailor_test.py
@@ -9,7 +9,16 @@ from pants.backend.go import target_type_rules
 from pants.backend.go.goals.tailor import PutativeGoTargetsRequest, has_package_main
 from pants.backend.go.goals.tailor import rules as go_tailor_rules
 from pants.backend.go.target_types import GoBinaryTarget, GoModTarget
-from pants.backend.go.util_rules import first_party_pkg, go_mod, sdk, third_party_pkg
+from pants.backend.go.util_rules import (
+    assembly,
+    build_pkg,
+    build_pkg_target,
+    first_party_pkg,
+    go_mod,
+    link,
+    sdk,
+    third_party_pkg,
+)
 from pants.core.goals.tailor import (
     AllOwnedSources,
     PutativeTarget,
@@ -30,6 +39,10 @@ def rule_runner() -> RuleRunner:
             *third_party_pkg.rules(),
             *sdk.rules(),
             *target_type_rules.rules(),
+            *build_pkg.rules(),
+            *build_pkg_target.rules(),
+            *assembly.rules(),
+            *link.rules(),
             QueryRule(PutativeTargets, [PutativeGoTargetsRequest, AllOwnedSources]),
         ],
         target_types=[GoModTarget, GoBinaryTarget],

--- a/src/python/pants/backend/go/goals/test_test.py
+++ b/src/python/pants/backend/go/goals/test_test.py
@@ -238,12 +238,12 @@ def test_internal_test_fails_to_compile(rule_runner: RuleRunner) -> None:
     tgt = rule_runner.get_target(Address("foo", generated_name="./"))
     result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
     assert result.exit_code == 1
-    assert result.stderr == "bad_test.go:1:1: expected 'package', found invalid\n"
+    assert "bad_test.go:1:1: expected 'package', found invalid\n" in result.stderr
 
     tgt = rule_runner.get_target(Address("foo", generated_name="./uses_dep"))
     result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
     assert result.exit_code == 1
-    assert result.stderr == "dep/f.go:1:1: expected 'package', found invalid\n"
+    assert "dep/f.go:1:1: expected 'package', found invalid\n" in result.stderr
 
 
 def test_external_test_success(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
@@ -12,7 +12,15 @@ from pants.backend.go.lint import fmt
 from pants.backend.go.lint.gofmt.rules import GofmtFieldSet, GofmtRequest
 from pants.backend.go.lint.gofmt.rules import rules as gofmt_rules
 from pants.backend.go.target_types import GoModTarget
-from pants.backend.go.util_rules import first_party_pkg, go_mod, sdk, third_party_pkg
+from pants.backend.go.util_rules import (
+    assembly,
+    build_pkg,
+    first_party_pkg,
+    go_mod,
+    link,
+    sdk,
+    third_party_pkg,
+)
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintResult, LintResults
 from pants.core.util_rules import source_files
@@ -36,6 +44,9 @@ def rule_runner() -> RuleRunner:
             *third_party_pkg.rules(),
             *sdk.rules(),
             *go_mod.rules(),
+            *build_pkg.rules(),
+            *link.rules(),
+            *assembly.rules(),
             QueryRule(LintResults, (GofmtRequest,)),
             QueryRule(FmtResult, (GofmtRequest,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),

--- a/src/python/pants/backend/go/target_type_rules_test.py
+++ b/src/python/pants/backend/go/target_type_rules_test.py
@@ -26,7 +26,15 @@ from pants.backend.go.target_types import (
     GoModTarget,
     GoThirdPartyPackageTarget,
 )
-from pants.backend.go.util_rules import first_party_pkg, go_mod, sdk, third_party_pkg
+from pants.backend.go.util_rules import (
+    assembly,
+    build_pkg,
+    first_party_pkg,
+    go_mod,
+    link,
+    sdk,
+    third_party_pkg,
+)
 from pants.base.exceptions import ResolveError
 from pants.build_graph.address import Address
 from pants.core.target_types import GenericTarget
@@ -58,6 +66,9 @@ def rule_runner() -> RuleRunner:
             *third_party_pkg.rules(),
             *sdk.rules(),
             *target_type_rules.rules(),
+            *build_pkg.rules(),
+            *link.rules(),
+            *assembly.rules(),
             QueryRule(Addresses, [DependenciesRequest]),
             QueryRule(GoBinaryMainPackage, [GoBinaryMainPackageRequest]),
             QueryRule(InjectedDependencies, [InjectGoBinaryMainDependencyRequest]),

--- a/src/python/pants/backend/go/util_rules/BUILD
+++ b/src/python/pants/backend/go/util_rules/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_sources(dependencies=[":analyzer_sources"])
+python_sources(dependencies=[":go_sources"])
 python_tests(name="tests", timeout=120)
 
-resource(name="analyzer_sources", source="generate_testmain.go")
+resources(name="go_sources", sources=["*.go"])

--- a/src/python/pants/backend/go/util_rules/analyze_package.go
+++ b/src/python/pants/backend/go/util_rules/analyze_package.go
@@ -1,0 +1,339 @@
+/* Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+/*
+ * Analyze a Go package for imports and other metadata.
+ *
+ * Note: `go list` can return this data but requires the full set of dependencies to be available. It is much
+ * better for performance to not copy those dependencies into the input root. Hence doing this analysis here.
+ *
+ * Loosely based on the analysis in the go/build stdlib module.
+ * See https://cs.opensource.google/go/go/+/refs/tags/go1.17.2:src/go/build/build.go;drc=refs%2Ftags%2Fgo1.17.2;l=512.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"go/build"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Package represents the results of analyzing a Go package.
+type Package struct {
+	Name string // package name
+
+	// Source files
+	GoFiles           []string `json:",omitempty"` // .go source files (excluding CgoFiles, TestGoFiles, XTestGoFiles)
+	CgoFiles          []string `json:",omitempty"` // .go source files that import "C"
+	IgnoredGoFiles    []string `json:",omitempty"` // .go source files ignored for this build (including ignored _test.go files)
+	IgnoredOtherFiles []string `json:",omitempty"` // non-.go source files ignored for this build
+	CFiles            []string `json:",omitempty"` // .c source files
+	CXXFiles          []string `json:",omitempty"` // .cc, .cpp and .cxx source files
+	MFiles            []string `json:",omitempty"` // .m (Objective-C) source files
+	HFiles            []string `json:",omitempty"` // .h, .hh, .hpp and .hxx source files
+	FFiles            []string `json:",omitempty"` // .f, .F, .for and .f90 Fortran source files
+	SFiles            []string `json:",omitempty"` // .s source files
+	SwigFiles         []string `json:",omitempty"` // .swig files
+	SwigCXXFiles      []string `json:",omitempty"` // .swigcxx files
+	SysoFiles         []string `json:",omitempty"` // .syso system object files to add to archive
+
+	// Test information
+	TestGoFiles  []string `json:",omitempty"`
+	XTestGoFiles []string `json:",omitempty"`
+
+	// Dependency information
+	// Note: This does not include the token position information for the imports.
+	Imports      []string `json:",omitempty"`
+	TestImports  []string `json:",omitempty"`
+	XTestImports []string `json:",omitempty"`
+
+	// //go:embed patterns found in Go source files
+	// For example, if a source file says
+	//	//go:embed a* b.c
+	// then the list will contain those two strings as separate entries.
+	// (See package embed for more details about //go:embed.)
+	EmbedPatterns      []string `json:",omitempty"` // patterns from GoFiles, CgoFiles
+	TestEmbedPatterns  []string `json:",omitempty"` // patterns from TestGoFiles
+	XTestEmbedPatterns []string `json:",omitempty"` // patterns from XTestGoFiles
+
+	// Error information. This differs from how `go list` reports errors.
+	InvalidGoFiles map[string]string `json:",omitempty"`
+	Error          string            `json:",omitempty"`
+}
+
+type fileAnalysis struct {
+	Name    string
+	Imports []string
+}
+
+func analyzeFile(fileSet *token.FileSet, filename string) (*fileAnalysis, error) {
+	parsed, err := parser.ParseFile(fileSet, filename, nil, parser.ImportsOnly|parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+
+	analysis := &fileAnalysis{}
+
+	analysis.Name = parsed.Name.Name
+	for _, spec := range parsed.Imports {
+		importPath, err := strconv.Unquote(spec.Path.Value)
+		if err != nil {
+			return nil, fmt.Errorf("unable to decode import %s in %s", spec.Path.Value, filename)
+		}
+		analysis.Imports = append(analysis.Imports, importPath)
+	}
+
+	return analysis, nil
+}
+
+// Copied from https://cs.opensource.google/go/go/+/refs/tags/go1.17.2:src/go/build/build.go;l=1024;drc=refs%2Ftags%2Fgo1.17.2
+func fileListForExt(p *Package, ext string) *[]string {
+	switch ext {
+	case ".c":
+		return &p.CFiles
+	case ".cc", ".cpp", ".cxx":
+		return &p.CXXFiles
+	case ".m":
+		return &p.MFiles
+	case ".h", ".hh", ".hpp", ".hxx":
+		return &p.HFiles
+	case ".f", ".F", ".for", ".f90":
+		return &p.FFiles
+	case ".s", ".S", ".sx":
+		return &p.SFiles
+	case ".swig":
+		return &p.SwigFiles
+	case ".swigcxx":
+		return &p.SwigCXXFiles
+	case ".syso":
+		return &p.SysoFiles
+	}
+	return nil
+}
+
+func cleanImports(importsMap map[string]bool) []string {
+	var imports []string
+	for importPath, _ := range importsMap {
+		imports = append(imports, importPath)
+	}
+	sort.Strings(imports)
+	return imports
+}
+
+func analyzePackage(directory string, buildContext *build.Context) (*Package, error) {
+	pkg := &Package{
+		InvalidGoFiles: make(map[string]string),
+	}
+
+	fileSet := token.NewFileSet()
+
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		return pkg, fmt.Errorf("failed to read directory %s: %s", directory, err)
+	}
+
+	// Keep track of the names used in `package` directives to ensure that only one package name is used.
+	packageNames := make(map[string]bool)
+
+	importsMap := make(map[string]bool)
+	testImportsMap := make(map[string]bool)
+	xtestImportsMap := make(map[string]bool)
+	var cgoSfiles []string // files with ".S"(capital S)/.sx(capital s equivalent for case insensitive filesystems)
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		ext := filepath.Ext(name)
+
+		if entry.Type()&fs.ModeSymlink != 0 {
+			linkFullPath := filepath.Join(directory, name)
+			linkStat, err := os.Stat(linkFullPath)
+			if err != nil {
+				// TODO: Report this error?
+				continue
+			}
+			if linkStat.IsDir() {
+				continue
+			}
+		}
+
+		// TODO: `MatchFile` will actually parse the imports but does not return the AST. Consider vendoring
+		// the MatchFile logic to avoid double parsing.
+		matches, err := buildContext.MatchFile(directory, name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check build tags for %s: %s", name, err)
+		}
+		if !matches {
+			if strings.HasPrefix(name, "_") || strings.HasPrefix(name, ".") {
+				// `go` ignores files prefixed with underscore or period. Since this is not due to
+				// build constraints, do not report it as an ignored file. Fall through.
+			} else if ext == ".go" {
+				pkg.IgnoredGoFiles = append(pkg.IgnoredGoFiles, name)
+			} else if fileListForExt(pkg, ext) != nil {
+				pkg.IgnoredOtherFiles = append(pkg.IgnoredOtherFiles, name)
+			}
+			continue
+		}
+
+		// Going to save the file. For non-Go files, can stop here.
+		switch ext {
+		case ".go":
+			// keep going
+		case ".S", ".sx":
+			// special case for cgo, handled at end
+			cgoSfiles = append(cgoSfiles, name)
+			continue
+		default:
+			if list := fileListForExt(pkg, ext); list != nil {
+				*list = append(*list, name)
+			}
+			continue
+		}
+
+		analysis, err := analyzeFile(fileSet, filepath.Join(directory, name))
+		if err != nil {
+			pkg.InvalidGoFiles[name] = err.Error()
+			// Fall-through to allow still listing the file's existence.
+		}
+
+		var pkgName string
+		if analysis != nil {
+			pkgName = analysis.Name
+			if pkgName == "documentation" {
+				// Ignore package documentation that are in `documentation` package.
+				pkg.IgnoredGoFiles = append(pkg.IgnoredGoFiles, name)
+				continue
+			}
+		}
+
+		isTest := strings.HasSuffix(name, "_test.go")
+		isXTest := false
+		if analysis != nil && isTest && strings.HasSuffix(analysis.Name, "_test") {
+			isXTest = true
+			pkgName = pkgName[:len(pkgName)-len("_test")]
+		}
+		packageNames[pkgName] = true
+
+		// TODO: Handle import comments?
+		// See https://cs.opensource.google/go/go/+/refs/tags/go1.17.2:src/go/build/build.go;drc=refs%2Ftags%2Fgo1.17.2;l=920
+
+		// Check whether CGo is in use.
+		isCGo := false
+		if analysis != nil {
+			for _, imp := range analysis.Imports {
+				if imp == "C" {
+					if isTest {
+						pkg.InvalidGoFiles[name] = fmt.Sprintf("use of cgo in test %s not supported", name)
+						continue
+					}
+					isCGo = true
+					// TODO: Save the cgo options.
+					// See https://cs.opensource.google/go/go/+/refs/tags/go1.17.2:src/go/build/build.go;drc=refs%2Ftags%2Fgo1.17.2;l=1640.
+				}
+			}
+		}
+
+		var fileList *[]string
+		var importsMapForFile map[string]bool
+
+		switch {
+		case isCGo:
+			// Ignore imports and embeds from cgo files since Pants does not support cgo.
+			// TODO: When we do handle cgo, add a build tag for it.
+			fileList = &pkg.IgnoredGoFiles
+		case isXTest:
+			fileList = &pkg.XTestGoFiles
+			importsMapForFile = xtestImportsMap
+		case isTest:
+			fileList = &pkg.TestGoFiles
+			importsMapForFile = testImportsMap
+		default:
+			fileList = &pkg.GoFiles
+			importsMapForFile = importsMap
+		}
+		*fileList = append(*fileList, name)
+
+		if importsMapForFile != nil && analysis != nil {
+			for _, importPath := range analysis.Imports {
+				importsMapForFile[importPath] = true
+			}
+		}
+	}
+
+	// TODO: Add generated build tags (like `cgo` tag) to a field in package analysis?
+	// Will probably need to vendor MatchFile (like rules_go does).
+
+	pkg.Imports = cleanImports(importsMap)
+	pkg.TestImports = cleanImports(testImportsMap)
+	pkg.XTestImports = cleanImports(xtestImportsMap)
+
+	// add the .S/.sx files only if we are using cgo
+	// (which means gcc will compile them).
+	// The standard assemblers expect .s files.
+	if len(pkg.CgoFiles) > 0 {
+		pkg.SFiles = append(pkg.SFiles, cgoSfiles...)
+		sort.Strings(pkg.SFiles)
+	} else {
+		pkg.IgnoredOtherFiles = append(pkg.IgnoredOtherFiles, cgoSfiles...)
+		sort.Strings(pkg.IgnoredOtherFiles)
+	}
+
+	// Set the package name from the observed package name. "There can be only one."
+	var packageNamesList []string
+	for pn, _ := range packageNames {
+		packageNamesList = append(packageNamesList, pn)
+	}
+	if len(packageNamesList) == 1 {
+		pkg.Name = packageNamesList[0]
+	} else if len(packageNamesList) > 1 {
+		return pkg, fmt.Errorf("multiple package names encountered: %s", strings.Join(packageNamesList, ", "))
+	}
+
+	if len(pkg.GoFiles)+len(pkg.CgoFiles)+len(pkg.TestGoFiles)+len(pkg.XTestGoFiles) == 0 {
+		return pkg, fmt.Errorf("no buildable Go source files in %s", directory)
+	}
+
+	return pkg, nil
+}
+
+func main() {
+	// TODO: Consider allowing caller to set build tags or platform? Setting platform GOOS/GOARCH will be
+	// necessary for multi-platform support.
+	buildContext := &build.Default
+
+	for _, arg := range os.Args[1:] {
+		pkg, err := analyzePackage(arg, buildContext)
+		if err != nil {
+			pkg.Error = err.Error()
+		}
+		if pkg.Error == "" && len(pkg.InvalidGoFiles) > 0 {
+			pkg.Error = "invalid Go sources encountered"
+		}
+
+		outputBytes, err := json.Marshal(pkg)
+		if err != nil {
+			fmt.Printf("{\"Error\": \"Failed to encode package metadata: %s\"}", err)
+			continue
+		}
+		_, err = os.Stdout.Write(outputBytes)
+		if err != nil {
+			fmt.Printf("{\"Error\": \"Failed to write package metadata: %s\"}", err)
+			continue
+		}
+	}
+
+	os.Exit(0)
+}

--- a/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
@@ -17,6 +17,7 @@ from pants.backend.go.util_rules import (
     first_party_pkg,
     go_mod,
     import_analysis,
+    link,
     sdk,
     third_party_pkg,
 )
@@ -43,6 +44,7 @@ def rule_runner() -> RuleRunner:
             *build_pkg.rules(),
             *build_pkg_target.rules(),
             *import_analysis.rules(),
+            *link.rules(),
             *go_mod.rules(),
             *first_party_pkg.rules(),
             *third_party_pkg.rules(),
@@ -337,7 +339,9 @@ def test_build_invalid_target(rule_runner: RuleRunner) -> None:
     )
     assert direct_build_request.request is None
     assert direct_build_request.exit_code == 1
-    assert direct_build_request.stderr == "direct/f.go:1:1: expected 'package', found invalid\n"
+    assert "direct/f.go:1:1: expected 'package', found invalid\n" in (
+        direct_build_request.stderr or ""
+    )
 
     dep_build_request = rule_runner.request(
         FallibleBuildGoPackageRequest,
@@ -345,4 +349,4 @@ def test_build_invalid_target(rule_runner: RuleRunner) -> None:
     )
     assert dep_build_request.request is None
     assert dep_build_request.exit_code == 1
-    assert dep_build_request.stderr == "dep/f.go:1:1: expected 'package', found invalid\n"
+    assert "dep/f.go:1:1: expected 'package', found invalid\n" in (dep_build_request.stderr or "")

--- a/src/python/pants/backend/go/util_rules/build_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_test.py
@@ -16,6 +16,7 @@ from pants.backend.go.util_rules import (
     first_party_pkg,
     go_mod,
     import_analysis,
+    link,
     sdk,
     third_party_pkg,
 )
@@ -40,6 +41,7 @@ def rule_runner() -> RuleRunner:
             *import_analysis.rules(),
             *go_mod.rules(),
             *first_party_pkg.rules(),
+            *link.rules(),
             *third_party_pkg.rules(),
             *target_type_rules.rules(),
             QueryRule(BuiltGoPackage, [BuildGoPackageRequest]),

--- a/src/python/pants/backend/go/util_rules/first_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg.py
@@ -179,7 +179,6 @@ async def setup_analyzer() -> PackageAnalyzerSetup:
             go_file_names=(source_entry.path,),
             s_file_names=(),
             direct_dependencies=(),
-            minimum_go_version=None,
         ),
     )
     main_pkg_a_file_path = built_analyzer_pkg.import_paths_to_pkg_a_files["main"]

--- a/src/python/pants/backend/go/util_rules/first_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg.py
@@ -25,6 +25,7 @@ from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests
 from pants.engine.process import FallibleProcessResult, Process
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import HydratedSources, HydrateSourcesRequest, WrappedTarget
+from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
 
@@ -107,6 +108,7 @@ async def compute_first_party_package_info(
             (analyzer.PATH, path),
             input_digest=input_digest,
             description=f"Determine metadata for {request.address}",
+            level=LogLevel.DEBUG,
         ),
     )
     if result.exit_code != 0:

--- a/src/python/pants/backend/go/util_rules/first_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg.py
@@ -6,23 +6,23 @@ from __future__ import annotations
 import json
 import logging
 import os
+import pkgutil
 from dataclasses import dataclass
+from typing import ClassVar
 
 from pants.backend.go.target_types import (
     GoFirstPartyPackageSourcesField,
     GoFirstPartyPackageSubpathField,
     GoImportPathField,
 )
+from pants.backend.go.util_rules.build_pkg import BuildGoPackageRequest, BuiltGoPackage
 from pants.backend.go.util_rules.go_mod import GoModInfo, GoModInfoRequest
-from pants.backend.go.util_rules.sdk import GoSdkProcess
-from pants.backend.go.util_rules.third_party_pkg import (
-    AllThirdPartyPackages,
-    AllThirdPartyPackagesRequest,
-)
+from pants.backend.go.util_rules.import_analysis import ImportConfig, ImportConfigRequest
+from pants.backend.go.util_rules.link import LinkedGoBinary, LinkGoBinaryRequest
 from pants.build_graph.address import Address
 from pants.engine.engine_aware import EngineAwareParameter
-from pants.engine.fs import Digest, MergeDigests
-from pants.engine.process import FallibleProcessResult
+from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests
+from pants.engine.process import FallibleProcessResult, Process
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import HydratedSources, HydrateSourcesRequest, WrappedTarget
 
@@ -71,9 +71,15 @@ class FirstPartyPkgInfoRequest(EngineAwareParameter):
         return self.address.spec
 
 
+@dataclass(frozen=True)
+class PackageAnalyzerSetup:
+    digest: Digest
+    PATH: ClassVar[str] = "./_analyze_package"
+
+
 @rule
 async def compute_first_party_package_info(
-    request: FirstPartyPkgInfoRequest,
+    request: FirstPartyPkgInfoRequest, analyzer: PackageAnalyzerSetup
 ) -> FallibleFirstPartyPkgInfo:
     go_mod_address = request.address.maybe_convert_to_target_generator()
     wrapped_target, go_mod_info = await MultiGet(
@@ -84,24 +90,23 @@ async def compute_first_party_package_info(
     import_path = target[GoImportPathField].value
     subpath = target[GoFirstPartyPackageSubpathField].value
 
-    pkg_sources, all_third_party_packages = await MultiGet(
-        Get(HydratedSources, HydrateSourcesRequest(target[GoFirstPartyPackageSourcesField])),
-        Get(AllThirdPartyPackages, AllThirdPartyPackagesRequest(go_mod_info.stripped_digest)),
+    pkg_sources = await Get(
+        HydratedSources, HydrateSourcesRequest(target[GoFirstPartyPackageSourcesField])
     )
     input_digest = await Get(
         Digest,
-        MergeDigests(
-            [pkg_sources.snapshot.digest, go_mod_info.digest, all_third_party_packages.digest]
-        ),
+        MergeDigests([pkg_sources.snapshot.digest, analyzer.digest]),
     )
-
+    path = request.address.spec_path if request.address.spec_path else "."
+    path = os.path.join(path, subpath) if subpath else path
+    if not path:
+        path = "."
     result = await Get(
         FallibleProcessResult,
-        GoSdkProcess(
+        Process(
+            (analyzer.PATH, path),
             input_digest=input_digest,
-            command=("list", "-json", f"./{subpath}"),
             description=f"Determine metadata for {request.address}",
-            working_dir=request.address.spec_path,  # i.e. the `go.mod`'s directory.
         ),
     )
     if result.exit_code != 0:
@@ -113,6 +118,19 @@ async def compute_first_party_package_info(
         )
 
     metadata = json.loads(result.stdout)
+    if "Error" in metadata or "InvalidGoFiles" in metadata:
+        error = metadata.get("Error", "")
+        if error:
+            error += "\n"
+        if "InvalidGoFiles" in metadata:
+            error += "\n".join(
+                f"{filename}: {error}"
+                for filename, error in metadata.get("InvalidGoFiles", {}).items()
+            )
+            error += "\n"
+        return FallibleFirstPartyPkgInfo(
+            info=None, import_path=import_path, exit_code=1, stderr=error
+        )
 
     if "CgoFiles" in metadata:
         raise NotImplementedError(
@@ -135,6 +153,50 @@ async def compute_first_party_package_info(
         s_files=tuple(metadata.get("SFiles", [])),
     )
     return FallibleFirstPartyPkgInfo(info, import_path)
+
+
+@rule
+async def setup_analyzer() -> PackageAnalyzerSetup:
+    source_entry_content = pkgutil.get_data("pants.backend.go.util_rules", "analyze_package.go")
+    if not source_entry_content:
+        raise AssertionError("Unable to find resource for `analyze_package.go`.")
+
+    source_entry = FileContent("analyze_package.go", source_entry_content)
+
+    source_digest, import_config = await MultiGet(
+        Get(Digest, CreateDigest([source_entry])),
+        Get(ImportConfig, ImportConfigRequest, ImportConfigRequest.stdlib_only()),
+    )
+
+    built_analyzer_pkg = await Get(
+        BuiltGoPackage,
+        BuildGoPackageRequest(
+            import_path="main",
+            subpath="",
+            digest=source_digest,
+            go_file_names=(source_entry.path,),
+            s_file_names=(),
+            direct_dependencies=(),
+            minimum_go_version=None,
+        ),
+    )
+    main_pkg_a_file_path = built_analyzer_pkg.import_paths_to_pkg_a_files["main"]
+    input_digest = await Get(
+        Digest, MergeDigests([built_analyzer_pkg.digest, import_config.digest])
+    )
+
+    analyzer = await Get(
+        LinkedGoBinary,
+        LinkGoBinaryRequest(
+            input_digest=input_digest,
+            archives=(main_pkg_a_file_path,),
+            import_config_path=import_config.CONFIG_PATH,
+            output_filename=PackageAnalyzerSetup.PATH,
+            description="Link Go package analyzer",
+        ),
+    )
+
+    return PackageAnalyzerSetup(analyzer.digest)
 
 
 def rules():

--- a/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
@@ -9,7 +9,15 @@ import pytest
 
 from pants.backend.go import target_type_rules
 from pants.backend.go.target_types import GoModTarget
-from pants.backend.go.util_rules import first_party_pkg, go_mod, sdk, third_party_pkg
+from pants.backend.go.util_rules import (
+    assembly,
+    build_pkg,
+    first_party_pkg,
+    go_mod,
+    link,
+    sdk,
+    third_party_pkg,
+)
 from pants.backend.go.util_rules.first_party_pkg import (
     FallibleFirstPartyPkgInfo,
     FirstPartyPkgInfoRequest,
@@ -29,6 +37,9 @@ def rule_runner() -> RuleRunner:
             *sdk.rules(),
             *third_party_pkg.rules(),
             *target_type_rules.rules(),
+            *build_pkg.rules(),
+            *link.rules(),
+            *assembly.rules(),
             QueryRule(FallibleFirstPartyPkgInfo, [FirstPartyPkgInfoRequest]),
         ],
         target_types=[GoModTarget],
@@ -165,9 +176,10 @@ def test_invalid_package(rule_runner) -> None:
     )
     assert maybe_info.info is None
     assert maybe_info.exit_code == 1
-    assert maybe_info.stderr == "bad.go:1:1: expected 'package', found invalid\n"
+    assert "bad.go:1:1: expected 'package', found invalid\n" in maybe_info.stderr
 
 
+@pytest.mark.xfail(reason="cgo is ignored")
 def test_cgo_not_supported(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {


### PR DESCRIPTION
## Motivation

`go list` requires that a package's dependency graph be available to analyze a package, even if all we want to do is obtain the package's imports which can be found by just parsing sources. This is fine if the packages are already available on the GOPATH. With the Pants execution sandbox, however, this means that Pants has to copy large trees of sources into the input root to make those packages available even if not actually needed. And that copying into the input root has a significant performance impact.

## Solution

Vendor some of the package analysis code from the [go/build standard library package](https://cs.opensource.google/go/go/+/refs/tags/go1.17.2:src/go/build/build.go) into Pants. This will be the basis for not using `go list` for package analysis.

Interestingly, Bazel rules_go went in a similar direction for package analysis.

## Benchmark

Running in https://github.com/toolchainlabs/remote-api-tools.

Before:

```
❯ hyperfine -r 5 './pants_from_sources --no-process-execution-local-cache --no-pantsd dependencies ::'
  Time (mean ± σ):     19.742 s ±  0.801 s    [User: 13.908 s, System: 26.641 s]
  Range (min … max):   19.113 s … 21.081 s    5 runs
```

After:

```
❯ hyperfine -r 5 './pants_from_sources --no-process-execution-local-cache --no-pantsd dependencies ::'
  Time (mean ± σ):     14.472 s ±  1.107 s    [User: 9.550 s, System: 5.793 s]
  Range (min … max):   13.561 s … 16.101 s    5 runs
```

Note the dramatic drop in System time. We suspect that this was resulting in IO contention before, which was causing Pants to hang in larger repositories like Helm.

[ci skip-rust]
[ci skip-build-wheels]