### PR TITLE
Declarative Options v2

### DIFF
--- a/src/python/pants/option/option_types.py
+++ b/src/python/pants/option/option_types.py
@@ -108,15 +108,15 @@ class OptionBase(Generic[PropType]):
         self.kwargs["fromfile"] = True
         return self
 
-    def metavar(self, metavar: str, /) -> OptionBase[PropType]:
+    def metavar(self, metavar: str) -> OptionBase[PropType]:
         self.kwargs["metavar"] = metavar
         return self
 
-    def mutually_exclusive_group(self, mutually_exclusive_group: str, /) -> OptionBase[PropType]:
+    def mutually_exclusive_group(self, mutually_exclusive_group: str) -> OptionBase[PropType]:
         self.kwargs["mutually_exclusive_group"] = mutually_exclusive_group
         return self
 
-    def default_help_repr(self, default_help_repr: str, /) -> OptionBase[PropType]:
+    def default_help_repr(self, default_help_repr: str) -> OptionBase[PropType]:
         self.kwargs["default_help_repr"] = default_help_repr
         return self
 

--- a/src/python/pants/option/option_types.py
+++ b/src/python/pants/option/option_types.py
@@ -1,0 +1,481 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from enum import Enum
+
+# NB: Avoid using "Optional" and use "| None" instead, as "Option" and "Optional" look similar.
+from typing import TYPE_CHECKING, Any, Dict, Generic, Type, TypeVar, cast, overload
+
+from pants.option import custom_types
+from pants.util.frozendict import FrozenDict
+
+if TYPE_CHECKING:
+    from pants.option.subsystem import Subsystem
+
+SubsystemT = TypeVar("SubsystemT", bound="Subsystem")
+OptionT = TypeVar("OptionT", bound="OptionBase")
+PropType = TypeVar("PropType")
+StrT = TypeVar("StrT", str, "str | None")
+IntT = TypeVar("IntT", int, "int | None")
+FloatT = TypeVar("FloatT", float, "float | None")
+BoolT = TypeVar("BoolT", bool, "bool | None")
+EnumT = TypeVar("EnumT", bound=Enum)
+ValueType = TypeVar("ValueType")
+# NB: We don't provide constraints, as our `XListOption` types act like a set of contraints
+ListMemberType = TypeVar("ListMemberType")
+
+
+# ================================================================
+
+
+class OptionBase(Generic[PropType]):
+    """Descriptor for subsystem options.
+
+    Clients shouldn't use this class directly, instead use one of the concrete classes below.
+
+    This class serves two purposes:
+        - Collect registration values for your option.
+        - Provide a typed property for Python usage
+
+    In order to define the `type` registration option, `self.option_type` must return a valid
+    registration type. This can either be set using a class variable or by passing it into
+    `__new__`.
+
+    NOTE: Due to https://github.com/python/mypy/issues/5146 subclasses unfortunately need to provide
+    overloaded `__new__` methods, as subclasses do not inherit overloaded function's annotations.
+    Use one of the existing subclasses as a guide on how to do this.
+    """
+
+    flag_names: tuple[str, ...]
+    kwargs: Dict
+    option_type: Any  # NB: This should be some kind of callable that returns PropType
+
+    # NB: Due to https://github.com/python/mypy/issues/5146, we try to keep the parameter list as
+    # short as possible to avoid having to repeat the param in each of the 3 `__new__` specs that
+    # each subclass must provide.
+    # If you need additional information, this class follows the "Builder" pattern. Use the
+    # "builder" methods to attach additional information. (E.g. see `advanced` method)
+    # NB: We define `__new__` rather than `__init__` because otherwise subclasses would have to
+    # define 3 `__new__`s AND `__init__`.
+    def __new__(
+        cls,
+        *flag_names: str,
+        default: Any,
+        option_type: Type | None = None,
+        help: str,
+    ):
+        self = super().__new__(cls)
+        self.flag_names = flag_names
+        if option_type is None:
+            option_type = cls.option_type
+
+        self.kwargs = dict(
+            type=option_type,
+            default=default,
+            help=help,
+        )
+        return self
+
+    @overload
+    def __get__(self, obj: None, objtype: Any) -> OptionBase[PropType]:
+        ...
+
+    @overload
+    def __get__(self, obj: object, objtype: Any) -> PropType:
+        ...
+
+    def __get__(self, obj, objtype):
+        if obj is None:
+            return self
+        long_name = self.flag_names[-1]
+        option_value = getattr(obj.options, long_name[2:].replace("-", "_"))
+        if option_value is None:
+            return None
+        return self._convert_(option_value)
+
+    # Subclasses can override if necessary
+    def _convert_(self, val: Any) -> PropType:
+        return cast("PropType", self.kwargs["type"](val))
+
+    # ===== "Builder" Methods =====
+    def advanced(self) -> OptionBase[PropType]:
+        self.kwargs["advanced"] = True
+        return self
+
+    def from_file(self) -> OptionBase[PropType]:
+        self.kwargs["fromfile"] = True
+        return self
+
+    def metavar(self, metavar: str, /) -> OptionBase[PropType]:
+        self.kwargs["metavar"] = metavar
+        return self
+
+    def mutually_exclusive_group(self, mutually_exclusive_group: str, /) -> OptionBase[PropType]:
+        self.kwargs["mutually_exclusive_group"] = mutually_exclusive_group
+        return self
+
+    def default_help_repr(self, default_help_repr: str, /) -> OptionBase[PropType]:
+        self.kwargs["default_help_repr"] = default_help_repr
+        return self
+
+    def will_be_removed(self, *, version: str, hint: str) -> OptionBase[PropType]:
+        self.kwargs["removal_version"] = version
+        self.kwargs["removal_hint"] = hint
+        return self
+
+    # TODO: These only seem relevant on global options?
+    def daemoned(self) -> OptionBase[PropType]:
+        self.kwargs["daemon"] = True
+        return self
+
+    def non_fingerprinted(self) -> OptionBase[PropType]:
+        self.kwargs["fingerprint"] = False
+        return self
+
+
+class ListOptionBase(OptionBase["tuple[ListMemberType, ...]"], Generic[ListMemberType]):
+    """A homogenous list of options of some type.
+
+    Don't use this class directly, instead use one of the conrete classes below.
+
+    The default value will always be set as an empty list, and the Python property always returns
+    a tuple (for immutability).
+
+    In order to define the `member_type` registration option, `self.member_type` must return a valid
+    list member type. This can either be set using a class variable or by passing it into `__new__`.
+    """
+
+    option_type = list
+    member_type: Any
+
+    def __new__(
+        cls,
+        *flag_names: str,
+        member_type: ListMemberType | None = None,
+        default: list[ListMemberType] | None = None,
+        help: str,
+    ):
+        if member_type is None:
+            member_type = cls.member_type
+
+        default = default or []
+        instance = super().__new__(
+            cls,  # type: ignore[arg-type]
+            *flag_names,
+            default=default,
+            help=help,
+        )
+        instance.kwargs["member_type"] = member_type
+        return instance
+
+    def _convert_(self, value: list[Any]) -> tuple[ListMemberType]:
+        return cast("tuple[ListMemberType]", tuple(map(self.kwargs["member_type"], value)))
+
+
+# ===== Concrete Classes =====
+
+
+class StrOption(OptionBase[StrT]):
+    """A string option."""
+
+    option_type: Any = str
+
+    @overload
+    def __new__(cls, *flag_names: str, default: str, help: str) -> StrOption[str]:
+        ...
+
+    @overload
+    def __new__(cls, *flag_names: str, help: str) -> StrOption[str | None]:
+        ...
+
+    def __new__(cls, *flag_names, default=None, help):
+        return super().__new__(cls, *flag_names, default=default, help=help)
+
+
+class IntOption(OptionBase[IntT]):
+    """An int option."""
+
+    option_type: Any = int
+
+    @overload
+    def __new__(cls, *flag_names: str, default: int, help: str) -> IntOption[int]:
+        ...
+
+    @overload
+    def __new__(cls, *flag_names: str, help: str) -> IntOption[int | None]:
+        ...
+
+    def __new__(cls, *flag_names, default=None, help):
+        return super().__new__(cls, *flag_names, default=default, help=help)
+
+
+class FloatOption(OptionBase[FloatT]):
+    """A float option."""
+
+    option_type: Any = float
+
+    @overload
+    def __new__(cls, *flag_names: str, default: float, help: str) -> FloatOption[float]:
+        ...
+
+    @overload
+    def __new__(cls, *flag_names: str, help: str) -> FloatOption[float | None]:
+        ...
+
+    def __new__(cls, *flag_names, default=None, help):
+        return super().__new__(cls, *flag_names, default=default, help=help)
+
+
+class BoolOption(OptionBase[BoolT]):
+    """A bool option.
+
+    If you don't provide a `default` value, this becomes a "tri-bool" where the property will return
+    `None` if unset by the user.
+    """
+
+    option_type: Any = bool
+
+    @overload
+    def __new__(cls, *flag_names: str, default: bool, help: str) -> BoolOption[bool]:
+        ...
+
+    @overload
+    def __new__(cls, *flag_names: str, help: str) -> BoolOption[bool | None]:
+        ...
+
+    def __new__(cls, *flag_names, default=None, help):
+        return super().__new__(cls, *flag_names, default=default, help=help)
+
+
+class EnumOption(OptionBase[PropType], Generic[PropType]):
+    """An Enum option.
+
+    If you provide a `default` parameter, the `option_type` parameter will be inferred from the type
+    of the default. Otherwise, you'll need to provide the `option_type`.
+    In either case, mypy will infer the correct Generic's type-parameter, so you shouldn't need to
+    provide it.
+
+    E.g.
+        EnumOption(..., option_type=MyEnum)  # property type is deduced as `MyEnum | None`
+        EnumOption(..., default=MyEnum.Value)  # property type is deduced as `MyEnum`
+    """
+
+    @overload
+    def __new__(cls, *flag_names: str, default: EnumT, help: str) -> EnumOption[EnumT]:
+        ...
+
+    # N.B. This has an additional param for the no-default-provided case: `option_type`.
+    @overload
+    def __new__(
+        cls, *flag_names: str, option_type: Type[EnumT], help: str
+    ) -> EnumOption[EnumT | None]:
+        ...
+
+    def __new__(
+        cls,
+        *flag_names,
+        option_type=None,
+        default=None,
+        help,
+    ):
+        if option_type is None:
+            if default is None:
+                raise ValueError("`option_type` must be provided if `default` isn't provided.")
+            option_type = type(default)
+
+        return super().__new__(
+            cls, *flag_names, default=default, option_type=option_type, help=help
+        )
+
+
+class DictOption(OptionBase[FrozenDict[str, ValueType]], Generic[ValueType]):
+    """A dictionary option mapping strings to client-provided `ValueType`.
+
+    If you provide a `default` parameter, the `ValueType` type parameter will be inferred from the
+    type of the values in the default. Otherwise, you'll need to provide `ValueType` if you want a
+    non-`Any` type.
+
+    E.g.
+        # Explicit
+        DictOption[str](...)  # property type is `FrozenDict[str, str]`
+        DictOption[Any](..., default=dict(key="val"))  # property type is `FrozenDict[str, Any]`
+
+        # Implicit
+        DictOption(...)  # property type is `FrozenDict[str, Any]`
+        DictOption(..., default={"key": "val"})  # property type is `FrozenDict[str, str]`
+        DictOption(..., default=dict(key="val"))  # property type is `FrozenDict[str, str]`
+        DictOption(..., default=dict(key=1))  # property type is `FrozenDict[str, int]`
+        DictOption(..., default=dict(key1=1, key2="str"))  # property type is `FrozenDict[str, Any]`
+
+    NOTE: Dictionary values are simply returned as parsed, and are not guaranteed to be of the
+    `ValueType` specified.
+    """
+
+    option_type: Any = dict
+
+    def __new__(cls, *flag_names, default: dict[str, ValueType] | None = None, help):
+        return super().__new__(
+            cls,  # type: ignore[arg-type]
+            *flag_names,
+            default=default or {},
+            help=help,
+        )
+
+    def _convert_(self, val: Any) -> FrozenDict[str, ValueType]:
+        return FrozenDict(val)
+
+
+class TargetOption(StrOption):
+    """A Pants Target option."""
+
+    option_type: Any = custom_types.target_option
+
+
+class DirOption(StrOption):
+    """A directory option."""
+
+    option_type: Any = custom_types.dir_option
+
+
+class FileOption(StrOption):
+    """A file option."""
+
+    option_type: Any = custom_types.file_option
+
+
+class ShellStrOption(StrOption):
+    """A shell string option."""
+
+    option_type: Any = custom_types.shell_str
+
+
+class MemorySizeOption(IntOption):
+    """A memory size option."""
+
+    option_type: Any = custom_types.memory_size
+
+
+class StrListOption(ListOptionBase[str]):
+    """A homogenous list of string options."""
+
+    member_type: Any = str
+
+
+class IntListOption(ListOptionBase[int]):
+    """A homogenous list of int options."""
+
+    member_type: Any = int
+
+
+class FloatListOption(ListOptionBase[float]):
+    """A homogenous list of float options."""
+
+    member_type: Any = float
+
+
+class BoolListOption(ListOptionBase[bool]):
+    """A homogenous list of bool options.
+
+    @TODO: Tri-bool.
+    """
+
+    member_type: Any = bool
+
+
+class EnumListOption(ListOptionBase[PropType], Generic[PropType]):
+    """An homogenous list of Enum options.
+
+    If you provide a `default` parameter, the `member_type` parameter will be inferred from the type
+    of the first element of the default. Otherwise, you'll need to provide the `option_type`.
+    In either case, mypy will infer the correct Generic's type-parameter, so you shouldn't need to
+    provide it.
+
+    E.g.
+        EnumListOption(..., member_type=MyEnum)  # property type is deduced as `[MyEnum]`
+        EnumListOption(..., default=[MyEnum.Value])  # property type is deduced as `[MyEnum]`
+    """
+
+    @overload
+    def __new__(cls, *flag_names: str, default: list[EnumT], help: str) -> EnumListOption[EnumT]:
+        ...
+
+    # N.B. This has an additional param for the no-default-provided case: `member_type`.
+    @overload
+    def __new__(
+        cls, *flag_names: str, member_type: Type[EnumT], help: str
+    ) -> EnumListOption[EnumT]:
+        ...
+
+    def __new__(
+        cls,
+        *flag_names,
+        member_type=None,
+        default=None,
+        help,
+    ):
+        if member_type is None:
+            if default is None:
+                raise ValueError("`member_type` must be provided if `default` isn't provided.")
+            member_type = type(default[0])
+
+        return super().__new__(
+            cls, *flag_names, member_type=member_type, default=default, help=help
+        )
+
+
+class TargetListOption(StrListOption):
+    """A homogenous list of target options."""
+
+    member_type: Any = custom_types.target_option
+
+
+class DirListOption(StrListOption):
+    """A homogenous list of directory options."""
+
+    member_type: Any = custom_types.dir_option
+
+
+class FileListOption(StrListOption):
+    """A homogenous list of file options."""
+
+    member_type: Any = custom_types.file_option
+
+
+class ShellStrListOption(StrListOption):
+    """A homogenous list of shell string options."""
+
+    member_type: Any = custom_types.shell_str
+
+
+class MemorySizeListOption(IntListOption):
+    """A homogenous list of memory size options."""
+
+    member_type: Any = custom_types.memory_size
+
+
+class ArgsListOption(ShellStrListOption):
+    """A homogenous list of shell str options, to be used as arguments passed to some other tool.
+
+    Clients can call `passthrough()` to set the "passthrough" flag. See `passthrough` for more info.
+    """
+
+    def __new__(cls, help: str):
+        return super().__new__(
+            cls,  # type: ignore[arg-type]
+            "--args",
+            help=help,
+        )
+
+    def passthrough(self) -> "ArgsListOption":
+        """Set the "passthrough" flag.
+
+        This should be used when callers can alternatively use "--" followed by the arguments,
+        instead of having to provide "--[scope]-args='--arg1 --arg2'".
+        """
+        self.kwargs["passthrough"] = True
+        return self
+
+
+# @TODO: Add Dict Options

