### PR TITLE
[internal] jvm: remove use of `sed` in runner script

### DIFF
--- a/src/python/pants/jvm/resolve/coursier_setup.py
+++ b/src/python/pants/jvm/resolve/coursier_setup.py
@@ -146,7 +146,7 @@ async def setup_coursier(
         working_dir="$(pwd)"
         "$coursier_exe" fetch {repos_args} \
           --json-output-file="$json_output_file" \
-          "$@//{Coursier.working_directory_placeholder}/$working_dir"
+          "${{@//{Coursier.working_directory_placeholder}/$working_dir}}"
         /bin/mkdir -p classpath
         {python.path} coursier_post_processing_script.py "$json_output_file"
         """

--- a/src/python/pants/jvm/resolve/coursier_setup.py
+++ b/src/python/pants/jvm/resolve/coursier_setup.py
@@ -143,12 +143,10 @@ async def setup_coursier(
         json_output_file="$1"
         shift
 
-        WORKING_DIRECTORY=$(pwd)
-        ARGS=$*
-        ARGS=$(echo $ARGS | /usr/bin/sed 's|{Coursier.working_directory_placeholder}|'$WORKING_DIRECTORY'|g')
-
-
-        "$coursier_exe" fetch {repos_args} --json-output-file="$json_output_file" $ARGS
+        working_dir="$(pwd)"
+        "$coursier_exe" fetch {repos_args} \
+          --json-output-file="$json_output_file" \
+          "$@/{Coursier.working_directory_placeholder}/$working_dir"
         /bin/mkdir -p classpath
         {python.path} coursier_post_processing_script.py "$json_output_file"
         """

--- a/src/python/pants/jvm/resolve/coursier_setup.py
+++ b/src/python/pants/jvm/resolve/coursier_setup.py
@@ -146,7 +146,7 @@ async def setup_coursier(
         working_dir="$(pwd)"
         "$coursier_exe" fetch {repos_args} \
           --json-output-file="$json_output_file" \
-          "$@/{Coursier.working_directory_placeholder}/$working_dir"
+          "$@//{Coursier.working_directory_placeholder}/$working_dir"
         /bin/mkdir -p classpath
         {python.path} coursier_post_processing_script.py "$json_output_file"
         """


### PR DESCRIPTION
https://github.com/pantsbuild/pants/commit/f6a46d7ff59454082a307b76f2db746cab50bd69#diff-76ff768034c27d10ead2f3f5964157f511dae025e790ec007ef88239da6e4d57R148 breaks on systems where `sed` is not at the exact path given in the script.

Let's use bash pattern substitution syntax. It works even if there is a `/` in the replacement string:

```
$ args=( "FOO/bar/ha"  "FOO/hello/world" )
$ echo "${args[@]}"
FOO/bar/ha FOO/hello/world
$ echo "${args[@]/FOO/BAR}"
BAR/bar/ha BAR/hello/world
$ echo "${args[@]/FOO/BAR/HA}"
BAR/HA/bar/ha BAR/HA/hello/world
$ repl="/BAR/HA"
$ echo "${args[@]/FOO/$repl}"
/BAR/HA/bar/ha /BAR/HA/hello/world
```

[ci skip-rust]

