### PR TITLE
Improve REPL multiple resolves error to mention `[python].default_resolve` (Cherry-pick of #14778)

### DIFF
--- a/src/python/pants/backend/python/goals/repl.py
+++ b/src/python/pants/backend/python/goals/repl.py
@@ -51,8 +51,9 @@ def validate_compatible_resolve(root_targets: Iterable[Target], python_setup: Py
                 'Then, run `./pants peek :: | jq -r \'.[] | select(.resolve == "example") | '
                 '.["address"]\' | xargs ./pants repl`, where you replace "example" with the '
                 "resolve name, and possibly replace the specs `::` with what you were using "
-                "before. This will result in opening a REPL with only targets using the desired "
-                "resolve."
+                "before. If the resolve is the `[python].default_resolve`, use "
+                '`select(.resolve == "example" or .resolve == null)`. These queries will result in '
+                "opening a REPL with only targets using the desired resolve."
             ),
         )
 


### PR DESCRIPTION
`./pants hep` will not have eagerly applied the default for the resolve field, so this is necessary to add.

Note that it's wrong to use `or .resolve == null` for any resolve but the default.

[ci skip-rust]
# Building wheels and fs_util will be skipped. Delete if not intended.
[ci skip-build-wheels]