### PR TITLE
[jvm] Parse maven coordinates using regular expression

### DIFF
--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -203,6 +203,9 @@ class ArtifactRequirement:
         )
 
     def to_coord_str(self, versioned: bool = True) -> str:
+        # NB: Coursier does not support the entire coordinate syntax as an input (and will report a
+        # "Malformed dependency" if either the classifier or packaging are specified). We don't strip
+        # those here, since the error from Coursier is helpful enough.
         without_url = self.coordinate.to_coord_str(versioned)
         url_suffix = ""
         if self.url:

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -137,7 +137,8 @@ class Coordinate:
         ${organisation}:${artifact}[:${packaging}[:${classifier}]]:${version}
         """
 
-        if parts := Coordinate.REGEX.match(s):
+        parts = Coordinate.REGEX.match(s)
+        if parts is not None:
             packaging_part = parts.group(4)
             return cls(
                 group=parts.group(1),

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -494,18 +494,16 @@ async def coursier_resolve_lockfile(
         )
     )
 
-    # NB: Parsing of the resolve JSON applies the workaround for
-    #   https://github.com/coursier/coursier/issues/2315: see `Coordinate.from_coord_str`.
     first_pass_lockfile = CoursierResolvedLockfile(
         entries=tuple(
             CoursierLockfileEntry(
-                coord=Coordinate.from_coord_str(dep["coord"], with_2315_workaround=True),
+                coord=Coordinate.from_coord_str(dep["coord"]),
                 direct_dependencies=Coordinates(
-                    Coordinate.from_coord_str(dd, with_2315_workaround=True)
+                    Coordinate.from_coord_str(dd)
                     for dd in dep["directDependencies"]
                 ),
                 dependencies=Coordinates(
-                    Coordinate.from_coord_str(d, with_2315_workaround=True)
+                    Coordinate.from_coord_str(d)
                     for d in dep["dependencies"]
                 ),
                 file_name=file_name,
@@ -633,10 +631,7 @@ async def coursier_fetch_one_coord(
         )
 
     dep = report_deps[0]
-
-    # NB: Parsing of the resolve JSON applies the workaround for
-    #   https://github.com/coursier/coursier/issues/2315: see `Coordinate.from_coord_str`.
-    resolved_coord = Coordinate.from_coord_str(dep["coord"], with_2315_workaround=True)
+    resolved_coord = Coordinate.from_coord_str(dep["coord"])
     if resolved_coord != request.coord:
         raise CoursierError(
             f'Coursier resolved coord "{resolved_coord.to_coord_str()}" does not match requested coord "{request.coord.to_coord_str()}".'

--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -251,16 +251,13 @@ def test_resolve_with_packaging(rule_runner: RuleRunner) -> None:
 @maybe_skip_jdk_test
 def test_resolve_with_classifier(rule_runner: RuleRunner) -> None:
     coordinate = Coordinate(
-        group="org.apache.kafka",
-        artifact="kafka-clients",
-        version="2.8.1",
-        classifier="test"
+        group="org.apache.kafka", artifact="kafka-clients", version="2.8.1", classifier="test"
     )
     resolved_lockfile = rule_runner.request(
         CoursierResolvedLockfile,
-        ArtifactRequirements.from_coordinates[coordinate],
+        ArtifactRequirements.from_coordinates([coordinate]),
     )
-    
+
     (head_entry,) = resolved_lockfile.entries
     assert head_entry.coord == Coordinate(
         group="org.apache.kafka",
@@ -268,11 +265,12 @@ def test_resolve_with_classifier(rule_runner: RuleRunner) -> None:
         version="2.8.1",
         packaging="jar",
         classifier="test",
-        strict=True
+        strict=True,
     )
     assert head_entry.file_digest == FileDigest(
         "b774d65ba44f3866261b3f4f217e19261451838067166cfb949a4122f5b01a90", 3684301
     )
+
 
 @maybe_skip_jdk_test
 def test_resolve_with_broken_url(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -249,6 +249,32 @@ def test_resolve_with_packaging(rule_runner: RuleRunner) -> None:
 
 
 @maybe_skip_jdk_test
+def test_resolve_with_classifier(rule_runner: RuleRunner) -> None:
+    coordinate = Coordinate(
+        group="org.apache.kafka",
+        artifact="kafka-clients",
+        version="2.8.1",
+        classifier="test"
+    )
+    resolved_lockfile = rule_runner.request(
+        CoursierResolvedLockfile,
+        ArtifactRequirements.from_coordinates[coordinate],
+    )
+    
+    (head_entry,) = resolved_lockfile.entries
+    assert head_entry.coord == Coordinate(
+        group="org.apache.kafka",
+        artifact="kafka-clients",
+        version="2.8.1",
+        packaging="jar",
+        classifier="test",
+        strict=True
+    )
+    assert head_entry.file_digest == FileDigest(
+        "b774d65ba44f3866261b3f4f217e19261451838067166cfb949a4122f5b01a90", 3684301
+    )
+
+@maybe_skip_jdk_test
 def test_resolve_with_broken_url(rule_runner: RuleRunner) -> None:
 
     coordinate = ArtifactRequirement(

--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -250,25 +250,23 @@ def test_resolve_with_packaging(rule_runner: RuleRunner) -> None:
 
 @maybe_skip_jdk_test
 def test_resolve_with_classifier(rule_runner: RuleRunner) -> None:
-    coordinate = Coordinate(
-        group="org.apache.kafka", artifact="kafka-clients", version="2.8.1", classifier="test"
-    )
+    # Has as a transitive dependency an artifact with both a `classifier` and `packaging`.
+    coordinate = Coordinate(group="org.apache.avro", artifact="avro-tools", version="1.11.0")
     resolved_lockfile = rule_runner.request(
         CoursierResolvedLockfile,
-        ArtifactRequirements.from_coordinates([coordinate]),
+        [ArtifactRequirements.from_coordinates([coordinate])],
     )
 
-    (head_entry,) = resolved_lockfile.entries
-    assert head_entry.coord == Coordinate(
-        group="org.apache.kafka",
-        artifact="kafka-clients",
-        version="2.8.1",
-        packaging="jar",
-        classifier="test",
-        strict=True,
-    )
-    assert head_entry.file_digest == FileDigest(
-        "b774d65ba44f3866261b3f4f217e19261451838067166cfb949a4122f5b01a90", 3684301
+    assert (
+        Coordinate(
+            group="org.apache.avro",
+            artifact="trevni-avro",
+            version="1.11.0",
+            packaging="jar",
+            classifier="tests",
+            strict=True,
+        )
+        in [e.coord for e in resolved_lockfile.entries]
     )
 
 

--- a/src/python/pants/jvm/resolve/coursier_fetch_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_test.py
@@ -116,9 +116,7 @@ def test_no_matching_for_leaf(rule_runner: RuleRunner) -> None:
 @pytest.mark.parametrize(
     "coord_str,expected",
     (
-        *(
-            ("group:artifact:version", Coordinate("group", "artifact", "version"))
-        ),
+        *(("group:artifact:version", Coordinate("group", "artifact", "version"))),
         (
             "group:artifact:packaging:version",
             Coordinate("group", "artifact", "version", "packaging"),
@@ -130,6 +128,4 @@ def test_no_matching_for_leaf(rule_runner: RuleRunner) -> None:
     ),
 )
 def test_from_coord_str(coord_str: str, expected: Coordinate) -> None:
-    assert (
-        Coordinate.from_coord_str(coord_str) == expected
-    )
+    assert Coordinate.from_coord_str(coord_str) == expected

--- a/src/python/pants/jvm/resolve/coursier_fetch_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_test.py
@@ -114,25 +114,22 @@ def test_no_matching_for_leaf(rule_runner: RuleRunner) -> None:
 
 
 @pytest.mark.parametrize(
-    "coord_str,with_2315_workaround,expected",
+    "coord_str,expected",
     (
         *(
-            ("group:artifact:version", b, Coordinate("group", "artifact", "version"))
-            for b in [True, False]
+            ("group:artifact:version", Coordinate("group", "artifact", "version"))
         ),
         (
             "group:artifact:packaging:version",
-            True,
             Coordinate("group", "artifact", "version", "packaging"),
         ),
         (
-            "group:artifact:version:packaging",
-            False,
-            Coordinate("group", "artifact", "version", "packaging"),
+            "group:artifact:packaging:classifier:version",
+            Coordinate("group", "artifact", "version", "packaging", "classifier"),
         ),
     ),
 )
-def test_from_coord_str(coord_str: str, with_2315_workaround: bool, expected: Coordinate) -> None:
+def test_from_coord_str(coord_str: str, expected: Coordinate) -> None:
     assert (
-        Coordinate.from_coord_str(coord_str, with_2315_workaround=with_2315_workaround) == expected
+        Coordinate.from_coord_str(coord_str) == expected
     )

--- a/src/python/pants/jvm/resolve/coursier_fetch_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_test.py
@@ -116,7 +116,7 @@ def test_no_matching_for_leaf(rule_runner: RuleRunner) -> None:
 @pytest.mark.parametrize(
     "coord_str,expected",
     (
-        *(("group:artifact:version", Coordinate("group", "artifact", "version"))),
+        ("group:artifact:version", Coordinate("group", "artifact", "version")),
         (
             "group:artifact:packaging:version",
             Coordinate("group", "artifact", "version", "packaging"),


### PR DESCRIPTION
This goes on top of #13996 removing the workaround on the maven coordinates after finding out that coursier's behaviour (reported at coursier/coursier#2315) is the correct one. While I haven't found any _spec_ of that, this is what I gather from [this Maven document](https://maven.apache.org/plugins/maven-assembly-plugin/examples/single/including-and-excluding-artifacts.html) and from inspecting other implementations.

This PR parses the Maven coordinates using a regular expression that is able to extract the packaging and classifier in case they are present. This should make it compatible with artifacts that only display three of the elements and with the ones that even include the classifier in it.