--- a/src/python/pants/option/option_types_test.py
+++ b/src/python/pants/option/option_types_test.py
@@ -1,0 +1,405 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from enum import Enum
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock, call
+
+import pytest
+
+from pants.option.custom_types import dir_option, file_option, memory_size, shell_str, target_option
+from pants.option.option_types import (
+    ArgsListOption,
+    BoolListOption,
+    BoolOption,
+    DictOption,
+    DirListOption,
+    DirOption,
+    EnumListOption,
+    EnumOption,
+    FileListOption,
+    FileOption,
+    FloatListOption,
+    FloatOption,
+    IntListOption,
+    IntOption,
+    MemorySizeListOption,
+    MemorySizeOption,
+    ShellStrListOption,
+    ShellStrOption,
+    StrListOption,
+    StrOption,
+    TargetListOption,
+    TargetOption,
+)
+from pants.option.subsystem import Subsystem
+from pants.util.frozendict import FrozenDict
+
+
+def test_option_typeclasses() -> None:
+    class MyEnum(Enum):
+        Val1 = "val1"
+        Val2 = "val2"
+
+    # NB: Option is only valid on Subsystem subclasses, but we won't use any Subsystem machinery for
+    # this test other than `register_options`.
+    class MySubsystem(Subsystem):
+        def __init__(self):
+            self.options = SimpleNamespace()
+            self.options.str_opt = ""
+            self.options.int_opt = 0
+            self.options.float_opt = 1.0
+            self.options.bool_opt = False
+            self.options.enum_opt = MyEnum.Val1
+            self.options.dict_opt = {"a key": "a val"}
+            self.options.target_opt = ""
+            self.options.dir_opt = "."
+            self.options.file_opt = "."
+            self.options.shellstr_opt = ""
+            self.options.memorysize_opt = 22
+            self.options.str_list_opt = ["str1", "str2"]
+            self.options.int_list_opt = [1, 2]
+            self.options.float_list_opt = [1.0, 2.0]
+            self.options.bool_list_opt = [False, True]
+            self.options.enum_list_opt = [MyEnum.Val2, MyEnum.Val1]
+            self.options.target_list_opt = ["str1", "str2"]
+            self.options.dir_list_opt = ["str1", "str2"]
+            self.options.file_list_opt = ["str1", "str2"]
+            self.options.shellstr_list_opt = ["str1", "str2"]
+            self.options.memorysize_list_opt = [33, 88]
+
+            self.options.defaultless_str_list_opt = ["str1", "str2"]
+            self.options.defaultless_int_list_opt = [1, 2]
+            self.options.defaultless_float_list_opt = [1.0, 2.0]
+            self.options.defaultless_bool_list_opt = [False, True]
+            self.options.defaultless_enum_list_opt = [MyEnum.Val2, MyEnum.Val1]
+            self.options.defaultless_target_list_opt = ["str1", "str2"]
+            self.options.defaultless_dir_list_opt = ["str1", "str2"]
+            self.options.defaultless_file_list_opt = ["str1", "str2"]
+            self.options.defaultless_shellstr_list_opt = ["str1", "str2"]
+            self.options.defaultless_memorysize_list_opt = [33, 88]
+
+            # NB: These must be set to None, as we must assert they are `None`.
+            # See the comment above the `is None` assertions for more detail.
+            # Once we test the types a better way, these should probably be set to values.
+            self.options.optional_str_opt = None
+            self.options.optional_int_opt = None
+            self.options.optional_float_opt = None
+            self.options.optional_bool_opt = None
+            self.options.optional_enum_opt = None
+            self.options.optional_target_opt = None
+            self.options.optional_dir_opt = None
+            self.options.optional_file_opt = None
+            self.options.optional_shellstr_opt = None
+            self.options.optional_memorysize_opt = None
+
+            # Misc types
+            self.options.args = ["arg1", "arg2"]
+
+        str_prop = StrOption("--str-opt", default="a str", help="")
+        int_prop = IntOption("--int-opt", default=500, help="")
+        float_prop = FloatOption("--float-opt", default=0.0, help="")
+        bool_prop = BoolOption("--bool-opt", default=True, help="")
+        enum_prop = EnumOption("--enum-opt", default=MyEnum.Val1, help="")
+        dict_prop = DictOption("--dict-opt", default={"key": "val"}, help="")
+        target_prop = TargetOption("--target-opt", default="a str", help="")
+        dir_prop = DirOption("--dir-opt", default="a str", help="")
+        file_prop = FileOption("--file-opt", default="a str", help="")
+        shellstr_prop = ShellStrOption("--shellstr-opt", default="a str", help="")
+        memorysize_prop = MemorySizeOption("--memorysize-opt", default=20, help="")
+
+        # Optional options
+        optional_str_prop = StrOption("--optional-str-opt", help="")
+        optional_int_prop = IntOption("--optional-int-opt", help="")
+        optional_float_prop = FloatOption("--optional-float-opt", help="")
+        optional_bool_prop = BoolOption("--optional-bool-opt", help="")
+        optional_enum_prop = EnumOption("--optional-enum-opt", option_type=MyEnum, help="")
+        optional_target_prop = TargetOption("--optional-target-opt", help="")
+        optional_dir_prop = DirOption("--optional-dir-opt", help="")
+        optional_file_prop = FileOption("--optional-file-opt", help="")
+        optional_shellstr_prop = ShellStrOption("--optional-shellstr-opt", help="")
+        optional_memorysize_prop = MemorySizeOption("--optional-memorysize-opt", help="")
+
+        # List options
+        str_list_prop = StrListOption("--str-list-opt", default=["a str"], help="")
+        int_list_prop = IntListOption("--int-list-opt", default=[10], help="")
+        float_list_prop = FloatListOption("--float-list-opt", default=[9.9], help="")
+        bool_list_prop = BoolListOption("--bool-list-opt", default=[True], help="")
+        enum_list_prop = EnumListOption("--enum-list-opt", default=[MyEnum.Val1], help="")
+        target_list_prop = TargetListOption("--target-list-opt", default=["a str"], help="")
+        dir_list_prop = DirListOption("--dir-list-opt", default=["a str"], help="")
+        file_list_prop = FileListOption("--file-list-opt", default=["a str"], help="")
+        shellstr_list_prop = ShellStrListOption("--shellstr-list-opt", default=["a str"], help="")
+        memorysize_list_prop = MemorySizeListOption("--memorysize-list-opt", default=[22], help="")
+        # And without default provided
+        defaultless_str_list_prop = StrListOption("--defaultless-str-list-opt", help="")
+        defaultless_int_list_prop = IntListOption("--defaultless-int-list-opt", help="")
+        defaultless_float_list_prop = FloatListOption("--defaultless-float-list-opt", help="")
+        defaultless_bool_list_prop = BoolListOption("--defaultless-bool-list-opt", help="")
+        defaultless_enum_list_prop = EnumListOption(
+            "--defaultless-enum-list-opt", member_type=MyEnum, help=""
+        )
+        defaultless_target_list_prop = TargetListOption("--defaultless-target-list-opt", help="")
+        defaultless_dir_list_prop = DirListOption("--defaultless-dir-list-opt", help="")
+        defaultless_file_list_prop = FileListOption("--defaultless-file-list-opt", help="")
+        defaultless_shellstr_list_prop = ShellStrListOption(
+            "--defaultless-shellstr-list-opt", help=""
+        )
+        defaultless_memorysize_list_prop = MemorySizeListOption(
+            "--defaultless-memorysize-list-opt", help=""
+        )
+
+        # Misc options
+        args_prop = ArgsListOption(help="")
+
+    register = Mock()
+    MySubsystem.register_options(register)
+
+    assert register.call_args_list == [
+        call("--str-opt", type=str, default="a str", help=""),
+        call("--int-opt", type=int, default=500, help=""),
+        call("--float-opt", type=float, default=0.0, help=""),
+        call("--bool-opt", type=bool, default=True, help=""),
+        call("--enum-opt", type=MyEnum, default=MyEnum.Val1, help=""),
+        call("--dict-opt", type=dict, default={"key": "val"}, help=""),
+        call("--target-opt", type=target_option, default="a str", help=""),
+        call("--dir-opt", type=dir_option, default="a str", help=""),
+        call("--file-opt", type=file_option, default="a str", help=""),
+        call("--shellstr-opt", type=shell_str, default="a str", help=""),
+        call("--memorysize-opt", type=memory_size, default=20, help=""),
+        call("--optional-str-opt", type=str, default=None, help=""),
+        call("--optional-int-opt", type=int, default=None, help=""),
+        call("--optional-float-opt", type=float, default=None, help=""),
+        call("--optional-bool-opt", type=bool, default=None, help=""),
+        call("--optional-enum-opt", type=MyEnum, default=None, help=""),
+        call("--optional-target-opt", type=target_option, default=None, help=""),
+        call("--optional-dir-opt", type=dir_option, default=None, help=""),
+        call("--optional-file-opt", type=file_option, default=None, help=""),
+        call("--optional-shellstr-opt", type=shell_str, default=None, help=""),
+        call("--optional-memorysize-opt", type=memory_size, default=None, help=""),
+        call("--str-list-opt", type=list, default=["a str"], help="", member_type=str),
+        call("--int-list-opt", type=list, default=[10], help="", member_type=int),
+        call("--float-list-opt", type=list, default=[9.9], help="", member_type=float),
+        call("--bool-list-opt", type=list, default=[True], help="", member_type=bool),
+        call("--enum-list-opt", type=list, default=[MyEnum.Val1], help="", member_type=MyEnum),
+        call(
+            "--target-list-opt",
+            type=list,
+            default=["a str"],
+            help="",
+            member_type=target_option,
+        ),
+        call("--dir-list-opt", type=list, default=["a str"], help="", member_type=dir_option),
+        call("--file-list-opt", type=list, default=["a str"], help="", member_type=file_option),
+        call("--shellstr-list-opt", type=list, default=["a str"], help="", member_type=shell_str),
+        call("--memorysize-list-opt", type=list, default=[22], help="", member_type=memory_size),
+        call("--defaultless-str-list-opt", type=list, default=[], help="", member_type=str),
+        call("--defaultless-int-list-opt", type=list, default=[], help="", member_type=int),
+        call("--defaultless-float-list-opt", type=list, default=[], help="", member_type=float),
+        call("--defaultless-bool-list-opt", type=list, default=[], help="", member_type=bool),
+        call("--defaultless-enum-list-opt", type=list, default=[], help="", member_type=MyEnum),
+        call(
+            "--defaultless-target-list-opt",
+            type=list,
+            default=[],
+            help="",
+            member_type=target_option,
+        ),
+        call("--defaultless-dir-list-opt", type=list, default=[], help="", member_type=dir_option),
+        call(
+            "--defaultless-file-list-opt", type=list, default=[], help="", member_type=file_option
+        ),
+        call(
+            "--defaultless-shellstr-list-opt", type=list, default=[], help="", member_type=shell_str
+        ),
+        call(
+            "--defaultless-memorysize-list-opt",
+            type=list,
+            default=[],
+            help="",
+            member_type=memory_size,
+        ),
+        call("--args", type=list, default=[], help="", member_type=shell_str),
+    ]
+
+    my_subsystem = MySubsystem()
+    assert my_subsystem.str_prop == ""
+    assert my_subsystem.int_prop == 0
+    assert my_subsystem.float_prop == 1.0
+    assert not my_subsystem.bool_prop
+    assert my_subsystem.enum_prop == MyEnum.Val1
+    assert my_subsystem.dict_prop == FrozenDict({"a key": "a val"})
+    assert my_subsystem.target_prop == ""
+    assert my_subsystem.dir_prop == "."
+    assert my_subsystem.file_prop == "."
+    assert my_subsystem.shellstr_prop == ""
+    assert my_subsystem.memorysize_prop == 22
+    assert my_subsystem.str_list_prop == ("str1", "str2")
+    assert my_subsystem.int_list_prop == (1, 2)
+    assert my_subsystem.float_list_prop == (1.0, 2.0)
+    assert my_subsystem.bool_list_prop == (False, True)
+    assert my_subsystem.enum_list_prop == (MyEnum.Val2, MyEnum.Val1)
+    assert my_subsystem.target_list_prop == ("str1", "str2")
+    assert my_subsystem.shellstr_list_prop == ("str1", "str2")
+    assert my_subsystem.memorysize_list_prop == (33, 88)
+    assert my_subsystem.defaultless_str_list_prop == ("str1", "str2")
+    assert my_subsystem.defaultless_int_list_prop == (1, 2)
+    assert my_subsystem.defaultless_float_list_prop == (1.0, 2.0)
+    assert my_subsystem.defaultless_bool_list_prop == (False, True)
+    assert my_subsystem.defaultless_enum_list_prop == (MyEnum.Val2, MyEnum.Val1)
+    assert my_subsystem.defaultless_target_list_prop == ("str1", "str2")
+    assert my_subsystem.defaultless_dir_list_prop == ("str1", "str2")
+    assert my_subsystem.defaultless_file_list_prop == ("str1", "str2")
+    assert my_subsystem.defaultless_shellstr_list_prop == ("str1", "str2")
+    assert my_subsystem.defaultless_memorysize_list_prop == (33, 88)
+    assert my_subsystem.args_prop == ("arg1", "arg2")
+
+    # These not only assert that we got the right value out of the `options` object, but also
+    # (indirectly) test that our property type is actually `Optional[T]` and not accidentally `T`.
+    # It does so by relying on two things:
+    #   - If the type was `T`, these assertions would always trigger
+    #   - Because there's code following these asserts, mypy would error that the code is
+    #     unreachable if we got this wrong.
+    assert my_subsystem.optional_str_prop is None
+    assert my_subsystem.optional_int_prop is None
+    assert my_subsystem.optional_float_prop is None
+    assert my_subsystem.optional_bool_prop is None
+    assert my_subsystem.optional_enum_prop is None
+    assert my_subsystem.optional_target_prop is None
+    assert my_subsystem.optional_dir_prop is None
+    assert my_subsystem.optional_file_prop is None
+    assert my_subsystem.optional_shellstr_prop is None
+    assert my_subsystem.optional_memorysize_prop is None
+
+    # This "tests" (through mypy) that the property types are what we expect
+    # Ideally, we'd test these with pytest-mypy-plugins (or similar)
+    #
+    # There's no point in repeating this for optional vars. If we got the type wrong
+    # (E.g. the property is `str` instead of `str | None`) mypy is happy to "promote" `str` to
+    # `str | None`. This gets tested via the "unreachable code" checks above.
+    var_str: str = my_subsystem.str_prop  # noqa: F841
+    var_int: int = my_subsystem.int_prop  # noqa: F841
+    var_float: float = my_subsystem.float_prop  # noqa: F841
+    var_bool: bool = my_subsystem.bool_prop  # noqa: F841
+    var_enum: MyEnum = my_subsystem.enum_prop  # noqa: F841
+    var_dict: FrozenDict[str, str] = my_subsystem.dict_prop  # noqa: F841
+
+    var_target: str = my_subsystem.target_prop  # noqa: F841
+    var_dir: str = my_subsystem.dir_prop  # noqa: F841
+    var_file: str = my_subsystem.file_prop  # noqa: F841
+    var_shellstr: str = my_subsystem.shellstr_prop  # noqa: F841
+    var_memorysize: int = my_subsystem.memorysize_prop  # noqa: F841
+
+    var_str_list: tuple[str, ...] = my_subsystem.str_list_prop  # noqa: F841
+    var_int_list: tuple[int, ...] = my_subsystem.int_list_prop  # noqa: F841
+    var_float_list: tuple[float, ...] = my_subsystem.float_list_prop  # noqa: F841
+    var_bool_list: tuple[bool, ...] = my_subsystem.bool_list_prop  # noqa: F841
+    var_enum_list: tuple[MyEnum, ...] = my_subsystem.enum_list_prop  # noqa: F841
+    var_target_list: tuple[str, ...] = my_subsystem.target_list_prop  # noqa: F841
+    var_dir_list: tuple[str, ...] = my_subsystem.dir_list_prop  # noqa: F841
+    var_file_list: tuple[str, ...] = my_subsystem.file_list_prop  # noqa: F841
+    var_shellstr_list: tuple[str, ...] = my_subsystem.shellstr_list_prop  # noqa: F841
+    var_memorysize_list: tuple[int, ...] = my_subsystem.memorysize_list_prop  # noqa: F841
+
+    var_args: tuple[str, ...] = my_subsystem.args_prop  # noqa: F841
+
+
+@pytest.mark.parametrize(
+    "prop_type, opt_val",
+    [
+        (DirOption, ""),
+        (FileOption, ""),
+        (MemorySizeOption, "2GiB"),
+        (DirListOption, [""]),
+        (FileListOption, [""]),
+        (MemorySizeListOption, ["2GiB"]),
+    ],
+)
+def test_conversion(prop_type, opt_val) -> None:
+    class MySubsystem(Subsystem):
+        def __init__(self):
+            self.options = SimpleNamespace()
+            self.options.opt = opt_val
+
+        prop = prop_type("--opt", help="")
+
+    my_subsystem = MySubsystem()
+    # We don't need to test the actual function, just that it transformed the value into something
+    # else.
+    assert my_subsystem.prop != opt_val
+
+
+def test_builder_methods():
+    class MySubsystem(Subsystem):
+        def __init__(self):
+            self.options = SimpleNamespace()
+
+        prop = (
+            StrOption("--opt", default=None, help="")
+            .advanced()
+            .metavar("META")
+            .from_file()
+            .mutually_exclusive_group("group")
+            .default_help_repr("Help!")
+            .will_be_removed(version="99.9.9", hint="it's purple")
+            .daemoned()
+            .non_fingerprinted()
+        )
+
+    assert MySubsystem.prop.kwargs["advanced"]
+    assert MySubsystem.prop.kwargs["metavar"] == "META"
+    assert MySubsystem.prop.kwargs["fromfile"]
+    assert MySubsystem.prop.kwargs["mutually_exclusive_group"] == "group"
+    assert MySubsystem.prop.kwargs["default_help_repr"] == "Help!"
+    assert MySubsystem.prop.kwargs["removal_version"] == "99.9.9"
+    assert MySubsystem.prop.kwargs["removal_hint"] == "it's purple"
+    assert MySubsystem.prop.kwargs["daemon"]
+    assert not MySubsystem.prop.kwargs["fingerprint"]
+
+
+def test_subsystem_option_ordering() -> None:
+    class MySubsystemBase(Subsystem):
+        # Make sure these are out of alphabetical order
+        z_prop = StrOption("--z", help="")
+        y_prop = StrOption("--y", help="")
+
+    class MySubsystem(MySubsystemBase):
+        b_prop = StrOption("--b", help="")
+        a_prop = StrOption("--a", help="")
+
+    register = Mock()
+    MySubsystem.register_options(register)
+    assert register.call_args_list == [
+        call("--z", type=str, default=None, help=""),
+        call("--y", type=str, default=None, help=""),
+        call("--b", type=str, default=None, help=""),
+        call("--a", type=str, default=None, help=""),
+    ]
+
+
+def test_dict_option_valuetype() -> None:
+    class MySubsystem(Subsystem):
+        def __init__(self):
+            self.options = SimpleNamespace()
+            self.options.opt = None
+
+        d1 = DictOption[str]("--opt", help="")
+        d2 = DictOption[Any]("--opt", default=dict(key="val"), help="")
+        # mypy correctly complains about needing a type annotation
+        d3 = DictOption("--opt", help="")  # type: ignore[var-annotated]
+        d4 = DictOption("--opt", default={"key": "val"}, help="")
+        d5 = DictOption("--opt", default=dict(key="val"), help="")
+        d6 = DictOption("--opt", default=dict(key=1), help="")
+        d7 = DictOption("--opt", default=dict(key1=1, key2="str"), help="")
+
+    my_subsystem = MySubsystem()
+    d1: FrozenDict[str, str] = my_subsystem.d1  # noqa: F841
+    d2: FrozenDict[str, Any] = my_subsystem.d2  # noqa: F841
+    d3: FrozenDict[str, Any] = my_subsystem.d3  # noqa: F841
+    d4: FrozenDict[str, str] = my_subsystem.d4  # noqa: F841
+    d5: FrozenDict[str, str] = my_subsystem.d5  # noqa: F841
+    d6: FrozenDict[str, int] = my_subsystem.d6  # noqa: F841
+    d7: FrozenDict[str, Any] = my_subsystem.d7  # noqa: F841

