### PR TITLE
Standardize how we reference formatters, linters, and checkers in goal summary

### DIFF
--- a/src/python/pants/backend/docker/lint/hadolint/rules.py
+++ b/src/python/pants/backend/docker/lint/hadolint/rules.py
@@ -34,7 +34,7 @@ class HadolintFieldSet(FieldSet):
 
 class HadolintRequest(LintTargetsRequest):
     field_set_type = HadolintFieldSet
-    name = "Hadolint"
+    name = Hadolint.options_scope
 
 
 def generate_argv(

--- a/src/python/pants/backend/go/goals/check.py
+++ b/src/python/pants/backend/go/goals/check.py
@@ -24,7 +24,7 @@ class GoCheckFieldSet(FieldSet):
 
 class GoCheckRequest(CheckRequest):
     field_set_type = GoCheckFieldSet
-    name = "go compile"
+    name = "go-compile"
 
 
 @rule(desc="Check Go compilation", level=LogLevel.DEBUG)

--- a/src/python/pants/backend/go/lint/gofmt/rules.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules.py
@@ -38,7 +38,7 @@ class GofmtFieldSet(FieldSet):
 
 class GofmtRequest(FmtRequest):
     field_set_type = GofmtFieldSet
-    name = "gofmt"
+    name = GofmtSubsystem.options_scope
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/go/lint/vet/rules.py
+++ b/src/python/pants/backend/go/lint/vet/rules.py
@@ -41,7 +41,7 @@ class GoVetFieldSet(FieldSet):
 
 class GoVetRequest(LintTargetsRequest):
     field_set_type = GoVetFieldSet
-    name = "go vet"
+    name = GoVetSubsystem.options_scope
 
 
 @rule(level=LogLevel.DEBUG)

--- a/src/python/pants/backend/java/goals/check.py
+++ b/src/python/pants/backend/java/goals/check.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 
+from pants.backend.java.subsystems.javac import JavacSubsystem
 from pants.backend.java.target_types import JavaFieldSet
 from pants.core.goals.check import CheckRequest, CheckResult, CheckResults
 from pants.engine.addresses import Addresses
@@ -20,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 class JavacCheckRequest(CheckRequest):
     field_set_type = JavaFieldSet
-    name = "javac"
+    name = JavacSubsystem.options_scope
 
 
 @rule(desc="Check javac compilation", level=LogLevel.DEBUG)

--- a/src/python/pants/backend/java/lint/google_java_format/rules.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules.py
@@ -40,7 +40,7 @@ class GoogleJavaFormatFieldSet(FieldSet):
 
 class GoogleJavaFormatRequest(FmtRequest, LintTargetsRequest):
     field_set_type = GoogleJavaFormatFieldSet
-    name = "Google Java Format"
+    name = GoogleJavaFormatSubsystem.options_scope
 
 
 class GoogleJavaFormatToolLockfileSentinel(GenerateToolLockfileSentinel):

--- a/src/python/pants/backend/project_info/regex_lint.py
+++ b/src/python/pants/backend/project_info/regex_lint.py
@@ -396,7 +396,7 @@ async def validate_goal(
 
 
 class RegexLintRequest(LintFilesRequest):
-    name = "regex-lint"
+    name = RegexLintSubsystem.options_scope
 
 
 @rule(desc="Lint with regex patterns", level=LogLevel.DEBUG)

--- a/src/python/pants/backend/python/lint/autoflake/rules.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules.py
@@ -35,7 +35,7 @@ class AutoflakeFieldSet(FieldSet):
 
 class AutoflakeRequest(FmtRequest, LintTargetsRequest):
     field_set_type = AutoflakeFieldSet
-    name = "autoflake"
+    name = Autoflake.options_scope
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -22,7 +22,7 @@ from pants.util.strutil import pluralize
 
 class BanditRequest(LintTargetsRequest):
     field_set_type = BanditFieldSet
-    name = "Bandit"
+    name = Bandit.options_scope
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -38,7 +38,7 @@ class BlackFieldSet(FieldSet):
 
 class BlackRequest(FmtRequest, LintTargetsRequest):
     field_set_type = BlackFieldSet
-    name = "Black"
+    name = Black.options_scope
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -34,7 +34,7 @@ class DocformatterFieldSet(FieldSet):
 
 class DocformatterRequest(FmtRequest, LintTargetsRequest):
     field_set_type = DocformatterFieldSet
-    name = "Docformatter"
+    name = Docformatter.options_scope
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -27,7 +27,7 @@ from pants.util.strutil import pluralize
 
 class Flake8Request(LintTargetsRequest):
     field_set_type = Flake8FieldSet
-    name = "Flake8"
+    name = Flake8.options_scope
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -35,7 +35,7 @@ class IsortFieldSet(FieldSet):
 
 class IsortRequest(FmtRequest, LintTargetsRequest):
     field_set_type = IsortFieldSet
-    name = "isort"
+    name = Isort.options_scope
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -57,7 +57,7 @@ class PylintPartitions(Collection[PylintPartition]):
 
 class PylintRequest(LintTargetsRequest):
     field_set_type = PylintFieldSet
-    name = "Pylint"
+    name = Pylint.options_scope
 
 
 def generate_argv(source_files: SourceFiles, pylint: Pylint) -> Tuple[str, ...]:

--- a/src/python/pants/backend/python/lint/pyupgrade/rules.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/rules.py
@@ -34,7 +34,7 @@ class PyUpgradeFieldSet(FieldSet):
 
 class PyUpgradeRequest(FmtRequest, LintTargetsRequest):
     field_set_type = PyUpgradeFieldSet
-    name = "pyupgrade"
+    name = PyUpgrade.options_scope
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/lint/yapf/rules.py
+++ b/src/python/pants/backend/python/lint/yapf/rules.py
@@ -35,7 +35,7 @@ class YapfFieldSet(FieldSet):
 
 class YapfRequest(FmtRequest, LintTargetsRequest):
     field_set_type = YapfFieldSet
-    name = "yapf"
+    name = Yapf.options_scope
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -60,7 +60,7 @@ class MyPyPartitions(Collection[MyPyPartition]):
 
 class MyPyRequest(CheckRequest):
     field_set_type = MyPyFieldSet
-    name = "MyPy"
+    name = MyPy.options_scope
 
 
 def generate_argv(

--- a/src/python/pants/backend/scala/goals/check.py
+++ b/src/python/pants/backend/scala/goals/check.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 
+from pants.backend.scala.subsystems.scalac import Scalac
 from pants.backend.scala.target_types import ScalaFieldSet
 from pants.core.goals.check import CheckRequest, CheckResult, CheckResults
 from pants.engine.addresses import Addresses
@@ -20,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 class ScalacCheckRequest(CheckRequest):
     field_set_type = ScalaFieldSet
-    name = "scalac"
+    name = Scalac.options_scope
 
 
 @rule(desc="Check compilation for Scala", level=LogLevel.DEBUG)

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -53,7 +53,7 @@ class ScalafmtFieldSet(FieldSet):
 
 class ScalafmtRequest(FmtRequest, LintTargetsRequest):
     field_set_type = ScalafmtFieldSet
-    name = "scalafmt"
+    name = ScalafmtSubsystem.options_scope
 
 
 class ScalafmtToolLockfileSentinel(GenerateToolLockfileSentinel):

--- a/src/python/pants/backend/shell/lint/shellcheck/rules.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/rules.py
@@ -41,7 +41,7 @@ class ShellcheckFieldSet(FieldSet):
 
 class ShellcheckRequest(LintTargetsRequest):
     field_set_type = ShellcheckFieldSet
-    name = "Shellcheck"
+    name = Shellcheck.options_scope
 
 
 @rule(desc="Lint with Shellcheck", level=LogLevel.DEBUG)

--- a/src/python/pants/backend/shell/lint/shfmt/rules.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules.py
@@ -34,7 +34,7 @@ class ShfmtFieldSet(FieldSet):
 
 class ShfmtRequest(FmtRequest, LintTargetsRequest):
     field_set_type = ShfmtFieldSet
-    name = "shfmt"
+    name = Shfmt.options_scope
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/terraform/goals/check.py
+++ b/src/python/pants/backend/terraform/goals/check.py
@@ -37,7 +37,7 @@ class TerraformValidateSubsystem(Subsystem):
 
 class TerraformCheckRequest(CheckRequest):
     field_set_type = TerraformFieldSet
-    name = "terraform validate"
+    name = TerraformValidateSubsystem.options_scope
 
 
 @rule

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
@@ -41,7 +41,7 @@ class TfFmtSubsystem(Subsystem):
 
 class TffmtRequest(FmtRequest):
     field_set_type = TerraformFieldSet
-    name = "tffmt"
+    name = TfFmtSubsystem.options_scope
 
 
 @rule(desc="Format with `terraform fmt`")


### PR DESCRIPTION
## Problem

Soon we're adding `lint --only=<tool>`, so the name of these tools will become part of our API. Some of the tools currently have spaces, which means you need quotes with `check --only='go compile'`. Generally, we're inconsistent with how we capitalize.

Because of inconsistent capitalization, our final summaries also don't sort how users might expect.

## Before 
Note that autoflake shows up as the 4th entry, not the 1st.

```
❯ ./pants lint src/python/pants/util/strutil.py
17:14:06.98 [INFO] Completed: Lint with regex patterns - regex-lint succeeded.
17:14:08.43 [INFO] Completed: Lint with Flake8 - Flake8 succeeded.                                                                              
17:14:08.43 [INFO] Completed: Lint with Black - Black succeeded.                                                                                
17:14:08.50 [INFO] Completed: Lint with docformatter - Docformatter succeeded.                                                                  
17:14:08.50 [INFO] Completed: Lint with autoflake - autoflake succeeded.                                                                        
17:14:08.50 [INFO] Completed: Lint with isort - isort succeeded.

✓ Black succeeded.
✓ Docformatter succeeded.
✓ Flake8 succeeded.
✓ autoflake succeeded.
✓ isort succeeded.
✓ regex-lint succeeded.
```

## After

```
❯ ./pants lint src/python/pants/util/strutil.py
17:10:41.10 [INFO] Completed: Lint with regex patterns - regex-lint succeeded.
17:10:42.46 [INFO] Completed: Lint with Flake8 - flake8 succeeded.                                                                              
17:10:42.46 [INFO] Completed: Lint with Black - black succeeded.                                                                                
17:10:42.54 [INFO] Completed: Lint with docformatter - docformatter succeeded.                                                                  
17:10:42.54 [INFO] Completed: Lint with autoflake - autoflake succeeded.                                                                        
17:10:42.54 [INFO] Completed: Lint with isort - isort succeeded.                                                                                

✓ autoflake succeeded.
✓ black succeeded.
✓ docformatter succeeded.
✓ flake8 succeeded.
✓ isort succeeded.
✓ regex-lint succeeded.
```

[ci skip-rust]
