### PR TITLE
[internal] Python module mapping considers resolves

### DIFF
--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -24,7 +24,7 @@ from pants.backend.python.subsystems.repos import PythonRepos
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (
     EntryPoint,
-    PythonCompatibleResolvesField,
+    PythonRequirementCompatibleResolvesField,
     PythonRequirementsField,
     UnrecognizedResolveNamesError,
 )
@@ -273,10 +273,10 @@ async def setup_user_lockfile_requests(
 
     resolve_to_requirements_fields = defaultdict(set)
     for tgt in all_targets:
-        if not tgt.has_field(PythonCompatibleResolvesField):
+        if not tgt.has_field(PythonRequirementCompatibleResolvesField):
             continue
-        tgt[PythonCompatibleResolvesField].validate(python_setup)
-        for resolve in tgt[PythonCompatibleResolvesField].value_or_default(python_setup):
+        tgt[PythonRequirementCompatibleResolvesField].validate(python_setup)
+        for resolve in tgt[PythonRequirementCompatibleResolvesField].value_or_default(python_setup):
             resolve_to_requirements_fields[resolve].add(tgt[PythonRequirementsField])
 
     # TODO: Figure out how to determine which interpreter constraints to use for each resolve...

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -1022,7 +1022,7 @@ class PythonRequirementTarget(Target):
         PythonRequirementsField,
         PythonRequirementModulesField,
         PythonRequirementTypeStubModulesField,
-        PythonCompatibleResolvesField,
+        PythonRequirementCompatibleResolvesField,
     )
     help = (
         "A Python requirement installable by pip.\n\n"


### PR DESCRIPTION
Part of https://github.com/pantsbuild/pants/issues/13621.

For third-party dependencies, we now associate each `python_requirement` with the resolves it is compatible with, rather than having a single global "universe". Soon, first-party targets like `python_source` will only be able to infer deps from resolves they themselves use.

This does not yet change user behavior. We still need to add `compatible_resolves` to the `python_source` target and then refactor our `PythonModuleOwners` rule to pass in this information.

[ci skip-rust]
[ci skip-build-wheels]