### PR TITLE
Move `--memory-summary` to `--stats-memory-summary`

### DIFF
--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -6,10 +6,9 @@ remote_cache_write = true
 # We want to continue to get logs when remote caching errors.
 remote_cache_warnings = "backoff"
 
-memory_summary = true
-
 [stats]
 log = true
+memory_summary = true
 
 [test]
 use_coverage = true

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import logging
 import sys
-from collections import Counter
 from dataclasses import dataclass
 
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE, ExitCode
@@ -32,7 +31,6 @@ from pants.init.specs_calculator import calculate_specs
 from pants.option.global_options import DynamicRemoteOptions, DynamicUIRenderer
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
-from pants.util.collections import deep_getsizeof
 from pants.util.contextutil import maybe_profiled
 from pants.util.logging import LogLevel
 
@@ -208,32 +206,6 @@ class LocalPantsRunner:
     def _finish_run(self, code: ExitCode) -> None:
         """Cleans up the run tracker."""
 
-    def _maybe_report_memory_summary(self) -> None:
-        global_options = self.options.for_global_scope()
-        if not global_options.memory_summary:
-            return
-
-        ids: set[int] = set()
-        count_by_type: Counter[type] = Counter()
-        sizes_by_type: Counter[type] = Counter()
-
-        items, rust_sizes = self.graph_session.scheduler_session.live_items()
-        for item in items:
-            count_by_type[type(item)] += 1
-            sizes_by_type[type(item)] += deep_getsizeof(item, ids)
-
-        entries = [
-            (size, count_by_type[typ], f"{typ.__module__}.{typ.__qualname__}")
-            for typ, size in sizes_by_type.items()
-        ]
-        entries.extend(
-            (size, count, f"(native) {name}") for name, (count, size) in rust_sizes.items()
-        )
-
-        print("Memory summary:", file=sys.stderr)
-        for size, count, name in sorted(entries):
-            print(f"{size}\t\t{count}\t\t{name}", file=sys.stderr)
-
     def _get_workunits_callbacks(self) -> tuple[WorkunitsCallback, ...]:
         # Load WorkunitsCallbacks by requesting WorkunitsCallbackFactories, and then constructing
         # a per-run instance of each WorkunitsCallback.
@@ -297,7 +269,6 @@ class LocalPantsRunner:
                 try:
                     engine_result = self._run_inner()
                 finally:
-                    self._maybe_report_memory_summary()
                     metrics = self.graph_session.scheduler_session.metrics()
                     self.run_tracker.set_pantsd_scheduler_metrics(metrics)
                     self.run_tracker.end_run(engine_result)

--- a/src/python/pants/goal/stats_aggregator.py
+++ b/src/python/pants/goal/stats_aggregator.py
@@ -18,6 +18,7 @@ from pants.engine.streaming_workunit_handler import (
 from pants.engine.unions import UnionRule
 from pants.option.option_types import BoolOption
 from pants.option.subsystem import Subsystem
+from pants.util.collections import deep_getsizeof
 
 logger = logging.getLogger(__name__)
 
@@ -32,18 +33,30 @@ class StatsAggregatorSubsystem(Subsystem):
         help=(
             "At the end of the Pants run, log all counter metrics and summaries of "
             "observation histograms, e.g. the number of cache hits and the time saved by "
-            "caching.\n\nFor histogram summaries to work, you must add `hdrhistogram` to "
-            "`[GLOBAL].plugins`."
+            "caching.\n\n"
+            "For histogram summaries to work, you must add `hdrhistogram` to `[GLOBAL].plugins`."
+        ),
+        advanced=True,
+    )
+    memory_summary = BoolOption(
+        "--memory-summary",
+        default=False,
+        help=(
+            "At the end of the Pants run, report a summary of memory usage.\n\n"
+            "Keys are the total size in bytes, the count, and the name. Note that the total size "
+            "is for all instances added together, so you can use total_size // count to get the "
+            "average size."
         ),
         advanced=True,
     )
 
 
 class StatsAggregatorCallback(WorkunitsCallback):
-    def __init__(self, *, has_histogram_module: bool) -> None:
+    def __init__(self, *, log: bool, memory: bool, has_histogram_module: bool) -> None:
         super().__init__()
+        self.log = log
+        self.memory = memory
         self.has_histogram_module = has_histogram_module
