### PR TITLE
Coursier caches are now determined by `-repos` configuration

### DIFF
--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -49,7 +49,7 @@ from pants.jvm.resolve.common import (
     Coordinates,
     GatherJvmCoordinatesRequest,
 )
-from pants.jvm.resolve.coursier_setup import Coursier, CoursierWrapperProcess
+from pants.jvm.resolve.coursier_setup import Coursier, CoursierFetchProcess
 from pants.jvm.resolve.key import CoursierResolveKey
 from pants.jvm.resolve.lockfile_metadata import JVMLockfileMetadata, LockfileContext
 from pants.jvm.subsystems import JvmSubsystem
@@ -365,7 +365,7 @@ async def coursier_resolve_lockfile(
 
     process_result = await Get(
         ProcessResult,
-        CoursierWrapperProcess(
+        CoursierFetchProcess(
             args=(
                 coursier_report_file_name,
                 *coursier_resolve_info.coord_arg_strings,
@@ -519,7 +519,7 @@ async def coursier_fetch_one_coord(
 
     process_result = await Get(
         ProcessResult,
-        CoursierWrapperProcess(
+        CoursierFetchProcess(
             args=(
                 coursier_report_file_name,
                 "--intransitive",

--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -570,3 +570,39 @@ def test_fetch_one_coord_with_mismatched_coord(rule_runner: RuleRunner) -> None:
     )
     with pytest.raises(ExecutionError, match=expected_exception_msg):
         rule_runner.request(ClasspathEntry, [lockfile_entry])
+
+
+@maybe_skip_jdk_test
+def test_user_repo_order_is_respected(rule_runner: RuleRunner) -> None:
+    """Tests that the repo resolution order issue found in #14577 is avoided."""
+
+    jai_core = Coordinate(group="javax.media", artifact="jai_core", version="1.1.3")
+
+    # `repo1.maven.org` has a bogus POM that Coursier hits first
+    # `repo.osgeo.org` has a valid POM and should succeed
+    rule_runner.set_options(
+        args=[
+            """--coursier-repos=['https://repo1.maven.org/maven2', 'https://repo.osgeo.org/repository/release']"""
+        ],
+        env_inherit=PYTHON_BOOTSTRAP_ENV,
+    )
+    with engine_error(ProcessExecutionFailure):
+        rule_runner.request(
+            CoursierResolvedLockfile,
+            [
+                ArtifactRequirements.from_coordinates([jai_core]),
+            ],
+        )
+
+    rule_runner.set_options(
+        args=[
+            """--coursier-repos=['https://repo.osgeo.org/repository/release', 'https://repo1.maven.org/maven2']"""
+        ],
+        env_inherit=PYTHON_BOOTSTRAP_ENV,
+    )
+    rule_runner.request(
+        CoursierResolvedLockfile,
+        [
+            ArtifactRequirements.from_coordinates([jai_core]),
+        ],
+    )

--- a/src/python/pants/jvm/resolve/coursier_setup.py
+++ b/src/python/pants/jvm/resolve/coursier_setup.py
@@ -22,6 +22,7 @@ from pants.engine.process import BashBinary, Process
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.python.binaries import PythonBinary
 from pants.util.logging import LogLevel
+from pants.util.memo import memoized_property
 from pants.util.ordered_set import FrozenOrderedSet
 
 
@@ -166,7 +167,7 @@ class Coursier:
             *args,
         )
 
-    @property
+    @memoized_property
     def _coursier_cache_prefix(self) -> str:
         """Returns a key for `COURSIER_CACHE` determined by the configured repositories.
 

--- a/src/python/pants/jvm/resolve/coursier_setup.py
+++ b/src/python/pants/jvm/resolve/coursier_setup.py
@@ -25,7 +25,6 @@ from pants.util.logging import LogLevel
 from pants.util.memo import memoized_property
 from pants.util.ordered_set import FrozenOrderedSet
 
-
 COURSIER_POST_PROCESSING_SCRIPT = textwrap.dedent(
     """\
     import json

--- a/src/python/pants/jvm/resolve/coursier_setup.py
+++ b/src/python/pants/jvm/resolve/coursier_setup.py
@@ -134,7 +134,8 @@ class CoursierSubsystem(TemplatedExternalTool):
                 "\n\n"
                 "Coursier will resolve these repositories in the order in which they are "
                 "specifed, and re-ordering repositories will cause artifacts to be "
-                "re-downloaded. This can result in artifacts in lockfiles becoming invalid."),
+                "re-downloaded. This can result in artifacts in lockfiles becoming invalid."
+            ),
         )
 
     def generate_exe(self, plat: Platform) -> str:

--- a/src/python/pants/jvm/resolve/coursier_setup.py
+++ b/src/python/pants/jvm/resolve/coursier_setup.py
@@ -128,7 +128,12 @@ class CoursierSubsystem(TemplatedExternalTool):
                 "https://maven-central.storage-download.googleapis.com/maven2",
                 "https://repo1.maven.org/maven2",
             ],
-            help=("Maven style repositories to resolve artifacts from."),
+            help=(
+                "Maven style repositories to resolve artifacts from."
+                "\n\n"
+                "Coursier will resolve these repositories in the order in which they are "
+                "specifed, and re-ordering repositories will cause artifacts to be "
+                "re-downloaded. This can result in artifacts in lockfiles becoming invalid."),
         )
 
     def generate_exe(self, plat: Platform) -> str:


### PR DESCRIPTION
As discovered in #14577, Coursier's maven cache behaviour is to use the local cache before checking remote repositories. This has meant that changing `--coursier-repos` definitions (which should have worked post-#14581) also required a user's pants cache to be wiped (and to not be using any remote caching).

This puts the Coursier maven cache into a subdirectory determined by the values of the `--coursier-repos` argument, which will be observed as part of the Cache key. Coursier fetches should now be properly hermetic.

Closes #14577 again :)
