### PR TITLE
Support interpolating Docker build args into the `repository` field of `docker_image` targets.

### DIFF
--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -132,9 +132,9 @@ class DockerFieldSet(PackageFieldSet, RunFieldSet):
 
             [<registry>/]<repository-name>[:<tag>]
 
-        Where the `<repository-name>` may have contain any number of separating slashes `/`,
-        depending on the `default_repository` from configuration or the `repository` field
-        on the target `docker_image`.
+        Where the `<repository-name>` may contain any number of separating slashes `/`, depending on
+        the `default_repository` from configuration or the `repository` field on the target
+        `docker_image`.
 
         This method will always return a non-empty tuple.
         """

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from os import path
+from typing import Any, Mapping
 
 from pants.backend.docker.registries import DockerRegistries
 from pants.backend.docker.subsystems.docker_options import DockerOptions
@@ -73,7 +74,7 @@ class DockerFieldSet(PackageFieldSet, RunFieldSet):
             if isinstance(e, KeyError):
                 msg += f"The placeholder {e} is unknown."
                 if version_context:
-                    msg += f' Try with one of: {", ".join(version_context.keys())}.'
+                    msg += f' Try with one of: {", ".join(sorted(version_context.keys()))}.'
                 else:
                     msg += (
                         " There are currently no known placeholders to use. These placeholders "
@@ -84,26 +85,35 @@ class DockerFieldSet(PackageFieldSet, RunFieldSet):
                 msg += str(e)
             raise DockerImageTagValueError(msg) from e
 
-    def format_repository(self, default_repository: str) -> str:
-        directory = path.basename(self.address.spec_path)
-        parent_directory = path.basename(path.dirname(self.address.spec_path))
+    def format_repository(
+        self, default_repository: str, repository_context: Mapping[str, Any]
+    ) -> str:
+        fmt_context = dict(
+            directory=path.basename(self.address.spec_path),
+            name=self.address.target_name,
+            parent_directory=path.basename(path.dirname(self.address.spec_path)),
+            **repository_context,
+        )
         repository_fmt = self.repository.value or default_repository
+
         try:
-            return repository_fmt.format(
-                name=self.address.target_name,
-                directory=directory,
-                parent_directory=parent_directory,
-            )
-        except KeyError as e:
+            return repository_fmt.format(**fmt_context)
+        except (KeyError, ValueError) as e:
             if self.repository.value:
-                source = "`repository` field of the `docker_image` target " f"at {self.address}"
+                source = f"`repository` field of the `docker_image` target at {self.address}"
             else:
                 source = "`[docker].default_repository` configuration option"
 
-            raise DockerRepositoryNameError(
-                f"Invalid value for the {source}: {repository_fmt!r}. Unknown placeholder: {e}.\n\n"
-                f"You may only reference any of `name`, `directory` or `parent_directory`."
-            ) from e
+            msg = f"Invalid value for the {source}: {repository_fmt!r}.\n\n"
+
+            if isinstance(e, KeyError):
+                msg += (
+                    f"The placeholder {e} is unknown. "
+                    f'Try with one of: {", ".join(sorted(fmt_context.keys()))}.'
+                )
+            else:
+                msg += str(e)
+            raise DockerRepositoryNameError(msg) from e
 
     def image_refs(
         self,
@@ -128,7 +138,11 @@ class DockerFieldSet(PackageFieldSet, RunFieldSet):
 
         This method will always return a non-empty tuple.
         """
-        repository = self.format_repository(default_repository)
+        repository_context = {}
+        if "build_args" in version_context:
+            repository_context["build_args"] = version_context["build_args"]
+
+        repository = self.format_repository(default_repository, repository_context)
         image_names = tuple(
             ":".join(s for s in [repository, self.format_tag(tag, version_context)] if s)
             for tag in self.tags.value or ()


### PR DESCRIPTION
Fixes #13720 
