### PR TITLE
[jvm] Fix parsing of `Coursier` report coordinates when `packaging` is reported.

### DIFF
--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -175,6 +175,80 @@ def test_resolve_conflicting(rule_runner: RuleRunner) -> None:
 
 
 @maybe_skip_jdk_test
+def test_resolve_with_packaging(rule_runner: RuleRunner) -> None:
+    # Tests that an artifact pom which actually reports packaging ends up with proper version and
+    # packaging information.
+    #   see https://github.com/pantsbuild/pants/issues/13986
+    resolved_lockfile = rule_runner.request(
+        CoursierResolvedLockfile,
+        [
+            ArtifactRequirements.from_coordinates(
+                [Coordinate(group="org.bouncycastle", artifact="bcutil-jdk15on", version="1.70")]
+            ),
+        ],
+    )
+
+    assert resolved_lockfile == CoursierResolvedLockfile(
+        entries=(
+            CoursierLockfileEntry(
+                coord=Coordinate(
+                    group="org.bouncycastle",
+                    artifact="bcprov-jdk15on",
+                    version="1.70",
+                    packaging="jar",
+                    strict=True,
+                ),
+                file_name="org.bouncycastle_bcprov-jdk15on_jar_1.70.jar",
+                direct_dependencies=Coordinates([]),
+                dependencies=Coordinates([]),
+                file_digest=FileDigest(
+                    "8f3c20e3e2d565d26f33e8d4857a37d0d7f8ac39b62a7026496fcab1bdac30d4", 5867298
+                ),
+                remote_url=None,
+                pants_address=None,
+            ),
+            CoursierLockfileEntry(
+                coord=Coordinate(
+                    group="org.bouncycastle",
+                    artifact="bcutil-jdk15on",
+                    version="1.70",
+                    packaging="jar",
+                    strict=True,
+                ),
+                file_name="org.bouncycastle_bcutil-jdk15on_1.70.jar",
+                direct_dependencies=Coordinates(
+                    [
+                        Coordinate(
+                            group="org.bouncycastle",
+                            artifact="bcprov-jdk15on",
+                            version="1.70",
+                            packaging="jar",
+                            strict=True,
+                        )
+                    ]
+                ),
+                dependencies=Coordinates(
+                    [
+                        Coordinate(
+                            group="org.bouncycastle",
+                            artifact="bcprov-jdk15on",
+                            version="1.70",
+                            packaging="jar",
+                            strict=True,
+                        )
+                    ]
+                ),
+                file_digest=FileDigest(
+                    "52dc5551b0257666526c5095424567fed7dc7b00d2b1ba7bd52298411112b1d0", 482530
+                ),
+                remote_url=None,
+                pants_address=None,
+            ),
+        )
+    )
+
+
+@maybe_skip_jdk_test
 def test_resolve_with_broken_url(rule_runner: RuleRunner) -> None:
 
     coordinate = ArtifactRequirement(

--- a/src/python/pants/jvm/resolve/coursier_fetch_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_test.py
@@ -12,7 +12,7 @@ from pants.backend.java.target_types import DeployJarTarget, JavaSourcesGenerato
 from pants.backend.java.target_types import rules as target_types_rules
 from pants.core.util_rules import config_files, source_files
 from pants.engine.addresses import Address, Addresses
-from pants.jvm.resolve.coursier_fetch import NoCompatibleResolve
+from pants.jvm.resolve.coursier_fetch import Coordinate, NoCompatibleResolve
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.key import CoursierResolveKey
 from pants.jvm.target_types import JvmArtifactTarget
@@ -111,3 +111,28 @@ def test_no_matching_for_root(rule_runner: RuleRunner) -> None:
 def test_no_matching_for_leaf(rule_runner: RuleRunner) -> None:
     with engine_error(NoCompatibleResolve):
         assert_resolve("n/a", rule_runner, "one", "one", ["two"])
+
+
+@pytest.mark.parametrize(
+    "coord_str,with_2315_workaround,expected",
+    (
+        *(
+            ("group:artifact:version", b, Coordinate("group", "artifact", "version"))
+            for b in [True, False]
+        ),
+        (
+            "group:artifact:packaging:version",
+            True,
+            Coordinate("group", "artifact", "version", "packaging"),
+        ),
+        (
+            "group:artifact:version:packaging",
+            False,
+            Coordinate("group", "artifact", "version", "packaging"),
+        ),
+    ),
+)
+def test_from_coord_str(coord_str: str, with_2315_workaround: bool, expected: Coordinate) -> None:
+    assert (
+        Coordinate.from_coord_str(coord_str, with_2315_workaround=with_2315_workaround) == expected
+    )


### PR DESCRIPTION
As reported in #13986, artifacts with `packaging` specified in their POMs currently parse incorrectly from the `Coursier` report. While we wait for clarity upstream in https://github.com/coursier/coursier/issues/2315, optionally apply fixed parsing in the relevant positions. Fixes #13986.

[ci skip-rust]
[ci skip-build-wheels]