### PR TITLE
[internal] Refactor Python lockfile validation

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -162,8 +162,6 @@ def _invalid_tool_lockfile_error(
     lockfile_interpreter_constraints: InterpreterConstraints,
 ) -> Iterator[str]:
     tool_name = requirements.options_scope_name
-    uses_source_plugins = requirements.uses_source_plugins
-    uses_project_interpreter_constraints = requirements.uses_project_interpreter_constraints
 
     yield "You are using "
     yield "the `<default>` lockfile provided by Pants " if isinstance(
@@ -188,7 +186,7 @@ def _invalid_tool_lockfile_error(
             "- You have set different requirements than those used to generate the lockfile. "
             f"You can fix this by not setting `[{tool_name}].version`, "
         )
-        if uses_source_plugins:
+        if requirements.uses_source_plugins:
             yield f"`[{tool_name}].source_plugins`, "
         yield f"and `[{tool_name}].extra_requirements`, or by using a new custom lockfile.\n"
 
@@ -201,7 +199,7 @@ def _invalid_tool_lockfile_error(
         yield (
             f"You can fix this by not setting `[{tool_name}].interpreter_constraints`, "
             "or by using a new custom lockfile. "
-        ) if not uses_project_interpreter_constraints else (
+        ) if not requirements.uses_project_interpreter_constraints else (
             f"`{tool_name}` determines its interpreter constraints based on your code's own "
             "constraints. To fix this error, you can either change your code's constraints "
             f"(see {doc_url('python-interpreter-compatibility')}) or generat a new "

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -15,7 +15,7 @@ from pants.backend.python.util_rules.lockfile_metadata import (
     InvalidPythonLockfileReason,
     PythonLockfileMetadata,
 )
-from pants.core.util_rules.lockfile_metadata import InvalidLockfileError
+from pants.core.util_rules.lockfile_metadata import InvalidLockfileError, LockfileMetadataValidation
 from pants.engine.fs import FileContent
 from pants.util.docutil import doc_url
 from pants.util.meta import frozen_after_init
@@ -115,7 +115,6 @@ def validate_metadata(
     requirements: (Lockfile | LockfileContent),
     python_setup: PythonSetup,
 ) -> None:
-
     # TODO(#12314): Improve this message: `Requirement.parse` raises `InvalidRequirement`, which
     # doesn't have mypy stubs at the moment; it may be hard to catch this exception and typecheck.
     req_strings = (
@@ -130,97 +129,92 @@ def validate_metadata(
         python_setup.interpreter_universe,
         req_strings,
     )
-
     if validation:
         return
 
-    def tool_message_parts(
-        requirements: (ToolCustomLockfile | ToolDefaultLockfile),
-    ) -> Iterator[str]:
+    message = (
+        "".join(
+            _invalid_tool_lockfile_error(
+                validation,
+                requirements,
+                actual_interpreter_constraints=interpreter_constraints,
+                lockfile_interpreter_constraints=metadata.valid_for_interpreter_constraints,
+            )
+        ).strip()
+        if isinstance(requirements, (ToolCustomLockfile, ToolDefaultLockfile))
+        else str(validation.failure_reasons)
+    )
 
-        tool_name = requirements.options_scope_name
-        uses_source_plugins = requirements.uses_source_plugins
-        uses_project_interpreter_constraints = requirements.uses_project_interpreter_constraints
+    if python_setup.invalid_lockfile_behavior == InvalidLockfileBehavior.error:
+        raise InvalidLockfileError(message)
+    logger.warning("%s", message)
 
-        yield "You are using "
 
-        if isinstance(requirements, ToolDefaultLockfile):
-            yield "the `<default>` lockfile provided by Pants "
-        elif isinstance(requirements, ToolCustomLockfile):
-            yield f"the lockfile at {requirements.file_path} "
+def _invalid_tool_lockfile_error(
+    validation: LockfileMetadataValidation,
+    requirements: ToolCustomLockfile | ToolDefaultLockfile,
+    *,
+    actual_interpreter_constraints: InterpreterConstraints,
+    lockfile_interpreter_constraints: InterpreterConstraints,
+) -> Iterator[str]:
+    tool_name = requirements.options_scope_name
+    uses_source_plugins = requirements.uses_source_plugins
+    uses_project_interpreter_constraints = requirements.uses_project_interpreter_constraints
 
+    yield "You are using "
+    yield "the `<default>` lockfile provided by Pants " if isinstance(
+        requirements, ToolDefaultLockfile
+    ) else f"the lockfile at {requirements.file_path} "
+    yield (
+        f"to install the tool `{tool_name}`, but it is not compatible with your "
+        "configuration: "
+        "\n\n"
+    )
+
+    if any(
+        i == InvalidPythonLockfileReason.INVALIDATION_DIGEST_MISMATCH
+        or i == InvalidPythonLockfileReason.REQUIREMENTS_MISMATCH
+        for i in validation.failure_reasons
+    ):
+        # TODO(12314): Add message showing _which_ requirements diverged.
         yield (
-            f"to install the tool `{tool_name}`, but it is not compatible with your "
-            "configuration: "
-            "\n\n"
+            "- You have set different requirements than those used to generate the lockfile. "
+            f"You can fix this by not setting `[{tool_name}].version`, "
         )
+        if uses_source_plugins:
+            yield f"`[{tool_name}].source_plugins`, "
+        yield f"and `[{tool_name}].extra_requirements`, or by using a new custom lockfile.\n"
 
-        if any(
-            i == InvalidPythonLockfileReason.INVALIDATION_DIGEST_MISMATCH
-            or i == InvalidPythonLockfileReason.REQUIREMENTS_MISMATCH
-            for i in validation.failure_reasons
-        ):
-            # TODO(12314): Add message showing _which_ requirements diverged.
-
+    if InvalidPythonLockfileReason.INTERPRETER_CONSTRAINTS_MISMATCH in validation.failure_reasons:
+        yield (
+            f"- You have set interpreter constraints (`{actual_interpreter_constraints}`) that "
+            "are not compatible with those used to generate the lockfile "
+            f"(`{lockfile_interpreter_constraints}`). "
+        )
+        if not uses_project_interpreter_constraints:
             yield (
-                "- You have set different requirements than those used to generate the lockfile. "
-                f"You can fix this by not setting `[{tool_name}].version`, "
-            )
-
-            if uses_source_plugins:
-                yield f"`[{tool_name}].source_plugins`, "
-
-            yield (
-                f"and `[{tool_name}].extra_requirements`, or by using a new "
-                "custom lockfile."
-                "\n"
-            )
-
-        if (
-            InvalidPythonLockfileReason.INTERPRETER_CONSTRAINTS_MISMATCH
-            in validation.failure_reasons
-        ):
-            yield (
-                f"- You have set interpreter constraints (`{interpreter_constraints}`) that "
-                "are not compatible with those used to generate the lockfile "
-                f"(`{metadata.valid_for_interpreter_constraints}`). "
-            )
-            if not uses_project_interpreter_constraints:
-                yield (
-                    f"You can fix this by not setting `[{tool_name}].interpreter_constraints`, "
-                    "or by using a new custom lockfile. "
-                )
-            else:
-                yield (
-                    f"`{tool_name}` determines its interpreter constraints based on your code's own "
-                    "constraints. To fix this error, you can either change your code's constraints "
-                    f"(see {doc_url('python-interpreter-compatibility')}) or by generating a new "
-                    "custom lockfile. "
-                )
-            yield "\n"
-
-        yield "\n"
-
-        if not isinstance(requirements, ToolCustomLockfile):
-            yield (
-                "To generate a custom lockfile based on your current configuration, set "
-                f"`[{tool_name}].lockfile` to where you want to create the lockfile, then run "
-                f"`./pants generate-lockfiles --resolve={tool_name}`. "
+                f"You can fix this by not setting `[{tool_name}].interpreter_constraints`, "
+                "or by using a new custom lockfile. "
             )
         else:
             yield (
-                "To regenerate your lockfile based on your current configuration, run "
-                f"`./pants generate-lockfiles --resolve={tool_name}`. "
+                f"`{tool_name}` determines its interpreter constraints based on your code's own "
+                "constraints. To fix this error, you can either change your code's constraints "
+                f"(see {doc_url('python-interpreter-compatibility')}) or generat a new "
+                "custom lockfile. "
             )
+        yield "\n"
 
-    message: str
-    if isinstance(requirements, (ToolCustomLockfile, ToolDefaultLockfile)):
-        message = "".join(tool_message_parts(requirements)).strip()
-    else:
-        # TODO(12314): Improve this message
-        raise InvalidLockfileError(f"{validation.failure_reasons}")
+    yield "\n"
 
-    if python_setup.invalid_lockfile_behavior == InvalidLockfileBehavior.error:
-        raise ValueError(message)
+    if not isinstance(requirements, ToolCustomLockfile):
+        yield (
+            "To generate a custom lockfile based on your current configuration, set "
+            f"`[{tool_name}].lockfile` to where you want to create the lockfile, then run "
+            f"`./pants generate-lockfiles --resolve={tool_name}`. "
+        )
     else:
-        logger.warning("%s", message)
+        yield (
+            "To regenerate your lockfile based on your current configuration, run "
+            f"`./pants generate-lockfiles --resolve={tool_name}`. "
+        )

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -176,8 +176,11 @@ def _invalid_tool_lockfile_error(
     )
 
     if any(
-        i == InvalidPythonLockfileReason.INVALIDATION_DIGEST_MISMATCH
-        or i == InvalidPythonLockfileReason.REQUIREMENTS_MISMATCH
+        i
+        in (
+            InvalidPythonLockfileReason.INVALIDATION_DIGEST_MISMATCH,
+            InvalidPythonLockfileReason.REQUIREMENTS_MISMATCH,
+        )
         for i in validation.failure_reasons
     ):
         # TODO(12314): Add message showing _which_ requirements diverged.
@@ -195,30 +198,23 @@ def _invalid_tool_lockfile_error(
             "are not compatible with those used to generate the lockfile "
             f"(`{lockfile_interpreter_constraints}`). "
         )
-        if not uses_project_interpreter_constraints:
-            yield (
-                f"You can fix this by not setting `[{tool_name}].interpreter_constraints`, "
-                "or by using a new custom lockfile. "
-            )
-        else:
-            yield (
-                f"`{tool_name}` determines its interpreter constraints based on your code's own "
-                "constraints. To fix this error, you can either change your code's constraints "
-                f"(see {doc_url('python-interpreter-compatibility')}) or generat a new "
-                "custom lockfile. "
-            )
+        yield (
+            f"You can fix this by not setting `[{tool_name}].interpreter_constraints`, "
+            "or by using a new custom lockfile. "
+        ) if not uses_project_interpreter_constraints else (
+            f"`{tool_name}` determines its interpreter constraints based on your code's own "
+            "constraints. To fix this error, you can either change your code's constraints "
+            f"(see {doc_url('python-interpreter-compatibility')}) or generat a new "
+            "custom lockfile. "
+        )
         yield "\n"
 
     yield "\n"
-
-    if not isinstance(requirements, ToolCustomLockfile):
-        yield (
-            "To generate a custom lockfile based on your current configuration, set "
-            f"`[{tool_name}].lockfile` to where you want to create the lockfile, then run "
-            f"`./pants generate-lockfiles --resolve={tool_name}`. "
-        )
-    else:
-        yield (
-            "To regenerate your lockfile based on your current configuration, run "
-            f"`./pants generate-lockfiles --resolve={tool_name}`. "
-        )
+    yield (
+        "To regenerate your lockfile based on your current configuration, run "
+        f"`./pants generate-lockfiles --resolve={tool_name}`. "
+    ) if isinstance(requirements, ToolCustomLockfile) else (
+        "To generate a custom lockfile based on your current configuration, set "
+        f"`[{tool_name}].lockfile` to where you want to create the lockfile, then run "
+        f"`./pants generate-lockfiles --resolve={tool_name}`. "
+    )

--- a/src/python/pants/backend/python/util_rules/pex_requirements_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements_test.py
@@ -130,7 +130,7 @@ def test_validate_metadata(
 
 def _metadata_validation_values(
     invalid_reqs: bool, invalid_constraints: bool
-) -> tuple[str, str, set[str], set[str]]:
+) -> tuple[str, str, set[str], set[PipRequirement]]:
     actual_reqs = {"ansicolors==0.1.0"}
     expected_reqs = {"requests==3.0.0"} if invalid_reqs else actual_reqs
     actual_constraints = "CPython>=3.6,<3.10"

--- a/src/python/pants/backend/python/util_rules/pex_requirements_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements_test.py
@@ -20,7 +20,7 @@ from pants.backend.python.util_rules.pex_requirements import (
     LockfileContent,
     ToolCustomLockfile,
     ToolDefaultLockfile,
-    validate_metadata,
+    maybe_validate_metadata,
 )
 from pants.engine.fs import FileContent
 from pants.testutil.rule_runner import RuleRunner
@@ -123,8 +123,8 @@ def test_validate_metadata(
         interpreter_universe=["3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"],
     )
 
-    validate_metadata(
-        metadata, InterpreterConstraints([actual_constraints]), requirements, python_setup
+    maybe_validate_metadata(
+        lambda: metadata, InterpreterConstraints([actual_constraints]), requirements, python_setup
     )
 
     txt = caplog.text.strip()


### PR DESCRIPTION
Prework for adding validation of user lockfiles. This has four main changes:

1. Move inner helper function for tool lockfiles to a dedicated function
2. DRY Pex rule for metadata, including by making metadata parsing lazy. Now `pex.py` does not deal with `--invalid-lockfile-behavior` at all.
3. Simplify integration test for lockfile validation. Now that `pex.py` does not handle `--invalid-lockfile-behavior` at all, we don't need to test every permutation of it - we have unit tests in `pex_requirements.py` for that.
4. Some simplifications for `pex_requirements_test.py`.