### PR TITLE
[internal] scala: refactor `scalapb` codegen and add JVM `protoc` plugin support

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/scala/BUILD
+++ b/src/python/pants/backend/codegen/protobuf/scala/BUILD
@@ -1,8 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_sources(dependencies=[":lockfile", ":scala_sources"])
-resource(name="lockfile", source="scalapbc.default.lockfile.txt")
-resources(name="scala_sources", sources=["*.scala"])
+python_sources(dependencies=[":resources"])
+resources(name="resources", sources=["*.scala", "scalapbc.default.lockfile.txt"])
 
 python_tests(name="tests")

--- a/src/python/pants/backend/codegen/protobuf/scala/BUILD
+++ b/src/python/pants/backend/codegen/protobuf/scala/BUILD
@@ -1,7 +1,8 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_sources(dependencies=[":lockfile"])
+python_sources(dependencies=[":lockfile", ":scala_sources"])
 resource(name="lockfile", source="scalapbc.default.lockfile.txt")
+resources(name="scala_sources", sources=["*.scala"])
 
 python_tests(name="tests")

--- a/src/python/pants/backend/codegen/protobuf/scala/ScalaPBShim.scala
+++ b/src/python/pants/backend/codegen/protobuf/scala/ScalaPBShim.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package org.pantsbuild.backend.scala.scalapb
+
+import java.util.jar.JarInputStream
+import java.io.{File, FileInputStream}
+import java.net.URLClassLoader
+import protocbridge.{ProtocBridge, ProtocCodeGenerator, ProtocRunner, SandboxedJvmGenerator}
+import scalapb.ScalaPbCodeGenerator
+
+
+// Derived in part from ScalaPBC under Apache License v2.0. Introduced errors are mine.
+
+case class Config(
+  protocPath: Option[String] = None,
+  throwException: Boolean = false,
+  args: Seq[String] = Seq.empty,
+  namedGenerators: Seq[(String, ProtocCodeGenerator)] = Seq("scala" -> ScalaPbCodeGenerator),
+)
+
+class ScalaPbcException(msg: String) extends RuntimeException(msg)
+
+object ScalaPBShim {
+  private val ProtocPathArgument     = "--protoc="
+
+  def processArgs(args: Array[String]): Config = {
+    case class State(cfg: Config, passThrough: Boolean)
+
+    args
+      .foldLeft(State(Config(), false)) { case (state, item) =>
+        (state.passThrough, item) match {
+          case (false, "--")      => state.copy(passThrough = true)
+          case (false, "--throw") => state.copy(cfg = state.cfg.copy(throwException = true))
+          case (false, p) if p.startsWith(ProtocPathArgument) =>
+            state.copy(
+              cfg = state.cfg
+                .copy(protocPath = Some(p.substring(ProtocPathArgument.length)))
+            )
+          case (_, other) =>
+            state.copy(passThrough = true, cfg = state.cfg.copy(args = state.cfg.args :+ other))
+        }
+      }
+      .cfg
+  }
+
+  def findMainClass(f: File): Either[String, String] = {
+    val jin = new JarInputStream(new FileInputStream(f))
+    try {
+      val manifest = jin.getManifest()
+      Option(manifest.getMainAttributes().getValue("Main-Class"))
+        .toRight("Could not find main class for plugin")
+        .map(_ + "$")
+    } finally {
+      jin.close()
+    }
+  }
+
+  private[scalapb] def runProtoc(config: Config): Int = {
+    val protoc = config.protocPath.getOrElse(throw new RuntimeException("--protoc not specified"))
+
+    ProtocBridge.runWithGenerators(
+      ProtocRunner(protoc),
+      namedGenerators = config.namedGenerators,
+      params = config.args
+    )
+  }
+
+  def main(args: Array[String]): Unit = {
+    val config = processArgs(args)
+    val code   = runProtoc(config)
+
+    if (!config.throwException) {
+      sys.exit(code)
+    } else {
+      if (code != 0) {
+        throw new ScalaPbcException(s"Exit with code $code")
+      }
+    }
+  }
+}

