### PR TITLE
Fix packaged file names for `pex_binaries` target generator

### DIFF
--- a/src/python/pants/backend/python/goals/run_pex_binary.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary.py
@@ -52,7 +52,7 @@ async def create_pex_binary_run_request(
 
     pex_filename = (
         field_set.address.generated_name.replace(".", "_")
-        if field_set.address.is_generated_target
+        if field_set.address.generated_name
         else field_set.address.target_name
     )
     pex_get = Get(

--- a/src/python/pants/backend/python/goals/run_pex_binary.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary.py
@@ -50,11 +50,16 @@ async def create_pex_binary_run_request(
         InterpreterConstraints, InterpreterConstraintsRequest(addresses)
     )
 
+    pex_filename = (
+        field_set.address.generated_name.replace(".", "_")
+        if field_set.address.is_generated_target
+        else field_set.address.target_name
+    )
     pex_get = Get(
         Pex,
         PexFromTargetsRequest(
             [field_set.address],
-            output_filename=f"{field_set.address.target_name}.pex",
+            output_filename=f"{pex_filename}.pex",
             internal_only=True,
             include_source_files=False,
             # Note that the file for first-party entry points is not in the PEX itself. In that

--- a/src/python/pants/core/goals/package.py
+++ b/src/python/pants/core/goals/package.py
@@ -60,11 +60,16 @@ class OutputPathField(StringField, AsyncFieldMixin):
     def value_or_default(self, *, file_ending: str | None) -> str:
         if self.value:
             return self.value
+        file_prefix = (
+            self.address.generated_name.replace(".", "_")
+            if self.address.is_generated_target
+            else self.address.target_name
+        )
         if file_ending is None:
-            file_name = self.address.target_name
+            file_name = file_prefix
         else:
             assert not file_ending.startswith("."), "`file_ending` should not start with `.`"
-            file_name = f"{self.address.target_name}.{file_ending}"
+            file_name = f"{file_prefix}.{file_ending}"
         return os.path.join(self.address.spec_path.replace(os.sep, "."), file_name)
 
 

--- a/src/python/pants/core/goals/package.py
+++ b/src/python/pants/core/goals/package.py
@@ -62,7 +62,7 @@ class OutputPathField(StringField, AsyncFieldMixin):
             return self.value
         file_prefix = (
             self.address.generated_name.replace(".", "_")
-            if self.address.is_generated_target
+            if self.address.generated_name
             else self.address.target_name
         )
         if file_ending is None:


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/13910 added the very useful `pex_binaries` target generator, but we missed that the `output_path` was still always using the target name to calculate the default. With generated targets, they all share the same `target_name`, so this was causing `./pants package build-support/bin:` to crash due to a merge conflict with `MergeDigests`.

Now:

```
12:26:02.50 [INFO] Wrote dist/build-support.bin/_generate_all_lockfiles_helper_py.pex
12:26:02.50 [INFO] Wrote dist/build-support.bin/_release_helper_py.pex
12:26:02.50 [INFO] Wrote dist/build-support.bin/changelog_py.pex
12:26:02.50 [INFO] Wrote dist/build-support.bin/check_banned_imports_py.pex
```

It also caused `./pants run` to be a bit confusing, saying that it was building `bin.pex` rather than `changelog_py.pex`.

> With generated targets, they all share the same `target_name`, so this was causing `./pants package build-support/bin:` to crash.

We still risk crashes if the user defines two `pex_binaries` over the same entry points (file names) in the same directory (i.e. same `Address.spec_path`). To truly make this robust, we need to use the `Address.spec_path`, `Address.target_name`, and `Address.generated_name`. Should we do that? It makes the result much more verbose.

[ci skip-rust]
[ci skip-build-wheels]