### PR TITLE
[internal] scala: parse and report package scopes

### DIFF
--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -115,6 +115,7 @@ class ScalaSourceDependencyAnalysis:
     provided_symbols_encoded: FrozenOrderedSet[str]
     imports_by_scope: FrozenDict[str, tuple[ScalaImport, ...]]
     consumed_symbols_by_scope: FrozenDict[str, FrozenOrderedSet[str]]
+    scopes: FrozenOrderedSet[str]
 
     def all_imports(self) -> Iterator[str]:
         # TODO: This might also be an import relative to its scope.
@@ -180,6 +181,7 @@ class ScalaSourceDependencyAnalysis:
                     for key, values in d["consumedSymbolsByScope"].items()
                 }
             ),
+            scopes=FrozenOrderedSet(d["scopes"]),
         )
 
     def to_debug_json_dict(self) -> dict[str, Any]:
@@ -193,6 +195,7 @@ class ScalaSourceDependencyAnalysis:
             "consumed_symbols_by_scope": {
                 k: sorted(list(v)) for k, v in self.consumed_symbols_by_scope.items()
             },
+            "scopes": list(self.scopes),
         }
 
 


### PR DESCRIPTION
As described in https://github.com/pantsbuild/pants/issues/13655, unqualified symbols in Scala code can come from any of the packages for which there is a `package` directive in the source file. The first step to solving this issue is to parse the packages referenced by a Scala file.

[ci skip-build-wheels]