### PR TITLE
[jvm] Expose `scala_junit_test`

### DIFF
--- a/src/python/pants/backend/experimental/scala/register.py
+++ b/src/python/pants/backend/experimental/scala/register.py
@@ -11,7 +11,12 @@ from pants.backend.java.test import junit  # TODO: Should move to the JVM packag
 from pants.backend.scala.compile import scalac
 from pants.backend.scala.dependency_inference import rules as dep_inf_rules
 from pants.backend.scala.goals import check, tailor
-from pants.backend.scala.target_types import ScalaSourcesGeneratorTarget, ScalaSourceTarget
+from pants.backend.scala.target_types import (
+    ScalaJunitTestsGeneratorTarget,
+    ScalaJunitTestTarget,
+    ScalaSourcesGeneratorTarget,
+    ScalaSourceTarget,
+)
 from pants.backend.scala.target_types import rules as target_types_rules
 from pants.jvm import classpath, jdk_rules
 from pants.jvm import util_rules as jvm_util_rules
@@ -23,12 +28,14 @@ from pants.jvm.target_types import JvmArtifact, JvmDependencyLockfile
 def target_types():
     return [
         DeployJar,
-        ScalaSourceTarget,
-        ScalaSourcesGeneratorTarget,
         JunitTestTarget,
         JunitTestsGeneratorTarget,
         JvmArtifact,
         JvmDependencyLockfile,
+        ScalaJunitTestTarget,
+        ScalaJunitTestsGeneratorTarget,
+        ScalaSourceTarget,
+        ScalaSourcesGeneratorTarget,
     ]
 
 

--- a/src/python/pants/backend/scala/goals/tailor.py
+++ b/src/python/pants/backend/scala/goals/tailor.py
@@ -7,7 +7,11 @@ import os
 from dataclasses import dataclass
 from typing import Iterable
 
-from pants.backend.scala.target_types import ScalaSourcesGeneratorTarget
+from pants.backend.scala.target_types import (
+    ScalaJunitTestsGeneratorTarget,
+    ScalaSourcesGeneratorTarget,
+    ScalaTestsGeneratorSourcesField,
+)
 from pants.core.goals.tailor import (
     AllOwnedSources,
     PutativeTarget,
@@ -20,6 +24,7 @@ from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule
+from pants.source.filespec import Filespec, matches_filespec
 from pants.util.logging import LogLevel
 
 
@@ -30,9 +35,13 @@ class PutativeScalaTargetsRequest(PutativeTargetsRequest):
 
 def classify_source_files(paths: Iterable[str]) -> dict[type[Target], set[str]]:
     """Returns a dict of target type -> files that belong to targets of that type."""
-    # TODO: Until https://github.com/pantsbuild/pants/issues/13332 is fixed, we classify all scala
-    # files as `scala_sources`, and none as tests.
-    return {ScalaSourcesGeneratorTarget: set(paths)}
+    tests_filespec = Filespec(includes=list(ScalaTestsGeneratorSourcesField.default))
+    test_filenames = set(
+        matches_filespec(tests_filespec, paths=[os.path.basename(path) for path in paths])
+    )
+    test_files = {path for path in paths if os.path.basename(path) in test_filenames}
+    sources_files = set(paths) - test_files
+    return {ScalaJunitTestsGeneratorTarget: test_files, ScalaSourcesGeneratorTarget: sources_files}
 
 
 @rule(level=LogLevel.DEBUG, desc="Determine candidate Scala targets to create")


### PR DESCRIPTION
Although testing of `scala_junit_test` is not yet actually implemented (no `FieldSet` hooked up to kick off testing), not having it exposed results in Scala repos with gaps in the files owned by `tailor`ed targets, which inhibits verifying compilation.

[ci skip-rust]
[ci skip-build-wheels]