### PR TITLE
Expose Pex `--resolve-local-platforms` option.

### DIFF
--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -18,6 +18,7 @@ from pants.backend.python.target_types import (
 )
 from pants.backend.python.target_types import PexPlatformsField as PythonPlatformsField
 from pants.backend.python.target_types import (
+    PexResolveLocalPlatformsField,
     PexScriptField,
     PexShebangField,
     PexStripEnvField,
@@ -62,6 +63,7 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
     shebang: PexShebangField
     strip_env: PexStripEnvField
     platforms: PythonPlatformsField
+    resolve_local_platforms: PexResolveLocalPlatformsField
     execution_mode: PexExecutionModeField
     include_tools: PexIncludeToolsField
     resolve: PythonResolveField
@@ -74,6 +76,8 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
         args = []
         if self.emit_warnings.value_or_global_default(pex_binary_defaults) is False:
             args.append("--no-emit-warnings")
+        if self.resolve_local_platforms.value_or_global_default(pex_binary_defaults) is True:
+            args.append("--resolve-local-platforms")
         if self.ignore_errors.value is True:
             args.append("--ignore-errors")
         if self.inherit_path.value is not None:

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -437,11 +437,11 @@ class PexEmitWarningsField(TriBoolField):
 class PexResolveLocalPlatformsField(TriBoolField):
     alias = "resolve_local_platforms"
     help = (
-        "Attempt to resolve a local interpreter that matches each of the "
-        f"`{PexPlatformsField.alias}` specified.\n\nIf found, use the interpreter to resolve "
-        "distributions and build any that are only available in source distribution form. If not "
-        "(or if this option is `False`), resolve for each platform by accepting only pre-built "
-        "binary distributions (wheels)."
+        f"For each of the `{PexPlatformsField.alias}` specified, attempt to find a local "
+        "interpreter that matches.\n\nIf a matching interpreter is found, use the interpreter to "
+        "resolve distributions and build any that are only available in source distribution form. "
+        "If no matching interpreter is found (or if this option is `False`), resolve for each "
+        "platform by accepting only pre-built binary distributions (wheels)."
     )
 
     def value_or_global_default(self, pex_binary_defaults: PexBinaryDefaults) -> bool:

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -440,7 +440,7 @@ class PexResolveLocalPlatformsField(TriBoolField):
         f"For each of the `{PexPlatformsField.alias}` specified, attempt to find a local "
         "interpreter that matches.\n\nIf a matching interpreter is found, use the interpreter to "
         "resolve distributions and build any that are only available in source distribution form. "
-        "If no matching interpreter is found (or if this option is `False`), resolve for each "
+        "If no matching interpreter is found (or if this option is `False`), resolve for the "
         "platform by accepting only pre-built binary distributions (wheels)."
     )
 


### PR DESCRIPTION
This provides a default knob in the `pex-binary-defaults` subsystem and
allows over-riding that with the new `resolve_local_platforms` field on
`pex_binary` targets.

Closes #13706

[ci skip-rust]
[ci skip-build-wheels]