### PR TITLE
[internal] minor cleanups for apache thrift codegen

### DIFF
--- a/src/python/pants/backend/codegen/thrift/apache/python/rules.py
+++ b/src/python/pants/backend/codegen/thrift/apache/python/rules.py
@@ -47,7 +47,7 @@ async def generate_python_from_thrift(
         # Verify that the python source root specified by the target is in fact a source root.
         source_root_request = SourceRootRequest(PurePath(py_source_root))
     else:
-        # The target didn't specify a python source root, so use the protobuf_source's source root.
+        # The target didn't specify a python source root, so use the thrift_source's source root.
         source_root_request = SourceRootRequest.for_target(request.protocol_target)
 
     source_root = await Get(SourceRoot, SourceRootRequest, source_root_request)

--- a/src/python/pants/backend/codegen/thrift/apache/rules.py
+++ b/src/python/pants/backend/codegen/thrift/apache/rules.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
-from pants.backend.codegen.thrift.apache.subsystem import ApachehriftSubsystem
+from pants.backend.codegen.thrift.apache.subsystem import ApacheThriftSubsystem
 from pants.backend.codegen.thrift.target_types import ThriftSourceField
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.environment import Environment, EnvironmentRequest
@@ -48,7 +48,7 @@ class ApacheThriftSetup:
 
 
 @rule
-async def generate_thrift_sources(
+async def generate_apache_thrift_sources(
     request: GenerateThriftSourcesRequest,
     thrift: ApacheThriftSetup,
 ) -> GeneratedThriftSources:
@@ -123,7 +123,7 @@ async def generate_thrift_sources(
 
 
 @rule
-async def setup_thrift_tool(apache_thrift: ApachehriftSubsystem) -> ApacheThriftSetup:
+async def setup_thrift_tool(apache_thrift: ApacheThriftSubsystem) -> ApacheThriftSetup:
     env = await Get(Environment, EnvironmentRequest(["PATH"]))
     search_paths = apache_thrift.thrift_search_paths(env)
     all_thrift_binary_paths = await Get(

--- a/src/python/pants/backend/codegen/thrift/apache/subsystem.py
+++ b/src/python/pants/backend/codegen/thrift/apache/subsystem.py
@@ -10,7 +10,7 @@ from pants.option.subsystem import Subsystem
 from pants.util.ordered_set import OrderedSet
 
 
-class ApachehriftSubsystem(Subsystem):
+class ApacheThriftSubsystem(Subsystem):
     options_scope = "apache-thrift"
     help = "Apache Thrift IDL compiler (https://thrift.apache.org/)."
 
@@ -34,7 +34,7 @@ class ApachehriftSubsystem(Subsystem):
             type=str,
             default="0.15",
             help=(
-                "The Thrift version you are using, such as `0.15.0`.\n\n"
+                "The major/minor version of Apache Thrift that  you are using, such as `0.15`.\n\n"
                 "Pants will only use Thrift binaries from `--thrift-search-paths` that have the "
                 "expected version, and it will error if none are found.\n\n"
                 "Do not include the patch version."


### PR DESCRIPTION
- Fix typo in `ApacheThriftSubsystem` class name.
- Cleanup some help text and comments.