### PR TITLE
py_awslambda: pass through `include_requirements:bool` to `pex_binary`

### DIFF
--- a/src/python/pants/backend/awslambda/python/rules.py
+++ b/src/python/pants/backend/awslambda/python/rules.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 from pants.backend.awslambda.python.target_types import (
     PythonAwsLambdaHandlerField,
+    PythonAwsLambdaIncludeRequirements,
     PythonAwsLambdaRuntime,
     ResolvedPythonAwsHandler,
     ResolvePythonAwsHandlerRequest,
@@ -47,6 +48,7 @@ class PythonAwsLambdaFieldSet(PackageFieldSet):
     required_fields = (PythonAwsLambdaHandlerField, PythonAwsLambdaRuntime)
 
     handler: PythonAwsLambdaHandlerField
+    include_requirements: PythonAwsLambdaIncludeRequirements
     runtime: PythonAwsLambdaRuntime
     output_path: OutputPathField
 
@@ -94,6 +96,7 @@ async def package_python_awslambda(
     pex_request = PexFromTargetsRequest(
         addresses=[field_set.address],
         internal_only=False,
+        include_requirements=field_set.include_requirements.value,
         output_filename=output_filename,
         platforms=PexPlatforms([platform_str]),
         additional_args=additional_pex_args,

--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -20,6 +20,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     AsyncFieldMixin,
+    BoolField,
     Dependencies,
     DependenciesRequest,
     ExplicitlyProvidedDependencies,
@@ -176,6 +177,14 @@ async def inject_lambda_handler_dependency(
     return InjectedDependencies(unambiguous_owners)
 
 
+class PythonAwsLambdaIncludeRequirements(BoolField):
+    alias = "include_requirements"
+    default = True
+    help = (
+        "Whether to resolve requirements and include them in the Pex. See "
+        "https://docs.aws.amazon.com/lambda/latest/dg/lambda-python.html."
+    )
+
 class PythonAwsLambdaRuntime(StringField):
     PYTHON_RUNTIME_REGEX = r"python(?P<major>\d)\.(?P<minor>\d+)"
 
@@ -210,6 +219,7 @@ class PythonAWSLambda(Target):
         OutputPathField,
         PythonAwsLambdaDependencies,
         PythonAwsLambdaHandlerField,
+        PythonAwsLambdaIncludeRequirements,
         PythonAwsLambdaRuntime,
         PythonResolveField,
     )

--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -181,8 +181,9 @@ class PythonAwsLambdaIncludeRequirements(BoolField):
     alias = "include_requirements"
     default = True
     help = (
-        "Whether to resolve requirements and include them in the Pex. See "
-        "https://docs.aws.amazon.com/lambda/latest/dg/lambda-python.html."
+        "Whether to resolve requirements and include them in the Pex. This is "
+        "most useful with Lambda Layers to make code uploads smaller when "
+        "deps are in layers. https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html"
     )
 
 

--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -185,6 +185,7 @@ class PythonAwsLambdaIncludeRequirements(BoolField):
         "https://docs.aws.amazon.com/lambda/latest/dg/lambda-python.html."
     )
 
+
 class PythonAwsLambdaRuntime(StringField):
     PYTHON_RUNTIME_REGEX = r"python(?P<major>\d)\.(?P<minor>\d+)"
 


### PR DESCRIPTION
PR #13894 added `include_requirements:bool` flag to exclude third-party deps from `pex_binary` artifacts. 

I have a similar need for `python_awslambda` builds, which already is using the `pex_binary` Request rule. This PR adds a `include_requirements` field to `python_awslambda` (default=True, not changing current behavior) and passes that to `PexFromTargetsRequest`. 


Some alternatives to this feature suggested in slack [full thread here](https://pantsbuild.slack.com/archives/C01CQHVDMMW/p1644844772442459): 
1. transitive excludes with `!!`: https://www.pantsbuild.org/docs/targets#dependencies-field on specific dependencies
2. reusing the same lambdex zip and alter the `LAMBDEX_ENTRY_POINT` on the functions themselves: https://github.com/pantsbuild/lambdex#controlling-runtime-execution


Alternative 1 requires adding a new exclusion every time a new third-party dep is added to any of your in-repo dependencies, meaning extra work & extra config.

Alternative 2 does not allow the use of [Lambda Layers](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html) to upload expensive/large/slow-changing deps once, and redeploy only your first-party changes.