### PR TITLE
[internal] `tailor` doesn't add `go_package` for `testdata` folder

### DIFF
--- a/src/python/pants/backend/go/goals/tailor.py
+++ b/src/python/pants/backend/go/goals/tailor.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import os
 import re
 from dataclasses import dataclass
+from pathlib import PurePath
 
 from pants.backend.go.target_types import (
     GoBinaryMainPackage,
@@ -69,11 +70,14 @@ async def find_putative_go_targets(
     # Add `go_package` targets.
     unowned_go_files = set(all_go_files.files) - set(all_owned_sources)
     for dirname, filenames in group_by_dir(unowned_go_files).items():
+        dir_path = PurePath(dirname)
+        if "testdata" in dir_path.parts:
+            continue
         putative_targets.append(
             PutativeTarget.for_target_type(
                 GoPackageTarget,
                 path=dirname,
-                name=os.path.basename(dirname),
+                name=dir_path.name,
                 triggering_sources=sorted(filenames),
             )
         )

--- a/src/python/pants/backend/go/goals/tailor_test.py
+++ b/src/python/pants/backend/go/goals/tailor_test.py
@@ -76,6 +76,9 @@ def test_find_go_package_targets(rule_runner: RuleRunner) -> None:
             "unowned/f1.go": "",
             "owned/f.go": "",
             "owned/BUILD": "go_package()",
+            # Any `.go` files under a `testdata` folder should be ignored.
+            "unowned/testdata/f.go": "",
+            "unowned/testdata/subdir/f.go": "",
         }
     )
     putative_targets = rule_runner.request(


### PR DESCRIPTION
Go tooling ignores the `testdata` folder. While it's uncommon to have `.go` files in this folder, we should not ever generate `go_package` targets inside it. Users can manually create targets if they so desire.

Note that we ignore Go files in subdirectories of `testdata`, which mirrors Go's handling.

[ci skip-rust]
[ci skip-build-wheels]