### PR TITLE
[internal] Fix `resolve` field handling for JVM

### DIFF
--- a/src/python/pants/backend/java/target_types.py
+++ b/src/python/pants/backend/java/target_types.py
@@ -24,9 +24,9 @@ from pants.engine.target import (
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.jvm.target_types import (
     JunitTestSourceField,
-    JvmCompatibleResolveNamesField,
+    JvmCompatibleResolvesField,
     JvmProvidesTypesField,
-    JvmResolveNameField,
+    JvmResolveField,
 )
 
 
@@ -67,7 +67,7 @@ class JunitTestTarget(Target):
         *COMMON_TARGET_FIELDS,
         JavaJunitTestSourceField,
         Dependencies,
-        JvmCompatibleResolveNamesField,
+        JvmCompatibleResolvesField,
         JvmProvidesTypesField,
     )
     help = "A single Java test, run with JUnit."
@@ -83,7 +83,7 @@ class JunitTestsGeneratorTarget(Target):
         *COMMON_TARGET_FIELDS,
         JavaTestsGeneratorSourcesField,
         Dependencies,
-        JvmCompatibleResolveNamesField,
+        JvmCompatibleResolvesField,
         JvmProvidesTypesField,
     )
     help = "Generate a `junit_test` target for each file in the `sources` field."
@@ -120,7 +120,7 @@ class JavaSourceTarget(Target):
         *COMMON_TARGET_FIELDS,
         Dependencies,
         JavaSourceField,
-        JvmCompatibleResolveNamesField,
+        JvmCompatibleResolvesField,
         JvmProvidesTypesField,
     )
     help = "A single Java source file containing application or library code."
@@ -136,7 +136,7 @@ class JavaSourcesGeneratorTarget(Target):
         *COMMON_TARGET_FIELDS,
         Dependencies,
         JavaSourcesGeneratorSourcesField,
-        JvmCompatibleResolveNamesField,
+        JvmCompatibleResolvesField,
         JvmProvidesTypesField,
     )
     help = "Generate a `java_source` target for each file in the `sources` field."
@@ -183,7 +183,7 @@ class DeployJarTarget(Target):
         Dependencies,
         OutputPathField,
         JvmMainClassNameField,
-        JvmResolveNameField,
+        JvmResolveField,
     )
     help = (
         "A `jar` file with first and third-party code bundled for deploys.\n\n"

--- a/src/python/pants/backend/scala/target_types.py
+++ b/src/python/pants/backend/scala/target_types.py
@@ -23,7 +23,7 @@ from pants.engine.target import (
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.jvm.target_types import (
     JunitTestSourceField,
-    JvmCompatibleResolveNamesField,
+    JvmCompatibleResolvesField,
     JvmProvidesTypesField,
 )
 
@@ -65,7 +65,7 @@ class ScalatestTestTarget(Target):
         *COMMON_TARGET_FIELDS,
         Dependencies,
         ScalatestTestSourceField,
-        JvmCompatibleResolveNamesField,
+        JvmCompatibleResolvesField,
         JvmProvidesTypesField,
     )
     help = "A single Scala test, run with Scalatest."
@@ -81,7 +81,7 @@ class ScalatestTestsGeneratorTarget(Target):
         *COMMON_TARGET_FIELDS,
         ScalatestTestsGeneratorSourcesField,
         Dependencies,
-        JvmCompatibleResolveNamesField,
+        JvmCompatibleResolvesField,
         JvmProvidesTypesField,
     )
     help = (
@@ -126,7 +126,7 @@ class ScalaJunitTestTarget(Target):
         *COMMON_TARGET_FIELDS,
         Dependencies,
         ScalaJunitTestSourceField,
-        JvmCompatibleResolveNamesField,
+        JvmCompatibleResolvesField,
         JvmProvidesTypesField,
     )
     help = "A single Scala test, run with JUnit."
