### PR TITLE
[internal] scala: add rules to build and invoke scala parser

### DIFF
--- a/src/python/pants/backend/scala/dependency_inference/BUILD
+++ b/src/python/pants/backend/scala/dependency_inference/BUILD
@@ -1,0 +1,7 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_sources(dependencies=[":scala_sources"])
+python_tests(name="tests", timeout=240)
+
+resources(name="scala_sources", sources=["*.scala"])

--- a/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
+++ b/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
@@ -1,0 +1,34 @@
+package org.pantsbuild.backend.scala.dependency_inference
+
+import io.circe._, io.circe.generic.auto._, io.circe.syntax._
+//import io.circe._
+//import io.circe.generic.auto._
+//import io.circe.syntax._
+
+import scala.meta._
+
+case class Analysis(
+  `package`: String
+)
+
+object ScalaParser {
+  def analyze(pathStr: String): Analysis = {
+    val path = java.nio.file.Paths.get(pathStr)
+    val bytes = java.nio.file.Files.readAllBytes(path)
+    val text = new String(bytes, "UTF-8")
+    val input = Input.VirtualFile(path.toString, text)
+
+    val tree = input.parse[Source].get
+
+    // TODO: Actually pare out the package (and other fields).
+    Analysis("foo")
+  }
+
+  def main(args: Array[String]): Unit = {
+    val analysis = analyze(args(0))
+
+    val json = analysis.asJson.noSpaces
+    // TODO: Write to file specified by the caler.
+    println(json)
+  }
+}

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -20,7 +20,7 @@ from pants.engine.fs import (
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.process import BashBinary, FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import collect_rules, rule
-from pants.jvm.compile import CompiledClassfiles
+from pants.jvm.compile import ClasspathEntry
 from pants.jvm.jdk_rules import JdkSetup
 from pants.jvm.resolve.coursier_fetch import (
     ArtifactRequirements,
@@ -97,7 +97,7 @@ class FallibleScalaSourceDependencyAnalysisResult:
     process_result: FallibleProcessResult
 
 
-class ScalaParserCompiledClassfiles(CompiledClassfiles):
+class ScalaParserCompiledClassfiles(ClasspathEntry):
     pass
 
 

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -1,0 +1,284 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+import logging
+import os
+import pkgutil
+from dataclasses import dataclass
+
+from pants.core.util_rules.source_files import SourceFiles
+from pants.engine.fs import (
+    AddPrefix,
+    CreateDigest,
+    Digest,
+    Directory,
+    FileContent,
+    MergeDigests,
+    RemovePrefix,
+)
+from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.process import BashBinary, FallibleProcessResult, Process, ProcessResult
+from pants.engine.rules import collect_rules, rule
+from pants.jvm.compile import CompiledClassfiles
+from pants.jvm.jdk_rules import JdkSetup
+from pants.jvm.resolve.coursier_fetch import (
+    ArtifactRequirements,
+    Coordinate,
+    MaterializedClasspath,
+    MaterializedClasspathRequest,
+)
+from pants.util.logging import LogLevel
+
+logger = logging.getLogger(__name__)
+
+PARSER_SCALA_VERSION = "2.13.7"
+SCALAMETA_VERSION = "4.4.30"
+CIRCE_VERSION = "0.14.1"
+
+PARSER_SCALA_VERSION_MAJOR_MINOR = ".".join(PARSER_SCALA_VERSION.split(".")[0:2])
+
+SCALAMETA_DEPENDENCIES = [
+    Coordinate.from_coord_str(s)
+    for s in [
+        "org.scalameta:scalameta_2.13:4.4.30",
+        "org.scala-lang:scala-library:2.13.7",
+        "com.thesamet.scalapb:scalapb-runtime_2.13:0.11.4",
+        "org.scalameta:parsers_2.13:4.4.30",
+        "org.scala-lang:scala-compiler:2.13.7",
+        "net.java.dev.jna:jna:5.8.0",
+        "org.scalameta:trees_2.13:4.4.30",
+        "org.scalameta:common_2.13:4.4.30",
+        "com.lihaoyi:sourcecode_2.13:0.2.7",
+        "org.jline:jline:3.20.0",
+        "org.scalameta:fastparse-v2_2.13:2.3.1",
+        "org.scala-lang.modules:scala-collection-compat_2.13:2.4.4",
+        "org.scala-lang:scalap:2.13.7",
+        "org.scala-lang:scala-reflect:2.13.7",
+        "com.google.protobuf:protobuf-java:3.15.8",
+        "com.thesamet.scalapb:lenses_2.13:0.11.4",
+        "com.lihaoyi:geny_2.13:0.6.5",
+    ]
+]
+
+
+CIRCE_DEPENDENCIES = [
+    Coordinate.from_coord_str(s)
+    for s in [
+        "io.circe:circe-generic_2.13:0.14.1",
+        "org.typelevel:simulacrum-scalafix-annotations_2.13:0.5.4",
+        "org.typelevel:cats-core_2.13:2.6.1",
+        "org.scala-lang:scala-library:2.13.6",
+        "io.circe:circe-numbers_2.13:0.14.1",
+        "com.chuusai:shapeless_2.13:2.3.7",
+        "io.circe:circe-core_2.13:0.14.1",
+        "org.typelevel:cats-kernel_2.13:2.6.1",
+    ]
+]
+
+SCALA_PARSER_ARTIFACT_REQUIREMENTS = ArtifactRequirements(
+    SCALAMETA_DEPENDENCIES + CIRCE_DEPENDENCIES
+)
+
+
+@dataclass(frozen=True)
+class ScalaSourceDependencyAnalysis:
+    package: str
+
+    @classmethod
+    def from_json_dict(cls, d: dict) -> ScalaSourceDependencyAnalysis:
+        return cls(
+            package=d["package"],
+        )
+
+
+@dataclass(frozen=True)
+class FallibleScalaSourceDependencyAnalysisResult:
+    process_result: FallibleProcessResult
+
+
+class ScalaParserCompiledClassfiles(CompiledClassfiles):
+    pass
+
+
+@rule(level=LogLevel.DEBUG)
+async def analyze_scala_source_dependencies(
+    bash: BashBinary,
+    jdk_setup: JdkSetup,
+    processor_classfiles: ScalaParserCompiledClassfiles,
+    source_files: SourceFiles,
+) -> FallibleScalaSourceDependencyAnalysisResult:
+    if len(source_files.files) > 1:
+        raise ValueError(
+            f"analyze_scala_source_dependencies expects sources with exactly 1 source file, but found {len(source_files.snapshot.files)}."
+        )
+    elif len(source_files.files) == 0:
+        raise ValueError(
+            "analyze_scala_source_dependencies expects sources with exactly 1 source file, but found none."
+        )
+    source_prefix = "__source_to_analyze"
+    source_path = os.path.join(source_prefix, source_files.files[0])
+    processorcp_relpath = "__processorcp"
+
+    (
+        tool_classpath,
+        prefixed_processor_classfiles_digest,
+        prefixed_source_files_digest,
+    ) = await MultiGet(
+        Get(
+            MaterializedClasspath,
+            MaterializedClasspathRequest(
+                prefix="__toolcp",
+                artifact_requirements=(SCALA_PARSER_ARTIFACT_REQUIREMENTS,),
+            ),
+        ),
+        Get(Digest, AddPrefix(processor_classfiles.digest, processorcp_relpath)),
+        Get(Digest, AddPrefix(source_files.snapshot.digest, source_prefix)),
+    )
+
+    tool_digest = await Get(
+        Digest,
+        MergeDigests(
+            (
+                prefixed_processor_classfiles_digest,
+                tool_classpath.digest,
+                jdk_setup.digest,
+            )
+        ),
+    )
+    merged_digest = await Get(
+        Digest,
+        MergeDigests(
+            (
+                tool_digest,
+                prefixed_source_files_digest,
+            )
+        ),
+    )
+
+    analysis_output_path = "__source_analysis.json"
+
+    process_result = await Get(
+        FallibleProcessResult,
+        Process(
+            argv=[
+                *jdk_setup.args(bash, [*tool_classpath.classpath_entries(), processorcp_relpath]),
+                "org.pantsbuild.backend.scala.dependency_inference.ScalaParser",
+                # analysis_output_path,
+                source_path,
+            ],
+            input_digest=merged_digest,
+            output_files=(analysis_output_path,),
+            use_nailgun=tool_digest,
+            append_only_caches=jdk_setup.append_only_caches,
+            env=jdk_setup.env,
+            description="Analyze Scala source for dependencies",
+            level=LogLevel.DEBUG,
+        ),
+    )
+
+    return FallibleScalaSourceDependencyAnalysisResult(process_result=process_result)
+
+
+@rule
+async def setup_scala_parser_classfiles(
+    bash: BashBinary, jdk_setup: JdkSetup
+) -> ScalaParserCompiledClassfiles:
+    dest_dir = "classfiles"
+
+    parser_source_content = pkgutil.get_data(
+        "pants.backend.scala.dependency_inference", "ScalaParser.scala"
+    )
+    if not parser_source_content:
+        raise AssertionError("Unable to find ScalaParser.scala resource.")
+
+    parser_source = FileContent("ScalaParser.scala", parser_source_content)
+
+    tool_classpath, parser_classpath, source_digest = await MultiGet(
+        Get(
+            MaterializedClasspath,
+            MaterializedClasspathRequest(
+                prefix="__toolcp",
+                artifact_requirements=(
+                    ArtifactRequirements(
+                        [
+                            Coordinate(
+                                group="org.scala-lang",
+                                artifact="scala-compiler",
+                                version=PARSER_SCALA_VERSION,
+                            ),
+                            Coordinate(
+                                group="org.scala-lang",
+                                artifact="scala-library",
+                                version=PARSER_SCALA_VERSION,
+                            ),
+                            Coordinate(
+                                group="org.scala-lang",
+                                artifact="scala-reflect",
+                                version=PARSER_SCALA_VERSION,
+                            ),
+                        ]
+                    ),
+                ),
+            ),
+        ),
+        Get(
+            MaterializedClasspath,
+            MaterializedClasspathRequest(
+                prefix="__parsercp", artifact_requirements=(SCALA_PARSER_ARTIFACT_REQUIREMENTS,)
+            ),
+        ),
+        Get(
+            Digest,
+            CreateDigest(
+                [
+                    parser_source,
+                    Directory(dest_dir),
+                ]
+            ),
+        ),
+    )
+
+    merged_digest = await Get(
+        Digest,
+        MergeDigests(
+            (
+                tool_classpath.digest,
+                parser_classpath.digest,
+                jdk_setup.digest,
+                source_digest,
+            )
+        ),
+    )
+
+    # NB: We do not use nailgun for this process, since it is launched exactly once.
+    process_result = await Get(
+        ProcessResult,
+        Process(
+            argv=[
+                *jdk_setup.args(bash, tool_classpath.classpath_entries()),
+                "scala.tools.nsc.Main",
+                "-bootclasspath",
+                ":".join(tool_classpath.classpath_entries()),
+                "-classpath",
+                ":".join(parser_classpath.classpath_entries()),
+                "-d",
+                dest_dir,
+                parser_source.path,
+            ],
+            input_digest=merged_digest,
+            append_only_caches=jdk_setup.append_only_caches,
+            env=jdk_setup.env,
+            output_directories=(dest_dir,),
+            description="Compile Scala parser for dependency inference with scalac",
+            level=LogLevel.DEBUG,
+        ),
+    )
+    stripped_classfiles_digest = await Get(
+        Digest, RemovePrefix(process_result.output_digest, dest_dir)
+    )
+    return ScalaParserCompiledClassfiles(digest=stripped_classfiles_digest)
+
+
+def rules():
+    return collect_rules()

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
@@ -1,0 +1,89 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import textwrap
+
+import pytest
+
+from pants.backend.scala import target_types
+from pants.backend.scala.dependency_inference import scala_parser
+from pants.backend.scala.dependency_inference.scala_parser import (
+    FallibleScalaSourceDependencyAnalysisResult,
+)
+from pants.backend.scala.target_types import ScalaSourceField, ScalaSourceTarget
+from pants.build_graph.address import Address
+from pants.core.util_rules import source_files
+from pants.core.util_rules.external_tool import rules as external_tool_rules
+from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.engine.target import SourcesField
+from pants.jvm import jdk_rules
+from pants.jvm import util_rules as jvm_util_rules
+from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
+from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
+from pants.jvm.target_types import JvmDependencyLockfile
+from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = RuleRunner(
+        preserve_tmpdirs=True,
+        rules=[
+            *scala_parser.rules(),
+            *coursier_fetch_rules(),
+            *coursier_setup_rules(),
+            *external_tool_rules(),
+            *source_files.rules(),
+            *jdk_rules.rules(),
+            *target_types.rules(),
+            *jvm_util_rules.rules(),
+            QueryRule(SourceFiles, (SourceFilesRequest,)),
+            QueryRule(FallibleScalaSourceDependencyAnalysisResult, (SourceFiles,)),
+        ],
+        target_types=[JvmDependencyLockfile, ScalaSourceTarget],
+    )
+    rule_runner.set_options(args=["-ldebug"], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    return rule_runner
+
+
+def test_parser_simple(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": textwrap.dedent(
+                """
+            scala_source(
+                name="simple-source",
+                source="SimpleSource.scala",
+            )
+            """
+            ),
+            "SimpleSource.scala": textwrap.dedent(
+                """
+            package org.pantsbuild.example
+
+            class Foo {
+            }
+            """
+            ),
+        }
+    )
+
+    target = rule_runner.get_target(address=Address("", target_name="simple-source"))
+
+    source_files = rule_runner.request(
+        SourceFiles,
+        [
+            SourceFilesRequest(
+                (target.get(SourcesField),),
+                for_sources_types=(ScalaSourceField,),
+                enable_codegen=True,
+            )
+        ],
+    )
+
+    analysis = rule_runner.request(
+        FallibleScalaSourceDependencyAnalysisResult,
+        [source_files],
+    )
+
+    assert analysis.process_result.exit_code == 0
+    assert analysis.process_result.stdout == b"""{"package":"foo"}\n"""

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -275,11 +275,14 @@ async def coursier_resolve_lockfile(
                 [
                     coursier_report_file_name,
                     *(req.to_coord_str() for req in artifact_requirements),
-                    *(
-                        f"--strict-include={req.to_coord_str(versioned=False)}"
-                        for req in artifact_requirements
-                        if req.strict
-                    ),
+                    # TODO(#13496): Disable --strict-include to work around Coursier issue
+                    # https://github.com/coursier/coursier/issues/1364 which erroneously rejects underscores in
+                    # artifact rules as malformed.
+                    # *(
+                    #     f"--strict-include={req.to_coord_str(versioned=False)}"
+                    #     for req in artifact_requirements
+                    #     if req.strict
+                    # ),
                 ],
                 wrapper=[bash.path, coursier.wrapper_script],
             ),


### PR DESCRIPTION
Add the basic infrastructure to compile and invoke a Scala source analysis tool. This will be used for dependency inference. This PR does not include any of the actual code to extract useful info from the parse tree; that will come in follow-on PRs.

[ci skip-rust]