### PR TITLE
[internal] Clean up Go `embed` support's handling of dependencies

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -97,6 +97,7 @@ ignore_adding_targets = [
   "src/python/pants/backend/go/go_sources:bin",
   "src/python/pants/backend/go/go_sources:go_sources0",
   "src/python/pants/backend/go/go_sources/analyze_package:bin",
+  "src/python/pants/backend/go/go_sources/embedcfg:bin",
   "src/python/pants/backend/go/go_sources/generate_testmain:bin",
   "src/python/pants/backend/docker/subsystems:dockerfile_wrapper_script",
   "src/python/pants/backend/python/dependency_inference:import_parser",

--- a/src/python/pants/backend/go/go_sources/BUILD
+++ b/src/python/pants/backend/go/go_sources/BUILD
@@ -4,6 +4,7 @@
 python_sources(
     dependencies=[
         "src/python/pants/backend/go/go_sources/analyze_package",
+        "src/python/pants/backend/go/go_sources/embedcfg",
         "src/python/pants/backend/go/go_sources/generate_testmain",
     ],
 )

--- a/src/python/pants/backend/go/go_sources/analyze_package/main.go
+++ b/src/python/pants/backend/go/go_sources/analyze_package/main.go
@@ -26,11 +26,6 @@ import (
 	"strings"
 )
 
-type EmbedCfg struct {
-	Patterns map[string][]string
-	Files    map[string]string
-}
-
 // Package represents the results of analyzing a Go package.
 type Package struct {
 	Name string // package name
@@ -66,11 +61,8 @@ type Package struct {
 	// then the list will contain those two strings as separate entries.
 	// (See package embed for more details about //go:embed.)
 	EmbedPatterns      []string  `json:",omitempty"` // patterns from GoFiles, CgoFiles
-	EmbedConfig        *EmbedCfg `json:",omitempty"` // files matching the EmbedPatterns
 	TestEmbedPatterns  []string  `json:",omitempty"` // patterns from TestGoFiles
-	TestEmbedConfig    *EmbedCfg `json:",omitempty"` // files matching the TestEmbedPatterns
 	XTestEmbedPatterns []string  `json:",omitempty"` // patterns from XTestGoFiles
-	XTestEmbedConfig   *EmbedCfg `json:",omitempty"` // files matching the XTestEmbedPatterns
 
 	// Error information. This differs from how `go list` reports errors.
 	InvalidGoFiles map[string]string `json:",omitempty"`
@@ -126,101 +118,6 @@ func cleanStringSet(valuesMap map[string]bool) []string {
 	}
 	sort.Strings(values)
 	return values
-}
-
-func computeEmbedConfigs(directory string, pkg *Package) error {
-	// Obtain a list of files in and under the package's directory. These will be embeddable files.
-	// TODO: Support resource targets elsewhere in the repository.
-
-	fmt.Fprintf(os.Stderr, "computeEmbedConfigs(directory=%s)\n", directory)
-	var embedSrcs []string
-	err := filepath.WalkDir(directory, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		fmt.Fprintf(os.Stderr, "path=%s\n", path)
-		embedSrcs = append(embedSrcs, path)
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-	fmt.Fprintf(os.Stderr, "embedSrcs=%v\n", embedSrcs)
-
-	root, err := buildEmbedTree(embedSrcs, []string{directory})
-	if err != nil {
-		return err
-	}
-
-	if len(pkg.EmbedPatterns) > 0 {
-		embedCfg := &EmbedCfg{
-			Patterns: make(map[string][]string),
-			Files:    make(map[string]string),
-		}
-
-		for _, pattern := range pkg.EmbedPatterns {
-			matchedPaths, matchedFiles, err := resolveEmbed(pattern, root)
-			if err != nil {
-				return err
-			}
-			embedCfg.Patterns[pattern] = matchedPaths
-			for i, rel := range matchedPaths {
-				embedCfg.Files[rel] = matchedFiles[i]
-			}
-		}
-
-		pkg.EmbedConfig = embedCfg
-	}
-
-	if len(pkg.TestEmbedPatterns) > 0 {
-		embedCfg := &EmbedCfg{
-			Patterns: make(map[string][]string),
-			Files:    make(map[string]string),
-		}
-		if pkg.EmbedConfig != nil {
-			for key, value := range pkg.EmbedConfig.Patterns {
-				embedCfg.Patterns[key] = value
-			}
-			for key, value := range pkg.EmbedConfig.Files {
-				embedCfg.Files[key] = value
-			}
-		}
-
-		for _, pattern := range pkg.TestEmbedPatterns {
-			matchedPaths, matchedFiles, err := resolveEmbed(pattern, root)
-			if err != nil {
-				return err
-			}
-			embedCfg.Patterns[pattern] = matchedPaths
-			for i, rel := range matchedPaths {
-				embedCfg.Files[rel] = matchedFiles[i]
-			}
-		}
-
-		pkg.TestEmbedConfig = embedCfg
-	}
-
-	if len(pkg.XTestEmbedPatterns) > 0 {
-		embedCfg := &EmbedCfg{
-			Patterns: make(map[string][]string),
-			Files:    make(map[string]string),
-		}
-
-		for _, pattern := range pkg.XTestEmbedPatterns {
-			matchedPaths, matchedFiles, err := resolveEmbed(pattern, root)
-			if err != nil {
-				return err
-			}
-			embedCfg.Patterns[pattern] = matchedPaths
-			for i, rel := range matchedPaths {
-				embedCfg.Files[rel] = matchedFiles[i]
-			}
-		}
-
-		pkg.XTestEmbedConfig = embedCfg
-	}
-
-	return nil
 }
 
 func analyzePackage(directory string, buildContext *build.Context) (*Package, error) {
@@ -397,13 +294,6 @@ func analyzePackage(directory string, buildContext *build.Context) (*Package, er
 	pkg.EmbedPatterns = cleanStringSet(embedsMap)
 	pkg.TestEmbedPatterns = cleanStringSet(testEmbedsMap)
 	pkg.XTestEmbedPatterns = cleanStringSet(xtestEmbedsMap)
-
-	// Fill in embedcfg needed for compiler.
-	// TOOD: Move embed config to a separate program.
-// 	err = computeEmbedConfigs("__resources__", pkg)
-// 	if err != nil {
-// 		return pkg, fmt.Errorf("unable to compute embedcfg: %s", err)
-// 	}
 
 	// add the .S/.sx files only if we are using cgo
 	// (which means gcc will compile them).

--- a/src/python/pants/backend/go/go_sources/analyze_package/main.go
+++ b/src/python/pants/backend/go/go_sources/analyze_package/main.go
@@ -399,10 +399,11 @@ func analyzePackage(directory string, buildContext *build.Context) (*Package, er
 	pkg.XTestEmbedPatterns = cleanStringSet(xtestEmbedsMap)
 
 	// Fill in embedcfg needed for compiler.
-	err = computeEmbedConfigs("__resources__", pkg)
-	if err != nil {
-		return pkg, fmt.Errorf("unable to compute embedcfg: %s", err)
-	}
+	// TOOD: Move embed config to a separate program.
+// 	err = computeEmbedConfigs("__resources__", pkg)
+// 	if err != nil {
+// 		return pkg, fmt.Errorf("unable to compute embedcfg: %s", err)
+// 	}
 
 	// add the .S/.sx files only if we are using cgo
 	// (which means gcc will compile them).

--- a/src/python/pants/backend/go/go_sources/embedcfg/BUILD
+++ b/src/python/pants/backend/go/go_sources/embedcfg/BUILD
@@ -1,0 +1,5 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_source(name="init", source="__init__.py")
+resources(sources=["*.go"], dependencies=[":init"])

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -20,8 +20,8 @@ from pants.backend.go.util_rules.build_pkg import (
 )
 from pants.backend.go.util_rules.build_pkg_target import BuildGoPackageTargetRequest
 from pants.backend.go.util_rules.first_party_pkg import (
-    FallibleFirstPartyPkgInfo,
-    FirstPartyPkgInfoRequest,
+    FallibleFirstPartyPkgAnalysis,
+    FirstPartyPkgAnalysisRequest,
 )
 from pants.backend.go.util_rules.import_analysis import ImportConfig, ImportConfigRequest
 from pants.backend.go.util_rules.link import LinkedGoBinary, LinkGoBinaryRequest
@@ -139,8 +139,8 @@ def transform_test_args(args: Sequence[str], timeout_field_value: int | None) ->
 async def run_go_tests(
     field_set: GoTestFieldSet, test_subsystem: TestSubsystem, go_test_subsystem: GoTestSubsystem
 ) -> TestResult:
-    maybe_pkg_info, dependencies = await MultiGet(
-        Get(FallibleFirstPartyPkgInfo, FirstPartyPkgInfoRequest(field_set.address)),
+    maybe_pkg_analysis, dependencies = await MultiGet(
+        Get(FallibleFirstPartyPkgAnalysis, FirstPartyPkgAnalysisRequest(field_set.address)),
         Get(Targets, DependenciesRequest(field_set.dependencies)),
     )
 
@@ -155,22 +155,22 @@ async def run_go_tests(
             output_setting=test_subsystem.output,
         )
 
-    if maybe_pkg_info.info is None:
-        assert maybe_pkg_info.stderr is not None
-        return compilation_failure(maybe_pkg_info.exit_code, None, maybe_pkg_info.stderr)
+    if maybe_pkg_analysis.analysis is None:
+        assert maybe_pkg_analysis.stderr is not None
+        return compilation_failure(maybe_pkg_analysis.exit_code, None, maybe_pkg_analysis.stderr)
 
-    pkg_info = maybe_pkg_info.info
-    import_path = pkg_info.import_path
+    pkg_analysis = maybe_pkg_analysis.analysis
+    import_path = pkg_analysis.import_path
 
     testmain = await Get(
         GeneratedTestMain,
         GenerateTestMainRequest(
-            pkg_info.digest,
+            pkg_analysis.digest,
             FrozenOrderedSet(
-                os.path.join(".", pkg_info.dir_path, name) for name in pkg_info.test_files
+                os.path.join(".", pkg_analysis.dir_path, name) for name in pkg_analysis.test_files
             ),
             FrozenOrderedSet(
-                os.path.join(".", pkg_info.dir_path, name) for name in pkg_info.xtest_files
+                os.path.join(".", pkg_analysis.dir_path, name) for name in pkg_analysis.xtest_files
             ),
             import_path,
             field_set.address,
@@ -210,21 +210,21 @@ async def run_go_tests(
             dep.import_path: dep for dep in test_pkg_build_request.direct_dependencies
         }
         direct_dependencies: OrderedSet[BuildGoPackageRequest] = OrderedSet()
-        for xtest_import in pkg_info.xtest_imports:
-            if xtest_import == pkg_info.import_path:
+        for xtest_import in pkg_analysis.xtest_imports:
+            if xtest_import == pkg_analysis.import_path:
                 direct_dependencies.add(test_pkg_build_request)
             elif xtest_import in dep_by_import_path:
                 direct_dependencies.add(dep_by_import_path[xtest_import])
 
         xtest_pkg_build_request = BuildGoPackageRequest(
             import_path=f"{import_path}_test",
-            digest=pkg_info.digest,
-            dir_path=pkg_info.dir_path,
-            go_file_names=pkg_info.xtest_files,
+            digest=pkg_analysis.digest,
+            dir_path=pkg_analysis.dir_path,
+            go_file_names=pkg_analysis.xtest_files,
             s_file_names=(),  # TODO: Are there .s files for xtest?
             direct_dependencies=tuple(direct_dependencies),
-            minimum_go_version=pkg_info.minimum_go_version,
-            embed_config=pkg_info.xtest_embed_config,
+            minimum_go_version=pkg_analysis.minimum_go_version,
+            embed_config=pkg_analysis.xtest_embed_config,
         )
         main_direct_deps.append(xtest_pkg_build_request)
 
@@ -238,7 +238,7 @@ async def run_go_tests(
             go_file_names=(GeneratedTestMain.TEST_MAIN_FILE,),
             s_file_names=(),
             direct_dependencies=tuple(main_direct_deps),
-            minimum_go_version=pkg_info.minimum_go_version,
+            minimum_go_version=pkg_analysis.minimum_go_version,
         ),
     )
     if maybe_built_main_pkg.output is None:

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -20,10 +20,10 @@ from pants.backend.go.target_types import (
 )
 from pants.backend.go.util_rules import first_party_pkg, import_analysis
 from pants.backend.go.util_rules.first_party_pkg import (
-    FallibleFirstPartyPkgInfo,
+    FallibleFirstPartyPkgAnalysis,
+    FirstPartyPkgAnalysisRequest,
     FirstPartyPkgImportPath,
     FirstPartyPkgImportPathRequest,
-    FirstPartyPkgInfoRequest,
 )
 from pants.backend.go.util_rules.go_mod import GoModInfo, GoModInfoRequest
 from pants.backend.go.util_rules.import_analysis import GoStdLibImports
@@ -106,21 +106,27 @@ async def infer_go_dependencies(
     package_mapping: ImportPathToPackages,
 ) -> InferredDependencies:
     addr = request.sources_field.address
-    maybe_pkg_info = await Get(FallibleFirstPartyPkgInfo, FirstPartyPkgInfoRequest(addr))
-    if maybe_pkg_info.info is None:
+    maybe_pkg_analysis = await Get(
+        FallibleFirstPartyPkgAnalysis, FirstPartyPkgAnalysisRequest(addr)
+    )
+    if maybe_pkg_analysis.analysis is None:
         logger.error(
-            f"Failed to analyze {maybe_pkg_info.import_path} for dependency inference:\n"
-            f"{maybe_pkg_info.stderr}"
+            f"Failed to analyze {maybe_pkg_analysis.import_path} for dependency inference:\n"
+            f"{maybe_pkg_analysis.stderr}"
         )
         return InferredDependencies([])
-    pkg_info = maybe_pkg_info.info
+    pkg_analysis = maybe_pkg_analysis.analysis
 
     inferred_dependencies = []
-    for import_path in (*pkg_info.imports, *pkg_info.test_imports, *pkg_info.xtest_imports):
+    for import_path in (
+        *pkg_analysis.imports,
+        *pkg_analysis.test_imports,
+        *pkg_analysis.xtest_imports,
+    ):
         if import_path in std_lib_imports:
             continue
         # Avoid a dependency cycle caused by external test imports of this package (i.e., "xtest").
-        if import_path == pkg_info.import_path:
+        if import_path == pkg_analysis.import_path:
             continue
         candidate_packages = package_mapping.mapping.get(import_path, ())
         if len(candidate_packages) > 1:

--- a/src/python/pants/backend/go/util_rules/embed_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/embed_integration_test.py
@@ -24,7 +24,7 @@ from pants.backend.go.util_rules import (
 )
 from pants.build_graph.address import Address
 from pants.core.goals.test import TestResult
-from pants.core.target_types import ResourcesGeneratorTarget, ResourceTarget
+from pants.core.target_types import ResourceTarget
 from pants.core.util_rules import source_files
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -47,24 +47,22 @@ def rule_runner() -> RuleRunner:
             *source_files.rules(),
             QueryRule(TestResult, [GoTestFieldSet]),
         ],
-        target_types=[GoModTarget, GoPackageTarget, ResourcesGeneratorTarget, ResourceTarget],
+        target_types=[GoModTarget, GoPackageTarget, ResourceTarget],
     )
     rule_runner.set_options(["--go-test-args=-v -bench=."], env_inherit={"PATH"})
     return rule_runner
 
 
-@pytest.mark.xfail
 def test_embeds_integration_test(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
             "BUILD": dedent(
                 """
                 go_mod(name='mod')
-                go_package(name='pkg', dependencies=[":resources"])
-                resources(
-                  name="resources",
-                  sources=["*.txt"],
-                )
+                go_package(name='pkg', dependencies=[":grok", ":test_grok", ":xtest_grok"])
+                resource(name='grok', source='grok.txt')
+                resource(name='test_grok', source='test_grok.txt')
+                resource(name='xtest_grok', source='xtest_grok.txt')
                 """
             ),
             "go.mod": dedent(

--- a/src/python/pants/backend/go/util_rules/embed_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/embed_integration_test.py
@@ -26,7 +26,7 @@ from pants.build_graph.address import Address
 from pants.core.goals.test import TestResult
 from pants.core.target_types import ResourcesGeneratorTarget, ResourceTarget
 from pants.core.util_rules import source_files
-from pants.testutil.rule_runner import QueryRule, RuleRunner, logging
+from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
 @pytest.fixture
@@ -53,7 +53,7 @@ def rule_runner() -> RuleRunner:
     return rule_runner
 
 
-@logging
+@pytest.mark.xfail
 def test_embeds_integration_test(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {

--- a/src/python/pants/backend/go/util_rules/embedcfg.py
+++ b/src/python/pants/backend/go/util_rules/embedcfg.py
@@ -18,20 +18,21 @@ class EmbedConfig:
     files: FrozenDict[str, str]
 
     def __init__(self, patterns: Mapping[str, Iterable[str]], files: Mapping[str, str]) -> None:
-        """Configuration passed to the Go compiler to configure file embedding. The compiler relies
-        entirely on the caller to map embed patterns to actual filesystem paths. All embed patterns
+        """Configuration passed to the Go compiler to configure file embedding.
+
+        The compiler relies entirely on the caller to map embed patterns to actual filesystem
+        paths. All embed patterns
         contained in the package must be mapped. Consult
-        `FirstPartyPkgInfo.{EmbedPatterns,TestEmbedPatterns,XTestEmbedPatterns}` for the embed
-        patterns obtained from analysis.
+        `FirstPartyPkgAnalysis.embed_patterns` for the embed patterns obtained from analysis.
 
-        :param patterns: Maps each pattern provided via a //go:embed directive to a list of file paths relative to
-        the package directory for files to embed for that pattern. When the embedded variable is an `embed.FS`,
-        those relative file paths define the virtual directory hierarchy exposed by the embed.FS filesystem
-        abstraction. The relative file paths are resolved to actual filesystem paths for their content by consulting
-        the `files` dictionary.
-
-        :param files: Maps each virtual, relative file path used as a value in the `patterns` dictionary to the actual
-        filesystem path with that file's content.
+        :param patterns: Maps each pattern provided via a //go:embed directive to a list of file
+          paths relative to the package directory for files to embed for that pattern. When the
+          embedded variable is an `embed.FS`, those relative file paths define the virtual
+          directory hierarchy exposed by the embed.FS filesystem abstraction. The relative file
+          paths are resolved to actual filesystem paths for their content by consulting the
+          `files` dictionary.
+        :param files: Maps each virtual, relative file path used as a value in the `patterns`
+          dictionary to the actual filesystem path with that file's content.
         """
         self.patterns = FrozenDict({k: tuple(v) for k, v in patterns.items()})
         self.files = FrozenDict(files)

--- a/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
@@ -19,6 +19,7 @@ from pants.backend.go.util_rules import (
     sdk,
     third_party_pkg,
 )
+from pants.backend.go.util_rules.embedcfg import EmbedConfig
 from pants.backend.go.util_rules.first_party_pkg import (
     FallibleFirstPartyPkgAnalysis,
     FallibleFirstPartyPkgDigest,
@@ -354,17 +355,16 @@ def test_embeds_supported(rule_runner: RuleRunner) -> None:
     )
     assert actual_snapshot == expected_snapshot
 
-    # TODO: fix this.
-    # assert pkg_digest.embed_config == EmbedConfig(
-    #     {"grok.txt": ["grok.txt"]}, {"grok.txt": "__resources__/grok.txt"}
-    # )
-    # assert pkg_digest.test_embed_config == EmbedConfig(
-    #     {"grok.txt": ["grok.txt"], "test_grok.txt": ["test_grok.txt"]},
-    #     {"grok.txt": "__resources__/grok.txt", "test_grok.txt": "__resources__/test_grok.txt"},
-    # )
-    # assert pkg_digest.xtest_embed_config == EmbedConfig(
-    #     {"xtest_grok.txt": ["xtest_grok.txt"]}, {"xtest_grok.txt": "__resources__/xtest_grok.txt"}
-    # )
+    assert pkg_digest.embed_config == EmbedConfig(
+        {"grok.txt": ["grok.txt"]}, {"grok.txt": "__resources__/grok.txt"}
+    )
+    assert pkg_digest.test_embed_config == EmbedConfig(
+        {"grok.txt": ["grok.txt"], "test_grok.txt": ["test_grok.txt"]},
+        {"grok.txt": "__resources__/grok.txt", "test_grok.txt": "__resources__/test_grok.txt"},
+    )
+    assert pkg_digest.xtest_embed_config == EmbedConfig(
+        {"xtest_grok.txt": ["xtest_grok.txt"]}, {"xtest_grok.txt": "__resources__/xtest_grok.txt"}
+    )
 
 
 @pytest.mark.xfail

--- a/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
@@ -400,4 +400,5 @@ def test_missing_embeds(rule_runner: RuleRunner) -> None:
     )
     assert maybe_digest.pkg_digest is None
     assert maybe_digest.exit_code == 1
+    assert maybe_digest.stderr is not None
     assert "Failed to find embedded resources: could not embed grok.txt" in maybe_digest.stderr

--- a/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
@@ -325,8 +325,8 @@ def test_embeds_supported(rule_runner: RuleRunner) -> None:
                 go 1.17
                 """
             ),
-            **resources,
-            **go_sources,
+            **resources,  # type: ignore[arg-type]
+            **go_sources,  # type: ignore[arg-type]
         }
     )
     maybe_analysis = rule_runner.request(

--- a/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import os.path
 from textwrap import dedent
-from typing import Iterable
 
 import pytest
 
@@ -22,10 +21,10 @@ from pants.backend.go.util_rules import (
 )
 from pants.backend.go.util_rules.embedcfg import EmbedConfig
 from pants.backend.go.util_rules.first_party_pkg import (
-    FallibleFirstPartyPkgInfo,
+    FallibleFirstPartyPkgAnalysis,
+    FirstPartyPkgAnalysisRequest,
     FirstPartyPkgImportPath,
     FirstPartyPkgImportPathRequest,
-    FirstPartyPkgInfoRequest,
 )
 from pants.core.target_types import ResourcesGeneratorTarget
 from pants.engine.addresses import Address
@@ -46,9 +45,8 @@ def rule_runner() -> RuleRunner:
             *build_pkg.rules(),
             *link.rules(),
             *assembly.rules(),
-            QueryRule(FallibleFirstPartyPkgInfo, [FirstPartyPkgInfoRequest]),
+            QueryRule(FallibleFirstPartyPkgAnalysis, [FirstPartyPkgAnalysisRequest]),
             QueryRule(FirstPartyPkgImportPath, [FirstPartyPkgImportPathRequest]),
-            QueryRule(Digest, [CreateDigest]),
             QueryRule(Snapshot, [MergeDigests]),
         ],
         target_types=[GoModTarget, GoPackageTarget, ResourcesGeneratorTarget],
@@ -83,7 +81,7 @@ def test_import_path(rule_runner: RuleRunner, mod_dir: str) -> None:
     assert info.dir_path_rel_to_gomod == "dir"
 
 
-def test_package_info(rule_runner: RuleRunner) -> None:
+def test_package_analysis(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
             "foo/BUILD": "go_mod()\n",
@@ -146,7 +144,7 @@ def test_package_info(rule_runner: RuleRunner) -> None:
         }
     )
 
-    def assert_info(
+    def assert_analysis(
         dir_path: str,
         *,
         imports: list[str],
@@ -155,17 +153,14 @@ def test_package_info(rule_runner: RuleRunner) -> None:
         go_files: list[str],
         test_files: list[str],
         xtest_files: list[str],
-        embed_patterns: Iterable[str] = (),
-        test_embed_patterns: Iterable[str] = (),
-        xtest_embed_patterns: Iterable[str] = (),
     ) -> None:
-        maybe_info = rule_runner.request(
-            FallibleFirstPartyPkgInfo,
-            [FirstPartyPkgInfoRequest(Address(os.path.join("foo", dir_path)))],
+        maybe_analysis = rule_runner.request(
+            FallibleFirstPartyPkgAnalysis,
+            [FirstPartyPkgAnalysisRequest(Address(os.path.join("foo", dir_path)))],
         )
-        assert maybe_info.info is not None
-        info = maybe_info.info
-        actual_snapshot = rule_runner.request(Snapshot, [info.digest])
+        assert maybe_analysis.analysis is not None
+        analysis = maybe_analysis.analysis
+        actual_snapshot = rule_runner.request(Snapshot, [analysis.digest])
         expected_source_digest = rule_runner.request(Digest, [PathGlobs([f"foo/{dir_path}/*.go"])])
         resource_dir_digest = rule_runner.request(
             Digest, [CreateDigest([Directory("__resources__")])]
@@ -175,21 +170,21 @@ def test_package_info(rule_runner: RuleRunner) -> None:
         )
         assert actual_snapshot == expected_snapshot
 
-        assert info.imports == tuple(imports)
-        assert info.test_imports == tuple(test_imports)
-        assert info.xtest_imports == tuple(xtest_imports)
-        assert info.go_files == tuple(go_files)
-        assert info.test_files == tuple(test_files)
-        assert info.xtest_files == tuple(xtest_files)
-        assert not info.s_files
+        assert analysis.imports == tuple(imports)
+        assert analysis.test_imports == tuple(test_imports)
+        assert analysis.xtest_imports == tuple(xtest_imports)
+        assert analysis.go_files == tuple(go_files)
+        assert analysis.test_files == tuple(test_files)
+        assert analysis.xtest_files == tuple(xtest_files)
+        assert not analysis.s_files
 
-        assert info.minimum_go_version == "1.16"
+        assert analysis.minimum_go_version == "1.16"
 
-        assert info.embed_patterns == tuple(embed_patterns)
-        assert info.test_embed_patterns == tuple(test_embed_patterns)
-        assert info.xtest_embed_patterns == tuple(xtest_embed_patterns)
+        assert analysis.embed_patterns == ()
+        assert analysis.test_embed_patterns == ()
+        assert analysis.xtest_embed_patterns == ()
 
-    assert_info(
+    assert_analysis(
         "pkg",
         imports=["github.com/google/uuid", "rsc.io/quote"],
         test_imports=[],
@@ -198,7 +193,7 @@ def test_package_info(rule_runner: RuleRunner) -> None:
         test_files=[],
         xtest_files=[],
     )
-    assert_info(
+    assert_analysis(
         "cmd",
         imports=["fmt", "go.example.com/foo/pkg"],
         test_imports=["testing"],
@@ -222,13 +217,13 @@ def test_invalid_package(rule_runner) -> None:
             "bad.go": "invalid!!!",
         }
     )
-    maybe_info = rule_runner.request(
-        FallibleFirstPartyPkgInfo,
-        [FirstPartyPkgInfoRequest(Address("", target_name="pkg"))],
+    maybe_analysis = rule_runner.request(
+        FallibleFirstPartyPkgAnalysis,
+        [FirstPartyPkgAnalysisRequest(Address("", target_name="pkg"))],
     )
-    assert maybe_info.info is None
-    assert maybe_info.exit_code == 1
-    assert "bad.go:1:1: expected 'package', found invalid\n" in maybe_info.stderr
+    assert maybe_analysis.analysis is None
+    assert maybe_analysis.exit_code == 1
+    assert "bad.go:1:1: expected 'package', found invalid\n" in maybe_analysis.stderr
 
 
 @pytest.mark.xfail(reason="cgo is ignored")
@@ -263,8 +258,8 @@ def test_cgo_not_supported(rule_runner: RuleRunner) -> None:
     )
     with engine_error(NotImplementedError):
         rule_runner.request(
-            FallibleFirstPartyPkgInfo,
-            [FirstPartyPkgInfoRequest(Address("", target_name="pkg"))],
+            FallibleFirstPartyPkgAnalysis,
+            [FirstPartyPkgAnalysisRequest(Address("", target_name="pkg"))],
         )
 
 
@@ -316,19 +311,22 @@ def test_embeds_supported(rule_runner: RuleRunner) -> None:
             ),
         }
     )
-    maybe_info = rule_runner.request(
-        FallibleFirstPartyPkgInfo,
-        [FirstPartyPkgInfoRequest(Address("", target_name="pkg"))],
+    maybe_analysis = rule_runner.request(
+        FallibleFirstPartyPkgAnalysis,
+        [FirstPartyPkgAnalysisRequest(Address("", target_name="pkg"))],
     )
-    assert maybe_info.info is not None
-    info = maybe_info.info
-    assert info.embed_config == EmbedConfig(
+    assert maybe_analysis.analysis is not None
+    analysis = maybe_analysis.analysis
+    assert analysis.embed_patterns == ("grok.txt",)
+    assert analysis.test_embed_patterns == ("test_grok.txt",)
+    assert analysis.xtest_embed_patterns == ("xtest_grok.txt",)
+    assert analysis.embed_config == EmbedConfig(
         {"grok.txt": ["grok.txt"]}, {"grok.txt": "__resources__/grok.txt"}
     )
-    assert info.test_embed_config == EmbedConfig(
+    assert analysis.test_embed_config == EmbedConfig(
         {"grok.txt": ["grok.txt"], "test_grok.txt": ["test_grok.txt"]},
         {"grok.txt": "__resources__/grok.txt", "test_grok.txt": "__resources__/test_grok.txt"},
     )
-    assert info.xtest_embed_config == EmbedConfig(
+    assert analysis.xtest_embed_config == EmbedConfig(
         {"xtest_grok.txt": ["xtest_grok.txt"]}, {"xtest_grok.txt": "__resources__/xtest_grok.txt"}
     )


### PR DESCRIPTION
Before, we were both analyzing embed patterns and using that to create the embed config in the same program. The issue is that creating the embed config requires having resource files present in the chroot, so finding the dependencies of the `go_package`. But because the rule to determine `FirstPartyPkgInfo` is used by dependency inference for the `go_package`, looking at the dependencies of that target to get `resources` results in a graph cycle.

The robust fix is to split out creation of the embed config into a distinct program. Concretely, `FirstPartyPkgInfo` is now `FirstPartyPkgAnalysis` and `FirstPartyPkgDigest`.