### PR TITLE
[internal] scala: initial dependency inference support (via explicit imports)

### DIFF
--- a/src/python/pants/backend/experimental/scala/register.py
+++ b/src/python/pants/backend/experimental/scala/register.py
@@ -9,7 +9,8 @@ from pants.backend.java.target_types import (  # TODO: All of these should move 
 )
 from pants.backend.java.test import junit  # TODO: Should move to the JVM package.
 from pants.backend.scala.compile import scalac
-from pants.backend.scala.dependency_inference import scala_parser
+from pants.backend.scala.dependency_inference import rules as dep_inf_rules
+from pants.backend.scala.dependency_inference import scala_parser, symbol_mapper
 from pants.backend.scala.goals import check, tailor
 from pants.backend.scala.target_types import ScalaSourcesGeneratorTarget, ScalaSourceTarget
 from pants.backend.scala.target_types import rules as target_types_rules
@@ -46,5 +47,7 @@ def rules():
         *jvm_util_rules.rules(),
         *jdk_rules.rules(),
         *scala_parser.rules(),
+        *symbol_mapper.rules(),
+        *dep_inf_rules.rules(),
         *target_types_rules(),
     ]

--- a/src/python/pants/backend/experimental/scala/register.py
+++ b/src/python/pants/backend/experimental/scala/register.py
@@ -10,7 +10,6 @@ from pants.backend.java.target_types import (  # TODO: All of these should move 
 from pants.backend.java.test import junit  # TODO: Should move to the JVM package.
 from pants.backend.scala.compile import scalac
 from pants.backend.scala.dependency_inference import rules as dep_inf_rules
-from pants.backend.scala.dependency_inference import scala_parser, symbol_mapper
 from pants.backend.scala.goals import check, tailor
 from pants.backend.scala.target_types import ScalaSourcesGeneratorTarget, ScalaSourceTarget
 from pants.backend.scala.target_types import rules as target_types_rules
@@ -46,8 +45,6 @@ def rules():
         *coursier_setup.rules(),
         *jvm_util_rules.rules(),
         *jdk_rules.rules(),
-        *scala_parser.rules(),
-        *symbol_mapper.rules(),
         *dep_inf_rules.rules(),
         *target_types_rules(),
     ]

--- a/src/python/pants/backend/scala/dependency_inference/rules.py
+++ b/src/python/pants/backend/scala/dependency_inference/rules.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 
+from pants.backend.scala.dependency_inference import scala_parser, symbol_mapper
 from pants.backend.scala.dependency_inference.scala_parser import ScalaSourceDependencyAnalysis
 from pants.backend.scala.dependency_inference.symbol_mapper import FirstPartyScalaSymbolMapping
 from pants.backend.scala.subsystems.scala_infer import ScalaInferSubsystem
