### PR TITLE
JVM Split coordinate and artifact requirement concepts

### DIFF
--- a/src/python/pants/backend/java/dependency_inference/java_parser_launcher.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser_launcher.py
@@ -32,7 +32,7 @@ def _load_javaparser_launcher_source() -> bytes:
 
 def java_parser_artifact_requirements() -> ArtifactRequirements:
     # Update in concert with the target definition for `java_parser`.
-    return ArtifactRequirements(
+    return ArtifactRequirements.from_coordinates(
         [
             Coordinate(
                 group="com.fasterxml.jackson.core", artifact="jackson-databind", version="2.12.4"

--- a/src/python/pants/backend/scala/compile/scalac.py
+++ b/src/python/pants/backend/scala/compile/scalac.py
@@ -116,7 +116,7 @@ async def compile_scala_source(
             MaterializedClasspathRequest(
                 prefix="__toolcp",
                 artifact_requirements=(
-                    ArtifactRequirements(
+                    ArtifactRequirements.from_coordinates(
                         [
                             Coordinate(
                                 group="org.scala-lang",

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -88,7 +88,7 @@ CIRCE_DEPENDENCIES = [
     ]
 ]
 
-SCALA_PARSER_ARTIFACT_REQUIREMENTS = ArtifactRequirements(
+SCALA_PARSER_ARTIFACT_REQUIREMENTS = ArtifactRequirements.from_coordinates(
     SCALAMETA_DEPENDENCIES + CIRCE_DEPENDENCIES
 )
 
@@ -323,7 +323,7 @@ async def setup_scala_parser_classfiles(
             MaterializedClasspathRequest(
                 prefix="__toolcp",
                 artifact_requirements=(
-                    ArtifactRequirements(
+                    ArtifactRequirements.from_coordinates(
                         [
                             Coordinate(
                                 group="org.scala-lang",

--- a/src/python/pants/backend/scala/goals/repl.py
+++ b/src/python/pants/backend/scala/goals/repl.py
@@ -44,7 +44,7 @@ async def create_scala_repl_request(
             MaterializedClasspathRequest(
                 prefix="__toolcp",
                 artifact_requirements=(
-                    ArtifactRequirements(
+                    ArtifactRequirements.from_coordinates(
                         [
                             Coordinate(
                                 group="org.scala-lang",

--- a/src/python/pants/jvm/goals/coursier.py
+++ b/src/python/pants/jvm/goals/coursier.py
@@ -21,14 +21,7 @@ from pants.engine.fs import (
 )
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
-from pants.engine.target import (
-    AllTargets,
-    InvalidTargetException,
-    Target,
-    Targets,
-    TransitiveTargets,
-    TransitiveTargetsRequest,
-)
+from pants.engine.target import AllTargets, Targets, TransitiveTargets, TransitiveTargetsRequest
 from pants.jvm.resolve.coursier_fetch import (
     ArtifactRequirements,
     Coordinate,
@@ -36,14 +29,7 @@ from pants.jvm.resolve.coursier_fetch import (
     CoursierResolvedLockfile,
 )
 from pants.jvm.subsystems import JvmSubsystem
-from pants.jvm.target_types import (
-    JvmArtifactArtifactField,
-    JvmArtifactFieldSet,
-    JvmArtifactGroupField,
-    JvmArtifactUrlField,
-    JvmArtifactVersionField,
-    JvmCompatibleResolveNamesField,
-)
+from pants.jvm.target_types import JvmArtifactFieldSet, JvmCompatibleResolveNamesField
 
 
 class CoursierResolveSubsystem(GoalSubsystem):
@@ -64,35 +50,6 @@ class CoursierResolveSubsystem(GoalSubsystem):
 
 class CoursierResolve(Goal):
     subsystem_cls = CoursierResolveSubsystem
-
-
-def coordinate_from_target(tgt: Target) -> Coordinate:
-    group = tgt[JvmArtifactGroupField].value
-    if not group:
-        raise InvalidTargetException(
-            f"The `group` field of {tgt.alias} target {tgt.address} must be set."
-        )
-
-    artifact = tgt[JvmArtifactArtifactField].value
-    if not artifact:
-        raise InvalidTargetException(
-            f"The `artifact` field of {tgt.alias} target {tgt.address} must be set."
-        )
-
-    version = tgt[JvmArtifactVersionField].value
-    if not version:
-        raise InvalidTargetException(
-            f"The `version` field of {tgt.alias} target {tgt.address} must be set."
-        )
-
-    url = tgt[JvmArtifactUrlField].value
-
-    return Coordinate(
-        group=group,
-        artifact=artifact,
-        version=version,
-        url=url,
-    )
 
 
 @dataclass(frozen=True)
@@ -180,7 +137,7 @@ async def coursier_generate_lockfile(
     ]
 
     artifact_requirements = ArtifactRequirements(
-        [coordinate_from_target(tgt) for tgt in resolvable_dependencies]
+        [Coordinate.from_jvm_artifact_target(tgt) for tgt in resolvable_dependencies]
     )
 
     resolved_lockfile = await Get(

--- a/src/python/pants/jvm/goals/coursier.py
+++ b/src/python/pants/jvm/goals/coursier.py
@@ -24,9 +24,9 @@ from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
 from pants.engine.target import AllTargets, Targets, TransitiveTargets, TransitiveTargetsRequest
 from pants.jvm.resolve.coursier_fetch import (
     ArtifactRequirements,
-    Coordinate,
     CoursierError,
     CoursierResolvedLockfile,
+    RequirementCoordinate,
 )
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmArtifactFieldSet, JvmCompatibleResolveNamesField
@@ -137,7 +137,7 @@ async def coursier_generate_lockfile(
     ]
 
     artifact_requirements = ArtifactRequirements(
-        [Coordinate.from_jvm_artifact_target(tgt) for tgt in resolvable_dependencies]
+        [RequirementCoordinate.from_jvm_artifact_target(tgt) for tgt in resolvable_dependencies]
     )
 
     resolved_lockfile = await Get(

--- a/src/python/pants/jvm/goals/coursier.py
+++ b/src/python/pants/jvm/goals/coursier.py
@@ -23,10 +23,10 @@ from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
 from pants.engine.target import AllTargets, Targets, TransitiveTargets, TransitiveTargetsRequest
 from pants.jvm.resolve.coursier_fetch import (
+    ArtifactRequirement,
     ArtifactRequirements,
     CoursierError,
     CoursierResolvedLockfile,
-    RequirementCoordinate,
 )
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmArtifactFieldSet, JvmCompatibleResolveNamesField
@@ -137,7 +137,7 @@ async def coursier_generate_lockfile(
     ]
 
     artifact_requirements = ArtifactRequirements(
-        [RequirementCoordinate.from_jvm_artifact_target(tgt) for tgt in resolvable_dependencies]
+        [ArtifactRequirement.from_jvm_artifact_target(tgt) for tgt in resolvable_dependencies]
     )
 
     resolved_lockfile = await Get(

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -114,13 +114,13 @@ class Coordinate:
             packaging=parts[3] if len(parts) == 4 else "jar",
         )
 
-    @classmethod
-    def from_requirement_coordinate(cls, req_coord: RequirementCoordinate) -> Coordinate:
-        """Converts a `RequirementCoordinate` to a coordinate.
-
-        Note that this will discard `url` and `jar` information, so it's generally not a good idea
-        to use this.
-        """
+    def to_requirement_coordinate(self, coord: Coordinate) -> RequirementCoordinate:
+        """Creates a `RequirementCoordinate` from a `Coordinate`."""
+        return RequirementCoordinate(
+            group=self.group,
+            artifact=self.artifact,
+            version=self.version,
+        )
 
     def to_coord_str(self, versioned: bool = True) -> str:
         unversioned = f"{self.group}:{self.artifact}"
@@ -191,17 +191,9 @@ class RequirementCoordinate:
             group=group, artifact=artifact, version=version, url=url, jar=jar
         )
 
-    @classmethod
-    def from_coordinate(cls, coord: Coordinate) -> RequirementCoordinate:
-        """Creates a `RequirementCoordinate` from a `Coordinate`."""
-        return cls(
-            group=coord.group,
-            artifact=coord.artifact,
-            version=coord.version,
-        )
 
     def to_coord_str(self, versioned: bool = True) -> str:
-        without_url = Coordinate.from_requirement_coordinate(self).to_coord_str(versioned)
+        without_url = self.to_coordinate().to_coord_str(versioned)
         if self.url:
             url_suffix = f",url={url_quote_plus(self.url)}"
         return f"{without_url}{url_suffix}"
@@ -227,6 +219,16 @@ class RequirementCoordinate:
             # Coursier requires exact URL
             url=f"file:{Coursier.working_directory_placeholder}/{rel_path}",
         )
+
+    def to_coordinate(self) -> Coordinate:
+        """Converts a `RequirementCoordinate` to a `Coordinate`.
+
+        Note that this will discard `url` and `jar` information, so it's generally not a good idea
+        to use this.
+        """
+
+        return Coordinate(self.group, self.artifact, self.version)
+
 
 
 class RequirementCoordinates(DeduplicatedCollection[RequirementCoordinate]):

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -214,10 +214,6 @@ class RequirementCoordinate:
         )
 
 
-class RequirementCoordinates(DeduplicatedCollection[RequirementCoordinate]):
-    """An ordered list of `Coordinate`s."""
-
-
 @dataclass(frozen=True)
 class AllJarTargets:
     """A dictionary of targets that provide JAR files, indexed by coordinate."""

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -200,20 +200,6 @@ async def all_jar_targets(all_targets: AllTargets) -> AllJarTargets:
 class ArtifactRequirements(DeduplicatedCollection[Coordinate]):
     """An ordered list of Coordinates used as requirements."""
 
-    @classmethod
-    def create_from_maven_coordinates_fields(
-        cls,
-        fields: Iterable[JvmRequirementsField],
-        *,
-        additional_requirements: Iterable[Coordinate] = (),
-    ) -> ArtifactRequirements:
-        field_requirements = (
-            Coordinate.from_coord_str(str(maven_coord))
-            for field in fields
-            for maven_coord in (field.value or ())
-        )
-        return ArtifactRequirements((*field_requirements, *additional_requirements))
-
 
 @dataclass(frozen=True)
 class CoursierLockfileEntry:

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -266,8 +266,8 @@ class CoursierLockfileEntry:
                 fingerprint=entry["file_digest"]["fingerprint"],
                 serialized_bytes_length=entry["file_digest"]["serialized_bytes_length"],
             ),
-            remote_url=entry["remote_url"],
-            pants_address=entry["pants_address"],
+            remote_url=entry.get("remote_url"),
+            pants_address=entry.get("pants_address"),
         )
 
     def to_json_dict(self) -> dict[str, Any]:

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -75,7 +75,7 @@ class CoursierError(Exception):
 
 @dataclass(frozen=True)
 class Coordinate:
-    """A single Maven-style coordinate for a JVM dependency that contains."""
+    """A single Maven-style coordinate for a JVM dependency."""
 
     group: str
     artifact: str

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -15,9 +15,8 @@ from typing import Any, FrozenSet, Iterable, Iterator, List, Tuple
 from urllib.parse import quote_plus as url_quote_plus
 
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
-from pants.build_graph.address import Address, AddressInput
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.engine.addresses import Addresses, UnparsedAddressInputs
+from pants.engine.addresses import UnparsedAddressInputs
 from pants.engine.collection import Collection, DeduplicatedCollection
 from pants.engine.fs import (
     AddPrefix,
@@ -584,13 +583,16 @@ async def coursier_fetch_one_coord(
     # Prepare any URL- or JAR-specifying entries for use with Coursier
     req: ArtifactRequirement
     if request.pants_address:
-        targets = await Get(Targets, UnparsedAddressInputs([request.pants_address], owning_address=None))
+        targets = await Get(
+            Targets, UnparsedAddressInputs([request.pants_address], owning_address=None)
+        )
         req = ArtifactRequirement(request.coord, jar=targets[0][JvmArtifactJarSourceField])
     else:
         req = ArtifactRequirement(request.coord, url=request.remote_url)
-    
+
     coursier_resolve_info = await Get(
-        CoursierResolveInfo, ArtifactRequirements([req]),
+        CoursierResolveInfo,
+        ArtifactRequirements([req]),
     )
 
     input_digest = await Get(Digest, MergeDigests([coursier.digest, coursier_resolve_info.digest]))

--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -12,12 +12,12 @@ from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.process import ProcessExecutionFailure
 from pants.jvm.compile import ClasspathEntry
 from pants.jvm.resolve.coursier_fetch import (
+    ArtifactRequirement,
     ArtifactRequirements,
     Coordinate,
     Coordinates,
     CoursierLockfileEntry,
     CoursierResolvedLockfile,
-    RequirementCoordinate,
 )
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
@@ -176,7 +176,7 @@ def test_resolve_conflicting(rule_runner: RuleRunner) -> None:
 @maybe_skip_jdk_test
 def test_resolve_with_broken_url(rule_runner: RuleRunner) -> None:
 
-    coordinate = RequirementCoordinate(
+    coordinate = ArtifactRequirement(
         coordinate=Coordinate(
             group="org.hamcrest",
             artifact="hamcrest-core",
@@ -197,7 +197,7 @@ def test_resolve_with_broken_url(rule_runner: RuleRunner) -> None:
 @maybe_skip_jdk_test
 def test_resolve_with_working_url(rule_runner: RuleRunner) -> None:
 
-    requirement = RequirementCoordinate(
+    requirement = ArtifactRequirement(
         coordinate=Coordinate(
             group="apache-commons-local",
             artifact="commons-collections",

--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -297,6 +297,53 @@ def test_resolve_with_a_jar(rule_runner: RuleRunner) -> None:
 
 
 @maybe_skip_jdk_test
+def test_fetch_one_coord_with_jar(rule_runner: RuleRunner) -> None:
+
+    rule_runner.write_files(
+        {
+            "BUILD": textwrap.dedent(
+                """\
+            jvm_artifact(
+              name="jeremy",
+              group="jeremy",
+              artifact="jeremy",
+              version="4.13.2",
+              jar="jeremy.jar",
+            )
+            """
+            ),
+            "jeremy.jar": "hello dave",
+        }
+    )
+
+    classpath_entry = rule_runner.request(
+        ClasspathEntry,
+        [
+            CoursierLockfileEntry(
+                coord=HAMCREST_COORD,
+                file_name="jeremy.jar",
+                direct_dependencies=Coordinates([]),
+                dependencies=Coordinates([]),
+                file_digest=FileDigest(
+                    fingerprint="55b9afa8d7776cd6c318eec51f506e9c7f66c247dcec343d4667f5f269714f86",
+                    serialized_bytes_length=10,
+                ),
+                pants_address="//:jeremy",
+            )
+        ],
+    )
+    assert classpath_entry.filenames == ("jeremy.jar",)
+    file_digest = rule_runner.request(
+        FileDigest,
+        [ExtractFileDigest(classpath_entry.digest, "jeremy.jar")],
+    )
+    assert file_digest == FileDigest(
+        fingerprint="55b9afa8d7776cd6c318eec51f506e9c7f66c247dcec343d4667f5f269714f86",
+        serialized_bytes_length=10,
+    )
+
+
+@maybe_skip_jdk_test
 def test_fetch_one_coord_with_no_deps(rule_runner: RuleRunner) -> None:
 
     classpath_entry = rule_runner.request(

--- a/src/python/pants/jvm/resolve/jvm_tool.py
+++ b/src/python/pants/jvm/resolve/jvm_tool.py
@@ -25,7 +25,6 @@ from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import collect_rules, goal_rule, rule
 from pants.engine.target import Targets
 from pants.engine.unions import UnionMembership, union
-from pants.jvm.goals.coursier import coordinate_from_target
 from pants.jvm.resolve.coursier_fetch import (
     ArtifactRequirements,
     Coordinate,
@@ -271,7 +270,7 @@ async def gather_coordinates_for_jvm_lockfile(request: GatherJvmCoordinatesReque
     other_targets = []
     for tgt in all_supplied_targets:
         if JvmArtifactFieldSet.is_applicable(tgt):
-            coordinates.add(coordinate_from_target(tgt))
+            coordinates.add(Coordinate.from_jvm_artifact_target(tgt))
         else:
             other_targets.append(tgt)
 

--- a/src/python/pants/jvm/resolve/jvm_tool.py
+++ b/src/python/pants/jvm/resolve/jvm_tool.py
@@ -26,10 +26,10 @@ from pants.engine.rules import collect_rules, goal_rule, rule
 from pants.engine.target import Targets
 from pants.engine.unions import UnionMembership, union
 from pants.jvm.resolve.coursier_fetch import (
+    ArtifactRequirement,
     ArtifactRequirements,
     Coordinate,
     CoursierResolvedLockfile,
-    RequirementCoordinate,
 )
 from pants.jvm.resolve.key import CoursierResolveKey
 from pants.jvm.target_types import JvmArtifactFieldSet
@@ -239,7 +239,7 @@ async def gather_coordinates_for_jvm_lockfile(
     request: GatherJvmCoordinatesRequest,
 ) -> ArtifactRequirements:
     # Separate `artifact_inputs` by whether the strings parse as an `Address` or not.
-    requirements: set[RequirementCoordinate] = set()
+    requirements: set[ArtifactRequirement] = set()
     candidate_address_inputs: set[AddressInput] = set()
     bad_artifact_inputs = []
     for artifact_input in request.artifact_inputs:
@@ -272,7 +272,7 @@ async def gather_coordinates_for_jvm_lockfile(
     other_targets = []
     for tgt in all_supplied_targets:
         if JvmArtifactFieldSet.is_applicable(tgt):
-            requirements.add(RequirementCoordinate.from_jvm_artifact_target(tgt))
+            requirements.add(ArtifactRequirement.from_jvm_artifact_target(tgt))
         else:
             other_targets.append(tgt)
 

--- a/src/python/pants/jvm/resolve/jvm_tool.py
+++ b/src/python/pants/jvm/resolve/jvm_tool.py
@@ -248,7 +248,7 @@ async def gather_coordinates_for_jvm_lockfile(
         # group name is a file on disk.
         if 2 <= artifact_input.count(":") <= 3:
             try:
-                maybe_coord = Coordinate.from_coord_str(artifact_input).to_requirement_coordinate()
+                maybe_coord = Coordinate.from_coord_str(artifact_input).as_requirement()
                 coordinates.add(maybe_coord)
                 continue
             except Exception:

--- a/src/python/pants/jvm/resolve/jvm_tool.py
+++ b/src/python/pants/jvm/resolve/jvm_tool.py
@@ -30,7 +30,6 @@ from pants.jvm.resolve.coursier_fetch import (
     Coordinate,
     CoursierResolvedLockfile,
     RequirementCoordinate,
-    RequirementCoordinates,
 )
 from pants.jvm.resolve.key import CoursierResolveKey
 from pants.jvm.target_types import JvmArtifactFieldSet
@@ -238,9 +237,9 @@ async def generate_lockfiles_goal(
 @rule
 async def gather_coordinates_for_jvm_lockfile(
     request: GatherJvmCoordinatesRequest,
-) -> RequirementCoordinates:
+) -> ArtifactRequirements:
     # Separate `artifact_inputs` by whether the strings parse as an `Address` or not.
-    coordinates: set[RequirementCoordinate] = set()
+    requirements: set[RequirementCoordinate] = set()
     candidate_address_inputs: set[AddressInput] = set()
     bad_artifact_inputs = []
     for artifact_input in request.artifact_inputs:
@@ -249,7 +248,7 @@ async def gather_coordinates_for_jvm_lockfile(
         if 2 <= artifact_input.count(":") <= 3:
             try:
                 maybe_coord = Coordinate.from_coord_str(artifact_input).as_requirement()
-                coordinates.add(maybe_coord)
+                requirements.add(maybe_coord)
                 continue
             except Exception:
                 pass
@@ -273,7 +272,7 @@ async def gather_coordinates_for_jvm_lockfile(
     other_targets = []
     for tgt in all_supplied_targets:
         if JvmArtifactFieldSet.is_applicable(tgt):
-            coordinates.add(RequirementCoordinate.from_jvm_artifact_target(tgt))
+            requirements.add(RequirementCoordinate.from_jvm_artifact_target(tgt))
         else:
             other_targets.append(tgt)
 
@@ -284,7 +283,7 @@ async def gather_coordinates_for_jvm_lockfile(
             f"option. The problematic addresses are: {', '.join(str(tgt.address) for tgt in other_targets)}."
         )
 
-    return RequirementCoordinates(coordinates)
+    return ArtifactRequirements(requirements)
 
 
 @rule
@@ -316,11 +315,11 @@ async def load_jvm_lockfile(
 async def generate_jvm_lockfile(
     request: JvmToolLockfileRequest,
 ) -> JvmToolLockfile:
-    coordinates = await Get(
-        RequirementCoordinates,
+    requirements = await Get(
+        ArtifactRequirements,
         GatherJvmCoordinatesRequest(request.artifact_inputs, f"[{request.resolve_name}].artifacts"),
     )
-    resolved_lockfile = await Get(CoursierResolvedLockfile, ArtifactRequirements(coordinates))
+    resolved_lockfile = await Get(CoursierResolvedLockfile, ArtifactRequirements, requirements)
     lockfile_content = resolved_lockfile.to_json()
     lockfile_digest = await Get(
         Digest, CreateDigest([FileContent(request.lockfile_dest, lockfile_content)])

--- a/src/python/pants/jvm/resolve/jvm_tool.py
+++ b/src/python/pants/jvm/resolve/jvm_tool.py
@@ -248,9 +248,7 @@ async def gather_coordinates_for_jvm_lockfile(
         # group name is a file on disk.
         if 2 <= artifact_input.count(":") <= 3:
             try:
-                maybe_coord = RequirementCoordinate.from_coordinate(
-                    Coordinate.from_coord_str(artifact_input)
-                )
+                maybe_coord = Coordinate.from_coord_str(artifact_input).to_requirement_coordinate()
                 coordinates.add(maybe_coord)
                 continue
             except Exception:

--- a/src/python/pants/jvm/resolve/jvm_tool_test.py
+++ b/src/python/pants/jvm/resolve/jvm_tool_test.py
@@ -14,7 +14,7 @@ from pants.core.util_rules.external_tool import rules as external_tool_rules
 from pants.engine.fs import Digest, DigestContents
 from pants.engine.rules import SubsystemRule, rule
 from pants.jvm.resolve import jvm_tool
-from pants.jvm.resolve.coursier_fetch import Coordinate, Coordinates
+from pants.jvm.resolve.coursier_fetch import ArtifactRequirements, Coordinate
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.jvm.resolve.jvm_tool import (
@@ -64,7 +64,7 @@ def test_jvm_tool_base_extracts_correct_coordinates() -> None:
             generate_test_tool_lockfile_request,
             SubsystemRule(MockJvmTool),
             QueryRule(JvmToolLockfileRequest, (MockJvmToolLockfileSentinel,)),
-            QueryRule(Coordinates, (GatherJvmCoordinatesRequest,)),
+            QueryRule(ArtifactRequirements, (GatherJvmCoordinatesRequest,)),
             QueryRule(DigestContents, (Digest,)),
         ],
         target_types=[JvmArtifact],
@@ -98,7 +98,7 @@ def test_jvm_tool_base_extracts_correct_coordinates() -> None:
     ]
 
     coordinates = rule_runner.request(
-        Coordinates, [GatherJvmCoordinatesRequest(lockfile_request.artifact_inputs, "")]
+        ArtifactRequirements, [GatherJvmCoordinatesRequest(lockfile_request.artifact_inputs, "")]
     )
     assert sorted(coordinates, key=lambda c: (c.group, c.artifact, c.version)) == [
         Coordinate(group="junit", artifact="junit", version="4.13.2"),

--- a/src/python/pants/jvm/resolve/jvm_tool_test.py
+++ b/src/python/pants/jvm/resolve/jvm_tool_test.py
@@ -97,9 +97,10 @@ def test_jvm_tool_base_extracts_correct_coordinates() -> None:
         "org.hamcrest:hamcrest-core:1.3",
     ]
 
-    coordinates = rule_runner.request(
+    requirements = rule_runner.request(
         ArtifactRequirements, [GatherJvmCoordinatesRequest(lockfile_request.artifact_inputs, "")]
     )
+    coordinates = [i.coordinate for i in requirements]
     assert sorted(coordinates, key=lambda c: (c.group, c.artifact, c.version)) == [
         Coordinate(group="junit", artifact="junit", version="4.13.2"),
         Coordinate(group="org.hamcrest", artifact="hamcrest-core", version="1.3"),


### PR DESCRIPTION
This adds (working) support for local JAR and URL coordinates at resolve and at fetch time. Summary of changes:

* Creates new `ArtifactRequirement` concept, which is used to build up download instructions for Coursier. It stores coordinates, (remote) URLs, and JAR source fields
* Adds a new concept called `CoursierResolveInfo`. This contains a list of coordinate (+url) strings and a Digest containing local JAR files
* Adds URL and JAR address fields to `CoursierResolvedLockfile` and the relevant serialized format. This is used to ensure that the correct JARs are used at fetch time
* Updates `coursier_fetch_one_coord` to use `CoursierResolveInfo` internally


Closes #13840 