### PR TITLE
Fix PyOxidizer to write to `~/.cache/pants` by using a named cache (Cherry-pick of #14582)

### DIFF
--- a/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
@@ -1,8 +1,13 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
+import dataclasses
 import logging
+import os
 from dataclasses import dataclass
+from textwrap import dedent
 
 from pants.backend.python.packaging.pyoxidizer.config import PyOxidizerConfig
 from pants.backend.python.packaging.pyoxidizer.subsystem import PyOxidizer
@@ -22,7 +27,7 @@ from pants.engine.fs import (
     MergeDigests,
     Snapshot,
 )
-from pants.engine.process import ProcessResult
+from pants.engine.process import BashBinary, Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     DependenciesRequest,
@@ -48,9 +53,38 @@ class PyOxidizerFieldSet(PackageFieldSet):
     template: PyOxidizerConfigSourceField
 
 
+@dataclass(frozen=True)
+class PyoxidizerRunnerScript:
+    digest: Digest
+    path: str
+
+    CACHE_PATH = os.path.join(".cache", "pyoxidizer")
+
+
+@rule
+async def create_pyoxidizer_runner_script() -> PyoxidizerRunnerScript:
+    # Note: PyOxidizer expects an absolute path for its cache dir, which can only be resolved
+    # from within the execution sandbox. Thus, this code uses a bash script to be able to resolve
+    # absolute paths inside the sandbox.
+    script = FileContent(
+        "__run_pyoxidizer.sh",
+        dedent(
+            f"""\
+            export PYOXIDIZER_CACHE_DIR="$(/bin/pwd)/{PyoxidizerRunnerScript.CACHE_PATH}"
+            exec "$@"
+            """
+        ).encode("utf-8"),
+    )
+    digest = await Get(Digest, CreateDigest([script]))
+    return PyoxidizerRunnerScript(digest, script.path)
+
+
 @rule(level=LogLevel.DEBUG)
 async def package_pyoxidizer_binary(
-    pyoxidizer: PyOxidizer, field_set: PyOxidizerFieldSet
+    pyoxidizer: PyOxidizer,
+    field_set: PyOxidizerFieldSet,
+    runner_script: PyoxidizerRunnerScript,
+    bash: BashBinary,
 ) -> BuiltPackage:
     direct_deps, pyoxidizer_pex = await MultiGet(
         Get(Targets, DependenciesRequest(field_set.dependencies)),
@@ -108,10 +142,16 @@ async def package_pyoxidizer_binary(
 
     input_digest = await Get(
         Digest,
-        MergeDigests((config_digest, *(built_package.digest for built_package in built_packages))),
+        MergeDigests(
+            (
+                config_digest,
+                runner_script.digest,
+                *(built_package.digest for built_package in built_packages),
+            )
+        ),
     )
-    result = await Get(
-        ProcessResult,
+    pex_process = await Get(
+        Process,
         PexProcess(
             pyoxidizer_pex,
             argv=["build", *pyoxidizer.args],
@@ -121,7 +161,16 @@ async def package_pyoxidizer_binary(
             output_directories=["build"],
         ),
     )
+    process_with_caching = dataclasses.replace(
+        pex_process,
+        argv=(bash.path, runner_script.path, *pex_process.argv),
+        append_only_caches={
+            **pex_process.append_only_caches,
+            "pyoxidizer": runner_script.CACHE_PATH,
+        },
+    )
 
+    result = await Get(ProcessResult, Process, process_with_caching)
     result_snapshot = await Get(Snapshot, Digest, result.output_digest)
     return BuiltPackage(
         result.output_digest,

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -823,7 +823,7 @@ class PexProcess:
     level: LogLevel
     input_digest: Digest | None
     working_directory: str | None
-    extra_env: FrozenDict[str, str] | None
+    extra_env: FrozenDict[str, str]
     output_files: tuple[str, ...] | None
     output_directories: tuple[str, ...] | None
     timeout_seconds: int | None
@@ -854,7 +854,7 @@ class PexProcess:
         self.level = level
         self.input_digest = input_digest
         self.working_directory = working_directory
-        self.extra_env = FrozenDict(extra_env) if extra_env else None
+        self.extra_env = FrozenDict(extra_env or {})
         self.output_files = tuple(output_files) if output_files else None
         self.output_directories = tuple(output_directories) if output_directories else None
         self.timeout_seconds = timeout_seconds
@@ -870,7 +870,7 @@ async def setup_pex_process(request: PexProcess, pex_environment: PexEnvironment
     argv = complete_pex_env.create_argv(pex.name, *request.argv, python=pex.python)
     env = {
         **complete_pex_env.environment_dict(python_configured=pex.python is not None),
-        **(request.extra_env or {}),
+        **request.extra_env,
     }
     input_digest = (
         await Get(Digest, MergeDigests((pex.digest, request.input_digest)))

--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from pathlib import Path, PurePath
+from pathlib import PurePath
 from typing import Mapping
 
 from pants.core.util_rules import subprocess_environment
@@ -15,7 +15,7 @@ from pants.engine.engine_aware import EngineAwareReturnType
 from pants.engine.environment import Environment
 from pants.engine.process import BinaryPath
 from pants.engine.rules import collect_rules, rule
-from pants.option.global_options import GlobalOptions
+from pants.option.global_options import NamedCachesDirOption
 from pants.option.option_types import BoolOption, IntOption, StrListOption
 from pants.option.subsystem import Subsystem
 from pants.python import binaries as python_binaries
@@ -159,15 +159,13 @@ async def find_pex_python(
     python_binary: PythonBinary,
     pex_runtime_env: PexRuntimeEnvironment,
     subprocess_env_vars: SubprocessEnvironmentVars,
-    global_options: GlobalOptions,
+    named_caches_dir: NamedCachesDirOption,
 ) -> PexEnvironment:
     return PexEnvironment(
         path=pex_runtime_env.path(python_bootstrap.environment),
         interpreter_search_paths=tuple(python_bootstrap.interpreter_search_paths()),
         subprocess_environment_dict=subprocess_env_vars.vars,
-        # TODO: This path normalization is duplicated with `engine_initializer.py`. How can we do
-        #  the normalization only once, via the options system?
-        named_caches_dir=Path(global_options.options.named_caches_dir).resolve(),
+        named_caches_dir=named_caches_dir.val,
         bootstrap_python=PythonExecutable.from_python_binary(python_binary),
         venv_use_symlinks=pex_runtime_env.venv_use_symlinks,
     )
@@ -210,9 +208,11 @@ class CompletePexEnvironment:
         d = dict(
             PATH=create_path_env_var(self._pex_environment.path),
             PEX_IGNORE_RCFILES="true",
-            PEX_ROOT=os.path.relpath(self.pex_root, self._working_directory)
-            if self._working_directory
-            else str(self.pex_root),
+            PEX_ROOT=(
+                os.path.relpath(self.pex_root, self._working_directory)
+                if self._working_directory
+                else str(self.pex_root)
+            ),
             **self._pex_environment.subprocess_environment_dict,
         )
         # NB: We only set `PEX_PYTHON_PATH` if the Python interpreter has not already been

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -42,6 +42,7 @@ from pants.backend.python.util_rules.pex_requirements import (
 from pants.core.util_rules.lockfile_metadata import InvalidLockfileError
 from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, Directory, FileContent
 from pants.engine.process import Process, ProcessCacheScope, ProcessResult
+from pants.option.global_options import GlobalOptions
 from pants.testutil.rule_runner import QueryRule, RuleRunner, engine_error
 from pants.util.dirutil import safe_rmtree
 from pants.util.ordered_set import FrozenOrderedSet
@@ -77,6 +78,7 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *pex_rules(),
+            QueryRule(GlobalOptions, []),
             QueryRule(Pex, (PexRequest,)),
             QueryRule(VenvPex, (PexRequest,)),
             QueryRule(Process, (PexProcess,)),
@@ -315,9 +317,7 @@ def test_pex_environment(rule_runner: RuleRunner, pex_type: type[Pex | VenvPex])
 
 @pytest.mark.parametrize("pex_type", [Pex, VenvPex])
 def test_pex_working_directory(rule_runner: RuleRunner, pex_type: type[Pex | VenvPex]) -> None:
-    named_caches_dir = (
-        rule_runner.options_bootstrapper.bootstrap_options.for_global_scope().named_caches_dir
-    )
+    named_caches_dir = rule_runner.request(GlobalOptions, []).named_caches_dir
     sources = rule_runner.request(
         Digest,
         [

--- a/src/python/pants/engine/internals/options_parsing.py
+++ b/src/python/pants/engine/internals/options_parsing.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.engine.internals.session import SessionValues
 from pants.engine.rules import collect_rules, rule
-from pants.option.global_options import GlobalOptions, ProcessCleanupOption
+from pants.option.global_options import GlobalOptions, NamedCachesDirOption, ProcessCleanupOption
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.option.scope import Scope, ScopedOptions
@@ -57,6 +57,11 @@ def log_level(global_options: GlobalOptions) -> LogLevel:
 @rule
 def extract_process_cleanup_option(global_options: GlobalOptions) -> ProcessCleanupOption:
     return ProcessCleanupOption(global_options.options.process_cleanup)
+
+
+@rule
+def extract_named_caches_dir_option(global_options: GlobalOptions) -> NamedCachesDirOption:
+    return NamedCachesDirOption(global_options.named_caches_dir)
 
 
 def rules():

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -13,7 +13,7 @@ import tempfile
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Any, Type, cast
 
 from pants.base.build_environment import (
@@ -37,7 +37,7 @@ from pants.option.subsystem import Subsystem
 from pants.util.dirutil import fast_relpath_optional
 from pants.util.docutil import doc_url
 from pants.util.logging import LogLevel
-from pants.util.memo import memoized_classmethod
+from pants.util.memo import memoized_classmethod, memoized_property
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 from pants.util.osutil import CPU_COUNT
 from pants.version import VERSION
@@ -1593,6 +1593,10 @@ class GlobalOptions(Subsystem):
     def get_options_flags(cls) -> GlobalOptionsFlags:
         return GlobalOptionsFlags.create(cast("Type[GlobalOptions]", cls))
 
+    @memoized_property
+    def named_caches_dir(self) -> PurePath:
+        return Path(self.options.named_caches_dir).resolve()
+
 
 @dataclass(frozen=True)
 class GlobalOptionsFlags:
@@ -1624,6 +1628,16 @@ class ProcessCleanupOption:
     """
 
     val: bool
+
+
+@dataclass(frozen=True)
+class NamedCachesDirOption:
+    """A wrapper around the global option `named_caches_dir`.
+
+    Prefer to use this rather than requesting `GlobalOptions` for more precise invalidation.
+    """
+
+    val: PurePath
 
 
 def maybe_warn_python_macros_deprecation(bootstrap_options: OptionValueContainer) -> None:


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/14578. This fixes it so that PyOxidizer doesn't write to paths not-owned-by Pants.

[ci skip-rust]