### PR TITLE
Compute _RepositoryPex directly from addresses.

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -152,6 +152,13 @@ class PexFromTargetsRequest:
         self.direct_deps_only = direct_deps_only
         self.description = description
 
+    def to_interpreter_constraints_request(self) -> InterpreterConstraintsRequest:
+        return InterpreterConstraintsRequest(
+            addresses=self.addresses,
+            hardcoded_interpreter_constraints=self.hardcoded_interpreter_constraints,
+            direct_deps_only=self.direct_deps_only,
+        )
+
 
 @frozen_after_init
 @dataclass(unsafe_hash=True)
@@ -231,14 +238,45 @@ async def interpreter_constraints_for_targets(
     return interpreter_constraints
 
 
-@dataclass(frozen=True)
+@frozen_after_init
+@dataclass(unsafe_hash=True)
 class _RepositoryPexRequest:
-    requirements: PexRequirements
+    addresses: Addresses
+    hardcoded_interpreter_constraints: InterpreterConstraints | None
+    direct_deps_only: bool
     platforms: PexPlatforms
-    interpreter_constraints: InterpreterConstraints
     internal_only: bool
     resolve_and_lockfile: tuple[str, str] | None
     additional_lockfile_args: tuple[str, ...]
+    additional_requirements: tuple[str, ...]
+
+    def __init__(
+        self,
+        addresses: Iterable[Address],
+        *,
+        internal_only: bool,
+        hardcoded_interpreter_constraints: InterpreterConstraints | None = None,
+        direct_deps_only: bool = False,
+        platforms: PexPlatforms = PexPlatforms(),
+        resolve_and_lockfile: tuple[str, str] | None = None,
+        additional_lockfile_args: tuple[str, ...] = (),
+        additional_requirements: tuple[str, ...] = (),
+    ) -> None:
+        self.addresses = Addresses(addresses)
+        self.internal_only = internal_only
+        self.hardcoded_interpreter_constraints = hardcoded_interpreter_constraints
+        self.direct_deps_only = direct_deps_only
+        self.platforms = platforms
+        self.resolve_and_lockfile = resolve_and_lockfile
+        self.additional_lockfile_args = additional_lockfile_args
+        self.additional_requirements = additional_requirements
+
+    def to_interpreter_constraints_request(self) -> InterpreterConstraintsRequest:
+        return InterpreterConstraintsRequest(
+            addresses=self.addresses,
+            hardcoded_interpreter_constraints=self.hardcoded_interpreter_constraints,
+            direct_deps_only=self.direct_deps_only,
+        )
 
 
 @dataclass(frozen=True)
@@ -250,11 +288,8 @@ class _ConstraintsRepositoryPexRequest:
 async def pex_from_targets(request: PexFromTargetsRequest) -> PexRequest:
     interpreter_constraints = await Get(
         InterpreterConstraints,
-        InterpreterConstraintsRequest(
-            request.addresses,
-            hardcoded_interpreter_constraints=request.hardcoded_interpreter_constraints,
-            direct_deps_only=request.direct_deps_only,
-        ),
+        InterpreterConstraintsRequest,
+        request.to_interpreter_constraints_request(),
     )
 
     relevant_targets = await Get(
@@ -320,12 +355,14 @@ async def pex_from_targets(request: PexFromTargetsRequest) -> PexRequest:
         repository_pex = await Get(
             OptionalPex,
             _RepositoryPexRequest(
-                requirements,
-                request.platforms,
-                interpreter_constraints,
-                request.internal_only,
-                request.resolve_and_lockfile,
-                request.additional_lockfile_args,
+                request.addresses,
+                hardcoded_interpreter_constraints=request.hardcoded_interpreter_constraints,
+                direct_deps_only=request.direct_deps_only,
+                platforms=request.platforms,
+                internal_only=request.internal_only,
+                resolve_and_lockfile=request.resolve_and_lockfile,
+                additional_lockfile_args=request.additional_lockfile_args,
+                additional_requirements=request.additional_requirements,
             ),
         )
         requirements = dataclasses.replace(requirements, repository_pex=repository_pex.maybe_pex)
@@ -348,6 +385,13 @@ async def pex_from_targets(request: PexFromTargetsRequest) -> PexRequest:
 async def get_repository_pex(
     request: _RepositoryPexRequest, python_setup: PythonSetup
 ) -> OptionalPexRequest:
+
+    interpreter_constraints = await Get(
+        InterpreterConstraints,
+        InterpreterConstraintsRequest,
+        request.to_interpreter_constraints_request(),
+    )
+
     repository_pex_request: PexRequest | None = None
     if python_setup.requirement_constraints:
         constraints_repository_pex_request = await Get(
@@ -379,7 +423,7 @@ async def get_repository_pex(
                 lockfile_hex_digest=None,
                 req_strings=None,
             ),
-            interpreter_constraints=request.interpreter_constraints,
+            interpreter_constraints=interpreter_constraints,
             platforms=request.platforms,
             additional_args=request.additional_lockfile_args,
         )
@@ -390,13 +434,13 @@ async def get_repository_pex(
             internal_only=request.internal_only,
             requirements=Lockfile(
                 file_path=python_setup.lockfile,
-                file_path_description_of_origin=("the option `[python].experimental_lockfile`"),
+                file_path_description_of_origin="the option `[python].experimental_lockfile`",
                 # TODO(#12314): Hook up lockfile staleness check once multiple lockfiles
                 # are supported.
                 lockfile_hex_digest=None,
                 req_strings=None,
             ),
-            interpreter_constraints=request.interpreter_constraints,
+            interpreter_constraints=interpreter_constraints,
             platforms=request.platforms,
             additional_args=request.additional_lockfile_args,
         )
@@ -430,6 +474,21 @@ async def _setup_constraints_repository_pex(
         )
     )
 
+    relevant_targets = await Get(
+        _RelevantTargets,
+        _RelevantTargetsRequest(request.addresses, direct_deps_only=request.direct_deps_only),
+    )
+
+    requirements = PexRequirements.create_from_requirement_fields(
+        (
+            tgt[PythonRequirementsField]
+            for tgt in relevant_targets.targets
+            if tgt.has_field(PythonRequirementsField)
+        ),
+        additional_requirements=request.additional_requirements,
+        apply_constraints=True,
+    )
+
     # In requirement strings, Foo_-Bar.BAZ and foo-bar-baz refer to the same project. We let
     # packaging canonicalize for us.
     # See: https://www.python.org/dev/peps/pep-0503/#normalized-names
@@ -437,7 +496,7 @@ async def _setup_constraints_repository_pex(
     name_reqs = set()  # E.g., foobar>=1.2.3
     name_req_projects = set()
 
-    for req_str in request.requirements.req_strings:
+    for req_str in requirements.req_strings:
         req = PipRequirement.parse(req_str)
         if req.url:
             url_reqs.add(req)
@@ -459,6 +518,12 @@ async def _setup_constraints_repository_pex(
         )
         return OptionalPexRequest(None)
 
+    interpreter_constraints = await Get(
+        InterpreterConstraints,
+        InterpreterConstraintsRequest,
+        request.to_interpreter_constraints_request(),
+    )
+
     # To get a full set of requirements we must add the URL requirements to the
     # constraints file, since the latter cannot contain URL requirements.
     # NB: We can only add the URL requirements we know about here, i.e., those that
@@ -478,7 +543,7 @@ async def _setup_constraints_repository_pex(
             # TODO: See PexRequirements docs.
             is_all_constraints_resolve=True,
         ),
-        interpreter_constraints=request.interpreter_constraints,
+        interpreter_constraints=interpreter_constraints,
         platforms=request.platforms,
         additional_args=request.additional_lockfile_args,
     )


### PR DESCRIPTION
Instead of requiring the caller to first turn those
addresses into interpreter constraints and requirements.

Thus, the caller does not need to know the intermediate
ingredients that go into creating a _RepositoryPex.

Engine caching will ensure that we don't recompute those
intermediate ingredients unnecessarily.

Since we now compute InterpreterConstraints in a few different
places, we introduce helper methods to generate their requests.

[ci skip-rust]

[ci skip-build-wheels]