### PR TITLE
Upgrade to cargo-audit 0.16.0.

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -31,7 +31,7 @@ jobs:
 
         '
     - name: Cargo audit (for security vulnerabilities)
-      run: './cargo install --version 0.13.1 cargo-audit
+      run: './cargo install --version 0.16.0 cargo-audit
 
         ./cargo audit
 

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -606,7 +606,7 @@ def generate() -> dict[Path, str]:
                         *checkout(),
                         {
                             "name": "Cargo audit (for security vulnerabilities)",
-                            "run": "./cargo install --version 0.13.1 cargo-audit\n./cargo audit\n",
+                            "run": "./cargo install --version 0.16.0 cargo-audit\n./cargo audit\n",
                         },
                     ],
                 }


### PR DESCRIPTION
This handles the migration of https://github.com/RustSec/advisory-db
from master -> main: https://github.com/rustsec/advisory-db/issues/312