### PR TITLE
Adds `PosixTools` object for use with internal shell scripts

### DIFF
--- a/src/python/pants/core/util_rules/posix_tools.py
+++ b/src/python/pants/core/util_rules/posix_tools.py
@@ -1,0 +1,43 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from enum import Enum
+from textwrap import dedent
+
+from pants.engine.fs import CreateDigest, Digest, Directory, MergeDigests, RemovePrefix, Snapshot
+from pants.engine.process import (
+    BinaryPath,
+    BinaryPathRequest,
+    BinaryPaths,
+    BinaryPathTest,
+    Process,
+    ProcessResult,
+)
+from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.python import binaries as python_binaries
+from pants.python.binaries import PythonBinary
+from pants.util.logging import LogLevel
+
+
+class GrepBinary(BinaryPath):
+    pass
+
+SEARCH_PATHS = ("/usr/bin", "/bin", "/usr/local/bin")
+
+
+@rule(desc="Finding the `grep` binary", level=LogLevel.DEBUG)
+async def find_grep() -> GrepBinary:
+    request = BinaryPathRequest(
+        binary_name="grep", search_path=SEARCH_PATHS, test=BinaryPathTest(args=["-V"])
+    )
+    paths = await Get(BinaryPaths, BinaryPathRequest, request)
+    first_path = paths.first_path_or_raise(request, rationale="use grep in internal shell scripts")
+    return GrepBinary(first_path.path, first_path.fingerprint)
+
+
+def rules():
+    return collect_rules()

--- a/src/python/pants/core/util_rules/posix_tools.py
+++ b/src/python/pants/core/util_rules/posix_tools.py
@@ -3,40 +3,47 @@
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
-from enum import Enum
-from textwrap import dedent
 
-from pants.engine.fs import CreateDigest, Digest, Directory, MergeDigests, RemovePrefix, Snapshot
-from pants.engine.process import (
-    BinaryPath,
-    BinaryPathRequest,
-    BinaryPaths,
-    BinaryPathTest,
-    Process,
-    ProcessResult,
-)
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.python import binaries as python_binaries
-from pants.python.binaries import PythonBinary
+from pants.engine.internals.selectors import MultiGet
+from pants.engine.process import BinaryPath, BinaryPathRequest, BinaryPaths, BinaryPathTest
+from pants.engine.rules import Get, collect_rules, rule
 from pants.util.logging import LogLevel
 
 
-class GrepBinary(BinaryPath):
-    pass
+@dataclass(frozen=True)
+class PosixTools:
+    """ `BinaryPath`s for standard Unix tools that may be used in internal shell scripts."""
+    ln: BinaryPath
+
 
 SEARCH_PATHS = ("/usr/bin", "/bin", "/usr/local/bin")
 
 
-@rule(desc="Finding the `grep` binary", level=LogLevel.DEBUG)
-async def find_grep() -> GrepBinary:
-    request = BinaryPathRequest(
-        binary_name="grep", search_path=SEARCH_PATHS, test=BinaryPathTest(args=["-V"])
+@rule(desc="Finding posix tools", level=LogLevel.DEBUG)
+async def find_posix_tools() -> PosixTools:
+    short_requests: dict[str, BinaryPathTest | None] = {
+        "ln": None,
+    }
+
+    requests = [
+        BinaryPathRequest(binary_name=name, search_path=SEARCH_PATHS, test=test)
+        for name, test in short_requests.items()
+    ]
+    all_tool_paths = await MultiGet(
+        Get(BinaryPaths, BinaryPathRequest, request) for request in requests
     )
-    paths = await Get(BinaryPaths, BinaryPathRequest, request)
-    first_path = paths.first_path_or_raise(request, rationale="use grep in internal shell scripts")
-    return GrepBinary(first_path.path, first_path.fingerprint)
+
+    first_paths = {
+        request.binary_name: paths.first_path_or_raise(
+            request, rationale=f"use `{request.binary_name}` in internal shell scripts"
+        )
+        for request, paths in zip(requests, all_tool_paths)
+    }
+
+    return PosixTools(
+        ln=first_paths["ln"],
+    )
 
 
 def rules():


### PR DESCRIPTION
Here's a take-or-leave from working on #13942. This fetches tools that are a standard part of unix systems for use in shell scripts, currently just `ln`, but an earlier version had `grep` as well.