### PR TITLE
[internal] Switch to AWS CLI v2

### DIFF
--- a/build-support/bin/install_aws_cli_for_ci.sh
+++ b/build-support/bin/install_aws_cli_for_ci.sh
@@ -19,12 +19,11 @@ if [[ ! -x "${AWS_CLI_BIN}" ]]; then
   TMPDIR=$(mktemp -d)
 
   pushd "${TMPDIR}"
-
-  curl --fail "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
-  unzip awscli-bundle.zip
+  curl --fail "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+  unzip awscliv2.zip
   # NB: We must run this with python3 because it defaults to `python`, which refers to Python 2 in Linux GitHub
   # Actions CI job and is no longer supported.
-  python3 ./awscli-bundle/install --install-dir "${AWS_CLI_ROOT}"
+  python3 ./aws/install --install-dir "${AWS_CLI_ROOT}"
 
   popd
 


### PR DESCRIPTION
AWS CLI v2 is the recommended way to interact w/ AWS.
see: https://github.com/pantsbuild/pants/runs/4730814987?check_suite_focus=true#step:12:57
<img width="1242" alt="Screen Shot 2022-01-06 at 2 04 25 PM" src="https://user-images.githubusercontent.com/1268088/148458758-65ad0b9b-dad6-4719-ba61-71f8749d47ee.png">


https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html

the command in deploy_to_s3.py should work just fine with the new CLI.
see: https://docs.aws.amazon.com/cli/latest/reference/s3/sync.html#synopsis
https://github.com/pantsbuild/pants/blob/8f679f18f5c8210a85ba1eb8b9ab5bbe118fa738/build-support/bin/deploy_to_s3.py#L35-L47