### PR TITLE
Rename Python resolve options and fields to not say "experimental"

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -112,7 +112,7 @@ venv_use_symlinks = true
 [python]
 interpreter_constraints = [">=3.7,<3.10"]
 macos_big_sur_compatibility = true
-experimental_resolves = { python-default = "3rdparty/python/lockfiles/user_reqs.txt" }
+resolves = { python-default = "3rdparty/python/lockfiles/user_reqs.txt" }
 enable_resolves = true
 
 [docformatter]

--- a/src/python/pants/backend/experimental/python/user_lockfiles.py
+++ b/src/python/pants/backend/experimental/python/user_lockfiles.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 class GenerateUserLockfileSubsystem(GoalSubsystem):
     name = "generate-user-lockfile"
     help = (
-        "Deprecated: use the option `[python].experimental_resolves` and the "
+        "Deprecated: use the option `[python].resolves` and the "
         "`generate-lockfiles` goal instead"
     )
 
@@ -30,7 +30,7 @@ async def generate_user_lockfile_goal() -> GenerateUserLockfileGoal:
         "2.11.0.dev0",
         "the `generate-user-lockfile` goal",
         (
-            "Instead, configure the option `[python].experimental_resolves`, then use the "
+            "Instead, configure the option `[python].resolves`, then use the "
             "`generate-lockfiles` goal. Read the deprecation message on "
             "`[python].experimental_lockfile` for more information."
         ),

--- a/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
@@ -305,7 +305,7 @@ def test_map_third_party_modules_to_addresses(rule_runner: RuleRunner) -> None:
             f"python_requirement(name='{tgt_name}', requirements=['{req_str}'], "
             f"modules={modules or []},"
             f"type_stub_modules={stub_modules or []},"
-            f"experimental_compatible_resolves={resolves or ['default']})"
+            f"compatible_resolves={resolves or ['default']})"
         )
 
     build_file = "\n\n".join(
@@ -330,7 +330,7 @@ def test_map_third_party_modules_to_addresses(rule_runner: RuleRunner) -> None:
         ]
     )
     rule_runner.write_files({"BUILD": build_file})
