### PR TITLE
Target generators (like `python_sources`) now only directly depend on their generated targets

### DIFF
--- a/src/python/pants/backend/codegen/avro/target_types.py
+++ b/src/python/pants/backend/codegen/avro/target_types.py
@@ -78,16 +78,12 @@ class AvroSourcesGeneratorTarget(TargetFilesGenerator):
     alias = "avro_sources"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        AvroDependenciesField,
         AvroSourcesGeneratingSourcesField,
         AvroSourcesOverridesField,
     )
     generated_target_cls = AvroSourceTarget
-    copied_fields = (
-        *COMMON_TARGET_FIELDS,
-        AvroDependenciesField,
-    )
-    moved_fields = ()
+    copied_fields = COMMON_TARGET_FIELDS
+    moved_fields = (AvroDependenciesField,)
     help = "Generate a `avro_source` target for each file in the `sources` field."
 
 

--- a/src/python/pants/backend/codegen/protobuf/target_types.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types.py
@@ -108,16 +108,15 @@ class ProtobufSourcesGeneratorTarget(TargetFilesGenerator):
     alias = "protobuf_sources"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        ProtobufDependenciesField,
         ProtobufSourcesGeneratingSourcesField,
         ProtobufSourcesOverridesField,
     )
     generated_target_cls = ProtobufSourceTarget
-    copied_fields = (
-        *COMMON_TARGET_FIELDS,
+    copied_fields = COMMON_TARGET_FIELDS
+    moved_fields = (
+        ProtobufGrpcToggleField,
         ProtobufDependenciesField,
     )
-    moved_fields = (ProtobufGrpcToggleField,)
     settings_request_cls = GeneratorSettingsRequest
     help = "Generate a `protobuf_source` target for each file in the `sources` field."
 

--- a/src/python/pants/backend/codegen/soap/target_types.py
+++ b/src/python/pants/backend/codegen/soap/target_types.py
@@ -61,12 +61,11 @@ class WsdlSourcesGeneratorTarget(TargetFilesGenerator):
     alias = "wsdl_sources"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        WsdlDependenciesField,
         WsdlSourcesGeneratingSourcesField,
     )
     generated_target_cls = WsdlSourceTarget
-    copied_fields = (*COMMON_TARGET_FIELDS, WsdlDependenciesField)
-    moved_fields = ()
+    copied_fields = COMMON_TARGET_FIELDS
+    moved_fields = (WsdlDependenciesField,)
     help = "Generate a `wsdl_source` target for each file in the `sources` field."
 
 

--- a/src/python/pants/backend/codegen/thrift/target_types.py
+++ b/src/python/pants/backend/codegen/thrift/target_types.py
@@ -96,16 +96,12 @@ class ThriftSourcesGeneratorTarget(TargetFilesGenerator):
     alias = "thrift_sources"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        ThriftDependenciesField,
         ThriftSourcesGeneratingSourcesField,
         ThriftSourcesOverridesField,
     )
     generated_target_cls = ThriftSourceTarget
-    copied_fields = (
-        *COMMON_TARGET_FIELDS,
-        ThriftDependenciesField,
-    )
-    moved_fields = ()
+    copied_fields = (*COMMON_TARGET_FIELDS,)
+    moved_fields = (ThriftDependenciesField,)
     settings_request_cls = GeneratorSettingsRequest
     help = "Generate a `thrift_source` target for each file in the `sources` field."
 

