### PR TITLE
[internal] Simplify Python dependency inference handling of type stubs

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -3,11 +3,12 @@
 
 from __future__ import annotations
 
+import enum
 import logging
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import DefaultDict
+from typing import DefaultDict, Tuple
 
 from packaging.utils import canonicalize_name as canonicalize_project_name
 
@@ -28,9 +29,19 @@ from pants.engine.target import AllTargets, Target
 from pants.engine.unions import UnionMembership, UnionRule, union
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
-from pants.util.ordered_set import FrozenOrderedSet
 
 logger = logging.getLogger(__name__)
+
+
+class ModuleProviderType(enum.Enum):
+    TYPE_STUB = enum.auto()
+    IMPL = enum.auto()
+
+
+@dataclass(frozen=True, order=True)
+class ModuleProvider:
+    addr: Address
+    typ: ModuleProviderType
 
 
 @dataclass(frozen=True)
@@ -40,7 +51,7 @@ class PythonModule:
     @classmethod
     def create_from_stripped_path(cls, path: PurePath) -> PythonModule:
         module_name_with_slashes = (
-            path.parent if path.name == "__init__.py" else path.with_suffix("")
+            path.parent if path.name in ("__init__.py", "__init__.pyi") else path.with_suffix("")
         )
         return cls(module_name_with_slashes.as_posix().replace("/", "."))
 
@@ -68,20 +79,9 @@ def find_all_python_projects(all_targets: AllTargets) -> AllPythonTargets:
 # -----------------------------------------------------------------------------------------------
 
 
-@dataclass(frozen=True)
-class FirstPartyPythonMappingImpl:
+class FirstPartyPythonMappingImpl(FrozenDict[str, Tuple[ModuleProvider, ...]]):
     """A mapping of module names to owning addresses that a specific implementation adds for Python
-    import dependency inference.
-
-    For almost every implementation, there should only be one address per module to avoid ambiguity.
-    However, the built-in implementation allows for 2 addresses when `.pyi` type stubs are used.
-
-    All ambiguous modules must be added to `ambiguous_modules` and not be included in `mapping`.
-    """
-
-    mapping: FrozenDict[str, tuple[Address, ...]]
-    ambiguous_modules: FrozenDict[str, tuple[Address, ...]]
-    modules_with_type_stub: FrozenOrderedSet[str] = FrozenOrderedSet()
+    import dependency inference."""
 
 
 @union
@@ -91,33 +91,20 @@ class FirstPartyPythonMappingImplMarker:
 
     All implementations will be merged together. Any modules that show up in multiple
     implementations will be marked ambiguous.
-
-    The addresses should all be file addresses, rather than BUILD addresses.
     """
 
 
-@dataclass(frozen=True)
-class FirstPartyPythonModuleMapping:
+class FirstPartyPythonModuleMapping(FrozenDict[str, Tuple[ModuleProvider, ...]]):
     """A merged mapping of module names to owning addresses.
 
     This mapping may have been constructed from multiple distinct implementations, e.g.
     implementations for each codegen backends.
     """
 
-    mapping: FrozenDict[str, tuple[Address, ...]]
-    ambiguous_modules: FrozenDict[str, tuple[Address, ...]]
-    modules_with_type_stub: FrozenOrderedSet[str] = FrozenOrderedSet()
-
-    def addresses_for_module(self, module: str) -> tuple[tuple[Address, ...], tuple[Address, ...]]:
-        """Return all unambiguous and ambiguous addresses.
-
-        The unambiguous addresses should be 0-2, but not more. We only expect 2 if there is both an
-        implementation (.py) and type stub (.pyi) with the same module name.
-        """
-        unambiguous = self.mapping.get(module, ())
-        ambiguous = self.ambiguous_modules.get(module, ())
-        if unambiguous or ambiguous:
-            return unambiguous, ambiguous
+    def providers_for_module(self, module: str) -> tuple[ModuleProvider, ...]:
+        result = self.get(module, ())
+        if result:
+            return result
 
         # If the module is not found, try the parent, if any. This is to accommodate `from`
         # imports, where we don't care about the specific symbol, but only the module. For example,
@@ -127,21 +114,9 @@ class FirstPartyPythonModuleMapping:
         # be resolved. This contrasts with the third-party module mapping, which will try every
         # ancestor.
         if "." not in module:
-            return (), ()
+            return ()
         parent_module = module.rsplit(".", maxsplit=1)[0]
