### PR TITLE
go: improve package analysis and actually disable cgo

### DIFF
--- a/src/python/pants/backend/go/go_sources/analyze_package/build_context.go
+++ b/src/python/pants/backend/go/go_sources/analyze_package/build_context.go
@@ -1,0 +1,95 @@
+/* Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package main
+
+import (
+	"go/build"
+	"go/build/constraint"
+	"strings"
+)
+
+// ORIGINAL LICENSE:
+//
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// This file was adapted from Go src/go/build/build.go at commit 7c694fbad1ed6f2f825fd09cf7a86da3be549cea
+// on 2022-02-25.
+
+// matchTag reports whether the name is one of:
+//
+//      cgo (if cgo is enabled)
+//      $GOOS
+//      $GOARCH
+//      ctxt.Compiler
+//      linux (if GOOS = android)
+//      solaris (if GOOS = illumos)
+//      tag (if tag is listed in ctxt.BuildTags or ctxt.ReleaseTags)
+//
+// It records all consulted tags in allTags.
+func matchTag(ctxt *build.Context, name string, allTags map[string]bool) bool {
+	if allTags != nil {
+		allTags[name] = true
+	}
+
+	// special tags
+	if ctxt.CgoEnabled && name == "cgo" {
+		return true
+	}
+	if name == ctxt.GOOS || name == ctxt.GOARCH || name == ctxt.Compiler {
+		return true
+	}
+	if ctxt.GOOS == "android" && name == "linux" {
+		return true
+	}
+	if ctxt.GOOS == "illumos" && name == "solaris" {
+		return true
+	}
+	if ctxt.GOOS == "ios" && name == "darwin" {
+		return true
+	}
+
+	// other tags
+	for _, tag := range ctxt.BuildTags {
+		if tag == name {
+			return true
+		}
+	}
+	for _, tag := range ctxt.ToolTags {
+		if tag == name {
+			return true
+		}
+	}
+	for _, tag := range ctxt.ReleaseTags {
+		if tag == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func eval(ctxt *build.Context, x constraint.Expr, allTags map[string]bool) bool {
+	return x.Eval(func(tag string) bool { return matchTag(ctxt, tag, allTags) })
+}
+
+// matchAuto interprets text as either a +build or //go:build expression (whichever works),
+// reporting whether the expression matches the build context.
+//
+// matchAuto is only used for testing of tag evaluation
+// and in #cgo lines, which accept either syntax.
+func matchAuto(ctxt *build.Context, text string, allTags map[string]bool) bool {
+	if strings.ContainsAny(text, "&|()") {
+		text = "//go:build " + text
+	} else {
+		text = "// +build " + text
+	}
+	x, err := constraint.Parse(text)
+	if err != nil {
+		return false
+	}
+	return eval(ctxt, x, allTags)
+}

--- a/src/python/pants/backend/go/go_sources/analyze_package/main.go
+++ b/src/python/pants/backend/go/go_sources/analyze_package/main.go
@@ -79,8 +79,16 @@ type Package struct {
 	Error          string            `json:",omitempty"`
 }
 
-func analyzeFile(fi *fileInfo, filename string) (*fileInfo, error) {
-	err = readGoInfo(f, fi)
+func analyzeFile(fileSet *token.FileSet, filename string) (*fileInfo, error) {
+	fi := fileInfo{filename: filename, fset: fileSet}
+
+	f, err := os.Open(filename)
+	if err != nil {
+		return &fi, err
+	}
+	defer f.Close()
+
+	err = readGoInfo(f, &fi)
 	if err != nil {
 		return &fi, err
 	}

--- a/src/python/pants/backend/go/go_sources/analyze_package/main.go
+++ b/src/python/pants/backend/go/go_sources/analyze_package/main.go
@@ -177,17 +177,8 @@ func saveCgo(filename string, pkg *Package, cg *ast.CommentGroup, buildContext *
 		//	args[i] = arg
 		//}
 
-		// PANTS NOTE: In the original Go code, this code would have expanded paths passed to -I and -L compiler
-		// options to be absolute. Given Pants uses an execution sandbox, this will be done when actually building.
-		//
-		// PANTS TODO: Warn the user if the file referenced by a relative path was not included via
-		// `files` or `resources`?
-		//
-		//switch verb {
-		//case "CFLAGS", "CPPFLAGS", "CXXFLAGS", "FFLAGS", "LDFLAGS":
-		//	// Change relative paths to absolute.
-		//	ctxt.makePathsAbsolute(args, di.Dir)
-		//}
+		// PANTS NOTE: In the original Go code, there was code to expanded paths passed to -I and -L compiler
+		// options to be absolute path. Given Pants uses an execution sandbox, this will be done when actually building.
 
 		switch verb {
 		case "CFLAGS":
@@ -385,8 +376,6 @@ func analyzePackage(directory string, buildContext *build.Context) (*Package, er
 		}
 	}
 
-	// TODO: We add `cgo` tag determined earlier by probably should other tags found.
-	// Will probably need to vendor MatchFile (like rules_go does).
 	pkg.AllTags = cleanStringSet(allTags)
 
 	pkg.Imports = cleanStringSet(importsMap)

--- a/src/python/pants/backend/go/go_sources/analyze_package/main.go
+++ b/src/python/pants/backend/go/go_sources/analyze_package/main.go
@@ -30,7 +30,7 @@ import (
 // Package represents the results of analyzing a Go package.
 type Package struct {
 	Name    string   // package name
-	AllTags []string // tags that can influence file selection in this directory
+	AllTags []string `json:",omitempty"` // tags that can influence file selection in this directory
 
 	// Source files
 	GoFiles           []string `json:",omitempty"` // .go source files (excluding CgoFiles, TestGoFiles, XTestGoFiles)
@@ -48,12 +48,12 @@ type Package struct {
 	SysoFiles         []string `json:",omitempty"` // .syso system object files to add to archive
 
 	// Cgo directives
-	CgoCFLAGS    []string // Cgo CFLAGS directives
-	CgoCPPFLAGS  []string // Cgo CPPFLAGS directives
-	CgoCXXFLAGS  []string // Cgo CXXFLAGS directives
-	CgoFFLAGS    []string // Cgo FFLAGS directives
-	CgoLDFLAGS   []string // Cgo LDFLAGS directives
-	CgoPkgConfig []string // Cgo pkg-config directives
+	CgoCFLAGS    []string `json:",omitempty"` // Cgo CFLAGS directives
+	CgoCPPFLAGS  []string `json:",omitempty"` // Cgo CPPFLAGS directives
+	CgoCXXFLAGS  []string `json:",omitempty"` // Cgo CXXFLAGS directives
+	CgoFFLAGS    []string `json:",omitempty"` // Cgo FFLAGS directives
+	CgoLDFLAGS   []string `json:",omitempty"` // Cgo LDFLAGS directives
+	CgoPkgConfig []string `json:",omitempty"` // Cgo pkg-config directives
 
 	// Test information
 	TestGoFiles  []string `json:",omitempty"`

--- a/src/python/pants/backend/go/go_sources/analyze_package/main.go
+++ b/src/python/pants/backend/go/go_sources/analyze_package/main.go
@@ -266,11 +266,13 @@ func analyzePackage(directory string, buildContext *build.Context) (*Package, er
 
 		// TODO: `MatchFile` will actually parse the imports but does not return the AST. Consider vendoring
 		// the MatchFile logic to avoid double parsing.
-		matches, err := buildContext.MatchFile(directory, name)
+		binaryOnly := false
+		fileInfo, err := matchFile(buildContext, directory, name, allTags, &binaryOnly, fileSet)
 		if err != nil {
-			return nil, fmt.Errorf("failed to check build tags for %s: %s", name, err)
+			pkg.InvalidGoFiles[name] = err.Error()
+			continue
 		}
-		if !matches {
+		if fileInfo == nil {
 			if strings.HasPrefix(name, "_") || strings.HasPrefix(name, ".") {
 				// `go` ignores files prefixed with underscore or period. Since this is not due to
 				// build constraints, do not report it as an ignored file. Fall through.

--- a/src/python/pants/backend/go/go_sources/analyze_package/main.go
+++ b/src/python/pants/backend/go/go_sources/analyze_package/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"go/ast"
 	"go/build"
 	"go/token"
 	"io/fs"
@@ -28,7 +29,8 @@ import (
 
 // Package represents the results of analyzing a Go package.
 type Package struct {
-	Name string // package name
+	Name    string   // package name
+	AllTags []string // tags that can influence file selection in this directory
 
 	// Source files
 	GoFiles           []string `json:",omitempty"` // .go source files (excluding CgoFiles, TestGoFiles, XTestGoFiles)
@@ -45,6 +47,14 @@ type Package struct {
 	SwigCXXFiles      []string `json:",omitempty"` // .swigcxx files
 	SysoFiles         []string `json:",omitempty"` // .syso system object files to add to archive
 
+	// Cgo directives
+	CgoCFLAGS    []string // Cgo CFLAGS directives
+	CgoCPPFLAGS  []string // Cgo CPPFLAGS directives
+	CgoCXXFLAGS  []string // Cgo CXXFLAGS directives
+	CgoFFLAGS    []string // Cgo FFLAGS directives
+	CgoLDFLAGS   []string // Cgo LDFLAGS directives
+	CgoPkgConfig []string // Cgo pkg-config directives
+
 	// Test information
 	TestGoFiles  []string `json:",omitempty"`
 	XTestGoFiles []string `json:",omitempty"`
@@ -60,9 +70,9 @@ type Package struct {
 	//	//go:embed a* b.c
 	// then the list will contain those two strings as separate entries.
 	// (See package embed for more details about //go:embed.)
-	EmbedPatterns      []string  `json:",omitempty"` // patterns from GoFiles, CgoFiles
-	TestEmbedPatterns  []string  `json:",omitempty"` // patterns from TestGoFiles
-	XTestEmbedPatterns []string  `json:",omitempty"` // patterns from XTestGoFiles
+	EmbedPatterns      []string `json:",omitempty"` // patterns from GoFiles, CgoFiles
+	TestEmbedPatterns  []string `json:",omitempty"` // patterns from TestGoFiles
+	XTestEmbedPatterns []string `json:",omitempty"` // patterns from XTestGoFiles
 
 	// Error information. This differs from how `go list` reports errors.
 	InvalidGoFiles map[string]string `json:",omitempty"`
@@ -120,6 +130,93 @@ func cleanStringSet(valuesMap map[string]bool) []string {
 	return values
 }
 
+// saveCgo saves the information from the #cgo lines in the import "C" comment.
+// These lines set CFLAGS, CPPFLAGS, CXXFLAGS and LDFLAGS and pkg-config directives
+// that affect the way cgo's C code is built.
+func saveCgo(filename string, pkg *Package, cg *ast.CommentGroup, buildContext *build.Context) error {
+	text := cg.Text()
+	for _, line := range strings.Split(text, "\n") {
+		orig := line
+
+		// Line is
+		//      #cgo [GOOS/GOARCH...] LDFLAGS: stuff
+		//
+		line = strings.TrimSpace(line)
+		if len(line) < 5 || line[:4] != "#cgo" || (line[4] != ' ' && line[4] != '\t') {
+			continue
+		}
+
+		// Split at colon.
+		line, argstr, ok := stringsCut(strings.TrimSpace(line[4:]), ":")
+		if !ok {
+			return fmt.Errorf("%s: invalid #cgo line: %s", filename, orig)
+		}
+
+		// Parse GOOS/GOARCH stuff.
+		f := strings.Fields(line)
+		if len(f) < 1 {
+			return fmt.Errorf("%s: invalid #cgo line: %s", filename, orig)
+		}
+
+		cond, verb := f[:len(f)-1], f[len(f)-1]
+		if len(cond) > 0 {
+			ok := false
+			for _, c := range cond {
+				if matchAuto(buildContext, c, nil) {
+					ok = true
+					break
+				}
+			}
+			if !ok {
+				continue
+			}
+		}
+		args, err := splitQuoted(argstr)
+		if err != nil {
+			return fmt.Errorf("%s: invalid #cgo line: %s", filename, orig)
+		}
+		// PANTS NOTE: In the original Go code, this code would have expanded `${SRCDIR}` in a path
+		// to the absolute directory where the cgo file was located. Given Pants uses an execution sandbox,
+		// this will be done when actually building.
+		//for i, arg := range args {
+		//	if arg, ok = expandSrcDir(arg, di.Dir); !ok {
+		//		return fmt.Errorf("%s: malformed #cgo argument: %s", filename, arg)
+		//	}
+		//	args[i] = arg
+		//}
+
+		// PANTS NOTE: In the original Go code, this code would have expanded paths passed to -I and -L compiler
+		// options to be absolute. Given Pants uses an execution sandbox, this will be done when actually building.
+		//
+		// PANTS TODO: Warn the user if the file referenced by a relative path was not included via
+		// `files` or `resources`?
+		//
+		//switch verb {
+		//case "CFLAGS", "CPPFLAGS", "CXXFLAGS", "FFLAGS", "LDFLAGS":
+		//	// Change relative paths to absolute.
+		//	ctxt.makePathsAbsolute(args, di.Dir)
+		//}
+
+		switch verb {
+		case "CFLAGS":
+			pkg.CgoCFLAGS = append(pkg.CgoCFLAGS, args...)
+		case "CPPFLAGS":
+			pkg.CgoCPPFLAGS = append(pkg.CgoCPPFLAGS, args...)
+		case "CXXFLAGS":
+			pkg.CgoCXXFLAGS = append(pkg.CgoCXXFLAGS, args...)
+		case "FFLAGS":
+			pkg.CgoFFLAGS = append(pkg.CgoFFLAGS, args...)
+		case "LDFLAGS":
+			pkg.CgoLDFLAGS = append(pkg.CgoLDFLAGS, args...)
+		case "pkg-config":
+			pkg.CgoPkgConfig = append(pkg.CgoPkgConfig, args...)
+		default:
+			return fmt.Errorf("%s: invalid #cgo verb: %s", filename, orig)
+		}
+	}
+	return nil
+}
+
 func analyzePackage(directory string, buildContext *build.Context) (*Package, error) {
 	pkg := &Package{
 		InvalidGoFiles: make(map[string]string),
@@ -142,6 +239,8 @@ func analyzePackage(directory string, buildContext *build.Context) (*Package, er
 	embedsMap := make(map[string]bool)
 	testEmbedsMap := make(map[string]bool)
 	xtestEmbedsMap := make(map[string]bool)
+
+	allTags := make(map[string]bool)
 
 	var cgoSfiles []string // files with ".S"(capital S)/.sx(capital s equivalent for case insensitive filesystems)
 
@@ -240,8 +339,10 @@ func analyzePackage(directory string, buildContext *build.Context) (*Package, er
 						continue
 					}
 					isCGo = true
-					// TODO: Save the cgo options.
-					// See https://cs.opensource.google/go/go/+/refs/tags/go1.17.2:src/go/build/build.go;drc=refs%2Ftags%2Fgo1.17.2;l=1640.
+					if err := saveCgo(name, pkg, imp.doc, buildContext); err != nil {
+						pkg.InvalidGoFiles[name] = fmt.Sprintf("cgo error: %s", err)
+						continue
+					}
 				}
 			}
 		}
@@ -252,9 +353,15 @@ func analyzePackage(directory string, buildContext *build.Context) (*Package, er
 
 		switch {
 		case isCGo:
-			// Ignore imports and embeds from cgo files since Pants does not support cgo.
-			// TODO: When we do handle cgo, add a build tag for it.
-			fileList = &pkg.IgnoredGoFiles
+			allTags["cgo"] = true
+			if buildContext.CgoEnabled {
+				fileList = &pkg.CgoFiles
+				importsMapForFile = importsMap
+				embedsMapForFile = embedsMap
+			} else {
+				// Ignore imports and embeds from cgo files if cgo is disabled.
+				fileList = &pkg.IgnoredGoFiles
+			}
 		case isXTest:
 			fileList = &pkg.XTestGoFiles
 			importsMapForFile = xtestImportsMap
@@ -284,8 +391,9 @@ func analyzePackage(directory string, buildContext *build.Context) (*Package, er
 		}
 	}
 
-	// TODO: Add generated build tags (like `cgo` tag) to a field in package analysis?
+	// TODO: We add `cgo` tag determined earlier by probably should other tags found.
 	// Will probably need to vendor MatchFile (like rules_go does).
+	pkg.AllTags = cleanStringSet(allTags)
 
 	pkg.Imports = cleanStringSet(importsMap)
 	pkg.TestImports = cleanStringSet(testImportsMap)

--- a/src/python/pants/backend/go/go_sources/analyze_package/main.go
+++ b/src/python/pants/backend/go/go_sources/analyze_package/main.go
@@ -79,16 +79,8 @@ type Package struct {
 	Error          string            `json:",omitempty"`
 }
 
-func analyzeFile(fileSet *token.FileSet, filename string) (*fileInfo, error) {
-	fi := fileInfo{filename: filename, fset: fileSet}
-
-	f, err := os.Open(filename)
-	if err != nil {
-		return &fi, err
-	}
-	defer f.Close()
-
-	err = readGoInfo(f, &fi)
+func analyzeFile(fi *fileInfo, filename string) (*fileInfo, error) {
+	err = readGoInfo(f, fi)
 	if err != nil {
 		return &fi, err
 	}

--- a/src/python/pants/backend/go/go_sources/analyze_package/read.go
+++ b/src/python/pants/backend/go/go_sources/analyze_package/read.go
@@ -728,16 +728,11 @@ func matchFile(ctxt *build.Context, dir, name string, allTags map[string]bool, b
 }
 
 var (
-	slashSlash = []byte("//")
-	slashStar  = []byte("/*")
-	starSlash  = []byte("*/")
-	newline    = []byte("\n")
-)
-var (
-	bSlashSlash = []byte(slashSlash)
-	bStarSlash  = []byte(starSlash)
-	bSlashStar  = []byte(slashStar)
+	bSlashSlash = []byte("//")
+	bStarSlash  = []byte("/*")
+	bSlashStar  = []byte("*/")
 	bPlusBuild  = []byte("+build")
+	newline     = []byte("\n")
 
 	goBuildComment = []byte("//go:build")
 
@@ -851,7 +846,7 @@ Lines:
 			end = len(content) - len(p)
 			continue Lines
 		}
