### PR TITLE
Deprecate `[python-protobuf].runtime_dependencies` in favor of Pants discovering the dependency

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/java/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/java/rules_integration_test.py
@@ -9,9 +9,6 @@ import pytest
 
 from pants.backend.codegen.protobuf.java.rules import GenerateJavaFromProtobufRequest
 from pants.backend.codegen.protobuf.java.rules import rules as protobuf_rules
-from pants.backend.codegen.protobuf.python.python_protobuf_subsystem import (
-    rules as protobuf_subsystem_rules,
-)
 from pants.backend.codegen.protobuf.target_types import (
     ProtobufSourceField,
     ProtobufSourcesGeneratorTarget,
@@ -50,7 +47,6 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *protobuf_rules(),
-            *protobuf_subsystem_rules(),
             *stripped_source_files.rules(),
             *target_types_rules(),
             QueryRule(HydratedSources, [HydrateSourcesRequest]),

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem_test.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem_test.py
@@ -1,45 +1,62 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 from pants.backend.codegen.protobuf import target_types
 from pants.backend.codegen.protobuf.python import python_protobuf_subsystem
 from pants.backend.codegen.protobuf.python.python_protobuf_subsystem import (
     InjectPythonProtobufDependencies,
 )
-from pants.backend.codegen.protobuf.target_types import (
-    ProtobufDependenciesField,
-    ProtobufSourcesGeneratorTarget,
+from pants.backend.codegen.protobuf.target_types import ProtobufSourcesGeneratorTarget
+from pants.backend.codegen.utils import (
+    AmbiguousPythonCodegenRuntimeLibrary,
+    MissingPythonCodegenRuntimeLibrary,
 )
-from pants.core.target_types import GenericTarget
+from pants.backend.python.dependency_inference import module_mapper
+from pants.backend.python.target_types import PythonRequirementTarget
+from pants.core.util_rules import stripped_source_files
 from pants.engine.addresses import Address
-from pants.engine.target import InjectedDependencies
-from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.engine.target import Dependencies, InjectedDependencies
+from pants.testutil.rule_runner import QueryRule, RuleRunner, engine_error
 
 
-def test_inject_dependencies() -> None:
+def test_find_protobuf_python_requirement() -> None:
     rule_runner = RuleRunner(
         rules=[
             *python_protobuf_subsystem.rules(),
             *target_types.rules(),
+            *module_mapper.rules(),
+            *stripped_source_files.rules(),
             QueryRule(InjectedDependencies, (InjectPythonProtobufDependencies,)),
         ],
-        target_types=[ProtobufSourcesGeneratorTarget, GenericTarget],
+        target_types=[ProtobufSourcesGeneratorTarget, PythonRequirementTarget],
     )
-    rule_runner.set_options(["--python-protobuf-runtime-dependencies=protos:injected_dep"])
-    # Note that injected deps can be any target type for `--python-protobuf-runtime-dependencies`.
+
     rule_runner.write_files(
-        {
-            "protos/BUILD": "protobuf_sources()\ntarget(name='injected_dep')",
-            "protos/f.proto": "",
-        }
+        {"codegen/dir/f.proto": "", "codegen/dir/BUILD": "protobuf_sources(grpc=True)"}
+    )
+    proto_tgt = rule_runner.get_target(Address("codegen/dir", relative_file_path="f.proto"))
+    request = InjectPythonProtobufDependencies(proto_tgt[Dependencies])
+
+    # Start with no relevant requirements.
+    with engine_error(MissingPythonCodegenRuntimeLibrary, contains="protobuf"):
+        rule_runner.request(InjectedDependencies, [request])
+    rule_runner.write_files({"proto1/BUILD": "python_requirement(requirements=['protobuf'])"})
+    with engine_error(MissingPythonCodegenRuntimeLibrary, contains="grpcio"):
+        rule_runner.request(InjectedDependencies, [request])
+
+    # If exactly one, match it.
+    rule_runner.write_files({"grpc1/BUILD": "python_requirement(requirements=['grpc'])"})
+    assert rule_runner.request(InjectedDependencies, [request]) == InjectedDependencies(
+        [Address("proto1"), Address("grpc1")]
     )
 
-    def assert_injected(addr: Address) -> None:
-        tgt = rule_runner.get_target(addr)
-        injected = rule_runner.request(
-            InjectedDependencies, [InjectPythonProtobufDependencies(tgt[ProtobufDependenciesField])]
-        )
-        assert injected == InjectedDependencies([Address("protos", target_name="injected_dep")])
-
-    assert_injected(Address("protos"))
-    assert_injected(Address("protos", relative_file_path="f.proto"))
+    # If multiple, error.
+    rule_runner.write_files({"grpc2/BUILD": "python_requirement(requirements=['grpc'])"})
+    with engine_error(
+        AmbiguousPythonCodegenRuntimeLibrary, contains="['grpc1:grpc1', 'grpc2:grpc2']"
+    ):
+        rule_runner.request(InjectedDependencies, [request])
+    rule_runner.write_files({"proto2/BUILD": "python_requirement(requirements=['protobuf'])"})
+    with engine_error(
+        AmbiguousPythonCodegenRuntimeLibrary, contains="['proto1:proto1', 'proto2:proto2']"
+    ):
+        rule_runner.request(InjectedDependencies, [request])

--- a/src/python/pants/backend/codegen/protobuf/python/register.py
+++ b/src/python/pants/backend/codegen/protobuf/python/register.py
@@ -20,6 +20,8 @@ from pants.backend.codegen.protobuf.target_types import (
     ProtobufSourceTarget,
 )
 from pants.backend.codegen.protobuf.target_types import rules as protobuf_target_rules
+from pants.backend.python.dependency_inference import module_mapper
+from pants.core.util_rules import stripped_source_files
 
 
 def rules():
@@ -32,6 +34,8 @@ def rules():
         *protobuf_tailor.rules(),
         *export_codegen_goal.rules(),
         *protobuf_target_rules(),
+        *module_mapper.rules(),
+        *stripped_source_files.rules(),
     ]
 
 

--- a/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
@@ -19,6 +19,7 @@ from pants.backend.codegen.protobuf.target_types import (
     ProtobufSourcesGeneratorTarget,
 )
 from pants.backend.codegen.protobuf.target_types import rules as target_types_rules
+from pants.backend.python.dependency_inference import module_mapper
 from pants.core.util_rules import stripped_source_files
 from pants.engine.addresses import Address
 from pants.engine.target import GeneratedSources, HydratedSources, HydrateSourcesRequest
@@ -58,6 +59,7 @@ def rule_runner() -> RuleRunner:
             *additional_fields.rules(),
             *stripped_source_files.rules(),
             *target_types_rules(),
+            *module_mapper.rules(),
             QueryRule(HydratedSources, [HydrateSourcesRequest]),
             QueryRule(GeneratedSources, [GeneratePythonFromProtobufRequest]),
         ],
