### PR TITLE
[internal] Use chevron instead of pystache to fix broken release process

### DIFF
--- a/3rdparty/python/lockfiles/user_reqs.txt
+++ b/3rdparty/python/lockfiles/user_reqs.txt
@@ -11,6 +11,7 @@
 #   "generated_with_requirements": [
 #     "PyYAML<7.0,>=6.0",
 #     "ansicolors==1.1.8",
+#     "chevron==0.14.0",
 #     "fasteners==0.16.3",
 #     "freezegun==1.1.0",
 #     "humbug==0.2.7",
@@ -49,6 +50,9 @@ certifi==2021.10.8; python_version >= "2.7" and python_full_version < "3.0.0" or
 charset-normalizer==2.0.7; python_full_version >= "3.6.0" and python_version >= "3" \
     --hash=sha256:e019de665e2bcf9c2b64e2e5aa025fa991da8720daa3c1138cadd2fd1856aed0 \
     --hash=sha256:f7af805c321bfa1ce6714c51f254e0d5bb5e5834039bc17db7ebe3a4cec9492b
+chevron==0.14.0 \
+    --hash=sha256:fbf996a709f8da2e745ef763f482ce2d311aa817d287593a5b990d6d6e4f0443 \
+    --hash=sha256:87613aafdf6d77b6a90ff073165a61ae5086e21ad49057aa0e53681601800ebf
 colorama==0.4.4; python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.5.0" \
     --hash=sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2 \
     --hash=sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b
@@ -170,12 +174,12 @@ psutil==5.8.0; (python_version >= "2.6" and python_full_version < "3.0.0") or (p
     --hash=sha256:ea372bcc129394485824ae3e3ddabe67dc0b118d262c568b4d2602a7070afdb0 \
     --hash=sha256:f4634b033faf0d968bb9220dd1c793b897ab7f1189956e1aa9eae752527127d3 \
     --hash=sha256:0c9ccb99ab76025f2f0bbecf341d4656e9c1351db8cc8a03ccd62e318ab4b5c6
-py==1.10.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6" \
-    --hash=sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a \
-    --hash=sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3
-pyparsing==3.0.4; python_version >= "3.6" \
-    --hash=sha256:c0a7dfcd26825bd4453574c4e7ad04aa095975ce54d04f738fe3a8350fbd223a \
-    --hash=sha256:e0df773d7fa2240322daae7805626dfc5f2d5effb34e1a7be2702c99cfb9f6b1
+py==1.11.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6" \
+    --hash=sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378 \
+    --hash=sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719
+pyparsing==3.0.5; python_version >= "3.6" \
+    --hash=sha256:4881e3d2979f27b41a3a2421b10be9cbfa7ce2baa6c7117952222f8bbea6650c \
+    --hash=sha256:9329d1c1b51f0f76371c4ded42c5ec4cc0be18456b22193e0570c2da98ed288b
 pystache==0.5.4 \
     --hash=sha256:f7bbc265fb957b4d6c7c042b336563179444ab313fb93a719759111eabd3b85a
 pytest==6.2.5; python_version >= "3.6" \

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -4,6 +4,7 @@
 # Consider pinging us on Slack if you're thinking a new dependency might be needed.
 
 ansicolors==1.1.8
+chevron==0.14.0  # Should only be used by build-support.
 fasteners==0.16.3
 freezegun==1.1.0
 
@@ -15,9 +16,7 @@ ijson==3.1.4
 packaging==21.0
 pex==2.1.54
 psutil==5.8.0
-pystache==0.5.4
-# This should be kept in sync with `pytest.py`.
-pytest>=6.2.4,<6.3
+pytest>=6.2.4,<6.3  # This should be kept in sync with `pytest.py`.
 PyYAML>=6.0,<7.0
 requests[security]>=2.25.1
 setproctitle==1.2.2

--- a/build-support/bin/BUILD
+++ b/build-support/bin/BUILD
@@ -14,13 +14,22 @@ python_sources(
     },
 )
 
+python_requirement(
+    name="chevron",
+    requirements=["chevron==0.14.0"],
+)
+
 python_tests(name="py_tests", overrides={"reversion_test.py": {"timeout": 90}})
 
 pex_binary(name="changelog", entry_point="changelog.py")
 pex_binary(name="check_banned_imports", entry_point="check_banned_imports.py")
 pex_binary(name="check_inits", entry_point="check_inits.py")
 pex_binary(name="deploy_to_s3", entry_point="deploy_to_s3.py")
