### PR TITLE
Default to `use_deprecated_python_macros = false` and deprecate the option

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -64,8 +64,6 @@ remote_store_address = "grpcs://cache.toolchain.com:443"
 remote_instance_name = "main"
 remote_auth_plugin = "toolchain.pants.auth.plugin:toolchain_auth_plugin"
 
-use_deprecated_python_macros = false
-
 [anonymous-telemetry]
 enabled = true
 repo_id = "7775F8D5-FC58-4DBC-9302-D00AE4A1505F"

--- a/src/python/pants/backend/python/macros/deprecation_fixers_test.py
+++ b/src/python/pants/backend/python/macros/deprecation_fixers_test.py
@@ -45,7 +45,9 @@ def rule_runner() -> RuleRunner:
         },
         use_deprecated_python_macros=True,
     )
-    rule_runner.set_options(["--update-build-files-fix-python-macros"])
+    rule_runner.set_options(
+        ["--use-deprecated-python-macros", "--update-build-files-fix-python-macros"]
+    )
     return rule_runner
 
 

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -29,11 +29,7 @@ from pants.init.engine_initializer import EngineInitializer, GraphScheduler, Gra
 from pants.init.logging import stdio_destination_use_color
 from pants.init.options_initializer import OptionsInitializer
 from pants.init.specs_calculator import calculate_specs
-from pants.option.global_options import (
-    DynamicRemoteOptions,
-    DynamicUIRenderer,
-    maybe_warn_python_macros_deprecation,
-)
+from pants.option.global_options import DynamicRemoteOptions, DynamicUIRenderer
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.util.contextutil import maybe_profiled
@@ -79,7 +75,6 @@ class LocalPantsRunner:
             dynamic_remote_options, _ = DynamicRemoteOptions.from_options(options, env)
             bootstrap_options = options.bootstrap_option_values()
             assert bootstrap_options is not None
-            maybe_warn_python_macros_deprecation(bootstrap_options)
             scheduler = EngineInitializer.setup_graph(
                 bootstrap_options, build_config, dynamic_remote_options
             )

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -23,7 +23,6 @@ from pants.base.build_environment import (
     is_in_container,
     pants_version,
 )
-from pants.base.deprecated import warn_or_error
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.engine.environment import CompleteEnvironment
 from pants.engine.internals.native_engine import PyExecutor
@@ -1291,17 +1290,35 @@ class GlobalOptions(Subsystem):
             "--use-deprecated-python-macros",
             advanced=True,
             type=bool,
-            default=True,
+            default=False,
             help=(
-                "If true, continue using Pants's deprecated macro system for "
+                "If true, use Pants's deprecated macro system for "
                 "`python_requirements`, `poetry_requirements`, and `pipenv_requirements` "
                 "rather than target generation.\n\n"
-                "The address for target generation is different. Rather than "
-                "`3rdparty/python:Django`, the address will look like `3rdparty/python#Django`. "
-                "The target generator (`python_requirements` et al) is a "
-                "target itself now, meaning you can give it a `name`. If the target generator "
+                "The address for macros is different. Rather than "
+                "`3rdparty/python#Django`, the address will look like `3rdparty/python:Django`. "
+                "The macro (`python_requirements` et al) also was not a proper target, meaning "
+                "that you could not give it a `name`. In contrast, if the target generator "
                 "sets its `name`, e.g. to `reqs`, generated targets will have an address like "
                 "`3rdparty/python:reqs#Django`."
+            ),
+            removal_version="2.12.0.dev0",
+            removal_hint=(
+                "In Pants 2.12, the deprecated Python macros like `python_requirements` will be "
+                "removed in favor of the improved target generators, which are now enabled by "
+                "default.\n\n"
+                "If you already migrated by setting `use_deprecated_python_macros = false`, simply "
+                "delete the option.\n\n"
+                "Otherwise, when you are ready to upgrade, follow these steps:\n\n"
+                "  1. Run `./pants update-build-files --fix-python-macros`\n"
+                "  2. Check the logs for an ERROR log to see if you have to manually add "
+                "`name=` anywhere.\n"
+                "  3. Remove `use_deprecated_python_macros = true` from `[GLOBAL]` in "
+                "pants.toml.\n\n"
+                "You can ignore this warning with `[GLOBAL].ignore_warnings`."
+                "(Why upgrade from the old macro mechanism to target generation? Among other "
+                "benefits, it makes sure that the Pants daemon is properly invalidated when you "
+                "change `requirements.txt` and `pyproject.toml`.)"
             ),
         )
 
@@ -1624,28 +1641,3 @@ class ProcessCleanupOption:
     """
 
     val: bool
-
-
-def maybe_warn_python_macros_deprecation(bootstrap_options: OptionValueContainer) -> None:
-    if (
-        bootstrap_options.is_default("use_deprecated_python_macros")
-        and "pants.backend.python" in bootstrap_options.backend_packages
-    ):
-        warn_or_error(
-            "2.11.0.dev0",
-            "the option `--use-deprecated-python-macros` defaulting to true",
-            (
-                "In Pants 2.11, the default for the global option "
-                "`--use-deprecated-python-macros` will change to false.\n\n"
-                "To fix this deprecation, explicitly set `use_deprecated_python_macros = true` in "
-                "the `[GLOBAL]` section of `pants.toml`. Or, when you are ready to upgrade to "
-                "the improved target generation mechanism, follow these steps:\n\n"
-                "  1. Run `./pants update-build-files --fix-python-macros`\n"
-                "  2. Check the logs for an ERROR log to see if you have to manually add "
-                "`name=` anywhere.\n"
-                "  3. Set `use_deprecated_python_macros = false` in `[GLOBAL]` in pants.toml.\n\n"
-                "(Why upgrade from the old macro mechanism to target generation? Among other "
-                "benefits, it makes sure that the Pants daemon is properly invalidated when you "
-                "change `requirements.txt` and `pyproject.toml`.)"
-            ),
-        )

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1305,7 +1305,7 @@ class GlobalOptions(Subsystem):
             removal_version="2.12.0.dev0",
             removal_hint=(
                 "In Pants 2.12, the deprecated Python macros like `python_requirements` will be "
-                "removed in favor of the improved target generators, which are now enabled by "
+                "replaced with improved target generators, which are now enabled by "
                 "default.\n\n"
                 "If you already migrated by setting `use_deprecated_python_macros = false`, simply "
                 "delete the option.\n\n"

--- a/src/python/pants/pantsd/pants_daemon_core.py
+++ b/src/python/pants/pantsd/pants_daemon_core.py
@@ -15,11 +15,7 @@ from pants.engine.environment import CompleteEnvironment
 from pants.engine.internals.native_engine import PyExecutor
 from pants.init.engine_initializer import EngineInitializer, GraphScheduler
 from pants.init.options_initializer import OptionsInitializer
-from pants.option.global_options import (
-    AuthPluginResult,
-    DynamicRemoteOptions,
-    maybe_warn_python_macros_deprecation,
-)
+from pants.option.global_options import AuthPluginResult, DynamicRemoteOptions
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.option.options_fingerprinter import OptionsFingerprinter
@@ -170,7 +166,6 @@ class PantsDaemonCore:
                 # and services.
                 bootstrap_options = options.bootstrap_option_values()
                 assert bootstrap_options is not None
-                maybe_warn_python_macros_deprecation(bootstrap_options)
                 with self._handle_exceptions():
                     self._initialize(
                         options_fingerprint,


### PR DESCRIPTION

[ci skip-rust]