### PR TITLE
Do not invalidate parent paths when only file content has changed

### DIFF
--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -277,10 +277,7 @@ class Scheduler:
             self.py_scheduler, root_subject_types, product_type
         )
 
-    def invalidate_files(self, direct_filenames: Iterable[str]) -> int:
-        filenames = set(direct_filenames)
-        # TODO(#11707): Evaluate removing the invalidation of parent directories.
-        filenames.update(os.path.dirname(f) for f in direct_filenames)
+    def invalidate_files(self, filenames: Iterable[str]) -> int:
         return native_engine.graph_invalidate_paths(self.py_scheduler, tuple(filenames))
 
     def invalidate_all_files(self) -> int:


### PR DESCRIPTION
We have avoided fine grained interaction with the `notify` crate so far, but now that we've seen that `notify` is reliable, we can slowly introduce more logic around event types.

This change skips invalidating the parent of a path when the event type is file-data-only (`Modify(Data(Content))`). As mentioned in #11707 though, it's not as effective as we might have hoped, since editors tend to write to temp files and then rename them. It might still have a positive impact in some cases, and seems like a relatively safe first step.

Fixes #11707.