### PR TITLE
[internal] BSP: add union to gather `BuildTarget` instances

### DIFF
--- a/src/python/pants/bsp/protocol.py
+++ b/src/python/pants/bsp/protocol.py
@@ -15,7 +15,12 @@ from pylsp_jsonrpc.exceptions import (  # type: ignore[import]
 )
 from pylsp_jsonrpc.streams import JsonRpcStreamReader, JsonRpcStreamWriter  # type: ignore[import]
 
-from pants.bsp.spec import InitializeBuildParams, InitializeBuildResult
+from pants.bsp.spec import (
+    InitializeBuildParams,
+    InitializeBuildResult,
+    WorkspaceBuildTargetsParams,
+    WorkspaceBuildTargetsResult,
+)
 from pants.engine.internals.scheduler import SchedulerSession
 from pants.util.frozendict import FrozenDict
 
@@ -32,6 +37,9 @@ class _HandlerMapping:
 BSP_HANDLER_MAPPING = {
     "build/initialize": _HandlerMapping(
         InitializeBuildParams.from_json_dict, InitializeBuildResult
+    ),
+    "workspace/buildTargets": _HandlerMapping(
+        WorkspaceBuildTargetsParams.from_json_dict, WorkspaceBuildTargetsResult
     ),
 }
 
@@ -97,6 +105,8 @@ class BSPConnection:
         )
         returns, throws = self._scheduler_session.execute(execution_request)
         if len(returns) == 1 and len(throws) == 0:
+            if method_name == self._INITIALIZE_METHOD_NAME:
+                self._initialized = True
             return returns[0][1].value.to_json_dict()
         elif len(returns) == 0 and len(throws) == 1:
             raise throws[0][1].exc

--- a/src/python/pants/bsp/protocol_test.py
+++ b/src/python/pants/bsp/protocol_test.py
@@ -3,7 +3,6 @@
 import os
 from contextlib import contextmanager
 from dataclasses import dataclass
-from pathlib import Path
 from threading import Thread
 from typing import BinaryIO
 
@@ -14,8 +13,14 @@ from pylsp_jsonrpc.streams import JsonRpcStreamReader, JsonRpcStreamWriter  # ty
 
 from pants.bsp.protocol import BSPConnection
 from pants.bsp.rules import rules as bsp_rules
-from pants.bsp.spec import BuildClientCapabilities, InitializeBuildParams, InitializeBuildResult
-from pants.engine.internals.scheduler_test_base import SchedulerTestBase
+from pants.bsp.spec import (
+    BuildClientCapabilities,
+    InitializeBuildParams,
+    InitializeBuildResult,
+    WorkspaceBuildTargetsParams,
+    WorkspaceBuildTargetsResult,
+)
+from pants.testutil.rule_runner import RuleRunner
 
 
 @dataclass(frozen=True)
@@ -52,48 +57,55 @@ def setup_pipes():
         outbound_writer.close()
 
 
-class TestBSPConnection(SchedulerTestBase):
-    def test_errors_for_uninitialized_connection(self, tmp_path: Path) -> None:
-        with setup_pipes() as pipes:
-            # TODO: This code should be moved to a context manager. For now, only the pipes are managed
-            # with a context manager.
-            scheduler = self.mk_scheduler(tmp_path, [*bsp_rules()])
-            conn = BSPConnection(scheduler, pipes.inbound_reader, pipes.outbound_writer)
+def test_basic_bsp_protocol() -> None:
+    with setup_pipes() as pipes:
+        # TODO: This code should be moved to a context manager. For now, only the pipes are managed
+        # with a context manager.
+        rule_runner = RuleRunner(rules=bsp_rules())
+        conn = BSPConnection(rule_runner.scheduler, pipes.inbound_reader, pipes.outbound_writer)
 
-            def run_bsp_server():
-                conn.run()
+        def run_bsp_server():
+            conn.run()
 
-            bsp_thread = Thread(target=run_bsp_server)
-            bsp_thread.daemon = True
-            bsp_thread.start()
+        bsp_thread = Thread(target=run_bsp_server)
+        bsp_thread.daemon = True
+        bsp_thread.start()
 
-            client_reader = JsonRpcStreamReader(pipes.outbound_reader)
-            client_writer = JsonRpcStreamWriter(pipes.inbound_writer)
-            endpoint = Endpoint({}, lambda msg: client_writer.write(msg))
+        client_reader = JsonRpcStreamReader(pipes.outbound_reader)
+        client_writer = JsonRpcStreamWriter(pipes.inbound_writer)
+        endpoint = Endpoint({}, lambda msg: client_writer.write(msg))
 
