### PR TITLE
Fix `tailor` not setting the `name` field

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/tailor.py
+++ b/src/python/pants/backend/codegen/protobuf/tailor.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import os.path
 from dataclasses import dataclass
 
 from pants.backend.codegen.protobuf.target_types import ProtobufSourcesGeneratorTarget
@@ -36,7 +35,7 @@ async def find_putative_targets(
         PutativeTarget.for_target_type(
             ProtobufSourcesGeneratorTarget,
             path=dirname,
-            name=os.path.basename(dirname),
+            name=None,
             triggering_sources=sorted(filenames),
         )
         for dirname, filenames in group_by_dir(unowned_proto_files).items()

--- a/src/python/pants/backend/codegen/protobuf/tailor_test.py
+++ b/src/python/pants/backend/codegen/protobuf/tailor_test.py
@@ -50,13 +50,13 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
                 PutativeTarget.for_target_type(
                     ProtobufSourcesGeneratorTarget,
                     path="protos/foo",
-                    name="foo",
+                    name=None,
                     triggering_sources=["f.proto"],
                 ),
                 PutativeTarget.for_target_type(
                     ProtobufSourcesGeneratorTarget,
                     path="protos/foo/bar",
-                    name="bar",
+                    name=None,
                     triggering_sources=["baz2.proto", "baz3.proto"],
                 ),
             ]
@@ -90,13 +90,13 @@ def test_find_putative_targets_subset(rule_runner: RuleRunner) -> None:
                 PutativeTarget.for_target_type(
                     ProtobufSourcesGeneratorTarget,
                     path="protos/foo/bar",
-                    name="bar",
+                    name=None,
                     triggering_sources=["bar.proto"],
                 ),
                 PutativeTarget.for_target_type(
                     ProtobufSourcesGeneratorTarget,
                     path="protos/foo/qux",
-                    name="qux",
+                    name=None,
                     triggering_sources=["qux.proto"],
                 ),
             ]

--- a/src/python/pants/backend/docker/goals/tailor.py
+++ b/src/python/pants/backend/docker/goals/tailor.py
@@ -34,13 +34,14 @@ async def find_putative_targets(
     pts = []
     for dockerfile in sorted(unowned_dockerfiles):
         dirname, filename = os.path.split(dockerfile)
-        target_name = "docker"
-        kwargs = {"name": target_name}
-        if filename != DockerImageSourceField.default:
-            kwargs["source"] = filename
+        kwargs = {} if filename == DockerImageSourceField.default else {"source": filename}
         pts.append(
             PutativeTarget.for_target_type(
-                DockerImageTarget, dirname, target_name, [filename], kwargs=kwargs
+                DockerImageTarget,
+                path=dirname,
+                name="docker",
+                triggering_sources=[filename],
+                kwargs=kwargs,
             )
         )
     return PutativeTargets(pts)

--- a/src/python/pants/backend/docker/goals/tailor.py
+++ b/src/python/pants/backend/docker/goals/tailor.py
@@ -34,12 +34,13 @@ async def find_putative_targets(
     pts = []
     for dockerfile in sorted(unowned_dockerfiles):
         dirname, filename = os.path.split(dockerfile)
-        kwargs = {}
+        target_name = "docker"
+        kwargs = {"name": target_name}
         if filename != DockerImageSourceField.default:
             kwargs["source"] = filename
         pts.append(
             PutativeTarget.for_target_type(
-                DockerImageTarget, dirname, "docker", [filename], kwargs=kwargs
+                DockerImageTarget, dirname, target_name, [filename], kwargs=kwargs
             )
         )
     return PutativeTargets(pts)

--- a/src/python/pants/backend/docker/goals/tailor_test.py
+++ b/src/python/pants/backend/docker/goals/tailor_test.py
@@ -44,14 +44,14 @@ def test_find_putative_targets() -> None:
                     "src/docker_orphan",
                     "docker",
                     ["Dockerfile"],
-                    kwargs={},
+                    kwargs={"name": "docker"},
                 ),
                 PutativeTarget.for_target_type(
                     DockerImageTarget,
                     "src/docker_orphan",
                     "docker",
                     ["Dockerfile.two"],
-                    kwargs={"source": "Dockerfile.two"},
+                    kwargs={"name": "docker", "source": "Dockerfile.two"},
                 ),
             ]
         )