-    rule_runner.set_options(["--python-experimental-resolves={'default': '', 'another': ''}"])
+    rule_runner.set_options(["--python-resolves={'default': '', 'another': ''}"])
     result = rule_runner.request(ThirdPartyPythonModuleMapping, [])
     assert result == ThirdPartyPythonModuleMapping(
         {
@@ -592,22 +592,20 @@ def test_map_module_considers_resolves(rule_runner: RuleRunner) -> None:
                 # result in ambiguity.
                 python_requirement(
                     name="dep1",
-                    experimental_compatible_resolves=["a"],
+                    compatible_resolves=["a"],
                     requirements=["dep"],
                 )
 
                 python_requirement(
                     name="dep2",
-                    experimental_compatible_resolves=["b"],
+                    compatible_resolves=["b"],
                     requirements=["dep"],
                 )
                 """
             )
         }
     )
-    rule_runner.set_options(
-        ["--python-experimental-resolves={'a': '', 'b': ''}", "--python-enable-resolves"]
-    )
+    rule_runner.set_options(["--python-resolves={'a': '', 'b': ''}", "--python-enable-resolves"])
 
     def get_owners(resolve: str | None) -> PythonModuleOwners:
         return rule_runner.request(PythonModuleOwners, [PythonModuleOwnersRequest("dep", resolve)])

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -255,7 +255,7 @@ def determine_python_user_resolves(
 ) -> KnownUserResolveNames:
     return KnownUserResolveNames(
         names=tuple(python_setup.resolves.keys()),
-        option_name="[python].experimental_resolves",
+        option_name="[python].resolves",
         requested_resolve_names_cls=RequestedPythonUserResolveNames,
     )
 

--- a/src/python/pants/backend/python/goals/lockfile_test.py
+++ b/src/python/pants/backend/python/goals/lockfile_test.py
@@ -91,17 +91,17 @@ def test_multiple_resolves() -> None:
                 python_requirement(
                     name='both',
                     requirements=['both1', 'both2'],
-                    experimental_compatible_resolves=['a', 'b'],
+                    compatible_resolves=['a', 'b'],
                 )
                 python_requirement(
                     name='a',
                     requirements=['a'],
-                    experimental_compatible_resolves=['a'],
+                    compatible_resolves=['a'],
                 )
                 python_requirement(
                     name='b',
                     requirements=['b'],
-                    experimental_compatible_resolves=['b'],
+                    compatible_resolves=['b'],
                 )
                 """
             ),
@@ -109,9 +109,9 @@ def test_multiple_resolves() -> None:
     )
     rule_runner.set_options(
         [
-            "--python-experimental-resolves={'a': 'a.lock', 'b': 'b.lock'}",
+            "--python-resolves={'a': 'a.lock', 'b': 'b.lock'}",
             # Override interpreter constraints for 'b', but use default for 'a'.
-            "--python-experimental-resolves-to-interpreter-constraints={'b': ['==3.7.*']}",
+            "--python-resolves-to-interpreter-constraints={'b': ['==3.7.*']}",
             "--python-enable-resolves",
         ],
         env_inherit=PYTHON_BOOTSTRAP_ENV,

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -137,7 +137,7 @@ class Flake8(PythonToolBase):
                 "To instead load third-party plugins, set the option "
                 "`[flake8].extra_requirements`.\n\n"
                 "Tip: it's often helpful to define a dedicated 'resolve' via "
-                "`[python].experimental_resolves` for your Flake8 plugins such as 'flake8-plugins' "
+                "`[python].resolves` for your Flake8 plugins such as 'flake8-plugins' "
                 "so that the third-party requirements used by your plugin, like `flake8`, do not "
                 "mix with the rest of your project. Read that option's help message for more info "
                 "on resolves."

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -469,13 +469,13 @@ def test_partition_targets(rule_runner: RuleRunner) -> None:
                 python_source(
                     name='dep',
                     source='dep.py',
-                    experimental_resolve='{resolve}',
+                    resolve='{resolve}',
                     interpreter_constraints=['=={interpreter}.*'],
                 )
                 python_source(
                     name='root',
                     source='root.py',
-                    experimental_resolve='{resolve}',
+                    resolve='{resolve}',
                     interpreter_constraints=['=={interpreter}.*'],
                     dependencies=[':dep'],
                 )
@@ -491,7 +491,7 @@ def test_partition_targets(rule_runner: RuleRunner) -> None:
     }
     rule_runner.write_files(files)  # type: ignore[arg-type]
     rule_runner.set_options(
-        ["--python-experimental-resolves={'a': '', 'b': ''}", "--python-enable-resolves"],
+        ["--python-resolves={'a': '', 'b': ''}", "--python-enable-resolves"],
         env_inherit={"PATH", "PYENV_ROOT", "HOME"},
     )
 

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -140,7 +140,7 @@ class Pylint(PythonToolBase):
                 "option `[pylint].extra_requirements` and set the `load-plugins` option in your "
                 "Pylint config.\n\n"
                 "Tip: it's often helpful to define a dedicated 'resolve' via "
