### PR TITLE
[internal] Don't use the type callable to convert values in typed options

### DIFF
--- a/src/python/pants/option/option_types.py
+++ b/src/python/pants/option/option_types.py
@@ -95,7 +95,7 @@ class _OptionBase(Generic[_PropType]):
 
     # Subclasses can override if necessary
     def _convert_(self, val: Any) -> _PropType:
-        return cast("_PropType", self._kwargs["type"](val))
+        return cast("_PropType", val)
 
     def advanced(self) -> _OptionBase[_PropType]:
         self._kwargs["advanced"] = True
@@ -167,7 +167,7 @@ class _ListOptionBase(_OptionBase["tuple[_ListMemberType, ...]"], Generic[_ListM
         return instance
 
     def _convert_(self, value: list[Any]) -> tuple[_ListMemberType]:
-        return cast("tuple[_ListMemberType]", tuple(map(self._kwargs["member_type"], value)))
+        return cast("tuple[_ListMemberType]", tuple(value))
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/option/option_types_test.py
+++ b/src/python/pants/option/option_types_test.py
@@ -8,8 +8,6 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import Mock, call
 
-import pytest
-
 from pants.option.custom_types import dir_option, file_option, memory_size, shell_str, target_option
 from pants.option.option_types import (
     ArgsListOption,
@@ -304,31 +302,6 @@ def test_option_typeclasses() -> None:
     var_memorysize_list: tuple[int, ...] = my_subsystem.memorysize_list_prop  # noqa: F841
 
     var_args: tuple[str, ...] = my_subsystem.args_prop  # noqa: F841
-
-
-@pytest.mark.parametrize(
-    "prop_type, opt_val",
-    [
-        (DirOption, ""),
-        (FileOption, ""),
-        (MemorySizeOption, "2GiB"),
-        (DirListOption, [""]),
-        (FileListOption, [""]),
-        (MemorySizeListOption, ["2GiB"]),
-    ],
-)
-def test_conversion(prop_type, opt_val) -> None:
-    class MySubsystem(Subsystem):
-        def __init__(self):
-            self.options = SimpleNamespace()
-            self.options.opt = opt_val
-
-        prop = prop_type("--opt", help="")
-
-    my_subsystem = MySubsystem()
-    # We don't need to test the actual function, just that it transformed the value into something
-    # else.
-    assert my_subsystem.prop != opt_val
 
 
 def test_builder_methods():


### PR DESCRIPTION
This is causing a test failure for https://github.com/pantsbuild/pants/pull/14444. 

As I understand it, the underlying options code should be doing this coercion for us.

[ci skip-rust]
[ci skip-build-wheels]