### PR TITLE
[internal] Switch usage of x.options.y to x.y

### DIFF
--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -255,7 +255,7 @@ async def build_docker_image(
             address=field_set.address,
             context_root=context_root,
             context=context,
-            colors=global_options.options.colors,
+            colors=global_options.colors,
         )
         if maybe_msg:
             logger.warning(maybe_msg)

--- a/src/python/pants/backend/go/lint/gofmt/rules.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules.py
@@ -82,7 +82,7 @@ async def setup_gofmt(setup_request: SetupRequest, goroot: GoRoot) -> Setup:
 
 @rule(desc="Format with gofmt")
 async def gofmt_fmt(request: GofmtRequest, gofmt: GofmtSubsystem) -> FmtResult:
-    if gofmt.options.skip:
+    if gofmt.skip:
         return FmtResult.skip(formatter_name=request.name)
     setup = await Get(Setup, SetupRequest(request, check_only=False))
     result = await Get(ProcessResult, Process, setup.process)
@@ -93,7 +93,7 @@ async def gofmt_fmt(request: GofmtRequest, gofmt: GofmtSubsystem) -> FmtResult:
 
 @rule(desc="Lint with gofmt", level=LogLevel.DEBUG)
 async def gofmt_lint(request: GofmtRequest, gofmt: GofmtSubsystem) -> LintResults:
-    if gofmt.options.skip:
+    if gofmt.skip:
         return LintResults([], linter_name=request.name)
     setup = await Get(Setup, SetupRequest(request, check_only=True))
     result = await Get(FallibleProcessResult, Process, setup.process)

--- a/src/python/pants/backend/project_info/filter_targets.py
+++ b/src/python/pants/backend/project_info/filter_targets.py
@@ -134,10 +134,10 @@ def filter_targets(
 
     anded_filter: TargetFilter = and_filters(
         [
-            *(create_filters(filter_subsystem.options.target_type, filter_target_type)),
-            *(create_filters(filter_subsystem.options.address_regex, filter_address_regex)),
-            *(create_filters(filter_subsystem.options.tag_regex, filter_tag_regex)),
-            filter_granularity(filter_subsystem.options.granularity),
+            *(create_filters(filter_subsystem.target_type, filter_target_type)),
+            *(create_filters(filter_subsystem.address_regex, filter_address_regex)),
+            *(create_filters(filter_subsystem.tag_regex, filter_tag_regex)),
+            filter_granularity(filter_subsystem.granularity),
         ]
     )
     addresses = sorted(target.address for target in targets if anded_filter(target))

--- a/src/python/pants/backend/python/goals/publish.py
+++ b/src/python/pants/backend/python/goals/publish.py
@@ -171,7 +171,7 @@ async def twine_upload(
         Get(ConfigFiles, ConfigFilesRequest, twine_subsystem.config_request()),
     )
 
-    ca_cert_request = twine_subsystem.ca_certs_digest_request(global_options.options.ca_certs_path)
+    ca_cert_request = twine_subsystem.ca_certs_digest_request(global_options.ca_certs_path)
     ca_cert = await Get(Snapshot, CreateDigest, ca_cert_request) if ca_cert_request else None
     ca_cert_digest = (ca_cert.digest,) if ca_cert else ()
 

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -252,14 +252,14 @@ async def setup_pytest_for_target(
         ),
     )
 
-    add_opts = [f"--color={'yes' if global_options.options.colors else 'no'}"]
+    add_opts = [f"--color={'yes' if global_options.colors else 'no'}"]
     output_files = []
 
     results_file_name = None
     if not request.is_debug:
         results_file_name = f"{request.field_set.address.path_safe_spec}.xml"
         add_opts.extend(
-            (f"--junitxml={results_file_name}", "-o", f"junit_family={pytest.options.junit_family}")
+            (f"--junitxml={results_file_name}", "-o", f"junit_family={pytest.junit_family}")
         )
         output_files.append(results_file_name)
 