-                "`[python].experimental_resolves` for your Pylint plugins such as 'pylint-plugins' "
+                "`[python].resolves` for your Pylint plugins such as 'pylint-plugins' "
                 "so that the third-party requirements used by your plugin, like `pylint`, do not "
                 "mix with the rest of your project. Read that option's help message for more info "
                 "on resolves."

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -111,12 +111,12 @@ class PythonSetup(Subsystem):
             help="Deprecated.",
             removal_version="2.11.0.dev0",
             removal_hint=(
-                "Instead, use the improved `[python].experimental_resolves` mechanism. Read its "
+                "Instead, use the improved `[python].resolves` mechanism. Read its "
                 "help message for more information.\n\n"
                 "If you want to keep using a single resolve like before, update "
-                "`[python].experimental_resolves` with a name for the resolve and the path to "
+                "`[python].resolves` with a name for the resolve and the path to "
                 "its lockfile, or use the default. Then make sure that "
-                "`[python].experimental_default_resolve` is set to that resolve name."
+                "`[python].default_resolve` is set to that resolve name."
             ),
         )
         register(
@@ -127,12 +127,12 @@ class PythonSetup(Subsystem):
             mutually_exclusive_group="lockfile",
             help=(
                 "Set to true to enable the multiple resolves mechanism. See "
-                "`[python].experimental_resolves` for an explanation of this feature.\n\n"
+                "`[python].resolves` for an explanation of this feature.\n\n"
                 "Mutually exclusive with `[python].requirement_constraints`."
             ),
         )
         register(
-            "--experimental-resolves",
+            "--resolves",
             advanced=True,
             type=dict,
             default={"python-default": "3rdparty/python/default_lock.txt"},
@@ -154,10 +154,10 @@ class PythonSetup(Subsystem):
                 "names and their lockfile paths. The names should be meaningful to your "
                 "repository, such as `data-science` or `pants-plugins`.\n"
                 "  2. Set the default with "
-                "`[python].experimental_default_resolve`.\n"
+                "`[python].default_resolve`.\n"
                 "  3. Update your `python_requirement` targets with the "
-                "`experimental_compatible_resolves` field to declare which resolve(s) they should "
-                "be available in. They default to `[python].experimental_default_resolve`, so you "
+                "`compatible_resolves` field to declare which resolve(s) they should "
+                "be available in. They default to `[python].default_resolve`, so you "
                 "only need to update targets that you want in non-default resolves. "
                 "(Often you'll set this via the `python_requirements` or `poetry_requirements` "
                 "target generators)\n"
@@ -165,32 +165,29 @@ class PythonSetup(Subsystem):
                 "aren't what you'd expect, adjust the prior step.\n"
                 "  5. Update any targets like `python_source` / `python_sources`, "
                 "`python_test` / `python_tests`, and `pex_binary` which need to set a non-default "
-                "resolve with the `experimental_resolve` field.\n\n"
-                "Only applies if `[python].enable_resolves` is true.\n\n"
-                "This option is experimental and may change without the normal deprecation policy."
+                "resolve with the `resolve` field.\n\n"
+                "Only applies if `[python].enable_resolves` is true."
             ),
         )
         register(
-            "--experimental-default-resolve",
+            "--default-resolve",
             advanced=True,
             type=str,
             default="python-default",
             help=(
-                "The default value used for the `experimental_resolve` and "
-                "`experimental_compatible_resolves` fields.\n\n"
-                "The name must be defined as a resolve in `[python].experimental_resolves`.\n\n"
-                "This option is experimental and may change without the normal deprecation policy."
+                "The default value used for the `resolve` and `compatible_resolves` fields.\n\n"
+                "The name must be defined as a resolve in `[python].resolves`."
             ),
         )
         register(
-            "--experimental-resolves-to-interpreter-constraints",
+            "--resolves-to-interpreter-constraints",
             advanced=True,
             type=dict,
             default={},
             help=(
                 "Override the interpreter constraints to use when generating a resolve's lockfile "
                 "with the `generate-lockfiles` goal.\n\n"
-                "By default, each resolve from `[python].experimental_resolves` will use your "
+                "By default, each resolve from `[python].resolves` will use your "
                 "global interpreter constraints set in `[python].interpreter_constraints`. With "
                 "this option, you can override each resolve to use certain interpreter "
                 "constraints, such as `{'data-science': ['==3.8.*']}`.\n\n"
@@ -199,8 +196,7 @@ class PythonSetup(Subsystem):
                 "code is set to use ['==3.9.*'] via the `interpreter_constraints` field, but it's "
                 "also using a resolve whose interpreter constraints are set to ['==3.7.*'], then "
                 "Pants will error explaining the incompatibility.\n\n"
-                "The keys must be defined as resolves in `[python].experimental_resolves`.\n\n"
-                "This option is experimental and may change without the normal deprecation policy."
+                "The keys must be defined as resolves in `[python].resolves`."
             ),
         )
         register(
@@ -314,21 +310,21 @@ class PythonSetup(Subsystem):
 
     @property
     def resolves(self) -> dict[str, str]:
-        return cast("dict[str, str]", self.options.experimental_resolves)
+        return cast("dict[str, str]", self.options.resolves)
 
     @property
     def default_resolve(self) -> str:
-        return cast(str, self.options.experimental_default_resolve)
+        return cast(str, self.options.default_resolve)
 
     @memoized_property
     def resolves_to_interpreter_constraints(self) -> dict[str, tuple[str, ...]]:
         result = {}
-        for resolve, ics in self.options.experimental_resolves_to_interpreter_constraints.items():
+        for resolve, ics in self.options.resolves_to_interpreter_constraints.items():
             if resolve not in self.resolves:
                 raise KeyError(
                     "Unrecognized resolve name in the option "
-                    f"`[python].experimental_resolves_to_interpreter_constraints`: {resolve}. Each "
-                    "key must be one of the keys in `[python].experimental_resolves`: "
+                    f"`[python].resolves_to_interpreter_constraints`: {resolve}. Each "
+                    "key must be one of the keys in `[python].resolves`: "
                     f"{sorted(self.resolves.keys())}"
                 )
             result[resolve] = tuple(ics)

--- a/src/python/pants/backend/python/subsystems/setup_test.py
+++ b/src/python/pants/backend/python/subsystems/setup_test.py
@@ -13,8 +13,8 @@ def test_resolves_to_interpreter_constraints_validation() -> None:
     def create(resolves_to_ics: dict[str, list[str]]) -> dict[str, tuple[str, ...]]:
         return create_subsystem(
             PythonSetup,
-            experimental_resolves={"a": "a.lock"},
-            experimental_resolves_to_interpreter_constraints=resolves_to_ics,
+            resolves={"a": "a.lock"},
+            resolves_to_interpreter_constraints=resolves_to_ics,
         ).resolves_to_interpreter_constraints
 
     assert create({"a": ["==3.7.*"]}) == {"a": ("==3.7.*",)}

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -104,16 +104,15 @@ class InterpreterConstraintsField(StringSequenceField):
 
 
 class PythonResolveField(StringField, AsyncFieldMixin):
-    alias = "experimental_resolve"
+    alias = "resolve"
     required = False
     help = (
-        "The resolve from `[python].experimental_resolves` to use.\n\n"
+        "The resolve from `[python].resolves` to use.\n\n"
         "If not defined, will default to `[python].default_resolve`.\n\n"
         "All dependencies must share the same resolve. This means that you can only depend on "
-        "first-party targets like `python_source` that set their `experimental_resolve` field "
+        "first-party targets like `python_source` that set their `resolve` field "
         "to the same value, and on `python_requirement` targets that include the resolve in "
-        "their `experimental_compatible_resolves` field.\n\n"
-        "This field is experimental and may change without the normal deprecation policy."
+        "their `compatible_resolves` field."
     )
 
     def normalized_value(self, python_setup: PythonSetup) -> str:
@@ -956,16 +955,16 @@ def normalize_module_mapping(
 
 
 class PythonRequirementCompatibleResolvesField(StringSequenceField, AsyncFieldMixin):
-    alias = "experimental_compatible_resolves"
+    alias = "compatible_resolves"
     required = False
     help = (
-        "The resolves from `[python].experimental_resolves` that this requirement should be "
+        "The resolves from `[python].resolves` that this requirement should be "
         "included in.\n\n"
         "If not defined, will default to `[python].default_resolve`.\n\n"
         "When generating a lockfile for a particular resolve via the `generate-lockfiles` goal, "
         "it will include all requirements that are declared compatible with that resolve. "
         "First-party targets like `python_source` and `pex_binary` then declare which resolve "
-        "they use via the `experimental_resolve` field; so, for your first-party code to use a "
+        "they use via the `resolve` field; so, for your first-party code to use a "
         "particular `python_requirement` target, that requirement must be included in the resolve "
         "used by that code."
     )

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -706,13 +706,13 @@ def test_partition_targets(rule_runner: RuleRunner) -> None:
                 python_source(
                     name='dep',
                     source='dep.py',
-                    experimental_resolve='{resolve}',
+                    resolve='{resolve}',
                     interpreter_constraints=['=={interpreter}.*'],
                 )
                 python_source(
                     name='root',
                     source='root.py',
-                    experimental_resolve='{resolve}',
+                    resolve='{resolve}',
                     interpreter_constraints=['=={interpreter}.*'],
                     dependencies=[':dep'],
                 )
@@ -728,7 +728,7 @@ def test_partition_targets(rule_runner: RuleRunner) -> None:
     }
     rule_runner.write_files(files)  # type: ignore[arg-type]
     rule_runner.set_options(
-        ["--python-experimental-resolves={'a': '', 'b': ''}", "--python-enable-resolves"],
+        ["--python-resolves={'a': '', 'b': ''}", "--python-enable-resolves"],
         env_inherit={"PATH", "PYENV_ROOT", "HOME"},
     )
 

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -134,7 +134,7 @@ class MyPy(PythonToolBase):
                 "To instead load third-party plugins, set the option `[mypy].extra_requirements` "
                 "and set the `plugins` option in `mypy.ini`."
                 "Tip: it's often helpful to define a dedicated 'resolve' via "
-                "`[python].experimental_resolves` for your MyPy plugins such as 'mypy-plugins' "
+                "`[python].resolves` for your MyPy plugins such as 'mypy-plugins' "
                 "so that the third-party requirements used by your plugin, like `mypy`, do not "
                 "mix with the rest of your project. Read that option's help message for more info "
                 "on resolves."

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -228,8 +228,8 @@ class NoCompatibleResolveException(Exception):
             f"{msg_prefix}:\n\n"
             f"{formatted_resolve_lists}\n\n"
             "Targets which will be used together must all have the same resolve (from the "
-            f"[resolve]({doc_url('reference-python_test#codeexperimental_resolvecode')}) or "
-            f"[compatible_resolves]({doc_url('reference-python_requirement#codeexperimental_compatible_resolvescode')}) "
+            f"[resolve]({doc_url('reference-python_test#coderesolvecode')}) or "
+            f"[compatible_resolves]({doc_url('reference-python_requirement#codecompatible_resolvescode')}) "
             "fields) in common."
         )
 
