### PR TITLE
[internal] BSP: add basic java rules plus stub out more APIs

### DIFF
--- a/src/python/pants/backend/experimental/java/register.py
+++ b/src/python/pants/backend/experimental/java/register.py
@@ -21,6 +21,7 @@ from pants.jvm.package.war import rules as war_rules
 from pants.jvm.resolve import coursier_fetch, jvm_tool
 from pants.jvm.target_types import DeployJarTarget, JvmArtifactTarget, JvmWarTarget
 from pants.jvm.test import junit
+from pants.backend.java.bsp import rules as java_bsp_rules
 
 
 def target_types():
@@ -56,4 +57,5 @@ def rules():
         *jvm_tool.rules(),
         *run_deploy_jar.rules(),
         *war_rules(),
+        *java_bsp_rules.rules(),
     ]

--- a/src/python/pants/backend/experimental/java/register.py
+++ b/src/python/pants/backend/experimental/java/register.py
@@ -1,6 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from pants.backend.java.bsp import rules as java_bsp_rules
 from pants.backend.java.compile import javac
 from pants.backend.java.dependency_inference import java_parser, java_parser_launcher
 from pants.backend.java.dependency_inference import rules as dependency_inference_rules
@@ -21,7 +22,6 @@ from pants.jvm.package.war import rules as war_rules
 from pants.jvm.resolve import coursier_fetch, jvm_tool
 from pants.jvm.target_types import DeployJarTarget, JvmArtifactTarget, JvmWarTarget
 from pants.jvm.test import junit
-from pants.backend.java.bsp import rules as java_bsp_rules
 
 
 def target_types():

--- a/src/python/pants/backend/java/bsp/BUILD
+++ b/src/python/pants/backend/java/bsp/BUILD
@@ -1,0 +1,4 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_sources()

