### PR TITLE
[internal] initial protocol implementation for BSP

### DIFF
--- a/3rdparty/python/lockfiles/pytest.txt
+++ b/3rdparty/python/lockfiles/pytest.txt
@@ -45,9 +45,6 @@ coverage==6.3; python_version >= "3.7" \
     --hash=sha256:2bc85664b06ba42d14bb74d6ddf19d8bfc520cb660561d2d9ce5786ae72f71b5 \
     --hash=sha256:27a94db5dc098c25048b0aca155f5fac674f2cf1b1736c5272ba28ead2fc267e \
     --hash=sha256:bde4aeabc0d1b2e52c4036c54440b1ad05beeca8113f47aceb4998bb7471e2c2 \
-    --hash=sha256:509c68c3e2015022aeda03b003dd68fa19987cdcf64e9d4edc98db41cfc45d30 \
-    --hash=sha256:e4ff163602c5c77e7bb4ea81ba5d3b793b4419f8acd296aae149370902cf4e92 \
-    --hash=sha256:d1675db48490e5fa0b300f6329ecb8a9a37c29b9ab64fa9c964d34111788ca2d \
     --hash=sha256:7eed8459a2b81848cafb3280b39d7d49950d5f98e403677941c752e7e7ee47cb \
     --hash=sha256:1b4285fde5286b946835a1a53bba3ad41ef74285ba9e8013e14b5ea93deaeafc \
     --hash=sha256:a4748349734110fd32d46ff8897b561e6300d8989a494ad5a0a2e4f0ca974fc7 \
@@ -119,9 +116,9 @@ pluggy==1.0.0; python_version >= "3.6" \
 pprintpp==0.4.0; python_version >= "3.6" \
     --hash=sha256:b6b4dcdd0c0c0d75e4d7b2f21a9e933e5b2ce62b26e1a54537f9651ae5a5c01d \
     --hash=sha256:ea826108e2c7f49dc6d66c752973c3fc9749142a798d6b254e1e301cfdbc6403
-prompt-toolkit==3.0.24; python_full_version >= "3.6.2" and python_version >= "3.7" \
-    --hash=sha256:e56f2ff799bacecd3e88165b1e2f5ebf9bcd59e80e06d395fa0cc4b8bd7bb506 \
-    --hash=sha256:1bb05628c7d87b645974a1bad3f17612be0c29fa39af9f7688030163f680bad6
+prompt-toolkit==3.0.26; python_full_version >= "3.6.2" and python_version >= "3.7" \
+    --hash=sha256:4bcf119be2200c17ed0d518872ef922f1de336eb6d1ddbd1e089ceb6447d97c6 \
+    --hash=sha256:a51d41a6a45fd9def54365bca8f0402c8f182f2b6f7e29c74d55faeb9fb38ac4
 ptyprocess==0.7.0; sys_platform != "win32" and python_version >= "3.7" \
     --hash=sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35 \
     --hash=sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220
@@ -148,9 +145,9 @@ pytest-metadata==1.11.0; python_version >= "3.6" and python_full_version < "3.0.
 pytest==6.2.5; python_version >= "3.6" \
     --hash=sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134 \
     --hash=sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89
-setuptools==60.5.0; python_version >= "3.7" \
-    --hash=sha256:68eb94073fc486091447fcb0501efd6560a0e5a1839ba249e5ff3c4c93f05f90 \
-    --hash=sha256:2404879cda71495fc4d5cbc445ed52fdaddf352b36e40be8dcc63147cb4edabe
+setuptools==60.6.0; python_version >= "3.7" \
+    --hash=sha256:c99207037c38984eae838c2fd986f39a9ddf4fabfe0fddd957e622d1d1dcdd05 \
+    --hash=sha256:eb83b1012ae6bf436901c2a2cee35d45b7260f31fd4b65fd1e50a9f99c11d7f8
 toml==0.10.2; python_version > "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version > "3.6" \
     --hash=sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b \
     --hash=sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f

--- a/3rdparty/python/lockfiles/user_reqs.txt
+++ b/3rdparty/python/lockfiles/user_reqs.txt
@@ -21,6 +21,7 @@
 #     "psutil==5.9.0",
 #     "pydevd-pycharm==203.5419.8",
 #     "pytest<6.3,>=6.2.4",
+#     "python-lsp-jsonrpc==1.0.0",
 #     "requests[security]>=2.25.1",
 #     "setproctitle==1.2.2",
 #     "setuptools<58.0,>=56.0.0",
