### PR TITLE
[internal] scala: add basic extraction of consumed symbols

### DIFF
--- a/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
+++ b/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
@@ -19,6 +19,7 @@ case class Analysis(
 
 class SourceAnalysisTraverser extends Traverser {
   val nameParts = ArrayBuffer[String]()
+  var skipProvidedNames = false
 
   val providedNames = ArrayBuffer[String]()
   val importsByScope = HashMap[String, ArrayBuffer[AnImport]]()
@@ -28,6 +29,7 @@ class SourceAnalysisTraverser extends Traverser {
   def extractName(tree: Tree): String = {
     tree match {
       case Term.Select(qual, name) => s"${extractName(qual)}.${extractName(name)}"
+      case Type.Select(qual, name) => s"${extractName(qual)}.${extractName(name)}"
       case Term.Name(name) => name
       case Type.Name(name) => name
       case Pat.Var(node) => extractName(node)
@@ -37,8 +39,10 @@ class SourceAnalysisTraverser extends Traverser {
   }
 
   def recordProvidedName(name: String): Unit = {
-    val fullPackageName = nameParts.mkString(".")
-    providedNames.append(s"${fullPackageName}.${name}")
+    if (!skipProvidedNames) {
+      val fullPackageName = nameParts.mkString(".")
+      providedNames.append(s"${fullPackageName}.${name}")
+    }
   }
 
   def withNamePart[T](namePart: String, f: () => T): T = {
@@ -61,7 +65,15 @@ class SourceAnalysisTraverser extends Traverser {
     if (!consumedSymbolsByScope.contains(fullPackageName)) {
       consumedSymbolsByScope(fullPackageName) = HashSet[String]()
     }
-    consumedSymbolsByScope(fullPackageName).add(name, isWildcard)
+    consumedSymbolsByScope(fullPackageName).add(name)
+  }
+
+  def visitTemplate(templ: Template, name: String): Unit = {
+    templ.inits.foreach(init => apply(init))
+    withNamePart(name, () => {
+      apply(templ.early)
+      apply(templ.stats)
+    })
   }
 
   override def apply(tree: Tree): Unit = tree match {
@@ -72,19 +84,19 @@ class SourceAnalysisTraverser extends Traverser {
     case Defn.Class(_mods, nameNode, _tparams, _ctor, templ) => {
       val name = extractName(nameNode)
       recordProvidedName(name)
-      withNamePart(name, () => super.apply(templ))
+      visitTemplate(templ, name)
     }
 
     case Defn.Trait(_mods, nameNode, _tparams, _ctor, templ) => {
       val name = extractName(nameNode)
       recordProvidedName(name)
-      withNamePart(name, () => super.apply(templ))
+      visitTemplate(templ, name)
     }
 
     case Defn.Object(_mods, nameNode, templ) => {
       val name = extractName(nameNode)
       recordProvidedName(name)
-      withNamePart(name, () => super.apply(templ))
+      visitTemplate(templ, name)
     }
 
     case Defn.Type(_mods, nameNode, _tparams, _body) => {
@@ -92,18 +104,40 @@ class SourceAnalysisTraverser extends Traverser {
       recordProvidedName(name)
     }
 
-    case Defn.Val(_mods, pats, _decltpe, _rhs) => {
+    case Defn.Val(_mods, pats, decltpe, rhs) => {
       pats.headOption.foreach(pat => {
         val name = extractName(pat)
         recordProvidedName(name)
       })
+      decltpe.foreach(tpe => {
+        recordConsumedSymbol(extractName(tpe))
+      })
+      super.apply(rhs)
     }
 
-    case Defn.Var(_mods, pats, _decltpe, _rhs) => {
+    case Defn.Var(_mods, pats, decltpe, rhs) => {
       pats.headOption.foreach(pat => {
         val name = extractName(pat)
         recordProvidedName(name)
       })
+      decltpe.foreach(tpe => {
+        recordConsumedSymbol(extractName(tpe))
+      })
+      super.apply(rhs)
+    }
+
+    case Defn.Def(_mods, nameNode, _tparams, _paramss, decltpe, body) => {
+      val name = extractName(nameNode)
+      recordProvidedName(name)
+
+      decltpe.foreach(tpe => {
+        recordConsumedSymbol(extractName(tpe))
+      })
+
+      val oldSkipProvidedNames = skipProvidedNames
+      skipProvidedNames = true
+      apply(body)
+      skipProvidedNames = oldSkipProvidedNames
     }
 
     case Import(importers) => {
@@ -118,6 +152,21 @@ class SourceAnalysisTraverser extends Traverser {
           }
         })
       })
+    }
+
+    case Init(tpe, _name, _argss) => {
+      val name = extractName(tpe)
+      recordConsumedSymbol(name)
+    }
+
+    case node @ Term.Select(_, _) => {
+      val name = extractName(node)
+      recordConsumedSymbol(name)
+    }
+
+    case node @ Term.Name(_) => {
+      val name = extractName(node)
+      recordConsumedSymbol(name)
     }
 
     case node => super.apply(node)
@@ -139,6 +188,7 @@ object ScalaParser {
     Analysis(
       providedNames = analysisTraverser.providedNames.toVector,
       importsByScope = analysisTraverser.importsByScope,
+      consumedSymbolsByScope = analysisTraverser.consumedSymbolsByScope,
     )
   }
 

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -113,6 +113,7 @@ class ScalaImport:
 class ScalaSourceDependencyAnalysis:
     provided_names: FrozenOrderedSet[str]
     imports_by_scope: FrozenDict[str, tuple[ScalaImport, ...]]
+    consumed_symbols_by_scope: FrozenDict[str, FrozenOrderedSet[str]]
 
     def all_imports(self) -> frozenset[str]:
         all_symbols: Set[str] = set()
@@ -131,6 +132,12 @@ class ScalaSourceDependencyAnalysis:
                     for key, values in d["importsByScope"].items()
                 }
             ),
+            consumed_symbols_by_scope=FrozenDict(
+                {
+                    key: FrozenOrderedSet(values)
+                    for key, values in d["consumedSymbolsByScope"].items()
+                }
+            ),
         )
 
     def to_debug_json_dict(self) -> dict[str, Any]:
@@ -140,6 +147,7 @@ class ScalaSourceDependencyAnalysis:
                 key: [v.to_debug_json_dict() for v in values]
                 for key, values in self.imports_by_scope.items()
             },
+            "consumed_symbols_by_scope": self.consumed_symbols_by_scope,
         }
 
 

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -147,7 +147,9 @@ class ScalaSourceDependencyAnalysis:
                 key: [v.to_debug_json_dict() for v in values]
                 for key, values in self.imports_by_scope.items()
             },
-            "consumed_symbols_by_scope": self.consumed_symbols_by_scope,
+            "consumed_symbols_by_scope": {
+                k: sorted(list(v)) for k, v in self.consumed_symbols_by_scope.items()
+            },
         }
 
 

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
@@ -78,6 +78,7 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
                 }
                 type NestedType = Foo
                 object NestedObject {
+                  val valWithType: String = "foo"
                 }
             }
 
