### PR TITLE
RFC: Add "implicit" dependees flag option

### DIFF
--- a/src/python/pants/backend/go/lint/gofmt/rules.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules.py
@@ -36,7 +36,7 @@ class GofmtFieldSet(FieldSet):
         return tgt.get(SkipGofmtField).value
 
 
-class GofmtRequest(FmtRequest):
+class GofmtRequest(FmtRequest, LintRequest):
     field_set_type = GofmtFieldSet
 
 

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -38,6 +38,7 @@ from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 from pants.util.meta import frozen_after_init
 from pants.util.strutil import pluralize
+from pants.vcs.changed import DependeesOption
 
 
 @dataclass(frozen=True)
@@ -71,6 +72,7 @@ class PylintPartition:
 
 class PylintRequest(LintRequest):
     field_set_type = PylintFieldSet
+    requires_dependees = DependeesOption.TRANSITIVE
 
 
 def generate_argv(source_files: SourceFiles, pylint: Pylint) -> Tuple[str, ...]:


### PR DESCRIPTION
(Fixes https://github.com/pantsbuild/pants/issues/14170)
(Also, fishing for thoughts at the moment)

This introduces a new flag for `--changed-dependees`, "implicit". The flag defaults to handing goals no dependees (*) but signals to union-membership goals to run union members on whichever `DependeeOption` makes the most sense (no dependees vs. direct vs. indirect).

As demonstrated by example:

`./pants --change-since=main --changed-dependees=transitive lint` hands 519 files to `black`, `docformatter`, `flake8`, and `isort`, but each and every one of those tools wouldn't be affected by a dependee change.

By contrast (and assuming the pants repo used `pylint`) that command would hand 4 files to `black`, `docformatter`, `flake8`, and `isort`, and 5190 files to `pylint`.

This can have a large impact on a decent change to a large monorepo (I hope to post numbers for my monorepo soon)

Additionally, requiring tools to declare (or inherit) `requires_dependees` _could_ possibly simplify per-tool setups (however that might be a bit too technically challenging)

Open Questions:
- What should the default be for the targets when `--changed-dependees=implicit` is used?
- Should `LintRequest` subclasses be forced to declare `requires_dependees`, as to not let them accidentally use `NONE`?
- How do people feel about this change, in general?
- Are there any other goals that could benefit from this?

