### PR TITLE
[internal] Wheel testing does not override backends

### DIFF
--- a/build-support/bin/_release_helper.py
+++ b/build-support/bin/_release_helper.py
@@ -279,29 +279,17 @@ def _pip_args(extra_pip_args: list[str]) -> tuple[str, ...]:
 def validate_pants_pkg(version: str, venv_dir: Path, extra_pip_args: list[str]) -> None:
     def run_venv_pants(args: list[str]) -> str:
         # When we do (dry-run) testing, we need to run the packaged pants. It doesn't have internal
-        # backend plugins so when we execute it at the repo build root, the root pants.toml will
-        # ask it to load internal backend packages and their dependencies which it doesn't have,
-        # and it'll fail. To solve that problem, we load the internal backend package dependencies
-        # into the pantsbuild.pants venv.
+        # backend plugins embedded (but it does have all other backends): to load only the internal
+        # packages, we override the `--python-path` to include them (and to implicitly exclude
+        # `src/python`).
         return (
             subprocess.run(
                 [
                     venv_dir / "bin/pants",
-                    "--no-verify-config",
                     "--no-remote-cache-read",
                     "--no-remote-cache-write",
                     "--no-pantsd",
                     "--pythonpath=['pants-plugins']",
-                    (
-                        "--backend-packages=["
-                        "'pants.backend.awslambda.python', "
-                        "'pants.backend.python', "
-                        "'pants.backend.shell', "
-                        "'pants.backend.experimental.java', "
-                        "'pants.backend.experimental.scala', "
-                        "'internal_plugins.releases'"
-                        "]"
-                    ),
                     *args,
                 ],
                 check=True,

--- a/build-support/githooks/prepare-commit-msg
+++ b/build-support/githooks/prepare-commit-msg
@@ -24,8 +24,10 @@ NUM_RUST_FILES=$(echo "${CHANGED_FILES})" | grep -c -E \
   -e "^build-support/bin/generate_github_workflows.py")
 
 NUM_RELEASE_FILES=$(echo "${CHANGED_FILES})" | grep -c -E \
+  -e "^pants.toml" \
   -e "^src/python/pants/VERSION" \
   -e "^src/python/pants/notes" \
+  -e "^src/python/pants/init/BUILD" \
   -e "^src/rust/engine/fs/fs_util" \
   -e "^build-support/bin/release.sh" \
   -e "^build-support/bin/release_helper.py" \


### PR DESCRIPTION
The comment was slightly stale: the `pantsbuild.pants` wheel includes all backends other than the internal backends, and so they only need to be added to the `--pythonpath`, while the public backends are validated as being loaded from within the wheel.

[ci skip-rust]