### PR TITLE
Register skip fields for python linters and mypy also on the `python_test_utils` target. (Cherry-pick of #13616)

### DIFF
--- a/src/python/pants/backend/python/lint/autoflake/skip_field.py
+++ b/src/python/pants/backend/python/lint/autoflake/skip_field.py
@@ -6,6 +6,7 @@ from pants.backend.python.target_types import (
     PythonSourceTarget,
     PythonTestsGeneratorTarget,
     PythonTestTarget,
+    PythonTestUtilsGeneratorTarget,
 )
 from pants.engine.target import BoolField
 
@@ -18,8 +19,9 @@ class SkipAutoflakeField(BoolField):
 
 def rules():
     return [
-        PythonSourceTarget.register_plugin_field(SkipAutoflakeField),
         PythonSourcesGeneratorTarget.register_plugin_field(SkipAutoflakeField),
-        PythonTestTarget.register_plugin_field(SkipAutoflakeField),
+        PythonSourceTarget.register_plugin_field(SkipAutoflakeField),
         PythonTestsGeneratorTarget.register_plugin_field(SkipAutoflakeField),
+        PythonTestTarget.register_plugin_field(SkipAutoflakeField),
+        PythonTestUtilsGeneratorTarget.register_plugin_field(SkipAutoflakeField),
     ]

--- a/src/python/pants/backend/python/lint/bandit/skip_field.py
+++ b/src/python/pants/backend/python/lint/bandit/skip_field.py
@@ -6,6 +6,7 @@ from pants.backend.python.target_types import (
     PythonSourceTarget,
     PythonTestsGeneratorTarget,
     PythonTestTarget,
+    PythonTestUtilsGeneratorTarget,
 )
 from pants.engine.target import BoolField
 
@@ -18,8 +19,9 @@ class SkipBanditField(BoolField):
 
 def rules():
     return [
-        PythonSourceTarget.register_plugin_field(SkipBanditField),
         PythonSourcesGeneratorTarget.register_plugin_field(SkipBanditField),
-        PythonTestTarget.register_plugin_field(SkipBanditField),
+        PythonSourceTarget.register_plugin_field(SkipBanditField),
         PythonTestsGeneratorTarget.register_plugin_field(SkipBanditField),
+        PythonTestTarget.register_plugin_field(SkipBanditField),
+        PythonTestUtilsGeneratorTarget.register_plugin_field(SkipBanditField),
     ]

--- a/src/python/pants/backend/python/lint/black/skip_field.py
+++ b/src/python/pants/backend/python/lint/black/skip_field.py
@@ -6,6 +6,7 @@ from pants.backend.python.target_types import (
     PythonSourceTarget,
     PythonTestsGeneratorTarget,
     PythonTestTarget,
+    PythonTestUtilsGeneratorTarget,
 )
 from pants.engine.target import BoolField
 
@@ -18,8 +19,9 @@ class SkipBlackField(BoolField):
 
 def rules():
     return [
-        PythonSourceTarget.register_plugin_field(SkipBlackField),
         PythonSourcesGeneratorTarget.register_plugin_field(SkipBlackField),
-        PythonTestTarget.register_plugin_field(SkipBlackField),
+        PythonSourceTarget.register_plugin_field(SkipBlackField),
         PythonTestsGeneratorTarget.register_plugin_field(SkipBlackField),
+        PythonTestTarget.register_plugin_field(SkipBlackField),
+        PythonTestUtilsGeneratorTarget.register_plugin_field(SkipBlackField),
     ]

--- a/src/python/pants/backend/python/lint/docformatter/skip_field.py
+++ b/src/python/pants/backend/python/lint/docformatter/skip_field.py
@@ -6,6 +6,7 @@ from pants.backend.python.target_types import (
     PythonSourceTarget,
     PythonTestsGeneratorTarget,
     PythonTestTarget,
+    PythonTestUtilsGeneratorTarget,
 )
 from pants.engine.target import BoolField
 
@@ -18,8 +19,9 @@ class SkipDocformatterField(BoolField):
 
 def rules():
     return [
-        PythonSourceTarget.register_plugin_field(SkipDocformatterField),
         PythonSourcesGeneratorTarget.register_plugin_field(SkipDocformatterField),
-        PythonTestTarget.register_plugin_field(SkipDocformatterField),
+        PythonSourceTarget.register_plugin_field(SkipDocformatterField),
         PythonTestsGeneratorTarget.register_plugin_field(SkipDocformatterField),
+        PythonTestTarget.register_plugin_field(SkipDocformatterField),
+        PythonTestUtilsGeneratorTarget.register_plugin_field(SkipDocformatterField),
     ]

--- a/src/python/pants/backend/python/lint/flake8/skip_field.py
+++ b/src/python/pants/backend/python/lint/flake8/skip_field.py
@@ -6,6 +6,7 @@ from pants.backend.python.target_types import (
     PythonSourceTarget,
     PythonTestsGeneratorTarget,
     PythonTestTarget,
+    PythonTestUtilsGeneratorTarget,
 )
 from pants.engine.target import BoolField
 
@@ -18,8 +19,9 @@ class SkipFlake8Field(BoolField):
 
 def rules():
     return [
-        PythonSourceTarget.register_plugin_field(SkipFlake8Field),
         PythonSourcesGeneratorTarget.register_plugin_field(SkipFlake8Field),
-        PythonTestTarget.register_plugin_field(SkipFlake8Field),
+        PythonSourceTarget.register_plugin_field(SkipFlake8Field),
         PythonTestsGeneratorTarget.register_plugin_field(SkipFlake8Field),
+        PythonTestTarget.register_plugin_field(SkipFlake8Field),
+        PythonTestUtilsGeneratorTarget.register_plugin_field(SkipFlake8Field),
     ]

--- a/src/python/pants/backend/python/lint/isort/skip_field.py
+++ b/src/python/pants/backend/python/lint/isort/skip_field.py
@@ -6,6 +6,7 @@ from pants.backend.python.target_types import (
     PythonSourceTarget,
     PythonTestsGeneratorTarget,
     PythonTestTarget,
+    PythonTestUtilsGeneratorTarget,
 )
 from pants.engine.target import BoolField
 
@@ -18,8 +19,9 @@ class SkipIsortField(BoolField):
 
 def rules():
     return [
-        PythonSourceTarget.register_plugin_field(SkipIsortField),
         PythonSourcesGeneratorTarget.register_plugin_field(SkipIsortField),
-        PythonTestTarget.register_plugin_field(SkipIsortField),
+        PythonSourceTarget.register_plugin_field(SkipIsortField),
         PythonTestsGeneratorTarget.register_plugin_field(SkipIsortField),
+        PythonTestTarget.register_plugin_field(SkipIsortField),
+        PythonTestUtilsGeneratorTarget.register_plugin_field(SkipIsortField),
     ]

--- a/src/python/pants/backend/python/lint/pylint/skip_field.py
+++ b/src/python/pants/backend/python/lint/pylint/skip_field.py
@@ -6,6 +6,7 @@ from pants.backend.python.target_types import (
     PythonSourceTarget,
     PythonTestsGeneratorTarget,
     PythonTestTarget,
+    PythonTestUtilsGeneratorTarget,
 )
 from pants.engine.target import BoolField
 
@@ -18,8 +19,9 @@ class SkipPylintField(BoolField):
 
 def rules():
     return [
-        PythonSourceTarget.register_plugin_field(SkipPylintField),
         PythonSourcesGeneratorTarget.register_plugin_field(SkipPylintField),
-        PythonTestTarget.register_plugin_field(SkipPylintField),
+        PythonSourceTarget.register_plugin_field(SkipPylintField),
         PythonTestsGeneratorTarget.register_plugin_field(SkipPylintField),
+        PythonTestTarget.register_plugin_field(SkipPylintField),
+        PythonTestUtilsGeneratorTarget.register_plugin_field(SkipPylintField),
     ]

--- a/src/python/pants/backend/python/lint/pyupgrade/skip_field.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/skip_field.py
@@ -6,6 +6,7 @@ from pants.backend.python.target_types import (
     PythonSourceTarget,
     PythonTestsGeneratorTarget,
     PythonTestTarget,
+    PythonTestUtilsGeneratorTarget,
 )
 from pants.engine.target import BoolField
 
@@ -18,8 +19,9 @@ class SkipPyUpgradeField(BoolField):
 
 def rules():
     return [
-        PythonSourceTarget.register_plugin_field(SkipPyUpgradeField),
         PythonSourcesGeneratorTarget.register_plugin_field(SkipPyUpgradeField),
-        PythonTestTarget.register_plugin_field(SkipPyUpgradeField),
+        PythonSourceTarget.register_plugin_field(SkipPyUpgradeField),
         PythonTestsGeneratorTarget.register_plugin_field(SkipPyUpgradeField),
+        PythonTestTarget.register_plugin_field(SkipPyUpgradeField),
+        PythonTestUtilsGeneratorTarget.register_plugin_field(SkipPyUpgradeField),
     ]

--- a/src/python/pants/backend/python/lint/yapf/skip_field.py
+++ b/src/python/pants/backend/python/lint/yapf/skip_field.py
@@ -6,6 +6,7 @@ from pants.backend.python.target_types import (
     PythonSourceTarget,
     PythonTestsGeneratorTarget,
     PythonTestTarget,
+    PythonTestUtilsGeneratorTarget,
 )
 from pants.engine.target import BoolField
 
@@ -18,8 +19,9 @@ class SkipYapfField(BoolField):
 
 def rules():
     return [
-        PythonSourceTarget.register_plugin_field(SkipYapfField),
         PythonSourcesGeneratorTarget.register_plugin_field(SkipYapfField),
-        PythonTestTarget.register_plugin_field(SkipYapfField),
+        PythonSourceTarget.register_plugin_field(SkipYapfField),
         PythonTestsGeneratorTarget.register_plugin_field(SkipYapfField),
+        PythonTestTarget.register_plugin_field(SkipYapfField),
+        PythonTestUtilsGeneratorTarget.register_plugin_field(SkipYapfField),
     ]

--- a/src/python/pants/backend/python/typecheck/mypy/skip_field.py
+++ b/src/python/pants/backend/python/typecheck/mypy/skip_field.py
@@ -6,6 +6,7 @@ from pants.backend.python.target_types import (
     PythonSourceTarget,
     PythonTestsGeneratorTarget,
     PythonTestTarget,
+    PythonTestUtilsGeneratorTarget,
 )
 from pants.engine.target import BoolField
 
@@ -18,8 +19,9 @@ class SkipMyPyField(BoolField):
 
 def rules():
     return [
-        PythonSourceTarget.register_plugin_field(SkipMyPyField),
         PythonSourcesGeneratorTarget.register_plugin_field(SkipMyPyField),
-        PythonTestTarget.register_plugin_field(SkipMyPyField),
+        PythonSourceTarget.register_plugin_field(SkipMyPyField),
         PythonTestsGeneratorTarget.register_plugin_field(SkipMyPyField),
+        PythonTestTarget.register_plugin_field(SkipMyPyField),
+        PythonTestUtilsGeneratorTarget.register_plugin_field(SkipMyPyField),
     ]


### PR DESCRIPTION
Cherry-pick #13616 