### PR TITLE
Remove deprecated `[scala] version` option.

### DIFF
--- a/src/python/pants/backend/scala/subsystems/scala.py
+++ b/src/python/pants/backend/scala/subsystems/scala.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import logging
 from typing import cast
 
-from pants.option.option_types import StrOption
 from pants.option.subsystem import Subsystem
 
 DEFAULT_SCALA_VERSION = "2.13.6"
@@ -17,17 +16,6 @@ _logger = logging.getLogger(__name__)
 class ScalaSubsystem(Subsystem):
     options_scope = "scala"
     help = "Scala programming language"
-
-    version = StrOption(
-        "--version",
-        default=DEFAULT_SCALA_VERSION,
-        help=(
-            "The version of Scala to use.\n\n"
-            "This option is deprecated in favor of the `[scala].version_for_resolve` option. If "
-            "`[scala].version_for_resolve` does not have an entry for a resolve, then the value of "
-            "this option will be used as the Scala version for that resolve."
-        ),
-    ).deprecated(removal_version="2.11.0.dev0", hint="Use `[scala].version_for_resolve` instead.")
 
     @classmethod
     def register_options(cls, register):
@@ -55,4 +43,4 @@ class ScalaSubsystem(Subsystem):
         version = self._version_for_resolve.get(resolve)
         if version:
             return version
-        return self.version
+        return DEFAULT_SCALA_VERSION


### PR DESCRIPTION
[ci skip-rust]
[ci skip-build-wheels]