### PR TITLE
[internal] Support deprecating classes.

### DIFF
--- a/src/python/pants/base/deprecated_test.py
+++ b/src/python/pants/base/deprecated_test.py
@@ -223,3 +223,22 @@ def test_is_deprecation_active() -> None:
     assert is_deprecation_active(start_version=None)
     assert is_deprecation_active(start_version="1.0.0")
     assert not is_deprecation_active(start_version=FUTURE_VERSION)
+
+
+def test_deprecation_class(caplog) -> None:
+    @deprecated(FUTURE_VERSION, "A hint!")
+    class DeprecatedClass:
+        """Doc string."""
+
+        def __init__(self, arg=42):
+            self.arg = arg
+
+    assert not caplog.records
+    assert DeprecatedClass.__name__ == "DeprecatedClass"
+    assert DeprecatedClass.__doc__ == "Doc string."
+
+    instance = DeprecatedClass(24)
+    assert instance.arg == 24
+    assert len(caplog.records) == 1
+    assert DeprecatedClass.__name__ in caplog.text
+    assert "A hint!" in caplog.text

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -141,7 +141,7 @@ def warn_deprecated_target_type(request: _WarnDeprecatedTargetRequest) -> _WarnD
     assert tgt_type.deprecated_alias_removal_version is not None
     warn_or_error(
         removal_version=tgt_type.deprecated_alias_removal_version,
-        entity=f"the target name {tgt_type.deprecated_alias}",
+        entity=f"the target name `{tgt_type.deprecated_alias}`",
         hint=(
             f"Instead, use `{tgt_type.alias}`, which behaves the same. Run `{bin_name()} "
             "update-build-files` to automatically fix your BUILD files."


### PR DESCRIPTION
The motivation is to be able to migrate the registration of a target class to another backend, like this:
```python
# pants.backend.shell.register.py

@deprecated(
    removal_version="2.12.0.dev0",
    hint=(
        "The `experimental_shell_command` target has migrated to the "
        "`pants.backend.experimental.shell` backend and renamed to `shell_command`."
    ),
)
class ExperimentalShellCommandTarget(ShellCommandTarget):
    pass


def target_types():
    return [
        ExperimentalShellCommandTarget,
        ...
```

Which will then warn in case it is being used as (the second message, the first is for the target rename):
```
09:42:42.05 [WARN] DEPRECATED: the target name `experimental_run_shell_command` will be removed in version 2.12.0.dev0.

Instead, use `run_shell_command`, which behaves the same. Run `./pants update-build-files` to automatically fix your BUILD files.
09:42:42.05 [WARN] DEPRECATED: class pants.backend.shell.register.ExperimentalShellCommandRunTarget will be removed in version 2.12.0.dev0.

The `experimental_run_shell_command` target has migrated to the `pants.backend.experimental.shell` backend and renamed to `run_shell_command`.

```
