### PR TITLE
[internal] Remove the minimum bucket size of batching to improve stability.

### DIFF
--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -212,7 +212,10 @@ async def fmt(
             )
             for fmt_requests, targets in targets_by_fmt_request_order.items()
             for target_batch in partition_sequentially(
-                targets, key=lambda t: t.address.spec, size_min=fmt_subsystem.batch_size
+                targets,
+                key=lambda t: t.address.spec,
+                size_target=fmt_subsystem.batch_size,
+                size_max=4 * fmt_subsystem.batch_size,
             )
         )
 

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -230,7 +230,10 @@ async def lint(
             for request in requests
             if request.field_sets
             for field_set_batch in partition_sequentially(
-                request.field_sets, key=address_str, size_min=lint_subsystem.batch_size
+                request.field_sets,
+                key=address_str,
+                size_target=lint_subsystem.batch_size,
+                size_max=4 * lint_subsystem.batch_size,
             )
         )
 

--- a/src/python/pants/core/goals/style_request.py
+++ b/src/python/pants/core/goals/style_request.py
@@ -26,7 +26,7 @@ _FS = TypeVar("_FS", bound=FieldSet)
 
 def style_batch_size_help(uppercase: str, lowercase: str) -> str:
     return (
-        f"The target minimum number of files that will be included in each {lowercase} batch.\n"
+        f"The target number of files to be included in each {lowercase} batch.\n"
         "\n"
         f"{uppercase} processes are batched for a few reasons:\n"
         "\n"
@@ -38,6 +38,9 @@ def style_batch_size_help(uppercase: str, lowercase: str) -> str:
         "parallelism, or -- if they do support internal parallelism -- to improve scheduling "
         "behavior when multiple processes are competing for cores and so internal "
         "parallelism cannot be used perfectly.\n"
+        "\n"
+        "In order to improve cache hit rates (see 2.), batches are created at stable boundaries, "
+        'and so this value is only a "target" batch size (rather than an exact value).'
     )
 
 

--- a/src/python/pants/util/collections_test.py
+++ b/src/python/pants/util/collections_test.py
@@ -88,21 +88,24 @@ def test_ensure_str_list() -> None:
         ensure_str_list([0, 1])  # type: ignore[list-item]
 
 
-@pytest.mark.parametrize("size_min", [0, 1, 16, 32, 64, 128])
-def test_partition_sequentially(size_min: int) -> None:
+@pytest.mark.parametrize("size_target", [0, 1, 8, 16, 32, 64, 128])
+def test_partition_sequentially(size_target: int) -> None:
     # Adding an item at any position in the input sequence should affect either 1 or 2 (if the added
     # item becomes a boundary) buckets in the output.
 
     def partitioned_buckets(items: list[str]) -> set[tuple[str, ...]]:
-        return set(tuple(p) for p in partition_sequentially(items, key=str, size_min=size_min))
+        return set(
+            tuple(p) for p in partition_sequentially(items, key=str, size_target=size_target)
+        )
 
     # We start with base items containing every other element from a sorted sequence.
-    all_items = sorted((f"item{i}" for i in range(0, 64)))
+    all_items = sorted((f"item{i}" for i in range(0, 1024)))
     base_items = [item for i, item in enumerate(all_items) if i % 2 == 0]
     base_partitions = partitioned_buckets(base_items)
 
-    # Then test that adding any of the remaining items elements (which will be interspersed in the
-    # base items) only affects 1 or 2 buckets in the output.
+    # Then test that adding any of the remaining items (which will be interspersed in the base
+    # items) only affects 1 or 2 buckets in the output (representing between a 1 and 4 delta
+    # in the `^`/symmetric_difference between before and after).
     for to_add in [item for i, item in enumerate(all_items) if i % 2 == 1]:
         updated_partitions = partitioned_buckets([to_add, *base_items])
-        assert 1 <= len(base_partitions ^ updated_partitions) <= 2
+        assert 1 <= len(base_partitions ^ updated_partitions) <= 4


### PR DESCRIPTION
As a followup to #14186, this change improves the stability (and thus cache hit rates) of batching by removing the minimum bucket size. It also fixes an issue in the tests, and expands the range that they test.

As mentioned in the expanded comments: capping bucket sizes (in either the `min` or the `max` direction) can cause streaks of bucket changes: when a bucket hits a `min`/`max` threshold and ignores a boundary, it increases the chance that the next bucket will trip a threshold as well.

Although it would be most-stable to remove the `max` threshold entirely, it is necessary to resolve the correctness issue of #13462. But we _can_ remove the `min` threshold, and so this change does that.

[ci skip-rust]
[ci skip-build-wheels]