--- a/src/python/pants/backend/java/bsp/rules.py
+++ b/src/python/pants/backend/java/bsp/rules.py
@@ -1,0 +1,207 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import dataclasses
+import logging
+import os
+from dataclasses import dataclass
+
+from pants.backend.java.bsp.spec import JavacOptionsItem, JavacOptionsParams, JavacOptionsResult
+from pants.backend.java.dependency_inference.symbol_mapper import AllJavaTargets
+from pants.backend.java.target_types import JavaSourceField
+from pants.backend.scala.compile.scalac import compute_output_jar_filename
+from pants.base.build_root import BuildRoot
+from pants.bsp.context import BSPContext
+from pants.bsp.protocol import BSPHandlerMapping
+from pants.bsp.spec.base import (
+    BuildTarget,
+    BuildTargetCapabilities,
+    BuildTargetIdentifier,
+    StatusCode,
+)
+from pants.bsp.util_rules.compile import BSPCompileFieldSet, BSPCompileResult
+from pants.bsp.util_rules.lifecycle import BSPLanguageSupport
+from pants.bsp.util_rules.targets import BSPBuildTargets, BSPBuildTargetsRequest
+from pants.build_graph.address import AddressInput
+from pants.engine.addresses import Addresses
+from pants.engine.fs import CreateDigest, DigestEntries
+from pants.engine.internals.native_engine import EMPTY_DIGEST, AddPrefix, Digest
+from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.rules import collect_rules, rule
+from pants.engine.target import (
+    CoarsenedTargets,
+    Dependencies,
+    DependenciesRequest,
+    Target,
+    WrappedTarget,
+)
+from pants.engine.unions import UnionMembership, UnionRule
+from pants.jvm.bsp.spec import JvmBuildTarget
+from pants.jvm.compile import ClasspathEntryRequest, FallibleClasspathEntry
+from pants.jvm.resolve.key import CoursierResolveKey
+
+LANGUAGE_ID = "java"
+
+_logger = logging.getLogger(__name__)
+
+
+class JavaBSPLanguageSupport(BSPLanguageSupport):
+    language_id = LANGUAGE_ID
+    can_compile = True
+
+
+class JavaBSPBuildTargetsRequest(BSPBuildTargetsRequest):
+    pass
+
+
+@dataclass(frozen=True)
+class ResolveJavaBSPBuildTargetRequest:
+    target: Target
+
+
+@rule
+async def bsp_resolve_one_java_build_target(
+    request: ResolveJavaBSPBuildTargetRequest,
+) -> BuildTarget:
+    dep_addrs = await Get(Addresses, DependenciesRequest(request.target[Dependencies]))
+
+    return BuildTarget(
+        id=BuildTargetIdentifier.from_address(request.target.address),
+        display_name=str(request.target.address),
+        base_directory=None,
+        tags=(),
+        capabilities=BuildTargetCapabilities(
+            can_compile=True,
+        ),
+        language_ids=(LANGUAGE_ID,),
+        dependencies=tuple(BuildTargetIdentifier.from_address(dep_addr) for dep_addr in dep_addrs),
+        data_kind="jvm",
+        data=JvmBuildTarget(),
+    )
+
+
+@rule
+async def bsp_resolve_all_java_build_targets(
+    _: JavaBSPBuildTargetsRequest,
+    all_java_targets: AllJavaTargets,
+    bsp_context: BSPContext,
+) -> BSPBuildTargets:
+    if LANGUAGE_ID not in bsp_context.client_params.capabilities.language_ids:
+        return BSPBuildTargets()
+    build_targets = await MultiGet(
+        Get(BuildTarget, ResolveJavaBSPBuildTargetRequest(tgt)) for tgt in all_java_targets
+    )
+    return BSPBuildTargets(targets=tuple(build_targets))
+
+
+# -----------------------------------------------------------------------------------------------
+# Javac Options Request
+# See https://build-server-protocol.github.io/docs/extensions/java.html#javac-options-request
+# -----------------------------------------------------------------------------------------------
+
+
+class JavacOptionsHandlerMapping(BSPHandlerMapping):
+    method_name = "buildTarget/javacOptions"
+    request_type = JavacOptionsParams
+    response_type = JavacOptionsResult
+
+
+@dataclass(frozen=True)
+class HandleJavacOptionsRequest:
+    bsp_target_id: BuildTargetIdentifier
+
+
+@dataclass(frozen=True)
+class HandleScalacOptionsResult:
+    item: JavacOptionsItem
+
+
+@rule
+async def handle_bsp_scalac_options_request(
+    request: HandleJavacOptionsRequest,
+    build_root: BuildRoot,
+) -> HandleScalacOptionsResult:
+    wrapped_target = await Get(WrappedTarget, AddressInput, request.bsp_target_id.address_input)
+    coarsened_targets = await Get(CoarsenedTargets, Addresses([wrapped_target.target.address]))
+    assert len(coarsened_targets) == 1
+    coarsened_target = coarsened_targets[0]
+    resolve = await Get(CoursierResolveKey, CoarsenedTargets([coarsened_target]))
+    output_file = compute_output_jar_filename(coarsened_target)
+
+    return HandleScalacOptionsResult(
+        JavacOptionsItem(
+            target=request.bsp_target_id,
+            options=(),
+            classpath=(
+                build_root.pathlib_path.joinpath(
+                    f"bsp/jvm/resolves/{resolve.name}/lib/{output_file}"
+                ).as_uri(),
+            ),
+            class_directory=build_root.pathlib_path.joinpath(
+                f"bsp/jvm/resolves/{resolve}/classes"
+            ).as_uri(),
+        )
+    )
+
+
+@rule
+async def bsp_javac_options_request(request: JavacOptionsParams) -> JavacOptionsResult:
+    results = await MultiGet(
+        Get(HandleScalacOptionsResult, HandleJavacOptionsRequest(btgt)) for btgt in request.targets
+    )
+    return JavacOptionsResult(items=tuple(result.item for result in results))
+
+
+# -----------------------------------------------------------------------------------------------
+# Compile Request
+# -----------------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class JavaBSPCompileFieldSet(BSPCompileFieldSet):
+    required_fields = (JavaSourceField,)
+    source: JavaSourceField
+
+
+@rule
+async def bsp_java_compile_request(
+    request: JavaBSPCompileFieldSet,
+    union_membership: UnionMembership,
+) -> BSPCompileResult:
+    coarsened_targets = await Get(CoarsenedTargets, Addresses([request.source.address]))
+    assert len(coarsened_targets) == 1
+    coarsened_target = coarsened_targets[0]
+    resolve = await Get(CoursierResolveKey, CoarsenedTargets([coarsened_target]))
+
+    result = await Get(
+        FallibleClasspathEntry,
+        ClasspathEntryRequest,
+        ClasspathEntryRequest.for_targets(
+            union_membership, component=coarsened_target, resolve=resolve
+        ),
+    )
+    _logger.info(f"java compile result = {result}")
+    output_digest = EMPTY_DIGEST
+    if result.exit_code == 0 and result.output:
+        entries = await Get(DigestEntries, Digest, result.output.digest)
+        new_entires = [
+            dataclasses.replace(entry, path=os.path.basename(entry.path)) for entry in entries
+        ]
+        flat_digest = await Get(Digest, CreateDigest(new_entires))
+        output_digest = await Get(
+            Digest, AddPrefix(flat_digest, f"bsp/jvm/resolves/{resolve.name}/lib")
+        )
+
+    return BSPCompileResult(
+        status=StatusCode.ERROR if result.exit_code != 0 else StatusCode.OK,
+        output_digest=output_digest,
+    )
+
+
+def rules():
+    return (
+        *collect_rules(),
+        UnionRule(BSPLanguageSupport, JavaBSPLanguageSupport),
+        UnionRule(BSPBuildTargetsRequest, JavaBSPBuildTargetsRequest),
+        UnionRule(BSPHandlerMapping, JavacOptionsHandlerMapping),
+        UnionRule(BSPCompileFieldSet, JavaBSPCompileFieldSet),
+    )

