### PR TITLE
Revert "Turn off validation for unset `SourcesField" if `required=False` (#13856)

### DIFF
--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1580,12 +1580,6 @@ class SourcesField(AsyncFieldMixin, Field):
         To enforce that there are only a certain number of resulting files, such as binary targets
         checking for only 0-1 sources, set the class property `expected_num_files`.
         """
-
-        if not self.required and not self.value:
-            # If this field isn't required or set, validation is done against the default value
-            # which is probably not valuable (See #13851).
-            return None
-
         if self.expected_file_extensions is not None:
             bad_files = [
                 fp for fp in files if not PurePath(fp).suffix in self.expected_file_extensions

--- a/src/python/pants/jvm/target_types.py
+++ b/src/python/pants/jvm/target_types.py
@@ -102,6 +102,7 @@ class JvmArtifactUrlField(StringField):
 class JvmArtifactJarSourceField(SingleSourceField):
     alias = "jar"
     expected_file_extensions = (".jar",)
+    expected_num_files = range(0, 2)
     required = False
     help = (
         "A local JAR file that provides this artifact to the lockfile resolver, instead of a "


### PR DESCRIPTION
We need to override how `SIngleSourceField` sets `expected_num_files = 1` because that causes issues when the `jar` field is unset: https://github.com/pantsbuild/pants/issues/13851. One approach is to use `expected_num_files = range(0, 2)`, but instead https://github.com/pantsbuild/pants/pull/13856 turned off the validation entirely.

As explained in that ticket, we do still want to validate that the file is exactly one if the field was explicitly set.

There's another way to do that though. We already validate that source globs are valid via `--files-not-found-behavior`. If you explicitly set the value, then we will set up `PathGlobs` such that it will warn or error if there is no match, meaning we handle zero files. Because we ban `*` and also have `expected_num_files`, we already handle >1 file.

[ci skip-rust]
[ci skip-build-wheels]