### PR TITLE
Fix rendering of "Scheduling: ..." workunits introduced by workunit filtering

### DIFF
--- a/src/rust/engine/process_execution/src/bounded.rs
+++ b/src/rust/engine/process_execution/src/bounded.rs
@@ -66,7 +66,14 @@ impl crate::CommandRunner for CommandRunner {
       context.workunit_store.clone(),
       "acquire_command_runner_slot".to_owned(),
       WorkunitMetadata {
-        level: Level::Trace,
+        // TODO: The UI uses the presence of a blocked workunit below a parent as an indication that
+        // the parent is blocked. If this workunit is filtered out, parents nodes which are waiting
+        // for the semaphore will render, even though they are effectively idle.
+        //
+        // https://github.com/pantsbuild/pants/issues/14680 will likely allow for a more principled
+        // solution to this problem, such as removing the mutable `blocking` flag, and then never
+        // filtering blocked workunits at creation time, regardless of level.
+        level: Level::Debug,
         ..WorkunitMetadata::default()
       },
       |workunit| async move {


### PR DESCRIPTION
#13483 resulted in `acquire_command_runner_slot` workunits being filtered out at capture time, which caused their (blocked) parents to render: in particular, `"Scheduling: $process"` workunits.