### PR TITLE
[internal] Refactor consumption of JVM tool lockfiles

### DIFF
--- a/src/python/pants/backend/codegen/avro/java/rules.py
+++ b/src/python/pants/backend/codegen/avro/java/rules.py
@@ -38,8 +38,8 @@ from pants.jvm.jdk_rules import JdkSetup
 from pants.jvm.resolve import jvm_tool
 from pants.jvm.resolve.coursier_fetch import (
     CoursierResolvedLockfile,
-    MaterializedClasspath,
-    MaterializedClasspathRequest,
+    ToolClasspath,
+    ToolClasspathRequest,
 )
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, ValidatedJvmToolLockfileRequest
 from pants.source.source_root import SourceRoot, SourceRootRequest
@@ -106,8 +106,8 @@ async def compile_avro_source(
 
     tool_classpath, subsetted_input_digest, empty_output_dir = await MultiGet(
         Get(
-            MaterializedClasspath,
-            MaterializedClasspathRequest(
+            ToolClasspath,
+            ToolClasspathRequest(
                 lockfiles=(lockfile,),
             ),
         ),

--- a/src/python/pants/backend/codegen/avro/java/rules.py
+++ b/src/python/pants/backend/codegen/avro/java/rules.py
@@ -105,12 +105,7 @@ async def compile_avro_source(
     lockfile = await Get(CoursierResolvedLockfile, ValidatedJvmToolLockfileRequest(avro_tools))
 
     tool_classpath, subsetted_input_digest, empty_output_dir = await MultiGet(
-        Get(
-            ToolClasspath,
-            ToolClasspathRequest(
-                lockfiles=(lockfile,),
-            ),
-        ),
+        Get(ToolClasspath, ToolClasspathRequest(lockfile=lockfile)),
         Get(
             Digest,
             DigestSubset(

--- a/src/python/pants/backend/codegen/protobuf/scala/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/rules.py
@@ -49,8 +49,8 @@ from pants.jvm.jdk_rules import JdkSetup
 from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
 from pants.jvm.resolve.coursier_fetch import (
     CoursierResolvedLockfile,
-    MaterializedClasspath,
-    MaterializedClasspathRequest,
+    ToolClasspath,
+    ToolClasspathRequest,
 )
 from pants.jvm.resolve.jvm_tool import (
     GatherJvmCoordinatesRequest,
@@ -83,7 +83,7 @@ class MaterializeJvmPluginRequest:
 @dataclass(frozen=True)
 class MaterializedJvmPlugin:
     name: str
-    classpath: MaterializedClasspath
+    classpath: ToolClasspath
 
     def setup_arg(self, plugin_relpath: str) -> str:
         classpath_arg = ":".join(self.classpath.classpath_entries(plugin_relpath))
@@ -130,8 +130,8 @@ async def generate_scala_from_protobuf(
     ) = await MultiGet(
         Get(DownloadedExternalTool, ExternalToolRequest, protoc.get_request(Platform.current)),
         Get(
-            MaterializedClasspath,
-            MaterializedClasspathRequest(
+            ToolClasspath,
+            ToolClasspathRequest(
                 lockfiles=(lockfile,),
             ),
         ),
@@ -249,7 +249,7 @@ async def materialize_jvm_plugin(request: MaterializeJvmPluginRequest) -> Materi
         ),
     )
     classpath = await Get(
-        MaterializedClasspath, MaterializedClasspathRequest(artifact_requirements=(requirements,))
+        ToolClasspath, ToolClasspathRequest(artifact_requirements=(requirements,))
     )
     return MaterializedJvmPlugin(
         name=request.plugin.name,
@@ -292,8 +292,8 @@ async def setup_scalapb_shim_classfiles(
 
     tool_classpath, shim_classpath, source_digest = await MultiGet(
         Get(
-            MaterializedClasspath,
-            MaterializedClasspathRequest(
+            ToolClasspath,
+            ToolClasspathRequest(
                 prefix="__toolcp",
                 artifact_requirements=(
                     ArtifactRequirements.from_coordinates(
@@ -319,8 +319,8 @@ async def setup_scalapb_shim_classfiles(
             ),
         ),
         Get(
-            MaterializedClasspath,
-            MaterializedClasspathRequest(
+            ToolClasspath,
+            ToolClasspathRequest(
                 prefix="__shimcp",
                 lockfiles=(lockfile,),
             ),

--- a/src/python/pants/backend/codegen/protobuf/scala/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/rules.py
@@ -132,7 +132,7 @@ async def generate_scala_from_protobuf(
         Get(
             ToolClasspath,
             ToolClasspathRequest(
-                lockfiles=(lockfile,),
+                lockfile=lockfile,
             ),
         ),
         Get(Digest, CreateDigest([Directory(output_dir)])),
@@ -248,9 +248,7 @@ async def materialize_jvm_plugin(request: MaterializeJvmPluginRequest) -> Materi
             option_name="[scalapb].jvm_plugins",
         ),
     )
-    classpath = await Get(
-        ToolClasspath, ToolClasspathRequest(artifact_requirements=(requirements,))
-    )
+    classpath = await Get(ToolClasspath, ToolClasspathRequest(artifact_requirements=requirements))
     return MaterializedJvmPlugin(
         name=request.plugin.name,
         classpath=classpath,
@@ -295,26 +293,24 @@ async def setup_scalapb_shim_classfiles(
             ToolClasspath,
             ToolClasspathRequest(
                 prefix="__toolcp",
-                artifact_requirements=(
-                    ArtifactRequirements.from_coordinates(
-                        [
-                            Coordinate(
-                                group="org.scala-lang",
-                                artifact="scala-compiler",
-                                version=SHIM_SCALA_VERSION,
-                            ),
-                            Coordinate(
-                                group="org.scala-lang",
-                                artifact="scala-library",
-                                version=SHIM_SCALA_VERSION,
-                            ),
-                            Coordinate(
-                                group="org.scala-lang",
-                                artifact="scala-reflect",
-                                version=SHIM_SCALA_VERSION,
-                            ),
-                        ]
-                    ),
+                artifact_requirements=ArtifactRequirements.from_coordinates(
+                    [
+                        Coordinate(
+                            group="org.scala-lang",
+                            artifact="scala-compiler",
+                            version=SHIM_SCALA_VERSION,
+                        ),
+                        Coordinate(
+                            group="org.scala-lang",
+                            artifact="scala-library",
+                            version=SHIM_SCALA_VERSION,
+                        ),
+                        Coordinate(
+                            group="org.scala-lang",
+                            artifact="scala-reflect",
+                            version=SHIM_SCALA_VERSION,
+                        ),
+                    ]
                 ),
             ),
         ),
@@ -322,7 +318,7 @@ async def setup_scalapb_shim_classfiles(
             ToolClasspath,
             ToolClasspathRequest(
                 prefix="__shimcp",
-                lockfiles=(lockfile,),
+                lockfile=lockfile,
             ),
         ),
         Get(

--- a/src/python/pants/backend/codegen/thrift/scrooge/rules.py
+++ b/src/python/pants/backend/codegen/thrift/scrooge/rules.py
@@ -19,8 +19,8 @@ from pants.jvm.goals import lockfile
 from pants.jvm.jdk_rules import JdkSetup
 from pants.jvm.resolve.coursier_fetch import (
     CoursierResolvedLockfile,
-    MaterializedClasspath,
-    MaterializedClasspathRequest,
+    ToolClasspath,
+    ToolClasspathRequest,
 )
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, ValidatedJvmToolLockfileRequest
 from pants.source.source_root import SourceRootsRequest, SourceRootsResult
@@ -57,8 +57,8 @@ async def generate_scrooge_thrift_sources(
 
     tool_classpath, transitive_targets, empty_output_dir_digest, wrapped_target = await MultiGet(
         Get(
-            MaterializedClasspath,
-            MaterializedClasspathRequest(
+            ToolClasspath,
+            ToolClasspathRequest(
                 lockfiles=(lockfile,),
             ),
         ),

--- a/src/python/pants/backend/codegen/thrift/scrooge/rules.py
+++ b/src/python/pants/backend/codegen/thrift/scrooge/rules.py
@@ -56,12 +56,7 @@ async def generate_scrooge_thrift_sources(
     lockfile = await Get(CoursierResolvedLockfile, ValidatedJvmToolLockfileRequest(scrooge))
 
     tool_classpath, transitive_targets, empty_output_dir_digest, wrapped_target = await MultiGet(
-        Get(
-            ToolClasspath,
-            ToolClasspathRequest(
-                lockfiles=(lockfile,),
-            ),
-        ),
+        Get(ToolClasspath, ToolClasspathRequest(lockfile=lockfile)),
         Get(TransitiveTargets, TransitiveTargetsRequest([request.thrift_source_field.address])),
         Get(Digest, CreateDigest([Directory(output_dir)])),
         Get(WrappedTarget, Address, request.thrift_source_field.address),

--- a/src/python/pants/backend/java/dependency_inference/java_parser.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser.py
@@ -19,7 +19,7 @@ from pants.engine.fs import AddPrefix, Digest, DigestContents
 from pants.engine.process import BashBinary, FallibleProcessResult, Process, ProcessExecutionFailure
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.jvm.jdk_rules import JdkSetup
-from pants.jvm.resolve.coursier_fetch import MaterializedClasspath, MaterializedClasspathRequest
+from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.option.global_options import ProcessCleanupOption
 from pants.util.logging import LogLevel
 
@@ -88,8 +88,8 @@ async def analyze_java_source_dependencies(
 
     (tool_classpath, prefixed_source_files_digest,) = await MultiGet(
         Get(
-            MaterializedClasspath,
-            MaterializedClasspathRequest(
+            ToolClasspath,
+            ToolClasspathRequest(
                 artifact_requirements=(java_parser_artifact_requirements(),),
             ),
         ),

--- a/src/python/pants/backend/java/dependency_inference/java_parser.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser.py
@@ -89,9 +89,7 @@ async def analyze_java_source_dependencies(
     (tool_classpath, prefixed_source_files_digest,) = await MultiGet(
         Get(
             ToolClasspath,
-            ToolClasspathRequest(
-                artifact_requirements=(java_parser_artifact_requirements(),),
-            ),
+            ToolClasspathRequest(artifact_requirements=java_parser_artifact_requirements()),
         ),
         Get(Digest, AddPrefix(source_files.snapshot.digest, source_prefix)),
     )

--- a/src/python/pants/backend/java/dependency_inference/java_parser_launcher.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser_launcher.py
@@ -13,7 +13,7 @@ from pants.engine.process import BashBinary, Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.jvm.jdk_rules import JdkSetup
 from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
-from pants.jvm.resolve.coursier_fetch import MaterializedClasspath, MaterializedClasspathRequest
+from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
@@ -59,8 +59,8 @@ async def build_processors(bash: BashBinary, jdk_setup: JdkSetup) -> JavaParserC
 
     materialized_classpath, source_digest = await MultiGet(
         Get(
-            MaterializedClasspath,
-            MaterializedClasspathRequest(
+            ToolClasspath,
+            ToolClasspathRequest(
                 prefix="__toolcp",
                 artifact_requirements=(java_parser_artifact_requirements(),),
             ),

--- a/src/python/pants/backend/java/dependency_inference/java_parser_launcher.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser_launcher.py
@@ -61,8 +61,7 @@ async def build_processors(bash: BashBinary, jdk_setup: JdkSetup) -> JavaParserC
         Get(
             ToolClasspath,
             ToolClasspathRequest(
-                prefix="__toolcp",
-                artifact_requirements=(java_parser_artifact_requirements(),),
+                prefix="__toolcp", artifact_requirements=java_parser_artifact_requirements()
             ),
         ),
         Get(

--- a/src/python/pants/backend/java/lint/google_java_format/rules.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules.py
@@ -21,8 +21,8 @@ from pants.jvm.jdk_rules import JdkSetup
 from pants.jvm.resolve import jvm_tool
 from pants.jvm.resolve.coursier_fetch import (
     CoursierResolvedLockfile,
-    MaterializedClasspath,
-    MaterializedClasspathRequest,
+    ToolClasspath,
+    ToolClasspathRequest,
 )
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, ValidatedJvmToolLockfileRequest
 from pants.util.logging import LogLevel
@@ -78,8 +78,8 @@ async def setup_google_java_format(
             SourceFilesRequest(field_set.source for field_set in setup_request.request.field_sets),
         ),
         Get(
-            MaterializedClasspath,
-            MaterializedClasspathRequest(
+            ToolClasspath,
+            ToolClasspathRequest(
                 lockfiles=(lockfile,),
             ),
         ),

--- a/src/python/pants/backend/java/lint/google_java_format/rules.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules.py
@@ -77,12 +77,7 @@ async def setup_google_java_format(
             SourceFiles,
             SourceFilesRequest(field_set.source for field_set in setup_request.request.field_sets),
         ),
-        Get(
-            ToolClasspath,
-            ToolClasspathRequest(
-                lockfiles=(lockfile,),
-            ),
-        ),
+        Get(ToolClasspath, ToolClasspathRequest(lockfile=lockfile)),
     )
 
     source_files_snapshot = (

--- a/src/python/pants/backend/scala/compile/scalac.py
+++ b/src/python/pants/backend/scala/compile/scalac.py
@@ -28,7 +28,7 @@ from pants.jvm.compile import (
 from pants.jvm.compile import rules as jvm_compile_rules
 from pants.jvm.jdk_rules import JdkSetup
 from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
-from pants.jvm.resolve.coursier_fetch import MaterializedClasspath, MaterializedClasspathRequest
+from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.jvm.resolve.coursier_setup import Coursier
 from pants.util.logging import LogLevel
 
@@ -116,8 +116,8 @@ async def compile_scala_source(
     user_classpath = Classpath(direct_dependency_classpath_entries)
     tool_classpath, sources_digest = await MultiGet(
         Get(
-            MaterializedClasspath,
-            MaterializedClasspathRequest(
+            ToolClasspath,
+            ToolClasspathRequest(
                 artifact_requirements=(
                     ArtifactRequirements.from_coordinates(
                         [

--- a/src/python/pants/backend/scala/compile/scalac.py
+++ b/src/python/pants/backend/scala/compile/scalac.py
@@ -118,21 +118,19 @@ async def compile_scala_source(
         Get(
             ToolClasspath,
             ToolClasspathRequest(
-                artifact_requirements=(
-                    ArtifactRequirements.from_coordinates(
-                        [
-                            Coordinate(
-                                group="org.scala-lang",
-                                artifact="scala-compiler",
-                                version=scala.version,
-                            ),
-                            Coordinate(
-                                group="org.scala-lang",
-                                artifact="scala-library",
-                                version=scala.version,
-                            ),
-                        ]
-                    ),
+                artifact_requirements=ArtifactRequirements.from_coordinates(
+                    [
+                        Coordinate(
+                            group="org.scala-lang",
+                            artifact="scala-compiler",
+                            version=scala.version,
+                        ),
+                        Coordinate(
+                            group="org.scala-lang",
+                            artifact="scala-library",
+                            version=scala.version,
+                        ),
+                    ]
                 ),
             ),
         ),

--- a/src/python/pants/backend/scala/compile/scalac_plugins.py
+++ b/src/python/pants/backend/scala/compile/scalac_plugins.py
@@ -102,10 +102,7 @@ async def global_scalac_plugins(
     lockfile = await Get(CoursierResolvedLockfile, GlobalScalacPluginsToolLockfileSentinel())
     classpath = await Get(
         ToolClasspath,
-        ToolClasspathRequest(
-            prefix="__scalac_plugin_cp",
-            lockfiles=(lockfile,),
-        ),
+        ToolClasspathRequest(prefix="__scalac_plugin_cp", lockfile=lockfile),
     )
     return GlobalScalacPlugins(loaded_global_plugins.names, classpath)
 

--- a/src/python/pants/backend/scala/compile/scalac_plugins.py
+++ b/src/python/pants/backend/scala/compile/scalac_plugins.py
@@ -20,8 +20,8 @@ from pants.engine.unions import UnionRule
 from pants.jvm.goals import lockfile
 from pants.jvm.resolve.coursier_fetch import (
     CoursierResolvedLockfile,
-    MaterializedClasspath,
-    MaterializedClasspathRequest,
+    ToolClasspath,
+    ToolClasspathRequest,
 )
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
 from pants.jvm.resolve.jvm_tool import rules as jvm_tool_rules
@@ -86,7 +86,7 @@ def generate_global_scalac_plugins_lockfile_request(
 @dataclass(frozen=True)
 class GlobalScalacPlugins:
     names: tuple[str, ...]
-    classpath: MaterializedClasspath
+    classpath: ToolClasspath
 
     def args(self, prefix: str | None = None) -> Iterator[str]:
         for scalac_plugin_path in self.classpath.classpath_entries(prefix):
@@ -101,8 +101,8 @@ async def global_scalac_plugins(
 ) -> GlobalScalacPlugins:
     lockfile = await Get(CoursierResolvedLockfile, GlobalScalacPluginsToolLockfileSentinel())
     classpath = await Get(
-        MaterializedClasspath,
-        MaterializedClasspathRequest(
+        ToolClasspath,
+        ToolClasspathRequest(
             prefix="__scalac_plugin_cp",
             lockfiles=(lockfile,),
         ),

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -230,9 +230,7 @@ async def analyze_scala_source_dependencies(
     (tool_classpath, prefixed_source_files_digest,) = await MultiGet(
         Get(
             ToolClasspath,
-            ToolClasspathRequest(
-                artifact_requirements=(SCALA_PARSER_ARTIFACT_REQUIREMENTS,),
-            ),
+            ToolClasspathRequest(artifact_requirements=SCALA_PARSER_ARTIFACT_REQUIREMENTS),
         ),
         Get(Digest, AddPrefix(source_files.snapshot.digest, source_prefix)),
     )
@@ -312,44 +310,34 @@ async def setup_scala_parser_classfiles(
             ToolClasspath,
             ToolClasspathRequest(
                 prefix="__toolcp",
-                artifact_requirements=(
-                    ArtifactRequirements.from_coordinates(
-                        [
-                            Coordinate(
-                                group="org.scala-lang",
-                                artifact="scala-compiler",
-                                version=PARSER_SCALA_VERSION,
-                            ),
-                            Coordinate(
-                                group="org.scala-lang",
-                                artifact="scala-library",
-                                version=PARSER_SCALA_VERSION,
-                            ),
-                            Coordinate(
-                                group="org.scala-lang",
-                                artifact="scala-reflect",
-                                version=PARSER_SCALA_VERSION,
-                            ),
-                        ]
-                    ),
+                artifact_requirements=ArtifactRequirements.from_coordinates(
+                    [
+                        Coordinate(
+                            group="org.scala-lang",
+                            artifact="scala-compiler",
+                            version=PARSER_SCALA_VERSION,
+                        ),
+                        Coordinate(
+                            group="org.scala-lang",
+                            artifact="scala-library",
+                            version=PARSER_SCALA_VERSION,
+                        ),
+                        Coordinate(
+                            group="org.scala-lang",
+                            artifact="scala-reflect",
+                            version=PARSER_SCALA_VERSION,
+                        ),
+                    ]
                 ),
             ),
         ),
         Get(
             ToolClasspath,
             ToolClasspathRequest(
-                prefix="__parsercp", artifact_requirements=(SCALA_PARSER_ARTIFACT_REQUIREMENTS,)
+                prefix="__parsercp", artifact_requirements=SCALA_PARSER_ARTIFACT_REQUIREMENTS
             ),
         ),
-        Get(
-            Digest,
-            CreateDigest(
-                [
-                    parser_source,
-                    Directory(dest_dir),
-                ]
-            ),
-        ),
+        Get(Digest, CreateDigest([parser_source, Directory(dest_dir)])),
     )
 
     merged_digest = await Get(

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -32,7 +32,7 @@ from pants.engine.rules import collect_rules, rule
 from pants.jvm.compile import ClasspathEntry
 from pants.jvm.jdk_rules import JdkSetup
 from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
-from pants.jvm.resolve.coursier_fetch import MaterializedClasspath, MaterializedClasspathRequest
+from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.option.global_options import ProcessCleanupOption
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
@@ -229,8 +229,8 @@ async def analyze_scala_source_dependencies(
 
     (tool_classpath, prefixed_source_files_digest,) = await MultiGet(
         Get(
-            MaterializedClasspath,
-            MaterializedClasspathRequest(
+            ToolClasspath,
+            ToolClasspathRequest(
                 artifact_requirements=(SCALA_PARSER_ARTIFACT_REQUIREMENTS,),
             ),
         ),
@@ -309,8 +309,8 @@ async def setup_scala_parser_classfiles(
 
     tool_classpath, parser_classpath, source_digest = await MultiGet(
         Get(
-            MaterializedClasspath,
-            MaterializedClasspathRequest(
+            ToolClasspath,
+            ToolClasspathRequest(
                 prefix="__toolcp",
                 artifact_requirements=(
                     ArtifactRequirements.from_coordinates(
@@ -336,8 +336,8 @@ async def setup_scala_parser_classfiles(
             ),
         ),
         Get(
-            MaterializedClasspath,
-            MaterializedClasspathRequest(
+            ToolClasspath,
+            ToolClasspathRequest(
                 prefix="__parsercp", artifact_requirements=(SCALA_PARSER_ARTIFACT_REQUIREMENTS,)
             ),
         ),

--- a/src/python/pants/backend/scala/goals/repl.py
+++ b/src/python/pants/backend/scala/goals/repl.py
@@ -13,7 +13,7 @@ from pants.engine.unions import UnionRule
 from pants.jvm.classpath import Classpath
 from pants.jvm.jdk_rules import JdkSetup
 from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
-from pants.jvm.resolve.coursier_fetch import MaterializedClasspath, MaterializedClasspathRequest
+from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.util.logging import LogLevel
 
 
@@ -28,8 +28,8 @@ async def create_scala_repl_request(
     user_classpath, tool_classpath = await MultiGet(
         Get(Classpath, Addresses(t.address for t in repl.targets)),
         Get(
-            MaterializedClasspath,
-            MaterializedClasspathRequest(
+            ToolClasspath,
+            ToolClasspathRequest(
                 prefix="__toolcp",
                 artifact_requirements=(
                     ArtifactRequirements.from_coordinates(

--- a/src/python/pants/backend/scala/goals/repl.py
+++ b/src/python/pants/backend/scala/goals/repl.py
@@ -31,26 +31,24 @@ async def create_scala_repl_request(
             ToolClasspath,
             ToolClasspathRequest(
                 prefix="__toolcp",
-                artifact_requirements=(
-                    ArtifactRequirements.from_coordinates(
-                        [
-                            Coordinate(
-                                group="org.scala-lang",
-                                artifact="scala-compiler",
-                                version=scala_subsystem.version,
-                            ),
-                            Coordinate(
-                                group="org.scala-lang",
-                                artifact="scala-library",
-                                version=scala_subsystem.version,
-                            ),
-                            Coordinate(
-                                group="org.scala-lang",
-                                artifact="scala-reflect",
-                                version=scala_subsystem.version,
-                            ),
-                        ]
-                    ),
+                artifact_requirements=ArtifactRequirements.from_coordinates(
+                    [
+                        Coordinate(
+                            group="org.scala-lang",
+                            artifact="scala-compiler",
+                            version=scala_subsystem.version,
+                        ),
+                        Coordinate(
+                            group="org.scala-lang",
+                            artifact="scala-library",
+                            version=scala_subsystem.version,
+                        ),
+                        Coordinate(
+                            group="org.scala-lang",
+                            artifact="scala-reflect",
+                            version=scala_subsystem.version,
+                        ),
+                    ]
                 ),
             ),
         ),

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -212,7 +212,7 @@ async def setup_scalafmt(
         Get(
             ToolClasspath,
             ToolClasspathRequest(
-                lockfiles=(lockfile,),
+                lockfile=lockfile,
             ),
         ),
     )

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -209,12 +209,7 @@ async def setup_scalafmt(
             SourceFiles,
             SourceFilesRequest(field_set.source for field_set in setup_request.request.field_sets),
         ),
-        Get(
-            ToolClasspath,
-            ToolClasspathRequest(
-                lockfile=lockfile,
-            ),
-        ),
+        Get(ToolClasspath, ToolClasspathRequest(lockfile=lockfile)),
     )
 
     source_files_snapshot = (
@@ -228,13 +223,7 @@ async def setup_scalafmt(
     )
 
     merged_sources_digest = await Get(
-        Digest,
-        MergeDigests(
-            [
-                source_files_snapshot.digest,
-                config_files.snapshot.digest,
-            ]
-        ),
+        Digest, MergeDigests([source_files_snapshot.digest, config_files.snapshot.digest])
     )
     immutable_input_digests = {
         **jdk_setup.immutable_input_digests,

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -33,8 +33,8 @@ from pants.jvm.goals import lockfile
 from pants.jvm.jdk_rules import JdkSetup
 from pants.jvm.resolve.coursier_fetch import (
     CoursierResolvedLockfile,
-    MaterializedClasspath,
-    MaterializedClasspathRequest,
+    ToolClasspath,
+    ToolClasspathRequest,
 )
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, ValidatedJvmToolLockfileRequest
 from pants.util.frozendict import FrozenDict
@@ -210,8 +210,8 @@ async def setup_scalafmt(
             SourceFilesRequest(field_set.source for field_set in setup_request.request.field_sets),
         ),
         Get(
-            MaterializedClasspath,
-            MaterializedClasspathRequest(
+            ToolClasspath,
+            ToolClasspathRequest(
                 lockfiles=(lockfile,),
             ),
         ),

--- a/src/python/pants/backend/scala/test/scalatest.py
+++ b/src/python/pants/backend/scala/test/scalatest.py
@@ -72,10 +72,7 @@ async def setup_scalatest_for_target(
 
     classpath, scalatest_classpath = await MultiGet(
         Get(Classpath, Addresses([request.field_set.address])),
-        Get(
-            ToolClasspath,
-            ToolClasspathRequest(lockfiles=(lockfile,)),
-        ),
+        Get(ToolClasspath, ToolClasspathRequest(lockfile=lockfile)),
     )
 
     merged_classpath_digest = await Get(Digest, MergeDigests(classpath.digests()))

--- a/src/python/pants/backend/scala/test/scalatest.py
+++ b/src/python/pants/backend/scala/test/scalatest.py
@@ -25,8 +25,8 @@ from pants.jvm.goals import lockfile
 from pants.jvm.jdk_rules import JdkSetup
 from pants.jvm.resolve.coursier_fetch import (
     CoursierResolvedLockfile,
-    MaterializedClasspath,
-    MaterializedClasspathRequest,
+    ToolClasspath,
+    ToolClasspathRequest,
 )
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, ValidatedJvmToolLockfileRequest
 from pants.jvm.subsystems import JvmSubsystem
@@ -73,8 +73,8 @@ async def setup_scalatest_for_target(
     classpath, scalatest_classpath = await MultiGet(
         Get(Classpath, Addresses([request.field_set.address])),
         Get(
-            MaterializedClasspath,
-            MaterializedClasspathRequest(lockfiles=(lockfile,)),
+            ToolClasspath,
+            ToolClasspathRequest(lockfiles=(lockfile,)),
         ),
     )
 

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -668,8 +668,9 @@ async def get_coursier_lockfile_for_resolve(
 
 
 @dataclass(frozen=True)
-class MaterializedClasspathRequest:
-    """A helper to merge various classpath elements.
+class ToolClasspathRequest:
+    """A request to set up the classpath for a JVM tool by fetching artifacts and merging the
+    classpath.
 
     :param prefix: if set, should be a relative directory that will
         be prepended to every classpath element.  This is useful for
@@ -685,11 +686,8 @@ class MaterializedClasspathRequest:
 
 
 @dataclass(frozen=True)
-class MaterializedClasspath:
-    """A fully fetched and merged classpath, ready to hand to a JVM process invocation.
-
-    TODO: Consider renaming to reflect the fact that this is always a 3rdparty classpath.
-    """
+class ToolClasspath:
+    """A fully fetched and merged classpath for running a JVM tool."""
 
     content: Snapshot
 
@@ -713,7 +711,7 @@ class MaterializedClasspath:
 
 
 @rule(level=LogLevel.DEBUG)
-async def materialize_classpath(request: MaterializedClasspathRequest) -> MaterializedClasspath:
+async def materialize_classpath_for_tool(request: ToolClasspathRequest) -> ToolClasspath:
     """Resolve, fetch, and merge various classpath types to a single `Digest` and metadata."""
 
     artifact_requirements_lockfiles = await MultiGet(
@@ -739,7 +737,7 @@ async def materialize_classpath(request: MaterializedClasspathRequest) -> Materi
     )
     if request.prefix is not None:
         merged_snapshot = await Get(Snapshot, AddPrefix(merged_snapshot.digest, request.prefix))
-    return MaterializedClasspath(content=merged_snapshot)
+    return ToolClasspath(content=merged_snapshot)
 
 
 def rules():

--- a/src/python/pants/jvm/test/junit.py
+++ b/src/python/pants/jvm/test/junit.py
@@ -24,8 +24,8 @@ from pants.jvm.goals import lockfile
 from pants.jvm.jdk_rules import JdkSetup
 from pants.jvm.resolve.coursier_fetch import (
     CoursierResolvedLockfile,
-    MaterializedClasspath,
-    MaterializedClasspathRequest,
+    ToolClasspath,
+    ToolClasspathRequest,
 )
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, ValidatedJvmToolLockfileRequest
 from pants.jvm.subsystems import JvmSubsystem
@@ -73,8 +73,8 @@ async def setup_junit_for_target(
     classpath, junit_classpath = await MultiGet(
         Get(Classpath, Addresses([request.field_set.address])),
         Get(
-            MaterializedClasspath,
-            MaterializedClasspathRequest(lockfiles=(lockfile,)),
+            ToolClasspath,
+            ToolClasspathRequest(lockfiles=(lockfile,)),
         ),
     )
 

--- a/src/python/pants/jvm/test/junit.py
+++ b/src/python/pants/jvm/test/junit.py
@@ -72,10 +72,7 @@ async def setup_junit_for_target(
 
     classpath, junit_classpath = await MultiGet(
         Get(Classpath, Addresses([request.field_set.address])),
-        Get(
-            ToolClasspath,
-            ToolClasspathRequest(lockfiles=(lockfile,)),
-        ),
+        Get(ToolClasspath, ToolClasspathRequest(lockfile=lockfile)),
     )
 
     merged_classpath_digest = await Get(Digest, MergeDigests(classpath.digests()))


### PR DESCRIPTION
Three improvements:

1. Rename `MaterializedClasspath` to `ToolClasspath`. The type is only being used to set up tools—whether those be external like Scalafmt or internal like our JVM parser. This rename makes that clear, which will allow us to start adding tool-specific functionality.
2. Embrace that `ToolClasspathRequest` is 1-per-tool. This is how we've been using it de facto, including in two rules where there are 2 tools used in the same process. This allows us to simplify callsites / remove verbosity.
3. Use the engine to read tool lockfiles, not `open()`. This is necessary to not break caching.

Tool lockfiles still have issues - a followup will fix these:

- `scalac_plugins.py` is not using lockfile validation
- callsites have more duplication than ideal
