### PR TITLE
[internal] Remove the builder pattern in favor of kwargs

### DIFF
--- a/src/python/pants/backend/docker/subsystems/docker_options.py
+++ b/src/python/pants/backend/docker/subsystems/docker_options.py
@@ -73,7 +73,7 @@ class DockerOptions(Subsystem):
     options_scope = "docker"
     help = "Options for interacting with Docker."
 
-    _registries = DictOption[Any]("--registries", help=registries_help).from_file()
+    _registries = DictOption[Any]("--registries", help=registries_help, fromfile=True)
     default_repository = StrOption(
         "--default-repository",
         help=default_repository_help,
@@ -135,7 +135,8 @@ class DockerOptions(Subsystem):
             "Entries are either strings in the form `ENV_VAR=value` to set an explicit value; "
             "or just `ENV_VAR` to copy the value from Pants's own environment."
         ),
-    ).advanced()
+        advanced=True,
+    )
     run_args = ShellStrListOption(
         "--run-args",
         default=["--interactive", "--tty"] if sys.stdout.isatty() else [],
@@ -152,18 +153,16 @@ class DockerOptions(Subsystem):
             "Defaults to `--interactive --tty` when stdout is connected to a terminal."
         ),
     )
-    _executable_search_paths = (
-        StrListOption(
-            "--executable-search-paths",
-            default=["<PATH>"],
-            help=(
-                "The PATH value that will be used to find the Docker client and any tools required."
-                "\n\n"
-                'The special string `"<PATH>"` will expand to the contents of the PATH env var.'
-            ),
-        )
-        .advanced()
-        .metavar("<binary-paths>")
+    _executable_search_paths = StrListOption(
+        "--executable-search-paths",
+        default=["<PATH>"],
+        help=(
+            "The PATH value that will be used to find the Docker client and any tools required."
+            "\n\n"
+            'The special string `"<PATH>"` will expand to the contents of the PATH env var.'
+        ),
+        advanced=True,
+        metavar="<binary-paths>",
     )
 
     @property

--- a/src/python/pants/backend/go/subsystems/golang.py
+++ b/src/python/pants/backend/go/subsystems/golang.py
@@ -60,7 +60,8 @@ class GolangSubsystem(Subsystem):
             "Entries are either strings in the form `ENV_VAR=value` to set an explicit value; "
             "or just `ENV_VAR` to copy the value from Pants's own environment."
         ),
-    ).advanced()
+        advanced=True,
+    )
 
     def go_search_paths(self, env: Environment) -> tuple[str, ...]:
         def iter_path_entries():

--- a/src/python/pants/backend/project_info/regex_lint.py
+++ b/src/python/pants/backend/project_info/regex_lint.py
@@ -122,7 +122,8 @@ class RegexLintSubsystem(Subsystem):
             "It's often helpful to load this config from a JSON or YAML file. To do that, set "
             "`[regex-lint].config = '@path/to/config.yaml'`, for example."
         ),
-    ).from_file()
+        fromfile=True,
+    )
     detail_level = EnumOption(
         "--detail-level",
         default=DetailLevel.nonmatching,

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -19,12 +19,14 @@ class PythonNativeCode(Subsystem):
         "--cpp-flags",
         default=safe_shlex_split(os.environ.get("CPPFLAGS", "")),
         help="Override the `CPPFLAGS` environment variable for any forked subprocesses.",
-    ).advanced()
+        advanced=True,
+    )
     ld_flags = StrListOption(
         "--ld-flags",
         default=safe_shlex_split(os.environ.get("LDFLAGS", "")),
         help="Override the `LDFLAGS` environment variable for any forked subprocesses.",
-    ).advanced()
+        advanced=True,
+    )
 
     @property
     def environment_dict(self) -> Dict[str, str]:

--- a/src/python/pants/backend/python/subsystems/repos.py
+++ b/src/python/pants/backend/python/subsystems/repos.py
@@ -24,7 +24,8 @@ class PythonRepos(Subsystem):
             "URLs of code repositories to look for requirements. In Pip and Pex, this option "
             "corresponds to the `--find-links` option."
         ),
-    ).advanced()
+        advanced=True,
+    )
     indexes = StrListOption(
         "--indexes",
         default=[pypi_index],
@@ -33,7 +34,8 @@ class PythonRepos(Subsystem):
             "list, then Pex will use no indices (meaning it will not use PyPI). The values "
             "should be compliant with PEP 503."
         ),
-    ).advanced()
+        advanced=True,
+    )
 
     @property
     def pex_args(self) -> Iterator[str]:

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -37,20 +37,18 @@ class PythonSetup(Subsystem):
     default_interpreter_constraints = ["CPython>=3.6,<4"]
     default_interpreter_universe = ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
 
