### PR TITLE
Deprecate `sourcefile-validation` in favor of `regex-lint`

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -164,7 +164,7 @@ extra_env_vars = [
 [coverage-py]
 interpreter_constraints = [">=3.7,<3.10"]
 
-[sourcefile-validation]
+[regex-lint]
 config = "@build-support/regexes/config.yaml"
 
 [generate-lockfiles]

--- a/src/python/pants/backend/project_info/regex_lint.py
+++ b/src/python/pants/backend/project_info/regex_lint.py
@@ -54,9 +54,7 @@ class ValidateSubsystem(GoalSubsystem):
             default=DetailLevel.nonmatching,
             help="How much detail to emit to the console.",
             removal_version="2.11.0.dev0",
-            removal_hint=(
-                "Use `[sourcefile-validation].detail_level` instead, which behaves the same."
-            ),
+            removal_hint="Use `[regex-lint].detail_level` instead, which behaves the same.",
         )
 
 
@@ -94,9 +92,12 @@ class ValidationConfig:
         )
 
 
-class SourceFileValidation(Subsystem):
-    options_scope = "sourcefile-validation"
-    help = "Configuration for source file validation."
+class RegexLintSubsystem(Subsystem):
+    options_scope = "regex-lint"
+    help = "Lint your code using regex patterns, e.g. to check for copyright headers."
+
+    deprecated_options_scope = "sourcefile-validation"
+    deprecated_options_scope_removal_version = "2.11.0.dev0"
 
     @classmethod
     def register_options(cls, register):
@@ -309,9 +310,9 @@ async def validate(
     console: Console,
     specs_snapshot: SpecsSnapshot,
     validate_subsystem: ValidateSubsystem,
-    source_file_validation: SourceFileValidation,
+    regex_lint_subsystem: RegexLintSubsystem,
 ) -> Validate:
-    multi_matcher = source_file_validation.get_multi_matcher()
+    multi_matcher = regex_lint_subsystem.get_multi_matcher()
     if multi_matcher is None:
         logger.error(
             "You must set the option `[sourcefile-validation].config` for the "
@@ -325,7 +326,7 @@ async def validate(
         for file_content in sorted(digest_contents, key=lambda fc: fc.path)
     )
 
-    detail_level = source_file_validation.detail_level(validate_subsystem)
+    detail_level = regex_lint_subsystem.detail_level(validate_subsystem)
     num_matched_all = 0
     num_nonmatched_some = 0
     for rmr in regex_match_results:

--- a/src/python/pants/backend/project_info/regex_lint_test.py
+++ b/src/python/pants/backend/project_info/regex_lint_test.py
@@ -5,7 +5,7 @@ import textwrap
 
 import pytest
 
-from pants.backend.project_info.source_file_validator import (
+from pants.backend.project_info.regex_lint import (
     Matcher,
     MultiMatcher,
     RegexMatchResult,

--- a/src/python/pants/backend/project_info/register.py
+++ b/src/python/pants/backend/project_info/register.py
@@ -13,7 +13,7 @@ from pants.backend.project_info import (
     list_targets,
     paths,
     peek,
-    source_file_validator,
+    regex_lint,
 )
 
 
@@ -28,5 +28,5 @@ def rules():
         *list_targets.rules(),
         *paths.rules(),
         *peek.rules(),
-        *source_file_validator.rules(),
+        *regex_lint.rules(),
     ]


### PR DESCRIPTION
This checker will soon be moved from the `validate` goal to the `lint` goal. When we do that, we need to have a name for the linter, e.g. in this message:

```
flake8 succeeded.
isort failed.
regex-lint succeeded.
```

We bike-shedded in Slack and came up with `regex-lint`:

- `lint` is better than `validate` because this is the `lint` goal
- `regex` is because the user has to provide regex patterns

We rejected the similar `regex-linter` because that sounds like it is linting regex expressions themselves.

[ci skip-rust]