### PR TITLE
[internal] only touch `__init__.py` when running pytest tests

### DIFF
--- a/src/python/pants/conftest.py
+++ b/src/python/pants/conftest.py
@@ -26,5 +26,14 @@ from pathlib import Path
 # Note that while this makes the (implicit) namespace package into a regular package,
 # that is fine at test time. We don't consume testutil from a dist but from source, in the same
 # source root (src/python). We only need `pants` to be a namespace package in the dists we create.
+namespace_init_path = Path("src/python/pants/__init__.py")
 
-Path("src/python/pants/__init__.py").touch()
+
+def pytest_sessionstart(session) -> None:
+    namespace_init_path.touch()
+
+
+def pytest_sessionfinish(session) -> None:
+    # Technically unecessary, but nice if people are running tests directly from repo
+    # (not using pants).
+    namespace_init_path.unlink()


### PR DESCRIPTION
I'm using VS Code test plugin which re-runs test discovery on occasion. This, in turn, was generating the `__init__.py` each time and making it annoying to have to continually revert the file.

Now that's not the case!

[ci skip-rust]
[ci skip-build-wheels]