### PR TITLE
Stop generating `go_package` targets from `go_mod`

### DIFF
--- a/src/python/pants/backend/go/goals/package_binary_integration_test.py
+++ b/src/python/pants/backend/go/goals/package_binary_integration_test.py
@@ -12,7 +12,7 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals import package_binary
 from pants.backend.go.goals.package_binary import GoBinaryFieldSet
-from pants.backend.go.target_types import GoBinaryTarget, GoModTarget
+from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackageTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -48,7 +48,7 @@ def rule_runner() -> RuleRunner:
             *sdk.rules(),
             QueryRule(BuiltPackage, (GoBinaryFieldSet,)),
         ],
-        target_types=[GoBinaryTarget, GoModTarget],
+        target_types=[GoBinaryTarget, GoModTarget, GoPackageTarget],
     )
     rule_runner.set_options([], env_inherit={"PATH"})
     return rule_runner
@@ -86,6 +86,7 @@ def test_package_simple(rule_runner: RuleRunner) -> None:
             "BUILD": dedent(
                 """\
                 go_mod(name='mod')
+                go_package(name='pkg')
                 go_binary(name='bin')
                 """
             ),
@@ -122,6 +123,7 @@ def test_package_with_dependencies(rule_runner: RuleRunner) -> None:
                 }
                 """
             ),
+            "lib/BUILD": "go_package()",
             "main.go": dedent(
                 """\
                 package main
@@ -161,6 +163,7 @@ def test_package_with_dependencies(rule_runner: RuleRunner) -> None:
             "BUILD": dedent(
                 """\
                 go_mod(name='mod')
+                go_package(name='pkg')
                 go_binary(name='bin')
                 """
             ),

--- a/src/python/pants/backend/go/goals/run_binary_integration_test.py
+++ b/src/python/pants/backend/go/goals/run_binary_integration_test.py
@@ -35,6 +35,7 @@ def test_run_binary() -> None:
         "BUILD": dedent(
             """\
                 go_mod(name='mod')
+                go_package(name='pkg')
                 go_binary(name='bin')
                 """
         ),

--- a/src/python/pants/backend/go/goals/tailor.py
+++ b/src/python/pants/backend/go/goals/tailor.py
@@ -76,10 +76,9 @@ async def find_putative_go_targets(
         if t.has_field(GoBinaryMainPackageField)
     )
     unowned_main_package_dirs = set(main_package_dirs) - {
-        # We can be confident `go_package` targets were generated, meaning that the
-        # below will get us the full path to the package's directory.
-        # TODO: generalize this
-        os.path.join(pkg.address.spec_path, pkg.address.generated_name[2:]).rstrip("/")  # type: ignore[index]
+        # NB: We assume the `go_package` lives in the directory it's defined, which we validate
+        # by e.g. banning `**` in its sources field.
+        pkg.address.spec_path
         for pkg in owned_main_packages
     }
     putative_targets.extend(

--- a/src/python/pants/backend/go/goals/test_test.py
+++ b/src/python/pants/backend/go/goals/test_test.py
@@ -11,7 +11,7 @@ from pants.backend.go import target_type_rules
 from pants.backend.go.goals.test import GoTestFieldSet
 from pants.backend.go.goals.test import rules as test_rules
 from pants.backend.go.goals.test import transform_test_args
-from pants.backend.go.target_types import GoModTarget
+from pants.backend.go.target_types import GoModTarget, GoPackageTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -45,7 +45,7 @@ def rule_runner() -> RuleRunner:
             *third_party_pkg.rules(),
             QueryRule(TestResult, [GoTestFieldSet]),
         ],
-        target_types=[GoModTarget],
+        target_types=[GoModTarget, GoPackageTarget],
     )
     rule_runner.set_options(["--go-test-args=-v -bench=."], env_inherit={"PATH"})
     return rule_runner
