### PR TITLE
[jvm] `jvm_artifact` targets can specify their `packages`, and default to owning their group.

### DIFF
--- a/src/python/pants/backend/java/dependency_inference/rules.py
+++ b/src/python/pants/backend/java/dependency_inference/rules.py
@@ -23,7 +23,6 @@ from pants.engine.target import (
 from pants.engine.unions import UnionRule
 from pants.jvm.dependency_inference import artifact_mapper
 from pants.jvm.dependency_inference.artifact_mapper import (
-    AvailableThirdPartyArtifacts,
     ThirdPartyPackageToArtifactMapping,
     find_artifact_mapping,
 )
@@ -43,7 +42,6 @@ async def infer_java_dependencies_via_imports(
     java_infer_subsystem: JavaInferSubsystem,
     first_party_dep_map: FirstPartySymbolMapping,
     third_party_artifact_mapping: ThirdPartyPackageToArtifactMapping,
-    available_artifacts: AvailableThirdPartyArtifacts,
 ) -> InferredDependencies:
     if (
         not java_infer_subsystem.imports
@@ -83,9 +81,7 @@ async def infer_java_dependencies_via_imports(
         first_party_matches = dep_map.addresses_for_symbol(typ)
         third_party_matches: FrozenOrderedSet[Address] = FrozenOrderedSet()
         if java_infer_subsystem.third_party_imports:
-            third_party_matches = find_artifact_mapping(
-                typ, third_party_artifact_mapping, available_artifacts
-            )
+            third_party_matches = find_artifact_mapping(typ, third_party_artifact_mapping)
         matches = first_party_matches.union(third_party_matches)
         if not matches:
             continue

--- a/src/python/pants/backend/java/subsystems/java_infer.py
+++ b/src/python/pants/backend/java/subsystems/java_infer.py
@@ -3,7 +3,6 @@
 from typing import cast
 
 from pants.option.subsystem import Subsystem
-from pants.util.docutil import git_url
 
 
 class JavaInferSubsystem(Subsystem):
@@ -31,19 +30,14 @@ class JavaInferSubsystem(Subsystem):
             type=bool,
             help="Infer a target's third-party dependencies using Java import statements.",
         )
-        _default_package_mapping_url = git_url(
-            "src/python/pants/backend/java/dependency_inference/jvm_artifact_mappings.py"
-        )
         # TODO: Move to `coursier` or a generic `jvm` subsystem.
         register(
             "--third-party-import-mapping",
             type=dict,
             help=(
-                "A dictionary mapping a Java package path to a JVM artifact coordinate (GROUP:ARTIFACT) "
-                "without the version. The package path may be made recursive to match symbols in subpackages "
-                "by adding `.**` to the end of the package path. For example, specify `{'org.junit.**': 'junit:junit'} `"
-                "to infer a dependency on junit:junit for any file importing a symbol from org.junit or its "
-                f"subpackages. Pants also supplies a default package mapping ({_default_package_mapping_url})."
+                "A dictionary mapping a Java package path to a JVM artifact coordinate "
+                "(GROUP:ARTIFACT) without the version.\n\n"
+                "See `jvm_artifact` for more information on the mapping syntax."
             ),
         )
 

--- a/src/python/pants/backend/scala/dependency_inference/rules.py
+++ b/src/python/pants/backend/scala/dependency_inference/rules.py
@@ -23,7 +23,6 @@ from pants.engine.target import (
 from pants.engine.unions import UnionRule
 from pants.jvm.dependency_inference import artifact_mapper
 from pants.jvm.dependency_inference.artifact_mapper import (
-    AvailableThirdPartyArtifacts,
     ThirdPartyPackageToArtifactMapping,
     find_artifact_mapping,
 )
@@ -43,7 +42,6 @@ async def infer_scala_dependencies_via_source_analysis(
     scala_infer_subsystem: ScalaInferSubsystem,
     first_party_symbol_map: FirstPartySymbolMapping,
     third_party_artifact_mapping: ThirdPartyPackageToArtifactMapping,
-    available_artifacts: AvailableThirdPartyArtifacts,
 ) -> InferredDependencies:
     if not scala_infer_subsystem.imports:
         return InferredDependencies([])
@@ -62,9 +60,7 @@ async def infer_scala_dependencies_via_source_analysis(
     dependencies: OrderedSet[Address] = OrderedSet()
     for symbol in symbols:
         first_party_matches = first_party_symbol_map.symbols.addresses_for_symbol(symbol)
-        third_party_matches = find_artifact_mapping(
-            symbol, third_party_artifact_mapping, available_artifacts
-        )
+        third_party_matches = find_artifact_mapping(symbol, third_party_artifact_mapping)
         matches = first_party_matches.union(third_party_matches)
         if not matches:
             continue

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -223,7 +223,7 @@ async def analyze_scala_source_dependencies(
             use_nailgun=tool_digest,
             append_only_caches=jdk_setup.append_only_caches,
             env=jdk_setup.env,
-            description="Analyze Scala source for dependencies",
+            description=f"Analyzing {source_files.files[0]}",
             level=LogLevel.DEBUG,
         ),
     )

--- a/src/python/pants/jvm/dependency_inference/artifact_mapper.py
+++ b/src/python/pants/jvm/dependency_inference/artifact_mapper.py
@@ -2,20 +2,27 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
+import logging
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, Iterable, Set
+from typing import Any, Iterable
 
 from pants.backend.java.subsystems.java_infer import JavaInferSubsystem
 from pants.build_graph.address import Address
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import AllTargets, Targets
 from pants.jvm.dependency_inference.jvm_artifact_mappings import JVM_ARTIFACT_MAPPINGS
-from pants.jvm.target_types import JvmArtifactArtifactField, JvmArtifactGroupField
+from pants.jvm.target_types import (
+    JvmArtifactArtifactField,
+    JvmArtifactGroupField,
+    JvmArtifactPackagesField,
+)
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.meta import frozen_after_init
-from pants.util.ordered_set import FrozenOrderedSet
+from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -33,26 +40,26 @@ class UnversionedCoordinate:
 
 @dataclass(frozen=True)
 class AvailableThirdPartyArtifacts:
-    """Maps JVM artifact coordinates (with only group and artifact set) to the `Address` of each
-    target specifying that coordinate."""
+    """Maps JVM unversioned coordinates to target `Address`es and declared packages."""
 
-    artifacts: FrozenDict[UnversionedCoordinate, FrozenOrderedSet[Address]]
+    artifacts: FrozenDict[UnversionedCoordinate, tuple[tuple[Address, ...], tuple[str, ...]]]
 
     def addresses_for_coordinates(
         self, coordinates: Iterable[UnversionedCoordinate]
-    ) -> FrozenOrderedSet[Address]:
-        candidate_artifact_addresses: Set[Address] = set()
+    ) -> OrderedSet[Address]:
+        candidate_artifact_addresses: OrderedSet[Address] = OrderedSet()
         for coordinate in coordinates:
-            candidates = self.artifacts.get(coordinate, FrozenOrderedSet())
-            candidate_artifact_addresses.update(candidates)
-        return FrozenOrderedSet(candidate_artifact_addresses)
+            candidates = self.artifacts.get(coordinate)
+            if candidates:
+                candidate_artifact_addresses.update(address for address in candidates[0])
+        return candidate_artifact_addresses
 
 
 class MutableTrieNode:
     def __init__(self):
         self.children: dict[str, MutableTrieNode] = {}
         self.recursive: bool = False
-        self.coordinates: set[UnversionedCoordinate] = set()
+        self.addresses: OrderedSet[Address] = OrderedSet()
 
     def ensure_child(self, name: str) -> MutableTrieNode:
         if name in self.children:
@@ -70,9 +77,7 @@ class FrozenTrieNode:
             children[key] = FrozenTrieNode(child)
         self._children: FrozenDict[str, FrozenTrieNode] = FrozenDict(children)
         self._recursive: bool = node.recursive
-        self._coordinates: FrozenOrderedSet[UnversionedCoordinate] = FrozenOrderedSet(
-            node.coordinates
-        )
+        self._addresses: FrozenOrderedSet[Address] = FrozenOrderedSet(node.addresses)
 
     def find_child(self, name: str) -> FrozenTrieNode | None:
         return self._children.get(name)
@@ -82,11 +87,11 @@ class FrozenTrieNode:
         return self._recursive
 
     @property
-    def coordinates(self) -> FrozenOrderedSet[UnversionedCoordinate]:
-        return self._coordinates
+    def addresses(self) -> FrozenOrderedSet[Address]:
+        return self._addresses
 
     def __hash__(self) -> int:
-        return hash((self._children, self._recursive, self._coordinates))
+        return hash((self._children, self._recursive, self._addresses))
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, FrozenTrieNode):
@@ -94,11 +99,11 @@ class FrozenTrieNode:
         return (
             self._children == other._children
             and self.recursive == other.recursive
-            and self.coordinates == other.coordinates
+            and self.addresses == other.addresses
         )
 
     def __repr__(self):
-        return f"FrozenTrieNode(children={repr(self._children)}, recursive={self._recursive}, coordinate={self._coordinates})"
+        return f"FrozenTrieNode(children={repr(self._children)}, recursive={self._recursive}, addresses={self._addresses})"
 
 
 class AllJvmArtifactTargets(Targets):
@@ -121,7 +126,8 @@ class ThirdPartyPackageToArtifactMapping:
 async def find_available_third_party_artifacts(
     all_jvm_artifact_tgts: AllJvmArtifactTargets,
 ) -> AvailableThirdPartyArtifacts:
-    artifact_mapping: dict[UnversionedCoordinate, set[Address]] = defaultdict(set)
+    address_mapping: dict[UnversionedCoordinate, OrderedSet[Address]] = defaultdict(OrderedSet)
+    package_mapping: dict[UnversionedCoordinate, OrderedSet[str]] = defaultdict(OrderedSet)
     for tgt in all_jvm_artifact_tgts:
         group = tgt[JvmArtifactGroupField].value
         if not group:
@@ -134,21 +140,36 @@ async def find_available_third_party_artifacts(
             raise ValueError(
                 f"The {JvmArtifactArtifactField.alias} field of target {tgt.address} must be set."
             )
+        packages: tuple[str, ...] = ()
+        declared_packages = tgt[JvmArtifactPackagesField].value
+        if declared_packages:
+            packages = tuple(declared_packages)
 
         key = UnversionedCoordinate(group=group, artifact=artifact)
-        artifact_mapping[key].add(tgt.address)
+        address_mapping[key].add(tgt.address)
+        package_mapping[key].update(packages)
 
     return AvailableThirdPartyArtifacts(
-        FrozenDict({key: FrozenOrderedSet(value) for key, value in artifact_mapping.items()})
+        FrozenDict(
+            {
+                key: (tuple(addresses), tuple(package_mapping[key]))
+                for key, addresses in address_mapping.items()
+            }
+        )
     )
 
 
 @rule
 async def compute_java_third_party_artifact_mapping(
     java_infer_subsystem: JavaInferSubsystem,
+    available_artifacts: AvailableThirdPartyArtifacts,
 ) -> ThirdPartyPackageToArtifactMapping:
-    def insert(mapping: MutableTrieNode, imp: str, coordinate: UnversionedCoordinate) -> None:
-        imp_parts = imp.split(".")
+    """Implements the mapping logic from the `jvm_artifact` and `java-infer` help."""
+
+    def insert(
+        mapping: MutableTrieNode, package_pattern: str, addresses: Iterable[Address]
+    ) -> None:
+        imp_parts = package_pattern.split(".")
         recursive = False
         if imp_parts[-1] == "**":
             recursive = True
@@ -159,16 +180,32 @@ async def compute_java_third_party_artifact_mapping(
             child_node = current_node.ensure_child(imp_part)
             current_node = child_node
 
-        current_node.coordinates.add(coordinate)
+        current_node.addresses.update(addresses)
         current_node.recursive = recursive
 
-    mapping = MutableTrieNode()
-    for imp_name, imp_action in {
+    # Build a default mapping from coord to package.
+    # TODO: Consider inverting the definitions of these mappings.
+    default_coords_to_packages: dict[UnversionedCoordinate, OrderedSet[str]] = defaultdict(
+        OrderedSet
+    )
+    for package, unversioned_coord_str in {
         **JVM_ARTIFACT_MAPPINGS,
         **java_infer_subsystem.third_party_import_mapping,
     }.items():
-        value = UnversionedCoordinate.from_coord_str(imp_action)
-        insert(mapping, imp_name, value)
+        unversioned_coord = UnversionedCoordinate.from_coord_str(unversioned_coord_str)
+        default_coords_to_packages[unversioned_coord].add(package)
+
+    # Build the mapping from packages to addresses.
+    mapping = MutableTrieNode()
+    for coord, (addresses, packages) in available_artifacts.artifacts.items():
+        if not packages:
+            # If no packages were explicitly defined, fall back to our default mapping.
+            packages = tuple(default_coords_to_packages[coord])
+        if not packages:
+            # Default to exposing the `group` name as a package.
+            packages = (f"{coord.group}.**",)
+        for package in packages:
+            insert(mapping, package, addresses)
 
     return ThirdPartyPackageToArtifactMapping(FrozenTrieNode(mapping))
 
@@ -176,7 +213,6 @@ async def compute_java_third_party_artifact_mapping(
 def find_artifact_mapping(
     import_name: str,
     mapping: ThirdPartyPackageToArtifactMapping,
-    available_artifacts: AvailableThirdPartyArtifacts,
 ) -> FrozenOrderedSet[Address]:
     imp_parts = import_name.split(".")
     current_node = mapping.mapping_root
@@ -195,14 +231,12 @@ def find_artifact_mapping(
     # If the length of the found nodes equals the number of parts of the package path, then there
     # is an exact match.
     if len(found_nodes) == len(imp_parts):
-        addresses = available_artifacts.addresses_for_coordinates(found_nodes[-1].coordinates)
-        return addresses
+        return found_nodes[-1].addresses
 
     # Otherwise, check for the first found node (in reverse order) to match recursively, and use its coordinate.
     for found_node in reversed(found_nodes):
         if found_node.recursive:
-            addresses = available_artifacts.addresses_for_coordinates(found_node.coordinates)
-            return addresses
+            return found_node.addresses
 
     # Nothing matched so return no match.
     return FrozenOrderedSet()

--- a/src/python/pants/jvm/target_types.py
+++ b/src/python/pants/jvm/target_types.py
@@ -12,15 +12,20 @@ from pants.engine.target import (
     StringSequenceField,
     Target,
 )
+from pants.util.docutil import git_url
+
+_DEFAULT_PACKAGE_MAPPING_URL = git_url(
+    "src/python/pants/jvm/dependency_inference/jvm_artifact_mappings.py"
+)
 
 
 class JvmArtifactGroupField(StringField):
     alias = "group"
+    required = True
     help = (
         "The 'group' part of a Maven-compatible coordinate to a third-party jar artifact. For the jar coordinate "
         "com.google.guava:guava:30.1.1-jre, the group is 'com.google.guava'."
     )
-    required = True
 
 
 class JvmArtifactArtifactField(StringField):
@@ -41,16 +46,36 @@ class JvmArtifactVersionField(StringField):
     )
 
 
+class JvmArtifactPackagesField(StringSequenceField):
+    alias = "packages"
+    help = (
+        "The JVM packages this artifact provides for the purposes of dependency inference.\n\n"
+        'For example, the JVM artifact `junit:junit` might provide `["org.junit.**"]`.\n\n'
+        "Usually you can leave this field off. If unspecified, Pants will fall back to the "
+        "`[java-infer].third_party_import_mapping`, then to a built in mapping "
+        f"({_DEFAULT_PACKAGE_MAPPING_URL}), and then finally it will default to "
+        "the normalized `group` of the artifact. For example, in the absence of any other mapping "
+        "the artifact `io.confluent:common-config` would default to providing "
+        '`["io.confluent.**"]`.\n\n'
+        "The package path may be made recursive to match symbols in subpackages "
+        'by adding `.**` to the end of the package path. For example, specify `["org.junit.**"]` '
+        "to infer a dependency on the artifact for any file importing a symbol from `org.junit` or "
+        "its subpackages."
+    )
+
+
 class JvmArtifactFieldSet(FieldSet):
 
     group: JvmArtifactGroupField
     artifact: JvmArtifactArtifactField
     version: JvmArtifactVersionField
+    packages: JvmArtifactPackagesField
 
     required_fields = (
         JvmArtifactGroupField,
         JvmArtifactArtifactField,
         JvmArtifactVersionField,
+        JvmArtifactPackagesField,
     )
 
 


### PR DESCRIPTION
Adds support for `jvm_artifact` targets declaring the `packages` that they provide, and falling back to providing their group if no default is specified. This aligns the JVM with how Python inference finds modules, and will ease adoption in new repositories.

Fixes #13598.

[ci skip-rust]
[ci skip-build-wheels]