--- a/src/python/pants/option/subsystem.py
+++ b/src/python/pants/option/subsystem.py
@@ -7,11 +7,11 @@ import functools
 import inspect
 import re
 from abc import ABCMeta
-from typing import Any, Callable, ClassVar, Generic, TypeVar, overload
+from typing import Any, ClassVar, TypeVar
 
 from pants.engine.internals.selectors import AwaitableConstraints, Get
-from pants.option.custom_types import shell_str
 from pants.option.errors import OptionsError
+from pants.option.option_types import OptionBase
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.scope import Scope, ScopedOptions, ScopeInfo, normalize_scope
 
@@ -101,10 +101,11 @@ class Subsystem(metaclass=ABCMeta):
 
         Subclasses may override and call register(*args, **kwargs).
         """
-        for attrname in dir(cls):
-            attr = getattr(cls, attrname)
-            if isinstance(attr, Option):
-                register(*attr.args, **attr.kwargs)
+        # NB: We register these in class attribute order, starting from the base class down.
+        for class_ in reversed(inspect.getmro(cls)):
+            for attr in class_.__dict__.values():
+                if isinstance(attr, OptionBase):
+                    register(*attr.flag_names, **attr.kwargs)
 
     @classmethod
     def register_options_on_scope(cls, options):
@@ -125,77 +126,6 @@ class Subsystem(metaclass=ABCMeta):
 
 
 _SubsystemT = TypeVar("_SubsystemT", bound=Subsystem)
-_T = TypeVar("_T")
-
-
-class Option(Generic[_T]):
-    """Descriptor for subsystem options.
-
-    This class serves two purposes:
-        - Register your subsystem's options
-        - Provide a typed property for Python usage
-
-    Usage:
-        class Engine(Subsystem):
-            ...
-
-            cylinders = Option[int]("--cylinders", default=6, help="...")
-
-        ...
-
-        engine: Engine = ...
-        engine.cylinders  # mypy knows this is an int
-
-    Under-the-hood:
-        - You can pass a `converter` function to convert the option value into the property value
-            E.g. `converter=tuple`
-    """
-
-    # NB: We have to ignore type because we can't `cast(_T, x)` as `_T` is purely a type-checking
-    # construct and `cast()` is a runtime function.
-    DEFAULT_CONVERTER: Callable[[Any], _T] = lambda x: x  # type: ignore
-
-    def __init__(
-        self,
-        *args: str,
-        converter: Callable[[Any], _T] = DEFAULT_CONVERTER,
-        **kwargs: Any,
-    ):
-        self.args = args
-        self.kwargs = kwargs
-        self._converter = converter
-
-    @overload
-    def __get__(self, obj: None, objtype: type[_SubsystemT]) -> Option:
-        ...
-
-    @overload
-    def __get__(self, obj: _SubsystemT, objtype: type[_SubsystemT]) -> _T:
-        ...
-
-    def __get__(self, obj: _SubsystemT | None, objtype: type[_SubsystemT]) -> Option | _T:
-        assert issubclass(
-            objtype, Subsystem
-        ), "Option should only be used as attributes of a Subsystem"
-        if obj is None:
-            return self
-        long_name = self.args[-1]
-        option_value = getattr(obj.options, long_name[2:].replace("-", "_"))
-        return self._converter(option_value)
-
-
-BoolOption: functools.partial[Option[bool]] = functools.partial(Option, type=bool)
-StrOption: functools.partial[Option[str]] = functools.partial(Option, type=str)
-IntOption: functools.partial[Option[int]] = functools.partial(Option, type=int)
-# NB: You'll still need to prive help=""
-ArgsOption: functools.partial[Option["tuple[str, ...]"]] = functools.partial(
-    Option,
-    "--args",
-    type=list,
-    member_type=shell_str,
-    passthrough=True,
-    converter=tuple,
-)
 
 
 async def _construct_subsytem(subsystem_typ: type[_SubsystemT]) -> _SubsystemT:

--- a/src/python/pants/option/subsystem.py
+++ b/src/python/pants/option/subsystem.py
@@ -11,7 +11,7 @@ from typing import Any, ClassVar, TypeVar
 
 from pants.engine.internals.selectors import AwaitableConstraints, Get
 from pants.option.errors import OptionsError
-from pants.option.option_types import OptionBase
+from pants.option.option_types import _OptionBase
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.scope import Scope, ScopedOptions, ScopeInfo, normalize_scope
 
@@ -101,11 +101,12 @@ class Subsystem(metaclass=ABCMeta):
 
         Subclasses may override and call register(*args, **kwargs).
         """
