### PR TITLE
[jvm] Add support for consuming types from the unnamed package.

### DIFF
--- a/src/python/pants/backend/java/dependency_inference/BUILD
+++ b/src/python/pants/backend/java/dependency_inference/BUILD
@@ -16,8 +16,12 @@ java_sources(
         "pants_java_parser",
     ],
     dependencies=[
+        # Update in concert with `java_parser_artifact_requirements`.
+        # TODO: Move these definitions to thirdparty, and add to the thirdparty mapping to
+        # enable inference.
         ":com.github.javaparser_javaparser-symbol-solver-core",
         ":com.fasterxml.jackson.core_jackson-databind",
+        ":com.fasterxml.jackson.datatype_jackson-datatype-jdk8",
     ],
 )
 
@@ -32,5 +36,12 @@ jvm_artifact(
     name="com.fasterxml.jackson.core_jackson-databind",
     group="com.fasterxml.jackson.core",
     artifact="jackson-databind",
+    version="2.12.4",
+)
+
+jvm_artifact(
+    name="com.fasterxml.jackson.datatype_jackson-datatype-jdk8",
+    group="com.fasterxml.jackson.datatype",
+    artifact="jackson-datatype-jdk8",
     version="2.12.4",
 )

--- a/src/python/pants/backend/java/dependency_inference/PantsJavaParserLauncher.java
+++ b/src/python/pants/backend/java/dependency_inference/PantsJavaParserLauncher.java
@@ -1,6 +1,8 @@
 package org.pantsbuild.javaparser;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
