### PR TITLE
[internal] Port most `Snapshot` operations to use of `DigestTrie`

### DIFF
--- a/src/rust/engine/fs/src/directory.rs
+++ b/src/rust/engine/fs/src/directory.rs
@@ -230,6 +230,10 @@ impl File {
     self.digest
   }
 
+  pub fn is_executable(&self) -> bool {
+    self.is_executable
+  }
+
   pub fn as_remexec_file_node(&self) -> remexec::FileNode {
     remexec::FileNode {
       name: self.name.as_ref().to_owned(),

--- a/src/rust/engine/fs/src/directory.rs
+++ b/src/rust/engine/fs/src/directory.rs
@@ -202,6 +202,10 @@ impl Directory {
     self.digest
   }
 
+  pub fn tree(&self) -> &DigestTrie {
+    &self.tree
+  }
+
   pub fn as_remexec_directory(&self) -> remexec::Directory {
     self.tree.as_remexec_directory()
   }

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -476,6 +476,22 @@ impl Store {
   }
 
   ///
+  /// Loads the given directory Digest as a DirectoryDigest, eagerly fetching its tree from
+  /// storage. To convert non-eagerly, use `DirectoryDigest::from_persisted_digest`.
+  ///
+  /// In general, DirectoryDigests should be consumed lazily to avoid fetching from a remote
+  /// store unnecessarily, so this method is primarily useful for tests and benchmarks.
+  ///
+  pub async fn load_directory_digest(&self, digest: Digest) -> Result<DirectoryDigest, String> {
+    Ok(DirectoryDigest::new(
+      digest,
+      self
+        .load_digest_trie(DirectoryDigest::from_persisted_digest(digest))
+        .await?,
+    ))
+  }
+
+  ///
   /// Loads a directory proto from the local store, back-filling from remote if necessary.
   ///
   /// Guarantees that if an Ok Some value is returned, it is valid, and canonical, and its

--- a/src/rust/engine/fs/store/src/snapshot.rs
+++ b/src/rust/engine/fs/store/src/snapshot.rs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 use std::collections::HashMap;
-use std::ffi::OsString;
 use std::fmt;
 use std::hash;
 use std::iter::Iterator;
@@ -244,12 +243,6 @@ impl From<Snapshot> for DirectoryDigest {
   fn from(s: Snapshot) -> Self {
     Self::new(s.digest, s.tree)
   }
-}
-
-pub fn osstring_as_utf8(path: OsString) -> Result<String, String> {
-  path
-    .into_string()
-    .map_err(|p| format!("{:?}'s file_name is not representable in UTF8", p))
 }
 
 // StoreFileByDigest allows a File to be saved to an underlying Store, in such a way that it can be

--- a/src/rust/engine/fs/store/src/snapshot.rs
+++ b/src/rust/engine/fs/store/src/snapshot.rs
@@ -100,35 +100,6 @@ impl Snapshot {
     })
   }
 
