### PR TITLE
go: introduce cache key for compile actions

### DIFF
--- a/src/python/pants/backend/go/subsystems/golang.py
+++ b/src/python/pants/backend/go/subsystems/golang.py
@@ -87,7 +87,7 @@ class GoRoot:
     path: str
     version: str
 
-    raw_metadata: FrozenDict[str, str]
+    _raw_metadata: FrozenDict[str, str]
 
     def is_compatible_version(self, version: str) -> bool:
         """Can this Go compiler handle the target version?
@@ -108,15 +108,15 @@ class GoRoot:
 
     @property
     def full_version(self) -> str:
-        return self.raw_metadata["GOVERSION"]
+        return self._raw_metadata["GOVERSION"]
 
     @property
     def goos(self) -> str:
-        return self.raw_metadata["GOOS"]
+        return self._raw_metadata["GOOS"]
 
     @property
     def goarch(self) -> str:
-        return self.raw_metadata["GOARCH"]
+        return self._raw_metadata["GOARCH"]
 
     def arch_env(self) -> tuple[str, str] | None:
         """Returns the name and setting of the GOARCH-specific architecture environment variable.
@@ -130,19 +130,19 @@ class GoRoot:
         # have some involved logic for determining the default. Maybe we need to vendor that logic as well?
         # (although it looks like that code would need to be in Go)
         if self.goarch == "arm":
-            return "GOARM", self.raw_metadata.get("GOARM", "")
+            return "GOARM", self._raw_metadata.get("GOARM", "")
         elif self.goarch == "386":
-            return "GO386", self.raw_metadata.get("GO386", "")
+            return "GO386", self._raw_metadata.get("GO386", "")
         elif self.goarch == "amd64":
-            return "GOAMD64", self.raw_metadata.get("GOAMD64", "")
+            return "GOAMD64", self._raw_metadata.get("GOAMD64", "")
         elif self.goarch in ("mips", "mipsle"):
-            return "GOMIPS", self.raw_metadata.get("GOMIPS", "")
+            return "GOMIPS", self._raw_metadata.get("GOMIPS", "")
         elif self.goarch in ("mips64", "mips64le"):
-            return "GOMIPS64", self.raw_metadata.get("GOMIPS64", "")
+            return "GOMIPS64", self._raw_metadata.get("GOMIPS64", "")
         elif self.goarch in ("ppc64", "ppc64le"):
-            return "GOPPC64", self.raw_metadata.get("GOPPC64", "")
+            return "GOPPC64", self._raw_metadata.get("GOPPC64", "")
         elif self.goarch == "wasm":
-            return "GOWASM", self.raw_metadata.get("GOWASM", "")
+            return "GOWASM", self._raw_metadata.get("GOWASM", "")
         else:
             return None
 
