### PR TITLE
Removing the `None` default for the `default` parameter in Options V2 for scalar types 

### DIFF
--- a/src/python/pants/backend/docker/subsystems/docker_options.py
+++ b/src/python/pants/backend/docker/subsystems/docker_options.py
@@ -114,6 +114,7 @@ class DockerOptions(Subsystem):
     )
     build_target_stage = StrOption(
         "--build-target-stage",
+        default=None,
         help=(
             "Global default value for `target_stage` on `docker_image` targets, overriding "
             "the field value on the targets, if there is a matching stage in the `Dockerfile`."

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -73,6 +73,7 @@ class PythonSetup(Subsystem):
     requirement_constraints = (
         FileOption(
             "--requirement-constraints",
+            default=None,
             help=(
                 "When resolving third-party requirements for your own code (vs. tools you run), "
                 "use this constraints file to determine which versions to use.\n\n"

--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -266,6 +266,7 @@ class TailorSubsystem(GoalSubsystem):
     ).advanced()
     build_file_header = StrOption(
         "--build-file-header",
+        default=None,
         help="A header, e.g., a copyright notice, to add to the content of created BUILD files.",
     ).advanced()
     build_file_indent = StrOption(

--- a/src/python/pants/goal/anonymous_telemetry.py
+++ b/src/python/pants/goal/anonymous_telemetry.py
@@ -47,6 +47,7 @@ class AnonymousTelemetry(Subsystem):
     ).advanced()
     repo_id = StrOption(
         "--repo-id",
+        default=None,
         help=(
             f"An anonymized ID representing this repo.\nFor private repos, you likely want the "
             f"ID to not be derived from, or algorithmically convertible to, anything "

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1416,7 +1416,9 @@ class GlobalOptions(Subsystem):
     ).advanced()
 
     _loop_flag = "--loop"
-    loop = BoolOption(_loop_flag, help="Run goals continuously as file changes are detected.")
+    loop = BoolOption(
+        _loop_flag, default=False, help="Run goals continuously as file changes are detected."
+    )
     loop_max = IntOption(
         "--loop-max",
         default=2**32,

--- a/src/python/pants/option/option_types.py
+++ b/src/python/pants/option/option_types.py
@@ -201,10 +201,10 @@ class StrOption(_OptionBase[_PropType]):
         ...
 
     @overload
-    def __new__(cls, *flag_names: str, help: _HelpT) -> StrOption[str | None]:
+    def __new__(cls, *flag_names: str, default: None, help: _HelpT) -> StrOption[str | None]:
         ...
 
-    def __new__(cls, *flag_names, default=None, help):
+    def __new__(cls, *flag_names, default, help):
         return super().__new__(cls, *flag_names, default=default, help=help)
 
 
@@ -218,10 +218,10 @@ class IntOption(_OptionBase[_PropType]):
         ...
 
     @overload
-    def __new__(cls, *flag_names: str, help: _HelpT) -> IntOption[int | None]:
+    def __new__(cls, *flag_names: str, default: None, help: _HelpT) -> IntOption[int | None]:
         ...
 
-    def __new__(cls, *flag_names, default=None, help):
+    def __new__(cls, *flag_names, default, help):
         return super().__new__(cls, *flag_names, default=default, help=help)
 
 
@@ -235,10 +235,10 @@ class FloatOption(_OptionBase[_PropType]):
         ...
 
     @overload
-    def __new__(cls, *flag_names: str, help: _HelpT) -> FloatOption[float | None]:
+    def __new__(cls, *flag_names: str, default: None, help: _HelpT) -> FloatOption[float | None]:
         ...
 
-    def __new__(cls, *flag_names, default=None, help):
+    def __new__(cls, *flag_names, default, help):
         return super().__new__(cls, *flag_names, default=default, help=help)
 
 
@@ -256,10 +256,10 @@ class BoolOption(_OptionBase[_PropType]):
         ...
 
     @overload
-    def __new__(cls, *flag_names: str, help: _HelpT) -> BoolOption[bool | None]:
+    def __new__(cls, *flag_names: str, default: None, help: _HelpT) -> BoolOption[bool | None]:
         ...
 
-    def __new__(cls, *flag_names, default=None, help):
+    def __new__(cls, *flag_names, default, help):
         return super().__new__(cls, *flag_names, default=default, help=help)
 
 
@@ -280,10 +280,10 @@ class EnumOption(_OptionBase[_PropType], Generic[_PropType]):
     def __new__(cls, *flag_names: str, default: _EnumT, help: _HelpT) -> EnumOption[_EnumT]:
         ...
 
-    # N.B. This has an additional param for the no-default-provided case: `enum_type`.
+    # N.B. This has an additional param for the ndefault-is-None case: `enum_type`.
     @overload
     def __new__(
-        cls, *flag_names: str, enum_type: type[_EnumT], help: _HelpT
+        cls, *flag_names: str, enum_type: type[_EnumT], default: None, help: _HelpT
     ) -> EnumOption[_EnumT | None]:
         ...
 
@@ -291,7 +291,7 @@ class EnumOption(_OptionBase[_PropType], Generic[_PropType]):
         cls,
         *flag_names,
         enum_type=None,
-        default=None,
+        default,
         help,
     ):
         instance = super().__new__(cls, *flag_names, default=default, help=help)
@@ -356,10 +356,10 @@ class TargetOption(_OptionBase[_PropType]):
         ...
 
     @overload
-    def __new__(cls, *flag_names: str, help: _HelpT) -> TargetOption[str | None]:
+    def __new__(cls, *flag_names: str, default: None, help: _HelpT) -> TargetOption[str | None]:
         ...
 
-    def __new__(cls, *flag_names, default=None, help):
+    def __new__(cls, *flag_names, default, help):
         return super().__new__(cls, *flag_names, default=default, help=help)
 
 
@@ -373,10 +373,10 @@ class DirOption(_OptionBase[_PropType]):
         ...
 
     @overload
-    def __new__(cls, *flag_names: str, help: _HelpT) -> DirOption[str | None]:
+    def __new__(cls, *flag_names: str, default: None, help: _HelpT) -> DirOption[str | None]:
         ...
 
-    def __new__(cls, *flag_names, default=None, help):
+    def __new__(cls, *flag_names, default, help):
         return super().__new__(cls, *flag_names, default=default, help=help)
 
 
@@ -390,10 +390,10 @@ class FileOption(_OptionBase[_PropType]):
         ...
 
     @overload
-    def __new__(cls, *flag_names: str, help: _HelpT) -> FileOption[str | None]:
+    def __new__(cls, *flag_names: str, default: None, help: _HelpT) -> FileOption[str | None]:
         ...
 
-    def __new__(cls, *flag_names, default=None, help):
+    def __new__(cls, *flag_names, default, help):
         return super().__new__(cls, *flag_names, default=default, help=help)
 
 
@@ -407,10 +407,10 @@ class ShellStrOption(_OptionBase[_PropType]):
         ...
 
     @overload
-    def __new__(cls, *flag_names: str, help: _HelpT) -> ShellStrOption[str | None]:
+    def __new__(cls, *flag_names: str, default: None, help: _HelpT) -> ShellStrOption[str | None]:
         ...
 
-    def __new__(cls, *flag_names, default=None, help):
+    def __new__(cls, *flag_names, default, help):
         return super().__new__(cls, *flag_names, default=default, help=help)
 
 
@@ -424,10 +424,12 @@ class WorkspacePathOption(_OptionBase[_PropType]):
         ...
 
     @overload
-    def __new__(cls, *flag_names: str, help: _HelpT) -> WorkspacePathOption[str | None]:
+    def __new__(
+        cls, *flag_names: str, default: None, help: _HelpT
+    ) -> WorkspacePathOption[str | None]:
         ...
 
-    def __new__(cls, *flag_names, default=None, help):
+    def __new__(cls, *flag_names, default, help):
         return super().__new__(cls, *flag_names, default=default, help=help)
 
 
@@ -441,10 +443,10 @@ class MemorySizeOption(_OptionBase[_PropType]):
         ...
 
     @overload
-    def __new__(cls, *flag_names: str, help: _HelpT) -> MemorySizeOption[int | None]:
+    def __new__(cls, *flag_names: str, default: None, help: _HelpT) -> MemorySizeOption[int | None]:
         ...
 
-    def __new__(cls, *flag_names, default=None, help):
+    def __new__(cls, *flag_names, default, help):
         return super().__new__(cls, *flag_names, default=default, help=help)
 
 

--- a/src/python/pants/option/option_types.py
+++ b/src/python/pants/option/option_types.py
@@ -280,7 +280,7 @@ class EnumOption(_OptionBase[_PropType], Generic[_PropType]):
     def __new__(cls, *flag_names: str, default: _EnumT, help: _HelpT) -> EnumOption[_EnumT]:
         ...
 
-    # N.B. This has an additional param for the ndefault-is-None case: `enum_type`.
+    # N.B. This has an additional param for the default-is-None case: `enum_type`.
     @overload
     def __new__(
         cls, *flag_names: str, enum_type: type[_EnumT], default: None, help: _HelpT

--- a/src/python/pants/option/option_types_test.py
+++ b/src/python/pants/option/option_types_test.py
@@ -79,7 +79,7 @@ def test_option_typeclasses(option_type, default, option_value, expected_registe
             self.options.dyn_opt = option_value
 
         prop = option_type("--opt", default=default, help="")
-        prop_no_default = option_type("--opt-no-default", help="")
+        prop_no_default = option_type("--opt-no-default", default=None, help="")
         dyn_prop = option_type("--dyn-opt", default=default, help=lambda cls: cls.dyn_help)
 
     class MySubsystem(MyBaseSubsystem):
@@ -114,7 +114,9 @@ def test_other_options():
 
         dict_prop = DictOption[Any]("--dict-opt", help="")
         enum_prop = EnumOption("--enum-opt", default=MyEnum.Val1, help="")
-        optional_enum_prop = EnumOption("--optional-enum-opt", enum_type=MyEnum, help="")
+        optional_enum_prop = EnumOption(
+            "--optional-enum-opt", enum_type=MyEnum, default=None, help=""
+        )
         enum_list_prop = EnumListOption("--enum-list-opt", default=[MyEnum.Val1], help="")
         defaultless_enum_list_prop = EnumListOption(
             "--defaultless-enum-list-opt", enum_type=MyEnum, help=""
@@ -173,12 +175,12 @@ def test_builder_methods():
 def test_subsystem_option_ordering() -> None:
     class MySubsystemBase(Subsystem):
         # Make sure these are out of alphabetical order
-        z_prop = StrOption("--z", help="")
-        y_prop = StrOption("--y", help="")
+        z_prop = StrOption("--z", default=None, help="")
+        y_prop = StrOption("--y", default=None, help="")
 
     class MySubsystem(MySubsystemBase):
-        b_prop = StrOption("--b", help="")
-        a_prop = StrOption("--a", help="")
+        b_prop = StrOption("--b", default=None, help="")
+        a_prop = StrOption("--a", default=None, help="")
 
     register = Mock()
     MySubsystem.register_options(register)
@@ -198,23 +200,23 @@ def test_property_types() -> None:
             pass
 
         str_opt = StrOption("--opt", default="", help="")
-        optional_str_opt = StrOption("--opt", help="")
+        optional_str_opt = StrOption("--opt", default=None, help="")
         int_opt = IntOption("--opt", default=0, help="")
-        optional_int_opt = IntOption("--opt", help="")
+        optional_int_opt = IntOption("--opt", default=None, help="")
         float_opt = FloatOption("--opt", default=1.0, help="")
-        optional_float_opt = FloatOption("--opt", help="")
+        optional_float_opt = FloatOption("--opt", default=None, help="")
         bool_opt = BoolOption("--opt", default=True, help="")
-        optional_bool_opt = BoolOption("--opt", help="")
+        optional_bool_opt = BoolOption("--opt", default=None, help="")
         target_opt = TargetOption("--opt", default="", help="")
-        optional_target_opt = TargetOption("--opt", help="")
+        optional_target_opt = TargetOption("--opt", default=None, help="")
         dir_opt = DirOption("--opt", default="", help="")
-        optional_dir_opt = DirOption("--opt", help="")
+        optional_dir_opt = DirOption("--opt", default=None, help="")
         file_opt = FileOption("--opt", default="", help="")
-        optional_file_opt = FileOption("--opt", help="")
+        optional_file_opt = FileOption("--opt", default=None, help="")
         shellstr_opt = ShellStrOption("--opt", default="", help="")
-        optional_shellstr_opt = ShellStrOption("--opt", help="")
+        optional_shellstr_opt = ShellStrOption("--opt", default=None, help="")
         memorysize_opt = MemorySizeOption("--opt", default=1, help="")
-        optional_memorysize_opt = MemorySizeOption("--opt", help="")
+        optional_memorysize_opt = MemorySizeOption("--opt", default=None, help="")
 
         # List opts
         str_list_opt = StrListOption("--opt", help="")
@@ -229,9 +231,9 @@ def test_property_types() -> None:
 
         # Enum opts
         enum_opt = EnumOption("--opt", default=MyEnum.Val1, help="")
-        optional_enum_opt = EnumOption("--opt", enum_type=MyEnum, help="")
+        optional_enum_opt = EnumOption("--opt", enum_type=MyEnum, default=None, help="")
         # mypy correctly complains about not matching any possibilities
-        enum_opt_bad = EnumOption("--opt", help="")  # type: ignore[call-overload]
+        enum_opt_bad = EnumOption("--opt", default=None, help="")  # type: ignore[call-overload]
         enum_list_opt1 = EnumListOption("--opt", default=[MyEnum.Val1], help="")
         enum_list_opt2 = EnumListOption("--opt", enum_type=MyEnum, help="")
         # mypy correctly complains about needing a type annotation

--- a/src/python/pants/option/options_test.py
+++ b/src/python/pants/option/options_test.py
@@ -428,16 +428,16 @@ def test_scope_deprecation(caplog) -> None:
         deprecated_options_scope = "deprecated"
         deprecated_options_scope_removal_version = "9999.9.9.dev0"
 
-        foo = StrOption("--foo", help="")
-        bar = StrOption("--bar", help="")
-        baz = StrOption("--baz", help="")
+        foo = StrOption("--foo", default=None, help="")
+        bar = StrOption("--bar", default=None, help="")
+        baz = StrOption("--baz", default=None, help="")
 
     class Subsystem2(Subsystem):
         options_scope = "new2"
         deprecated_options_scope = "deprecated"
         deprecated_options_scope_removal_version = "9999.9.9.dev0"
 
-        qux = StrOption("--qux", help="")
+        qux = StrOption("--qux", default=None, help="")
 
     def register(opts: Options) -> None:
         opts.register(Subsystem1.options_scope, "--foo")

--- a/src/python/pants/vcs/changed.py
+++ b/src/python/pants/vcs/changed.py
@@ -96,10 +96,12 @@ class Changed(Subsystem):
 
     since = StrOption(
         "--since",
+        default=None,
         help="Calculate changes since this Git spec (commit range/SHA/ref).",
     )
     diffspec = StrOption(
         "--diffspec",
+        default=None,
         help="Calculate changes contained within a given Git spec (commit range/SHA/ref).",
     )
     dependees = EnumOption(


### PR DESCRIPTION
Reasoning:
- The `None` default for the scalar types (especially bool) might be surprising to some who thing the default would be equivalent to `type()` for whatever type (E.g. `""` or `0`)
- The Zen of Python says explicit is better than implicit :wink: 
- This removes the need for the `__new__` overloads in each `Option` class, which is a HUGE win (will be in future PR, due to intricacies)

[ci skip-rust]    
[ci skip-build-wheels]