### PR TITLE
add runtime dependencies field for Apache Thrift for Python

### DIFF
--- a/src/python/pants/backend/codegen/thrift/apache/python/subsystem.py
+++ b/src/python/pants/backend/codegen/thrift/apache/python/subsystem.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import cast
 
+from pants.engine.addresses import UnparsedAddressInputs
 from pants.engine.rules import collect_rules
+from pants.option.custom_types import target_option
 from pants.option.subsystem import Subsystem
 
 
@@ -25,10 +27,27 @@ class ThriftPythonSubsystem(Subsystem):
                 "See `thrift -help` for supported values."
             ),
         )
+        register(
+            "--runtime-dependencies",
+            type=list,
+            member_type=target_option,
+            help=(
+                "A list of addresses to `python_requirement` targets for the runtime "
+                "dependencies needed for generated Python code to work. For example, "
+                "`['3rdparty/python:thrift']`. These dependencies will "
+                "be automatically added to every `thrift_source` target. At the very least, "
+                "this option must be set to a `python_requirement` for the "
+                "`thrift` runtime library."
+            ),
+        )
 
     @property
     def gen_options(self) -> tuple[str, ...]:
         return cast("tuple[str, ...]", tuple(self.options.options))
+
+    @property
+    def runtime_dependencies(self) -> UnparsedAddressInputs:
+        return UnparsedAddressInputs(self.options.runtime_dependencies, owning_address=None)
 
 
 def rules():


### PR DESCRIPTION
Add a `--thrift-python-runtime-dependencies` field to allow adding `thrift` PyPi package automatically as a dependency.

With this PR, Thrift for Python works in forthcoming `example-codegen` repo.

[ci skip-rust]
