### PR TITLE
[internal] tailor adds go_package targets

### DIFF
--- a/src/python/pants/backend/go/goals/tailor_test.py
+++ b/src/python/pants/backend/go/goals/tailor_test.py
@@ -69,7 +69,7 @@ def test_find_go_mod_targets(rule_runner: RuleRunner) -> None:
     )
 
 
-def test_find_go_mod_targets(rule_runner: RuleRunner) -> None:
+def test_find_go_package_targets(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
             "unowned/f.go": "",
@@ -104,9 +104,6 @@ def test_find_go_binary_targets(rule_runner: RuleRunner) -> None:
             "missing_binary_tgt/BUILD": "go_package()",
             "tgt_already_exists/app.go": "package main",
             "tgt_already_exists/BUILD": "go_binary(name='bin')\ngo_package()",
-            # TODO: should not fail the build
-            # "missing_pkg_tgt/app.go": "package main",
-            # "missing_pkg_tgt/BUILD": "go_binary()",
             "missing_pkg_and_binary_tgt/app.go": "package main",
             "main_set_to_different_dir/subdir/app.go": "package main",
             "main_set_to_different_dir/subdir/BUILD": "go_package()",

--- a/src/python/pants/backend/go/goals/tailor_test.py
+++ b/src/python/pants/backend/go/goals/tailor_test.py
@@ -51,41 +51,100 @@ def rule_runner() -> RuleRunner:
     return rule_runner
 
 
-def test_find_putative_go_targets(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files(
-        {
-            # No `go_mod`, should be created.
-            "src/go/unowned/go.mod": "module example.com/src/go/unowned\n",
-            # Already has `go_mod`.
-            "src/go/owned/go.mod": "module example.com/src/go/owned\n",
-            "src/go/owned/BUILD": "go_mod()\n",
-            # Missing `go_binary()`, should be created.
-            "src/go/owned/pkg1/app.go": "package main",
-            "src/go/owned/pkg1/BUILD": "go_package()",
-            # Already has a `go_binary()`.
-            "src/go/owned/pkg2/app.go": "package main",
-            "src/go/owned/pkg2/BUILD": "go_binary()\ngo_package(name='pkg')",
-            # Has a `go_binary` defined in a different directory.
-            "src/go/owned/pkg3/subdir/app.go": "package main",
-            "src/go/owned/pkg3/subdir/BUILD": "go_package()",
-            "src/go/owned/pkg3/BUILD": "go_binary(main='src/go/owned/pkg3/subdir')",
-        }
-    )
+def test_find_go_mod_targets(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files({"unowned/go.mod": "", "owned/go.mod": "", "owned/BUILD": "go_mod()"})
     putative_targets = rule_runner.request(
         PutativeTargets,
         [
-            PutativeGoTargetsRequest(PutativeTargetsSearchPaths(("src/",))),
-            AllOwnedSources(["src/go/owned/go.mod"]),
+            PutativeGoTargetsRequest(PutativeTargetsSearchPaths(("",))),
+            AllOwnedSources(["owned/go.mod"]),
         ],
     )
     assert putative_targets == PutativeTargets(
         [
             PutativeTarget.for_target_type(
-                GoModTarget, path="src/go/unowned", name="unowned", triggering_sources=["go.mod"]
+                GoModTarget, path="unowned", name="unowned", triggering_sources=["go.mod"]
+            )
+        ]
+    )
+
+
+def test_find_go_mod_targets(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "unowned/f.go": "",
+            "unowned/f1.go": "",
+            "owned/f.go": "",
+            "owned/BUILD": "go_package()",
+        }
+    )
+    putative_targets = rule_runner.request(
+        PutativeTargets,
+        [
+            PutativeGoTargetsRequest(PutativeTargetsSearchPaths(("",))),
+            AllOwnedSources(["owned/f.go"]),
+        ],
+    )
+    assert putative_targets == PutativeTargets(
+        [
+            PutativeTarget.for_target_type(
+                GoPackageTarget,
+                path="unowned",
+                name="unowned",
+                triggering_sources=["f.go", "f1.go"],
+            )
+        ]
+    )
+
+
+def test_find_go_binary_targets(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "missing_binary_tgt/app.go": "package main",
+            "missing_binary_tgt/BUILD": "go_package()",
+            "tgt_already_exists/app.go": "package main",
+            "tgt_already_exists/BUILD": "go_binary(name='bin')\ngo_package()",
+            # TODO: should not fail the build
+            # "missing_pkg_tgt/app.go": "package main",
+            # "missing_pkg_tgt/BUILD": "go_binary()",
+            "missing_pkg_and_binary_tgt/app.go": "package main",
+            "main_set_to_different_dir/subdir/app.go": "package main",
+            "main_set_to_different_dir/subdir/BUILD": "go_package()",
+            "main_set_to_different_dir/BUILD": "go_binary(main='main_set_to_different_dir/subdir')",
+        }
+    )
+    putative_targets = rule_runner.request(
+        PutativeTargets,
+        [
+            PutativeGoTargetsRequest(PutativeTargetsSearchPaths(("",))),
+            AllOwnedSources(
+                [
+                    "missing_binary_tgt/app.go",
+                    "tgt_already_exists/app.go",
+                    "main_set_to_different_dir/subdir/app.go",
+                ]
+            ),
+        ],
+    )
+    assert putative_targets == PutativeTargets(
+        [
+            PutativeTarget.for_target_type(
+                GoBinaryTarget,
+                path="missing_binary_tgt",
+                name="bin",
+                triggering_sources=[],
+                kwargs={"name": "bin"},
+            ),
+            PutativeTarget.for_target_type(
+                GoPackageTarget,
+                path="missing_pkg_and_binary_tgt",
+                name="missing_pkg_and_binary_tgt",
+                triggering_sources=["app.go"],
+                kwargs={},
             ),
             PutativeTarget.for_target_type(
                 GoBinaryTarget,
-                path="src/go/owned/pkg1",
+                path="missing_pkg_and_binary_tgt",
                 name="bin",
                 triggering_sources=[],
                 kwargs={"name": "bin"},

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -261,8 +261,9 @@ async def determine_main_pkg_for_go_binary(
     if not relevant_pkg_targets:
         raise ResolveError(
             f"The `{alias}` target {addr} requires that there is a `go_package` "
-            f"target for its directory {addr.spec_path}, but none were found.\n\n"
-            "(Run `./pants tailor` to automatically add `go_package` targets.)"
+            f"target defined in its directory {addr.spec_path}, but none were found.\n\n"
+            "To fix, add a target like `go_package()` or `go_package(name='pkg')` to the BUILD "
+            f"file in {addr.spec_path}."
         )
     raise ResolveError(
         f"There are multiple `go_package` targets for the same directory of the "

--- a/testprojects/src/go/pants_test/bar/BUILD
+++ b/testprojects/src/go/pants_test/bar/BUILD
@@ -2,5 +2,3 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 go_package()
-
-go_binary(name="bin")


### PR DESCRIPTION
Follow up to https://github.com/pantsbuild/pants/pull/13702.

## Weird edge when upgrading from Pants 2.8: `go_binary`

`go_binary` has a `main` field that points to a `go_package`, but usually it's left off to default to the `go_package` defined in the directory.

Because we no longer generate `go_package` targets, the `go_binary` will now not have a `go_package` target, so our `tailor` rule will error (because it tries to determine which main packages are already owned).

I tried to fix this by making our `GoBinaryMainPackage` fallible, but it was pretty complex code and it resulted in trying to add a second `go_binary` target because it looked like the package was unowned. We could make that much more nuanced, like check if the `main` field is set for the `go_binary` w/ a missing `go_package`. But the code was getting really complex for what should be a one-time migration issue with an experimental backend.

So I kept it simple and made the error message more informative.