### PR TITLE
Make tailor generate correct fields for python_requirements (cherrypick of #13687)

### DIFF
--- a/src/python/pants/backend/python/goals/tailor.py
+++ b/src/python/pants/backend/python/goals/tailor.py
@@ -137,7 +137,7 @@ async def find_putative_targets(
                     triggering_sources=[req_file],
                     owned_sources=[req_file],
                     addressable=False,
-                    kwargs={} if name == "requirements.txt" else {"requirements_relpath": name},
+                    kwargs={} if name == "requirements.txt" else {"source": name},
                 )
             )
 

--- a/src/python/pants/backend/python/goals/tailor_test.py
+++ b/src/python/pants/backend/python/goals/tailor_test.py
@@ -107,7 +107,7 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
                     ("3rdparty/requirements-test.txt",),
                     ("3rdparty/requirements-test.txt",),
                     addressable=False,
-                    kwargs={"requirements_relpath": "requirements-test.txt"},
+                    kwargs={"source": "requirements-test.txt"},
                 ),
                 PutativeTarget.for_target_type(
                     PythonSourcesGeneratorTarget, "src/python/foo", "foo", ["__init__.py"]

--- a/src/python/pants/backend/python/macros/pipenv_requirements.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements.py
@@ -58,7 +58,7 @@ class PipenvRequirements:
             requirement name as the default module, e.g. "Django" will default to
             `modules=["django"]`.
         :param pipfile_target: a `_python_requirements_file` target to provide for cache invalidation
-        if the requirements_relpath value is not in the current rel_path
+        if the source value is not in the current rel_path
         """
         if requirements_relpath and source:
             raise ValueError(


### PR DESCRIPTION
The requirements_relpath field no longer exists, but tailor was
still using it. This change makes it use the source field instead.

[ci skip-rust]

[ci skip-build-wheels]