### PR TITLE
[internal] Rename `CompiledClassfiles` to `ClasspathEntry`.

### DIFF
--- a/src/python/pants/backend/java/dependency_inference/java_parser_launcher.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser_launcher.py
@@ -4,13 +4,13 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 
 import pkg_resources
 
 from pants.engine.fs import CreateDigest, Digest, Directory, FileContent, MergeDigests, RemovePrefix
 from pants.engine.process import BashBinary, Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.jvm.compile import CompiledClassfiles
 from pants.jvm.jdk_rules import JdkSetup
 from pants.jvm.resolve.coursier_fetch import (
     ArtifactRequirements,
@@ -45,8 +45,9 @@ def java_parser_artifact_requirements() -> ArtifactRequirements:
     )
 
 
-class JavaParserCompiledClassfiles(CompiledClassfiles):
-    pass
+@dataclass(frozen=True)
+class JavaParserCompiledClassfiles:
+    digest: Digest
 
 
 @rule

--- a/src/python/pants/backend/java/goals/check.py
+++ b/src/python/pants/backend/java/goals/check.py
@@ -11,7 +11,7 @@ from pants.engine.addresses import Addresses
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import CoarsenedTargets, Targets
 from pants.engine.unions import UnionRule
-from pants.jvm.compile import FallibleCompiledClassfiles
+from pants.jvm.compile import FallibleClasspathEntry
 from pants.jvm.resolve.coursier_fetch import CoursierResolveKey
 from pants.util.logging import LogLevel
 
@@ -34,7 +34,7 @@ async def javac_check(request: JavacCheckRequest) -> CheckResults:
 
     results = await MultiGet(
         Get(
-            FallibleCompiledClassfiles,
+            FallibleClasspathEntry,
             CompileJavaSourceRequest(component=target, resolve=resolve),
         )
         for target, resolve in zip(coarsened_targets, resolves)

--- a/src/python/pants/backend/scala/goals/check.py
+++ b/src/python/pants/backend/scala/goals/check.py
@@ -11,7 +11,7 @@ from pants.engine.addresses import Addresses
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import CoarsenedTargets, Targets
 from pants.engine.unions import UnionRule
-from pants.jvm.compile import FallibleCompiledClassfiles
+from pants.jvm.compile import FallibleClasspathEntry
 from pants.jvm.resolve.coursier_fetch import CoursierResolveKey
 from pants.util.logging import LogLevel
 
@@ -34,7 +34,7 @@ async def scalac_check(request: ScalacCheckRequest) -> CheckResults:
 
     # TODO: This should be fallible so that we exit cleanly.
     results = await MultiGet(
-        Get(FallibleCompiledClassfiles, CompileScalaSourceRequest(component=t, resolve=r))
+        Get(FallibleClasspathEntry, CompileScalaSourceRequest(component=t, resolve=r))
         for t, r in zip(coarsened_targets, resolves)
     )
 

--- a/src/python/pants/jvm/classpath.py
+++ b/src/python/pants/jvm/classpath.py
@@ -11,7 +11,7 @@ from pants.backend.java.compile.javac import CompileJavaSourceRequest
 from pants.engine.fs import AddPrefix, Digest, MergeDigests, Snapshot
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import CoarsenedTargets, Targets
-from pants.jvm.compile import CompiledClassfiles
+from pants.jvm.compile import ClasspathEntry
 from pants.jvm.resolve.coursier_fetch import (
     CoursierResolvedLockfile,
     CoursierResolveKey,
@@ -72,7 +72,7 @@ async def classpath(coarsened_targets: CoarsenedTargets) -> Classpath:
         ),
     )
     transitive_user_classfiles = await MultiGet(
-        Get(CompiledClassfiles, CompileJavaSourceRequest(component=t, resolve=resolve))
+        Get(ClasspathEntry, CompileJavaSourceRequest(component=t, resolve=resolve))
         for t in coarsened_targets.closure()
     )
     merged_transitive_user_classfiles_digest = await Get(


### PR DESCRIPTION
#13506 and #13061 moved all usecases of `CompiledClassfiles` to producing and consuming JARs. To clarify the contract, and to prepare to produce this type in non-compilation positions in #13329, rename to `ClasspathEntry`.

[ci skip-rust]
[ci skip-build-wheels]