@@ -70,4 +71,8 @@ async def infer_scala_dependencies_via_source_analysis(
 
 
 def rules():
-    return collect_rules()
+    return [
+        *collect_rules(),
+        *scala_parser.rules(),
+        *symbol_mapper.rules(),
+    ]

--- a/src/python/pants/backend/scala/dependency_inference/rules.py
+++ b/src/python/pants/backend/scala/dependency_inference/rules.py
@@ -1,0 +1,73 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+import logging
+
+from pants.backend.scala.dependency_inference.scala_parser import ScalaSourceDependencyAnalysis
+from pants.backend.scala.dependency_inference.symbol_mapper import FirstPartyScalaSymbolMapping
+from pants.backend.scala.subsystems.scala_infer import ScalaInferSubsystem
+from pants.backend.scala.target_types import ScalaSourceField
+from pants.build_graph.address import Address
+from pants.core.util_rules.source_files import SourceFilesRequest
+from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.rules import collect_rules, rule
+from pants.engine.target import (
+    Dependencies,
+    DependenciesRequest,
+    ExplicitlyProvidedDependencies,
+    InferDependenciesRequest,
+    InferredDependencies,
+    WrappedTarget,
+)
+from pants.util.ordered_set import OrderedSet
+
+logger = logging.getLogger(__name__)
+
+
+class InferScalaSourceDependencies(InferDependenciesRequest):
+    infer_from = ScalaSourceField
+
+
+@rule(desc="Inferring Scala dependencies by analyzing sources")
+async def infer_scala_dependencies_via_source_analysis(
+    request: InferScalaSourceDependencies,
+    scala_infer_subsystem: ScalaInferSubsystem,
+    first_party_symbol_map: FirstPartyScalaSymbolMapping,
+) -> InferredDependencies:
+    if not scala_infer_subsystem.imports:
+        return InferredDependencies([])
+
+    address = request.sources_field.address
+    wrapped_tgt = await Get(WrappedTarget, Address, address)
+    explicitly_provided_deps, analysis = await MultiGet(
+        Get(ExplicitlyProvidedDependencies, DependenciesRequest(wrapped_tgt.target[Dependencies])),
+        Get(ScalaSourceDependencyAnalysis, SourceFilesRequest([request.sources_field])),
+    )
+
+    symbols: OrderedSet[str] = OrderedSet()
+    if scala_infer_subsystem.imports:
+        symbols.update(analysis.all_imports())
+
+    dependencies: OrderedSet[Address] = OrderedSet()
+    for symbol in symbols:
+        matches = first_party_symbol_map.symbols.addresses_for_symbol(symbol)
+        if not matches:
+            continue
+
+        explicitly_provided_deps.maybe_warn_of_ambiguous_dependency_inference(
+            matches,
+            address,
+            import_reference="type",
+            context=f"The target {address} imports `{symbol}`",
+        )
+
+        maybe_disambiguated = explicitly_provided_deps.disambiguated(matches)
+        if maybe_disambiguated:
+            dependencies.add(maybe_disambiguated)
+
+    return InferredDependencies(dependencies)
+
+
+def rules():
+    return collect_rules()

--- a/src/python/pants/backend/scala/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/rules_test.py
@@ -1,0 +1,216 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+from textwrap import dedent
+
+import pytest
+
+from pants.backend.scala.dependency_inference import scala_parser, symbol_mapper
+from pants.backend.scala.dependency_inference.rules import InferScalaSourceDependencies
+from pants.backend.scala.dependency_inference.rules import rules as dep_inference_rules
+from pants.backend.scala.target_types import ScalaSourceField, ScalaSourcesGeneratorTarget
+from pants.backend.scala.target_types import rules as scala_target_rules
+from pants.core.util_rules import config_files, source_files
+from pants.core.util_rules.external_tool import rules as external_tool_rules
+from pants.engine.addresses import Address, Addresses, UnparsedAddressInputs
+from pants.engine.target import (
+    DependenciesRequest,
+    ExplicitlyProvidedDependencies,
+    InferredDependencies,
+    Targets,
+)
+from pants.jvm.jdk_rules import rules as jdk_rules
+from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
+from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
+from pants.jvm.testutil import maybe_skip_jdk_test
+from pants.jvm.util_rules import rules as util_rules
+from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
+
+NAMED_RESOLVE_OPTIONS = '--jvm-resolves={"test": "coursier_resolve.lockfile"}'
+DEFAULT_RESOLVE_OPTION = "--jvm-default-resolve=test"
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = RuleRunner(
+        rules=[
+            *config_files.rules(),
+            *coursier_fetch_rules(),
+            *coursier_setup_rules(),
+            *dep_inference_rules(),
+            *external_tool_rules(),
+            *scala_parser.rules(),
+            *symbol_mapper.rules(),
+            *scala_target_rules(),
+            *source_files.rules(),
+            *util_rules(),
+            *jdk_rules(),
+            QueryRule(Addresses, [DependenciesRequest]),
+            QueryRule(ExplicitlyProvidedDependencies, [DependenciesRequest]),
+            QueryRule(InferredDependencies, [InferScalaSourceDependencies]),
+            QueryRule(Targets, [UnparsedAddressInputs]),
+        ],
+        target_types=[ScalaSourcesGeneratorTarget],
+    )
+    rule_runner.set_options(
+        args=[NAMED_RESOLVE_OPTIONS, DEFAULT_RESOLVE_OPTION], env_inherit=PYTHON_BOOTSTRAP_ENV
+    )
+    return rule_runner
+
+
+@maybe_skip_jdk_test
+def test_infer_scala_imports_same_target(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                """\
+                scala_sources(
+                    name = 't',
+
+                )
+                """
+            ),
+            "A.scala": dedent(
+                """\
+                package org.pantsbuild.a
+
+                object A {}
+                """
+            ),
+            "B.scala": dedent(
+                """\
+                package org.pantsbuild.b
+
+                object B {}
+                """
+            ),
+        }
+    )
+
+    target_a = rule_runner.get_target(Address("", target_name="t", relative_file_path="A.scala"))
+    target_b = rule_runner.get_target(Address("", target_name="t", relative_file_path="B.scala"))
+
+    assert (
+        rule_runner.request(
+            InferredDependencies,
+            [InferScalaSourceDependencies(target_a[ScalaSourceField])],
+        )
+        == InferredDependencies(dependencies=[])
+    )
+
+    assert (
+        rule_runner.request(
+            InferredDependencies,
+            [InferScalaSourceDependencies(target_b[ScalaSourceField])],
+        )
+        == InferredDependencies(dependencies=[])
+    )
+
+
+@maybe_skip_jdk_test
+def test_infer_scala_imports_with_cycle(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                """\
+                scala_sources(
+                    name = 'a',
+                )
+                """
+            ),
+            "A.scala": dedent(
+                """\
+                package org.pantsbuild.a
+
+                import org.pantsbuild.b.B
+
+                class A {}
+                """
+            ),
+            "sub/BUILD": dedent(
+                """\
+                scala_sources(
+                    name = 'b',
+                )
+                """
+            ),
+            "sub/B.scala": dedent(
+                """\
+                package org.pantsbuild.b
+
+                import org.pantsbuild.a.A
+
+                class B {}
+                """
+            ),
+        }
+    )
+
+    target_a = rule_runner.get_target(Address("", target_name="a", relative_file_path="A.scala"))
+    target_b = rule_runner.get_target(Address("sub", target_name="b", relative_file_path="B.scala"))
+
+    assert rule_runner.request(
+        InferredDependencies, [InferScalaSourceDependencies(target_a[ScalaSourceField])]
+    ) == InferredDependencies(dependencies=[target_b.address])
+
+    assert rule_runner.request(
+        InferredDependencies, [InferScalaSourceDependencies(target_b[ScalaSourceField])]
+    ) == InferredDependencies(dependencies=[target_a.address])
+
+
+@maybe_skip_jdk_test
+def test_infer_java_imports_ambiguous(rule_runner: RuleRunner, caplog) -> None:
+    ambiguous_source = dedent(
+        """\
+                package org.pantsbuild.a
+                class A {}
+                """
+    )
+    rule_runner.write_files(
+        {
+            "a_one/BUILD": "scala_sources()",
+            "a_one/A.scala": ambiguous_source,
+            "a_two/BUILD": "scala_sources()",
+            "a_two/A.scala": ambiguous_source,
+            "b/BUILD": "scala_sources()",
+            "b/B.scala": dedent(
+                """\
+                package org.pantsbuild.b
+                import org.pantsbuild.a.A
+                class B {}
+                """
+            ),
+            "c/BUILD": dedent(
+                """\
+                scala_sources(
+                  dependencies=["!a_two/A.scala"],
+                )
+                """
+            ),
+            "c/C.scala": dedent(
+                """\
+                package org.pantsbuild.c
+                import org.pantsbuild.a.A
+                class C {}
+                """
+            ),
+        }
+    )
+    target_b = rule_runner.get_target(Address("b", relative_file_path="B.scala"))
+    target_c = rule_runner.get_target(Address("c", relative_file_path="C.scala"))
+
+    # Because there are two sources of `org.pantsbuild.a.A`, neither should be inferred for B. But C
+    # disambiguates with a `!`, and so gets the appropriate version.
+    caplog.clear()
+    assert rule_runner.request(
+        InferredDependencies, [InferScalaSourceDependencies(target_b[ScalaSourceField])]
+    ) == InferredDependencies(dependencies=[])
+    assert len(caplog.records) == 1
+    assert (
+        "The target b/B.scala imports `org.pantsbuild.a.A`, but Pants cannot safely" in caplog.text
+    )
+
+    assert rule_runner.request(
+        InferredDependencies, [InferScalaSourceDependencies(target_c[ScalaSourceField])]
+    ) == InferredDependencies(dependencies=[Address("a_one", relative_file_path="A.scala")])

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -7,7 +7,7 @@ import logging
 import os
 import pkgutil
 from dataclasses import dataclass
