### PR TITLE
[internal] Move `PexRequirements` to `pex_requirements.py`

### DIFF
--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -25,8 +25,9 @@ from pants.backend.python.target_types import (
 )
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.lockfile_metadata import PythonLockfileMetadata
-from pants.backend.python.util_rules.pex import PexRequest, PexRequirements, VenvPex, VenvPexProcess
+from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.backend.python.util_rules.pex_cli import PexCliProcess
+from pants.backend.python.util_rules.pex_requirements import PexRequirements
 from pants.core.goals.generate_lockfiles import (
     GenerateLockfile,
     GenerateLockfileResult,

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -40,7 +40,7 @@ from pants.backend.python.util_rules.dists import (
 )
 from pants.backend.python.util_rules.dists import rules as dists_rules
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.pex import PexRequirements
+from pants.backend.python.util_rules.pex_requirements import PexRequirements
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFilesRequest,
     StrippedPythonSourceFiles,

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -20,7 +20,7 @@ from pants.backend.python.target_types import (
 )
 from pants.backend.python.util_rules import python_sources
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.pex import PexRequirements
+from pants.backend.python.util_rules.pex_requirements import PexRequirements
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFilesRequest,
     StrippedPythonSourceFiles,

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -20,7 +20,7 @@ from pants.backend.python.target_types import (
     PythonSourceField,
 )
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.pex import PexRequirements
+from pants.backend.python.util_rules.pex_requirements import PexRequirements
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFilesRequest,
     StrippedPythonSourceFiles,

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -8,7 +8,7 @@ from typing import ClassVar, Iterable, Sequence, cast
 
 from pants.backend.python.target_types import ConsoleScript, EntryPoint, MainSpecification
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.pex import (
+from pants.backend.python.util_rules.pex_requirements import (
     Lockfile,
     LockfileContent,
     PexRequirements,

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -16,14 +16,9 @@ from pants.backend.python.typecheck.mypy.subsystem import (
 )
 from pants.backend.python.util_rules import pex_from_targets
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.pex import (
-    Pex,
-    PexRequest,
-    PexRequirements,
-    VenvPex,
-    VenvPexProcess,
-)
+from pants.backend.python.util_rules.pex import Pex, PexRequest, VenvPex, VenvPexProcess
 from pants.backend.python.util_rules.pex_from_targets import RequirementsPexRequest
+from pants.backend.python.util_rules.pex_requirements import PexRequirements
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
     PythonSourceFilesRequest,

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -19,7 +19,7 @@ from pants.backend.python.target_types import (
 )
 from pants.backend.python.typecheck.mypy.skip_field import SkipMyPyField
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.pex import PexRequirements
+from pants.backend.python.util_rules.pex_requirements import PexRequirements
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
     PythonSourceFilesRequest,

--- a/src/python/pants/backend/python/util_rules/dists.py
+++ b/src/python/pants/backend/python/util_rules/dists.py
@@ -14,15 +14,13 @@ import toml
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.subsystems.setuptools import Setuptools
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.pex import (
+from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
+from pants.backend.python.util_rules.pex import rules as pex_rules
+from pants.backend.python.util_rules.pex_requirements import (
     Lockfile,
     LockfileContent,
-    PexRequest,
     PexRequirements,
-    VenvPex,
-    VenvPexProcess,
 )
-from pants.backend.python.util_rules.pex import rules as pex_rules
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.engine.fs import (
     CreateDigest,

--- a/src/python/pants/backend/python/util_rules/local_dists.py
+++ b/src/python/pants/backend/python/util_rules/local_dists.py
@@ -11,8 +11,9 @@ from typing import Iterable
 
 from pants.backend.python.subsystems.setuptools import PythonDistributionFieldSet
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.pex import Pex, PexRequest, PexRequirements
+from pants.backend.python.util_rules.pex import Pex, PexRequest
 from pants.backend.python.util_rules.pex import rules as pex_rules
+from pants.backend.python.util_rules.pex_requirements import PexRequirements
 from pants.backend.python.util_rules.python_sources import PythonSourceFiles
 from pants.build_graph.address import Address
 from pants.core.goals.package import BuiltPackage, PackageFieldSet

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -373,7 +373,9 @@ async def build_pex(
                 request.requirements.file_path,
                 resolve_name,
             )
-            _validate_metadata(metadata, request, request.requirements, python_setup)
+            _validate_metadata(
+                metadata, request.interpreter_constraints, request.requirements, python_setup
+            )
 
     elif isinstance(request.requirements, LockfileContent):
         is_monolithic_resolve = True
@@ -388,7 +390,9 @@ async def build_pex(
             metadata = PythonLockfileMetadata.from_lockfile(
                 file_content.content, resolve_name=resolve_name
             )
-            _validate_metadata(metadata, request, request.requirements, python_setup)
+            _validate_metadata(
+                metadata, request.interpreter_constraints, request.requirements, python_setup
+            )
         requirements_file_digest = await Get(Digest, CreateDigest([file_content]))
     else:
         assert isinstance(request.requirements, PexRequirements)
@@ -478,7 +482,7 @@ async def build_pex(
 
 def _validate_metadata(
     metadata: PythonLockfileMetadata,
-    request: PexRequest,
+    interpreter_constraints: InterpreterConstraints,
     requirements: (Lockfile | LockfileContent),
     python_setup: PythonSetup,
 ) -> None:
@@ -493,7 +497,7 @@ def _validate_metadata(
 
     validation = metadata.is_valid_for(
         requirements.lockfile_hex_digest,
-        request.interpreter_constraints,
+        interpreter_constraints,
         python_setup.interpreter_universe,
         req_strings,
     )
@@ -548,7 +552,7 @@ def _validate_metadata(
             in validation.failure_reasons
         ):
             yield (
-                f"- You have set interpreter constraints (`{request.interpreter_constraints}`) that "
+                f"- You have set interpreter constraints (`{interpreter_constraints}`) that "
                 "are not compatible with those used to generate the lockfile "
                 f"(`{metadata.valid_for_interpreter_constraints}`). "
             )

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -25,14 +25,13 @@ from pants.backend.python.util_rules.interpreter_constraints import InterpreterC
 from pants.backend.python.util_rules.local_dists import LocalDistsPex, LocalDistsPexRequest
 from pants.backend.python.util_rules.local_dists import rules as local_dists_rules
 from pants.backend.python.util_rules.pex import (
-    Lockfile,
     OptionalPex,
     OptionalPexRequest,
     PexPlatforms,
     PexRequest,
-    PexRequirements,
 )
 from pants.backend.python.util_rules.pex import rules as pex_rules
+from pants.backend.python.util_rules.pex_requirements import Lockfile, PexRequirements
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
     PythonSourceFilesRequest,

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -26,7 +26,7 @@ from pants.backend.python.target_types import (
     PythonTestTarget,
 )
 from pants.backend.python.util_rules import pex_from_targets
-from pants.backend.python.util_rules.pex import Pex, PexPlatforms, PexRequest, PexRequirements
+from pants.backend.python.util_rules.pex import Pex, PexPlatforms, PexRequest
 from pants.backend.python.util_rules.pex_from_targets import (
     ChosenPythonResolve,
     ChosenPythonResolveRequest,
@@ -34,6 +34,7 @@ from pants.backend.python.util_rules.pex_from_targets import (
     NoCompatibleResolveException,
     PexFromTargetsRequest,
 )
+from pants.backend.python.util_rules.pex_requirements import PexRequirements
 from pants.build_graph.address import Address
 from pants.engine.addresses import Addresses
 from pants.testutil.option_util import create_subsystem

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -3,16 +3,29 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING, Iterable, Iterator
 
+from pants.backend.python.pip_requirement import PipRequirement
+from pants.backend.python.subsystems.setup import InvalidLockfileBehavior, PythonSetup
 from pants.backend.python.target_types import PythonRequirementsField
+from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
+from pants.backend.python.util_rules.lockfile_metadata import (
+    InvalidPythonLockfileReason,
+    PythonLockfileMetadata,
+)
+from pants.core.util_rules.lockfile_metadata import InvalidLockfileError
 from pants.engine.fs import FileContent
+from pants.util.docutil import doc_url
 from pants.util.meta import frozen_after_init
 from pants.util.ordered_set import FrozenOrderedSet
 
 if TYPE_CHECKING:
     from pants.backend.python.util_rules.pex import Pex
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -94,3 +107,120 @@ class PexRequirements:
 
     def __bool__(self) -> bool:
         return bool(self.req_strings)
+
+
+def validate_metadata(
+    metadata: PythonLockfileMetadata,
+    interpreter_constraints: InterpreterConstraints,
+    requirements: (Lockfile | LockfileContent),
+    python_setup: PythonSetup,
+) -> None:
+
+    # TODO(#12314): Improve this message: `Requirement.parse` raises `InvalidRequirement`, which
+    # doesn't have mypy stubs at the moment; it may be hard to catch this exception and typecheck.
+    req_strings = (
+        {PipRequirement.parse(i) for i in requirements.req_strings}
+        if requirements.req_strings is not None
+        else None
+    )
+
+    validation = metadata.is_valid_for(
+        requirements.lockfile_hex_digest,
+        interpreter_constraints,
+        python_setup.interpreter_universe,
+        req_strings,
+    )
+
+    if validation:
+        return
+
+    def tool_message_parts(
+        requirements: (ToolCustomLockfile | ToolDefaultLockfile),
+    ) -> Iterator[str]:
+
+        tool_name = requirements.options_scope_name
+        uses_source_plugins = requirements.uses_source_plugins
+        uses_project_interpreter_constraints = requirements.uses_project_interpreter_constraints
+
+        yield "You are using "
+
+        if isinstance(requirements, ToolDefaultLockfile):
+            yield "the `<default>` lockfile provided by Pants "
+        elif isinstance(requirements, ToolCustomLockfile):
+            yield f"the lockfile at {requirements.file_path} "
+
+        yield (
+            f"to install the tool `{tool_name}`, but it is not compatible with your "
+            "configuration: "
+            "\n\n"
+        )
+
+        if any(
+            i == InvalidPythonLockfileReason.INVALIDATION_DIGEST_MISMATCH
+            or i == InvalidPythonLockfileReason.REQUIREMENTS_MISMATCH
+            for i in validation.failure_reasons
+        ):
+            # TODO(12314): Add message showing _which_ requirements diverged.
+
+            yield (
+                "- You have set different requirements than those used to generate the lockfile. "
+                f"You can fix this by not setting `[{tool_name}].version`, "
+            )
+
+            if uses_source_plugins:
+                yield f"`[{tool_name}].source_plugins`, "
+
+            yield (
+                f"and `[{tool_name}].extra_requirements`, or by using a new "
+                "custom lockfile."
+                "\n"
+            )
+
+        if (
+            InvalidPythonLockfileReason.INTERPRETER_CONSTRAINTS_MISMATCH
+            in validation.failure_reasons
+        ):
+            yield (
+                f"- You have set interpreter constraints (`{interpreter_constraints}`) that "
+                "are not compatible with those used to generate the lockfile "
+                f"(`{metadata.valid_for_interpreter_constraints}`). "
+            )
+            if not uses_project_interpreter_constraints:
+                yield (
+                    f"You can fix this by not setting `[{tool_name}].interpreter_constraints`, "
+                    "or by using a new custom lockfile. "
+                )
+            else:
+                yield (
+                    f"`{tool_name}` determines its interpreter constraints based on your code's own "
+                    "constraints. To fix this error, you can either change your code's constraints "
+                    f"(see {doc_url('python-interpreter-compatibility')}) or by generating a new "
+                    "custom lockfile. "
+                )
+            yield "\n"
+
+        yield "\n"
+
+        if not isinstance(requirements, ToolCustomLockfile):
+            yield (
+                "To generate a custom lockfile based on your current configuration, set "
+                f"`[{tool_name}].lockfile` to where you want to create the lockfile, then run "
+                f"`./pants generate-lockfiles --resolve={tool_name}`. "
+            )
+        else:
+            yield (
+                "To regenerate your lockfile based on your current configuration, run "
+                f"`./pants generate-lockfiles --resolve={tool_name}`. "
+            )
+
+    message: str
+    if isinstance(requirements, (ToolCustomLockfile, ToolDefaultLockfile)):
+        message = "".join(tool_message_parts(requirements)).strip()
+    else:
+        # TODO(12314): Improve this message
+        raise InvalidLockfileError(f"{validation.failure_reasons}")
+
+    if python_setup.invalid_lockfile_behavior == InvalidLockfileBehavior.error:
+        raise ValueError(message)
+    else:
+        logger.warning("%s", message)

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -1,0 +1,96 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Iterable
+
+from pants.backend.python.target_types import PythonRequirementsField
+from pants.engine.fs import FileContent
+from pants.util.meta import frozen_after_init
+from pants.util.ordered_set import FrozenOrderedSet
+
+if TYPE_CHECKING:
+    from pants.backend.python.util_rules.pex import Pex
+
+
+@dataclass(frozen=True)
+class Lockfile:
+    file_path: str
+    file_path_description_of_origin: str
+    lockfile_hex_digest: str | None
+    req_strings: FrozenOrderedSet[str] | None
+
+
+@dataclass(frozen=True)
+class LockfileContent:
+    file_content: FileContent
+    lockfile_hex_digest: str | None
+    req_strings: FrozenOrderedSet[str] | None
+
+
+@dataclass(frozen=True)
+class _ToolLockfileMixin:
+    options_scope_name: str
+    uses_source_plugins: bool
+    uses_project_interpreter_constraints: bool
+
+
+@dataclass(frozen=True)
+class ToolDefaultLockfile(LockfileContent, _ToolLockfileMixin):
+    pass
+
+
+@dataclass(frozen=True)
+class ToolCustomLockfile(Lockfile, _ToolLockfileMixin):
+    pass
+
+
+@frozen_after_init
+@dataclass(unsafe_hash=True)
+class PexRequirements:
+    req_strings: FrozenOrderedSet[str]
+    constraints_strings: FrozenOrderedSet[str]
+    # TODO: The constraints.txt resolve for `resolve_all_constraints` will be removed as part of
+    # #12314, but in the meantime, it "acts like" a lockfile, but isn't actually typed as a Lockfile
+    # because the constraints are modified in memory first. This flag marks a `PexRequirements`
+    # resolve as being a request for the entire constraints file.
+    is_all_constraints_resolve: bool
+    repository_pex: Pex | None
+
+    def __init__(
+        self,
+        req_strings: Iterable[str] = (),
+        *,
+        constraints_strings: Iterable[str] = (),
+        is_all_constraints_resolve: bool = False,
+        repository_pex: Pex | None = None,
+    ) -> None:
+        """
+        :param req_strings: The requirement strings to resolve.
+        :param constraints_strings: Constraints strings to apply during the resolve.
+        :param repository_pex: An optional PEX to resolve requirements from via the Pex CLI
+            `--pex-repository` option.
+        """
+        self.req_strings = FrozenOrderedSet(sorted(req_strings))
+        self.constraints_strings = FrozenOrderedSet(sorted(constraints_strings))
+        self.is_all_constraints_resolve = is_all_constraints_resolve
+        self.repository_pex = repository_pex
+
+    @classmethod
+    def create_from_requirement_fields(
+        cls,
+        fields: Iterable[PythonRequirementsField],
+        constraints_strings: Iterable[str],
+        *,
+        additional_requirements: Iterable[str] = (),
+    ) -> PexRequirements:
+        field_requirements = {str(python_req) for field in fields for python_req in field.value}
+        return PexRequirements(
+            {*field_requirements, *additional_requirements},
+            constraints_strings=constraints_strings,
+        )
+
+    def __bool__(self) -> bool:
+        return bool(self.req_strings)

--- a/src/python/pants/backend/python/util_rules/pex_requirements_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements_test.py
@@ -22,16 +22,22 @@ from pants.backend.python.util_rules.pex_requirements import (
     ToolDefaultLockfile,
     validate_metadata,
 )
-from pants.backend.python.util_rules.pex_test import (
-    BOOLEANS,
-    DEFAULT,
-    FILE,
-    LOCKFILE_TYPES,
-    VERSIONS,
-)
 from pants.engine.fs import FileContent
 from pants.testutil.rule_runner import RuleRunner
 from pants.util.ordered_set import FrozenOrderedSet
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner()
+
+
+DEFAULT = "DEFAULT"
+FILE = "FILE"
+
+LOCKFILE_TYPES = (DEFAULT, FILE)
+BOOLEANS = (True, False)
+VERSIONS = (1, 2)
 
 
 @pytest.mark.parametrize(

--- a/src/python/pants/backend/python/util_rules/pex_requirements_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements_test.py
@@ -1,0 +1,230 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pants.backend.python.pip_requirement import PipRequirement
+from pants.backend.python.subsystems.setup import InvalidLockfileBehavior
+from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
+from pants.backend.python.util_rules.lockfile_metadata import (
+    PythonLockfileMetadata,
+    PythonLockfileMetadataV1,
+    PythonLockfileMetadataV2,
+)
+from pants.backend.python.util_rules.pex_requirements import (
+    Lockfile,
+    LockfileContent,
+    ToolCustomLockfile,
+    ToolDefaultLockfile,
+    validate_metadata,
+)
+from pants.backend.python.util_rules.pex_test import (
+    BOOLEANS,
+    DEFAULT,
+    FILE,
+    LOCKFILE_TYPES,
+    VERSIONS,
+)
+from pants.engine.fs import FileContent
+from pants.testutil.rule_runner import RuleRunner
+from pants.util.ordered_set import FrozenOrderedSet
+
+
+@pytest.mark.parametrize(
+    "lockfile_type,invalid_reqs,invalid_constraints,uses_source_plugins,uses_project_ic,version",
+    [
+        (lft, ir, ic, usp, upi, v)
+        for lft in LOCKFILE_TYPES
+        for ir in BOOLEANS
+        for ic in BOOLEANS
+        for usp in BOOLEANS
+        for upi in BOOLEANS
+        for v in VERSIONS
+        if (ir or ic)
+    ],
+)
+def test_validate_metadata(
+    rule_runner,
+    lockfile_type: str,
+    invalid_reqs,
+    invalid_constraints,
+    uses_source_plugins,
+    uses_project_ic,
+    version,
+    caplog,
+) -> None:
+    class M:
+        opening_default = "You are using the `<default>` lockfile provided by Pants"
+        opening_file = "You are using the lockfile at"
+
+        invalid_requirements = (
+            "You have set different requirements than those used to generate the lockfile"
+        )
+        invalid_requirements_source_plugins = ".source_plugins`, and"
+
+        invalid_interpreter_constraints = "You have set interpreter constraints"
+        invalid_interpreter_constraints_tool_ics = (
+            ".interpreter_constraints`, or by using a new custom lockfile."
+        )
+        invalid_interpreter_constraints_project_ics = (
+            "determines its interpreter constraints based on your code's own constraints."
+        )
+
+        closing_lockfile_content = (
+            "To generate a custom lockfile based on your current configuration"
+        )
+        closing_file = "To regenerate your lockfile based on your current configuration"
+
+    (
+        actual_digest,
+        expected_digest,
+        actual_constraints,
+        expected_constraints,
+        actual_requirements,
+        expected_requirements_,
+        options_scope_name,
+    ) = _metadata_validation_values(
+        invalid_reqs, invalid_constraints, uses_source_plugins, uses_project_ic
+    )
+
+    metadata: PythonLockfileMetadata
+    if version == 1:
+        metadata = PythonLockfileMetadataV1(
+            InterpreterConstraints([expected_constraints]), expected_digest
+        )
+    elif version == 2:
+        expected_requirements = {PipRequirement.parse(i) for i in expected_requirements_}
+        metadata = PythonLockfileMetadataV2(
+            InterpreterConstraints([expected_constraints]), expected_requirements
+        )
+    requirements = _prepare_pex_requirements(
+        rule_runner,
+        lockfile_type,
+        "lockfile_data_goes_here",
+        actual_digest,
+        actual_requirements,
+        options_scope_name,
+        uses_source_plugins,
+        uses_project_ic,
+    )
+
+    python_setup = MagicMock(
+        invalid_lockfile_behavior=InvalidLockfileBehavior.warn,
+        interpreter_universe=["3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"],
+    )
+
+    validate_metadata(
+        metadata, InterpreterConstraints([actual_constraints]), requirements, python_setup
+    )
+
+    txt = caplog.text.strip()
+
+    expected_opening = {
+        DEFAULT: M.opening_default,
+        FILE: M.opening_file,
+    }[lockfile_type]
+
+    assert expected_opening in txt
+
+    if invalid_reqs:
+        assert M.invalid_requirements in txt
+        if uses_source_plugins:
+            assert M.invalid_requirements_source_plugins in txt
+        else:
+            assert M.invalid_requirements_source_plugins not in txt
+    else:
+        assert M.invalid_requirements not in txt
+
+    if invalid_constraints:
+        assert M.invalid_interpreter_constraints in txt
+        if uses_project_ic:
+            assert M.invalid_interpreter_constraints_project_ics in txt
+            assert M.invalid_interpreter_constraints_tool_ics not in txt
+        else:
+            assert M.invalid_interpreter_constraints_project_ics not in txt
+            assert M.invalid_interpreter_constraints_tool_ics in txt
+
+    else:
+        assert M.invalid_interpreter_constraints not in txt
+
+    if lockfile_type == FILE:
+        assert M.closing_lockfile_content not in txt
+        assert M.closing_file in txt
+
+
+def _metadata_validation_values(
+    invalid_reqs: bool, invalid_constraints: bool, uses_source_plugins: bool, uses_project_ic: bool
+) -> tuple[str, str, str, str, set[str], set[str], str]:
+
+    actual_digest = "900d"
+    expected_digest = actual_digest
+    actual_reqs = {"ansicolors==0.1.0"}
+    expected_reqs = actual_reqs
+    if invalid_reqs:
+        expected_digest = "baad"
+        expected_reqs = {"requests==3.0.0"}
+
+    actual_constraints = "CPython>=3.6,<3.10"
+    expected_constraints = actual_constraints
+    if invalid_constraints:
+        expected_constraints = "CPython>=3.9"
+
+    options_scope_name: str
+    if uses_source_plugins and uses_project_ic:
+        options_scope_name = "pylint"
+    elif uses_source_plugins:
+        options_scope_name = "mypy"
+    elif uses_project_ic:
+        options_scope_name = "bandit"
+    else:
+        options_scope_name = "kevin"
+
+    return (
+        actual_digest,
+        expected_digest,
+        actual_constraints,
+        expected_constraints,
+        actual_reqs,
+        expected_reqs,
+        options_scope_name,
+    )
+
+
+def _prepare_pex_requirements(
+    rule_runner: RuleRunner,
+    lockfile_type: str,
+    lockfile: str,
+    expected_digest: str,
+    expected_requirements: set[str],
+    options_scope_name: str,
+    uses_source_plugins: bool,
+    uses_project_interpreter_constraints: bool,
+) -> Lockfile | LockfileContent:
+    if lockfile_type == FILE:
+        file_path = "lockfile.txt"
+        rule_runner.write_files({file_path: lockfile})
+        return ToolCustomLockfile(
+            file_path=file_path,
+            file_path_description_of_origin="iceland",
+            lockfile_hex_digest=expected_digest,
+            req_strings=FrozenOrderedSet(expected_requirements),
+            options_scope_name=options_scope_name,
+            uses_source_plugins=uses_source_plugins,
+            uses_project_interpreter_constraints=uses_project_interpreter_constraints,
+        )
+    elif lockfile_type == DEFAULT:
+        content = FileContent("lockfile.txt", lockfile.encode("utf-8"))
+        return ToolDefaultLockfile(
+            file_content=content,
+            lockfile_hex_digest=expected_digest,
+            req_strings=FrozenOrderedSet(expected_requirements),
+            options_scope_name=options_scope_name,
+            uses_source_plugins=uses_source_plugins,
+            uses_project_interpreter_constraints=uses_project_interpreter_constraints,
+        )
+    else:
+        raise Exception("incorrect lockfile_type value in test")

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -11,7 +11,6 @@ import zipfile
 from dataclasses import dataclass
 from pathlib import PurePath
 from typing import Any, Iterable, Iterator, Mapping
-from unittest.mock import MagicMock
 
 import pytest
 from packaging.specifiers import SpecifierSet
@@ -19,14 +18,8 @@ from packaging.version import Version
 from pkg_resources import Requirement
 
 from pants.backend.python.pip_requirement import PipRequirement
-from pants.backend.python.subsystems.setup import InvalidLockfileBehavior
 from pants.backend.python.target_types import EntryPoint, MainSpecification
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.lockfile_metadata import (
-    PythonLockfileMetadata,
-    PythonLockfileMetadataV1,
-    PythonLockfileMetadataV2,
-)
 from pants.backend.python.util_rules.pex import (
     Pex,
     PexDistributionInfo,
@@ -37,7 +30,6 @@ from pants.backend.python.util_rules.pex import (
     VenvPex,
     VenvPexProcess,
     _build_pex_description,
-    _validate_metadata,
 )
 from pants.backend.python.util_rules.pex import rules as pex_rules
 from pants.backend.python.util_rules.pex_cli import PexPEX
@@ -45,15 +37,16 @@ from pants.backend.python.util_rules.pex_requirements import (
     Lockfile,
     LockfileContent,
     PexRequirements,
-    ToolCustomLockfile,
-    ToolDefaultLockfile,
+)
+from pants.backend.python.util_rules.pex_requirements_test import (
+    _metadata_validation_values,
+    _prepare_pex_requirements,
 )
 from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, Directory, FileContent
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.process import Process, ProcessCacheScope, ProcessResult
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 from pants.util.dirutil import safe_rmtree
-from pants.util.ordered_set import FrozenOrderedSet
 
 
 @dataclass(frozen=True)
@@ -780,199 +773,3 @@ ansicolors==1.1.8
         requirements=requirements,
         additional_pants_args=(f"--python-invalid-lockfile-behavior={behavior}",),
     )
-
-
-@pytest.mark.parametrize(
-    "lockfile_type,invalid_reqs,invalid_constraints,uses_source_plugins,uses_project_ic,version",
-    [
-        (lft, ir, ic, usp, upi, v)
-        for lft in LOCKFILE_TYPES
-        for ir in BOOLEANS
-        for ic in BOOLEANS
-        for usp in BOOLEANS
-        for upi in BOOLEANS
-        for v in VERSIONS
-        if (ir or ic)
-    ],
-)
-def test_validate_metadata(
-    rule_runner,
-    lockfile_type: str,
-    invalid_reqs,
-    invalid_constraints,
-    uses_source_plugins,
-    uses_project_ic,
-    version,
-    caplog,
-) -> None:
-    class M:
-        opening_default = "You are using the `<default>` lockfile provided by Pants"
-        opening_file = "You are using the lockfile at"
-
-        invalid_requirements = (
-            "You have set different requirements than those used to generate the lockfile"
-        )
-        invalid_requirements_source_plugins = ".source_plugins`, and"
-
-        invalid_interpreter_constraints = "You have set interpreter constraints"
-        invalid_interpreter_constraints_tool_ics = (
-            ".interpreter_constraints`, or by using a new custom lockfile."
-        )
-        invalid_interpreter_constraints_project_ics = (
-            "determines its interpreter constraints based on your code's own constraints."
-        )
-
-        closing_lockfile_content = (
-            "To generate a custom lockfile based on your current configuration"
-        )
-        closing_file = "To regenerate your lockfile based on your current configuration"
-
-    (
-        actual_digest,
-        expected_digest,
-        actual_constraints,
-        expected_constraints,
-        actual_requirements,
-        expected_requirements_,
-        options_scope_name,
-    ) = _metadata_validation_values(
-        invalid_reqs, invalid_constraints, uses_source_plugins, uses_project_ic
-    )
-
-    metadata: PythonLockfileMetadata
-    if version == 1:
-        metadata = PythonLockfileMetadataV1(
-            InterpreterConstraints([expected_constraints]), expected_digest
-        )
-    elif version == 2:
-        expected_requirements = {PipRequirement.parse(i) for i in expected_requirements_}
-        metadata = PythonLockfileMetadataV2(
-            InterpreterConstraints([expected_constraints]), expected_requirements
-        )
-    requirements = _prepare_pex_requirements(
-        rule_runner,
-        lockfile_type,
-        "lockfile_data_goes_here",
-        actual_digest,
-        actual_requirements,
-        options_scope_name,
-        uses_source_plugins,
-        uses_project_ic,
-    )
-
-    python_setup = MagicMock(
-        invalid_lockfile_behavior=InvalidLockfileBehavior.warn,
-        interpreter_universe=["3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"],
-    )
-
-    _validate_metadata(
-        metadata, InterpreterConstraints([actual_constraints]), requirements, python_setup
-    )
-
-    txt = caplog.text.strip()
-
-    expected_opening = {
-        DEFAULT: M.opening_default,
-        FILE: M.opening_file,
-    }[lockfile_type]
-
-    assert expected_opening in txt
-
-    if invalid_reqs:
-        assert M.invalid_requirements in txt
-        if uses_source_plugins:
-            assert M.invalid_requirements_source_plugins in txt
-        else:
-            assert M.invalid_requirements_source_plugins not in txt
-    else:
-        assert M.invalid_requirements not in txt
-
-    if invalid_constraints:
-        assert M.invalid_interpreter_constraints in txt
-        if uses_project_ic:
-            assert M.invalid_interpreter_constraints_project_ics in txt
-            assert M.invalid_interpreter_constraints_tool_ics not in txt
-        else:
-            assert M.invalid_interpreter_constraints_project_ics not in txt
-            assert M.invalid_interpreter_constraints_tool_ics in txt
-
-    else:
-        assert M.invalid_interpreter_constraints not in txt
-
-    if lockfile_type == FILE:
-        assert M.closing_lockfile_content not in txt
-        assert M.closing_file in txt
-
-
-def _metadata_validation_values(
-    invalid_reqs: bool, invalid_constraints: bool, uses_source_plugins: bool, uses_project_ic: bool
-) -> tuple[str, str, str, str, set[str], set[str], str]:
-
-    actual_digest = "900d"
-    expected_digest = actual_digest
-    actual_reqs = {"ansicolors==0.1.0"}
-    expected_reqs = actual_reqs
-    if invalid_reqs:
-        expected_digest = "baad"
-        expected_reqs = {"requests==3.0.0"}
-
-    actual_constraints = "CPython>=3.6,<3.10"
-    expected_constraints = actual_constraints
-    if invalid_constraints:
-        expected_constraints = "CPython>=3.9"
-
-    options_scope_name: str
-    if uses_source_plugins and uses_project_ic:
-        options_scope_name = "pylint"
-    elif uses_source_plugins:
-        options_scope_name = "mypy"
-    elif uses_project_ic:
-        options_scope_name = "bandit"
-    else:
-        options_scope_name = "kevin"
-
-    return (
-        actual_digest,
-        expected_digest,
-        actual_constraints,
-        expected_constraints,
-        actual_reqs,
-        expected_reqs,
-        options_scope_name,
-    )
-
-
-def _prepare_pex_requirements(
-    rule_runner: RuleRunner,
-    lockfile_type: str,
-    lockfile: str,
-    expected_digest: str,
-    expected_requirements: set[str],
-    options_scope_name: str,
-    uses_source_plugins: bool,
-    uses_project_interpreter_constraints: bool,
-) -> Lockfile | LockfileContent:
-    if lockfile_type == FILE:
-        file_path = "lockfile.txt"
-        rule_runner.write_files({file_path: lockfile})
-        return ToolCustomLockfile(
-            file_path=file_path,
-            file_path_description_of_origin="iceland",
-            lockfile_hex_digest=expected_digest,
-            req_strings=FrozenOrderedSet(expected_requirements),
-            options_scope_name=options_scope_name,
-            uses_source_plugins=uses_source_plugins,
-            uses_project_interpreter_constraints=uses_project_interpreter_constraints,
-        )
-    elif lockfile_type == DEFAULT:
-        content = FileContent("lockfile.txt", lockfile.encode("utf-8"))
-        return ToolDefaultLockfile(
-            file_content=content,
-            lockfile_hex_digest=expected_digest,
-            req_strings=FrozenOrderedSet(expected_requirements),
-            options_scope_name=options_scope_name,
-            uses_source_plugins=uses_source_plugins,
-            uses_project_interpreter_constraints=uses_project_interpreter_constraints,
-        )
-    else:
-        raise Exception("incorrect lockfile_type value in test")

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -28,17 +28,12 @@ from pants.backend.python.util_rules.lockfile_metadata import (
     PythonLockfileMetadataV2,
 )
 from pants.backend.python.util_rules.pex import (
-    Lockfile,
-    LockfileContent,
     Pex,
     PexDistributionInfo,
     PexPlatforms,
     PexProcess,
     PexRequest,
-    PexRequirements,
     PexResolveInfo,
-    ToolCustomLockfile,
-    ToolDefaultLockfile,
     VenvPex,
     VenvPexProcess,
     _build_pex_description,
@@ -46,6 +41,13 @@ from pants.backend.python.util_rules.pex import (
 )
 from pants.backend.python.util_rules.pex import rules as pex_rules
 from pants.backend.python.util_rules.pex_cli import PexPEX
+from pants.backend.python.util_rules.pex_requirements import (
+    Lockfile,
+    LockfileContent,
+    PexRequirements,
+    ToolCustomLockfile,
+    ToolDefaultLockfile,
+)
 from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, Directory, FileContent
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.process import Process, ProcessCacheScope, ProcessResult

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -860,16 +860,14 @@ def test_validate_metadata(
         uses_project_ic,
     )
 
-    request = MagicMock(
-        options_scope_name=options_scope_name,
-        interpreter_constraints=InterpreterConstraints([actual_constraints]),
-    )
     python_setup = MagicMock(
         invalid_lockfile_behavior=InvalidLockfileBehavior.warn,
         interpreter_universe=["3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"],
     )
 
-    _validate_metadata(metadata, request, requirements, python_setup)
+    _validate_metadata(
+        metadata, InterpreterConstraints([actual_constraints]), requirements, python_setup
+    )
 
     txt = caplog.text.strip()
 

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -39,6 +39,8 @@ from pants.backend.python.util_rules.pex_requirements import (
     PexRequirements,
 )
 from pants.backend.python.util_rules.pex_requirements_test import (
+    DEFAULT,
+    FILE,
     _metadata_validation_values,
     _prepare_pex_requirements,
 )
@@ -637,10 +639,6 @@ def test_build_pex_description() -> None:
     )
 
 
-DEFAULT = "DEFAULT"
-FILE = "FILE"
-
-
 def test_error_on_invalid_lockfile_with_path(rule_runner: RuleRunner) -> None:
     with pytest.raises(ExecutionError):
         _run_pex_for_lockfile_test(
@@ -713,11 +711,6 @@ def test_warn_on_invalid_lockfile_with_content(rule_runner: RuleRunner, caplog) 
 def test_no_warning_on_valid_lockfile_with_content(rule_runner: RuleRunner, caplog) -> None:
     _run_pex_for_lockfile_test(rule_runner, lockfile_type=DEFAULT, behavior="warn")
     assert not caplog.text.strip()
-
-
-LOCKFILE_TYPES = (DEFAULT, FILE)
-BOOLEANS = (True, False)
-VERSIONS = (1, 2)
 
 
 def _run_pex_for_lockfile_test(

--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -13,8 +13,9 @@ from pkg_resources import Requirement, WorkingSet
 from pkg_resources import working_set as global_working_set
 
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.pex import PexRequest, PexRequirements, VenvPex, VenvPexProcess
+from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.backend.python.util_rules.pex_environment import PythonExecutable
+from pants.backend.python.util_rules.pex_requirements import PexRequirements
 from pants.engine.collection import DeduplicatedCollection
 from pants.engine.environment import CompleteEnvironment
 from pants.engine.internals.session import SessionValues

--- a/tests/python/pants_test/init/test_plugin_resolver.py
+++ b/tests/python/pants_test/init/test_plugin_resolver.py
@@ -18,7 +18,8 @@ from pkg_resources import Distribution, Requirement, WorkingSet
 
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.pex import Pex, PexProcess, PexRequest, PexRequirements
+from pants.backend.python.util_rules.pex import Pex, PexProcess, PexRequest
+from pants.backend.python.util_rules.pex_requirements import PexRequirements
 from pants.core.util_rules import archive, external_tool
 from pants.engine.environment import CompleteEnvironment
 from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests, Snapshot


### PR DESCRIPTION
`pex.py` has gotten enormous, over 1200 lines. `pex_test.py` is huge too. Part of this is because it takes a lot of code to write excellent error messages for invalid tool lockfiles. 

That code cannot live in `lockfile_metadata.py` because it would cause a circular import with `pex.py`. Instead, the solution is to create a new file `pex_requirements.py` which is imported by `pex.py`, where the good error messages can be defined.

This does not rewrite any code beyond a trivial change to `validate_metadata` to directly take `InterpreterConstraints` rather than `PexRequest` then solely using its `interpreter_contraints` field.

To reduce churn for plugin authors, we re-export `PexRequirements` from `pex.py.