### PR TITLE
[internal] Include link dest in symlink error.

### DIFF
--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -566,7 +566,7 @@ impl PosixFS {
             if path_buf.is_absolute() {
               Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("Absolute symlink: {:?}", link_abs),
+                format!("Absolute symlink: {:?}", path_buf),
               ))
             } else {
               link_parent
@@ -574,7 +574,7 @@ impl PosixFS {
                 .ok_or_else(|| {
                   io::Error::new(
                     io::ErrorKind::InvalidData,
-                    format!("Symlink without a parent?: {:?}", link_abs),
+                    format!("Symlink without a parent?: {:?}", path_buf),
                   )
                 })
             }

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -570,7 +570,7 @@ impl PosixFS {
               ))
             } else {
               link_parent
-                .map(|parent| parent.join(path_buf))
+                .map(|parent| parent.join(&path_buf))
                 .ok_or_else(|| {
                   io::Error::new(
                     io::ErrorKind::InvalidData,


### PR DESCRIPTION
I think it is relevant to include the rejected target path (`path_buf`) in the error message, and the `link_abs` is already presented in the outer error message `"Failed to read link <link_abs>: ..."` which was giving us the same path info twice.

Example:
```
Failed to read link "/private/tmp/process-executionCEiV14/.docker_tools/sh": Absolute symlink: "/private/tmp/process-executionCEiV14/.docker_tools/sh"
```

There's some Rust data ownership I'm not aware of how to fix in this patch, assuming it will be easy for you to see how to fix that.