### PR TITLE
golang: fix regression in analysis code

### DIFF
--- a/src/python/pants/backend/go/go_sources/analyze_package/build_context.go
+++ b/src/python/pants/backend/go/go_sources/analyze_package/build_context.go
@@ -58,7 +58,8 @@ func matchTag(ctxt *build.Context, name string, allTags map[string]bool) bool {
 			return true
 		}
 	}
-	for _, tag := range ctxt.ToolTags {
+	toolTags := extractToolTags(ctxt)
+	for _, tag := range toolTags {
 		if tag == name {
 			return true
 		}

--- a/src/python/pants/backend/go/go_sources/analyze_package/tags.go
+++ b/src/python/pants/backend/go/go_sources/analyze_package/tags.go
@@ -1,0 +1,15 @@
+//go:build !go1.17
+
+/* Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package main
+
+import (
+	"go/build"
+)
+
+func extractToolTags(ctxt *build.Context) []string {
+	return nil
+}

--- a/src/python/pants/backend/go/go_sources/analyze_package/tags.go1.17.go
+++ b/src/python/pants/backend/go/go_sources/analyze_package/tags.go1.17.go
@@ -1,0 +1,15 @@
+//go:build go1.17
+
+/* Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package main
+
+import (
+	"go/build"
+)
+
+func extractToolTags(ctxt *build.Context) []string {
+	return ctxt.ToolTags
+}

--- a/src/python/pants/backend/go/util_rules/pkg_analyzer.py
+++ b/src/python/pants/backend/go/util_rules/pkg_analyzer.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 
 from pants.backend.go.go_sources import load_go_binary
 from pants.backend.go.go_sources.load_go_binary import LoadedGoBinary, LoadedGoBinaryRequest
+from pants.backend.go.subsystems.golang import GoRoot
 from pants.engine.fs import Digest
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
@@ -17,13 +18,21 @@ class PackageAnalyzerSetup:
 
 
 @rule
-async def setup_go_package_analyzer() -> PackageAnalyzerSetup:
+async def setup_go_package_analyzer(goroot: GoRoot) -> PackageAnalyzerSetup:
     binary_path = "./package_analyzer"
+    sources = (
+        "main.go",
+        "read.go",
+        "build_context.go",
+        "string_utils.go",
+        "syslist.go",
+        "tags.go1.17.go" if goroot.is_compatible_version("1.17") else "tags.go",
+    )
     binary = await Get(
         LoadedGoBinary,
         LoadedGoBinaryRequest(
             "analyze_package",
-            ("main.go", "read.go", "build_context.go", "string_utils.go", "syslist.go"),
+            sources,
             binary_path,
         ),
     )


### PR DESCRIPTION
As described in https://github.com/pantsbuild/pants/issues/14732, https://github.com/pantsbuild/pants/pull/14623 introduced a regression in the package analysis code for `go` versions earlier than v1.17 by using vendored analysis code from the `go` tool which only works on Go 1.17 and higher.

Solution: Split the problematic access to the `ToolTags` attribute to a separate file and conditionally compile a stub in its place on Go versions earlier than v1.17. (Go conditional compilation is file-based.)

Closes https://github.com/pantsbuild/pants/issues/14732.

[ci skip-rust]

[ci skip-build-wheels]