@@ -104,6 +105,16 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
                 object NestedObject {
                 }
             }
+
+            object Functions {
+              def func1(a: Integer): Unit = {
+                val a = foo + 5
+                val b = bar(5, "hello") + OuterObject.NestedVal
+              }
+            }
+
+            class ASubClass extends ABaseClass with ATrait1 with ATrait2.Nested { }
+            trait ASubTrait extends ATrait1 with ATrait2.Nested { }
             """
             ),
         }
@@ -136,6 +147,7 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
             "org.pantsbuild.example.OuterClass.NestedClass",
             "org.pantsbuild.example.OuterClass.NestedType",
             "org.pantsbuild.example.OuterClass.NestedObject",
+            "org.pantsbuild.example.OuterClass.NestedObject.valWithType",
             "org.pantsbuild.example.OuterTrait",
             "org.pantsbuild.example.OuterTrait.NestedVal",
             "org.pantsbuild.example.OuterTrait.NestedVar",
@@ -150,6 +162,10 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
             "org.pantsbuild.example.OuterObject.NestedClass",
             "org.pantsbuild.example.OuterObject.NestedType",
             "org.pantsbuild.example.OuterObject.NestedObject",
+            "org.pantsbuild.example.Functions",
+            "org.pantsbuild.example.Functions.func1",
+            "org.pantsbuild.example.ASubClass",
+            "org.pantsbuild.example.ASubTrait",
         ]
     )
 
@@ -163,5 +179,15 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
                 ScalaImport(name="scala.collection.mutable.HashMap", is_wildcard=False),
                 ScalaImport(name="java.io", is_wildcard=True),
             ),
+        }
+    )
+
+    assert analysis.consumed_symbols_by_scope == FrozenDict(
+        {
+            "org.pantsbuild.example.OuterClass.NestedObject": FrozenOrderedSet(["String"]),
+            "org.pantsbuild.example.Functions": FrozenOrderedSet(
+                ["bar", "foo", "OuterObject.NestedVal", "+", "Unit"]
+            ),
+            "org.pantsbuild.example": FrozenOrderedSet(["ABaseClass", "ATrait1", "ATrait2.Nested"]),
         }
     )


### PR DESCRIPTION
Add basic extraction of consumed symbols including inherited/implemented types and symbols used in expressions. The symbols are reported to the scope in which they were encountered. This PR does not update the inference code to use these symbols.