### PR TITLE
:speak_no_evil: black and mypy need to shush

### DIFF
--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -54,7 +54,7 @@ class Setup:
 
 
 def generate_argv(source_files: SourceFiles, black: Black, *, check_only: bool) -> Tuple[str, ...]:
-    args = ["-q"]
+    args = ["--quiet"]
     if check_only:
         args.append("--check")
     if black.config:

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -54,7 +54,7 @@ class Setup:
 
 
 def generate_argv(source_files: SourceFiles, black: Black, *, check_only: bool) -> Tuple[str, ...]:
-    args = []
+    args = ["-q"]
     if check_only:
         args.append("--check")
     if black.config:

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -111,8 +111,6 @@ def test_passing(rule_runner: RuleRunner, major_minor_interpreter: str) -> None:
     )
     assert len(lint_results) == 1
     assert lint_results[0].exit_code == 0
-    assert "1 file would be left unchanged" in lint_results[0].stderr
-    assert "1 file left unchanged" in fmt_result.stderr
     assert fmt_result.output == get_digest(rule_runner, {"f.py": GOOD_FILE})
     assert fmt_result.did_change is False
 
@@ -123,8 +121,6 @@ def test_failing(rule_runner: RuleRunner) -> None:
     lint_results, fmt_result = run_black(rule_runner, [tgt])
     assert len(lint_results) == 1
     assert lint_results[0].exit_code == 1
-    assert "1 file would be reformatted" in lint_results[0].stderr
-    assert "1 file reformatted" in fmt_result.stderr
     assert fmt_result.output == get_digest(rule_runner, {"f.py": FIXED_BAD_FILE})
     assert fmt_result.did_change is True
 
@@ -140,8 +136,6 @@ def test_multiple_targets(rule_runner: RuleRunner) -> None:
     lint_results, fmt_result = run_black(rule_runner, tgts)
     assert len(lint_results) == 1
     assert lint_results[0].exit_code == 1
-    assert "1 file would be reformatted, 1 file would be left unchanged" in lint_results[0].stderr
-    assert "1 file reformatted, 1 file left unchanged" in fmt_result.stderr
     assert fmt_result.output == get_digest(
         rule_runner, {"good.py": GOOD_FILE, "bad.py": FIXED_BAD_FILE}
     )
@@ -164,8 +158,6 @@ def test_config_file(rule_runner: RuleRunner, config_path: str, extra_args: list
     lint_results, fmt_result = run_black(rule_runner, [tgt], extra_args=extra_args)
     assert len(lint_results) == 1
     assert lint_results[0].exit_code == 0
-    assert "1 file would be left unchanged" in lint_results[0].stderr
-    assert "1 file left unchanged" in fmt_result.stderr
     assert fmt_result.output == get_digest(rule_runner, {"f.py": NEEDS_CONFIG_FILE})
     assert fmt_result.did_change is False
 
@@ -178,8 +170,6 @@ def test_passthrough_args(rule_runner: RuleRunner) -> None:
     )
     assert len(lint_results) == 1
     assert lint_results[0].exit_code == 0
-    assert "1 file would be left unchanged" in lint_results[0].stderr
-    assert "1 file left unchanged" in fmt_result.stderr
     assert fmt_result.output == get_digest(rule_runner, {"f.py": NEEDS_CONFIG_FILE})
     assert fmt_result.did_change is False
 
@@ -217,8 +207,6 @@ def test_works_with_python38(rule_runner: RuleRunner) -> None:
     lint_results, fmt_result = run_black(rule_runner, [tgt])
     assert len(lint_results) == 1
     assert lint_results[0].exit_code == 0
-    assert "1 file would be left unchanged" in lint_results[0].stderr
-    assert "1 file left unchanged" in fmt_result.stderr
     assert fmt_result.output == get_digest(rule_runner, {"f.py": content})
     assert fmt_result.did_change is False
 
@@ -241,8 +229,6 @@ def test_works_with_python39(rule_runner: RuleRunner) -> None:
     lint_results, fmt_result = run_black(rule_runner, [tgt])
     assert len(lint_results) == 1
     assert lint_results[0].exit_code == 0
-    assert "1 file would be left unchanged" in lint_results[0].stderr
-    assert "1 file left unchanged" in fmt_result.stderr
     assert fmt_result.output == get_digest(rule_runner, {"f.py": content})
     assert fmt_result.did_change is False
 
