### PR TITLE
[internal] java: fix junit sentinel rule setup

### DIFF
--- a/src/python/pants/backend/java/test/junit.py
+++ b/src/python/pants/backend/java/test/junit.py
@@ -101,7 +101,9 @@ async def setup_junit_debug_request(_field_set: JavaTestFieldSet) -> TestDebugRe
 
 
 @rule
-async def generate_junit_lockfile_request(junit: JUnit) -> JvmToolLockfileRequest:
+async def generate_junit_lockfile_request(
+    _: JunitToolLockfileSentinel, junit: JUnit
+) -> JvmToolLockfileRequest:
     return JvmToolLockfileRequest.from_tool(junit)
 
 


### PR DESCRIPTION
Fix the junit tool lockfile rule to actually refer to the sentinel instance. This is necessary for the rule to operate properly once other PRs will add more JVM tools.