### PR TITLE
Deprecate `Subsystem.register_options` in favor of the new attribute-based Option types

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -59,6 +59,11 @@ build_ignore.add = [
   "testprojects/src/go/**",
 ]
 
+ignore_warnings.add = [
+  # TODO: `toolchain.pants.plugin==0.17.0` must still use the old options system
+  "DEPRECATED: pants.option.subsystem.register_options"
+]
+
 # NB: Users must still set `--remote-cache-{read,write}` to enable the remote cache.
 remote_store_address = "grpcs://cache.toolchain.com:443"
 remote_instance_name = "main"

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -12,7 +12,7 @@ from pants.engine.unions import UnionMembership
 from pants.help.help_info_extracter import HelpInfoExtracter, pretty_print_type_hint, to_help_str
 from pants.option.config import Config
 from pants.option.global_options import GlobalOptions
-from pants.option.option_types import BoolOption, IntOption, StrListOption
+from pants.option.option_types import BoolOption, IntOption
 from pants.option.options import Options
 from pants.option.parser import Parser
 from pants.option.ranked_value import Rank, RankedValue
@@ -235,8 +235,7 @@ def test_get_all_help_info():
         options_scope = "foo"
         help = "A foo."
 
-        opt2 = BoolOption("--opt2", default=True, help="Option 2")
-        opt3 = StrListOption("--opt3", advanced=True, default=["a", "b", "c"])
+        opt2 = BoolOption("--opt2", default=True, advanced=True, help="Option 2")
 
     class Bar(GoalSubsystem):
         name = "bar"
@@ -334,7 +333,8 @@ def test_get_all_help_info():
                 "description": "A foo.",
                 "is_goal": False,
                 "deprecated_scope": None,
-                "basic": (
+                "basic": (),
+                "advanced": (
                     {
                         "display_args": ("--[no-]foo-opt2",),
                         "comma_separated_display_args": "--[no-]foo-opt2",
@@ -351,28 +351,6 @@ def test_get_all_help_info():
                         "typ": bool,
                         "default": True,
                         "help": "Option 2",
-                        "deprecation_active": False,
-                        "deprecated_message": None,
-                        "removal_version": None,
-                        "removal_hint": None,
-                        "choices": None,
-                        "comma_separated_choices": None,
-                    },
-                ),
-                "advanced": (
-                    {
-                        "display_args": ("--foo-opt3=<str>",),
-                        "comma_separated_display_args": "--foo-opt3=<str>",
-                        "scoped_cmd_line_args": ("--foo-opt3",),
-                        "unscoped_cmd_line_args": ("--opt3",),
-                        "config_key": "opt3",
-                        "env_var": "PANTS_FOO_OPT3",
-                        "value_history": {
-                            "ranked_values": ({"rank": Rank.NONE, "value": None, "details": None},),
-                        },
-                        "typ": str,
-                        "default": ["a", "b", "c"],
-                        "help": "No help available.",
                         "deprecation_active": False,
                         "deprecated_message": None,
                         "removal_version": None,

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -12,7 +12,7 @@ from pants.engine.unions import UnionMembership
 from pants.help.help_info_extracter import HelpInfoExtracter, pretty_print_type_hint, to_help_str
 from pants.option.config import Config
 from pants.option.global_options import GlobalOptions
-from pants.option.option_types import IntOption
+from pants.option.option_types import BoolOption, IntOption, StrListOption
 from pants.option.options import Options
 from pants.option.parser import Parser
 from pants.option.ranked_value import Rank, RankedValue
@@ -235,10 +235,8 @@ def test_get_all_help_info():
         options_scope = "foo"
         help = "A foo."
 
-        @classmethod
-        def register_options(cls, register):
-            register("--opt2", type=bool, default=True, help="Option 2")
-            register("--opt3", advanced=True, choices=["a", "b", "c"])
+        opt2 = BoolOption("--opt2", default=True, help="Option 2")
+        opt3 = StrListOption("--opt3", advanced=True, default=["a", "b", "c"])
 
     class Bar(GoalSubsystem):
         name = "bar"
@@ -373,14 +371,14 @@ def test_get_all_help_info():
                             "ranked_values": ({"rank": Rank.NONE, "value": None, "details": None},),
                         },
                         "typ": str,
-                        "default": None,
+                        "default": ["a", "b", "c"],
                         "help": "No help available.",
                         "deprecation_active": False,
                         "deprecated_message": None,
                         "removal_version": None,
                         "removal_hint": None,
-                        "choices": ("a", "b", "c"),
-                        "comma_separated_choices": "a, b, c",
+                        "choices": None,
+                        "comma_separated_choices": None,
                     },
                 ),
                 "deprecated": tuple(),

