### PR TITLE
Validate Python user lockfiles & improve tool lockfile error message

### DIFF
--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -9,8 +9,6 @@ from typing import ClassVar, Iterable, Sequence, cast
 from pants.backend.python.target_types import ConsoleScript, EntryPoint, MainSpecification
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex_requirements import (
-    Lockfile,
-    LockfileContent,
     PexRequirements,
     ToolCustomLockfile,
     ToolDefaultLockfile,
@@ -137,7 +135,7 @@ class PythonToolRequirementsBase(Subsystem):
         self,
         *,
         extra_requirements: Iterable[str] = (),
-    ) -> PexRequirements | Lockfile | LockfileContent:
+    ) -> PexRequirements | ToolDefaultLockfile | ToolCustomLockfile:
         """The requirements to be used when installing the tool.
 
         If the tool supports lockfiles, the returned type will install from the lockfile rather than
@@ -160,7 +158,7 @@ class PythonToolRequirementsBase(Subsystem):
                 ),
                 lockfile_hex_digest=hex_digest,
                 req_strings=FrozenOrderedSet(requirements),
-                options_scope_name=self.options_scope,
+                resolve_name=self.options_scope,
                 uses_project_interpreter_constraints=(not self.register_interpreter_constraints),
                 uses_source_plugins=self.uses_requirements_from_source_plugins,
             )
@@ -169,7 +167,7 @@ class PythonToolRequirementsBase(Subsystem):
             file_path_description_of_origin=f"the option `[{self.options_scope}].lockfile`",
             lockfile_hex_digest=hex_digest,
             req_strings=FrozenOrderedSet(requirements),
-            options_scope_name=self.options_scope,
+            resolve_name=self.options_scope,
             uses_project_interpreter_constraints=(not self.register_interpreter_constraints),
             uses_source_plugins=self.uses_requirements_from_source_plugins,
         )

--- a/src/python/pants/backend/python/util_rules/lockfile_metadata.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_metadata.py
@@ -75,7 +75,7 @@ class PythonLockfileMetadata(LockfileMetadata):
         expected_invalidation_digest: str | None,
         user_interpreter_constraints: InterpreterConstraints,
         interpreter_universe: Iterable[str],
-        user_requirements: Iterable[PipRequirement] | None,
+        user_requirements: Iterable[PipRequirement],
     ) -> LockfileMetadataValidation:
         """Returns Truthy if this `PythonLockfileMetadata` can be used in the current execution
         context."""
@@ -117,7 +117,7 @@ class PythonLockfileMetadataV1(PythonLockfileMetadata):
         expected_invalidation_digest: str | None,
         user_interpreter_constraints: InterpreterConstraints,
         interpreter_universe: Iterable[str],
-        user_requirements: Iterable[PipRequirement] | None,  # User requirements are not used by V1
+        user_requirements: Iterable[PipRequirement],  # User requirements are not used by V1
     ) -> LockfileMetadataValidation:
         failure_reasons: set[InvalidPythonLockfileReason] = set()
 
@@ -186,12 +186,9 @@ class PythonLockfileMetadataV2(PythonLockfileMetadata):
         expected_invalidation_digest: str | None,  # Validation digests are not used by V2.
         user_interpreter_constraints: InterpreterConstraints,
         interpreter_universe: Iterable[str],
-        user_requirements: Iterable[PipRequirement] | None,
+        user_requirements: Iterable[PipRequirement],
     ) -> LockfileMetadataValidation:
-        failure_reasons: set[InvalidPythonLockfileReason] = set()
-
-        if user_requirements is None:
-            return LockfileMetadataValidation(failure_reasons)
+        failure_reasons = set()
 
         invalid_reqs = (
             self.requirements != set(user_requirements)

--- a/src/python/pants/backend/python/util_rules/lockfile_metadata.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_metadata.py
@@ -50,7 +50,7 @@ class PythonLockfileMetadata(LockfileMetadata):
 
     @classmethod
     def from_lockfile(
-        cls, lockfile: bytes, lockfile_path: str | None = None, resolve_name: str | None = None
+        cls, resolve_name: str, lockfile: bytes, lockfile_path: str | None = None
     ) -> PythonLockfileMetadata:
         return cast(
             PythonLockfileMetadata,

--- a/src/python/pants/backend/python/util_rules/lockfile_metadata_test.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_metadata_test.py
@@ -11,6 +11,7 @@ import pytest
 from pants.backend.python.pip_requirement import PipRequirement
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.lockfile_metadata import (
+    InvalidPythonLockfileReason,
     PythonLockfileMetadata,
     PythonLockfileMetadataV1,
     PythonLockfileMetadataV2,
@@ -141,51 +142,86 @@ def test_is_valid_for_v1(user_digest, expected_digest, user_ic, expected_ic, mat
     assert (
         bool(
             m.is_valid_for(
-                user_digest,
-                InterpreterConstraints(user_ic),
-                INTERPRETER_UNIVERSE,
-                set(),
+                is_tool=True,
+                expected_invalidation_digest=user_digest,
+                user_interpreter_constraints=InterpreterConstraints(user_ic),
+                interpreter_universe=INTERPRETER_UNIVERSE,
+                user_requirements=set(),
             )
         )
         == matches
     )
 
 
-@pytest.mark.parametrize(
-    "user_ics_iter, expected_ics_iter, user_reqs, expected_reqs, matches",
+_VALID_ICS = [">=3.5"]
+_VALID_REQS = ["ansicolors==0.1.0", "requests==1.0.0"]
+
+# Different scenarios that are the same for both tool lockfiles and user lockfiles.
+_LockfileConditions = (
+    [_VALID_ICS, _VALID_ICS, _VALID_REQS, _VALID_REQS, []],
+    [_VALID_ICS, _VALID_ICS, _VALID_REQS, list(reversed(_VALID_REQS)), []],
     [
-        # Exact requirements match
-        [[">=3.5"], [">=3.5"], ["ansicolors==0.1.0"], ["ansicolors==0.1.0"], True],
-        # Version mismatch
-        [[">=3.5"], [">=3.5"], ["ansicolors==0.1.0"], ["ansicolors==0.1.1"], False],
-        # Range specifier mismatch
-        [[">=3.5"], [">=3.5"], ["ansicolors==0.1.0"], ["ansicolors>=0.1.0"], False],
-        # Requirements mismatch
-        [[">=3.5"], [">=3.5"], ["requests==1.0.0"], ["ansicolors==0.1.0"], False],
-        # Multiple requirements
-        [
-            [">=3.5"],
-            [">=3.5"],
-            ["ansicolors==0.1.0", "requests==1.0.0"],
-            ["ansicolors==0.1.0", "requests==1.0.0"],
-            True,
-        ],
-        # Multiple requirements, order mismatch still passes
-        [
-            [">=3.5"],
-            [">=3.5"],
-            ["ansicolors==0.1.0", "requests==1.0.0"],
-            ["requests==1.0.0", "ansicolors==0.1.0"],
-            True,
-        ],
-        # Exact requirements match, non-matching ICs (user includes 3.7 range and above)
-        [[">=3.5.5"], [">=3.5, <=3.6"], ["ansicolors==0.1.0"], ["ansicolors==0.1.0"], False],
+        _VALID_ICS,
+        _VALID_ICS,
+        _VALID_REQS,
+        [_VALID_REQS[0], "requests==2.0.0"],
+        [InvalidPythonLockfileReason.REQUIREMENTS_MISMATCH],
+    ],
+    [
+        _VALID_ICS,
+        _VALID_ICS,
+        _VALID_REQS,
+        [_VALID_REQS[0], "different"],
+        [InvalidPythonLockfileReason.REQUIREMENTS_MISMATCH],
+    ],
+    [
+        _VALID_ICS,
+        _VALID_ICS,
+        _VALID_REQS,
+        [*_VALID_REQS, "a-third-req"],
+        [InvalidPythonLockfileReason.REQUIREMENTS_MISMATCH],
+    ],
+    [
+        _VALID_ICS,
+        ["==2.7.*"],
+        _VALID_REQS,
+        _VALID_REQS,
+        [InvalidPythonLockfileReason.INTERPRETER_CONSTRAINTS_MISMATCH],
     ],
 )
-def test_is_valid_for_v2_only(
-    user_ics_iter, expected_ics_iter, user_reqs, expected_reqs, matches
+
+
+@pytest.mark.parametrize(
+    "is_tool, lock_ics, user_ics, lock_reqs, user_reqs, expected",
+    [
+        *([True, *conditions] for conditions in _LockfileConditions),
+        *([False, *conditions] for conditions in _LockfileConditions),
+        # Tools require exact matches, whereas user lockfiles only need to subset.
+        [False, _VALID_ICS, _VALID_ICS, _VALID_REQS, [_VALID_REQS[0]], []],
+        [
+            True,
+            _VALID_ICS,
+            _VALID_ICS,
+            _VALID_REQS,
+            [_VALID_REQS[0]],
+            [InvalidPythonLockfileReason.REQUIREMENTS_MISMATCH],
+        ],
+    ],
+)
+def test_is_valid_for_v2(
+    is_tool: bool,
+    user_ics: list[str],
+    lock_ics: list[str],
+    user_reqs: list[str],
+    lock_reqs: list[str],
+    expected: list[InvalidPythonLockfileReason],
 ) -> None:
-    user_ic = InterpreterConstraints(user_ics_iter)
-    expected_ic = InterpreterConstraints(expected_ics_iter)
-    m = PythonLockfileMetadataV2(expected_ic, reqset(*expected_reqs))
-    assert bool(m.is_valid_for("", user_ic, INTERPRETER_UNIVERSE, reqset(*user_reqs))) == matches
+    m = PythonLockfileMetadataV2(InterpreterConstraints(lock_ics), reqset(*lock_reqs))
+    result = m.is_valid_for(
+        is_tool=is_tool,
+        expected_invalidation_digest="",
+        user_interpreter_constraints=InterpreterConstraints(user_ics),
+        interpreter_universe=INTERPRETER_UNIVERSE,
+        user_requirements=reqset(*user_reqs),
+    )
+    assert result.failure_reasons == set(expected)

--- a/src/python/pants/backend/python/util_rules/lockfile_metadata_test.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_metadata_test.py
@@ -33,7 +33,7 @@ def test_metadata_header_round_trip() -> None:
     serialized_lockfile = input_metadata.add_header_to_lockfile(
         b"req1==1.0", regenerate_command="./pants lock"
     )
-    output_metadata = PythonLockfileMetadata.from_lockfile(serialized_lockfile)
+    output_metadata = PythonLockfileMetadata.from_lockfile("a", serialized_lockfile)
     assert input_metadata == output_metadata
 
 

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -353,9 +353,7 @@ async def build_pex(
             lock_bytes = _digest_contents[0].content
 
             def parse_metadata() -> PythonLockfileMetadata:
-                return PythonLockfileMetadata.from_lockfile(
-                    lock_bytes, lock_path, resolve_name=resolve_name
-                )
+                return PythonLockfileMetadata.from_lockfile(resolve_name, lock_bytes, lock_path)
 
         else:
             _fc = request.requirements.file_content
@@ -363,7 +361,7 @@ async def build_pex(
             requirements_file_digest = await Get(Digest, CreateDigest([_fc]))
 
             def parse_metadata() -> PythonLockfileMetadata:
-                return PythonLockfileMetadata.from_lockfile(lock_bytes, resolve_name=resolve_name)
+                return PythonLockfileMetadata.from_lockfile(resolve_name, lock_bytes)
 
         is_monolithic_resolve = True
         argv.extend(["--requirement", lock_path, "--no-transitive"])

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -35,11 +35,7 @@ from pants.backend.python.util_rules.pex_requirements import Lockfile, LockfileC
 from pants.backend.python.util_rules.pex_requirements import (
     PexRequirements as PexRequirements,  # Explicit re-export.
 )
-from pants.backend.python.util_rules.pex_requirements import (
-    ToolCustomLockfile,
-    ToolDefaultLockfile,
-    maybe_validate_metadata,
-)
+from pants.backend.python.util_rules.pex_requirements import maybe_validate_metadata
 from pants.engine.collection import Collection, DeduplicatedCollection
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import (
@@ -342,13 +338,7 @@ async def build_pex(
     requirement_count: int
 
     if isinstance(request.requirements, (Lockfile, LockfileContent)):
-        # TODO(#12314): Capture the resolve name for multiple user lockfiles.
-        resolve_name = (
-            request.requirements.options_scope_name
-            if isinstance(request.requirements, (ToolDefaultLockfile, ToolCustomLockfile))
-            else None
-        )
-
+        resolve_name = request.requirements.resolve_name
         if isinstance(request.requirements, Lockfile):
             lock_path = request.requirements.file_path
             requirements_file_digest = await Get(
@@ -363,7 +353,9 @@ async def build_pex(
             lock_bytes = _digest_contents[0].content
 
             def parse_metadata() -> PythonLockfileMetadata:
-                return PythonLockfileMetadata.from_lockfile(lock_bytes, lock_path, resolve_name)
+                return PythonLockfileMetadata.from_lockfile(
+                    lock_bytes, lock_path, resolve_name=resolve_name
+                )
 
         else:
             _fc = request.requirements.file_content

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -517,6 +517,7 @@ async def get_repository_pex(
                 file_path_description_of_origin=(
                     f"the resolve `{chosen_resolve.name}` (from `[python].resolves`)"
                 ),
+                resolve_name=chosen_resolve.name,
                 req_strings=request.requirements.req_strings,
             ),
             interpreter_constraints=interpreter_constraints,

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -136,9 +136,9 @@ def maybe_validate_metadata(
         user_requirements=user_requirements,
     )
     msg_iter = (
-        _invalid_tool_lockfile_error(**error_msg_kwargs)
+        _invalid_tool_lockfile_error(**error_msg_kwargs)  # type: ignore[arg-type]
         if isinstance(lockfile, (ToolCustomLockfile, ToolDefaultLockfile))
-        else _invalid_user_lockfile_error(**error_msg_kwargs)
+        else _invalid_user_lockfile_error(**error_msg_kwargs)  # type: ignore[arg-type]
     )
     msg = "".join(msg_iter).strip()
     if python_setup.invalid_lockfile_behavior == InvalidLockfileBehavior.error:

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -123,10 +123,11 @@ def maybe_validate_metadata(
 
     metadata = parse_metadata()
     validation = metadata.is_valid_for(
-        requirements.lockfile_hex_digest,
-        interpreter_constraints,
-        python_setup.interpreter_universe,
-        req_strings,
+        is_tool=isinstance(requirements, (ToolCustomLockfile, ToolDefaultLockfile)),
+        expected_invalidation_digest=requirements.lockfile_hex_digest,
+        user_interpreter_constraints=interpreter_constraints,
+        interpreter_universe=python_setup.interpreter_universe,
+        user_requirements=req_strings,
     )
     if validation:
         return

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 class Lockfile:
     file_path: str
     file_path_description_of_origin: str
+    resolve_name: str
     req_strings: FrozenOrderedSet[str]
     lockfile_hex_digest: str | None = None
 
@@ -39,13 +40,13 @@ class Lockfile:
 @dataclass(frozen=True)
 class LockfileContent:
     file_content: FileContent
+    resolve_name: str
     req_strings: FrozenOrderedSet[str]
     lockfile_hex_digest: str | None = None
 
 
 @dataclass(frozen=True)
 class _ToolLockfileMixin:
-    options_scope_name: str
     uses_source_plugins: bool
     uses_project_interpreter_constraints: bool
 
@@ -150,7 +151,7 @@ def _invalid_tool_lockfile_error(
     actual_interpreter_constraints: InterpreterConstraints,
     lockfile_interpreter_constraints: InterpreterConstraints,
 ) -> Iterator[str]:
-    tool_name = requirements.options_scope_name
+    tool_name = requirements.resolve_name
 
     yield "You are using "
     yield "the `<default>` lockfile provided by Pants " if isinstance(

--- a/src/python/pants/backend/python/util_rules/pex_requirements_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements_test.py
@@ -33,7 +33,7 @@ def create_tool_lock(
 ) -> ToolDefaultLockfile | ToolCustomLockfile:
     common_kwargs = dict(
         req_strings=FrozenOrderedSet(req_strings),
-        options_scope_name="my_tool",
+        resolve_name="my_tool",
         uses_source_plugins=uses_source_plugins,
         uses_project_interpreter_constraints=uses_project_interpreter_constraints,
     )

--- a/src/python/pants/backend/python/util_rules/pex_requirements_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements_test.py
@@ -32,7 +32,6 @@ def create_tool_lock(
     uses_project_interpreter_constraints: bool = False,
 ) -> ToolDefaultLockfile | ToolCustomLockfile:
     common_kwargs = dict(
-        lockfile_hex_digest=None,
         req_strings=FrozenOrderedSet(req_strings),
         options_scope_name="my_tool",
         uses_source_plugins=uses_source_plugins,

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -618,8 +618,8 @@ def test_build_pex_description() -> None:
     assert_description(
         LockfileContent(
             file_content=FileContent("lock.txt", b""),
-            lockfile_hex_digest=None,
-            req_strings=None,
+            resolve_name="a",
+            req_strings=FrozenOrderedSet(),
         ),
         expected="Building new.pex from lock.txt",
     )
@@ -628,8 +628,8 @@ def test_build_pex_description() -> None:
         Lockfile(
             file_path="lock.txt",
             file_path_description_of_origin="foo",
-            lockfile_hex_digest=None,
-            req_strings=None,
+            resolve_name="a",
+            req_strings=FrozenOrderedSet(),
         ),
         expected="Building new.pex from lock.txt",
     )
@@ -652,7 +652,7 @@ def test_lockfile_validation(rule_runner: RuleRunner) -> None:
     lockfile = Lockfile(
         "lock.txt",
         file_path_description_of_origin="a test",
-        lockfile_hex_digest=None,
+        resolve_name="a",
         req_strings=FrozenOrderedSet("ansicolors"),
     )
     with engine_error(InvalidLockfileError):
@@ -660,7 +660,7 @@ def test_lockfile_validation(rule_runner: RuleRunner) -> None:
 
     lockfile_content = LockfileContent(
         FileContent("lock.txt", lock_content),
-        lockfile_hex_digest=None,
+        resolve_name="a",
         req_strings=FrozenOrderedSet("ansicolors"),
     )
     with engine_error(InvalidLockfileError):

--- a/src/python/pants/core/util_rules/lockfile_metadata.py
+++ b/src/python/pants/core/util_rules/lockfile_metadata.py
@@ -98,7 +98,7 @@ class LockfileMetadata:
             "`./pants generate-lockfiles"
         )
         if resolve_name:
-            error_suffix += " --resolve={tool_name}"
+            error_suffix += f" --resolve={resolve_name}"
         error_suffix += "`."
 
         if lockfile_path is not None and resolve_name is not None:


### PR DESCRIPTION
Checks that interpreter constraints + requirements of the current run are compatible with the lockfile.

> InvalidLockfileError: You are using the lockfile at 3rdparty/python/lockfiles/user_reqs.txt  to install the resolve `python-default` (from `[python].resolves`). However, it is not compatible with the current targets:
>
> - The targets use requirements that are not in the lockfile: ['flake8-plugin==2.3']
This most often happens when adding a new requirement to your project, or bumping requirement versions. You can fix this by regenerating the lockfile with `generate-lockfiles`.
>
> - The targets use interpreter constraints (`CPython==3.9.*`) that are not compatible with those used to generate the lockfile (`CPython<3.10,>=3.7`). You can fix this by either adjusting your targets to use different interpreter constraints (https://www.pantsbuild.org/v2.10/docs/python-interpreter-compatibility) or by generating the lockfile with different interpreter constraints by setting the option `[python].resolves_to_interpreter_constraints`, then running `generate-lockfiles`.
>
> To regenerate your lockfile, run `./pants generate-lockfiles --resolve=python-default`.

This also improves the error message for tool lockfiles to say how the resolves diverge:

> - You have set different requirements than those used to generate the lockfile. You can fix this by updating `[black].version` and/or `[black].extra_requirements`, or by using a new custom lockfile.
In the input requirements, but not in the lockfile: ['typing-extensions>=3.50.0.0; python_version < "3.10"']
In the lockfile, but not in the input requirements: ['typing-extensions>=3.10.0.0; python_version < "3.10"']