### PR TITLE
Fix file sources codegen for the Docker build context.

### DIFF
--- a/src/python/pants/backend/docker/util_rules/docker_build_context.py
+++ b/src/python/pants/backend/docker/util_rules/docker_build_context.py
@@ -56,7 +56,7 @@ class DockerBuildContextError(Exception):
 
 class DockerContextFilesAcceptableInputsField(ABC, SourcesField):
     """This is a meta field for the context files generator, to tell the codegen machinery what
-    source fields are good to use.
+    source fields are good to use as-is.
 
     Use `DockerContextFilesAcceptableInputsField.register(<SourceField>)` to register input fields
     that should be accepted.
@@ -66,7 +66,7 @@ class DockerContextFilesAcceptableInputsField(ABC, SourcesField):
     """
 
 
-DockerContextFilesAcceptableInputsField.register(FileSourceField)
+# These sources will be used to populate the build context as-is.
 DockerContextFilesAcceptableInputsField.register(ShellSourceField)
 
 
@@ -204,7 +204,10 @@ async def create_docker_build_context(
         SourceFiles,
         SourceFilesRequest(
             sources_fields=[tgt.get(SourcesField) for tgt in root_dependencies],
-            for_sources_types=(DockerContextFilesSourcesField,),
+            for_sources_types=(
+                DockerContextFilesSourcesField,
+                FileSourceField,
+            ),
             enable_codegen=True,
         ),
     )


### PR DESCRIPTION
The nifty construct with `DockerContextFilesAcceptableInputsField` side-stepped all source fields which could codegen to `FileSourceField`.. this fixes that.
