### PR TITLE
[internal] Update the release volume limit and remove `validate` from hooks.

### DIFF
--- a/build-support/bin/_release_helper.py
+++ b/build-support/bin/_release_helper.py
@@ -390,8 +390,8 @@ MINIMUM_STALE_AGE = timedelta(days=180)
 PANTS_PKG = Package(
     "pantsbuild.pants",
     "src/python/pants:pants-packaged",
-    # TODO: See https://github.com/pypa/pypi-support/issues/1376.
-    20000,
+    # Increased from the default limit of 20GB via https://github.com/pypa/pypi-support/issues/1376.
+    40000,
     validate_pants_pkg,
 )
 TESTUTIL_PKG = Package(

--- a/build-support/githooks/pre-commit
+++ b/build-support/githooks/pre-commit
@@ -24,7 +24,7 @@ echo "* Typechecking"
 ./pants --changed-since="${MERGE_BASE}" --changed-dependees=transitive check
 
 echo "* Checking linters, formatters, and headers"
-./pants --changed-since="${MERGE_BASE}" lint validate ||
+./pants --changed-since="${MERGE_BASE}" lint ||
   die "If there were formatting errors, run \`./pants --changed-since=$(git rev-parse --symbolic "${MERGE_BASE}") fmt\`"
 
 if git diff "${MERGE_BASE}" --name-only | grep build-support/bin/generate_github_workflows.py > /dev/null; then


### PR DESCRIPTION
https://github.com/pypa/pypi-support/issues/1376 was approved, so increase the limit for the pre-release size check. Additionally, remove the deprecated `validate` goal from the commit hooks.

[ci skip-rust]