### PR TITLE
Fix caching of binary lookups and avoid re-running `pytest` setup for environment changes

### DIFF
--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -35,7 +35,7 @@ from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.collection import Collection
-from pants.engine.environment import CompleteEnvironment
+from pants.engine.environment import Environment, EnvironmentRequest
 from pants.engine.fs import (
     EMPTY_DIGEST,
     CreateDigest,
@@ -159,7 +159,6 @@ async def setup_pytest_for_target(
     coverage_subsystem: CoverageSubsystem,
     test_extra_env: TestExtraEnv,
     global_options: GlobalOptions,
-    complete_env: CompleteEnvironment,
 ) -> TestSetup:
     transitive_targets, plugin_setups = await MultiGet(
         Get(TransitiveTargets, TransitiveTargetsRequest([request.field_set.address])),
@@ -199,17 +198,23 @@ async def setup_pytest_for_target(
     # to test, rather than using auto-discovery.
     field_set_source_files_get = Get(SourceFiles, SourceFilesRequest([request.field_set.source]))
 
+    field_set_extra_env_get = Get(
+        Environment, EnvironmentRequest(request.field_set.extra_env_vars.value or ())
+    )
+
     (
         pytest_pex,
         requirements_pex,
         prepared_sources,
         field_set_source_files,
+        field_set_extra_env,
         extra_output_directory_digest,
     ) = await MultiGet(
         pytest_pex_get,
         requirements_pex_get,
         prepared_sources_get,
         field_set_source_files_get,
+        field_set_extra_env_get,
         extra_output_directory_digest_get,
     )
 
@@ -289,9 +294,9 @@ async def setup_pytest_for_target(
         "PYTEST_ADDOPTS": " ".join(add_opts),
         "PEX_EXTRA_SYS_PATH": ":".join(prepared_sources.source_roots),
         **test_extra_env.env,
-        # NOTE: `complete_env` intentionally after `test_extra_env` to allow overriding within
-        # `python_tests`
-        **complete_env.get_subset(request.field_set.extra_env_vars.value or ()),
+        # NOTE: field_set_extra_env intentionally after `test_extra_env` to allow overriding within
+        # `python_tests`.
+        **field_set_extra_env,
     }
 
     # Cache test runs only if they are successful, or not at all if `--test-force`.

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -18,7 +18,7 @@ from pants.engine.collection import Collection
 from pants.engine.console import Console
 from pants.engine.desktop import OpenFiles, OpenFilesRequest
 from pants.engine.engine_aware import EngineAwareReturnType
-from pants.engine.environment import CompleteEnvironment
+from pants.engine.environment import Environment, EnvironmentRequest
 from pants.engine.fs import Digest, FileDigest, MergeDigests, Snapshot, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import FallibleProcessResult, InteractiveProcess, InteractiveProcessResult
@@ -35,7 +35,6 @@ from pants.engine.target import (
     Targets,
 )
 from pants.engine.unions import UnionMembership, union
-from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
@@ -474,19 +473,12 @@ async def run_tests(
 
 @dataclass(frozen=True)
 class TestExtraEnv:
-    env: FrozenDict[str, str]
+    env: Environment
 
 
 @rule
-def get_filtered_environment(
-    test_subsystem: TestSubsystem, complete_env: CompleteEnvironment
-) -> TestExtraEnv:
-    env = (
-        complete_env.get_subset(test_subsystem.extra_env_vars)
-        if test_subsystem.extra_env_vars
-        else FrozenDict({})
-    )
-    return TestExtraEnv(env)
+async def get_filtered_environment(test_subsystem: TestSubsystem) -> TestExtraEnv:
+    return TestExtraEnv(await Get(Environment, EnvironmentRequest(test_subsystem.extra_env_vars)))
 
 
 # -------------------------------------------------------------------------------------------

--- a/src/python/pants/engine/environment.py
+++ b/src/python/pants/engine/environment.py
@@ -17,12 +17,21 @@ logger = logging.getLogger(__name__)
 name_value_re = re.compile(r"([A-Za-z_]\w*)=(.*)")
 shorthand_re = re.compile(r"([A-Za-z_]\w*)")
 
+"""
+Accesses to `os.environ` cannot be accurately tracked, so @rules that need access to the
+environment should use APIs from this module instead.
+
+Wherever possible, the `Environment` type should be consumed rather than the
+`CompleteEnvironment`, as it represents a filtered/relevant subset of the environment, rather
+than the entire unfiltered environment.
+"""
+
 
 class CompleteEnvironment(FrozenDict):
     """CompleteEnvironment contains all environment variables from the current Pants process.
 
-    Accesses to `os.environ` cannot be accurately tracked, so @rules that need access to the
-    environment should request this type instead.
+    NB: Consumers should almost always prefer to consume the `Environment` type, which is
+    filtered to a relevant subset of the environment.
     """
 
     def get_subset(

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -604,7 +604,9 @@ async def find_binary(request: BinaryPathRequest) -> BinaryPaths:
                 description=f"Test binary {path}.",
                 level=LogLevel.DEBUG,
                 argv=[path, *request.test.args],
-                cache_scope=ProcessCacheScope.PER_RESTART_SUCCESSFUL,
+                # NB: Since a failure is a valid result for this script, we always cache it for
+                # `pantsd`'s lifetime, regardless of success or failure.
+                cache_scope=ProcessCacheScope.PER_RESTART_ALWAYS,
             ),
         )
         for path in found_paths

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -566,6 +566,11 @@ impl<N: Node> Graph<N> {
   ) -> bool {
     let generation_matches = {
       let inner = self.inner.lock();
+      let entry = if log::log_enabled!(log::Level::Debug) {
+        Some(inner.pg[entry_id].clone())
+      } else {
+        None
+      };
       let dependency_ids = inner
         .pg
         .neighbors_directed(entry_id, Direction::Outgoing)
@@ -581,12 +586,13 @@ impl<N: Node> Graph<N> {
         .into_iter()
         .zip(previous_dep_generations.into_iter())
         .map(|(dep_id, previous_dep_generation)| {
-          let mut entry = inner
+          let entry = entry.clone();
+          let mut dep_entry = inner
             .entry_for_id(dep_id)
             .unwrap_or_else(|| panic!("Dependency not present in Graph."))
             .clone();
           async move {
-            let (_, generation) = entry
+            let (_, generation) = dep_entry
               .get_node_result(context, dep_id)
               .await
               .map_err(|_| ())?;
@@ -595,6 +601,11 @@ impl<N: Node> Graph<N> {
               Ok(())
             } else {
               // Did not match. We error here to trigger fail-fast in `try_join_all`.
+              log::debug!(
+                "Dependency {} of {:?} changed.",
+                dep_entry.node(),
+                entry.map(|e| e.node().to_string())
+              );
               Err(())
             }
           }


### PR DESCRIPTION
Two issues were causing re-runs of `test` to do more work than expected:
1. The `"Test binary $x"` `Process` expects to fail in many cases, but was marked `ProcessCacheScope.PER_RESTART_SUCCESSFUL`, meaning that failures would be re-executed in each run.
    * Switched to `PER_RESTART_ALWAYS`. This should improve performance for all runs, including `test`.
2. `setup_pytest_for_target` was consuming the `CompleteEnvironment` in order to filter it for individual `python_test` targets. This meant that it re-ran for any environment change, rather than only for relevant changed environment variables.
    * Switched to requesting a filtered relevant `Environment` via `EnvironmentRequest`, and improved the docs.

Additionally, add a log message at `DEBUG` level to help with triaging why `@rule`s are re-running.

After these changes, iterating on a single test with `-ldebug` and no filesystem changes shows only expected re-runs of `@rule`s (for `Environment` filtering). Fixes #13551.