### PR TITLE
[internal] fix code path in generate_all_lockfiles_helper

### DIFF
--- a/build-support/bin/_generate_all_lockfiles_helper.py
+++ b/build-support/bin/_generate_all_lockfiles_helper.py
@@ -10,7 +10,6 @@ import subprocess
 import sys
 from dataclasses import dataclass
 
-
 from pants.backend.codegen.protobuf.python.python_protobuf_subsystem import PythonProtobufMypyPlugin
 from pants.backend.docker.subsystems.dockerfile_parser import DockerfileParser
 from pants.backend.java.lint.google_java_format.subsystem import GoogleJavaFormatSubsystem

--- a/build-support/bin/_generate_all_lockfiles_helper.py
+++ b/build-support/bin/_generate_all_lockfiles_helper.py
@@ -115,12 +115,10 @@ AllTools = (
     DefaultTool.jvm(JUnit),
     DefaultTool.jvm(GoogleJavaFormatSubsystem),
     DefaultTool.jvm(ScalafmtSubsystem),
-    DefaultTool.jvm(ScalaPBSubsystem, backend="pants.backend.experimental.codegen.protobuf.scala"),
     DefaultTool.jvm(Scalatest),
     DefaultTool.jvm(
         ScroogeSubsystem, backend="pants.backend.experimental.codegen.thrift.scrooge.scala"
     ),
-    DefaultTool.jvm(AvroSubsystem, backend="pants.backend.experimental.codegen.avro.java"),
     DefaultTool(
         "scalac-plugins",
         (f"--scalac-plugins-global-lockfile={Scalac.default_plugins_lockfile_path}",),

--- a/build-support/bin/_generate_all_lockfiles_helper.py
+++ b/build-support/bin/_generate_all_lockfiles_helper.py
@@ -10,10 +10,8 @@ import subprocess
 import sys
 from dataclasses import dataclass
 
-from pants.backend.codegen.avro.java.subsystem import AvroSubsystem
+
 from pants.backend.codegen.protobuf.python.python_protobuf_subsystem import PythonProtobufMypyPlugin
-from pants.backend.codegen.protobuf.scala.subsystem import ScalaPBSubsystem
-from pants.backend.codegen.thrift.scrooge.subsystem import ScroogeSubsystem
 from pants.backend.docker.subsystems.dockerfile_parser import DockerfileParser
 from pants.backend.java.lint.google_java_format.subsystem import GoogleJavaFormatSubsystem
 from pants.backend.java.subsystems.junit import JUnit
@@ -116,9 +114,6 @@ AllTools = (
     DefaultTool.jvm(GoogleJavaFormatSubsystem),
     DefaultTool.jvm(ScalafmtSubsystem),
     DefaultTool.jvm(Scalatest),
-    DefaultTool.jvm(
-        ScroogeSubsystem, backend="pants.backend.experimental.codegen.thrift.scrooge.scala"
-    ),
     DefaultTool(
         "scalac-plugins",
         (f"--scalac-plugins-global-lockfile={Scalac.default_plugins_lockfile_path}",),


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/14351 removed Java/Scala codegen backends temporarilly to ensure they were not released with 2.10. That PR was apparently incomplete. Removal of the `DefaultTool.jvm` entries for those backends is also necessary since those entries refer to the names of the removed backends.