### PR TITLE
[wip] Add failing test for import parser

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/parse_python_imports_test.py
+++ b/src/python/pants/backend/python/dependency_inference/parse_python_imports_test.py
@@ -98,7 +98,8 @@ def test_normal_imports(rule_runner: RuleRunner) -> None:
             ignored3 as  # pants: no-infer-dep
                 alias3,
             ignored4 as alias4, ignored4,  # pants: no-infer-dep
-            not_ignored2,
+            not_ignored2, \\
+            not_ignored3
         )
         from multiline_import2 import (ignored1,  # pants: no-infer-dep
             not_ignored)
@@ -121,8 +122,9 @@ def test_normal_imports(rule_runner: RuleRunner) -> None:
             "project.demo.OriginalName": ImpInfo(lineno=12, weak=False),
             "multiline_import1.not_ignored1": ImpInfo(lineno=16, weak=False),
             "multiline_import1.not_ignored2": ImpInfo(lineno=23, weak=False),
-            "multiline_import2.not_ignored": ImpInfo(lineno=26, weak=False),
-            "project.circular_dep.CircularDep": ImpInfo(lineno=29, weak=False),
+            "multiline_import1.not_ignored3": ImpInfo(lineno=24, weak=False),
+            "multiline_import2.not_ignored": ImpInfo(lineno=27, weak=False),
+            "project.circular_dep.CircularDep": ImpInfo(lineno=30, weak=False),
         },
     )
 


### PR DESCRIPTION
Failure looks like:

```
E           stderr:
E           Traceback (most recent call last):
E             File "./__parse_python_imports.py", line 194, in <module>
E               main(sys.argv[1])
E             File "./__parse_python_imports.py", line 172, in main
E               visitor.visit(tree)
E             File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/ast.py", line 360, in visit
E               return visitor(node)
E             File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/ast.py", line 368, in generic_visit
E               self.visit(item)
E             File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/ast.py", line 360, in visit
E               return visitor(node)
E             File "./__parse_python_imports.py", line 97, in visit_ImportFrom
E               self._visit_import_stmt(node, abs_module + ".")
E             File "./__parse_python_imports.py", line 76, in _visit_import_stmt
E               while token[4].endswith("\\"):
E           TypeError: 'NoneType' object is not subscriptable
E           
E           
E           
E           Use `--no-process-cleanup` to preserve process chroots for inspection.

```

[ci skip-rust]
[ci skip-build-wheels]