### PR TITLE
[internal] Switch Rust `throw()` to use `String`

### DIFF
--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -732,9 +732,10 @@ fn py_result_from_root(py: Python, result: Result<Value, Failure>) -> CPyResult<
       let (val, python_traceback, engine_traceback) = match f {
         f @ Failure::Invalidated => {
           let msg = format!("{}", f);
+          let python_traceback = Failure::native_traceback(&msg);
           (
-            externs::create_exception(py, &msg),
-            Failure::native_traceback(&msg),
+            externs::create_exception(py, msg),
+            python_traceback,
             Vec::new(),
           )
         }

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -198,7 +198,7 @@ pub fn doc_url(py: Python, slug: &str) -> String {
     .unwrap()
 }
 
-pub fn create_exception(py: Python, msg: &str) -> Value {
+pub fn create_exception(py: Python, msg: String) -> Value {
   Value::from(PyErr::new::<cpython::exc::Exception, _>(py, msg).instance(py))
 }
 

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -448,15 +448,16 @@ impl fmt::Display for Failure {
 
 impl From<String> for Failure {
   fn from(err: String) -> Self {
-    throw(&err)
+    throw(err)
   }
 }
 
-pub fn throw(msg: &str) -> Failure {
+pub fn throw(msg: String) -> Failure {
   let gil = Python::acquire_gil();
+  let python_traceback = Failure::native_traceback(&msg);
   Failure::Throw {
     val: externs::create_exception(gil.python(), msg),
-    python_traceback: Failure::native_traceback(msg),
+    python_traceback,
     engine_traceback: Vec::new(),
   }
 }


### PR DESCRIPTION
Prework for https://github.com/pantsbuild/pants/pull/13526. We won't be able to use `&str` here:

```rust
pub fn create_exception(py: Python, msg: &str) -> Value {
  Value::from(PyErr::new_err(msg).into_py(py))
}
```

The `&str` has a lifetime that conflicted with being stored in the `Value`. Using `String` fixes it. 

Turns out, there was almost no benefit to use `&str` in the first place because the vast majority of our call sites were converting `String` into` &str`. Thus, this PR has an unintended benefit of reducing boilerplate.

[ci skip-build-wheels]