-    interpreter_constraints = (
-        StrListOption(
-            "--interpreter-constraints",
-            default=default_interpreter_constraints,
-            help=(
-                "The Python interpreters your codebase is compatible with.\n\nSpecify with "
-                "requirement syntax, e.g. 'CPython>=2.7,<3' (A CPython interpreter with version "
-                ">=2.7 AND version <3) or 'PyPy' (A pypy interpreter of any version). Multiple "
-                "constraint strings will be ORed together.\n\nThese constraints are used as the "
-                "default value for the `interpreter_constraints` field of Python targets."
-            ),
-        )
-        .advanced()
-        .metavar("<requirement>")
+    interpreter_constraints = StrListOption(
+        "--interpreter-constraints",
+        default=default_interpreter_constraints,
+        help=(
+            "The Python interpreters your codebase is compatible with.\n\nSpecify with "
+            "requirement syntax, e.g. 'CPython>=2.7,<3' (A CPython interpreter with version "
+            ">=2.7 AND version <3) or 'PyPy' (A pypy interpreter of any version). Multiple "
+            "constraint strings will be ORed together.\n\nThese constraints are used as the "
+            "default value for the `interpreter_constraints` field of Python targets."
+        ),
+        advanced=True,
+        metavar="<requirement>",
     )
     interpreter_universe = StrListOption(
         "--interpreter-versions-universe",
@@ -69,25 +67,24 @@ class PythonSetup(Subsystem):
             "All elements must be the minor and major Python version, e.g. '2.7' or '3.10'. Do "
             "not include the patch version.\n\n"
         ),
-    ).advanced()
-    requirement_constraints = (
-        FileOption(
-            "--requirement-constraints",
-            default=None,
-            help=(
-                "When resolving third-party requirements for your own code (vs. tools you run), "
-                "use this constraints file to determine which versions to use.\n\n"
-                "This only applies when resolving user requirements, rather than tools you run "
-                "like Black and Pytest. To constrain tools, set `[tool].lockfile`, e.g. "
-                "`[black].lockfile`.\n\n"
-                "See https://pip.pypa.io/en/stable/user_guide/#constraints-files for more "
-                "information on the format of constraint files and how constraints are applied in "
-                "Pex and pip.\n\n"
-                "Mutually exclusive with `[python].enable_resolves`."
-            ),
-        )
-        .advanced()
-        .mutually_exclusive_group("lockfile")
+        advanced=True,
+    )
+    requirement_constraints = FileOption(
+        "--requirement-constraints",
+        default=None,
+        help=(
+            "When resolving third-party requirements for your own code (vs. tools you run), "
+            "use this constraints file to determine which versions to use.\n\n"
+            "This only applies when resolving user requirements, rather than tools you run "
+            "like Black and Pytest. To constrain tools, set `[tool].lockfile`, e.g. "
+            "`[black].lockfile`.\n\n"
+            "See https://pip.pypa.io/en/stable/user_guide/#constraints-files for more "
+            "information on the format of constraint files and how constraints are applied in "
+            "Pex and pip.\n\n"
+            "Mutually exclusive with `[python].enable_resolves`."
+        ),
+        advanced=True,
+        mutually_exclusive_group="lockfile",
     )
     resolve_all_constraints = BoolOption(
         "--resolve-all-constraints",
@@ -103,41 +100,40 @@ class PythonSetup(Subsystem):
             "resolves."
             "\n\nRequires [python].requirement_constraints to be set."
         ),
-    ).advanced()
-    enable_resolves = (
-        BoolOption(
-            "--enable-resolves",
-            default=False,
-            help=(
-                "Set to true to enable the multiple resolves mechanism. See "
-                "`[python].resolves` for an explanation of this feature.\n\n"
-                "Warning: you may have issues with generating valid lockfiles via the "
-                "`generate-lockfiles` goal. Categorically, the resolves feature will not work if "
-                "you need to use VCS (Git) requirements and local requirements, along with "
-                "`[python-repos]` for custom indexes/cheeseshops. Several users have also had "
-                "issues with how Poetry's lockfile generation handles environment markers for "
-                "transitive dependencies; certain dependencies end up with nonsensical "
-                "environment markers which cause the dependency to not be installed, then "
-                "for Pants/Pex to complain the dependency is missing, even though it's in the "
-                "lockfile. The workaround is to manually create a `python_requirement` target for "
-                "the problematic transitive dependencies so that they are seen as direct "
-                "requirements, rather than transitive, then to regenerate the lockfile with "
-                "`generate-lockfiles`. We are working to fix these issues by using PEX & pip to "
-                "generate the lockfile.\n\n"
-                "Outside of the above issues with lockfile generation, we believe this "
-                "feature is stable. It offers three major benefits compared to "
-                "`[python].requirement_constraints`:\n\n"
-                "  1. Uses `--hash` to validate that all downloaded files are expected, which "
-                "reduces the risk of supply chain attacks.\n"
-                "  2. Enforces that all transitive dependencies are in the lockfile, whereas "
-                "constraints allow you to leave off dependencies. This ensures your build is more "
-                "stable and reduces the risk of supply chain attacks.\n"
-                "  3. Allows you to have multiple resolves in your repository.\n\n"
-                "Mutually exclusive with `[python].requirement_constraints`."
-            ),
-        )
-        .advanced()
-        .mutually_exclusive_group("lockfile")
+        advanced=True,
+    )
+    enable_resolves = BoolOption(
+        "--enable-resolves",
+        default=False,
+        help=(
+            "Set to true to enable the multiple resolves mechanism. See "
+            "`[python].resolves` for an explanation of this feature.\n\n"
+            "Warning: you may have issues with generating valid lockfiles via the "
+            "`generate-lockfiles` goal. Categorically, the resolves feature will not work if "
+            "you need to use VCS (Git) requirements and local requirements, along with "
+            "`[python-repos]` for custom indexes/cheeseshops. Several users have also had "
+            "issues with how Poetry's lockfile generation handles environment markers for "
+            "transitive dependencies; certain dependencies end up with nonsensical "
+            "environment markers which cause the dependency to not be installed, then "
+            "for Pants/Pex to complain the dependency is missing, even though it's in the "
+            "lockfile. The workaround is to manually create a `python_requirement` target for "
+            "the problematic transitive dependencies so that they are seen as direct "
+            "requirements, rather than transitive, then to regenerate the lockfile with "
+            "`generate-lockfiles`. We are working to fix these issues by using PEX & pip to "
+            "generate the lockfile.\n\n"
+            "Outside of the above issues with lockfile generation, we believe this "
+            "feature is stable. It offers three major benefits compared to "
+            "`[python].requirement_constraints`:\n\n"
+            "  1. Uses `--hash` to validate that all downloaded files are expected, which "
+            "reduces the risk of supply chain attacks.\n"
+            "  2. Enforces that all transitive dependencies are in the lockfile, whereas "
+            "constraints allow you to leave off dependencies. This ensures your build is more "
+            "stable and reduces the risk of supply chain attacks.\n"
+            "  3. Allows you to have multiple resolves in your repository.\n\n"
+            "Mutually exclusive with `[python].requirement_constraints`."
+        ),
+        advanced=True,
+        mutually_exclusive_group="lockfile",
     )
     resolves = DictOption[str](
         "--resolves",
@@ -173,7 +169,8 @@ class PythonSetup(Subsystem):
             "resolve with the `resolve` field.\n\n"
             "Only applies if `[python].enable_resolves` is true."
         ),
-    ).advanced()
+        advanced=True,
+    )
     default_resolve = StrOption(
         "--default-resolve",
         default="python-default",
@@ -181,7 +178,8 @@ class PythonSetup(Subsystem):
             "The default value used for the `resolve` field.\n\n"
             "The name must be defined as a resolve in `[python].resolves`."
         ),
