### PR TITLE
Add try/except parsing to import_parser

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/parse_python_imports_test.py
+++ b/src/python/pants/backend/python/dependency_inference/parse_python_imports_test.py
@@ -126,6 +126,7 @@ def test_normal_imports(rule_runner: RuleRunner) -> None:
         },
     )
 
+
 def test_dunder_import_call(rule_runner: RuleRunner) -> None:
     content = dedent(
         """\
@@ -151,6 +152,7 @@ def test_dunder_import_call(rule_runner: RuleRunner) -> None:
             "also_not_ignored_but_looks_like_it_could_be": ImpInfo(lineno=10, weak=False),
         },
     )
+
 
 def test_try_except(rule_runner: RuleRunner) -> None:
     content = dedent(
@@ -217,6 +219,7 @@ def test_try_except(rule_runner: RuleRunner) -> None:
             "strong8": ImpInfo(lineno=37, weak=False),
         },
     )
+
 
 @pytest.mark.parametrize("basename", ["foo.py", "__init__.py"])
 def test_relative_imports(rule_runner: RuleRunner, basename: str) -> None:
@@ -307,6 +310,7 @@ def test_real_import_beats_string_import(rule_runner: RuleRunner) -> None:
         expected={"one.two.three": ImpInfo(lineno=1, weak=False)},
     )
 
+
 def test_real_import_beats_tryexcept_import(rule_runner: RuleRunner) -> None:
     assert_imports_parsed(
         rule_runner,
@@ -319,6 +323,7 @@ def test_real_import_beats_tryexcept_import(rule_runner: RuleRunner) -> None:
         ),
         expected={"one.two.three": ImpInfo(lineno=1, weak=False)},
     )
+
 
 def test_gracefully_handle_syntax_errors(rule_runner: RuleRunner) -> None:
     assert_imports_parsed(rule_runner, "x =", expected={})

--- a/src/python/pants/backend/python/dependency_inference/parse_python_imports_test.py
+++ b/src/python/pants/backend/python/dependency_inference/parse_python_imports_test.py
@@ -302,6 +302,8 @@ def test_real_import_beats_tryexcept_import(rule_runner: RuleRunner) -> None:
         dedent(
             """\
                 import one.two.three
+                try: import one.two.three
+                except ImportError: pass
             """
         ),
         expected={"one.two.three": ImpInfo(lineno=1, weak=False)},

--- a/src/python/pants/backend/python/dependency_inference/parse_python_imports_test.py
+++ b/src/python/pants/backend/python/dependency_inference/parse_python_imports_test.py
@@ -185,6 +185,15 @@ def test_try_except(rule_runner: RuleRunner) -> None:
         except AssertionError:
             try: import weak7
             except ImportError: import strong6
+
+        try: import strong7
+        # This would be too complicated to try and handle
+        except (lambda: ImportError)(): pass
+
+        ImpError = ImportError
+        try: import strong8
+        # This would be too complicated to try and handle
+        except ImpError: pass
         """
     )
     assert_imports_parsed(
@@ -204,6 +213,8 @@ def test_try_except(rule_runner: RuleRunner) -> None:
             "strong5": ImpInfo(lineno=25, weak=False),
             "weak7": ImpInfo(lineno=29, weak=True),
             "strong6": ImpInfo(lineno=30, weak=False),
+            "strong7": ImpInfo(lineno=32, weak=False),
+            "strong8": ImpInfo(lineno=37, weak=False),
         },
     )
 

--- a/src/python/pants/backend/python/dependency_inference/parse_python_imports_test.py
+++ b/src/python/pants/backend/python/dependency_inference/parse_python_imports_test.py
@@ -122,6 +122,13 @@ def test_normal_imports(rule_runner: RuleRunner) -> None:
         __import__(
             "also_not_ignored_but_looks_like_it_could_be"
         )  # pants: ignore
