### PR TITLE
Add PyPDF2 to module mapping

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -73,6 +73,7 @@ DEFAULT_MODULE_MAPPING = {
     "protobuf": ("google.protobuf",),
     "pycrypto": ("Crypto",),
     "pyopenssl": ("OpenSSL",),
+    "pypdf2": ("PyPDF2",),
     "python-dateutil": ("dateutil",),
     "python-docx": ("docx",),
     "python-dotenv": ("dotenv",),


### PR DESCRIPTION
The last commit was years ago, but it's because the package itself doesn't need major changes. That being said, take that into account, as I know we don't want to put unmaintained projects on this list.

Important links:
- https://github.com/mstamy2/PyPDF2
- https://pypistats.org/packages/pypdf2