### PR TITLE
[jvm] Use `immutable_inputs` to provide the compiletime classpath

### DIFF
--- a/src/python/pants/backend/scala/compile/scalac.py
+++ b/src/python/pants/backend/scala/compile/scalac.py
@@ -169,8 +169,10 @@ async def compile_scala_source(
         scalac_plugins_relpath: scalac_plugins.classpath.digest,
     }
 
-    classpath_arg = ClasspathEntry.arg(
-        ClasspathEntry.closure(direct_dependency_classpath_entries), prefix=usercp
+    classpath_arg = ":".join(
+        ClasspathEntry.args(
+            ClasspathEntry.closure(direct_dependency_classpath_entries), prefix=usercp
+        )
     )
 
     output_file = f"{request.component.representative.address.path_safe_spec}.scalac.jar"

--- a/src/python/pants/jvm/classpath.py
+++ b/src/python/pants/jvm/classpath.py
@@ -4,59 +4,36 @@
 from __future__ import annotations
 
 import logging
-import os
-from dataclasses import dataclass
-from typing import Callable, Iterator
+from typing import Iterator
 
-from pants.engine.fs import AddPrefix, Digest, MergeDigests, Snapshot
+from pants.engine.collection import Collection
+from pants.engine.fs import Digest
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import CoarsenedTargets, Targets
 from pants.engine.unions import UnionMembership
 from pants.jvm.compile import ClasspathEntry, ClasspathEntryRequest
 from pants.jvm.resolve.key import CoursierResolveKey
 
-_USERCP_RELPATH = "__cp"
-
-
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
-class Classpath:
+class Classpath(Collection[ClasspathEntry]):
     """A transitive classpath which is sufficient to launch the target(s) it was generated for.
 
     This classpath is guaranteed to contain only JAR files.
-
-    TODO: Reuse `ClasspathEntry` prefixes, and replace `user_classpath` logic with inspecting only
-    the "root" `ClasspathEntry` for a test target.
     """
 
-    content: Snapshot
+    def args(self, *, prefix: str = "") -> Iterator[str]:
+        """All transitive filenames for this Classpath."""
+        return ClasspathEntry.args(ClasspathEntry.closure(self), prefix=prefix)
 
-    def classpath_entries(self, prefix: str | None = None) -> Iterator[str]:
-        """Returns optionally prefixed classpath entry filenames.
+    def root_args(self, *, prefix: str = "") -> Iterator[str]:
+        """The root filenames for this Classpath."""
+        return ClasspathEntry.args(self, prefix=prefix)
 
-        :param prefix: if set, will be prepended to all entries.  This is useful
-            if the process working directory is not the same as the root
-            directory for the process input `Digest`.
-        """
-        return self._classpath(lambda _: True, prefix=prefix)
-
-    def user_classpath_entries(self, prefix: str | None = None) -> Iterator[str]:
-        """Like `classpath_entries`, but returns only entries corresponding to first-party code."""
-        return self._classpath(lambda f: f.startswith(_USERCP_RELPATH), prefix=prefix)
-
-    def _classpath(
-        self, predicate: Callable[[str], bool], prefix: str | None = None
-    ) -> Iterator[str]:
-        def maybe_add_prefix(file_name: str) -> str:
-            if prefix is None:
-                return file_name
-            return os.path.join(prefix, file_name)
-
-        return (
-            maybe_add_prefix(file_path) for file_path in self.content.files if predicate(file_path)
-        )
+    def digests(self) -> Iterator[Digest]:
+        """All transitive Digests for this Classpath."""
+        return (entry.digest for entry in ClasspathEntry.closure(self))
 
 
 @rule
@@ -78,14 +55,8 @@ async def classpath(
         )
         for t in coarsened_targets
     )
-    merged_transitive_classpath_entries_digest = await Get(
-        Digest,
-        MergeDigests(classfiles.digest for classfiles in ClasspathEntry.closure(classpath_entries)),
-    )
 
