### PR TITLE
Upgrade to Pex 2.1.61 and use `--venv` copies.

### DIFF
--- a/3rdparty/python/lockfiles/pytest.txt
+++ b/3rdparty/python/lockfiles/pytest.txt
@@ -151,9 +151,9 @@ pytest-metadata==1.11.0; python_version >= "3.6" and python_full_version < "3.0.
 pytest==6.2.5; python_version >= "3.6" \
     --hash=sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134 \
     --hash=sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89
-setuptools==60.0.3; python_version >= "3.7" \
-    --hash=sha256:032e5949c02878c405552fb800743aad96940097460bc6f115340402852dcdde \
-    --hash=sha256:989ab2d3e632ba23358b8d43950bd46babde5bbb1516760dc5f5ccfe7accdd45
+setuptools==60.0.5; python_version >= "3.7" \
+    --hash=sha256:8d1f26f7cc0c81b7b372b0d133bb8b1b0abbb36f2083cb4a474a8b64cede98a7 \
+    --hash=sha256:4dcae26c87ddbd48275d24a8cb06c30b52503b2dd51619e3ec1bc63b45dacdea
 toml==0.10.2; python_version > "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version > "3.6" \
     --hash=sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b \
     --hash=sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f

--- a/3rdparty/python/lockfiles/user_reqs.txt
+++ b/3rdparty/python/lockfiles/user_reqs.txt
@@ -17,7 +17,7 @@
 #     "humbug==0.2.7",
 #     "ijson==3.1.4",
 #     "packaging==21.0",
-#     "pex==2.1.60",
+#     "pex==2.1.61",
 #     "psutil==5.8.0",
 #     "pytest<6.3,>=6.2.4",
 #     "requests[security]>=2.25.1",
@@ -138,9 +138,9 @@ iniconfig==1.1.1; python_version >= "3.6" \
 packaging==21.0; python_version >= "3.6" \
     --hash=sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14 \
     --hash=sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7
-pex==2.1.60; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0" and python_version < "3.11") \
-    --hash=sha256:474604ef7db5c74cbe9f2400167b4859fb9f21f09ae41bafd2321c9b35ec0d12 \
-    --hash=sha256:3a0cd1bdb70a52d5a3c0ca08a5560329cf5ccc661c53b741128ce3d3f730a3c5
+pex==2.1.61; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0" and python_version < "3.11") \
+    --hash=sha256:c09fda0f0477f3894f7a7a464b7e4c03d44734de46caddd25291565eed32a882 \
+    --hash=sha256:6b00014cc74cc39fda191d8e07006bc423f8165cf04e42cdb02431593f33ff02
 pluggy==1.0.0; python_version >= "3.6" \
     --hash=sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3 \
     --hash=sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -14,7 +14,7 @@ humbug==0.2.7
 
 ijson==3.1.4
 packaging==21.0
-pex==2.1.60
+pex==2.1.61
 psutil==5.8.0
 pytest>=6.2.4,<6.3  # This should be kept in sync with `pytest.py`.
 PyYAML>=6.0,<7.0

--- a/pants.toml
+++ b/pants.toml
@@ -107,6 +107,9 @@ ignore_adding_targets = [
   "src/python/pants/backend/terraform:hcl2_parser0",
 ]
 
+[pex]
+venv_use_symlinks = true
+
 [python]
 experimental_lockfile = "3rdparty/python/lockfiles/user_reqs.txt"
 interpreter_constraints = [">=3.7,<3.10"]

--- a/src/python/pants/backend/python/subsystems/lambdex_lockfile.txt
+++ b/src/python/pants/backend/python/subsystems/lambdex_lockfile.txt
@@ -17,6 +17,6 @@
 lambdex==0.1.6; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0" and python_version < "3.10") \
     --hash=sha256:cb685b106617fbd1afd26d6e9472b2e0c99df8574c6d358aee4e6c13aeef8eb1 \
     --hash=sha256:6d1a95c8a31baa703edece8e36a705045b0203c7e886812c27a4dd945aa694e0
-pex==2.1.60; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "3.10" \
-    --hash=sha256:474604ef7db5c74cbe9f2400167b4859fb9f21f09ae41bafd2321c9b35ec0d12 \
-    --hash=sha256:3a0cd1bdb70a52d5a3c0ca08a5560329cf5ccc661c53b741128ce3d3f730a3c5
+pex==2.1.61; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "3.10" \
+    --hash=sha256:c09fda0f0477f3894f7a7a464b7e4c03d44734de46caddd25291565eed32a882 \
+    --hash=sha256:6b00014cc74cc39fda191d8e07006bc423f8165cf04e42cdb02431593f33ff02

--- a/src/python/pants/backend/python/subsystems/setuptools_lockfile.txt
+++ b/src/python/pants/backend/python/subsystems/setuptools_lockfile.txt
@@ -18,6 +18,6 @@
 setuptools==57.5.0; python_version >= "3.6" \
     --hash=sha256:60d78588f15b048f86e35cdab73003d8b21dd45108ee61a6693881a427f22073 \
     --hash=sha256:d9d3266d50f59c6967b9312844470babbdb26304fe740833a5f8d89829ba3a24
-wheel==0.37.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0") \
-    --hash=sha256:21014b2bd93c6d0034b6ba5d35e4eb284340e09d63c59aef6fc14b0f346146fd \
-    --hash=sha256:e2ef7239991699e3355d54f8e968a21bb940a1dbf34a4d226741e64462516fad
+wheel==0.37.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0") \
+    --hash=sha256:4bdcd7d840138086126cd09254dc6195fb4fc6f01c050a1d7236f2630db1d22a \
+    --hash=sha256:e9a504e793efbca1b8e0e9cb979a249cf4a0a7b5b8c9e8b65a5e39d49529c1c4

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -925,9 +925,9 @@ async def create_venv_pex(
             "--venv",
             "--seed",
             "verbose",
-            "--venv-site-packages-copies"
-            if request.site_packages_copies
-            else "--no-venv-site-packages-copies",
+            pex_environment.venv_site_packages_copies_option(
+                use_copies=request.site_packages_copies
+            ),
         ),
     )
     venv_pex_result = await Get(BuildPexResult, PexRequest, seeded_venv_request)

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -39,9 +39,9 @@ class PexBinary(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."
 
-    default_version = "v2.1.60"
+    default_version = "v2.1.61"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.1.59,<3.0"
+    version_constraints = ">=2.1.61,<3.0"
 
     @classproperty
     def default_known_versions(cls):
@@ -50,8 +50,8 @@ class PexBinary(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "89d1e801efb56552281d3766906e1a697ecf103aa7a5cadf6dd986f694772606",
-                    "3693781",
+                    "8072340969ad517279f153551f34d6c43ba51f7984223da4fb0913cc734d0c90",
+                    "3693575",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64"]


### PR DESCRIPTION
This picks up a fix for `--venv` copies (hardlinks) mode that allows
Pants to work with more distributions (including its own!).

See the changelog here:
  https://github.com/pantsbuild/pex/releases/tag/v2.1.61

An advanced `pex` option is plumbed to use symlinks when possible, but
but does not turn this on by default since it can break given certain
distributions. Pants does dogfood the optimization though since it is
not plagued by such distributions.
    
[ci skip-rust]