@@ -47,9 +48,9 @@ attrs==21.4.0; python_version >= "3.6" and python_full_version < "3.0.0" or pyth
 certifi==2021.10.8; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" \
     --hash=sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569 \
     --hash=sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872
-charset-normalizer==2.0.10; python_full_version >= "3.6.0" and python_version >= "3" \
-    --hash=sha256:876d180e9d7432c5d1dfd4c5d26b72f099d503e8fcc0feb7532c9289be60fcbd \
-    --hash=sha256:cb957888737fc0bbcd78e3df769addb41fd1ff8cf950dc9e7ad7793f1bf44455
+charset-normalizer==2.0.11; python_full_version >= "3.6.0" and python_version >= "3" \
+    --hash=sha256:98398a9d69ee80548c762ba991a4728bfc3836768ed226b3945908d1a688371c \
+    --hash=sha256:2842d8f5e82a1f6aa437380934d5e1cd4fcf2003b06fed6940769c164a480a45
 chevron==0.14.0 \
     --hash=sha256:fbf996a709f8da2e745ef763f482ce2d311aa817d287593a5b990d6d6e4f0443 \
     --hash=sha256:87613aafdf6d77b6a90ff073165a61ae5086e21ad49057aa0e53681601800ebf
@@ -192,6 +193,9 @@ pytest==6.2.5; python_version >= "3.6" \
 python-dateutil==2.8.2; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5" \
     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
     --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9
+python-lsp-jsonrpc==1.0.0 \
+    --hash=sha256:7bec170733db628d3506ea3a5288ff76aa33c70215ed223abdb0d95e957660bd \
+    --hash=sha256:079b143be64b0a378bdb21dff5e28a8c1393fe7e8a654ef068322d754e545fc7
 pyyaml==6.0; python_version >= "3.6" \
     --hash=sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53 \
     --hash=sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c \
@@ -275,12 +279,63 @@ types-setuptools==57.4.7 \
 types-toml==0.10.3 \
     --hash=sha256:215a7a79198651ec5bdfd66193c1e71eb681a42f3ef7226c9af3123ced62564a \
     --hash=sha256:988457744d9774d194e3539388772e3a685d8057b7c4a89407afeb0a6cbd1b14
-types-urllib3==1.26.7 \
-    --hash=sha256:cfd1fbbe4ba9a605ed148294008aac8a7b8b7472651d1cc357d507ae5962e3d2 \
-    --hash=sha256:3adcf2cb5981809091dbff456e6999fe55f201652d8c360f99997de5ac2f556e
+types-urllib3==1.26.8 \
+    --hash=sha256:aa0de26893f138523d5552bbb023826c0cc7ea5749d80c1693c57aab7b55f469 \
+    --hash=sha256:a929c68a57b24eee8f7003357b935b802e17767e752d9237266f799ca48ee326
 typing-extensions==4.0.1; python_version >= "3.6" \
     --hash=sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b \
     --hash=sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e
