### PR TITLE
[WIP] add dependency metadata syntax and filtering

### DIFF
--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -34,7 +34,7 @@ from typing import (
 from typing_extensions import final
 
 from pants.base.deprecated import warn_or_error
-from pants.engine.addresses import Address, UnparsedAddressInputs, assert_single_address
+from pants.engine.addresses import Address, Addresses, UnparsedAddressInputs, assert_single_address
 from pants.engine.collection import Collection, DeduplicatedCollection
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import (
@@ -2028,6 +2028,22 @@ class DependenciesRequest(EngineAwareParameter):
 
 
 @dataclass(frozen=True)
+class DependenciesResult:
+    addresses: Addresses
+    metadata: FrozenDict[Address, DependencyEdgeMetadata]
+
+
+@dataclass(frozen=True)
+class DependencyEdgeMetadata:
+    """Metadata for a dependency edge from a target to another target."""
+
+    labels: FrozenDict[str, str]
+
+    def __bool__(self) -> bool:
+        return bool(self.labels)
+
+
+@dataclass(frozen=True)
 class ExplicitlyProvidedDependencies:
     """The literal addresses from a BUILD file `dependencies` field.
 
@@ -2045,6 +2061,7 @@ class ExplicitlyProvidedDependencies:
     address: Address
     includes: FrozenOrderedSet[Address]
     ignores: FrozenOrderedSet[Address]
+    metadata: FrozenDict[Address, DependencyEdgeMetadata]
 
     @memoized_method
     def any_are_covered_by_includes(self, addresses: Iterable[Address]) -> bool:

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -764,11 +764,14 @@ class TransitiveTargetsRequest:
 
     roots: Tuple[Address, ...]
     include_special_cased_deps: bool
-    filter_spec: DependencyFilterSpec
+    filter_spec: DependencyFilterSpec | None
 
     def __init__(
-        self, roots: Iterable[Address], *, include_special_cased_deps: bool = False,
-        filter_spec: DependencyFilterSpec | None = None
+        self,
+        roots: Iterable[Address],
+        *,
+        include_special_cased_deps: bool = False,
+        filter_spec: DependencyFilterSpec | None = None,
     ) -> None:
         self.roots = tuple(roots)
         self.include_special_cased_deps = include_special_cased_deps

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -739,6 +739,22 @@ class TransitiveTargets:
 
 @frozen_after_init
 @dataclass(unsafe_hash=True)
+class DependencyFilterSpec:
+    label_filters: FrozenDict[str, FrozenOrderedSet[str]]
+    missing_values: FrozenDict[str, str]
+
+    def __init__(
+        self,
+        label_filters: Mapping[str, Iterable[str]],
+        *,
+        missing_values: Mapping[str, str] | None = None,
+    ) -> None:
+        self.label_filters = FrozenDict({k: FrozenOrderedSet(v) for k, v in label_filters.items()})
+        self.missing_values = FrozenDict(missing_values or {})
+
+
+@frozen_after_init
+@dataclass(unsafe_hash=True)
 class TransitiveTargetsRequest:
     """A request to get the transitive dependencies of the input roots.
 
@@ -748,12 +764,15 @@ class TransitiveTargetsRequest:
 
     roots: Tuple[Address, ...]
     include_special_cased_deps: bool
+    filter_spec: DependencyFilterSpec
 
     def __init__(
-        self, roots: Iterable[Address], *, include_special_cased_deps: bool = False
+        self, roots: Iterable[Address], *, include_special_cased_deps: bool = False,
+        filter_spec: DependencyFilterSpec | None = None
     ) -> None:
         self.roots = tuple(roots)
         self.include_special_cased_deps = include_special_cased_deps
+        self.filter_spec = filter_spec
 
 
 @frozen_after_init

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -1195,6 +1195,7 @@ def test_explicitly_provided_dependencies_any_are_covered_by_includes() -> None:
         Address("", target_name="input_tgt"),
         includes=FrozenOrderedSet([addr, generated_addr]),
         ignores=FrozenOrderedSet(),
+        metadata=FrozenDict(),
     )
 
     assert epd.any_are_covered_by_includes(()) is False
@@ -1223,6 +1224,7 @@ def test_explicitly_provided_dependencies_remaining_after_disambiguation() -> No
         Address("", target_name="input_tgt"),
         includes=FrozenOrderedSet(),
         ignores=FrozenOrderedSet([addr, generated_addr]),
+        metadata=FrozenDict(),
     )
 
     def assert_disambiguated_via_ignores(ambiguous: List[Address], expected: Set[Address]) -> None:
@@ -1246,7 +1248,10 @@ def test_explicitly_provided_dependencies_remaining_after_disambiguation() -> No
 
     # Check disambiguation via `owners_must_be_ancestors`.
     epd = ExplicitlyProvidedDependencies(
-        Address("src/lang/project"), FrozenOrderedSet(), FrozenOrderedSet()
+        Address("src/lang/project"),
+        FrozenOrderedSet(),
+        FrozenOrderedSet(),
+        FrozenDict(),
     )
     valid_candidates = {
         Address("src/lang/project", target_name="another_tgt"),
@@ -1280,6 +1285,7 @@ def test_explicitly_provided_dependencies_disambiguated() -> None:
             address=Address("dir", target_name="input_tgt"),
             includes=FrozenOrderedSet(includes or []),
             ignores=FrozenOrderedSet(ignores or []),
+            metadata=FrozenDict(),
         )
         return epd.disambiguated(
             tuple(ambiguous), owners_must_be_ancestors=owners_must_be_ancestors
@@ -1341,6 +1347,7 @@ def test_explicitly_provided_dependencies_maybe_warn_of_ambiguous_dependency_inf
             Address("dir", target_name="input_tgt"),
             includes=FrozenOrderedSet(includes or []),
             ignores=FrozenOrderedSet(ignores or []),
+            metadata=FrozenDict(),
         )
         epd.maybe_warn_of_ambiguous_dependency_inference(
             tuple(ambiguous),


### PR DESCRIPTION
WIP PR for https://github.com/pantsbuild/pants/issues/12794 to add a syntax for dependency edge metadata ("labels") and filtering of transitive dependencies based on label filters.

This PR contains several commits: the base commit adds the label syntax and the others add a filtering API.

Putting up for early feedback on direction and API design.