@@ -74,7 +76,11 @@ def assert_files_generated(
     mypy: bool = False,
     extra_args: list[str] | None = None,
 ) -> None:
-    args = [f"--source-root-patterns={repr(source_roots)}", *(extra_args or ())]
+    args = [
+        f"--source-root-patterns={repr(source_roots)}",
+        "--no-python-protobuf-infer-runtime-dependency",
+        *(extra_args or ()),
+    ]
     if mypy:
         args.append("--python-protobuf-mypy-plugin")
     rule_runner.set_options(args, env_inherit={"PATH", "PYENV_ROOT", "HOME"})

--- a/src/python/pants/backend/codegen/thrift/apache/python/register.py
+++ b/src/python/pants/backend/codegen/thrift/apache/python/register.py
@@ -9,6 +9,8 @@ from pants.backend.codegen.thrift.target_types import (
     ThriftSourcesGeneratorTarget,
     ThriftSourceTarget,
 )
+from pants.backend.python.dependency_inference import module_mapper
+from pants.core.util_rules import stripped_source_files
 
 
 def target_types():
@@ -21,4 +23,6 @@ def rules():
         *apache_thrift_rules(),
         *apache_thrift_python_rules(),
         *python_thrift_module_mapper.rules(),
+        *module_mapper.rules(),
+        *stripped_source_files.rules(),
     ]