+ujson==5.1.0; python_version >= "3.7" \
+    --hash=sha256:644552d1e89983c08d0c24358fbcb5829ae5b5deee9d876e16d20085cfa7dc81 \
+    --hash=sha256:0cae4a9c141856f7ad1a79c17ff1aaebf7fd8faa2f2c2614c37d6f82ed261d96 \
+    --hash=sha256:4ba63b789d83ca92237dbc72041a268d91559f981c01763a107105878bae442e \
+    --hash=sha256:fe4e8f71e2fd42dce245bace7e2aa97dabef13926750a351eadca89a1e0f1abd \
+    --hash=sha256:6f73946c047a38640b1f5a2a459237b7bdc417ab028a76c796e4eea984b359b9 \
+    --hash=sha256:afe91153c2046fa8210b92def513124e0ea5b87ad8fa4c14fef8197204b980f1 \
+    --hash=sha256:b1ef400fc73ab0cb61b74a662ad4207917223aba6f933a9fea9b0fbe75de2361 \
+    --hash=sha256:5c8a884d60dd2eed2fc95a9474d57ead82adf254f54caffb3d9e8ed185c49aba \
+    --hash=sha256:173b90a2c2836ee42f708df88ecfe3efbc4d868df73c9fcea8cb8f6f3ab93892 \
+    --hash=sha256:6c45ad95e82155372d9908774db46e0ef7880af28a734d0b14eaa4f505e64982 \
+    --hash=sha256:4155a7c29bf330329519027c815e15e381c1fff22f50d26f135584d482bbd95d \
+    --hash=sha256:fa616d0d3c594785c6e9b7f42686bb1c86f9e64aa0f30a72c86d8eb315f54194 \
+    --hash=sha256:a48efcb5d3695b295c26835ed81048da8cd40e76c4fde2940c807aa452b560c9 \
+    --hash=sha256:838d35eb9006d36f9241e95958d9f4819bcf1ea2ec155daf92d5751c31bcc62b \
+    --hash=sha256:05aa6c7297a22081f65497b6f586de6b7060ea47c3ecda80896f47200e9dbf04 \
+    --hash=sha256:ce441ab7ad1db592e2db95b6c2a1eb882123532897340afac1342c28819e9833 \
+    --hash=sha256:9937e819196b894ffd00801b24f1042dabda142f355313c3f20410993219bc4f \
+    --hash=sha256:06bed66ae62d517f67a61cf53c056800b35ef364270723168a1db62702e2d30c \
+    --hash=sha256:74e41a0222e6e8136e38f103d6cc228e4e20f1c35cc80224a42804fd67fb35c8 \
+    --hash=sha256:7bbb87f040e618bebe8c6257b3e4e8ae2f708dcbff3270c84718b3360a152799 \
+    --hash=sha256:68e38122115a8097fbe1cfe52979a797eaff91c10c1bf4b27774e5f30e7f723a \
+    --hash=sha256:b09843123425337d2efee5c8ff6519e4dfc7b044db66c8bd560517fc1070a157 \
+    --hash=sha256:8dca10174a3bd482d969a2d12d0aec2fdd63fb974e255ec0147e36a516a2d68a \
+    --hash=sha256:202ae52f4a53f03c42ead6d046b1a146517e93bd757f517bdeef0a26228e0260 \
+    --hash=sha256:7a4bed7bd7b288cf73ba47bda27fdd1d78ef6906831489e7f296aef9e786eccb \
+    --hash=sha256:d423956f8dfd98a075c9338b886414b6e3c2817dbf67935797466c998af39936 \
+    --hash=sha256:083c1078e4de3a39019e590c43865b17e07a763fee25b012e650bb4f42c89703 \
+    --hash=sha256:31671ad99f0395eb881d698f2871dc64ff00fbd4380c5d9bfd8bff3d4c8f8d88 \
+    --hash=sha256:994eaf4369e6bc24258f59fe8c6345037abcf24557571814e27879851c4353aa \
+    --hash=sha256:00d6ea9702c2eaeaf1a826934eaba1b4c609c873379bf54e36ba7b7e128edf94 \
+    --hash=sha256:a53c4fe8e1c067e6c98b4526e982ed9486f08578ad8eb5f0e94f8cadf0c1d911 \
+    --hash=sha256:368f855779fded560724a6448838304621f498113a116d66bc5ed5ad5ad3ca92 \
+    --hash=sha256:4dd97e45a0f450ba2c43cda18147e54b8e41e886c22e3506c62f7d61e9e53b0d \
+    --hash=sha256:caeadbf95ce277f1f8f4f71913bc20c01f49fc9228f238920f9ff6f7645d2a5f \
+    --hash=sha256:681fed63c948f757466eeb3aea98873e2ab8b2b18e9020c96a97479a513e2018 \
+    --hash=sha256:6fc4376266ae67f6d8f9e69386ab950eb84ba345c6fdbeb1884fa5b773c8c76b \
+    --hash=sha256:585271d6ad545a2ccfc237582f70c160e627735c89d0ca2bde24afa321bc0750 \
+    --hash=sha256:b631af423e6d5d35f9f37fbcc4fbdb6085abc1c441cf864c64b7fbb5b150faf7 \
+    --hash=sha256:08265db5ccff8b521ff68aee13a417d68cca784d7e711d961b92fda6ccffcc4f \
+    --hash=sha256:e2b1c372583eb4363b42e21222d3a18116a41973781d502d61e1b0daf4b8352f \
+    --hash=sha256:51142c9d40439f299594e399bef8892a16586ded54c88d3af926865ca221a177 \
+    --hash=sha256:7ba8be1717b1867a85b2413a8585bad0e4507a22d6af2c244e1c74151f6d5cc0 \
+    --hash=sha256:d0b26d9d6eb9a0979d37f28c715e717a409c9e03163e5cd8fa73aab806351ab5 \
+    --hash=sha256:b2c7e4afde0d36926b091fa9613b18b65e911fcaa60024e8721f2dcfedc25329 \
+    --hash=sha256:110633a8dda6c8ca78090292231e15381f8b2423e998399d4bc5f135149c722b \
+    --hash=sha256:fdac161127ef8e0889180a4c07475457c55fe0bbd644436d8f4c7ef07565d653 \
+    --hash=sha256:452990c2b18445a7379a45873527d2ec47789b9289c13a17a3c1cc76b9641126 \
+    --hash=sha256:5304ad25d100d50b5bc8513ef110335df678f66c7ccf3d4728c0c3aa69e08e0c \
+    --hash=sha256:ce620a6563b21aa3fbb1658bc1bfddb484a6dad542de1efb5121eb7bb4f2b93a \
+    --hash=sha256:a88944d2f99db71a3ca0c63d81f37e55b660edde0b07216fb65a3e46403ef004
 urllib3==1.26.8; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "4" \
     --hash=sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed \
     --hash=sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -17,6 +17,7 @@ packaging==21.3
 pex==2.1.65
 psutil==5.9.0
 pytest>=6.2.4,<6.3  # This should be kept in sync with `pytest.py`.
