### PR TITLE
[internal] Refactor and expand Python lockfile validation tests

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_requirements_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements_test.py
@@ -39,10 +39,10 @@ def create_tool_lock(
         uses_project_interpreter_constraints=uses_project_interpreter_constraints,
     )
     return (
-        ToolDefaultLockfile(file_content=FileContent("", b""), **common_kwargs)
+        ToolDefaultLockfile(file_content=FileContent("", b""), **common_kwargs)  # type: ignore[arg-type]
         if default_lock
         else ToolCustomLockfile(
-            file_path="lock.txt", file_path_description_of_origin="", **common_kwargs
+            file_path="lock.txt", file_path_description_of_origin="", **common_kwargs  # type: ignore[arg-type]
         )
     )
 

--- a/src/python/pants/backend/python/util_rules/pex_requirements_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements_test.py
@@ -3,33 +3,87 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-
 import pytest
 
 from pants.backend.python.pip_requirement import PipRequirement
-from pants.backend.python.subsystems.setup import InvalidLockfileBehavior
+from pants.backend.python.subsystems.setup import InvalidLockfileBehavior, PythonSetup
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.lockfile_metadata import PythonLockfileMetadataV2
 from pants.backend.python.util_rules.pex_requirements import (
-    Lockfile,
-    LockfileContent,
     ToolCustomLockfile,
     ToolDefaultLockfile,
     maybe_validate_metadata,
 )
+from pants.core.util_rules.lockfile_metadata import InvalidLockfileError
 from pants.engine.fs import FileContent
+from pants.testutil.option_util import create_subsystem
 from pants.util.ordered_set import FrozenOrderedSet
 
-DEFAULT = "DEFAULT"
-FILE = "FILE"
+METADATA = PythonLockfileMetadataV2(
+    InterpreterConstraints(["==3.8.*"]), {PipRequirement.parse("ansicolors")}
+)
+
+
+def create_tool_lock(
+    req_strings: list[str],
+    *,
+    default_lock: bool = False,
+    uses_source_plugins: bool = False,
+    uses_project_interpreter_constraints: bool = False,
+) -> ToolDefaultLockfile | ToolCustomLockfile:
+    common_kwargs = dict(
+        lockfile_hex_digest=None,
+        req_strings=FrozenOrderedSet(req_strings),
+        options_scope_name="my_tool",
+        uses_source_plugins=uses_source_plugins,
+        uses_project_interpreter_constraints=uses_project_interpreter_constraints,
+    )
+    return (
+        ToolDefaultLockfile(file_content=FileContent("", b""), **common_kwargs)
+        if default_lock
+        else ToolCustomLockfile(
+            file_path="lock.txt", file_path_description_of_origin="", **common_kwargs
+        )
+    )
+
+
+def create_python_setup(behavior: InvalidLockfileBehavior) -> PythonSetup:
+    return create_subsystem(
+        PythonSetup,
+        invalid_lockfile_behavior=behavior,
+        interpreter_versions_universe=PythonSetup.default_interpreter_universe,
+    )
+
+
+def test_invalid_lockfile_behavior_option(caplog) -> None:
+    """Test that you can toggle between warnings, errors, and ignoring."""
+
+    def validate(behavior: InvalidLockfileBehavior) -> None:
+        maybe_validate_metadata(
+            lambda: METADATA,
+            METADATA.valid_for_interpreter_constraints,
+            create_tool_lock(["bad-req"]),
+            create_python_setup(behavior),
+        )
+
+    caplog.clear()
+    validate(InvalidLockfileBehavior.ignore)
+    assert not caplog.records
+
+    validate(InvalidLockfileBehavior.warn)
+    assert caplog.records
+    assert "./pants generate-lockfiles" in caplog.text
+    caplog.clear()
+
+    with pytest.raises(InvalidLockfileError, match="./pants generate-lockfiles"):
+        validate(InvalidLockfileBehavior.error)
 
 
 @pytest.mark.parametrize(
-    "lockfile_type,invalid_reqs,invalid_constraints,uses_source_plugins,uses_project_ic",
+    "is_default_lock,invalid_reqs,invalid_constraints,uses_source_plugins,uses_project_ic",
     [
-        (lockfile_type, invalid_reqs, invalid_constraints, source_plugins, project_ics)
-        for lockfile_type in (DEFAULT, FILE)
+        (is_default_lock, invalid_reqs, invalid_constraints, source_plugins, project_ics)
+        for is_default_lock in (True, False)
         for invalid_reqs in (True, False)
         for invalid_constraints in (True, False)
         for source_plugins in (True, False)
@@ -37,136 +91,54 @@ FILE = "FILE"
         if (invalid_reqs or invalid_constraints)
     ],
 )