+
+        try:
+            import maybe_exists1
+        except ImportError:
+            import should_exist1
+
+
         """
     )
     assert_imports_parsed(
@@ -140,11 +147,13 @@ def test_normal_imports(rule_runner: RuleRunner) -> None:
             "multiline_import1.not_ignored2": ImpInfo(lineno=23, weak=False),
             "multiline_import2.not_ignored": ImpInfo(lineno=26, weak=False),
             "project.circular_dep.CircularDep": ImpInfo(lineno=29, weak=False),
-            "subprocess": ImpInfo(lineno=32, weak=False),
+            "subprocess": ImpInfo(lineno=32, weak=True),
             "subprocess23": ImpInfo(lineno=34, weak=False),
             "pkg_resources": ImpInfo(lineno=36, weak=False),
             "not_ignored_but_looks_like_it_could_be": ImpInfo(lineno=39, weak=False),
             "also_not_ignored_but_looks_like_it_could_be": ImpInfo(lineno=45, weak=False),
+            "maybe_exists1": ImpInfo(lineno=49, weak=True),
+            "should_exist1": ImpInfo(lineno=51, weak=False),
         },
     )
 

--- a/src/python/pants/backend/python/dependency_inference/scripts/import_parser.py
+++ b/src/python/pants/backend/python/dependency_inference/scripts/import_parser.py
@@ -127,7 +127,6 @@ class AstVisitor(ast.NodeVisitor):
         for stmt in node.finalbody:
             self.visit(stmt)
 
-
     def visit_Call(self, node):
         # Handle __import__("string_literal").  This is commonly used in __init__.py files,
         # to explicitly mark namespace packages.  Note that we don't handle more complex

--- a/src/python/pants/backend/python/dependency_inference/scripts/import_parser.py
+++ b/src/python/pants/backend/python/dependency_inference/scripts/import_parser.py
@@ -16,7 +16,6 @@ import re
 import sys
 import tokenize
 from io import open
-from typing import Iterable, Sequence
 
 MIN_DOTS = os.environ["MIN_DOTS"]
 

--- a/src/python/pants/backend/python/dependency_inference/scripts/import_parser.py
+++ b/src/python/pants/backend/python/dependency_inference/scripts/import_parser.py
@@ -16,6 +16,7 @@ import re
 import sys
 import tokenize
 from io import open
+from typing import Iterable, Sequence
 
 MIN_DOTS = os.environ["MIN_DOTS"]
 
@@ -38,10 +39,15 @@ class AstVisitor(ast.NodeVisitor):
         #   weak/strong)
         self.strong_imports = {}
         self.weak_imports = {}
+        self._weaken_strong_imports = False
 
     def maybe_add_string_import(self, node, s):
         if os.environ["STRING_IMPORTS"] == "y" and STRING_IMPORT_REGEX.match(s):
             self.weak_imports.setdefault(s, node.lineno)
+
+    def add_strong_import(self, name, lineno):
+        imports = self.weak_imports if self._weaken_strong_imports else self.strong_imports
+        imports.setdefault(name, lineno)
 
     @staticmethod
     def _is_pragma_ignored(line):
@@ -72,9 +78,7 @@ class AstVisitor(ast.NodeVisitor):
                 token = next(token_iter)
 
             if not self._is_pragma_ignored(token[4]):
-                self.strong_imports.setdefault(
-                    import_prefix + alias.name, token[3][0] + node.lineno - 1
-                )
+                self.add_strong_import(import_prefix + alias.name, token[3][0] + node.lineno - 1)
             if alias.asname and token[1] != alias.asname:
                 consume_until(alias.asname)
 
@@ -93,6 +97,38 @@ class AstVisitor(ast.NodeVisitor):
             abs_module = node.module
         self._visit_import_stmt(node, abs_module + ".")
 
+    def visit_TryExcept(self, node):
+        for handler in node.handlers:
+            # N.B. Python allows any arbitrary expression as an except handler.
+            # We only parse Name, or (Set/Tuple/List)-of-Names expressions
+            if isinstance(handler.type, ast.Name):
+                exprs = (handler.type,)
+            elif isinstance(handler.type, (ast.Tuple, ast.Set, ast.List)):
+                exprs = handler.type.elts
+            else:
+                continue
+
+            if any(isinstance(expr, ast.Name) and expr.id == "ImportError" for expr in exprs):
+                self._weaken_strong_imports = True
+                break
+
+        for stmt in node.body:
+            self.visit(stmt)
+
+        self._weaken_strong_imports = False
+
+        for handler in node.handlers:
+            self.visit(handler)
+
+        for stmt in node.orelse:
+            self.visit(stmt)
+
+    def visit_Try(self, node):
+        self.visit_TryExcept(node)
+        for stmt in node.finalbody:
+            self.visit(stmt)
+
+
     def visit_Call(self, node):
         # Handle __import__("string_literal").  This is commonly used in __init__.py files,
         # to explicitly mark namespace packages.  Note that we don't handle more complex
@@ -107,7 +143,7 @@ class AstVisitor(ast.NodeVisitor):
             if name is not None:
                 lineno = node.args[0].lineno
                 if not self._is_pragma_ignored(self._contents_lines[lineno - 1]):
-                    self.strong_imports.setdefault(name, lineno)
+                    self.add_strong_import(name, lineno)
                 return
 
         self.generic_visit(node)


### PR DESCRIPTION
This adds support for try/except parsing of imports. 

Specifically if an import is found to be within a `try` with some `ImportError` handler, it gets demoted to "weak".