### PR TITLE
Don't run push workflow on dependabot branches

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -713,7 +713,7 @@ jobs:
     timeout-minutes: 40
 name: Pull Request CI
 'on':
+- pull_request
 - push:
     branches-ignore:
     - dependabot/*
-- pull_request

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -713,7 +713,7 @@ jobs:
     timeout-minutes: 40
 name: Pull Request CI
 'on':
-- pull_request
-- push:
+  pull_request: {}
+  push:
     branches-ignore:
     - dependabot/*

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -713,5 +713,7 @@ jobs:
     timeout-minutes: 40
 name: Pull Request CI
 'on':
-- push
+- push:
+    branches-ignore:
+    - dependabot/*
 - pull_request

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -561,7 +561,7 @@ def generate() -> dict[Path, str]:
     test_yaml = yaml.dump(
         {
             "name": test_workflow_name,
-            "on": [{"push": {"branches-ignore": ["dependabot/*"]}}, "pull_request"],
+            "on": ["pull_request", {"push": {"branches-ignore": ["dependabot/*"]}}],
             "jobs": test_workflow_jobs([PYTHON37_VERSION], cron=False),
             "env": global_env(),
         },

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -561,7 +561,7 @@ def generate() -> dict[Path, str]:
     test_yaml = yaml.dump(
         {
             "name": test_workflow_name,
-            "on": ["pull_request", {"push": {"branches-ignore": ["dependabot/*"]}}],
+            "on": {"pull_request": {}, "push": {"branches-ignore": ["dependabot/*"]}},
             "jobs": test_workflow_jobs([PYTHON37_VERSION], cron=False),
             "env": global_env(),
         },

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -561,7 +561,7 @@ def generate() -> dict[Path, str]:
     test_yaml = yaml.dump(
         {
             "name": test_workflow_name,
-            "on": ["push", "pull_request"],
+            "on": [{"push": {"branches-ignore": ["dependabot/*"]}}, "pull_request"],
             "jobs": test_workflow_jobs([PYTHON37_VERSION], cron=False),
             "env": global_env(),
         },


### PR DESCRIPTION
Dependabot creates and pushes branches on the main repo (and not from a fork)
We only want to run the PR CI on it and not the push CI on those PRs.
<img width="1156" alt="Screen Shot 2022-01-06 at 2 21 27 PM" src="https://user-images.githubusercontent.com/1268088/148460538-32ad30f1-3494-4193-a430-fd987224a854.png">

