### PR TITLE
Fix `.pyi` files not automatically depending on `__init__.py`

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -85,7 +85,7 @@ def test_infer_python_imports(caplog) -> None:
     def run_dep_inference(
         address: Address, *, enable_string_imports: bool = False
     ) -> InferredDependencies:
-        args = ["--backend-packages=pants.backend.python", "--source-root-patterns=src/python"]
+        args = ["--source-root-patterns=src/python"]
         if enable_string_imports:
             args.append("--python-infer-string-imports")
         rule_runner.set_options(args, env_inherit={"PATH", "PYENV_ROOT", "HOME"})
@@ -167,11 +167,7 @@ def test_infer_python_inits() -> None:
         target_types=[PythonSourcesGeneratorTarget],
     )
     rule_runner.set_options(
-        [
-            "--backend-packages=pants.backend.python",
-            "--python-infer-inits",
-            "--source-root-patterns=src/python",
-        ],
+        ["--python-infer-inits", "--source-root-patterns=src/python"],
         env_inherit={"PATH", "PYENV_ROOT", "HOME"},
     )
 
@@ -184,6 +180,9 @@ def test_infer_python_inits() -> None:
             "src/python/root/mid/leaf/__init__.py": "",
             "src/python/root/mid/leaf/f.py": "",
             "src/python/root/mid/leaf/BUILD": "python_sources()",
+            "src/python/type_stub/__init__.pyi": "",
+            "src/python/type_stub/foo.pyi": "",
+            "src/python/type_stub/BUILD": "python_sources()",
         }
     )
 
@@ -203,6 +202,9 @@ def test_infer_python_inits() -> None:
             Address("src/python/root/mid/leaf", relative_file_path="__init__.py"),
         ],
     )
+    assert run_dep_inference(
+        Address("src/python/type_stub", relative_file_path="foo.pyi")
+    ) == InferredDependencies([Address("src/python/type_stub", relative_file_path="__init__.pyi")])
 
 
 def test_infer_python_conftests() -> None:
