### PR TITLE
[internal] switch back to official `cargo-ensure-prefix` crate

### DIFF
--- a/build-support/bin/check_rust_target_headers.sh
+++ b/build-support/bin/check_rust_target_headers.sh
@@ -2,8 +2,7 @@
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-"${REPO_ROOT}/cargo" install cargo-ensure-prefix \
-  --git=https://github.com/pantsbuild/cargo-ensure-prefix --branch=upgrade_deps_for_rust_2021_support
+"${REPO_ROOT}/cargo" install cargo-ensure-prefix "=0.1.7"
 
 if ! out="$("${REPO_ROOT}/cargo" ensure-prefix \
   --manifest-path="${REPO_ROOT}/src/rust/engine/Cargo.toml" \


### PR DESCRIPTION
Switch back to the official `cargo-ensure-prefix` instead of the fork.

[ci skip-rust]

[ci skip-build-wheels]