### PR TITLE
Fix handling of Go version for third-party packages

### DIFF
--- a/src/python/pants/backend/go/subsystems/golang.py
+++ b/src/python/pants/backend/go/subsystems/golang.py
@@ -96,7 +96,12 @@ class GoRoot:
         """
         if version == "1.0":
             return True
-        return int(version[2:]) <= int(self.version[2:])  # e.g. `1.17` -> `17`
+
+        def parse(v: str) -> tuple[int, int]:
+            major, minor = v.split(".", maxsplit=1)
+            return int(major), int(minor)
+
+        return parse(version) <= parse(self.version)
 
 
 @rule(desc="Find Go binary", level=LogLevel.DEBUG)

--- a/src/python/pants/backend/go/subsystems/golang.py
+++ b/src/python/pants/backend/go/subsystems/golang.py
@@ -84,6 +84,19 @@ class GoRoot:
     """Path to the Go installation (the `GOROOT`)."""
 
     path: str
+    version: str
+
+    def is_compatible_version(self, version: str) -> bool:
+        """Can this Go compiler handle the target version?
+
+        Inspired by
+        https://github.com/golang/go/blob/30501bbef9fcfc9d53e611aaec4d20bb3cdb8ada/src/cmd/go/internal/work/exec.go#L429-L445.
+
+        Input expected in the form `1.17`.
+        """
+        if version == "1.0":
+            return True
+        return int(version[2:]) <= int(self.version[2:])  # e.g. `1.17` -> `17`
 
 
 @rule(desc="Find Go binary", level=LogLevel.DEBUG)
@@ -150,7 +163,7 @@ async def setup_goroot(golang_subsystem: GolangSubsystem) -> GoRoot:
                 ),
             )
             goroot = env_result.stdout.decode("utf-8").strip()
-            return GoRoot(goroot)
+            return GoRoot(goroot, version)
 
         logger.debug(
             f"Go binary at {binary_path.path} has version {version}, but this "

--- a/src/python/pants/backend/go/subsystems/golang_test.py
+++ b/src/python/pants/backend/go/subsystems/golang_test.py
@@ -114,3 +114,11 @@ def test_no_valid_versions(rule_runner: RuleRunner) -> None:
     exc = e.value.wrapped_exceptions[0]
     assert isinstance(exc, BinaryNotFoundError)
     assert "Cannot find a `go` binary with the expected version" in str(exc)
+
+
+def test_valid_go_version() -> None:
+    go_root = GoRoot("", "1.15")
+    for v in range(16):
+        assert go_root.is_compatible_version(f"1.{v}") is True
+    for v in range(17, 40):
+        assert go_root.is_compatible_version(f"1.{v}") is False

--- a/src/python/pants/backend/go/subsystems/golang_test.py
+++ b/src/python/pants/backend/go/subsystems/golang_test.py
@@ -122,3 +122,5 @@ def test_valid_go_version() -> None:
         assert go_root.is_compatible_version(f"1.{v}") is True
     for v in range(17, 40):
         assert go_root.is_compatible_version(f"1.{v}") is False
+    for v in range(2, 4):
+        assert go_root.is_compatible_version(f"{v}.0") is False


### PR DESCRIPTION
We weren't following the spec properly. Closes https://github.com/pantsbuild/pants/issues/14446.

[ci skip-rust]
[ci skip-build-wheels]