### PR TITLE
`relocate_files` no longer used with `export-codegen` goal

### DIFF
--- a/src/python/pants/backend/codegen/export_codegen_goal.py
+++ b/src/python/pants/backend/codegen/export_codegen_goal.py
@@ -42,7 +42,9 @@ async def export_codegen(
     # We run all possible code generators. Running codegen requires specifying the expected
     # output_type, so we must inspect what is possible to generate.
     all_generate_request_types = union_membership.get(GenerateSourcesRequest)
-    inputs_to_outputs = {req.input: req.output for req in all_generate_request_types}
+    inputs_to_outputs = {
+        req.input: req.output for req in all_generate_request_types if req.exportable
+    }
     codegen_sources_fields_with_output = []
     for tgt in targets:
         if not tgt.has_field(SourcesField):
@@ -72,12 +74,12 @@ async def export_codegen(
         Get(
             HydratedSources,
             HydrateSourcesRequest(
-                sources_and_output_type[0],
-                for_sources_types=(sources_and_output_type[1],),
+                sources,
+                for_sources_types=(output_type,),
                 enable_codegen=True,
             ),
         )
-        for sources_and_output_type in codegen_sources_fields_with_output
+        for sources, output_type in codegen_sources_fields_with_output
     )
 
     merged_digest = await Get(

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -225,6 +225,7 @@ class RelocatedFiles(Target):
 class RelocateFilesViaCodegenRequest(GenerateSourcesRequest):
     input = RelocatedFilesSources
     output = FileSourceField
+    exportable = False
 
 
 @rule(desc="Relocating loose files for `relocated_files` targets", level=LogLevel.DEBUG)

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1848,6 +1848,9 @@ class GenerateSourcesRequest:
     The rule to actually implement the codegen should take the subclass as input, and it must
     return `GeneratedSources`.
 
+    The `exportable` attribute disables the use of this codegen by the `export-codegen` goal when
+    set to False.
+
     For example:
 
         class GenerateFortranFromAvroRequest:
@@ -1870,6 +1873,8 @@ class GenerateSourcesRequest:
 
     input: ClassVar[type[SourcesField]]
     output: ClassVar[type[SourcesField]]
+
+    exportable: ClassVar[bool] = True
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Do not export the loose files from `relocate_files` targets.

Requires #13828
