### PR TITLE
Add `--use-deprecated-python-macros` to allow safely using target generators

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -55,6 +55,8 @@ build_ignore.add = [
   "testprojects/src/go/**",
 ]
 
+use_deprecated_python_macros = false
+
 # NB: Users must still set `--remote-cache-{read,write}` to enable the remote cache.
 remote_store_address = "grpcs://cache.toolchain.com:443"
 remote_instance_name = "main"

--- a/src/python/pants/backend/python/macros/pants_requirement.py
+++ b/src/python/pants/backend/python/macros/pants_requirement.py
@@ -1,0 +1,92 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from typing import Optional, cast
+
+from pants.backend.python.target_types import (
+    PythonRequirementModulesField,
+    PythonRequirementsField,
+    PythonRequirementTarget,
+)
+from pants.base.build_environment import pants_version
+from pants.engine.addresses import Address
+from pants.engine.rules import collect_rules, rule
+from pants.engine.target import (
+    COMMON_TARGET_FIELDS,
+    GeneratedTargets,
+    GenerateTargetsRequest,
+    InvalidFieldException,
+    StringField,
+    Target,
+)
+from pants.engine.unions import UnionRule
+
+
+class PantsDistField(StringField):
+    alias = "dist"
+    default = "pantsbuild.pants"
+    help = (
+        "The Pants distribution. Must start with `pantsbuild.`, e.g. `pantsbuild.pants.testutil`."
+    )
+    value: str
+
+    @classmethod
+    def compute_value(cls, raw_value: Optional[str], address: Address) -> str:
+        value_or_default = cast(str, super().compute_value(raw_value, address))
+        if value_or_default != "pantsbuild.pants" and not value_or_default.startswith(
+            "pantsbuild.pants."
+        ):
+            raise InvalidFieldException(
+                f"The `{cls.alias}` field in target {address} must be `pantsbuild.pants` or "
+                f"start with `pantsbuild.pants.`, but it was: `{value_or_default}`."
+            )
+        return value_or_default
+
+
+class PantsModulesField(PythonRequirementModulesField):
+    help = (
+        "The modules exposed by the dist, e.g. `['pants.testutil']`.\n\n"
+        "This defaults to the name of the dist without the leading `pantsbuild`."
+    )
+
+
+class PantsRequirementTargetGenerator(Target):
+    alias = "pants_requirement"
+    help = (
+        "Generate a `python_requirement` target for Pants distributions using your current Pants "
+        "version.\n\n"
+        "This requirement is useful when writing plugins so that you can build and test your "
+        "plugin using Pants. Using the resulting target as a dependency of their plugin target "
+        "ensures the project version of Pants.\n\n"
+        "Note: the requirement generated is for official Pants releases on PyPI; so may not be "
+        "appropriate for use in a repo that uses custom Pants dists."
+    )
+    core_fields = (*COMMON_TARGET_FIELDS, PantsDistField, PantsModulesField)
+
+
+class GenerateFromPantsRequirementRequest(GenerateTargetsRequest):
+    generate_from = PantsRequirementTargetGenerator
+
+
+@rule
+def generate_from_pants_requirement(
+    request: GenerateFromPantsRequirementRequest,
+) -> GeneratedTargets:
+    generator = request.generator
+    dist = generator[PantsDistField].value
+    modules = generator[PantsModulesField].value or [dist.replace("pantsbuild.", "")]
+    tgt = PythonRequirementTarget(
+        {
+            PythonRequirementsField.alias: [f"{dist}=={pants_version()}"],
+            PythonRequirementModulesField.alias: modules,
+        },
+        generator.address.create_generated(dist),
+    )
+    return GeneratedTargets(generator, [tgt])
+
+
+def rules():
+    return (
+        *collect_rules(),
+        UnionRule(GenerateTargetsRequest, GenerateFromPantsRequirementRequest),
+    )

--- a/src/python/pants/backend/python/macros/pants_requirement_caof.py
+++ b/src/python/pants/backend/python/macros/pants_requirement_caof.py
@@ -10,7 +10,7 @@ from pants.build_graph.address import Address
 from pants.util.meta import classproperty
 
 
