### PR TITLE
[internal] scala: fix a type in subsystem

### DIFF
--- a/src/python/pants/backend/scala/lint/scalafmt/subsystem.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/subsystem.py
@@ -11,7 +11,7 @@ class ScalafmtSubsystem(JvmToolBase):
     help = "scalafmt (https://scalameta.org/scalafmt/)"
 
     default_version = "3.2.1"
-    default_artifacts = ["org.scalameta:scalafmt-cli_2.13:{version}"]
+    default_artifacts = ("org.scalameta:scalafmt-cli_2.13:{version}",)
     default_lockfile_resource = (
         "pants.backend.scala.lint.scalafmt",
         "scalafmt.default.lockfile.txt",


### PR DESCRIPTION
The type of `JvmToolBase.default_artifacts` changed in a PR landed just before I landed https://github.com/pantsbuild/pants/pull/13814. Fix the type accordingly.

[ci skip-rust]

[ci skip-build-wheels]