### PR TITLE
Move `PythonBinary` from `python.binaries` to `core.util_rules.system_binaries`

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -10,6 +10,7 @@ from typing import Mapping
 
 from pants.core.util_rules import subprocess_environment
 from pants.core.util_rules.subprocess_environment import SubprocessEnvironmentVars
+from pants.core.util_rules.system_binaries import PythonBinary
 from pants.engine import process
 from pants.engine.engine_aware import EngineAwareReturnType
 from pants.engine.environment import Environment
@@ -19,7 +20,7 @@ from pants.option.global_options import NamedCachesDirOption
 from pants.option.option_types import BoolOption, IntOption, StrListOption
 from pants.option.subsystem import Subsystem
 from pants.python import binaries as python_binaries
-from pants.python.binaries import PythonBinary, PythonBootstrap
+from pants.python.binaries import PythonBootstrap
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized_method

--- a/src/python/pants/core/util_rules/system_binaries_test.py
+++ b/src/python/pants/core/util_rules/system_binaries_test.py
@@ -1,0 +1,62 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+
+import pytest
+
+from pants.core.util_rules import system_binaries
+from pants.core.util_rules.system_binaries import PythonBinary
+from pants.engine.internals.selectors import Get
+from pants.engine.process import Process, ProcessResult
+from pants.engine.rules import QueryRule, rule
+from pants.testutil.rule_runner import RuleRunner
+
+
+@dataclass(frozen=True)
+class PythonBinaryVersion:
+    version: str
+
+
+@rule
+async def python_binary_version(python_binary: PythonBinary) -> PythonBinaryVersion:
+    process_result = await Get(
+        ProcessResult,
+        Process(
+            argv=(python_binary.path, "--version"),
+            description=rf"Running `{python_binary.path} --version`",
+        ),
+    )
+    return PythonBinaryVersion(process_result.stdout.decode())
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[*system_binaries.rules(), python_binary_version, QueryRule(PythonBinaryVersion, [])]
+    )
+
+
+def test_python_binary(rule_runner: RuleRunner) -> None:
+    rule_runner.set_options((), env_inherit={"PATH", "PYENV_ROOT", "HOME"})
+    python_binary_version = rule_runner.request(PythonBinaryVersion, [])
+    assert python_binary_version.version.startswith("Python 3.")
+
+
+def test_interpreter_search_path_file_entries() -> None:
+    rule_runner = RuleRunner(
+        rules=[*system_binaries.rules(), QueryRule(PythonBinary, input_types=())]
+    )
+    current_python = os.path.realpath(sys.executable)
+    rule_runner.set_options(
+        args=[
+            f"--python-bootstrap-search-path=[{current_python!r}]",
+            f"--python-bootstrap-names=[{os.path.basename(current_python)!r}]",
+        ]
+    )
+    python_binary = rule_runner.request(PythonBinary, inputs=())
+    assert current_python == python_binary.path

--- a/src/python/pants/jvm/resolve/coursier_setup.py
+++ b/src/python/pants/jvm/resolve/coursier_setup.py
@@ -16,11 +16,11 @@ from pants.core.util_rules.external_tool import (
     ExternalToolRequest,
     TemplatedExternalTool,
 )
+from pants.core.util_rules.system_binaries import PythonBinary
 from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests
 from pants.engine.platform import Platform
 from pants.engine.process import BashBinary, Process
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.python.binaries import PythonBinary
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized_property
 from pants.util.ordered_set import FrozenOrderedSet

--- a/src/python/pants/python/binaries.py
+++ b/src/python/pants/python/binaries.py
@@ -9,24 +9,15 @@ import re
 from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path, PurePath
-from textwrap import dedent
 
 from pex.variables import Variables
 
 from pants.base.build_environment import get_buildroot
 from pants.engine.environment import Environment, EnvironmentRequest
