### PR TITLE
[internal] fix starts_with -> startswith

### DIFF
--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -108,7 +108,7 @@ class RunTracker:
         return [
             backend
             for backend in self._all_options.for_global_scope().backend_packages
-            if backend.starts_with("pants.backend.")
+            if backend.startswith("pants.backend.")
         ]
 
     def start(self, run_start_time: float, specs: list[str]) -> None:


### PR DESCRIPTION
Typo in method name made it through to `main`. Fix it. 🤦 

[ci skip-rust]

[ci skip-build-wheels]