### PR TITLE
Go tests can depend on `file` targets (e.g. `testdata` folder) 

### DIFF
--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -130,11 +130,11 @@ async def run_go_tests(
         Get(Targets, DependenciesRequest(field_set.dependencies)),
     )
 
-    def compilation_failure(exit_code: int, stdout: str, stderr: str) -> TestResult:
+    def compilation_failure(exit_code: int, stdout: str | None, stderr: str | None) -> TestResult:
         return TestResult(
             exit_code=exit_code,
-            stdout=stdout,
-            stderr=stderr,
+            stdout=stdout or "",
+            stderr=stderr or "",
             stdout_digest=EMPTY_FILE_DIGEST,
             stderr_digest=EMPTY_FILE_DIGEST,
             address=field_set.address,
@@ -143,7 +143,7 @@ async def run_go_tests(
 
     if maybe_pkg_info.info is None:
         assert maybe_pkg_info.stderr is not None
-        return compilation_failure(maybe_pkg_info.exit_code, "", maybe_pkg_info.stderr)
+        return compilation_failure(maybe_pkg_info.exit_code, None, maybe_pkg_info.stderr)
 
     pkg_info = maybe_pkg_info.info
     import_path = pkg_info.import_path
@@ -165,7 +165,7 @@ async def run_go_tests(
 
     if testmain.failed_exit_code_and_stderr is not None:
         _exit_code, _stderr = testmain.failed_exit_code_and_stderr
-        return compilation_failure(_exit_code, "", _stderr)
+        return compilation_failure(_exit_code, None, _stderr)
 
     if not testmain.has_tests and not testmain.has_xtests:
         return TestResult.skip(field_set.address, output_setting=test_subsystem.output)
@@ -178,7 +178,7 @@ async def run_go_tests(
     if maybe_test_pkg_build_request.request is None:
         assert maybe_test_pkg_build_request.stderr is not None
         return compilation_failure(
-            maybe_test_pkg_build_request.exit_code, "", maybe_test_pkg_build_request.stderr
+            maybe_test_pkg_build_request.exit_code, None, maybe_test_pkg_build_request.stderr
         )
     test_pkg_build_request = maybe_test_pkg_build_request.request
 

--- a/src/python/pants/backend/go/goals/test_test.py
+++ b/src/python/pants/backend/go/goals/test_test.py
@@ -23,8 +23,10 @@ from pants.backend.go.util_rules import (
     tests_analysis,
     third_party_pkg,
 )
-from pants.build_graph.address import Address
 from pants.core.goals.test import TestResult
+from pants.core.target_types import FileTarget
+from pants.core.util_rules import source_files
+from pants.engine.addresses import Address
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
@@ -43,9 +45,10 @@ def rule_runner() -> RuleRunner:
             *target_type_rules.rules(),
             *tests_analysis.rules(),
             *third_party_pkg.rules(),
+            *source_files.rules(),
             QueryRule(TestResult, [GoTestFieldSet]),
         ],
-        target_types=[GoModTarget, GoPackageTarget],
+        target_types=[GoModTarget, GoPackageTarget, FileTarget],
     )
     rule_runner.set_options(["--go-test-args=-v -bench=."], env_inherit={"PATH"})
     return rule_runner
@@ -546,3 +549,44 @@ def test_compilation_error(rule_runner: RuleRunner) -> None:
     result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
     assert result.exit_code == 1
     assert "failed to parse" in result.stderr
+
+
+def test_file_dependencies(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "f.txt": "",
+            "BUILD": "file(name='root', source='f.txt')",
+            "foo/BUILD": textwrap.dedent(
+                """
+                go_mod(name='mod')
+                go_package(dependencies=[":testdata", "//:root"])
+                file(name="testdata", source="testdata/f.txt")
+                """
+            ),
+            "foo/go.mod": "module foo",
+            "foo/foo_test.go": textwrap.dedent(
+                """
+                package foo
+                import (
+                  "os"
+                  "testing"
+                )
+
+                func TestFilesAvailable(t *testing.T) {
+                  _, err1 := os.Stat("testdata/f.txt")
+                  if err1 != nil {
+                    t.Fatalf("Could not stat foo/testdata/f.txt: %v", err1)
+                  }
+                  _, err2 := os.Stat("../f.txt")
+                  if err2 != nil {
+                    t.Fatalf("Could not stat f.txt: %v", err2)
+                  }
+                }
+                """
+            ),
+            "foo/testdata/f.txt": "",
+        }
+    )
+    tgt = rule_runner.get_target(Address("foo"))
+    result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
+    assert result.exit_code == 0


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/13200. Builds off of https://github.com/pantsbuild/pants/pull/13737.

Note that it's important tests can load `file` targets from ancestor directories, and that they load files using the same relpaths they would use without Pants. So, we emulate Go by setting the working directory to the package's directory.

This also fixes a compilation error that wasn't rendering because it was from `stdout` instead of `stderr`, which we didn't propagate.

--

A followup PR will special-case the `testdata` folder for `tailor` and possibly dependency inference.