### PR TITLE
Docker context troubleshooter (Cherry pick of #13896)

### DIFF
--- a/src/python/pants/backend/docker/BUILD
+++ b/src/python/pants/backend/docker/BUILD
@@ -2,3 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_sources()
+
+python_tests(
+    name="tests",
+)

--- a/src/python/pants/backend/docker/goals/BUILD
+++ b/src/python/pants/backend/docker/goals/BUILD
@@ -2,4 +2,4 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_sources()
-python_tests(name="tests", timeout=120)
+python_tests(name="tests", timeout=200)

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from os import path
+from textwrap import dedent
 from typing import Any, Iterator, Mapping
 
 from pants.backend.docker.registries import DockerRegistries
@@ -22,13 +23,15 @@ from pants.backend.docker.util_rules.docker_build_context import (
     DockerBuildContextRequest,
     DockerVersionContext,
 )
+from pants.backend.docker.utils import format_rename_suggestion
 from pants.core.goals.package import BuiltPackage, BuiltPackageArtifact, PackageFieldSet
 from pants.core.goals.run import RunFieldSet
 from pants.engine.addresses import Address
-from pants.engine.process import Process, ProcessResult
+from pants.engine.process import FallibleProcessResult, Process, ProcessExecutionFailure
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import Target, WrappedTarget
 from pants.engine.unions import UnionRule
+from pants.option.global_options import GlobalOptions, ProcessCleanupOption
 from pants.util.strutil import bullet_list, pluralize
 
 logger = logging.getLogger(__name__)
@@ -173,7 +176,9 @@ def get_build_options(target: Target) -> Iterator[str]:
 async def build_docker_image(
     field_set: DockerFieldSet,
     options: DockerOptions,
+    global_options: GlobalOptions,
     docker: DockerBinary,
+    process_cleanup: ProcessCleanupOption,
 ) -> BuiltPackage:
     context, wrapped_target = await MultiGet(
         Get(
@@ -192,29 +197,90 @@ async def build_docker_image(
         version_context=context.version_context,
     )
 
-    result = await Get(
-        ProcessResult,
-        Process,
-        docker.build_image(
-            build_args=context.build_args,
-            digest=context.digest,
-            dockerfile=context.dockerfile,
-            env=context.build_env.environment,
-            tags=tags,
-            extra_args=tuple(get_build_options(wrapped_target.target)),
-        ),
+    process = docker.build_image(
+        build_args=context.build_args,
+        digest=context.digest,
+        dockerfile=context.dockerfile,
+        env=context.build_env.environment,
+        tags=tags,
+        extra_args=tuple(get_build_options(wrapped_target.target)),
     )
+    result = await Get(FallibleProcessResult, Process, process)
+
+    if result.exit_code != 0:
+        maybe_msg = docker_build_failed(
+            field_set.address,
+            context,
+            global_options.options.colors,
+        )
+        if maybe_msg:
+            logger.warning(maybe_msg)
+
+        raise ProcessExecutionFailure(
+            result.exit_code,
+            result.stdout,
+            result.stderr,
+            process.description,
+            process_cleanup=process_cleanup.val,
+        )
 
     logger.debug(
-        f"Docker build output for {tags[0]}:\n"
-        f"{result.stdout.decode()}\n"
-        f"{result.stderr.decode()}"
+        dedent(
+            f"""\
+            Docker build output for {tags[0]}:
+            stdout:
+            {result.stdout.decode()}
+
+            stderr:
+            {result.stderr.decode()}
+            """
+        )
     )
 
     return BuiltPackage(
         result.output_digest,
         (BuiltDockerImage.create(tags),),
     )
+
+
+def docker_build_failed(address: Address, context: DockerBuildContext, colors: bool) -> str | None:
+    if not context.copy_source_vs_context_source:
+        return None
+
+    msg = (
+        f"Docker build failed for `docker_image` {address}. The {context.dockerfile} have `COPY` "
+        "instructions where the source files may not have been found in the Docker build context."
+        "\n\n"
+    )
+
+    renames = [
+        format_rename_suggestion(src, dst, colors=colors)
+        for src, dst in context.copy_source_vs_context_source
+        if src and dst
+    ]
+    if renames:
+        msg += (
+            f"However there are possible matches. Please review the following list of suggested "
+            f"renames:\n\n{bullet_list(renames)}\n\n"
+        )
+
+    unknown = [src for src, dst in context.copy_source_vs_context_source if not dst]
+    if unknown:
+        msg += (
+            f"The following files were not found in the Docker build context:\n\n"
+            f"{bullet_list(unknown)}\n\n"
+        )
+
+    unreferenced = [dst for src, dst in context.copy_source_vs_context_source if not src]
+    if unreferenced:
+        if len(unreferenced) > 10:
+            unreferenced = unreferenced[:9] + [f"... and {len(unreferenced)-9} more"]
+        msg += (
+            f"There are additional files in the Docker build context that were not referenced by "
+            f"any `COPY` instruction (this is not an error):\n\n{bullet_list(unreferenced)}\n\n"
+        )
+
+    return msg
 
 
 def rules():

--- a/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
+++ b/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
@@ -126,6 +126,7 @@ class DockerfileInfo:
     putative_target_addresses: tuple[str, ...] = ()
     version_tags: tuple[str, ...] = ()
     build_args: DockerBuildArgs = DockerBuildArgs()
+    copy_sources: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -162,12 +163,12 @@ async def parse_dockerfile(request: DockerfileInfoRequest) -> DockerfileInfo:
         ProcessResult,
         DockerfileParseRequest(
             sources.snapshot.digest,
-            ("version-tags,putative-targets,build-args", dockerfile),
+            ("version-tags,putative-targets,build-args,copy-sources", dockerfile),
         ),
     )
 
     output = result.stdout.decode("utf-8").strip().split("\n")
-    version_tags, putative_targets, build_args = split_iterable("---", output)
+    version_tags, putative_targets, build_args, copy_sources = split_iterable("---", output)
 
     try:
         return DockerfileInfo(
@@ -177,6 +178,7 @@ async def parse_dockerfile(request: DockerfileInfoRequest) -> DockerfileInfo:
             putative_target_addresses=putative_targets,
             version_tags=version_tags,
             build_args=DockerBuildArgs.from_strings(*build_args, duplicates_must_match=True),
+            copy_sources=copy_sources,
         )
     except ValueError as e:
         raise DockerfileInfoError(

--- a/src/python/pants/backend/docker/subsystems/dockerfile_parser_test.py
+++ b/src/python/pants/backend/docker/subsystems/dockerfile_parser_test.py
@@ -129,3 +129,24 @@ def test_inconsistent_build_args(rule_runner: RuleRunner) -> None:
     )
     with pytest.raises(ExecutionError, match=err_msg):
         rule_runner.request(DockerfileInfo, [DockerfileInfoRequest(addr)])
+
+
+def test_copy_source_references(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "test/BUILD": "docker_image()",
+            "test/Dockerfile": dedent(
+                """\
+                FROM base
+                COPY a b /
+                COPY --option c/d e/f/g /h
+                ADD ignored
+                COPY j k /
+                COPY
+                """
+            ),
+        }
+    )
+
+    info = rule_runner.request(DockerfileInfo, [DockerfileInfoRequest(Address("test"))])
+    assert info.copy_sources == ("a", "b", "c/d", "e/f/g", "j", "k")

--- a/src/python/pants/backend/docker/subsystems/dockerfile_wrapper_script.py
+++ b/src/python/pants/backend/docker/subsystems/dockerfile_wrapper_script.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import re
 import sys
 from dataclasses import dataclass
+from itertools import chain
 from typing import Generator
 
 #
@@ -116,6 +117,10 @@ def main(cmd: str, args: list[str]) -> None:
             """Return all defined build args, including any default values."""
             return tuple(cmd.original[4:].strip() for cmd in self.get_all("ARG"))
 
+        def copy_source_references(self) -> tuple[str, ...]:
+            """Return all files referenced from the build context using COPY instruction."""
+            return tuple(chain(*(cmd.value[:-1] for cmd in self.get_all("COPY"))))
+
     for parsed in map(ParsedDockerfile.from_file, args):
         if cmd == "putative-targets":
             for addr in parsed.putative_target_addresses():
@@ -126,6 +131,9 @@ def main(cmd: str, args: list[str]) -> None:
         elif cmd == "build-args":
             for arg in parsed.build_args():
                 print(arg)
+        elif cmd == "copy-sources":
+            for src in parsed.copy_source_references():
+                print(src)
 
 
 if __name__ == "__main__":

--- a/src/python/pants/backend/docker/util_rules/docker_build_context.py
+++ b/src/python/pants/backend/docker/util_rules/docker_build_context.py
@@ -20,12 +20,13 @@ from pants.backend.docker.util_rules.docker_build_env import (
     DockerBuildEnvironmentError,
     DockerBuildEnvironmentRequest,
 )
+from pants.backend.docker.utils import suggest_renames
 from pants.backend.shell.target_types import ShellSourceField
 from pants.core.goals.package import BuiltPackage, PackageFieldSet
 from pants.core.target_types import FileSourceField
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
-from pants.engine.fs import Digest, MergeDigests
+from pants.engine.fs import Digest, MergeDigests, Snapshot
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     Dependencies,
@@ -165,12 +166,13 @@ class DockerBuildContext:
     build_env: DockerBuildEnvironment
     dockerfile: str
     version_context: DockerVersionContext
+    copy_source_vs_context_source: tuple[tuple[str, str], ...]
 
     @classmethod
     def create(
         cls,
         build_args: DockerBuildArgs,
-        digest: Digest,
+        snapshot: Snapshot,
         build_env: DockerBuildEnvironment,
         dockerfile_info: DockerfileInfo,
     ) -> DockerBuildContext:
@@ -225,10 +227,21 @@ class DockerBuildContext:
 
         return cls(
             build_args=build_args,
-            digest=digest,
+            digest=snapshot.digest,
             dockerfile=dockerfile_info.source,
             build_env=build_env,
             version_context=DockerVersionContext.from_dict(version_context),
+            copy_source_vs_context_source=tuple(
+                suggest_renames(
+                    tentative_paths=(
+                        # We don't want to include the Dockerfile as a suggested rename
+                        dockerfile_info.source,
+                        *dockerfile_info.copy_sources,
+                    ),
+                    actual_files=snapshot.files,
+                    actual_dirs=snapshot.dirs,
+                )
+            ),
         )
 
 
@@ -281,7 +294,7 @@ async def create_docker_build_context(
     all_digests = (dockerfile_info.digest, sources.snapshot.digest, *embedded_pkgs_digest)
 
     # Merge all digests to get the final docker build context digest.
-    context_request = Get(Digest, MergeDigests(d for d in all_digests if d))
+    context_request = Get(Snapshot, MergeDigests(d for d in all_digests if d))
 
     # Requests for build args and env
     build_args_request = Get(DockerBuildArgs, DockerBuildArgsRequest(docker_image))
@@ -292,7 +305,7 @@ async def create_docker_build_context(
 
     return DockerBuildContext.create(
         build_args=build_args,
-        digest=context,
+        snapshot=context,
         dockerfile_info=dockerfile_info,
         build_env=build_env,
     )

--- a/src/python/pants/backend/docker/utils.py
+++ b/src/python/pants/backend/docker/utils.py
@@ -3,8 +3,12 @@
 
 from __future__ import annotations
 
-from typing import TypeVar
+import difflib
+import os.path
+from fnmatch import fnmatch
+from typing import Iterable, Iterator, Sequence, TypeVar
 
+from pants.help.maybe_color import MaybeColor
 from pants.util.ordered_set import FrozenOrderedSet
 
 _T = TypeVar("_T", bound="KeyValueSequenceUtil")
@@ -47,3 +51,108 @@ class KeyValueSequenceUtil(FrozenOrderedSet[str]):
             entry_and_value[0] for entry_and_value in key_to_entry_and_value.values()
         )
         return cls(FrozenOrderedSet(deduped_entries))
+
+
+def suggest_renames(
+    tentative_paths: Iterable[str], actual_files: Sequence[str], actual_dirs: Sequence[str]
+) -> Iterator[tuple[str, str]]:
+    """Return each pair of `tentative_paths` matched to the best possible match of `actual_paths`
+    that are not an exact match.
+
+    A pair of `(tentative_path, "")` means there were no possible match to find in the
+    `actual_paths`, while a pair of `("", actual_path)` indicates a file in the build context that
+    is not taking part in any `COPY` instruction.
+    """
+
+    actual_paths = (*actual_files, *actual_dirs)
+    referenced: dict[str, set[str] | bool] = {}
+
+    def reference(path: str) -> None:
+        """Track which actual files has been referenced either explicitly by a tentative path, or as
+        a suggested rename."""
+        if path in actual_dirs:
+            referenced[path] = True
+        else:
+            dirname = os.path.dirname(path)
+            refs = referenced.setdefault(dirname, set())
+            if isinstance(refs, set):
+                refs.add(path)
+
+        # Recalculate possible matches, to avoid suggesting the same file twice.
+        nonlocal actual_paths
+        actual_paths = tuple(get_unreferenced(actual_files, actual_dirs))
+
+    def is_referenced(path: str, dirname: str | None = None) -> bool:
+        """Check the list of referenced files to see if `path` has been flagged.
+
+        Walks up the directory tree in case there is a recursive flag on one of the parent
+        directories.
+        """
+        if dirname is None:
+            dirname = os.path.dirname(path)
+        refs = referenced.get(dirname, set())
+        if isinstance(refs, bool):
+            return refs
+        if path in refs:
+            return True
+        parentdir = os.path.dirname(dirname)
+        if parentdir:
+            return is_referenced(path, parentdir)
+        return False
+
+    def get_unreferenced(files: Sequence[str] = (), dirs: Sequence[str] = ()) -> Iterator[str]:
+        unreferenced_files = tuple(path for path in files if not is_referenced(path))
+        yield from unreferenced_files
+        for path in dirs:
+            if not any(filename.startswith(path + "/") for filename in unreferenced_files):
+                # Skip paths where we don't have any unreferenced files any longer.
+                continue
+            if not is_referenced(path, path):
+                yield path
+
+    def get_matches(path: str) -> tuple[str, ...]:
+        is_pattern = any(all(c in path for c in cs) for cs in ["*", "?", "[]"])
+        if not is_pattern:
+            return (path,) if path in actual_paths else ()
+        #
+        # NOTICE: There is a slight difference in the pattern syntax used for the Dockerfile `COPY`
+        # instruction, than what is implemented by the `fnmatch` function in Python.
+        # https://docs.docker.com/engine/reference/builder/#copy which is implemented using
+        # https://golang.org/pkg/path/filepath#Match compared to
+        # https://docs.python.org/3/library/fnmatch.html#fnmatch.fnmatch
+        #
+        # For best experience when using globs, this should be addressed, but for now, I'll settle
+        # for a "close enough" approximation to get this moving.
+        return tuple(p for p in actual_paths if fnmatch(p, path))
+
+    # Go over exact matches first, so we don't target them as possible matches for renames.
+    unmatched_paths = set()
+    for path in tentative_paths:
+        matches = get_matches(path)
+        for match in matches:
+            reference(match)
+        if not matches:
+            unmatched_paths.add(path)
+
+    # List unknown files, possibly with a rename suggestion.
+    for path in sorted(unmatched_paths):
+        for suggestion in difflib.get_close_matches(path, actual_paths, n=1, cutoff=0.1):
+            # Suggest rename to match what files there are.
+            reference(suggestion)
+            yield path, suggestion
+            break
+        else:
+            # No match for this path.
+            yield path, ""
+
+    # List unused files.
+    for path in sorted(get_unreferenced(actual_files)):
+        yield "", path
+
+
+def format_rename_suggestion(src_path: str, dst_path: str, *, colors: bool) -> str:
+    """Given two paths, formats a line showing what to change in `src_path` to get to `dst_path`."""
+    color = MaybeColor(colors)
+    rem = color.maybe_red(src_path)
+    add = color.maybe_green(dst_path)
+    return f"{rem} => {add}"

--- a/src/python/pants/backend/docker/utils_test.py
+++ b/src/python/pants/backend/docker/utils_test.py
@@ -1,0 +1,170 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import pytest
+
+from pants.backend.docker.utils import format_rename_suggestion, suggest_renames
+
+
+@pytest.mark.parametrize(
+    "tentative_paths, actual_files, actual_dirs, expected_renames",
+    [
+        (
+            ("src/project/cmd.pex",),
+            ("src.project/cmd.pex",),
+            (),
+            [("src/project/cmd.pex", "src.project/cmd.pex")],
+        ),
+        (
+            ("src/project/cmd.pex",),
+            ("src/unrelated/file.py",),
+            ("src/unrelated",),
+            [
+                # "false" positive, this is not an expected "correct" rename suggestion, but it was
+                # all we got here.
+                ("src/project/cmd.pex", "src/unrelated/file.py"),
+            ],
+        ),
+        pytest.param(
+            ("files",),
+            (
+                "src/docker/files/a.txt",
+                "src/docker/files/b.txt",
+                "src/docker/files/sub/c.txt",
+                "src/docker/config.ini",
+            ),
+            ("src", "src/docker", "src/docker/files"),
+            [
+                ("files", "src/docker/files"),
+                ("", "src/docker/config.ini"),
+            ],
+            id="Copy'ing a folder, includes the entire tree below it",
+        ),
+        pytest.param(
+            (
+                "src.proj/bin_a.pex",
+                "src.proj/binb.pex",
+            ),
+            ("src.proj/bin_a.pex",),
+            ("src.proj",),
+            [
+                ("src.proj/binb.pex", ""),
+            ],
+            id="Should not suggest renaming to a file we already reference",
+        ),
+        pytest.param(
+            (
+                "src.proj/binb.pex",
+                "src.proj/bin_a.pex",
+            ),
+            ("src.proj/bin_a.pex",),
+            ("src.proj",),
+            [
+                ("src.proj/binb.pex", ""),
+            ],
+            id="Should not suggest renaming to a file we already reference, order should not matter",
+        ),
+        pytest.param(
+            # I'm not entirely sure if `fnmatch` treats the ../*.pex the same as golangs
+            # filepath.Match does. See notice comment in
+            # pants.backend.docker.utils.suggest_renames().get_matches()
+            (
+                "src.proj/*.pex",
+                "src.proj/config.ini",
+            ),
+            (
+                "src.proj/bin_a.pex",
+                "src.proj/bin_b.pex",
+                "src.proj/other.txt",
+                "src.proj/nested/file.txt",
+                "src/proj/config.ini",
+            ),
+            (
+                "src.proj",
+                "src/proj",
+                "src.proj/nested",
+            ),
+            [
+                ("src.proj/config.ini", "src/proj/config.ini"),
+                ("", "src.proj/nested/file.txt"),
+                ("", "src.proj/other.txt"),
+            ],
+            id="Glob pattern captures matching files only",
+        ),
+        pytest.param(
+            (
+                "src/project/file",
+                "sources",
+            ),
+            ("src/project/file",),
+            (
+                "src",
+                "src/project",
+            ),
+            [
+                ("sources", ""),
+            ],
+            id="Do not suggest renaming to an 'empty' directory",
+        ),
+        pytest.param(
+            (
+                "testprojects/src/python/docker/Dockerfile.test-example-synth",
+                "testprojects.src.python.hello.main/mains.pez",
+                "blarg",
+                "baz",
+            ),
+            (
+                "testprojects/src/python/docker/Dockerfile.test-example-synth",
+                "testprojects.src.python.hello.main/main.pex",
+            ),
+            (
+                "testprojects",
+                "testprojects/src",
+                "testprojects/src/python",
+                "testprojects/src/python/docker",
+                "testprojects.src.python.hello.main",
+            ),
+            [
+                ("baz", ""),
+                ("blarg", ""),
+                (
+                    "testprojects.src.python.hello.main/mains.pez",
+                    "testprojects.src.python.hello.main/main.pex",
+                ),
+            ],
+            id="Skip Dockerfile",
+        ),
+    ],
+)
+def test_suggest_renames(
+    tentative_paths: tuple[str, ...],
+    actual_files: tuple[str, ...],
+    actual_dirs: tuple[str, ...],
+    expected_renames: list[tuple[str, str]],
+) -> None:
+    actual_renames = list(suggest_renames(tentative_paths, actual_files, actual_dirs))
+    assert actual_renames == expected_renames
+
+
+@pytest.mark.parametrize(
+    "src, dst",
+    [
+        (
+            "src/project/cmd.pex",
+            "src.project/cmd.pex",
+        ),
+        (
+            "srcs/projcet/cmd",
+            "src/project/cmd.pex",
+        ),
+        (
+            "src/bar-foo/file",
+            "src/foo-bar/file",
+        ),
+    ],
+)
+def test_format_rename_suggestion(src: str, dst: str) -> None:
+    actual = format_rename_suggestion(src, dst, colors=False)
+    assert actual == f"{src} => {dst}"

--- a/src/python/pants/testutil/pytest_util.py
+++ b/src/python/pants/testutil/pytest_util.py
@@ -11,11 +11,17 @@ def assert_logged(caplog, expect_logged: list[tuple[int, str]] | None = None) ->
         assert not caplog.records
         return
 
-    assert len(caplog.records) == len(expect_logged)
+    assert len(caplog.records) == len(
+        expect_logged
+    ), f"Expected {len(expect_logged)} records, but got {len(caplog.records)}."
     for idx, (lvl, msg) in enumerate(expect_logged):
         log_record = caplog.records[idx]
-        assert msg in log_record.message
-        assert lvl == log_record.levelno
+        assert (
+            msg in log_record.message
+        ), f"The text {msg!r} was not found in {log_record.message!r}."
+        assert (
+            lvl == log_record.levelno
+        ), f"Expected level {lvl}, but got level {log_record.levelno}."
 
 
 @contextmanager


### PR DESCRIPTION
Logs warning about the docker build context, and what files where referenced and not, and possible renames to get more matches in case of docker build failure.

Fixes #13428

If `docker build` fails, you get a WARNING log like this (from the tests):
```
WARNING     pants.backend.docker.goals.package_image:package_image.py:282 Docker build failed for `docker_image` docker/test:test. The docker/test/Dockerfile have `COPY`instructions where the source files may not have been found in the Docker build context.

However there are possible matches. Please review the following list of suggested renames:

  * src/project/bin.pex => src.project/binary.pex

There are additional files in the Docker build context that were not referenced by any `COPY` instruction (this is not an error):

  * src/project/app.py
```

[ci skip-rust]

[ci skip-build-wheels]