### PR TITLE
Make pants.pex more useable.

### DIFF
--- a/build-support/bin/_release_helper.py
+++ b/build-support/bin/_release_helper.py
@@ -695,7 +695,10 @@ def build_fs_util() -> None:
 def build_pex(fetch: bool) -> None:
     if fetch:
         extra_pex_args = [
-            "--interpreter-constraint=CPython>=3.7,<3.10",
+            "--python-shebang",
+            "/usr/bin/env python",
+            "--interpreter-constraint",
+            "CPython>=3.7,<3.10",
             *(
                 f"--platform={plat}-{abi}"
                 for plat in ("linux_x86_64", "macosx_10.15_x86_64")

--- a/build-support/bin/_release_helper.py
+++ b/build-support/bin/_release_helper.py
@@ -695,16 +695,23 @@ def build_fs_util() -> None:
 def build_pex(fetch: bool) -> None:
     if fetch:
         extra_pex_args = [
-            f"--platform={plat}-{abi}"
-            for plat in ("linux_x86_64", "macosx_10.15_x86_64")
-            for abi in ("cp-37-m", "cp-38-cp38", "cp-39-cp39")
+            "--interpreter-constraint=CPython>=3.7,<3.10",
+            *(
+                f"--platform={plat}-{abi}"
+                for plat in ("linux_x86_64", "macosx_10.15_x86_64")
+                for abi in ("cp-37-m", "cp-38-cp38", "cp-39-cp39")
+            ),
         ]
         pex_name = f"pants.{CONSTANTS.pants_unstable_version}.pex"
         banner(f"Building {pex_name} by fetching wheels.")
     else:
-        extra_pex_args = [f"--python={sys.executable}"]
+        major, minor = sys.version_info[:2]
+        extra_pex_args = [
+            f"--interpreter-constraint=CPython=={major}.{minor}.*",
+            f"--python={sys.executable}",
+        ]
         plat = os.uname()[0].lower()
-        py = f"cp{''.join(map(str, sys.version_info[:2]))}"
+        py = f"cp{major}{minor}"
         pex_name = f"pants.{CONSTANTS.pants_unstable_version}.{plat}-{py}.pex"
         banner(f"Building {pex_name} by building wheels.")
 
@@ -744,6 +751,7 @@ def build_pex(fetch: bool) -> None:
                 "--console-script=pants",
                 *extra_pex_args,
                 f"pantsbuild.pants=={CONSTANTS.pants_unstable_version}",
+                "--venv",
             ],
             env=env,
             check=True,


### PR DESCRIPTION
Previously:
1. The shebang was fixed at `#!/usr/bin/env python3.7` so the universal
   PEX would not work on machines with only Python 3.8 or Python 3.9.
2. There were no ICs; which are required by 1.
3. The PEX did not take advantage of `--venv` mode, which is almost 
   surely what you want for a repeatedly run tool.

[ci skip-rust]
[ci skip-build-wheels]