@@ -264,10 +250,6 @@ def test_stub_files(rule_runner: RuleRunner) -> None:
     ]
     lint_results, fmt_result = run_black(rule_runner, good_tgts)
     assert len(lint_results) == 1 and lint_results[0].exit_code == 0
-    assert (
-        "2 files would be left unchanged" in lint_results[0].stderr
-        and "2 files left unchanged" in fmt_result.stderr
-    )
     assert fmt_result.output == get_digest(
         rule_runner, {"good.pyi": GOOD_FILE, "good.py": GOOD_FILE}
     )
@@ -279,10 +261,6 @@ def test_stub_files(rule_runner: RuleRunner) -> None:
     ]
     lint_results, fmt_result = run_black(rule_runner, bad_tgts)
     assert len(lint_results) == 1 and lint_results[0].exit_code == 1
-    assert (
-        "2 files would be reformatted" in lint_results[0].stderr
-        and "2 files reformatted" in fmt_result.stderr
-    )
     assert fmt_result.output == get_digest(
         rule_runner, {"bad.pyi": FIXED_BAD_FILE, "bad.py": FIXED_BAD_FILE}
     )

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -265,3 +265,18 @@ def test_stub_files(rule_runner: RuleRunner) -> None:
         rule_runner, {"bad.pyi": FIXED_BAD_FILE, "bad.py": FIXED_BAD_FILE}
     )
     assert fmt_result.did_change