-class PantsRequirement:
+class PantsRequirementCAOF:
     """Exports a `python_requirement` pointing at the active Pants's corresponding dist.
 
     This requirement is useful for custom plugin authors who want to build and test their plugin with

--- a/src/python/pants/backend/python/macros/pants_requirement_caof_test.py
+++ b/src/python/pants/backend/python/macros/pants_requirement_caof_test.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from pants.backend.python.macros.pants_requirement import PantsRequirement
+from pants.backend.python.macros.pants_requirement_caof import PantsRequirementCAOF
 from pants.backend.python.pip_requirement import PipRequirement
 from pants.backend.python.target_types import (
     PythonRequirementModulesField,
@@ -20,7 +20,7 @@ from pants.testutil.rule_runner import RuleRunner
 def rule_runner() -> RuleRunner:
     return RuleRunner(
         target_types=[PythonRequirementTarget],
-        context_aware_object_factories={PantsRequirement.alias: PantsRequirement},
+        context_aware_object_factories={PantsRequirementCAOF.alias: PantsRequirementCAOF},
     )
 
 

--- a/src/python/pants/backend/python/macros/pants_requirement_test.py
+++ b/src/python/pants/backend/python/macros/pants_requirement_test.py
@@ -1,0 +1,81 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import pytest
+
+from pants.backend.python.macros import pants_requirement
+from pants.backend.python.macros.pants_requirement import (
+    GenerateFromPantsRequirementRequest,
+    PantsDistField,
+    PantsRequirementTargetGenerator,
+)
+from pants.backend.python.pip_requirement import PipRequirement
+from pants.backend.python.target_types import (
+    PythonRequirementModulesField,
+    PythonRequirementsField,
+    PythonRequirementTarget,
+)
+from pants.base.build_environment import pants_version
+from pants.engine.addresses import Address
+from pants.engine.target import GeneratedTargets, InvalidFieldException
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=(
+            *pants_requirement.rules(),
+            QueryRule(GeneratedTargets, [GenerateFromPantsRequirementRequest]),
+        ),
+        target_types=[PantsRequirementTargetGenerator],
+    )
+
+
+def assert_pants_requirement(
+    rule_runner: RuleRunner,
+    build_file_entry: str,
+    *,
+    expected_dist: str = "pantsbuild.pants",
+    expected_module: str = "pants",
+) -> None:
+    rule_runner.write_files({"BUILD": f"{build_file_entry}\n"})
+    generator = rule_runner.get_target(Address("", target_name="pants_req"))
+    result = rule_runner.request(GeneratedTargets, [GenerateFromPantsRequirementRequest(generator)])
+
+    assert len(result) == 1
+    generated = list(result.values())[0]
+    assert isinstance(generated, PythonRequirementTarget)
+    assert generated.address == generator.address.create_generated(expected_dist)
+
+    assert generated[PythonRequirementsField].value == (
+        PipRequirement.parse(f"{expected_dist}=={pants_version()}"),
+    )
+    modules = generated[PythonRequirementModulesField].value
+    assert modules == (expected_module,)
+
+
+def test_default(rule_runner: RuleRunner) -> None:
+    assert_pants_requirement(rule_runner, "pants_requirement(name='pants_req')")
+
+
+def test_override_dist(rule_runner: RuleRunner) -> None:
+    assert_pants_requirement(
+        rule_runner,
+        "pants_requirement(name='pants_req', dist='pantsbuild.pants.contrib')",
+        expected_dist="pantsbuild.pants.contrib",
+        expected_module="pants.contrib",
+    )
+
+
+def test_override_modules(rule_runner: RuleRunner) -> None:
+    assert_pants_requirement(
+        rule_runner,
+        "pants_requirement(name='pants_req', modules=['fake'])",
+        expected_module="fake",
+    )
+
+
+def test_bad_dist(rule_runner: RuleRunner) -> None:
+    with pytest.raises(InvalidFieldException):
+        PantsDistField("not_pants.dist", Address("", target_name="t"))

--- a/src/python/pants/backend/python/macros/pipenv_requirements_caof_test.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements_caof_test.py
@@ -7,7 +7,7 @@ from typing import Iterable
 
 import pytest
 
-from pants.backend.python.macros.pipenv_requirements import PipenvRequirements
+from pants.backend.python.macros.pipenv_requirements_caof import PipenvRequirementsCAOF
 from pants.backend.python.pip_requirement import PipRequirement
 from pants.backend.python.target_types import PythonRequirementsFile, PythonRequirementTarget
 from pants.engine.addresses import Address
@@ -19,7 +19,7 @@ from pants.testutil.rule_runner import RuleRunner
 def rule_runner() -> RuleRunner:
     return RuleRunner(
         target_types=[PythonRequirementTarget, PythonRequirementsFile],
-        context_aware_object_factories={"pipenv_requirements": PipenvRequirements},
+        context_aware_object_factories={"pipenv_requirements": PipenvRequirementsCAOF},
     )
 
 

--- a/src/python/pants/backend/python/macros/poetry_requirements_caof.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements_caof.py
@@ -356,7 +356,7 @@ def parse_pyproject_toml(pyproject_toml: PyProjectToml) -> set[PipRequirement]:
     )
 
 
-class PoetryRequirements:
+class PoetryRequirementsCAOF:
     """Translates dependencies specified in a  pyproject.toml Poetry file to a set of
     "python_requirements_library" targets.
 

