### PR TITLE
Ban `*` globs and `!` ignores in `source: str` field (Cherry-pick of #13629)

### DIFF
--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -1311,17 +1311,6 @@ def test_sources_expected_num_files(sources_rule_runner: RuleRunner) -> None:
         "f3.txt",
     )
 
-    # `SingleSourceField` must have one file.
-    with engine_error(contains="must have 1 file"):
-        sources_rule_runner.request(
-            HydratedSources,
-            [
-                HydrateSourcesRequest(
-                    SingleSourceField("*.txt", Address("", target_name="example"))
-                ),
-            ],
-        )
-
 
 # -----------------------------------------------------------------------------------------------
 # Test codegen. Also see `engine/target_test.py`.

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1697,6 +1697,25 @@ class SingleSourceField(SourcesField, StringField):
     required = True
     expected_num_files: ClassVar[int | range] = 1  # Can set to `range(0, 2)` for 0-1 files.
 
+    @classmethod
+    def compute_value(cls, raw_value: Optional[str], address: Address) -> Optional[str]:
+        value_or_default = super().compute_value(raw_value, address)
+        if value_or_default is None:
+            return None
+        if "*" in value_or_default:
+            raise InvalidFieldException(
+                f"The {repr(cls.alias)} field in target {address} should not include `*` globs, "
+                f"but was set to {value_or_default}. Instead, use a literal file path (relative "
+                "to the BUILD file)."
+            )
+        if value_or_default.startswith("!"):
+            raise InvalidFieldException(
+                f"The {repr(cls.alias)} field in target {address} should not start with `!`, which "
+                f"is usually used in the `sources` field to exclude certain files. Instead, use a "
+                "literal file path (relative to the BUILD file)."
+            )
+        return value_or_default
+
     @property
     def globs(self) -> tuple[str, ...]:
         # Subclasses might override `required = False`, so `self.value` could be `None`.

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -1008,6 +1008,16 @@ def test_targets_with_sources_types() -> None:
     assert set(result) == {tgt2}
 
 
+def test_single_source_field_bans_globs() -> None:
+    class TestSingleSourceField(SingleSourceField):
+        pass
+
+    with pytest.raises(InvalidFieldException):
+        TestSingleSourceField("*.ext", Address("project"))
+    with pytest.raises(InvalidFieldException):
+        TestSingleSourceField("!f.ext", Address("project"))
+
+
 # -----------------------------------------------------------------------------------------------
 # Test `ExplicitlyProvidedDependencies` helper functions
 # -----------------------------------------------------------------------------------------------


### PR DESCRIPTION
There's no reason to support them. The `SingleSourceField` should be 0-1 file, so a glob would cause an error. While it is technically possible to have a glob that only matches one file, that's error-prone.

Enforcing this unblocks us from rendering a useful file name representing the target type in more places without needing to hydrate. For example, our streaming workunit handler code uses `Address.filename`, but that doesn't work with manually created per-file targets like `python_source`: https://github.com/pantsbuild/pants/pull/13627. This PR means that we can instead use `SingleSourceField.file_path` for the same effect.

[ci skip-rust]
[ci skip-build-wheels]