### PR TITLE
scala: add `scalafmt` support for `fmt` and `lint` goals

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -180,6 +180,9 @@ lockfile = "src/python/pants/backend/java/test/junit.default.lockfile.txt"
 [google-java-format]
 lockfile = "src/python/pants/backend/java/lint/google_java_format/google_java_format.default.lockfile.txt"
 
+[scalafmt]
+lockfile = "src/python/pants/backend/scala/lint/scalafmt/scalafmt.default.lockfile.txt"
+
 [toolchain-setup]
 repo = "pants"
 

--- a/pants.toml
+++ b/pants.toml
@@ -23,6 +23,7 @@ backend_packages.add = [
   "pants.backend.experimental.java.debug_goals",
   "pants.backend.experimental.python",
   "pants.backend.experimental.scala",
+  "pants.backend.experimental.scala.lint.scalafmt",
   "pants.backend.experimental.scala.debug_goals",
   "internal_plugins.releases",
 ]

--- a/src/python/pants/backend/experimental/scala/lint/scalafmt/BUILD
+++ b/src/python/pants/backend/experimental/scala/lint/scalafmt/BUILD
@@ -1,0 +1,4 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_sources()

--- a/src/python/pants/backend/experimental/scala/lint/scalafmt/register.py
+++ b/src/python/pants/backend/experimental/scala/lint/scalafmt/register.py
@@ -1,7 +1,6 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from pants.backend.scala.lint import scala_fmt
-
 from pants.backend.scala.lint.scalafmt import rules as scalafmt_rules
 from pants.backend.scala.lint.scalafmt import skip_field
 

--- a/src/python/pants/backend/experimental/scala/lint/scalafmt/register.py
+++ b/src/python/pants/backend/experimental/scala/lint/scalafmt/register.py
@@ -1,0 +1,14 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from pants.backend.scala.lint import scala_fmt
+
+from pants.backend.scala.lint.scalafmt import rules as scalafmt_rules
+from pants.backend.scala.lint.scalafmt import skip_field
+
+
+def rules():
+    return [
+        *scala_fmt.rules(),
+        *scalafmt_rules.rules(),
+        *skip_field.rules(),
+    ]

--- a/src/python/pants/backend/experimental/scala/lint/scalafmt/register.py
+++ b/src/python/pants/backend/experimental/scala/lint/scalafmt/register.py
@@ -1,13 +1,15 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-from pants.backend.scala.lint import scala_fmt
+from pants.backend.experimental.scala.register import rules as all_scala_rules
+from pants.backend.scala.lint import scala_lang_fmt
 from pants.backend.scala.lint.scalafmt import rules as scalafmt_rules
 from pants.backend.scala.lint.scalafmt import skip_field
 
 
 def rules():
     return [
-        *scala_fmt.rules(),
+        *all_scala_rules(),
+        *scala_lang_fmt.rules(),
         *scalafmt_rules.rules(),
         *skip_field.rules(),
     ]

--- a/src/python/pants/backend/java/lint/google_java_format/rules.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules.py
@@ -96,15 +96,11 @@ async def setup_google_java_format(
             "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
         ]
 
-    maybe_aosp_option = []
-    if tool.aosp:
-        maybe_aosp_option = ["--aosp"]
-
     args = [
         *jdk_setup.args(bash, tool_classpath.classpath_entries()),
         *maybe_java16_or_higher_options,
         "com.google.googlejavaformat.java.Main",
-        *maybe_aosp_option,
+        *(["--aosp"] if tool.aosp else []),
         "--dry-run" if setup_request.check_only else "--replace",
         *source_files.files,
     ]

--- a/src/python/pants/backend/scala/dependency_inference/BUILD
+++ b/src/python/pants/backend/scala/dependency_inference/BUILD
@@ -10,4 +10,6 @@ python_tests(name="tests", timeout=240)
 scala_sources(
     name="scala_parser",
     compatible_resolves=["scala_parser"],
+    # TODO: Allow the parser files to be formatted.
+    skip_scalafmt=True,
 )

--- a/src/python/pants/backend/scala/lint/BUILD
+++ b/src/python/pants/backend/scala/lint/BUILD
@@ -1,0 +1,4 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_sources()

--- a/src/python/pants/backend/scala/lint/scala_fmt.py
+++ b/src/python/pants/backend/scala/lint/scala_fmt.py
@@ -1,0 +1,61 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from dataclasses import dataclass
+from typing import Iterable
+
+from pants.backend.scala.target_types import ScalaSourceField
+from pants.core.goals.fmt import FmtResult, LanguageFmtResults, LanguageFmtTargets
+from pants.core.goals.style_request import StyleRequest
+from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.engine.fs import Digest, Snapshot
+from pants.engine.internals.selectors import Get
+from pants.engine.rules import collect_rules, rule
+from pants.engine.unions import UnionMembership, UnionRule, union
+
+
+@dataclass(frozen=True)
+class ScalaFmtTargets(LanguageFmtTargets):
+    required_fields = (ScalaSourceField,)
+
+
+@union
+class ScalaFmtRequest(StyleRequest):
+    pass
+
+
+@rule
+async def format_scala_target(
+    scala_fmt_targets: ScalaFmtTargets, union_membership: UnionMembership
+) -> LanguageFmtResults:
+    original_sources = await Get(
+        SourceFiles,
+        SourceFilesRequest(target[ScalaSourceField] for target in scala_fmt_targets.targets),
+    )
+    prior_formatter_result = original_sources.snapshot
+
+    results = []
+    fmt_request_types: Iterable[type[StyleRequest]] = union_membership[ScalaFmtRequest]
+    for fmt_request_type in fmt_request_types:
+        request = fmt_request_type(
+            (
+                fmt_request_type.field_set_type.create(target)
+                for target in scala_fmt_targets.targets
+                if fmt_request_type.field_set_type.is_applicable(target)
+            ),
+            prior_formatter_result=prior_formatter_result,
+        )
+        if not request.field_sets:
+            continue
+        result = await Get(FmtResult, ScalaFmtRequest, request)
+        results.append(result)
+        if result.did_change:
+            prior_formatter_result = await Get(Snapshot, Digest, result.output)
+    return LanguageFmtResults(
+        tuple(results),
+        input=original_sources.snapshot.digest,
+        output=prior_formatter_result.digest,
+    )
+
+
+def rules():
+    return [*collect_rules(), UnionRule(LanguageFmtTargets, ScalaFmtTargets)]

--- a/src/python/pants/backend/scala/lint/scala_lang_fmt.py
+++ b/src/python/pants/backend/scala/lint/scala_lang_fmt.py
@@ -14,18 +14,18 @@ from pants.engine.unions import UnionMembership, UnionRule, union
 
 
 @dataclass(frozen=True)
-class ScalaFmtTargets(LanguageFmtTargets):
+class ScalaLangFmtTargets(LanguageFmtTargets):
     required_fields = (ScalaSourceField,)
 
 
 @union
