### PR TITLE
[internal] Pulls `Coordinate` and `ArtifactRequirement` out into a separate file

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/scala/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/rules.py
@@ -44,12 +44,8 @@ from pants.engine.target import (
 from pants.engine.unions import UnionRule
 from pants.jvm.compile import ClasspathEntry
 from pants.jvm.jdk_rules import JdkSetup
-from pants.jvm.resolve.coursier_fetch import (
-    ArtifactRequirements,
-    Coordinate,
-    MaterializedClasspath,
-    MaterializedClasspathRequest,
-)
+from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
+from pants.jvm.resolve.coursier_fetch import MaterializedClasspath, MaterializedClasspathRequest
 from pants.jvm.resolve.jvm_tool import (
     GatherJvmCoordinatesRequest,
     JvmToolLockfileRequest,

--- a/src/python/pants/backend/java/compile/javac_test.py
+++ b/src/python/pants/backend/java/compile/javac_test.py
@@ -25,12 +25,8 @@ from pants.engine.target import CoarsenedTargets, Targets
 from pants.jvm import jdk_rules, testutil
 from pants.jvm.compile import ClasspathEntry, CompileResult, FallibleClasspathEntry
 from pants.jvm.goals.coursier import rules as coursier_rules
-from pants.jvm.resolve.coursier_fetch import (
-    Coordinate,
-    Coordinates,
-    CoursierLockfileEntry,
-    CoursierResolvedLockfile,
-)
+from pants.jvm.resolve.common import Coordinate, Coordinates
+from pants.jvm.resolve.coursier_fetch import CoursierLockfileEntry, CoursierResolvedLockfile
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.jvm.target_types import JvmArtifactTarget

--- a/src/python/pants/backend/java/dependency_inference/java_parser_launcher.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser_launcher.py
@@ -12,12 +12,8 @@ from pants.engine.fs import CreateDigest, Digest, Directory, FileContent, MergeD
 from pants.engine.process import BashBinary, Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.jvm.jdk_rules import JdkSetup
-from pants.jvm.resolve.coursier_fetch import (
-    ArtifactRequirements,
-    Coordinate,
-    MaterializedClasspath,
-    MaterializedClasspathRequest,
-)
+from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
+from pants.jvm.resolve.coursier_fetch import MaterializedClasspath, MaterializedClasspathRequest
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)

--- a/src/python/pants/backend/scala/compile/scalac.py
+++ b/src/python/pants/backend/scala/compile/scalac.py
@@ -27,12 +27,8 @@ from pants.jvm.compile import (
 )
 from pants.jvm.compile import rules as jvm_compile_rules
 from pants.jvm.jdk_rules import JdkSetup
-from pants.jvm.resolve.coursier_fetch import (
-    ArtifactRequirements,
-    Coordinate,
-    MaterializedClasspath,
-    MaterializedClasspathRequest,
-)
+from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
+from pants.jvm.resolve.coursier_fetch import MaterializedClasspath, MaterializedClasspathRequest
 from pants.jvm.resolve.coursier_setup import Coursier
 from pants.util.logging import LogLevel
 

--- a/src/python/pants/backend/scala/compile/scalac_test.py
+++ b/src/python/pants/backend/scala/compile/scalac_test.py
@@ -21,12 +21,8 @@ from pants.engine.fs import FileDigest
 from pants.engine.target import CoarsenedTargets
 from pants.jvm import jdk_rules, testutil
 from pants.jvm.compile import CompileResult, FallibleClasspathEntry
-from pants.jvm.resolve.coursier_fetch import (
-    Coordinate,
-    Coordinates,
-    CoursierLockfileEntry,
-    CoursierResolvedLockfile,
-)
+from pants.jvm.resolve.common import Coordinate, Coordinates
+from pants.jvm.resolve.coursier_fetch import CoursierLockfileEntry, CoursierResolvedLockfile
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.jvm.target_types import JvmArtifactTarget

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -31,12 +31,8 @@ from pants.engine.process import (
 from pants.engine.rules import collect_rules, rule
 from pants.jvm.compile import ClasspathEntry
 from pants.jvm.jdk_rules import JdkSetup
-from pants.jvm.resolve.coursier_fetch import (
-    ArtifactRequirements,
-    Coordinate,
-    MaterializedClasspath,
-    MaterializedClasspathRequest,
-)
+from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
+from pants.jvm.resolve.coursier_fetch import MaterializedClasspath, MaterializedClasspathRequest
 from pants.option.global_options import ProcessCleanupOption
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel

--- a/src/python/pants/backend/scala/goals/repl.py
+++ b/src/python/pants/backend/scala/goals/repl.py
@@ -12,12 +12,8 @@ from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.jvm.classpath import Classpath
 from pants.jvm.jdk_rules import JdkSetup
-from pants.jvm.resolve.coursier_fetch import (
-    ArtifactRequirements,
-    Coordinate,
-    MaterializedClasspath,
-    MaterializedClasspathRequest,
-)
+from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
+from pants.jvm.resolve.coursier_fetch import MaterializedClasspath, MaterializedClasspathRequest
 from pants.util.logging import LogLevel
 
 

--- a/src/python/pants/jvm/goals/coursier.py
+++ b/src/python/pants/jvm/goals/coursier.py
@@ -21,12 +21,8 @@ from pants.engine.fs import (
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
 from pants.engine.target import AllTargets
-from pants.jvm.resolve.coursier_fetch import (
-    ArtifactRequirement,
-    ArtifactRequirements,
-    CoursierError,
-    CoursierResolvedLockfile,
-)
+from pants.jvm.resolve.common import ArtifactRequirement, ArtifactRequirements
+from pants.jvm.resolve.coursier_fetch import CoursierError, CoursierResolvedLockfile
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmArtifactCompatibleResolvesField
 from pants.util.frozendict import FrozenDict

--- a/src/python/pants/jvm/goals/coursier_integration_test.py
+++ b/src/python/pants/jvm/goals/coursier_integration_test.py
@@ -13,12 +13,8 @@ from pants.core.util_rules.external_tool import rules as external_tool_rules
 from pants.engine.fs import FileDigest
 from pants.jvm.goals.coursier import CoursierResolve
 from pants.jvm.goals.coursier import rules as coursier_goal_rules
-from pants.jvm.resolve.coursier_fetch import (
-    Coordinate,
-    Coordinates,
-    CoursierLockfileEntry,
-    CoursierResolvedLockfile,
-)
+from pants.jvm.resolve.common import Coordinate, Coordinates
+from pants.jvm.resolve.coursier_fetch import CoursierLockfileEntry, CoursierResolvedLockfile
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.jvm.target_types import JvmArtifactTarget

--- a/src/python/pants/jvm/jdk_rules.py
+++ b/src/python/pants/jvm/jdk_rules.py
@@ -15,7 +15,8 @@ from pants.engine.internals.selectors import Get
 from pants.engine.process import BashBinary, FallibleProcessResult, Process, ProcessCacheScope
 from pants.engine.rules import collect_rules, rule
 from pants.jvm.compile import ClasspathEntry
-from pants.jvm.resolve.coursier_fetch import Coordinate, Coordinates, CoursierLockfileEntry
+from pants.jvm.resolve.common import Coordinate, Coordinates
+from pants.jvm.resolve.coursier_fetch import CoursierLockfileEntry
 from pants.jvm.resolve.coursier_setup import Coursier
 from pants.jvm.subsystems import JvmSubsystem
 from pants.util.logging import LogLevel

--- a/src/python/pants/jvm/resolve/common.py
+++ b/src/python/pants/jvm/resolve/common.py
@@ -1,0 +1,193 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable
+from urllib.parse import quote_plus as url_quote_plus
+
+from pants.engine.collection import DeduplicatedCollection
+from pants.engine.target import Target
+from pants.jvm.target_types import (
+    JvmArtifactArtifactField,
+    JvmArtifactFieldSet,
+    JvmArtifactGroupField,
+    JvmArtifactJarSourceField,
+    JvmArtifactUrlField,
+    JvmArtifactVersionField,
+)
+
+
+class InvalidCoordinateString(Exception):
+    """The coordinate string being passed is invalid or malformed."""
+
+    def __init__(self, coords: str) -> None:
+        super().__init__(f"Received invalid artifact coordinates: {coords}")
+
+
+@dataclass(frozen=True)
+class Coordinate:
+    """A single Maven-style coordinate for a JVM dependency.
+
+    Coursier uses at least two string serializations of coordinates:
+    1. A format that is accepted by the Coursier CLI which uses trailing attributes to specify
+       optional fields like `packaging`/`type`, `classifier`, `url`, etc. See `to_coord_arg_str`.
+    2. A format in the JSON report, which uses token counts to specify optional fields. We
+       additionally use this format in our own lockfile. See `to_coord_str` and `from_coord_str`.
+    """
+
+    REGEX = re.compile("([^: ]+):([^: ]+)(:([^: ]*)(:([^: ]+))?)?:([^: ]+)")
+
+    group: str
+    artifact: str
+    version: str
+    packaging: str = "jar"
+    classifier: str | None = None
+
+    # True to enforce that the exact declared version of a coordinate is fetched, rather than
+    # allowing dependency resolution to adjust the version when conflicts occur.
+    strict: bool = True
+
+    @staticmethod
+    def from_json_dict(data: dict) -> Coordinate:
+        return Coordinate(
+            group=data["group"],
+            artifact=data["artifact"],
+            version=data["version"],
+            packaging=data.get("packaging", "jar"),
+            classifier=data.get("classifier", None),
+        )
+
+    def to_json_dict(self) -> dict:
+        ret = {
+            "group": self.group,
+            "artifact": self.artifact,
+            "version": self.version,
+            "packaging": self.packaging,
+            "classifier": self.classifier,
+        }
+        return ret
+
+    @classmethod
+    def from_coord_str(cls, s: str) -> Coordinate:
+        """Parses from a coordinate string with optional `packaging` and `classifier` coordinates.
+
+        See the classdoc for more information on the format.
+
+        Using Aether's implementation as reference
+        http://www.javased.com/index.php?source_dir=aether-core/aether-api/src/main/java/org/eclipse/aether/artifact/DefaultArtifact.java
+
+        ${organisation}:${artifact}[:${packaging}[:${classifier}]]:${version}
+
+        See also: `to_coord_str`.
+        """
+
+        parts = Coordinate.REGEX.match(s)
+        if parts is not None:
+            packaging_part = parts.group(4)
+            return cls(
+                group=parts.group(1),
+                artifact=parts.group(2),
+                packaging=packaging_part if packaging_part is not None else "jar",
+                classifier=parts.group(6),
+                version=parts.group(7),
+            )
+        else:
+            raise InvalidCoordinateString(s)
+
+    def as_requirement(self) -> ArtifactRequirement:
+        """Creates a `RequirementCoordinate` from a `Coordinate`."""
+        return ArtifactRequirement(coordinate=self)
+
+    def to_coord_str(self, versioned: bool = True) -> str:
+        """Renders the coordinate in Coursier's JSON-report format, which does not use attributes.
+
+        See also: `from_coord_str`.
+        """
+        unversioned = f"{self.group}:{self.artifact}"
+        if self.classifier is not None:
+            unversioned += f":{self.packaging}:{self.classifier}"
+        elif self.packaging != "jar":
+            unversioned += f":{self.packaging}"
+
+        version_suffix = ""
+        if versioned:
+            version_suffix = f":{self.version}"
+        return f"{unversioned}{version_suffix}"
+
+    def to_coord_arg_str(self, extra_attrs: dict[str, str] | None = None) -> str:
+        """Renders the coordinate in Coursier's CLI input format.
+
+        The CLI input format uses trailing key-val attributes to specify `packaging`, `url`, etc.
+
+        See https://github.com/coursier/coursier/blob/b5d5429a909426f4465a9599d25c678189a54549/modules/coursier/shared/src/test/scala/coursier/parse/DependencyParserTests.scala#L7
+        """
+        attrs = dict(extra_attrs or {})
+        if self.packaging != "jar":
+            # NB: Coursier refers to `packaging` as `type` internally.
+            attrs["type"] = self.packaging
+        if self.classifier:
+            attrs["classifier"] = self.classifier
+        attrs_sep_str = "," if attrs else ""
+        attrs_str = ",".join((f"{k}={v}" for k, v in attrs.items()))
+        return f"{self.group}:{self.artifact}:{self.version}{attrs_sep_str}{attrs_str}"
+
+
+class Coordinates(DeduplicatedCollection[Coordinate]):
+    """An ordered list of `Coordinate`s."""
+
+
+@dataclass(frozen=True)
+class ArtifactRequirement:
+    """A single Maven-style coordinate for a JVM dependency, along with information of how to fetch
+    the dependency if it is not to be fetched from a Maven repository."""
+
+    coordinate: Coordinate
+
+    url: str | None = None
+    jar: JvmArtifactJarSourceField | None = None
+
+    @classmethod
+    def from_jvm_artifact_target(cls, target: Target) -> ArtifactRequirement:
+        if not JvmArtifactFieldSet.is_applicable(target):
+            raise AssertionError(
+                "`ArtifactRequirement.from_jvm_artifact_target()` only works on targets with "
+                "`JvmArtifactFieldSet` fields present."
+            )
+        return ArtifactRequirement(
+            coordinate=Coordinate(
+                group=target[JvmArtifactGroupField].value,
+                artifact=target[JvmArtifactArtifactField].value,
+                version=target[JvmArtifactVersionField].value,
+            ),
+            url=target[JvmArtifactUrlField].value,
+            jar=(
+                target[JvmArtifactJarSourceField]
+                if target[JvmArtifactJarSourceField].value
+                else None
+            ),
+        )
+
+    def to_coord_arg_str(self) -> str:
+        return self.coordinate.to_coord_arg_str(
+            {"url": url_quote_plus(self.url)} if self.url else {}
+        )
+
+    def to_metadata_str(self) -> str:
+        return self.coordinate.to_coord_arg_str(
+            {
+                "url": self.url or "not_provided",
+                "jar": self.jar.address.spec if self.jar else "not_provided",
+            }
+        )
+
+
+# TODO: Consider whether to carry classpath scope in some fashion via ArtifactRequirements.
+class ArtifactRequirements(DeduplicatedCollection[ArtifactRequirement]):
+    """An ordered list of Coordinates used as requirements."""
+
+    @classmethod
+    def from_coordinates(cls, coordinates: Iterable[Coordinate]) -> ArtifactRequirements:
+        return ArtifactRequirements(coord.as_requirement() for coord in coordinates)

--- a/src/python/pants/jvm/resolve/coursier_fetch_filter_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_filter_test.py
@@ -9,12 +9,8 @@ from unittest import mock
 import pytest
 
 from pants.engine.fs import EMPTY_DIGEST
-from pants.jvm.resolve.coursier_fetch import (
-    Coordinate,
-    Coordinates,
-    CoursierLockfileEntry,
-    CoursierResolvedLockfile,
-)
+from pants.jvm.resolve.common import Coordinate, Coordinates
+from pants.jvm.resolve.coursier_fetch import CoursierLockfileEntry, CoursierResolvedLockfile
 from pants.jvm.resolve.key import CoursierResolveKey
 
 coord1 = Coordinate("test", "art1", "1.0.0")

--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -14,14 +14,13 @@ from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.process import ProcessExecutionFailure
 from pants.engine.target import Targets
 from pants.jvm.compile import ClasspathEntry
-from pants.jvm.resolve.coursier_fetch import (
+from pants.jvm.resolve.common import (
     ArtifactRequirement,
     ArtifactRequirements,
     Coordinate,
     Coordinates,
-    CoursierLockfileEntry,
-    CoursierResolvedLockfile,
 )
+from pants.jvm.resolve.coursier_fetch import CoursierLockfileEntry, CoursierResolvedLockfile
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.target_types import JvmArtifactJarSourceField, JvmArtifactTarget
 from pants.jvm.testutil import maybe_skip_jdk_test

--- a/src/python/pants/jvm/resolve/coursier_fetch_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_test.py
@@ -12,7 +12,8 @@ from pants.backend.java.target_types import DeployJarTarget, JavaSourcesGenerato
 from pants.backend.java.target_types import rules as target_types_rules
 from pants.core.util_rules import config_files, source_files
 from pants.engine.addresses import Address, Addresses
-from pants.jvm.resolve.coursier_fetch import Coordinate, NoCompatibleResolve
+from pants.jvm.resolve.common import Coordinate
+from pants.jvm.resolve.coursier_fetch import NoCompatibleResolve
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.key import CoursierResolveKey
 from pants.jvm.target_types import JvmArtifactTarget

--- a/src/python/pants/jvm/resolve/jvm_tool.py
+++ b/src/python/pants/jvm/resolve/jvm_tool.py
@@ -26,12 +26,8 @@ from pants.engine.rules import collect_rules, goal_rule, rule
 from pants.engine.target import Targets
 from pants.engine.unions import UnionMembership, union
 from pants.jvm.resolve import coursier_fetch
-from pants.jvm.resolve.coursier_fetch import (
-    ArtifactRequirement,
-    ArtifactRequirements,
-    Coordinate,
-    CoursierResolvedLockfile,
-)
+from pants.jvm.resolve.common import ArtifactRequirement, ArtifactRequirements, Coordinate
+from pants.jvm.resolve.coursier_fetch import CoursierResolvedLockfile
 from pants.jvm.resolve.key import CoursierResolveKey
 from pants.jvm.target_types import JvmArtifactFieldSet
 from pants.option.subsystem import Subsystem

--- a/src/python/pants/jvm/resolve/jvm_tool_test.py
+++ b/src/python/pants/jvm/resolve/jvm_tool_test.py
@@ -13,7 +13,7 @@ from pants.core.util_rules.external_tool import rules as external_tool_rules
 from pants.engine.fs import Digest, DigestContents
 from pants.engine.rules import SubsystemRule, rule
 from pants.jvm.resolve import jvm_tool
-from pants.jvm.resolve.coursier_fetch import ArtifactRequirements, Coordinate
+from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.jvm.resolve.jvm_tool import (

--- a/src/python/pants/jvm/test/junit_test.py
+++ b/src/python/pants/jvm/test/junit_test.py
@@ -23,12 +23,8 @@ from pants.engine.fs import FileDigest
 from pants.engine.target import CoarsenedTargets
 from pants.jvm import classpath
 from pants.jvm.jdk_rules import rules as java_util_rules
-from pants.jvm.resolve.coursier_fetch import (
-    Coordinate,
-    Coordinates,
-    CoursierLockfileEntry,
-    CoursierResolvedLockfile,
-)
+from pants.jvm.resolve.common import Coordinate, Coordinates
+from pants.jvm.resolve.coursier_fetch import CoursierLockfileEntry, CoursierResolvedLockfile
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.jvm.target_types import JvmArtifactTarget


### PR DESCRIPTION
This commit helps avoid an irreconcilable circular import in an upcoming PR, and otherwise shortens `coursier_fetch.py`, which is otherwise unnecessarily long and complicated.

Enjoy.