### PR TITLE
Upgrade packaging, types-setuptools

### DIFF
--- a/3rdparty/python/lockfiles/user_reqs.txt
+++ b/3rdparty/python/lockfiles/user_reqs.txt
@@ -16,7 +16,7 @@
 #     "freezegun==1.1.0",
 #     "humbug==0.2.7",
 #     "ijson==3.1.4",
-#     "packaging==21.0",
+#     "packaging==21.3",
 #     "pex==2.1.61",
 #     "psutil==5.8.0",
 #     "pytest<6.3,>=6.2.4",
@@ -27,7 +27,7 @@
 #     "types-PyYAML==5.4.3",
 #     "types-freezegun==0.1.4",
 #     "types-requests==2.25.0",
-#     "types-setuptools==57.0.0",
+#     "types-setuptools==57.4.5",
 #     "types-toml==0.1.3",
 #     "typing-extensions==3.10.0.2"
 #   ]
@@ -40,9 +40,9 @@ ansicolors==1.1.8 \
 atomicwrites==1.4.0; python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.4.0" \
     --hash=sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197 \
     --hash=sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a
-attrs==21.2.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6" \
-    --hash=sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1 \
-    --hash=sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb
+attrs==21.3.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6" \
+    --hash=sha256:8f7335278dedd26b58c38e006338242cc0977f06d51579b2b8b87b9b33bff66c \
+    --hash=sha256:50f3c9b216dc9021042f71b392859a773b904ce1a029077f58f6598272432045
 certifi==2021.10.8; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" \
     --hash=sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569 \
     --hash=sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872
@@ -135,9 +135,9 @@ importlib-metadata==4.10.0; python_version < "3.8" and python_version >= "3.7" \
 iniconfig==1.1.1; python_version >= "3.6" \
     --hash=sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3 \
     --hash=sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32
-packaging==21.0; python_version >= "3.6" \
-    --hash=sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14 \
-    --hash=sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7
+packaging==21.3; python_version >= "3.6" \
+    --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522 \
+    --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb
 pex==2.1.61; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0" and python_version < "3.11") \
     --hash=sha256:c09fda0f0477f3894f7a7a464b7e4c03d44734de46caddd25291565eed32a882 \
     --hash=sha256:6b00014cc74cc39fda191d8e07006bc423f8165cf04e42cdb02431593f33ff02
@@ -262,9 +262,9 @@ types-pyyaml==5.4.3 \
 types-requests==2.25.0 \
     --hash=sha256:ee0d0c507210141b7d5b8639cc43eaa726084178775db2a5fb06fbf85c185808 \
     --hash=sha256:fa5c1e5e832ff6193507d8da7e1159281383908ee193a2f4b37bc08140b51844
-types-setuptools==57.0.0 \
-    --hash=sha256:b3ada82b21dcb8e0cafd7658d8a16018a000e55bdb7f6f3cec033223360563ce \
-    --hash=sha256:71ed0f4c71d8fb5f3026a90ae82d163c13749b110e157d82126725ac8f714360
+types-setuptools==57.4.5 \
+    --hash=sha256:a4600efdca68a33204ad9c083fd9966d63aee61a7d007e912b6afc6ff57d6e02 \
+    --hash=sha256:920a7c1ee120025e939a1707f8fd09a1266edbf7848eae7b8de7c5909a824cc8
 types-toml==0.1.3 \
     --hash=sha256:33ebe67bebaec55a123ecbaa2bd98fe588335d8d8dda2c7ac53502ef5a81a79a \
     --hash=sha256:d4add39a90993173d49ff0b069edd122c66ad4cf5c01082b590e380ca670ee1a

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -13,7 +13,7 @@ freezegun==1.1.0
 humbug==0.2.7
 
 ijson==3.1.4
-packaging==21.0
+packaging==21.3
 pex==2.1.61
 psutil==5.8.0
 pytest>=6.2.4,<6.3  # This should be kept in sync with `pytest.py`.
@@ -25,6 +25,6 @@ toml==0.10.2
 types-freezegun==0.1.4
 types-PyYAML==5.4.3
 types-requests==2.25.0
-types-setuptools==57.0.0
+types-setuptools==57.4.5
 types-toml==0.1.3
 typing-extensions==3.10.0.2

--- a/testprojects/src/python/native/setup.py
+++ b/testprojects/src/python/native/setup.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from colors import red
-from setuptools import Extension, setup  # type: ignore[import]
+from setuptools import Extension, setup
 
 native_impl = Extension("native.impl", sources=["impl.c"])
 


### PR DESCRIPTION
packaging [changes](https://github.com/pypa/packaging/blob/main/CHANGELOG.rst#213---2021-11-17):
21.3 - 2021-11-17
~~~~~~~~~~~~~~~~~

* Add a ``pp3-none-any`` tag (:issue:`311`)
* Replace the blank pyparsing 3 exclusion with a 3.0.5 exclusion (:issue:`481`, :issue:`486`)
* Fix a spelling mistake (:issue:`479`)

21.2 - 2021-10-29
~~~~~~~~~~~~~~~~~

* Update documentation entry for 21.1.

21.1 - 2021-10-29
~~~~~~~~~~~~~~~~~

* Update pin to pyparsing to exclude 3.0.0.

