### PR TITLE
[internal] scala: add debug goal to dump source analysis

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -21,6 +21,7 @@ backend_packages.add = [
   "pants.backend.experimental.java.debug_goals",
   "pants.backend.experimental.python",
   "pants.backend.experimental.scala",
+  "pants.backend.experimental.scala.debug_goals",
   "internal_plugins.releases",
 ]
 plugins = [

--- a/src/python/pants/backend/experimental/scala/debug_goals/BUILD
+++ b/src/python/pants/backend/experimental/scala/debug_goals/BUILD
@@ -1,0 +1,4 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_sources()

--- a/src/python/pants/backend/experimental/scala/debug_goals/register.py
+++ b/src/python/pants/backend/experimental/scala/debug_goals/register.py
@@ -1,0 +1,7 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from pants.backend.scala.goals import debug_goals
+
+
+def rules():
+    return debug_goals.rules()

--- a/src/python/pants/backend/experimental/scala/register.py
+++ b/src/python/pants/backend/experimental/scala/register.py
@@ -9,6 +9,7 @@ from pants.backend.java.target_types import (  # TODO: All of these should move 
 )
 from pants.backend.java.test import junit  # TODO: Should move to the JVM package.
 from pants.backend.scala.compile import scalac
+from pants.backend.scala.dependency_inference import scala_parser
 from pants.backend.scala.goals import check
 from pants.backend.scala.target_types import ScalaSourcesGeneratorTarget, ScalaSourceTarget
 from pants.backend.scala.target_types import rules as target_types_rules
@@ -43,5 +44,6 @@ def rules():
         *coursier_setup.rules(),
         *jvm_util_rules.rules(),
         *jdk_rules.rules(),
+        *scala_parser.rules(),
         *target_types_rules(),
     ]

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -7,6 +7,7 @@ import logging
 import os
 import pkgutil
 from dataclasses import dataclass
+from typing import Any
 
 from pants.core.util_rules.source_files import SourceFiles
 from pants.engine.fs import (
@@ -100,6 +101,11 @@ class ScalaSourceDependencyAnalysis:
         return cls(
             provided_names=FrozenOrderedSet(d["providedNames"]),
         )
+
+    def to_debug_json_dict(self) -> dict[str, Any]:
+        return {
+            "provided_names": self.provided_names,
+        }
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/scala/goals/debug_goals.py
+++ b/src/python/pants/backend/scala/goals/debug_goals.py
@@ -1,3 +1,6 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 import json
 
 from pants.backend.experimental.scala.register import rules as scala_rules

--- a/src/python/pants/backend/scala/goals/debug_goals.py
+++ b/src/python/pants/backend/scala/goals/debug_goals.py
@@ -1,0 +1,44 @@
+import json
+
+from pants.backend.experimental.scala.register import rules as scala_rules
+from pants.backend.scala.dependency_inference.scala_parser import ScalaSourceDependencyAnalysis
+from pants.backend.scala.target_types import ScalaFieldSet
+from pants.core.util_rules.source_files import SourceFilesRequest
+from pants.engine.console import Console
+from pants.engine.goal import Goal, GoalSubsystem
+from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.rules import collect_rules, goal_rule
+from pants.engine.target import Targets
+
+
+class DumpScalaSourceAnalysisSubsystem(GoalSubsystem):
+    name = "scala-dump-source-analysis"
+    help = "Dump source analysis for scala_source targets."
+
+
+class DumpScalaSourceAnalysis(Goal):
+    subsystem_cls = DumpScalaSourceAnalysisSubsystem
+
+
+@goal_rule
+async def dump_scala_source_analysis(targets: Targets, console: Console) -> DumpScalaSourceAnalysis:
+    scala_source_field_sets = [
+        ScalaFieldSet.create(tgt) for tgt in targets if ScalaFieldSet.is_applicable(tgt)
+    ]
+    scala_source_analysis = await MultiGet(
+        Get(ScalaSourceDependencyAnalysis, SourceFilesRequest([fs.sources]))
+        for fs in scala_source_field_sets
+    )
+    scala_source_analysis_json = [
+        {"address": str(fs.address), **analysis.to_debug_json_dict()}
+        for (fs, analysis) in zip(scala_source_field_sets, scala_source_analysis)
+    ]
+    console.write_stdout(json.dumps(scala_source_analysis_json))
+    return DumpScalaSourceAnalysis(exit_code=0)
+
+
+def rules():
+    return [
+        *collect_rules(),
+        *scala_rules(),
+    ]


### PR DESCRIPTION
Add `scala-dump-source-analysis` debug goal to dump Scala source analysis. Also sets up `pants.backend.experimental.scala.debug_goals` backend to include debug goals, and adds scala_parser to the scala backend setup.

[ci skip-rust]
