### PR TITLE
[jvm] Parse maven coordinates using regular expression (#14010)

### DIFF
--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -249,6 +249,28 @@ def test_resolve_with_packaging(rule_runner: RuleRunner) -> None:
 
 
 @maybe_skip_jdk_test
+def test_resolve_with_classifier(rule_runner: RuleRunner) -> None:
+    # Has as a transitive dependency an artifact with both a `classifier` and `packaging`.
+    coordinate = Coordinate(group="org.apache.avro", artifact="avro-tools", version="1.11.0")
+    resolved_lockfile = rule_runner.request(
+        CoursierResolvedLockfile,
+        [ArtifactRequirements.from_coordinates([coordinate])],
+    )
+
+    assert (
+        Coordinate(
+            group="org.apache.avro",
+            artifact="trevni-avro",
+            version="1.11.0",
+            packaging="jar",
+            classifier="tests",
+            strict=True,
+        )
+        in [e.coord for e in resolved_lockfile.entries]
+    )
+
+
+@maybe_skip_jdk_test
 def test_resolve_with_broken_url(rule_runner: RuleRunner) -> None:
 
     coordinate = ArtifactRequirement(

--- a/src/python/pants/jvm/resolve/coursier_fetch_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_test.py
@@ -114,25 +114,18 @@ def test_no_matching_for_leaf(rule_runner: RuleRunner) -> None:
 
 
 @pytest.mark.parametrize(
-    "coord_str,with_2315_workaround,expected",
+    "coord_str,expected",
     (
-        *(
-            ("group:artifact:version", b, Coordinate("group", "artifact", "version"))
-            for b in [True, False]
-        ),
+        ("group:artifact:version", Coordinate("group", "artifact", "version")),
         (
             "group:artifact:packaging:version",
-            True,
             Coordinate("group", "artifact", "version", "packaging"),
         ),
         (
-            "group:artifact:version:packaging",
-            False,
-            Coordinate("group", "artifact", "version", "packaging"),
+            "group:artifact:packaging:classifier:version",
+            Coordinate("group", "artifact", "version", "packaging", "classifier"),
         ),
     ),
 )
-def test_from_coord_str(coord_str: str, with_2315_workaround: bool, expected: Coordinate) -> None:
-    assert (
-        Coordinate.from_coord_str(coord_str, with_2315_workaround=with_2315_workaround) == expected
-    )
+def test_from_coord_str(coord_str: str, expected: Coordinate) -> None:
+    assert Coordinate.from_coord_str(coord_str) == expected


### PR DESCRIPTION
This goes on top of #13996 removing the workaround on the maven coordinates after finding out that coursier's behaviour (reported at coursier/coursier#2315) is the correct one. While I haven't found any _spec_ of that, this is what I gather from [this Maven document](https://maven.apache.org/plugins/maven-assembly-plugin/examples/single/including-and-excluding-artifacts.html) and from inspecting other implementations.

This PR parses the Maven coordinates using a regular expression that is able to extract the packaging and classifier in case they are present. This should make it compatible with artifacts that only display three of the elements and with the ones that even include the classifier in it.

[ci skip-rust]
[ci skip-build-wheels]