-from typing import Any, Mapping
+from typing import Any, Mapping, Set
 
 from pants.core.util_rules.source_files import SourceFiles
 from pants.engine.fs import (
@@ -113,6 +113,13 @@ class ScalaImport:
 class ScalaSourceDependencyAnalysis:
     provided_names: FrozenOrderedSet[str]
     imports_by_scope: FrozenDict[str, tuple[ScalaImport, ...]]
+
+    def all_imports(self) -> frozenset[str]:
+        all_symbols: Set[str] = set()
+        for imports in self.imports_by_scope.values():
+            for imp in imports:
+                all_symbols.add(imp.name)
+        return frozenset(all_symbols)
 
     @classmethod
     def from_json_dict(cls, d: dict) -> ScalaSourceDependencyAnalysis:

--- a/src/python/pants/backend/scala/dependency_inference/symbol_mapper.py
+++ b/src/python/pants/backend/scala/dependency_inference/symbol_mapper.py
@@ -1,0 +1,93 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+
+from pants.backend.scala.dependency_inference.scala_parser import ScalaSourceDependencyAnalysis
+from pants.backend.scala.target_types import ScalaSourceField
+from pants.build_graph.address import Address
+from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.rules import collect_rules, rule
+from pants.engine.target import AllTargets, Targets
+from pants.util.logging import LogLevel
+
+
+class SymbolMap:
+    def __init__(self):
+        self._symbol_map: dict[str, set[Address]] = defaultdict(set)
+
+    def add_symbol(self, symbol: str, address: Address):
+        """Declare a single Address as a provider of a symbol."""
+        self._symbol_map[symbol].add(address)
+
+    def addresses_for_symbol(self, symbol: str) -> frozenset[Address]:
+        """Returns the set of addresses that provide the passed symbol.
+
+        :param symbol: a fully-qualified Scala symbol (e.g. `foo.bar.Thing`).
+        """
+        return frozenset(self._symbol_map[symbol])
+
+    def merge(self, other: SymbolMap) -> None:
+        """Merge 'other' into this dependency map."""
+        for symbol, addresses in other._symbol_map.items():
+            self._symbol_map[symbol] |= addresses
+
+    def to_json_dict(self):
+        return {
+            "symbol_map": {
+                sym: [str(addr) for addr in addrs] for sym, addrs in self._symbol_map.items()
+            },
+        }
+
+    def __repr__(self) -> str:
+        symbol_map = ", ".join(
+            f"{ty}:{', '.join(str(addr) for addr in addrs)}"
+            for ty, addrs in self._symbol_map.items()
+        )
+        return f"SymbolMap(symbol_map={symbol_map})"
+
+
+@dataclass(frozen=True)
+class FirstPartyScalaSymbolMapping:
+    """A merged mapping of symbol names to owning addresses for Scala code."""
+
+    symbols: SymbolMap
+
+
+# TODO: add third-party targets here? That would allow us to avoid iterating over AllTargets twice.
+#  See `backend/python/dependency_inference/module_mapper.py` for an example.
+class AllScalaTargets(Targets):
+    pass
+
+
+@rule(desc="Find all Scala targets in project", level=LogLevel.DEBUG)
+def find_all_java_targets(targets: AllTargets) -> AllScalaTargets:
+    return AllScalaTargets(tgt for tgt in targets if tgt.has_field(ScalaSourceField))
+
+
+@rule(desc="Map all first party Scala targets to their symbols", level=LogLevel.DEBUG)
+async def map_first_party_scala_targets_to_symbols(
+    scala_targets: AllScalaTargets,
+) -> FirstPartyScalaSymbolMapping:
+    source_files = await MultiGet(
+        Get(SourceFiles, SourceFilesRequest([target[ScalaSourceField]])) for target in scala_targets
+    )
+    source_analysis = await MultiGet(
+        Get(ScalaSourceDependencyAnalysis, SourceFiles, source_files)
+        for source_files in source_files
+    )
+    address_and_analysis = zip([t.address for t in scala_targets], source_analysis)
+
+    symbol_map = SymbolMap()
+    for address, analysis in address_and_analysis:
+        for symbol in analysis.provided_names:
+            symbol_map.add_symbol(symbol, address)
+
+    return FirstPartyScalaSymbolMapping(symbol_map)
+
+
+def rules():
+    return collect_rules()

--- a/src/python/pants/backend/scala/subsystems/BUILD
+++ b/src/python/pants/backend/scala/subsystems/BUILD
@@ -1,0 +1,4 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_sources()

--- a/src/python/pants/backend/scala/subsystems/scala_infer.py
+++ b/src/python/pants/backend/scala/subsystems/scala_infer.py
@@ -1,0 +1,24 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from typing import cast
+
+from pants.option.subsystem import Subsystem
+
+
+class ScalaInferSubsystem(Subsystem):
+    options_scope = "scala-infer"
+    help = "Options controlling which dependencies will be inferred for Scala targets."
+
+    @classmethod
+    def register_options(cls, register):
+        super().register_options(register)
+        register(
+            "--imports",
+            default=True,
+            type=bool,
+            help="Infer a target's dependencies by parsing import statements from sources.",
+        )
+
+    @property
+    def imports(self) -> bool:
+        return cast(bool, self.options.imports)


### PR DESCRIPTION
Add initial support for dependency inference of Scala sources using explicit imports. This support is based somewhat on the Java dependency inference but without the indirection through a union in gathering dependencies (which didn't seem necessary yet).

Consumed types inference and third party artifact inference will come in subsequent PRs.

[ci skip-rust]