### PR TITLE
[internal] Add `compatible_resolves` to `jvm_artifact` target

### DIFF
--- a/3rdparty/jvm/com/fasterxml/jackson/core/BUILD
+++ b/3rdparty/jvm/com/fasterxml/jackson/core/BUILD
@@ -8,4 +8,5 @@ jvm_artifact(
     # NB: Keep in sync with all other `3rdparty/jvm/com/fasterxml/jackson` libraries.
     # See https://github.com/pantsbuild/pants/issues/13767 for how this might be deduped.
     version="2.12.4",
+    compatible_resolves=["java_parser"],
 )

--- a/3rdparty/jvm/com/fasterxml/jackson/datatype/BUILD
+++ b/3rdparty/jvm/com/fasterxml/jackson/datatype/BUILD
@@ -8,4 +8,5 @@ jvm_artifact(
     # NB: Keep in sync with all other `3rdparty/jvm/com/fasterxml/jackson` libraries.
     # See https://github.com/pantsbuild/pants/issues/13767 for how this might be deduped.
     version="2.12.4",
+    compatible_resolves=["java_parser"],
 )

--- a/3rdparty/jvm/com/github/javaparser/BUILD
+++ b/3rdparty/jvm/com/github/javaparser/BUILD
@@ -6,4 +6,5 @@ jvm_artifact(
     group="com.github.javaparser",
     artifact="javaparser-symbol-solver-core",
     version="3.23.0",
+    compatible_resolves=["java_parser"],
 )

--- a/3rdparty/jvm/io/circe/BUILD
+++ b/3rdparty/jvm/io/circe/BUILD
@@ -6,4 +6,5 @@ jvm_artifact(
     group="io.circe",
     artifact="circe-generic_2.13",
     version="0.14.1",
+    compatible_resolves=["scala_parser"],
 )

--- a/3rdparty/jvm/org/scalameta/BUILD
+++ b/3rdparty/jvm/org/scalameta/BUILD
@@ -7,4 +7,5 @@ jvm_artifact(
     artifact="scalameta_2.13",
     version="4.4.30",
     packages=["scala.meta.**"],
+    compatible_resolves=["scala_parser"],
 )

