### PR TITLE
[internal] Somewhat simplify config parsing

### DIFF
--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -17,7 +17,7 @@ from typing import Any
 from pants.base.build_environment import get_buildroot
 from pants.base.exiter import PANTS_SUCCEEDED_EXIT_CODE, ExitCode
 from pants.engine.internals import native_engine
-from pants.option.config import Config
+from pants.option.errors import ConfigValidationError
 from pants.option.options import Options
 from pants.option.options_fingerprinter import CoercingOptionEncoder
 from pants.option.scope import GLOBAL_SCOPE, GLOBAL_SCOPE_CONFIG_SECTION
@@ -231,7 +231,7 @@ class RunTracker:
                 return value
             else:
                 return value[option]
-        except (Config.ConfigValidationError, AttributeError) as e:
+        except (ConfigValidationError, AttributeError) as e:
             option_str = "" if option is None else f" option {option}"
             raise ValueError(
                 f"Couldn't find option scope {scope}{option_str} for recording ({e!r})"

--- a/src/python/pants/option/config_test.py
+++ b/src/python/pants/option/config_test.py
@@ -1,7 +1,6 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import configparser
 import unittest
 from dataclasses import dataclass
 from textwrap import dedent
@@ -11,6 +10,7 @@ import pytest
 
 from pants.engine.fs import FileContent
 from pants.option.config import Config, TomlSerializer
+from pants.option.errors import NoSectionError
 from pants.util.ordered_set import OrderedSet
 
 
@@ -194,7 +194,7 @@ class ConfigTest(unittest.TestCase):
             ]
         # Check non-existent section
         for config in file1_config, file2_config:
-            with pytest.raises(configparser.NoSectionError):
+            with pytest.raises(NoSectionError):
                 config.values.options("fake")
 
     def test_default_values(self) -> None:
@@ -228,14 +228,6 @@ class ConfigTest(unittest.TestCase):
             for option, default_value in FILE_1.default_values.items():
                 expected = default_value if option not in section_values else section_values[option]
                 assert self.config.get(section=section, option=option) == expected
-
-        def check_defaults(default: str) -> None:
-            assert self.config.get(section="c", option="fast") is None
-            assert self.config.get(section="c", option="preempt", default=None) is None
-            assert self.config.get(section="c", option="jake", default=default) == default
-
-        check_defaults("")
-        check_defaults("42")
 
     def test_empty(self) -> None:
         config = Config.load([])

--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -169,7 +169,10 @@ def _convert(val, acceptable_types):
     """
     if isinstance(val, acceptable_types):
         return val
-    return parse_expression(val, acceptable_types, raise_type=ParseError)
+    try:
+        return parse_expression(val, acceptable_types)
+    except ValueError as e:
+        raise ParseError(str(e)) from e
 
 
 def _convert_list(val, member_type, is_enum):

--- a/src/python/pants/option/errors.py
+++ b/src/python/pants/option/errors.py
@@ -121,3 +121,35 @@ class UnknownFlagsError(ParseError):
         scope = f"scope {self.arg_scope}" if self.arg_scope else "global scope"
         msg = f"Unknown flags {', '.join(self.flags)} on {scope}"
         super().__init__(msg)
+
+
+# -----------------------------------------------------------------------
+# Config parsing errors
+# -----------------------------------------------------------------------
+
+
+class ConfigError(OptionsError):
+    """An error encountered while parsing a config file."""
+
+
+class ConfigValidationError(ConfigError):
+    """A config file is invalid."""
+
+
+class NoSectionError(ConfigError):
+    def __init__(self, section: str):
+        super().__init__(f"No section: {section}")
+
+
+class NoOptionError(ConfigError):
+    def __init__(self, option: str, section: str):
+        super().__init__(f"No option {option} in section {section}")
+
+
+class InterpolationMissingOptionError(ConfigError):
+    def __init__(self, option, section, rawval, reference):
+        super().__init__(
+            self,
+            f"Bad value substitution: option {option} in section {section} contains an "
+            f"interpolation key {reference} which is not a valid option name. Raw value: {rawval}",
+        )

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -11,6 +11,7 @@ from pants.base.build_environment import get_buildroot
 from pants.base.deprecated import warn_or_error
 from pants.option.arg_splitter import ArgSplitter
 from pants.option.config import Config
+from pants.option.errors import ConfigValidationError
 from pants.option.option_util import is_list_option
 from pants.option.option_value_container import OptionValueContainer, OptionValueContainerBuilder
 from pants.option.parser import Parser
@@ -229,7 +230,7 @@ class Options:
                 try:
                     valid_options_under_scope = set(self.for_scope(scope, check_deprecations=False))
                 # Only catch ConfigValidationError. Other exceptions will be raised directly.
-                except Config.ConfigValidationError:
+                except ConfigValidationError:
                     error_log.append(f"Invalid scope [{section}] in {config.config_path}")
                 else:
                     # All the options specified under [`section`] in `config` excluding bootstrap defaults.
@@ -245,9 +246,9 @@ class Options:
         if error_log:
             for error in error_log:
                 logger.error(error)
-            raise Config.ConfigValidationError(
-                "Invalid config entries detected. See log for details on which entries to update or "
-                "remove.\n(Specify --no-verify-config to disable this check.)"
+            raise ConfigValidationError(
+                "Invalid config entries detected. See log for details on which entries to update "
+                "or remove.\n(Specify --no-verify-config to disable this check.)"
             )
 
     def is_known_scope(self, scope: str) -> bool:
@@ -283,7 +284,7 @@ class Options:
         try:
             return self._parser_by_scope[scope]
         except KeyError:
-            raise Config.ConfigValidationError(f"No such options scope: {scope}")
+            raise ConfigValidationError(f"No such options scope: {scope}")
 
     def _check_and_apply_deprecations(self, scope, values):
         """Checks whether a ScopeInfo has options specified in a deprecated scope.

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -585,10 +585,8 @@ class Parser:
         # Get value from config files, and capture details about its derivation.
         config_details = None
         config_section = GLOBAL_SCOPE_CONFIG_SECTION if self._scope == GLOBAL_SCOPE else self._scope
