### PR TITLE
Add `skip_tests` field to `go_package` and `shunit2_test`

### DIFF
--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -7,7 +7,7 @@ import os
 from typing import Sequence
 
 from pants.backend.go.subsystems.gotest import GoTestSubsystem
-from pants.backend.go.target_types import GoPackageSourcesField
+from pants.backend.go.target_types import GoPackageSourcesField, SkipGoTestsField
 from pants.backend.go.util_rules.build_pkg import (
     BuildGoPackageRequest,
     FallibleBuildGoPackageRequest,
@@ -26,6 +26,7 @@ from pants.engine.fs import EMPTY_FILE_DIGEST, Digest, MergeDigests
 from pants.engine.internals.selectors import Get
 from pants.engine.process import FallibleProcessResult, Process, ProcessCacheScope
 from pants.engine.rules import collect_rules, rule
+from pants.engine.target import Target
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
@@ -64,6 +65,10 @@ class GoTestFieldSet(TestFieldSet):
     required_fields = (GoPackageSourcesField,)
 
     sources: GoPackageSourcesField
+
+    @classmethod
+    def opt_out(cls, tgt: Target) -> bool:
+        return tgt.get(SkipGoTestsField).value
 
 
 def transform_test_args(args: Sequence[str]) -> tuple[str, ...]:

--- a/src/python/pants/backend/go/goals/test_test.py
+++ b/src/python/pants/backend/go/goals/test_test.py
@@ -472,3 +472,24 @@ def test_both_internal_and_external_tests_fail(rule_runner: RuleRunner) -> None:
     assert result.exit_code == 1
     assert "FAIL: TestAddInternal" in result.stdout
     assert "FAIL: TestAddExternal" in result.stdout
+
+
+def test_skip_tests(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "f_test.go": "",
+            "BUILD": textwrap.dedent(
+                """\
+                go_package(name='run')
+                go_package(name='skip', skip_tests=True)
+                """
+            ),
+        }
+    )
+
+    def is_applicable(tgt_name: str) -> bool:
+        tgt = rule_runner.get_target(Address("", target_name=tgt_name))
+        return GoTestFieldSet.is_applicable(tgt)
+
+    assert is_applicable("run")
+    assert not is_applicable("skip")

--- a/src/python/pants/backend/go/lint/gofmt/skip_field.py
+++ b/src/python/pants/backend/go/lint/gofmt/skip_field.py
@@ -8,7 +8,7 @@ from pants.engine.target import BoolField
 class SkipGofmtField(BoolField):
     alias = "skip_gofmt"
     default = False
-    help = "If true, don't run gofmt on this target's code."
+    help = "If true, don't run gofmt on this package."
 
 
 def rules():

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -14,6 +14,7 @@ from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     AsyncFieldMixin,
+    BoolField,
     Dependencies,
     InvalidFieldException,
     InvalidTargetException,
@@ -120,12 +121,24 @@ class GoPackageDependenciesField(Dependencies):
     pass
 
 
+class SkipGoTestsField(BoolField):
+    alias = "skip_tests"
+    default = False
+    help = "If true, don't run this package's tests."
+
+
 class GoPackageTarget(Target):
     alias = "go_package"
-    core_fields = (*COMMON_TARGET_FIELDS, GoPackageDependenciesField, GoPackageSourcesField)
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        GoPackageDependenciesField,
+        GoPackageSourcesField,
+        SkipGoTestsField,
+    )
     help = (
         "A first-party Go package (corresponding to a directory with `.go` files).\n\n"
-        "Expects that there is a `go_mod` target in the current or ancestor directory."
+        "Expects that there is a `go_mod` target in its directory or in an ancestor "
+        "directory."
     )
 
 

--- a/src/python/pants/backend/shell/shunit2_test_runner.py
+++ b/src/python/pants/backend/shell/shunit2_test_runner.py
@@ -12,6 +12,7 @@ from pants.backend.shell.target_types import (
     Shunit2TestsGeneratorTarget,
     Shunit2TestSourceField,
     Shunit2TestTimeoutField,
+    SkipShunit2TestsField,
 )
 from pants.core.goals.test import (
     BuildPackageDependenciesRequest,
@@ -47,7 +48,7 @@ from pants.engine.process import (
     ProcessCacheScope,
 )
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import SourcesField, TransitiveTargets, TransitiveTargetsRequest
+from pants.engine.target import SourcesField, Target, TransitiveTargets, TransitiveTargetsRequest
 from pants.engine.unions import UnionRule
 from pants.option.global_options import GlobalOptions
 from pants.util.logging import LogLevel
@@ -62,6 +63,10 @@ class Shunit2FieldSet(TestFieldSet):
     timeout: Shunit2TestTimeoutField
     shell: Shunit2ShellField
     runtime_package_dependencies: RuntimePackageDependenciesField
+
+    @classmethod
+    def opt_out(cls, tgt: Target) -> bool:
+        return tgt.get(SkipShunit2TestsField).value
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/shell/shunit2_test_runner_test.py
+++ b/src/python/pants/backend/shell/shunit2_test_runner_test.py
@@ -3,7 +3,13 @@
 
 import pytest
 
-from pants.backend.shell.shunit2_test_runner import add_source_shunit2
+from pants.backend.shell.shunit2_test_runner import Shunit2FieldSet, add_source_shunit2
+from pants.backend.shell.target_types import (
+    Shunit2TestSourceField,
+    Shunit2TestTarget,
+    SkipShunit2TestsField,
+)
+from pants.engine.addresses import Address
 from pants.engine.fs import FileContent
 
 
@@ -30,3 +36,15 @@ def test_add_source_shunit2(original: str, expected: str) -> None:
     result = add_source_shunit2(FileContent("f.sh", original.encode())).content.decode()
     print(result)
     assert result == expected
+
+
+@pytest.mark.parametrize("skipped", (True, False))
+def test_skip_tests(skipped: bool) -> None:
+    tgt = Shunit2TestTarget(
+        {Shunit2TestSourceField.alias: "tests.sh", SkipShunit2TestsField.alias: skipped},
+        Address("tests"),
+    )
+    if skipped:
+        assert not Shunit2FieldSet.is_applicable(tgt)
+    else:
+        assert Shunit2FieldSet.is_applicable(tgt)

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -106,6 +106,12 @@ class Shunit2TestTimeoutField(IntField):
     valid_numbers = ValidNumbers.positive_only
 
 
+class SkipShunit2TestsField(BoolField):
+    alias = "skip_tests"
+    default = False
+    help = "If true, don't run this target's tests."
+
+
 class Shunit2TestSourceField(ShellSourceField):
     pass
 
@@ -123,6 +129,7 @@ class Shunit2TestTarget(Target):
         Shunit2TestSourceField,
         Shunit2TestDependenciesField,
         Shunit2TestTimeoutField,
+        SkipShunit2TestsField,
         Shunit2ShellField,
         RuntimePackageDependenciesField,
     )
@@ -167,6 +174,7 @@ class Shunit2TestsGeneratorTarget(Target):
         Shunit2TestsGeneratorSourcesField,
         Shunit2TestDependenciesField,
         Shunit2TestTimeoutField,
+        SkipShunit2TestsField,
         Shunit2ShellField,
         RuntimePackageDependenciesField,
         Shunit2TestsOverrideField,


### PR DESCRIPTION
This is useful for incremental migration, e.g. using Pants to run gofmt but `./pants test ::` not trying to run tests.