### PR TITLE
[internal] Rename classes for `generate_lockfiles.py` for clarity

### DIFF
--- a/src/python/pants/backend/codegen/avro/java/rules.py
+++ b/src/python/pants/backend/codegen/avro/java/rules.py
@@ -11,7 +11,7 @@ from pants.backend.codegen.avro.java.subsystem import AvroSubsystem
 from pants.backend.codegen.avro.target_types import AvroSourceField
 from pants.backend.java.target_types import JavaSourceField
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
-from pants.core.goals.generate_lockfiles import ToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.fs import (
     AddPrefix,
     CreateDigest,
@@ -35,7 +35,7 @@ from pants.engine.target import (
 )
 from pants.engine.unions import UnionRule
 from pants.jvm.goals import lockfile
-from pants.jvm.goals.lockfile import JvmLockfileRequest, JvmLockfileRequestFromTool
+from pants.jvm.goals.lockfile import GenerateJvmLockfile, GenerateJvmLockfileFromTool
 from pants.jvm.jdk_rules import JdkSetup
 from pants.jvm.resolve.coursier_fetch import (
     CoursierResolvedLockfile,
@@ -52,7 +52,7 @@ class GenerateJavaFromAvroRequest(GenerateSourcesRequest):
     output = JavaSourceField
 
 
-class AvroToolLockfileSentinel(ToolLockfileSentinel):
+class AvroToolLockfileSentinel(GenerateToolLockfileSentinel):
     options_scope = AvroSubsystem.options_scope
 
 
@@ -219,8 +219,8 @@ async def compile_avro_source(
 @rule
 async def generate_avro_tools_lockfile_request(
     _: AvroToolLockfileSentinel, tool: AvroSubsystem
-) -> JvmLockfileRequest:
-    return await Get(JvmLockfileRequest, JvmLockfileRequestFromTool(tool))
+) -> GenerateJvmLockfile:
+    return await Get(GenerateJvmLockfile, GenerateJvmLockfileFromTool(tool))
 
 
 def rules():
@@ -228,5 +228,5 @@ def rules():
         *collect_rules(),
         *lockfile.rules(),
         UnionRule(GenerateSourcesRequest, GenerateJavaFromAvroRequest),
-        UnionRule(ToolLockfileSentinel, AvroToolLockfileSentinel),
+        UnionRule(GenerateToolLockfileSentinel, AvroToolLockfileSentinel),
     )

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -5,9 +5,9 @@ from typing import cast
 
 from pants.backend.codegen.protobuf.target_types import ProtobufDependenciesField
 from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import PythonLockfileRequest
+from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
-from pants.core.goals.generate_lockfiles import ToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.addresses import Addresses, UnparsedAddressInputs
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import InjectDependenciesRequest, InjectedDependencies
@@ -74,15 +74,15 @@ class PythonProtobufMypyPlugin(PythonToolRequirementsBase):
     default_lockfile_url = git_url(default_lockfile_path)
 
 
-class MypyProtobufLockfileSentinel(ToolLockfileSentinel):
+class MypyProtobufLockfileSentinel(GenerateToolLockfileSentinel):
     options_scope = PythonProtobufMypyPlugin.options_scope
 
 
 @rule
 def setup_mypy_protobuf_lockfile(
     _: MypyProtobufLockfileSentinel, mypy_protobuf: PythonProtobufMypyPlugin
-) -> PythonLockfileRequest:
-    return PythonLockfileRequest.from_tool(mypy_protobuf)
+) -> GeneratePythonLockfile:
+    return GeneratePythonLockfile.from_tool(mypy_protobuf)
 
 
 class InjectPythonProtobufDependencies(InjectDependenciesRequest):
@@ -102,5 +102,5 @@ def rules():
         *collect_rules(),
         *lockfile.rules(),
         UnionRule(InjectDependenciesRequest, InjectPythonProtobufDependencies),
-        UnionRule(ToolLockfileSentinel, MypyProtobufLockfileSentinel),
+        UnionRule(GenerateToolLockfileSentinel, MypyProtobufLockfileSentinel),
     ]

--- a/src/python/pants/backend/codegen/protobuf/scala/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/rules.py
@@ -13,7 +13,7 @@ from pants.backend.codegen.protobuf.target_types import (
     ProtobufSourceField,
 )
 from pants.backend.scala.target_types import ScalaSourceField
-from pants.core.goals.generate_lockfiles import ToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.core.util_rules.source_files import SourceFilesRequest
 from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
@@ -45,7 +45,7 @@ from pants.engine.target import (
 from pants.engine.unions import UnionRule
 from pants.jvm.compile import ClasspathEntry
 from pants.jvm.goals import lockfile
-from pants.jvm.goals.lockfile import JvmLockfileRequest, JvmLockfileRequestFromTool
+from pants.jvm.goals.lockfile import GenerateJvmLockfile, GenerateJvmLockfileFromTool
 from pants.jvm.jdk_rules import JdkSetup
 from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
 from pants.jvm.resolve.coursier_fetch import (
@@ -64,7 +64,7 @@ class GenerateScalaFromProtobufRequest(GenerateSourcesRequest):
     output = ScalaSourceField
 
 
-class ScalapbcToolLockfileSentinel(ToolLockfileSentinel):
+class ScalapbcToolLockfileSentinel(GenerateToolLockfileSentinel):
     options_scope = ScalaPBSubsystem.options_scope
 
 
@@ -377,8 +377,8 @@ async def setup_scalapb_shim_classfiles(
 @rule
 async def generate_scalapbc_lockfile_request(
     _: ScalapbcToolLockfileSentinel, tool: ScalaPBSubsystem
-) -> JvmLockfileRequest:
-    return await Get(JvmLockfileRequest, JvmLockfileRequestFromTool(tool))
+) -> GenerateJvmLockfile:
+    return await Get(GenerateJvmLockfile, GenerateJvmLockfileFromTool(tool))
 
 
 def rules():
@@ -386,5 +386,5 @@ def rules():
         *collect_rules(),
         *lockfile.rules(),
         UnionRule(GenerateSourcesRequest, GenerateScalaFromProtobufRequest),
-        UnionRule(ToolLockfileSentinel, ScalapbcToolLockfileSentinel),
+        UnionRule(GenerateToolLockfileSentinel, ScalapbcToolLockfileSentinel),
     ]

--- a/src/python/pants/backend/codegen/thrift/scrooge/rules.py
+++ b/src/python/pants/backend/codegen/thrift/scrooge/rules.py
@@ -7,7 +7,7 @@ from pants.backend.codegen.thrift.scrooge.additional_fields import ScroogeFinagl
 from pants.backend.codegen.thrift.scrooge.subsystem import ScroogeSubsystem
 from pants.backend.codegen.thrift.target_types import ThriftSourceField
 from pants.build_graph.address import Address
-from pants.core.goals.generate_lockfiles import ToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import CreateDigest, Digest, Directory, MergeDigests, RemovePrefix, Snapshot
 from pants.engine.internals.selectors import Get, MultiGet
@@ -16,7 +16,7 @@ from pants.engine.rules import collect_rules, rule
 from pants.engine.target import TransitiveTargets, TransitiveTargetsRequest, WrappedTarget
 from pants.engine.unions import UnionRule
 from pants.jvm.goals import lockfile
-from pants.jvm.goals.lockfile import JvmLockfileRequest, JvmLockfileRequestFromTool
+from pants.jvm.goals.lockfile import GenerateJvmLockfile, GenerateJvmLockfileFromTool
 from pants.jvm.jdk_rules import JdkSetup
 from pants.jvm.resolve.coursier_fetch import (
     CoursierResolvedLockfile,
@@ -40,7 +40,7 @@ class GeneratedScroogeThriftSources:
     snapshot: Snapshot
 
 
-class ScroogeToolLockfileSentinel(ToolLockfileSentinel):
+class ScroogeToolLockfileSentinel(GenerateToolLockfileSentinel):
     options_scope = ScroogeSubsystem.options_scope
 
 
@@ -143,8 +143,8 @@ async def generate_scrooge_thrift_sources(
 @rule
 async def generate_scrooge_lockfile_request(
     _: ScroogeToolLockfileSentinel, scrooge: ScroogeSubsystem
-) -> JvmLockfileRequest:
-    return await Get(JvmLockfileRequest, JvmLockfileRequestFromTool(scrooge))
+) -> GenerateJvmLockfile:
+    return await Get(GenerateJvmLockfile, GenerateJvmLockfileFromTool(scrooge))
 
 
 def rules():
@@ -152,5 +152,5 @@ def rules():
         *collect_rules(),
         *additional_fields.rules(),
         *lockfile.rules(),
-        UnionRule(ToolLockfileSentinel, ScroogeToolLockfileSentinel),
+        UnionRule(GenerateToolLockfileSentinel, ScroogeToolLockfileSentinel),
     ]

--- a/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
+++ b/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
@@ -11,11 +11,11 @@ from typing import Iterator
 from pants.backend.docker.target_types import DockerImageSourceField
 from pants.backend.docker.util_rules.docker_build_args import DockerBuildArgs
 from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import PythonLockfileRequest
+from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
 from pants.backend.python.target_types import EntryPoint
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
-from pants.core.goals.generate_lockfiles import ToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.process import Process, ProcessResult
@@ -46,15 +46,15 @@ class DockerfileParser(PythonToolRequirementsBase):
     default_lockfile_url = git_url(default_lockfile_path)
 
 
-class DockerfileParserLockfileSentinel(ToolLockfileSentinel):
+class DockerfileParserLockfileSentinel(GenerateToolLockfileSentinel):
     options_scope = DockerfileParser.options_scope
 
 
 @rule
 def setup_lockfile_request(
     _: DockerfileParserLockfileSentinel, dockerfile_parser: DockerfileParser
-) -> PythonLockfileRequest:
-    return PythonLockfileRequest.from_tool(dockerfile_parser)
+) -> GeneratePythonLockfile:
+    return GeneratePythonLockfile.from_tool(dockerfile_parser)
 
 
 @dataclass(frozen=True)
