### PR TITLE
Add `test_timeout` fields to `go_package`

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -54,7 +54,7 @@ pants_ignore.add = [
 
 build_ignore.add = [
   # Disable Go targets by default so Pants developers do not need Go installed.
-#  "testprojects/src/go/**",
+  "testprojects/src/go/**",
 ]
 
 # NB: Users must still set `--remote-cache-{read,write}` to enable the remote cache.

--- a/pants.toml
+++ b/pants.toml
@@ -54,7 +54,7 @@ pants_ignore.add = [
 
 build_ignore.add = [
   # Disable Go targets by default so Pants developers do not need Go installed.
-  "testprojects/src/go/**",
+#  "testprojects/src/go/**",
 ]
 
 # NB: Users must still set `--remote-cache-{read,write}` to enable the remote cache.

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 from typing import Sequence
 
 from pants.backend.go.subsystems.gotest import GoTestSubsystem
@@ -65,6 +66,7 @@ TEST_FLAGS = {
 }
 
 
+@dataclass(frozen=True)
 class GoTestFieldSet(TestFieldSet):
     required_fields = (GoPackageSourcesField,)
 

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -78,11 +78,9 @@ class GoTestFieldSet(TestFieldSet):
 
 def transform_test_args(args: Sequence[str], timeout_field_value: int | None) -> tuple[str, ...]:
     result = []
-    if timeout_field_value is not None:
-        result.append(f"-test.timeout={timeout_field_value}s")
-
     i = 0
     next_arg_is_option_value = False
+    timeout_is_set = False
     while i < len(args):
         arg = args[i]
         i += 1
@@ -116,10 +114,7 @@ def transform_test_args(args: Sequence[str], timeout_field_value: int | None) ->
         if arg_name in TEST_FLAGS:
             no_opt_provided = TEST_FLAGS[arg_name] and option_value == ""
             if arg_name == "timeout" and timeout_field_value is not None:
-                if no_opt_provided:
-                    # Skip the option value.
-                    i += 1
-                continue
+                timeout_is_set = True
 
             rewritten_arg = f"{arg[0:start_index]}test.{arg_name}{option_value}"
             result.append(rewritten_arg)
@@ -127,6 +122,9 @@ def transform_test_args(args: Sequence[str], timeout_field_value: int | None) ->
                 next_arg_is_option_value = True
         else:
             result.append(arg)
+
+    if not timeout_is_set and timeout_field_value is not None:
+        result.append(f"-test.timeout={timeout_field_value}s")
 
     result.extend(args[i:])
     return tuple(result)

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -114,12 +114,13 @@ def transform_test_args(args: Sequence[str], timeout_field_value: int | None) ->
             option_value = ""
 
         if arg_name in TEST_FLAGS:
-            no_opt_provided = TEST_FLAGS[arg_name] and option_value == ""
-            if arg_name == "timeout" and timeout_field_value is not None:
+            if arg_name == "timeout":
                 timeout_is_set = True
 
             rewritten_arg = f"{arg[0:start_index]}test.{arg_name}{option_value}"
             result.append(rewritten_arg)
+
+            no_opt_provided = TEST_FLAGS[arg_name] and option_value == ""
             if no_opt_provided:
                 next_arg_is_option_value = True
         else:

--- a/src/python/pants/backend/go/goals/test_test.py
+++ b/src/python/pants/backend/go/goals/test_test.py
@@ -52,12 +52,38 @@ def rule_runner() -> RuleRunner:
 
 
 def test_transform_test_args() -> None:
-    assert transform_test_args(["-v", "--", "-v"]) == ("-test.v", "--", "-v")
-    assert transform_test_args(["-run=TestFoo", "-v"]) == ("-test.run=TestFoo", "-test.v")
-    assert transform_test_args(["-run", "TestFoo", "-foo", "-v"]) == (
+    assert transform_test_args(["-v", "--", "-v"], timeout_field_value=None) == (
+        "-test.v",
+        "--",
+        "-v",
+    )
+    assert transform_test_args(["-run=TestFoo", "-v"], timeout_field_value=None) == (
+        "-test.run=TestFoo",
+        "-test.v",
+    )
+    assert transform_test_args(["-run", "TestFoo", "-foo", "-v"], timeout_field_value=None) == (
         "-test.run",
         "TestFoo",
         "-foo",
+        "-test.v",
+    )
+
+    assert transform_test_args(["-timeout=1m", "-v"], timeout_field_value=None) == (
+        "-test.timeout=1m",
+        "-test.v",
+    )
+    assert transform_test_args(["-timeout", "1m", "-v"], timeout_field_value=None) == (
+        "-test.timeout",
+        "1m",
+        "-test.v",
+    )
+    assert transform_test_args(["-v"], timeout_field_value=100) == ("-test.timeout=100s", "-test.v")
+    assert transform_test_args(["-timeout=1m", "-v"], timeout_field_value=100) == (
+        "-test.timeout=100s",
+        "-test.v",
+    )
+    assert transform_test_args(["-timeout", "1m", "-v"], timeout_field_value=100) == (
+        "-test.timeout=100s",
         "-test.v",
     )
 

--- a/src/python/pants/backend/go/goals/test_test.py
+++ b/src/python/pants/backend/go/goals/test_test.py
@@ -77,13 +77,14 @@ def test_transform_test_args() -> None:
         "1m",
         "-test.v",
     )
-    assert transform_test_args(["-v"], timeout_field_value=100) == ("-test.timeout=100s", "-test.v")
+    assert transform_test_args(["-v"], timeout_field_value=100) == ("-test.v", "-test.timeout=100s")
     assert transform_test_args(["-timeout=1m", "-v"], timeout_field_value=100) == (
-        "-test.timeout=100s",
+        "-test.timeout=1m",
         "-test.v",
     )
     assert transform_test_args(["-timeout", "1m", "-v"], timeout_field_value=100) == (
-        "-test.timeout=100s",
+        "-test.timeout",
+        "1m",
         "-test.v",
     )
 

--- a/src/python/pants/backend/go/subsystems/gotest.py
+++ b/src/python/pants/backend/go/subsystems/gotest.py
@@ -24,10 +24,7 @@ class GoTestSubsystem(Subsystem):
                 '`--go-test-args="-run TestFoo -v"`.\n\n'
                 "Known Go test options will be transformed into the form expected by the test "
                 "binary, e.g. `-v` becomes `-test.v`. Run `go help testflag` from the Go SDK to "
-                "learn more about the options supported by Go test binaries.\n\n"
-                "The `-timeout` arg can be used to set a default timeout for each `go_package`, "
-                "e.g. `-timeout=2m`. The default can be overridden for each `go_package` via the "
-                "`test_timeout` field."
+                "learn more about the options supported by Go test binaries."
             ),
         )
 

