### PR TITLE
[internal] Store `DigestTrie`s to local storage using batched writes

### DIFF
--- a/src/rust/engine/fs/src/directory.rs
+++ b/src/rust/engine/fs/src/directory.rs
@@ -180,6 +180,10 @@ impl Directory {
     }
   }
 
+  pub fn digest(&self) -> Digest {
+    self.digest
+  }
+
   pub fn as_remexec_directory(&self) -> remexec::Directory {
     self.tree.as_remexec_directory()
   }

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -271,7 +271,7 @@ impl Store {
   }
 
   ///
-  /// A convenience method for storing a file.
+  /// A convenience method for storing small files.
   ///
   /// NB: This method should not be used for large blobs: prefer to stream them from their source
   /// using `store_file`.
@@ -283,7 +283,7 @@ impl Store {
   ) -> Result<Digest, String> {
     self
       .local
-      .store_bytes(EntryType::File, bytes, initial_lease)
+      .store_bytes(EntryType::File, None, bytes, initial_lease)
       .await
   }
 
@@ -413,7 +413,12 @@ impl Store {
   ) -> Result<Digest, String> {
     let local = self.local.clone();
     local
-      .store_bytes(EntryType::Directory, directory.to_bytes(), initial_lease)
+      .store_bytes(
+        EntryType::Directory,
+        None,
+        directory.to_bytes(),
+        initial_lease,
+      )
       .await
   }
 
