### PR TITLE
Add `core/util_rules/system_binaries.py` and relocate `archive.py` types like `UnzipBinary` to it

### DIFF
--- a/src/python/pants/backend/java/compile/javac.py
+++ b/src/python/pants/backend/java/compile/javac.py
@@ -14,8 +14,8 @@ from pants.backend.java.dependency_inference.rules import (
 from pants.backend.java.dependency_inference.rules import rules as java_dep_inference_rules
 from pants.backend.java.subsystems.javac import JavacSubsystem
 from pants.backend.java.target_types import JavaFieldSet, JavaGeneratorFieldSet, JavaSourceField
-from pants.core.util_rules.archive import ZipBinary
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.core.util_rules.system_binaries import ZipBinary
 from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, Directory, MergeDigests, Snapshot
 from pants.engine.process import BashBinary, FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule

--- a/src/python/pants/backend/java/compile/javac_test.py
+++ b/src/python/pants/backend/java/compile/javac_test.py
@@ -16,7 +16,7 @@ from pants.backend.java.target_types import JavaSourcesGeneratorTarget
 from pants.backend.java.target_types import rules as target_types_rules
 from pants.build_graph.address import Address
 from pants.core.goals.check import CheckResult, CheckResults
-from pants.core.util_rules import archive, config_files, source_files
+from pants.core.util_rules import config_files, source_files, system_binaries
 from pants.engine.addresses import Addresses
 from pants.engine.fs import FileDigest
 from pants.engine.internals.scheduler import ExecutionError
@@ -43,7 +43,7 @@ from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunn
 def rule_runner() -> RuleRunner:
     rule_runner = RuleRunner(
         rules=[
-            *archive.rules(),
+            *system_binaries.rules(),
             *config_files.rules(),
             *jvm_tool.rules(),
             *source_files.rules(),

--- a/src/python/pants/backend/python/util_rules/local_dists.py
+++ b/src/python/pants/backend/python/util_rules/local_dists.py
@@ -16,9 +16,9 @@ from pants.backend.python.util_rules.pex_requirements import PexRequirements
 from pants.backend.python.util_rules.python_sources import PythonSourceFiles
 from pants.build_graph.address import Address
 from pants.core.goals.package import BuiltPackage, PackageFieldSet
-from pants.core.util_rules import archive
-from pants.core.util_rules.archive import UnzipBinary
+from pants.core.util_rules import system_binaries
 from pants.core.util_rules.source_files import SourceFiles
+from pants.core.util_rules.system_binaries import UnzipBinary
 from pants.engine.addresses import Addresses
 from pants.engine.fs import Digest, DigestSubset, MergeDigests, PathGlobs, Snapshot
 from pants.engine.process import BashBinary, Process, ProcessResult
@@ -213,5 +213,5 @@ def rules():
     return (
         *collect_rules(),
         *pex_rules(),
-        *archive.rules(),
+        *system_binaries.rules(),
     )

--- a/src/python/pants/backend/scala/resolve/lockfile_test.py
+++ b/src/python/pants/backend/scala/resolve/lockfile_test.py
@@ -12,8 +12,7 @@ from pants.backend.scala.dependency_inference import rules as scala_dep_inf_rule
 from pants.backend.scala.resolve.lockfile import rules as scala_lockfile_rules
 from pants.backend.scala.target_types import ScalaSourcesGeneratorTarget, ScalaSourceTarget
 from pants.core.goals.generate_lockfiles import GenerateLockfileResult, UserGenerateLockfiles
-from pants.core.util_rules import archive, source_files
-from pants.core.util_rules.external_tool import rules as external_tool_rules
+from pants.core.util_rules import external_tool, source_files, system_binaries
 from pants.engine.internals import build_files, graph
 from pants.jvm import jdk_rules
 from pants.jvm.goals import lockfile
@@ -38,10 +37,10 @@ def rule_runner() -> RuleRunner:
             *coursier_jvm_tool_rules(),
             *lockfile.rules(),
             *coursier_setup_rules(),
-            *external_tool_rules(),
+            *external_tool.rules(),
             *source_files.rules(),
             *util_rules(),
-            *archive.rules(),
+            *system_binaries.rules(),
             *graph.rules(),
             *build_files.rules(),
             *target_types.rules(),

--- a/src/python/pants/backend/scala/test/scalatest_test.py
+++ b/src/python/pants/backend/scala/test/scalatest_test.py
@@ -21,7 +21,7 @@ from pants.backend.scala.test.scalatest import rules as scalatest_rules
 from pants.build_graph.address import Address
 from pants.core.goals.test import TestResult
 from pants.core.target_types import FilesGeneratorTarget, FileTarget, RelocatedFiles
-from pants.core.util_rules import config_files, source_files
+from pants.core.util_rules import config_files, source_files, system_binaries
 from pants.engine.addresses import Addresses
 from pants.engine.target import CoarsenedTargets
 from pants.jvm import classpath
@@ -54,6 +54,7 @@ def rule_runner() -> RuleRunner:
             *scala_target_types_rules(),
             *scalac_rules(),
             *source_files.rules(),
+            *system_binaries.rules(),
             *target_types_rules(),
             *util_rules(),
             QueryRule(CoarsenedTargets, (Addresses,)),

--- a/src/python/pants/backend/shell/shell_command_test.py
+++ b/src/python/pants/backend/shell/shell_command_test.py
@@ -22,7 +22,7 @@ from pants.backend.shell.target_types import (
 from pants.core.goals.run import RunRequest
 from pants.core.target_types import ArchiveTarget, FilesGeneratorTarget, FileSourceField
 from pants.core.target_types import rules as core_target_type_rules
-from pants.core.util_rules import source_files, system_binaries
+from pants.core.util_rules import archive, source_files
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import EMPTY_SNAPSHOT, DigestContents
@@ -40,7 +40,7 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 def rule_runner() -> RuleRunner:
     rule_runner = RuleRunner(
         rules=[
-            *system_binaries.rules(),
+            *archive.rules(),
             *shell_command_rules(),
             *source_files.rules(),
             *core_target_type_rules(),

--- a/src/python/pants/backend/shell/shell_command_test.py
+++ b/src/python/pants/backend/shell/shell_command_test.py
@@ -22,9 +22,8 @@ from pants.backend.shell.target_types import (
 from pants.core.goals.run import RunRequest
 from pants.core.target_types import ArchiveTarget, FilesGeneratorTarget, FileSourceField
 from pants.core.target_types import rules as core_target_type_rules
-from pants.core.util_rules.archive import rules as archive_rules
+from pants.core.util_rules import source_files, system_binaries
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.core.util_rules.source_files import rules as source_files_rules
 from pants.engine.addresses import Address
 from pants.engine.fs import EMPTY_SNAPSHOT, DigestContents
 from pants.engine.process import Process
@@ -41,9 +40,9 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 def rule_runner() -> RuleRunner:
     rule_runner = RuleRunner(
         rules=[
-            *archive_rules(),
+            *system_binaries.rules(),
             *shell_command_rules(),
-            *source_files_rules(),
+            *source_files.rules(),
             *core_target_type_rules(),
             QueryRule(GeneratedSources, [GenerateFilesFromShellCommandRequest]),
             QueryRule(Process, [ShellCommandProcessRequest]),

--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -39,6 +39,7 @@ from pants.core.util_rules import (
     source_files,
     stripped_source_files,
     subprocess_environment,
+    system_binaries,
 )
 from pants.engine.internals.parametrize import Parametrize
 from pants.goal import anonymous_telemetry, stats_aggregator
@@ -74,6 +75,7 @@ def rules():
         *stats_aggregator.rules(),
         *stripped_source_files.rules(),
         *subprocess_environment.rules(),
+        *system_binaries.rules(),
         *target_type_rules(),
     ]
 

--- a/src/python/pants/core/target_types_test.py
+++ b/src/python/pants/core/target_types_test.py
@@ -26,9 +26,8 @@ from pants.core.target_types import (
     ResourceTarget,
 )
 from pants.core.target_types import rules as target_type_rules
-from pants.core.util_rules.archive import rules as archive_rules
+from pants.core.util_rules import archive, source_files, system_binaries
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.core.util_rules.source_files import rules as source_files_rules
 from pants.engine.addresses import Address
 from pants.engine.fs import EMPTY_SNAPSHOT, DigestContents, FileContent
 from pants.engine.internals.graph import _TargetParametrizations
@@ -47,8 +46,9 @@ def test_relocated_files() -> None:
     rule_runner = RuleRunner(
         rules=[
             *target_type_rules(),
-            *archive_rules(),
-            *source_files_rules(),
+            *archive.rules(),
+            *source_files.rules(),
+            *system_binaries.rules(),
             QueryRule(GeneratedSources, [RelocateFilesViaCodegenRequest]),
             QueryRule(TransitiveTargets, [TransitiveTargetsRequest]),
             QueryRule(SourceFiles, [SourceFilesRequest]),

--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -4,177 +4,24 @@
 from __future__ import annotations
 
 import os
-from collections import Sequence
 from dataclasses import dataclass
-from enum import Enum
-from textwrap import dedent
 
-from pants.engine import process
-from pants.engine.fs import CreateDigest, Digest, Directory, MergeDigests, RemovePrefix, Snapshot
-from pants.engine.process import (
-    BinaryPath,
-    BinaryPathRequest,
-    BinaryPaths,
-    BinaryPathTest,
-    Process,
-    ProcessResult,
+from pants.core.util_rules.system_binaries import SEARCH_PATHS
+from pants.core.util_rules.system_binaries import ArchiveFormat as ArchiveFormat
+from pants.core.util_rules.system_binaries import (
+    Gunzip,
+    TarBinary,
+    UnzipBinary,
+    ZipBinary,
+    _GunzipRequest,
+    _TarBinaryRequest,
+    _UnzipBinaryRequest,
+    _ZipBinaryRequest,
 )
+from pants.engine.fs import CreateDigest, Digest, Directory, MergeDigests, RemovePrefix, Snapshot
+from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.python import binaries as python_binaries
-from pants.python.binaries import PythonBinary
 from pants.util.logging import LogLevel
-
-
-# Note that updating this will impact the `archive` target defined in `core/target_types.py`.
-class ArchiveFormat(Enum):
-    TAR = "tar"
-    TGZ = "tar.gz"
-    TBZ2 = "tar.bz2"
-    TXZ = "tar.xz"
-    ZIP = "zip"
-
-
-# -----------------------------------------------------------------------------------------------
-# Find binaries to create/extract archives
-# -----------------------------------------------------------------------------------------------
-
-# TODO: Should this be configurable?
-SEARCH_PATHS = ("/usr/bin", "/bin", "/usr/local/bin")
-
-
-class ZipBinary(BinaryPath):
-    def create_archive_argv(
-        self, output_filename: str, input_files: Sequence[str]
-    ) -> tuple[str, ...]:
-        return (self.path, output_filename, *input_files)
-
-
-class UnzipBinary(BinaryPath):
-    def extract_archive_argv(self, archive_path: str, extract_path: str) -> tuple[str, ...]:
-        # Note that the `output_dir` does not need to already exist.
-        # The caller should validate that it's a valid `.zip` file.
-        return (self.path, archive_path, "-d", extract_path)
-
-
-@dataclass(frozen=True)
-class Gunzip:
-    python: PythonBinary
-
-    def extract_archive_argv(self, archive_path: str, extract_path: str) -> tuple[str, ...]:
-        archive_name = os.path.basename(archive_path)
-        dest_file_name = os.path.splitext(archive_name)[0]
-        dest_path = os.path.join(extract_path, dest_file_name)
-        script = dedent(
-            f"""
-            import gzip
-            import shutil
-            with gzip.GzipFile(filename={archive_path!r}, mode="rb") as source:
-                with open({dest_path!r}, "wb") as dest:
-                    shutil.copyfileobj(source, dest)
-            """
-        )
-        return (self.python.path, "-c", script)
-
-
-class TarBinary(BinaryPath):
-    def create_archive_argv(
-        self, output_filename: str, input_files: Sequence[str], tar_format: ArchiveFormat
-    ) -> tuple[str, ...]:
-        # Note that the parent directory for the output_filename must already exist.
-        #
-        # We do not use `-a` (auto-set compression) because it does not work with older tar
-        # versions. Not all tar implementations will support these compression formats - in that
-        # case, the user will need to choose a different format.
-        compression = {ArchiveFormat.TGZ: "z", ArchiveFormat.TBZ2: "j", ArchiveFormat.TXZ: "J"}.get(
-            tar_format, ""
-        )
-        return (self.path, f"c{compression}f", output_filename, *input_files)
-
-    def extract_archive_argv(self, archive_path: str, extract_path: str) -> tuple[str, ...]:
-        # Note that the `output_dir` must already exist.
-        # The caller should validate that it's a valid `.tar` file.
-        return (self.path, "xf", archive_path, "-C", extract_path)
-
-
-@rule(desc="Finding the `zip` binary", level=LogLevel.DEBUG)
-async def find_zip() -> ZipBinary:
-    request = BinaryPathRequest(
-        binary_name="zip", search_path=SEARCH_PATHS, test=BinaryPathTest(args=["-v"])
-    )
-    paths = await Get(BinaryPaths, BinaryPathRequest, request)
-    first_path = paths.first_path_or_raise(request, rationale="create `.zip` archives")
-    return ZipBinary(first_path.path, first_path.fingerprint)
-
-
-@rule(desc="Finding the `unzip` binary", level=LogLevel.DEBUG)
-async def find_unzip() -> UnzipBinary:
-    request = BinaryPathRequest(
-        binary_name="unzip", search_path=SEARCH_PATHS, test=BinaryPathTest(args=["-v"])
-    )
-    paths = await Get(BinaryPaths, BinaryPathRequest, request)
-    first_path = paths.first_path_or_raise(
-        request, rationale="download the tools Pants needs to run"
-    )
-    return UnzipBinary(first_path.path, first_path.fingerprint)
-
-
-@rule
-def prepare_gunzip(python: PythonBinary) -> Gunzip:
-    return Gunzip(python)
-
-
-@rule(desc="Finding the `tar` binary", level=LogLevel.DEBUG)
-async def find_tar() -> TarBinary:
-    request = BinaryPathRequest(
-        binary_name="tar", search_path=SEARCH_PATHS, test=BinaryPathTest(args=["--version"])
-    )
-    paths = await Get(BinaryPaths, BinaryPathRequest, request)
-    first_path = paths.first_path_or_raise(
-        request, rationale="download the tools Pants needs to run"
-    )
-    return TarBinary(first_path.path, first_path.fingerprint)
-
-
-# TODO(#12946): Get rid of this when it becomes possible to use `Get()` with only one arg.
-class _ZipBinaryRequest:
-    pass
-
-
-class _UnzipBinaryRequest:
-    pass
-
-
-class _GunzipRequest:
-    pass
-
-
-class _TarBinaryRequest:
-    pass
-
-
-@rule
-async def find_zip_wrapper(_: _ZipBinaryRequest, zip_binary: ZipBinary) -> ZipBinary:
-    return zip_binary
-
-
-@rule
-async def find_unzip_wrapper(_: _UnzipBinaryRequest, unzip_binary: UnzipBinary) -> UnzipBinary:
-    return unzip_binary
-
-
-@rule
-async def find_gunzip_wrapper(_: _GunzipRequest, gunzip: Gunzip) -> Gunzip:
-    return gunzip
-
-
-@rule
-async def find_tar_wrapper(_: _TarBinaryRequest, tar_binary: TarBinary) -> TarBinary:
-    return tar_binary
-
-
-# -----------------------------------------------------------------------------------------------
-# Create archives
-# -----------------------------------------------------------------------------------------------
 
 
 @dataclass(frozen=True)
@@ -221,11 +68,6 @@ async def create_archive(request: CreateArchive) -> Digest:
         ),
     )
     return result.output_digest
-
-
-# -----------------------------------------------------------------------------------------------
-# Extract archives
-# -----------------------------------------------------------------------------------------------
 
 
 @dataclass(frozen=True)
@@ -295,8 +137,4 @@ async def maybe_extract_archive(digest: Digest) -> ExtractedArchive:
 
 
 def rules():
-    return [
-        *collect_rules(),
-        *python_binaries.rules(),
-        *process.rules(),
-    ]
+    return collect_rules()

--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 
+from pants.core.util_rules import system_binaries
 from pants.core.util_rules.system_binaries import SEARCH_PATHS
 from pants.core.util_rules.system_binaries import ArchiveFormat as ArchiveFormat
 from pants.core.util_rules.system_binaries import (
@@ -137,4 +138,4 @@ async def maybe_extract_archive(digest: Digest) -> ExtractedArchive:
 
 
 def rules():
-    return collect_rules()
+    return (*collect_rules(), *system_binaries.rules())

--- a/src/python/pants/core/util_rules/archive_test.py
+++ b/src/python/pants/core/util_rules/archive_test.py
@@ -8,8 +8,9 @@ from io import BytesIO
 
 import pytest
 
-from pants.core.util_rules.archive import ArchiveFormat, CreateArchive, ExtractedArchive
-from pants.core.util_rules.archive import rules as archive_rules
+from pants.core.util_rules import archive, system_binaries
+from pants.core.util_rules.archive import CreateArchive, ExtractedArchive
+from pants.core.util_rules.system_binaries import ArchiveFormat
 from pants.engine.fs import Digest, DigestContents, FileContent
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -18,7 +19,8 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
-            *archive_rules(),
+            *archive.rules(),
+            *system_binaries.rules(),
             QueryRule(Digest, [CreateArchive]),
             QueryRule(ExtractedArchive, [Digest]),
         ],

--- a/src/python/pants/core/util_rules/external_tool.py
+++ b/src/python/pants/core/util_rules/external_tool.py
@@ -13,7 +13,7 @@ from typing import Dict, Optional, cast
 
 from pkg_resources import Requirement
 
-from pants.core.util_rules import archive
+from pants.core.util_rules import archive, system_binaries
 from pants.core.util_rules.archive import ExtractedArchive
 from pants.engine.fs import CreateDigest, Digest, DigestEntries, DownloadFile, FileDigest, FileEntry
 from pants.engine.platform import Platform
@@ -358,4 +358,4 @@ async def download_external_tool(request: ExternalToolRequest) -> DownloadedExte
 
 
 def rules():
-    return (*collect_rules(), *archive.rules())
+    return (*collect_rules(), *archive.rules(), *system_binaries.rules())

--- a/src/python/pants/core/util_rules/external_tool.py
+++ b/src/python/pants/core/util_rules/external_tool.py
@@ -13,7 +13,7 @@ from typing import Dict, Optional, cast
 
 from pkg_resources import Requirement
 
-from pants.core.util_rules import archive, system_binaries
+from pants.core.util_rules import archive
 from pants.core.util_rules.archive import ExtractedArchive
 from pants.engine.fs import CreateDigest, Digest, DigestEntries, DownloadFile, FileDigest, FileEntry
 from pants.engine.platform import Platform
@@ -358,4 +358,4 @@ async def download_external_tool(request: ExternalToolRequest) -> DownloadedExte
 
 
 def rules():
-    return (*collect_rules(), *archive.rules(), *system_binaries.rules())
+    return (*collect_rules(), *archive.rules())

--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -1,0 +1,166 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from enum import Enum
+from textwrap import dedent
+from typing import Sequence
+
+from pants.engine import process
+from pants.engine.internals.selectors import Get
+from pants.engine.process import BinaryPath, BinaryPathRequest, BinaryPaths, BinaryPathTest
+from pants.engine.rules import collect_rules, rule
+from pants.python import binaries as python_binaries
+from pants.python.binaries import PythonBinary
+from pants.util.logging import LogLevel
+
+# TODO: Should this be configurable?
+SEARCH_PATHS = ("/usr/bin", "/bin", "/usr/local/bin")
+
+
+# Note that updating this will impact the `archive` target defined in `core/target_types.py`.
+class ArchiveFormat(Enum):
+    TAR = "tar"
+    TGZ = "tar.gz"
+    TBZ2 = "tar.bz2"
+    TXZ = "tar.xz"
+    ZIP = "zip"
+
+
+class ZipBinary(BinaryPath):
+    def create_archive_argv(
+        self, output_filename: str, input_files: Sequence[str]
+    ) -> tuple[str, ...]:
+        return (self.path, output_filename, *input_files)
+
+
+class UnzipBinary(BinaryPath):
+    def extract_archive_argv(self, archive_path: str, extract_path: str) -> tuple[str, ...]:
+        # Note that the `output_dir` does not need to already exist.
+        # The caller should validate that it's a valid `.zip` file.
+        return (self.path, archive_path, "-d", extract_path)
+
+
+@dataclass(frozen=True)
+class Gunzip:
+    python: PythonBinary
+
+    def extract_archive_argv(self, archive_path: str, extract_path: str) -> tuple[str, ...]:
+        archive_name = os.path.basename(archive_path)
+        dest_file_name = os.path.splitext(archive_name)[0]
+        dest_path = os.path.join(extract_path, dest_file_name)
+        script = dedent(
+            f"""
+            import gzip
+            import shutil
+            with gzip.GzipFile(filename={archive_path!r}, mode="rb") as source:
+                with open({dest_path!r}, "wb") as dest:
+                    shutil.copyfileobj(source, dest)
+            """
+        )
+        return (self.python.path, "-c", script)
+
+
+class TarBinary(BinaryPath):
+    def create_archive_argv(
+        self, output_filename: str, input_files: Sequence[str], tar_format: ArchiveFormat
+    ) -> tuple[str, ...]:
+        # Note that the parent directory for the output_filename must already exist.
+        #
+        # We do not use `-a` (auto-set compression) because it does not work with older tar
+        # versions. Not all tar implementations will support these compression formats - in that
+        # case, the user will need to choose a different format.
+        compression = {ArchiveFormat.TGZ: "z", ArchiveFormat.TBZ2: "j", ArchiveFormat.TXZ: "J"}.get(
+            tar_format, ""
+        )
+        return (self.path, f"c{compression}f", output_filename, *input_files)
+
+    def extract_archive_argv(self, archive_path: str, extract_path: str) -> tuple[str, ...]:
+        # Note that the `output_dir` must already exist.
+        # The caller should validate that it's a valid `.tar` file.
+        return (self.path, "xf", archive_path, "-C", extract_path)
+
+
+@rule(desc="Finding the `zip` binary", level=LogLevel.DEBUG)
+async def find_zip() -> ZipBinary:
+    request = BinaryPathRequest(
+        binary_name="zip", search_path=SEARCH_PATHS, test=BinaryPathTest(args=["-v"])
+    )
+    paths = await Get(BinaryPaths, BinaryPathRequest, request)
+    first_path = paths.first_path_or_raise(request, rationale="create `.zip` archives")
+    return ZipBinary(first_path.path, first_path.fingerprint)
+
+
+@rule(desc="Finding the `unzip` binary", level=LogLevel.DEBUG)
+async def find_unzip() -> UnzipBinary:
+    request = BinaryPathRequest(
+        binary_name="unzip", search_path=SEARCH_PATHS, test=BinaryPathTest(args=["-v"])
+    )
+    paths = await Get(BinaryPaths, BinaryPathRequest, request)
+    first_path = paths.first_path_or_raise(
+        request, rationale="download the tools Pants needs to run"
+    )
+    return UnzipBinary(first_path.path, first_path.fingerprint)
+
+
+@rule
+def prepare_gunzip(python: PythonBinary) -> Gunzip:
+    return Gunzip(python)
+
+
+@rule(desc="Finding the `tar` binary", level=LogLevel.DEBUG)
+async def find_tar() -> TarBinary:
+    request = BinaryPathRequest(
+        binary_name="tar", search_path=SEARCH_PATHS, test=BinaryPathTest(args=["--version"])
+    )
+    paths = await Get(BinaryPaths, BinaryPathRequest, request)
+    first_path = paths.first_path_or_raise(
+        request, rationale="download the tools Pants needs to run"
+    )
+    return TarBinary(first_path.path, first_path.fingerprint)
+
+
+# TODO(#12946): Get rid of this when it becomes possible to use `Get()` with only one arg.
+
+
+class _ZipBinaryRequest:
+    pass
+
+
+class _UnzipBinaryRequest:
+    pass
+
+
+class _GunzipRequest:
+    pass
+
+
+class _TarBinaryRequest:
+    pass
+
+
+@rule
+async def find_zip_wrapper(_: _ZipBinaryRequest, zip_binary: ZipBinary) -> ZipBinary:
+    return zip_binary
+
+
+@rule
+async def find_unzip_wrapper(_: _UnzipBinaryRequest, unzip_binary: UnzipBinary) -> UnzipBinary:
+    return unzip_binary
+
+
+@rule
+async def find_gunzip_wrapper(_: _GunzipRequest, gunzip: Gunzip) -> Gunzip:
+    return gunzip
+
+
+@rule
+async def find_tar_wrapper(_: _TarBinaryRequest, tar_binary: TarBinary) -> TarBinary:
+    return tar_binary
+
+
+def rules():
+    return [*collect_rules(), *python_binaries.rules(), *process.rules()]

--- a/src/python/pants/jvm/dependency_inference/artifact_mapper_test.py
+++ b/src/python/pants/jvm/dependency_inference/artifact_mapper_test.py
@@ -15,7 +15,7 @@ from pants.backend.java.target_types import (
     JunitTestsGeneratorTarget,
 )
 from pants.backend.java.target_types import rules as java_target_rules
-from pants.core.util_rules import config_files, source_files
+from pants.core.util_rules import config_files, source_files, system_binaries
 from pants.engine.addresses import Address, Addresses
 from pants.engine.internals.parametrize import Parametrize
 from pants.engine.target import Dependencies, DependenciesRequest
@@ -49,6 +49,7 @@ def rule_runner() -> RuleRunner:
             *java_util_rules(),
             *javac_rules(),
             *source_files.rules(),
+            *system_binaries.rules(),
             *util_rules(),
             QueryRule(Addresses, [DependenciesRequest]),
             QueryRule(ThirdPartyPackageToArtifactMapping, []),

--- a/src/python/pants/jvm/dependency_inference/java_scala_interop_test.py
+++ b/src/python/pants/jvm/dependency_inference/java_scala_interop_test.py
@@ -14,7 +14,7 @@ from pants.backend.scala.dependency_inference import rules as scala_dep_inferenc
 from pants.backend.scala.dependency_inference import scala_parser
 from pants.backend.scala.dependency_inference import symbol_mapper as scala_symbol_mapper
 from pants.backend.scala.target_types import ScalaSourcesGeneratorTarget, ScalaSourceTarget
-from pants.core.util_rules import config_files, source_files
+from pants.core.util_rules import config_files, source_files, system_binaries
 from pants.engine.addresses import Address, Addresses
 from pants.engine.rules import QueryRule
 from pants.engine.target import Dependencies, DependenciesRequest
@@ -40,6 +40,7 @@ def rule_runner() -> RuleRunner:
             *scala_symbol_mapper.rules(),
             *scala_dep_inference_rules.rules(),
             *scala_target_types.rules(),
+            *system_binaries.rules(),
             *util_rules(),
             QueryRule(Addresses, (DependenciesRequest,)),
         ],

--- a/src/python/pants/jvm/package/deploy_jar.py
+++ b/src/python/pants/jvm/package/deploy_jar.py
@@ -14,7 +14,7 @@ from pants.core.goals.package import (
     PackageFieldSet,
 )
 from pants.core.goals.run import RunFieldSet
-from pants.core.util_rules.archive import ZipBinary
+from pants.core.util_rules.system_binaries import ZipBinary
 from pants.engine.addresses import Addresses
 from pants.engine.fs import EMPTY_DIGEST, AddPrefix, CreateDigest, Digest, FileContent, MergeDigests
 from pants.engine.process import BashBinary, Process, ProcessResult

--- a/src/python/pants/jvm/resources.py
+++ b/src/python/pants/jvm/resources.py
@@ -5,9 +5,9 @@ import logging
 from itertools import chain
 
 from pants.core.target_types import ResourcesFieldSet, ResourcesGeneratorFieldSet
-from pants.core.util_rules.archive import ZipBinary
 from pants.core.util_rules.source_files import SourceFilesRequest
 from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
+from pants.core.util_rules.system_binaries import ZipBinary
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.internals.selectors import MultiGet
 from pants.engine.process import Process, ProcessResult

--- a/src/python/pants/jvm/testutil.py
+++ b/src/python/pants/jvm/testutil.py
@@ -10,8 +10,8 @@ from dataclasses import dataclass
 import pytest
 
 from pants.build_graph.address import Address
-from pants.core.util_rules import archive
-from pants.core.util_rules.archive import UnzipBinary
+from pants.core.util_rules import system_binaries
+from pants.core.util_rules.system_binaries import UnzipBinary
 from pants.engine.addresses import Addresses
 from pants.engine.fs import Digest, PathGlobs, RemovePrefix, Snapshot
 from pants.engine.process import Process, ProcessResult
@@ -102,7 +102,7 @@ async def render_classpath(classpath: Classpath) -> RenderedClasspath:
 def rules():
     return [
         *collect_rules(),
-        *archive.rules(),
+        *system_binaries.rules(),
         QueryRule(RenderedClasspath, (Classpath,)),
         QueryRule(RenderedClasspath, (ClasspathEntry,)),
         QueryRule(CoarsenedTargets, (Addresses,)),

--- a/tests/python/pants_test/init/test_plugin_resolver.py
+++ b/tests/python/pants_test/init/test_plugin_resolver.py
@@ -20,7 +20,7 @@ from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import Pex, PexProcess, PexRequest
 from pants.backend.python.util_rules.pex_requirements import PexRequirements
-from pants.core.util_rules import archive, external_tool
+from pants.core.util_rules import external_tool
 from pants.engine.environment import CompleteEnvironment
 from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests, Snapshot
 from pants.engine.internals.scheduler import ExecutionError
@@ -47,7 +47,6 @@ def rule_runner() -> RuleRunner:
         rules=[
             *pex.rules(),
             *external_tool.rules(),
-            *archive.rules(),
             QueryRule(Pex, [PexRequest]),
             QueryRule(ProcessResult, [PexProcess]),
         ]


### PR DESCRIPTION
## Motivation

Have one central location where all our system binaries are set up. We have two objectives with system binaries:

1. Ensure people use `BinaryPath` rather than hardcoding `/bin/tool`, which is necessary for working on diverse machines like NixOS https://github.com/pantsbuild/pants/issues/14492.
2. Limit the number of binaries we use. It has some performance hit + increases the requirements for Pants to work.

By centralizing _all_ of our system binaries code here, I think we will better achieve both goals. For example, https://github.com/pantsbuild/pants/issues/14492 proposes a new `[system-binaries]` subsystem (credit @benjyw for name), and this gives us a single place to make sure every binary is wired up to the subsytem.

## Followup
1. Move `BinaryPath` and `BashBinary` from `pants.engine.process` to this file. Also `PythonBinary` here.
      - We put these types in `process.py` because we didn't have a home at the time. Imo, they belong better in `core/util_rules` than `engine/`: these are not foundational types to the engine. They are conveniences, similar to `external-tool.py` helping to download tools.
      - This will be a breaking change. We can't re-export the types due to import cycles.
4. Add some new binaries like `Mkdir`.
