### PR TITLE
Adding conditional registration to Options V2

### DIFF
--- a/src/python/pants/option/option_types_test.py
+++ b/src/python/pants/option/option_types_test.py
@@ -230,6 +230,61 @@ def test_subsystem_option_ordering() -> None:
     ]
 
 
+@pytest.mark.parametrize(
+    "cls",
+    [
+        StrOption,
+        IntOption,
+        FloatOption,
+        BoolOption,
+        TargetOption,
+        DirOption,
+        FileOption,
+        ShellStrOption,
+        MemorySizeOption,
+        StrListOption,
+        IntListOption,
+        FloatListOption,
+        BoolListOption,
+        TargetListOption,
+        DirListOption,
+        FileListOption,
+        ShellStrListOption,
+        MemorySizeListOption,
+        EnumOption,
+        EnumListOption,
+        DictOption,
+    ],
+)
+def test_register_if(cls) -> None:
+    extra_kwargs = {"enum_type": MyEnum} if cls in {EnumOption, EnumListOption} else {}
+
+    class MySubsystemBase(Subsystem):
+        registered_prop = cls(
+            "--registered",
+            register_if=lambda cls: cls.truthy,
+            default=None,
+            **extra_kwargs,
+            help="",
+        )
+        not_registered_prop = cls(
+            "--not-registered",
+            register_if=lambda cls: cls.falsey,
+            default=None,
+            **extra_kwargs,
+            help="",
+        )
+
+    class MySubsystem(MySubsystemBase):
+        truthy = True
+        falsey = False
+
+    register = Mock()
+    MySubsystem.register_options(register)
+    assert len(register.call_args_list) == 1
+    assert register.call_args_list[0].args == ("--registered",)
+
+
 def test_property_types() -> None:
     # NB: This test has no runtime assertions
 

--- a/src/python/pants/option/option_types_test.py
+++ b/src/python/pants/option/option_types_test.py
@@ -282,7 +282,7 @@ def test_register_if(cls) -> None:
     register = Mock()
     MySubsystem.register_options(register)
     assert len(register.call_args_list) == 1
-    assert register.call_args_list[0].args == ("--registered",)
+    assert register.call_args_list[0][0] == ("--registered",)
 
 
 def test_property_types() -> None:


### PR DESCRIPTION
This will allow us to support "base" subsystems like `PythonToolRequirementsBase` which chooses to register options based on class variables.

[ci skip-rust]
[ci skip-build-wheels]