-        # NB: We register these in class attribute order, starting from the base class down.
+        # NB: Since registration ordering matters (it impacts `help` output), we register these in
+        # class attribute order, starting from the base class down.
         for class_ in reversed(inspect.getmro(cls)):
             for attr in class_.__dict__.values():
-                if isinstance(attr, OptionBase):
-                    register(*attr.flag_names, **attr.kwargs)
+                if isinstance(attr, _OptionBase):
+                    register(*attr.flag_names, **attr.flag_options)
 
     @classmethod
     def register_options_on_scope(cls, options):

--- a/src/python/pants/option/subsystem_test.py
+++ b/src/python/pants/option/subsystem_test.py
@@ -1,17 +1,11 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import annotations
-
-from types import SimpleNamespace
-from unittest.mock import Mock, call
-
 import pytest
 
-from pants.option.custom_types import shell_str
 from pants.option.errors import OptionsError
 from pants.option.option_value_container import OptionValueContainer
-from pants.option.subsystem import ArgsOption, BoolOption, IntOption, Option, StrOption, Subsystem
+from pants.option.subsystem import Subsystem
 
 
 def test_scope_existence() -> None:
@@ -61,98 +55,3 @@ def test_is_valid_scope_name() -> None:
     check_false("foo.bar.")
     check_false("foo--bar")
     check_false("foo-bar-")
