### PR TITLE
scala: support multiple scala versions

### DIFF
--- a/src/python/pants/backend/java/compile/javac.py
+++ b/src/python/pants/backend/java/compile/javac.py
@@ -149,7 +149,7 @@ async def compile_java_source(
     )
 
     usercp = "__cp"
-    user_classpath = Classpath(direct_dependency_classpath_entries)
+    user_classpath = Classpath(direct_dependency_classpath_entries, request.resolve)
     classpath_arg = ":".join(user_classpath.root_immutable_inputs_args(prefix=usercp))
     immutable_input_digests = dict(user_classpath.root_immutable_inputs(prefix=usercp))
 

--- a/src/python/pants/backend/scala/compile/scalac.py
+++ b/src/python/pants/backend/scala/compile/scalac.py
@@ -131,6 +131,8 @@ async def compile_scala_source(
     usercp = "__cp"
 
     user_classpath = Classpath(direct_dependency_classpath_entries)
+
+    scala_version = scala.version_for_resolve(request.resolve.name)
     tool_classpath, sources_digest = await MultiGet(
         Get(
             ToolClasspath,
@@ -140,12 +142,12 @@ async def compile_scala_source(
                         Coordinate(
                             group="org.scala-lang",
                             artifact="scala-compiler",
-                            version=scala.version,
+                            version=scala_version,
                         ),
                         Coordinate(
                             group="org.scala-lang",
                             artifact="scala-library",
-                            version=scala.version,
+                            version=scala_version,
                         ),
                     ]
                 ),

--- a/src/python/pants/backend/scala/compile/scalac.py
+++ b/src/python/pants/backend/scala/compile/scalac.py
@@ -130,7 +130,7 @@ async def compile_scala_source(
     scalac_plugins_relpath = "__plugincp"
     usercp = "__cp"
 
-    user_classpath = Classpath(direct_dependency_classpath_entries)
+    user_classpath = Classpath(direct_dependency_classpath_entries, request.resolve)
 
     scala_version = scala.version_for_resolve(request.resolve.name)
     tool_classpath, sources_digest = await MultiGet(

--- a/src/python/pants/backend/scala/compile/scalac.py
+++ b/src/python/pants/backend/scala/compile/scalac.py
@@ -81,12 +81,14 @@ async def compile_scala_source(
         for filename in dependency.filenames
     ]
 
+    scala_version = scala.version_for_resolve(request.resolve.name)
+
     # TODO(14171): Stop-gap for making sure that scala supplies all of its dependencies to
     # deploy targets.
     if not any(
         filename.startswith("org.scala-lang_scala-library_") for filename in all_dependency_jars
     ):
-        scala_library = await Get(ClasspathEntry, ScalaLibraryRequest(scala.version))
+        scala_library = await Get(ClasspathEntry, ScalaLibraryRequest(scala_version))
         direct_dependency_classpath_entries += (scala_library,)
 
     component_members_with_sources = tuple(
@@ -132,7 +134,6 @@ async def compile_scala_source(
 
     user_classpath = Classpath(direct_dependency_classpath_entries, request.resolve)
 
-    scala_version = scala.version_for_resolve(request.resolve.name)
     tool_classpath, sources_digest = await MultiGet(
         Get(
             ToolClasspath,

--- a/src/python/pants/backend/scala/goals/repl.py
+++ b/src/python/pants/backend/scala/goals/repl.py
@@ -26,31 +26,31 @@ async def create_scala_repl_request(
     request: ScalaRepl, bash: BashBinary, jdk_setup: JdkSetup, scala_subsystem: ScalaSubsystem
 ) -> ReplRequest:
     jdk = jdk_setup.jdk
-    user_classpath, tool_classpath = await MultiGet(
-        Get(Classpath, Addresses, request.addresses),
-        Get(
-            ToolClasspath,
-            ToolClasspathRequest(
-                prefix="__toolcp",
-                artifact_requirements=ArtifactRequirements.from_coordinates(
-                    [
-                        Coordinate(
-                            group="org.scala-lang",
-                            artifact="scala-compiler",
-                            version=scala_subsystem.version,
-                        ),
-                        Coordinate(
-                            group="org.scala-lang",
-                            artifact="scala-library",
-                            version=scala_subsystem.version,
-                        ),
-                        Coordinate(
-                            group="org.scala-lang",
-                            artifact="scala-reflect",
-                            version=scala_subsystem.version,
-                        ),
-                    ]
-                ),
+
+    user_classpath = await Get(Classpath, Addresses, request.addresses)
+    scala_version = scala_subsystem.version_for_resolve(user_classpath.resolve.name)
+    tool_classpath = await Get(
+        ToolClasspath,
+        ToolClasspathRequest(
+            prefix="__toolcp",
+            artifact_requirements=ArtifactRequirements.from_coordinates(
+                [
+                    Coordinate(
+                        group="org.scala-lang",
+                        artifact="scala-compiler",
+                        version=scala_version,
+                    ),
+                    Coordinate(
+                        group="org.scala-lang",
+                        artifact="scala-library",
+                        version=scala_version,
+                    ),
+                    Coordinate(
+                        group="org.scala-lang",
+                        artifact="scala-reflect",
+                        version=scala_version,
+                    ),
+                ]
             ),
         ),
     )

--- a/src/python/pants/backend/scala/subsystems/scala.py
+++ b/src/python/pants/backend/scala/subsystems/scala.py
@@ -3,10 +3,15 @@
 
 from __future__ import annotations
 
+import logging
+from typing import cast
+
 from pants.option.option_types import StrOption
 from pants.option.subsystem import Subsystem
 
 DEFAULT_SCALA_VERSION = "2.13.6"
+
+_logger = logging.getLogger(__name__)
 
 
 class ScalaSubsystem(Subsystem):
@@ -14,5 +19,42 @@ class ScalaSubsystem(Subsystem):
     help = "Scala programming language"
 
     version = StrOption(
-        "--version", default=DEFAULT_SCALA_VERSION, help="The version of Scala to use"
-    )
+        "--version",
+        default=DEFAULT_SCALA_VERSION,
+        help=(
+            "The version of Scala to use.\n\n"
+            "This option is deprecated in favor of the `[scala].version_for_resolve` option. If "
+            "`[scala].version_for_resolve` does not have an entry for a resolve, then the value of "
+            "this option will be used as the Scala version for that resolve."
+        ),
+    ).deprecated(removal_version="2.11.0.dev0", hint="Use `[scala].version_for_resolve` instead.")
+
+    @classmethod
+    def register_options(cls, register):
+        super().register_options(register)
+
+        register(
+            "--version-for-resolve",
+            type=dict,
+            help=(
+                "A dictionary mapping the name of a resolve to the Scala version to use for all Scala "
+                "targets consuming that resolve.\n\n"
+                'All Scala-compiled jars on a resolve\'s classpath must be "compatible" with one another and '
+                "with all Scala-compiled first-party sources from `scala_sources` and other Scala target types. "
+                "This implies that the Scala version maps one to one with a resolve.\n\n"
+                "For each resolve listed in this option, Pants will (1) use the mapped Scala version as the version "
+                "of the Scala compiler to use when compiling first-party sources, (2) ensure the Scala runtime "
+                "libraries are added to the resolve, and (3) attempt to error if any Scala-compiled jars are part of "
+                'the resolve\'s classpath if "incompatible" with the Scala version.'
+            ),
+        )
+
+    @property
+    def _version_for_resolve(self) -> dict[str, str]:
+        return cast("dict[str, str]", self.options.version_for_resolve)
+
+    def version_for_resolve(self, resolve: str):
+        version = self._version_for_resolve.get(resolve)
+        if version:
+            return version
+        return self.version

--- a/src/python/pants/backend/scala/subsystems/scala.py
+++ b/src/python/pants/backend/scala/subsystems/scala.py
@@ -40,12 +40,10 @@ class ScalaSubsystem(Subsystem):
                 "A dictionary mapping the name of a resolve to the Scala version to use for all Scala "
                 "targets consuming that resolve.\n\n"
                 'All Scala-compiled jars on a resolve\'s classpath must be "compatible" with one another and '
-                "with all Scala-compiled first-party sources from `scala_sources` and other Scala target types. "
-                "This implies that the Scala version maps one to one with a resolve.\n\n"
-                "For each resolve listed in this option, Pants will (1) use the mapped Scala version as the version "
-                "of the Scala compiler to use when compiling first-party sources, (2) ensure the Scala runtime "
-                "libraries are added to the resolve, and (3) attempt to error if any Scala-compiled jars are part of "
-                'the resolve\'s classpath if "incompatible" with the Scala version.'
+                "with all Scala-compiled first-party sources from `scala_sources` (and other Scala target types) "
+                "using that resolve. The option sets the Scala version that will be used to compile all "
+                "first-party sources using the resolve. This ensures that the compatibility property is "
+                "maintained for a resolve. To support multiple Scala versions, use multiple resolves."
             ),
         )
 

--- a/src/python/pants/backend/scala/subsystems/scala.py
+++ b/src/python/pants/backend/scala/subsystems/scala.py
@@ -51,7 +51,7 @@ class ScalaSubsystem(Subsystem):
     def _version_for_resolve(self) -> dict[str, str]:
         return cast("dict[str, str]", self.options.version_for_resolve)
 
-    def version_for_resolve(self, resolve: str):
+    def version_for_resolve(self, resolve: str) -> str:
         version = self._version_for_resolve.get(resolve)
         if version:
             return version

--- a/src/python/pants/jvm/classpath.py
+++ b/src/python/pants/jvm/classpath.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import Iterator
 
 from pants.engine.fs import Digest
@@ -16,6 +17,7 @@ from pants.jvm.resolve.key import CoursierResolveKey
 logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True)
 class Classpath:
     """A transitive classpath which is sufficient to launch the target(s) it was generated for.
 
@@ -30,9 +32,8 @@ class Classpath:
     This classpath is guaranteed to contain only JAR files.
     """
 
-    def __init__(self, entries: tuple[ClasspathEntry, ...], resolve: CoursierResolveKey) -> None:
-        self.entries: tuple[ClasspathEntry, ...] = entries
-        self.resolve: CoursierResolveKey = resolve
+    entries: tuple[ClasspathEntry, ...]
+    resolve: CoursierResolveKey
 
     def args(self, *, prefix: str = "") -> Iterator[str]:
         """All transitive filenames for this Classpath."""

--- a/src/python/pants/jvm/testutil.py
+++ b/src/python/pants/jvm/testutil.py
@@ -93,7 +93,8 @@ async def render_classpath_entry(
 @rule
 async def render_classpath(classpath: Classpath) -> RenderedClasspath:
     rendered_classpaths = await MultiGet(
-        Get(RenderedClasspath, ClasspathEntry, cpe) for cpe in ClasspathEntry.closure(classpath)
+        Get(RenderedClasspath, ClasspathEntry, cpe)
+        for cpe in ClasspathEntry.closure(classpath.entries)
     )
     return RenderedClasspath({k: v for rc in rendered_classpaths for k, v in rc.content.items()})
 


### PR DESCRIPTION
Implement support for multiple Scala versions in the same repository. Each resolve will be assigned a single Scala version.

Scala requires that all Scala-compiled jars on a classpath (i.e, a resolve) be "compatible" with one another (regardless of whether they are third-party jars or jars compiled from first-party sources). For Scala 2.x versions, for example, "compatibility" means that all Scala-compiled jars were compiled with the same minor version of Scala (i.e., 2.12). We can maintain this "Scala compatibility" property for a resolve by assigning the resolve a single Scala version which ensures that there is single Scala version that all of the third-party jars must be compatible with and that all first-party sources are compiled with. 

Introduce the `--scala-version-for-resolve` option to implement the mapping from resolve to Scala version. The `--scala-version` option is deprecated and will be used as a fallback if the Scala version for a particular resolve is not set in `--scala-version-for-resolve`.

Closes https://github.com/pantsbuild/pants/issues/13994.