### PR TITLE
Fix PyOxidizer to write to `~/.cache/pants` by using a named cache

### DIFF
--- a/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
@@ -58,6 +58,8 @@ class PyoxidizerRunnerScript:
     digest: Digest
     path: str
 
+    CACHE_PATH = os.path.join(".cache", "pyoxidizer")
+
 
 @rule
 async def create_pyoxidizer_runner_script() -> PyoxidizerRunnerScript:
@@ -67,8 +69,8 @@ async def create_pyoxidizer_runner_script() -> PyoxidizerRunnerScript:
     script = FileContent(
         "__run_pyoxidizer.sh",
         dedent(
-            """\
-            export PYOXIDIZER_CACHE_DIR="$(/bin/pwd)/.cache/pyoxidizer"
+            f"""\
+            export PYOXIDIZER_CACHE_DIR="$(/bin/pwd)/{PyoxidizerRunnerScript.CACHE_PATH}"
             exec "$@"
             """
         ).encode("utf-8"),
@@ -164,7 +166,7 @@ async def package_pyoxidizer_binary(
         argv=(bash.path, runner_script.path, *pex_process.argv),
         append_only_caches={
             **pex_process.append_only_caches,
-            "pyoxidizer": os.path.join(".cache", "pyoxidizer"),
+            "pyoxidizer": runner_script.CACHE_PATH,
         },
     )
 

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -830,7 +830,6 @@ class PexProcess:
     execution_slot_variable: str | None
     concurrency_available: int
     cache_scope: ProcessCacheScope
-    extra_append_only_caches: FrozenDict[str, str]
 
     def __init__(
         self,
@@ -863,7 +862,6 @@ class PexProcess:
         self.execution_slot_variable = execution_slot_variable
         self.concurrency_available = concurrency_available
         self.cache_scope = cache_scope
-        self.extra_append_only_caches = FrozenDict(extra_append_only_caches or {})
 
 
 @rule
@@ -889,10 +887,7 @@ async def setup_pex_process(request: PexProcess, pex_environment: PexEnvironment
         env=env,
         output_files=request.output_files,
         output_directories=request.output_directories,
-        append_only_caches={
-            **complete_pex_env.append_only_caches,
-            **request.extra_append_only_caches,
-        },
+        append_only_caches=complete_pex_env.append_only_caches,
         timeout_seconds=request.timeout_seconds,
         execution_slot_variable=request.execution_slot_variable,
         concurrency_available=request.concurrency_available,

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -847,7 +847,6 @@ class PexProcess:
         execution_slot_variable: str | None = None,
         concurrency_available: int = 0,
         cache_scope: ProcessCacheScope = ProcessCacheScope.SUCCESSFUL,
-        extra_append_only_caches: Mapping[str, str] | None = None,
     ) -> None:
         self.pex = pex
         self.argv = tuple(argv)

--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -208,9 +208,11 @@ class CompletePexEnvironment:
         d = dict(
             PATH=create_path_env_var(self._pex_environment.path),
             PEX_IGNORE_RCFILES="true",
-            PEX_ROOT=os.path.relpath(self.pex_root, self._working_directory)
-            if self._working_directory
-            else str(self.pex_root),
+            PEX_ROOT=(
+                os.path.relpath(self.pex_root, self._working_directory)
+                if self._working_directory
+                else str(self.pex_root)
+            ),
             **self._pex_environment.subprocess_environment_dict,
         )
         # NB: We only set `PEX_PYTHON_PATH` if the Python interpreter has not already been

--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from pathlib import Path, PurePath
+from pathlib import PurePath
 from typing import Mapping
 
 from pants.core.util_rules import subprocess_environment
@@ -15,7 +15,7 @@ from pants.engine.engine_aware import EngineAwareReturnType
 from pants.engine.environment import Environment
 from pants.engine.process import BinaryPath
 from pants.engine.rules import collect_rules, rule
-from pants.option.global_options import GlobalOptions
+from pants.option.global_options import NamedCachesDirOption
 from pants.option.option_types import BoolOption, IntOption, StrListOption
 from pants.option.subsystem import Subsystem
 from pants.python import binaries as python_binaries
@@ -159,15 +159,13 @@ async def find_pex_python(
     python_binary: PythonBinary,
     pex_runtime_env: PexRuntimeEnvironment,
     subprocess_env_vars: SubprocessEnvironmentVars,
-    global_options: GlobalOptions,
+    named_caches_dir: NamedCachesDirOption,
 ) -> PexEnvironment:
     return PexEnvironment(
         path=pex_runtime_env.path(python_bootstrap.environment),
         interpreter_search_paths=tuple(python_bootstrap.interpreter_search_paths()),
         subprocess_environment_dict=subprocess_env_vars.vars,
-        # TODO: This path normalization is duplicated with `engine_initializer.py`. How can we do
-        #  the normalization only once, via the options system?
-        named_caches_dir=Path(global_options.options.named_caches_dir).resolve(),
+        named_caches_dir=named_caches_dir.val,
         bootstrap_python=PythonExecutable.from_python_binary(python_binary),
         venv_use_symlinks=pex_runtime_env.venv_use_symlinks,
     )

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -42,6 +42,7 @@ from pants.backend.python.util_rules.pex_requirements import (
 from pants.core.util_rules.lockfile_metadata import InvalidLockfileError
 from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, Directory, FileContent
 from pants.engine.process import Process, ProcessCacheScope, ProcessResult
+from pants.option.global_options import GlobalOptions
 from pants.testutil.rule_runner import QueryRule, RuleRunner, engine_error
 from pants.util.dirutil import safe_rmtree
 from pants.util.ordered_set import FrozenOrderedSet
@@ -315,9 +316,7 @@ def test_pex_environment(rule_runner: RuleRunner, pex_type: type[Pex | VenvPex])
 
 @pytest.mark.parametrize("pex_type", [Pex, VenvPex])
 def test_pex_working_directory(rule_runner: RuleRunner, pex_type: type[Pex | VenvPex]) -> None:
-    named_caches_dir = (
-        rule_runner.options_bootstrapper.bootstrap_options.for_global_scope().named_caches_dir
-    )
+    named_caches_dir = rule_runner.request(GlobalOptions, []).named_caches_dir
     sources = rule_runner.request(
         Digest,
         [

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -78,6 +78,7 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *pex_rules(),
+            QueryRule(GlobalOptions, []),
             QueryRule(Pex, (PexRequest,)),
             QueryRule(VenvPex, (PexRequest,)),
             QueryRule(Process, (PexProcess,)),

--- a/src/python/pants/engine/internals/options_parsing.py
+++ b/src/python/pants/engine/internals/options_parsing.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.engine.internals.session import SessionValues
 from pants.engine.rules import collect_rules, rule
-from pants.option.global_options import GlobalOptions, ProcessCleanupOption
+from pants.option.global_options import GlobalOptions, NamedCachesDirOption, ProcessCleanupOption
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.option.scope import Scope, ScopedOptions
@@ -57,6 +57,11 @@ def log_level(global_options: GlobalOptions) -> LogLevel:
 @rule
 def extract_process_cleanup_option(global_options: GlobalOptions) -> ProcessCleanupOption:
     return ProcessCleanupOption(global_options.options.process_cleanup)
+
+
+@rule
+def extract_named_caches_dir_option(global_options: GlobalOptions) -> NamedCachesDirOption:
+    return NamedCachesDirOption(global_options.named_caches_dir)
 
 
 def rules():

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -13,7 +13,7 @@ import tempfile
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Any, Type, cast
 
 from pants.base.build_environment import (
@@ -36,7 +36,7 @@ from pants.option.subsystem import Subsystem
 from pants.util.dirutil import fast_relpath_optional
 from pants.util.docutil import bin_name, doc_url
 from pants.util.logging import LogLevel
-from pants.util.memo import memoized_classmethod
+from pants.util.memo import memoized_classmethod, memoized_property
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 from pants.util.osutil import CPU_COUNT
 from pants.version import VERSION
@@ -1609,6 +1609,10 @@ class GlobalOptions(Subsystem):
     def get_options_flags(cls) -> GlobalOptionsFlags:
         return GlobalOptionsFlags.create(cast("Type[GlobalOptions]", cls))
 
+    @memoized_property
+    def named_caches_dir(self) -> PurePath:
+        return Path(self.options.named_caches_dir).resolve()
+
 
 @dataclass(frozen=True)
 class GlobalOptionsFlags:
@@ -1640,3 +1644,13 @@ class ProcessCleanupOption:
     """
 
     val: bool
+
+
+@dataclass(frozen=True)
+class NamedCachesDirOption:
+    """A wrapper around the global option `named_caches_dir`.
+
+    Prefer to use this rather than requesting `GlobalOptions` for more precise invalidation.
+    """
+
+    val: PurePath


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/14578. This fixes it so that PyOxidizer doesn't write to paths not-owned-by Pants.

