### PR TITLE
[internal] scala: extract imports from source files

### DIFF
--- a/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
+++ b/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
@@ -14,14 +14,14 @@ case class AnImport(name: String, isWildcard: Boolean)
 
 case class Analysis(
   providedNames: Vector[String],
-  importsByNamespace: HashMap[String, ArrayBuffer[AnImport]],
+  importsByScope: HashMap[String, ArrayBuffer[AnImport]],
 )
 
 class SourceAnalysisTraverser extends Traverser {
   val nameParts = ArrayBuffer[String]()
 
   val providedNames = ArrayBuffer[String]()
-  val importsByNamespace = HashMap[String, ArrayBuffer[AnImport]]()
+  val importsByScope = HashMap[String, ArrayBuffer[AnImport]]()
 
   // Extract a qualified name from a tree.
   def extractName(tree: Tree): String = {
@@ -49,10 +49,10 @@ class SourceAnalysisTraverser extends Traverser {
 
   def recordImport(name: String, isWildcard: Boolean): Unit = {
     val fullPackageName = nameParts.mkString(".")
-    if (!importsByNamespace.contains(fullPackageName)) {
-      importsByNamespace(fullPackageName) = ArrayBuffer[AnImport]()
+    if (!importsByScope.contains(fullPackageName)) {
+      importsByScope(fullPackageName) = ArrayBuffer[AnImport]()
     }
-    importsByNamespace(fullPackageName).append(AnImport(name, isWildcard))
+    importsByScope(fullPackageName).append(AnImport(name, isWildcard))
   }
 
   override def apply(tree: Tree): Unit = tree match {
@@ -129,7 +129,7 @@ object ScalaParser {
 
     Analysis(
       providedNames = analysisTraverser.providedNames.toVector,
-      importsByNamespace = analysisTraverser.importsByNamespace,
+      importsByScope = analysisTraverser.importsByScope,
     )
   }
 

--- a/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
+++ b/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
@@ -8,14 +8,20 @@ import scala.meta._
 import scala.meta.transversers.Traverser
 
 import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable.HashMap
+
+case class AnImport(name: String, isWildcard: Boolean)
 
 case class Analysis(
-  providedNames: Vector[String]
+  providedNames: Vector[String],
+  importsByNamespace: HashMap[String, ArrayBuffer[AnImport]],
 )
 
-class ProvidedTypesTraverser extends Traverser {
+class SourceAnalysisTraverser extends Traverser {
   val nameParts = ArrayBuffer[String]()
+
   val providedNames = ArrayBuffer[String]()
+  val importsByNamespace = HashMap[String, ArrayBuffer[AnImport]]()
 
   // Extract a qualified name from a tree.
   def extractName(tree: Tree): String = {
@@ -24,6 +30,7 @@ class ProvidedTypesTraverser extends Traverser {
       case Term.Name(name) => name
       case Type.Name(name) => name
       case Pat.Var(node) => extractName(node)
+      case Name.Indeterminate(name) => name
       case _ => ""
     }
   }
@@ -38,6 +45,14 @@ class ProvidedTypesTraverser extends Traverser {
     val result = f()
     nameParts.remove(nameParts.length - 1)
     result
+  }
+
+  def recordImport(name: String, isWildcard: Boolean): Unit = {
+    val fullPackageName = nameParts.mkString(".")
+    if (!importsByNamespace.contains(fullPackageName)) {
+      importsByNamespace(fullPackageName) = ArrayBuffer[AnImport]()
+    }
+    importsByNamespace(fullPackageName).append(AnImport(name, isWildcard))
   }
 
   override def apply(tree: Tree): Unit = tree match {
@@ -82,6 +97,20 @@ class ProvidedTypesTraverser extends Traverser {
       })
     }
 
+    case Import(importers) => {
+      importers.foreach({ case Importer(ref, importees) =>
+        val baseName = extractName(ref)
+        importees.foreach(importee => {
+          importee match {
+            case Importee.Wildcard() => recordImport(baseName, true)
+            case Importee.Name(nameNode) => recordImport(s"${baseName}.${extractName(nameNode)}", false)
+            case Importee.Rename(nameNode, _) => recordImport(s"${baseName}.${extractName(nameNode)}", false)
+            case _ =>
+          }
+        })
+      })
+    }
+
     case node => super.apply(node)
   }
 }
@@ -95,10 +124,13 @@ object ScalaParser {
 
     val tree = input.parse[Source].get
 
-    val providedNamesTraverser = new ProvidedTypesTraverser()
-    providedNamesTraverser.apply(tree)
+    val analysisTraverser = new SourceAnalysisTraverser()
+    analysisTraverser.apply(tree)
 
-    Analysis(providedNames = providedNamesTraverser.providedNames.toVector)
+    Analysis(
+      providedNames = analysisTraverser.providedNames.toVector,
+      importsByNamespace = analysisTraverser.importsByNamespace,
+    )
   }
 
   def main(args: Array[String]): Unit = {

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -112,16 +112,16 @@ class ScalaImport:
 @dataclass(frozen=True)
 class ScalaSourceDependencyAnalysis:
     provided_names: FrozenOrderedSet[str]
-    imports_by_namespace: FrozenDict[str, tuple[ScalaImport, ...]]
+    imports_by_scope: FrozenDict[str, tuple[ScalaImport, ...]]
 
     @classmethod
     def from_json_dict(cls, d: dict) -> ScalaSourceDependencyAnalysis:
         return cls(
             provided_names=FrozenOrderedSet(d["providedNames"]),
-            imports_by_namespace=FrozenDict(
+            imports_by_scope=FrozenDict(
                 {
                     key: tuple([ScalaImport.from_json_dict(v) for v in values])
-                    for key, values in d["importsByNamespace"].items()
+                    for key, values in d["importsByScope"].items()
                 }
             ),
         )
@@ -129,9 +129,9 @@ class ScalaSourceDependencyAnalysis:
     def to_debug_json_dict(self) -> dict[str, Any]:
         return {
             "provided_names": self.provided_names,
-            "imports_by_namespace": {
+            "imports_by_scope": {
                 key: [v.to_debug_json_dict() for v in values]
-                for key, values in self.imports_by_namespace.items()
+                for key, values in self.imports_by_scope.items()
             },
         }
 

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
@@ -153,7 +153,7 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
         ]
     )
 
-    assert analysis.imports_by_namespace == FrozenDict(
+    assert analysis.imports_by_scope == FrozenDict(
         {
             "org.pantsbuild.example.OuterClass": (
                 ScalaImport(name="foo.bar.SomeItem", is_wildcard=False),


### PR DESCRIPTION
Extract imports from Scala sources and report them for dependency inference. Unlike Java, Scala imports can occur in many different scopes in a file (and not just the file's top-level scope), and so this PR reports the imports by scope. (I am not sure if reporting by scope name will be useful but easy enough to extract that information now so I can attempt to make use of it in subsequent PRs.)

[ci skip-rust]