### PR TITLE
Extend update-build-files goal to support yapf formatter

### DIFF
--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -9,12 +9,14 @@ import os.path
 import tokenize
 from collections import defaultdict
 from dataclasses import dataclass
+from enum import Enum
 from io import BytesIO
 from typing import DefaultDict, Mapping, cast
 
 from colors import green, red
 
 from pants.backend.python.lint.black.subsystem import Black
+from pants.backend.python.lint.yapf.subsystem import Yapf
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
@@ -55,6 +57,11 @@ class RewrittenBuildFile:
     path: str
     lines: tuple[str, ...]
     change_descriptions: tuple[str, ...]
+
+
+class Formatter(Enum):
+    YAPF = "yapf"
+    BLACK = "black"
 
 
 @union
@@ -123,12 +130,20 @@ class UpdateBuildFilesSubsystem(GoalSubsystem):
             type=bool,
             default=True,
             help=(
-                "Format BUILD files using Black.\n\n"
-                "Set `[black].args`, `[black].config`, and `[black].config_discovery` to change "
-                "Black's behavior. Set `[black].interpreter_constraints` and "
-                "`[python].interpreter_search_path` to change which interpreter is used to "
-                "run Black."
+                "Format BUILD files using Black or Yapf.\n\n"
+                "Set `[black].args` / `[yapf].args`, `[black].config` / `[yapf].config` , "
+                "and `[black].config_discovery` / `[yapf].config_discovery` to change "
+                "Black's or Yapf's behavior. Set "
+                "`[black].interpreter_constraints` / `[yapf].interpreter_constraints` "
+                "and `[python].interpreter_search_path` to change which interpreter is "
+                "used to run the formatter."
             ),