--- a/src/python/pants/backend/java/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/java/dependency_inference/rules_test.py
@@ -391,26 +391,26 @@ def test_dependencies_from_inferred_deps(rule_runner: RuleRunner) -> None:
     # Neither //:t nor either of its source subtargets have explicitly provided deps
     assert (
         rule_runner.request(
-            ExplicitlyProvidedDependencies, [DependenciesRequest(target_t[Dependencies])]
+            ExplicitlyProvidedDependencies, [DependenciesRequest(target_t.get(Dependencies))]
         ).includes
         == FrozenOrderedSet()
     )
     assert (
         rule_runner.request(
-            ExplicitlyProvidedDependencies, [DependenciesRequest(target_a[Dependencies])]
+            ExplicitlyProvidedDependencies, [DependenciesRequest(target_a.get(Dependencies))]
         ).includes
         == FrozenOrderedSet()
     )
     assert (
         rule_runner.request(
-            ExplicitlyProvidedDependencies, [DependenciesRequest(target_b[Dependencies])]
+            ExplicitlyProvidedDependencies, [DependenciesRequest(target_b.get(Dependencies))]
         ).includes
         == FrozenOrderedSet()
     )
 
     # //:t has an automatic dependency on each of its subtargets
     assert rule_runner.request(
-        Addresses, [DependenciesRequest(target_t[Dependencies])]
+        Addresses, [DependenciesRequest(target_t.get(Dependencies))]
     ) == Addresses(
         [
             target_a.address,
@@ -420,13 +420,14 @@ def test_dependencies_from_inferred_deps(rule_runner: RuleRunner) -> None:
 
     # A.java has an inferred dependency on B.java
     assert rule_runner.request(
-        Addresses, [DependenciesRequest(target_a[Dependencies])]
+        Addresses, [DependenciesRequest(target_a.get(Dependencies))]
     ) == Addresses([target_b.address])
 
     # B.java does NOT have a dependency on A.java, as it would if we just had subtargets without
     # inferred dependencies.
     assert (
-        rule_runner.request(Addresses, [DependenciesRequest(target_b[Dependencies])]) == Addresses()
+        rule_runner.request(Addresses, [DependenciesRequest(target_b.get(Dependencies))])
+        == Addresses()
     )
 
 

--- a/src/python/pants/backend/java/target_types.py
+++ b/src/python/pants/backend/java/target_types.py
@@ -75,15 +75,12 @@ class JunitTestsGeneratorTarget(TargetFilesGenerator):
     alias = "junit_tests"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        Dependencies,
         JavaTestsGeneratorSourcesField,
     )
     generated_target_cls = JunitTestTarget
-    copied_fields = (
-        *COMMON_TARGET_FIELDS,
-        Dependencies,
-    )
+    copied_fields = COMMON_TARGET_FIELDS
     moved_fields = (
+        Dependencies,
         JvmJdkField,
         JvmProvidesTypesField,
         JvmResolveField,
@@ -117,15 +114,12 @@ class JavaSourcesGeneratorTarget(TargetFilesGenerator):
     alias = "java_sources"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        Dependencies,
         JavaSourcesGeneratorSourcesField,
     )
     generated_target_cls = JavaSourceTarget
-    copied_fields = (
-        *COMMON_TARGET_FIELDS,
-        Dependencies,
-    )
+    copied_fields = COMMON_TARGET_FIELDS
     moved_fields = (
+        Dependencies,
         JvmResolveField,
         JvmJdkField,
         JvmProvidesTypesField,

--- a/src/python/pants/backend/project_info/peek_test.py
+++ b/src/python/pants/backend/project_info/peek_test.py
@@ -85,7 +85,6 @@ from pants.testutil.rule_runner import RuleRunner
                     "address": "example:files_target",
                     "target_type": "files",
                     "dependencies": [],
-                    "dependencies_raw": null,
                     "description": null,
                     "overrides": null,
                     "sources": [],

--- a/src/python/pants/backend/python/goals/setup_py_test.py
+++ b/src/python/pants/backend/python/goals/setup_py_test.py
@@ -845,8 +845,11 @@ def test_get_requirements() -> None:
                 python_requirement(name='ext3', requirements=['ext3==0.0.1'])
                 """
             ),
-            "src/python/foo/bar/baz/BUILD": "python_sources(dependencies=['3rdparty:ext1'], sources=[])",
-            "src/python/foo/bar/qux/BUILD": "python_sources(dependencies=['3rdparty:ext2', 'src/python/foo/bar/baz'], sources=[])",
+            "src/python/foo/bar/baz/a.py": "",
+            "src/python/foo/bar/baz/BUILD": "python_sources(dependencies=['3rdparty:ext1'])",
+            "src/python/foo/bar/qux/a.py": "",
+            "src/python/foo/bar/qux/BUILD": "python_sources(dependencies=['3rdparty:ext2', 'src/python/foo/bar/baz'])",
+            "src/python/foo/bar/a.py": "",
             "src/python/foo/bar/BUILD": textwrap.dedent(
                 """
                 python_distribution(
@@ -855,12 +858,10 @@ def test_get_requirements() -> None:
                     provides=setup_py(name='bar', version='9.8.7'),
                 )
 
-                python_sources(
-                    sources=[],
-                    dependencies=['src/python/foo/bar/baz', 'src/python/foo/bar/qux'],
-                )
+                python_sources(dependencies=['src/python/foo/bar/baz', 'src/python/foo/bar/qux'])
               """
             ),
+            "src/python/foo/corge/a.py": "",
             "src/python/foo/corge/BUILD": textwrap.dedent(
                 """
                 python_distribution(
@@ -870,10 +871,7 @@ def test_get_requirements() -> None:
                     provides=setup_py(name='corge', version='2.2.2'),
                 )
 
-                python_sources(
-                    sources=[],
-                    dependencies=['src/python/foo/bar'],
-                )
+                python_sources(dependencies=['src/python/foo/bar'])
                 """
             ),
         }
@@ -925,8 +923,11 @@ def test_get_requirements_with_exclude() -> None:
                 python_requirement(name='ext3', requirements=['ext3==0.0.1'])
                 """
             ),
-            "src/python/foo/bar/baz/BUILD": "python_sources(dependencies=['3rdparty:ext1'], sources=[])",
-            "src/python/foo/bar/qux/BUILD": "python_sources(dependencies=['3rdparty:ext2', 'src/python/foo/bar/baz'], sources=[])",
+            "src/python/foo/bar/baz/a.py": "",
+            "src/python/foo/bar/baz/BUILD": "python_sources(dependencies=['3rdparty:ext1'])",
+            "src/python/foo/bar/qux/a.py": "",
+            "src/python/foo/bar/qux/BUILD": "python_sources(dependencies=['3rdparty:ext2', 'src/python/foo/bar/baz'])",
+            "src/python/foo/bar/a.py": "",
             "src/python/foo/bar/BUILD": textwrap.dedent(
                 """
                 python_distribution(
@@ -935,10 +936,7 @@ def test_get_requirements_with_exclude() -> None:
                     provides=setup_py(name='bar', version='9.8.7'),
                 )
 
-                python_sources(
-                    sources=[],
-                    dependencies=['src/python/foo/bar/baz', 'src/python/foo/bar/qux'],
-                )
+                python_sources(dependencies=['src/python/foo/bar/baz', 'src/python/foo/bar/qux'])
               """
             ),
         }
