### PR TITLE
[internal] Hook up `[python-repos]` and `manylinux` to Pex lockfile generation

### DIFF
--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -148,6 +148,7 @@ async def generate_lockfile(
                 subcommand=("lock", "create"),
                 extra_args=(
                     "--output=lock.json",
+                    "--no-emit-warnings",
                     # See https://github.com/pantsbuild/pants/issues/12458. For now, we always
                     # generate universal locks because they have the best compatibility. We may
                     # want to let users change this, as `style=strict` is safer.

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -106,8 +106,14 @@ class MaybeWarnPythonRepos:
     pass
 
 
+class MaybeWarnPythonReposRequest:
+    pass
+
+
 @rule
-def maybe_warn_python_repos(python_repos: PythonRepos) -> MaybeWarnPythonRepos:
+def maybe_warn_python_repos(
+    _: MaybeWarnPythonReposRequest, python_repos: PythonRepos
+) -> MaybeWarnPythonRepos:
     def warn_python_repos(option: str) -> None:
         logger.warning(
             f"The option `[python-repos].{option}` is configured, but it does not currently work "
@@ -132,14 +138,14 @@ async def generate_lockfile(
     req: GeneratePythonLockfile,
     poetry_subsystem: PoetrySubsystem,
     generate_lockfiles_subsystem: GenerateLockfilesSubsystem,
-    _: MaybeWarnPythonRepos,
+    python_repos: PythonRepos,
+    python_setup: PythonSetup,
 ) -> GenerateLockfileResult:
     if req.use_pex:
         result = await Get(
             ProcessResult,
             PexCliProcess(
                 subcommand=("lock", "create"),
-                # TODO: Hook up to [python-repos]. Don't call `MaybeWarnPythonRepos` in this case.
                 extra_args=(
                     "--output=lock.json",
                     # See https://github.com/pantsbuild/pants/issues/12458. For now, we always
@@ -148,6 +154,8 @@ async def generate_lockfile(
                     "--style=universal",
                     "--resolver-version",
                     "pip-2020-resolver",
+                    *python_repos.pex_args,
+                    *python_setup.manylinux_pex_args,
                     *req.interpreter_constraints.generate_pex_arg_list(),
                     *req.requirements,
                 ),
@@ -167,6 +175,7 @@ async def generate_lockfile(
             ),
         )
     else:
+        await Get(MaybeWarnPythonRepos, MaybeWarnPythonReposRequest())
         _pyproject_toml = create_pyproject_toml(
             req.requirements, req.interpreter_constraints
         ).encode()

--- a/src/python/pants/backend/python/subsystems/repos.py
+++ b/src/python/pants/backend/python/subsystems/repos.py
@@ -1,7 +1,9 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import List, cast
+from __future__ import annotations
+
+from typing import Iterator, cast
 
 from pants.option.subsystem import Subsystem
 
@@ -41,9 +43,19 @@ class PythonRepos(Subsystem):
         )
 
     @property
-    def repos(self) -> List[str]:
-        return cast(List[str], self.options.repos)
+    def repos(self) -> list[str]:
+        return cast("list[str]", self.options.repos)
 
     @property
-    def indexes(self) -> List[str]:
-        return cast(List[str], self.options.indexes)
+    def indexes(self) -> list[str]:
+        return cast("list[str]", self.options.indexes)
+
+    @property
+    def pex_args(self) -> Iterator[str]:
+        # NB: In setting `--no-pypi`, we rely on the default value of `--python-repos-indexes`
+        # including PyPI, which will override `--no-pypi` and result in using PyPI in the default
+        # case. Why set `--no-pypi`, then? We need to do this so that
+        # `--python-repos-repos=['custom_url']` will only point to that index and not include PyPI.
+        yield "--no-pypi"
+        yield from (f"--index={index}" for index in self.indexes)
+        yield from (f"--repo={repo}" for repo in self.repos)

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import enum
 import logging
 import os
-from typing import Iterable, Optional, cast
+from typing import Iterable, Iterator, Optional, cast
 
 from pants.option.custom_types import file_option
 from pants.option.subsystem import Subsystem
@@ -338,6 +338,14 @@ class PythonSetup(Subsystem):
         if manylinux is None or manylinux.lower() in ("false", "no", "none"):
             return None
         return manylinux
+
+    @property
+    def manylinux_pex_args(self) -> Iterator[str]:
+        if self.manylinux:
+            yield "--manylinux"
+            yield self.manylinux
+        else:
+            yield "--no-manylinux"
 
     @property
     def resolver_jobs(self) -> int:


### PR DESCRIPTION
[ci skip-rust]