-  pub fn directories_and_files(directories: &[String], files: &[String]) -> String {
-    format!(
-      "{}{}{}",
-      if directories.is_empty() {
-        String::new()
-      } else {
-        format!(
-          "director{} named: {}",
-          if directories.len() == 1 { "y" } else { "ies" },
-          directories.join(", ")
-        )
-      },
-      if !directories.is_empty() && !files.is_empty() {
-        " and "
-      } else {
-        ""
-      },
-      if files.is_empty() {
-        String::new()
-      } else {
-        format!(
-          "file{} named: {}",
-          if files.len() == 1 { "" } else { "s" },
-          files.join(", ")
-        )
-      },
-    )
-  }
-
   pub async fn get_directory_or_err(
     store: Store,
     digest: Digest,

--- a/src/rust/engine/fs/store/src/tests.rs
+++ b/src/rust/engine/fs/store/src/tests.rs
@@ -8,10 +8,10 @@ use tempfile::TempDir;
 use testutil::data::{TestData, TestDirectory};
 
 use bytes::{Bytes, BytesMut};
-use fs::{DigestEntry, FileEntry, Permissions};
+use fs::{DigestEntry, FileEntry, Permissions, EMPTY_DIRECTORY_DIGEST};
 use grpc_util::prost::MessageExt;
 use grpc_util::tls;
-use hashing::{Digest, Fingerprint, EMPTY_DIGEST};
+use hashing::{Digest, Fingerprint};
 use mock::StubCAS;
 use protos::gen::build::bazel::remote::execution::v2 as remexec;
 
@@ -1101,7 +1101,7 @@ async fn contents_for_directory_empty() {
   let store = new_local_store(store_dir.path());
 
   let file_contents = store
-    .contents_for_directory(TestDirectory::empty().digest())
+    .contents_for_directory(TestDirectory::empty().directory_digest())
     .await
     .expect("Getting FileContents");
 
@@ -1135,7 +1135,7 @@ async fn contents_for_directory() {
     .expect("Error saving catnip file bytes");
 
   let file_contents = store
-    .contents_for_directory(recursive_testdir.digest())
+    .contents_for_directory(recursive_testdir.directory_digest())
     .await
     .expect("Getting FileContents");
 
@@ -1223,7 +1223,7 @@ async fn entries_for_directory() {
     .expect("Error saving catnip file bytes");
 
   let digest_entries = store
-    .entries_for_directory(recursive_testdir.digest())
+    .entries_for_directory(recursive_testdir.directory_digest())
     .await
     .expect("Getting FileContents");
 
@@ -1244,7 +1244,7 @@ async fn entries_for_directory() {
   );
 
   let empty_digest_entries = store
-    .entries_for_directory(EMPTY_DIGEST)
+    .entries_for_directory(EMPTY_DIRECTORY_DIGEST.clone())
     .await
     .expect("Getting EMTPY_DIGEST");
 

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -3,6 +3,7 @@ use std::io::Write;
 use std::path::PathBuf;
 
 use cache::PersistentCache;
+use fs::DirectoryDigest;
 use sharded_lmdb::DEFAULT_LEASE_TIME;
 use store::Store;
 use tempfile::TempDir;
@@ -168,7 +169,7 @@ async fn recover_from_missing_store_contents() {
     let removed = store.remove_file(output_child_digest).await.unwrap();
     assert!(removed);
     assert!(store
-      .contents_for_directory(output_dir_digest)
+      .contents_for_directory(DirectoryDigest::from_persisted_digest(output_dir_digest))
       .await
       .err()
       .is_some())
@@ -182,7 +183,9 @@ async fn recover_from_missing_store_contents() {
 
   // And that the entire output directory can be loaded.
   assert!(store
-    .contents_for_directory(second_result.output_directory)
+    .contents_for_directory(DirectoryDigest::from_persisted_digest(
+      second_result.output_directory
+    ))
     .await
     .ok()
     .is_some())

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -11,7 +11,7 @@ use async_oncecell::OnceCell;
 use async_trait::async_trait;
 use bytes::Bytes;
 use concrete_time::TimeSpan;
-use fs::{self, File, PathStat};
+use fs::{self, DirectoryDigest, File, PathStat};
 use futures::future::{self, BoxFuture, TryFutureExt};
 use futures::FutureExt;
 use futures::{Stream, StreamExt};
@@ -1229,7 +1229,8 @@ pub fn extract_output_files(
             digest = store.record_directory(&directory, true).await?;
           }
         }
-        let res: Result<_, String> = Ok(digest);
+        // TODO: Implement an operation to directly convert a `Tree` into a `DigestTrie`. See #13112.
+        let res: Result<_, String> = Ok(DirectoryDigest::todo_from_digest(digest));
         res
       })
       .map_err(|err| format!("Error saving remote output directory: {}", err)),
@@ -1299,12 +1300,13 @@ pub fn extract_output_files(
     let (files_snapshot, mut directory_digests) =
       future::try_join(files_snapshot, future::try_join_all(directory_digests)).await?;
 
-    directory_digests.push(files_snapshot.digest);
+    directory_digests.push(files_snapshot.into());
 
-    store
+    let directory_digest = store
       .merge(directory_digests)
       .map_err(|err| format!("Error when merging output files and directories: {:?}", err))
-      .await
+      .await?;
+    Ok(directory_digest.todo_as_digest())
   }
   .boxed()
 }

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -559,6 +559,10 @@ async fn make_execute_request_using_immutable_inputs() {
 
   let prefix = RelativePath::new("cats").unwrap();
   let input_directory = TestDirectory::containing_roland();
+  store
+    .record_directory(&input_directory.directory(), false)
+    .await
+    .expect("Saving directory bytes to store");
   let input_digests = InputDigests::new(
     &store,
     EMPTY_DIGEST,
@@ -572,9 +576,9 @@ async fn make_execute_request_using_immutable_inputs() {
   .await
   .unwrap();
 
-  // The computed input root digest should be prefixed will be prefixed with the mount point.
+  // The computed input root digest will be prefixed with the mount point.
   let expected_digest = store
-    .add_prefix(input_directory.digest(), &prefix)
+    .add_prefix(input_directory.directory_digest(), &prefix)
     .await
     .unwrap();
 
@@ -627,7 +631,7 @@ async fn make_execute_request_using_immutable_inputs() {
       ))
         .into(),
     ),
-    input_root_digest: Some((&expected_digest).into()),
+    input_root_digest: Some((&expected_digest.as_digest()).into()),
     ..Default::default()
   };
 

--- a/src/rust/engine/src/externs/fs.rs
+++ b/src/rust/engine/src/externs/fs.rs
@@ -301,7 +301,7 @@ impl PyAddPrefix {
 #[pyclass(name = "RemovePrefix")]
 #[derive(Debug, PartialEq)]
 pub struct PyRemovePrefix {
-  pub digest: Digest,
+  pub digest: DirectoryDigest,
   pub prefix: PathBuf,
 }
 
@@ -310,14 +310,14 @@ impl PyRemovePrefix {
   #[new]
   fn __new__(digest: PyDigest, prefix: PathBuf) -> Self {
     Self {
-      digest: digest.0.todo_as_digest(),
+      digest: digest.0,
       prefix,
     }
   }
 
   fn __hash__(&self) -> u64 {
     let mut s = DefaultHasher::new();
-    self.digest.hash.prefix_hash().hash(&mut s);
+    self.digest.as_digest().hash.prefix_hash().hash(&mut s);
     self.prefix.hash(&mut s);
     s.finish()
   }
@@ -325,7 +325,7 @@ impl PyRemovePrefix {
   fn __repr__(&self) -> String {
     format!(
       "RemovePrefix('{}', {})",
-      PyDigest(DirectoryDigest::todo_from_digest(self.digest)),
+      PyDigest(self.digest.clone()),
       self.prefix.display()
     )
   }

--- a/src/rust/engine/src/externs/fs.rs
+++ b/src/rust/engine/src/externs/fs.rs
@@ -218,16 +218,16 @@ impl PySnapshot {
 
 #[pyclass(name = "MergeDigests")]
 #[derive(Debug, PartialEq)]
-pub struct PyMergeDigests(pub Vec<Digest>);
+pub struct PyMergeDigests(pub Vec<DirectoryDigest>);
 
 #[pymethods]
 impl PyMergeDigests {
   #[new]
   fn __new__(digests: &PyAny, py: Python) -> PyResult<Self> {
-    let digests: PyResult<Vec<Digest>> = PyIterator::from_object(py, digests)?
+    let digests: PyResult<Vec<DirectoryDigest>> = PyIterator::from_object(py, digests)?
       .map(|v| {
         let py_digest = v?.extract::<PyDigest>()?;
-        Ok(py_digest.0.todo_as_digest())
+        Ok(py_digest.0)
       })
       .collect();
     Ok(Self(digests?))
@@ -243,7 +243,7 @@ impl PyMergeDigests {
     let digests = self
       .0
       .iter()
-      .map(|d| format!("{}", PyDigest(DirectoryDigest::todo_from_digest(*d))))
+      .map(|d| format!("{}", PyDigest(d.clone())))
       .join(", ");
     format!("MergeDigests([{}])", digests)
   }

--- a/src/rust/engine/src/externs/fs.rs
+++ b/src/rust/engine/src/externs/fs.rs
@@ -260,7 +260,7 @@ impl PyMergeDigests {
 #[pyclass(name = "AddPrefix")]
 #[derive(Debug, PartialEq)]
 pub struct PyAddPrefix {
-  pub digest: Digest,
+  pub digest: DirectoryDigest,
   pub prefix: PathBuf,
 }
 
@@ -269,14 +269,14 @@ impl PyAddPrefix {
   #[new]
   fn __new__(digest: PyDigest, prefix: PathBuf) -> Self {
     Self {
-      digest: digest.0.todo_as_digest(),
+      digest: digest.0,
       prefix,
     }
   }
 
   fn __hash__(&self) -> u64 {
     let mut s = DefaultHasher::new();
-    self.digest.hash.prefix_hash().hash(&mut s);
+    self.digest.as_digest().hash.prefix_hash().hash(&mut s);
     self.prefix.hash(&mut s);
     s.finish()
   }
@@ -284,7 +284,7 @@ impl PyAddPrefix {
   fn __repr__(&self) -> String {
     format!(
       "AddPrefix('{}', {})",
-      PyDigest(DirectoryDigest::todo_from_digest(self.digest)),
+      PyDigest(self.digest.clone()),
       self.prefix.display()
     )
   }

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -397,10 +397,9 @@ fn download_file_to_digest(
 ) -> BoxFuture<'static, NodeResult<Value>> {
   async move {
     let key = Key::from_value(args.pop().unwrap()).map_err(Failure::from_py_err)?;
-    let digest = context.get(DownloadedFile(key)).await?;
+    let snapshot = context.get(DownloadedFile(key)).await?;
     let gil = Python::acquire_gil();
-    Snapshot::store_directory_digest(gil.python(), DirectoryDigest::todo_from_digest(digest))
-      .map_err(throw)
+    Snapshot::store_directory_digest(gil.python(), snapshot.into()).map_err(throw)
   }
   .boxed()
 }

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -258,17 +258,16 @@ fn directory_digest_to_digest_contents(
       lift_directory_digest(py_digest)
     })
     .map_err(throw)?;
-    let snapshot = context
+
+    let digest_contents = context
       .core
       .store()
-      .contents_for_directory(digest.todo_as_digest())
+      .contents_for_directory(digest)
       .await
-      .and_then(move |digest_contents| {
-        let gil = Python::acquire_gil();
-        Snapshot::store_digest_contents(gil.python(), &context, &digest_contents)
-      })
       .map_err(throw)?;
-    Ok(snapshot)
+
+    let gil = Python::acquire_gil();
+    Snapshot::store_digest_contents(gil.python(), &context, &digest_contents).map_err(throw)
   }
   .boxed()
 }

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -310,18 +310,17 @@ fn remove_prefix_request_to_digest(
         .map_err(|e| throw(format!("{}", e)))?;
       let prefix = RelativePath::new(&py_remove_prefix.prefix)
         .map_err(|e| throw(format!("The `prefix` must be relative: {:?}", e)))?;
-      let res: NodeResult<(Digest, RelativePath)> = Ok((py_remove_prefix.digest, prefix));
+      let res: NodeResult<_> = Ok((py_remove_prefix.digest.clone(), prefix));
       res
     })?;
     let digest = context
       .core
       .store()
-      .strip_prefix(digest, prefix)
+      .strip_prefix(digest, &prefix)
       .await
       .map_err(|e| throw(format!("{:?}", e)))?;
     let gil = Python::acquire_gil();
-    Snapshot::store_directory_digest(gil.python(), DirectoryDigest::todo_from_digest(digest))
-      .map_err(throw)
+    Snapshot::store_directory_digest(gil.python(), digest).map_err(throw)
   }
   .boxed()
 }

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -285,7 +285,7 @@ fn directory_digest_to_digest_entries(
     let snapshot = context
       .core
       .store()
-      .entries_for_directory(digest.todo_as_digest())
+      .entries_for_directory(digest)
       .await
       .and_then(move |digest_entries| {
         let gil = Python::acquire_gil();

--- a/src/rust/engine/testutil/src/data.rs
+++ b/src/rust/engine/testutil/src/data.rs
@@ -320,6 +320,10 @@ impl TestDirectory {
   pub fn digest(&self) -> hashing::Digest {
     hashing::Digest::of_bytes(&self.bytes())
   }
+
+  pub fn directory_digest(&self) -> fs::DirectoryDigest {
+    fs::DirectoryDigest::from_persisted_digest(self.digest())
+  }
 }
 
 pub struct TestTree {


### PR DESCRIPTION
This change continues #13112 by porting most of `Snapshot`'s operations to use of `DigestTrie`, including:
* `merge_directories`
* `add_prefix`
* `remove_prefix`
* `contents_for_directory`
* `entries_for_directory`

But because many operations still assume that an input `Digest` has been persisted (with boundaries marked by `DirectoryDigest::{todo_as_digest,todo_from_digest}`), modified methods in this change will continue to persist `DigestTrie`s that they produce. #14723 will remove that persistence.