### PR TITLE
[jvm] Add consumed-symbols inference for `scala`.

### DIFF
--- a/src/python/pants/backend/scala/dependency_inference/rules.py
+++ b/src/python/pants/backend/scala/dependency_inference/rules.py
@@ -56,6 +56,8 @@ async def infer_scala_dependencies_via_source_analysis(
     symbols: OrderedSet[str] = OrderedSet()
     if scala_infer_subsystem.imports:
         symbols.update(analysis.all_imports())
+    if scala_infer_subsystem.consumed_types:
+        symbols.update(analysis.fully_qualified_consumed_symbols())
 
     dependencies: OrderedSet[Address] = OrderedSet()
     for symbol in symbols:

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
@@ -203,3 +203,37 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
             ),
         }
     )
+
+    assert set(analysis.fully_qualified_consumed_symbols()) == {
+        # Because they contain dots, and thus might be fully qualified. See #13545.
+        "ATrait2.Nested",
+        "OuterObject.NestedVal",
+        # Because of the wildcard import.
+        "java.io.+",
+        "java.io.ABaseClass",
+        "java.io.AParameterType",
+        "java.io.ATrait1",
+        "java.io.ATrait2.Nested",
+        "java.io.BaseWithConstructor",
+        "java.io.OuterObject.NestedVal",
+        "java.io.String",
+        "java.io.Unit",
+        "java.io.Integer",
+        "java.io.SomeTypeInSecondaryConstructor",
+        "java.io.bar",
+        "java.io.foo",
+        # Because it's the top-most scope in the file.
+        "org.pantsbuild.example.+",
+        "org.pantsbuild.example.ABaseClass",
+        "org.pantsbuild.example.AParameterType",
+        "org.pantsbuild.example.BaseWithConstructor",
+        "org.pantsbuild.example.Integer",
+        "org.pantsbuild.example.SomeTypeInSecondaryConstructor",
+        "org.pantsbuild.example.ATrait1",
+        "org.pantsbuild.example.ATrait2.Nested",
+        "org.pantsbuild.example.OuterObject.NestedVal",
+        "org.pantsbuild.example.String",
+        "org.pantsbuild.example.Unit",
+        "org.pantsbuild.example.bar",
+        "org.pantsbuild.example.foo",
+    }

--- a/src/python/pants/backend/scala/subsystems/scala_infer.py
+++ b/src/python/pants/backend/scala/subsystems/scala_infer.py
@@ -18,7 +18,17 @@ class ScalaInferSubsystem(Subsystem):
             type=bool,
             help="Infer a target's dependencies by parsing import statements from sources.",
         )
+        register(
+            "--consumed-types",
+            default=True,
+            type=bool,
+            help=("Infer a target's dependencies by parsing consumed types from sources."),
+        )
 
     @property
     def imports(self) -> bool:
         return cast(bool, self.options.imports)
+
+    @property
+    def consumed_types(self) -> bool:
+        return cast(bool, self.options.consumed_types)


### PR DESCRIPTION
Consumes #13628 and uses it to infer consumed types. Experiments in larger repos show improved results.

There are a few different sources of false positives here: see the TODOs.

[ci skip-rust]
[ci skip-build-wheels]