### PR TITLE
[internal] Revert "use nailgun for jvm tests"

### DIFF
--- a/src/python/pants/backend/scala/test/scalatest.py
+++ b/src/python/pants/backend/scala/test/scalatest.py
@@ -108,11 +108,11 @@ async def setup_scalatest_for_target(
         ],
         input_digest=merged_classpath_digest,
         extra_immutable_input_digests=extra_immutable_input_digests,
-        extra_nailgun_keys=extra_immutable_input_digests,
         output_directories=(reports_dir,),
         description=f"Run Scalatest runner for {request.field_set.address}",
         level=LogLevel.DEBUG,
         cache_scope=cache_scope,
+        use_nailgun=False,
     )
     return TestSetup(process=process, reports_dir_prefix=reports_dir_prefix)
 

--- a/src/python/pants/jvm/test/junit.py
+++ b/src/python/pants/jvm/test/junit.py
@@ -105,11 +105,11 @@ async def setup_junit_for_target(
         ],
         input_digest=merged_classpath_digest,
         extra_immutable_input_digests=extra_immutable_input_digests,
-        extra_nailgun_keys=extra_immutable_input_digests,
         output_directories=(reports_dir,),
         description=f"Run JUnit 5 ConsoleLauncher against {request.field_set.address}",
         level=LogLevel.DEBUG,
         cache_scope=cache_scope,
+        use_nailgun=False,
     )
     return TestSetup(process=process, reports_dir_prefix=reports_dir_prefix)
 


### PR DESCRIPTION
This reverts commit cda0b74f76539be48f1e28d6e5d0616e74fbb746, fixing invalidation in scalatest (and maybe junit) by disabling nailgun. See #13871 for details.