### PR TITLE
Fix Java / Scala cycle artifact filename collision

### DIFF
--- a/src/python/pants/backend/java/compile/javac.py
+++ b/src/python/pants/backend/java/compile/javac.py
@@ -205,7 +205,7 @@ async def compile_java_source(
     # invoking via a `bash` wrapper (since the trailing portion of the command is executed by
     # the nailgun server). We might be able to resolve this in the future via a Javac wrapper shim.
     output_snapshot = await Get(Snapshot, Digest, compile_result.output_digest)
-    output_file = f"{request.component.representative.address.path_safe_spec}.jar"
+    output_file = f"{request.component.representative.address.path_safe_spec}.javac.jar"
     if output_snapshot.files:
         jar_result = await Get(
             ProcessResult,

--- a/src/python/pants/backend/java/compile/javac_test.py
+++ b/src/python/pants/backend/java/compile/javac_test.py
@@ -139,7 +139,7 @@ def test_compile_no_deps(rule_runner: RuleRunner) -> None:
 
     classpath = rule_runner.request(RenderedClasspath, [compiled_classfiles.digest])
     assert classpath.content == {
-        ".ExampleLib.java.lib.jar": {"org/pantsbuild/example/lib/ExampleLib.class"}
+        ".ExampleLib.java.lib.javac.jar": {"org/pantsbuild/example/lib/ExampleLib.class"}
     }
 
     # Additionally validate that `check` works.
@@ -186,7 +186,7 @@ def test_compile_jdk_versions(rule_runner: RuleRunner) -> None:
     compiled_classfiles = rule_runner.request(ClasspathEntry, [request])
     classpath = rule_runner.request(RenderedClasspath, [compiled_classfiles.digest])
     assert classpath.content == {
-        ".ExampleLib.java.lib.jar": {"org/pantsbuild/example/lib/ExampleLib.class"}
+        ".ExampleLib.java.lib.javac.jar": {"org/pantsbuild/example/lib/ExampleLib.class"}
     }
 
     rule_runner.set_options(
@@ -252,7 +252,7 @@ def test_compile_multiple_source_files(rule_runner: RuleRunner) -> None:
     compiled_classfiles0 = rule_runner.request(ClasspathEntry, [request0])
     classpath0 = rule_runner.request(RenderedClasspath, [compiled_classfiles0.digest])
     assert classpath0.content == {
-        ".ExampleLib.java.lib.jar": {
+        ".ExampleLib.java.lib.javac.jar": {
             "org/pantsbuild/example/lib/ExampleLib.class",
         }
     }
@@ -263,7 +263,7 @@ def test_compile_multiple_source_files(rule_runner: RuleRunner) -> None:
     compiled_classfiles1 = rule_runner.request(ClasspathEntry, [request1])
     classpath1 = rule_runner.request(RenderedClasspath, [compiled_classfiles1.digest])
     assert classpath1.content == {
-        ".OtherLib.java.lib.jar": {
+        ".OtherLib.java.lib.javac.jar": {
             "org/pantsbuild/example/lib/OtherLib.class",
         }
     }
@@ -347,7 +347,7 @@ def test_compile_with_cycle(rule_runner: RuleRunner) -> None:
     compiled_classfiles = rule_runner.request(ClasspathEntry, [request])
     classpath = rule_runner.request(RenderedClasspath, [compiled_classfiles.digest])
     assert classpath.content == {
-        "a.A.java.jar": {
+        "a.A.java.javac.jar": {
             "org/pantsbuild/a/A.class",
             "org/pantsbuild/a/C.class",
             "org/pantsbuild/b/B.class",
@@ -437,7 +437,7 @@ def test_compile_with_transitive_cycle(rule_runner: RuleRunner) -> None:
         ],
     )
     classpath = rule_runner.request(RenderedClasspath, [compiled_classfiles.digest])
-    assert classpath.content == {".Main.java.main.jar": {"org/pantsbuild/main/Main.class"}}
+    assert classpath.content == {".Main.java.main.javac.jar": {"org/pantsbuild/main/Main.class"}}
 
 
 @logging
@@ -508,7 +508,10 @@ def test_compile_with_transitive_multiple_sources(rule_runner: RuleRunner) -> No
     )
     classpath = rule_runner.request(RenderedClasspath, [compiled_classfiles.digest])
     assert classpath.content == {
-        ".Main.java.main.jar": {"org/pantsbuild/main/Main.class", "org/pantsbuild/main/Other.class"}
+        ".Main.java.main.javac.jar": {
+            "org/pantsbuild/main/Main.class",
+            "org/pantsbuild/main/Other.class",
+        }
     }
 
 
@@ -554,7 +557,9 @@ def test_compile_with_deps(rule_runner: RuleRunner) -> None:
         ],
     )
     classpath = rule_runner.request(RenderedClasspath, [compiled_classfiles.digest])
-    assert classpath.content == {".Example.java.main.jar": {"org/pantsbuild/example/Example.class"}}
+    assert classpath.content == {
+        ".Example.java.main.javac.jar": {"org/pantsbuild/example/Example.class"}
+    }
 
 
 @maybe_skip_jdk_test
@@ -688,7 +693,9 @@ def test_compile_with_maven_deps(rule_runner: RuleRunner) -> None:
     )
     compiled_classfiles = rule_runner.request(ClasspathEntry, [request])
     classpath = rule_runner.request(RenderedClasspath, [compiled_classfiles.digest])
-    assert classpath.content == {".Example.java.main.jar": {"org/pantsbuild/example/Example.class"}}
+    assert classpath.content == {
+        ".Example.java.main.javac.jar": {"org/pantsbuild/example/Example.class"}
+    }
 
 
 @maybe_skip_jdk_test

--- a/src/python/pants/backend/scala/compile/scalac.py
+++ b/src/python/pants/backend/scala/compile/scalac.py
@@ -164,7 +164,7 @@ async def compile_scala_source(
         ClasspathEntry.closure(direct_dependency_classpath_entries), prefix=usercp
     )
 
-    output_file = f"{request.component.representative.address.path_safe_spec}.jar"
+    output_file = f"{request.component.representative.address.path_safe_spec}.scalac.jar"
     process_result = await Get(
         FallibleProcessResult,
         Process(

--- a/src/python/pants/backend/scala/compile/scalac_test.py
+++ b/src/python/pants/backend/scala/compile/scalac_test.py
@@ -130,7 +130,10 @@ def test_compile_no_deps(rule_runner: RuleRunner) -> None:
 
     classpath = rule_runner.request(RenderedClasspath, [compiled_classfiles.digest])
     assert classpath.content == {
-        ".ExampleLib.scala.lib.jar": {"META-INF/MANIFEST.MF", "org/pantsbuild/example/lib/C.class"}
+        ".ExampleLib.scala.lib.scalac.jar": {
+            "META-INF/MANIFEST.MF",
+            "org/pantsbuild/example/lib/C.class",
+        }
     }
 
     # Additionally validate that `check` works.
@@ -189,7 +192,7 @@ def test_compile_with_deps(rule_runner: RuleRunner) -> None:
     )
     classpath = rule_runner.request(RenderedClasspath, [compiled_classfiles.digest])
     assert classpath.content == {
-        ".Example.scala.main.jar": {
+        ".Example.scala.main.scalac.jar": {
             "META-INF/MANIFEST.MF",
             "org/pantsbuild/example/Main$.class",
             "org/pantsbuild/example/Main.class",
@@ -288,7 +291,7 @@ def test_compile_with_maven_deps(rule_runner: RuleRunner) -> None:
     compiled_classfiles = rule_runner.request(ClasspathEntry, [request])
     classpath = rule_runner.request(RenderedClasspath, [compiled_classfiles.digest])
     assert classpath.content == {
-        ".Example.scala.main.jar": {
+        ".Example.scala.main.scalac.jar": {
             "META-INF/MANIFEST.MF",
             "org/pantsbuild/example/Main$.class",
             "org/pantsbuild/example/Main.class",

--- a/src/python/pants/jvm/compile_test.py
+++ b/src/python/pants/jvm/compile_test.py
@@ -226,12 +226,12 @@ def test_compile_mixed(rule_runner: RuleRunner) -> None:
     )
     rendered_classpath = rule_runner.request(RenderedClasspath, [classpath.content.digest])
     assert rendered_classpath.content == {
-        "__cp/.Example.scala.main.jar": {
+        "__cp/.Example.scala.main.scalac.jar": {
             "META-INF/MANIFEST.MF",
             "org/pantsbuild/example/Main$.class",
             "org/pantsbuild/example/Main.class",
         },
-        "__cp/lib.C.java.jar": {
+        "__cp/lib.C.java.javac.jar": {
             "org/pantsbuild/example/lib/C.class",
         },
     }
@@ -251,5 +251,6 @@ def test_compile_mixed_cycle(rule_runner: RuleRunner) -> None:
     )
 
     main_address = Address(spec_path="", target_name="main")
+    lib_address = Address(spec_path="lib")
     assert len(expect_single_expanded_coarsened_target(rule_runner, main_address).members) == 2
-    rule_runner.request(Classpath, [Addresses([main_address])])
+    rule_runner.request(Classpath, [Addresses([main_address, lib_address])])


### PR DESCRIPTION
When actually consumed, the cyclic classpaths from #13653 collided by using the [same artifact filename with different contents](https://github.com/pantsbuild/pants/blob/8fc8d0bd757cb4700185f1867ec67b9a157430cf/src/rust/engine/fs/store/src/snapshot_ops.rs#L270-L276).

Adjust the test to trigger the failure, and then fix artifact names.

[ci skip-rust]
[ci skip-build-wheels]