### PR TITLE
[internal] Make explicit when using the GIL with `store_*` FFI helpers

### DIFF
--- a/src/rust/engine/src/externs/fs.rs
+++ b/src/rust/engine/src/externs/fs.rs
@@ -29,9 +29,8 @@ use store::Snapshot;
 /// TODO: See https://github.com/dgrunwald/rust-cpython/issues/242
 ///
 
-pub fn to_py_digest(digest: Digest) -> PyResult<PyDigest> {
-  let gil = Python::acquire_gil();
-  PyDigest::create_instance(gil.python(), digest)
+pub fn to_py_digest(py: Python, digest: Digest) -> PyResult<PyDigest> {
+  PyDigest::create_instance(py, digest)
 }
 
 pub fn from_py_digest(digest: &PyObject) -> PyResult<Digest> {
@@ -82,9 +81,8 @@ py_class!(pub class PyDigest |py| {
     }
 });
 
-pub fn to_py_snapshot(snapshot: Snapshot) -> PyResult<PySnapshot> {
-  let gil = Python::acquire_gil();
-  PySnapshot::create_instance(gil.python(), snapshot)
+pub fn to_py_snapshot(py: Python, snapshot: Snapshot) -> PyResult<PySnapshot> {
+  PySnapshot::create_instance(py, snapshot)
 }
 
 py_class!(pub class PySnapshot |py| {
@@ -106,7 +104,7 @@ py_class!(pub class PySnapshot |py| {
     }
 
     @property def digest(&self) -> PyResult<PyDigest> {
-      to_py_digest(self.snapshot(py).digest)
+      to_py_digest(py, self.snapshot(py).digest)
     }
 
     @property def files(&self) -> PyResult<PyTuple> {

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1029,10 +1029,10 @@ async fn workunit_to_py_value(
             let gil = Python::acquire_gil();
             PyErr::new::<exc::Exception, _>(gil.python(), (err_str,))
           })?;
-        crate::nodes::Snapshot::store_snapshot(snapshot).map_err(|err_str| {
-          let gil = Python::acquire_gil();
-          PyErr::new::<exc::Exception, _>(gil.python(), (err_str,))
-        })?
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        crate::nodes::Snapshot::store_snapshot(py, snapshot)
+          .map_err(|err_str| PyErr::new::<exc::Exception, _>(py, (err_str,)))?
       }
     };
 
@@ -1714,7 +1714,8 @@ fn capture_snapshots(
               digest_hint,
             )
             .await?;
-            nodes::Snapshot::store_snapshot(snapshot)
+            let gil = Python::acquire_gil();
+            nodes::Snapshot::store_snapshot(gil.python(), snapshot)
           }
         })
         .collect::<Vec<_>>();

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -778,6 +778,7 @@ fn nailgun_server_create(
             .collect::<Vec<_>>(),
         );
         let env = externs::store_dict(
+          py,
           exe
             .cmd
             .env
@@ -1067,7 +1068,7 @@ async fn workunit_to_py_value(
 
   dict_entries.push((
     externs::store_utf8("metadata"),
-    externs::store_dict(user_metadata_entries)?,
+    externs::store_dict(py, user_metadata_entries)?,
   ));
 
   if let Some(stdout_digest) = &workunit.metadata.stdout.as_ref() {
@@ -1086,7 +1087,7 @@ async fn workunit_to_py_value(
 
   dict_entries.push((
     externs::store_utf8("artifacts"),
-    externs::store_dict(artifact_entries)?,
+    externs::store_dict(py, artifact_entries)?,
   ));
 
   if !workunit.counters.is_empty() {
@@ -1103,11 +1104,11 @@ async fn workunit_to_py_value(
 
     dict_entries.push((
       externs::store_utf8("counters"),
-      externs::store_dict(counters_entries)?,
+      externs::store_dict(py, counters_entries)?,
     ));
   }
 
-  externs::store_dict(dict_entries)
+  externs::store_dict(py, dict_entries)
 }
 
 async fn workunits_to_py_tuple_value<'a>(
@@ -1207,7 +1208,7 @@ fn scheduler_metrics(
         .into_iter()
         .map(|(metric, value)| (externs::store_utf8(metric), externs::store_i64(py, value)))
         .collect::<Vec<_>>();
-      externs::store_dict(values).map(|d| d.consume_into_py_object(py))
+      externs::store_dict(py, values).map(|d| d.consume_into_py_object(py))
     })
   })
 }

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -78,12 +78,9 @@ pub fn store_dict(keys_and_values: Vec<(Value, Value)>) -> Result<Value, PyErr> 
   Ok(Value::from(dict.into_object()))
 }
 
