### PR TITLE
[Doc] Include backend source for goals, subsystems and targets in generated docsite.

### DIFF
--- a/build-support/bin/docs_templates/options_scope_reference.md.mustache
+++ b/build-support/bin/docs_templates/options_scope_reference.md.mustache
@@ -3,6 +3,7 @@
 ```{{/is_goal}}
 {{{description}}}
 
+Backend: <span style="color: purple"><code>{{provider}}</code></span>
 Config section: <span style="color: purple"><code>[{{scope}}{{^scope}}GLOBAL{{/scope}}]</code></span>
 
 ## Basic options

--- a/build-support/bin/docs_templates/target_reference.md.mustache
+++ b/build-support/bin/docs_templates/target_reference.md.mustache
@@ -1,10 +1,15 @@
 {{{description}}}
 
+Backend: <span style="color: purple"><code>{{provider}}</code></span>
+
 {{#fields}}
 ## <code>{{alias}}</code>
 
 <span style="color: purple">type: <code>{{type_hint}}</code></span>
 <span style="color: green">{{{default_or_required}}}</span>
+{{#provider}}
+backend: <span style="color: green"><code>{{provider}}</code></span>
+{{/provider}}
 
 {{{description}}}
 


### PR DESCRIPTION
I've manually copied the sources for these three pages to make it easier to review the end result:
1. https://www.pantsbuild.org/v2.9/docs/reference-publish
2. https://www.pantsbuild.org/v2.9/docs/reference-docker
3. https://www.pantsbuild.org/v2.9/docs/reference-docker_image

I want to highlight that plugin fields get called out, when applicable:
![image](https://user-images.githubusercontent.com/72965/148752211-3e223f20-92f7-4ca8-8fff-96a1b70b72df.png)

Open questions are on style: placement/wording/color etc.
Also, I've considered hiding this information in case the backend is `pants.core`, but I'm not sure if it is better to leave in, to make it clear when it is a core feature that will always be present...?
