### PR TITLE
[internal] Refactor how call sites interact with Python resolves

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -222,8 +222,7 @@ async def map_third_party_modules_to_addresses(
     ] = {}
 
     for tgt in all_python_tgts.third_party:
-        tgt[PythonRequirementCompatibleResolvesField].validate(python_setup)
-        resolves = tgt[PythonRequirementCompatibleResolvesField].value_or_default(python_setup)
+        resolves = tgt[PythonRequirementCompatibleResolvesField].normalized_value(python_setup)
 
         def add_modules(modules: Iterable[str], *, type_stub: bool = False) -> None:
             for resolve in resolves:

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -193,11 +193,11 @@ async def infer_python_dependencies_via_imports(
         ),
     )
 
-    resolve = None
-    if tgt.has_field(PythonResolveField):
-        resolve_field = tgt[PythonResolveField]
-        resolve_field.validate(python_setup)
-        resolve = resolve_field.value_or_default(python_setup)
+    resolve = (
+        tgt[PythonResolveField].normalized_value(python_setup)
+        if tgt.has_field(PythonResolveField)
+        else None
+    )
 
     owners_per_import = await MultiGet(
         Get(PythonModuleOwners, PythonModuleOwnersRequest(imported_module, resolve=resolve))

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -274,8 +274,7 @@ async def setup_user_lockfile_requests(
     for tgt in all_targets:
         if not tgt.has_fields((PythonRequirementCompatibleResolvesField, PythonRequirementsField)):
             continue
-        tgt[PythonRequirementCompatibleResolvesField].validate(python_setup)
-        for resolve in tgt[PythonRequirementCompatibleResolvesField].value_or_default(python_setup):
+        for resolve in tgt[PythonRequirementCompatibleResolvesField].normalized_value(python_setup):
             resolve_to_requirements_fields[resolve].add(tgt[PythonRequirementsField])
 
     return UserGenerateLockfiles(

--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -5,7 +5,6 @@ import logging
 from dataclasses import dataclass
 from typing import Tuple
 
-from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (
     PexBinaryDefaults,
     PexEmitWarningsField,
@@ -25,7 +24,6 @@ from pants.backend.python.target_types import (
     PexScriptField,
     PexShebangField,
     PexStripEnvField,
-    PythonResolveField,
     ResolvedPexEntryPoint,
     ResolvePexEntryPointRequest,
 )
@@ -71,7 +69,6 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
     execution_mode: PexExecutionModeField
     include_requirements: PexIncludeRequirementsField
     include_tools: PexIncludeToolsField
-    resolve: PythonResolveField
 
     @property
     def _execution_mode(self) -> PexExecutionMode:
@@ -102,7 +99,6 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
 async def package_pex_binary(
     field_set: PexBinaryFieldSet,
     pex_binary_defaults: PexBinaryDefaults,
-    python_setup: PythonSetup,
     union_membership: UnionMembership,
 ) -> BuiltPackage:
     resolved_entry_point, transitive_targets = await MultiGet(
@@ -136,7 +132,6 @@ async def package_pex_binary(
             internal_only=False,
             main=resolved_entry_point.val or field_set.script.value,
             platforms=PexPlatforms.create_from_platforms_field(field_set.platforms),
-            resolve_and_lockfile=field_set.resolve.resolve_and_lockfile(python_setup),
             output_filename=output_filename,
             layout=PexLayout(field_set.layout.value),
             additional_args=field_set.generate_additional_args(pex_binary_defaults),

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -169,12 +169,7 @@ async def setup_pytest_for_target(
     interpreter_constraints = InterpreterConstraints.create_from_targets(all_targets, python_setup)
 
     requirements_pex_get = Get(
-        Pex,
-        RequirementsPexRequest(
-            [request.field_set.address],
-            internal_only=True,
-            resolve_and_lockfile=request.field_set.resolve.resolve_and_lockfile(python_setup),
-        ),
+        Pex, RequirementsPexRequest([request.field_set.address], internal_only=True)
     )
     pytest_pex_get = Get(
         Pex,

--- a/src/python/pants/backend/python/goals/run_pex_binary.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary.py
@@ -4,7 +4,6 @@
 import os
 
 from pants.backend.python.goals.package_pex_binary import PexBinaryFieldSet
-from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (
     PexBinaryDefaults,
     ResolvedPexEntryPoint,
@@ -32,10 +31,7 @@ from pants.util.logging import LogLevel
 
 @rule(level=LogLevel.DEBUG)
 async def create_pex_binary_run_request(
-    field_set: PexBinaryFieldSet,
-    pex_binary_defaults: PexBinaryDefaults,
-    pex_env: PexEnvironment,
-    python_setup: PythonSetup,
+    field_set: PexBinaryFieldSet, pex_binary_defaults: PexBinaryDefaults, pex_env: PexEnvironment
 ) -> RunRequest:
     entry_point, transitive_targets = await MultiGet(
         Get(
@@ -65,7 +61,6 @@ async def create_pex_binary_run_request(
             # Note that the file for first-party entry points is not in the PEX itself. In that
             # case, it's loaded by setting `PEX_EXTRA_SYS_PATH`.
             main=entry_point.val or field_set.script.value,
-            resolve_and_lockfile=field_set.resolve.resolve_and_lockfile(python_setup),
             additional_args=(
                 *field_set.generate_additional_args(pex_binary_defaults),
                 # N.B.: Since we cobble together the runtime environment via PEX_EXTRA_SYS_PATH

--- a/src/python/pants/backend/python/macros/pipenv_requirements.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements.py
@@ -100,7 +100,7 @@ async def generate_from_pipenv_requirement(
     )
     lock_info = json.loads(digest_contents[0].content)
 
-    generator[PythonRequirementCompatibleResolvesField].validate(python_setup)
+    generator[PythonRequirementCompatibleResolvesField].normalized_value(python_setup)
 
     module_mapping = generator[ModuleMappingField].value
     stubs_mapping = generator[TypeStubsModuleMappingField].value

--- a/src/python/pants/backend/python/macros/poetry_requirements.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements.py
@@ -448,7 +448,7 @@ async def generate_from_python_requirement(
         )
     )
 
-    generator[PythonRequirementCompatibleResolvesField].validate(python_setup)
+    generator[PythonRequirementCompatibleResolvesField].normalized_value(python_setup)
 
     module_mapping = generator[ModuleMappingField].value
     stubs_mapping = generator[TypeStubsModuleMappingField].value

--- a/src/python/pants/backend/python/macros/python_requirements.py
+++ b/src/python/pants/backend/python/macros/python_requirements.py
@@ -103,7 +103,7 @@ async def generate_from_python_requirement(
         requirements, lambda parsed_req: parsed_req.project_name
     )
 
-    generator[PythonRequirementCompatibleResolvesField].validate(python_setup)
+    generator[PythonRequirementCompatibleResolvesField].normalized_value(python_setup)
 
     module_mapping = generator[ModuleMappingField].value
     stubs_mapping = generator[TypeStubsModuleMappingField].value

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -17,7 +17,6 @@ from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (
     ConsoleScript,
-    PythonResolveField,
     PythonTestsExtraEnvVarsField,
     PythonTestSourceField,
     PythonTestsTimeoutField,
@@ -51,7 +50,6 @@ class PythonTestFieldSet(TestFieldSet):
     timeout: PythonTestsTimeoutField
     runtime_package_dependencies: RuntimePackageDependenciesField
     extra_env_vars: PythonTestsExtraEnvVarsField
-    resolve: PythonResolveField
 
     @classmethod
     def opt_out(cls, tgt: Target) -> bool:

--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -319,12 +319,11 @@ async def inject_pex_binary_entry_point_dependency(
     if entry_point.val is None:
         return InjectedDependencies()
 
-    resolve_field = original_tgt.target[PythonResolveField]
-    resolve_field.validate(python_setup)
     owners = await Get(
         PythonModuleOwners,
         PythonModuleOwnersRequest(
-            entry_point.val.module, resolve=resolve_field.value_or_default(python_setup)
+            entry_point.val.module,
+            resolve=original_tgt.target[PythonResolveField].normalized_value(python_setup),
         ),
     )
     address = original_tgt.target.address

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -75,7 +75,6 @@ class PexFromTargetsRequest:
     include_local_dists: bool
     additional_sources: Digest | None
     additional_inputs: Digest | None
-    resolve_and_lockfile: tuple[str, str] | None
     hardcoded_interpreter_constraints: InterpreterConstraints | None
     direct_deps_only: bool
     # This field doesn't participate in comparison (and therefore hashing), as it doesn't affect
@@ -100,7 +99,6 @@ class PexFromTargetsRequest:
         additional_sources: Digest | None = None,
         additional_inputs: Digest | None = None,
         hardcoded_interpreter_constraints: InterpreterConstraints | None = None,
-        resolve_and_lockfile: tuple[str, str] | None = None,
         direct_deps_only: bool = False,
         description: str | None = None,
     ) -> None:
@@ -138,7 +136,6 @@ class PexFromTargetsRequest:
             directly in the Pex, but should be present in the environment when building the Pex.
         :param hardcoded_interpreter_constraints: Use these constraints rather than resolving the
             constraints from the input.
-        :param resolve_and_lockfile: if set, use this "named resolve" and lockfile.
         :param direct_deps_only: Only consider the input addresses and their direct dependencies,
             rather than the transitive closure.
         :param description: A human-readable description to render in the dynamic UI when building
@@ -159,7 +156,6 @@ class PexFromTargetsRequest:
         self.additional_sources = additional_sources
         self.additional_inputs = additional_inputs
         self.hardcoded_interpreter_constraints = hardcoded_interpreter_constraints
-        self.resolve_and_lockfile = resolve_and_lockfile
         self.direct_deps_only = direct_deps_only
         self.description = description
 
@@ -285,7 +281,6 @@ class _RepositoryPexRequest:
     direct_deps_only: bool
     platforms: PexPlatforms
     internal_only: bool
-    resolve_and_lockfile: tuple[str, str] | None
     additional_lockfile_args: tuple[str, ...]
     additional_requirements: tuple[str, ...]
 
@@ -297,7 +292,6 @@ class _RepositoryPexRequest:
         hardcoded_interpreter_constraints: InterpreterConstraints | None = None,
         direct_deps_only: bool = False,
         platforms: PexPlatforms = PexPlatforms(),
-        resolve_and_lockfile: tuple[str, str] | None = None,
         additional_lockfile_args: tuple[str, ...] = (),
         additional_requirements: tuple[str, ...] = (),
     ) -> None:
@@ -306,7 +300,6 @@ class _RepositoryPexRequest:
         self.hardcoded_interpreter_constraints = hardcoded_interpreter_constraints
         self.direct_deps_only = direct_deps_only
         self.platforms = platforms
-        self.resolve_and_lockfile = resolve_and_lockfile
         self.additional_lockfile_args = additional_lockfile_args
         self.additional_requirements = additional_requirements
 
@@ -405,7 +398,6 @@ async def pex_from_targets(
                 direct_deps_only=request.direct_deps_only,
                 platforms=request.platforms,
                 internal_only=request.internal_only,
-                resolve_and_lockfile=request.resolve_and_lockfile,
                 additional_lockfile_args=request.additional_lockfile_args,
                 additional_requirements=request.additional_requirements,
             ),
@@ -453,8 +445,11 @@ async def get_repository_pex(
             "`[python].resolve_all_constraints` is enabled, so "
             "`[python].requirement_constraints` must also be set."
         )
-    elif request.resolve_and_lockfile:
-        resolve, lockfile = request.resolve_and_lockfile
+    elif python_setup.enable_resolves:
+        # TODO: compute the resolve based on request.addresses, and validate that the
+        #  transitive closure is compatible. See coursier_fetch.py for inspiration.
+        resolve = python_setup.default_resolve
+        lockfile = python_setup.resolves[resolve]
         repository_pex_request = PexRequest(
             description=f"Installing {lockfile} for the resolve `{resolve}`",
             output_filename=f"{path_safe(resolve)}_lockfile.pex",
@@ -480,8 +475,6 @@ async def get_repository_pex(
             requirements=Lockfile(
                 file_path=python_setup.lockfile,
                 file_path_description_of_origin="the option `[python].experimental_lockfile`",
-                # TODO(#12314): Hook up lockfile staleness check once multiple lockfiles
-                # are supported.
                 lockfile_hex_digest=None,
                 req_strings=None,
             ),
@@ -591,7 +584,6 @@ class RequirementsPexRequest:
     internal_only: bool
     hardcoded_interpreter_constraints: InterpreterConstraints | None
     direct_deps_only: bool
-    resolve_and_lockfile: tuple[str, str] | None
 
     def __init__(
         self,
@@ -600,13 +592,11 @@ class RequirementsPexRequest:
         internal_only: bool,
         hardcoded_interpreter_constraints: InterpreterConstraints | None = None,
         direct_deps_only: bool = False,
-        resolve_and_lockfile: tuple[str, str] | None = None,
     ) -> None:
         self.addresses = Addresses(addresses)
         self.internal_only = internal_only
         self.hardcoded_interpreter_constraints = hardcoded_interpreter_constraints
         self.direct_deps_only = direct_deps_only
-        self.resolve_and_lockfile = resolve_and_lockfile
 
 
 @rule
@@ -619,7 +609,6 @@ async def get_requirements_pex(request: RequirementsPexRequest, setup: PythonSet
                 internal_only=request.internal_only,
                 hardcoded_interpreter_constraints=request.hardcoded_interpreter_constraints,
                 direct_deps_only=request.direct_deps_only,
-                resolve_and_lockfile=request.resolve_and_lockfile,
             ),
         )
         if opt_pex_request.maybe_pex_request is None:
@@ -639,7 +628,6 @@ async def get_requirements_pex(request: RequirementsPexRequest, setup: PythonSet
             include_source_files=False,
             hardcoded_interpreter_constraints=request.hardcoded_interpreter_constraints,
             direct_deps_only=request.direct_deps_only,
-            resolve_and_lockfile=request.resolve_and_lockfile,
         ),
     )
     return pex_request


### PR DESCRIPTION
The first change bundles `ResolveField.validate()` and `.value_or_default()`, which makes call sites much less clunky. 

Note that this contrasts with JVM where we use `JvmSubsystem.resolves_for_target()` - I stuck with `Field`-based methods because it gives us better MyPy typing between `ResolveField` vs `CompatibleResolveFields`.

--

The second change prepares for how we will calculate the resolve to use. Before, we had call sites like `pytest_runner.py` setting the resolve. Instead, `pex_from_targets.py` should choose the resolve based on the direct _input_ addresses to the request. Then it validates that the transitive closure is correct. This implies:

* `test`, `package`, and `run` are chosen by simply inspecting the single `python_test `or `pex_binary` target, but validating all deps
* The onus is on MyPy and Pylint to partition so that the input targets to `PexFromTargets` are all compatible
* For `repl`, we can't do any partitioning, only validation

For now, we simply use the default resolve. A followup will implement this algorithm, similar to our JVM code in `coursier_fetch.py`. 

Note that this means `--enable-resolves` now gives you roughly the same behavior as `[python].experimental_lockfile`! That is, for now, we only support a single resolve, whatever is set by `[python].default_resolve`. This means that we can remove `[python].experimental_lockfile` and `generate-user-lockfile` to simplify this code.