### PR TITLE
[internal] BSP: hide bsp goal from help

### DIFF
--- a/src/python/pants/bsp/goal.py
+++ b/src/python/pants/bsp/goal.py
@@ -22,6 +22,10 @@ class BSPGoal(BuiltinGoal):
     name = "experimental-bsp"
     help = "Run server for Build Server Protocol (https://build-server-protocol.github.io/)."
 
+    @classmethod
+    def activated(cls, union_membership: UnionMembership) -> bool:
+        return False
+
     def run(
         self,
         *,


### PR DESCRIPTION
Hide the `experimental-bsp` goal from being included in `./pants help goals` output. It is still under development and exposing it in help would suggest it is usable.

[ci skip-rust]

[ci skip-build-wheels]