### PR TITLE
Turns off validation for unset `SourceFiles` fields if `required=False`

### DIFF
--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1578,7 +1578,8 @@ class SourcesField(AsyncFieldMixin, Field):
         """
 
         if not self.required and not self.value:
-            # #13851 if value is not set, validation results are spurious
+            # If this field isn't required or set, validation is done against the default value
+            # which is probably not valuable (See #13851).
             return None
 
         if self.expected_file_extensions is not None:

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1576,6 +1576,11 @@ class SourcesField(AsyncFieldMixin, Field):
         To enforce that there are only a certain number of resulting files, such as binary targets
         checking for only 0-1 sources, set the class property `expected_num_files`.
         """
+
+        if not self.required and not self.value:
+            # #13851 if value is not set, validation results are spurious
+            return None
+
         if self.expected_file_extensions is not None:
             bad_files = [
                 fp for fp in files if not PurePath(fp).suffix in self.expected_file_extensions


### PR DESCRIPTION
Closes #13851.