### PR TITLE
[WIP] [internal] scala: work around coursier parsing bug in `--strict-include`

### DIFF
--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -274,12 +274,7 @@ async def coursier_resolve_lockfile(
             argv=coursier.args(
                 [
                     coursier_report_file_name,
-                    *(req.to_coord_str() for req in artifact_requirements),
-                    *(
-                        f"--strict-include={req.to_coord_str(versioned=False)}"
-                        for req in artifact_requirements
-                        if req.strict
-                    ),
+                    *(f"{req.to_coord_str()}:strict" for req in artifact_requirements),
                 ],
                 wrapper=[bash.path, coursier.wrapper_script],
             ),


### PR DESCRIPTION
This is a WIP attempt to fix https://github.com/pantsbuild/pants/issues/13496.

[ci skip-rust]
