### PR TITLE
[jvm] Split nailgun digest from input file digests

### DIFF
--- a/src/python/pants/backend/java/compile/javac.py
+++ b/src/python/pants/backend/java/compile/javac.py
@@ -158,7 +158,6 @@ async def compile_java_source(
             (
                 prefixed_direct_dependency_classpath_digest,
                 dest_dir_digest,
-                jdk_setup.digest,
                 *(
                     sources.snapshot.digest
                     for _, sources in component_members_and_java_source_files

--- a/src/python/pants/backend/java/dependency_inference/java_parser.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser.py
@@ -111,15 +111,6 @@ async def analyze_java_source_dependencies(
             )
         ),
     )
-    merged_digest = await Get(
-        Digest,
-        MergeDigests(
-            (
-                tool_digest,
-                prefixed_source_files_digest,
-            )
-        ),
-    )
 
     analysis_output_path = "__source_analysis.json"
 
@@ -132,7 +123,7 @@ async def analyze_java_source_dependencies(
                 analysis_output_path,
                 source_path,
             ],
-            input_digest=merged_digest,
+            input_digest=prefixed_source_files_digest,
             output_files=(analysis_output_path,),
             use_nailgun=tool_digest,
             append_only_caches=jdk_setup.append_only_caches,

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -256,15 +256,6 @@ async def analyze_scala_source_dependencies(
             )
         ),
     )
-    merged_digest = await Get(
-        Digest,
-        MergeDigests(
-            (
-                tool_digest,
-                prefixed_source_files_digest,
-            )
-        ),
-    )
 
     analysis_output_path = "__source_analysis.json"
 
@@ -277,7 +268,7 @@ async def analyze_scala_source_dependencies(
                 analysis_output_path,
                 source_path,
             ],
-            input_digest=merged_digest,
+            input_digest=prefixed_source_files_digest,
             output_files=(analysis_output_path,),
             use_nailgun=tool_digest,
             append_only_caches=jdk_setup.append_only_caches,

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -282,6 +282,18 @@ impl super::CommandRunner for CommandRunner {
           }
         };
 
