### PR TITLE
Workaround for immutable_input_digests in InteractiveProcess

### DIFF
--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -13,7 +13,15 @@ from typing import Iterable, Mapping
 
 from pants.engine.collection import DeduplicatedCollection
 from pants.engine.engine_aware import EngineAwareReturnType, SideEffecting
-from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, FileContent, FileDigest
+from pants.engine.fs import (
+    EMPTY_DIGEST,
+    AddPrefix,
+    CreateDigest,
+    Digest,
+    FileContent,
+    FileDigest,
+    MergeDigests,
+)
 from pants.engine.internals.selectors import MultiGet
 from pants.engine.internals.session import RunId
 from pants.engine.platform import Platform
@@ -339,6 +347,14 @@ class InteractiveProcess(SideEffecting):
         forward_signals_to_process: bool = True,
         restartable: bool = False,
     ) -> InteractiveProcess:
+        # TODO: Remove this check once https://github.com/pantsbuild/pants/issues/13852 is
+        #  implemented and the immutable_input_digests are propagated into the InteractiveProcess.
+        if process.immutable_input_digests:
+            raise ValueError(
+                "Process has immutable_input_digests, so it cannot be converted to an "
+                "InteractiveProcess by calling from_process().  Use an async "
+                "InteractiveProcessRequest instead."
+            )
         return InteractiveProcess(
             argv=process.argv,
             env=process.env,
@@ -347,6 +363,39 @@ class InteractiveProcess(SideEffecting):
             restartable=restartable,
             append_only_caches=process.append_only_caches,
         )
+
+
+@dataclass(frozen=True)
+class InteractiveProcessRequest:
+    process: Process
+    forward_signals_to_process: bool = True
+    restartable: bool = False
+
+
+@rule
+async def interactive_process_from_process(req: InteractiveProcessRequest) -> InteractiveProcess:
+    # TODO: Temporary workaround until https://github.com/pantsbuild/pants/issues/13852
+    #  is implemented. Once that is implemented we can get rid of this rule, and the
+    #  InteractiveProcessRequest type, and use InteractiveProcess.from_process directly.
+
+    if req.process.immutable_input_digests:
+        prefixed_immutable_input_digests = await MultiGet(
+            Get(Digest, AddPrefix(digest, prefix))
+            for prefix, digest in req.process.immutable_input_digests.items()
+        )
+        full_input_digest = await Get(
+            Digest, MergeDigests([req.process.input_digest, *prefixed_immutable_input_digests])
+        )
+    else:
+        full_input_digest = req.process.input_digest
+    return InteractiveProcess(
+        argv=req.process.argv,
+        env=req.process.env,
+        input_digest=full_input_digest,
+        forward_signals_to_process=req.forward_signals_to_process,
+        restartable=req.restartable,
+        append_only_caches=req.process.append_only_caches,
+    )
 
 
 @frozen_after_init

--- a/src/python/pants/engine/process_test.py
+++ b/src/python/pants/engine/process_test.py
@@ -285,6 +285,8 @@ def test_interactive_process_immutable_input_digests(rule_runner: RuleRunner) ->
         immutable_input_digests={"prefix1": digest1, "prefix2": digest2},
     )
     iproc = rule_runner.request(InteractiveProcess, [InteractiveProcessRequest(process)])
+    assert iproc.argv == process.argv
+    assert iproc.env == process.env
     snapshot = rule_runner.request(Snapshot, [iproc.input_digest])
     assert snapshot.files == ("file0", "prefix1/file1", "prefix2/file2", "prefix2/file3")
 

--- a/src/python/pants/engine/process_test.py
+++ b/src/python/pants/engine/process_test.py
@@ -14,6 +14,7 @@ from pants.engine.fs import (
     DigestContents,
     Directory,
     FileContent,
+    Snapshot,
 )
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.process import (
@@ -21,6 +22,7 @@ from pants.engine.process import (
     BinaryPaths,
     FallibleProcessResult,
     InteractiveProcess,
+    InteractiveProcessRequest,
     Process,
     ProcessCacheScope,
     ProcessResult,
@@ -35,6 +37,7 @@ def new_rule_runner() -> RuleRunner:
             QueryRule(BinaryPaths, [BinaryPathRequest]),
             QueryRule(ProcessResult, [Process]),
             QueryRule(FallibleProcessResult, [Process]),
+            QueryRule(InteractiveProcess, [InteractiveProcessRequest]),
         ],
     )
 
@@ -266,6 +269,24 @@ def test_interactive_process_cannot_have_append_only_caches_and_workspace() -> N
         InteractiveProcess(
             argv=["/bin/echo"], append_only_caches={"foo": "bar"}, run_in_workspace=True
         )
+
+
+def test_interactive_process_immutable_input_digests(rule_runner: RuleRunner) -> None:
+    digest0 = rule_runner.request(Digest, [CreateDigest([FileContent("file0", b"")])])
+    digest1 = rule_runner.request(Digest, [CreateDigest([FileContent("file1", b"")])])
+    digest2 = rule_runner.request(
+        Digest, [CreateDigest([FileContent("file2", b""), FileContent("file3", b"")])]
+    )
+    process = Process(
+        argv=["foo", "bar"],
+        description="dummy",
+        env={"BAZ": "QUX"},
+        input_digest=digest0,
+        immutable_input_digests={"prefix1": digest1, "prefix2": digest2},
+    )
+    iproc = rule_runner.request(InteractiveProcess, [InteractiveProcessRequest(process)])
+    snapshot = rule_runner.request(Snapshot, [iproc.input_digest])
+    assert snapshot.files == ("file0", "prefix1/file1", "prefix2/file2", "prefix2/file3")
 
 
 def test_find_binary_non_existent(rule_runner: RuleRunner, tmp_path: Path) -> None:


### PR DESCRIPTION
Creates a regular input_digest with prefixed copies of the immutable
input digests.

This is a temporary workaround until InteractiveProcess supports
immutable_input_digests intrinsically. See
https://github.com/pantsbuild/pants/issues/13852

[ci skip-rust]

[ci skip-build-wheels]