### PR TITLE
[internal] java: add debug goal to dump source analysis

### DIFF
--- a/src/python/pants/backend/java/dependency_inference/types.py
+++ b/src/python/pants/backend/java/dependency_inference/types.py
@@ -21,6 +21,13 @@ class JavaImport:
             is_static=imp["isStatic"],
         )
 
+    def to_debug_json_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "is_static": self.is_static,
+            "is_asterisk": self.is_asterisk,
+        }
+
 
 @dataclass(frozen=True)
 class JavaSourceDependencyAnalysis:
@@ -37,3 +44,11 @@ class JavaSourceDependencyAnalysis:
             top_level_types=tuple(analysis["topLevelTypes"]),
             consumed_unqualified_types=tuple(analysis["consumedUnqualifiedTypes"]),
         )
+
+    def to_debug_json_dict(self) -> dict[str, Any]:
+        return {
+            "declared_package": self.declared_package,
+            "imports": [imp.to_debug_json_dict() for imp in self.imports],
+            "top_level_types": self.top_level_types,
+            "consumed_unqualified_types": self.consumed_unqualified_types,
+        }

--- a/src/python/pants/backend/java/goals/debug_goals.py
+++ b/src/python/pants/backend/java/goals/debug_goals.py
@@ -5,9 +5,14 @@ import json
 
 from pants.backend.experimental.java.register import rules as java_rules
 from pants.backend.java.dependency_inference.package_mapper import FirstPartyJavaPackageMapping
+from pants.backend.java.dependency_inference.types import JavaSourceDependencyAnalysis
+from pants.backend.java.target_types import JavaFieldSet
+from pants.core.util_rules.source_files import SourceFilesRequest
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem
+from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import collect_rules, goal_rule
+from pants.engine.target import Targets
 
 
 class DumpFirstPartyDepMapSubsystem(GoalSubsystem):
@@ -27,6 +32,32 @@ async def dump_dep_inference_data(
         json.dumps(first_party_dep_map.package_rooted_dependency_map.to_json_dict())
     )
     return DumpFirstPartyDepMap(exit_code=0)
+
+
+class DumpJavaSourceAnalysisSubsystem(GoalSubsystem):
+    name = "java-dump-source-analysis"
+    help = "Dump source analysis for java_source[s] targets."
+
+
+class DumpJavaSourceAnalysis(Goal):
+    subsystem_cls = DumpJavaSourceAnalysisSubsystem
+
+
+@goal_rule
+async def dump_java_source_analysis(targets: Targets, console: Console) -> DumpJavaSourceAnalysis:
+    java_source_field_sets = [
+        JavaFieldSet.create(tgt) for tgt in targets if JavaFieldSet.is_applicable(tgt)
+    ]
+    java_source_analysis = await MultiGet(
+        Get(JavaSourceDependencyAnalysis, SourceFilesRequest([fs.sources]))
+        for fs in java_source_field_sets
+    )
+    java_source_analysis_json = [
+        {"address": str(fs.address), **analysis.to_debug_json_dict()}
+        for (fs, analysis) in zip(java_source_field_sets, java_source_analysis)
+    ]
+    console.write_stdout(json.dumps(java_source_analysis_json))
+    return DumpJavaSourceAnalysis(exit_code=0)
 
 
 def rules():


### PR DESCRIPTION
Add `java-dump-source-analysis` debug goal to dump the `JavaSourceDependencyAnalysis` data for Java sources.

[ci skip-rust]