@@ -65,7 +65,7 @@ def test_transform_test_args() -> None:
 def test_internal_test_success(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "foo/BUILD": "go_mod()",
+            "foo/BUILD": "go_mod(name='mod')\ngo_package()",
             "foo/go.mod": "module foo",
             "foo/add.go": textwrap.dedent(
                 """
@@ -88,7 +88,7 @@ def test_internal_test_success(rule_runner: RuleRunner) -> None:
             ),
         }
     )
-    tgt = rule_runner.get_target(Address("foo", generated_name="./"))
+    tgt = rule_runner.get_target(Address("foo"))
     result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
     assert result.exit_code == 0
     assert "PASS: TestAdd" in result.stdout
@@ -97,7 +97,7 @@ def test_internal_test_success(rule_runner: RuleRunner) -> None:
 def test_internal_test_fails(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "foo/BUILD": "go_mod()",
+            "foo/BUILD": "go_mod(name='mod')\ngo_package()",
             "foo/go.mod": "module foo",
             "foo/bar_test.go": textwrap.dedent(
                 """
@@ -110,7 +110,7 @@ def test_internal_test_fails(rule_runner: RuleRunner) -> None:
             ),
         }
     )
-    tgt = rule_runner.get_target(Address("foo", generated_name="./"))
+    tgt = rule_runner.get_target(Address("foo"))
     result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
     assert result.exit_code == 1
     assert "FAIL: TestAdd" in result.stdout
@@ -119,7 +119,7 @@ def test_internal_test_fails(rule_runner: RuleRunner) -> None:
 def test_internal_benchmark_passes(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "foo/BUILD": "go_mod()",
+            "foo/BUILD": "go_mod(name='mod')\ngo_package()",
             "foo/go.mod": "module foo",
             "foo/fib.go": textwrap.dedent(
                 """
@@ -145,7 +145,7 @@ def test_internal_benchmark_passes(rule_runner: RuleRunner) -> None:
             ),
         }
     )
-    tgt = rule_runner.get_target(Address("foo", generated_name="./"))
+    tgt = rule_runner.get_target(Address("foo"))
     result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
     assert result.exit_code == 0
     assert "BenchmarkAdd" in result.stdout
@@ -155,7 +155,7 @@ def test_internal_benchmark_passes(rule_runner: RuleRunner) -> None:
 def test_internal_example_passes(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "foo/BUILD": "go_mod()",
+            "foo/BUILD": "go_mod(name='mod')\ngo_package()",
             "foo/go.mod": "module foo",
             "foo/print_test.go": textwrap.dedent(
                 """
@@ -171,7 +171,7 @@ def test_internal_example_passes(rule_runner: RuleRunner) -> None:
             ),
         }
     )
-    tgt = rule_runner.get_target(Address("foo", generated_name="./"))
+    tgt = rule_runner.get_target(Address("foo"))
     result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
     assert result.exit_code == 0
     assert "PASS: ExamplePrint" in result.stdout
@@ -180,7 +180,7 @@ def test_internal_example_passes(rule_runner: RuleRunner) -> None:
 def test_internal_test_with_test_main(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "foo/BUILD": "go_mod()",
+            "foo/BUILD": "go_mod(name='mod')\ngo_package()",
             "foo/go.mod": "module foo",
             "foo/add_test.go": textwrap.dedent(
                 """
@@ -200,7 +200,7 @@ def test_internal_test_with_test_main(rule_runner: RuleRunner) -> None:
             ),
         }
     )
-    tgt = rule_runner.get_target(Address("foo", generated_name="./"))
+    tgt = rule_runner.get_target(Address("foo"))
     result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
     assert result.exit_code == 1
     assert "foo.TestMain called" in result.stdout
@@ -211,12 +211,14 @@ def test_internal_test_fails_to_compile(rule_runner: RuleRunner) -> None:
     """A compilation failure should not cause Pants to error, only the test to fail."""
     rule_runner.write_files(
         {
-            "foo/BUILD": "go_mod()",
+            "foo/BUILD": "go_mod(name='mod')\ngo_package()",
             "foo/go.mod": "module foo",
             # Test itself is bad.
             "foo/bad_test.go": "invalid!!!",
             # A dependency of the test is bad.
             "foo/dep/f.go": "invalid!!!",
+            "foo/dep/BUILD": "go_package()",
+            "foo/uses_dep/BUILD": "go_package()",
             "foo/uses_dep/f_test.go": textwrap.dedent(
                 """
                 package uses_dep
@@ -235,12 +237,12 @@ def test_internal_test_fails_to_compile(rule_runner: RuleRunner) -> None:
             ),
         }
     )
