### PR TITLE
Replace `compatible_resolves` with `resolve` for JVM targets

### DIFF
--- a/3rdparty/jvm/com/fasterxml/jackson/core/BUILD
+++ b/3rdparty/jvm/com/fasterxml/jackson/core/BUILD
@@ -8,5 +8,5 @@ jvm_artifact(
     # NB: Keep in sync with all other `3rdparty/jvm/com/fasterxml/jackson` libraries.
     # See https://github.com/pantsbuild/pants/issues/13767 for how this might be deduped.
     version="2.12.4",
-    compatible_resolves=["java_parser"],
+    resolve="java_parser",
 )

--- a/3rdparty/jvm/com/fasterxml/jackson/datatype/BUILD
+++ b/3rdparty/jvm/com/fasterxml/jackson/datatype/BUILD
@@ -8,5 +8,5 @@ jvm_artifact(
     # NB: Keep in sync with all other `3rdparty/jvm/com/fasterxml/jackson` libraries.
     # See https://github.com/pantsbuild/pants/issues/13767 for how this might be deduped.
     version="2.12.4",
-    compatible_resolves=["java_parser"],
+    resolve="java_parser",
 )

--- a/3rdparty/jvm/com/github/javaparser/BUILD
+++ b/3rdparty/jvm/com/github/javaparser/BUILD
@@ -6,5 +6,5 @@ jvm_artifact(
     group="com.github.javaparser",
     artifact="javaparser-symbol-solver-core",
     version="3.23.0",
-    compatible_resolves=["java_parser"],
+    resolve="java_parser",
 )

--- a/3rdparty/jvm/io/circe/BUILD
+++ b/3rdparty/jvm/io/circe/BUILD
@@ -6,5 +6,5 @@ jvm_artifact(
     group="io.circe",
     artifact="circe-generic_2.13",
     version="0.14.1",
-    compatible_resolves=["scala_parser"],
+    resolve="scala_parser",
 )

--- a/3rdparty/jvm/org/scalameta/BUILD
+++ b/3rdparty/jvm/org/scalameta/BUILD
@@ -7,5 +7,5 @@ jvm_artifact(
     artifact="scalameta_2.13",
     version="4.4.30",
     packages=["scala.meta.**"],
-    compatible_resolves=["scala_parser"],
+    resolve="scala_parser",
 )

--- a/src/python/pants/backend/java/dependency_inference/BUILD
+++ b/src/python/pants/backend/java/dependency_inference/BUILD
@@ -8,5 +8,5 @@ python_tests(name="tests", timeout=240)
 # Targets for developing on the Java parser outside of engine rules.
 java_sources(
     name="java_parser",
-    compatible_resolves=["java_parser"],
+    resolve="java_parser",
 )

