### PR TITLE
[internal] Add plugin hook for Go codegen support

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/go/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/go/rules_integration_test.py
@@ -7,9 +7,10 @@ from typing import Iterable
 
 import pytest
 
-from pants.backend.codegen.protobuf.go.rules import GenerateGoFromProtobufRequest
+from pants.backend.codegen.protobuf.go.rules import _GeneratedGoFiles, _GeneratedGoFilesRequest
 from pants.backend.codegen.protobuf.go.rules import rules as go_protobuf_rules
 from pants.backend.codegen.protobuf.target_types import (
+    ProtobufGrpcToggleField,
     ProtobufSourceField,
     ProtobufSourcesGeneratorTarget,
 )
@@ -19,9 +20,9 @@ from pants.backend.go.util_rules import sdk
 from pants.build_graph.address import Address
 from pants.core.util_rules import config_files, source_files, stripped_source_files
 from pants.core.util_rules.external_tool import rules as external_tool_rules
-from pants.engine.fs import Digest, DigestContents
+from pants.engine.fs import Digest, DigestContents, Snapshot
 from pants.engine.rules import QueryRule
-from pants.engine.target import GeneratedSources, HydratedSources, HydrateSourcesRequest
+from pants.engine.target import HydratedSources, HydrateSourcesRequest
 from pants.jvm.jdk_rules import rules as jdk_rules
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, RuleRunner
 
@@ -39,7 +40,7 @@ def rule_runner() -> RuleRunner:
             *go_protobuf_rules(),
             *sdk.rules(),
             QueryRule(HydratedSources, [HydrateSourcesRequest]),
