### PR TITLE
[internal] Remove `staticproperty` and `decorated_type_checkable` decorators

### DIFF
--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -27,7 +27,7 @@ class SingletonMetaclass(type):
         return cls.instance
 
 
-class ClassPropertyDescriptor:
+class _ClassPropertyDescriptor:
     """Define a readable attribute on a class, given a function."""
 
     # The current solution is preferred as it doesn't require any modifications to the class
@@ -85,44 +85,9 @@ def classproperty(func: Callable[..., T]) -> T:
         # we need to use TypeVars for the call sites of this decorator to work properly.
         func = classmethod(func)  # type: ignore[assignment]
 
-    # If we properly annotated this function as returning a ClassPropertyDescriptor, then MyPy would
+    # If we properly annotated this function as returning a _ClassPropertyDescriptor, then MyPy would
     # no longer work correctly at call sites for this decorator.
-    return ClassPropertyDescriptor(func, doc)  # type: ignore[arg-type, return-value]
-
-
-def staticproperty(func: Callable[..., T]) -> T:
-    """Use as a decorator on a method definition to make it a class-level attribute (without
-    binding).
-
-    This decorator can be applied to a method or a staticmethod. This decorator does not bind any
-    arguments.
-
-    Usage:
-    >>> other_x = 'value'
-    >>> class Foo:
-    ...   @staticproperty
-    ...   def x():
-    ...     return other_x
-    ...
-    >>> Foo.x
-    'value'
-
-    Setting or deleting the attribute of this name will overwrite this property.
-
-    The docstring of the classproperty `x` for a class `C` can be obtained by
-    `C.__dict__['x'].__doc__`.
-    """
-    doc = func.__doc__
-
-    if not isinstance(func, staticmethod):
-        # MyPy complains about converting a Callable -> staticmethod. We use a Callable in the first
-        # place because there is no typing.staticmethod, i.e. a type that takes generic arguments, and
-        # we need to use TypeVars for the call sites of this decorator to work properly.
-        func = staticmethod(func)  # type: ignore[assignment]
-
-    # If we properly annotated this function as returning a ClassPropertyDescriptor, then MyPy would
-    # no longer work correctly at call sites for this decorator.
-    return ClassPropertyDescriptor(func, doc)  # type: ignore[arg-type, return-value]
+    return _ClassPropertyDescriptor(func, doc)  # type: ignore[arg-type, return-value]
 
 
 class _ClassDecoratorWithSentinelAttribute(ABC):
@@ -142,29 +107,6 @@ class _ClassDecoratorWithSentinelAttribute(ABC):
         return getattr(obj, "_decorated_type_checkable_type", None) is type(self)
 
 