@@ -201,5 +201,5 @@ def rules():
     return (
         *collect_rules(),
         *lockfile.rules(),
-        UnionRule(ToolLockfileSentinel, DockerfileParserLockfileSentinel),
+        UnionRule(GenerateToolLockfileSentinel, DockerfileParserLockfileSentinel),
     )

--- a/src/python/pants/backend/experimental/python/user_lockfiles.py
+++ b/src/python/pants/backend/experimental/python/user_lockfiles.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 
 import logging
 
-from pants.backend.python.goals.lockfile import PythonLockfileRequest
+from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import PythonRequirementsField
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import PexRequirements
-from pants.core.goals.generate_lockfiles import Lockfile
+from pants.core.goals.generate_lockfiles import GenerateLockfileResult
 from pants.engine.addresses import Addresses
 from pants.engine.fs import Workspace
 from pants.engine.goal import Goal, GoalSubsystem
@@ -66,8 +66,8 @@ async def generate_user_lockfile_goal(
         return GenerateUserLockfileGoal(exit_code=0)
 
     result = await Get(
-        Lockfile,
-        PythonLockfileRequest(
+        GenerateLockfileResult,
+        GeneratePythonLockfile(
             requirements=req_strings,
             # TODO(#12314): Use interpreter constraints from the transitive closure.
             interpreter_constraints=InterpreterConstraints(python_setup.interpreter_constraints),

--- a/src/python/pants/backend/java/lint/google_java_format/rules.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules.py
@@ -8,7 +8,7 @@ from pants.backend.java.lint.google_java_format.skip_field import SkipGoogleJava
 from pants.backend.java.lint.google_java_format.subsystem import GoogleJavaFormatSubsystem
 from pants.backend.java.target_types import JavaSourceField
 from pants.core.goals.fmt import FmtRequest, FmtResult
-from pants.core.goals.generate_lockfiles import ToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.goals.lint import LintRequest, LintResult, LintResults
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest
@@ -18,7 +18,7 @@ from pants.engine.rules import collect_rules, rule
 from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.jvm.goals import lockfile
-from pants.jvm.goals.lockfile import JvmLockfileRequest, JvmLockfileRequestFromTool
+from pants.jvm.goals.lockfile import GenerateJvmLockfile, GenerateJvmLockfileFromTool
 from pants.jvm.jdk_rules import JdkSetup
 from pants.jvm.resolve.coursier_fetch import (
     CoursierResolvedLockfile,
@@ -47,7 +47,7 @@ class GoogleJavaFormatRequest(FmtRequest, LintRequest):
     field_set_type = GoogleJavaFormatFieldSet
 
 
-class GoogleJavaFormatToolLockfileSentinel(ToolLockfileSentinel):
+class GoogleJavaFormatToolLockfileSentinel(GenerateToolLockfileSentinel):
     options_scope = GoogleJavaFormatSubsystem.options_scope
 
 
@@ -170,8 +170,8 @@ async def google_java_format_lint(
 @rule
 async def generate_google_java_format_lockfile_request(
     _: GoogleJavaFormatToolLockfileSentinel, tool: GoogleJavaFormatSubsystem
-) -> JvmLockfileRequest:
-    return await Get(JvmLockfileRequest, JvmLockfileRequestFromTool(tool))
+) -> GenerateJvmLockfile:
+    return await Get(GenerateJvmLockfile, GenerateJvmLockfileFromTool(tool))
 
 
 def rules():
@@ -180,5 +180,5 @@ def rules():
         *lockfile.rules(),
         UnionRule(FmtRequest, GoogleJavaFormatRequest),
         UnionRule(LintRequest, GoogleJavaFormatRequest),
-        UnionRule(ToolLockfileSentinel, GoogleJavaFormatToolLockfileSentinel),
+        UnionRule(GenerateToolLockfileSentinel, GoogleJavaFormatToolLockfileSentinel),
     ]

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -13,7 +13,7 @@ from typing import cast
 import toml
 
 from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import PythonLockfileRequest
+from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
@@ -21,7 +21,7 @@ from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
     PythonSourceFilesRequest,
 )
-from pants.core.goals.generate_lockfiles import ToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.goals.test import (
     ConsoleCoverageReport,
     CoverageData,
@@ -236,15 +236,15 @@ class CoverageSubsystem(PythonToolBase):
         return cast(int, self.options.fail_under)
 
 
-class CoveragePyLockfileSentinel(ToolLockfileSentinel):
+class CoveragePyLockfileSentinel(GenerateToolLockfileSentinel):
     options_scope = CoverageSubsystem.options_scope
 
 
 @rule
 def setup_coverage_lockfile(
     _: CoveragePyLockfileSentinel, coverage: CoverageSubsystem
-) -> PythonLockfileRequest:
-    return PythonLockfileRequest.from_tool(coverage)
+) -> GeneratePythonLockfile:
+    return GeneratePythonLockfile.from_tool(coverage)
 
 
 @dataclass(frozen=True)
@@ -610,5 +610,5 @@ def rules():
         *collect_rules(),
         *lockfile.rules(),
         UnionRule(CoverageDataCollection, PytestCoverageDataCollection),
-        UnionRule(ToolLockfileSentinel, CoveragePyLockfileSentinel),
+        UnionRule(GenerateToolLockfileSentinel, CoveragePyLockfileSentinel),
     ]

--- a/src/python/pants/backend/python/goals/lockfile_test.py
+++ b/src/python/pants/backend/python/goals/lockfile_test.py
@@ -6,14 +6,14 @@ from __future__ import annotations
 from textwrap import dedent
 
 from pants.backend.python.goals.lockfile import (
-    PythonLockfileRequest,
+    GeneratePythonLockfile,
     RequestedPythonUserResolveNames,
     setup_user_lockfile_requests,
 )
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import PythonRequirementTarget
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.core.goals.generate_lockfiles import UserLockfileRequests
+from pants.core.goals.generate_lockfiles import UserGenerateLockfiles
 from pants.engine.rules import SubsystemRule
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
 from pants.util.ordered_set import FrozenOrderedSet
@@ -24,7 +24,7 @@ def test_multiple_resolves() -> None:
         rules=[
             setup_user_lockfile_requests,
             SubsystemRule(PythonSetup),
-            QueryRule(UserLockfileRequests, [RequestedPythonUserResolveNames]),
+            QueryRule(UserGenerateLockfiles, [RequestedPythonUserResolveNames]),
         ],
         target_types=[PythonRequirementTarget],
     )
@@ -59,10 +59,10 @@ def test_multiple_resolves() -> None:
         env_inherit=PYTHON_BOOTSTRAP_ENV,
     )
     result = rule_runner.request(
-        UserLockfileRequests, [RequestedPythonUserResolveNames(["a", "b"])]
+        UserGenerateLockfiles, [RequestedPythonUserResolveNames(["a", "b"])]
     )
     assert set(result) == {
-        PythonLockfileRequest(
+        GeneratePythonLockfile(
             requirements=FrozenOrderedSet(["a", "both1", "both2"]),
             interpreter_constraints=InterpreterConstraints(
                 PythonSetup.default_interpreter_constraints
@@ -70,7 +70,7 @@ def test_multiple_resolves() -> None:
             resolve_name="a",
             lockfile_dest="a.lock",
         ),
-        PythonLockfileRequest(
+        GeneratePythonLockfile(
             requirements=FrozenOrderedSet(["b", "both1", "both2"]),
             interpreter_constraints=InterpreterConstraints(
                 PythonSetup.default_interpreter_constraints

--- a/src/python/pants/backend/python/lint/autoflake/subsystem.py
+++ b/src/python/pants/backend/python/lint/autoflake/subsystem.py
@@ -6,10 +6,10 @@ from __future__ import annotations
 from typing import cast
 
 from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import PythonLockfileRequest
+from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
-from pants.core.goals.generate_lockfiles import ToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.option.custom_types import shell_str
@@ -62,20 +62,20 @@ class Autoflake(PythonToolBase):
         return tuple(self.options.args)
 
 
-class AutoflakeLockfileSentinel(ToolLockfileSentinel):
+class AutoflakeLockfileSentinel(GenerateToolLockfileSentinel):
     options_scope = Autoflake.options_scope
 
 
 @rule()
 async def setup_autoflake_lockfile(
     _: AutoflakeLockfileSentinel, autoflake: Autoflake
-) -> PythonLockfileRequest:
-    return PythonLockfileRequest.from_tool(autoflake)
+) -> GeneratePythonLockfile:
+    return GeneratePythonLockfile.from_tool(autoflake)
 
 
 def rules():
     return (
         *collect_rules(),
         *lockfile.rules(),
-        UnionRule(ToolLockfileSentinel, AutoflakeLockfileSentinel),
+        UnionRule(GenerateToolLockfileSentinel, AutoflakeLockfileSentinel),
     )

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import cast
 
 from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import PythonLockfileRequest
+from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.lint.bandit.skip_field import SkipBanditField
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
@@ -18,7 +18,7 @@ from pants.backend.python.target_types import (
     PythonSourceField,
 )
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.core.goals.generate_lockfiles import ToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import AllTargets, AllTargetsRequest, FieldSet, Target
@@ -111,7 +111,7 @@ class Bandit(PythonToolBase):
         )
 
 
-class BanditLockfileSentinel(ToolLockfileSentinel):
+class BanditLockfileSentinel(GenerateToolLockfileSentinel):
     options_scope = Bandit.options_scope
 
 
@@ -124,9 +124,9 @@ class BanditLockfileSentinel(ToolLockfileSentinel):
 )
 async def setup_bandit_lockfile(
     _: BanditLockfileSentinel, bandit: Bandit, python_setup: PythonSetup
-) -> PythonLockfileRequest:
+) -> GeneratePythonLockfile:
     if not bandit.uses_lockfile:
-        return PythonLockfileRequest.from_tool(bandit)
+        return GeneratePythonLockfile.from_tool(bandit)
 
     # While Bandit will run in partitions, we need a single lockfile that works with every
     # partition.
@@ -140,7 +140,7 @@ async def setup_bandit_lockfile(
         if BanditFieldSet.is_applicable(tgt)
     }
     constraints = InterpreterConstraints(itertools.chain.from_iterable(unique_constraints))
-    return PythonLockfileRequest.from_tool(
+    return GeneratePythonLockfile.from_tool(
         bandit, constraints or InterpreterConstraints(python_setup.interpreter_constraints)
     )
 
@@ -149,5 +149,5 @@ def rules():
     return (
         *collect_rules(),
         *lockfile.rules(),
-        UnionRule(ToolLockfileSentinel, BanditLockfileSentinel),
+        UnionRule(GenerateToolLockfileSentinel, BanditLockfileSentinel),
     )

--- a/src/python/pants/backend/python/lint/bandit/subsystem_test.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem_test.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from textwrap import dedent
 
 from pants.backend.python import target_types_rules
-from pants.backend.python.goals.lockfile import PythonLockfileRequest
+from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.lint.bandit import skip_field
 from pants.backend.python.lint.bandit.subsystem import BanditLockfileSentinel
 from pants.backend.python.lint.bandit.subsystem import rules as subsystem_rules
@@ -22,7 +22,7 @@ def test_setup_lockfile_interpreter_constraints() -> None:
             *subsystem_rules(),
             *skip_field.rules(),
             *target_types_rules.rules(),
-            QueryRule(PythonLockfileRequest, [BanditLockfileSentinel]),
+            QueryRule(GeneratePythonLockfile, [BanditLockfileSentinel]),
         ],
         target_types=[PythonSourcesGeneratorTarget, GenericTarget],
     )
@@ -35,7 +35,7 @@ def test_setup_lockfile_interpreter_constraints() -> None:
 
     def assert_ics(build_file: str, expected: list[str]) -> None:
         rule_runner.write_files({"project/BUILD": build_file, "project/f.py": ""})
-        lockfile_request = rule_runner.request(PythonLockfileRequest, [BanditLockfileSentinel()])
+        lockfile_request = rule_runner.request(GeneratePythonLockfile, [BanditLockfileSentinel()])
         assert lockfile_request.interpreter_constraints == InterpreterConstraints(expected)
 
     assert_ics("python_sources()", [global_constraint])

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -7,13 +7,13 @@ import os.path
 from typing import Iterable, cast
 
 from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import PythonLockfileRequest
+from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.lint.black.skip_field import SkipBlackField
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import ConsoleScript
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.core.goals.generate_lockfiles import ToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import AllTargets, AllTargetsRequest
@@ -107,7 +107,7 @@ class Black(PythonToolBase):
         )
 
 
