### PR TITLE
[internal] BSP: freeze non-empty `data` json in init message

### DIFF
--- a/src/python/pants/bsp/protocol.py
+++ b/src/python/pants/bsp/protocol.py
@@ -22,7 +22,6 @@ from pants.bsp.spec import (
     WorkspaceBuildTargetsResult,
 )
 from pants.engine.internals.scheduler import SchedulerSession
-from pants.util.frozendict import FrozenDict
 
 _logger = logging.getLogger(__name__)
 
@@ -123,21 +122,3 @@ class BSPConnection:
             return self._handle_inbound_message(method_name=method_name, params=params)
 
         return handler
-
-
-def _freeze(item: Any) -> Any:
-    if item is None:
-        return None
-    elif isinstance(item, list) or isinstance(item, tuple):
-        return tuple(_freeze(x) for x in item)
-    elif isinstance(item, dict):
-        result = {}
-        for k, v in item.items():
-            if not isinstance(k, str):
-                raise AssertionError("Got non-`str` key for _freeze.")
-            result[k] = _freeze(v)
-        return FrozenDict(result)
-    elif isinstance(item, str) or isinstance(item, int) or isinstance(item, float):
-        return item
-    else:
-        raise AssertionError(f"Unsupported value type for _freeze: {type(item)}")

--- a/src/python/pants/bsp/protocol_test.py
+++ b/src/python/pants/bsp/protocol_test.py
@@ -94,13 +94,13 @@ def test_basic_bsp_protocol() -> None:
             bsp_version="0.0.0",
             root_uri="https://example.com",
             capabilities=BuildClientCapabilities(language_ids=()),
-            data=None,
+            data={"test": "foo"},
         )
         response_fut = endpoint.request("build/initialize", init_request.to_json_dict())
         raw_response = response_fut.result(timeout=15)
         response = InitializeBuildResult.from_json_dict(raw_response)
         assert response.display_name == "Pants"
-        assert response.bsp_version == "0.0.1"
+        assert response.bsp_version == "2.0.0-M15"
 
         build_targets_request = WorkspaceBuildTargetsParams()
         response_fut = endpoint.request(

--- a/src/python/pants/bsp/protocol_test.py
+++ b/src/python/pants/bsp/protocol_test.py
@@ -100,7 +100,7 @@ def test_basic_bsp_protocol() -> None:
         raw_response = response_fut.result(timeout=15)
         response = InitializeBuildResult.from_json_dict(raw_response)
         assert response.display_name == "Pants"
-        assert response.bsp_version == "2.0.0-M15"
+        assert response.bsp_version == "2.0.0"
 
         build_targets_request = WorkspaceBuildTargetsParams()
         response_fut = endpoint.request(

--- a/src/python/pants/bsp/rules.py
+++ b/src/python/pants/bsp/rules.py
@@ -17,7 +17,7 @@ from pants.engine.rules import QueryRule, collect_rules, rule
 from pants.engine.unions import UnionMembership, union
 from pants.version import VERSION
 
-BSP_VERSION = "2.0.0-M15"
+BSP_VERSION = "2.0.0"
 
 
 @union

--- a/src/python/pants/bsp/rules.py
+++ b/src/python/pants/bsp/rules.py
@@ -17,6 +17,8 @@ from pants.engine.rules import QueryRule, collect_rules, rule
 from pants.engine.unions import UnionMembership, union
 from pants.version import VERSION
 
+BSP_VERSION = "2.0.0-M15"
+
 
 @union
 class BSPBuildTargetsRequest:
@@ -34,7 +36,7 @@ async def bsp_build_initialize(_request: InitializeBuildParams) -> InitializeBui
     return InitializeBuildResult(
         display_name="Pants",
         version=VERSION,
-        bsp_version="0.0.1",  # TODO: replace with an actual BSP version
+        bsp_version=BSP_VERSION,  # TODO: replace with an actual BSP version
         capabilities=BuildServerCapabilities(
             compile_provider=None,
             test_provider=None,

--- a/src/python/pants/bsp/spec.py
+++ b/src/python/pants/bsp/spec.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from pants.bsp.utils import freeze_json
+
 # -----------------------------------------------------------------------------------------------
 # Base types
 # -----------------------------------------------------------------------------------------------
@@ -277,7 +279,7 @@ class InitializeBuildParams:
             bsp_version=d["bspVersion"],
             root_uri=d["rootUri"],
             capabilities=BuildClientCapabilities.from_json_dict(d["capabilities"]),
-            data=d.get("data"),
+            data=freeze_json(d.get("data")),
         )
 
     def to_json_dict(self):

--- a/src/python/pants/bsp/utils.py
+++ b/src/python/pants/bsp/utils.py
@@ -1,0 +1,26 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from typing import Any
+
+from pants.util.frozendict import FrozenDict
+
+
+def freeze_json(item: Any) -> Any:
+    if item is None:
+        return None
+    elif isinstance(item, list) or isinstance(item, tuple):
+        return tuple(freeze_json(x) for x in item)
+    elif isinstance(item, dict):
+        result = {}
+        for k, v in item.items():
+            if not isinstance(k, str):
+                raise AssertionError("Got non-`str` key for _freeze.")
+            result[k] = freeze_json(v)
+        return FrozenDict(result)
+    elif isinstance(item, str) or isinstance(item, int) or isinstance(item, float):
+        return item
+    else:
+        raise AssertionError(f"Unsupported value type for _freeze: {type(item)}")


### PR DESCRIPTION
If the BSP client passes a non-empty `data` in `build/initialize` method, freeze the `dict` before sending it into the engine or else the request will fail with `unhashable type: dict` error.

[ci skip-rust]

[ci skip-build-wheels]