### PR TITLE
upgrade python-hcl2 to version 3.0.3

### DIFF
--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -34,7 +34,7 @@ class TerraformHcl2Parser(PythonToolRequirementsBase):
     options_scope = "terraform-hcl2-parser"
     help = "Used to parse Terraform modules to infer their dependencies."
 
-    default_version = "python-hcl2==3.0.1"
+    default_version = "python-hcl2==3.0.3"
 
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.6"]

--- a/src/python/pants/backend/terraform/hcl2_lockfile.txt
+++ b/src/python/pants/backend/terraform/hcl2_lockfile.txt
@@ -9,12 +9,12 @@
 #     "CPython>=3.6"
 #   ],
 #   "generated_with_requirements": [
-#     "python-hcl2==3.0.1"
+#     "python-hcl2==3.0.3"
 #   ]
 # }
 # --- END PANTS LOCKFILE METADATA ---
 
 lark-parser==0.10.1; python_full_version >= "3.6.0" \
     --hash=sha256:42f367612a1bbc4cf9d8c8eb1b209d8a9b397d55af75620c9e6f53e502235996
-python-hcl2==3.0.1; python_full_version >= "3.6.0" \
-    --hash=sha256:f6c178d216e9d8ef1ef9fceeb16792cbabfb69d2ae1a73e263974ab6f74489ab
+python-hcl2==3.0.3; python_full_version >= "3.6.0" \
+    --hash=sha256:31b8135f474aa2dbd2325d7924f5ffe0b8a713669ca2d043511d8ed5a91798e5


### PR DESCRIPTION
This release fixes a bug I encountered and fixed:
https://github.com/amplify-education/python-hcl2/pull/87
