### PR TITLE
Make help command remind users about help-advanced command

### DIFF
--- a/src/python/pants/help/help_formatter.py
+++ b/src/python/pants/help/help_formatter.py
@@ -9,7 +9,7 @@ from typing import List, Optional
 from pants.help.help_info_extracter import OptionHelpInfo, OptionScopeHelpInfo, to_help_str
 from pants.help.maybe_color import MaybeColor
 from pants.option.ranked_value import Rank, RankedValue
-from pants.util.docutil import terminal_width
+from pants.util.docutil import bin_name, terminal_width
 from pants.util.strutil import hard_wrap
 
 
@@ -56,8 +56,8 @@ class HelpFormatter(MaybeColor):
         if oshi.advanced and not self._show_advanced:
             lines.append(
                 self.maybe_green(
-                    f"There are advanced options which you can list by running "
-                    f"`./pants help-advanced {oshi.scope}`"
+                    f"Advanced options available. You can list them by running "
+                    f"{bin_name()} help-advanced {oshi.scope}."
                 )
             )
         return [*lines, ""]

--- a/src/python/pants/help/help_formatter.py
+++ b/src/python/pants/help/help_formatter.py
@@ -49,6 +49,10 @@ class HelpFormatter(MaybeColor):
                 lines.extend([*self.format_option(ohi), ""])
 
         add_option(oshi.basic)
+        if self._show_advanced:
+            add_option(oshi.advanced, category="advanced")
+        if self._show_deprecated:
+            add_option(oshi.deprecated, category="deprecated")
         if oshi.advanced and not self._show_advanced:
             lines.append(
                 self.maybe_green(
@@ -56,10 +60,6 @@ class HelpFormatter(MaybeColor):
                     f"`./pants help-advanced {oshi.scope}`"
                 )
             )
-        if self._show_advanced:
-            add_option(oshi.advanced, category="advanced")
-        if self._show_deprecated:
-            add_option(oshi.deprecated, category="deprecated")
         return [*lines, ""]
 
     def format_option(self, ohi: OptionHelpInfo) -> List[str]:

--- a/src/python/pants/help/help_formatter.py
+++ b/src/python/pants/help/help_formatter.py
@@ -9,7 +9,7 @@ from typing import List, Optional
 from pants.help.help_info_extracter import OptionHelpInfo, OptionScopeHelpInfo, to_help_str
 from pants.help.maybe_color import MaybeColor
 from pants.option.ranked_value import Rank, RankedValue
-from pants.util.docutil import bin_name, terminal_width
+from pants.util.docutil import terminal_width
 from pants.util.strutil import hard_wrap
 
 
@@ -57,7 +57,7 @@ class HelpFormatter(MaybeColor):
             lines.append(
                 self.maybe_green(
                     f"Advanced options available. You can list them by running "
-                    f"{bin_name()} help-advanced {oshi.scope}."
+                    f"./pants help-advanced {oshi.scope}."
                 )
             )
         return [*lines, ""]

--- a/src/python/pants/help/help_formatter.py
+++ b/src/python/pants/help/help_formatter.py
@@ -14,11 +14,8 @@ from pants.util.strutil import hard_wrap
 
 
 class HelpFormatter(MaybeColor):
-    def __init__(
-        self, *, show_advanced: bool, show_deprecated: bool, color: bool, entity: str
-    ) -> None:
+    def __init__(self, *, show_advanced: bool, show_deprecated: bool, color: bool) -> None:
         super().__init__(color=color)
-        self.entity = entity
         self._show_advanced = show_advanced
         self._show_deprecated = show_deprecated
         self._width = terminal_width()
@@ -56,7 +53,7 @@ class HelpFormatter(MaybeColor):
             lines.append(
                 self.maybe_green(
                     f"There are advanced options which you can list by running "
-                    f"`./pants help-advanced {self.entity}`"
+                    f"`./pants help-advanced {oshi.scope}`"
                 )
             )
         if self._show_advanced:

--- a/src/python/pants/help/help_formatter.py
+++ b/src/python/pants/help/help_formatter.py
@@ -14,8 +14,11 @@ from pants.util.strutil import hard_wrap
 
 
 class HelpFormatter(MaybeColor):
-    def __init__(self, *, show_advanced: bool, show_deprecated: bool, color: bool) -> None:
+    def __init__(
+        self, *, show_advanced: bool, show_deprecated: bool, color: bool, entity: str
+    ) -> None:
         super().__init__(color=color)
+        self.entity = entity
         self._show_advanced = show_advanced
         self._show_deprecated = show_deprecated
         self._width = terminal_width()
@@ -49,6 +52,13 @@ class HelpFormatter(MaybeColor):
                 lines.extend([*self.format_option(ohi), ""])
 
         add_option(oshi.basic)