--- a/src/python/pants/backend/java/dependency_inference/rules.py
+++ b/src/python/pants/backend/java/dependency_inference/rules.py
@@ -122,6 +122,11 @@ async def infer_java_dependencies_and_exports_via_source_analysis(
 
     dep_map = first_party_dep_map.symbols
     resolve = jvm.resolve_for_target(tgt)
+    if not resolve:
+        raise ValueError(
+            "Cannot infer Java dependencies for a target without a `resolve` field: "
+            "`{address}` (with type `{tgt.alias}`)."
+        )
 
     dependencies: OrderedSet[Address] = OrderedSet()
     exports: OrderedSet[Address] = OrderedSet()

--- a/src/python/pants/backend/java/dependency_inference/rules.py
+++ b/src/python/pants/backend/java/dependency_inference/rules.py
@@ -121,7 +121,7 @@ async def infer_java_dependencies_and_exports_via_source_analysis(
     export_types.update(typ for typ in analysis.export_types if "." in typ)
 
     dep_map = first_party_dep_map.symbols
-    resolves = jvm.resolves_for_target(tgt)
+    resolve = jvm.resolve_for_target(tgt)
 
     dependencies: OrderedSet[Address] = OrderedSet()
     exports: OrderedSet[Address] = OrderedSet()
@@ -129,7 +129,7 @@ async def infer_java_dependencies_and_exports_via_source_analysis(
     for typ in types:
         first_party_matches = dep_map.addresses_for_symbol(typ)
         third_party_matches = (
-            third_party_artifact_mapping.addresses_for_symbol(typ, resolves)
+            third_party_artifact_mapping.addresses_for_symbol(typ, [resolve])
             if java_infer_subsystem.third_party_imports
             else FrozenOrderedSet()
         )

--- a/src/python/pants/backend/java/target_types.py
+++ b/src/python/pants/backend/java/target_types.py
@@ -15,12 +15,7 @@ from pants.engine.target import (
     Target,
     TargetFilesGenerator,
 )
-from pants.jvm.target_types import (
-    JunitTestSourceField,
-    JvmCompatibleResolvesField,
-    JvmProvidesTypesField,
-    JvmResolveField,
-)
+from pants.jvm.target_types import JunitTestSourceField, JvmProvidesTypesField, JvmResolveField
 
 
 class JavaSourceField(SingleSourceField):
@@ -100,7 +95,7 @@ class JavaSourceTarget(Target):
         *COMMON_TARGET_FIELDS,
         Dependencies,
         JavaSourceField,
-        JvmCompatibleResolvesField,
+        JvmResolveField,
         JvmProvidesTypesField,
     )
     help = "A single Java source file containing application or library code."
@@ -116,13 +111,13 @@ class JavaSourcesGeneratorTarget(TargetFilesGenerator):
         *COMMON_TARGET_FIELDS,
         Dependencies,
         JavaSourcesGeneratorSourcesField,
-        JvmCompatibleResolvesField,
+        JvmResolveField,
     )
     generated_target_cls = JavaSourceTarget
     copied_fields = (
         *COMMON_TARGET_FIELDS,
         Dependencies,
-        JvmCompatibleResolvesField,
+        JvmResolveField,
     )
     moved_fields = (JvmProvidesTypesField,)
     help = "Generate a `java_source` target for each file in the `sources` field."

--- a/src/python/pants/backend/java/target_types.py
+++ b/src/python/pants/backend/java/target_types.py
@@ -111,15 +111,16 @@ class JavaSourcesGeneratorTarget(TargetFilesGenerator):
         *COMMON_TARGET_FIELDS,
         Dependencies,
         JavaSourcesGeneratorSourcesField,
-        JvmResolveField,
     )
     generated_target_cls = JavaSourceTarget
     copied_fields = (
         *COMMON_TARGET_FIELDS,
         Dependencies,
-        JvmResolveField,
     )
-    moved_fields = (JvmProvidesTypesField,)
+    moved_fields = (
+        JvmResolveField,
+        JvmProvidesTypesField,
+    )
     help = "Generate a `java_source` target for each file in the `sources` field."
 
 

--- a/src/python/pants/backend/scala/dependency_inference/BUILD
+++ b/src/python/pants/backend/scala/dependency_inference/BUILD
@@ -9,7 +9,7 @@ python_tests(name="tests", timeout=240)
 # Targets for developing on the Scala parser outside of engine rules.
 scala_sources(
     name="scala_parser",
-    compatible_resolves=["scala_parser"],
+    resolve="scala_parser",
     # TODO: Allow the parser files to be formatted.
     skip_scalafmt=True,
 )

--- a/src/python/pants/backend/scala/dependency_inference/rules.py
+++ b/src/python/pants/backend/scala/dependency_inference/rules.py
@@ -48,7 +48,7 @@ async def infer_scala_dependencies_via_source_analysis(
         Get(ScalaSourceDependencyAnalysis, SourceFilesRequest([request.sources_field])),
     )
 
-    resolves = jvm.resolves_for_target(tgt)
+    resolve = jvm.resolve_for_target(tgt)
 
     symbols: OrderedSet[str] = OrderedSet()
     if scala_infer_subsystem.imports:
@@ -59,7 +59,7 @@ async def infer_scala_dependencies_via_source_analysis(
     dependencies: OrderedSet[Address] = OrderedSet()
     for symbol in symbols:
         first_party_matches = first_party_symbol_map.symbols.addresses_for_symbol(symbol)
-        third_party_matches = third_party_artifact_mapping.addresses_for_symbol(symbol, resolves)
+        third_party_matches = third_party_artifact_mapping.addresses_for_symbol(symbol, [resolve])
         matches = first_party_matches.union(third_party_matches)
         if not matches:
             continue

--- a/src/python/pants/backend/scala/dependency_inference/rules.py
+++ b/src/python/pants/backend/scala/dependency_inference/rules.py
@@ -49,6 +49,11 @@ async def infer_scala_dependencies_via_source_analysis(
     )
 
     resolve = jvm.resolve_for_target(tgt)
+    if not resolve:
+        raise ValueError(
+            "Cannot infer Scala dependencies for a target without a `resolve` field: "
+            "`{address}` (with type `{tgt.alias}`)."
+        )
 
     symbols: OrderedSet[str] = OrderedSet()
     if scala_infer_subsystem.imports:

--- a/src/python/pants/backend/scala/target_types.py
+++ b/src/python/pants/backend/scala/target_types.py
@@ -19,12 +19,7 @@ from pants.engine.target import (
     TargetFilesGeneratorSettingsRequest,
 )
 from pants.engine.unions import UnionRule
-from pants.jvm.target_types import (
-    JunitTestSourceField,
-    JvmCompatibleResolvesField,
-    JvmProvidesTypesField,
-    JvmResolveField,
-)
+from pants.jvm.target_types import JunitTestSourceField, JvmProvidesTypesField, JvmResolveField
 
 
 class ScalaSettingsRequest(TargetFilesGeneratorSettingsRequest):
@@ -163,7 +158,7 @@ class ScalaSourceTarget(Target):
         *COMMON_TARGET_FIELDS,
         Dependencies,
         ScalaSourceField,
-        JvmCompatibleResolvesField,
+        JvmResolveField,
         JvmProvidesTypesField,
     )
     help = "A single Scala source file containing application or library code."
@@ -189,14 +184,14 @@ class ScalaSourcesGeneratorTarget(TargetFilesGenerator):
     core_fields = (
         *COMMON_TARGET_FIELDS,
         Dependencies,
-        JvmCompatibleResolvesField,
+        JvmResolveField,
         ScalaSourcesGeneratorSourcesField,
     )
     generated_target_cls = ScalaSourceTarget
     copied_fields = (
         *COMMON_TARGET_FIELDS,
         Dependencies,
-        JvmCompatibleResolvesField,
+        JvmResolveField,
     )
     moved_fields = (JvmProvidesTypesField,)
     settings_request_cls = ScalaSettingsRequest

--- a/src/python/pants/backend/scala/target_types.py
+++ b/src/python/pants/backend/scala/target_types.py
@@ -184,16 +184,17 @@ class ScalaSourcesGeneratorTarget(TargetFilesGenerator):
     core_fields = (
         *COMMON_TARGET_FIELDS,
         Dependencies,
-        JvmResolveField,
         ScalaSourcesGeneratorSourcesField,
     )
     generated_target_cls = ScalaSourceTarget
     copied_fields = (
         *COMMON_TARGET_FIELDS,
         Dependencies,
-        JvmResolveField,
     )
-    moved_fields = (JvmProvidesTypesField,)
+    moved_fields = (
+        JvmResolveField,
+        JvmProvidesTypesField,
+    )
     settings_request_cls = ScalaSettingsRequest
     help = "Generate a `scala_source` target for each file in the `sources` field."
 

--- a/src/python/pants/jvm/dependency_inference/BUILD
+++ b/src/python/pants/jvm/dependency_inference/BUILD
@@ -7,5 +7,6 @@ python_tests(
     name="tests",
     overrides={
         "java_scala_interop_test.py": {"timeout": 120},
+        "artifact_mapper_test.py": {"timeout": 120},
     },
 )

