### PR TITLE
`--changed-since` works on target-less goals like `count-loc`

### DIFF
--- a/src/python/pants/backend/project_info/count_loc.py
+++ b/src/python/pants/backend/project_info/count_loc.py
@@ -1,6 +1,6 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
+import logging
 
 from pants.core.util_rules.external_tool import (
     DownloadedExternalTool,
@@ -68,6 +68,9 @@ async def count_loc(
     if not specs_snapshot.snapshot.files:
         return CountLinesOfCode(exit_code=0)
 
+    logging.error("HERE")
+    logging.error(specs_snapshot.snapshot.files)
+    logging.error("DONE")
     scc_program = await Get(
         DownloadedExternalTool,
         ExternalToolRequest,

--- a/src/python/pants/backend/project_info/count_loc.py
+++ b/src/python/pants/backend/project_info/count_loc.py
@@ -1,6 +1,5 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-import logging
 
 from pants.core.util_rules.external_tool import (
     DownloadedExternalTool,
@@ -68,9 +67,6 @@ async def count_loc(
     if not specs_snapshot.snapshot.files:
         return CountLinesOfCode(exit_code=0)
 
-    logging.error("HERE")
-    logging.error(specs_snapshot.snapshot.files)
-    logging.error("DONE")
     scc_program = await Get(
         DownloadedExternalTool,
         ExternalToolRequest,

--- a/src/python/pants/backend/project_info/count_loc.py
+++ b/src/python/pants/backend/project_info/count_loc.py
@@ -1,5 +1,6 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+import logging
 
 from pants.core.util_rules.external_tool import (
     DownloadedExternalTool,
@@ -67,6 +68,9 @@ async def count_loc(
     if not specs_snapshot.snapshot.files:
         return CountLinesOfCode(exit_code=0)
 
+    logging.error("HERE")
+    logging.error(specs_snapshot.snapshot.files)
+    logging.error("DONE")
     scc_program = await Get(
         DownloadedExternalTool,
         ExternalToolRequest,

--- a/src/python/pants/backend/project_info/regex_lint.py
+++ b/src/python/pants/backend/project_info/regex_lint.py
@@ -81,9 +81,8 @@ class RegexLintSubsystem(Subsystem):
         To activate this with the `lint` goal, you must set `[regex-lint].config`.
 
         Unlike other linters, this can run on files not owned by targets, such as BUILD files. To
-        run on those, use `lint '**'` rather than `lint ::`, for example. Unfortunately,
-        `--changed-since=<sha>` does not yet cause this linter to run. We are exploring how to
-        improve both these gotchas.
+        run on those, use `lint '**'` rather than `lint ::`, for example. We are exploring how to
+        improve this gotchas.
         """
     )
 

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -343,6 +343,7 @@ class SpecsWithOnlyFileOwners:
     file_globs: tuple[FileGlobSpec, ...] = ()
 
     filter_by_global_options: bool = False
+    from_change_detection: bool = False
 
     @classmethod
     def from_specs(cls, specs: Specs) -> SpecsWithOnlyFileOwners:
@@ -350,13 +351,16 @@ class SpecsWithOnlyFileOwners:
             specs.file_literals,
             specs.file_globs,
             filter_by_global_options=specs.filter_by_global_options,
+            from_change_detection=specs.from_change_detection,
         )
 
-    @staticmethod
     def _generate_path_globs(
+        self,
         specs: Iterable[FileLiteralSpec | FileGlobSpec],
         glob_match_error_behavior: GlobMatchErrorBehavior,
     ) -> PathGlobs:
+        if self.from_change_detection:
+            glob_match_error_behavior = GlobMatchErrorBehavior.ignore
         return PathGlobs(
             globs=(s.to_glob() for s in specs),
             glob_match_error_behavior=glob_match_error_behavior,

--- a/src/python/pants/engine/internals/specs_rules.py
+++ b/src/python/pants/engine/internals/specs_rules.py
@@ -215,7 +215,8 @@ async def addresses_from_specs_with_only_file_owners(
     addresses: set[Address] = set()
     for spec, owners in zip(specs.all_specs(), owners_per_include):
         if (
-            owners_not_found_behavior != OwnersNotFoundBehavior.ignore
+            not specs.from_change_detection
+            and owners_not_found_behavior != OwnersNotFoundBehavior.ignore
             and isinstance(spec, FileLiteralSpec)
             and not owners
         ):

--- a/src/python/pants/init/specs_calculator.py
+++ b/src/python/pants/init/specs_calculator.py
@@ -4,7 +4,7 @@
 import logging
 from typing import cast
 
-from pants.base.specs import AddressLiteralSpec, Specs
+from pants.base.specs import AddressLiteralSpec, FileLiteralSpec, Specs
 from pants.base.specs_parser import SpecsParser
 from pants.core.util_rules.system_binaries import GitBinary, GitBinaryRequest
 from pants.engine.addresses import AddressInput
@@ -55,10 +55,16 @@ def calculate_specs(
         raise InvalidSpecConstraint(
             "The `--changed-*` options are only available if Git is used for the repository."
         )
-    changed_request = ChangedRequest(
-        sources=tuple(changed_options.changed_files(maybe_git_worktree.git_worktree)),
-        dependees=changed_options.dependees,
-    )
+
+    changed_files = tuple(changed_options.changed_files(maybe_git_worktree.git_worktree))
+
+    # We input all changed files as file arguments, which makes sure that target-less goals like
+    # `count-loc` recognize all files that have changed, not just ones owned by targets.
+    file_literal_specs = tuple(FileLiteralSpec(f) for f in changed_files)
+
+    # We must no matter what also find the target owners to handle deleted targets, along with
+    # `--changed-dependees`.
+    changed_request = ChangedRequest(changed_files, changed_options.dependees)
     (changed_addresses,) = session.product_request(
         ChangedAddresses, [Params(changed_request, options_bootstrapper)]
     )
@@ -75,8 +81,10 @@ def calculate_specs(
                 parameters=address_input.parameters,
             )
         )
+
     return Specs(
         address_literals=tuple(address_literal_specs),
+        file_literals=file_literal_specs,
         filter_by_global_options=True,
         from_change_detection=True,
     )

--- a/src/python/pants/init/specs_calculator.py
+++ b/src/python/pants/init/specs_calculator.py
@@ -57,13 +57,8 @@ def calculate_specs(
         )
 
     changed_files = tuple(changed_options.changed_files(maybe_git_worktree.git_worktree))
-
-    # We input all changed files as file arguments, which makes sure that target-less goals like
-    # `count-loc` recognize all files that have changed, not just ones owned by targets.
     file_literal_specs = tuple(FileLiteralSpec(f) for f in changed_files)
 
-    # We must no matter what also find the target owners to handle deleted targets, along with
-    # `--changed-dependees`.
     changed_request = ChangedRequest(changed_files, changed_options.dependees)
     (changed_addresses,) = session.product_request(
         ChangedAddresses, [Params(changed_request, options_bootstrapper)]
@@ -83,6 +78,8 @@ def calculate_specs(
         )
 
     return Specs(
+        # We need both address_literals and file_literals to cover all our edge cases, including
+        # target-aware vs. target-less goals, e.g. `list` vs `count-loc`.
         address_literals=tuple(address_literal_specs),
         file_literals=file_literal_specs,
         filter_by_global_options=True,

--- a/src/python/pants/testutil/pants_integration_test.py
+++ b/src/python/pants/testutil/pants_integration_test.py
@@ -90,7 +90,12 @@ def run_pants_with_workdir_without_waiting(
     extra_env: Mapping[str, str] | None = None,
     shell: bool = False,
 ) -> PantsJoinHandle:
-    args = ["--no-pantsrc", f"--pants-workdir={workdir}"]
+    args = [
+        "--no-pantsrc",
+        f"--pants-workdir={workdir}",
+        # For some reason, Pants's CI adds this file and it is not ignored by default.
+        "--pants-ignore=+['.coverage.*']",
+    ]
 
     pantsd_in_command = "--no-pantsd" in command or "--pantsd" in command
     pantsd_in_config = config and "GLOBAL" in config and "pantsd" in config["GLOBAL"]
@@ -101,7 +106,7 @@ def run_pants_with_workdir_without_waiting(
         args.append("--pants-config-files=[]")
         # Certain tests may be invoking `./pants test` for a pytest test with conftest discovery
         # enabled. We should ignore the root conftest.py for these cases.
-        args.append("--pants-ignore=/conftest.py")
+        args.append("--pants-ignore=+['/conftest.py']")
 
     if config:
         toml_file_name = os.path.join(workdir, "pants.toml")

--- a/src/python/pants/vcs/BUILD
+++ b/src/python/pants/vcs/BUILD
@@ -6,7 +6,7 @@ python_sources()
 python_tests(
     name="tests",
     overrides={
-        "changed_integration_test.py": {"timeout": 500},
+        "changed_integration_test.py": {"timeout": 350},
         "git_test.py": {"timeout": 120},
     },
 )

--- a/src/python/pants/vcs/changed_integration_test.py
+++ b/src/python/pants/vcs/changed_integration_test.py
@@ -37,6 +37,7 @@ def repo() -> Iterator[str]:
                 {worktree}
                 .pids
                 __pycache__
+                .coverage*  # For some reason, our CI adds this file.
                 """
             ),
             "pants.toml": dedent(
@@ -128,8 +129,6 @@ def assert_count_loc(
         hermetic=False,
     )
     result.assert_success()
-    print(result.stdout)
-    print(result.stderr)
     if expected_num_files:
         assert f"Total                        {expected_num_files}" in result.stdout
     else:

--- a/src/python/pants/vcs/changed_integration_test.py
+++ b/src/python/pants/vcs/changed_integration_test.py
@@ -36,6 +36,7 @@ def repo() -> Iterator[str]:
                 f"""\
                 {worktree}
                 .pids
+                __pycache__
                 """
             ),
             "pants.toml": dedent(

--- a/src/python/pants/vcs/changed_integration_test.py
+++ b/src/python/pants/vcs/changed_integration_test.py
@@ -123,18 +123,12 @@ def assert_count_loc(
     workdir: str, *, expected_num_files: int, extra_args: list[str] | None = None
 ) -> None:
     result = run_pants_with_workdir(
-        [
-            *(extra_args or ()),
-            "--changed-since=HEAD",
-            "count-loc"
-        ],
+        [*(extra_args or ()), "--changed-since=HEAD", "count-loc"],
         workdir=workdir,
         # We must set `hermetic=False` for some reason.
         hermetic=False,
     )
     result.assert_success()
-    print(result.stdout)
-    print(result.stderr)
     if expected_num_files:
         assert f"Total                        {expected_num_files}" in result.stdout
     else:

--- a/src/python/pants/vcs/changed_integration_test.py
+++ b/src/python/pants/vcs/changed_integration_test.py
@@ -117,6 +117,22 @@ def assert_list_stdout(
     assert sorted(result.stdout.strip().splitlines()) == sorted(expected)
 
 
+def assert_count_loc(
+    workdir: str, *, expected_num_files: int, extra_args: list[str] | None = None
+) -> None:
+    result = run_pants_with_workdir(
+        [*(extra_args or ()), "--changed-since=HEAD", "count-loc"],
+        workdir=workdir,
+        # We must set `hermetic=False` for some reason.
+        hermetic=False,
+    )
+    result.assert_success()
+    if expected_num_files:
+        assert f"Total                        {expected_num_files}" in result.stdout
+    else:
+        assert not result.stdout
+
+
 def test_no_changes(repo: str) -> None:
     assert_list_stdout(repo, [])
 
@@ -145,23 +161,12 @@ def test_unowned_file(repo: str) -> None:
 
     If a file was removed, the target-less goals should simply ignore it.
     """
-
-    def run_count_loc() -> str:
-        result = run_pants_with_workdir(
-            ["--changed-since=HEAD", "count-loc"],
-            workdir=repo,
-            # For some reason, we must set `hermetic=False` for Git to be detected.
-            hermetic=False,
-        )
-        result.assert_success()
-        return result.stdout
-
     create_file("dir/some_file.sh", "# blah")
-    assert "Shell" in run_count_loc()
+    assert_count_loc(repo, expected_num_files=1)
     assert_list_stdout(repo, [])
 
     delete_file("dir/some_file.sh")
-    assert "Shell" not in run_count_loc()
+    assert_count_loc(repo, expected_num_files=0)
 
 
 def test_delete_generated_target(repo: str) -> None:
@@ -220,6 +225,11 @@ def test_tag_filtering(repo: str) -> None:
     assert_list_stdout(
         repo, ["//dep.sh:lib"], dependees=DependeesOption.TRANSITIVE, extra_args=["--tag=+b"]
     )
+
+    # Target-less goals should still respect the tag, per
+    # https://github.com/pantsbuild/pants/pull/15479.
+    assert_count_loc(repo, expected_num_files=2)
+    assert_count_loc(repo, expected_num_files=1, extra_args=["--tag=-b"])
 
     # Regression test for https://github.com/pantsbuild/pants/issues/14977: make sure a generated
     # target w/ different tags via `overrides` is excluded no matter what.

--- a/src/python/pants/vcs/changed_integration_test.py
+++ b/src/python/pants/vcs/changed_integration_test.py
@@ -126,8 +126,7 @@ def assert_count_loc(
         [
             *(extra_args or ()),
             "--changed-since=HEAD",
-            "count-loc",
-            "--pants-ignore=+['.coverage.*']",
+            "count-loc"
         ],
         workdir=workdir,
         # We must set `hermetic=False` for some reason.

--- a/src/python/pants/vcs/changed_integration_test.py
+++ b/src/python/pants/vcs/changed_integration_test.py
@@ -129,6 +129,8 @@ def assert_count_loc(
         hermetic=False,
     )
     result.assert_success()
+    print(result.stdout)
+    print(result.stderr)
     if expected_num_files:
         assert f"Total                        {expected_num_files}" in result.stdout
     else:

--- a/src/python/pants/vcs/changed_integration_test.py
+++ b/src/python/pants/vcs/changed_integration_test.py
@@ -27,6 +27,14 @@ def repo() -> Iterator[str]:
     with temporary_dir(root_dir=get_buildroot()) as worktree, environment_as(
         GIT_CONFIG_GLOBAL="/dev/null"
     ):
+        # FIXME: Our CI is adding files like `.coverage.fv-az167-838.29971.396383`, which for some
+        #  reason Pants is including in the `SpecsSnapshot` when running `count-loc`, even when
+        #  adding `.coverage*` to `.gitignore. It causes tests to fail because `count-loc` thinks
+        #  there are files to run on. This has only happened in CI.
+        coverage_files = list(Path().glob("coverage.*"))
+        for f in coverage_files:
+            f.unlink()
+
         _run_git(["init"])
         _run_git(["config", "user.email", "you@example.com"])
         _run_git(["config", "user.name", "Your Name"])

--- a/src/python/pants/vcs/changed_integration_test.py
+++ b/src/python/pants/vcs/changed_integration_test.py
@@ -128,6 +128,8 @@ def assert_count_loc(
         hermetic=False,
     )
     result.assert_success()
+    print(result.stdout)
+    print(result.stderr)
     if expected_num_files:
         assert f"Total                        {expected_num_files}" in result.stdout
     else:

--- a/tests/python/pants_test/pantsd/pantsd_integration_test.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test.py
@@ -72,7 +72,12 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
     def test_pantsd_broken_pipe(self):
         with self.pantsd_test_context() as (workdir, pantsd_config, checker):
             run = self.run_pants_with_workdir(
-                "help | head -1", workdir=workdir, config=pantsd_config, shell=True
+                "help | head -1",
+                workdir=workdir,
+                config=pantsd_config,
+                shell=True,
+                # FIXME: Why is this necessary to set?
+                set_pants_ignore=False,
             )
             self.assertNotIn("broken pipe", run.stderr.lower())
             checker.assert_started()


### PR DESCRIPTION
Now `./pants --changed-since=HEAD count-loc` will report _all_ changed files.

Target-aware goals like `list` will simply ignore files with no owners, as before.

[ci skip-rust]
[ci skip-build-wheels]