+        if oshi.advanced and not self._show_advanced:
+            lines.append(
+                self.maybe_green(
+                    f"There are advanced options which you can list by running "
+                    f"`./pants help-advanced {self.entity}`"
+                )
+            )
         if self._show_advanced:
             add_option(oshi.advanced, category="advanced")
         if self._show_deprecated:

--- a/src/python/pants/help/help_formatter_test.py
+++ b/src/python/pants/help/help_formatter_test.py
@@ -74,7 +74,7 @@ class OptionHelpFormatterTest(unittest.TestCase):
         args = ["--foo"]
         kwargs = {"advanced": True}
         lines = self._format_for_global_scope(False, False, args, kwargs)
-        assert len(lines) == 8
+        assert len(lines) == 9
         assert not any("--foo" in line for line in lines)
         lines = self._format_for_global_scope(True, False, args, kwargs)
         assert len(lines) == 18

--- a/src/python/pants/help/help_formatter_test.py
+++ b/src/python/pants/help/help_formatter_test.py
@@ -36,7 +36,7 @@ class OptionHelpFormatterTest(unittest.TestCase):
         )
         ohi = replace(ohi, **kwargs)
         lines = HelpFormatter(
-            show_advanced=False, show_deprecated=False, color=False, entity="some"
+            show_advanced=False, show_deprecated=False, color=False
         ).format_option(ohi)
         choices = kwargs.get("choices")
         assert len(lines) == 7 if choices else 6
@@ -67,7 +67,7 @@ class OptionHelpFormatterTest(unittest.TestCase):
         parser.parse_args(Parser.ParseArgsRequest((), OptionValueContainerBuilder(), [], False))
         oshi = HelpInfoExtracter("").get_option_scope_help_info("", parser, False, "help.test")
         return HelpFormatter(
-            show_advanced=show_advanced, show_deprecated=show_deprecated, color=False, entity="some"
+            show_advanced=show_advanced, show_deprecated=show_deprecated, color=False
         ).format_options(oshi)
 
     def test_suppress_advanced(self):

--- a/src/python/pants/help/help_formatter_test.py
+++ b/src/python/pants/help/help_formatter_test.py
@@ -36,7 +36,7 @@ class OptionHelpFormatterTest(unittest.TestCase):
         )
         ohi = replace(ohi, **kwargs)
         lines = HelpFormatter(
-            show_advanced=False, show_deprecated=False, color=False
+            show_advanced=False, show_deprecated=False, color=False, entity="some"
         ).format_option(ohi)
         choices = kwargs.get("choices")
         assert len(lines) == 7 if choices else 6
@@ -67,7 +67,7 @@ class OptionHelpFormatterTest(unittest.TestCase):
         parser.parse_args(Parser.ParseArgsRequest((), OptionValueContainerBuilder(), [], False))
         oshi = HelpInfoExtracter("").get_option_scope_help_info("", parser, False, "help.test")
         return HelpFormatter(
-            show_advanced=show_advanced, show_deprecated=show_deprecated, color=False
+            show_advanced=show_advanced, show_deprecated=show_deprecated, color=False, entity="some"
         ).format_options(oshi)
 
     def test_suppress_advanced(self):

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -268,16 +268,26 @@ class HelpPrinter(MaybeColor):
 
         Assumes that self._help_request is an instance of OptionsHelp.
         """
+        oshi = self._all_help_info.scope_to_help_info.get(scope)
+        if not oshi:
+            return
+
+        # getting name of the entity for which the help needs to be shown
+        goal_info = self._all_help_info.name_to_goal_info.get(scope)
+        if goal_info:
+            entity = goal_info.name
+        else:
+            subsystem = self._all_help_info.scope_to_help_info.get(scope)
+            if subsystem:
+                entity = subsystem.scope
+
         help_formatter = HelpFormatter(
             show_advanced=show_advanced_and_deprecated,
             show_deprecated=show_advanced_and_deprecated,
             color=self.color,
+            entity=entity,
         )
-        oshi = self._all_help_info.scope_to_help_info.get(scope)
-        if not oshi:
-            return
         formatted_lines = help_formatter.format_options(oshi)
-        goal_info = self._all_help_info.name_to_goal_info.get(scope)
         if goal_info:
             related_scopes = sorted(set(goal_info.consumed_scopes) - {GLOBAL_SCOPE, goal_info.name})
             if related_scopes:

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -268,26 +268,16 @@ class HelpPrinter(MaybeColor):
 
         Assumes that self._help_request is an instance of OptionsHelp.
         """