--- a/src/python/pants/backend/java/bsp/rules.py
+++ b/src/python/pants/backend/java/bsp/rules.py
@@ -125,15 +125,15 @@ class HandleJavacOptionsRequest:
 
 
 @dataclass(frozen=True)
-class HandleScalacOptionsResult:
+class HandleJavacOptionsResult:
     item: JavacOptionsItem
 
 
 @rule
-async def handle_bsp_scalac_options_request(
+async def handle_bsp_java_options_request(
     request: HandleJavacOptionsRequest,
     build_root: BuildRoot,
-) -> HandleScalacOptionsResult:
+) -> HandleJavacOptionsResult:
     wrapped_target = await Get(WrappedTarget, AddressInput, request.bsp_target_id.address_input)
     coarsened_targets = await Get(CoarsenedTargets, Addresses([wrapped_target.target.address]))
     assert len(coarsened_targets) == 1
@@ -141,7 +141,7 @@ async def handle_bsp_scalac_options_request(
     resolve = await Get(CoursierResolveKey, CoarsenedTargets([coarsened_target]))
     output_file = compute_output_jar_filename(coarsened_target)
 
-    return HandleScalacOptionsResult(
+    return HandleJavacOptionsResult(
         JavacOptionsItem(
             target=request.bsp_target_id,
             options=(),
@@ -160,7 +160,7 @@ async def handle_bsp_scalac_options_request(
 @rule
 async def bsp_javac_options_request(request: JavacOptionsParams) -> JavacOptionsResult:
     results = await MultiGet(
-        Get(HandleScalacOptionsResult, HandleJavacOptionsRequest(btgt)) for btgt in request.targets
+        Get(HandleJavacOptionsResult, HandleJavacOptionsRequest(btgt)) for btgt in request.targets
     )
     return JavacOptionsResult(items=tuple(result.item for result in results))
 

--- a/src/python/pants/backend/java/bsp/rules.py
+++ b/src/python/pants/backend/java/bsp/rules.py
@@ -6,9 +6,9 @@ import os
 from dataclasses import dataclass
 
 from pants.backend.java.bsp.spec import JavacOptionsItem, JavacOptionsParams, JavacOptionsResult
+from pants.backend.java.compile.javac import compute_output_jar_filename
 from pants.backend.java.dependency_inference.symbol_mapper import AllJavaTargets
 from pants.backend.java.target_types import JavaSourceField
-from pants.backend.scala.compile.scalac import compute_output_jar_filename
 from pants.base.build_root import BuildRoot
 from pants.bsp.context import BSPContext
 from pants.bsp.protocol import BSPHandlerMapping
@@ -137,7 +137,7 @@ async def handle_bsp_scalac_options_request(
                 ).as_uri(),
             ),
             class_directory=build_root.pathlib_path.joinpath(
-                f".pants.d/bsp/jvm/resolves/{resolve}/classes"
+                f".pants.d/bsp/jvm/resolves/{resolve.name}/classes"
             ).as_uri(),
         )
     )

--- a/src/python/pants/backend/java/bsp/rules.py
+++ b/src/python/pants/backend/java/bsp/rules.py
@@ -133,11 +133,11 @@ async def handle_bsp_scalac_options_request(
             options=(),
             classpath=(
                 build_root.pathlib_path.joinpath(
-                    f"bsp/jvm/resolves/{resolve.name}/lib/{output_file}"
+                    f".pants.d/bsp/jvm/resolves/{resolve.name}/lib/{output_file}"
                 ).as_uri(),
             ),
             class_directory=build_root.pathlib_path.joinpath(
-                f"bsp/jvm/resolves/{resolve}/classes"
+                f".pants.d/bsp/jvm/resolves/{resolve}/classes"
             ).as_uri(),
         )
     )
@@ -188,7 +188,7 @@ async def bsp_java_compile_request(
         ]
         flat_digest = await Get(Digest, CreateDigest(new_entires))
         output_digest = await Get(
-            Digest, AddPrefix(flat_digest, f"bsp/jvm/resolves/{resolve.name}/lib")
+            Digest, AddPrefix(flat_digest, f"jvm/resolves/{resolve.name}/lib")
         )
 
     return BSPCompileResult(

--- a/src/python/pants/backend/java/bsp/spec.py
+++ b/src/python/pants/backend/java/bsp/spec.py
@@ -1,0 +1,62 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pants.bsp.spec.base import BuildTargetIdentifier, Uri
+
+# -----------------------------------------------------------------------------------------------
+# Javac Options Request
+# See https://build-server-protocol.github.io/docs/extensions/java.html#javac-options-request
+# -----------------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class JavacOptionsParams:
+    targets: tuple[BuildTargetIdentifier, ...]
+
+    @classmethod
+    def from_json_dict(cls, d):
+        return cls(
+            targets=tuple(BuildTargetIdentifier.from_json_dict(x) for x in d["targets"]),
+        )
+
+    def to_json_dict(self):
+        return {
+            "targets": [tgt.to_json_dict() for tgt in self.targets],
+        }
+
+
+@dataclass(frozen=True)
+class JavacOptionsItem:
+    target: BuildTargetIdentifier
+
+    # Additional arguments to the compiler.
+    # For example, -deprecation.
+    options: tuple[str, ...]
+
+    # The dependency classpath for this target, must be
+    # identical to what is passed as arguments to
+    # the -classpath flag in the command line interface
+    # of javac.
+    classpath: tuple[Uri, ...]
+
+    # The output directory for classfiles produced by this target
+    class_directory: Uri
+
+    def to_json_dict(self):
+        return {
+            "target": self.target.to_json_dict(),
+            "options": self.options,
+            "classpath": self.classpath,
+            "classDirectory": self.class_directory,
+        }
+
+
+@dataclass(frozen=True)
+class JavacOptionsResult:
+    items: tuple[JavacOptionsItem, ...]
+
+    def to_json_dict(self):
+        return {"items": [item.to_json_dict() for item in self.items]}

--- a/src/python/pants/backend/java/compile/javac.py
+++ b/src/python/pants/backend/java/compile/javac.py
@@ -42,7 +42,7 @@ class CompileJavaSourceRequest(ClasspathEntryRequest):
     field_sets = (JavaFieldSet, JavaGeneratorFieldSet)
 
 
-# TODO: This code is duplicated in the scalac and BSP rules.
+# TODO: This code is duplicated in the javac and BSP rules.
 def compute_output_jar_filename(ctgt: CoarsenedTarget) -> str:
     return f"{ctgt.representative.address.path_safe_spec}.javac.jar"
 

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -153,11 +153,11 @@ async def handle_bsp_scalac_options_request(
             options=(),
             classpath=(
                 build_root.pathlib_path.joinpath(
-                    f"bsp/jvm/resolves/{resolve.name}/lib/{output_file}"
+                    f".pants.d/bsp/jvm/resolves/{resolve.name}/lib/{output_file}"
                 ).as_uri(),
             ),
             class_directory=build_root.pathlib_path.joinpath(
-                f"bsp/jvm/resolves/{resolve}/classes"
+                f".pants.d/bsp/jvm/resolves/{resolve}/classes"
             ).as_uri(),
         )
     )
@@ -210,7 +210,7 @@ async def bsp_scala_compile_request(
         ]
         flat_digest = await Get(Digest, CreateDigest(new_entires))
         output_digest = await Get(
-            Digest, AddPrefix(flat_digest, f"bsp/jvm/resolves/{resolve.name}/lib")
+            Digest, AddPrefix(flat_digest, f"jvm/resolves/{resolve.name}/lib")
         )
 
     return BSPCompileResult(

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -28,7 +28,7 @@ from pants.bsp.spec.base import (
 from pants.bsp.util_rules.compile import BSPCompileFieldSet, BSPCompileResult
 from pants.bsp.util_rules.lifecycle import BSPLanguageSupport
 from pants.bsp.util_rules.targets import BSPBuildTargets, BSPBuildTargetsRequest
-from pants.build_graph.address import AddressInput, Address
+from pants.build_graph.address import Address, AddressInput
 from pants.core.util_rules.system_binaries import BashBinary, UnzipBinary
 from pants.engine.addresses import Addresses
 from pants.engine.fs import EMPTY_DIGEST, AddPrefix, CreateDigest, Digest, DigestEntries

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -157,7 +157,7 @@ async def handle_bsp_scalac_options_request(
                 ).as_uri(),
             ),
             class_directory=build_root.pathlib_path.joinpath(
-                f".pants.d/bsp/jvm/resolves/{resolve}/classes"
+                f".pants.d/bsp/jvm/resolves/{resolve.name}/classes"
             ).as_uri(),
         )
     )

