### PR TITLE
[jvm] Add support for compiling cycles between Java and Scala

### DIFF
--- a/src/python/pants/backend/java/compile/javac.py
+++ b/src/python/pants/backend/java/compile/javac.py
@@ -47,17 +47,20 @@ async def compile_java_source(
     union_membership: UnionMembership,
     request: CompileJavaSourceRequest,
 ) -> FallibleClasspathEntry:
-    # Request the component's direct dependency classpath.
-    direct_dependency_classpath_entries = FallibleClasspathEntry.if_all_succeeded(
-        await MultiGet(
-            Get(
-                FallibleClasspathEntry,
-                ClasspathEntryRequest,
-                ClasspathEntryRequest.for_targets(
-                    union_membership, component=coarsened_dep, resolve=request.resolve
-                ),
+    # Request the component's direct dependency classpath, and additionally any preqrequisite.
+    classpath_entry_requests = [
+        *((request.prerequisite,) if request.prerequisite else ()),
+        *(
+            ClasspathEntryRequest.for_targets(
+                union_membership, component=coarsened_dep, resolve=request.resolve
             )
             for coarsened_dep in request.component.dependencies
+        ),
+    ]
+    direct_dependency_classpath_entries = FallibleClasspathEntry.if_all_succeeded(
+        await MultiGet(
+            Get(FallibleClasspathEntry, ClasspathEntryRequest, cpe)
+            for cpe in classpath_entry_requests
         )
     )
     if direct_dependency_classpath_entries is None:

--- a/src/python/pants/backend/scala/compile/scalac.py
+++ b/src/python/pants/backend/scala/compile/scalac.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import logging
 from itertools import chain
 
+from pants.backend.java.target_types import JavaFieldSet, JavaGeneratorFieldSet
 from pants.backend.scala.compile.scala_subsystem import ScalaSubsystem
 from pants.backend.scala.target_types import ScalaFieldSet, ScalaGeneratorFieldSet, ScalaSourceField
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
@@ -36,6 +37,7 @@ logger = logging.getLogger(__name__)
 
 class CompileScalaSourceRequest(ClasspathEntryRequest):
     field_sets = (ScalaFieldSet, ScalaGeneratorFieldSet)
+    field_sets_consume_only = (JavaFieldSet, JavaGeneratorFieldSet)
 
 
 @rule(desc="Compile with scalac")

--- a/src/python/pants/backend/scala/compile/scalac.py
+++ b/src/python/pants/backend/scala/compile/scalac.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import logging
 from itertools import chain
 
-from pants.backend.java.target_types import JavaFieldSet, JavaGeneratorFieldSet
+from pants.backend.java.target_types import JavaFieldSet, JavaGeneratorFieldSet, JavaSourceField
 from pants.backend.scala.compile.scala_subsystem import ScalaSubsystem
 from pants.backend.scala.target_types import ScalaFieldSet, ScalaGeneratorFieldSet, ScalaSourceField
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
@@ -80,7 +80,7 @@ async def compile_scala_source(
                 SourceFiles,
                 SourceFilesRequest(
                     (t.get(SourcesField),),
-                    for_sources_types=(ScalaSourceField,),
+                    for_sources_types=(ScalaSourceField, JavaSourceField),
                     enable_codegen=True,
                 ),
             )

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -192,6 +192,7 @@ async def resolve_targets(
 ) -> Targets:
     # Replace all generating targets with what it generates. Otherwise, keep it. If a target
     # generator does not generate any targets, keep the target generator.
+    # TODO: This method does not preserve the order of inputs.
     expanded_targets: OrderedSet[Target] = OrderedSet()
     generator_targets = []
     generate_gets = []

--- a/src/python/pants/jvm/testutil.py
+++ b/src/python/pants/jvm/testutil.py
@@ -88,4 +88,5 @@ def rules():
         *collect_rules(),
         *archive.rules(),
         QueryRule(RenderedClasspath, (Digest,)),
+        QueryRule(CoarsenedTargets, (Addresses,)),
     ]


### PR DESCRIPTION
As described in #13520, `scalac` is able to parse `Java` sources, but will not emit classfiles for them. To support compiling cycles, adjust `ClasspathEntryRequest` to support specifying "consume-only" `FieldSets`, and give `ClasspathEntryRequest` an optional `prerequisite` request which is treated as a dependency.

Additionally, begin to generalize testing of Java and Scala slightly by using mustache templating in `jvm/compile_test.py` to avoid new definitions per test.

Fixes #13520.