### PR TITLE
Graduate Docker backend from experimental status.

### DIFF
--- a/build-support/bin/_generate_all_lockfiles_helper.py
+++ b/build-support/bin/_generate_all_lockfiles_helper.py
@@ -109,7 +109,7 @@ AllTools = (
     DefaultTool.python(PyTest),
     DefaultTool.python(CoverageSubsystem),
     DefaultTool.python(TerraformHcl2Parser, backend="pants.backend.experimental.terraform"),
-    DefaultTool.python(DockerfileParser, backend="pants.backend.experimental.docker"),
+    DefaultTool.python(DockerfileParser, backend="pants.backend.docker"),
     DefaultTool.python(TwineSubsystem),
     # JVM
     DefaultTool.jvm(JUnit),

--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -203,8 +203,8 @@ def run_pants_help_all() -> dict[str, Any]:
     backends = [
         "pants.backend.awslambda.python",
         "pants.backend.codegen.protobuf.python",
+        "pants.backend.docker",
         "pants.backend.experimental.codegen.thrift.apache.python",
-        "pants.backend.experimental.docker",
         "pants.backend.experimental.docker.lint.hadolint",
         "pants.backend.experimental.go",
         "pants.backend.experimental.java",

--- a/pants.toml
+++ b/pants.toml
@@ -15,7 +15,7 @@ backend_packages.add = [
   "pants.backend.shell",
   "pants.backend.shell.lint.shellcheck",
   "pants.backend.shell.lint.shfmt",
-  "pants.backend.experimental.docker",
+  "pants.backend.docker",
   "pants.backend.experimental.docker.lint.hadolint",
   "pants.backend.experimental.go",
   "pants.backend.experimental.java",

--- a/src/python/pants/backend/docker/goals/run_image_integration_test.py
+++ b/src/python/pants/backend/docker/goals/run_image_integration_test.py
@@ -12,7 +12,7 @@ def run_pants_with_sources(sources: dict[str, str], *args: str) -> PantsResult:
     with setup_tmpdir(sources) as tmpdir:
         return run_pants(
             [
-                "--backend-packages=pants.backend.experimental.docker",
+                "--backend-packages=pants.backend.docker",
                 "--pants-ignore=__pycache__",
             ]
             + [arg.format(tmpdir=tmpdir) for arg in args]

--- a/src/python/pants/backend/docker/register.py
+++ b/src/python/pants/backend/docker/register.py
@@ -1,0 +1,21 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.backend.codegen import export_codegen_goal
+from pants.backend.docker.goals.tailor import rules as tailor_rules
+from pants.backend.docker.rules import rules as docker_rules
+from pants.backend.docker.target_types import DockerImageTarget
+from pants.backend.python.util_rules.pex import rules as pex_rules
+
+
+def rules():
+    return (
+        *docker_rules(),
+        *export_codegen_goal.rules(),
+        *pex_rules(),
+        *tailor_rules(),
+    )
+
+
+def target_types():
+    return (DockerImageTarget,)

--- a/src/python/pants/backend/experimental/docker/register.py
+++ b/src/python/pants/backend/experimental/docker/register.py
@@ -1,21 +1,17 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.codegen import export_codegen_goal
-from pants.backend.docker.goals.tailor import rules as tailor_rules
-from pants.backend.docker.rules import rules as docker_rules
-from pants.backend.docker.target_types import DockerImageTarget
-from pants.backend.python.util_rules.pex import rules as pex_rules
+from pants.backend.docker import register
+from pants.base.deprecated import deprecated
 
 
+@deprecated(
+    "2.11.0.dev0",
+    "The `pants.backend.experimental.docker` backend has graduated. Use `pants.backend.docker` instead.",
+)
 def rules():
-    return (
-        *docker_rules(),
-        *export_codegen_goal.rules(),
-        *pex_rules(),
-        *tailor_rules(),
-    )
+    return register.rules()
 
 
 def target_types():
-    return (DockerImageTarget,)
+    return register.target_types()

--- a/src/python/pants/init/BUILD
+++ b/src/python/pants/init/BUILD
@@ -9,6 +9,7 @@ target(
     dependencies=[
         "src/python/pants/backend/awslambda/python",
         "src/python/pants/backend/codegen/protobuf/python",
+        "src/python/pants/backend/docker",
         "src/python/pants/backend/experimental/codegen/avro/java",
         "src/python/pants/backend/experimental/codegen/protobuf/java",
         "src/python/pants/backend/experimental/codegen/protobuf/scala",
@@ -17,7 +18,6 @@ target(
         "src/python/pants/backend/experimental/codegen/thrift/scrooge/java",
         "src/python/pants/backend/experimental/codegen/thrift/scrooge/scala",
         "src/python/pants/backend/experimental/debian",
-        "src/python/pants/backend/experimental/docker",
         "src/python/pants/backend/experimental/docker/lint/hadolint",
         "src/python/pants/backend/experimental/go",
         "src/python/pants/backend/experimental/go/lint/vet",

--- a/src/python/pants/init/BUILD
+++ b/src/python/pants/init/BUILD
@@ -18,6 +18,7 @@ target(
         "src/python/pants/backend/experimental/codegen/thrift/scrooge/java",
         "src/python/pants/backend/experimental/codegen/thrift/scrooge/scala",
         "src/python/pants/backend/experimental/debian",
+        "src/python/pants/backend/experimental/docker",
         "src/python/pants/backend/experimental/docker/lint/hadolint",
         "src/python/pants/backend/experimental/go",
         "src/python/pants/backend/experimental/go/lint/vet",


### PR DESCRIPTION
The Docker backend was introduced in Pantsbuild 2.7.0. It is now proven to be a functional backend for many common Docker use cases.