### PR TITLE
upgrade to Rust v1.58.0

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -52,7 +52,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.57.0-*
+        path: '~/.rustup/toolchains/1.58.0-*
 
           ~/.rustup/update-hashes
 
@@ -203,7 +203,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.57.0-*
+        path: '~/.rustup/toolchains/1.58.0-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,7 +52,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.57.0-*
+        path: '~/.rustup/toolchains/1.58.0-*
 
           ~/.rustup/update-hashes
 
@@ -202,7 +202,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.57.0-*
+        path: '~/.rustup/toolchains/1.58.0-*
 
           ~/.rustup/update-hashes
 
@@ -399,7 +399,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.57.0-*
+        path: '~/.rustup/toolchains/1.58.0-*
 
           ~/.rustup/update-hashes
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.57.0"
+channel = "1.58.0"
 components = [
   "cargo",
   "clippy",

--- a/src/rust/engine/async_value/src/lib.rs
+++ b/src/rust/engine/async_value/src/lib.rs
@@ -99,6 +99,7 @@ impl<T: Clone + Send + Sync + 'static> AsyncValueReceiver<T> {
         return Some(value.clone());
       }
 
+      #[allow(clippy::question_mark)]
       if item_receiver.changed().await.is_err() {
         return None;
       }


### PR DESCRIPTION
Upgrade to Rust v1.58.0.

Changes:
- [Captured identifiers in format strings](https://blog.rust-lang.org/2022/01/13/Rust-1.58.0.html#captured-identifiers-in-format-strings)
- [More #[must_use] in the standard library](https://blog.rust-lang.org/2022/01/13/Rust-1.58.0.html#more-must_use-in-the-standard-library)