### PR TITLE
[internal] Don't clone `PyAddPrefix` and `PyRemovePrefix`

### DIFF
--- a/src/rust/engine/src/externs/fs.rs
+++ b/src/rust/engine/src/externs/fs.rs
@@ -208,7 +208,7 @@ impl PySnapshot {
 }
 
 #[pyclass]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct PyAddPrefix {
   pub digest: Digest,
   pub prefix: PathBuf,
@@ -249,7 +249,7 @@ impl PyAddPrefix {
 }
 
 #[pyclass]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct PyRemovePrefix {
   pub digest: Digest,
   pub prefix: PathBuf,


### PR DESCRIPTION
Follow up to https://github.com/pantsbuild/pants/pull/13646.

The key when going from `&PyAny` to one of our custom `#[pyclass]` structs is to use `PyRef<>`, which is kind of like `RefCell<>`: https://pyo3.rs/v0.15.0/types.html#pyrefsometype-and-pyrefmutsometype

Even though this isn't a huge deal for cloning a `PathBuf`, this will become more important when porting `MergeDigests` and friends to Rust so that we don't copy the `Vec<>`.

[ci skip-build-wheels]