### PR TITLE
[docs] Enable `Java` and `Scala` backends on the docsite

### DIFF
--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -201,9 +201,7 @@ def create_parser() -> argparse.ArgumentParser:
 def run_pants_help_all() -> dict[str, Any]:
     deactivated_backends = [
         "internal_plugins.releases",
-        "pants.backend.experimental.java",
         "pants.backend.experimental.java.debug_goals",
-        "pants.backend.experimental.scala",
         "pants.backend.experimental.scala.debug_goals",
     ]
     activated_backends = [


### PR DESCRIPTION
`2.9.0` will contain an alpha quality release of `Java` and `Scala` support. We should expose their targets and subsystems in the `2.9` docsite.

[ci skip-rust]
[ci skip-build-wheels]