### PR TITLE
Provide helpful error message in case of undefined Docker build arg.

### DIFF
--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -217,7 +217,7 @@ def test_build_docker_image(rule_runner: RuleRunner) -> None:
     err1 = (
         r"Invalid value for the `repository` field of the `docker_image` target at "
         r"docker/test:err1: '{bad_template}'\.\n\nThe placeholder 'bad_template' is unknown\. "
-        r"Try with one of: directory, name, parent_directory\."
+        r"Try with one of: build_args, directory, name, parent_directory\."
     )
     with pytest.raises(DockerRepositoryNameError, match=err1):
         assert_build(

--- a/src/python/pants/backend/docker/target_types.py
+++ b/src/python/pants/backend/docker/target_types.py
@@ -170,7 +170,7 @@ class DockerBuildSecretsOptionField(
 ):
     alias = "secrets"
     help = (
-        "Secret file to expose to the build (only if BuildKit enabled).\n\n"
+        "Secret files to expose to the build (only if BuildKit enabled).\n\n"
         "Secrets may use absolute paths, or paths relative to your BUILD file. The id should be "
         "valid as used by the Docker build `--secret` option. "
         "See [Docker secrets](https://docs.docker.com/engine/swarm/secrets/) for more "
@@ -181,7 +181,8 @@ class DockerBuildSecretsOptionField(
 
                 docker_image(
                     secrets={
-                        "mysecret": "/local/secret",
+                        "mysecret": "/var/secrets/some-secret",
+                        "repo-secret": "proj/path/some-secret",
                     }
                 )
             """


### PR DESCRIPTION
Fixes #13850 

Also sneaked in a few remaining minor nits from a previous PR, in `../docker/target_types.py`.