-        self.counters: Counter = Counter()
 
     @property
     def can_finish_async(self) -> bool:
@@ -61,21 +74,44 @@ class StatsAggregatorCallback(WorkunitsCallback):
         if not finished:
             return
 
-        # Capture global counters.
-        self.counters = Counter(context.get_metrics())
+        if self.log:
+            # Capture global counters.
+            counters = Counter(context.get_metrics())
 
-        # Add any counters with a count of 0.
-        for counter in context.run_tracker.counter_names:
-            if counter not in self.counters:
-                self.counters[counter] = 0
+            # Add any counters with a count of 0.
+            for counter in context.run_tracker.counter_names:
+                if counter not in counters:
+                    counters[counter] = 0
 
-        # Log aggregated counters.
-        counter_lines = "\n".join(
-            f"  {name}: {count}" for name, count in sorted(self.counters.items())
-        )
-        logger.info(f"Counters:\n{counter_lines}")
+            # Log aggregated counters.
+            counter_lines = "\n".join(
+                f"  {name}: {count}" for name, count in sorted(counters.items())
+            )
+            logger.info(f"Counters:\n{counter_lines}")
 
-        if not self.has_histogram_module:
+        if self.memory:
+            ids: set[int] = set()
+            count_by_type: Counter[type] = Counter()
+            sizes_by_type: Counter[type] = Counter()
+
+            items, rust_sizes = context._scheduler.live_items()
+            for item in items:
+                count_by_type[type(item)] += 1
+                sizes_by_type[type(item)] += deep_getsizeof(item, ids)
+
+            entries = [
+                (size, count_by_type[typ], f"{typ.__module__}.{typ.__qualname__}")
+                for typ, size in sizes_by_type.items()
+            ]
+            entries.extend(
+                (size, count, f"(native) {name}") for name, (count, size) in rust_sizes.items()
+            )
+            memory_lines = "\n".join(
+                f"  {size}\t\t{count}\t\t{name}" for size, count, name in sorted(entries)
+            )
+            logger.info(f"Memory summary (total size in bytes, count, name):\n{memory_lines}")
+
+        if not (self.log and self.has_histogram_module):
             return
         from hdrh.histogram import HdrHistogram
 
@@ -115,9 +151,8 @@ class StatsAggregatorCallbackFactoryRequest:
 def construct_callback(
     _: StatsAggregatorCallbackFactoryRequest, subsystem: StatsAggregatorSubsystem
 ) -> WorkunitsCallbackFactory:
-    enabled = subsystem.log
     has_histogram_module = False
-    if enabled:
+    if subsystem.log:
         try:
             import hdrh.histogram  # noqa: F401
         except ImportError:
@@ -131,9 +166,15 @@ def construct_callback(
             has_histogram_module = True
 
     return WorkunitsCallbackFactory(
-        lambda: StatsAggregatorCallback(has_histogram_module=has_histogram_module)
-        if enabled
-        else None
+        lambda: (
+            StatsAggregatorCallback(
+                log=subsystem.log,
+                memory=subsystem.memory_summary,
+                has_histogram_module=has_histogram_module,
+            )
+            if subsystem.log or subsystem.memory_summary
+            else None
+        )
     )
 
 

--- a/src/python/pants/goal/stats_aggregator_integration_test.py
+++ b/src/python/pants/goal/stats_aggregator_integration_test.py
@@ -33,6 +33,13 @@ def test_counters_and_histograms() -> None:
     assert re.search(r"p99: \d", result.stderr)
 
 
+def test_memory_summary() -> None:
+    result = run_pants(["--stats-memory-summary", "--version"])
+    result.assert_success()
+    assert "Memory summary" in result.stderr
+    assert "pants.engine.unions.UnionMembership" in result.stderr
+
+
 def test_warn_if_no_histograms() -> None:
     result = run_pants(["--stats-log", "roots"])
     result.assert_success()

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1464,13 +1464,6 @@ class GlobalOptions(Subsystem):
         advanced=True,
     )
 
-    memory_summary = BoolOption(
-        "--memory-summary",
-        default=False,
-        help=("Report a summary of memory usage at the end of each run."),
-        advanced=True,
-    )
-
     @classmethod
     def validate_instance(cls, opts):
         """Validates an instance of global options for cases that are not prohibited via


### PR DESCRIPTION
This also uses our `WorkunitsCallback` function rather than a hardcoded function.