--- a/src/python/pants/backend/docker/goals/tailor_test.py
+++ b/src/python/pants/backend/docker/goals/tailor_test.py
@@ -41,17 +41,16 @@ def test_find_putative_targets() -> None:
             [
                 PutativeTarget.for_target_type(
                     DockerImageTarget,
-                    "src/docker_orphan",
-                    "docker",
-                    ["Dockerfile"],
-                    kwargs={"name": "docker"},
+                    path="src/docker_orphan",
+                    name="docker",
+                    triggering_sources=["Dockerfile"],
                 ),
                 PutativeTarget.for_target_type(
                     DockerImageTarget,
-                    "src/docker_orphan",
-                    "docker",
-                    ["Dockerfile.two"],
-                    kwargs={"name": "docker", "source": "Dockerfile.two"},
+                    path="src/docker_orphan",
+                    name="docker",
+                    triggering_sources=["Dockerfile.two"],
+                    kwargs={"source": "Dockerfile.two"},
                 ),
             ]
         )

--- a/src/python/pants/backend/go/goals/tailor.py
+++ b/src/python/pants/backend/go/goals/tailor.py
@@ -62,7 +62,7 @@ async def find_putative_go_targets(
             PutativeTarget.for_target_type(
                 GoModTarget,
                 path=dirname,
-                name=os.path.basename(dirname),
+                name=None,
                 triggering_sources=sorted(filenames),
             )
         )
@@ -70,14 +70,13 @@ async def find_putative_go_targets(
     # Add `go_package` targets.
     unowned_go_files = set(all_go_files.files) - set(all_owned_sources)
     for dirname, filenames in group_by_dir(unowned_go_files).items():
-        dir_path = PurePath(dirname)
-        if "testdata" in dir_path.parts:
+        if "testdata" in PurePath(dirname).parts:
             continue
         putative_targets.append(
             PutativeTarget.for_target_type(
                 GoPackageTarget,
                 path=dirname,
-                name=dir_path.name,
+                name=None,
                 triggering_sources=sorted(filenames),
             )
         )
@@ -104,11 +103,10 @@ async def find_putative_go_targets(
     }
     putative_targets.extend(
         PutativeTarget.for_target_type(
-            target_type=GoBinaryTarget,
+            GoBinaryTarget,
             path=main_pkg_dir,
             name="bin",
             triggering_sources=tuple(),
-            kwargs={"name": "bin"},
         )
         for main_pkg_dir in unowned_main_package_dirs
     )

--- a/src/python/pants/backend/go/goals/tailor_test.py
+++ b/src/python/pants/backend/go/goals/tailor_test.py
@@ -63,7 +63,7 @@ def test_find_go_mod_targets(rule_runner: RuleRunner) -> None:
     assert putative_targets == PutativeTargets(
         [
             PutativeTarget.for_target_type(
-                GoModTarget, path="unowned", name="unowned", triggering_sources=["go.mod"]
+                GoModTarget, path="unowned", name=None, triggering_sources=["go.mod"]
             )
         ]
     )
@@ -93,7 +93,7 @@ def test_find_go_package_targets(rule_runner: RuleRunner) -> None:
             PutativeTarget.for_target_type(
                 GoPackageTarget,
                 path="unowned",
-                name="unowned",
+                name=None,
                 triggering_sources=["f.go", "f1.go"],
             )
         ]
@@ -133,7 +133,6 @@ def test_find_go_binary_targets(rule_runner: RuleRunner) -> None:
                 path="missing_binary_tgt",
                 name="bin",
                 triggering_sources=[],
-                kwargs={"name": "bin"},
             ),
             PutativeTarget.for_target_type(
                 GoPackageTarget,
@@ -147,7 +146,6 @@ def test_find_go_binary_targets(rule_runner: RuleRunner) -> None:
                 path="missing_pkg_and_binary_tgt",
                 name="bin",
                 triggering_sources=[],
-                kwargs={"name": "bin"},
             ),
         ]
     )

