### PR TITLE
[internal] Fix Go codegen to work with target generators

### DIFF
--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -38,7 +38,7 @@ from pants.engine.target import (
     DependenciesRequest,
     SourcesField,
     Target,
-    UnexpandedTargets,
+    Targets,
     WrappedTarget,
 )
 from pants.engine.unions import UnionMembership, union
@@ -186,14 +186,12 @@ async def setup_build_go_package_target_request(
 
     else:
         raise AssertionError(
-            f"Unknown how to build `{target.alias}` target at address {request.address} with Go."
+            f"Unknown how to build `{target.alias}` target at address {request.address} with Go. "
             "Please open a bug at https://github.com/pantsbuild/pants/issues/new/choose with this "
             "message!"
         )
 
-    # TODO: If you use `Targets` here, then we replace the direct dep on the `go_mod` with all
-    #  of its generated targets...Figure this out.
-    all_deps = await Get(UnexpandedTargets, DependenciesRequest(target[Dependencies]))
+    all_deps = await Get(Targets, DependenciesRequest(target[Dependencies]))
     maybe_direct_dependencies = await MultiGet(
         Get(FallibleBuildGoPackageRequest, BuildGoPackageTargetRequest(tgt.address))
         for tgt in all_deps


### PR DESCRIPTION
We used to inject a dependency on the owning `go_mod` target for each `go_third_party_package`. That was causing our compilation code to think that each `go_third_party_package` dependend on _every single target_ generated by that `go_mod`, due to its alias mechanism, which causes issues.

As a result, when you explicitly depend on `protobuf_sources`, we don't replace that with each generated `protobuf_source` target.

Turns out we removed the problematic dependency injection a while ago! So we can fix this easily to properly expand aliases. 

[ci skip-rust]
[ci skip-build-wheels]