### PR TITLE
Fix dup 3rdparty dists introduced by local dists.

### DIFF
--- a/src/python/pants/backend/python/util_rules/local_dists.py
+++ b/src/python/pants/backend/python/util_rules/local_dists.py
@@ -60,6 +60,13 @@ class LocalDistsPex:
 
     Can be consumed from another PEX, e.g., by adding to PEX_PATH.
 
+    The PEX will only contain locally built dists and not their dependencies. For Pants generated
+    `setup.py` / `pyproject.toml`, the dependencies will be included in the standard resolve process
+    that the locally-built dists PEX is adjoined to via PEX_PATH. For hand-made `setup.py` /
+    `pyproject.toml` with 3rdparty dependencies not hand-mirrored into BUILD file dependencies, this
+    will lead to issues. See https://github.com/pantsbuild/pants/issues/13587#issuecomment-974863636
+    for one way to fix this corner which is intentionally punted on for now.
+
     Lists the files provided by the dists on sys.path, so they can be subtracted from
     sources digests, to prevent the same file ending up on sys.path twice.
     """
@@ -132,6 +139,7 @@ async def build_local_dists(
             interpreter_constraints=request.interpreter_constraints,
             additional_inputs=wheels_digest,
             internal_only=request.internal_only,
+            additional_args=["--intransitive"],
         ),
     )
 


### PR DESCRIPTION
When building local dists for inclusion on the `sys.path` of a process
execution, we cheat and leave these dists out of the normal resolve
process for a performance win. This works as long as the local dists
don't have a hand-written `setup.py` / `pyproject.toml` with 3rdparty
dependencies that are conflicting with requirements in the associated
resolve. Besides that corner case being broken, it does introduce
duplicate 3rdparty dists to a resolve though. We fix that by switching
the local dists PEX to be `--intransitive`. This fixes the duplicate
dists issue, but also shifts the broken corner case to a new broken
corner. Now, for custom `setup.py` / `pyproject.toml` with hand-declared
3rdparty dependencies, those dependencies will need to be mirrored into
the associated `python_distribution` target's `dependencies` list to
produce a correct resolve outcome. Since the use-case for a hand-written
`setup.py` / `pyproject.toml` is building CPython C extensions this
problem can be worked around by separating the python code that uses
3rdparty Python code and wraps the C extension into its own target. This
only falls down for a `python_distribution` using 3rdparty code and a
native extension intended to be shipped publically to PyPI where
breaking the dist into 2 just to satisfy Pants would not be acceptable.

Fixes #13587

[ci skip-rust]
[ci skip-build-wheels]