### PR TITLE
Cap number of UI bars to terminal height

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -3545,6 +3545,7 @@ dependencies = [
  "parking_lot",
  "stdio",
  "task_executor",
+ "terminal_size",
  "uuid",
  "workunit_store",
 ]

--- a/src/rust/engine/ui/Cargo.toml
+++ b/src/rust/engine/ui/Cargo.toml
@@ -15,6 +15,7 @@ indicatif = "0.16.2"
 logging = { path = "../logging" }
 parking_lot = "0.11"
 stdio = { path = "../stdio" }
+terminal_size = "0.1.15"
 task_executor = { path = "../task_executor" }
 uuid = { version = "0.8", features = ["v4"] }
 workunit_store = { path = "../workunit_store" }

--- a/src/rust/engine/ui/src/console_ui.rs
+++ b/src/rust/engine/ui/src/console_ui.rs
@@ -35,7 +35,7 @@ use futures::future::{self, FutureExt, TryFutureExt};
 use indexmap::IndexMap;
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle, WeakProgressBar};
 use parking_lot::Mutex;
-use terminal_size::{terminal_size, Height, Width};
+use terminal_size::terminal_size;
 
 use task_executor::Executor;
 use workunit_store::{format_workunit_duration, SpanId, WorkunitStore};

--- a/src/rust/engine/ui/src/console_ui.rs
+++ b/src/rust/engine/ui/src/console_ui.rs
@@ -120,6 +120,7 @@ impl ConsoleUI {
     // render might barely miss a data refresh.
     let draw_target = ProgressDrawTarget::term(term, Self::render_rate_hz() * 2);
     let multi_progress = MultiProgress::with_draw_target(draw_target);
+    multi_progress.set_move_cursor(false);
     let terminal_dimensions = terminal_size().unwrap_or((Width(50), Height(self.local_parallelism.try_into().unwrap())));
     let terminal_width = terminal_dimensions.0.0;
     let terminal_height = terminal_dimensions.1.0 - 1;

--- a/src/rust/engine/ui/src/console_ui.rs
+++ b/src/rust/engine/ui/src/console_ui.rs
@@ -120,12 +120,9 @@ impl ConsoleUI {
     // render might barely miss a data refresh.
     let draw_target = ProgressDrawTarget::term(term, Self::render_rate_hz() * 2);
     let multi_progress = MultiProgress::with_draw_target(draw_target);
-    let (terminal_width, terminal_height) = terminal_size().map(|terminal_dimensions| {
-      (terminal_dimensions.0.0, terminal_dimensions.1.0 - 1)
-    }).unwrap_or((
-      50,
-      self.local_parallelism.try_into().unwrap(),
-    ));
+    let (terminal_width, terminal_height) = terminal_size()
+      .map(|terminal_dimensions| (terminal_dimensions.0 .0, terminal_dimensions.1 .0 - 1))
+      .unwrap_or((50, self.local_parallelism.try_into().unwrap()));
 
     let bars = (0..cmp::min(self.local_parallelism, terminal_height.into()))
       .map(|_n| {

--- a/src/rust/engine/ui/src/console_ui.rs
+++ b/src/rust/engine/ui/src/console_ui.rs
@@ -29,11 +29,13 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
+use std::cmp;
 
 use futures::future::{self, FutureExt, TryFutureExt};
 use indexmap::IndexMap;
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle, WeakProgressBar};
 use parking_lot::Mutex;
+use terminal_size::{Width, Height, terminal_size};
 
 use task_executor::Executor;
 use workunit_store::{format_workunit_duration, SpanId, WorkunitStore};
@@ -118,11 +120,14 @@ impl ConsoleUI {
     // render might barely miss a data refresh.
     let draw_target = ProgressDrawTarget::term(term, Self::render_rate_hz() * 2);
     let multi_progress = MultiProgress::with_draw_target(draw_target);
+    let terminal_dimensions = terminal_size().unwrap_or((Width(50), Height(self.local_parallelism.try_into().unwrap())));
+    let terminal_width = terminal_dimensions.0.0;
+    let terminal_height = terminal_dimensions.1.0 - 1;
 
-    let bars = (0..self.local_parallelism)
+    let bars = (0..cmp::min(self.local_parallelism, terminal_height.into()))
       .map(|_n| {
         let style = ProgressStyle::default_bar().template("{spinner} {wide_msg}");
-        multi_progress.add(ProgressBar::new(50).with_style(style))
+        multi_progress.add(ProgressBar::new(terminal_width.into()).with_style(style))
       })
       .collect::<Vec<_>>();
     *stderr_dest_bar_guard = Some(bars[0].downgrade());

--- a/src/rust/engine/ui/src/console_ui.rs
+++ b/src/rust/engine/ui/src/console_ui.rs
@@ -120,12 +120,12 @@ impl ConsoleUI {
     // render might barely miss a data refresh.
     let draw_target = ProgressDrawTarget::term(term, Self::render_rate_hz() * 2);
     let multi_progress = MultiProgress::with_draw_target(draw_target);
-    let terminal_dimensions = terminal_size().unwrap_or((
-      Width(50),
-      Height(self.local_parallelism.try_into().unwrap()),
+    let (terminal_width, terminal_height) = terminal_size().map(|terminal_dimensions| {
+      (terminal_dimensions.0.0, terminal_dimensions.1.0 - 1)
+    }).unwrap_or((
+      50,
+      self.local_parallelism.try_into().unwrap(),
     ));
-    let terminal_width = terminal_dimensions.0 .0;
-    let terminal_height = terminal_dimensions.1 .0 - 1;
 
     let bars = (0..cmp::min(self.local_parallelism, terminal_height.into()))
       .map(|_n| {

--- a/src/rust/engine/ui/src/console_ui.rs
+++ b/src/rust/engine/ui/src/console_ui.rs
@@ -25,17 +25,17 @@
 // Arc<Mutex> can be more clear than needing to grok Orderings:
 #![allow(clippy::mutex_atomic)]
 
+use std::cmp;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
-use std::cmp;
 
 use futures::future::{self, FutureExt, TryFutureExt};
 use indexmap::IndexMap;
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle, WeakProgressBar};
 use parking_lot::Mutex;
-use terminal_size::{Width, Height, terminal_size};
+use terminal_size::{terminal_size, Height, Width};
 
 use task_executor::Executor;
 use workunit_store::{format_workunit_duration, SpanId, WorkunitStore};
@@ -121,9 +121,12 @@ impl ConsoleUI {
     let draw_target = ProgressDrawTarget::term(term, Self::render_rate_hz() * 2);
     let multi_progress = MultiProgress::with_draw_target(draw_target);
     multi_progress.set_move_cursor(false);
-    let terminal_dimensions = terminal_size().unwrap_or((Width(50), Height(self.local_parallelism.try_into().unwrap())));
-    let terminal_width = terminal_dimensions.0.0;
-    let terminal_height = terminal_dimensions.1.0 - 1;
+    let terminal_dimensions = terminal_size().unwrap_or((
+      Width(50),
+      Height(self.local_parallelism.try_into().unwrap()),
+    ));
+    let terminal_width = terminal_dimensions.0 .0;
+    let terminal_height = terminal_dimensions.1 .0 - 1;
 
     let bars = (0..cmp::min(self.local_parallelism, terminal_height.into()))
       .map(|_n| {

--- a/src/rust/engine/ui/src/console_ui.rs
+++ b/src/rust/engine/ui/src/console_ui.rs
@@ -120,7 +120,6 @@ impl ConsoleUI {
     // render might barely miss a data refresh.
     let draw_target = ProgressDrawTarget::term(term, Self::render_rate_hz() * 2);
     let multi_progress = MultiProgress::with_draw_target(draw_target);
-    multi_progress.set_move_cursor(false);
     let terminal_dimensions = terminal_size().unwrap_or((
       Width(50),
       Height(self.local_parallelism.try_into().unwrap()),


### PR DESCRIPTION
Fixes https://github.com/pantsbuild/pants/issues/13367 by capping the # of progress bars to terminal height.
Also sets the progress bar width to terminal width.

|Scenario | Before | After |
| ----------- | ----------- | ---- |
| Terminal height > # cores | [MP4](https://user-images.githubusercontent.com/3956745/150561570-1d69c273-f597-48e5-8a33-63eac70b72fc.mp4)       | [MP4](https://user-images.githubusercontent.com/3956745/150560736-8becce2c-a07e-4d67-9151-0a5603c76631.mp4) |
| Terminal height < # cores | [MP4](https://user-images.githubusercontent.com/3956745/150561691-3dffc9d2-9012-4237-b94e-d8bf3456ca5c.mp4) | [MP4](https://user-images.githubusercontent.com/3956745/150560943-47787fd3-25c4-4cc8-8156-c96d01e70c21.mp4) | 







