### PR TITLE
Invalidate Go cache when Go version changes (Cherry-pick of #14661)

### DIFF
--- a/src/python/pants/backend/go/subsystems/golang.py
+++ b/src/python/pants/backend/go/subsystems/golang.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 from dataclasses import dataclass
@@ -20,6 +21,7 @@ from pants.engine.process import (
 )
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.option.subsystem import Subsystem
+from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import OrderedSet
 from pants.util.strutil import bullet_list
@@ -99,6 +101,8 @@ class GoRoot:
     path: str
     version: str
 
+    _raw_metadata: FrozenDict[str, str]
+
     def is_compatible_version(self, version: str) -> bool:
         """Can this Go compiler handle the target version?
 
@@ -115,6 +119,18 @@ class GoRoot:
             return int(major), int(minor)
 
         return parse(version) <= parse(self.version)
+
+    @property
+    def full_version(self) -> str:
+        return self._raw_metadata["GOVERSION"]
+
+    @property
+    def goos(self) -> str:
+        return self._raw_metadata["GOOS"]
+
+    @property
+    def goarch(self) -> str:
+        return self._raw_metadata["GOARCH"]
 
 
 @rule(desc="Find Go binary", level=LogLevel.DEBUG)
@@ -173,15 +189,17 @@ async def setup_goroot(golang_subsystem: GolangSubsystem) -> GoRoot:
             env_result = await Get(
                 ProcessResult,
                 Process(
-                    (binary_path.path, "env", "GOROOT"),
-                    description=f"Determine Go version and GOROOT for {binary_path.path}",
+                    (binary_path.path, "env", "-json"),
+                    description=f"Determine Go SDK metadata for {binary_path.path}",
                     level=LogLevel.DEBUG,
                     cache_scope=ProcessCacheScope.PER_RESTART_SUCCESSFUL,
                     env={"GOPATH": "/does/not/matter"},
                 ),
             )
-            goroot = env_result.stdout.decode("utf-8").strip()
-            return GoRoot(goroot, version)
+            sdk_metadata = json.loads(env_result.stdout.decode())
+            return GoRoot(
+                path=sdk_metadata["GOROOT"], version=version, _raw_metadata=FrozenDict(sdk_metadata)
+            )
 
         logger.debug(
             f"Go binary at {binary_path.path} has version {version}, but this "

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+import hashlib
 import os.path
 from dataclasses import dataclass
 
@@ -15,7 +16,7 @@ from pants.backend.go.util_rules.assembly import (
 )
 from pants.backend.go.util_rules.embedcfg import EmbedConfig
 from pants.backend.go.util_rules.import_analysis import ImportConfig, ImportConfigRequest
-from pants.backend.go.util_rules.sdk import GoSdkProcess
+from pants.backend.go.util_rules.sdk import GoSdkProcess, GoSdkToolIDRequest, GoSdkToolIDResult
 from pants.engine.engine_aware import EngineAwareParameter, EngineAwareReturnType
 from pants.engine.fs import EMPTY_DIGEST, AddPrefix, CreateDigest, Digest, FileContent, MergeDigests
 from pants.engine.process import FallibleProcessResult
@@ -196,6 +197,16 @@ class RenderedEmbedConfig:
     PATH = "./embedcfg"
 
 
+@dataclass(frozen=True)
+class GoCompileActionIdRequest:
+    build_request: BuildGoPackageRequest
+
+
+@dataclass(frozen=True)
+class GoCompileActionIdResult:
+    action_id: str
+
+
 # NB: We must have a description for the streaming of this rule to work properly
 # (triggered by `FallibleBuiltGoPackage` subclassing `EngineAwareReturnType`).
 @rule(desc="Compile with Go", level=LogLevel.DEBUG)
@@ -218,10 +229,11 @@ async def build_go_package(
         import_paths_to_pkg_a_files.update(dep.import_paths_to_pkg_a_files)
         dep_digests.append(dep.digest)
 
-    merged_deps_digest, import_config, embedcfg = await MultiGet(
+    merged_deps_digest, import_config, embedcfg, action_id_result = await MultiGet(
         Get(Digest, MergeDigests(dep_digests)),
         Get(ImportConfig, ImportConfigRequest(FrozenDict(import_paths_to_pkg_a_files))),
         Get(RenderedEmbedConfig, RenderEmbedConfigRequest(request.embed_config)),
+        Get(GoCompileActionIdResult, GoCompileActionIdRequest(request)),
     )
 
     input_digest = await Get(
@@ -251,6 +263,8 @@ async def build_go_package(
     compile_args = [
         "tool",
         "compile",
+        "-buildid",
+        action_id_result.action_id,
         "-o",
         "__pkg__.a",
         "-pack",
@@ -289,6 +303,7 @@ async def build_go_package(
             command=tuple(compile_args),
             description=f"Compile Go package: {request.import_path}",
             output_files=("__pkg__.a",),
+            env={"__PANTS_GO_COMPILE_ACTION_ID": action_id_result.action_id},
         ),
     )
     if compile_result.exit_code != 0:
@@ -352,6 +367,51 @@ async def render_embed_config(request: RenderEmbedConfigRequest) -> RenderedEmbe
             ),
         )
     return RenderedEmbedConfig(digest)
+
+
+# Compute a cache key for the compile action. This computation is intended to capture similar values to the
+# action ID computed by the `go` tool for its own cache.
+# For details, see https://github.com/golang/go/blob/21998413ad82655fef1f31316db31e23e0684b21/src/cmd/go/internal/work/exec.go#L216-L403
+@rule
+async def compute_compile_action_id(
+    request: GoCompileActionIdRequest, goroot: GoRoot
+) -> GoCompileActionIdResult:
+    bq = request.build_request
+
+    h = hashlib.sha256()
+
+    # All Go action IDs have the full version (as returned by `runtime.Version()` in the key.
+    # See https://github.com/golang/go/blob/master/src/cmd/go/internal/cache/hash.go#L32-L46
+    h.update(goroot.full_version.encode())
+
+    h.update("compile\n".encode())
+    if bq.minimum_go_version:
+        h.update(f"go {bq.minimum_go_version}\n".encode())
+    h.update(f"goos {goroot.goos} goarch {goroot.goarch}\n".encode())
+    h.update(f"import {bq.import_path}\n".encode())
+    # TODO: Consider what to do with this information from Go tool:
+    # fmt.Fprintf(h, "omitdebug %v standard %v local %v prefix %q\n", p.Internal.OmitDebug, p.Standard, p.Internal.Local, p.Internal.LocalPrefix)
+    # TODO: Inject cgo-related values here.
+    # TODO: Inject cover mode values here.
+    # TODO: Inject fuzz instrumentation values here.
+
+    compile_tool_id = await Get(GoSdkToolIDResult, GoSdkToolIDRequest("compile"))
+    h.update(f"compile {compile_tool_id.tool_id}\n".encode())
+    # TODO: Add compiler flags as per `go`'s algorithm. Need to figure out
+    if bq.s_file_names:
+        asm_tool_id = await Get(GoSdkToolIDResult, GoSdkToolIDRequest("asm"))
+        h.update(f"asm {asm_tool_id.tool_id}\n".encode())
+        # TODO: Add asm flags as per `go`'s algorithm.
+    # TODO: Add micro-architecture into cache key (e.g., GOAMD64 setting).
+    if "GOEXPERIMENT" in goroot._raw_metadata:
+        h.update(f"GOEXPERIMENT={goroot._raw_metadata['GOEXPERIMENT']}".encode())
+    # TODO: Maybe handle go "magic" env vars: "GOCLOBBERDEADHASH", "GOSSAFUNC", "GOSSADIR", "GOSSAHASH" ?
+    # TODO: Handle GSHS_LOGFILE compiler debug option by breaking cache?
+
+    # Note: Input files are already part of cache key. Thus, this algorithm omits incorporating their
+    # content hashes into the action ID.
+
+    return GoCompileActionIdResult(h.hexdigest())
 
 
 def rules():

--- a/src/python/pants/backend/go/util_rules/sdk.py
+++ b/src/python/pants/backend/go/util_rules/sdk.py
@@ -12,7 +12,7 @@ from pants.backend.go.subsystems.golang import GolangSubsystem, GoRoot
 from pants.engine.environment import Environment, EnvironmentRequest
 from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, FileContent, MergeDigests
 from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.process import BashBinary, Process
+from pants.engine.process import BashBinary, Process, ProcessResult
 from pants.engine.rules import collect_rules, rule
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
@@ -112,6 +112,29 @@ async def setup_go_sdk_process(
         output_directories=request.output_directories,
         level=LogLevel.DEBUG,
     )
+
+
+@dataclass(frozen=True)
+class GoSdkToolIDRequest:
+    tool_name: str
+
+
+@dataclass(frozen=True)
+class GoSdkToolIDResult:
+    tool_name: str
+    tool_id: str
+
+
+@rule
+async def compute_go_tool_id(request: GoSdkToolIDRequest) -> GoSdkToolIDResult:
+    result = await Get(
+        ProcessResult,
+        GoSdkProcess(
+            ["tool", request.tool_name, "-V=full"],
+            description=f"Obtain tool ID for Go tool `{request.tool_name}`.",
+        ),
+    )
+    return GoSdkToolIDResult(tool_name=request.tool_name, tool_id=result.stdout.decode().strip())
 
 
 def rules():


### PR DESCRIPTION
As described in https://github.com/pantsbuild/pants/issues/14625, the Go version and other compiler values that influence the output (other than input file content hashes) were not incorporated into the cache key for building a Go package. (The input files were handled by being part of the input root's `Digest`.) This caused issues when, for example, changing the version of the compiler where incompatible artifacts built by an earlier Go compiler were being used with an upgraded Go compiler.

The `go` tool handles this by incorporating "action IDs" into the "build ID" of a build product. This PR introduces a similar concept to Pants and tries to follow the `go` tool's algorithm as much as possible. (Links to relevant code are in comments in the code.)

[ci skip-rust]

[ci skip-build-wheels]