### PR TITLE
[internal] scala: extract type names from all Type.* AST nodes

### DIFF
--- a/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
@@ -198,8 +198,20 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
         {
             "org.pantsbuild.example.OuterClass.NestedObject": FrozenOrderedSet(["String"]),
             "org.pantsbuild.example.Functions": FrozenOrderedSet(
-                ["TupleTypeArg2", "foo", "TupleTypeArg1", "LambdaReturnType", "+", "Unit", "Integer",
-                 "LambdaTypeArg2", "AParameterType", "LambdaTypeArg1", "bar", "OuterObject.NestedVal"]
+                [
+                    "TupleTypeArg2",
+                    "foo",
+                    "TupleTypeArg1",
+                    "LambdaReturnType",
+                    "+",
+                    "Unit",
+                    "Integer",
+                    "LambdaTypeArg2",
+                    "AParameterType",
+                    "LambdaTypeArg1",
+                    "bar",
+                    "OuterObject.NestedVal",
+                ]
             ),
             "org.pantsbuild.example.HasPrimaryConstructor": FrozenOrderedSet(
                 ["bar", "SomeTypeInSecondaryConstructor"]
@@ -231,8 +243,8 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
         "java.io.SomeTypeInSecondaryConstructor",
         "java.io.bar",
         "java.io.foo",
-        'java.io.TupleTypeArg1',
-        'java.io.TupleTypeArg2',
+        "java.io.TupleTypeArg1",
+        "java.io.TupleTypeArg2",
         # Because it's the top-most scope in the file.
         "org.pantsbuild.example.+",
         "org.pantsbuild.example.ABaseClass",
@@ -247,9 +259,9 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
         "org.pantsbuild.example.Unit",
         "org.pantsbuild.example.bar",
         "org.pantsbuild.example.foo",
-        'org.pantsbuild.example.LambdaReturnType',
-        'org.pantsbuild.example.LambdaTypeArg1',
-        'org.pantsbuild.example.LambdaTypeArg2',
-        'org.pantsbuild.example.TupleTypeArg1',
-        'org.pantsbuild.example.TupleTypeArg2',
+        "org.pantsbuild.example.LambdaReturnType",
+        "org.pantsbuild.example.LambdaTypeArg1",
+        "org.pantsbuild.example.LambdaTypeArg2",
+        "org.pantsbuild.example.TupleTypeArg1",
+        "org.pantsbuild.example.TupleTypeArg2",
     }

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
@@ -21,7 +21,7 @@ from pants.jvm import util_rules as jvm_util_rules
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.jvm.target_types import JvmDependencyLockfile
-from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
+from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner, logging
 from pants.util.frozendict import FrozenDict
 from pants.util.ordered_set import FrozenOrderedSet
 
@@ -48,6 +48,7 @@ def rule_runner() -> RuleRunner:
     return rule_runner
 
 
+@logging
 def test_parser_simple(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -111,6 +112,8 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
                 val a = foo + 5
                 val b = bar(5, "hello") + OuterObject.NestedVal
               }
+              def func2: (TupleTypeArg1, TupleTypeArg2) = {}
+              def func3: (LambdaTypeArg1, LambdaTypeArg2) => LambdaReturnType = {}
             }
 
             class ASubClass extends ABaseClass with ATrait1 with ATrait2.Nested { }
@@ -170,6 +173,8 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
             "org.pantsbuild.example.OuterObject.NestedObject",
             "org.pantsbuild.example.Functions",
             "org.pantsbuild.example.Functions.func1",
+            "org.pantsbuild.example.Functions.func2",
+            "org.pantsbuild.example.Functions.func3",
             "org.pantsbuild.example.ASubClass",
             "org.pantsbuild.example.ASubTrait",
             "org.pantsbuild.example.HasPrimaryConstructor",
@@ -193,7 +198,8 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
         {
             "org.pantsbuild.example.OuterClass.NestedObject": FrozenOrderedSet(["String"]),
             "org.pantsbuild.example.Functions": FrozenOrderedSet(
-                ["Integer", "AParameterType", "bar", "foo", "OuterObject.NestedVal", "+", "Unit"]
+                ["TupleTypeArg2", "foo", "TupleTypeArg1", "LambdaReturnType", "+", "Unit", "Integer",
+                 "LambdaTypeArg2", "AParameterType", "LambdaTypeArg1", "bar", "OuterObject.NestedVal"]
             ),
             "org.pantsbuild.example.HasPrimaryConstructor": FrozenOrderedSet(
                 ["bar", "SomeTypeInSecondaryConstructor"]
@@ -219,9 +225,14 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
         "java.io.String",
         "java.io.Unit",
         "java.io.Integer",
+        "java.io.LambdaReturnType",
+        "java.io.LambdaTypeArg1",
+        "java.io.LambdaTypeArg2",
         "java.io.SomeTypeInSecondaryConstructor",
         "java.io.bar",
         "java.io.foo",
+        'java.io.TupleTypeArg1',
+        'java.io.TupleTypeArg2',
         # Because it's the top-most scope in the file.
         "org.pantsbuild.example.+",
         "org.pantsbuild.example.ABaseClass",
@@ -236,4 +247,9 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
         "org.pantsbuild.example.Unit",
         "org.pantsbuild.example.bar",
         "org.pantsbuild.example.foo",
+        'org.pantsbuild.example.LambdaReturnType',
+        'org.pantsbuild.example.LambdaTypeArg1',
+        'org.pantsbuild.example.LambdaTypeArg2',
+        'org.pantsbuild.example.TupleTypeArg1',
+        'org.pantsbuild.example.TupleTypeArg2',
     }


### PR DESCRIPTION
As described in https://github.com/pantsbuild/pants/issues/13663, the Scala parser for dependency inference was not extracting consumed type names from more complex type syntax. This was because the initial version of the parser did not process all Type.* AST nodes. This PR does.

Fixes https://github.com/pantsbuild/pants/issues/13663