--- a/src/python/pants/jvm/dependency_inference/artifact_mapper.py
+++ b/src/python/pants/jvm/dependency_inference/artifact_mapper.py
@@ -208,10 +208,10 @@ async def find_available_third_party_artifacts(
         coord = UnversionedCoordinate(
             group=tgt[JvmArtifactGroupField].value, artifact=tgt[JvmArtifactArtifactField].value
         )
-        for resolve in jvm.resolves_for_target(tgt):
-            key = (resolve, coord)
-            address_mapping[key].add(tgt.address)
-            package_mapping[key].update(tgt[JvmArtifactPackagesField].value or ())
+        resolve = jvm.resolve_for_target(tgt)
+        key = (resolve, coord)
+        address_mapping[key].add(tgt.address)
+        package_mapping[key].update(tgt[JvmArtifactPackagesField].value or ())
 
     return AvailableThirdPartyArtifacts(
         {

--- a/src/python/pants/jvm/dependency_inference/artifact_mapper.py
+++ b/src/python/pants/jvm/dependency_inference/artifact_mapper.py
@@ -209,6 +209,7 @@ async def find_available_third_party_artifacts(
             group=tgt[JvmArtifactGroupField].value, artifact=tgt[JvmArtifactArtifactField].value
         )
         resolve = jvm.resolve_for_target(tgt)
+        assert resolve
         key = (resolve, coord)
         address_mapping[key].add(tgt.address)
         package_mapping[key].update(tgt[JvmArtifactPackagesField].value or ())

--- a/src/python/pants/jvm/dependency_inference/artifact_mapper_test.py
+++ b/src/python/pants/jvm/dependency_inference/artifact_mapper_test.py
@@ -160,14 +160,13 @@ def test_third_party_dep_inference_resolve(rule_runner: RuleRunner) -> None:
                 """\
                 artifact_args = {"group": "joda-time", "artifact": "joda-time", "version": "2.10.10"}
 
-                jvm_artifact(name="artifact_a", **artifact_args, compatible_resolves=["a"])
-                jvm_artifact(name="artifact_b", **artifact_args, compatible_resolves=["b"])
-                jvm_artifact(name="artifact_c", **artifact_args, compatible_resolves=["c"])
+                jvm_artifact(name="artifact_a", **artifact_args, resolve="a")
+                jvm_artifact(name="artifact_b", **artifact_args, resolve="b")
+                jvm_artifact(name="artifact_c", **artifact_args, resolve="c")
 
-                java_source(name='lib_a', source='PrintDate.java', compatible_resolves=['a'])
-                java_source(name='lib_b', source='PrintDate.java', compatible_resolves=['b'])
-                java_source(name='lib_c', source='PrintDate.java', compatible_resolves=['c'])
-                java_source(name='lib_ambiguous', source='PrintDate.java', compatible_resolves=['a', 'b'])
+                java_source(name='lib_a', source='PrintDate.java', resolve='a')
+                java_source(name='lib_b', source='PrintDate.java', resolve='b')
+                java_source(name='lib_c', source='PrintDate.java', resolve='c')
                 """
             ),
             "PrintDate.java": dedent(
@@ -189,7 +188,6 @@ def test_third_party_dep_inference_resolve(rule_runner: RuleRunner) -> None:
     assert_inferred("lib_a", ["artifact_a"])
     assert_inferred("lib_b", ["artifact_b"])
     assert_inferred("lib_c", ["artifact_c"])
-    assert_inferred("lib_ambiguous", [])
 
 
 @maybe_skip_jdk_test

--- a/src/python/pants/jvm/goals/lockfile.py
+++ b/src/python/pants/jvm/goals/lockfile.py
@@ -24,7 +24,7 @@ from pants.jvm.resolve.common import ArtifactRequirement, ArtifactRequirements
 from pants.jvm.resolve.coursier_fetch import CoursierResolvedLockfile
 from pants.jvm.resolve.lockfile_metadata import JVMLockfileMetadata
 from pants.jvm.subsystems import JvmSubsystem
-from pants.jvm.target_types import JvmArtifactCompatibleResolvesField
+from pants.jvm.target_types import JvmArtifactResolveField
 from pants.util.docutil import bin_name
 from pants.util.logging import LogLevel
 
@@ -83,10 +83,10 @@ async def setup_user_lockfile_requests(
 ) -> UserGenerateLockfiles:
     resolve_to_artifacts = defaultdict(set)
     for tgt in all_targets:
-        if not tgt.has_field(JvmArtifactCompatibleResolvesField):
+        if not tgt.has_field(JvmArtifactResolveField):
             continue
         artifact = ArtifactRequirement.from_jvm_artifact_target(tgt)
-        for resolve in jvm_subsystem.resolves_for_target(tgt):
+        for resolve in jvm_subsystem.resolve_for_target(tgt):
             resolve_to_artifacts[resolve].add(artifact)
 
     return UserGenerateLockfiles(

--- a/src/python/pants/jvm/goals/lockfile.py
+++ b/src/python/pants/jvm/goals/lockfile.py
@@ -86,8 +86,9 @@ async def setup_user_lockfile_requests(
         if not tgt.has_field(JvmArtifactResolveField):
             continue
         artifact = ArtifactRequirement.from_jvm_artifact_target(tgt)
-        for resolve in jvm_subsystem.resolve_for_target(tgt):
-            resolve_to_artifacts[resolve].add(artifact)
+        resolve = jvm_subsystem.resolve_for_target(tgt)
+        assert resolve
+        resolve_to_artifacts[resolve].add(artifact)
 
     return UserGenerateLockfiles(
         GenerateJvmLockfile(

--- a/src/python/pants/jvm/goals/lockfile_test.py
+++ b/src/python/pants/jvm/goals/lockfile_test.py
@@ -84,30 +84,41 @@ def test_generate_lockfile(rule_runner: RuleRunner) -> None:
 
 @maybe_skip_jdk_test
 def test_multiple_resolves(rule_runner: RuleRunner) -> None:
+    # TODO: Adjust to use https://github.com/pantsbuild/pants/pull/14408 for the
+    # duplicated artifact.
     rule_runner.write_files(
         {
             "BUILD": dedent(
                 """\
                 jvm_artifact(
-                    name='hamcrest',
+                    name='hamcrest_a',
                     group='org.hamcrest',
                     artifact='hamcrest-core',
                     version="1.3",
-                    compatible_resolves=["a", "b"],
+                    resolve="a",
                 )
+                jvm_artifact(
+                    name='hamcrest_b',
+                    group='org.hamcrest',
+                    artifact='hamcrest-core',
+                    version="1.3",
+                    resolve="b",
+                )
+
                 jvm_artifact(
                     name='opentest4j',
                     group='org.opentest4j',
                     artifact='opentest4j',
                     version='1.2.0',
-                    compatible_resolves=["a"],
+                    resolve="a",
                 )
+
                 jvm_artifact(
                     name='apiguardian-api',
                     group='org.apiguardian',
                     artifact='apiguardian-api',
                     version='1.1.0',
-                    compatible_resolves=["b"],
+                    resolve="b",
                 )
                 """
             ),

--- a/src/python/pants/jvm/package/BUILD
+++ b/src/python/pants/jvm/package/BUILD
@@ -2,4 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_sources()
-python_tests(name="tests")
+python_tests(
+    name="tests",
+    timeout=120,
+)

--- a/src/python/pants/jvm/resolve/coursier_fetch_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_test.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 from textwrap import dedent
-from typing import Sequence
 
 import pytest
 
@@ -55,7 +54,7 @@ def assert_resolve(
     rule_runner: RuleRunner,
     root_one_resolve: str,
     root_two_resolve: str,
-    leaf_resolves: Sequence[str],
+    leaf_resolve: str,
 ) -> None:
     rule_runner.write_files(
         {
@@ -68,7 +67,7 @@ def assert_resolve(
                   group='ex',
                   artifact='ex',
                   version='0.0.0',
-                  compatible_resolves={repr(list(leaf_resolves))},
+                  resolve='{leaf_resolve}',
                 )
                 """
             ),
@@ -94,24 +93,19 @@ def assert_resolve(
 
 @maybe_skip_jdk_test
 def test_all_matching(rule_runner: RuleRunner) -> None:
-    assert_resolve("one", rule_runner, "one", "one", ["one"])
-
-
-@maybe_skip_jdk_test
-def test_leaf_partial_matching(rule_runner: RuleRunner) -> None:
-    assert_resolve("one", rule_runner, "one", "one", ["two", "one"])
+    assert_resolve("one", rule_runner, "one", "one", "one")
 
 
 @maybe_skip_jdk_test
 def test_no_matching_for_root(rule_runner: RuleRunner) -> None:
     with engine_error(NoCompatibleResolve):
-        assert_resolve("n/a", rule_runner, "one", "two", ["two", "one"])
+        assert_resolve("n/a", rule_runner, "one", "two", "two")
 
 
 @maybe_skip_jdk_test
 def test_no_matching_for_leaf(rule_runner: RuleRunner) -> None:
     with engine_error(NoCompatibleResolve):
-        assert_resolve("n/a", rule_runner, "one", "one", ["two"])
+        assert_resolve("n/a", rule_runner, "one", "one", "two")
 
 
 @pytest.mark.parametrize(

--- a/src/python/pants/jvm/subsystems.py
+++ b/src/python/pants/jvm/subsystems.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from typing import cast
 
 from pants.engine.target import InvalidFieldException, Target
-from pants.jvm.target_types import JvmCompatibleResolvesField, JvmResolveField
+from pants.jvm.target_types import JvmResolveField
 from pants.option.subsystem import Subsystem
 
 
@@ -42,7 +42,7 @@ class JvmSubsystem(Subsystem):
             type=str,
             default="jvm-default",
             help=(
-                "The default value used for the `resolve` and `compatible_resolves` fields.\n\n"
+                "The default value used for the `resolve` field.\n\n"
                 "The name must be defined as a resolve in `[jvm].resolves`."
             ),
         )
@@ -74,11 +74,11 @@ class JvmSubsystem(Subsystem):
     def debug_args(self) -> tuple[str, ...]:
         return cast("tuple[str, ...]", tuple(self.options.debug_args))
 
-    def is_jvm_target(self, target: Target) -> bool:
+    def has_resolve(self, target: Target) -> bool:
         """Returns `True` only if the given target is a valid JVM source or destination target."""
-        return target.has_field(JvmResolveField) or target.has_field(JvmCompatibleResolvesField)
+        return target.has_field(JvmResolveField)
 
-    def resolves_for_target(self, target: Target) -> tuple[str, ...]:
+    def resolve_for_target(self, target: Target) -> str:
         if target.has_field(JvmResolveField):
             val = target[JvmResolveField].value or self.default_resolve
             if val not in self.resolves:
@@ -88,19 +88,8 @@ class JvmSubsystem(Subsystem):
                     "All valid resolve names (from `[jvm.resolves]`): "
                     f"{sorted(self.resolves.keys())}"
                 )
-            return (val,)
-        if target.has_field(JvmCompatibleResolvesField):
-            vals = target[JvmCompatibleResolvesField].value or (self.default_resolve,)
-            invalid_resolves = set(vals) - set(self.resolves.keys())
-            if invalid_resolves:
-                raise InvalidFieldException(
-                    f"Unrecognized resolves in the {target[JvmCompatibleResolvesField].alias} "
-                    f"field for {target.address}: {sorted(vals)}.\n\n"
-                    "All valid resolve names (from `[jvm.resolves]`): "
-                    f"{sorted(self.resolves.keys())}"
-                )
-            return vals
+            return val
         raise AssertionError(
-            f"Invalid target type {target.alias} for {target.address}. Needs to have `resolve` or "
-            "`compatible_resolves` field registered."
+            f"Invalid target type {target.alias} for {target.address}. Needs to have a "
+            f"`{JvmResolveField.alias}` field registered."
         )

--- a/src/python/pants/jvm/subystems_test.py
+++ b/src/python/pants/jvm/subystems_test.py
@@ -45,5 +45,4 @@ def test_resolve_for_target() -> None:
             )
         )
 
-    with pytest.raises(AssertionError):
-        jvm.resolve_for_target(GenericTarget({}, Address("dir")))
+    assert jvm.resolve_for_target(GenericTarget({}, Address("dir"))) is None

--- a/src/python/pants/jvm/target_types.py
+++ b/src/python/pants/jvm/target_types.py
@@ -28,16 +28,6 @@ from pants.util.docutil import git_url
 # -----------------------------------------------------------------------------------------------
 
 
-class JvmCompatibleResolvesField(StringSequenceField):
-    alias = "compatible_resolves"
-    required = False
-    help = (
-        "The set of resolves from `[jvm].resolves` that this target is compatible with.\n\n"
-        "If not defined, will default to `[jvm].default_resolve`.\n\n"
-        # TODO: Document expectations for dependencies once we validate that.
-    )
-
-
 class JvmResolveField(StringField):
     alias = "resolve"
     required = False
@@ -154,15 +144,15 @@ class JvmProvidesTypesField(StringSequenceField):
     )
 
 
-class JvmArtifactCompatibleResolvesField(JvmCompatibleResolvesField):
+class JvmArtifactResolveField(JvmResolveField):
     help = (
-        "The resolves from `[jvm].resolves` that this artifact should be included in.\n\n"
+        "The resolve from `[jvm].resolves` that this artifact should be included in.\n\n"
         "If not defined, will default to `[jvm].default_resolve`.\n\n"
         "When generating a lockfile for a particular resolve via the `coursier-resolve` goal, "
         "it will include all artifacts that are declared compatible with that resolve. First-party "
-        "targets like `java_source` and `scala_source` then declare which resolve(s) they use "
-        "via the `resolve` and `compatible_resolves` field; so, for your first-party code to use "
-        "a particular `jvm_artifact` target, that artifact must be included in the resolve(s) "
+        "targets like `java_source` and `scala_source` also declare which resolve they use "
+        "via the `resolve` field; so, for your first-party code to use "
+        "a particular `jvm_artifact` target, that artifact must be included in the resolve "
         "used by that code."
     )
 
@@ -189,14 +179,14 @@ class JvmArtifactTarget(Target):
         *JvmArtifactFieldSet.required_fields,
         JvmArtifactUrlField,  # TODO: should `JvmArtifactFieldSet` have an `all_fields` field?
         JvmArtifactJarSourceField,
-        JvmArtifactCompatibleResolvesField,
+        JvmArtifactResolveField,
     )
     help = (
         "A third-party JVM artifact, as identified by its Maven-compatible coordinate.\n\n"
         "That is, an artifact identified by its `group`, `artifact`, and `version` components.\n\n"
         "Each artifact is associated with one or more resolves (a logical name you give to a "
         "lockfile). For this artifact to be used by your first-party code, it must be "
-        "associated with the resolve(s) used by that code. See the `compatible_resolves` field."
+        "associated with the resolve(s) used by that code. See the `resolve` field."
     )
 
     def validate(self) -> None:


### PR DESCRIPTION
As designed in #13882 (and elaborated on in #14420 in the context of Python), the `parametrize` builtin means that targets which want to support multiple resolves (or Scala versions) should use `resolve=parametrize(..)`, so that a different target is created per resolve.

This change replaces the `compatible_resolves` field with `resolve` for the JVM. And in order to allow the `resolve` field to be `parametrize`d, it also moves it from the `core_fields` of JVM target generators (which cannot be `parametrize`d) to the `moved_fields`.