### PR TITLE
[jvm] Apply the resolve for `deploy_jar` and restore validation of resolve compatibility

### DIFF
--- a/src/python/pants/backend/java/goals/check.py
+++ b/src/python/pants/backend/java/goals/check.py
@@ -9,7 +9,7 @@ from pants.backend.java.target_types import JavaFieldSet
 from pants.core.goals.check import CheckRequest, CheckResult, CheckResults
 from pants.engine.addresses import Addresses
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import CoarsenedTargets, Targets
+from pants.engine.target import CoarsenedTargets
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.jvm.compile import ClasspathEntryRequest, FallibleClasspathEntry
 from pants.jvm.resolve.key import CoursierResolveKey
@@ -31,8 +31,10 @@ async def javac_check(
         CoarsenedTargets, Addresses(field_set.address for field_set in request.field_sets)
     )
 
+    # NB: Each root can have an independent resolve, because there is no inherent relation
+    # between them other than that they were on the commandline together.
     resolves = await MultiGet(
-        Get(CoursierResolveKey, Targets(t.members)) for t in coarsened_targets
+        Get(CoursierResolveKey, CoarsenedTargets([t])) for t in coarsened_targets
     )
 
     results = await MultiGet(

--- a/src/python/pants/backend/scala/goals/check.py
+++ b/src/python/pants/backend/scala/goals/check.py
@@ -9,7 +9,7 @@ from pants.backend.scala.target_types import ScalaFieldSet
 from pants.core.goals.check import CheckRequest, CheckResult, CheckResults
 from pants.engine.addresses import Addresses
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import CoarsenedTargets, Targets
+from pants.engine.target import CoarsenedTargets
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.jvm.compile import ClasspathEntryRequest, FallibleClasspathEntry
 from pants.jvm.resolve.key import CoursierResolveKey
@@ -31,8 +31,10 @@ async def scalac_check(
         CoarsenedTargets, Addresses(field_set.address for field_set in request.field_sets)
     )
 
+    # NB: Each root can have an independent resolve, because there is no inherent relation
+    # between them other than that they were on the commandline together.
     resolves = await MultiGet(
-        Get(CoursierResolveKey, Targets(t.members)) for t in coarsened_targets
+        Get(CoursierResolveKey, CoarsenedTargets([t])) for t in coarsened_targets
     )
 
     results = await MultiGet(

--- a/src/python/pants/backend/scala/goals/repl.py
+++ b/src/python/pants/backend/scala/goals/repl.py
@@ -2,8 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
-import itertools
-
 from pants.backend.scala.compile.scala_subsystem import ScalaSubsystem
 from pants.core.goals.repl import ReplImplementation, ReplRequest
 from pants.engine.addresses import Addresses
@@ -11,7 +9,6 @@ from pants.engine.fs import AddPrefix, Digest, MergeDigests
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.process import BashBinary
 from pants.engine.rules import collect_rules, rule
-from pants.engine.target import Dependencies, DependenciesRequest
 from pants.engine.unions import UnionRule
 from pants.jvm.classpath import Classpath
 from pants.jvm.jdk_rules import JdkSetup
@@ -32,13 +29,8 @@ class ScalaRepl(ReplImplementation):
 async def create_scala_repl_request(
     repl: ScalaRepl, bash: BashBinary, jdk_setup: JdkSetup, scala_subsystem: ScalaSubsystem
 ) -> ReplRequest:
-    dependencies_for_each_target = await MultiGet(
-        Get(Addresses, DependenciesRequest(tgt[Dependencies])) for tgt in repl.targets
-    )
-    dependencies = list(itertools.chain.from_iterable(dependencies_for_each_target))
-
     user_classpath, tool_classpath = await MultiGet(
-        Get(Classpath, Addresses(dependencies)),
+        Get(Classpath, Addresses(t.address for t in repl.targets)),
         Get(
             MaterializedClasspath,
             MaterializedClasspathRequest(

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -54,7 +54,7 @@ from pants.util.frozendict import FrozenDict
 from pants.util.memo import memoized_classproperty, memoized_method, memoized_property
 from pants.util.meta import frozen_after_init
 from pants.util.ordered_set import FrozenOrderedSet
-from pants.util.strutil import pluralize
+from pants.util.strutil import bullet_list, pluralize
 
 logger = logging.getLogger(__name__)
 
@@ -672,6 +672,10 @@ class CoarsenedTarget(EngineAwareParameter):
     def representative(self) -> Target:
         """A stable "representative" target in the cycle."""
         return next(iter(self.members))
+
+    def bullet_list(self) -> str:
+        """The addresses and type aliases of all members of the cycle."""
+        return bullet_list(sorted(f"{t.address.spec}\t({type(t).alias})" for t in self.members))
 
     def __hash__(self) -> int:
         return self._hashcode

--- a/src/python/pants/jvm/classpath.py
+++ b/src/python/pants/jvm/classpath.py
@@ -9,7 +9,7 @@ from typing import Iterator
 from pants.engine.collection import Collection
 from pants.engine.fs import Digest
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import CoarsenedTargets, Targets
+from pants.engine.target import CoarsenedTargets
 from pants.engine.unions import UnionMembership
 from pants.jvm.compile import ClasspathEntry, ClasspathEntryRequest
 from pants.jvm.resolve.key import CoursierResolveKey
@@ -66,10 +66,8 @@ async def classpath(
     union_membership: UnionMembership,
 ) -> Classpath:
     # Compute a single shared resolve for all of the roots, which will validate that they
-    # are compatible.
-    resolve = await Get(
-        CoursierResolveKey, Targets(t for ct in coarsened_targets for t in ct.members)
-    )
+    # are compatible with one another.
+    resolve = await Get(CoursierResolveKey, CoarsenedTargets, coarsened_targets)
 
     # Then request classpath entries for each root.
     classpath_entries = await MultiGet(

--- a/src/python/pants/jvm/compile.py
+++ b/src/python/pants/jvm/compile.py
@@ -34,7 +34,7 @@ class ClasspathSourceAmbiguity(Exception):
     """Too many compiler instances were compatible with a CoarsenedTarget."""
 
 
-class ClasspathSourceRootOnlyWasInner(Exception):
+class ClasspathRootOnlyWasInner(Exception):
     """A root_only request type was used as an inner node in a compile graph."""
 
 
@@ -104,7 +104,7 @@ class ClasspathEntryRequest(metaclass=ABCMeta):
 
         if len(compatible) == 1:
             if not root and impl.root_only:
-                raise ClasspathSourceRootOnlyWasInner(
+                raise ClasspathRootOnlyWasInner(
                     "The following targets had dependees, but can only be used as roots in a "
                     f"build graph:\n{component.bullet_list()}"
                 )

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -671,9 +671,8 @@ async def select_coursier_resolve_for_targets(
         raise NoCompatibleResolve(
             jvm, "The selected targets did not have a resolve in common", root_targets
         )
-    else:
-        # Take the first compatible resolve.
-        resolve = min(compatible_resolves)
+    # Take the first compatible resolve.
+    resolve = min(compatible_resolves)
 
     # Validate that the selected resolve is compatible with all transitive dependencies.
     incompatible_targets = []

--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -9,7 +9,6 @@ import pytest
 
 from pants.base.specs import AddressSpecs, DescendantAddresses
 from pants.core.util_rules import config_files, source_files
-from pants.core.util_rules.external_tool import rules as external_tool_rules
 from pants.engine.fs import FileDigest
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.process import ProcessExecutionFailure
@@ -24,7 +23,6 @@ from pants.jvm.resolve.coursier_fetch import (
     CoursierResolvedLockfile,
 )
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
-from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.jvm.target_types import JvmArtifactJarSourceField, JvmArtifactTarget
 from pants.jvm.testutil import maybe_skip_jdk_test
 from pants.jvm.util_rules import ExtractFileDigest
@@ -44,8 +42,6 @@ def rule_runner() -> RuleRunner:
         rules=[
             *config_files.rules(),
             *coursier_fetch_rules(),
-            *coursier_setup_rules(),
-            *external_tool_rules(),
             *source_files.rules(),
             *util_rules(),
             QueryRule(Targets, [AddressSpecs]),

--- a/src/python/pants/jvm/resolve/coursier_fetch_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_test.py
@@ -1,0 +1,113 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from textwrap import dedent
+from typing import Sequence
+
+import pytest
+
+from pants.backend.java.target_types import DeployJarTarget, JavaSourcesGeneratorTarget
+from pants.backend.java.target_types import rules as target_types_rules
+from pants.core.util_rules import config_files, source_files
+from pants.engine.addresses import Address, Addresses
+from pants.jvm.resolve.coursier_fetch import NoCompatibleResolve
+from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
+from pants.jvm.resolve.key import CoursierResolveKey
+from pants.jvm.target_types import JvmArtifactTarget
+from pants.jvm.testutil import maybe_skip_jdk_test
+from pants.jvm.util_rules import rules as util_rules
+from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner, engine_error
+
+NAMED_RESOLVE_OPTIONS = (
+    '--jvm-resolves={"one": "coursier_resolve.lockfile", "two": "coursier_resolve.lockfile"}'
+)
+DEFAULT_RESOLVE_OPTION = "--jvm-default-resolve=one"
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = RuleRunner(
+        rules=[
+            *config_files.rules(),
+            *coursier_fetch_rules(),
+            *source_files.rules(),
+            *util_rules(),
+            *target_types_rules(),
+            QueryRule(CoursierResolveKey, (Addresses,)),
+        ],
+        target_types=[DeployJarTarget, JavaSourcesGeneratorTarget, JvmArtifactTarget],
+    )
+    rule_runner.set_options(
+        args=[
+            NAMED_RESOLVE_OPTIONS,
+            DEFAULT_RESOLVE_OPTION,
+        ],
+        env_inherit=PYTHON_BOOTSTRAP_ENV,
+    )
+    return rule_runner
+
+
+def assert_resolve(
+    expected_resolve: str,
+    rule_runner: RuleRunner,
+    root_one_resolve: str,
+    root_two_resolve: str,
+    leaf_resolves: Sequence[str],
+) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                f"""\
+                deploy_jar(name='root_one', main='Ex', dependencies=[':leaf'], resolve='{root_one_resolve}')
+                deploy_jar(name='root_two', main='Ex', dependencies=[':leaf'], resolve='{root_two_resolve}')
+                jvm_artifact(
+                  name='leaf',
+                  group='ex',
+                  artifact='ex',
+                  version='0.0.0',
+                  compatible_resolves={repr(list(leaf_resolves))},
+                )
+                """
+            ),
+            "coursier_resolve.lockfile": "[]",
+        }
+    )
+    resolve_key = rule_runner.request(
+        CoursierResolveKey,
+        # NB: Although it will not happen for `deploy_jars` in production, we resolve two of them
+        # together here to validate the handling of multiple roots, which _can_ happen for things
+        # like the `repl` goal, and other goals which create an adhoc merged Classpath.
+        [
+            Addresses(
+                [
+                    Address(spec_path="", target_name="root_one"),
+                    Address(spec_path="", target_name="root_two"),
+                ]
+            )
+        ],
+    )
+    assert resolve_key.name == expected_resolve
+
+
+@maybe_skip_jdk_test
+def test_all_matching(rule_runner: RuleRunner) -> None:
+    assert_resolve("one", rule_runner, "one", "one", ["one"])
+
+
+@maybe_skip_jdk_test
+def test_leaf_partial_matching(rule_runner: RuleRunner) -> None:
+    assert_resolve("one", rule_runner, "one", "one", ["two", "one"])
+
+
+@maybe_skip_jdk_test
+def test_no_matching_for_root(rule_runner: RuleRunner) -> None:
+    with engine_error(NoCompatibleResolve):
+        assert_resolve("n/a", rule_runner, "one", "two", ["two", "one"])
+
+
+@maybe_skip_jdk_test
+def test_no_matching_for_leaf(rule_runner: RuleRunner) -> None:
+    with engine_error(NoCompatibleResolve):
+        assert_resolve("n/a", rule_runner, "one", "one", ["two"])


### PR DESCRIPTION
The `resolve` field for `deploy_jar` was not being respected, because the `deploy_jar` itself was not included in the targets for which we were calculating the resolve (only its dependencies). To fix this, we add support to `ClasspathEntryRequest` for "root only" requests, which allow for requesting a classpath for a target when it is a root, but failing when the target type is used as an inner node (since we don't want `deploy_jar`s to be used as dependencies of JVM compile targets anytime soon).

Additionally, restore the validation of resolve compatibility when computing a `CoursierResolveKey` (temporarily removed in #13876). This time around, the `@rule` takes `CoarsenedTargets` as input, which removes redundant walking while checking the transitive graph, while still allowing us to differentiate between the roots of the request, and the dependencies of the request.

[ci skip-rust]
[ci skip-build-wheels]