### PR TITLE
Fix `tailor` confusion with macros vs. targets (Cherry-pick of #13574)

### DIFF
--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -321,7 +321,8 @@ class TailorSubsystem(GoalSubsystem):
                 "combine the BUILD file path with the target's name. For example, if `tailor` "
                 "would add the target `bin` to `project/BUILD`, then the address would be "
                 "`project:bin`. If the BUILD file is at the root of your repository, use `//` for "
-                "the path, e.g. `//:bin`."
+                "the path, e.g. `//:bin`.\n\n"
+                "Does not work with macros."
             ),
         )
 
@@ -646,7 +647,11 @@ async def tailor(
     )
     for build_file_path, ptgts in ptgts_by_build_file.items():
         formatted_changes = "\n".join(
-            f"  - Add {console.green(ptgt.type_alias)} target {console.cyan(ptgt.name)}"
+            (
+                f"  - Add {console.green(ptgt.type_alias)} target {console.cyan(ptgt.name)}"
+                if ptgt.addressable
+                else f"  - Add macro {console.green(ptgt.type_alias)}"
+            )
             for ptgt in ptgts
         )
         if build_file_path in updated_build_files:


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/13572. We were incorrectly suggesting that `python_requirements` is a target, when really it is our old style of macros that does not have an address. (This problem also applies if you were to hook up `tailor` to our new [macros](https://www.pantsbuild.org/v2.8/docs/macros) feature)

This fixes the confusing UX. It does not update `[tailor].ignore_adding_targets` to try to handle macros because there is not a safe way to do so, given that macros are address-less. Instead, there are two workarounds identified in #13572

[ci skip-rust]
[ci skip-build-wheels]