-    tgt = rule_runner.get_target(Address("foo", generated_name="./"))
+    tgt = rule_runner.get_target(Address("foo"))
     result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
     assert result.exit_code == 1
     assert "bad_test.go:1:1: expected 'package', found invalid\n" in result.stderr
 
-    tgt = rule_runner.get_target(Address("foo", generated_name="./uses_dep"))
+    tgt = rule_runner.get_target(Address("foo/uses_dep"))
     result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
     assert result.exit_code == 1
     assert "dep/f.go:1:1: expected 'package', found invalid\n" in result.stderr
@@ -249,7 +251,7 @@ def test_internal_test_fails_to_compile(rule_runner: RuleRunner) -> None:
 def test_external_test_success(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "foo/BUILD": "go_mod()",
+            "foo/BUILD": "go_mod(name='mod')\ngo_package()",
             "foo/go.mod": "module foo",
             "foo/add.go": textwrap.dedent(
                 """
@@ -275,7 +277,7 @@ def test_external_test_success(rule_runner: RuleRunner) -> None:
             ),
         }
     )
-    tgt = rule_runner.get_target(Address("foo", generated_name="./"))
+    tgt = rule_runner.get_target(Address("foo"))
     result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
     assert result.exit_code == 0
     assert "PASS: TestAdd" in result.stdout
@@ -284,7 +286,7 @@ def test_external_test_success(rule_runner: RuleRunner) -> None:
 def test_external_test_fails(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "foo/BUILD": "go_mod()",
+            "foo/BUILD": "go_mod(name='mod')\ngo_package()",
             "foo/go.mod": "module foo",
             "foo/add.go": textwrap.dedent(
                 """
@@ -317,7 +319,7 @@ def test_external_test_fails(rule_runner: RuleRunner) -> None:
 def test_external_benchmark_passes(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "foo/BUILD": "go_mod()",
+            "foo/BUILD": "go_mod(name='mod')\ngo_package()",
             "foo/go.mod": "module foo",
             "foo/fib.go": textwrap.dedent(
                 """
@@ -346,7 +348,7 @@ def test_external_benchmark_passes(rule_runner: RuleRunner) -> None:
             ),
         }
     )
-    tgt = rule_runner.get_target(Address("foo", generated_name="./"))
+    tgt = rule_runner.get_target(Address("foo"))
     result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
     assert result.exit_code == 0
     assert "BenchmarkAdd" in result.stdout
@@ -356,7 +358,7 @@ def test_external_benchmark_passes(rule_runner: RuleRunner) -> None:
 def test_external_example_passes(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "foo/BUILD": "go_mod()",
+            "foo/BUILD": "go_mod(name='mod')\ngo_package()",
             "foo/go.mod": "module foo",
             "foo/print.go": textwrap.dedent(
                 """
@@ -381,7 +383,7 @@ def test_external_example_passes(rule_runner: RuleRunner) -> None:
             ),
         }
     )
-    tgt = rule_runner.get_target(Address("foo", generated_name="./"))
+    tgt = rule_runner.get_target(Address("foo"))
     result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
     assert result.exit_code == 0
     assert "PASS: ExamplePrint" in result.stdout
@@ -390,7 +392,7 @@ def test_external_example_passes(rule_runner: RuleRunner) -> None:
 def test_external_test_with_test_main(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "foo/BUILD": "go_mod()",
+            "foo/BUILD": "go_mod(name='mod')\ngo_package()",
             "foo/go.mod": "module foo",
             "foo/add.go": textwrap.dedent(
                 """
@@ -430,7 +432,7 @@ def test_external_test_with_test_main(rule_runner: RuleRunner) -> None:
 def test_both_internal_and_external_tests_fail(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "foo/BUILD": "go_mod()",
+            "foo/BUILD": "go_mod(name='mod')\ngo_package()",
             "foo/go.mod": "module foo",
             "foo/add.go": textwrap.dedent(
                 """
@@ -465,7 +467,7 @@ def test_both_internal_and_external_tests_fail(rule_runner: RuleRunner) -> None:
             ),
         }
     )
