### PR TITLE
Rename `_python_requirements_file` target to `_generator_sources_helper`

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -20,7 +20,6 @@ from pants.backend.python.dependency_inference.rules import (
 from pants.backend.python.macros import python_requirements
 from pants.backend.python.macros.python_requirements import PythonRequirementsTargetGenerator
 from pants.backend.python.target_types import (
-    PythonRequirementsFileTarget,
     PythonRequirementTarget,
     PythonSourceField,
     PythonSourcesGeneratorTarget,
@@ -267,7 +266,6 @@ def test_infer_python_strict(caplog) -> None:
         target_types=[
             PythonSourcesGeneratorTarget,
             PythonRequirementTarget,
-            PythonRequirementsFileTarget,
             PythonRequirementsTargetGenerator,
         ],
     )

--- a/src/python/pants/backend/python/macros/deprecation_fixers.py
+++ b/src/python/pants/backend/python/macros/deprecation_fixers.py
@@ -12,7 +12,7 @@ from typing import DefaultDict
 
 from pants.backend.python.lint.flake8.subsystem import Flake8
 from pants.backend.python.lint.pylint.subsystem import Pylint
-from pants.backend.python.target_types import PythonRequirementsFileTarget, PythonRequirementTarget
+from pants.backend.python.target_types import PythonRequirementTarget
 from pants.backend.python.typecheck.mypy.subsystem import MyPy
 from pants.build_graph.address import AddressParseException, InvalidAddress
 from pants.core.goals.update_build_files import (
@@ -20,6 +20,10 @@ from pants.core.goals.update_build_files import (
     RewrittenBuildFile,
     RewrittenBuildFileRequest,
     UpdateBuildFilesSubsystem,
+)
+from pants.core.target_types import (
+    TargetGeneratorSourcesHelperSourcesField,
+    TargetGeneratorSourcesHelperTarget,
 )
 from pants.engine.addresses import (
     Address,
@@ -34,7 +38,6 @@ from pants.engine.target import (
     Dependencies,
     DependenciesRequest,
     ExplicitlyProvidedDependencies,
-    SingleSourceField,
     UnexpandedTargets,
 )
 from pants.engine.unions import UnionRule
@@ -102,12 +105,17 @@ async def determine_macro_changes(all_targets: AllTargets, _: MacroRenamesReques
         python_requirement_dependencies_fields, build_file_addresses_per_tgt, deps_per_tgt
     ):
         generator_tgt = next(
-            (tgt for tgt in deps if isinstance(tgt, PythonRequirementsFileTarget)), None
+            (tgt for tgt in deps if isinstance(tgt, TargetGeneratorSourcesHelperTarget)), None
         )
         if generator_tgt is None:
             continue
 
-        generator_source = generator_tgt[SingleSourceField].value
+        generator_sources = generator_tgt[TargetGeneratorSourcesHelperSourcesField].value
+        if not generator_sources or len(generator_sources) != 1:
+            continue
+        generator_source = generator_sources[0]
+        if "go." in generator_source:
+            continue
         if "Pipfile" in generator_source:
             generator_alias = "pipenv_requirements"
         elif "pyproject.toml" in generator_source:

--- a/src/python/pants/backend/python/macros/deprecation_fixers_test.py
+++ b/src/python/pants/backend/python/macros/deprecation_fixers_test.py
@@ -21,9 +21,9 @@ from pants.backend.python.macros.deprecation_fixers import (
 from pants.backend.python.macros.pipenv_requirements_caof import PipenvRequirementsCAOF
 from pants.backend.python.macros.poetry_requirements_caof import PoetryRequirementsCAOF
 from pants.backend.python.macros.python_requirements_caof import PythonRequirementsCAOF
-from pants.backend.python.target_types import PythonRequirementsFileTarget, PythonRequirementTarget
+from pants.backend.python.target_types import PythonRequirementTarget
 from pants.core.goals.update_build_files import RewrittenBuildFile
-from pants.core.target_types import GenericTarget
+from pants.core.target_types import GenericTarget, TargetGeneratorSourcesHelperTarget
 from pants.engine.addresses import Address
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 from pants.util.frozendict import FrozenDict
@@ -38,7 +38,7 @@ def rule_runner() -> RuleRunner:
             QueryRule(MacroRenames, [MacroRenamesRequest]),
             QueryRule(RewrittenBuildFile, [UpdatePythonMacrosRequest]),
         ),
-        target_types=[GenericTarget, PythonRequirementsFileTarget, PythonRequirementTarget],
+        target_types=[GenericTarget, TargetGeneratorSourcesHelperTarget, PythonRequirementTarget],
         context_aware_object_factories={
             "python_requirements": PythonRequirementsCAOF,
             "poetry_requirements": PoetryRequirementsCAOF,

--- a/src/python/pants/backend/python/macros/pipenv_requirements.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements.py
@@ -18,10 +18,12 @@ from pants.backend.python.target_types import (
     PythonRequirementModulesField,
     PythonRequirementResolveField,
     PythonRequirementsField,
-    PythonRequirementsFileSourcesField,
-    PythonRequirementsFileTarget,
     PythonRequirementTarget,
     PythonRequirementTypeStubModulesField,
+)
+from pants.core.target_types import (
+    TargetGeneratorSourcesHelperSourcesField,
+    TargetGeneratorSourcesHelperTarget,
 )
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents, GlobMatchErrorBehavior, PathGlobs
@@ -76,8 +78,8 @@ async def generate_from_pipenv_requirement(
         for k, v in request.require_unparametrized_overrides().items()
     }
 
-    file_tgt = PythonRequirementsFileTarget(
-        {PythonRequirementsFileSourcesField.alias: lock_rel_path},
+    file_tgt = TargetGeneratorSourcesHelperTarget(
+        {TargetGeneratorSourcesHelperSourcesField.alias: [lock_rel_path]},
         Address(
             generator.address.spec_path,
             target_name=generator.address.target_name,

--- a/src/python/pants/backend/python/macros/pipenv_requirements_caof.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements_caof.py
@@ -16,6 +16,7 @@ from pants.backend.python.macros.caof_utils import (
 from pants.backend.python.pip_requirement import PipRequirement
 from pants.backend.python.target_types import normalize_module_mapping
 from pants.base.build_environment import get_buildroot
+from pants.core.target_types import TargetGeneratorSourcesHelperTarget
 
 
 # TODO(#10655): add support for PEP 440 direct references (aka VCS style).
@@ -64,9 +65,9 @@ class PipenvRequirementsCAOF:
         else:
             requirements_file_target_name = source
             self._parse_context.create_object(
-                "_python_requirements_file",
+                TargetGeneratorSourcesHelperTarget.alias,
                 name=requirements_file_target_name,
-                source=source,
+                sources=[source],
             )
             requirements_dep = f":{requirements_file_target_name}"
 

--- a/src/python/pants/backend/python/macros/pipenv_requirements_caof_test.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements_caof_test.py
@@ -9,7 +9,8 @@ import pytest
 
 from pants.backend.python.macros.pipenv_requirements_caof import PipenvRequirementsCAOF
 from pants.backend.python.pip_requirement import PipRequirement
-from pants.backend.python.target_types import PythonRequirementsFileTarget, PythonRequirementTarget
+from pants.backend.python.target_types import PythonRequirementTarget
+from pants.core.target_types import TargetGeneratorSourcesHelperTarget
 from pants.engine.addresses import Address
 from pants.engine.target import AllTargets
 from pants.testutil.rule_runner import RuleRunner
@@ -18,7 +19,7 @@ from pants.testutil.rule_runner import RuleRunner
 @pytest.fixture
 def rule_runner() -> RuleRunner:
     return RuleRunner(
-        target_types=[PythonRequirementTarget, PythonRequirementsFileTarget],
+        target_types=[PythonRequirementTarget, TargetGeneratorSourcesHelperTarget],
         context_aware_object_factories={"pipenv_requirements": PipenvRequirementsCAOF},
         use_deprecated_python_macros=True,
     )
@@ -29,7 +30,7 @@ def assert_pipenv_requirements(
     build_file_entry: str,
     pipfile_lock: dict,
     *,
-    expected_file_dep: PythonRequirementsFileTarget,
+    expected_file_dep: TargetGeneratorSourcesHelperTarget,
     expected_targets: Iterable[PythonRequirementTarget],
     pipfile_lock_relpath: str = "Pipfile.lock",
 ) -> None:
@@ -54,8 +55,8 @@ def test_pipfile_lock(rule_runner: RuleRunner) -> None:
             "default": {"ansicolors": {"version": ">=1.18.0"}},
             "develop": {"cachetools": {"markers": "python_version ~= '3.5'", "version": "==4.1.1"}},
         },
-        expected_file_dep=PythonRequirementsFileTarget(
-            {"source": "Pipfile.lock"}, Address("", target_name="Pipfile.lock")
+        expected_file_dep=TargetGeneratorSourcesHelperTarget(
+            {"sources": ["Pipfile.lock"]}, Address("", target_name="Pipfile.lock")
         ),
         expected_targets=[
             PythonRequirementTarget(
@@ -94,8 +95,8 @@ def test_properly_creates_extras_requirements(rule_runner: RuleRunner) -> None:
                 }
             },
         },
-        expected_file_dep=PythonRequirementsFileTarget(
-            {"source": "Pipfile.lock"}, Address("", target_name="Pipfile.lock")
+        expected_file_dep=TargetGeneratorSourcesHelperTarget(
+            {"sources": ["Pipfile.lock"]}, Address("", target_name="Pipfile.lock")
         ),
         expected_targets=[
             PythonRequirementTarget(
@@ -131,15 +132,15 @@ def test_supply_python_requirements_file(rule_runner: RuleRunner) -> None:
                 pipfile_target='//:custom_pipfile_target'
             )
 
-            _python_requirements_file(
+            _target_generator_sources_helper(
                 name='custom_pipfile_target',
-                source='custom/pipfile/Pipfile.lock'
+                sources=['custom/pipfile/Pipfile.lock']
             )
             """
         ),
         {"default": {"ansicolors": {"version": ">=1.18.0"}}},
-        expected_file_dep=PythonRequirementsFileTarget(
-            {"source": "custom/pipfile/Pipfile.lock"},
+        expected_file_dep=TargetGeneratorSourcesHelperTarget(
+            {"sources": ["custom/pipfile/Pipfile.lock"]},
             Address("", target_name="custom_pipfile_target"),
         ),
         expected_targets=[

--- a/src/python/pants/backend/python/macros/pipenv_requirements_caof_test.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements_caof_test.py
@@ -132,7 +132,7 @@ def test_supply_python_requirements_file(rule_runner: RuleRunner) -> None:
                 pipfile_target='//:custom_pipfile_target'
             )
 
-            _target_generator_sources_helper(
+            _generator_sources_helper(
                 name='custom_pipfile_target',
                 sources=['custom/pipfile/Pipfile.lock']
             )

--- a/src/python/pants/backend/python/macros/pipenv_requirements_test.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements_test.py
@@ -9,7 +9,8 @@ import pytest
 
 from pants.backend.python.macros import pipenv_requirements
 from pants.backend.python.macros.pipenv_requirements import PipenvRequirementsTargetGenerator
-from pants.backend.python.target_types import PythonRequirementsFileTarget, PythonRequirementTarget
+from pants.backend.python.target_types import PythonRequirementTarget
+from pants.core.target_types import TargetGeneratorSourcesHelperTarget
 from pants.engine.addresses import Address
 from pants.engine.internals.graph import _TargetParametrizations
 from pants.engine.target import Target
@@ -78,6 +79,6 @@ def test_pipfile_lock(rule_runner: RuleRunner) -> None:
                 },
                 Address("", target_name="reqs", generated_name="cachetools"),
             ),
-            PythonRequirementsFileTarget({"source": "Pipfile.lock"}, file_addr),
+            TargetGeneratorSourcesHelperTarget({"sources": ["Pipfile.lock"]}, file_addr),
         },
     )

--- a/src/python/pants/backend/python/macros/poetry_requirements.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements.py
@@ -26,13 +26,15 @@ from pants.backend.python.target_types import (
     PythonRequirementModulesField,
     PythonRequirementResolveField,
     PythonRequirementsField,
-    PythonRequirementsFileSourcesField,
-    PythonRequirementsFileTarget,
     PythonRequirementTarget,
     PythonRequirementTypeStubModulesField,
 )
 from pants.base.build_root import BuildRoot
 from pants.base.parse_context import ParseContext
+from pants.core.target_types import (
+    TargetGeneratorSourcesHelperSourcesField,
+    TargetGeneratorSourcesHelperTarget,
+)
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents, GlobMatchErrorBehavior, PathGlobs
 from pants.engine.rules import Get, collect_rules, rule
@@ -426,8 +428,8 @@ async def generate_from_python_requirement(
         for k, v in request.require_unparametrized_overrides().items()
     }
 
-    file_tgt = PythonRequirementsFileTarget(
-        {PythonRequirementsFileSourcesField.alias: pyproject_rel_path},
+    file_tgt = TargetGeneratorSourcesHelperTarget(
+        {TargetGeneratorSourcesHelperSourcesField.alias: [pyproject_rel_path]},
         Address(
             generator.address.spec_path,
             target_name=generator.address.target_name,

--- a/src/python/pants/backend/python/macros/poetry_requirements_caof.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements_caof.py
@@ -14,6 +14,7 @@ from pants.backend.python.macros.caof_utils import (
 )
 from pants.backend.python.macros.poetry_requirements import PyProjectToml, parse_pyproject_toml
 from pants.backend.python.target_types import normalize_module_mapping
+from pants.core.target_types import TargetGeneratorSourcesHelperTarget
 
 
 class PoetryRequirementsCAOF:
@@ -67,9 +68,9 @@ class PoetryRequirementsCAOF:
             `modules=["django"]`.
         """
         req_file_tgt = self._parse_context.create_object(
-            "_python_requirements_file",
+            TargetGeneratorSourcesHelperTarget.alias,
             name=source.replace(os.path.sep, "_"),
-            source=source,
+            sources=[source],
         )
         requirements_dep = f":{req_file_tgt.name}"
 

--- a/src/python/pants/backend/python/macros/poetry_requirements_caof_test.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements_caof_test.py
@@ -10,7 +10,8 @@ import pytest
 
 from pants.backend.python.macros.poetry_requirements_caof import PoetryRequirementsCAOF
 from pants.backend.python.pip_requirement import PipRequirement
-from pants.backend.python.target_types import PythonRequirementsFileTarget, PythonRequirementTarget
+from pants.backend.python.target_types import PythonRequirementTarget
+from pants.core.target_types import TargetGeneratorSourcesHelperTarget
 from pants.engine.addresses import Address
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.target import AllTargets
@@ -20,7 +21,7 @@ from pants.testutil.rule_runner import RuleRunner
 @pytest.fixture
 def rule_runner() -> RuleRunner:
     return RuleRunner(
-        target_types=[PythonRequirementTarget, PythonRequirementsFileTarget],
+        target_types=[PythonRequirementTarget, TargetGeneratorSourcesHelperTarget],
         context_aware_object_factories={"poetry_requirements": PoetryRequirementsCAOF},
         use_deprecated_python_macros=True,
     )
@@ -31,7 +32,7 @@ def assert_poetry_requirements(
     build_file_entry: str,
     pyproject_toml: str,
     *,
-    expected_file_dep: PythonRequirementsFileTarget,
+    expected_file_dep: TargetGeneratorSourcesHelperTarget,
     expected_targets: Iterable[PythonRequirementTarget],
     pyproject_toml_relpath: str = "pyproject.toml",
 ) -> None:
@@ -68,8 +69,8 @@ def test_pyproject_toml(rule_runner: RuleRunner) -> None:
             ansicolors = ">=1.18.0"
             """
         ),
-        expected_file_dep=PythonRequirementsFileTarget(
-            {"source": "pyproject.toml"},
+        expected_file_dep=TargetGeneratorSourcesHelperTarget(
+            {"sources": ["pyproject.toml"]},
             address=Address("", target_name="pyproject.toml"),
         ),
         expected_targets=[
@@ -119,8 +120,8 @@ def test_source_override(rule_runner: RuleRunner) -> None:
             """
         ),
         pyproject_toml_relpath="subdir/pyproject.toml",
-        expected_file_dep=PythonRequirementsFileTarget(
-            {"source": "subdir/pyproject.toml"},
+        expected_file_dep=TargetGeneratorSourcesHelperTarget(
+            {"sources": ["subdir/pyproject.toml"]},
             address=Address("", target_name="subdir_pyproject.toml"),
         ),
         expected_targets=[
@@ -145,8 +146,8 @@ def test_non_pep440_error(rule_runner: RuleRunner, caplog: Any) -> None:
             foo = "~r62b"
             [tool.poetry.dev-dependencies]
             """,
-            expected_file_dep=PythonRequirementsFileTarget(
-                {"source": "pyproject.toml"},
+            expected_file_dep=TargetGeneratorSourcesHelperTarget(
+                {"sources": ["pyproject.toml"]},
                 address=Address("", target_name="pyproject.toml"),
             ),
             expected_targets=[],
@@ -162,8 +163,8 @@ def test_no_req_defined_warning(rule_runner: RuleRunner, caplog: Any) -> None:
         [tool.poetry.dependencies]
         [tool.poetry.dev-dependencies]
         """,
-        expected_file_dep=PythonRequirementsFileTarget(
-            {"source": "pyproject.toml"},
+        expected_file_dep=TargetGeneratorSourcesHelperTarget(
+            {"sources": ["pyproject.toml"]},
             address=Address("", target_name="pyproject.toml"),
         ),
         expected_targets=[],
@@ -181,8 +182,8 @@ def test_bad_dict_format(rule_runner: RuleRunner) -> None:
             foo = {bad_req = "test"}
             [tool.poetry.dev-dependencies]
             """,
-            expected_file_dep=PythonRequirementsFileTarget(
-                {"source": "pyproject.toml"},
+            expected_file_dep=TargetGeneratorSourcesHelperTarget(
+                {"sources": ["pyproject.toml"]},
                 address=Address("", target_name="pyproject.toml"),
             ),
             expected_targets=[],
@@ -200,8 +201,8 @@ def test_bad_req_type(rule_runner: RuleRunner) -> None:
             foo = 4
             [tool.poetry.dev-dependencies]
             """,
-            expected_file_dep=PythonRequirementsFileTarget(
-                {"source": "pyproject.toml"},
+            expected_file_dep=TargetGeneratorSourcesHelperTarget(
+                {"sources": ["pyproject.toml"]},
                 address=Address("", target_name="pyproject.toml"),
             ),
             expected_targets=[],
@@ -217,8 +218,8 @@ def test_no_tool_poetry(rule_runner: RuleRunner) -> None:
             """
             foo = 4
             """,
-            expected_file_dep=PythonRequirementsFileTarget(
-                {"source": "pyproject.toml"},
+            expected_file_dep=TargetGeneratorSourcesHelperTarget(
+                {"sources": ["pyproject.toml"]},
                 address=Address("", target_name="pyproject.toml"),
             ),
             expected_targets=[],

--- a/src/python/pants/backend/python/macros/poetry_requirements_test.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements_test.py
@@ -23,7 +23,8 @@ from pants.backend.python.macros.poetry_requirements import (
     parse_str_version,
 )
 from pants.backend.python.pip_requirement import PipRequirement
-from pants.backend.python.target_types import PythonRequirementsFileTarget, PythonRequirementTarget
+from pants.backend.python.target_types import PythonRequirementTarget
+from pants.core.target_types import TargetGeneratorSourcesHelperTarget
 from pants.engine.addresses import Address
 from pants.engine.internals.graph import _TargetParametrizations
 from pants.engine.target import Target
@@ -483,7 +484,7 @@ def test_pyproject_toml(rule_runner: RuleRunner) -> None:
                 },
                 address=Address("", target_name="reqs", generated_name="Un-Normalized-PROJECT"),
             ),
-            PythonRequirementsFileTarget({"source": "pyproject.toml"}, file_addr),
+            TargetGeneratorSourcesHelperTarget({"sources": ["pyproject.toml"]}, file_addr),
         },
     )
 
@@ -506,7 +507,7 @@ def test_source_override(rule_runner: RuleRunner) -> None:
                 {"dependencies": [file_addr.spec], "requirements": ["ansicolors>=1.18.0"]},
                 address=Address("", target_name="reqs", generated_name="ansicolors"),
             ),
-            PythonRequirementsFileTarget({"source": "subdir/pyproject.toml"}, file_addr),
+            TargetGeneratorSourcesHelperTarget({"sources": ["subdir/pyproject.toml"]}, file_addr),
         },
     )
 
@@ -534,8 +535,8 @@ def test_no_req_defined_warning(rule_runner: RuleRunner, caplog) -> None:
         [tool.poetry.dev-dependencies]
         """,
         expected_targets={
-            PythonRequirementsFileTarget(
-                {"source": "pyproject.toml"},
+            TargetGeneratorSourcesHelperTarget(
+                {"sources": ["pyproject.toml"]},
                 Address("", target_name="reqs", relative_file_path="pyproject.toml"),
             )
         },

--- a/src/python/pants/backend/python/macros/python_requirements.py
+++ b/src/python/pants/backend/python/macros/python_requirements.py
@@ -19,11 +19,13 @@ from pants.backend.python.target_types import (
     PythonRequirementModulesField,
     PythonRequirementResolveField,
     PythonRequirementsField,
-    PythonRequirementsFileSourcesField,
-    PythonRequirementsFileTarget,
     PythonRequirementTarget,
     PythonRequirementTypeStubModulesField,
     parse_requirements_file,
+)
+from pants.core.target_types import (
+    TargetGeneratorSourcesHelperSourcesField,
+    TargetGeneratorSourcesHelperTarget,
 )
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents, GlobMatchErrorBehavior, PathGlobs
@@ -83,8 +85,8 @@ async def generate_from_python_requirement(
         for k, v in request.require_unparametrized_overrides().items()
     }
 
-    file_tgt = PythonRequirementsFileTarget(
-        {PythonRequirementsFileSourcesField.alias: requirements_rel_path},
+    file_tgt = TargetGeneratorSourcesHelperTarget(
+        {TargetGeneratorSourcesHelperSourcesField.alias: [requirements_rel_path]},
         Address(
             generator.address.spec_path,
             target_name=generator.address.target_name,

--- a/src/python/pants/backend/python/macros/python_requirements_caof.py
+++ b/src/python/pants/backend/python/macros/python_requirements_caof.py
@@ -16,6 +16,7 @@ from pants.backend.python.macros.caof_utils import (
 )
 from pants.backend.python.target_types import normalize_module_mapping, parse_requirements_file
 from pants.base.build_environment import get_buildroot
+from pants.core.target_types import TargetGeneratorSourcesHelperTarget
 
 
 class PythonRequirementsCAOF:
@@ -68,9 +69,9 @@ class PythonRequirementsCAOF:
             `modules=["django"]`.
         """
         req_file_tgt = self._parse_context.create_object(
-            "_python_requirements_file",
+            TargetGeneratorSourcesHelperTarget.alias,
             name=source.replace(os.path.sep, "_"),
-            source=source,
+            sources=[source],
         )
         requirements_dep = f":{req_file_tgt.name}"
 

--- a/src/python/pants/backend/python/macros/python_requirements_test.py
+++ b/src/python/pants/backend/python/macros/python_requirements_test.py
@@ -9,7 +9,8 @@ import pytest
 
 from pants.backend.python.macros import python_requirements
 from pants.backend.python.macros.python_requirements import PythonRequirementsTargetGenerator
-from pants.backend.python.target_types import PythonRequirementsFileTarget, PythonRequirementTarget
+from pants.backend.python.target_types import PythonRequirementTarget
+from pants.core.target_types import TargetGeneratorSourcesHelperTarget
 from pants.engine.addresses import Address
 from pants.engine.internals.graph import _TargetParametrizations
 from pants.engine.target import Target
@@ -113,7 +114,7 @@ def test_requirements_txt(rule_runner: RuleRunner) -> None:
                 },
                 Address("", target_name="reqs", generated_name="pip"),
             ),
-            PythonRequirementsFileTarget({"source": "requirements.txt"}, file_addr),
+            TargetGeneratorSourcesHelperTarget({"sources": ["requirements.txt"]}, file_addr),
         },
     )
 
@@ -150,7 +151,7 @@ def test_multiple_versions(rule_runner: RuleRunner) -> None:
                 {"requirements": ["repletewateringcan>=7"], "dependencies": [file_addr.spec]},
                 Address("", target_name="reqs", generated_name="repletewateringcan"),
             ),
-            PythonRequirementsFileTarget({"source": "requirements.txt"}, file_addr),
+            TargetGeneratorSourcesHelperTarget({"sources": ["requirements.txt"]}, file_addr),
         },
     )
 
