### PR TITLE
[internal] localize build-support reqs and remove them from the global requirements.txt

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -4,7 +4,6 @@
 # Consider pinging us on Slack if you're thinking a new dependency might be needed.
 
 ansicolors==1.1.8
-chevron==0.14.0  # Should only be used by build-support.
 fasteners==0.16.3
 freezegun==1.1.0
 
@@ -18,7 +17,6 @@ pex==2.1.54
 psutil==5.8.0
 pytest>=6.2.4,<6.3  # This should be kept in sync with `pytest.py`.
 PyYAML>=6.0,<7.0
-requests[security]>=2.25.1
 setproctitle==1.2.2
 setuptools>=56.0.0,<58.0
 toml==0.10.2

--- a/build-support/bin/BUILD
+++ b/build-support/bin/BUILD
@@ -14,15 +14,30 @@ python_sources(
     },
 )
 
-python_tests(name="py_tests", overrides={"reversion_test.py": {"timeout": 90}})
+python_requirement(
+    name="requests",
+    requirements=["requests[security]>=2.25.1"],
+)
+
+
+python_requirement(
+    name="chevron",
+    requirements=["chevron==0.14.0"],
+)
+
+python_tests(
+    name="py_tests", overrides={"reversion_test.py": {"timeout": 90}}, dependencies=[":requests"]
+)
 
 pex_binary(name="changelog", entry_point="changelog.py")
 pex_binary(name="check_banned_imports", entry_point="check_banned_imports.py")
 pex_binary(name="check_inits", entry_point="check_inits.py")
 pex_binary(name="deploy_to_s3", entry_point="deploy_to_s3.py")
 pex_binary(name="generate_all_lockfiles_helper", entry_point="_generate_all_lockfiles_helper.py")
-pex_binary(name="generate_docs", entry_point="generate_docs.py")
+pex_binary(
+    name="generate_docs", entry_point="generate_docs.py", dependencies=[":chevron", ":requests"]
+)
 pex_binary(name="generate_github_workflows", entry_point="generate_github_workflows.py")
 pex_binary(name="generate_user_list", entry_point="generate_user_list.py")
-pex_binary(name="release_helper", entry_point="_release_helper.py")
+pex_binary(name="release_helper", entry_point="_release_helper.py", dependencies=[":requests"])
 pex_binary(name="reversion", entry_point="reversion.py")


### PR DESCRIPTION
I think this is a better pattern and also limits the usage of dependencies by scoping them to the build-support directory.

Feel free to close if this doesn't make sense.