-class BlackLockfileSentinel(ToolLockfileSentinel):
+class BlackLockfileSentinel(GenerateToolLockfileSentinel):
     options_scope = Black.options_scope
 
 
@@ -117,9 +117,9 @@ class BlackLockfileSentinel(ToolLockfileSentinel):
 )
 async def setup_black_lockfile(
     _: BlackLockfileSentinel, black: Black, python_setup: PythonSetup
-) -> PythonLockfileRequest:
+) -> GeneratePythonLockfile:
     if not black.uses_lockfile:
-        return PythonLockfileRequest.from_tool(black)
+        return GeneratePythonLockfile.from_tool(black)
 
     constraints = black.interpreter_constraints
     if black.options.is_default("interpreter_constraints"):
@@ -131,12 +131,12 @@ async def setup_black_lockfile(
         if code_constraints.requires_python38_or_newer(python_setup.interpreter_universe):
             constraints = code_constraints
 
-    return PythonLockfileRequest.from_tool(black, constraints)
+    return GeneratePythonLockfile.from_tool(black, constraints)
 
 
 def rules():
     return (
         *collect_rules(),
         *lockfile.rules(),
-        UnionRule(ToolLockfileSentinel, BlackLockfileSentinel),
+        UnionRule(GenerateToolLockfileSentinel, BlackLockfileSentinel),
     )

--- a/src/python/pants/backend/python/lint/black/subsystem_test.py
+++ b/src/python/pants/backend/python/lint/black/subsystem_test.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from textwrap import dedent
 
-from pants.backend.python.goals.lockfile import PythonLockfileRequest
+from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.lint.black import skip_field
 from pants.backend.python.lint.black.subsystem import Black, BlackLockfileSentinel
 from pants.backend.python.lint.black.subsystem import rules as subsystem_rules
@@ -20,7 +20,7 @@ def test_setup_lockfile_interpreter_constraints() -> None:
         rules=[
             *subsystem_rules(),
             *skip_field.rules(),
-            QueryRule(PythonLockfileRequest, [BlackLockfileSentinel]),
+            QueryRule(GeneratePythonLockfile, [BlackLockfileSentinel]),
         ],
         target_types=[PythonSourcesGeneratorTarget, GenericTarget],
     )
@@ -33,7 +33,7 @@ def test_setup_lockfile_interpreter_constraints() -> None:
 
     def assert_ics(build_file: str, expected: list[str]) -> None:
         rule_runner.write_files({"project/BUILD": build_file})
-        lockfile_request = rule_runner.request(PythonLockfileRequest, [BlackLockfileSentinel()])
+        lockfile_request = rule_runner.request(GeneratePythonLockfile, [BlackLockfileSentinel()])
         assert lockfile_request.interpreter_constraints == InterpreterConstraints(expected)
 
     # If all code is Py38+, use those constraints. Otherwise, use subsystem constraints.

--- a/src/python/pants/backend/python/lint/docformatter/subsystem.py
+++ b/src/python/pants/backend/python/lint/docformatter/subsystem.py
@@ -4,10 +4,10 @@
 from typing import Tuple, cast
 
 from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import PythonLockfileRequest
+from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
-from pants.core.goals.generate_lockfiles import ToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.option.custom_types import shell_str
@@ -60,20 +60,20 @@ class Docformatter(PythonToolBase):
         return tuple(self.options.args)
 
 
-class DocformatterLockfileSentinel(ToolLockfileSentinel):
+class DocformatterLockfileSentinel(GenerateToolLockfileSentinel):
     options_scope = Docformatter.options_scope
 
 
 @rule
 def setup_lockfile_request(
     _: DocformatterLockfileSentinel, docformatter: Docformatter
-) -> PythonLockfileRequest:
-    return PythonLockfileRequest.from_tool(docformatter)
+) -> GeneratePythonLockfile:
+    return GeneratePythonLockfile.from_tool(docformatter)
 
 
 def rules():
     return (
         *collect_rules(),
         *lockfile.rules(),
-        UnionRule(ToolLockfileSentinel, DocformatterLockfileSentinel),
+        UnionRule(GenerateToolLockfileSentinel, DocformatterLockfileSentinel),
     )

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import cast
 
 from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import PythonLockfileRequest
+from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.lint.flake8.skip_field import SkipFlake8Field
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
@@ -24,7 +24,7 @@ from pants.backend.python.util_rules.python_sources import (
     PythonSourceFilesRequest,
     StrippedPythonSourceFiles,
 )
-from pants.core.goals.generate_lockfiles import ToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.addresses import Addresses, UnparsedAddressInputs
 from pants.engine.fs import AddPrefix, Digest
@@ -231,7 +231,7 @@ async def flake8_first_party_plugins(flake8: Flake8) -> Flake8FirstPartyPlugins:
 # --------------------------------------------------------------------------------------
 
 
-class Flake8LockfileSentinel(ToolLockfileSentinel):
+class Flake8LockfileSentinel(GenerateToolLockfileSentinel):
     options_scope = Flake8.options_scope
 
 
@@ -247,9 +247,9 @@ async def setup_flake8_lockfile(
     first_party_plugins: Flake8FirstPartyPlugins,
     flake8: Flake8,
     python_setup: PythonSetup,
-) -> PythonLockfileRequest:
+) -> GeneratePythonLockfile:
     if not flake8.uses_lockfile:
-        return PythonLockfileRequest.from_tool(flake8)
+        return GeneratePythonLockfile.from_tool(flake8)
 
     # While Flake8 will run in partitions, we need a single lockfile that works with every
     # partition.
@@ -276,7 +276,7 @@ async def setup_flake8_lockfile(
             )
         )
     constraints = InterpreterConstraints(itertools.chain.from_iterable(unique_constraints))
-    return PythonLockfileRequest.from_tool(
+    return GeneratePythonLockfile.from_tool(
         flake8,
         constraints or InterpreterConstraints(python_setup.interpreter_constraints),
         extra_requirements=first_party_plugins.requirement_strings,
@@ -287,5 +287,5 @@ def rules():
     return (
         *collect_rules(),
         *lockfile.rules(),
-        UnionRule(ToolLockfileSentinel, Flake8LockfileSentinel),
+        UnionRule(GenerateToolLockfileSentinel, Flake8LockfileSentinel),
     )

--- a/src/python/pants/backend/python/lint/flake8/subsystem_test.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem_test.py
@@ -8,7 +8,7 @@ from textwrap import dedent
 import pytest
 
 from pants.backend.python import target_types_rules
-from pants.backend.python.goals.lockfile import PythonLockfileRequest
+from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.lint.flake8 import skip_field
 from pants.backend.python.lint.flake8.subsystem import (
     Flake8,
@@ -38,7 +38,7 @@ def rule_runner() -> RuleRunner:
             *python_sources.rules(),
             *target_types_rules.rules(),
             QueryRule(Flake8FirstPartyPlugins, []),
-            QueryRule(PythonLockfileRequest, [Flake8LockfileSentinel]),
+            QueryRule(GeneratePythonLockfile, [Flake8LockfileSentinel]),
         ],
         target_types=[PythonSourcesGeneratorTarget, GenericTarget, PythonRequirementTarget],
     )
@@ -119,7 +119,7 @@ def test_setup_lockfile_interpreter_constraints(rule_runner) -> None:
             env={"PANTS_PYTHON_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"},
             env_inherit={"PATH", "PYENV_ROOT", "HOME"},
         )
