### PR TITLE
[internal] BSP: bootstrap enough of BSP to let IntelliJ load for Scala

### DIFF
--- a/src/python/pants/backend/experimental/scala/register.py
+++ b/src/python/pants/backend/experimental/scala/register.py
@@ -1,5 +1,6 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+from pants.backend.scala.bsp.rules import rules as bsp_rules
 from pants.backend.scala.compile import scalac
 from pants.backend.scala.dependency_inference import rules as dep_inf_rules
 from pants.backend.scala.goals import check, repl, tailor
@@ -22,7 +23,6 @@ from pants.jvm.package import deploy_jar
 from pants.jvm.resolve import coursier_fetch, coursier_setup, jvm_tool
 from pants.jvm.target_types import DeployJarTarget, JvmArtifactTarget
 from pants.jvm.test import junit
-from pants.backend.scala.bsp.rules import rules as bsp_rules
 
 
 def target_types():

--- a/src/python/pants/backend/experimental/scala/register.py
+++ b/src/python/pants/backend/experimental/scala/register.py
@@ -22,6 +22,7 @@ from pants.jvm.package import deploy_jar
 from pants.jvm.resolve import coursier_fetch, coursier_setup, jvm_tool
 from pants.jvm.target_types import DeployJarTarget, JvmArtifactTarget
 from pants.jvm.test import junit
+from pants.backend.scala.bsp.rules import rules as bsp_rules
 
 
 def target_types():
@@ -59,4 +60,5 @@ def rules():
         *resources.rules(),
         *run_deploy_jar.rules(),
         *scala_lockfile_rules(),
+        *bsp_rules(),
     ]

--- a/src/python/pants/backend/scala/bsp/BUILD
+++ b/src/python/pants/backend/scala/bsp/BUILD
@@ -1,0 +1,4 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_sources()

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -17,7 +17,7 @@ from pants.bsp.spec import BuildTarget, BuildTargetCapabilities, BuildTargetIden
 from pants.build_graph.address import AddressInput
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import QueryRule, collect_rules, rule
-from pants.engine.target import Target, WrappedTarget
+from pants.engine.target import WrappedTarget
 from pants.engine.unions import UnionRule
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
@@ -28,13 +28,13 @@ class ScalaBSPBuildTargetsRequest(BSPBuildTargetsRequest):
 
 
 def _pants_target_to_bsp_build_target(
-    target: Target, jvm: JvmSubsystem, scala: ScalaSubsystem
+    resolve_field: JvmResolveField, jvm: JvmSubsystem, scala: ScalaSubsystem
 ) -> BuildTarget:
