### PR TITLE
scala: add scala-library to resolves automatically

### DIFF
--- a/src/python/pants/backend/scala/resolve/BUILD
+++ b/src/python/pants/backend/scala/resolve/BUILD
@@ -1,0 +1,5 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_sources()
+python_tests(name="tests", timeout=240)

--- a/src/python/pants/backend/scala/resolve/lockfile.py
+++ b/src/python/pants/backend/scala/resolve/lockfile.py
@@ -1,0 +1,83 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from pants.backend.scala.dependency_inference.symbol_mapper import AllScalaTargets
+from pants.backend.scala.subsystems.scala import ScalaSubsystem
+from pants.engine.rules import collect_rules, rule
+from pants.engine.unions import UnionRule
+from pants.jvm.goals.lockfile import (
+    EditProposedJvmArtifactsForResolveRequest,
+    ProposedJvmArtifactsForResolve,
+)
+from pants.jvm.resolve.common import ArtifactRequirement, ArtifactRequirements, Coordinate
+from pants.jvm.subsystems import JvmSubsystem
+
+_SCALA_LIBRARY_GROUP = "org.scala-lang"
+_SCALA_LIBRARY_ARTIFACT = "scala-library"
+
+
+class ProposeScalaArtifactsForResolveRequest(EditProposedJvmArtifactsForResolveRequest):
+    pass
+
+
+@rule
+async def propose_scala_artifacts_for_resolve(
+    request: ProposeScalaArtifactsForResolveRequest,
+    scala_subsystem: ScalaSubsystem,
+    scala_targets: AllScalaTargets,
+    jvm: JvmSubsystem,
+) -> ProposedJvmArtifactsForResolve:
+    print(f"propose_scala_artifacts_for_resolve: request={request}")
+    first_party_target_uses_this_resolve = False
+    for tgt in scala_targets:
+        resolves_for_target = jvm.resolves_for_target(tgt)
+        if request.resolve_name in resolves_for_target:
+            first_party_target_uses_this_resolve = True
+            break
+
+    if not first_party_target_uses_this_resolve:
+        return ProposedJvmArtifactsForResolve(request.artifacts)
+
+    scala_version = scala_subsystem.version_for_resolve(request.resolve_name)
+    # TODO: Uncomment this once `--scala-version` goes away in v2.11.x.
+    # if scala_version is None:
+    #     raise ValueError(
+    #         f"Resolve `{request.resolve_name}` is used by at least one Scala target, but no Scala version "
+    #         "for the resolve was set in the `[scala].version_for_resolve` option. Please set the "
+    #         "Scala version to use in the `[scala].version_for_resolve` option."
+    #     )
+
+    has_scala_library_artifact = False
+    for artifact in request.artifacts:
+        if (
+            artifact.coordinate.group == _SCALA_LIBRARY_GROUP
+            and artifact.coordinate.artifact == _SCALA_LIBRARY_ARTIFACT
+        ):
+            has_scala_library_artifact = True
+
+    if not has_scala_library_artifact:
+        artifacts = ArtifactRequirements(
+            sorted(
+                [
+                    *request.artifacts,
+                    ArtifactRequirement(
+                        coordinate=Coordinate(
+                            group=_SCALA_LIBRARY_GROUP,
+                            artifact=_SCALA_LIBRARY_ARTIFACT,
+                            version=scala_version,
+                        )
+                    ),
+                ]
+            )
+        )
+        return ProposedJvmArtifactsForResolve(artifacts)
+    else:
+        return ProposedJvmArtifactsForResolve(request.artifacts)
+
+
+def rules():
+    return (
+        *collect_rules(),
+        UnionRule(
+            EditProposedJvmArtifactsForResolveRequest, ProposeScalaArtifactsForResolveRequest
+        ),
+    )

