### PR TITLE
[Plugins] Debian packaging: make dpkg-deb run in a Process for sources

### DIFF
--- a/src/python/pants/backend/debian/BUILD
+++ b/src/python/pants/backend/debian/BUILD
@@ -1,4 +1,5 @@
-# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_sources()
+python_tests(name="tests")

--- a/src/python/pants/backend/debian/rules.py
+++ b/src/python/pants/backend/debian/rules.py
@@ -14,19 +14,11 @@ from pants.core.goals.package import (
     OutputPathField,
     PackageFieldSet,
 )
-from pants.engine.fs import CreateDigest, Digest
-from pants.core.util_rules.system_binaries import BinaryPathRequest, BinaryPaths
-from pants.core.util_rules.archive import TarBinary
+from pants.core.util_rules.system_binaries import BinaryPathRequest, BinaryPaths, TarBinary
 from pants.engine.fs import CreateDigest, DigestEntries, FileEntry
 from pants.engine.internals.native_engine import Digest
 from pants.engine.internals.selectors import Get
-from pants.engine.process import (
-    BinaryPathRequest,
-    BinaryPaths,
-    Process,
-    ProcessCacheScope,
-    ProcessResult,
-)
+from pants.engine.process import Process, ProcessCacheScope, ProcessResult
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import HydratedSources, HydrateSourcesRequest
 from pants.engine.unions import UnionRule

--- a/src/python/pants/backend/debian/rules.py
+++ b/src/python/pants/backend/debian/rules.py
@@ -47,12 +47,14 @@ async def package_debian_package(
         ),
     )
     if not dpkg_deb_path.first_path:
-        raise OSError(f"Could not find the `{dpkg_deb_path.binary_name}` program on search paths ")
+        raise OSError(f"Could not find the `{dpkg_deb_path.binary_name}` program in `/usr/bin`.")
 
     hydrated_sources = await Get(HydratedSources, HydrateSourcesRequest(field_set.sources_dir))
 
     # Since all the sources are coming only from a single directory, it is
     # safe to pick an arbitrary file and get its root directory name.