-            QueryRule(GeneratedSources, [GenerateGoFromProtobufRequest]),
+            QueryRule(_GeneratedGoFiles, [_GeneratedGoFilesRequest]),
             QueryRule(DigestContents, (Digest,)),
         ],
         target_types=[
@@ -65,14 +66,16 @@ def assert_files_generated(
     args = [f"--source-root-patterns={repr(source_roots)}", *extra_args]
     rule_runner.set_options(args, env_inherit=PYTHON_BOOTSTRAP_ENV)
     tgt = rule_runner.get_target(address)
-    protocol_sources = rule_runner.request(
-        HydratedSources, [HydrateSourcesRequest(tgt[ProtobufSourceField])]
-    )
     generated_sources = rule_runner.request(
-        GeneratedSources,
-        [GenerateGoFromProtobufRequest(protocol_sources.snapshot, tgt)],
+        _GeneratedGoFiles,
+        [
+            _GeneratedGoFilesRequest(
+                tgt[ProtobufSourceField], grpc=tgt[ProtobufGrpcToggleField].value
+            )
+        ],
     )
-    assert set(generated_sources.snapshot.files) == set(expected_files)
+    snapshot = rule_runner.request(Snapshot, [generated_sources.digest])
+    assert set(snapshot.files) == set(expected_files)
 
 
 def test_generates_go(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -121,6 +121,10 @@ async def setup_build_go_package_target_request(
         go_file_names = _third_party_pkg_info.go_files
         s_file_names = _third_party_pkg_info.s_files
 
+    # TODO(codegen): If the target can generate code, then apply it here.
+    elif False:
+        pass
+
     else:
         raise AssertionError(
             f"Unknown how to build `{target.alias}` target at address {request.address} with Go."
@@ -137,6 +141,7 @@ async def setup_build_go_package_target_request(
         if (
             tgt.has_field(GoPackageSourcesField)
             or tgt.has_field(GoThirdPartyPackageDependenciesField)
+            # TODO(codegen): or can generate
         )
     )
     direct_dependencies = []

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -97,7 +97,7 @@ def maybe_get_codegen_request_type(
     if len(relevant_requests) > 1:
         generate_from_sources = relevant_requests[0].generate_from.__name__
         raise AmbiguousCodegenImplementationsException(
-            f"Multiple of the registered code generators from {GoCodegenBuildRequest.__name__} can "
+            f"Multiple registered code generators from {GoCodegenBuildRequest.__name__} can "
             f"generate from {generate_from_sources}. It is ambiguous which implementation to "
             f"use.\n\n"
             f"Possible implementations:\n\n"

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import dataclasses
 from dataclasses import dataclass
-from typing import ClassVar, cast
+from typing import ClassVar, Type, cast
 
 from pants.backend.go.target_types import (
     GoImportPathField,
@@ -88,7 +88,7 @@ def maybe_get_codegen_request_type(
     if not tgt.has_field(SourcesField):
         return None
     generate_request_types = cast(
-        FrozenOrderedSet[type[GoCodegenBuildRequest]], union_membership.get(GoCodegenBuildRequest)
+        FrozenOrderedSet[Type[GoCodegenBuildRequest]], union_membership.get(GoCodegenBuildRequest)
     )
     sources_field = tgt[SourcesField]
     relevant_requests = [

--- a/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
@@ -32,40 +32,52 @@ from pants.backend.go.util_rules.build_pkg_target import (
     GoCodegenBuildRequest,
 )
 from pants.core.target_types import FileSourceField, FileTarget
-from pants.engine.addresses import Address
+from pants.engine.addresses import Address, Addresses
 from pants.engine.fs import CreateDigest, Digest, FileContent, Snapshot
 from pants.engine.rules import Get, QueryRule, rule
+from pants.engine.target import Dependencies, DependenciesRequest
 from pants.engine.unions import UnionRule
 from pants.testutil.rule_runner import RuleRunner
 from pants.util.strutil import path_safe
 
 
-# Set up a trivial codegen plugin.
+# Set up a semi-complex codegen plugin. Note that we cyclically call into the
+# `BuildGoPackageTargetRequest` rule to set up a dependency on a third-party package, as this
+# is common for codegen plugins to need to do.
 class GoCodegenBuildFilesRequest(GoCodegenBuildRequest):
     generate_from = FileSourceField
 
 
 @rule
-async def generate_from_file(_: GoCodegenBuildFilesRequest) -> BuildGoPackageRequest:
+async def generate_from_file(request: GoCodegenBuildFilesRequest) -> BuildGoPackageRequest:
     content = dedent(
         """\
         package gen
 
         import "fmt"
+        import "github.com/google/uuid"
 
         func Quote(s string) string {
+            uuid.SetClockSequence(-1)  // A trivial line to use uuid.
             return fmt.Sprintf(">> %s <<", s)
         }
         """
     )
     digest = await Get(Digest, CreateDigest([FileContent("codegen/f.go", content.encode())]))
+
+    deps = await Get(Addresses, DependenciesRequest(request.target[Dependencies]))
+    assert len(deps) == 1
+    assert deps[0].generated_name == "github.com/google/uuid"
+    thirdparty_dep = await Get(FallibleBuildGoPackageRequest, BuildGoPackageTargetRequest(deps[0]))
+    assert thirdparty_dep.request is not None
+
     return BuildGoPackageRequest(
         import_path="codegen.com/gen",
         digest=digest,
         dir_path="codegen",
         go_file_names=("f.go",),
         s_file_names=(),
-        direct_dependencies=(),
+        direct_dependencies=(thirdparty_dep.request,),
         minimum_go_version=None,
     )
 
@@ -399,6 +411,13 @@ def test_build_codegen_target(rule_runner: RuleRunner) -> None:
                 """\
                 module example.com/greeter
                 go 1.17
+                require github.com/google/uuid v1.3.0
+                """
+            ),
+            "go.sum": dedent(
+                """\
+                github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+                github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
                 """
             ),
             "generate_from_me.txt": "",
@@ -418,7 +437,11 @@ def test_build_codegen_target(rule_runner: RuleRunner) -> None:
                 """\
                 go_mod(name='mod')
                 go_package(name='pkg', dependencies=[":gen"])
-                file(name='gen', source='generate_from_me.txt')
+                file(
+                    name='gen',
+                    source='generate_from_me.txt',
+                    dependencies=[':mod#github.com/google/uuid'],
+                )
                 """
             ),
         }
@@ -431,7 +454,7 @@ def test_build_codegen_target(rule_runner: RuleRunner) -> None:
         expected_import_path="codegen.com/gen",
         expected_dir_path="codegen",
         expected_go_file_names=["f.go"],
-        expected_direct_dependency_import_paths=[],
+        expected_direct_dependency_import_paths=["github.com/google/uuid"],
         expected_transitive_dependency_import_paths=[],
     )
 
@@ -443,5 +466,5 @@ def test_build_codegen_target(rule_runner: RuleRunner) -> None:
         expected_dir_path="",
         expected_go_file_names=["greeter.go"],
         expected_direct_dependency_import_paths=["codegen.com/gen"],
-        expected_transitive_dependency_import_paths=[],
+        expected_transitive_dependency_import_paths=["github.com/google/uuid"],
     )

--- a/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
@@ -29,7 +29,7 @@ from pants.backend.go.util_rules.build_pkg import (
 )
 from pants.backend.go.util_rules.build_pkg_target import (
     BuildGoPackageTargetRequest,
-    GoCodegenRequest,
+    GoCodegenBuildRequest,
 )
 from pants.core.target_types import FileSourceField, FileTarget
 from pants.engine.addresses import Address
@@ -41,12 +41,12 @@ from pants.util.strutil import path_safe
 
 
 # Set up a trivial codegen plugin.
-class GoCodegenFilesRequest(GoCodegenRequest):
+class GoCodegenBuildFilesRequest(GoCodegenBuildRequest):
     generate_from = FileSourceField
 
 
 @rule
-async def generate_from_file(_: GoCodegenFilesRequest) -> BuildGoPackageRequest:
+async def generate_from_file(_: GoCodegenBuildFilesRequest) -> BuildGoPackageRequest:
     content = dedent(
         """\
         package gen
@@ -89,7 +89,7 @@ def rule_runner() -> RuleRunner:
             QueryRule(FallibleBuiltGoPackage, [BuildGoPackageRequest]),
             QueryRule(BuildGoPackageRequest, [BuildGoPackageTargetRequest]),
             QueryRule(FallibleBuildGoPackageRequest, [BuildGoPackageTargetRequest]),
-            UnionRule(GoCodegenRequest, GoCodegenFilesRequest),
+            UnionRule(GoCodegenBuildRequest, GoCodegenBuildFilesRequest),
         ],
         target_types=[GoModTarget, GoPackageTarget, FileTarget],
     )

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -826,12 +826,13 @@ class AmbiguousCodegenImplementationsException(Exception):
     """Exception for when there are multiple codegen implementations and it is ambiguous which to
     use."""
 
-    def __init__(
-        self,
+    @classmethod
+    def create(
+        cls,
         generators: Iterable[type[GenerateSourcesRequest]],
         *,
         for_sources_types: Iterable[type[SourcesField]],
-    ) -> None:
+    ) -> AmbiguousCodegenImplementationsException:
         all_same_generator_paths = (
             len({(generator.input, generator.output) for generator in generators}) == 1
         )
@@ -839,29 +840,28 @@ class AmbiguousCodegenImplementationsException(Exception):
         input = example_generator.input.__name__
         if all_same_generator_paths:
             output = example_generator.output.__name__
-            super().__init__(
+            return cls(
                 f"Multiple of the registered code generators can generate {output} from {input}. "
                 "It is ambiguous which implementation to use.\n\nPossible implementations:\n\n"
                 f"{bullet_list(sorted(generator.__name__ for generator in generators))}"
             )
-        else:
-            possible_output_types = sorted(
-                generator.output.__name__
-                for generator in generators
-                if issubclass(generator.output, tuple(for_sources_types))
-            )
-            possible_generators_with_output = [
-                f"{generator.__name__} -> {generator.output.__name__}"
-                for generator in sorted(generators, key=lambda generator: generator.output.__name__)
-            ]
-            super().__init__(
-                f"Multiple of the registered code generators can generate one of "
-                f"{possible_output_types} from {input}. It is ambiguous which implementation to "
-                f"use. This can happen when the call site requests too many different output types "
-                f"from the same original protocol sources.\n\nPossible implementations with their "
-                f"output type:\n\n"
-                f"{bullet_list(possible_generators_with_output)}"
-            )
+        possible_output_types = sorted(
+            generator.output.__name__
+            for generator in generators
+            if issubclass(generator.output, tuple(for_sources_types))
+        )
+        possible_generators_with_output = [
+            f"{generator.__name__} -> {generator.output.__name__}"
+            for generator in sorted(generators, key=lambda generator: generator.output.__name__)
+        ]
+        return cls(
+            f"Multiple of the registered code generators can generate one of "
+            f"{possible_output_types} from {input}. It is ambiguous which implementation to "
+            f"use. This can happen when the call site requests too many different output types "
+            f"from the same original protocol sources.\n\nPossible implementations with their "
+            f"output type:\n\n"
+            f"{bullet_list(possible_generators_with_output)}"
+        )
 
 
 @rule(desc="Hydrate the `sources` field")
@@ -884,7 +884,7 @@ async def hydrate_sources(
         and issubclass(generate_request_type.output, request.for_sources_types)
     ]
     if request.enable_codegen and len(relevant_generate_request_types) > 1:
-        raise AmbiguousCodegenImplementationsException(
+        raise AmbiguousCodegenImplementationsException.create(
             relevant_generate_request_types, for_sources_types=request.for_sources_types
         )
     generate_request_type = next(iter(relevant_generate_request_types), None)

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -841,7 +841,7 @@ class AmbiguousCodegenImplementationsException(Exception):
         if all_same_generator_paths:
             output = example_generator.output.__name__
             return cls(
-                f"Multiple of the registered code generators can generate {output} from {input}. "
+                f"Multiple registered code generators can generate {output} from {input}. "
                 "It is ambiguous which implementation to use.\n\nPossible implementations:\n\n"
                 f"{bullet_list(sorted(generator.__name__ for generator in generators))}"
             )
@@ -855,7 +855,7 @@ class AmbiguousCodegenImplementationsException(Exception):
             for generator in sorted(generators, key=lambda generator: generator.output.__name__)
         ]
         return cls(
-            f"Multiple of the registered code generators can generate one of "
+            f"Multiple registered code generators can generate one of "
             f"{possible_output_types} from {input}. It is ambiguous which implementation to "
             f"use. This can happen when the call site requests too many different output types "
             f"from the same original protocol sources.\n\nPossible implementations with their "

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -1726,7 +1726,7 @@ def test_ambiguous_codegen_implementations_exception() -> None:
         pass
 
     # Test when all generators have the same input and output.
-    exc = AmbiguousCodegenImplementationsException(
+    exc = AmbiguousCodegenImplementationsException.create(
         [SmalltalkGenerator1, SmalltalkGenerator2], for_sources_types=[SmalltalkSource]
     )
     assert "can generate SmalltalkSource from AvroSources" in str(exc)
@@ -1735,7 +1735,7 @@ def test_ambiguous_codegen_implementations_exception() -> None:
 
     # Test when the generators have different input and output, which usually happens because
     # the call site used too expansive of a `for_sources_types` argument.
-    exc = AmbiguousCodegenImplementationsException(
+    exc = AmbiguousCodegenImplementationsException.create(
         [SmalltalkGenerator1, AdaGenerator],
         for_sources_types=[SmalltalkSource, AdaSources, IrrelevantSources],
     )


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/14258. As described there, codegen for compiled languages is more complex because the generated code must be _compiled_, unlike Python where the code only needs to be present.

We still use the `GenerateSourcesRequest` plugin hook to generate the raw `.go` files and so that integrations like `export-codegen` goal still work. But that alone is not powerful enough to know how to compile the Go code. 

So, we add a new Go-specific plugin hook. Plugin implementations return back the standardized type `BuildGoPackageRequest`, which is all the information needed to compile a particular package, including by compiling its transitive dependencies. That allows for complex codegen modeling such as Protobuf needing the Protobuf third-party Go package compiled first, or Protobufs depending on other Protobufs.

Rule authors can then directly tell Pants to compile that codegen (https://github.com/pantsbuild/pants/issues/14705), or it can be loaded via a `dependency` on a normal `go_package`.