### PR TITLE
Fix UI rendering of Go packages with no tests

### DIFF
--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -149,17 +149,7 @@ async def run_go_tests(
     )
 
     if not testmain.has_tests and not testmain.has_xtests:
-        # Nothing to do so return an empty result.
-        # TODO: There should really be a "skipped entirely" mechanism for `TestResult`.
-        return TestResult(
-            exit_code=0,
-            stdout="",
-            stderr="",
-            stdout_digest=EMPTY_FILE_DIGEST,
-            stderr_digest=EMPTY_FILE_DIGEST,
-            address=field_set.address,
-            output_setting=test_subsystem.output,
-        )
+        return TestResult.skip(field_set.address, output_setting=test_subsystem.output)
 
     # Construct the build request for the package under test.
     maybe_test_pkg_build_request = await Get(
@@ -263,7 +253,7 @@ async def run_go_tests(
             input_digest=binary.digest,
             description=f"Run Go tests: {field_set.address}",
             cache_scope=cache_scope,
-            level=LogLevel.INFO,
+            level=LogLevel.DEBUG,
         ),
     )
     return TestResult.from_fallible_process_result(result, field_set.address, test_subsystem.output)

--- a/src/python/pants/backend/go/goals/test_test.py
+++ b/src/python/pants/backend/go/goals/test_test.py
@@ -493,3 +493,23 @@ def test_skip_tests(rule_runner: RuleRunner) -> None:
 
     assert is_applicable("run")
     assert not is_applicable("skip")
+
+
+def test_no_tests(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "foo/BUILD": "go_mod(name='mod')\ngo_package()",
+            "foo/go.mod": "module foo",
+            "foo/add.go": textwrap.dedent(
+                """
+                package foo
+                func add(x, y int) int {
+                  return x + y
+                }
+                """
+            ),
+        }
+    )
+    tgt = rule_runner.get_target(Address("foo"))
+    result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
+    assert result.skipped

--- a/src/python/pants/backend/go/util_rules/tests_analysis.py
+++ b/src/python/pants/backend/go/util_rules/tests_analysis.py
@@ -10,20 +10,23 @@ from typing import ClassVar
 from pants.backend.go.util_rules.build_pkg import BuildGoPackageRequest, BuiltGoPackage
 from pants.backend.go.util_rules.import_analysis import ImportConfig, ImportConfigRequest
 from pants.backend.go.util_rules.link import LinkedGoBinary, LinkGoBinaryRequest
+from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests
-from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import collect_rules, rule
+from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
 
 
 @dataclass(frozen=True)
-class GenerateTestMainRequest:
+class GenerateTestMainRequest(EngineAwareParameter):
     digest: Digest
     test_paths: FrozenOrderedSet[str]
     xtest_paths: FrozenOrderedSet[str]
     import_path: str
+
+    def debug_hint(self) -> str | None:
+        return self.import_path
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -19,7 +19,7 @@ from pants.engine.console import Console
 from pants.engine.desktop import OpenFiles, OpenFilesRequest
 from pants.engine.engine_aware import EngineAwareReturnType
 from pants.engine.environment import Environment, EnvironmentRequest
-from pants.engine.fs import Digest, FileDigest, MergeDigests, Snapshot, Workspace
+from pants.engine.fs import Digest, FileDigest, MergeDigests, Snapshot, Workspace, EMPTY_FILE_DIGEST
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import FallibleProcessResult, InteractiveProcess, InteractiveProcessResult
 from pants.engine.rules import Effect, Get, MultiGet, collect_rules, goal_rule, rule
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class TestResult(EngineAwareReturnType):
-    exit_code: int
+    exit_code: int | None
     stdout: str
     stdout_digest: FileDigest
     stderr: str
@@ -57,6 +57,18 @@ class TestResult(EngineAwareReturnType):
 
     # Prevent this class from being detected by pytest as a test class.
     __test__ = False
+
+    @classmethod
+    def skip(cls, address: Address, output_setting: ShowOutput) -> TestResult:
+        return cls(
+            exit_code=None,
+            stdout="",
+            stderr="",
+            stdout_digest=EMPTY_FILE_DIGEST,
+            stderr_digest=EMPTY_FILE_DIGEST,
+            address=address,
+            output_setting=output_setting,
+        )
 
     @classmethod
     def from_fallible_process_result(
@@ -82,13 +94,21 @@ class TestResult(EngineAwareReturnType):
             extra_output=extra_output,
         )
 
+    @property
+    def skipped(self) -> bool:
+        return self.exit_code is None and not self.stdout and not self.stderr
+
     def __lt__(self, other: Any) -> bool:
-        """We sort first by status (failed vs succeeded), then alphanumerically within each
-        group."""
+        """We sort first by status (skipped vs failed vs succeeded), then alphanumerically within
+        each group."""
         if not isinstance(other, TestResult):
             return NotImplemented
         if self.exit_code == other.exit_code:
             return self.address.spec < other.address.spec
