### PR TITLE
Fix slow performance from recursive `__repr__` and `__hash__` for Go (Cherry-pick of #13492)

### DIFF
--- a/src/python/pants/backend/go/goals/check.py
+++ b/src/python/pants/backend/go/goals/check.py
@@ -21,8 +21,6 @@ from pants.util.logging import LogLevel
 class GoCheckFieldSet(FieldSet):
     required_fields = (GoFirstPartyPackageSourcesField,)
 
-    sources: GoFirstPartyPackageSourcesField
-
 
 class GoCheckRequest(CheckRequest):
     field_set_type = GoCheckFieldSet

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -633,21 +633,16 @@ class UnexpandedTargets(Collection[Target]):
 
 
 class CoarsenedTarget(EngineAwareParameter):
-    """A set of Targets which cyclicly reach one another, and are thus indivisible.
-
-    Instances of this class form a structure-shared DAG, and so a hashcode is pre-computed for the
-    recursive portion.
-    """
-
-    # The members of the cycle.
-    members: FrozenOrderedSet[Target]
-    # The deduped direct (not transitive) dependencies of all Targets in the cycle. Dependencies
-    # between members of the cycle are excluded.
-    dependencies: FrozenOrderedSet[CoarsenedTarget]
-    # Pre-computed hashcode: see the class doc.
-    _hashcode: int
-
     def __init__(self, members: Iterable[Target], dependencies: Iterable[CoarsenedTarget]) -> None:
+        """A set of Targets which cyclicly reach one another, and are thus indivisible.
+
+        Instances of this class form a structure-shared DAG, and so a hashcode is pre-computed for the
+        recursive portion.
+
+        :param members: The members of the cycle.
+        :param dependencies: The deduped direct (not transitive) dependencies of all Targets in
+            the cycle. Dependencies between members of the cycle are excluded.
+        """
         self.members = FrozenOrderedSet(members)
         self.dependencies = FrozenOrderedSet(dependencies)
         self._hashcode = hash((self.members, self.dependencies))
@@ -672,6 +667,7 @@ class CoarsenedTarget(EngineAwareParameter):
         return (
             self._hashcode == other._hashcode
             and self.members == other.members
+            # TODO: Use a recursive memoized __eq__ if this ever shows up in profiles.
             and self.dependencies == other.dependencies
         )
 


### PR DESCRIPTION
`BuildGoPackageRequest` is a recursive data structure (DAG). The default `__hash__` and `__repr__` were doing recursive transitive graph walks, which showed up in profiles as pathologically slow, where it looked like building https://github.com/toolchainlabs/external-dns was hung when running `./pants check source:`.

## Benchmark

Before:

```
❯ hyperfine -r 5 './pants_from_sources --no-process-execution-local-cache --no-pantsd check ::'
  Time (mean ± σ):     20.316 s ±  0.877 s    [User: 20.548 s, System: 9.075 s]
  Range (min … max):   19.663 s … 21.668 s    5 runs
```

After:

```
❯ hyperfine -r 5 './pants_from_sources --no-process-execution-local-cache --no-pantsd check ::'
  Time (mean ± σ):     16.163 s ±  0.198 s    [User: 16.970 s, System: 9.193 s]
  Range (min … max):   15.912 s … 16.355 s    5 runs
```

[ci skip-rust]
[ci skip-build-wheels]