-    ).advanced()
+        advanced=True,
+    )
     _resolves_to_interpreter_constraints = DictOption["list[str]"](
         "--resolves-to-interpreter-constraints",
         help=(
@@ -198,7 +196,8 @@ class PythonSetup(Subsystem):
             "Pants will error explaining the incompatibility.\n\n"
             "The keys must be defined as resolves in `[python].resolves`."
         ),
-    ).advanced()
+        advanced=True,
+    )
     invalid_lockfile_behavior = EnumOption(
         "--invalid-lockfile-behavior",
         default=InvalidLockfileBehavior.error,
@@ -207,7 +206,8 @@ class PythonSetup(Subsystem):
             "not compatible with what the current build is using.\n\n"
             "We recommend keeping the default of `error` for CI builds."
         ),
-    ).advanced()
+        advanced=True,
+    )
     run_against_entire_lockfile = BoolOption(
         "--run-against-entire-lockfile",
         default=False,
@@ -223,14 +223,16 @@ class PythonSetup(Subsystem):
             "PEX files, wheels and cloud functions, which will still use just the exact "
             "subset of requirements needed."
         ),
-    ).advanced()
+        advanced=True,
+    )
     resolver_manylinux = StrOption(
         "--resolver-manylinux",
         default="manylinux2014",
         help="Whether to allow resolution of manylinux wheels when resolving requirements for "
         "foreign linux platforms. The value should be a manylinux platform upper bound, "
         "e.g.: 'manylinux2010', or else the string 'no' to disallow.",
-    ).advanced()
+        advanced=True,
+    )
     tailor_ignore_solitary_init_files = BoolOption(
         "--tailor-ignore-solitary-init-files",
         default=True,
@@ -238,17 +240,20 @@ class PythonSetup(Subsystem):
         "those usually exist as import scaffolding rather than true library code.\n\n"
         "Set to False if you commonly have packages containing real code in "
         "`__init__.py` and there are no other .py files in the package.",
-    ).advanced()
+        advanced=True,
+    )
     tailor_requirements_targets = BoolOption(
         "--tailor-requirements-targets",
         default=True,
         help="Tailor python_requirements() targets for requirements files.",
-    ).advanced()
+        advanced=True,
+    )
     tailor_pex_binary_targets = BoolOption(
         "--tailor-pex-binary-targets",
         default=True,
         help="Tailor pex_binary() targets for Python entry point files.",
-    ).advanced()
+        advanced=True,
+    )
     macos_big_sur_compatibility = BoolOption(
         "--macos-big-sur-compatibility",
         default=False,

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -597,7 +597,8 @@ class PexBinaryDefaults(Subsystem):
             "\n\nCan be overridden by specifying the `emit_warnings` parameter of individual "
             "`pex_binary` targets"
         ),
-    ).advanced()
+        advanced=True,
+    )
     resolve_local_platforms = BoolOption(
         "--resolve-local-platforms",
         default=False,
@@ -609,7 +610,8 @@ class PexBinaryDefaults(Subsystem):
             "is found (or if this option is `False`), resolve for the platform by accepting "
             "only pre-built binary distributions (wheels)."
         ),
-    ).advanced()
+        advanced=True,
+    )
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -33,24 +33,23 @@ class PexRuntimeEnvironment(Subsystem):
 
     # TODO(#9760): We'll want to deprecate this in favor of a global option which allows for a
     #  per-process override.
-    _executable_search_paths = (
-        StrListOption(
-            "--executable-search-paths",
-            default=["<PATH>"],
-            help=(
-                "The PATH value that will be used by the PEX subprocess and any subprocesses it "
-                'spawns.\n\nThe special string "<PATH>" will expand to the contents of the PATH '
-                "env var."
-            ),
-        )
-        .advanced()
-        .metavar("<binary-paths>")
+    _executable_search_paths = StrListOption(
+        "--executable-search-paths",
+        default=["<PATH>"],
+        help=(
+            "The PATH value that will be used by the PEX subprocess and any subprocesses it "
+            'spawns.\n\nThe special string "<PATH>" will expand to the contents of the PATH '
+            "env var."
+        ),
+        advanced=True,
+        metavar="<binary-paths>",
     )
     _verbosity = IntOption(
         "--verbosity",
         default=0,
         help=("Set the verbosity level of PEX logging, from 0 (no logging) up to 9 (max logging)."),
-    ).advanced()
+        advanced=True,
+    )
     venv_use_symlinks = BoolOption(
         "--venv-use-symlinks",
         default=False,
@@ -61,7 +60,8 @@ class PexRuntimeEnvironment(Subsystem):
             "distributions do not work with symlinked venvs though, so you may not be able to "
             "enable this optimization as a result."
         ),
-    ).advanced()
+        advanced=True,
+    )
 
     @memoized_method
     def path(self, env: Environment) -> tuple[str, ...]:

--- a/src/python/pants/backend/scala/subsystems/scalac.py
+++ b/src/python/pants/backend/scala/subsystems/scalac.py
@@ -23,20 +23,16 @@ class Scalac(Subsystem):
     args = ArgsListOption(
         help=f"Global `scalac` compiler flags, e.g. `--{options_scope}-args='-encoding UTF-8'`."
     )
-    plugins_global = (
-        StrListOption(
-            "--plugins-global",
-            help=(
-                "A list of addresses of `scalac_plugin` targets which should be used for "
-                "compilation of all Scala targets in a build.\n\nIf you set this, you must also "
-                "set `[scalac].plugins_global_lockfile`."
-            ),
-        )
-        .advanced()
-        .deprecated(
-            removal_version="2.12.0.dev0",
-            hint="Use `--scalac-plugins-for-resolve` instead to use user resolves",
-        )
+    plugins_global = StrListOption(
+        "--plugins-global",
+        help=(
+            "A list of addresses of `scalac_plugin` targets which should be used for "
+            "compilation of all Scala targets in a build.\n\nIf you set this, you must also "
+            "set `[scalac].plugins_global_lockfile`."
+        ),
+        advanced=True,
+        removal_version="2.12.0.dev0",
+        removal_hint="Use `--scalac-plugins-for-resolve` instead to use user resolves",
     )
 
     # TODO: see if we can use an actual list mechanism? If not, this seems like an OK option
@@ -50,21 +46,17 @@ class Scalac(Subsystem):
         ),
     )
 
