### PR TITLE
Add the ability for option_type instances to use cls-based default/help/etc...

### DIFF
--- a/src/python/pants/option/option_types.py
+++ b/src/python/pants/option/option_types.py
@@ -15,7 +15,6 @@ _EnumT = TypeVar("_EnumT", bound=Enum)
 _ValueT = TypeVar("_ValueT")
 # NB: We don't provide constraints, as our `XListOption` types act like a set of contraints
 _ListMemberType = TypeVar("_ListMemberType")
-_SubsystemT = TypeVar("_SubsystemT")
 _MaybeClassFunc = Union[Callable[[Any], _ValueT], _ValueT]
 _HelpT = _MaybeClassFunc[str]
 
@@ -38,8 +37,6 @@ class _OptionBase(Generic[_PropType]):
     This class serves two purposes:
         - Collect registration values for your option.
         - Provide a typed property for Python usage
-
-    @TODO: option_type
 
     NOTE: Due to https://github.com/python/mypy/issues/5146 subclasses unfortunately need to provide
     overloaded `__new__` methods, as subclasses do not inherit overloaded function's annotations.
@@ -71,8 +68,8 @@ class _OptionBase(Generic[_PropType]):
         self._extra_kwargs = {}
         return self
 
+    # Override if necessary
     def get_option_type(self, subsystem_cls):
-        # Default implementation
         return type(self).option_type
 
     def get_flag_options(self, subsystem_cls) -> dict:
@@ -167,8 +164,8 @@ class _ListOptionBase(_OptionBase["tuple[_ListMemberType, ...]"], Generic[_ListM
         )
         return instance
 
+    # Override if necessary
     def get_member_type(self, subsystem_cls):
-        # Default implementation
         return type(self).member_type
 
     def get_flag_options(self, subsystem_cls) -> dict[str, Any]:

--- a/src/python/pants/option/option_types_test.py
+++ b/src/python/pants/option/option_types_test.py
@@ -160,7 +160,7 @@ def test_enum_options() -> None:
         enum_list_prop = EnumListOption(
             "--enum-list-opt", default=[MyEnum.Val1], help=lambda cls: f"{cls.dyn_help}"
         )
-        dyn_enum_list_prop = EnumListOption(
+        dyn_enum_list_prop = EnumListOption[MyEnum](
             "--dyn-enum-list-opt", default=lambda cls: [cls.dyn_enum_val], help=""
         )
         defaultless_enum_list_prop = EnumListOption(

--- a/src/python/pants/option/option_types_test.py
+++ b/src/python/pants/option/option_types_test.py
@@ -151,9 +151,9 @@ def test_enum_options() -> None:
         enum_prop = EnumOption(
             "--enum-opt", default=MyEnum.Val1, help=lambda cls: f"{cls.dyn_help}"
         )
-        dyn_enum_prop = EnumOption(
+        dyn_enum_prop = EnumOption[MyEnum](
             "--dyn-enum-opt",
-            default=lambda cls: cls.dyn_enum_val,  # type: ignore[no-any-return]
+            default=lambda cls: cls.dyn_enum_val,
             help="",
         )
         optional_enum_prop = EnumOption("--optional-enum-opt", enum_type=MyEnum, help="")

--- a/src/python/pants/option/subsystem.py
+++ b/src/python/pants/option/subsystem.py
@@ -11,7 +11,7 @@ from typing import Any, ClassVar, TypeVar
 
 from pants.engine.internals.selectors import AwaitableConstraints, Get
 from pants.option.errors import OptionsError
-from pants.option.option_types import _OptionBase
+from pants.option.option_types import OptionsInfo
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.scope import Scope, ScopedOptions, ScopeInfo, normalize_scope
 
@@ -104,8 +104,10 @@ class Subsystem(metaclass=ABCMeta):
         # NB: Since registration ordering matters (it impacts `help` output), we register these in
         # class attribute order, starting from the base class down.
         for class_ in reversed(inspect.getmro(cls)):
-            for attr in class_.__dict__.values():
-                if isinstance(attr, _OptionBase):
+            for attrname in class_.__dict__.keys():
+                # NB: We use attrname and getattr to trigger descriptors
+                attr = getattr(cls, attrname)
+                if isinstance(attr, OptionsInfo):
                     register(*attr.flag_names, **attr.flag_options)
 
     @classmethod


### PR DESCRIPTION
In order to support Subsystem "base" classes, where values are defined in the subclass, we should allow instances constructed with "classfunction" lambdas, and delay evaluation until we're registering options.

This is needed for classes such as [`ExternalTool`](https://github.com/pantsbuild/pants/blob/1d828786c3c0f352e7811e29dd80f7877f5e170c/src/python/pants/core/util_rules/external_tool.py).

Unfortunately this change is quite pervasive to `option_types` :disappointed: 

Main refactors:
- The default/help/enum types are now possibly classfunctions
- When the descriptor is "gotten" it returns an instance of `OptionsInfo`
- We now collect options through `get_*` methods. Namely `get_flag_options` (but also `get_option_type` and `get_member_type`)


[ci rust]
[ci skip-build-wheels]