### PR TITLE
Expose Pex `--layout` option for `pex_binary`.

### DIFF
--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -15,6 +15,8 @@ from pants.backend.python.target_types import (
     PexIgnoreErrorsField,
     PexIncludeToolsField,
     PexInheritPathField,
+    PexLayout,
+    PexLayoutField,
 )
 from pants.backend.python.target_types import PexPlatformsField as PythonPlatformsField
 from pants.backend.python.target_types import (
@@ -62,6 +64,7 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
     shebang: PexShebangField
     strip_env: PexStripEnvField
     platforms: PythonPlatformsField
+    layout: PexLayoutField
     execution_mode: PexExecutionModeField
     include_tools: PexIncludeToolsField
     resolve: PythonResolveField
@@ -129,6 +132,7 @@ async def package_pex_binary(
             platforms=PexPlatforms.create_from_platforms_field(field_set.platforms),
             resolve_and_lockfile=field_set.resolve.resolve_and_lockfile(python_setup),
             output_filename=output_filename,
+            layout=PexLayout(field_set.layout.value),
             additional_args=field_set.generate_additional_args(pex_binary_defaults),
             include_local_dists=True,
         ),

--- a/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import os.path
+import subprocess
 from textwrap import dedent
 
 import pytest
@@ -10,7 +12,7 @@ import pytest
 from pants.backend.python import target_types_rules
 from pants.backend.python.goals import package_pex_binary
 from pants.backend.python.goals.package_pex_binary import PexBinaryFieldSet
-from pants.backend.python.target_types import PexBinary
+from pants.backend.python.target_types import PexBinary, PexLayout, PythonSourcesGeneratorTarget
 from pants.backend.python.util_rules import pex_from_targets
 from pants.build_graph.address import Address
 from pants.core.goals.package import BuiltPackage
@@ -21,7 +23,7 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
-    return RuleRunner(
+    rule_runner = RuleRunner(
         rules=[
             *package_pex_binary.rules(),
             *pex_from_targets.rules(),
@@ -29,12 +31,19 @@ def rule_runner() -> RuleRunner:
             *core_target_types_rules(),
             QueryRule(BuiltPackage, [PexBinaryFieldSet]),
         ],
-        target_types=[PexBinary, FilesGeneratorTarget, RelocatedFiles, ResourcesGeneratorTarget],
+        target_types=[
+            FilesGeneratorTarget,
+            PexBinary,
+            PythonSourcesGeneratorTarget,
+            RelocatedFiles,
+            ResourcesGeneratorTarget,
+        ],
     )
+    rule_runner.set_options([], env_inherit={"PATH", "PYENV_ROOT", "HOME"})
+    return rule_runner
 
 
 def test_warn_files_targets(rule_runner: RuleRunner, caplog) -> None:
-    rule_runner.set_options([], env_inherit={"PATH", "PYENV_ROOT", "HOME"})
     rule_runner.write_files(
         {
             "assets/f.txt": "",
@@ -77,3 +86,39 @@ def test_warn_files_targets(rule_runner: RuleRunner, caplog) -> None:
 
     assert len(result.artifacts) == 1
     assert result.artifacts[0].relpath == "src.py.project/project.pex"
+
+
+@pytest.mark.parametrize(
+    "layout",
+    [pytest.param(layout, id=layout.value) for layout in PexLayout],
+)
+def test_layout(rule_runner: RuleRunner, layout: PexLayout) -> None:
+    rule_runner.write_files(
+        {
+            "src/py/project/app.py": "print('hello')",
+            "src/py/project/BUILD": dedent(
+                f"""\
+                python_sources(name="lib")
+                pex_binary(
+                    entry_point="app.py",
+                    layout="{layout.value}",
+                )
+                """
+            ),
+        }
+    )
+    tgt = rule_runner.get_target(Address("src/py/project"))
+    field_set = PexBinaryFieldSet.create(tgt)
+    result = rule_runner.request(BuiltPackage, [field_set])
+    assert len(result.artifacts) == 1
+    expected_pex_relpath = "src.py.project/project.pex"
+    assert expected_pex_relpath == result.artifacts[0].relpath
+
+    rule_runner.write_digest(result.digest)
+    executable = os.path.join(
+        rule_runner.build_root,
+        expected_pex_relpath
+        if PexLayout.ZIPAPP is layout
+        else os.path.join(expected_pex_relpath, "__main__.py"),
+    )
+    assert b"hello\n" == subprocess.run([executable], check=True, stdout=subprocess.PIPE).stdout

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -441,6 +441,35 @@ class PexExecutionModeField(StringField):
     )
 
 
+class PexLayout(Enum):
+    ZIPAPP = "zipapp"
+    PACKED = "packed"
+    LOOSE = "loose"
+
+
+class PexLayoutField(StringField):
+    alias = "layout"
+    valid_choices = PexLayout
+    expected_type = str
+    default = PexLayout.ZIPAPP.value
+    help = (
+        "The layout used for the PEX binary.\n\nBy default, a PEX is created as a single file "
+        "zipapp, but either a packed or loose directory tree based layout can be chosen instead."
+        "\n\nA packed layout PEX is an executable directory structure designed to have "
+        "cache-friendly characteristics for syncing incremental updates to PEXed applications over "
+        "a network. At the top level of the packed directory tree there is an executable "
+        "`__main__.py` script. The directory can also be executed by passing its path to a Python "
+        "executable; e.g: `python packed-pex-dir/`. The Pex bootstrap code and all dependency code "
+        "are packed into individual zip files for efficient caching and syncing.\n\nA loose layout "
+        "PEX is similar to a packed PEX, except that neither the Pex bootstrap code nor the "
+        "dependency code are packed into zip files, but are instead present as collections of "
+        "loose files in the directory tree providing different caching and syncing tradeoffs.\n\n"
+        "Both zipapp and packed layouts install themselves in the `$PEX_ROOT` as loose apps by "
+        "default before executing, but these layouts compose with "
+        f"`{PexExecutionModeField.alias}='{PexExecutionMode.ZIPAPP.value}'` as well."
+    )
+
+
 class PexIncludeToolsField(BoolField):
     alias = "include_tools"
     default = False
@@ -467,6 +496,7 @@ class PexBinary(Target):
         PexIgnoreErrorsField,
         PexShebangField,
         PexEmitWarningsField,
+        PexLayoutField,
         PexExecutionModeField,
         PexIncludeToolsField,
         RestartableField,

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -518,19 +518,19 @@ async def build_pex(
         ),
     )
 
-    layout = request.layout or PexLayout.ZIPAPP
-    output_files: Iterable[str] | None = None
-    output_directories: Iterable[str] | None = None
     if request.internal_only or is_monolithic_resolve:
         # This is a much friendlier layout for the CAS than the default zipapp.
         layout = PexLayout.PACKED
-        output_directories = [request.output_filename]
     else:
-        if PexLayout.ZIPAPP == layout:
-            output_files = [request.output_filename]
-        else:
-            output_directories = [request.output_filename]
+        layout = request.layout or PexLayout.ZIPAPP
     argv.extend(["--layout", layout.value])
+
+    output_files: Iterable[str] | None = None
+    output_directories: Iterable[str] | None = None
+    if PexLayout.ZIPAPP == layout:
+        output_files = [request.output_filename]
+    else:
+        output_directories = [request.output_filename]
 
     process = await Get(
         Process,

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -20,7 +20,7 @@ from pkg_resources import Requirement
 from pants.backend.python.pip_requirement import PipRequirement
 from pants.backend.python.subsystems.repos import PythonRepos
 from pants.backend.python.subsystems.setup import InvalidLockfileBehavior, PythonSetup
-from pants.backend.python.target_types import MainSpecification
+from pants.backend.python.target_types import MainSpecification, PexLayout
 from pants.backend.python.target_types import PexPlatformsField as PythonPlatformsField
 from pants.backend.python.target_types import PythonRequirementsField
 from pants.backend.python.util_rules import pex_cli
@@ -169,6 +169,7 @@ class PexPlatforms(DeduplicatedCollection[str]):
 class PexRequest(EngineAwareParameter):
     output_filename: str
     internal_only: bool
+    layout: PexLayout | None
     python: PythonExecutable | None
     requirements: PexRequirements | Lockfile | LockfileContent
     interpreter_constraints: InterpreterConstraints
@@ -185,6 +186,7 @@ class PexRequest(EngineAwareParameter):
         *,
         output_filename: str,
         internal_only: bool,
+        layout: PexLayout | None = None,
         python: PythonExecutable | None = None,
         requirements: PexRequirements | Lockfile | LockfileContent = PexRequirements(),
         interpreter_constraints=InterpreterConstraints(),
@@ -204,6 +206,7 @@ class PexRequest(EngineAwareParameter):
             to end users, such as with the `binary` goal. Typically, instead, the user never
             directly uses the Pex, e.g. with `lint` and `test`. If True, we will use a Pex setting
             that results in faster build time but compatibility with fewer interpreters at runtime.
+        :param layout: The filesystem layout to create the PEX with.
         :param python: A particular PythonExecutable to use, which must match any relevant
             interpreter_constraints.
         :param requirements: The requirements that the PEX should contain.
@@ -223,6 +226,7 @@ class PexRequest(EngineAwareParameter):
         """
         self.output_filename = output_filename
         self.internal_only = internal_only
+        self.layout = layout
         self.python = python
         self.requirements = requirements
         self.interpreter_constraints = interpreter_constraints
@@ -241,6 +245,11 @@ class PexRequest(EngineAwareParameter):
                 "Internal only PEXes can only constrain interpreters with interpreter_constraints."
                 f"Given platform constraints {self.platforms} for internal only pex request: "
                 f"{self}."
+            )
+        if self.internal_only and self.layout:
+            raise ValueError(
+                "Internal only PEXes have their layout controlled centrally. Given layout "
+                f"{self.layout} for internal only pex request: {self}."
             )
         if self.python and self.platforms:
             raise ValueError(
@@ -509,14 +518,19 @@ async def build_pex(
         ),
     )
 
+    layout = request.layout or PexLayout.ZIPAPP
     output_files: Iterable[str] | None = None
     output_directories: Iterable[str] | None = None
     if request.internal_only or is_monolithic_resolve:
         # This is a much friendlier layout for the CAS than the default zipapp.
-        argv.extend(["--layout", "packed"])
+        layout = PexLayout.PACKED
         output_directories = [request.output_filename]
     else:
-        output_files = [request.output_filename]
+        if PexLayout.ZIPAPP == layout:
+            output_files = [request.output_filename]
+        else:
+            output_directories = [request.output_filename]
+    argv.extend(["--layout", layout.value])
 
     process = await Get(
         Process,

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -15,6 +15,7 @@ from pants.backend.python.pip_requirement import PipRequirement
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (
     MainSpecification,
+    PexLayout,
     PythonRequirementsField,
     parse_requirements_file,
 )
@@ -61,6 +62,7 @@ class PexFromTargetsRequest:
     addresses: Addresses
     output_filename: str
     internal_only: bool
+    layout: PexLayout | None
     main: MainSpecification | None
     platforms: PexPlatforms
     additional_args: tuple[str, ...]
@@ -83,6 +85,7 @@ class PexFromTargetsRequest:
         *,
         output_filename: str,
         internal_only: bool,
+        layout: PexLayout | None = None,
         main: MainSpecification | None = None,
         platforms: PexPlatforms = PexPlatforms(),
         additional_args: Iterable[str] = (),
@@ -107,6 +110,7 @@ class PexFromTargetsRequest:
             to end users, such as with the `binary` goal. Typically, instead, the user never
             directly uses the Pex, e.g. with `lint` and `test`. If True, we will use a Pex setting
             that results in faster build time but compatibility with fewer interpreters at runtime.
+        :param layout: The filesystem layout to create the PEX with.
         :param main: The main for the built Pex, equivalent to Pex's `-e` or `-c` flag. If
             left off, the Pex will open up as a REPL.
         :param platforms: Which platforms should be supported. Setting this value will cause
@@ -138,6 +142,7 @@ class PexFromTargetsRequest:
         self.addresses = Addresses(addresses)
         self.output_filename = output_filename
         self.internal_only = internal_only
+        self.layout = layout
         self.main = main
         self.platforms = platforms
         self.additional_args = tuple(additional_args)
@@ -333,6 +338,7 @@ async def pex_from_targets(request: PexFromTargetsRequest) -> PexRequest:
     return PexRequest(
         output_filename=request.output_filename,
         internal_only=request.internal_only,
+        layout=request.layout,
         requirements=requirements,
         interpreter_constraints=interpreter_constraints,
         platforms=request.platforms,


### PR DESCRIPTION
This keeps the default of 'zipapp' but allows for advanced uses that may
benefit from 'packed' or 'loose' layouts.

Closes #13397

[ci skip-rust]
[ci skip-build-wheels]