### PR TITLE
[internal] Fix bad Git reference for PyO3 crate

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -2331,14 +2331,14 @@ dependencies = [
 [[package]]
 name = "pyo3"
 version = "0.15.0"
-source = "git+https://github.com/davidhewitt/pyo3.git?rev=51b6b947b82e61adad61524f9c58e3b1c89247a5#51b6b947b82e61adad61524f9c58e3b1c89247a5"
+source = "git+https://github.com/PyO3/pyo3.git?rev=45059cbdb81fd3ab72a5ce530e3b99cc90383327#45059cbdb81fd3ab72a5ce530e3b99cc90383327"
 dependencies = [
  "cfg-if 1.0.0",
  "indoc",
  "libc",
  "parking_lot",
  "paste",
- "pyo3-build-config 0.15.0 (git+https://github.com/davidhewitt/pyo3.git?rev=51b6b947b82e61adad61524f9c58e3b1c89247a5)",
+ "pyo3-build-config 0.15.0 (git+https://github.com/PyO3/pyo3.git?rev=45059cbdb81fd3ab72a5ce530e3b99cc90383327)",
  "pyo3-macros",
  "unindent",
 ]
@@ -2355,7 +2355,7 @@ dependencies = [
 [[package]]
 name = "pyo3-build-config"
 version = "0.15.0"
-source = "git+https://github.com/davidhewitt/pyo3.git?rev=51b6b947b82e61adad61524f9c58e3b1c89247a5#51b6b947b82e61adad61524f9c58e3b1c89247a5"
+source = "git+https://github.com/PyO3/pyo3.git?rev=45059cbdb81fd3ab72a5ce530e3b99cc90383327#45059cbdb81fd3ab72a5ce530e3b99cc90383327"
 dependencies = [
  "once_cell",
 ]
@@ -2363,7 +2363,7 @@ dependencies = [
 [[package]]
 name = "pyo3-macros"
 version = "0.15.0"
-source = "git+https://github.com/davidhewitt/pyo3.git?rev=51b6b947b82e61adad61524f9c58e3b1c89247a5#51b6b947b82e61adad61524f9c58e3b1c89247a5"
+source = "git+https://github.com/PyO3/pyo3.git?rev=45059cbdb81fd3ab72a5ce530e3b99cc90383327#45059cbdb81fd3ab72a5ce530e3b99cc90383327"
 dependencies = [
  "pyo3-macros-backend",
  "quote 1.0.10",
@@ -2373,10 +2373,10 @@ dependencies = [
 [[package]]
 name = "pyo3-macros-backend"
 version = "0.15.0"
-source = "git+https://github.com/davidhewitt/pyo3.git?rev=51b6b947b82e61adad61524f9c58e3b1c89247a5#51b6b947b82e61adad61524f9c58e3b1c89247a5"
+source = "git+https://github.com/PyO3/pyo3.git?rev=45059cbdb81fd3ab72a5ce530e3b99cc90383327#45059cbdb81fd3ab72a5ce530e3b99cc90383327"
 dependencies = [
  "proc-macro2 1.0.32",
- "pyo3-build-config 0.15.0 (git+https://github.com/davidhewitt/pyo3.git?rev=51b6b947b82e61adad61524f9c58e3b1c89247a5)",
+ "pyo3-build-config 0.15.0 (git+https://github.com/PyO3/pyo3.git?rev=45059cbdb81fd3ab72a5ce530e3b99cc90383327)",
  "quote 1.0.10",
  "syn 1.0.81",
 ]

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -135,7 +135,7 @@ parking_lot = "0.11"
 petgraph = "0.5"
 process_execution = { path = "process_execution" }
 # TODO: Switch back to official PyO3 once https://github.com/PyO3/pyo3/pull/1990 is released.
-pyo3 = { git = "https://github.com/davidhewitt/pyo3.git", rev = "51b6b947b82e61adad61524f9c58e3b1c89247a5" }
+pyo3 = { git = "https://github.com/PyO3/pyo3.git", rev = "45059cbdb81fd3ab72a5ce530e3b99cc90383327" }
 rand = "0.8"
 regex = "1"
 reqwest = { version = "0.11", default_features = false, features = ["stream", "rustls-tls"] }

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -400,7 +400,9 @@ impl Failure {
   }
 
   pub fn from_py_err_with_gil(py: Python, py_err: PyErr) -> Failure {
-    let maybe_ptraceback = py_err.ptraceback(py).map(|res| res.into_py(py));
+    let maybe_ptraceback = py_err
+      .ptraceback(py)
+      .map(|traceback| traceback.to_object(py));
     let val = Value::from(py_err.into_py(py));
     let python_traceback = if let Some(tb) = maybe_ptraceback {
       let locals = PyDict::new(py);


### PR DESCRIPTION
We were depending on a commit that was force-pushed so broke our build.

The PR from the maintainer's fork has now been merged into PyO3's main branch, so we can be more confident that this commit will not be force-pushed and will always exist.

The maintainer has said that they plan to do a stable release in a week.

[ci skip-build-wheels]