### PR TITLE
[internal] Fix incorrect explanation of VenvPex shim.

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -592,8 +592,9 @@ class VenvScriptWriter:
         cls, pex_environment: PexEnvironment, pex: Pex, venv_rel_dir: PurePath
     ) -> VenvScriptWriter:
         # N.B.: We don't know the working directory that will be used in any given
-        # invocation of the venv scripts; so we deal with working_directory inside the scripts
-        # themselves by absolutifying all relevant paths at runtime.
+        # invocation of the venv scripts; so we deal with working_directory once in an
+        # `adjust_relative_paths` function inside the script to save rule authors from having to do
+        # CWD offset math in every rule for all the relative paths their process depends on.
         complete_pex_env = pex_environment.in_sandbox(working_directory=None)
         venv_dir = complete_pex_env.pex_root / venv_rel_dir
         return cls(complete_pex_env=complete_pex_env, pex=pex, venv_dir=venv_dir)
@@ -615,7 +616,7 @@ class VenvScriptWriter:
         target_venv_executable = shlex.quote(str(venv_executable))
         venv_dir = shlex.quote(str(self.venv_dir))
         execute_pex_args = " ".join(
-            f"$(ensure_relative_to_sandbox_root {shlex.quote(arg)})"
+            f"$(adjust_relative_paths {shlex.quote(arg)})"
             for arg in self.complete_pex_env.create_argv(self.pex.name, python=self.pex.python)
         )
 
@@ -625,31 +626,41 @@ class VenvScriptWriter:
             set -euo pipefail
 
             # N.B.: This relies on BASH_SOURCE which has been available since bash-3.0, released in
-            # 2004. It will either contain the (absolute or relative) path of the venv script, which
-            # we know to live in the sandbox root.
+            # 2004. It will either contain either the absolute path of the venv script or the
+            # relative path from the CWD to the venv script. Either way, we know the venv script
+            # path parent directory is the sandbox root directory.
             SANDBOX_ROOT="${{BASH_SOURCE%/*}}"
 
-            function ensure_relative_to_sandbox_root() {{
+            function adjust_relative_paths() {{
                 local value0="$1"
                 shift
                 if [ "${{value0:0:1}}" == "/" ]; then
+                    # Don't relativize absolute paths.
                     echo "${{value0}}" "$@"
                 else
-                    # N.B.: We convert all relative paths (`./right/here`) to paths relative to the
-                    # sandbox root so this script works when run with a cwd set elsewhere. If our
-                    # sandbox root is `/this/dir` we get `/this/dir/./right/here` and if it's
-                    # `../..` (say we're in a CWD of `foo/bar` relative to the sandbox root) we get
-                    # `../.././right/here`.
+                    # N.B.: We convert all relative paths to paths relative to the sandbox root so
+                    # this script works when run with a PWD set somewhere else than the sandbox
+                    # root.
+                    #
+                    # There are two cases to consider. For the purposes of example, assume PWD is
+                    # `/tmp/sandboxes/abc123/foo/bar`; i.e.: the rule API sets working_directory to
+                    # `foo/bar`. Also assume `config/tool.yml` is the relative path in question.
+                    #
+                    # 1. If our BASH_SOURCE is  `/tmp/sandboxes/abc123/pex_shim.sh`; so our
+                    #    SANDBOX_ROOT is `/tmp/sandboxes/abc123`, we calculate
+                    #    `/tmp/sandboxes/abc123/config/tool.yml`.
+                    # 2. If our BASH_SOURCE is instead `../../pex_shim.sh`; so our SANDBOX_ROOT is
+                    #    `../..`, we calculate `../../config/tool.yml`.
                     echo "${{SANDBOX_ROOT}}/${{value0}}" "$@"
                 fi
             }}
 
             export {" ".join(env_vars)}
-            export PEX_ROOT="$(ensure_relative_to_sandbox_root ${{PEX_ROOT}})"
+            export PEX_ROOT="$(adjust_relative_paths ${{PEX_ROOT}})"
 
             execute_pex_args="{execute_pex_args}"
-            target_venv_executable="$(ensure_relative_to_sandbox_root {target_venv_executable})"
-            venv_dir="$(ensure_relative_to_sandbox_root {venv_dir})"
+            target_venv_executable="$(adjust_relative_paths {target_venv_executable})"
+            venv_dir="$(adjust_relative_paths {venv_dir})"
 
             # Let PEX_TOOLS invocations pass through to the original PEX file since venvs don't come
             # with tools support.

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -626,9 +626,9 @@ class VenvScriptWriter:
             set -euo pipefail
 
             # N.B.: This relies on BASH_SOURCE which has been available since bash-3.0, released in
-            # 2004. It will either contain either the absolute path of the venv script or the
-            # relative path from the CWD to the venv script. Either way, we know the venv script
-            # path parent directory is the sandbox root directory.
+            # 2004. It will either contain the absolute path of the venv script or it will contain
+            # the relative path from the CWD to the venv script. Either way, we know the venv script
+            # parent directory is the sandbox root directory.
             SANDBOX_ROOT="${{BASH_SOURCE%/*}}"
 
             function adjust_relative_paths() {{

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -376,8 +376,8 @@ def test_pex_working_directory(rule_runner: RuleRunner, pex_type: type[Pex | Ven
         # situations where a PEX creation hits the process cache, while venv seeding misses the PEX
         # cache.
         if isinstance(pex_data.pex, VenvPex):
-            # Request once to ensure that the directory is seeded, and then start a new session so that
-            # the second run happens as well.
+            # Request once to ensure that the directory is seeded, and then start a new session so
+            # that the second run happens as well.
             _ = rule_runner.request(ProcessResult, [process])
             rule_runner.new_session("re-run-for-venv-pex")
             rule_runner.set_options(


### PR DESCRIPTION
The mechanics were right but the bash function name and explanation
were wrong. This led to much confusion.

Fixes #14586

[ci skip-rust]
[ci skip-build-wheels]