### PR TITLE
[internal] Refer to `go.mod` path when downloading packages

### DIFF
--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -160,7 +160,9 @@ async def inject_go_third_party_package_dependencies(
     tgt = wrapped_target.target
     pkg_info = await Get(
         ThirdPartyPkgInfo,
-        ThirdPartyPkgInfoRequest(tgt[GoImportPathField].value, go_mod_info.stripped_digest),
+        ThirdPartyPkgInfoRequest(
+            tgt[GoImportPathField].value, go_mod_info.digest, go_mod_info.mod_path
+        ),
     )
 
     inferred_dependencies = []
@@ -203,7 +205,8 @@ async def generate_targets_from_go_mod(
     generator_addr = request.generator.address
     go_mod_info = await Get(GoModInfo, GoModInfoRequest(generator_addr))
     all_packages = await Get(
-        AllThirdPartyPackages, AllThirdPartyPackagesRequest(go_mod_info.stripped_digest)
+        AllThirdPartyPackages,
+        AllThirdPartyPackagesRequest(go_mod_info.digest, go_mod_info.mod_path),
     )
 
     def create_tgt(pkg_info: ThirdPartyPkgInfo) -> GoThirdPartyPackageTarget:

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -84,9 +84,7 @@ async def setup_build_go_package_target_request(
         _go_mod_info = await Get(GoModInfo, GoModInfoRequest(_go_mod_address))
         _third_party_pkg_info = await Get(
             ThirdPartyPkgInfo,
-            ThirdPartyPkgInfoRequest(
-                import_path=import_path, go_mod_stripped_digest=_go_mod_info.stripped_digest
-            ),
+            ThirdPartyPkgInfoRequest(import_path, _go_mod_info.digest, _go_mod_info.mod_path),
         )
 
         # We error if trying to _build_ a package with issues (vs. only generating the target and

--- a/src/python/pants/backend/go/util_rules/go_mod_test.py
+++ b/src/python/pants/backend/go/util_rules/go_mod_test.py
@@ -81,7 +81,5 @@ def test_go_mod_info(rule_runner: RuleRunner) -> None:
             {"foo/go.mod": go_mod_content, "foo/go.sum": go_sum_content}
         ).digest
     )
-    assert (
-        go_mod_info.stripped_digest
-        == rule_runner.make_snapshot({"go.mod": go_mod_content, "go.sum": go_sum_content}).digest
-    )
+    assert go_mod_info.mod_path == "foo/go.mod"
+    assert go_mod_info.minimum_go_version == "1.17"

--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -64,10 +64,11 @@ class ThirdPartyPkgInfoRequest(EngineAwareParameter):
     """
 
     import_path: str
-    go_mod_stripped_digest: Digest
+    go_mod_digest: Digest
+    go_mod_path: str
 
     def debug_hint(self) -> str:
-        return self.import_path
+        return f"{self.import_path} from {self.go_mod_path}"
 
 
 @dataclass(frozen=True)
@@ -85,26 +86,30 @@ class AllThirdPartyPackages(FrozenDict[str, ThirdPartyPkgInfo]):
 
 @dataclass(frozen=True)
 class AllThirdPartyPackagesRequest:
-    go_mod_stripped_digest: Digest
+    go_mod_digest: Digest
+    go_mod_path: str
 
 
 @rule(desc="Download and analyze all third-party Go packages", level=LogLevel.DEBUG)
 async def download_and_analyze_third_party_packages(
     request: AllThirdPartyPackagesRequest,
 ) -> AllThirdPartyPackages:
-    # NB: We download all modules to GOPATH=$(pwd)/gopath. Running `go list ...` from $(pwd) would
-    # naively try analyzing the contents of the GOPATH like they were first-party packages. This
-    # results in errors like this:
+    # NB: We download all modules to GOPATH={chroot}/gopath. Running `go list ...` from {chroot}
+    # would naively try analyzing the contents of the GOPATH like they were first-party packages.
+    # This results in errors like this:
     #
     #   package <import_path>/gopath/pkg/mod/golang.org/x/text@v0.3.0/unicode: can only use
     #   path@version syntax with 'go get' and 'go install' in module-aware mode
     #
-    # Instead, we run `go list` from a subdirectory of the chroot. It can still access the
-    # contents of `GOPATH`, but won't incorrectly treat its contents as first-party packages.
-    go_mod_prefix = "go_mod_prefix"
-    go_mod_prefixed_digest = await Get(
-        Digest, AddPrefix(request.go_mod_stripped_digest, go_mod_prefix)
-    )
+    # Instead, we make sure we run `go list` from a subdirectory of the chroot. It can still
+    # access the contents of `GOPATH`, but won't incorrectly treat its contents as
+    # first-party packages.
+    go_mod_dir = os.path.dirname(request.go_mod_path)
+    if not go_mod_dir:
+        go_mod_dir = "go_mod_prefix"
+        go_mod_digest = await Get(Digest, AddPrefix(request.go_mod_digest, go_mod_dir))
+    else:
+        go_mod_digest = request.go_mod_digest
 
     list_argv = (
         "list",
@@ -134,11 +139,10 @@ async def download_and_analyze_third_party_packages(
         ProcessResult,
         GoSdkProcess(
             command=list_argv,
-            # TODO: make this more descriptive: point to the actual `go_mod` target or path.
-            description="Run `go list` to download and analyze all third-party Go packages",
-            input_digest=go_mod_prefixed_digest,
+            description=f"Run `go list` to download {request.go_mod_path}",
+            input_digest=go_mod_digest,
             output_directories=("gopath/pkg/mod",),
-            working_dir=go_mod_prefix,
+            working_dir=go_mod_dir,
             allow_downloads=True,
         ),
     )
@@ -199,7 +203,8 @@ async def download_and_analyze_third_party_packages(
 @rule
 async def extract_package_info(request: ThirdPartyPkgInfoRequest) -> ThirdPartyPkgInfo:
     all_packages = await Get(
-        AllThirdPartyPackages, AllThirdPartyPackagesRequest(request.go_mod_stripped_digest)
+        AllThirdPartyPackages,
+        AllThirdPartyPackagesRequest(request.go_mod_digest, request.go_mod_path),
     )
     pkg_info = all_packages.import_paths_to_pkg_info.get(request.import_path)
     if pkg_info:


### PR DESCRIPTION
Part of https://github.com/pantsbuild/pants/issues/13136.

This makes the dynamic UI and stacktraces more useful, especially when we eventually have multiple `go.mod` support.

[ci skip-rust]
[ci skip-build-wheels]