### PR TITLE
Add `run` support to `pyoxidizer_binary`

### DIFF
--- a/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
@@ -22,6 +22,7 @@ from pants.backend.python.packaging.pyoxidizer.target_types import (
 from pants.backend.python.target_types import GenerateSetupField, WheelField
 from pants.backend.python.util_rules.pex import Pex, PexProcess, PexRequest
 from pants.core.goals.package import BuiltPackage, BuiltPackageArtifact, PackageFieldSet
+from pants.core.goals.run import RunFieldSet, RunRequest
 from pants.core.util_rules.system_binaries import BashBinary
 from pants.engine.fs import (
     AddPrefix,
@@ -185,8 +186,17 @@ async def package_pyoxidizer_binary(
     )
 
 
+@rule
+async def run_pyoxidizer_binary(field_set: PyOxidizerFieldSet) -> RunRequest:
+    binary = await Get(BuiltPackage, PackageFieldSet, field_set)
+    artifact_relpath = binary.artifacts[0].relpath
+    assert artifact_relpath is not None
+    return RunRequest(digest=binary.digest, args=(os.path.join("{chroot}", artifact_relpath),))
+
+
 def rules():
     return (
         *collect_rules(),
         UnionRule(PackageFieldSet, PyOxidizerFieldSet),
+        UnionRule(RunFieldSet, PyOxidizerFieldSet),
     )

--- a/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
@@ -190,10 +190,10 @@ async def package_pyoxidizer_binary(
 @rule
 async def run_pyoxidizer_binary(field_set: PyOxidizerFieldSet) -> RunRequest:
     def is_executable_binary(target_name: str, artifact_relpath: str | None) -> bool:
-        """
-        After packaging, the PyOxidizer plugin will place the executable in a location like this:
+        """After packaging, the PyOxidizer plugin will place the executable in a location like this:
         dist/{project}/{target name}/{platform arch}/{compilation mode}/install/{target name}
-        e.g. dist/helloworld/helloworld-bin/x86_64-apple-darwin/debug/install/helloworld-bin
+
+        e.g. dist/helloworld/helloworld-bin/x86_64-apple-darwin/debug/install/helloworld-bin.
 
         PyOxidizer will place associated libraries in {...}/install/lib
 
@@ -204,9 +204,7 @@ async def run_pyoxidizer_binary(field_set: PyOxidizerFieldSet) -> RunRequest:
             return False
 
         artifact_path = Path(artifact_relpath)
-        return (
-            artifact_path.name == target_name and artifact_path.parent.name == "install"
-        )
+        return artifact_path.name == target_name and artifact_path.parent.name == "install"
 
     binary = await Get(BuiltPackage, PackageFieldSet, field_set)
     artifact = next(
@@ -215,9 +213,7 @@ async def run_pyoxidizer_binary(field_set: PyOxidizerFieldSet) -> RunRequest:
         if is_executable_binary(field_set.address.target_name, artifact.relpath)
     )
     assert artifact.relpath is not None
-    return RunRequest(
-        digest=binary.digest, args=(os.path.join("{chroot}", artifact.relpath),)
-    )
+    return RunRequest(digest=binary.digest, args=(os.path.join("{chroot}", artifact.relpath),))
 
 
 def rules():

--- a/src/python/pants/backend/python/packaging/pyoxidizer/rules_integration_test.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/rules_integration_test.py
@@ -13,6 +13,7 @@ def test_end_to_end() -> None:
 
     * Third-party dependencies can be used.
     * A `python_distribution` (implicitly) depending on another `python_distribution`.
+    * `package` vs `run`
     """
     sources = {
         "hellotest/utils/greeter.py": "GREET = 'Hello world!'",
@@ -73,7 +74,7 @@ def test_end_to_end() -> None:
         assert bin_result.returncode == 42
         assert bin_result.stdout == b"Hello world!\n"
 
-        # Performing `./pants run` check immediately after `./pants package`, in order to re-use package results and save time
+        # Check that the binary runs.
         run_args = [
             "--backend-packages=['pants.backend.python', 'pants.backend.experimental.python.packaging.pyoxidizer']",
             f"--source-root-patterns=['/{tmpdir}']",


### PR DESCRIPTION
[ci skip-rust]

This PR adds support for the `run` goal allowing something like: `./pants run helloworld:helloworld-bin` (which packages and then immediately executes the resulting binary).

A new `run` test was added, but given the time it takes to package a PyOxidizer binary, it might make more sense to merge this with the `test_end_to_end` and re-use the same binary file. or even drop the explicit `package` step from the test and use `run` directly. Draft/WIP status is pending this question.

(Closes issue #14579)  