### PR TITLE
Fix address parse bug in `update-build-files --fix-python-macros`.

### DIFF
--- a/src/python/pants/backend/python/macros/deprecation_fixers.py
+++ b/src/python/pants/backend/python/macros/deprecation_fixers.py
@@ -16,7 +16,7 @@ from pants.backend.python.lint.flake8.subsystem import Flake8
 from pants.backend.python.lint.pylint.subsystem import Pylint
 from pants.backend.python.target_types import PythonRequirementsFileTarget, PythonRequirementTarget
 from pants.backend.python.typecheck.mypy.subsystem import MyPy
-from pants.build_graph.address import InvalidAddress
+from pants.build_graph.address import AddressParseException, InvalidAddress
 from pants.core.goals.update_build_files import (
     DeprecationFixerRequest,
     RewrittenBuildFile,
@@ -170,7 +170,7 @@ def maybe_address(val: str, renames: MacroRenames, *, relative_to: str | None) -
         # we know that none of the generated targets will be file addresses. That is, we can
         # ignore file addresses.
         addr = AddressInput.parse(val, relative_to=relative_to).dir_to_address()
-    except InvalidAddress:
+    except (AddressParseException, InvalidAddress):
         return None
 
     return addr if addr in renames.generated else None

--- a/src/python/pants/backend/python/macros/deprecation_fixers_test.py
+++ b/src/python/pants/backend/python/macros/deprecation_fixers_test.py
@@ -16,6 +16,7 @@ from pants.backend.python.macros.deprecation_fixers import (
     OptionsChecker,
     OptionsCheckerRequest,
     UpdatePythonMacrosRequest,
+    maybe_address,
 )
 from pants.backend.python.macros.pipenv_requirements_caof import PipenvRequirementsCAOF
 from pants.backend.python.macros.poetry_requirements_caof import PoetryRequirementsCAOF
@@ -275,3 +276,10 @@ def test_check_options(rule_runner: RuleRunner, caplog) -> None:
     assert "pylint" not in caplog.text
     assert "mypy" not in caplog.text
     assert "python-thrift" not in caplog.text
+
+
+def test_invalid_address() -> None:
+    assert (
+        maybe_address("no/address@here:123", MacroRenames((), FrozenDict()), relative_to=None)
+        is None
+    )


### PR DESCRIPTION
This issue was introduced by #14346 

I made the change as small as possible. However, I think it might be more correct to catch the engine exception in the `Address.parse()` method, and re-throw as `InvalidAddress` from there.

wdyt?
