### PR TITLE
Rename `LintRequest` to `LintTargetsRequest`

### DIFF
--- a/src/python/pants/backend/docker/lint/hadolint/rules.py
+++ b/src/python/pants/backend/docker/lint/hadolint/rules.py
@@ -8,7 +8,7 @@ from pants.backend.docker.lint.hadolint.skip_field import SkipHadolintField
 from pants.backend.docker.lint.hadolint.subsystem import Hadolint
 from pants.backend.docker.subsystems.dockerfile_parser import DockerfileInfo, DockerfileInfoRequest
 from pants.backend.docker.target_types import DockerImageSourceField
-from pants.core.goals.lint import LintRequest, LintResult, LintResults
+from pants.core.goals.lint import LintResult, LintResults, LintTargetsRequest
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.engine.fs import Digest, MergeDigests
@@ -32,7 +32,7 @@ class HadolintFieldSet(FieldSet):
         return tgt.get(SkipHadolintField).value
 
 
-class HadolintRequest(LintRequest):
+class HadolintRequest(LintTargetsRequest):
     field_set_type = HadolintFieldSet
     name = "Hadolint"
 
@@ -104,5 +104,5 @@ async def run_hadolint(request: HadolintRequest, hadolint: Hadolint) -> LintResu
 def rules():
     return [
         *collect_rules(),
-        UnionRule(LintRequest, HadolintRequest),
+        UnionRule(LintTargetsRequest, HadolintRequest),
     ]

--- a/src/python/pants/backend/go/lint/gofmt/rules.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules.py
@@ -13,7 +13,7 @@ from pants.backend.go.subsystems import golang
 from pants.backend.go.subsystems.golang import GoRoot
 from pants.backend.go.target_types import GoPackageSourcesField
 from pants.core.goals.fmt import FmtRequest, FmtResult
-from pants.core.goals.lint import LintRequest, LintResult, LintResults
+from pants.core.goals.lint import LintResult, LintResults, LintTargetsRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest
 from pants.engine.internals.selectors import Get
@@ -114,5 +114,5 @@ def rules():
         *collect_rules(),
         *golang.rules(),
         UnionRule(FmtRequest, GofmtRequest),
-        UnionRule(LintRequest, GofmtRequest),
+        UnionRule(LintTargetsRequest, GofmtRequest),
     ]

--- a/src/python/pants/backend/go/lint/vet/rules.py
+++ b/src/python/pants/backend/go/lint/vet/rules.py
@@ -16,7 +16,7 @@ from pants.backend.go.util_rules.go_mod import (
     OwningGoModRequest,
 )
 from pants.backend.go.util_rules.sdk import GoSdkProcess
-from pants.core.goals.lint import LintRequest, LintResult, LintResults
+from pants.core.goals.lint import LintResult, LintResults, LintTargetsRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.internals.selectors import Get, MultiGet
@@ -39,7 +39,7 @@ class GoVetFieldSet(FieldSet):
         return tgt.get(SkipGoVetField).value
 
 
-class GoVetRequest(LintRequest):
+class GoVetRequest(LintTargetsRequest):
     field_set_type = GoVetFieldSet
     name = "go vet"
 
@@ -87,5 +87,5 @@ async def run_go_vet(request: GoVetRequest, go_vet_subsystem: GoVetSubsystem) ->
 def rules():
     return [
         *collect_rules(),
-        UnionRule(LintRequest, GoVetRequest),
+        UnionRule(LintTargetsRequest, GoVetRequest),
     ]

--- a/src/python/pants/backend/java/lint/google_java_format/rules.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules.py
@@ -9,7 +9,7 @@ from pants.backend.java.lint.google_java_format.subsystem import GoogleJavaForma
 from pants.backend.java.target_types import JavaSourceField
 from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
-from pants.core.goals.lint import LintRequest, LintResult, LintResults
+from pants.core.goals.lint import LintResult, LintResults, LintTargetsRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest
 from pants.engine.internals.selectors import Get, MultiGet
