### PR TITLE
Add `image_labels` field to the `docker_image` target

### DIFF
--- a/src/python/pants/backend/docker/subsystems/docker_options.py
+++ b/src/python/pants/backend/docker/subsystems/docker_options.py
@@ -52,7 +52,8 @@ class DockerOptions(Subsystem):
         )
         default_repository_help = (
             "Configure the default repository name used in the Docker image tag.\n\n"
-            "The value is formatted and may reference these variables:\n\n"
+            "The value is formatted and may reference these variables (in addition to the normal "
+            "placeheolders derived from the Dockerfile and build args etc):\n\n"
             + bullet_list(["name", "directory", "parent_directory"])
             + "\n\n"
             'Example: `--default-repository="{directory}/{name}"`.\n\n'


### PR DESCRIPTION
This builds on top of previous PRs, one commit per PR. May review just the last commit, for this PR (or postpone review until previous PRs has landed)

```python
docker_image(
  ...
  image_labels={
    "my.label": "some value",
  }
)
```

### Use case

Using the `LABEL` Dockerfile instruction gets you a long way. However, when the `docker_image` target is defined using a macro, and the labels you want to define depends on inputs on that macro call, it becomes cumbersome and ugly to rely on `LABEL`s in the Dockerfile.