### PR TITLE
More accurate reported runtime when `pantsd` is in use

### DIFF
--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -113,6 +113,12 @@ class DaemonPantsRunner:
             # Capture the client's start time, which we propagate here in order to get an accurate
             # view of total time.
             env_start_time = env.get("PANTSD_RUNTRACKER_CLIENT_START_TIME", None)
+            if not env_start_time:
+                # NB: We warn rather than erroring here because it eases use of non-Pants nailgun
+                # clients for testing.
+                logger.warning(
+                    "No start time was reported by the client! Metrics may be inaccurate."
+                )
             start_time = float(env_start_time) if env_start_time else time.time()
 
             options_bootstrapper = OptionsBootstrapper.create(

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -83,7 +83,7 @@ class PantsRunner:
             if self._should_run_with_pantsd(global_bootstrap_options):
                 try:
                     remote_runner = RemotePantsRunner(self.args, self.env, options_bootstrapper)
-                    return remote_runner.run()
+                    return remote_runner.run(start_time)
                 except RemotePantsRunner.Fallback as e:
                     logger.warning(f"Client exception: {e!r}, falling back to non-daemon mode")
 


### PR DESCRIPTION
The `PantsLoader` captures a `start_time` as early as possible, which is then supposed to be propagated all the way to the `pantsd` server via environment variables. But the `RemotePantsRunner` was calculating its own start time, which would miss out on some of the startup costs (options parsing in particular).

[ci skip-rust]
[ci skip-build-wheels]