### PR TITLE
[internal] BSP: stub out the compile request and associated data types

### DIFF
--- a/src/python/pants/bsp/types.py
+++ b/src/python/pants/bsp/types.py
@@ -1,0 +1,17 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from typing import ClassVar
+
+from pants.engine.unions import union
+
+
+@union
+class BSPLanguageSupport:
+    """Union exposed by language backends to inform BSP core rules of capabilities to advertise to
+    clients."""
+
+    language_id: ClassVar[str]
+    can_compile: bool = False
+    can_test: bool = False
+    can_run: bool = False
+    can_debug: bool = False


### PR DESCRIPTION
Stub out the BSP compile request support including associated data types. The compile request will always generate compile failures for now, but this bootstraps the ability to receive compilation requests in core code. Follow-on PRs will figure out how to wire up compilation into the Scala backend.

This PR contains several changes since it is intended to bootstrap the code:

1. Introduce the `BSPLanguageSupport` union which allows language-specific backends to advertise their capabilities. This is used by the initialization logic in core rules to inform the client of the server's capabilities.
2. Bind BSP types for compilation and task notifications.
3. Implement compile request and emit the required notifications and result to simulate an error.
4. Add the `notify_client` method on `BSPContext` which allows BSP rules to send async notifications to the client. Compile requests are required by BSP to send "task start" and "task finished" notifications for compilation work.
5. Add the `tempdir` property to `BSPContext` which will be used for session-specific state in future PRs; for example, classfiles from compilation.

[ci skip-rust]

[ci skip-build-wheels]