--- a/src/python/pants/bsp/spec/targets.py
+++ b/src/python/pants/bsp/spec/targets.py
@@ -152,3 +152,71 @@ class DependencySourcesResult:
 
     def to_json_dict(self):
         return {"items": [item.to_json_dict() for item in self.items]}
+
+
+# -----------------------------------------------------------------------------------------------
+# Dependency Modules Request
+# See https://build-server-protocol.github.io/docs/specification.html#dependency-modules-request
+# -----------------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DependencyModulesParams:
+    targets: tuple[BuildTargetIdentifier, ...]
+
+    @classmethod
+    def from_json_dict(cls, d):
+        return cls(
+            targets=tuple(BuildTargetIdentifier.from_json_dict(x) for x in d["targets"]),
+        )
+
+    def to_json_dict(self):
+        return {
+            "targets": [tgt.to_json_dict() for tgt in self.targets],
+        }
+
+
+class DependencyModule:
+    # Module name
+    name: str
+
+    # Module version
+    version: str
+
+    # Kind of data to expect in the `data` field. If this field is not set, the kind of data is not specified.
+    data_kind: str | None
+
+    # Language-specific metadata about this module.
+    # See MavenDependencyModule as an example.
+    data: Any | None
+
+    def to_json_dict(self) -> dict[str, Any]:
+        result = {
+            "name": self.name,
+            "version": self.version,
+        }
+        if self.data_kind is not None:
+            result["dataKind"] = self.data_kind
+        if self.data is not None:
+            result["data"] = self.data.to_json_dict()
+        return result
+
+
+@dataclass(frozen=True)
+class DependencyModulesItem:
+    target: BuildTargetIdentifier
+    modules: tuple[DependencyModule, ...]
+
+    def to_json_dict(self) -> dict[str, Any]:
+        return {
+            "target": self.target.to_json_dict(),
+            "modules": [m.to_json_dict() for m in self.modules],
+        }
+
+
+@dataclass(frozen=True)
+class DependencyModulesResult:
+    items: tuple[DependencyModulesItem, ...]
+
+    def to_json_dict(self):
+        return {"items": [item.to_json_dict() for item in self.items]}

