### PR TITLE
[internal] java/thrift: register union that was not registered

### DIFF
--- a/src/python/pants/backend/codegen/thrift/apache/java/rules.py
+++ b/src/python/pants/backend/codegen/thrift/apache/java/rules.py
@@ -73,4 +73,5 @@ def rules():
         *collect_rules(),
         *subsystem.rules(),
         UnionRule(GenerateSourcesRequest, GenerateJavaFromThriftRequest),
+        UnionRule(InjectDependenciesRequest, InjectApacheThriftJavaDependencies),
     )


### PR DESCRIPTION
I missed registering the union type needed for runtime deps to be injected with Apache Thrift for Java.

[ci skip-rust]
