### PR TITLE
upgrade to Rust v1.58.1

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -52,7 +52,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.58.0-*
+        path: '~/.rustup/toolchains/1.58.1-*
 
           ~/.rustup/update-hashes
 
@@ -203,7 +203,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.58.0-*
+        path: '~/.rustup/toolchains/1.58.1-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,7 +52,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.58.0-*
+        path: '~/.rustup/toolchains/1.58.1-*
 
           ~/.rustup/update-hashes
 
@@ -202,7 +202,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.58.0-*
+        path: '~/.rustup/toolchains/1.58.1-*
 
           ~/.rustup/update-hashes
 
@@ -399,7 +399,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.58.0-*
+        path: '~/.rustup/toolchains/1.58.1-*
 
           ~/.rustup/update-hashes
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.58.0"
+channel = "1.58.1"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
Upgrade to Rust v1.58.1 with a security vulnerability fix and fixes for a few regressions.

> Rust 1.58.1 fixes a race condition in the std::fs::remove_dir_all standard library function. This security vulnerability is tracked as CVE-2022-21658, and you can read more about it on the advisory we published earlier today. We recommend all users to update their toolchain immediately and rebuild their programs with the updated compiler.

