### PR TITLE
Fix `pyoxidizer_binary` to support `python_distribution` targets that depend on others (Cherry-pick of #14620)

### DIFF
--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -213,6 +213,7 @@ def run_pants_help_all() -> dict[str, Any]:
         "pants.backend.experimental.python",
         "pants.backend.experimental.python.lint.autoflake",
         "pants.backend.experimental.python.lint.pyupgrade",
+        "pants.backend.experimental.python.packaging.pyoxidizer",
         "pants.backend.experimental.scala",
         "pants.backend.experimental.scala.lint.scalafmt",
         "pants.backend.google_cloud_function.python",

--- a/src/python/pants/backend/python/packaging/pyoxidizer/rules_integration_test.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/rules_integration_test.py
@@ -9,8 +9,32 @@ from pants.testutil.pants_integration_test import run_pants, setup_tmpdir
 
 
 def test_end_to_end() -> None:
+    """We test a couple edge cases:
+
+    * Third-party dependencies can be used.
+    * A `python_distribution` (implicitly) depending on another `python_distribution`.
+    """
     sources = {
-        "hellotest/main.py": "import colors; print('Hello test')",
+        "hellotest/utils/greeter.py": "GREET = 'Hello world!'",
+        "hellotest/utils/BUILD": dedent(
+            """\
+            python_sources(name="lib")
+
+            python_distribution(
+                name="dist",
+                dependencies=[":lib"],
+                provides=python_artifact(name="utils-dist", version="0.0.1"),
+            )
+            """
+        ),
+        "hellotest/main.py": dedent(
+            """\
+            import colors
+            from hellotest.utils.greeter import GREET
+
+            print(GREET)
+            """
+        ),
         "hellotest/BUILD": dedent(
             """\
             python_requirement(name="req", requirements=["ansicolors==1.1.8"])
@@ -20,13 +44,13 @@ def test_end_to_end() -> None:
             python_distribution(
                 name="dist",
                 dependencies=[":lib"],
-                provides=python_artifact(name="dist", version="0.0.1"),
+                provides=python_artifact(name="main-dist", version="0.0.1"),
             )
 
             pyoxidizer_binary(
                 name="bin",
                 entry_point="hellotest.main",
-                dependencies=[":dist"],
+                dependencies=[":dist", "{tmpdir}/hellotest/utils:dist"],
             )
             """
         ),
@@ -44,4 +68,30 @@ def test_end_to_end() -> None:
         # Check that the binary is executable.
         bin_path = next(Path("dist", f"{tmpdir}.hellotest", "bin").glob("*/debug/install/bin"))
         bin_stdout = subprocess.run([bin_path], check=True, stdout=subprocess.PIPE).stdout
-        assert bin_stdout == b"Hello test\n"
+        assert bin_stdout == b"Hello world!\n"
+
+
+def test_requires_wheels() -> None:
+    sources = {
+        "hellotest/BUILD": dedent(
+            """\
+            python_distribution(
+                name="dist",
+                wheel=False,
+                provides=python_artifact(name="dist", version="0.0.1"),
+            )
+
+            pyoxidizer_binary(name="bin", dependencies=[":dist"])
+            """
+        ),
+    }
+    with setup_tmpdir(sources) as tmpdir:
+        args = [
+            "--backend-packages=['pants.backend.python', 'pants.backend.experimental.python.packaging.pyoxidizer']",
+            f"--source-root-patterns=['/{tmpdir}']",
+            "package",
+            f"{tmpdir}/hellotest:bin",
+        ]
+        result = run_pants(args)
+        result.assert_failure()
+        assert "InvalidTargetException" in result.stderr

--- a/src/python/pants/backend/python/packaging/pyoxidizer/target_types.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/target_types.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from pants.backend.python.target_types import GenerateSetupField, WheelField
 from pants.core.goals.package import OutputPathField
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
@@ -12,6 +13,7 @@ from pants.engine.target import (
     StringSequenceField,
     Target,
 )
+from pants.util.docutil import doc_url
 
 
 class PyOxidizerOutputPathField(OutputPathField):
@@ -47,14 +49,32 @@ class PyOxidizerEntryPointField(StringField):
 
 
 class PyOxidizerDependenciesField(Dependencies):
-    pass
+    required = True
+    supports_transitive_excludes = True
+    help = (
+        "The addresses of `python_distribution` target(s) to include in the binary, e.g. "
+        "`['src/python/project:dist']`.\n\n"
+        "The distribution(s) must generate at least one wheel file. For example, if using "
+        f"`{GenerateSetupField.alias}=True`, then make sure `{WheelField.alias}=True`. See "
+        f"{doc_url('python-distributions')}.\n\n"
+        "Usually, you only need to specify a single `python_distribution`. However, if "
+        "that distribution depends on another first-party distribution in your repository, you "
+        "must specify that dependency too, otherwise PyOxidizer would try installing the "
+        "distribution from PyPI. Note that a `python_distribution` target might depend on "
+        "another `python_distribution` target even if it is not included in its own `dependencies` "
+        f"field, as explained at {doc_url('python-distributions')}; if code from one distribution "
+        "imports code from another distribution, then there is a dependency and you must "
+        "include both `python_distribution` targets in the `dependencies` field of this "
+        "`pyoxidizer_binary` target.\n\n"
+        "Target types other than `python_distribution` will be ignored."
+    )
 
 
 class PyOxidizerUnclassifiedResources(StringSequenceField):
     alias = "filesystem_resources"
     help = (
         "Adds support for listing dependencies that MUST be installed to the filesystem "
-        "(e.g. Numpy). See"
+        "(e.g. Numpy). See "
         "https://pyoxidizer.readthedocs.io/en/stable/pyoxidizer_packaging_additional_files.html#installing-unclassified-files-on-the-filesystem"
     )
 
@@ -88,5 +108,14 @@ class PyOxidizerTarget(Target):
         PyOxidizerUnclassifiedResources,
     )
     help = (
-        "A single-file Python executable with a Python interpreter embedded, built via PyOxidizer."
+        "A single-file Python executable with a Python interpreter embedded, built via "
+        "PyOxidizer.\n\n"
+        "To use this target, first create a `python_distribution` target with the code you want "
+        f"included in your binary, per {doc_url('python-distributions')}. Then add this "
+        f"`python_distribution` target to the `dependencies` field. See the `help` for "
+        f"`dependencies` for more information.\n\n"
+        f"You may optionally want to set the `{PyOxidizerEntryPointField.alias}` field. For "
+        "advanced use cases, you can use a custom PyOxidizer config file, rather than what Pants "
+        f"generates, by setting the `{PyOxidizerConfigSourceField.alias}` field. You may also want "
+        "to set `[pyoxidizer].args` to a value like `['--release']`."
     )


### PR DESCRIPTION
It's very common for one `python_distribution` to depend on another, e.g. `pantsbuild.pants.testutil` depends on `pantsbuild.pants`. We can easily support that by having the user specify all necessary `python_distribution` targets in the `dependencies` field.

A fancier implementation would calculate for you automatically what dists a `python_distribution` depends on. But that's more complex than it sounds! Note that the dependency is not expressed explicitly via the `dependencies` field, but instead via very complex logic in `setup_py.py`; we'd need to leak that implementation here, or scan the generated `install_requires`. Pants's support for PEP 517 also makes things complicated. So, instead, for now at least, we go with the simple workaround.

[ci skip-rust]
[ci skip-build-wheels]