### PR TITLE
Support materializing files through file symlinks.

### DIFF
--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -1012,13 +1012,10 @@ impl Store {
     let res = async move {
       let write_result = store
         .load_file_bytes_with(digest, move |bytes| {
-          if destination.exists() {
-            std::fs::remove_file(&destination)
-              .map_err(|e| format!("Failed to overwrite {}: {:?}", destination.display(), e))?;
-          }
           let mut f = OpenOptions::new()
             .create(true)
             .write(true)
+            .truncate(true)
             .mode(if is_executable { 0o755 } else { 0o644 })
             .open(&destination)
             .map_err(|e| {


### PR DESCRIPTION
Previously we checked if the file exists, and deleted it if so.
Now we truncate the file if it exists and overwrite it in place.
This will write through symlinks, as expected.

Fixes https://github.com/pantsbuild/pants/issues/13780

[ci skip-build-wheels]