+python-lsp-jsonrpc==1.0.0
 PyYAML>=6.0,<7.0
 requests[security]>=2.25.1
 setproctitle==1.2.2

--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -79,6 +79,7 @@ DEFAULT_MODULE_MAPPING = {
     "python-dotenv": ("dotenv",),
     "python-hcl2": ("hcl2",),
     "python-jose": ("jose",),
+    "python-lsp-jsonrpc": ("pylsp_jsonrpc",),
     "python-pptx": ("pptx",),
     "pyyaml": ("yaml",),
     "pymongo": ("bson", "gridfs", "pymongo"),

--- a/src/python/pants/bsp/BUILD
+++ b/src/python/pants/bsp/BUILD
@@ -2,3 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_sources()
+
+python_tests(name="tests")

--- a/src/python/pants/bsp/goal.py
+++ b/src/python/pants/bsp/goal.py
@@ -1,0 +1,47 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import logging
+import os
+import sys
+
+from pants.base.exiter import ExitCode
+from pants.base.specs import Specs
+from pants.bsp.protocol import BSPConnection
+from pants.build_graph.build_configuration import BuildConfiguration
+from pants.engine.unions import UnionMembership
+from pants.goal.builtin_goal import BuiltinGoal
+from pants.init.engine_initializer import GraphSession
+from pants.option.options import Options
+
+_logger = logging.getLogger(__name__)
+
+
+class BSPGoal(BuiltinGoal):
+    name = "bsp"
+    help = 'Run server for Build Server Protocol ("BSP").'
+
+    def run(
+        self,
+        *,
+        build_config: BuildConfiguration,
+        graph_session: GraphSession,
+        options: Options,
+        specs: Specs,
+        union_membership: UnionMembership
+    ) -> ExitCode:
+        saved_stdout = sys.stdout
+        saved_stdin = sys.stdin
+        try:
+            sys.stdout = os.fdopen(sys.stdout.fileno(), "wb", buffering=0)  # type: ignore[assignment]
+            sys.stdin = os.fdopen(sys.stdin.fileno(), "rb", buffering=0)  # type: ignore[assignment]
+            conn = BSPConnection(
+                graph_session.scheduler_session,
+                sys.stdin,  # type: ignore[arg-type]
+                sys.stdout,  # type: ignore[arg-type]
+            )
+            conn.run()
+        finally:
+            sys.stdout = saved_stdout
+            sys.stdin = saved_stdin
+
+        return ExitCode(0)

--- a/src/python/pants/bsp/goal.py
+++ b/src/python/pants/bsp/goal.py
@@ -17,8 +17,8 @@ _logger = logging.getLogger(__name__)
 
 
 class BSPGoal(BuiltinGoal):
-    name = "bsp"
-    help = 'Run server for Build Server Protocol ("BSP").'
+    name = "experimental-bsp"
+    help = "Run server for Build Server Protocol (https://build-server-protocol.github.io/)."
 
     def run(
         self,
@@ -29,13 +29,17 @@ class BSPGoal(BuiltinGoal):
         specs: Specs,
         union_membership: UnionMembership
     ) -> ExitCode:
+        scheduler_session = graph_session.scheduler_session.scheduler.new_session(
+            build_id="bsp", dynamic_ui=False
+        )
+
         saved_stdout = sys.stdout
         saved_stdin = sys.stdin
         try:
             sys.stdout = os.fdopen(sys.stdout.fileno(), "wb", buffering=0)  # type: ignore[assignment]
             sys.stdin = os.fdopen(sys.stdin.fileno(), "rb", buffering=0)  # type: ignore[assignment]
             conn = BSPConnection(
-                graph_session.scheduler_session,
+                scheduler_session,
                 sys.stdin,  # type: ignore[arg-type]
                 sys.stdout,  # type: ignore[arg-type]
             )

--- a/src/python/pants/bsp/protocol.py
+++ b/src/python/pants/bsp/protocol.py
@@ -1,0 +1,112 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+import logging
+from concurrent.futures import Future
+from dataclasses import dataclass
+from typing import Any, BinaryIO
+
+from pylsp_jsonrpc.endpoint import Endpoint  # type: ignore[import]
+from pylsp_jsonrpc.exceptions import JsonRpcException  # type: ignore[import]
+from pylsp_jsonrpc.streams import JsonRpcStreamReader, JsonRpcStreamWriter  # type: ignore[import]
+
+from pants.engine.internals.scheduler import SchedulerSession
+from pants.util.frozendict import FrozenDict
+
+_logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class BSPRequest:
+    method_name: str
+    params: Any
+
+
+@dataclass(frozen=True)
+class BSPResponse:
+    response: Any | None
+    error: JsonRpcException | None
+
+
+class BSPConnection:
+    _INITIALIZE_METHOD_NAME = "build/initialize"
+
+    def __init__(
+        self,
+        scheduler_session: SchedulerSession,
+        inbound: BinaryIO,
+        outbound: BinaryIO,
+        max_workers: int = 5,
+    ) -> None:
+        self._scheduler_session = scheduler_session
+        self._inbound = JsonRpcStreamReader(inbound)
+        self._outbound = JsonRpcStreamWriter(outbound)
+        self._initialized = False
+        self._endpoint = Endpoint(self, self._send_outbound_message, max_workers=max_workers)
+
+    def run(self) -> None:
+        """Run the listener for inbound JSON-RPC messages."""
+        self._inbound.listen(self._received_inbound_message)
+
+    def _received_inbound_message(self, msg):
+        """Process each inbound JSON-RPC message."""
+        _logger.info(f"_received_inbound_message: msg={msg}")
+        self._endpoint.consume(msg)
+
+    def _send_outbound_message(self, msg):
+        _logger.info(f"_send_outbound_message: msg={msg}")
+        self._outbound.write(msg)
+
+    def _handle_inbound_message(self, *, method_name: str, params: Any):
+        if not self._initialized and method_name != self._INITIALIZE_METHOD_NAME:
+            fut: Future = Future()
+            fut.set_exception(
+                JsonRpcException(
+                    code=-32002, message=f"Client must first call `{self._INITIALIZE_METHOD_NAME}`."
+                )
+            )
+            return fut
+        request = BSPRequest(
+            method_name=method_name,
+            params=_freeze(params),
+        )
+        execution_request = self._scheduler_session.execution_request(
+            products=[BSPResponse], subjects=[request]
+        )
+        returns, throws = self._scheduler_session.execute(execution_request)
+        if len(returns) == 1 and len(throws) == 0:
+            return returns[0][1].value
+        elif len(returns) == 0 and len(throws) == 1:
+            raise throws[0][1].exc
+        else:
+            raise AssertionError(
+                f"Received unexpected result from engine: returns={returns}; throws={throws}"
+            )
+
+    # Called by `Endpoint` to dispatch requests and notifications.
+    # TODO: Should probably vendor `Endpoint` so we can detect notifications vs method calls and also not
+    # handle
+    def __getitem__(self, method_name):
+        def handler(params):
+            return self._handle_inbound_message(method_name=method_name, params=params)
+
+        return handler
+
+
+def _freeze(item: Any) -> Any:
+    if item is None:
+        return None
+    elif isinstance(item, list) or isinstance(item, tuple):
+        return tuple(_freeze(x) for x in item)
+    elif isinstance(item, dict):
+        result = {}
+        for k, v in item.items():
+            if not isinstance(k, str):
+                raise AssertionError("Got non-`str` key for _freeze.")
+            result[k] = _freeze(v)
+        return FrozenDict(result)
+    elif isinstance(item, str) or isinstance(item, int) or isinstance(item, float):
+        return item
+    else:
+        raise AssertionError(f"Unsupported value type for _freeze: {type(item)}")

--- a/src/python/pants/bsp/protocol.py
+++ b/src/python/pants/bsp/protocol.py
@@ -85,8 +85,8 @@ class BSPConnection:
             )
 
     # Called by `Endpoint` to dispatch requests and notifications.
