### PR TITLE
An include_requirements field on pex_binary.

### DIFF
--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -13,6 +13,7 @@ from pants.backend.python.target_types import (
     PexExecutionMode,
     PexExecutionModeField,
     PexIgnoreErrorsField,
+    PexIncludeRequirementsField,
     PexIncludeToolsField,
     PexInheritPathField,
     PexLayout,
@@ -68,6 +69,7 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
     resolve_local_platforms: PexResolveLocalPlatformsField
     layout: PexLayoutField
     execution_mode: PexExecutionModeField
+    include_requirements: PexIncludeRequirementsField
     include_tools: PexIncludeToolsField
     resolve: PythonResolveField
 
@@ -138,6 +140,7 @@ async def package_pex_binary(
             output_filename=output_filename,
             layout=PexLayout(field_set.layout.value),
             additional_args=field_set.generate_additional_args(pex_binary_defaults),
+            include_requirements=field_set.include_requirements.value,
             include_local_dists=True,
         ),
     )

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -504,6 +504,15 @@ class PexLayoutField(StringField):
     )
 
 
+class PexIncludeRequirementsField(BoolField):
+    alias = "include_requirements"
+    default = True
+    help = (
+        "Whether to include the third party requirements the binary depends on in the "
+        "packaged PEX file."
+    )
+
+
 class PexIncludeToolsField(BoolField):
     alias = "include_tools"
     default = False
@@ -533,6 +542,7 @@ class PexBinary(Target):
         PexEmitWarningsField,
         PexLayoutField,
         PexExecutionModeField,
+        PexIncludeRequirementsField,
         PexIncludeToolsField,
         RestartableField,
     )

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -70,6 +70,7 @@ class PexFromTargetsRequest:
     additional_lockfile_args: tuple[str, ...]
     additional_requirements: tuple[str, ...]
     include_source_files: bool
+    include_requirements: bool
     include_local_dists: bool
     additional_sources: Digest | None
     additional_inputs: Digest | None
@@ -93,6 +94,7 @@ class PexFromTargetsRequest:
         additional_lockfile_args: Iterable[str] = (),
         additional_requirements: Iterable[str] = (),
         include_source_files: bool = True,
+        include_requirements: bool = True,
         include_local_dists: bool = False,
         additional_sources: Digest | None = None,
         additional_inputs: Digest | None = None,
@@ -128,6 +130,7 @@ class PexFromTargetsRequest:
             Setting this to `False` and loading the source files by instead populating the chroot
             and setting the environment variable `PEX_EXTRA_SYS_PATH` will result in substantially
             fewer rebuilds of the Pex.
+        :param include_requirements: Whether to resolve requirements and include them in the Pex.
         :param include_local_dists: Whether to build local dists and include them in the built pex.
         :param additional_sources: Any additional source files to include in the built Pex.
         :param additional_inputs: Any inputs that are not source files and should not be included
@@ -150,6 +153,7 @@ class PexFromTargetsRequest:
         self.additional_lockfile_args = tuple(additional_lockfile_args)
         self.additional_requirements = tuple(additional_requirements)
         self.include_source_files = include_source_files
+        self.include_requirements = include_requirements
         self.include_local_dists = include_local_dists
         self.additional_sources = additional_sources
         self.additional_inputs = additional_inputs
@@ -345,17 +349,20 @@ async def pex_from_targets(request: PexFromTargetsRequest) -> PexRequest:
         Get(Digest, MergeDigests(additional_inputs_digests)),
     )
 
-    requirements = PexRequirements.create_from_requirement_fields(
-        (
-            tgt[PythonRequirementsField]
-            for tgt in relevant_targets.targets
-            if tgt.has_field(PythonRequirementsField)
-        ),
-        additional_requirements=request.additional_requirements,
-        apply_constraints=True,
-    )
-
     description = request.description
+
+    if request.include_requirements:
+        requirements = PexRequirements.create_from_requirement_fields(
+            (
+                tgt[PythonRequirementsField]
+                for tgt in relevant_targets.targets
+                if tgt.has_field(PythonRequirementsField)
+            ),
+            additional_requirements=request.additional_requirements,
+            apply_constraints=True,
+        )
+    else:
+        requirements = PexRequirements()
 
     if requirements:
         repository_pex = await Get(


### PR DESCRIPTION
The field defaults to True, but if explicitly set to False
the packaged Pex file will not contain requirements, only
first-party sources and resources.

This is useful if the requirements are huge but can be provided in the
deployment environment in some other way (e.g., in a prebuilt
virtualenv in a docker container).

Note that this does not affect `test`, `run`, `repl` etc, just packaging .pex files.

[ci skip-rust]

[ci skip-build-wheels]