### PR TITLE
[internal] Change `heavy_hitters` to report start_time instead of duration

### DIFF
--- a/src/rust/engine/src/session.rs
+++ b/src/rust/engine/src/session.rs
@@ -21,7 +21,7 @@ use pyo3::prelude::*;
 use task_executor::Executor;
 use tokio::signal::unix::{signal, SignalKind};
 use ui::ConsoleUI;
-use workunit_store::{format_workunit_duration, RunId, UserMetadataPyValue, WorkunitStore};
+use workunit_store::{format_workunit_duration_ms, RunId, UserMetadataPyValue, WorkunitStore};
 
 // When enabled, the interval at which all stragglers that have been running for longer than a
 // threshold should be logged. The threshold might become configurable, but this might not need
@@ -346,7 +346,11 @@ impl Session {
               "Long running tasks:\n  {}",
               straggling_workunits
                 .into_iter()
-                .map(|(duration, desc)| format!("{}\t{}", format_workunit_duration(duration), desc))
+                .map(|(duration, desc)| format!(
+                  "{}\t{}",
+                  format_workunit_duration_ms!(duration.as_millis()),
+                  desc
+                ))
                 .collect::<Vec<_>>()
                 .join("\n  ")
             );

--- a/src/rust/engine/ui/src/console_ui.rs
+++ b/src/rust/engine/ui/src/console_ui.rs
@@ -150,7 +150,7 @@ impl ConsoleUI {
       .map(|(_, (label, start_time))| {
         let duration_label = match now.duration_since(*start_time).ok() {
           None => "(Waiting)".to_string(),
-          Some(duration) => format_workunit_duration_ms!((duration).as_millis()).to_string()
+          Some(duration) => format_workunit_duration_ms!((duration).as_millis()).to_string(),
         };
         format!("{} {}", duration_label, label)
       })


### PR DESCRIPTION
(Thanks to @stuhood for the implementation)

`start_time` is arguably more useful than duration, so :tada: 