### PR TITLE
jvm: teach dependency inference about multiple resolves

### DIFF
--- a/src/python/pants/backend/java/dependency_inference/rules.py
+++ b/src/python/pants/backend/java/dependency_inference/rules.py
@@ -126,7 +126,7 @@ async def infer_java_dependencies_and_exports_via_source_analysis(
     dependencies: OrderedSet[Address] = OrderedSet()
     exports: OrderedSet[Address] = OrderedSet()
     for typ in types:
-        first_party_matches = first_party_dep_map.symbols.addresses_for_symbol(typ)
+        first_party_matches = first_party_dep_map.symbols.addresses_for_symbol(typ, resolve=resolve)
         third_party_matches = (
             third_party_artifact_mapping.addresses_for_symbol(typ, resolve)
             if java_infer_subsystem.third_party_imports

--- a/src/python/pants/backend/java/dependency_inference/symbol_mapper.py
+++ b/src/python/pants/backend/java/dependency_inference/symbol_mapper.py
@@ -35,14 +35,18 @@ class FirstPartyJavaTargetsMappingRequest(FirstPartyMappingRequest):
 
 @rule(desc="Map all first party Java targets to their packages", level=LogLevel.DEBUG)
 async def map_first_party_java_targets_to_symbols(
-    _: FirstPartyJavaTargetsMappingRequest, java_targets: AllJavaTargets,
+    _: FirstPartyJavaTargetsMappingRequest,
+    java_targets: AllJavaTargets,
     jvm: JvmSubsystem,
 ) -> SymbolMap:
     source_analysis = await MultiGet(
         Get(JavaSourceDependencyAnalysis, SourceFilesRequest([target[JavaSourceField]]))
         for target in java_targets
     )
-    address_and_analysis = zip([(tgt.address, tgt[JvmResolveField].normalized_value(jvm)) for tgt in java_targets], source_analysis)
+    address_and_analysis = zip(
+        [(tgt.address, tgt[JvmResolveField].normalized_value(jvm)) for tgt in java_targets],
+        source_analysis,
+    )
 
     dep_map = SymbolMap()
     for (address, resolve), analysis in address_and_analysis:

--- a/src/python/pants/backend/scala/dependency_inference/rules.py
+++ b/src/python/pants/backend/scala/dependency_inference/rules.py
@@ -74,7 +74,9 @@ async def infer_scala_dependencies_via_source_analysis(
 
     dependencies: OrderedSet[Address] = OrderedSet()
     for symbol in symbols:
-        first_party_matches = first_party_symbol_map.symbols.addresses_for_symbol(symbol)
+        first_party_matches = first_party_symbol_map.symbols.addresses_for_symbol(
+            symbol, resolve=resolve
+        )
         third_party_matches = third_party_artifact_mapping.addresses_for_symbol(symbol, resolve)
         matches = first_party_matches.union(third_party_matches)
         if not matches:

--- a/src/python/pants/backend/scala/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/rules_test.py
@@ -293,3 +293,13 @@ def test_multi_resolve_dependency_inference(rule_runner: RuleRunner) -> None:
     assert deps == InferredDependencies(
         [Address("lib", relative_file_path="Library.scala", target_name="lib_2_13")]
     )
+
+    tgt = rule_runner.get_target(
+        Address("user", relative_file_path="Main.scala", target_name="user_2_12")
+    )
+    deps = rule_runner.request(
+        InferredDependencies, [InferScalaSourceDependencies(tgt[ScalaSourceField])]
+    )
+    assert deps == InferredDependencies(
+        [Address("lib", relative_file_path="Library.scala", target_name="lib_2_12")]
+    )

--- a/src/python/pants/backend/scala/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/rules_test.py
@@ -266,6 +266,8 @@ def test_multi_resolve_dependency_inference(rule_runner: RuleRunner) -> None:
                 """\
             package org.pantsbuild.user
 
+            import org.pantsbuild.lib.Library
+
             object Main {
               def main(args: Array[String]): Unit = {
                 Library.grok()


### PR DESCRIPTION
As described in https://github.com/pantsbuild/pants/issues/14293, dependency inference does not currently work properly for first-party sources when multiple resolves are configured. This PR fixes the issue for JVM (Java/Scala) first-party-sources.

The solution is similar to what was already done for third-party dependency inference: make the resolve part of the key in the symbol map. With this change, dependency inference looks up symbols by both name and resolve.