--- a/src/python/pants/bsp/spec/targets.py
+++ b/src/python/pants/bsp/spec/targets.py
@@ -107,3 +107,48 @@ class SourcesResult:
 
     def to_json_dict(self):
         return {"items": [item.to_json_dict() for item in self.items]}
+
+
+# -----------------------------------------------------------------------------------------------
+# Dependency Sources Request
+# See https://build-server-protocol.github.io/docs/specification.html#dependency-sources-request
+# -----------------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DependencySourcesParams:
+    targets: tuple[BuildTargetIdentifier, ...]
+
+    @classmethod
+    def from_json_dict(cls, d):
+        return cls(
+            targets=tuple(BuildTargetIdentifier.from_json_dict(x) for x in d["targets"]),
+        )
+
+    def to_json_dict(self):
+        return {
+            "targets": [tgt.to_json_dict() for tgt in self.targets],
+        }
+
+
+@dataclass(frozen=True)
+class DependencySourcesItem:
+    target: BuildTargetIdentifier
+    # List of resources containing source files of the
+    # target's dependencies.
+    # Can be source files, jar files, zip files, or directories.
+    sources: tuple[Uri, ...]
+
+    def to_json_dict(self) -> dict[str, Any]:
+        return {
+            "target": self.target.to_json_dict(),
+            "sources": self.sources,
+        }
+
+
+@dataclass(frozen=True)
+class DependencySourcesResult:
+    items: tuple[DependencySourcesItem, ...]
+
+    def to_json_dict(self):
+        return {"items": [item.to_json_dict() for item in self.items]}

