### PR TITLE
[internal] Support the `pex3` console script with `PexCliProcess`

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -288,12 +288,13 @@ async def find_interpreter(
         ProcessResult,
         PexCliProcess(
             description=f"Find interpreter for constraints: {formatted_constraints}",
+            subcommand=(),
             # Here, we run the Pex CLI with no requirements, which just selects an interpreter.
             # Normally, this would start an isolated repl. By passing `--`, we force the repl to
             # instead act as an interpreter (the selected one) and tell us about itself. The upshot
             # is we run the Pex interpreter selection logic unperturbed but without resolving any
             # distributions.
-            argv=(
+            extra_args=(
                 *interpreter_constraints.generate_pex_arg_list(),
                 "--",
                 "-c",
@@ -530,7 +531,8 @@ async def build_pex(
         Process,
         PexCliProcess(
             python=python,
-            argv=argv,
+            subcommand=(),
+            extra_args=argv,
             additional_input_digest=merged_digest,
             description=_build_pex_description(request),
             output_files=output_files,

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -63,12 +63,12 @@ class PexBinary(TemplatedExternalTool):
 class PexCliProcess:
     subcommand: tuple[str, ...]
     extra_args: tuple[str, ...]
+    set_resolve_args: bool
     description: str = dataclasses.field(compare=False)
     additional_input_digest: Optional[Digest]
     extra_env: Optional[FrozenDict[str, str]]
     output_files: Optional[Tuple[str, ...]]
     output_directories: Optional[Tuple[str, ...]]
-    set_resolve_args: bool
     python: Optional[PythonExecutable]
     level: LogLevel
     cache_scope: ProcessCacheScope
@@ -79,23 +79,23 @@ class PexCliProcess:
         subcommand: Iterable[str],
         extra_args: Iterable[str],
         description: str,
+        set_resolve_args: bool = True,
         additional_input_digest: Optional[Digest] = None,
         extra_env: Optional[Mapping[str, str]] = None,
         output_files: Optional[Iterable[str]] = None,
         output_directories: Optional[Iterable[str]] = None,
-        set_resolve_args: bool = True,
         python: Optional[PythonExecutable] = None,
         level: LogLevel = LogLevel.INFO,
         cache_scope: ProcessCacheScope = ProcessCacheScope.SUCCESSFUL,
     ) -> None:
         self.subcommand = tuple(subcommand)
         self.extra_args = tuple(extra_args)
+        self.set_resolve_args = set_resolve_args
         self.description = description
         self.additional_input_digest = additional_input_digest
         self.extra_env = FrozenDict(extra_env) if extra_env else None
         self.output_files = tuple(output_files) if output_files else None
         self.output_directories = tuple(output_directories) if output_directories else None
-        self.set_resolve_args = set_resolve_args
         self.python = python
         self.level = level
         self.cache_scope = cache_scope
@@ -172,8 +172,6 @@ async def setup_pex_cli_process(
         if request.set_resolve_args
         else []
     )
-    # NB: This comes at the end of the argv because the request may use `--` passthrough args,
-    # which must come at the end.
     args = [
         *global_args,
         *request.subcommand,

--- a/src/python/pants/backend/python/util_rules/pex_cli_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli_test.py
@@ -32,9 +32,9 @@ def test_custom_ca_certs(tmp_path: Path, rule_runner: RuleRunner) -> None:
     )
     proc = rule_runner.request(
         Process,
-        [PexCliProcess(argv=["some", "--args"], description="")],
+        [PexCliProcess(subcommand=(), extra_args=("some", "--args"), description="")],
     )
-    assert proc.argv[2:4] == ("--cert", "certsfile")
+    assert proc.argv[4:6] == ("--cert", "certsfile")
     files = rule_runner.request(DigestContents, [proc.input_digest])
     chrooted_certs_file = [f for f in files if f.path == "certsfile"]
     assert len(chrooted_certs_file) == 1


### PR DESCRIPTION
Prework for switching to Pex for lockfile generation https://github.com/pantsbuild/pants/pull/13962. 

The main change with `pex3` is that it uses subcommands like `pex lock create` and `pex lock export`. Certain options like `--cert` are only available for certain subcommands.

[ci skip-rust]
[ci skip-build-wheels]