### PR TITLE
Add a "Pex binaries from sources" macro, with semantics akin to `python_sources`

### DIFF
--- a/build-support/bin/BUILD
+++ b/build-support/bin/BUILD
@@ -32,5 +32,5 @@ pex_binaries_from_sources(
     overrides={
         "_generate_all_lockfiles_helper.py": {"name": "generate_all_lockfiles_helper"},
         "_release_helper.py": {"name": "release_helper"},
-    }
+    },
 )

--- a/build-support/bin/BUILD
+++ b/build-support/bin/BUILD
@@ -16,13 +16,21 @@ python_sources(
 
 python_tests(name="py_tests", overrides={"reversion_test.py": {"timeout": 90}})
 
-pex_binary(name="changelog", entry_point="changelog.py")
-pex_binary(name="check_banned_imports", entry_point="check_banned_imports.py")
-pex_binary(name="check_inits", entry_point="check_inits.py")
-pex_binary(name="deploy_to_s3", entry_point="deploy_to_s3.py")
-pex_binary(name="generate_all_lockfiles_helper", entry_point="_generate_all_lockfiles_helper.py")
-pex_binary(name="generate_docs", entry_point="generate_docs.py")
-pex_binary(name="generate_github_workflows", entry_point="generate_github_workflows.py")
-pex_binary(name="generate_user_list", entry_point="generate_user_list.py")
-pex_binary(name="release_helper", entry_point="_release_helper.py")
-pex_binary(name="reversion", entry_point="reversion.py")
+pex_binaries_from_sources(
+    sources=[
+        "changelog.py",
+        "check_banned_imports.py",
+        "check_inits.py",
+        "deploy_to_s3.py",
+        "_generate_all_lockfiles_helper.py",
+        "generate_docs.py",
+        "generate_github_workflows.py",
+        "generate_user_list.py",
+        "_release_helper.py",
+        "reversion.py",
+    ],
+    overrides={
+        "_generate_all_lockfiles_helper.py": {"name": "generate_all_lockfiles_helper"},
+        "_release_helper.py": {"name": "release_helper"},
+    }
+)

--- a/src/python/pants/backend/python/goals/tailor.py
+++ b/src/python/pants/backend/python/goals/tailor.py
@@ -193,12 +193,13 @@ async def find_putative_targets(
                     owned_sources=[],
                     addressable=False,
                     kwargs={
-                        "sources": tuple(sorted(
-                            os.path.split(module_to_entry_point[entry_point_module])[1]
-                            for entry_point_module in
-                            unowned_entry_point_modules
-                        ))
-                    }
+                        "sources": tuple(
+                            sorted(
+                                os.path.split(module_to_entry_point[entry_point_module])[1]
+                                for entry_point_module in unowned_entry_point_modules
+                            )
+                        )
+                    },
                 )
             )
 

--- a/src/python/pants/backend/python/goals/tailor.py
+++ b/src/python/pants/backend/python/goals/tailor.py
@@ -189,13 +189,16 @@ async def find_putative_targets(
                     path=dirname,
                     name="pex_binaries_from_sources",
                     type_alias="pex_binaries_from_sources",
-                    triggering_sources=tuple(
+                    triggering_sources=tuple(),
+                    owned_sources=[],
+                    addressable=False,
+                    kwargs={
+                        "sources": tuple(sorted(
                             os.path.split(module_to_entry_point[entry_point_module])[1]
                             for entry_point_module in
                             unowned_entry_point_modules
-                        ),
-                    owned_sources=[],
-                    addressable=False,
+                        ))
+                    }
                 )
             )
 

--- a/src/python/pants/backend/python/goals/tailor_test.py
+++ b/src/python/pants/backend/python/goals/tailor_test.py
@@ -182,7 +182,7 @@ def test_find_putative_targets_subset(rule_runner: RuleRunner) -> None:
 
 
 def test_find_putative_targets_for_entry_points(rule_runner: RuleRunner) -> None:
-    mains = ("main1.py", "main2.py", "main3.py",  "main4.py")
+    mains = ("main1.py", "main2.py", "main3.py", "main4.py")
     rule_runner.write_files(
         {
             f"src/python/foo/{name}": textwrap.dedent(
@@ -218,7 +218,7 @@ def test_find_putative_targets_for_entry_points(rule_runner: RuleRunner) -> None
                     addressable=False,
                     kwargs={
                         "sources": ("main3.py", "main4.py"),
-                    }
+                    },
                 )
             ]
         )