+        if self.exit_code is None:
+            return True
+        if other.exit_code is None:
+            return False
         return abs(self.exit_code) < abs(other.exit_code)
 
     def artifacts(self) -> dict[str, FileDigest | Snapshot] | None:
@@ -101,9 +121,13 @@ class TestResult(EngineAwareReturnType):
         return output
 
     def level(self) -> LogLevel:
+        if self.skipped:
+            return LogLevel.DEBUG
         return LogLevel.INFO if self.exit_code == 0 else LogLevel.ERROR
 
     def message(self) -> str:
+        if self.skipped:
+            return f"{self.address} skipped."
         status = "succeeded" if self.exit_code == 0 else f"failed (exit code {self.exit_code})"
         message = f"{self.address} {status}."
         if self.output_setting == ShowOutput.NONE or (
@@ -137,7 +161,7 @@ class ShowOutput(Enum):
 
 @dataclass(frozen=True)
 class TestDebugRequest:
-    process: InteractiveProcess
+    process: InteractiveProcess | None
 
     # Prevent this class from being detected by pytest as a test class.
     __test__ = False
@@ -375,7 +399,10 @@ async def run_tests(
             for field_set in targets_to_valid_field_sets.field_sets
         )
         exit_code = 0
-        for debug_request in debug_requests:
+        for debug_request, field_set in zip(debug_requests, targets_to_valid_field_sets.field_sets):
+            if debug_request.process is None:
+                logger.debug(f"Skipping tests for {field_set.address}")
+                continue
             debug_result = await Effect(
                 InteractiveProcessResult, InteractiveProcess, debug_request.process
             )
@@ -401,13 +428,15 @@ async def run_tests(
     if results:
         console.print_stderr("")
     for result in sorted(results):
+        if result.skipped:
+            continue
         if result.exit_code == 0:
             sigil = console.sigil_succeeded()
             status = "succeeded"
         else:
             sigil = console.sigil_failed()
             status = "failed"
-            exit_code = result.exit_code
+            exit_code = cast(int, result.exit_code)
         console.print_stderr(f"{sigil} {result.address} {status}.")
         if result.extra_output and result.extra_output.files:
             workspace.write_digest(

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -19,7 +19,7 @@ from pants.engine.console import Console
 from pants.engine.desktop import OpenFiles, OpenFilesRequest
 from pants.engine.engine_aware import EngineAwareReturnType
 from pants.engine.environment import Environment, EnvironmentRequest
-from pants.engine.fs import Digest, FileDigest, MergeDigests, Snapshot, Workspace, EMPTY_FILE_DIGEST
+from pants.engine.fs import EMPTY_FILE_DIGEST, Digest, FileDigest, MergeDigests, Snapshot, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import FallibleProcessResult, InteractiveProcess, InteractiveProcessResult
 from pants.engine.rules import Effect, Get, MultiGet, collect_rules, goal_rule, rule

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -318,7 +318,7 @@ def sort_results() -> None:
 
 def assert_streaming_output(
     *,
-    exit_code: int,
+    exit_code: int | None,
     stdout: str = "stdout",
     stderr: str = "stderr",
     output_setting: ShowOutput = ShowOutput.ALL,
@@ -336,6 +336,16 @@ def assert_streaming_output(
     )
     assert result.level() == expected_level
     assert result.message() == expected_message
+
+
+def test_streaming_output_skip() -> None:
+    assert_streaming_output(
+        exit_code=None,
+        stdout="",
+        stderr="",
+        expected_level=LogLevel.DEBUG,
+        expected_message="demo_test:demo_test skipped.",
+    )
 
 
 def test_streaming_output_success() -> None:

--- a/testprojects/src/go/pants_test/bar/bar.go
+++ b/testprojects/src/go/pants_test/bar/bar.go
@@ -3,7 +3,7 @@ package bar
 import "github.com/google/uuid"
 
 func GenUuid() string {
-    return uuid.NewString()
+	return uuid.NewString()
 }
 
 func Quote(s string) string {

--- a/testprojects/src/go/pants_test/bar/bar_test.go
+++ b/testprojects/src/go/pants_test/bar/bar_test.go
@@ -1,0 +1,9 @@
+package bar
+
+import "testing"
+
+func TestQuote(t *testing.T) {
+	if Quote("hi") != ">> hi <<" {
+		t.Fail()
+	}
+}

--- a/testprojects/src/go/pants_test/foo.go
+++ b/testprojects/src/go/pants_test/foo.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"github.com/pantsbuild/pants/testprojects/src/go/pants_test/bar"
+	"os"
 )
 
 func main() {


### PR DESCRIPTION
Before, we would confusingly render a package without tests as having succeeded, even though it did not run.

This reverts https://github.com/pantsbuild/pants/pull/12516. It turns out that while we can eagerly opt out of running tests sometimes based only on the Target API, e.g. looking at the `skip_tests` field, we sometimes need more information. With Go, we must analyze the package to see if it has tests.

If the analysis didn't succeed to determine if we have tests, we pessimistically assume there were tests and render the analysis/compilation failure as a test failure.

[ci skip-rust]
[ci skip-build-wheels]