--- a/src/python/pants/backend/java/dependency_inference/java_parser.lockfile
+++ b/src/python/pants/backend/java/dependency_inference/java_parser.lockfile
@@ -12,7 +12,9 @@
         "file_digest": {
             "fingerprint": "f6aa3706a875689b66cdac3334f65dfdb795ccfad4117bf072893b196ed1ec8e",
             "serialized_bytes_length": 75705
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -27,7 +29,9 @@
         "file_digest": {
             "fingerprint": "3506ce47ec2604ae2d80d79505f7cb374f718060639415c07d144adadd2d68a3",
             "serialized_bytes_length": 365223
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -68,7 +72,9 @@
         "file_digest": {
             "fingerprint": "e99a7b4b89074bc689aabcd9eb1f2c1318b68cc5c34979daf3e34edc558c7a01",
             "serialized_bytes_length": 1516044
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -115,7 +121,9 @@
         "file_digest": {
             "fingerprint": "00852350fc1503344723b590f1afe9593ab732fb5b035659b503b49bbea5c9b2",
             "serialized_bytes_length": 34438
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -130,7 +138,9 @@
         "file_digest": {
             "fingerprint": "1d732f1b057b9e2ea69935180b5a6abf2c776f5e311a96651c3c03b0616032cc",
             "serialized_bytes_length": 1308975
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -219,7 +229,9 @@
         "file_digest": {
             "fingerprint": "a27067d886e72b35b4af31c8534f13ac54e924995f8f05ab2c3c4ab412ed3fb4",
             "serialized_bytes_length": 480392
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -234,7 +246,9 @@
         "file_digest": {
             "fingerprint": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
             "serialized_bytes_length": 19936
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -249,7 +263,9 @@
         "file_digest": {
             "fingerprint": "ff80626baaf12a09342befd4e84cba9d50662f5fcd7f7a9b3490a6b7cf87e66c",
             "serialized_bytes_length": 13854
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -264,7 +280,9 @@
         "file_digest": {
             "fingerprint": "a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26",
             "serialized_bytes_length": 4617
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -353,7 +371,9 @@
         "file_digest": {
             "fingerprint": "44ce229ce26d880bf3afc362bbfcec34d7e6903d195bbb1db9f3b6e0d9834f06",
             "serialized_bytes_length": 2874025
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -368,7 +388,9 @@
         "file_digest": {
             "fingerprint": "b372a037d4230aa57fbeffdef30fd6123f9c0c2db85d0aced00c91b974f33f99",
             "serialized_bytes_length": 2199
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -383,7 +405,9 @@
         "file_digest": {
             "fingerprint": "21af30c92267bd6122c0e0b4d20cccb6641a37eaf956c6540ec471d584e64a7b",
             "serialized_bytes_length": 8781
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -398,7 +422,9 @@
         "file_digest": {
             "fingerprint": "c88c2e6a5fdaeb9f26fcf879264042de8a9ee9d376e2477838feaabcfa44dda6",
             "serialized_bytes_length": 230905
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -413,6 +439,8 @@
         "file_digest": {
             "fingerprint": "57d0a9e9286f82f4eaa851125186997f811befce0e2060ff0a15a77f5a9dd9a7",
             "serialized_bytes_length": 851531
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     }
 ]

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.lockfile
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.lockfile
@@ -26,7 +26,9 @@
         "file_digest": {
             "fingerprint": "072c83eca9996aed92310dc7225cfc313edc7b74a3a96e2bf25459ebfc04ac96",
             "serialized_bytes_length": 3221281
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -41,7 +43,9 @@
         "file_digest": {
             "fingerprint": "8d0e2f9834f4fc1a083a65239adc507ca83682c754a27f4c80e4f21990eff686",
             "serialized_bytes_length": 1674945
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -56,7 +60,9 @@
         "file_digest": {
             "fingerprint": "ca3857a3f95266e0d87e1a1f26c8592c53c12ac7203f911759415f6c8a43df7d",
             "serialized_bytes_length": 85365
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -71,7 +77,9 @@
         "file_digest": {
             "fingerprint": "a639a90e2d21bbafd8a5e213c65442aad200ee086951605cbda8835bc6ef11d3",
             "serialized_bytes_length": 118671
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -112,7 +120,9 @@
         "file_digest": {
             "fingerprint": "18943a007752b150ae45f27e901c34f0e92009304f2f804ef156ab3056d79874",
             "serialized_bytes_length": 34801
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -177,7 +187,9 @@
         "file_digest": {
             "fingerprint": "3be88effcb57ea136a2e5c377cdda3924d61b024afc2169f892c46662e266288",
             "serialized_bytes_length": 2421167
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -242,7 +254,9 @@
         "file_digest": {
             "fingerprint": "9c196ded5b0c2a710a57bcb36be1f0971915353f08ae587a1541f4b114853edf",
             "serialized_bytes_length": 1116215
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -319,7 +333,9 @@
         "file_digest": {
             "fingerprint": "a664c96f45c70b2d6165907b7ffc5ea9696921c5a13843b0bc8dc72fb0ade7e6",
             "serialized_bytes_length": 175900
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -348,7 +364,9 @@
         "file_digest": {
             "fingerprint": "03b8e75db5d2b8bcae53fd106af404a82297e8d864a9c04cbe7931823c79254e",
             "serialized_bytes_length": 13018
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -363,7 +381,9 @@
         "file_digest": {
             "fingerprint": "930273cc1c492f25661ea62413a6da3fd7f6e01bf1c4dcc0817fc8696a7b07ac",
             "serialized_bytes_length": 1729586
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -378,7 +398,9 @@
         "file_digest": {
             "fingerprint": "e2ee4b0bd3a2248f9ec6cf33f7d5b97e34ae652aecd3f42e13bded91f0df6bb6",
             "serialized_bytes_length": 992903
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -407,7 +429,9 @@
         "file_digest": {
             "fingerprint": "f17aec79f7588c60c028d879affe1bbbb92b3d2475cf8fa44b0afb9d3da2861f",
             "serialized_bytes_length": 5609
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -472,7 +496,9 @@
         "file_digest": {
             "fingerprint": "a450602f03a4686919e60d1aeced549559f1eaffbaf30ffa7987c8d97e3e79a9",
             "serialized_bytes_length": 12092802
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -487,7 +513,9 @@
         "file_digest": {
             "fingerprint": "a8bc08f3b9ff93d0496032bf2677163071b8d212992f41dbf04212e07d91616b",
             "serialized_bytes_length": 6004712
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -516,7 +544,9 @@
         "file_digest": {
             "fingerprint": "a7bc4eca6970083d426a8d081aec313c7b7207d5f83b6724995e34078edc5cbb",
             "serialized_bytes_length": 3771937
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -569,7 +599,9 @@
         "file_digest": {
             "fingerprint": "f6fb1c7f4ff257edb900d66e02d6ee1c8b5b4d7f7084b2d1710120cd36c524cc",
             "serialized_bytes_length": 530688
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -640,7 +672,9 @@
         "file_digest": {
             "fingerprint": "faec8003d08e27971b292062f79e16a4a428491f50736d140b8a1de38cd5c6b1",
             "serialized_bytes_length": 2344659
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -681,7 +715,9 @@
         "file_digest": {
             "fingerprint": "8fca8597ad6d7c13c48009ee13bbe80c176b08ab12e68af54a50f7f69d8447c5",
             "serialized_bytes_length": 320855
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -770,7 +806,9 @@
         "file_digest": {
             "fingerprint": "66c78cdb5ed6c6345089603eee8e1b41392245252019d1268bd87fd97a7d8bcc",
             "serialized_bytes_length": 1364598
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -901,7 +939,9 @@
         "file_digest": {
             "fingerprint": "2ee7a9b93baa8ca2213f516ed3ced26990fe34e3df4ddb149ee58aa5d46d6160",
             "serialized_bytes_length": 791746
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -990,7 +1030,9 @@
         "file_digest": {
             "fingerprint": "79fdf691ff0f75265c99422f31db519ee044e88f52a32bbc39d30c16f6781315",
             "serialized_bytes_length": 4274882
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -1043,7 +1085,9 @@
         "file_digest": {
             "fingerprint": "263d5982aa88702a3c8024d792f9dcc237cd0c6da3cca610c1fcc107c337b49a",
             "serialized_bytes_length": 5914514
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -1072,7 +1116,9 @@
         "file_digest": {
             "fingerprint": "485f13f6e0071b6a526061ab74f8711d0db20c58c6a692d08067de87f8d0133c",
             "serialized_bytes_length": 5262002
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -1101,6 +1147,8 @@
         "file_digest": {
             "fingerprint": "0efeedbb2ab7ffe517a8a5279998a2a85e1eedc1a9374289c6104b49a98912e8",
             "serialized_bytes_length": 7201
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     }
 ]

--- a/src/python/pants/jvm/goals/coursier.py
+++ b/src/python/pants/jvm/goals/coursier.py
@@ -7,7 +7,6 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Sequence
 
-from pants.engine.addresses import Address
 from pants.engine.console import Console
 from pants.engine.fs import (
     EMPTY_DIGEST,
@@ -32,7 +31,6 @@ from pants.jvm.resolve.coursier_fetch import (
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmArtifactCompatibleResolvesField
 from pants.util.frozendict import FrozenDict
-from pants.util.ordered_set import FrozenOrderedSet
 
 
 class CoursierResolveSubsystem(GoalSubsystem):

--- a/src/python/pants/jvm/goals/coursier.py
+++ b/src/python/pants/jvm/goals/coursier.py
@@ -57,7 +57,7 @@ class CoursierResolve(Goal):
     subsystem_cls = CoursierResolveSubsystem
 
 
-class JvmResolvesToArtifacts(FrozenDict[str, FrozenOrderedSet[Address]]):
+class JvmResolvesToArtifacts(FrozenDict[str, ArtifactRequirements]):
     pass
 
 

--- a/src/python/pants/jvm/goals/coursier.py
+++ b/src/python/pants/jvm/goals/coursier.py
@@ -68,7 +68,8 @@ async def map_resolves_to_consuming_targets(
         if not tgt.has_field(JvmArtifactCompatibleResolvesField):
             continue
         # TODO: add a `default_compatible_resolves` field.
-        # TODO: error if no resolves for the target? Which would mean it's practically invisible.
+        # TODO: error if no resolves for the target. Wait to change until we automatically set a
+        #  default resolve.
         resolves: Sequence[str] = tgt[JvmArtifactCompatibleResolvesField].value or (
             [jvm.default_resolve] if jvm.default_resolve is not None else []
         )
@@ -109,9 +110,8 @@ async def coursier_generate_lockfile(
 ) -> CoursierGenerateLockfileResult:
     resolved_lockfile = await Get(
         CoursierResolvedLockfile,
-        ArtifactRequirements,
-        # TODO: error if no artifacts associated with a resolve?
-        resolves_to_artifacts.get(request.resolve, ()),
+        # Note that it's legal to have a resolve with no artifacts.
+        ArtifactRequirements(resolves_to_artifacts.get(request.resolve, ())),
     )
     resolved_lockfile_json = resolved_lockfile.to_json()
     lockfile_path = jvm.resolves[request.resolve]

--- a/src/python/pants/jvm/goals/coursier.py
+++ b/src/python/pants/jvm/goals/coursier.py
@@ -22,7 +22,7 @@ from pants.engine.fs import (
 )
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
-from pants.engine.target import AllTargets, TransitiveTargets, TransitiveTargetsRequest
+from pants.engine.target import AllTargets
 from pants.jvm.resolve.coursier_fetch import (
     ArtifactRequirement,
     ArtifactRequirements,
@@ -30,7 +30,7 @@ from pants.jvm.resolve.coursier_fetch import (
     CoursierResolvedLockfile,
 )
 from pants.jvm.subsystems import JvmSubsystem
-from pants.jvm.target_types import JvmArtifactFieldSet, JvmCompatibleResolvesField, JvmResolveField
+from pants.jvm.target_types import JvmArtifactCompatibleResolvesField
 from pants.util.frozendict import FrozenDict
 from pants.util.ordered_set import FrozenOrderedSet
 
@@ -57,38 +57,35 @@ class CoursierResolve(Goal):
     subsystem_cls = CoursierResolveSubsystem
 
 
-class JvmResolvesToAddresses(FrozenDict[str, FrozenOrderedSet[Address]]):
+class JvmResolvesToArtifacts(FrozenDict[str, FrozenOrderedSet[Address]]):
     pass
 
 
 @rule
 async def map_resolves_to_consuming_targets(
     all_targets: AllTargets, jvm: JvmSubsystem
-) -> JvmResolvesToAddresses:
-    resolve_to_addresses = defaultdict(set)
+) -> JvmResolvesToArtifacts:
+    resolve_to_artifacts = defaultdict(set)
     for tgt in all_targets:
-        if tgt.has_field(JvmResolveField):
-            resolve = tgt[JvmResolveField].value or jvm.default_resolve
-            # TODO: remove once we always have a default resolve.
-            if not resolve:
-                continue
-            resolve_to_addresses[resolve].add(tgt.address)
-        elif tgt.has_field(JvmCompatibleResolvesField):
-            # TODO: add a `default_compatible_resolves` field.
-            resolves: Sequence[str] = tgt[JvmCompatibleResolvesField].value or (
-                [jvm.default_resolve] if jvm.default_resolve is not None else []
-            )
-            for resolve in resolves:
-                resolve_to_addresses[resolve].add(tgt.address)
-    return JvmResolvesToAddresses(
-        (resolve, FrozenOrderedSet(addresses))
-        for resolve, addresses in resolve_to_addresses.items()
+        if not tgt.has_field(JvmArtifactCompatibleResolvesField):
+            continue
+        # TODO: add a `default_compatible_resolves` field.
+        # TODO: error if no resolves for the target? Which would mean it's practically invisible.
+        resolves: Sequence[str] = tgt[JvmArtifactCompatibleResolvesField].value or (
+            [jvm.default_resolve] if jvm.default_resolve is not None else []
+        )
+        artifact = ArtifactRequirement.from_jvm_artifact_target(tgt)
+        for resolve in resolves:
+            resolve_to_artifacts[resolve].add(artifact)
+    return JvmResolvesToArtifacts(
+        (resolve, ArtifactRequirements(artifacts))
+        for resolve, artifacts in resolve_to_artifacts.items()
     )
 
 
 @dataclass(frozen=True)
 class CoursierGenerateLockfileRequest:
-    """Regenerate a coursier_lockfile target's lockfile from its JVM requirements.
+    """Regenerate a lockfile from its JVM requirements.
 
     This request allows a user to manually regenerate their lockfile. This is done for a few reasons: to
     generate the lockfile for the first time, to regenerate it because the input JVM requirements
@@ -110,21 +107,13 @@ class CoursierGenerateLockfileResult:
 async def coursier_generate_lockfile(
     request: CoursierGenerateLockfileRequest,
     jvm: JvmSubsystem,
-    resolves_to_addresses: JvmResolvesToAddresses,
+    resolves_to_artifacts: JvmResolvesToArtifacts,
 ) -> CoursierGenerateLockfileResult:
-    # Find JVM artifacts in the dependency tree of the targets that depend on this lockfile.
-    # These artifacts constitute the requirements that will be resolved for this lockfile.
-    dependee_targets = await Get(
-        TransitiveTargets, TransitiveTargetsRequest(resolves_to_addresses.get(request.resolve, ()))
-    )
-    artifact_requirements = ArtifactRequirements(
-        ArtifactRequirement.from_jvm_artifact_target(tgt)
-        for tgt in dependee_targets.closure
-        if JvmArtifactFieldSet.is_applicable(tgt)
-    )
-
     resolved_lockfile = await Get(
-        CoursierResolvedLockfile, ArtifactRequirements, artifact_requirements
+        CoursierResolvedLockfile,
+        ArtifactRequirements,
+        # TODO: error if no artifacts associated with a resolve?
+        resolves_to_artifacts.get(request.resolve, ()),
     )
     resolved_lockfile_json = resolved_lockfile.to_json()
     lockfile_path = jvm.resolves[request.resolve]

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -491,10 +491,7 @@ async def coursier_resolve_lockfile(
 
 
 @rule(desc="Fetch with coursier")
-async def fetch_with_coursier(
-    coursier: Coursier,
-    request: CoursierFetchRequest,
-) -> FallibleClasspathEntry:
+async def fetch_with_coursier(request: CoursierFetchRequest) -> FallibleClasspathEntry:
     # TODO: Loading this per JvmArtifact.
     lockfile = await Get(CoursierResolvedLockfile, CoursierResolveKey, request.resolve)
 

--- a/src/python/pants/jvm/target_types.py
+++ b/src/python/pants/jvm/target_types.py
@@ -154,6 +154,21 @@ class JvmProvidesTypesField(StringSequenceField):
     )
 
 
+class JvmArtifactCompatibleResolvesField(JvmCompatibleResolvesField):
+    help = (
+        "The resolves that this artifact should be included in.\n\n"
+        # TODO: Switch to `[jvm].default_compatible_resolves`.
+        "If not defined, will default to `[jvm].default_resolve`.\n\n"
+        "Each name must be defined as a resolve in `[jvm].resolves`.\n\n"
+        "When generating a lockfile for a particular resolve via the `coursier-resolve` goal, "
+        "it will include all artifacts that are declared compatible with that resolve. First-party "
+        "targets like `java_source` and `scala_source` then declare which resolve(s) they use "
+        "via the `resolve` and `compatible_resolves` field; so, for your first-party code to use "
+        "a particular `jvm_artifact` target, that artifact must be included in the resolve(s) "
+        "used by that code."
+    )
+
+
 class JvmArtifactFieldSet(FieldSet):
     group: JvmArtifactGroupField
     artifact: JvmArtifactArtifactField
@@ -176,10 +191,14 @@ class JvmArtifactTarget(Target):
         *JvmArtifactFieldSet.required_fields,
         JvmArtifactUrlField,  # TODO: should `JvmArtifactFieldSet` have an `all_fields` field?
         JvmArtifactJarSourceField,
+        JvmArtifactCompatibleResolvesField,
     )
     help = (
         "A third-party JVM artifact, as identified by its Maven-compatible coordinate.\n\n"
-        "That is, an artifact identified by its `group`, `artifact`, and `version` components."
+        "That is, an artifact identified by its `group`, `artifact`, and `version` components.\n\n"
+        "Each artifact is associated with one or more resolves (a logical name you give to a "
+        "lockfile). For this artifact to be used by your first-party code, it must be "
+        "associated with the resolve(s) used by that code. See the `compatible_resolves` field."
     )
 
     def validate(self) -> None:


### PR DESCRIPTION
Part of https://github.com/pantsbuild/pants/issues/13621.

As explained in https://github.com/pantsbuild/pants/issues/13621#issuecomment-992978245, `jvm_artifact` targets now declare explicitly which resolves they should be used with. Rather than where before we inferred this based on analyzing which first-party targets consumed the artifacts and worked backward by seeing the resolves those targets themselves used.

Having `jvm_artifact` targets declare which resolves they use is necessary for us to update dependency inference so that you can only infer deps on artifacts that belong to your resolve. Whereas right now you can infer deps on the entire universe of artifacts. We need to know what's in a resolve before any dependency inference has happened.

This change also brings clearer modeling for users, less magic. While there's more up-front work when you add a new `jvm_artifact`, it makes it much clearer what your intent is for where the resolve should be used.


[ci skip-rust]
[ci skip-build-wheels]