### PR TITLE
Make sure `[python].enable_resolves = false` disables checking for valid resolves (Cherry-pick of #14418)

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -316,12 +316,9 @@ async def map_module_to_address(
     request: PythonModuleOwnersRequest,
     first_party_mapping: FirstPartyPythonModuleMapping,
     third_party_mapping: ThirdPartyPythonModuleMapping,
-    python_setup: PythonSetup,
 ) -> PythonModuleOwners:
     providers = [
-        *third_party_mapping.providers_for_module(
-            request.module, resolve=request.resolve if python_setup.enable_resolves else None
-        ),
+        *third_party_mapping.providers_for_module(request.module, resolve=request.resolve),
         *first_party_mapping.providers_for_module(request.module),
     ]
     addresses = tuple(provider.addr for provider in providers)

--- a/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
@@ -330,7 +330,9 @@ def test_map_third_party_modules_to_addresses(rule_runner: RuleRunner) -> None:
         ]
     )
     rule_runner.write_files({"BUILD": build_file})
-    rule_runner.set_options(["--python-resolves={'default': '', 'another': ''}"])
+    rule_runner.set_options(
+        ["--python-resolves={'default': '', 'another': ''}", "--python-enable-resolves"]
+    )
     result = rule_runner.request(ThirdPartyPythonModuleMapping, [])
     assert result == ThirdPartyPythonModuleMapping(
         {
@@ -428,7 +430,7 @@ def test_map_module_to_address(rule_runner: RuleRunner) -> None:
         assert list(from_import_owners.unambiguous) == expected
         assert list(from_import_owners.ambiguous) == (expected_ambiguous or [])
 
-    rule_runner.set_options(["--source-root-patterns=['root', '/']"])
+    rule_runner.set_options(["--source-root-patterns=['root', '/']", "--python-enable-resolves"])
     rule_runner.write_files(
         {
             # A root-level module.

--- a/src/python/pants/backend/python/goals/repl_integration_test.py
+++ b/src/python/pants/backend/python/goals/repl_integration_test.py
@@ -114,5 +114,7 @@ def test_eagerly_validate_roots_have_common_resolve(rule_runner: RuleRunner) -> 
     )
     with engine_error(NoCompatibleResolveException, contains="./pants peek"):
         run_repl(
-            rule_runner, ["//:t1", "//:t2"], global_args=["--python-resolves={'a': '', 'b': ''}"]
+            rule_runner,
+            ["//:t1", "//:t2"],
+            global_args=["--python-resolves={'a': '', 'b': ''}", "--python-enable-resolves"],
         )

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -115,6 +115,8 @@ class PythonResolveField(StringField, AsyncFieldMixin):
 
     def normalized_value(self, python_setup: PythonSetup) -> str:
         """Get the value after applying the default and validating that the key is recognized."""
+        if not python_setup.enable_resolves:
+            return "<ignore>"
         resolve = self.value or python_setup.default_resolve
         if resolve not in python_setup.resolves:
             raise UnrecognizedResolveNamesError(

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -60,7 +60,7 @@ def rule_runner() -> RuleRunner:
 
 
 def test_no_compatible_resolve_error() -> None:
-    python_setup = create_subsystem(PythonSetup, resolves={"a": "", "b": ""})
+    python_setup = create_subsystem(PythonSetup, resolves={"a": "", "b": ""}, enable_resolves=True)
     targets = [
         PythonRequirementTarget(
             {PythonRequirementsField.alias: [], PythonResolveField.alias: "a"},
@@ -108,7 +108,7 @@ def test_choose_compatible_resolve(rule_runner: RuleRunner) -> None:
             """
         )
 
-    rule_runner.set_options(["--python-resolves={'a': '', 'b': ''}"])
+    rule_runner.set_options(["--python-resolves={'a': '', 'b': ''}", "--python-enable-resolves"])
     rule_runner.write_files(
         {
             # Note that each of these BUILD files are entirely self-contained.


### PR DESCRIPTION
There's an edge case where you have multiple `--resolves` defined, but you want to turn off the feature overall. In that case, we should not try partitioning or eagerly validating for resolves.

We work around that by having every target claim that its resolve is `<ignore>`, which means that every target will be using the exact same resolve.

[ci skip-rust]
[ci skip-build-wheels]