### PR TITLE
[internal] Refactor `engine_aware.rs` to acquire the GIL fewer times

### DIFF
--- a/src/rust/engine/src/externs/engine_aware.rs
+++ b/src/rust/engine/src/externs/engine_aware.rs
@@ -5,113 +5,99 @@ use crate::context::Context;
 use crate::externs;
 use crate::nodes::{lift_directory_digest, lift_file_digest};
 use crate::python::{TypeId, Value};
-use crate::Failure;
 use crate::Types;
 
-use cpython::{PyDict, PyString, Python};
-use workunit_store::{ArtifactOutput, Level, UserMetadataItem, UserMetadataPyValue};
+use cpython::{ObjectProtocol, PyDict, PyString, Python};
+use workunit_store::{
+  ArtifactOutput, Level, RunningWorkunit, UserMetadataItem, UserMetadataPyValue,
+};
 
-pub struct EngineAwareReturnType;
+#[derive(Default, Clone, Debug)]
+pub(crate) struct EngineAwareReturnType {
+  level: Option<Level>,
+  message: Option<String>,
+  metadata: Vec<(String, UserMetadataItem)>,
+  artifacts: Vec<(String, ArtifactOutput)>,
+}
 
 impl EngineAwareReturnType {
-  pub fn level(value: &Value) -> Option<Level> {
-    let gil = Python::acquire_gil();
-    let py = gil.python();
-    let level_val = externs::call_method0(py, value.as_ref(), "level").ok()?;
+  pub(crate) fn from_task_result(py: Python, task_result: &Value, context: &Context) -> Self {
+    Self {
+      level: Self::level(py, task_result),
+      message: Self::message(py, task_result),
+      artifacts: Self::artifacts(py, &context.core.types, task_result),
+      metadata: metadata(py, context, task_result),
+    }
+  }
+
+  pub(crate) fn update_workunit(self, workunit: &mut RunningWorkunit) {
+    workunit.update_metadata(|mut metadata| {
+      if let Some(new_level) = self.level {
+        metadata.level = new_level;
+      }
+      metadata.message = self.message;
+      metadata.artifacts.extend(self.artifacts);
+      metadata.user_metadata.extend(self.metadata);
+      metadata
+    });
+  }
+
+  fn level(py: Python, value: &Value) -> Option<Level> {
+    let level_val = externs::call_method0(py, value, "level").unwrap();
     if level_val.is_none(py) {
       return None;
     }
-    externs::val_to_log_level(&level_val).ok()
+    Some(externs::val_to_log_level(&level_val).unwrap())
   }
 
-  pub fn message(value: &Value) -> Option<String> {
-    let gil = Python::acquire_gil();
-    let py = gil.python();
-    let msg_val = externs::call_method0(py, value, "message").ok()?;
+  fn message(py: Python, value: &Value) -> Option<String> {
+    let msg_val = externs::call_method0(py, value, "message").unwrap();
     if msg_val.is_none(py) {
       return None;
     }
-    msg_val.extract(py).ok()
+    msg_val.extract(py).unwrap()
   }
 
-  pub fn cacheable(value: &Value) -> Option<bool> {
-    let gil = Python::acquire_gil();
-    let py = gil.python();
-    externs::call_method0(py, value, "cacheable")
-      .ok()?
-      .extract(py)
-      .ok()
-  }
-
-  pub fn metadata(context: &Context, value: &Value) -> Option<Vec<(String, UserMetadataItem)>> {
-    metadata(context, value)
-  }
-
-  pub fn artifacts(types: &Types, value: &Value) -> Option<Vec<(String, ArtifactOutput)>> {
-    let gil = Python::acquire_gil();
-    let py = gil.python();
-    let artifacts_val = match externs::call_method0(py, value, "artifacts") {
-      Ok(value) => value,
-      Err(py_err) => {
-        let failure = Failure::from_py_err(py_err);
-        log::error!("Error calling `artifacts` method: {}", failure);
-        return None;
-      }
-    };
+  fn artifacts(py: Python, types: &Types, value: &Value) -> Vec<(String, ArtifactOutput)> {
+    let artifacts_val = externs::call_method0(py, value, "artifacts").unwrap();
     if artifacts_val.is_none(py) {
-      return None;
+      return vec![];
     }
 
-    let artifacts_dict: &PyDict = artifacts_val.cast_as::<PyDict>(py).ok()?;
+    let artifacts_dict: &PyDict = artifacts_val.cast_as::<PyDict>(py).unwrap();
     let mut output = Vec::new();
 
     for (key, value) in artifacts_dict.items(py).into_iter() {
-      let key_name: String = match key.cast_as::<PyString>(py) {
-        Ok(s) => s.to_string_lossy(py).into(),
-        Err(e) => {
-          log::error!(
-            "Error in EngineAware.artifacts() implementation - non-string key: {:?}",
-            e
-          );
-          return None;
-        }
-      };
+      let key_name: String = key
+        .cast_as::<PyString>(py)
+        .unwrap()
+        .to_string_lossy(py)
+        .into();
 
       let artifact_output = if TypeId::new(&value.get_type(py)) == types.file_digest {
-        match lift_file_digest(types, &value) {
-          Ok(digest) => ArtifactOutput::FileDigest(digest),
-          Err(e) => {
-            log::error!("Error in EngineAware.artifacts() implementation: {}", e);
-            return None;
-          }
-        }
+        lift_file_digest(types, &value).map(ArtifactOutput::FileDigest)
       } else {
-        let digest_value = externs::getattr(&value, "digest")
-          .map_err(|e| {
-            log::error!("Error in EngineAware.artifacts() - no `digest` attr: {}", e);
-          })
-          .ok()?;
-
-        match lift_directory_digest(&Value::new(digest_value)) {
-          Ok(digest) => ArtifactOutput::Snapshot(digest),
-          Err(e) => {
-            log::error!("Error in EngineAware.artifacts() implementation: {}", e);
-            return None;
-          }
-        }
-      };
+        let digest_value = value.getattr(py, "digest").unwrap();
+        lift_directory_digest(&digest_value).map(ArtifactOutput::Snapshot)
+      }
+      .unwrap();
       output.push((key_name, artifact_output));
     }
-    Some(output)
+    output
+  }
+
+  pub(crate) fn is_cacheable(py: Python, value: &Value) -> bool {
+    externs::call_method0(py, value, "cacheable")
+      .unwrap()
+      .extract(py)
+      .unwrap()
   }
 }
 
 pub struct EngineAwareParameter;
 
 impl EngineAwareParameter {
-  pub fn debug_hint(value: &Value) -> Option<String> {
-    let gil = Python::acquire_gil();
-    let py = gil.python();
+  pub fn debug_hint(py: Python, value: &Value) -> Option<String> {
     let hint = externs::call_method0(py, value, "debug_hint").ok()?;
     if hint.is_none(py) {
       return None;
@@ -119,41 +105,22 @@ impl EngineAwareParameter {
     hint.extract(py).ok()
   }
 
-  pub fn metadata(context: &Context, value: &Value) -> Option<Vec<(String, UserMetadataItem)>> {
-    metadata(context, value)
+  pub fn metadata(py: Python, context: &Context, value: &Value) -> Vec<(String, UserMetadataItem)> {
+    metadata(py, context, value)
   }
 }
 
-fn metadata(context: &Context, value: &Value) -> Option<Vec<(String, UserMetadataItem)>> {
-  let gil = Python::acquire_gil();
-  let py = gil.python();
-  let metadata_val = match externs::call_method0(py, value, "metadata") {
-    Ok(value) => value,
-    Err(py_err) => {
-      let failure = Failure::from_py_err(py_err);
-      log::error!("Error calling `metadata` method: {}", failure);
-      return None;
-    }
-  };
+fn metadata(py: Python, context: &Context, value: &Value) -> Vec<(String, UserMetadataItem)> {
+  let metadata_val = externs::call_method0(py, value, "metadata").unwrap();
   if metadata_val.is_none(py) {
-    return None;
+    return vec![];
   }
 
   let mut output = Vec::new();
-  let metadata_dict: &PyDict = metadata_val.cast_as::<PyDict>(py).ok()?;
+  let metadata_dict: &PyDict = metadata_val.cast_as::<PyDict>(py).unwrap();
 
   for (key, value) in metadata_dict.items(py).into_iter() {
-    let key_name: String = match key.extract(py) {
-      Ok(s) => s,
-      Err(e) => {
-        log::error!(
-          "Error in EngineAware.metadata() implementation - non-string key: {:?}",
-          e
-        );
-        return None;
-      }
-    };
-
+    let key_name: String = key.extract(py).unwrap();
     let py_value_handle = UserMetadataPyValue::new();
     let umi = UserMetadataItem::PyValue(py_value_handle.clone());
     context.session.with_metadata_map(|map| {
@@ -161,5 +128,5 @@ fn metadata(context: &Context, value: &Value) -> Option<Vec<(String, UserMetadat
     });
     output.push((key_name, umi));
   }
-  Some(output)
+  output
 }

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -229,20 +229,8 @@ pub fn create_exception(msg: &str) -> Value {
   Value::from(PyErr::new::<cpython::exc::Exception, _>(py, msg).instance(py))
 }
 
-pub fn check_for_python_none(value: PyObject) -> Option<PyObject> {
-  let gil = Python::acquire_gil();
-  let py = gil.python();
-  if value == py.None() {
-    return None;
-  }
-  Some(value)
-}
-
-pub fn call_method(value: &PyObject, method: &str, args: &[Value]) -> Result<PyObject, PyErr> {
-  let arg_handles: Vec<PyObject> = args.iter().map(|v| v.clone().into()).collect();
-  let gil = Python::acquire_gil();
-  let args_tuple = PyTuple::new(gil.python(), &arg_handles);
-  value.call_method(gil.python(), method, args_tuple, None)
+pub fn call_method0(py: Python, value: &PyObject, method: &str) -> Result<PyObject, PyErr> {
+  value.call_method(py, method, PyTuple::new(py, &[]), None)
 }
 
 pub fn call_function<T: AsRef<PyObject>>(func: T, args: &[Value]) -> Result<PyObject, PyErr> {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -20,7 +20,6 @@ use url::Url;
 use crate::context::{Context, Core};
 use crate::downloads;
 use crate::externs;
-use crate::externs::engine_aware;
 use crate::python::{display_sorted_in_parens, throw, Failure, Key, Params, TypeId, Value};
 use crate::selectors;
 use crate::tasks::{self, Rule};
@@ -36,6 +35,7 @@ use process_execution::{
   ProcessResultSource,
 };
 
+use crate::externs::engine_aware::{EngineAwareParameter, EngineAwareReturnType};
 use graph::{Entry, Node, NodeError, NodeVisualizer};
 use hashing::{Digest, Fingerprint};
 use store::{self, StoreFileByDigest};
@@ -1131,26 +1131,24 @@ impl WrappedNode for Task {
     };
 
     let func = self.task.func;
-    let entry = self.entry;
-    let product = self.product;
-    let side_effecting = self.task.side_effecting;
-    let engine_aware_return_type = self.task.engine_aware_return_type;
 
-    let result_val = maybe_side_effecting(side_effecting, &self.side_effected, async move {
-      externs::call_function(&func.0.to_value(), &deps).map_err(Failure::from_py_err)
-    })
-    .await?;
-    let mut result_val: Value = result_val.into();
+    let mut result_val: Value =
+      maybe_side_effecting(self.task.side_effecting, &self.side_effected, async move {
+        externs::call_function(&func.0.to_value(), &deps).map_err(Failure::from_py_err)
+      })
+      .await?
+      .into();
     let mut result_type = {
       let gil = Python::acquire_gil();
       let py = gil.python();
       TypeId::new(&result_val.get_type(py))
     };
+
     if result_type == context.core.types.coroutine {
       result_val = maybe_side_effecting(
-        side_effecting,
+        self.task.side_effecting,
         &self.side_effected,
-        Self::generate(&context, workunit, params, entry, result_val),
+        Self::generate(&context, workunit, params, self.entry, result_val),
       )
       .await?;
       let gil = Python::acquire_gil();
@@ -1158,35 +1156,23 @@ impl WrappedNode for Task {
       result_type = TypeId::new(&result_val.get_type(py));
     }
 
-    if result_type == product {
-      let (new_level, message, new_artifacts, new_metadata) = if engine_aware_return_type {
-        (
-          engine_aware::EngineAwareReturnType::level(&result_val),
-          engine_aware::EngineAwareReturnType::message(&result_val),
-          engine_aware::EngineAwareReturnType::artifacts(&context.core.types, &result_val)
-            .unwrap_or_else(Vec::new),
-          engine_aware::EngineAwareReturnType::metadata(&context, &result_val)
-            .unwrap_or_else(Vec::new),
-        )
-      } else {
-        (None, None, Vec::new(), Vec::new())
-      };
-      workunit.update_metadata(|mut metadata| {
-        if let Some(new_level) = new_level {
-          metadata.level = new_level;
-        }
-        metadata.message = message;
-        metadata.artifacts.extend(new_artifacts);
-        metadata.user_metadata.extend(new_metadata);
-        metadata
-      });
-      Ok(result_val)
-    } else {
-      Err(throw(&format!(
+    if result_type != self.product {
+      return Err(throw(&format!(
         "{:?} returned a result value that did not satisfy its constraints: {:?}",
         func, result_val
-      )))
+      )));
     }
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let engine_aware_return_type = if self.task.engine_aware_return_type {
+      EngineAwareReturnType::from_task_result(py, &result_val, &context)
+    } else {
+      EngineAwareReturnType::default()
+    };
+    engine_aware_return_type.update_workunit(workunit);
+
+    Ok(result_val)
   }
 }
 
@@ -1374,11 +1360,14 @@ impl Node for NodeKey {
       }
       _ => vec![],
     };
-    let user_metadata = engine_aware_params
-      .iter()
-      .filter_map(|val| engine_aware::EngineAwareParameter::metadata(&context, val))
-      .flatten()
-      .collect();
+    let user_metadata = {
+      let gil = Python::acquire_gil();
+      let py = gil.python();
+      engine_aware_params
+        .iter()
+        .flat_map(|val| EngineAwareParameter::metadata(py, &context, val))
+        .collect()
+    };
 
     let metadata = WorkunitMetadata {
       desc: user_facing_name,
@@ -1475,10 +1464,14 @@ impl Node for NodeKey {
         // If the node failed, expand the Failure with a new frame.
         result = result.map_err(|failure| {
           let name = workunit_name;
-          let displayable_param_names: Vec<_> = engine_aware_params
-            .iter()
-            .filter_map(|val| engine_aware::EngineAwareParameter::debug_hint(val))
-            .collect();
+          let displayable_param_names: Vec<_> = {
+            let gil = Python::acquire_gil();
+            let py = gil.python();
+            engine_aware_params
+              .iter()
+              .filter_map(|val| EngineAwareParameter::debug_hint(py, val))
+              .collect()
+          };
           let failure_name = if displayable_param_names.is_empty() {
             name
           } else if displayable_param_names.len() == 1 {
@@ -1534,7 +1527,9 @@ impl Node for NodeKey {
         ProcessCacheScope::PerSession => false,
       },
       (NodeKey::Task(ref t), NodeOutput::Value(ref v)) if t.task.engine_aware_return_type => {
-        engine_aware::EngineAwareReturnType::cacheable(v).unwrap_or(true)
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        EngineAwareReturnType::is_cacheable(py, v)
       }
       _ => true,
     }
@@ -1553,11 +1548,15 @@ impl Display for NodeKey {
       &NodeKey::Scandir(ref s) => write!(f, "Scandir({})", (s.0).0.display()),
       &NodeKey::Select(ref s) => write!(f, "{}", s.product),
       &NodeKey::Task(ref task) => {
-        let params = task
-          .params
-          .keys()
-          .filter_map(|k| engine_aware::EngineAwareParameter::debug_hint(&k.to_value()))
-          .collect::<Vec<_>>();
+        let params = {
+          let gil = Python::acquire_gil();
+          let py = gil.python();
+          task
+            .params
+            .keys()
+            .filter_map(|k| EngineAwareParameter::debug_hint(py, &k.to_value()))
+            .collect::<Vec<_>>()
+        };
         write!(
           f,
           "@rule({}({}))",

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1163,9 +1163,9 @@ impl WrappedNode for Task {
       )));
     }
 
-    let gil = Python::acquire_gil();
-    let py = gil.python();
     let engine_aware_return_type = if self.task.engine_aware_return_type {
+      let gil = Python::acquire_gil();
+      let py = gil.python();
       EngineAwareReturnType::from_task_result(py, &result_val, &context)
     } else {
       EngineAwareReturnType::default()

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1529,7 +1529,7 @@ impl Node for NodeKey {
       (NodeKey::Task(ref t), NodeOutput::Value(ref v)) if t.task.engine_aware_return_type => {
         let gil = Python::acquire_gil();
         let py = gil.python();
-        EngineAwareReturnType::is_cacheable(py, v)
+        EngineAwareReturnType::is_cacheable(py, v).unwrap_or(true)
       }
       _ => true,
     }


### PR DESCRIPTION
The PyO3 maintainers recommended that our low-level helpers request `Python` (a lock for the GIL) as an argument, rather than acquiring it directly: https://github.com/pantsbuild/pants/pull/12451#discussion_r678854195. This is because acquiring the GIL has a non-trivial overhead, and it allows callers to batch the operation. Indeed, this PR has two `map` operations where we now only acquire the GIL once, rather than n times.

This also simplifies our handling of `TypeError`s for less verbose code. As explained in https://github.com/pantsbuild/pants/pull/13515#issuecomment-962679500, MyPy already will handle these issues and they're also not mission-critical. Not worth the boilerplate to duplicate MyPy.