-class ScalaFmtRequest(StyleRequest):
+class ScalaLangFmtRequest(StyleRequest):
     pass
 
 
 @rule
 async def format_scala_target(
-    scala_fmt_targets: ScalaFmtTargets, union_membership: UnionMembership
+    scala_fmt_targets: ScalaLangFmtTargets, union_membership: UnionMembership
 ) -> LanguageFmtResults:
     original_sources = await Get(
         SourceFiles,
@@ -34,7 +34,7 @@ async def format_scala_target(
     prior_formatter_result = original_sources.snapshot
 
     results = []
-    fmt_request_types: Iterable[type[StyleRequest]] = union_membership[ScalaFmtRequest]
+    fmt_request_types: Iterable[type[StyleRequest]] = union_membership[ScalaLangFmtRequest]
     for fmt_request_type in fmt_request_types:
         request = fmt_request_type(
             (
@@ -46,7 +46,7 @@ async def format_scala_target(
         )
         if not request.field_sets:
             continue
-        result = await Get(FmtResult, ScalaFmtRequest, request)
+        result = await Get(FmtResult, ScalaLangFmtRequest, request)
         results.append(result)
         if result.did_change:
             prior_formatter_result = await Get(Snapshot, Digest, result.output)
@@ -58,4 +58,4 @@ async def format_scala_target(
 
 
 def rules():
-    return [*collect_rules(), UnionRule(LanguageFmtTargets, ScalaFmtTargets)]
+    return [*collect_rules(), UnionRule(LanguageFmtTargets, ScalaLangFmtTargets)]

--- a/src/python/pants/backend/scala/lint/scalafmt/BUILD
+++ b/src/python/pants/backend/scala/lint/scalafmt/BUILD
@@ -1,0 +1,8 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_sources(dependencies=[":resources"])
+
+python_tests(name="tests")
+
+resources(name="resources", sources=["*.lockfile.txt"])

--- a/src/python/pants/backend/scala/lint/scalafmt/BUILD
+++ b/src/python/pants/backend/scala/lint/scalafmt/BUILD
@@ -1,8 +1,8 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_sources(dependencies=[":resources"])
+python_sources(dependencies=[":lockfile"])
 
 python_tests(name="tests")
 
-resources(name="resources", sources=["*.lockfile.txt"])
+resource(name="lockfile", source="scalafmt.default.lockfile.txt")

--- a/src/python/pants/backend/scala/lint/scalafmt/BUILD
+++ b/src/python/pants/backend/scala/lint/scalafmt/BUILD
@@ -3,6 +3,6 @@
 
 python_sources(dependencies=[":lockfile"])
 
-python_tests(name="tests")
+python_tests(name="tests", timeout=360)
 
 resource(name="lockfile", source="scalafmt.default.lockfile.txt")

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -97,9 +97,9 @@ class SetupScalafmtPartition:
     check_only: bool
 
 
-def find_nearest_ancestor_config_file(files: set[str], dir: str) -> str | None:
+def find_nearest_ancestor_file(files: set[str], dir: str, config_file: str) -> str | None:
     while True:
-        candidate_config_file_path = os.path.join(dir, _SCALAFMT_CONF_FILENAME)
+        candidate_config_file_path = os.path.join(dir, config_file)
         if candidate_config_file_path in files:
             return candidate_config_file_path
 
@@ -132,7 +132,9 @@ async def gather_scalafmt_config_files(
 
     source_dir_to_config_file: dict[str, str] = {}
     for source_dir in source_dirs:
-        config_file = find_nearest_ancestor_config_file(config_files_set, source_dir)
+        config_file = find_nearest_ancestor_file(
+            config_files_set, source_dir, _SCALAFMT_CONF_FILENAME
+        )
         if not config_file:
             raise ValueError(
                 f"No scalafmt config file (`{_SCALAFMT_CONF_FILENAME}`) found for "

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -1,6 +1,10 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+import os.path
 import textwrap
+from collections import defaultdict
 from dataclasses import dataclass
 
 from pants.backend.scala.lint.scala_lang_fmt import ScalaLangFmtRequest
@@ -9,10 +13,11 @@ from pants.backend.scala.lint.scalafmt.subsystem import ScalafmtSubsystem
 from pants.backend.scala.target_types import ScalaSourceField
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintRequest, LintResult, LintResults
+from pants.core.goals.tailor import group_by_dir
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests
+from pants.engine.fs import Digest, MergeDigests, PathGlobs, Snapshot
 from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.process import BashBinary, FallibleProcessResult, Process, ProcessResult
+from pants.engine.process import BashBinary, FallibleProcessResult, Process
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
@@ -20,8 +25,11 @@ from pants.jvm.jdk_rules import JdkSetup
 from pants.jvm.resolve.coursier_fetch import MaterializedClasspath, MaterializedClasspathRequest
 from pants.jvm.resolve.jvm_tool import JvmToolLockfileRequest, JvmToolLockfileSentinel
 from pants.testutil.rule_runner import logging
+from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
+
+_SCALAFMT_CONF_FILENAME = ".scalafmt.conf"
 
 
 @dataclass(frozen=True)
@@ -44,26 +52,87 @@ class ScalafmtToolLockfileSentinel(JvmToolLockfileSentinel):
 
 
 @dataclass(frozen=True)
-class SetupRequest:
+class ScalafmtSetupRequest:
     request: ScalafmtRequest
     check_only: bool
 
 
 @dataclass(frozen=True)
-class Setup:
+class ScalafmtPartition:
     process: Process
+    description: str
+
+
+@dataclass(frozen=True)
+class ScalafmtSetup:
+    partitions: tuple[ScalafmtPartition, ...]
     original_digest: Digest
+
+
+@dataclass(frozen=True)
+class GatherScalafmtConfigFilesRequest:
+    snapshot: Snapshot
+
+
+@dataclass(frozen=True)
+class ScalafmtConfigFiles:
+    snapshot: Snapshot
+    config_files_for_source_dir: FrozenDict[str, str]
+
+
+def find_nearest_ancestor_config_file(files: set[str], dir: str) -> str | None:
+    while True:
+        candidate_config_file_path = os.path.join(dir, _SCALAFMT_CONF_FILENAME)
+        if candidate_config_file_path in files:
+            return candidate_config_file_path
+
+        if dir == "":
+            return None
+        dir = os.path.dirname(dir)
+
+
+@rule
+async def gather_scalafmt_config_files(
+    request: GatherScalafmtConfigFilesRequest,
+) -> ScalafmtConfigFiles:
+    """Gather scalafmt config files and identify which config files to use for each source
+    directory."""
+    source_dirs = frozenset(os.path.dirname(path) for path in request.snapshot.files)
+
+    source_dirs_with_ancestors = {"", *source_dirs}
+    for source_dir in source_dirs:
+        source_dir_parts = source_dir.split(os.path.sep)
+        for i in range(0, len(source_dir_parts) - 1):
+            source_dirs_with_ancestors.add(os.path.join(*source_dir_parts[0:i]))
+
+    config_file_globs = [
+        os.path.join(dir, _SCALAFMT_CONF_FILENAME) for dir in source_dirs_with_ancestors
+    ]
+    config_files_snapshot = await Get(Snapshot, PathGlobs(config_file_globs))
+    config_files_set = set(config_files_snapshot.files)
+
+    config_files_for_source_dir: dict[str, str] = {}
+    for source_dir in source_dirs:
+        config_file = find_nearest_ancestor_config_file(config_files_set, source_dir)
+        if not config_file:
+            raise ValueError(
+                f"No scalafmt config file (`{_SCALAFMT_CONF_FILENAME}`) found for "
+                f"source directory '{source_dir}'"
+            )
+        config_files_for_source_dir[source_dir] = config_file
+
+    return ScalafmtConfigFiles(config_files_snapshot, FrozenDict(config_files_for_source_dir))
 
 
 @logging
 @rule(level=LogLevel.DEBUG)
-async def setup_google_java_format(
-    setup_request: SetupRequest,
+async def setup_scalafmt(
+    setup_request: ScalafmtSetupRequest,
     tool: ScalafmtSubsystem,
     jdk_setup: JdkSetup,
     bash: BashBinary,
-) -> Setup:
-    source_files, tool_classpath, conf_digest = await MultiGet(
+) -> ScalafmtSetup:
+    source_files, tool_classpath = await MultiGet(
         Get(
             SourceFiles,
             SourceFilesRequest(field_set.source for field_set in setup_request.request.field_sets),
@@ -75,24 +144,6 @@ async def setup_google_java_format(
                 lockfiles=(tool.resolved_lockfile(),),
             ),
         ),
-        # TODO: Figure out how to scan for the correct configuration file to use while also dealing with
-        #  the seeming requirement that `version` must be set in the configuration file.
-        Get(
-            Digest,
-            CreateDigest(
-                [
-                    FileContent(
-                        path=".scalafmt.conf",
-                        content=textwrap.dedent(
-                            f"""\
-                version = "{tool.version}"
-                runner.dialect = scala213
-                """
-                        ).encode(),
-                    )
-                ]
-            ),
-        ),
     )
 
     source_files_snapshot = (
@@ -101,58 +152,109 @@ async def setup_google_java_format(
         else setup_request.request.prior_formatter_result
     )
 
+    config_files = await Get(
+        ScalafmtConfigFiles, GatherScalafmtConfigFilesRequest(source_files_snapshot)
+    )
+
     input_digest = await Get(
         Digest,
         MergeDigests(
-            [source_files_snapshot.digest, conf_digest, tool_classpath.digest, jdk_setup.digest]
+            [
+                source_files_snapshot.digest,
+                config_files.snapshot.digest,
+                tool_classpath.digest,
+                jdk_setup.digest,
+            ]
         ),
     )
 
-    args = [
-        *jdk_setup.args(bash, tool_classpath.classpath_entries()),
-        "org.scalafmt.cli.Cli",
-        "--config=.scalafmt.conf",
-        "--non-interactive",
-    ]
-    if setup_request.check_only:
-        args.append("--list")
-    args.extend(source_files.files)
+    # Partition the work by which source files share the same config file (regardless of directory).
+    source_files_by_config_file: dict[str, set[str]] = defaultdict(set)
+    for source_dir, files_in_source_dir in group_by_dir(source_files_snapshot.files).items():
+        config_file_for_source_dir = config_files.config_files_for_source_dir[source_dir]
+        source_files_by_config_file[config_file_for_source_dir].union(files_in_source_dir)
 
-    process = Process(
-        argv=args,
-        input_digest=input_digest,
-        output_files=source_files_snapshot.files,
-        append_only_caches=jdk_setup.append_only_caches,
-        env=jdk_setup.env,
-        description=f"Run `scalafmt` on {pluralize(len(setup_request.request.field_sets), 'file')}.",
-        level=LogLevel.DEBUG,
-    )
+    partitions = []
+    for config_file, files in source_files_by_config_file.items():
+        args = [
+            *jdk_setup.args(bash, tool_classpath.classpath_entries()),
+            "org.scalafmt.cli.Cli",
+            f"--config={config_file}",
+            "--non-interactive",
+        ]
+        if setup_request.check_only:
+            args.append("--list")
+        args.extend(sorted(files))
 
-    return Setup(process, original_digest=source_files_snapshot.digest)
+        process = Process(
+            argv=args,
+            input_digest=input_digest,
+            output_files=source_files_snapshot.files,
+            append_only_caches=jdk_setup.append_only_caches,
+            env=jdk_setup.env,
+            description=f"Run `scalafmt` on {pluralize(len(files), 'file')}.",
+            level=LogLevel.DEBUG,
+        )
+        partitions.append(
+            ScalafmtPartition(process, f"{pluralize(len(files), 'file')} ({config_file})")
+        )
+
+    return ScalafmtSetup(tuple(partitions), original_digest=source_files_snapshot.digest)
 
 
 @rule(desc="Format with scalafmt", level=LogLevel.DEBUG)
 async def scalafmt_fmt(field_sets: ScalafmtRequest, tool: ScalafmtSubsystem) -> FmtResult:
     if tool.skip:
         return FmtResult.skip(formatter_name="scalafmt")
-    setup = await Get(Setup, SetupRequest(field_sets, check_only=False))
-    result = await Get(ProcessResult, Process, setup.process)
-    return FmtResult.from_process_result(
-        result,
-        original_digest=setup.original_digest,
-        formatter_name="scalafmt",
-        strip_chroot_path=True,
+    setup = await Get(ScalafmtSetup, ScalafmtSetupRequest(field_sets, check_only=False))
+    results = await MultiGet(
+        Get(FallibleProcessResult, Process, partition.process) for partition in setup.partitions
     )
+
+    def format(description, output):
+        if len(output.strip()) == 0:
+            return ""
+
+        return textwrap.dedent(
+            f"""\
+        Output from `scalafmt fmt` on {description}:
+        {output.decode("utf-8")}
+
+        """
+        )
+
+    stdout_content = ""
+    stderr_content = ""
+    for partition, result in zip(setup.partitions, results):
+        stdout_content += format(partition.description, result.stdout)
+        stderr_content += format(partition.description, result.stderr)
+
+    # Merge all of the outputs into a single output.
+    output_digest = await Get(Digest, MergeDigests(r.output_digest for r in results))
+
+    fmt_result = FmtResult(
+        input=setup.original_digest,
+        output=output_digest,
+        stdout=stdout_content,
+        stderr=stderr_content,
+        formatter_name="scalafmt",
+    )
+    return fmt_result
 
 
 @rule(desc="Lint with scalafmt", level=LogLevel.DEBUG)
 async def scalafmt_lint(field_sets: ScalafmtRequest, tool: ScalafmtSubsystem) -> LintResults:
     if tool.skip:
         return LintResults([], linter_name="scalafmt")
-    setup = await Get(Setup, SetupRequest(field_sets, check_only=True))
-    result = await Get(FallibleProcessResult, Process, setup.process)
-    lint_result = LintResult.from_fallible_process_result(result)
-    return LintResults([lint_result], linter_name="scalafmt")
+    setup = await Get(ScalafmtSetup, ScalafmtSetupRequest(field_sets, check_only=True))
+    results = await MultiGet(
+        Get(FallibleProcessResult, Process, partition.process) for partition in setup.partitions
+    )
+    lint_results = [
+        LintResult.from_fallible_process_result(result, partition_description=partition.description)
+        for result, partition in zip(results, setup.partitions)
+    ]
+    return LintResults(lint_results, linter_name="scalafmt")
 
 
 @rule

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -4,7 +4,7 @@ import textwrap
 from dataclasses import dataclass
 from typing import Iterable
 
-from pants.backend.scala.lint.scala_fmt import ScalaFmtRequest
+from pants.backend.scala.lint.scala_lang_fmt import ScalaLangFmtRequest
 from pants.backend.scala.lint.scalafmt.skip_field import SkipScalafmtField
 from pants.backend.scala.lint.scalafmt.subsystem import ScalafmtSubsystem
 from pants.backend.scala.target_types import ScalaSourceField
@@ -36,7 +36,7 @@ class ScalafmtFieldSet(FieldSet):
         return tgt.get(SkipScalafmtField).value
 
 
-class ScalafmtRequest(ScalaFmtRequest, LintRequest):
+class ScalafmtRequest(ScalaLangFmtRequest, LintRequest):
     field_set_type = ScalafmtFieldSet
 
 
@@ -170,6 +170,6 @@ async def generate_scalafmt_lockfile_request(
 def rules():
     return [
         *collect_rules(),
-        UnionRule(ScalaFmtRequest, ScalafmtRequest),
+        UnionRule(ScalaLangFmtRequest, ScalafmtRequest),
         UnionRule(JvmToolLockfileSentinel, ScalafmtToolLockfileSentinel),
     ]

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 import textwrap
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.scala.lint.scala_lang_fmt import ScalaLangFmtRequest
 from pants.backend.scala.lint.scalafmt.skip_field import SkipScalafmtField
@@ -109,17 +108,14 @@ async def setup_google_java_format(
         ),
     )
 
-    def add_check_args() -> Iterable[str]:
-        if setup_request.check_only:
-            yield "--list"
-
     args = [
         *jdk_setup.args(bash, tool_classpath.classpath_entries()),
         "org.scalafmt.cli.Cli",
         "--config=.scalafmt.conf",
         "--non-interactive",
-        *add_check_args(),
     ]
+    if setup_request.check_only:
+        args.append("--list")
     args.extend(source_files.files)
 
     process = Process(
@@ -128,7 +124,7 @@ async def setup_google_java_format(
         output_files=source_files_snapshot.files,
         append_only_caches=jdk_setup.append_only_caches,
         env=jdk_setup.env,
-        description=f"Run `scalafmt` against {pluralize(len(setup_request.request.field_sets), 'file')}.",
+        description=f"Run `scalafmt` on {pluralize(len(setup_request.request.field_sets), 'file')}.",
         level=LogLevel.DEBUG,
     )
 

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -1,0 +1,175 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import textwrap
+from dataclasses import dataclass
+from typing import Iterable
+
+from pants.backend.scala.lint.scala_fmt import ScalaFmtRequest
+from pants.backend.scala.lint.scalafmt.skip_field import SkipScalafmtField
+from pants.backend.scala.lint.scalafmt.subsystem import ScalafmtSubsystem
+from pants.backend.scala.target_types import ScalaSourceField
+from pants.core.goals.fmt import FmtResult
+from pants.core.goals.lint import LintRequest, LintResult, LintResults
+from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests
+from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.process import BashBinary, FallibleProcessResult, Process, ProcessResult
+from pants.engine.rules import collect_rules, rule
+from pants.engine.target import FieldSet, Target
+from pants.engine.unions import UnionRule
+from pants.jvm.jdk_rules import JdkSetup
+from pants.jvm.resolve.coursier_fetch import MaterializedClasspath, MaterializedClasspathRequest
+from pants.jvm.resolve.jvm_tool import JvmToolLockfileRequest, JvmToolLockfileSentinel
+from pants.testutil.rule_runner import logging
+from pants.util.logging import LogLevel
+from pants.util.strutil import pluralize
+
+
+@dataclass(frozen=True)
+class ScalafmtFieldSet(FieldSet):
+    required_fields = (ScalaSourceField,)
+
+    source: ScalaSourceField
+
+    @classmethod
+    def opt_out(cls, tgt: Target) -> bool:
+        return tgt.get(SkipScalafmtField).value
+
+
+class ScalafmtRequest(ScalaFmtRequest, LintRequest):
+    field_set_type = ScalafmtFieldSet
+
+
+class ScalafmtToolLockfileSentinel(JvmToolLockfileSentinel):
+    options_scope = ScalafmtSubsystem.options_scope
+
+
+@dataclass(frozen=True)
+class SetupRequest:
+    request: ScalafmtRequest
+    check_only: bool
+
+
+@dataclass(frozen=True)
+class Setup:
+    process: Process
+    original_digest: Digest
+
+
+@logging
+@rule(level=LogLevel.DEBUG)
+async def setup_google_java_format(
+    setup_request: SetupRequest,
+    tool: ScalafmtSubsystem,
+    jdk_setup: JdkSetup,
+    bash: BashBinary,
+) -> Setup:
+    source_files, tool_classpath, conf_digest = await MultiGet(
+        Get(
+            SourceFiles,
+            SourceFilesRequest(field_set.source for field_set in setup_request.request.field_sets),
+        ),
+        Get(
+            MaterializedClasspath,
+            MaterializedClasspathRequest(
+                prefix="__toolcp",
+                lockfiles=(tool.resolved_lockfile(),),
+            ),
+        ),
+        # TODO: Figure out how to scan for the correct configuration file to use while also dealing with
+        #  the seeming requirement that `version` must be set in the configuration file.
+        Get(
+            Digest,
+            CreateDigest(
+                [
+                    FileContent(
+                        path=".scalafmt.conf",
+                        content=textwrap.dedent(
+                            f"""\
+                version = "{tool.version}"
+                runner.dialect = scala213
+                """
+                        ).encode(),
+                    )
+                ]
+            ),
+        ),
+    )
+
+    source_files_snapshot = (
+        source_files.snapshot
+        if setup_request.request.prior_formatter_result is None
+        else setup_request.request.prior_formatter_result
+    )
+
+    input_digest = await Get(
+        Digest,
+        MergeDigests(
+            [source_files_snapshot.digest, conf_digest, tool_classpath.digest, jdk_setup.digest]
+        ),
+    )
+
+    def add_check_args() -> Iterable[str]:
+        if setup_request.check_only:
+            yield "--list"
+
+    args = [
+        *jdk_setup.args(bash, tool_classpath.classpath_entries()),
+        "org.scalafmt.cli.Cli",
+        "--config=.scalafmt.conf",
+        "--non-interactive",
+        *add_check_args(),
+    ]
+    args.extend(source_files.files)
+
+    process = Process(
+        argv=args,
+        input_digest=input_digest,
+        output_files=source_files_snapshot.files,
+        append_only_caches=jdk_setup.append_only_caches,
+        env=jdk_setup.env,
+        description=f"Run `scalafmt` against {pluralize(len(setup_request.request.field_sets), 'file')}.",
+        level=LogLevel.DEBUG,
+    )
+
+    return Setup(process, original_digest=source_files_snapshot.digest)
+
+
+@rule(desc="Format with scalafmt", level=LogLevel.DEBUG)
+async def scalafmt_fmt(field_sets: ScalafmtRequest, tool: ScalafmtSubsystem) -> FmtResult:
+    if tool.skip:
+        return FmtResult.skip(formatter_name="scalafmt")
+    setup = await Get(Setup, SetupRequest(field_sets, check_only=False))
+    result = await Get(ProcessResult, Process, setup.process)
+    return FmtResult.from_process_result(
+        result,
+        original_digest=setup.original_digest,
+        formatter_name="scalafmt",
+        strip_chroot_path=True,
+    )
+
+
+@rule(desc="Lint with scalafmt", level=LogLevel.DEBUG)
+async def scalafmt_lint(field_sets: ScalafmtRequest, tool: ScalafmtSubsystem) -> LintResults:
+    if tool.skip:
+        return LintResults([], linter_name="scalafmt")
+    setup = await Get(Setup, SetupRequest(field_sets, check_only=True))
+    result = await Get(FallibleProcessResult, Process, setup.process)
+    lint_result = LintResult.from_fallible_process_result(result)
+    return LintResults([lint_result], linter_name="scalafmt")
+
+
+@rule
+async def generate_scalafmt_lockfile_request(
+    _: ScalafmtToolLockfileSentinel,
+    tool: ScalafmtSubsystem,
+) -> JvmToolLockfileRequest:
+    return JvmToolLockfileRequest.from_tool(tool)
+
+
+def rules():
+    return [
+        *collect_rules(),
+        UnionRule(ScalaFmtRequest, ScalafmtRequest),
+        UnionRule(JvmToolLockfileSentinel, ScalafmtToolLockfileSentinel),
+    ]

--- a/src/python/pants/backend/scala/lint/scalafmt/rules_integration_test.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules_integration_test.py
@@ -120,11 +120,13 @@ def get_digest(rule_runner: RuleRunner, source_files: dict[str, str]) -> Digest:
 
 
 def test_passing(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files({
-        "Foo.scala": GOOD_FILE,
-        "BUILD": "scala_sources(name='t')",
-        ".scalafmt.conf": SCALAFMT_CONF_FILE,
-    })
+    rule_runner.write_files(
+        {
+            "Foo.scala": GOOD_FILE,
+            "BUILD": "scala_sources(name='t')",
+            ".scalafmt.conf": SCALAFMT_CONF_FILE,
+        }
+    )
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="Foo.scala"))
     lint_results, fmt_result = run_scalafmt(rule_runner, [tgt])
     assert len(lint_results) == 1
@@ -134,11 +136,13 @@ def test_passing(rule_runner: RuleRunner) -> None:
 
 
 def test_failing(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files({
-        "Bar.scala": BAD_FILE,
-        "BUILD": "scala_sources(name='t')",
-        ".scalafmt.conf": SCALAFMT_CONF_FILE,
-    })
+    rule_runner.write_files(
+        {
+            "Bar.scala": BAD_FILE,
+            "BUILD": "scala_sources(name='t')",
+            ".scalafmt.conf": SCALAFMT_CONF_FILE,
+        }
+    )
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="Bar.scala"))
     lint_results, fmt_result = run_scalafmt(rule_runner, [tgt])
     assert len(lint_results) == 1
@@ -149,12 +153,14 @@ def test_failing(rule_runner: RuleRunner) -> None:
 
 
 def test_multiple_targets(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files({
-        "Foo.scala": GOOD_FILE,
-        "Bar.scala": BAD_FILE,
-        "BUILD": "scala_sources(name='t')",
-         ".scalafmt.conf": SCALAFMT_CONF_FILE,
-    })
+    rule_runner.write_files(
+        {
+            "Foo.scala": GOOD_FILE,
+            "Bar.scala": BAD_FILE,
+            "BUILD": "scala_sources(name='t')",
+            ".scalafmt.conf": SCALAFMT_CONF_FILE,
+        }
+    )
     tgts = [
         rule_runner.get_target(Address("", target_name="t", relative_file_path="Foo.scala")),
         rule_runner.get_target(Address("", target_name="t", relative_file_path="Bar.scala")),

--- a/src/python/pants/backend/scala/lint/scalafmt/rules_integration_test.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules_integration_test.py
@@ -1,0 +1,153 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+import pytest
+
+from pants.backend.scala import target_types
+from pants.backend.scala.compile.scalac import rules as scalac_rules
+from pants.backend.scala.lint import scala_fmt
+from pants.backend.scala.lint.scalafmt import skip_field
+from pants.backend.scala.lint.scalafmt.rules import ScalafmtFieldSet, ScalafmtRequest
+from pants.backend.scala.lint.scalafmt.rules import rules as scalafmt_rules
+from pants.backend.scala.target_types import ScalaSourcesGeneratorTarget, ScalaSourceTarget
+from pants.build_graph.address import Address
+from pants.core.goals.fmt import FmtResult
+from pants.core.goals.lint import LintResult, LintResults
+from pants.core.util_rules import config_files, source_files
+from pants.core.util_rules.external_tool import rules as external_tool_rules
+from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.engine.fs import CreateDigest, Digest, FileContent
+from pants.engine.rules import QueryRule
+from pants.engine.target import Target
+from pants.jvm import classpath
+from pants.jvm.jdk_rules import rules as jdk_rules
+from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
+from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
+from pants.jvm.util_rules import rules as util_rules
+from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, RuleRunner
+
+NAMED_RESOLVE_OPTIONS = '--jvm-resolves={"test": "coursier_resolve.lockfile"}'
+DEFAULT_RESOLVE_OPTION = "--jvm-default-resolve=test"
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = RuleRunner(
+        rules=[
+            *config_files.rules(),
+            *classpath.rules(),
+            *coursier_fetch_rules(),
+            *coursier_setup_rules(),
+            *external_tool_rules(),
+            *source_files.rules(),
+            *scalac_rules(),
+            *util_rules(),
+            *jdk_rules(),
+            *target_types.rules(),
+            *scala_fmt.rules(),
+            *scalafmt_rules(),
+            *skip_field.rules(),
+            QueryRule(LintResults, (ScalafmtRequest,)),
+            QueryRule(FmtResult, (ScalafmtRequest,)),
+            QueryRule(SourceFiles, (SourceFilesRequest,)),
+        ],
+        target_types=[ScalaSourceTarget, ScalaSourcesGeneratorTarget],
+    )
+    rule_runner.set_options(
+        [
+            NAMED_RESOLVE_OPTIONS,
+            DEFAULT_RESOLVE_OPTION,
+        ],
+        env_inherit=PYTHON_BOOTSTRAP_ENV,
+    )
+    return rule_runner
+
+
+GOOD_FILE = """\
+package org.pantsbuild.example
+
+object Foo {
+  val Foo = 3
+}
+"""
+
+BAD_FILE = """\
+package org.pantsbuild.example
+
+object Bar {
+val Foo = 3
+}
+"""
+
+FIXED_BAD_FILE = """\
+package org.pantsbuild.example
+
+object Bar {
+  val Foo = 3
+}
+"""
+
+
+def run_scalafmt(
+    rule_runner: RuleRunner, targets: list[Target]
+) -> tuple[tuple[LintResult, ...], FmtResult]:
+    field_sets = [ScalafmtFieldSet.create(tgt) for tgt in targets]
+    lint_results = rule_runner.request(LintResults, [ScalafmtRequest(field_sets)])
+    input_sources = rule_runner.request(
+        SourceFiles,
+        [
+            SourceFilesRequest(field_set.source for field_set in field_sets),
+        ],
+    )
+    fmt_result = rule_runner.request(
+        FmtResult,
+        [
+            ScalafmtRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+        ],
+    )
+    return lint_results.results, fmt_result
+
+
+def get_digest(rule_runner: RuleRunner, source_files: dict[str, str]) -> Digest:
+    files = [FileContent(path, content.encode()) for path, content in source_files.items()]
+    return rule_runner.request(Digest, [CreateDigest(files)])
+
+
+def test_passing(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files({"Foo.scala": GOOD_FILE, "BUILD": "scala_sources(name='t')"})
+    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="Foo.scala"))
+    lint_results, fmt_result = run_scalafmt(rule_runner, [tgt])
+    assert len(lint_results) == 1
+    assert lint_results[0].exit_code == 0
+    assert fmt_result.output == get_digest(rule_runner, {"Foo.scala": GOOD_FILE})
+    assert fmt_result.did_change is False
+
+
+def test_failing(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files({"Bar.scala": BAD_FILE, "BUILD": "scala_sources(name='t')"})
+    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="Bar.scala"))
+    lint_results, fmt_result = run_scalafmt(rule_runner, [tgt])
+    assert len(lint_results) == 1
+    assert lint_results[0].exit_code == 1
+    assert "Bar.scala\n" == lint_results[0].stdout
+    assert fmt_result.output == get_digest(rule_runner, {"Bar.scala": FIXED_BAD_FILE})
+    assert fmt_result.did_change is True
+
+
+def test_multiple_targets(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {"Foo.scala": GOOD_FILE, "Bar.scala": BAD_FILE, "BUILD": "scala_sources(name='t')"}
+    )
+    tgts = [
+        rule_runner.get_target(Address("", target_name="t", relative_file_path="Foo.scala")),
+        rule_runner.get_target(Address("", target_name="t", relative_file_path="Bar.scala")),
+    ]
+    lint_results, fmt_result = run_scalafmt(rule_runner, tgts)
+    assert len(lint_results) == 1
+    assert lint_results[0].exit_code == 1
+    assert "Bar.scala\n" == lint_results[0].stdout
+    assert fmt_result.output == get_digest(
+        rule_runner, {"Foo.scala": GOOD_FILE, "Bar.scala": FIXED_BAD_FILE}
+    )
+    assert fmt_result.did_change is True

--- a/src/python/pants/backend/scala/lint/scalafmt/rules_integration_test.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules_integration_test.py
@@ -6,7 +6,7 @@ import pytest
 
 from pants.backend.scala import target_types
 from pants.backend.scala.compile.scalac import rules as scalac_rules
-from pants.backend.scala.lint import scala_fmt
+from pants.backend.scala.lint import scala_lang_fmt
 from pants.backend.scala.lint.scalafmt import skip_field
 from pants.backend.scala.lint.scalafmt.rules import ScalafmtFieldSet, ScalafmtRequest
 from pants.backend.scala.lint.scalafmt.rules import rules as scalafmt_rules
@@ -45,7 +45,7 @@ def rule_runner() -> RuleRunner:
             *util_rules(),
             *jdk_rules(),
             *target_types.rules(),
-            *scala_fmt.rules(),
+            *scala_lang_fmt.rules(),
             *scalafmt_rules(),
             *skip_field.rules(),
             QueryRule(LintResults, (ScalafmtRequest,)),

--- a/src/python/pants/backend/scala/lint/scalafmt/rules_integration_test.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules_integration_test.py
@@ -88,6 +88,11 @@ object Bar {
 }
 """
 
+SCALAFMT_CONF_FILE = """\
+version = "3.2.1"
+runner.dialect = scala213
+"""
+
 
 def run_scalafmt(
     rule_runner: RuleRunner, targets: list[Target]
@@ -115,7 +120,11 @@ def get_digest(rule_runner: RuleRunner, source_files: dict[str, str]) -> Digest:
 
 
 def test_passing(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files({"Foo.scala": GOOD_FILE, "BUILD": "scala_sources(name='t')"})
+    rule_runner.write_files({
+        "Foo.scala": GOOD_FILE,
+        "BUILD": "scala_sources(name='t')",
+        ".scalafmt.conf": SCALAFMT_CONF_FILE,
+    })
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="Foo.scala"))
     lint_results, fmt_result = run_scalafmt(rule_runner, [tgt])
     assert len(lint_results) == 1
@@ -125,7 +134,11 @@ def test_passing(rule_runner: RuleRunner) -> None:
 
 
 def test_failing(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files({"Bar.scala": BAD_FILE, "BUILD": "scala_sources(name='t')"})
+    rule_runner.write_files({
+        "Bar.scala": BAD_FILE,
+        "BUILD": "scala_sources(name='t')",
+        ".scalafmt.conf": SCALAFMT_CONF_FILE,
+    })
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="Bar.scala"))
     lint_results, fmt_result = run_scalafmt(rule_runner, [tgt])
     assert len(lint_results) == 1
@@ -136,9 +149,12 @@ def test_failing(rule_runner: RuleRunner) -> None:
 
 
 def test_multiple_targets(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files(
-        {"Foo.scala": GOOD_FILE, "Bar.scala": BAD_FILE, "BUILD": "scala_sources(name='t')"}
-    )
+    rule_runner.write_files({
+        "Foo.scala": GOOD_FILE,
+        "Bar.scala": BAD_FILE,
+        "BUILD": "scala_sources(name='t')",
+         ".scalafmt.conf": SCALAFMT_CONF_FILE,
+    })
     tgts = [
         rule_runner.get_target(Address("", target_name="t", relative_file_path="Foo.scala")),
         rule_runner.get_target(Address("", target_name="t", relative_file_path="Bar.scala")),

--- a/src/python/pants/backend/scala/lint/scalafmt/scalafmt.default.lockfile.txt
+++ b/src/python/pants/backend/scala/lint/scalafmt/scalafmt.default.lockfile.txt
@@ -1,0 +1,1683 @@
+[
+    {
+        "coord": {
+            "group": "com.geirsson",
+            "artifact": "metaconfig-core_2.13",
+            "version": "0.9.15",
+            "packaging": "jar"
+        },
+        "directDependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.typelevel",
+                "artifact": "paiges-core_2.13",
+                "version": "0.4.2",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang.modules",
+                "artifact": "scala-collection-compat_2.13",
+                "version": "2.5.0",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.lihaoyi",
+                "artifact": "pprint_2.13",
+                "version": "0.6.6",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-reflect",
+                "version": "2.13.7",
+                "packaging": "jar"
+            }
+        ],
+        "dependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.lihaoyi",
+                "artifact": "fansi_2.13",
+                "version": "0.2.14",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.typelevel",
+                "artifact": "paiges-core_2.13",
+                "version": "0.4.2",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang.modules",
+                "artifact": "scala-collection-compat_2.13",
+                "version": "2.5.0",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.lihaoyi",
+                "artifact": "sourcecode_2.13",
+                "version": "0.2.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.lihaoyi",
+                "artifact": "pprint_2.13",
+                "version": "0.6.6",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-reflect",
+                "version": "2.13.7",
+                "packaging": "jar"
+            }
+        ],
+        "file_name": "com.geirsson_metaconfig-core_2.13_0.9.15.jar",
+        "file_digest": {
+            "fingerprint": "c5aad998af8b4ee8c1750e4e2fa214d3a997e8904cf1b5a1235a0a3e374c91e4",
+            "serialized_bytes_length": 523681
+        }
+    },
+    {
+        "coord": {
+            "group": "com.geirsson",
+            "artifact": "metaconfig-typesafe-config_2.13",
+            "version": "0.9.15",
+            "packaging": "jar"
+        },
+        "directDependencies": [
+            {
+                "group": "com.geirsson",
+                "artifact": "metaconfig-core_2.13",
+                "version": "0.9.15",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.typesafe",
+                "artifact": "config",
+                "version": "1.4.1",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            }
+        ],
+        "dependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.typesafe",
+                "artifact": "config",
+                "version": "1.4.1",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.geirsson",
+                "artifact": "metaconfig-core_2.13",
+                "version": "0.9.15",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.lihaoyi",
+                "artifact": "fansi_2.13",
+                "version": "0.2.14",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.typelevel",
+                "artifact": "paiges-core_2.13",
+                "version": "0.4.2",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang.modules",
+                "artifact": "scala-collection-compat_2.13",
+                "version": "2.5.0",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.lihaoyi",
+                "artifact": "sourcecode_2.13",
+                "version": "0.2.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.lihaoyi",
+                "artifact": "pprint_2.13",
+                "version": "0.6.6",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-reflect",
+                "version": "2.13.7",
+                "packaging": "jar"
+            }
+        ],
+        "file_name": "com.geirsson_metaconfig-typesafe-config_2.13_0.9.15.jar",
+        "file_digest": {
+            "fingerprint": "e49ffa30df2f2266a387320366c3022319cacd33d26eca0d26d93acdd536cabc",
+            "serialized_bytes_length": 17289
+        }
+    },
+    {
+        "coord": {
+            "group": "com.github.scopt",
+            "artifact": "scopt_2.13",
+            "version": "4.0.1",
+            "packaging": "jar"
+        },
+        "directDependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            }
+        ],
+        "dependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            }
+        ],
+        "file_name": "com.github.scopt_scopt_2.13_4.0.1.jar",
+        "file_digest": {
+            "fingerprint": "d0173938db4e6f1429eb4b93136c5d857c1fa81eaa34b8c59f8b7b99ad0165f5",
+            "serialized_bytes_length": 126307
+        }
+    },
+    {
+        "coord": {
+            "group": "com.googlecode.java-diff-utils",
+            "artifact": "diffutils",
+            "version": "1.3.0",
+            "packaging": "jar"
+        },
+        "directDependencies": [],
+        "dependencies": [],
+        "file_name": "com.googlecode.java-diff-utils_diffutils_1.3.0.jar",
+        "file_digest": {
+            "fingerprint": "61ba4dc49adca95243beaa0569adc2a23aedb5292ae78aa01186fa782ebdc5c2",
+            "serialized_bytes_length": 34130
+        }
+    },
+    {
+        "coord": {
+            "group": "com.lihaoyi",
+            "artifact": "fansi_2.13",
+            "version": "0.2.14",
+            "packaging": "jar"
+        },
+        "directDependencies": [
+            {
+                "group": "com.lihaoyi",
+                "artifact": "sourcecode_2.13",
+                "version": "0.2.7",
+                "packaging": "jar"
+            }
+        ],
+        "dependencies": [
+            {
+                "group": "com.lihaoyi",
+                "artifact": "sourcecode_2.13",
+                "version": "0.2.7",
+                "packaging": "jar"
+            }
+        ],
+        "file_name": "com.lihaoyi_fansi_2.13_0.2.14.jar",
+        "file_digest": {
+            "fingerprint": "250014f81c734b9f5bb8ffc92cfad42c2425ffd8d60fa27e0828adf07483ebfb",
+            "serialized_bytes_length": 65403
+        }
+    },
+    {
+        "coord": {
+            "group": "com.lihaoyi",
+            "artifact": "geny_2.13",
+            "version": "0.6.5",
+            "packaging": "jar"
+        },
+        "directDependencies": [],
+        "dependencies": [],
+        "file_name": "com.lihaoyi_geny_2.13_0.6.5.jar",
+        "file_digest": {
+            "fingerprint": "ca3857a3f95266e0d87e1a1f26c8592c53c12ac7203f911759415f6c8a43df7d",
+            "serialized_bytes_length": 85365
+        }
+    },
+    {
+        "coord": {
+            "group": "com.lihaoyi",
+            "artifact": "pprint_2.13",
+            "version": "0.6.6",
+            "packaging": "jar"
+        },
+        "directDependencies": [
+            {
+                "group": "com.lihaoyi",
+                "artifact": "fansi_2.13",
+                "version": "0.2.14",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.lihaoyi",
+                "artifact": "sourcecode_2.13",
+                "version": "0.2.7",
+                "packaging": "jar"
+            }
+        ],
+        "dependencies": [
+            {
+                "group": "com.lihaoyi",
+                "artifact": "fansi_2.13",
+                "version": "0.2.14",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.lihaoyi",
+                "artifact": "sourcecode_2.13",
+                "version": "0.2.7",
+                "packaging": "jar"
+            }
+        ],
+        "file_name": "com.lihaoyi_pprint_2.13_0.6.6.jar",
+        "file_digest": {
+            "fingerprint": "c4f89810da70c3100b52458a85f8d520f54243e05047b98e829e2473f0092283",
+            "serialized_bytes_length": 165433
+        }
+    },
+    {
+        "coord": {
+            "group": "com.lihaoyi",
+            "artifact": "sourcecode_2.13",
+            "version": "0.2.7",
+            "packaging": "jar"
+        },
+        "directDependencies": [],
+        "dependencies": [],
+        "file_name": "com.lihaoyi_sourcecode_2.13_0.2.7.jar",
+        "file_digest": {
+            "fingerprint": "a639a90e2d21bbafd8a5e213c65442aad200ee086951605cbda8835bc6ef11d3",
+            "serialized_bytes_length": 118671
+        }
+    },
+    {
+        "coord": {
+            "group": "com.martiansoftware",
+            "artifact": "nailgun-server",
+            "version": "0.9.1",
+            "packaging": "jar"
+        },
+        "directDependencies": [],
+        "dependencies": [],
+        "file_name": "com.martiansoftware_nailgun-server_0.9.1.jar",
+        "file_digest": {
+            "fingerprint": "4518faa6bf4bd26fccdc4d85e1625dc679381a08d56872d8ad12151dda9cef25",
+            "serialized_bytes_length": 32927
+        }
+    },
+    {
+        "coord": {
+            "group": "com.typesafe",
+            "artifact": "config",
+            "version": "1.4.1",
+            "packaging": "jar"
+        },
+        "directDependencies": [],
+        "dependencies": [],
+        "file_name": "com.typesafe_config_1.4.1.jar",
+        "file_digest": {
+            "fingerprint": "4c0aa7e223c75c8840c41fc183d4cd3118140a1ee503e3e08ce66ed2794c948f",
+            "serialized_bytes_length": 295197
+        }
+    },
+    {
+        "coord": {
+            "group": "io.get-coursier",
+            "artifact": "interface",
+            "version": "0.0.17",
+            "packaging": "jar"
+        },
+        "directDependencies": [],
+        "dependencies": [],
+        "file_name": "io.get-coursier_interface_0.0.17.jar",
+        "file_digest": {
+            "fingerprint": "b3987e8c02441e82d88ab8727acd64eabf3a35217ffedba904b125e06a722a77",
+            "serialized_bytes_length": 3131490
+        }
+    },
+    {
+        "coord": {
+            "group": "net.java.dev.jna",
+            "artifact": "jna",
+            "version": "5.8.0",
+            "packaging": "jar"
+        },
+        "directDependencies": [],
+        "dependencies": [],
+        "file_name": "net.java.dev.jna_jna_5.8.0.jar",
+        "file_digest": {
+            "fingerprint": "930273cc1c492f25661ea62413a6da3fd7f6e01bf1c4dcc0817fc8696a7b07ac",
+            "serialized_bytes_length": 1729586
+        }
+    },
+    {
+        "coord": {
+            "group": "org.jline",
+            "artifact": "jline",
+            "version": "3.20.0",
+            "packaging": "jar"
+        },
+        "directDependencies": [],
+        "dependencies": [],
+        "file_name": "org.jline_jline_3.20.0.jar",
+        "file_digest": {
+            "fingerprint": "e2ee4b0bd3a2248f9ec6cf33f7d5b97e34ae652aecd3f42e13bded91f0df6bb6",
+            "serialized_bytes_length": 992903
+        }
+    },
+    {
+        "coord": {
+            "group": "org.scala-lang.modules",
+            "artifact": "scala-collection-compat_2.13",
+            "version": "2.5.0",
+            "packaging": "jar"
+        },
+        "directDependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            }
+        ],
+        "dependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            }
+        ],
+        "file_name": "org.scala-lang.modules_scala-collection-compat_2.13_2.5.0.jar",
+        "file_digest": {
+            "fingerprint": "93f8bf202ac28c4ca13562e31f6881a7770768e12b056b568139f37c025a3841",
+            "serialized_bytes_length": 5610
+        }
+    },
+    {
+        "coord": {
+            "group": "org.scala-lang.modules",
+            "artifact": "scala-parallel-collections_2.13",
+            "version": "1.0.4",
+            "packaging": "jar"
+        },
+        "directDependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            }
+        ],
+        "dependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            }
+        ],
+        "file_name": "org.scala-lang.modules_scala-parallel-collections_2.13_1.0.4.jar",
+        "file_digest": {
+            "fingerprint": "68f266c4fa37cb20a76e905ad940e241190ce288b7e4a9877f1dd1261cd1a9a7",
+            "serialized_bytes_length": 1127123
+        }
+    },
+    {
+        "coord": {
+            "group": "org.scala-lang.modules",
+            "artifact": "scala-xml_2.13",
+            "version": "1.3.0",
+            "packaging": "jar"
+        },
+        "directDependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            }
+        ],
+        "dependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            }
+        ],
+        "file_name": "org.scala-lang.modules_scala-xml_2.13_1.3.0.jar",
+        "file_digest": {
+            "fingerprint": "6d96d45a7fc6fc7ab69bdbac841b48cf67ab109f048c8db375ae4effae524f39",
+            "serialized_bytes_length": 571493
+        }
+    },
+    {
+        "coord": {
+            "group": "org.scala-lang",
+            "artifact": "scala-compiler",
+            "version": "2.13.7",
+            "packaging": "jar"
+        },
+        "directDependencies": [
+            {
+                "group": "net.java.dev.jna",
+                "artifact": "jna",
+                "version": "5.8.0",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.jline",
+                "artifact": "jline",
+                "version": "3.20.0",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-reflect",
+                "version": "2.13.7",
+                "packaging": "jar"
+            }
+        ],
+        "dependencies": [
+            {
+                "group": "net.java.dev.jna",
+                "artifact": "jna",
+                "version": "5.8.0",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.jline",
+                "artifact": "jline",
+                "version": "3.20.0",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-reflect",
+                "version": "2.13.7",
+                "packaging": "jar"
+            }
+        ],
+        "file_name": "org.scala-lang_scala-compiler_2.13.7.jar",
+        "file_digest": {
+            "fingerprint": "a450602f03a4686919e60d1aeced549559f1eaffbaf30ffa7987c8d97e3e79a9",
+            "serialized_bytes_length": 12092802
+        }
+    },
+    {
+        "coord": {
+            "group": "org.scala-lang",
+            "artifact": "scala-library",
+            "version": "2.13.7",
+            "packaging": "jar"
+        },
+        "directDependencies": [],
+        "dependencies": [],
+        "file_name": "org.scala-lang_scala-library_2.13.7.jar",
+        "file_digest": {
+            "fingerprint": "a8bc08f3b9ff93d0496032bf2677163071b8d212992f41dbf04212e07d91616b",
+            "serialized_bytes_length": 6004712
+        }
+    },
+    {
+        "coord": {
+            "group": "org.scala-lang",
+            "artifact": "scala-reflect",
+            "version": "2.13.7",
+            "packaging": "jar"
+        },
+        "directDependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            }
+        ],
+        "dependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            }
+        ],
+        "file_name": "org.scala-lang_scala-reflect_2.13.7.jar",
+        "file_digest": {
+            "fingerprint": "a7bc4eca6970083d426a8d081aec313c7b7207d5f83b6724995e34078edc5cbb",
+            "serialized_bytes_length": 3771937
+        }
+    },
+    {
+        "coord": {
+            "group": "org.scala-lang",
+            "artifact": "scalap",
+            "version": "2.13.7",
+            "packaging": "jar"
+        },
+        "directDependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-compiler",
+                "version": "2.13.7",
+                "packaging": "jar"
+            }
+        ],
+        "dependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-compiler",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "net.java.dev.jna",
+                "artifact": "jna",
+                "version": "5.8.0",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.jline",
+                "artifact": "jline",
+                "version": "3.20.0",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-reflect",
+                "version": "2.13.7",
+                "packaging": "jar"
+            }
+        ],
+        "file_name": "org.scala-lang_scalap_2.13.7.jar",
+        "file_digest": {
+            "fingerprint": "f6fb1c7f4ff257edb900d66e02d6ee1c8b5b4d7f7084b2d1710120cd36c524cc",
+            "serialized_bytes_length": 530688
+        }
+    },
+    {
+        "coord": {
+            "group": "org.scalameta",
+            "artifact": "common_2.13",
+            "version": "4.4.30",
+            "packaging": "jar"
+        },
+        "directDependencies": [
+            {
+                "group": "com.lihaoyi",
+                "artifact": "sourcecode_2.13",
+                "version": "0.2.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            }
+        ],
+        "dependencies": [
+            {
+                "group": "com.lihaoyi",
+                "artifact": "sourcecode_2.13",
+                "version": "0.2.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            }
+        ],
+        "file_name": "org.scalameta_common_2.13_4.4.30.jar",
+        "file_digest": {
+            "fingerprint": "faec8003d08e27971b292062f79e16a4a428491f50736d140b8a1de38cd5c6b1",
+            "serialized_bytes_length": 2344659
+        }
+    },
+    {
+        "coord": {
+            "group": "org.scalameta",
+            "artifact": "fastparse-v2_2.13",
+            "version": "2.3.1",
+            "packaging": "jar"
+        },
+        "directDependencies": [
+            {
+                "group": "com.lihaoyi",
+                "artifact": "geny_2.13",
+                "version": "0.6.5",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.lihaoyi",
+                "artifact": "sourcecode_2.13",
+                "version": "0.2.7",
+                "packaging": "jar"
+            }
+        ],
+        "dependencies": [
+            {
+                "group": "com.lihaoyi",
+                "artifact": "geny_2.13",
+                "version": "0.6.5",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.lihaoyi",
+                "artifact": "sourcecode_2.13",
+                "version": "0.2.7",
+                "packaging": "jar"
+            }
+        ],
+        "file_name": "org.scalameta_fastparse-v2_2.13_2.3.1.jar",
+        "file_digest": {
+            "fingerprint": "8fca8597ad6d7c13c48009ee13bbe80c176b08ab12e68af54a50f7f69d8447c5",
+            "serialized_bytes_length": 320855
+        }
+    },
+    {
+        "coord": {
+            "group": "org.scalameta",
+            "artifact": "parsers_2.13",
+            "version": "4.4.30",
+            "packaging": "jar"
+        },
+        "directDependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "trees_2.13",
+                "version": "4.4.30",
+                "packaging": "jar"
+            }
+        ],
+        "dependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "trees_2.13",
+                "version": "4.4.30",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "common_2.13",
+                "version": "4.4.30",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.lihaoyi",
+                "artifact": "sourcecode_2.13",
+                "version": "0.2.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "fastparse-v2_2.13",
+                "version": "2.3.1",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.lihaoyi",
+                "artifact": "geny_2.13",
+                "version": "0.6.5",
+                "packaging": "jar"
+            }
+        ],
+        "file_name": "org.scalameta_parsers_2.13_4.4.30.jar",
+        "file_digest": {
+            "fingerprint": "66c78cdb5ed6c6345089603eee8e1b41392245252019d1268bd87fd97a7d8bcc",
+            "serialized_bytes_length": 1364598
+        }
+    },
+    {
+        "coord": {
+            "group": "org.scalameta",
+            "artifact": "scalafmt-cli_2.13",
+            "version": "3.2.1",
+            "packaging": "jar"
+        },
+        "directDependencies": [
+            {
+                "group": "org.scalameta",
+                "artifact": "svm-subs",
+                "version": "101.0.0",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "scalafmt-dynamic_2.13",
+                "version": "3.2.1",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.martiansoftware",
+                "artifact": "nailgun-server",
+                "version": "0.9.1",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "scalafmt-core_2.13",
+                "version": "3.2.1",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang.modules",
+                "artifact": "scala-xml_2.13",
+                "version": "1.3.0",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.github.scopt",
+                "artifact": "scopt_2.13",
+                "version": "4.0.1",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.googlecode.java-diff-utils",
+                "artifact": "diffutils",
+                "version": "1.3.0",
+                "packaging": "jar"
+            }
+        ],
+        "dependencies": [
+            {
+                "group": "org.scalameta",
+                "artifact": "svm-subs",
+                "version": "101.0.0",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.typesafe",
+                "artifact": "config",
+                "version": "1.4.1",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "scalafmt-dynamic_2.13",
+                "version": "3.2.1",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang.modules",
+                "artifact": "scala-parallel-collections_2.13",
+                "version": "1.0.4",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.geirsson",
+                "artifact": "metaconfig-core_2.13",
+                "version": "0.9.15",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.martiansoftware",
+                "artifact": "nailgun-server",
+                "version": "0.9.1",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "scalafmt-core_2.13",
+                "version": "3.2.1",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.geirsson",
+                "artifact": "metaconfig-typesafe-config_2.13",
+                "version": "0.9.15",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "scalafmt-config_2.13",
+                "version": "3.2.1",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang.modules",
+                "artifact": "scala-xml_2.13",
+                "version": "1.3.0",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "parsers_2.13",
+                "version": "4.4.30",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-compiler",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "io.get-coursier",
+                "artifact": "interface",
+                "version": "0.0.17",
+                "packaging": "jar"
+            },
+            {
+                "group": "net.java.dev.jna",
+                "artifact": "jna",
+                "version": "5.8.0",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "trees_2.13",
+                "version": "4.4.30",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.lihaoyi",
+                "artifact": "fansi_2.13",
+                "version": "0.2.14",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.github.scopt",
+                "artifact": "scopt_2.13",
+                "version": "4.0.1",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "common_2.13",
+                "version": "4.4.30",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.typelevel",
+                "artifact": "paiges-core_2.13",
+                "version": "0.4.2",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang.modules",
+                "artifact": "scala-collection-compat_2.13",
+                "version": "2.5.0",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.lihaoyi",
+                "artifact": "sourcecode_2.13",
+                "version": "0.2.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.jline",
+                "artifact": "jline",
+                "version": "3.20.0",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.googlecode.java-diff-utils",
+                "artifact": "diffutils",
+                "version": "1.3.0",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "fastparse-v2_2.13",
+                "version": "2.3.1",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.lihaoyi",
+                "artifact": "pprint_2.13",
+                "version": "0.6.6",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "scalameta_2.13",
+                "version": "4.4.30",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scalap",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "scalafmt-sysops_2.13",
+                "version": "3.2.1",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "scalafmt-interfaces",
+                "version": "3.2.1",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-reflect",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.lihaoyi",
+                "artifact": "geny_2.13",
+                "version": "0.6.5",
+                "packaging": "jar"
+            }
+        ],
+        "file_name": "org.scalameta_scalafmt-cli_2.13_3.2.1.jar",
+        "file_digest": {
+            "fingerprint": "f29db3984599972097fb92d1841ae528dd9989e57cc73daec6e758ee55087ecd",
+            "serialized_bytes_length": 164800
+        }
+    },
+    {
+        "coord": {
+            "group": "org.scalameta",
+            "artifact": "scalafmt-config_2.13",
+            "version": "3.2.1",
+            "packaging": "jar"
+        },
+        "directDependencies": [
+            {
+                "group": "com.geirsson",
+                "artifact": "metaconfig-core_2.13",
+                "version": "0.9.15",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.geirsson",
+                "artifact": "metaconfig-typesafe-config_2.13",
+                "version": "0.9.15",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            }
+        ],
+        "dependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.typesafe",
+                "artifact": "config",
+                "version": "1.4.1",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.geirsson",
+                "artifact": "metaconfig-core_2.13",
+                "version": "0.9.15",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.geirsson",
+                "artifact": "metaconfig-typesafe-config_2.13",
+                "version": "0.9.15",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.lihaoyi",
+                "artifact": "fansi_2.13",
+                "version": "0.2.14",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.typelevel",
+                "artifact": "paiges-core_2.13",
+                "version": "0.4.2",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang.modules",
+                "artifact": "scala-collection-compat_2.13",
+                "version": "2.5.0",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.lihaoyi",
+                "artifact": "sourcecode_2.13",
+                "version": "0.2.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.lihaoyi",
+                "artifact": "pprint_2.13",
+                "version": "0.6.6",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-reflect",
+                "version": "2.13.7",
+                "packaging": "jar"
+            }
+        ],
+        "file_name": "org.scalameta_scalafmt-config_2.13_3.2.1.jar",
+        "file_digest": {
+            "fingerprint": "be394d7869f91d33995d82dc9b857acb6331103952cb8fea25cf330e7d2b3324",
+            "serialized_bytes_length": 9412
+        }
+    },
+    {
+        "coord": {
+            "group": "org.scalameta",
+            "artifact": "scalafmt-core_2.13",
+            "version": "3.2.1",
+            "packaging": "jar"
+        },
+        "directDependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "scalafmt-config_2.13",
+                "version": "3.2.1",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "scalameta_2.13",
+                "version": "4.4.30",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "scalafmt-sysops_2.13",
+                "version": "3.2.1",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-reflect",
+                "version": "2.13.7",
+                "packaging": "jar"
+            }
+        ],
+        "dependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.typesafe",
+                "artifact": "config",
+                "version": "1.4.1",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang.modules",
+                "artifact": "scala-parallel-collections_2.13",
+                "version": "1.0.4",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.geirsson",
+                "artifact": "metaconfig-core_2.13",
+                "version": "0.9.15",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.geirsson",
+                "artifact": "metaconfig-typesafe-config_2.13",
+                "version": "0.9.15",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "scalafmt-config_2.13",
+                "version": "3.2.1",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "parsers_2.13",
+                "version": "4.4.30",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-compiler",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "net.java.dev.jna",
+                "artifact": "jna",
+                "version": "5.8.0",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "trees_2.13",
+                "version": "4.4.30",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.lihaoyi",
+                "artifact": "fansi_2.13",
+                "version": "0.2.14",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "common_2.13",
+                "version": "4.4.30",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.typelevel",
+                "artifact": "paiges-core_2.13",
+                "version": "0.4.2",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang.modules",
+                "artifact": "scala-collection-compat_2.13",
+                "version": "2.5.0",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.lihaoyi",
+                "artifact": "sourcecode_2.13",
+                "version": "0.2.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.jline",
+                "artifact": "jline",
+                "version": "3.20.0",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "fastparse-v2_2.13",
+                "version": "2.3.1",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.lihaoyi",
+                "artifact": "pprint_2.13",
+                "version": "0.6.6",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "scalameta_2.13",
+                "version": "4.4.30",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scalap",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "scalafmt-sysops_2.13",
+                "version": "3.2.1",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-reflect",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.lihaoyi",
+                "artifact": "geny_2.13",
+                "version": "0.6.5",
+                "packaging": "jar"
+            }
+        ],
+        "file_name": "org.scalameta_scalafmt-core_2.13_3.2.1.jar",
+        "file_digest": {
+            "fingerprint": "aee4a122642450de70661f3777470e26e38f03c3f53f22fdfd62ac8eb45b9d22",
+            "serialized_bytes_length": 1964531
+        }
+    },
+    {
+        "coord": {
+            "group": "org.scalameta",
+            "artifact": "scalafmt-dynamic_2.13",
+            "version": "3.2.1",
+            "packaging": "jar"
+        },
+        "directDependencies": [
+            {
+                "group": "com.typesafe",
+                "artifact": "config",
+                "version": "1.4.1",
+                "packaging": "jar"
+            },
+            {
+                "group": "io.get-coursier",
+                "artifact": "interface",
+                "version": "0.0.17",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "scalafmt-interfaces",
+                "version": "3.2.1",
+                "packaging": "jar"
+            }
+        ],
+        "dependencies": [
+            {
+                "group": "com.typesafe",
+                "artifact": "config",
+                "version": "1.4.1",
+                "packaging": "jar"
+            },
+            {
+                "group": "io.get-coursier",
+                "artifact": "interface",
+                "version": "0.0.17",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "scalafmt-interfaces",
+                "version": "3.2.1",
+                "packaging": "jar"
+            }
+        ],
+        "file_name": "org.scalameta_scalafmt-dynamic_2.13_3.2.1.jar",
+        "file_digest": {
+            "fingerprint": "983d043a1f3a974844ead98b581cd9399b754c32971f7986efa30c5020d8b805",
+            "serialized_bytes_length": 141924
+        }
+    },
+    {
+        "coord": {
+            "group": "org.scalameta",
+            "artifact": "scalafmt-interfaces",
+            "version": "3.2.1",
+            "packaging": "jar"
+        },
+        "directDependencies": [],
+        "dependencies": [],
+        "file_name": "org.scalameta_scalafmt-interfaces_3.2.1.jar",
+        "file_digest": {
+            "fingerprint": "58dba0553bd2fe291b8ae557f2dde8441f556b009d2ec72f94c67d5d1045ab88",
+            "serialized_bytes_length": 5371
+        }
+    },
+    {
+        "coord": {
+            "group": "org.scalameta",
+            "artifact": "scalafmt-sysops_2.13",
+            "version": "3.2.1",
+            "packaging": "jar"
+        },
+        "directDependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang.modules",
+                "artifact": "scala-parallel-collections_2.13",
+                "version": "1.0.4",
+                "packaging": "jar"
+            }
+        ],
+        "dependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang.modules",
+                "artifact": "scala-parallel-collections_2.13",
+                "version": "1.0.4",
+                "packaging": "jar"
+            }
+        ],
+        "file_name": "org.scalameta_scalafmt-sysops_2.13_3.2.1.jar",
+        "file_digest": {
+            "fingerprint": "7d4fc40ce68a9a0d818bbbab84847ac379bbdf3f58bb7b8b816e78203fb07fe1",
+            "serialized_bytes_length": 45886
+        }
+    },
+    {
+        "coord": {
+            "group": "org.scalameta",
+            "artifact": "scalameta_2.13",
+            "version": "4.4.30",
+            "packaging": "jar"
+        },
+        "directDependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scalap",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "parsers_2.13",
+                "version": "4.4.30",
+                "packaging": "jar"
+            }
+        ],
+        "dependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "parsers_2.13",
+                "version": "4.4.30",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-compiler",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "net.java.dev.jna",
+                "artifact": "jna",
+                "version": "5.8.0",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "trees_2.13",
+                "version": "4.4.30",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "common_2.13",
+                "version": "4.4.30",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.lihaoyi",
+                "artifact": "sourcecode_2.13",
+                "version": "0.2.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.jline",
+                "artifact": "jline",
+                "version": "3.20.0",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "fastparse-v2_2.13",
+                "version": "2.3.1",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scalap",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-reflect",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.lihaoyi",
+                "artifact": "geny_2.13",
+                "version": "0.6.5",
+                "packaging": "jar"
+            }
+        ],
+        "file_name": "org.scalameta_scalameta_2.13_4.4.30.jar",
+        "file_digest": {
+            "fingerprint": "2ee7a9b93baa8ca2213f516ed3ced26990fe34e3df4ddb149ee58aa5d46d6160",
+            "serialized_bytes_length": 791746
+        }
+    },
+    {
+        "coord": {
+            "group": "org.scalameta",
+            "artifact": "svm-subs",
+            "version": "101.0.0",
+            "packaging": "jar"
+        },
+        "directDependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            }
+        ],
+        "dependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            }
+        ],
+        "file_name": "org.scalameta_svm-subs_101.0.0.jar",
+        "file_digest": {
+            "fingerprint": "b31eb8ef90bec4c22a8ec858f5bd007bd46ce80c3dcef9dce238c6f9dd15c1a4",
+            "serialized_bytes_length": 3591
+        }
+    },
+    {
+        "coord": {
+            "group": "org.scalameta",
+            "artifact": "trees_2.13",
+            "version": "4.4.30",
+            "packaging": "jar"
+        },
+        "directDependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "common_2.13",
+                "version": "4.4.30",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "fastparse-v2_2.13",
+                "version": "2.3.1",
+                "packaging": "jar"
+            }
+        ],
+        "dependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "common_2.13",
+                "version": "4.4.30",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.lihaoyi",
+                "artifact": "sourcecode_2.13",
+                "version": "0.2.7",
+                "packaging": "jar"
+            },
+            {
+                "group": "org.scalameta",
+                "artifact": "fastparse-v2_2.13",
+                "version": "2.3.1",
+                "packaging": "jar"
+            },
+            {
+                "group": "com.lihaoyi",
+                "artifact": "geny_2.13",
+                "version": "0.6.5",
+                "packaging": "jar"
+            }
+        ],
+        "file_name": "org.scalameta_trees_2.13_4.4.30.jar",
+        "file_digest": {
+            "fingerprint": "79fdf691ff0f75265c99422f31db519ee044e88f52a32bbc39d30c16f6781315",
+            "serialized_bytes_length": 4274882
+        }
+    },
+    {
+        "coord": {
+            "group": "org.typelevel",
+            "artifact": "paiges-core_2.13",
+            "version": "0.4.2",
+            "packaging": "jar"
+        },
+        "directDependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            }
+        ],
+        "dependencies": [
+            {
+                "group": "org.scala-lang",
+                "artifact": "scala-library",
+                "version": "2.13.7",
+                "packaging": "jar"
+            }
+        ],
+        "file_name": "org.typelevel_paiges-core_2.13_0.4.2.jar",
+        "file_digest": {
+            "fingerprint": "9484ac95856510459d1bd52a77a6b93cdd641560decdf9910395ee4d17e88163",
+            "serialized_bytes_length": 121417
+        }
+    }
+]

--- a/src/python/pants/backend/scala/lint/scalafmt/skip_field.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/skip_field.py
@@ -1,0 +1,18 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.backend.scala.target_types import ScalaSourcesGeneratorTarget, ScalaSourceTarget
+from pants.engine.target import BoolField
+
+
+class SkipScalafmtField(BoolField):
+    alias = "skip_scalafmt"
+    default = False
+    help = "If true, don't run `scalafmt` on this target's code."
+
+
+def rules():
+    return [
+        ScalaSourceTarget.register_plugin_field(SkipScalafmtField),
+        ScalaSourcesGeneratorTarget.register_plugin_field(SkipScalafmtField),
+    ]

--- a/src/python/pants/backend/scala/lint/scalafmt/subsystem.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/subsystem.py
@@ -1,0 +1,39 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from typing import cast
+
+from pants.jvm.resolve.jvm_tool import JvmToolBase
+from pants.util.docutil import git_url
+
+
+class ScalafmtSubsystem(JvmToolBase):
+    options_scope = "scalafmt"
+    help = "scalafmt (https://scalameta.org/scalafmt/)"
+
+    default_version = "3.2.1"
+    default_artifacts = ["org.scalameta:scalafmt-cli_2.13:{version}"]
+    default_lockfile_resource = (
+        "pants.backend.scala.lint.scalafmt",
+        "scalafmt.default.lockfile.txt",
+    )
+    default_lockfile_path = (
+        "src/python/pants/backend/scala/lint/scalafmt/scalafmt.default.lockfile.txt"
+    )
+    default_lockfile_url = git_url(default_lockfile_path)
+
+    @classmethod
+    def register_options(cls, register):
+        super().register_options(register)
+        register(
+            "--skip",
+            type=bool,
+            default=False,
+            help=(
+                f"Don't use `scalafmt` when running `{register.bootstrap.pants_bin_name} fmt` and "
+                f"`{register.bootstrap.pants_bin_name} lint`"
+            ),
+        )
+
+    @property
+    def skip(self) -> bool:
+        return cast(bool, self.options.skip)

--- a/src/python/pants/init/BUILD
+++ b/src/python/pants/init/BUILD
@@ -21,6 +21,7 @@ target(
         "src/python/pants/backend/experimental/python/lint/pyupgrade",
         "src/python/pants/backend/experimental/scala",
         "src/python/pants/backend/experimental/scala/debug_goals",
+        "src/python/pants/backend/experimental/scala/lint/scalafmt",
         "src/python/pants/backend/experimental/terraform",
         "src/python/pants/backend/google_cloud_function/python",
         "src/python/pants/backend/plugin_development",


### PR DESCRIPTION
Add the `scalafmt` tool for `fmt` and `lint` goals.

Pants will choose the nearest ancestor `.scalafmt.conf` file as the configuration file to use for a source file. This differs from the logic used by `scalafmt` which only chooses between a `.scalafmt.conf` in the same directory as a file or one in the root of the repository. This should provide a better experience for multi-team monorepos where it could be useful to have a `.scalafmt.conf` that applies to a subtree of the repository.

Closes #11943.