@@ -142,7 +142,7 @@ class ScalaJunitTestsGeneratorTarget(Target):
         *COMMON_TARGET_FIELDS,
         ScalaJunitTestsGeneratorSourcesField,
         Dependencies,
-        JvmCompatibleResolveNamesField,
+        JvmCompatibleResolvesField,
         JvmProvidesTypesField,
     )
     help = "Generate a `junit_test` target for each file in the `sources` field."
@@ -180,7 +180,7 @@ class ScalaSourceTarget(Target):
         *COMMON_TARGET_FIELDS,
         Dependencies,
         ScalaSourceField,
-        JvmCompatibleResolveNamesField,
+        JvmCompatibleResolvesField,
         JvmProvidesTypesField,
     )
     help = "A single Scala source file containing application or library code."
@@ -207,7 +207,7 @@ class ScalaSourcesGeneratorTarget(Target):
         *COMMON_TARGET_FIELDS,
         Dependencies,
         ScalaSourcesGeneratorSourcesField,
-        JvmCompatibleResolveNamesField,
+        JvmCompatibleResolvesField,
         JvmProvidesTypesField,
     )
     help = "Generate a `scala_source` target for each file in the `sources` field."

--- a/src/python/pants/jvm/classpath.py
+++ b/src/python/pants/jvm/classpath.py
@@ -66,9 +66,7 @@ async def classpath(
     union_membership: UnionMembership,
 ) -> Classpath:
     resolve = await Get(
-        CoursierResolveKey,
-        Targets,
-        Targets(t for ct in coarsened_targets.closure() for t in ct.members),
+        CoursierResolveKey, Targets(t for ct in coarsened_targets.closure() for t in ct.members)
     )
 
     classpath_entries = await MultiGet(

--- a/src/python/pants/jvm/dependency_inference/BUILD
+++ b/src/python/pants/jvm/dependency_inference/BUILD
@@ -5,4 +5,7 @@ python_sources()
 
 python_tests(
     name="tests",
+    overrides={
+        "java_scala_interop_test.py": {"timeout": 120},
+    },
 )

--- a/src/python/pants/jvm/goals/coursier.py
+++ b/src/python/pants/jvm/goals/coursier.py
@@ -3,10 +3,11 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from dataclasses import dataclass
-from itertools import groupby
 
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
+from pants.engine.addresses import Address
 from pants.engine.console import Console
 from pants.engine.fs import (
     EMPTY_DIGEST,
@@ -21,7 +22,7 @@ from pants.engine.fs import (
 )
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
-from pants.engine.target import AllTargets, Targets, TransitiveTargets, TransitiveTargetsRequest
+from pants.engine.target import AllTargets, TransitiveTargets, TransitiveTargetsRequest
 from pants.jvm.resolve.coursier_fetch import (
     ArtifactRequirement,
     ArtifactRequirements,
@@ -29,7 +30,9 @@ from pants.jvm.resolve.coursier_fetch import (
     CoursierResolvedLockfile,
 )
 from pants.jvm.subsystems import JvmSubsystem
-from pants.jvm.target_types import JvmArtifactFieldSet, JvmCompatibleResolvesField
+from pants.jvm.target_types import JvmArtifactFieldSet, JvmCompatibleResolvesField, JvmResolveField
+from pants.util.frozendict import FrozenDict
+from pants.util.ordered_set import FrozenOrderedSet
 
 
 class CoursierResolveSubsystem(GoalSubsystem):
@@ -52,44 +55,33 @@ class CoursierResolve(Goal):
     subsystem_cls = CoursierResolveSubsystem
 
 
-@dataclass(frozen=True)
-class JvmTargetsByResolveName:
-    targets_by_resolve_name: dict[str, Targets]
+class JvmResolvesToAddresses(FrozenDict[str, FrozenOrderedSet[Address]]):
+    pass
 
 
 @rule
-async def get_jvm_targets_by_resolve_name(
-    all_targets: AllTargets,
-    jvm: JvmSubsystem,
-) -> JvmTargetsByResolveName:
-    # Get all targets that depend on JVM resolves
-
-    targets = [tgt for tgt in all_targets if tgt.has_field(JvmCompatibleResolvesField)]
-
-    default_resolve: str | None = jvm.options.default_resolve
-
-    # TODO: simplify this with Py3.9 walrus operator
-    flat_targets_ = ((tgt, tgt[JvmCompatibleResolvesField].value) for tgt in targets)
-    flat_targets__ = (
-        (
-            tgt,
-            names
-            if names is not None
-            else (default_resolve,)
-            if default_resolve is not None
-            else None,
-        )
-        for (tgt, names) in flat_targets_
+async def map_resolves_to_consuming_targets(
+    all_targets: AllTargets, jvm: JvmSubsystem
+) -> JvmResolvesToAddresses:
+    resolve_to_addresses = defaultdict(set)
+    for tgt in all_targets:
+        if tgt.has_field(JvmResolveField):
+            resolve = tgt[JvmResolveField].value or jvm.default_resolve
+            # TODO: remove once we always have a default resolve.
+            if not resolve:
+                continue
+            resolve_to_addresses[resolve].add(tgt.address)
+        elif tgt.has_field(JvmCompatibleResolvesField):
+            # TODO: add a `default_compatible_resolves` field.
+            resolves = tgt[JvmCompatibleResolvesField].value or (
+                [jvm.default_resolve] if jvm.default_resolve else []
+            )
+            for resolve in resolves:
+                resolve_to_addresses[resolve].add(tgt.address)
+    return JvmResolvesToAddresses(
+        (resolve, FrozenOrderedSet(addresses))
+        for resolve, addresses in resolve_to_addresses.items()
     )
-    flat_targets = [
-        (name, tgt) for (tgt, names) in flat_targets__ if names is not None for name in names
-    ]
-
-    targets_by_resolve_name = {
-        i: Targets(k[1] for k in j) for (i, j) in groupby(flat_targets, lambda x: x[0])
-    }
-
-    return JvmTargetsByResolveName(targets_by_resolve_name)
 
 
 @dataclass(frozen=True)
@@ -116,28 +108,17 @@ class CoursierGenerateLockfileResult:
 async def coursier_generate_lockfile(
     request: CoursierGenerateLockfileRequest,
     jvm: JvmSubsystem,
-    targets_by_resolve_name: JvmTargetsByResolveName,
+    resolves_to_addresses: JvmResolvesToAddresses,
 ) -> CoursierGenerateLockfileResult:
-
-    # `targets_by_resolve_name` supplies all of the targets that depend on each JVM resolve, so
-    # no need to find transitive deps?
-
-    # This task finds all of the sources that depend on this lockfile, and then resolves
-    # a lockfile that satisfies all of their `jvm_artifact` dependencies.
-
-    targets = targets_by_resolve_name.targets_by_resolve_name.get(request.resolve, ())
-
     # Find JVM artifacts in the dependency tree of the targets that depend on this lockfile.
     # These artifacts constitute the requirements that will be resolved for this lockfile.
     dependee_targets = await Get(
-        TransitiveTargets, TransitiveTargetsRequest(tgt.address for tgt in targets)
+        TransitiveTargets, TransitiveTargetsRequest(resolves_to_addresses.get(request.resolve, ()))
     )
-    resolvable_dependencies = [
-        tgt for tgt in dependee_targets.closure if JvmArtifactFieldSet.is_applicable(tgt)
-    ]
-
     artifact_requirements = ArtifactRequirements(
-        [ArtifactRequirement.from_jvm_artifact_target(tgt) for tgt in resolvable_dependencies]
+        ArtifactRequirement.from_jvm_artifact_target(tgt)
+        for tgt in dependee_targets.closure
+        if JvmArtifactFieldSet.is_applicable(tgt)
     )
 
     resolved_lockfile = await Get(

--- a/src/python/pants/jvm/goals/coursier.py
+++ b/src/python/pants/jvm/goals/coursier.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass
+from typing import Sequence
 
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.engine.addresses import Address
@@ -73,8 +74,8 @@ async def map_resolves_to_consuming_targets(
             resolve_to_addresses[resolve].add(tgt.address)
         elif tgt.has_field(JvmCompatibleResolvesField):
             # TODO: add a `default_compatible_resolves` field.
-            resolves = tgt[JvmCompatibleResolvesField].value or (
-                [jvm.default_resolve] if jvm.default_resolve else []
+            resolves: Sequence[str] = tgt[JvmCompatibleResolvesField].value or (
+                [jvm.default_resolve] if jvm.default_resolve is not None else []
             )
             for resolve in resolves:
                 resolve_to_addresses[resolve].add(tgt.address)

--- a/src/python/pants/jvm/goals/coursier.py
+++ b/src/python/pants/jvm/goals/coursier.py
@@ -29,7 +29,7 @@ from pants.jvm.resolve.coursier_fetch import (
     CoursierResolvedLockfile,
 )
 from pants.jvm.subsystems import JvmSubsystem
-from pants.jvm.target_types import JvmArtifactFieldSet, JvmCompatibleResolveNamesField
+from pants.jvm.target_types import JvmArtifactFieldSet, JvmCompatibleResolvesField
 
 
 class CoursierResolveSubsystem(GoalSubsystem):
@@ -64,12 +64,12 @@ async def get_jvm_targets_by_resolve_name(
 ) -> JvmTargetsByResolveName:
     # Get all targets that depend on JVM resolves
 
-    targets = [tgt for tgt in all_targets if tgt.has_field(JvmCompatibleResolveNamesField)]
+    targets = [tgt for tgt in all_targets if tgt.has_field(JvmCompatibleResolvesField)]
 
     default_resolve: str | None = jvm.options.default_resolve
 
     # TODO: simplify this with Py3.9 walrus operator
-    flat_targets_ = ((tgt, tgt[JvmCompatibleResolveNamesField].value) for tgt in targets)
+    flat_targets_ = ((tgt, tgt[JvmCompatibleResolvesField].value) for tgt in targets)
     flat_targets__ = (
         (
             tgt,

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -658,19 +658,19 @@ async def coursier_fetch_lockfile(lockfile: CoursierResolvedLockfile) -> Resolve
 async def select_coursier_resolve_for_targets(
     targets: Targets, jvm: JvmSubsystem
 ) -> CoursierResolveKey:
-    encountered_resolves = []
-    encountered_compatible_resolves = []
+    encountered_resolves: list[str] = []
+    encountered_compatible_resolves: list[str] = []
     for tgt in targets:
         if tgt.has_field(JvmResolveField):
             resolve = tgt[JvmResolveField].value or jvm.default_resolve
             # TODO: remove once we always have a default resolve.
-            if not resolve:
+            if resolve is None:
                 continue
             encountered_resolves.append(resolve)
         if tgt.has_field(JvmCompatibleResolvesField):
             encountered_compatible_resolves.extend(
                 tgt[JvmCompatibleResolvesField].value
-                or ([jvm.default_resolve] if jvm.default_resolve else [])
+                or ([jvm.default_resolve] if jvm.default_resolve is not None else [])
             )
 
     # TODO: validate that all specified resolves are defined in [jvm].resolves and that all

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -6,10 +6,8 @@ from __future__ import annotations
 import dataclasses
 import json
 import logging
-import operator
 import os
 from dataclasses import dataclass
-from functools import reduce
 from itertools import chain
 from typing import Any, FrozenSet, Iterable, Iterator, List, Tuple
 from urllib.parse import quote_plus as url_quote_plus
@@ -31,13 +29,7 @@ from pants.engine.fs import (
 )
 from pants.engine.process import BashBinary, Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import (
-    InvalidTargetException,
-    Target,
-    Targets,
-    TransitiveTargets,
-    TransitiveTargetsRequest,
-)
+from pants.engine.target import InvalidTargetException, Target, Targets
 from pants.engine.unions import UnionRule
 from pants.jvm.compile import (
     ClasspathEntry,
@@ -57,6 +49,7 @@ from pants.jvm.target_types import (
     JvmArtifactUrlField,
     JvmArtifactVersionField,
     JvmCompatibleResolvesField,
+    JvmResolveField,
 )
 from pants.jvm.util_rules import ExtractFileDigest
 from pants.util.logging import LogLevel
@@ -665,107 +658,44 @@ async def coursier_fetch_lockfile(lockfile: CoursierResolvedLockfile) -> Resolve
 async def select_coursier_resolve_for_targets(
     targets: Targets, jvm: JvmSubsystem
 ) -> CoursierResolveKey:
-    """Determine the lockfile that applies for given JVM targets and resolve configuration.
+    encountered_resolves = []
+    encountered_compatible_resolves = []
+    for tgt in targets:
+        if tgt.has_field(JvmResolveField):
+            resolve = tgt[JvmResolveField].value or jvm.default_resolve
+            # TODO: remove once we always have a default resolve.
+            if not resolve:
+                continue
+            encountered_resolves.append(resolve)
+        if tgt.has_field(JvmCompatibleResolvesField):
+            encountered_compatible_resolves.extend(
+                tgt[JvmCompatibleResolvesField].value
+                or ([jvm.default_resolve] if jvm.default_resolve else [])
+            )
 
-    This walks the target's transitive dependencies to find the set of resolve names that are
-    compatible with the entirety of this build (defined as the intersection of all
-    `compatible_resolves` fields). This is then compared with the JVM subsystem's `resolves` flag to
-    determine which resolve to use for this scenario.
-    """
+    # TODO: validate that all specified resolves are defined in [jvm].resolves and that all
+    #  encountered resolves are compatible with each other. Note that we don't validate that
+    #  dependencies are compatible, just the specified targets.
 
-    default_resolve_name: str | None = jvm.options.default_resolve
-
-    transitive_targets = await Get(
-        TransitiveTargets, TransitiveTargetsRequest(target.address for target in targets)
-    )
-
-    transitive_jvm_resolve_names = [
-        target[JvmCompatibleResolvesField].value
-        for target in transitive_targets.closure
-        if target.has_field(JvmCompatibleResolvesField)
-    ]
-
-    any_unspecified_resolves = not transitive_jvm_resolve_names or any(
-        i is None for i in transitive_jvm_resolve_names
-    )
-
-    if not default_resolve_name and any_unspecified_resolves:
-        raise CoursierError(
-            "Either the `--jvm-default-resolve` must be set, or all JVM source targets must "
-            "specify their `compatible_resolves` in order to materialize the classpath."
-        )
-
-    transitive_jvm_resolve_names_ = (
-        # If any resolves are unspecified, the only acceptable resolve will be the default one,
-        # but individual targets must also support the default resolve if they specify _any_
-        # compatible resolves.
-        set(resolves)
-        if resolves is not None
-        else {default_resolve_name}
-        if default_resolve_name is not None
-        else set()
-        for resolves in transitive_jvm_resolve_names
-    )
-    compatible_resolves = reduce(operator.iand, transitive_jvm_resolve_names_)
-
-    if not compatible_resolves:
-        raise CoursierError(
-            "There are no resolve names that are compatible with all of the targets in this build. "
-            f"The targets are {targets}.  At least one resolve must be compatible with every "
-            "target -- including dependencies and transitive dependencies in order to complete the "
-            "build."
-        )
-
-    available_resolves = jvm.options.resolves
-    if not available_resolves:
-        raise CoursierError(
-            "No values were set for `--jvm-resolves`, so we can't fulfil any dependencies for the "
-            "build. You can fix this by specifying `--jvm-resolves`."
-        )
-    available_resolve_names = set(available_resolves.keys())
-    usable_resolve_names = compatible_resolves & available_resolve_names
-
-    if not usable_resolve_names:
-        raise CoursierError(
-            "None of the resolves specified in the `--jvm-resolves` option are compatible with "
-            "all of the targets (including dependencies) in this build. You supplied the following "
-            f"resolve names: {available_resolve_names}, but the compatible resolve names are: "
-            f"{compatible_resolves}."
-        )
-
-    # Resolve to use is:
-    # - The resolve name that is specifically requested (by `--jvm-use-resolve`; eventually by
-    #     the `deploy_jar` target, but not yet)
-    # - The default resolve name
-
-    # See if any target has a specified resolve:
-
-    specified_resolve: str | None = jvm.options.use_resolve
-    if specified_resolve is not None and specified_resolve not in available_resolve_names:
-        raise CoursierError(
-            f"You specified the resolve name `{specified_resolve}`, however, that resolve does not "
-            f"exist. The available resolve names are `{available_resolve_names}`."
-        )
-
-    resolve_name: str
-    if specified_resolve:
-        resolve_name = specified_resolve
-    if default_resolve_name is not None and default_resolve_name in usable_resolve_names:
-        resolve_name = default_resolve_name
+    if len(encountered_resolves) > 1:
+        raise AssertionError(f"Encountered >1 `resolve` field, which was not expected. {targets}")
+    elif len(encountered_resolves) == 1:
+        resolve = encountered_resolves[0]
+    elif encountered_compatible_resolves:
+        resolve = min(encountered_compatible_resolves)
     else:
-        # Pick a consistent default resolve name
-        resolve_name = min(usable_resolve_names)
+        raise AssertionError(
+            f"No `resolve` or `compatible_resolves` specified for these targets: {targets}"
+        )
 
-    resolve_path = available_resolves[resolve_name]
-
+    resolve_path = jvm.resolves[resolve]
     lockfile_source = PathGlobs(
         [resolve_path],
         glob_match_error_behavior=GlobMatchErrorBehavior.error,
-        description_of_origin=f"Path associated with the JVM resolve with name '{resolve_name}'",
+        description_of_origin=f"The resolve `{resolve}` from `[jvm].resolves`",
     )
     resolve_digest = await Get(Digest, PathGlobs, lockfile_source)
-
-    return CoursierResolveKey(resolve_name, resolve_path, resolve_digest)
+    return CoursierResolveKey(resolve, resolve_path, resolve_digest)
 
 
 @rule

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -663,9 +663,7 @@ async def coursier_fetch_lockfile(lockfile: CoursierResolvedLockfile) -> Resolve
 
 @rule
 async def select_coursier_resolve_for_targets(
-    targets: Targets,
-    jvm: JvmSubsystem,
-    coursier: Coursier,
+    targets: Targets, jvm: JvmSubsystem
 ) -> CoursierResolveKey:
     """Determine the lockfile that applies for given JVM targets and resolve configuration.
 
@@ -770,28 +768,13 @@ async def select_coursier_resolve_for_targets(
     return CoursierResolveKey(resolve_name, resolve_path, resolve_digest)
 
 
-@dataclass(frozen=True)
-class CoursierLockfileForTargetRequest:
-    targets: Targets
-
-
 @rule
 async def get_coursier_lockfile_for_resolve(
     coursier_resolve: CoursierResolveKey,
 ) -> CoursierResolvedLockfile:
-
     lockfile_digest_contents = await Get(DigestContents, Digest, coursier_resolve.digest)
     lockfile_contents = lockfile_digest_contents[0].content
-
     return CoursierResolvedLockfile.from_json_dict(json.loads(lockfile_contents))
-
-
-@rule
-async def get_coursier_lockfile_for_target(
-    request: CoursierLockfileForTargetRequest,
-) -> CoursierResolvedLockfile:
-    coursier_resolve = await Get(CoursierResolveKey, Targets, request.targets)
-    return await Get(CoursierResolvedLockfile, CoursierResolveKey, coursier_resolve)
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -56,7 +56,7 @@ from pants.jvm.target_types import (
     JvmArtifactTarget,
     JvmArtifactUrlField,
     JvmArtifactVersionField,
-    JvmCompatibleResolveNamesField,
+    JvmCompatibleResolvesField,
 )
 from pants.jvm.util_rules import ExtractFileDigest
 from pants.util.logging import LogLevel
@@ -682,9 +682,9 @@ async def select_coursier_resolve_for_targets(
     )
 
     transitive_jvm_resolve_names = [
-        target[JvmCompatibleResolveNamesField].value
+        target[JvmCompatibleResolvesField].value
         for target in transitive_targets.closure
-        if target.has_field(JvmCompatibleResolveNamesField)
+        if target.has_field(JvmCompatibleResolvesField)
     ]
 
     any_unspecified_resolves = not transitive_jvm_resolve_names or any(

--- a/src/python/pants/jvm/subsystems.py
+++ b/src/python/pants/jvm/subsystems.py
@@ -3,11 +3,9 @@
 
 from __future__ import annotations
 
-import logging
+from typing import cast
 
 from pants.option.subsystem import Subsystem
-
-logger = logging.getLogger(__name__)
 
 
 class JvmSubsystem(Subsystem):
@@ -20,25 +18,20 @@ class JvmSubsystem(Subsystem):
         register(
             "--resolves",
             type=dict,
-            help=("A dictionary, mapping resolve names to the path of their lockfile. "),
+            help="A dictionary mapping resolve names to the path of their lockfile.",
         )
-
         register(
             "--default-resolve",
             type=str,
-            help=(
-                "The name of the resolve to use by default, if a specific one is not specified "
-                "using `--jvm-use-resolve`. This name must be one of the keys specified in "
-                "`--jvm-resolves`."
-            ),
+            # TODO: Default this to something like `jvm-default`.
+            default=None,
+            help="The name of the resolve to use by default.",
         )
 
-        register(
-            "--use-resolve",
-            type=str,
-            help=(
-                "The name of the resolve to use for this build. This name must be one of the keys "
-                "specified in `--jvm-resolves`. If this or `--default-resolve` is not specified, "
-                "one compatible resolve will be used instead."
-            ),
-        )
+    @property
+    def resolves(self) -> dict[str, str]:
+        return cast("dict[str, str]", self.options.resolves)
+
+    @property
+    def default_resolve(self) -> str | None:
+        return cast(str, self.options.default_resolve)

--- a/src/python/pants/jvm/target_types.py
+++ b/src/python/pants/jvm/target_types.py
@@ -152,7 +152,7 @@ class JunitTestSourceField(SingleSourceField, metaclass=ABCMeta):
 # -----------------------------------------------------------------------------------------------
 
 
-class JvmCompatibleResolveNamesField(StringSequenceField):
+class JvmCompatibleResolvesField(StringSequenceField):
     alias = "compatible_resolves"
     required = False
     help = (
@@ -164,7 +164,7 @@ class JvmCompatibleResolveNamesField(StringSequenceField):
     )
 
 
-class JvmResolveNameField(StringField):
+class JvmResolveField(StringField):
     alias = "resolve"
     required = False
     help = (


### PR DESCRIPTION
We weren't properly handling the `resolve` field, which blocked switching our test targets to use `resolve` instead of `compatible_resolves` in https://github.com/pantsbuild/pants/pull/13870.

* When generating lockfiles, we ignored targets with `resolve`.
* When determining which lockfile to use, we ignored `resolve`.

The algorithm to determine which lockfile to use is fairly simplistic. If for the set of targets (~`CoarsenedTargets`) there is a `resolve` field, use that. Else, use any of the `compatible_resolves`. 

Some followups we still need to do:

* validate that the input to `CoursierResolveKey` is all compatible with each other
* validate that the dependencies of the `CoursierResolveKey` targets are compatible
* always set a default resolve
* add `default_compatible_resolves`
* update check to run on all relevant resolves for the root, whereas now we choose one
