### PR TITLE
Make the pex-from-targets functionality more modular.

### DIFF
--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -10,7 +10,7 @@ from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import VenvPex, VenvPexProcess
 from pants.backend.python.util_rules.pex_environment import PexEnvironment
-from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
+from pants.backend.python.util_rules.pex_from_targets import RequirementsPexRequest
 from pants.core.goals.export import ExportableData, ExportableDataRequest, ExportError, Symlink
 from pants.engine.internals.selectors import Get
 from pants.engine.process import ProcessResult
@@ -45,8 +45,7 @@ async def export_venv(
 
     venv_pex = await Get(
         VenvPex,
-        PexFromTargetsRequest,
-        PexFromTargetsRequest.for_requirements(
+        RequirementsPexRequest(
             (tgt.address for tgt in request.targets),
             internal_only=True,
             hardcoded_interpreter_constraints=min_interpreter,

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -16,7 +16,7 @@ from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.local_dists import LocalDistsPex, LocalDistsPexRequest
 from pants.backend.python.util_rules.pex import Pex, PexRequest, VenvPex, VenvPexProcess
-from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
+from pants.backend.python.util_rules.pex_from_targets import RequirementsPexRequest
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
     PythonSourceFilesRequest,
@@ -170,8 +170,7 @@ async def setup_pytest_for_target(
 
     requirements_pex_get = Get(
         Pex,
-        PexFromTargetsRequest,
-        PexFromTargetsRequest.for_requirements(
+        RequirementsPexRequest(
             [request.field_set.address],
             internal_only=True,
             resolve_and_lockfile=request.field_set.resolve.resolve_and_lockfile(python_setup),

--- a/src/python/pants/backend/python/goals/run_pex_binary.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary.py
@@ -10,10 +10,14 @@ from pants.backend.python.target_types import (
     ResolvedPexEntryPoint,
     ResolvePexEntryPointRequest,
 )
+from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.local_dists import LocalDistsPex, LocalDistsPexRequest
-from pants.backend.python.util_rules.pex import Pex, PexRequest
+from pants.backend.python.util_rules.pex import Pex
 from pants.backend.python.util_rules.pex_environment import PexEnvironment
-from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
+from pants.backend.python.util_rules.pex_from_targets import (
+    InterpreterConstraintsRequest,
+    PexFromTargetsRequest,
+)
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
     PythonSourceFilesRequest,
@@ -41,10 +45,13 @@ async def create_pex_binary_run_request(
         Get(TransitiveTargets, TransitiveTargetsRequest([field_set.address])),
     )
 
-    # Note that we get an intermediate PexRequest here (instead of going straight to a Pex)
-    # so that we can get the interpreter constraints for use in local_dists_get.
-    requirements_pex_request = await Get(
-        PexRequest,
+    addresses = [field_set.address]
+    interpreter_constraints = await Get(
+        InterpreterConstraints, InterpreterConstraintsRequest(addresses)
+    )
+
+    pex_get = Get(
+        Pex,
         PexFromTargetsRequest(
             [field_set.address],
             output_filename=f"{field_set.address.target_name}.pex",
@@ -63,7 +70,6 @@ async def create_pex_binary_run_request(
             ),
         ),
     )
-    pex_get = Get(Pex, PexRequest, requirements_pex_request)
     sources_get = Get(
         PythonSourceFiles, PythonSourceFilesRequest(transitive_targets.closure, include_files=True)
     )
@@ -74,7 +80,7 @@ async def create_pex_binary_run_request(
         LocalDistsPexRequest(
             [field_set.address],
             internal_only=True,
-            interpreter_constraints=requirements_pex_request.interpreter_constraints,
+            interpreter_constraints=interpreter_constraints,
             sources=sources,
         ),
     )

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -15,7 +15,7 @@ from pants.backend.python.target_types import InterpreterConstraintsField
 from pants.backend.python.util_rules import pex_from_targets
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import Pex, PexRequest, VenvPex, VenvPexProcess
-from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
+from pants.backend.python.util_rules.pex_from_targets import RequirementsPexRequest
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
     PythonSourceFilesRequest,
@@ -82,8 +82,7 @@ async def pylint_lint_partition(
 ) -> LintResult:
     requirements_pex_get = Get(
         Pex,
-        PexFromTargetsRequest,
-        PexFromTargetsRequest.for_requirements(
+        RequirementsPexRequest(
             (field_set.address for field_set in partition.field_sets),
             # NB: These constraints must be identical to the other PEXes. Otherwise, we risk using
             # a different version for the requirements than the other two PEXes, which can result

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -23,7 +23,7 @@ from pants.backend.python.util_rules.pex import (
     VenvPex,
     VenvPexProcess,
 )
-from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
+from pants.backend.python.util_rules.pex_from_targets import RequirementsPexRequest
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
     PythonSourceFilesRequest,
@@ -130,8 +130,7 @@ async def mypy_typecheck_partition(
     # See `requirements_venv_pex` for how this will get wrapped in a `VenvPex`.
     requirements_pex_get = Get(
         Pex,
-        PexFromTargetsRequest,
-        PexFromTargetsRequest.for_requirements(
+        RequirementsPexRequest(
             (tgt.address for tgt in partition.root_targets),
             hardcoded_interpreter_constraints=partition.interpreter_constraints,
             internal_only=True,

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -41,6 +41,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     Dependencies,
     DependenciesRequest,
+    Target,
     Targets,
     TransitiveTargets,
     TransitiveTargetsRequest,
@@ -111,10 +112,10 @@ class PexFromTargetsRequest:
             interpreter constraints to not be used because platforms already constrain the valid
             Python versions, e.g. by including `cp36m` in the platform string.
         :param additional_args: Any additional Pex flags.
-        :param additional_args: Any additional Pex flags that should be used with the lockfile.pex.
-            Many Pex args like `--emit-warnings` do not impact the lockfile, and setting them
-            would reduce reuse with other call sites. Generally, this should only be flags that
-            impact lockfile resolution like `--manylinux`.
+        :param additional_lockfile_args: Any additional Pex flags that should be used with the
+            lockfile.pex. Many Pex args like `--emit-warnings` do not impact the lockfile, and
+            setting them would reduce reuse with other call sites. Generally, these should only be
+            flags that impact lockfile resolution like `--manylinux`.
         :param additional_requirements: Additional requirements to install, in addition to any
             requirements used by the transitive closure of the given addresses.
         :param include_source_files: Whether to include source files in the built Pex or not.
@@ -150,30 +151,83 @@ class PexFromTargetsRequest:
         self.direct_deps_only = direct_deps_only
         self.description = description
 
-    @classmethod
-    def for_requirements(
-        cls,
+
+@frozen_after_init
+@dataclass(unsafe_hash=True)
+class _RelevantTargetsRequest:
+    addresses: Addresses
+    direct_deps_only: bool
+
+    def __init__(
+        self,
         addresses: Iterable[Address],
         *,
-        internal_only: bool,
+        direct_deps_only: bool = False,
+    ) -> None:
+        self.addresses = Addresses(addresses)
+        self.direct_deps_only = direct_deps_only
+
+
+@dataclass(frozen=True)
+class _RelevantTargets:
+    targets: FrozenOrderedSet[Target]
+
+
+@rule
+async def get_relevant_targets(request: _RelevantTargetsRequest) -> _RelevantTargets:
+    if request.direct_deps_only:
+        targets = await Get(Targets, Addresses(request.addresses))
+        direct_deps = await MultiGet(
+            Get(Targets, DependenciesRequest(tgt.get(Dependencies))) for tgt in targets
+        )
+        relevant_targets = FrozenOrderedSet(itertools.chain(*direct_deps, targets))
+    else:
+        transitive_targets = await Get(
+            TransitiveTargets, TransitiveTargetsRequest(request.addresses)
+        )
+        relevant_targets = transitive_targets.closure
+    return _RelevantTargets(relevant_targets)
+
+
+@frozen_after_init
+@dataclass(unsafe_hash=True)
+class InterpreterConstraintsRequest:
+    addresses: Addresses
+    hardcoded_interpreter_constraints: InterpreterConstraints | None
+    direct_deps_only: bool
+
+    def __init__(
+        self,
+        addresses: Iterable[Address],
+        *,
         hardcoded_interpreter_constraints: InterpreterConstraints | None = None,
         direct_deps_only: bool = False,
-        resolve_and_lockfile: tuple[str, str] | None = None,
-    ) -> PexFromTargetsRequest:
-        """Create an instance that can be used to get a requirements pex.
+    ) -> None:
+        self.addresses = Addresses(addresses)
+        self.hardcoded_interpreter_constraints = hardcoded_interpreter_constraints
+        self.direct_deps_only = direct_deps_only
 
-        Useful to ensure that these requests are uniform (e.g., the using the same output filename),
-        so that the underlying pexes are more likely to be reused instead of re-resolved.
-        """
-        return PexFromTargetsRequest(
-            addresses=sorted(addresses),
-            output_filename="requirements.pex",
-            include_source_files=False,
-            hardcoded_interpreter_constraints=hardcoded_interpreter_constraints,
-            internal_only=internal_only,
-            direct_deps_only=direct_deps_only,
-            resolve_and_lockfile=resolve_and_lockfile,
-        )
+
+@rule
+async def interpreter_constraints_for_targets(
+    request: InterpreterConstraintsRequest, python_setup: PythonSetup
+) -> InterpreterConstraints:
+    if request.hardcoded_interpreter_constraints:
+        return request.hardcoded_interpreter_constraints
+
+    relevant_targets = await Get(
+        _RelevantTargets,
+        _RelevantTargetsRequest(request.addresses, direct_deps_only=request.direct_deps_only),
+    )
+    calculated_constraints = InterpreterConstraints.create_from_targets(
+        relevant_targets.targets, python_setup
+    )
+    # If there are no targets, we fall back to the global constraints. This is relevant,
+    # for example, when running `./pants repl` with no specs.
+    interpreter_constraints = calculated_constraints or InterpreterConstraints(
+        python_setup.interpreter_constraints
+    )
+    return interpreter_constraints
 
 
 @dataclass(frozen=True)
@@ -197,36 +251,26 @@ class _ConstraintsRepositoryPexRequest:
 
 
 @rule(level=LogLevel.DEBUG)
-async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonSetup) -> PexRequest:
-    if request.direct_deps_only:
-        targets = await Get(Targets, Addresses(request.addresses))
-        direct_deps = await MultiGet(
-            Get(Targets, DependenciesRequest(tgt.get(Dependencies))) for tgt in targets
-        )
-        all_targets = FrozenOrderedSet(itertools.chain(*direct_deps, targets))
-    else:
-        transitive_targets = await Get(
-            TransitiveTargets, TransitiveTargetsRequest(request.addresses)
-        )
-        all_targets = transitive_targets.closure
+async def pex_from_targets(request: PexFromTargetsRequest) -> PexRequest:
+    interpreter_constraints = await Get(
+        InterpreterConstraints,
+        InterpreterConstraintsRequest(
+            request.addresses,
+            hardcoded_interpreter_constraints=request.hardcoded_interpreter_constraints,
+            direct_deps_only=request.direct_deps_only,
+        ),
+    )
 
-    if request.hardcoded_interpreter_constraints:
-        interpreter_constraints = request.hardcoded_interpreter_constraints
-    else:
-        calculated_constraints = InterpreterConstraints.create_from_targets(
-            all_targets, python_setup
-        )
-        # If there are no targets, we fall back to the global constraints. This is relevant,
-        # for example, when running `./pants repl` with no specs.
-        interpreter_constraints = calculated_constraints or InterpreterConstraints(
-            python_setup.interpreter_constraints
-        )
+    relevant_targets = await Get(
+        _RelevantTargets,
+        _RelevantTargetsRequest(request.addresses, direct_deps_only=request.direct_deps_only),
+    )
 
     sources_digests = []
     if request.additional_sources:
         sources_digests.append(request.additional_sources)
     if request.include_source_files:
-        sources = await Get(PythonSourceFiles, PythonSourceFilesRequest(all_targets))
+        sources = await Get(PythonSourceFiles, PythonSourceFilesRequest(relevant_targets.targets))
     else:
         sources = PythonSourceFiles.empty()
 
@@ -267,7 +311,7 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
     requirements = PexRequirements.create_from_requirement_fields(
         (
             tgt[PythonRequirementsField]
-            for tgt in all_targets
+            for tgt in relevant_targets.targets
             if tgt.has_field(PythonRequirementsField)
         ),
         additional_requirements=request.additional_requirements,
@@ -453,6 +497,48 @@ async def _setup_constraints_repository_pex(
         ),
     )
     return _RepositoryPex(repository_pex)
+
+
+@frozen_after_init
+@dataclass(unsafe_hash=True)
+class RequirementsPexRequest:
+    addresses: tuple[Address, ...]
+    internal_only: bool
+    hardcoded_interpreter_constraints: InterpreterConstraints | None
+    direct_deps_only: bool
+    resolve_and_lockfile: tuple[str, str] | None
+
+    def __init__(
+        self,
+        addresses: Iterable[Address],
+        *,
+        internal_only: bool,
+        hardcoded_interpreter_constraints: InterpreterConstraints | None = None,
+        direct_deps_only: bool = False,
+        resolve_and_lockfile: tuple[str, str] | None = None,
+    ) -> None:
+        self.addresses = Addresses(addresses)
+        self.internal_only = internal_only
+        self.hardcoded_interpreter_constraints = hardcoded_interpreter_constraints
+        self.direct_deps_only = direct_deps_only
+        self.resolve_and_lockfile = resolve_and_lockfile
+
+
+@rule
+async def get_requirements_pex(request: RequirementsPexRequest) -> PexRequest:
+    pex_request = await Get(
+        PexRequest,
+        PexFromTargetsRequest(
+            addresses=sorted(request.addresses),
+            output_filename="requirements.pex",
+            include_source_files=False,
+            hardcoded_interpreter_constraints=request.hardcoded_interpreter_constraints,
+            internal_only=request.internal_only,
+            direct_deps_only=request.direct_deps_only,
+            resolve_and_lockfile=request.resolve_and_lockfile,
+        ),
+    )
+    return pex_request
 
 
 def rules():


### PR DESCRIPTION
This change replaces a couple of not-great idioms with more engine-centric ones.

- Occasionally, instead of going from PexFromTargetsRequest to Pex, we'd request an intermediate PexRequest, 
  so we could read interpreter constraints off it. This change makes requesting InterpreterConstraints off a 
  target set a first class thing. The engine ensures that even if they are requested in multiple places, 
  we only compute them once.

- This change also gets rid of `PexFromTargetsRequest.for_requirements()`. Instead, you request a 
  RequirementsPexRequest. This provides a formal engine type to represent a requirements pex, 
  instead of its representation being implicitly "a PexFromTargetsRequest that happens to be set up a 
  certain way".

[ci skip-rust]

[ci skip-build-wheels]