### PR TITLE
Allow for codegen targets to be used directly by JVM compiler requests

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/java/register.py
+++ b/src/python/pants/backend/codegen/protobuf/java/register.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-"""Generate Python sources from Protocol Buffers (Protobufs).
+"""Generate Java sources from Protocol Buffers (Protobufs).
 
 See https://www.pantsbuild.org/docs/protobuf.
 """

--- a/src/python/pants/backend/codegen/protobuf/java/register.py
+++ b/src/python/pants/backend/codegen/protobuf/java/register.py
@@ -1,0 +1,33 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+"""Generate Python sources from Protocol Buffers (Protobufs).
+
+See https://www.pantsbuild.org/docs/protobuf.
+"""
+
+from pants.backend.codegen import export_codegen_goal
+from pants.backend.codegen.protobuf import protobuf_dependency_inference
+from pants.backend.codegen.protobuf import tailor as protobuf_tailor
+from pants.backend.codegen.protobuf.java.rules import rules as java_rules
+from pants.backend.codegen.protobuf.target_types import (
+    ProtobufSourcesGeneratorTarget,
+    ProtobufSourceTarget,
+)
+from pants.backend.codegen.protobuf.target_types import rules as protobuf_target_rules
+from pants.core.util_rules import stripped_source_files
+
+
+def rules():
+    return [
+        *java_rules(),
+        *protobuf_dependency_inference.rules(),
+        *protobuf_tailor.rules(),
+        *export_codegen_goal.rules(),
+        *protobuf_target_rules(),
+        *stripped_source_files.rules(),
+    ]
+
+
+def target_types():
+    return [ProtobufSourcesGeneratorTarget, ProtobufSourceTarget]

--- a/src/python/pants/backend/codegen/protobuf/java/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/java/rules.py
@@ -3,7 +3,11 @@
 
 
 from pants.backend.codegen.protobuf.protoc import Protoc
-from pants.backend.codegen.protobuf.target_types import ProtobufSourceField
+from pants.backend.codegen.protobuf.target_types import (
+    ProtobufSourceField,
+    ProtobufSourcesGeneratorTarget,
+    ProtobufSourceTarget,
+)
 from pants.backend.java.target_types import JavaSourceField
 from pants.backend.python.util_rules import pex
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
@@ -28,6 +32,7 @@ from pants.engine.target import (
     TransitiveTargetsRequest,
 )
 from pants.engine.unions import UnionRule
+from pants.jvm.target_types import JvmJdkField
 from pants.source.source_root import SourceRoot, SourceRootRequest
 from pants.util.logging import LogLevel
 
@@ -116,9 +121,15 @@ async def generate_java_from_protobuf(
     return GeneratedSources(source_root_restored)
 
 
+class PrefixedJvmJdkField(JvmJdkField):
+    alias = "jvm_jdk"
+
+
 def rules():
     return [
         *collect_rules(),
         *pex.rules(),
         UnionRule(GenerateSourcesRequest, GenerateJavaFromProtobufRequest),
+        ProtobufSourceTarget.register_plugin_field(PrefixedJvmJdkField),
+        ProtobufSourcesGeneratorTarget.register_plugin_field(PrefixedJvmJdkField),
     ]

--- a/src/python/pants/backend/codegen/protobuf/scala/register.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/register.py
@@ -1,7 +1,7 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-"""Generate Java sources from Protocol Buffers (Protobufs).
+"""Generate Scala sources from Protocol Buffers (Protobufs).
 
 See https://www.pantsbuild.org/docs/protobuf.
 """
@@ -9,7 +9,7 @@ See https://www.pantsbuild.org/docs/protobuf.
 from pants.backend.codegen import export_codegen_goal
 from pants.backend.codegen.protobuf import protobuf_dependency_inference
 from pants.backend.codegen.protobuf import tailor as protobuf_tailor
