### PR TITLE
`ReplImplementation` now passes root targets, not transitive closure

### DIFF
--- a/src/python/pants/backend/python/goals/repl.py
+++ b/src/python/pants/backend/python/goals/repl.py
@@ -16,9 +16,9 @@ from pants.backend.python.util_rules.python_sources import (
     PythonSourceFilesRequest,
 )
 from pants.core.goals.repl import ReplImplementation, ReplRequest
-from pants.engine.addresses import Addresses
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.target import TransitiveTargets, TransitiveTargetsRequest
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 
@@ -28,25 +28,24 @@ class PythonRepl(ReplImplementation):
 
 
 @rule(level=LogLevel.DEBUG)
-async def create_python_repl_request(repl: PythonRepl, pex_env: PexEnvironment) -> ReplRequest:
-
-    addresses = tuple(tgt.address for tgt in repl.targets)
-    interpreter_constraints = await Get(
-        InterpreterConstraints, InterpreterConstraintsRequest(addresses)
+async def create_python_repl_request(request: PythonRepl, pex_env: PexEnvironment) -> ReplRequest:
+    interpreter_constraints, transitive_targets = await MultiGet(
+        Get(InterpreterConstraints, InterpreterConstraintsRequest(request.addresses)),
+        Get(TransitiveTargets, TransitiveTargetsRequest(request.addresses)),
     )
-    requirements_request = Get(Pex, RequirementsPexRequest(addresses, internal_only=True))
 
+    requirements_request = Get(Pex, RequirementsPexRequest(request.addresses, internal_only=True))
     local_dists_request = Get(
         LocalDistsPex,
         LocalDistsPexRequest(
-            Addresses(tgt.address for tgt in repl.targets),
+            request.addresses,
             internal_only=True,
             interpreter_constraints=interpreter_constraints,
         ),
     )
 
     sources_request = Get(
-        PythonSourceFiles, PythonSourceFilesRequest(repl.targets, include_files=True)
+        PythonSourceFiles, PythonSourceFilesRequest(transitive_targets.closure, include_files=True)
     )
 
     requirements_pex, local_dists, sources = await MultiGet(
@@ -61,14 +60,14 @@ async def create_python_repl_request(repl: PythonRepl, pex_env: PexEnvironment) 
 
     complete_pex_env = pex_env.in_workspace()
     args = complete_pex_env.create_argv(
-        repl.in_chroot(requirements_pex.name), python=requirements_pex.python
+        request.in_chroot(requirements_pex.name), python=requirements_pex.python
     )
 
-    chrooted_source_roots = [repl.in_chroot(sr) for sr in sources.source_roots]
+    chrooted_source_roots = [request.in_chroot(sr) for sr in sources.source_roots]
     extra_env = {
         **complete_pex_env.environment_dict(python_configured=requirements_pex.python is not None),
         "PEX_EXTRA_SYS_PATH": ":".join(chrooted_source_roots),
-        "PEX_PATH": repl.in_chroot(local_dists.pex.name),
+        "PEX_PATH": request.in_chroot(local_dists.pex.name),
     }
 
     return ReplRequest(digest=merged_digest, args=args, extra_env=extra_env)
@@ -80,16 +79,16 @@ class IPythonRepl(ReplImplementation):
 
 @rule(level=LogLevel.DEBUG)
 async def create_ipython_repl_request(
-    repl: IPythonRepl, ipython: IPython, pex_env: PexEnvironment
+    request: IPythonRepl, ipython: IPython, pex_env: PexEnvironment
 ) -> ReplRequest:
-    addresses = tuple(tgt.address for tgt in repl.targets)
-    interpreter_constraints = await Get(
-        InterpreterConstraints, InterpreterConstraintsRequest(addresses)
+    interpreter_constraints, transitive_targets = await MultiGet(
+        Get(InterpreterConstraints, InterpreterConstraintsRequest(request.addresses)),
+        Get(TransitiveTargets, TransitiveTargetsRequest(request.addresses)),
     )
-    requirements_request = Get(Pex, RequirementsPexRequest(addresses, internal_only=True))
 
+    requirements_request = Get(Pex, RequirementsPexRequest(request.addresses, internal_only=True))
     sources_request = Get(
-        PythonSourceFiles, PythonSourceFilesRequest(repl.targets, include_files=True)
+        PythonSourceFiles, PythonSourceFilesRequest(transitive_targets.closure, include_files=True)
     )
 
     ipython_request = Get(
@@ -110,7 +109,7 @@ async def create_ipython_repl_request(
     local_dists = await Get(
         LocalDistsPex,
         LocalDistsPexRequest(
-            [tgt.address for tgt in repl.targets],
+            request.addresses,
             internal_only=True,
             interpreter_constraints=interpreter_constraints,
             sources=sources,
@@ -131,18 +130,18 @@ async def create_ipython_repl_request(
 
     complete_pex_env = pex_env.in_workspace()
     args = list(
-        complete_pex_env.create_argv(repl.in_chroot(ipython_pex.name), python=ipython_pex.python)
+        complete_pex_env.create_argv(request.in_chroot(ipython_pex.name), python=ipython_pex.python)
     )
     if ipython.options.ignore_cwd:
         args.append("--ignore-cwd")
 
-    chrooted_source_roots = [repl.in_chroot(sr) for sr in sources.source_roots]
+    chrooted_source_roots = [request.in_chroot(sr) for sr in sources.source_roots]
     extra_env = {
         **complete_pex_env.environment_dict(python_configured=ipython_pex.python is not None),
         "PEX_PATH": os.pathsep.join(
             [
-                repl.in_chroot(requirements_pex.name),
-                repl.in_chroot(local_dists.pex.name),
+                request.in_chroot(requirements_pex.name),
+                request.in_chroot(local_dists.pex.name),
             ]
         ),
         "PEX_EXTRA_SYS_PATH": os.pathsep.join(chrooted_source_roots),

--- a/src/python/pants/backend/scala/goals/repl.py
+++ b/src/python/pants/backend/scala/goals/repl.py
@@ -23,10 +23,10 @@ class ScalaRepl(ReplImplementation):
 
 @rule(level=LogLevel.DEBUG)
 async def create_scala_repl_request(
-    repl: ScalaRepl, bash: BashBinary, jdk_setup: JdkSetup, scala_subsystem: ScalaSubsystem
+    request: ScalaRepl, bash: BashBinary, jdk_setup: JdkSetup, scala_subsystem: ScalaSubsystem
 ) -> ReplRequest:
     user_classpath, tool_classpath = await MultiGet(
-        Get(Classpath, Addresses(t.address for t in repl.targets)),
+        Get(Classpath, Addresses, request.addresses),
         Get(
             ToolClasspath,
             ToolClasspathRequest(

--- a/src/python/pants/core/goals/repl.py
+++ b/src/python/pants/core/goals/repl.py
@@ -17,11 +17,12 @@ from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.internals.native_engine import EMPTY_DIGEST
 from pants.engine.process import InteractiveProcess, InteractiveProcessResult
 from pants.engine.rules import Effect, Get, collect_rules, goal_rule
-from pants.engine.target import Targets, TransitiveTargets, TransitiveTargetsRequest
+from pants.engine.target import Targets
 from pants.engine.unions import UnionMembership, union
 from pants.option.global_options import GlobalOptions
 from pants.util.contextutil import temporary_dir
 from pants.util.frozendict import FrozenDict
+from pants.util.memo import memoized_property
 from pants.util.meta import frozen_after_init
 
 
@@ -34,11 +35,16 @@ class ReplImplementation(ABC):
     """
 
     name: ClassVar[str]
+
     targets: Targets
     chroot: str  # Absolute path of the chroot the sources will be materialized to.
 
     def in_chroot(self, relpath: str) -> str:
         return os.path.join(self.chroot, relpath)
+
+    @memoized_property
+    def addresses(self) -> Addresses:
+        return Addresses(t.address for t in self.targets)
 
 
 class ReplSubsystem(GoalSubsystem):
@@ -106,16 +112,12 @@ async def run_repl(
     console: Console,
     workspace: Workspace,
     repl_subsystem: ReplSubsystem,
-    all_specified_addresses: Addresses,
+    specified_targets: Targets,
     build_root: BuildRoot,
     union_membership: UnionMembership,
     global_options: GlobalOptions,
     complete_env: CompleteEnvironment,
 ) -> Repl:
-    transitive_targets = await Get(
-        TransitiveTargets, TransitiveTargetsRequest(all_specified_addresses)
-    )
-
     # TODO: When we support multiple languages, detect the default repl to use based
     #  on the targets.  For now we default to the python repl.
     repl_shell_name = repl_subsystem.shell or "python"
@@ -130,9 +132,7 @@ async def run_repl(
         return Repl(-1)
 
     with temporary_dir(root_dir=global_options.options.pants_workdir, cleanup=False) as tmpdir:
-        repl_impl = repl_implementation_cls(
-            targets=Targets(transitive_targets.closure), chroot=tmpdir
-        )
+        repl_impl = repl_implementation_cls(targets=specified_targets, chroot=tmpdir)
         request = await Get(ReplRequest, ReplImplementation, repl_impl)
 
         input_digest = request.digest


### PR DESCRIPTION
It is useful for implementations to distinguish between what were the input targets, such as for https://github.com/pantsbuild/pants/issues/14295.

This also facilitates a proposal I made in Slack. Default to `repl --shell=<infer>`, where we inspect the _root_ targets (not transitive closure) to see what target type is most common. If Python, use Python. And so on. 

[ci skip-rust]
[ci skip-build-wheels]