### PR TITLE
adds --no-default to Coursier args so that we only use user-configured maven repos (Cherry-pick of #14581) (#14584)

### DIFF
--- a/src/python/pants/jvm/resolve/coursier_setup.py
+++ b/src/python/pants/jvm/resolve/coursier_setup.py
@@ -215,7 +215,10 @@ async def setup_coursier(
     coursier_subsystem: CoursierSubsystem,
     python: PythonBinary,
 ) -> Coursier:
-    repos_args = " ".join(f"-r={shlex.quote(repo)}" for repo in coursier_subsystem.options.repos)
+    repos_args = (
+        " ".join(f"-r={shlex.quote(repo)}" for repo in coursier_subsystem.options.repos)
+        + " --no-default"
+    )
     coursier_wrapper_script = COURSIER_FETCH_WRAPPER_SCRIPT.format(
         repos_args=repos_args,
         coursier_working_directory=Coursier.working_directory_placeholder,


### PR DESCRIPTION
See-also: #14577

---

Per #14577, `repo1.maven.org` contains a bogus POM for `jai_core`. Coursier's behaviour is to look at its default repos before any user-configured repos, and will download the first POM it finds, regardless of whether it is valid. This means that even if you specify a repo that contains a valid POM, the invalid POM wins out because it is given priority.

Further, the `repo1.maven.org` behaviour is opaque, since we have our own `--coursier-repos` option.

This PR disables the default repos, so we _only_ use the repos specified by the user.

When using `--coursier-repos="['https://repo.osgeo.org/repository/geotools-releases', 'https://maven-central.storage-download.googleapis.com/maven2']"`, Pants is able to resolve `jai_core`.
