### PR TITLE
[internal] Add a dependabot config to help with keeping rust crates up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/src/rust"
+    open-pull-requests-limit: 3
+    rebase-strategy: auto
+    schedule:
+      interval: "weekly" 
+      day: "tuesday"
+      time: "9:00"
+      timezone: "US/Pacific"
+    reviewers:
+      - Eric-Arellano
+      - stuhood
+    labels:
+      - "rust"
+      - "dependencies"


### PR DESCRIPTION
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#labels