@@ -986,6 +984,8 @@ def test_owned_dependencies() -> None:
                 """
             ),
             "src/python/foo/bar/resource.txt": "",
+            "src/python/foo/bar/bar1.py": "",
+            "src/python/foo/bar/bar2.py": "",
             "src/python/foo/bar/BUILD": textwrap.dedent(
                 """
                 python_distribution(
@@ -996,18 +996,19 @@ def test_owned_dependencies() -> None:
 
                 python_sources(
                     name='bar1',
-                    sources=[],
+                    sources=['bar1.py'],
                     dependencies=['src/python/foo/bar/baz:baz1'],
                 )
 
                 python_sources(
                     name='bar2',
-                    sources=[],
+                    sources=['bar2.py'],
                     dependencies=[':bar-resources', 'src/python/foo/bar/baz:baz2'],
                 )
                 resource(name='bar-resources', source='resource.txt')
                 """
             ),
+            "src/python/foo/foo.py": "",
             "src/python/foo/BUILD": textwrap.dedent(
                 """
                 python_distribution(
@@ -1017,7 +1018,7 @@ def test_owned_dependencies() -> None:
                 )
 
                 python_sources(
-                    sources=[],
+                    sources=['foo.py'],
                     dependencies=['src/python/foo/bar:bar1', 'src/python/foo/bar:bar2'],
                 )
                 """
@@ -1036,14 +1037,18 @@ def test_owned_dependencies() -> None:
         )
 
     assert_owned(
-        ["src/python/foo/bar:bar1", "src/python/foo/bar:bar1-dist", "src/python/foo/bar/baz:baz1"],
+        [
+            "src/python/foo/bar/bar1.py:bar1",
+            "src/python/foo/bar:bar1-dist",
+            "src/python/foo/bar/baz:baz1",
+        ],
         Address("src/python/foo/bar", target_name="bar1-dist"),
     )
     assert_owned(
         [
-            "src/python/foo:foo",
+            "src/python/foo/bar/bar2.py:bar2",
+            "src/python/foo/foo.py",
             "src/python/foo:foo-dist",
-            "src/python/foo/bar:bar2",
             "src/python/foo/bar:bar-resources",
             "src/python/foo/bar/baz:baz2",
         ],
@@ -1103,6 +1108,7 @@ def test_get_owner_simple(exporting_owner_rule_runner: RuleRunner) -> None:
                 """
             ),
             "src/python/foo/bar/resource.ext": "",
+            "src/python/foo/bar/bar2.py": "",
             "src/python/foo/bar/BUILD": textwrap.dedent(
                 """
                 python_distribution(
@@ -1112,12 +1118,12 @@ def test_get_owner_simple(exporting_owner_rule_runner: RuleRunner) -> None:
                 )
                 python_sources(
                     name='bar2',
-                    sources=[],
                     dependencies=[':bar-resources', 'src/python/foo/bar/baz:baz2'],
                 )
                 resource(name='bar-resources', source='resource.ext')
                 """
             ),
