### PR TITLE
[internal] Bump strum_macros from 0.20.1 to 0.23.1 in /src/rust/engine

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -2691,6 +2691,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3067,13 +3073,14 @@ checksum = "7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c"
 
 [[package]]
 name = "strum_macros"
-version = "0.20.1"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
+checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
 dependencies = [
  "heck",
  "proc-macro2 1.0.32",
  "quote 1.0.10",
+ "rustversion",
  "syn 1.0.81",
 ]
 

--- a/src/rust/engine/client/Cargo.toml
+++ b/src/rust/engine/client/Cargo.toml
@@ -19,7 +19,7 @@ nix = "0.20"
 options = { path = "../options" }
 sha2 = "0.9"
 strum = "0.20"
-strum_macros = "0.20"
+strum_macros = "0.23"
 sysinfo = "0.17.1"
 tokio = { version = "1.4", features = ["rt-multi-thread", "macros", "net", "io-std", "io-util"] }
 uname = "0.1"

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -46,7 +46,7 @@ rand = "0.8"
 prost = "0.9"
 prost-types = "0.9"
 strum = "0.20"
-strum_macros = "0.20"
+strum_macros = "0.23"
 tonic = { version = "0.6", features = ["transport", "codegen", "tls", "tls-roots", "prost"] }
 tryfuture = { path = "../tryfuture" }
 

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -16,5 +16,5 @@ tokio = { version = "1.4", features = ["rt"] }
 petgraph = "0.5"
 log = "0.4"
 strum = "0.20"
-strum_macros = "0.20"
+strum_macros = "0.23"
 uuid = { version = "0.8", features = ["v4"] }

--- a/src/rust/engine/workunit_store/src/metrics.rs
+++ b/src/rust/engine/workunit_store/src/metrics.rs
@@ -13,7 +13,7 @@ use strum::IntoEnumIterator;
   Debug,
   strum_macros::AsRefStr,
   strum_macros::EnumIter,
-  strum_macros::ToString,
+  strum_macros::Display,
 )]
 #[strum(serialize_all = "snake_case")]
 pub enum Metric {


### PR DESCRIPTION
See https://github.com/pantsbuild/pants/pull/14136 for details.