### PR TITLE
Support complete_platforms for Python GCFs. (Cherry-pick of #14530)

### DIFF
--- a/src/python/pants/backend/google_cloud_function/python/rules.py
+++ b/src/python/pants/backend/google_cloud_function/python/rules.py
@@ -1,6 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import logging
 from dataclasses import dataclass
 
@@ -12,8 +14,10 @@ from pants.backend.google_cloud_function.python.target_types import (
     ResolvePythonGoogleHandlerRequest,
 )
 from pants.backend.python.subsystems.lambdex import Lambdex
+from pants.backend.python.target_types import PexCompletePlatformsField
 from pants.backend.python.util_rules import pex_from_targets
 from pants.backend.python.util_rules.pex import (
+    CompletePlatforms,
     Pex,
     PexPlatforms,
     PexRequest,
@@ -45,10 +49,11 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class PythonGoogleCloudFunctionFieldSet(PackageFieldSet):
-    required_fields = (PythonGoogleCloudFunctionHandlerField, PythonGoogleCloudFunctionRuntime)
+    required_fields = (PythonGoogleCloudFunctionHandlerField,)
 
     handler: PythonGoogleCloudFunctionHandlerField
     runtime: PythonGoogleCloudFunctionRuntime
+    complete_platforms: PexCompletePlatformsField
     type: PythonGoogleCloudFunctionType
     output_path: OutputPathField
 
@@ -78,11 +83,15 @@ async def package_python_google_cloud_function(
     # We hardcode the platform value to the appropriate one for each Google Cloud Function runtime.
     # (Running the "hello world" cloud function in the example code will report the platform, and can be
     # used to verify correctness of these platform strings.)
-    py_major, py_minor = field_set.runtime.to_interpreter_version()
-    platform_str = f"linux_x86_64-cp-{py_major}{py_minor}-cp{py_major}{py_minor}"
-    # set pymalloc ABI flag - this was removed in python 3.8 https://bugs.python.org/issue36707
-    if py_major <= 3 and py_minor < 8:
-        platform_str += "m"
+    pex_platforms = []
+    interpreter_version = field_set.runtime.to_interpreter_version()
+    if interpreter_version:
+        py_major, py_minor = interpreter_version
+        platform_str = f"linux_x86_64-cp-{py_major}{py_minor}-cp{py_major}{py_minor}"
+        # set pymalloc ABI flag - this was removed in python 3.8 https://bugs.python.org/issue36707
+        if py_major <= 3 and py_minor < 8:
+            platform_str += "m"
+        pex_platforms.append(platform_str)
 
     additional_pex_args = (
         # Ensure we can resolve manylinux wheels in addition to any AMI-specific wheels.
@@ -91,11 +100,17 @@ async def package_python_google_cloud_function(
         # available and matching the AMI platform.
         "--resolve-local-platforms",
     )
+
+    complete_platforms = await Get(
+        CompletePlatforms, PexCompletePlatformsField, field_set.complete_platforms
+    )
+
     pex_request = PexFromTargetsRequest(
         addresses=[field_set.address],
         internal_only=False,
         output_filename=output_filename,
-        platforms=PexPlatforms([platform_str]),
+        platforms=PexPlatforms(pex_platforms),
+        complete_platforms=complete_platforms,
         additional_args=additional_pex_args,
         additional_lockfile_args=additional_pex_args,
     )
@@ -142,13 +157,20 @@ async def package_python_google_cloud_function(
             description=f"Setting up handler in {output_filename}",
         ),
     )
+
+    extra_log_data: list[tuple[str, str]] = []
+    if field_set.runtime.value:
+        extra_log_data.append(("Runtime", field_set.runtime.value))
+    extra_log_data.extend(("Complete platform", path) for path in complete_platforms)
+    # The GCP-facing handler function is always main.handler, which is the
+    # wrapper injected by lambdex that manages invocation of the actual handler.
+    extra_log_data.append(("Handler", "main.handler"))
+
+    first_column_width = 4 + max(len(header) for header, _ in extra_log_data)
     artifact = BuiltPackageArtifact(
         output_filename,
-        extra_log_lines=(
-            f"    Runtime: {field_set.runtime.value}",
-            # The GCP-facing handler function is always main.handler, which is the
-            # wrapper injected by lambdex that manages invocation of the actual handler.
-            "    Handler: main.handler",
+        extra_log_lines=tuple(
+            f"{header.rjust(first_column_width, ' ')}: {data}" for header, data in extra_log_data
         ),
     )
     return BuiltPackage(digest=result.output_digest, artifacts=(artifact,))

--- a/src/python/pants/backend/google_cloud_function/python/rules_test.py
+++ b/src/python/pants/backend/google_cloud_function/python/rules_test.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
 import sys
 from io import BytesIO
 from textwrap import dedent
@@ -16,14 +18,25 @@ from pants.backend.google_cloud_function.python.rules import (
 )
 from pants.backend.google_cloud_function.python.target_types import PythonGoogleCloudFunction
 from pants.backend.google_cloud_function.python.target_types import rules as target_rules
+from pants.backend.python.goals import package_pex_binary
+from pants.backend.python.goals.package_pex_binary import PexBinaryFieldSet
 from pants.backend.python.subsystems.lambdex import Lambdex
 from pants.backend.python.subsystems.lambdex import (
     rules as python_google_cloud_function_subsystem_rules,
 )
-from pants.backend.python.target_types import PythonSourcesGeneratorTarget
+from pants.backend.python.target_types import (
+    PexBinary,
+    PythonRequirementTarget,
+    PythonSourcesGeneratorTarget,
+)
 from pants.backend.python.target_types_rules import rules as python_target_types_rules
 from pants.core.goals.package import BuiltPackage
-from pants.core.target_types import FilesGeneratorTarget, RelocatedFiles, ResourcesGeneratorTarget
+from pants.core.target_types import (
+    FilesGeneratorTarget,
+    FileTarget,
+    RelocatedFiles,
+    ResourcesGeneratorTarget,
+)
 from pants.core.target_types import rules as core_target_types_rules
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents
@@ -33,8 +46,9 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
-    return RuleRunner(
+    rule_runner = RuleRunner(
         rules=[
+            *package_pex_binary.rules(),
             *python_google_cloud_function_rules(),
             *python_google_cloud_function_subsystem_rules(),
             *target_rules(),
@@ -43,17 +57,26 @@ def rule_runner() -> RuleRunner:
             QueryRule(BuiltPackage, (PythonGoogleCloudFunctionFieldSet,)),
         ],
         target_types=[
-            PythonGoogleCloudFunction,
-            PythonSourcesGeneratorTarget,
+            FileTarget,
             FilesGeneratorTarget,
+            PexBinary,
+            PythonGoogleCloudFunction,
+            PythonRequirementTarget,
+            PythonSourcesGeneratorTarget,
             RelocatedFiles,
             ResourcesGeneratorTarget,
         ],
     )
+    rule_runner.set_options([], env_inherit={"PATH", "PYENV_ROOT", "HOME"})
+    return rule_runner
 
 
 def create_python_google_cloud_function(
-    rule_runner: RuleRunner, addr: Address, *, extra_args: list[str] | None = None
+    rule_runner: RuleRunner,
+    addr: Address,
+    *,
+    expected_extra_log_lines: tuple[str, ...],
+    extra_args: list[str] | None = None,
 ) -> tuple[str, bytes]:
     rule_runner.set_options(
         [
@@ -66,15 +89,37 @@ def create_python_google_cloud_function(
     built_asset = rule_runner.request(
         BuiltPackage, [PythonGoogleCloudFunctionFieldSet.create(target)]
     )
-    assert (
-        "    Runtime: python37",
-        "    Handler: main.handler",
-    ) == built_asset.artifacts[0].extra_log_lines
+    assert expected_extra_log_lines == built_asset.artifacts[0].extra_log_lines
     digest_contents = rule_runner.request(DigestContents, [built_asset.digest])
     assert len(digest_contents) == 1
     relpath = built_asset.artifacts[0].relpath
     assert relpath is not None
     return relpath, digest_contents[0].content
+
+
+@pytest.fixture
+def complete_platform(rule_runner: RuleRunner) -> bytes:
+    rule_runner.write_files(
+        {
+            "pex_exe/BUILD": dedent(
+                """\
+                python_requirement(name="req", requirements=["pex==2.1.66"])
+                pex_binary(dependencies=[":req"], script="pex")
+                """
+            ),
+        }
+    )
+    result = rule_runner.request(
+        BuiltPackage, [PexBinaryFieldSet.create(rule_runner.get_target(Address("pex_exe")))]
+    )
+    rule_runner.write_digest(result.digest)
+    pex_executable = os.path.join(rule_runner.build_root, "pex_exe/pex_exe.pex")
+    return subprocess.run(
+        args=[pex_executable, "interpreter", "inspect", "-mt"],
+        env=dict(PEX_MODULE="pex.cli", **os.environ),
+        check=True,
+        stdout=subprocess.PIPE,
+    ).stdout
 
 
 @pytest.mark.platform_specific_behavior
@@ -83,7 +128,7 @@ def create_python_google_cloud_function(
     all_major_minor_python_versions(Lambdex.default_interpreter_constraints),
 )
 def test_create_hello_world_lambda(
-    rule_runner: RuleRunner, major_minor_interpreter: str, caplog
+    rule_runner: RuleRunner, major_minor_interpreter: str, complete_platform: str, caplog
 ) -> None:
     rule_runner.write_files(
         {
@@ -93,15 +138,18 @@ def test_create_hello_world_lambda(
                     print('Hello, World!')
                 """
             ),
+            "src/python/foo/bar/platform.json": complete_platform,
             "src/python/foo/bar/BUILD": dedent(
                 """
                 python_sources(name='lib')
 
+                file(name="platform", source="platform.json")
                 python_google_cloud_function(
                     name='lambda',
                     dependencies=[':lib'],
                     handler='foo.bar.hello_world:handler',
                     runtime='python37',
+                    complete_platforms=[':platform'],
                     type='event',
                 )
                 """
@@ -111,6 +159,11 @@ def test_create_hello_world_lambda(
     zip_file_relpath, content = create_python_google_cloud_function(
         rule_runner,
         Address("src/python/foo/bar", target_name="lambda"),
+        expected_extra_log_lines=(
+            "              Runtime: python37",
+            "    Complete platform: src/python/foo/bar/platform.json",
+            "              Handler: main.handler",
+        ),
         extra_args=[f"--lambdex-interpreter-constraints=['=={major_minor_interpreter}.*']"],
     )
     assert "src.python.foo.bar/lambda.zip" == zip_file_relpath
@@ -168,7 +221,12 @@ def test_warn_files_targets(rule_runner: RuleRunner, caplog) -> None:
 
     assert not caplog.records
     zip_file_relpath, _ = create_python_google_cloud_function(
-        rule_runner, Address("src/py/project", target_name="lambda")
+        rule_runner,
+        Address("src/py/project", target_name="lambda"),
+        expected_extra_log_lines=(
+            "    Runtime: python37",
+            "    Handler: main.handler",
+        ),
     )
     assert caplog.records
     assert "src.py.project/lambda.zip" == zip_file_relpath

--- a/src/python/pants/backend/google_cloud_function/python/target_types_test.py
+++ b/src/python/pants/backend/google_cloud_function/python/target_types_test.py
@@ -1,6 +1,6 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
+import re
 from textwrap import dedent
 from typing import List, Optional
 
@@ -16,9 +16,14 @@ from pants.backend.google_cloud_function.python.target_types import (
     ResolvePythonGoogleHandlerRequest,
 )
 from pants.backend.google_cloud_function.python.target_types import rules as target_type_rules
-from pants.backend.python.target_types import PythonRequirementTarget, PythonSourcesGeneratorTarget
+from pants.backend.python.target_types import (
+    PexCompletePlatformsField,
+    PythonRequirementTarget,
+    PythonSourcesGeneratorTarget,
+)
 from pants.backend.python.target_types_rules import rules as python_target_types_rules
 from pants.build_graph.address import Address
+from pants.core.target_types import FileTarget
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.target import InjectedDependencies, InvalidFieldException
 from pants.testutil.rule_runner import QueryRule, RuleRunner
@@ -34,6 +39,7 @@ def rule_runner() -> RuleRunner:
             QueryRule(InjectedDependencies, [InjectPythonCloudFunctionHandlerDependency]),
         ],
         target_types=[
+            FileTarget,
             PythonGoogleCloudFunction,
             PythonRequirementTarget,
             PythonSourcesGeneratorTarget,
@@ -251,3 +257,66 @@ def test_inject_handler_dependency(rule_runner: RuleRunner, caplog) -> None:
     # Test that we can turn off the injection.
     rule_runner.set_options(["--no-python-infer-entry-points"])
     assert_injected(Address("project", target_name="first_party"), expected=None)
+
+
+def test_at_least_one_target_platform(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "project/app.py": "",
+            "project/platform-py37.json": "",
+            "project/BUILD": dedent(
+                """\
+                python_google_cloud_function(
+                    name='runtime',
+                    handler='project.app:func',
+                    runtime='python37',
+                    type='event',
+                )
+                file(name="python37", source="platform-py37.json")
+                python_google_cloud_function(
+                    name='complete_platforms',
+                    handler='project.app:func',
+                    complete_platforms=[':python37'],
+                    type='event',
+                )
+                python_google_cloud_function(
+                    name='both',
+                    handler='project.app:func',
+                    runtime='python37',
+                    complete_platforms=[':python37'],
+                    type='event',
+                )
+                python_google_cloud_function(
+                    name='neither',
+                    handler='project.app:func',
+                    type='event',
+                )
+                """
+            ),
+        }
+    )
+
+    runtime = rule_runner.get_target(Address("project", target_name="runtime"))
+    assert "python37" == runtime[PythonGoogleCloudFunctionRuntime].value
+    assert runtime[PexCompletePlatformsField].value is None
+
+    complete_platforms = rule_runner.get_target(
+        Address("project", target_name="complete_platforms")
+    )
+    assert complete_platforms[PythonGoogleCloudFunctionRuntime].value is None
+    assert (":python37",) == complete_platforms[PexCompletePlatformsField].value
+
+    both = rule_runner.get_target(Address("project", target_name="both"))
+    assert "python37" == both[PythonGoogleCloudFunctionRuntime].value
+    assert (":python37",) == both[PexCompletePlatformsField].value
+
+    with pytest.raises(
+        ExecutionError,
+        match=r".*{}.*".format(
+            re.escape(
+                "InvalidTargetException: The `python_google_cloud_function` target project:neither "
+                "must specify either a `runtime` or `complete_platforms` or both."
+            )
+        ),
+    ):
+        rule_runner.get_target(Address("project", target_name="neither"))


### PR DESCRIPTION
Instead of (or in addition to) specifying a `runtime` for a
`python_google_cloud_function`, you can now specify
`complete_platforms`. This allows creating a lambdex when an abbreviated
platform string does not provide enough information to evaluate
environment markers during the requirement resolution phase of building
the lambdex.

(cherry picked from commit 920832f9cf8ca7fbffb3ec31168699122606ae29)

[ci skip-rust]
[ci skip-build-wheels]