### PR TITLE
Set a default for `[jvm].resolves` and `[jvm].default_resolve`

### DIFF
--- a/src/python/pants/backend/java/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/java/dependency_inference/rules_test.py
@@ -38,9 +38,6 @@ from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
 from pants.util.ordered_set import FrozenOrderedSet
 
-NAMED_RESOLVE_OPTIONS = '--jvm-resolves={"test": "coursier_resolve.lockfile"}'
-DEFAULT_RESOLVE_OPTION = "--jvm-default-resolve=test"
-
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
@@ -65,9 +62,7 @@ def rule_runner() -> RuleRunner:
         ],
         target_types=[JavaSourcesGeneratorTarget, JunitTestsGeneratorTarget, JvmArtifactTarget],
     )
-    rule_runner.set_options(
-        args=[NAMED_RESOLVE_OPTIONS, DEFAULT_RESOLVE_OPTION], env_inherit=PYTHON_BOOTSTRAP_ENV
-    )
+    rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
     return rule_runner
 
 

--- a/src/python/pants/backend/java/package/deploy_jar_test.py
+++ b/src/python/pants/backend/java/package/deploy_jar_test.py
@@ -52,10 +52,7 @@ def rule_runner() -> RuleRunner:
             DeployJarTarget,
         ],
     )
-    rule_runner.set_options(
-        args=['--jvm-resolves={"test": "coursier_resolve.lockfile"}', "--jvm-default-resolve=test"],
-        env_inherit=PYTHON_BOOTSTRAP_ENV,
-    )
+    rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
     return rule_runner
 
 
@@ -230,9 +227,7 @@ def test_deploy_jar_no_deps(rule_runner: RuleRunner) -> None:
                     )
                 """
             ),
-            "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
-            .to_json()
-            .decode("utf-8"),
+            "3rdparty/jvm/default.lock": CoursierResolvedLockfile(()).to_json().decode(),
             "Example.java": JAVA_MAIN_SOURCE_NO_DEPS,
         }
     )
@@ -261,9 +256,7 @@ def test_deploy_jar_local_deps(rule_runner: RuleRunner) -> None:
                     )
                 """
             ),
-            "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
-            .to_json()
-            .decode("utf-8"),
+            "3rdparty/jvm/default.lock": CoursierResolvedLockfile(()).to_json().decode(),
             "Example.java": JAVA_MAIN_SOURCE,
             "lib/ExampleLib.java": JAVA_LIB_SOURCE,
         }
@@ -303,7 +296,7 @@ def test_deploy_jar_coursier_deps(rule_runner: RuleRunner) -> None:
                     )
                 """
             ),
-            "coursier_resolve.lockfile": COURSIER_LOCKFILE_SOURCE,
+            "3rdparty/jvm/default.lock": COURSIER_LOCKFILE_SOURCE,
             "Example.java": JAVA_MAIN_SOURCE,
             "lib/ExampleLib.java": JAVA_JSON_MANGLING_LIB_SOURCE,
         }

--- a/src/python/pants/backend/scala/compile/scalac_test.py
+++ b/src/python/pants/backend/scala/compile/scalac_test.py
@@ -39,9 +39,6 @@ from pants.jvm.testutil import (
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner, logging
 
-NAMED_RESOLVE_OPTIONS = '--jvm-resolves={"test": "coursier_resolve.lockfile"}'
-DEFAULT_RESOLVE_OPTION = "--jvm-default-resolve=test"
-
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
@@ -63,13 +60,7 @@ def rule_runner() -> RuleRunner:
         ],
         target_types=[JvmArtifactTarget, ScalaSourcesGeneratorTarget, ScalacPluginTarget],
     )
-    rule_runner.set_options(
-        args=[
-            NAMED_RESOLVE_OPTIONS,
-            DEFAULT_RESOLVE_OPTION,
-        ],
-        env_inherit=PYTHON_BOOTSTRAP_ENV,
-    )
+    rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
     return rule_runner
 
 
@@ -111,9 +102,7 @@ def test_compile_no_deps(rule_runner: RuleRunner) -> None:
                 )
                 """
             ),