-    return Classpath(
-        await Get(Snapshot, AddPrefix(merged_transitive_classpath_entries_digest, _USERCP_RELPATH))
-    )
+    return Classpath(classpath_entries)
 
 
 def rules():

--- a/src/python/pants/jvm/compile.py
+++ b/src/python/pants/jvm/compile.py
@@ -172,12 +172,12 @@ class ClasspathEntry:
         )
 
     @classmethod
-    def arg(cls, entries: Iterable[ClasspathEntry], *, prefix: str = "") -> str:
-        """Builds the non-recursive classpath arg for the given entries.
+    def args(cls, entries: Iterable[ClasspathEntry], *, prefix: str = "") -> Iterator[str]:
+        """Returns the filenames for the given entries.
 
-        To construct a recursive classpath arg, first expand the entries with `cls.closure()`.
+        To compute transitive filenames, first expand the entries with `cls.closure()`.
         """
-        return ":".join(os.path.join(prefix, f) for cpe in entries for f in cpe.filenames)
+        return (os.path.join(prefix, f) for cpe in entries for f in cpe.filenames)
 
     @classmethod
     def closure(cls, roots: Iterable[ClasspathEntry]) -> Iterator[ClasspathEntry]:

--- a/src/python/pants/jvm/compile.py
+++ b/src/python/pants/jvm/compile.py
@@ -175,9 +175,35 @@ class ClasspathEntry:
     def args(cls, entries: Iterable[ClasspathEntry], *, prefix: str = "") -> Iterator[str]:
         """Returns the filenames for the given entries.
 
