### PR TITLE
upgrade to Rust v1.59.0

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -53,7 +53,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.58.1-*
+        path: '~/.rustup/toolchains/1.59.0-*
 
           ~/.rustup/update-hashes
 
@@ -215,7 +215,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.58.1-*
+        path: '~/.rustup/toolchains/1.59.0-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,7 +53,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.58.1-*
+        path: '~/.rustup/toolchains/1.59.0-*
 
           ~/.rustup/update-hashes
 
@@ -214,7 +214,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.58.1-*
+        path: '~/.rustup/toolchains/1.59.0-*
 
           ~/.rustup/update-hashes
 
@@ -415,7 +415,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.58.1-*
+        path: '~/.rustup/toolchains/1.59.0-*
 
           ~/.rustup/update-hashes
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.58.1"
+channel = "1.59.0"
 components = [
   "cargo",
   "clippy",

--- a/src/rust/engine/address/src/lib.rs
+++ b/src/rust/engine/address/src/lib.rs
@@ -73,7 +73,7 @@ peg::parser! {
                     path,
                     target,
                     generated,
-                    parameters: parameters.unwrap_or_else(Vec::new),
+                    parameters: parameters.unwrap_or_default(),
                 }
             }
 

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -650,7 +650,7 @@ trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: Vfs<E> {
         // Escape any globs in the parsed dest, which should guarantee one output PathGlob.
         PathGlob::create(vec![Pattern::escape(dest_str)]).ok()
       })
-      .unwrap_or_else(Vec::new);
+      .unwrap_or_default();
 
     let path_globs =
       PreparedPathGlobs::from_globs(link_globs).map_err(|e| Self::mk_error(e.as_str()))?;

--- a/src/rust/engine/graph/src/entry.rs
+++ b/src/rust/engine/graph/src/entry.rs
@@ -841,6 +841,6 @@ impl<N: Node> Entry<N> {
       Some(ref nr) => format!("{:?}", nr),
       None => "<None>".to_string(),
     };
-    format!("{} == {}", self.node, state).replace("\"", "\\\"")
+    format!("{} == {}", self.node, state).replace('"', "\\\"")
   }
 }

--- a/src/rust/engine/options/src/env.rs
+++ b/src/rust/engine/options/src/env.rs
@@ -25,7 +25,7 @@ impl Env {
     let name = id.name("_", NameTransform::ToUpper);
     let mut names = vec![format!(
       "PANTS_{}_{}",
-      id.0.name().replace("-", "_").to_ascii_uppercase(),
+      id.0.name().replace('-', "_").to_ascii_uppercase(),
       name
     )];
     if id.0 == Scope::Global {

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -1341,11 +1341,7 @@ pub async fn check_action_cache(
         move |mut client| {
           let request = remexec::GetActionResultRequest {
             action_digest: Some(action_digest.into()),
-            instance_name: metadata
-              .instance_name
-              .as_ref()
-              .cloned()
-              .unwrap_or_else(String::new),
+            instance_name: metadata.instance_name.as_ref().cloned().unwrap_or_default(),
             ..remexec::GetActionResultRequest::default()
           };
           let request = apply_headers(Request::new(request), &context.build_id);

--- a/src/rust/engine/rule_graph/src/builder.rs
+++ b/src/rust/engine/rule_graph/src/builder.rs
@@ -1121,7 +1121,7 @@ impl<R: Rule> Builder<R> {
       .flat_map(|(_, errors)| {
         let mut errors = errors.clone();
         errors.sort();
-        errors.into_iter().map(|e| e.trim().replace("\n", "\n    "))
+        errors.into_iter().map(|e| e.trim().replace('\n', "\n    "))
       })
       .collect::<Vec<_>>();
 

--- a/src/rust/engine/src/externs/engine_aware.rs
+++ b/src/rust/engine/src/externs/engine_aware.rs
@@ -37,10 +37,10 @@ impl EngineAwareReturnType {
       metadata.message = Self::message(task_result);
       metadata
         .artifacts
-        .extend(Self::artifacts(task_result).unwrap_or_else(Vec::new));
+        .extend(Self::artifacts(task_result).unwrap_or_default());
       metadata
         .user_metadata
-        .extend(metadata_for(task_result).unwrap_or_else(Vec::new));
+        .extend(metadata_for(task_result).unwrap_or_default());
       Some(metadata)
     });
   }
@@ -101,7 +101,7 @@ impl EngineAwareParameter {
   }
 
   pub fn metadata(obj: &PyAny) -> Vec<(String, UserMetadataItem)> {
-    metadata_for(obj).unwrap_or_else(Vec::new)
+    metadata_for(obj).unwrap_or_default()
   }
 }
 

--- a/src/rust/engine/src/session.rs
+++ b/src/rust/engine/src/session.rs
@@ -399,6 +399,7 @@ impl Sessions {
         .map_err(|err| format!("Failed to install interrupt handler: {}", err))?;
       let (abort_handle, abort_registration) = AbortHandle::new_pair();
       let sessions = sessions.clone();
+      #[allow(clippy::let_underscore_lock)]
       let _ = executor.spawn(Abortable::new(
         async move {
           loop {


### PR DESCRIPTION
Upgrade to Rust v1.59.0.

[Changes:](https://blog.rust-lang.org/2022/02/24/Rust-1.59.0.html):
- Destructuring assignments
- Const generics defaults and interleaving
- Future incompatibility warnings
- Incremental compilation off by default

[ci skip-build-wheels]