-        unambiguous = self.mapping.get(parent_module, ())
-        ambiguous = self.ambiguous_modules.get(parent_module, ())
-        return unambiguous, ambiguous
-
-    def has_type_stub(self, module: str) -> bool:
-        if module in self.modules_with_type_stub:
-            return True
-
-        # Also check for the parent module if relevant. See self.addresses_for_module.
-        if "." not in module:
-            return False
-        parent_module = module.rsplit(".", maxsplit=1)[0]
-        return parent_module in self.modules_with_type_stub
+        return self.get(parent_module, ())
 
 
 @rule(level=LogLevel.DEBUG)
@@ -156,42 +131,12 @@ async def merge_first_party_module_mappings(
         )
         for marker_cls in union_membership.get(FirstPartyPythonMappingImplMarker)
     )
-
-    # First, record all known ambiguous modules.
-    modules_with_multiple_implementations: DefaultDict[str, set[Address]] = defaultdict(set)
+    modules_to_providers: DefaultDict[str, list[ModuleProvider]] = defaultdict(list)
     for mapping_impl in all_mappings:
-        for module, addresses in mapping_impl.ambiguous_modules.items():
-            modules_with_multiple_implementations[module].update(addresses)
-
-    # Then, merge the unambiguous modules within each MappingImpls while checking for ambiguity
-    # across the other implementations.
-    modules_to_addresses: dict[str, tuple[Address, ...]] = {}
-    modules_with_type_stub: set[str] = set()
-    for mapping_impl in all_mappings:
-        for module, addresses in mapping_impl.mapping.items():
-            if module in modules_with_multiple_implementations:
-                modules_with_multiple_implementations[module].update(addresses)
-            elif module in modules_to_addresses:
-                modules_with_multiple_implementations[module].update(
-                    {*modules_to_addresses[module], *addresses}
-                )
-            else:
-                modules_to_addresses[module] = addresses
-                if module in mapping_impl.modules_with_type_stub:
-                    modules_with_type_stub.add(module)
-
-    # Finally, remove any newly ambiguous modules from the previous step.
-    for module in modules_with_multiple_implementations:
-        if module in modules_to_addresses:
-            modules_to_addresses.pop(module)
-            modules_with_type_stub.discard(module)
-
+        for module, providers in mapping_impl.items():
+            modules_to_providers[module].extend(providers)
     return FirstPartyPythonModuleMapping(
-        mapping=FrozenDict(sorted(modules_to_addresses.items())),
-        ambiguous_modules=FrozenDict(
-            (k, tuple(sorted(v))) for k, v in sorted(modules_with_multiple_implementations.items())
-        ),
-        modules_with_type_stub=FrozenOrderedSet(modules_with_type_stub),
+        (k, tuple(sorted(v))) for k, v in sorted(modules_to_providers.items())
     )
 
 
@@ -210,46 +155,17 @@ async def map_first_party_python_targets_to_modules(
         for tgt in all_python_targets.first_party
     )
 
-    modules_to_addresses: DefaultDict[str, list[Address]] = defaultdict(list)
-    modules_with_type_stub: set[str] = set()
-    modules_with_multiple_implementations: DefaultDict[str, set[Address]] = defaultdict(set)
+    modules_to_providers: DefaultDict[str, list[ModuleProvider]] = defaultdict(list)
     for tgt, stripped_file in zip(all_python_targets.first_party, stripped_file_per_target):
         stripped_f = PurePath(stripped_file.value)