-		if !bytes.HasPrefix(line, slashSlash) { // Not comment line
+		if !bytes.HasPrefix(line, bSlashSlash) { // Not comment line
 			ended = true
 		}
 
@@ -867,9 +862,9 @@ Lines:
 	Comments:
 		for len(line) > 0 {
 			if inSlashStar {
-				if i := bytes.Index(line, starSlash); i >= 0 {
+				if i := bytes.Index(line, bStarSlash); i >= 0 {
 					inSlashStar = false
-					line = bytes.TrimSpace(line[i+len(starSlash):])
+					line = bytes.TrimSpace(line[i+len(bStarSlash):])
 					continue Comments
 				}
 				continue Lines

--- a/src/python/pants/backend/go/go_sources/analyze_package/string_utils.go
+++ b/src/python/pants/backend/go/go_sources/analyze_package/string_utils.go
@@ -1,0 +1,89 @@
+/* Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+/** Vendored from Go
+ *
+ */
+
+package main
+
+import (
+	"errors"
+	"strings"
+	"unicode"
+)
+
+// Cut slices s around the first instance of sep,
+// returning the text before and after sep.
+// The found result reports whether sep appears in s.
+// If sep does not appear in s, cut returns s, "", false.
+//
+// Vendored from `go` 1.18+ since not available in earlier releases.
+func stringsCut(s, sep string) (before, after string, found bool) {
+	if i := strings.Index(s, sep); i >= 0 {
+		return s[:i], s[i+len(sep):], true
+	}
+	return s, "", false
+}
+
+// splitQuoted splits the string s around each instance of one or more consecutive
+// white space characters while taking into account quotes and escaping, and
+// returns an array of substrings of s or an empty list if s contains only white space.
+// Single quotes and double quotes are recognized to prevent splitting within the
+// quoted region, and are removed from the resulting substrings. If a quote in s
+// isn't closed err will be set and r will have the unclosed argument as the
+// last element. The backslash is used for escaping.
+//
+// For example, the following string:
+//
+//     a b:"c d" 'e''f'  "g\""
+//
+// Would be parsed as:
+//
+//     []string{"a", "b:c d", "ef", `g"`}
+//
+func splitQuoted(s string) (r []string, err error) {
+	var args []string
+	arg := make([]rune, len(s))
+	escaped := false
+	quoted := false
+	quote := '\x00'
+	i := 0
+	for _, rune := range s {
+		switch {
+		case escaped:
+			escaped = false
+		case rune == '\\':
+			escaped = true
+			continue
+		case quote != '\x00':
+			if rune == quote {
+				quote = '\x00'
+				continue
+			}
+		case rune == '"' || rune == '\'':
+			quoted = true
+			quote = rune
+			continue
+		case unicode.IsSpace(rune):
+			if quoted || i > 0 {
+				quoted = false
+				args = append(args, string(arg[:i]))
+				i = 0
+			}
+			continue
+		}
+		arg[i] = rune
+		i++
+	}
+	if quoted || i > 0 {
+		args = append(args, string(arg[:i]))
+	}
+	if quote != 0 {
+		err = errors.New("unclosed quote")
+	} else if escaped {
+		err = errors.New("unfinished escaping")
+	}
+	return args, err
+}

--- a/src/python/pants/backend/go/go_sources/analyze_package/string_utils.go
+++ b/src/python/pants/backend/go/go_sources/analyze_package/string_utils.go
@@ -2,9 +2,10 @@
  * Licensed under the Apache License, Version 2.0 (see LICENSE).
  */
 
-/** Vendored from Go
- *
- */
+// Vendored from Go:
+// - stringCut is vendored from `go` 1.18+ stdlib since not available in earlier releases.
+//   see https://github.com/golang/go/blob/57e3809884dd695d484acaefba8ded720c5a02c1/src/strings/strings.go#L1177-L1186
+// - splitQuoted is from https://github.com/golang/go/blob/57e3809884dd695d484acaefba8ded720c5a02c1/src/go/build/build.go#L1787-L1846
 
 package main
 
@@ -19,7 +20,6 @@ import (
 // The found result reports whether sep appears in s.
 // If sep does not appear in s, cut returns s, "", false.
 //
-// Vendored from `go` 1.18+ since not available in earlier releases.
 func stringsCut(s, sep string) (before, after string, found bool) {
 	if i := strings.Index(s, sep); i >= 0 {
 		return s[:i], s[i+len(sep):], true

--- a/src/python/pants/backend/go/go_sources/analyze_package/syslist.go
+++ b/src/python/pants/backend/go/go_sources/analyze_package/syslist.go
@@ -4,6 +4,9 @@
 
 package main
 
+// PANTS NOTE:
+// Copied verbatim from https://github.com/golang/go/blob/master/src/go/build/syslist.go.
+
 // List of past, present, and future known GOOS and GOARCH values.
 // Do not remove from this list, as these are used for go/build filename matching.
 

--- a/src/python/pants/backend/go/go_sources/analyze_package/syslist.go
+++ b/src/python/pants/backend/go/go_sources/analyze_package/syslist.go
@@ -1,0 +1,11 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+// List of past, present, and future known GOOS and GOARCH values.
+// Do not remove from this list, as these are used for go/build filename matching.
+
+const goosList = "aix android darwin dragonfly freebsd hurd illumos ios js linux nacl netbsd openbsd plan9 solaris windows zos "
+const goarchList = "386 amd64 amd64p32 arm armbe arm64 arm64be loong64 mips mipsle mips64 mips64le mips64p32 mips64p32le ppc ppc64 ppc64le riscv riscv64 s390 s390x sparc sparc64 wasm "

--- a/src/python/pants/backend/go/subsystems/golang.py
+++ b/src/python/pants/backend/go/subsystems/golang.py
@@ -62,9 +62,6 @@ class GolangSubsystem(Subsystem):
         ),
     ).advanced()
 
-    # TODO: Make this a proper option once cgo is enabled.
-    cgo_enabled: bool = False
-
     def go_search_paths(self, env: Environment) -> tuple[str, ...]:
         def iter_path_entries():
             for entry in self._go_search_paths:

--- a/src/python/pants/backend/go/subsystems/golang.py
+++ b/src/python/pants/backend/go/subsystems/golang.py
@@ -62,14 +62,8 @@ class GolangSubsystem(Subsystem):
         ),
     ).advanced()
 
-    cgo_enabled = BoolOption(
-        "--experimental-cgo",
-        default=False,
-        help=(
-            "Enable cgo. This option is for testing purposes only to allow Pants developers to enable cgo support. "
-            "Pants does not currently have full cgo support."
-        ),
-    ).advanced()
+    # TODO: Make this a proper option once cgo is enabled.
+    cgo_enabled: bool = False
 
     def go_search_paths(self, env: Environment) -> tuple[str, ...]:
         def iter_path_entries():

--- a/src/python/pants/backend/go/subsystems/golang.py
+++ b/src/python/pants/backend/go/subsystems/golang.py
@@ -18,7 +18,7 @@ from pants.engine.process import (
     ProcessResult,
 )
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.option.option_types import StrListOption, StrOption
+from pants.option.option_types import BoolOption, StrListOption, StrOption
 from pants.option.subsystem import Subsystem
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import OrderedSet
@@ -59,6 +59,15 @@ class GolangSubsystem(Subsystem):
             "Environment variables to set when invoking the `go` tool. "
             "Entries are either strings in the form `ENV_VAR=value` to set an explicit value; "
             "or just `ENV_VAR` to copy the value from Pants's own environment."
+        ),
+    ).advanced()
+
+    cgo_enabled = BoolOption(
+        "--experimental-cgo",
+        default=False,
+        help=(
+            "Enable cgo. This option is for testing purposes only to allow Pants developers to enable cgo support. "
+            "Pants does not currently have full cgo support."
         ),
     ).advanced()
 

--- a/src/python/pants/backend/go/subsystems/golang.py
+++ b/src/python/pants/backend/go/subsystems/golang.py
@@ -18,7 +18,7 @@ from pants.engine.process import (
     ProcessResult,
 )
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.option.option_types import BoolOption, StrListOption, StrOption
+from pants.option.option_types import StrListOption, StrOption
 from pants.option.subsystem import Subsystem
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import OrderedSet

--- a/src/python/pants/backend/go/util_rules/first_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 
 from pants.backend.go.go_sources import load_go_binary
 from pants.backend.go.go_sources.load_go_binary import LoadedGoBinary, LoadedGoBinaryRequest
+from pants.backend.go.subsystems.golang import GolangSubsystem
 from pants.backend.go.target_types import GoPackageSourcesField
 from pants.backend.go.util_rules import pkg_analyzer
 from pants.backend.go.util_rules.embedcfg import EmbedConfig
@@ -160,6 +161,7 @@ async def compute_first_party_package_import_path(
 async def analyze_first_party_package(
     request: FirstPartyPkgAnalysisRequest,
     analyzer: PackageAnalyzerSetup,
+    golang_subsystem: GolangSubsystem,
 ) -> FallibleFirstPartyPkgAnalysis:
     wrapped_target, import_path_info, owning_go_mod = await MultiGet(
         Get(WrappedTarget, Address, request.address),
@@ -181,6 +183,7 @@ async def analyze_first_party_package(
             input_digest=input_digest,
             description=f"Determine metadata for {request.address}",
             level=LogLevel.DEBUG,
+            env={"CGO_ENABLED": "1" if golang_subsystem.cgo_enabled else "0"},
         ),
     )
     if result.exit_code != 0:
@@ -211,7 +214,10 @@ async def analyze_first_party_package(
             f"The first-party package {request.address} includes `CgoFiles`, which Pants does "
             "not yet support. Please open a feature request at "
             "https://github.com/pantsbuild/pants/issues/new/choose so that we know to "
-            "prioritize adding support."
+            "prioritize adding support.\n\n"
+            "Note: You should only encounter this error if `--golang-experimental-cgo` was set, which "
+            "only Pants developers should have enabled. Pants should have compiled the applicable Go package "
+            'in "pure" mode otherwise.'
         )
 
     analysis = FirstPartyPkgAnalysis(

--- a/src/python/pants/backend/go/util_rules/first_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg.py
@@ -215,9 +215,6 @@ async def analyze_first_party_package(
             "not yet support. Please open a feature request at "
             "https://github.com/pantsbuild/pants/issues/new/choose so that we know to "
             "prioritize adding support.\n\n"
-            "Note: You should only encounter this error if `--golang-experimental-cgo` was set, which "
-            "only Pants developers should have enabled. Pants should have compiled the applicable Go package "
-            'in "pure" mode otherwise.'
         )
 
     analysis = FirstPartyPkgAnalysis(

--- a/src/python/pants/backend/go/util_rules/first_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg.py
@@ -183,7 +183,7 @@ async def analyze_first_party_package(
             input_digest=input_digest,
             description=f"Determine metadata for {request.address}",
             level=LogLevel.DEBUG,
-            env={"CGO_ENABLED": "1" if golang_subsystem.cgo_enabled else "0"},
+            env={"CGO_ENABLED": "0"},
         ),
     )
     if result.exit_code != 0:

--- a/src/python/pants/backend/go/util_rules/pkg_analyzer.py
+++ b/src/python/pants/backend/go/util_rules/pkg_analyzer.py
@@ -23,7 +23,7 @@ async def setup_go_package_analyzer() -> PackageAnalyzerSetup:
         LoadedGoBinary,
         LoadedGoBinaryRequest(
             "analyze_package",
-            ("main.go", "read.go", "build_context.go", "string_utils.go"),
+            ("main.go", "read.go", "build_context.go", "string_utils.go", "syslist.go"),
             binary_path,
         ),
     )

--- a/src/python/pants/backend/go/util_rules/pkg_analyzer.py
+++ b/src/python/pants/backend/go/util_rules/pkg_analyzer.py
@@ -21,7 +21,11 @@ async def setup_go_package_analyzer() -> PackageAnalyzerSetup:
     binary_path = "./package_analyzer"
     binary = await Get(
         LoadedGoBinary,
-        LoadedGoBinaryRequest("analyze_package", ("main.go", "read.go"), binary_path),
+        LoadedGoBinaryRequest(
+            "analyze_package",
+            ("main.go", "read.go", "build_context.go", "string_utils.go"),
+            binary_path,
+        ),
     )
     return PackageAnalyzerSetup(
         digest=binary.digest,

--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import ijson
 
+from pants.backend.go.subsystems.golang import GolangSubsystem
 from pants.backend.go.util_rules import pkg_analyzer
 from pants.backend.go.util_rules.pkg_analyzer import PackageAnalyzerSetup
 from pants.backend.go.util_rules.sdk import GoSdkProcess
@@ -253,6 +254,7 @@ def _freeze_json_dict(d: dict[Any, Any]) -> FrozenDict[str, Any]:
 async def analyze_go_third_party_module(
     request: AnalyzeThirdPartyModuleRequest,
     analyzer: PackageAnalyzerSetup,
+    golang_subsystem: GolangSubsystem,
 ) -> AnalyzedThirdPartyModule:
     # Download the module.
     download_result = await Get(
@@ -319,6 +321,7 @@ async def analyze_go_third_party_module(
             },
             description=f"Analyze metadata for Go third-party module: {request.name}@{request.version}",
             level=LogLevel.DEBUG,
+            env={"CGO_ENABLED": "1" if golang_subsystem.cgo_enabled else "0"},
         ),
     )
 

--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -321,7 +321,7 @@ async def analyze_go_third_party_module(
             },
             description=f"Analyze metadata for Go third-party module: {request.name}@{request.version}",
             level=LogLevel.DEBUG,
-            env={"CGO_ENABLED": "1" if golang_subsystem.cgo_enabled else "0"},
+            env={"CGO_ENABLED": "0"},
         ),
     )
 


### PR DESCRIPTION
Improve Go package analysis to:
- Export (via `AllTags`) key the build tags consulted during analysis. (This will be used for incorporating the build tags into the cache key.) The requires vendoring the `MatchFile` function from the `go/build` package which does not expose the tags that it parses.
- Analyze cgo-related metadata. (This will be used once we support cgo.)

This PR also properly disables cgo so that it is treated as ignored. This was an unintended semantic difference from `go` which ignores cgo files when cgo is disabled.