### PR TITLE
[internal] Make GIL usage explicit for `session_poll_workunits`

### DIFF
--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -1760,13 +1760,12 @@ async fn remote_workunits_are_stored() {
     .await
     .unwrap();
 
-  let got_workunit_items: HashSet<String> =
-    workunit_store.with_latest_workunits(log::Level::Trace, |_, completed| {
-      completed
-        .iter()
-        .map(|workunit| workunit.name.clone())
-        .collect()
-    });
+  let got_workunit_items: HashSet<String> = workunit_store
+    .latest_workunits(log::Level::Trace)
+    .1
+    .into_iter()
+    .map(|workunit| workunit.name)
+    .collect();
 
   let wanted_workunit_items = hashset! {
     String::from("remote execution action scheduling"),

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1117,19 +1117,19 @@ async fn workunit_to_py_value(
   externs::store_dict(py, dict_entries)
 }
 
-async fn workunits_to_py_tuple_value<'a>(
-  workunits: impl Iterator<Item = &'a Workunit>,
+async fn workunits_to_py_tuple_value<'py>(
+  py: Python<'py>,
+  workunits: Vec<Workunit>,
   core: &Arc<Core>,
   session: &Session,
 ) -> CPyResult<Value> {
   let mut workunit_values = Vec::new();
   for workunit in workunits {
-    let py_value = workunit_to_py_value(workunit, core, session).await?;
+    let py_value = workunit_to_py_value(&workunit, core, session).await?;
     workunit_values.push(py_value);
   }
 
-  let gil = Python::acquire_gil();
-  Ok(externs::store_tuple(gil.python(), workunit_values))
+  Ok(externs::store_tuple(py, workunit_values))
 }
 
 fn session_poll_workunits(
@@ -1144,28 +1144,22 @@ fn session_poll_workunits(
   with_scheduler(py, scheduler_ptr, |scheduler| {
     with_session(py, session_ptr, |session| {
       let core = scheduler.core.clone();
-      py.allow_threads(|| {
-        session
-          .workunit_store()
-          .with_latest_workunits(py_level.into(), |started, completed| {
-            let mut started_iter = started.iter();
-            let started = core.executor.block_on(workunits_to_py_tuple_value(
-              &mut started_iter,
-              &scheduler.core,
-              session,
-            ))?;
+      let (started, completed) =
+        py.allow_threads(|| session.workunit_store().latest_workunits(py_level.into()));
 
-            let mut completed_iter = completed.iter();
-            let completed = core.executor.block_on(workunits_to_py_tuple_value(
-              &mut completed_iter,
-              &scheduler.core,
-              session,
-            ))?;
-
-            let gil = Python::acquire_gil();
-            Ok(externs::store_tuple(gil.python(), vec![started, completed]).into())
-          })
-      })
+      let started_val = core.executor.block_on(workunits_to_py_tuple_value(
+        py,
+        started,
+        &scheduler.core,
+        session,
+      ))?;
+      let completed_val = core.executor.block_on(workunits_to_py_tuple_value(
+        py,
+        completed,
+        &scheduler.core,
+        session,
+      ))?;
+      Ok(externs::store_tuple(py, vec![started_val, completed_val]).into())
     })
   })
 }

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1117,8 +1117,8 @@ async fn workunit_to_py_value(
   externs::store_dict(py, dict_entries)
 }
 
-async fn workunits_to_py_tuple_value<'py>(
-  py: Python<'py>,
+async fn workunits_to_py_tuple_value(
+  py: Python<'_>,
   workunits: Vec<Workunit>,
   core: &Arc<Core>,
   session: &Session,


### PR DESCRIPTION
Prework for https://github.com/pantsbuild/pants/pull/13526. We were reacquiring the GIL directly inside `py.allow_threads(||)`. Rust-cpython allows that, but PyO3 does not. (PyO3 has the benefit of instilling much stronger confidence in reasoning when the GIL is held or not.)

We can easily work around this by having `WorkunitStore.with_latest_workunits` return `Vec<Workunit>` instead of `&[Workunit]`. No new clones are happening! We already were making this Vec. Only now we move the value out, rather than referencing it via a closure passed in as a callback.

That change allows for operating on the `Vec<Workunit>` safely outside of the `py.allow_threads(||)` to convert it into the FFI boundary.

## Benchmark

These benchmarks use the Toolchain BuildSense plugin + anonymous telemetrics streaming workunit handlers.

### No pantsd

Before:

```
❯ hyperfine -w 1 -r 10 './pants -ldebug --no-pantsd list ::'
  Time (mean ± σ):      4.611 s ±  0.206 s    [User: 2.940 s, System: 0.474 s]
  Range (min … max):    4.419 s …  5.153 s    10 runs
```

After:

```
❯ hyperfine -w 1 -r 10 './pants -ldebug --no-pantsd list ::'
  Time (mean ± σ):      4.655 s ±  0.113 s    [User: 2.975 s, System: 0.509 s]
  Range (min … max):    4.430 s …  4.827 s    10 runs
```

### Pantsd

Before:

```
❯ hyperfine -w 1 -r 10 './pants -ldebug --concurrent --pantsd list ::'
  Time (mean ± σ):      2.641 s ±  0.021 s    [User: 2.026 s, System: 0.323 s]
  Range (min … max):    2.602 s …  2.670 s    10 runs
```

After:

```
❯ hyperfine -w 1 -r 10 './pants -ldebug --concurrent --pantsd list ::'
  Time (mean ± σ):      2.651 s ±  0.023 s    [User: 2.036 s, System: 0.334 s]
  Range (min … max):    2.611 s …  2.693 s    10 runs
```

[ci skip-build-wheels]