### PR TITLE
Rename `[python].experimental_resolves_to_lockfiles` to `[python].experimental_resolves`

### DIFF
--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -77,7 +77,7 @@ class GenerateLockfilesSubsystem(GoalSubsystem):
                 "Only generate lockfiles for the specified resolve(s).\n\n"
                 "Resolves are the logical names for the different lockfiles used in your project. "
                 "For your own code's dependencies, these come from the option "
-                "`[python].experimental_resolves_to_lockfiles`. For tool lockfiles, resolve "
+                "`[python].experimental_resolves`. For tool lockfiles, resolve "
                 "names are the options scope for that tool such as `black`, `pytest`, and "
                 "`mypy-protobuf`.\n\n"
                 "For example, you can run `./pants generate-lockfiles --resolve=black "
@@ -307,7 +307,7 @@ async def setup_user_lockfile_requests(
             requirements.req_strings,
             interpreter_constraints,
             resolve_name=resolve,
-            lockfile_dest=python_setup.resolves_to_lockfiles[resolve],
+            lockfile_dest=python_setup.resolves[resolve],
         )
         for resolve, requirements, interpreter_constraints in zip(
             requested, pex_requirements_per_resolve, interpreter_constraints_per_resolve
@@ -339,7 +339,7 @@ async def generate_lockfiles_goal(
         warn_python_repos("indexes")
 
     specified_user_resolves, specified_tool_sentinels = determine_resolves_to_generate(
-        python_setup.resolves_to_lockfiles.keys(),
+        python_setup.resolves.keys(),
         union_membership[PythonToolLockfileSentinel],
         generate_lockfiles_subsystem.resolve_names,
     )
@@ -386,20 +386,17 @@ class AmbiguousResolveNamesError(Exception):
     def __init__(self, ambiguous_names: list[str]) -> None:
         if len(ambiguous_names) == 1:
             first_paragraph = (
-                "A resolve name from the option "
-                "`[python].experimental_resolves_to_lockfiles` collides with the name of a "
-                f"tool resolve: {ambiguous_names[0]}"
+                "A resolve name from the option `[python].experimental_resolves` collides with the "
+                f"name of a tool resolve: {ambiguous_names[0]}"
             )
         else:
             first_paragraph = (
-                "Some resolve names from the option "
-                "`[python].experimental_resolves_to_lockfiles` collide with the names of "
-                f"tool resolves: {sorted(ambiguous_names)}"
+                "Some resolve names from the option `[python].experimental_resolves` collide with "
+                f"the names of tool resolves: {sorted(ambiguous_names)}"
             )
         super().__init__(
             f"{first_paragraph}\n\n"
-            "To fix, please update `[python].experimental_resolves_to_lockfiles` to use "
-            "different resolve names."
+            "To fix, please update `[python].experimental_resolves` to use different resolve names."
         )
 
 

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -126,7 +126,7 @@ class PythonSetup(Subsystem):
             ),
         )
         register(
-            "--experimental-resolves-to-lockfiles",
+            "--experimental-resolves",
             advanced=True,
             type=dict,
             help=(
@@ -272,8 +272,8 @@ class PythonSetup(Subsystem):
         return cast("str | None", self.options.experimental_lockfile)
 
     @property
-    def resolves_to_lockfiles(self) -> dict[str, str]:
-        return cast("dict[str, str]", self.options.experimental_resolves_to_lockfiles)
+    def resolves(self) -> dict[str, str]:
+        return cast("dict[str, str]", self.options.experimental_resolves)
 
     @property
     def invalid_lockfile_behavior(self) -> InvalidLockfileBehavior:

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -128,7 +128,7 @@ class PythonResolveField(StringField, AsyncFieldMixin):
     # TODO(#12314): Figure out how to model the default and disabling lockfile, e.g. if we
     #  hardcode to `default` or let the user set it.
     help = (
-        "The resolve from `[python].experimental_resolves_to_lockfiles` to use, if any.\n\n"
+        "The resolve from `[python].experimental_resolves` to use, if any.\n\n"
         "This field is highly experimental and may change without the normal deprecation policy."
     )
 
@@ -136,10 +136,10 @@ class PythonResolveField(StringField, AsyncFieldMixin):
         """Check that the resolve name is recognized."""
         if not self.value:
             return None
-        if self.value not in python_setup.resolves_to_lockfiles:
+        if self.value not in python_setup.resolves:
             raise UnrecognizedResolveNamesError(
                 [self.value],
-                python_setup.resolves_to_lockfiles.keys(),
+                python_setup.resolves.keys(),
                 description_of_origin=f"the field `{self.alias}` in the target {self.address}",
             )
 
@@ -149,11 +149,7 @@ class PythonResolveField(StringField, AsyncFieldMixin):
         Error if the resolve name is invalid.
         """
         self.validate(python_setup)
-        return (
-            (self.value, python_setup.resolves_to_lockfiles[self.value])
-            if self.value is not None
-            else None
-        )
+        return (self.value, python_setup.resolves[self.value]) if self.value is not None else None
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -430,8 +430,7 @@ async def get_repository_pex(
             requirements=Lockfile(
                 file_path=lockfile,
                 file_path_description_of_origin=(
-                    f"the resolve `{resolve}` (from "
-                    "`[python].experimental_resolves_to_lockfiles`)"
+                    f"the resolve `{resolve}` (from `[python].experimental_resolves`)"
                 ),
                 # TODO(#12314): Hook up lockfile staleness check.
                 lockfile_hex_digest=None,


### PR DESCRIPTION
We've been using `[jvm].resolves` and I think it works well. Turns out we reference the option a lot in `help` messages etc. The `to_lockfiles` part doesn't pull its weight.

Because we marked this option as highly experimental and it didn't even really work properly, we don't use a deprecation. 

[ci skip-rust]
[ci skip-build-wheels]