### PR TITLE
[internal] Add link to mailing list to project urls

### DIFF
--- a/pants-plugins/internal_plugins/releases/register.py
+++ b/pants-plugins/internal_plugins/releases/register.py
@@ -138,6 +138,7 @@ async def pants_setup_kwargs(
             "Twitter": "https://twitter.com/pantsbuild",
             "Slack": "https://pantsbuild.slack.com/join/shared_invite/zt-d0uh0mok-RLvVosDiX6JDpvStH~bFBA#/shared-invite/email",
             "YouTube": "https://www.youtube.com/channel/UCCcfCbDqtqlCkFEuENsHlbQ",
+            "Mailing lists": "https://groups.google.com/g/pants-devel",
         },
         license="Apache License, Version 2.0",
         zip_safe=True,


### PR DESCRIPTION
Noticed that [this](https://pypi.org/project/PyYAML/) is a[ thing](https://github.com/yaml/pyyaml/blob/8cdff2c80573b8be8e8ad28929264a913a63aa33/setup.py#L45), so adding it.
<img width="629" alt="Screen Shot 2021-12-18 at 7 47 25 PM" src="https://user-images.githubusercontent.com/1268088/146663188-d9f5c1a6-5e8f-414a-9e37-29d4e25e0799.png">