+    # Validation of the resolved files has been called on the target, so it is known that
+    # snapshot.files isn't empty.
     sources_directory_name = PurePath(hydrated_sources.snapshot.files[0]).parts[0]
 
     result = await Get(

--- a/src/python/pants/backend/debian/rules.py
+++ b/src/python/pants/backend/debian/rules.py
@@ -18,7 +18,7 @@ from pants.core.util_rules.system_binaries import BinaryPathRequest, BinaryPaths
 from pants.engine.fs import CreateDigest, DigestEntries, FileEntry
 from pants.engine.internals.native_engine import Digest
 from pants.engine.internals.selectors import Get
-from pants.engine.process import Process, ProcessCacheScope, ProcessResult
+from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import HydratedSources, HydrateSourcesRequest
 from pants.engine.unions import UnionRule
@@ -51,8 +51,8 @@ async def package_debian_package(
 
     hydrated_sources = await Get(HydratedSources, HydrateSourcesRequest(field_set.sources_dir))
 
-    # since all the sources are coming only from a single directory, it is
-    # safe to pick an arbitrary file and get its root directory name
+    # Since all the sources are coming only from a single directory, it is
+    # safe to pick an arbitrary file and get its root directory name.
     sources_directory_name = PurePath(hydrated_sources.snapshot.files[0]).parts[0]
 
     result = await Get(
@@ -68,11 +68,9 @@ async def package_debian_package(
             # dpkg-deb produces a file with the same name as the input directory
             output_files=(f"{sources_directory_name}.deb",),
             env={"PATH": str(PurePath(tar_binary_path.path).parent)},
-            cache_scope=ProcessCacheScope.PER_SESSION,
         ),
     )
-    # the output Debian package file needs to be renamed to match the name field in the
-    # debian_package target declaration
+    # The output Debian package file needs to be renamed to match the output_path field.
     output_filename = field_set.output_path.value_or_default(
         file_ending="deb",
     )

--- a/src/python/pants/backend/debian/rules.py
+++ b/src/python/pants/backend/debian/rules.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from dataclasses import dataclass
 from pathlib import PurePath

--- a/src/python/pants/backend/debian/rules.py
+++ b/src/python/pants/backend/debian/rules.py
@@ -1,10 +1,10 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 from dataclasses import dataclass
+from pathlib import PurePath
 
 from pants.backend.debian.target_types import (
-    DebianControlFile,
+    DebianSources,
     DebianInstallPrefix,
     DebianPackageDependencies,
 )
@@ -16,25 +16,28 @@ from pants.core.goals.package import (
 )
 from pants.engine.fs import CreateDigest, Digest
 from pants.core.util_rules.system_binaries import BinaryPathRequest, BinaryPaths
+from pants.core.util_rules.archive import TarBinary
 from pants.engine.internals.selectors import Get
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import collect_rules, rule
+from pants.engine.target import HydrateSourcesRequest, HydratedSources
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 
 
 @dataclass(frozen=True)
 class DebianPackageFieldSet(PackageFieldSet):
-    required_fields = (DebianControlFile, DebianInstallPrefix, DebianPackageDependencies)
+    required_fields = (DebianSources, DebianInstallPrefix, DebianPackageDependencies)
 
-    control: DebianControlFile
+    metadata_dir: DebianSources
     install_prefix: DebianInstallPrefix
     packages: DebianPackageDependencies
     output_path: OutputPathField
 
 
-@rule(level=LogLevel.DEBUG)
-async def package_debian_package(field_set: DebianPackageFieldSet) -> BuiltPackage:
+@rule(level=LogLevel.INFO)
+async def package_debian_package(field_set: DebianPackageFieldSet,
+                                 tar_binary_path: TarBinary) -> BuiltPackage:
     dpkg_deb_path = await Get(
         BinaryPaths,
         BinaryPathRequest(
@@ -42,17 +45,25 @@ async def package_debian_package(field_set: DebianPackageFieldSet) -> BuiltPacka
             search_path=["/usr/bin"],
         ),
     )
+    tar_path = await Get(
+        BinaryPaths,
+        BinaryPathRequest(
+            binary_name="tar",
+            search_path=["/usr/bin"],
+        ),
+    )
+
     if not dpkg_deb_path.first_path:
         raise OSError("Could not find the `dpkg-deb` program on search paths ")
+    if not tar_path.first_path:
+        raise EnvironmentError("Could not find the `tar` program on search paths ")
 
     output_filename = field_set.output_path.value_or_default(
 
         file_ending="deb",
     )
 
-    # TODO: need to create a digest from the directory from the "sources" field of
-    #  "debian_package" target, i.e. field_set.control.filespec['includes'][0]
-    package_metadata_dir_digest = await Get(Digest, CreateDigest("?"))
+    hydrated_sources = await Get(HydratedSources, HydrateSourcesRequest(field_set.metadata_dir))
 
     result = await Get(
         ProcessResult,
@@ -60,17 +71,12 @@ async def package_debian_package(field_set: DebianPackageFieldSet) -> BuiltPacka
             argv=(
                 "/usr/bin/dpkg-deb",
                 "--build",
-                # this is assumed to be a directory from the "sources" field of
-                # "debian_package" target
-                field_set.control.filespec["includes"][0],
+                "sample-debian-package",
             ),
             description="Create a Debian package from the produced packages.",
-            input_digest=package_metadata_dir_digest,
-            # TODO: don't need the working_dir since the "sources" will become available?
-            #  and the output .deb file will become available as a BuiltPackage because
-            #  it has been specified in the "output_files"?
-            working_dir="?",
+            input_digest=hydrated_sources.snapshot.digest,
             output_files=(output_filename,),
+            env={"PATH": str(PurePath(tar_binary_path.path).parent)},
         ),
     )
     return BuiltPackage(result.output_digest, artifacts=(BuiltPackageArtifact(output_filename),))

--- a/src/python/pants/backend/debian/rules_integration_test.py
+++ b/src/python/pants/backend/debian/rules_integration_test.py
@@ -6,13 +6,14 @@ from textwrap import dedent
 
 import pytest
 
-from pants.backend.debian.rules import rules as debian_rules, DebianPackageFieldSet
+from pants.backend.debian.rules import DebianPackageFieldSet
+from pants.backend.debian.rules import rules as debian_rules
 from pants.backend.debian.target_types import DebianPackage
 from pants.backend.python import target_types_rules
 from pants.build_graph.address import Address
 from pants.core.goals.package import BuiltPackage
 from pants.core.util_rules import source_files
-from pants.core.util_rules.source_files import SourceFilesRequest, SourceFiles
+from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.rules import QueryRule
 from pants.engine.target import Target
 from pants.testutil.rule_runner import RuleRunner
@@ -41,18 +42,19 @@ def build_package(rule_runner: RuleRunner, binary_target: Target) -> BuiltPackag
 
 def test_create_debian_package(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
-        {"BUILD": dedent(
-            """
+        {
+            "BUILD": dedent(
+                """
             debian_package(
                 name='sample-debian-package',
                 description='Useful tools installed as a Debian package.',
-                packages=[],                                
+                packages=[],
                 sources=['project/**/*'],
             )
             """
-        ),
-         "project/DEBIAN/control": dedent(
-            """
+            ),
+            "project/DEBIAN/control": dedent(
+                """
             Package: sample-debian-package
             Version: 1.0
             Architecture: amd64
@@ -63,12 +65,12 @@ def test_create_debian_package(rule_runner: RuleRunner) -> None:
             Maintainer: me@company.com
             Description: A sample Debian package built with Pants.
             """
-        ),
-         "project/opt/company/platform.conf": dedent(
-            """
+            ),
+            "project/opt/company/platform.conf": dedent(
+                """
             Some configuration.
             """
-         )
+            ),
         }
     )
 
@@ -78,8 +80,10 @@ def test_create_debian_package(rule_runner: RuleRunner) -> None:
     assert built_package.artifacts[0].relpath == "sample-debian-package.deb"
 
     # list the contents of a Debian package to see that a file was included
-    result = subprocess.run(["dpkg", "-c", os.path.join(rule_runner.build_root, "sample-debian-package.deb")],
-                            stdout=subprocess.PIPE)
+    result = subprocess.run(
+        ["dpkg", "-c", os.path.join(rule_runner.build_root, "sample-debian-package.deb")],
+        stdout=subprocess.PIPE,
+    )
     assert result.returncode == 0
     assert b"opt/company/platform.conf" in result.stdout
     return

--- a/src/python/pants/backend/debian/rules_integration_test.py
+++ b/src/python/pants/backend/debian/rules_integration_test.py
@@ -1,15 +1,20 @@
-# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+import os
+import subprocess
 from textwrap import dedent
 
 import pytest
 
-from pants.backend.debian.rules import package_debian_package
+from pants.backend.debian.rules import rules as debian_rules, DebianPackageFieldSet
 from pants.backend.debian.target_types import DebianPackage
 from pants.backend.python import target_types_rules
+from pants.build_graph.address import Address
+from pants.core.goals.package import BuiltPackage
 from pants.core.util_rules import source_files
 from pants.core.util_rules.source_files import SourceFilesRequest, SourceFiles
 from pants.engine.rules import QueryRule
+from pants.engine.target import Target
 from pants.testutil.rule_runner import RuleRunner
 
 
@@ -17,27 +22,36 @@ from pants.testutil.rule_runner import RuleRunner
 def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
-            *package_debian_package(),
+            *debian_rules(),
             *source_files.rules(),
             *target_types_rules.rules(),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
+            QueryRule(BuiltPackage, (DebianPackageFieldSet,)),
         ],
         target_types=[DebianPackage],
     )
 
 
-def create_debian_package(rule_runner: RuleRunner) -> None:
+def build_package(rule_runner: RuleRunner, binary_target: Target) -> BuiltPackage:
+    field_set = DebianPackageFieldSet.create(binary_target)
+    result = rule_runner.request(BuiltPackage, [field_set])
+    rule_runner.write_digest(result.digest)
+    return result
+
+
+def test_create_debian_package(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
-        {"project/BUILD": dedent(
+        {"BUILD": dedent(
             """
             debian_package(
-                name='my-package',
-                description='Useful tools installed as Debian package.',                                
-                sources=['project/files/**/*'],
+                name='sample-debian-package',
+                description='Useful tools installed as a Debian package.',
+                packages=[],                                
+                sources=['project/**/*'],
             )
             """
         ),
-         "project/files/DEBIAN/control": dedent(
+         "project/DEBIAN/control": dedent(
             """
             Package: sample-debian-package
             Version: 1.0
@@ -50,7 +64,7 @@ def create_debian_package(rule_runner: RuleRunner) -> None:
             Description: A sample Debian package built with Pants.
             """
         ),
-         "project/files/platform.conf": dedent(
+         "project/opt/company/platform.conf": dedent(
             """
             Some configuration.
             """
@@ -58,5 +72,14 @@ def create_debian_package(rule_runner: RuleRunner) -> None:
         }
     )
 
-    # TODO(alexey): create a Debian package
+    binary_tgt = rule_runner.get_target(Address("", target_name="sample-debian-package"))
+    built_package = build_package(rule_runner, binary_tgt)
+    assert len(built_package.artifacts) == 1
+    assert built_package.artifacts[0].relpath == "sample-debian-package.deb"
+
+    # list the contents of a Debian package to see that a file was included
+    result = subprocess.run(["dpkg", "-c", os.path.join(rule_runner.build_root, "sample-debian-package.deb")],
+                            stdout=subprocess.PIPE)
+    assert result.returncode == 0
+    assert b"opt/company/platform.conf" in result.stdout
     return

--- a/src/python/pants/backend/debian/rules_integration_test.py
+++ b/src/python/pants/backend/debian/rules_integration_test.py
@@ -1,0 +1,62 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from textwrap import dedent
+
+import pytest
+
+from pants.backend.debian.rules import package_debian_package
+from pants.backend.debian.target_types import DebianPackage
+from pants.backend.python import target_types_rules
+from pants.core.util_rules import source_files
+from pants.core.util_rules.source_files import SourceFilesRequest, SourceFiles
+from pants.engine.rules import QueryRule
+from pants.testutil.rule_runner import RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *package_debian_package(),
+            *source_files.rules(),
+            *target_types_rules.rules(),
+            QueryRule(SourceFiles, (SourceFilesRequest,)),
+        ],
+        target_types=[DebianPackage],
+    )
+
+
+def create_debian_package(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {"project/BUILD": dedent(
+            """
+            debian_package(
+                name='my-package',
+                description='Useful tools installed as Debian package.',                                
+                sources=['project/files/**/*'],
+            )
+            """
+        ),
+         "project/files/DEBIAN/control": dedent(
+            """
+            Package: sample-debian-package
+            Version: 1.0
+            Architecture: amd64
+            Essential: no
+            Section: dev
+            Priority: optional
+            Depends: python3, python3-distutils
+            Maintainer: me@company.com
+            Description: A sample Debian package built with Pants.
+            """
+        ),
+         "project/files/platform.conf": dedent(
+            """
+            Some configuration.
+            """
+         )
+        }
+    )
+
+    # TODO(alexey): create a Debian package
+    return

--- a/src/python/pants/backend/debian/rules_integration_test.py
+++ b/src/python/pants/backend/debian/rules_integration_test.py
@@ -1,8 +1,8 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 import os
+import shutil
 import subprocess
-import sys
 from textwrap import dedent
 
 import pytest
@@ -37,7 +37,10 @@ def build_package(rule_runner: RuleRunner, binary_target: Target) -> BuiltPackag
     return result
 
 
-@pytest.mark.skipif(sys.platform != "linux", reason="Test requires dpkg so only works on Linux")
+@pytest.mark.skipif(
+    shutil.which("dpkg") is None,
+    reason="Test requires dpkg so only works on Debian-based Linux distributions.",
+)
 def test_create_debian_package(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {

--- a/src/python/pants/backend/debian/target_types.py
+++ b/src/python/pants/backend/debian/target_types.py
@@ -19,9 +19,11 @@ from pants.util.docutil import bin_name, doc_url
 class DebianSources(MultipleSourcesField):
     required = True
     help = (
-        "Paths that will be included in the package to be produced."
-        "It is required to include a Debian control file.\n\n"
-        "Paths are relative to the BUILD file's directory."
+        "Paths that will be included in the package to be produced such as Debian metadata files. "
+        "You must include a DEBIAN/control file.\n\n"
+        "Paths are relative to the BUILD file's directory and all paths must belong to the same parent directory. "
+        "For example, `sources=['dir/**']` is valid, but `sources=['top_level_file.txt']` "
+        "and `sources=['dir1/*', 'dir2/*']` are not."
     )
 
     def validate_resolved_files(self, files: Sequence[str]) -> None:

--- a/src/python/pants/backend/debian/target_types.py
+++ b/src/python/pants/backend/debian/target_types.py
@@ -13,11 +13,11 @@ from pants.engine.target import (
 from pants.util.docutil import bin_name, doc_url
 
 
-class DebianControlFile(MultipleSourcesField):
+class DebianSources(MultipleSourcesField):
     required = True
-    expected_num_files = 1
     help = (
-        "Path to a Debian control file for the package to be produced.\n\n"
+        "Paths that will be included in the package to be produced."
+        "It is required to include a Debian control file.\n\n"
         "Paths are relative to the BUILD file's directory."
     )
 
@@ -53,7 +53,7 @@ class DebianPackage(Target):
     core_fields = (
         *COMMON_TARGET_FIELDS,
         OutputPathField,
-        DebianControlFile,
+        DebianSources,
         DebianSymlinks,
         DebianInstallPrefix,
         DebianPackageDependencies,

--- a/src/python/pants/backend/debian/target_types.py
+++ b/src/python/pants/backend/debian/target_types.py
@@ -26,6 +26,12 @@ class DebianSources(MultipleSourcesField):
 
     def validate_resolved_files(self, files: Sequence[str]) -> None:
         """Check that all files are coming from the same directory."""
+        if not files:
+            raise InvalidFieldException(
+                f"The `{self.alias}` field in target `{self.address}` must "
+                f"resolve to at least one file."
+            )
+
         files_outside_dirs = [f for f in files if len(PurePath(f).parts) == 1]
         if files_outside_dirs:
             raise InvalidFieldException(

--- a/src/python/pants/backend/debian/target_types.py
+++ b/src/python/pants/backend/debian/target_types.py
@@ -40,7 +40,7 @@ class DebianSources(MultipleSourcesField):
                 f"were found: {files_outside_dirs}"
             )
 
-        directory_prefixes = set([PurePath(f).parts[0] for f in files])
+        directory_prefixes = {PurePath(f).parts[0] for f in files}
         if len(directory_prefixes) > 1:
             raise InvalidFieldException(
                 f"The `{self.alias}` field in target `{self.address}` must be paths to "

--- a/src/python/pants/backend/debian/target_types.py
+++ b/src/python/pants/backend/debian/target_types.py
@@ -28,6 +28,7 @@ class DebianSources(MultipleSourcesField):
 
     def validate_resolved_files(self, files: Sequence[str]) -> None:
         """Check that all files are coming from the same directory."""
+        super().validate_resolved_files(files)
         if not files:
             raise InvalidFieldException(
                 f"The `{self.alias}` field in target `{self.address}` must "

--- a/src/python/pants/backend/debian/target_types_test.py
+++ b/src/python/pants/backend/debian/target_types_test.py
@@ -1,0 +1,69 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from typing import Iterable, Type
+
+import pytest
+
+from pants.backend.debian.target_types import DebianSources
+from pants.build_graph.address import Address
+from pants.engine.rules import QueryRule
+from pants.engine.target import (
+    HydratedSources,
+    HydrateSourcesRequest,
+    SourcesPaths,
+    SourcesPathsRequest,
+)
+from pants.testutil.rule_runner import RuleRunner, engine_error
+
+
+@pytest.fixture
+def sources_rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            QueryRule(HydratedSources, [HydrateSourcesRequest]),
+            QueryRule(SourcesPaths, [SourcesPathsRequest]),
+        ]
+    )
+
+
+def test_sources_expected_num_files(sources_rule_runner: RuleRunner) -> None:
+    sources_rule_runner.write_files(
+        {
+            f: ""
+            for f in [
+                "f1.txt",
+                "f2.txt",
+                "dirA/f3.txt",
+                "dirB/f4.txt",
+                "dirC/f5.txt",
+                "dirC/f6.txt",
+            ]
+        }
+    )
+
+    def hydrate(sources_cls: Type[DebianSources], sources: Iterable[str]) -> HydratedSources:
+        return sources_rule_runner.request(
+            HydratedSources,
+            [
+                HydrateSourcesRequest(sources_cls(sources, Address("", target_name="example"))),
+            ],
+        )
+
+    with engine_error(contains="must resolve to at least one file"):
+        hydrate(DebianSources, [])
+
+    with engine_error(contains="must resolve to at least one file"):
+        hydrate(DebianSources, ["non-existing-dir/*"])
+
+    with engine_error(contains="Individual files were found"):
+        hydrate(DebianSources, ["f1.txt", "f2.txt"])
+
+    with engine_error(contains="Multiple directories were found"):
+        hydrate(DebianSources, ["dirA/f3.txt", "dirB/f4.txt"])
+
+    # Also check that we support valid sources declarations.
+    assert hydrate(DebianSources, ["dirC/f5.txt", "dirC/f6.txt"]).snapshot.files == (
+        "dirC/f5.txt",
+        "dirC/f6.txt",
+    )
+    assert hydrate(DebianSources, ["dirC/*"]).snapshot.files == ("dirC/f5.txt", "dirC/f6.txt")


### PR DESCRIPTION
Restoration of https://github.com/pantsbuild/pants/pull/12604

Work towards https://github.com/pantsbuild/pants/issues/12421

With this PR, it is now possible to produce a Debian package out of a `debian_package` target declaration:

```
debian_package(
    name='my-package',
    packages=[':dummy'],
    description='Useful tools installed as Debian package.',
    sources=['data-package/**/*'],
)
```

The `sources` field must have glob patterns for a single directory only and standalone files are not allowed.
The `sources` directory globs are validated after being resolved to avoid dealing with glob patterns evaluations. One of the expectations is to have `DEBIAN/control` found under `sources` as this metadata file is necessary for `dpkg-deb` to produce a Debian package.

```
$ ./pants package //:my-package
22:40:00.92 [INFO] Completed: Create a Debian package from the produced packages.
22:40:00.93 [INFO] Completed: pants.backend.debian.rules.package_debian_package
22:40:00.93 [INFO] Wrote dist/my-package.deb
```

With the sources being:

```
$ tree data-package/
data-package/
├── DEBIAN
│   └── control
└── opt
    └── company
        └── data.txt
```

Having Debian installed:

```
$ sudo dpkg -i dist/my-package.deb 
[sudo] password for username: 
Selecting previously unselected package sample-debian-package.
(Reading database ... 229092 files and directories currently installed.)
Preparing to unpack dist/my-package.deb ...
Unpacking sample-debian-package (1.0) ...
Setting up sample-debian-package (1.0) ...
$ tree /opt
/opt
├── company
│   └── data.txt
└── containerd [error opening dir]

2 directories, 1 file
```

The `packages` field is currently required, but ignored. In the future PRs, Debian package will incorporate PEX files.