-    # TODO: Should probably vendor `Endpoint` so we can detect notifications vs method calls and also not
-    # handle
+    # TODO: Should probably vendor `Endpoint` so we can detect notifications versus method calls, which
+    # matters when ignoring unknown notifications versus erroring for unknown methods.
     def __getitem__(self, method_name):
         def handler(params):
             return self._handle_inbound_message(method_name=method_name, params=params)

--- a/src/python/pants/bsp/protocol_test.py
+++ b/src/python/pants/bsp/protocol_test.py
@@ -93,6 +93,7 @@ class TestBSPConnection(SchedulerTestBase):
                 data=None,
             )
             response_fut = endpoint.request("build/initialize", init_request.to_json_dict())
-            response: InitializeBuildResult = response_fut.result(timeout=15)
+            raw_response = response_fut.result(timeout=15)
+            response = InitializeBuildResult.from_json_dict(raw_response)
             assert response.display_name == "Pants"
             assert response.bsp_version == "0.0.1"

--- a/src/python/pants/bsp/protocol_test.py
+++ b/src/python/pants/bsp/protocol_test.py
@@ -1,0 +1,90 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import os
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from threading import Thread
+from typing import BinaryIO
+
+import pytest
+from pylsp_jsonrpc.endpoint import Endpoint  # type: ignore[import]
+from pylsp_jsonrpc.exceptions import JsonRpcException, JsonRpcMethodNotFound  # type: ignore[import]
+from pylsp_jsonrpc.streams import JsonRpcStreamReader, JsonRpcStreamWriter  # type: ignore[import]
+
+from pants.bsp.protocol import BSPConnection
+from pants.bsp.rules import rules as bsp_rules
+from pants.engine.internals.scheduler_test_base import SchedulerTestBase
+
+
+@dataclass(frozen=True)
+class PipesForTest:
+    inbound_reader: BinaryIO
+    inbound_writer: BinaryIO
+    outbound_reader: BinaryIO
+    outbound_writer: BinaryIO
+
+
+@contextmanager
+def setup_pipes():
+    inbound_reader_fd, inbound_writer_fd = os.pipe()
+    inbound_reader = os.fdopen(inbound_reader_fd, "rb", buffering=0)
+    inbound_writer = os.fdopen(inbound_writer_fd, "wb", buffering=0)
+
+    outbound_reader_fd, outbound_writer_fd = os.pipe()
+    outbound_reader = os.fdopen(outbound_reader_fd, "rb", buffering=0)
+    outbound_writer = os.fdopen(outbound_writer_fd, "wb", buffering=0)
+
+    wrapper = PipesForTest(
+        inbound_reader=inbound_reader,
+        inbound_writer=inbound_writer,
+        outbound_reader=outbound_reader,
+        outbound_writer=outbound_writer,
+    )
+
+    try:
+        yield wrapper
+    finally:
+        inbound_reader.close()
+        inbound_writer.close()
+        outbound_reader.close()
+        outbound_writer.close()
+
+
+class TestBSPConnection(SchedulerTestBase):
+    def test_errors_for_uninitialized_connection(self, tmp_path: Path) -> None:
+        with setup_pipes() as pipes:
+            # TODO: This code should be moved to a context manager. For now, only the pipes are managed
+            # with a context manager.
+            scheduler = self.mk_scheduler(tmp_path, [*bsp_rules()])
+            conn = BSPConnection(scheduler, pipes.inbound_reader, pipes.outbound_writer)
+
+            def run_bsp_server():
+                conn.run()
+
+            bsp_thread = Thread(target=run_bsp_server)
+            bsp_thread.daemon = True
+            bsp_thread.start()
+
+            client_reader = JsonRpcStreamReader(pipes.outbound_reader)
+            client_writer = JsonRpcStreamWriter(pipes.inbound_writer)
+            endpoint = Endpoint({}, lambda msg: client_writer.write(msg))
+
+            def run_client():
+                client_reader.listen(lambda msg: endpoint.consume(msg))
+
+            client_thread = Thread(target=run_client)
+            client_thread.daemon = True
+            client_thread.start()
+
+            response_fut = endpoint.request("foo")
+            with pytest.raises(JsonRpcException) as exc_info:
+                response_fut.result(timeout=15)
+            assert exc_info.value.code == -32002
+            assert exc_info.value.message == "Client must first call `build/initialize`."
+
+            response_fut = endpoint.request("build/initialize")
+            with pytest.raises(JsonRpcMethodNotFound) as exc_info:
+                response_fut.result(timeout=15)
+            assert exc_info.value.code == -32601
+            assert exc_info.value.message == "Method Not Found: build/initialize"

