### PR TITLE
[internal] rename some codegen scopes to put language first

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -183,7 +183,7 @@ java_parser = "src/python/pants/backend/java/dependency_inference/java_parser.lo
 # Has the same isolation requirements as `java_parser`.
 scala_parser = "src/python/pants/backend/scala/dependency_inference/scala_parser.lockfile"
 
-[avro-java]
+[java-avro]
 lockfile = "src/python/pants/backend/codegen/avro/java/avro-tools.default.lockfile.txt"
 
 [junit]

--- a/src/python/pants/backend/codegen/avro/java/subsystem.py
+++ b/src/python/pants/backend/codegen/avro/java/subsystem.py
@@ -6,7 +6,7 @@ from pants.util.docutil import git_url
 
 
 class AvroSubsystem(JvmToolBase):
-    options_scope = "avro-java"
+    options_scope = "java-avro"
     help = "Avro IDL compiler (https://avro.apache.org/)."
 
     default_version = "1.11.0"

--- a/src/python/pants/backend/codegen/thrift/apache/java/subsystem.py
+++ b/src/python/pants/backend/codegen/thrift/apache/java/subsystem.py
@@ -11,7 +11,7 @@ from pants.option.subsystem import Subsystem
 
 
 class ApacheThriftJavaSubsystem(Subsystem):
-    options_scope = "apache-thrift-java"
+    options_scope = "java-thrift"
     help = "Options specific to generating Java from Thrift using the Apache Thrift generator"
 
     @classmethod

--- a/src/python/pants/backend/codegen/thrift/apache/python/subsystem.py
+++ b/src/python/pants/backend/codegen/thrift/apache/python/subsystem.py
@@ -11,7 +11,7 @@ from pants.option.subsystem import Subsystem
 
 
 class ThriftPythonSubsystem(Subsystem):
-    options_scope = "thrift-python"
+    options_scope = "python-thrift"
     help = "Options specific to generating Python from Thrift using Apache Thrift"
 
     @classmethod

--- a/src/python/pants/backend/codegen/thrift/scrooge/java/subsystem.py
+++ b/src/python/pants/backend/codegen/thrift/scrooge/java/subsystem.py
@@ -8,7 +8,7 @@ from pants.option.subsystem import Subsystem
 
 
 class ScroogeJavaSubsystem(Subsystem):
-    options_scope = "scrooge-java"
+    options_scope = "java-scrooge"
     help = "Java-specific options for the Scrooge Thrift IDL compiler (https://twitter.github.io/scrooge/)."
 
     @classmethod

--- a/src/python/pants/backend/codegen/thrift/scrooge/scala/subsystem.py
+++ b/src/python/pants/backend/codegen/thrift/scrooge/scala/subsystem.py
@@ -9,7 +9,7 @@ from pants.option.subsystem import Subsystem
 
 
 class ScroogeScalaSubsystem(Subsystem):
-    options_scope = "scrooge-scala"
+    options_scope = "scala-scrooge"
     help = "Scala-specific options for the Scrooge Thrift IDL compiler (https://twitter.github.io/scrooge/)."
 
     @classmethod


### PR DESCRIPTION
As per [consensus with this comment](https://github.com/pantsbuild/example-codegen/pull/1#discussion_r786230888), put the language first in scope names for codegen.

[ci skip-rust]