### PR TITLE
Ban `*` globs and `!` ignores in `source: str` field

### DIFF
--- a/src/python/pants/backend/shell/dependency_inference.py
+++ b/src/python/pants/backend/shell/dependency_inference.py
@@ -16,7 +16,7 @@ from pants.backend.shell.target_types import ShellSourceField
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.engine.addresses import Address
 from pants.engine.collection import DeduplicatedCollection
-from pants.engine.fs import Digest, DigestSubset, MergeDigests, PathGlobs
+from pants.engine.fs import Digest, MergeDigests
 from pants.engine.platform import Platform
 from pants.engine.process import FallibleProcessResult, Process, ProcessCacheScope
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
@@ -61,6 +61,7 @@ class ShellMapping:
 
 @rule(desc="Creating map of Shell file names to Shell targets", level=LogLevel.DEBUG)
 async def map_shell_files(tgts: AllShellTargets) -> ShellMapping:
+    # We could simply look at `ShellSourceField.file_path`, but we want to validate the file exists.
     sources_per_target = await MultiGet(
         Get(SourcesPaths, SourcesPathsRequest(tgt[ShellSourceField])) for tgt in tgts
     )
@@ -68,11 +69,12 @@ async def map_shell_files(tgts: AllShellTargets) -> ShellMapping:
     files_to_addresses: dict[str, Address] = {}
     files_with_multiple_owners: DefaultDict[str, set[Address]] = defaultdict(set)
     for tgt, sources in zip(tgts, sources_per_target):
-        for f in sources.files:
-            if f in files_to_addresses:
-                files_with_multiple_owners[f].update({files_to_addresses[f], tgt.address})
-            else:
-                files_to_addresses[f] = tgt.address
+        assert len(sources.files) == 1
+        fp = sources.files[0]
+        if fp in files_to_addresses:
+            files_with_multiple_owners[fp].update({files_to_addresses[fp], tgt.address})
+        else:
+            files_to_addresses[fp] = tgt.address
 
     # Remove files with ambiguous owners.
     for ambiguous_f in files_with_multiple_owners:
@@ -92,9 +94,6 @@ class ParsedShellImports(DeduplicatedCollection):
 
 @dataclass(frozen=True)
 class ParseShellImportsRequest:
-    # NB: We parse per-file, rather than per-target. This is necessary so that we can have each
-    # file in complete isolation without its sibling files present so that Shellcheck errors when
-    # trying to source a sibling file, which then allows us to extract that path.
     digest: Digest
     fp: str
 
@@ -176,32 +175,30 @@ async def infer_shell_dependencies(
         Get(ExplicitlyProvidedDependencies, DependenciesRequest(wrapped_tgt.target[Dependencies])),
         Get(HydratedSources, HydrateSourcesRequest(request.sources_field)),
     )
-    per_file_digests = await MultiGet(
-        Get(Digest, DigestSubset(hydrated_sources.snapshot.digest, PathGlobs([f])))
-        for f in hydrated_sources.snapshot.files
-    )
-    all_detected_imports = await MultiGet(
-        Get(ParsedShellImports, ParseShellImportsRequest(digest, f))
-        for digest, f in zip(per_file_digests, hydrated_sources.snapshot.files)
-    )
+    assert len(hydrated_sources.snapshot.files) == 1
 
+    detected_imports = await Get(
+        ParsedShellImports,
+        ParseShellImportsRequest(
+            hydrated_sources.snapshot.digest, hydrated_sources.snapshot.files[0]
+        ),
+    )
     result: OrderedSet[Address] = OrderedSet()
-    for detected_imports in all_detected_imports:
-        for import_path in detected_imports:
-            unambiguous = shell_mapping.mapping.get(import_path)
-            ambiguous = shell_mapping.ambiguous_modules.get(import_path)
-            if unambiguous:
-                result.add(unambiguous)
-            elif ambiguous:
-                explicitly_provided_deps.maybe_warn_of_ambiguous_dependency_inference(
-                    ambiguous,
-                    address,
-                    import_reference="file",
-                    context=f"The target {address} sources `{import_path}`",
-                )
-                maybe_disambiguated = explicitly_provided_deps.disambiguated(ambiguous)
-                if maybe_disambiguated:
-                    result.add(maybe_disambiguated)
+    for import_path in detected_imports:
+        unambiguous = shell_mapping.mapping.get(import_path)
+        ambiguous = shell_mapping.ambiguous_modules.get(import_path)
+        if unambiguous:
+            result.add(unambiguous)
+        elif ambiguous:
+            explicitly_provided_deps.maybe_warn_of_ambiguous_dependency_inference(
+                ambiguous,
+                address,
+                import_reference="file",
+                context=f"The target {address} sources `{import_path}`",
+            )
+            maybe_disambiguated = explicitly_provided_deps.disambiguated(ambiguous)
+            if maybe_disambiguated:
+                result.add(maybe_disambiguated)
     return InferredDependencies(sorted(result))
 
 

