### PR TITLE
[internal] Use `PyObject` instead of `Value` in more places

### DIFF
--- a/src/rust/engine/src/externs/engine_aware.rs
+++ b/src/rust/engine/src/externs/engine_aware.rs
@@ -4,7 +4,6 @@
 use crate::context::Context;
 use crate::externs;
 use crate::nodes::{lift_directory_digest, lift_file_digest};
-use crate::python::Value;
 
 use crate::externs::fs::PyFileDigest;
 use pyo3::prelude::*;
@@ -121,7 +120,7 @@ fn metadata(context: &Context, obj: &PyAny) -> Option<Vec<(String, UserMetadataI
     let py_value_handle = UserMetadataPyValue::new();
     let umi = UserMetadataItem::PyValue(py_value_handle.clone());
     context.session.with_metadata_map(|map| {
-      map.insert(py_value_handle.clone(), Value::new(value.into_py(obj.py())));
+      map.insert(py_value_handle.clone(), value.into());
     });
     output.push((key, umi));
   }

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -360,7 +360,7 @@ impl PySession {
           core,
           should_render_ui,
           build_id,
-          session_values.into(),
+          session_values,
           cancellation_latch,
         )
       })

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -34,7 +34,7 @@ use pyo3::prelude::{
   PyResult as PyO3Result, Python,
 };
 use pyo3::types::{PyBytes, PyDict, PyList, PyTuple, PyType};
-use pyo3::{create_exception, PyAny};
+use pyo3::{create_exception, IntoPy, PyAny};
 use regex::Regex;
 use rule_graph::{self, RuleGraph};
 use task_executor::Executor;
@@ -740,8 +740,8 @@ async fn workunit_to_py_value(
   let mut user_metadata_entries = Vec::with_capacity(workunit.metadata.user_metadata.len());
   for (user_metadata_key, user_metadata_item) in workunit.metadata.user_metadata.iter() {
     let value = match user_metadata_item {
-      UserMetadataItem::ImmediateString(v) => externs::store_utf8(py, v),
-      UserMetadataItem::ImmediateInt(n) => externs::store_i64(py, *n),
+      UserMetadataItem::ImmediateString(v) => v.into_py(py),
+      UserMetadataItem::ImmediateInt(n) => n.into_py(py),
       UserMetadataItem::PyValue(py_val_handle) => {
         match session.with_metadata_map(|map| map.get(py_val_handle).cloned()) {
           None => {
@@ -755,7 +755,10 @@ async fn workunit_to_py_value(
         }
       }
     };
-    user_metadata_entries.push((externs::store_utf8(py, user_metadata_key.as_str()), value));
+    user_metadata_entries.push((
+      externs::store_utf8(py, user_metadata_key.as_str()),
+      Value::new(value),
+    ));
   }
 
   dict_entries.push((

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -302,7 +302,7 @@ impl Get {
       output: TypeId::new(get.product.as_ref(py)),
       input_type: TypeId::new(get.declared_subject.as_ref(py)),
       input: INTERNS
-        .key_insert(py, get.subject.clone_ref(py).into())
+        .key_insert(py, get.subject.clone_ref(py))
         .map_err(|e| Failure::from_py_err_with_gil(py, e))?,
     })
   }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -676,7 +676,7 @@ impl WrappedNode for SessionValues {
     context: Context,
     _workunit: &mut RunningWorkunit,
   ) -> NodeResult<Value> {
-    Ok(context.session.session_values())
+    Ok(Value::new(context.session.session_values()))
   }
 }
 

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -260,11 +260,12 @@ impl Key {
 
   pub fn from_value(val: Value) -> PyResult<Key> {
     let gil = Python::acquire_gil();
-    externs::INTERNS.key_insert(gil.python(), val)
+    let py = gil.python();
+    externs::INTERNS.key_insert(py, val.consume_into_py_object(py))
   }
 
   pub fn to_value(&self) -> Value {
-    externs::INTERNS.key_get(self)
+    Value::new(externs::INTERNS.key_get(self))
   }
 }
 

--- a/src/rust/engine/src/session.rs
+++ b/src/rust/engine/src/session.rs
@@ -17,6 +17,7 @@ use futures::FutureExt;
 use graph::LastObserved;
 use log::warn;
 use parking_lot::{Mutex, RwLock};
+use pyo3::prelude::*;
 use task_executor::Executor;
 use tokio::signal::unix::{signal, SignalKind};
 use ui::ConsoleUI;
@@ -79,7 +80,7 @@ struct SessionState {
   // A place to store info about workunits in rust part
   workunit_store: WorkunitStore,
   // Per-Session values that have been set for this session.
-  session_values: Mutex<Value>,
+  session_values: Mutex<PyObject>,
   // An id used to control the visibility of uncacheable rules. Generally this is identical for an
   // entire Session, but in some cases (in particular, a `--loop`) the caller wants to retain the
   // same Session while still observing new values for uncacheable rules like Goals.
@@ -140,7 +141,7 @@ impl Session {
     core: Arc<Core>,
     should_render_ui: bool,
     build_id: String,
-    session_values: Value,
+    session_values: PyObject,
     cancelled: AsyncLatch,
   ) -> Result<Session, String> {
     let workunit_store = WorkunitStore::new(!should_render_ui);
@@ -252,7 +253,7 @@ impl Session {
     roots.keys().map(|r| r.clone().into()).collect()
   }
 
-  pub fn session_values(&self) -> Value {
+  pub fn session_values(&self) -> PyObject {
     self.state.session_values.lock().clone()
   }
 

--- a/src/rust/engine/src/session.rs
+++ b/src/rust/engine/src/session.rs
@@ -85,7 +85,7 @@ struct SessionState {
   // entire Session, but in some cases (in particular, a `--loop`) the caller wants to retain the
   // same Session while still observing new values for uncacheable rules like Goals.
   run_id: AtomicU32,
-  workunit_metadata_map: RwLock<HashMap<UserMetadataPyValue, Value>>,
+  workunit_metadata_map: RwLock<HashMap<UserMetadataPyValue, PyObject>>,
 }
 
 ///
@@ -227,7 +227,7 @@ impl Session {
 
   pub fn with_metadata_map<F, T>(&self, f: F) -> T
   where
-    F: FnOnce(&mut HashMap<UserMetadataPyValue, Value>) -> T,
+    F: FnOnce(&mut HashMap<UserMetadataPyValue, PyObject>) -> T,
   {
     f(&mut self.state.workunit_metadata_map.write())
   }


### PR DESCRIPTION
`PyObject` (aka `Py<PyAny>`) already provides a GIL-independent reference to a Python object. Wrapping it in `Arc` is not necessary, as described at https://github.com/pantsbuild/pants/pull/13526#discussion_r748744461.

Using `PyObject` directly removes a layer of indirection.