@@ -189,6 +190,6 @@ def test_source_override(rule_runner: RuleRunner) -> None:
                 {"requirements": ["ansicolors>=1.18.0"], "dependencies": [file_addr.spec]},
                 Address("", target_name="reqs", generated_name="ansicolors"),
             ),
-            PythonRequirementsFileTarget({"source": "subdir/requirements.txt"}, file_addr),
+            TargetGeneratorSourcesHelperTarget({"sources": ["subdir/requirements.txt"]}, file_addr),
         },
     )

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -37,7 +37,6 @@ from pants.backend.python.target_types import (
     PexBinariesGeneratorTarget,
     PexBinary,
     PythonDistribution,
-    PythonRequirementsFileTarget,
     PythonRequirementTarget,
     PythonSourcesGeneratorTarget,
     PythonSourceTarget,
@@ -55,6 +54,7 @@ from pants.backend.python.util_rules import (
     python_sources,
 )
 from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.core.target_types import TargetGeneratorSourcesHelperTarget
 
 
 def build_file_aliases():
@@ -105,7 +105,7 @@ def target_types():
         PexBinary,
         PexBinariesGeneratorTarget,
         PythonDistribution,
-        PythonRequirementsFileTarget,
+        TargetGeneratorSourcesHelperTarget,
         PythonRequirementTarget,
         PythonSourcesGeneratorTarget,
         PythonSourceTarget,

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -1034,11 +1034,6 @@ class PythonRequirementTarget(Target):
             )
 
 
