### PR TITLE
Fix `--resolve-local-platforms` help.

### DIFF
--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -185,10 +185,12 @@ class PexBinaryDefaults(Subsystem):
             type=bool,
             default=False,
             help=(
-                "Whether to resolve a local interpreter that matches each of the "
-                f"`{PexPlatformsField.alias}` specified for a `{PexBinary.alias}` target.\n\n"
-                f"Can be overridden by specifying the `{PexResolveLocalPlatformsField.alias}` "
-                f"parameter of individual `{PexBinary.alias}` targets."
+                f"For each of the `{PexPlatformsField.alias}` specified for a `{PexBinary.alias}` "
+                "target, attempt to find a local interpreter that matches.\n\nIf a matching "
+                "interpreter is found, use the interpreter to resolve distributions and build any "
+                "that are only available in source distribution form. If no matching interpreter "
+                "is found (or if this option is `False`), resolve for the platform by accepting "
+                "only pre-built binary distributions (wheels)."
             ),
         )
 


### PR DESCRIPTION
The help was updated for the `pex_binary` `resolve_local_platforms`
field but not the corresponding `pex-binary-defaults` subsystem option.

Follow up to #13715.

[ci skip-rust]
[ci skip-build-wheels]