@@ -281,7 +283,6 @@ def test_infer_python_strict(caplog) -> None:
     ) -> InferredDependencies:
         rule_runner.set_options(
             [
-                "--backend-packages=pants.backend.python",
                 f"--python-infer-unowned-dependency-behavior={unowned_dependency_behavior}",
                 "--source-root-patterns=src/python",
             ],

--- a/src/python/pants/backend/python/util_rules/ancestor_files.py
+++ b/src/python/pants/backend/python/util_rules/ancestor_files.py
@@ -3,30 +3,21 @@
 
 import os
 from dataclasses import dataclass
-from typing import Sequence, Set
 
 from pants.engine.fs import EMPTY_SNAPSHOT, PathGlobs, Snapshot
 from pants.engine.rules import Get, collect_rules, rule
-from pants.util.ordered_set import FrozenOrderedSet
 
 
 @dataclass(frozen=True)
 class AncestorFilesRequest:
-    """A request for ancestor files of a given name.
+    """A request for ancestor files of the given names.
 
-    "Ancestor files" for name foobar means all files of that name that are siblings of,
-    or in parent directories of, a .py file in the snapshot.
-
-    This is useful when the presence of such ancestor files has semantic meaning.
-    For example, ancestor __init__.py files denote packages, and ancestor conftest.py
-    files denote pytest configuration.
-
-    This allows us to pull in these files without requiring explicit or implicit
-    dependencies on them.
+    "Ancestor files" means all files with one of the given names that are siblings of, or in parent
+    directories of, a `.py` or `.pyi` file in the input_files.
     """
 
-    name: str
-    snapshot: Snapshot
+    input_files: tuple[str]
+    requested: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -36,7 +27,7 @@ class AncestorFiles:
     snapshot: Snapshot
 
 
-def identify_missing_ancestor_files(name: str, sources: Sequence[str]) -> FrozenOrderedSet[str]:
+def putative_ancestor_files(input_files: tuple[str, ...], requested: tuple[str, ...]) -> set[str]:
     """Return the paths of potentially missing ancestor files.
 
     NB: The sources are expected to not have had their source roots stripped.
@@ -44,11 +35,11 @@ def identify_missing_ancestor_files(name: str, sources: Sequence[str]) -> Frozen
     (e.g., src/python/<name>, src/<name>). It is the caller's responsibility to filter these
     out if necessary.
     """
-    packages: Set[str] = set()
-    for source in sources:
-        if not source.endswith(".py"):
+    packages: set[str] = set()
+    for input_file in input_files:
+        if not input_file.endswith((".py", ".pyi")):
             continue
-        pkg_dir = os.path.dirname(source)
+        pkg_dir = os.path.dirname(input_file)
         if pkg_dir in packages:
             continue
         package = ""
@@ -57,20 +48,19 @@ def identify_missing_ancestor_files(name: str, sources: Sequence[str]) -> Frozen
             package = os.path.join(package, component)
             packages.add(package)
 
-    return FrozenOrderedSet(
-        sorted({os.path.join(package, name) for package in packages} - set(sources))
-    )
+    return {
+        os.path.join(package, requested_f) for package in packages for requested_f in requested
+    } - set(input_files)
 
 
 @rule
-async def find_missing_ancestor_files(request: AncestorFilesRequest) -> AncestorFiles:
-    """Find any named ancestor files that exist on the filesystem but are not in the snapshot."""
-    missing_ancestor_files = identify_missing_ancestor_files(request.name, request.snapshot.files)
-    if not missing_ancestor_files:
+async def find_ancestor_files(request: AncestorFilesRequest) -> AncestorFiles:
+    putative = putative_ancestor_files(request.input_files, request.requested)
+    if not putative:
         return AncestorFiles(EMPTY_SNAPSHOT)
 
     # NB: This will intentionally _not_ error on any unmatched globs.
-    discovered_ancestors_snapshot = await Get(Snapshot, PathGlobs(missing_ancestor_files))
+    discovered_ancestors_snapshot = await Get(Snapshot, PathGlobs(putative))
     return AncestorFiles(discovered_ancestors_snapshot)
 
 

--- a/src/python/pants/backend/python/util_rules/ancestor_files.py
+++ b/src/python/pants/backend/python/util_rules/ancestor_files.py
@@ -18,7 +18,7 @@ class AncestorFilesRequest:
     directories of, a `.py` or `.pyi` file in the input_files.
     """
 
-    input_files: tuple[str]
+    input_files: tuple[str, ...]
     requested: tuple[str, ...]
 
 

--- a/src/python/pants/backend/python/util_rules/ancestor_files.py
+++ b/src/python/pants/backend/python/util_rules/ancestor_files.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import os
 from dataclasses import dataclass
 

--- a/src/python/pants/backend/python/util_rules/ancestor_files_test.py
+++ b/src/python/pants/backend/python/util_rules/ancestor_files_test.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import pytest
 
 from pants.backend.python.util_rules import ancestor_files

--- a/src/python/pants/backend/python/util_rules/ancestor_files_test.py
+++ b/src/python/pants/backend/python/util_rules/ancestor_files_test.py
@@ -1,15 +1,13 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import List
-
 import pytest
 
 from pants.backend.python.util_rules import ancestor_files
 from pants.backend.python.util_rules.ancestor_files import (
     AncestorFiles,
     AncestorFilesRequest,
-    identify_missing_ancestor_files,
+    putative_ancestor_files,
 )
 from pants.engine.fs import DigestContents
 from pants.testutil.rule_runner import QueryRule, RuleRunner
@@ -28,16 +26,20 @@ def rule_runner() -> RuleRunner:
 def assert_injected(
     rule_runner: RuleRunner,
     *,
-    source_roots: List[str],
-    original_declared_files: List[str],
-    original_undeclared_files: List[str],
-    expected_discovered: List[str],
+    source_roots: list[str],
+    original_declared_files: list[str],
+    original_undeclared_files: list[str],
+    expected_discovered: list[str],
 ) -> None:
     rule_runner.set_options([f"--source-root-patterns={source_roots}"])
-    rule_runner.write_files({f: "# undeclared" for f in original_undeclared_files})
+    rule_runner.write_files(
+        {
+            **{f: "# undeclared" for f in original_undeclared_files},
+            **{f: "# declared" for f in original_declared_files},
+        }
+    )
     request = AncestorFilesRequest(
-        "__init__.py",
-        rule_runner.make_snapshot({fp: "# declared" for fp in original_declared_files}),
+        requested=("__init__.py",), input_files=tuple(original_declared_files)
     )
     result = rule_runner.request(AncestorFiles, [request]).snapshot
     assert list(result.files) == sorted(expected_discovered)
@@ -90,10 +92,14 @@ def test_unstripped_source_root_at_buildroot(rule_runner: RuleRunner) -> None:
 
 
 def test_identify_missing_ancestor_files() -> None:
-    assert {"__init__.py", "a/__init__.py", "a/b/__init__.py", "a/b/c/d/__init__.py"} == set(
-        identify_missing_ancestor_files(
-            "__init__.py", ["a/b/foo.py", "a/b/c/__init__.py", "a/b/c/d/bar.py", "a/e/__init__.py"]
-        )
+    assert {
+        "__init__.py",
+        "a/__init__.py",
+        "a/b/__init__.py",
+        "a/b/c/d/__init__.py",
+    } == putative_ancestor_files(
+        requested=("__init__.py",),
+        input_files=("a/b/foo.py", "a/b/c/__init__.py", "a/b/c/d/bar.py", "a/e/__init__.py"),
     )
 
     assert {
@@ -103,14 +109,22 @@ def test_identify_missing_ancestor_files() -> None:
         "src/python/a/__init__.py",
         "src/python/a/b/__init__.py",
         "src/python/a/b/c/d/__init__.py",
-    } == set(
-        identify_missing_ancestor_files(
-            "__init__.py",
-            [
-                "src/python/a/b/foo.py",
-                "src/python/a/b/c/__init__.py",
-                "src/python/a/b/c/d/bar.py",
-                "src/python/a/e/__init__.py",
-            ],
-        )
+    } == putative_ancestor_files(
+        requested=("__init__.py",),
+        input_files=(
+            "src/python/a/b/foo.py",
+            "src/python/a/b/c/__init__.py",
+            "src/python/a/b/c/d/bar.py",
+            "src/python/a/e/__init__.py",
+        ),
     )
+
+    assert putative_ancestor_files(requested=("f.py", "f.pyi"), input_files=("subdir/foo.py",)) == {
+        "f.py",
+        "f.pyi",
+        "subdir/f.py",
+        "subdir/f.pyi",
+    }
+    assert putative_ancestor_files(
+        requested=("f.py", "f.pyi"), input_files=("subdir/foo.pyi",)
+    ) == {"f.py", "f.pyi", "subdir/f.py", "subdir/f.pyi"}

--- a/src/python/pants/backend/python/util_rules/python_sources.py
+++ b/src/python/pants/backend/python/util_rules/python_sources.py
@@ -96,12 +96,12 @@ async def prepare_python_sources(
 
     missing_init_files = await Get(
         AncestorFiles,
-        AncestorFilesRequest("__init__.py", sources.snapshot),
+        AncestorFilesRequest(
+            input_files=sources.snapshot.files, requested=("__init__.py", "__init__.pyi")
+        ),
     )
-
     init_injected = await Get(
-        Snapshot,
-        MergeDigests((sources.snapshot.digest, missing_init_files.snapshot.digest)),
+        Snapshot, MergeDigests((sources.snapshot.digest, missing_init_files.snapshot.digest))
     )
 
     # Codegen is able to generate code in any arbitrary location, unlike sources normally being

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -974,7 +974,8 @@ async def resolve_dependencies(
         relevant_inference_request_types = [
             inference_request_type
             for inference_request_type in inference_request_types
-            if isinstance(sources_field, inference_request_type.infer_from)
+            # NB: `type: ignore`d due to https://github.com/python/mypy/issues/9815.
+            if isinstance(sources_field, inference_request_type.infer_from)  # type: ignore[misc]
         ]
         inferred = await MultiGet(
             Get(

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -2177,9 +2177,12 @@ class InjectedDependencies(DeduplicatedCollection[Address]):
     sort_input = True
 
 
+SF = TypeVar("SF", bound="SourcesField")
+
+
 @union
 @dataclass(frozen=True)
-class InferDependenciesRequest(EngineAwareParameter):
+class InferDependenciesRequest(Generic[SF], EngineAwareParameter):
     """A request to infer dependencies by analyzing source files.
 
     To set up a new inference implementation, subclass this class. Set the class property
@@ -2209,8 +2212,8 @@ class InferDependenciesRequest(EngineAwareParameter):
             ]
     """
 
-    sources_field: SourcesField
-    infer_from: ClassVar[type[SourcesField]]
+    sources_field: SF
+    infer_from: ClassVar[Type[SF]]
 
     def debug_hint(self) -> str:
         return self.sources_field.address.spec

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1769,6 +1769,20 @@ class SingleSourceField(SourcesField, StringField):
         return value_or_default
 
     @property
+    def file_path(self) -> str | None:
+        """The path to the file, relative to the build root.
+
+        This works without hydration because we validate that `*` globs and `!` ignores are not
+        used. However, consider still hydrating so that you verify the source file actually exists.
+
+        The return type is optional because it's possible to have 0-1 files. Most subclasses
+        will have 1 file, though.
+        """
+        if self.value is None:
+            return None
+        return os.path.join(self.address.spec_path, self.value)
+
+    @property
     def globs(self) -> tuple[str, ...]:
         # Subclasses might override `required = False`, so `self.value` could be `None`.
         if self.value is None:

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -1164,6 +1164,15 @@ def test_single_source_path_globs(
             assert getattr(actual, attr) == expect
 
 
+def test_single_source_file_path() -> None:
+    class TestSingleSourceField(SingleSourceField):
+        required = False
+        expected_num_files = range(0, 2)
+
+    assert TestSingleSourceField(None, Address("project")).file_path is None
+    assert TestSingleSourceField("f.ext", Address("project")).file_path == "project/f.ext"
+
+
 def test_single_source_field_bans_globs() -> None:
     class TestSingleSourceField(SingleSourceField):
         pass


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/13654. We were skipping automatically including `__init__.py` because we incorrectly short-circuited if a source file ended in `.pyi` instead of `.py`. 

We also were not automatically adding dependencies on `__init__.pyi` files.

Finally, this simplifies `AncestorFilesRequest` to take `tuple[str, ...]` as input files, rather than `Snapshot`. That allows us to avoid having to call `HydrateSources` for the `conftest` and `__init__` dependency inference rules. We can simply look at the target's source field to determine what the input file is, which is faster.

[ci skip-rust]
[ci skip-build-wheels]