+        )
+        register(
+            "--formatter",
+            type=Formatter,
+            default=Formatter.BLACK,
+            help="Which formatter Pants should use to format BUILD files.",
         )
         register(
             "--fix-safe-deprecations",
@@ -157,6 +172,10 @@ class UpdateBuildFilesSubsystem(GoalSubsystem):
     @property
     def fmt(self) -> bool:
         return cast(bool, self.options.fmt)
+
+    @property
+    def formatter(self) -> str:
+        return cast(str, self.options.formatter)
 
     @property
     def fix_safe_deprecations(self) -> bool:
@@ -192,7 +211,7 @@ async def update_build_files(
 
     rewrite_request_classes = []
     for request in union_membership[RewrittenBuildFileRequest]:
-        if issubclass(request, FormatWithBlackRequest):
+        if issubclass(request, (FormatWithBlackRequest, FormatWithYapfRequest)):
             if update_build_files_subsystem.fmt:
                 rewrite_request_classes.append(request)
             else:
@@ -264,6 +283,69 @@ async def update_build_files(
         )
 
     return UpdateBuildFilesGoal(exit_code=1 if update_build_files_subsystem.check else 0)
+
+
+# ------------------------------------------------------------------------------------------
+# Yapf formatter fixer
+# ------------------------------------------------------------------------------------------
+
+class FormatWithYapfRequest(RewrittenBuildFileRequest):
+    pass
+
+
+@rule
+async def format_build_file_with_yapf(
+    request: FormatWithYapfRequest, yapf: Yapf
+) -> RewrittenBuildFile:
+    yapf_pex_get = Get(
+        VenvPex,
+        PexRequest(
+            output_filename="yapf.pex",
+            internal_only=True,
+            requirements=yapf.pex_requirements(),
+            interpreter_constraints=yapf.interpreter_constraints,
+            main=yapf.main,
+        ),
+    )
+    build_file_digest_get = Get(Digest, CreateDigest([request.to_file_content()]))
+    config_files_get = Get(
+        ConfigFiles, ConfigFilesRequest, yapf.config_request(recursive_dirname(request.path))
+    )
+    yapf_pex, build_file_digest, config_files = await MultiGet(
+        yapf_pex_get, build_file_digest_get, config_files_get
+    )
+
+    input_digest = await Get(
+        Digest, MergeDigests((build_file_digest, config_files.snapshot.digest))
+    )
+
+    argv = []
+    if yapf.config:
+        argv.extend(["--config", yapf.config])
+    argv.extend(yapf.args)
+    argv.append(request.path)
+
+    yapf_result = await Get(
+        ProcessResult,
+        VenvPexProcess(
+            yapf_pex,
+            argv=argv,
+            input_digest=input_digest,
+            output_files=(request.path,),
+            description=f"Run Yapf on {request.path}.",
+            level=LogLevel.DEBUG,
+        ),
+    )
+
+    if yapf_result.output_digest == build_file_digest:
+        return RewrittenBuildFile(request.path, request.lines, change_descriptions=())
+
+    result_contents = await Get(DigestContents, Digest, yapf_result.output_digest)
+    assert len(result_contents) == 1
+    result_lines = tuple(result_contents[0].content.decode("utf-8").splitlines())
+    return RewrittenBuildFile(
+        request.path, result_lines, change_descriptions=("Format with Yapf",)
+    )
 
 
 # ------------------------------------------------------------------------------------------
@@ -539,7 +621,8 @@ def rules():
         *pex.rules(),
         UnionRule(RewrittenBuildFileRequest, RenameDeprecatedTargetsRequest),
         UnionRule(RewrittenBuildFileRequest, RenameDeprecatedFieldsRequest),
-        # NB: We want this to come at the end so that running Black happens after all our
-        # deprecation fixers.
+        # NB: We want this to come at the end so that running Black or Yapf happens
+        # after all our deprecation fixers.
         UnionRule(RewrittenBuildFileRequest, FormatWithBlackRequest),
+        UnionRule(RewrittenBuildFileRequest, FormatWithYapfRequest),
     )

--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -324,11 +324,10 @@ async def format_build_file_with_yapf(
         Digest, MergeDigests((build_file_digest, config_files.snapshot.digest))
     )
 
-    argv = []
+    argv = ["--in-place"]
     if yapf.config:
         argv.extend(["--config", yapf.config])
     argv.extend(yapf.args)
-    argv.append("--in-place")  # modify files in place
     argv.append(request.path)
 
     yapf_result = await Get(

--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -212,7 +212,11 @@ async def update_build_files(
     rewrite_request_classes = []
     for request in union_membership[RewrittenBuildFileRequest]:
         if issubclass(request, (FormatWithBlackRequest, FormatWithYapfRequest)):
-            if update_build_files_subsystem.fmt:
+            is_chosen_formatter = issubclass(request, FormatWithBlackRequest) ^ (
+                update_build_files_subsystem.formatter == Formatter.YAPF
+            )
+
+            if update_build_files_subsystem.fmt and is_chosen_formatter:
                 rewrite_request_classes.append(request)
             else:
                 continue
@@ -324,6 +328,7 @@ async def format_build_file_with_yapf(
     if yapf.config:
         argv.extend(["--config", yapf.config])
     argv.extend(yapf.args)
+    argv.append("--in-place")  # modify files in place
     argv.append(request.path)
 
     yapf_result = await Get(

--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -174,8 +174,8 @@ class UpdateBuildFilesSubsystem(GoalSubsystem):
         return cast(bool, self.options.fmt)
 
     @property
-    def formatter(self) -> str:
-        return cast(str, self.options.formatter)
+    def formatter(self) -> Formatter:
+        return cast(Formatter, self.options.formatter)
 
     @property
     def fix_safe_deprecations(self) -> bool:

--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -289,6 +289,7 @@ async def update_build_files(
 # Yapf formatter fixer
 # ------------------------------------------------------------------------------------------
 
+
 class FormatWithYapfRequest(RewrittenBuildFileRequest):
     pass
 
@@ -343,9 +344,7 @@ async def format_build_file_with_yapf(
     result_contents = await Get(DigestContents, Digest, yapf_result.output_digest)
     assert len(result_contents) == 1
     result_lines = tuple(result_contents[0].content.decode("utf-8").splitlines())
-    return RewrittenBuildFile(
-        request.path, result_lines, change_descriptions=("Format with Yapf",)
-    )
+    return RewrittenBuildFile(request.path, result_lines, change_descriptions=("Format with Yapf",))
 
 
 # ------------------------------------------------------------------------------------------


### PR DESCRIPTION
Work against #14086 

This PR adds a new option to the `update-build-files` goal:

```
$ ./pants update-build-files --help

...

  --update-build-files-formatter=<Formatter>
  PANTS_UPDATE_BUILD_FILES_FORMATTER
  formatter
      one of: [yapf, black]
      default: black
      current value: black
      Which formatter Pants should use to format BUILD files.
...
```

By passing the `--formatter` option you can choose what formatter will be used to format `BUILD` files.

```
$ ./pants update-build-files --fmt --formatter=yapf --help
...
  --update-build-files-formatter=<Formatter>
  PANTS_UPDATE_BUILD_FILES_FORMATTER
  formatter
      one of: [yapf, black]
      default: black
      current value: yapf (from command-line flag)
      Which formatter Pants should use to format BUILD files.
...
```


Running on files that do not need to be changed:

```
$ ./pants update-build-files --fmt --formatter=yapf
12:49:58.22 [INFO] Initializing scheduler...
12:49:58.73 [INFO] Scheduler initialized.
12:50:05.44 [INFO] Completed: Building yapf.pex from yapf_default_lockfile.txt
12:50:11.90 [INFO] No required changes to BUILD files found. However, there may still be deprecations that `update-build-files` doesn't know how to fix. See https://www.pantsbuild.org/v2.10/docs/upgrade-tips for upgrade tips.
```

I can see that yapf.pex is created, so I am able to tell Pants to use yapf.

Running on files that would be formatted:

```
$ ./pants update-build-files --fmt --formatter=yapf
Updated src/python/pants/backend/python/lint/yapf/BUILD:
  - Format with Black
```

The formatting does happen, but unfortunately, the message still shows `- Format with Black` for some reason.