--- a/src/python/pants/bsp/rules.py
+++ b/src/python/pants/bsp/rules.py
@@ -1,18 +1,34 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-from pylsp_jsonrpc.exceptions import JsonRpcMethodNotFound  # type: ignore[import]
-
-from pants.bsp.protocol import BSPRequest, BSPResponse
+from pants.bsp.spec import BuildServerCapabilities, InitializeBuildParams, InitializeBuildResult
 from pants.engine.rules import QueryRule, collect_rules, rule
+from pants.version import VERSION
 
 
 @rule
-async def dispatch_bsp_request(request: BSPRequest) -> BSPResponse:
-    raise JsonRpcMethodNotFound.of(request.method_name)
+async def bsp_build_initialize(_request: InitializeBuildParams) -> InitializeBuildResult:
+    return InitializeBuildResult(
+        display_name="Pants",
+        version=VERSION,
+        bsp_version="0.0.1",  # TODO: replace with an actual BSP version
+        capabilities=BuildServerCapabilities(
+            compile_provider=None,
+            test_provider=None,
+            run_provider=None,
+            debug_provider=None,
+            inverse_sources_provider=None,
+            dependency_sources_provider=None,
+            dependency_modules_provider=None,
+            resources_provider=None,
+            can_reload=None,
+            build_target_changed_provider=None,
+        ),
+        data=None,
+    )
 
 
 def rules():
     return (
         *collect_rules(),
-        QueryRule(BSPResponse, (BSPRequest,)),
+        QueryRule(InitializeBuildResult, (InitializeBuildParams,)),
     )