--- a/src/python/pants/backend/java/goals/tailor.py
+++ b/src/python/pants/backend/java/goals/tailor.py
@@ -57,11 +57,10 @@ async def find_putative_targets(
     putative_targets = []
     for tgt_type, paths in classified_unowned_java_files.items():
         for dirname, filenames in group_by_dir(paths).items():
-            name = "tests" if tgt_type == JunitTestsGeneratorTarget else os.path.basename(dirname)
-            kwargs = {"name": name} if tgt_type == JunitTestsGeneratorTarget else {}
+            name = "tests" if tgt_type == JunitTestsGeneratorTarget else None
             putative_targets.append(
                 PutativeTarget.for_target_type(
-                    tgt_type, dirname, name, sorted(filenames), kwargs=kwargs
+                    tgt_type, path=dirname, name=name, triggering_sources=sorted(filenames)
                 )
             )
 

--- a/src/python/pants/backend/java/goals/tailor_test.py
+++ b/src/python/pants/backend/java/goals/tailor_test.py
@@ -30,15 +30,13 @@ def test_classify_source_files() -> None:
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
-    rule_runner = RuleRunner(
+    return RuleRunner(
         rules=[
             *tailor.rules(),
             QueryRule(PutativeTargets, (PutativeJavaTargetsRequest, AllOwnedSources)),
         ],
         target_types=[JavaSourcesGeneratorTarget, JunitTestsGeneratorTarget],
     )
-    rule_runner.set_options(["--backend-packages=pants.backend.experimental.java"])
-    return rule_runner
 
 
 def test_find_putative_targets(rule_runner: RuleRunner) -> None:
@@ -68,7 +66,6 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
                     "src/java/unowned",
                     "tests",
                     ["UnownedFileTest.java"],
-                    kwargs={"name": "tests"},
                 ),
             ]
         )

--- a/src/python/pants/backend/python/goals/tailor.py
+++ b/src/python/pants/backend/python/goals/tailor.py
@@ -99,15 +99,13 @@ async def find_putative_targets(
     pts = []
     for tgt_type, paths in classified_unowned_py_files.items():
         for dirname, filenames in group_by_dir(paths).items():
+            name: str | None
             if issubclass(tgt_type, PythonTestsGeneratorTarget):
                 name = "tests"
-                kwargs = {"name": name}
             elif issubclass(tgt_type, PythonTestUtilsGeneratorTarget):
                 name = "test_utils"
-                kwargs = {"name": name}
             else:
-                name = os.path.basename(dirname)
-                kwargs = {}
+                name = None
             if (
                 python_setup.tailor_ignore_solitary_init_files
                 and tgt_type == PythonSourcesGeneratorTarget
@@ -116,7 +114,7 @@ async def find_putative_targets(
                 continue
             pts.append(
                 PutativeTarget.for_target_type(
-                    tgt_type, dirname, name, sorted(filenames), kwargs=kwargs
+                    tgt_type, path=dirname, name=name, triggering_sources=sorted(filenames)
                 )
             )
 
@@ -192,7 +190,7 @@ async def find_putative_targets(
                     path=path,
                     name=name,
                     triggering_sources=tuple(),
-                    kwargs={"name": name, "entry_point": fname},
+                    kwargs={"entry_point": fname},
                 )
             )
 

--- a/src/python/pants/backend/python/goals/tailor_test.py
+++ b/src/python/pants/backend/python/goals/tailor_test.py
@@ -110,12 +110,12 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
                     kwargs={"source": "requirements-test.txt"},
                 ),
                 PutativeTarget.for_target_type(
-                    PythonSourcesGeneratorTarget, "src/python/foo", "foo", ["__init__.py"]
+                    PythonSourcesGeneratorTarget, "src/python/foo", None, ["__init__.py"]
                 ),
                 PutativeTarget.for_target_type(
                     PythonSourcesGeneratorTarget,
                     "src/python/foo/bar",
-                    "bar",
+                    None,
                     ["baz2.py", "baz3.py"],
                 ),
                 PutativeTarget.for_target_type(
@@ -123,14 +123,12 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
                     "src/python/foo/bar",
                     "tests",
                     ["baz1_test.py", "baz2_test.py"],
-                    kwargs={"name": "tests"},
                 ),
                 PutativeTarget.for_target_type(
                     PythonTestUtilsGeneratorTarget,
                     "src/python/foo/bar",
                     "test_utils",
                     ["conftest.py"],
-                    kwargs={"name": "test_utils"},
                 ),
             ]
         )
