### PR TITLE
Add `setrlimit` filter to coursier invocations

### DIFF
--- a/src/python/pants/jvm/compile.py
+++ b/src/python/pants/jvm/compile.py
@@ -272,13 +272,7 @@ class FallibleClasspathEntry(EngineAwareReturnType):
             return strip_v2_chroot_path(s) if strip_chroot_path else s.decode()
 
         exit_code = process_result.exit_code
-        # TODO: Coursier renders this line on macOS.
-        #   see https://github.com/pantsbuild/pants/issues/13942.
-        stderr = "\n".join(
-            line
-            for line in prep_output(process_result.stderr).splitlines()
-            if line != "setrlimit to increase file descriptor limit failed, errno 22"
-        )
+        stderr = prep_output(process_result.stderr)
         return cls(
             description=description,
             result=(CompileResult.SUCCEEDED if exit_code == 0 else CompileResult.FAILED),

--- a/src/python/pants/jvm/resolve/coursier_setup.py
+++ b/src/python/pants/jvm/resolve/coursier_setup.py
@@ -147,13 +147,11 @@ class Coursier:
     working_directory_placeholder: ClassVar[str] = "___COURSIER_WORKING_DIRECTORY___"
 
     def args(self, args: Iterable[str], *, wrapper: Iterable[str] = ()) -> tuple[str, ...]:
-        return tuple(
-            (
-                self.post_process_stderr,
-                *wrapper,
-                os.path.join(self.bin_dir, self.coursier.exe),
-                *args,
-            )
+        return (
+            self.post_process_stderr,
+            *wrapper,
+            os.path.join(self.bin_dir, self.coursier.exe),
+            *args,
         )
 
     @property

--- a/src/python/pants/jvm/resolve/coursier_setup.py
+++ b/src/python/pants/jvm/resolve/coursier_setup.py
@@ -75,7 +75,7 @@ COURSIER_FETCH_WRAPPER_SCRIPT = textwrap.dedent(
 )
 
 
-# TODO: Coursier renders this line on macOS.
+# TODO: Coursier renders setrlimit error line on macOS.
 #   see https://github.com/pantsbuild/pants/issues/13942.
 POST_PROCESS_COURSIER_STDERR_SCRIPT = textwrap.dedent(
     """\
@@ -87,6 +87,7 @@ POST_PROCESS_COURSIER_STDERR_SCRIPT = textwrap.dedent(
 
     sys.stdout.buffer.write(proc.stdout)
     sys.stderr.buffer.write(proc.stderr.replace(b"setrlimit to increase file descriptor limit failed, errno 22\\n", b""))
+    sys.exit(proc.returncode)
     """
 )
 

--- a/src/python/pants/jvm/resolve/coursier_setup.py
+++ b/src/python/pants/jvm/resolve/coursier_setup.py
@@ -75,17 +75,19 @@ COURSIER_FETCH_WRAPPER_SCRIPT = textwrap.dedent(
 )
 
 
+# TODO: Coursier renders this line on macOS.
+#   see https://github.com/pantsbuild/pants/issues/13942.
 POST_PROCESS_COURSIER_STDERR_SCRIPT = textwrap.dedent(
     """\
-#!{python_path}
-import sys
-from subprocess import run, PIPE
+    #!{python_path}
+    import sys
+    from subprocess import run, PIPE
 
-proc = run(sys.argv[1:], stdout=PIPE, stderr=PIPE)
+    proc = run(sys.argv[1:], stdout=PIPE, stderr=PIPE)
 
-sys.stdout.buffer.write(proc.stdout)
-sys.stderr.buffer.write(proc.stderr.replace(b"setrlimit to increase file descriptor limit failed, errno 22\\n", b""))
-"""
+    sys.stdout.buffer.write(proc.stdout)
+    sys.stderr.buffer.write(proc.stderr.replace(b"setrlimit to increase file descriptor limit failed, errno 22\\n", b""))
+    """
 )
 
 

--- a/src/python/pants/jvm/resolve/coursier_setup.py
+++ b/src/python/pants/jvm/resolve/coursier_setup.py
@@ -56,7 +56,7 @@ COURSIER_POST_PROCESSING_SCRIPT = textwrap.dedent(
     """
 )
 
-COURSIER_WRAPPER_SCRIPT = textwrap.dedent(
+COURSIER_FETCH_WRAPPER_SCRIPT = textwrap.dedent(
     """\
     set -eux
 
@@ -139,7 +139,7 @@ class Coursier:
     _digest: Digest
 
     bin_dir: ClassVar[str] = "__coursier"
-    wrapper_script: ClassVar[str] = f"{bin_dir}/coursier_wrapper_script.sh"
+    fetch_wrapper_script: ClassVar[str] = f"{bin_dir}/coursier_fetch_wrapper_script.sh"
     post_processing_script: ClassVar[str] = f"{bin_dir}/coursier_post_processing_script.py"
     post_process_stderr: ClassVar[str] = f"{bin_dir}/coursier_post_process_stderr.py"
     cache_name: ClassVar[str] = "coursier"
@@ -196,7 +196,7 @@ async def invoke_coursier_wrapper(
     return Process(
         argv=coursier.args(
             request.args,
-            wrapper=[bash.path, coursier.wrapper_script],
+            wrapper=[bash.path, coursier.fetch_wrapper_script],
         ),
         input_digest=request.input_digest,
         immutable_input_digests=coursier.immutable_input_digests,
@@ -215,7 +215,7 @@ async def setup_coursier(
     python: PythonBinary,
 ) -> Coursier:
     repos_args = " ".join(f"-r={shlex.quote(repo)}" for repo in coursier_subsystem.options.repos)
-    coursier_wrapper_script = COURSIER_WRAPPER_SCRIPT.format(
+    coursier_wrapper_script = COURSIER_FETCH_WRAPPER_SCRIPT.format(
         repos_args=repos_args,
         coursier_working_directory=Coursier.working_directory_placeholder,
         python_path=python.path,
@@ -234,7 +234,7 @@ async def setup_coursier(
         CreateDigest(
             [
                 FileContent(
-                    os.path.basename(Coursier.wrapper_script),
+                    os.path.basename(Coursier.fetch_wrapper_script),
                     coursier_wrapper_script.encode("utf-8"),
                     is_executable=True,
                 ),


### PR DESCRIPTION
After a few attempts to close #13942, I have emerged from a giant pile of yaks and discovered that the solution was actually attached to a sheep.

Annoyingly, a large number of our coursier invocations are used to look at outputs from stderr, which makes using `grep` (as suggested as an easy fix in #13942) to filter out spurious warnings quite difficult. Instead, this change adds another wrapper in the form of a Python script, which preserves separation of stdout and stderr for all Coursier invocations, but removes all instances of the setrlimit warning from stderr before outputting it. 

I've also renamed `coursier_wrapper`* to `coursier_fetch_wrapper`* to indicate that only `coursier fetch` calls are wrapped; calls like `coursier java-home` continue to be called more directly.