### PR TITLE
pymongo can be imported

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -81,7 +81,7 @@ DEFAULT_MODULE_MAPPING = {
     "python-jose": ("jose",),
     "python-pptx": ("pptx",),
     "pyyaml": ("yaml",),
-    "pymongo": ("bson", "gridfs"),
+    "pymongo": ("bson", "gridfs", "pymongo"),
     "pymupdf": ("fitz",),
     "pytest-runner": ("ptr",),
     "scikit-image": ("skimage",),


### PR DESCRIPTION
See https://pantsbuild.slack.com/archives/C046T6T9U/p1643311795359369

TL;DR `import pymongo` wouldn't add `pymongo` as a dependency :disappointed: 