### PR TITLE
`LintRequest`, `FmtRequest`, and `CheckRequest` must set `name: ClassVar[str]`

### DIFF
--- a/src/python/pants/backend/docker/lint/hadolint/rules.py
+++ b/src/python/pants/backend/docker/lint/hadolint/rules.py
@@ -34,6 +34,7 @@ class HadolintFieldSet(FieldSet):
 
 class HadolintRequest(LintRequest):
     field_set_type = HadolintFieldSet
+    tool_name = "Hadolint"
 
 
 def generate_argv(
@@ -50,7 +51,7 @@ def generate_argv(
 @rule(desc="Lint with Hadolint", level=LogLevel.DEBUG)
 async def run_hadolint(request: HadolintRequest, hadolint: Hadolint) -> LintResults:
     if hadolint.skip:
-        return LintResults([], linter_name="Hadolint")
+        return LintResults([], linter_name=request.tool_name)
 
     downloaded_hadolint, config_files = await MultiGet(
         Get(DownloadedExternalTool, ExternalToolRequest, hadolint.get_request(Platform.current)),
@@ -96,7 +97,7 @@ async def run_hadolint(request: HadolintRequest, hadolint: Hadolint) -> LintResu
     )
 
     return LintResults(
-        [LintResult.from_fallible_process_result(process_result)], linter_name="hadolint"
+        [LintResult.from_fallible_process_result(process_result)], linter_name=request.tool_name
     )
 
 

--- a/src/python/pants/backend/docker/lint/hadolint/rules.py
+++ b/src/python/pants/backend/docker/lint/hadolint/rules.py
@@ -34,7 +34,7 @@ class HadolintFieldSet(FieldSet):
 
 class HadolintRequest(LintRequest):
     field_set_type = HadolintFieldSet
-    tool_name = "Hadolint"
+    name = "Hadolint"
 
 
 def generate_argv(
@@ -51,7 +51,7 @@ def generate_argv(
 @rule(desc="Lint with Hadolint", level=LogLevel.DEBUG)
 async def run_hadolint(request: HadolintRequest, hadolint: Hadolint) -> LintResults:
     if hadolint.skip:
-        return LintResults([], linter_name=request.tool_name)
+        return LintResults([], linter_name=request.name)
 
     downloaded_hadolint, config_files = await MultiGet(
         Get(DownloadedExternalTool, ExternalToolRequest, hadolint.get_request(Platform.current)),
@@ -97,7 +97,7 @@ async def run_hadolint(request: HadolintRequest, hadolint: Hadolint) -> LintResu
     )
 
     return LintResults(
-        [LintResult.from_fallible_process_result(process_result)], linter_name=request.tool_name
+        [LintResult.from_fallible_process_result(process_result)], linter_name=request.name
     )
 
 

--- a/src/python/pants/backend/go/goals/check.py
+++ b/src/python/pants/backend/go/goals/check.py
@@ -24,6 +24,7 @@ class GoCheckFieldSet(FieldSet):
 
 class GoCheckRequest(CheckRequest):
     field_set_type = GoCheckFieldSet
+    tool_name = "go compile"
 
 
 @rule(desc="Check Go compilation", level=LogLevel.DEBUG)
@@ -53,7 +54,7 @@ async def check_go(request: GoCheckRequest) -> CheckResults:
         ),
         0,
     )
-    return CheckResults([CheckResult(exit_code, "", "")], checker_name="go compile")
+    return CheckResults([CheckResult(exit_code, "", "")], checker_name=request.tool_name)
 
 
 def rules():

--- a/src/python/pants/backend/go/goals/check.py
+++ b/src/python/pants/backend/go/goals/check.py
@@ -24,7 +24,7 @@ class GoCheckFieldSet(FieldSet):
 
 class GoCheckRequest(CheckRequest):
     field_set_type = GoCheckFieldSet
-    tool_name = "go compile"
+    name = "go compile"
 
 
 @rule(desc="Check Go compilation", level=LogLevel.DEBUG)
@@ -54,7 +54,7 @@ async def check_go(request: GoCheckRequest) -> CheckResults:
         ),
         0,
     )
-    return CheckResults([CheckResult(exit_code, "", "")], checker_name=request.tool_name)
+    return CheckResults([CheckResult(exit_code, "", "")], checker_name=request.name)
 
 
 def rules():

--- a/src/python/pants/backend/go/lint/gofmt/rules.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules.py
@@ -38,7 +38,7 @@ class GofmtFieldSet(FieldSet):
 
 class GofmtRequest(FmtRequest):
     field_set_type = GofmtFieldSet
-    tool_name = "gofmt"
+    name = "gofmt"
 
 
 @dataclass(frozen=True)
@@ -83,18 +83,18 @@ async def setup_gofmt(setup_request: SetupRequest, goroot: GoRoot) -> Setup:
 @rule(desc="Format with gofmt")
 async def gofmt_fmt(request: GofmtRequest, gofmt: GofmtSubsystem) -> FmtResult:
     if gofmt.options.skip:
-        return FmtResult.skip(formatter_name=request.tool_name)
+        return FmtResult.skip(formatter_name=request.name)
     setup = await Get(Setup, SetupRequest(request, check_only=False))
     result = await Get(ProcessResult, Process, setup.process)
     return FmtResult.from_process_result(
-        result, original_digest=setup.original_digest, formatter_name=request.tool_name
+        result, original_digest=setup.original_digest, formatter_name=request.name
     )
 
 
 @rule(desc="Lint with gofmt", level=LogLevel.DEBUG)
 async def gofmt_lint(request: GofmtRequest, gofmt: GofmtSubsystem) -> LintResults:
     if gofmt.options.skip:
-        return LintResults([], linter_name=request.tool_name)
+        return LintResults([], linter_name=request.name)
     setup = await Get(Setup, SetupRequest(request, check_only=True))
     result = await Get(FallibleProcessResult, Process, setup.process)
     lint_result = LintResult.from_fallible_process_result(result)
@@ -106,7 +106,7 @@ async def gofmt_lint(request: GofmtRequest, gofmt: GofmtSubsystem) -> LintResult
             exit_code=1,
             stdout=f"The following Go files require formatting:\n{lint_result.stdout}\n",
         )
-    return LintResults([lint_result], linter_name=request.tool_name)
+    return LintResults([lint_result], linter_name=request.name)
 
 
 def rules():

--- a/src/python/pants/backend/go/lint/vet/rules.py
+++ b/src/python/pants/backend/go/lint/vet/rules.py
@@ -41,13 +41,13 @@ class GoVetFieldSet(FieldSet):
 
 class GoVetRequest(LintRequest):
     field_set_type = GoVetFieldSet
-    tool_name = "go vet"
+    name = "go vet"
 
 
 @rule(level=LogLevel.DEBUG)
 async def run_go_vet(request: GoVetRequest, go_vet_subsystem: GoVetSubsystem) -> LintResults:
     if go_vet_subsystem.skip:
-        return LintResults([], linter_name=request.tool_name)
+        return LintResults([], linter_name=request.name)
 
     source_files = await Get(
         SourceFiles,
@@ -81,7 +81,7 @@ async def run_go_vet(request: GoVetRequest, go_vet_subsystem: GoVetSubsystem) ->
     )
 
     result = LintResult.from_fallible_process_result(process_result)
-    return LintResults([result], linter_name=request.tool_name)
+    return LintResults([result], linter_name=request.name)
 
 
 def rules():

--- a/src/python/pants/backend/go/lint/vet/rules.py
+++ b/src/python/pants/backend/go/lint/vet/rules.py
@@ -41,12 +41,13 @@ class GoVetFieldSet(FieldSet):
 
 class GoVetRequest(LintRequest):
     field_set_type = GoVetFieldSet
+    tool_name = "go vet"
 
 
 @rule(level=LogLevel.DEBUG)
 async def run_go_vet(request: GoVetRequest, go_vet_subsystem: GoVetSubsystem) -> LintResults:
     if go_vet_subsystem.skip:
-        return LintResults([], linter_name="go vet")
+        return LintResults([], linter_name=request.tool_name)
 
     source_files = await Get(
         SourceFiles,
@@ -80,7 +81,7 @@ async def run_go_vet(request: GoVetRequest, go_vet_subsystem: GoVetSubsystem) ->
     )
 
     result = LintResult.from_fallible_process_result(process_result)
-    return LintResults([result], linter_name="go vet")
+    return LintResults([result], linter_name=request.tool_name)
 
 
 def rules():

--- a/src/python/pants/backend/java/goals/check.py
+++ b/src/python/pants/backend/java/goals/check.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 class JavacCheckRequest(CheckRequest):
     field_set_type = JavaFieldSet
-    tool_name = "javac"
+    name = "javac"
 
 
 @rule(desc="Check javac compilation", level=LogLevel.DEBUG)