+        // Prepare the workdir.
+        let exclusive_spawn = prepare_workdir(
+          workdir_path.clone(),
+          &req,
+          req.input_digests.complete,
+          context.clone(),
+          self.store.clone(),
+          self.executor.clone(),
+          self.named_caches(),
+        )
+        .await?;
+
         workunit.increment_counter(Metric::LocalExecutionRequests, 1);
         let res = self
           .run_and_capture_workdir(
@@ -291,6 +303,7 @@ impl super::CommandRunner for CommandRunner {
             self.executor.clone(),
             workdir_path.clone(),
             (),
+            exclusive_spawn,
             self.platform(),
           )
           .map_err(|msg| {
@@ -453,20 +466,10 @@ pub trait CapturedWorkdir {
     executor: task_executor::Executor,
     workdir_path: PathBuf,
     workdir_token: Self::WorkdirToken,
+    exclusive_spawn: bool,
     platform: Platform,
   ) -> Result<FallibleProcessResultWithPlatform, String> {
     let start_time = Instant::now();
-
-    // Prepare the workdir.
-    let exclusive_spawn = prepare_workdir(
-      workdir_path.clone(),
-      &req,
-      context.clone(),
-      store.clone(),
-      executor.clone(),
-      self.named_caches(),
-    )
-    .await?;
 
     // Spawn the process.
     // NB: We fully buffer up the `Stream` above into final `ChildResults` below and so could
@@ -602,6 +605,7 @@ pub trait CapturedWorkdir {
 pub async fn prepare_workdir(
   workdir_path: PathBuf,
   req: &Process,
+  input_digest: hashing::Digest,
   context: Context,
   store: Store,
   executor: task_executor::Executor,
@@ -627,7 +631,6 @@ pub async fn prepare_workdir(
   // non-determinism when paths overlap.
   let store2 = store.clone();
   let workdir_path_2 = workdir_path.clone();
-  let input_files = req.input_files;
   in_workunit!(
     context.workunit_store.clone(),
     "setup_sandbox".to_owned(),
@@ -637,7 +640,7 @@ pub async fn prepare_workdir(
     },
     |_workunit| async move {
       store2
-        .materialize_directory(workdir_path_2, input_files)
+        .materialize_directory(workdir_path_2, input_digest)
         .await
     },
   )

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -3,7 +3,7 @@ use testutil;
 
 use crate::{
   CacheDest, CacheName, CommandRunner as CommandRunnerTrait, Context,
-  FallibleProcessResultWithPlatform, NamedCaches, Platform, Process, RelativePath,
+  FallibleProcessResultWithPlatform, InputDigests, NamedCaches, Platform, Process, RelativePath,
 };
 use hashing::EMPTY_DIGEST;
 use shell_quote::bash;
@@ -377,7 +377,7 @@ async fn test_directory_preservation() {
 
   let mut process =
     Process::new(argv.clone()).output_files(relative_paths(&["roland.ext"]).collect());
-  process.input_files = TestDirectory::nested().digest();
+  process.input_digests = InputDigests::with_input_files(TestDirectory::nested().digest());
   process.working_directory = Some(RelativePath::new("cats").unwrap());
 
   let result = run_command_locally_in_dir(
@@ -553,7 +553,7 @@ async fn working_directory() {
   let mut process = Process::new(vec![find_bash(), "-c".to_owned(), "/bin/ls".to_string()]);
   process.working_directory = Some(RelativePath::new("cats").unwrap());
   process.output_directories = relative_paths(&["roland.ext"]).collect::<BTreeSet<_>>();
-  process.input_files = TestDirectory::nested().digest();
+  process.input_digests = InputDigests::with_input_files(TestDirectory::nested().digest());
   process.timeout = one_second();
   process.description = "confused-cat".to_string();
 

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -791,7 +791,7 @@ impl crate::CommandRunner for CommandRunner {
       &self.store,
       command_digest,
       action_digest,
-      Some(request.input_files),
+      Some(request.input_digests.complete),
     )
     .await?;
 
@@ -1030,7 +1030,7 @@ pub fn make_execute_request(
 
   let mut action = remexec::Action {
     command_digest: Some((&digest(&command)?).into()),
-    input_root_digest: Some((&req.input_files).into()),
+    input_root_digest: Some((&req.input_digests.complete).into()),
     ..remexec::Action::default()
   };
 

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -34,7 +34,9 @@ use std::time::Duration;
 
 use fs::RelativePath;
 use hashing::{Digest, Fingerprint, EMPTY_DIGEST};
-use process_execution::{Context, NamedCaches, Platform, ProcessCacheScope, ProcessMetadata};
+use process_execution::{
+  Context, InputDigests, NamedCaches, Platform, ProcessCacheScope, ProcessMetadata,
+};
 use prost::Message;
 use protos::gen::build::bazel::remote::execution::v2::{Action, Command};
 use protos::gen::buildbarn::cas::UncachedActionResult;
@@ -372,7 +374,7 @@ async fn make_request(
     args.buildbarn_url.as_ref(),
   ) {
     (Some(input_digest), Some(input_digest_length), None, None, None) => {
-      make_request_from_flat_args(args, Digest::new(input_digest, input_digest_length))
+      make_request_from_flat_args(store, args, Digest::new(input_digest, input_digest_length)).await
 
     }
     (None, None, Some(action_fingerprint), Some(action_digest_length), None) => {
@@ -390,9 +392,10 @@ async fn make_request(
   }
 }
 
-fn make_request_from_flat_args(
+async fn make_request_from_flat_args(
+  store: &Store,
   args: &Opt,
-  input_root_digest: Digest,
+  input_files: Digest,
 ) -> Result<(process_execution::Process, ProcessMetadata), String> {
   let output_files = args
     .command
@@ -428,11 +431,15 @@ fn make_request_from_flat_args(
     _ => EMPTY_DIGEST,
   };
 
+  let input_digests = InputDigests::new(store, input_files, use_nailgun)
+    .await
+    .map_err(|e| format!("Could not create input digest for process: {:?}", e))?;
+
   let process = process_execution::Process {
     argv: args.command.argv.clone(),
     env: collection_from_keyvalues(args.command.env.iter()),
     working_directory,
-    input_files: input_root_digest,
+    input_digests,
     output_files,
     output_directories,
     timeout: Some(Duration::new(15 * 60, 0)),
@@ -441,7 +448,6 @@ fn make_request_from_flat_args(
     append_only_caches: BTreeMap::new(),
     jdk_home: args.command.jdk.clone(),
     platform_constraint: None,
-    use_nailgun,
     execution_slot_variable: None,
     cache_scope: ProcessCacheScope::Always,
   };
@@ -492,12 +498,14 @@ async fn extract_request_from_action_digest(
     )
   };
 
-  let input_files = require_digest(&action.input_root_digest)
-    .map_err(|err| format!("Bad input root digest: {:?}", err))?;
+  let input_digests = InputDigests::with_input_files(
+    require_digest(&action.input_root_digest)
+      .map_err(|err| format!("Bad input root digest: {:?}", err))?,
+  );
 
   // In case the local Store doesn't have the input root Directory,
   // have it fetch it and identify it as a Directory, so that it doesn't get confused about the unknown metadata.
-  store.load_directory_or_err(input_files).await?;
+  store.load_directory_or_err(input_digests.complete).await?;
 
   let process = process_execution::Process {
     argv: command.arguments,
@@ -507,7 +515,7 @@ async fn extract_request_from_action_digest(
       .map(|env| (env.name.clone(), env.value.clone()))
       .collect(),
     working_directory,
-    input_files,
+    input_digests,
     output_files: command
       .output_files
       .iter()
@@ -527,7 +535,6 @@ async fn extract_request_from_action_digest(
     append_only_caches: BTreeMap::new(),
     jdk_home: None,
     platform_constraint: None,
-    use_nailgun: EMPTY_DIGEST,
     cache_scope: ProcessCacheScope::Always,
   };
 

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -183,9 +183,12 @@ impl Core {
           local_execution_root_dir.to_path_buf(),
           store.clone(),
           executor.clone(),
-          // TODO: The nailgun pool size should almost certainly be configurable independent
-          // of concurrency, along with per-instance memory usage.
-          exec_strategy_opts.local_parallelism,
+          // We set the nailgun pool size to twice the number that will ever be active in order to
+          // keep warm but idle processes for task fingerprints which are not currently busy (e.g.
+          // while busy running scalac, keeping some javac processes idle).
+          // TODO: The nailgun pool size should be configurable independent of concurrency, along
+          // with per-instance memory usage. See https://github.com/pantsbuild/pants/issues/13067.
+          exec_strategy_opts.local_parallelism * 2,
         ))
       } else {
         Box::new(local_command_runner)


### PR DESCRIPTION
As discussed in #13787, the `input_files` digest must currently include the `use_nailgun` digest, and that means that the input files for the server are materialized for every run.
* Add an `InputDigests` struct to encapsulate managing the collection of input digests for a `Process` (which will soon also include the immutable digests from #12716), and split the `use_nailgun` digest from the `input_files` digest.
* Move nailgun spawning (which uses `std::process` and `std::fs`, and so is synchronous) onto the `Executor`.
* Adjust the (still hardcoded) nailgun pool size to keep idle servers beyond the number that are currently active (e.g. to allow for idle `javac` processes while `scalac` processes are active).

Collectively, these changes make compilation 40% faster.

Fixes #13787.