-        is_type_stub = stripped_f.suffix == ".pyi"
-
-        module = PythonModule.create_from_stripped_path(stripped_f).module
-        if module not in modules_to_addresses:
-            modules_to_addresses[module].append(tgt.address)
-            if is_type_stub:
-                modules_with_type_stub.add(module)
-            continue
-
-        # Else, possible ambiguity. Check if one of the targets is an implementation
-        # (.py file) and the other is a type stub (.pyi file), which we allow. Otherwise, it's
-        # ambiguous.
-        prior_is_type_stub = (
-            len(modules_to_addresses[module]) == 1 and module in modules_with_type_stub
+        provider_type = (
+            ModuleProviderType.TYPE_STUB if stripped_f.suffix == ".pyi" else ModuleProviderType.IMPL
         )
-        if is_type_stub ^ prior_is_type_stub:
-            modules_to_addresses[module].append(tgt.address)
-            if is_type_stub:
-                modules_with_type_stub.add(module)
-        else:
-            modules_with_multiple_implementations[module].update(
-                {*modules_to_addresses[module], tgt.address}
-            )
-
-    # Remove modules with ambiguous owners.
-    for module in modules_with_multiple_implementations:
-        modules_to_addresses.pop(module)
-        modules_with_type_stub.discard(module)
+        module = PythonModule.create_from_stripped_path(stripped_f).module
+        modules_to_providers[module].append(ModuleProvider(tgt.address, provider_type))
 
     return FirstPartyPythonMappingImpl(
-        mapping=FrozenDict((k, tuple(sorted(v))) for k, v in sorted(modules_to_addresses.items())),
-        ambiguous_modules=FrozenDict(
-            (k, tuple(sorted(v))) for k, v in sorted(modules_with_multiple_implementations.items())
-        ),
-        modules_with_type_stub=FrozenOrderedSet(modules_with_type_stub),
+        (k, tuple(sorted(v))) for k, v in sorted(modules_to_providers.items())
     )
 
 
@@ -258,67 +174,41 @@ async def map_first_party_python_targets_to_modules(
 # -----------------------------------------------------------------------------------------------
 
 
-@dataclass(frozen=True)
-class ThirdPartyPythonModuleMapping:
-    mapping: FrozenDict[str, tuple[Address, ...]]
-    ambiguous_modules: FrozenDict[str, tuple[Address, ...]]
-
-    def addresses_for_module(self, module: str) -> tuple[tuple[Address, ...], tuple[Address, ...]]:
-        """Return all unambiguous and ambiguous addresses.
-
-        The unambiguous addresses should be 0-2, but not more. We only expect 2 if there is both an
-        implementation and type stub with the same module name.
-        """
-        unambiguous = self.mapping.get(module, ())
-        ambiguous = self.ambiguous_modules.get(module, ())
-        if unambiguous or ambiguous:
-            return unambiguous, ambiguous
+class ThirdPartyPythonModuleMapping(FrozenDict[str, Tuple[ModuleProvider, ...]]):
+    def providers_for_module(self, module: str) -> tuple[ModuleProvider, ...]:
+        result = self.get(module, ())
+        if result:
+            return result
 
         # If the module is not found, recursively try the ancestor modules, if any. For example,
         # pants.task.task.Task -> pants.task.task -> pants.task -> pants
         if "." not in module:
-            return (), ()
+            return ()
         parent_module = module.rsplit(".", maxsplit=1)[0]
-        return self.addresses_for_module(parent_module)
+        return self.providers_for_module(parent_module)
 
 
 @rule(desc="Creating map of third party targets to Python modules", level=LogLevel.DEBUG)
 async def map_third_party_modules_to_addresses(
     all_python_tgts: AllPythonTargets,
 ) -> ThirdPartyPythonModuleMapping:
-    modules_to_addresses: dict[str, Address] = {}
-    modules_to_stub_addresses: dict[str, Address] = {}
-    modules_with_multiple_owners: DefaultDict[str, set[Address]] = defaultdict(set)
-
-    def add_modules(modules: tuple[str, ...], address: Address) -> None:
-        for module in modules:
-            if module in modules_with_multiple_owners:
-                modules_with_multiple_owners[module].add(address)
-            elif module in modules_to_addresses:
-                modules_with_multiple_owners[module].update({modules_to_addresses[module], address})
-            else:
-                modules_to_addresses[module] = address
-
-    def add_stub_modules(modules: tuple[str, ...], address: Address) -> None:
-        for module in modules:
-            if module in modules_with_multiple_owners:
-                modules_with_multiple_owners[module].add(address)
-            elif module in modules_to_stub_addresses:
-                modules_with_multiple_owners[module].update(
-                    {modules_to_stub_addresses[module], address}
-                )
-            else:
-                modules_to_stub_addresses[module] = address
+    modules_to_providers: DefaultDict[str, list[ModuleProvider]] = defaultdict(list)
 
     for tgt in all_python_tgts.third_party:
         explicit_modules = tgt.get(PythonRequirementModulesField).value
         if explicit_modules:
-            add_modules(explicit_modules, tgt.address)
+            for module in explicit_modules:
+                modules_to_providers[module].append(
+                    ModuleProvider(tgt.address, ModuleProviderType.IMPL)
+                )
             continue
 
         explicit_stub_modules = tgt.get(PythonRequirementTypeStubModulesField).value
         if explicit_stub_modules:
-            add_stub_modules(explicit_stub_modules, tgt.address)
+            for module in explicit_stub_modules:
+                modules_to_providers[module].append(
+                    ModuleProvider(tgt.address, ModuleProviderType.TYPE_STUB)
+                )
             continue
 
         # Else, fall back to defaults.
@@ -341,28 +231,18 @@ async def map_third_party_modules_to_addresses(
                     stub_modules = (
                         fallback_value[6:] if starts_with_prefix else fallback_value[:-6],
                     )
-                add_stub_modules(stub_modules, tgt.address)
+                for module in stub_modules:
+                    modules_to_providers[module].append(
+                        ModuleProvider(tgt.address, ModuleProviderType.TYPE_STUB)
+                    )
             else:
-                add_modules(DEFAULT_MODULE_MAPPING.get(proj_name, (fallback_value,)), tgt.address)
-
-    # Remove modules with ambiguous owners.
-    for module in modules_with_multiple_owners:
-        if module in modules_to_addresses:
-            modules_to_addresses.pop(module)
-        if module in modules_to_stub_addresses:
-            modules_to_stub_addresses.pop(module)
-
-    merged_mapping: DefaultDict[str, list[Address]] = defaultdict(list)
-    for k, v in modules_to_addresses.items():
-        merged_mapping[k].append(v)
-    for k, v in modules_to_stub_addresses.items():
-        merged_mapping[k].append(v)
+                for module in DEFAULT_MODULE_MAPPING.get(proj_name, (fallback_value,)):
+                    modules_to_providers[module].append(
+                        ModuleProvider(tgt.address, ModuleProviderType.IMPL)
+                    )
 
     return ThirdPartyPythonModuleMapping(
-        mapping=FrozenDict((k, tuple(sorted(v))) for k, v in sorted(merged_mapping.items())),
-        ambiguous_modules=FrozenDict(
-            (k, tuple(sorted(v))) for k, v in sorted(modules_with_multiple_owners.items())
-        ),
+        (k, tuple(sorted(v))) for k, v in sorted(modules_to_providers.items())
     )
 
 
@@ -397,48 +277,24 @@ async def map_module_to_address(
     first_party_mapping: FirstPartyPythonModuleMapping,
     third_party_mapping: ThirdPartyPythonModuleMapping,
 ) -> PythonModuleOwners:
-    third_party_addresses, third_party_ambiguous = third_party_mapping.addresses_for_module(
-        module.module
-    )
-    first_party_addresses, first_party_ambiguous = first_party_mapping.addresses_for_module(
-        module.module
-    )
+    providers = [
+        *third_party_mapping.providers_for_module(module.module),
+        *first_party_mapping.providers_for_module(module.module),
+    ]
+    addresses = tuple(provider.addr for provider in providers)
 
-    # First, check if there was any ambiguity within the first-party or third-party mappings. Note
-    # that even if there's ambiguity purely within either third-party or first-party, all targets
-    # with that module become ambiguous.
-    if third_party_ambiguous or first_party_ambiguous:
-        ambiguous = {
-            *first_party_ambiguous,
-            *first_party_addresses,
-            *third_party_ambiguous,
-            *third_party_addresses,
-        }
-        return PythonModuleOwners((), ambiguous=tuple(sorted(ambiguous)))
+    # There's no ambiguity if there are only 0-1 providers.
+    if len(providers) < 2:
+        return PythonModuleOwners(addresses)
 
-    # It's possible for a user to write type stubs (`.pyi` files) for their third-party
-    # dependencies. We check if that happened, but we're strict in validating that there is only a
-    # single third party address and a single first-party address referring to a `.pyi` file;
-    # otherwise, we have ambiguous implementations.
-    if third_party_addresses and not first_party_addresses:
-        return PythonModuleOwners(third_party_addresses)
-    if (
-        len(third_party_addresses) == 1
-        and len(first_party_addresses) == 1
-        and first_party_mapping.has_type_stub(module.module)
+    # Else, it's ambiguous unless there are exactly two providers and one is a type stub and the
+    # other an implementation.
+    if len(providers) == 2 and (providers[0].typ == ModuleProviderType.TYPE_STUB) ^ (
+        providers[1].typ == ModuleProviderType.TYPE_STUB
     ):
-        return PythonModuleOwners((*third_party_addresses, *first_party_addresses))
-    # Else, we have ambiguity between the third-party and first-party addresses.
-    if third_party_addresses and first_party_addresses:
-        return PythonModuleOwners(
-            (), ambiguous=tuple(sorted((*third_party_addresses, *first_party_addresses)))
-        )
+        return PythonModuleOwners(addresses)
 
-    # We're done with looking at third-party addresses, and now solely look at first-party, which
-    # was already validated for ambiguity.
-    if first_party_addresses:
-        return PythonModuleOwners(first_party_addresses)
-    return PythonModuleOwners(())
+    return PythonModuleOwners((), ambiguous=addresses)
 
 
 def rules():


### PR DESCRIPTION
Our Python dependency inference code is tricky because we allow you to have one type stub and implementation, whereas that would normally result in ambiguity.

The original implementation was much more complex than necessary because it had each specific module mapping handle ambiguity, e.g. the first-party vs third-party module mappings. Now, we simply have each mapping record _all_ owners and whether each owner is a type stub vs. implementation. Then, our final `ModuleOwners` rule can easily determine ambiguity.

[ci skip-rust]
[ci skip-build-wheels]