### PR TITLE
[internal] use a union for registration of BSP handlers

### DIFF
--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -12,12 +12,13 @@ from pants.backend.scala.bsp.spec import (
 from pants.backend.scala.dependency_inference.symbol_mapper import AllScalaTargets
 from pants.backend.scala.subsystems.scala import ScalaSubsystem
 from pants.base.build_root import BuildRoot
+from pants.bsp.protocol import BSPHandlerMapping
 from pants.bsp.rules import BSPBuildTargets, BSPBuildTargetsRequest
 from pants.bsp.spec import BuildTarget, BuildTargetCapabilities, BuildTargetIdentifier
 from pants.build_graph.address import AddressInput
 from pants.engine.addresses import Addresses
 from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.rules import QueryRule, collect_rules, rule
+from pants.engine.rules import collect_rules, rule
 from pants.engine.target import Dependencies, DependenciesRequest, Target, WrappedTarget
 from pants.engine.unions import UnionRule
 from pants.jvm.subsystems import JvmSubsystem
@@ -82,6 +83,12 @@ async def bsp_resolve_all_scala_build_targets(
 # -----------------------------------------------------------------------------------------------
 
 
+class ScalacOptionsHandlerMapping(BSPHandlerMapping):
+    method_name = "buildTarget/scalacOptions"
+    request_type = ScalacOptionsParams
+    response_type = ScalacOptionsResult
+
+
 @dataclass(frozen=True)
 class HandleScalacOptionsRequest:
     bsp_target_id: BuildTargetIdentifier
@@ -123,5 +130,5 @@ def rules():
     return (
         *collect_rules(),
         UnionRule(BSPBuildTargetsRequest, ScalaBSPBuildTargetsRequest),
-        QueryRule(ScalacOptionsResult, (ScalacOptionsParams,)),
+        UnionRule(BSPHandlerMapping, ScalacOptionsHandlerMapping),
     )

--- a/src/python/pants/bsp/goal.py
+++ b/src/python/pants/bsp/goal.py
@@ -36,6 +36,7 @@ class BSPGoal(BuiltinGoal):
             sys.stdin = os.fdopen(sys.stdin.fileno(), "rb", buffering=0)  # type: ignore[assignment]
             conn = BSPConnection(
                 graph_session.scheduler_session,
+                union_membership,
                 sys.stdin,  # type: ignore[arg-type]
                 sys.stdout,  # type: ignore[arg-type]
             )

--- a/src/python/pants/bsp/protocol_test.py
+++ b/src/python/pants/bsp/protocol_test.py
@@ -62,7 +62,12 @@ def test_basic_bsp_protocol() -> None:
         # TODO: This code should be moved to a context manager. For now, only the pipes are managed
         # with a context manager.
         rule_runner = RuleRunner(rules=bsp_rules())
-        conn = BSPConnection(rule_runner.scheduler, pipes.inbound_reader, pipes.outbound_writer)
+        conn = BSPConnection(
+            rule_runner.scheduler,
+            rule_runner.union_membership,
+            pipes.inbound_reader,
+            pipes.outbound_writer,
+        )
 
         def run_bsp_server():
             conn.run()

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -12,6 +12,7 @@ from pants.base.build_environment import get_buildroot
 from pants.base.build_root import BuildRoot
 from pants.base.exiter import PANTS_SUCCEEDED_EXIT_CODE
 from pants.base.specs import Specs
+from pants.bsp.protocol import BSPHandlerMapping
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.engine import desktop, environment, fs, platform, process
 from pants.engine.console import Console
@@ -265,7 +266,16 @@ class EngineInitializer:
                 *rules,
             )
         )
+
         goal_map = EngineInitializer._make_goal_map_from_rules(rules)
+
+        union_membership = UnionMembership.from_rules(
+            (
+                *build_configuration.union_rules,
+                *(r for r in rules if isinstance(r, UnionRule)),
+            )
+        )
+
         rules = FrozenOrderedSet(
             (
                 *rules,
@@ -274,13 +284,11 @@ class EngineInitializer:
                     QueryRule(goal_type, GraphSession.goal_param_types)
                     for goal_type in goal_map.values()
                 ),
+                *(
+                    QueryRule(impl.response_type, (impl.request_type,))
+                    for impl in union_membership.get(BSPHandlerMapping)
+                ),
                 QueryRule(Snapshot, [PathGlobs]),  # Used by the SchedulerService.
-            )
-        )
-        union_membership = UnionMembership.from_rules(
-            (
-                *build_configuration.union_rules,
-                *(r for r in rules if isinstance(r, UnionRule)),
             )
         )
 

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -284,6 +284,9 @@ class EngineInitializer:
                     QueryRule(goal_type, GraphSession.goal_param_types)
                     for goal_type in goal_map.values()
                 ),
+                # Install queries for each request/response pair used by the BSP support.
+                # Note: These are necessary because the BSP support is a built-in goal and that makes
+                # synchronous requests into the engine.
                 *(
                     QueryRule(impl.response_type, (impl.request_type,))
                     for impl in union_membership.get(BSPHandlerMapping)


### PR DESCRIPTION
Introduce `BSPHandlerMapping` union to allow rules to register BSP method handlers. This allows the core BSP protocol driver to be unaware of the particular BSP methods that are handled incuding any registered by language-specific plugins.

[ci skip-rust]

[ci skip-build-wheels]