### PR TITLE
PoC: Adding goal name to dynamic UI output

### DIFF
--- a/src/rust/engine/ui/src/console_ui.rs
+++ b/src/rust/engine/ui/src/console_ui.rs
@@ -141,17 +141,21 @@ impl ConsoleUI {
   }
 
   fn get_label_from_heavy_hitters(
-    tasks_to_display: &IndexMap<SpanId, (String, Option<Duration>)>,
+    tasks_to_display: &IndexMap<SpanId, (String, Option<String>, Option<Duration>)>,
     index: usize,
   ) -> Option<String> {
     tasks_to_display
       .get_index(index)
-      .map(|(_, (label, maybe_duration))| {
+      .map(|(_, (label, maybe_goalname, maybe_duration))| {
         let duration_label = match maybe_duration {
           None => "(Waiting) ".to_string(),
           Some(duration) => format_workunit_duration(*duration),
         };
-        format!("{}{}", duration_label, label)
+        let goal_label = match maybe_goalname {
+          None => "".to_string(),
+          Some(label) => format!("[{}] ", label.clone()),
+        };
+        format!("{}{}{}", duration_label, goal_label, label)
       })
   }
 
@@ -236,7 +240,7 @@ type MultiProgressTask = Pin<Box<dyn Future<Output = std::io::Result<()>> + Send
 
 /// The state for one run of the ConsoleUI.
 struct Instance {
-  tasks_to_display: IndexMap<SpanId, (String, Option<Duration>)>,
+  tasks_to_display: IndexMap<SpanId, (String, Option<String>, Option<Duration>)>,
   multi_progress_task: MultiProgressTask,
   bars: Vec<ProgressBar>,
 }


### PR DESCRIPTION
This PR is mostly a conversation-starter.

It exists because of a culmination of a few things:
- In the move to #14221 , to apply the same fix as #14093 I'll likely need a "swimlane" that is alive the entire run. Since `prodash::Root::Item`s will come and go, I thought "hey what if we nested each item under a root item that was the goal that was running?" and so, this idea.
- The UI displaying the goal name is wonderful for runs where you have multiple goals running sequentially (see MP4)
- Additionally, this could be adapted to show multi-goal parallel executions a la #10542 

---

The implementation is _mostly_ just hacked together for demo purposes, but gives us a place to discuss some questions:
- Grabbing the goal from the heavy hitter workunit works for `indicatif`, where we might not be displaying any heavy hitters, but wouldn't work for the `prodash` use case listed above.
- Grabbing the goal by choosing the child-of-the-root-node is extremely hacky. What are people's thoughts on how to propagate this information? Maybe the rule type in the metadata? Another field?

https://user-images.githubusercontent.com/3956745/151011126-25a7d118-b63a-48d1-92a4-41a08c8574ad.mp4

