### PR TITLE
[internal] fs_util: tweak output for `directory cat-proto --output-format recursive-file-list-with-digests`.

### DIFF
--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -649,7 +649,9 @@ async fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
             maybe_v
               .map(|v| {
                 v.into_iter()
-                  .map(|(name, digest)| format!("{} {} {}\n", name, digest.hash, digest.size_bytes))
+                  .map(|(name, digest)| {
+                    format!("{} {:<16} {}\n", digest.hash, digest.size_bytes, name)
+                  })
                   .collect::<Vec<String>>()
                   .join("")
               })


### PR DESCRIPTION
Before:
```
$ fs_util --local-store-path .../lmdb_store directory cat-proto --output-format recursive-file-list-with-digests 14cf3fecfaedecfd1743525438861200228419c09ac3af27287a9bb8a22abc32 3397
PyYAML-6.0-cp38-cp38-macosx_10_9_x86_64.whl d028c0133a84aae079ed28c5d7493401cd9d021e310f1e17389df4eb101aa3e2 192909
ansicolors-1.1.8-py2.py3-none-any.whl c941417a1c2b81ac2b9a0db39c48ea0e524e97c97e84e96f424d7179800b29fa 14536
attrs-21.4.0-py2.py3-none-any.whl ff011407720a6da77b9618a50ce37364766fecb6433885d11eb0920d7dfae475 61291
certifi-2021.10.8-py2.py3-none-any.whl e693f7e7be618b134c66ac991e9cfcda5785607fb3287d8c61df342e04dac5d7 149898
charset_normalizer-2.0.10-py3-none-any.whl 67c61df63b80f7c48eac39537d22c7c3c58d8e8e4b49c9aa9577ea69ed50d10a 40766
click-8.0.3-py3-none-any.whl e4cd9798805310e6c908c16409815c7a47661c38aa785ab9f09e63041aeeec29 98153
fasteners-0.16.3-py2.py3-none-any.whl a19ef663f9a0017f989b1c924f5386ec9068eea16848edd869fea665099e42ce 29495
humbug-0.2.7-py3-none-any.whl 1464a78447cbc1c285f1a981a3d7a5fa2e9b40a21116054f108108afa0c25d18 11851
idna-3.3-py3-none-any.whl a38550c70d3a2b035bb96e43a4508d12ffae520eff01a70dbde72d3b039f3f96 61772
ijson-3.1.4-cp38-cp38-macosx_10_9_x86_64.whl 047853cfc5e7f149318ff5af78cd7e5931566e31e089563430e60e0e8d5d2dfa 53790
iniconfig-1.1.1-py2.py3-none-any.whl d016c0d36e1f5f87dcb1c4e8840d78d8535d06f21b2efbfddd340941e24dad61 5653
packaging-21.0-py3-none-any.whl 58ca81d63f675e70caac41967132ae5c2effc880f37a5ec13cfdec1dea4c2c2b 41015
pantsbuild.pants-2.9.0rc2-cp38-cp38-macosx_10_15_x86_64.whl 93e187e800b84fe171e5ffcd0e825b18a8e8680780638bc1c9b6fd164d444d70 7953172
pantsbuild.pants.testutil-2.9.0rc2-py37.py38.py39-none-any.whl 156cccf6d114545f57583721643e73e63c270071e0b4e4edebeee6b269f68575 26302
[...]
```

After:
```
$ fs_util --local-store-path .../lmdb_store directory cat-proto --output-format recursive-file-list-with-digests 14cf3fecfaedecfd1743525438861200228419c09ac3af27287a9bb8a22abc32 3397
d028c0133a84aae079ed28c5d7493401cd9d021e310f1e17389df4eb101aa3e2 192909           PyYAML-6.0-cp38-cp38-macosx_10_9_x86_64.whl
c941417a1c2b81ac2b9a0db39c48ea0e524e97c97e84e96f424d7179800b29fa 14536            ansicolors-1.1.8-py2.py3-none-any.whl
ff011407720a6da77b9618a50ce37364766fecb6433885d11eb0920d7dfae475 61291            attrs-21.4.0-py2.py3-none-any.whl
e693f7e7be618b134c66ac991e9cfcda5785607fb3287d8c61df342e04dac5d7 149898           certifi-2021.10.8-py2.py3-none-any.whl
67c61df63b80f7c48eac39537d22c7c3c58d8e8e4b49c9aa9577ea69ed50d10a 40766            charset_normalizer-2.0.10-py3-none-any.whl
e4cd9798805310e6c908c16409815c7a47661c38aa785ab9f09e63041aeeec29 98153            click-8.0.3-py3-none-any.whl
a19ef663f9a0017f989b1c924f5386ec9068eea16848edd869fea665099e42ce 29495            fasteners-0.16.3-py2.py3-none-any.whl
1464a78447cbc1c285f1a981a3d7a5fa2e9b40a21116054f108108afa0c25d18 11851            humbug-0.2.7-py3-none-any.whl
a38550c70d3a2b035bb96e43a4508d12ffae520eff01a70dbde72d3b039f3f96 61772            idna-3.3-py3-none-any.whl
047853cfc5e7f149318ff5af78cd7e5931566e31e089563430e60e0e8d5d2dfa 53790            ijson-3.1.4-cp38-cp38-macosx_10_9_x86_64.whl
d016c0d36e1f5f87dcb1c4e8840d78d8535d06f21b2efbfddd340941e24dad61 5653             iniconfig-1.1.1-py2.py3-none-any.whl
58ca81d63f675e70caac41967132ae5c2effc880f37a5ec13cfdec1dea4c2c2b 41015            packaging-21.0-py3-none-any.whl
93e187e800b84fe171e5ffcd0e825b18a8e8680780638bc1c9b6fd164d444d70 7953172          pantsbuild.pants-2.9.0rc2-cp38-cp38-macosx_10_15_x86_64.whl
156cccf6d114545f57583721643e73e63c270071e0b4e4edebeee6b269f68575 26302            pantsbuild.pants.testutil-2.9.0rc2-py37.py38.py39-none-any.whl
[...]
```