### PR TITLE
Fix `.pyi` files not automatically depending on `__init__.py` (cherrypick of #13844)

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -24,8 +24,6 @@ from pants.engine.target import (
     Dependencies,
     DependenciesRequest,
     ExplicitlyProvidedDependencies,
-    HydratedSources,
-    HydrateSourcesRequest,
     InferDependenciesRequest,
     InferredDependencies,
     WrappedTarget,
@@ -191,20 +189,13 @@ async def infer_python_init_dependencies(
     if not python_infer_subsystem.inits:
         return InferredDependencies([])
 
-    # Locate __init__.py files not already in the Snapshot.
-    hydrated_sources = await Get(HydratedSources, HydrateSourcesRequest(request.sources_field))
-    extra_init_files = await Get(
+    fp = request.sources_field.file_path
+    assert fp is not None
+    init_files = await Get(
         AncestorFiles,
-        AncestorFilesRequest("__init__.py", hydrated_sources.snapshot),
+        AncestorFilesRequest(input_files=(fp,), requested=("__init__.py", "__init__.pyi")),
     )
-
-    # And add dependencies on their owners.
-    # NB: Because the python_sources rules always locate __init__.py files, and will trigger an
-    # error for files that have content but have not already been included via a dependency, we
-    # don't need to error for unowned files here.
-    owners = await MultiGet(
-        Get(Owners, OwnersRequest((f,))) for f in extra_init_files.snapshot.files
-    )
+    owners = await MultiGet(Get(Owners, OwnersRequest((f,))) for f in init_files.snapshot.files)
     return InferredDependencies(itertools.chain.from_iterable(owners))
 
 
@@ -220,18 +211,17 @@ async def infer_python_conftest_dependencies(
     if not python_infer_subsystem.conftests:
         return InferredDependencies([])
 
-    # Locate conftest.py files not already in the Snapshot.
-    hydrated_sources = await Get(HydratedSources, HydrateSourcesRequest(request.sources_field))
-    extra_conftest_files = await Get(
+    fp = request.sources_field.file_path
+    assert fp is not None
+    conftest_files = await Get(
         AncestorFiles,
-        AncestorFilesRequest("conftest.py", hydrated_sources.snapshot),
+        AncestorFilesRequest(input_files=(fp,), requested=("conftest.py",)),
     )
-
-    # And add dependencies on their owners.
-    # NB: Because conftest.py files effectively always have content, we require an owning target.
     owners = await MultiGet(
+        # NB: Because conftest.py files effectively always have content, we require an
+        # owning target.
         Get(Owners, OwnersRequest((f,), OwnersNotFoundBehavior.error))
-        for f in extra_conftest_files.snapshot.files
+        for f in conftest_files.snapshot.files
     )
     return InferredDependencies(itertools.chain.from_iterable(owners))
 

--- a/src/python/pants/backend/python/util_rules/ancestor_files.py
+++ b/src/python/pants/backend/python/util_rules/ancestor_files.py
@@ -1,32 +1,25 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import os
 from dataclasses import dataclass
-from typing import Sequence, Set
 
 from pants.engine.fs import EMPTY_SNAPSHOT, PathGlobs, Snapshot
 from pants.engine.rules import Get, collect_rules, rule
-from pants.util.ordered_set import FrozenOrderedSet
 
 
 @dataclass(frozen=True)
 class AncestorFilesRequest:
-    """A request for ancestor files of a given name.
+    """A request for ancestor files of the given names.
 
-    "Ancestor files" for name foobar means all files of that name that are siblings of,
-    or in parent directories of, a .py file in the snapshot.
-
-    This is useful when the presence of such ancestor files has semantic meaning.
-    For example, ancestor __init__.py files denote packages, and ancestor conftest.py
-    files denote pytest configuration.
-
-    This allows us to pull in these files without requiring explicit or implicit
-    dependencies on them.
+    "Ancestor files" means all files with one of the given names that are siblings of, or in parent
+    directories of, a `.py` or `.pyi` file in the input_files.
     """
 
-    name: str
-    snapshot: Snapshot
+    input_files: tuple[str, ...]
+    requested: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -36,7 +29,7 @@ class AncestorFiles:
     snapshot: Snapshot
 
 
-def identify_missing_ancestor_files(name: str, sources: Sequence[str]) -> FrozenOrderedSet[str]:
+def putative_ancestor_files(input_files: tuple[str, ...], requested: tuple[str, ...]) -> set[str]:
     """Return the paths of potentially missing ancestor files.
 
     NB: The sources are expected to not have had their source roots stripped.
@@ -44,11 +37,11 @@ def identify_missing_ancestor_files(name: str, sources: Sequence[str]) -> Frozen
     (e.g., src/python/<name>, src/<name>). It is the caller's responsibility to filter these
     out if necessary.
     """
-    packages: Set[str] = set()
-    for source in sources:
-        if not source.endswith(".py"):
+    packages: set[str] = set()
+    for input_file in input_files:
+        if not input_file.endswith((".py", ".pyi")):
             continue
-        pkg_dir = os.path.dirname(source)
+        pkg_dir = os.path.dirname(input_file)
         if pkg_dir in packages:
             continue
         package = ""
@@ -57,20 +50,19 @@ def identify_missing_ancestor_files(name: str, sources: Sequence[str]) -> Frozen
             package = os.path.join(package, component)
             packages.add(package)
 
-    return FrozenOrderedSet(
-        sorted({os.path.join(package, name) for package in packages} - set(sources))
-    )
+    return {
+        os.path.join(package, requested_f) for package in packages for requested_f in requested
+    } - set(input_files)
 
 
 @rule
-async def find_missing_ancestor_files(request: AncestorFilesRequest) -> AncestorFiles:
-    """Find any named ancestor files that exist on the filesystem but are not in the snapshot."""
-    missing_ancestor_files = identify_missing_ancestor_files(request.name, request.snapshot.files)
-    if not missing_ancestor_files:
+async def find_ancestor_files(request: AncestorFilesRequest) -> AncestorFiles:
+    putative = putative_ancestor_files(request.input_files, request.requested)
+    if not putative:
         return AncestorFiles(EMPTY_SNAPSHOT)
 
     # NB: This will intentionally _not_ error on any unmatched globs.
-    discovered_ancestors_snapshot = await Get(Snapshot, PathGlobs(missing_ancestor_files))
+    discovered_ancestors_snapshot = await Get(Snapshot, PathGlobs(putative))
     return AncestorFiles(discovered_ancestors_snapshot)
 
 

--- a/src/python/pants/backend/python/util_rules/python_sources.py
+++ b/src/python/pants/backend/python/util_rules/python_sources.py
@@ -96,12 +96,12 @@ async def prepare_python_sources(
 
     missing_init_files = await Get(
         AncestorFiles,
-        AncestorFilesRequest("__init__.py", sources.snapshot),
+        AncestorFilesRequest(
+            input_files=sources.snapshot.files, requested=("__init__.py", "__init__.pyi")
+        ),
     )
-
     init_injected = await Get(
-        Snapshot,
-        MergeDigests((sources.snapshot.digest, missing_init_files.snapshot.digest)),
+        Snapshot, MergeDigests((sources.snapshot.digest, missing_init_files.snapshot.digest))
     )
 
     # Codegen is able to generate code in any arbitrary location, unlike sources normally being

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -936,7 +936,8 @@ async def resolve_dependencies(
         relevant_inference_request_types = [
             inference_request_type
             for inference_request_type in inference_request_types
-            if isinstance(sources_field, inference_request_type.infer_from)
+            # NB: `type: ignore`d due to https://github.com/python/mypy/issues/9815.
+            if isinstance(sources_field, inference_request_type.infer_from)  # type: ignore[misc]
         ]
         inferred = await MultiGet(
             Get(

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -1008,6 +1008,15 @@ def test_targets_with_sources_types() -> None:
     assert set(result) == {tgt2}
 
 
+def test_single_source_file_path() -> None:
+    class TestSingleSourceField(SingleSourceField):
+        required = False
+        expected_num_files = range(0, 2)
+
+    assert TestSingleSourceField(None, Address("project")).file_path is None
+    assert TestSingleSourceField("f.ext", Address("project")).file_path == "project/f.ext"
+
+
 def test_single_source_field_bans_globs() -> None:
     class TestSingleSourceField(SingleSourceField):
         pass


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/13654. We were skipping automatically including `__init__.py` because we incorrectly short-circuited if a source file ended in `.pyi` instead of `.py`.

We also were not automatically adding dependencies on `__init__.pyi` files.

Finally, this simplifies `AncestorFilesRequest` to take `tuple[str, ...]` as input files, rather than `Snapshot`. That allows us to avoid having to call `HydrateSources` for the `conftest` and `__init__` dependency inference rules. We can simply look at the target's source field to determine what the input file is, which is faster.

[ci skip-rust]
[ci skip-build-wheels]