### PR TITLE
Fix help strings which were accidentally tuples, and add a validation.

### DIFF
--- a/src/python/pants/jvm/subsystems.py
+++ b/src/python/pants/jvm/subsystems.py
@@ -43,7 +43,7 @@ class JvmSubsystem(Subsystem):
             default="jvm-default",
             help=(
                 "The default value used for the `resolve` and `compatible_resolves` fields.\n\n"
-                "The name must be defined as a resolve in `[jvm].resolves`.",
+                "The name must be defined as a resolve in `[jvm].resolves`."
             ),
         )
         register(
@@ -54,7 +54,7 @@ class JvmSubsystem(Subsystem):
             help=(
                 "Extra JVM arguments to use when running tests in debug mode.\n\n"
                 "For example, if you want to attach a remote debugger, use something like "
-                "['-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005']",
+                "['-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005']"
             ),
         )
 

--- a/src/python/pants/option/errors.py
+++ b/src/python/pants/option/errors.py
@@ -44,6 +44,10 @@ class DefaultMemberValueType(DefaultValueType):
     """
 
 
+class HelpType(RegistrationError):
+    """The `help=` argument must be a string, but was of type `{help_type}`."""
+
+
 class ImplicitValIsNone(RegistrationError):
     """Implicit value cannot be None."""
 

--- a/src/python/pants/option/options_test.py
+++ b/src/python/pants/option/options_test.py
@@ -27,6 +27,7 @@ from pants.option.errors import (
     BooleanOptionNameWithNo,
     DefaultValueType,
     FromfileError,
+    HelpType,
     ImplicitValIsNone,
     InvalidKwarg,
     InvalidMemberType,
@@ -1061,7 +1062,8 @@ class OptionsTest(unittest.TestCase):
         assertError(MemberTypeNotAllowed, "--foo", type=dict, member_type=int)
         assertError(InvalidMemberType, "--foo", type=list, member_type=set)
         assertError(InvalidMemberType, "--foo", type=list, member_type=list)
-        assertError(InvalidMemberType, "--foo", type=list, member_type=list)
+        assertError(HelpType, "--foo", help=())
+        assertError(HelpType, "--foo", help=("Help!",))
 
     def test_implicit_value(self) -> None:
         def check(*, flag: str = "", expected: str) -> None:

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -35,6 +35,7 @@ from pants.option.errors import (
     DefaultMemberValueType,
     DefaultValueType,
     FromfileError,
+    HelpType,
     ImplicitValIsNone,
     InvalidKwarg,
     InvalidKwargNonGlobalScope,
@@ -413,6 +414,10 @@ class Parser:
         is_enum = inspect.isclass(member_type) and issubclass(member_type, Enum)
         if not is_enum and member_type not in self._allowed_member_types:
             error(InvalidMemberType, member_type=member_type.__name__)
+
+        help_arg = kwargs.get("help")
+        if help_arg is not None and not isinstance(help_arg, str):
+            error(HelpType, help_type=type(help_arg).__name__)
 
         # check type of default value
         default_value = kwargs.get("default")


### PR DESCRIPTION
`./pants help jvm` was failing due to two arguments which had been added as tuples. `./pants help-all` (and thus docsite generation) succeeded, albeit with additional nesting.

Fix those instances, and add validation.

[ci skip-rust]