-    tgt = rule_runner.get_target(Address("foo", generated_name="./"))
+    tgt = rule_runner.get_target(Address("foo"))
     result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
     assert result.exit_code == 1
     assert "FAIL: TestAddInternal" in result.stdout

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Sequence
+from typing import Iterable, Optional, Sequence, Tuple
 
 from pants.core.goals.package import OutputPathField
 from pants.core.goals.run import RestartableField
 from pants.engine.addresses import Address
 from pants.engine.engine_aware import EngineAwareParameter
-from pants.engine.fs import GlobExpansionConjunction, GlobMatchErrorBehavior, PathGlobs
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     AsyncFieldMixin,
@@ -20,10 +19,8 @@ from pants.engine.target import (
     InvalidTargetException,
     MultipleSourcesField,
     StringField,
-    StringSequenceField,
     Target,
 )
-from pants.option.global_options import FilesNotFoundBehavior
 
 # -----------------------------------------------------------------------------------------------
 # `go_mod` target generator
@@ -69,51 +66,17 @@ class GoModDependenciesField(Dependencies):
     alias = "_dependencies"
 
 
-# TODO(#12953): generalize this?
-class GoModPackageSourcesField(StringSequenceField, AsyncFieldMixin):
-    alias = "package_sources"
-    default = ("**/*.go", "**/*.s")
-    help = (
-        "What sources to generate `go_package` targets for.\n\n"
-        "Pants will generate one target per matching directory.\n\n"
-        "Pants does not yet support some file types like `.c` and `.h` files, along with cgo "
-        "files. If you need to use these files, please open a feature request at "
-        "https://github.com/pantsbuild/pants/issues/new/choose so that we know to "
-        "prioritize adding support."
-    )
-
-    def _prefix_glob_with_address(self, glob: str) -> str:
-        if glob.startswith("!"):
-            return f"!{os.path.join(self.address.spec_path, glob[1:])}"
-        return os.path.join(self.address.spec_path, glob)
-
-    def path_globs(self, files_not_found_behavior: FilesNotFoundBehavior) -> PathGlobs:
-        error_behavior = files_not_found_behavior.to_glob_match_error_behavior()
-        return PathGlobs(
-            (self._prefix_glob_with_address(glob) for glob in self.value or ()),
-            conjunction=GlobExpansionConjunction.any_match,
-            glob_match_error_behavior=error_behavior,
-            description_of_origin=(
-                f"{self.address}'s `{self.alias}` field"
-                if error_behavior != GlobMatchErrorBehavior.ignore
-                else None
-            ),
-        )
-
-
 class GoModTarget(Target):
     alias = "go_mod"
     core_fields = (
         *COMMON_TARGET_FIELDS,
         GoModDependenciesField,
         GoModSourcesField,
-        GoModPackageSourcesField,
     )
     help = (
         "A first-party Go module (corresponding to a `go.mod` file).\n\n"
-        "Generates `go_package` targets for each directory from the "
-        "`package_sources` field, and generates `go_third_party_package` targets based on "
-        "the `require` directives in your `go.mod`.\n\n"
+        "Generates `go_third_party_package` targets based on the `require` directives in your "
+        "`go.mod`.\n\n"
         "If you have third-party packages, make sure you have an up-to-date `go.sum`. Run "
         "`go mod tidy` directly to update your `go.mod` and `go.sum`."
     )
@@ -125,7 +88,32 @@ class GoModTarget(Target):
 
 
 class GoPackageSourcesField(MultipleSourcesField):
+    default = ("*.go", "*.s")
     expected_file_extensions = (".go", ".s")
