### PR TITLE
Java: Handle 3rd-party FQTNs better

### DIFF
--- a/src/python/pants/backend/java/dependency_inference/PantsJavaParserLauncher.java
+++ b/src/python/pants/backend/java/dependency_inference/PantsJavaParserLauncher.java
@@ -57,18 +57,18 @@ class CompilationUnitAnalysis {
         Optional<String> declaredPackage,
         ArrayList<Import> imports,
         ArrayList<String> topLevelTypes,
-        ArrayList<String> consumedUnqualifiedTypes
+        ArrayList<String> consumedTypes
     ) {
         this.declaredPackage = declaredPackage;
         this.imports = imports;
         this.topLevelTypes = topLevelTypes;
-        this.consumedUnqualifiedTypes = consumedUnqualifiedTypes;
+        this.consumedTypes = consumedTypes;
     }
 
     public final Optional<String> declaredPackage;
     public final ArrayList<Import> imports;
     public final ArrayList<String> topLevelTypes;
-    public final ArrayList<String> consumedUnqualifiedTypes;
+    public final ArrayList<String> consumedTypes;
 }
 
 
@@ -199,9 +199,9 @@ public class PantsJavaParserLauncher {
             identifiers.addAll(identifiersForType);
         }
 
-        ArrayList<String> consumedUnqualifiedTypes = new ArrayList<>(identifiers);
+        ArrayList<String> consumedTypes = new ArrayList<>(identifiers);
 
-        CompilationUnitAnalysis analysis = new CompilationUnitAnalysis(declaredPackage, imports, topLevelTypes, consumedUnqualifiedTypes);
+        CompilationUnitAnalysis analysis = new CompilationUnitAnalysis(declaredPackage, imports, topLevelTypes, consumedTypes);
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new Jdk8Module());
         mapper.writeValue(new File(analysisOutputPath), analysis);

--- a/src/python/pants/backend/java/dependency_inference/java_parser_test.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser_test.py
@@ -124,7 +124,7 @@ def test_simple_java_parser_analysis(rule_runner: RuleRunner) -> None:
         "org.pantsbuild.example.SimpleSource",
         "org.pantsbuild.example.Foo",
     )
-    assert sorted(analysis.consumed__types) == [
+    assert sorted(analysis.consumed_types) == [
         "Date",
         "System",
         "date",  # note: false positive on a variable identifier

--- a/src/python/pants/backend/java/dependency_inference/java_parser_test.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser_test.py
@@ -124,7 +124,7 @@ def test_simple_java_parser_analysis(rule_runner: RuleRunner) -> None:
         "org.pantsbuild.example.SimpleSource",
         "org.pantsbuild.example.Foo",
     )
-    assert sorted(analysis.consumed_unqualified_types) == [
+    assert sorted(analysis.consumed__types) == [
         "Date",
         "System",
         "date",  # note: false positive on a variable identifier
@@ -223,11 +223,11 @@ def test_java_parser_unnamed_package(rule_runner: RuleRunner) -> None:
     assert analysis.declared_package is None
     assert analysis.imports == ()
     assert analysis.top_level_types == ("SimpleSource", "Foo")
-    assert analysis.consumed_unqualified_types == ("System",)
+    assert analysis.consumed_types == ("System",)
 
 
 @maybe_skip_jdk_test
-def test_java_parser_consumed_unqualified_types(rule_runner: RuleRunner) -> None:
+def test_java_parser_consumed_types(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
             "BUILD": dedent(
@@ -283,7 +283,7 @@ def test_java_parser_consumed_unqualified_types(rule_runner: RuleRunner) -> None
     assert analysis.declared_package == "org.pantsbuild.test"
     assert analysis.imports == ()
     assert analysis.top_level_types == ("org.pantsbuild.test.AnImpl",)
-    assert sorted(analysis.consumed_unqualified_types) == [
+    assert sorted(analysis.consumed_types) == [
         "AThrownException",
         "ClassAnnotation",
         "FieldAnnotation",

--- a/src/python/pants/backend/java/dependency_inference/rules.py
+++ b/src/python/pants/backend/java/dependency_inference/rules.py
@@ -68,13 +68,13 @@ async def infer_java_dependencies_via_imports(
         types.update(dependency_name(imp.name, imp.is_static) for imp in analysis.imports)
     if java_infer_subsystem.consumed_types:
         package = analysis.declared_package
-        if package:
-            types.update(
-                f"{package}.{consumed_type}"
-                for consumed_type in analysis.consumed_unqualified_types
-            )
-        else:
-            types.update(analysis.consumed_unqualified_types)
+
+        maybe_qualify_types = (
+            f"{package}.{consumed_type}" if package and "." not in consumed_type else consumed_type
+            for consumed_type in analysis.consumed_unqualified_types
+        )
+
+        types.update(maybe_qualify_types)
 
     dep_map = first_party_dep_map.package_rooted_dependency_map
 

--- a/src/python/pants/backend/java/dependency_inference/rules.py
+++ b/src/python/pants/backend/java/dependency_inference/rules.py
@@ -69,9 +69,12 @@ async def infer_java_dependencies_via_imports(
     if java_infer_subsystem.consumed_types:
         package = analysis.declared_package
 
+        # 13545: `analysis.consumed_types` may be unqualified (package-local or imported) or qualified
+        # (prefixed by package name). Heuristic for now is that if there's a `.` in the type name, it's
+        # probably fully qualified. This is probably fine for now.
         maybe_qualify_types = (
             f"{package}.{consumed_type}" if package and "." not in consumed_type else consumed_type
-            for consumed_type in analysis.consumed_unqualified_types
+            for consumed_type in analysis.consumed_types
         )
 
         types.update(maybe_qualify_types)

--- a/src/python/pants/backend/java/dependency_inference/types.py
+++ b/src/python/pants/backend/java/dependency_inference/types.py
@@ -34,7 +34,7 @@ class JavaSourceDependencyAnalysis:
     declared_package: str | None
     imports: Sequence[JavaImport]
     top_level_types: Sequence[str]
-    consumed_unqualified_types: Sequence[str]
+    consumed_types: Sequence[str]
 
     @classmethod
     def from_json_dict(cls, analysis: dict[str, Any]) -> JavaSourceDependencyAnalysis:
@@ -42,7 +42,7 @@ class JavaSourceDependencyAnalysis:
             declared_package=analysis.get("declaredPackage"),
             imports=tuple(JavaImport.from_json_dict(imp) for imp in analysis["imports"]),
             top_level_types=tuple(analysis["topLevelTypes"]),
-            consumed_unqualified_types=tuple(analysis["consumedUnqualifiedTypes"]),
+            consumed_types=tuple(analysis["consumedTypes"]),
         )
 
     def to_debug_json_dict(self) -> dict[str, Any]:
@@ -50,5 +50,5 @@ class JavaSourceDependencyAnalysis:
             "declared_package": self.declared_package,
             "imports": [imp.to_debug_json_dict() for imp in self.imports],
             "top_level_types": self.top_level_types,
-            "consumed_unqualified_types": self.consumed_unqualified_types,
+            "consumed_types": self.consumed_types,
         }


### PR DESCRIPTION
FQTNs were often correctly extracted to `consumed_unqualified_types`, but then had an incorrect root package appended to it, causing an invalid dependency to get picked up.

This probably closes #13545.