### PR TITLE
[internal] Replace `apply_constraints` with an explicit list of constraints.

### DIFF
--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -287,7 +287,8 @@ async def setup_user_lockfile_requests(
     return _UserLockfileRequests(
         PythonLockfileRequest(
             PexRequirements.create_from_requirement_fields(
-                resolve_to_requirements_fields[resolve]
+                resolve_to_requirements_fields[resolve],
+                constraints_strings=(),
             ).req_strings,
             InterpreterConstraints(python_setup.interpreter_constraints),
             resolve_name=resolve,

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -707,12 +707,16 @@ async def get_requirements(
     direct_deps_chained = FrozenOrderedSet(itertools.chain.from_iterable(direct_deps_tgts))
     direct_deps_with_excl = direct_deps_chained.difference(transitive_excludes)
 
-    reqs = PexRequirements.create_from_requirement_fields(
-        tgt[PythonRequirementsField]
-        for tgt in direct_deps_with_excl
-        if tgt.has_field(PythonRequirementsField)
+    req_strs = list(
+        PexRequirements.create_from_requirement_fields(
+            (
+                tgt[PythonRequirementsField]
+                for tgt in direct_deps_with_excl
+                if tgt.has_field(PythonRequirementsField)
+            ),
+            constraints_strings=(),
+        ).req_strings
     )
-    req_strs = list(reqs.req_strings)
 
     # Add the requirements on any exported targets on which we depend.
     kwargs_for_exported_targets_we_depend_on = await MultiGet(

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -219,7 +219,8 @@ async def pylint_first_party_plugins(pylint: Pylint) -> PylintFirstPartyPlugins:
 
     return PylintFirstPartyPlugins(
         requirement_strings=PexRequirements.create_from_requirement_fields(
-            requirements_fields
+            requirements_fields,
+            constraints_strings=(),
         ).req_strings,
         interpreter_constraints_fields=FrozenOrderedSet(interpreter_constraints_fields),
         sources_digest=prefixed_sources,

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -19,7 +19,6 @@ from pants.backend.python.target_types import (
 from pants.backend.python.typecheck.mypy.skip_field import SkipMyPyField
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import PexRequirements
-from pants.backend.python.util_rules.pex_from_targets import GlobalRequirementConstraints
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
     PythonSourceFilesRequest,
@@ -251,7 +250,6 @@ class MyPyFirstPartyPlugins:
 @rule("Prepare [mypy].source_plugins", level=LogLevel.DEBUG)
 async def mypy_first_party_plugins(
     mypy: MyPy,
-    global_requirement_constraints: GlobalRequirementConstraints,
 ) -> MyPyFirstPartyPlugins:
     if not mypy.source_plugins:
         return MyPyFirstPartyPlugins(FrozenOrderedSet(), EMPTY_DIGEST, ())
@@ -267,7 +265,7 @@ async def mypy_first_party_plugins(
             for plugin_tgt in transitive_targets.closure
             if plugin_tgt.has_field(PythonRequirementsField)
         ),
-        constraints_strings=(str(constraint) for constraint in global_requirement_constraints),
+        constraints_strings=(),
     )
 
     sources = await Get(PythonSourceFiles, PythonSourceFilesRequest(transitive_targets.closure))

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem_test.py
@@ -17,7 +17,7 @@ from pants.backend.python.typecheck.mypy.subsystem import (
     MyPyFirstPartyPlugins,
     MyPyLockfileSentinel,
 )
-from pants.backend.python.util_rules import pex_from_targets, python_sources
+from pants.backend.python.util_rules import python_sources
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.core.target_types import GenericTarget
 from pants.core.util_rules import config_files
@@ -35,7 +35,6 @@ def rule_runner() -> RuleRunner:
             *config_files.rules(),
             *python_sources.rules(),
             *target_types_rules.rules(),
-            *pex_from_targets.rules(),
             QueryRule(MyPyConfigFile, []),
             QueryRule(MyPyFirstPartyPlugins, []),
             QueryRule(PythonLockfileRequest, [MyPyLockfileSentinel]),

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem_test.py
@@ -17,7 +17,7 @@ from pants.backend.python.typecheck.mypy.subsystem import (
     MyPyFirstPartyPlugins,
     MyPyLockfileSentinel,
 )
-from pants.backend.python.util_rules import python_sources
+from pants.backend.python.util_rules import pex_from_targets, python_sources
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.core.target_types import GenericTarget
 from pants.core.util_rules import config_files
@@ -35,6 +35,7 @@ def rule_runner() -> RuleRunner:
             *config_files.rules(),
             *python_sources.rules(),
             *target_types_rules.rules(),
+            *pex_from_targets.rules(),
             QueryRule(MyPyConfigFile, []),
             QueryRule(MyPyFirstPartyPlugins, []),
             QueryRule(PythonLockfileRequest, [MyPyLockfileSentinel]),

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -445,7 +445,7 @@ def test_requirement_constraints(rule_runner: RuleRunner) -> None:
     # Unconstrained, we should always pick the top of the range (requests 2.23.0) since the top of
     # the range is a transitive closure over universal wheels.
     direct_pex_info = create_pex_and_get_pex_info(
-        rule_runner, requirements=PexRequirements(direct_deps, apply_constraints=False)
+        rule_runner, requirements=PexRequirements(direct_deps)
     )
     assert_direct_requirements(direct_pex_info)
     assert "requests-2.23.0-py2.py3-none-any.whl" in set(direct_pex_info["distributions"].keys())
@@ -460,7 +460,7 @@ def test_requirement_constraints(rule_runner: RuleRunner) -> None:
     rule_runner.write_files({"constraints.txt": "\n".join(constraints)})
     constrained_pex_info = create_pex_and_get_pex_info(
         rule_runner,
-        requirements=PexRequirements(direct_deps, apply_constraints=True),
+        requirements=PexRequirements(direct_deps, constraints_strings=constraints),
         additional_pants_args=("--python-requirement-constraints=constraints.txt",),
     )
     assert_direct_requirements(constrained_pex_info)
@@ -563,7 +563,7 @@ def test_venv_pex_resolve_info(rule_runner: RuleRunner, pex_type: type[Pex | Ven
     pex = create_pex_and_get_all_data(
         rule_runner,
         pex_type=pex_type,
-        requirements=PexRequirements(["requests==2.23.0"], apply_constraints=True),
+        requirements=PexRequirements(["requests==2.23.0"], constraints_strings=constraints),
         additional_pants_args=("--python-requirement-constraints=constraints.txt",),
     ).pex
     dists = rule_runner.request(PexResolveInfo, [pex])

--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -51,9 +51,9 @@ async def resolve_plugins(
     `named_caches` directory), but consequently needs to disable the process cache: see the
     ProcessCacheScope reference in the body.
     """
-    # The repository's constraints are not relevant here, because this resolve is mixed
-    # into the Pants' process' path, and never into user code.
-    requirements = PexRequirements(sorted(global_options.options.plugins), apply_constraints=False)
+    requirements = PexRequirements(
+        req_strings=sorted(global_options.options.plugins),
+    )
     if not requirements:
         return ResolvedPluginDistributions()
 


### PR DESCRIPTION
Some callers (#14058) of `PexRequirements` will soon need to be able to specify explicit constraints for building a PEX which are _not_ the global constraints. Additionally, consuming the `constraints` directly as a file (rather than parsing and re-materializing the file) forces whitespace/comment edits to the constraints file to invalidate all resolves ([reported here](https://github.com/pantsbuild/requirements-perf/issues/1#issuecomment-990086088)).

To fix this, replace `apply_constraints: bool` (for the global constraints) with an explicit list of constraints.

[ci skip-rust]
[ci skip-build-wheels]