### PR TITLE
[internal] BSP: cleanup Scala build target resolution

### DIFF
--- a/src/python/pants/bsp/rules.py
+++ b/src/python/pants/bsp/rules.py
@@ -107,16 +107,13 @@ async def materialize_bsp_build_target_sources(
     request: MaterializeBuildTargetSourcesRequest,
     build_root: BuildRoot,
 ) -> MaterializeBuildTargetSourcesResult:
-    uri = request.bsp_target_id.uri
-    if not uri.startswith("pants:"):
-        raise ValueError(f"Unknown URI for Pants BSP: {uri}")
-    raw_addr = uri[len("pants:") :]
-
-    wrapped_target = await Get(WrappedTarget, AddressInput, AddressInput.parse(raw_addr))
+    wrapped_target = await Get(WrappedTarget, AddressInput, request.bsp_target_id.address_input)
     target = wrapped_target.target
 
     if not target.has_field(SourcesField):
-        raise AssertionError(f"BSP only handles targets with sources: uri={uri}")
+        raise AssertionError(
+            f"BSP only handles targets with sources: uri={request.bsp_target_id.uri}"
+        )
 
     sources_paths = await Get(SourcesPaths, SourcesPathsRequest(target[SourcesField]))
     sources_full_paths = [

--- a/src/python/pants/bsp/spec.py
+++ b/src/python/pants/bsp/spec.py
@@ -7,6 +7,7 @@ from enum import IntEnum
 from typing import Any
 
 from pants.bsp.utils import freeze_json
+from pants.build_graph.address import Address, AddressInput
 
 # -----------------------------------------------------------------------------------------------
 # Base types
@@ -33,6 +34,19 @@ class BuildTargetIdentifier:
 
     def to_json_dict(self):
         return {"uri": self.uri}
+
+    @classmethod
+    def from_address(cls, addr: Address) -> BuildTargetIdentifier:
+        return cls(uri=f"pants:{str(addr)}")
+
+    @property
+    def address_input(self) -> AddressInput:
+        if not self.uri.startswith("pants:"):
+            raise ValueError(
+                f"Unknown URI scheme for BSP BuildTargetIdentifier. Expected scheme `pants`, but URI was: {self.uri}"
+            )
+        raw_addr = self.uri[len("pants:") :]
+        return AddressInput.parse(raw_addr)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Cleanup Scala build target resolution so that dependencies are computed and included in the BSP `BuildTarget`. This still just includes file-level targets.

Also refactors decoding of BSP target identifiers into `BuildTargetIdentifier`.

[ci skip-rust]

[ci skip-build-wheels]