--- a/src/python/pants/bsp/util_rules/lifecycle.py
+++ b/src/python/pants/bsp/util_rules/lifecycle.py
@@ -78,7 +78,7 @@ async def bsp_build_initialize(
             debug_provider=DebugProvider(language_ids=tuple(sorted(debug_provider_language_ids))),
             inverse_sources_provider=None,
             dependency_sources_provider=True,
-            dependency_modules_provider=None,
+            dependency_modules_provider=True,
             resources_provider=None,
             can_reload=None,
             build_target_changed_provider=None,

--- a/src/python/pants/bsp/util_rules/lifecycle.py
+++ b/src/python/pants/bsp/util_rules/lifecycle.py
@@ -77,7 +77,7 @@ async def bsp_build_initialize(
             run_provider=RunProvider(language_ids=tuple(sorted(run_provider_language_ids))),
             debug_provider=DebugProvider(language_ids=tuple(sorted(debug_provider_language_ids))),
             inverse_sources_provider=None,
-            dependency_sources_provider=None,
+            dependency_sources_provider=True,
             dependency_modules_provider=None,
             resources_provider=None,
             can_reload=None,

--- a/src/python/pants/bsp/util_rules/targets.py
+++ b/src/python/pants/bsp/util_rules/targets.py
@@ -8,6 +8,9 @@ from pants.base.build_root import BuildRoot
 from pants.bsp.protocol import BSPHandlerMapping
 from pants.bsp.spec.base import BuildTarget, BuildTargetIdentifier
 from pants.bsp.spec.targets import (
+    DependencySourcesItem,
+    DependencySourcesParams,
+    DependencySourcesResult,
     SourceItem,
     SourceItemKind,
     SourcesItem,
@@ -131,9 +134,29 @@ async def bsp_build_target_sources(request: SourcesParams) -> SourcesResult:
     return SourcesResult(items=tuple(si.sources_item for si in sources_items))
 
 
+# -----------------------------------------------------------------------------------------------
+# Dependency Sources Request
+# See https://build-server-protocol.github.io/docs/specification.html#dependency-sources-request
+# -----------------------------------------------------------------------------------------------
+
+
+class DependencySourcesHandlerMapping(BSPHandlerMapping):
+    method_name = "buildTarget/dependencySources"
+    request_type = DependencySourcesParams
+    response_type = DependencySourcesResult
+
+
+@rule
+async def bsp_dependency_sources(request: DependencySourcesParams) -> DependencySourcesResult:
+    return DependencySourcesResult(
+        tuple(DependencySourcesItem(target=tgt, sources=()) for tgt in request.targets)
+    )
+
+
 def rules():
     return (
         *collect_rules(),
         UnionRule(BSPHandlerMapping, WorkspaceBuildTargetsHandlerMapping),
         UnionRule(BSPHandlerMapping, BuildTargetSourcesHandlerMapping),
+        UnionRule(BSPHandlerMapping, DependencySourcesHandlerMapping),
     )

--- a/src/python/pants/bsp/util_rules/targets.py
+++ b/src/python/pants/bsp/util_rules/targets.py
@@ -8,6 +8,9 @@ from pants.base.build_root import BuildRoot
 from pants.bsp.protocol import BSPHandlerMapping
 from pants.bsp.spec.base import BuildTarget, BuildTargetIdentifier
 from pants.bsp.spec.targets import (
+    DependencyModulesItem,
+    DependencyModulesParams,
+    DependencyModulesResult,
     DependencySourcesItem,
     DependencySourcesParams,
     DependencySourcesResult,
@@ -153,10 +156,30 @@ async def bsp_dependency_sources(request: DependencySourcesParams) -> Dependency
     )
 
 
+# -----------------------------------------------------------------------------------------------
+# Dependency Modules Request
+# See https://build-server-protocol.github.io/docs/specification.html#dependency-modules-request
+# -----------------------------------------------------------------------------------------------
+
+
+class DependencyModulesHandlerMapping(BSPHandlerMapping):
+    method_name = "buildTarget/dependencyModules"
+    request_type = DependencyModulesParams
+    response_type = DependencyModulesResult
+
+
+@rule
+async def bsp_dependency_modules(request: DependencyModulesParams) -> DependencyModulesResult:
+    return DependencyModulesResult(
+        tuple(DependencyModulesItem(target=tgt, modules=()) for tgt in request.targets)
+    )
+
+
 def rules():
     return (
         *collect_rules(),
         UnionRule(BSPHandlerMapping, WorkspaceBuildTargetsHandlerMapping),
         UnionRule(BSPHandlerMapping, BuildTargetSourcesHandlerMapping),
         UnionRule(BSPHandlerMapping, DependencySourcesHandlerMapping),
+        UnionRule(BSPHandlerMapping, DependencyModulesHandlerMapping),
     )

--- a/src/python/pants/bsp/util_rules/targets.py
+++ b/src/python/pants/bsp/util_rules/targets.py
@@ -151,6 +151,7 @@ class DependencySourcesHandlerMapping(BSPHandlerMapping):
 
 @rule
 async def bsp_dependency_sources(request: DependencySourcesParams) -> DependencySourcesResult:
+    # TODO: This is a stub.
     return DependencySourcesResult(
         tuple(DependencySourcesItem(target=tgt, sources=()) for tgt in request.targets)
     )
@@ -170,6 +171,8 @@ class DependencyModulesHandlerMapping(BSPHandlerMapping):
 
 @rule
 async def bsp_dependency_modules(request: DependencyModulesParams) -> DependencyModulesResult:
+    # TODO: This is a stub.
+    # Note: VSCode expects this endpoint to exist even if the capability bit for it is set `false`.
     return DependencyModulesResult(
         tuple(DependencyModulesItem(target=tgt, modules=()) for tgt in request.targets)
     )


### PR DESCRIPTION
- Port the current Scala rules to setup basic Java BSP rules.
- Fix classpath returned from Scala and Java rules.
- Stub out "Dependency Sources Request"
- Stub out "Dependency Modules Request"