+        TODO: See whether this method can be completely eliminated in favor of
+        `immutable_inputs(_args)`.
+
         To compute transitive filenames, first expand the entries with `cls.closure()`.
         """
         return (os.path.join(prefix, f) for cpe in entries for f in cpe.filenames)
+
+    @classmethod
+    def immutable_inputs(
+        cls, entries: Iterable[ClasspathEntry], *, prefix: str = ""
+    ) -> Iterator[tuple[str, Digest]]:
+        """Returns (relpath, Digest) tuples for use with `Process.immutable_input_digests`.
+
+        To compute transitive input tuples, first expand the entries with `cls.closure()`.
+        """
+        return ((os.path.join(prefix, cpe.digest.fingerprint[:12]), cpe.digest) for cpe in entries)
+
+    @classmethod
+    def immutable_inputs_args(
+        cls, entries: Iterable[ClasspathEntry], *, prefix: str = ""
+    ) -> Iterator[str]:
+        """Returns the relative filenames for the given entries to be used as immutable_inputs.
+
+        To compute transitive input tuples, first expand the entries with `cls.closure()`.
+        """
+        for cpe in entries:
+            fingerprint_prefix = cpe.digest.fingerprint[:12]
+            for filename in cpe.filenames:
+                yield os.path.join(prefix, fingerprint_prefix, filename)
 
     @classmethod
     def closure(cls, roots: Iterable[ClasspathEntry]) -> Iterator[ClasspathEntry]:

--- a/src/python/pants/jvm/compile_test.py
+++ b/src/python/pants/jvm/compile_test.py
@@ -84,6 +84,7 @@ def rule_runner() -> RuleRunner:
             *util_rules(),
             *testutil.rules(),
             QueryRule(Classpath, (Addresses,)),
+            QueryRule(RenderedClasspath, (Addresses,)),
             QueryRule(UnexpandedTargets, (Addresses,)),
         ],
         target_types=[ScalaSourcesGeneratorTarget, JavaSourcesGeneratorTarget, JvmArtifact],
@@ -221,17 +222,16 @@ def test_compile_mixed(rule_runner: RuleRunner) -> None:
             "lib/C.java": java_lib_source(),
         }
     )
-    classpath = rule_runner.request(
-        Classpath, [Addresses([Address(spec_path="", target_name="main")])]
+    rendered_classpath = rule_runner.request(
+        RenderedClasspath, [Addresses([Address(spec_path="", target_name="main")])]
     )
-    rendered_classpath = rule_runner.request(RenderedClasspath, [classpath.content.digest])
     assert rendered_classpath.content == {
-        "__cp/.Example.scala.main.scalac.jar": {
+        ".Example.scala.main.scalac.jar": {
             "META-INF/MANIFEST.MF",
             "org/pantsbuild/example/Main$.class",
             "org/pantsbuild/example/Main.class",
         },
-        "__cp/lib.C.java.javac.jar": {
+        "lib.C.java.javac.jar": {
             "org/pantsbuild/example/lib/C.class",
         },
     }

--- a/src/python/pants/jvm/testutil.py
+++ b/src/python/pants/jvm/testutil.py
@@ -17,6 +17,8 @@ from pants.engine.fs import Digest, PathGlobs, RemovePrefix, Snapshot
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, QueryRule, collect_rules, rule
 from pants.engine.target import CoarsenedTarget, CoarsenedTargets, Targets
+from pants.jvm.classpath import Classpath
+from pants.jvm.compile import ClasspathEntry
 from pants.jvm.resolve.key import CoursierResolveKey
 from pants.testutil.rule_runner import RuleRunner
 
@@ -54,7 +56,9 @@ class RenderedClasspath:
 
 
 @rule
-async def render_classpath(snapshot: Snapshot, unzip_binary: UnzipBinary) -> RenderedClasspath:
+async def render_classpath_entry(
+    classpath_entry: ClasspathEntry, unzip_binary: UnzipBinary
+) -> RenderedClasspath:
     dest_dir = "dest"
     process_results = await MultiGet(
         Get(
@@ -66,12 +70,12 @@ async def render_classpath(snapshot: Snapshot, unzip_binary: UnzipBinary) -> Ren
                     dest_dir,
                     filename,
                 ],
-                input_digest=snapshot.digest,
+                input_digest=classpath_entry.digest,
                 output_directories=(dest_dir,),
                 description=f"Extract {filename}",
             ),
         )
-        for filename in snapshot.files
+        for filename in classpath_entry.filenames
     )
 
     listing_snapshots = await MultiGet(
@@ -79,14 +83,26 @@ async def render_classpath(snapshot: Snapshot, unzip_binary: UnzipBinary) -> Ren
     )
 
     return RenderedClasspath(
-        {path: set(listing.files) for path, listing in zip(snapshot.files, listing_snapshots)}
+        {
+            path: set(listing.files)
+            for path, listing in zip(classpath_entry.filenames, listing_snapshots)
+        }
     )
+
+
+@rule
+async def render_classpath(classpath: Classpath) -> RenderedClasspath:
+    rendered_classpaths = await MultiGet(
+        Get(RenderedClasspath, ClasspathEntry, cpe) for cpe in ClasspathEntry.closure(classpath)
+    )
+    return RenderedClasspath({k: v for rc in rendered_classpaths for k, v in rc.content.items()})
 
 
 def rules():
     return [
         *collect_rules(),
         *archive.rules(),
-        QueryRule(RenderedClasspath, (Digest,)),
+        QueryRule(RenderedClasspath, (Classpath,)),
+        QueryRule(RenderedClasspath, (ClasspathEntry,)),
         QueryRule(CoarsenedTargets, (Addresses,)),
     ]


### PR DESCRIPTION
As described in #13435, we expect large sandboxes for JVM compiles (for Scala in particular). #13848 added support for symlinking immutable inputs into sandboxes, and used it for tools. This change uses it for JVM classpaths as well.

In a test repo, this reduces the total amount of time taken to create sandboxes for compilation by ~30% (from 14s to 10s), with an average sandbox creation time of 40ms (including amortized materialization of the symlink destinations).

[ci skip-rust]
[ci skip-build-wheels]