### PR TITLE
rename `pypi_repositories` field to `repositories`

### DIFF
--- a/src/python/pants/backend/python/goals/publish_test.py
+++ b/src/python/pants/backend/python/goals/publish_test.py
@@ -7,7 +7,11 @@ from textwrap import dedent
 
 import pytest
 
-from pants.backend.python.goals.publish import PublishToPyPiFieldSet, PublishToPyPiRequest, rules
+from pants.backend.python.goals.publish import (
+    PublishPythonPackageFieldSet,
+    PublishPythonPackageRequest,
+    rules,
+)
 from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.target_types import PythonDistribution, PythonSourcesGeneratorTarget
 from pants.backend.python.util_rules import pex_from_targets
@@ -28,7 +32,7 @@ def rule_runner() -> RuleRunner:
             *config_files_rules(),
             *pex_from_targets.rules(),
             *rules(),
-            QueryRule(PublishProcesses, [PublishToPyPiRequest]),
+            QueryRule(PublishProcesses, [PublishPythonPackageRequest]),
         ],
         target_types=[PythonSourcesGeneratorTarget, PythonDistribution],
         objects={"python_artifact": PythonArtifact},
@@ -71,7 +75,7 @@ def project_files(
                 name="my-package",
                 version="0.1.0",
               ),
-              pypi_repositories={repositories!r},
+              repositories={repositories!r},
               skip_twine={skip_twine},
             )
             """
@@ -83,7 +87,7 @@ def project_files(
 
 def request_publish_processes(rule_runner: RuleRunner, packages) -> PublishProcesses:
     tgt = rule_runner.get_target(Address("src", target_name="dist"))
-    fs = PublishToPyPiFieldSet.create(tgt)
+    fs = PublishPythonPackageFieldSet.create(tgt)
     return rule_runner.request(PublishProcesses, [fs._request(packages)])
 
 


### PR DESCRIPTION
This is to reflect the fact that Twine supports more repositories than just `pypi` ones.
