### PR TITLE
Add Thrift, Protobuf, Java, and Scala folders to default for `[source].root_patterns`

### DIFF
--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -93,7 +93,17 @@ class SourceRootConfig(Subsystem):
     options_scope = "source"
     help = "Configuration for roots of source trees."
 
-    DEFAULT_ROOT_PATTERNS = ["/", "src", "src/python", "src/py"]
+    DEFAULT_ROOT_PATTERNS = [
+        "/",
+        "src",
+        "src/python",
+        "src/py",
+        "src/thrift",
+        "src/protobuf",
+        "src/protos",
+        "src/scala",
+        "src/java",
+    ]
 
     @classmethod
     def register_options(cls, register):


### PR DESCRIPTION
Note that Go (currently) does not use source roots, so that's not relevant.

[ci skip-rust]
[ci skip-build-wheels]