### PR TITLE
Fix deprecated `[python-setup].interpreter_search_paths` and `[pex].bootstrap_interpreter_names` not working

### DIFF
--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -8,12 +8,9 @@ import logging
 import os
 from typing import Iterable, Optional, cast
 
-from pants.engine.environment import Environment
 from pants.option.custom_types import file_option
 from pants.option.subsystem import Subsystem
-from pants.python.binaries import PythonBootstrap
 from pants.util.docutil import doc_url
-from pants.util.memo import memoized_method
 from pants.util.osutil import CPU_COUNT
 
 logger = logging.getLogger(__name__)
@@ -289,14 +286,6 @@ class PythonSetup(Subsystem):
 
     def resolve_all_constraints_was_set_explicitly(self) -> bool:
         return not self.options.is_default("resolve_all_constraints")
-
-    @memoized_method
-    def interpreter_search_paths(self, env: Environment):
-        # TODO: When the `interpreter_search_paths` option is removed, callers who need the
-        # interpreter search path should directly use `PythonBootstrap.interpreter_search_path`.
-        return PythonBootstrap.expand_interpreter_search_paths(
-            self.options.interpreter_search_paths, env
-        )
 
     @property
     def manylinux(self) -> str | None:

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -53,6 +53,7 @@ from pants.engine.fs import (
 from pants.engine.platform import Platform
 from pants.engine.process import BashBinary, Process, ProcessCacheScope, ProcessResult
 from pants.engine.rules import Get, collect_rules, rule
+from pants.python import _binaries_rules
 from pants.util.docutil import doc_url
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
@@ -1193,4 +1194,4 @@ async def determine_pex_resolve_info(pex_pex: PexPEX, pex: Pex) -> PexResolveInf
 
 
 def rules():
-    return [*collect_rules(), *pex_cli.rules()]
+    return [*collect_rules(), *pex_cli.rules(), *_binaries_rules.rules()]

--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -100,10 +100,6 @@ class PexRuntimeEnvironment(Subsystem):
         return tuple(OrderedSet(iter_path_entries()))
 
     @property
-    def bootstrap_interpreter_names(self) -> tuple[str, ...]:
-        return tuple(self.options.bootstrap_interpreter_names)
-
-    @property
     def verbosity(self) -> int:
         level = cast(int, self.options.verbosity)
         if level < 0 or level > 9:
@@ -195,9 +191,7 @@ async def find_pex_python(
 ) -> PexEnvironment:
     return PexEnvironment(
         path=pex_runtime_env.path(python_bootstrap.environment),
-        interpreter_search_paths=tuple(
-            python_setup.interpreter_search_paths(python_bootstrap.environment)
-        ),
+        interpreter_search_paths=python_bootstrap.interpreter_search_paths(python_setup),
         subprocess_environment_dict=subprocess_env_vars.vars,
         # TODO: This path normalization is duplicated with `engine_initializer.py`. How can we do
         #  the normalization only once, via the options system?

--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -40,6 +40,7 @@ from pants.core.util_rules import (
     subprocess_environment,
 )
 from pants.goal import anonymous_telemetry, stats_aggregator
+from pants.python import _binaries_rules as python_binaries2
 from pants.python import binaries as python_binaries
 from pants.source import source_root
 
@@ -63,6 +64,7 @@ def rules():
         *archive.rules(),
         *config_files.rules(),
         *python_binaries.rules(),
+        *python_binaries2.rules(),
         *distdir.rules(),
         *external_tool.rules(),
         *pants_bin.rules(),

--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -18,6 +18,7 @@ from pants.engine.process import (
     ProcessResult,
 )
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.python import _binaries_rules as python_binaries2
 from pants.python import binaries as python_binaries
 from pants.python.binaries import PythonBinary
 from pants.util.logging import LogLevel
@@ -290,4 +291,5 @@ def rules():
     return [
         *collect_rules(),
         *python_binaries.rules(),
+        *python_binaries2.rules(),
     ]

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -37,8 +37,8 @@ from pants.option.global_options import (
 )
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.subsystem import Subsystem
-from pants.python import binaries as python_binaries
 from pants.python import _binaries_rules as python_binaries2
+from pants.python import binaries as python_binaries
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.vcs.changed import rules as changed_rules
 

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -38,6 +38,7 @@ from pants.option.global_options import (
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.subsystem import Subsystem
 from pants.python import binaries as python_binaries
+from pants.python import _binaries_rules as python_binaries2
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.vcs.changed import rules as changed_rules
 
@@ -256,6 +257,7 @@ class EngineInitializer:
                 *options_parsing.rules(),
                 *process.rules(),
                 *python_binaries.rules(),
+                *python_binaries2.rules(),
                 *platform.rules(),
                 *changed_rules(),
                 *streaming_workunit_handler_rules(),

--- a/src/python/pants/python/_binaries_rules.py
+++ b/src/python/pants/python/_binaries_rules.py
@@ -1,0 +1,91 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# NB: This only exists to resolve a circular import that will be fixed in Pants 2.10.
+from __future__ import annotations
+
+from textwrap import dedent
+
+from pants.backend.python.subsystems.setup import PythonSetup
+from pants.backend.python.util_rules.pex_environment import PexRuntimeEnvironment
+from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.process import BinaryNotFoundError, BinaryPathRequest, BinaryPaths, BinaryPathTest
+from pants.engine.rules import collect_rules, rule
+from pants.python.binaries import PythonBinary, PythonBootstrap
+from pants.util.logging import LogLevel
+
+
+@rule(desc="Finding a `python` binary", level=LogLevel.TRACE)
+async def find_python(
+    python_bootstrap: PythonBootstrap,
+    python_setup: PythonSetup,
+    pex_runtime_environment: PexRuntimeEnvironment,
+) -> PythonBinary:
+
+    # PEX files are compatible with bootstrapping via Python 2.7 or Python 3.5+, but we select 3.6+
+    # for maximum compatibility with internal scripts.
+    interpreter_search_paths = python_bootstrap.interpreter_search_paths(python_setup)
+    all_python_binary_paths = await MultiGet(
+        Get(
+            BinaryPaths,
+            BinaryPathRequest(
+                search_path=interpreter_search_paths,
+                binary_name=binary_name,
+                check_file_entries=True,
+                test=BinaryPathTest(
+                    args=[
+                        "-c",
+                        # N.B.: The following code snippet must be compatible with Python 3.6+.
+                        #
+                        # We hash the underlying Python interpreter executable to ensure we detect
+                        # changes in the real interpreter that might otherwise be masked by Pyenv
+                        # shim scripts found on the search path. Naively, just printing out the full
+                        # version_info would be enough, but that does not account for supported abi
+                        # changes (e.g.: a pyenv switch from a py27mu interpreter to a py27m
+                        # interpreter.)
+                        #
+                        # When hashing, we pick 8192 for efficiency of reads and fingerprint updates
+                        # (writes) since it's a common OS buffer size and an even multiple of the
+                        # hash block size.
+                        dedent(
+                            """\
+                            import sys
+
+                            major, minor = sys.version_info[:2]
+                            if not (major == 3 and minor >= 6):
+                                sys.exit(1)
+
+                            import hashlib
+                            hasher = hashlib.sha256()
+                            with open(sys.executable, "rb") as fp:
+                                for chunk in iter(lambda: fp.read(8192), b""):
+                                    hasher.update(chunk)
+                            sys.stdout.write(hasher.hexdigest())
+                            """
+                        ),
+                    ],
+                    fingerprint_stdout=False,  # We already emit a usable fingerprint to stdout.
+                ),
+            ),
+        )
+        for binary_name in python_bootstrap.interpreter_names(pex_runtime_environment)
+    )
+
+    for binary_paths in all_python_binary_paths:
+        path = binary_paths.first_path
+        if path:
+            return PythonBinary(
+                path=path.path,
+                fingerprint=path.fingerprint,
+            )
+
+    raise BinaryNotFoundError(
+        "Was not able to locate a Python interpreter to execute rule code.\n"
+        "Please ensure that Python is available in one of the locations identified by "
+        "`[python-bootstrap] search_path`, which currently expands to:\n"
+        f"  {interpreter_search_paths}"
+    )
+
+
+def rules():
+    return collect_rules()

--- a/src/python/pants/python/binaries.py
+++ b/src/python/pants/python/binaries.py
@@ -9,24 +9,22 @@ import re
 from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path, PurePath
-from textwrap import dedent
+from typing import TYPE_CHECKING
 
 from pex.variables import Variables
 
 from pants.base.build_environment import get_buildroot
+from pants.base.deprecated import resolve_conflicting_options
 from pants.engine.environment import Environment, EnvironmentRequest
-from pants.engine.process import (
-    BinaryNotFoundError,
-    BinaryPath,
-    BinaryPathRequest,
-    BinaryPaths,
-    BinaryPathTest,
-)
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.process import BinaryPath
+from pants.engine.rules import Get, collect_rules, rule
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.subsystem import Subsystem
-from pants.util.logging import LogLevel
-from pants.util.memo import memoized_method
+
+if TYPE_CHECKING:
+    from pants.backend.python.subsystems.setup import PythonSetup
+    from pants.backend.python.util_rules.pex_environment import PexRuntimeEnvironment
+
 
 logger = logging.getLogger(__name__)
 
@@ -90,13 +88,28 @@ class PythonBootstrap:
     environment: Environment
     options: OptionValueContainer
 
-    @property
-    def interpreter_names(self) -> tuple[str, ...]:
-        return tuple(self.options.names)
+    def interpreter_names(self, pex_runtime_environment: PexRuntimeEnvironment) -> tuple[str, ...]:
+        return tuple(
+            resolve_conflicting_options(
+                old_option="bootstrap_interpreter_names",
+                new_option="names",
+                old_container=pex_runtime_environment.options,
+                new_container=self.options,
+                old_scope=pex_runtime_environment.options_scope,
+                new_scope=PythonBootstrapSubsystem.options_scope,
+            )
+        )
 
-    @memoized_method
-    def interpreter_search_paths(self):
-        return self.expand_interpreter_search_paths(self.options.search_path, self.environment)
+    def interpreter_search_paths(self, python_setup: PythonSetup):
+        search_path = resolve_conflicting_options(
+            old_option="interpreter_search_paths",
+            new_option="search_path",
+            old_container=python_setup.options,
+            new_container=self.options,
+            old_scope=python_setup.options_scope,
+            new_scope=PythonBootstrapSubsystem.options_scope,
+        )
+        return self.expand_interpreter_search_paths(search_path, self.environment)
 
     @classmethod
     def expand_interpreter_search_paths(cls, interpreter_search_paths, env: Environment):
@@ -368,74 +381,6 @@ class PythonBinary(BinaryPath):
 
     TODO: Consider extracting PEX out into the core in order to support thirdparty dependencies.
     """
-
-
-@rule(desc="Finding a `python` binary", level=LogLevel.TRACE)
-async def find_python(python_bootstrap: PythonBootstrap) -> PythonBinary:
-
-    # PEX files are compatible with bootstrapping via Python 2.7 or Python 3.5+, but we select 3.6+
-    # for maximum compatibility with internal scripts.
-    interpreter_search_paths = python_bootstrap.interpreter_search_paths()
-    all_python_binary_paths = await MultiGet(
-        Get(
-            BinaryPaths,
-            BinaryPathRequest(
-                search_path=interpreter_search_paths,
-                binary_name=binary_name,
-                check_file_entries=True,
-                test=BinaryPathTest(
-                    args=[
-                        "-c",
-                        # N.B.: The following code snippet must be compatible with Python 3.6+.
-                        #
-                        # We hash the underlying Python interpreter executable to ensure we detect
-                        # changes in the real interpreter that might otherwise be masked by Pyenv
-                        # shim scripts found on the search path. Naively, just printing out the full
-                        # version_info would be enough, but that does not account for supported abi
-                        # changes (e.g.: a pyenv switch from a py27mu interpreter to a py27m
-                        # interpreter.)
-                        #
-                        # When hashing, we pick 8192 for efficiency of reads and fingerprint updates
-                        # (writes) since it's a common OS buffer size and an even multiple of the
-                        # hash block size.
-                        dedent(
-                            """\
-                            import sys
-
-                            major, minor = sys.version_info[:2]
-                            if not (major == 3 and minor >= 6):
-                                sys.exit(1)
-
-                            import hashlib
-                            hasher = hashlib.sha256()
-                            with open(sys.executable, "rb") as fp:
-                                for chunk in iter(lambda: fp.read(8192), b""):
-                                    hasher.update(chunk)
-                            sys.stdout.write(hasher.hexdigest())
-                            """
-                        ),
-                    ],
-                    fingerprint_stdout=False,  # We already emit a usable fingerprint to stdout.
-                ),
-            ),
-        )
-        for binary_name in python_bootstrap.interpreter_names
-    )
-
-    for binary_paths in all_python_binary_paths:
-        path = binary_paths.first_path
-        if path:
-            return PythonBinary(
-                path=path.path,
-                fingerprint=path.fingerprint,
-            )
-
-    raise BinaryNotFoundError(
-        "Was not able to locate a Python interpreter to execute rule code.\n"
-        "Please ensure that Python is available in one of the locations identified by "
-        "`[python-bootstrap] search_path`, which currently expands to:\n"
-        f"  {interpreter_search_paths}"
-    )
 
 
 def rules():

--- a/src/python/pants/python/binaries_test.py
+++ b/src/python/pants/python/binaries_test.py
@@ -14,6 +14,7 @@ from pants.base.build_environment import get_pants_cachedir
 from pants.engine.environment import Environment
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, rule
+from pants.python import _binaries_rules as python_binaries2
 from pants.python import binaries as python_binaries
 from pants.python.binaries import PythonBinary, PythonBootstrap, get_asdf_data_dir, get_pyenv_root
 from pants.testutil.rule_runner import QueryRule, RuleRunner
@@ -134,7 +135,12 @@ async def python_binary_version(python_binary: PythonBinary) -> PythonBinaryVers
 @pytest.fixture
 def rule_runner() -> RuleRunner:
     return RuleRunner(
-        rules=[*python_binaries.rules(), python_binary_version, QueryRule(PythonBinaryVersion, [])]
+        rules=[
+            *python_binaries.rules(),
+            *python_binaries2.rules(),
+            python_binary_version,
+            QueryRule(PythonBinaryVersion, []),
+        ]
     )
 
 
@@ -300,7 +306,11 @@ def test_expand_interpreter_search_paths(rule_runner: RuleRunner) -> None:
 
 def test_interpreter_search_path_file_entries() -> None:
     rule_runner = RuleRunner(
-        rules=[*python_binaries.rules(), QueryRule(PythonBinary, input_types=())]
+        rules=[
+            *python_binaries.rules(),
+            *python_binaries2.rules(),
+            QueryRule(PythonBinary, input_types=()),
+        ]
     )
     current_python = os.path.realpath(sys.executable)
     rule_runner.set_options(


### PR DESCRIPTION
Our deprecation policy says that the old options must continue to work.

This PR introduces a circular dependency between `python/binaries.py` and two files in `backend/python`. Because this cycle is temporary and already removed in Pants 2.10 (https://github.com/pantsbuild/pants/pull/14003), I took a quick and dirty approach of using `if TYPE_CHECKING` and moving the `@rule` into a dedicated file.

[ci skip-rust]
[ci skip-build-wheels]