### PR TITLE
[internal] Store `Value`s and `DirectoryDigest`s as boxed references in the workunit store.

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -851,6 +851,7 @@ dependencies = [
  "tempfile",
  "testutil",
  "tokio",
+ "workunit_store",
 ]
 
 [[package]]
@@ -3977,7 +3978,6 @@ dependencies = [
  "strum",
  "strum_macros",
  "tokio",
- "uuid",
 ]
 
 [[package]]

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -26,6 +26,7 @@ protos = { path = "../protos" }
 rlimit = "0.3"
 serde = "1.0.104"
 task_executor = { path = "../task_executor" }
+workunit_store = { path = "../workunit_store" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/rust/engine/fs/src/directory.rs
+++ b/src/rust/engine/fs/src/directory.rs
@@ -42,6 +42,12 @@ pub struct DirectoryDigest {
   pub tree: Option<DigestTrie>,
 }
 
+impl workunit_store::DirectoryDigest for DirectoryDigest {
+  fn as_any(&self) -> &dyn std::any::Any {
+    self
+  }
+}
+
 impl Eq for DirectoryDigest {}
 
 impl PartialEq for DirectoryDigest {

--- a/src/rust/engine/src/externs/engine_aware.rs
+++ b/src/rust/engine/src/externs/engine_aware.rs
@@ -1,16 +1,17 @@
 // Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-use crate::context::Context;
-use crate::externs;
-use crate::nodes::{lift_directory_digest, lift_file_digest};
+use std::sync::Arc;
 
+use crate::externs;
 use crate::externs::fs::PyFileDigest;
+use crate::nodes::{lift_directory_digest, lift_file_digest};
+use crate::Value;
+
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
-use workunit_store::{
-  ArtifactOutput, Level, RunningWorkunit, UserMetadataItem, UserMetadataPyValue,
-};
+
+use workunit_store::{ArtifactOutput, Level, RunningWorkunit, UserMetadataItem};
 
 // Note: these functions should not panic, but we also don't preserve errors (e.g. to log) because
 // we rely on MyPy to catch TypeErrors with using the APIs incorrectly. So we convert errors to
@@ -25,12 +26,12 @@ pub(crate) struct EngineAwareReturnType {
 }
 
 impl EngineAwareReturnType {
-  pub(crate) fn from_task_result(task_result: &PyAny, context: &Context) -> Self {
+  pub(crate) fn from_task_result(task_result: &PyAny) -> Self {
     Self {
       level: Self::level(task_result),
       message: Self::message(task_result),
       artifacts: Self::artifacts(task_result).unwrap_or_else(Vec::new),
-      metadata: metadata(context, task_result).unwrap_or_else(Vec::new),
+      metadata: metadata(task_result).unwrap_or_else(Vec::new),
     }
   }
 
@@ -77,7 +78,7 @@ impl EngineAwareReturnType {
         lift_file_digest(value).map(ArtifactOutput::FileDigest)
       } else {
         let digest_value = value.getattr("digest").ok()?;
-        lift_directory_digest(digest_value).map(|dd| ArtifactOutput::Snapshot(dd.todo_as_digest()))
+        lift_directory_digest(digest_value).map(|dd| ArtifactOutput::Snapshot(Arc::new(dd)))
       }
       .ok()?;
       output.push((key, artifact_output));
@@ -101,12 +102,12 @@ impl EngineAwareParameter {
     hint.extract().ok()
   }
 
-  pub fn metadata(context: &Context, obj: &PyAny) -> Vec<(String, UserMetadataItem)> {
-    metadata(context, obj).unwrap_or_else(Vec::new)
+  pub fn metadata(obj: &PyAny) -> Vec<(String, UserMetadataItem)> {
+    metadata(obj).unwrap_or_else(Vec::new)
   }
 }
 
-fn metadata(context: &Context, obj: &PyAny) -> Option<Vec<(String, UserMetadataItem)>> {
+fn metadata(obj: &PyAny) -> Option<Vec<(String, UserMetadataItem)>> {
   let metadata_val = obj.call_method0("metadata").ok()?;
   if metadata_val.is_none() {
     return None;
@@ -116,13 +117,9 @@ fn metadata(context: &Context, obj: &PyAny) -> Option<Vec<(String, UserMetadataI
   let metadata_dict = metadata_val.cast_as::<PyDict>().ok()?;
 
   for kv_pair in metadata_dict.items().into_iter() {
-    let (key, value): (String, &PyAny) = kv_pair.extract().ok()?;
-    let py_value_handle = UserMetadataPyValue::new();
-    let umi = UserMetadataItem::PyValue(py_value_handle.clone());
-    context.session.with_metadata_map(|map| {
-      map.insert(py_value_handle.clone(), value.into());
-    });
-    output.push((key, umi));
+    let (key, py_any): (String, &PyAny) = kv_pair.extract().ok()?;
+    let value: Value = Value::new(py_any.into());
+    output.push((key, UserMetadataItem::PyValue(Arc::new(value))));
   }
   Some(output)
 }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1192,7 +1192,7 @@ impl WrappedNode for Task {
     let engine_aware_return_type = if self.task.engine_aware_return_type {
       let gil = Python::acquire_gil();
       let py = gil.python();
-      EngineAwareReturnType::from_task_result((*result_val).as_ref(py), &context)
+      EngineAwareReturnType::from_task_result((*result_val).as_ref(py))
     } else {
       EngineAwareReturnType::default()
     };
@@ -1397,7 +1397,7 @@ impl Node for NodeKey {
       let py = gil.python();
       engine_aware_params
         .iter()
-        .flat_map(|val| EngineAwareParameter::metadata(&context, (**val).as_ref(py)))
+        .flat_map(|val| EngineAwareParameter::metadata((**val).as_ref(py)))
         .collect()
     };
 

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -273,8 +273,8 @@ impl Key {
 pub struct Value(Arc<PyObject>);
 
 // NB: The size of objects held by a Graph is tracked independently, so we assert that each Value
-// is only as large as its pointers.
-known_deep_size!(8 * 3; Value);
+// is only as large as its pointer.
+known_deep_size!(8; Value);
 
 impl Value {
   pub fn new(obj: PyObject) -> Value {
@@ -287,6 +287,12 @@ impl Value {
       Ok(obj) => obj,
       Err(arc_handle) => arc_handle.clone_ref(py),
     }
+  }
+}
+
+impl workunit_store::Value for Value {
+  fn as_any(&self) -> &dyn std::any::Any {
+    self
   }
 }
 

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -19,4 +19,3 @@ rand = "0.8"
 strum = "0.20"
 strum_macros = "0.23"
 tokio = { version = "1.16", features = ["rt"] }
-uuid = { version = "0.8", features = ["v4"] }

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -224,7 +224,6 @@ impl Default for WorkunitMetadata {
 /// Abstract id for passing user metadata items around
 #[derive(Clone, Debug)]
 pub enum UserMetadataItem {
-  // NB: Always stores a ...
   PyValue(Arc<dyn Value>),
   ImmediateInt(i64),
   ImmediateString(String),


### PR DESCRIPTION
To avoid cycles between the `workunit_store` crate and the `engine` and `fs` crates, `UserMetadataItem::PyValue` and `ArtifactOutput::Snapshot` both used indirection.

But in #14723, `ArtifactOutput::Snapshot` storing a `hashing::Digest` will no longer be a sufficient replacement for storing a `fs::DirectoryDigest`, because we no longer guarantee that all (directory) `Digest`s have actually been persisted to disk: some of them exist only in memory as `DigestTrie`s held by `DirectoryDigest`s. And we don't want to introduce a cycle between `fs` and the `workunit_store` crate.

To fix both cases, we use a `Box`ed `Any` (technically, `Arc`ed, since we need `Clone`), and downcast to the underlying type at the consume side.