-        lockfile_request = rule_runner.request(PythonLockfileRequest, [Flake8LockfileSentinel()])
+        lockfile_request = rule_runner.request(GeneratePythonLockfile, [Flake8LockfileSentinel()])
         assert lockfile_request.interpreter_constraints == InterpreterConstraints(expected_ics)
         assert lockfile_request.requirements == FrozenOrderedSet(
             [

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -7,10 +7,10 @@ import os.path
 from typing import Iterable, cast
 
 from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import PythonLockfileRequest
+from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
-from pants.core.goals.generate_lockfiles import ToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
@@ -126,18 +126,18 @@ class Isort(PythonToolBase):
         )
 
 
-class IsortLockfileSentinel(ToolLockfileSentinel):
+class IsortLockfileSentinel(GenerateToolLockfileSentinel):
     options_scope = Isort.options_scope
 
 
 @rule
-def setup_isort_lockfile(_: IsortLockfileSentinel, isort: Isort) -> PythonLockfileRequest:
-    return PythonLockfileRequest.from_tool(isort)
+def setup_isort_lockfile(_: IsortLockfileSentinel, isort: Isort) -> GeneratePythonLockfile:
+    return GeneratePythonLockfile.from_tool(isort)
 
 
 def rules():
     return (
         *collect_rules(),
         *lockfile.rules(),
-        UnionRule(ToolLockfileSentinel, IsortLockfileSentinel),
+        UnionRule(GenerateToolLockfileSentinel, IsortLockfileSentinel),
     )

--- a/src/python/pants/backend/python/lint/pylint/subsystem_test.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem_test.py
@@ -8,7 +8,7 @@ from textwrap import dedent
 import pytest
 
 from pants.backend.python import target_types_rules
-from pants.backend.python.goals.lockfile import PythonLockfileRequest
+from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.lint.pylint import skip_field
 from pants.backend.python.lint.pylint.subsystem import (
     Pylint,
@@ -38,7 +38,7 @@ def rule_runner() -> RuleRunner:
             *python_sources.rules(),
             *target_types_rules.rules(),
             QueryRule(PylintFirstPartyPlugins, []),
-            QueryRule(PythonLockfileRequest, [PylintLockfileSentinel]),
+            QueryRule(GeneratePythonLockfile, [PylintLockfileSentinel]),
         ],
         target_types=[PythonSourcesGeneratorTarget, GenericTarget, PythonRequirementTarget],
     )
@@ -119,7 +119,7 @@ def test_setup_lockfile_interpreter_constraints(rule_runner: RuleRunner) -> None
             env={"PANTS_PYTHON_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"},
             env_inherit={"PATH", "PYENV_ROOT", "HOME"},
         )
-        lockfile_request = rule_runner.request(PythonLockfileRequest, [PylintLockfileSentinel()])
+        lockfile_request = rule_runner.request(GeneratePythonLockfile, [PylintLockfileSentinel()])
         assert lockfile_request.interpreter_constraints == InterpreterConstraints(expected_ics)
         assert lockfile_request.requirements == FrozenOrderedSet(
             [

--- a/src/python/pants/backend/python/lint/pyupgrade/subsystem.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/subsystem.py
@@ -6,10 +6,10 @@ from __future__ import annotations
 from typing import cast
 
 from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import PythonLockfileRequest
+from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
-from pants.core.goals.generate_lockfiles import ToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.option.custom_types import shell_str
@@ -65,20 +65,20 @@ class PyUpgrade(PythonToolBase):
         return tuple(self.options.args)
 
 
-class PyUpgradeLockfileSentinel(ToolLockfileSentinel):
+class PyUpgradeLockfileSentinel(GenerateToolLockfileSentinel):
     options_scope = PyUpgrade.options_scope
 
 
 @rule
 def setup_pyupgrade_lockfile(
     _: PyUpgradeLockfileSentinel, pyupgrade: PyUpgrade
-) -> PythonLockfileRequest:
-    return PythonLockfileRequest.from_tool(pyupgrade)
+) -> GeneratePythonLockfile:
+    return GeneratePythonLockfile.from_tool(pyupgrade)
 
 
 def rules():
     return (
         *collect_rules(),
         *lockfile.rules(),
-        UnionRule(ToolLockfileSentinel, PyUpgradeLockfileSentinel),
+        UnionRule(GenerateToolLockfileSentinel, PyUpgradeLockfileSentinel),
     )

--- a/src/python/pants/backend/python/lint/yapf/subsystem.py
+++ b/src/python/pants/backend/python/lint/yapf/subsystem.py
@@ -7,10 +7,10 @@ import os.path
 from typing import Iterable, cast
 
 from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import PythonLockfileRequest
+from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
-from pants.core.goals.generate_lockfiles import ToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
@@ -118,18 +118,18 @@ class Yapf(PythonToolBase):
         )
 
 
-class YapfLockfileSentinel(ToolLockfileSentinel):
+class YapfLockfileSentinel(GenerateToolLockfileSentinel):
     options_scope = Yapf.options_scope
 
 
 @rule
-def setup_yapf_lockfile(_: YapfLockfileSentinel, yapf: Yapf) -> PythonLockfileRequest:
-    return PythonLockfileRequest.from_tool(yapf)
+def setup_yapf_lockfile(_: YapfLockfileSentinel, yapf: Yapf) -> GeneratePythonLockfile:
+    return GeneratePythonLockfile.from_tool(yapf)
 
 
 def rules():
     return (
         *collect_rules(),
         *lockfile.rules(),
-        UnionRule(ToolLockfileSentinel, YapfLockfileSentinel),
+        UnionRule(GenerateToolLockfileSentinel, YapfLockfileSentinel),
     )

--- a/src/python/pants/backend/python/subsystems/ipython.py
+++ b/src/python/pants/backend/python/subsystems/ipython.py
@@ -6,12 +6,12 @@ from __future__ import annotations
 import itertools
 
 from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import PythonLockfileRequest
+from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import ConsoleScript, InterpreterConstraintsField
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.core.goals.generate_lockfiles import ToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import AllTargets, AllTargetsRequest
 from pants.engine.unions import UnionRule
@@ -48,7 +48,7 @@ class IPython(PythonToolBase):
         )
 
 
-class IPythonLockfileSentinel(ToolLockfileSentinel):
+class IPythonLockfileSentinel(GenerateToolLockfileSentinel):
     options_scope = IPython.options_scope
 
 
@@ -61,9 +61,9 @@ class IPythonLockfileSentinel(ToolLockfileSentinel):
 )
 async def setup_ipython_lockfile(
     _: IPythonLockfileSentinel, ipython: IPython, python_setup: PythonSetup
-) -> PythonLockfileRequest:
+) -> GeneratePythonLockfile:
     if not ipython.uses_lockfile:
-        return PythonLockfileRequest.from_tool(ipython)
+        return GeneratePythonLockfile.from_tool(ipython)
 
     # IPython is often run against the whole repo (`./pants repl ::`), but it is possible to run
     # on subsets of the codebase with disjoint interpreter constraints, such as
@@ -81,7 +81,7 @@ async def setup_ipython_lockfile(
         if tgt.has_field(InterpreterConstraintsField)
     }
     constraints = InterpreterConstraints(itertools.chain.from_iterable(unique_constraints))