@@ -506,7 +506,7 @@ async def get_repository_pex(
             requirements=Lockfile(
                 file_path=chosen_resolve.lockfile_path,
                 file_path_description_of_origin=(
-                    f"the resolve `{chosen_resolve.name}` (from `[python].experimental_resolves`)"
+                    f"the resolve `{chosen_resolve.name}` (from `[python].resolves`)"
                 ),
                 # TODO(#12314): Hook up lockfile staleness check.
                 lockfile_hex_digest=None,

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -61,7 +61,7 @@ def rule_runner() -> RuleRunner:
 
 
 def test_no_compatible_resolve_error() -> None:
-    python_setup = create_subsystem(PythonSetup, experimental_resolves={"a": "", "b": ""})
+    python_setup = create_subsystem(PythonSetup, resolves={"a": "", "b": ""})
     targets = [
         PythonRequirementTarget(
             {
@@ -100,20 +100,20 @@ def test_choose_compatible_resolve(rule_runner: RuleRunner) -> None:
     def create_build(*, req_resolves: list[str], source_resolve: str, test_resolve: str) -> str:
         return dedent(
             f"""\
-            python_source(name="dep", source="dep.py", experimental_resolve="{source_resolve}")
+            python_source(name="dep", source="dep.py", resolve="{source_resolve}")
             python_requirement(
-                name="req", requirements=[], experimental_compatible_resolves={repr(req_resolves)}
+                name="req", requirements=[], compatible_resolves={repr(req_resolves)}
             )
             python_test(
                 name="test",
                 source="tests.py",
                 dependencies=[":dep", ":req"],
-                experimental_resolve="{test_resolve}",
+                resolve="{test_resolve}",
             )
             """
         )
 
-    rule_runner.set_options(["--python-experimental-resolves={'a': '', 'b': ''}"])
+    rule_runner.set_options(["--python-resolves={'a': '', 'b': ''}"])
     rule_runner.write_files(
         {
             # Note that each of these BUILD files are entirely self-contained.

--- a/src/python/pants/core/goals/generate_lockfiles.py
+++ b/src/python/pants/core/goals/generate_lockfiles.py
@@ -299,7 +299,7 @@ class GenerateLockfilesSubsystem(GoalSubsystem):
                 "Only generate lockfiles for the specified resolve(s).\n\n"
                 "Resolves are the logical names for the different lockfiles used in your project. "
                 "For your own code's dependencies, these come from the option "
-                "`[python].experimental_resolves`. For tool lockfiles, resolve "
+                "`[python].resolves`. For tool lockfiles, resolve "
                 "names are the options scope for that tool such as `black`, `pytest`, and "
                 "`mypy-protobuf`.\n\n"
                 "For example, you can run `./pants generate-lockfiles --resolve=black "


### PR DESCRIPTION
We believe that this feature is now stable enough to not hedge with the `--experimental` name. The key insight is that we won't have `compatible_resolves` on `python_source` targets, per https://github.com/pantsbuild/pants/pull/14299. 

We still don't have this feature on by default via `--enable-resolves`, and we likely won't until using PEX for lockfile generation. But this lowers the barrier to entry for people who want to try out this new mechanism.

[ci skip-rust]