-    plugins_global_lockfile = (
-        StrOption(
-            "--plugins-global-lockfile",
-            default=DEFAULT_TOOL_LOCKFILE,
-            help=(
-                "The filename of the lockfile for global plugins. You must set this option to a "
-                "file path, e.g. '3rdparty/jvm/global_scalac_plugins.lock', if you set "
-                "`[scalac].plugins_global`."
-            ),
-        )
-        .advanced()
-        .deprecated(
-            removal_version="2.12.0.dev0",
-            hint="Use `--scalac-plugins-for-resolve` instead, which will add plugin dependencies to JVM user resolves.",
-        )
+    plugins_global_lockfile = StrOption(
+        "--plugins-global-lockfile",
+        default=DEFAULT_TOOL_LOCKFILE,
+        help=(
+            "The filename of the lockfile for global plugins. You must set this option to a "
+            "file path, e.g. '3rdparty/jvm/global_scalac_plugins.lock', if you set "
+            "`[scalac].plugins_global`."
+        ),
+        advanced=True,
+        removal_version="2.12.0.dev0",
+        removal_hint="Use `--scalac-plugins-for-resolve` instead, which will add plugin dependencies to JVM user resolves.",
     )
 
     def parsed_default_plugins(self) -> dict[str, list[str]]:

--- a/src/python/pants/backend/shell/shell_setup.py
+++ b/src/python/pants/backend/shell/shell_setup.py
@@ -16,24 +16,23 @@ class ShellSetup(Subsystem):
     options_scope = "shell-setup"
     help = "Options for Pants's Shell support."
 
-    _executable_search_path = (
-        StrListOption(
-            "--executable-search-paths",
-            default=["<PATH>"],
-            help=(
-                "The PATH value that will be used to find shells and to run certain processes "
-                "like the shunit2 test runner.\n\n"
-                'The special string "<PATH>" will expand to the contents of the PATH env var.'
-            ),
-        )
-        .advanced()
-        .metavar("<binary-paths>")
+    _executable_search_path = StrListOption(
+        "--executable-search-paths",
+        default=["<PATH>"],
+        help=(
+            "The PATH value that will be used to find shells and to run certain processes "
+            "like the shunit2 test runner.\n\n"
+            'The special string "<PATH>" will expand to the contents of the PATH env var.'
+        ),
+        advanced=True,
+        metavar="<binary-paths>",
     )
     dependency_inference = BoolOption(
         "--dependency-inference",
         default=True,
         help="Infer Shell dependencies on other Shell files by analyzing `source` statements.",
-    ).advanced()
+        advanced=True,
+    )
 
     @memoized_method
     def executable_search_path(self, env: Environment) -> tuple[str, ...]:

--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -263,17 +263,20 @@ class TailorSubsystem(GoalSubsystem):
             "The name to use for generated BUILD files.\n\n"
             "This must be compatible with `[GLOBAL].build_patterns`."
         ),
-    ).advanced()
+        advanced=True,
+    )
     build_file_header = StrOption(
         "--build-file-header",
         default=None,
         help="A header, e.g., a copyright notice, to add to the content of created BUILD files.",
-    ).advanced()
+        advanced=True,
+    )
     build_file_indent = StrOption(
         "--build-file-indent",
         default="    ",
         help="The indent to use when auto-editing BUILD files.",
-    ).advanced()
+        advanced=True,
+    )
     _alias_mapping = DictOption[str](
         "--alias-mapping",
         help=(
@@ -281,7 +284,8 @@ class TailorSubsystem(GoalSubsystem):
             "type can be a custom target type or a macro that offers compatible functionality "
             f"to the one it replaces (see {doc_url('macros')})."
         ),
-    ).advanced()
+        advanced=True,
+    )
     ignore_paths = StrListOption(
         "--ignore-paths",
         help=(
@@ -292,7 +296,8 @@ class TailorSubsystem(GoalSubsystem):
             "_read_ BUILD files at certain paths. In contrast, this option only tells Pants to "
             "not edit/create BUILD files at the specified paths."
         ),
-    ).advanced()
+        advanced=True,
+    )
     _ignore_adding_targets = StrListOption(
         "--ignore-adding-targets",
         help=(
@@ -305,7 +310,8 @@ class TailorSubsystem(GoalSubsystem):
             "the path, e.g. `//:bin`.\n\n"
             "Does not work with macros."
         ),
-    ).advanced()
+        advanced=True,
+    )
 
     @property
     def ignore_adding_targets(self) -> set[str]:

--- a/src/python/pants/core/subsystems/python_bootstrap.py
+++ b/src/python/pants/core/subsystems/python_bootstrap.py
@@ -33,46 +33,42 @@ class PythonBootstrapSubsystem(Subsystem):
         "`python` subsystem for that."
     )
 