-    resolve = target[JvmResolveField].normalized_value(jvm)
+    resolve = resolve_field.normalized_value(jvm)
     scala_version = scala.version_for_resolve(resolve)
     return BuildTarget(
-        id=BuildTargetIdentifier(uri=f"pants:{target.address}"),
-        display_name=str(target.address),
+        id=BuildTargetIdentifier(uri=f"pants:{resolve_field.address}"),
+        display_name=str(resolve_field.address),
         base_directory=None,
         tags=(),
         capabilities=BuildTargetCapabilities(),
@@ -59,7 +59,8 @@ async def determine_scala_bsp_build_targets(
     scala: ScalaSubsystem,
 ) -> BSPBuildTargets:
     scala_bsp_build_targets = [
-        _pants_target_to_bsp_build_target(tgt, jvm, scala) for tgt in all_scala_targets
+        _pants_target_to_bsp_build_target(tgt[JvmResolveField], jvm, scala)
+        for tgt in all_scala_targets
     ]
     return BSPBuildTargets(targets=tuple(scala_bsp_build_targets))
 

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -1,0 +1,120 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from dataclasses import dataclass
+
+from pants.backend.scala.bsp.spec import (
+    ScalaBuildTarget,
+    ScalacOptionsItem,
+    ScalacOptionsParams,
+    ScalacOptionsResult,
+    ScalaPlatform,
+)
+from pants.backend.scala.dependency_inference.symbol_mapper import AllScalaTargets
+from pants.backend.scala.subsystems.scala import ScalaSubsystem
+from pants.base.build_root import BuildRoot
+from pants.bsp.rules import BSPBuildTargets, BSPBuildTargetsRequest
+from pants.bsp.spec import BuildTarget, BuildTargetCapabilities, BuildTargetIdentifier
+from pants.build_graph.address import AddressInput
+from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.rules import QueryRule, collect_rules, rule
+from pants.engine.target import Target, WrappedTarget
+from pants.engine.unions import UnionRule
+from pants.jvm.subsystems import JvmSubsystem
+from pants.jvm.target_types import JvmResolveField
+
+
+class ScalaBSPBuildTargetsRequest(BSPBuildTargetsRequest):
+    pass
+
+
+def _pants_target_to_bsp_build_target(
+    target: Target, jvm: JvmSubsystem, scala: ScalaSubsystem
+) -> BuildTarget:
+    resolve = target[JvmResolveField].normalized_value(jvm)
+    scala_version = scala.version_for_resolve(resolve)
+    return BuildTarget(
+        id=BuildTargetIdentifier(uri=f"pants:{target.address}"),
+        display_name=str(target.address),
+        base_directory=None,
+        tags=(),
+        capabilities=BuildTargetCapabilities(),
+        language_ids=("scala",),
+        dependencies=(),
+        data_kind="scala",
+        data=ScalaBuildTarget(
+            scala_organization="unknown",
+            scala_version=".".join(scala_version.split(".")[0:2]),
+            scala_binary_version=scala_version,
+            platform=ScalaPlatform.JVM,
+            jars=(),
+        ),
+    )
+
+
+@rule
+async def determine_scala_bsp_build_targets(
+    _: ScalaBSPBuildTargetsRequest,
+    all_scala_targets: AllScalaTargets,
+    jvm: JvmSubsystem,
+    scala: ScalaSubsystem,
+) -> BSPBuildTargets:
+    scala_bsp_build_targets = [
+        _pants_target_to_bsp_build_target(tgt, jvm, scala) for tgt in all_scala_targets
+    ]
+    return BSPBuildTargets(targets=tuple(scala_bsp_build_targets))
+
+
+# -----------------------------------------------------------------------------------------------
+# Scalac Options Request
+# See https://build-server-protocol.github.io/docs/extensions/scala.html#scalac-options-request
+# -----------------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class HandleScalacOptionsRequest:
+    bsp_target_id: BuildTargetIdentifier
+
+
+@dataclass(frozen=True)
+class HandleScalacOptionsResult:
+    item: ScalacOptionsItem
+
+
+@rule
+async def handle_bsp_scalac_options_request(
+    request: HandleScalacOptionsRequest,
+    build_root: BuildRoot,
+) -> HandleScalacOptionsResult:
+    uri = request.bsp_target_id.uri
+    if not uri.startswith("pants:"):
+        raise ValueError(f"Unknown URI for Pants BSP: {uri}")
+    raw_addr = uri[len("pants:") :]
+
+    # Verify the target exists by loading it. Exception will be thrown if it does not.
+    _ = await Get(WrappedTarget, AddressInput, AddressInput.parse(raw_addr))
+
+    return HandleScalacOptionsResult(
+        ScalacOptionsItem(
+            target=request.bsp_target_id,
+            options=(),
+            classpath=(),
+            # TODO: Figure out how to provide a classfiles output directory
+            class_directory=build_root.pathlib_path.joinpath("dist/bsp").as_uri(),
+        )
+    )
+
+
+@rule
+async def bsp_scalac_options_request(request: ScalacOptionsParams) -> ScalacOptionsResult:
+    results = await MultiGet(
+        Get(HandleScalacOptionsResult, HandleScalacOptionsRequest(btgt)) for btgt in request.targets
+    )
+    return ScalacOptionsResult(items=tuple(result.item for result in results))
+
+
+def rules():
+    return (
+        *collect_rules(),
+        UnionRule(BSPBuildTargetsRequest, ScalaBSPBuildTargetsRequest),
+        QueryRule(ScalacOptionsResult, (ScalacOptionsParams,)),
+    )

--- a/src/python/pants/backend/scala/bsp/spec.py
+++ b/src/python/pants/backend/scala/bsp/spec.py
@@ -13,6 +13,12 @@ class JvmBuildTarget:
     pass
 
 
+# -----------------------------------------------------------------------------------------------
+# Scala-specific Build Target
+# See https://build-server-protocol.github.io/docs/extensions/scala.html#scala-build-target
+# -----------------------------------------------------------------------------------------------
+
+
 class ScalaPlatform:
     JVM = 1
     JS = 2

--- a/src/python/pants/backend/scala/bsp/spec.py
+++ b/src/python/pants/backend/scala/bsp/spec.py
@@ -1,0 +1,119 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from pants.bsp.spec import BuildTargetIdentifier, Uri
+
+
+@dataclass(frozen=True)
+class JvmBuildTarget:
+    pass
+
+
+class ScalaPlatform:
+    JVM = 1
+    JS = 2
+    Native = 3
+
+
+@dataclass(frozen=True)
+class ScalaBuildTarget:
+    # The Scala organization that is used for a target.
+    scala_organization: str
+
+    # The scala version to compile this target
+    scala_version: str
+
+    # The binary version of scalaVersion.
+    # For example, 2.12 if scalaVersion is 2.12.4.
+    scala_binary_version: str
+
+    # The target platform for this target.
+    # See `ScalaPlatform` constants.
+    platform: int
+
+    # A sequence of Scala jars such as scala-library, scala-compiler and scala-reflect.
+    jars: tuple[str, ...]
+
+    # The jvm build target describing jdk to be used
+    jvm_build_target: JvmBuildTarget | None = None
+
+    @classmethod
+    def from_json_dict(cls, d: Any):
+        return cls(
+            scala_organization=d["scalaOrganization"],
+            scala_version=d["scalaVersion"],
+            scala_binary_version=d["scalaBinaryVersion"],
+            platform=d["platform"],
+            jars=tuple(d.get("jars", [])),
+            jvm_build_target=JvmBuildTarget(),  # TODO: deserialize this
+        )
+
+    def to_json_dict(self):
+        return {
+            "scalaOrganization": self.scala_organization,
+            "scalaVersion": self.scala_version,
+            "scalaBinaryVersion": self.scala_binary_version,
+            "platform": self.platform,
+            "jars": list(self.jars),
+            "jvmBuildTarget": None,  # TODO: serialize this
+        }
+
+
+# -----------------------------------------------------------------------------------------------
+# Scalac Options Request
+# See https://build-server-protocol.github.io/docs/extensions/scala.html#scalac-options-request
+# -----------------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ScalacOptionsParams:
+    targets: tuple[BuildTargetIdentifier, ...]
+
+    @classmethod
+    def from_json_dict(cls, d):
+        return cls(
+            targets=tuple(BuildTargetIdentifier.from_json_dict(x) for x in d["targets"]),
+        )
+
+    def to_json_dict(self):
+        return {
+            "targets": [tgt.to_json_dict() for tgt in self.targets],
+        }
+
+
+@dataclass(frozen=True)
+class ScalacOptionsItem:
+    target: BuildTargetIdentifier
+
+    # Additional arguments to the compiler.
+    # For example, -deprecation.
+    options: tuple[str, ...]
+
+    # The dependency classpath for this target, must be
+    # identical to what is passed as arguments to
+    # the -classpath flag in the command line interface
+    # of scalac.
+    classpath: tuple[Uri, ...]
+
+    # The output directory for classfiles produced by this target
+    class_directory: Uri
+
+    def to_json_dict(self):
+        return {
+            "target": self.target.to_json_dict(),
+            "options": self.options,
+            "classpath": self.classpath,
+            "classDirectory": self.class_directory,
+        }
+
+
+@dataclass(frozen=True)
+class ScalacOptionsResult:
+    items: tuple[ScalacOptionsItem, ...]
+
+    def to_json_dict(self):
+        return {"items": [item.to_json_dict() for item in self.items]}

--- a/src/python/pants/bsp/goal.py
+++ b/src/python/pants/bsp/goal.py
@@ -29,9 +29,9 @@ class BSPGoal(BuiltinGoal):
         specs: Specs,
         union_membership: UnionMembership
     ) -> ExitCode:
-        scheduler_session = graph_session.scheduler_session.scheduler.new_session(
-            build_id="bsp", dynamic_ui=False
-        )
+        # scheduler_session = graph_session.scheduler_session.scheduler.new_session(
+        #     build_id="bsp", dynamic_ui=False
+        # )
 
         saved_stdout = sys.stdout
         saved_stdin = sys.stdin
@@ -39,7 +39,7 @@ class BSPGoal(BuiltinGoal):
             sys.stdout = os.fdopen(sys.stdout.fileno(), "wb", buffering=0)  # type: ignore[assignment]
             sys.stdin = os.fdopen(sys.stdin.fileno(), "rb", buffering=0)  # type: ignore[assignment]
             conn = BSPConnection(
-                scheduler_session,
+                graph_session.scheduler_session,
                 sys.stdin,  # type: ignore[arg-type]
                 sys.stdout,  # type: ignore[arg-type]
             )

--- a/src/python/pants/bsp/goal.py
+++ b/src/python/pants/bsp/goal.py
@@ -29,10 +29,6 @@ class BSPGoal(BuiltinGoal):
         specs: Specs,
         union_membership: UnionMembership
     ) -> ExitCode:
-        # scheduler_session = graph_session.scheduler_session.scheduler.new_session(
-        #     build_id="bsp", dynamic_ui=False
-        # )
-
         saved_stdout = sys.stdout
         saved_stdin = sys.stdin
         try:

