### PR TITLE
New `--docker-build-verbose` option to print build output to the console. (Cherry pick of #14557)

### DIFF
--- a/src/python/pants/backend/docker/goals/package_image_integration_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_integration_test.py
@@ -59,4 +59,7 @@ def test_docker_build(rule_runner) -> None:
     target = rule_runner.get_target(Address("src", target_name="test-image"))
     result = run_docker(rule_runner, target)
     assert len(result.artifacts) == 1
-    assert "Built docker image: test-image:1.0" in result.artifacts[0].extra_log_lines
+    assert len(result.artifacts[0].extra_log_lines) == 2
+    assert "Built docker image: test-image:1.0" == result.artifacts[0].extra_log_lines[0]
+    assert "Docker image ID:" in result.artifacts[0].extra_log_lines[1]
+    assert "<unknown>" not in result.artifacts[0].extra_log_lines[1]

--- a/src/python/pants/backend/docker/goals/publish_test.py
+++ b/src/python/pants/backend/docker/goals/publish_test.py
@@ -59,6 +59,7 @@ def build(tgt: DockerImageTarget, options: DockerOptions):
             EMPTY_DIGEST,
             (
                 BuiltDockerImage.create(
+                    "sha256:made-up",
                     fs.image_refs(
                         options.default_repository,
                         options.registries(),

--- a/src/python/pants/backend/docker/package_types.py
+++ b/src/python/pants/backend/docker/package_types.py
@@ -14,12 +14,13 @@ class BuiltDockerImage(BuiltPackageArtifact):
     tags: tuple[str, ...] = ()
 
     @classmethod
-    def create(cls, tags: tuple[str, ...]) -> BuiltDockerImage:
+    def create(cls, image_id: str, tags: tuple[str, ...]) -> BuiltDockerImage:
         tags_string = tags[0] if len(tags) == 1 else (f"\n{bullet_list(tags)}")
         return cls(
             tags=tags,
             relpath=None,
             extra_log_lines=(
                 f"Built docker {pluralize(len(tags), 'image', False)}: {tags_string}",
+                f"Docker image ID: {image_id}",
             ),
         )

--- a/src/python/pants/backend/docker/subsystems/docker_options.py
+++ b/src/python/pants/backend/docker/subsystems/docker_options.py
@@ -143,6 +143,13 @@ class DockerOptions(Subsystem):
         )
 
         register(
+            "--build-verbose",
+            type=bool,
+            default=False,
+            help="Whether to log the Docker output to the console. If false, only the image ID is logged.",
+        )
+
+        register(
             "--env-vars",
             type=list,
             member_type=shell_str,
@@ -194,6 +201,10 @@ class DockerOptions(Subsystem):
     @property
     def build_target_stage(self) -> str | None:
         return cast("str | None", self.options.build_target_stage)
+
+    @property
+    def build_verbose(self) -> bool:
+        return cast("bool", self.options.build_verbose)
 
     @property
     def run_args(self) -> tuple[str, ...]:


### PR DESCRIPTION
Also print the image id (digest) for each built image.