@@ -170,10 +168,9 @@ def test_find_putative_targets_subset(rule_runner: RuleRunner) -> None:
                     "src/python/foo/bar",
                     "tests",
                     ["bar_test.py"],
-                    kwargs={"name": "tests"},
                 ),
                 PutativeTarget.for_target_type(
-                    PythonSourcesGeneratorTarget, "src/python/foo/qux", "qux", ["qux.py"]
+                    PythonSourcesGeneratorTarget, "src/python/foo/qux", None, ["qux.py"]
                 ),
             ]
         )
@@ -217,7 +214,7 @@ def test_find_putative_targets_for_entry_points(rule_runner: RuleRunner) -> None
                     "src/python/foo",
                     "main3",
                     [],
-                    kwargs={"name": "main3", "entry_point": "main3.py"},
+                    kwargs={"entry_point": "main3.py"},
                 ),
             ]
         )

--- a/src/python/pants/backend/scala/goals/tailor.py
+++ b/src/python/pants/backend/scala/goals/tailor.py
@@ -74,10 +74,9 @@ async def find_putative_targets(
     putative_targets = []
     for tgt_type, paths in classified_unowned_scala_files.items():
         for dirname, filenames in group_by_dir(paths).items():
-            name = os.path.basename(dirname)
             putative_targets.append(
                 PutativeTarget.for_target_type(
-                    tgt_type, dirname, name, sorted(filenames), kwargs={}
+                    tgt_type, path=dirname, name=None, triggering_sources=sorted(filenames)
                 )
             )
 

--- a/src/python/pants/backend/shell/tailor.py
+++ b/src/python/pants/backend/shell/tailor.py
@@ -54,11 +54,10 @@ async def find_putative_targets(
     pts = []
     for tgt_type, paths in classified_unowned_shell_files.items():
         for dirname, filenames in group_by_dir(paths).items():
-            name = "tests" if tgt_type == Shunit2TestsGeneratorTarget else os.path.basename(dirname)
-            kwargs = {"name": name} if tgt_type == Shunit2TestsGeneratorTarget else {}
+            name = "tests" if tgt_type == Shunit2TestsGeneratorTarget else None
             pts.append(
                 PutativeTarget.for_target_type(
-                    tgt_type, dirname, name, sorted(filenames), kwargs=kwargs
+                    tgt_type, path=dirname, name=name, triggering_sources=sorted(filenames)
                 )
             )
     return PutativeTargets(pts)

--- a/src/python/pants/backend/shell/tailor_test.py
+++ b/src/python/pants/backend/shell/tailor_test.py
@@ -64,17 +64,22 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
         PutativeTargets(
             [
                 PutativeTarget.for_target_type(
-                    ShellSourcesGeneratorTarget, "src/sh/foo", "foo", ["f.sh"]
+                    ShellSourcesGeneratorTarget,
+                    path="src/sh/foo",
+                    name=None,
+                    triggering_sources=["f.sh"],
                 ),
                 PutativeTarget.for_target_type(
-                    ShellSourcesGeneratorTarget, "src/sh/foo/bar", "bar", ["baz2.sh", "baz3.sh"]
+                    ShellSourcesGeneratorTarget,
+                    path="src/sh/foo/bar",
+                    name=None,
+                    triggering_sources=["baz2.sh", "baz3.sh"],
                 ),
                 PutativeTarget.for_target_type(
                     Shunit2TestsGeneratorTarget,
-                    "src/sh/foo/bar",
-                    "tests",
-                    ["baz2_test.sh"],
-                    kwargs={"name": "tests"},
+                    path="src/sh/foo/bar",
+                    name="tests",
+                    triggering_sources=["baz2_test.sh"],
                 ),
             ]
         )
@@ -109,13 +114,15 @@ def test_find_putative_targets_subset(rule_runner: RuleRunner) -> None:
             [
                 PutativeTarget.for_target_type(
                     Shunit2TestsGeneratorTarget,
-                    "src/sh/foo/bar",
-                    "tests",
-                    ["bar_test.sh"],
-                    kwargs={"name": "tests"},
+                    path="src/sh/foo/bar",
+                    name="tests",
+                    triggering_sources=["bar_test.sh"],
                 ),
                 PutativeTarget.for_target_type(
-                    ShellSourcesGeneratorTarget, "src/sh/foo/qux", "qux", ["qux.sh"]
+                    ShellSourcesGeneratorTarget,
+                    path="src/sh/foo/qux",
+                    name=None,
+                    triggering_sources=["qux.sh"],
                 ),
             ]
         )

--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -102,10 +102,8 @@ class PutativeTarget:
     # Whether the pututative target has an address (or, e.g., is a macro with no address).
     addressable: bool
 
-    # Note that we generate the BUILD file target entry exclusively from these kwargs (plus the
-    # type_alias), not from the fields above, which are broken out for other uses.
-    # This allows the creator of instances of this class to control whether the generated
-    # target should assume default kwarg values or provide them explicitly.
+    # Note that we generate the BUILD file target entry from these kwargs, the
+    # `name`, and `type_alias`.
     kwargs: FrozenDict[str, str | int | bool | tuple[str, ...]]
 
     # Any comment lines to add above the BUILD file stanza we generate for this putative target.
@@ -117,11 +115,14 @@ class PutativeTarget:
         cls,
         target_type: type[Target],
         path: str,
-        name: str,
+        name: str | None,
         triggering_sources: Iterable[str],
         kwargs: Mapping[str, str | int | bool | tuple[str, ...]] | None = None,
         comments: Iterable[str] = tuple(),
-    ):
+    ) -> PutativeTarget:
+        if name is None:
+            name = os.path.basename(path)
+
         explicit_sources = (kwargs or {}).get("sources")
         if explicit_sources is not None and not isinstance(explicit_sources, tuple):
             raise TypeError(
@@ -130,7 +131,7 @@ class PutativeTarget:
 
         default_sources = default_sources_for_target_type(target_type)
         if (explicit_sources or triggering_sources) and not default_sources:
-            raise ValueError(
+            raise AssertionError(
                 f"A target of type {target_type.__name__} was proposed at "
                 f"address {path}:{name} with explicit sources {', '.join(explicit_sources or triggering_sources)}, "
                 "but this target type does not have a `sources` field."
@@ -190,9 +191,7 @@ class PutativeTarget:
 
     def rename(self, new_name: str) -> PutativeTarget:
         """A copy of this object with the name replaced to the given name."""
-        # We assume that a rename imposes an explicit "name=" kwarg, overriding any previous
-        # explicit "name=" kwarg, even if the rename happens to be to the default name.
-        return dataclasses.replace(self, name=new_name, kwargs={**self.kwargs, "name": new_name})
+        return dataclasses.replace(self, name=new_name)
 
     def restrict_sources(self) -> PutativeTarget:
         """A copy of this object with the sources explicitly set to just the triggering sources."""
@@ -216,9 +215,14 @@ class PutativeTarget:
                 return f"[{val_str}\n{indent}]"
             return repr(v)
 
-        if self.kwargs:
-            kwargs_str_parts = [f"\n{indent}{k}={fmt_val(v)}" for k, v in self.kwargs.items()]
-            kwargs_str = ",".join(kwargs_str_parts) + ",\n"
+        is_default_name = self.name == os.path.basename(self.path)
+        if self.kwargs or not is_default_name:
+            _kwargs = {
+                **({} if is_default_name else {"name": self.name}),
+                **self.kwargs,  # type: ignore[arg-type]
+            }
+            _kwargs_str_parts = [f"\n{indent}{k}={fmt_val(v)}" for k, v in _kwargs.items()]
+            kwargs_str = ",".join(_kwargs_str_parts) + ",\n"
         else:
             kwargs_str = ""
 


### PR DESCRIPTION
We were setting the target name to always be `docker`, but not setting the kwargs so the name _actually_ ended up being the default of the directory name. This caused tailor to not properly handle collisions in the target name.

This fixes it by removing the gotcha entirely. Now, `core/goals/tailor.py` determines if the `name` field will be set or not based on whether the `name` is the default of the directory name.

[ci skip-rust]
[ci skip-build-wheels]