### PR TITLE
[internal] upgrade to Rust 2021 Edition

### DIFF
--- a/build-support/bin/check_rust_target_headers.sh
+++ b/build-support/bin/check_rust_target_headers.sh
@@ -2,7 +2,8 @@
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-"${REPO_ROOT}/cargo" install cargo-ensure-prefix --version "=0.1.3"
+"${REPO_ROOT}/cargo" install cargo-ensure-prefix \
+  --git=https://github.com/pantsbuild/cargo-ensure-prefix --branch=upgrade_deps_for_rust_2021_support
 
 if ! out="$("${REPO_ROOT}/cargo" ensure-prefix \
   --manifest-path="${REPO_ROOT}/src/rust/engine/Cargo.toml" \

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 name = "engine"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false

--- a/src/rust/engine/async_latch/Cargo.toml
+++ b/src/rust/engine/async_latch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 name = "async_latch"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false

--- a/src/rust/engine/async_semaphore/Cargo.toml
+++ b/src/rust/engine/async_semaphore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 name = "async_semaphore"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false

--- a/src/rust/engine/async_value/Cargo.toml
+++ b/src/rust/engine/async_value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 name = "async_value"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false

--- a/src/rust/engine/cache/Cargo.toml
+++ b/src/rust/engine/cache/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cache"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
 

--- a/src/rust/engine/client/Cargo.toml
+++ b/src/rust/engine/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 name = "client"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false

--- a/src/rust/engine/concrete_time/Cargo.toml
+++ b/src/rust/engine/concrete_time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 name = "concrete_time"
 publish = false

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 name = "fs"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false

--- a/src/rust/engine/fs/brfs/Cargo.toml
+++ b/src/rust/engine/fs/brfs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brfs"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
 

--- a/src/rust/engine/fs/fs_util/Cargo.toml
+++ b/src/rust/engine/fs/fs_util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fs_util"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
 

--- a/src/rust/engine/fs/store/Cargo.toml
+++ b/src/rust/engine/fs/store/Cargo.toml
@@ -2,7 +2,7 @@
 name = "store"
 version = "0.1.0"
 authors = ["Daniel Wagner-Hall <dwagnerhall@twitter.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 async-stream = "0.3"

--- a/src/rust/engine/graph/Cargo.toml
+++ b/src/rust/engine/graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 name = "graph"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false

--- a/src/rust/engine/grpc_util/Cargo.toml
+++ b/src/rust/engine/grpc_util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 name = "grpc_util"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false

--- a/src/rust/engine/hashing/Cargo.toml
+++ b/src/rust/engine/hashing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hashing"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
 

--- a/src/rust/engine/logging/Cargo.toml
+++ b/src/rust/engine/logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 name = "logging"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false

--- a/src/rust/engine/nailgun/Cargo.toml
+++ b/src/rust/engine/nailgun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 name = "nailgun"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false

--- a/src/rust/engine/options/Cargo.toml
+++ b/src/rust/engine/options/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 name = "options"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 name = "process_execution"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false

--- a/src/rust/engine/process_executor/Cargo.toml
+++ b/src/rust/engine/process_executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 name = "process_executor"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false

--- a/src/rust/engine/protos/Cargo.toml
+++ b/src/rust/engine/protos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 name = "protos"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false

--- a/src/rust/engine/rule_graph/Cargo.toml
+++ b/src/rust/engine/rule_graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 name = "rule_graph"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false

--- a/src/rust/engine/sharded_lmdb/Cargo.toml
+++ b/src/rust/engine/sharded_lmdb/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sharded_lmdb"
 version = "0.0.1"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 bytes = "1.0"

--- a/src/rust/engine/stdio/Cargo.toml
+++ b/src/rust/engine/stdio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 name = "stdio"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false

--- a/src/rust/engine/task_executor/Cargo.toml
+++ b/src/rust/engine/task_executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 name = "task_executor"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false

--- a/src/rust/engine/testutil/Cargo.toml
+++ b/src/rust/engine/testutil/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 name = "testutil"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false

--- a/src/rust/engine/testutil/local_cas/Cargo.toml
+++ b/src/rust/engine/testutil/local_cas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "local_cas"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
 

--- a/src/rust/engine/testutil/local_execution_server/Cargo.toml
+++ b/src/rust/engine/testutil/local_execution_server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "local_execution_server"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
 

--- a/src/rust/engine/testutil/mock/Cargo.toml
+++ b/src/rust/engine/testutil/mock/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mock"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
 

--- a/src/rust/engine/tryfuture/Cargo.toml
+++ b/src/rust/engine/tryfuture/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 name = "tryfuture"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false

--- a/src/rust/engine/ui/Cargo.toml
+++ b/src/rust/engine/ui/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ui"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 
 [lib]

--- a/src/rust/engine/watch/Cargo.toml
+++ b/src/rust/engine/watch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 name = "watch"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 name = "workunit_store"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false


### PR DESCRIPTION
Use the [Rust 2021 Edition](https://doc.rust-lang.org/edition-guide/rust-2021/index.html) for all crates. Upgrades the use of `cargo-ensure-prefix` in `build-support/bin/check_rust_target_headers.sh` to support Rust 2021 edition.