### PR TITLE
[internal] fix JVM tool lockfile generation (cherrypick of #13988)

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/scala/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/rules.py
@@ -66,7 +66,7 @@ class GenerateScalaFromProtobufRequest(GenerateSourcesRequest):
 
 
 class ScalapbcToolLockfileSentinel(JvmToolLockfileSentinel):
-    options_scope = ScalaPBSubsystem.options_scope
+    resolve_name = ScalaPBSubsystem.options_scope
 
 
 class ScalaPBShimCompiledClassfiles(ClasspathEntry):

--- a/src/python/pants/backend/codegen/protobuf/scala/scalapbc.default.lockfile.txt
+++ b/src/python/pants/backend/codegen/protobuf/scala/scalapbc.default.lockfile.txt
@@ -26,7 +26,9 @@
         "file_digest": {
             "fingerprint": "1569de6437d71e878807302f8e1b06a06b62d217cd4a30e8019c9543d6683dff",
             "serialized_bytes_length": 3285506
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -85,7 +87,9 @@
         "file_digest": {
             "fingerprint": "0d75e8d13af1c78c55def7645dfc001edf91e45c987bfd420de0f0cda2044200",
             "serialized_bytes_length": 91593
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -100,7 +104,9 @@
         "file_digest": {
             "fingerprint": "8d0e2f9834f4fc1a083a65239adc507ca83682c754a27f4c80e4f21990eff686",
             "serialized_bytes_length": 1674945
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -177,7 +183,9 @@
         "file_digest": {
             "fingerprint": "25aed9ea609c6009c74b58f7759e4461299f7a7f4c814523e4d64fdd8f89c600",
             "serialized_bytes_length": 585060
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -218,7 +226,9 @@
         "file_digest": {
             "fingerprint": "3b595b94c21d899b94b84190f87905b5586e0b813f056a85892ec726dec4d581",
             "serialized_bytes_length": 128899
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -337,7 +347,9 @@
         "file_digest": {
             "fingerprint": "fc1856b638b0434d8d7db7442e283bca311a78a8337f37f22142d1e1e1394d79",
             "serialized_bytes_length": 6187
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -384,7 +396,9 @@
         "file_digest": {
             "fingerprint": "00257d1ccfb9890bb12382df13175822a24992162d12950dc710db27bf5c9f24",
             "serialized_bytes_length": 22110
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -551,7 +565,9 @@
         "file_digest": {
             "fingerprint": "314e88805de922f0a7cab9f3920ae99553c5586a18a22e83619a545fcf97f5b9",
             "serialized_bytes_length": 25381
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -566,7 +582,9 @@
         "file_digest": {
             "fingerprint": "6d18fe25aa30b7e08b908cd21151d8f96e22965c640acd7751add9bbfe6137d4",
             "serialized_bytes_length": 14239
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -601,7 +619,9 @@
         "file_digest": {
             "fingerprint": "e88e55332fba0826bef2d80d2a471dcf808e67f978f9537cb95cbf13168f50d5",
             "serialized_bytes_length": 802637
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -666,7 +686,9 @@
         "file_digest": {
             "fingerprint": "88c1812998b902ee6d61cfb48a262bef29dcc9e32fd4f392e08fec3f16335b86",
             "serialized_bytes_length": 387140
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -737,7 +759,9 @@
         "file_digest": {
             "fingerprint": "57df50ddd6d32bf91292b4f22e7ee99f6409e727a8b7477fd1b2afca1cce2dee",
             "serialized_bytes_length": 1295823
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -778,7 +802,9 @@
         "file_digest": {
             "fingerprint": "101b561504f58af88c53b4e0e556bea16789c14350dbca80e5b2b621f8e7363c",
             "serialized_bytes_length": 488342
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -897,7 +923,9 @@
         "file_digest": {
             "fingerprint": "b0a18751171ef36720e61ffcbf9f1dfdcf781d15d6f00df492f59a20af8a987b",
             "serialized_bytes_length": 496062
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -926,7 +954,9 @@
         "file_digest": {
             "fingerprint": "ad622c46395c28246f6ac3e1f4970b370e3ff19daa41af94ecfb61697cec4e92",
             "serialized_bytes_length": 6360
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -941,7 +971,9 @@
         "file_digest": {
             "fingerprint": "6f23a489c24743f1109125554e0d1c6420ab784f36acedd80a0704c8873b9642",
             "serialized_bytes_length": 23575
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -956,7 +988,9 @@
         "file_digest": {
             "fingerprint": "109e64fc65767c7a1a3bd654709d76f107b0a3b39db32cbf11139e13a6f5229b",
             "serialized_bytes_length": 287352
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -985,7 +1019,9 @@
         "file_digest": {
             "fingerprint": "93f8bf202ac28c4ca13562e31f6881a7770768e12b056b568139f37c025a3841",
             "serialized_bytes_length": 5610
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -1014,7 +1050,9 @@
         "file_digest": {
             "fingerprint": "6d96d45a7fc6fc7ab69bdbac841b48cf67ab109f048c8db375ae4effae524f39",
             "serialized_bytes_length": 571493
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -1029,7 +1067,9 @@
         "file_digest": {
             "fingerprint": "f19ed732e150d3537794fd3fe42ee18470a3f707efd499ecd05a99e727ff6c8a",
             "serialized_bytes_length": 5955737
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -1058,6 +1098,8 @@
         "file_digest": {
             "fingerprint": "c8acaef84ae06ad83416a7e121ba8cb3da83c8581106be0695b8066c5d7c38ae",
             "serialized_bytes_length": 3607717
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     }
 ]

--- a/src/python/pants/backend/java/lint/google_java_format/google_java_format.default.lockfile.txt
+++ b/src/python/pants/backend/java/lint/google_java_format/google_java_format.default.lockfile.txt
@@ -12,7 +12,9 @@
         "file_digest": {
             "fingerprint": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
             "serialized_bytes_length": 19936
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -27,7 +29,9 @@
         "file_digest": {
             "fingerprint": "ff80626baaf12a09342befd4e84cba9d50662f5fcd7f7a9b3490a6b7cf87e66c",
             "serialized_bytes_length": 13854
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -92,7 +96,9 @@
         "file_digest": {
             "fingerprint": "770ae53bd2f0b750bdbbda6e2c685d54378a71d276a64418333ccdde00d021ee",
             "serialized_bytes_length": 266289
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -107,7 +113,9 @@
         "file_digest": {
             "fingerprint": "a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26",
             "serialized_bytes_length": 4617
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -196,7 +204,9 @@
         "file_digest": {
             "fingerprint": "44ce229ce26d880bf3afc362bbfcec34d7e6903d195bbb1db9f3b6e0d9834f06",
             "serialized_bytes_length": 2874025
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -211,7 +221,9 @@
         "file_digest": {
             "fingerprint": "b372a037d4230aa57fbeffdef30fd6123f9c0c2db85d0aced00c91b974f33f99",
             "serialized_bytes_length": 2199
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -226,7 +238,9 @@
         "file_digest": {
             "fingerprint": "21af30c92267bd6122c0e0b4d20cccb6641a37eaf956c6540ec471d584e64a7b",
             "serialized_bytes_length": 8781
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -241,6 +255,8 @@
         "file_digest": {
             "fingerprint": "c88c2e6a5fdaeb9f26fcf879264042de8a9ee9d376e2477838feaabcfa44dda6",
             "serialized_bytes_length": 230905
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     }
 ]

--- a/src/python/pants/backend/scala/lint/scalafmt/scalafmt.default.lockfile.txt
+++ b/src/python/pants/backend/scala/lint/scalafmt/scalafmt.default.lockfile.txt
@@ -86,7 +86,9 @@
         "file_digest": {
             "fingerprint": "c5aad998af8b4ee8c1750e4e2fa214d3a997e8904cf1b5a1235a0a3e374c91e4",
             "serialized_bytes_length": 523681
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -175,7 +177,9 @@
         "file_digest": {
             "fingerprint": "e49ffa30df2f2266a387320366c3022319cacd33d26eca0d26d93acdd536cabc",
             "serialized_bytes_length": 17289
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -204,7 +208,9 @@
         "file_digest": {
             "fingerprint": "d0173938db4e6f1429eb4b93136c5d857c1fa81eaa34b8c59f8b7b99ad0165f5",
             "serialized_bytes_length": 126307
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -219,7 +225,9 @@
         "file_digest": {
             "fingerprint": "61ba4dc49adca95243beaa0569adc2a23aedb5292ae78aa01186fa782ebdc5c2",
             "serialized_bytes_length": 34130
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -248,7 +256,9 @@
         "file_digest": {
             "fingerprint": "250014f81c734b9f5bb8ffc92cfad42c2425ffd8d60fa27e0828adf07483ebfb",
             "serialized_bytes_length": 65403
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -263,7 +273,9 @@
         "file_digest": {
             "fingerprint": "ca3857a3f95266e0d87e1a1f26c8592c53c12ac7203f911759415f6c8a43df7d",
             "serialized_bytes_length": 85365
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -304,7 +316,9 @@
         "file_digest": {
             "fingerprint": "c4f89810da70c3100b52458a85f8d520f54243e05047b98e829e2473f0092283",
             "serialized_bytes_length": 165433
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -319,7 +333,9 @@
         "file_digest": {
             "fingerprint": "a639a90e2d21bbafd8a5e213c65442aad200ee086951605cbda8835bc6ef11d3",
             "serialized_bytes_length": 118671
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -334,7 +350,9 @@
         "file_digest": {
             "fingerprint": "4518faa6bf4bd26fccdc4d85e1625dc679381a08d56872d8ad12151dda9cef25",
             "serialized_bytes_length": 32927
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -349,7 +367,9 @@
         "file_digest": {
             "fingerprint": "4c0aa7e223c75c8840c41fc183d4cd3118140a1ee503e3e08ce66ed2794c948f",
             "serialized_bytes_length": 295197
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -364,7 +384,9 @@
         "file_digest": {
             "fingerprint": "b3987e8c02441e82d88ab8727acd64eabf3a35217ffedba904b125e06a722a77",
             "serialized_bytes_length": 3131490
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -379,7 +401,9 @@
         "file_digest": {
             "fingerprint": "930273cc1c492f25661ea62413a6da3fd7f6e01bf1c4dcc0817fc8696a7b07ac",
             "serialized_bytes_length": 1729586
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -394,7 +418,9 @@
         "file_digest": {
             "fingerprint": "e2ee4b0bd3a2248f9ec6cf33f7d5b97e34ae652aecd3f42e13bded91f0df6bb6",
             "serialized_bytes_length": 992903
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -423,7 +449,9 @@
         "file_digest": {
             "fingerprint": "93f8bf202ac28c4ca13562e31f6881a7770768e12b056b568139f37c025a3841",
             "serialized_bytes_length": 5610
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -452,7 +480,9 @@
         "file_digest": {
             "fingerprint": "68f266c4fa37cb20a76e905ad940e241190ce288b7e4a9877f1dd1261cd1a9a7",
             "serialized_bytes_length": 1127123
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -481,7 +511,9 @@
         "file_digest": {
             "fingerprint": "6d96d45a7fc6fc7ab69bdbac841b48cf67ab109f048c8db375ae4effae524f39",
             "serialized_bytes_length": 571493
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -546,7 +578,9 @@
         "file_digest": {
             "fingerprint": "a450602f03a4686919e60d1aeced549559f1eaffbaf30ffa7987c8d97e3e79a9",
             "serialized_bytes_length": 12092802
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -561,7 +595,9 @@
         "file_digest": {
             "fingerprint": "a8bc08f3b9ff93d0496032bf2677163071b8d212992f41dbf04212e07d91616b",
             "serialized_bytes_length": 6004712
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -590,7 +626,9 @@
         "file_digest": {
             "fingerprint": "a7bc4eca6970083d426a8d081aec313c7b7207d5f83b6724995e34078edc5cbb",
             "serialized_bytes_length": 3771937
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -643,7 +681,9 @@
         "file_digest": {
             "fingerprint": "f6fb1c7f4ff257edb900d66e02d6ee1c8b5b4d7f7084b2d1710120cd36c524cc",
             "serialized_bytes_length": 530688
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -684,7 +724,9 @@
         "file_digest": {
             "fingerprint": "faec8003d08e27971b292062f79e16a4a428491f50736d140b8a1de38cd5c6b1",
             "serialized_bytes_length": 2344659
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -725,7 +767,9 @@
         "file_digest": {
             "fingerprint": "8fca8597ad6d7c13c48009ee13bbe80c176b08ab12e68af54a50f7f69d8447c5",
             "serialized_bytes_length": 320855
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -790,7 +834,9 @@
         "file_digest": {
             "fingerprint": "66c78cdb5ed6c6345089603eee8e1b41392245252019d1268bd87fd97a7d8bcc",
             "serialized_bytes_length": 1364598
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -1047,7 +1093,9 @@
         "file_digest": {
             "fingerprint": "f29db3984599972097fb92d1841ae528dd9989e57cc73daec6e758ee55087ecd",
             "serialized_bytes_length": 164800
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -1142,7 +1190,9 @@
         "file_digest": {
             "fingerprint": "be394d7869f91d33995d82dc9b857acb6331103952cb8fea25cf330e7d2b3324",
             "serialized_bytes_length": 9412
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -1327,7 +1377,9 @@
         "file_digest": {
             "fingerprint": "aee4a122642450de70661f3777470e26e38f03c3f53f22fdfd62ac8eb45b9d22",
             "serialized_bytes_length": 1964531
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -1392,7 +1444,9 @@
         "file_digest": {
             "fingerprint": "983d043a1f3a974844ead98b581cd9399b754c32971f7986efa30c5020d8b805",
             "serialized_bytes_length": 141924
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -1407,7 +1461,9 @@
         "file_digest": {
             "fingerprint": "58dba0553bd2fe291b8ae557f2dde8441f556b009d2ec72f94c67d5d1045ab88",
             "serialized_bytes_length": 5371
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -1448,7 +1504,9 @@
         "file_digest": {
             "fingerprint": "7d4fc40ce68a9a0d818bbbab84847ac379bbdf3f58bb7b8b816e78203fb07fe1",
             "serialized_bytes_length": 45886
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -1555,7 +1613,9 @@
         "file_digest": {
             "fingerprint": "2ee7a9b93baa8ca2213f516ed3ced26990fe34e3df4ddb149ee58aa5d46d6160",
             "serialized_bytes_length": 791746
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -1584,7 +1644,9 @@
         "file_digest": {
             "fingerprint": "b31eb8ef90bec4c22a8ec858f5bd007bd46ce80c3dcef9dce238c6f9dd15c1a4",
             "serialized_bytes_length": 3591
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -1649,7 +1711,9 @@
         "file_digest": {
             "fingerprint": "79fdf691ff0f75265c99422f31db519ee044e88f52a32bbc39d30c16f6781315",
             "serialized_bytes_length": 4274882
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -1678,6 +1742,8 @@
         "file_digest": {
             "fingerprint": "9484ac95856510459d1bd52a77a6b93cdd641560decdf9910395ee4d17e88163",
             "serialized_bytes_length": 121417
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     }
 ]

--- a/src/python/pants/jvm/test/junit.default.lockfile.txt
+++ b/src/python/pants/jvm/test/junit.default.lockfile.txt
@@ -26,7 +26,9 @@
         "file_digest": {
             "fingerprint": "4b8532f63bdc0e0661507f947eb324a954d1dbac631ad19c8aa9a00feed1d863",
             "serialized_bytes_length": 381765
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -41,7 +43,9 @@
         "file_digest": {
             "fingerprint": "a9aae9ff8ae3e17a2a18f79175e82b16267c246fbbd3ca9dfbbb290b08dcfdd4",
             "serialized_bytes_length": 2387
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -56,7 +60,9 @@
         "file_digest": {
             "fingerprint": "66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9",
             "serialized_bytes_length": 45024
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -109,7 +115,9 @@
         "file_digest": {
             "fingerprint": "bc98326ecbc501e1860a2bc9780aebe5777bd29cf00059f88c2a56f48fbc9ce6",
             "serialized_bytes_length": 175588
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -174,7 +182,9 @@
         "file_digest": {
             "fingerprint": "8a35afb26cd5e8393cb763ff13d26a52a507a35c5b2d7650d42024a7226b80db",
             "serialized_bytes_length": 212870
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -203,7 +213,9 @@
         "file_digest": {
             "fingerprint": "738d0df021a0611fff5d277634e890cc91858fa72227cf0bcf36232a7caf014c",
             "serialized_bytes_length": 100008
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -268,7 +280,9 @@
         "file_digest": {
             "fingerprint": "51b26b69a9c17df699cef22c998ebd4d2741edee1f5e6a1ff55efd72938d9e8b",
             "serialized_bytes_length": 474908
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -321,7 +335,9 @@
         "file_digest": {
             "fingerprint": "abebbfa420fa8ffdc51083c06807e8692dd9bf8c52455dcdb72474ab90425573",
             "serialized_bytes_length": 181408
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -374,7 +390,9 @@
         "file_digest": {
             "fingerprint": "a5923c861c27ff3ee79b11d6396896e7169a76967801b18b49488f9b16480b4e",
             "serialized_bytes_length": 137160
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -433,7 +451,9 @@
         "file_digest": {
             "fingerprint": "22eaee01eefd3be3fe7583f664577f3a5b92b66458a594451393d2edff39169b",
             "serialized_bytes_length": 25904
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -504,7 +524,9 @@
         "file_digest": {
             "fingerprint": "5fd722dbc11b1cfb61ebfb1382bdfa83581d3aaf2d4f05995d578d4c0ad36a73",
             "serialized_bytes_length": 64299
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     },
     {
         "coord": {
@@ -519,6 +541,8 @@
         "file_digest": {
             "fingerprint": "58812de60898d976fb81ef3b62da05c6604c18fd4a249f5044282479fc286af2",
             "serialized_bytes_length": 7653
-        }
+        },
+        "remote_url": null,
+        "pants_address": null
     }
 ]


### PR DESCRIPTION
Fix a call site where `options_scope` was not renamed to `resolve_name` which prevented `./pants jvm-generate-lockfiles` from working. Then re-generate all JVM lockfiles.

[ci skip-rust]
[ci skip-build-wheels]