### PR TITLE
[internal] Only warn about `--use-deprecated-python-macros` when Python used

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1643,7 +1643,10 @@ class ProcessCleanupOption:
 
 
 def maybe_warn_python_macros_deprecation(bootstrap_options: OptionValueContainer) -> None:
-    if bootstrap_options.is_default("use_deprecated_python_macros"):
+    if (
+        bootstrap_options.is_default("use_deprecated_python_macros")
+        and "pants.backend.python" in bootstrap_options.backend_packages
+    ):
         warn_or_error(
             "2.11.0.dev0",
             "the option `--use-deprecated-python-macros` defaulting to true",


### PR DESCRIPTION
It's annoying and noisy to warn about this option in JVM and Go repositories.

[ci skip-rust]
[ci skip-build-wheels]