### PR TITLE
[internal] go: pass `-complete` flag to compiler

### DIFF
--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -234,6 +234,10 @@ async def build_go_package(request: BuildGoPackageRequest) -> FallibleBuiltGoPac
 
     if symabis_path:
         compile_args.extend(["-symabis", symabis_path])
+    if not request.s_file_names:
+        # If there are no non-Go sources, then pass -complete flag which tells the compiler that the provided
+        # Go files are the entire package.
+        compile_args.append("-complete")
     relativized_sources = (
         f"./{request.subpath}/{name}" if request.subpath else f"./{name}"
         for name in request.go_file_names


### PR DESCRIPTION
Pass the `-complete` flag to the compiler if there are no non-Go sources which could be built separately from the compiler invocation. This allows the compiler to make certain assumptions about available symbols.

[ci skip-rust]
