### PR TITLE
Per-resolve scala plugins

### DIFF
--- a/src/python/pants/backend/scala/compile/scalac.py
+++ b/src/python/pants/backend/scala/compile/scalac.py
@@ -102,7 +102,10 @@ async def compile_scala_source(
     )
 
     plugins_ = await MultiGet(
-        Get(ScalaPluginTargetsForTarget, ScalaPluginsForTargetRequest(target))
+        Get(
+            ScalaPluginTargetsForTarget,
+            ScalaPluginsForTargetRequest(target, request.resolve.name),
+        )
         for target in request.component.members
     )
     plugins_request = ScalaPluginsRequest.from_target_plugins(plugins_, request.resolve)

--- a/src/python/pants/backend/scala/compile/scalac.py
+++ b/src/python/pants/backend/scala/compile/scalac.py
@@ -10,8 +10,10 @@ from itertools import chain
 from pants.backend.java.target_types import JavaFieldSet, JavaGeneratorFieldSet, JavaSourceField
 from pants.backend.scala.compile.scalac_plugins import (
     GlobalScalacPlugins,
-    ScalaPluginsForTarget,
+    ScalaPlugins,
     ScalaPluginsForTargetRequest,
+    ScalaPluginsRequest,
+    ScalaPluginTargetsForTarget,
 )
 from pants.backend.scala.compile.scalac_plugins import rules as scalac_plugins_rules
 from pants.backend.scala.subsystems.scala import ScalaSubsystem
@@ -99,10 +101,13 @@ async def compile_scala_source(
         ),
     )
 
