### PR TITLE
Add local .pantsrc support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ __pycache__/
 .idea
 /.vscode/
 .cache
-.pantsrc
 .pants.d
 .pants.run
 .pants.workdir.file_lock
@@ -57,5 +56,6 @@ GSYMS
 GTAGS
 .mypy_cache/
 /.pants
+/.pantsrc
 /.venv
 .tool-versions

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ __pycache__/
 .idea
 /.vscode/
 .cache
+.pantsrc
 .pants.d
 .pants.run
 .pants.workdir.file_lock

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,6 @@ GSYMS
 GTAGS
 .mypy_cache/
 /.pants
-/.pantsrc
+/.pants.rc
 /.venv
 .tool-versions

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -663,7 +663,7 @@ class GlobalOptions(Subsystem):
             metavar="<path>",
             # NB: See `--pants-config-files`.
             fingerprint=False,
-            default=["/etc/pantsrc", "~/.pants.rc"],
+            default=["/etc/pantsrc", "~/.pants.rc", ".pantsrc"],
             help=(
                 "Override config with values from these files, using syntax matching that of "
                 "`--pants-config-files`."

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -663,7 +663,7 @@ class GlobalOptions(Subsystem):
             metavar="<path>",
             # NB: See `--pants-config-files`.
             fingerprint=False,
-            default=["/etc/pantsrc", "~/.pants.rc", ".pantsrc"],
+            default=["/etc/pantsrc", "~/.pants.rc", ".pants.rc"],
             help=(
                 "Override config with values from these files, using syntax matching that of "
                 "`--pants-config-files`."


### PR DESCRIPTION
This allows developers to customize their Pants settings without dirtying any repo files. For instance, I like bumping the logging level up to `warn` :wink: 