### PR TITLE
[internal] Rename Python macros to use CAOF

### DIFF
--- a/src/python/pants/backend/python/macros/pants_requirement_caof.py
+++ b/src/python/pants/backend/python/macros/pants_requirement_caof.py
@@ -10,7 +10,7 @@ from pants.build_graph.address import Address
 from pants.util.meta import classproperty
 
 
-class PantsRequirement:
+class PantsRequirementCAOF:
     """Exports a `python_requirement` pointing at the active Pants's corresponding dist.
 
     This requirement is useful for custom plugin authors who want to build and test their plugin with

--- a/src/python/pants/backend/python/macros/pants_requirement_caof_test.py
+++ b/src/python/pants/backend/python/macros/pants_requirement_caof_test.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from pants.backend.python.macros.pants_requirement import PantsRequirement
+from pants.backend.python.macros.pants_requirement_caof import PantsRequirementCAOF
 from pants.backend.python.pip_requirement import PipRequirement
 from pants.backend.python.target_types import (
     PythonRequirementModulesField,
@@ -20,7 +20,7 @@ from pants.testutil.rule_runner import RuleRunner
 def rule_runner() -> RuleRunner:
     return RuleRunner(
         target_types=[PythonRequirementTarget],
-        context_aware_object_factories={PantsRequirement.alias: PantsRequirement},
+        context_aware_object_factories={PantsRequirementCAOF.alias: PantsRequirementCAOF},
     )
 
 

--- a/src/python/pants/backend/python/macros/pipenv_requirements_caof_test.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements_caof_test.py
@@ -7,7 +7,7 @@ from typing import Iterable
 
 import pytest
 
-from pants.backend.python.macros.pipenv_requirements import PipenvRequirements
+from pants.backend.python.macros.pipenv_requirements_caof import PipenvRequirementsCAOF
 from pants.backend.python.pip_requirement import PipRequirement
 from pants.backend.python.target_types import PythonRequirementsFile, PythonRequirementTarget
 from pants.engine.addresses import Address
@@ -19,7 +19,7 @@ from pants.testutil.rule_runner import RuleRunner
 def rule_runner() -> RuleRunner:
     return RuleRunner(
         target_types=[PythonRequirementTarget, PythonRequirementsFile],
-        context_aware_object_factories={"pipenv_requirements": PipenvRequirements},
+        context_aware_object_factories={"pipenv_requirements": PipenvRequirementsCAOF},
     )
 
 

--- a/src/python/pants/backend/python/macros/poetry_requirements_caof.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements_caof.py
@@ -356,7 +356,7 @@ def parse_pyproject_toml(pyproject_toml: PyProjectToml) -> set[PipRequirement]:
     )
 
 
-class PoetryRequirements:
+class PoetryRequirementsCAOF:
     """Translates dependencies specified in a  pyproject.toml Poetry file to a set of
     "python_requirements_library" targets.
 

--- a/src/python/pants/backend/python/macros/poetry_requirements_caof_test.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements_caof_test.py
@@ -10,8 +10,8 @@ from typing import Any, Iterable
 import pytest
 from packaging.version import Version
 