--- a/src/python/pants/bsp/protocol.py
+++ b/src/python/pants/bsp/protocol.py
@@ -15,9 +15,12 @@ from pylsp_jsonrpc.exceptions import (  # type: ignore[import]
 )
 from pylsp_jsonrpc.streams import JsonRpcStreamReader, JsonRpcStreamWriter  # type: ignore[import]
 
+from pants.backend.scala.bsp.spec import ScalacOptionsParams, ScalacOptionsResult
 from pants.bsp.spec import (
     InitializeBuildParams,
     InitializeBuildResult,
+    SourcesParams,
+    SourcesResult,
     WorkspaceBuildTargetsParams,
     WorkspaceBuildTargetsResult,
 )
@@ -39,6 +42,12 @@ BSP_HANDLER_MAPPING = {
     ),
     "workspace/buildTargets": _HandlerMapping(
         WorkspaceBuildTargetsParams.from_json_dict, WorkspaceBuildTargetsResult
+    ),
+    "buildTarget/sources": _HandlerMapping(SourcesParams.from_json_dict, SourcesResult),
+    # scala-specific methods
+    # TODO: Discover these via a union so they only load when Scala backend is loaded.
+    "buildTarget/scalacOptions": _HandlerMapping(
+        ScalacOptionsParams.from_json_dict, ScalacOptionsResult
     ),
 }
 

--- a/src/python/pants/bsp/rules.py
+++ b/src/python/pants/bsp/rules.py
@@ -4,16 +4,25 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from pants.base.build_root import BuildRoot
 from pants.bsp.spec import (
     BuildServerCapabilities,
     BuildTarget,
+    BuildTargetIdentifier,
     InitializeBuildParams,
     InitializeBuildResult,
+    SourceItem,
+    SourceItemKind,
+    SourcesItem,
+    SourcesParams,
+    SourcesResult,
     WorkspaceBuildTargetsParams,
     WorkspaceBuildTargetsResult,
 )
