### PR TITLE
Move `--memory-summary` to `--stats-memory-summary` (Cherry-pick of #14652)

### DIFF
--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -6,10 +6,9 @@ remote_cache_write = true
 # We want to continue to get logs when remote caching errors.
 remote_cache_warnings = "backoff"
 
-memory_summary = true
-
 [stats]
 log = true
+memory_summary = true
 
 [test]
 use_coverage = true

--- a/src/python/pants/goal/stats_aggregator_integration_test.py
+++ b/src/python/pants/goal/stats_aggregator_integration_test.py
@@ -33,6 +33,13 @@ def test_counters_and_histograms() -> None:
     assert re.search(r"p99: \d", result.stderr)
 
 
+def test_memory_summary() -> None:
+    result = run_pants(["--stats-memory-summary", "--version"])
+    result.assert_success()
+    assert "Memory summary" in result.stderr
+    assert "pants.engine.unions.UnionMembership" in result.stderr
+
+
 def test_warn_if_no_histograms() -> None:
     result = run_pants(["--stats-log", "roots"])
     result.assert_success()

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1423,12 +1423,6 @@ class GlobalOptions(Subsystem):
         ),
     ).advanced()
 
-    memory_summary = BoolOption(
-        "--memory-summary",
-        default=False,
-        help=("Report a summary of memory usage at the end of each run."),
-    ).advanced()
-
     @classmethod
     def validate_instance(cls, opts):
         """Validates an instance of global options for cases that are not prohibited via


### PR DESCRIPTION
This also uses our `WorkunitsCallback` function rather than a hardcoded function.

[ci skip-rust]