--- a/src/python/pants/backend/codegen/thrift/apache/python/rules.py
+++ b/src/python/pants/backend/codegen/thrift/apache/python/rules.py
@@ -1,6 +1,8 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 from pants.backend.codegen.thrift.apache.python import subsystem
 from pants.backend.codegen.thrift.apache.python.subsystem import ThriftPythonSubsystem
 from pants.backend.codegen.thrift.apache.rules import (
@@ -8,8 +10,9 @@ from pants.backend.codegen.thrift.apache.rules import (
     GenerateThriftSourcesRequest,
 )
 from pants.backend.codegen.thrift.target_types import ThriftDependenciesField, ThriftSourceField
+from pants.backend.codegen.utils import find_python_runtime_library_or_error
+from pants.backend.python.dependency_inference.module_mapper import ThirdPartyPythonModuleMapping
 from pants.backend.python.target_types import PythonSourceField
-from pants.engine.addresses import Addresses, UnparsedAddressInputs
 from pants.engine.fs import AddPrefix, Digest, Snapshot
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
@@ -63,11 +66,24 @@ class InjectApacheThriftPythonDependencies(InjectDependenciesRequest):
 
 
 @rule
-async def inject_apache_thrift_java_dependencies(
-    _: InjectApacheThriftPythonDependencies, thrift_python: ThriftPythonSubsystem
+async def find_apache_thrift_python_requirement(
+    request: InjectApacheThriftPythonDependencies,
+    thrift_python: ThriftPythonSubsystem,
+    # TODO(#12946): Make this a lazy Get once possible.
+    module_mapping: ThirdPartyPythonModuleMapping,
 ) -> InjectedDependencies:
-    addresses = await Get(Addresses, UnparsedAddressInputs, thrift_python.runtime_dependencies)
-    return InjectedDependencies(addresses)
+    if not thrift_python.infer_runtime_dependency:
+        return InjectedDependencies()
+
+    addr = find_python_runtime_library_or_error(
+        module_mapping,
+        request.dependencies_field.address,
+        "thrift",
+        recommended_requirement_name="thrift",
+        recommended_requirement_url="https://pypi.org/project/thrift/",
+        disable_inference_option=f"[{thrift_python.options_scope}].infer_runtime_dependency",
+    )
+    return InjectedDependencies([addr])
 
 
 def rules():

--- a/src/python/pants/backend/codegen/thrift/apache/python/rules.py
+++ b/src/python/pants/backend/codegen/thrift/apache/python/rules.py
@@ -10,7 +10,7 @@ from pants.backend.codegen.thrift.apache.rules import (
     GenerateThriftSourcesRequest,
 )
 from pants.backend.codegen.thrift.target_types import ThriftDependenciesField, ThriftSourceField
-from pants.backend.codegen.utils import find_python_runtime_library_or_error
+from pants.backend.codegen.utils import find_python_runtime_library_or_raise_error
 from pants.backend.python.dependency_inference.module_mapper import ThirdPartyPythonModuleMapping
 from pants.backend.python.target_types import PythonSourceField
 from pants.engine.fs import AddPrefix, Digest, Snapshot
@@ -75,7 +75,7 @@ async def find_apache_thrift_python_requirement(
     if not thrift_python.infer_runtime_dependency:
         return InjectedDependencies()
 
-    addr = find_python_runtime_library_or_error(
+    addr = find_python_runtime_library_or_raise_error(
         module_mapping,
         request.dependencies_field.address,
         "thrift",

--- a/src/python/pants/backend/codegen/thrift/apache/python/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/thrift/apache/python/rules_integration_test.py
@@ -6,7 +6,10 @@ from textwrap import dedent
 
 import pytest
 
-from pants.backend.codegen.thrift.apache.python.rules import GeneratePythonFromThriftRequest
+from pants.backend.codegen.thrift.apache.python.rules import (
+    GeneratePythonFromThriftRequest,
+    InjectApacheThriftPythonDependencies,
+)
 from pants.backend.codegen.thrift.apache.python.rules import rules as apache_thrift_python_rules
 from pants.backend.codegen.thrift.apache.rules import rules as apache_thrift_rules
 from pants.backend.codegen.thrift.rules import rules as thrift_rules
@@ -14,14 +17,26 @@ from pants.backend.codegen.thrift.target_types import (
     ThriftSourceField,
     ThriftSourcesGeneratorTarget,
 )
+from pants.backend.codegen.utils import (
+    AmbiguousPythonCodegenRuntimeLibrary,
+    MissingPythonCodegenRuntimeLibrary,
+)
+from pants.backend.python.dependency_inference import module_mapper
+from pants.backend.python.target_types import PythonRequirementTarget
 from pants.build_graph.address import Address
 from pants.core.util_rules import source_files, stripped_source_files
 from pants.engine import process
 from pants.engine.internals import graph
 from pants.engine.rules import QueryRule
-from pants.engine.target import GeneratedSources, HydratedSources, HydrateSourcesRequest
+from pants.engine.target import (
+    Dependencies,
+    GeneratedSources,
+    HydratedSources,
+    HydrateSourcesRequest,
+    InjectedDependencies,
+)
 from pants.source import source_root
-from pants.testutil.rule_runner import RuleRunner
+from pants.testutil.rule_runner import RuleRunner, engine_error
 
 
 @pytest.fixture
@@ -36,10 +51,11 @@ def rule_runner() -> RuleRunner:
             *graph.rules(),
             *stripped_source_files.rules(),
             *process.rules(),
+            *module_mapper.rules(),
             QueryRule(HydratedSources, [HydrateSourcesRequest]),
             QueryRule(GeneratedSources, [GeneratePythonFromThriftRequest]),
         ],
-        target_types=[ThriftSourcesGeneratorTarget],
+        target_types=[ThriftSourcesGeneratorTarget, PythonRequirementTarget],
     )
 
 
@@ -51,7 +67,11 @@ def assert_files_generated(
     source_roots: list[str],
     extra_args: list[str] | None = None,
 ) -> None:
-    args = [f"--source-root-patterns={repr(source_roots)}", *(extra_args or ())]
+    args = [
+        f"--source-root-patterns={repr(source_roots)}",
+        "--no-python-thrift-infer-runtime-dependency",
+        *(extra_args or ()),
+    ]
     rule_runner.set_options(args, env_inherit={"PATH", "PYENV_ROOT", "HOME"})
     tgt = rule_runner.get_target(address)
     thrift_sources = rule_runner.request(
@@ -158,3 +178,26 @@ def test_top_level_source_root(rule_runner: RuleRunner) -> None:
             "custom_namespace/module/ttypes.py",
         ],
     )
+
+
+def test_find_thrift_python_requirement(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files({"codegen/dir/f.thrift": "", "codegen/dir/BUILD": "thrift_sources()"})
+    thrift_tgt = rule_runner.get_target(Address("codegen/dir", relative_file_path="f.thrift"))
+    request = InjectApacheThriftPythonDependencies(thrift_tgt[Dependencies])
+
+    # Start with no relevant requirements.
+    with engine_error(MissingPythonCodegenRuntimeLibrary):
+        rule_runner.request(InjectedDependencies, [request])
+
+    # If exactly one, match it.
+    rule_runner.write_files({"reqs1/BUILD": "python_requirement(requirements=['thrift'])"})
+    assert rule_runner.request(InjectedDependencies, [request]) == InjectedDependencies(
+        [Address("reqs1")]
+    )
+
+    # If multiple, error.
+    rule_runner.write_files({"reqs2/BUILD": "python_requirement(requirements=['thrift'])"})
+    with engine_error(
+        AmbiguousPythonCodegenRuntimeLibrary, contains="['reqs1:reqs1', 'reqs2:reqs2']"
+    ):
+        rule_runner.request(InjectedDependencies, [request])

--- a/src/python/pants/backend/codegen/thrift/apache/python/subsystem.py
+++ b/src/python/pants/backend/codegen/thrift/apache/python/subsystem.py
@@ -1,10 +1,10 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 from __future__ import annotations
 
-from pants.engine.addresses import UnparsedAddressInputs
 from pants.engine.rules import collect_rules
-from pants.option.option_types import StrListOption, TargetListOption
+from pants.option.option_types import BoolOption, StrListOption
 from pants.option.subsystem import Subsystem
 
 
@@ -20,21 +20,16 @@ class ThriftPythonSubsystem(Subsystem):
             "See `thrift -help` for supported values."
         ),
     )
-    _runtime_dependencies = TargetListOption(
-        "--runtime-dependencies",
+    infer_runtime_dependency = BoolOption(
+        "--infer-runtime-dependency",
+        default=True,
         help=(
-            "A list of addresses to `python_requirement` targets for the runtime "
-            "dependencies needed for generated Python code to work. For example, "
-            "`['3rdparty/python:thrift']`. These dependencies will "
-            "be automatically added to every `thrift_source` target. At the very least, "
-            "this option must be set to a `python_requirement` for the "
-            "`thrift` runtime library."
+            "If True, will add a dependency on a `python_requirement` target exposing the `thrift` "
+            "module (usually from the `thrift` requirement).\n\n"
+            "Unless this option is disabled, will error if no relevant target is found or if >2 "
+            "is found which causes ambiguity."
         ),
-    )
-
-    @property
-    def runtime_dependencies(self) -> UnparsedAddressInputs:
-        return UnparsedAddressInputs(self._runtime_dependencies, owning_address=None)
+    ).advanced()
 
 
 def rules():

--- a/src/python/pants/backend/codegen/thrift/apache/python/subsystem.py
+++ b/src/python/pants/backend/codegen/thrift/apache/python/subsystem.py
@@ -26,8 +26,8 @@ class ThriftPythonSubsystem(Subsystem):
         help=(
             "If True, will add a dependency on a `python_requirement` target exposing the `thrift` "
             "module (usually from the `thrift` requirement).\n\n"
-            "Unless this option is disabled, will error if no relevant target is found or if >2 "
-            "is found which causes ambiguity."
+            "Unless this option is disabled, Pants will error if no relevant target is found or "
+            "more than one is found which causes ambiguity."
         ),
     ).advanced()
 