--- a/src/python/pants/backend/shell/dependency_inference.py
+++ b/src/python/pants/backend/shell/dependency_inference.py
@@ -61,7 +61,6 @@ class ShellMapping:
 
 @rule(desc="Creating map of Shell file names to Shell targets", level=LogLevel.DEBUG)
 async def map_shell_files(tgts: AllShellTargets) -> ShellMapping:
-    # We could simply look at `ShellSourceField.file_path`, but we want to validate the file exists.
     sources_per_target = await MultiGet(
         Get(SourcesPaths, SourcesPathsRequest(tgt[ShellSourceField])) for tgt in tgts
     )

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -1312,17 +1312,6 @@ def test_sources_expected_num_files(sources_rule_runner: RuleRunner) -> None:
         "f3.txt",
     )
 
-    # `SingleSourceField` must have one file.
-    with engine_error(contains="must have 1 file"):
-        sources_rule_runner.request(
-            HydratedSources,
-            [
-                HydrateSourcesRequest(
-                    SingleSourceField("*.txt", Address("", target_name="example"))
-                ),
-            ],
-        )
-
 
 # -----------------------------------------------------------------------------------------------
 # Test codegen. Also see `engine/target_test.py`.

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1729,20 +1729,6 @@ class SingleSourceField(SourcesField, StringField):
         return value_or_default
 
     @property
-    def file_path(self) -> str | None:
-        """The path to the file, relative to the build root.
-
-        This works without hydration because we validate that `*` globs and `!` ignores are not
-        used. However, consider still hydrating so that you verify the source file actually exists.
-
-        The return type is optional because it's possible to have 0-1 files. Most subclasses
-        will have 1 file, though.
-        """
-        if self.value is None:
-            return None
-        return os.path.join(self.address.spec_path, self.value)
-
-    @property
     def globs(self) -> tuple[str, ...]:
         # Subclasses might override `required = False`, so `self.value` could be `None`.
         if self.value is None:

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -1127,6 +1127,25 @@ def test_single_source_path_globs(
             assert getattr(actual, attr) == expect
 
 
+def test_single_source_file_path() -> None:
+    class TestSingleSourceField(SingleSourceField):
+        required = False
+        expected_num_files = range(0, 2)
+
+    assert TestSingleSourceField(None, Address("project")).file_path is None
+    assert TestSingleSourceField("f.ext", Address("project")).file_path == "project/f.ext"
+
+
+def test_single_source_field_bans_globs() -> None:
+    class TestSingleSourceField(SingleSourceField):
+        pass
+
+    with pytest.raises(InvalidFieldException):
+        TestSingleSourceField("*.ext", Address("project"))
+    with pytest.raises(InvalidFieldException):
+        TestSingleSourceField("!f.ext", Address("project"))
+
+
 # -----------------------------------------------------------------------------------------------
 # Test `ExplicitlyProvidedDependencies` helper functions
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -1127,15 +1127,6 @@ def test_single_source_path_globs(
             assert getattr(actual, attr) == expect
 
 
-def test_single_source_file_path() -> None:
-    class TestSingleSourceField(SingleSourceField):
-        required = False
-        expected_num_files = range(0, 2)
-
-    assert TestSingleSourceField(None, Address("project")).file_path is None
-    assert TestSingleSourceField("f.ext", Address("project")).file_path == "project/f.ext"
-
-
 def test_single_source_field_bans_globs() -> None:
     class TestSingleSourceField(SingleSourceField):
         pass


### PR DESCRIPTION
There's no reason to support them. The `SingleSourceField` should be 0-1 file, so a glob would cause an error. While it is technically possible to have a glob that only matches one file, that's error-prone.

Enforcing this unblocks us from rendering a useful file name representing the target type in more places without needing to hydrate. For example, our streaming workunit handler code uses `Address.filename`, but that doesn't work with manually created per-file targets like `python_source`: https://github.com/pantsbuild/pants/pull/13627. This PR means that we can instead use `SingleSourceField.file_path` for the same effect.