@@ -38,7 +38,7 @@ class GoogleJavaFormatFieldSet(FieldSet):
         return tgt.get(SkipGoogleJavaFormatField).value
 
 
-class GoogleJavaFormatRequest(FmtRequest, LintRequest):
+class GoogleJavaFormatRequest(FmtRequest, LintTargetsRequest):
     field_set_type = GoogleJavaFormatFieldSet
     name = "Google Java Format"
 
@@ -168,6 +168,6 @@ def rules():
         *collect_rules(),
         *jvm_tool.rules(),
         UnionRule(FmtRequest, GoogleJavaFormatRequest),
-        UnionRule(LintRequest, GoogleJavaFormatRequest),
+        UnionRule(LintTargetsRequest, GoogleJavaFormatRequest),
         UnionRule(GenerateToolLockfileSentinel, GoogleJavaFormatToolLockfileSentinel),
     ]

--- a/src/python/pants/backend/python/lint/autoflake/rules.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules.py
@@ -10,7 +10,7 @@ from pants.backend.python.target_types import InterpreterConstraintsField, Pytho
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtRequest, FmtResult
-from pants.core.goals.lint import LintRequest, LintResult, LintResults
+from pants.core.goals.lint import LintResult, LintResults, LintTargetsRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
@@ -33,7 +33,7 @@ class AutoflakeFieldSet(FieldSet):
         return tgt.get(SkipAutoflakeField).value
 
 
-class AutoflakeRequest(FmtRequest, LintRequest):
+class AutoflakeRequest(FmtRequest, LintTargetsRequest):
     field_set_type = AutoflakeFieldSet
     name = "autoflake"
 