-    search_path = (
-        StrListOption(
-            "--search-path",
-            default=["<PYENV>", "<PATH>"],
-            help=(
-                "A list of paths to search for Python interpreters.\n\n"
-                "Which interpeters are actually used from these paths is context-specific: "
-                "the Python backend selects interpreters using options on the `python` subsystem, "
-                "in particular, the `[python].interpreter_constraints` option.\n\n"
-                "You can specify absolute paths to interpreter binaries "
-                "and/or to directories containing interpreter binaries. The order of entries does "
-                "not matter.\n\n"
-                "The following special strings are supported:\n\n"
-                "* `<PATH>`, the contents of the PATH env var\n"
-                "* `<ASDF>`, all Python versions currently configured by ASDF "
-                "`(asdf shell, ${HOME}/.tool-versions)`, with a fallback to all installed versions\n"
-                "* `<ASDF_LOCAL>`, the ASDF interpreter with the version in "
-                "BUILD_ROOT/.tool-versions\n"
-                "* `<PYENV>`, all Python versions under $(pyenv root)/versions\n"
-                "* `<PYENV_LOCAL>`, the Pyenv interpreter with the version in "
-                "BUILD_ROOT/.python-version\n"
-                "* `<PEXRC>`, paths in the PEX_PYTHON_PATH variable in /etc/pexrc or ~/.pexrc"
-            ),
-        )
-        .advanced()
-        .metavar("<binary-paths>")
+    search_path = StrListOption(
+        "--search-path",
+        default=["<PYENV>", "<PATH>"],
+        help=(
+            "A list of paths to search for Python interpreters.\n\n"
+            "Which interpeters are actually used from these paths is context-specific: "
+            "the Python backend selects interpreters using options on the `python` subsystem, "
+            "in particular, the `[python].interpreter_constraints` option.\n\n"
+            "You can specify absolute paths to interpreter binaries "
+            "and/or to directories containing interpreter binaries. The order of entries does "
+            "not matter.\n\n"
+            "The following special strings are supported:\n\n"
+            "* `<PATH>`, the contents of the PATH env var\n"
+            "* `<ASDF>`, all Python versions currently configured by ASDF "
+            "`(asdf shell, ${HOME}/.tool-versions)`, with a fallback to all installed versions\n"
+            "* `<ASDF_LOCAL>`, the ASDF interpreter with the version in "
+            "BUILD_ROOT/.tool-versions\n"
+            "* `<PYENV>`, all Python versions under $(pyenv root)/versions\n"
+            "* `<PYENV_LOCAL>`, the Pyenv interpreter with the version in "
+            "BUILD_ROOT/.python-version\n"
+            "* `<PEXRC>`, paths in the PEX_PYTHON_PATH variable in /etc/pexrc or ~/.pexrc"
+        ),
+        advanced=True,
+        metavar="<binary-paths>",
     )
-    names = (
-        StrListOption(
-            "--names",
-            default=["python", "python3"],
-            help=(
-                "The names of Python binaries to search for. See the `--search-path` option to "
-                "influence where interpreters are searched for.\n\n"
-                "This does not impact which Python interpreter is used to run your code, only what "
-                "is used to run internal tools."
-            ),
-        )
-        .advanced()
-        .metavar("<python-binary-names>")
+    names = StrListOption(
+        "--names",
+        default=["python", "python3"],
+        help=(
+            "The names of Python binaries to search for. See the `--search-path` option to "
+            "influence where interpreters are searched for.\n\n"
+            "This does not impact which Python interpreter is used to run your code, only what "
+            "is used to run internal tools."
+        ),
+        advanced=True,
+        metavar="<python-binary-names>",
     )
 
 

--- a/src/python/pants/core/util_rules/subprocess_environment.py
+++ b/src/python/pants/core/util_rules/subprocess_environment.py
@@ -26,7 +26,8 @@ class SubprocessEnvironment(Subsystem):
             "Entries are either strings in the form `ENV_VAR=value` to set an explicit value; "
             "or just `ENV_VAR` to copy the value from Pants's own environment."
         ),
-    ).advanced()
+        advanced=True,
+    )
 
     @property
     def env_vars_to_pass_to_subprocesses(self) -> Tuple[str, ...]:

--- a/src/python/pants/goal/anonymous_telemetry.py
+++ b/src/python/pants/goal/anonymous_telemetry.py
@@ -44,7 +44,8 @@ class AnonymousTelemetry(Subsystem):
             f"asynchronously, with silent failure, and does not impact build times or "
             f"outcomes.\n{_telemetry_docs_referral}."
         ),
-    ).advanced()
+        advanced=True,
+    )
     repo_id = StrOption(
         "--repo-id",
         default=None,
@@ -55,7 +56,8 @@ class AnonymousTelemetry(Subsystem):
             f"config file, so anonymity of the repo is not guaranteed (although user anonymity "
             f"is always guaranteed).\n{_telemetry_docs_referral}."
         ),
-    ).advanced()
+        advanced=True,
+    )
 
 
 class AnonymousTelemetryCallback(WorkunitsCallback):

--- a/src/python/pants/goal/stats_aggregator.py
+++ b/src/python/pants/goal/stats_aggregator.py
@@ -35,7 +35,8 @@ class StatsAggregatorSubsystem(Subsystem):
             "caching.\n\nFor histogram summaries to work, you must add `hdrhistogram` to "
             "`[GLOBAL].plugins`."
         ),
-    ).advanced()
+        advanced=True,
+    )
 
 
 class StatsAggregatorCallback(WorkunitsCallback):

--- a/src/python/pants/jvm/subsystems.py
+++ b/src/python/pants/jvm/subsystems.py
@@ -25,7 +25,8 @@ class JvmSubsystem(Subsystem):
             "The JDK to use when building and running Pants' internal JVM support code and other "
             "non-compiler tools. See `jvm` help for supported values."
         ),
-    ).advanced()
+        advanced=True,
+    )
     jdk = StrOption(
         "--jdk",
         default="adopt:1.11",
@@ -37,7 +38,8 @@ class JvmSubsystem(Subsystem):
             " instead, but note that this can lead to inconsistent behavior since the JVM version"
             " will be whatever happens to be found first on the system's PATH."
         ),
-    ).advanced()
+        advanced=True,
+    )
     resolves = DictOption(
         "--resolves",
         default={"jvm-default": "3rdparty/jvm/default.lock"},

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1358,11 +1358,13 @@ class GlobalOptions(Subsystem):
             "Include only targets with these tags (optional '+' prefix) or without these "
             f"tags ('-' prefix). See {doc_url('advanced-target-selection')}."
         ),
-    ).metavar("[+-]tag1,tag2,...")
+        metavar="[+-]tag1,tag2,...",
+    )
     exclude_target_regexp = StrListOption(
         "--exclude-target-regexp",
         help="Exclude targets that match these regexes. This does not impact file arguments.",
-    ).metavar("<regexp>")
+        metavar="<regexp>",
+    )
 
     files_not_found_behavior = EnumOption(
         "--files-not-found-behavior",
@@ -1370,7 +1372,8 @@ class GlobalOptions(Subsystem):
         help="What to do when files and globs specified in BUILD files, such as in the "
         "`sources` field, cannot be found. This happens when the files do not exist on "
         "your machine or when they are ignored by the `--pants-ignore` option.",
-    ).advanced()
+        advanced=True,
+    )
 
     owners_not_found_behavior = EnumOption(
         "--owners-not-found-behavior",
@@ -1379,7 +1382,8 @@ class GlobalOptions(Subsystem):
             "What to do when file arguments do not have any owning target. This happens when "
             "there are no targets whose `sources` fields include the file argument."
         ),
