### PR TITLE
[internal] Update to `toolchain.pants.plugin==0.17.0`. (cherrypick of #14050)

### DIFF
--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -211,7 +211,7 @@ def run_pants_help_all() -> dict[str, Any]:
         "pants.backend.python.lint.pylint",
         "pants.backend.python.lint.yapf",
     ]
-    deactivated_plugins = ["toolchain.pants.plugin==0.15.0"]
+    deactivated_plugins = ["toolchain.pants.plugin==0.17.0"]
     argv = [
         "./pants",
         "--concurrent",

--- a/pants.toml
+++ b/pants.toml
@@ -25,7 +25,7 @@ backend_packages.add = [
 plugins = [
   "hdrhistogram",  # For use with `--stats-log`.
   # NOTE: Keep this version in sync with `generate_docs.py`!
-  "toolchain.pants.plugin==0.15.0",
+  "toolchain.pants.plugin==0.17.0",
 ]
 
 # The invalidation globs cover the PYTHONPATH by default, but we exclude some files that are on the
@@ -139,6 +139,7 @@ custom_command = "build-support/bin/generate_all_lockfiles.sh"
 
 [toolchain-setup]
 repo = "pants"
+org = "pantsbuild"
 
 [buildsense]
 enable = false


### PR DESCRIPTION
`requests` released `2.27.0` this morning, but the Toolchain plugin was pinned to `2.26.0`: meanwhile, Pants uses a floating version, and so newly created virtualenvs would have incompatible plugin versions.

Bump to a version with a range requirement for `requests`.

[ci skip-rust]
[ci skip-build-wheels]