### PR TITLE
[internal] Inline some of `externs/mod.rs` and make GIL acquisition explicit

### DIFF
--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Iterable, Optional, Tuple, Union
@@ -139,14 +141,14 @@ class PathGlobs:
     globs: Tuple[str, ...]
     glob_match_error_behavior: GlobMatchErrorBehavior
     conjunction: GlobExpansionConjunction
-    description_of_origin: str
+    description_of_origin: str | None
 
     def __init__(
         self,
         globs: Iterable[str],
         glob_match_error_behavior: GlobMatchErrorBehavior = GlobMatchErrorBehavior.ignore,
         conjunction: GlobExpansionConjunction = GlobExpansionConjunction.any_match,
-        description_of_origin: Optional[str] = None,
+        description_of_origin: str | None = None,
     ) -> None:
         """A request to find files given a set of globs.
 
@@ -167,7 +169,7 @@ class PathGlobs:
         self.globs = tuple(sorted(globs))
         self.glob_match_error_behavior = glob_match_error_behavior
         self.conjunction = conjunction
-        self.description_of_origin = description_of_origin or ""
+        self.description_of_origin = description_of_origin
         self.__post_init__()
 
     def __post_init__(self) -> None:

--- a/src/rust/engine/engine_pyo3/src/externs/interface/fs.rs
+++ b/src/rust/engine/engine_pyo3/src/externs/interface/fs.rs
@@ -44,11 +44,11 @@ impl<'source> FromPyObject<'source> for PyPathGlobs {
   fn extract(obj: &'source PyAny) -> PyResult<Self> {
     let globs: Vec<String> = obj.getattr("globs")?.extract()?;
 
-    let description_of_origin_field: String = obj.getattr("description_of_origin")?.extract()?;
-    let description_of_origin = if description_of_origin_field.is_empty() {
+    let description_of_origin_field = obj.getattr("description_of_origin")?;
+    let description_of_origin = if description_of_origin_field.is_none() {
       None
     } else {
-      Some(description_of_origin_field)
+      Some(description_of_origin_field.extract()?)
     };
 
     let match_behavior_str: &str = obj

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1690,7 +1690,7 @@ fn capture_snapshots(
           );
           let digest_hint = {
             let maybe_digest: PyObject = externs::getattr(value, "digest_hint").unwrap();
-            if maybe_digest == externs::none() {
+            if maybe_digest.is_none(py) {
               None
             } else {
               Some(nodes::lift_directory_digest(&Value::new(maybe_digest))?)

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1684,7 +1684,7 @@ fn capture_snapshots(
       let path_globs_and_roots = values
         .iter()
         .map(|value| {
-          let root = PathBuf::from(externs::getattr_as_string(value, "root"));
+          let root = PathBuf::from(externs::getattr::<String>(value, "root").unwrap());
           let path_globs = nodes::Snapshot::lift_prepared_path_globs(
             &externs::getattr(value, "path_globs").unwrap(),
           );

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -729,7 +729,7 @@ fn py_result_from_root(py: Python, result: Result<Value, Failure>) -> CPyResult<
         f @ Failure::Invalidated => {
           let msg = format!("{}", f);
           (
-            externs::create_exception(&msg),
+            externs::create_exception(py, &msg),
             Failure::native_traceback(&msg),
             Vec::new(),
           )

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -31,12 +31,6 @@ use lazy_static::lazy_static;
 
 use logging::PythonLogLevel;
 
-/// Return the Python value None.
-pub fn none() -> PyObject {
-  let gil = Python::acquire_gil();
-  gil.python().None()
-}
-
 pub fn equals(h1: &PyObject, h2: &PyObject) -> bool {
   let gil = Python::acquire_gil();
   let py = gil.python();

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -247,18 +247,14 @@ pub fn generator_send(generator: &Value, arg: &Value) -> Result<GeneratorRespons
   }
 }
 
-///
 /// NB: Panics on failure. Only recommended for use with built-in types, such as
 /// those configured in types::Types.
-///
-pub fn unsafe_call(type_id: TypeId, args: &[Value]) -> Value {
-  let gil = Python::acquire_gil();
-  let py = gil.python();
+pub fn unsafe_call(py: Python, type_id: TypeId, args: &[Value]) -> Value {
   let py_type = type_id.as_py_type(py);
   let arg_handles: Vec<PyObject> = args.iter().map(|v| v.clone().into()).collect();
   let args_tuple = PyTuple::new(py, &arg_handles);
   py_type
-    .call(gil.python(), args_tuple, None)
+    .call(py, args_tuple, None)
     .map(Value::from)
     .unwrap_or_else(|e| {
       panic!(

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -183,9 +183,7 @@ pub fn val_to_log_level(obj: &PyObject) -> Result<log::Level, String> {
 }
 
 /// Link to the Pants docs using the current version of Pants.
-pub fn doc_url(slug: &str) -> String {
-  let gil = Python::acquire_gil();
-  let py = gil.python();
+pub fn doc_url(py: Python, slug: &str) -> String {
   let docutil = py.import("pants.util.docutil").unwrap();
   docutil
     .call(py, "doc_url", (slug,), None)

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -92,15 +92,6 @@ pub fn store_bool(py: Python, val: bool) -> Value {
 }
 
 ///
-/// Check if a Python object has the specified field.
-///
-pub fn hasattr(value: &PyObject, field: &str) -> bool {
-  let gil = Python::acquire_gil();
-  let py = gil.python();
-  value.hasattr(py, field).unwrap()
-}
-
-///
 /// Gets an attribute of the given value as the given type.
 ///
 pub fn getattr<T>(value: &PyObject, field: &str) -> Result<T, String>

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -31,9 +31,7 @@ use lazy_static::lazy_static;
 
 use logging::PythonLogLevel;
 
-pub fn equals(h1: &PyObject, h2: &PyObject) -> bool {
-  let gil = Python::acquire_gil();
-  let py = gil.python();
+pub fn equals(py: Python, h1: &PyObject, h2: &PyObject) -> bool {
   // NB: Although it does not precisely align with Python's definition of equality, we ban matches
   // between non-equal types to avoid legacy behavior like `assert True == 1`, which is very
   // surprising in interning, and would likely be surprising anywhere else in the engine where we
@@ -41,9 +39,9 @@ pub fn equals(h1: &PyObject, h2: &PyObject) -> bool {
   if h1.get_type(py) != h2.get_type(py) {
     return false;
   }
-  h1.rich_compare(gil.python(), h2, CompareOp::Eq)
+  h1.rich_compare(py, h2, CompareOp::Eq)
     .unwrap()
-    .cast_as::<PyBool>(gil.python())
+    .cast_as::<PyBool>(py)
     .unwrap()
     .is_true()
 }

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -152,12 +152,14 @@ pub fn getattr_from_frozendict(value: &PyObject, field: &str) -> BTreeMap<String
     .collect()
 }
 
-pub fn getattr_as_string(value: &PyObject, field: &str) -> String {
+pub fn getattr_as_optional_string(py: Python, value: &PyObject, field: &str) -> Option<String> {
+  let v = value.getattr(py, field).unwrap();
+  if v.is_none(py) {
+    return None;
+  }
   // TODO: It's possible to view a python string as a `Cow<str>`, so we could avoid actually
   // cloning in some cases.
-  // TODO: We can't directly extract as a string here, because val_to_str defaults to empty string
-  // for None.
-  val_to_str(&getattr(value, field).unwrap())
+  Some(v.extract(py).unwrap())
 }
 
 pub fn val_to_str(obj: &PyObject) -> String {

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -194,9 +194,7 @@ pub fn doc_url(slug: &str) -> String {
     .unwrap()
 }
 
-pub fn create_exception(msg: &str) -> Value {
-  let gil = Python::acquire_gil();
-  let py = gil.python();
+pub fn create_exception(py: Python, msg: &str) -> Value {
   Value::from(PyErr::new::<cpython::exc::Exception, _>(py, msg).instance(py))
 }
 

--- a/src/rust/engine/src/interning.rs
+++ b/src/rust/engine/src/interning.rs
@@ -99,7 +99,8 @@ impl Eq for InternKey {}
 
 impl PartialEq for InternKey {
   fn eq(&self, other: &InternKey) -> bool {
-    externs::equals(&self.1, &other.1)
+    let gil = Python::acquire_gil();
+    externs::equals(gil.python(), &self.1, &other.1)
   }
 }
 

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -200,6 +200,7 @@ fn multi_platform_process_request_to_process_result(
     let gil = Python::acquire_gil();
     let py = gil.python();
     Ok(externs::unsafe_call(
+      py,
       context.core.types.process_result,
       &[
         externs::store_bytes(py, &stdout_bytes),
@@ -209,6 +210,7 @@ fn multi_platform_process_request_to_process_result(
         externs::store_i64(py, result.exit_code.into()),
         Snapshot::store_directory_digest(py, &result.output_directory).map_err(|s| throw(&s))?,
         externs::unsafe_call(
+          py,
           context.core.types.platform,
           &[externs::store_utf8(py, &platform_name)],
         ),
@@ -601,6 +603,7 @@ fn interactive_process(
       let gil = Python::acquire_gil();
       let py = gil.python();
       externs::unsafe_call(
+        py,
         interactive_process_result,
         &[externs::store_i64(py, i64::from(code))],
       )

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -272,7 +272,7 @@ fn remove_prefix_request_to_digest(
   async move {
     let input_digest = lift_directory_digest(&externs::getattr(&args[0], "digest").unwrap())
       .map_err(|e| throw(&e))?;
-    let prefix = externs::getattr_as_string(&args[0], "prefix");
+    let prefix: String = externs::getattr(&args[0], "prefix").unwrap();
     let prefix = RelativePath::new(PathBuf::from(prefix))
       .map_err(|e| throw(&format!("The `prefix` must be relative: {:?}", e)))?;
     let digest = store
@@ -294,7 +294,7 @@ fn add_prefix_request_to_digest(
   async move {
     let input_digest = lift_directory_digest(&externs::getattr(&args[0], "digest").unwrap())
       .map_err(|e| throw(&e))?;
-    let prefix = externs::getattr_as_string(&args[0], "prefix");
+    let prefix: String = externs::getattr(&args[0], "prefix").unwrap();
     let prefix = RelativePath::new(PathBuf::from(prefix))
       .map_err(|e| throw(&format!("The `prefix` must be relative: {:?}", e)))?;
     let digest = store
@@ -394,7 +394,7 @@ fn create_digest_to_digest(
   let digests: Vec<_> = file_items
     .into_iter()
     .map(|file_item| {
-      let path = externs::getattr_as_string(&file_item, "path");
+      let path: String = externs::getattr(&file_item, "path").unwrap();
       let store = context.core.store();
       async move {
         let path = RelativePath::new(PathBuf::from(path))

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -605,11 +605,13 @@ impl From<Scandir> for NodeKey {
 }
 
 fn unmatched_globs_additional_context() -> Option<String> {
+  let gil = Python::acquire_gil();
+  let url = externs::doc_url(gil.python(), "troubleshooting#pants-cannot-find-a-file-in-your-project");
   Some(format!(
     "\n\nDo the file(s) exist? If so, check if the file(s) are in your `.gitignore` or the global \
     `pants_ignore` option, which may result in Pants not being able to see the file(s) even though \
     they exist on disk. Refer to {}.",
-    externs::doc_url("troubleshooting#pants-cannot-find-a-file-in-your-project")
+    url
   ))
 }
 
@@ -1617,6 +1619,8 @@ impl NodeError for Failure {
       path[0] += " <-";
       path[path_len - 1] += " <-"
     }
+    let gil = Python::acquire_gil();
+    let url = externs::doc_url(gil.python(), "targets#dependencies-and-dependency-inference");
     throw(&format!(
       "The dependency graph contained a cycle:\
       \n\n  \
@@ -1628,7 +1632,7 @@ impl NodeError for Failure {
       \n\n\
       See {} for more information.",
       path.join("\n  "),
-      externs::doc_url("targets#dependencies-and-dependency-inference")
+     url
     ))
   }
 }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1098,7 +1098,10 @@ impl Task {
     entry: Arc<rule_graph::Entry<Rule>>,
     generator: Value,
   ) -> NodeResult<Value> {
-    let mut input = Value::from(externs::none());
+    let mut input = {
+      let gil = Python::acquire_gil();
+      Value::from(gil.python().None())
+    };
     loop {
       let context = context.clone();
       let params = params.clone();

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -606,7 +606,10 @@ impl From<Scandir> for NodeKey {
 
 fn unmatched_globs_additional_context() -> Option<String> {
   let gil = Python::acquire_gil();
-  let url = externs::doc_url(gil.python(), "troubleshooting#pants-cannot-find-a-file-in-your-project");
+  let url = externs::doc_url(
+    gil.python(),
+    "troubleshooting#pants-cannot-find-a-file-in-your-project",
+  );
   Some(format!(
     "\n\nDo the file(s) exist? If so, check if the file(s) are in your `.gitignore` or the global \
     `pants_ignore` option, which may result in Pants not being able to see the file(s) even though \
@@ -651,6 +654,7 @@ impl Paths {
       }
     }
     Ok(externs::unsafe_call(
+      py,
       core.types.paths,
       &[
         externs::store_tuple(py, files),
@@ -778,6 +782,7 @@ impl Snapshot {
     item: &hashing::Digest,
   ) -> Value {
     externs::unsafe_call(
+      py,
       types.file_digest,
       &[
         externs::store_utf8(py, &item.hash.to_hex()),
@@ -806,6 +811,7 @@ impl Snapshot {
     item: &FileContent,
   ) -> Result<Value, String> {
     Ok(externs::unsafe_call(
+      py,
       types.file_content,
       &[
         Self::store_path(py, &item.path)?,
@@ -821,6 +827,7 @@ impl Snapshot {
     item: &FileEntry,
   ) -> Result<Value, String> {
     Ok(externs::unsafe_call(
+      py,
       types.file_entry,
       &[
         Self::store_path(py, &item.path)?,
@@ -836,6 +843,7 @@ impl Snapshot {
     path: &Path,
   ) -> Result<Value, String> {
     Ok(externs::unsafe_call(
+      py,
       types.directory,
       &[Self::store_path(py, path)?],
     ))
@@ -851,6 +859,7 @@ impl Snapshot {
       .map(|e| Self::store_file_content(py, &context.core.types, e))
       .collect::<Result<Vec<_>, _>>()?;
     Ok(externs::unsafe_call(
+      py,
       context.core.types.digest_contents,
       &[externs::store_tuple(py, entries)],
     ))
@@ -873,6 +882,7 @@ impl Snapshot {
       })
       .collect::<Result<Vec<_>, _>>()?;
     Ok(externs::unsafe_call(
+      py,
       context.core.types.digest_entries,
       &[externs::store_tuple(py, entries)],
     ))
@@ -1620,7 +1630,10 @@ impl NodeError for Failure {
       path[path_len - 1] += " <-"
     }
     let gil = Python::acquire_gil();
-    let url = externs::doc_url(gil.python(), "targets#dependencies-and-dependency-inference");
+    let url = externs::doc_url(
+      gil.python(),
+      "targets#dependencies-and-dependency-inference",
+    );
     throw(&format!(
       "The dependency graph contained a cycle:\
       \n\n  \
@@ -1632,7 +1645,7 @@ impl NodeError for Failure {
       \n\n\
       See {} for more information.",
       path.join("\n  "),
-     url
+      url
     ))
   }
 }

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -453,8 +453,9 @@ impl From<String> for Failure {
 }
 
 pub fn throw(msg: &str) -> Failure {
+  let gil = Python::acquire_gil();
   Failure::Throw {
-    val: externs::create_exception(msg),
+    val: externs::create_exception(gil.python(), msg),
     python_traceback: Failure::native_traceback(msg),
     engine_traceback: Vec::new(),
   }

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -293,7 +293,8 @@ impl Value {
 
 impl PartialEq for Value {
   fn eq(&self, other: &Value) -> bool {
-    externs::equals(&self.0, &other.0)
+    let gil = Python::acquire_gil();
+    externs::equals(gil.python(), &self.0, &other.0)
   }
 }
 


### PR DESCRIPTION
A couple of refactors to simplify our rust-cpython FFI code. 

Most notable is rewriting `gettattr_as_string` to be `getattr_as_optional_string`, which is always how it was behaving. That is, we used to tolerate if Python was set to `str | None`, even though most call sites expected `str`. This rename makes clear the difference.