### PR TITLE
Improve `export` goal to handle multiple Python resolves

### DIFF
--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -3,50 +3,67 @@
 
 from __future__ import annotations
 
+import logging
 import os
+from collections import defaultdict
 from dataclasses import dataclass
+from typing import DefaultDict
 
 from pants.backend.python.subsystems.setup import PythonSetup
+from pants.backend.python.target_types import PythonResolveField
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import VenvPex, VenvPexProcess
 from pants.backend.python.util_rules.pex_environment import PexEnvironment
 from pants.backend.python.util_rules.pex_from_targets import RequirementsPexRequest
 from pants.core.goals.export import ExportError, ExportRequest, ExportResult, ExportResults, Symlink
-from pants.engine.internals.selectors import Get
+from pants.core.util_rules.distdir import DistDir
+from pants.engine.engine_aware import EngineAwareParameter
+from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.process import ProcessResult
 from pants.engine.rules import collect_rules, rule
+from pants.engine.target import Target
 from pants.engine.unions import UnionRule
+from pants.util.docutil import bin_name
+from pants.util.strutil import path_safe
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class ExportVenvRequest(ExportRequest):
+class ExportVenvsRequest(ExportRequest):
     pass
 
 
+@dataclass(frozen=True)
+class _ExportVenvRequest(EngineAwareParameter):
+    resolve: str
+    root_python_targets: tuple[Target, ...]
+
+    def debug_hint(self) -> str:
+        return self.resolve
+
+
 @rule
