### PR TITLE
Adds enough 3rd-party dependency mappings to compile `guice`.

### DIFF
--- a/src/python/pants/backend/java/dependency_inference/jvm_artifact_mappings.py
+++ b/src/python/pants/backend/java/dependency_inference/jvm_artifact_mappings.py
@@ -3,5 +3,15 @@
 from __future__ import annotations
 
 JVM_ARTIFACT_MAPPINGS = {
+    "com.google.common.collect.**": "com.google.guava:guava",
+    "com.google.common.testing.**": "com.google.guava:guava-testlib",
+    "com.google.common.truth.**": "com.google.truth:truth",
+    "javax.inject.**": "javax.inject:javax.inject",
+    "junit.framework.**": "junit:junit",
+    "org.aopalliance.**": "aopalliance:aopalliance",
+    "org.atinject.tck.**": "javax.inject:javax.inject-tck",
     "org.junit.**": "junit:junit",
+    "org.objectweb.asm.**": "org.ow2.asm:asm",
+    "org.osgi.framework.**": "org.osgi:org.osgi.framework",
+    "org.springframework.beans.**": "org.springframework:spring-beans",
 }


### PR DESCRIPTION
This adds enough entries to the `JVM_ARTIFACT_MAPPINGS` dict to resolve all 3rd-party imports in `guice`.