### PR TITLE
Docker secrets path

### DIFF
--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -553,8 +553,9 @@ def test_docker_build_secrets_option(rule_runner: RuleRunner) -> None:
                 docker_image(
                   name="img1",
                   secrets={
-                    "mysecret": "/var/run/secrets/mysecret",
-                    "project-secret": "project/secrets/mysecret",
+                    "system-secret": "/var/run/secrets/mysecret",
+                    "project-secret": "secrets/mysecret",
+                    "target-secret": "./mysecret",
                   }
                 )
                 """
@@ -566,8 +567,9 @@ def test_docker_build_secrets_option(rule_runner: RuleRunner) -> None:
         assert process.argv == (
             "/dummy/docker",
             "build",
-            "--secret=id=mysecret,src=/var/run/secrets/mysecret",
-            f"--secret=id=project-secret,src={rule_runner.build_root}/docker/test/project/secrets/mysecret",
+            "--secret=id=system-secret,src=/var/run/secrets/mysecret",
+            f"--secret=id=project-secret,src={rule_runner.build_root}/secrets/mysecret",
+            f"--secret=id=target-secret,src={rule_runner.build_root}/docker/test/mysecret",
             "-t",
             "img1:latest",
             "-f",

--- a/src/python/pants/backend/docker/target_types.py
+++ b/src/python/pants/backend/docker/target_types.py
@@ -170,7 +170,7 @@ class DockerBuildSecretsOptionField(
 ):
     alias = "secrets"
     help = (
-        "Secret file to expose to the build (only if BuildKit enabled).\n\n"
+        "Secret files to expose to the build (only if BuildKit enabled).\n\n"
         "Secrets may use absolute paths, or paths relative to your BUILD file. The id should be "
         "valid as used by the Docker build `--secret` option. "
         "See [Docker secrets](https://docs.docker.com/engine/swarm/secrets/) for more "
@@ -181,7 +181,8 @@ class DockerBuildSecretsOptionField(
 
                 docker_image(
                     secrets={
-                        "mysecret": "/local/secret",
+                        "mysecret": "/var/secrets/some-secret",
+                        "repo-secret": "proj/path/some-secret",
                     }
                 )
             """


### PR DESCRIPTION
Address use case that arised on Slack, where the secrets may be in one central place. This makes it more ergonomic to use for all related `docker_image` targets, regardless of where in the source tree they reside.

Ps.
Cherry-picked fix for some follow up tweaks from another PR relating to the secrets field.