@@ -49,7 +49,7 @@ async def javac_check(
 
     # NB: We don't pass stdout/stderr as it will have already been rendered as streaming.
     exit_code = next((result.exit_code for result in results if result.exit_code != 0), 0)
-    return CheckResults([CheckResult(exit_code, "", "")], checker_name=request.tool_name)
+    return CheckResults([CheckResult(exit_code, "", "")], checker_name=request.name)
 
 
 def rules():

--- a/src/python/pants/backend/java/goals/check.py
+++ b/src/python/pants/backend/java/goals/check.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 class JavacCheckRequest(CheckRequest):
     field_set_type = JavaFieldSet
+    tool_name = "javac"
 
 
 @rule(desc="Check javac compilation", level=LogLevel.DEBUG)
@@ -48,7 +49,7 @@ async def javac_check(
 
     # NB: We don't pass stdout/stderr as it will have already been rendered as streaming.
     exit_code = next((result.exit_code for result in results if result.exit_code != 0), 0)
-    return CheckResults([CheckResult(exit_code, "", "")], checker_name="javac")
+    return CheckResults([CheckResult(exit_code, "", "")], checker_name=request.tool_name)
 
 
 def rules():

--- a/src/python/pants/backend/java/lint/google_java_format/rules.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules.py
@@ -40,7 +40,7 @@ class GoogleJavaFormatFieldSet(FieldSet):
 
 class GoogleJavaFormatRequest(FmtRequest, LintRequest):
     field_set_type = GoogleJavaFormatFieldSet
-    tool_name = "Google Java Format"
+    name = "Google Java Format"
 
 
 class GoogleJavaFormatToolLockfileSentinel(GenerateToolLockfileSentinel):
@@ -125,13 +125,13 @@ async def google_java_format_fmt(
     request: GoogleJavaFormatRequest, tool: GoogleJavaFormatSubsystem
 ) -> FmtResult:
     if tool.skip:
-        return FmtResult.skip(formatter_name=request.tool_name)
+        return FmtResult.skip(formatter_name=request.name)
     setup = await Get(Setup, SetupRequest(request, check_only=False))
     result = await Get(ProcessResult, JvmProcess, setup.process)
     return FmtResult.from_process_result(
         result,
         original_digest=setup.original_digest,
-        formatter_name=request.tool_name,
+        formatter_name=request.name,
         strip_chroot_path=True,
     )
 
@@ -141,7 +141,7 @@ async def google_java_format_lint(
     request: GoogleJavaFormatRequest, tool: GoogleJavaFormatSubsystem
 ) -> LintResults:
     if tool.skip:
-        return LintResults([], linter_name=request.tool_name)
+        return LintResults([], linter_name=request.name)
     setup = await Get(Setup, SetupRequest(request, check_only=True))
     result = await Get(FallibleProcessResult, JvmProcess, setup.process)
     lint_result = LintResult.from_fallible_process_result(result)
@@ -153,7 +153,7 @@ async def google_java_format_lint(
             exit_code=1,
             stdout=f"The following Java files require formatting:\n{lint_result.stdout}\n",
         )
-    return LintResults([lint_result], linter_name=request.tool_name)
+    return LintResults([lint_result], linter_name=request.name)
 
 
 @rule

--- a/src/python/pants/backend/java/lint/google_java_format/rules.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules.py
@@ -40,6 +40,7 @@ class GoogleJavaFormatFieldSet(FieldSet):
 
 class GoogleJavaFormatRequest(FmtRequest, LintRequest):
     field_set_type = GoogleJavaFormatFieldSet
+    tool_name = "Google Java Format"
 
 
 class GoogleJavaFormatToolLockfileSentinel(GenerateToolLockfileSentinel):
@@ -121,27 +122,27 @@ async def setup_google_java_format(
 
 @rule(desc="Format with Google Java Format", level=LogLevel.DEBUG)
 async def google_java_format_fmt(
-    field_sets: GoogleJavaFormatRequest, tool: GoogleJavaFormatSubsystem
+    request: GoogleJavaFormatRequest, tool: GoogleJavaFormatSubsystem
 ) -> FmtResult:
     if tool.skip:
-        return FmtResult.skip(formatter_name="Google Java Format")
-    setup = await Get(Setup, SetupRequest(field_sets, check_only=False))
+        return FmtResult.skip(formatter_name=request.tool_name)
+    setup = await Get(Setup, SetupRequest(request, check_only=False))
     result = await Get(ProcessResult, JvmProcess, setup.process)
     return FmtResult.from_process_result(
         result,
         original_digest=setup.original_digest,
-        formatter_name="Google Java Format",
+        formatter_name=request.tool_name,
         strip_chroot_path=True,
     )
 
 
 @rule(desc="Lint with Google Java Format", level=LogLevel.DEBUG)
 async def google_java_format_lint(
-    field_sets: GoogleJavaFormatRequest, tool: GoogleJavaFormatSubsystem
+    request: GoogleJavaFormatRequest, tool: GoogleJavaFormatSubsystem
 ) -> LintResults:
     if tool.skip:
-        return LintResults([], linter_name="Google Java Format")
-    setup = await Get(Setup, SetupRequest(field_sets, check_only=True))
+        return LintResults([], linter_name=request.tool_name)
+    setup = await Get(Setup, SetupRequest(request, check_only=True))
     result = await Get(FallibleProcessResult, JvmProcess, setup.process)
     lint_result = LintResult.from_fallible_process_result(result)
     if lint_result.exit_code == 0 and lint_result.stdout.strip() != "":
@@ -152,7 +153,7 @@ async def google_java_format_lint(
             exit_code=1,
             stdout=f"The following Java files require formatting:\n{lint_result.stdout}\n",
         )
-    return LintResults([lint_result], linter_name="Google Java Format")
+    return LintResults([lint_result], linter_name=request.tool_name)
 
 
 @rule

--- a/src/python/pants/backend/python/lint/autoflake/rules.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules.py
@@ -35,7 +35,7 @@ class AutoflakeFieldSet(FieldSet):
 
 class AutoflakeRequest(FmtRequest, LintRequest):
     field_set_type = AutoflakeFieldSet
-    tool_name = "autoflake"
+    name = "autoflake"
 
 
 @dataclass(frozen=True)
@@ -106,13 +106,13 @@ async def setup_autoflake(setup_request: SetupRequest, autoflake: Autoflake) -> 
 @rule(desc="Format with Autoflake", level=LogLevel.DEBUG)
 async def autoflake_fmt(request: AutoflakeRequest, autoflake: Autoflake) -> FmtResult:
     if autoflake.skip:
-        return FmtResult.skip(formatter_name=request.tool_name)
+        return FmtResult.skip(formatter_name=request.name)
     setup = await Get(Setup, SetupRequest(request, check_only=False))
     result = await Get(ProcessResult, Process, setup.process)
     return FmtResult.from_process_result(
         result,
         original_digest=setup.original_digest,
-        formatter_name=request.tool_name,
+        formatter_name=request.name,
         strip_chroot_path=True,
     )
 
@@ -120,7 +120,7 @@ async def autoflake_fmt(request: AutoflakeRequest, autoflake: Autoflake) -> FmtR
 @rule(desc="Lint with autoflake", level=LogLevel.DEBUG)
 async def autoflake_lint(request: AutoflakeRequest, autoflake: Autoflake) -> LintResults:
     if autoflake.skip:
-        return LintResults([], linter_name=request.tool_name)
+        return LintResults([], linter_name=request.name)
     setup = await Get(Setup, SetupRequest(request, check_only=True))
     result = await Get(FallibleProcessResult, Process, setup.process)
 
@@ -135,7 +135,7 @@ async def autoflake_lint(request: AutoflakeRequest, autoflake: Autoflake) -> Lin
                 result.stderr.decode(),
             )
         ],
-        linter_name=request.tool_name,
+        linter_name=request.name,
     )
 
 

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -22,6 +22,7 @@ from pants.util.strutil import pluralize
 
 class BanditRequest(LintRequest):
     field_set_type = BanditFieldSet
+    tool_name = "Bandit"
 
 
 @dataclass(frozen=True)
@@ -95,7 +96,7 @@ async def bandit_lint(
     request: BanditRequest, bandit: Bandit, python_setup: PythonSetup
 ) -> LintResults:
     if bandit.skip:
-        return LintResults([], linter_name="Bandit")
+        return LintResults([], linter_name=request.tool_name)
 
     # NB: Bandit output depends upon which Python interpreter version it's run with
     # ( https://github.com/PyCQA/bandit#under-which-version-of-python-should-i-install-bandit). We
@@ -108,7 +109,7 @@ async def bandit_lint(
         Get(LintResult, BanditPartition(partition_field_sets, partition_compatibility))
         for partition_compatibility, partition_field_sets in constraints_to_field_sets.items()
     )
-    return LintResults(partitioned_results, linter_name="Bandit")
+    return LintResults(partitioned_results, linter_name=request.tool_name)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -22,7 +22,7 @@ from pants.util.strutil import pluralize
 
 class BanditRequest(LintRequest):
     field_set_type = BanditFieldSet
-    tool_name = "Bandit"
+    name = "Bandit"
 
 
 @dataclass(frozen=True)
@@ -96,7 +96,7 @@ async def bandit_lint(
     request: BanditRequest, bandit: Bandit, python_setup: PythonSetup
 ) -> LintResults:
     if bandit.skip:
-        return LintResults([], linter_name=request.tool_name)
+        return LintResults([], linter_name=request.name)
 
     # NB: Bandit output depends upon which Python interpreter version it's run with
     # ( https://github.com/PyCQA/bandit#under-which-version-of-python-should-i-install-bandit). We
@@ -109,7 +109,7 @@ async def bandit_lint(
         Get(LintResult, BanditPartition(partition_field_sets, partition_compatibility))
         for partition_compatibility, partition_field_sets in constraints_to_field_sets.items()
     )
-    return LintResults(partitioned_results, linter_name=request.tool_name)
+    return LintResults(partitioned_results, linter_name=request.name)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -38,7 +38,7 @@ class BlackFieldSet(FieldSet):
 
 class BlackRequest(FmtRequest, LintRequest):
     field_set_type = BlackFieldSet
-    tool_name = "Black"
+    name = "Black"
 
 
 @dataclass(frozen=True)
