### PR TITLE
Fix executability of materialized files for non-owners. (cherrypick of #14298)

### DIFF
--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -978,9 +978,9 @@ impl Store {
           let path = destination.join(file_node.name.clone());
           let digest = try_future!(require_digest(file_node.digest.as_ref()));
           let mode = match perms {
-            Permissions::ReadOnly if file_node.is_executable => 0o544,
+            Permissions::ReadOnly if file_node.is_executable => 0o555,
             Permissions::ReadOnly => 0o444,
-            Permissions::Writable if file_node.is_executable => 0o744,
+            Permissions::Writable if file_node.is_executable => 0o755,
             Permissions::Writable => 0o644,
           };
           store.materialize_file(path, digest, mode).boxed()


### PR DESCRIPTION
As reported in #14280, #13857 removed the executable bit for non-owners of a file. This change restores it (and expands the test to note a subtlety of the default umask on macOS).

Fixes #14280.

[ci skip-build-wheels]