### PR TITLE
Add `--fmt-only`, `--check-only`, and `--lint-only`

### DIFF
--- a/src/python/pants/core/goals/check.py
+++ b/src/python/pants/core/goals/check.py
@@ -8,7 +8,12 @@ from dataclasses import dataclass
 from typing import Any, Iterable, cast
 
 from pants.core.goals.lint import REPORT_DIR as REPORT_DIR  # noqa: F401
-from pants.core.goals.style_request import StyleRequest, write_reports
+from pants.core.goals.style_request import (
+    StyleRequest,
+    determine_specified_tool_names,
+    only_option_help,
+    write_reports,
+)
 from pants.core.util_rules.distdir import DistDir
 from pants.engine.console import Console
 from pants.engine.engine_aware import EngineAwareReturnType
@@ -138,6 +143,21 @@ class CheckSubsystem(GoalSubsystem):
 
     required_union_implementations = (CheckRequest,)
 
+    @classmethod
+    def register_options(cls, register) -> None:
+        super().register_options(register)
+        register(
+            "--only",
+            type=list,
+            member_type=str,
+            default=[],
+            help=only_option_help("check", "checkers", "mypy", "javac"),
+        )
+
+    @property
+    def only(self) -> tuple[str, ...]:
+        return tuple(self.options.only)
+
 
 class Check(Goal):
     subsystem_cls = CheckSubsystem
@@ -150,15 +170,21 @@ async def check(
     targets: Targets,
     dist_dir: DistDir,
     union_membership: UnionMembership,
+    check_subsystem: CheckSubsystem,
 ) -> Check:
-    typecheck_request_types = cast("Iterable[type[StyleRequest]]", union_membership[CheckRequest])
+    request_types = cast("Iterable[type[StyleRequest]]", union_membership[CheckRequest])
+    specified_names = determine_specified_tool_names("check", check_subsystem.only, request_types)
+
     requests = tuple(
-        typecheck_request_type(
-            typecheck_request_type.field_set_type.create(target)
+        request_type(
+            request_type.field_set_type.create(target)
             for target in targets
-            if typecheck_request_type.field_set_type.is_applicable(target)
+            if (
+                request_type.name in specified_names
+                and request_type.field_set_type.is_applicable(target)
+            )
         )
-        for typecheck_request_type in typecheck_request_types
+        for request_type in request_types
     )
     all_results = await MultiGet(
         Get(CheckResults, CheckRequest, request) for request in requests if request.field_sets

--- a/src/python/pants/core/goals/style_request_test.py
+++ b/src/python/pants/core/goals/style_request_test.py
@@ -28,8 +28,8 @@ def test_determine_specified_tool_names() -> None:
             extra_valid_names=["extra-tool"],
         )
     assert (
-        f"Unrecognized name with the option `--fake-goal-only`: 'bad'\n\n"
-        f"All valid names: ['extra-tool', 'my-tool']"
+        "Unrecognized name with the option `--fake-goal-only`: 'bad'\n\n"
+        "All valid names: ['extra-tool', 'my-tool']"
     ) in str(exc.value)
 
 

--- a/src/python/pants/core/goals/style_request_test.py
+++ b/src/python/pants/core/goals/style_request_test.py
@@ -3,11 +3,34 @@
 
 from pathlib import Path
 
+import pytest
+
 from pants.core.goals.check import CheckResult, CheckResults
-from pants.core.goals.style_request import write_reports
+from pants.core.goals.style_request import (
+    StyleRequest,
+    determine_specified_tool_names,
+    write_reports,
+)
 from pants.core.util_rules.distdir import DistDir
 from pants.engine.fs import EMPTY_DIGEST, Workspace
 from pants.testutil.rule_runner import RuleRunner
+
+
+def test_determine_specified_tool_names() -> None:
+    class StyleReq(StyleRequest):
+        name = "my-tool"
+
+    with pytest.raises(ValueError) as exc:
+        determine_specified_tool_names(
+            "fake-goal",
+            only_option=["bad"],
+            all_style_requests=[StyleReq],
+            extra_valid_names=["extra-tool"],
+        )
+    assert (
+        f"Unrecognized name with the option `--fake-goal-only`: 'bad'\n\n"
+        f"All valid names: ['extra-tool', 'my-tool']"
+    ) in str(exc.value)
 
 
 def test_write_reports() -> None:


### PR DESCRIPTION
```
❯ ./pants lint --only=isort src/python/pants/util/strutil.py
17:52:30.84 [INFO] Completed: Lint with isort - isort succeeded.

✓ isort succeeded.
```

```
❯ ./pants lint --only=fake              
ValueError: Unrecognized name with the option `--lint-only`: 'fake'

All valid names: ['autoflake', 'black', 'docformatter', 'flake8', 'gofmt', 'google-java-format', 'hadolint', 'isort', 'regex-lint', 'scalafmt', 'shellcheck', 'shfmt']


[ci skip-rust]
[ci skip-build-wheels]