### PR TITLE
[internal] remove a python_tests target where there are no tests

### DIFF
--- a/src/python/pants/backend/codegen/thrift/scrooge/BUILD
+++ b/src/python/pants/backend/codegen/thrift/scrooge/BUILD
@@ -4,5 +4,3 @@
 python_sources(dependencies=[":lockfile"])
 
 resource(name="lockfile", source="scrooge.default.lockfile.txt")
-
-python_tests(name="tests")


### PR DESCRIPTION
Remove a `python_tests` target from a directory where the tests had been refactored out of the package in a prior PR. Fixes error messages related to missing globs.

[ci skip-rust]

[ci skip-build-wheels]