--- a/src/python/pants/backend/go/subsystems/gotest.py
+++ b/src/python/pants/backend/go/subsystems/gotest.py
@@ -20,10 +20,14 @@ class GoTestSubsystem(Subsystem):
             member_type=shell_str,
             passthrough=True,
             help=(
-                'Arguments to pass directly to the Go test binary, e.g. `--go-test-args="-run TestFoo -v"` '
-                "Known Go test options will be transformed into the form expected by the test binary, "
-                "e.g. `-v` becomes `-test.v`. Run `go help testflag` from the Go SDK to learn more about "
-                "the options supported by Go test binaries."
+                "Arguments to pass directly to the Go test binary, e.g. "
+                '`--go-test-args="-run TestFoo -v"`.\n\n'
+                "Known Go test options will be transformed into the form expected by the test "
+                "binary, e.g. `-v` becomes `-test.v`. Run `go help testflag` from the Go SDK to "
+                "learn more about the options supported by Go test binaries.\n\n"
+                "The `-timeout` arg can be used to set a default timeout for each `go_package`, "
+                "e.g. `-timeout=2m`. The default can be overridden for each `go_package` via the "
+                "`test_timeout` field."
             ),
         )
 

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -133,9 +133,7 @@ class GoTestTimeoutField(IntField):
     alias = "test_timeout"
     help = (
         "A timeout (in seconds) when running this package's tests.\n\n"
-        "You can set a default timeout by setting `-timeout=2m`, for example, in the "
-        "`[go-test].args` option. Otherwise, if this field is not set, the test will never time "
-        "out."
+        "If this field is not set, the test will never time out."
     )
     valid_numbers = ValidNumbers.positive_and_zero
 

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -16,11 +16,13 @@ from pants.engine.target import (
     AsyncFieldMixin,
     BoolField,
     Dependencies,
+    IntField,
     InvalidFieldException,
     InvalidTargetException,
     MultipleSourcesField,
     StringField,
     Target,
+    ValidNumbers,
 )
 
 # -----------------------------------------------------------------------------------------------
@@ -127,12 +129,24 @@ class SkipGoTestsField(BoolField):
     help = "If true, don't run this package's tests."
 
 
+class GoTestTimeoutField(IntField):
+    alias = "test_timeout"
+    help = (
+        "A timeout (in seconds) when running this package's tests.\n\n"
+        "You can set a default timeout by setting `-timeout=2m`, for example, in the "
+        "`[go-test].args` option. Otherwise, if this field is not set, the test will never time "
+        "out."
+    )
+    valid_numbers = ValidNumbers.positive_and_zero
+
+
 class GoPackageTarget(Target):
     alias = "go_package"
     core_fields = (
         *COMMON_TARGET_FIELDS,
         GoPackageDependenciesField,
         GoPackageSourcesField,
+        GoTestTimeoutField,
         SkipGoTestsField,
     )
     help = (


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/13530.

Unlike Python, we use Go's native timeout support instead of the engine's. Users could have already set the timeout globally via `[go-test].args`, so we have to special-case that the field should override those args.