-from pants.backend.python.macros.poetry_requirements import (
-    PoetryRequirements,
+from pants.backend.python.macros.poetry_requirements_caof import (
+    PoetryRequirementsCAOF,
     PyprojectAttr,
     PyProjectToml,
     add_markers,
@@ -392,7 +392,7 @@ def test_parse_multi_reqs() -> None:
 def rule_runner() -> RuleRunner:
     return RuleRunner(
         target_types=[PythonRequirementTarget, PythonRequirementsFile],
-        context_aware_object_factories={"poetry_requirements": PoetryRequirements},
+        context_aware_object_factories={"poetry_requirements": PoetryRequirementsCAOF},
     )
 
 

--- a/src/python/pants/backend/python/macros/python_requirements_caof.py
+++ b/src/python/pants/backend/python/macros/python_requirements_caof.py
@@ -1,9 +1,10 @@
-# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import annotations
 
-import json
+import os
+from itertools import groupby
 from pathlib import Path
 from typing import Iterable, Mapping
 
@@ -13,22 +14,35 @@ from pants.backend.python.macros.caof_utils import (
     OVERRIDES_TYPE,
     flatten_overrides_to_dependency_field,
 )
-from pants.backend.python.pip_requirement import PipRequirement
-from pants.backend.python.target_types import normalize_module_mapping
+from pants.backend.python.target_types import normalize_module_mapping, parse_requirements_file
 from pants.base.build_environment import get_buildroot
 
 
-# TODO(#10655): add support for PEP 440 direct references (aka VCS style).
-# TODO(#10655): differentiate between Pipfile vs. Pipfile.lock.
-class PipenvRequirements:
-    """Translates a Pipenv.lock file into an equivalent set `python_requirement` targets.
+class PythonRequirementsCAOF:
+    """Translates a pip requirements file into an equivalent set of `python_requirement` targets.
+
+    If the `requirements.txt` file has lines `foo>=3.14` and `bar>=2.7`,
+    then this will translate to:
+
+      python_requirement(
+        name="foo",
+        requirements=["foo>=3.14"],
+      )
+
+      python_requirement(
+        name="bar",
+        requirements=["bar>=2.7"],
+      )
+
+    See the requirements file spec here:
+    https://pip.pypa.io/en/latest/reference/pip_install.html#requirements-file-format
 
     You may also use the parameter `module_mapping` to teach Pants what modules each of your
     requirements provide. For any requirement unspecified, Pants will default to the name of the
     requirement. This setting is important for Pants to know how to convert your import
     statements back into your dependencies. For example:
 
-        pipenv_requirements(
+        python_requirements(
           module_mapping={
             "ansicolors": ["colors"],
             "setuptools": ["pkg_resources"],
@@ -42,10 +56,9 @@ class PipenvRequirements:
     def __call__(
         self,
         *,
-        source: str = "Pipfile.lock",
+        source: str = "requirements.txt",
         module_mapping: Mapping[str, Iterable[str]] | None = None,
         type_stubs_module_mapping: Mapping[str, Iterable[str]] | None = None,
-        pipfile_target: str | None = None,
         overrides: OVERRIDES_TYPE = None,
     ) -> None:
         """
@@ -53,48 +66,37 @@ class PipenvRequirements:
             For example, `{"ansicolors": ["colors"]}`. Any unspecified requirements will use the
             requirement name as the default module, e.g. "Django" will default to
             `modules=["django"]`.
-        :param pipfile_target: a `_python_requirements_file` target to provide for cache invalidation
-        if the requirements_relpath value is not in the current rel_path
         """
-        requirements_path = Path(get_buildroot(), self._parse_context.rel_path, source)
-        lock_info = json.loads(requirements_path.read_text())
-
-        if pipfile_target:
-            requirements_dep = pipfile_target
-        else:
-            requirements_file_target_name = source
-            self._parse_context.create_object(
-                "_python_requirements_file",
-                name=requirements_file_target_name,
-                sources=[source],
-            )
-            requirements_dep = f":{requirements_file_target_name}"
+        req_file_tgt = self._parse_context.create_object(
+            "_python_requirements_file",
+            name=source.replace(os.path.sep, "_"),
+            sources=[source],
+        )
+        requirements_dep = f":{req_file_tgt.name}"
 
         normalized_module_mapping = normalize_module_mapping(module_mapping)
         normalized_type_stubs_module_mapping = normalize_module_mapping(type_stubs_module_mapping)
 
+        req_file = Path(get_buildroot(), self._parse_context.rel_path, source)
+        requirements = parse_requirements_file(
+            req_file.read_text(), rel_path=str(req_file.relative_to(get_buildroot()))
+        )
+
         dependencies_overrides = flatten_overrides_to_dependency_field(
             overrides, macro_name="python_requirements", build_file_dir=self._parse_context.rel_path
         )
+        grouped_requirements = groupby(requirements, lambda parsed_req: parsed_req.project_name)
 
-        requirements = {**lock_info.get("default", {}), **lock_info.get("develop", {})}
-        for req, info in requirements.items():
-            extras = [x for x in info.get("extras", [])]
-            extras_str = f"[{','.join(extras)}]" if extras else ""
-            req_str = f"{req}{extras_str}{info.get('version','')}"
-            if info.get("markers"):
-                req_str += f";{info['markers']}"
-
-            parsed_req = PipRequirement.parse(req_str)
-            normalized_proj_name = canonicalize_project_name(parsed_req.project_name)
+        for project_name, parsed_reqs_ in grouped_requirements:
+            normalized_proj_name = canonicalize_project_name(project_name)
             self._parse_context.create_object(
                 "python_requirement",
-                name=parsed_req.project_name,
-                requirements=[parsed_req],
+                name=project_name,
+                requirements=list(parsed_reqs_),
+                modules=normalized_module_mapping.get(normalized_proj_name),
+                type_stub_modules=normalized_type_stubs_module_mapping.get(normalized_proj_name),
                 dependencies=[
                     requirements_dep,
                     *dependencies_overrides.get(normalized_proj_name, []),
                 ],
-                modules=normalized_module_mapping.get(normalized_proj_name),
-                type_stub_modules=normalized_type_stubs_module_mapping.get(normalized_proj_name),
             )

--- a/src/python/pants/backend/python/macros/python_requirements_caof_test.py
+++ b/src/python/pants/backend/python/macros/python_requirements_caof_test.py
@@ -6,7 +6,7 @@ from typing import Iterable
 
 import pytest
 
-from pants.backend.python.macros.python_requirements import PythonRequirements
+from pants.backend.python.macros.python_requirements_caof import PythonRequirementsCAOF
 from pants.backend.python.pip_requirement import PipRequirement
 from pants.backend.python.target_types import PythonRequirementsFile, PythonRequirementTarget
 from pants.engine.addresses import Address
@@ -19,7 +19,7 @@ from pants.testutil.rule_runner import RuleRunner
 def rule_runner() -> RuleRunner:
     return RuleRunner(
         target_types=[PythonRequirementTarget, PythonRequirementsFile],
-        context_aware_object_factories={"python_requirements": PythonRequirements},
+        context_aware_object_factories={"python_requirements": PythonRequirementsCAOF},
     )
 
 

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -19,11 +19,11 @@ from pants.backend.python.goals import (
     setup_py,
     tailor,
 )
-from pants.backend.python.macros.pants_requirement import PantsRequirement
-from pants.backend.python.macros.pipenv_requirements import PipenvRequirements
-from pants.backend.python.macros.poetry_requirements import PoetryRequirements
+from pants.backend.python.macros.pants_requirement_caof import PantsRequirementCAOF
+from pants.backend.python.macros.pipenv_requirements_caof import PipenvRequirementsCAOF
+from pants.backend.python.macros.poetry_requirements_caof import PoetryRequirementsCAOF
 from pants.backend.python.macros.python_artifact import PythonArtifact
-from pants.backend.python.macros.python_requirements import PythonRequirements
+from pants.backend.python.macros.python_requirements_caof import PythonRequirementsCAOF
 from pants.backend.python.subsystems import ipython, pytest, python_native_code, setuptools
 from pants.backend.python.target_types import (
     PexBinary,
@@ -52,10 +52,10 @@ def build_file_aliases():
     return BuildFileAliases(
         objects={"python_artifact": PythonArtifact, "setup_py": PythonArtifact},
         context_aware_object_factories={
-            "python_requirements": PythonRequirements,
-            "poetry_requirements": PoetryRequirements,
-            "pipenv_requirements": PipenvRequirements,
-            PantsRequirement.alias: PantsRequirement,
+            "python_requirements": PythonRequirementsCAOF,
+            "poetry_requirements": PoetryRequirementsCAOF,
+            "pipenv_requirements": PipenvRequirementsCAOF,
+            PantsRequirementCAOF.alias: PantsRequirementCAOF,
         },
     )
 


### PR DESCRIPTION
Prework for https://github.com/pantsbuild/pants/issues/12915. This makes more clear what is an old macro vs what will be a new target generator.

See https://github.com/pantsbuild/pants/pull/12802 for an example followup.

[ci skip-rust]
[ci skip-build-wheels]