### PR TITLE
[internal] Rename ambiguous `subpath` variable for Go code

### DIFF
--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -139,10 +139,10 @@ async def run_go_tests(
         GenerateTestMainRequest(
             pkg_info.digest,
             FrozenOrderedSet(
-                os.path.join(".", pkg_info.subpath, name) for name in pkg_info.test_files
+                os.path.join(".", pkg_info.dir_path, name) for name in pkg_info.test_files
             ),
             FrozenOrderedSet(
-                os.path.join(".", pkg_info.subpath, name) for name in pkg_info.xtest_files
+                os.path.join(".", pkg_info.dir_path, name) for name in pkg_info.xtest_files
             ),
             import_path=import_path,
         ),
@@ -201,7 +201,7 @@ async def run_go_tests(
         xtest_pkg_build_request = BuildGoPackageRequest(
             import_path=f"{import_path}_test",
             digest=pkg_info.digest,
-            subpath=pkg_info.subpath,
+            dir_path=pkg_info.dir_path,
             go_file_names=pkg_info.xtest_files,
             s_file_names=(),  # TODO: Are there .s files for xtest?
             direct_dependencies=tuple(direct_dependencies),
@@ -215,7 +215,7 @@ async def run_go_tests(
         BuildGoPackageRequest(
             import_path="main",
             digest=testmain.digest,
-            subpath="",
+            dir_path="",
             go_file_names=(GeneratedTestMain.TEST_MAIN_FILE,),
             s_file_names=(),
             direct_dependencies=tuple(main_direct_deps),

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -229,16 +229,16 @@ async def generate_targets_from_go_mod(
     matched_dirs = [dir for dir, filenames in dir_to_filenames.items() if filenames]
 
     def create_first_party_package_tgt(dir: str) -> GoPackageTarget:
-        subpath = fast_relpath(dir, generator_addr.spec_path)
+        dir_path_rel_to_gomod = fast_relpath(dir, generator_addr.spec_path)
 
         return GoPackageTarget(
             {
                 GoPackageSourcesField.alias: tuple(
-                    sorted(os.path.join(subpath, f) for f in dir_to_filenames[dir])
+                    sorted(os.path.join(dir_path_rel_to_gomod, f) for f in dir_to_filenames[dir])
                 )
             },
             # E.g. `src/go:mod#./subdir`.
-            generator_addr.create_generated(f"./{subpath}"),
+            generator_addr.create_generated(f"./{dir_path_rel_to_gomod}"),
             union_membership,
             residence_dir=dir,
         )

--- a/src/python/pants/backend/go/util_rules/assembly_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/assembly_integration_test.py
@@ -132,7 +132,7 @@ def test_build_package_with_assembly(rule_runner: RuleRunner) -> None:
 def test_build_invalid_package(rule_runner: RuleRunner) -> None:
     request = BuildGoPackageRequest(
         import_path="example.com/assembly",
-        subpath="",
+        dir_path="",
         go_file_names=("add_amd64.go", "add_arm64.go"),
         digest=rule_runner.make_snapshot(
             {

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -66,7 +66,7 @@ async def setup_build_go_package_target_request(
 
         digest = _first_party_pkg_info.digest
         import_path = _first_party_pkg_info.import_path
-        subpath = _first_party_pkg_info.subpath
+        dir_path = _first_party_pkg_info.dir_path
         minimum_go_version = _first_party_pkg_info.minimum_go_version
 
         go_file_names = _first_party_pkg_info.go_files
@@ -94,7 +94,7 @@ async def setup_build_go_package_target_request(
         if _third_party_pkg_info.error:
             raise _third_party_pkg_info.error
 
-        subpath = _third_party_pkg_info.subpath
+        dir_path = _third_party_pkg_info.dir_path
         digest = _third_party_pkg_info.digest
         minimum_go_version = _third_party_pkg_info.minimum_go_version
         go_file_names = _third_party_pkg_info.go_files
@@ -131,7 +131,7 @@ async def setup_build_go_package_target_request(
     result = BuildGoPackageRequest(
         digest=digest,
         import_path="main" if request.is_main else import_path,
-        subpath=subpath,
+        dir_path=dir_path,
         go_file_names=go_file_names,
         s_file_names=s_file_names,
         minimum_go_version=minimum_go_version,

--- a/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
@@ -78,14 +78,14 @@ def assert_pkg_target_built(
     addr: Address,
     *,
     expected_import_path: str,
-    expected_subpath: str,
+    expected_dir_path: str,
     expected_direct_dependency_import_paths: list[str],
     expected_transitive_dependency_import_paths: list[str],
     expected_go_file_names: list[str],
 ) -> None:
     build_request = rule_runner.request(BuildGoPackageRequest, [BuildGoPackageTargetRequest(addr)])
     assert build_request.import_path == expected_import_path
-    assert build_request.subpath == expected_subpath
+    assert build_request.dir_path == expected_dir_path
     assert build_request.go_file_names == tuple(expected_go_file_names)
     assert not build_request.s_file_names
     assert [
@@ -129,7 +129,7 @@ def test_build_first_party_pkg_target(rule_runner: RuleRunner) -> None:
         rule_runner,
         Address("", target_name="mod", generated_name="./"),
         expected_import_path="example.com/greeter",
-        expected_subpath="",
+        expected_dir_path="",
         expected_go_file_names=["greeter.go"],
         expected_direct_dependency_import_paths=[],
         expected_transitive_dependency_import_paths=[],
@@ -160,7 +160,7 @@ def test_build_third_party_pkg_target(rule_runner: RuleRunner) -> None:
         rule_runner,
         Address("", target_name="mod", generated_name=import_path),
         expected_import_path=import_path,
-        expected_subpath="github.com/google/uuid@v1.3.0",
+        expected_dir_path="github.com/google/uuid@v1.3.0",
         expected_go_file_names=[
             "dce.go",
             "doc.go",
@@ -245,7 +245,7 @@ def test_build_target_with_dependencies(rule_runner: RuleRunner) -> None:
         rule_runner,
         Address("", target_name="mod", generated_name=xerrors_internal_import_path),
         expected_import_path=xerrors_internal_import_path,
-        expected_subpath="golang.org/x/xerrors@v0.0.0-20191204190536-9bdfabe68543/internal",
+        expected_dir_path="golang.org/x/xerrors@v0.0.0-20191204190536-9bdfabe68543/internal",
         expected_go_file_names=["internal.go"],
         expected_direct_dependency_import_paths=[],
         expected_transitive_dependency_import_paths=[],
@@ -256,7 +256,7 @@ def test_build_target_with_dependencies(rule_runner: RuleRunner) -> None:
         rule_runner,
         Address("", target_name="mod", generated_name=xerrors_import_path),
         expected_import_path=xerrors_import_path,
-        expected_subpath="golang.org/x/xerrors@v0.0.0-20191204190536-9bdfabe68543",
+        expected_dir_path="golang.org/x/xerrors@v0.0.0-20191204190536-9bdfabe68543",
         expected_go_file_names=[
             "adaptor.go",
             "doc.go",
@@ -275,7 +275,7 @@ def test_build_target_with_dependencies(rule_runner: RuleRunner) -> None:
         rule_runner,
         Address("", target_name="mod", generated_name="./greeter/quoter"),
         expected_import_path=quoter_import_path,
-        expected_subpath="greeter/quoter",
+        expected_dir_path="greeter/quoter",
         expected_go_file_names=["lib.go"],
         expected_direct_dependency_import_paths=[],
         expected_transitive_dependency_import_paths=[],
@@ -286,7 +286,7 @@ def test_build_target_with_dependencies(rule_runner: RuleRunner) -> None:
         rule_runner,
         Address("", target_name="mod", generated_name="./greeter"),
         expected_import_path=greeter_import_path,
-        expected_subpath="greeter",
+        expected_dir_path="greeter",
         expected_go_file_names=["lib.go"],
         expected_direct_dependency_import_paths=[quoter_import_path, xerrors_import_path],
         expected_transitive_dependency_import_paths=[xerrors_internal_import_path],
@@ -296,7 +296,7 @@ def test_build_target_with_dependencies(rule_runner: RuleRunner) -> None:
         rule_runner,
         Address("", target_name="mod", generated_name="./"),
         expected_import_path="example.com/project",
-        expected_subpath="",
+        expected_dir_path="",
         expected_go_file_names=["main.go"],
         expected_direct_dependency_import_paths=[greeter_import_path],
         expected_transitive_dependency_import_paths=[

--- a/src/python/pants/backend/go/util_rules/build_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_test.py
@@ -69,7 +69,7 @@ def assert_built(
 def test_build_pkg(rule_runner: RuleRunner) -> None:
     transitive_dep = BuildGoPackageRequest(
         import_path="example.com/foo/dep/transitive",
-        subpath="dep/transitive",
+        dir_path="dep/transitive",
         go_file_names=("f.go",),
         digest=rule_runner.make_snapshot(
             {
@@ -92,7 +92,7 @@ def test_build_pkg(rule_runner: RuleRunner) -> None:
     )
     direct_dep = BuildGoPackageRequest(
         import_path="example.com/foo/dep",
-        subpath="dep",
+        dir_path="dep",
         go_file_names=("f.go",),
         digest=rule_runner.make_snapshot(
             {
@@ -115,7 +115,7 @@ def test_build_pkg(rule_runner: RuleRunner) -> None:
     )
     main = BuildGoPackageRequest(
         import_path="example.com/foo",
-        subpath="",
+        dir_path="",
         go_file_names=("f.go",),
         digest=rule_runner.make_snapshot(
             {
@@ -160,7 +160,7 @@ def test_build_pkg(rule_runner: RuleRunner) -> None:
 def test_build_invalid_pkg(rule_runner: RuleRunner) -> None:
     invalid_dep = BuildGoPackageRequest(
         import_path="example.com/foo/dep",
-        subpath="dep",
+        dir_path="dep",
         go_file_names=("f.go",),
         digest=rule_runner.make_snapshot({"dep/f.go": "invalid!!!"}).digest,
         s_file_names=(),
@@ -169,7 +169,7 @@ def test_build_invalid_pkg(rule_runner: RuleRunner) -> None:
     )
     main = BuildGoPackageRequest(
         import_path="example.com/foo",
-        subpath="",
+        dir_path="",
         go_file_names=("f.go",),
         digest=rule_runner.make_snapshot(
             {

--- a/src/python/pants/backend/go/util_rules/first_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg.py
@@ -54,16 +54,15 @@ class FirstPartyPkgImportPathRequest(EngineAwareParameter):
 class FirstPartyPkgInfo:
     """All the info and digest needed to build a first-party Go package.
 
-    The digest does not strip its source files. You must set `working_dir` appropriately to use
-    the `subpath`.
+    The digest does not strip its source files; `dir_path` is relative to the build root.
 
     Use `FirstPartyPkgImportPath` if you only need the derived import path.
     """
 
     digest: Digest
+    dir_path: str
 
     import_path: str
-    subpath: str
 
     imports: tuple[str, ...]
     test_imports: tuple[str, ...]
@@ -193,7 +192,7 @@ async def compute_first_party_package_info(
 
     info = FirstPartyPkgInfo(
         digest=pkg_sources.snapshot.digest,
-        subpath=os.path.join(request.address.spec_path, import_path_info.dir_path_rel_to_gomod),
+        dir_path=os.path.join(request.address.spec_path, import_path_info.dir_path_rel_to_gomod),
         import_path=import_path_info.import_path,
         imports=tuple(metadata.get("Imports", [])),
         test_imports=tuple(metadata.get("TestImports", [])),
@@ -231,7 +230,7 @@ async def setup_analyzer() -> PackageAnalyzerSetup:
         BuiltGoPackage,
         BuildGoPackageRequest(
             import_path="main",
-            subpath="",
+            dir_path="",
             digest=source_digest,
             go_file_names=tuple(fc.path for fc in analyer_sources_content),
             s_file_names=(),

--- a/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
@@ -143,7 +143,7 @@ def test_package_info(rule_runner: RuleRunner) -> None:
     )
 
     def assert_info(
-        subpath: str,
+        dir_path: str,
         *,
         imports: list[str],
         test_imports: list[str],
@@ -157,12 +157,12 @@ def test_package_info(rule_runner: RuleRunner) -> None:
     ) -> None:
         maybe_info = rule_runner.request(
             FallibleFirstPartyPkgInfo,
-            [FirstPartyPkgInfoRequest(Address("foo", generated_name=f"./{subpath}"))],
+            [FirstPartyPkgInfoRequest(Address("foo", generated_name=f"./{dir_path}"))],
         )
         assert maybe_info.info is not None
         info = maybe_info.info
         actual_snapshot = rule_runner.request(Snapshot, [info.digest])
-        expected_snapshot = rule_runner.request(Snapshot, [PathGlobs([f"foo/{subpath}/*.go"])])
+        expected_snapshot = rule_runner.request(Snapshot, [PathGlobs([f"foo/{dir_path}/*.go"])])
         assert actual_snapshot == expected_snapshot
 
         assert info.imports == tuple(imports)

--- a/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
@@ -67,7 +67,7 @@ def test_import_path(rule_runner: RuleRunner, mod_dir: str) -> None:
         [FirstPartyPkgImportPathRequest(Address(mod_dir, target_name="mod", generated_name="./"))],
     )
     assert info.import_path == "go.example.com/foo"
-    assert info.subpath == ""
+    assert info.dir_path_rel_to_gomod == ""
 
     info = rule_runner.request(
         FirstPartyPkgImportPath,
@@ -78,7 +78,7 @@ def test_import_path(rule_runner: RuleRunner, mod_dir: str) -> None:
         ],
     )
     assert info.import_path == "go.example.com/foo/dir"
-    assert info.subpath == "dir"
+    assert info.dir_path_rel_to_gomod == "dir"
 
 
 def test_package_info(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/go/util_rules/go_mod.py
+++ b/src/python/pants/backend/go/util_rules/go_mod.py
@@ -18,6 +18,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     HydratedSources,
     HydrateSourcesRequest,
+    InvalidTargetException,
     UnexpandedTargets,
     WrappedTarget,
 )
@@ -52,10 +53,10 @@ async def find_nearest_go_mod(request: OwningGoModRequest) -> OwningGoMod:
         reverse=True,
     )
     if not go_mod_targets:
-        raise Exception(
-            f"The target {request.address} does not have any `go_mod` target in any ancestor "
-            "BUILD files. To fix, please make sure your project has a `go.mod` file and add a "
-            "`go_mod` target (you can run `./pants tailor` to do this)."
+        raise InvalidTargetException(
+            f"The target {request.address} does not have a `go_mod` target in its BUILD file or "
+            "any ancestor BUILD files. To fix, please make sure your project has a `go.mod` file "
+            "and add a `go_mod` target (you can run `./pants tailor` to do this)."
         )
     nearest_go_mod_target = go_mod_targets[0]
     return OwningGoMod(nearest_go_mod_target.address)

--- a/src/python/pants/backend/go/util_rules/tests_analysis.py
+++ b/src/python/pants/backend/go/util_rules/tests_analysis.py
@@ -60,7 +60,7 @@ async def setup_analyzer() -> AnalyzerSetup:
         BuiltGoPackage,
         BuildGoPackageRequest(
             import_path="main",
-            subpath="",
+            dir_path="",
             digest=source_digest,
             go_file_names=(source_entry.path,),
             s_file_names=(),

--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -41,9 +41,9 @@ class ThirdPartyPkgInfo:
     """
 
     import_path: str
-    subpath: str
 
     digest: Digest
+    dir_path: str
 
     # Note that we don't care about test-related metadata like `TestImports`, as we'll never run
     # tests directly on a third-party package.
@@ -165,7 +165,7 @@ async def download_and_analyze_third_party_packages(
         all_pkg_info_kwargs.append(
             dict(
                 import_path=import_path,
-                subpath=dir_path,
+                dir_path=dir_path,
                 imports=tuple(pkg_json.get("Imports", ())),
                 go_files=tuple(pkg_json.get("GoFiles", ())),
                 s_files=tuple(pkg_json.get("SFiles", ())),
@@ -244,7 +244,7 @@ def maybe_raise_or_create_error_or_create_failed_pkg_info(
         )
         return None, ThirdPartyPkgInfo(
             import_path=import_path,
-            subpath="",
+            dir_path="",
             digest=EMPTY_DIGEST,
             imports=(),
             go_files=(),

--- a/src/python/pants/backend/go/util_rules/third_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg_test.py
@@ -135,7 +135,7 @@ def test_download_and_analyze_all_packages(rule_runner: RuleRunner) -> None:
 
     def assert_pkg_info(
         import_path: str,
-        subpath: str,
+        dir_path: str,
         imports: tuple[str, ...],
         go_files: tuple[str, ...],
         extra_files: tuple[str, ...],
@@ -144,19 +144,19 @@ def test_download_and_analyze_all_packages(rule_runner: RuleRunner) -> None:
         assert import_path in all_packages.import_paths_to_pkg_info
         pkg_info = all_packages.import_paths_to_pkg_info[import_path]
         assert pkg_info.import_path == import_path
-        assert pkg_info.subpath == subpath
+        assert pkg_info.dir_path == dir_path
         assert pkg_info.imports == imports
         assert pkg_info.go_files == go_files
         assert not pkg_info.s_files
         snapshot = rule_runner.request(Snapshot, [pkg_info.digest])
         assert set(snapshot.files) == {
-            os.path.join(subpath, file_name) for file_name in (*go_files, *extra_files)
+            os.path.join(dir_path, file_name) for file_name in (*go_files, *extra_files)
         }
         assert pkg_info.minimum_go_version == minimum_go_version
 
     assert_pkg_info(
         import_path="github.com/google/uuid",
-        subpath="github.com/google/uuid@v1.3.0",
+        dir_path="github.com/google/uuid@v1.3.0",
         imports=(
             "bytes",
             "crypto/md5",
@@ -209,7 +209,7 @@ def test_download_and_analyze_all_packages(rule_runner: RuleRunner) -> None:
     )
     assert_pkg_info(
         import_path="golang.org/x/text/unicode/bidi",
-        subpath="golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c/unicode/bidi",
+        dir_path="golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c/unicode/bidi",
         imports=("container/list", "fmt", "log", "sort", "unicode/utf8"),
         go_files=("bidi.go", "bracket.go", "core.go", "prop.go", "tables.go", "trieval.go"),
         extra_files=(
@@ -515,7 +515,7 @@ def test_determine_pkg_info_module_with_replace_directive(rule_runner: RuleRunne
         ThirdPartyPkgInfo,
         [ThirdPartyPkgInfoRequest("github.com/hashicorp/consul/api", digest)],
     )
-    assert pkg_info.subpath == "github.com/hashicorp/consul/api@v1.3.0"
+    assert pkg_info.dir_path == "github.com/hashicorp/consul/api@v1.3.0"
     assert "raw.go" in pkg_info.go_files
 
 
@@ -545,6 +545,6 @@ def test_ambiguous_package(rule_runner: RuleRunner) -> None:
     )
     assert pkg_info.error is not None
     # This particular error is tricky because `Dir` will not have been set, which we need to
-    # determine the subpath and the digest.
-    assert pkg_info.subpath == ""
+    # determine the dir_path and the digest.
+    assert pkg_info.dir_path == ""
     assert pkg_info.digest == EMPTY_DIGEST


### PR DESCRIPTION
We were using the `subpath` to mean two different things, which was really confusing when trying to implement  https://github.com/pantsbuild/pants/issues/13488.

Now we use `dir_path` and `dir_path_rel_to_gomod`.