### PR TITLE
Don't enumerate deprecated scopes in help.

### DIFF
--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -244,6 +244,8 @@ def test_get_all_help_info():
     class Bar(GoalSubsystem):
         name = "bar"
         help = "The bar goal."
+        deprecated_options_scope = "bar-old"
+        deprecated_options_scope_removal_version = "9.9.999"
 
     class QuxField(StringField):
         alias = "qux"
@@ -300,6 +302,7 @@ def test_get_all_help_info():
                 "description": "Global options.",
                 "provider": "",
                 "is_goal": False,
+                "deprecated_scope": None,
                 "basic": (
                     {
                         "display_args": ("-o=<int>", "--opt1=<int>"),
@@ -333,6 +336,7 @@ def test_get_all_help_info():
                 "provider": "help_info_extracter_test",
                 "description": "A foo.",
                 "is_goal": False,
+                "deprecated_scope": None,
                 "basic": (
                     {
                         "display_args": ("--[no-]foo-opt2",),
@@ -387,6 +391,17 @@ def test_get_all_help_info():
                 "provider": "help_info_extracter_test",
                 "description": "The bar goal.",
                 "is_goal": True,
+                "deprecated_scope": "bar-old",
+                "basic": tuple(),
+                "advanced": tuple(),
+                "deprecated": tuple(),
+            },
+            "bar-old": {
+                "scope": "bar-old",
+                "provider": "help_info_extracter_test",
+                "description": "The bar goal.",
+                "is_goal": True,
+                "deprecated_scope": "bar-old",
                 "basic": tuple(),
                 "advanced": tuple(),
                 "deprecated": tuple(),
@@ -431,7 +446,14 @@ def test_get_all_help_info():
                 "description": "The bar goal.",
                 "consumed_scopes": ("somescope", "used_by_bar"),
                 "is_implemented": True,
-            }
+            },
+            "bar-old": {
+                "name": "bar",
+                "provider": "help_info_extracter_test",
+                "description": "The bar goal.",
+                "consumed_scopes": ("somescope", "used_by_bar-old"),
+                "is_implemented": True,
+            },
         },
         "name_to_target_type_info": {
             "baz_library": {

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -157,9 +157,9 @@ class HelpPrinter(MaybeColor):
         self._print_title("Subsystems")
 
         subsystem_description: Dict[str, str] = {}
-        for alias, help_info in self._all_help_info.scope_to_help_info.items():
-            if not help_info.is_goal and alias:
-                subsystem_description[alias] = first_paragraph(help_info.description)
+        for help_info in self._all_help_info.non_deprecated_option_scope_help_infos():
+            if not help_info.is_goal and help_info.scope:
+                subsystem_description[help_info.scope] = first_paragraph(help_info.description)
 
         longest_subsystem_alias = max(len(alias) for alias in subsystem_description.keys())
         chars_before_description = longest_subsystem_alias + 2

--- a/src/python/pants/help/help_tools.py
+++ b/src/python/pants/help/help_tools.py
@@ -34,7 +34,7 @@ class ToolHelpInfo:
 
     @classmethod
     def iter(cls, all_help_info: AllHelpInfo) -> Generator[ToolHelpInfo, None, None]:
-        for oshi in all_help_info.scope_to_help_info.values():
+        for oshi in all_help_info.non_deprecated_option_scope_help_infos():
             tool_info = cls.from_option_scope_help_info(oshi)
             if tool_info:
                 yield tool_info


### PR DESCRIPTION
But still show help for them if individually requested.

[ci skip-rust]

[ci skip-build-wheels]