### PR TITLE
[internal] BSP: progress on third-party deps

### DIFF
--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -47,7 +47,6 @@ from pants.jvm.compile import (
     ClasspathEntryRequestFactory,
     FallibleClasspathEntry,
 )
-from pants.jvm.compile import ClasspathEntryRequest, FallibleClasspathEntry
 from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.jvm.resolve.key import CoursierResolveKey

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -31,6 +31,7 @@ from pants.bsp.util_rules.targets import BSPBuildTargets, BSPBuildTargetsRequest
 from pants.build_graph.address import Address, AddressInput
 from pants.engine.addresses import Addresses
 from pants.engine.fs import EMPTY_DIGEST, AddPrefix, CreateDigest, Digest, DigestEntries
+from pants.engine.internals.native_engine import MergeDigests, Snapshot
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import (
@@ -46,6 +47,9 @@ from pants.jvm.compile import (
     ClasspathEntryRequestFactory,
     FallibleClasspathEntry,
 )
+from pants.jvm.compile import ClasspathEntryRequest, FallibleClasspathEntry
+from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
+from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.jvm.resolve.key import CoursierResolveKey
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
@@ -69,17 +73,69 @@ class ResolveScalaBSPBuildTargetRequest:
     target: Target
 
 
+@dataclass(frozen=True)
+class ResolveScalaBSPBuildTargetResult:
+    build_target: BuildTarget
+    scala_runtime: Snapshot
+
+
+@dataclass(frozen=True)
+class MaterializeScalaRuntimeJarsRequest:
+    scala_version: str
+
+
+@dataclass(frozen=True)
+class MaterializeScalaRuntimeJarsResult:
+    content: Snapshot
+
+
+@rule
+async def materialize_scala_runtime_jars(
+    request: MaterializeScalaRuntimeJarsRequest,
+) -> MaterializeScalaRuntimeJarsResult:
+    tool_classpath = await Get(
+        ToolClasspath,
+        ToolClasspathRequest(
+            artifact_requirements=ArtifactRequirements.from_coordinates(
+                [
+                    Coordinate(
+                        group="org.scala-lang",
+                        artifact="scala-compiler",
+                        version=request.scala_version,
+                    ),
+                    Coordinate(
+                        group="org.scala-lang",
+                        artifact="scala-library",
+                        version=request.scala_version,
+                    ),
+                ]
+            ),
+        ),
+    )
+
+    materialized_classpath_digest = await Get(
+        Digest,
+        AddPrefix(tool_classpath.content.digest, f"jvm/scala-runtime/{request.scala_version}"),
+    )
+    materialized_classpath = await Get(Snapshot, Digest, materialized_classpath_digest)
+    return MaterializeScalaRuntimeJarsResult(materialized_classpath)
+
+
 @rule
 async def bsp_resolve_one_scala_build_target(
     request: ResolveScalaBSPBuildTargetRequest,
     jvm: JvmSubsystem,
     scala: ScalaSubsystem,
     union_membership: UnionMembership,
-) -> BuildTarget:
+    build_root: BuildRoot,
+) -> ResolveScalaBSPBuildTargetResult:
     resolve = request.target[JvmResolveField].normalized_value(jvm)
     scala_version = scala.version_for_resolve(resolve)
 
-    dep_addrs = await Get(Addresses, DependenciesRequest(request.target[Dependencies]))
+    dep_addrs, scala_runtime = await MultiGet(
+        Get(Addresses, DependenciesRequest(request.target[Dependencies])),
+        Get(MaterializeScalaRuntimeJarsResult, MaterializeScalaRuntimeJarsRequest(scala_version)),
+    )
     impls = union_membership.get(BSPCompileFieldSet)
 
     reported_deps = []
