### PR TITLE
Fix Python dependency inference breaking with `python_source` targets

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -207,11 +207,12 @@ async def map_first_party_python_targets_to_modules(
         # `PythonSourceFile` validates that each target has exactly one file.
         assert len(stripped_sources) == 1
         stripped_f = PurePath(stripped_sources[0])
+        is_type_stub = stripped_f.suffix == ".pyi"
 
         module = PythonModule.create_from_stripped_path(stripped_f).module
         if module not in modules_to_addresses:
             modules_to_addresses[module].append(tgt.address)
-            if stripped_f.suffix == ".pyi":
+            if is_type_stub:
                 modules_with_type_stub.add(module)
             continue
 
@@ -221,10 +222,9 @@ async def map_first_party_python_targets_to_modules(
         prior_is_type_stub = (
             len(modules_to_addresses[module]) == 1 and module in modules_with_type_stub
         )
-        current_is_type_stub = stripped_f.suffix == ".pyi"
-        if prior_is_type_stub ^ current_is_type_stub:
+        if is_type_stub ^ prior_is_type_stub:
             modules_to_addresses[module].append(tgt.address)
-            if current_is_type_stub:
+            if is_type_stub:
                 modules_with_type_stub.add(module)
         else:
             modules_with_multiple_implementations[module].update(

--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -28,6 +28,7 @@ from pants.engine.target import AllTargets, SourcesPathsRequest, Target
 from pants.engine.unions import UnionMembership, UnionRule, union
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
+from pants.util.ordered_set import FrozenOrderedSet
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +81,7 @@ class FirstPartyPythonMappingImpl:
 
     mapping: FrozenDict[str, tuple[Address, ...]]
     ambiguous_modules: FrozenDict[str, tuple[Address, ...]]
+    modules_with_type_stub: FrozenOrderedSet[str] = FrozenOrderedSet()
 
 
 @union
@@ -104,6 +106,7 @@ class FirstPartyPythonModuleMapping:
 
     mapping: FrozenDict[str, tuple[Address, ...]]
     ambiguous_modules: FrozenDict[str, tuple[Address, ...]]
+    modules_with_type_stub: FrozenOrderedSet[str] = FrozenOrderedSet()
 
     def addresses_for_module(self, module: str) -> tuple[tuple[Address, ...], tuple[Address, ...]]:
         """Return all unambiguous and ambiguous addresses.
@@ -144,8 +147,7 @@ async def merge_first_party_module_mappings(
         for marker_cls in union_membership.get(FirstPartyPythonMappingImplMarker)
     )
 
-    # First, record all known ambiguous modules. We will need to check that an implementation's
-    # module is not ambiguous within another implementation.
+    # First, record all known ambiguous modules.
     modules_with_multiple_implementations: DefaultDict[str, set[Address]] = defaultdict(set)
     for mapping_impl in all_mappings:
         for module, addresses in mapping_impl.ambiguous_modules.items():
@@ -154,6 +156,7 @@ async def merge_first_party_module_mappings(
     # Then, merge the unambiguous modules within each MappingImpls while checking for ambiguity
     # across the other implementations.
     modules_to_addresses: dict[str, tuple[Address, ...]] = {}
+    modules_with_type_stub: set[str] = set()
     for mapping_impl in all_mappings:
         for module, addresses in mapping_impl.mapping.items():
             if module in modules_with_multiple_implementations:
@@ -164,17 +167,21 @@ async def merge_first_party_module_mappings(
                 )
             else:
                 modules_to_addresses[module] = addresses
+                if module in mapping_impl.modules_with_type_stub:
+                    modules_with_type_stub.add(module)
 
     # Finally, remove any newly ambiguous modules from the previous step.
     for module in modules_with_multiple_implementations:
         if module in modules_to_addresses:
             modules_to_addresses.pop(module)
+            modules_with_type_stub.discard(module)
 
     return FirstPartyPythonModuleMapping(
         mapping=FrozenDict(sorted(modules_to_addresses.items())),
         ambiguous_modules=FrozenDict(
             (k, tuple(sorted(v))) for k, v in sorted(modules_with_multiple_implementations.items())
         ),
+        modules_with_type_stub=FrozenOrderedSet(modules_with_type_stub),
     )
 
 
@@ -194,26 +201,31 @@ async def map_first_party_python_targets_to_modules(
     )
 
     modules_to_addresses: DefaultDict[str, list[Address]] = defaultdict(list)
+    modules_with_type_stub: set[str] = set()
     modules_with_multiple_implementations: DefaultDict[str, set[Address]] = defaultdict(set)
     for tgt, stripped_sources in zip(all_python_targets.first_party, stripped_sources_per_target):
         # `PythonSourceFile` validates that each target has exactly one file.
         assert len(stripped_sources) == 1
-        stripped_f = stripped_sources[0]
+        stripped_f = PurePath(stripped_sources[0])
 
-        module = PythonModule.create_from_stripped_path(PurePath(stripped_f)).module
+        module = PythonModule.create_from_stripped_path(stripped_f).module
         if module not in modules_to_addresses:
             modules_to_addresses[module].append(tgt.address)
+            if stripped_f.suffix == ".pyi":
+                modules_with_type_stub.add(module)
             continue
 
         # Else, possible ambiguity. Check if one of the targets is an implementation
         # (.py file) and the other is a type stub (.pyi file), which we allow. Otherwise, it's
         # ambiguous.
-        prior_is_type_stub = len(modules_to_addresses[module]) == 1 and modules_to_addresses[
-            module
-        ][0].filename.endswith(".pyi")
-        current_is_type_stub = tgt.address.filename.endswith(".pyi")
+        prior_is_type_stub = (
+            len(modules_to_addresses[module]) == 1 and module in modules_with_type_stub
+        )
+        current_is_type_stub = stripped_f.suffix == ".pyi"
         if prior_is_type_stub ^ current_is_type_stub:
             modules_to_addresses[module].append(tgt.address)
+            if current_is_type_stub:
+                modules_with_type_stub.add(module)
         else:
             modules_with_multiple_implementations[module].update(
                 {*modules_to_addresses[module], tgt.address}
@@ -222,12 +234,14 @@ async def map_first_party_python_targets_to_modules(
     # Remove modules with ambiguous owners.
     for module in modules_with_multiple_implementations:
         modules_to_addresses.pop(module)
+        modules_with_type_stub.discard(module)
 
     return FirstPartyPythonMappingImpl(
         mapping=FrozenDict((k, tuple(sorted(v))) for k, v in sorted(modules_to_addresses.items())),
         ambiguous_modules=FrozenDict(
             (k, tuple(sorted(v))) for k, v in sorted(modules_with_multiple_implementations.items())
         ),
+        modules_with_type_stub=FrozenOrderedSet(modules_with_type_stub),
     )
 
 
@@ -400,10 +414,11 @@ async def map_module_to_address(
     # otherwise, we have ambiguous implementations.
     if third_party_addresses and not first_party_addresses:
         return PythonModuleOwners(third_party_addresses)
-    first_party_is_type_stub = len(first_party_addresses) == 1 and first_party_addresses[
-        0
-    ].filename.endswith(".pyi")
-    if len(third_party_addresses) == 1 and first_party_is_type_stub:
+    first_party_is_type_stub = (
+        len(first_party_addresses) == 1
+        and module.module in first_party_mapping.modules_with_type_stub
+    )
+    if first_party_is_type_stub and len(third_party_addresses) == 1:
         return PythonModuleOwners((*third_party_addresses, *first_party_addresses))
     # Else, we have ambiguity between the third-party and first-party addresses.
     if third_party_addresses and first_party_addresses:

--- a/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
@@ -401,6 +401,12 @@ def test_map_module_to_address(rule_runner: RuleRunner) -> None:
         assert list(owners.unambiguous) == expected
         assert list(owners.ambiguous) == (expected_ambiguous or [])
 
+        from_import_owners = rule_runner.request(
+            PythonModuleOwners, [PythonModule(f"{module}.Class")]
+        )
+        assert list(from_import_owners.unambiguous) == expected
+        assert list(from_import_owners.ambiguous) == (expected_ambiguous or [])
+
     rule_runner.set_options(["--source-root-patterns=['root', '/']"])
     rule_runner.write_files(
         {
@@ -491,7 +497,7 @@ def test_map_module_to_address(rule_runner: RuleRunner) -> None:
         "dep_w_stub",
         [Address("", target_name="dep_w_stub"), Address("", target_name="dep_w_stub-types")],
     )
-    assert_owners("script.Demo", [Address("", target_name="script")])
+    assert_owners("script", [Address("", target_name="script")])
     assert_owners("no_stub.app", expected=[Address("root/no_stub", relative_file_path="app.py")])
     assert_owners(
         "stub.app",


### PR DESCRIPTION
It is no longer safe to rely on `Address.filename` because the `python_source` target might have been explicitly declared, rather than generated.

[ci skip-rust]
[ci skip-build-wheels]