### PR TITLE
Rename `go_first_party_package` target to `go_package`

### DIFF
--- a/src/python/pants/backend/experimental/go/register.py
+++ b/src/python/pants/backend/experimental/go/register.py
@@ -9,8 +9,8 @@ from pants.backend.go.lint.gofmt.rules import rules as gofmt_rules
 from pants.backend.go.subsystems import golang
 from pants.backend.go.target_types import (
     GoBinaryTarget,
-    GoFirstPartyPackageTarget,
     GoModTarget,
+    GoPackageTarget,
     GoThirdPartyPackageTarget,
 )
 from pants.backend.go.util_rules import (
@@ -28,7 +28,7 @@ from pants.backend.go.util_rules import (
 
 
 def target_types():
-    return [GoFirstPartyPackageTarget, GoModTarget, GoThirdPartyPackageTarget, GoBinaryTarget]
+    return [GoPackageTarget, GoModTarget, GoThirdPartyPackageTarget, GoBinaryTarget]
 
 
 def rules():

--- a/src/python/pants/backend/go/goals/check.py
+++ b/src/python/pants/backend/go/goals/check.py
@@ -3,7 +3,7 @@
 
 from dataclasses import dataclass
 
-from pants.backend.go.target_types import GoFirstPartyPackageSourcesField
+from pants.backend.go.target_types import GoPackageSourcesField
 from pants.backend.go.util_rules.build_pkg import (
     BuildGoPackageRequest,
     FallibleBuildGoPackageRequest,
@@ -19,7 +19,7 @@ from pants.util.logging import LogLevel
 
 @dataclass(frozen=True)
 class GoCheckFieldSet(FieldSet):
-    required_fields = (GoFirstPartyPackageSourcesField,)
+    required_fields = (GoPackageSourcesField,)
 
 
 class GoCheckRequest(CheckRequest):

--- a/src/python/pants/backend/go/goals/tailor.py
+++ b/src/python/pants/backend/go/goals/tailor.py
@@ -76,7 +76,7 @@ async def find_putative_go_targets(
         if t.has_field(GoBinaryMainPackageField)
     )
     unowned_main_package_dirs = set(main_package_dirs) - {
-        # We can be confident `go_first_party_package` targets were generated, meaning that the
+        # We can be confident `go_package` targets were generated, meaning that the
         # below will get us the full path to the package's directory.
         # TODO: generalize this
         os.path.join(pkg.address.spec_path, pkg.address.generated_name[2:]).rstrip("/")  # type: ignore[index]

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -7,7 +7,7 @@ import os
 from typing import Sequence
 
 from pants.backend.go.subsystems.gotest import GoTestSubsystem
-from pants.backend.go.target_types import GoFirstPartyPackageSourcesField
+from pants.backend.go.target_types import GoPackageSourcesField
 from pants.backend.go.util_rules.build_pkg import (
     BuildGoPackageRequest,
     FallibleBuildGoPackageRequest,
@@ -61,9 +61,9 @@ TEST_FLAGS = {
 
 
 class GoTestFieldSet(TestFieldSet):
-    required_fields = (GoFirstPartyPackageSourcesField,)
+    required_fields = (GoPackageSourcesField,)
 
-    sources: GoFirstPartyPackageSourcesField
+    sources: GoPackageSourcesField
 
 
 def transform_test_args(args: Sequence[str]) -> tuple[str, ...]:

--- a/src/python/pants/backend/go/lint/fmt.py
+++ b/src/python/pants/backend/go/lint/fmt.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass
 from typing import Iterable
 
-from pants.backend.go.target_types import GoFirstPartyPackageSourcesField
+from pants.backend.go.target_types import GoPackageSourcesField
 from pants.core.goals.fmt import FmtResult, LanguageFmtResults, LanguageFmtTargets
 from pants.core.goals.style_request import StyleRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
@@ -18,7 +18,7 @@ from pants.engine.unions import UnionMembership, UnionRule, union
 # While gofmt is one of those, this is more generic and can work with other formatters.
 @dataclass(frozen=True)
 class GoLangFmtTargets(LanguageFmtTargets):
-    required_fields = (GoFirstPartyPackageSourcesField,)
+    required_fields = (GoPackageSourcesField,)
 
 
 @union
@@ -32,9 +32,7 @@ async def format_golang_targets(
 ) -> LanguageFmtResults:
     original_sources = await Get(
         SourceFiles,
-        SourceFilesRequest(
-            target[GoFirstPartyPackageSourcesField] for target in go_fmt_targets.targets
-        ),
+        SourceFilesRequest(target[GoPackageSourcesField] for target in go_fmt_targets.targets),
     )
     prior_formatter_result = original_sources.snapshot
 

--- a/src/python/pants/backend/go/lint/gofmt/rules.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules.py
@@ -12,7 +12,7 @@ from pants.backend.go.lint.gofmt.skip_field import SkipGofmtField
 from pants.backend.go.lint.gofmt.subsystem import GofmtSubsystem
 from pants.backend.go.subsystems import golang
 from pants.backend.go.subsystems.golang import GoRoot
-from pants.backend.go.target_types import GoFirstPartyPackageSourcesField
+from pants.backend.go.target_types import GoPackageSourcesField
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintRequest, LintResult, LintResults
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
@@ -28,9 +28,9 @@ from pants.util.strutil import pluralize
 
 @dataclass(frozen=True)
 class GofmtFieldSet(FieldSet):
-    required_fields = (GoFirstPartyPackageSourcesField,)
+    required_fields = (GoPackageSourcesField,)
 
-    sources: GoFirstPartyPackageSourcesField
+    sources: GoPackageSourcesField
 
     @classmethod
     def opt_out(cls, tgt: Target) -> bool:

--- a/src/python/pants/backend/go/lint/gofmt/skip_field.py
+++ b/src/python/pants/backend/go/lint/gofmt/skip_field.py
@@ -1,7 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.go.target_types import GoFirstPartyPackageTarget
+from pants.backend.go.target_types import GoPackageTarget
 from pants.engine.target import BoolField
 
 
@@ -12,4 +12,4 @@ class SkipGofmtField(BoolField):
 
 
 def rules():
-    return [GoFirstPartyPackageTarget.register_plugin_field(SkipGofmtField)]
+    return [GoPackageTarget.register_plugin_field(SkipGofmtField)]

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -142,7 +142,7 @@ async def infer_go_dependencies(
         else:
             logger.debug(
                 f"Unable to infer dependency for import path '{import_path}' "
-                f"in go_first_party_package at address '{addr}'."
+                f"in go_package at address '{addr}'."
             )
 
     return InferredDependencies(inferred_dependencies)
@@ -194,7 +194,7 @@ async def inject_go_third_party_package_dependencies(
 
 
 # -----------------------------------------------------------------------------------------------
-# Generate `go_first_party_package` and `go_third_party_package` targets
+# Generate `go_package` and `go_third_party_package` targets
 # -----------------------------------------------------------------------------------------------
 
 
@@ -203,10 +203,7 @@ class GenerateTargetsFromGoModRequest(GenerateTargetsRequest):
 
 
 @rule(
-    desc=(
-        "Generate `go_first_party_package` and `go_third_party_package` targets from `go_mod` "
-        "target"
-    ),
+    desc=("Generate `go_package` and `go_third_party_package` targets from `go_mod` " "target"),
     level=LogLevel.DEBUG,
 )
 async def generate_targets_from_go_mod(
@@ -283,11 +280,11 @@ async def determine_main_pkg_for_go_binary(
         if not wrapped_specified_tgt.target.has_field(GoPackageSourcesField):
             raise InvalidFieldException(
                 f"The {repr(GoBinaryMainPackageField.alias)} field in target {addr} must point to "
-                "a `go_first_party_package` target, but was the address for a "
+                "a `go_package` target, but was the address for a "
                 f"`{wrapped_specified_tgt.target.alias}` target.\n\n"
                 "Hint: you should normally not specify this field so that Pants will find the "
-                "`go_first_party_package` target for you. (Pants generates "
-                "`go_first_party_package` targets based on the `go_mod` target)."
+                "`go_package` target for you. (Pants generates "
+                "`go_package` targets based on the `go_mod` target)."
             )
         return GoBinaryMainPackage(wrapped_specified_tgt.target.address)
 
@@ -304,17 +301,17 @@ async def determine_main_pkg_for_go_binary(
     alias = wrapped_tgt.target.alias
     if not relevant_pkg_targets:
         raise ResolveError(
-            f"The `{alias}` target {addr} requires that there is a `go_first_party_package` "
+            f"The `{alias}` target {addr} requires that there is a `go_package` "
             f"target for its directory {addr.spec_path}, but none were found.\n\n"
-            "Have you added a `go_mod` target (which will generate `go_first_party_package` "
+            "Have you added a `go_mod` target (which will generate `go_package` "
             "targets)?"
         )
     raise ResolveError(
-        f"There are multiple `go_first_party_package` targets for the same directory of the "
+        f"There are multiple `go_package` targets for the same directory of the "
         f"`{alias}` target {addr}: {addr.spec_path}. It is ambiguous what to use as the `main` "
         "package.\n\n"
         f"To fix, please either set the `main` field for `{addr} or remove these "
-        "`go_first_party_package` targets so that only one remains: "
+        "`go_package` targets so that only one remains: "
         f"{sorted(tgt.address.spec for tgt in relevant_pkg_targets)}"
     )
 

--- a/src/python/pants/backend/go/target_type_rules_test.py
+++ b/src/python/pants/backend/go/target_type_rules_test.py
@@ -293,9 +293,7 @@ def test_determine_main_pkg_for_go_binary(rule_runner: RuleRunner) -> None:
 
     with engine_error(ResolveError, contains="none were found"):
         get_main(Address("missing"))
-    with engine_error(ResolveError, contains="There are multiple `go_first_party_package` targets"):
+    with engine_error(ResolveError, contains="There are multiple `go_package` targets"):
         get_main(Address("ambiguous"))
-    with engine_error(
-        InvalidFieldException, contains="must point to a `go_first_party_package` target"
-    ):
+    with engine_error(InvalidFieldException, contains="must point to a `go_package` target"):
         get_main(Address("explicit_wrong_type"))

--- a/src/python/pants/backend/go/target_type_rules_test.py
+++ b/src/python/pants/backend/go/target_type_rules_test.py
@@ -19,10 +19,10 @@ from pants.backend.go.target_types import (
     GoBinaryMainPackageField,
     GoBinaryMainPackageRequest,
     GoBinaryTarget,
-    GoFirstPartyPackageSourcesField,
-    GoFirstPartyPackageTarget,
     GoImportPathField,
     GoModTarget,
+    GoPackageSourcesField,
+    GoPackageTarget,
     GoThirdPartyPackageTarget,
 )
 from pants.backend.go.util_rules import (
@@ -122,14 +122,14 @@ def test_go_package_dependency_inference(rule_runner: RuleRunner) -> None:
     tgt1 = rule_runner.get_target(Address("foo", generated_name="./cmd"))
     inferred_deps1 = rule_runner.request(
         InferredDependencies,
-        [InferGoPackageDependenciesRequest(tgt1[GoFirstPartyPackageSourcesField])],
+        [InferGoPackageDependenciesRequest(tgt1[GoPackageSourcesField])],
     )
     assert inferred_deps1.dependencies == FrozenOrderedSet([Address("foo", generated_name="./pkg")])
 
     tgt2 = rule_runner.get_target(Address("foo", generated_name="./pkg"))
     inferred_deps2 = rule_runner.request(
         InferredDependencies,
-        [InferGoPackageDependenciesRequest(tgt2[GoFirstPartyPackageSourcesField])],
+        [InferGoPackageDependenciesRequest(tgt2[GoPackageSourcesField])],
     )
     assert inferred_deps2.dependencies == FrozenOrderedSet(
         [Address("foo", generated_name="github.com/google/uuid")]
@@ -139,7 +139,7 @@ def test_go_package_dependency_inference(rule_runner: RuleRunner) -> None:
     bad_tgt = rule_runner.get_target(Address("foo", generated_name="./bad"))
     assert not rule_runner.request(
         InferredDependencies,
-        [InferGoPackageDependenciesRequest(bad_tgt[GoFirstPartyPackageSourcesField])],
+        [InferGoPackageDependenciesRequest(bad_tgt[GoPackageSourcesField])],
     )
 
 
@@ -183,9 +183,9 @@ def test_generate_package_targets(rule_runner: RuleRunner) -> None:
     generator = rule_runner.get_target(Address("src/go"))
     generated = rule_runner.request(GeneratedTargets, [GenerateTargetsFromGoModRequest(generator)])
 
-    def gen_first_party_tgt(rel_dir: str, sources: list[str]) -> GoFirstPartyPackageTarget:
-        return GoFirstPartyPackageTarget(
-            {GoFirstPartyPackageSourcesField.alias: tuple(sources)},
+    def gen_first_party_tgt(rel_dir: str, sources: list[str]) -> GoPackageTarget:
+        return GoPackageTarget(
+            {GoPackageSourcesField.alias: tuple(sources)},
             Address("src/go", generated_name=f"./{rel_dir}"),
             residence_dir=os.path.join("src/go", rel_dir).rstrip("/"),
         )
@@ -227,7 +227,7 @@ def test_generate_package_targets(rule_runner: RuleRunner) -> None:
 
 def test_package_targets_cannot_be_manually_created() -> None:
     with pytest.raises(InvalidTargetException):
-        GoFirstPartyPackageTarget({}, Address("foo"))
+        GoPackageTarget({}, Address("foo"))
     with pytest.raises(InvalidTargetException):
         GoThirdPartyPackageTarget(
             {GoImportPathField.alias: "foo"},

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -74,7 +74,7 @@ class GoModPackageSourcesField(StringSequenceField, AsyncFieldMixin):
     alias = "package_sources"
     default = ("**/*.go", "**/*.s")
     help = (
-        "What sources to generate `go_first_party_package` targets for.\n\n"
+        "What sources to generate `go_package` targets for.\n\n"
         "Pants will generate one target per matching directory.\n\n"
         "Pants does not yet support some file types like `.c` and `.h` files, along with cgo "
         "files. If you need to use these files, please open a feature request at "
@@ -111,7 +111,7 @@ class GoModTarget(Target):
     )
     help = (
         "A first-party Go module (corresponding to a `go.mod` file).\n\n"
-        "Generates `go_first_party_package` targets for each directory from the "
+        "Generates `go_package` targets for each directory from the "
         "`package_sources` field, and generates `go_third_party_package` targets based on "
         "the `require` directives in your `go.mod`.\n\n"
         "If you have third-party packages, make sure you have an up-to-date `go.sum`. Run "
@@ -139,7 +139,7 @@ class GoPackageTarget(Target):
         "A first-party Go package (corresponding to a directory with `.go` files).\n\n"
         "You should not explicitly create this target in BUILD files. Instead, add a `go_mod` "
         "target where you have your `go.mod` file, which will generate "
-        "`go_first_party_package` targets for you."
+        "`go_package` targets for you."
     )
 
     def validate(self) -> None:
@@ -201,8 +201,8 @@ class GoThirdPartyPackageTarget(Target):
 class GoBinaryMainPackageField(StringField, AsyncFieldMixin):
     alias = "main"
     help = (
-        "Address of the `go_first_party_package` with the `main` for this binary.\n\n"
-        "If not specified, will default to the `go_first_party_package` for the same "
+        "Address of the `go_package` with the `main` for this binary.\n\n"
+        "If not specified, will default to the `go_package` for the same "
         "directory as this target's BUILD file. You should usually rely on this default."
     )
     value: str

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -120,27 +120,23 @@ class GoModTarget(Target):
 
 
 # -----------------------------------------------------------------------------------------------
-# `go_first_party_package` target
+# `go_package` target
 # -----------------------------------------------------------------------------------------------
 
 
-class GoFirstPartyPackageSourcesField(MultipleSourcesField):
+class GoPackageSourcesField(MultipleSourcesField):
     expected_file_extensions = (".go", ".s")
 
 
-class GoFirstPartyPackageDependenciesField(Dependencies):
+class GoPackageDependenciesField(Dependencies):
     pass
 
 
-class GoFirstPartyPackageTarget(Target):
-    alias = "go_first_party_package"
-    core_fields = (
-        *COMMON_TARGET_FIELDS,
-        GoFirstPartyPackageDependenciesField,
-        GoFirstPartyPackageSourcesField,
-    )
+class GoPackageTarget(Target):
+    alias = "go_package"
+    core_fields = (*COMMON_TARGET_FIELDS, GoPackageDependenciesField, GoPackageSourcesField)
     help = (
-        "A Go package (corresponding to a directory with `.go` files).\n\n"
+        "A first-party Go package (corresponding to a directory with `.go` files).\n\n"
         "You should not explicitly create this target in BUILD files. Instead, add a `go_mod` "
         "target where you have your `go.mod` file, which will generate "
         "`go_first_party_package` targets for you."

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -31,8 +31,8 @@ from pants.util.logging import LogLevel
 
 @dataclass(frozen=True)
 class BuildGoPackageTargetRequest(EngineAwareParameter):
-    """Build a `go_first_party_package` or `go_third_party_package` target and its dependencies as
-    `__pkg__.a` files."""
+    """Build a `go_package` or `go_third_party_package` target and its dependencies as `__pkg__.a`
+    files."""
 
     address: Address
     is_main: bool = False

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -7,8 +7,8 @@ import dataclasses
 from dataclasses import dataclass
 
 from pants.backend.go.target_types import (
-    GoFirstPartyPackageSourcesField,
     GoImportPathField,
+    GoPackageSourcesField,
     GoThirdPartyPackageDependenciesField,
 )
 from pants.backend.go.util_rules.build_pkg import (
@@ -51,7 +51,7 @@ async def setup_build_go_package_target_request(
     wrapped_target = await Get(WrappedTarget, Address, request.address)
     target = wrapped_target.target
 
-    if target.has_field(GoFirstPartyPackageSourcesField):
+    if target.has_field(GoPackageSourcesField):
         _maybe_first_party_pkg_info = await Get(
             FallibleFirstPartyPkgInfo, FirstPartyPkgInfoRequest(target.address)
         )
@@ -114,7 +114,7 @@ async def setup_build_go_package_target_request(
         Get(FallibleBuildGoPackageRequest, BuildGoPackageTargetRequest(tgt.address))
         for tgt in all_deps
         if (
-            tgt.has_field(GoFirstPartyPackageSourcesField)
+            tgt.has_field(GoPackageSourcesField)
             or tgt.has_field(GoThirdPartyPackageDependenciesField)
         )
     )

--- a/src/python/pants/backend/go/util_rules/first_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg.py
@@ -10,7 +10,7 @@ import pkgutil
 from dataclasses import dataclass
 from typing import ClassVar
 
-from pants.backend.go.target_types import GoFirstPartyPackageSourcesField
+from pants.backend.go.target_types import GoPackageSourcesField
 from pants.backend.go.util_rules.build_pkg import BuildGoPackageRequest, BuiltGoPackage
 from pants.backend.go.util_rules.go_mod import GoModInfo, GoModInfoRequest
 from pants.backend.go.util_rules.import_analysis import ImportConfig, ImportConfigRequest
@@ -128,7 +128,7 @@ async def compute_first_party_package_info(
 
     pkg_sources = await Get(
         HydratedSources,
-        HydrateSourcesRequest(wrapped_target.target[GoFirstPartyPackageSourcesField]),
+        HydrateSourcesRequest(wrapped_target.target[GoPackageSourcesField]),
     )
     input_digest = await Get(
         Digest,

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -313,11 +313,9 @@ class Target:
             target generator was explicitly defined. Target generators can, however, set this to
             the directory where the generated target provides metadata for. For example, a
             file-based target like `python_source` should set this to the parent directory of
-            its file. A directory-based target like `go_first_party_package` should set it to the
-            directory. A subtree-based target might set it to the root of the subtree. A file-less
-            target like `go_third_party_package` should keep the default of `address.spec_path`.
-            This field impacts how command line specs work, so that globs like `dir:` know whether
-            to match the target or not.
+            its file. A file-less target like `go_third_party_package` should keep the default of
+            `address.spec_path`. This field impacts how command line specs work, so that globs
+            like `dir:` know whether to match the target or not.
         """
         if self.removal_version and not address.is_generated_target:
             if not self.removal_hint:


### PR DESCRIPTION
Prework for https://github.com/pantsbuild/pants/issues/13488. Given that users will need to have this target in BUILD files (even if generated), we believe the brevity is worth it.

[ci skip-rust]
[ci skip-build-wheels]