### PR TITLE
Adds `.env` file to make vscode auto-imports work correctly out of the box

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,5 @@
 # Sets the python source roots in vscode to match Pants' repo layout
+# Unless it turns out some other IDE relies on this, this file can
+# be removed once #10920 is solved.
 
 PYTHONPATH=$PYTHONPATH:src/python

--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+# Sets the python source roots in vscode to match Pants' repo layout
+
+PYTHONPATH=$PYTHONPATH:src/python


### PR DESCRIPTION
Per [the docs](https://code.visualstudio.com/docs/python/environments#_environment-variable-definitions-file), vs code's Python source roots are defined in a `.env` file in the root of a repo. If such a file does not exist, it makes guesses that are not correct for the Pants repo:

![2022-01-10 at 9 37 AM](https://user-images.githubusercontent.com/622300/148814115-27dd8c53-be16-483e-a799-e387d19cf105.jpg)

When this `.env` file is in place, auto-import works fine out of the box.

![2022-01-10 at 9 40 AM](https://user-images.githubusercontent.com/622300/148814135-0e2e08f3-8c43-4710-94df-a03e68776e62.jpg)

The of this is not needing to correct auto-generated imports nearly as often (normally I'd discover these incorrect imports deep during a pants run)


I'm offering up this PR because I've had the `.env` file sitting in my repo for several months with no ill effects, and accidentally committed it the other day. It doesn't seem to be harmful to any of the tools that I otherwise use in the Pants repo.
