### PR TITLE
[internal] Further tweak dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,16 +2,13 @@ version: 2
 updates:
   - package-ecosystem: "cargo"
     directory: "/src/rust/engine"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 5
     rebase-strategy: auto
     schedule:
       interval: "weekly" 
-      day: "thursday"
-      time: "12:00"
+      day: "wednesday"
+      time: "03:00"
       timezone: "US/Pacific"
     reviewers:
       - Eric-Arellano
       - stuhood
-    labels:
-      - "rust"
-      - "dependencies"


### PR DESCRIPTION
Remove labels - since it seems they are not desired, see discussion: https://github.com/pantsbuild/pants/pull/14089#issuecomment-1006835891

Also change it to run at a time where GHA CI is mostly idle so those PR don't compete on resources with human generated PRs.