### PR TITLE
Reduce memory usage by interning Tasks and RuleGraph entries.

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -16,6 +16,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
+name = "ahash"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
+dependencies = [
+ "getrandom 0.2.1",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,9 +563,10 @@ dependencies = [
 [[package]]
 name = "deepsize"
 version = "0.2.0"
-source = "git+https://github.com/stuhood/deepsize.git?rev=67c6cfc2afa1303c06b19c1b96ebe11fd3217d34#67c6cfc2afa1303c06b19c1b96ebe11fd3217d34"
+source = "git+https://github.com/stuhood/deepsize.git?rev=5c8bee5443fcafe4aaa9274490d354412d0955c1#5c8bee5443fcafe4aaa9274490d354412d0955c1"
 dependencies = [
  "deepsize_derive",
+ "internment",
  "log",
  "smallvec",
 ]
@@ -562,7 +574,7 @@ dependencies = [
 [[package]]
 name = "deepsize_derive"
 version = "0.1.2"
-source = "git+https://github.com/stuhood/deepsize.git?rev=67c6cfc2afa1303c06b19c1b96ebe11fd3217d34#67c6cfc2afa1303c06b19c1b96ebe11fd3217d34"
+source = "git+https://github.com/stuhood/deepsize.git?rev=5c8bee5443fcafe4aaa9274490d354412d0955c1#5c8bee5443fcafe4aaa9274490d354412d0955c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -655,6 +667,7 @@ dependencies = [
  "grpc_util",
  "hashing",
  "indexmap",
+ "internment",
  "itertools",
  "lazy_static",
  "libc",
@@ -1121,6 +1134,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
+name = "hashbrown"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c21d40587b92fa6a6c6e3c1bdbf87d75511db5672f9c93175574b3a00df1758"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
 name = "hashing"
 version = "0.0.1"
 dependencies = [
@@ -1306,7 +1328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -1357,6 +1379,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "internment"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73bd1419c48e9f496d5830cc2f7fff35cab112193f289fd7266ab0679bb97237"
+dependencies = [
+ "hashbrown 0.12.0",
+ "parking_lot 0.12.0",
 ]
 
 [[package]]
@@ -2655,6 +2687,7 @@ dependencies = [
  "deepsize",
  "env_logger",
  "indexmap",
+ "internment",
  "log",
  "petgraph 0.5.1",
 ]

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -113,8 +113,8 @@ bytes = "1.0"
 cache = { path = "cache" }
 concrete_time = { path = "concrete_time" }
 crossbeam-channel = "0.5"
-# TODO: Waiting on https://github.com/Aeledfyr/deepsize/pull/30 and https://github.com/Aeledfyr/deepsize/pull/31.
-deepsize = { git = "https://github.com/stuhood/deepsize.git", rev = "67c6cfc2afa1303c06b19c1b96ebe11fd3217d34", features=["smallvec"] }
+# TODO: Waiting on https://github.com/Aeledfyr/deepsize/pull/{30,31,32}.
+deepsize = { git = "https://github.com/stuhood/deepsize.git", rev = "5c8bee5443fcafe4aaa9274490d354412d0955c1", features=["internment", "smallvec"] }
 derivative = "2.2"
 async-oncecell = "0.2"
 either = "1.6"
@@ -126,6 +126,7 @@ graph = { path = "graph" }
 grpc_util = { path = "grpc_util" }
 hashing = { path = "hashing" }
 indexmap = "1.8"
+internment = "0.6"
 itertools = "0.10"
 lazy_static = "1"
 libc = "0.2.112"

--- a/src/rust/engine/concrete_time/Cargo.toml
+++ b/src/rust/engine/concrete_time/Cargo.toml
@@ -6,8 +6,8 @@ name = "concrete_time"
 publish = false
 
 [dependencies]
-# TODO: Waiting on https://github.com/Aeledfyr/deepsize/pull/30 and https://github.com/Aeledfyr/deepsize/pull/31.
-deepsize = { git = "https://github.com/stuhood/deepsize.git", rev = "67c6cfc2afa1303c06b19c1b96ebe11fd3217d34" }
+# TODO: Waiting on https://github.com/Aeledfyr/deepsize/pull/{30,31,32}.
+deepsize = { git = "https://github.com/stuhood/deepsize.git", rev = "5c8bee5443fcafe4aaa9274490d354412d0955c1" }
 log = "0.4"
 prost = "0.9"
 prost-types = "0.9"

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 # Pin async-trait due to https://github.com/dtolnay/async-trait/issues/144.
 async-trait = "=0.1.42"
 bytes = "1.0"
-# TODO: Waiting on https://github.com/Aeledfyr/deepsize/pull/30 and https://github.com/Aeledfyr/deepsize/pull/31.
-deepsize = { git = "https://github.com/stuhood/deepsize.git", rev = "67c6cfc2afa1303c06b19c1b96ebe11fd3217d34" }
+# TODO: Waiting on https://github.com/Aeledfyr/deepsize/pull/{30,31,32}.
+deepsize = { git = "https://github.com/stuhood/deepsize.git", rev = "5c8bee5443fcafe4aaa9274490d354412d0955c1" }
 dirs-next = "2"
 futures = "0.3"
 glob = "0.3.0"

--- a/src/rust/engine/hashing/Cargo.toml
+++ b/src/rust/engine/hashing/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 
 [dependencies]
 byteorder = "1.3"
-# TODO: Waiting on https://github.com/Aeledfyr/deepsize/pull/30 and https://github.com/Aeledfyr/deepsize/pull/31.
-deepsize = { git = "https://github.com/stuhood/deepsize.git", rev = "67c6cfc2afa1303c06b19c1b96ebe11fd3217d34" }
+# TODO: Waiting on https://github.com/Aeledfyr/deepsize/pull/{30,31,32}.
+deepsize = { git = "https://github.com/stuhood/deepsize.git", rev = "5c8bee5443fcafe4aaa9274490d354412d0955c1" }
 digest = "0.9"
 generic-array = "0.14"
 hex = "0.4.3"

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -14,8 +14,8 @@ protos = { path = "../protos" }
 bytes = "1.0"
 cache = { path = "../cache" }
 derivative = "2.2"
-# TODO: Waiting on https://github.com/Aeledfyr/deepsize/pull/30 and https://github.com/Aeledfyr/deepsize/pull/31.
-deepsize = { git = "https://github.com/stuhood/deepsize.git", rev = "67c6cfc2afa1303c06b19c1b96ebe11fd3217d34", features=["log"] }
+# TODO: Waiting on https://github.com/Aeledfyr/deepsize/pull/{30,31,32}.
+deepsize = { git = "https://github.com/stuhood/deepsize.git", rev = "5c8bee5443fcafe4aaa9274490d354412d0955c1", features=["log"] }
 grpc_util = { path = "../grpc_util" }
 fs = { path = "../fs" }
 futures = "0.3"

--- a/src/rust/engine/rule_graph/Cargo.toml
+++ b/src/rust/engine/rule_graph/Cargo.toml
@@ -6,9 +6,10 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
 
 [dependencies]
-# TODO: Waiting on https://github.com/Aeledfyr/deepsize/pull/30 and https://github.com/Aeledfyr/deepsize/pull/31.
-deepsize = { git = "https://github.com/stuhood/deepsize.git", rev = "67c6cfc2afa1303c06b19c1b96ebe11fd3217d34" }
+# TODO: Waiting on https://github.com/Aeledfyr/deepsize/pull/{30,31,32}.
+deepsize = { git = "https://github.com/stuhood/deepsize.git", rev = "5c8bee5443fcafe4aaa9274490d354412d0955c1" }
 indexmap = "1.8"
+internment = "0.6"
 log = "0.4"
 petgraph = "0.5"
 

--- a/src/rust/engine/rule_graph/src/builder.rs
+++ b/src/rust/engine/rule_graph/src/builder.rs
@@ -7,6 +7,7 @@ use crate::{params_str, Entry, EntryWithDeps, InnerEntry, RootEntry, RuleEdges, 
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 
 use indexmap::IndexSet;
+use internment::Intern;
 use petgraph::graph::{DiGraph, EdgeReference, NodeIndex};
 use petgraph::visit::{DfsPostOrder, EdgeRef, IntoNodeReferences, NodeRef, VisitMap, Visitable};
 use petgraph::Direction;
@@ -1156,11 +1157,11 @@ impl<R: Rule> Builder<R> {
     let entry_for = |node_id| -> Entry<R> {
       let (node, in_set): &(Node<R>, ParamTypes<_>) = &graph[node_id];
       match node {
-        Node::Rule(rule) => Entry::WithDeps(EntryWithDeps::Inner(InnerEntry {
+        Node::Rule(rule) => Entry::WithDeps(Intern::new(EntryWithDeps::Inner(InnerEntry {
           params: in_set.clone(),
           rule: rule.clone(),
-        })),
-        Node::Query(q) => Entry::WithDeps(EntryWithDeps::Root(RootEntry(q.clone()))),
+        }))),
+        Node::Query(q) => Entry::WithDeps(Intern::new(EntryWithDeps::Root(RootEntry(q.clone())))),
         Node::Param(p) => Entry::Param(*p),
       }
     };
@@ -1182,8 +1183,13 @@ impl<R: Rule> Builder<R> {
       // there was one dependency per DependencyKey.
       let dependencies = graph
         .edges_directed(node_id, Direction::Outgoing)
-        .map(|edge_ref| (*edge_ref.weight(), vec![entry_for(edge_ref.target())]))
-        .collect::<HashMap<_, _>>();
+        .map(|edge_ref| {
+          (
+            *edge_ref.weight(),
+            Intern::new(entry_for(edge_ref.target())),
+          )
+        })
+        .collect::<HashMap<_, Intern<Entry<R>>>>();
 
       match entry {
         Entry::WithDeps(wd) => {

--- a/src/rust/engine/rule_graph/src/lib.rs
+++ b/src/rust/engine/rule_graph/src/lib.rs
@@ -509,8 +509,6 @@ impl<R: Rule> RuleGraph<R> {
 ///
 /// Records the dependency rules for a rule.
 ///
-/// TODO: No longer needs a Vec<Entry>.
-///
 #[derive(Eq, PartialEq, Clone, Debug)]
 pub struct RuleEdges<R: Rule> {
   dependencies: HashMap<R::DependencyKey, Intern<Entry<R>>>,

--- a/src/rust/engine/rule_graph/src/rules.rs
+++ b/src/rust/engine/rule_graph/src/rules.rs
@@ -12,7 +12,7 @@ use super::{params_str, Palette};
 pub type ParamTypes<T> = BTreeSet<T>;
 
 pub trait TypeId:
-  Clone + Copy + Debug + DeepSizeOf + Display + Hash + Eq + Ord + Sized + 'static
+  Clone + Copy + Debug + DeepSizeOf + Display + Hash + Eq + Ord + Sized + Send + Sync + 'static
 {
   ///
   /// Render a string for a collection of TypeIds.
@@ -77,7 +77,9 @@ impl DisplayForGraphArgs {
   }
 }
 
-pub trait Rule: Clone + Debug + Display + Hash + Eq + Sized + DisplayForGraph + 'static {
+pub trait Rule:
+  Clone + Debug + Display + Hash + Eq + Sized + DisplayForGraph + Send + Sync + 'static
+{
   type TypeId: TypeId;
   type DependencyKey: DependencyKey<TypeId = Self::TypeId>;
 

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -907,7 +907,7 @@ fn session_run_interactive_process(
       true,
       &Arc::new(std::sync::atomic::AtomicBool::new(true)),
       core.intrinsics.run(
-        Intrinsic {
+        &Intrinsic {
           product: core.types.interactive_process_result,
           inputs: vec![core.types.interactive_process],
         },

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -154,13 +154,13 @@ impl Intrinsics {
 
   pub async fn run(
     &self,
-    intrinsic: Intrinsic,
+    intrinsic: &Intrinsic,
     context: Context,
     args: Vec<Value>,
   ) -> NodeResult<Value> {
     let function = self
       .intrinsics
-      .get(&intrinsic)
+      .get(intrinsic)
       .unwrap_or_else(|| panic!("Unrecognized intrinsic: {:?}", intrinsic));
     function(context, args).await
   }

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -9,15 +9,16 @@ use crate::selectors::{DependencyKey, Get, Select};
 
 use deepsize::DeepSizeOf;
 use indexmap::IndexSet;
+use internment::Intern;
 use log::Level;
 use rule_graph::{DisplayForGraph, DisplayForGraphArgs, Query};
 
 #[derive(DeepSizeOf, Eq, Hash, PartialEq, Clone, Debug)]
 pub enum Rule {
   // Intrinsic rules are implemented in rust.
-  Intrinsic(Intrinsic),
+  Intrinsic(Intern<Intrinsic>),
   // Task rules are implemented in python.
-  Task(Task),
+  Task(Intern<Task>),
 }
 
 impl DisplayForGraph for Rule {
@@ -82,16 +83,14 @@ impl rule_graph::Rule for Rule {
 
   fn dependency_keys(&self) -> Vec<DependencyKey> {
     match self {
-      &Rule::Task(Task {
-        ref clause,
-        ref gets,
-        ..
-      }) => clause
+      &Rule::Task(task) => task
+        .clause
         .iter()
         .map(|t| DependencyKey::JustSelect(Select::new(*t)))
-        .chain(gets.iter().map(|g| DependencyKey::JustGet(*g)))
+        .chain(task.gets.iter().map(|g| DependencyKey::JustGet(*g)))
         .collect(),
-      &Rule::Intrinsic(Intrinsic { ref inputs, .. }) => inputs
+      &Rule::Intrinsic(intrinsic) => intrinsic
+        .inputs
         .iter()
         .map(|t| DependencyKey::JustSelect(Select::new(*t)))
         .collect(),
@@ -211,7 +210,9 @@ impl Tasks {
 
   pub fn intrinsics_set(&mut self, intrinsics: &Intrinsics) {
     for intrinsic in intrinsics.keys() {
-      self.rules.insert(Rule::Intrinsic(intrinsic.clone()));
+      self
+        .rules
+        .insert(Rule::Intrinsic(Intern::new(intrinsic.clone())));
     }
   }
 
@@ -282,7 +283,7 @@ impl Tasks {
       .preparing
       .take()
       .expect("Must `begin()` a task creation before ending it!");
-    self.rules.insert(Rule::Task(task));
+    self.rules.insert(Rule::Task(Intern::new(task)));
   }
 
   pub fn query_add(&mut self, product: TypeId, params: Vec<TypeId>) {

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 [dependencies]
 bytes = "1.0"
 concrete_time = { path = "../concrete_time" }
-# TODO: Waiting on https://github.com/Aeledfyr/deepsize/pull/30 and https://github.com/Aeledfyr/deepsize/pull/31.
-deepsize = { git = "https://github.com/stuhood/deepsize.git", rev = "67c6cfc2afa1303c06b19c1b96ebe11fd3217d34" }
+# TODO: Waiting on https://github.com/Aeledfyr/deepsize/pull/{30,31,32}.
+deepsize = { git = "https://github.com/stuhood/deepsize.git", rev = "5c8bee5443fcafe4aaa9274490d354412d0955c1" }
 hashing = { path = "../hashing" }
 hdrhistogram = "7.4"
 log = "0.4"


### PR DESCRIPTION
The `--stats-memory-summary` added in #14638/#14652 was [reporting surprisingly large sizes](https://github.com/pantsbuild/pants/issues/12662#issuecomment-1054486267)  for native `NodeKey` structs -- even when excluding the actual Python values that they held. Investigation showed that both the `Task` and `Entry` structs were contributing significantly to the size of the `Task` struct.

The [`internment` crate](https://crates.io/crates/internment) used here (and in #14654) is an alternative to giving these values integer IDs. They become pointers to a unique, shared (technically: leaked) copy of the value. They are consequently 1) much smaller, 2) much faster to compare.

The `top`-reported memory usage of `./pants dependencies --transitive ::`:
* `313M` before (summary [before.txt](https://github.com/pantsbuild/pants/files/8175461/before.txt))
* `220M` after (summary [after.txt](https://github.com/pantsbuild/pants/files/8175462/after.txt))

[ci skip-build-wheels]