### PR TITLE
Migrate `experimental_shell_command` to `pants.backend.experimental.shell` as `shell_command`.

### DIFF
--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -214,6 +214,7 @@ def run_pants_help_all() -> dict[str, Any]:
         "pants.backend.experimental.python.lint.pyupgrade",
         "pants.backend.experimental.scala",
         "pants.backend.experimental.scala.lint.scalafmt",
+        "pants.backend.experimental.shell",
         "pants.backend.google_cloud_function.python",
         "pants.backend.plugin_development",
         "pants.backend.python",

--- a/pants.toml
+++ b/pants.toml
@@ -6,6 +6,7 @@ pythonpath = ["%(buildroot)s/pants-plugins"]
 backend_packages.add = [
   "pants.backend.python",
   "pants.backend.experimental.python.lint.autoflake",
+  "pants.backend.experimental.shell",
   "pants.backend.python.lint.black",
   "pants.backend.python.lint.docformatter",
   "pants.backend.python.lint.flake8",

--- a/src/python/pants/backend/experimental/shell/BUILD
+++ b/src/python/pants/backend/experimental/shell/BUILD
@@ -1,0 +1,4 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_sources()

--- a/src/python/pants/backend/experimental/shell/BUILD
+++ b/src/python/pants/backend/experimental/shell/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_sources()

--- a/src/python/pants/backend/experimental/shell/register.py
+++ b/src/python/pants/backend/experimental/shell/register.py
@@ -1,0 +1,18 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.backend.shell import shell_command
+from pants.backend.shell.target_types import ShellCommandRunTarget, ShellCommandTarget
+
+
+def target_types():
+    return [
+        ShellCommandTarget,
+        ShellCommandRunTarget,
+    ]
+
+
+def rules():
+    return [
+        *shell_command.rules(),
+    ]

--- a/src/python/pants/backend/shell/register.py
+++ b/src/python/pants/backend/shell/register.py
@@ -11,38 +11,15 @@ from pants.backend.shell.target_types import (
     Shunit2TestTarget,
 )
 from pants.backend.shell.target_types import rules as target_types_rules
-from pants.base.deprecated import deprecated
-
-
-@deprecated(
-    removal_version="2.12.0.dev0",
-    hint=(
-        "The `experimental_run_shell_command` target has migrated to the "
-        "`pants.backend.experimental.shell` backend and renamed to `run_shell_command`."
-    ),
-)
-class ExperimentalShellCommandRunTarget(ShellCommandRunTarget):
-    pass
-
-
-@deprecated(
-    removal_version="2.12.0.dev0",
-    hint=(
-        "The `experimental_shell_command` target has migrated to the "
-        "`pants.backend.experimental.shell` backend and renamed to `shell_command`."
-    ),
-)
-class ExperimentalShellCommandTarget(ShellCommandTarget):
-    pass
 
 
 def target_types():
     return [
-        ExperimentalShellCommandRunTarget,
-        ExperimentalShellCommandTarget,
+        ShellCommandRunTarget,
+        ShellCommandTarget,
         ShellSourcesGeneratorTarget,
-        Shunit2TestsGeneratorTarget,
         ShellSourceTarget,
+        Shunit2TestsGeneratorTarget,
         Shunit2TestTarget,
     ]
 

--- a/src/python/pants/backend/shell/register.py
+++ b/src/python/pants/backend/shell/register.py
@@ -11,12 +11,35 @@ from pants.backend.shell.target_types import (
     Shunit2TestTarget,
 )
 from pants.backend.shell.target_types import rules as target_types_rules
+from pants.base.deprecated import deprecated
+
+
+@deprecated(
+    removal_version="2.12.0.dev0",
+    hint=(
+        "The `experimental_run_shell_command` target has migrated to the "
+        "`pants.backend.experimental.shell` backend and renamed to `run_shell_command`."
+    ),
+)
+class ExperimentalShellCommandRunTarget(ShellCommandRunTarget):
+    pass
+
+
+@deprecated(
+    removal_version="2.12.0.dev0",
+    hint=(
+        "The `experimental_shell_command` target has migrated to the "
+        "`pants.backend.experimental.shell` backend and renamed to `shell_command`."
+    ),
+)
+class ExperimentalShellCommandTarget(ShellCommandTarget):
+    pass
 
 
 def target_types():
     return [
-        ShellCommandTarget,
-        ShellCommandRunTarget,
+        ExperimentalShellCommandRunTarget,
+        ExperimentalShellCommandTarget,
         ShellSourcesGeneratorTarget,
         Shunit2TestsGeneratorTarget,
         ShellSourceTarget,

--- a/src/python/pants/backend/shell/shell_command_test.py
+++ b/src/python/pants/backend/shell/shell_command_test.py
@@ -93,7 +93,7 @@ def test_sources_and_files(rule_runner: RuleRunner) -> None:
         {
             "src/BUILD": dedent(
                 """\
-                experimental_shell_command(
+                shell_command(
                   name="hello",
                   dependencies=[":build-utils", ":files"],
                   tools=[
@@ -143,7 +143,7 @@ def test_quotes_command(rule_runner: RuleRunner) -> None:
         {
             "src/BUILD": dedent(
                 """\
-                experimental_shell_command(
+                shell_command(
                   name="quotes",
                   tools=["echo", "tee"],
                   command='echo "foo bar" | tee out.log',
@@ -166,7 +166,7 @@ def test_chained_shell_commands(rule_runner: RuleRunner) -> None:
         {
             "src/a/BUILD": dedent(
                 """\
-                experimental_shell_command(
+                shell_command(
                   name="msg",
                   tools=["echo"],
                   outputs=["msg"],
@@ -176,7 +176,7 @@ def test_chained_shell_commands(rule_runner: RuleRunner) -> None:
             ),
             "src/b/BUILD": dedent(
                 """\
-                experimental_shell_command(
+                shell_command(
                   name="msg",
                   tools=["cp", "echo"],
                   outputs=["msg"],
@@ -209,7 +209,7 @@ def test_side_effecting_command(caplog, rule_runner: RuleRunner) -> None:
         {
             "src/BUILD": dedent(
                 """\
-                experimental_shell_command(
+                shell_command(
                   name="side-effect",
                   command="echo 'server started' && echo 'warn msg' >&2",
                   tools=["echo"],
@@ -240,7 +240,7 @@ def test_tool_search_path_stable(rule_runner: RuleRunner) -> None:
         {
             "src/BUILD": dedent(
                 """\
-                experimental_shell_command(
+                shell_command(
                   name="paths",
                   command="mkdir subdir; cd subdir; ls .",
                   tools=["cd", "ls", "mkdir"],
@@ -262,7 +262,7 @@ def test_shell_command_masquerade_as_a_files_target(rule_runner: RuleRunner) -> 
         {
             "src/BUILD": dedent(
                 """\
-                experimental_shell_command(
+                shell_command(
                   name="content-gen",
                   command="echo contents > contents.txt",
                   tools=["echo"],
@@ -304,7 +304,7 @@ def test_package_dependencies(caplog, rule_runner: RuleRunner) -> None:
         {
             "src/BUILD": dedent(
                 """\
-                experimental_shell_command(
+                shell_command(
                   name="msg-gen",
                   command="echo message > msg.txt",
                   tools=["echo"],
@@ -317,7 +317,7 @@ def test_package_dependencies(caplog, rule_runner: RuleRunner) -> None:
                   files=[":msg-gen"],
                 )
 
-                experimental_shell_command(
+                shell_command(
                   name="test",
                   command="ls .",
                   tools=["ls"],
@@ -345,12 +345,12 @@ def test_run_shell_command_request(rule_runner: RuleRunner) -> None:
         {
             "src/BUILD": dedent(
                 """\
-                experimental_run_shell_command(
+                run_shell_command(
                   name="test",
                   command="some cmd string",
                 )
 
-                experimental_run_shell_command(
+                run_shell_command(
                   name="cd-test",
                   command="some cmd string",
                   workdir="src/with space'n quote",
@@ -376,7 +376,7 @@ def test_shell_command_boot_script(rule_runner: RuleRunner) -> None:
         {
             "src/BUILD": dedent(
                 """\
-                experimental_shell_command(
+                shell_command(
                   name="boot-script-test",
                   tools=[
                     "python3.8",

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -301,7 +301,9 @@ class ShellCommandRunWorkdirField(StringField):
 
 
 class ShellCommandTarget(Target):
-    alias = "experimental_shell_command"
+    alias = "shell_command"
+    deprecated_alias = "experimental_shell_command"
+    deprecated_alias_removal_version = "2.12.0.dev0"
     core_fields = (
         *COMMON_TARGET_FIELDS,
         Dependencies,
@@ -319,7 +321,7 @@ class ShellCommandTarget(Target):
 
             Example BUILD file:
 
-                experimental_shell_command(
+                shell_command(
                   command="./my-script.sh --flag",
                   tools=["tar", "curl", "cat", "bash", "env"],
                   dependencies=[":scripts"],
@@ -338,7 +340,9 @@ class ShellCommandTarget(Target):
 
 
 class ShellCommandRunTarget(Target):
-    alias = "experimental_run_shell_command"
+    alias = "run_shell_command"
+    deprecated_alias = "experimental_run_shell_command"
+    deprecated_alias_removal_version = "2.12.0.dev0"
     core_fields = (
         *COMMON_TARGET_FIELDS,
         Dependencies,
@@ -352,7 +356,7 @@ class ShellCommandRunTarget(Target):
 
             Example BUILD file:
 
-                experimental_run_shell_command(
+                run_shell_command(
                   command="./scripts/my-script.sh --data-files-dir={chroot}",
                   dependencies=["src/project/files:data"],
                 )
@@ -361,7 +365,7 @@ class ShellCommandRunTarget(Target):
         )
         + "The `command` may use either `{chroot}` on the command line, or the `$CHROOT` "
         "environment variable to get the root directory for where any dependencies are located.\n\n"
-        "In contrast to the `experimental_shell_command`, in addition to `workdir` you only have "
+        "In contrast to the `shell_command`, in addition to `workdir` you only have "
         "the `command` and `dependencies` fields as the `tools` you are going to use are already "
         "on the PATH which is inherited from the Pants environment. Also, the `outputs` does not "
         "apply, as any output files produced will end up directly in your project tree."

--- a/src/python/pants/init/BUILD
+++ b/src/python/pants/init/BUILD
@@ -25,6 +25,7 @@ target(
         "src/python/pants/backend/experimental/scala",
         "src/python/pants/backend/experimental/scala/debug_goals",
         "src/python/pants/backend/experimental/scala/lint/scalafmt",
+        "src/python/pants/backend/experimental/shell",
         "src/python/pants/backend/experimental/terraform",
         "src/python/pants/backend/google_cloud_function/python",
         "src/python/pants/backend/plugin_development",

--- a/testprojects/src/python/BUILD
+++ b/testprojects/src/python/BUILD
@@ -19,7 +19,7 @@ files(name="python_targets_directory", sources=["python_targets/**/*"])
 
 files(name="sources_directory", sources=["sources/**/*"])
 
-experimental_run_shell_command(
+run_shell_command(
     name="cmd",
     command='{{ tree {chroot}; echo "in: $CHROOT"; }} | tee output.log',
     dependencies=[":hello_directory"],


### PR DESCRIPTION
Deprecating the `experimental_` prefix in favour of registering the targets from an experimental backend instead.
