### PR TITLE
Deprecate `[validate].detail_level` in favor of `[sourcefile-validation].detail_level`

### DIFF
--- a/src/python/pants/backend/project_info/source_file_validator.py
+++ b/src/python/pants/backend/project_info/source_file_validator.py
@@ -7,7 +7,7 @@ import re
 import textwrap
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from typing import Any, cast
 
 from pants.base.deprecated import resolve_conflicting_options
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE
@@ -144,13 +144,16 @@ class SourceFileValidation(Subsystem):
         return MultiMatcher(ValidationConfig.from_dict(self.options.config))
 
     def detail_level(self, validate_subsystem: ValidateSubsystem) -> DetailLevel:
-        return resolve_conflicting_options(
-            old_option="detail_level",
-            new_option="detail_level",
-            old_container=validate_subsystem.options,
-            new_container=self.options,
-            old_scope=validate_subsystem.name,
-            new_scope=self.options_scope,
+        return cast(
+            DetailLevel,
+            resolve_conflicting_options(
+                old_option="detail_level",
+                new_option="detail_level",
+                old_container=validate_subsystem.options,
+                new_container=self.options,
+                old_scope=validate_subsystem.name,
+                new_scope=self.options_scope,
+            ),
         )
 
 


### PR DESCRIPTION
Prework for https://github.com/pantsbuild/pants/pull/14102. The `GoalSubsystem` will be going away so the option should live on the relevant subsystem instead.

I'm not sure if `sourcefile-validation` is the best options scope for #14102, but I'm not sure what else we would call it.

[ci skip-rust]
[ci skip-build-wheels]