-///
 /// Store an opaque buffer of bytes to pass to Python. This will end up as a Python `bytes`.
-///
-pub fn store_bytes(bytes: &[u8]) -> Value {
-  let gil = Python::acquire_gil();
-  Value::from(PyBytes::new(gil.python(), bytes).into_object())
+pub fn store_bytes(py: Python, bytes: &[u8]) -> Value {
+  Value::from(PyBytes::new(py, bytes).into_object())
 }
 
 ///

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -96,9 +96,8 @@ pub fn store_u64(val: u64) -> Value {
   Value::from(val.to_py_object(gil.python()).into_object())
 }
 
-pub fn store_i64(val: i64) -> Value {
-  let gil = Python::acquire_gil();
-  Value::from(val.to_py_object(gil.python()).into_object())
+pub fn store_i64(py: Python, val: i64) -> Value {
+  Value::from(val.to_py_object(py).into_object())
 }
 
 pub fn store_bool(val: bool) -> Value {

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -54,13 +54,12 @@ pub fn equals(h1: &PyObject, h2: &PyObject) -> bool {
     .is_true()
 }
 
-pub fn store_tuple(values: Vec<Value>) -> Value {
-  let gil = Python::acquire_gil();
+pub fn store_tuple(py: Python, values: Vec<Value>) -> Value {
   let arg_handles: Vec<_> = values
     .into_iter()
-    .map(|v| v.consume_into_py_object(gil.python()))
+    .map(|v| v.consume_into_py_object(py))
     .collect();
-  Value::from(PyTuple::new(gil.python(), &arg_handles).into_object())
+  Value::from(PyTuple::new(py, &arg_handles).into_object())
 }
 
 /// Store a slice containing 2-tuples of (key, value) as a Python dictionary.

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -91,9 +91,8 @@ pub fn store_utf8(utf8: &str) -> Value {
   Value::from(utf8.to_py_object(gil.python()).into_object())
 }
 
-pub fn store_u64(val: u64) -> Value {
-  let gil = Python::acquire_gil();
-  Value::from(val.to_py_object(gil.python()).into_object())
+pub fn store_u64(py: Python, val: u64) -> Value {
+  Value::from(val.to_py_object(py).into_object())
 }
 
 pub fn store_i64(py: Python, val: i64) -> Value {

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -80,12 +80,9 @@ pub fn store_bytes(py: Python, bytes: &[u8]) -> Value {
   Value::from(PyBytes::new(py, bytes).into_object())
 }
 
-///
-/// Store an buffer of utf8 bytes to pass to Python. This will end up as a Python `unicode`.
-///
-pub fn store_utf8(utf8: &str) -> Value {
-  let gil = Python::acquire_gil();
-  Value::from(utf8.to_py_object(gil.python()).into_object())
+/// Store an buffer of utf8 bytes to pass to Python. This will end up as a Python `str`.
+pub fn store_utf8(py: Python, utf8: &str) -> Value {
+  Value::from(utf8.to_py_object(py).into_object())
 }
 
 pub fn store_u64(py: Python, val: u64) -> Value {

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -63,13 +63,11 @@ pub fn store_tuple(py: Python, values: Vec<Value>) -> Value {
 }
 
 /// Store a slice containing 2-tuples of (key, value) as a Python dictionary.
-pub fn store_dict(keys_and_values: Vec<(Value, Value)>) -> Result<Value, PyErr> {
-  let gil = Python::acquire_gil();
-  let py = gil.python();
+pub fn store_dict(py: Python, keys_and_values: Vec<(Value, Value)>) -> Result<Value, PyErr> {
   let dict = PyDict::new(py);
   for (k, v) in keys_and_values {
     dict.set_item(
-      gil.python(),
+      py,
       k.consume_into_py_object(py),
       v.consume_into_py_object(py),
     )?;

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -99,9 +99,8 @@ pub fn store_i64(py: Python, val: i64) -> Value {
   Value::from(val.to_py_object(py).into_object())
 }
 
-pub fn store_bool(val: bool) -> Value {
-  let gil = Python::acquire_gil();
-  Value::from(val.to_py_object(gil.python()).into_object())
+pub fn store_bool(py: Python, val: bool) -> Value {
+  Value::from(val.to_py_object(py).into_object())
 }
 
 ///

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -374,7 +374,8 @@ fn path_globs_to_paths(
     let path_globs = Snapshot::lift_path_globs(&val)
       .map_err(|e| throw(&format!("Failed to parse PathGlobs: {}", e)))?;
     let paths = context.get(Paths::from_path_globs(path_globs)).await?;
-    Paths::store_paths(&core, &paths).map_err(|e: String| throw(&e))
+    let gil = Python::acquire_gil();
+    Paths::store_paths(gil.python(), &core, &paths).map_err(|e: String| throw(&e))
   }
   .boxed()
 }

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -210,7 +210,7 @@ fn multi_platform_process_request_to_process_result(
         Snapshot::store_directory_digest(&result.output_directory).map_err(|s| throw(&s))?,
         externs::unsafe_call(
           context.core.types.platform,
-          &[externs::store_utf8(&platform_name)],
+          &[externs::store_utf8(py, &platform_name)],
         ),
       ],
     ))

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -791,12 +791,16 @@ impl Snapshot {
     }
   }
 
-  fn store_file_content(types: &crate::types::Types, item: &FileContent) -> Result<Value, String> {
+  fn store_file_content(
+    py: Python,
+    types: &crate::types::Types,
+    item: &FileContent,
+  ) -> Result<Value, String> {
     Ok(externs::unsafe_call(
       types.file_content,
       &[
         Self::store_path(&item.path)?,
-        externs::store_bytes(&item.content),
+        externs::store_bytes(py, &item.content),
         externs::store_bool(item.is_executable),
       ],
     ))
@@ -820,10 +824,14 @@ impl Snapshot {
     ))
   }
 
-  pub fn store_digest_contents(context: &Context, item: &[FileContent]) -> Result<Value, String> {
+  pub fn store_digest_contents(
+    py: Python,
+    context: &Context,
+    item: &[FileContent],
+  ) -> Result<Value, String> {
     let entries = item
       .iter()
-      .map(|e| Self::store_file_content(&context.core.types, e))
+      .map(|e| Self::store_file_content(py, &context.core.types, e))
       .collect::<Result<Vec<_>, _>>()?;
     Ok(externs::unsafe_call(
       context.core.types.digest_contents,

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -755,8 +755,8 @@ impl Snapshot {
       .map_err(|e| format!("Failed to parse PathGlobs for globs({:?}): {}", item, e))
   }
 
-  pub fn store_directory_digest(item: &hashing::Digest) -> Result<Value, String> {
-    externs::fs::to_py_digest(*item)
+  pub fn store_directory_digest(py: Python, item: &hashing::Digest) -> Result<Value, String> {
+    externs::fs::to_py_digest(py, *item)
       .map(|d| d.into_object().into())
       .map_err(|e| format!("{:?}", e))
   }
@@ -784,8 +784,8 @@ impl Snapshot {
     )
   }
 
-  pub fn store_snapshot(item: store::Snapshot) -> Result<Value, String> {
-    externs::fs::to_py_snapshot(item)
+  pub fn store_snapshot(py: Python, item: store::Snapshot) -> Result<Value, String> {
+    externs::fs::to_py_snapshot(py, item)
       .map(|d| d.into_object().into())
       .map_err(|e| format!("{:?}", e))
   }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -805,7 +805,7 @@ impl Snapshot {
       &[
         Self::store_path(&item.path)?,
         externs::store_bytes(py, &item.content),
-        externs::store_bool(item.is_executable),
+        externs::store_bool(py, item.is_executable),
       ],
     ))
   }
@@ -820,7 +820,7 @@ impl Snapshot {
       &[
         Self::store_path(&item.path)?,
         Self::store_file_digest(py, types, &item.digest),
-        externs::store_bool(item.is_executable),
+        externs::store_bool(py, item.is_executable),
       ],
     ))
   }


### PR DESCRIPTION
See https://github.com/pantsbuild/pants/pull/13515 for the motivation. Making GIL access explicit does make call sites more verbose, but it also makes it easier to reason about where the GIL is used and ensures we are not continually dropping and then reacquiring the GIL. 

Compare to https://github.com/pantsbuild/pants/pull/11186, which resulted in sharing the GIL but also relied on an intricate implementation detail. The modeling is now explicit.
