### PR TITLE
Add Myst AI to users list.

### DIFF
--- a/build-support/bin/generate_user_list.py
+++ b/build-support/bin/generate_user_list.py
@@ -67,6 +67,7 @@ _orgs = (
         "https://files.readme.io/dd2a703-housinganywhere-small.png",
     ),
     Org("iManage", "https://imanage.com/", "https://files.readme.io/0f7b5f6-imanage-small.png"),
+    Org("Myst AI", "https://www.myst.ai/", "https://files.readme.io/802d8fa-myst_ai_small.png"),
     Org("Ocrolus", "https://www.ocrolus.com/", "https://files.readme.io/ff166fa-ocrolus-small.png"),
     Org(
         "Orca Security",


### PR DESCRIPTION
We'd applied this a while back, but were waiting for Orca to approve
re-adding them to the list, which they have now done. 

[ci skip-rust]

[ci skip-build-wheels]