### PR TITLE
Add `--docker-run-args` option to support `docker run [args] <image>`.

### DIFF
--- a/src/python/pants/backend/docker/goals/run_image.py
+++ b/src/python/pants/backend/docker/goals/run_image.py
@@ -3,32 +3,38 @@
 from __future__ import annotations
 
 import sys
-from typing import cast
+from typing import Iterator, cast
 
 from pants.backend.docker.goals.package_image import BuiltDockerImage, DockerFieldSet
+from pants.backend.docker.subsystems.docker_options import DockerOptions
 from pants.backend.docker.util_rules.docker_binary import DockerBinary
 from pants.core.goals.package import BuiltPackage, PackageFieldSet
 from pants.core.goals.run import RunRequest
-from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.environment import Environment, EnvironmentRequest
+from pants.engine.rules import Get, MultiGet, collect_rules, rule
+
+
+def get_docker_run_args(options: DockerOptions) -> Iterator[str]:
+    if sys.stdout.isatty():
+        yield "-it"
+
+    yield "--rm"
+    yield from options.run_args
 
 
 @rule
-async def docker_image_run_request(field_set: DockerFieldSet, docker: DockerBinary) -> RunRequest:
-    image = await Get(BuiltPackage, PackageFieldSet, field_set)
-    return RunRequest(
-        digest=image.digest,
-        args=tuple(
-            cast(str, arg)
-            for arg in (
-                docker.path,
-                "run",
-                "-it" if sys.stdout.isatty() else False,
-                "--rm",
-                cast(BuiltDockerImage, image.artifacts[0]).tags[0],
-            )
-            if arg
-        ),
+async def docker_image_run_request(
+    field_set: DockerFieldSet, docker: DockerBinary, options: DockerOptions
+) -> RunRequest:
+    env, image = await MultiGet(
+        Get(Environment, EnvironmentRequest(options.env_vars)),
+        Get(BuiltPackage, PackageFieldSet, field_set),
     )
+    tag = cast(BuiltDockerImage, image.artifacts[0]).tags[0]
+    args = tuple(get_docker_run_args(options))
+    run = docker.run_image(tag, docker_run_args=args, env=env)
+
+    return RunRequest(args=run.argv, digest=image.digest, extra_env=run.env)
 
 
 def rules():

--- a/src/python/pants/backend/docker/goals/run_image.py
+++ b/src/python/pants/backend/docker/goals/run_image.py
@@ -1,9 +1,9 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 from __future__ import annotations
 
-import sys
-from typing import Iterator, cast
+from typing import cast
 
 from pants.backend.docker.goals.package_image import BuiltDockerImage, DockerFieldSet
 from pants.backend.docker.subsystems.docker_options import DockerOptions
@@ -12,14 +12,6 @@ from pants.core.goals.package import BuiltPackage, PackageFieldSet
 from pants.core.goals.run import RunRequest
 from pants.engine.environment import Environment, EnvironmentRequest
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-
-
-def get_docker_run_args(options: DockerOptions) -> Iterator[str]:
-    if sys.stdout.isatty():
-        yield "-it"
-
-    yield "--rm"
-    yield from options.run_args
 
 
 @rule
@@ -31,8 +23,7 @@ async def docker_image_run_request(
         Get(BuiltPackage, PackageFieldSet, field_set),
     )
     tag = cast(BuiltDockerImage, image.artifacts[0]).tags[0]
-    args = tuple(get_docker_run_args(options))
-    run = docker.run_image(tag, docker_run_args=args, env=env)
+    run = docker.run_image(tag, docker_run_args=options.run_args, env=env)
 
     return RunRequest(args=run.argv, digest=image.digest, extra_env=run.env)
 

--- a/src/python/pants/backend/docker/subsystems/docker_options.py
+++ b/src/python/pants/backend/docker/subsystems/docker_options.py
@@ -11,6 +11,12 @@ from pants.option.subsystem import Subsystem
 from pants.util.memo import memoized_method
 from pants.util.strutil import bullet_list
 
+doc_links = {
+    "docker_env_vars": (
+        "https://docs.docker.com/engine/reference/commandline/cli/#environment-variables"
+    ),
+}
+
 
 class DockerOptions(Subsystem):
     options_scope = "docker"
@@ -86,15 +92,32 @@ class DockerOptions(Subsystem):
             default=[],
             advanced=True,
             help=(
-                "Environment variables to set for `docker` invocations. "
+                "Environment variables to set for `docker` invocations.\n\n"
                 "Entries are either strings in the form `ENV_VAR=value` to set an explicit value; "
                 "or just `ENV_VAR` to copy the value from Pants's own environment."
+            ),
+        )
+
+        register(
+            "--run-args",
+            type=list,
+            member_type=str,
+            default=[],
+            help=(
+                "Additional arguments to use for `docker run` invocations.\n\n"
+                "To provide the top-level options to the `docker` client, use `[docker].env_vars` "
+                f"to configure the [Environment variables]({doc_links['docker_env_vars']}) as "
+                "appropriate."
             ),
         )
 
     @property
     def build_args(self) -> tuple[str, ...]:
         return tuple(sorted(set(self.options.build_args)))
+
+    @property
+    def run_args(self) -> tuple[str, ...]:
+        return tuple(self.options.run_args)
 
     @property
     def env_vars(self) -> tuple[str, ...]:

--- a/src/python/pants/backend/docker/util_rules/docker_binary.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary.py
@@ -75,6 +75,21 @@ class DockerBinary(BinaryPath):
             for tag in tags
         )
 
+    def run_image(
+        self,
+        tag: str,
+        *,
+        docker_run_args: tuple[str, ...] | None = None,
+        image_args: tuple[str, ...] | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> Process:
+        return Process(
+            argv=(self.path, "run", *(docker_run_args or []), tag, *(image_args or [])),
+            cache_scope=ProcessCacheScope.PER_SESSION,
+            description=f"Running docker image {tag}",
+            env=env,
+        )
+
 
 @dataclass(frozen=True)
 class DockerBinaryRequest:

--- a/src/python/pants/backend/docker/util_rules/docker_binary_test.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary_test.py
@@ -51,3 +51,17 @@ def test_docker_binary_push_image(docker_path: str, docker: DockerBinary) -> Non
         ),
     )
     assert push_request[0].description == f"Pushing docker image {image_ref}"
+
+
+def test_docker_binary_run_image(docker_path: str, docker: DockerBinary) -> None:
+    image_ref = "registry/repo/name:tag"
+    port_spec = "127.0.0.1:80:8080/tcp"
+    run_request = docker.run_image(
+        image_ref, docker_run_args=("-p", port_spec), image_args=("test-input",)
+    )
+    assert run_request == Process(
+        argv=(docker_path, "run", "-p", port_spec, image_ref, "test-input"),
+        cache_scope=ProcessCacheScope.PER_SESSION,
+        description="",  # The description field is marked `compare=False`
+    )
+    assert run_request.description == f"Running docker image {image_ref}"


### PR DESCRIPTION
New option for the `[docker]` scope, which allows passing additional options when executing `docker run [OPTIONS] <image>`, in addition to the `--run-args` which are passed to the image entrypoint.

Fixes #13806 

```
$ ./pants run --docker-run-args="-p 8080/tcp" src/docker:example -- [image entry point args...]
```

This translates to:
```
$ docker run -p 8080/tcp example:latest [image entry point args...]
```
