### PR TITLE
Don't require an argument to SpecsParser in normal usage.

### DIFF
--- a/src/python/pants/base/specs_parser.py
+++ b/src/python/pants/base/specs_parser.py
@@ -7,6 +7,7 @@ import os.path
 from pathlib import Path, PurePath
 from typing import Iterable
 
+from pants.base.build_environment import get_buildroot
 from pants.base.specs import (
     AddressLiteralSpec,
     AddressSpec,
@@ -44,8 +45,8 @@ class SpecsParser:
     class BadSpecError(Exception):
         """Indicates an unparseable command line selector."""
 
-    def __init__(self, root_dir: str) -> None:
-        self._root_dir = os.path.realpath(root_dir)
+    def __init__(self, root_dir: str | None = None) -> None:
+        self._root_dir = os.path.realpath(root_dir or get_buildroot())
 
     def _normalize_spec_path(self, path: str) -> str:
         is_abs = not path.startswith("//") and os.path.isabs(path)

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -7,7 +7,6 @@ import logging
 import sys
 from dataclasses import dataclass
 
-from pants.base.build_environment import get_buildroot
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE, ExitCode
 from pants.base.specs import Specs
 from pants.base.specs_parser import SpecsParser
@@ -151,7 +150,6 @@ class LocalPantsRunner:
         specs = calculate_specs(
             options_bootstrapper=options_bootstrapper,
             options=options,
-            build_root=get_buildroot(),
             session=graph_session.scheduler_session,
         )
 
@@ -240,7 +238,7 @@ class LocalPantsRunner:
 
     def run(self, start_time: float) -> ExitCode:
         with maybe_profiled(self.profile_path):
-            spec_parser = SpecsParser(get_buildroot())
+            spec_parser = SpecsParser()
             specs = [str(spec_parser.parse_spec(spec)) for spec in self.options.specs]
             self.run_tracker.start(run_start_time=start_time, specs=specs)
             global_options = self.options.for_global_scope()

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -11,7 +11,6 @@ from typing import List, Optional, Tuple
 import pytest
 
 from pants.backend.python.target_types import PythonSourcesGeneratorTarget
-from pants.base.build_environment import get_buildroot
 from pants.base.specs import Specs
 from pants.base.specs_parser import SpecsParser
 from pants.engine.engine_aware import EngineAwareParameter, EngineAwareReturnType
@@ -901,9 +900,7 @@ def test_streaming_workunits_expanded_specs(run_tracker: RunTracker) -> None:
             "src/python/others/b.py": "print('')",
         }
     )
-    specs = SpecsParser(get_buildroot()).parse_specs(
-        ["src/python/somefiles::", "src/python/others/b.py"]
-    )
+    specs = SpecsParser().parse_specs(["src/python/somefiles::", "src/python/others/b.py"])
 
     class Callback(WorkunitsCallback):
         @property

--- a/src/python/pants/init/specs_calculator.py
+++ b/src/python/pants/init/specs_calculator.py
@@ -26,11 +26,9 @@ def calculate_specs(
     options_bootstrapper: OptionsBootstrapper,
     options: Options,
     session: SchedulerSession,
-    *,
-    build_root: str,
 ) -> Specs:
     """Determine the specs for a given Pants run."""
-    specs = SpecsParser(build_root).parse_specs(options.specs)
+    specs = SpecsParser().parse_specs(options.specs)
     changed_options = ChangedOptions.from_options(options.for_scope("changed"))
 
     logger.debug("specs are: %s", specs)


### PR DESCRIPTION
This will allow it to be more easily used to parse specs that
were not provided in the standard way, as positional CLI args.

For example, it will allow usage of specs in the --from and --to
options of the `paths` goal.

[ci skip-rust]

[ci skip-build-wheels]