### PR TITLE
Fix plugin resolution running twice

### DIFF
--- a/tests/python/pants_test/init/test_plugin_resolver.py
+++ b/tests/python/pants_test/init/test_plugin_resolver.py
@@ -185,17 +185,17 @@ def plugin_resolution(
             {**{k: os.environ[k] for k in ["PATH", "HOME", "PYENV_ROOT"] if k in os.environ}, **env}
         )
         bootstrap_scheduler = create_bootstrap_scheduler(options_bootstrapper)
-        plugin_resolver = PluginResolver(bootstrap_scheduler)
         cache_dir = options_bootstrapper.bootstrap_options.for_global_scope().named_caches_dir
 
         input_working_set = WorkingSet(entries=[])
         for dist in working_set_entries:
             input_working_set.add(dist)
+        plugin_resolver = PluginResolver(
+            bootstrap_scheduler, interpreter_constraints, input_working_set
+        )
         working_set = plugin_resolver.resolve(
             options_bootstrapper,
             complete_env,
-            interpreter_constraints,
-            input_working_set,
         )
         for dist in working_set:
             assert (


### PR DESCRIPTION
As described in #14246, #14058 caused plugin loading to run twice when we missed the cache. This was because after loading plugins, the working set has changed, and represents a new set of constraints on plugin loading.

While the current behavior is accurate, it isn't useful. Instead, we adjust `PluginResolver` to make the inputs to plugin loading idempotent, even if the outputs cannot be.

Fixes #14246.

[ci skip-rust]