### PR TITLE
Don't render skipped tools in final summary with `fmt`, `lint`, `check`, and `test`

### DIFF
--- a/src/python/pants/core/goals/check.py
+++ b/src/python/pants/core/goals/check.py
@@ -180,8 +180,7 @@ async def check(
         console.print_stderr("")
     for results in sorted(all_results, key=lambda results: results.checker_name):
         if results.skipped:
-            sigil = console.sigil_skipped()
-            status = "skipped"
+            continue
         elif results.exit_code == 0:
             sigil = console.sigil_succeeded()
             status = "succeeded"

--- a/src/python/pants/core/goals/check_test.py
+++ b/src/python/pants/core/goals/check_test.py
@@ -161,7 +161,6 @@ def test_summary() -> None:
 
         𐄂 ConditionallySucceedsChecker failed.
         𐄂 FailingChecker failed.
-        - SkippedChecker skipped.
         ✓ SuccessfulChecker succeeded.
         """
     )

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -255,8 +255,7 @@ async def fmt(
             sigil = console.sigil_succeeded_with_edits()
             status = "made changes"
         elif all(result.skipped for result in results):
-            sigil = console.sigil_skipped()
-            status = "skipped"
+            continue
         else:
             sigil = console.sigil_succeeded()
             status = "made no changes"

--- a/src/python/pants/core/goals/fmt_test.py
+++ b/src/python/pants/core/goals/fmt_test.py
@@ -174,7 +174,6 @@ def test_summary(per_file_caching: bool) -> None:
 
         + FortranConditionallyDidChange made changes.
         ✓ SmalltalkDidNotChange made no changes.
-        - SmalltalkSkipped skipped.
         """
     )
 

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -276,8 +276,7 @@ async def lint(
         console.print_stderr("")
     for results in all_results:
         if results.skipped:
-            sigil = console.sigil_skipped()
-            status = "skipped"
+            continue
         elif results.exit_code == 0:
             sigil = console.sigil_succeeded()
             status = "succeeded"

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -126,7 +126,7 @@ def run_lint_rule(
                 create_goal_subsystem(
                     LintSubsystem,
                     per_file_caching=per_file_caching,
-                    batch_size=128,
+                    batch_size=batch_size,
                 ),
                 union_membership,
                 DistDir(relpath=Path("dist")),
@@ -184,7 +184,6 @@ def test_summary(rule_runner: RuleRunner, per_file_caching: bool) -> None:
 
         𐄂 ConditionallySucceedsLinter failed.
         𐄂 FailingLinter failed.
-        - SkippedLinter skipped.
         ✓ SuccessfulLinter succeeded.
         """
     )
@@ -209,7 +208,6 @@ def test_batched(rule_runner: RuleRunner, batch_size: int) -> None:
 
         ✓ ConditionallySucceedsLinter succeeded.
         𐄂 FailingLinter failed.
-        - SkippedLinter skipped.
         ✓ SuccessfulLinter succeeded.
         """
     )

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -271,7 +271,6 @@ def test_summary(rule_runner: RuleRunner) -> None:
         """\
 
         ✓ //:good succeeded in 1.00s (memoized).
-        - //:skipped skipped.
         𐄂 //:bad failed in 1.00s (memoized).
         """
     )
@@ -324,12 +323,6 @@ def test_format_summary_memoized(rule_runner: RuleRunner) -> None:
         exit_code=0,
         run_id=1234,
         result_metadata=ProcessResultMetadata(50, "ran_locally", 0),
-    )
-
-
-def test_format_summary_skipped(rule_runner: RuleRunner) -> None:
-    _assert_test_summary(
-        "- //:dummy_address skipped.", exit_code=None, run_id=0, result_metadata=None
     )
 
 


### PR DESCRIPTION
Before:

```
❯ ./pants --black-skip fmt src/python/pants/util/strutil.py
07:22:21.51 [INFO] Completed: Format with Autoflake - autoflake made no changes.
07:22:22.52 [INFO] Completed: Format with docformatter - Docformatter made no changes.
07:22:22.54 [INFO] Completed: Format with isort - isort made no changes.

- Black skipped.
✓ Docformatter made no changes.
✓ autoflake made no changes.
✓ isort made no changes.
```


After:

```
❯ ./pants --black-skip fmt src/python/pants/util/strutil.py                                           
07:22:01.24 [INFO] Completed: Format with Autoflake - autoflake made no changes.
07:22:01.41 [INFO] Completed: Format with docformatter - Docformatter made no changes.
07:22:01.70 [INFO] Completed: Format with isort - isort made no changes.

✓ Docformatter made no changes.
✓ autoflake made no changes.
✓ isort made no changes.
```

As we've added more tools, rendering skipping is somewhat noisy. 

More importantly, it causes a problem when tools want to disable themselves via some complex logic that requires the Rules API. For example, with Go, we don't know if a `go_package` has tests in it or not until compiling the code and running our analyzer: 

https://github.com/pantsbuild/pants/blob/0488605f54ef3602797d68a5c4797dea9d706b14/src/python/pants/backend/go/goals/test.py#L192-L193

With the upcoming `regex-lint` (formerly `validate`), we want to only enable the linter if `[regex-lint].config` is set up: https://github.com/pantsbuild/pants/pull/14102. 

In both these cases, it is annoying & noisy to render the skipped tools in the summary. I wasn't anticipating these use cases when designing this summary in 2020: https://github.com/pantsbuild/pants/pull/9710.

We will still log that the tool is skipped at `-ldebug`, which helps if users are confused why something isn't showing up.

[ci skip-rust]
[ci skip-build-wheels]