### PR TITLE
Adds the plugin names field to scala sources

### DIFF
--- a/src/python/pants/backend/scala/target_types.py
+++ b/src/python/pants/backend/scala/target_types.py
@@ -58,6 +58,7 @@ class ScalaConsumedPluginNamesField(StringSequenceField):
     """
 
     alias = "scalac_plugins"
+    required = False
 
 
 @dataclass(frozen=True)
@@ -89,6 +90,7 @@ class ScalatestTestTarget(Target):
         *COMMON_TARGET_FIELDS,
         ScalaDependenciesField,
         ScalatestTestSourceField,
+        ScalaConsumedPluginNamesField,
         JvmResolveField,
         JvmProvidesTypesField,
         JvmJdkField,
@@ -112,6 +114,7 @@ class ScalatestTestsGeneratorTarget(TargetFilesGenerator):
     copied_fields = (
         *COMMON_TARGET_FIELDS,
         ScalaDependenciesField,
+        ScalaConsumedPluginNamesField,
         JvmJdkField,
     )
     moved_fields = (
@@ -140,6 +143,7 @@ class ScalaJunitTestTarget(Target):
         *COMMON_TARGET_FIELDS,
         ScalaDependenciesField,
         ScalaJunitTestSourceField,
+        ScalaConsumedPluginNamesField,
         JvmResolveField,
         JvmProvidesTypesField,
         JvmJdkField,
@@ -163,6 +167,7 @@ class ScalaJunitTestsGeneratorTarget(TargetFilesGenerator):
     copied_fields = (
         *COMMON_TARGET_FIELDS,
         ScalaDependenciesField,
+        ScalaConsumedPluginNamesField,
         JvmJdkField,
     )
     moved_fields = (
@@ -184,6 +189,7 @@ class ScalaSourceTarget(Target):
         *COMMON_TARGET_FIELDS,
         ScalaDependenciesField,
         ScalaSourceField,
+        ScalaConsumedPluginNamesField,
         JvmResolveField,
         JvmProvidesTypesField,
         JvmJdkField,
@@ -216,6 +222,7 @@ class ScalaSourcesGeneratorTarget(TargetFilesGenerator):
     copied_fields = (
         *COMMON_TARGET_FIELDS,
         ScalaDependenciesField,
+        ScalaConsumedPluginNamesField,
         JvmJdkField,
     )
     moved_fields = (

--- a/src/python/pants/backend/scala/target_types.py
+++ b/src/python/pants/backend/scala/target_types.py
@@ -51,11 +51,14 @@ class ScalaDependenciesField(Dependencies):
 
 
 class ScalaConsumedPluginNamesField(StringSequenceField):
-    """The names of Scala plugins that this source file requires.
+    help = """The names of Scala plugins that this source file requires.
 
-    If not specified, this will default to the plugins specified in `--scalac-plugins` for this
-    target's resolve.
-    """
+        The plugin must be defined by a corresponding `scalac_plugin` AND `jvm_artifact` target,
+        and must be present in this target's resolve's lockfile.
+
+        If not specified, this will default to the plugins specified in `--scalac-plugins` for this
+        target's resolve.
+        """
 
     alias = "scalac_plugins"
     required = False


### PR DESCRIPTION
This was missed in yesterday's PR, and wasn't picked up by existing tests.

Tests for local Scala plugins will follow shortly.