### PR TITLE
Upgrade Pex to 2.1.71. (Cherry-pick of #14768)

### DIFF
--- a/3rdparty/python/lockfiles/user_reqs.txt
+++ b/3rdparty/python/lockfiles/user_reqs.txt
@@ -17,7 +17,7 @@
 #     "humbug==0.2.7",
 #     "ijson==3.1.4",
 #     "packaging==21.3",
-#     "pex==2.1.70",
+#     "pex==2.1.71",
 #     "psutil==5.9.0",
 #     "pydevd-pycharm==203.5419.8",
 #     "pytest<8,>=6.2.4",
@@ -141,9 +141,9 @@ iniconfig==1.1.1; python_version >= "3.6" \
 packaging==21.3; python_version >= "3.6" \
     --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522 \
     --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb
-pex==2.1.70; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0" and python_version < "3.11") \
-    --hash=sha256:83801a1006b7f42bef9abf5b96dbbd676cc739fcffc7f604f80cc6f9d0d9c703 \
-    --hash=sha256:bddf329765bfe1db7d2ce8336de2f99b73bacb789fcc1c78882fa52183cc5bfd
+pex==2.1.71; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0" and python_version < "3.11") \
+    --hash=sha256:7b65897566bb5bcbc2d3c62adaad61db3a2a100244250ec61dcd59a3e4f5fe1f \
+    --hash=sha256:8c9ec9e2ea432f55f512eb7591459d26edc88769a178d16dd3023e41364c2a8c
 pluggy==1.0.0; python_version >= "3.6" \
     --hash=sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3 \
     --hash=sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -14,7 +14,7 @@ humbug==0.2.7
 
 ijson==3.1.4
 packaging==21.3
-pex==2.1.70
+pex==2.1.71
 psutil==5.9.0
 pytest>=6.2.4,<8  # This should be compatible with pytest.py, although it can be looser so that we don't over-constrain pantsbuild.pants.testutil
 python-lsp-jsonrpc==1.0.0

--- a/src/python/pants/backend/python/subsystems/lambdex_lockfile.txt
+++ b/src/python/pants/backend/python/subsystems/lambdex_lockfile.txt
@@ -17,6 +17,6 @@
 lambdex==0.1.6; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0" and python_version < "3.10") \
     --hash=sha256:cb685b106617fbd1afd26d6e9472b2e0c99df8574c6d358aee4e6c13aeef8eb1 \
     --hash=sha256:6d1a95c8a31baa703edece8e36a705045b0203c7e886812c27a4dd945aa694e0
-pex==2.1.70; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "3.10" \
-    --hash=sha256:83801a1006b7f42bef9abf5b96dbbd676cc739fcffc7f604f80cc6f9d0d9c703 \
-    --hash=sha256:bddf329765bfe1db7d2ce8336de2f99b73bacb789fcc1c78882fa52183cc5bfd
+pex==2.1.71; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "3.10" \
+    --hash=sha256:7b65897566bb5bcbc2d3c62adaad61db3a2a100244250ec61dcd59a3e4f5fe1f \
+    --hash=sha256:8c9ec9e2ea432f55f512eb7591459d26edc88769a178d16dd3023e41364c2a8c

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -42,9 +42,9 @@ class PexCli(TemplatedExternalTool):
     deprecated_options_scope = "download-pex-bin"
     deprecated_options_scope_removal_version = "2.11.0.dev0"
 
-    default_version = "v2.1.70"
+    default_version = "v2.1.71"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.1.70,<3.0"
+    version_constraints = ">=2.1.71,<3.0"
 
     @classproperty
     def default_known_versions(cls):
@@ -53,8 +53,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "b0cbd713fc8d0bc590980748d5e2a57cecc02f11e9c881df4861a980597b8c33",
-                    "3785513",
+                    "d7fddbdfc374b78768fee6729a53077593a6ad6834df401fff4061ad5602cb19",
+                    "3734831",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64"]


### PR DESCRIPTION
This fixes issues in the 2.1.68-2.1.70 series with a new internal
layout.

Changelog: https://github.com/pantsbuild/pex/releases/tag/v2.1.71
(cherry picked from commit 920b186a31b7028a8f5e30bb0298e7626b9fd7e1)

[ci skip-rust]
[ci skip-build-wheels]