### PR TITLE
[internal] Intern using a Python dict, and remove reverse mapping

### DIFF
--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -544,12 +544,12 @@ fn strongly_connected_components(
   for (node, adjacency_list) in adjacency_lists {
     let node_key = Key::from_value(node.into())?;
     let node_id = *node_ids
-      .entry(node_key)
+      .entry(node_key.clone())
       .or_insert_with(|| graph.add_node(node_key));
     for dependency in adjacency_list {
       let dependency_key = Key::from_value(dependency.into())?;
       let dependency_id = node_ids
-        .entry(dependency_key)
+        .entry(dependency_key.clone())
         .or_insert_with(|| graph.add_node(dependency_key));
       graph.add_edge(node_id, *dependency_id, ());
     }

--- a/src/rust/engine/src/interning.rs
+++ b/src/rust/engine/src/interning.rs
@@ -63,12 +63,12 @@ impl Interns {
     py.allow_threads(|| {
       let mut forward_keys = self.forward_keys.lock();
       let key = if let Some(key) = forward_keys.get(&intern_key) {
-        *key
+        key.clone()
       } else {
         let id = self.id_generator.fetch_add(1, atomic::Ordering::Relaxed);
         let key = Key::new(id, type_id);
-        self.reverse_keys.write().insert(key, v);
-        forward_keys.insert(intern_key, key);
+        self.reverse_keys.write().insert(key.clone(), v);
+        forward_keys.insert(intern_key, key.clone());
         key
       };
       Ok(key)

--- a/src/rust/engine/src/interning.rs
+++ b/src/rust/engine/src/interning.rs
@@ -1,15 +1,12 @@
 // Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-use std::collections::HashMap;
-use std::hash;
 use std::sync::atomic;
 
-use parking_lot::{Mutex, RwLock};
 use pyo3::prelude::*;
+use pyo3::types::PyDict;
 
-use crate::externs;
-use crate::python::{Fnv, Key};
+use crate::python::{Key, TypeId};
 
 ///
 /// A struct that encapsulates interning of python `Value`s as comparable `Key`s.
@@ -39,75 +36,34 @@ use crate::python::{Fnv, Key};
 /// it before acquiring inner locks. That way we can guarantee that these locks are always acquired
 /// before the GIL (Value equality in particular might re-acquire it).
 ///
-#[derive(Default)]
 pub struct Interns {
-  forward_keys: Mutex<HashMap<InternKey, Key, Fnv>>,
-  reverse_keys: RwLock<HashMap<Key, PyObject, Fnv>>,
+  // A mapping between Python objects and integer ids.
+  keys: Py<PyDict>,
   id_generator: atomic::AtomicU64,
 }
 
 impl Interns {
-  pub fn new() -> Interns {
-    Interns::default()
+  pub fn new() -> Self {
+    Self {
+      keys: Python::with_gil(|py| PyDict::new(py).into()),
+      id_generator: atomic::AtomicU64::default(),
+    }
   }
 
   pub fn key_insert(&self, py: Python, v: PyObject) -> PyResult<Key> {
-    let (intern_key, type_id) = {
-      let obj = v.as_ref(py);
-      (
-        InternKey(obj.hash()?, v.clone_ref(py)),
-        obj.get_type().into(),
-      )
-    };
-
-    py.allow_threads(|| {
-      let mut forward_keys = self.forward_keys.lock();
-      let key = if let Some(key) = forward_keys.get(&intern_key) {
-        key.clone()
+    let (id, type_id): (u64, TypeId) = {
+      let v = v.as_ref(py);
+      let keys = self.keys.as_ref(py);
+      let id: u64 = if let Some(key) = keys.get_item(v) {
+        key.extract()?
       } else {
         let id = self.id_generator.fetch_add(1, atomic::Ordering::Relaxed);
-        let key = Key::new(id, type_id);
-        self.reverse_keys.write().insert(key.clone(), v);
-        forward_keys.insert(intern_key, key.clone());
-        key
+        keys.set_item(v, id)?;
+        id
       };
-      Ok(key)
-    })
-  }
+      (id, v.get_type().into())
+    };
 
-  pub fn key_get(&self, k: &Key) -> PyObject {
-    // NB: We do not need to acquire+release the GIL before getting a Value for a Key, because
-    // neither `Key::eq` nor `Value::clone` acquire the GIL.
-    self.reverse_keys.read().get(k).cloned().unwrap_or_else(|| {
-      // N.B.: This panic is effectively an assertion that `Key::new` is only ever called above in
-      // `key_insert` under an exclusive lock where it is then inserted in `reverse_keys` before
-      // exiting the lock and being returned to the caller. This ensures that all `Key`s in the
-      // wild _must_ be in `reverse_keys`. As such, the code involved in generating the panic
-      // message should be immaterial and never fire. If it does fire though, then the assertion
-      // was proven incorrect and the `Key` is not, in fact, in `reverse_keys`. Since the `Debug`
-      // impl for `Key` currently uses this very method to render the `Key` we avoid using the
-      // debug formatting for `Key` to avoid generating a panic while panicking.
-      panic!(
-        "Previously memoized object disappeared for Key {{ id: {}, type_id: {} }}!",
-        k.id(),
-        k.type_id()
-      )
-    })
-  }
-}
-
-struct InternKey(isize, PyObject);
-
-impl Eq for InternKey {}
-
-impl PartialEq for InternKey {
-  fn eq(&self, other: &InternKey) -> bool {
-    Python::with_gil(|py| externs::equals(self.1.as_ref(py), other.1.as_ref(py)))
-  }
-}
-
-impl hash::Hash for InternKey {
-  fn hash<H: hash::Hasher>(&self, state: &mut H) {
-    self.0.hash(state);
+    Ok(Key::new(id, type_id, v.into()))
   }
 }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -879,7 +879,7 @@ impl From<Snapshot> for NodeKey {
   }
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DownloadedFile(pub Key);
 
 impl DownloadedFile {
@@ -1006,7 +1006,7 @@ impl Task {
             output: get.output,
             input: *get.input.type_id(),
           });
-          params.put(get.input);
+          params.put(get.input.clone());
 
           let edges = context
             .core
@@ -1148,7 +1148,7 @@ impl WrappedNode for Task {
       .await?
     };
 
-    let func = self.task.func;
+    let func = self.task.func.clone();
 
     let (mut result_val, mut result_type) =
       maybe_side_effecting(self.task.side_effecting, &self.side_effected, async move {
@@ -1180,7 +1180,7 @@ impl WrappedNode for Task {
     if result_type != self.product {
       return Err(throw(format!(
         "{:?} returned a result value that did not satisfy its constraints: {:?}",
-        func, result_val
+        self.task.func, result_val
       )));
     }
 

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -264,8 +264,9 @@ impl Key {
   }
 }
 
-// TODO: simplify to use `PyObject` (aka `Py<PyAny>`) directly. There is no benefit to wrapping
-// this in an `Arc`, given that it's already GIL-independent.
+// NB: Although `PyObject` (aka `Py<PyAny>`) directly implements `Clone`, it's ~4% faster to wrap
+// in `Arc` like this, because `Py<T>` internally acquires a (non-GIL) global lock during `Clone`
+// and `Drop`.
 #[derive(Clone)]
 pub struct Value(Arc<PyObject>);
 

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -21,7 +21,6 @@ pub type Fnv = hash::BuildHasherDefault<FnvHasher>;
 ///
 /// For efficiency and hashability, they're stored as sorted Keys (with distinct TypeIds).
 ///
-#[repr(C)]
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Params(SmallVec<[Key; 4]>);
 
@@ -178,8 +177,7 @@ impl rule_graph::TypeId for TypeId {
 }
 
 /// An identifier for a Python function.
-#[repr(C)]
-#[derive(Clone, Copy, Eq, Hash, PartialEq)]
+#[derive(Clone, Eq, Hash, PartialEq)]
 pub struct Function(pub Key);
 
 impl Function {
@@ -212,8 +210,7 @@ impl fmt::Display for Function {
 }
 
 /// An interned key for a Value for use as a key in HashMaps and sets.
-#[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Key {
   id: Id,
   type_id: TypeId,

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -6,15 +6,12 @@ use std::ops::Deref;
 use std::sync::Arc;
 use std::{fmt, hash};
 
-use fnv::FnvHasher;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyType};
 use pyo3::{FromPyObject, ToPyObject};
 use smallvec::SmallVec;
 
 use crate::externs;
-
-pub type Fnv = hash::BuildHasherDefault<FnvHasher>;
 
 ///
 /// Params represent a TypeId->Key map.
@@ -214,6 +211,7 @@ impl fmt::Display for Function {
 pub struct Key {
   id: Id,
   type_id: TypeId,
+  pub value: Value,
 }
 
 impl Eq for Key {}
@@ -243,8 +241,8 @@ impl fmt::Display for Key {
 }
 
 impl Key {
-  pub fn new(id: Id, type_id: TypeId) -> Key {
-    Key { id, type_id }
+  pub fn new(id: Id, type_id: TypeId, value: Value) -> Key {
+    Key { id, type_id, value }
   }
 
   pub fn id(&self) -> Id {
@@ -262,7 +260,7 @@ impl Key {
   }
 
   pub fn to_value(&self) -> Value {
-    Value::new(externs::INTERNS.key_get(self))
+    self.value.clone()
   }
 }
 


### PR DESCRIPTION
Profiling showed that we're still spending quite a bit of time acquiring and releasing the GIL for interning (since we release it to interact with the `HashMap`, and then reacquire it for `Eq`). But it also showed a surprising amount of time spent interacting with the locks around the internal `HashMap`s.

Since we're already under the GIL, and since Python dicts are plenty optimized on their own, this change moves interning to directly using a `PyDict` (effectively `dict[Any,int]`). It also removes the reverse mapping by giving `Key` a reference to its `Value`. Finally, it replaces the `TODO` about removing the `Arc` in `Value` with an explanation that using `Arc<PyObject>` is about 4% faster.

`./pants dependencies --transitive ::` gets ~6% faster.

[ci skip-build-wheels]