### PR TITLE
[internal] Add support for materializing directory structures as read-only

### DIFF
--- a/src/rust/engine/fs/brfs/src/tests.rs
+++ b/src/rust/engine/fs/brfs/src/tests.rs
@@ -203,7 +203,7 @@ async fn files_are_correctly_executable() {
     Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
 
   let treat_bytes = TestData::catnip();
-  let directory = TestDirectory::with_mixed_executable_files();
+  let directory = TestDirectory::with_maybe_executable_files(true);
 
   store
     .store_file_bytes(treat_bytes.bytes(), false)

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -35,7 +35,8 @@ use std::time::Duration;
 use bytes::Bytes;
 use clap::{value_t, App, Arg, SubCommand};
 use fs::{
-  GlobExpansionConjunction, GlobMatching, PreparedPathGlobs, RelativePath, StrictGlobMatching,
+  GlobExpansionConjunction, GlobMatching, Permissions, PreparedPathGlobs, RelativePath,
+  StrictGlobMatching,
 };
 use futures::future::{self, BoxFuture};
 use futures::FutureExt;
@@ -520,7 +521,7 @@ async fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
         let output_digest =
           output_digest_opt.ok_or_else(|| ExitError("not found".into(), ExitCode::NotFound))?;
         store
-          .materialize_directory(destination, output_digest)
+          .materialize_directory(destination, output_digest, Permissions::Writable)
           .await
           .map_err(|err| {
             if err.contains("not found") {
@@ -543,7 +544,7 @@ async fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
           .expect("size_bytes must be a non-negative number");
         let digest = Digest::new(fingerprint, size_bytes);
         store
-          .materialize_directory(destination, digest)
+          .materialize_directory(destination, digest, Permissions::Writable)
           .await
           .map_err(|err| {
             if err.contains("not found") {

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -73,6 +73,13 @@ pub fn default_cache_path() -> PathBuf {
   cache_path.join("pants")
 }
 
+/// Simplified filesystem Permissions.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum Permissions {
+  ReadOnly,
+  Writable,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash, Serialize)]
 pub struct RelativePath(PathBuf);
 

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -74,7 +74,7 @@ pub fn default_cache_path() -> PathBuf {
 }
 
 /// Simplified filesystem Permissions.
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Permissions {
   ReadOnly,
   Writable,

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
 use fs::{
   self, safe_create_dir_all_ioerror, GlobExpansionConjunction, GlobMatching, PathGlobs,
-  RelativePath, StrictGlobMatching,
+  Permissions, RelativePath, StrictGlobMatching,
 };
 use futures::future::{BoxFuture, FutureExt, TryFutureExt};
 use futures::stream::{BoxStream, StreamExt, TryStreamExt};
@@ -640,7 +640,7 @@ pub async fn prepare_workdir(
     },
     |_workunit| async move {
       store2
-        .materialize_directory(workdir_path_2, input_digest)
+        .materialize_directory(workdir_path_2, input_digest, Permissions::Writable)
         .await
     },
   )

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -32,7 +32,7 @@ use std::path::PathBuf;
 use std::process::exit;
 use std::time::Duration;
 
-use fs::RelativePath;
+use fs::{Permissions, RelativePath};
 use hashing::{Digest, Fingerprint, EMPTY_DIGEST};
 use process_execution::{
   Context, InputDigests, NamedCaches, Platform, ProcessCacheScope, ProcessMetadata,
@@ -340,7 +340,7 @@ async fn main() {
 
   if let Some(output) = args.materialize_output_to {
     store
-      .materialize_directory(output, result.output_directory)
+      .materialize_directory(output, result.output_directory, Permissions::Writable)
       .await
       .unwrap();
   }

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1442,9 +1442,11 @@ fn write_digest(
     destination.push(path_prefix);
 
     block_in_place_and_wait(py, || {
-      core
-        .store()
-        .materialize_directory(destination.clone(), lifted_digest)
+      core.store().materialize_directory(
+        destination.clone(),
+        lifted_digest,
+        fs::Permissions::Writable,
+      )
     })
     .map_err(PyValueError::new_err)
   })

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -19,7 +19,7 @@ use crate::tasks::Intrinsic;
 use crate::types::Types;
 use crate::Failure;
 
-use fs::{safe_create_dir_all_ioerror, PreparedPathGlobs, RelativePath};
+use fs::{safe_create_dir_all_ioerror, Permissions, PreparedPathGlobs, RelativePath};
 use futures::future::{self, BoxFuture, FutureExt, TryFutureExt};
 use hashing::{Digest, EMPTY_DIGEST};
 use indexmap::IndexMap;
@@ -604,7 +604,7 @@ fn interactive_process(
       context
         .core
         .store()
-        .materialize_directory(destination, input_digest)
+        .materialize_directory(destination, input_digest, Permissions::Writable)
         .await?;
     }
 

--- a/src/rust/engine/testutil/src/data.rs
+++ b/src/rust/engine/testutil/src/data.rs
@@ -57,6 +57,7 @@ impl TestData {
   }
 }
 
+#[derive(Clone)]
 pub struct TestDirectory {
   pub directory: remexec::Directory,
 }
@@ -256,10 +257,18 @@ impl TestDirectory {
   // /cats/roland.ext
   // /treats.ext
   pub fn recursive() -> TestDirectory {
+    Self::recursive_with(TestDirectory::containing_roland())
+  }
+
+  // Directory structure:
+  //
+  // /cats/(param)
+  // /treats.ext
+  pub fn recursive_with(inner: TestDirectory) -> TestDirectory {
     let directory = remexec::Directory {
       directories: vec![remexec::DirectoryNode {
         name: "cats".to_owned(),
-        digest: Some((&TestDirectory::containing_roland().digest()).into()),
+        digest: Some((&inner.digest()).into()),
       }],
       files: vec![remexec::FileNode {
         name: "treats.ext".to_owned(),
@@ -273,15 +282,15 @@ impl TestDirectory {
 
   // Directory structure:
   //
-  // /feed.ext (executable)
-  // /food.ext
-  pub fn with_mixed_executable_files() -> TestDirectory {
+  // /feed.ext (is_executable=?)
+  // /food.ext (is_executable=False)
+  pub fn with_maybe_executable_files(is_executable: bool) -> TestDirectory {
     let directory = remexec::Directory {
       files: vec![
         remexec::FileNode {
           name: "feed.ext".to_owned(),
           digest: Some((&TestData::catnip().digest()).into()),
-          is_executable: true,
+          is_executable,
           ..remexec::FileNode::default()
         },
         remexec::FileNode {


### PR DESCRIPTION
To make #13848 more rigorous, directory structures that are created for use as immutable inputs should be created as readonly. This change adds support to `materialize_directory` for creating files/directories as readonly.

[ci skip-build-wheels]