### PR TITLE
[internal] Add `[python].experimental_resolves_to_interpreter_constraints`

### DIFF
--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -243,18 +243,17 @@ async def setup_user_lockfile_requests(
         for resolve in tgt[PythonRequirementCompatibleResolvesField].value_or_default(python_setup):
             resolve_to_requirements_fields[resolve].add(tgt[PythonRequirementsField])
 
-    # TODO: Figure out how to determine which interpreter constraints to use for each resolve...
-    #  Note that `python_requirement` does not have interpreter constraints, so we either need to
-    #  inspect all consumers of that resolve or start to closely couple the resolve with the
-    #  interpreter constraints (a "context").
-
     return UserGenerateLockfiles(
         GeneratePythonLockfile(
             requirements=PexRequirements.create_from_requirement_fields(
                 resolve_to_requirements_fields[resolve],
                 constraints_strings=(),
             ).req_strings,
-            interpreter_constraints=InterpreterConstraints(python_setup.interpreter_constraints),
+            interpreter_constraints=InterpreterConstraints(
+                python_setup.resolves_to_interpreter_constraints.get(
+                    resolve, python_setup.interpreter_constraints
+                )
+            ),
             resolve_name=resolve,
             lockfile_dest=python_setup.resolves[resolve],
         )

--- a/src/python/pants/backend/python/goals/lockfile_test.py
+++ b/src/python/pants/backend/python/goals/lockfile_test.py
@@ -54,6 +54,8 @@ def test_multiple_resolves() -> None:
     rule_runner.set_options(
         [
             "--python-experimental-resolves={'a': 'a.lock', 'b': 'b.lock'}",
+            # Override interpreter constraints for 'b', but use default for 'a'.
+            "--python-experimental-resolves-to-interpreter-constraints={'b': ['==3.7.*']}",
             "--python-enable-resolves",
         ],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
@@ -72,9 +74,7 @@ def test_multiple_resolves() -> None:
         ),
         GeneratePythonLockfile(
             requirements=FrozenOrderedSet(["b", "both1", "both2"]),
-            interpreter_constraints=InterpreterConstraints(
-                PythonSetup.default_interpreter_constraints
-            ),
+            interpreter_constraints=InterpreterConstraints(["==3.7.*"]),
             resolve_name="b",
             lockfile_dest="b.lock",
         ),

--- a/src/python/pants/backend/python/subsystems/setup_test.py
+++ b/src/python/pants/backend/python/subsystems/setup_test.py
@@ -1,0 +1,22 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import pytest
+
+from pants.backend.python.subsystems.setup import PythonSetup
+from pants.testutil.option_util import create_subsystem
+
+
+def test_resolves_to_interpreter_constraints_validation() -> None:
+    def create(resolves_to_ics: dict[str, list[str]]) -> dict[str, tuple[str, ...]]:
+        return create_subsystem(
+            PythonSetup,
+            experimental_resolves={"a": "a.lock"},
+            experimental_resolves_to_interpreter_constraints=resolves_to_ics,
+        ).resolves_to_interpreter_constraints
+
+    assert create({"a": ["==3.7.*"]}) == {"a": ("==3.7.*",)}
+    with pytest.raises(KeyError):
+        create({"fake": []})


### PR DESCRIPTION
## Problem

We need to know which interpreter constraints to use when generating a user lockfile, which will affect the behavior of Poetry & (soon) Pex.

The interpreter constraints of the resolve itself should be a superset of the user's actual code consuming that resolve. For example, the resolve might work with 3.6-3.9, and then there are some individual `python_test` targets that are specifically 3.6, 3.7, etc. It's necessary that the resolve can accommodate those more specific values.

## Solution

Let the user manually set the interpreter constraints for each resolve, with it defaulting to the global interpreter constraints.

This setting only impacts lockfile generation—the value is not mixed into call sites' computation of which interpreter constraints to use for user code. However, we store the resolve's interpreter constraints in the lockfile's header, which allows us to validate that the user's code is a subset of the resolve's constraints.

## Alternatives rejected

### Magically determine ICs based on consumers

We would scan all consumers of a resolve, then merge together to form interpreter constraints. 

@stuhood and I believe this is too magical and brittle, that you could too easily inadvertently change the ICs of an entire resolve by changing the `interpreter_constraints` of one target.

### Add `interpreter_constraints` to `python_requirement` target

Each individual target would have the field, and we would merge all `python_requirement` targets for that resolve. 

I believe this is too fine-grained and thus confusing for users. It would be tedious to have to set the interpreter constraints for each individual requirement, and it's also hard to be accurate because you would have to reason about transitive deps which are not pinned until you generate the lockfile, so could change when regenerating. Instead, treat each resolve as an atomic unit.

By avoiding this design, we also avoid having the resolve's interpreter constraints changing the code's computed interpreter constraints, outside of lockfile validation. Everything behaves the same as before.

[ci skip-rust]