### PR TITLE
Allow use of `parametrize` with the `jdk=` field of JVM targets

### DIFF
--- a/src/python/pants/backend/java/compile/javac.py
+++ b/src/python/pants/backend/java/compile/javac.py
@@ -71,8 +71,6 @@ async def compile_java_source(
             exit_code=1,
         )
 
-    jdk = await Get(JdkEnvironment, JdkRequest, JdkRequest.from_target(request.component))
-
     # Capture just the `ClasspathEntry` objects that are listed as `export` types by source analysis
     deps_to_classpath_entries = dict(
         zip(request.component.dependencies, direct_dependency_classpath_entries or ())
@@ -131,9 +129,12 @@ async def compile_java_source(
         )
 
     dest_dir = "classfiles"
-    dest_dir_digest = await Get(
-        Digest,
-        CreateDigest([Directory(dest_dir)]),
+    dest_dir_digest, jdk = await MultiGet(
+        Get(
+            Digest,
+            CreateDigest([Directory(dest_dir)]),
+        ),
+        Get(JdkEnvironment, JdkRequest, JdkRequest.from_target(request.component)),
     )
     merged_digest = await Get(
         Digest,

--- a/src/python/pants/backend/java/target_types.py
+++ b/src/python/pants/backend/java/target_types.py
@@ -77,17 +77,16 @@ class JunitTestsGeneratorTarget(TargetFilesGenerator):
         *COMMON_TARGET_FIELDS,
         Dependencies,
         JavaTestsGeneratorSourcesField,
-        JvmJdkField,
     )
     generated_target_cls = JunitTestTarget
     copied_fields = (
         *COMMON_TARGET_FIELDS,
         Dependencies,
-        JvmJdkField,
     )
     moved_fields = (
-        JvmResolveField,
+        JvmJdkField,
         JvmProvidesTypesField,
+        JvmResolveField,
     )
     help = "Generate a `junit_test` target for each file in the `sources` field."
 
@@ -120,13 +119,11 @@ class JavaSourcesGeneratorTarget(TargetFilesGenerator):
         *COMMON_TARGET_FIELDS,
         Dependencies,
         JavaSourcesGeneratorSourcesField,
-        JvmJdkField,
     )
     generated_target_cls = JavaSourceTarget
     copied_fields = (
         *COMMON_TARGET_FIELDS,
         Dependencies,
-        JvmJdkField,
     )
     moved_fields = (
         JvmResolveField,

--- a/src/python/pants/backend/scala/compile/scalac.py
+++ b/src/python/pants/backend/scala/compile/scalac.py
@@ -80,7 +80,6 @@ async def compile_scala_source(
             exit_code=1,
         )
 
-    jdk = await Get(JdkEnvironment, JdkRequest, JdkRequest.from_target(request.component))
     scala_version = scala.version_for_resolve(request.resolve.name)
 
     component_members_with_sources = tuple(
@@ -137,7 +136,7 @@ async def compile_scala_source(
 
     user_classpath = Classpath(direct_dependency_classpath_entries, request.resolve)
 
-    tool_classpath, sources_digest = await MultiGet(
+    tool_classpath, sources_digest, jdk = await MultiGet(
         Get(
             ToolClasspath,
             ToolClasspathRequest(
@@ -163,6 +162,7 @@ async def compile_scala_source(
                 (sources.snapshot.digest for _, sources in component_members_and_scala_source_files)
             ),
         ),
+        Get(JdkEnvironment, JdkRequest, JdkRequest.from_target(request.component)),
     )
 
     extra_immutable_input_digests = {

--- a/src/python/pants/backend/scala/target_types.py
+++ b/src/python/pants/backend/scala/target_types.py
@@ -111,18 +111,17 @@ class ScalatestTestsGeneratorTarget(TargetFilesGenerator):
         *COMMON_TARGET_FIELDS,
         ScalatestTestsGeneratorSourcesField,
         ScalaDependenciesField,
-        JvmJdkField,
     )
     generated_target_cls = ScalatestTestTarget
     copied_fields = (
         *COMMON_TARGET_FIELDS,
         ScalaDependenciesField,
         ScalaConsumedPluginNamesField,
-        JvmJdkField,
     )
     moved_fields = (
-        JvmResolveField,
+        JvmJdkField,
         JvmProvidesTypesField,
+        JvmResolveField,
     )
     settings_request_cls = ScalaSettingsRequest
     help = (
@@ -164,18 +163,17 @@ class ScalaJunitTestsGeneratorTarget(TargetFilesGenerator):
         *COMMON_TARGET_FIELDS,
         ScalaJunitTestsGeneratorSourcesField,
         ScalaDependenciesField,
-        JvmJdkField,
     )
     generated_target_cls = ScalaJunitTestTarget
     copied_fields = (
         *COMMON_TARGET_FIELDS,
         ScalaDependenciesField,
         ScalaConsumedPluginNamesField,
-        JvmJdkField,
     )
     moved_fields = (
-        JvmResolveField,
+        JvmJdkField,
         JvmProvidesTypesField,
+        JvmResolveField,
     )
     settings_request_cls = ScalaSettingsRequest
     help = "Generate a `scala_junit_test` target for each file in the `sources` field."
@@ -219,14 +217,12 @@ class ScalaSourcesGeneratorTarget(TargetFilesGenerator):
         *COMMON_TARGET_FIELDS,
         ScalaDependenciesField,
         ScalaSourcesGeneratorSourcesField,
-        JvmJdkField,
     )
     generated_target_cls = ScalaSourceTarget
     copied_fields = (
         *COMMON_TARGET_FIELDS,
         ScalaDependenciesField,
         ScalaConsumedPluginNamesField,
-        JvmJdkField,
     )
     moved_fields = (
         JvmResolveField,


### PR DESCRIPTION
In order to allow it to be `parametrized`, the `JvmJdkField` needs to be a `moved_field` (rather than a `copied_field`) of any JVM generator targets. The impact of this is that not "all" targets in a graph will have a `jdk` value: the generator target will "move" its JDK to the generated targets instead.

This change makes `jdk=` a `moved_field`, and then:
1. Fetches it more lazily during compilation, so that we only actually require one for targets which will be compiled (i.e.: not for generators)
2. Adjusts `JdkRequest.from_target` to:
    1. Only require a `jdk=` field on one member
    2. Assert that if multiple members set the `jdk=`, they all use the same value.

Fixes #14509.

[ci skip-rust]
[ci skip-build-wheels]