### PR TITLE
[internal] Refer to project as "Pantsbuild"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,24 @@
-# Pants Build System
+# Pantsbuild
 
-Pants is a scalable build system for _monorepos_: codebases containing 
-multiple projects, often using multiple programming languages and frameworks, 
-in a single unified code repository.
+Pantsbuild is a fast, scalable, user-friendly build system for codebases of 
+all sizes. It's currently focused on Python, Shell, Docker, and Go, with support for 
+Java and Scala coming soon.
 
-Some noteworthy features include:
+Pantsbuild orchestrates the various tools and steps that process your source code into deployable software, including:
 
-* Explicit dependency modeling.
-* Fine-grained invalidation.
-* Shared result caching.
-* Concurrent execution.
-* Remote execution.
-* Unified interface for multiple tools and languages.
-* Extensibility and customizability via a plugin API.
+* Dependency resolution
+* Code generation
+* Compilation/type checking
+* Testing
+* Linting
+* Formatting
+* Packaging
+* Project introspection
 
 Documentation: [www.pantsbuild.org](https://www.pantsbuild.org/).
+
+Community: [www.pantsbuild.org/getting-help](https://www.pantsbuild.org/docs/getting-help).
 
 We release to [PyPI](https://pypi.org/pypi)
 [![version](https://img.shields.io/pypi/v/pantsbuild.pants.svg)](https://pypi.org/pypi/pantsbuild.pants)
 [![license](https://img.shields.io/pypi/l/pantsbuild.pants.svg)](https://pypi.org/pypi/pantsbuild.pants)
-
-# Requirements
-
-To run Pants, you need:
-
-* Linux or macOS.
-* Python 3.7+ discoverable on your `PATH`.
-* A C compiler, system headers and Python headers (to compile native Python modules).
-* Internet access (so that Pants can fully bootstrap itself).


### PR DESCRIPTION
As discussed in Slack, we've found that "Pants" has two problems:

1. Comments about the name being silly, especially in the UK
2. SEO conflicts with the article of clothing

It's clunky to say "Pants Build System". Instead, we can improve (but not solve) both problems by using the name "Pantsbuild". We already were doing this in some places like our social media account handles.

[ci skip-rust]