+
+def test_verbosity(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files({"f.py": GOOD_FILE, "BUILD": "python_sources(name='t')"})
+    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
+
+    lint_results, fmt_result = run_black(rule_runner, [tgt])
+    assert "1 file would be left unchanged" not in lint_results[0].stderr
+    assert "1 file left unchanged" not in fmt_result.stderr
+
+    # If the user wants to increase verbosity, they should be able to
+    lint_results, fmt_result = run_black(
+        rule_runner, [tgt], extra_args=["--black-args='--verbose'"]
+    )
+    assert "1 file would be left unchanged" in lint_results[0].stderr
+    assert "1 file left unchanged" in fmt_result.stderr

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -69,7 +69,7 @@ def generate_argv(
     file_list_path: str,
     python_version: Optional[str],
 ) -> Tuple[str, ...]:
-    args = [f"--python-executable={venv_python}", *mypy.args]
+    args = [f"--python-executable={venv_python}", "--no-error-summary", *mypy.args]
     if mypy.config:
         args.append(f"--config-file={mypy.config}")
     if python_version:

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -98,7 +98,6 @@ def assert_success(
     result = run_mypy(rule_runner, [target], extra_args=extra_args)
     assert len(result) == 1
     assert result[0].exit_code == 0
-    assert "Success: no issues found" in result[0].stdout.strip()
     assert result[0].report == EMPTY_DIGEST
 
 
@@ -144,7 +143,6 @@ def test_multiple_targets(rule_runner: RuleRunner) -> None:
     assert result[0].exit_code == 1
     assert f"{PACKAGE}/good.py" not in result[0].stdout
     assert f"{PACKAGE}/bad.py:4" in result[0].stdout
-    assert "checked 2 source files" in result[0].stdout
     assert result[0].report == EMPTY_DIGEST
 
 
@@ -191,7 +189,6 @@ def test_report_file(rule_runner: RuleRunner) -> None:
     result = run_mypy(rule_runner, [tgt], extra_args=["--mypy-args='--linecount-report=reports'"])
     assert len(result) == 1
     assert result[0].exit_code == 0
-    assert "Success: no issues found" in result[0].stdout.strip()
     report_files = rule_runner.request(DigestContents, [result[0].report])
     assert len(report_files) == 1
     assert "4       4      1      1 f" in report_files[0].content.decode()
@@ -452,11 +449,9 @@ def test_uses_correct_python_version(rule_runner: RuleRunner) -> None:
 
     assert py2_result.exit_code == 0
     assert py2_result.partition_description == "['CPython==2.7.*', 'CPython==2.7.*,>=3.6']"
-    assert "Success: no issues found" in py2_result.stdout
 
     assert py3_result.exit_code == 0
     assert py3_result.partition_description == "['CPython==2.7.*,>=3.6', 'CPython>=3.6']"
-    assert "Success: no issues found" in py3_result.stdout
 
 
 def test_run_only_on_specified_files(rule_runner: RuleRunner) -> None:
@@ -616,6 +611,7 @@ def test_source_plugin(rule_runner: RuleRunner) -> None:
             rule_runner,
             [tgt],
             extra_args=[
+                "--mypy-args='--error-summary'",
                 "--mypy-source-plugins=['pants-plugins/plugins']",
                 "--mypy-lockfile=<none>",
                 "--source-root-patterns=['pants-plugins', 'src/py']",

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -691,3 +691,16 @@ def test_determine_python_files() -> None:
     assert determine_python_files(["f.py", "f.pyi"]) == ("f.pyi",)
     assert determine_python_files(["f.pyi", "f.py"]) == ("f.pyi",)
     assert determine_python_files(["f.json"]) == ()
+
+def test_verbosity(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files({f"{PACKAGE}/f.py": GOOD_FILE, f"{PACKAGE}/BUILD": "python_sources()"})
+    tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="f.py"))
+
+    result = run_mypy(rule_runner, [tgt])
+    assert "Success: no issues found" not in result[0].stdout.strip()
+
+    # If the user wants error summaries, they should have them
+    result = run_mypy(
+        rule_runner, [tgt], extra_args=["--mypy-args='--error-summary'"]
+    )
+    assert "Success: no issues found" in result[0].stdout.strip()


### PR DESCRIPTION
Before:
```
10:53:28.89 [INFO] Initializing scheduler...
10:53:29.24 [INFO] Scheduler initialized.
10:53:30.72 [INFO] Completed: Format with Autoflake - autoflake made no changes.
10:53:31.96 [INFO] Completed: Format with Black - Black made no changes.
All done! ✨ 🍰 ✨
1 file left unchanged.


10:53:33.07 [INFO] Completed: Format with docformatter - Docformatter made no changes.
10:53:33.18 [INFO] Completed: Format with isort - isort made no changes.

✓ Black made no changes.
✓ Docformatter made no changes.
✓ autoflake made no changes.
✓ isort made no changes.
10:53:33.24 [INFO] Completed: Lint with docformatter - Docformatter succeeded.
10:53:33.27 [INFO] Completed: Lint with isort - isort succeeded.
10:53:33.29 [INFO] Completed: Lint with autoflake - autoflake succeeded.
10:53:33.37 [INFO] Completed: Lint with Black - Black succeeded.
All done! ✨ 🍰 ✨
1 file would be left unchanged.


10:53:34.41 [INFO] Completed: Lint with Flake8 - Flake8 succeeded.

✓ Black succeeded.
✓ Docformatter succeeded.
✓ Flake8 succeeded.
✓ autoflake succeeded.
✓ isort succeeded.
10:53:40.02 [INFO] Completed: Typecheck using MyPy - MyPy succeeded.
Success: no issues found in 1 source file



✓ MyPy succeeded.
```

After:
```
10:56:48.96 [INFO] Initializing scheduler...
10:56:49.32 [INFO] Scheduler initialized.
10:56:50.71 [INFO] Completed: Format with Autoflake - autoflake made no changes.
10:56:51.79 [INFO] Completed: Format with Black - Black made no changes.
10:56:52.87 [INFO] Completed: Format with docformatter - Docformatter made no changes.
10:56:52.90 [INFO] Completed: Format with isort - isort made no changes.

✓ Black made no changes.
✓ Docformatter made no changes.
✓ autoflake made no changes.
✓ isort made no changes.
10:56:52.92 [INFO] Completed: Lint with docformatter - Docformatter succeeded.
10:56:52.92 [INFO] Completed: Lint with autoflake - autoflake succeeded.
10:56:52.92 [INFO] Completed: Lint with Black - Black succeeded.
10:56:52.92 [INFO] Completed: Lint with isort - isort succeeded.
10:56:54.00 [INFO] Completed: Lint with Flake8 - Flake8 succeeded.

✓ Black succeeded.
✓ Docformatter succeeded.
✓ Flake8 succeeded.
✓ autoflake succeeded.
✓ isort succeeded.
10:56:55.88 [INFO] Completed: Typecheck using MyPy - MyPy succeeded.

✓ MyPy succeeded.
```