### PR TITLE
[internal] add comment re clippy issue

### DIFF
--- a/src/rust/engine/async_value/src/lib.rs
+++ b/src/rust/engine/async_value/src/lib.rs
@@ -99,6 +99,8 @@ impl<T: Clone + Send + Sync + 'static> AsyncValueReceiver<T> {
         return Some(value.clone());
       }
 
+      // TODO: Remove the `allow` once https://github.com/rust-lang/rust-clippy/issues/8281
+      // is fixed upstream.
       #[allow(clippy::question_mark)]
       if item_receiver.changed().await.is_err() {
         return None;


### PR DESCRIPTION
Add a comment regarding a clippy work-around that we had to introduce when upgrading to Rust v1.58.0.

[ci skip-build-wheels]