### PR TITLE
Upgrade Pex to 2.1.67.

### DIFF
--- a/3rdparty/python/lockfiles/user_reqs.txt
+++ b/3rdparty/python/lockfiles/user_reqs.txt
@@ -18,7 +18,7 @@
 #     "ijson==3.1.4",
 #     "mypy-typing-asserts==0.1.1",
 #     "packaging==21.3",
-#     "pex==2.1.66",
+#     "pex==2.1.67",
 #     "psutil==5.9.0",
 #     "pydevd-pycharm==203.5419.8",
 #     "pytest<8,>=6.2.4",
@@ -80,6 +80,7 @@ ijson==3.1.4 \
     --hash=sha256:fa10a1d88473303ec97aae23169d77c5b92657b7fb189f9c584974c00a79f383 \
     --hash=sha256:9a5bf5b9d8f2ceaca131ee21fc7875d0f34b95762f4f32e4d65109ca46472147 \
     --hash=sha256:81cc8cee590c8a70cca3c9aefae06dd7cb8e9f75f3a7dc12b340c2e332d33a2a \
+    --hash=sha256:4ea5fc50ba158f72943d5174fbc29ebefe72a2adac051c814c87438dc475cf78 \
     --hash=sha256:3b98861a4280cf09d267986cefa46c3bd80af887eae02aba07488d80eb798afa \
     --hash=sha256:068c692efba9692406b86736dcc6803e4a0b6280d7f0b7534bff3faec677ff38 \
     --hash=sha256:86884ac06ac69cea6d89ab7b84683b3b4159c4013e4a20276d3fc630fe9b7588 \
@@ -144,9 +145,9 @@ mypy-typing-asserts==0.1.1; python_version >= "3.7" and python_version < "4.0" \
 packaging==21.3; python_version >= "3.6" \
     --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522 \
     --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb
-pex==2.1.66; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0" and python_version < "3.11") \
-    --hash=sha256:a6543af27bdfef2b8c88a92765f25bb30178a91d1fcda5963475d1719bd65dae \
-    --hash=sha256:1580ee7680a0c64db09233d55d39f31f3090470b479a0252fb69b0a0a6e3dccb
+pex==2.1.67; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0" and python_version < "3.11") \
+    --hash=sha256:9ebd76d04f1b9f576c38639197b0c93d41d7b1359f2917663951f8fda89d9436 \
+    --hash=sha256:aedc4746e677d12f35a5d594bd09d22267045fafef098fe9bca14d63bb09681c
 pluggy==1.0.0; python_version >= "3.6" \
     --hash=sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3 \
     --hash=sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -14,7 +14,7 @@ humbug==0.2.7
 
 ijson==3.1.4
 packaging==21.3
-pex==2.1.66
+pex==2.1.67
 psutil==5.9.0
 pytest>=6.2.4,<8  # This should be compatible with pytest.py, although it can be looser so that we don't over-constrain pantsbuild.pants.testutil
 python-lsp-jsonrpc==1.0.0

--- a/src/python/pants/backend/python/subsystems/lambdex_lockfile.txt
+++ b/src/python/pants/backend/python/subsystems/lambdex_lockfile.txt
@@ -17,6 +17,6 @@
 lambdex==0.1.6; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0" and python_version < "3.10") \
     --hash=sha256:cb685b106617fbd1afd26d6e9472b2e0c99df8574c6d358aee4e6c13aeef8eb1 \
     --hash=sha256:6d1a95c8a31baa703edece8e36a705045b0203c7e886812c27a4dd945aa694e0
-pex==2.1.66; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "3.10" \
-    --hash=sha256:a6543af27bdfef2b8c88a92765f25bb30178a91d1fcda5963475d1719bd65dae \
-    --hash=sha256:1580ee7680a0c64db09233d55d39f31f3090470b479a0252fb69b0a0a6e3dccb
+pex==2.1.67; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "3.10" \
+    --hash=sha256:9ebd76d04f1b9f576c38639197b0c93d41d7b1359f2917663951f8fda89d9436 \
+    --hash=sha256:aedc4746e677d12f35a5d594bd09d22267045fafef098fe9bca14d63bb09681c

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -303,18 +303,20 @@ class PexPlatformsField(StringSequenceField):
         "meaning that the PEX will be executable in all of the supported environments.\n\n"
         "Platforms should be in the format defined by Pex "
         "(https://pex.readthedocs.io/en/latest/buildingpex.html#platform), i.e. "
-        'PLATFORM-IMPL-PYVER-ABI (e.g. "linux_x86_64-cp-27-cp27mu", '
-        '"macosx_10.12_x86_64-cp-36-cp36m"):\n\n'
+        'PLATFORM-IMPL-PYVER-ABI (e.g. "linux_x86_64-cp-37-cp37m", '
+        '"macosx_10.12_x86_64-cp-310-cp310"):\n\n'
         "  - PLATFORM: the host platform, e.g. "
-        '"linux-x86_64", "macosx-10.12-x86_64".\n  - IMPL: the Python implementation '
-        'abbreviation, e.g. "cp", "pp", "jp".\n  - PYVER: a two-digit string representing '
-        'the Python version, e.g. "27", "36".\n  - ABI: the ABI tag, e.g. "cp36m", '
-        '"cp27mu", "abi3", "none".\n\nNote that using an abbreviated platform means that certain '
-        "resolves will fail when they contain environment markers that cannot be deduced from the "
-        "abbreviated platform string. A common example of this is 'python_full_version' which "
-        "requires knowing the patch level version of the foreign platform. If your resolves fail "
-        "due to undefined environment markers like this, you should switch to specifying "
-        "`complete_platforms` instead."
+        '"linux-x86_64", "macosx-10.12-x86_64".\n  - IMPL: the Python implementation abbreviation, '
+        'e.g. "cp" or "pp".\n  - PYVER: a two or more digit string representing the python '
+        'major/minor version (e.g., "37" or "310") or else a component dotted version string (e.g.,'
+        '"3.7" or "3.10.1").\n  - ABI: the ABI tag, e.g. "cp37m", "cp310", "abi3", "none".\n\nNote '
+        "that using an abbreviated platform means that certain resolves will fail when they "
+        "encounter environment markers that cannot be deduced from the abbreviated platform "
+        "string. A common example of this is 'python_full_version' which requires knowing the "
+        "patch level version of the foreign Python interpreter. To remedy this you should use a "
+        "3-component dotted version for PYVER. If your resolves fail due to more esoteric "
+        "undefined environment markers, you should switch to specifying `complete_platforms` "
+        "instead."
     )
 
 

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -39,9 +39,9 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."
 
-    default_version = "v2.1.66"
+    default_version = "v2.1.67"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.1.66,<3.0"
+    version_constraints = ">=2.1.67,<3.0"
 
     @classproperty
     def default_known_versions(cls):
@@ -50,8 +50,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "d3f985ab510a3a9442ae33d1e13277e29ab4d32c948800edf546f4f8bd7ca470",
-                    "3722278",
+                    "3f376dba013a6f1a810bfb59fd56a7d95a5ad297f04f57011d0b96cb1624676f",
+                    "3726119",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64"]


### PR DESCRIPTION
See the changelog here:
  https://github.com/pantsbuild/pex/releases/tag/v2.1.67

This pulls in support for `--platform` values with 3-component dotted
PYVER allowing an easier workaround than resorting to complete
platforms for evaluating `python_full_version` environment markers in
platform resolves.

[ci skip-rust]
[ci skip-build-wheels]