### PR TITLE
Fix bug when `docker push`ing multiple tags.

### DIFF
--- a/src/python/pants/backend/docker/goals/publish.py
+++ b/src/python/pants/backend/docker/goals/publish.py
@@ -71,13 +71,14 @@ async def push_docker_images(
         )
 
     env = await Get(Environment, EnvironmentRequest(options.env_vars))
-    process = docker.push_image(tags, env)
+    processes = zip(tags, docker.push_image(tags, env))
     return PublishProcesses(
         [
             PublishPackages(
-                names=tags,
-                process=InteractiveProcess.from_process(process) if process else None,
-            ),
+                names=(tag,),
+                process=InteractiveProcess.from_process(process),
+            )
+            for tag, process in processes
         ]
     )
 

--- a/src/python/pants/backend/docker/goals/publish_test.py
+++ b/src/python/pants/backend/docker/goals/publish_test.py
@@ -140,19 +140,27 @@ def test_docker_push_registries(rule_runner: RuleRunner) -> None:
             }
         },
     )
-    assert len(result) == 1
+    assert len(result) == 2
     assert_publish(
         result[0],
-        (
-            "inhouse1.registry/registries/registries:latest",
-            "inhouse2.registry/registries/registries:latest",
-        ),
+        ("inhouse1.registry/registries/registries:latest",),
         None,
         process_assertion(
             argv=(
                 docker.path,
                 "push",
                 "inhouse1.registry/registries/registries:latest",
+            )
+        ),
+    )
+    assert_publish(
+        result[1],
+        ("inhouse2.registry/registries/registries:latest",),
+        None,
+        process_assertion(
+            argv=(
+                docker.path,
+                "push",
                 "inhouse2.registry/registries/registries:latest",
             )
         ),

--- a/src/python/pants/backend/docker/util_rules/docker_binary.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary.py
@@ -64,15 +64,15 @@ class DockerBinary(BinaryPath):
 
     def push_image(
         self, tags: tuple[str, ...], env: Mapping[str, str] | None = None
-    ) -> Process | None:
-        if not tags:
-            return None
-
-        return Process(
-            argv=(self.path, "push", *tags),
-            cache_scope=ProcessCacheScope.PER_SESSION,
-            description=f"Pushing docker image {tags[0]}",
-            env=env,
+    ) -> tuple[Process, ...]:
+        return tuple(
+            Process(
+                argv=(self.path, "push", tag),
+                cache_scope=ProcessCacheScope.PER_SESSION,
+                description=f"Pushing docker image {tag}",
+                env=env,
+            )
+            for tag in tags
         )
 
 

--- a/src/python/pants/backend/docker/util_rules/docker_binary_test.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary_test.py
@@ -39,13 +39,15 @@ def test_docker_binary_build_image(docker_path: str, docker: DockerBinary) -> No
 
 
 def test_docker_binary_push_image(docker_path: str, docker: DockerBinary) -> None:
-    assert docker.push_image(()) is None
+    assert docker.push_image(()) == ()
 
     image_ref = "registry/repo/name:tag"
     push_request = docker.push_image((image_ref,))
-    assert push_request == Process(
-        argv=(docker_path, "push", image_ref),
-        cache_scope=ProcessCacheScope.PER_SESSION,
-        description="",  # The description field is marked `compare=False`
+    assert push_request == (
+        Process(
+            argv=(docker_path, "push", image_ref),
+            cache_scope=ProcessCacheScope.PER_SESSION,
+            description="",  # The description field is marked `compare=False`
+        ),
     )
-    assert push_request.description == f"Pushing docker image {image_ref}"
+    assert push_request[0].description == f"Pushing docker image {image_ref}"


### PR DESCRIPTION
I'm sure this used to be a thing, that you could push multiple images at once by listing all images on the command line. Apparently that is no more.