--- a/src/python/pants/bsp/rules.py
+++ b/src/python/pants/bsp/rules.py
@@ -1,0 +1,18 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from pylsp_jsonrpc.exceptions import JsonRpcMethodNotFound  # type: ignore[import]
+
+from pants.bsp.protocol import BSPRequest, BSPResponse
+from pants.engine.rules import QueryRule, collect_rules, rule
+
+
+@rule
+async def dispatch_bsp_request(request: BSPRequest) -> BSPResponse:
+    raise JsonRpcMethodNotFound.of(request.method_name)
+
+
+def rules():
+    return (
+        *collect_rules(),
+        QueryRule(BSPResponse, (BSPRequest,)),
+    )

--- a/src/python/pants/bsp/spec.py
+++ b/src/python/pants/bsp/spec.py
@@ -213,6 +213,11 @@ class BuildClientCapabilities:
     def from_json_dict(cls, d):
         return cls(language_ids=tuple(d.get("languageIds", [])))
 
+    def to_json_dict(self):
+        return {
+            "languageIds": self.language_ids,
+        }
+
 
 @dataclass(frozen=True)
 class InitializeBuildParams:
@@ -245,6 +250,18 @@ class InitializeBuildParams:
             data=d.get("data"),
         )
 
+    def to_json_dict(self):
+        result = {
+            "displayName": self.display_name,
+            "version": self.version,
+            "bspVersion": self.bsp_version,
+            "rootUri": self.root_uri,
+            "capabilities": self.capabilities.to_json_dict(),
+        }
+        if self.data is not None:
+            result["data"] = self.data
+        return result
+
 
 @dataclass(frozen=True)
 class CompileProvider:
@@ -253,6 +270,11 @@ class CompileProvider:
     @classmethod
     def from_json_dict(cls, d):
         return cls(language_ids=tuple(d.get("languageIds", [])))
+
+    def to_json_dict(self):
+        return {
+            "languageIds": self.language_ids,
+        }
 
 
 @dataclass(frozen=True)
@@ -263,6 +285,11 @@ class RunProvider:
     def from_json_dict(cls, d):
         return cls(language_ids=tuple(d.get("languageIds", [])))
 
+    def to_json_dict(self):
+        return {
+            "languageIds": self.language_ids,
+        }
+
 
 @dataclass(frozen=True)
 class DebugProvider:
@@ -272,6 +299,11 @@ class DebugProvider:
     def from_json_dict(cls, d):
         return cls(language_ids=tuple(d.get("languageIds", [])))
 
+    def to_json_dict(self):
+        return {
+            "languageIds": self.language_ids,
+        }
+
 
 @dataclass(frozen=True)
 class TestProvider:
@@ -280,6 +312,11 @@ class TestProvider:
     @classmethod
     def from_json_dict(cls, d):
         return cls(language_ids=tuple(d.get("languageIds", [])))
+
+    def to_json_dict(self):
+        return {
+            "languageIds": self.language_ids,
+        }
 
 
 @dataclass(frozen=True)
@@ -342,6 +379,30 @@ class BuildServerCapabilities:
             build_target_changed_provider=d.get("buildTargetChangedProvider"),
         )
 