@@ -143,6 +143,6 @@ def rules():
     return [
         *collect_rules(),
         UnionRule(FmtRequest, AutoflakeRequest),
-        UnionRule(LintRequest, AutoflakeRequest),
+        UnionRule(LintTargetsRequest, AutoflakeRequest),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -9,7 +9,7 @@ from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
-from pants.core.goals.lint import REPORT_DIR, LintRequest, LintResult, LintResults
+from pants.core.goals.lint import REPORT_DIR, LintResult, LintResults, LintTargetsRequest
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import CreateDigest, Digest, Directory, MergeDigests, RemovePrefix
@@ -20,7 +20,7 @@ from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
 
 
-class BanditRequest(LintRequest):
+class BanditRequest(LintTargetsRequest):
     field_set_type = BanditFieldSet
     name = "Bandit"
 
@@ -113,4 +113,4 @@ async def bandit_lint(
 
 
 def rules():
-    return [*collect_rules(), UnionRule(LintRequest, BanditRequest), *pex.rules()]
+    return [*collect_rules(), UnionRule(LintTargetsRequest, BanditRequest), *pex.rules()]

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -12,7 +12,7 @@ from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtRequest, FmtResult
-from pants.core.goals.lint import LintRequest, LintResult, LintResults
+from pants.core.goals.lint import LintResult, LintResults, LintTargetsRequest
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, MergeDigests
@@ -36,7 +36,7 @@ class BlackFieldSet(FieldSet):
         return tgt.get(SkipBlackField).value
 
 
-class BlackRequest(FmtRequest, LintRequest):
+class BlackRequest(FmtRequest, LintTargetsRequest):
     field_set_type = BlackFieldSet
     name = "Black"
 
@@ -164,6 +164,6 @@ def rules():
     return [
         *collect_rules(),
         UnionRule(FmtRequest, BlackRequest),
-        UnionRule(LintRequest, BlackRequest),
+        UnionRule(LintTargetsRequest, BlackRequest),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -10,7 +10,7 @@ from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtRequest, FmtResult
-from pants.core.goals.lint import LintRequest, LintResult, LintResults
+from pants.core.goals.lint import LintResult, LintResults, LintTargetsRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
@@ -32,7 +32,7 @@ class DocformatterFieldSet(FieldSet):
         return tgt.get(SkipDocformatterField).value
 
 
-class DocformatterRequest(FmtRequest, LintRequest):
+class DocformatterRequest(FmtRequest, LintTargetsRequest):
     field_set_type = DocformatterFieldSet
     name = "Docformatter"
 
@@ -126,6 +126,6 @@ def rules():
     return [
         *collect_rules(),
         UnionRule(FmtRequest, DocformatterRequest),
-        UnionRule(LintRequest, DocformatterRequest),
+        UnionRule(LintTargetsRequest, DocformatterRequest),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -14,7 +14,7 @@ from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
-from pants.core.goals.lint import REPORT_DIR, LintRequest, LintResult, LintResults
+from pants.core.goals.lint import REPORT_DIR, LintResult, LintResults, LintTargetsRequest
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import CreateDigest, Digest, Directory, MergeDigests, RemovePrefix
@@ -25,7 +25,7 @@ from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
 
 
-class Flake8Request(LintRequest):
+class Flake8Request(LintTargetsRequest):
     field_set_type = Flake8FieldSet
     name = "Flake8"
 
@@ -138,4 +138,4 @@ async def flake8_lint(
 
 
 def rules():
-    return [*collect_rules(), UnionRule(LintRequest, Flake8Request), *pex.rules()]
+    return [*collect_rules(), UnionRule(LintTargetsRequest, Flake8Request), *pex.rules()]

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -10,7 +10,7 @@ from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, PexResolveInfo, VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtRequest, FmtResult
-from pants.core.goals.lint import LintRequest, LintResult, LintResults
+from pants.core.goals.lint import LintResult, LintResults, LintTargetsRequest
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, MergeDigests
@@ -33,7 +33,7 @@ class IsortFieldSet(FieldSet):
         return tgt.get(SkipIsortField).value
 
 
-class IsortRequest(FmtRequest, LintRequest):
+class IsortRequest(FmtRequest, LintTargetsRequest):
     field_set_type = IsortFieldSet
     name = "isort"
 
@@ -162,6 +162,6 @@ def rules():
     return [
         *collect_rules(),
         UnionRule(FmtRequest, IsortRequest),
-        UnionRule(LintRequest, IsortRequest),
+        UnionRule(LintTargetsRequest, IsortRequest),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -26,7 +26,7 @@ from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
     PythonSourceFilesRequest,
 )
-from pants.core.goals.lint import REPORT_DIR, LintRequest, LintResult, LintResults
+from pants.core.goals.lint import REPORT_DIR, LintResult, LintResults, LintTargetsRequest
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Addresses
@@ -69,7 +69,7 @@ class PylintPartition:
         self.interpreter_constraints = interpreter_constraints
 
 
-class PylintRequest(LintRequest):
+class PylintRequest(LintTargetsRequest):
     field_set_type = PylintFieldSet
     name = "Pylint"
 
@@ -254,6 +254,6 @@ async def pylint_lint(
 def rules():
     return [
         *collect_rules(),
-        UnionRule(LintRequest, PylintRequest),
+        UnionRule(LintTargetsRequest, PylintRequest),
         *pex_from_targets.rules(),
     ]

--- a/src/python/pants/backend/python/lint/pyupgrade/rules.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/rules.py
@@ -10,7 +10,7 @@ from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtRequest, FmtResult
-from pants.core.goals.lint import LintRequest, LintResult, LintResults
+from pants.core.goals.lint import LintResult, LintResults, LintTargetsRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest
 from pants.engine.process import FallibleProcessResult
@@ -32,7 +32,7 @@ class PyUpgradeFieldSet(FieldSet):
         return tgt.get(SkipPyUpgradeField).value
 
 
-class PyUpgradeRequest(FmtRequest, LintRequest):
+class PyUpgradeRequest(FmtRequest, LintTargetsRequest):
     field_set_type = PyUpgradeFieldSet
     name = "pyupgrade"
 
@@ -107,6 +107,6 @@ def rules():
     return [
         *collect_rules(),
         UnionRule(FmtRequest, PyUpgradeRequest),
-        UnionRule(LintRequest, PyUpgradeRequest),
+        UnionRule(LintTargetsRequest, PyUpgradeRequest),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/python/lint/yapf/rules.py
+++ b/src/python/pants/backend/python/lint/yapf/rules.py
@@ -10,7 +10,7 @@ from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtRequest, FmtResult
-from pants.core.goals.lint import LintRequest, LintResult, LintResults
+from pants.core.goals.lint import LintResult, LintResults, LintTargetsRequest
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, MergeDigests
@@ -33,7 +33,7 @@ class YapfFieldSet(FieldSet):
         return tgt.get(SkipYapfField).value
 
 
-class YapfRequest(FmtRequest, LintRequest):
+class YapfRequest(FmtRequest, LintTargetsRequest):
     field_set_type = YapfFieldSet
     name = "yapf"
 
@@ -144,6 +144,6 @@ def rules():
     return [
         *collect_rules(),
         UnionRule(FmtRequest, YapfRequest),
-        UnionRule(LintRequest, YapfRequest),
+        UnionRule(LintTargetsRequest, YapfRequest),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -13,7 +13,7 @@ from pants.backend.scala.target_types import ScalaSourceField
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
-from pants.core.goals.lint import LintRequest, LintResult, LintResults
+from pants.core.goals.lint import LintResult, LintResults, LintTargetsRequest
 from pants.core.goals.tailor import group_by_dir
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import (
@@ -51,7 +51,7 @@ class ScalafmtFieldSet(FieldSet):
         return tgt.get(SkipScalafmtField).value
 
 
-class ScalafmtRequest(FmtRequest, LintRequest):
+class ScalafmtRequest(FmtRequest, LintTargetsRequest):
     field_set_type = ScalafmtFieldSet
     name = "scalafmt"
 
@@ -315,6 +315,6 @@ def rules():
         *collect_rules(),
         *lockfile.rules(),
         UnionRule(FmtRequest, ScalafmtRequest),
-        UnionRule(LintRequest, ScalafmtRequest),
+        UnionRule(LintTargetsRequest, ScalafmtRequest),
         UnionRule(GenerateToolLockfileSentinel, ScalafmtToolLockfileSentinel),
     ]

--- a/src/python/pants/backend/shell/lint/shellcheck/rules.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/rules.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pants.backend.shell.lint.shellcheck.skip_field import SkipShellcheckField
 from pants.backend.shell.lint.shellcheck.subsystem import Shellcheck
 from pants.backend.shell.target_types import ShellSourceField
-from pants.core.goals.lint import LintRequest, LintResult, LintResults
+from pants.core.goals.lint import LintResult, LintResults, LintTargetsRequest
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
@@ -39,7 +39,7 @@ class ShellcheckFieldSet(FieldSet):
         return tgt.get(SkipShellcheckField).value
 
 
-class ShellcheckRequest(LintRequest):
+class ShellcheckRequest(LintTargetsRequest):
     field_set_type = ShellcheckFieldSet
     name = "Shellcheck"
 
@@ -110,4 +110,4 @@ async def run_shellcheck(request: ShellcheckRequest, shellcheck: Shellcheck) -> 
 
 
 def rules():
-    return [*collect_rules(), UnionRule(LintRequest, ShellcheckRequest)]
+    return [*collect_rules(), UnionRule(LintTargetsRequest, ShellcheckRequest)]

--- a/src/python/pants/backend/shell/lint/shfmt/rules.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules.py
@@ -7,7 +7,7 @@ from pants.backend.shell.lint.shfmt.skip_field import SkipShfmtField
 from pants.backend.shell.lint.shfmt.subsystem import Shfmt
 from pants.backend.shell.target_types import ShellSourceField
 from pants.core.goals.fmt import FmtRequest, FmtResult
-from pants.core.goals.lint import LintRequest, LintResult, LintResults
+from pants.core.goals.lint import LintResult, LintResults, LintTargetsRequest
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
@@ -32,7 +32,7 @@ class ShfmtFieldSet(FieldSet):
         return tgt.get(SkipShfmtField).value
 
 
-class ShfmtRequest(FmtRequest, LintRequest):
+class ShfmtRequest(FmtRequest, LintTargetsRequest):
     field_set_type = ShfmtFieldSet
     name = "shfmt"
 
@@ -119,5 +119,5 @@ def rules():
     return [
         *collect_rules(),
         UnionRule(FmtRequest, ShfmtRequest),
-        UnionRule(LintRequest, ShfmtRequest),
+        UnionRule(LintTargetsRequest, ShfmtRequest),
     ]

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
@@ -8,7 +8,7 @@ from pants.backend.terraform.target_types import TerraformFieldSet
 from pants.backend.terraform.tool import TerraformProcess
 from pants.backend.terraform.tool import rules as tool_rules
 from pants.core.goals.fmt import FmtRequest, FmtResult
-from pants.core.goals.lint import LintRequest, LintResult, LintResults
+from pants.core.goals.lint import LintResult, LintResults, LintTargetsRequest
 from pants.core.util_rules import external_tool
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.internals.selectors import Get, MultiGet
@@ -103,6 +103,6 @@ def rules():
         *collect_rules(),
         *external_tool.rules(),
         *tool_rules(),
-        UnionRule(LintRequest, TffmtRequest),
+        UnionRule(LintTargetsRequest, TffmtRequest),
         UnionRule(FmtRequest, TffmtRequest),
     ]

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -11,10 +11,10 @@ import pytest
 from pants.core.goals.lint import (
     Lint,
     LintFilesRequest,
-    LintRequest,
     LintResult,
     LintResults,
     LintSubsystem,
+    LintTargetsRequest,
     lint,
 )
 from pants.core.util_rules.distdir import DistDir
@@ -36,7 +36,7 @@ class MockLinterFieldSet(FieldSet):
     required_fields = (MultipleSourcesField,)
 
 
-class MockLintRequest(LintRequest, metaclass=ABCMeta):
+class MockLintRequest(LintTargetsRequest, metaclass=ABCMeta):
     field_set_type = MockLinterFieldSet
 
     @staticmethod
@@ -125,7 +125,7 @@ def make_target(address: Optional[Address] = None) -> Target:
 def run_lint_rule(
     rule_runner: RuleRunner,
     *,
-    lint_request_types: List[Type[LintRequest]],
+    lint_request_types: List[Type[LintTargetsRequest]],
     targets: List[Target],
     run_files_linter: bool = False,
     per_file_caching: bool = False,
@@ -133,7 +133,7 @@ def run_lint_rule(
 ) -> Tuple[int, str]:
     union_membership = UnionMembership(
         {
-            LintRequest: lint_request_types,
+            LintTargetsRequest: lint_request_types,
             LintFilesRequest: [MockFilesRequest] if run_files_linter else [],
         }
     )
@@ -158,7 +158,7 @@ def run_lint_rule(
             mock_gets=[
                 MockGet(
                     output_type=LintResults,
-                    input_type=LintRequest,
+                    input_type=LintTargetsRequest,
                     mock=lambda mock_request: mock_request.lint_results,
                 ),
                 MockGet(


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/14102 added `LintFilesRequest`, so now `LintRequest` is poorly named.

I don't yet rename `FmtRequest` to `FmtTargetsRequest` because that API is still in flux until we figure out how to safely have target-less formatters. No need to rename `CheckRequest` because we need dependencies information there, so we will need targets (possibly inferred).

[ci skip-rust]
[ci skip-build-wheels]