### PR TITLE
Fix `.pyi` type stubs to show up in `python_distribution` (Cherry-pick of #14033)

### DIFF
--- a/src/python/pants/backend/python/goals/setup_py_test.py
+++ b/src/python/pants/backend/python/goals/setup_py_test.py
@@ -407,7 +407,7 @@ def test_generate_chroot(chroot_rule_runner: RuleRunner) -> None:
             "plugin_demo": "hello world",
             "packages": ("foo", "foo.qux"),
             "namespace_packages": ("foo",),
-            "package_data": {"foo": ("resources/js/code.js",)},
+            "package_data": {"foo": ("resources/js/code.js",), "foo.qux": ("qux.pyi",)},
             "install_requires": ("baz==1.1.1",),
             "entry_points": {"console_scripts": ["foo_main = foo.qux.bin:main"]},
         },


### PR DESCRIPTION
We discovered that even though we were including `.pyi` files in the chroot we give to `setuptools`, we need to set the value in `package_data` for setuptools to actually include the file. See https://blog.ian.stapletoncordas.co/2019/02/distributing-python-libraries-with-type-annotations.html.

Because of this issue, `pantsbuild.pants` was not including `native_engine.pyi` in the wheel.

[ci skip-rust]
[ci skip-build-wheels]