### PR TITLE
[internal] Pretty-print lockfiles generated by PEX

### DIFF
--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -155,6 +155,8 @@ async def generate_lockfile(
                     "--style=universal",
                     "--resolver-version",
                     "pip-2020-resolver",
+                    # This makes diffs more readable when lockfiles change.
+                    "--indent=2",
                     *python_repos.pex_args,
                     *python_setup.manylinux_pex_args,
                     *req.interpreter_constraints.generate_pex_arg_list(),


### PR DESCRIPTION
This causes each key to be printed on a new line, which is much more readable.

2 spaces is arbitrary - there's lots of nesting for each artifact in the resolve, and 2 spaces rather than 4 results in much less horizontal scrolling. I doubt we should ever expose this option to users - options fatigue.

[ci skip-rust]
[ci skip-build-wheels]