### PR TITLE
Fix #14153 by adding file/lineno to error lines

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -187,7 +187,7 @@ async def infer_python_dependencies_via_imports(
 
     owners_per_import = await MultiGet(
         Get(PythonModuleOwners, PythonModule(imported_module))
-        for imported_module in detected_imports
+        for imported_module in detected_imports.keys()
     )
 
     merged_result: set[Address] = set()
@@ -210,10 +210,14 @@ async def infer_python_dependencies_via_imports(
 
     unowned_dependency_behavior = python_infer_subsystem.unowned_dependency_behavior
     if unowned_imports and unowned_dependency_behavior is not UnownedDependencyUsage.DoNothing:
+        unowned_imports_with_lines = [
+            f"{modname} ({request.sources_field.address.filename}:{detected_imports[modname]})"
+            for modname in sorted(unowned_imports)
+        ]
         raise_error = unowned_dependency_behavior is UnownedDependencyUsage.RaiseError
         log = logger.error if raise_error else logger.warning
         log(
-            f"The following imports in {address} have no owners:\n\n{bullet_list(unowned_imports)}\n\n"
+            f"The following imports in {address} have no owners:\n\n{bullet_list(unowned_imports_with_lines)}\n\n"
             "If you are expecting this import to be provided by your own firstparty code, ensure that it is contained within a source root. "
             "Otherwise if you are using a requirements file, consider adding the relevant package.\n"
             "Otherwise consider declaring a `python_requirement_library` target, which can then be inferred.\n"

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -211,8 +211,8 @@ async def infer_python_dependencies_via_imports(
     unowned_dependency_behavior = python_infer_subsystem.unowned_dependency_behavior
     if unowned_imports and unowned_dependency_behavior is not UnownedDependencyUsage.DoNothing:
         unowned_imports_with_lines = [
-            f"{modname} ({request.sources_field.address.filename}:{detected_imports[modname]})"
-            for modname in sorted(unowned_imports)
+            f"{module_name} ({request.sources_field.file_path}:{detected_imports[module_name]})"
+            for module_name in sorted(unowned_imports)
         ]
         raise_error = unowned_dependency_behavior is UnownedDependencyUsage.RaiseError
         log = logger.error if raise_error else logger.warning

--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -298,7 +298,7 @@ def test_infer_python_strict(caplog) -> None:
     run_dep_inference(Address("src/python", relative_file_path="cheesey.py"), "warning")
     assert len(caplog.records) == 1
     assert "The following imports in src/python/cheesey.py have no owners:" in caplog.text
-    assert "  * venezuelan_beaver_cheese" in caplog.text
+    assert "  * venezuelan_beaver_cheese (src/python/cheesey.py:1)" in caplog.text
 
     # Now test with "error"
     caplog.clear()
@@ -308,7 +308,7 @@ def test_infer_python_strict(caplog) -> None:
     assert isinstance(exc_info.value.wrapped_exceptions[0], UnownedDependencyError)
     assert len(caplog.records) == 2  # one for the error being raised and one for our message
     assert "The following imports in src/python/cheesey.py have no owners:" in caplog.text
-    assert "  * venezuelan_beaver_cheese" in caplog.text
+    assert "  * venezuelan_beaver_cheese (src/python/cheesey.py:1)" in caplog.text
 
     caplog.clear()
 

--- a/src/python/pants/backend/python/dependency_inference/scripts/import_parser.py
+++ b/src/python/pants/backend/python/dependency_inference/scripts/import_parser.py
@@ -32,7 +32,7 @@ class AstVisitor(ast.NodeVisitor):
         self._package_parts = package_parts
         self._contents_lines = contents.decode(errors="ignore").splitlines()
         # N.B. use `setdefault` when adding imports
-        self.imports = {}  # maps modname to first lineno of occurance
+        self.imports = {}  # maps module_name to first lineno of occurance
 
     def maybe_add_string_import(self, node, s):
         if STRING_IMPORT_REGEX.match(s):

--- a/src/python/pants/backend/python/dependency_inference/scripts/import_parser.py
+++ b/src/python/pants/backend/python/dependency_inference/scripts/import_parser.py
@@ -3,11 +3,14 @@
 # -*- coding: utf-8 -*-
 
 # NB: This must be compatible with Python 2.7 and 3.5+.
+# NB: If you're needing to debug this, an easy way is to just invoke it on a file.
+#   E.g. `MIN_DOTS=1 STRING_IMPORTS=N python3 src/python/pants/backend/python/dependency_inference/scripts/import_parser.py FILENAME`
 
 from __future__ import print_function, unicode_literals
 
 import ast
 import itertools
+import json
 import os
 import re
 import sys
@@ -28,11 +31,12 @@ class AstVisitor(ast.NodeVisitor):
     def __init__(self, package_parts, contents):
         self._package_parts = package_parts
         self._contents_lines = contents.decode(errors="ignore").splitlines()
-        self.imports = set()
+        # N.B. use `setdefault` when adding imports
+        self.imports = {}  # maps modname to first lineno of occurance
 
-    def maybe_add_string_import(self, s):
+    def maybe_add_string_import(self, node, s):
         if STRING_IMPORT_REGEX.match(s):
-            self.imports.add(s)
+            self.imports.setdefault(s, node.lineno)
 
     @staticmethod
     def _is_pragma_ignored(line):
@@ -47,23 +51,23 @@ class AstVisitor(ast.NodeVisitor):
         token_iter = tokenize.generate_tokens(lambda: next(node_lines_iter))
 
         def consume_until(string):
-            return list(itertools.takewhile(lambda t: t[1] != string, token_iter))
+            for token in token_iter:
+                if token[1] == string:
+                    return token
 
         consume_until("import")
 
         # N.B. The names in this list are in the same order as the import statement
         for alias in node.names:
-            consume_until(alias.name.split(".")[-1])
+            token = consume_until(alias.name.split(".")[-1])
 
             # N.B. Keep consuming lines while they end in a line-continuation
             #   (unfortunately `tokenize` doesn't capture this)
-            line = "\\"
-            while line.endswith("\\"):
+            while token[4].endswith("\\"):
                 token = next(token_iter)
-                line = token[4]
 
-            if not self._is_pragma_ignored(line):
-                self.imports.add(import_prefix + alias.name)
+            if not self._is_pragma_ignored(token[4]):
+                self.imports.setdefault(import_prefix + alias.name, token[3][0] + node.lineno - 1)
             if alias.asname and token[1] != alias.asname:
                 consume_until(alias.asname)
 
@@ -94,8 +98,9 @@ class AstVisitor(ast.NodeVisitor):
                 name = str(node.args[0].value)
 
             if name is not None:
-                if not self._is_pragma_ignored(self._contents_lines[node.args[0].lineno - 1]):
-                    self.imports.add(name)
+                lineno = node.args[0].lineno
+                if not self._is_pragma_ignored(self._contents_lines[lineno - 1]):
+                    self.imports.setdefault(name, lineno)
                 return
 
         self.generic_visit(node)
@@ -109,7 +114,7 @@ if os.environ["STRING_IMPORTS"] == "y":
         def visit_Str(self, node):
             try:
                 val = node.s.decode("utf8") if isinstance(node.s, bytes) else node.s
-                self.maybe_add_string_import(val)
+                self.maybe_add_string_import(node, val)
             except UnicodeError:
                 pass
 
@@ -118,7 +123,7 @@ if os.environ["STRING_IMPORTS"] == "y":
     elif sys.version_info[0:2] < (3, 8):
 
         def visit_Str(self, node):
-            self.maybe_add_string_import(node.s)
+            self.maybe_add_string_import(node, node.s)
 
         setattr(AstVisitor, "visit_Str", visit_Str)
 
@@ -126,7 +131,7 @@ if os.environ["STRING_IMPORTS"] == "y":
 
         def visit_Constant(self, node):
             if isinstance(node.value, str):
-                self.maybe_add_string_import(node.value)
+                self.maybe_add_string_import(node, node.value)
 
         setattr(AstVisitor, "visit_Constant", visit_Constant)
 
@@ -146,7 +151,8 @@ def main(filename):
     # We have to be careful to set the encoding explicitly and write raw bytes ourselves.
     # See below for where we explicitly decode.
     buffer = sys.stdout if sys.version_info[0:2] == (2, 7) else sys.stdout.buffer
-    buffer.write("\n".join(sorted(visitor.imports)).encode("utf8"))
+    output = json.dumps(visitor.imports)
+    buffer.write(output.encode("utf8"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Before:
```
08:27:12.67 [ERROR] The following imports in path/to/file.py:address have no owners:

  * mod.name
```

After:
```
08:27:12.67 [ERROR] The following imports in path/to/file.py:address have no owners:

  * mod.name (path/to/file.py:255)
```