### PR TITLE
[internal] Simplify Rust FFI `getattr_from_frozendict()`

### DIFF
--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -140,7 +140,8 @@ pub fn collect_iterable(value: &PyObject) -> Result<Vec<PyObject>, String> {
   }
 }
 
-pub fn getattr_from_frozendict(value: &PyObject, field: &str) -> BTreeMap<String, String> {
+/// Read a `FrozenDict[str, str]`.
+pub fn getattr_from_str_frozendict(value: &PyObject, field: &str) -> BTreeMap<String, String> {
   let frozendict = getattr(value, field).unwrap();
   let pydict: PyDict = getattr(&frozendict, "_data").unwrap();
   let gil = Python::acquire_gil();
@@ -148,7 +149,7 @@ pub fn getattr_from_frozendict(value: &PyObject, field: &str) -> BTreeMap<String
   pydict
     .items(py)
     .into_iter()
-    .map(|(k, v)| (val_to_str(&Value::new(k)), val_to_str(&Value::new(v))))
+    .map(|(k, v)| (k.extract(py).unwrap(), v.extract(py).unwrap()))
     .collect()
 }
 
@@ -162,6 +163,9 @@ pub fn getattr_as_optional_string(py: Python, value: &PyObject, field: &str) -> 
   Some(v.extract(py).unwrap())
 }
 
+/// Call the equivalent of `str()` on an arbitrary Python object.
+///
+/// Converts `None` to the empty string.
 pub fn val_to_str(obj: &PyObject) -> String {
   let gil = Python::acquire_gil();
   let py = gil.python();

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -497,7 +497,7 @@ fn interactive_process(
     let restartable: bool = externs::getattr(&value, "restartable").unwrap();
     let input_digest_value: Value = externs::getattr(&value, "input_digest").unwrap();
     let input_digest: Digest = lift_directory_digest(&input_digest_value)?;
-    let env = externs::getattr_from_frozendict(&value, "env");
+    let env = externs::getattr_from_str_frozendict(&value, "env");
     let session = context.session;
 
     if !restartable {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -294,7 +294,7 @@ impl MultiPlatformExecuteProcess {
   fn lift_process(value: &Value, platform_constraint: Option<Platform>) -> Result<Process, String> {
     let gil = Python::acquire_gil();
     let py = gil.python();
-    let env = externs::getattr_from_frozendict(value, "env");
+    let env = externs::getattr_from_str_frozendict(value, "env");
     let working_directory =
       match externs::getattr_as_optional_string(py, value, "working_directory") {
         None => None,
@@ -329,7 +329,7 @@ impl MultiPlatformExecuteProcess {
     let py_level: PyObject = externs::getattr(value, "level").unwrap();
     let level = externs::val_to_log_level(&py_level)?;
 
-    let append_only_caches = externs::getattr_from_frozendict(value, "append_only_caches")
+    let append_only_caches = externs::getattr_from_str_frozendict(value, "append_only_caches")
       .into_iter()
       .map(|(name, dest)| Ok((CacheName::new(name)?, CacheDest::new(dest)?)))
       .collect::<Result<_, String>>()?;


### PR DESCRIPTION
All three of all our callsites were `FrozenDict[str, str]`. There was no need to call `val_to_str`, which required wrapping in `Value` (creating an `Arc`).