### PR TITLE
Add `#pants: ignore` pragma for ignoring imports

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/parse_python_imports_test.py
+++ b/src/python/pants/backend/python/dependency_inference/parse_python_imports_test.py
@@ -86,10 +86,16 @@ def test_normal_imports(rule_runner: RuleRunner) -> None:
         from project.demo import OriginalName as Renamed
         import pragma_ignored  # pants: ignore
         from also_pragma_ignored import doesnt_matter  # pants: ignore
-        from multiline_import import (
-            not_ignored,
-            should_be_ignored_but_isnt  # pants: ignore
+        from multiline_import1 import (
+            not_ignored1,
+            ignored1 as alias1,  # pants: ignore
+            ignored2 as \\
+                alias2,  # pants: ignore
+            ignored3 as alias3, ignored4,  # pants: ignore
+            not_ignored2,
         )
+        from multiline_import2 import (ignored1,  # pants: ignore
+            not_ignored)
 
         if TYPE_CHECKING:
             from project.circular_dep import CircularDep
@@ -100,7 +106,16 @@ def test_normal_imports(rule_runner: RuleRunner) -> None:
             import subprocess23 as subprocess
 
         __import__("pkg_resources")
-        __import("dunder_import_ignored")  # pants: ignore
+        __import__("dunder_import_ignored")  # pants: ignore
+        __import__(  # pants: ignore
+            "not_ignored_but_looks_like_it_could_be"
+        )
+        __import__(
+            "ignored"  # pants: ignore
+        )
+        __import__(  # pants: ignore
+            "also_not_ignored_but_looks_like_it_could_be"
+        )
         """
     )
     assert_imports_parsed(
@@ -115,8 +130,11 @@ def test_normal_imports(rule_runner: RuleRunner) -> None:
             "demo",
             "project.demo.Demo",
             "project.demo.OriginalName",
-            "multiline_import.not_ignored",
-            "multiline_import.should_be_ignored_but_isnt",
+            "multiline_import.not_ignored1",
+            "multiline_import.not_ignored2",
+            "multiline_import2.not_ignored",
+            "not_ignored_but_looks_like_it_could_be",
+            "also_not_ignored_but_looks_like_it_could_be",
             "project.circular_dep.CircularDep",
             "subprocess",
             "subprocess23",
@@ -133,6 +151,10 @@ def test_relative_imports(rule_runner: RuleRunner, basename: str) -> None:
         from .sibling import Nibling
         from .subdir.child import Child
         from ..parent import Parent
+        from ..parent import (
+            Parent1,
+            Guardian as Parent2
+        )
         """
     )
     assert_imports_parsed(
@@ -144,6 +166,8 @@ def test_relative_imports(rule_runner: RuleRunner, basename: str) -> None:
             "project.util.sibling.Nibling",
             "project.util.subdir.child.Child",
             "project.parent.Parent",
+            "project.parent.Parent1",
+            "project.parent.Guardian",
         ],
     )
 

--- a/src/python/pants/backend/python/dependency_inference/parse_python_imports_test.py
+++ b/src/python/pants/backend/python/dependency_inference/parse_python_imports_test.py
@@ -84,6 +84,12 @@ def test_normal_imports(rule_runner: RuleRunner) -> None:
         import demo
         from project.demo import Demo
         from project.demo import OriginalName as Renamed
+        import pragma_ignored  # pants: ignore
+        from also_pragma_ignored import doesnt_matter  # pants: ignore
+        from multiline_import import (
+            not_ignored,
+            should_be_ignored_but_isnt  # pants: ignore
+        )
 
         if TYPE_CHECKING:
             from project.circular_dep import CircularDep
@@ -94,6 +100,7 @@ def test_normal_imports(rule_runner: RuleRunner) -> None:
             import subprocess23 as subprocess
 
         __import__("pkg_resources")