--- a/src/python/pants/backend/codegen/protobuf/scala/ScalaPBShim.scala
+++ b/src/python/pants/backend/codegen/protobuf/scala/ScalaPBShim.scala
@@ -12,7 +12,9 @@ import protocbridge.{ProtocBridge, ProtocCodeGenerator, ProtocRunner, SandboxedJ
 import scalapb.ScalaPbCodeGenerator
 
 
-// Derived in part from ScalaPBC under Apache License v2.0. Introduced errors are mine.
+// Derived from ScalaPBC under Apache License v2.0.
+// Forked from:
+// https://github.com/scalapb/ScalaPB/blob/d7e88f3783172f652d63229c7359a1de2e87eac6/scalapbc/src/main/scala/scalapb/ScalaPBC.scala
 
 case class Config(
   protocPath: Option[String] = None,

--- a/src/python/pants/backend/codegen/protobuf/scala/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/rules.py
@@ -1,6 +1,6 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-import textwrap
+import pkgutil
 
 from pants.backend.codegen.protobuf.protoc import Protoc
 from pants.backend.codegen.protobuf.scala.scalapbc import ScalaPBSubsystem
@@ -13,6 +13,7 @@ from pants.core.util_rules.external_tool import DownloadedExternalTool, External
 from pants.core.util_rules.source_files import SourceFilesRequest
 from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
 from pants.engine.addresses import Addresses, UnparsedAddressInputs
+from pants.engine.environment import Environment, EnvironmentRequest
 from pants.engine.fs import (
     AddPrefix,
     CreateDigest,
@@ -36,8 +37,14 @@ from pants.engine.target import (
     TransitiveTargetsRequest,
 )
 from pants.engine.unions import UnionRule
+from pants.jvm.compile import ClasspathEntry
 from pants.jvm.jdk_rules import JdkSetup
-from pants.jvm.resolve.coursier_fetch import MaterializedClasspath, MaterializedClasspathRequest
+from pants.jvm.resolve.coursier_fetch import (
+    ArtifactRequirements,
+    Coordinate,
+    MaterializedClasspath,
+    MaterializedClasspathRequest,
+)
 from pants.jvm.resolve.jvm_tool import JvmToolLockfileRequest, JvmToolLockfileSentinel
 from pants.source.source_root import SourceRoot, SourceRootRequest
 from pants.util.logging import LogLevel
@@ -52,18 +59,30 @@ class ScalapbcToolLockfileSentinel(JvmToolLockfileSentinel):
     options_scope = ScalaPBSubsystem.options_scope
 
 
+class ScalaPBShimCompiledClassfiles(ClasspathEntry):
+    pass
+
+
 @rule(desc="Generate Scala from Protobuf", level=LogLevel.DEBUG)
 async def generate_scala_from_protobuf(
     request: GenerateScalaFromProtobufRequest,
     protoc: Protoc,
     scalapbc: ScalaPBSubsystem,
+    shim_classfiles: ScalaPBShimCompiledClassfiles,
     jdk_setup: JdkSetup,
     bash: BashBinary,
 ) -> GeneratedSources:
     output_dir = "_generated_files"
     toolcp_relpath = "__toolcp"
+    shimcp_relpath = "__shimcp"
 
-    downloaded_protoc_binary, tool_classpath, empty_output_dir, transitive_targets = await MultiGet(
+    (
+        downloaded_protoc_binary,
+        tool_classpath,
+        empty_output_dir,
+        transitive_targets,
+        inherit_env,
+    ) = await MultiGet(
         Get(DownloadedExternalTool, ExternalToolRequest, protoc.get_request(Platform.current)),
         Get(
             MaterializedClasspath,
@@ -73,11 +92,13 @@ async def generate_scala_from_protobuf(
         ),
         Get(Digest, CreateDigest([Directory(output_dir)])),
         Get(TransitiveTargets, TransitiveTargetsRequest([request.protocol_target.address])),
+        # Need PATH so that ScalaPB can invoke `mkfifo`.
+        Get(Environment, EnvironmentRequest(requested=["PATH"])),
     )
 
     # NB: By stripping the source roots, we avoid having to set the value `--proto_path`
     # for Protobuf imports to be discoverable.
-    all_sources_stripped, target_sources_stripped, protoc_gen_scala_digest = await MultiGet(
+    all_sources_stripped, target_sources_stripped = await MultiGet(
         Get(
             StrippedSourceFiles,
             SourceFilesRequest(
@@ -89,58 +110,41 @@ async def generate_scala_from_protobuf(
         Get(
             StrippedSourceFiles, SourceFilesRequest([request.protocol_target[ProtobufSourceField]])
         ),
-        Get(
-            Digest,
-            CreateDigest(
-                [
-                    FileContent(
-                        "protoc-gen-scala",
-                        textwrap.dedent(
-                            f"""\
-                                       #!{bash.path}
-                                       exec {' '.join(jdk_setup.args(bash, tool_classpath.classpath_entries(toolcp_relpath))[1:])} scalapb.ScalaPbCodeGenerator "$@"
-                                       """
-                        ).encode(),
-                        is_executable=True,
-                    )
-                ]
-            ),
-        ),
     )
 
     unmerged_digests = [
         all_sources_stripped.snapshot.digest,
         downloaded_protoc_binary.digest,
-        protoc_gen_scala_digest,
         empty_output_dir,
     ]
 
     immutable_input_digests = {
         **jdk_setup.immutable_input_digests,
         toolcp_relpath: tool_classpath.digest,
+        shimcp_relpath: shim_classfiles.digest,
     }
 
     input_digest = await Get(Digest, MergeDigests(unmerged_digests))
 
-    args = [
-        downloaded_protoc_binary.exe,
-        "--plugin=protoc-gen-scala=./protoc-gen-scala",
-        "--scala_out",
-        output_dir,
-        *target_sources_stripped.snapshot.files,
-    ]
-
-    # TODO: Consider using nailgun or how to use the GraalVM-built native image for `scalapbc`.
+    # TODO: Use nailgun to invoke the shim..
     result = await Get(
         ProcessResult,
         Process(
-            args,
+            argv=[
+                *jdk_setup.args(
+                    bash, [*tool_classpath.classpath_entries(toolcp_relpath), shimcp_relpath]
+                ),
+                "org.pantsbuild.backend.scala.scalapb.ScalaPBShim",
+                f"--protoc={downloaded_protoc_binary.exe}",
+                f"--scala_out={output_dir}",
+                *target_sources_stripped.snapshot.files,
+            ],
             input_digest=input_digest,
             immutable_input_digests=immutable_input_digests,
             description=f"Generating Scala sources from {request.protocol_target.address}.",
             level=LogLevel.DEBUG,
             output_directories=(output_dir,),
-            env=jdk_setup.env,
+            env={**jdk_setup.env, **inherit_env},
             append_only_caches=jdk_setup.append_only_caches,
         ),
     )
@@ -168,6 +172,110 @@ async def inject_scalapb_dependencies(
 ) -> InjectedDependencies:
     addresses = await Get(Addresses, UnparsedAddressInputs, scalapb.runtime_dependencies)
     return InjectedDependencies(addresses)
+
+
+SHIM_SCALA_VERSION = "2.13.7"
+
+
+@rule
+async def setup_scalapb_shim_classfiles(
+    scalapb: ScalaPBSubsystem, jdk_setup: JdkSetup, bash: BashBinary
+) -> ScalaPBShimCompiledClassfiles:
+    dest_dir = "classfiles"
+
+    scalapb_shim_content = pkgutil.get_data(
+        "pants.backend.codegen.protobuf.scala", "ScalaPBShim.scala"
+    )
+    if not scalapb_shim_content:
+        raise AssertionError("Unable to find ScalaParser.scala resource.")
+
+    scalapb_shim_source = FileContent("ScalaPBShim.scala", scalapb_shim_content)
+
+    tool_classpath, shim_classpath, source_digest = await MultiGet(
+        Get(
+            MaterializedClasspath,
+            MaterializedClasspathRequest(
+                prefix="__toolcp",
+                artifact_requirements=(
+                    ArtifactRequirements.from_coordinates(
+                        [
+                            Coordinate(
+                                group="org.scala-lang",
+                                artifact="scala-compiler",
+                                version=SHIM_SCALA_VERSION,
+                            ),
+                            Coordinate(
+                                group="org.scala-lang",
+                                artifact="scala-library",
+                                version=SHIM_SCALA_VERSION,
+                            ),
+                            Coordinate(
+                                group="org.scala-lang",
+                                artifact="scala-reflect",
+                                version=SHIM_SCALA_VERSION,
+                            ),
+                        ]
+                    ),
+                ),
+            ),
+        ),
+        Get(
+            MaterializedClasspath,
+            MaterializedClasspathRequest(
+                prefix="__shimcp",
+                lockfiles=(scalapb.resolved_lockfile(),),
+            ),
+        ),
+        Get(
+            Digest,
+            CreateDigest(
+                [
+                    scalapb_shim_source,
+                    Directory(dest_dir),
+                ]
+            ),
+        ),
+    )
+
+    merged_digest = await Get(
+        Digest,
+        MergeDigests(
+            (
+                tool_classpath.digest,
+                shim_classpath.digest,
+                source_digest,
+            )
+        ),
+    )
+
+    # NB: We do not use nailgun for this process, since it is launched exactly once.
+    process_result = await Get(
+        ProcessResult,
+        Process(
+            argv=[
+                *jdk_setup.args(bash, tool_classpath.classpath_entries()),
+                "scala.tools.nsc.Main",
+                "-bootclasspath",
+                ":".join(tool_classpath.classpath_entries()),
+                "-classpath",
+                ":".join(shim_classpath.classpath_entries()),
+                "-d",
+                dest_dir,
+                scalapb_shim_source.path,
+            ],
+            input_digest=merged_digest,
+            append_only_caches=jdk_setup.append_only_caches,
+            immutable_input_digests=jdk_setup.immutable_input_digests,
+            env=jdk_setup.env,
+            output_directories=(dest_dir,),
+            description="Compile ScalaPB shim with scalac",
+            level=LogLevel.DEBUG,
+        ),
+    )
+    stripped_classfiles_digest = await Get(
+        Digest, RemovePrefix(process_result.output_digest, dest_dir)
+    )
+    return ScalaPBShimCompiledClassfiles(digest=stripped_classfiles_digest)
 
 
 @rule

--- a/src/python/pants/backend/codegen/protobuf/scala/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/rules_integration_test.py
@@ -246,7 +246,5 @@ def test_generates_fs2_grpc_via_jvm_plugin(rule_runner: RuleRunner) -> None:
             "service/service/TestMessage.scala",
             "service/service/TestServiceFs2Grpc.scala",
         ],
-        extra_args=[
-            "--scalapb-jvm-plugin-artifacts=+['fs2=org.typelevel:fs2-grpc-codegen_2.12:2.3.1']"
-        ],
+        extra_args=["--scalapb-jvm-plugins=+['fs2=org.typelevel:fs2-grpc-codegen_2.12:2.3.1']"],
     )

--- a/src/python/pants/backend/codegen/protobuf/scala/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/rules_integration_test.py
@@ -20,6 +20,7 @@ from pants.backend.scala.target_types import ScalaSourcesGeneratorTarget, ScalaS
 from pants.build_graph.address import Address
 from pants.core.util_rules import config_files, source_files, stripped_source_files
 from pants.core.util_rules.external_tool import rules as external_tool_rules
+from pants.engine.fs import Digest, DigestContents
 from pants.engine.rules import QueryRule
 from pants.engine.target import GeneratedSources, HydratedSources, HydrateSourcesRequest
 from pants.jvm import classpath
@@ -71,6 +72,7 @@ def rule_runner() -> RuleRunner:
             *scala_protobuf_rules(),
             QueryRule(HydratedSources, [HydrateSourcesRequest]),
             QueryRule(GeneratedSources, [GenerateScalaFromProtobufRequest]),
+            QueryRule(DigestContents, (Digest,)),
         ],
         target_types=[
             ScalaSourceTarget,
@@ -91,8 +93,9 @@ def assert_files_generated(
     *,
     expected_files: list[str],
     source_roots: list[str],
+    extra_args: Iterable[str] = (),
 ) -> None:
-    args = [f"--source-root-patterns={repr(source_roots)}"]
+    args = [f"--source-root-patterns={repr(source_roots)}", *extra_args]
     rule_runner.set_options(args, env_inherit=PYTHON_BOOTSTRAP_ENV)
     tgt = rule_runner.get_target(address)
     protocol_sources = rule_runner.request(
@@ -102,6 +105,9 @@ def assert_files_generated(
         GeneratedSources,
         [GenerateScalaFromProtobufRequest(protocol_sources.snapshot, tgt)],
     )
+    sources_contents = rule_runner.request(DigestContents, [generated_sources.snapshot.digest])
+    for sc in sources_contents:
+        print(f"{sc.path}:\n{sc.content.decode()}")
     assert set(generated_sources.snapshot.files) == set(expected_files)
 
 
@@ -204,4 +210,43 @@ def test_top_level_proto_root(rule_runner: RuleRunner) -> None:
         Address("protos", relative_file_path="f.proto"),
         source_roots=["/"],
         expected_files=["protos/f/FProto.scala"],
+    )
+
+
+def test_generates_fs2_grpc_via_jvm_plugin(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "protos/BUILD": "protobuf_sources()",
+            "protos/service.proto": dedent(
+                """\
+            syntax = "proto3";
+
+            package service;
+
+            message TestMessage {
+              string foo = 1;
+            }
+
+            service TestService {
+              rpc noStreaming (TestMessage) returns (TestMessage);
+              rpc clientStreaming (stream TestMessage) returns (TestMessage);
+              rpc serverStreaming (TestMessage) returns (stream TestMessage);
+              rpc bothStreaming (stream TestMessage) returns (stream TestMessage);
+            }
+            """
+            ),
+        }
+    )
+    assert_files_generated(
+        rule_runner,
+        Address("protos", relative_file_path="service.proto"),
+        source_roots=["/"],
+        expected_files=[
+            "service/service/ServiceProto.scala",
+            "service/service/TestMessage.scala",
+            "service/service/TestServiceFs2Grpc.scala",
+        ],
+        extra_args=[
+            "--scalapb-jvm-plugin-artifacts=+['fs2=org.typelevel:fs2-grpc-codegen_2.12:2.3.1']"
+        ],
     )

--- a/src/python/pants/backend/codegen/protobuf/scala/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/rules_integration_test.py
@@ -91,13 +91,9 @@ def assert_files_generated(
     *,
     expected_files: list[str],
     source_roots: list[str],
-    mypy: bool = False,
-    extra_args: list[str] | None = None,
 ) -> None:
-    args = [f"--source-root-patterns={repr(source_roots)}", *(extra_args or ())]
-    if mypy:
-        args.append("--python-protobuf-mypy-plugin")
-    rule_runner.set_options(args, env_inherit={"PATH", "PYENV_ROOT", "HOME"})
+    args = [f"--source-root-patterns={repr(source_roots)}"]
+    rule_runner.set_options(args, env_inherit=PYTHON_BOOTSTRAP_ENV)
     tgt = rule_runner.get_target(address)
     protocol_sources = rule_runner.request(
         HydratedSources, [HydrateSourcesRequest(tgt[ProtobufSourceField])]

--- a/src/python/pants/backend/codegen/protobuf/scala/scalapbc.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/scalapbc.py
@@ -1,5 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
 from pants.engine.addresses import UnparsedAddressInputs
 from pants.jvm.resolve.jvm_tool import JvmToolBase
 from pants.option.custom_types import target_option

--- a/src/python/pants/backend/codegen/protobuf/scala/scalapbc.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/scalapbc.py
@@ -31,7 +31,7 @@ class ScalaPBSubsystem(JvmToolBase):
                 "A list of addresses to `jvm_artifact` targets for the runtime "
                 "dependencies needed for generated Scala code to work. For example, "
                 "`['3rdparty/jvm:scalapb-runtime']`. These dependencies will "
-                "be automatically added to every `protobuf_sources` target. At the very leasst, "
+                "be automatically added to every `protobuf_sources` target. At the very least, "
                 "this option must be set to a `jvm_artifact` for the "
                 f"`com.thesamet.scalapb:scalapb-runtime_SCALAVER:{cls.default_version}` runtime library."
             ),

--- a/src/python/pants/backend/codegen/protobuf/scala/subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/subsystem.py
@@ -58,15 +58,18 @@ class ScalaPBSubsystem(JvmToolBase):
             ),
         )
         register(
-            "--jvm-plugin-artifacts",
+            "--jvm-plugins",
             type=list,
             member_type=str,
-            # TODO: Add example of how to invoke a plugin like `fs2-grpc`.
             help=(
                 "A list of JVM-based `protoc` plugins to invoke when generating Scala code from protobuf files. "
                 "The format for each plugin specifier is `NAME=ARTIFACT` where NAME is the name of the "
                 "plugin and ARTIFACT is either the address of a `jvm_artifact` target or the colon-separated "
-                "Maven coordinate for the plugin's jar artifact."
+                "Maven coordinate for the plugin's jar artifact.\n\n"
+                "For example, to invoke the fs2-grpc protoc plugin, the following option would work: "
+                "`--scalapb-jvm-plugins=fs2=org.typelevel:fs2-grpc-codegen_2.12:2.3.1`. "
+                "(Note: you would also need to set --scalapb-runtime-dependencies appropriately "
+                "to include the applicable runtime libraries for your chosen protoc plugins.)"
             ),
         )
 
@@ -75,7 +78,5 @@ class ScalaPBSubsystem(JvmToolBase):
         return UnparsedAddressInputs(self.options.runtime_dependencies, owning_address=None)
 
     @property
-    def jvm_plugin_artifacts(self) -> tuple[PluginArtifactSpec, ...]:
-        return tuple(
-            PluginArtifactSpec.from_str(pa_str) for pa_str in self.options.jvm_plugin_artifacts
-        )
+    def jvm_plugins(self) -> tuple[PluginArtifactSpec, ...]:
+        return tuple(PluginArtifactSpec.from_str(pa_str) for pa_str in self.options.jvm_plugins)


### PR DESCRIPTION
Refactor the ScalaPB protobuf codegen support to use a new compiled shim for invoking ScalaPB instead of passing the ScalaPB `protoc` plugin to the `protoc` binary. This will allow us to be as close in behavior to the `scalapbc` standalone compiler as is feasible, while still allowing for Pants-specific customizations. (It also allows nailgun to cache the shim, unlike a solution which would invoke the GraalVM-built native binary for `scalapbc`.)

Add support for JVM-based `protoc` plugins. The plugins are exposed via the `--scalapb-jvm-plugins` option. The integration test demonstrates enabling code generation with the https://github.com/typelevel/fs2-grpc gRPC code generator.