@@ -301,13 +301,13 @@ async def setup_pytest_for_target(
         Process,
         VenvPexProcess(
             pytest_runner_pex,
-            argv=(*pytest.options.args, *coverage_args, *field_set_source_files.files),
+            argv=(*pytest.args, *coverage_args, *field_set_source_files.files),
             extra_env=extra_env,
             input_digest=input_digest,
             output_directories=(_EXTRA_OUTPUT_DIR,),
             output_files=output_files,
             timeout_seconds=request.field_set.timeout.calculate_from_global_options(pytest),
-            execution_slot_variable=pytest.options.execution_slot_var,
+            execution_slot_variable=pytest.execution_slot_var,
             description=f"Run Pytest for {request.field_set.address}",
             level=LogLevel.DEBUG,
             cache_scope=cache_scope,

--- a/src/python/pants/backend/python/goals/repl.py
+++ b/src/python/pants/backend/python/goals/repl.py
@@ -166,7 +166,7 @@ async def create_ipython_repl_request(
     args = list(
         complete_pex_env.create_argv(request.in_chroot(ipython_pex.name), python=ipython_pex.python)
     )
-    if ipython.options.ignore_cwd:
+    if ipython.ignore_cwd:
         args.append("--ignore-cwd")
 
     chrooted_source_roots = [request.in_chroot(sr) for sr in sources.source_roots]

--- a/src/python/pants/backend/python/goals/tailor.py
+++ b/src/python/pants/backend/python/goals/tailor.py
@@ -135,7 +135,7 @@ async def find_putative_targets(
                     type_alias="python_requirements",
                     triggering_sources=[req_file],
                     owned_sources=[req_file],
-                    addressable=not global_options.options.use_deprecated_python_macros,
+                    addressable=not global_options.use_deprecated_python_macros,
                     kwargs={} if name == "requirements.txt" else {"source": name},
                 )
             )

--- a/src/python/pants/backend/python/lint/yapf/subsystem.py
+++ b/src/python/pants/backend/python/lint/yapf/subsystem.py
@@ -82,7 +82,7 @@ class Yapf(PythonToolBase):
         return ConfigFilesRequest(
             specified=self.config,
             specified_option_name=f"[{self.options_scope}].config",
-            discovery=self.options.config_discovery,
+            discovery=self.config_discovery,
             check_existence=check_existence,
             check_content=check_content,
         )

--- a/src/python/pants/backend/python/macros/deprecation_fixers.py
+++ b/src/python/pants/backend/python/macros/deprecation_fixers.py
@@ -254,7 +254,7 @@ async def maybe_update_macros_references(
     if not update_build_files_subsystem.fix_python_macros:
         return RewrittenBuildFile(request.path, request.lines, ())
 
-    if not global_options.options.use_deprecated_python_macros:
+    if not global_options.use_deprecated_python_macros:
         raise ValueError(
             "`--update-build-files-fix-python-macros` specified when "
             "`[GLOBAL].use_deprecated_python_macros` is already set to false, which means that "

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -98,7 +98,7 @@ class PyTest(PythonToolBase):
         advanced=True,
         help="The maximum timeout (in seconds) that may be used on a `python_tests` target.",
     )
-    juint_family = StrOption(
+    junit_family = StrOption(
         "--junit-family",
         default="xunit2",
         advanced=True,

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -136,9 +136,9 @@ async def setup_pex_cli_process(
     # The certs file will typically not be in the repo, so we can't digest it via a PathGlobs.
     # Instead we manually create a FileContent for it.
     cert_args = []
-    if global_options.options.ca_certs_path:
-        ca_certs_content = Path(global_options.options.ca_certs_path).read_bytes()
-        chrooted_ca_certs_path = os.path.basename(global_options.options.ca_certs_path)
+    if global_options.ca_certs_path:
+        ca_certs_content = Path(global_options.ca_certs_path).read_bytes()
+        chrooted_ca_certs_path = os.path.basename(global_options.ca_certs_path)
 
         gets.append(
             Get(

--- a/src/python/pants/backend/scala/test/scalatest.py
+++ b/src/python/pants/backend/scala/test/scalatest.py
@@ -127,7 +127,7 @@ async def setup_scalatest_for_target(
             "-o",
             "-u",
             reports_dir,
-            *scalatest.options.args,
+            *scalatest.args,
         ],
         input_digest=input_digest,
         extra_immutable_input_digests=extra_immutable_input_digests,

--- a/src/python/pants/backend/shell/shunit2_test_runner.py
+++ b/src/python/pants/backend/shell/shunit2_test_runner.py
@@ -218,7 +218,7 @@ async def setup_shunit2_for_target(
 
     env_dict = {
         "PATH": create_path_env_var(shell_setup.executable_search_path(env)),
-        "SHUNIT_COLOR": "always" if global_options.options.colors else "none",
+        "SHUNIT_COLOR": "always" if global_options.colors else "none",
         **test_extra_env.env,
     }
     argv = (

--- a/src/python/pants/core/goals/repl.py
+++ b/src/python/pants/core/goals/repl.py
@@ -121,7 +121,7 @@ async def run_repl(
         )
         return Repl(-1)
 
-    with temporary_dir(root_dir=global_options.options.pants_workdir, cleanup=False) as tmpdir:
+    with temporary_dir(root_dir=global_options.pants_workdir, cleanup=False) as tmpdir:
         repl_impl = repl_implementation_cls(targets=specified_targets, chroot=tmpdir)
         request = await Get(ReplRequest, ReplImplementation, repl_impl)
 

--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -121,7 +121,7 @@ async def run(
     restartable = wrapped_target.target.get(RestartableField).value
 
     with temporary_dir(
-        root_dir=global_options.options.pants_workdir, cleanup=run_subsystem.cleanup
+        root_dir=global_options.pants_workdir, cleanup=run_subsystem.cleanup
     ) as tmpdir:
         if not run_subsystem.cleanup:
             logger.info(f"Preserving running binary chroot {tmpdir}")

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -419,8 +419,8 @@ async def run_tests(
                 path_prefix=str(dist_dir.relpath / "test" / result.address.path_safe_spec),
             )
 
-    if test_subsystem.options.xml_dir:
-        xml_dir = test_subsystem.options.xml_dir
+    if test_subsystem.xml_dir:
+        xml_dir = test_subsystem.xml_dir
         merged_xml_results = await Get(
             Digest,
             MergeDigests(result.xml_results.digest for result in results if result.xml_results),

--- a/src/python/pants/core/util_rules/distdir.py
+++ b/src/python/pants/core/util_rules/distdir.py
@@ -27,7 +27,7 @@ class DistDir:
 
 @rule
 async def get_distdir(global_options: GlobalOptions, buildroot: BuildRoot) -> DistDir:
-    return validate_distdir(Path(global_options.options.pants_distdir), buildroot.pathlib_path)
+    return validate_distdir(Path(global_options.pants_distdir), buildroot.pathlib_path)
 
 
 def validate_distdir(distdir: Path, buildroot: Path) -> DistDir:

--- a/src/python/pants/core/util_rules/external_tool.py
+++ b/src/python/pants/core/util_rules/external_tool.py
@@ -232,7 +232,7 @@ class ExternalTool(Subsystem, metaclass=ABCMeta):
             "release if you cannot change the version.",
         ]
 
-        if self.options.use_unsupported_version is UnsupportedVersionUsage.LogWarning:
+        if self.use_unsupported_version is UnsupportedVersionUsage.LogWarning:
             msg.extend(
                 [
                     "Alternatively, you can ignore this warning (at your own peril) by adding this",
@@ -241,7 +241,7 @@ class ExternalTool(Subsystem, metaclass=ABCMeta):
                 ]
             )
             logger.warning(" ".join(msg))
-        elif self.options.use_unsupported_version is UnsupportedVersionUsage.RaiseError:
+        elif self.use_unsupported_version is UnsupportedVersionUsage.RaiseError:
             msg.append(
                 f"Alternatively, update [{self.options_scope}].use_unsupported_version to be "
                 f"'warning'."

--- a/src/python/pants/engine/goal.py
+++ b/src/python/pants/engine/goal.py
@@ -30,8 +30,8 @@ class GoalSubsystem(Subsystem):
     ```
     @rule
     def list(console: Console, list_subsystem: ListSubsystem) -> List:
-      transitive = list_subsystem.options.transitive
-      documented = list_subsystem.options.documented
+      transitive = list_subsystem.transitive
+      documented = list_subsystem.documented
       ...
     ```
     """
@@ -117,8 +117,8 @@ class Outputting:
     @contextmanager
     def output_sink(self, console: "Console") -> Iterator:
         stdout_file = None
-        if self.options.output_file:  # type: ignore[attr-defined]
-            stdout_file = open(self.options.output_file, "w")  # type: ignore[attr-defined]
+        if self.output_file:
+            stdout_file = open(self.output_file, "w")
             output_sink = stdout_file
         else:
             output_sink = console.stdout
@@ -145,6 +145,6 @@ class LineOriented(Outputting):
 
         The passed options instance will generally be the `Goal.Options` of an `Outputting` `Goal`.
         """
-        sep = self.options.sep.encode().decode("unicode_escape")  # type: ignore[attr-defined]
+        sep = self.sep.encode().decode("unicode_escape")
         with self.output_sink(console) as output_sink:
             yield lambda msg: print(msg, file=output_sink, end=sep)

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -36,9 +36,9 @@ class BuildFileOptions:
 @rule
 def extract_build_file_options(global_options: GlobalOptions) -> BuildFileOptions:
     return BuildFileOptions(
-        patterns=tuple(global_options.options.build_patterns),
-        ignores=tuple(global_options.options.build_ignore),
-        prelude_globs=tuple(global_options.options.build_file_prelude_globs),
+        patterns=tuple(global_options.build_patterns),
+        ignores=tuple(global_options.build_ignore),
+        prelude_globs=tuple(global_options.build_file_prelude_globs),
     )
 
 
@@ -173,8 +173,9 @@ async def find_target_adaptor(address: Address) -> TargetAdaptor:
 
 @rule
 def setup_address_specs_filter(global_options: GlobalOptions) -> AddressSpecsFilter:
-    opts = global_options.options
-    return AddressSpecsFilter(tags=opts.tag, exclude_target_regexps=opts.exclude_target_regexp)
+    return AddressSpecsFilter(
+        tags=global_options.tag, exclude_target_regexps=global_options.exclude_target_regexp
+    )
 
 
 @rule

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -9,7 +9,7 @@ import logging
 import os.path
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Iterable, NamedTuple, Sequence, cast
+from typing import Iterable, NamedTuple, Sequence
 
 from pants.base.deprecated import warn_or_error
 from pants.base.exceptions import ResolveError
@@ -688,7 +688,7 @@ async def find_owners(owners_request: OwnersRequest) -> Owners:
 
 @rule
 def extract_owners_not_found_behavior(global_options: GlobalOptions) -> OwnersNotFoundBehavior:
-    return cast(OwnersNotFoundBehavior, global_options.options.owners_not_found_behavior)
+    return global_options.owners_not_found_behavior
 
 
 def _log_or_raise_unmatched_owners(
@@ -819,7 +819,7 @@ async def resolve_specs_snapshot(
 
 @rule
 def extract_files_not_found_behavior(global_options: GlobalOptions) -> FilesNotFoundBehavior:
-    return cast(FilesNotFoundBehavior, global_options.options.files_not_found_behavior)
+    return global_options.files_not_found_behavior
 
 
 class AmbiguousCodegenImplementationsException(Exception):
@@ -953,7 +953,7 @@ class SubprojectRoots(Collection[str]):
 
 @rule
 def extract_subproject_roots(global_options: GlobalOptions) -> SubprojectRoots:
-    return SubprojectRoots(global_options.options.subproject_roots)
+    return SubprojectRoots(global_options.subproject_roots)
 
 
 class ParsedDependencies(NamedTuple):

--- a/src/python/pants/engine/internals/options_parsing.py
+++ b/src/python/pants/engine/internals/options_parsing.py
@@ -50,13 +50,12 @@ def scope_options(scope: Scope, options: _Options) -> ScopedOptions:
 
 @rule
 def log_level(global_options: GlobalOptions) -> LogLevel:
-    log_level: LogLevel = global_options.options.level
-    return log_level
+    return global_options.level
 
 
 @rule
 def extract_process_cleanup_option(global_options: GlobalOptions) -> ProcessCleanupOption:
-    return ProcessCleanupOption(global_options.options.process_cleanup)
+    return ProcessCleanupOption(global_options.process_cleanup)
 
 
 @rule

--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -54,7 +54,7 @@ async def resolve_plugins(
     ProcessCacheScope reference in the body.
     """
     requirements = PexRequirements(
-        req_strings=sorted(global_options.options.plugins),
+        req_strings=sorted(global_options.plugins),
         constraints_strings=(str(constraint) for constraint in request.constraints),
     )
     if not requirements:
@@ -85,7 +85,7 @@ async def resolve_plugins(
     # paths in a way that invalidates the Process-cache. See the method doc.
     cache_scope = (
         ProcessCacheScope.PER_SESSION
-        if global_options.options.plugins_force_resolve
+        if global_options.plugins_force_resolve
         else ProcessCacheScope.PER_RESTART_SUCCESSFUL
     )
 

--- a/src/python/pants/jvm/resolve/coursier_setup.py
+++ b/src/python/pants/jvm/resolve/coursier_setup.py
@@ -240,8 +240,7 @@ async def setup_coursier(
     python: PythonBinary,
 ) -> Coursier:
     repos_args = (
-        " ".join(f"-r={shlex.quote(repo)}" for repo in coursier_subsystem.options.repos)
-        + " --no-default"
+        " ".join(f"-r={shlex.quote(repo)}" for repo in coursier_subsystem.repos) + " --no-default"
     )
     coursier_wrapper_script = COURSIER_FETCH_WRAPPER_SCRIPT.format(
         repos_args=repos_args,
@@ -295,7 +294,7 @@ async def setup_coursier(
                 ]
             ),
         ),
-        repos=FrozenOrderedSet(coursier_subsystem.options.repos),
+        repos=FrozenOrderedSet(coursier_subsystem.repos),
     )
 
 

--- a/src/python/pants/jvm/test/junit.py
+++ b/src/python/pants/jvm/test/junit.py
@@ -123,7 +123,7 @@ async def setup_junit_for_target(
             *(("--scan-class-path", user_classpath_arg) if user_classpath_arg else ()),
             "--reports-dir",
             reports_dir,
-            *junit.options.args,
+            *junit.args,
         ],
         input_digest=input_digest,
         extra_immutable_input_digests=extra_immutable_input_digests,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1551,7 +1551,7 @@ class GlobalOptions(BootstrapOptions, Subsystem):
 
     @memoized_property
     def named_caches_dir(self) -> PurePath:
-        return Path(self.options.named_caches_dir).resolve()
+        return Path(self._named_caches_dir).resolve()
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -132,7 +132,7 @@ class SourceRootConfig(Subsystem):
 
     @memoized_method
     def get_pattern_matcher(self) -> SourceRootPatternMatcher:
-        return SourceRootPatternMatcher(self.options.root_patterns)
+        return SourceRootPatternMatcher(self.root_patterns)
 
 
 @frozen_after_init
@@ -322,7 +322,7 @@ async def all_roots(source_root_config: SourceRootConfig) -> AllSourceRoots:
 
     # Create globs for any marker files.
     marker_file_matches: set[str] = set()
-    for marker_filename in source_root_config.options.marker_filenames:
+    for marker_filename in source_root_config.marker_filenames:
         marker_file_matches.add(f"**/{marker_filename}")
 
     # Match the patterns against actual files, to find the roots that actually exist.

--- a/testprojects/pants-plugins/src/python/test_pants_plugin/register.py
+++ b/testprojects/pants-plugins/src/python/test_pants_plugin/register.py
@@ -27,7 +27,7 @@ class LifecycleStubsGoal(Goal):
 
 @goal_rule
 async def run_lifecycle_stubs(opts: LifecycleStubsSubsystem) -> LifecycleStubsGoal:
-    output_file = opts.options.new_interactive_stream_output_file
+    output_file = opts.new_interactive_stream_output_file
     if output_file:
         file_stream = open(output_file, "wb")
     raise Exception("erroneous!")

--- a/testprojects/pants-plugins/src/python/workunit_logger/register.py
+++ b/testprojects/pants-plugins/src/python/workunit_logger/register.py
@@ -68,8 +68,9 @@ def construct_workunits_logger_callback(
     _: WorkunitsLoggerRequest,
     opts: WorkunitsLoggerOptions,
 ) -> WorkunitsCallbackFactory:
-    output_file = opts.options.dest
-    return WorkunitsCallbackFactory(lambda: WorkunitsLogger(output_file))
+    assert opts.dest is not None
+    dest = opts.dest
+    return WorkunitsCallbackFactory(lambda: WorkunitsLogger(dest))
 
 
 def rules():


### PR DESCRIPTION
Now that we're all descriptor/propertyd up, let's use the nice type-safe properties! :raised_hands: 

[ci skip-build-wheels]
[ci skip-rust]