### PR TITLE
[internal] add append_only_caches to InteractiveProcess

### DIFF
--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -312,6 +312,7 @@ class InteractiveProcess(SideEffecting):
     run_in_workspace: bool
     forward_signals_to_process: bool
     restartable: bool
+    append_only_caches: FrozenDict[str, str]
 
     def __init__(
         self,
@@ -322,6 +323,7 @@ class InteractiveProcess(SideEffecting):
         run_in_workspace: bool = False,
         forward_signals_to_process: bool = True,
         restartable: bool = False,
+        append_only_caches: Mapping[str, str] | None = None,
     ) -> None:
         """Request to run a subprocess in the foreground, similar to subprocess.run().
 
@@ -340,14 +342,21 @@ class InteractiveProcess(SideEffecting):
         self.run_in_workspace = run_in_workspace
         self.forward_signals_to_process = forward_signals_to_process
         self.restartable = restartable
+        self.append_only_caches = FrozenDict(append_only_caches or {})
 
         self.__post_init__()
 
     def __post_init__(self):
         if self.input_digest != EMPTY_DIGEST and self.run_in_workspace:
             raise ValueError(
-                "InteractiveProcessRequest should use the Workspace API to materialize any needed "
+                "InteractiveProcess should use the Workspace API to materialize any needed "
                 "files when it runs in the workspace"
+            )
+        if self.append_only_caches and self.run_in_workspace:
+            raise ValueError(
+                "InteractiveProcess requested setup of append-only caches and also requested to run in "
+                "the workspace. These options are incompatible since setting up append-only caches would "
+                "modify the workspace."
             )
 
     @classmethod
@@ -364,6 +373,7 @@ class InteractiveProcess(SideEffecting):
             input_digest=process.input_digest,
             forward_signals_to_process=forward_signals_to_process,
             restartable=restartable,
+            append_only_caches=process.append_only_caches,
         )
 
 

--- a/src/python/pants/engine/process_test.py
+++ b/src/python/pants/engine/process_test.py
@@ -261,6 +261,11 @@ def test_interactive_process_cannot_have_input_files_and_workspace() -> None:
         InteractiveProcess(argv=["/bin/echo"], input_digest=mock_digest, run_in_workspace=True)
 
 
+def test_interactive_process_cannot_have_append_only_caches_and_workspace() -> None:
+    with pytest.raises(ValueError):
+        InteractiveProcess(argv=["/bin/echo"], append_only_caches={"foo": "bar"}, run_in_workspace=True)
+
+
 def test_find_binary_non_existent(rule_runner: RuleRunner, tmp_path: Path) -> None:
     binary_paths = rule_runner.request(
         BinaryPaths, [BinaryPathRequest(binary_name="nonexistent-bin", search_path=[str(tmp_path)])]

--- a/src/python/pants/engine/process_test.py
+++ b/src/python/pants/engine/process_test.py
@@ -263,7 +263,9 @@ def test_interactive_process_cannot_have_input_files_and_workspace() -> None:
 
 def test_interactive_process_cannot_have_append_only_caches_and_workspace() -> None:
     with pytest.raises(ValueError):
-        InteractiveProcess(argv=["/bin/echo"], append_only_caches={"foo": "bar"}, run_in_workspace=True)
+        InteractiveProcess(
+            argv=["/bin/echo"], append_only_caches={"foo": "bar"}, run_in_workspace=True
+        )
 
 
 def test_find_binary_non_existent(rule_runner: RuleRunner, tmp_path: Path) -> None:

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -67,6 +67,7 @@ pub struct Core {
   pub build_root: PathBuf,
   pub local_parallelism: usize,
   pub sessions: Sessions,
+  pub named_caches_dir: PathBuf,
 }
 
 #[derive(Clone, Debug)]
@@ -476,6 +477,7 @@ impl Core {
       watcher,
       local_parallelism: exec_strategy_opts.local_parallelism,
       sessions,
+      named_caches_dir,
     })
   }
 

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -600,7 +600,7 @@ fn interactive_process(
         })?;
 
         let dst = destination.join(&named_cache_symlink.dst);
-        if let Some(dir) = named_cache_symlink.dst.parent() {
+        if let Some(dir) = dst.parent() {
           safe_create_dir_all_ioerror(dir).map_err(|err| {
             format!(
               "Error making {} for local execution: {:?}", dir.display(), err

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -598,7 +598,15 @@ fn interactive_process(
             err
           )
         })?;
+
         let dst = destination.join(&named_cache_symlink.dst);
+        if let Some(dir) = named_cache_symlink.dst.parent() {
+          safe_create_dir_all_ioerror(dir).map_err(|err| {
+            format!(
+              "Error making {} for local execution: {:?}", dir.display(), err
+            )
+          })?;
+        }
         symlink(&named_cache_symlink.src, &dst).map_err(|err| {
           format!(
             "Error linking {} -> {} for local execution: {:?}",


### PR DESCRIPTION
Add `append_only_caches` attribute to `InteractiveProcess` to set up named caches within interactive processes (when not run within the workspace). 

Needed for Scala repl support. https://github.com/pantsbuild/pants/pull/13576