### PR TITLE
Add `output_path` field to `pyoxidizer_binary` and change its default destination

### DIFF
--- a/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
@@ -15,16 +15,19 @@ from pants.backend.python.packaging.pyoxidizer.target_types import (
     PyOxidizerConfigSourceField,
     PyOxidizerDependenciesField,
     PyOxidizerEntryPointField,
+    PyOxidizerOutputPathField,
     PyOxidizerUnclassifiedResources,
 )
 from pants.backend.python.util_rules.pex import Pex, PexProcess, PexRequest
 from pants.core.goals.package import BuiltPackage, BuiltPackageArtifact, PackageFieldSet
 from pants.engine.fs import (
+    AddPrefix,
     CreateDigest,
     Digest,
     DigestContents,
     FileContent,
     MergeDigests,
+    RemovePrefix,
     Snapshot,
 )
 from pants.engine.process import BashBinary, Process, ProcessResult
@@ -51,6 +54,7 @@ class PyOxidizerFieldSet(PackageFieldSet):
     dependencies: PyOxidizerDependenciesField
     unclassified_resources: PyOxidizerUnclassifiedResources
     template: PyOxidizerConfigSourceField
+    output_path: PyOxidizerOutputPathField
 
 
 @dataclass(frozen=True)
@@ -154,11 +158,11 @@ async def package_pyoxidizer_binary(
         Process,
         PexProcess(
             pyoxidizer_pex,
-            argv=["build", *pyoxidizer.args],
+            argv=("build", *pyoxidizer.args),
             description=f"Building {field_set.address} with PyOxidizer",
             input_digest=input_digest,
             level=LogLevel.INFO,
-            output_directories=["build"],
+            output_directories=("build",),
         ),
     )
     process_with_caching = dataclasses.replace(
@@ -171,10 +175,15 @@ async def package_pyoxidizer_binary(
     )
 
     result = await Get(ProcessResult, Process, process_with_caching)
-    result_snapshot = await Get(Snapshot, Digest, result.output_digest)
+
+    stripped_digest = await Get(Digest, RemovePrefix(result.output_digest, "build"))
+    final_snapshot = await Get(
+        Snapshot,
+        AddPrefix(stripped_digest, field_set.output_path.value_or_default(file_ending=None)),
+    )
     return BuiltPackage(
-        result.output_digest,
-        artifacts=tuple(BuiltPackageArtifact(file) for file in result_snapshot.files),
+        final_snapshot.digest,
+        artifacts=tuple(BuiltPackageArtifact(file) for file in final_snapshot.files),
     )
 
 

--- a/src/python/pants/backend/python/packaging/pyoxidizer/rules_integration_test.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/rules_integration_test.py
@@ -42,6 +42,6 @@ def test_end_to_end() -> None:
         result.assert_success()
 
         # Check that the binary is executable.
-        bin_path = next(Path("dist", "build").glob("*/debug/install/bin"))
+        bin_path = next(Path("dist", f"{tmpdir}.hellotest", "bin").glob("*/debug/install/bin"))
         bin_stdout = subprocess.run([bin_path], check=True, stdout=subprocess.PIPE).stdout
         assert bin_stdout == b"Hello test\n"

--- a/src/python/pants/backend/python/packaging/pyoxidizer/target_types.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/target_types.py
@@ -1,6 +1,9 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
+from pants.core.goals.package import OutputPathField
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     Dependencies,
@@ -9,10 +12,26 @@ from pants.engine.target import (
     StringSequenceField,
     Target,
 )
+from pants.util.docutil import bin_name
 
-# TODO: This runs into https://github.com/pantsbuild/pants/issues/13587
-# class PyOxidizerEntryPointField(PexEntryPointField):
-#     pass
+
+class PyOxidizerOutputPathField(OutputPathField):
+    help = (
+        "Where the built directory tree should be located.\n\n"
+        "If undefined, this will use the path to the BUILD file, followed by the target name. "
+        "For example, `src/python/project:bin` would be "
+        "`src.python.project/bin/`.\n\n"
+        "Regardless of whether you use the default or set this field, the path will end with "
+        "PyOxidizer's file format of `<platform>/{debug,release}/install/<binary_name>`, where "
+        "`platform` is a Rust platform triplet like `aarch-64-apple-darwin` and `binary_name` is "
+        "the `name` of the `pyoxidizer_target`. So, using the default for this field, the target "
+        "`src/python/project:bin` might have a final path like "
+        "`src.python.project/bin/aarch-64-apple-darwin/release/bin`.\n\n"
+        f"When running `{bin_name()} package`, this path will be prefixed by `--distdir` (e.g. "
+        "`dist/`).\n\n"
+        "Warning: setting this value risks naming collisions with other package targets you may "
+        "have."
+    )
 
 
 class PyOxidizerEntryPointField(StringField):
@@ -63,6 +82,7 @@ class PyOxidizerTarget(Target):
     alias = "pyoxidizer_binary"
     core_fields = (
         *COMMON_TARGET_FIELDS,
+        PyOxidizerOutputPathField,
         PyOxidizerConfigSourceField,
         PyOxidizerDependenciesField,
         PyOxidizerEntryPointField,

--- a/src/python/pants/core/goals/package.py
+++ b/src/python/pants/core/goals/package.py
@@ -51,11 +51,13 @@ class BuiltPackage:
 class OutputPathField(StringField, AsyncFieldMixin):
     alias = "output_path"
     help = (
-        "Where the built asset should be located.\n\nIf undefined, this will use the path to the "
-        "BUILD file, followed by the target name. For example, `src/python/project:app` would be "
-        f"`src.python.project/app.ext`.\n\nWhen running `{bin_name()} package`, this path will be "
-        "prefixed by `--distdir` (e.g. `dist/`).\n\nWarning: setting this value risks naming "
-        "collisions with other package targets you may have."
+        "Where the built asset should be located.\n\n"
+        "If undefined, this will use the path to the BUILD file, followed by the target name. "
+        "For example, `src/python/project:app` would be `src.python.project/app.ext`.\n\n"
+        f"When running `{bin_name()} package`, this path will be prefixed by `--distdir` (e.g. "
+        "`dist/`).\n\n"
+        "Warning: setting this value risks naming collisions with other package targets you may "
+        "have."
     )
 
     def value_or_default(self, *, file_ending: str | None) -> str:


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/14565.

Before: `build/aarch64-apple-darwin/debug/install/bin`
After: `src.python/bin/aarch64-apple-darwin/debug/install/bin`

As explained on the ticket, we get rid of `build/` because it was noisy. 

We also need to add a prefix to the directory so that when you have multiple `pyoxidizer_binary` targets, there's no risk of overwriting each other. It's a bummer this causes a longer path, but correctness is more important.

We don't mess with PyOxidizer's platform and {debug,release} folders, as considered in https://github.com/pantsbuild/pants/issues/14565. We decided it's too magical and could cause issues for users who want it.

[ci skip-rust]
[ci skip-build-wheels]