-from pants.backend.codegen.protobuf.java.rules import rules as java_rules
+from pants.backend.codegen.protobuf.scala.rules import rules as scala_rules
 from pants.backend.codegen.protobuf.target_types import (
     ProtobufSourcesGeneratorTarget,
     ProtobufSourceTarget,
@@ -20,7 +20,7 @@ from pants.core.util_rules import stripped_source_files
 
 def rules():
     return [
-        *java_rules(),
+        *scala_rules(),
         *protobuf_dependency_inference.rules(),
         *protobuf_tailor.rules(),
         *export_codegen_goal.rules(),

--- a/src/python/pants/backend/codegen/protobuf/target_types.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types.py
@@ -19,6 +19,7 @@ from pants.engine.target import (
     generate_file_based_overrides_field_help_message,
 )
 from pants.engine.unions import UnionRule
+from pants.jvm.target_types import JvmJdkField
 from pants.util.docutil import doc_url
 from pants.util.logging import LogLevel
 
@@ -60,7 +61,9 @@ class ProtobufSourceTarget(Target):
         ProtobufDependenciesField,
         ProtobufSourceField,
         ProtobufGrpcToggleField,
+        JvmJdkField,
     )
+    jdk = JvmJdkField
     help = (
         "A single Protobuf file used to generate various languages.\n\n"
         f"See {doc_url('protobuf')}."
@@ -117,7 +120,10 @@ class ProtobufSourcesGeneratorTarget(TargetFilesGenerator):
         *COMMON_TARGET_FIELDS,
         ProtobufDependenciesField,
     )
-    moved_fields = (ProtobufGrpcToggleField,)
+    moved_fields = (
+        ProtobufGrpcToggleField,
+        JvmJdkField,
+    )
     settings_request_cls = GeneratorSettingsRequest
     help = "Generate a `protobuf_source` target for each file in the `sources` field."
 

--- a/src/python/pants/backend/codegen/protobuf/target_types.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types.py
@@ -19,7 +19,6 @@ from pants.engine.target import (
     generate_file_based_overrides_field_help_message,
 )
 from pants.engine.unions import UnionRule
-from pants.jvm.target_types import JvmJdkField
 from pants.util.docutil import doc_url
 from pants.util.logging import LogLevel
 
@@ -61,9 +60,7 @@ class ProtobufSourceTarget(Target):
         ProtobufDependenciesField,
         ProtobufSourceField,
         ProtobufGrpcToggleField,
-        JvmJdkField,
     )
-    jdk = JvmJdkField
     help = (
         "A single Protobuf file used to generate various languages.\n\n"
         f"See {doc_url('protobuf')}."
@@ -120,10 +117,7 @@ class ProtobufSourcesGeneratorTarget(TargetFilesGenerator):
         *COMMON_TARGET_FIELDS,
         ProtobufDependenciesField,
     )
-    moved_fields = (
-        ProtobufGrpcToggleField,
-        JvmJdkField,
-    )
+    moved_fields = (ProtobufGrpcToggleField,)
     settings_request_cls = GeneratorSettingsRequest
     help = "Generate a `protobuf_source` target for each file in the `sources` field."
 

--- a/src/python/pants/backend/java/bsp/rules.py
+++ b/src/python/pants/backend/java/bsp/rules.py
@@ -36,7 +36,11 @@ from pants.engine.target import (
 )
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.jvm.bsp.spec import JvmBuildTarget
-from pants.jvm.compile import ClasspathEntryRequest, FallibleClasspathEntry, JVMRequestTypes
+from pants.jvm.compile import (
+    ClasspathEntryRequest,
+    ClasspathEntryRequestFactory,
+    FallibleClasspathEntry,
+)
 from pants.jvm.resolve.key import CoursierResolveKey
 
 LANGUAGE_ID = "java"
@@ -178,7 +182,7 @@ class JavaBSPCompileFieldSet(BSPCompileFieldSet):
 
 @rule
 async def bsp_java_compile_request(
-    request: JavaBSPCompileFieldSet, jvm_request_types: JVMRequestTypes
+    request: JavaBSPCompileFieldSet, classpath_entry_request: ClasspathEntryRequestFactory
 ) -> BSPCompileResult:
     coarsened_targets = await Get(CoarsenedTargets, Addresses([request.source.address]))
     assert len(coarsened_targets) == 1
