### PR TITLE
[internal] Improve `generate_all_lockfiles.sh` script

### DIFF
--- a/build-support/bin/_generate_all_lockfiles_helper.py
+++ b/build-support/bin/_generate_all_lockfiles_helper.py
@@ -56,7 +56,7 @@ class DefaultTool:
     args: tuple[str, ...]
 
     @classmethod
-    def from_python_tool(
+    def python(
         cls,
         tool: type[PythonToolRequirementsBase],
         *,
@@ -79,7 +79,7 @@ class DefaultTool:
         return DefaultTool(tool.options_scope, tuple(args))
 
     @classmethod
-    def from_jvm_tool(cls, tool: type[JvmToolBase], *, backend: str | None = None) -> DefaultTool:
+    def jvm(cls, tool: type[JvmToolBase], *, backend: str | None = None) -> DefaultTool:
         args = [
             f"--{tool.options_scope}-version={tool.default_version}",
             f"--{tool.options_scope}-artifacts={tool.default_artifacts}",
@@ -92,47 +92,35 @@ class DefaultTool:
 
 AllTools = (
     # Python
-    DefaultTool.from_python_tool(Autoflake),
-    DefaultTool.from_python_tool(Bandit, backend="pants.backend.python.lint.bandit"),
-    DefaultTool.from_python_tool(Black),
-    DefaultTool.from_python_tool(Docformatter),
-    DefaultTool.from_python_tool(Flake8, source_plugins=True),
-    DefaultTool.from_python_tool(Isort),
-    DefaultTool.from_python_tool(
-        Pylint, backend="pants.backend.python.lint.pylint", source_plugins=True
-    ),
-    DefaultTool.from_python_tool(Yapf, backend="pants.backend.python.lint.yapf"),
-    DefaultTool.from_python_tool(
-        PyUpgrade, backend="pants.backend.experimental.python.lint.pyupgrade"
-    ),
-    DefaultTool.from_python_tool(IPython),
-    DefaultTool.from_python_tool(Setuptools),
-    DefaultTool.from_python_tool(MyPy, source_plugins=True),
-    DefaultTool.from_python_tool(
-        PythonProtobufMypyPlugin, backend="pants.backend.codegen.protobuf.python"
-    ),
-    DefaultTool.from_python_tool(Lambdex, backend="pants.backend.awslambda.python"),
-    DefaultTool.from_python_tool(PyTest),
-    DefaultTool.from_python_tool(CoverageSubsystem),
-    DefaultTool.from_python_tool(
-        TerraformHcl2Parser, backend="pants.backend.experimental.terraform"
-    ),
-    DefaultTool.from_python_tool(DockerfileParser, backend="pants.backend.experimental.docker"),
-    DefaultTool.from_python_tool(TwineSubsystem),
+    DefaultTool.python(Autoflake),
+    DefaultTool.python(Bandit, backend="pants.backend.python.lint.bandit"),
+    DefaultTool.python(Black),
+    DefaultTool.python(Docformatter),
+    DefaultTool.python(Flake8, source_plugins=True),
+    DefaultTool.python(Isort),
+    DefaultTool.python(Pylint, backend="pants.backend.python.lint.pylint", source_plugins=True),
+    DefaultTool.python(Yapf, backend="pants.backend.python.lint.yapf"),
+    DefaultTool.python(PyUpgrade, backend="pants.backend.experimental.python.lint.pyupgrade"),
+    DefaultTool.python(IPython),
+    DefaultTool.python(Setuptools),
+    DefaultTool.python(MyPy, source_plugins=True),
+    DefaultTool.python(PythonProtobufMypyPlugin, backend="pants.backend.codegen.protobuf.python"),
+    DefaultTool.python(Lambdex, backend="pants.backend.awslambda.python"),
+    DefaultTool.python(PyTest),
+    DefaultTool.python(CoverageSubsystem),
+    DefaultTool.python(TerraformHcl2Parser, backend="pants.backend.experimental.terraform"),
+    DefaultTool.python(DockerfileParser, backend="pants.backend.experimental.docker"),
+    DefaultTool.python(TwineSubsystem),
     # JVM
-    DefaultTool.from_jvm_tool(JUnit),
-    DefaultTool.from_jvm_tool(GoogleJavaFormatSubsystem),
-    DefaultTool.from_jvm_tool(ScalafmtSubsystem),
-    DefaultTool.from_jvm_tool(
-        ScalaPBSubsystem, backend="pants.backend.experimental.codegen.protobuf.scala"
-    ),
-    DefaultTool.from_jvm_tool(Scalatest),
-    DefaultTool.from_jvm_tool(
+    DefaultTool.jvm(JUnit),
+    DefaultTool.jvm(GoogleJavaFormatSubsystem),
+    DefaultTool.jvm(ScalafmtSubsystem),
+    DefaultTool.jvm(ScalaPBSubsystem, backend="pants.backend.experimental.codegen.protobuf.scala"),
+    DefaultTool.jvm(Scalatest),
+    DefaultTool.jvm(
         ScroogeSubsystem, backend="pants.backend.experimental.codegen.thrift.scrooge.scala"
     ),
-    DefaultTool.from_jvm_tool(
-        AvroSubsystem, backend="pants.backend.experimental.codegen.avro.java"
-    ),
+    DefaultTool.jvm(AvroSubsystem, backend="pants.backend.experimental.codegen.avro.java"),
     DefaultTool(
         "scalac-plugins",
         (f"--scalac-plugins-global-lockfile={Scalac.default_plugins_lockfile_path}",),

--- a/build-support/bin/_generate_all_lockfiles_helper.py
+++ b/build-support/bin/_generate_all_lockfiles_helper.py
@@ -8,8 +8,12 @@ users. We need to decouple our own internal usage (e.g. using Flake8 plugins) fr
 should be.
 """
 
+from __future__ import annotations
+
+import itertools
 import logging
 import subprocess
+from dataclasses import dataclass
 
 from pants.backend.codegen.protobuf.python.python_protobuf_subsystem import PythonProtobufMypyPlugin
 from pants.backend.docker.subsystems.dockerfile_parser import DockerfileParser
@@ -26,6 +30,7 @@ from pants.backend.python.lint.yapf.subsystem import Yapf
 from pants.backend.python.subsystems.ipython import IPython
 from pants.backend.python.subsystems.lambdex import Lambdex
 from pants.backend.python.subsystems.pytest import PyTest
+from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.subsystems.setuptools import Setuptools
 from pants.backend.python.subsystems.twine import TwineSubsystem
@@ -35,9 +40,73 @@ from pants.backend.terraform.dependency_inference import TerraformHcl2Parser
 logger = logging.getLogger(__name__)
 
 
-def main() -> None:
-    # First, generate what we internally use.
-    logger.info("First, generating lockfiles for internal usage")
+@dataclass(frozen=True)
+class DefaultTool:
+    """How to generate the default lockfile for a tool.
+
+    We must be careful that we configure our settings properly so that internal config does not mess
+    up the default.
+    """
+
+    resolve_name: str
+    args: tuple[str, ...]
+
+    @classmethod
+    def from_python_tool(
+        cls,
+        tool: type[PythonToolRequirementsBase],
+        *,
+        backend: str | None = None,
+        source_plugins: bool = False,
+    ) -> DefaultTool:
+        args = [
+            f"--{tool.options_scope}-version={tool.default_version}",
+            f"--{tool.options_scope}-extra-requirements={repr(tool.default_extra_requirements)}",
+            f"--{tool.options_scope}-lockfile={tool.default_lockfile_path}",  # type: ignore[attr-defined]
+        ]
+        if tool.register_interpreter_constraints:
+            args.append(
+                f"--{tool.options_scope}-interpreter-constraints={repr(tool.default_interpreter_constraints)}"
+            )
+        if source_plugins:
+            args.append(f"--{tool.options_scope}-source-plugins=[]")
+        if backend:
+            args.append(f"--backend-packages=+['{backend}']")
+        return DefaultTool(tool.options_scope, tuple(args))
+
+
+AllTools = (
+    DefaultTool.from_python_tool(Autoflake),
+    DefaultTool.from_python_tool(Bandit, backend="pants.backend.python.lint.bandit"),
+    DefaultTool.from_python_tool(Black),
+    DefaultTool.from_python_tool(Docformatter),
+    DefaultTool.from_python_tool(Flake8, source_plugins=True),
+    DefaultTool.from_python_tool(Isort),
+    DefaultTool.from_python_tool(
+        Pylint, backend="pants.backend.python.lint.pylint", source_plugins=True
+    ),
+    DefaultTool.from_python_tool(Yapf, backend="pants.backend.python.lint.yapf"),
+    DefaultTool.from_python_tool(
+        PyUpgrade, backend="pants.backend.experimental.python.lint.pyupgrade"
+    ),
+    DefaultTool.from_python_tool(IPython),
+    DefaultTool.from_python_tool(Setuptools),
+    DefaultTool.from_python_tool(MyPy, source_plugins=True),
+    DefaultTool.from_python_tool(
+        PythonProtobufMypyPlugin, backend="pants.backend.codegen.protobuf.python"
+    ),
+    DefaultTool.from_python_tool(Lambdex, backend="pants.backend.awslambda.python"),
+    DefaultTool.from_python_tool(PyTest),
+    DefaultTool.from_python_tool(CoverageSubsystem),
+    DefaultTool.from_python_tool(
+        TerraformHcl2Parser, backend="pants.backend.experimental.terraform"
+    ),
+    DefaultTool.from_python_tool(DockerfileParser, backend="pants.backend.experimental.docker"),
+    DefaultTool.from_python_tool(TwineSubsystem),
+)
+
+
+def update_internal_lockfiles() -> None:
     subprocess.run(
         [
             "./pants",
@@ -54,118 +123,23 @@ def main() -> None:
         check=True,
     )
 
-    logger.info("Now, generating default tool lockfiles for users")
-    # Now, generate default tool lockfiles. We must be careful that our own internal settings
-    # (e.g. custom extra requirements) do not mess up the defaults.
+
+def update_default_lockfiles() -> None:
     subprocess.run(
         [
             "./pants",
             "--concurrent",
             f"--python-interpreter-constraints={repr(PythonSetup.default_interpreter_constraints)}",
-            # Autoflake.
-            f"--autoflake-version={Autoflake.default_version}",
-            f"--autoflake-extra-requirements={repr(Autoflake.default_extra_requirements)}",
-            f"--autoflake-interpreter-constraints={repr(Autoflake.default_interpreter_constraints)}",
-            f"--autoflake-lockfile={Autoflake.default_lockfile_path}",
-            # Bandit.
-            "--backend-packages=+['pants.backend.python.lint.bandit']",
-            f"--bandit-version={Bandit.default_version}",
-            f"--bandit-extra-requirements={repr(Bandit.default_extra_requirements)}",
-            f"--bandit-lockfile={Bandit.default_lockfile_path}",
-            # Black.
-            f"--black-version={Black.default_version}",
-            f"--black-extra-requirements={repr(Black.default_extra_requirements)}",
-            f"--black-interpreter-constraints={repr(Black.default_interpreter_constraints)}",
-            f"--black-lockfile={Black.default_lockfile_path}",
-            # Docformatter.
-            f"--docformatter-version={Docformatter.default_version}",
-            f"--docformatter-extra-requirements={repr(Docformatter.default_extra_requirements)}",
-            f"--docformatter-interpreter-constraints={repr(Docformatter.default_interpreter_constraints)}",
-            f"--docformatter-lockfile={Docformatter.default_lockfile_path}",
-            # Flake8.
-            f"--flake8-version={Flake8.default_version}",
-            f"--flake8-extra-requirements={repr(Flake8.default_extra_requirements)}",
-            f"--flake8-lockfile={Flake8.default_lockfile_path}",
-            # Isort.
-            f"--isort-version={Isort.default_version}",
-            f"--isort-extra-requirements={repr(Isort.default_extra_requirements)}",
-            f"--isort-interpreter-constraints={repr(Isort.default_interpreter_constraints)}",
-            f"--isort-lockfile={Isort.default_lockfile_path}",
-            # Pylint.
-            "--backend-packages=+['pants.backend.python.lint.pylint']",
-            f"--pylint-version={Pylint.default_version}",
-            f"--pylint-extra-requirements={repr(Pylint.default_extra_requirements)}",
-            "--pylint-source-plugins=[]",
-            f"--pylint-lockfile={Pylint.default_lockfile_path}",
-            # Yapf.
-            "--backend-packages=+['pants.backend.python.lint.yapf']",
-            f"--yapf-version={Yapf.default_version}",
-            f"--yapf-extra-requirements={repr(Yapf.default_extra_requirements)}",
-            f"--yapf-interpreter-constraints={repr(Yapf.default_interpreter_constraints)}",
-            f"--yapf-lockfile={Yapf.default_lockfile_path}",
-            # PyUpgrade.
-            "--backend-packages=+['pants.backend.experimental.python.lint.pyupgrade']",
-            f"--pyupgrade-version={PyUpgrade.default_version}",
-            f"--pyupgrade-extra-requirements={repr(PyUpgrade.default_extra_requirements)}",
-            f"--pyupgrade-interpreter-constraints={repr(PyUpgrade.default_interpreter_constraints)}",
-            f"--pyupgrade-lockfile={PyUpgrade.default_lockfile_path}",
-            # IPython.
-            f"--ipython-version={IPython.default_version}",
-            f"--ipython-extra-requirements={repr(IPython.default_extra_requirements)}",
-            f"--ipython-lockfile={IPython.default_lockfile_path}",
-            # Setuptools.
-            f"--setuptools-version={Setuptools.default_version}",
-            f"--setuptools-extra-requirements={repr(Setuptools.default_extra_requirements)}",
-            f"--setuptools-lockfile={Setuptools.default_lockfile_path}",
-            # MyPy.
-            f"--mypy-version={MyPy.default_version}",
-            f"--mypy-extra-requirements={repr(MyPy.default_extra_requirements)}",
-            "--mypy-source-plugins=[]",
-            f"--mypy-interpreter-constraints={repr(MyPy.default_interpreter_constraints)}",
-            f"--mypy-lockfile={MyPy.default_lockfile_path}",
-            # MyPy Protobuf.
-            "--backend-packages=+['pants.backend.codegen.protobuf.python']",
-            f"--mypy-protobuf-version={PythonProtobufMypyPlugin.default_version}",
-            f"--mypy-protobuf-extra-requirements={repr(PythonProtobufMypyPlugin.default_extra_requirements)}",
-            f"--mypy-protobuf-interpreter-constraints={repr(PythonProtobufMypyPlugin.default_interpreter_constraints)}",
-            f"--mypy-protobuf-lockfile={PythonProtobufMypyPlugin.default_lockfile_path}",
-            # Lambdex.
-            "--backend-packages=+['pants.backend.google_cloud_function.python','pants.backend.awslambda.python']",
-            f"--lambdex-version={Lambdex.default_version}",
-            f"--lambdex-extra-requirements={repr(Lambdex.default_extra_requirements)}",
-            f"--lambdex-interpreter-constraints={repr(Lambdex.default_interpreter_constraints)}",
-            f"--lambdex-lockfile={Lambdex.default_lockfile_path}",
-            # Pytest
-            f"--pytest-version={PyTest.default_version}",
-            f"--pytest-extra-requirements={repr(PyTest.default_extra_requirements)}",
-            f"--pytest-lockfile={PyTest.default_lockfile_path}",
-            # Coverage.py
-            f"--coverage-py-version={CoverageSubsystem.default_version}",
-            f"--coverage-py-extra-requirements={repr(CoverageSubsystem.default_extra_requirements)}",
-            f"--coverage-py-interpreter-constraints={repr(CoverageSubsystem.default_interpreter_constraints)}",
-            f"--coverage-py-lockfile={CoverageSubsystem.default_lockfile_path}",
-            # HCL2 for Terraform dependency inference
-            "--backend-packages=+['pants.backend.experimental.terraform']",
-            f"--terraform-hcl2-parser-version={TerraformHcl2Parser.default_version}",
-            f"--terraform-hcl2-parser-extra-requirements={repr(TerraformHcl2Parser.default_extra_requirements)}",
-            f"--terraform-hcl2-parser-interpreter-constraints={repr(TerraformHcl2Parser.default_interpreter_constraints)}",
-            f"--terraform-hcl2-parser-lockfile={TerraformHcl2Parser.default_lockfile_path}",
-            # Dockerfile parser for Docker dependency inference
-            "--backend-packages=+['pants.backend.experimental.docker']",
-            f"--dockerfile-parser-version={DockerfileParser.default_version}",
-            f"--dockerfile-parser-extra-requirements={repr(DockerfileParser.default_extra_requirements)}",
-            f"--dockerfile-parser-interpreter-constraints={repr(DockerfileParser.default_interpreter_constraints)}",
-            f"--dockerfile-parser-lockfile={DockerfileParser.default_lockfile_path}",
-            # Twine.
-            f"--twine-version={TwineSubsystem.default_version}",
-            f"--twine-extra-requirements={repr(TwineSubsystem.default_extra_requirements)}",
-            f"--twine-interpreter-constraints={repr(TwineSubsystem.default_interpreter_constraints)}",
-            f"--twine-lockfile={TwineSubsystem.default_lockfile_path}",
-            # Run the goal.
+            *itertools.chain.from_iterable(tool.args for tool in AllTools),
             "generate-lockfiles",
         ],
         check=True,
     )
+
+
+def main() -> None:
+    update_internal_lockfiles()
+    update_default_lockfiles()
 
 
 if __name__ == "__main__":

--- a/build-support/bin/generate_all_lockfiles.sh
+++ b/build-support/bin/generate_all_lockfiles.sh
@@ -19,7 +19,7 @@ if is_macos_arm; then
   # Generate the lockfiles with the correct notated interpreter constraints, but make
   # Pants execute with a version of Python that actually runs on MacOS ARM
   unset PANTS_PYTHON_INTERPRETER_CONSTRAINTS
-  exec ./pants run build-support/bin/_generate_all_lockfiles_helper.py --python-interpreter-constraints="['==3.9.*']"
+  exec ./pants run build-support/bin/_generate_all_lockfiles_helper.py --python-interpreter-constraints="['==3.9.*']" -- "$@"
 else
-  exec ./pants run build-support/bin/_generate_all_lockfiles_helper.py
+  exec ./pants run build-support/bin/_generate_all_lockfiles_helper.py -- "$@"
 fi

--- a/pants.toml
+++ b/pants.toml
@@ -116,9 +116,16 @@ ignore_adding_targets = [
 venv_use_symlinks = true
 
 [python]
-experimental_lockfile = "3rdparty/python/lockfiles/user_reqs.txt"
 interpreter_constraints = [">=3.7,<3.10"]
 macos_big_sur_compatibility = true
+
+# To use resolves, switch which line is commented out.
+experimental_lockfile = "3rdparty/python/lockfiles/user_reqs.txt"
+#enable_resolves = true
+
+[python.experimental_resolves]
+python-default = "3rdparty/python/lockfiles/user_reqs.lock"
+python-testprojects = "testprojects/3rdparty/python/user_reqs.lock"
 
 [docformatter]
 args = ["--wrap-summaries=100", "--wrap-descriptions=100"]

--- a/pants.toml
+++ b/pants.toml
@@ -15,8 +15,6 @@ backend_packages.add = [
   "pants.backend.shell",
   "pants.backend.shell.lint.shellcheck",
   "pants.backend.shell.lint.shfmt",
-  "pants.backend.experimental.codegen.thrift.apache.python",
-  "pants.backend.experimental.codegen.thrift.apache.java",
   "pants.backend.experimental.docker",
   "pants.backend.experimental.docker.lint.hadolint",
   "pants.backend.experimental.go",
@@ -26,9 +24,6 @@ backend_packages.add = [
   "pants.backend.experimental.python",
   "pants.backend.experimental.scala",
   "pants.backend.experimental.scala.lint.scalafmt",
-  "pants.backend.experimental.codegen.avro.java",
-  "pants.backend.experimental.codegen.protobuf.scala",
-  "pants.backend.experimental.codegen.thrift.scrooge.scala",
   "pants.backend.experimental.scala.debug_goals",
   "internal_plugins.releases",
 ]
@@ -190,30 +185,6 @@ jvm_testprojects = "3rdparty/jvm/testprojects.lockfile"
 java_parser = "src/python/pants/backend/java/dependency_inference/java_parser.lockfile"
 # Has the same isolation requirements as `java_parser`.
 scala_parser = "src/python/pants/backend/scala/dependency_inference/scala_parser.lockfile"
-
-[java-avro]
-lockfile = "src/python/pants/backend/codegen/avro/java/avro-tools.default.lockfile.txt"
-
-[junit]
-lockfile = "src/python/pants/jvm/test/junit.default.lockfile.txt"
-
-[google-java-format]
-lockfile = "src/python/pants/backend/java/lint/google_java_format/google_java_format.default.lockfile.txt"
-
-[scalac]
-plugins_global_lockfile = "src/python/pants/backend/scala/subsystems/scalac_plugins.default.lockfile.txt"
-
-[scalafmt]
-lockfile = "src/python/pants/backend/scala/lint/scalafmt/scalafmt.default.lockfile.txt"
-
-[scalapb]
-lockfile = "src/python/pants/backend/codegen/protobuf/scala/scalapbc.default.lockfile.txt"
-
-[scalatest]
-lockfile = "src/python/pants/backend/scala/subsystems/scalatest.default.lockfile.txt"
-
-[scrooge]
-lockfile = "src/python/pants/backend/codegen/thrift/scrooge/scrooge.default.lockfile.txt"
 
 [toolchain-setup]
 repo = "pants"

--- a/src/python/pants/backend/codegen/avro/java/subsystem.py
+++ b/src/python/pants/backend/codegen/avro/java/subsystem.py
@@ -15,9 +15,10 @@ class AvroSubsystem(JvmToolBase):
         "pants.backend.codegen.avro.java",
         "avro-tools.default.lockfile.txt",
     )
-    default_lockfile_url = git_url(
+    default_lockfile_path = (
         "src/python/pants/backend/codegen/avro/java/avro-tools.default.lockfile.txt"
     )
+    default_lockfile_url = git_url(default_lockfile_path)
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/codegen/protobuf/scala/subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/subsystem.py
@@ -37,9 +37,10 @@ class ScalaPBSubsystem(JvmToolBase):
         "pants.backend.codegen.protobuf.scala",
         "scalapbc.default.lockfile.txt",
     )
-    default_lockfile_url = git_url(
+    default_lockfile_path = (
         "src/python/pants/backend/codegen/protobuf/scala/scalapbc.default.lockfile.txt"
     )
+    default_lockfile_url = git_url(default_lockfile_path)
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/codegen/thrift/scrooge/subsystem.py
+++ b/src/python/pants/backend/codegen/thrift/scrooge/subsystem.py
@@ -16,6 +16,7 @@ class ScroogeSubsystem(JvmToolBase):
         "pants.backend.codegen.thrift.scrooge",
         "scrooge.default.lockfile.txt",
     )
-    default_lockfile_url = git_url(
+    default_lockfile_path = (
         "src/python/pants/backend/codegen/thrift/scrooge/scrooge.default.lockfile.txt"
     )
+    default_lockfile_url = git_url(default_lockfile_path)

--- a/src/python/pants/backend/java/lint/google_java_format/subsystem.py
+++ b/src/python/pants/backend/java/lint/google_java_format/subsystem.py
@@ -16,9 +16,10 @@ class GoogleJavaFormatSubsystem(JvmToolBase):
         "pants.backend.java.lint.google_java_format",
         "google_java_format.default.lockfile.txt",
     )
-    default_lockfile_url = git_url(
+    default_lockfile_path = (
         "src/python/pants/backend/java/lint/google_java_format/google_java_format.default.lockfile.txt"
     )
+    default_lockfile_url = git_url(default_lockfile_path)
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/java/lint/google_java_format/subsystem.py
+++ b/src/python/pants/backend/java/lint/google_java_format/subsystem.py
@@ -16,9 +16,7 @@ class GoogleJavaFormatSubsystem(JvmToolBase):
         "pants.backend.java.lint.google_java_format",
         "google_java_format.default.lockfile.txt",
     )
-    default_lockfile_path = (
-        "src/python/pants/backend/java/lint/google_java_format/google_java_format.default.lockfile.txt"
-    )
+    default_lockfile_path = "src/python/pants/backend/java/lint/google_java_format/google_java_format.default.lockfile.txt"
     default_lockfile_url = git_url(default_lockfile_path)
 
     @classmethod

--- a/src/python/pants/backend/java/subsystems/junit.py
+++ b/src/python/pants/backend/java/subsystems/junit.py
@@ -17,7 +17,8 @@ class JUnit(JvmToolBase):
         "org.junit.vintage:junit-vintage-engine:{version}",
     )
     default_lockfile_resource = ("pants.jvm.test", "junit.default.lockfile.txt")
-    default_lockfile_url = git_url("src/python/pants/jvm/test/junit.default.lockfile.txt")
+    default_lockfile_path = "src/python/pants/jvm/test/junit.default.lockfile.txt"
+    default_lockfile_url = git_url(default_lockfile_path)
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/scala/subsystems/scalac.py
+++ b/src/python/pants/backend/scala/subsystems/scalac.py
@@ -14,6 +14,9 @@ class Scalac(Subsystem):
     options_scope = "scalac"
     help = "The Scala compiler."
 
+    default_plugins_lockfile_path = (
+        "src/python/pants/backend/scala/subsystems/scalac_plugins.default.lockfile.txt"
+    )
     default_plugins_lockfile_resource = (
         "pants.backend.scala.subsystems",
         "scalac_plugins.default.lockfile.txt",

--- a/src/python/pants/backend/scala/subsystems/scalatest.py
+++ b/src/python/pants/backend/scala/subsystems/scalatest.py
@@ -13,9 +13,10 @@ class Scalatest(JvmToolBase):
     default_version = "3.2.10"
     default_artifacts = ("org.scalatest:scalatest_2.13:{version}",)
     default_lockfile_resource = ("pants.backend.scala.subsystems", "scalatest.default.lockfile.txt")
-    default_lockfile_url = git_url(
+    default_lockfile_path = (
         "src/python/pants/backend/scala/subsystems/scalatest.default.lockfile.txt"
     )
+    default_lockfile_url = git_url(default_lockfile_path)
 
     @classmethod
     def register_options(cls, register):

--- a/testprojects/3rdparty/python/BUILD
+++ b/testprojects/3rdparty/python/BUILD
@@ -1,4 +1,21 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_requirements()
+# TODO(#14268): Once python_requirements passes down `tags` and `compatible_resolves`, we can DRY
+#  this again with that target generator.
+common_kwargs = dict(
+    experimental_compatible_resolves=["python-testprojects"],
+    tags=["lockfile_ignore"],
+)
+
+python_requirement(
+    name="checksumdir",
+    requirements=["checksumdir==1.1.7"],
+    **common_kwargs,
+)
+
+python_requirement(
+    name="numpy",
+    requirements=["numpy==1.14.5"],
+    **common_kwargs,
+)

--- a/testprojects/3rdparty/python/requirements.txt
+++ b/testprojects/3rdparty/python/requirements.txt
@@ -1,2 +1,0 @@
-checksumdir==1.1.7
-numpy==1.14.5


### PR DESCRIPTION
This makes the script more readable + useful:

* Code is DRYed
* JVM tools are now included
* You now specify what you want to generate, `--internal`, `--tool black bandit`, or `--all`

```
❯ build-support/bin/generate_all_lockfiles.sh                    
usage: generate_all_lockfiles.sh  [-h] [--internal] [--tool [TOOL ...]] [--all]

Generate lockfiles for internal usage + default tool lockfiles that we distribute. This script makes sure
that tool lockfiles are generated with the correct values.

optional arguments:
  -h, --help         show this help message and exit
  --internal         Regenerate all internal lockfiles.
  --tool [TOOL ...]  Regenerate these default tool lockfile(s). Valid options: ['autoflake', 'bandit',
                     'black', 'coverage-py', 'docformatter', 'dockerfile-parser', 'flake8', 'google-java-
                     format', 'ipython', 'isort', 'java-avro', 'junit', 'lambdex', 'mypy', 'mypy-
                     protobuf', 'pylint', 'pytest', 'pyupgrade', 'scalac-plugins', 'scalafmt', 'scalapb',
                     'scalatest', 'scrooge', 'setuptools', 'terraform-hcl2-parser', 'twine', 'yapf']
  --all              Regenerate all internal and default tool lockfiles.

```

That last change is because we've found most PRs to regenerate lockfiles for, say, a PEX upgrade, end up changing unrelated things.