+from pants.build_graph.address import AddressInput
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import QueryRule, collect_rules, rule
+from pants.engine.target import SourcesField, SourcesPaths, SourcesPathsRequest, WrappedTarget
 from pants.engine.unions import UnionMembership, union
 from pants.version import VERSION
 
@@ -53,6 +62,12 @@ async def bsp_build_initialize(_request: InitializeBuildParams) -> InitializeBui
     )
 
 
+# -----------------------------------------------------------------------------------------------
+# Workspace Build Targets Request
+# See https://build-server-protocol.github.io/docs/specification.html#workspace-build-targets-request
+# -----------------------------------------------------------------------------------------------
+
+
 @rule
 async def bsp_workspace_build_targets(
     _: WorkspaceBuildTargetsParams, union_membership: UnionMembership
@@ -71,9 +86,72 @@ async def bsp_workspace_build_targets(
     )
 
 
+# -----------------------------------------------------------------------------------------------
+# Build Target Sources Request
+# See https://build-server-protocol.github.io/docs/specification.html#build-target-sources-request
+# -----------------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MaterializeBuildTargetSourcesRequest:
+    bsp_target_id: BuildTargetIdentifier
+
+
+@dataclass(frozen=True)
+class MaterializeBuildTargetSourcesResult:
+    sources_item: SourcesItem
+
+
+@rule
+async def materialize_bsp_build_target_sources(
+    request: MaterializeBuildTargetSourcesRequest,
+    build_root: BuildRoot,
+) -> MaterializeBuildTargetSourcesResult:
+    uri = request.bsp_target_id.uri
+    if not uri.startswith("pants:"):
+        raise ValueError(f"Unknown URI for Pants BSP: {uri}")
+    raw_addr = uri[len("pants:") :]
+
+    wrapped_target = await Get(WrappedTarget, AddressInput, AddressInput.parse(raw_addr))
+    target = wrapped_target.target
+
+    if not target.has_field(SourcesField):
+        raise AssertionError(f"BSP only handles targets with sources: uri={uri}")
+
+    sources_paths = await Get(SourcesPaths, SourcesPathsRequest(target[SourcesField]))
+    sources_full_paths = [
+        build_root.pathlib_path.joinpath(src_path) for src_path in sources_paths.files
+    ]
+
+    sources_item = SourcesItem(
+        target=request.bsp_target_id,
+        sources=tuple(
+            SourceItem(
+                uri=src_full_path.as_uri(),
+                kind=SourceItemKind.FILE,
+                generated=False,
+            )
+            for src_full_path in sources_full_paths
+        ),
+        roots=(),
+    )
+
+    return MaterializeBuildTargetSourcesResult(sources_item)
+
+
+@rule
+async def bsp_build_target_sources(request: SourcesParams) -> SourcesResult:
+    sources_items = await MultiGet(
+        Get(MaterializeBuildTargetSourcesResult, MaterializeBuildTargetSourcesRequest(btgt))
+        for btgt in request.targets
+    )
+    return SourcesResult(items=tuple(si.sources_item for si in sources_items))
+
+
 def rules():
     return (
         *collect_rules(),
         QueryRule(InitializeBuildResult, (InitializeBuildParams,)),
         QueryRule(WorkspaceBuildTargetsResult, (WorkspaceBuildTargetsParams,)),
+        QueryRule(SourcesResult, (SourcesParams,)),
     )


### PR DESCRIPTION
Implement just enough of Build Server Protocol to allow IntelliJ's Scala plugin to load successfully using Pants as the BSP server. No BSP actions (e.g., compile or test) are implemented, but IntelliJ is able to successfully interact with the Pants BSP server and load metadata for [`example-jvm` repository](https://github.com/pantsbuild/example-jvm/).

[ci skip-rust]

[ci skip-build-wheels]