### PR TITLE
Add `fmt --style-only` to avoid semantic changes like PyUpgrade and Autoflake

### DIFF
--- a/src/python/pants/backend/python/lint/autoflake/rules.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules.py
@@ -36,7 +36,7 @@ class AutoflakeFieldSet(FieldSet):
 class AutoflakeRequest(FmtRequest, LintRequest):
     field_set_type = AutoflakeFieldSet
     name = "autoflake"
-    fixer = True
+    makes_semantic_changes = True
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/lint/autoflake/rules.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules.py
@@ -36,6 +36,7 @@ class AutoflakeFieldSet(FieldSet):
 class AutoflakeRequest(FmtRequest, LintRequest):
     field_set_type = AutoflakeFieldSet
     name = "autoflake"
+    fixer = True
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/lint/pyupgrade/rules.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/rules.py
@@ -35,7 +35,7 @@ class PyUpgradeFieldSet(FieldSet):
 class PyUpgradeRequest(FmtRequest, LintRequest):
     field_set_type = PyUpgradeFieldSet
     name = "pyupgrade"
-    fixer = True
+    makes_semantic_changes = True
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/lint/pyupgrade/rules.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/rules.py
@@ -35,6 +35,7 @@ class PyUpgradeFieldSet(FieldSet):
 class PyUpgradeRequest(FmtRequest, LintRequest):
     field_set_type = PyUpgradeFieldSet
     name = "pyupgrade"
+    fixer = True
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
First part of https://github.com/pantsbuild/pants/issues/13504.

We believe there is a meaningful distinction for formatters that make semantic changes, such as removing imports (Autoflake) and upgrading syntax (PyUpgrade). It is desirable to let users easily run "safe" formatters without the semantic changing ones. Using `--pyupgrade-skip` or the upcoming `--fmt-only` is not acceptable, as it's too verbose.

At the same time, we want to avoid a proliferation of goals, what one user calls "command creep": https://github.com/pantsbuild/pants/issues/13504#issuecomment-1002723800. Per that ticket, we're likely going to rename `fmt` to be `fix`, rather than having both `fmt` and `fix`.

This tries to get the benefits of both. By default, we run all formatters with `fmt`. If you aren't ready for semantic changes, you can use `./pants fmt --style-only`.

## `tailor` & `update-build-files`

Everyone agrees that `tailor` and `update-build-files` should merge. It's also been proposed that we merge that with `fmt` (renamed to `fix`)

This would be very challenging to do, regardless of `fmt` vs `fix` being distinct goals. Because `tailor` adds new targets, that means that it can impact the behavior of target-aware formatters: which means that it _must_ run before any of those formatters.

There is a far simpler solution to that:

- `fix` is for strictly user code
- `tailor` or `pants-meta` etc is for strictly Pants metadata files (including pants.toml)

I think there are benefits to that split. It's much rarer that you need to touch Pants metadata files; you shouldn't be hand editing them frequently, and you only need to generate new targets generally when adding new _directories_, not even new files thanks to `*` globs for `sources`. Splitting avoids wasted performance when running `./pants --changed-since=HEAD fix`.

[ci skip-rust]
[ci skip-build-wheels]