### PR TITLE
[internal] fix a typo in test lockfiles

### DIFF
--- a/src/python/pants/jvm/resolve/coursier_test_util.py
+++ b/src/python/pants/jvm/resolve/coursier_test_util.py
@@ -25,7 +25,7 @@ class TestCoursierWrapper:
         return (
             JVMLockfileMetadata.new(requirements)
             .add_header_to_lockfile(
-                self.lockfile.to_serialized(), regenerate_command=f"{bin_name()} generate_lockfiles"
+                self.lockfile.to_serialized(), regenerate_command=f"{bin_name()} generate-lockfiles"
             )
             .decode()
         )


### PR DESCRIPTION
Fix a typo in test lockfiles. Ultimately doesn't affect anything of consequence but it is a nit.

[ci skip-build-wheels]