### PR TITLE
Export a pip-ified copy of the requirements venv.

### DIFF
--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -128,9 +128,7 @@ async def export_virtualenv(
                 ],
                 {"PEX_MODULE": "pex.tools"},
             ),
-            # Don't fail in the unlikely case that we don't have `rm` on the PATH.
-            # It's better to leave a stray pex.pex in dist/ than to error the entire export.
-            PostProcessingCommand(["rm", "-f", pex_pex_path, "||", "true"]),
+            PostProcessingCommand(["rm", "-f", pex_pex_path]),
         ],
     )
 

--- a/src/python/pants/backend/python/goals/export_integration_test.py
+++ b/src/python/pants/backend/python/goals/export_integration_test.py
@@ -85,8 +85,6 @@ def test_export_venvs(rule_runner: RuleRunner) -> None:
                 "rm",
                 "-f",
                 os.path.join("{digest_root}", ".", "pex"),
-                "||",
-                "true",
             )
             assert ppc1.extra_env == FrozenDict()
 

--- a/src/python/pants/backend/python/goals/export_integration_test.py
+++ b/src/python/pants/backend/python/goals/export_integration_test.py
@@ -1,5 +1,6 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+import os
 import sys
 from textwrap import dedent
 
@@ -16,6 +17,7 @@ from pants.core.util_rules import distdir
 from pants.engine.rules import QueryRule
 from pants.engine.target import Targets
 from pants.testutil.rule_runner import RuleRunner
+from pants.util.frozendict import FrozenDict
 
 
 @pytest.fixture
@@ -64,10 +66,29 @@ def test_export_venvs(rule_runner: RuleRunner) -> None:
         all_results = rule_runner.request(ExportResults, [ExportVenvsRequest(targets)])
 
         for result in all_results:
-            assert len(result.symlinks) == 1
-            symlink = result.symlinks[0]
-            assert symlink.link_rel_path == current_interpreter
-            assert "named_caches/pex_root/venvs/" in symlink.source_path
+            assert len(result.post_processing_cmds) == 2
+
+            ppc0 = result.post_processing_cmds[0]
+            assert ppc0.argv == (
+                os.path.join("{digest_root}", ".", "pex"),
+                os.path.join("{digest_root}", "requirements.pex"),
+                "venv",
+                "--pip",
+                "--collisions-ok",
+                "--remove=all",
+                f"{{digest_root}}/{current_interpreter}",
+            )
+            assert ppc0.extra_env == FrozenDict({"PEX_MODULE": "pex.tools"})
+
+            ppc1 = result.post_processing_cmds[1]
+            assert ppc1.argv == (
+                "rm",
+                "-f",
+                os.path.join("{digest_root}", ".", "pex"),
+                "||",
+                "true",
+            )
+            assert ppc1.extra_env == FrozenDict()
 
         return all_results
 

--- a/src/python/pants/core/goals/export.py
+++ b/src/python/pants/core/goals/export.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import subprocess
 from dataclasses import dataclass
 from typing import Iterable, cast
 
@@ -11,6 +12,7 @@ from pants.base.build_root import BuildRoot
 from pants.core.util_rules.distdir import DistDir
 from pants.engine.collection import Collection
 from pants.engine.console import Console
+from pants.engine.environment import Environment, EnvironmentRequest
 from pants.engine.fs import EMPTY_DIGEST, AddPrefix, Digest, MergeDigests, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.internals.selectors import Get, MultiGet
@@ -60,7 +62,15 @@ class ExportResult:
     digest: Digest
     # Create these symlinks. Symlinks are created after the digest is materialized,
     # so may reference files/dirs in the digest.
+    # TODO: Remove this functionality entirely? We introduced symlinks as a too-clever way of
+    #  linking from distdir into named caches. However that is risky, so we don't currently use it.
     symlinks: tuple[Symlink, ...]
+    # Run these shell commands as local processes after the digest is materialized.
+    # Note that each string element is an entire command to be parsed and interpreted by the shell.
+    # Each command will be run with the following environment:
+    #  PATH: The pants process's original PATH.
+    #  DIGEST_ROOT: The location under the distdir in which the digest is materialized.
+    post_processing_shell_cmds: tuple[str, ...]
 
     def __init__(
         self,
@@ -69,11 +79,13 @@ class ExportResult:
         *,
         digest: Digest = EMPTY_DIGEST,
         symlinks: Iterable[Symlink] = tuple(),
+        post_processing_shell_cmds: Iterable[str] = tuple(),
     ):
         self.description = description
         self.reldir = reldir
         self.digest = digest
         self.symlinks = tuple(symlinks)
+        self.post_processing_shell_cmds = tuple(post_processing_shell_cmds)
 
 
 class ExportResults(Collection[ExportResult]):
@@ -110,6 +122,7 @@ async def export(
     merged_digest = await Get(Digest, MergeDigests(prefixed_digests))
     dist_digest = await Get(Digest, AddPrefix(merged_digest, output_dir))
     workspace.write_digest(dist_digest)
+    environment = await Get(Environment, EnvironmentRequest(["PATH"]))
     for result in flattened_results:
         for symlink in result.symlinks:
             # Note that if symlink.source_path is an abspath, join returns it unchanged.
@@ -118,6 +131,24 @@ async def export(
                 os.path.join(output_dir, result.reldir, symlink.link_rel_path)
             )
             absolute_symlink(source_abspath, link_abspath)
+        for cmd in result.post_processing_shell_cmds:
+            # These are side-effecting, non-cacheable, and local-only, so we don't use Process.
+            try:
+                subprocess.check_output(
+                    cmd,
+                    stderr=subprocess.STDOUT,
+                    shell=True,
+                    env={
+                        "PATH": environment.get("PATH", ""),
+                        "DIGEST_ROOT": os.path.join(build_root.path, output_dir, result.reldir),
+                    },
+                )
+            except subprocess.CalledProcessError as e:
+                raise ExportError(
+                    f"Post-processing command `{cmd}` failed with exit code "
+                    f"{e.returncode}: {e.output}"
+                )
+
         console.print_stdout(
             f"Wrote {result.description} to {os.path.join(output_dir, result.reldir)}"
         )


### PR DESCRIPTION
Previously we symlinked directly into the named cache,
which was iffy for multiple reasons, including incorrect
interaction with remote execution, possible corruption
of the cache via that symlink, and the immutability of
the venv (due to lack of pip) being inconvenient to users.

Now we create a venv from scratch in the distdir, and
endow it with pip, so users can use it like a regular venv.

[ci skip-rust]

[ci skip-build-wheels]