-            "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
-            .to_json()
-            .decode("utf-8"),
+            "3rdparty/jvm/default.lock": CoursierResolvedLockfile(()).to_json().decode(),
             "ExampleLib.scala": SCALA_LIB_SOURCE,
         }
     )
@@ -163,9 +152,7 @@ def test_compile_with_deps(rule_runner: RuleRunner) -> None:
                 )
                 """
             ),
-            "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
-            .to_json()
-            .decode("utf-8"),
+            "3rdparty/jvm/default.lock": CoursierResolvedLockfile(()).to_json().decode(),
             "Example.scala": SCALA_LIB_MAIN_SOURCE,
             "lib/BUILD": dedent(
                 """\
@@ -210,9 +197,7 @@ def test_compile_with_missing_dep_fails(rule_runner: RuleRunner) -> None:
                 """
             ),
             "Example.scala": SCALA_LIB_MAIN_SOURCE,
-            "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
-            .to_json()
-            .decode("utf-8"),
+            "3rdparty/jvm/default.lock": CoursierResolvedLockfile(()).to_json().decode(),
         }
     )
     request = CompileScalaSourceRequest(
@@ -261,7 +246,7 @@ def test_compile_with_maven_deps(rule_runner: RuleRunner) -> None:
                 )
                 """
             ),
-            "coursier_resolve.lockfile": resolved_joda_lockfile.to_json().decode("utf-8"),
+            "3rdparty/jvm/default.lock": resolved_joda_lockfile.to_json().decode(),
             "Example.scala": dedent(
                 """
                 package org.pantsbuild.example
@@ -309,9 +294,7 @@ def test_compile_with_undeclared_jvm_artifact_target_fails(rule_runner: RuleRunn
                 )
                 """
             ),
-            "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
-            .to_json()
-            .decode("utf-8"),
+            "3rdparty/jvm/default.lock": CoursierResolvedLockfile(()).to_json().decode("utf-8"),
             "Example.scala": dedent(
                 """
                 package org.pantsbuild.example
@@ -358,9 +341,7 @@ def test_compile_with_undeclared_jvm_artifact_dependency_fails(rule_runner: Rule
                 )
                 """
             ),
-            "coursier_resolve.lockfile": CoursierResolvedLockfile(entries=())
-            .to_json()
-            .decode("utf-8"),
+            "3rdparty/jvm/default.lock": CoursierResolvedLockfile(()).to_json().decode(),
             "Example.scala": dedent(
                 """
                 package org.pantsbuild.example
@@ -414,7 +395,7 @@ def test_compile_with_scalac_plugins(rule_runner: RuleRunner) -> None:
                 )
                 """
             ),
-            "coursier_resolve.lockfile": CoursierResolvedLockfile(
+            "3rdparty/jvm/default.lock": CoursierResolvedLockfile(
                 entries=(
                     CoursierLockfileEntry(
                         coord=Coordinate(
@@ -455,10 +436,8 @@ def test_compile_with_scalac_plugins(rule_runner: RuleRunner) -> None:
     )
     rule_runner.set_options(
         args=[
-            NAMED_RESOLVE_OPTIONS,
-            DEFAULT_RESOLVE_OPTION,
             "--scalac-plugins-global=lib:acyclic",
-            "--scalac-plugins-lockfile=coursier_resolve.lockfile",
+            "--scalac-plugins-lockfile=3rdparty/jvm/default.lock",
         ],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
     )

--- a/src/python/pants/backend/scala/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/rules_test.py
@@ -27,9 +27,6 @@ from pants.jvm.testutil import maybe_skip_jdk_test
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
 
-NAMED_RESOLVE_OPTIONS = '--jvm-resolves={"test": "coursier_resolve.lockfile"}'
-DEFAULT_RESOLVE_OPTION = "--jvm-default-resolve=test"
-
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
@@ -53,9 +50,7 @@ def rule_runner() -> RuleRunner:
         ],
         target_types=[ScalaSourcesGeneratorTarget],
     )
-    rule_runner.set_options(
-        args=[NAMED_RESOLVE_OPTIONS, DEFAULT_RESOLVE_OPTION], env_inherit=PYTHON_BOOTSTRAP_ENV
-    )
+    rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
     return rule_runner
 
 

--- a/src/python/pants/backend/scala/lint/scalafmt/rules_integration_test.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules_integration_test.py
@@ -35,9 +35,6 @@ from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, RuleRunner
 
-NAMED_RESOLVE_OPTIONS = '--jvm-resolves={"test": "coursier_resolve.lockfile"}'
-DEFAULT_RESOLVE_OPTION = "--jvm-default-resolve=test"
-
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
@@ -64,13 +61,7 @@ def rule_runner() -> RuleRunner:
         ],
         target_types=[ScalaSourceTarget, ScalaSourcesGeneratorTarget],
     )
