### PR TITLE
[internal] go: initial support for embedding resources

### DIFF
--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -224,6 +224,7 @@ async def run_go_tests(
             s_file_names=(),  # TODO: Are there .s files for xtest?
             direct_dependencies=tuple(direct_dependencies),
             minimum_go_version=pkg_info.minimum_go_version,
+            embed_config=pkg_info.xtest_embed_config,
         )
         main_direct_deps.append(xtest_pkg_build_request)
 

--- a/src/python/pants/backend/go/util_rules/analyze_package.go
+++ b/src/python/pants/backend/go/util_rules/analyze_package.go
@@ -26,6 +26,11 @@ import (
 	"strings"
 )
 
+type EmbedCfg struct {
+	Patterns map[string][]string
+	Files    map[string]string
+}
+
 // Package represents the results of analyzing a Go package.
 type Package struct {
 	Name string // package name
@@ -60,9 +65,12 @@ type Package struct {
 	//	//go:embed a* b.c
 	// then the list will contain those two strings as separate entries.
 	// (See package embed for more details about //go:embed.)
-	EmbedPatterns      []string `json:",omitempty"` // patterns from GoFiles, CgoFiles
-	TestEmbedPatterns  []string `json:",omitempty"` // patterns from TestGoFiles
-	XTestEmbedPatterns []string `json:",omitempty"` // patterns from XTestGoFiles
+	EmbedPatterns      []string  `json:",omitempty"` // patterns from GoFiles, CgoFiles
+	EmbedConfig        *EmbedCfg `json:",omitempty"` // files matching the EmbedPatterns
+	TestEmbedPatterns  []string  `json:",omitempty"` // patterns from TestGoFiles
+	TestEmbedConfig    *EmbedCfg `json:",omitempty"` // files matching the TestEmbedPatterns
+	XTestEmbedPatterns []string  `json:",omitempty"` // patterns from XTestGoFiles
+	XTestEmbedConfig   *EmbedCfg `json:",omitempty"` // files matching the XTestEmbedPatterns
 
 	// Error information. This differs from how `go list` reports errors.
 	InvalidGoFiles map[string]string `json:",omitempty"`
@@ -118,6 +126,98 @@ func cleanStringSet(valuesMap map[string]bool) []string {
 	}
 	sort.Strings(values)
 	return values
+}
+
+func computeEmbedConfigs(directory string, pkg *Package) error {
+	// Obtain a list of files in and under the package's directory. These will be embeddable files.
+	// TODO: Support resource targets elsewhere in the repository.
+
+	var embedSrcs []string
+	err := filepath.WalkDir(directory, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		embedSrcs = append(embedSrcs, path)
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	root, err := buildEmbedTree(embedSrcs, []string{directory})
+	if err != nil {
+		return err
+	}
+
+	if len(pkg.EmbedPatterns) > 0 {
+		embedCfg := &EmbedCfg{
+			Patterns: make(map[string][]string),
+			Files:    make(map[string]string),
+		}
+
+		for _, pattern := range pkg.EmbedPatterns {
+			matchedPaths, matchedFiles, err := resolveEmbed(pattern, root)
+			if err != nil {
+				return err
+			}
+			embedCfg.Patterns[pattern] = matchedPaths
+			for i, rel := range matchedPaths {
+				embedCfg.Files[rel] = matchedFiles[i]
+			}
+		}
+
+		pkg.EmbedConfig = embedCfg
+	}
+
+	if len(pkg.TestEmbedPatterns) > 0 {
+		embedCfg := &EmbedCfg{
+			Patterns: make(map[string][]string),
+			Files:    make(map[string]string),
+		}
+		if pkg.EmbedConfig != nil {
+			for key, value := range pkg.EmbedConfig.Patterns {
+				embedCfg.Patterns[key] = value
+			}
+			for key, value := range pkg.EmbedConfig.Files {
+				embedCfg.Files[key] = value
+			}
+		}
+
+		for _, pattern := range pkg.TestEmbedPatterns {
+			matchedPaths, matchedFiles, err := resolveEmbed(pattern, root)
+			if err != nil {
+				return err
+			}
+			embedCfg.Patterns[pattern] = matchedPaths
+			for i, rel := range matchedPaths {
+				embedCfg.Files[rel] = matchedFiles[i]
+			}
+		}
+
+		pkg.TestEmbedConfig = embedCfg
+	}
+
+	if len(pkg.XTestEmbedPatterns) > 0 {
+		embedCfg := &EmbedCfg{
+			Patterns: make(map[string][]string),
+			Files:    make(map[string]string),
+		}
+
+		for _, pattern := range pkg.XTestEmbedPatterns {
+			matchedPaths, matchedFiles, err := resolveEmbed(pattern, root)
+			if err != nil {
+				return err
+			}
+			embedCfg.Patterns[pattern] = matchedPaths
+			for i, rel := range matchedPaths {
+				embedCfg.Files[rel] = matchedFiles[i]
+			}
+		}
+
+		pkg.XTestEmbedConfig = embedCfg
+	}
+
+	return nil
 }
 
 func analyzePackage(directory string, buildContext *build.Context) (*Package, error) {
@@ -294,6 +394,12 @@ func analyzePackage(directory string, buildContext *build.Context) (*Package, er
 	pkg.EmbedPatterns = cleanStringSet(embedsMap)
 	pkg.TestEmbedPatterns = cleanStringSet(testEmbedsMap)
 	pkg.XTestEmbedPatterns = cleanStringSet(xtestEmbedsMap)
+
+	// Fill in embedcfg needed for compiler.
+	err = computeEmbedConfigs(directory, pkg)
+	if err != nil {
+		return pkg, fmt.Errorf("unable to compute embedcfg: %s", err)
+	}
 
 	// add the .S/.sx files only if we are using cgo
 	// (which means gcc will compile them).

--- a/src/python/pants/backend/go/util_rules/analyze_package.go
+++ b/src/python/pants/backend/go/util_rules/analyze_package.go
@@ -132,17 +132,20 @@ func computeEmbedConfigs(directory string, pkg *Package) error {
 	// Obtain a list of files in and under the package's directory. These will be embeddable files.
 	// TODO: Support resource targets elsewhere in the repository.
 
+	fmt.Fprintf(os.Stderr, "computeEmbedConfigs(directory=%s)\n", directory)
 	var embedSrcs []string
 	err := filepath.WalkDir(directory, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
+		fmt.Fprintf(os.Stderr, "path=%s\n", path)
 		embedSrcs = append(embedSrcs, path)
 		return nil
 	})
 	if err != nil {
 		return err
 	}
+	fmt.Fprintf(os.Stderr, "embedSrcs=%v\n", embedSrcs)
 
 	root, err := buildEmbedTree(embedSrcs, []string{directory})
 	if err != nil {
@@ -396,7 +399,7 @@ func analyzePackage(directory string, buildContext *build.Context) (*Package, er
 	pkg.XTestEmbedPatterns = cleanStringSet(xtestEmbedsMap)
 
 	// Fill in embedcfg needed for compiler.
-	err = computeEmbedConfigs(directory, pkg)
+	err = computeEmbedConfigs("__resources__", pkg)
 	if err != nil {
 		return pkg, fmt.Errorf("unable to compute embedcfg: %s", err)
 	}

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -15,6 +15,7 @@ from pants.backend.go.util_rules.build_pkg import (
     BuildGoPackageRequest,
     FallibleBuildGoPackageRequest,
 )
+from pants.backend.go.util_rules.embedcfg import EmbedConfig
 from pants.backend.go.util_rules.first_party_pkg import (
     FallibleFirstPartyPkgInfo,
     FirstPartyPkgInfoRequest,
@@ -51,6 +52,7 @@ async def setup_build_go_package_target_request(
     wrapped_target = await Get(WrappedTarget, Address, request.address)
     target = wrapped_target.target
 
+    embed_config: EmbedConfig | None = None
     if target.has_field(GoPackageSourcesField):
         _maybe_first_party_pkg_info = await Get(
             FallibleFirstPartyPkgInfo, FirstPartyPkgInfoRequest(target.address)
@@ -70,11 +72,13 @@ async def setup_build_go_package_target_request(
         minimum_go_version = _first_party_pkg_info.minimum_go_version
 
         go_file_names = _first_party_pkg_info.go_files
+        embed_config = _first_party_pkg_info.embed_config
         if request.for_tests:
             # TODO: Build the test sources separately and link the two object files into the package archive?
             # TODO: The `go` tool changes the displayed import path for the package when it has test files. Do we
             #   need to do something similar?
             go_file_names += _first_party_pkg_info.test_files
+            embed_config = _first_party_pkg_info.test_embed_config
         s_file_names = _first_party_pkg_info.s_files
 
     elif target.has_field(GoThirdPartyPackageDependenciesField):
@@ -137,6 +141,7 @@ async def setup_build_go_package_target_request(
         minimum_go_version=minimum_go_version,
         direct_dependencies=tuple(direct_dependencies),
         for_tests=request.for_tests,
+        embed_config=embed_config,
     )
     return FallibleBuildGoPackageRequest(result, import_path)
 

--- a/src/python/pants/backend/go/util_rules/embed_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/embed_integration_test.py
@@ -1,0 +1,127 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from textwrap import dedent
+
+import pytest
+
+from pants.backend.go import target_type_rules
+from pants.backend.go.goals.test import GoTestFieldSet
+from pants.backend.go.goals.test import rules as test_rules
+from pants.backend.go.target_types import GoModTarget, GoPackageTarget
+from pants.backend.go.util_rules import (
+    assembly,
+    build_pkg,
+    build_pkg_target,
+    first_party_pkg,
+    go_mod,
+    link,
+    sdk,
+    tests_analysis,
+    third_party_pkg,
+)
+from pants.build_graph.address import Address
+from pants.core.goals.test import TestResult
+from pants.core.target_types import ResourcesGeneratorTarget, ResourceTarget
+from pants.testutil.rule_runner import QueryRule, RuleRunner, logging
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = RuleRunner(
+        rules=[
+            *test_rules(),
+            *assembly.rules(),
+            *build_pkg.rules(),
+            *build_pkg_target.rules(),
+            *first_party_pkg.rules(),
+            *go_mod.rules(),
+            *link.rules(),
+            *sdk.rules(),
+            *target_type_rules.rules(),
+            *tests_analysis.rules(),
+            *third_party_pkg.rules(),
+            QueryRule(TestResult, [GoTestFieldSet]),
+        ],
+        target_types=[GoModTarget, GoPackageTarget, ResourcesGeneratorTarget, ResourceTarget],
+    )
+    rule_runner.set_options(["--go-test-args=-v -bench=."], env_inherit={"PATH"})
+    return rule_runner
+
+
+@logging
+def test_embeds_integration_test(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                """
+                go_mod(name='mod')
+                go_package(name='pkg', dependencies=[":resources"])
+                resources(
+                  name="resources",
+                  sources=["*.txt"],
+                )
+                """
+            ),
+            "go.mod": dedent(
+                """\
+                module go.example.com/foo
+                go 1.17
+                """
+            ),
+            "grok.txt": "hello",
+            "test_grok.txt": "world",
+            "xtest_grok.txt": "xtest",
+            "foo.go": dedent(
+                """\
+                package foo
+                import _ "embed"
+                //go:embed grok.txt
+                var message string
+                """
+            ),
+            "foo_test.go": dedent(
+                """\
+                package foo
+                import (
+                  _ "embed"
+                  "testing"
+                )
+                //go:embed test_grok.txt
+                var testMessage string
+
+                func TestFoo(t *testing.T) {
+                  if message != "hello" {
+                    t.Fatalf("message mismatch: want=%s; got=%s", "hello", message)
+                  }
+                  if testMessage != "world" {
+                    t.Fatalf("testMessage mismatch: want=%s; got=%s", "world", testMessage)
+                  }
+                }
+                """
+            ),
+            "bar_test.go": dedent(
+                """\
+                package foo_test
+                import (
+                  _ "embed"
+                  "testing"
+                )
+                //go:embed xtest_grok.txt
+                var testMessage string
+
+                func TestBar(t *testing.T) {
+                  if testMessage != "xtest" {
+                    t.Fatalf("testMessage mismatch: want=%s; got=%s", "xtest", testMessage)
+                  }
+                }
+                """
+            ),
+        }
+    )
+    tgt = rule_runner.get_target(Address("", target_name="pkg"))
+    result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
+    print(f"test_result={result}")
+    assert result.exit_code == 0

--- a/src/python/pants/backend/go/util_rules/embed_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/embed_integration_test.py
@@ -25,6 +25,7 @@ from pants.backend.go.util_rules import (
 from pants.build_graph.address import Address
 from pants.core.goals.test import TestResult
 from pants.core.target_types import ResourcesGeneratorTarget, ResourceTarget
+from pants.core.util_rules import source_files
 from pants.testutil.rule_runner import QueryRule, RuleRunner, logging
 
 
@@ -43,6 +44,7 @@ def rule_runner() -> RuleRunner:
             *target_type_rules.rules(),
             *tests_analysis.rules(),
             *third_party_pkg.rules(),
+            *source_files.rules(),
             QueryRule(TestResult, [GoTestFieldSet]),
         ],
         target_types=[GoModTarget, GoPackageTarget, ResourcesGeneratorTarget, ResourceTarget],
@@ -123,5 +125,4 @@ def test_embeds_integration_test(rule_runner: RuleRunner) -> None:
     )
     tgt = rule_runner.get_target(Address("", target_name="pkg"))
     result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
-    print(f"test_result={result}")
     assert result.exit_code == 0

--- a/src/python/pants/backend/go/util_rules/embedcfg.go
+++ b/src/python/pants/backend/go/util_rules/embedcfg.go
@@ -157,7 +157,7 @@ func buildEmbedTree(embedSrcs, embedRootDirs []string) (root *embedNode, err err
 			err = fmt.Errorf("building tree of embeddable files in directories %s: %v", strings.Join(embedRootDirs, string(filepath.ListSeparator)), err)
 		}
 	}()
-
+	fmt.Fprintf(os.Stderr, "embedSrcs=%v", embedSrcs)
 	// Add each path to the tree.
 	root = &embedNode{name: "", children: make(map[string]*embedNode)}
 	for _, src := range embedSrcs {

--- a/src/python/pants/backend/go/util_rules/embedcfg.go
+++ b/src/python/pants/backend/go/util_rules/embedcfg.go
@@ -1,0 +1,285 @@
+/* Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+/*
+ * Match embed patterns against files.
+ * Based in part on Bazel rules_go:
+ * https://github.com/bazelbuild/rules_go/blob/bd7fbccc635af297db7b36f6c81d0e7db7921cca/go/tools/builders/embedcfg.go
+ */
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// findInRootDirs returns a string from rootDirs which is a parent of the
+// file path p. If there is no such string, findInRootDirs returns "".
+func findInRootDirs(p string, rootDirs []string) string {
+	dir := filepath.Dir(p)
+	for _, rootDir := range rootDirs {
+		if rootDir == dir ||
+			(strings.HasPrefix(dir, rootDir) && len(dir) > len(rootDir)+1 && dir[len(rootDir)] == filepath.Separator) {
+			return rootDir
+		}
+	}
+	return ""
+}
+
+// embedNode represents an embeddable file or directory in a tree.
+type embedNode struct {
+	name       string                // base name
+	path       string                // full file path relative to the base package directory
+	children   map[string]*embedNode // non-nil for directory
+	childNames []string              // sorted
+}
+
+// add inserts file nodes into the tree rooted at f for the slash-separated
+// path src, relative to the absolute file path rootDir. If src points to a
+// directory, add recursively inserts nodes for its contents. If a node already
+// exists (for example, if a source file and a generated file have the same
+// name), add leaves the existing node in place.
+func (n *embedNode) add(rootDir, src string) error {
+	// Create nodes for parents of src.
+	parent := n
+	parts := strings.Split(src, "/")
+	for _, p := range parts[:len(parts)-1] {
+		if parent.children[p] == nil {
+			parent.children[p] = &embedNode{
+				name:     p,
+				children: make(map[string]*embedNode),
+			}
+		}
+		parent = parent.children[p]
+	}
+
+	// Create a node for src. If src is a directory, recursively create nodes for
+	// its contents. Go embedding ignores symbolic links, and they are ignored here
+	// as well.
+	// TODO: Actually ignore symbolic links.
+	var visit func(*embedNode, string, os.FileInfo) error
+	visit = func(parent *embedNode, path string, fi os.FileInfo) error {
+		base := filepath.Base(path)
+		if parent.children[base] == nil {
+			parent.children[base] = &embedNode{name: base, path: path}
+		}
+		if !fi.IsDir() {
+			return nil
+		}
+		node := parent.children[base]
+		node.children = make(map[string]*embedNode)
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		names, err := f.Readdirnames(0)
+		f.Close()
+		if err != nil {
+			return err
+		}
+		for _, name := range names {
+			cPath := filepath.Join(path, name)
+			cfi, err := os.Stat(cPath)
+			if err != nil {
+				return err
+			}
+			if err := visit(node, cPath, cfi); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	path := filepath.Join(rootDir, src)
+	fi, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	return visit(parent, path, fi)
+}
+
+func (n *embedNode) isDir() bool {
+	return n.children != nil
+}
+
+// get returns a tree node, given a slash-separated path relative to the
+// receiver. get returns nil if no node exists with that path.
+func (n *embedNode) get(path string) *embedNode {
+	if path == "." || path == "" {
+		return n
+	}
+	for _, part := range strings.Split(path, "/") {
+		n = n.children[part]
+		if n == nil {
+			return nil
+		}
+	}
+	return n
+}
+
+var errSkip = errors.New("skip")
+
+// walk calls fn on each node in the tree rooted at n in depth-first pre-order.
+func (n *embedNode) walk(fn func(rel string, n *embedNode) error) error {
+	var visit func(string, *embedNode) error
+	visit = func(rel string, node *embedNode) error {
+		err := fn(rel, node)
+		if err == errSkip {
+			return nil
+		} else if err != nil {
+			return err
+		}
+		for _, name := range node.childNames {
+			if err := visit(path.Join(rel, name), node.children[name]); err != nil && err != errSkip {
+				return err
+			}
+		}
+		return nil
+	}
+	err := visit("", n)
+	if err == errSkip {
+		return nil
+	}
+	return err
+}
+
+// buildEmbedTree constructs a logical directory tree of embeddable files.
+func buildEmbedTree(embedSrcs, embedRootDirs []string) (root *embedNode, err error) {
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("building tree of embeddable files in directories %s: %v", strings.Join(embedRootDirs, string(filepath.ListSeparator)), err)
+		}
+	}()
+
+	// Add each path to the tree.
+	root = &embedNode{name: "", children: make(map[string]*embedNode)}
+	for _, src := range embedSrcs {
+		rootDir := findInRootDirs(src, embedRootDirs)
+		if rootDir == "" {
+			// Embedded path cannot be matched by any valid pattern. Ignore.
+			continue
+		}
+		rel := filepath.ToSlash(src[len(rootDir)+1:])
+		if err := root.add(rootDir, rel); err != nil {
+			return nil, err
+		}
+	}
+
+	// Sort children in each directory node.
+	var visit func(*embedNode)
+	visit = func(node *embedNode) {
+		node.childNames = make([]string, 0, len(node.children))
+		for name, child := range node.children {
+			node.childNames = append(node.childNames, name)
+			visit(child)
+		}
+		sort.Strings(node.childNames)
+	}
+	visit(root)
+
+	return root, nil
+}
+
+// resolveEmbed matches a //go:embed pattern in a source file to a set of
+// embeddable files in the given tree.
+func resolveEmbed(pattern string, root *embedNode) (matchedPaths, matchedFiles []string, err error) {
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("could not embed %s: %v", pattern, err)
+		}
+	}()
+
+	// Check that the pattern has valid syntax.
+	if _, err := path.Match(pattern, ""); err != nil || !validEmbedPattern(pattern) {
+		return nil, nil, fmt.Errorf("invalid pattern syntax")
+	}
+
+	// Search for matching files.
+	err = root.walk(func(matchRel string, matchNode *embedNode) error {
+		if ok, _ := path.Match(pattern, matchRel); !ok {
+			// Non-matching file or directory.
+			return nil
+		}
+		if !matchNode.isDir() {
+			// Matching file. Add to list.
+			matchedPaths = append(matchedPaths, matchRel)
+			matchedFiles = append(matchedFiles, matchNode.path)
+			return nil
+		}
+
+		// Matching directory. Recursively add all files in subdirectories.
+		// Don't add hidden files or directories (starting with "." or "_").
+		// See golang/go#42328.
+		matchTreeErr := matchNode.walk(func(childRel string, childNode *embedNode) error {
+			if childRel != "" {
+				if base := path.Base(childRel); strings.HasPrefix(base, ".") || strings.HasPrefix(base, "_") {
+					return errSkip
+				}
+			}
+			if !childNode.isDir() {
+				matchedPaths = append(matchedPaths, path.Join(matchRel, childRel))
+				matchedFiles = append(matchedFiles, childNode.path)
+			}
+			return nil
+		})
+		if matchTreeErr != nil {
+			return matchTreeErr
+		}
+		return errSkip
+	})
+	if err != nil && err != errSkip {
+		return nil, nil, err
+	}
+	if len(matchedPaths) == 0 {
+		return nil, nil, fmt.Errorf("no matching files found")
+	}
+	return matchedPaths, matchedFiles, nil
+}
+
+func validEmbedPattern(pattern string) bool {
+	return pattern != "." && fsValidPath(pattern)
+}
+
+// validPath reports whether the given path name
+// is valid for use in a call to Open.
+// Path names passed to open are unrooted, slash-separated
+// sequences of path elements, like “x/y/z”.
+// Path names must not contain a “.” or “..” or empty element,
+// except for the special case that the root directory is named “.”.
+//
+// Paths are slash-separated on all systems, even Windows.
+// Backslashes must not appear in path names.
+//
+// Copied from io/fs.ValidPath in Go 1.16beta1.
+func fsValidPath(name string) bool {
+	if name == "." {
+		// special case
+		return true
+	}
+
+	// Iterate over elements in name, checking each.
+	for {
+		i := 0
+		for i < len(name) && name[i] != '/' {
+			if name[i] == '\\' {
+				return false
+			}
+			i++
+		}
+		elem := name[:i]
+		if elem == "" || elem == "." || elem == ".." {
+			return false
+		}
+		if i == len(name) {
+			return true // reached clean ending
+		}
+		name = name[i+1:]
+	}
+}

--- a/src/python/pants/backend/go/util_rules/embedcfg.py
+++ b/src/python/pants/backend/go/util_rules/embedcfg.py
@@ -39,8 +39,10 @@ class EmbedConfig:
     @classmethod
     def from_json_dict(cls, d: dict[str, Any]) -> EmbedConfig:
         return cls(
-            patterns=d["Patterns"],
-            files=d["Files"],
+            patterns=FrozenDict(
+                {key: tuple(value) for key, value in d.get("Patterns", {}).items()}
+            ),
+            files=FrozenDict(d.get("Files", {})),
         )
 
     def to_embedcfg(self) -> bytes:

--- a/src/python/pants/backend/go/util_rules/embedcfg.py
+++ b/src/python/pants/backend/go/util_rules/embedcfg.py
@@ -45,7 +45,7 @@ class EmbedConfig:
 
     def to_embedcfg(self) -> bytes:
         data = {
-            "Patterns": self.patterns,
-            "Files": self.files,
+            "Patterns": dict(self.patterns),
+            "Files": dict(self.files),
         }
         return json.dumps(data).encode("utf-8")

--- a/src/python/pants/backend/go/util_rules/embedcfg.py
+++ b/src/python/pants/backend/go/util_rules/embedcfg.py
@@ -37,13 +37,14 @@ class EmbedConfig:
         self.files = FrozenDict(files)
 
     @classmethod
-    def from_json_dict(cls, d: dict[str, Any]) -> EmbedConfig:
-        return cls(
+    def from_json_dict(cls, d: dict[str, Any]) -> EmbedConfig | None:
+        result = cls(
             patterns=FrozenDict(
                 {key: tuple(value) for key, value in d.get("Patterns", {}).items()}
             ),
             files=FrozenDict(d.get("Files", {})),
         )
+        return result if result else None
 
     def to_embedcfg(self) -> bytes:
         data = {
@@ -51,3 +52,6 @@ class EmbedConfig:
             "Files": dict(self.files),
         }
         return json.dumps(data).encode("utf-8")
+
+    def __bool__(self) -> bool:
+        return bool(self.patterns) or bool(self.files)

--- a/src/python/pants/backend/go/util_rules/embedcfg.py
+++ b/src/python/pants/backend/go/util_rules/embedcfg.py
@@ -1,0 +1,51 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping
+
+from pants.util.frozendict import FrozenDict
+from pants.util.meta import frozen_after_init
+
+
+@dataclass(unsafe_hash=True)
+@frozen_after_init
+class EmbedConfig:
+    patterns: FrozenDict[str, tuple[str, ...]]
+    files: FrozenDict[str, str]
+
+    def __init__(self, patterns: Mapping[str, Iterable[str]], files: Mapping[str, str]) -> None:
+        """Configuration passed to the Go compiler to configure file embedding. The compiler relies
+        entirely on the caller to map embed patterns to actual filesystem paths. All embed patterns
+        contained in the package must be mapped. Consult
+        `FirstPartyPkgInfo.{EmbedPatterns,TestEmbedPatterns,XTestEmbedPatterns}` for the embed
+        patterns obtained from analysis.
+
+        :param patterns: Maps each pattern provided via a //go:embed directive to a list of file paths relative to
+        the package directory for files to embed for that pattern. When the embedded variable is an `embed.FS`,
+        those relative file paths define the virtual directory hierarchy exposed by the embed.FS filesystem
+        abstraction. The relative file paths are resolved to actual filesystem paths for their content by consulting
+        the `files` dictionary.
+
+        :param files: Maps each virtual, relative file path used as a value in the `patterns` dictionary to the actual
+        filesystem path with that file's content.
+        """
+        self.patterns = FrozenDict({k: tuple(v) for k, v in patterns.items()})
+        self.files = FrozenDict(files)
+
+    @classmethod
+    def from_json_dict(cls, d: dict[str, Any]) -> EmbedConfig:
+        return cls(
+            patterns=d["Patterns"],
+            files=d["Files"],
+        )
+
+    def to_embedcfg(self) -> bytes:
+        data = {
+            "Patterns": self.patterns,
+            "Files": self.files,
+        }
+        return json.dumps(data).encode("utf-8")

--- a/src/python/pants/backend/go/util_rules/first_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg.py
@@ -24,15 +24,7 @@ from pants.build_graph.address import Address
 from pants.core.target_types import ResourcesGeneratingSourcesField, ResourceSourceField
 from pants.engine.addresses import Addresses
 from pants.engine.engine_aware import EngineAwareParameter
-from pants.engine.fs import (
-    AddPrefix,
-    CreateDigest,
-    Digest,
-    FileContent,
-    MergeDigests,
-    RemovePrefix,
-    Snapshot,
-)
+from pants.engine.fs import AddPrefix, CreateDigest, Digest, FileContent, MergeDigests, RemovePrefix
 from pants.engine.process import FallibleProcessResult, Process
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
@@ -168,7 +160,6 @@ async def compute_first_party_package_info(
         ExplicitlyProvidedDependencies, DependenciesRequest(target[Dependencies])
     )
     explicit_deps_targets = await Get(Targets, Addresses(explicit_deps.includes))
-    print(f"explicit_deps_targets={explicit_deps_targets}")
     pkg_relative_resource_targets = [
         tgt
         for tgt in explicit_deps_targets
@@ -178,7 +169,6 @@ async def compute_first_party_package_info(
         # have paths be relative to the resources' spec_path.
         and tgt.address.spec_path.startswith(request.address.spec_path)
     ]
-    print(f"pkg_relative_resource_targets={pkg_relative_resource_targets}")
 
     pkg_sources = await Get(
         HydratedSources,
@@ -207,8 +197,6 @@ async def compute_first_party_package_info(
         Digest, RemovePrefix(original_resources_digest, request.address.spec_path)
     )
     resources_digest = await Get(Digest, AddPrefix(stripped_resources_digest, "__resources__"))
-    ss = await Get(Snapshot, Digest, resources_digest)
-    print(f"ss.files={ss.files}")
 
     sources_digest = await Get(
         Digest,
@@ -237,7 +225,6 @@ async def compute_first_party_package_info(
             stderr=result.stderr.decode("utf-8"),
         )
 
-    print(f"stdout:\n{result.stdout.decode()}\nstderr:\n{result.stderr.decode()}")
     metadata = json.loads(result.stdout)
     if "Error" in metadata or "InvalidGoFiles" in metadata:
         error = metadata.get("Error", "")

--- a/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
@@ -312,8 +312,16 @@ def test_embeds_supported(rule_runner: RuleRunner) -> None:
         FallibleFirstPartyPkgInfo,
         [FirstPartyPkgInfoRequest(Address("", target_name="pkg"))],
     )
+    print(f"stderr:\n{maybe_info.stderr}")
     assert maybe_info.info is not None
     info = maybe_info.info
-    assert info.embed_config == EmbedConfig({}, {})
-    assert info.test_embed_config == EmbedConfig({}, {})
-    assert info.xtest_embed_config == EmbedConfig({}, {})
+    assert info.embed_config == EmbedConfig(
+        {"grok.txt": ["grok.txt"]}, {"grok.txt": "__resources__/grok.txt"}
+    )
+    assert info.test_embed_config == EmbedConfig(
+        {"grok.txt": ["grok.txt"], "test_grok.txt": ["test_grok.txt"]},
+        {"grok.txt": "__resources__/grok.txt", "test_grok.txt": "__resources__/test_grok.txt"},
+    )
+    assert info.xtest_embed_config == EmbedConfig(
+        {"xtest_grok.txt": ["xtest_grok.txt"]}, {"xtest_grok.txt": "__resources__/xtest_grok.txt"}
+    )


### PR DESCRIPTION
Support embedding resources into Go binaries as per the [`embed` package](https://pkg.go.dev/embed).

Note: The analysis of what to embed is done by our Go-based package analysis code and not in the Python rules.

[ci skip-rust]