-    ).advanced()
+        advanced=True,
+    )
 
     build_patterns = StrListOption(
         "--build-patterns",
@@ -1391,7 +1395,8 @@ class GlobalOptions(Subsystem):
             "You may also need to update the option `[tailor].build_file_name` so that it is "
             "compatible with this option."
         ),
-    ).advanced()
+        advanced=True,
+    )
 
     build_ignore = StrListOption(
         "--build-ignore",
@@ -1401,19 +1406,22 @@ class GlobalOptions(Subsystem):
             "that instead.\n\n"
             "Patterns use the gitignore pattern syntax (https://git-scm.com/docs/gitignore)."
         ),
-    ).advanced()
+        advanced=True,
+    )
     build_file_prelude_globs = StrListOption(
         "--build-file-prelude-globs",
         help=(
             "Python files to evaluate and whose symbols should be exposed to all BUILD files. "
             f"See {doc_url('macros')}."
         ),
-    ).advanced()
+        advanced=True,
+    )
     subproject_roots = StrListOption(
         "--subproject-roots",
         help="Paths that correspond with build roots for any subproject that this "
         "project depends on.",
-    ).advanced()
+        advanced=True,
+    )
 
     _loop_flag = "--loop"
     loop = BoolOption(
@@ -1423,13 +1431,15 @@ class GlobalOptions(Subsystem):
         "--loop-max",
         default=2**32,
         help=f"The maximum number of times to loop when `{_loop_flag}` is specified.",
-    ).advanced()
+        advanced=True,
+    )
 
     streaming_workunits_report_interval = FloatOption(
         "--streaming-workunits-report-interval",
         default=1.0,
         help="Interval in seconds between when streaming workunit event receivers will be polled.",
-    ).advanced()
+        advanced=True,
+    )
     streaming_workunits_complete_async = BoolOption(
         "--streaming-workunits-complete-async",
         default=not is_in_container(),
@@ -1439,7 +1449,8 @@ class GlobalOptions(Subsystem):
             "To reduce data loss, this flag defaults to false inside of containers, such as "
             "when run with Docker."
         ),
-    ).advanced()
+        advanced=True,
+    )
 
     @classmethod
     def validate_instance(cls, opts):

--- a/src/python/pants/option/option_types.py
+++ b/src/python/pants/option/option_types.py
@@ -62,12 +62,36 @@ class _OptionBase(Generic[_OptT, _DefaultT]):
         *flag_names: str,
         default: _DefaultT,
         help: _HelpT,
+        # Additional bells/whistles
+        advanced: bool | None = None,
+        daemon: bool | None = None,
+        default_help_repr: str | None = None,
+        fingerprint: bool | None = None,
+        fromfile: bool | None = None,
+        metavar: str | None = None,
+        mutually_exclusive_group: str | None = None,
+        removal_hint: str | None = None,
+        removal_version: str | None = None,
     ):
         self = super().__new__(cls)
         self._flag_names = flag_names
         self._default = default
         self._help = help
-        self._extra_kwargs = {}
+        self._extra_kwargs = {
+            k: v
+            for k, v in {
+                "advanced": advanced,
+                "daemon": daemon,
+                "default_help_repr": default_help_repr,
+                "fingerprint": fingerprint,
+                "fromfile": fromfile,
+                "metavar": metavar,
+                "mutually_exclusive_group": mutually_exclusive_group,
+                "removal_hint": removal_hint,
+                "removal_version": removal_version,
+            }.items()
+            if v is not None
+        }
         return self
 
     # Subclasses can override if necessary
@@ -103,41 +127,6 @@ class _OptionBase(Generic[_OptT, _DefaultT]):
             return None
         return self._convert_(option_value)
 
-    def advanced(self) -> _OptionBase[_OptT, _DefaultT]:
-        self._extra_kwargs["advanced"] = True
-        return self
-
-    def from_file(self) -> _OptionBase[_OptT, _DefaultT]:
-        self._extra_kwargs["fromfile"] = True
-        return self
-
-    def metavar(self, metavar: str) -> _OptionBase[_OptT, _DefaultT]:
-        self._extra_kwargs["metavar"] = metavar
-        return self
-
-    def mutually_exclusive_group(
-        self, mutually_exclusive_group: str
-    ) -> _OptionBase[_OptT, _DefaultT]:
-        self._extra_kwargs["mutually_exclusive_group"] = mutually_exclusive_group
-        return self
-
-    def default_help_repr(self, default_help_repr: str) -> _OptionBase[_OptT, _DefaultT]:
-        self._extra_kwargs["default_help_repr"] = default_help_repr
-        return self
-
-    def deprecated(self, *, removal_version: str, hint: str) -> _OptionBase[_OptT, _DefaultT]:
-        self._extra_kwargs["removal_version"] = removal_version
-        self._extra_kwargs["removal_hint"] = hint
-        return self
-
-    def daemoned(self) -> _OptionBase[_OptT, _DefaultT]:
-        self._extra_kwargs["daemon"] = True
-        return self
-
-    def non_fingerprinted(self) -> _OptionBase[_OptT, _DefaultT]:
-        self._extra_kwargs["fingerprint"] = False
-        return self
-
 
 # The type of the list members.
 # NB: We don't provide constraints, as our `XListOption` types act like a set of contraints