-        oshi = self._all_help_info.scope_to_help_info.get(scope)
-        if not oshi:
-            return
-
-        # getting name of the entity for which the help needs to be shown
-        goal_info = self._all_help_info.name_to_goal_info.get(scope)
-        if goal_info:
-            entity = goal_info.name
-        else:
-            subsystem = self._all_help_info.scope_to_help_info.get(scope)
-            if subsystem:
-                entity = subsystem.scope
-
         help_formatter = HelpFormatter(
             show_advanced=show_advanced_and_deprecated,
             show_deprecated=show_advanced_and_deprecated,
             color=self.color,
-            entity=entity,
         )
+        oshi = self._all_help_info.scope_to_help_info.get(scope)
+        if not oshi:
+            return
         formatted_lines = help_formatter.format_options(oshi)
+        goal_info = self._all_help_info.name_to_goal_info.get(scope)
         if goal_info:
             related_scopes = sorted(set(goal_info.consumed_scopes) - {GLOBAL_SCOPE, goal_info.name})
             if related_scopes:


### PR DESCRIPTION
Work towards https://github.com/pantsbuild/pants/issues/13363

### Subsystems:

With advanced options:

```
$ ./pants help anonymous-telemetry

`anonymous-telemetry` subsystem options
---------------------------------------

Options related to sending anonymous stats to the Pants project, to aid development.
 
Activated by pants.core
Config section: [anonymous-telemetry]
 
None available.
There are advanced options which you can list by running `./pants help-advanced anonymous-telemetry`
```

```
$ ./pants help yapf

`yapf` subsystem options
------------------------

A formatter for Python files (https://github.com/google/yapf).
 
Activated by pants.core
Config section: [yapf]
 
  --[no-]yapf-skip
  PANTS_YAPF_SKIP
  skip
      default: False
      current value: False
      Don't use yapf when running `./pants fmt` and `./pants lint`.

  --yapf-args="[<shell_str>, <shell_str>, ...]"
  PANTS_YAPF_ARGS
  args
      default: []
      current value: []
      Arguments to pass directly to yapf, e.g. `--yapf-args="--no-local-style"`.
      
      Certain arguments, specifically `--recursive`, `--in-place`, and `--parallel`, will be ignored because Pants takes care of finding all the relevant files and running the formatting in parallel.

There are advanced options which you can list by running `./pants help-advanced yapf`
```

Without advanced options:

```
$ ./pants help cli

`cli` subsystem options
-----------------------

Options for configuring CLI behavior, such as command line aliases.
 
Activated by 
Config section: [cli]
 
  --cli-alias="{'key1': val1, 'key2': val2, ...}"
  PANTS_CLI_ALIAS
  alias
      default: {}
      current value: {
          "all-changed": "--changed-since=HEAD --changed-dependees=transitive",
          "run-pyupgrade": "--backend-packages=pants.backend.experimental.python.lint.pyupgrade fmt"
      } (from pants.toml)
      Register command line aliases.
      Example:
      
          [cli.alias]
          green = "fmt lint check"
          all-changed = "--changed-since=HEAD --changed-dependees=transitive"
      
      This would allow you to run `./pants green all-changed`, which is shorthand for `./pants fmt lint check --changed-since=HEAD --changed-dependees=transitive`.
      
      Notice: this option must be placed in a config file (e.g. `pants.toml` or `pantsrc`) to have any effect.
```

### Goals:

With advanced options:

```
$ ./pants help tailor

`tailor` goal options
---------------------

Auto-generate BUILD file targets for new source files.
 
Activated by pants.core
Config section: [tailor]
 
  --[no-]tailor-check
  PANTS_TAILOR_CHECK
  check
      default: False
      current value: False
      Do not write changes to disk, only write back what would change. Return code 0 means there would be no changes, and 1 means that there would be.

There are advanced options which you can list by running `./pants help-advanced tailor`
```

Without advanced options:

```
$ ./pants help run

`run` goal options
------------------

Runs a binary target.

This goal propagates the return code of the underlying executable.

If your application can safely be restarted while it is running, you can pass `restartable=True` on your binary target (for supported types), and the `run` goal will automatically restart them as all
relevant files change. This can be particularly useful for server applications.
 
Activated by pants.core
Config section: [run]
 
  --run-args="[<shell_str>, <shell_str>, ...]"
  ... -- [<shell_str> [<shell_str> [...]]]
  PANTS_RUN_ARGS
  args
      default: []
      current value: [] (from command-line flag)
      Arguments to pass directly to the executed target, e.g. `--run-args="val1 val2 --debug"`

  --[no-]run-cleanup
  PANTS_RUN_CLEANUP
  cleanup
      default: True
      current value: True
      Whether to clean up the temporary directory in which the binary is chrooted. Set to false to retain the directory, e.g., for debugging.


```

Targets do not have a concept of an option and therefore do not need any special handling.
