### PR TITLE
[jvm] Expose additional JVM backends and symbols (cherrypick of #13943)

### DIFF
--- a/src/python/pants/backend/experimental/java/lint/google_java_format/register.py
+++ b/src/python/pants/backend/experimental/java/lint/google_java_format/register.py
@@ -3,10 +3,17 @@
 
 from pants.backend.java.lint.google_java_format import rules as fmt_rules
 from pants.backend.java.lint.google_java_format import skip_field
+from pants.jvm import jdk_rules
+from pants.jvm import util_rules as jvm_util_rules
+from pants.jvm.resolve import coursier_fetch, jvm_tool
 
 
 def rules():
     return [
         *fmt_rules.rules(),
         *skip_field.rules(),
+        *jdk_rules.rules(),
+        *jvm_tool.rules(),
+        *coursier_fetch.rules(),
+        *jvm_util_rules.rules(),
     ]

--- a/src/python/pants/backend/experimental/java/register.py
+++ b/src/python/pants/backend/experimental/java/register.py
@@ -18,7 +18,7 @@ from pants.jvm import classpath, jdk_rules
 from pants.jvm import util_rules as jvm_util_rules
 from pants.jvm.dependency_inference import symbol_mapper
 from pants.jvm.goals import coursier
-from pants.jvm.resolve import coursier_fetch, coursier_setup, jvm_tool
+from pants.jvm.resolve import coursier_fetch, jvm_tool
 from pants.jvm.target_types import JvmArtifactTarget
 from pants.jvm.test import junit
 
@@ -43,7 +43,6 @@ def rules():
         *deploy_jar.rules(),
         *coursier.rules(),
         *coursier_fetch.rules(),
-        *coursier_setup.rules(),
         *java_parser.rules(),
         *java_parser_launcher.rules(),
         *symbol_mapper.rules(),

--- a/src/python/pants/backend/experimental/scala/register.py
+++ b/src/python/pants/backend/experimental/scala/register.py
@@ -6,6 +6,7 @@ from pants.backend.scala.compile import scalac
 from pants.backend.scala.dependency_inference import rules as dep_inf_rules
 from pants.backend.scala.goals import check, repl, tailor
 from pants.backend.scala.target_types import (
+    ScalacPluginTarget,
     ScalaJunitTestsGeneratorTarget,
     ScalaJunitTestTarget,
     ScalaSourcesGeneratorTarget,
@@ -31,6 +32,7 @@ def target_types():
         ScalaJunitTestsGeneratorTarget,
         ScalaSourceTarget,
         ScalaSourcesGeneratorTarget,
+        ScalacPluginTarget,
         ScalatestTestTarget,
         ScalatestTestsGeneratorTarget,
     ]

--- a/src/python/pants/backend/java/lint/google_java_format/rules.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules.py
@@ -3,6 +3,7 @@
 import dataclasses
 from dataclasses import dataclass
 
+from pants.backend.java.lint import java_fmt
 from pants.backend.java.lint.google_java_format.skip_field import SkipGoogleJavaFormatField
 from pants.backend.java.lint.google_java_format.subsystem import GoogleJavaFormatSubsystem
 from pants.backend.java.lint.java_fmt import JavaFmtRequest
@@ -166,5 +167,7 @@ async def generate_google_java_format_lockfile_request(
 def rules():
     return [
         *collect_rules(),
+        *java_fmt.rules(),
+        UnionRule(JavaFmtRequest, GoogleJavaFormatRequest),
         UnionRule(JvmToolLockfileSentinel, GoogleJavaFormatToolLockfileSentinel),
     ]

--- a/src/python/pants/jvm/compile.py
+++ b/src/python/pants/jvm/compile.py
@@ -273,6 +273,7 @@ class FallibleClasspathEntry(EngineAwareReturnType):
 
         exit_code = process_result.exit_code
         # TODO: Coursier renders this line on macOS.
+        #   see https://github.com/pantsbuild/pants/issues/13942.
         stderr = "\n".join(
             line
             for line in prep_output(process_result.stderr).splitlines()

--- a/src/python/pants/jvm/resolve/jvm_tool.py
+++ b/src/python/pants/jvm/resolve/jvm_tool.py
@@ -25,6 +25,7 @@ from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import collect_rules, goal_rule, rule
 from pants.engine.target import Targets
 from pants.engine.unions import UnionMembership, union
+from pants.jvm.resolve import coursier_fetch
 from pants.jvm.resolve.coursier_fetch import (
     ArtifactRequirement,
     ArtifactRequirements,
@@ -385,4 +386,7 @@ def filter_tool_lockfile_requests(
 
 
 def rules():
-    return collect_rules()
+    return [
+        *collect_rules(),
+        *coursier_fetch.rules(),
+    ]


### PR DESCRIPTION
The `google_java_format` backend was not registering itself (or the generic Java formatting rules), and the `scalac_plugin` target type wasn't exposed.

[ci skip-rust]
[ci skip-build-wheels]