### PR TITLE
Add `--local-cache` and `--process-cleanup` to replace `--process-execution-local-cache` and `--process-execution-local-cleanup`

### DIFF
--- a/src/python/pants/backend/java/dependency_inference/java_parser.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser.py
@@ -20,7 +20,7 @@ from pants.engine.process import BashBinary, FallibleProcessResult, Process, Pro
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.jvm.jdk_rules import JdkSetup
 from pants.jvm.resolve.coursier_fetch import MaterializedClasspath, MaterializedClasspathRequest
-from pants.option.global_options import GlobalOptions
+from pants.option.global_options import ProcessCleanupOption
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
@@ -39,7 +39,7 @@ class FallibleJavaSourceDependencyAnalysisResult:
 @rule(level=LogLevel.DEBUG)
 async def resolve_fallible_result_to_analysis(
     fallible_result: FallibleJavaSourceDependencyAnalysisResult,
-    global_options: GlobalOptions,
+    process_cleanup: ProcessCleanupOption,
 ) -> JavaSourceDependencyAnalysis:
     # TODO(#12725): Just convert directly to a ProcessResult like this:
     # result = await Get(ProcessResult, FallibleProcessResult, fallible_result.process_result)
@@ -54,7 +54,7 @@ async def resolve_fallible_result_to_analysis(
         fallible_result.process_result.stdout,
         fallible_result.process_result.stderr,
         "Java source dependency analysis failed.",
-        local_cleanup=global_options.options.process_execution_local_cleanup,
+        process_cleanup=process_cleanup.val,
     )
 
 

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -46,7 +46,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import TransitiveTargets, TransitiveTargetsRequest
 from pants.engine.unions import UnionRule
 from pants.option.custom_types import file_option
-from pants.option.global_options import GlobalOptions
+from pants.option.global_options import ProcessCleanupOption
 from pants.source.source_root import AllSourceRoots
 from pants.util.docutil import git_url
 from pants.util.logging import LogLevel
