### PR TITLE
[internal] Fix namespace package

### DIFF
--- a/build-support/githooks/prepare-commit-msg
+++ b/build-support/githooks/prepare-commit-msg
@@ -25,6 +25,7 @@ NUM_RUST_FILES=$(echo "${CHANGED_FILES})" | grep -c -E \
 
 NUM_RELEASE_FILES=$(echo "${CHANGED_FILES})" | grep -c -E \
   -e "^pants.toml" \
+  -e "^src/python/pants/__init__" \
   -e "^src/python/pants/VERSION" \
   -e "^src/python/pants/notes" \
   -e "^src/python/pants/init/BUILD" \

--- a/src/python/pants/conftest.py
+++ b/src/python/pants/conftest.py
@@ -30,6 +30,11 @@ namespace_init_path = Path("src/python/pants/__init__.py")
 
 
 def pytest_sessionstart(session) -> None:
+    if namespace_init_path.exists():
+        raise Exception(
+            f"In order for `pants` to be a namespace package, {namespace_init_path} must not "
+            f"exist on disk. See the explanation in {__file__}."
+        )
     namespace_init_path.touch()
 
 


### PR DESCRIPTION
Fixes https://github.com/pantsbuild/pants/commit/10f631b0f98217e829954889e0e3952cc4b8918f adding an `__init__.py` file that breaks namespace packages.

Also make sure that CI runs if this file gets added again.

[ci skip-rust]