-from pants.engine.process import (
-    BinaryNotFoundError,
-    BinaryPath,
-    BinaryPathRequest,
-    BinaryPaths,
-    BinaryPathTest,
-)
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.rules import Get, collect_rules, rule
 from pants.option.option_types import StrListOption
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.subsystem import Subsystem
-from pants.util.logging import LogLevel
 from pants.util.memo import memoized_method
 
 logger = logging.getLogger(__name__)
@@ -358,84 +349,6 @@ async def python_bootstrap(python_bootstrap_subsystem: PythonBootstrapSubsystem)
         Environment, EnvironmentRequest(["PATH", "HOME", "PYENV_ROOT", "ASDF_DIR", "ASDF_DATA_DIR"])
     )
     return PythonBootstrap(environment, python_bootstrap_subsystem.options)
-
-
-class PythonBinary(BinaryPath):
-    """A Python3 interpreter for use by `@rule` code as an alternative to BashBinary scripts.
-
-    Python is usable for `@rule` scripting independently of `pants.backend.python`, but currently
-    thirdparty dependencies are not supported, because PEX lives in that backend.
-
-    TODO: Consider extracting PEX out into the core in order to support thirdparty dependencies.
-    """
-
-
-@rule(desc="Finding a `python` binary", level=LogLevel.TRACE)
-async def find_python(python_bootstrap: PythonBootstrap) -> PythonBinary:
-
-    # PEX files are compatible with bootstrapping via Python 2.7 or Python 3.5+, but we select 3.6+
-    # for maximum compatibility with internal scripts.
-    interpreter_search_paths = python_bootstrap.interpreter_search_paths()
-    all_python_binary_paths = await MultiGet(
-        Get(
-            BinaryPaths,
-            BinaryPathRequest(
-                search_path=interpreter_search_paths,
-                binary_name=binary_name,
-                check_file_entries=True,
-                test=BinaryPathTest(
-                    args=[
-                        "-c",
-                        # N.B.: The following code snippet must be compatible with Python 3.6+.
-                        #
-                        # We hash the underlying Python interpreter executable to ensure we detect
-                        # changes in the real interpreter that might otherwise be masked by Pyenv
-                        # shim scripts found on the search path. Naively, just printing out the full
-                        # version_info would be enough, but that does not account for supported abi
-                        # changes (e.g.: a pyenv switch from a py27mu interpreter to a py27m
-                        # interpreter.)
-                        #
-                        # When hashing, we pick 8192 for efficiency of reads and fingerprint updates
-                        # (writes) since it's a common OS buffer size and an even multiple of the
-                        # hash block size.
-                        dedent(
-                            """\
-                            import sys
-
-                            major, minor = sys.version_info[:2]
-                            if not (major == 3 and minor >= 6):
-                                sys.exit(1)
-
-                            import hashlib
-                            hasher = hashlib.sha256()
-                            with open(sys.executable, "rb") as fp:
-                                for chunk in iter(lambda: fp.read(8192), b""):
-                                    hasher.update(chunk)
-                            sys.stdout.write(hasher.hexdigest())
-                            """
-                        ),
-                    ],
-                    fingerprint_stdout=False,  # We already emit a usable fingerprint to stdout.
-                ),
-            ),
-        )
-        for binary_name in python_bootstrap.interpreter_names
-    )
-
-    for binary_paths in all_python_binary_paths:
-        path = binary_paths.first_path
-        if path:
-            return PythonBinary(
-                path=path.path,
-                fingerprint=path.fingerprint,
-            )
-
-    raise BinaryNotFoundError(
-        "Was not able to locate a Python interpreter to execute rule code.\n"
-        "Please ensure that Python is available in one of the locations identified by "
-        "`[python-bootstrap] search_path`, which currently expands to:\n"
-        f"  {interpreter_search_paths}"
-    )
 
 
 def rules():


### PR DESCRIPTION
Builds off of https://github.com/pantsbuild/pants/pull/14601.

In a followup, I'll propose moving the remainder of `python.binaries` to a new location.

[ci skip-rust]
[ci skip-build-wheels]