### PR TITLE
Improve rule graph error message.

### DIFF
--- a/src/rust/engine/rule_graph/src/builder.rs
+++ b/src/rust/engine/rule_graph/src/builder.rs
@@ -1117,10 +1117,16 @@ impl<R: Rule> Builder<R> {
           .neighbors_directed(node_id, Direction::Outgoing)
           .any(|dependency_id| errored.contains_key(&dependency_id) && node_id != dependency_id)
       })
-      .flat_map(|(_, errors)| {
+      .flat_map(|(&node_id, errors)| {
         let mut errors = errors.clone();
         errors.sort();
-        errors.into_iter().map(|e| e.trim().replace("\n", "\n    "))
+        errors.into_iter().map(move |e| {
+          format!(
+            "{}: {}",
+            params_str(&graph[node_id].0.out_set),
+            e.trim().replace("\n", "\n    ")
+          )
+        })
       })
       .collect::<Vec<_>>();
 

--- a/src/rust/engine/rule_graph/src/tests.rs
+++ b/src/rust/engine/rule_graph/src/tests.rs
@@ -83,7 +83,7 @@ fn ambiguity() {
   assert!(RuleGraph::new(rules, queries)
     .err()
     .unwrap()
-    .contains("Encountered 1 rule graph error:\n  Too many"));
+    .contains("Encountered 1 rule graph error:\n  b+c: Too many"));
 }
 
 #[test]


### PR DESCRIPTION
The wording could certainly be improved, but already as-is in this PR, I think it's more helpful.. as it helps pinpoint what type was requested, that we don't have a satisfying rule for ;) 

Better would've perhaps been to get the `Get(PyDigest, CreateArchive)` wording, but didn't spend enough time figuring out where to get that (I'm sure it's easy enough)

Before:
```
E       ValueError: Encountered 7 rule graph errors:
E         No installed rules return the type CreateDigest, and it was not provided by potential callers of @rule(<intrinsic>(CreateDigest) -> PyDigest).
E           If that type should be computed by a rule, ensure that that rule is installed.
E           If it should be provided by a caller, ensure that it is included in any relevant Query or Get.
E         No installed rules return the type DigestSubset, and it was not provided by potential callers of @rule(<intrinsic>(DigestSubset) -> PyDigest).
E           If that type should be computed by a rule, ensure that that rule is installed.
E           If it should be provided by a caller, ensure that it is included in any relevant Query or Get.
E         No installed rules return the type DownloadFile, and it was not provided by potential callers of @rule(<intrinsic>(DownloadFile) -> PyDigest).
E           If that type should be computed by a rule, ensure that that rule is installed.
E           If it should be provided by a caller, ensure that it is included in any relevant Query or Get.
E         No installed rules return the type PathGlobs, and it was not provided by potential callers of @rule(<intrinsic>(PathGlobs) -> PyDigest).
E           If that type should be computed by a rule, ensure that that rule is installed.
E           If it should be provided by a caller, ensure that it is included in any relevant Query or Get.
E         No installed rules return the type PyAddPrefix, and it was not provided by potential callers of @rule(<intrinsic>(PyAddPrefix) -> PyDigest).
E           If that type should be computed by a rule, ensure that that rule is installed.
E           If it should be provided by a caller, ensure that it is included in any relevant Query or Get.
E         No installed rules return the type PyMergeDigests, and it was not provided by potential callers of @rule(<intrinsic>(PyMergeDigests) -> PyDigest).
E           If that type should be computed by a rule, ensure that that rule is installed.
E           If it should be provided by a caller, ensure that it is included in any relevant Query or Get.
E         No installed rules return the type PyRemovePrefix, and it was not provided by potential callers of @rule(<intrinsic>(PyRemovePrefix) -> PyDigest).
E           If that type should be computed by a rule, ensure that that rule is installed.
E           If it should be provided by a caller, ensure that it is included in any relevant Query or Get.

src/python/pants/engine/internals/scheduler.py:224: ValueError
```

After:
```
E       ValueError: Encountered 7 rule graph errors:
E         CreateArchive: No installed rules return the type CreateDigest, and it was not provided by potential callers of @rule(<intrinsic>(CreateDigest) -> PyDigest).
E           If that type should be computed by a rule, ensure that that rule is installed.
E           If it should be provided by a caller, ensure that it is included in any relevant Query or Get.
E         CreateArchive: No installed rules return the type DigestSubset, and it was not provided by potential callers of @rule(<intrinsic>(DigestSubset) -> PyDigest).
E           If that type should be computed by a rule, ensure that that rule is installed.
E           If it should be provided by a caller, ensure that it is included in any relevant Query or Get.
E         CreateArchive: No installed rules return the type DownloadFile, and it was not provided by potential callers of @rule(<intrinsic>(DownloadFile) -> PyDigest).
E           If that type should be computed by a rule, ensure that that rule is installed.
E           If it should be provided by a caller, ensure that it is included in any relevant Query or Get.
E         CreateArchive: No installed rules return the type PathGlobs, and it was not provided by potential callers of @rule(<intrinsic>(PathGlobs) -> PyDigest).
E           If that type should be computed by a rule, ensure that that rule is installed.
E           If it should be provided by a caller, ensure that it is included in any relevant Query or Get.
E         CreateArchive: No installed rules return the type PyAddPrefix, and it was not provided by potential callers of @rule(<intrinsic>(PyAddPrefix) -> PyDigest).
E           If that type should be computed by a rule, ensure that that rule is installed.
E           If it should be provided by a caller, ensure that it is included in any relevant Query or Get.
E         CreateArchive: No installed rules return the type PyMergeDigests, and it was not provided by potential callers of @rule(<intrinsic>(PyMergeDigests) -> PyDigest).
E           If that type should be computed by a rule, ensure that that rule is installed.
E           If it should be provided by a caller, ensure that it is included in any relevant Query or Get.
E         CreateArchive: No installed rules return the type PyRemovePrefix, and it was not provided by potential callers of @rule(<intrinsic>(PyRemovePrefix) -> PyDigest).
E           If that type should be computed by a rule, ensure that that rule is installed.
E           If it should be provided by a caller, ensure that it is included in any relevant Query or Get.

src/python/pants/engine/internals/scheduler.py:224: ValueError
```
