### PR TITLE
[internal] fix typos in codegen registration

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/java/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/java/rules.py
@@ -4,7 +4,7 @@
 
 from pants.backend.codegen.protobuf.protoc import Protoc
 from pants.backend.codegen.protobuf.target_types import ProtobufSourceField
-from pants.backend.python.target_types import PythonSourceField
+from pants.backend.java.target_types import JavaSourceField
 from pants.backend.python.util_rules import pex
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.core.util_rules.source_files import SourceFilesRequest
@@ -34,7 +34,7 @@ from pants.util.logging import LogLevel
 
 class GenerateJavaFromProtobufRequest(GenerateSourcesRequest):
     input = ProtobufSourceField
-    output = PythonSourceField
+    output = JavaSourceField
 
 
 @rule(desc="Generate Java from Protobuf", level=LogLevel.DEBUG)

--- a/src/python/pants/backend/codegen/thrift/scrooge/scala/rules.py
+++ b/src/python/pants/backend/codegen/thrift/scrooge/scala/rules.py
@@ -6,7 +6,7 @@ from pants.backend.codegen.thrift.scrooge.rules import (
 )
 from pants.backend.codegen.thrift.scrooge.scala.subsystem import ScroogeScalaSubsystem
 from pants.backend.codegen.thrift.target_types import ThriftDependenciesField, ThriftSourceField
-from pants.backend.java.target_types import JavaSourceField
+from pants.backend.scala.target_types import ScalaSourceField
 from pants.engine.addresses import Addresses, UnparsedAddressInputs
 from pants.engine.fs import AddPrefix, Digest, Snapshot
 from pants.engine.internals.selectors import Get
@@ -24,7 +24,7 @@ from pants.util.logging import LogLevel
 
 class GenerateScalaFromThriftRequest(GenerateSourcesRequest):
     input = ThriftSourceField
-    output = JavaSourceField
+    output = ScalaSourceField
 
 
 class InjectScroogeScalaDependencies(InjectDependenciesRequest):


### PR DESCRIPTION
Thanks to copy/paste errors, I introduced bugs in registration of two of the codegen backends. Fix the target types to be correct.

[ci skip-rust]