--- a/src/python/pants/backend/scala/resolve/lockfile.py
+++ b/src/python/pants/backend/scala/resolve/lockfile.py
@@ -37,13 +37,6 @@ async def propose_scala_artifacts_for_resolve(
         return AugmentedJvmArtifactsForResolve(None)
 
     scala_version = scala_subsystem.version_for_resolve(request.resolve_name)
-    # TODO: Uncomment this once `--scala-version` goes away in v2.11.x.
-    # if scala_version is None:
-    #     raise ValueError(
-    #         f"Resolve `{request.resolve_name}` is used by at least one Scala target, but no Scala version "
-    #         "for the resolve was set in the `[scala].version_for_resolve` option. Please set the "
-    #         "Scala version to use in the `[scala].version_for_resolve` option."
-    #     )
 
     has_scala_library_artifact = False
     for artifact in request.artifacts:

--- a/src/python/pants/backend/scala/resolve/lockfile_test.py
+++ b/src/python/pants/backend/scala/resolve/lockfile_test.py
@@ -1,0 +1,90 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import pytest
+
+from pants.backend.scala.dependency_inference import rules as scala_dep_inf_rules
+from pants.backend.scala.resolve.lockfile import rules as scala_lockfile_rules
+from pants.core.goals.generate_lockfiles import GenerateLockfileResult
+from pants.core.util_rules import archive, source_files
+from pants.core.util_rules.external_tool import rules as external_tool_rules
+from pants.engine.fs import DigestContents, FileDigest
+from pants.engine.internals import graph
+from pants.jvm import jdk_rules
+from pants.jvm.goals import lockfile
+from pants.jvm.goals.lockfile import RequestedJVMserResolveNames
+from pants.jvm.resolve.common import ArtifactRequirements, Coordinate, Coordinates
+from pants.jvm.resolve.coursier_fetch import CoursierLockfileEntry, CoursierResolvedLockfile
+from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
+from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
+from pants.jvm.resolve.jvm_tool import rules as coursier_jvm_tool_rules
+from pants.jvm.resolve.lockfile_metadata import JVMLockfileMetadata
+from pants.jvm.target_types import JvmArtifactTarget
+from pants.jvm.testutil import maybe_skip_jdk_test
+from pants.jvm.util_rules import rules as util_rules
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = RuleRunner(
+        rules=[
+            *scala_lockfile_rules(),
+            *scala_dep_inf_rules.rules(),
+            *jdk_rules.rules(),
+            *coursier_fetch_rules(),
+            *coursier_jvm_tool_rules(),
+            *lockfile.rules(),
+            *coursier_setup_rules(),
+            *external_tool_rules(),
+            *source_files.rules(),
+            *util_rules(),
+            *archive.rules(),
+            *graph.rules(),
+            # QueryRule(UserGenerateLockfiles, [RequestedJVMserResolveNames]),
+            QueryRule(GenerateLockfileResult, [RequestedJVMserResolveNames]),
+        ],
+        target_types=[JvmArtifactTarget],
+    )
+    rule_runner.set_options(['--scala-version-for-resolve={"foo":"2.13.8"}'], env_inherit={"PATH"})
+    return rule_runner
+
+
+@maybe_skip_jdk_test
+def test_scala_library_added_to_resolve(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "foo/BUILD": "scala_sources(resolve='foo')",
+            "foo/Foo.scala": "package foo",
+        }
+    )
+    artifacts = ArtifactRequirements()
+    result = rule_runner.request(
+        GenerateLockfileResult,
+        [RequestedJVMserResolveNames(["foo"])],
+    )
+    digest_contents = rule_runner.request(DigestContents, [result.digest])
+    assert len(digest_contents) == 1
+
+    expected = CoursierResolvedLockfile(
+        entries=(
+            CoursierLockfileEntry(
+                coord=Coordinate(
+                    group="org.scala-lang",
+                    artifact="scala-library",
+                    version="2.13.8",
+                ),
+                file_name="",
+                direct_dependencies=Coordinates([]),
+                dependencies=Coordinates([]),
+                file_digest=FileDigest(
+                    fingerprint="66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9",
+                    serialized_bytes_length=45024,
+                ),
+            ),
+        ),
+        metadata=JVMLockfileMetadata.new(artifacts),
+    )
+    assert CoursierResolvedLockfile.from_serialized(digest_contents[0].content) == expected

--- a/src/python/pants/backend/scala/resolve/lockfile_test.py
+++ b/src/python/pants/backend/scala/resolve/lockfile_test.py
@@ -5,17 +5,24 @@ from __future__ import annotations
 
 import pytest
 
+from pants.backend.scala import target_types
 from pants.backend.scala.dependency_inference import rules as scala_dep_inf_rules
 from pants.backend.scala.resolve.lockfile import rules as scala_lockfile_rules
-from pants.core.goals.generate_lockfiles import GenerateLockfileResult
+from pants.backend.scala.target_types import ScalaSourcesGeneratorTarget, ScalaSourceTarget
+from pants.core.goals.generate_lockfiles import GenerateLockfileResult, UserGenerateLockfiles
 from pants.core.util_rules import archive, source_files
 from pants.core.util_rules.external_tool import rules as external_tool_rules
 from pants.engine.fs import DigestContents, FileDigest
