### PR TITLE
Reduce output from `scalafmt`, and lower reflective access option threshold for Google Java Format. (cherrypick #14109)

### DIFF
--- a/src/python/pants/backend/java/lint/google_java_format/rules.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules.py
@@ -87,9 +87,9 @@ async def setup_google_java_format(
         toolcp_relpath: tool_classpath.digest,
     }
 
-    maybe_java16_or_higher_options = []
-    if jdk_setup.jre_major_version >= 16:
-        maybe_java16_or_higher_options = [
+    maybe_java11_or_higher_options = []
+    if jdk_setup.jre_major_version >= 11:
+        maybe_java11_or_higher_options = [
             "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
             "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
             "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
@@ -99,7 +99,7 @@ async def setup_google_java_format(
 
     args = [
         *jdk_setup.args(bash, tool_classpath.classpath_entries(toolcp_relpath)),
-        *maybe_java16_or_higher_options,
+        *maybe_java11_or_higher_options,
         "com.google.googlejavaformat.java.Main",
         *(["--aosp"] if tool.aosp else []),
         "--dry-run" if setup_request.check_only else "--replace",

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -170,6 +170,8 @@ async def setup_scalafmt_partition(
     ]
     if request.check_only:
         args.append("--list")
+    else:
+        args.append("--quiet")
     args.extend(request.files)
 
     process = Process(


### PR DESCRIPTION
Fixes #13951, and silences output from `scalafmt` like:
```
Reformatting...
Reformatting... (1.39 %, 20 / 1443)

Reformatting... (6.72 %, 97 / 1443)

...
```
... which is only useful when rendered as streaming.

[ci skip-rust]
[ci skip-build-wheels]