-            def run_client():
-                client_reader.listen(lambda msg: endpoint.consume(msg))
+        def run_client():
+            client_reader.listen(lambda msg: endpoint.consume(msg))
 
-            client_thread = Thread(target=run_client)
-            client_thread.daemon = True
-            client_thread.start()
+        client_thread = Thread(target=run_client)
+        client_thread.daemon = True
+        client_thread.start()
 
-            response_fut = endpoint.request("foo")
-            with pytest.raises(JsonRpcException) as exc_info:
-                response_fut.result(timeout=15)
-            assert exc_info.value.code == -32002
-            assert exc_info.value.message == "Client must first call `build/initialize`."
+        response_fut = endpoint.request("foo")
+        with pytest.raises(JsonRpcException) as exc_info:
+            response_fut.result(timeout=15)
+        assert exc_info.value.code == -32002
+        assert exc_info.value.message == "Client must first call `build/initialize`."
 
-            init_request = InitializeBuildParams(
-                display_name="test",
-                version="0.0.0",
-                bsp_version="0.0.0",
-                root_uri="https://example.com",
-                capabilities=BuildClientCapabilities(language_ids=()),
-                data=None,
-            )
-            response_fut = endpoint.request("build/initialize", init_request.to_json_dict())
-            raw_response = response_fut.result(timeout=15)
-            response = InitializeBuildResult.from_json_dict(raw_response)
-            assert response.display_name == "Pants"
-            assert response.bsp_version == "0.0.1"
+        init_request = InitializeBuildParams(
+            display_name="test",
+            version="0.0.0",
+            bsp_version="0.0.0",
+            root_uri="https://example.com",
+            capabilities=BuildClientCapabilities(language_ids=()),
+            data=None,
+        )
+        response_fut = endpoint.request("build/initialize", init_request.to_json_dict())
+        raw_response = response_fut.result(timeout=15)
+        response = InitializeBuildResult.from_json_dict(raw_response)
+        assert response.display_name == "Pants"
+        assert response.bsp_version == "0.0.1"
+
+        build_targets_request = WorkspaceBuildTargetsParams()
+        response_fut = endpoint.request(
+            "workspace/buildTargets", build_targets_request.to_json_dict()
+        )
+        raw_response = response_fut.result(timeout=15)
+        response = WorkspaceBuildTargetsResult.from_json_dict(raw_response)
+        assert response.targets == ()

--- a/src/python/pants/bsp/rules.py
+++ b/src/python/pants/bsp/rules.py
@@ -1,8 +1,32 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-from pants.bsp.spec import BuildServerCapabilities, InitializeBuildParams, InitializeBuildResult
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pants.bsp.spec import (
+    BuildServerCapabilities,
+    BuildTarget,
+    InitializeBuildParams,
+    InitializeBuildResult,
+    WorkspaceBuildTargetsParams,
+    WorkspaceBuildTargetsResult,
+)
+from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import QueryRule, collect_rules, rule
+from pants.engine.unions import UnionMembership, union
 from pants.version import VERSION
+
+
+@union
+class BSPBuildTargetsRequest:
+    """Request language backends to provide BSP `BuildTarget` instances for their managed target
+    types."""
+
+
+@dataclass(frozen=True)
+class BSPBuildTargets:
+    targets: tuple[BuildTarget, ...]
 
 
 @rule
@@ -27,8 +51,27 @@ async def bsp_build_initialize(_request: InitializeBuildParams) -> InitializeBui
     )
 
 
+@rule
+async def bsp_workspace_build_targets(
+    _: WorkspaceBuildTargetsParams, union_membership: UnionMembership
+) -> WorkspaceBuildTargetsResult:
+    request_types = union_membership.get(BSPBuildTargetsRequest)
+    responses = await MultiGet(
+        Get(BSPBuildTargets, BSPBuildTargetsRequest, request_type())
+        for request_type in request_types
+    )
+    result: list[BuildTarget] = []
+    for response in responses:
+        result.extend(response.targets)
+    result.sort(key=lambda btgt: btgt.id.uri)
+    return WorkspaceBuildTargetsResult(
+        targets=tuple(result),
+    )
+
+
 def rules():
     return (
         *collect_rules(),
         QueryRule(InitializeBuildResult, (InitializeBuildParams,)),
+        QueryRule(WorkspaceBuildTargetsResult, (WorkspaceBuildTargetsParams,)),
     )


### PR DESCRIPTION
Add a union to allow the BSP rules to request BSP `BuildTarget` instances from language backends.

[ci skip-rust]

[ci skip-build-wheels]