@@ -212,7 +212,7 @@ async def setup_goroot(golang_subsystem: GolangSubsystem) -> GoRoot:
             )
             sdk_metadata = json.loads(env_result.stdout.decode())
             return GoRoot(
-                path=sdk_metadata["GOROOT"], version=version, raw_metadata=FrozenDict(sdk_metadata)
+                path=sdk_metadata["GOROOT"], version=version, _raw_metadata=FrozenDict(sdk_metadata)
             )
 
         logger.debug(

--- a/src/python/pants/backend/go/subsystems/golang.py
+++ b/src/python/pants/backend/go/subsystems/golang.py
@@ -118,34 +118,6 @@ class GoRoot:
     def goarch(self) -> str:
         return self._raw_metadata["GOARCH"]
 
-    def arch_env(self) -> tuple[str, str] | None:
-        """Returns the name and setting of the GOARCH-specific architecture environment variable.
-
-        If the current architecture has no GOARCH-specific variable, returns empty key and value.
-        """
-
-        # See https://github.com/golang/go/blob/21998413ad82655fef1f31316db31e23e0684b21/src/cmd/go/internal/cfg/cfg.go#L261-L312
-        # for the original algorithm.
-        # TODO: It is not clear whether these would ever show up in `go env` output. The Go tool sources actually
-        # have some involved logic for determining the default. Maybe we need to vendor that logic as well?
-        # (although it looks like that code would need to be in Go)
-        if self.goarch == "arm":
-            return "GOARM", self._raw_metadata.get("GOARM", "")
-        elif self.goarch == "386":
-            return "GO386", self._raw_metadata.get("GO386", "")
-        elif self.goarch == "amd64":
-            return "GOAMD64", self._raw_metadata.get("GOAMD64", "")
-        elif self.goarch in ("mips", "mipsle"):
-            return "GOMIPS", self._raw_metadata.get("GOMIPS", "")
-        elif self.goarch in ("mips64", "mips64le"):
-            return "GOMIPS64", self._raw_metadata.get("GOMIPS64", "")
-        elif self.goarch in ("ppc64", "ppc64le"):
-            return "GOPPC64", self._raw_metadata.get("GOPPC64", "")
-        elif self.goarch == "wasm":
-            return "GOWASM", self._raw_metadata.get("GOWASM", "")
-        else:
-            return None
-
 
 @rule(desc="Find Go binary", level=LogLevel.DEBUG)
 async def setup_goroot(golang_subsystem: GolangSubsystem) -> GoRoot:

--- a/src/python/pants/backend/go/subsystems/golang_test.py
+++ b/src/python/pants/backend/go/subsystems/golang_test.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import json
+import typing
 from pathlib import Path
 from textwrap import dedent
 
@@ -15,6 +17,7 @@ from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
 from pants.util.contextutil import temporary_dir
+from pants.util.frozendict import FrozenDict
 
 EXPECTED_VERSION = "1.17"
 
@@ -46,7 +49,7 @@ def get_goroot(rule_runner: RuleRunner, binary_names_to_scripts: list[tuple[str,
         return rule_runner.request(GoRoot, [])
 
 
-def mock_go_binary(*, version_output: str, env_output: str) -> str:
+def mock_go_binary(*, version_output: str, env_output: typing.Mapping[str, str]) -> str:
     """Return a bash script that emulates `go version` and `go env`."""
     return dedent(
         f"""\
@@ -55,7 +58,7 @@ def mock_go_binary(*, version_output: str, env_output: str) -> str:
         if [[ "$1" == version ]]; then
             echo '{version_output}'
         else
-            echo '{env_output}'
+            echo '{json.dumps(env_output)}'
         fi
         """
     )
@@ -64,19 +67,19 @@ def mock_go_binary(*, version_output: str, env_output: str) -> str:
 def test_find_valid_binary(rule_runner: RuleRunner) -> None:
     valid_without_patch = mock_go_binary(
         version_output=f"go version go{EXPECTED_VERSION} darwin/arm64",
-        env_output="/valid/binary",
+        env_output={"GOROOT": "/valid/binary"},
     )
     assert get_goroot(rule_runner, [("go", valid_without_patch)]).path == "/valid/binary"
 
     valid_with_patch = mock_go_binary(
         version_output=f"go version go{EXPECTED_VERSION}.1 darwin/arm64",
-        env_output="/valid/patch_binary",
+        env_output={"GOROOT": "/valid/patch_binary"},
     )
     assert get_goroot(rule_runner, [("go", valid_with_patch)]).path == "/valid/patch_binary"
 
     # Should still work even if there are other Go versions with an invalid version.
     invalid_version = mock_go_binary(
-        version_output="go version go1.8 darwin/arm64", env_output="/not/valid"
+        version_output="go version go1.8 darwin/arm64", env_output={"GOROOT": "/not/valid"}
     )
     assert (
         get_goroot(rule_runner, [("go", valid_without_patch), ("go", invalid_version)]).path
@@ -104,10 +107,10 @@ def test_no_binaries(rule_runner: RuleRunner) -> None:
 
 def test_no_valid_versions(rule_runner: RuleRunner) -> None:
     invalid1 = mock_go_binary(
-        version_output="go version go1.8 darwin/arm64", env_output="/not/valid1"
+        version_output="go version go1.8 darwin/arm64", env_output={"GOROOT": "/not/valid1"}
     )
     invalid2 = mock_go_binary(
-        version_output="go version go1.8 darwin/arm64", env_output="/not/valid2"
+        version_output="go version go1.8 darwin/arm64", env_output={"GOROOT": "/not/valid2"}
     )
     with pytest.raises(ExecutionError) as e:
         get_goroot(rule_runner, [("go", invalid1), ("go", invalid2)])
@@ -117,7 +120,7 @@ def test_no_valid_versions(rule_runner: RuleRunner) -> None:
 
 
 def test_valid_go_version() -> None:
-    go_root = GoRoot("", "1.15")
+    go_root = GoRoot("", "1.15", FrozenDict())
     for v in range(16):
         assert go_root.is_compatible_version(f"1.{v}") is True
     for v in range(17, 40):

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -407,8 +407,8 @@ async def compute_compile_action_id(
     go_arch_env = goroot.arch_env()
     if go_arch_env:
         h.update(f"{go_arch_env[0]}={go_arch_env[1]}\n".encode())
-    if "GOEXPERIMENT" in goroot.raw_metadata:
-        h.update(f"GOEXPERIMENT={goroot.raw_metadata['GOEXPERIMENT']}".encode())
+    if "GOEXPERIMENT" in goroot._raw_metadata:
+        h.update(f"GOEXPERIMENT={goroot._raw_metadata['GOEXPERIMENT']}".encode())
     # TODO: Maybe handle go "magic" env vars: "GOCLOBBERDEADHASH", "GOSSAFUNC", "GOSSADIR", "GOSSAHASH" ?
     # TODO: Handle GSHS_LOGFILE compiler debug option by breaking cache?
 

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -396,14 +396,12 @@ async def compute_compile_action_id(
     # TODO: Inject fuzz instrumentation values here.
 
     compile_tool_id = await Get(GoSdkToolIDResult, GoSdkToolIDRequest("compile"))
-    h.update(
-        f"compile {compile_tool_id.tool_id}\n".encode()
-    )  # TODO: Add compiler flags as per `go`'s algorithm?
+    h.update(f"compile {compile_tool_id.tool_id}\n".encode())
+    # TODO: Add compiler flags as per `go`'s algorithm. Need to figure out
     if bq.s_file_names:
         asm_tool_id = await Get(GoSdkToolIDResult, GoSdkToolIDRequest("asm"))
-        h.update(
-            f"asm {asm_tool_id.tool_id}\n".encode()
-        )  # TODO: Add asm flags as per `go`'s algorithm?
+        h.update(f"asm {asm_tool_id.tool_id}\n".encode())
+        # TODO: Add asm flags as per `go`'s algorithm.
     # TODO: Add micro-architecture into cache key (e.g., GOAMD64 setting).
     if "GOEXPERIMENT" in goroot._raw_metadata:
         h.update(f"GOEXPERIMENT={goroot._raw_metadata['GOEXPERIMENT']}".encode())

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -404,9 +404,7 @@ async def compute_compile_action_id(
         h.update(
             f"asm {asm_tool_id.tool_id}\n".encode()
         )  # TODO: Add asm flags as per `go`'s algorithm?
-    go_arch_env = goroot.arch_env()
-    if go_arch_env:
-        h.update(f"{go_arch_env[0]}={go_arch_env[1]}\n".encode())
+    # TODO: Add micro-architecture into cache key (e.g., GOAMD64 setting).
     if "GOEXPERIMENT" in goroot._raw_metadata:
         h.update(f"GOEXPERIMENT={goroot._raw_metadata['GOEXPERIMENT']}".encode())
     # TODO: Maybe handle go "magic" env vars: "GOCLOBBERDEADHASH", "GOSSAFUNC", "GOSSADIR", "GOSSAHASH" ?

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+import hashlib
 import os.path
 from dataclasses import dataclass
 
@@ -15,7 +16,7 @@ from pants.backend.go.util_rules.assembly import (
 )
 from pants.backend.go.util_rules.embedcfg import EmbedConfig
 from pants.backend.go.util_rules.import_analysis import ImportConfig, ImportConfigRequest
-from pants.backend.go.util_rules.sdk import GoSdkProcess
+from pants.backend.go.util_rules.sdk import GoSdkProcess, GoSdkToolIDRequest, GoSdkToolIDResult
 from pants.engine.engine_aware import EngineAwareParameter, EngineAwareReturnType
 from pants.engine.fs import EMPTY_DIGEST, AddPrefix, CreateDigest, Digest, FileContent, MergeDigests
 from pants.engine.process import FallibleProcessResult
@@ -196,6 +197,16 @@ class RenderedEmbedConfig:
     PATH = "./embedcfg"
 
 
+@dataclass(frozen=True)
+class GoCompileActionIdRequest:
+    build_request: BuildGoPackageRequest
+
+
+@dataclass(frozen=True)
+class GoCompileActionIdResult:
+    action_id: str
+
+
 # NB: We must have a description for the streaming of this rule to work properly
 # (triggered by `FallibleBuiltGoPackage` subclassing `EngineAwareReturnType`).
 @rule(desc="Compile with Go", level=LogLevel.DEBUG)
@@ -218,10 +229,11 @@ async def build_go_package(
         import_paths_to_pkg_a_files.update(dep.import_paths_to_pkg_a_files)
         dep_digests.append(dep.digest)
 
-    merged_deps_digest, import_config, embedcfg = await MultiGet(
+    merged_deps_digest, import_config, embedcfg, action_id_result = await MultiGet(
         Get(Digest, MergeDigests(dep_digests)),
         Get(ImportConfig, ImportConfigRequest(FrozenDict(import_paths_to_pkg_a_files))),
         Get(RenderedEmbedConfig, RenderEmbedConfigRequest(request.embed_config)),
+        Get(GoCompileActionIdResult, GoCompileActionIdRequest(request)),
     )
 
     input_digest = await Get(
@@ -251,6 +263,8 @@ async def build_go_package(
     compile_args = [
         "tool",
         "compile",
+        "-buildid",
+        action_id_result.action_id,
         "-o",
         "__pkg__.a",
         "-pack",
@@ -289,6 +303,7 @@ async def build_go_package(
             command=tuple(compile_args),
             description=f"Compile Go package: {request.import_path}",
             output_files=("__pkg__.a",),
+            env={"__PANTS_GO_COMPILE_ACTION_ID": action_id_result.action_id},
         ),
     )
     if compile_result.exit_code != 0:
@@ -352,6 +367,55 @@ async def render_embed_config(request: RenderEmbedConfigRequest) -> RenderedEmbe
             ),
         )
     return RenderedEmbedConfig(digest)
+
+
+# Compute a cache key for the compile action. This computation is intended to capture similar values to the
+# action ID computed by the `go` tool for its own cache.
+# For details, see https://github.com/golang/go/blob/21998413ad82655fef1f31316db31e23e0684b21/src/cmd/go/internal/work/exec.go#L216-L403
+@rule
+async def compute_compile_action_id(
+    request: GoCompileActionIdRequest, goroot: GoRoot
+) -> GoCompileActionIdResult:
+    bq = request.build_request
+
+    h = hashlib.sha256()
+
+    # All Go action IDs have the full version (as returned by `runtime.Version()` in the key.
+    # See https://github.com/golang/go/blob/master/src/cmd/go/internal/cache/hash.go#L32-L46
+    h.update(goroot.full_version.encode())
+
+    h.update("compile\n".encode())
+    if bq.minimum_go_version:
+        h.update(f"go {bq.minimum_go_version}\n".encode())
+    h.update(f"goos {goroot.goos} goarch {goroot.goarch}\n".encode())
+    h.update(f"import {bq.import_path}\n".encode())
+    # TODO: Consider what to do with this information from Go tool:
+    # fmt.Fprintf(h, "omitdebug %v standard %v local %v prefix %q\n", p.Internal.OmitDebug, p.Standard, p.Internal.Local, p.Internal.LocalPrefix)
+    # TODO: Inject cgo-related values here.
+    # TODO: Inject cover mode values here.
+    # TODO: Inject fuzz instrumentation values here.
+
+    compile_tool_id = await Get(GoSdkToolIDResult, GoSdkToolIDRequest("compile"))
+    h.update(
+        f"compile {compile_tool_id.tool_id}\n".encode()
+    )  # TODO: Add compiler flags as per `go`'s algorithm?
+    if bq.s_file_names:
+        asm_tool_id = await Get(GoSdkToolIDResult, GoSdkToolIDRequest("asm"))
+        h.update(
+            f"asm {asm_tool_id.tool_id}\n".encode()
+        )  # TODO: Add asm flags as per `go`'s algorithm?
+    go_arch_env = goroot.arch_env()
+    if go_arch_env:
+        h.update(f"{go_arch_env[0]}={go_arch_env[1]}\n".encode())
+    if "GOEXPERIMENT" in goroot.raw_metadata:
+        h.update(f"GOEXPERIMENT={goroot.raw_metadata['GOEXPERIMENT']}".encode())
+    # TODO: Maybe handle go "magic" env vars: "GOCLOBBERDEADHASH", "GOSSAFUNC", "GOSSADIR", "GOSSAHASH" ?
+    # TODO: Handle GSHS_LOGFILE compiler debug option by breaking cache?
+
+    # Note: Input files are already part of cache key. Thus, this algorithm omits incorporating their
+    # content hashes into the action ID.
+
+    return GoCompileActionIdResult(h.hexdigest())
 
 
 def rules():

--- a/src/python/pants/backend/go/util_rules/sdk.py
+++ b/src/python/pants/backend/go/util_rules/sdk.py
@@ -13,7 +13,7 @@ from pants.core.util_rules.system_binaries import BashBinary
 from pants.engine.environment import Environment, EnvironmentRequest
 from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, FileContent, MergeDigests
 from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.process import Process
+from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import collect_rules, rule
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
@@ -113,6 +113,29 @@ async def setup_go_sdk_process(
         output_directories=request.output_directories,
         level=LogLevel.DEBUG,
     )
+
+
+@dataclass(frozen=True)
+class GoSdkToolIDRequest:
+    tool_name: str
+
+
+@dataclass(frozen=True)
+class GoSdkToolIDResult:
+    tool_name: str
+    tool_id: str
+
+
+@rule
+async def compute_go_tool_id(request: GoSdkToolIDRequest) -> GoSdkToolIDResult:
+    result = await Get(
+        ProcessResult,
+        GoSdkProcess(
+            ["tool", request.tool_name, "-V=full"],
+            description=f"Obtain tool ID for Go tool `{request.tool_name}`.",
+        ),
+    )
+    return GoSdkToolIDResult(tool_name=request.tool_name, tool_id=result.stdout.decode().strip())
 
 
 def rules():


### PR DESCRIPTION
As described in https://github.com/pantsbuild/pants/issues/14625, the Go version and other compiler values that influence the output (other than input file content hashes) were not incorporated into the cache key for building a Go package. (The input files were handled by being part of the input root's `Digest`.) This caused issues when, for example, changing the version of the compiler where incompatible artifacts built by an earlier Go compiler were being used with an upgraded Go compiler.

The `go` tool handles this by incorporating "action IDs" into the "build ID" of a build product. This PR introduces a similar concept to Pants and tries to follow the `go` tool's algorithm as much as possible. (Links to relevant code are in comments in the code.)

[ci skip-rust]

[ci skip-build-wheels]