### PR TITLE
[jvm] Fix `tailor` for the addition of `Scalatest`

### DIFF
--- a/src/python/pants/backend/scala/goals/BUILD
+++ b/src/python/pants/backend/scala/goals/BUILD
@@ -2,3 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_sources()
+
+python_tests(
+    name="tests",
+)

--- a/src/python/pants/backend/scala/goals/tailor_test.py
+++ b/src/python/pants/backend/scala/goals/tailor_test.py
@@ -1,0 +1,26 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+
+from pants.backend.scala.goals.tailor import classify_source_files
+from pants.backend.scala.target_types import (
+    ScalaJunitTestsGeneratorTarget,
+    ScalaSourcesGeneratorTarget,
+    ScalatestTestsGeneratorTarget,
+)
+
+
+def test_classify_source_files() -> None:
+    scalatest_files = {
+        "foo/bar/BazSpec.scala",
+    }
+    junit_files = {
+        "foo/bar/BazTest.scala",
+    }
+    lib_files = {"foo/bar/Baz.scala"}
+
+    assert {
+        ScalatestTestsGeneratorTarget: scalatest_files,
+        ScalaJunitTestsGeneratorTarget: junit_files,
+        ScalaSourcesGeneratorTarget: lib_files,
+    } == classify_source_files(junit_files | lib_files | scalatest_files)


### PR DESCRIPTION
#13872 broke `tailor` for `*Specs` tests, since after matching for `scalatest_test`, it created a `scala_junit_test` target (which wouldn't match the glob).

[ci skip-rust]
[ci skip-build-wheels]