--- a/src/python/pants/backend/python/macros/poetry_requirements_caof_test.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements_caof_test.py
@@ -10,8 +10,8 @@ from typing import Any, Iterable
 import pytest
 from packaging.version import Version
 
-from pants.backend.python.macros.poetry_requirements import (
-    PoetryRequirements,
+from pants.backend.python.macros.poetry_requirements_caof import (
+    PoetryRequirementsCAOF,
     PyprojectAttr,
     PyProjectToml,
     add_markers,
@@ -392,7 +392,7 @@ def test_parse_multi_reqs() -> None:
 def rule_runner() -> RuleRunner:
     return RuleRunner(
         target_types=[PythonRequirementTarget, PythonRequirementsFile],
-        context_aware_object_factories={"poetry_requirements": PoetryRequirements},
+        context_aware_object_factories={"poetry_requirements": PoetryRequirementsCAOF},
     )
 
 

--- a/src/python/pants/backend/python/macros/python_requirements_caof.py
+++ b/src/python/pants/backend/python/macros/python_requirements_caof.py
@@ -1,9 +1,10 @@
-# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import annotations
 
-import json
+import os
+from itertools import groupby
 from pathlib import Path
 from typing import Iterable, Mapping
 
@@ -13,22 +14,35 @@ from pants.backend.python.macros.caof_utils import (
     OVERRIDES_TYPE,
     flatten_overrides_to_dependency_field,
 )
-from pants.backend.python.pip_requirement import PipRequirement
-from pants.backend.python.target_types import normalize_module_mapping
+from pants.backend.python.target_types import normalize_module_mapping, parse_requirements_file
 from pants.base.build_environment import get_buildroot
 
 
-# TODO(#10655): add support for PEP 440 direct references (aka VCS style).
-# TODO(#10655): differentiate between Pipfile vs. Pipfile.lock.
-class PipenvRequirements:
-    """Translates a Pipenv.lock file into an equivalent set `python_requirement` targets.
+class PythonRequirementsCAOF:
+    """Translates a pip requirements file into an equivalent set of `python_requirement` targets.
+
+    If the `requirements.txt` file has lines `foo>=3.14` and `bar>=2.7`,
+    then this will translate to:
+
+      python_requirement(
+        name="foo",
+        requirements=["foo>=3.14"],
+      )
+
+      python_requirement(
+        name="bar",
+        requirements=["bar>=2.7"],
+      )
+
+    See the requirements file spec here:
+    https://pip.pypa.io/en/latest/reference/pip_install.html#requirements-file-format
 
     You may also use the parameter `module_mapping` to teach Pants what modules each of your
     requirements provide. For any requirement unspecified, Pants will default to the name of the
     requirement. This setting is important for Pants to know how to convert your import
     statements back into your dependencies. For example:
 
-        pipenv_requirements(
+        python_requirements(
           module_mapping={
             "ansicolors": ["colors"],
             "setuptools": ["pkg_resources"],
@@ -42,10 +56,9 @@ class PipenvRequirements:
     def __call__(
         self,
         *,
-        source: str = "Pipfile.lock",
+        source: str = "requirements.txt",
         module_mapping: Mapping[str, Iterable[str]] | None = None,
         type_stubs_module_mapping: Mapping[str, Iterable[str]] | None = None,
-        pipfile_target: str | None = None,
         overrides: OVERRIDES_TYPE = None,
     ) -> None:
         """
@@ -53,48 +66,37 @@ class PipenvRequirements:
             For example, `{"ansicolors": ["colors"]}`. Any unspecified requirements will use the
             requirement name as the default module, e.g. "Django" will default to
             `modules=["django"]`.
-        :param pipfile_target: a `_python_requirements_file` target to provide for cache invalidation
-        if the requirements_relpath value is not in the current rel_path
         """
-        requirements_path = Path(get_buildroot(), self._parse_context.rel_path, source)
-        lock_info = json.loads(requirements_path.read_text())
-
-        if pipfile_target:
-            requirements_dep = pipfile_target
-        else:
-            requirements_file_target_name = source
-            self._parse_context.create_object(
-                "_python_requirements_file",
-                name=requirements_file_target_name,
-                sources=[source],
-            )
-            requirements_dep = f":{requirements_file_target_name}"
+        req_file_tgt = self._parse_context.create_object(
+            "_python_requirements_file",
+            name=source.replace(os.path.sep, "_"),
+            sources=[source],
+        )
+        requirements_dep = f":{req_file_tgt.name}"
 
         normalized_module_mapping = normalize_module_mapping(module_mapping)
         normalized_type_stubs_module_mapping = normalize_module_mapping(type_stubs_module_mapping)
 
+        req_file = Path(get_buildroot(), self._parse_context.rel_path, source)
+        requirements = parse_requirements_file(
+            req_file.read_text(), rel_path=str(req_file.relative_to(get_buildroot()))
+        )
+
         dependencies_overrides = flatten_overrides_to_dependency_field(
             overrides, macro_name="python_requirements", build_file_dir=self._parse_context.rel_path
         )
+        grouped_requirements = groupby(requirements, lambda parsed_req: parsed_req.project_name)
 
-        requirements = {**lock_info.get("default", {}), **lock_info.get("develop", {})}
-        for req, info in requirements.items():
-            extras = [x for x in info.get("extras", [])]
-            extras_str = f"[{','.join(extras)}]" if extras else ""
-            req_str = f"{req}{extras_str}{info.get('version','')}"
-            if info.get("markers"):
-                req_str += f";{info['markers']}"
-
-            parsed_req = PipRequirement.parse(req_str)
-            normalized_proj_name = canonicalize_project_name(parsed_req.project_name)
+        for project_name, parsed_reqs_ in grouped_requirements:
+            normalized_proj_name = canonicalize_project_name(project_name)
             self._parse_context.create_object(
                 "python_requirement",
-                name=parsed_req.project_name,
-                requirements=[parsed_req],
+                name=project_name,
+                requirements=list(parsed_reqs_),
+                modules=normalized_module_mapping.get(normalized_proj_name),
+                type_stub_modules=normalized_type_stubs_module_mapping.get(normalized_proj_name),
                 dependencies=[
                     requirements_dep,
                     *dependencies_overrides.get(normalized_proj_name, []),
                 ],
-                modules=normalized_module_mapping.get(normalized_proj_name),
-                type_stub_modules=normalized_type_stubs_module_mapping.get(normalized_proj_name),
             )

--- a/src/python/pants/backend/python/macros/python_requirements_caof_test.py
+++ b/src/python/pants/backend/python/macros/python_requirements_caof_test.py
@@ -6,7 +6,7 @@ from typing import Iterable
 
 import pytest
 
-from pants.backend.python.macros.python_requirements import PythonRequirements
+from pants.backend.python.macros.python_requirements_caof import PythonRequirementsCAOF
 from pants.backend.python.pip_requirement import PipRequirement
 from pants.backend.python.target_types import PythonRequirementsFile, PythonRequirementTarget
 from pants.engine.addresses import Address
@@ -19,7 +19,7 @@ from pants.testutil.rule_runner import RuleRunner
 def rule_runner() -> RuleRunner:
     return RuleRunner(
         target_types=[PythonRequirementTarget, PythonRequirementsFile],
-        context_aware_object_factories={"python_requirements": PythonRequirements},
+        context_aware_object_factories={"python_requirements": PythonRequirementsCAOF},
     )
 
 

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -19,6 +19,8 @@ from pants.backend.python.goals import (
     setup_py,
     tailor,
 )
+from pants.backend.python.macros import pants_requirement
+from pants.backend.python.macros.pants_requirement import PantsRequirementTargetGenerator
 from pants.backend.python.macros.pants_requirement_caof import PantsRequirementCAOF
 from pants.backend.python.macros.pipenv_requirements_caof import PipenvRequirementsCAOF
 from pants.backend.python.macros.poetry_requirements_caof import PoetryRequirementsCAOF
@@ -84,6 +86,8 @@ def rules():
         *setuptools.rules(),
         *ipython.rules(),
         *pytest.rules(),
+        # Macros
+        *pants_requirement.rules(),
     )
 
 
@@ -98,4 +102,6 @@ def target_types():
         PythonTestTarget,
         PythonTestsGeneratorTarget,
         PythonTestUtilsGeneratorTarget,
+        # Macros
+        PantsRequirementTargetGenerator,
     ]

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -19,11 +19,11 @@ from pants.backend.python.goals import (
     setup_py,
     tailor,
 )
-from pants.backend.python.macros.pants_requirement import PantsRequirement
-from pants.backend.python.macros.pipenv_requirements import PipenvRequirements
-from pants.backend.python.macros.poetry_requirements import PoetryRequirements
+from pants.backend.python.macros.pants_requirement_caof import PantsRequirementCAOF
+from pants.backend.python.macros.pipenv_requirements_caof import PipenvRequirementsCAOF
+from pants.backend.python.macros.poetry_requirements_caof import PoetryRequirementsCAOF
 from pants.backend.python.macros.python_artifact import PythonArtifact
-from pants.backend.python.macros.python_requirements import PythonRequirements
+from pants.backend.python.macros.python_requirements_caof import PythonRequirementsCAOF
 from pants.backend.python.subsystems import ipython, pytest, python_native_code, setuptools
 from pants.backend.python.target_types import (
     PexBinary,
@@ -52,10 +52,10 @@ def build_file_aliases():
     return BuildFileAliases(
         objects={"python_artifact": PythonArtifact, "setup_py": PythonArtifact},
         context_aware_object_factories={
-            "python_requirements": PythonRequirements,
-            "poetry_requirements": PoetryRequirements,
-            "pipenv_requirements": PipenvRequirements,
-            PantsRequirement.alias: PantsRequirement,
+            "python_requirements": PythonRequirementsCAOF,
+            "poetry_requirements": PoetryRequirementsCAOF,
+            "pipenv_requirements": PipenvRequirementsCAOF,
+            PantsRequirementCAOF.alias: PantsRequirementCAOF,
         },
     )
 

--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -57,6 +57,9 @@ class ParseState(threading.local):
         return list(self._target_adapters)
 
 
+_AMBIGUOUS_PYTHON_MACRO_SYMBOLS = {"pants_requirement"}
+
+
 class Parser:
     def __init__(
         self,
@@ -64,9 +67,10 @@ class Parser:
         build_root: str,
         target_type_aliases: Iterable[str],
         object_aliases: BuildFileAliases,
+        use_deprecated_python_macros: bool = True,
     ) -> None:
         self._symbols, self._parse_state = self._generate_symbols(
-            build_root, target_type_aliases, object_aliases
+            build_root, target_type_aliases, object_aliases, use_deprecated_python_macros
         )
 
     @staticmethod
@@ -74,6 +78,7 @@ class Parser:
         build_root: str,
         target_type_aliases: Iterable[str],
         object_aliases: BuildFileAliases,
+        use_deprecated_python_macros: bool,
     ) -> tuple[dict[str, Any], ParseState]:
         # N.B.: We re-use the thread local ParseState across symbols for performance reasons.
         # This allows a single construction of all symbols here that can be re-used for each BUILD
@@ -99,13 +104,18 @@ class Parser:
                 return target_adaptor
 
         symbols: dict[str, Any] = dict(object_aliases.objects)
-        symbols.update((alias, Registrar(alias)) for alias in target_type_aliases)
+        symbols.update(
+            (alias, Registrar(alias))
+            for alias in target_type_aliases
+            if not use_deprecated_python_macros or alias not in _AMBIGUOUS_PYTHON_MACRO_SYMBOLS
+        )
 
         parse_context = ParseContext(
             build_root=build_root, type_aliases=symbols, rel_path_oracle=parse_state
         )
         for alias, object_factory in object_aliases.context_aware_object_factories.items():
-            symbols[alias] = object_factory(parse_context)
+            if use_deprecated_python_macros or alias not in _AMBIGUOUS_PYTHON_MACRO_SYMBOLS:
+                symbols[alias] = object_factory(parse_context)
 
         return symbols, parse_state
 

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -193,6 +193,7 @@ class EngineInitializer:
             include_trace_on_error=bootstrap_options.print_stacktrace,
             engine_visualize_to=bootstrap_options.engine_visualize_to,
             watch_filesystem=bootstrap_options.watch_filesystem,
+            use_deprecated_python_macros=bootstrap_options.use_deprecated_python_macros,
         )
 
     @staticmethod
@@ -211,6 +212,7 @@ class EngineInitializer:
         include_trace_on_error: bool = True,
         engine_visualize_to: str | None = None,
         watch_filesystem: bool = True,
+        use_deprecated_python_macros: bool = True,
     ) -> GraphScheduler:
         build_root_path = build_root or get_buildroot()
 
@@ -226,6 +228,7 @@ class EngineInitializer:
                 build_root=build_root_path,
                 target_type_aliases=registered_target_types.aliases,
                 object_aliases=build_configuration.registered_aliases,
+                use_deprecated_python_macros=use_deprecated_python_macros,
             )
 
         @rule

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1276,6 +1276,25 @@ class GlobalOptions(Subsystem):
             "may not be enabled.",
         )
 
+        register(
+            "--use-deprecated-python-macros",
+            advanced=True,
+            type=bool,
+            default=True,
+            help=(
+                "If true, continue using Pants's deprecated macro system for `pants_requirement` "
+                "rather than target generation.\n\n"
+                "The address for target generation is different. Rather than "
+                "`3rdparty/python:Django`, the address will look like `3rdparty/python#Django`. "
+                "The target generator (`pants_requirement`, `python_requirements`, etc) is a "
+                "target itself now, meaning you can give it a `name`. If the target generator sets "
+                "its `name`, e.g. to `reqs`, generated targets will have an address like "
+                "`3rdparty/python:reqs#Django`.\n\n"
+                "Soon, this option will also toggle for `poetry_requirements`, "
+                "`pipenv_requirements`, and `python_requirements`."
+            ),
+        )
+
     @classmethod
     def register_options(cls, register):
         """Register options not tied to any particular task or subsystem."""


### PR DESCRIPTION
Unblocks https://github.com/pantsbuild/pants/issues/12915. We now have a safe way to toggle whether symbols like `python_requirements` uses the old context-aware object factory (CAOF) vs. the new target generation.