+
+    @classmethod
+    def compute_value(
+        cls, raw_value: Optional[Iterable[str]], address: Address
+    ) -> Optional[Tuple[str, ...]]:
+        value_or_default = super().compute_value(raw_value, address)
+        if not value_or_default:
+            raise InvalidFieldException(
+                f"The {repr(cls.alias)} field in target {address} must be set to files/globs in "
+                f"the target's directory, but it was set to {repr(value_or_default)}."
+            )
+
+        # Ban recursive globs and subdirectories. We assume that a `go_package` corresponds
+        # to exactly one directory.
+        invalid_globs = [
+            glob for glob in (value_or_default or ()) if "**" in glob or os.path.sep in glob
+        ]
+        if invalid_globs:
+            raise InvalidFieldException(
+                f"The {repr(cls.alias)} field in target {address} must only have globs for the "
+                f"target's directory, i.e. it cannot include values with `**` and `{os.path.sep}`, "
+                f"but it was set to: {sorted(value_or_default)}"
+            )
+        return value_or_default
 
 
 class GoPackageDependenciesField(Dependencies):
@@ -137,19 +125,8 @@ class GoPackageTarget(Target):
     core_fields = (*COMMON_TARGET_FIELDS, GoPackageDependenciesField, GoPackageSourcesField)
     help = (
         "A first-party Go package (corresponding to a directory with `.go` files).\n\n"
-        "You should not explicitly create this target in BUILD files. Instead, add a `go_mod` "
-        "target where you have your `go.mod` file, which will generate "
-        "`go_package` targets for you."
+        "Expects that there is a `go_mod` target in the current or ancestor directory."
     )
-
-    def validate(self) -> None:
-        if not self.address.is_generated_target:
-            raise InvalidTargetException(
-                f"The `{self.alias}` target type should not be manually created in BUILD "
-                f"files, but it was created for {self.address}.\n\n"
-                "Instead, add a `go_mod` target where you have your `go.mod` file, which will "
-                f"generate `{self.alias}` targets for you."
-            )
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/backend/go/util_rules/assembly_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/assembly_integration_test.py
@@ -12,7 +12,7 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals import package_binary
 from pants.backend.go.goals.package_binary import GoBinaryFieldSet
-from pants.backend.go.target_types import GoBinaryTarget, GoModTarget
+from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackageTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -50,7 +50,7 @@ def rule_runner() -> RuleRunner:
             QueryRule(BuiltPackage, (GoBinaryFieldSet,)),
             QueryRule(FallibleBuiltGoPackage, (BuildGoPackageRequest,)),
         ],
-        target_types=[GoBinaryTarget, GoModTarget],
+        target_types=[GoBinaryTarget, GoModTarget, GoPackageTarget],
     )
     rule_runner.set_options([], env_inherit={"PATH"})
     return rule_runner
@@ -113,6 +113,7 @@ def test_build_package_with_assembly(rule_runner: RuleRunner) -> None:
             "BUILD": dedent(
                 """\
                 go_mod(name="mod")
+                go_package(name="pkg")
                 go_binary(name="bin")
                 """
             ),

--- a/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
@@ -9,7 +9,7 @@ from textwrap import dedent
 import pytest
 
 from pants.backend.go import target_type_rules
-from pants.backend.go.target_types import GoModTarget
+from pants.backend.go.target_types import GoModTarget, GoPackageTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -54,7 +54,7 @@ def rule_runner() -> RuleRunner:
             QueryRule(BuildGoPackageRequest, [BuildGoPackageTargetRequest]),
             QueryRule(FallibleBuildGoPackageRequest, [BuildGoPackageTargetRequest]),
         ],
-        target_types=[GoModTarget],
+        target_types=[GoModTarget, GoPackageTarget],
     )
     rule_runner.set_options([], env_inherit={"PATH"})
     return rule_runner
@@ -122,12 +122,12 @@ def test_build_first_party_pkg_target(rule_runner: RuleRunner) -> None:
                 }
                 """
             ),
-            "BUILD": "go_mod(name='mod')",
+            "BUILD": "go_mod(name='mod')\ngo_package(name='pkg')",
         }
     )
     assert_pkg_target_built(
         rule_runner,
-        Address("", target_name="mod", generated_name="./"),
+        Address("", target_name="pkg"),
         expected_import_path="example.com/greeter",
         expected_dir_path="",
         expected_go_file_names=["greeter.go"],
@@ -196,6 +196,7 @@ def test_build_target_with_dependencies(rule_runner: RuleRunner) -> None:
                 }
                 """
             ),
