### PR TITLE
Fix hadolint SIGSEGV.

### DIFF
--- a/src/python/pants/backend/docker/lint/hadolint/rules.py
+++ b/src/python/pants/backend/docker/lint/hadolint/rules.py
@@ -76,6 +76,19 @@ async def run_hadolint(request: HadolintRequest, hadolint: Hadolint) -> LintResu
         FallibleProcessResult,
         Process(
             argv=[downloaded_hadolint.exe, *generate_argv(dockerfile_infos, hadolint)],
+            # Hadolint tries to read a configuration file from a few locations on the system:
+            # https://github.com/hadolint/hadolint/blob/43d2bfe9f71dea9ddd203d5bdbd2cc1fb512e4dd/src/Hadolint/Config/Configfile.hs#L75-L101
+            #
+            # We don't want it to do this in order to have reproducible results machine to machine
+            # and there is also the problem that on some machines, an unset (as opposed to empty)
+            # HOME env var crashes hadolint with SIGSEGV.
+            # See: https://github.com/hadolint/hadolint/issues/741
+            #
+            # As such, we set HOME to blank so no system configuration is found and, as a side
+            # benefit, we don't crash.
+            #
+            # See https://github.com/pantsbuild/pants/issues/13735 for more details.
+            env={"HOME": ""},
             input_digest=input_digest,
             description=f"Run `hadolint` on {pluralize(len(dockerfile_infos), 'Dockerfile')}.",
             level=LogLevel.DEBUG,


### PR DESCRIPTION
This also has the benefit of making hadolint executions more hermetic.

Fixes #13735

[ci skip-rust]
[ci skip-build-wheels]