-from pants.engine.internals import graph
+from pants.engine.internals import build_files, graph
 from pants.jvm import jdk_rules
 from pants.jvm.goals import lockfile
-from pants.jvm.goals.lockfile import RequestedJVMserResolveNames
-from pants.jvm.resolve.common import ArtifactRequirements, Coordinate, Coordinates
+from pants.jvm.goals.lockfile import GenerateJvmLockfile, RequestedJVMserResolveNames
+from pants.jvm.resolve.common import (
+    ArtifactRequirement,
+    ArtifactRequirements,
+    Coordinate,
+    Coordinates,
+)
 from pants.jvm.resolve.coursier_fetch import CoursierLockfileEntry, CoursierResolvedLockfile
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
@@ -43,12 +50,20 @@ def rule_runner() -> RuleRunner:
             *util_rules(),
             *archive.rules(),
             *graph.rules(),
-            # QueryRule(UserGenerateLockfiles, [RequestedJVMserResolveNames]),
-            QueryRule(GenerateLockfileResult, [RequestedJVMserResolveNames]),
+            *build_files.rules(),
+            *target_types.rules(),
+            QueryRule(UserGenerateLockfiles, (RequestedJVMserResolveNames,)),
+            QueryRule(GenerateLockfileResult, (GenerateJvmLockfile,)),
         ],
-        target_types=[JvmArtifactTarget],
+        target_types=[JvmArtifactTarget, ScalaSourceTarget, ScalaSourcesGeneratorTarget],
     )
-    rule_runner.set_options(['--scala-version-for-resolve={"foo":"2.13.8"}'], env_inherit={"PATH"})
+    rule_runner.set_options(
+        [
+            '--scala-version-for-resolve={"foo":"2.13.8"}',
+            '--jvm-resolves={"foo": "foo/foo.lock"}',
+        ],
+        env_inherit={"PATH"},
+    )
     return rule_runner
 
 
@@ -56,16 +71,22 @@ def rule_runner() -> RuleRunner:
 def test_scala_library_added_to_resolve(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "foo/BUILD": "scala_sources(resolve='foo')",
+            "foo/BUILD": "scala_sources(compatible_resolves=['foo'])",
             "foo/Foo.scala": "package foo",
         }
     )
-    artifacts = ArtifactRequirements()
+
     result = rule_runner.request(
-        GenerateLockfileResult,
+        UserGenerateLockfiles,
         [RequestedJVMserResolveNames(["foo"])],
     )
-    digest_contents = rule_runner.request(DigestContents, [result.digest])
+    assert len(result) == 1
+    user_gen_lockfile = result[0]
+    assert isinstance(user_gen_lockfile, GenerateJvmLockfile)
+
+    lockfile_result = rule_runner.request(GenerateLockfileResult, [user_gen_lockfile])
+
+    digest_contents = rule_runner.request(DigestContents, [lockfile_result.digest])
     assert len(digest_contents) == 1
 
     expected = CoursierResolvedLockfile(
@@ -76,15 +97,27 @@ def test_scala_library_added_to_resolve(rule_runner: RuleRunner) -> None:
                     artifact="scala-library",
                     version="2.13.8",
                 ),
-                file_name="",
+                file_name="org.scala-lang_scala-library_2.13.8.jar",
                 direct_dependencies=Coordinates([]),
                 dependencies=Coordinates([]),
                 file_digest=FileDigest(
-                    fingerprint="66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9",
-                    serialized_bytes_length=45024,
+                    fingerprint="a0882b82514190c2bac7d1a459872a75f005fc0f3e88b2bc0390367146e35db7",
+                    serialized_bytes_length=6003601,
                 ),
             ),
         ),
-        metadata=JVMLockfileMetadata.new(artifacts),
+        metadata=JVMLockfileMetadata.new(
+            ArtifactRequirements(
+                [
+                    ArtifactRequirement(
+                        coordinate=Coordinate(
+                            group="org.scala-lang",
+                            artifact="scala-library",
+                            version="2.13.8",
+                        )
+                    ),
+                ]
+            )
+        ),
     )
     assert CoursierResolvedLockfile.from_serialized(digest_contents[0].content) == expected


### PR DESCRIPTION
Add `AugmentJvmArtifactsForResolveRequest` union for backends to add artifact requirements to a JVM resolve. Teach the Scala backend to add the `scala-library` runtime library to any resolve consumed by Scala targets.

[ci skip-rust]

[ci skip-build-wheels]