### PR TITLE
Upgrade console and indacatif.

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -372,12 +372,13 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.14.1"
-source = "git+https://github.com/mitsuhiko/console?rev=3232775295149e6f0aace26d4cfe61013ed3e2d8#3232775295149e6f0aace26d4cfe61013ed3e2d8"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
 dependencies = [
  "encode_unicode",
- "lazy_static",
  "libc",
+ "once_cell",
  "regex",
  "terminal_size",
  "unicode-width",
@@ -1297,8 +1298,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.15.0"
-source = "git+https://github.com/mitsuhiko/indicatif?rev=fa5e3c7ccc877c117f1db88bdaf19c48498d9616#fa5e3c7ccc877c117f1db88bdaf19c48498d9616"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
 dependencies = [
  "console",
  "lazy_static",

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -163,7 +163,3 @@ env_logger = "0.5.4"
 
 [build-dependencies]
 pyo3-build-config = "0.15"
-
-[patch.crates-io]
-# TODO: Waiting for release after https://github.com/mitsuhiko/console/pull/93.
-console = { git = "https://github.com/mitsuhiko/console", rev = "3232775295149e6f0aace26d4cfe61013ed3e2d8" }

--- a/src/rust/engine/ui/Cargo.toml
+++ b/src/rust/engine/ui/Cargo.toml
@@ -8,11 +8,10 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 path = "src/console_ui.rs"
 
 [dependencies]
-console = "0.14"
+console = "0.15.0"
 futures = "0.3"
 indexmap = "1.4"
-# TODO: Waiting for https://github.com/mitsuhiko/indicatif/pull/241 to be released.
-indicatif = { git = "https://github.com/mitsuhiko/indicatif", rev = "fa5e3c7ccc877c117f1db88bdaf19c48498d9616" }
+indicatif = "0.16.2"
 logging = { path = "../logging" }
 stdio = { path = "../stdio" }
 task_executor = { path = "../task_executor" }

--- a/src/rust/engine/ui/src/console_ui.rs
+++ b/src/rust/engine/ui/src/console_ui.rs
@@ -99,7 +99,7 @@ impl ConsoleUI {
     );
     // NB: We render more frequently than we receive new data in order to minimize aliasing where a
     // render might barely miss a data refresh.
-    let draw_target = ProgressDrawTarget::to_term(term, Self::render_rate_hz() * 2);
+    let draw_target = ProgressDrawTarget::term(term, Self::render_rate_hz() * 2);
     let multi_progress = MultiProgress::with_draw_target(draw_target);
 
     let bars = (0..self.local_parallelism)
@@ -173,7 +173,7 @@ impl ConsoleUI {
 
     for (n, pbar) in instance.bars.iter().enumerate() {
       match Self::get_label_from_heavy_hitters(tasks_to_display, n) {
-        Some(ref label) => pbar.set_message(label),
+        Some(label) => pbar.set_message(label),
         None => pbar.set_message(""),
       }
     }


### PR DESCRIPTION
This gets us on released versions of both with the patches we needed.

The console change log:
  https://github.com/mitsuhiko/console/blob/master/CHANGELOG.md

[ci skip-build-wheels]