@@ -52,7 +54,7 @@ class Import {
 
 class CompilationUnitAnalysis {
     CompilationUnitAnalysis(
-        String declaredPackage,
+        Optional<String> declaredPackage,
         ArrayList<Import> imports,
         ArrayList<String> topLevelTypes,
         ArrayList<String> consumedUnqualifiedTypes
@@ -63,7 +65,7 @@ class CompilationUnitAnalysis {
         this.consumedUnqualifiedTypes = consumedUnqualifiedTypes;
     }
 
-    public final String declaredPackage;
+    public final Optional<String> declaredPackage;
     public final ArrayList<Import> imports;
     public final ArrayList<String> topLevelTypes;
     public final ArrayList<String> consumedUnqualifiedTypes;
@@ -118,10 +120,9 @@ public class PantsJavaParserLauncher {
         CompilationUnit cu = StaticJavaParser.parse(new File(sourceToAnalyze));
 
         // Get the source's declare package.
-        String declaredPackage = cu.getPackageDeclaration()
+        Optional<String> declaredPackage = cu.getPackageDeclaration()
             .map(PackageDeclaration::getName)
-            .map(Name::toString)
-            .orElse("");
+            .map(Name::toString);
 
         // Get the source's imports.
         ArrayList<Import> imports = new ArrayList<Import>(
@@ -202,6 +203,7 @@ public class PantsJavaParserLauncher {
 
         CompilationUnitAnalysis analysis = new CompilationUnitAnalysis(declaredPackage, imports, topLevelTypes, consumedUnqualifiedTypes);
         ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new Jdk8Module());
         mapper.writeValue(new File(analysisOutputPath), analysis);
     }
 }

--- a/src/python/pants/backend/java/dependency_inference/coursier_resolve.lockfile
+++ b/src/python/pants/backend/java/dependency_inference/coursier_resolve.lockfile
@@ -53,7 +53,54 @@
         "dependencies": [
             {
                 "group": "com.fasterxml.jackson.core",
+                "artifact": "jackson-annotations",
+                "version": "2.12.4",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.fasterxml.jackson.core",
                 "artifact": "jackson-core",
+                "version": "2.12.4",
+                "packaging": "jar"
+            }
+        ],
+        "file_name": "jackson-databind-2.12.4.jar",
+        "file_digest": {
+            "fingerprint": "e99a7b4b89074bc689aabcd9eb1f2c1318b68cc5c34979daf3e34edc558c7a01",
+            "serialized_bytes_length": 1516044
+        }
+    },
+    {
+        "coord": {
+            "group": "com.fasterxml.jackson.datatype",
+            "artifact": "jackson-datatype-jdk8",
+            "version": "2.12.4",
+            "packaging": "jar"
+        },
+        "directDependencies": [
+            {
+                "group": "com.fasterxml.jackson.core",
+                "artifact": "jackson-core",
+                "version": "2.12.4",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.fasterxml.jackson.core",
+                "artifact": "jackson-databind",
+                "version": "2.12.4",
+                "packaging": "jar"
+            }
+        ],
+        "dependencies": [
+            {
+                "group": "com.fasterxml.jackson.core",
+                "artifact": "jackson-core",
+                "version": "2.12.4",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.fasterxml.jackson.core",
+                "artifact": "jackson-databind",
                 "version": "2.12.4",
                 "packaging": "jar"
             },
@@ -64,10 +111,10 @@
                 "packaging": "jar"
             }
         ],
-        "file_name": "jackson-databind-2.12.4.jar",
+        "file_name": "jackson-datatype-jdk8-2.12.4.jar",
         "file_digest": {
-            "fingerprint": "e99a7b4b89074bc689aabcd9eb1f2c1318b68cc5c34979daf3e34edc558c7a01",
-            "serialized_bytes_length": 1516044
+            "fingerprint": "00852350fc1503344723b590f1afe9593ab732fb5b035659b503b49bbea5c9b2",
+            "serialized_bytes_length": 34438
         }
     },
     {

--- a/src/python/pants/backend/java/dependency_inference/java_parser_launcher.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser_launcher.py
@@ -31,10 +31,16 @@ def _load_javaparser_launcher_source() -> bytes:
 
 
 def java_parser_artifact_requirements() -> ArtifactRequirements:
+    # Update in concert with the target definition for `java_parser`.
     return ArtifactRequirements(
         [
             Coordinate(
                 group="com.fasterxml.jackson.core", artifact="jackson-databind", version="2.12.4"
+            ),
+            Coordinate(
+                group="com.fasterxml.jackson.datatype",
+                artifact="jackson-datatype-jdk8",
+                version="2.12.4",
             ),
             Coordinate(
                 group="com.github.javaparser",

--- a/src/python/pants/backend/java/dependency_inference/java_parser_test.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser_test.py
@@ -220,7 +220,7 @@ def test_java_parser_unnamed_package(rule_runner: RuleRunner) -> None:
     )
 
     analysis = rule_runner.request(JavaSourceDependencyAnalysis, [source_files])
-    assert analysis.declared_package == ""
+    assert analysis.declared_package is None
     assert analysis.imports == ()
     assert analysis.top_level_types == ("SimpleSource", "Foo")
     assert analysis.consumed_unqualified_types == ("System",)

--- a/src/python/pants/backend/java/dependency_inference/package_mapper.py
+++ b/src/python/pants/backend/java/dependency_inference/package_mapper.py
@@ -102,13 +102,7 @@ async def map_first_party_java_targets_to_symbols(
     dep_map = PackageRootedDependencyMap()
     for address, analysis in address_and_analysis:
         for top_level_type in analysis.top_level_types:
-            components = top_level_type.rsplit(".", maxsplit=1)
-            if len(components) != 2:
-                # A package without a name cannot be imported, and so does not expose any symbols.
-                # https://docs.oracle.com/javase/specs/jls/se8/html/jls-7.html#jls-7.4.2
-                continue
-            package, type_ = components
-            dep_map.add_top_level_type(package=package, type_=type_, address=address)
+            dep_map.add_top_level_type(top_level_type, address=address)
 
     return FirstPartyJavaMappingImpl(package_rooted_dependency_map=dep_map)
 

--- a/src/python/pants/backend/java/dependency_inference/package_prefix_tree.py
+++ b/src/python/pants/backend/java/dependency_inference/package_prefix_tree.py
@@ -17,17 +17,9 @@ class PackageRootedDependencyMap:
     def __init__(self):
         self._type_map: dict[str, set[Address]] = defaultdict(set)
 
-    def add_top_level_type(self, package: str, type_: str, address: Address):
-        """Declare a single Address as a provider of a top level type.
-
-        This method also associates the address with the type's package, and there can be more than
-        one address associated with a given package.
-        """
-        fqt = ".".join([package, type_])
-        self._type_map[fqt].add(address)
-
-    def add_package(self, package: str, address: Address):
-        """Add an address as one of the providers of a package."""
+    def add_top_level_type(self, type_: str, address: Address):
+        """Declare a single Address as a provider of a top level type."""
+        self._type_map[type_].add(address)
 
     def addresses_for_type(self, symbol: str) -> frozenset[Address]:
         """Returns the set of addresses that provide the passed type.

--- a/src/python/pants/backend/java/dependency_inference/package_prefix_tree_test.py
+++ b/src/python/pants/backend/java/dependency_inference/package_prefix_tree_test.py
@@ -11,7 +11,7 @@ def test_package_rooted_dependency_map() -> None:
     dep_map = PackageRootedDependencyMap()
 
     a = Address("a")
-    dep_map.add_top_level_type(package="org.pantsbuild", type_="Foo", address=a)
+    dep_map.add_top_level_type(type_="org.pantsbuild.Foo", address=a)
     # An exact match yields the exact matching address
     assert dep_map.addresses_for_type("org.pantsbuild.Foo") == frozenset([a])
     # A miss returns nothing
@@ -19,7 +19,7 @@ def test_package_rooted_dependency_map() -> None:
     assert dep_map.addresses_for_type("org.other.Foo") == frozenset()
 
     b = Address("b")
-    dep_map.add_top_level_type(package="org.pantsbuild", type_="Baz", address=b)
+    dep_map.add_top_level_type(type_="org.pantsbuild.Baz", address=b)
     # Again, exact matches yield exact providers
     assert dep_map.addresses_for_type("org.pantsbuild.Foo") == frozenset([a])
     assert dep_map.addresses_for_type("org.pantsbuild.Baz") == frozenset([b])

--- a/src/python/pants/backend/java/dependency_inference/rules.py
+++ b/src/python/pants/backend/java/dependency_inference/rules.py
@@ -68,9 +68,13 @@ async def infer_java_dependencies_via_imports(
         types.update(imp.name for imp in analysis.imports)
     if java_infer_subsystem.consumed_types:
         package = analysis.declared_package
-        types.update(
-            f"{package}.{consumed_type}" for consumed_type in analysis.consumed_unqualified_types
-        )
+        if package:
+            types.update(
+                f"{package}.{consumed_type}"
+                for consumed_type in analysis.consumed_unqualified_types
+            )
+        else:
+            types.update(analysis.consumed_unqualified_types)
 
     dep_map = first_party_dep_map.package_rooted_dependency_map
 

--- a/src/python/pants/backend/java/dependency_inference/types.py
+++ b/src/python/pants/backend/java/dependency_inference/types.py
@@ -24,7 +24,7 @@ class JavaImport:
 
 @dataclass(frozen=True)
 class JavaSourceDependencyAnalysis:
-    declared_package: str
+    declared_package: str | None
     imports: Sequence[JavaImport]
     top_level_types: Sequence[str]
     consumed_unqualified_types: Sequence[str]
@@ -32,7 +32,7 @@ class JavaSourceDependencyAnalysis:
     @classmethod
     def from_json_dict(cls, analysis: dict[str, Any]) -> JavaSourceDependencyAnalysis:
         return cls(
-            declared_package=analysis["declaredPackage"],
+            declared_package=analysis.get("declaredPackage"),
             imports=tuple(JavaImport.from_json_dict(imp) for imp in analysis["imports"]),
             top_level_types=tuple(analysis["topLevelTypes"]),
             consumed_unqualified_types=tuple(analysis["consumedUnqualifiedTypes"]),


### PR DESCRIPTION
The assertion in #13214 was technically true: you cannot `import` a symbol from the unnamed package. But a file may still use a symbol from the unnamed package if it is also in the unnamed package.

Although heavily using the unnamed package is ill-advised, we should account for the fact that packages are optional. 

[ci skip-rust]
[ci skip-build-wheels]