-        config_default_val_or_str = expand(
-            self._config.get(Config.DEFAULT_SECTION, dest, default=None)
-        )
-        config_val_or_str = expand(self._config.get(config_section, dest, default=None))
+        config_default_val_or_str = expand(self._config.get(Config.DEFAULT_SECTION, dest))
+        config_val_or_str = expand(self._config.get(config_section, dest))
         config_source_file = self._config.get_source_for_option(
             config_section, dest
         ) or self._config.get_source_for_option(Config.DEFAULT_SECTION, dest)

--- a/src/python/pants/util/eval.py
+++ b/src/python/pants/util/eval.py
@@ -8,10 +8,7 @@ from typing import Any
 
 
 def parse_expression(
-    val: str,
-    acceptable_types: type | tuple[type, ...],
-    name: str | None = None,
-    raise_type: type[BaseException] = ValueError,
+    val: str, acceptable_types: type | tuple[type, ...], name: str | None = None
 ) -> Any:
     """Attempts to parse the given `val` as a python expression of the specified `acceptable_types`.
 
@@ -19,7 +16,6 @@ def parse_expression(
     :param acceptable_types: The acceptable types of the parsed object.
     :param name: An optional logical name for the value being parsed; ie if the literal val
                         represents a person's age, 'age'.
-    :param raise_type: The type of exception to raise for all failures; ValueError by default.
     :raises: If `val` is not a valid python literal expression or it is but evaluates to an object
              that is not a an instance of one of the `acceptable_types`.
     """
@@ -28,7 +24,7 @@ def parse_expression(
         return typ.__name__
 
     if not isinstance(val, str):
-        raise raise_type(
+        raise ValueError(
             f"The raw `val` is not a str.  Given {val} of type {format_type(type(val))}."
         )
 
@@ -46,7 +42,7 @@ def parse_expression(
     try:
         parsed_value = eval(val)
     except Exception as e:
-        raise raise_type(
+        raise ValueError(
             dedent(
                 f"""\
                 The {get_name()} cannot be evaluated as a literal expression: {e!r}
@@ -70,7 +66,7 @@ def parse_expression(
                 )
 
         expected_types = ", ".join(format_type(t) for t in iter_types(acceptable_types))
-        raise raise_type(
+        raise ValueError(
             dedent(
                 f"""\
                 The {get_name()} is not of the expected type(s): {expected_types}:

--- a/src/python/pants/util/eval_test.py
+++ b/src/python/pants/util/eval_test.py
@@ -31,10 +31,3 @@ class TestParseLiteral:
         # Now we can safely assume the ValueError is raise due to type checking.
         with pytest.raises(ValueError):
             parse_expression("1.0", acceptable_types=int)
-
-    def test_custom_error_type(self) -> None:
-        class CustomError(Exception):
-            pass
-
-        with pytest.raises(CustomError):
-            parse_expression("1.0", acceptable_types=int, raise_type=CustomError)


### PR DESCRIPTION
- Simplify Config.get to always return a string.

  It was being used that way in practice everywhere within
  the options system (which does the type conversion later).

  The only place Config.get was used for type conversion was
  in the special case of cli.alias, which the options bootstrapper
  reads directly from config. So the conversion in that one
  case was inlined.

  As a byproduct, gets rid of the default= arg to Config.get,
  and always returns None if the value doesn't exist, since
  the default= arg was, again, only used in that one special case.

- Fix the type signature of get_value, which can never
  in fact return None.

- Use our own exception types and constants, instead of 
  borrowing the ones from configparser, now that ini parsing is 
  a distant memory.

This makes the Config class easier to reason about.

[ci skip-rust]

[ci skip-build-wheels]