### PR TITLE
Add some missing backends to generated docs (Cherry-pick of #14290)

### DIFF
--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -199,25 +199,41 @@ def create_parser() -> argparse.ArgumentParser:
 
 
 def run_pants_help_all() -> dict[str, Any]:
-    deactivated_backends = [
-        "internal_plugins.releases",
-        "pants.backend.experimental.java.debug_goals",
-        "pants.backend.experimental.scala.debug_goals",
-    ]
-    activated_backends = [
-        "pants.backend.codegen.protobuf.python",
+    # List all (stable enough) backends here.
+    backends = [
         "pants.backend.awslambda.python",
+        "pants.backend.codegen.protobuf.python",
+        "pants.backend.experimental.docker",
+        "pants.backend.experimental.docker.lint.hadolint",
+        "pants.backend.experimental.go",
+        "pants.backend.experimental.java",
+        "pants.backend.experimental.java.lint.google_java_format",
+        "pants.backend.experimental.python",
+        "pants.backend.experimental.python.lint.autoflake",
+        "pants.backend.experimental.python.lint.pyupgrade",
+        "pants.backend.experimental.scala",
+        "pants.backend.experimental.scala.lint.scalafmt",
+        "pants.backend.google_cloud_function.python",
+        "pants.backend.plugin_development",
+        "pants.backend.python",
         "pants.backend.python.lint.bandit",
+        "pants.backend.python.lint.black",
+        "pants.backend.python.lint.docformatter",
+        "pants.backend.python.lint.flake8",
+        "pants.backend.python.lint.isort",
         "pants.backend.python.lint.pylint",
         "pants.backend.python.lint.yapf",
+        "pants.backend.python.mixed_interpreter_constraints",
+        "pants.backend.python.typecheck.mypy",
+        "pants.backend.shell",
+        "pants.backend.shell.lint.shellcheck",
+        "pants.backend.shell.lint.shfmt",
     ]
-    deactivated_plugins = ["toolchain.pants.plugin==0.17.0"]
     argv = [
         "./pants",
         "--concurrent",
-        f"--plugins=-[{', '.join(map(repr, deactivated_plugins))}]",
-        f"--backend-packages=-[{', '.join(map(repr, deactivated_backends))}]",
-        f"--backend-packages=+[{', '.join(map(repr, activated_backends))}]",
+        "--plugins=[]",
+        f"--backend-packages={repr(backends)}",
         "--no-verify-config",
         "--remote-auth-plugin= ",
         "help-all",

--- a/pants.toml
+++ b/pants.toml
@@ -30,7 +30,6 @@ backend_packages.add = [
 ]
 plugins = [
   "hdrhistogram",  # For use with `--stats-log`.
-  # NOTE: Keep this version in sync with `generate_docs.py`!
   "toolchain.pants.plugin==0.17.0",
 ]
 

--- a/src/python/pants/init/BUILD
+++ b/src/python/pants/init/BUILD
@@ -3,6 +3,7 @@
 
 python_sources(dependencies=[":plugins"])
 
+# NOTE: When adding a new backend, add it `generate_docs.py` too! (If stable enough for docs)
 target(
     name="plugins",
     dependencies=[


### PR DESCRIPTION
I discovered we're missing some backends like `google_cloud_function.python`.

Our current approach of matching all backends available (`init/BUILD`) against what we activate internally (`pants.toml`) against `generate_docs.py` has proven too error-prone. So, I'm simplifying by ignoring what we have internally and simply listing in `generate_docs.py` everything that is publishable.

[ci skip-rust]