### PR TITLE
Revert "[internal] Switch to AWS CLI v2 (#14095)"

### DIFF
--- a/build-support/bin/install_aws_cli_for_ci.sh
+++ b/build-support/bin/install_aws_cli_for_ci.sh
@@ -19,11 +19,12 @@ if [[ ! -x "${AWS_CLI_BIN}" ]]; then
   TMPDIR=$(mktemp -d)
 
   pushd "${TMPDIR}"
-  curl --fail "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-  unzip awscliv2.zip
+
+  curl --fail "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
+  unzip awscli-bundle.zip
   # NB: We must run this with python3 because it defaults to `python`, which refers to Python 2 in Linux GitHub
   # Actions CI job and is no longer supported.
-  python3 ./aws/install --install-dir "${AWS_CLI_ROOT}"
+  python3 ./awscli-bundle/install --install-dir "${AWS_CLI_ROOT}"
 
   popd
 


### PR DESCRIPTION
This caused the Linux shard to fail: https://github.com/pantsbuild/pants/runs/4733182135?check_suite_focus=true#step:12:7080

[ci skip-rust]

[ci skip-build-wheels]