### PR TITLE
Fix `run` goal for `pex_binary` with a script entry point from a 3rdparty dependency.

### DIFF
--- a/src/python/pants/backend/python/goals/run_pex_binary.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary.py
@@ -12,11 +12,11 @@ from pants.backend.python.target_types import (
 )
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.local_dists import LocalDistsPex, LocalDistsPexRequest
-from pants.backend.python.util_rules.pex import Pex, PexRequest
+from pants.backend.python.util_rules.pex import Pex
 from pants.backend.python.util_rules.pex_environment import PexEnvironment
 from pants.backend.python.util_rules.pex_from_targets import (
     InterpreterConstraintsRequest,
-    RequirementsPexRequest,
+    PexFromTargetsRequest,
 )
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
@@ -50,15 +50,17 @@ async def create_pex_binary_run_request(
         InterpreterConstraints, InterpreterConstraintsRequest(addresses)
     )
 
-    entry_point_pex_get = Get(
+    pex_get = Get(
         Pex,
-        PexRequest(
+        PexFromTargetsRequest(
+            [field_set.address],
             output_filename=f"{field_set.address.target_name}.pex",
             internal_only=True,
+            include_source_files=False,
             # Note that the file for first-party entry points is not in the PEX itself. In that
             # case, it's loaded by setting `PEX_EXTRA_SYS_PATH`.
             main=entry_point.val or field_set.script.value,
-            interpreter_constraints=interpreter_constraints,
+            resolve_and_lockfile=field_set.resolve.resolve_and_lockfile(python_setup),
             additional_args=(
                 *field_set.generate_additional_args(pex_binary_defaults),
                 # N.B.: Since we cobble together the runtime environment via PEX_EXTRA_SYS_PATH
@@ -68,20 +70,10 @@ async def create_pex_binary_run_request(
             ),
         ),
     )
-    requirements_pex_get = Get(
-        Pex,
-        RequirementsPexRequest(
-            addresses=[field_set.address],
-            internal_only=True,
-            resolve_and_lockfile=field_set.resolve.resolve_and_lockfile(python_setup),
-        ),
-    )
     sources_get = Get(
         PythonSourceFiles, PythonSourceFilesRequest(transitive_targets.closure, include_files=True)
     )
-    entry_point_pex, requirements_pex, sources = await MultiGet(
-        entry_point_pex_get, requirements_pex_get, sources_get
-    )
+    pex, sources = await MultiGet(pex_get, sources_get)
 
     local_dists = await Get(
         LocalDistsPex,
@@ -97,10 +89,9 @@ async def create_pex_binary_run_request(
         Digest,
         MergeDigests(
             [
-                entry_point_pex.digest,
+                pex.digest,
                 local_dists.pex.digest,
                 local_dists.remaining_sources.source_files.snapshot.digest,
-                requirements_pex.digest,
             ]
         ),
     )
@@ -109,14 +100,12 @@ async def create_pex_binary_run_request(
         return os.path.join("{chroot}", relpath)
 
     complete_pex_env = pex_env.in_workspace()
-    args = complete_pex_env.create_argv(
-        in_chroot(entry_point_pex.name), python=entry_point_pex.python
-    )
+    args = complete_pex_env.create_argv(in_chroot(pex.name), python=pex.python)
 
     chrooted_source_roots = [in_chroot(sr) for sr in sources.source_roots]
     extra_env = {
-        **complete_pex_env.environment_dict(python_configured=entry_point_pex.python is not None),
-        "PEX_PATH": ":".join([in_chroot(requirements_pex.name), in_chroot(local_dists.pex.name)]),
+        **complete_pex_env.environment_dict(python_configured=pex.python is not None),
+        "PEX_PATH": in_chroot(local_dists.pex.name),
         "PEX_EXTRA_SYS_PATH": os.pathsep.join(chrooted_source_roots),
     }
 


### PR DESCRIPTION
Reverted #13693 as it broke for running `pex_binary` targets with a `script` entry point from a dependency.

Added a test case for this scenario, so that the gist of #13693 may be reimplemented.

Fixes #13747 
