### PR TITLE
[jvm] UX improvements for compilation and thirdparty dependency lookups

### DIFF
--- a/src/python/pants/backend/java/dependency_inference/java_parser.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser.py
@@ -124,7 +124,7 @@ async def analyze_java_source_dependencies(
             use_nailgun=tool_digest,
             append_only_caches=jdk_setup.append_only_caches,
             env=jdk_setup.env,
-            description="Run Spoon analysis against Java source",
+            description=f"Analyzing {source_files.files[0]}",
             level=LogLevel.DEBUG,
         ),
     )

--- a/src/python/pants/jvm/resolve/coursier_fetch_filter_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_filter_test.py
@@ -8,12 +8,14 @@ from unittest import mock
 
 import pytest
 
+from pants.engine.fs import EMPTY_DIGEST
 from pants.jvm.resolve.coursier_fetch import (
     Coordinate,
     Coordinates,
     CoursierLockfileEntry,
     CoursierResolvedLockfile,
 )
+from pants.jvm.resolve.key import CoursierResolveKey
 
 coord1 = Coordinate("test", "art1", "1.0.0")
 coord2 = Coordinate("test", "art2", "1.0.0")
@@ -85,8 +87,9 @@ def test_filter_transitive_includes_transitive_deps(lockfile: CoursierResolvedLo
 
 
 def filter(coordinate, lockfile, transitive) -> Sequence[Coordinate]:
+    key = CoursierResolveKey("example", "example.json", EMPTY_DIGEST)
     if transitive:
-        root, deps = lockfile.dependencies(coordinate)
+        root, deps = lockfile.dependencies(key, coordinate)
     else:
-        root, deps = lockfile.direct_dependencies(coordinate)
+        root, deps = lockfile.direct_dependencies(key, coordinate)
     return list(i.coord for i in (root, *deps))

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -10,7 +10,7 @@ use nails::execution::{self, child_channel, ChildInput, Command};
 use store::Store;
 use task_executor::Executor;
 use tokio::net::TcpStream;
-use workunit_store::RunningWorkunit;
+use workunit_store::{in_workunit, Metric, RunningWorkunit, WorkunitMetadata};
 
 use crate::local::{CapturedWorkdir, ChildOutput};
 use crate::{
@@ -130,44 +130,60 @@ impl super::CommandRunner for CommandRunner {
       trace!("The request is not nailgunnable! Short-circuiting to regular process execution");
       return self.inner.run(context, workunit, req).await;
     }
-    debug!("Running request under nailgun:\n {:#?}", &original_request);
+    debug!("Running request under nailgun:\n {:?}", &original_request);
 
-    // Separate argument lists, to form distinct EPRs for (1) starting the nailgun server and (2) running the client in it.
-    let ParsedJVMCommandLines {
-      nailgun_args,
-      client_main_class,
-      ..
-    } = ParsedJVMCommandLines::parse_command_lines(&original_request.argv)?;
-    let nailgun_name = CommandRunner::calculate_nailgun_name(&client_main_class);
+    in_workunit!(
+      context.workunit_store.clone(),
+      "run_nailgun_process".to_owned(),
+      WorkunitMetadata {
+        // NB: See engine::nodes::NodeKey::workunit_level for more information on why this workunit
+        // renders at the Process's level.
+        level: original_request.level,
+        desc: Some(original_request.description.clone()),
+        ..WorkunitMetadata::default()
+      },
+      |workunit| async move {
+        workunit.increment_counter(Metric::LocalExecutionRequests, 1);
 
-    let nailgun_req =
-      construct_nailgun_server_request(&nailgun_name, nailgun_args, original_request.clone());
-    trace!("Extracted nailgun request:\n {:#?}", &nailgun_req);
+        // Separate argument lists, to form distinct EPRs for (1) starting the nailgun server and (2) running the client in it.
+        let ParsedJVMCommandLines {
+          nailgun_args,
+          client_main_class,
+          ..
+        } = ParsedJVMCommandLines::parse_command_lines(&original_request.argv)?;
+        let nailgun_name = CommandRunner::calculate_nailgun_name(&client_main_class);
 
-    // Get an instance of a nailgun server for this fingerprint, and then run in its directory.
-    let mut nailgun_process = self
-      .nailgun_pool
-      .acquire(nailgun_req, context.clone())
-      .await
-      .map_err(|e| format!("Failed to connect to nailgun! {}", e))?;
+        let nailgun_req =
+          construct_nailgun_server_request(&nailgun_name, nailgun_args, original_request.clone());
+        trace!("Running request under nailgun:\n {:#?}", &nailgun_req);
 
-    let res = self
-      .run_and_capture_workdir(
-        original_request,
-        context,
-        self.inner.store.clone(),
-        self.executor.clone(),
-        nailgun_process.workdir_path().to_owned(),
-        (nailgun_process.name().to_owned(), nailgun_process.address()),
-        Platform::current().unwrap(),
-      )
-      .await;
+        // Get an instance of a nailgun server for this fingerprint, and then run in its directory.
+        let mut nailgun_process = self
+          .nailgun_pool
+          .acquire(nailgun_req, context.clone())
+          .await
+          .map_err(|e| format!("Failed to connect to nailgun! {}", e))?;
 
-    // NB: We explicitly release the BorrowedNailgunProcess, because when it is Dropped without
-    // release, it assumes that it has been canceled and kills the server.
-    nailgun_process.release().await?;
+        let res = self
+          .run_and_capture_workdir(
+            original_request,
+            context,
+            self.inner.store.clone(),
+            self.executor.clone(),
+            nailgun_process.workdir_path().to_owned(),
+            (nailgun_process.name().to_owned(), nailgun_process.address()),
+            Platform::current().unwrap(),
+          )
+          .await;
 
-    res
+        // NB: We explicitly release the BorrowedNailgunProcess, because when it is Dropped without
+        // release, it assumes that it has been canceled and kills the server.
+        nailgun_process.release().await?;
+
+        res
+      }
+    )
+    .await
   }
 
   fn extract_compatible_request(&self, req: &MultiPlatformProcess) -> Option<Process> {


### PR DESCRIPTION
Nailgun processes were not wrapped in a workunit, which resulted in their entire runtime being blamed to the `Scheduling: $description` process wrapper workunit. Add a workunit, and additionally improve the process description for Java analysis.

Additionally, improve the error when the coordinate from a `jvm_artifact` is not present in a lockfile, by suggesting updating the lockfile.

Fixes #13364.