### PR TITLE
[internal] Refactor finding owning `go_mod` for first-party packages

### DIFF
--- a/src/python/pants/backend/go/util_rules/first_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg.py
@@ -104,12 +104,12 @@ class FirstPartyPkgInfoRequest(EngineAwareParameter):
 async def compute_first_party_package_import_path(
     request: FirstPartyPkgImportPathRequest,
 ) -> FirstPartyPkgImportPath:
-    go_mod_address = await Get(OwningGoMod, OwningGoModRequest(request.address))
+    owning_go_mod = await Get(OwningGoMod, OwningGoModRequest(request.address))
 
     # The generated_name will have been set to `./{subpath}`.
     subpath = request.address.generated_name[2:]  # type: ignore[index]
 
-    go_mod_info = await Get(GoModInfo, GoModInfoRequest(go_mod_address))
+    go_mod_info = await Get(GoModInfo, GoModInfoRequest(owning_go_mod.address))
     import_path = f"{go_mod_info.import_path}/{subpath}" if subpath else go_mod_info.import_path
     return FirstPartyPkgImportPath(import_path, subpath)
 
@@ -124,11 +124,11 @@ class PackageAnalyzerSetup:
 async def compute_first_party_package_info(
     request: FirstPartyPkgInfoRequest, analyzer: PackageAnalyzerSetup
 ) -> FallibleFirstPartyPkgInfo:
-    go_mod_address = await Get(OwningGoMod, OwningGoModRequest(request.address))
+    owning_go_mod = await Get(OwningGoMod, OwningGoModRequest(request.address))
     wrapped_target, import_path_info, go_mod_info = await MultiGet(
         Get(WrappedTarget, Address, request.address),
         Get(FirstPartyPkgImportPath, FirstPartyPkgImportPathRequest(request.address)),
-        Get(GoModInfo, GoModInfoRequest(go_mod_address)),
+        Get(GoModInfo, GoModInfoRequest(owning_go_mod.address)),
     )
 
     pkg_sources = await Get(

--- a/src/python/pants/backend/go/util_rules/go_mod.py
+++ b/src/python/pants/backend/go/util_rules/go_mod.py
@@ -9,14 +9,56 @@ from dataclasses import dataclass
 
 from pants.backend.go.target_types import GoModSourcesField
 from pants.backend.go.util_rules.sdk import GoSdkProcess
+from pants.base.specs import AddressSpecs, AscendantAddresses
 from pants.build_graph.address import Address
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import Digest, RemovePrefix
 from pants.engine.process import ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import HydratedSources, HydrateSourcesRequest, WrappedTarget
+from pants.engine.target import (
+    HydratedSources,
+    HydrateSourcesRequest,
+    UnexpandedTargets,
+    WrappedTarget,
+)
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class OwningGoModRequest(EngineAwareParameter):
+    address: Address
+
+    def debug_hint(self) -> str:
+        return self.address.spec
+
+
+@dataclass(frozen=True)
+class OwningGoMod:
+    address: Address
+
+
+@rule
+async def find_nearest_go_mod(request: OwningGoModRequest) -> OwningGoMod:
+    # We don't expect `go_mod` targets to be generated, so we can use UnexpandedTargets.
+    candidate_targets = await Get(
+        UnexpandedTargets, AddressSpecs([AscendantAddresses(request.address.spec_path)])
+    )
+
+    # Sort by address.spec_path in descending order so the nearest go_mod target is sorted first.
+    go_mod_targets = sorted(
+        (tgt for tgt in candidate_targets if tgt.has_field(GoModSourcesField)),
+        key=lambda tgt: tgt.address.spec_path,
+        reverse=True,
+    )
+    if not go_mod_targets:
+        raise Exception(
+            f"The target {request.address} does not have any `go_mod` target in any ancestor "
+            "BUILD files. To fix, please make sure your project has a `go.mod` file and add a "
+            "`go_mod` target (you can run `./pants tailor` to do this)."
+        )
+    nearest_go_mod_target = go_mod_targets[0]
+    return OwningGoMod(nearest_go_mod_target.address)
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/go/util_rules/go_mod_test.py
+++ b/src/python/pants/backend/go/util_rules/go_mod_test.py
@@ -9,7 +9,12 @@ import pytest
 
 from pants.backend.go.target_types import GoModTarget
 from pants.backend.go.util_rules import go_mod, sdk
-from pants.backend.go.util_rules.go_mod import GoModInfo, GoModInfoRequest
+from pants.backend.go.util_rules.go_mod import (
+    GoModInfo,
+    GoModInfoRequest,
+    OwningGoMod,
+    OwningGoModRequest,
+)
 from pants.build_graph.address import Address
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
@@ -21,12 +26,47 @@ def rule_runner() -> RuleRunner:
         rules=[
             *sdk.rules(),
             *go_mod.rules(),
+            QueryRule(OwningGoMod, [OwningGoModRequest]),
             QueryRule(GoModInfo, [GoModInfoRequest]),
         ],
         target_types=[GoModTarget],
     )
     rule_runner.set_options([], env_inherit={"PATH"})
     return rule_runner
+
+
+def test_owning_go_mod(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "go.mod": "",
+            "f.go": "",
+            "BUILD": "go_mod(name='mod')",
+            "dir/f.go": "",
+            "dir/subdir/go.mod": "",
+            "dir/subdir/BUILD": "go_mod(name='mod')",
+            "dir/subdir/f.go": "",
+            "dir/subdir/another/f.go": "",
+        }
+    )
+
+    def assert_owner(pkg: Address, mod: Address) -> None:
+        owner = rule_runner.request(OwningGoMod, [OwningGoModRequest(pkg)])
+        assert owner.address == mod
+
+    assert_owner(
+        Address("", target_name="mod", generated_name="./"), Address("", target_name="mod")
+    )
+    assert_owner(
+        Address("", target_name="mod", generated_name="./dir"), Address("", target_name="mod")
+    )
+    assert_owner(
+        Address("dir/subdir", target_name="mod", generated_name="./"),
+        Address("dir/subdir", target_name="mod"),
+    )
+    assert_owner(
+        Address("dir/subdir", target_name="mod", generated_name="./another"),
+        Address("dir/subdir", target_name="mod"),
+    )
 
 
 def test_go_mod_info(rule_runner: RuleRunner) -> None:


### PR DESCRIPTION
Prework for https://github.com/pantsbuild/pants/issues/13488.

We used to find the owning `go_mod` by relying on the fact that `go_package` targets are generated and simply converting the address to its target generator. That won't work once we allow manually creating `go_package` targets, though.

We could require that a `go_package` target have a `go_mod` field that points to the address of the owning `go_mod`. That would avoid the need for this rule and be slightly faster. But that is not ergonomic. Even with `tailor` setting it, it would not be resilient to reorganizing files and it would add extra boilerplate.

[ci skip-rust]
[ci skip-build-wheels]