### PR TITLE
[internal] Don't store derived values on go_first_party_package targets

### DIFF
--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -14,7 +14,6 @@ from pants.backend.go.target_types import (
     GoBinaryMainPackageField,
     GoBinaryMainPackageRequest,
     GoFirstPartyPackageSourcesField,
-    GoFirstPartyPackageSubpathField,
     GoFirstPartyPackageTarget,
     GoImportPathField,
     GoModPackageSourcesField,
@@ -222,7 +221,6 @@ async def generate_targets_from_go_mod(
         return GoFirstPartyPackageTarget(
             {
                 GoImportPathField.alias: import_path,
-                GoFirstPartyPackageSubpathField.alias: subpath,
                 GoFirstPartyPackageSourcesField.alias: tuple(
                     sorted(os.path.join(subpath, f) for f in dir_to_filenames[dir])
                 ),

--- a/src/python/pants/backend/go/target_type_rules_test.py
+++ b/src/python/pants/backend/go/target_type_rules_test.py
@@ -185,12 +185,7 @@ def test_generate_package_targets(rule_runner: RuleRunner) -> None:
 
     def gen_first_party_tgt(rel_dir: str, sources: list[str]) -> GoFirstPartyPackageTarget:
         return GoFirstPartyPackageTarget(
-            {
-                GoImportPathField.alias: (
-                    os.path.join("example.com/src/go", rel_dir) if rel_dir else "example.com/src/go"
-                ),
-                GoFirstPartyPackageSourcesField.alias: tuple(sources),
-            },
+            {GoFirstPartyPackageSourcesField.alias: tuple(sources)},
             Address("src/go", generated_name=f"./{rel_dir}"),
             residence_dir=os.path.join("src/go", rel_dir).rstrip("/"),
         )
@@ -232,7 +227,7 @@ def test_generate_package_targets(rule_runner: RuleRunner) -> None:
 
 def test_package_targets_cannot_be_manually_created() -> None:
     with pytest.raises(InvalidTargetException):
-        GoFirstPartyPackageTarget({GoImportPathField.alias: "foo"}, Address("foo"))
+        GoFirstPartyPackageTarget({}, Address("foo"))
     with pytest.raises(InvalidTargetException):
         GoThirdPartyPackageTarget(
             {GoImportPathField.alias: "foo"},

--- a/src/python/pants/backend/go/target_type_rules_test.py
+++ b/src/python/pants/backend/go/target_type_rules_test.py
@@ -20,7 +20,6 @@ from pants.backend.go.target_types import (
     GoBinaryMainPackageRequest,
     GoBinaryTarget,
     GoFirstPartyPackageSourcesField,
-    GoFirstPartyPackageSubpathField,
     GoFirstPartyPackageTarget,
     GoImportPathField,
     GoModTarget,
@@ -190,7 +189,6 @@ def test_generate_package_targets(rule_runner: RuleRunner) -> None:
                 GoImportPathField.alias: (
                     os.path.join("example.com/src/go", rel_dir) if rel_dir else "example.com/src/go"
                 ),
-                GoFirstPartyPackageSubpathField.alias: rel_dir,
                 GoFirstPartyPackageSourcesField.alias: tuple(sources),
             },
             Address("src/go", generated_name=f"./{rel_dir}"),
@@ -234,10 +232,7 @@ def test_generate_package_targets(rule_runner: RuleRunner) -> None:
 
 def test_package_targets_cannot_be_manually_created() -> None:
     with pytest.raises(InvalidTargetException):
-        GoFirstPartyPackageTarget(
-            {GoImportPathField.alias: "foo", GoFirstPartyPackageSubpathField.alias: "foo"},
-            Address("foo"),
-        )
+        GoFirstPartyPackageTarget({GoImportPathField.alias: "foo"}, Address("foo"))
     with pytest.raises(InvalidTargetException):
         GoThirdPartyPackageTarget(
             {GoImportPathField.alias: "foo"},

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -143,22 +143,11 @@ class GoFirstPartyPackageDependenciesField(Dependencies):
     pass
 
 
-class GoFirstPartyPackageSubpathField(StringField, AsyncFieldMixin):
-    alias = "subpath"
-    help = (
-        "The path from the owning `go.mod` to this package's directory, e.g. `subdir`.\n\n"
-        "This field should not be overridden; use the value from target generation."
-    )
-    required = True
-    value: str
-
-
 class GoFirstPartyPackageTarget(Target):
     alias = "go_first_party_package"
     core_fields = (
         *COMMON_TARGET_FIELDS,
         GoImportPathField,
-        GoFirstPartyPackageSubpathField,
         GoFirstPartyPackageDependenciesField,
         GoFirstPartyPackageSourcesField,
     )

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -25,17 +25,6 @@ from pants.engine.target import (
 )
 from pants.option.global_options import FilesNotFoundBehavior
 
-
-class GoImportPathField(StringField):
-    alias = "import_path"
-    help = (
-        "Import path in Go code to import this package.\n\n"
-        "This field should not be overridden; use the value from target generation."
-    )
-    required = True
-    value: str
-
-
 # -----------------------------------------------------------------------------------------------
 # `go_mod` target generator
 # -----------------------------------------------------------------------------------------------
@@ -147,7 +136,6 @@ class GoFirstPartyPackageTarget(Target):
     alias = "go_first_party_package"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        GoImportPathField,
         GoFirstPartyPackageDependenciesField,
         GoFirstPartyPackageSourcesField,
     )
@@ -171,6 +159,16 @@ class GoFirstPartyPackageTarget(Target):
 # -----------------------------------------------------------------------------------------------
 # `go_third_party_package` target
 # -----------------------------------------------------------------------------------------------
+
+
+class GoImportPathField(StringField):
+    alias = "import_path"
+    help = (
+        "Import path in Go code to import this package.\n\n"
+        "This field should not be overridden; use the value from target generation."
+    )
+    required = True
+    value: str
 
 
 class GoThirdPartyPackageDependenciesField(Dependencies):

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -50,7 +50,6 @@ async def setup_build_go_package_target_request(
 ) -> FallibleBuildGoPackageRequest:
     wrapped_target = await Get(WrappedTarget, Address, request.address)
     target = wrapped_target.target
-    import_path = target[GoImportPathField].value
 
     if target.has_field(GoFirstPartyPackageSourcesField):
         _maybe_first_party_pkg_info = await Get(
@@ -59,13 +58,14 @@ async def setup_build_go_package_target_request(
         if _maybe_first_party_pkg_info.info is None:
             return FallibleBuildGoPackageRequest(
                 None,
-                import_path,
+                _maybe_first_party_pkg_info.import_path,
                 exit_code=_maybe_first_party_pkg_info.exit_code,
                 stderr=_maybe_first_party_pkg_info.stderr,
             )
         _first_party_pkg_info = _maybe_first_party_pkg_info.info
 
         digest = _first_party_pkg_info.digest
+        import_path = _first_party_pkg_info.import_path
         subpath = _first_party_pkg_info.subpath
         minimum_go_version = _first_party_pkg_info.minimum_go_version
 
@@ -78,6 +78,8 @@ async def setup_build_go_package_target_request(
         s_file_names = _first_party_pkg_info.s_files
 
     elif target.has_field(GoThirdPartyPackageDependenciesField):
+        import_path = target[GoImportPathField].value
+
         _go_mod_address = target.address.maybe_convert_to_target_generator()
         _go_mod_info = await Get(GoModInfo, GoModInfoRequest(_go_mod_address))
         _third_party_pkg_info = await Get(

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -4,12 +4,10 @@
 from __future__ import annotations
 
 import dataclasses
-import os
 from dataclasses import dataclass
 
 from pants.backend.go.target_types import (
     GoFirstPartyPackageSourcesField,
-    GoFirstPartyPackageSubpathField,
     GoImportPathField,
     GoThirdPartyPackageDependenciesField,
 )
@@ -68,9 +66,7 @@ async def setup_build_go_package_target_request(
         _first_party_pkg_info = _maybe_first_party_pkg_info.info
 
         digest = _first_party_pkg_info.digest
-        subpath = os.path.join(
-            target.address.spec_path, target[GoFirstPartyPackageSubpathField].value
-        )
+        subpath = _first_party_pkg_info.subpath
         minimum_go_version = _first_party_pkg_info.minimum_go_version
 
         go_file_names = _first_party_pkg_info.go_files

--- a/src/python/pants/backend/go/util_rules/first_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg.py
@@ -10,11 +10,7 @@ import pkgutil
 from dataclasses import dataclass
 from typing import ClassVar
 
-from pants.backend.go.target_types import (
-    GoFirstPartyPackageSourcesField,
-    GoFirstPartyPackageSubpathField,
-    GoImportPathField,
-)
+from pants.backend.go.target_types import GoFirstPartyPackageSourcesField, GoImportPathField
 from pants.backend.go.util_rules.build_pkg import BuildGoPackageRequest, BuiltGoPackage
 from pants.backend.go.util_rules.go_mod import GoModInfo, GoModInfoRequest
 from pants.backend.go.util_rules.import_analysis import ImportConfig, ImportConfigRequest
@@ -95,7 +91,9 @@ async def compute_first_party_package_info(
     )
     target = wrapped_target.target
     import_path = target[GoImportPathField].value
-    subpath = target[GoFirstPartyPackageSubpathField].value
+
+    # The generated_name will have been set to `./{subpath}`.
+    subpath = request.address.generated_name[2:]  # type: ignore[index]
 
     pkg_sources = await Get(
         HydratedSources, HydrateSourcesRequest(target[GoFirstPartyPackageSourcesField])

--- a/src/python/pants/backend/go/util_rules/first_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg.py
@@ -10,7 +10,7 @@ import pkgutil
 from dataclasses import dataclass
 from typing import ClassVar
 
-from pants.backend.go.target_types import GoFirstPartyPackageSourcesField, GoImportPathField
+from pants.backend.go.target_types import GoFirstPartyPackageSourcesField
 from pants.backend.go.util_rules.build_pkg import BuildGoPackageRequest, BuiltGoPackage
 from pants.backend.go.util_rules.go_mod import GoModInfo, GoModInfoRequest
 from pants.backend.go.util_rules.import_analysis import ImportConfig, ImportConfigRequest
@@ -27,17 +27,38 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
+class FirstPartyPkgImportPath:
+    """The derived import path of a first party package, based on its owning go.mod.
+
+    Use `FirstPartyPkgInfo` instead for more detailed information like parsed imports.
+    """
+
+    import_path: str
+    subpath: str
+
+
+@dataclass(frozen=True)
+class FirstPartyPkgImportPathRequest(EngineAwareParameter):
+    address: Address
+
+    def debug_hint(self) -> str:
+        return self.address.spec
+
+
+@dataclass(frozen=True)
 class FirstPartyPkgInfo:
     """All the info and digest needed to build a first-party Go package.
 
-    The digest does not strip its source files. You must set `working_dir` appropriately to use the
-    `go_first_party_package` target's `subpath` field.
+    The digest does not strip its source files. You must set `working_dir` appropriately to use
+    the `subpath`.
+
+    Use `FirstPartyPkgImportPath` if you only need the derived import path.
     """
 
     digest: Digest
-    subpath: str
 
     import_path: str
+    subpath: str
 
     imports: tuple[str, ...]
     test_imports: tuple[str, ...]
@@ -74,6 +95,20 @@ class FirstPartyPkgInfoRequest(EngineAwareParameter):
         return self.address.spec
 
 
+@rule
+async def compute_first_party_package_import_path(
+    request: FirstPartyPkgImportPathRequest,
+) -> FirstPartyPkgImportPath:
+    go_mod_address = request.address.maybe_convert_to_target_generator()
+
+    # The generated_name will have been set to `./{subpath}`.
+    subpath = request.address.generated_name[2:]  # type: ignore[index]
+
+    go_mod_info = await Get(GoModInfo, GoModInfoRequest(go_mod_address))
+    import_path = f"{go_mod_info.import_path}/{subpath}" if subpath else go_mod_info.import_path
+    return FirstPartyPkgImportPath(import_path, subpath)
+
+
 @dataclass(frozen=True)
 class PackageAnalyzerSetup:
     digest: Digest
@@ -85,25 +120,22 @@ async def compute_first_party_package_info(
     request: FirstPartyPkgInfoRequest, analyzer: PackageAnalyzerSetup
 ) -> FallibleFirstPartyPkgInfo:
     go_mod_address = request.address.maybe_convert_to_target_generator()
-    wrapped_target, go_mod_info = await MultiGet(
+    wrapped_target, import_path_info, go_mod_info = await MultiGet(
         Get(WrappedTarget, Address, request.address),
+        Get(FirstPartyPkgImportPath, FirstPartyPkgImportPathRequest(request.address)),
         Get(GoModInfo, GoModInfoRequest(go_mod_address)),
     )
-    target = wrapped_target.target
-    import_path = target[GoImportPathField].value
-
-    # The generated_name will have been set to `./{subpath}`.
-    subpath = request.address.generated_name[2:]  # type: ignore[index]
 
     pkg_sources = await Get(
-        HydratedSources, HydrateSourcesRequest(target[GoFirstPartyPackageSourcesField])
+        HydratedSources,
+        HydrateSourcesRequest(wrapped_target.target[GoFirstPartyPackageSourcesField]),
     )
     input_digest = await Get(
         Digest,
         MergeDigests([pkg_sources.snapshot.digest, analyzer.digest]),
     )
     path = request.address.spec_path if request.address.spec_path else "."
-    path = os.path.join(path, subpath) if subpath else path
+    path = os.path.join(path, import_path_info.subpath) if import_path_info.subpath else path
     if not path:
         path = "."
     result = await Get(
@@ -118,7 +150,7 @@ async def compute_first_party_package_info(
     if result.exit_code != 0:
         return FallibleFirstPartyPkgInfo(
             info=None,
-            import_path=import_path,
+            import_path=import_path_info.import_path,
             exit_code=result.exit_code,
             stderr=result.stderr.decode("utf-8"),
         )
@@ -135,7 +167,7 @@ async def compute_first_party_package_info(
             )
             error += "\n"
         return FallibleFirstPartyPkgInfo(
-            info=None, import_path=import_path, exit_code=1, stderr=error
+            info=None, import_path=import_path_info.import_path, exit_code=1, stderr=error
         )
 
     if "CgoFiles" in metadata:
@@ -148,8 +180,8 @@ async def compute_first_party_package_info(
 
     info = FirstPartyPkgInfo(
         digest=pkg_sources.snapshot.digest,
-        subpath=os.path.join(target.address.spec_path, subpath),
-        import_path=import_path,
+        subpath=os.path.join(request.address.spec_path, import_path_info.subpath),
+        import_path=import_path_info.import_path,
         imports=tuple(metadata.get("Imports", [])),
         test_imports=tuple(metadata.get("TestImports", [])),
         xtest_imports=tuple(metadata.get("XTestImports", [])),
@@ -162,7 +194,7 @@ async def compute_first_party_package_info(
         test_embed_patterns=tuple(metadata.get("TestEmbedPatterns", [])),
         xtest_embed_patterns=tuple(metadata.get("XTestEmbedPatterns", [])),
     )
-    return FallibleFirstPartyPkgInfo(info, import_path)
+    return FallibleFirstPartyPkgInfo(info, import_path_info.import_path)
 
 
 @rule


### PR DESCRIPTION
We now compute the `import_path` and `subpath`, rather than storing them on the target via target generation.

This unblocks https://github.com/pantsbuild/pants/issues/13488. We do not want users to have to explicitly set these values. Even if `tailor` could set it automatically, that would be brittle to users moving around where code is located or renaming their `go.mod`'s module.