### PR TITLE
[internal] java: cleanups for protobuf codegen

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/java/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/java/rules.py
@@ -49,7 +49,7 @@ async def generate_java_from_protobuf(
     output_dir = "_generated_files"
     create_output_dir_request = Get(Digest, CreateDigest([Directory(output_dir)]))
 
-    # Protoc needs all transitive dependencies on `protobuf_libraries` to work properly. It won't
+    # Protoc needs all transitive dependencies on `protobuf_source` to work properly. It won't
     # actually generate those dependencies; it only needs to look at their .proto files to work
     # with imports.
     transitive_targets = await Get(

--- a/src/python/pants/backend/codegen/protobuf/java/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/java/rules_integration_test.py
@@ -66,12 +66,9 @@ def assert_files_generated(
     *,
     expected_files: list[str],
     source_roots: list[str],
-    mypy: bool = False,
     extra_args: list[str] | None = None,
 ) -> None:
     args = [f"--source-root-patterns={repr(source_roots)}", *(extra_args or ())]
-    if mypy:
-        args.append("--python-protobuf-mypy-plugin")
     rule_runner.set_options(args, env_inherit={"PATH", "PYENV_ROOT", "HOME"})
     tgt = rule_runner.get_target(address)
     protocol_sources = rule_runner.request(


### PR DESCRIPTION
Make some small cleanups to Java protobuf codegen as per comments on https://github.com/pantsbuild/pants/pull/13989.

[ci skip-rust]
