### PR TITLE
[internal] BSP: swap scala versions to conform to spec

### DIFF
--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -104,8 +104,8 @@ async def bsp_resolve_one_scala_build_target(
         data_kind="scala",
         data=ScalaBuildTarget(
             scala_organization="unknown",
-            scala_version=".".join(scala_version.split(".")[0:2]),
-            scala_binary_version=scala_version,
+            scala_version=scala_version,
+            scala_binary_version=".".join(scala_version.split(".")[0:2]),
             platform=ScalaPlatform.JVM,
             # TODO: These are the jars for the scalac tool.
             jars=(),


### PR DESCRIPTION
I had the Scala version fields reversed. Swap them so we actually follow the spec.

[ci skip-rust]

[ci skip-build-wheels]