-    plugins = await MultiGet(
-        Get(ScalaPluginsForTarget, ScalaPluginsForTargetRequest(target))
+    plugins_ = await MultiGet(
+        Get(ScalaPluginTargetsForTarget, ScalaPluginsForTargetRequest(target))
         for target in request.component.members
     )
+    plugins_request = ScalaPluginsRequest.from_target_plugins(plugins_, request.resolve)
+    local_plugins = await Get(ScalaPlugins, ScalaPluginsRequest, plugins_request)
+
     component_members_and_scala_source_files = [
         (target, sources)
         for target, sources in component_members_and_source_files
@@ -124,6 +129,7 @@ async def compile_scala_source(
 
     toolcp_relpath = "__toolcp"
     scalac_plugins_relpath = "__plugincp"
+    local_scalac_plugins_relpath = "__localplugincp"
     usercp = "__cp"
 
     user_classpath = Classpath(direct_dependency_classpath_entries, request.resolve)
@@ -159,6 +165,7 @@ async def compile_scala_source(
     extra_immutable_input_digests = {
         toolcp_relpath: tool_classpath.digest,
         scalac_plugins_relpath: scalac_plugins.classpath.digest,
+        local_scalac_plugins_relpath: local_plugins.classpath.digest,
     }
     extra_nailgun_keys = tuple(extra_immutable_input_digests)
     extra_immutable_input_digests.update(user_classpath.immutable_inputs(prefix=usercp))
@@ -176,6 +183,7 @@ async def compile_scala_source(
                 "-bootclasspath",
                 ":".join(tool_classpath.classpath_entries(toolcp_relpath)),
                 *scalac_plugins.args(scalac_plugins_relpath),
+                *local_plugins.args(local_scalac_plugins_relpath),
                 *(("-classpath", classpath_arg) if classpath_arg else ()),
                 *scalac.args,
                 "-d",

--- a/src/python/pants/backend/scala/compile/scalac.py
+++ b/src/python/pants/backend/scala/compile/scalac.py
@@ -8,7 +8,11 @@ from dataclasses import dataclass
 from itertools import chain
 
 from pants.backend.java.target_types import JavaFieldSet, JavaGeneratorFieldSet, JavaSourceField
-from pants.backend.scala.compile.scalac_plugins import GlobalScalacPlugins
+from pants.backend.scala.compile.scalac_plugins import (
+    GlobalScalacPlugins,
+    ScalaPluginsForTarget,
+    ScalaPluginsForTargetRequest,
+)
 from pants.backend.scala.compile.scalac_plugins import rules as scalac_plugins_rules
 from pants.backend.scala.subsystems.scala import ScalaSubsystem
 from pants.backend.scala.subsystems.scalac import Scalac
@@ -95,6 +99,10 @@ async def compile_scala_source(
         ),
     )
 
+    plugins = await MultiGet(
+        Get(ScalaPluginsForTarget, ScalaPluginsForTargetRequest(target))
+        for target in request.component.members
+    )
     component_members_and_scala_source_files = [
         (target, sources)
         for target, sources in component_members_and_source_files

--- a/src/python/pants/backend/scala/compile/scalac_plugins.py
+++ b/src/python/pants/backend/scala/compile/scalac_plugins.py
@@ -178,7 +178,7 @@ async def resolve_scala_plugins_for_target(
         if plugin_name not in plugins:
             raise Exception(f"Could not find Scala plugin `{plugin_name}` in resolve `{resolve}`")
 
-    plugin_targets, artifact_targets = zip(*plugins.values())
+    plugin_targets, artifact_targets = zip(*plugins.values()) if plugins else ((), ())
     return ScalaPluginsForTarget(Targets(plugin_targets), Targets(artifact_targets))
 
 

--- a/src/python/pants/backend/scala/dependency_inference/rules.py
+++ b/src/python/pants/backend/scala/dependency_inference/rules.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from pants.backend.scala.compile.scalac_plugins import (
-    ScalaPluginsForTarget,
     ScalaPluginsForTargetRequest,
+    ScalaPluginTargetsForTarget,
 )
 from pants.backend.scala.dependency_inference import scala_parser, symbol_mapper
 from pants.backend.scala.dependency_inference.scala_parser import ScalaSourceDependencyAnalysis
@@ -178,7 +178,7 @@ async def inject_scala_plugin_dependencies(
     if not target.has_field(JvmResolveField):
         return InjectedDependencies()
 
-    scala_plugins = await Get(ScalaPluginsForTarget, ScalaPluginsForTargetRequest(target))
+    scala_plugins = await Get(ScalaPluginTargetsForTarget, ScalaPluginsForTargetRequest(target))
 
     plugin_addresses = [target.address for target in scala_plugins.artifacts]
 

--- a/src/python/pants/backend/scala/dependency_inference/rules.py
+++ b/src/python/pants/backend/scala/dependency_inference/rules.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from pants.backend.scala.compile import scalac_plugins
 from pants.backend.scala.compile.scalac_plugins import (
-    ScalaPluginsForTargetRequest,
+    ScalaPluginsForTargetWithoutResolveRequest,
     ScalaPluginTargetsForTarget,
 )
 from pants.backend.scala.dependency_inference import scala_parser, symbol_mapper
@@ -178,7 +179,9 @@ async def inject_scala_plugin_dependencies(
     if not target.has_field(JvmResolveField):
         return InjectedDependencies()
 
-    scala_plugins = await Get(ScalaPluginTargetsForTarget, ScalaPluginsForTargetRequest(target))
+    scala_plugins = await Get(
+        ScalaPluginTargetsForTarget, ScalaPluginsForTargetWithoutResolveRequest(target)
+    )
 
     plugin_addresses = [target.address for target in scala_plugins.artifacts]
 
@@ -190,6 +193,7 @@ def rules():
         *collect_rules(),
         *artifact_mapper.rules(),
         *scala_parser.rules(),
+        *scalac_plugins.rules(),
         *symbol_mapper.rules(),
         UnionRule(InferDependenciesRequest, InferScalaSourceDependencies),
         UnionRule(InjectDependenciesRequest, InjectScalaLibraryDependencyRequest),

--- a/src/python/pants/backend/scala/dependency_inference/rules.py
+++ b/src/python/pants/backend/scala/dependency_inference/rules.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from pants.backend.scala.compile.scalac_plugins import AllScalaPluginTargets
+from pants.backend.scala.compile.scalac_plugins import (
+    ScalaPluginsForTarget,
+    ScalaPluginsForTargetRequest,
+)
 from pants.backend.scala.dependency_inference import scala_parser, symbol_mapper
 from pants.backend.scala.dependency_inference.scala_parser import ScalaSourceDependencyAnalysis
 from pants.backend.scala.resolve.lockfile import (
@@ -15,17 +18,9 @@ from pants.backend.scala.resolve.lockfile import (
 )
 from pants.backend.scala.subsystems.scala import ScalaSubsystem
 from pants.backend.scala.subsystems.scala_infer import ScalaInferSubsystem
-from pants.backend.scala.subsystems.scalac import Scalac
-from pants.backend.scala.target_types import (
-    ScalaConsumedPluginNamesField,
-    ScalacPluginArtifactField,
-    ScalacPluginNameField,
-    ScalaDependenciesField,
-    ScalaSourceField,
-)
-from pants.build_graph.address import Address, AddressInput
+from pants.backend.scala.target_types import ScalaDependenciesField, ScalaSourceField
+from pants.build_graph.address import Address
 from pants.core.util_rules.source_files import SourceFilesRequest
-from pants.engine.addresses import Addresses
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     Dependencies,
@@ -35,8 +30,6 @@ from pants.engine.target import (
     InferredDependencies,
     InjectDependenciesRequest,
     InjectedDependencies,
-    Target,
-    Targets,
     WrappedTarget,
 )
 from pants.engine.unions import UnionRule
@@ -109,6 +102,10 @@ class InjectScalaLibraryDependencyRequest(InjectDependenciesRequest):
     inject_for = ScalaDependenciesField
 
 
+class InjectScalaPluginDependenciesRequest(InjectDependenciesRequest):
+    inject_for = ScalaDependenciesField
+
+
 @dataclass(frozen=True)
 class ScalaRuntimeForResolveRequest:
     resolve_name: str
@@ -150,68 +147,6 @@ async def resolve_scala_library_for_resolve(
     raise MissingScalaLibraryInResolveError(request.resolve_name, scala_version)
 
 
-@dataclass(frozen=True)
-class ScalaPluginsForTargetRequest:
-    target: Target
-
-
-@dataclass(frozen=True)
-class ScalaPluginsForTarget:
-    plugins: Targets
-    artifacts: Targets
-
-
-@rule
-async def resolve_scala_plugins_for_target(
-    request: ScalaPluginsForTargetRequest,
-    all_scala_plugins: AllScalaPluginTargets,
-    jvm: JvmSubsystem,
-    scalac: Scalac,
-) -> ScalaPluginsForTarget:
-
-    target = request.target
-    resolve = target[JvmResolveField].normalized_value(jvm)
-
-    plugin_names = target.get(ScalaConsumedPluginNamesField).value
-    if plugin_names is None:
-        plugin_names_by_resolve = scalac.parsed_default_plugins()
-        plugin_names = tuple(plugin_names_by_resolve.get(resolve) or ())
-
-    candidate_plugins: list[Target] = []
-    for plugin in all_scala_plugins:
-        if plugin[ScalacPluginNameField].value in plugin_names:
-            candidate_plugins.append(plugin)
-
-    artifact_address_inputs = (
-        plugin[ScalacPluginArtifactField].value for plugin in candidate_plugins
-    )
-
-    artifact_addresses = await MultiGet(
-        # `is not None` is solely to satiate mypy. artifact field is required.
-        Get(Address, AddressInput, AddressInput.parse(ai))
-        for ai in artifact_address_inputs
-        if ai is not None
-    )
-
-    candidate_artifacts = await Get(Targets, Addresses(artifact_addresses))
-
-    plugins: dict[str, tuple[Target, Target]] = {}  # Maps plugin name to relevant JVM artifact
-    for plugin, artifact in zip(candidate_plugins, candidate_artifacts):
-        if artifact[JvmResolveField].normalized_value(jvm) != resolve:
-            continue
-
-        plugin_name = plugin[ScalacPluginNameField].value
-        assert plugin_name is not None
-        plugins[plugin_name] = (plugin, artifact)
-
-    for plugin_name in plugin_names:
-        if plugin_name not in plugins:
-            raise Exception(f"Could not find Scala plugin `{plugin_name}` in resolve `{resolve}`")
-
-    plugin_targets, artifact_targets = zip(*plugins.values())
-    return ScalaPluginsForTarget(Targets(plugin_targets), Targets(artifact_targets))
-
-
 @rule(desc="Inject dependency on scala-library artifact for Scala target.")
 async def inject_scala_library_dependency(
     request: InjectScalaLibraryDependencyRequest,
@@ -230,6 +165,26 @@ async def inject_scala_library_dependency(
     return InjectedDependencies((scala_library_target_info.address,))
 
 
+@rule(desc="Inject dependency on scala plugin artifacts for Scala target.")
+async def inject_scala_plugin_dependencies(
+    request: InjectScalaPluginDependenciesRequest,
+) -> InjectedDependencies:
+    """Adds dependencies on plugins for scala source files, so that they get included in the
+    target's resolve."""
+
+    wrapped_target = await Get(WrappedTarget, Address, request.dependencies_field.address)
+    target = wrapped_target.target
+
+    if not target.has_field(JvmResolveField):
+        return InjectedDependencies()
+
+    scala_plugins = await Get(ScalaPluginsForTarget, ScalaPluginsForTargetRequest(target))
+
+    plugin_addresses = [target.address for target in scala_plugins.artifacts]
+
+    return InjectedDependencies(plugin_addresses)
+
+
 def rules():
     return [
         *collect_rules(),
@@ -238,4 +193,5 @@ def rules():
         *symbol_mapper.rules(),
         UnionRule(InferDependenciesRequest, InferScalaSourceDependencies),
         UnionRule(InjectDependenciesRequest, InjectScalaLibraryDependencyRequest),
+        UnionRule(InjectDependenciesRequest, InjectScalaPluginDependenciesRequest),
     ]

--- a/src/python/pants/backend/scala/subsystems/scalac.py
+++ b/src/python/pants/backend/scala/subsystems/scalac.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from pants.core.goals.generate_lockfiles import DEFAULT_TOOL_LOCKFILE
-from pants.option.option_types import ArgsListOption, StrListOption, StrOption
+from pants.option.option_types import ArgsListOption, DictOption, StrListOption, StrOption
 from pants.option.subsystem import Subsystem
 
 
@@ -26,17 +26,33 @@ class Scalac(Subsystem):
     plugins_global = StrListOption(
         "--plugins-global",
         help=(
-            "A list of addresses of `scalac_plugin` targets which should be used for "
+            "DEPRECATED: A list of addresses of `scalac_plugin` targets which should be used for "
             "compilation of all Scala targets in a build.\n\nIf you set this, you must also "
             "set `[scalac].plugins_global_lockfile`."
         ),
     ).advanced()
+
+    # TODO: see if we can use an actual list mechanism? If not, this seems like an OK option
+    default_plugins = DictOption[str](
+        "--experimental-plugins",
+        help=(
+            "A dictionary, whose keys are the names of each JVM resolve that requires default "
+            "Scala plugins, and the value is a comma-separated string consisting of scala plugin "
+            "names. Each speficied plugin must have a corresponding `jvm_artifact` that specifies "
+            "the name in its `experimental_provides_scala_plugin` field, and is compatible with "
+            "the current resolve."
+        ),
+    )
+
     plugins_global_lockfile = StrOption(
         "--plugins-global-lockfile",
         default=DEFAULT_TOOL_LOCKFILE,
         help=(
-            "The filename of the lockfile for global plugins. You must set this option to a "
+            "DEPRECATED: The filename of the lockfile for global plugins. You must set this option to a "
             "file path, e.g. '3rdparty/jvm/global_scalac_plugins.lock', if you set "
             "`[scalac].plugins_global`."
         ),
     ).advanced()
+
+    def parsed_default_plugins(self) -> dict[str, list[str]]:
+        return {key: ",".split(value) for key, value in self.default_plugins.items()}

--- a/src/python/pants/backend/scala/subsystems/scalac.py
+++ b/src/python/pants/backend/scala/subsystems/scalac.py
@@ -23,18 +23,25 @@ class Scalac(Subsystem):
     args = ArgsListOption(
         help=f"Global `scalac` compiler flags, e.g. `--{options_scope}-args='-encoding UTF-8'`."
     )
-    plugins_global = StrListOption(
-        "--plugins-global",
-        help=(
-            "DEPRECATED: A list of addresses of `scalac_plugin` targets which should be used for "
-            "compilation of all Scala targets in a build.\n\nIf you set this, you must also "
-            "set `[scalac].plugins_global_lockfile`."
-        ),
-    ).advanced()
+    plugins_global = (
+        StrListOption(
+            "--plugins-global",
+            help=(
+                "A list of addresses of `scalac_plugin` targets which should be used for "
+                "compilation of all Scala targets in a build.\n\nIf you set this, you must also "
+                "set `[scalac].plugins_global_lockfile`."
+            ),
+        )
+        .advanced()
+        .deprecated(
+            removal_version="2.12.0dev0",
+            hint="Use `--plugins-for-resolve` instead to use user resolves",
+        )
+    )
 
     # TODO: see if we can use an actual list mechanism? If not, this seems like an OK option
     default_plugins = DictOption[str](
-        "--experimental-plugins",
+        "--plugins-for-resolve",
         help=(
             "A dictionary, whose keys are the names of each JVM resolve that requires default "
             "Scala plugins, and the value is a comma-separated string consisting of scala plugin "
@@ -44,15 +51,22 @@ class Scalac(Subsystem):
         ),
     )
 
-    plugins_global_lockfile = StrOption(
-        "--plugins-global-lockfile",
-        default=DEFAULT_TOOL_LOCKFILE,
-        help=(
-            "DEPRECATED: The filename of the lockfile for global plugins. You must set this option to a "
-            "file path, e.g. '3rdparty/jvm/global_scalac_plugins.lock', if you set "
-            "`[scalac].plugins_global`."
-        ),
-    ).advanced()
+    plugins_global_lockfile = (
+        StrOption(
+            "--plugins-global-lockfile",
+            default=DEFAULT_TOOL_LOCKFILE,
+            help=(
+                "The filename of the lockfile for global plugins. You must set this option to a "
+                "file path, e.g. '3rdparty/jvm/global_scalac_plugins.lock', if you set "
+                "`[scalac].plugins_global`."
+            ),
+        )
+        .advanced()
+        .deprecated(
+            removal_version="2.12.0dev0",
+            hint="Use `--plugins-for-resolve`, which will add plugin dependencies to JVM user resolves instead.",
+        )
+    )
 
     def parsed_default_plugins(self) -> dict[str, list[str]]:
         return {

--- a/src/python/pants/backend/scala/subsystems/scalac.py
+++ b/src/python/pants/backend/scala/subsystems/scalac.py
@@ -55,4 +55,7 @@ class Scalac(Subsystem):
     ).advanced()
 
     def parsed_default_plugins(self) -> dict[str, list[str]]:
-        return {key: ",".split(value) for key, value in self.default_plugins.items()}
+        return {
+            key: [i.strip() for i in value.split(",")]
+            for key, value in self.default_plugins.items()
+        }

--- a/src/python/pants/backend/scala/target_types.py
+++ b/src/python/pants/backend/scala/target_types.py
@@ -57,7 +57,7 @@ class ScalaConsumedPluginNamesField(StringSequenceField):
     target's resolve.
     """
 
-    alias = "experimental_plugins"
+    alias = "scalac_plugins"
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/scala/target_types.py
+++ b/src/python/pants/backend/scala/target_types.py
@@ -13,6 +13,7 @@ from pants.engine.target import (
     MultipleSourcesField,
     SingleSourceField,
     StringField,
+    StringSequenceField,
     Target,
     TargetFilesGenerator,
     TargetFilesGeneratorSettings,
@@ -47,6 +48,14 @@ class ScalaGeneratorSourcesField(MultipleSourcesField):
 
 class ScalaDependenciesField(Dependencies):
     pass
+
+
+class ScalaPluginNamesField(StringSequenceField):
+    """The names of Scala plugins that this source file requires.
+
+    If not specified, this will default to the plugins specified in `--scalac-plugins` for this
+    target's resolve.
+    """
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/scala/target_types.py
+++ b/src/python/pants/backend/scala/target_types.py
@@ -50,12 +50,14 @@ class ScalaDependenciesField(Dependencies):
     pass
 
 
-class ScalaPluginNamesField(StringSequenceField):
+class ScalaConsumedPluginNamesField(StringSequenceField):
     """The names of Scala plugins that this source file requires.
 
     If not specified, this will default to the plugins specified in `--scalac-plugins` for this
     target's resolve.
     """
+
+    alias = "experimental_plugins"
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/jvm/target_types.py
+++ b/src/python/pants/jvm/target_types.py
@@ -180,12 +180,21 @@ class JvmArtifactResolveField(JvmResolveField):
     )
 
 
+class JvmArtifactProvidesScalaPluginField(StringField):
+    alias = "experimental_provides_scala_plugin"
+    help = (
+        "Optionally specifies the name of the scala plugin that this artifact provides. If None, "
+        "this artifact does not provide a Scala plugin."
+    )
+
+
 class JvmArtifactFieldSet(FieldSet):
     group: JvmArtifactGroupField
     artifact: JvmArtifactArtifactField
     version: JvmArtifactVersionField
     packages: JvmArtifactPackagesField
     url: JvmArtifactUrlField
+    scala_plugin: JvmArtifactProvidesScalaPluginField
 
     required_fields = (
         JvmArtifactGroupField,
@@ -203,6 +212,7 @@ class JvmArtifactTarget(Target):
         JvmArtifactUrlField,  # TODO: should `JvmArtifactFieldSet` have an `all_fields` field?
         JvmArtifactJarSourceField,
         JvmArtifactResolveField,
+        JvmArtifactProvidesScalaPluginField,
     )
     help = (
         "A third-party JVM artifact, as identified by its Maven-compatible coordinate.\n\n"

--- a/src/python/pants/jvm/target_types.py
+++ b/src/python/pants/jvm/target_types.py
@@ -180,21 +180,12 @@ class JvmArtifactResolveField(JvmResolveField):
     )
 
 
-class JvmArtifactProvidesScalaPluginField(StringField):
-    alias = "experimental_provides_scala_plugin"
-    help = (
-        "Optionally specifies the name of the scala plugin that this artifact provides. If None, "
-        "this artifact does not provide a Scala plugin."
-    )
-
-
 class JvmArtifactFieldSet(FieldSet):
     group: JvmArtifactGroupField
     artifact: JvmArtifactArtifactField
     version: JvmArtifactVersionField
     packages: JvmArtifactPackagesField
     url: JvmArtifactUrlField
-    scala_plugin: JvmArtifactProvidesScalaPluginField
 
     required_fields = (
         JvmArtifactGroupField,
@@ -212,7 +203,6 @@ class JvmArtifactTarget(Target):
         JvmArtifactUrlField,  # TODO: should `JvmArtifactFieldSet` have an `all_fields` field?
         JvmArtifactJarSourceField,
         JvmArtifactResolveField,
-        JvmArtifactProvidesScalaPluginField,
     )
     help = (
         "A third-party JVM artifact, as identified by its Maven-compatible coordinate.\n\n"


### PR DESCRIPTION
Code quality isn't that great -- I could do a much better job of threading the resolves through the various objects in `scala_plugins.py`, but it seems to work for now?

You can test this in the example-jvm repo using:

```
$ ./pants_from_sources --scalac-plugins-global='[]' --scalac-plugins-global-lockfile=ignoreme.txt generate-lockfiles --resolve=scalac-plugins
$  ./pants_from_sources --scalac-plugins-for-resolve='{"jvm-default": "acyclic"}' --scalac-plugins-global='[]' --scalac-plugins-global-lockfile=ignoreme.txt check src::
```

Closes #14490