### PR TITLE
Fix dropped output race during UI teardown (cherrypick of #14093)

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -3586,6 +3586,7 @@ dependencies = [
  "indexmap",
  "indicatif",
  "logging",
+ "parking_lot",
  "stdio",
  "task_executor",
  "uuid",

--- a/src/rust/engine/ui/Cargo.toml
+++ b/src/rust/engine/ui/Cargo.toml
@@ -13,6 +13,7 @@ futures = "0.3"
 indexmap = "1.4"
 indicatif = "0.16.2"
 logging = { path = "../logging" }
+parking_lot = "0.11"
 stdio = { path = "../stdio" }
 task_executor = { path = "../task_executor" }
 uuid = { version = "0.7", features = ["v4"] }


### PR DESCRIPTION
As described in #13276 and #11626, a race condition can occur between releasing exclusive access to the Console and the dynamic UI shutting down. In #13276, the issue was triaged to a task accepting output without confirming that the UI was still valid, and then dropping it if the UI was no longer valid.

To fix this, replace the extra task and channel (which could not be used "transactionally" to both accept stderr and validate that the UI was still valid), with an anonymous `Mutex` directly around the stderr destination.

Fixes #13276 and #11626.

[ci skip-build-wheels]