--- a/src/python/pants/option/option_types_test.py
+++ b/src/python/pants/option/option_types_test.py
@@ -37,6 +37,7 @@ from pants.option.option_types import (
     TargetOption,
 )
 from pants.option.subsystem import Subsystem
+from pants.option.options import Options
 
 if TYPE_CHECKING:
     from mypy_typing_asserts import assert_type
@@ -92,8 +93,8 @@ def test_option_typeclasses(option_type, default, option_value, expected_registe
         dyn_help = "Dynamic Help"
         dyn_default = default
 
-    register = Mock()
-    MySubsystem.register_options(register)
+    #register = Mock()
+    #MySubsystem.register_options_on_scope(register)
     my_subsystem = MySubsystem()
     default_if_not_given: Any | None = [] if expected_register_kwargs["type"] is list else None
     transform_opt: Any = tuple if expected_register_kwargs["type"] is list else lambda x: x  # type: ignore

--- a/src/python/pants/option/option_types_test.py
+++ b/src/python/pants/option/option_types_test.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from enum import Enum
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
-from unittest.mock import Mock, call
 
 import pytest
 
@@ -28,6 +27,7 @@ from pants.option.option_types import (
     IntOption,
     MemorySizeListOption,
     MemorySizeOption,
+    OptionsInfo,
     ShellStrListOption,
     ShellStrOption,
     SkipOption,
@@ -35,9 +35,9 @@ from pants.option.option_types import (
     StrOption,
     TargetListOption,
     TargetOption,
+    collect_options_info,
 )
 from pants.option.subsystem import Subsystem
-from pants.option.options import Options
 
 if TYPE_CHECKING:
     from mypy_typing_asserts import assert_type
@@ -46,6 +46,13 @@ if TYPE_CHECKING:
 class MyEnum(Enum):
     Val1 = "val1"
     Val2 = "val2"
+
+
+def opt_info(*names, **options):
+    return OptionsInfo(
+        flag_names=names,
+        flag_options=options,
+    )
 
 
 @pytest.mark.parametrize(
@@ -93,17 +100,18 @@ def test_option_typeclasses(option_type, default, option_value, expected_registe
         dyn_help = "Dynamic Help"
         dyn_default = default
 
-    #register = Mock()
-    #MySubsystem.register_options_on_scope(register)
-    my_subsystem = MySubsystem()
     default_if_not_given: Any | None = [] if expected_register_kwargs["type"] is list else None
-    transform_opt: Any = tuple if expected_register_kwargs["type"] is list else lambda x: x  # type: ignore
 
-    assert register.call_args_list == [
-        call("--opt", default=default, help="", **expected_register_kwargs),
-        call("--opt-no-default", default=default_if_not_given, help="", **expected_register_kwargs),
-        call("--dyn-opt", default=default, help="Dynamic Help", **expected_register_kwargs),
+    assert list(collect_options_info(MySubsystem)) == [
+        opt_info("--opt", default=default, help="", **expected_register_kwargs),
+        opt_info(
+            "--opt-no-default", default=default_if_not_given, help="", **expected_register_kwargs
+        ),
+        opt_info("--dyn-opt", default=default, help="Dynamic Help", **expected_register_kwargs),
     ]
+
+    my_subsystem = MySubsystem()
+    transform_opt: Any = tuple if expected_register_kwargs["type"] is list else lambda x: x  # type: ignore
     assert my_subsystem.prop == transform_opt(option_value)
     assert my_subsystem.prop_no_default == transform_opt(option_value)
     assert my_subsystem.dyn_prop == transform_opt(option_value)
@@ -148,25 +156,23 @@ def test_other_options() -> None:
         dyn_default = MyEnum.Val1
         dyn_default_list = [MyEnum.Val1]
 
-    register = Mock()
-    MySubsystem.register_options(register)
-    my_subsystem = MySubsystem()
-
-    assert register.call_args_list == [
-        call("--enum-opt", default=MyEnum.Val1, help="", type=MyEnum),
-        call("--dyn-enum-opt", default=MyEnum.Val1, type=MyEnum, help="Dynamic Help"),
-        call("--optional-enum-opt", default=None, help="", type=MyEnum),
-        call("--enum-list-opt", default=[MyEnum.Val1], help="", type=list, member_type=MyEnum),
-        call(
+    assert list(collect_options_info(MySubsystem)) == [
+        opt_info("--enum-opt", default=MyEnum.Val1, help="", type=MyEnum),
+        opt_info("--dyn-enum-opt", default=MyEnum.Val1, type=MyEnum, help="Dynamic Help"),
+        opt_info("--optional-enum-opt", default=None, help="", type=MyEnum),
+        opt_info("--enum-list-opt", default=[MyEnum.Val1], help="", type=list, member_type=MyEnum),
+        opt_info(
             "--dyn-enum-list-opt",
             default=[MyEnum.Val1],
             help="Dynamic Help",
             type=list,
             member_type=MyEnum,
         ),
-        call("--defaultless-enum-list-opt", default=[], help="", type=list, member_type=MyEnum),
-        call("--dict-opt", default={}, help="", type=dict),
+        opt_info("--defaultless-enum-list-opt", default=[], help="", type=list, member_type=MyEnum),
+        opt_info("--dict-opt", default={}, help="", type=dict),
     ]
+
+    my_subsystem = MySubsystem()
     assert my_subsystem.enum_prop == MyEnum.Val2
     assert my_subsystem.dyn_enum_prop == MyEnum.Val2
     assert my_subsystem.optional_enum_prop == MyEnum.Val2
@@ -199,20 +205,16 @@ def test_specialized_options() -> None:
         args_prop1 = ArgsListOption(example="--nail")
         args_prop2 = ArgsListOption(example="--screw", tool_name="Screwdriver")
 
-    register = Mock()
-    MySubsystem.register_options(register)
-    SubsystemWithName.register_options(register)
-
-    def expected_skip_call(help: str):
-        return call(
+    def expected_skip_opt_info(help: str):
+        return opt_info(
             "--skip",
             help=help,
             default=False,
             type=bool,
         )
 
-    def expected_args_call(help: str):
-        return call(
+    def expected_args_opt_info(help: str):
+        return opt_info(
             "--args",
             member_type=shell_str,
             help=help,
@@ -220,23 +222,25 @@ def test_specialized_options() -> None:
             type=list,
         )
 
-    assert register.call_args_list == [
-        expected_skip_call("Don't use Wrench when running `./pants fmt` and `./pants lint`."),
-        expected_skip_call("Don't use Wrench when running `./pants fmt`."),
-        expected_args_call(
+    assert list(collect_options_info(MySubsystem)) == [
+        expected_skip_opt_info("Don't use Wrench when running `./pants fmt` and `./pants lint`."),
+        expected_skip_opt_info("Don't use Wrench when running `./pants fmt`."),
+        expected_args_opt_info(
             "Arguments to pass directly to Wrench, e.g. `--my-subsystem-args='--foo'`."
         ),
-        expected_args_call(
+        expected_args_opt_info(
             "Arguments to pass directly to Drill, e.g. `--my-subsystem-args='--bar'`."
         ),
-        expected_args_call(
+        expected_args_opt_info(
             "Arguments to pass directly to Wrench, e.g. `--my-subsystem-args='--baz'`.\n\nSwing it!"
         ),
-        expected_skip_call("Don't use Hammer when running `./pants fmt`."),
-        expected_args_call(
+    ]
+    assert list(collect_options_info(SubsystemWithName)) == [
+        expected_skip_opt_info("Don't use Hammer when running `./pants fmt`."),
+        expected_args_opt_info(
             "Arguments to pass directly to Hammer, e.g. `--other-subsystem-args='--nail'`."
         ),
-        expected_args_call(
+        expected_args_opt_info(
             "Arguments to pass directly to Screwdriver, e.g. `--other-subsystem-args='--screw'`."
         ),
     ]
@@ -289,13 +293,11 @@ def test_subsystem_option_ordering() -> None:
         b_prop = StrOption("--b", default=None, help="")
         a_prop = StrOption("--a", default=None, help="")
 
-    register = Mock()
-    MySubsystem.register_options(register)
-    assert register.call_args_list == [
-        call("--z", type=str, default=None, help=""),
-        call("--y", type=str, default=None, help=""),
-        call("--b", type=str, default=None, help=""),
-        call("--a", type=str, default=None, help=""),
+    assert list(collect_options_info(MySubsystem)) == [
+        opt_info("--z", type=str, default=None, help=""),
+        opt_info("--y", type=str, default=None, help=""),
+        opt_info("--b", type=str, default=None, help=""),
+        opt_info("--a", type=str, default=None, help=""),
     ]
 
 
@@ -348,10 +350,9 @@ def test_register_if(cls) -> None:
         truthy = True
         falsey = False
 
-    register = Mock()
-    MySubsystem.register_options(register)
-    assert len(register.call_args_list) == 1
-    assert register.call_args_list[0][0] == ("--registered",)
+    options_info = list(collect_options_info(MySubsystem))
+    assert len(options_info) == 1
+    assert options_info[0].flag_names == ("--registered",)
 
 
 def test_property_types() -> None:

--- a/src/python/pants/option/options_integration_test.py
+++ b/src/python/pants/option/options_integration_test.py
@@ -55,6 +55,8 @@ def test_deprecation_and_ignore_warnings(use_pantsd: bool) -> None:
 
             deprecated = StrOption(
                 "--deprecated",
+                default=None,
+                help="doens't matter",
                 removal_version="999.99.9.dev0",
                 removal_hint="blah",
             )

--- a/src/python/pants/option/options_integration_test.py
+++ b/src/python/pants/option/options_integration_test.py
@@ -46,20 +46,18 @@ def test_deprecation_and_ignore_warnings(use_pantsd: bool) -> None:
     plugin = dedent(
         """\
         from pants.option.subsystem import Subsystem
+        from pants.option.option_types import StrOption
         from pants.engine.rules import SubsystemRule
 
         class Options(Subsystem):
             help = "Options just for a test."
             options_scope = "mock-options"
 
-            @classmethod
-            def register_options(cls, register):
-                super().register_options(register)
-                register(
-                    "--deprecated",
-                    removal_version="999.99.9.dev0",
-                    removal_hint="blah",
-                )
+            deprecated = StrOption(
+                "--deprecated",
+                removal_version="999.99.9.dev0",
+                removal_hint="blah",
+            )
 
         def rules():
             return [SubsystemRule(Options)]

--- a/src/python/pants/option/subsystem.py
+++ b/src/python/pants/option/subsystem.py
@@ -8,6 +8,7 @@ import inspect
 import re
 from abc import ABCMeta
 from typing import Any, ClassVar, TypeVar
+from pants.base.deprecated import deprecated
 
 from pants.engine.internals.selectors import AwaitableConstraints, Get
 from pants.option.errors import OptionsError
@@ -96,6 +97,10 @@ class Subsystem(metaclass=ABCMeta):
         return cls.create_scope_info(scope=cls.options_scope, subsystem_cls=cls)
 
     @classmethod
+    @deprecated(
+        removal_version="2.12.0.dev0",
+        hint="Declare class attributes using the types in pants/option.option_types.py",
+    )
     def register_options(cls, register):
         """Register options for this Subsystem.
 
@@ -110,7 +115,9 @@ class Subsystem(metaclass=ABCMeta):
 
         Subclasses should not generally need to override this method.
         """
-        cls.register_options(options.registration_function_for_subsystem(cls))
+        register = options.registration_function_for_subsystem(cls)
+        for options_info in collect_options_info(cls):
+            register(*options_info.flag_names, **options_info.flag_options)
 
     def __init__(self, options: OptionValueContainer) -> None:
         self.validate_scope()

--- a/src/python/pants/option/subsystem.py
+++ b/src/python/pants/option/subsystem.py
@@ -8,8 +8,8 @@ import inspect
 import re
 from abc import ABCMeta
 from typing import Any, ClassVar, TypeVar
-from pants.base.deprecated import deprecated
 
+from pants.base.deprecated import deprecated
 from pants.engine.internals.selectors import AwaitableConstraints, Get
 from pants.option.errors import OptionsError
 from pants.option.option_types import collect_options_info
@@ -99,15 +99,16 @@ class Subsystem(metaclass=ABCMeta):
     @classmethod
     @deprecated(
         removal_version="2.12.0.dev0",
-        hint="Declare class attributes using the types in pants/option.option_types.py",
+        hint=(
+            "Options are now registered by declaring class attributes using the types in "
+            "pants/option.option_types.py"
+        ),
     )
     def register_options(cls, register):
         """Register options for this Subsystem.
 
         Subclasses may override and call register(*args, **kwargs).
         """
-        for options_info in collect_options_info(cls):
-            register(*options_info.flag_names, **options_info.flag_options)
 
     @classmethod
     def register_options_on_scope(cls, options):
@@ -118,6 +119,10 @@ class Subsystem(metaclass=ABCMeta):
         register = options.registration_function_for_subsystem(cls)
         for options_info in collect_options_info(cls):
             register(*options_info.flag_names, **options_info.flag_options)
+
+        # NB: Still call `register_options` for classes which haven't switched
+        if cls.register_options is not Subsystem.register_options:
+            cls.register_options(register)
 
     def __init__(self, options: OptionValueContainer) -> None:
         self.validate_scope()


### PR DESCRIPTION
It's been a long road, and honestly the fun can only start beginning.