### PR TITLE
[Docker] Fix bug when a putative target address did not exist. (Cherry pick of #14125)

### DIFF
--- a/src/python/pants/backend/docker/util_rules/dependencies.py
+++ b/src/python/pants/backend/docker/util_rules/dependencies.py
@@ -3,6 +3,7 @@
 
 from pants.backend.docker.subsystems.dockerfile_parser import DockerfileInfo, DockerfileInfoRequest
 from pants.backend.docker.target_types import DockerDependenciesField
+from pants.base.specs import AddressSpecs, MaybeEmptySiblingAddresses
 from pants.core.goals.package import PackageFieldSet
 from pants.engine.addresses import Addresses, UnparsedAddressInputs
 from pants.engine.rules import Get, collect_rules, rule
@@ -22,17 +23,28 @@ class InjectDockerDependencies(InjectDependenciesRequest):
 
 @rule
 async def inject_docker_dependencies(request: InjectDockerDependencies) -> InjectedDependencies:
-    """Inspects COPY instructions in the Dockerfile for references to known targets."""
+    """Inspects COPY instructions in the Dockerfile for references to known packagable targets."""
     dockerfile_info = await Get(
         DockerfileInfo, DockerfileInfoRequest(request.dependencies_field.address)
     )
-    targets = await Get(
-        Targets,
+
+    # Parse all putative target addresses.
+    putative_addresses = await Get(
+        Addresses,
         UnparsedAddressInputs(
             dockerfile_info.putative_target_addresses,
             owning_address=None,
         ),
     )
+
+    # Get the target for those addresses that are known.
+    directories = {address.spec_path for address in putative_addresses}
+    all_addresses = await Get(Addresses, AddressSpecs(map(MaybeEmptySiblingAddresses, directories)))
+    targets = await Get(
+        Targets, Addresses((address for address in putative_addresses if address in all_addresses))
+    )
+
+    # Only keep those targets that we can "package".
     package = await Get(FieldSetsPerTarget, FieldSetsPerTargetRequest(PackageFieldSet, targets))
     referenced_targets = (
         field_sets[0].address for field_sets in package.collection if len(field_sets) > 0


### PR DESCRIPTION
The issue was that we attempted to translate all inferred addresses for dependencies to targets, and if they didn't exist, boom.

This fix goes via all known addresses for the relevant directories, and filters the list of inferred addresses down to what is actually defined.
