### PR TITLE
Fix complex `__import__` statements failing to parse with Python 2.7 - 3.7 (Cherry-pick of #14232)

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/import_parser.py
+++ b/src/python/pants/backend/python/dependency_inference/import_parser.py
@@ -67,14 +67,15 @@ class AstVisitor(ast.NodeVisitor):
           and node.func.id == "__import__"
           and len(node.args) == 1
       ):
-          if sys.version_info[0:2] < (3, 8) and isinstance(node.args[0], ast.Str):
-              arg_s = node.args[0].s
-              val = arg_s.decode("utf-8") if isinstance(arg_s, bytes) else arg_s
-              self.imports.add(arg_s)
-              return
-          elif isinstance(node.args[0], ast.Constant):
-              self.imports.add(str(node.args[0].value))
-              return
+            if sys.version_info[0:2] < (3, 8):
+                name = node.args[0].s if isinstance(node.args[0], ast.Str) else None
+            else:
+                name = node.args[0].value if isinstance(node.args[0], ast.Constant) else None
+
+            if name is not None:
+                self.imports_add(name)
+                return
+
       self.generic_visit(node)
 
 if os.environ["STRING_IMPORTS"] == "y":

--- a/src/python/pants/backend/python/dependency_inference/import_parser.py
+++ b/src/python/pants/backend/python/dependency_inference/import_parser.py
@@ -73,7 +73,7 @@ class AstVisitor(ast.NodeVisitor):
                 name = node.args[0].value if isinstance(node.args[0], ast.Constant) else None
 
             if name is not None:
-                self.imports_add(name)
+                self.imports.add(name)
                 return
 
       self.generic_visit(node)

--- a/src/python/pants/backend/python/dependency_inference/import_parser_test.py
+++ b/src/python/pants/backend/python/dependency_inference/import_parser_test.py
@@ -212,6 +212,7 @@ def test_works_with_python2(rule_runner: RuleRunner) -> None:
 
         __import__(u"pkg_resources")
         __import__(b"treat.as.a.regular.import.not.a.string.import")
+        __import__(u"{}".format("interpolation"))
 
         importlib.import_module(b"dep.from.bytes")
         importlib.import_module(u"dep.from.str")


### PR DESCRIPTION
See https://github.com/pantsbuild/pants/pull/14232.

[ci skip-rust]
[ci skip-build-wheels]