### PR TITLE
Add support for inferring relative imports from Scala

### DIFF
--- a/src/python/pants/backend/java/compile/javac.py
+++ b/src/python/pants/backend/java/compile/javac.py
@@ -52,7 +52,7 @@ async def compile_java_source(
     union_membership: UnionMembership,
     request: CompileJavaSourceRequest,
 ) -> FallibleClasspathEntry:
-    # Request the component's direct dependency classpath, and additionally any preqrequisite.
+    # Request the component's direct dependency classpath, and additionally any prerequisite.
     classpath_entry_requests = [
         *((request.prerequisite,) if request.prerequisite else ()),
         *(

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -96,15 +96,17 @@ SCALA_PARSER_ARTIFACT_REQUIREMENTS = ArtifactRequirements(
 @dataclass(frozen=True)
 class ScalaImport:
     name: str
+    alias: str | None
     is_wildcard: bool
 
     @classmethod
     def from_json_dict(cls, data: Mapping[str, Any]):
-        return cls(name=data["name"], is_wildcard=data["isWildcard"])
+        return cls(name=data["name"], alias=data.get("alias"), is_wildcard=data["isWildcard"])
 
     def to_debug_json_dict(self) -> dict[str, Any]:
         return {
             "name": self.name,
+            "alias": self.alias,
             "is_wildcard": self.is_wildcard,
         }
 
@@ -130,29 +132,40 @@ class ScalaSourceDependencyAnalysis:
         have been provided by any wildcard import in scope, as well as being declared in the current
         package.
         """
-        # Collect all wildcard imports.
-        wildcard_imports_by_scope = {}
-        for scope, imports in self.imports_by_scope.items():
-            wildcard_imports = tuple(imp for imp in imports if imp.is_wildcard)
-            if wildcard_imports:
-                wildcard_imports_by_scope[scope] = wildcard_imports
 
-        for scope, consumed_symbols in self.consumed_symbols_by_scope.items():
-            parent_scope_wildcards = {
-                wi
-                for s, wildcard_imports in wildcard_imports_by_scope.items()
-                for wi in wildcard_imports
-                if scope.startswith(s)
-            }
+        def scope_and_parents(scope: str) -> Iterator[str]:
+            while True:
+                yield scope
+                if scope == "":
+                    break
+                scope, _, _ = scope.rpartition(".")
+
+        for consumption_scope, consumed_symbols in self.consumed_symbols_by_scope.items():
+            parent_scopes = tuple(scope_and_parents(consumption_scope))
             for symbol in consumed_symbols:
-                for scope in self.scopes:
-                    yield f"{scope}.{symbol}"
-                if not self.scopes or "." in symbol:
+                symbol_rel_prefix, dot_in_symbol, symbol_rel_suffix = symbol.partition(".")
+                if not self.scopes or dot_in_symbol:
                     # TODO: Similar to #13545: we assume that a symbol containing a dot might already
                     # be fully qualified.
                     yield symbol
-                for wildcard_scope in parent_scope_wildcards:
-                    yield f"{wildcard_scope.name}.{symbol}"
+                for parent_scope in parent_scopes:
+                    if parent_scope in self.scopes:
+                        # A package declaration is a parent of this scope, and any of its symbols
+                        # could be in scope.
+                        yield f"{parent_scope}.{symbol}"
+
+                    for imp in self.imports_by_scope.get(parent_scope, ()):
+                        if imp.is_wildcard:
+                            # There is a wildcard import in a parent scope.
+                            yield f"{imp.name}.{symbol}"
+                        if dot_in_symbol:
+                            # If the parent scope has an import which defines the first token of the
+                            # symbol, then it might be a relative usage of an import.
+                            if imp.alias:
+                                if imp.alias == symbol_rel_prefix:
+                                    yield f"{imp.name}.{symbol_rel_suffix}"
+                            elif imp.name.endswith(f".{symbol_rel_prefix}"):
+                                yield f"{imp.name}.{symbol_rel_suffix}"
 
     @classmethod
     def from_json_dict(cls, d: dict) -> ScalaSourceDependencyAnalysis:


### PR DESCRIPTION
Relative imports are common in Scala, and not supporting them caused ~12% of the issues in our test repository. See #13740 for background.

To support them, compares the final token of an import (or its alias, if it has one) to the first token of any multi-token symbol that is scoped below the import.

Fixes #13740.