### PR TITLE
Add `cache` field to `docker_image` target.

### DIFF
--- a/src/python/pants/backend/docker/subsystems/docker_options.py
+++ b/src/python/pants/backend/docker/subsystems/docker_options.py
@@ -141,6 +141,28 @@ class DockerOptions(Subsystem):
             ),
         )
 
+        register(
+            "--build-cache-images",
+            type=bool,
+            default=False,
+            help=(
+                "Build new cache images for `docker_image` targets with `cache=True` or "
+                '`cache="<tag>"`.\n\n'
+                "See the documentation for the `cache` field of the `docker_image` target for "
+                "more information."
+            ),
+        )
+
+        register(
+            "--push-cache-images",
+            type=bool,
+            default=False,
+            help=(
+                "Automatically push cache images after building them.\n\n"
+                "This uses `docker buildx build` which requires that BuildKit is enabled."
+            ),
+        )
+
     @property
     def build_args(self) -> tuple[str, ...]:
         return tuple(sorted(set(self.options.build_args)))
@@ -164,3 +186,11 @@ class DockerOptions(Subsystem):
     @memoized_method
     def registries(self) -> DockerRegistries:
         return DockerRegistries.from_dict(self.options.registries)
+
+    @property
+    def build_cache_images(self) -> bool:
+        return cast(bool, self.options.build_cache_images)
+
+    @property
+    def push_cache_images(self) -> bool:
+        return cast(bool, self.options.push_cache_images)

--- a/src/python/pants/backend/docker/util_rules/docker_binary.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary.py
@@ -37,7 +37,9 @@ class DockerBinary(BinaryPath):
         env: Mapping[str, str] | None = None,
         extra_args: tuple[str, ...] = (),
     ) -> Process:
-        args = [self.path, "build", *extra_args]
+        # If the first extra arg is "build", we use `docker buildx build ...`
+        subcommand = "buildx" if "build" in extra_args[:1] else "build"
+        args = [self.path, subcommand, *extra_args]
 
         for tag in tags:
             args.extend(["--tag", tag])


### PR DESCRIPTION
This feature leverages the `docker build --cache-from` option to support fetching previously built layers from another image .

Useful to speed up building images with time expensive layers that rarely change. (N.b. these layers must come before the layers that change frequently, as the first layer with a cache miss, invalidates all the following layers.)

Usage:
```python
# BUILD
docker_image(
  ...,
  cache=True
)
```

And then to refresh the cache version of your images:
```sh
$ ./pants package --docker-build-cache-images ::
```

And optionally, push those cache images too:
```sh
$ ./pants package --docker-build-cache-images --docker-push-cache-images ::
```

To make them reusable across multiple nodes.

By default, the image is tagged with `cache`, but you can override this with:
```python
# BUILD
docker_image(
  ...,
  cache="my-cache-tag"
)
```

Example output:
```sh
$ ./pants package --docker-registries='{"repo":{"address":"custom.registry", "default": True}}' --docker-push-cache-images --docker-build-cache-images testprojects/src/python/docker:test-example
12:04:52.13 [INFO] Completed: Building docker image custom.registry/test-example:cache
12:04:53.15 [INFO] Completed: Building docker image custom.registry/test-example:1.2.5
12:04:53.15 [INFO] Built docker image: custom.registry/test-example:1.2.5
```