-def test_validate_metadata(
-    lockfile_type: str,
-    invalid_reqs,
-    invalid_constraints,
-    uses_source_plugins,
-    uses_project_ic,
+def test_validate_tool_lockfiles(
+    is_default_lock: bool,
+    invalid_reqs: bool,
+    invalid_constraints: bool,
+    uses_source_plugins: bool,
+    uses_project_ic: bool,
     caplog,
 ) -> None:
-    class M:
-        opening_default = "You are using the `<default>` lockfile provided by Pants"
-        opening_file = "You are using the lockfile at"
-
-        invalid_requirements = (
-            "You have set different requirements than those used to generate the lockfile"
-        )
-        invalid_requirements_source_plugins = ".source_plugins`, and"
-
-        invalid_interpreter_constraints = "You have set interpreter constraints"
-        invalid_interpreter_constraints_tool_ics = (
-            ".interpreter_constraints`, or by using a new custom lockfile."
-        )
-        invalid_interpreter_constraints_project_ics = (
-            "determines its interpreter constraints based on your code's own constraints."
-        )
-
-        closing_lockfile_content = (
-            "To generate a custom lockfile based on your current configuration"
-        )
-        closing_file = "To regenerate your lockfile based on your current configuration"
-
-    (
-        actual_constraints,
-        expected_constraints,
-        actual_requirements,
-        expected_requirements,
-    ) = _metadata_validation_values(invalid_reqs, invalid_constraints)
-
-    metadata = PythonLockfileMetadataV2(
-        InterpreterConstraints([expected_constraints]), expected_requirements
+    runtime_interpreter_constraints = (
+        InterpreterConstraints(["==2.7.*"])
+        if invalid_constraints
+        else METADATA.valid_for_interpreter_constraints
     )
-    requirements = _prepare_pex_requirements(
-        lockfile_type,
-        actual_requirements,
-        uses_source_plugins,
-        uses_project_ic,
+    requirements = create_tool_lock(
+        ["bad-req" if invalid_reqs else "ansicolors"],
+        default_lock=is_default_lock,
+        uses_source_plugins=uses_source_plugins,
+        uses_project_interpreter_constraints=uses_project_ic,
     )
-
-    python_setup = MagicMock(
-        invalid_lockfile_behavior=InvalidLockfileBehavior.warn,
-        interpreter_universe=["3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"],
-    )
-
     maybe_validate_metadata(
-        lambda: metadata, InterpreterConstraints([actual_constraints]), requirements, python_setup
+        lambda: METADATA,
+        runtime_interpreter_constraints,
+        requirements,
+        create_python_setup(InvalidLockfileBehavior.warn),
     )
 
-    txt = caplog.text.strip()
+    def contains(msg: str, if_: bool) -> None:
+        assert (msg in caplog.text) is if_
 
-    expected_opening = {
-        DEFAULT: M.opening_default,
-        FILE: M.opening_file,
-    }[lockfile_type]
+    contains("You are using the `<default>` lockfile provided by Pants", if_=is_default_lock)
+    contains("You are using the lockfile at lock.txt", if_=not is_default_lock)
 
-    assert expected_opening in txt
+    contains("You have set different requirements", if_=invalid_reqs)
+    contains(".source_plugins`, and", if_=invalid_reqs and uses_source_plugins)
 
-    if invalid_reqs:
-        assert M.invalid_requirements in txt
-        if uses_source_plugins:
-            assert M.invalid_requirements_source_plugins in txt
-        else:
-            assert M.invalid_requirements_source_plugins not in txt
-    else:
-        assert M.invalid_requirements not in txt
-
-    if invalid_constraints:
-        assert M.invalid_interpreter_constraints in txt
-        if uses_project_ic:
-            assert M.invalid_interpreter_constraints_project_ics in txt
-            assert M.invalid_interpreter_constraints_tool_ics not in txt
-        else:
-            assert M.invalid_interpreter_constraints_project_ics not in txt
-            assert M.invalid_interpreter_constraints_tool_ics in txt
-
-    else:
-        assert M.invalid_interpreter_constraints not in txt
-
-    if lockfile_type == FILE:
-        assert M.closing_lockfile_content not in txt
-        assert M.closing_file in txt
-
-
-def _metadata_validation_values(
-    invalid_reqs: bool, invalid_constraints: bool
-) -> tuple[str, str, set[str], set[PipRequirement]]:
-    actual_reqs = {"ansicolors==0.1.0"}
-    expected_reqs = {"requests==3.0.0"} if invalid_reqs else actual_reqs
-    actual_constraints = "CPython>=3.6,<3.10"
-    expected_constraints = "CPython>=3.9" if invalid_constraints else actual_constraints
-    return (
-        actual_constraints,
-        expected_constraints,
-        actual_reqs,
-        {PipRequirement.parse(r) for r in expected_reqs},
+    contains("You have set interpreter constraints", if_=invalid_constraints)
+    contains(
+        "determines its interpreter constraints based on your code's own constraints.",
+        if_=invalid_constraints and uses_project_ic,
+    )
+    contains(
+        ".interpreter_constraints`, or by using a new custom lockfile.",
+        if_=invalid_constraints and not uses_project_ic,
     )
 
-
-def _prepare_pex_requirements(
-    lockfile_type: str,
-    expected_requirements: set[str],
-    uses_source_plugins: bool,
-    uses_project_interpreter_constraints: bool,
-) -> Lockfile | LockfileContent:
-    if lockfile_type == FILE:
-        return ToolCustomLockfile(
-            file_path="lock.txt",
-            file_path_description_of_origin="",
-            lockfile_hex_digest=None,
-            req_strings=FrozenOrderedSet(expected_requirements),
-            options_scope_name="my_tool",
-            uses_source_plugins=uses_source_plugins,
-            uses_project_interpreter_constraints=uses_project_interpreter_constraints,
-        )
-    elif lockfile_type == DEFAULT:
-        return ToolDefaultLockfile(
-            file_content=FileContent("", b""),
-            lockfile_hex_digest=None,
-            req_strings=FrozenOrderedSet(expected_requirements),
-            options_scope_name="my_tool",
-            uses_source_plugins=uses_source_plugins,
-            uses_project_interpreter_constraints=uses_project_interpreter_constraints,
-        )
-    else:
-        raise Exception("incorrect lockfile_type value in test")
+    contains(
+        "To generate a custom lockfile based on your current configuration", if_=is_default_lock
+    )
+    contains(
+        "To regenerate your lockfile based on your current configuration", if_=not is_default_lock
+    )


### PR DESCRIPTION
This adds a new test to ensure we handle `--invalid-lockfile-behavior` correctly.

It also rewrites our test for the tool lockfile error message for readability. It still tests the exact same thing and same permutations, only in a different way. Key change is a little helper function called `contains("my msg", if_=invalid_reqs)`, for example.

[ci skip-rust]
[ci skip-build-wheels]