--- a/src/python/pants/backend/codegen/utils.py
+++ b/src/python/pants/backend/codegen/utils.py
@@ -19,7 +19,7 @@ class AmbiguousPythonCodegenRuntimeLibrary(Exception):
     pass
 
 
-def find_python_runtime_library_or_error(
+def find_python_runtime_library_or_raise_error(
     module_mapping: ThirdPartyPythonModuleMapping,
     codegen_address: Address,
     runtime_library_module: str,
@@ -38,8 +38,8 @@ def find_python_runtime_library_or_error(
 
     if not addresses:
         raise MissingPythonCodegenRuntimeLibrary(
-            f"No `python_requirement` found with the module `{runtime_library_module}` in your "
-            f"project, so the Python code generated from the target {codegen_address} will "
+            f"No `python_requirement` target was found with the module `{runtime_library_module}` "
+            f"in your project, so the Python code generated from the target {codegen_address} will "
             f"not work properly. See {doc_url('python-third-party-dependencies')} for how to "
             "add a requirement, such as adding to requirements.txt. Usually you will want to use "
             f"the `{recommended_requirement_name}` project at {recommended_requirement_url}.\n\n"
@@ -48,7 +48,7 @@ def find_python_runtime_library_or_error(
 
     if len(addresses) > 1:
         raise AmbiguousPythonCodegenRuntimeLibrary(
-            "Multiple `python_requirement` targets found with the module "
+            "Multiple `python_requirement` targets were found with the module "
             f"`{runtime_library_module}` in your project, so it is ambiguous which to use for the "
             f"runtime library for the Python code generated from the the target {codegen_address}: "
             f"{sorted(addr.spec for addr in addresses)}\n\n"

--- a/src/python/pants/backend/codegen/utils.py
+++ b/src/python/pants/backend/codegen/utils.py
@@ -1,0 +1,62 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from pants.backend.python.dependency_inference.module_mapper import (
+    ModuleProviderType,
+    ThirdPartyPythonModuleMapping,
+)
+from pants.engine.addresses import Address
+from pants.util.docutil import doc_url
+
+
+class MissingPythonCodegenRuntimeLibrary(Exception):
+    pass
+
+
+class AmbiguousPythonCodegenRuntimeLibrary(Exception):
+    pass
+
+
+def find_python_runtime_library_or_error(
+    module_mapping: ThirdPartyPythonModuleMapping,
+    codegen_address: Address,
+    runtime_library_module: str,
+    *,
+    recommended_requirement_name: str,
+    recommended_requirement_url: str,
+    disable_inference_option: str,
+) -> Address:
+    addresses = [
+        module_provider.addr
+        for module_provider in module_mapping.providers_for_module(
+            runtime_library_module, resolve=None
+        )
+        if module_provider.typ == ModuleProviderType.IMPL
+    ]
+
+    if not addresses:
+        raise MissingPythonCodegenRuntimeLibrary(
+            f"No `python_requirement` found with the module `{runtime_library_module}` in your "
+            f"project, so the Python code generated from the target {codegen_address} will "
+            f"not work properly. See {doc_url('python-third-party-dependencies')} for how to "
+            "add a requirement, such as adding to requirements.txt. Usually you will want to use "
+            f"the `{recommended_requirement_name}` project at {recommended_requirement_url}.\n\n"
+            f"To ignore this error, set `{disable_inference_option} = false` in `pants.toml`."
+        )
+
+    if len(addresses) > 1:
+        raise AmbiguousPythonCodegenRuntimeLibrary(
+            "Multiple `python_requirement` targets found with the module "
+            f"`{runtime_library_module}` in your project, so it is ambiguous which to use for the "
+            f"runtime library for the Python code generated from the the target {codegen_address}: "
+            f"{sorted(addr.spec for addr in addresses)}\n\n"
+            "To fix, remove one of these `python_requirement` targets so that there is no "
+            "ambiguity and Pants can infer a dependency. Alternatively, if you do want to have "
+            f"multiple conflicting versions of the `{runtime_library_module}` requirement, set "
+            f"`{disable_inference_option} = false` in `pants.toml`. "
+            f"Then manually add a dependency on the relevant `python_requirement` target to each "
+            "target that directly depends on this generated code (e.g. `python_source` targets)."
+        )
+    return addresses[0]

--- a/src/python/pants/backend/python/macros/deprecation_fixers.py
+++ b/src/python/pants/backend/python/macros/deprecation_fixers.py
@@ -219,7 +219,6 @@ async def maybe_warn_options_macro_references(
                 opt_to_renames[option].add((runtime_dep, new_addr))
 
     check(python_protobuf.runtime_dependencies, "[python-protobuf].runtime_dependencies")
-    check(python_thrift.runtime_dependencies, "[python-thrift].runtime_dependencies")
     check(flake8.source_plugins, "[flake8].source_plugins")
     check(pylint.source_plugins, "[pylint].source_plugins")
     check(mypy.source_plugins, "[mypy].source_plugins")

--- a/src/python/pants/backend/python/util_rules/python_sources_test.py
+++ b/src/python/pants/backend/python/util_rules/python_sources_test.py
@@ -15,6 +15,7 @@ from pants.backend.codegen.protobuf.python.python_protobuf_subsystem import (
 )
 from pants.backend.codegen.protobuf.python.rules import rules as protobuf_rules
 from pants.backend.codegen.protobuf.target_types import ProtobufSourceTarget
+from pants.backend.python.dependency_inference import module_mapper
 from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
@@ -46,6 +47,7 @@ def rule_runner() -> RuleRunner:
             *additional_fields.rules(),
             *protobuf_rules(),
             *protobuf_subsystem_rules(),
+            *module_mapper.rules(),
             QueryRule(PythonSourceFiles, [PythonSourceFilesRequest]),
             QueryRule(StrippedPythonSourceFiles, [PythonSourceFilesRequest]),
         ],
@@ -74,7 +76,11 @@ def get_stripped_sources(
     extra_args: list[str] | None = None,
 ) -> StrippedPythonSourceFiles:
     rule_runner.set_options(
-        [f"--source-root-patterns={source_roots or ['src/python']}", *(extra_args or [])],
+        [
+            f"--source-root-patterns={source_roots or ['src/python']}",
+            "--no-python-protobuf-infer-runtime-dependency",
+            *(extra_args or []),
+        ],
         env_inherit={"PATH", "PYENV_ROOT", "HOME"},
     )
     return rule_runner.request(
@@ -99,6 +105,7 @@ def get_unstripped_sources(
     rule_runner.set_options(
         [
             f"--source-root-patterns={source_roots or ['src/python']}",
+            "--no-python-protobuf-infer-runtime-dependency",
             *(extra_args or []),
         ],
         env_inherit={"PATH", "PYENV_ROOT", "HOME"},


### PR DESCRIPTION
@tdyas had the idea that rather than you having to tell Pants where to load `protobuf`, `grpcio`, and `thrift`, we can simply discover it! We do this for Scala already and it works well. 

There's minimal performance hit because we already will have created a third-party module mapping.

Two motivations:

1. Ergonomics.
2. Unblock codegen supporting multiple resolves: https://github.com/pantsbuild/pants/issues/14484. Otherwise we would need to add `[python-protobuf].runtime_dependencies_per_resolve`, which violates our goal for resolves to not make things more complex for the average user who only wants one resolve.

We deprecate Protobuf, but completely update Thrift since it hasn't reached stable yet.

[ci skip-rust]