### PR TITLE
Add `[twine].ca_certs_path` option. (Cherry-pick of #13593)

### DIFF
--- a/build-support/bin/_generate_all_lockfiles_helper.py
+++ b/build-support/bin/_generate_all_lockfiles_helper.py
@@ -28,7 +28,7 @@ from pants.backend.python.subsystems.lambdex import Lambdex
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.subsystems.setuptools import Setuptools
-from pants.backend.python.subsystems.twine import Twine
+from pants.backend.python.subsystems.twine import TwineSubsystem
 from pants.backend.python.typecheck.mypy.subsystem import MyPy
 from pants.backend.terraform.dependency_inference import TerraformHcl2Parser
 
@@ -157,10 +157,10 @@ def main() -> None:
             f"--dockerfile-parser-interpreter-constraints={repr(DockerfileParser.default_interpreter_constraints)}",
             f"--dockerfile-parser-lockfile={DockerfileParser.default_lockfile_path}",
             # Twine.
-            f"--twine-version={Twine.default_version}",
-            f"--twine-extra-requirements={repr(Twine.default_extra_requirements)}",
-            f"--twine-interpreter-constraints={repr(Twine.default_interpreter_constraints)}",
-            f"--twine-lockfile={Twine.default_lockfile_path}",
+            f"--twine-version={TwineSubsystem.default_version}",
+            f"--twine-extra-requirements={repr(TwineSubsystem.default_extra_requirements)}",
+            f"--twine-interpreter-constraints={repr(TwineSubsystem.default_interpreter_constraints)}",
+            f"--twine-lockfile={TwineSubsystem.default_lockfile_path}",
             # Run the goal.
             "generate-lockfiles",
         ],

--- a/src/python/pants/backend/python/goals/publish.py
+++ b/src/python/pants/backend/python/goals/publish.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
-from pants.backend.python.subsystems.twine import Twine
+from pants.backend.python.subsystems.twine import TwineSubsystem
 from pants.backend.python.target_types import PythonDistribution
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.core.goals.publish import (
@@ -18,10 +18,11 @@ from pants.core.goals.publish import (
 )
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.engine.environment import Environment, EnvironmentRequest
-from pants.engine.fs import Digest, MergeDigests
+from pants.engine.fs import CreateDigest, Digest, MergeDigests, Snapshot
 from pants.engine.process import InteractiveProcess, Process
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import BoolField, StringSequenceField
+from pants.option.global_options import GlobalOptions
 
 logger = logging.getLogger(__name__)
 
@@ -69,9 +70,16 @@ class PublishToPyPiFieldSet(PublishFieldSet):
 
 
 def twine_upload_args(
-    twine_subsystem: Twine, config_files: ConfigFiles, repo: str, dists: tuple[str, ...]
+    twine_subsystem: TwineSubsystem,
+    config_files: ConfigFiles,
+    repo: str,
+    dists: tuple[str, ...],
+    ca_cert: Snapshot | None,
 ) -> tuple[str, ...]:
     args = ["upload", "--non-interactive"]
+
+    if ca_cert and ca_cert.files:
+        args.append(f"--cert={ca_cert.files[0]}")
 
     if config_files.snapshot.files:
         args.append(f"--config-file={config_files.snapshot.files[0]}")
@@ -101,7 +109,6 @@ def twine_env_request(repo: str) -> EnvironmentRequest:
                 "TWINE_USERNAME",
                 "TWINE_PASSWORD",
                 "TWINE_REPOSITORY_URL",
-                # "TWINE_CERT",  # Does the --cert arg to pex take care of this for us?
             ]
         ]
     )
@@ -117,7 +124,9 @@ def twine_env(env: Environment, repo: str) -> Environment:
 
 
 @rule
-async def twine_upload(request: PublishToPyPiRequest, twine_subsystem: Twine) -> PublishProcesses:
+async def twine_upload(
+    request: PublishToPyPiRequest, twine_subsystem: TwineSubsystem, global_options: GlobalOptions
+) -> PublishProcesses:
     dists = tuple(
         artifact.relpath
         for pkg in request.packages
@@ -162,7 +171,13 @@ async def twine_upload(request: PublishToPyPiRequest, twine_subsystem: Twine) ->
         Get(ConfigFiles, ConfigFilesRequest, twine_subsystem.config_request()),
     )
 
-    input_digest = await Get(Digest, MergeDigests((packages_digest, config_files.snapshot.digest)))
+    ca_cert_request = twine_subsystem.ca_certs_digest_request(global_options.options.ca_certs_path)
+    ca_cert = await Get(Snapshot, CreateDigest, ca_cert_request) if ca_cert_request else None
+    ca_cert_digest = (ca_cert.digest,) if ca_cert else ()
+
+    input_digest = await Get(
+        Digest, MergeDigests((packages_digest, config_files.snapshot.digest, *ca_cert_digest))
+    )
     pex_proc_requests = []
     twine_envs = await MultiGet(
         Get(Environment, EnvironmentRequest, twine_env_request(repo))
@@ -173,7 +188,7 @@ async def twine_upload(request: PublishToPyPiRequest, twine_subsystem: Twine) ->
         pex_proc_requests.append(
             VenvPexProcess(
                 twine_pex,
-                argv=twine_upload_args(twine_subsystem, config_files, repo, dists),
+                argv=twine_upload_args(twine_subsystem, config_files, repo, dists, ca_cert),
                 input_digest=input_digest,
                 extra_env=twine_env(env, repo),
                 description=repo,

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -365,8 +365,6 @@ def validate_commands(commands: tuple[str, ...]):
     # happens in dependency order).  Note that `upload` and `register` were removed in
     # setuptools 42.0.0, in favor of Twine, but we still check for them in case the user modified
     # the default version used by our Setuptools subsystem.
-    # TODO: A `publish` rule, that can invoke Twine to do the actual uploading.
-    #  See https://github.com/pantsbuild/pants/issues/8935.
     if "upload" in commands or "register" in commands:
         raise InvalidSetupPyArgs("Cannot use the `upload` or `register` setup.py commands.")
 

--- a/src/python/pants/engine/internals/selectors.py
+++ b/src/python/pants/engine/internals/selectors.py
@@ -260,7 +260,7 @@ class _MultiGet:
         return cast(Tuple, result)
 
 
-# These type variables are used to parameterize from 1 to 10 Gets when used in a tuple-style
+# These type variables are used to parametrize from 1 to 10 Gets when used in a tuple-style
 # MultiGet call.
 
 _Out0 = TypeVar("_Out0")


### PR DESCRIPTION
When publishing to a cheese chop, support providing custom ca bundle for the uploads.

Defaults to use the ca bundle configured for downloads in `[GLOBAL].ca_certs_path`.
I think it is a reasonable assumption to make that it will be the same ca bundle to use for any custom certificate authority, in most cases.

[ci skip-rust]
[ci skip-build-wheels]