### PR TITLE
[internal] Port `remexec::Tree` interactions to `DigestTrie`

### DIFF
--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -523,9 +523,8 @@ async fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
           .load_tree_from_remote(digest)
           .await
           .expect("protocol error");
-        let output_digest = DirectoryDigest::from_persisted_digest(
-          output_digest_opt.ok_or_else(|| ExitError("not found".into(), ExitCode::NotFound))?,
-        );
+        let output_digest =
+          output_digest_opt.ok_or_else(|| ExitError("not found".into(), ExitCode::NotFound))?;
         store
           .materialize_directory(destination, output_digest, Permissions::Writable)
           .await

--- a/src/rust/engine/process_execution/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_cache_tests.rs
@@ -412,25 +412,12 @@ async fn make_tree_from_directory() {
     .store_file_bytes(TestData::roland().bytes(), false)
     .await
     .expect("Error saving file bytes");
-  store
-    .record_directory(&TestDirectory::containing_roland().directory(), true)
-    .await
-    .expect("Error saving directory");
-  store
-    .record_directory(&TestDirectory::nested().directory(), true)
-    .await
-    .expect("Error saving directory");
-  let directory_digest = store
-    .record_directory(&TestDirectory::double_nested().directory(), true)
-    .await
-    .expect("Error saving directory");
+  let input_tree = TestTree::double_nested();
 
   let (tree, file_digests) = crate::remote_cache::CommandRunner::make_tree_for_output_directory(
-    directory_digest,
+    &input_tree.digest_trie(),
     RelativePath::new("pets").unwrap(),
-    &store,
   )
-  .await
   .unwrap()
   .unwrap();
 
@@ -457,21 +444,17 @@ async fn make_tree_from_directory() {
   // Test that extracting non-existent output directories fails gracefully.
   assert!(
     crate::remote_cache::CommandRunner::make_tree_for_output_directory(
-      directory_digest,
+      &input_tree.digest_trie(),
       RelativePath::new("animals").unwrap(),
-      &store,
     )
-    .await
     .unwrap()
     .is_none()
   );
   assert!(
     crate::remote_cache::CommandRunner::make_tree_for_output_directory(
-      directory_digest,
+      &input_tree.digest_trie(),
       RelativePath::new("pets/xyzzy").unwrap(),
-      &store,
     )
-    .await
     .unwrap()
     .is_none()
   );
@@ -487,55 +470,41 @@ async fn extract_output_file() {
     .store_file_bytes(TestData::roland().bytes(), false)
     .await
     .expect("Error saving file bytes");
-  store
-    .record_directory(&TestDirectory::containing_roland().directory(), true)
-    .await
-    .expect("Error saving directory");
-  let directory_digest = store
-    .record_directory(&TestDirectory::nested().directory(), true)
-    .await
-    .expect("Error saving directory");
+  let input_tree = TestTree::nested();
 
-  let file_node = crate::remote_cache::CommandRunner::extract_output_file(
-    directory_digest,
-    RelativePath::new("cats/roland.ext").unwrap(),
-    &store,
+  let output_file = crate::remote_cache::CommandRunner::extract_output_file(
+    &input_tree.digest_trie(),
+    "cats/roland.ext",
   )
-  .await
   .unwrap()
   .unwrap();
 
-  // Note that the `FileNode` only stores the file name, but we will end up storing the full path
-  // in the final ActionResult.
-  assert_eq!(file_node.name, "roland.ext");
-  let file_digest: Digest = file_node.digest.unwrap().try_into().unwrap();
+  assert_eq!(output_file.path, "cats/roland.ext");
+  let file_digest: Digest = output_file.digest.unwrap().try_into().unwrap();
   assert_eq!(file_digest, TestData::roland().digest());
 
   // Extract non-existent files to make sure that Ok(None) is returned.
   assert!(crate::remote_cache::CommandRunner::extract_output_file(
-    directory_digest,
-    RelativePath::new("animals.ext").unwrap(),
-    &store,
+    &input_tree.digest_trie(),
+    "animals.ext",
   )
-  .await
   .unwrap()
   .is_none());
   assert!(crate::remote_cache::CommandRunner::extract_output_file(
-    directory_digest,
-    RelativePath::new("cats").unwrap(),
-    &store,
+    &input_tree.digest_trie(),
+    "cats/xyzzy",
   )
-  .await
   .unwrap()
   .is_none());
-  assert!(crate::remote_cache::CommandRunner::extract_output_file(
-    directory_digest,
-    RelativePath::new("cats/xyzzy").unwrap(),
-    &store,
-  )
-  .await
-  .unwrap()
-  .is_none());
+
+  // Error if a path has been declared as a file but isn't.
+  assert_eq!(
+    crate::remote_cache::CommandRunner::extract_output_file(&input_tree.digest_trie(), "cats",),
+    Err(format!(
+      "Declared output file path \"cats\" in output digest {:?} contained a directory instead.",
+      TestDirectory::nested().digest()
+    ))
+  );
 }
 
 #[tokio::test]

--- a/src/rust/engine/testutil/src/data.rs
+++ b/src/rust/engine/testutil/src/data.rs
@@ -338,9 +338,35 @@ impl TestTree {
   pub fn robin_at_root() -> TestTree {
     TestDirectory::containing_robin().into()
   }
+
+  pub fn nested() -> TestTree {
+    TestTree::new(
+      TestDirectory::nested().directory(),
+      vec![TestDirectory::containing_roland().directory()],
+    )
+  }
+
+  pub fn double_nested() -> TestTree {
+    TestTree::new(
+      TestDirectory::double_nested().directory(),
+      vec![
+        TestDirectory::nested().directory(),
+        TestDirectory::containing_roland().directory(),
+      ],
+    )
+  }
 }
 
 impl TestTree {
+  pub fn new(root: remexec::Directory, children: Vec<remexec::Directory>) -> Self {
+    Self {
+      tree: remexec::Tree {
+        root: Some(root),
+        children,
+      },
+    }
+  }
+
   pub fn bytes(&self) -> bytes::Bytes {
     self.tree.to_bytes()
   }
@@ -352,14 +378,14 @@ impl TestTree {
   pub fn digest(&self) -> hashing::Digest {
     hashing::Digest::of_bytes(&self.bytes())
   }
+
+  pub fn digest_trie(&self) -> fs::DigestTrie {
+    self.tree.clone().try_into().unwrap()
+  }
 }
 
 impl From<TestDirectory> for TestTree {
   fn from(dir: TestDirectory) -> Self {
-    let tree = remexec::Tree {
-      root: Some(dir.directory),
-      ..remexec::Tree::default()
-    };
-    TestTree { tree }
+    Self::new(dir.directory(), vec![])
   }
 }


### PR DESCRIPTION
Continues #13112 by porting operations which consume and produce `remexec::Tree`s to `DigestTrie`. In particular: conversions in both directions are implemented via:
```rust
impl TryFrom<remexec::Tree> for DigestTrie { .. }
impl From<&DigestTrie> for remexec::Tree { .. }
```