### PR TITLE
Switch from Aegean Check Mark to Multiplication X

### DIFF
--- a/src/python/pants/core/goals/check_test.py
+++ b/src/python/pants/core/goals/check_test.py
@@ -168,8 +168,8 @@ def test_summary() -> None:
     assert stderr == dedent(
         """\
 
-        𐄂 ConditionallySucceedsChecker failed.
-        𐄂 FailingChecker failed.
+        ✕ ConditionallySucceedsChecker failed.
+        ✕ FailingChecker failed.
         ✓ SuccessfulChecker succeeded.
         """
     )
@@ -180,7 +180,7 @@ def test_summary() -> None:
     assert stderr == dedent(
         """\
 
-        𐄂 FailingChecker failed.
+        ✕ FailingChecker failed.
         ✓ SuccessfulChecker succeeded.
         """
     )

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -211,8 +211,8 @@ def test_summary(rule_runner: RuleRunner) -> None:
     assert stderr == dedent(
         """\
 
-        𐄂 ConditionallySucceedsLinter failed.
-        𐄂 FailingLinter failed.
+        ✕ ConditionallySucceedsLinter failed.
+        ✕ FailingLinter failed.
         ✓ FilesLinter succeeded.
         ✓ SuccessfulLinter succeeded.
         """
@@ -228,7 +228,7 @@ def test_summary(rule_runner: RuleRunner) -> None:
     assert stderr == dedent(
         """\
 
-        𐄂 FailingLinter failed.
+        ✕ FailingLinter failed.
         ✓ FilesLinter succeeded.
         """
     )
@@ -252,7 +252,7 @@ def test_batched(rule_runner: RuleRunner, batch_size: int) -> None:
         """\
 
         ✓ ConditionallySucceedsLinter succeeded.
-        𐄂 FailingLinter failed.
+        ✕ FailingLinter failed.
         ✓ SuccessfulLinter succeeded.
         """
     )

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -271,7 +271,7 @@ def test_summary(rule_runner: RuleRunner) -> None:
         """\
 
         ✓ //:good succeeded in 1.00s (memoized).
-        𐄂 //:bad failed in 1.00s (memoized).
+        ✕ //:bad failed in 1.00s (memoized).
         """
     )
 

--- a/src/python/pants/engine/console.py
+++ b/src/python/pants/engine/console.py
@@ -86,7 +86,7 @@ class Console(SideEffecting):
 
     def sigil_failed(self) -> str:
         """Sigil for a failed item."""
-        return self.red("𐄂")
+        return self.red("✕")
 
     def sigil_skipped(self) -> str:
         """Sigil for a skipped item."""


### PR DESCRIPTION
My browser/editor/terminal doesn't support the "Aegean Check Mark" so all I see is a rectangle. "Multiplication X" was chosen because it is the neighbor to "Check Mark" (what we use for the check mark) in the [Dingbat](https://en.wikipedia.org/wiki/Dingbat) block of Unicode 

[ci skip-rust]