-    rule_runner.set_options(
-        [
-            NAMED_RESOLVE_OPTIONS,
-            DEFAULT_RESOLVE_OPTION,
-        ],
-        env_inherit=PYTHON_BOOTSTRAP_ENV,
-    )
+    rule_runner.set_options([], env_inherit=PYTHON_BOOTSTRAP_ENV)
     return rule_runner
 
 

--- a/src/python/pants/backend/scala/test/scalatest_test.py
+++ b/src/python/pants/backend/scala/test/scalatest_test.py
@@ -34,9 +34,6 @@ from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunn
 
 # TODO(12812): Switch tests to using parsed scalatest.xml results instead of scanning stdout strings.
 
-NAMED_RESOLVE_OPTIONS = '--jvm-resolves={"test": "coursier_resolve.lockfile"}'
-DEFAULT_RESOLVE_OPTION = "--jvm-default-resolve=test"
-
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
@@ -66,13 +63,7 @@ def rule_runner() -> RuleRunner:
             ScalatestTestsGeneratorTarget,
         ],
     )
-    rule_runner.set_options(
-        args=[
-            NAMED_RESOLVE_OPTIONS,
-            DEFAULT_RESOLVE_OPTION,
-        ],
-        env_inherit=PYTHON_BOOTSTRAP_ENV,
-    )
+    rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
     return rule_runner
 
 
