### PR TITLE
[internal] scala: handle `package object` syntax in parser

### DIFF
--- a/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
+++ b/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
@@ -170,6 +170,12 @@ class SourceAnalysisTraverser extends Traverser {
       withNamePart(name, () => super.apply(stats))
     }
 
+    case Pkg.Object(_mods, nameNode, templ) => {
+      val name = extractName(nameNode)
+      recordScope(name)
+      visitTemplate(templ, name)
+    }
+
     case Defn.Class(_mods, nameNode, _tparams, _ctor, templ) => {
       val name = extractName(nameNode)
       recordProvidedName(name, sawClass = true)

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
@@ -373,3 +373,18 @@ def test_relative_import(rule_runner: RuleRunner) -> None:
         "scala.io.apply",
         "sio.apply",
     }
+
+
+def test_package_object(rule_runner: RuleRunner) -> None:
+    analysis = _analyze(
+        rule_runner,
+        textwrap.dedent(
+            """
+            package foo
+            package object bar {
+              val Hello = "World"
+            }
+            """
+        ),
+    )
+    assert sorted(analysis.provided_symbols) == ["foo.bar.Hello"]


### PR DESCRIPTION
Handle `package object` syntax in the Scala parser used by dependency inference.

Closes https://github.com/pantsbuild/pants/issues/13753.