### PR TITLE
go: filter out `vendor` directories in tailor

### DIFF
--- a/src/python/pants/backend/go/goals/tailor.py
+++ b/src/python/pants/backend/go/goals/tailor.py
@@ -70,8 +70,11 @@ async def find_putative_go_targets(
     # Add `go_package` targets.
     unowned_go_files = set(all_go_files.files) - set(all_owned_sources)
     for dirname, filenames in group_by_dir(unowned_go_files).items():
+        # Ignore paths that have `testdata` or `vendor` in them.
+        # From `go help packages`: Note, however, that a directory named vendor that itself contains code
+        # is not a vendored package: cmd/vendor would be a command named vendor.
         dirname_parts = PurePath(dirname).parts
-        if "testdata" in dirname_parts or "vendor" in dirname_parts:
+        if "testdata" in dirname_parts or "vendor" in dirname_parts[0:-1]:
             continue
         putative_targets.append(
             PutativeTarget.for_target_type(

--- a/src/python/pants/backend/go/goals/tailor.py
+++ b/src/python/pants/backend/go/goals/tailor.py
@@ -70,7 +70,8 @@ async def find_putative_go_targets(
     # Add `go_package` targets.
     unowned_go_files = set(all_go_files.files) - set(all_owned_sources)
     for dirname, filenames in group_by_dir(unowned_go_files).items():
-        if "testdata" in PurePath(dirname).parts:
+        dirname_parts = PurePath(dirname).parts
+        if "testdata" in dirname_parts or "vendor" in dirname_parts:
             continue
         putative_targets.append(
             PutativeTarget.for_target_type(

--- a/src/python/pants/backend/go/goals/tailor_test.py
+++ b/src/python/pants/backend/go/goals/tailor_test.py
@@ -76,9 +76,10 @@ def test_find_go_package_targets(rule_runner: RuleRunner) -> None:
             "unowned/f1.go": "",
             "owned/f.go": "",
             "owned/BUILD": "go_package()",
-            # Any `.go` files under a `testdata` folder should be ignored.
+            # Any `.go` files under a `testdata` or `vendor` folder should be ignored.
             "unowned/testdata/f.go": "",
             "unowned/testdata/subdir/f.go": "",
+            "unowned/vendor/example.com/foo/bar.go": "",
         }
     )
     putative_targets = rule_runner.request(

--- a/src/python/pants/backend/go/goals/tailor_test.py
+++ b/src/python/pants/backend/go/goals/tailor_test.py
@@ -80,6 +80,8 @@ def test_find_go_package_targets(rule_runner: RuleRunner) -> None:
             "unowned/testdata/f.go": "",
             "unowned/testdata/subdir/f.go": "",
             "unowned/vendor/example.com/foo/bar.go": "",
+            # Except if `vendor` is the last directory.
+            "unowned/cmd/vendor/main.go": "",
         }
     )
     putative_targets = rule_runner.request(
@@ -96,7 +98,13 @@ def test_find_go_package_targets(rule_runner: RuleRunner) -> None:
                 path="unowned",
                 name=None,
                 triggering_sources=["f.go", "f1.go"],
-            )
+            ),
+            PutativeTarget.for_target_type(
+                GoPackageTarget,
+                path="unowned/cmd/vendor",
+                name=None,
+                triggering_sources=["main.go"],
+            ),
         ]
     )
 


### PR DESCRIPTION
As described in https://github.com/pantsbuild/pants/issues/14255, `./pants tailor` is generating targets for Go code in `vendor` directories. The Go backend does not currently support `vendor` directories, and the likely implementation will use target generation to put those sources into the build graph, so there is no reason for tailor to create explicit targets.

Closes https://github.com/pantsbuild/pants/issues/14255.

[ci skip-rust]

[ci skip-build-wheels]