-# -----------------------------------------------------------------------------------------------
-# `_python_requirements_file` target
-# -----------------------------------------------------------------------------------------------
-
-
 def parse_requirements_file(content: str, *, rel_path: str) -> Iterator[PipRequirement]:
     """Parse all `PipRequirement` objects from a requirements.txt-style file.
 
@@ -1057,21 +1052,6 @@ def parse_requirements_file(content: str, *, rel_path: str) -> Iterator[PipRequi
                     line, e, description_of_origin=f"{rel_path} at line {i + 1}"
                 )
             )
-
-
-class PythonRequirementsFileSourcesField(SingleSourceField):
-    uses_source_roots = False
-
-
-# This allows us to work around https://github.com/pantsbuild/pants/issues/13118. Because a
-# generated target does not depend on its target generator, `--changed-since --changed-dependees`
-# would not mark the generated targets as changing when the `requirements.txt` changes, even though
-# it may be impacted. Fixing that will be A Thing and requires design work, so instead we can
-# depend on this private target type that owns `requirements.txt` to get `--changed-since` working.
-class PythonRequirementsFileTarget(Target):
-    alias = "_python_requirements_file"
-    core_fields = (*COMMON_TARGET_FIELDS, PythonRequirementsFileSourcesField)
-    help = "A private helper target type used by `python_requirement` target generators."
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -1,5 +1,6 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
 
 from dataclasses import dataclass
 from textwrap import dedent
@@ -304,6 +305,34 @@ class GenericTarget(Target):
         'A generic target with no specific type.\n\nThis can be used as a generic "bag of '
         'dependencies", i.e. you can group several different targets into one single target so '
         "that your other targets only need to depend on one thing."
+    )
+
+
+# -----------------------------------------------------------------------------------------------
+# `_target_generator_sources_helper` target
+# -----------------------------------------------------------------------------------------------
+
+
+class TargetGeneratorSourcesHelperSourcesField(MultipleSourcesField):
+    uses_source_roots = False
+    required = True
+
+
+class TargetGeneratorSourcesHelperTarget(Target):
+    """Target generators that work by reading in some source file(s) should also generate this
+    target and add it as a dependency to every generated target so that `--changed-since` works
+    properly.
+
+    See https://github.com/pantsbuild/pants/issues/13118 for discussion of why this is necessary and
+    alternatives considered.
+    """
+
+    alias = "_target_generator_sources_helper"
+    core_fields = (*COMMON_TARGET_FIELDS, TargetGeneratorSourcesHelperSourcesField)
+    help = (
+        "A private helper target type used by some target generators.\n\n"
+        "This tracks their `sources` field so that `--changed-since --changed-dependees` works "
+        "properly for generated targets."
     )
 
 

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -327,7 +327,7 @@ class TargetGeneratorSourcesHelperTarget(Target):
     alternatives considered.
     """
 
-    alias = "_target_generator_sources_helper"
+    alias = "_generator_sources_helper"
     core_fields = (*COMMON_TARGET_FIELDS, TargetGeneratorSourcesHelperSourcesField)
     help = (
         "A private helper target type used by some target generators.\n\n"


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/13118 and https://github.com/pantsbuild/pants/issues/12953. 

Really that first ticket was about getting `--changed-since` to work properly for generated targets that depend on the contents of a source file like `go.mod` or `requirements.txt`. (Note that this is different than `python_sources` -> `python_source` etc, which don't actually consume the contents of their `sources` during generation.)

I originally hypothesized that to do that we would need to stop having target generators depend on generated targets. But that was a red herring.

Instead, the simplest solution is to lean into the fix we've used for Python since https://github.com/pantsbuild/pants/pull/9307: generate a distinct target type to "own" the generating sources. Then add a dependency on that target to all the other generated targets. This gives us the exact semantics we want! It's not the most elegant solution—e.g. boilerplate for rule authors—but it solves a real problem well.

[ci skip-rust]
[ci skip-build-wheels]