+            "src/python/foo/foo2.py": "",
             "src/python/foo/BUILD": textwrap.dedent(
                 """
                 python_distribution(
@@ -1125,7 +1131,7 @@ def test_get_owner_simple(exporting_owner_rule_runner: RuleRunner) -> None:
                     dependencies=['src/python/foo/bar/baz:baz2'],
                     provides=setup_py(name='foo1', version='0.1.2'),
                 )
-                python_sources(name='foo2', sources=[])
+                python_sources(name='foo2')
                 python_distribution(
                     name='foo3',
                     dependencies=['src/python/foo/bar:bar2'],
@@ -1161,7 +1167,7 @@ def test_get_owner_simple(exporting_owner_rule_runner: RuleRunner) -> None:
     assert_is_owner(
         exporting_owner_rule_runner,
         "src/python/foo:foo3",
-        Address("src/python/foo/bar", target_name="bar2"),
+        Address("src/python/foo/bar", target_name="bar2", relative_file_path="bar2.py"),
     )
     assert_is_owner(
         exporting_owner_rule_runner,

--- a/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints_test.py
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints_test.py
@@ -38,10 +38,10 @@ def write_files(rule_runner: RuleRunner) -> None:
             "lib2/a.py": "",
             "lib2/b.py": "",
             "lib2/BUILD": "python_sources()",
+            "app/a.py": "",
             "app/BUILD": dedent(
                 """\
                 python_sources(
-                    sources=[],
                     dependencies=['lib1', 'lib2/a.py', 'lib2/b.py'],
                     interpreter_constraints=['==3.7.*'],
                 )
@@ -81,6 +81,7 @@ def test_render_constraints(rule_runner: RuleRunner) -> None:
 
         CPython==3.7.*
           app:app
+          app/a.py
 
         CPython>=3.6
           lib2/a.py
@@ -102,10 +103,11 @@ def test_constraints_summary(rule_runner: RuleRunner) -> None:
     assert result.stdout == dedent(
         """\
         Target,Constraints,Transitive Constraints,# Dependencies,# Dependees\r
-        app:app,CPython==3.7.*,"CPython==2.7.*,==3.7.*,>=3.6 OR CPython==3.7.*,>=3.5,>=3.6",3,0\r
-        lib1:lib1,CPython==2.7.* OR CPython>=3.5,CPython==2.7.* OR CPython>=3.5,0,1\r
+        app:app,CPython==3.7.*,"CPython==2.7.*,==3.7.*,>=3.6 OR CPython==3.7.*,>=3.5,>=3.6",4,0\r
+        app/a.py,CPython==3.7.*,"CPython==2.7.*,==3.7.*,>=3.6 OR CPython==3.7.*,>=3.5,>=3.6",3,1\r
+        lib1:lib1,CPython==2.7.* OR CPython>=3.5,CPython==2.7.* OR CPython>=3.5,0,2\r
         lib2:lib2,CPython>=3.6,CPython>=3.6,2,0\r
-        lib2/a.py,CPython>=3.6,CPython>=3.6,0,2\r
-        lib2/b.py,CPython>=3.6,CPython>=3.6,0,2\r
+        lib2/a.py,CPython>=3.6,CPython>=3.6,0,3\r
+        lib2/b.py,CPython>=3.6,CPython>=3.6,0,3\r
         """
     )

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -683,6 +683,7 @@ class SkipPythonTestsField(BoolField):
 
 _PYTHON_TEST_MOVED_FIELDS = (
     *COMMON_TARGET_FIELDS,
+    PythonTestsDependenciesField,
     PythonResolveField,
     PythonTestsTimeoutField,
     RuntimePackageDependenciesField,
@@ -744,16 +745,12 @@ class PythonTestsOverrideField(OverridesField):
 class PythonTestsGeneratorTarget(TargetFilesGenerator):
     alias = "python_tests"
     core_fields = (
-        PythonTestsDependenciesField,
         PythonTestsGeneratingSourcesField,
         InterpreterConstraintsField,
         PythonTestsOverrideField,
     )
     generated_target_cls = PythonTestTarget
-    copied_fields = (
-        PythonTestsDependenciesField,
-        InterpreterConstraintsField,
-    )
+    copied_fields = (InterpreterConstraintsField,)
     moved_fields = _PYTHON_TEST_MOVED_FIELDS
     settings_request_cls = PythonFilesGeneratorSettingsRequest
     help = "Generate a `python_test` target for each file in the `sources` field."
@@ -806,17 +803,18 @@ class PythonTestUtilsGeneratorTarget(TargetFilesGenerator):
     # Keep in sync with `PythonSourcesGeneratorTarget`, outside of the `sources` field.
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        Dependencies,
         PythonTestUtilsGeneratingSourcesField,
         PythonSourcesOverridesField,
     )
     generated_target_cls = PythonSourceTarget
     copied_fields = (
         *COMMON_TARGET_FIELDS,
-        Dependencies,
         InterpreterConstraintsField,
     )
-    moved_fields = (PythonResolveField,)
+    moved_fields = (
+        PythonResolveField,
+        Dependencies,
+    )
     settings_request_cls = PythonFilesGeneratorSettingsRequest
     help = (
         "Generate a `python_source` target for each file in the `sources` field.\n\n"
@@ -834,7 +832,6 @@ class PythonSourcesGeneratorTarget(TargetFilesGenerator):
     # Keep in sync with `PythonTestUtilsGeneratorTarget`, outside of the `sources` field.
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        Dependencies,
         PythonSourcesGeneratingSourcesField,
         InterpreterConstraintsField,
         PythonSourcesOverridesField,
@@ -842,10 +839,12 @@ class PythonSourcesGeneratorTarget(TargetFilesGenerator):
     generated_target_cls = PythonSourceTarget
     copied_fields = (
         *COMMON_TARGET_FIELDS,
-        Dependencies,
         InterpreterConstraintsField,
     )
-    moved_fields = (PythonResolveField,)
+    moved_fields = (
+        PythonResolveField,
+        Dependencies,
+    )
     settings_request_cls = PythonFilesGeneratorSettingsRequest
     help = (
         "Generate a `python_source` target for each file in the `sources` field.\n\n"

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem_test.py
@@ -232,7 +232,6 @@ def test_setup_lockfile_interpreter_constraints(rule_runner: RuleRunner) -> None
         dedent(
             """\
             python_sources(
-                sources=[],
                 dependencies=[":thirdparty"],
                 skip_mypy=True,
             )

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -273,14 +273,16 @@ def test_constraints_validation(tmp_path: Path, rule_runner: RuleRunner) -> None
 
     rule_runner.write_files(
         {
+            "util.py": "",
+            "app.py": "",
             "BUILD": dedent(
                 f"""
                 python_requirement(name="foo", requirements=["foo-bar>=0.1.2"])
                 python_requirement(name="bar", requirements=["bar==5.5.5"])
                 python_requirement(name="baz", requirements=["baz"])
                 python_requirement(name="foorl", requirements=["{url_req}"])
-                python_sources(name="util", sources=[], dependencies=[":foo", ":bar"])
-                python_sources(name="app", sources=[], dependencies=[":util", ":baz", ":foorl"])
+                python_sources(name="util", sources=["util.py"], dependencies=[":foo", ":bar"])
+                python_sources(name="app", sources=["app.py"], dependencies=[":util", ":baz", ":foorl"])
                 """
             ),
             "constraints1.txt": dedent(
@@ -415,11 +417,12 @@ def test_issue_12222(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
             "constraints.txt": "\n".join(constraints),
+            "a.py": "",
             "BUILD": dedent(
                 """
                 python_requirement(name="foo",requirements=["foo"])
                 python_requirement(name="bar",requirements=["bar"])
-                python_sources(name="lib",sources=[],dependencies=[":foo"])
+                python_sources(name="lib",dependencies=[":foo"])
                 """
             ),
         }
@@ -434,7 +437,8 @@ def test_issue_12222(rule_runner: RuleRunner) -> None:
         [
             "--python-requirement-constraints=constraints.txt",
             "--python-resolve-all-constraints",
-        ]
+        ],
+        env_inherit={"PATH"},
     )
     result = rule_runner.request(PexRequest, [request])
 

--- a/src/python/pants/backend/scala/target_types.py
+++ b/src/python/pants/backend/scala/target_types.py
@@ -109,14 +109,11 @@ class ScalatestTestsGeneratorTarget(TargetFilesGenerator):
     core_fields = (
         *COMMON_TARGET_FIELDS,
         ScalatestTestsGeneratorSourcesField,
-        ScalaDependenciesField,
     )
     generated_target_cls = ScalatestTestTarget
-    copied_fields = (
-        *COMMON_TARGET_FIELDS,
-        ScalaDependenciesField,
-    )
+    copied_fields = COMMON_TARGET_FIELDS
     moved_fields = (
+        ScalaDependenciesField,
         ScalaConsumedPluginNamesField,
         JvmJdkField,
         JvmProvidesTypesField,
@@ -161,14 +158,11 @@ class ScalaJunitTestsGeneratorTarget(TargetFilesGenerator):
     core_fields = (
         *COMMON_TARGET_FIELDS,
         ScalaJunitTestsGeneratorSourcesField,
-        ScalaDependenciesField,
     )
     generated_target_cls = ScalaJunitTestTarget
-    copied_fields = (
-        *COMMON_TARGET_FIELDS,
-        ScalaDependenciesField,
-    )
+    copied_fields = COMMON_TARGET_FIELDS
     moved_fields = (
+        ScalaDependenciesField,
         ScalaConsumedPluginNamesField,
         JvmJdkField,
         JvmProvidesTypesField,
@@ -214,15 +208,12 @@ class ScalaSourcesGeneratorTarget(TargetFilesGenerator):
     alias = "scala_sources"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        ScalaDependenciesField,
         ScalaSourcesGeneratorSourcesField,
     )
     generated_target_cls = ScalaSourceTarget
-    copied_fields = (
-        *COMMON_TARGET_FIELDS,
-        ScalaDependenciesField,
-    )
+    copied_fields = COMMON_TARGET_FIELDS
     moved_fields = (
+        ScalaDependenciesField,
         ScalaConsumedPluginNamesField,
         JvmResolveField,
         JvmJdkField,

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -182,15 +182,12 @@ class Shunit2TestsGeneratorTarget(TargetFilesGenerator):
     core_fields = (
         *COMMON_TARGET_FIELDS,
         Shunit2TestsGeneratorSourcesField,
-        Shunit2TestDependenciesField,
         Shunit2TestsOverrideField,
     )
     generated_target_cls = Shunit2TestTarget
-    copied_fields = (
-        *COMMON_TARGET_FIELDS,
-        Shunit2TestDependenciesField,
-    )
+    copied_fields = COMMON_TARGET_FIELDS
     moved_fields = (
+        Shunit2TestDependenciesField,
         Shunit2TestTimeoutField,
         SkipShunit2TestsField,
         Shunit2ShellField,
@@ -231,16 +228,12 @@ class ShellSourcesGeneratorTarget(TargetFilesGenerator):
     alias = "shell_sources"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        Dependencies,
         ShellSourcesGeneratingSourcesField,
         ShellSourcesOverridesField,
     )
     generated_target_cls = ShellSourceTarget
-    copied_fields = (
-        *COMMON_TARGET_FIELDS,
-        Dependencies,
-    )
-    moved_fields = ()
+    copied_fields = COMMON_TARGET_FIELDS
+    moved_fields = (Dependencies,)
     help = "Generate a `shell_source` target for each file in the `sources` field."
 
 

--- a/src/python/pants/build_graph/subproject_integration_test.py
+++ b/src/python/pants/build_graph/subproject_integration_test.py
@@ -29,9 +29,11 @@ SUBPROJ_ROOT = "testprojects/src/python/subproject_test/subproject"
 
 
 BUILD_FILES = {
+    f"{SUBPROJ_SPEC}/a.py": "",
     f"{SUBPROJ_SPEC}/BUILD": (
         f"python_sources(dependencies = ['{SUBPROJ_ROOT}/src/python:helpers'])"
     ),
+    f"{SUBPROJ_ROOT}/src/python/a.py": "",
     f"{SUBPROJ_ROOT}/src/python/BUILD": dedent(
         """
         python_sources(
@@ -40,6 +42,7 @@ BUILD_FILES = {
         )
       """
     ),
+    f"{SUBPROJ_ROOT}/src/python/helpershelpers/a.py": "",
     f"{SUBPROJ_ROOT}/src/python/helpershelpers/BUILD": "python_sources()",
     f"{SUBPROJ_ROOT}/BUILD": dedent(
         """\

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -86,16 +86,12 @@ class FilesGeneratorTarget(TargetFilesGenerator):
     alias = "files"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        Dependencies,
         FilesGeneratingSourcesField,
         FilesOverridesField,
     )
     generated_target_cls = FileTarget
-    copied_fields = (
-        *COMMON_TARGET_FIELDS,
-        Dependencies,
-    )
-    moved_fields = ()
+    copied_fields = COMMON_TARGET_FIELDS
+    moved_fields = (Dependencies,)
     help = "Generate a `file` target for each file in the `sources` field."
 
 
@@ -270,16 +266,12 @@ class ResourcesGeneratorTarget(TargetFilesGenerator):
     alias = "resources"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        Dependencies,
         ResourcesGeneratingSourcesField,
         ResourcesOverridesField,
     )
     generated_target_cls = ResourceTarget
-    copied_fields = (
-        *COMMON_TARGET_FIELDS,
-        Dependencies,
-    )
-    moved_fields = ()
+    copied_fields = COMMON_TARGET_FIELDS
+    moved_fields = (Dependencies,)
     help = "Generate a `resource` target for each file in the `sources` field."
 
 

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -154,27 +154,6 @@ def warn_deprecated_field_type(field_type: type[Field]) -> None:
     )
 
 
-@memoized
-def maybe_warn_dependencies_as_copied_field(tgt_type: type[TargetGenerator]) -> None:
-    copied_dependencies_field_types = [
-        field_type.__name__
-        for field_type in tgt_type.copied_fields
-        if issubclass(field_type, Dependencies)
-    ]
-    if copied_dependencies_field_types:
-        warn_or_error(
-            removal_version="2.12.0.dev0",
-            entity=(
-                f"using a `Dependencies` field subclass ({copied_dependencies_field_types}) "
-                "as a `TargetGenerator.copied_field`"
-            ),
-            hint=(
-                "`Dependencies` fields should be `TargetGenerator.moved_field`s, to avoid "
-                "redundant graph edges."
-            ),
-        )
-
-
 @rule
 async def resolve_target_parametrizations(
     address: Address,
@@ -207,7 +186,6 @@ async def resolve_target_parametrizations(
         template_fields = {}
         # TODO: Require for all instances before landing.
         if issubclass(target_type, TargetGenerator):
-            maybe_warn_dependencies_as_copied_field(target_type)
             copied_fields = (
                 *target_type.copied_fields,
                 *target_type._find_plugin_fields(union_membership),

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -121,10 +121,10 @@ class MockGeneratedTarget(Target):
 
 class MockTargetGenerator(TargetFilesGenerator):
     alias = "generator"
-    core_fields = (Dependencies, MultipleSourcesField, OverridesField)
+    core_fields = (MultipleSourcesField, OverridesField)
     generated_target_cls = MockGeneratedTarget
-    copied_fields = (Dependencies,)
-    moved_fields = (Tags, ResolveField)
+    copied_fields = ()
+    moved_fields = (Dependencies, Tags, ResolveField)
 
 
 @pytest.fixture
@@ -1814,10 +1814,10 @@ class SmalltalkLibrary(Target):
 class SmalltalkLibraryGenerator(TargetFilesGenerator):
     alias = "smalltalk_libraries"
     # Note that we use MockDependencies so that we support transitive excludes (`!!`).
-    core_fields = (MockDependencies, MultipleSourcesField)
+    core_fields = (MultipleSourcesField,)
     generated_target_cls = SmalltalkLibrary
-    copied_fields = (MockDependencies,)
-    moved_fields = ()
+    copied_fields = ()
+    moved_fields = (MockDependencies,)
 
 
 class InferSmalltalkDependencies(InferDependenciesRequest):

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1033,10 +1033,13 @@ def _generate_file_level_targets(
 
     def gen_tgt(address: Address, full_fp: str, generated_target_fields: dict[str, Any]) -> Target:
         if add_dependencies_on_all_siblings:
-            if not generator.has_field(Dependencies):
+            if union_membership and not generated_target_cls.class_has_field(
+                Dependencies, union_membership
+            ):
                 raise AssertionError(
-                    f"The `{generator.alias}` target {template_address.spec} does "
-                    "not have a `dependencies` field, and thus cannot "
+                    f"The {type(generator).__name__} target class generates "
+                    f"{generated_target_cls.__name__} targets, which do not "
+                    f"have a `{Dependencies.alias}` field, and thus cannot "
                     "`add_dependencies_on_all_siblings`."
                 )
             original_deps = generated_target_fields.get(Dependencies.alias, ())

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -52,7 +52,7 @@ from pants.util.collections import ensure_list, ensure_str_list
 from pants.util.dirutil import fast_relpath
 from pants.util.docutil import bin_name, doc_url
 from pants.util.frozendict import FrozenDict
-from pants.util.memo import memoized_classproperty, memoized_method, memoized_property
+from pants.util.memo import memoized, memoized_classproperty, memoized_method, memoized_property
 from pants.util.meta import frozen_after_init
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.strutil import bullet_list, pluralize
@@ -810,6 +810,27 @@ class AllTargetsRequest:
 # -----------------------------------------------------------------------------------------------
 
 
+@memoized
+def maybe_warn_dependencies_as_copied_field(tgt_type: type[TargetGenerator]) -> None:
+    copied_dependencies_field_types = [
+        field_type.__name__
+        for field_type in tgt_type.copied_fields
+        if issubclass(field_type, Dependencies)
+    ]
+    if copied_dependencies_field_types:
+        warn_or_error(
+            removal_version="2.12.0.dev0",
+            entity=(
+                f"using a `Dependencies` field subclass ({copied_dependencies_field_types}) "
+                "as a `TargetGenerator.copied_field`"
+            ),
+            hint=(
+                "`Dependencies` fields should be `TargetGenerator.moved_field`s, to avoid "
+                "redundant graph edges."
+            ),
+        )
+
+
 class TargetGenerator(Target):
     """A Target type which generates other Targets via installed `@rule` logic.
 
@@ -841,6 +862,10 @@ class TargetGenerator(Target):
     # acting as a convenient place for them to be specified.
     moved_fields: ClassVar[Tuple[Type[Field], ...]]
 
+    def validate(self) -> None:
+        super().validate()
+        maybe_warn_dependencies_as_copied_field(type(self))
+
 
 class TargetFilesGenerator(TargetGenerator):
     """A TargetGenerator which generates a Target per file matched by the generator.
@@ -851,6 +876,25 @@ class TargetFilesGenerator(TargetGenerator):
     """
 
     settings_request_cls: ClassVar[type[TargetFilesGeneratorSettingsRequest] | None] = None
+
+    def validate(self) -> None:
+        super().validate()
+
+        if self.has_field(MultipleSourcesField) and not self[MultipleSourcesField].value:
+            sources_field = self[MultipleSourcesField]
+            warn_or_error(
+                removal_version="2.12.0.dev0",
+                entity=(
+                    f"specifying an empty `{sources_field.alias}` field for target generator type "
+                    f"`{self.alias}`"
+                ),
+                hint=(
+                    f"The target generator at {self.address} will not generate any targets. If its "
+                    "purpose is to act as an alias for its dependencies, then it should be "
+                    "declared as a `target(..)` generic target instead. If it is unused, then it "
+                    "should be removed."
+                ),
+            )
 
 
 @union

--- a/src/python/pants/vcs/changed_integration_test.py
+++ b/src/python/pants/vcs/changed_integration_test.py
@@ -206,21 +206,23 @@ class ChangedIntegrationTest(unittest.TestCase, AbstractTestGenerator):
                 "src/python/python_targets/test_binary.py:binary_file",
                 "src/python/python_targets/test_library.py:test_library",
                 "src/python/python_targets:test_library",
+                "src/python/python_targets/test_direct_dependee.py:test_library_direct_dependee",
                 # NB: 'src/python/python_targets:test_binary' does not show up here because it is
                 # not a direct dependee of `test_library.py:test_library`; instead, it depends on
                 # `test_binary.py:binary_file`, which is itself a direct dependee.
             ],
             transitive=[
                 "src/python/python_targets/test_binary.py:binary_file",
+                "src/python/python_targets/test_direct_dependee.py:test_library_direct_dependee",
                 "src/python/python_targets/test_library.py:test_library",
+                "src/python/python_targets/test_library_transitive_dependee.py:test_library_transitive_dependee",
+                "src/python/python_targets/test_library_transitive_dependee_2.py:test_library_transitive_dependee_2",
                 "src/python/python_targets:binary_file",
                 "src/python/python_targets:test_binary",
                 "src/python/python_targets:test_library",
                 "src/python/python_targets:test_library_direct_dependee",
                 "src/python/python_targets:test_library_transitive_dependee",
                 "src/python/python_targets:test_library_transitive_dependee_2",
-                "src/python/python_targets:test_library_transitive_dependee_3",
-                "src/python/python_targets:test_library_transitive_dependee_4",
             ],
         ),
         # A `python_sources` with `sources=['file.name'] .
@@ -273,8 +275,7 @@ class ChangedIntegrationTest(unittest.TestCase, AbstractTestGenerator):
         exclude_target_regexp = r"_[0-9]"
         excluded_set = {
             "src/python/python_targets:test_library_transitive_dependee_2",
-            "src/python/python_targets:test_library_transitive_dependee_3",
-            "src/python/python_targets:test_library_transitive_dependee_4",
+            "src/python/python_targets/test_library_transitive_dependee_2.py:test_library_transitive_dependee_2",
         }
         expected_set = set(self.TEST_MAPPING[changed_src]["transitive"]) - excluded_set
 
@@ -304,8 +305,7 @@ class ChangedIntegrationTest(unittest.TestCase, AbstractTestGenerator):
         exclude_target_regexp = r"_[0-9]"
         excluded_set = {
             "src/python/python_targets:test_library_transitive_dependee_2",
-            "src/python/python_targets:test_library_transitive_dependee_3",
-            "src/python/python_targets:test_library_transitive_dependee_4",
+            "src/python/python_targets/test_library_transitive_dependee_2.py:test_library_transitive_dependee_2",
         }
         expected_set = set(self.TEST_MAPPING[changed_src]["transitive"]) - excluded_set
 

--- a/testprojects/src/python/python_targets/BUILD
+++ b/testprojects/src/python/python_targets/BUILD
@@ -7,28 +7,20 @@ pex_binary(name="test_binary", entry_point="test_binary.py", dependencies=[":bin
 
 python_sources(name="test_library", sources=["test_library.py"])
 
-python_sources(name="test_library_direct_dependee", sources=[], dependencies=[":test_library"])
+python_sources(
+    name="test_library_direct_dependee",
+    sources=["test_direct_dependee.py"],
+    dependencies=[":test_library"],
+)
 
 python_sources(
     name="test_library_transitive_dependee",
-    sources=[],
+    sources=["test_library_transitive_dependee.py"],
     dependencies=[":test_library_direct_dependee"],
 )
 
 python_sources(
     name="test_library_transitive_dependee_2",
-    sources=[],
+    sources=["test_library_transitive_dependee_2.py"],
     dependencies=[":test_library_transitive_dependee"],
-)
-
-python_sources(
-    name="test_library_transitive_dependee_3",
-    sources=[],
-    dependencies=[":test_library_transitive_dependee"],
-)
-
-python_sources(
-    name="test_library_transitive_dependee_4",
-    sources=[],
-    dependencies=[":test_library_transitive_dependee_3"],
 )

--- a/testprojects/src/python/python_targets/test_direct_dependee.py
+++ b/testprojects/src/python/python_targets/test_direct_dependee.py
@@ -1,0 +1,8 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from python_targets import test_library
+
+
+def say_test():
+    test_library.say_test()

--- a/testprojects/src/python/python_targets/test_library_transitive_dependee.py
+++ b/testprojects/src/python/python_targets/test_library_transitive_dependee.py
@@ -1,0 +1,2 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).

--- a/testprojects/src/python/python_targets/test_library_transitive_dependee_2.py
+++ b/testprojects/src/python/python_targets/test_library_transitive_dependee_2.py
@@ -1,0 +1,2 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).

--- a/tests/python/pants_test/integration/build_ignore_integration_test.py
+++ b/tests/python/pants_test/integration/build_ignore_integration_test.py
@@ -16,14 +16,16 @@ def test_build_ignore_list() -> None:
 
 def test_build_ignore_dependency() -> None:
     sources = {
-        "dir1/BUILD": "files(sources=[])",
-        "dir2/BUILD": "files(sources=[], dependencies=['{tmpdir}/dir1'])",
+        "dir1/f.txt": "",
+        "dir1/BUILD": "files(sources=['*.txt'])",
+        "dir2/f.txt": "",
+        "dir2/BUILD": "files(sources=['*.txt'], dependencies=['{tmpdir}/dir1'])",
     }
     with setup_tmpdir(sources) as tmpdir:
         ignore_result = run_pants(
-            [f"--build-ignore={tmpdir}/dir1", "dependencies", f"{tmpdir}/dir2"]
+            [f"--build-ignore={tmpdir}/dir1", "dependencies", f"{tmpdir}/dir2/f.txt"]
         )
-        no_ignore_result = run_pants(["dependencies", f"{tmpdir}/dir2"])
+        no_ignore_result = run_pants(["dependencies", f"{tmpdir}/dir2/f.txt"])
     ignore_result.assert_failure()
     assert f"{tmpdir}/dir1" in ignore_result.stderr
     no_ignore_result.assert_success()


### PR DESCRIPTION
Move (rather than copy) `Dependencies` fields from generators to generated targets. This avoids redundant graph edges and calculations for explicit dependencies. And in particular, it prevents us from needing to fill in missing parameters when computing the dependencies of generators (which is challenging, since they no longer have the `Field`s corresponding to their address values for comparison) for #14519.

This has a lot of fallout in tests, which in many cases were using "empty" generator targets (with no sources) as inner graph nodes. Because the target will no longer keep explicitly specified dependencies if it doesn't have sources, those targets either need to gain sources, or become generic `target`s.

To warn users of this behavior change, we additionally deprecate declaring a generator target with an explicitly empty `sources=[]` field.

[ci skip-build-wheels]