### PR TITLE
[internal] go: add test for embed.FS usage

### DIFF
--- a/src/python/pants/backend/go/util_rules/embed_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/embed_integration_test.py
@@ -297,6 +297,4 @@ def test_embed_filesystem(rule_runner: RuleRunner) -> None:
     )
     tgt = rule_runner.get_target(Address("", target_name="pkg"))
     result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
-    print(f"stdout = {result.stdout}")
-    print(f"stderr = {result.stderr}")
     assert result.exit_code == 0


### PR DESCRIPTION
Add a test of Go file embedding where the embedded variable is an `embed.FS` instead of just a `string`.

[ci skip-rust]