-async def export_venv(
-    request: ExportVenvRequest, python_setup: PythonSetup, pex_env: PexEnvironment
-) -> ExportResults:
-    # Pick a single interpreter for the venv.
-    interpreter_constraints = InterpreterConstraints.create_from_targets(
-        request.targets, python_setup
+async def export_virtualenv(
+    request: _ExportVenvRequest, python_setup: PythonSetup, pex_env: PexEnvironment
+) -> ExportResult:
+    interpreter_constraints = InterpreterConstraints(
+        python_setup.resolves_to_interpreter_constraints.get(
+            request.resolve, python_setup.interpreter_constraints
+        )
     )
-    if not interpreter_constraints:
-        # If there were no targets that defined any constraints, fall back to the global ones.
-        interpreter_constraints = InterpreterConstraints(python_setup.interpreter_constraints)
     min_interpreter = interpreter_constraints.snap_to_minimum(python_setup.interpreter_universe)
     if not min_interpreter:
         raise ExportError(
-            "The following interpreter constraints were computed for all the targets for which "
-            f"export was requested: {interpreter_constraints}. There is no python interpreter "
-            "compatible with these constraints. Please restrict the target set to one that shares "
-            "a compatible interpreter."
+            f"The resolve '{request.resolve}' (from `[python].resolves`) has invalid interpreter "
+            f"constraints, which are set via `[python].resolves_to_interpreter_constraints`: "
+            f"{interpreter_constraints}. Could not determine the minimum compatible interpreter."
         )
 
     venv_pex = await Get(
         VenvPex,
         RequirementsPexRequest(
-            (tgt.address for tgt in request.targets),
+            (tgt.address for tgt in request.root_python_targets),
             internal_only=True,
             hardcoded_interpreter_constraints=min_interpreter,
         ),
@@ -68,16 +85,48 @@ async def export_venv(
     )
     py_version = res.stdout.strip().decode()
 
-    result = ExportResult(
-        f"virtualenv for {min_interpreter}",
-        os.path.join("python", "virtualenv"),
+    return ExportResult(
+        f"virtualenv for the resolve '{request.resolve}' (using {min_interpreter})",
+        os.path.join("python", "virtualenvs", path_safe(request.resolve)),
         symlinks=[Symlink(venv_abspath, py_version)],
     )
-    return ExportResults((result,))
+
+
+@rule
+async def export_virtualenvs(
+    request: ExportVenvsRequest, python_setup: PythonSetup, dist_dir: DistDir
+) -> ExportResults:
+    resolve_to_root_targets: DefaultDict[str, list[Target]] = defaultdict(list)
+    for tgt in request.targets:
+        if not tgt.has_field(PythonResolveField):
+            continue
+        resolve = tgt[PythonResolveField].normalized_value(python_setup)
+        resolve_to_root_targets[resolve].append(tgt)
+
+    venvs = await MultiGet(
+        Get(
+            ExportResult,
+            _ExportVenvRequest(
+                resolve if resolve != "<ignore>" else python_setup.default_resolve, tuple(tgts)
+            ),
+        )
+        for resolve, tgts in resolve_to_root_targets.items()
+    )
+
+    deprecated_path = dist_dir.relpath / "python" / "virtualenv"
+    if venvs and deprecated_path.exists():
+        logger.warning(
+            f"`{bin_name()} export ::` no longer writes virtualenvs to {deprecated_path}, but "
+            f"instead underneath {dist_dir.relpath / 'python' / 'virtualenvs'}. You will need to "
+            "update your IDE to point to the new virtualenv.\n\n"
+            f"To silence this error, delete {deprecated_path}"
+        )
+
+    return ExportResults(venvs)
 
 
 def rules():
     return [
         *collect_rules(),
-        UnionRule(ExportRequest, ExportVenvRequest),
+        UnionRule(ExportRequest, ExportVenvsRequest),
     ]

--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -39,7 +39,7 @@ class _ExportVenvRequest(EngineAwareParameter):
     resolve: str | None
     root_python_targets: tuple[Target, ...]
 
-    def debug_hint(self) -> str:
+    def debug_hint(self) -> str | None:
         return self.resolve
 
 

--- a/src/python/pants/core/goals/export.py
+++ b/src/python/pants/core/goals/export.py
@@ -93,7 +93,6 @@ class Export(Goal):
 async def export(
     console: Console,
     targets: Targets,
-    export_subsystem: ExportSubsystem,
     workspace: Workspace,
     union_membership: UnionMembership,
     build_root: BuildRoot,

--- a/src/python/pants/core/goals/export_test.py
+++ b/src/python/pants/core/goals/export_test.py
@@ -13,7 +13,6 @@ from pants.core.goals.export import (
     ExportRequest,
     ExportResult,
     ExportResults,
-    ExportSubsystem,
     Symlink,
     export,
 )

--- a/src/python/pants/core/goals/export_test.py
+++ b/src/python/pants/core/goals/export_test.py
@@ -23,7 +23,7 @@ from pants.engine.fs import AddPrefix, CreateDigest, Digest, FileContent, MergeD
 from pants.engine.rules import QueryRule
 from pants.engine.target import Target, Targets
 from pants.engine.unions import UnionMembership, UnionRule
-from pants.testutil.option_util import create_goal_subsystem, create_options_bootstrapper
+from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import MockGet, RuleRunner, mock_console, run_rule_with_mocks
 
 
@@ -60,7 +60,6 @@ def run_export_rule(rule_runner: RuleRunner, targets: List[Target]) -> Tuple[int
             rule_args=[
                 console,
                 Targets(targets),
-                create_goal_subsystem(ExportSubsystem),
                 Workspace(rule_runner.scheduler, _enforce_effects=False),
                 union_membership,
                 BuildRoot(),


### PR DESCRIPTION
We generate a distinct virtualenv for each resolve, using the path `dist/python/virtualenvs/<resolve>`. From there, the user can load in their IDE which one to use.

If users want to only generate for one IDE, they can use the `peek` snippet from https://github.com/pantsbuild/pants/pull/14327.

--

If `enable_resolves = false`, we stick with the old behavior. This is convenient because it would be a misnomer to write the path to `[python].default_resolve`, which doesn't make sense to use if resolves aren't enabled.

We log a warning when you do migrate to `enable-resolves` that the old path will no longer be valid.