### PR TITLE
[internal] Use chevron instead of pystache to fix broken release process (Cherry-pick of #13528)

### DIFF
--- a/3rdparty/python/lockfiles/pytest.txt
+++ b/3rdparty/python/lockfiles/pytest.txt
@@ -75,9 +75,6 @@ coverage==6.1.1; python_version >= "3.6" \
     --hash=sha256:e14bceb1f3ae8a14374be2b2d7bc12a59226872285f91d66d301e5f41705d4d6 \
     --hash=sha256:0147f7833c41927d84f5af9219d9b32f875c0689e5e74ac8ca3cb61e73a698f9 \
     --hash=sha256:b1d0a1bce919de0dd8da5cff4e616b2d9e6ebf3bd1410ff645318c3dd615010a \
-    --hash=sha256:ae6de0e41f44794e68d23644636544ed8003ce24845f213b24de097cbf44997f \
-    --hash=sha256:db2797ed7a7e883b9ab76e8e778bb4c859fc2037d6fd0644d8675e64d58d1653 \
-    --hash=sha256:c40966b683d92869b72ea3c11fd6b99a091fd30e12652727eca117273fc97366 \
     --hash=sha256:a11a2c019324fc111485e79d55907e7289e53d0031275a6c8daed30690bc50c0 \
     --hash=sha256:4d8b453764b9b26b0dd2afb83086a7c3f9379134e340288d2a52f8a91592394b \
     --hash=sha256:3b270c6b48d3ff5a35deb3648028ba2643ad8434b07836782b1139cf9c66313f \
@@ -124,15 +121,15 @@ pluggy==1.0.0; python_version >= "3.6" \
 pprintpp==0.4.0; python_version >= "3.6" \
     --hash=sha256:b6b4dcdd0c0c0d75e4d7b2f21a9e933e5b2ce62b26e1a54537f9651ae5a5c01d \
     --hash=sha256:ea826108e2c7f49dc6d66c752973c3fc9749142a798d6b254e1e301cfdbc6403
-prompt-toolkit==3.0.21; python_full_version >= "3.6.2" and python_version >= "3.7" \
-    --hash=sha256:62b3d3ea5a3ccee94dc1aac018279cf64866a76837156ebe159b981c42dd20a8 \
-    --hash=sha256:27f13ff4e4850fe8f860b77414c7880f67c6158076a7b099062cc8570f1562e5
+prompt-toolkit==3.0.22; python_full_version >= "3.6.2" and python_version >= "3.7" \
+    --hash=sha256:48d85cdca8b6c4f16480c7ce03fd193666b62b0a21667ca56b4bb5ad679d1170 \
+    --hash=sha256:449f333dd120bd01f5d296a8ce1452114ba3a71fae7288d2f0ae2c918764fa72
 ptyprocess==0.7.0; sys_platform != "win32" and python_version >= "3.7" \
     --hash=sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35 \
     --hash=sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220
-py==1.10.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6" \
-    --hash=sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a \
-    --hash=sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3
+py==1.11.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6" \
+    --hash=sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378 \
+    --hash=sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719
 pygments==2.10.0; python_version >= "3.5" \
     --hash=sha256:b8e67fe6af78f492b3c4b3e2970c0624cbf08beb1e493b2c99b9fa1b67a20380 \
     --hash=sha256:f398865f7eb6874156579fdf36bc840a03cab64d1cde9e93d68f46a425ec52c6
@@ -153,9 +150,9 @@ pytest-metadata==1.11.0; python_version >= "3.6" and python_full_version < "3.0.
 pytest==6.2.5; python_version >= "3.6" \
     --hash=sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134 \
     --hash=sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89
-setuptools==58.4.0; python_version >= "3.7" \
-    --hash=sha256:e8b1d3127a0441fb99a130bcc3c2bf256c2d3ead3aba8fd400e5cbbaf788e036 \
-    --hash=sha256:af632270cb4b5ca0ebd272ac1939a3e8f76aa975d2722e999cfdcea2b9e824cb
+setuptools==58.5.3; python_version >= "3.7" \
+    --hash=sha256:a481fbc56b33f5d8f6b33dce41482e64c68b668be44ff42922903b03872590bf \
+    --hash=sha256:dae6b934a965c8a59d6d230d3867ec408bb95e73bd538ff77e71fedf1eaca729
 toml==0.10.2; python_version > "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version > "3.6" \
     --hash=sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b \
     --hash=sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f

--- a/3rdparty/python/lockfiles/user_reqs.txt
+++ b/3rdparty/python/lockfiles/user_reqs.txt
@@ -11,6 +11,7 @@
 #   "generated_with_requirements": [
 #     "PyYAML<7.0,>=6.0",
 #     "ansicolors==1.1.8",
+#     "chevron==0.14.0",
 #     "fasteners==0.16",
 #     "freezegun==1.1.0",
 #     "humbug==0.2.6",
@@ -18,7 +19,6 @@
 #     "packaging==21.0",
 #     "pex==2.1.54",
 #     "psutil==5.8.0",
-#     "pystache==0.5.4",
 #     "pytest<6.3,>=6.2.4",
 #     "requests[security]>=2.25.1",
 #     "setproctitle==1.2.2",
@@ -49,6 +49,9 @@ certifi==2021.10.8; python_version >= "2.7" and python_full_version < "3.0.0" or
 charset-normalizer==2.0.7; python_full_version >= "3.6.0" and python_version >= "3" \
     --hash=sha256:e019de665e2bcf9c2b64e2e5aa025fa991da8720daa3c1138cadd2fd1856aed0 \
     --hash=sha256:f7af805c321bfa1ce6714c51f254e0d5bb5e5834039bc17db7ebe3a4cec9492b
+chevron==0.14.0 \
+    --hash=sha256:fbf996a709f8da2e745ef763f482ce2d311aa817d287593a5b990d6d6e4f0443 \
+    --hash=sha256:87613aafdf6d77b6a90ff073165a61ae5086e21ad49057aa0e53681601800ebf
 colorama==0.4.4; python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.5.0" \
     --hash=sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2 \
     --hash=sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b
@@ -170,14 +173,12 @@ psutil==5.8.0; (python_version >= "2.6" and python_full_version < "3.0.0") or (p
     --hash=sha256:ea372bcc129394485824ae3e3ddabe67dc0b118d262c568b4d2602a7070afdb0 \
     --hash=sha256:f4634b033faf0d968bb9220dd1c793b897ab7f1189956e1aa9eae752527127d3 \
     --hash=sha256:0c9ccb99ab76025f2f0bbecf341d4656e9c1351db8cc8a03ccd62e318ab4b5c6
-py==1.10.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6" \
-    --hash=sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a \
-    --hash=sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3
-pyparsing==3.0.4; python_version >= "3.6" \
-    --hash=sha256:c0a7dfcd26825bd4453574c4e7ad04aa095975ce54d04f738fe3a8350fbd223a \
-    --hash=sha256:e0df773d7fa2240322daae7805626dfc5f2d5effb34e1a7be2702c99cfb9f6b1
-pystache==0.5.4 \
-    --hash=sha256:f7bbc265fb957b4d6c7c042b336563179444ab313fb93a719759111eabd3b85a
+py==1.11.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6" \
+    --hash=sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378 \
+    --hash=sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719
+pyparsing==3.0.5; python_version >= "3.6" \
+    --hash=sha256:4881e3d2979f27b41a3a2421b10be9cbfa7ce2baa6c7117952222f8bbea6650c \
+    --hash=sha256:9329d1c1b51f0f76371c4ded42c5ec4cc0be18456b22193e0570c2da98ed288b
 pytest==6.2.5; python_version >= "3.6" \
     --hash=sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134 \
     --hash=sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -1,4 +1,5 @@
 ansicolors==1.1.8
+chevron==0.14.0  # Should only be used by build-support.
 fasteners==0.16
 freezegun==1.1.0
 
@@ -10,9 +11,7 @@ ijson==3.1.4
 packaging==21.0
 pex==2.1.54
 psutil==5.8.0
-pystache==0.5.4
-# This should be kept in sync with `pytest.py`.
-pytest>=6.2.4,<6.3
+pytest>=6.2.4,<6.3  # This should be kept in sync with `pytest.py`.
 PyYAML>=6.0,<7.0
 requests[security]>=2.25.1
 setproctitle==1.2.2

--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -29,7 +29,7 @@ from html.parser import HTMLParser
 from pathlib import Path, PosixPath
 from typing import Any, Dict, Iterable, cast
 
-import pystache
+import chevron
 import requests
 from common import die
 from readme_api import DocRef, ReadmeAPI
@@ -280,13 +280,13 @@ class ReferenceGenerator:
         options_scope_tpl = get_tpl("options_scope_reference.md.mustache")
         single_option_tpl = get_tpl("single_option_reference.md.mustache")
         target_tpl = get_tpl("target_reference.md.mustache")
-        self._renderer = pystache.Renderer(
-            partials={
+        self._renderer_args = {
+            "partials_dict": {
                 "scoped_options": options_scope_tpl,
                 "single_option": single_option_tpl,
                 "target": target_tpl,
             }
-        )
+        }
         self._category_id: str | None = None  # Fetched lazily.
 
         # Load the data.
@@ -399,11 +399,15 @@ class ReferenceGenerator:
         self._readme_api.update_doc(slug=slug, title=title, category=self.category_id, body=body)
 
     def _render_target(self, alias: str) -> str:
-        return cast(str, self._renderer.render("{{> target}}", self._targets_info[alias]))
+        return cast(
+            str, chevron.render("{{> target}}", self._targets_info[alias], **self._renderer_args)
+        )
 
     def _render_options_body(self, scope_help_info: dict) -> str:
         """Renders the body of a single options help page."""
-        return cast(str, self._renderer.render("{{> scoped_options}}", scope_help_info))
+        return cast(
+            str, chevron.render("{{> scoped_options}}", scope_help_info, **self._renderer_args)
+        )
 
     @classmethod
     def _render_parent_page_body(cls, items: Iterable[str], *, sync: bool) -> str:

--- a/build-support/bin/generate_user_list.py
+++ b/build-support/bin/generate_user_list.py
@@ -5,7 +5,7 @@
 import pkgutil
 from dataclasses import dataclass
 
-import pystache
+import chevron
 
 """Generates the custom HTML/CSS block in https://www.pantsbuild.org/docs/who-uses-pants .
 
@@ -104,7 +104,7 @@ def main():
         orgs.append(Org("", "", ""))
     org_pairs = tuple(OrgPair(orgs[i], orgs[i + 1]) for i in range(0, len(orgs), 2))
     buf = pkgutil.get_data("generate_user_list", "user_list_templates/table.html.mustache")
-    print(pystache.render(buf.decode(), context={"org_pairs": org_pairs}))
+    print(chevron.render(buf.decode(), context={"org_pairs": org_pairs}))
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ show_traceback = true
 [[tool.mypy.overrides]]
 module = [
     "bs4",
+    "chevron",
     "colors",
     "dockerfile",
     "fasteners",
@@ -59,7 +60,6 @@ module = [
     "ijson",
     "pex.*",
     "psutil",
-    "pystache",
     "setproctitle",
 ]
 ignore_missing_imports = true


### PR DESCRIPTION
since pystache hasn't been updated since 2014.
also opted to have the chevron req specified in the single place we need it instead of in the somewhat global requirements.txt

[ci skip-rust]
[ci skip-build-wheels]