### PR TITLE
Rename `GenerateToolLockfileSentinel.options_scope` to `resolve_name`

### DIFF
--- a/src/python/pants/backend/codegen/avro/java/rules.py
+++ b/src/python/pants/backend/codegen/avro/java/rules.py
@@ -53,7 +53,7 @@ class GenerateJavaFromAvroRequest(GenerateSourcesRequest):
 
 
 class AvroToolLockfileSentinel(GenerateToolLockfileSentinel):
-    options_scope = AvroSubsystem.options_scope
+    resolve_name = AvroSubsystem.options_scope
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -75,7 +75,7 @@ class PythonProtobufMypyPlugin(PythonToolRequirementsBase):
 
 
 class MypyProtobufLockfileSentinel(GenerateToolLockfileSentinel):
-    options_scope = PythonProtobufMypyPlugin.options_scope
+    resolve_name = PythonProtobufMypyPlugin.options_scope
 
 
 @rule

--- a/src/python/pants/backend/codegen/protobuf/scala/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/rules.py
@@ -65,7 +65,7 @@ class GenerateScalaFromProtobufRequest(GenerateSourcesRequest):
 
 
 class ScalapbcToolLockfileSentinel(GenerateToolLockfileSentinel):
-    options_scope = ScalaPBSubsystem.options_scope
+    resolve_name = ScalaPBSubsystem.options_scope
 
 
 class ScalaPBShimCompiledClassfiles(ClasspathEntry):

--- a/src/python/pants/backend/codegen/thrift/scrooge/rules.py
+++ b/src/python/pants/backend/codegen/thrift/scrooge/rules.py
@@ -41,7 +41,7 @@ class GeneratedScroogeThriftSources:
 
 
 class ScroogeToolLockfileSentinel(GenerateToolLockfileSentinel):
-    options_scope = ScroogeSubsystem.options_scope
+    resolve_name = ScroogeSubsystem.options_scope
 
 
 @rule

--- a/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
+++ b/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
@@ -47,7 +47,7 @@ class DockerfileParser(PythonToolRequirementsBase):
 
 
 class DockerfileParserLockfileSentinel(GenerateToolLockfileSentinel):
-    options_scope = DockerfileParser.options_scope
+    resolve_name = DockerfileParser.options_scope
 
 
 @rule

--- a/src/python/pants/backend/java/lint/google_java_format/rules.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules.py
@@ -48,7 +48,7 @@ class GoogleJavaFormatRequest(FmtRequest, LintRequest):
 
 
 class GoogleJavaFormatToolLockfileSentinel(GenerateToolLockfileSentinel):
-    options_scope = GoogleJavaFormatSubsystem.options_scope
+    resolve_name = GoogleJavaFormatSubsystem.options_scope
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -237,7 +237,7 @@ class CoverageSubsystem(PythonToolBase):
 
 
 class CoveragePyLockfileSentinel(GenerateToolLockfileSentinel):
-    options_scope = CoverageSubsystem.options_scope
+    resolve_name = CoverageSubsystem.options_scope
 
 
 @rule

--- a/src/python/pants/backend/python/lint/autoflake/subsystem.py
+++ b/src/python/pants/backend/python/lint/autoflake/subsystem.py
@@ -63,7 +63,7 @@ class Autoflake(PythonToolBase):
 
 
 class AutoflakeLockfileSentinel(GenerateToolLockfileSentinel):
-    options_scope = Autoflake.options_scope
+    resolve_name = Autoflake.options_scope
 
 
 @rule()

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -112,7 +112,7 @@ class Bandit(PythonToolBase):
 
 
 class BanditLockfileSentinel(GenerateToolLockfileSentinel):
