### PR TITLE
Fix formatting of `overrides` field in docs

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/target_types.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types.py
@@ -85,11 +85,11 @@ class ProtobufSourcesOverridesField(OverridesField):
     help = generate_file_based_overrides_field_help_message(
         ProtobufSourceTarget.alias,
         (
-            "  overrides={\n"
-            '    "foo.proto": {"grpc": True]},\n'
-            '    "bar.proto": {"description": "our user model"]},\n'
-            '    ("foo.proto", "bar.proto"): {"tags": ["overridden"]},\n'
-            "  }"
+            "overrides={\n"
+            '  "foo.proto": {"grpc": True]},\n'
+            '  "bar.proto": {"description": "our user model"]},\n'
+            '  ("foo.proto", "bar.proto"): {"tags": ["overridden"]},\n'
+            "}"
         ),
     )
 

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -607,11 +607,11 @@ class PythonTestsOverrideField(OverridesField):
     help = generate_file_based_overrides_field_help_message(
         PythonTestTarget.alias,
         (
-            "  overrides={\n"
-            '    "foo_test.py": {"timeout": 120]},\n'
-            '    "bar_test.py": {"timeout": 200]},\n'
-            '    ("foo_test.py", "bar_test.py"): {"tags": ["slow_tests"]},\n'
-            "  }"
+            "overrides={\n"
+            '  "foo_test.py": {"timeout": 120]},\n'
+            '  "bar_test.py": {"timeout": 200]},\n'
+            '  ("foo_test.py", "bar_test.py"): {"tags": ["slow_tests"]},\n'
+            "}"
         ),
     )
 
@@ -646,11 +646,11 @@ class PythonSourcesOverridesField(OverridesField):
     help = generate_file_based_overrides_field_help_message(
         PythonSourceTarget.alias,
         (
-            "  overrides={\n"
-            '    "foo.py": {"skip_pylint": True]},\n'
-            '    "bar.py": {"skip_flake8": True]},\n'
-            '    ("foo.py", "bar.py"): {"tags": ["linter_disabled"]},\n'
-            "  }"
+            "overrides={\n"
+            '  "foo.py": {"skip_pylint": True]},\n'
+            '  "bar.py": {"skip_flake8": True]},\n'
+            '  ("foo.py", "bar.py"): {"tags": ["linter_disabled"]},\n'
+            "}"
         ),
     )
 

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -162,11 +162,11 @@ class Shunit2TestsOverrideField(OverridesField):
     help = generate_file_based_overrides_field_help_message(
         Shunit2TestTarget.alias,
         (
-            "  overrides={\n"
-            '    "foo_test.sh": {"timeout": 120]},\n'
-            '    "bar_test.sh": {"timeout": 200]},\n'
-            '    ("foo_test.sh", "bar_test.sh"): {"tags": ["slow_tests"]},\n'
-            "  }"
+            "overrides={\n"
+            '  "foo_test.sh": {"timeout": 120]},\n'
+            '  "bar_test.sh": {"timeout": 200]},\n'
+            '  ("foo_test.sh", "bar_test.sh"): {"tags": ["slow_tests"]},\n'
+            "}"
         ),
     )
 
@@ -240,11 +240,11 @@ class ShellSourcesOverridesField(OverridesField):
     help = generate_file_based_overrides_field_help_message(
         ShellSourceTarget.alias,
         (
-            "  overrides={\n"
-            '    "foo.sh": {"skip_shellcheck": True]},\n'
-            '    "bar.sh": {"skip_shfmt": True]},\n'
-            '    ("foo.sh", "bar.sh"): {"tags": ["linter_disabled"]},\n'
-            "  }"
+            "overrides={\n"
+            '  "foo.sh": {"skip_shellcheck": True]},\n'
+            '  "bar.sh": {"skip_shfmt": True]},\n'
+            '  ("foo.sh", "bar.sh"): {"tags": ["linter_disabled"]},\n'
+            "}"
         ),
     )
 

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -79,11 +79,11 @@ class FilesOverridesField(OverridesField):
     help = generate_file_based_overrides_field_help_message(
         FileTarget.alias,
         (
-            "  overrides={\n"
-            '    "foo.json": {"description": "our customer model"]},\n'
-            '    "bar.json": {"description": "our product model"]},\n'
-            '    ("foo.json", "bar.json"): {"tags": ["overridden"]},\n'
-            "  }"
+            "overrides={\n"
+            '  "foo.json": {"description": "our customer model"]},\n'
+            '  "bar.json": {"description": "our product model"]},\n'
+            '  ("foo.json", "bar.json"): {"tags": ["overridden"]},\n'
+            "}"
         ),
     )
 
@@ -289,11 +289,11 @@ class ResourcesOverridesField(OverridesField):
     help = generate_file_based_overrides_field_help_message(
         ResourceTarget.alias,
         (
-            "  overrides={\n"
-            '    "foo.json": {"description": "our customer model"]},\n'
-            '    "bar.json": {"description": "our product model"]},\n'
-            '    ("foo.json", "bar.json"): {"tags": ["overridden"]},\n'
-            "  }"
+            "overrides={\n"
+            '  "foo.json": {"description": "our customer model"]},\n'
+            '  "bar.json": {"description": "our product model"]},\n'
+            '  ("foo.json", "bar.json"): {"tags": ["overridden"]},\n'
+            "}"
         ),
     )
 

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -2292,7 +2292,7 @@ def generate_file_based_overrides_field_help_message(
         "overrides. You may either use a string for a single path / glob, "
         "or a string tuple for multiple paths / globs. Each override is a dictionary of "
         "field names to the overridden value.\n\n"
-        f"For example:\n\n{example}\n\n"
+        f"For example:\n\n```\n{example}\n```\n\n"
         "File paths and globs are relative to the BUILD file's directory. Every overridden file is "
         "validated to belong to this target's `sources` field.\n\n"
         f"If you'd like to override a field's value for every `{generated_target_name}` target "


### PR DESCRIPTION
These weren't being rendered as code before:

<img width="391" alt="Screen Shot 2021-11-09 at 10 20 30 AM" src="https://user-images.githubusercontent.com/14852634/140973180-5c8f84ce-cc82-4c9b-8570-e55b4f0addb6.png">

It's a little weird imo to put ``` in `./pants help`, but it looks acceptable after removing indentation:

<img width="539" alt="Screen Shot 2021-11-09 at 10 21 27 AM" src="https://user-images.githubusercontent.com/14852634/140973328-2dc64133-0002-4a2a-a646-af2b8691b543.png">



[ci skip-rust]
[ci skip-build-wheels]