### PR TITLE
[internal] scala: extract provided names from source files

### DIFF
--- a/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
+++ b/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
@@ -57,6 +57,12 @@ class ProvidedTypesTraverser extends Traverser {
       withNamePart(name, () => super.apply(templ))
     }
 
+    case Defn.Object(_mods, nameNode, templ) => {
+      val name = extractName(nameNode)
+      recordProvidedType(name)
+      withNamePart(name, () => super.apply(templ))
+    }
+
     case Defn.Type(_mods, nameNode, _tparams, _body) => {
       val name = extractName(nameNode)
       recordProvidedType(name)

--- a/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
+++ b/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
@@ -23,6 +23,7 @@ class ProvidedTypesTraverser extends Traverser {
       case Term.Select(qual, name) => s"${extractName(qual)}.${extractName(name)}"
       case Term.Name(name) => name
       case Type.Name(name) => name
+      case Pat.Var(node) => extractName(node)
       case _ => ""
     }
   }
@@ -54,6 +55,25 @@ class ProvidedTypesTraverser extends Traverser {
       val name = extractName(nameNode)
       recordProvidedType(name)
       withNamePart(name, () => super.apply(templ))
+    }
+
+    case Defn.Type(_mods, nameNode, _tparams, _body) => {
+      val name = extractName(nameNode)
+      recordProvidedType(name)
+    }
+
+    case Defn.Val(_mods, pats, _decltpe, _rhs) => {
+      pats.headOption.foreach(pat => {
+        val name = extractName(pat)
+        recordProvidedType(name)
+      })
+    }
+
+    case Defn.Var(_mods, pats, _decltpe, _rhs) => {
+      pats.headOption.foreach(pat => {
+        val name = extractName(pat)
+        recordProvidedType(name)
+      })
     }
 
     case node => super.apply(node)

