### PR TITLE
Don't show no-op regex-lint output. (Cherry-pick of #14656)

### DIFF
--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -252,10 +252,14 @@ async def lint(
         )
         for request_type in target_request_types
     )
-    file_requests = tuple(
-        request_type(specs_snapshot.snapshot.files)
-        for request_type in file_request_types
-        if request_type.name in specified_names
+    file_requests = (
+        tuple(
+            request_type(specs_snapshot.snapshot.files)
+            for request_type in file_request_types
+            if request_type.name in specified_names
+        )
+        if specs_snapshot.snapshot.files
+        else ()
     )
 
     if lint_subsystem.per_file_caching:


### PR DESCRIPTION
Other linters only display output if they acted on at least one file.
Previously, we would always show regex-lint output, even in the
no-op case of acting on no files. This change brings regex-lint
into line with the other linters.

[ci skip-rust]

[ci skip-build-wheels]