### PR TITLE
Simplify Coursier wrapper invocations

### DIFF
--- a/src/python/pants/backend/codegen/avro/java/rules.py
+++ b/src/python/pants/backend/codegen/avro/java/rules.py
@@ -25,7 +25,7 @@ from pants.engine.fs import (
     Snapshot,
 )
 from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.process import BashBinary, ProcessResult
+from pants.engine.process import ProcessResult
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import (
     GeneratedSources,

--- a/src/python/pants/backend/codegen/avro/java/rules.py
+++ b/src/python/pants/backend/codegen/avro/java/rules.py
@@ -35,7 +35,7 @@ from pants.engine.target import (
 )
 from pants.engine.unions import UnionRule
 from pants.jvm import jdk_rules
-from pants.jvm.jdk_rules import JdkSetup, JvmProcess
+from pants.jvm.jdk_rules import JvmProcess
 from pants.jvm.resolve import jvm_tool
 from pants.jvm.resolve.coursier_fetch import (
     CoursierResolvedLockfile,
@@ -97,7 +97,6 @@ async def generate_java_from_avro(
 async def compile_avro_source(
     request: CompileAvroSourceRequest,
     avro_tools: AvroSubsystem,
-    jdk_setup: JdkSetup,
 ) -> CompiledAvroSource:
     output_dir = "_generated_files"
     toolcp_relpath = "__toolcp"
@@ -132,7 +131,6 @@ async def compile_avro_source(
     )
 
     immutable_input_digests = {
-        **jdk_setup.immutable_input_digests,
         toolcp_relpath: tool_classpath.digest,
     }
 
@@ -144,7 +142,7 @@ async def compile_avro_source(
     ) -> JvmProcess:
 
         return JvmProcess(
-            args=(
+            argv=(
                 "org.apache.avro.tool.Main",
                 *args,
             ),
@@ -156,7 +154,7 @@ async def compile_avro_source(
                 toolcp_relpath: tool_classpath.digest,
             },
             # TODO: figure out how to generalise this -- I'm not sure how this argument is actually used.
-            use_nailgun=immutable_input_digests,
+            extra_nailgun_keys=immutable_input_digests,
             description="Generating Java sources from Avro source.",
             level=LogLevel.DEBUG,
             output_directories=(overridden_output_dir if overridden_output_dir else output_dir,),

--- a/src/python/pants/backend/codegen/protobuf/scala/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/rules.py
@@ -32,7 +32,7 @@ from pants.engine.fs import (
 from pants.engine.internals.native_engine import EMPTY_DIGEST
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.platform import Platform
-from pants.engine.process import BashBinary, Process, ProcessResult
+from pants.engine.process import ProcessResult
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import (
     GeneratedSources,
@@ -45,7 +45,7 @@ from pants.engine.target import (
 from pants.engine.unions import UnionRule
 from pants.jvm.compile import ClasspathEntry
 from pants.jvm.goals import lockfile
-from pants.jvm.jdk_rules import JdkSetup
+from pants.jvm.jdk_rules import JvmProcess
 from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
 from pants.jvm.resolve.coursier_fetch import (
     CoursierResolvedLockfile,
@@ -110,8 +110,6 @@ async def generate_scala_from_protobuf(
     protoc: Protoc,
     scalapb: ScalaPBSubsystem,
     shim_classfiles: ScalaPBShimCompiledClassfiles,
-    jdk_setup: JdkSetup,
-    bash: BashBinary,
 ) -> GeneratedSources:
     output_dir = "_generated_files"
     toolcp_relpath = "__toolcp"
@@ -167,7 +165,6 @@ async def generate_scala_from_protobuf(
         )
 
     immutable_input_digests = {
-        **jdk_setup.immutable_input_digests,
         toolcp_relpath: tool_classpath.digest,
         shimcp_relpath: shim_classfiles.digest,
         plugins_relpath: merged_jvm_plugins_digest,
@@ -180,11 +177,9 @@ async def generate_scala_from_protobuf(
 
     result = await Get(
         ProcessResult,
-        Process(
-            argv=[
-                *jdk_setup.args(
-                    bash, [*tool_classpath.classpath_entries(toolcp_relpath), shimcp_relpath]
-                ),
+        JvmProcess(
+            classpath_entries=[*tool_classpath.classpath_entries(toolcp_relpath), shimcp_relpath],
+            args=[
                 "org.pantsbuild.backend.scala.scalapb.ScalaPBShim",
                 f"--protoc={os.path.join(protoc_relpath, downloaded_protoc_binary.exe)}",
                 *maybe_jvm_plugins_setup_args,
@@ -193,13 +188,13 @@ async def generate_scala_from_protobuf(
                 *target_sources_stripped.snapshot.files,
             ],
             input_digest=input_digest,
-            immutable_input_digests=immutable_input_digests,
+            # TODO: figure out how to generalise this -- I'm not sure how this argument is actually used.
+            extra_immutable_input_digests=immutable_input_digests,
             use_nailgun=immutable_input_digests,
             description=f"Generating Scala sources from {request.protocol_target.address}.",
             level=LogLevel.DEBUG,
             output_directories=(output_dir,),
-            env={**jdk_setup.env, **inherit_env},
-            append_only_caches=jdk_setup.append_only_caches,
+            extra_env=inherit_env,
         ),
     )
 
@@ -260,7 +255,7 @@ SHIM_SCALA_VERSION = "2.13.7"
 # TODO(13879): Consolidate compilation of wrapper binaries to common rules.
 @rule
 async def setup_scalapb_shim_classfiles(
-    scalapb: ScalaPBSubsystem, jdk_setup: JdkSetup, bash: BashBinary
+    scalapb: ScalaPBSubsystem,
 ) -> ScalaPBShimCompiledClassfiles:
     dest_dir = "classfiles"
 
@@ -311,9 +306,9 @@ async def setup_scalapb_shim_classfiles(
     # NB: We do not use nailgun for this process, since it is launched exactly once.
     process_result = await Get(
         ProcessResult,
-        Process(
-            argv=[
-                *jdk_setup.args(bash, tool_classpath.classpath_entries()),
+        JvmProcess(
+            classpath_entries=tool_classpath.classpath_entries(),
+            args=[
                 "scala.tools.nsc.Main",
                 "-bootclasspath",
                 ":".join(tool_classpath.classpath_entries()),
@@ -324,9 +319,6 @@ async def setup_scalapb_shim_classfiles(
                 scalapb_shim_source.path,
             ],
             input_digest=merged_digest,
-            append_only_caches=jdk_setup.append_only_caches,
-            immutable_input_digests=jdk_setup.immutable_input_digests,
-            env=jdk_setup.env,
             output_directories=(dest_dir,),
             description="Compile ScalaPB shim with scalac",
             level=LogLevel.DEBUG,

--- a/src/python/pants/backend/codegen/protobuf/scala/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/rules.py
@@ -179,7 +179,7 @@ async def generate_scala_from_protobuf(
         ProcessResult,
         JvmProcess(
             classpath_entries=[*tool_classpath.classpath_entries(toolcp_relpath), shimcp_relpath],
-            args=[
+            argv=[
                 "org.pantsbuild.backend.scala.scalapb.ScalaPBShim",
                 f"--protoc={os.path.join(protoc_relpath, downloaded_protoc_binary.exe)}",
                 *maybe_jvm_plugins_setup_args,
@@ -190,7 +190,7 @@ async def generate_scala_from_protobuf(
             input_digest=input_digest,
             # TODO: figure out how to generalise this -- I'm not sure how this argument is actually used.
             extra_immutable_input_digests=immutable_input_digests,
-            use_nailgun=immutable_input_digests,
+            extra_nailgun_keys=immutable_input_digests,
             description=f"Generating Scala sources from {request.protocol_target.address}.",
             level=LogLevel.DEBUG,
             output_directories=(output_dir,),
@@ -308,7 +308,7 @@ async def setup_scalapb_shim_classfiles(
         ProcessResult,
         JvmProcess(
             classpath_entries=tool_classpath.classpath_entries(),
-            args=[
+            argv=[
                 "scala.tools.nsc.Main",
                 "-bootclasspath",
                 ":".join(tool_classpath.classpath_entries()),

--- a/src/python/pants/backend/java/compile/javac.py
+++ b/src/python/pants/backend/java/compile/javac.py
@@ -157,7 +157,7 @@ async def compile_java_source(
         FallibleProcessResult,
         JvmProcess(
             classpath_entries=[f"{jdk_setup.java_home}/lib/tools.jar"],
-            args=[
+            argv=[
                 "com.sun.tools.javac.Main",
                 *(("-cp", classpath_arg) if classpath_arg else ()),
                 *javac.args,
@@ -173,7 +173,7 @@ async def compile_java_source(
             input_digest=merged_digest,
             extra_immutable_input_digests=immutable_input_digests,
             # TODO: figure out how to generalise this -- I'm not sure how this argument is actually used.
-            use_nailgun=jdk_setup.immutable_input_digests,
+            extra_nailgun_keys=jdk_setup.immutable_input_digests,
             output_directories=(dest_dir,),
             description=f"Compile {request.component} with javac",
             level=LogLevel.DEBUG,

--- a/src/python/pants/backend/java/compile/javac.py
+++ b/src/python/pants/backend/java/compile/javac.py
@@ -28,7 +28,7 @@ from pants.jvm.compile import (
     FallibleClasspathEntry,
 )
 from pants.jvm.compile import rules as jvm_compile_rules
-from pants.jvm.jdk_rules import JdkSetup
+from pants.jvm.jdk_rules import JdkSetup, JvmProcess
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
@@ -150,17 +150,14 @@ async def compile_java_source(
     usercp = "__cp"
     user_classpath = Classpath(direct_dependency_classpath_entries)
     classpath_arg = ":".join(user_classpath.root_immutable_inputs_args(prefix=usercp))
-    immutable_input_digests = {
-        **jdk_setup.immutable_input_digests,
-        **dict(user_classpath.root_immutable_inputs(prefix=usercp)),
-    }
+    immutable_input_digests = dict(user_classpath.root_immutable_inputs(prefix=usercp))
 
     # Compile.
     compile_result = await Get(
         FallibleProcessResult,
-        Process(
-            argv=[
-                *jdk_setup.args(bash, [f"{jdk_setup.java_home}/lib/tools.jar"]),
+        JvmProcess(
+            classpath_entries=[f"{jdk_setup.java_home}/lib/tools.jar"],
+            args=[
                 "com.sun.tools.javac.Main",
                 *(("-cp", classpath_arg) if classpath_arg else ()),
                 *javac.args,
@@ -174,10 +171,9 @@ async def compile_java_source(
                 ),
             ],
             input_digest=merged_digest,
-            immutable_input_digests=immutable_input_digests,
-            use_nailgun=jdk_setup.immutable_input_digests.keys(),
-            append_only_caches=jdk_setup.append_only_caches,
-            env=jdk_setup.env,
+            extra_immutable_input_digests=immutable_input_digests,
+            # TODO: figure out how to generalise this -- I'm not sure how this argument is actually used.
+            use_nailgun=jdk_setup.immutable_input_digests,
             output_directories=(dest_dir,),
             description=f"Compile {request.component} with javac",
             level=LogLevel.DEBUG,

--- a/src/python/pants/backend/java/dependency_inference/java_parser_launcher.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser_launcher.py
@@ -9,9 +9,9 @@ from dataclasses import dataclass
 import pkg_resources
 
 from pants.engine.fs import CreateDigest, Digest, Directory, FileContent, MergeDigests, RemovePrefix
-from pants.engine.process import BashBinary, Process, ProcessResult
+from pants.engine.process import BashBinary, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.jvm.jdk_rules import JdkSetup
+from pants.jvm.jdk_rules import JdkSetup, JvmProcess
 from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.util.logging import LogLevel
@@ -91,9 +91,9 @@ async def build_processors(bash: BashBinary, jdk_setup: JdkSetup) -> JavaParserC
     # NB: We do not use nailgun for this process, since it is launched exactly once.
     process_result = await Get(
         ProcessResult,
-        Process(
+        JvmProcess(
+            classpath_entries=[f"{jdk_setup.java_home}/lib/tools.jar"],
             argv=[
-                *jdk_setup.args(bash, [f"{jdk_setup.java_home}/lib/tools.jar"]),
                 "com.sun.tools.javac.Main",
                 "-cp",
                 ":".join(materialized_classpath.classpath_entries()),
@@ -102,9 +102,6 @@ async def build_processors(bash: BashBinary, jdk_setup: JdkSetup) -> JavaParserC
                 _LAUNCHER_BASENAME,
             ],
             input_digest=merged_digest,
-            append_only_caches=jdk_setup.append_only_caches,
-            immutable_input_digests=jdk_setup.immutable_input_digests,
-            env=jdk_setup.env,
             output_directories=(dest_dir,),
             description=f"Compile {_LAUNCHER_BASENAME} import processors with javac",
             level=LogLevel.DEBUG,

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -21,16 +21,10 @@ from pants.engine.fs import (
     RemovePrefix,
 )
 from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.process import (
-    BashBinary,
-    FallibleProcessResult,
-    Process,
-    ProcessExecutionFailure,
-    ProcessResult,
-)
+from pants.engine.process import FallibleProcessResult, ProcessExecutionFailure, ProcessResult
 from pants.engine.rules import collect_rules, rule
 from pants.jvm.compile import ClasspathEntry
-from pants.jvm.jdk_rules import JdkSetup
+from pants.jvm.jdk_rules import JvmProcess
 from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.option.global_options import ProcessCleanupOption
@@ -209,8 +203,6 @@ class ScalaParserCompiledClassfiles(ClasspathEntry):
 
 @rule(level=LogLevel.DEBUG)
 async def analyze_scala_source_dependencies(
-    bash: BashBinary,
-    jdk_setup: JdkSetup,
     processor_classfiles: ScalaParserCompiledClassfiles,
     source_files: SourceFiles,
 ) -> FallibleScalaSourceDependencyAnalysisResult:
@@ -235,8 +227,7 @@ async def analyze_scala_source_dependencies(
         Get(Digest, AddPrefix(source_files.snapshot.digest, source_prefix)),
     )
 
-    immutable_input_digests = {
-        **jdk_setup.immutable_input_digests,
+    extra_immutable_input_digests = {
         toolcp_relpath: tool_classpath.digest,
         processorcp_relpath: processor_classfiles.digest,
     }
@@ -245,21 +236,21 @@ async def analyze_scala_source_dependencies(
 
     process_result = await Get(
         FallibleProcessResult,
-        Process(
+        JvmProcess(
+            classpath_entries=[
+                *tool_classpath.classpath_entries(toolcp_relpath),
+                processorcp_relpath,
+            ],
             argv=[
-                *jdk_setup.args(
-                    bash, [*tool_classpath.classpath_entries(toolcp_relpath), processorcp_relpath]
-                ),
                 "org.pantsbuild.backend.scala.dependency_inference.ScalaParser",
                 analysis_output_path,
                 source_path,
             ],
             input_digest=prefixed_source_files_digest,
-            immutable_input_digests=immutable_input_digests,
+            extra_immutable_input_digests=extra_immutable_input_digests,
             output_files=(analysis_output_path,),
-            use_nailgun=immutable_input_digests.keys(),
-            append_only_caches=jdk_setup.append_only_caches,
-            env=jdk_setup.env,
+            # TODO: etc
+            extra_nailgun_keys=extra_immutable_input_digests,
             description=f"Analyzing {source_files.files[0]}",
             level=LogLevel.DEBUG,
         ),
@@ -292,9 +283,7 @@ async def resolve_fallible_result_to_analysis(
 
 # TODO(13879): Consolidate compilation of wrapper binaries to common rules.
 @rule
-async def setup_scala_parser_classfiles(
-    bash: BashBinary, jdk_setup: JdkSetup
-) -> ScalaParserCompiledClassfiles:
+async def setup_scala_parser_classfiles() -> ScalaParserCompiledClassfiles:
     dest_dir = "classfiles"
 
     parser_source_content = pkgutil.get_data(
@@ -354,9 +343,9 @@ async def setup_scala_parser_classfiles(
     # NB: We do not use nailgun for this process, since it is launched exactly once.
     process_result = await Get(
         ProcessResult,
-        Process(
+        JvmProcess(
+            classpath_entries=tool_classpath.classpath_entries(),
             argv=[
-                *jdk_setup.args(bash, tool_classpath.classpath_entries()),
                 "scala.tools.nsc.Main",
                 "-bootclasspath",
                 ":".join(tool_classpath.classpath_entries()),
@@ -367,9 +356,6 @@ async def setup_scala_parser_classfiles(
                 parser_source.path,
             ],
             input_digest=merged_digest,
-            append_only_caches=jdk_setup.append_only_caches,
-            immutable_input_digests=jdk_setup.immutable_input_digests,
-            env=jdk_setup.env,
             output_directories=(dest_dir,),
             description="Compile Scala parser for dependency inference with scalac",
             level=LogLevel.DEBUG,

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -25,12 +25,12 @@ from pants.engine.fs import (
     Snapshot,
 )
 from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.process import BashBinary, FallibleProcessResult, Process, ProcessResult
+from pants.engine.process import FallibleProcessResult, ProcessResult
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.jvm.goals import lockfile
-from pants.jvm.jdk_rules import JdkSetup
+from pants.jvm.jdk_rules import JvmProcess
 from pants.jvm.resolve.coursier_fetch import (
     CoursierResolvedLockfile,
     ToolClasspath,
@@ -71,7 +71,7 @@ class SetupRequest:
 
 @dataclass(frozen=True)
 class Partition:
-    process: Process
+    process: JvmProcess
     description: str
 
 
@@ -94,9 +94,9 @@ class ScalafmtConfigFiles:
 
 @dataclass(frozen=True)
 class SetupScalafmtPartition:
+    classpath_entries: tuple[str, ...]
     merged_sources_digest: Digest
-    jdk_invoke_args: tuple[str, ...]
-    immutable_input_digests: FrozenDict[str, Digest]
+    extra_immutable_input_digests: FrozenDict[str, Digest]
     config_file: str
     files: tuple[str, ...]
     check_only: bool
@@ -151,9 +151,7 @@ async def gather_scalafmt_config_files(
 
 
 @rule
-async def setup_scalafmt_partition(
-    request: SetupScalafmtPartition, jdk_setup: JdkSetup
-) -> Partition:
+async def setup_scalafmt_partition(request: SetupScalafmtPartition) -> Partition:
     sources_digest = await Get(
         Digest,
         DigestSubset(
@@ -168,7 +166,6 @@ async def setup_scalafmt_partition(
     )
 
     args = [
-        *request.jdk_invoke_args,
         "org.scalafmt.cli.Cli",
         f"--config={request.config_file}",
         "--non-interactive",
@@ -179,13 +176,12 @@ async def setup_scalafmt_partition(
         args.append("--quiet")
     args.extend(request.files)
 
-    process = Process(
+    process = JvmProcess(
         argv=args,
+        classpath_entries=request.classpath_entries,
         input_digest=sources_digest,
         output_files=request.files,
-        append_only_caches=jdk_setup.append_only_caches,
-        immutable_input_digests=request.immutable_input_digests,
-        env=jdk_setup.env,
+        extra_immutable_input_digests=request.extra_immutable_input_digests,
         description=f"Run `scalafmt` on {pluralize(len(request.files), 'file')}.",
         level=LogLevel.DEBUG,
     )
@@ -197,8 +193,6 @@ async def setup_scalafmt_partition(
 async def setup_scalafmt(
     setup_request: SetupRequest,
     tool: ScalafmtSubsystem,
-    jdk_setup: JdkSetup,
-    bash: BashBinary,
 ) -> Setup:
     toolcp_relpath = "__toolcp"
 
@@ -225,8 +219,8 @@ async def setup_scalafmt(
     merged_sources_digest = await Get(
         Digest, MergeDigests([source_files_snapshot.digest, config_files.snapshot.digest])
     )
-    immutable_input_digests = {
-        **jdk_setup.immutable_input_digests,
+
+    extra_immutable_input_digests = {
         toolcp_relpath: tool_classpath.digest,
     }
 
@@ -238,14 +232,13 @@ async def setup_scalafmt(
             os.path.join(source_dir, name) for name in files_in_source_dir
         )
 
-    jdk_invoke_args = jdk_setup.args(bash, tool_classpath.classpath_entries(toolcp_relpath))
     partitions = await MultiGet(
         Get(
             Partition,
             SetupScalafmtPartition(
+                classpath_entries=tuple(tool_classpath.classpath_entries(toolcp_relpath)),
                 merged_sources_digest=merged_sources_digest,
-                immutable_input_digests=FrozenDict(immutable_input_digests),
-                jdk_invoke_args=jdk_invoke_args,
+                extra_immutable_input_digests=FrozenDict(extra_immutable_input_digests),
                 config_file=config_file,
                 files=tuple(sorted(files)),
                 check_only=setup_request.check_only,
@@ -263,7 +256,7 @@ async def scalafmt_fmt(field_sets: ScalafmtRequest, tool: ScalafmtSubsystem) -> 
         return FmtResult.skip(formatter_name="scalafmt")
     setup = await Get(Setup, SetupRequest(field_sets, check_only=False))
     results = await MultiGet(
-        Get(ProcessResult, Process, partition.process) for partition in setup.partitions
+        Get(ProcessResult, JvmProcess, partition.process) for partition in setup.partitions
     )
 
     def format(description: str, output) -> str:
@@ -303,7 +296,7 @@ async def scalafmt_lint(field_sets: ScalafmtRequest, tool: ScalafmtSubsystem) ->
         return LintResults([], linter_name="scalafmt")
     setup = await Get(Setup, SetupRequest(field_sets, check_only=True))
     results = await MultiGet(
-        Get(FallibleProcessResult, Process, partition.process) for partition in setup.partitions
+        Get(FallibleProcessResult, JvmProcess, partition.process) for partition in setup.partitions
     )
     lint_results = [
         LintResult.from_fallible_process_result(result, partition_description=partition.description)

--- a/src/python/pants/backend/scala/test/scalatest.py
+++ b/src/python/pants/backend/scala/test/scalatest.py
@@ -11,7 +11,6 @@ from pants.core.goals.test import TestDebugRequest, TestFieldSet, TestResult, Te
 from pants.engine.addresses import Addresses
 from pants.engine.fs import Digest, DigestSubset, MergeDigests, PathGlobs, RemovePrefix, Snapshot
 from pants.engine.process import (
-    BashBinary,
     FallibleProcessResult,
     InteractiveProcess,
     InteractiveProcessRequest,
@@ -22,7 +21,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.jvm.classpath import Classpath
 from pants.jvm.goals import lockfile
-from pants.jvm.jdk_rules import JdkSetup
+from pants.jvm.jdk_rules import JvmProcess
 from pants.jvm.resolve.coursier_fetch import (
     CoursierResolvedLockfile,
     ToolClasspath,
@@ -54,15 +53,13 @@ class TestSetupRequest:
 
 @dataclass(frozen=True)
 class TestSetup:
-    process: Process
+    process: JvmProcess
     reports_dir_prefix: str
 
 
 @rule(level=LogLevel.DEBUG)
 async def setup_scalatest_for_target(
     request: TestSetupRequest,
-    bash: BashBinary,
-    jdk_setup: JdkSetup,
     jvm: JvmSubsystem,
     scalatest: Scalatest,
     test_subsystem: TestSubsystem,
@@ -78,8 +75,7 @@ async def setup_scalatest_for_target(
     merged_classpath_digest = await Get(Digest, MergeDigests(classpath.digests()))
 
     toolcp_relpath = "__toolcp"
-    immutable_input_digests = {
-        **jdk_setup.immutable_input_digests,
+    extra_immutable_input_digests = {
         toolcp_relpath: scalatest_classpath.digest,
     }
 
@@ -98,15 +94,12 @@ async def setup_scalatest_for_target(
     if request.is_debug:
         extra_jvm_args.extend(jvm.debug_args)
 
-    process = Process(
+    process = JvmProcess(
+        classpath_entries=[
+            *classpath.args(),
+            *scalatest_classpath.classpath_entries(toolcp_relpath),
+        ],
         argv=[
-            *jdk_setup.args(
-                bash,
-                [
-                    *classpath.args(),
-                    *scalatest_classpath.classpath_entries(toolcp_relpath),
-                ],
-            ),
             *extra_jvm_args,
             "org.scalatest.tools.Runner",
             # TODO: We currently give the entire user classpath to the JVM for startup (which
@@ -119,10 +112,8 @@ async def setup_scalatest_for_target(
             *scalatest.options.args,
         ],
         input_digest=merged_classpath_digest,
-        immutable_input_digests=immutable_input_digests,
+        extra_immutable_input_digests=extra_immutable_input_digests,
         output_directories=(reports_dir,),
-        append_only_caches=jdk_setup.append_only_caches,
-        env=jdk_setup.env,
         description=f"Run Scalatest runner for {request.field_set.address}",
         level=LogLevel.DEBUG,
         cache_scope=cache_scope,
@@ -136,7 +127,7 @@ async def run_scalatest_test(
     field_set: ScalatestTestFieldSet,
 ) -> TestResult:
     test_setup = await Get(TestSetup, TestSetupRequest(field_set, is_debug=False))
-    process_result = await Get(FallibleProcessResult, Process, test_setup.process)
+    process_result = await Get(FallibleProcessResult, JvmProcess, test_setup.process)
     reports_dir_prefix = test_setup.reports_dir_prefix
 
     xml_result_subset = await Get(
@@ -155,11 +146,11 @@ async def run_scalatest_test(
 @rule(level=LogLevel.DEBUG)
 async def setup_scalatest_debug_request(field_set: ScalatestTestFieldSet) -> TestDebugRequest:
     setup = await Get(TestSetup, TestSetupRequest(field_set, is_debug=True))
+
+    process = await Get(Process, JvmProcess, setup.process)
     interactive_process = await Get(
         InteractiveProcess,
-        InteractiveProcessRequest(
-            setup.process, forward_signals_to_process=False, restartable=True
-        ),
+        InteractiveProcessRequest(process, forward_signals_to_process=False, restartable=True),
     )
     return TestDebugRequest(interactive_process)
 

--- a/src/python/pants/jvm/compile.py
+++ b/src/python/pants/jvm/compile.py
@@ -274,11 +274,7 @@ class FallibleClasspathEntry(EngineAwareReturnType):
         exit_code = process_result.exit_code
         # TODO: Coursier renders this line on macOS.
         #   see https://github.com/pantsbuild/pants/issues/13942.
-        stderr = "\n".join(
-            line
-            for line in prep_output(process_result.stderr).splitlines()
-            if line != "setrlimit to increase file descriptor limit failed, errno 22"
-        )
+        stderr = prep_output(process_result.stderr).splitlines()
         return cls(
             description=description,
             result=(CompileResult.SUCCEEDED if exit_code == 0 else CompileResult.FAILED),

--- a/src/python/pants/jvm/compile.py
+++ b/src/python/pants/jvm/compile.py
@@ -274,11 +274,11 @@ class FallibleClasspathEntry(EngineAwareReturnType):
         exit_code = process_result.exit_code
         # TODO: Coursier renders this line on macOS.
         #   see https://github.com/pantsbuild/pants/issues/13942.
-        stderr = prep_output(process_result.stderr).splitlines()
+        stderr = prep_output(process_result.stderr)
         return cls(
             description=description,
-            result=(CompileResult.SUCCEEDED if exit_code == 0 else CompileResult.FAILED),
             output=output,
+            result=(CompileResult.SUCCEEDED if exit_code == 0 else CompileResult.FAILED),
             exit_code=exit_code,
             stdout=prep_output(process_result.stdout),
             stderr=stderr,

--- a/src/python/pants/jvm/jdk_rules.py
+++ b/src/python/pants/jvm/jdk_rules.py
@@ -9,7 +9,7 @@ import re
 import shlex
 import textwrap
 from dataclasses import dataclass
-from typing import ClassVar, Iterable
+from typing import ClassVar, Iterable, Mapping
 
 from pants.engine.fs import CreateDigest, Digest, FileContent, FileDigest, MergeDigests
 from pants.engine.internals.selectors import Get
@@ -215,7 +215,7 @@ class JvmProcess:
         output_files: Iterable[str] | None = None,
         output_directories: Iterable[str] | None = None,
         extra_immutable_input_digests: dict[str, Digest] | None = None,
-        extra_env: dict[str, str] | None = None,
+        extra_env: Mapping[str, str] | None = None,
         timeout_seconds: int | float | None = None,
         platform: Platform | None = None,
     ):

--- a/src/python/pants/jvm/jdk_rules_test.py
+++ b/src/python/pants/jvm/jdk_rules_test.py
@@ -9,10 +9,11 @@ import pytest
 
 from pants.core.util_rules import config_files, source_files
 from pants.core.util_rules.external_tool import rules as external_tool_rules
+from pants.engine.internals.native_engine import EMPTY_DIGEST
 from pants.engine.internals.scheduler import ExecutionError
-from pants.engine.process import BashBinary, Process, ProcessResult
+from pants.engine.process import BashBinary, ProcessResult
 from pants.engine.process import rules as process_rules
-from pants.jvm.jdk_rules import JdkSetup, parse_jre_major_version
+from pants.jvm.jdk_rules import JdkSetup, JvmProcess, parse_jre_major_version
 from pants.jvm.jdk_rules import rules as jdk_rules
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
@@ -35,7 +36,7 @@ def rule_runner() -> RuleRunner:
             *process_rules(),
             QueryRule(BashBinary, ()),
             QueryRule(JdkSetup, ()),
-            QueryRule(ProcessResult, (Process,)),
+            QueryRule(ProcessResult, (JvmProcess,)),
         ],
     )
     rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
@@ -43,19 +44,15 @@ def rule_runner() -> RuleRunner:
 
 
 def run_javac_version(rule_runner: RuleRunner) -> str:
-    jdk_setup = rule_runner.request(JdkSetup, [])
-    bash = rule_runner.request(BashBinary, [])
     process_result = rule_runner.request(
         ProcessResult,
         [
-            Process(
+            JvmProcess(
+                classpath_entries=(),
                 argv=[
-                    *jdk_setup.args(bash, []),
                     "-version",
                 ],
-                append_only_caches=jdk_setup.append_only_caches,
-                immutable_input_digests=jdk_setup.immutable_input_digests,
-                env=jdk_setup.env,
+                input_digest=EMPTY_DIGEST,
                 description="",
             )
         ],

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -45,7 +45,7 @@ from pants.jvm.resolve.common import (
     Coordinate,
     Coordinates,
 )
-from pants.jvm.resolve.coursier_setup import Coursier, CoursierWrapperRequest, CoursierWrapperResult
+from pants.jvm.resolve.coursier_setup import Coursier, CoursierWrapperProcess, CoursierWrapperResult
 from pants.jvm.resolve.key import CoursierResolveKey
 from pants.jvm.resolve.lockfile_metadata import JVMLockfileMetadata
 from pants.jvm.subsystems import JvmSubsystem
@@ -364,7 +364,7 @@ async def coursier_resolve_lockfile(
 
     process_result = await Get(
         CoursierWrapperResult,
-        CoursierWrapperRequest(
+        CoursierWrapperProcess(
             args=(
                 coursier_report_file_name,
                 *coursier_resolve_info.coord_arg_strings,
@@ -524,7 +524,7 @@ async def coursier_fetch_one_coord(
 
     process_result = await Get(
         CoursierWrapperResult,
-        CoursierWrapperRequest(
+        CoursierWrapperProcess(
             args=(
                 coursier_report_file_name,
                 "--intransitive",

--- a/src/python/pants/jvm/resolve/coursier_setup.py
+++ b/src/python/pants/jvm/resolve/coursier_setup.py
@@ -196,8 +196,14 @@ async def invoke_coursier_wrapper(
         ),
     )
 
+    filtered_stderr = b"\n".join(
+        line
+        for line in process_result.stderr.splitlines()
+        if line != "AAAsetrlimit to increase file descriptor limit failed, errno 22"
+    )
+
     return CoursierWrapperResult(
-        process_result.output_digest, process_result.stdout, process_result.stderr
+        process_result.output_digest, process_result.stdout, filtered_stderr
     )
 
 

--- a/src/python/pants/jvm/resolve/coursier_setup.py
+++ b/src/python/pants/jvm/resolve/coursier_setup.py
@@ -155,7 +155,7 @@ class Coursier:
 
 
 @dataclass(frozen=True)
-class CoursierWrapperRequest:
+class CoursierWrapperProcess:
 
     args: Tuple[str, ...]
     input_digest: Digest
@@ -175,7 +175,7 @@ class CoursierWrapperResult:
 async def invoke_coursier_wrapper(
     bash: BashBinary,
     coursier: Coursier,
-    request: CoursierWrapperRequest,
+    request: CoursierWrapperProcess,
 ) -> CoursierWrapperResult:
 
     process_result = await Get(
@@ -199,7 +199,7 @@ async def invoke_coursier_wrapper(
     filtered_stderr = b"\n".join(
         line
         for line in process_result.stderr.splitlines()
-        if line != "AAAsetrlimit to increase file descriptor limit failed, errno 22"
+        if line != b"setrlimit to increase file descriptor limit failed, errno 22"
     )
 
     return CoursierWrapperResult(

--- a/src/python/pants/jvm/test/junit.py
+++ b/src/python/pants/jvm/test/junit.py
@@ -10,7 +10,6 @@ from pants.core.goals.test import TestDebugRequest, TestFieldSet, TestResult, Te
 from pants.engine.addresses import Addresses
 from pants.engine.fs import Digest, DigestSubset, MergeDigests, PathGlobs, RemovePrefix, Snapshot
 from pants.engine.process import (
-    BashBinary,
     FallibleProcessResult,
     InteractiveProcess,
     InteractiveProcessRequest,
@@ -21,7 +20,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.jvm.classpath import Classpath
 from pants.jvm.goals import lockfile
-from pants.jvm.jdk_rules import JdkSetup
+from pants.jvm.jdk_rules import JvmProcess
 from pants.jvm.resolve.coursier_fetch import (
     CoursierResolvedLockfile,
     ToolClasspath,
@@ -54,15 +53,13 @@ class TestSetupRequest:
 
 @dataclass(frozen=True)
 class TestSetup:
-    process: Process
+    process: JvmProcess
     reports_dir_prefix: str
 
 
 @rule(level=LogLevel.DEBUG)
 async def setup_junit_for_target(
     request: TestSetupRequest,
-    bash: BashBinary,
-    jdk_setup: JdkSetup,
     jvm: JvmSubsystem,
     junit: JUnit,
     test_subsystem: TestSubsystem,
@@ -78,8 +75,7 @@ async def setup_junit_for_target(
     merged_classpath_digest = await Get(Digest, MergeDigests(classpath.digests()))
 
     toolcp_relpath = "__toolcp"
-    immutable_input_digests = {
-        **jdk_setup.immutable_input_digests,
+    extra_immutable_input_digests = {
         toolcp_relpath: junit_classpath.digest,
     }
 
@@ -98,15 +94,12 @@ async def setup_junit_for_target(
     if request.is_debug:
         extra_jvm_args.extend(jvm.debug_args)
 
-    process = Process(
+    process = JvmProcess(
+        classpath_entries=[
+            *classpath.args(),
+            *junit_classpath.classpath_entries(toolcp_relpath),
+        ],
         argv=[
-            *jdk_setup.args(
-                bash,
-                [
-                    *classpath.args(),
-                    *junit_classpath.classpath_entries(toolcp_relpath),
-                ],
-            ),
             *extra_jvm_args,
             "org.junit.platform.console.ConsoleLauncher",
             *(("--classpath", user_classpath_arg) if user_classpath_arg else ()),
@@ -116,10 +109,8 @@ async def setup_junit_for_target(
             *junit.options.args,
         ],
         input_digest=merged_classpath_digest,
-        immutable_input_digests=immutable_input_digests,
+        extra_immutable_input_digests=extra_immutable_input_digests,
         output_directories=(reports_dir,),
-        append_only_caches=jdk_setup.append_only_caches,
-        env=jdk_setup.env,
         description=f"Run JUnit 5 ConsoleLauncher against {request.field_set.address}",
         level=LogLevel.DEBUG,
         cache_scope=cache_scope,
@@ -133,7 +124,7 @@ async def run_junit_test(
     field_set: JunitTestFieldSet,
 ) -> TestResult:
     test_setup = await Get(TestSetup, TestSetupRequest(field_set, is_debug=False))
-    process_result = await Get(FallibleProcessResult, Process, test_setup.process)
+    process_result = await Get(FallibleProcessResult, JvmProcess, test_setup.process)
     reports_dir_prefix = test_setup.reports_dir_prefix
 
     xml_result_subset = await Get(
@@ -152,11 +143,10 @@ async def run_junit_test(
 @rule(level=LogLevel.DEBUG)
 async def setup_junit_debug_request(field_set: JunitTestFieldSet) -> TestDebugRequest:
     setup = await Get(TestSetup, TestSetupRequest(field_set, is_debug=True))
+    process = await Get(Process, JvmProcess, setup.process)
     interactive_process = await Get(
         InteractiveProcess,
-        InteractiveProcessRequest(
-            setup.process, forward_signals_to_process=False, restartable=True
-        ),
+        InteractiveProcessRequest(process, forward_signals_to_process=False, restartable=True),
     )
     return TestDebugRequest(interactive_process)
 


### PR DESCRIPTION
Replaces ad-hoc, repetitive `Process` requests with a rule that calls the coursier wrapper script in a consistent way. Filters the JVM `setrlimit` errors at the source, too.

Closes #13942