-    return PythonLockfileRequest.from_tool(
+    return GeneratePythonLockfile.from_tool(
         ipython, constraints or InterpreterConstraints(python_setup.interpreter_constraints)
     )
 
@@ -90,5 +90,5 @@ def rules():
     return (
         *collect_rules(),
         *lockfile.rules(),
-        UnionRule(ToolLockfileSentinel, IPythonLockfileSentinel),
+        UnionRule(GenerateToolLockfileSentinel, IPythonLockfileSentinel),
     )

--- a/src/python/pants/backend/python/subsystems/ipython_test.py
+++ b/src/python/pants/backend/python/subsystems/ipython_test.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from textwrap import dedent
 
-from pants.backend.python.goals.lockfile import PythonLockfileRequest
+from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.subsystems.ipython import IPythonLockfileSentinel
 from pants.backend.python.subsystems.ipython import rules as subsystem_rules
 from pants.backend.python.target_types import PythonSourcesGeneratorTarget
@@ -16,7 +16,7 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 def test_setup_lockfile_interpreter_constraints() -> None:
     rule_runner = RuleRunner(
-        rules=[*subsystem_rules(), QueryRule(PythonLockfileRequest, [IPythonLockfileSentinel])],
+        rules=[*subsystem_rules(), QueryRule(GeneratePythonLockfile, [IPythonLockfileSentinel])],
         target_types=[PythonSourcesGeneratorTarget, GenericTarget],
     )
 
@@ -28,7 +28,7 @@ def test_setup_lockfile_interpreter_constraints() -> None:
 
     def assert_ics(build_file: str, expected: list[str]) -> None:
         rule_runner.write_files({"project/BUILD": build_file})
-        lockfile_request = rule_runner.request(PythonLockfileRequest, [IPythonLockfileSentinel()])
+        lockfile_request = rule_runner.request(GeneratePythonLockfile, [IPythonLockfileSentinel()])
         assert lockfile_request.interpreter_constraints == InterpreterConstraints(expected)
 
     assert_ics("python_sources()", [global_constraint])

--- a/src/python/pants/backend/python/subsystems/lambdex.py
+++ b/src/python/pants/backend/python/subsystems/lambdex.py
@@ -2,10 +2,10 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import PythonLockfileRequest
+from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
-from pants.core.goals.generate_lockfiles import ToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.util.docutil import git_url
@@ -30,18 +30,18 @@ class Lambdex(PythonToolBase):
     default_lockfile_url = git_url(default_lockfile_path)
 
 
-class LambdexLockfileSentinel(ToolLockfileSentinel):
+class LambdexLockfileSentinel(GenerateToolLockfileSentinel):
     options_scope = Lambdex.options_scope
 
 
 @rule
-def setup_lambdex_lockfile(_: LambdexLockfileSentinel, lambdex: Lambdex) -> PythonLockfileRequest:
-    return PythonLockfileRequest.from_tool(lambdex)
+def setup_lambdex_lockfile(_: LambdexLockfileSentinel, lambdex: Lambdex) -> GeneratePythonLockfile:
+    return GeneratePythonLockfile.from_tool(lambdex)
 
 
 def rules():
     return (
         *collect_rules(),
         *lockfile.rules(),
-        UnionRule(ToolLockfileSentinel, LambdexLockfileSentinel),
+        UnionRule(GenerateToolLockfileSentinel, LambdexLockfileSentinel),
     )

--- a/src/python/pants/backend/python/subsystems/pytest_test.py
+++ b/src/python/pants/backend/python/subsystems/pytest_test.py
@@ -8,7 +8,7 @@ from textwrap import dedent
 import pytest
 
 from pants.backend.python import target_types_rules
-from pants.backend.python.goals.lockfile import PythonLockfileRequest
+from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.subsystems.pytest import PyTest, PytestLockfileSentinel
 from pants.backend.python.subsystems.pytest import rules as subsystem_rules
 from pants.backend.python.target_types import (
@@ -27,7 +27,7 @@ def test_setup_lockfile_interpreter_constraints() -> None:
         rules=[
             *subsystem_rules(),
             *target_types_rules.rules(),
-            QueryRule(PythonLockfileRequest, [PytestLockfileSentinel]),
+            QueryRule(GeneratePythonLockfile, [PytestLockfileSentinel]),
         ],
         target_types=[PythonSourcesGeneratorTarget, PythonTestsGeneratorTarget, GenericTarget],
     )
@@ -41,7 +41,7 @@ def test_setup_lockfile_interpreter_constraints() -> None:
 
     def assert_ics(build_file: str, expected: list[str]) -> None:
         rule_runner.write_files({"project/BUILD": build_file, "project/f_test.py": ""})
-        lockfile_request = rule_runner.request(PythonLockfileRequest, [PytestLockfileSentinel()])
+        lockfile_request = rule_runner.request(GeneratePythonLockfile, [PytestLockfileSentinel()])
         assert lockfile_request.interpreter_constraints == InterpreterConstraints(expected)
 
     assert_ics("python_tests()", [global_constraint])

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -37,8 +37,8 @@ class PythonToolRequirementsBase(Subsystem):
     # If this tool does not mix with user requirements (e.g. Flake8 and Isort, but not Pylint and
     # Pytest), you should set this to True.
     #
-    # You also need to subclass `PythonToolLockfileSentinel` and create a rule that goes from
-    # it -> PythonToolLockfileRequest by calling `PythonLockFileRequest.from_python_tool()`.
+    # You also need to subclass `GenerateToolLockfileSentinel` and create a rule that goes from
+    # it -> GeneratePythonLockfile by calling `GeneratePythonLockfile.from_python_tool()`.
     # Register the UnionRule.
     register_lockfile: ClassVar[bool] = False
     default_lockfile_resource: ClassVar[tuple[str, str] | None] = None

--- a/src/python/pants/backend/python/subsystems/setuptools_test.py
+++ b/src/python/pants/backend/python/subsystems/setuptools_test.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from textwrap import dedent
 
-from pants.backend.python.goals.lockfile import PythonLockfileRequest
+from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.subsystems import setuptools
 from pants.backend.python.subsystems.setuptools import SetuptoolsLockfileSentinel
@@ -18,7 +18,7 @@ def test_setup_lockfile_interpreter_constraints() -> None:
     rule_runner = RuleRunner(
         rules=[
             *setuptools.rules(),
-            QueryRule(PythonLockfileRequest, [SetuptoolsLockfileSentinel]),
+            QueryRule(GeneratePythonLockfile, [SetuptoolsLockfileSentinel]),
         ],
         target_types=[PythonSourcesGeneratorTarget, PythonDistribution],
         objects={"setup_py": PythonArtifact},
@@ -33,7 +33,7 @@ def test_setup_lockfile_interpreter_constraints() -> None:
     def assert_ics(build_file: str, expected: list[str]) -> None:
         rule_runner.write_files({"project/BUILD": build_file})
         lockfile_request = rule_runner.request(
-            PythonLockfileRequest, [SetuptoolsLockfileSentinel()]
+            GeneratePythonLockfile, [SetuptoolsLockfileSentinel()]
         )
         assert lockfile_request.interpreter_constraints == InterpreterConstraints(expected)
 

--- a/src/python/pants/backend/python/subsystems/twine.py
+++ b/src/python/pants/backend/python/subsystems/twine.py
@@ -8,10 +8,10 @@ from pathlib import Path
 from typing import cast
 
 from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import PythonLockfileRequest
+from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
-from pants.core.goals.generate_lockfiles import ToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.fs import CreateDigest, FileContent
 from pants.engine.rules import collect_rules, rule
@@ -129,18 +129,18 @@ class TwineSubsystem(PythonToolBase):
         return CreateDigest((FileContent(chrooted_ca_certs_path, ca_certs_content),))
 
 
-class TwineLockfileSentinel(ToolLockfileSentinel):
+class TwineLockfileSentinel(GenerateToolLockfileSentinel):
     options_scope = TwineSubsystem.options_scope
 
 
 @rule
-def setup_twine_lockfile(_: TwineLockfileSentinel, twine: TwineSubsystem) -> PythonLockfileRequest:
-    return PythonLockfileRequest.from_tool(twine)
+def setup_twine_lockfile(_: TwineLockfileSentinel, twine: TwineSubsystem) -> GeneratePythonLockfile:
+    return GeneratePythonLockfile.from_tool(twine)
 
 
 def rules():
     return (
         *collect_rules(),
         *lockfile.rules(),
-        UnionRule(ToolLockfileSentinel, TwineLockfileSentinel),
+        UnionRule(GenerateToolLockfileSentinel, TwineLockfileSentinel),
     )

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from typing import Iterable, cast
 
 from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import PythonLockfileRequest
+from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (
@@ -24,7 +24,7 @@ from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
     PythonSourceFilesRequest,
 )
-from pants.core.goals.generate_lockfiles import ToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.engine.addresses import Addresses, UnparsedAddressInputs
 from pants.engine.fs import EMPTY_DIGEST, Digest, DigestContents, FileContent
@@ -283,7 +283,7 @@ async def mypy_first_party_plugins(
 # --------------------------------------------------------------------------------------
 
 
-class MyPyLockfileSentinel(ToolLockfileSentinel):
+class MyPyLockfileSentinel(GenerateToolLockfileSentinel):
     options_scope = MyPy.options_scope
 
 
@@ -296,9 +296,9 @@ async def setup_mypy_lockfile(
     first_party_plugins: MyPyFirstPartyPlugins,
     mypy: MyPy,
     python_setup: PythonSetup,
-) -> PythonLockfileRequest:
+) -> GeneratePythonLockfile:
     if not mypy.uses_lockfile:
-        return PythonLockfileRequest.from_tool(mypy)
+        return GeneratePythonLockfile.from_tool(mypy)
 
     constraints = mypy.interpreter_constraints
     if mypy.options.is_default("interpreter_constraints"):
@@ -316,7 +316,7 @@ async def setup_mypy_lockfile(
         if code_constraints.requires_python38_or_newer(python_setup.interpreter_universe):
             constraints = code_constraints
 
-    return PythonLockfileRequest.from_tool(
+    return GeneratePythonLockfile.from_tool(
         mypy, constraints, extra_requirements=first_party_plugins.requirement_strings
     )
 
@@ -325,5 +325,5 @@ def rules():
     return (
         *collect_rules(),
         *lockfile.rules(),
-        UnionRule(ToolLockfileSentinel, MyPyLockfileSentinel),
+        UnionRule(GenerateToolLockfileSentinel, MyPyLockfileSentinel),
     )

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem_test.py
@@ -8,7 +8,7 @@ from textwrap import dedent
 import pytest
 
 from pants.backend.python import target_types_rules
-from pants.backend.python.goals.lockfile import PythonLockfileRequest
+from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.target_types import PythonRequirementTarget, PythonSourcesGeneratorTarget
 from pants.backend.python.typecheck.mypy import skip_field, subsystem
 from pants.backend.python.typecheck.mypy.subsystem import (
@@ -37,7 +37,7 @@ def rule_runner() -> RuleRunner:
             *target_types_rules.rules(),
             QueryRule(MyPyConfigFile, []),
             QueryRule(MyPyFirstPartyPlugins, []),
-            QueryRule(PythonLockfileRequest, [MyPyLockfileSentinel]),
+            QueryRule(GeneratePythonLockfile, [MyPyLockfileSentinel]),
         ],
         target_types=[PythonSourcesGeneratorTarget, PythonRequirementTarget, GenericTarget],
     )
@@ -158,7 +158,7 @@ def test_setup_lockfile_interpreter_constraints(rule_runner: RuleRunner) -> None
             env={"PANTS_PYTHON_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"},
             env_inherit={"PATH", "PYENV_ROOT", "HOME"},
         )
-        lockfile_request = rule_runner.request(PythonLockfileRequest, [MyPyLockfileSentinel()])
+        lockfile_request = rule_runner.request(GeneratePythonLockfile, [MyPyLockfileSentinel()])
         assert lockfile_request.interpreter_constraints == InterpreterConstraints(expected_ics)
         assert lockfile_request.requirements == FrozenOrderedSet(
             [

--- a/src/python/pants/backend/python/util_rules/lockfile_metadata.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_metadata.py
@@ -64,13 +64,12 @@ class PythonLockfileMetadata(LockfileMetadata):
 
         Subclasses should call `super` and update the resulting dictionary.
         """
-
-        d = super()._header_dict()
-        d["valid_for_interpreter_constraints"] = [
-            str(ic) for ic in self.valid_for_interpreter_constraints
-        ]
-
-        return d
+        return {
+            **super()._header_dict(),
+            "valid_for_interpreter_constraints": [
+                str(ic) for ic in self.valid_for_interpreter_constraints
+            ]
+        }
 
     def is_valid_for(
         self,
@@ -108,9 +107,10 @@ class PythonLockfileMetadataV1(PythonLockfileMetadata):
         return PythonLockfileMetadataV1(interpreter_constraints, requirements_digest)
 
     def _header_dict(self) -> dict[Any, Any]:
-        d = super()._header_dict()
-        d["requirements_invalidation_digest"] = self.requirements_invalidation_digest
-        return d
+        return {
+            **super()._header_dict(),
+            "requirements_invalidation_digest": self.requirements_invalidation_digest
+        }
 
     def is_valid_for(
         self,
@@ -167,14 +167,14 @@ class PythonLockfileMetadataV2(PythonLockfileMetadata):
         return PythonLockfileMetadataV2(interpreter_constraints, requirements)
 
     def _header_dict(self) -> dict[Any, Any]:
-        out = super()._header_dict()
-
-        # Requirements need to be stringified then sorted so that tests are deterministic. Sorting
-        # followed by stringifying does not produce a meaningful result.
-        out["generated_with_requirements"] = (
-            sorted(str(i) for i in self.requirements) if self.requirements is not None else None
-        )
-        return out
+        return {
+            **super()._header_dict(),
+            # Requirements need to be stringified then sorted so that tests are deterministic.
+            # Sorting followed by stringifying does not produce a meaningful result.
+            "generated_with_requirements": (
+                sorted(str(i) for i in self.requirements) if self.requirements is not None else None
+            )
+        }
 
     def is_valid_for(
         self,

--- a/src/python/pants/backend/python/util_rules/lockfile_metadata.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_metadata.py
@@ -68,7 +68,7 @@ class PythonLockfileMetadata(LockfileMetadata):
             **super()._header_dict(),
             "valid_for_interpreter_constraints": [
                 str(ic) for ic in self.valid_for_interpreter_constraints
-            ]
+            ],
         }
 
     def is_valid_for(
@@ -109,7 +109,7 @@ class PythonLockfileMetadataV1(PythonLockfileMetadata):
     def _header_dict(self) -> dict[Any, Any]:
         return {
             **super()._header_dict(),
-            "requirements_invalidation_digest": self.requirements_invalidation_digest
+            "requirements_invalidation_digest": self.requirements_invalidation_digest,
         }
 
     def is_valid_for(
@@ -173,7 +173,7 @@ class PythonLockfileMetadataV2(PythonLockfileMetadata):
             # Sorting followed by stringifying does not produce a meaningful result.
             "generated_with_requirements": (
                 sorted(str(i) for i in self.requirements) if self.requirements is not None else None
-            )
+            ),
         }
 
     def is_valid_for(

--- a/src/python/pants/backend/scala/compile/scalac_plugins.py
+++ b/src/python/pants/backend/scala/compile/scalac_plugins.py
@@ -13,12 +13,12 @@ from pants.backend.scala.target_types import (
     ScalacPluginTarget,
 )
 from pants.build_graph.address import AddressInput
-from pants.core.goals.generate_lockfiles import ToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import WrappedTarget
 from pants.engine.unions import UnionRule
 from pants.jvm.goals import lockfile
-from pants.jvm.goals.lockfile import JvmLockfileRequest
+from pants.jvm.goals.lockfile import GenerateJvmLockfile
 from pants.jvm.resolve.common import ArtifactRequirements
 from pants.jvm.resolve.coursier_fetch import (
     CoursierResolvedLockfile,
@@ -67,7 +67,7 @@ async def parse_global_scalac_plugins(scalac_plugins: Scalac) -> _LoadedGlobalSc
     )
 
 
-class GlobalScalacPluginsToolLockfileSentinel(ToolLockfileSentinel):
+class GlobalScalacPluginsToolLockfileSentinel(GenerateToolLockfileSentinel):
     options_scope = "scalac-plugins"
 
 
@@ -76,7 +76,7 @@ async def generate_global_scalac_plugins_lockfile_request(
     _: GlobalScalacPluginsToolLockfileSentinel,
     loaded_global_plugins: _LoadedGlobalScalacPlugins,
     scalac_plugins: Scalac,
-) -> JvmLockfileRequest:
+) -> GenerateJvmLockfile:
     artifacts = await Get(
         ArtifactRequirements,
         GatherJvmCoordinatesRequest(
@@ -84,7 +84,7 @@ async def generate_global_scalac_plugins_lockfile_request(
             f"[{scalac_plugins.options_scope}].plugins_global",
         ),
     )
-    return JvmLockfileRequest(
+    return GenerateJvmLockfile(
         artifacts=artifacts,
         resolve_name="scalac-plugins",
         lockfile_dest=scalac_plugins.plugins_global_lockfile,
@@ -123,5 +123,5 @@ def rules():
         *collect_rules(),
         *jvm_tool_rules(),
         *lockfile.rules(),
-        UnionRule(ToolLockfileSentinel, GlobalScalacPluginsToolLockfileSentinel),
+        UnionRule(GenerateToolLockfileSentinel, GlobalScalacPluginsToolLockfileSentinel),
     )

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -12,7 +12,7 @@ from pants.backend.scala.lint.scalafmt.subsystem import ScalafmtSubsystem
 from pants.backend.scala.target_types import ScalaSourceField
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.core.goals.fmt import FmtRequest, FmtResult
-from pants.core.goals.generate_lockfiles import ToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.goals.lint import LintRequest, LintResult, LintResults
 from pants.core.goals.tailor import group_by_dir
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
@@ -30,7 +30,7 @@ from pants.engine.rules import collect_rules, rule
 from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.jvm.goals import lockfile
-from pants.jvm.goals.lockfile import JvmLockfileRequest, JvmLockfileRequestFromTool
+from pants.jvm.goals.lockfile import GenerateJvmLockfile, GenerateJvmLockfileFromTool
 from pants.jvm.jdk_rules import JdkSetup
 from pants.jvm.resolve.coursier_fetch import (
     CoursierResolvedLockfile,
@@ -60,7 +60,7 @@ class ScalafmtRequest(FmtRequest, LintRequest):
     field_set_type = ScalafmtFieldSet
 
 
-class ScalafmtToolLockfileSentinel(ToolLockfileSentinel):
+class ScalafmtToolLockfileSentinel(GenerateToolLockfileSentinel):
     options_scope = ScalafmtSubsystem.options_scope
 
 
@@ -327,8 +327,8 @@ async def scalafmt_lint(field_sets: ScalafmtRequest, tool: ScalafmtSubsystem) ->
 @rule
 async def generate_scalafmt_lockfile_request(
     _: ScalafmtToolLockfileSentinel, tool: ScalafmtSubsystem
-) -> JvmLockfileRequest:
-    return await Get(JvmLockfileRequest, JvmLockfileRequestFromTool(tool))
+) -> GenerateJvmLockfile:
+    return await Get(GenerateJvmLockfile, GenerateJvmLockfileFromTool(tool))
 
 
 def rules():
@@ -337,5 +337,5 @@ def rules():
         *lockfile.rules(),
         UnionRule(FmtRequest, ScalafmtRequest),
         UnionRule(LintRequest, ScalafmtRequest),
-        UnionRule(ToolLockfileSentinel, ScalafmtToolLockfileSentinel),
+        UnionRule(GenerateToolLockfileSentinel, ScalafmtToolLockfileSentinel),
     ]

--- a/src/python/pants/backend/scala/test/scalatest.py
+++ b/src/python/pants/backend/scala/test/scalatest.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 from pants.backend.scala.subsystems.scalatest import Scalatest
 from pants.backend.scala.target_types import ScalatestTestSourceField
-from pants.core.goals.generate_lockfiles import ToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.goals.test import TestDebugRequest, TestFieldSet, TestResult, TestSubsystem
 from pants.engine.addresses import Addresses
 from pants.engine.fs import Digest, DigestSubset, MergeDigests, PathGlobs, RemovePrefix, Snapshot
@@ -22,7 +22,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.jvm.classpath import Classpath
 from pants.jvm.goals import lockfile
-from pants.jvm.goals.lockfile import JvmLockfileRequest, JvmLockfileRequestFromTool
+from pants.jvm.goals.lockfile import GenerateJvmLockfile, GenerateJvmLockfileFromTool
 from pants.jvm.jdk_rules import JdkSetup
 from pants.jvm.resolve.coursier_fetch import (
     CoursierResolvedLockfile,
@@ -43,7 +43,7 @@ class ScalatestTestFieldSet(TestFieldSet):
     sources: ScalatestTestSourceField
 
 
-class ScalatestToolLockfileSentinel(ToolLockfileSentinel):
+class ScalatestToolLockfileSentinel(GenerateToolLockfileSentinel):
     options_scope = Scalatest.options_scope
 
 
@@ -171,8 +171,8 @@ async def setup_scalatest_debug_request(field_set: ScalatestTestFieldSet) -> Tes
 @rule
 async def generate_scalatest_lockfile_request(
     _: ScalatestToolLockfileSentinel, scalatest: Scalatest
-) -> JvmLockfileRequest:
-    return await Get(JvmLockfileRequest, JvmLockfileRequestFromTool(scalatest))
+) -> GenerateJvmLockfile:
+    return await Get(GenerateJvmLockfile, GenerateJvmLockfileFromTool(scalatest))
 
 
 def rules():
@@ -180,5 +180,5 @@ def rules():
         *collect_rules(),
         *lockfile.rules(),
         UnionRule(TestFieldSet, ScalatestTestFieldSet),
-        UnionRule(ToolLockfileSentinel, ScalatestToolLockfileSentinel),
+        UnionRule(GenerateToolLockfileSentinel, ScalatestToolLockfileSentinel),
     ]

--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -7,13 +7,13 @@ from dataclasses import dataclass
 from pathlib import PurePath
 
 from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import PythonLockfileRequest
+from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
 from pants.backend.python.target_types import EntryPoint
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.backend.terraform.target_types import TerraformModuleSourcesField
 from pants.base.specs import AddressSpecs, MaybeEmptySiblingAddresses
-from pants.core.goals.generate_lockfiles import ToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.internals.selectors import Get
 from pants.engine.process import Process, ProcessResult
@@ -45,15 +45,15 @@ class TerraformHcl2Parser(PythonToolRequirementsBase):
     default_lockfile_url = git_url(default_lockfile_path)
 
 
-class TerraformHcl2ParserLockfileSentinel(ToolLockfileSentinel):
+class TerraformHcl2ParserLockfileSentinel(GenerateToolLockfileSentinel):
     options_scope = TerraformHcl2Parser.options_scope
 
 
 @rule
 def setup_lockfile_request(
     _: TerraformHcl2ParserLockfileSentinel, hcl2_parser: TerraformHcl2Parser
-) -> PythonLockfileRequest:
-    return PythonLockfileRequest.from_tool(hcl2_parser)
+) -> GeneratePythonLockfile:
+    return GeneratePythonLockfile.from_tool(hcl2_parser)
 
 
 @dataclass(frozen=True)
@@ -154,5 +154,5 @@ def rules():
         *collect_rules(),
         *lockfile.rules(),
         UnionRule(InferDependenciesRequest, InferTerraformModuleDependenciesRequest),
-        UnionRule(ToolLockfileSentinel, TerraformHcl2ParserLockfileSentinel),
+        UnionRule(GenerateToolLockfileSentinel, TerraformHcl2ParserLockfileSentinel),
     ]

--- a/src/python/pants/core/goals/generate_lockfiles.py
+++ b/src/python/pants/core/goals/generate_lockfiles.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class Lockfile:
+class GenerateLockfileResult:
     """The result of generating a lockfile for a particular resolve."""
 
     digest: Digest
@@ -31,15 +31,15 @@ class Lockfile:
 
 @union
 @dataclass(frozen=True)
-class LockfileRequest:
+class GenerateLockfile:
     """A union base for generating ecosystem-specific lockfiles.
 
-    Each language ecosystem should set up a subclass of `LockfileRequest`, like
-    `PythonLockfileRequest` and `CoursierLockfileRequest`, and register a union rule. They should
-    also set up a simple rule that goes from that class -> `WrappedLockfileRequest`.
+    Each language ecosystem should set up a subclass of `GenerateLockfile`, like
+    `GeneratePythonLockfile` and `GenerateJVMLockfile`, and register a union rule. They should
+    also set up a simple rule that goes from that class -> `WrappedGenerateLockfile`.
 
-    Subclasses will usually want to add additional properties, such as Python interpreter
-    constraints.
+    Subclasses will usually want to add additional properties, such as what requirements to
+    install and Python interpreter constraints.
     """
 
     resolve_name: str
@@ -47,32 +47,32 @@ class LockfileRequest:
 
 
 @dataclass(frozen=True)
-class WrappedLockfileRequest:
-    request: LockfileRequest
+class WrappedGenerateLockfile:
+    request: GenerateLockfile
 
 
 @union
-class ToolLockfileSentinel:
+class GenerateToolLockfileSentinel:
     """Tools use this as an entry point to say how to generate their tool lockfile.
 
-    Each language ecosystem should set up a union member of `LockfileRequest`, like
-    `PythonLockfileRequest`, as explained in that class's docstring.
+    Each language ecosystem should set up a union member of `GenerateLockfile`, like
+    `GeneratePythonLockfile`, as explained in that class's docstring.
 
-    Then, each tool should subclass `ToolLockfileSentinel` and set up a rule that goes from the
+    Then, each tool should subclass `GenerateToolLockfileSentinel` and set up a rule that goes from the
     subclass -> the language's lockfile request, e.g. BlackLockfileSentinel ->
-    PythonLockfileRequest. Register a union rule for the `ToolLockfileSentinel` subclass.
+    GeneratePythonLockfile. Register a union rule for the `GenerateToolLockfileSentinel` subclass.
     """
 
     options_scope: ClassVar[str]
 
 
-class UserLockfileRequests(Collection[LockfileRequest]):
+class UserGenerateLockfiles(Collection[GenerateLockfile]):
     """All user resolves for a particular language ecosystem to build.
 
     Each language ecosystem should set up a subclass of `RequestedUserResolveNames` (see its
-    docstring), and implement a rule going from that subclass -> UserLockfileRequests. Each element
-    in the returned `UserLockfileRequests` should be a subclass of `LockfileRequest`, like
-    `PythonLockfileRequest`.
+    docstring), and implement a rule going from that subclass -> UserGenerateLockfiles. Each element
+    in the returned `UserGenerateLockfiles` should be a subclass of `GenerateLockfile`, like
+    `GeneratePythonLockfile`.
     """
 
 
@@ -104,7 +104,7 @@ class RequestedUserResolveNames(Collection[str]):
     """The user resolves requested for a particular language ecosystem.
 
     Each language ecosystem should set up a subclass and register it with a UnionRule. Implement a
-    rule that goes from the subclass -> UserLockfileRequests.
+    rule that goes from the subclass -> UserGenerateLockfiles.
     """
 
 
@@ -158,8 +158,8 @@ class AmbiguousResolveNamesError(Exception):
             if not user_providers:
                 raise AssertionError(
                     f"{len(tool_providers)} tools have the same options_scope: {ambiguous_name}. "
-                    "If you're writing a plugin, rename your `ToolLockfileSentinel`s so that "
-                    "there is no ambiguity. Otherwise, please open a bug at "
+                    "If you're writing a plugin, rename your `GenerateToolLockfileSentinel`s so "
+                    "that there is no ambiguity. Otherwise, please open a bug at "
                     "https://github.com/pantsbuild/pants/issues/new."
                 )
             if len(user_providers) == 1:
@@ -188,7 +188,7 @@ class AmbiguousResolveNamesError(Exception):
 
 def _check_ambiguous_resolve_names(
     all_known_user_resolve_names: Iterable[KnownUserResolveNames],
-    all_tool_sentinels: Iterable[type[ToolLockfileSentinel]],
+    all_tool_sentinels: Iterable[type[GenerateToolLockfileSentinel]],
 ) -> None:
     resolve_name_to_providers = defaultdict(set)
     for sentinel in all_tool_sentinels:
@@ -208,9 +208,9 @@ def _check_ambiguous_resolve_names(
 
 def determine_resolves_to_generate(
     all_known_user_resolve_names: Iterable[KnownUserResolveNames],
-    all_tool_sentinels: Iterable[type[ToolLockfileSentinel]],
+    all_tool_sentinels: Iterable[type[GenerateToolLockfileSentinel]],
     requested_resolve_names: set[str],
-) -> tuple[list[RequestedUserResolveNames], list[type[ToolLockfileSentinel]]]:
+) -> tuple[list[RequestedUserResolveNames], list[type[GenerateToolLockfileSentinel]]]:
     """Apply the `--resolve` option to determine which resolves are specified.
 
     Return a tuple of `(user_resolves, tool_lockfile_sentinels)`.
@@ -259,8 +259,8 @@ def determine_resolves_to_generate(
 
 
 def filter_tool_lockfile_requests(
-    specified_requests: Sequence[WrappedLockfileRequest], *, resolve_specified: bool
-) -> list[LockfileRequest]:
+    specified_requests: Sequence[WrappedGenerateLockfile], *, resolve_specified: bool
+) -> list[GenerateLockfile]:
     result = []
     for wrapped_req in specified_requests:
         req = wrapped_req.request
@@ -285,7 +285,7 @@ def filter_tool_lockfile_requests(
 class GenerateLockfilesSubsystem(GoalSubsystem):
     name = "generate-lockfiles"
     help = "Generate lockfiles for Python third-party dependencies."
-    required_union_implementations = (ToolLockfileSentinel, KnownUserResolveNamesRequest)
+    required_union_implementations = (GenerateToolLockfileSentinel, KnownUserResolveNamesRequest)
 
     @classmethod
     def register_options(cls, register) -> None:
@@ -346,16 +346,16 @@ async def generate_lockfiles_goal(
     )
     requested_user_resolve_names, requested_tool_sentinels = determine_resolves_to_generate(
         known_user_resolve_names,
-        union_membership.get(ToolLockfileSentinel),
+        union_membership.get(GenerateToolLockfileSentinel),
         set(generate_lockfiles_subsystem.resolve_names),
     )
 
     all_specified_user_requests = await MultiGet(
-        Get(UserLockfileRequests, RequestedUserResolveNames, resolve_names)
+        Get(UserGenerateLockfiles, RequestedUserResolveNames, resolve_names)
         for resolve_names in requested_user_resolve_names
     )
     specified_tool_requests = await MultiGet(
-        Get(WrappedLockfileRequest, ToolLockfileSentinel, sentinel())
+        Get(WrappedGenerateLockfile, GenerateToolLockfileSentinel, sentinel())
         for sentinel in requested_tool_sentinels
     )
     applicable_tool_requests = filter_tool_lockfile_requests(
@@ -364,7 +364,7 @@ async def generate_lockfiles_goal(
     )
 
     results = await MultiGet(
-        Get(Lockfile, LockfileRequest, req)
+        Get(GenerateLockfileResult, GenerateLockfile, req)
         for req in (
             *(req for reqs in all_specified_user_requests for req in reqs),
             *applicable_tool_requests,

--- a/src/python/pants/core/goals/generate_lockfiles_test.py
+++ b/src/python/pants/core/goals/generate_lockfiles_test.py
@@ -9,25 +9,25 @@ from pants.core.goals.generate_lockfiles import (
     DEFAULT_TOOL_LOCKFILE,
     NO_TOOL_LOCKFILE,
     AmbiguousResolveNamesError,
+    GenerateLockfile,
+    GenerateToolLockfileSentinel,
     KnownUserResolveNames,
-    LockfileRequest,
     RequestedUserResolveNames,
-    ToolLockfileSentinel,
     UnrecognizedResolveNamesError,
-    WrappedLockfileRequest,
+    WrappedGenerateLockfile,
     determine_resolves_to_generate,
     filter_tool_lockfile_requests,
 )
 
 
 def test_determine_tool_sentinels_to_generate() -> None:
-    class Tool1(ToolLockfileSentinel):
+    class Tool1(GenerateToolLockfileSentinel):
         options_scope = "tool1"
 
-    class Tool2(ToolLockfileSentinel):
+    class Tool2(GenerateToolLockfileSentinel):
         options_scope = "tool2"
 
-    class Tool3(ToolLockfileSentinel):
+    class Tool3(GenerateToolLockfileSentinel):
         options_scope = "tool3"
 
     class Lang1Requested(RequestedUserResolveNames):
@@ -46,7 +46,7 @@ def test_determine_tool_sentinels_to_generate() -> None:
     def assert_chosen(
         requested: set[str],
         expected_user_resolves: list[RequestedUserResolveNames],
-        expected_tools: list[type[ToolLockfileSentinel]],
+        expected_tools: list[type[GenerateToolLockfileSentinel]],
     ) -> None:
         user_resolves, tools = determine_resolves_to_generate(
             [lang1_resolves, lang2_resolves], [Tool1, Tool2, Tool3], requested
@@ -76,7 +76,7 @@ def test_determine_tool_sentinels_to_generate() -> None:
         assert_chosen({"fake"}, expected_user_resolves=[], expected_tools=[])
 
     # Error if same resolve name used for tool lockfiles and user lockfiles.
-    class AmbiguousTool(ToolLockfileSentinel):
+    class AmbiguousTool(GenerateToolLockfileSentinel):
         options_scope = "ambiguous"
 
     with pytest.raises(AmbiguousResolveNamesError):
@@ -111,8 +111,8 @@ def test_determine_tool_sentinels_to_generate() -> None:
 
 
 def test_filter_tool_lockfile_requests() -> None:
-    def create_request(name: str, lockfile_dest: str | None = None) -> LockfileRequest:
-        return LockfileRequest(resolve_name=name, lockfile_dest=lockfile_dest or f"{name}.txt")
+    def create_request(name: str, lockfile_dest: str | None = None) -> GenerateLockfile:
+        return GenerateLockfile(resolve_name=name, lockfile_dest=lockfile_dest or f"{name}.txt")
 
     tool1 = create_request("tool1")
     tool2 = create_request("tool2")
@@ -120,13 +120,13 @@ def test_filter_tool_lockfile_requests() -> None:
     default_tool = create_request("default", lockfile_dest=DEFAULT_TOOL_LOCKFILE)
 
     def assert_filtered(
-        extra_request: LockfileRequest | None,
+        extra_request: GenerateLockfile | None,
         *,
         resolve_specified: bool,
     ) -> None:
-        requests = [WrappedLockfileRequest(tool1), WrappedLockfileRequest(tool2)]
+        requests = [WrappedGenerateLockfile(tool1), WrappedGenerateLockfile(tool2)]
         if extra_request:
-            requests.append(WrappedLockfileRequest(extra_request))
+            requests.append(WrappedGenerateLockfile(extra_request))
         assert filter_tool_lockfile_requests(requests, resolve_specified=resolve_specified) == [
             tool1,
             tool2,

--- a/src/python/pants/jvm/resolve/jvm_tool.py
+++ b/src/python/pants/jvm/resolve/jvm_tool.py
@@ -89,8 +89,7 @@ class JvmToolBase(Subsystem):
     @property
     def lockfile(self) -> str:
         f"""The path to a lockfile or special string '{DEFAULT_TOOL_LOCKFILE}'."""
-        lockfile = cast(str, self.options.lockfile)
-        return lockfile
+        return cast(str, self.options.lockfile)
 
     def lockfile_content(self) -> bytes:
         lockfile_path = self.lockfile

--- a/src/python/pants/jvm/resolve/lockfile_metadata.py
+++ b/src/python/pants/jvm/resolve/lockfile_metadata.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Iterable, cast
@@ -17,8 +16,6 @@ from pants.core.util_rules.lockfile_metadata import (
 )
 from pants.jvm.resolve.common import ArtifactRequirement
 from pants.util.ordered_set import FrozenOrderedSet
-
-logger = logging.getLogger(__name__)
 
 _jvm_lockfile_metadata = lockfile_metadata_registrar(LockfileScope.JVM)
 
@@ -56,15 +53,6 @@ class JVMLockfileMetadata(LockfileMetadata):
                 LockfileScope.JVM, lockfile, lockfile_path, resolve_name
             ),
         )
-
-    def _header_dict(self) -> dict[Any, Any]:
-        """Produce a dictionary to be serialized into the lockfile header.
-
-        Subclasses should call `super` and update the resulting dictionary.
-        """
-
-        d = super()._header_dict()
-        return d
 
     def is_valid_for(
         self,
@@ -111,12 +99,12 @@ class JVMLockfileMetadataV1(JVMLockfileMetadata):
         return JVMLockfileMetadataV1(requirements)
 
     def _header_dict(self) -> dict[Any, Any]:
-        out = super()._header_dict()
-
-        out["generated_with_requirements"] = (
-            sorted(self.requirements) if self.requirements is not None else None
-        )
-        return out
+        return {
+            **super()._header_dict(),
+            "generated_with_requirements": (
+                sorted(self.requirements) if self.requirements is not None else None
+            ),
+        }
 
     def is_valid_for(
         self,

--- a/src/python/pants/jvm/resolve/lockfile_metadata.py
+++ b/src/python/pants/jvm/resolve/lockfile_metadata.py
@@ -54,6 +54,14 @@ class JVMLockfileMetadata(LockfileMetadata):
             ),
         )
 
+    def _header_dict(self) -> dict[Any, Any]:
+        """Produce a dictionary to be serialized into the lockfile header.
+
+        Subclasses should call `super` and update the resulting dictionary.
+        """
+        d = super()._header_dict()
+        return d
+
     def is_valid_for(
         self,
         requirements: Iterable[ArtifactRequirement] | None,

--- a/src/python/pants/jvm/test/junit.py
+++ b/src/python/pants/jvm/test/junit.py
@@ -5,7 +5,7 @@ import logging
 from dataclasses import dataclass
 
 from pants.backend.java.subsystems.junit import JUnit
-from pants.core.goals.generate_lockfiles import ToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.goals.test import TestDebugRequest, TestFieldSet, TestResult, TestSubsystem
 from pants.engine.addresses import Addresses
 from pants.engine.fs import Digest, DigestSubset, MergeDigests, PathGlobs, RemovePrefix, Snapshot
@@ -21,7 +21,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.jvm.classpath import Classpath
 from pants.jvm.goals import lockfile
-from pants.jvm.goals.lockfile import JvmLockfileRequest, JvmLockfileRequestFromTool
+from pants.jvm.goals.lockfile import GenerateJvmLockfile, GenerateJvmLockfileFromTool
 from pants.jvm.jdk_rules import JdkSetup
 from pants.jvm.resolve.coursier_fetch import (
     CoursierResolvedLockfile,
@@ -43,7 +43,7 @@ class JunitTestFieldSet(TestFieldSet):
     sources: JunitTestSourceField
 
 
-class JunitToolLockfileSentinel(ToolLockfileSentinel):
+class JunitToolLockfileSentinel(GenerateToolLockfileSentinel):
     options_scope = JUnit.options_scope
 
 
@@ -168,8 +168,8 @@ async def setup_junit_debug_request(field_set: JunitTestFieldSet) -> TestDebugRe
 @rule
 async def generate_junit_lockfile_request(
     _: JunitToolLockfileSentinel, junit: JUnit
-) -> JvmLockfileRequest:
-    return await Get(JvmLockfileRequest, JvmLockfileRequestFromTool(junit))
+) -> GenerateJvmLockfile:
+    return await Get(GenerateJvmLockfile, GenerateJvmLockfileFromTool(junit))
 
 
 def rules():
@@ -177,5 +177,5 @@ def rules():
         *collect_rules(),
         *lockfile.rules(),
         UnionRule(TestFieldSet, JunitTestFieldSet),
-        UnionRule(ToolLockfileSentinel, JunitToolLockfileSentinel),
+        UnionRule(GenerateToolLockfileSentinel, JunitToolLockfileSentinel),
     ]


### PR DESCRIPTION
There are two ways we "consume" lockfiles:

* To generate it and save on disk, which requires doing a resolve.
* To read an already-generated lockfile on disk.

@chrisjrn and I found that the current types are confusing to distinguish between these two uses. This is the first of multiple refactors to make more clear the types by renaming `LockfileRequest` to `GenerateLockfile` and `Lockfile` to `GenerateLockfileResult`.