### PR TITLE
[internal] BSP: introduce JvmBuildTarget type

### DIFF
--- a/src/python/pants/backend/scala/bsp/spec.py
+++ b/src/python/pants/backend/scala/bsp/spec.py
@@ -6,12 +6,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from pants.bsp.spec import BuildTargetIdentifier, Uri
-
-
-@dataclass(frozen=True)
-class JvmBuildTarget:
-    pass
-
+from pants.jvm.bsp.spec import JvmBuildTarget
 
 # -----------------------------------------------------------------------------------------------
 # Scala-specific Build Target
@@ -55,18 +50,22 @@ class ScalaBuildTarget:
             scala_binary_version=d["scalaBinaryVersion"],
             platform=d["platform"],
             jars=tuple(d.get("jars", [])),
-            jvm_build_target=JvmBuildTarget(),  # TODO: deserialize this
+            jvm_build_target=JvmBuildTarget.from_json_dict(d["jvmBuildTarget"])
+            if "jvmBuildTarget" in d
+            else None,
         )
 
     def to_json_dict(self):
-        return {
+        result = {
             "scalaOrganization": self.scala_organization,
             "scalaVersion": self.scala_version,
             "scalaBinaryVersion": self.scala_binary_version,
             "platform": self.platform,
             "jars": list(self.jars),
-            "jvmBuildTarget": None,  # TODO: serialize this
         }
+        if self.jvm_build_target is not None:
+            result["jvmBuildTarget"] = self.jvm_build_target.to_json_dict()
+        return result
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/jvm/bsp/BUILD
+++ b/src/python/pants/jvm/bsp/BUILD
@@ -1,0 +1,4 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_sources()

--- a/src/python/pants/jvm/bsp/spec.py
+++ b/src/python/pants/jvm/bsp/spec.py
@@ -1,0 +1,34 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from pants.bsp.spec import Uri
+
+
+@dataclass(frozen=True)
+class JvmBuildTarget:
+    # Uri representing absolute path to jdk
+    # For example: file:///usr/lib/jvm/java-8-openjdk-amd64
+    java_home: Uri | None = None
+
+    # The java version this target is supposed to use.
+    # For example: 1.8
+    java_version: str | None = None
+
+    @classmethod
+    def from_json_dict(cls, d: dict[str, Any]) -> Any:
+        return cls(
+            java_home=d.get("javaHome"),
+            java_version=d.get("javaVersion"),
+        )
+
+    def to_json_dict(self) -> dict[str, Any]:
+        result = {}
+        if self.java_home is not None:
+            result["javaHome"] = self.java_home
+        if self.java_version is not None:
+            result["javaVersion"] = self.java_version
+        return result


### PR DESCRIPTION
Fill in fields for `JvmBuildTarget` type and move to `pants.jvm.bsp.spec` which will be new home for JVM-specific BSP types.

[ci skip-rust]

[ci skip-build-wheels]