### PR TITLE
[internal] `python_requirement` target generators pass down some fields to generated targets

### DIFF
--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -237,7 +237,7 @@ async def setup_user_lockfile_requests(
 
     resolve_to_requirements_fields = defaultdict(set)
     for tgt in all_targets:
-        if not tgt.has_field(PythonRequirementCompatibleResolvesField):
+        if not tgt.has_fields((PythonRequirementCompatibleResolvesField, PythonRequirementsField)):
             continue
         tgt[PythonRequirementCompatibleResolvesField].validate(python_setup)
         for resolve in tgt[PythonRequirementCompatibleResolvesField].value_or_default(python_setup):

--- a/src/python/pants/backend/python/macros/pipenv_requirements.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements.py
@@ -13,7 +13,9 @@ from pants.backend.python.macros.common_fields import (
     TypeStubsModuleMappingField,
 )
 from pants.backend.python.pip_requirement import PipRequirement
+from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (
+    PythonRequirementCompatibleResolvesField,
     PythonRequirementModulesField,
     PythonRequirementsField,
     PythonRequirementsFileSourcesField,
@@ -53,6 +55,7 @@ class PipenvPipfileTargetField(StringField):
 class PipenvRequirementsTargetGenerator(Target):
     alias = "pipenv_requirements"
     help = "Generate a `python_requirement` for each entry in `Pipenv.lock`."
+    # Note that this does not have a `dependencies` field.
     core_fields = (
         *COMMON_TARGET_FIELDS,
         ModuleMappingField,
@@ -60,6 +63,7 @@ class PipenvRequirementsTargetGenerator(Target):
         PipenvSourceField,
         PipenvPipfileTargetField,
         RequirementsOverrideField,
+        PythonRequirementCompatibleResolvesField,
     )
 
 
@@ -71,7 +75,7 @@ class GenerateFromPipenvRequirementsRequest(GenerateTargetsRequest):
 # TODO(#10655): differentiate between Pipfile vs. Pipfile.lock.
 @rule(desc="Generate `python_requirement` targets from Pipfile.lock", level=LogLevel.DEBUG)
 async def generate_from_pipenv_requirement(
-    request: GenerateFromPipenvRequirementsRequest,
+    request: GenerateFromPipenvRequirementsRequest, python_setup: PythonSetup
 ) -> GeneratedTargets:
     generator = request.generator
     lock_rel_path = generator[PipenvSourceField].value
@@ -96,9 +100,16 @@ async def generate_from_pipenv_requirement(
     )
     lock_info = json.loads(digest_contents[0].content)
 
+    generator[PythonRequirementCompatibleResolvesField].validate(python_setup)
+
     module_mapping = generator[ModuleMappingField].value
     stubs_mapping = generator[TypeStubsModuleMappingField].value
     overrides = generator[RequirementsOverrideField].flatten_and_normalize()
+    inherited_fields = {
+        field.alias: field.value
+        for field in request.generator.field_values.values()
+        if isinstance(field, (*COMMON_TARGET_FIELDS, PythonRequirementCompatibleResolvesField))
+    }
 
     def generate_tgt(raw_req: str, info: dict) -> PythonRequirementTarget:
         if info.get("extras"):
@@ -115,10 +126,9 @@ async def generate_from_pipenv_requirement(
                 file_tgt.address.spec
             ]
 
-        # TODO: Consider letting you set metadata in the target generator and having it pass down
-        #  to all generated targets. Especially useful for compatible_resolves.
         return PythonRequirementTarget(
             {
+                **inherited_fields,
                 PythonRequirementsField.alias: [parsed_req],
                 PythonRequirementModulesField.alias: module_mapping.get(normalized_proj_name),
                 PythonRequirementTypeStubModulesField.alias: stubs_mapping.get(

--- a/src/python/pants/backend/python/macros/poetry_requirements.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements.py
@@ -21,7 +21,9 @@ from pants.backend.python.macros.common_fields import (
     TypeStubsModuleMappingField,
 )
 from pants.backend.python.pip_requirement import PipRequirement
+from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (
+    PythonRequirementCompatibleResolvesField,
     PythonRequirementModulesField,
     PythonRequirementsField,
     PythonRequirementsFileSourcesField,
@@ -397,12 +399,14 @@ class PoetryRequirementsSourceField(SingleSourceField):
 class PoetryRequirementsTargetGenerator(Target):
     alias = "poetry_requirements"
     help = "Generate a `python_requirement` for each entry in a Poetry pyproject.toml."
+    # Note that this does not have a `dependencies` field.
     core_fields = (
         *COMMON_TARGET_FIELDS,
         ModuleMappingField,
         TypeStubsModuleMappingField,
         PoetryRequirementsSourceField,
         RequirementsOverrideField,
+        PythonRequirementCompatibleResolvesField,
     )
 
 
@@ -412,7 +416,7 @@ class GenerateFromPoetryRequirementsRequest(GenerateTargetsRequest):
 
 @rule(desc="Generate `python_requirement` targets from Poetry pyproject.toml", level=LogLevel.DEBUG)
 async def generate_from_python_requirement(
-    request: GenerateFromPoetryRequirementsRequest, build_root: BuildRoot
+    request: GenerateFromPoetryRequirementsRequest, build_root: BuildRoot, python_setup: PythonSetup
 ) -> GeneratedTargets:
     generator = request.generator
     pyproject_rel_path = generator[PoetryRequirementsSourceField].value
@@ -444,9 +448,16 @@ async def generate_from_python_requirement(
         )
     )
 
+    generator[PythonRequirementCompatibleResolvesField].validate(python_setup)
+
     module_mapping = generator[ModuleMappingField].value
     stubs_mapping = generator[TypeStubsModuleMappingField].value
     overrides = generator[RequirementsOverrideField].flatten_and_normalize()
+    inherited_fields = {
+        field.alias: field.value
+        for field in request.generator.field_values.values()
+        if isinstance(field, (*COMMON_TARGET_FIELDS, PythonRequirementCompatibleResolvesField))
+    }
 
     def generate_tgt(parsed_req: PipRequirement) -> PythonRequirementTarget:
         normalized_proj_name = canonicalize_project_name(parsed_req.project_name)
@@ -456,10 +467,9 @@ async def generate_from_python_requirement(
                 file_tgt.address.spec
             ]
 
-        # TODO: Consider letting you set metadata in the target generator and having it pass down
-        #  to all generated targets. Especially useful for compatible_resolves.
         return PythonRequirementTarget(
             {
+                **inherited_fields,
                 PythonRequirementsField.alias: [parsed_req],
                 PythonRequirementModulesField.alias: module_mapping.get(normalized_proj_name),
                 PythonRequirementTypeStubModulesField.alias: stubs_mapping.get(

--- a/testprojects/3rdparty/python/BUILD
+++ b/testprojects/3rdparty/python/BUILD
@@ -1,21 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-# TODO(#14268): Once python_requirements passes down `tags` and `compatible_resolves`, we can DRY
-#  this again with that target generator.
-common_kwargs = dict(
+python_requirements(
     experimental_compatible_resolves=["python-testprojects"],
     tags=["lockfile_ignore"],
-)
-
-python_requirement(
-    name="checksumdir",
-    requirements=["checksumdir==1.1.7"],
-    **common_kwargs,
-)
-
-python_requirement(
-    name="numpy",
-    requirements=["numpy==1.14.5"],
-    **common_kwargs,
 )

--- a/testprojects/3rdparty/python/requirements.txt
+++ b/testprojects/3rdparty/python/requirements.txt
@@ -1,0 +1,2 @@
+checksumdir==1.1.7
+numpy==1.14.5


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/14268.

Now it's ergonomic to set `tags`, `description`, and `compatible_resolves` on all generated targets. As before, you can also use `overrides` for per-target settings. With `compatible_resolves`, you can also leave it off and use `[python].default_resolve`.

This does mean that it's impossible to have `tags` and `description` _just_ on the target generator and not generated targets. But that is already the case with `python_sources -> python_source` etc. So this makes things consistent, at least.

[ci skip-rust]