### PR TITLE
Shortcircuit local distribution source subsetting if there are no dists.

### DIFF
--- a/src/python/pants/backend/python/util_rules/local_dists.py
+++ b/src/python/pants/backend/python/util_rules/local_dists.py
@@ -178,6 +178,12 @@ async def build_local_dists(
         ),
     )
 
+    if not wheels:
+        # The source calculations below are not (always) cheap, so we skip them if no wheels were
+        # produced. See https://github.com/pantsbuild/pants/issues/14561 for one possible approach
+        # to sharing the cost of these calculations.
+        return LocalDistsPex(dists_pex, request.sources)
+
     # We check source roots in reverse lexicographic order,
     # so we'll find the innermost root that matches.
     source_roots = sorted(request.sources.source_roots, reverse=True)


### PR DESCRIPTION
#14551 improved the performance of local dist building when local distributions are actually present. But there are cases (which @benjyw is pursuing) where the `@rule` takes a long time to run, even when no dists are actually present. This is likely to do with the source subtraction: either the calculation of the subset paths, or the execution of `DigestSubset`.

[ci skip-rust]
[ci skip-build-wheels]