-def decorated_type_checkable(
-    decorator: Callable[[Type], Type]
-) -> _ClassDecoratorWithSentinelAttribute:
-    """Wraps a class decorator to add a "sentinel attribute" to decorated classes.
-
-    A "sentinel attribute" is an attribute added to the wrapped class decorator's result with
-    `.define_instance_of()`. The wrapped class decorator can then be imported and used to check
-    whether some class object was wrapped with that decorator with `.is_instance()`.
-
-    When used on a class decorator method, the method should return
-    `<method name>.define_instance_of(cls)`, where `cls` is the class object that the decorator would
-    otherwise return.
-    """
-
-    class WrappedFunction(_ClassDecoratorWithSentinelAttribute):
-        @wraps(decorator)
-        def __call__(self, cls: Type) -> Type:
-            return decorator(cls)
-
-    return WrappedFunction()
-
-
-@decorated_type_checkable
 def frozen_after_init(cls: C) -> C:
     """Class decorator to freeze any modifications to the object after __init__() is done.
 

--- a/src/python/pants/util/meta_test.py
+++ b/src/python/pants/util/meta_test.py
@@ -6,13 +6,7 @@ from dataclasses import FrozenInstanceError, dataclass
 
 import pytest
 
-from pants.util.meta import (
-    SingletonMetaclass,
-    classproperty,
-    decorated_type_checkable,
-    frozen_after_init,
-    staticproperty,
-)
+from pants.util.meta import SingletonMetaclass, classproperty, frozen_after_init
 
 
 def test_singleton() -> None:
@@ -33,11 +27,6 @@ class WithProp:
     @classmethod
     def class_method(cls):
         return cls._value
-
-    @staticproperty
-    def static_property():  # type: ignore[misc]  # MyPy expects methods to have `self` or `cls`
-        """static_property docs."""
-        return "static_property"
 
     @staticmethod
     def static_method():
@@ -98,9 +87,6 @@ def test_access() -> None:
     assert "val0" == WithProp.class_method()
     assert "val0" == WithProp().class_method()
 
-    assert "static_property" == WithProp.static_property
-    assert "static_property" == WithProp().static_property
-
     assert "static_method" == WithProp.static_method()
     assert "static_method" == WithProp().static_method()
 
@@ -112,7 +98,6 @@ def test_has_attr() -> None:
 
 def test_docstring() -> None:
     assert "class_property docs." == WithProp.__dict__["class_property"].__doc__
-    assert "static_property docs." == WithProp.__dict__["static_property"].__doc__
 
 
 def test_override_value() -> None:
@@ -159,25 +144,17 @@ def test_set_attr():
     class SetValue:
         _x = "x0"
 
-        @staticproperty
-        def static_property():
-            return "s0"
-
         @classproperty
         def class_property(cls):
             return cls._x
 
     assert "x0" == SetValue.class_property
-    assert "s0" == SetValue.static_property
 
     # The @classproperty is gone, this is just a regular property now.
     SetValue.class_property = "x1"
     assert "x1" == SetValue.class_property
     # The source field is unmodified.
     assert "x0" == SetValue._x
-
-    SetValue.static_property = "s1"
-    assert "s1" == SetValue.static_property
 
 
 def test_delete_attr():
@@ -188,20 +165,12 @@ def test_delete_attr():
         def class_property(cls):
             return cls._y
 
-        @staticproperty
-        def static_property():
-            return "s0"
-
     assert "y0" == DeleteValue.class_property
-    assert "s0" == DeleteValue.static_property
 
     # The @classproperty is gone, but the source field is still alive.
     del DeleteValue.class_property
     assert hasattr(DeleteValue, "class_property") is False
     assert hasattr(DeleteValue, "_y") is True
-
-    del DeleteValue.static_property
-    assert hasattr(DeleteValue, "static_property") is False
 
 
 def test_abstract_classproperty():
@@ -242,32 +211,6 @@ def test_abstract_classproperty():
             return "hello"
 
     assert Concrete2.f == "hello"
-
-
-def test_decorated_type_checkable():
-    @decorated_type_checkable
-    def f(cls):
-        return f.define_instance_of(cls)
-
-    @f
-    class C:
-        pass
-
-    assert C._decorated_type_checkable_type == type(f)
-    assert f.is_instance(C) is True
-
-    # Check that .is_instance() is only true for exactly the decorator @g used on the class D!
-    @decorated_type_checkable
-    def g(cls):
-        return g.define_instance_of(cls)
-
-    @g
-    class D:
-        pass
-
-    assert D._decorated_type_checkable_type == type(g)
-    assert g.is_instance(D) is True
-    assert f.is_instance(D) is False
 
 
 def test_no_init() -> None:


### PR DESCRIPTION
These aren't being used anymore.

- `@staticproperty`: we always use `@classproperty` instead and I don't see why we'd need something to be static.
- `@decorated_type_checkable`: we used to use this for some engine types, but no longer need to. I don't see any reason to annotate `frozen_after_init` with it - our tests still pass.

They're getting in the way of @thejcannon's attempt to run Pants with Mypyc.

[ci skip-rust]
[ci skip-build-wheels]