@@ -163,6 +152,16 @@ class _ListOptionBase(
         *flag_names: str,
         default: list[_ListMemberT] = [],
         help: _HelpT,
+        # Additional bells/whistles
+        advanced: bool | None = None,
+        daemon: bool | None = None,
+        default_help_repr: str | None = None,
+        fingerprint: bool | None = None,
+        fromfile: bool | None = None,
+        metavar: str | None = None,
+        mutually_exclusive_group: str | None = None,
+        removal_hint: str | None = None,
+        removal_version: str | None = None,
     ):
         default = default or []
         instance = super().__new__(
@@ -170,6 +169,15 @@ class _ListOptionBase(
             *flag_names,
             default=default,  # type: ignore[arg-type]
             help=help,
+            advanced=advanced,
+            daemon=daemon,
+            default_help_repr=default_help_repr,
+            fingerprint=fingerprint,
+            fromfile=fromfile,
+            metavar=metavar,
+            mutually_exclusive_group=mutually_exclusive_group,
+            removal_hint=removal_hint,
+            removal_version=removal_version,
         )
         return instance
 
@@ -349,8 +357,23 @@ class EnumOption(_OptionBase[_OptT, _DefaultT]):
         EnumOption(..., enum_type=MyEnum, default=None)
     """
 
-    @overload  # Case: static default
-    def __new__(cls, *flag_names: str, default: _EnumT, help: _HelpT) -> EnumOption[_EnumT, _EnumT]:
+    @overload
+    def __new__(
+        cls,
+        *flag_names: str,
+        default: _EnumT,
+        help: _HelpT,
+        # Additional bells/whistles
+        advanced: bool | None = None,
+        daemon: bool | None = None,
+        default_help_repr: str | None = None,
+        fingerprint: bool | None = None,
+        fromfile: bool | None = None,
+        metavar: str | None = None,
+        mutually_exclusive_group: str | None = None,
+        removal_hint: str | None = None,
+        removal_version: str | None = None,
+    ) -> EnumOption[_EnumT, _EnumT]:
         ...
 
     # N.B. This has an additional param: `enum_type`.
@@ -363,13 +386,37 @@ class EnumOption(_OptionBase[_OptT, _DefaultT]):
         # mypy won't be able to have enough info to deduce the correct type.
         default: _DynamicDefaultT[Any],
         help: _HelpT,
+        # Additional bells/whistles
+        advanced: bool | None = None,
+        daemon: bool | None = None,
+        default_help_repr: str | None = None,
+        fingerprint: bool | None = None,
+        fromfile: bool | None = None,
+        metavar: str | None = None,
+        mutually_exclusive_group: str | None = None,
+        removal_hint: str | None = None,
+        removal_version: str | None = None,
     ) -> EnumOption[_EnumT, _EnumT]:
         ...
 
     # N.B. This has an additional param: `enum_type`.
     @overload  # Case: default is `None`
     def __new__(
-        cls, *flag_names: str, enum_type: type[_EnumT], default: None, help: _HelpT
+        cls,
+        *flag_names: str,
+        enum_type: type[_EnumT],
+        default: None,
+        help: _HelpT,
+        # Additional bells/whistles
+        advanced: bool | None = None,
+        daemon: bool | None = None,
+        default_help_repr: str | None = None,
+        fingerprint: bool | None = None,
+        fromfile: bool | None = None,
+        metavar: str | None = None,
+        mutually_exclusive_group: str | None = None,
+        removal_hint: str | None = None,
+        removal_version: str | None = None,
     ) -> EnumOption[_EnumT, None]:
         ...
 
@@ -379,8 +426,32 @@ class EnumOption(_OptionBase[_OptT, _DefaultT]):
         enum_type=None,
         default,
         help,
+        # Additional bells/whistles
+        advanced=None,
+        daemon=None,
+        default_help_repr=None,
+        fingerprint=None,
+        fromfile=None,
+        metavar=None,
+        mutually_exclusive_group=None,
+        removal_hint=None,
+        removal_version=None,
     ):
-        instance = super().__new__(cls, *flag_names, default=default, help=help)
+        instance = super().__new__(
+            cls,
+            *flag_names,
+            default=default,
+            help=help,
+            advanced=advanced,
+            daemon=daemon,
+            default_help_repr=default_help_repr,
+            fingerprint=fingerprint,
+            fromfile=fromfile,
+            metavar=metavar,
+            mutually_exclusive_group=mutually_exclusive_group,
+            removal_hint=removal_hint,
+            removal_version=removal_version,
+        )
         instance._enum_type = enum_type
         return instance
 
@@ -415,7 +486,20 @@ class EnumListOption(_ListOptionBase[_OptT], Generic[_OptT]):
 
     @overload  # Case: static default
     def __new__(
-        cls, *flag_names: str, default: list[_EnumT], help: _HelpT
+        cls,
+        *flag_names: str,
+        default: list[_EnumT],
+        help: _HelpT,
+        # Additional bells/whistles
+        advanced: bool | None = ...,
+        daemon: bool | None = ...,
+        default_help_repr: str | None = ...,
+        fingerprint: bool | None = ...,
+        fromfile: bool | None = ...,
+        metavar: str | None = ...,
+        mutually_exclusive_group: str | None = ...,
+        removal_hint: str | None = ...,
+        removal_version: str | None = ...,
     ) -> EnumListOption[_EnumT]:
         ...
 
@@ -429,13 +513,36 @@ class EnumListOption(_ListOptionBase[_OptT], Generic[_OptT]):
         # because mypy won't be able to have enough info to deduce the correct type.
         default: _DynamicDefaultT[Any],
         help: _HelpT,
+        # Additional bells/whistles
+        advanced: bool | None = ...,
+        daemon: bool | None = ...,
+        default_help_repr: str | None = ...,
+        fingerprint: bool | None = ...,
+        fromfile: bool | None = ...,
+        metavar: str | None = ...,
+        mutually_exclusive_group: str | None = ...,
+        removal_hint: str | None = ...,
+        removal_version: str | None = ...,
     ) -> EnumListOption[_EnumT]:
         ...
 
     # N.B. This has an additional param: `enum_type`.
     @overload  # Case: implicit default
     def __new__(
-        cls, *flag_names: str, enum_type: type[_EnumT], help: _HelpT
+        cls,
+        *flag_names: str,
+        enum_type: type[_EnumT],
+        help: _HelpT,
+        # Additional bells/whistles
+        advanced: bool | None = ...,
+        daemon: bool | None = ...,
+        default_help_repr: str | None = ...,
+        fingerprint: bool | None = ...,
+        fromfile: bool | None = ...,
+        metavar: str | None = ...,
+        mutually_exclusive_group: str | None = ...,
+        removal_hint: str | None = ...,
+        removal_version: str | None = ...,
     ) -> EnumListOption[_EnumT]:
         ...
 
@@ -445,8 +552,32 @@ class EnumListOption(_ListOptionBase[_OptT], Generic[_OptT]):
         enum_type=None,
         default=[],
         help,
+        # Additional bells/whistles
+        advanced=None,
+        daemon=None,
+        default_help_repr=None,
+        fingerprint=None,
+        fromfile=None,
+        metavar=None,
+        mutually_exclusive_group=None,
+        removal_hint=None,
+        removal_version=None,
     ):
-        instance = super().__new__(cls, *flag_names, default=default, help=help)
+        instance = super().__new__(
+            cls,
+            *flag_names,
+            default=default,
+            help=help,
+            advanced=advanced,
+            daemon=daemon,
+            default_help_repr=default_help_repr,
+            fingerprint=fingerprint,
+            fromfile=fromfile,
+            metavar=metavar,
+            mutually_exclusive_group=mutually_exclusive_group,
+            removal_hint=removal_hint,
+            removal_version=removal_version,
+        )
         instance._enum_type = enum_type
         return instance
 
@@ -493,12 +624,35 @@ class DictOption(_OptionBase["dict[str, _ValueT]", "dict[str, _ValueT]"], Generi
 
     option_type: Any = dict
 
-    def __new__(cls, *flag_names, default: dict[str, _ValueT] = {}, help):
+    def __new__(
+        cls,
+        *flag_names,
+        default: dict[str, _ValueT] = {},
+        help,
+        advanced: bool | None = None,
+        daemon: bool | None = None,
+        default_help_repr: str | None = None,
+        fingerprint: bool | None = None,
+        fromfile: bool | None = None,
+        metavar: str | None = None,
+        mutually_exclusive_group: str | None = None,
+        removal_hint: str | None = None,
+        removal_version: str | None = None,
+    ):
         return super().__new__(
             cls,  # type: ignore[arg-type]
             *flag_names,
             default=default,  # type: ignore[arg-type]
             help=help,
+            advanced=advanced,
+            daemon=daemon,
+            default_help_repr=default_help_repr,
+            fingerprint=fingerprint,
+            fromfile=fromfile,
+            metavar=metavar,
+            mutually_exclusive_group=mutually_exclusive_group,
+            removal_hint=removal_hint,
+            removal_version=removal_version,
         )
 
     def _convert_(self, val: Any) -> dict[str, _ValueT]:

--- a/src/python/pants/option/option_types_test.py
+++ b/src/python/pants/option/option_types_test.py
@@ -177,21 +177,24 @@ def test_other_options() -> None:
     assert my_subsystem.args_prop == ("--arg1",)
 
 
-def test_builder_methods():
+def test_advanced_params():
     class MySubsystem(Subsystem):
         def __init__(self):
             self.options = SimpleNamespace()
 
-        prop = (
-            StrOption("--opt", default=None, help="")
-            .advanced()
-            .metavar("META")
-            .from_file()
-            .mutually_exclusive_group("group")
-            .default_help_repr("Help!")
-            .deprecated(removal_version="99.9.9", hint="it's purple")
-            .daemoned()
-            .non_fingerprinted()
+        prop = StrOption(
+            "--opt",
+            default=None,
+            help="",
+            advanced=True,
+            daemon=True,
+            default_help_repr="Help!",
+            fingerprint=False,
+            fromfile=True,
+            metavar="META",
+            mutually_exclusive_group="group",
+            removal_hint="it's purple",
+            removal_version="99.9.9",
         )
 
     flag_options = MySubsystem.prop.flag_options

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -106,32 +106,28 @@ class SourceRootConfig(Subsystem):
         "src/java",
     ]
 
-    root_patterns = (
-        StrListOption(
-            "--root-patterns",
-            default=DEFAULT_ROOT_PATTERNS,
-            help="A list of source root suffixes. A directory with this suffix will be considered "
-            "a potential source root. E.g., `src/python` will match `<buildroot>/src/python`, "
-            "`<buildroot>/project1/src/python` etc. Prepend a `/` to anchor the match at the "
-            "buildroot. E.g., `/src/python` will match `<buildroot>/src/python` but not "
-            "`<buildroot>/project1/src/python`. A `*` wildcard will match a single path segment, "
-            "e.g., `src/*` will match `<buildroot>/src/python` and `<buildroot>/src/rust`. "
-            "Use `/` to signify that the buildroot itself is a source root. "
-            f"See {doc_url('source-roots')}.",
-        )
-        .advanced()
-        .metavar('["pattern1", "pattern2", ...]')
+    root_patterns = StrListOption(
+        "--root-patterns",
+        default=DEFAULT_ROOT_PATTERNS,
+        help="A list of source root suffixes. A directory with this suffix will be considered "
+        "a potential source root. E.g., `src/python` will match `<buildroot>/src/python`, "
+        "`<buildroot>/project1/src/python` etc. Prepend a `/` to anchor the match at the "
+        "buildroot. E.g., `/src/python` will match `<buildroot>/src/python` but not "
+        "`<buildroot>/project1/src/python`. A `*` wildcard will match a single path segment, "
+        "e.g., `src/*` will match `<buildroot>/src/python` and `<buildroot>/src/rust`. "
+        "Use `/` to signify that the buildroot itself is a source root. "
+        f"See {doc_url('source-roots')}.",
+        advanced=True,
+        metavar='["pattern1", "pattern2", ...]',
     )
-    marker_filenames = (
-        StrListOption(
-            "--marker-filenames",
-            help="The presence of a file of this name in a directory indicates that the directory "
-            "is a source root. The content of the file doesn't matter, and may be empty. "
-            "Useful when you can't or don't wish to centrally enumerate source roots via "
-            "`root_patterns`.",
-        )
-        .advanced()
-        .metavar("filename")
+    marker_filenames = StrListOption(
+        "--marker-filenames",
+        help="The presence of a file of this name in a directory indicates that the directory "
+        "is a source root. The content of the file doesn't matter, and may be empty. "
+        "Useful when you can't or don't wish to centrally enumerate source roots via "
+        "`root_patterns`.",
+        advanced=True,
+        metavar="filename",
     )
 
     @memoized_method


### PR DESCRIPTION
This is much nicer, and now that there's only a handful of `__new__`s it's not as painful.

This also allows us to customize params in the future (E.g. maybe certain option types do/dont support a param?)

NOTE: Commits are useful to review.

[ci skip-rust]
[ci skip-build-wheels]