### PR TITLE
Fix Go compilation failures causing `test` goal to error

### DIFF
--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -125,17 +125,21 @@ async def run_go_tests(
         FallibleFirstPartyPkgInfo, FirstPartyPkgInfoRequest(field_set.address)
     )
 
-    if maybe_pkg_info.info is None:
-        assert maybe_pkg_info.stderr is not None
+    def compilation_failure(exit_code: int, stderr: str) -> TestResult:
         return TestResult(
-            exit_code=maybe_pkg_info.exit_code,
+            exit_code=exit_code,
             stdout="",
-            stderr=maybe_pkg_info.stderr,
+            stderr=stderr,
             stdout_digest=EMPTY_FILE_DIGEST,
             stderr_digest=EMPTY_FILE_DIGEST,
             address=field_set.address,
             output_setting=test_subsystem.output,
         )
+
+    if maybe_pkg_info.info is None:
+        assert maybe_pkg_info.stderr is not None
+        return compilation_failure(maybe_pkg_info.exit_code, maybe_pkg_info.stderr)
+
     pkg_info = maybe_pkg_info.info
     import_path = pkg_info.import_path
 
@@ -149,9 +153,13 @@ async def run_go_tests(
             FrozenOrderedSet(
                 os.path.join(".", pkg_info.dir_path, name) for name in pkg_info.xtest_files
             ),
-            import_path=import_path,
+            import_path,
+            field_set.address,
         ),
     )
+
+    if testmain.failed_exit_code_and_stderr is not None:
+        return compilation_failure(*testmain.failed_exit_code_and_stderr)
 
     if not testmain.has_tests and not testmain.has_xtests:
         return TestResult.skip(field_set.address, output_setting=test_subsystem.output)
@@ -163,16 +171,11 @@ async def run_go_tests(
     )
     if maybe_test_pkg_build_request.request is None:
         assert maybe_test_pkg_build_request.stderr is not None
-        return TestResult(
-            exit_code=maybe_test_pkg_build_request.exit_code,
-            stdout="",
-            stderr=maybe_test_pkg_build_request.stderr,
-            stdout_digest=EMPTY_FILE_DIGEST,
-            stderr_digest=EMPTY_FILE_DIGEST,
-            address=field_set.address,
-            output_setting=test_subsystem.output,
+        return compilation_failure(
+            maybe_test_pkg_build_request.exit_code, maybe_test_pkg_build_request.stderr
         )
     test_pkg_build_request = maybe_test_pkg_build_request.request
+
     main_direct_deps = [test_pkg_build_request]
 
     if testmain.has_xtests:
@@ -219,15 +222,7 @@ async def run_go_tests(
     )
     if maybe_built_main_pkg.output is None:
         assert maybe_built_main_pkg.stderr is not None
-        return TestResult(
-            exit_code=maybe_built_main_pkg.exit_code,
-            stdout="",
-            stderr=maybe_built_main_pkg.stderr,
-            stdout_digest=EMPTY_FILE_DIGEST,
-            stderr_digest=EMPTY_FILE_DIGEST,
-            address=field_set.address,
-            output_setting=test_subsystem.output,
-        )
+        compilation_failure(maybe_built_main_pkg.exit_code, maybe_built_main_pkg.stderr)
     built_main_pkg = maybe_built_main_pkg.output
 
     main_pkg_a_file_path = built_main_pkg.import_paths_to_pkg_a_files["main"]

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -222,7 +222,7 @@ async def run_go_tests(
     )
     if maybe_built_main_pkg.output is None:
         assert maybe_built_main_pkg.stderr is not None
-        compilation_failure(maybe_built_main_pkg.exit_code, maybe_built_main_pkg.stderr)
+        return compilation_failure(maybe_built_main_pkg.exit_code, maybe_built_main_pkg.stderr)
     built_main_pkg = maybe_built_main_pkg.output
 
     main_pkg_a_file_path = built_main_pkg.import_paths_to_pkg_a_files["main"]


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/13709. It's important that a compilation failure only causes the test to fail, not Pants to crash.

[ci skip-rust]
[ci skip-build-wheels]