@@ -94,7 +150,11 @@ async def bsp_resolve_one_scala_build_target(
                 reported_deps.append(BuildTargetIdentifier.from_address(dep_tgt.address))
                 break
 
-    return BuildTarget(
+    scala_jar_uris = tuple(
+        build_root.pathlib_path.joinpath(".pants.d/bsp").joinpath(p).as_uri()
+        for p in scala_runtime.content.files
+    )
+    bsp_target = BuildTarget(
         id=BuildTargetIdentifier.from_address(request.target.address),
         display_name=str(request.target.address),
         base_directory=None,
@@ -110,10 +170,10 @@ async def bsp_resolve_one_scala_build_target(
             scala_version=scala_version,
             scala_binary_version=".".join(scala_version.split(".")[0:2]),
             platform=ScalaPlatform.JVM,
-            # TODO: These are the jars for the scalac tool.
-            jars=(),
+            jars=scala_jar_uris,
         ),
     )
+    return ResolveScalaBSPBuildTargetResult(bsp_target, scala_runtime=scala_runtime.content)
 
 
 @rule
@@ -125,9 +185,13 @@ async def bsp_resolve_all_scala_build_targets(
     if LANGUAGE_ID not in bsp_context.client_params.capabilities.language_ids:
         return BSPBuildTargets()
     build_targets = await MultiGet(
-        Get(BuildTarget, ResolveScalaBSPBuildTargetRequest(tgt)) for tgt in all_scala_targets
+        Get(ResolveScalaBSPBuildTargetResult, ResolveScalaBSPBuildTargetRequest(tgt))
+        for tgt in all_scala_targets
     )
-    return BSPBuildTargets(targets=tuple(build_targets))
+    output_digest = await Get(Digest, MergeDigests([d.scala_runtime.digest for d in build_targets]))
+    return BSPBuildTargets(
+        targets=tuple(btgt.build_target for btgt in build_targets), digest=output_digest
+    )
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/bsp/spec/base.py
+++ b/src/python/pants/bsp/spec/base.py
@@ -12,6 +12,7 @@ from pants.build_graph.address import Address, AddressInput
 # Basic JSON Structures
 # See https://build-server-protocol.github.io/docs/specification.html#basic-json-structures
 # -----------------------------------------------------------------------------------------------
+from pants.util.meta import classproperty
 
 Uri = str
 
@@ -252,3 +253,14 @@ class StatusCode(IntEnum):
 
     # Execution was cancelled.
     CANCELLED = 3
+
+
+class BSPData:
+    """Mix-in for BSP spec types that can live in a data field."""
+
+    @classproperty
+    def DATA_KIND(cls):
+        raise NotImplementedError
+
+    def to_json_dict(self) -> dict[str, Any]:
+        raise NotImplementedError

--- a/src/python/pants/bsp/spec/base.py
+++ b/src/python/pants/bsp/spec/base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Any
+from typing import Any, ClassVar
 
 from pants.build_graph.address import Address, AddressInput
 
@@ -12,7 +12,6 @@ from pants.build_graph.address import Address, AddressInput
 # Basic JSON Structures
 # See https://build-server-protocol.github.io/docs/specification.html#basic-json-structures
 # -----------------------------------------------------------------------------------------------
-from pants.util.meta import classproperty
 
 Uri = str
 
@@ -258,9 +257,7 @@ class StatusCode(IntEnum):
 class BSPData:
     """Mix-in for BSP spec types that can live in a data field."""
 
-    @classproperty
-    def DATA_KIND(cls):
-        raise NotImplementedError
+    DATA_KIND: ClassVar[str]
 
     def to_json_dict(self) -> dict[str, Any]:
         raise NotImplementedError

--- a/src/python/pants/bsp/spec/targets.py
+++ b/src/python/pants/bsp/spec/targets.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from enum import IntEnum
 from typing import Any
 
-from pants.bsp.spec.base import BuildTarget, BuildTargetIdentifier, Uri
+from pants.bsp.spec.base import BSPData, BuildTarget, BuildTargetIdentifier, Uri
 
 # -----------------------------------------------------------------------------------------------
 # Workspace Build Targets Request
@@ -183,21 +183,17 @@ class DependencyModule:
     # Module version
     version: str
 
-    # Kind of data to expect in the `data` field. If this field is not set, the kind of data is not specified.
-    data_kind: str | None
-
     # Language-specific metadata about this module.
     # See MavenDependencyModule as an example.
-    data: Any | None
+    data: BSPData | None
 
     def to_json_dict(self) -> dict[str, Any]:
-        result = {
+        result: dict[str, Any] = {
             "name": self.name,
             "version": self.version,
         }
-        if self.data_kind is not None:
-            result["dataKind"] = self.data_kind
         if self.data is not None:
+            result["dataKind"] = self.data.DATA_KIND
             result["data"] = self.data.to_json_dict()
         return result
 

--- a/src/python/pants/jvm/bsp/spec.py
+++ b/src/python/pants/jvm/bsp/spec.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from typing import Any
 
 from pants.bsp.spec.base import BSPData, Uri
-from pants.util.meta import classproperty
 
 
 @dataclass(frozen=True)
@@ -61,9 +60,7 @@ class MavenDependencyModule(BSPData):
     scope: str | None
     artifacts: tuple[MavenDependencyModuleArtifact, ...]
 
-    @classproperty
-    def DATA_KIND(cls):
-        return "maven"
+    DATA_KIND = "maven"
 
     @classmethod
     def from_json_dict(cls, d: dict[str, Any]) -> Any:


### PR DESCRIPTION
- Expose scala compiler runtime via BSP `ScalaBuildTarget`. Jars are written to stable path.
- Introduce `MavenDependencyModule` BSP type.
- Add `BSPDependencyModulesFieldSet` to allow language backends to provide response for "Dependency Modules Request" (which handles third-party deps). Will implement Scala/Java backend support in follow-on.