### PR TITLE
Interactive processes kill the process and its children on Ctrl+C.

### DIFF
--- a/src/python/pants/engine/streaming_workunit_handler_integration_test.py
+++ b/src/python/pants/engine/streaming_workunit_handler_integration_test.py
@@ -67,7 +67,7 @@ def test_ctrl_c(pantsd: bool) -> None:
         dest = os.path.join(workdir, "dest.log")
 
         # Start a pantsd run that will wait forever, then kill the pantsd client.
-        client_handle, _, _ = launch_waiter(
+        client_handle, _, _, _ = launch_waiter(
             workdir=workdir, config=workunit_logger_config(dest, pantsd=pantsd)
         )
         client_pid = client_handle.process.pid

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -2202,6 +2202,7 @@ dependencies = [
  "maplit",
  "mock",
  "nails",
+ "nix",
  "parking_lot",
  "prost",
  "prost-types",

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -22,6 +22,7 @@ hashing = { path = "../hashing" }
 libc = "0.2.39"
 log = "0.4"
 nails = "0.12"
+nix = "0.20"
 sha2 = "0.9"
 shell-quote = "0.1.0"
 store = { path = "../fs/store" }

--- a/src/rust/engine/process_execution/src/children.rs
+++ b/src/rust/engine/process_execution/src/children.rs
@@ -1,0 +1,84 @@
+use std::ops::{Deref, DerefMut};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use nix::sys::signal;
+use nix::unistd::getpgid;
+use nix::unistd::Pid;
+use tokio::process::{Child, Command};
+
+/// A child process running in its own PGID, with a drop implementation that will kill that
+/// PGID.
+///
+/// TODO: If this API is useful, we should consider extending it to parented Nailgun processes
+/// and to all local execution in general. It could also be adjusted for sending other posix
+/// signals in sequence for https://github.com/pantsbuild/pants/issues/13230.
+pub struct ManagedChild {
+  child: Child,
+  killed: AtomicBool,
+}
+
+impl ManagedChild {
+  pub fn spawn(mut command: Command) -> Result<Self, String> {
+    // Set `kill_on_drop` to encourage `tokio` to `wait` the process via its own "reaping"
+    // mechanism:
+    //   see https://docs.rs/tokio/1.14.0/tokio/process/struct.Command.html#method.kill_on_drop
+    command.kill_on_drop(true);
+
+    // Adjust the Command to create its own PGID as it starts, to make it safe to kill the PGID
+    // later.
+    unsafe {
+      command.pre_exec(|| {
+        nix::unistd::setsid().map(|_pgid| ()).map_err(|e| {
+          std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("Could not create new pgid: {}", e),
+          )
+        })
+      });
+    };
+
+    // Then spawn.
+    let child = command
+      .spawn()
+      .map_err(|e| format!("Error executing interactive process: {}", e))?;
+    Ok(Self {
+      child,
+      killed: AtomicBool::new(false),
+    })
+  }
+
+  /// Kill the process's unique PGID or return an error if we don't have a PID or cannot kill.
+  pub fn kill_pgid(&mut self) -> Result<(), String> {
+    let pid = self.id().ok_or_else(|| "Process had no PID.".to_owned())?;
+    let pgid = getpgid(Some(Pid::from_raw(pid as i32)))
+      .map_err(|e| format!("Could not get process group id of child process: {}", e))?;
+    // Kill the negative PGID to kill the entire process group.
+    signal::kill(Pid::from_raw(-pgid.as_raw()), signal::Signal::SIGKILL)
+      .map_err(|e| format!("Failed to interrupt child process group: {}", e))?;
+    self.killed.store(true, Ordering::SeqCst);
+    Ok(())
+  }
+}
+
+impl Deref for ManagedChild {
+  type Target = Child;
+
+  fn deref(&self) -> &Child {
+    &self.child
+  }
+}
+
+impl DerefMut for ManagedChild {
+  fn deref_mut(&mut self) -> &mut Child {
+    &mut self.child
+  }
+}
+
+/// Implements drop by killing the process group.
+impl Drop for ManagedChild {
+  fn drop(&mut self) {
+    if !self.killed.load(Ordering::SeqCst) {
+      let _ = self.kill_pgid();
+    }
+  }
+}

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -27,8 +27,16 @@ use workunit_store::{
 use crate::remote::make_execute_request;
 use crate::{
   Context, FallibleProcessResultWithPlatform, MultiPlatformProcess, Platform, Process,
-  ProcessCacheScope, ProcessMetadata, RemoteCacheWarningsBehavior,
+  ProcessCacheScope, ProcessMetadata,
 };
+
+#[derive(Clone, Copy, Debug, PartialEq, strum_macros::EnumString)]
+#[strum(serialize_all = "snake_case")]
+pub enum RemoteCacheWarningsBehavior {
+  Ignore,
+  FirstOnly,
+  Backoff,
+}
 
 /// This `CommandRunner` implementation caches results remotely using the Action Cache service
 /// of the Remote Execution API.

--- a/testprojects/src/python/coordinated_runs/waiter.py
+++ b/testprojects/src/python/coordinated_runs/waiter.py
@@ -5,15 +5,35 @@
 import os
 import sys
 import time
+from multiprocessing import Process
 
 waiting_for_file = sys.argv[1]
 pid_file = sys.argv[2]
+child_pid_file = sys.argv[3]
 attempts = 60
+
+
+def run_child():
+    while True:
+        print("Child running...")
+        time.sleep(1)
+
+
+child = Process(target=run_child, daemon=True)
+child.start()
+
+with open(child_pid_file, "w") as pf:
+    pf.write(str(child.pid))
+
 with open(pid_file, "w") as pf:
     pf.write(str(os.getpid()))
-while not os.path.isfile(waiting_for_file):
-    if attempts <= 0:
-        raise Exception("File was never written.")
-    attempts -= 1
-    sys.stderr.write("Waiting for file {}\n".format(waiting_for_file))
-    time.sleep(1)
+
+try:
+    while not os.path.isfile(waiting_for_file):
+        if attempts <= 0:
+            raise Exception("File was never written.")
+        attempts -= 1
+        sys.stderr.write("Waiting for file {}\n".format(waiting_for_file))
+        time.sleep(1)
+finally:
+    child.terminate()


### PR DESCRIPTION
As described in #12603, an interactive process which spawns children will currently orphan those children when it is killed. Despite spawning processes with `daemon=True`, the example in the description works when run directly as a PEX because the shell interrupts all processes in the parent's process group.

To get to a place where everything is terminated (even if not yet as gracefully as we would like: see #13230), this change wraps interactive processes in a new `ManagedChild` wrapper, which helps to ensure that the root process is in a new PGID, and then kills that PGID on drop.

If this strategy proves to be useful, we can extend it to `nailgun` servers and local processes, but this is kept intentionally small for cherry-picking.

[ci skip-build-wheels]