@@ -81,7 +72,7 @@ def test_simple_success(rule_runner: RuleRunner) -> None:
     scalatest = rule_runner.request(Scalatest, [])
     rule_runner.write_files(
         {
-            "coursier_resolve.lockfile": scalatest.resolved_lockfile().to_json().decode("utf-8"),
+            "3rdparty/jvm/default.lock": scalatest.resolved_lockfile().to_json().decode("utf-8"),
             "BUILD": dedent(
                 """\
                 jvm_artifact(

--- a/src/python/pants/jvm/compile_test.py
+++ b/src/python/pants/jvm/compile_test.py
@@ -59,9 +59,6 @@ from pants.jvm.testutil import (
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
 
-NAMED_RESOLVE_OPTIONS = '--jvm-resolves={"test": "coursier_resolve.lockfile"}'
-DEFAULT_RESOLVE_OPTION = "--jvm-default-resolve=test"
-
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
@@ -89,13 +86,7 @@ def rule_runner() -> RuleRunner:
         ],
         target_types=[ScalaSourcesGeneratorTarget, JavaSourcesGeneratorTarget, JvmArtifactTarget],
     )
-    rule_runner.set_options(
-        args=[
-            NAMED_RESOLVE_OPTIONS,
-            DEFAULT_RESOLVE_OPTION,
-        ],
-        env_inherit=PYTHON_BOOTSTRAP_ENV,
-    )
+    rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
     return rule_runner
 
 
@@ -216,7 +207,7 @@ def test_compile_mixed(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
             "BUILD": "scala_sources(name='main')",
-            "coursier_resolve.lockfile": "[]",
+            "3rdparty/jvm/default.lock": "[]",
             "Example.scala": scala_main_source(),
             "lib/BUILD": "java_sources()",
             "lib/C.java": java_lib_source(),
@@ -243,7 +234,7 @@ def test_compile_mixed_cycle(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
             "BUILD": "scala_sources(name='main')",
-            "coursier_resolve.lockfile": "[]",
+            "3rdparty/jvm/default.lock": "[]",
             "Example.scala": scala_main_source(),
             "lib/BUILD": "java_sources()",
             "lib/C.java": java_lib_source(["org.pantsbuild.example.Main"]),

--- a/src/python/pants/jvm/dependency_inference/artifact_mapper_test.py
+++ b/src/python/pants/jvm/dependency_inference/artifact_mapper_test.py
@@ -114,7 +114,7 @@ def test_third_party_mapping_parsing(rule_runner: RuleRunner) -> None:
     )
 
     mapping = rule_runner.request(ThirdPartyPackageToArtifactMapping, [])
-    root_node = mapping.mapping_roots["test"]
+    root_node = mapping.mapping_roots["jvm-default"]
 
     # Handy trie traversal function to placate mypy
     def traverse(*children) -> FrozenTrieNode:

--- a/src/python/pants/jvm/dependency_inference/artifact_mapper_test.py
+++ b/src/python/pants/jvm/dependency_inference/artifact_mapper_test.py
@@ -38,9 +38,6 @@ from pants.testutil.rule_runner import (
     logging,
 )
 
-NAMED_RESOLVE_OPTIONS = '--jvm-resolves={"test": "coursier_resolve.lockfile"}'
-DEFAULT_RESOLVE_OPTION = "--jvm-default-resolve=test"
-
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
@@ -66,9 +63,7 @@ def rule_runner() -> RuleRunner:
             JvmArtifactTarget,
         ],
     )
-    rule_runner.set_options(
-        args=[NAMED_RESOLVE_OPTIONS, DEFAULT_RESOLVE_OPTION], env_inherit=PYTHON_BOOTSTRAP_ENV
-    )
+    rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
     return rule_runner
 
 
@@ -77,9 +72,7 @@ def rule_runner() -> RuleRunner:
 def test_third_party_mapping_parsing(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(
         [
-            "--java-infer-third-party-import-mapping={'io.github.frenchtoast.savory.**': 'github-frenchtoast:savory'}",
-            NAMED_RESOLVE_OPTIONS,
-            DEFAULT_RESOLVE_OPTION,
+            "--java-infer-third-party-import-mapping={'io.github.frenchtoast.savory.**': 'github-frenchtoast:savory'}"
         ],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
     )
@@ -206,11 +199,7 @@ def test_third_party_dep_inference_resolve(rule_runner: RuleRunner) -> None:
 @maybe_skip_jdk_test
 def test_third_party_dep_inference_fqtn(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(
-        [
-            "--java-infer-third-party-import-mapping={'org.joda.time.**': 'joda-time:joda-time'}",
-            NAMED_RESOLVE_OPTIONS,
-            DEFAULT_RESOLVE_OPTION,
-        ],
+        ["--java-infer-third-party-import-mapping={'org.joda.time.**': 'joda-time:joda-time'}"],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
     )
     rule_runner.write_files(
@@ -255,8 +244,6 @@ def test_third_party_dep_inference_nonrecursive(rule_runner: RuleRunner) -> None
     rule_runner.set_options(
         [
             "--java-infer-third-party-import-mapping={'org.joda.time.**':'joda-time:joda-time', 'org.joda.time.DateTime':'joda-time:joda-time-2'}",
-            NAMED_RESOLVE_OPTIONS,
-            DEFAULT_RESOLVE_OPTION,
         ],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
     )
@@ -336,8 +323,6 @@ def test_third_party_dep_inference_with_provides(rule_runner: RuleRunner) -> Non
     rule_runner.set_options(
         [
             "--java-infer-third-party-import-mapping={'org.joda.time.**':'joda-time:joda-time', 'org.joda.time.DateTime':'joda-time:joda-time-2'}",
-            NAMED_RESOLVE_OPTIONS,
-            DEFAULT_RESOLVE_OPTION,
         ],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
     )
@@ -405,8 +390,6 @@ def test_third_party_dep_inference_with_incorrect_provides(rule_runner: RuleRunn
     rule_runner.set_options(
         [
             "--java-infer-third-party-import-mapping={'org.joda.time.**':'joda-time:joda-time', 'org.joda.time.DateTime':'joda-time:joda-time-2'}",
-            NAMED_RESOLVE_OPTIONS,
-            DEFAULT_RESOLVE_OPTION,
         ],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
     )

--- a/src/python/pants/jvm/dependency_inference/java_scala_interop_test.py
+++ b/src/python/pants/jvm/dependency_inference/java_scala_interop_test.py
@@ -25,9 +25,6 @@ from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, RuleRunner
 
-NAMED_RESOLVE_OPTIONS = '--jvm-resolves={"test": "coursier_resolve.lockfile"}'
-DEFAULT_RESOLVE_OPTION = "--jvm-default-resolve=test"
-
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
@@ -57,9 +54,7 @@ def rule_runner() -> RuleRunner:
             ScalaSourceTarget,
         ],
     )
-    rule_runner.set_options(
-        args=[NAMED_RESOLVE_OPTIONS, DEFAULT_RESOLVE_OPTION], env_inherit=PYTHON_BOOTSTRAP_ENV
-    )
+    rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
     return rule_runner
 
 
@@ -69,28 +64,28 @@ def test_java_infers_scala_dependency(rule_runner: RuleRunner) -> None:
             "org/pantsbuild/lib/BUILD": "scala_sources()\n",
             "org/pantsbuild/lib/Foo.scala": textwrap.dedent(
                 """
-            package org.pantsbuild.lib
+                package org.pantsbuild.lib
 
-            object Foo {
-              def grok(): Unit = {
-                println("Hello world!")
-              }
-            }
-            """
+                object Foo {
+                  def grok(): Unit = {
+                    println("Hello world!")
+                  }
+                }
+                """
             ),
             "org/pantsbuild/example/BUILD": "java_sources()\n",
             "org/pantsbuild/example/Bar.java": textwrap.dedent(
                 """
-            package org.pantsbuild.example;
+                package org.pantsbuild.example;
 
-            import org.pantsbuild.lib.Foo$;
+                import org.pantsbuild.lib.Foo$;
 
-            public class Bar {
-              public static void main(String[] args) {
-                Foo$.MODULE$.grok();
-              }
-            }
-            """
+                public class Bar {
+                  public static void main(String[] args) {
+                    Foo$.MODULE$.grok();
+                  }
+                }
+                """
             ),
         }
     )

--- a/src/python/pants/jvm/goals/coursier_integration_test.py
+++ b/src/python/pants/jvm/goals/coursier_integration_test.py
@@ -56,13 +56,6 @@ HAMCREST_EXPECTED_LOCKFILE = CoursierResolvedLockfile(
 )
 
 
-ARGS = [
-    "--jvm-resolves={'test': 'coursier_resolve.lockfile'}",
-    "--jvm-default-resolve=test",
-    "--coursier-resolve-names=test",
-]
-
-
 @pytest.fixture
 def rule_runner() -> RuleRunner:
     rule_runner = RuleRunner(
@@ -76,18 +69,18 @@ def rule_runner() -> RuleRunner:
         ],
         target_types=[JvmArtifactTarget],
     )
-    rule_runner.set_options(args=ARGS, env_inherit={"PATH"})
+    rule_runner.set_options([], env_inherit={"PATH"})
     return rule_runner
 
 
 @maybe_skip_jdk_test
 def test_creates_missing_lockfile(rule_runner: RuleRunner) -> None:
     rule_runner.write_files({"BUILD": HAMCREST_BUILD_FILE})
-    result = rule_runner.run_goal_rule(CoursierResolve, args=ARGS, env_inherit={"PATH"})
+    result = rule_runner.run_goal_rule(CoursierResolve, args=[], env_inherit={"PATH"})
     assert result.exit_code == 0
-    assert result.stderr == "Updated lockfile at: coursier_resolve.lockfile\n"
+    assert result.stderr == "Updated lockfile at: 3rdparty/jvm/default.lock\n"
     assert (
-        Path(rule_runner.build_root, "coursier_resolve.lockfile").read_bytes()
+        Path(rule_runner.build_root, "3rdparty/jvm/default.lock").read_bytes()
         == HAMCREST_EXPECTED_LOCKFILE.to_json()
     )
 
@@ -97,26 +90,26 @@ def test_noop_does_not_touch_lockfile(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
             "BUILD": HAMCREST_BUILD_FILE,
-            "coursier_resolve.lockfile": HAMCREST_EXPECTED_LOCKFILE.to_json().decode("utf-8"),
+            "3rdparty/jvm/default.lock": HAMCREST_EXPECTED_LOCKFILE.to_json().decode("utf-8"),
         }
     )
-    result = rule_runner.run_goal_rule(CoursierResolve, args=ARGS, env_inherit={"PATH"})
+    result = rule_runner.run_goal_rule(CoursierResolve, args=[], env_inherit={"PATH"})
     assert result.exit_code == 0
     assert result.stderr == ""
     assert (
-        Path(rule_runner.build_root, "coursier_resolve.lockfile").read_bytes()
+        Path(rule_runner.build_root, "3rdparty/jvm/default.lock").read_bytes()
         == HAMCREST_EXPECTED_LOCKFILE.to_json()
     )
 
 
 @maybe_skip_jdk_test
 def test_updates_lockfile(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files({"BUILD": HAMCREST_BUILD_FILE, "coursier_resolve.lockfile": "[]"})
-    result = rule_runner.run_goal_rule(CoursierResolve, args=ARGS, env_inherit={"PATH"})
+    rule_runner.write_files({"BUILD": HAMCREST_BUILD_FILE, "3rdparty/jvm/default.lock": "[]"})
+    result = rule_runner.run_goal_rule(CoursierResolve, args=[], env_inherit={"PATH"})
     assert result.exit_code == 0
-    assert result.stderr == "Updated lockfile at: coursier_resolve.lockfile\n"
+    assert result.stderr == "Updated lockfile at: 3rdparty/jvm/default.lock\n"
     assert (
-        Path(rule_runner.build_root, "coursier_resolve.lockfile").read_bytes()
+        Path(rule_runner.build_root, "3rdparty/jvm/default.lock").read_bytes()
         == HAMCREST_EXPECTED_LOCKFILE.to_json()
     )
 

--- a/src/python/pants/jvm/test/junit_test.py
+++ b/src/python/pants/jvm/test/junit_test.py
@@ -40,9 +40,6 @@ from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunn
 
 # TODO(12812): Switch tests to using parsed junit.xml results instead of scanning stdout strings.
 
-NAMED_RESOLVE_OPTIONS = '--jvm-resolves={"test": "coursier_resolve.lockfile"}'
-DEFAULT_RESOLVE_OPTION = "--jvm-default-resolve=test"
-
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
@@ -74,11 +71,7 @@ def rule_runner() -> RuleRunner:
     )
     rule_runner.set_options(
         # Makes JUnit output predictable and parseable across versions (#12933):
-        args=[
-            "--junit-args=['--disable-ansi-colors','--details=flat','--details-theme=ascii']",
-            NAMED_RESOLVE_OPTIONS,
-            DEFAULT_RESOLVE_OPTION,
-        ],
+        args=["--junit-args=['--disable-ansi-colors','--details=flat','--details-theme=ascii']"],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
     )
     return rule_runner
@@ -132,7 +125,7 @@ JUNIT4_RESOLVED_LOCKFILE = CoursierResolvedLockfile(
 def test_vintage_simple_success(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "coursier_resolve.lockfile": JUNIT4_RESOLVED_LOCKFILE.to_json().decode("utf-8"),
+            "3rdparty/jvm/default.lock": JUNIT4_RESOLVED_LOCKFILE.to_json().decode(),
             "BUILD": dedent(
                 """\
                 jvm_artifact(
@@ -179,7 +172,7 @@ def test_vintage_simple_success(rule_runner: RuleRunner) -> None:
 def test_vintage_simple_failure(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "coursier_resolve.lockfile": JUNIT4_RESOLVED_LOCKFILE.to_json().decode("utf-8"),
+            "3rdparty/jvm/default.lock": JUNIT4_RESOLVED_LOCKFILE.to_json().decode(),
             "BUILD": dedent(
                 """\
                 jvm_artifact(
@@ -234,7 +227,7 @@ def test_vintage_simple_failure(rule_runner: RuleRunner) -> None:
 def test_vintage_success_with_dep(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "coursier_resolve.lockfile": JUNIT4_RESOLVED_LOCKFILE.to_json().decode("utf-8"),
+            "3rdparty/jvm/default.lock": JUNIT4_RESOLVED_LOCKFILE.to_json().decode(),
             "BUILD": dedent(
                 """\
                 jvm_artifact(
@@ -298,7 +291,7 @@ def test_vintage_success_with_dep(rule_runner: RuleRunner) -> None:
 def test_vintage_scala_simple_success(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "coursier_resolve.lockfile": JUNIT4_RESOLVED_LOCKFILE.to_json().decode("utf-8"),
+            "3rdparty/jvm/default.lock": JUNIT4_RESOLVED_LOCKFILE.to_json().decode(),
             "BUILD": dedent(
                 """\
                 jvm_artifact(
@@ -437,7 +430,7 @@ JUNIT5_RESOLVED_LOCKFILE = CoursierResolvedLockfile(
 def test_jupiter_simple_success(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "coursier_resolve.lockfile": JUNIT5_RESOLVED_LOCKFILE.to_json().decode("utf-8"),
+            "3rdparty/jvm/default.lock": JUNIT5_RESOLVED_LOCKFILE.to_json().decode(),
             "BUILD": dedent(
                 """\
                 jvm_artifact(
@@ -487,7 +480,7 @@ def test_jupiter_simple_success(rule_runner: RuleRunner) -> None:
 def test_jupiter_simple_failure(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "coursier_resolve.lockfile": JUNIT5_RESOLVED_LOCKFILE.to_json().decode("utf-8"),
+            "3rdparty/jvm/default.lock": JUNIT5_RESOLVED_LOCKFILE.to_json().decode(),
             "BUILD": dedent(
                 """\
                 jvm_artifact(
@@ -543,7 +536,7 @@ def test_jupiter_simple_failure(rule_runner: RuleRunner) -> None:
 def test_jupiter_success_with_dep(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "coursier_resolve.lockfile": JUNIT5_RESOLVED_LOCKFILE.to_json().decode("utf-8"),
+            "3rdparty/jvm/default.lock": JUNIT5_RESOLVED_LOCKFILE.to_json().decode(),
             "BUILD": dedent(
                 """\
                 jvm_artifact(

--- a/src/python/pants/jvm/testutil.py
+++ b/src/python/pants/jvm/testutil.py
@@ -41,8 +41,8 @@ def expect_single_expanded_coarsened_target(
 
 def make_resolve(
     rule_runner: RuleRunner,
-    resolve_name: str = "test",
-    resolve_path: str = "coursier_resolve.lockfile",
+    resolve_name: str = "jvm-default",
+    resolve_path: str = "3rdparty/jvm/default.lock",
 ) -> CoursierResolveKey:
     digest = rule_runner.request(Digest, [PathGlobs([resolve_path])])
     return CoursierResolveKey(name=resolve_name, path=resolve_path, digest=digest)


### PR DESCRIPTION
Part of https://github.com/pantsbuild/pants/issues/12742.

We set a default because it's important to the Pants project that onboarding is as effortless as possible, e.g. via sensible defaults.

An additional benefit is that we can now be confident a resolve is set up, as it is impossible to override an option to be `None` (https://github.com/pantsbuild/pants/issues/11719). We decided that we want to require lockfiles when using Pants, so this is seen as a benefit.

--

This uses the resolve name `jvm-default` because the namespace will be shared with Python, e.g. `py-default`. 

It uses the lockfile path `3rdparty/jvm/default.lock`. We use the file extension `.lock` instead of `.json` to better express the semantics, including that you should not hand-edit the file. Using the `3rdparty/jvm` folder is a sensible default for monorepos, and people can override it to where they want.

[ci skip-rust]
[ci skip-build-wheels]