### PR TITLE
[internal] Add `Address.parameters_repr`

### DIFF
--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -322,6 +322,13 @@ class Address(EngineAwareParameter):
         return self._target_name
 
     @property
+    def parameters_repr(self) -> str:
+        if not self.parameters:
+            return ""
+        rhs = ",".join(f"{k}={v}" for k, v in self.parameters.items())
+        return f"@{rhs}"
+
+    @property
     def spec(self) -> str:
         """The canonical string representation of the Address.
 
@@ -333,7 +340,11 @@ class Address(EngineAwareParameter):
         prefix = "//" if not self.spec_path else ""
         if self._relative_file_path is None:
             path = self.spec_path
-            target = "" if self._target_name is None and self.generated_name else self.target_name
+            target = (
+                ""
+                if self._target_name is None and (self.generated_name or self.parameters)
+                else self.target_name
+            )
         else:
             path = self.filename
             parent_prefix = "../" * self._relative_file_path.count(os.path.sep)
@@ -343,20 +354,8 @@ class Address(EngineAwareParameter):
                 else f"{parent_prefix}{self.target_name}"
             )
         target_sep = ":" if target else ""
-        if self.parameters:
-            params_sep = "@"
-            params = ",".join(f"{k}={v}" for k, v in self.parameters.items())
-        else:
-            params_sep = ""
-            params = ""
-        if self.generated_name is None:
-            generated_sep = ""
-            generated = ""
-        else:
-            generated_sep = "#"
-            generated = self.generated_name
-
-        return f"{prefix}{path}{target_sep}{target}{params_sep}{params}{generated_sep}{generated}"
+        generated = "" if self.generated_name is None else f"#{self.generated_name}"
+        return f"{prefix}{path}{target_sep}{target}{self.parameters_repr}{generated}"
 
     @property
     def path_safe_spec(self) -> str:

--- a/src/python/pants/build_graph/address_test.py
+++ b/src/python/pants/build_graph/address_test.py
@@ -289,10 +289,6 @@ def test_address_spec() -> None:
     assert_spec(Address("", target_name="root"), expected="//:root", expected_path_spec=".root")
 
     assert_spec(
-        Address("a/b", parameters={"k": "v"}), expected="a/b:b@k=v", expected_path_spec="a.b@@k=v"
-    )
-
-    assert_spec(
         Address("a/b", generated_name="generated"),
         expected="a/b#generated",
         expected_path_spec="a.b@generated",
@@ -348,6 +344,34 @@ def test_address_spec() -> None:
         expected="a/b/subdir/dir2/f.txt:../../b",
         expected_path_spec="a.b.subdir.dir2.f.txt@@b",
     )
+
+    assert_spec(
+        Address("", target_name="template", parameters={"k1": "v", "k2": "v"}),
+        expected="//:template@k1=v,k2=v",
+        expected_path_spec=".template@@k1=v,k2=v",
+    )
+    assert_spec(
+        Address("a/b", parameters={"k1": "v", "k2": "v"}),
+        expected="a/b@k1=v,k2=v",
+        expected_path_spec="a.b@@k1=v,k2=v",
+    )
+    assert_spec(
+        Address("a/b", generated_name="gen", parameters={"k": "v"}),
+        expected="a/b@k=v#gen",
+        expected_path_spec="a.b@@k=v@gen",
+    )
+    assert_spec(
+        Address("a/b", relative_file_path="f.ext", parameters={"k": "v"}),
+        expected="a/b/f.ext@k=v",
+        expected_path_spec="a.b.f.ext@@k=v",
+    )
+
+
+@pytest.mark.parametrize(
+    "params,expected", (({}, ""), ({"k": "v"}, "@k=v"), ({"k1": "v", "k2": "v"}, "@k1=v,k2=v"))
+)
+def test_address_parameters_repr(params: dict[str, str], expected: str) -> None:
+    assert Address("", target_name="foo", parameters=params).parameters_repr == expected
 
 
 def test_address_maybe_convert_to_target_generator() -> None:

--- a/src/python/pants/engine/internals/parametrize_test.py
+++ b/src/python/pants/engine/internals/parametrize_test.py
@@ -48,20 +48,20 @@ def test_to_parameters_failure(exception_str: str, args: list[Any], kwargs: dict
     "expected,fields",
     [
         ([("a:a", {"f": "b"})], {"f": "b"}),
-        ([("a:a@f=b", {"f": "b"})], {"f": Parametrize("b")}),
+        ([("a@f=b", {"f": "b"})], {"f": Parametrize("b")}),
         (
             [
-                ("a:a@f=b", {"f": "b"}),
-                ("a:a@f=c", {"f": "c"}),
+                ("a@f=b", {"f": "b"}),
+                ("a@f=c", {"f": "c"}),
             ],
             {"f": Parametrize("b", "c")},
         ),
         (
             [
-                ("a:a@f=b,x=d", {"f": "b", "x": "d"}),
-                ("a:a@f=b,x=e", {"f": "b", "x": "e"}),
-                ("a:a@f=c,x=d", {"f": "c", "x": "d"}),
-                ("a:a@f=c,x=e", {"f": "c", "x": "e"}),
+                ("a@f=b,x=d", {"f": "b", "x": "d"}),
+                ("a@f=b,x=e", {"f": "b", "x": "e"}),
+                ("a@f=c,x=d", {"f": "c", "x": "d"}),
+                ("a@f=c,x=e", {"f": "c", "x": "e"}),
             ],
             {"f": Parametrize("b", "c"), "x": Parametrize("d", "e")},
         ),


### PR DESCRIPTION
This method will be useful for part of https://github.com/pantsbuild/pants/issues/14493, as we will need `engine/internals/parser.py` to determine the string representation of parametrization.

This also improves testing for the functionality we already had.

[ci skip-rust]
[ci skip-build-wheels]