+        __import("dunder_import_ignored")  # pants: ignore
         """
     )
     assert_imports_parsed(
@@ -108,6 +115,8 @@ def test_normal_imports(rule_runner: RuleRunner) -> None:
             "demo",
             "project.demo.Demo",
             "project.demo.OriginalName",
+            "multiline_import.not_ignored",
+            "multiline_import.should_be_ignored_but_isnt",
             "project.circular_dep.CircularDep",
             "subprocess",
             "subprocess23",

--- a/src/python/pants/backend/python/dependency_inference/parse_python_imports_test.py
+++ b/src/python/pants/backend/python/dependency_inference/parse_python_imports_test.py
@@ -115,9 +115,9 @@ def test_normal_imports(rule_runner: RuleRunner) -> None:
         __import__(
             "ignored"  # pants: ignore
         )
-        __import__(  # pants: ignore
+        __import__(
             "also_not_ignored_but_looks_like_it_could_be"
-        )
+        )  # pants: ignore
         """
     )
     assert_imports_parsed(

--- a/src/python/pants/backend/python/dependency_inference/parse_python_imports_test.py
+++ b/src/python/pants/backend/python/dependency_inference/parse_python_imports_test.py
@@ -91,7 +91,9 @@ def test_normal_imports(rule_runner: RuleRunner) -> None:
             ignored1 as alias1,  # pants: ignore
             ignored2 as \\
                 alias2,  # pants: ignore
-            ignored3 as alias3, ignored4,  # pants: ignore
+            ignored3 as  # pants: ignore
+                alias3,
+            ignored4 as alias4, ignored4,  # pants: ignore
             not_ignored2,
         )
         from multiline_import2 import (ignored1,  # pants: ignore
@@ -123,22 +125,22 @@ def test_normal_imports(rule_runner: RuleRunner) -> None:
         content,
         expected=[
             "__future__.print_function",
-            "os",
-            "os.path",
-            "typing.TYPE_CHECKING",
-            "requests",
+            "also_not_ignored_but_looks_like_it_could_be",
             "demo",
-            "project.demo.Demo",
-            "project.demo.OriginalName",
-            "multiline_import.not_ignored1",
-            "multiline_import.not_ignored2",
+            "multiline_import1.not_ignored1",
+            "multiline_import1.not_ignored2",
             "multiline_import2.not_ignored",
             "not_ignored_but_looks_like_it_could_be",
-            "also_not_ignored_but_looks_like_it_could_be",
+            "os",
+            "os.path",
+            "requests",
             "project.circular_dep.CircularDep",
+            "project.demo.Demo",
+            "project.demo.OriginalName",
+            "pkg_resources",
             "subprocess",
             "subprocess23",
-            "pkg_resources",
+            "typing.TYPE_CHECKING",
         ],
     )
 

--- a/src/python/pants/backend/python/dependency_inference/scripts/import_parser.py
+++ b/src/python/pants/backend/python/dependency_inference/scripts/import_parser.py
@@ -51,6 +51,7 @@ class AstVisitor(ast.NodeVisitor):
 
         consume_until("import")
 
+        # N.B. The names in this list are in the same order as the import statement
         for alias in node.names:
             consume_until(alias.name.split(".")[-1])
 

--- a/src/python/pants/backend/python/dependency_inference/scripts/import_parser.py
+++ b/src/python/pants/backend/python/dependency_inference/scripts/import_parser.py
@@ -7,11 +7,11 @@
 from __future__ import print_function, unicode_literals
 
 import ast
-import os
-import tokenize
 import itertools
+import os
 import re
 import sys
+import tokenize
 from io import open
 
 MIN_DOTS = os.environ["MIN_DOTS"]
@@ -22,6 +22,7 @@ STRING_IMPORT_REGEX = re.compile(
     r"^([a-z_][a-z_\d]*\.){" + MIN_DOTS + r",}[a-zA-Z_]\w*$",
     re.UNICODE,
 )
+
 
 class AstVisitor(ast.NodeVisitor):
     def __init__(self, package_parts, contents):
@@ -89,7 +90,6 @@ class AstVisitor(ast.NodeVisitor):
                 if not self._is_pragma_ignored(node.args[0]):
                     self.imports.add(name)
                 return
-
 
         self.generic_visit(node)
 


### PR DESCRIPTION
Adding a way to tell pants __not__ to infer what is seemingly a very legitimate dependency.

See thread: https://pantsbuild.slack.com/archives/C0D7TNJHL/p1641227325498500

For documentation purposes: `# pants: ignore` suppresses the inference of an import for all imports inferred for the line it is on.

N.B. There isn't way to have a single `# pants: ignore` suppress multi lines (e.g. putting it on the open or closing parenthesis does something special). This is shown in the tests.

