### PR TITLE
Add `OptionalSingleSourceField`

### DIFF
--- a/src/python/pants/backend/docker/target_types.py
+++ b/src/python/pants/backend/docker/target_types.py
@@ -22,7 +22,7 @@ from pants.engine.target import (
     BoolField,
     Dependencies,
     DictStringToStringField,
-    SingleSourceField,
+    OptionalSingleSourceField,
     StringField,
     StringSequenceField,
     Target,
@@ -41,7 +41,7 @@ class DockerBuildArgsField(StringSequenceField):
     )
 
 
-class DockerImageSourceField(SingleSourceField):
+class DockerImageSourceField(OptionalSingleSourceField):
     default = "Dockerfile"
 
     # When the default glob value is in effect, we don't want the normal glob match error behavior
@@ -51,8 +51,6 @@ class DockerImageSourceField(SingleSourceField):
     # to the user.
     default_glob_match_error_behavior = GlobMatchErrorBehavior.ignore
 
-    expected_num_files = range(0, 2)
-    required = False
     help = (
         "The Dockerfile to use when building the Docker image.\n\n"
         "Use the `instructions` field instead if you prefer not having the Dockerfile in your "

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -30,6 +30,7 @@ from pants.engine.target import (
     InvalidTargetException,
     MultipleSourcesField,
     NestedDictStringToStringField,
+    OptionalSingleSourceField,
     OverridesField,
     RequiredFieldMissingException,
     ScalarField,
@@ -1165,9 +1166,8 @@ def test_single_source_path_globs(
 
 
 def test_single_source_file_path() -> None:
-    class TestSingleSourceField(SingleSourceField):
-        required = False
-        expected_num_files = range(0, 2)
+    class TestSingleSourceField(OptionalSingleSourceField):
+        pass
 
     assert TestSingleSourceField(None, Address("project")).file_path is None
     assert TestSingleSourceField("f.ext", Address("project")).file_path == "project/f.ext"

--- a/src/python/pants/jvm/target_types.py
+++ b/src/python/pants/jvm/target_types.py
@@ -12,6 +12,7 @@ from pants.engine.target import (
     FieldSet,
     InvalidFieldException,
     InvalidTargetException,
+    OptionalSingleSourceField,
     SingleSourceField,
     StringField,
     StringSequenceField,
@@ -97,11 +98,9 @@ class JvmArtifactUrlField(StringField):
     )
 
 
-class JvmArtifactJarSourceField(SingleSourceField):
+class JvmArtifactJarSourceField(OptionalSingleSourceField):
     alias = "jar"
     expected_file_extensions = (".jar",)
-    expected_num_files = range(0, 2)
-    required = False
     help = (
         "A local JAR file that provides this artifact to the lockfile resolver, instead of a "
         "Maven repository.\n\n"


### PR DESCRIPTION
This allows us to represent the two types of `source: str` fields we've encountered in the past two months via the type system. It DRYs and also avoids awkward code for callers like having to use `cast` in https://github.com/pantsbuild/pants/pull/13981.

[ci skip-rust]