### PR TITLE
[internal] Rename enum type parameters to be `enum_type`

### DIFF
--- a/src/python/pants/option/option_types.py
+++ b/src/python/pants/option/option_types.py
@@ -266,13 +266,13 @@ class BoolOption(_OptionBase[_PropType]):
 class EnumOption(_OptionBase[_PropType], Generic[_PropType]):
     """An Enum option.
 
-    If you provide a `default` parameter, the `option_type` parameter will be inferred from the type
-    of the default. Otherwise, you'll need to provide the `option_type`.
+    If you provide a `default` parameter, the `enum_type` parameter will be inferred from the type
+    of the default. Otherwise, you'll need to provide the `enum_type`.
     In either case, mypy will infer the correct Generic's type-parameter, so you shouldn't need to
     provide it.
 
     E.g.
-        EnumOption(..., option_type=MyEnum)  # property type is deduced as `MyEnum | None`
+        EnumOption(..., enum_type=MyEnum)  # property type is deduced as `MyEnum | None`
         EnumOption(..., default=MyEnum.Value)  # property type is deduced as `MyEnum`
     """
 
@@ -280,34 +280,34 @@ class EnumOption(_OptionBase[_PropType], Generic[_PropType]):
     def __new__(cls, *flag_names: str, default: _EnumT, help: _HelpT) -> EnumOption[_EnumT]:
         ...
 
-    # N.B. This has an additional param for the no-default-provided case: `option_type`.
+    # N.B. This has an additional param for the no-default-provided case: `enum_type`.
     @overload
     def __new__(
-        cls, *flag_names: str, option_type: type[_EnumT], help: _HelpT
+        cls, *flag_names: str, enum_type: type[_EnumT], help: _HelpT
     ) -> EnumOption[_EnumT | None]:
         ...
 
     def __new__(
         cls,
         *flag_names,
-        option_type=None,
+        enum_type=None,
         default=None,
         help,
     ):
         instance = super().__new__(cls, *flag_names, default=default, help=help)
-        instance._option_type = option_type
+        instance._enum_type = enum_type
         return instance
 
     def get_option_type(self):
-        option_type = self._option_type
+        enum_type = self._enum_type
         default = self._default
-        if option_type is None:
+        if enum_type is None:
             if default is None:
                 raise ValueError(
                     "`enum_type` must be provided to the constructor if `default` isn't provided."
                 )
             return type(default)
-        return option_type
+        return enum_type
 
 
 class DictOption(_OptionBase["dict[str, _ValueT]"], Generic[_ValueT]):
@@ -478,13 +478,13 @@ class BoolListOption(_ListOptionBase[bool]):
 class EnumListOption(_ListOptionBase[_PropType], Generic[_PropType]):
     """An homogenous list of Enum options.
 
-    If you provide a `default` parameter, the `member_type` parameter will be inferred from the type
+    If you provide a `default` parameter, the `enum_type` parameter will be inferred from the type
     of the first element of the default. Otherwise, you'll need to provide the `option_type`.
     In either case, mypy will infer the correct Generic's type-parameter, so you shouldn't need to
     provide it.
 
     E.g.
-        EnumListOption(..., member_type=MyEnum)  # property type is deduced as `[MyEnum]`
+        EnumListOption(..., enum_type=MyEnum)  # property type is deduced as `[MyEnum]`
         EnumListOption(..., default=[MyEnum.Value])  # property type is deduced as `[MyEnum]`
     """
 
@@ -494,35 +494,35 @@ class EnumListOption(_ListOptionBase[_PropType], Generic[_PropType]):
     ) -> EnumListOption[_EnumT]:
         ...
 
-    # N.B. This has an additional param for the no-default-provided case: `member_type`.
+    # N.B. This has an additional param for the no-default-provided case: `enum_type`.
     @overload
     def __new__(
-        cls, *flag_names: str, member_type: type[_EnumT], help: _HelpT
+        cls, *flag_names: str, enum_type: type[_EnumT], help: _HelpT
     ) -> EnumListOption[_EnumT]:
         ...
 
     def __new__(
         cls,
         *flag_names,
-        member_type=None,
+        enum_type=None,
         default=None,
         help,
     ):
         instance = super().__new__(cls, *flag_names, default=default, help=help)
-        instance._member_type = member_type
+        instance._enum_type = enum_type
         return instance
 
     def get_member_type(self):
-        member_type = self._member_type
+        enum_type = self._enum_type
         default = self._default
-        if member_type is None:
+        if enum_type is None:
             if not default:
                 raise ValueError(
                     "`enum_type` must be provided to the constructor if `default` isn't provided "
                     "or is empty."
                 )
             return type(default[0])
-        return member_type
+        return enum_type
 
 
 class TargetListOption(StrListOption):

--- a/src/python/pants/option/option_types_test.py
+++ b/src/python/pants/option/option_types_test.py
@@ -114,10 +114,10 @@ def test_other_options():
 
         dict_prop = DictOption[Any]("--dict-opt", help="")
         enum_prop = EnumOption("--enum-opt", default=MyEnum.Val1, help="")
-        optional_enum_prop = EnumOption("--optional-enum-opt", option_type=MyEnum, help="")
+        optional_enum_prop = EnumOption("--optional-enum-opt", enum_type=MyEnum, help="")
         enum_list_prop = EnumListOption("--enum-list-opt", default=[MyEnum.Val1], help="")
         defaultless_enum_list_prop = EnumListOption(
-            "--defaultless-enum-list-opt", member_type=MyEnum, help=""
+            "--defaultless-enum-list-opt", enum_type=MyEnum, help=""
         )
         args_prop = ArgsListOption(help="")
 
@@ -229,11 +229,11 @@ def test_property_types() -> None:
 
         # Enum opts
         enum_opt = EnumOption("--opt", default=MyEnum.Val1, help="")
-        optional_enum_opt = EnumOption("--opt", option_type=MyEnum, help="")
+        optional_enum_opt = EnumOption("--opt", enum_type=MyEnum, help="")
         # mypy correctly complains about not matching any possibilities
         enum_opt_bad = EnumOption("--opt", help="")  # type: ignore[call-overload]
         enum_list_opt1 = EnumListOption("--opt", default=[MyEnum.Val1], help="")
-        enum_list_opt2 = EnumListOption("--opt", member_type=MyEnum, help="")
+        enum_list_opt2 = EnumListOption("--opt", enum_type=MyEnum, help="")
         # mypy correctly complains about needing a type annotation
         enum_list_bad_opt = EnumListOption("--opt", default=[], help="")  # type: ignore[var-annotated]
 


### PR DESCRIPTION
Minor, but this was bugging me.

[ci skip-rust]
[ci skip-build-wheels]