### PR TITLE
[internal] Improve `JdkEnvironment` cache performance

### DIFF
--- a/src/python/pants/backend/java/compile/javac.py
+++ b/src/python/pants/backend/java/compile/javac.py
@@ -18,7 +18,7 @@ from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, Directory, MergeDigests, Snapshot
 from pants.engine.process import BashBinary, FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import CoarsenedTarget, SourcesField
+from pants.engine.target import SourcesField
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.jvm.classpath import Classpath
 from pants.jvm.compile import (
@@ -28,7 +28,7 @@ from pants.jvm.compile import (
     FallibleClasspathEntry,
 )
 from pants.jvm.compile import rules as jvm_compile_rules
-from pants.jvm.jdk_rules import JdkEnvironment, JvmProcess
+from pants.jvm.jdk_rules import JdkEnvironment, JdkRequest, JvmProcess
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
@@ -71,7 +71,7 @@ async def compile_java_source(
             exit_code=1,
         )
 
-    jdk = await Get(JdkEnvironment, CoarsenedTarget, request.component)
+    jdk = await Get(JdkEnvironment, JdkRequest, JdkRequest.from_target(request.component))
 
     # Capture just the `ClasspathEntry` objects that are listed as `export` types by source analysis
     deps_to_classpath_entries = dict(

--- a/src/python/pants/backend/scala/compile/scalac.py
+++ b/src/python/pants/backend/scala/compile/scalac.py
@@ -17,7 +17,7 @@ from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import EMPTY_DIGEST, Digest, MergeDigests
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import CoarsenedTarget, SourcesField
+from pants.engine.target import SourcesField
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.jvm.classpath import Classpath
 from pants.jvm.compile import (
@@ -27,7 +27,7 @@ from pants.jvm.compile import (
     FallibleClasspathEntry,
 )
 from pants.jvm.compile import rules as jvm_compile_rules
-from pants.jvm.jdk_rules import JdkEnvironment, JvmProcess
+from pants.jvm.jdk_rules import JdkEnvironment, JdkRequest, JvmProcess
 from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.util.logging import LogLevel
@@ -80,7 +80,7 @@ async def compile_scala_source(
         for filename in dependency.filenames
     ]
 
-    jdk = await Get(JdkEnvironment, CoarsenedTarget, request.component)
+    jdk = await Get(JdkEnvironment, JdkRequest, JdkRequest.from_target(request.component))
     scala_version = scala.version_for_resolve(request.resolve.name)
 
     # TODO(14171): Stop-gap for making sure that scala supplies all of its dependencies to

--- a/src/python/pants/backend/scala/goals/repl.py
+++ b/src/python/pants/backend/scala/goals/repl.py
@@ -9,10 +9,10 @@ from pants.engine.fs import AddPrefix, Digest, MergeDigests
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.process import BashBinary
 from pants.engine.rules import collect_rules, rule
-from pants.engine.target import CoarsenedTarget, CoarsenedTargets
+from pants.engine.target import CoarsenedTargets
 from pants.engine.unions import UnionRule
 from pants.jvm.classpath import Classpath
-from pants.jvm.jdk_rules import JdkEnvironment
+from pants.jvm.jdk_rules import JdkEnvironment, JdkRequest
 from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.util.logging import LogLevel
@@ -29,7 +29,9 @@ async def create_scala_repl_request(
     user_classpath = await Get(Classpath, Addresses, request.addresses)
 
     roots = await Get(CoarsenedTargets, Addresses, request.addresses)
-    environs = await MultiGet(Get(JdkEnvironment, CoarsenedTarget, target) for target in roots)
+    environs = await MultiGet(
+        Get(JdkEnvironment, JdkRequest, JdkRequest.from_target(target)) for target in roots
+    )
     jdk = max(environs, key=lambda j: j.jre_major_version)
 
     scala_version = scala_subsystem.version_for_resolve(user_classpath.resolve.name)

--- a/src/python/pants/backend/scala/test/scalatest.py
+++ b/src/python/pants/backend/scala/test/scalatest.py
@@ -21,7 +21,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.jvm.classpath import Classpath
 from pants.jvm.goals import lockfile
-from pants.jvm.jdk_rules import JdkEnvironment, JdkRequest, JvmProcess
+from pants.jvm.jdk_rules import JdkEnvironment, JvmProcess
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
 from pants.jvm.subsystems import JvmSubsystem
@@ -65,7 +65,7 @@ async def setup_scalatest_for_target(
     scalatest: Scalatest,
     test_subsystem: TestSubsystem,
 ) -> TestSetup:
-    jdk = await Get(JdkEnvironment, JdkRequest(request.field_set.jdk_version))
+    jdk = await Get(JdkEnvironment, JvmJdkField, request.field_set.jdk_version)
 
     lockfile_request = await Get(GenerateJvmLockfileFromTool, ScalatestToolLockfileSentinel())
     classpath, scalatest_classpath = await MultiGet(

--- a/src/python/pants/backend/scala/test/scalatest.py
+++ b/src/python/pants/backend/scala/test/scalatest.py
@@ -21,7 +21,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.jvm.classpath import Classpath
 from pants.jvm.goals import lockfile
-from pants.jvm.jdk_rules import JdkEnvironment, JvmProcess
+from pants.jvm.jdk_rules import JdkEnvironment, JdkRequest, JvmProcess
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
 from pants.jvm.subsystems import JvmSubsystem
@@ -65,7 +65,9 @@ async def setup_scalatest_for_target(
     scalatest: Scalatest,
     test_subsystem: TestSubsystem,
 ) -> TestSetup:
-    jdk = await Get(JdkEnvironment, JvmJdkField, request.field_set.jdk_version)
+    jdk = await Get(
+        JdkEnvironment, JdkRequest, JdkRequest.from_field(request.field_set.jdk_version)
+    )
 
     lockfile_request = await Get(GenerateJvmLockfileFromTool, ScalatestToolLockfileSentinel())
     classpath, scalatest_classpath = await MultiGet(

--- a/src/python/pants/jvm/jdk_rules.py
+++ b/src/python/pants/jvm/jdk_rules.py
@@ -44,7 +44,7 @@ class DefaultJdk(Enum):
 
 @dataclass(frozen=True)
 class JdkRequest:
-    """Request for a JDK with a specific major version, or None (use System JDK)."""
+    """Request for a JDK with a specific major version, or a default (`--jvm-jdk` or System)."""
 
     version: str | DefaultJdk
 

--- a/src/python/pants/jvm/jdk_rules.py
+++ b/src/python/pants/jvm/jdk_rules.py
@@ -49,17 +49,19 @@ class JdkRequest:
     version: str | DefaultJdk
 
     @classproperty
-    def system(cls) -> JdkRequest:
+    def SYSTEM(cls) -> JdkRequest:
         return JdkRequest(DefaultJdk.SYSTEM)
 
     @classproperty
-    def source_default(cls) -> JdkRequest:
+    def SOURCE_DEFAULT(cls) -> JdkRequest:
         return JdkRequest(DefaultJdk.SOURCE_DEFAULT)
 
     @staticmethod
     def from_field(field: JvmJdkField) -> JdkRequest:
         version = field.value
-        return JdkRequest(version) if version is not None else JdkRequest.source_default
+        if version == "system":
+            return JdkRequest.SYSTEM
+        return JdkRequest(version) if version is not None else JdkRequest.SOURCE_DEFAULT
 
     @staticmethod
     def from_target(target: CoarsenedTarget) -> JdkRequest:
@@ -153,7 +155,7 @@ async def internal_jdk(jvm: JvmSubsystem) -> InternalJdk:
     matching compatibility with source files (e.g. compilation/testing).
     """
 
-    request = JdkRequest(jvm.tool_jdk) if jvm.tool_jdk is not None else JdkRequest.system
+    request = JdkRequest(jvm.tool_jdk) if jvm.tool_jdk is not None else JdkRequest.SYSTEM
     env = await Get(JdkEnvironment, JdkRequest, request)
     return InternalJdk(env._digest, env.nailgun_jar, env.coursier, env.jre_major_version)
 

--- a/src/python/pants/jvm/run_deploy_jar.py
+++ b/src/python/pants/jvm/run_deploy_jar.py
@@ -13,8 +13,9 @@ from pants.engine.internals.native_engine import AddPrefix
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.unions import UnionRule
-from pants.jvm.jdk_rules import JdkEnvironment, JdkRequest, JvmProcess
+from pants.jvm.jdk_rules import JdkEnvironment, JvmProcess
 from pants.jvm.package.deploy_jar import DeployJarFieldSet
+from pants.jvm.target_types import JvmJdkField
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 
@@ -38,7 +39,7 @@ async def create_deploy_jar_run_request(
     field_set: DeployJarFieldSet,
 ) -> RunRequest:
 
-    jdk = await Get(JdkEnvironment, JdkRequest(field_set.jdk_version))
+    jdk = await Get(JdkEnvironment, JvmJdkField, field_set.jdk_version)
 
     main_class = field_set.main_class.value
     assert main_class is not None

--- a/src/python/pants/jvm/run_deploy_jar.py
+++ b/src/python/pants/jvm/run_deploy_jar.py
@@ -13,9 +13,8 @@ from pants.engine.internals.native_engine import AddPrefix
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.unions import UnionRule
-from pants.jvm.jdk_rules import JdkEnvironment, JvmProcess
+from pants.jvm.jdk_rules import JdkEnvironment, JdkRequest, JvmProcess
 from pants.jvm.package.deploy_jar import DeployJarFieldSet
-from pants.jvm.target_types import JvmJdkField
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 
@@ -39,7 +38,7 @@ async def create_deploy_jar_run_request(
     field_set: DeployJarFieldSet,
 ) -> RunRequest:
 
-    jdk = await Get(JdkEnvironment, JvmJdkField, field_set.jdk_version)
+    jdk = await Get(JdkEnvironment, JdkRequest, JdkRequest.from_field(field_set.jdk_version))
 
     main_class = field_set.main_class.value
     assert main_class is not None

--- a/src/python/pants/jvm/test/junit.py
+++ b/src/python/pants/jvm/test/junit.py
@@ -20,7 +20,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.jvm.classpath import Classpath
 from pants.jvm.goals import lockfile
-from pants.jvm.jdk_rules import JdkEnvironment, JvmProcess
+from pants.jvm.jdk_rules import JdkEnvironment, JdkRequest, JvmProcess
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
 from pants.jvm.subsystems import JvmSubsystem
@@ -65,7 +65,9 @@ async def setup_junit_for_target(
     test_subsystem: TestSubsystem,
 ) -> TestSetup:
 
-    jdk = await Get(JdkEnvironment, JvmJdkField, request.field_set.jdk_version)
+    jdk = await Get(
+        JdkEnvironment, JdkRequest, JdkRequest.from_field(request.field_set.jdk_version)
+    )
 
     lockfile_request = await Get(GenerateJvmLockfileFromTool, JunitToolLockfileSentinel())
     classpath, junit_classpath = await MultiGet(

--- a/src/python/pants/jvm/test/junit.py
+++ b/src/python/pants/jvm/test/junit.py
@@ -20,7 +20,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.jvm.classpath import Classpath
 from pants.jvm.goals import lockfile
-from pants.jvm.jdk_rules import JdkEnvironment, JdkRequest, JvmProcess
+from pants.jvm.jdk_rules import JdkEnvironment, JvmProcess
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
 from pants.jvm.subsystems import JvmSubsystem
@@ -65,7 +65,7 @@ async def setup_junit_for_target(
     test_subsystem: TestSubsystem,
 ) -> TestSetup:
 
-    jdk = await Get(JdkEnvironment, JdkRequest(request.field_set.jdk_version))
+    jdk = await Get(JdkEnvironment, JvmJdkField, request.field_set.jdk_version)
 
     lockfile_request = await Get(GenerateJvmLockfileFromTool, JunitToolLockfileSentinel())
     classpath, junit_classpath = await MultiGet(


### PR DESCRIPTION
Previously we were constructing a `JdkEnvironment` for every instance of `JvmJdkField` rather than caching by version. This refactors `JdkRequest` to no longer store a field, and instead, always store a version string or magic constant.

This should reduce the number of times we download a JDK.

(Fast-follow for #14421, addresses #13995)