### PR TITLE
Fix slow performance from recursive `__repr__` and `__hash__` for Go

### DIFF
--- a/src/python/pants/backend/go/goals/check.py
+++ b/src/python/pants/backend/go/goals/check.py
@@ -21,8 +21,6 @@ from pants.util.logging import LogLevel
 class GoCheckFieldSet(FieldSet):
     required_fields = (GoFirstPartyPackageSourcesField,)
 
-    sources: GoFirstPartyPackageSourcesField
-
 
 class GoCheckRequest(CheckRequest):
     field_set_type = GoCheckFieldSet

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -22,26 +22,80 @@ from pants.util.logging import LogLevel
 from pants.util.strutil import path_safe
 
 
-@dataclass(frozen=True)
 class BuildGoPackageRequest(EngineAwareParameter):
-    """Build a package and its dependencies as `__pkg__.a` files."""
+    def __init__(
+        self,
+        *,
+        import_path: str,
+        digest: Digest,
+        subpath: str,
+        go_file_names: tuple[str, ...],
+        s_file_names: tuple[str, ...],
+        direct_dependencies: tuple[BuildGoPackageRequest, ...],
+        minimum_go_version: str | None,
+        for_tests: bool = False,
+    ) -> None:
+        """Build a package and its dependencies as `__pkg__.a` files.
 
-    import_path: str
+        Instances of this class form a structure-shared DAG, and so a hashcode is pre-computed for
+        the recursive portion.
+        """
 
-    digest: Digest
-    # Path from the root of the digest to the package to build.
-    subpath: str
+        self.import_path = import_path
+        self.digest = digest
+        self.subpath = subpath
+        self.go_file_names = go_file_names
+        self.s_file_names = s_file_names
+        self.direct_dependencies = direct_dependencies
+        self.minimum_go_version = minimum_go_version
+        self.for_tests = for_tests
+        self._hashcode = hash(
+            (
+                self.import_path,
+                self.digest,
+                self.subpath,
+                self.go_file_names,
+                self.s_file_names,
+                self.direct_dependencies,
+                self.minimum_go_version,
+                self.for_tests,
+            )
+        )
 
-    go_file_names: tuple[str, ...]
-    s_file_names: tuple[str, ...]
+    def __repr__(self) -> str:
+        # NB: We must override the default `__repr__` so that `direct_dependencies` does not
+        # traverse into transitive dependencies, which was pathologically slow.
+        return (
+            f"{self.__class__}("
+            f"import_path={repr(self.import_path)}, "
+            f"digest={self.digest}, "
+            f"subpath={self.subpath}, "
+            f"go_file_names={self.go_file_names}, "
+            f"go_file_names={self.s_file_names}, "
+            f"direct_dependencies={[dep.import_path for dep in self.direct_dependencies]}, "
+            f"minimum_go_version={self.minimum_go_version}, "
+            f"for_tests={self.for_tests}"
+            ")"
+        )
 
-    # These dependencies themselves often have dependencies, such that we recursively build.
-    direct_dependencies: tuple[BuildGoPackageRequest, ...]
+    def __hash__(self) -> int:
+        return self._hashcode
 
-    # In the form `1.16`. This is declared in the `go` directive of `go.mod`.
-    minimum_go_version: str | None
-
-    for_tests: bool = False
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return (
+            self._hashcode == other._hashcode
+            and self.import_path == other.import_path
+            and self.digest == other.digest
+            and self.subpath == other.subpath
+            and self.go_file_names == other.go_file_names
+            and self.s_file_names == other.s_file_names
+            and self.minimum_go_version == other.minimum_go_version
+            and self.for_tests == other.for_tests
+            # TODO: Use a recursive memoized __eq__ if this ever shows up in profiles.
+            and self.direct_dependencies == other.direct_dependencies
+        )
 
     def debug_hint(self) -> str | None:
         return self.import_path

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -638,21 +638,16 @@ class UnexpandedTargets(Collection[Target]):
 
 
 class CoarsenedTarget(EngineAwareParameter):
-    """A set of Targets which cyclicly reach one another, and are thus indivisible.
-
-    Instances of this class form a structure-shared DAG, and so a hashcode is pre-computed for the
-    recursive portion.
-    """
-
-    # The members of the cycle.
-    members: FrozenOrderedSet[Target]
-    # The deduped direct (not transitive) dependencies of all Targets in the cycle. Dependencies
-    # between members of the cycle are excluded.
-    dependencies: FrozenOrderedSet[CoarsenedTarget]
-    # Pre-computed hashcode: see the class doc.
-    _hashcode: int
-
     def __init__(self, members: Iterable[Target], dependencies: Iterable[CoarsenedTarget]) -> None:
+        """A set of Targets which cyclicly reach one another, and are thus indivisible.
+
+        Instances of this class form a structure-shared DAG, and so a hashcode is pre-computed for the
+        recursive portion.
+
+        :param members: The members of the cycle.
+        :param dependencies: The deduped direct (not transitive) dependencies of all Targets in
+            the cycle. Dependencies between members of the cycle are excluded.
+        """
         self.members = FrozenOrderedSet(members)
         self.dependencies = FrozenOrderedSet(dependencies)
         self._hashcode = hash((self.members, self.dependencies))
@@ -677,6 +672,7 @@ class CoarsenedTarget(EngineAwareParameter):
         return (
             self._hashcode == other._hashcode
             and self.members == other.members
+            # TODO: Use a recursive memoized __eq__ if this ever shows up in profiles.
             and self.dependencies == other.dependencies
         )
 


### PR DESCRIPTION
`BuildGoPackageRequest` is a recursive data structure (DAG). The default `__hash__` and `__repr__` were doing recursive transitive graph walks, which showed up in profiles as pathologically slow, where it looked like building https://github.com/toolchainlabs/external-dns was hung when running `./pants check source:`.

## Benchmark

Before:

```
❯ hyperfine -r 5 './pants_from_sources --no-process-execution-local-cache --no-pantsd check ::'
  Time (mean ± σ):     20.316 s ±  0.877 s    [User: 20.548 s, System: 9.075 s]
  Range (min … max):   19.663 s … 21.668 s    5 runs
```

After:

```
❯ hyperfine -r 5 './pants_from_sources --no-process-execution-local-cache --no-pantsd check ::'
  Time (mean ± σ):     16.163 s ±  0.198 s    [User: 16.970 s, System: 9.193 s]
  Range (min … max):   15.912 s … 16.355 s    5 runs
```

[ci skip-rust]
[ci skip-build-wheels]