+            "greeter/quoter/BUILD": "go_package()",
             "greeter/lib.go": dedent(
                 """\
                 package greeter
@@ -212,6 +213,7 @@ def test_build_target_with_dependencies(rule_runner: RuleRunner) -> None:
                 }
                 """
             ),
+            "greeter/BUILD": "go_package()",
             "main.go": dedent(
                 """\
                 package main
@@ -236,7 +238,7 @@ def test_build_target_with_dependencies(rule_runner: RuleRunner) -> None:
                 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
                 """
             ),
-            "BUILD": "go_mod(name='mod')",
+            "BUILD": "go_mod(name='mod')\ngo_package(name='pkg')",
         }
     )
 
@@ -273,7 +275,7 @@ def test_build_target_with_dependencies(rule_runner: RuleRunner) -> None:
     quoter_import_path = "example.com/project/greeter/quoter"
     assert_pkg_target_built(
         rule_runner,
-        Address("", target_name="mod", generated_name="./greeter/quoter"),
+        Address("greeter/quoter"),
         expected_import_path=quoter_import_path,
         expected_dir_path="greeter/quoter",
         expected_go_file_names=["lib.go"],
@@ -284,17 +286,17 @@ def test_build_target_with_dependencies(rule_runner: RuleRunner) -> None:
     greeter_import_path = "example.com/project/greeter"
     assert_pkg_target_built(
         rule_runner,
-        Address("", target_name="mod", generated_name="./greeter"),
+        Address("greeter"),
         expected_import_path=greeter_import_path,
         expected_dir_path="greeter",
         expected_go_file_names=["lib.go"],
-        expected_direct_dependency_import_paths=[quoter_import_path, xerrors_import_path],
+        expected_direct_dependency_import_paths=[xerrors_import_path, quoter_import_path],
         expected_transitive_dependency_import_paths=[xerrors_internal_import_path],
     )
 
     assert_pkg_target_built(
         rule_runner,
-        Address("", target_name="mod", generated_name="./"),
+        Address("", target_name="pkg"),
         expected_import_path="example.com/project",
         expected_dir_path="",
         expected_go_file_names=["main.go"],
@@ -318,7 +320,9 @@ def test_build_invalid_target(rule_runner: RuleRunner) -> None:
             ),
             "BUILD": "go_mod(name='mod')",
             "direct/f.go": "invalid!!!",
+            "direct/BUILD": "go_package()",
             "dep/f.go": "invalid!!!",
+            "dep/BUILD": "go_package()",
             "uses_dep/f.go": dedent(
                 """\
                 package uses_dep
@@ -330,12 +334,12 @@ def test_build_invalid_target(rule_runner: RuleRunner) -> None:
                 }
                 """
             ),
+            "uses_dep/BUILD": "go_package()",
         }
     )
 
     direct_build_request = rule_runner.request(
-        FallibleBuildGoPackageRequest,
-        [BuildGoPackageTargetRequest(Address("", target_name="mod", generated_name="./direct"))],
+        FallibleBuildGoPackageRequest, [BuildGoPackageTargetRequest(Address("direct"))]
     )
     assert direct_build_request.request is None
     assert direct_build_request.exit_code == 1
@@ -344,8 +348,7 @@ def test_build_invalid_target(rule_runner: RuleRunner) -> None:
     )
 
     dep_build_request = rule_runner.request(
-        FallibleBuildGoPackageRequest,
-        [BuildGoPackageTargetRequest(Address("", target_name="mod", generated_name="./uses_dep"))],
+        FallibleBuildGoPackageRequest, [BuildGoPackageTargetRequest(Address("uses_dep"))]
     )
     assert dep_build_request.request is None
     assert dep_build_request.exit_code == 1


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/13488. Tl;dr: we believe that metadata should live near the code it defines. 

At first it seemed like there was no need to have metadata on a `go_package` target, but turns out we need things like a `test_timeout` field and `dependencies` for `resources`. It's clunky to force people into using `overrides`.

A followup will have `./pants tailor` generate these targets.

Note that we enforce that the target corresponds to exactly one directory by banning `**` and `/` in the `sources` field.

[ci skip-rust]
[ci skip-build-wheels]