-
-
-def test_option() -> None:
-    # NB: Option is only valid on Subsystem subclasses, but we won't use any Subsystem machinery for
-    # this test.
-    class Ghostbusters(Subsystem):
-        def __init__(self):
-            self.options = SimpleNamespace()
-            self.options.peter_venkman = "He slimed me!"
-            self.options.egon_spengler = 5000
-            self.options.raymond_stantz = ["HOLDIN!", "SMOKIN!", "READY!"]
-
-        cast1 = Option[str]("-p", "--peter-venkman", actor_name="Bill Murray")
-        cast2 = Option[int]("--egon-spengler", actor_name="Harold Ramis")
-        cast3 = Option["tuple[str, ...]"]("--raymond-stantz", converter=tuple)
-
-    assert Ghostbusters.cast1.args == ("-p", "--peter-venkman")
-    assert Ghostbusters.cast1.kwargs == dict(actor_name="Bill Murray")
-    assert Ghostbusters.cast2.args == ("--egon-spengler",)
-    assert Ghostbusters.cast2.kwargs == dict(actor_name="Harold Ramis")
-
-    who_im_gonna_call = Ghostbusters()
-    assert who_im_gonna_call.cast1 == "He slimed me!"
-    assert who_im_gonna_call.cast2 == 5000
-    assert who_im_gonna_call.cast3 == ("HOLDIN!", "SMOKIN!", "READY!")
-
-    # This "tests" (through mypy) that the property types are what we expect
-    var1: str = who_im_gonna_call.cast1  # noqa: F841
-    var2: int = who_im_gonna_call.cast2  # noqa: F841
-    var3: tuple[str, ...] = who_im_gonna_call.cast3  # noqa: F841
-
-
-def test_option_in_subsystem() -> None:
-    class Ghostbusters(Subsystem):
-        options_scope = "ghostbusters"
-
-        cast1 = Option[str]("-p", "--peter-venkman", actor_name="Bill Murray")
-        cast2 = Option[int]("--egon-spengler", actor_name="Harold Ramis")
-        cast3 = Option["tuple[str, ...]"](
-            "--raymond-stantz", actor_name="Dan Aykroyd", converter=tuple
-        )
-
-    register = Mock()
-    Ghostbusters.register_options(register)
-
-    register.assert_has_calls(
-        [
-            call("-p", "--peter-venkman", actor_name="Bill Murray"),
-            call("--egon-spengler", actor_name="Harold Ramis"),
-            call("--raymond-stantz", actor_name="Dan Aykroyd"),
-        ],
-        any_order=True,
-    )
-
-
-def test_option_typeclasses() -> None:
-    # NB: Option is only valid on Subsystem subclasses, but we won't use any Subsystem machinery for
-    # this test.
-    class SubmarineSystems(Subsystem):
-        def __init__(self):
-            self.options = SimpleNamespace()
-            self.options.propulsion = False
-            self.options.hydraulic = ""
-            self.options.radar = 0
-            self.options.args = ["looky"]
-
-        bool_opt = BoolOption("--propulsion", help="propulsion")
-        str_opt = StrOption("--hydraulic", help="hydraulic")
-        int_opt = IntOption("--radar", help="radar")
-        args_opt = ArgsOption(help="periscope")
-
-    register = Mock()
-    SubmarineSystems.register_options(register)
-
-    register.assert_has_calls(
-        [
-            call("--propulsion", type=bool, help="propulsion"),
-            call("--hydraulic", type=str, help="hydraulic"),
-            call("--radar", type=int, help="radar"),
-            call("--args", type=list, member_type=shell_str, passthrough=True, help="periscope"),
-        ],
-        any_order=True,
-    )
-
-    systems = SubmarineSystems()
-    assert not systems.bool_opt
-    assert systems.str_opt == ""
-    assert systems.int_opt == 0
-    assert systems.args_opt == ("looky",)
-
-    # This "tests" (through mypy) that the property types are what we expect
-    var1: bool = systems.bool_opt  # noqa: F841
-    var2: str = systems.str_opt  # noqa: F841
-    var3: int = systems.int_opt  # noqa: F841
-    var4: tuple[str, ...] = systems.args_opt  # noqa: F841


### PR DESCRIPTION
Adding `option_types.py` which is meant to be a complete set of all possible option types. Each possible type has been stamped out into a concretely(-ish for Enums) typed class.

__Great__ (great, great, _great_) care has been taken to make this as boilerplate-free and "automagical" as possible. Unfortunately, after countless hours, I've come to realize there is no no-boilerplate solution. This one at least contains the boilerplate to one file, so that's ultimately a huge win.

The client code retrofits will follow in a separate PR. All the Pants call sites have been audited to ensure the kwargs are handled here.

I don't expect this to be the final iteration of this code. But I wanted to lay enough groundwork that 80% of the existing code can switch over without a hitch. Further modifications will possibly be made in the same PR as switchover.

![oh yeah](https://media.giphy.com/media/KEYEpIngcmXlHetDqz/giphy.gif)