@@ -477,7 +477,7 @@ async def generate_coverage_reports(
     coverage_setup: CoverageSetup,
     coverage_config: CoverageConfig,
     coverage_subsystem: CoverageSubsystem,
-    global_options: GlobalOptions,
+    process_cleanup: ProcessCleanupOption,
 ) -> CoverageReports:
     """Takes all Python test results and generates a single coverage report."""
     transitive_targets = await Get(
@@ -554,7 +554,7 @@ async def generate_coverage_reports(
                 res.stdout,
                 res.stderr,
                 proc.description,
-                local_cleanup=global_options.options.process_execution_local_cleanup,
+                process_cleanup=process_cleanup.val,
             )
 
     # In practice if one result triggers --fail-under, they all will, but no need to rely on that.

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -37,7 +37,7 @@ from pants.jvm.resolve.coursier_fetch import (
     MaterializedClasspath,
     MaterializedClasspathRequest,
 )
-from pants.option.global_options import GlobalOptions
+from pants.option.global_options import ProcessCleanupOption
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
@@ -280,7 +280,7 @@ async def analyze_scala_source_dependencies(
 @rule(level=LogLevel.DEBUG)
 async def resolve_fallible_result_to_analysis(
     fallible_result: FallibleScalaSourceDependencyAnalysisResult,
-    global_options: GlobalOptions,
+    process_cleanup: ProcessCleanupOption,
 ) -> ScalaSourceDependencyAnalysis:
     # TODO(#12725): Just convert directly to a ProcessResult like this:
     # result = await Get(ProcessResult, FallibleProcessResult, fallible_result.process_result)
@@ -295,7 +295,7 @@ async def resolve_fallible_result_to_analysis(
         fallible_result.process_result.stdout,
         fallible_result.process_result.stderr,
         "Scala source dependency analysis failed.",
-        local_cleanup=global_options.options.process_execution_local_cleanup,
+        process_cleanup=process_cleanup.val,
     )
 
 

--- a/src/python/pants/engine/internals/options_parsing.py
+++ b/src/python/pants/engine/internals/options_parsing.py
@@ -3,10 +3,11 @@
 
 from dataclasses import dataclass
 
+from pants.base.deprecated import resolve_conflicting_options
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.engine.internals.session import SessionValues
 from pants.engine.rules import collect_rules, rule
-from pants.option.global_options import GlobalOptions
+from pants.option.global_options import GlobalOptions, ProcessCleanupOption
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.option.scope import Scope, ScopedOptions
@@ -52,6 +53,19 @@ def scope_options(scope: Scope, options: _Options) -> ScopedOptions:
 def log_level(global_options: GlobalOptions) -> LogLevel:
     log_level: LogLevel = global_options.options.level
     return log_level
+
+
+@rule
+def extract_process_cleanup_option(global_options: GlobalOptions) -> ProcessCleanupOption:
+    cleanup = resolve_conflicting_options(
+        old_option="process_execution_local_cleanup",
+        new_option="process_cleanup",
+        old_scope="",
+        new_scope="",
+        old_container=global_options.options,
+        new_container=global_options.options,
+    )
+    return ProcessCleanupOption(cleanup)
 
 
 def rules():

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -201,10 +201,10 @@ class Scheduler:
             shard_count=local_store_options.shard_count,
         )
         exec_stategy_opts = PyExecutionStrategyOptions(
-            local_cache=execution_options.process_execution_local_cache,
+            local_cache=execution_options.local_cache,
             remote_cache_read=execution_options.remote_cache_read,
             remote_cache_write=execution_options.remote_cache_write,
-            local_cleanup=execution_options.process_execution_local_cleanup,
+            local_cleanup=execution_options.process_cleanup,
             local_parallelism=execution_options.process_execution_local_parallelism,
             local_enable_nailgun=execution_options.process_execution_local_enable_nailgun,
             remote_parallelism=execution_options.process_execution_remote_parallelism,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -23,6 +23,7 @@ from pants.base.build_environment import (
     is_in_container,
     pants_version,
 )
+from pants.base.deprecated import resolve_conflicting_options
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.engine.environment import CompleteEnvironment
 from pants.engine.internals.native_engine import PyExecutor
@@ -314,8 +315,8 @@ class ExecutionOptions:
     remote_instance_name: str | None
     remote_ca_certs_path: str | None
 
-    process_execution_local_cache: bool
-    process_execution_local_cleanup: bool
+    process_cleanup: bool
+    local_cache: bool
     process_execution_local_parallelism: int
     process_execution_local_enable_nailgun: bool
     process_execution_remote_parallelism: int
@@ -354,10 +355,24 @@ class ExecutionOptions:
             remote_instance_name=dynamic_remote_options.instance_name,
             remote_ca_certs_path=bootstrap_options.remote_ca_certs_path,
             # Process execution setup.
-            process_execution_local_cache=bootstrap_options.process_execution_local_cache,
+            process_cleanup=resolve_conflicting_options(
+                old_option="process_execution_local_cleanup",
+                new_option="process_cleanup",
+                old_scope="",
+                new_scope="",
+                old_container=bootstrap_options,
+                new_container=bootstrap_options,
+            ),
+            local_cache=resolve_conflicting_options(
+                old_option="process_execution_local_cache",
+                new_option="local_cache",
+                old_scope="",
+                new_scope="",
+                old_container=bootstrap_options,
+                new_container=bootstrap_options,
+            ),
             process_execution_local_parallelism=bootstrap_options.process_execution_local_parallelism,
             process_execution_remote_parallelism=dynamic_remote_options.parallelism,
-            process_execution_local_cleanup=bootstrap_options.process_execution_local_cleanup,
             process_execution_cache_namespace=bootstrap_options.process_execution_cache_namespace,
             process_execution_local_enable_nailgun=bootstrap_options.process_execution_local_enable_nailgun,
             # Remote store setup.
@@ -434,8 +449,8 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     process_execution_local_parallelism=CPU_COUNT,
     process_execution_remote_parallelism=128,
     process_execution_cache_namespace=None,
-    process_execution_local_cleanup=True,
-    process_execution_local_cache=True,
+    process_cleanup=True,
+    local_cache=True,
     process_execution_local_enable_nailgun=True,
     # Remote store setup.
     remote_store_address=None,
@@ -746,7 +761,6 @@ class GlobalOptions(Subsystem):
 
         register(
             "--pantsd",
-            advanced=True,
             type=bool,
             default=True,
             daemon=True,
@@ -762,7 +776,6 @@ class GlobalOptions(Subsystem):
         # NB: Eventually, we would like to deprecate this flag in favor of making pantsd runs parallelizable.
         register(
             "--concurrent",
-            advanced=True,
             type=bool,
             default=False,
             help="Enable concurrent runs of Pants. Without this enabled, Pants will "
@@ -967,19 +980,41 @@ class GlobalOptions(Subsystem):
             default=tempfile.gettempdir(),
         )
         register(
-            "--process-execution-local-cache",
+            "--local-cache",
             type=bool,
-            default=DEFAULT_EXECUTION_OPTIONS.process_execution_local_cache,
-            advanced=True,
+            default=DEFAULT_EXECUTION_OPTIONS.local_cache,
             help=(
                 "Whether to cache process executions in a local cache persisted to disk at "
                 "`--local-store-dir`."
             ),
         )
         register(
+            "--process-execution-local-cache",
+            type=bool,
+            default=DEFAULT_EXECUTION_OPTIONS.local_cache,
+            advanced=True,
+            help=(
+                "Whether to cache process executions in a local cache persisted to disk at "
+                "`--local-store-dir`."
+            ),
+            removal_version="2.10.0.dev0",
+            removal_hint="Use `--local-cache`, which behaves the same.",
+        )
+        register(
+            "--process-cleanup",
+            type=bool,
+            default=DEFAULT_EXECUTION_OPTIONS.process_cleanup,
+            help=(
+                "If false, Pants will not clean up local directories used as chroots for running "
+                "processes. Pants will log their location so that you can inspect the chroot, and "
+                "run the `__run.sh` script to recreate the process using the same argv and "
+                "environment variables used by Pants. This option is useful for debugging."
+            ),
+        )
+        register(
             "--process-execution-local-cleanup",
             type=bool,
-            default=DEFAULT_EXECUTION_OPTIONS.process_execution_local_cleanup,
+            default=DEFAULT_EXECUTION_OPTIONS.process_cleanup,
             advanced=True,
             help=(
                 "If false, Pants will not clean up local directories used as chroots for running "
@@ -987,6 +1022,8 @@ class GlobalOptions(Subsystem):
                 "run the `__run.sh` script to recreate the process using the same argv and "
                 "environment variables used by Pants. This option is useful for debugging."
             ),
+            removal_version="2.10.0.dev0",
+            removal_hint="Use `--process-cleanup`, which behaves the same.",
         )
 
         register(
@@ -1041,7 +1078,6 @@ class GlobalOptions(Subsystem):
 
         register(
             "--remote-execution",
-            advanced=True,
             type=bool,
             default=DEFAULT_EXECUTION_OPTIONS.remote_execution,
             help=(
@@ -1054,7 +1090,6 @@ class GlobalOptions(Subsystem):
             "--remote-cache-read",
             type=bool,
             default=DEFAULT_EXECUTION_OPTIONS.remote_cache_read,
-            advanced=True,
             help=(
                 "Whether to enable reading from a remote cache.\n\nThis cannot be used at the same "
                 "time as `--remote-execution`."
@@ -1064,7 +1099,6 @@ class GlobalOptions(Subsystem):
             "--remote-cache-write",
             type=bool,
             default=DEFAULT_EXECUTION_OPTIONS.remote_cache_write,
-            advanced=True,
             help=(
                 "Whether to enable writing results to a remote cache.\n\nThis cannot be used at "
                 "the same time as `--remote-execution`."
@@ -1608,3 +1642,13 @@ class GlobalOptionsFlags:
 
         GlobalOptionsType.register_bootstrap_options(capture_the_flags)
         return cls(FrozenOrderedSet(flags), FrozenOrderedSet(short_flags))
+
+
+@dataclass(frozen=True)
+class ProcessCleanupOption:
+    """A wrapper around the global option `process_cleanup`.
+
+    Prefer to use this rather than requesting `GlobalOptions` for more precise invalidation.
+    """
+
+    val: bool

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -197,10 +197,7 @@ class RuleRunner:
             root_dir = Path(mkdtemp(prefix="RuleRunner."))
             print(f"Preserving rule runner temporary directories at {root_dir}.", file=sys.stderr)
             bootstrap_args.extend(
-                [
-                    "--no-process-execution-local-cleanup",
-                    f"--local-execution-root-dir={root_dir}",
-                ]
+                ["--no-process-cleanup", f"--local-execution-root-dir={root_dir}"]
             )
             build_root = (root_dir / "BUILD_ROOT").resolve()
             build_root.mkdir()


### PR DESCRIPTION
We frequently encourage in Slack and our docs using these two flags for debugging. 

They are almost exclusively used as command line flags, rather than in config files. However, they still have very verbose names. Multiple users have pointed this out.

The namespacing with the other `--process-execution` options isn't that useful. In particular, these two options are no longer `advanced`, so they don't even show up next to the related `--process-execution` options with `./pants help-advanced` anymore. The "process-execution" namespace is not pulling its weight.

`--local-cache` complements `--remote-cache-{read,write}`.

--

This also marks some global options to not be `advanced=True`, as these are frequently used on the command line.

--

Finally, this extracts out a rule to look at the `process_cleanup` value, rather than downstream rules having to request `GlobalOptions`. This reduces invalidation - changing unrelated global options no longer forces those rules to rerun.

[ci skip-rust]
[ci skip-build-wheels]