@@ -188,9 +192,7 @@ async def bsp_java_compile_request(
     result = await Get(
         FallibleClasspathEntry,
         ClasspathEntryRequest,
-        ClasspathEntryRequest.for_targets(
-            jvm_request_types, component=coarsened_target, resolve=resolve
-        ),
+        classpath_entry_request.for_targets(component=coarsened_target, resolve=resolve),
     )
     _logger.info(f"java compile result = {result}")
     output_digest = EMPTY_DIGEST

--- a/src/python/pants/backend/java/bsp/rules.py
+++ b/src/python/pants/backend/java/bsp/rules.py
@@ -36,7 +36,7 @@ from pants.engine.target import (
 )
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.jvm.bsp.spec import JvmBuildTarget
-from pants.jvm.compile import ClasspathEntryRequest, FallibleClasspathEntry
+from pants.jvm.compile import ClasspathEntryRequest, FallibleClasspathEntry, JVMRequestTypes
 from pants.jvm.resolve.key import CoursierResolveKey
 
 LANGUAGE_ID = "java"
@@ -178,8 +178,7 @@ class JavaBSPCompileFieldSet(BSPCompileFieldSet):
 
 @rule
 async def bsp_java_compile_request(
-    request: JavaBSPCompileFieldSet,
-    union_membership: UnionMembership,
+    request: JavaBSPCompileFieldSet, jvm_request_types: JVMRequestTypes
 ) -> BSPCompileResult:
     coarsened_targets = await Get(CoarsenedTargets, Addresses([request.source.address]))
     assert len(coarsened_targets) == 1
@@ -190,7 +189,7 @@ async def bsp_java_compile_request(
         FallibleClasspathEntry,
         ClasspathEntryRequest,
         ClasspathEntryRequest.for_targets(
-            union_membership, component=coarsened_target, resolve=resolve
+            jvm_request_types, component=coarsened_target, resolve=resolve
         ),
     )
     _logger.info(f"java compile result = {result}")

--- a/src/python/pants/backend/java/goals/check.py
+++ b/src/python/pants/backend/java/goals/check.py
@@ -11,8 +11,8 @@ from pants.core.goals.check import CheckRequest, CheckResult, CheckResults
 from pants.engine.addresses import Addresses
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import CoarsenedTargets
-from pants.engine.unions import UnionMembership, UnionRule
-from pants.jvm.compile import ClasspathEntryRequest, FallibleClasspathEntry
+from pants.engine.unions import UnionRule
+from pants.jvm.compile import ClasspathEntryRequest, FallibleClasspathEntry, JVMRequestTypes
 from pants.jvm.resolve.key import CoursierResolveKey
 from pants.util.logging import LogLevel
 
@@ -27,7 +27,7 @@ class JavacCheckRequest(CheckRequest):
 @rule(desc="Check javac compilation", level=LogLevel.DEBUG)
 async def javac_check(
     request: JavacCheckRequest,
-    union_membership: UnionMembership,
+    jvm_request_types: JVMRequestTypes,
 ) -> CheckResults:
     coarsened_targets = await Get(
         CoarsenedTargets, Addresses(field_set.address for field_set in request.field_sets)
@@ -43,7 +43,7 @@ async def javac_check(
         Get(
             FallibleClasspathEntry,
             ClasspathEntryRequest,
-            ClasspathEntryRequest.for_targets(union_membership, component=target, resolve=resolve),
+            ClasspathEntryRequest.for_targets(jvm_request_types, component=target, resolve=resolve),
         )
         for target, resolve in zip(coarsened_targets, resolves)
     )

--- a/src/python/pants/backend/java/goals/check.py
+++ b/src/python/pants/backend/java/goals/check.py
@@ -12,7 +12,11 @@ from pants.engine.addresses import Addresses
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import CoarsenedTargets
 from pants.engine.unions import UnionRule
-from pants.jvm.compile import ClasspathEntryRequest, FallibleClasspathEntry, JVMRequestTypes
+from pants.jvm.compile import (
+    ClasspathEntryRequest,
+    ClasspathEntryRequestFactory,
+    FallibleClasspathEntry,
+)
 from pants.jvm.resolve.key import CoursierResolveKey
 from pants.util.logging import LogLevel
 
@@ -27,7 +31,7 @@ class JavacCheckRequest(CheckRequest):
 @rule(desc="Check javac compilation", level=LogLevel.DEBUG)
 async def javac_check(
     request: JavacCheckRequest,
-    jvm_request_types: JVMRequestTypes,
+    classpath_entry_request: ClasspathEntryRequestFactory,
 ) -> CheckResults:
     coarsened_targets = await Get(
         CoarsenedTargets, Addresses(field_set.address for field_set in request.field_sets)
@@ -43,7 +47,7 @@ async def javac_check(
         Get(
             FallibleClasspathEntry,
             ClasspathEntryRequest,
-            ClasspathEntryRequest.for_targets(jvm_request_types, component=target, resolve=resolve),
+            classpath_entry_request.for_targets(component=target, resolve=resolve),
         )
         for target, resolve in zip(coarsened_targets, resolves)
     )

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -29,7 +29,6 @@ from pants.bsp.util_rules.compile import BSPCompileFieldSet, BSPCompileResult
 from pants.bsp.util_rules.lifecycle import BSPLanguageSupport
 from pants.bsp.util_rules.targets import BSPBuildTargets, BSPBuildTargetsRequest
 from pants.build_graph.address import Address, AddressInput
-from pants.core.util_rules.system_binaries import BashBinary, UnzipBinary
 from pants.engine.addresses import Addresses
 from pants.engine.fs import EMPTY_DIGEST, AddPrefix, CreateDigest, Digest, DigestEntries
 from pants.engine.internals.selectors import Get, MultiGet
@@ -42,7 +41,7 @@ from pants.engine.target import (
     WrappedTarget,
 )
 from pants.engine.unions import UnionMembership, UnionRule
-from pants.jvm.compile import ClasspathEntryRequest, FallibleClasspathEntry
+from pants.jvm.compile import ClasspathEntryRequest, FallibleClasspathEntry, JVMRequestTypes
 from pants.jvm.resolve.key import CoursierResolveKey
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
@@ -199,9 +198,7 @@ class ScalaBSPCompileFieldSet(BSPCompileFieldSet):
 @rule
 async def bsp_scala_compile_request(
     request: ScalaBSPCompileFieldSet,
-    union_membership: UnionMembership,
-    unzip: UnzipBinary,
-    bash: BashBinary,
+    jvm_request_types: JVMRequestTypes,
 ) -> BSPCompileResult:
     coarsened_targets = await Get(CoarsenedTargets, Addresses([request.source.address]))
     assert len(coarsened_targets) == 1
@@ -212,7 +209,7 @@ async def bsp_scala_compile_request(
         FallibleClasspathEntry,
         ClasspathEntryRequest,
         ClasspathEntryRequest.for_targets(
-            union_membership, component=coarsened_target, resolve=resolve
+            jvm_request_types, component=coarsened_target, resolve=resolve
         ),
     )
     _logger.info(f"scala compile result = {result}")

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -41,7 +41,11 @@ from pants.engine.target import (
     WrappedTarget,
 )
 from pants.engine.unions import UnionMembership, UnionRule
-from pants.jvm.compile import ClasspathEntryRequest, FallibleClasspathEntry, JVMRequestTypes
+from pants.jvm.compile import (
+    ClasspathEntryRequest,
+    ClasspathEntryRequestFactory,
+    FallibleClasspathEntry,
+)
 from pants.jvm.resolve.key import CoursierResolveKey
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
@@ -198,7 +202,7 @@ class ScalaBSPCompileFieldSet(BSPCompileFieldSet):
 @rule
 async def bsp_scala_compile_request(
     request: ScalaBSPCompileFieldSet,
-    jvm_request_types: JVMRequestTypes,
+    classpath_entry_request: ClasspathEntryRequestFactory,
 ) -> BSPCompileResult:
     coarsened_targets = await Get(CoarsenedTargets, Addresses([request.source.address]))
     assert len(coarsened_targets) == 1
@@ -208,9 +212,7 @@ async def bsp_scala_compile_request(
     result = await Get(
         FallibleClasspathEntry,
         ClasspathEntryRequest,
-        ClasspathEntryRequest.for_targets(
-            jvm_request_types, component=coarsened_target, resolve=resolve
-        ),
+        classpath_entry_request.for_targets(component=coarsened_target, resolve=resolve),
     )
     _logger.info(f"scala compile result = {result}")
     output_digest = EMPTY_DIGEST

--- a/src/python/pants/backend/scala/goals/check.py
+++ b/src/python/pants/backend/scala/goals/check.py
@@ -11,8 +11,8 @@ from pants.core.goals.check import CheckRequest, CheckResult, CheckResults
 from pants.engine.addresses import Addresses
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import CoarsenedTargets
-from pants.engine.unions import UnionMembership, UnionRule
-from pants.jvm.compile import ClasspathEntryRequest, FallibleClasspathEntry
+from pants.engine.unions import UnionRule
+from pants.jvm.compile import ClasspathEntryRequest, FallibleClasspathEntry, JVMRequestTypes
 from pants.jvm.resolve.key import CoursierResolveKey
 from pants.util.logging import LogLevel
 
@@ -27,7 +27,7 @@ class ScalacCheckRequest(CheckRequest):
 @rule(desc="Check compilation for Scala", level=LogLevel.DEBUG)
 async def scalac_check(
     request: ScalacCheckRequest,
-    union_membership: UnionMembership,
+    jvm_request_types: JVMRequestTypes,
 ) -> CheckResults:
     coarsened_targets = await Get(
         CoarsenedTargets, Addresses(field_set.address for field_set in request.field_sets)
@@ -43,7 +43,7 @@ async def scalac_check(
         Get(
             FallibleClasspathEntry,
             ClasspathEntryRequest,
-            ClasspathEntryRequest.for_targets(union_membership, component=target, resolve=resolve),
+            ClasspathEntryRequest.for_targets(jvm_request_types, component=target, resolve=resolve),
         )
         for target, resolve in zip(coarsened_targets, resolves)
     )

--- a/src/python/pants/backend/scala/goals/check.py
+++ b/src/python/pants/backend/scala/goals/check.py
@@ -12,7 +12,11 @@ from pants.engine.addresses import Addresses
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import CoarsenedTargets
 from pants.engine.unions import UnionRule
-from pants.jvm.compile import ClasspathEntryRequest, FallibleClasspathEntry, JVMRequestTypes
+from pants.jvm.compile import (
+    ClasspathEntryRequest,
+    ClasspathEntryRequestFactory,
+    FallibleClasspathEntry,
+)
 from pants.jvm.resolve.key import CoursierResolveKey
 from pants.util.logging import LogLevel
 
@@ -27,7 +31,7 @@ class ScalacCheckRequest(CheckRequest):
 @rule(desc="Check compilation for Scala", level=LogLevel.DEBUG)
 async def scalac_check(
     request: ScalacCheckRequest,
-    jvm_request_types: JVMRequestTypes,
+    classpath_entry_request: ClasspathEntryRequestFactory,
 ) -> CheckResults:
     coarsened_targets = await Get(
         CoarsenedTargets, Addresses(field_set.address for field_set in request.field_sets)
@@ -43,7 +47,7 @@ async def scalac_check(
         Get(
             FallibleClasspathEntry,
             ClasspathEntryRequest,
-            ClasspathEntryRequest.for_targets(jvm_request_types, component=target, resolve=resolve),
+            classpath_entry_request.for_targets(component=target, resolve=resolve),
         )
         for target, resolve in zip(coarsened_targets, resolves)
     )

--- a/src/python/pants/jvm/classpath.py
+++ b/src/python/pants/jvm/classpath.py
@@ -10,7 +10,7 @@ from typing import Iterator
 from pants.engine.fs import Digest
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import CoarsenedTargets
-from pants.jvm.compile import ClasspathEntry, ClasspathEntryRequest, JVMRequestTypes
+from pants.jvm.compile import ClasspathEntry, ClasspathEntryRequest, ClasspathEntryRequestFactory
 from pants.jvm.resolve.key import CoursierResolveKey
 
 logger = logging.getLogger(__name__)
@@ -68,7 +68,7 @@ class Classpath:
 @rule
 async def classpath(
     coarsened_targets: CoarsenedTargets,
-    jvm_request_types: JVMRequestTypes,
+    classpath_entry_request: ClasspathEntryRequestFactory,
 ) -> Classpath:
     # Compute a single shared resolve for all of the roots, which will validate that they
     # are compatible with one another.
@@ -79,9 +79,7 @@ async def classpath(
         Get(
             ClasspathEntry,
             ClasspathEntryRequest,
-            ClasspathEntryRequest.for_targets(
-                jvm_request_types, component=t, resolve=resolve, root=True
-            ),
+            classpath_entry_request.for_targets(component=t, resolve=resolve, root=True),
         )
         for t in coarsened_targets
     )

--- a/src/python/pants/jvm/classpath.py
+++ b/src/python/pants/jvm/classpath.py
@@ -10,8 +10,7 @@ from typing import Iterator
 from pants.engine.fs import Digest
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import CoarsenedTargets
-from pants.engine.unions import UnionMembership
-from pants.jvm.compile import ClasspathEntry, ClasspathEntryRequest
+from pants.jvm.compile import ClasspathEntry, ClasspathEntryRequest, JVMRequestTypes
 from pants.jvm.resolve.key import CoursierResolveKey
 
 logger = logging.getLogger(__name__)
@@ -69,7 +68,7 @@ class Classpath:
 @rule
 async def classpath(
     coarsened_targets: CoarsenedTargets,
-    union_membership: UnionMembership,
+    jvm_request_types: JVMRequestTypes,
 ) -> Classpath:
     # Compute a single shared resolve for all of the roots, which will validate that they
     # are compatible with one another.
@@ -81,7 +80,7 @@ async def classpath(
             ClasspathEntry,
             ClasspathEntryRequest,
             ClasspathEntryRequest.for_targets(
-                union_membership, component=t, resolve=resolve, root=True
+                jvm_request_types, component=t, resolve=resolve, root=True
             ),
         )
         for t in coarsened_targets

--- a/src/python/pants/jvm/compile.py
+++ b/src/python/pants/jvm/compile.py
@@ -129,12 +129,15 @@ class ClasspathEntryRequest(metaclass=ABCMeta):
         """
 
         for (input, request_types) in jvm_request_types.code_generator_requests.items():
+            if not component.representative.has_field(input):
+                continue
             if len(request_types) > 1:
-                # TODO: filter usable generators by acceptable languages
-                pass
+                raise ClasspathSourceAmbiguity(
+                    f"More than one code generator ({request_types}) was compatible with the "
+                    f"inputs:\n{component.bullet_list()}"
+                )
             request_type = request_types[0]
-            if component.representative.has_field(input):
-                return request_type(component, resolve, None)
+            return request_type(component, resolve, None)
 
         compatible = []
         partial = []

--- a/src/python/pants/jvm/compile_test.py
+++ b/src/python/pants/jvm/compile_test.py
@@ -66,6 +66,7 @@ from pants.jvm.testutil import (
 )
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
+from pants.util.frozendict import FrozenDict
 
 DEFAULT_LOCKFILE = TestCoursierWrapper(
     CoursierResolvedLockfile(
@@ -193,7 +194,7 @@ def test_request_classification(rule_runner: RuleRunner) -> None:
         members: Sequence[type[ClasspathEntryRequest]],
     ) -> tuple[type[ClasspathEntryRequest], type[ClasspathEntryRequest] | None]:
         req = ClasspathEntryRequest.for_targets(
-            JVMRequestTypes(tuple(members), ()),
+            JVMRequestTypes(tuple(members), FrozenDict()),
             CoarsenedTarget(targets, ()),
             CoursierResolveKey("example", "path", EMPTY_DIGEST),
         )

--- a/src/python/pants/jvm/compile_test.py
+++ b/src/python/pants/jvm/compile_test.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import textwrap
 from textwrap import dedent
-from typing import Sequence, cast
+from typing import Sequence, Type, cast
 
 import chevron
 import pytest
@@ -272,7 +272,7 @@ def test_request_classification(rule_runner: RuleRunner) -> None:
     all_members = [CompileJavaSourceRequest, CompileScalaSourceRequest, CoursierFetchRequest]
     generators = FrozenDict(
         {
-            CompileJavaSourceRequest: frozenset([cast(type[SourcesField], ProtobufSourceField)]),
+            CompileJavaSourceRequest: frozenset([cast(Type[SourcesField], ProtobufSourceField)]),
             CompileScalaSourceRequest: frozenset(),
         }
     )

--- a/src/python/pants/jvm/compile_test.py
+++ b/src/python/pants/jvm/compile_test.py
@@ -39,13 +39,13 @@ from pants.engine.addresses import Addresses
 from pants.engine.fs import EMPTY_DIGEST
 from pants.engine.internals.native_engine import FileDigest
 from pants.engine.target import CoarsenedTarget, Target, UnexpandedTargets
-from pants.engine.unions import UnionMembership
 from pants.jvm import classpath, jdk_rules, testutil
 from pants.jvm.classpath import Classpath
 from pants.jvm.compile import (
     ClasspathEntryRequest,
     ClasspathSourceAmbiguity,
     ClasspathSourceMissing,
+    JVMRequestTypes,
 )
 from pants.jvm.goals import lockfile
 from pants.jvm.resolve.common import ArtifactRequirement, Coordinate, Coordinates
@@ -193,7 +193,7 @@ def test_request_classification(rule_runner: RuleRunner) -> None:
         members: Sequence[type[ClasspathEntryRequest]],
     ) -> tuple[type[ClasspathEntryRequest], type[ClasspathEntryRequest] | None]:
         req = ClasspathEntryRequest.for_targets(
-            UnionMembership({ClasspathEntryRequest: members}),
+            JVMRequestTypes(tuple(members), ()),
             CoarsenedTarget(targets, ()),
             CoursierResolveKey("example", "path", EMPTY_DIGEST),
         )

--- a/src/python/pants/jvm/compile_test.py
+++ b/src/python/pants/jvm/compile_test.py
@@ -43,9 +43,9 @@ from pants.jvm import classpath, jdk_rules, testutil
 from pants.jvm.classpath import Classpath
 from pants.jvm.compile import (
     ClasspathEntryRequest,
+    ClasspathEntryRequestFactory,
     ClasspathSourceAmbiguity,
     ClasspathSourceMissing,
-    JVMRequestTypes,
 )
 from pants.jvm.goals import lockfile
 from pants.jvm.resolve.common import ArtifactRequirement, Coordinate, Coordinates
@@ -193,8 +193,7 @@ def test_request_classification(rule_runner: RuleRunner) -> None:
         targets: Sequence[Target],
         members: Sequence[type[ClasspathEntryRequest]],
     ) -> tuple[type[ClasspathEntryRequest], type[ClasspathEntryRequest] | None]:
-        req = ClasspathEntryRequest.for_targets(
-            JVMRequestTypes(tuple(members), FrozenDict()),
+        req = ClasspathEntryRequestFactory(tuple(members), FrozenDict()).for_targets(
             CoarsenedTarget(targets, ()),
             CoursierResolveKey("example", "path", EMPTY_DIGEST),
         )

--- a/src/python/pants/jvm/compile_test.py
+++ b/src/python/pants/jvm/compile_test.py
@@ -18,6 +18,10 @@ from typing import Sequence, cast
 import chevron
 import pytest
 
+from pants.backend.codegen.protobuf.java.rules import GenerateJavaFromProtobufRequest
+from pants.backend.codegen.protobuf.java.rules import rules as protobuf_rules
+from pants.backend.codegen.protobuf.target_types import ProtobufSourceField, ProtobufSourceTarget
+from pants.backend.codegen.protobuf.target_types import rules as protobuf_target_types_rules
 from pants.backend.java.compile.javac import CompileJavaSourceRequest
 from pants.backend.java.compile.javac import rules as javac_rules
 from pants.backend.java.dependency_inference.rules import rules as java_dep_inf_rules
@@ -33,12 +37,20 @@ from pants.backend.scala.dependency_inference.rules import rules as scala_dep_in
 from pants.backend.scala.target_types import ScalaSourcesGeneratorTarget
 from pants.backend.scala.target_types import rules as scala_target_types_rules
 from pants.build_graph.address import Address
-from pants.core.util_rules import config_files, source_files
+from pants.core.util_rules import config_files, source_files, stripped_source_files
 from pants.core.util_rules.external_tool import rules as external_tool_rules
 from pants.engine.addresses import Addresses
 from pants.engine.fs import EMPTY_DIGEST
 from pants.engine.internals.native_engine import FileDigest
-from pants.engine.target import CoarsenedTarget, Target, UnexpandedTargets
+from pants.engine.target import (
+    CoarsenedTarget,
+    GeneratedSources,
+    HydratedSources,
+    HydrateSourcesRequest,
+    SourcesField,
+    Target,
+    UnexpandedTargets,
+)
 from pants.jvm import classpath, jdk_rules, testutil
 from pants.jvm.classpath import Classpath
 from pants.jvm.compile import (
@@ -126,11 +138,21 @@ def rule_runner() -> RuleRunner:
             *java_target_types_rules(),
             *util_rules(),
             *testutil.rules(),
+            *protobuf_rules(),
+            *stripped_source_files.rules(),
+            *protobuf_target_types_rules(),
             QueryRule(Classpath, (Addresses,)),
             QueryRule(RenderedClasspath, (Addresses,)),
             QueryRule(UnexpandedTargets, (Addresses,)),
+            QueryRule(HydratedSources, [HydrateSourcesRequest]),
+            QueryRule(GeneratedSources, [GenerateJavaFromProtobufRequest]),
         ],
-        target_types=[ScalaSourcesGeneratorTarget, JavaSourcesGeneratorTarget, JvmArtifactTarget],
+        target_types=[
+            JavaSourcesGeneratorTarget,
+            JvmArtifactTarget,
+            ProtobufSourceTarget,
+            ScalaSourcesGeneratorTarget,
+        ],
     )
     rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
     return rule_runner
@@ -183,6 +205,22 @@ def scala_main_source(extra_imports: Sequence[str] = ()) -> str:
     )
 
 
+def proto_source() -> str:
+    return dedent(
+        """\
+                syntax = "proto3";
+
+                package dir1;
+
+                message Person {
+                  string name = 1;
+                  int32 id = 2;
+                  string email = 3;
+                }
+                """
+    )
+
+
 class CompileMockSourceRequest(ClasspathEntryRequest):
     field_sets = (JavaFieldSet, JavaGeneratorFieldSet)
 
@@ -192,8 +230,12 @@ def test_request_classification(rule_runner: RuleRunner) -> None:
     def classify(
         targets: Sequence[Target],
         members: Sequence[type[ClasspathEntryRequest]],
+        generators: FrozenDict[type[ClasspathEntryRequest], frozenset[type[SourcesField]]],
     ) -> tuple[type[ClasspathEntryRequest], type[ClasspathEntryRequest] | None]:
-        req = ClasspathEntryRequestFactory(tuple(members), FrozenDict()).for_targets(
+
+        factory = ClasspathEntryRequestFactory(tuple(members), generators)
+
+        req = factory.for_targets(
             CoarsenedTarget(targets, ()),
             CoursierResolveKey("example", "path", EMPTY_DIGEST),
         )
@@ -206,13 +248,15 @@ def test_request_classification(rule_runner: RuleRunner) -> None:
                 scala_sources(name='scala')
                 java_sources(name='java')
                 jvm_artifact(name='jvm_artifact', group='ex', artifact='ex', version='0.0.0')
+                protobuf_source(name='proto', source="f.proto")
                 {DEFAULT_SCALA_LIBRARY_TARGET}
                 """
             ),
+            "f.proto": proto_source(),
             "3rdparty/jvm/default.lock": DEFAULT_LOCKFILE,
         }
     )
-    scala, java, jvm_artifact = rule_runner.request(
+    scala, java, jvm_artifact, proto = rule_runner.request(
         UnexpandedTargets,
         [
             Addresses(
@@ -220,33 +264,41 @@ def test_request_classification(rule_runner: RuleRunner) -> None:
                     Address("", target_name="scala"),
                     Address("", target_name="java"),
                     Address("", target_name="jvm_artifact"),
+                    Address("", target_name="proto"),
                 ]
             )
         ],
     )
     all_members = [CompileJavaSourceRequest, CompileScalaSourceRequest, CoursierFetchRequest]
+    generators = FrozenDict(
+        {
+            CompileJavaSourceRequest: frozenset([cast(type[SourcesField], ProtobufSourceField)]),
+            CompileScalaSourceRequest: frozenset(),
+        }
+    )
 
     # Fully compatible.
-    assert (CompileJavaSourceRequest, None) == classify([java], all_members)
-    assert (CompileScalaSourceRequest, None) == classify([scala], all_members)
-    assert (CoursierFetchRequest, None) == classify([jvm_artifact], all_members)
+    assert (CompileJavaSourceRequest, None) == classify([java], all_members, generators)
+    assert (CompileScalaSourceRequest, None) == classify([scala], all_members, generators)
+    assert (CoursierFetchRequest, None) == classify([jvm_artifact], all_members, generators)
+    assert (CompileJavaSourceRequest, None) == classify([proto], all_members, generators)
 
     # Partially compatible.
     assert (CompileJavaSourceRequest, CompileScalaSourceRequest) == classify(
-        [java, scala], all_members
+        [java, scala], all_members, generators
     )
     with pytest.raises(ClasspathSourceMissing):
-        classify([java, jvm_artifact], all_members)
+        classify([java, jvm_artifact], all_members, generators)
 
     # None compatible.
     with pytest.raises(ClasspathSourceMissing):
-        classify([java], [])
+        classify([java], [], generators)
     with pytest.raises(ClasspathSourceMissing):
-        classify([scala, java, jvm_artifact], all_members)
+        classify([scala, java, jvm_artifact], all_members, generators)
 
     # Too many compatible.
     with pytest.raises(ClasspathSourceAmbiguity):
-        classify([java], [CompileJavaSourceRequest, CompileMockSourceRequest])
+        classify([java], [CompileJavaSourceRequest, CompileMockSourceRequest], generators)
 
 
 @maybe_skip_jdk_test


### PR DESCRIPTION
This amends `ClasspathEntryRequest.for_targets` to accept a codegen source request target and output a `ClasspathEntryRequest` that corresponds to a relevant JVM compilation request.

With this approach, it seems that any `GenerateSourcesRequest` with `output` that is compatible with a `ClasspathEntryRequest` will Just Work™. To demonstrate this in action, there's backend registration support for the Java and Scala protobuf generators included in this PR too. 

The main current limitation is when multiple language backends are enabled for a given codegen source type. A solution for this would address #14041, and realistically needs to take multiple JVM languages into account.