@@ -504,7 +509,7 @@ impl Store {
         match maybe_bytes {
           Some(bytes) => {
             let value = f_remote(bytes.clone())?;
-            let stored_digest = local.store_bytes(entry_type, bytes, true).await?;
+            let stored_digest = local.store_bytes(entry_type, None, bytes, true).await?;
             if digest == stored_digest {
               Ok(Some(value))
             } else {

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -33,7 +33,7 @@ mod snapshot_ops;
 mod snapshot_ops_tests;
 #[cfg(test)]
 mod snapshot_tests;
-pub use crate::snapshot_ops::{SnapshotOps, SnapshotOpsError, StoreWrapper, SubsetParams};
+pub use crate::snapshot_ops::{SnapshotOps, SnapshotOpsError, SubsetParams};
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Debug;
@@ -48,8 +48,8 @@ use async_oncecell::OnceCell;
 use async_trait::async_trait;
 use bytes::Bytes;
 use fs::{
-  default_cache_path, directory, DigestEntry, DigestTrie, DirectoryDigest, FileContent, FileEntry,
-  Permissions, RelativePath,
+  default_cache_path, directory, DigestEntry, DigestTrie, Dir, DirectoryDigest, File, FileContent,
+  FileEntry, PathStat, Permissions, RelativePath,
 };
 use futures::future::{self, BoxFuture, Either, FutureExt, TryFutureExt};
 use grpc_util::prost::MessageExt;
@@ -377,27 +377,26 @@ impl Store {
   ///
   /// Ensure that the recursive contents of the given DigestTrie are persisted in the local Store.
   ///
-  pub async fn record_digest_tree(
+  pub async fn record_digest_trie(
     &self,
     tree: DigestTrie,
     initial_lease: bool,
   ) -> Result<DirectoryDigest, String> {
+    // Collect all Directory structs in the trie.
     let mut directories = Vec::new();
-
-    // TODO: Use the Directory entry's recorded Digest, and execute a batch store rather than
-    // recomputing it via `record_directory`.
     tree.walk(&mut |_, entry| match entry {
-      directory::Entry::Directory(d) => directories.push(d.as_remexec_directory()),
+      directory::Entry::Directory(d) => {
+        directories.push((Some(d.digest()), d.as_remexec_directory().to_bytes()))
+      }
       directory::Entry::File(_) => (),
     });
 
-    let digests = future::try_join_all(
-      directories
-        .into_iter()
-        .map(|d| async move { self.record_directory(&d, initial_lease).await })
-        .collect::<Vec<_>>(),
-    )
-    .await?;
+    // Then store them as a batch.
+    let local = self.local.clone();
+    let digests = local
+      .store_bytes_batch(EntryType::Directory, directories, initial_lease)
+      .await?;
+
     Ok(DirectoryDigest::new(digests[0], tree))
   }
 
@@ -420,6 +419,60 @@ impl Store {
         initial_lease,
       )
       .await
+  }
+
+  ///
+  /// Loads a DigestTree from the local store, back-filling from remote if necessary.
+  ///
+  /// TODO: Add a native implementation that skips creating PathStats and directly produces
+  /// a DigestTrie.
+  ///
+  pub async fn load_digest_trie(&self, digest: DirectoryDigest) -> Result<DigestTrie, String> {
+    if let Some(tree) = digest.tree {
+      // The DigestTrie is already loaded.
+      return Ok(tree);
+    }
+
+    // The DigestTrie needs to be loaded from the Store.
+    let path_stats_per_directory = self
+      .walk(digest.as_digest(), |_, path_so_far, _, directory| {
+        let mut path_stats = Vec::new();
+        path_stats.extend(directory.directories.iter().map(move |dir_node| {
+          let path = path_so_far.join(dir_node.name.clone());
+          (PathStat::dir(path.clone(), Dir(path)), None)
+        }));
+        path_stats.extend(directory.files.iter().map(move |file_node| {
+          let path = path_so_far.join(file_node.name.clone());
+          (
+            PathStat::file(
+              path.clone(),
+              File {
+                path: path.clone(),
+                is_executable: file_node.is_executable,
+              },
+            ),
+            Some((path, file_node.digest.as_ref().unwrap().try_into().unwrap())),
+          )
+        }));
+        future::ok(path_stats).boxed()
+      })
+      .await?;
+
+    let (path_stats, maybe_digests): (Vec<_>, Vec<_>) =
+      Iterator::flatten(path_stats_per_directory.into_iter().map(Vec::into_iter)).unzip();
+    let file_digests = maybe_digests.into_iter().flatten().collect();
+
+    let tree = DigestTrie::from_path_stats(path_stats, &file_digests)?;
+    let computed_digest = tree.compute_root_digest();
+    if digest.as_digest() != computed_digest {
+      return Err(format!(
+        "Computed digest for Snapshot loaded from store mismatched: {:?} vs {:?}",
+        digest.as_digest(),
+        computed_digest
+      ));
+    }
+
+    Ok(tree)
   }
 
   ///
@@ -1297,21 +1350,29 @@ pub enum LocalMissingBehavior {
 }
 
 #[async_trait]
-impl StoreWrapper for Store {
+impl SnapshotOps for Store {
   async fn load_file_bytes_with<T: Send + 'static, F: Fn(&[u8]) -> T + Send + Sync + 'static>(
     &self,
     digest: Digest,
     f: F,
   ) -> Result<Option<T>, String> {
-    Ok(Store::load_file_bytes_with(self, digest, f).await?)
+    Store::load_file_bytes_with(self, digest, f).await
+  }
+
+  async fn load_digest_trie(&self, digest: DirectoryDigest) -> Result<DigestTrie, String> {
+    Store::load_digest_trie(self, digest).await
   }
 
   async fn load_directory(&self, digest: Digest) -> Result<Option<remexec::Directory>, String> {
-    Ok(Store::load_directory(self, digest).await?)
+    Store::load_directory(self, digest).await
   }
 
   async fn load_directory_or_err(&self, digest: Digest) -> Result<remexec::Directory, String> {
     Snapshot::get_directory_or_err(self.clone(), digest).await
+  }
+
+  async fn record_digest_trie(&self, tree: DigestTrie) -> Result<DirectoryDigest, String> {
+    Store::record_digest_trie(self, tree, true).await
   }
 
   async fn record_directory(&self, directory: &remexec::Directory) -> Result<Digest, String> {

--- a/src/rust/engine/fs/store/src/local.rs
+++ b/src/rust/engine/fs/store/src/local.rs
@@ -278,7 +278,6 @@ impl ByteStore {
   ///
   /// See also: `Self::store_bytes`.
   ///
-  #[allow(dead_code)]
   pub async fn store_bytes_batch(
     &self,
     entry_type: EntryType,

--- a/src/rust/engine/fs/store/src/local.rs
+++ b/src/rust/engine/fs/store/src/local.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::{self, Duration, Instant};
 
-use bytes::{Buf, Bytes};
+use bytes::Bytes;
 use futures::future;
 use hashing::{Digest, Fingerprint, EMPTY_DIGEST};
 use lmdb::Error::NotFound;
@@ -248,19 +248,77 @@ impl ByteStore {
     dbs?.remove(digest.hash).await
   }
 
+  ///
+  /// Store the given data in a single pass, optionally using the given Digest. Prefer `Self::store`
+  /// for values which should not be pulled into memory, and `Self::store_bytes_batch` when storing
+  /// multiple values at a time.
+  ///
   pub async fn store_bytes(
     &self,
     entry_type: EntryType,
+    digest: Option<Digest>,
     bytes: Bytes,
     initial_lease: bool,
   ) -> Result<Digest, String> {
-    self
-      .store(entry_type, initial_lease, true, move || {
-        Ok(bytes.clone().reader())
-      })
-      .await
+    let dbs = match entry_type {
+      EntryType::Directory => self.inner.directory_dbs.clone(),
+      EntryType::File => self.inner.file_dbs.clone(),
+    };
+    let len = bytes.len();
+    let fingerprint = dbs?
+      .store_bytes(digest.map(|d| d.hash), bytes, initial_lease)
+      .await?;
+
+    Ok(Digest::new(fingerprint, len))
   }
 
+  ///
+  /// Store the given items in a single pass, optionally using the given Digests. Prefer `Self::store`
+  /// for values which should not be pulled into memory.
+  ///
+  /// See also: `Self::store_bytes`.
+  ///
+  #[allow(dead_code)]
+  pub async fn store_bytes_batch(
+    &self,
+    entry_type: EntryType,
+    items: Vec<(Option<Digest>, Bytes)>,
+    initial_lease: bool,
+  ) -> Result<Vec<Digest>, String> {
+    let dbs = match entry_type {
+      EntryType::Directory => self.inner.directory_dbs.clone(),
+      EntryType::File => self.inner.file_dbs.clone(),
+    };
+    // NB: False positive: we do actually need to create the Vec here, since `items` will move
+    // before we use `lens`.
+    #[allow(clippy::needless_collect)]
+    let lens = items
+      .iter()
+      .map(|(_, bytes)| bytes.len())
+      .collect::<Vec<_>>();
+    let fingerprints = dbs?
+      .store_bytes_batch(
+        items
+          .into_iter()
+          .map(|(d, bytes)| (d.map(|d| d.hash), bytes))
+          .collect(),
+        initial_lease,
+      )
+      .await?;
+
+    Ok(
+      fingerprints
+        .into_iter()
+        .zip(lens.into_iter())
+        .map(|(f, len)| Digest::new(f, len))
+        .collect(),
+    )
+  }
+
+  ///
+  /// Store data in two passes, without buffering it entirely into memory. Prefer
+  /// `Self::store_bytes` for small values which fit comfortably in memory.
+  ///
   pub async fn store<F, R>(
     &self,
     entry_type: EntryType,

--- a/src/rust/engine/fs/store/src/tests.rs
+++ b/src/rust/engine/fs/store/src/tests.rs
@@ -106,7 +106,7 @@ async fn load_file_prefers_local() {
   let testdata = TestData::roland();
 
   crate::local_tests::new_store(dir.path())
-    .store_bytes(EntryType::File, testdata.bytes(), false)
+    .store_bytes(EntryType::File, None, testdata.bytes(), false)
     .await
     .expect("Store failed");
 
@@ -125,7 +125,7 @@ async fn load_directory_prefers_local() {
   let testdir = TestDirectory::containing_roland();
 
   crate::local_tests::new_store(dir.path())
-    .store_bytes(EntryType::Directory, testdir.bytes(), false)
+    .store_bytes(EntryType::Directory, None, testdir.bytes(), false)
     .await
     .expect("Store failed");
 

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -41,7 +41,7 @@ use prost::Message;
 use protos::gen::build::bazel::remote::execution::v2::{Action, Command};
 use protos::gen::buildbarn::cas::UncachedActionResult;
 use protos::require_digest;
-use store::{Store, StoreWrapper};
+use store::{SnapshotOps, Store};
 use structopt::StructOpt;
 use workunit_store::{in_workunit, WorkunitMetadata, WorkunitStore};
 

--- a/src/rust/engine/sharded_lmdb/src/tests.rs
+++ b/src/rust/engine/sharded_lmdb/src/tests.rs
@@ -32,7 +32,7 @@ async fn shard_counts() {
     let mut databases = HashMap::new();
     for prefix_byte in 0u8..=255u8 {
       *databases
-        .entry(s.get_raw(prefix_byte).0.clone())
+        .entry(s.get_raw(&[prefix_byte]).0.clone())
         .or_insert(0) += 1;
     }
     assert_eq!(databases.len(), shard_count as usize);


### PR DESCRIPTION
#13112 is porting more operations on `Digest`/`Snapshot` to use of `DigestTrie` in order to reduce IO by allowing them to operate entirely in memory.

When we have a `DigestTrie` in memory, we are able to persist all of its recursive `remexec::Directory` structures in parallel. To that end, this change adds batch persistence to the local LMDB store, which allows us to use a single context switch and write transaction (*per LMDB shard) to persist an entire `DigestTrie`.