--- a/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
+++ b/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
@@ -10,12 +10,12 @@ import scala.meta.transversers.Traverser
 import scala.collection.mutable.ArrayBuffer
 
 case class Analysis(
-  providedTypes: Vector[String]
+  providedNames: Vector[String]
 )
 
 class ProvidedTypesTraverser extends Traverser {
   val nameParts = ArrayBuffer[String]()
-  val providedTypes = ArrayBuffer[String]()
+  val providedNames = ArrayBuffer[String]()
 
   // Extract a qualified name from a tree.
   def extractName(tree: Tree): String = {
@@ -28,9 +28,9 @@ class ProvidedTypesTraverser extends Traverser {
     }
   }
 
-  def recordProvidedType(name: String): Unit = {
+  def recordProvidedName(name: String): Unit = {
     val fullPackageName = nameParts.mkString(".")
-    providedTypes.append(s"${fullPackageName}.${name}")
+    providedNames.append(s"${fullPackageName}.${name}")
   }
 
   def withNamePart[T](namePart: String, f: () => T): T = {
@@ -47,38 +47,38 @@ class ProvidedTypesTraverser extends Traverser {
 
     case Defn.Class(_mods, nameNode, _tparams, _ctor, templ) => {
       val name = extractName(nameNode)
-      recordProvidedType(name)
+      recordProvidedName(name)
       withNamePart(name, () => super.apply(templ))
     }
 
     case Defn.Trait(_mods, nameNode, _tparams, _ctor, templ) => {
       val name = extractName(nameNode)
-      recordProvidedType(name)
+      recordProvidedName(name)
       withNamePart(name, () => super.apply(templ))
     }
 
     case Defn.Object(_mods, nameNode, templ) => {
       val name = extractName(nameNode)
-      recordProvidedType(name)
+      recordProvidedName(name)
       withNamePart(name, () => super.apply(templ))
     }
 
     case Defn.Type(_mods, nameNode, _tparams, _body) => {
       val name = extractName(nameNode)
-      recordProvidedType(name)
+      recordProvidedName(name)
     }
 
     case Defn.Val(_mods, pats, _decltpe, _rhs) => {
       pats.headOption.foreach(pat => {
         val name = extractName(pat)
-        recordProvidedType(name)
+        recordProvidedName(name)
       })
     }
 
     case Defn.Var(_mods, pats, _decltpe, _rhs) => {
       pats.headOption.foreach(pat => {
         val name = extractName(pat)
-        recordProvidedType(name)
+        recordProvidedName(name)
       })
     }
 
@@ -95,10 +95,10 @@ object ScalaParser {
 
     val tree = input.parse[Source].get
 
-    val providedTypesTraverser = new ProvidedTypesTraverser()
-    providedTypesTraverser.apply(tree)
+    val providedNamesTraverser = new ProvidedTypesTraverser()
+    providedNamesTraverser.apply(tree)
 
-    Analysis(providedTypes = providedTypesTraverser.providedTypes.toVector)
+    Analysis(providedNames = providedNamesTraverser.providedNames.toVector)
   }
 
   def main(args: Array[String]): Unit = {

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
+import json
 import logging
 import os
 import pkgutil
@@ -12,13 +13,20 @@ from pants.engine.fs import (
     AddPrefix,
     CreateDigest,
     Digest,
+    DigestContents,
     Directory,
     FileContent,
     MergeDigests,
     RemovePrefix,
 )
 from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.process import BashBinary, FallibleProcessResult, Process, ProcessResult
+from pants.engine.process import (
+    BashBinary,
+    FallibleProcessResult,
+    Process,
+    ProcessExecutionFailure,
+    ProcessResult,
+)
 from pants.engine.rules import collect_rules, rule
 from pants.jvm.compile import ClasspathEntry
 from pants.jvm.jdk_rules import JdkSetup
@@ -28,7 +36,9 @@ from pants.jvm.resolve.coursier_fetch import (
     MaterializedClasspath,
     MaterializedClasspathRequest,
 )
+from pants.option.global_options import GlobalOptions
 from pants.util.logging import LogLevel
+from pants.util.ordered_set import FrozenOrderedSet
 
 logger = logging.getLogger(__name__)
 
@@ -83,12 +93,12 @@ SCALA_PARSER_ARTIFACT_REQUIREMENTS = ArtifactRequirements(
 
 @dataclass(frozen=True)
 class ScalaSourceDependencyAnalysis:
-    package: str
+    provided_types: FrozenOrderedSet[str]
 
     @classmethod
     def from_json_dict(cls, d: dict) -> ScalaSourceDependencyAnalysis:
         return cls(
-            package=d["package"],
+            provided_types=FrozenOrderedSet(d["providedTypes"]),
         )
 
 
@@ -164,7 +174,7 @@ async def analyze_scala_source_dependencies(
             argv=[
                 *jdk_setup.args(bash, [*tool_classpath.classpath_entries(), processorcp_relpath]),
                 "org.pantsbuild.backend.scala.dependency_inference.ScalaParser",
-                # analysis_output_path,
+                analysis_output_path,
                 source_path,
             ],
             input_digest=merged_digest,
@@ -178,6 +188,28 @@ async def analyze_scala_source_dependencies(
     )
 
     return FallibleScalaSourceDependencyAnalysisResult(process_result=process_result)
+
+
+@rule(level=LogLevel.DEBUG)
+async def resolve_fallible_result_to_analysis(
+    fallible_result: FallibleScalaSourceDependencyAnalysisResult,
+    global_options: GlobalOptions,
+) -> ScalaSourceDependencyAnalysis:
+    # TODO(#12725): Just convert directly to a ProcessResult like this:
+    # result = await Get(ProcessResult, FallibleProcessResult, fallible_result.process_result)
+    if fallible_result.process_result.exit_code == 0:
+        analysis_contents = await Get(
+            DigestContents, Digest, fallible_result.process_result.output_digest
+        )
+        analysis = json.loads(analysis_contents[0].content)
+        return ScalaSourceDependencyAnalysis.from_json_dict(analysis)
+    raise ProcessExecutionFailure(
+        fallible_result.process_result.exit_code,
+        fallible_result.process_result.stdout,
+        fallible_result.process_result.stderr,
+        "Scala source dependency analysis failed.",
+        local_cleanup=global_options.options.process_execution_local_cleanup,
+    )
 
 
 @rule

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -93,12 +93,12 @@ SCALA_PARSER_ARTIFACT_REQUIREMENTS = ArtifactRequirements(
 
 @dataclass(frozen=True)
 class ScalaSourceDependencyAnalysis:
-    provided_types: FrozenOrderedSet[str]
+    provided_names: FrozenOrderedSet[str]
 
     @classmethod
     def from_json_dict(cls, d: dict) -> ScalaSourceDependencyAnalysis:
         return cls(
-            provided_types=FrozenOrderedSet(d["providedTypes"]),
+            provided_names=FrozenOrderedSet(d["providedNames"]),
         )
 
 

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
@@ -118,7 +118,7 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
         [source_files],
     )
 
-    assert analysis.provided_types == FrozenOrderedSet(
+    assert analysis.provided_names == FrozenOrderedSet(
         [
             "org.pantsbuild.example.OuterClass",
             "org.pantsbuild.example.OuterClass.NestedVal",

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
@@ -60,7 +60,16 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
             package org.pantsbuild
             package example
 
-            class Foo {
+            class OuterClass {
+                trait NestedTrait {
+                }
+                class NestedClass {
+                }
+            }
+
+            trait OuterTrait {
+                trait NestedTrait {
+                }
                 class NestedClass {
                 }
             }
@@ -89,7 +98,11 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
 
     assert analysis.provided_types == FrozenOrderedSet(
         [
-            "org.pantsbuild.example.Foo",
-            "org.pantsbuild.example.Foo.NestedClass",
+            "org.pantsbuild.example.OuterClass",
+            "org.pantsbuild.example.OuterClass.NestedTrait",
+            "org.pantsbuild.example.OuterClass.NestedClass",
+            "org.pantsbuild.example.OuterTrait",
+            "org.pantsbuild.example.OuterTrait.NestedTrait",
+            "org.pantsbuild.example.OuterTrait.NestedClass",
         ]
     )

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
@@ -68,6 +68,8 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
                 class NestedClass {
                 }
                 type NestedType = Foo
+                object NestedObject {
+                }
             }
 
             trait OuterTrait {
@@ -78,6 +80,20 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
                 class NestedClass {
                 }
                 type NestedType = Foo
+                object NestedObject {
+                }
+            }
+
+            object OuterObject {
+                val NestedVal = 3
+                var NestedVar = "foo"
+                trait NestedTrait {
+                }
+                class NestedClass {
+                }
+                type NestedType = Foo
+                object NestedObject {
+                }
             }
             """
             ),
@@ -110,11 +126,20 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
             "org.pantsbuild.example.OuterClass.NestedTrait",
             "org.pantsbuild.example.OuterClass.NestedClass",
             "org.pantsbuild.example.OuterClass.NestedType",
+            "org.pantsbuild.example.OuterClass.NestedObject",
             "org.pantsbuild.example.OuterTrait",
             "org.pantsbuild.example.OuterTrait.NestedVal",
             "org.pantsbuild.example.OuterTrait.NestedVar",
             "org.pantsbuild.example.OuterTrait.NestedTrait",
             "org.pantsbuild.example.OuterTrait.NestedClass",
             "org.pantsbuild.example.OuterTrait.NestedType",
+            "org.pantsbuild.example.OuterTrait.NestedObject",
+            "org.pantsbuild.example.OuterObject",
+            "org.pantsbuild.example.OuterObject.NestedVal",
+            "org.pantsbuild.example.OuterObject.NestedVar",
+            "org.pantsbuild.example.OuterObject.NestedTrait",
+            "org.pantsbuild.example.OuterObject.NestedClass",
+            "org.pantsbuild.example.OuterObject.NestedType",
+            "org.pantsbuild.example.OuterObject.NestedObject",
         ]
     )

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
@@ -61,17 +61,23 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
             package example
 
             class OuterClass {
+                val NestedVal = 3
+                var NestedVar = "foo"
                 trait NestedTrait {
                 }
                 class NestedClass {
                 }
+                type NestedType = Foo
             }
 
             trait OuterTrait {
+                val NestedVal = 3
+                var NestedVar = "foo"
                 trait NestedTrait {
                 }
                 class NestedClass {
                 }
+                type NestedType = Foo
             }
             """
             ),
@@ -99,10 +105,16 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
     assert analysis.provided_types == FrozenOrderedSet(
         [
             "org.pantsbuild.example.OuterClass",
+            "org.pantsbuild.example.OuterClass.NestedVal",
+            "org.pantsbuild.example.OuterClass.NestedVar",
             "org.pantsbuild.example.OuterClass.NestedTrait",
             "org.pantsbuild.example.OuterClass.NestedClass",
+            "org.pantsbuild.example.OuterClass.NestedType",
             "org.pantsbuild.example.OuterTrait",
+            "org.pantsbuild.example.OuterTrait.NestedVal",
+            "org.pantsbuild.example.OuterTrait.NestedVar",
             "org.pantsbuild.example.OuterTrait.NestedTrait",
             "org.pantsbuild.example.OuterTrait.NestedClass",
+            "org.pantsbuild.example.OuterTrait.NestedType",
         ]
     )


### PR DESCRIPTION
Extract and report on names provided by a Scala source file. This will be used for dependency inference once the "consumed types" side of the analysis is available.