--- a/src/python/pants/backend/python/goals/tailor_test.py
+++ b/src/python/pants/backend/python/goals/tailor_test.py
@@ -213,9 +213,12 @@ def test_find_putative_targets_for_entry_points(rule_runner: RuleRunner) -> None
                     path="src/python/foo",
                     name="pex_binaries_from_sources",
                     type_alias="pex_binaries_from_sources",
-                    triggering_sources=("main3.py", "main4.py"),
+                    triggering_sources=tuple(),
                     owned_sources=[],
                     addressable=False,
+                    kwargs={
+                        "sources": ("main3.py", "main4.py"),
+                    }
                 )
             ]
         )

--- a/src/python/pants/backend/python/goals/tailor_test.py
+++ b/src/python/pants/backend/python/goals/tailor_test.py
@@ -182,7 +182,7 @@ def test_find_putative_targets_subset(rule_runner: RuleRunner) -> None:
 
 
 def test_find_putative_targets_for_entry_points(rule_runner: RuleRunner) -> None:
-    mains = ("main1.py", "main2.py", "main3.py")
+    mains = ("main1.py", "main2.py", "main3.py",  "main4.py")
     rule_runner.write_files(
         {
             f"src/python/foo/{name}": textwrap.dedent(
@@ -209,13 +209,14 @@ def test_find_putative_targets_for_entry_points(rule_runner: RuleRunner) -> None
     assert (
         PutativeTargets(
             [
-                PutativeTarget.for_target_type(
-                    PexBinary,
-                    "src/python/foo",
-                    "main3",
-                    [],
-                    kwargs={"name": "main3", "entry_point": "main3.py"},
-                ),
+                PutativeTarget(
+                    path="src/python/foo",
+                    name="pex_binaries_from_sources",
+                    type_alias="pex_binaries_from_sources",
+                    triggering_sources=("main3.py", "main4.py"),
+                    owned_sources=[],
+                    addressable=False,
+                )
             ]
         )
         == pts

--- a/src/python/pants/backend/python/macros/caof_utils.py
+++ b/src/python/pants/backend/python/macros/caof_utils.py
@@ -13,39 +13,50 @@ from pants.util.collections import ensure_str_list
 OVERRIDES_TYPE = Optional[Dict[Union[str, Tuple[str, ...]], Dict[str, Any]]]
 
 
+def flatten_overrides(
+    overrides: OVERRIDES_TYPE, *, macro_name: str, build_file_dir: str
+) -> dict[str, Dict[str, Any]]:
+    overrides = overrides or {}
+    result: dict[str, Dict[str, Any]] = {}
+    for key_or_keys, override_values in (overrides or {}).items():
+        keys = (key_or_keys,) if isinstance(key_or_keys, str) else key_or_keys
+        for key in keys:
+            if key in result:
+                raise InvalidFieldException(
+                    f"Conflicting overrides in the `overrides` field of the `{macro_name}` macro "
+                    f"in the BUILD file in {build_file_dir} for the key `{key}`. You cannot specify "
+                    "the same field name multiple times for the same key.\n\n"
+                    f"(One override sets the field to `{repr(result[key])}` "
+                    f"but another sets to `{repr(overrides[key_or_keys])}`.)"
+                )
+            result[key] = override_values
+    return result
+
+
 def flatten_overrides_to_dependency_field(
-    overrides_value: OVERRIDES_TYPE, *, macro_name: str, build_file_dir: str
+    overrides: OVERRIDES_TYPE, *, macro_name: str, build_file_dir: str
 ) -> dict[str, list[str]]:
     """Flatten `overrides` by ensuring that only `dependencies` is specified."""
 
     result: dict[str, list[str]] = {}
-    for maybe_key_or_keys, override in (overrides_value or {}).items():
-        keys = (maybe_key_or_keys,) if isinstance(maybe_key_or_keys, str) else maybe_key_or_keys
-        for _raw_key in keys:
-            key = canonicalize_project_name(_raw_key)
-            for field, value in override.items():
-                if field != "dependencies":
-                    raise InvalidFieldException(
-                        "Can only specify the `dependencies` field (for now) in the `overrides` "
-                        f"field of the {macro_name} macro in the BUILD file in {build_file_dir} "
-                        f"for the key `{key}`, but you specified `{field}`."
-                    )
-                if key in result:
-                    raise InvalidFieldException(
-                        f"Conflicting overrides in the `overrides` field of "
-                        f"the {macro_name} macro in the BUILD file in {build_file_dir} for the key "
-                        f"`{key}` for the field `{field}`. You cannot specify the same field name "
-                        "multiple times for the same key.\n\n"
-                        f"(One override sets the field to `{repr(result[key])}` "
-                        f"but another sets to `{repr(value)}`.)"
-                    )
-                try:
-                    normalized_value = ensure_str_list(value)
-                except ValueError:
-                    raise InvalidFieldException(
-                        f"The 'overrides' field in the {macro_name} macro in the BUILD file in "
-                        f"{build_file_dir} must be `dict[str | tuple[str, ...], dict[str, Any]]`, "
-                        f"but was `{repr(value)}` with type `{type(value).__name__}`."
-                    )
-                result[key] = normalized_value
+    for raw_key, override_values in flatten_overrides(
+        overrides, macro_name=macro_name, build_file_dir=build_file_dir
+    ).items():
+        key = canonicalize_project_name(raw_key)
+        for field, value in override_values.items():
+            if field != "dependencies":
+                raise InvalidFieldException(
+                    "Can only specify the `dependencies` field (for now) in the `overrides` "
+                    f"field of the `{macro_name}` macro in the BUILD file in {build_file_dir} "
+                    f"for the key `{key}`, but you specified `{field}`."
+                )
+            try:
+                normalized_value = ensure_str_list(value)
+            except ValueError:
+                raise InvalidFieldException(
+                    f"The `{field}` field in the `overrides` field of the `{macro_name}` "
+                    f"macro in the BUILD file in {build_file_dir} must be `list[str]`, "
+                    f"but was `{repr(value)}` with type `{type(value).__name__}`."
+                )
+            result[key] = normalized_value
     return result

--- a/src/python/pants/backend/python/macros/caof_utils.py
+++ b/src/python/pants/backend/python/macros/caof_utils.py
@@ -46,7 +46,7 @@ def flatten_overrides_to_dependency_field(
         for field, value in override_values.items():
             if field != "dependencies":
                 raise InvalidFieldException(
-                    "Can only specify the `dependencies` field (for now) in the `overrides` "
+                    "Can only specify the `dependencies` key (for now) in the `overrides` "
                     f"field of the `{macro_name}` macro in the BUILD file in {build_file_dir} "
                     f"for the key `{key}`, but you specified `{field}`."
                 )
@@ -54,7 +54,7 @@ def flatten_overrides_to_dependency_field(
                 normalized_value = ensure_str_list(value)
             except ValueError:
                 raise InvalidFieldException(
-                    f"The `{field}` field in the `overrides` field of the `{macro_name}` "
+                    f"The `{field}` key in the `overrides` field of the `{macro_name}` "
                     f"macro in the BUILD file in {build_file_dir} must be `list[str]`, "
                     f"but was `{repr(value)}` with type `{type(value).__name__}`."
                 )

--- a/src/python/pants/backend/python/macros/caof_utils.py
+++ b/src/python/pants/backend/python/macros/caof_utils.py
@@ -24,7 +24,7 @@ def flatten_overrides(
             if key in result:
                 raise InvalidFieldException(
                     f"Conflicting overrides in the `overrides` field of the `{macro_name}` macro "
-                    f"in the BUILD file in {build_file_dir} for the key `{key}`. "
+                    f"in the BUILD file in {build_file_dir} for the key `{key}`.\n\n"
                     f"(One override sets the field to `{repr(result[key])}` "
                     f"but another sets to `{repr(overrides[key_or_keys])}`.)"
                 )

--- a/src/python/pants/backend/python/macros/caof_utils.py
+++ b/src/python/pants/backend/python/macros/caof_utils.py
@@ -24,8 +24,7 @@ def flatten_overrides(
             if key in result:
                 raise InvalidFieldException(
                     f"Conflicting overrides in the `overrides` field of the `{macro_name}` macro "
-                    f"in the BUILD file in {build_file_dir} for the key `{key}`. You cannot specify "
-                    "the same field name multiple times for the same key.\n\n"
+                    f"in the BUILD file in {build_file_dir} for the key `{key}`. "
                     f"(One override sets the field to `{repr(result[key])}` "
                     f"but another sets to `{repr(overrides[key_or_keys])}`.)"
                 )

--- a/src/python/pants/backend/python/macros/caof_utils_test.py
+++ b/src/python/pants/backend/python/macros/caof_utils_test.py
@@ -76,7 +76,7 @@ def test_flatten_overrides_same_key() -> None:
 
 
 def test_flatten_overrides_only_dependencies_field() -> None:
-    with pytest.raises(InvalidFieldException, match="Can only specify the `dependencies` field"):
+    with pytest.raises(InvalidFieldException, match="Can only specify the `dependencies` key"):
         flatten_overrides_to_dependency_field(
             {"d": {"tags": []}}, macro_name="macro", build_file_dir="dir"
         )

--- a/src/python/pants/backend/python/macros/pex_binaries_from_sources_caof.py
+++ b/src/python/pants/backend/python/macros/pex_binaries_from_sources_caof.py
@@ -2,16 +2,15 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os.path
-
 from typing import Iterable
 
+from pants.backend.python.macros.caof_utils import OVERRIDES_TYPE
 from pants.engine.target import InvalidFieldException
-from pants.backend.python.macros.caof_utils import (
-    OVERRIDES_TYPE,
-)
+
 
 class PexBinariesFromSourcesCAOF:
-    """Translates N sources to equivalent `pex_binary` targets with entry_point set to the source."""
+    """Translates N sources to equivalent `pex_binary` targets with entry_point set to the
+    source."""
 
     def __init__(self, parse_context):
         self._parse_context = parse_context
@@ -19,10 +18,10 @@ class PexBinariesFromSourcesCAOF:
     def __call__(
         self,
         *,
-        sources: str = Iterable[str],
+        sources: Iterable[str],
         overrides: OVERRIDES_TYPE = None,
     ) -> None:
-        overrides = overrides.copy() or {}
+        overrides = (overrides or {}).copy()
         for source in sources:
             values = overrides.pop(source, {})
             values.setdefault("name", os.path.splitext(source)[0])
@@ -32,5 +31,5 @@ class PexBinariesFromSourcesCAOF:
         if overrides:
             raise InvalidFieldException(
                 "overrides field contained one or more keys that aren't in `sources`. "
-                f" Invalid keys were: '{', '.join(sorted(overrides))}'"
+                f" Invalid keys were: '{', '.join(sorted(overrides.keys()))}'"
             )

--- a/src/python/pants/backend/python/macros/pex_binaries_from_sources_caof.py
+++ b/src/python/pants/backend/python/macros/pex_binaries_from_sources_caof.py
@@ -1,0 +1,36 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os.path
+
+from typing import Iterable
+
+from pants.engine.target import InvalidFieldException
+from pants.backend.python.macros.caof_utils import (
+    OVERRIDES_TYPE,
+)
+
+class PexBinariesFromSourcesCAOF:
+    """Translates N sources to equivalent `pex_binary` targets with entry_point set to the source."""
+
+    def __init__(self, parse_context):
+        self._parse_context = parse_context
+
+    def __call__(
+        self,
+        *,
+        sources: str = Iterable[str],
+        overrides: OVERRIDES_TYPE = None,
+    ) -> None:
+        overrides = overrides.copy() or {}
+        for source in sources:
+            values = overrides.pop(source, {})
+            values.setdefault("name", os.path.splitext(source)[0])
+            values.setdefault("entry_point", source)
+            self._parse_context.create_object("pex_binary", **values)
+
+        if overrides:
+            raise InvalidFieldException(
+                "overrides field contained one or more keys that aren't in `sources`. "
+                f" Invalid keys were: '{', '.join(sorted(overrides))}'"
+            )

--- a/src/python/pants/backend/python/macros/pex_binaries_from_sources_caof_test.py
+++ b/src/python/pants/backend/python/macros/pex_binaries_from_sources_caof_test.py
@@ -6,11 +6,12 @@ from textwrap import dedent
 import pytest
 
 from pants.backend.python.macros.pex_binaries_from_sources_caof import PexBinariesFromSourcesCAOF
-from pants.backend.python.target_types import PexBinary, PythonRequirementsFile, PythonRequirementTarget
+from pants.backend.python.target_types import PexBinary
 from pants.engine.addresses import Address
 from pants.engine.internals.scheduler import ExecutionError
-from pants.engine.target import AllTargets, InvalidFieldException
+from pants.engine.target import AllTargets
 from pants.testutil.rule_runner import RuleRunner
+
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
@@ -18,6 +19,7 @@ def rule_runner() -> RuleRunner:
         target_types=[PexBinary],
         context_aware_object_factories={"pex_binaries_from_sources": PexBinariesFromSourcesCAOF},
     )
+
 
 def test_pex_binaries_from_sources(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
@@ -51,10 +53,11 @@ def test_pex_binaries_from_sources(rule_runner: RuleRunner) -> None:
                 "entry_point": "_main2.py",
                 "tags": ["overridden"],
             },
-            Address("", target_name="ThePexBinaryFormerlyKnownAsMain2")
+            Address("", target_name="ThePexBinaryFormerlyKnownAsMain2"),
         ),
         PexBinary({"entry_point": "main3.py"}, Address("", target_name="main3")),
     }
+
 
 def test_invalid_overrides(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(

--- a/src/python/pants/backend/python/macros/pex_binaries_from_sources_caof_test.py
+++ b/src/python/pants/backend/python/macros/pex_binaries_from_sources_caof_test.py
@@ -1,0 +1,76 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from textwrap import dedent
+
+import pytest
+
+from pants.backend.python.macros.pex_binaries_from_sources_caof import PexBinariesFromSourcesCAOF
+from pants.backend.python.target_types import PexBinary, PythonRequirementsFile, PythonRequirementTarget
+from pants.engine.addresses import Address
+from pants.engine.internals.scheduler import ExecutionError
+from pants.engine.target import AllTargets, InvalidFieldException
+from pants.testutil.rule_runner import RuleRunner
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        target_types=[PexBinary],
+        context_aware_object_factories={"pex_binaries_from_sources": PexBinariesFromSourcesCAOF},
+    )
+
+def test_pex_binaries_from_sources(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                """\
+                    pex_binaries_from_sources(
+                        sources=[
+                            "main1.py",
+                            "main2.py",
+                            "main3.py",
+                        ],
+                        overrides = {
+                            "main2.py": {
+                                "tags": ["overridden"],
+                                "entry_point": "_main2.py",
+                                "name": "ThePexBinaryFormerlyKnownAsMain2",
+                            }
+                        }
+                    )
+                """
+            ),
+        }
+    )
+
+    targets = rule_runner.request(AllTargets, [])
+    assert set(targets) == {
+        PexBinary({"entry_point": "main1.py"}, Address("", target_name="main1")),
+        PexBinary(
+            {
+                "entry_point": "_main2.py",
+                "tags": ["overridden"],
+            },
+            Address("", target_name="ThePexBinaryFormerlyKnownAsMain2")
+        ),
+        PexBinary({"entry_point": "main3.py"}, Address("", target_name="main3")),
+    }
+
+def test_invalid_overrides(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                """\
+                    pex_binaries_from_sources(
+                        sources=[],
+                        overrides = {"invalid1": {}, "invalid2": {}}
+                    )
+                """
+            ),
+        }
+    )
+
+    with pytest.raises(ExecutionError) as exc_info:
+        rule_runner.request(AllTargets, [])
+
+    assert "'invalid1, invalid2'" in exc_info.value.wrapped_exceptions[0].args[0]

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -24,6 +24,7 @@ from pants.backend.python.macros.pipenv_requirements_caof import PipenvRequireme
 from pants.backend.python.macros.poetry_requirements_caof import PoetryRequirementsCAOF
 from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.macros.python_requirements_caof import PythonRequirementsCAOF
+from pants.backend.python.macros.pex_binaries_from_sources_caof import PexBinariesFromSourcesCAOF
 from pants.backend.python.subsystems import ipython, pytest, python_native_code, setuptools
 from pants.backend.python.target_types import (
     PexBinary,
@@ -56,6 +57,7 @@ def build_file_aliases():
             "poetry_requirements": PoetryRequirementsCAOF,
             "pipenv_requirements": PipenvRequirementsCAOF,
             PantsRequirementCAOF.alias: PantsRequirementCAOF,
+            "pex_binaries_from_sources": PexBinariesFromSourcesCAOF,
         },
     )
 

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -20,11 +20,11 @@ from pants.backend.python.goals import (
     tailor,
 )
 from pants.backend.python.macros.pants_requirement_caof import PantsRequirementCAOF
+from pants.backend.python.macros.pex_binaries_from_sources_caof import PexBinariesFromSourcesCAOF
 from pants.backend.python.macros.pipenv_requirements_caof import PipenvRequirementsCAOF
 from pants.backend.python.macros.poetry_requirements_caof import PoetryRequirementsCAOF
 from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.macros.python_requirements_caof import PythonRequirementsCAOF
-from pants.backend.python.macros.pex_binaries_from_sources_caof import PexBinariesFromSourcesCAOF
 from pants.backend.python.subsystems import ipython, pytest, python_native_code, setuptools
 from pants.backend.python.target_types import (
     PexBinary,


### PR DESCRIPTION
Fixes #13554 by adding `pex_binaries_from_sources`, along with the plumbing and changes to `tailor`.

Also did some boy-scout cleanup of `src/python/pants/backend/python/macros/caof_utils.py` and it's tests ;)