### PR TITLE
[internal] repl: add append_only_caches / run_in_workspace attributes to ReplRequest

### DIFF
--- a/src/python/pants/backend/python/goals/repl.py
+++ b/src/python/pants/backend/python/goals/repl.py
@@ -71,7 +71,7 @@ async def create_python_repl_request(repl: PythonRepl, pex_env: PexEnvironment) 
         "PEX_PATH": repl.in_chroot(local_dists.pex.name),
     }
 
-    return ReplRequest(digest=merged_digest, args=args, extra_env=extra_env)
+    return ReplRequest(digest=merged_digest, args=args, extra_env=extra_env, run_in_workspace=False)
 
 
 class IPythonRepl(ReplImplementation):
@@ -148,7 +148,7 @@ async def create_ipython_repl_request(
         "PEX_EXTRA_SYS_PATH": os.pathsep.join(chrooted_source_roots),
     }
 
-    return ReplRequest(digest=merged_digest, args=args, extra_env=extra_env)
+    return ReplRequest(digest=merged_digest, args=args, extra_env=extra_env, run_in_workspace=False)
 
 
 def rules():

--- a/src/python/pants/backend/python/goals/repl.py
+++ b/src/python/pants/backend/python/goals/repl.py
@@ -71,7 +71,7 @@ async def create_python_repl_request(repl: PythonRepl, pex_env: PexEnvironment) 
         "PEX_PATH": repl.in_chroot(local_dists.pex.name),
     }
 
-    return ReplRequest(digest=merged_digest, args=args, extra_env=extra_env, run_in_workspace=False)
+    return ReplRequest(digest=merged_digest, args=args, extra_env=extra_env)
 
 
 class IPythonRepl(ReplImplementation):
@@ -148,7 +148,7 @@ async def create_ipython_repl_request(
         "PEX_EXTRA_SYS_PATH": os.pathsep.join(chrooted_source_roots),
     }
 
-    return ReplRequest(digest=merged_digest, args=args, extra_env=extra_env, run_in_workspace=False)
+    return ReplRequest(digest=merged_digest, args=args, extra_env=extra_env)
 
 
 def rules():

--- a/src/python/pants/core/goals/repl_test.py
+++ b/src/python/pants/core/goals/repl_test.py
@@ -18,7 +18,11 @@ class MockRepl(ReplImplementation):
 @rule
 async def create_mock_repl_request(repl: MockRepl) -> ReplRequest:
     digest = await Get(Digest, CreateDigest([FileContent("repl.sh", b"exit 0")]))
-    return ReplRequest(digest=digest, args=("/bin/bash", repl.in_chroot("repl.sh")))
+    return ReplRequest(
+        digest=digest,
+        args=("/bin/bash", "repl.sh"),
+        run_in_workspace=False,
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
Changes to the core `repl` rules needed by [the Scala repl support](https://github.com/pantsbuild/pants/pull/13576):

- Add `run_in_workspace` and `append_only_caches` attributes to `ReplRequest` and pass them into the `InteractiveProcess` for the repl. 

- Previously, the repl goal did not pass the input digest through to the `InteractiveProcess`. This causes an issue for the Scala repl since it needs to materialize Coursier (which references paths in an append-only cache).  If an input digest is provided in the `ReplRequest` and `run_in_workspace=True`, then the rule continues to write the digest to the temporary directory (and does not pass the input digest to the `InteractiveProcess`). For `run_in_workspace=False`, the input digest will now be passed into the `InteractiveProcess`.

[ci skip-rust]