-    options_scope = Bandit.options_scope
+    resolve_name = Bandit.options_scope
 
 
 @rule(

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -108,7 +108,7 @@ class Black(PythonToolBase):
 
 
 class BlackLockfileSentinel(GenerateToolLockfileSentinel):
-    options_scope = Black.options_scope
+    resolve_name = Black.options_scope
 
 
 @rule(

--- a/src/python/pants/backend/python/lint/docformatter/subsystem.py
+++ b/src/python/pants/backend/python/lint/docformatter/subsystem.py
@@ -61,7 +61,7 @@ class Docformatter(PythonToolBase):
 
 
 class DocformatterLockfileSentinel(GenerateToolLockfileSentinel):
-    options_scope = Docformatter.options_scope
+    resolve_name = Docformatter.options_scope
 
 
 @rule

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -232,7 +232,7 @@ async def flake8_first_party_plugins(flake8: Flake8) -> Flake8FirstPartyPlugins:
 
 
 class Flake8LockfileSentinel(GenerateToolLockfileSentinel):
-    options_scope = Flake8.options_scope
+    resolve_name = Flake8.options_scope
 
 
 @rule(

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -127,7 +127,7 @@ class Isort(PythonToolBase):
 
 
 class IsortLockfileSentinel(GenerateToolLockfileSentinel):
-    options_scope = Isort.options_scope
+    resolve_name = Isort.options_scope
 
 
 @rule

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -235,7 +235,7 @@ async def pylint_first_party_plugins(pylint: Pylint) -> PylintFirstPartyPlugins:
 
 
 class PylintLockfileSentinel(GenerateToolLockfileSentinel):
-    options_scope = Pylint.options_scope
+    resolve_name = Pylint.options_scope
 
 
 @rule(

--- a/src/python/pants/backend/python/lint/pyupgrade/subsystem.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/subsystem.py
@@ -66,7 +66,7 @@ class PyUpgrade(PythonToolBase):
 
 
 class PyUpgradeLockfileSentinel(GenerateToolLockfileSentinel):
-    options_scope = PyUpgrade.options_scope
+    resolve_name = PyUpgrade.options_scope
 
 
 @rule

--- a/src/python/pants/backend/python/lint/yapf/subsystem.py
+++ b/src/python/pants/backend/python/lint/yapf/subsystem.py
@@ -119,7 +119,7 @@ class Yapf(PythonToolBase):
 
 
 class YapfLockfileSentinel(GenerateToolLockfileSentinel):
-    options_scope = Yapf.options_scope
+    resolve_name = Yapf.options_scope
 
 
 @rule

--- a/src/python/pants/backend/python/subsystems/ipython.py
+++ b/src/python/pants/backend/python/subsystems/ipython.py
@@ -49,7 +49,7 @@ class IPython(PythonToolBase):
 
 
 class IPythonLockfileSentinel(GenerateToolLockfileSentinel):
-    options_scope = IPython.options_scope
+    resolve_name = IPython.options_scope
 
 
 @rule(

--- a/src/python/pants/backend/python/subsystems/lambdex.py
+++ b/src/python/pants/backend/python/subsystems/lambdex.py
@@ -31,7 +31,7 @@ class Lambdex(PythonToolBase):
 
 
 class LambdexLockfileSentinel(GenerateToolLockfileSentinel):
-    options_scope = Lambdex.options_scope
+    resolve_name = Lambdex.options_scope
 
 
 @rule

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -205,7 +205,7 @@ class PyTest(PythonToolBase):
 
 
 class PytestLockfileSentinel(GenerateToolLockfileSentinel):
-    options_scope = PyTest.options_scope
+    resolve_name = PyTest.options_scope
 
 
 @rule(

--- a/src/python/pants/backend/python/subsystems/setuptools.py
+++ b/src/python/pants/backend/python/subsystems/setuptools.py
@@ -45,7 +45,7 @@ class Setuptools(PythonToolRequirementsBase):
 
 
 class SetuptoolsLockfileSentinel(GenerateToolLockfileSentinel):
-    options_scope = Setuptools.options_scope
+    resolve_name = Setuptools.options_scope
 
 
 @rule(

--- a/src/python/pants/backend/python/subsystems/twine.py
+++ b/src/python/pants/backend/python/subsystems/twine.py
@@ -130,7 +130,7 @@ class TwineSubsystem(PythonToolBase):
 
 
 class TwineLockfileSentinel(GenerateToolLockfileSentinel):
-    options_scope = TwineSubsystem.options_scope
+    resolve_name = TwineSubsystem.options_scope
 
 
 @rule

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -284,7 +284,7 @@ async def mypy_first_party_plugins(
 
 
 class MyPyLockfileSentinel(GenerateToolLockfileSentinel):
-    options_scope = MyPy.options_scope
+    resolve_name = MyPy.options_scope
 
 
 @rule(

--- a/src/python/pants/backend/scala/compile/scalac_plugins.py
+++ b/src/python/pants/backend/scala/compile/scalac_plugins.py
@@ -68,7 +68,7 @@ async def parse_global_scalac_plugins(scalac_plugins: Scalac) -> _LoadedGlobalSc
 
 
 class GlobalScalacPluginsToolLockfileSentinel(GenerateToolLockfileSentinel):
-    options_scope = "scalac-plugins"
+    resolve_name = "scalac-plugins"
 
 
 @rule

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -61,7 +61,7 @@ class ScalafmtRequest(FmtRequest, LintRequest):
 
 
 class ScalafmtToolLockfileSentinel(GenerateToolLockfileSentinel):
-    options_scope = ScalafmtSubsystem.options_scope
+    resolve_name = ScalafmtSubsystem.options_scope
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/scala/test/scalatest.py
+++ b/src/python/pants/backend/scala/test/scalatest.py
@@ -44,7 +44,7 @@ class ScalatestTestFieldSet(TestFieldSet):
 
 
 class ScalatestToolLockfileSentinel(GenerateToolLockfileSentinel):
-    options_scope = Scalatest.options_scope
+    resolve_name = Scalatest.options_scope
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -46,7 +46,7 @@ class TerraformHcl2Parser(PythonToolRequirementsBase):
 
 
 class TerraformHcl2ParserLockfileSentinel(GenerateToolLockfileSentinel):
-    options_scope = TerraformHcl2Parser.options_scope
+    resolve_name = TerraformHcl2Parser.options_scope
 
 
 @rule

--- a/src/python/pants/core/goals/generate_lockfiles.py
+++ b/src/python/pants/core/goals/generate_lockfiles.py
@@ -63,7 +63,7 @@ class GenerateToolLockfileSentinel:
     GeneratePythonLockfile. Register a union rule for the `GenerateToolLockfileSentinel` subclass.
     """
 
-    options_scope: ClassVar[str]
+    resolve_name: ClassVar[str]
 
 
 class UserGenerateLockfiles(Collection[GenerateLockfile]):
@@ -192,8 +192,8 @@ def _check_ambiguous_resolve_names(
 ) -> None:
     resolve_name_to_providers = defaultdict(set)
     for sentinel in all_tool_sentinels:
-        resolve_name_to_providers[sentinel.options_scope].add(
-            _ResolveProvider(sentinel.options_scope, _ResolveProviderType.TOOL)
+        resolve_name_to_providers[sentinel.resolve_name].add(
+            _ResolveProvider(sentinel.resolve_name, _ResolveProviderType.TOOL)
         )
     for known_user_resolve_names in all_known_user_resolve_names:
         for resolve_name in known_user_resolve_names.names:
@@ -218,7 +218,7 @@ def determine_resolves_to_generate(
     _check_ambiguous_resolve_names(all_known_user_resolve_names, all_tool_sentinels)
 
     resolve_names_to_sentinels = {
-        sentinel.options_scope: sentinel for sentinel in all_tool_sentinels
+        sentinel.resolve_name: sentinel for sentinel in all_tool_sentinels
     }
 
     if not requested_resolve_names:

--- a/src/python/pants/core/goals/generate_lockfiles_test.py
+++ b/src/python/pants/core/goals/generate_lockfiles_test.py
@@ -22,13 +22,13 @@ from pants.core.goals.generate_lockfiles import (
 
 def test_determine_tool_sentinels_to_generate() -> None:
     class Tool1(GenerateToolLockfileSentinel):
-        options_scope = "tool1"
+        resolve_name = "tool1"
 
     class Tool2(GenerateToolLockfileSentinel):
-        options_scope = "tool2"
+        resolve_name = "tool2"
 
     class Tool3(GenerateToolLockfileSentinel):
-        options_scope = "tool3"
+        resolve_name = "tool3"
 
     class Lang1Requested(RequestedUserResolveNames):
         pass
@@ -55,12 +55,12 @@ def test_determine_tool_sentinels_to_generate() -> None:
         assert tools == expected_tools
 
     assert_chosen(
-        {Tool2.options_scope, "u2"},
+        {Tool2.resolve_name, "u2"},
         expected_user_resolves=[Lang1Requested(["u2"])],
         expected_tools=[Tool2],
     )
     assert_chosen(
-        {Tool1.options_scope, Tool3.options_scope},
+        {Tool1.resolve_name, Tool3.resolve_name},
         expected_user_resolves=[],
         expected_tools=[Tool1, Tool3],
     )
@@ -77,7 +77,7 @@ def test_determine_tool_sentinels_to_generate() -> None:
 
     # Error if same resolve name used for tool lockfiles and user lockfiles.
     class AmbiguousTool(GenerateToolLockfileSentinel):
-        options_scope = "ambiguous"
+        resolve_name = "ambiguous"
 
     with pytest.raises(AmbiguousResolveNamesError):
         determine_resolves_to_generate(

--- a/src/python/pants/jvm/resolve/jvm_tool_test.py
+++ b/src/python/pants/jvm/resolve/jvm_tool_test.py
@@ -33,7 +33,7 @@ class MockJvmTool(JvmToolBase):
 
 
 class MockJvmToolLockfileSentinel(GenerateToolLockfileSentinel):
-    options_scope = MockJvmTool.options_scope
+    resolve_name = MockJvmTool.options_scope
 
 
 @rule

--- a/src/python/pants/jvm/test/junit.py
+++ b/src/python/pants/jvm/test/junit.py
@@ -44,7 +44,7 @@ class JunitTestFieldSet(TestFieldSet):
 
 
 class JunitToolLockfileSentinel(GenerateToolLockfileSentinel):
-    options_scope = JUnit.options_scope
+    resolve_name = JUnit.options_scope
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
When I named this, I was not expecting to ever have tool lockfiles where the resolve_name != the options_scope. But `scalac-plugins` from `[scalac]` is one example of where this assumption is bad.

[ci skip-rust]
[ci skip-build-wheels]