### PR TITLE
[internal] go: merge test and regular embed configurations

### DIFF
--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -90,7 +90,11 @@ async def setup_build_go_package_target_request(
             # TODO: The `go` tool changes the displayed import path for the package when it has
             #  test files. Do we need to do something similar?
             go_file_names += _first_party_pkg_analysis.test_files
-            embed_config = _first_party_pkg_digest.test_embed_config
+            if _first_party_pkg_digest.test_embed_config:
+                if embed_config:
+                    embed_config = embed_config.merge(_first_party_pkg_digest.test_embed_config)
+                else:
+                    embed_config = _first_party_pkg_digest.test_embed_config
         s_file_names = _first_party_pkg_analysis.s_files
 
     elif target.has_field(GoThirdPartyPackageDependenciesField):

--- a/src/python/pants/backend/go/util_rules/embedcfg.py
+++ b/src/python/pants/backend/go/util_rules/embedcfg.py
@@ -56,3 +56,33 @@ class EmbedConfig:
 
     def __bool__(self) -> bool:
         return bool(self.patterns) or bool(self.files)
+
+    def merge(self, other: EmbedConfig) -> EmbedConfig:
+        """Merge two EmbedConfig's into one.
+
+        Overlapping keys must have the same values.
+        """
+        overlapping_patterns_keys = set(self.patterns.keys()) & set(other.patterns.keys())
+        for key in overlapping_patterns_keys:
+            if self.patterns[key] != other.patterns[key]:
+                raise AssertionError(
+                    "Unable to merge conflicting golang file embed configurations. This should not have occurred. "
+                    "Please open an issue at https://github.com/pantsbuild/pants/issues/new/choose "
+                    "with the following information: "
+                    f"Patterns Key: {key}; Left: {self.patterns[key]}; Right: {other.patterns[key]} "
+                )
+
+        overlapping_files_keys = set(self.files.keys()) & set(other.files.keys())
+        for key in overlapping_files_keys:
+            if self.files[key] != other.files[key]:
+                raise AssertionError(
+                    "Unable to merge conflicting golang file embed configurations. This should not have occurred. "
+                    "Please open an issue at https://github.com/pantsbuild/pants/issues/new/choose "
+                    "with the following information: "
+                    f"Files Key: {key}; Left: {self.patterns[key]}; Right: {other.patterns[key]} "
+                )
+
+        return EmbedConfig(
+            patterns={**self.patterns, **other.patterns},
+            files={**self.files, **other.files},
+        )

--- a/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
@@ -367,7 +367,6 @@ def test_embeds_supported(rule_runner: RuleRunner) -> None:
     )
 
 
-@pytest.mark.xfail
 def test_missing_embeds(rule_runner: RuleRunner) -> None:
     """Failing to set up embeds should not crash Pants."""
     rule_runner.write_files(
@@ -401,4 +400,4 @@ def test_missing_embeds(rule_runner: RuleRunner) -> None:
     assert maybe_digest.pkg_digest is None
     assert maybe_digest.exit_code == 1
     assert maybe_digest.stderr is not None
-    assert "Failed to find embedded resources: could not embed grok.txt" in maybe_digest.stderr
+    assert "Failed to find embedded resources: could not embed fake.txt" in maybe_digest.stderr


### PR DESCRIPTION
File embedding was broken for packages with internal tests because the embed configuration from the internal tests overwrote the embed configurations from the regular sources.

The solution is to merge both embed configurations.

[ci skip-rust]