### PR TITLE
[internal] Remove `[pex].bootstrap_interpreter_names` and `[python].interpreter_search_paths`

### DIFF
--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -8,12 +8,9 @@ import logging
 import os
 from typing import Iterable, Optional, cast
 
-from pants.engine.environment import Environment
 from pants.option.custom_types import file_option
 from pants.option.subsystem import Subsystem
-from pants.python.binaries import PythonBootstrap
 from pants.util.docutil import doc_url
-from pants.util.memo import memoized_method
 from pants.util.osutil import CPU_COUNT
 
 logger = logging.getLogger(__name__)
@@ -196,32 +193,6 @@ class PythonSetup(Subsystem):
             ),
         )
         register(
-            "--interpreter-search-paths",
-            advanced=True,
-            type=list,
-            default=["<PYENV>", "<PATH>"],
-            metavar="<binary-paths>",
-            removal_version="2.10.0.dev0",
-            removal_hint=("Moved to `[python-bootstrap] search_path`."),
-            help=(
-                "A list of paths to search for Python interpreters that match your project's "
-                "interpreter constraints.\n\n"
-                "You can specify absolute paths to interpreter binaries "
-                "and/or to directories containing interpreter binaries. The order of entries does "
-                "not matter.\n\n"
-                "The following special strings are supported:\n\n"
-                "* `<PATH>`, the contents of the PATH env var\n"
-                "* `<ASDF>`, all Python versions currently configured by ASDF "
-                "`(asdf shell, ${HOME}/.tool-versions)`, with a fallback to all installed versions\n"
-                "* `<ASDF_LOCAL>`, the ASDF interpreter with the version in "
-                "BUILD_ROOT/.tool-versions\n"
-                "* `<PYENV>`, all Python versions under $(pyenv root)/versions\n"
-                "* `<PYENV_LOCAL>`, the Pyenv interpreter with the version in "
-                "BUILD_ROOT/.python-version\n"
-                "* `<PEXRC>`, paths in the PEX_PYTHON_PATH variable in /etc/pexrc or ~/.pexrc"
-            ),
-        )
-        register(
             "--resolver-manylinux",
             advanced=True,
             type=str,
@@ -325,14 +296,6 @@ class PythonSetup(Subsystem):
 
     def resolve_all_constraints_was_set_explicitly(self) -> bool:
         return not self.options.is_default("resolve_all_constraints")
-
-    @memoized_method
-    def interpreter_search_paths(self, env: Environment):
-        # TODO: When the `interpreter_search_paths` option is removed, callers who need the
-        # interpreter search path should directly use `PythonBootstrap.interpreter_search_path`.
-        return PythonBootstrap.expand_interpreter_search_paths(
-            self.options.interpreter_search_paths, env
-        )
 
     @property
     def manylinux(self) -> str | None:

--- a/src/python/pants/python/binaries.py
+++ b/src/python/pants/python/binaries.py
@@ -96,10 +96,10 @@ class PythonBootstrap:
 
     @memoized_method
     def interpreter_search_paths(self):
-        return self.expand_interpreter_search_paths(self.options.search_path, self.environment)
+        return self._expand_interpreter_search_paths(self.options.search_path, self.environment)
 
     @classmethod
-    def expand_interpreter_search_paths(cls, interpreter_search_paths, env: Environment):
+    def _expand_interpreter_search_paths(cls, interpreter_search_paths, env: Environment):
         special_strings = {
             "<PEXRC>": cls.get_pex_python_paths,
             "<PATH>": lambda: cls.get_environment_paths(env),

--- a/src/python/pants/python/binaries_test.py
+++ b/src/python/pants/python/binaries_test.py
@@ -276,7 +276,7 @@ def test_expand_interpreter_search_paths(rule_runner: RuleRunner) -> None:
                     "ASDF_DATA_DIR": asdf_dir,
                 }
             )
-            expanded_paths = PythonBootstrap.expand_interpreter_search_paths(
+            expanded_paths = PythonBootstrap._expand_interpreter_search_paths(
                 paths,
                 env,
             )


### PR DESCRIPTION
Moved to `[python-bootstrap]` in Pants 2.9.

[ci skip-rust]
[ci skip-build-wheels]