### PR TITLE
[internal] Switch to a maintained fork of the `fuse` crate for `brfs`.

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -191,12 +191,12 @@ dependencies = [
  "dirs-next",
  "env_logger",
  "errno",
- "fuse",
+ "fuser",
  "futures",
  "grpc_util",
  "hashing",
  "libc",
- "log 0.4.14",
+ "log",
  "parking_lot",
  "protobuf",
  "protos",
@@ -326,7 +326,7 @@ dependencies = [
  "env_logger",
  "futures",
  "libc",
- "log 0.4.14",
+ "log",
  "nailgun",
  "nix",
  "options",
@@ -363,7 +363,7 @@ dependencies = [
 name = "concrete_time"
 version = "0.0.1"
 dependencies = [
- "log 0.4.14",
+ "log",
  "prost",
  "prost-types",
  "serde",
@@ -651,7 +651,7 @@ dependencies = [
  "itertools 0.10.1",
  "lazy_static",
  "libc",
- "log 0.4.14",
+ "log",
  "logging",
  "mock",
  "nailgun",
@@ -691,7 +691,7 @@ checksum = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
 dependencies = [
  "atty",
  "humantime",
- "log 0.4.14",
+ "log",
  "regex",
  "termcolor",
 ]
@@ -787,7 +787,7 @@ dependencies = [
  "hashing",
  "ignore",
  "lazy_static",
- "log 0.4.14",
+ "log",
  "parking_lot",
  "rlimit",
  "serde",
@@ -869,16 +869,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ba62103ce691c2fd80fbae2213dfdda9ce60804973ac6b6e97de818ea7f52c8"
 
 [[package]]
-name = "fuse"
-version = "0.3.1"
+name = "fuser"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e57070510966bfef93662a81cb8aa2b1c7db0964354fa9921434f04b9e8660"
+checksum = "096c834eabc44f7151b8f17d28eb0501e30ea9139b4a2d64f33ad9ef4bdae8d3"
 dependencies = [
  "libc",
- "log 0.3.9",
+ "log",
+ "memchr",
+ "page_size",
  "pkg-config",
- "thread-scoped",
- "time",
+ "smallvec 1.7.0",
+ "users",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1028,7 +1031,7 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "fnv",
- "log 0.4.14",
+ "log",
  "regex",
 ]
 
@@ -1042,7 +1045,7 @@ dependencies = [
  "fixedbitset 0.2.0",
  "fnv",
  "futures",
- "log 0.4.14",
+ "log",
  "parking_lot",
  "petgraph 0.5.1",
  "rand 0.8.2",
@@ -1237,7 +1240,7 @@ checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
 dependencies = [
  "futures-util",
  "hyper",
- "log 0.4.14",
+ "log",
  "rustls",
  "tokio",
  "tokio-rustls",
@@ -1276,7 +1279,7 @@ dependencies = [
  "crossbeam-utils 0.8.1",
  "globset",
  "lazy_static",
- "log 0.4.14",
+ "log",
  "memchr",
  "regex",
  "same-file",
@@ -1497,15 +1500,6 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-dependencies = [
- "log 0.4.14",
-]
-
-[[package]]
-name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
@@ -1522,7 +1516,7 @@ dependencies = [
  "chrono",
  "colored",
  "lazy_static",
- "log 0.4.14",
+ "log",
  "num_enum",
  "parking_lot",
  "regex",
@@ -1611,7 +1605,7 @@ dependencies = [
  "iovec",
  "kernel32-sys",
  "libc",
- "log 0.4.14",
+ "log",
  "miow 0.2.2",
  "net2",
  "slab",
@@ -1625,7 +1619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
  "libc",
- "log 0.4.14",
+ "log",
  "miow 0.3.7",
  "ntapi",
  "winapi 0.3.9",
@@ -1638,7 +1632,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
 dependencies = [
  "lazycell",
- "log 0.4.14",
+ "log",
  "mio 0.6.23",
  "slab",
 ]
@@ -1674,7 +1668,7 @@ dependencies = [
  "grpc_util",
  "hashing",
  "hyper",
- "log 0.4.14",
+ "log",
  "parking_lot",
  "prost",
  "prost-types",
@@ -1697,7 +1691,7 @@ dependencies = [
  "async_latch",
  "bytes",
  "futures",
- "log 0.4.14",
+ "log",
  "nails",
  "os_pipe",
  "task_executor",
@@ -1713,7 +1707,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "futures",
- "log 0.4.14",
+ "log",
  "tokio",
  "tokio-util",
 ]
@@ -1925,7 +1919,7 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 name = "options"
 version = "0.0.1"
 dependencies = [
- "log 0.4.14",
+ "log",
  "peg",
  "shellexpand",
  "tempfile",
@@ -1937,6 +1931,16 @@ name = "os_pipe"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb233f06c2307e1f5ce2ecad9f8121cffbbee2c95428f44ea85222e460d0d213"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "page_size"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -2198,7 +2202,7 @@ dependencies = [
  "itertools 0.10.1",
  "lazy_static",
  "libc",
- "log 0.4.14",
+ "log",
  "maplit",
  "mock",
  "nails",
@@ -2241,7 +2245,7 @@ dependencies = [
  "futures",
  "grpc_util",
  "hashing",
- "log 0.4.14",
+ "log",
  "process_execution",
  "prost",
  "protos",
@@ -2273,7 +2277,7 @@ dependencies = [
  "heck",
  "itertools 0.10.1",
  "lazy_static",
- "log 0.4.14",
+ "log",
  "multimap",
  "petgraph 0.6.0",
  "prost",
@@ -2682,7 +2686,7 @@ dependencies = [
  "ipnet",
  "js-sys",
  "lazy_static",
- "log 0.4.14",
+ "log",
  "mime",
  "percent-encoding",
  "pin-project-lite",
@@ -2730,7 +2734,7 @@ version = "0.0.1"
 dependencies = [
  "env_logger",
  "indexmap",
- "log 0.4.14",
+ "log",
  "petgraph 0.5.1",
 ]
 
@@ -2756,7 +2760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
  "base64",
- "log 0.4.14",
+ "log",
  "ring",
  "sct",
  "webpki",
@@ -2947,7 +2951,7 @@ dependencies = [
  "futures",
  "hashing",
  "lmdb",
- "log 0.4.14",
+ "log",
  "parking_lot",
  "task_executor",
  "tempfile",
@@ -3040,7 +3044,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 name = "stdio"
 version = "0.0.1"
 dependencies = [
- "log 0.4.14",
+ "log",
  "parking_lot",
  "tokio",
 ]
@@ -3065,7 +3069,7 @@ dependencies = [
  "indexmap",
  "itertools 0.10.1",
  "lmdb",
- "log 0.4.14",
+ "log",
  "madvise",
  "memmap",
  "mock",
@@ -3183,6 +3187,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
+ "unicode-xid 0.2.2",
+]
+
+[[package]]
 name = "sysinfo"
 version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3290,12 +3306,6 @@ dependencies = [
  "quote 1.0.10",
  "syn 1.0.81",
 ]
-
-[[package]]
-name = "thread-scoped"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbb6aa301e5d3b0b5ef639c9a9c7e2f1c944f177b460c04dc24c69b1fa2bd99"
 
 [[package]]
 name = "thread_local"
@@ -3414,7 +3424,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "log 0.4.14",
+ "log",
  "pin-project-lite",
  "tokio",
 ]
@@ -3512,7 +3522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
  "cfg-if 1.0.0",
- "log 0.4.14",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3667,6 +3677,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "users"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
+dependencies = [
+ "libc",
+ "log",
+]
+
+[[package]]
 name = "uuid"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3710,7 +3730,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log 0.4.14",
+ "log",
  "try-lock",
 ]
 
@@ -3746,7 +3766,7 @@ checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
 dependencies = [
  "bumpalo",
  "lazy_static",
- "log 0.4.14",
+ "log",
  "proc-macro2 1.0.32",
  "quote 1.0.10",
  "syn 1.0.81",
@@ -3802,7 +3822,7 @@ dependencies = [
  "fs",
  "futures",
  "hashing",
- "log 0.4.14",
+ "log",
  "notify",
  "parking_lot",
  "task_executor",
@@ -3910,7 +3930,7 @@ dependencies = [
  "concrete_time",
  "hashing",
  "hdrhistogram",
- "log 0.4.14",
+ "log",
  "parking_lot",
  "petgraph 0.5.1",
  "rand 0.8.2",
@@ -3935,3 +3955,24 @@ name = "wyz"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+
+[[package]]
+name = "zerocopy"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e59ec1d2457bd6c0dd89b50e7d9d6b0b647809bf3f0a59ac85557046950b7b2"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0fbc82b82efe24da867ee52e015e58178684bd9dd64c34e66bdf21da2582a9f"
+dependencies = [
+ "proc-macro2 1.0.32",
+ "syn 1.0.81",
+ "synstructure",
+]

--- a/src/rust/engine/fs/brfs/Cargo.toml
+++ b/src/rust/engine/fs/brfs/Cargo.toml
@@ -11,7 +11,7 @@ clap = "2"
 dirs-next = "2"
 env_logger = "0.5.4"
 errno = "0.2.3"
-fuse = "0.3.1"
+fuser = "0.9.1"
 futures = "0.3"
 grpc_util = { path = "../../grpc_util" }
 hashing = { path = "../../hashing" }


### PR DESCRIPTION
The [`fuse` crate](https://crates.io/crates/fuse) has not been published in a while, and hadn't been updated for `macFUSE`'s rename (causing linking errors on macOS). There is an actively maintained fork in [`fuser`](https://crates.io/crates/fuser).