### PR TITLE
Fix target parametrization by making it more eager

### DIFF
--- a/src/python/pants/backend/python/macros/pipenv_requirements.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements.py
@@ -71,10 +71,7 @@ async def generate_from_pipenv_requirement(
     generator = request.generator
     lock_rel_path = generator[PipenvSourceField].value
     lock_full_path = generator[PipenvSourceField].file_path
-    overrides = {
-        canonicalize_project_name(k): v
-        for k, v in request.require_unparametrized_overrides().items()
-    }
+    overrides = {canonicalize_project_name(k): v for k, v in request.overrides.items()}
 
     file_tgt = PythonRequirementsFileTarget(
         {PythonRequirementsFileSourcesField.alias: lock_rel_path},

--- a/src/python/pants/backend/python/macros/poetry_requirements.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements.py
@@ -421,10 +421,7 @@ async def generate_from_python_requirement(
     generator = request.generator
     pyproject_rel_path = generator[PoetryRequirementsSourceField].value
     pyproject_full_path = generator[PoetryRequirementsSourceField].file_path
-    overrides = {
-        canonicalize_project_name(k): v
-        for k, v in request.require_unparametrized_overrides().items()
-    }
+    overrides = {canonicalize_project_name(k): v for k, v in request.overrides.items()}
 
     file_tgt = PythonRequirementsFileTarget(
         {PythonRequirementsFileSourcesField.alias: pyproject_rel_path},

--- a/src/python/pants/backend/python/macros/python_requirements.py
+++ b/src/python/pants/backend/python/macros/python_requirements.py
@@ -78,10 +78,7 @@ async def generate_from_python_requirement(
     generator = request.generator
     requirements_rel_path = generator[PythonRequirementsSourceField].value
     requirements_full_path = generator[PythonRequirementsSourceField].file_path
-    overrides = {
-        canonicalize_project_name(k): v
-        for k, v in request.require_unparametrized_overrides().items()
-    }
+    overrides = {canonicalize_project_name(k): v for k, v in request.overrides.items()}
 
     file_tgt = PythonRequirementsFileTarget(
         {PythonRequirementsFileSourcesField.alias: requirements_rel_path},

--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -93,7 +93,7 @@ async def generate_targets_from_pex_binaries(
 ) -> GeneratedTargets:
     generator_addr = request.generator.address
     entry_points_field = request.generator[PexEntryPointsField].value or []
-    overrides = request.require_unparametrized_overrides()
+    overrides = request.overrides
     inherited_fields = {
         field.alias: field.value
         for field in request.generator.field_values.values()

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -400,12 +400,14 @@ class Address(EngineAwareParameter):
         )
 
     def maybe_convert_to_target_generator(self) -> Address:
-        """If this address is generated or parametrized, convert it to its generator target.
+        """If this address is generated, convert it to its generator target.
 
         Otherwise, return self unmodified.
         """
-        if self.is_generated_target or self.is_parametrized:
-            return self.__class__(self.spec_path, target_name=self._target_name)
+        if self.is_generated_target:
+            return self.__class__(
+                self.spec_path, target_name=self._target_name, parameters=self.parameters
+            )
         return self
 
     def create_generated(self, generated_name: str) -> Address:

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -42,7 +42,6 @@ from pants.engine.internals.graph import (
     TransitiveExcludesNotSupportedError,
     _TargetParametrizations,
 )
-from pants.engine.internals.parametrize import Parametrize
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.rules import Get, MultiGet, rule
 from pants.engine.target import (
@@ -923,7 +922,6 @@ def generated_targets_rule_runner() -> RuleRunner:
             QueryRule(_TargetParametrizations, [Address]),
         ],
         target_types=[MockTargetGenerator, MockGeneratedTarget],
-        objects={"parametrize": Parametrize},
     )
 
 

--- a/src/python/pants/engine/internals/target_adaptor.py
+++ b/src/python/pants/engine/internals/target_adaptor.py
@@ -7,11 +7,16 @@ from typing import Any
 
 from typing_extensions import final
 
+from pants.build_graph.address import Address
+
 
 @final
 class TargetAdaptor:
-    """A light-weight object to store target information before being converted into the Target
-    API."""
+    """A light-weight object to store target information before being converted into the Target API.
+
+    Note that the `name` may include parametrization, e.g. `tgt@k=v`. It is not strictly equal to
+    `Address.target_name`.
+    """
 
     def __init__(self, type_alias: str, name: str, **kwargs: Any) -> None:
         self.type_alias = type_alias
@@ -29,3 +34,18 @@ class TargetAdaptor:
             and self.name == other.name
             and self.kwargs == other.kwargs
         )
+
+    def to_address(self, spec_path: str) -> Address:
+        if "@" in self.name:
+            tgt, params_str = self.name.split("@")
+            parameters = {}
+            for kv in params_str.split(","):
+                k, v = kv.split("=", 1)
+                parameters[k] = v
+        else:
+            tgt = self.name
+            parameters = None
+
+        # Because a `TargetAdaptor` cannot represent a generated target, we don't need to worry
+        # about those parts of the address.
+        return Address(spec_path, target_name=tgt, parameters=parameters)

--- a/src/python/pants/engine/internals/target_adaptor.py
+++ b/src/python/pants/engine/internals/target_adaptor.py
@@ -36,15 +36,15 @@ class TargetAdaptor:
         )
 
     def to_address(self, spec_path: str) -> Address:
+        parameters = {}
         if "@" in self.name:
             tgt, params_str = self.name.split("@")
-            parameters = {}
+
             for kv in params_str.split(","):
                 k, v = kv.split("=", 1)
                 parameters[k] = v
         else:
             tgt = self.name
-            parameters = None
 
         # Because a `TargetAdaptor` cannot represent a generated target, we don't need to worry
         # about those parts of the address.

--- a/src/python/pants/engine/internals/target_adaptor_test.py
+++ b/src/python/pants/engine/internals/target_adaptor_test.py
@@ -1,0 +1,21 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import pytest
+
+from pants.build_graph.address import Address
+from pants.engine.internals.target_adaptor import TargetAdaptor
+
+
+@pytest.mark.parametrize(
+    "tgt_adaptor_name,expected",
+    (
+        ("tgt", Address("", target_name="tgt")),
+        ("tgt@k=v", Address("", target_name="tgt", parameters={"k": "v"})),
+        ("tgt@k1=v,k2=v", Address("", target_name="tgt", parameters={"k1": "v", "k2": "v"})),
+    ),
+)
+def test_target_adaptor_to_address(tgt_adaptor_name: str, expected: Address) -> None:
+    assert TargetAdaptor("some_tgt_alias", tgt_adaptor_name).to_address("") == expected

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -27,6 +27,7 @@ from pants.engine.fs import Digest, PathGlobs, PathGlobsAndRoot, Snapshot, Works
 from pants.engine.goal import Goal
 from pants.engine.internals import native_engine
 from pants.engine.internals.native_engine import PyExecutor
+from pants.engine.internals.parametrize import Parametrize
 from pants.engine.internals.scheduler import ExecutionError, SchedulerSession
 from pants.engine.internals.selectors import Effect, Get, Params
 from pants.engine.internals.session import SessionValues
@@ -221,7 +222,8 @@ class RuleRunner:
         build_config_builder = BuildConfiguration.Builder()
         build_config_builder.register_aliases(
             BuildFileAliases(
-                objects=objects, context_aware_object_factories=context_aware_object_factories
+                objects={"parametrize": Parametrize, **(objects or {})},
+                context_aware_object_factories=context_aware_object_factories,
             )
         )
         build_config_builder.register_rules("_dummy_for_test_", all_rules)


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/14493.

As explained there, a "template target" is not a real target: it is _not_ addressable. It's nonsensical to have an `Address` for the template, and doing so was causing `AllTargets` and `./pants list ::` to fail because Pants thought that the template was a valid target.

Another example of why this was a problem: before, we lied saying that you could refer to the "template" target, which doesn't actually exist:

```
E               raise ResolveError.did_you_mean(
E           pants.base.exceptions.ResolveError: 'lib' was not found in namespace ''. Did you mean one of:
E             :artifact
E             :lib
```

Now:

```
E               raise ResolveError.did_you_mean(
E           pants.base.exceptions.ResolveError: 'lib' was not found in namespace ''. Did you mean one of:
E             :artifact@resolve=a
E             :artifact@resolve=b
E             :artifact@resolve=c
E             :lib@resolve=a
E             :lib@resolve=b
E             :lib@resolve=c
```

The solution is to apply parametrization extremely eagerly: at BUILD file parsing time. That way, we only ever parse `TargetAdaptor`s that actually exist and are valid.

## Target generation & `overrides`

This already supports parametrization of target generators, as shown in `graph_test.py`:

```python
java_sources(resolve=parametrize("a", "b"))
```

This will generate two `java_sources` target generators: `dir@resolve=a` and `dir@resolve=b`. Then, those will generate their own generated targets: `dir/Foo.java@resolve=a` and `dir/Foo.java@resolve=b`, and so on.

This does not yet support `overrides`, but there is a path forward: we don't eagerly evaluate nested `parametrize()` calls, so target generation rules can apply the parametrization at generation time.

## TODOs

* Add a test to `build_files_test.py` for `AddressSpecs` that uses parametrization.
* Implement `overrides` support.
* Consider refactoring/renaming the code from https://github.com/pantsbuild/pants/pull/14408 and https://github.com/pantsbuild/pants/pull/14377, e.g. `_TargetParametrizations`.