@@ -137,13 +137,13 @@ async def setup_black(
 @rule(desc="Format with Black", level=LogLevel.DEBUG)
 async def black_fmt(request: BlackRequest, black: Black) -> FmtResult:
     if black.skip:
-        return FmtResult.skip(formatter_name=request.tool_name)
+        return FmtResult.skip(formatter_name=request.name)
     setup = await Get(Setup, SetupRequest(request, check_only=False))
     result = await Get(ProcessResult, Process, setup.process)
     return FmtResult.from_process_result(
         result,
         original_digest=setup.original_digest,
-        formatter_name=request.tool_name,
+        formatter_name=request.name,
         strip_chroot_path=True,
     )
 
@@ -151,12 +151,12 @@ async def black_fmt(request: BlackRequest, black: Black) -> FmtResult:
 @rule(desc="Lint with Black", level=LogLevel.DEBUG)
 async def black_lint(request: BlackRequest, black: Black) -> LintResults:
     if black.skip:
-        return LintResults([], linter_name=request.tool_name)
+        return LintResults([], linter_name=request.name)
     setup = await Get(Setup, SetupRequest(request, check_only=True))
     result = await Get(FallibleProcessResult, Process, setup.process)
     return LintResults(
         [LintResult.from_fallible_process_result(result, strip_chroot_path=True)],
-        linter_name=request.tool_name,
+        linter_name=request.name,
     )
 
 

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -38,6 +38,7 @@ class BlackFieldSet(FieldSet):
 
 class BlackRequest(FmtRequest, LintRequest):
     field_set_type = BlackFieldSet
+    tool_name = "Black"
 
 
 @dataclass(frozen=True)
@@ -134,28 +135,28 @@ async def setup_black(
 
 
 @rule(desc="Format with Black", level=LogLevel.DEBUG)
-async def black_fmt(field_sets: BlackRequest, black: Black) -> FmtResult:
+async def black_fmt(request: BlackRequest, black: Black) -> FmtResult:
     if black.skip:
-        return FmtResult.skip(formatter_name="Black")
-    setup = await Get(Setup, SetupRequest(field_sets, check_only=False))
+        return FmtResult.skip(formatter_name=request.tool_name)
+    setup = await Get(Setup, SetupRequest(request, check_only=False))
     result = await Get(ProcessResult, Process, setup.process)
     return FmtResult.from_process_result(
         result,
         original_digest=setup.original_digest,
-        formatter_name="Black",
+        formatter_name=request.tool_name,
         strip_chroot_path=True,
     )
 
 
 @rule(desc="Lint with Black", level=LogLevel.DEBUG)
-async def black_lint(field_sets: BlackRequest, black: Black) -> LintResults:
+async def black_lint(request: BlackRequest, black: Black) -> LintResults:
     if black.skip:
-        return LintResults([], linter_name="Black")
-    setup = await Get(Setup, SetupRequest(field_sets, check_only=True))
+        return LintResults([], linter_name=request.tool_name)
+    setup = await Get(Setup, SetupRequest(request, check_only=True))
     result = await Get(FallibleProcessResult, Process, setup.process)
     return LintResults(
         [LintResult.from_fallible_process_result(result, strip_chroot_path=True)],
-        linter_name="Black",
+        linter_name=request.tool_name,
     )
 
 

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -34,6 +34,7 @@ class DocformatterFieldSet(FieldSet):
 
 class DocformatterRequest(FmtRequest, LintRequest):
     field_set_type = DocformatterFieldSet
+    tool_name = "Docformatter"
 
 
 @dataclass(frozen=True)
@@ -102,11 +103,11 @@ async def setup_docformatter(setup_request: SetupRequest, docformatter: Docforma
 @rule(desc="Format with docformatter", level=LogLevel.DEBUG)
 async def docformatter_fmt(request: DocformatterRequest, docformatter: Docformatter) -> FmtResult:
     if docformatter.skip:
-        return FmtResult.skip(formatter_name="Docformatter")
+        return FmtResult.skip(formatter_name=request.tool_name)
     setup = await Get(Setup, SetupRequest(request, check_only=False))
     result = await Get(ProcessResult, Process, setup.process)
     return FmtResult.from_process_result(
-        result, original_digest=setup.original_digest, formatter_name="Docformatter"
+        result, original_digest=setup.original_digest, formatter_name=request.tool_name
     )
 
 
@@ -115,11 +116,11 @@ async def docformatter_lint(
     request: DocformatterRequest, docformatter: Docformatter
 ) -> LintResults:
     if docformatter.skip:
-        return LintResults([], linter_name="Docformatter")
+        return LintResults([], linter_name=request.tool_name)
     setup = await Get(Setup, SetupRequest(request, check_only=True))
     result = await Get(FallibleProcessResult, Process, setup.process)
     return LintResults(
-        [LintResult.from_fallible_process_result(result)], linter_name="Docformatter"
+        [LintResult.from_fallible_process_result(result)], linter_name=request.tool_name
     )
 
 

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -34,7 +34,7 @@ class DocformatterFieldSet(FieldSet):
 
 class DocformatterRequest(FmtRequest, LintRequest):
     field_set_type = DocformatterFieldSet
-    tool_name = "Docformatter"
+    name = "Docformatter"
 
 
 @dataclass(frozen=True)
@@ -103,11 +103,11 @@ async def setup_docformatter(setup_request: SetupRequest, docformatter: Docforma
 @rule(desc="Format with docformatter", level=LogLevel.DEBUG)
 async def docformatter_fmt(request: DocformatterRequest, docformatter: Docformatter) -> FmtResult:
     if docformatter.skip:
-        return FmtResult.skip(formatter_name=request.tool_name)
+        return FmtResult.skip(formatter_name=request.name)
     setup = await Get(Setup, SetupRequest(request, check_only=False))
     result = await Get(ProcessResult, Process, setup.process)
     return FmtResult.from_process_result(
-        result, original_digest=setup.original_digest, formatter_name=request.tool_name
+        result, original_digest=setup.original_digest, formatter_name=request.name
     )
 
 
@@ -116,12 +116,10 @@ async def docformatter_lint(
     request: DocformatterRequest, docformatter: Docformatter
 ) -> LintResults:
     if docformatter.skip:
-        return LintResults([], linter_name=request.tool_name)
+        return LintResults([], linter_name=request.name)
     setup = await Get(Setup, SetupRequest(request, check_only=True))
     result = await Get(FallibleProcessResult, Process, setup.process)
-    return LintResults(
-        [LintResult.from_fallible_process_result(result)], linter_name=request.tool_name
-    )
+    return LintResults([LintResult.from_fallible_process_result(result)], linter_name=request.name)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -27,7 +27,7 @@ from pants.util.strutil import pluralize
 
 class Flake8Request(LintRequest):
     field_set_type = Flake8FieldSet
-    tool_name = "Flake8"
+    name = "Flake8"
 
 
 @dataclass(frozen=True)
@@ -113,7 +113,7 @@ async def flake8_lint(
     first_party_plugins: Flake8FirstPartyPlugins,
 ) -> LintResults:
     if flake8.skip:
-        return LintResults([], linter_name=request.tool_name)
+        return LintResults([], linter_name=request.name)
 
     # NB: Flake8 output depends upon which Python interpreter version it's run with
     # (http://flake8.pycqa.org/en/latest/user/invocation.html). We batch targets by their
@@ -134,7 +134,7 @@ async def flake8_lint(
         )
         for constraints, field_sets in sorted(results.items())
     )
-    return LintResults(partitioned_results, linter_name=request.tool_name)
+    return LintResults(partitioned_results, linter_name=request.name)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -27,6 +27,7 @@ from pants.util.strutil import pluralize
 
 class Flake8Request(LintRequest):
     field_set_type = Flake8FieldSet
+    tool_name = "Flake8"
 
 
 @dataclass(frozen=True)
@@ -112,7 +113,7 @@ async def flake8_lint(
     first_party_plugins: Flake8FirstPartyPlugins,
 ) -> LintResults:
     if flake8.skip:
-        return LintResults([], linter_name="Flake8")
+        return LintResults([], linter_name=request.tool_name)
 
     # NB: Flake8 output depends upon which Python interpreter version it's run with
     # (http://flake8.pycqa.org/en/latest/user/invocation.html). We batch targets by their
@@ -133,7 +134,7 @@ async def flake8_lint(
         )
         for constraints, field_sets in sorted(results.items())
     )
-    return LintResults(partitioned_results, linter_name="Flake8")
+    return LintResults(partitioned_results, linter_name=request.tool_name)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -35,7 +35,7 @@ class IsortFieldSet(FieldSet):
 
 class IsortRequest(FmtRequest, LintRequest):
     field_set_type = IsortFieldSet
-    tool_name = "isort"
+    name = "isort"
 
 
 @dataclass(frozen=True)
@@ -135,13 +135,13 @@ async def setup_isort(setup_request: SetupRequest, isort: Isort) -> Setup:
 @rule(desc="Format with isort", level=LogLevel.DEBUG)
 async def isort_fmt(request: IsortRequest, isort: Isort) -> FmtResult:
     if isort.skip:
-        return FmtResult.skip(formatter_name=request.tool_name)
+        return FmtResult.skip(formatter_name=request.name)
     setup = await Get(Setup, SetupRequest(request, check_only=False))
     result = await Get(ProcessResult, Process, setup.process)
     return FmtResult.from_process_result(
         result,
         original_digest=setup.original_digest,
-        formatter_name=request.tool_name,
+        formatter_name=request.name,
         strip_chroot_path=True,
     )
 
@@ -149,12 +149,12 @@ async def isort_fmt(request: IsortRequest, isort: Isort) -> FmtResult:
 @rule(desc="Lint with isort", level=LogLevel.DEBUG)
 async def isort_lint(request: IsortRequest, isort: Isort) -> LintResults:
     if isort.skip:
-        return LintResults([], linter_name=request.tool_name)
+        return LintResults([], linter_name=request.name)
     setup = await Get(Setup, SetupRequest(request, check_only=True))
     result = await Get(FallibleProcessResult, Process, setup.process)
     return LintResults(
         [LintResult.from_fallible_process_result(result, strip_chroot_path=True)],
-        linter_name=request.tool_name,
+        linter_name=request.name,
     )
 
 

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -35,6 +35,7 @@ class IsortFieldSet(FieldSet):
 
 class IsortRequest(FmtRequest, LintRequest):
     field_set_type = IsortFieldSet
+    tool_name = "isort"
 
 
 @dataclass(frozen=True)
@@ -134,13 +135,13 @@ async def setup_isort(setup_request: SetupRequest, isort: Isort) -> Setup:
 @rule(desc="Format with isort", level=LogLevel.DEBUG)
 async def isort_fmt(request: IsortRequest, isort: Isort) -> FmtResult:
     if isort.skip:
-        return FmtResult.skip(formatter_name="isort")
+        return FmtResult.skip(formatter_name=request.tool_name)
     setup = await Get(Setup, SetupRequest(request, check_only=False))
     result = await Get(ProcessResult, Process, setup.process)
     return FmtResult.from_process_result(
         result,
         original_digest=setup.original_digest,
-        formatter_name="isort",
+        formatter_name=request.tool_name,
         strip_chroot_path=True,
     )
 
@@ -148,12 +149,12 @@ async def isort_fmt(request: IsortRequest, isort: Isort) -> FmtResult:
 @rule(desc="Lint with isort", level=LogLevel.DEBUG)
 async def isort_lint(request: IsortRequest, isort: Isort) -> LintResults:
     if isort.skip:
-        return LintResults([], linter_name="isort")
+        return LintResults([], linter_name=request.tool_name)
     setup = await Get(Setup, SetupRequest(request, check_only=True))
     result = await Get(FallibleProcessResult, Process, setup.process)
     return LintResults(
         [LintResult.from_fallible_process_result(result, strip_chroot_path=True)],
-        linter_name="isort",
+        linter_name=request.tool_name,
     )
 
 

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -71,6 +71,7 @@ class PylintPartition:
 
 class PylintRequest(LintRequest):
     field_set_type = PylintFieldSet
+    tool_name = "Pylint"
 
 
 def generate_argv(source_files: SourceFiles, pylint: Pylint) -> Tuple[str, ...]:
@@ -201,7 +202,7 @@ async def pylint_lint(
     first_party_plugins: PylintFirstPartyPlugins,
 ) -> LintResults:
     if pylint.skip:
-        return LintResults([], linter_name="Pylint")
+        return LintResults([], linter_name=request.tool_name)
 
     # Pylint needs direct dependencies in the chroot to ensure that imports are valid. However, it
     # doesn't lint those direct dependencies nor does it care about transitive dependencies.
@@ -247,7 +248,7 @@ async def pylint_lint(
     partitioned_results = await MultiGet(
         Get(LintResult, PylintPartition, partition) for partition in partitions
     )
-    return LintResults(partitioned_results, linter_name="Pylint")
+    return LintResults(partitioned_results, linter_name=request.tool_name)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -71,7 +71,7 @@ class PylintPartition:
 
 class PylintRequest(LintRequest):
     field_set_type = PylintFieldSet
-    tool_name = "Pylint"
+    name = "Pylint"
 
 
 def generate_argv(source_files: SourceFiles, pylint: Pylint) -> Tuple[str, ...]:
@@ -202,7 +202,7 @@ async def pylint_lint(
     first_party_plugins: PylintFirstPartyPlugins,
 ) -> LintResults:
     if pylint.skip:
-        return LintResults([], linter_name=request.tool_name)
+        return LintResults([], linter_name=request.name)
 
     # Pylint needs direct dependencies in the chroot to ensure that imports are valid. However, it
     # doesn't lint those direct dependencies nor does it care about transitive dependencies.
@@ -248,7 +248,7 @@ async def pylint_lint(
     partitioned_results = await MultiGet(
         Get(LintResult, PylintPartition, partition) for partition in partitions
     )
-    return LintResults(partitioned_results, linter_name=request.tool_name)
+    return LintResults(partitioned_results, linter_name=request.name)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/pyupgrade/rules.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/rules.py
@@ -34,7 +34,7 @@ class PyUpgradeFieldSet(FieldSet):
 
 class PyUpgradeRequest(FmtRequest, LintRequest):
     field_set_type = PyUpgradeFieldSet
-    tool_name = "pyupgrade"
+    name = "pyupgrade"
 
 
 @dataclass(frozen=True)
@@ -84,22 +84,22 @@ async def run_pyupgrade(request: PyUpgradeRequest, pyupgrade: PyUpgrade) -> PyUp
 @rule(desc="Format with pyupgrade", level=LogLevel.DEBUG)
 async def pyupgrade_fmt(result: PyUpgradeResult, pyupgrade: PyUpgrade) -> FmtResult:
     if pyupgrade.skip:
-        return FmtResult.skip(formatter_name=PyUpgradeRequest.tool_name)
+        return FmtResult.skip(formatter_name=PyUpgradeRequest.name)
 
     return FmtResult.from_process_result(
         result.process_result,
         original_digest=result.original_digest,
-        formatter_name=PyUpgradeRequest.tool_name,
+        formatter_name=PyUpgradeRequest.name,
     )
 
 
 @rule(desc="Lint with pyupgrade", level=LogLevel.DEBUG)
 async def pyupgrade_lint(result: PyUpgradeResult, pyupgrade: PyUpgrade) -> LintResults:
     if pyupgrade.skip:
-        return LintResults([], linter_name=PyUpgradeRequest.tool_name)
+        return LintResults([], linter_name=PyUpgradeRequest.name)
     return LintResults(
         [LintResult.from_fallible_process_result(result.process_result)],
-        linter_name=PyUpgradeRequest.tool_name,
+        linter_name=PyUpgradeRequest.name,
     )
 
 

--- a/src/python/pants/backend/python/lint/pyupgrade/rules.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/rules.py
@@ -34,6 +34,7 @@ class PyUpgradeFieldSet(FieldSet):
 
 class PyUpgradeRequest(FmtRequest, LintRequest):
     field_set_type = PyUpgradeFieldSet
+    tool_name = "pyupgrade"
 
 
 @dataclass(frozen=True)
@@ -83,22 +84,22 @@ async def run_pyupgrade(request: PyUpgradeRequest, pyupgrade: PyUpgrade) -> PyUp
 @rule(desc="Format with pyupgrade", level=LogLevel.DEBUG)
 async def pyupgrade_fmt(result: PyUpgradeResult, pyupgrade: PyUpgrade) -> FmtResult:
     if pyupgrade.skip:
-        return FmtResult.skip(formatter_name="pyupgrade")
+        return FmtResult.skip(formatter_name=PyUpgradeRequest.tool_name)
 
     return FmtResult.from_process_result(
         result.process_result,
         original_digest=result.original_digest,
-        formatter_name="pyupgrade",
+        formatter_name=PyUpgradeRequest.tool_name,
     )
 
 
 @rule(desc="Lint with pyupgrade", level=LogLevel.DEBUG)
 async def pyupgrade_lint(result: PyUpgradeResult, pyupgrade: PyUpgrade) -> LintResults:
     if pyupgrade.skip:
-        return LintResults([], linter_name="pyupgrade")
+        return LintResults([], linter_name=PyUpgradeRequest.tool_name)
     return LintResults(
         [LintResult.from_fallible_process_result(result.process_result)],
-        linter_name="pyupgrade",
+        linter_name=PyUpgradeRequest.tool_name,
     )
 
 

--- a/src/python/pants/backend/python/lint/yapf/rules.py
+++ b/src/python/pants/backend/python/lint/yapf/rules.py
@@ -35,7 +35,7 @@ class YapfFieldSet(FieldSet):
 
 class YapfRequest(FmtRequest, LintRequest):
     field_set_type = YapfFieldSet
-    tool_name = "yapf"
+    name = "yapf"
 
 
 @dataclass(frozen=True)
@@ -118,25 +118,25 @@ async def setup_yapf(setup_request: SetupRequest, yapf: Yapf) -> Setup:
 @rule(desc="Format with yapf", level=LogLevel.DEBUG)
 async def yapf_fmt(request: YapfRequest, yapf: Yapf) -> FmtResult:
     if yapf.skip:
-        return FmtResult.skip(formatter_name=request.tool_name)
+        return FmtResult.skip(formatter_name=request.name)
     setup = await Get(Setup, SetupRequest(request, check_only=False))
     result = await Get(ProcessResult, Process, setup.process)
     return FmtResult.from_process_result(
         result,
         original_digest=setup.original_digest,
-        formatter_name=request.tool_name,
+        formatter_name=request.name,
     )
 
 
 @rule(desc="Lint with yapf", level=LogLevel.DEBUG)
 async def yapf_lint(request: YapfRequest, yapf: Yapf) -> LintResults:
     if yapf.skip:
-        return LintResults([], linter_name=request.tool_name)
+        return LintResults([], linter_name=request.name)
     setup = await Get(Setup, SetupRequest(request, check_only=True))
     result = await Get(FallibleProcessResult, Process, setup.process)
     return LintResults(
         [LintResult.from_fallible_process_result(result)],
-        linter_name=request.tool_name,
+        linter_name=request.name,
     )
 
 

--- a/src/python/pants/backend/python/lint/yapf/rules.py
+++ b/src/python/pants/backend/python/lint/yapf/rules.py
@@ -35,6 +35,7 @@ class YapfFieldSet(FieldSet):
 
 class YapfRequest(FmtRequest, LintRequest):
     field_set_type = YapfFieldSet
+    tool_name = "yapf"
 
 
 @dataclass(frozen=True)
@@ -117,25 +118,25 @@ async def setup_yapf(setup_request: SetupRequest, yapf: Yapf) -> Setup:
 @rule(desc="Format with yapf", level=LogLevel.DEBUG)
 async def yapf_fmt(request: YapfRequest, yapf: Yapf) -> FmtResult:
     if yapf.skip:
-        return FmtResult.skip(formatter_name="yapf")
+        return FmtResult.skip(formatter_name=request.tool_name)
     setup = await Get(Setup, SetupRequest(request, check_only=False))
     result = await Get(ProcessResult, Process, setup.process)
     return FmtResult.from_process_result(
         result,
         original_digest=setup.original_digest,
-        formatter_name="yapf",
+        formatter_name=request.tool_name,
     )
 
 
 @rule(desc="Lint with yapf", level=LogLevel.DEBUG)
 async def yapf_lint(request: YapfRequest, yapf: Yapf) -> LintResults:
     if yapf.skip:
-        return LintResults([], linter_name="yapf")
+        return LintResults([], linter_name=request.tool_name)
     setup = await Get(Setup, SetupRequest(request, check_only=True))
     result = await Get(FallibleProcessResult, Process, setup.process)
     return LintResults(
         [LintResult.from_fallible_process_result(result)],
-        linter_name="yapf",
+        linter_name=request.tool_name,
     )
 
 

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -60,7 +60,7 @@ class MyPyPartition:
 
 class MyPyRequest(CheckRequest):
     field_set_type = MyPyFieldSet
-    tool_name = "MyPy"
+    name = "MyPy"
 
 
 def generate_argv(
@@ -256,7 +256,7 @@ async def mypy_typecheck(
     request: MyPyRequest, mypy: MyPy, python_setup: PythonSetup
 ) -> CheckResults:
     if mypy.skip:
-        return CheckResults([], checker_name=request.tool_name)
+        return CheckResults([], checker_name=request.name)
 
     # When determining how to batch by interpreter constraints, we must consider the entire
     # transitive closure to get the final resulting constraints.
@@ -296,7 +296,7 @@ async def mypy_typecheck(
     partitioned_results = await MultiGet(
         Get(CheckResult, MyPyPartition, partition) for partition in partitions
     )
-    return CheckResults(partitioned_results, checker_name=request.tool_name)
+    return CheckResults(partitioned_results, checker_name=request.name)
 
 
 def rules():

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -60,6 +60,7 @@ class MyPyPartition:
 
 class MyPyRequest(CheckRequest):
     field_set_type = MyPyFieldSet
+    tool_name = "MyPy"
 
 
 def generate_argv(
@@ -255,7 +256,7 @@ async def mypy_typecheck(
     request: MyPyRequest, mypy: MyPy, python_setup: PythonSetup
 ) -> CheckResults:
     if mypy.skip:
-        return CheckResults([], checker_name="MyPy")
+        return CheckResults([], checker_name=request.tool_name)
 
     # When determining how to batch by interpreter constraints, we must consider the entire
     # transitive closure to get the final resulting constraints.
@@ -295,7 +296,7 @@ async def mypy_typecheck(
     partitioned_results = await MultiGet(
         Get(CheckResult, MyPyPartition, partition) for partition in partitions
     )
-    return CheckResults(partitioned_results, checker_name="MyPy")
+    return CheckResults(partitioned_results, checker_name=request.tool_name)
 
 
 def rules():

--- a/src/python/pants/backend/scala/goals/check.py
+++ b/src/python/pants/backend/scala/goals/check.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 class ScalacCheckRequest(CheckRequest):
     field_set_type = ScalaFieldSet
-    tool_name = "scalac"
+    name = "scalac"
 
 
 @rule(desc="Check compilation for Scala", level=LogLevel.DEBUG)
@@ -49,7 +49,7 @@ async def scalac_check(
 
     # NB: We don't pass stdout/stderr as it will have already been rendered as streaming.
     exit_code = next((result.exit_code for result in results if result.exit_code != 0), 0)
-    return CheckResults([CheckResult(exit_code, "", "")], checker_name=request.tool_name)
+    return CheckResults([CheckResult(exit_code, "", "")], checker_name=request.name)
 
 
 def rules():

--- a/src/python/pants/backend/scala/goals/check.py
+++ b/src/python/pants/backend/scala/goals/check.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 class ScalacCheckRequest(CheckRequest):
     field_set_type = ScalaFieldSet
+    tool_name = "scalac"
 
 
 @rule(desc="Check compilation for Scala", level=LogLevel.DEBUG)
@@ -48,7 +49,7 @@ async def scalac_check(
 
     # NB: We don't pass stdout/stderr as it will have already been rendered as streaming.
     exit_code = next((result.exit_code for result in results if result.exit_code != 0), 0)
-    return CheckResults([CheckResult(exit_code, "", "")], checker_name="scalac")
+    return CheckResults([CheckResult(exit_code, "", "")], checker_name=request.tool_name)
 
 
 def rules():

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -53,7 +53,7 @@ class ScalafmtFieldSet(FieldSet):
 
 class ScalafmtRequest(FmtRequest, LintRequest):
     field_set_type = ScalafmtFieldSet
-    tool_name = "scalafmt"
+    name = "scalafmt"
 
 
 class ScalafmtToolLockfileSentinel(GenerateToolLockfileSentinel):
@@ -251,7 +251,7 @@ async def setup_scalafmt(
 @rule(desc="Format with scalafmt", level=LogLevel.DEBUG)
 async def scalafmt_fmt(request: ScalafmtRequest, tool: ScalafmtSubsystem) -> FmtResult:
     if tool.skip:
-        return FmtResult.skip(formatter_name=request.tool_name)
+        return FmtResult.skip(formatter_name=request.name)
     setup = await Get(Setup, SetupRequest(request, check_only=False))
     results = await MultiGet(
         Get(ProcessResult, JvmProcess, partition.process) for partition in setup.partitions
@@ -283,7 +283,7 @@ async def scalafmt_fmt(request: ScalafmtRequest, tool: ScalafmtSubsystem) -> Fmt
         output=output_digest,
         stdout=stdout_content,
         stderr=stderr_content,
-        formatter_name=request.tool_name,
+        formatter_name=request.name,
     )
     return fmt_result
 
@@ -291,7 +291,7 @@ async def scalafmt_fmt(request: ScalafmtRequest, tool: ScalafmtSubsystem) -> Fmt
 @rule(desc="Lint with scalafmt", level=LogLevel.DEBUG)
 async def scalafmt_lint(request: ScalafmtRequest, tool: ScalafmtSubsystem) -> LintResults:
     if tool.skip:
-        return LintResults([], linter_name=request.tool_name)
+        return LintResults([], linter_name=request.name)
     setup = await Get(Setup, SetupRequest(request, check_only=True))
     results = await MultiGet(
         Get(FallibleProcessResult, JvmProcess, partition.process) for partition in setup.partitions
@@ -300,7 +300,7 @@ async def scalafmt_lint(request: ScalafmtRequest, tool: ScalafmtSubsystem) -> Li
         LintResult.from_fallible_process_result(result, partition_description=partition.description)
         for result, partition in zip(results, setup.partitions)
     ]
-    return LintResults(lint_results, linter_name=request.tool_name)
+    return LintResults(lint_results, linter_name=request.name)
 
 
 @rule

--- a/src/python/pants/backend/shell/lint/shellcheck/rules.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/rules.py
@@ -41,13 +41,13 @@ class ShellcheckFieldSet(FieldSet):
 
 class ShellcheckRequest(LintRequest):
     field_set_type = ShellcheckFieldSet
-    tool_name = "Shellcheck"
+    name = "Shellcheck"
 
 
 @rule(desc="Lint with Shellcheck", level=LogLevel.DEBUG)
 async def run_shellcheck(request: ShellcheckRequest, shellcheck: Shellcheck) -> LintResults:
     if shellcheck.skip:
-        return LintResults([], linter_name=request.tool_name)
+        return LintResults([], linter_name=request.name)
 
     # Shellcheck looks at direct dependencies to make sure that every symbol is defined, so we must
     # include those in the run.
@@ -106,7 +106,7 @@ async def run_shellcheck(request: ShellcheckRequest, shellcheck: Shellcheck) -> 
         ),
     )
     result = LintResult.from_fallible_process_result(process_result)
-    return LintResults([result], linter_name=request.tool_name)
+    return LintResults([result], linter_name=request.name)
 
 
 def rules():

--- a/src/python/pants/backend/shell/lint/shellcheck/rules.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/rules.py
@@ -41,12 +41,13 @@ class ShellcheckFieldSet(FieldSet):
 
 class ShellcheckRequest(LintRequest):
     field_set_type = ShellcheckFieldSet
+    tool_name = "Shellcheck"
 
 
 @rule(desc="Lint with Shellcheck", level=LogLevel.DEBUG)
 async def run_shellcheck(request: ShellcheckRequest, shellcheck: Shellcheck) -> LintResults:
     if shellcheck.skip:
-        return LintResults([], linter_name="Shellcheck")
+        return LintResults([], linter_name=request.tool_name)
 
     # Shellcheck looks at direct dependencies to make sure that every symbol is defined, so we must
     # include those in the run.
@@ -105,7 +106,7 @@ async def run_shellcheck(request: ShellcheckRequest, shellcheck: Shellcheck) -> 
         ),
     )
     result = LintResult.from_fallible_process_result(process_result)
-    return LintResults([result], linter_name="Shellcheck")
+    return LintResults([result], linter_name=request.tool_name)
 
 
 def rules():

--- a/src/python/pants/backend/shell/lint/shfmt/rules.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules.py
@@ -34,6 +34,7 @@ class ShfmtFieldSet(FieldSet):
 
 class ShfmtRequest(FmtRequest, LintRequest):
     field_set_type = ShfmtFieldSet
+    tool_name = "shfmt"
 
 
 @dataclass(frozen=True)
@@ -97,21 +98,23 @@ async def setup_shfmt(setup_request: SetupRequest, shfmt: Shfmt) -> Setup:
 @rule(desc="Format with shfmt", level=LogLevel.DEBUG)
 async def shfmt_fmt(request: ShfmtRequest, shfmt: Shfmt) -> FmtResult:
     if shfmt.skip:
-        return FmtResult.skip(formatter_name="shfmt")
+        return FmtResult.skip(formatter_name=request.tool_name)
     setup = await Get(Setup, SetupRequest(request, check_only=False))
     result = await Get(ProcessResult, Process, setup.process)
     return FmtResult.from_process_result(
-        result, original_digest=setup.original_digest, formatter_name="shfmt"
+        result, original_digest=setup.original_digest, formatter_name=request.tool_name
     )
 
 
 @rule(desc="Lint with shfmt", level=LogLevel.DEBUG)
 async def shfmt_lint(request: ShfmtRequest, shfmt: Shfmt) -> LintResults:
     if shfmt.skip:
-        return LintResults([], linter_name="shfmt")
+        return LintResults([], linter_name=request.tool_name)
     setup = await Get(Setup, SetupRequest(request, check_only=True))
     result = await Get(FallibleProcessResult, Process, setup.process)
-    return LintResults([LintResult.from_fallible_process_result(result)], linter_name="shfmt")
+    return LintResults(
+        [LintResult.from_fallible_process_result(result)], linter_name=request.tool_name
+    )
 
 
 def rules():

--- a/src/python/pants/backend/shell/lint/shfmt/rules.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules.py
@@ -34,7 +34,7 @@ class ShfmtFieldSet(FieldSet):
 
 class ShfmtRequest(FmtRequest, LintRequest):
     field_set_type = ShfmtFieldSet
-    tool_name = "shfmt"
+    name = "shfmt"
 
 
 @dataclass(frozen=True)
@@ -98,23 +98,21 @@ async def setup_shfmt(setup_request: SetupRequest, shfmt: Shfmt) -> Setup:
 @rule(desc="Format with shfmt", level=LogLevel.DEBUG)
 async def shfmt_fmt(request: ShfmtRequest, shfmt: Shfmt) -> FmtResult:
     if shfmt.skip:
-        return FmtResult.skip(formatter_name=request.tool_name)
+        return FmtResult.skip(formatter_name=request.name)
     setup = await Get(Setup, SetupRequest(request, check_only=False))
     result = await Get(ProcessResult, Process, setup.process)
     return FmtResult.from_process_result(
-        result, original_digest=setup.original_digest, formatter_name=request.tool_name
+        result, original_digest=setup.original_digest, formatter_name=request.name
     )
 
 
 @rule(desc="Lint with shfmt", level=LogLevel.DEBUG)
 async def shfmt_lint(request: ShfmtRequest, shfmt: Shfmt) -> LintResults:
     if shfmt.skip:
-        return LintResults([], linter_name=request.tool_name)
+        return LintResults([], linter_name=request.name)
     setup = await Get(Setup, SetupRequest(request, check_only=True))
     result = await Get(FallibleProcessResult, Process, setup.process)
-    return LintResults(
-        [LintResult.from_fallible_process_result(result)], linter_name=request.tool_name
-    )
+    return LintResults([LintResult.from_fallible_process_result(result)], linter_name=request.name)
 
 
 def rules():

--- a/src/python/pants/backend/terraform/goals/check.py
+++ b/src/python/pants/backend/terraform/goals/check.py
@@ -37,7 +37,7 @@ class TerraformValidateSubsystem(Subsystem):
 
 class TerraformCheckRequest(CheckRequest):
     field_set_type = TerraformFieldSet
-    tool_name = "terraform validate"
+    name = "terraform validate"
 
 
 @rule
@@ -45,7 +45,7 @@ async def terraform_check(
     request: TerraformCheckRequest, subsystem: TerraformValidateSubsystem
 ) -> CheckResults:
     if subsystem.options.skip:
-        return CheckResults([], checker_name=request.tool_name)
+        return CheckResults([], checker_name=request.name)
 
     setup = await Get(StyleSetup, StyleSetupRequest(request, ("validate",)))
     results = await MultiGet(
@@ -61,7 +61,7 @@ async def terraform_check(
             )
         )
 
-    return CheckResults(check_results, checker_name=request.tool_name)
+    return CheckResults(check_results, checker_name=request.name)
 
 
 def rules():

--- a/src/python/pants/backend/terraform/goals/check.py
+++ b/src/python/pants/backend/terraform/goals/check.py
@@ -37,6 +37,7 @@ class TerraformValidateSubsystem(Subsystem):
 
 class TerraformCheckRequest(CheckRequest):
     field_set_type = TerraformFieldSet
+    tool_name = "terraform validate"
 
 
 @rule
@@ -44,7 +45,7 @@ async def terraform_check(
     request: TerraformCheckRequest, subsystem: TerraformValidateSubsystem
 ) -> CheckResults:
     if subsystem.options.skip:
-        return CheckResults([], checker_name="terraform validate")
+        return CheckResults([], checker_name=request.tool_name)
 
     setup = await Get(StyleSetup, StyleSetupRequest(request, ("validate",)))
     results = await MultiGet(
@@ -60,7 +61,7 @@ async def terraform_check(
             )
         )
 
-    return CheckResults(check_results, checker_name="terraform validate")
+    return CheckResults(check_results, checker_name=request.tool_name)
 
 
 def rules():

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
@@ -41,13 +41,13 @@ class TfFmtSubsystem(Subsystem):
 
 class TffmtRequest(FmtRequest):
     field_set_type = TerraformFieldSet
-    tool_name = "tffmt"
+    name = "tffmt"
 
 
 @rule(desc="Format with `terraform fmt`")
 async def tffmt_fmt(request: TffmtRequest, tffmt: TfFmtSubsystem) -> FmtResult:
     if tffmt.options.skip:
-        return FmtResult.skip(formatter_name=request.tool_name)
+        return FmtResult.skip(formatter_name=request.name)
     setup = await Get(StyleSetup, StyleSetupRequest(request, ("fmt",)))
     results = await MultiGet(
         Get(ProcessResult, TerraformProcess, process)
@@ -80,7 +80,7 @@ async def tffmt_fmt(request: TffmtRequest, tffmt: TfFmtSubsystem) -> FmtResult:
         output=output_digest,
         stdout=stdout_content,
         stderr=stderr_content,
-        formatter_name=request.tool_name,
+        formatter_name=request.name,
     )
     return fmt_result
 
@@ -88,14 +88,14 @@ async def tffmt_fmt(request: TffmtRequest, tffmt: TfFmtSubsystem) -> FmtResult:
 @rule(desc="Lint with `terraform fmt`", level=LogLevel.DEBUG)
 async def tffmt_lint(request: TffmtRequest, tffmt: TfFmtSubsystem) -> LintResults:
     if tffmt.options.skip:
-        return LintResults([], linter_name=request.tool_name)
+        return LintResults([], linter_name=request.name)
     setup = await Get(StyleSetup, StyleSetupRequest(request, ("fmt", "-check")))
     results = await MultiGet(
         Get(FallibleProcessResult, TerraformProcess, process)
         for _, (process, _) in setup.directory_to_process.items()
     )
     lint_results = [LintResult.from_fallible_process_result(result) for result in results]
-    return LintResults(lint_results, linter_name=request.tool_name)
+    return LintResults(lint_results, linter_name=request.name)
 
 
 def rules():

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 class TfFmtSubsystem(Subsystem):
     options_scope = "terraform-fmt"
-    help = """Terraform fmt options."""
+    help = "Terraform fmt options."
 
     @classmethod
     def register_options(cls, register):
@@ -41,12 +41,13 @@ class TfFmtSubsystem(Subsystem):
 
 class TffmtRequest(FmtRequest):
     field_set_type = TerraformFieldSet
+    tool_name = "tffmt"
 
 
 @rule(desc="Format with `terraform fmt`")
 async def tffmt_fmt(request: TffmtRequest, tffmt: TfFmtSubsystem) -> FmtResult:
     if tffmt.options.skip:
-        return FmtResult.skip(formatter_name="tffmt")
+        return FmtResult.skip(formatter_name=request.tool_name)
     setup = await Get(StyleSetup, StyleSetupRequest(request, ("fmt",)))
     results = await MultiGet(
         Get(ProcessResult, TerraformProcess, process)
@@ -79,7 +80,7 @@ async def tffmt_fmt(request: TffmtRequest, tffmt: TfFmtSubsystem) -> FmtResult:
         output=output_digest,
         stdout=stdout_content,
         stderr=stderr_content,
-        formatter_name="tffmt",
+        formatter_name=request.tool_name,
     )
     return fmt_result
 
@@ -87,14 +88,14 @@ async def tffmt_fmt(request: TffmtRequest, tffmt: TfFmtSubsystem) -> FmtResult:
 @rule(desc="Lint with `terraform fmt`", level=LogLevel.DEBUG)
 async def tffmt_lint(request: TffmtRequest, tffmt: TfFmtSubsystem) -> LintResults:
     if tffmt.options.skip:
-        return LintResults([], linter_name="tffmt")
+        return LintResults([], linter_name=request.tool_name)
     setup = await Get(StyleSetup, StyleSetupRequest(request, ("fmt", "-check")))
     results = await MultiGet(
         Get(FallibleProcessResult, TerraformProcess, process)
         for _, (process, _) in setup.directory_to_process.items()
     )
     lint_results = [LintResult.from_fallible_process_result(result) for result in results]
-    return LintResults(lint_results, linter_name="tffmt")
+    return LintResults(lint_results, linter_name=request.tool_name)
 
 
 def rules():

--- a/src/python/pants/core/goals/check.py
+++ b/src/python/pants/core/goals/check.py
@@ -164,7 +164,7 @@ async def check(
         Get(CheckResults, CheckRequest, request) for request in requests if request.field_sets
     )
 
-    def get_tool_name(res: CheckResults) -> str:
+    def get_name(res: CheckResults) -> str:
         return res.checker_name
 
     write_reports(
@@ -172,7 +172,7 @@ async def check(
         workspace,
         dist_dir,
         goal_name=CheckSubsystem.name,
-        get_tool_name=get_tool_name,
+        get_name=get_name,
     )
 
     exit_code = 0

--- a/src/python/pants/core/goals/check_test.py
+++ b/src/python/pants/core/goals/check_test.py
@@ -39,12 +39,12 @@ class MockCheckRequest(CheckRequest, metaclass=ABCMeta):
         addresses = [config.address for config in self.field_sets]
         return CheckResults(
             [CheckResult(self.exit_code(addresses), "", "")],
-            checker_name=self.tool_name,
+            checker_name=self.name,
         )
 
 
 class SuccessfulRequest(MockCheckRequest):
-    tool_name = "SuccessfulChecker"
+    name = "SuccessfulChecker"
 
     @staticmethod
     def exit_code(_: Iterable[Address]) -> int:
@@ -52,7 +52,7 @@ class SuccessfulRequest(MockCheckRequest):
 
 
 class FailingRequest(MockCheckRequest):
-    tool_name = "FailingChecker"
+    name = "FailingChecker"
 
     @staticmethod
     def exit_code(_: Iterable[Address]) -> int:
@@ -60,7 +60,7 @@ class FailingRequest(MockCheckRequest):
 
 
 class ConditionallySucceedsRequest(MockCheckRequest):
-    tool_name = "ConditionallySucceedsChecker"
+    name = "ConditionallySucceedsChecker"
 
     @staticmethod
     def exit_code(addresses: Iterable[Address]) -> int:
@@ -70,7 +70,7 @@ class ConditionallySucceedsRequest(MockCheckRequest):
 
 
 class SkippedRequest(MockCheckRequest):
-    tool_name = "SkippedChecker"
+    name = "SkippedChecker"
 
     @staticmethod
     def exit_code(_) -> int:
@@ -78,7 +78,7 @@ class SkippedRequest(MockCheckRequest):
 
     @property
     def check_results(self) -> CheckResults:
-        return CheckResults([], checker_name=self.tool_name)
+        return CheckResults([], checker_name=self.name)
 
 
 class InvalidField(MultipleSourcesField):
@@ -91,7 +91,7 @@ class InvalidFieldSet(MockCheckFieldSet):
 
 class InvalidRequest(MockCheckRequest):
     field_set_type = InvalidFieldSet
-    tool_name = "InvalidChecker"
+    name = "InvalidChecker"
 
     @staticmethod
     def exit_code(_: Iterable[Address]) -> int:

--- a/src/python/pants/core/goals/check_test.py
+++ b/src/python/pants/core/goals/check_test.py
@@ -4,7 +4,7 @@
 from abc import ABCMeta, abstractmethod
 from pathlib import Path
 from textwrap import dedent
-from typing import ClassVar, Iterable, List, Optional, Tuple, Type
+from typing import Iterable, List, Optional, Tuple, Type
 
 from pants.core.goals.check import Check, CheckRequest, CheckResult, CheckResults, check
 from pants.core.util_rules.distdir import DistDir
@@ -28,7 +28,6 @@ class MockCheckFieldSet(FieldSet):
 
 class MockCheckRequest(CheckRequest, metaclass=ABCMeta):
     field_set_type = MockCheckFieldSet
-    checker_name: ClassVar[str]
 
     @staticmethod
     @abstractmethod
@@ -39,19 +38,13 @@ class MockCheckRequest(CheckRequest, metaclass=ABCMeta):
     def check_results(self) -> CheckResults:
         addresses = [config.address for config in self.field_sets]
         return CheckResults(
-            [
-                CheckResult(
-                    self.exit_code(addresses),
-                    "",
-                    "",
-                )
-            ],
-            checker_name=self.checker_name,
+            [CheckResult(self.exit_code(addresses), "", "")],
+            checker_name=self.tool_name,
         )
 
 
 class SuccessfulRequest(MockCheckRequest):
-    checker_name = "SuccessfulChecker"
+    tool_name = "SuccessfulChecker"
 
     @staticmethod
     def exit_code(_: Iterable[Address]) -> int:
@@ -59,7 +52,7 @@ class SuccessfulRequest(MockCheckRequest):
 
 
 class FailingRequest(MockCheckRequest):
-    checker_name = "FailingChecker"
+    tool_name = "FailingChecker"
 
     @staticmethod
     def exit_code(_: Iterable[Address]) -> int:
@@ -67,7 +60,7 @@ class FailingRequest(MockCheckRequest):
 
 
 class ConditionallySucceedsRequest(MockCheckRequest):
-    checker_name = "ConditionallySucceedsChecker"
+    tool_name = "ConditionallySucceedsChecker"
 
     @staticmethod
     def exit_code(addresses: Iterable[Address]) -> int:
@@ -77,13 +70,15 @@ class ConditionallySucceedsRequest(MockCheckRequest):
 
 
 class SkippedRequest(MockCheckRequest):
+    tool_name = "SkippedChecker"
+
     @staticmethod
     def exit_code(_) -> int:
         return 0
 
     @property
     def check_results(self) -> CheckResults:
-        return CheckResults([], checker_name="SkippedChecker")
+        return CheckResults([], checker_name=self.tool_name)
 
 
 class InvalidField(MultipleSourcesField):
@@ -96,7 +91,7 @@ class InvalidFieldSet(MockCheckFieldSet):
 
 class InvalidRequest(MockCheckRequest):
     field_set_type = InvalidFieldSet
-    checker_name = "InvalidChecker"
+    tool_name = "InvalidChecker"
 
     @staticmethod
     def exit_code(_: Iterable[Address]) -> int:

--- a/src/python/pants/core/goals/fmt_test.py
+++ b/src/python/pants/core/goals/fmt_test.py
@@ -42,6 +42,7 @@ class FortranFieldSet(FieldSet):
 
 class FortranFmtRequest(FmtRequest):
     field_set_type = FortranFieldSet
+    tool_name = "FortranConditionallyDidChange"
 
 
 @rule
@@ -52,11 +53,7 @@ async def fortran_fmt(request: FortranFmtRequest) -> FmtResult:
         else EMPTY_DIGEST
     )
     return FmtResult(
-        input=EMPTY_DIGEST,
-        output=output,
-        stdout="",
-        stderr="",
-        formatter_name="FortranConditionallyDidChange",
+        input=EMPTY_DIGEST, output=output, stdout="", stderr="", formatter_name=request.tool_name
     )
 
 
@@ -78,17 +75,18 @@ class SmalltalkFieldSet(FieldSet):
 
 class SmalltalkNoopRequest(FmtRequest):
     field_set_type = SmalltalkFieldSet
+    tool_name = "SmalltalkDidNotChange"
 
 
 @rule
-async def smalltalk_noop(_: SmalltalkNoopRequest) -> FmtResult:
+async def smalltalk_noop(request: SmalltalkNoopRequest) -> FmtResult:
     result_digest = await Get(Digest, CreateDigest([SMALLTALK_FILE]))
     return FmtResult(
         input=result_digest,
         output=result_digest,
         stdout="",
         stderr="",
-        formatter_name="SmalltalkDidNotChange",
+        formatter_name=request.tool_name,
     )
 
 

--- a/src/python/pants/core/goals/fmt_test.py
+++ b/src/python/pants/core/goals/fmt_test.py
@@ -42,7 +42,7 @@ class FortranFieldSet(FieldSet):
 
 class FortranFmtRequest(FmtRequest):
     field_set_type = FortranFieldSet
-    tool_name = "FortranConditionallyDidChange"
+    name = "FortranConditionallyDidChange"
 
 
 @rule
@@ -53,7 +53,7 @@ async def fortran_fmt(request: FortranFmtRequest) -> FmtResult:
         else EMPTY_DIGEST
     )
     return FmtResult(
-        input=EMPTY_DIGEST, output=output, stdout="", stderr="", formatter_name=request.tool_name
+        input=EMPTY_DIGEST, output=output, stdout="", stderr="", formatter_name=request.name
     )
 
 
@@ -75,7 +75,7 @@ class SmalltalkFieldSet(FieldSet):
 
 class SmalltalkNoopRequest(FmtRequest):
     field_set_type = SmalltalkFieldSet
-    tool_name = "SmalltalkDidNotChange"
+    name = "SmalltalkDidNotChange"
 
 
 @rule
@@ -86,7 +86,7 @@ async def smalltalk_noop(request: SmalltalkNoopRequest) -> FmtResult:
         output=result_digest,
         stdout="",
         stderr="",
-        formatter_name=request.tool_name,
+        formatter_name=request.name,
     )
 
 

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -260,7 +260,7 @@ async def lint(
         )
     )
 
-    def get_tool_name(res: LintResults) -> str:
+    def get_name(res: LintResults) -> str:
         return res.linter_name
 
     write_reports(
@@ -268,7 +268,7 @@ async def lint(
         workspace,
         dist_dir,
         goal_name=LintSubsystem.name,
-        get_tool_name=get_tool_name,
+        get_name=get_name,
     )
 
     exit_code = 0

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -39,13 +39,11 @@ class MockLintRequest(LintRequest, metaclass=ABCMeta):
     @property
     def lint_results(self) -> LintResults:
         addresses = [config.address for config in self.field_sets]
-        return LintResults(
-            [LintResult(self.exit_code(addresses), "", "")], linter_name=self.tool_name
-        )
+        return LintResults([LintResult(self.exit_code(addresses), "", "")], linter_name=self.name)
 
 
 class SuccessfulRequest(MockLintRequest):
-    tool_name = "SuccessfulLinter"
+    name = "SuccessfulLinter"
 
     @staticmethod
     def exit_code(_: Iterable[Address]) -> int:
@@ -53,7 +51,7 @@ class SuccessfulRequest(MockLintRequest):
 
 
 class FailingRequest(MockLintRequest):
-    tool_name = "FailingLinter"
+    name = "FailingLinter"
 
     @staticmethod
     def exit_code(_: Iterable[Address]) -> int:
@@ -61,7 +59,7 @@ class FailingRequest(MockLintRequest):
 
 
 class ConditionallySucceedsRequest(MockLintRequest):
-    tool_name = "ConditionallySucceedsLinter"
+    name = "ConditionallySucceedsLinter"
 
     @staticmethod
     def exit_code(addresses: Iterable[Address]) -> int:
@@ -71,7 +69,7 @@ class ConditionallySucceedsRequest(MockLintRequest):
 
 
 class SkippedRequest(MockLintRequest):
-    tool_name = "SkippedLinter"
+    name = "SkippedLinter"
 
     @staticmethod
     def exit_code(_) -> int:
@@ -79,7 +77,7 @@ class SkippedRequest(MockLintRequest):
 
     @property
     def lint_results(self) -> LintResults:
-        return LintResults([], linter_name=self.tool_name)
+        return LintResults([], linter_name=self.name)
 
 
 class InvalidField(MultipleSourcesField):
@@ -92,7 +90,7 @@ class InvalidFieldSet(MockLinterFieldSet):
 
 class InvalidRequest(MockLintRequest):
     field_set_type = InvalidFieldSet
-    tool_name = "InvalidLinter"
+    name = "InvalidLinter"
 
     @staticmethod
     def exit_code(_: Iterable[Address]) -> int:

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -125,7 +125,7 @@ def run_lint_rule(
                 create_goal_subsystem(
                     LintSubsystem,
                     per_file_caching=per_file_caching,
-                    batch_size=128,
+                    batch_size=batch_size,
                 ),
                 union_membership,
                 DistDir(relpath=Path("dist")),

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -4,7 +4,7 @@
 from abc import ABCMeta, abstractmethod
 from pathlib import Path
 from textwrap import dedent
-from typing import ClassVar, Iterable, List, Optional, Tuple, Type
+from typing import Iterable, List, Optional, Tuple, Type
 
 import pytest
 
@@ -30,7 +30,6 @@ class MockLinterFieldSet(FieldSet):
 
 class MockLintRequest(LintRequest, metaclass=ABCMeta):
     field_set_type = MockLinterFieldSet
-    linter_name: ClassVar[str]
 
     @staticmethod
     @abstractmethod
@@ -41,12 +40,12 @@ class MockLintRequest(LintRequest, metaclass=ABCMeta):
     def lint_results(self) -> LintResults:
         addresses = [config.address for config in self.field_sets]
         return LintResults(
-            [LintResult(self.exit_code(addresses), "", "")], linter_name=self.linter_name
+            [LintResult(self.exit_code(addresses), "", "")], linter_name=self.tool_name
         )
 
 
 class SuccessfulRequest(MockLintRequest):
-    linter_name = "SuccessfulLinter"
+    tool_name = "SuccessfulLinter"
 
     @staticmethod
     def exit_code(_: Iterable[Address]) -> int:
@@ -54,7 +53,7 @@ class SuccessfulRequest(MockLintRequest):
 
 
 class FailingRequest(MockLintRequest):
-    linter_name = "FailingLinter"
+    tool_name = "FailingLinter"
 
     @staticmethod
     def exit_code(_: Iterable[Address]) -> int:
@@ -62,7 +61,7 @@ class FailingRequest(MockLintRequest):
 
 
 class ConditionallySucceedsRequest(MockLintRequest):
-    linter_name = "ConditionallySucceedsLinter"
+    tool_name = "ConditionallySucceedsLinter"
 
     @staticmethod
     def exit_code(addresses: Iterable[Address]) -> int:
@@ -72,13 +71,15 @@ class ConditionallySucceedsRequest(MockLintRequest):
 
 
 class SkippedRequest(MockLintRequest):
+    tool_name = "SkippedLinter"
+
     @staticmethod
     def exit_code(_) -> int:
         return 0
 
     @property
     def lint_results(self) -> LintResults:
-        return LintResults([], linter_name="SkippedLinter")
+        return LintResults([], linter_name=self.tool_name)
 
 
 class InvalidField(MultipleSourcesField):
@@ -91,7 +92,7 @@ class InvalidFieldSet(MockLinterFieldSet):
 
 class InvalidRequest(MockLintRequest):
     field_set_type = InvalidFieldSet
-    linter_name = "InvalidLinter"
+    tool_name = "InvalidLinter"
 
     @staticmethod
     def exit_code(_: Iterable[Address]) -> int:

--- a/src/python/pants/core/goals/style_request.py
+++ b/src/python/pants/core/goals/style_request.py
@@ -54,7 +54,7 @@ class StyleRequest(Generic[_FS], EngineAwareParameter, metaclass=ABCMeta):
     """
 
     field_set_type: ClassVar[type[_FS]]
-    tool_name: ClassVar[str]
+    name: ClassVar[str]
 
     field_sets: Collection[_FS]
     # TODO: Move this onto `FmtRequest`.
@@ -70,7 +70,7 @@ class StyleRequest(Generic[_FS], EngineAwareParameter, metaclass=ABCMeta):
         self.prior_formatter_result = prior_formatter_result
 
     def debug_hint(self) -> str:
-        return self.tool_name
+        return self.name
 
     def metadata(self) -> dict[str, Any]:
         return {"addresses": [fs.address.spec for fs in self.field_sets]}
@@ -101,7 +101,7 @@ def write_reports(
     dist_dir: DistDir,
     *,
     goal_name: str,
-    get_tool_name: Callable[[_R], str],
+    get_name: Callable[[_R], str],
 ) -> None:
     disambiguated_dirs: set[str] = set()
 
@@ -116,7 +116,7 @@ def write_reports(
         logger.info(f"Wrote {goal_name} report files to {output_dir}.")
 
     for results in all_results:
-        tool_name = get_tool_name(results).lower()  # type: ignore[arg-type]
+        tool_name = get_name(results).lower()  # type: ignore[arg-type]
         if len(results.results) == 1 and results.results[0].report != EMPTY_DIGEST:
             write_report(results.results[0].report, tool_name)
         else:

--- a/src/python/pants/core/goals/style_request.py
+++ b/src/python/pants/core/goals/style_request.py
@@ -54,6 +54,7 @@ class StyleRequest(Generic[_FS], EngineAwareParameter, metaclass=ABCMeta):
     """
 
     field_set_type: ClassVar[type[_FS]]
+    tool_name: ClassVar[str]
 
     field_sets: Collection[_FS]
     # TODO: Move this onto `FmtRequest`.
@@ -67,6 +68,9 @@ class StyleRequest(Generic[_FS], EngineAwareParameter, metaclass=ABCMeta):
     ) -> None:
         self.field_sets = Collection[_FS](field_sets)
         self.prior_formatter_result = prior_formatter_result
+
+    def debug_hint(self) -> str:
+        return self.tool_name
 
     def metadata(self) -> dict[str, Any]:
         return {"addresses": [fs.address.spec for fs in self.field_sets]}

--- a/src/python/pants/core/goals/style_request_test.py
+++ b/src/python/pants/core/goals/style_request_test.py
@@ -36,7 +36,7 @@ def test_write_reports() -> None:
         checker_name="partition_duplicate",
     )
 
-    def get_tool_name(res: CheckResults) -> str:
+    def get_name(res: CheckResults) -> str:
         return res.checker_name
 
     write_reports(
@@ -51,7 +51,7 @@ def test_write_reports() -> None:
         Workspace(rule_runner.scheduler, _enforce_effects=False),
         DistDir(Path("dist")),
         goal_name="check",
-        get_tool_name=get_tool_name,
+        get_name=get_name,
     )
 
     check_dir = Path(rule_runner.build_root, "dist", "check")


### PR DESCRIPTION
This will be necessary for us to add `lint --only=isort` and so on. To do that, we need to know _before_ executing any requests what the name of each tool is, so that we can then match it against 

I at first called this `tool_request`, but realized a plugin might not always be a "tool", like `regex-lint` (aka `validate`) which is in-memory. Simply `name` seems the most flexible.

I originally also renamed `FmtResult(formatter_name=)` to be `name=` for parity, but I reverted it to reduce churn for Plugin developers. That is still probably a good change to do, but we could do it more gracefully with a deprecation warning. It's low priority either way.

[ci skip-build-wheels]