### PR TITLE
[internal] Hotfix `fmt` crashing on non-formattable targets

### DIFF
--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -170,7 +170,8 @@ async def fmt(
         for fmt_request in union_membership[FmtRequest]:
             if fmt_request.field_set_type.is_applicable(target):  # type: ignore[misc]
                 fmt_requests.append(fmt_request)
-        targets_by_fmt_request_order[tuple(fmt_requests)].append(target)
+        if fmt_requests:
+            targets_by_fmt_request_order[tuple(fmt_requests)].append(target)
 
     # Spawn sequential formatting per unique sequence of FmtRequests.
     if fmt_subsystem.per_file_caching:


### PR DESCRIPTION
We'd try running the `_LanguageFmts` rule on targets with no applicable `FmtRequests`, which is not necessary. It would then crash when trying to call `tgt[SourceFiles]` on the code.

Fixes https://github.com/pantsbuild/pants/pull/14166.