-pex_binary(name="generate_all_lockfiles_helper", entry_point="_generate_all_lockfiles_helper.py")
+pex_binary(
+    name="generate_all_lockfiles_helper",
+    entry_point="_generate_all_lockfiles_helper.py",
+    dependencies=[":chevron"],
+)
 pex_binary(name="generate_docs", entry_point="generate_docs.py")
 pex_binary(name="generate_github_workflows", entry_point="generate_github_workflows.py")
 pex_binary(name="generate_user_list", entry_point="generate_user_list.py")

--- a/build-support/bin/BUILD
+++ b/build-support/bin/BUILD
@@ -14,22 +14,13 @@ python_sources(
     },
 )
 
-python_requirement(
-    name="chevron",
-    requirements=["chevron==0.14.0"],
-)
-
 python_tests(name="py_tests", overrides={"reversion_test.py": {"timeout": 90}})
 
 pex_binary(name="changelog", entry_point="changelog.py")
 pex_binary(name="check_banned_imports", entry_point="check_banned_imports.py")
 pex_binary(name="check_inits", entry_point="check_inits.py")
 pex_binary(name="deploy_to_s3", entry_point="deploy_to_s3.py")
-pex_binary(
-    name="generate_all_lockfiles_helper",
-    entry_point="_generate_all_lockfiles_helper.py",
-    dependencies=[":chevron"],
-)
+pex_binary(name="generate_all_lockfiles_helper", entry_point="_generate_all_lockfiles_helper.py")
 pex_binary(name="generate_docs", entry_point="generate_docs.py")
 pex_binary(name="generate_github_workflows", entry_point="generate_github_workflows.py")
 pex_binary(name="generate_user_list", entry_point="generate_user_list.py")

--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -29,7 +29,7 @@ from html.parser import HTMLParser
 from pathlib import Path, PosixPath
 from typing import Any, Dict, Iterable, cast
 
-import pystache
+import chevron
 import requests
 from common import die
 from readme_api import DocRef, ReadmeAPI
@@ -280,13 +280,13 @@ class ReferenceGenerator:
         options_scope_tpl = get_tpl("options_scope_reference.md.mustache")
         single_option_tpl = get_tpl("single_option_reference.md.mustache")
         target_tpl = get_tpl("target_reference.md.mustache")
-        self._renderer = pystache.Renderer(
-            partials={
+        self._renderer_args = {
+            "partials_dict": {
                 "scoped_options": options_scope_tpl,
                 "single_option": single_option_tpl,
                 "target": target_tpl,
             }
-        )
+        }
         self._category_id: str | None = None  # Fetched lazily.
 
         # Load the data.
@@ -399,11 +399,15 @@ class ReferenceGenerator:
         self._readme_api.update_doc(slug=slug, title=title, category=self.category_id, body=body)
 
     def _render_target(self, alias: str) -> str:
-        return cast(str, self._renderer.render("{{> target}}", self._targets_info[alias]))
+        return cast(
+            str, chevron.render("{{> target}}", self._targets_info[alias], **self._renderer_args)
+        )
 
     def _render_options_body(self, scope_help_info: dict) -> str:
         """Renders the body of a single options help page."""
-        return cast(str, self._renderer.render("{{> scoped_options}}", scope_help_info))
+        return cast(
+            str, chevron.render("{{> scoped_options}}", scope_help_info, **self._renderer_args)
+        )
 
     @classmethod
     def _render_parent_page_body(cls, items: Iterable[str], *, sync: bool) -> str:

--- a/build-support/bin/generate_user_list.py
+++ b/build-support/bin/generate_user_list.py
@@ -5,7 +5,7 @@
 import pkgutil
 from dataclasses import dataclass
 
-import pystache
+import chevron
 
 """Generates the custom HTML/CSS block in https://www.pantsbuild.org/docs/who-uses-pants .
 
@@ -104,7 +104,7 @@ def main():
         orgs.append(Org("", "", ""))
     org_pairs = tuple(OrgPair(orgs[i], orgs[i + 1]) for i in range(0, len(orgs), 2))
     buf = pkgutil.get_data("generate_user_list", "user_list_templates/table.html.mustache")
-    print(pystache.render(buf.decode(), context={"org_pairs": org_pairs}))
+    print(chevron.render(buf.decode(), context={"org_pairs": org_pairs}))
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ show_traceback = true
 [[tool.mypy.overrides]]
 module = [
     "bs4",
+    "chevron",
     "colors",
     "dockerfile",
     "fasteners",
@@ -59,7 +60,6 @@ module = [
     "ijson",
     "pex.*",
     "psutil",
-    "pystache",
     "setproctitle",
 ]
 ignore_missing_imports = true


### PR DESCRIPTION
since pystache hasn't been updated since 2014.
also opted to have the chevron req specified in the single place we need it instead of in the somewhat global requirements.txt
