### PR TITLE
[internal] Add Scala backend to dryrun for wheel builds.

### DIFF
--- a/build-support/bin/_release_helper.py
+++ b/build-support/bin/_release_helper.py
@@ -298,6 +298,7 @@ def validate_pants_pkg(version: str, venv_dir: Path, extra_pip_args: list[str]) 
                         "'pants.backend.python', "
                         "'pants.backend.shell', "
                         "'pants.backend.experimental.java', "
+                        "'pants.backend.experimental.scala', "
                         "'internal_plugins.releases'"
                         "]"
                     ),


### PR DESCRIPTION
#13771 added usage of a target from the `scala` backend, which is not enabled during dryruns. Enable it.

[ci skip-rust]