+    def to_json_dict(self):
+        result = {}
+        if self.compile_provider is not None:
+            result["compileProvider"] = self.compile_provider.to_json_dict()
+        if self.test_provider is not None:
+            result["testProvider"] = self.test_provider.to_json_dict()
+        if self.run_provider is not None:
+            result["runProvider"] = self.run_provider.to_json_dict()
+        if self.debug_provider is not None:
+            result["debugProvider"] = self.debug_provider.to_json_dict()
+        if self.inverse_sources_provider is not None:
+            result["inverseSourcesProvider"] = self.inverse_sources_provider
+        if self.dependency_sources_provider is not None:
+            result["dependencySourcesProvider"] = self.dependency_sources_provider
+        if self.dependency_modules_provider is not None:
+            result["dependencyModulesProvider"] = self.dependency_modules_provider
+        if self.resources_provider is not None:
+            result["resourcesProvider"] = self.resources_provider
+        if self.can_reload is not None:
+            result["canReload"] = self.can_reload
+        if self.build_target_changed_provider is not None:
+            result["buildTargetChangedProvider"] = self.build_target_changed_provider
+        return result
+
 
 @dataclass(frozen=True)
 class InitializeBuildResult:
@@ -359,3 +420,15 @@ class InitializeBuildResult:
 
     # Additional metadata about the server
     data: Any | None
+
+    def to_json_dict(self):
+        result = {
+            "displayName": self.display_name,
+            "version": self.version,
+            "bspVersion": self.bsp_version,
+            "capabilities": self.capabilities.to_json_dict(),
+        }
+        if self.data is not None:
+            # TODO: Figure out whether to encode/decode data in a generic manner.
+            result["data"] = self.data
+        return result

--- a/src/python/pants/bsp/spec.py
+++ b/src/python/pants/bsp/spec.py
@@ -53,6 +53,8 @@ class BuildTargetCapabilities:
         )
 
 
+# Note: The BSP "build target" concept is _not_ the same as a Pants "target". They are similar but
+# should be not be conflated with one another.
 @dataclass(frozen=True)
 class BuildTarget:
     """Build target contains metadata about an artifact (for example library, test, or binary

--- a/src/python/pants/bsp/spec.py
+++ b/src/python/pants/bsp/spec.py
@@ -421,6 +421,16 @@ class InitializeBuildResult:
     # Additional metadata about the server
     data: Any | None
 
+    @classmethod
+    def from_json_dict(cls, d):
+        return cls(
+            display_name=d["displayName"],
+            version=d["version"],
+            bsp_version=d["bspVersion"],
+            capabilities=BuildServerCapabilities.from_json_dict(d["capabilities"]),
+            data=d.get("data"),
+        )
+
     def to_json_dict(self):
         result = {
             "displayName": self.display_name,

--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -5,7 +5,7 @@
 
 These are always activated and cannot be disabled.
 """
-
+from pants.bsp.rules import rules as bsp_rules
 from pants.core.goals import (
     check,
     export,
@@ -60,6 +60,7 @@ def rules():
         *run.rules(),
         *tailor.rules(),
         *test.rules(),
+        *bsp_rules(),
         # util_rules
         *anonymous_telemetry.rules(),
         *archive.rules(),

--- a/src/python/pants/goal/builtins.py
+++ b/src/python/pants/goal/builtins.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.goal import help
 from pants.goal.builtin_goal import BuiltinGoal
+from pants.bsp.goal import BSPGoal
 
 
 def register_builtin_goals(build_configuration: BuildConfiguration.Builder) -> None:
@@ -20,4 +21,5 @@ def builtin_goals() -> tuple[type[BuiltinGoal], ...]:
         help.ThingHelpAdvancedBuiltinGoal,
         help.UnknownGoalHelpBuiltinGoal,
         help.VersionHelpBuiltinGoal,
+        BSPGoal,
     )

--- a/src/python/pants/goal/builtins.py
+++ b/src/python/pants/goal/builtins.py
@@ -3,10 +3,10 @@
 
 from __future__ import annotations
 
+from pants.bsp.goal import BSPGoal
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.goal import help
 from pants.goal.builtin_goal import BuiltinGoal
-from pants.bsp.goal import BSPGoal
 
 
 def register_builtin_goals(build_configuration: BuildConfiguration.Builder) -> None:


### PR DESCRIPTION
Adds the base protocol support for [Build Server Protocol](https://build-server-protocol.github.io/docs/specification.html) sufficient to receive and reject properly formatted requests. Subsequent PRs will actually add support for BSP methods but this is the foundation for all that coming work.

[ci skip-rust]

[ci skip-build-wheels]