### PR TITLE
Fix a coverage config rewriting bug.

### DIFF
--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -240,25 +240,6 @@ class CoverageConfig:
     path: str
 
 
-def _validate_and_update_config(
-    coverage_config: configparser.ConfigParser, config_path: str | None
-) -> None:
-    if not coverage_config.has_section("run"):
-        coverage_config.add_section("run")
-    run_section = coverage_config["run"]
-    relative_files_str = run_section.get("relative_files", "True")
-    if relative_files_str.lower() != "true":
-        raise ValueError(
-            "relative_files under the 'run' section must be set to True in the config "
-            f"file {config_path}"
-        )
-    coverage_config.set("run", "relative_files", "True")
-    omit_elements = list(run_section.get("omit", "").split("\n")) or ["\n"]
-    if "pytest.pex/*" not in omit_elements:
-        omit_elements.append("pytest.pex/*")
-    run_section["omit"] = "\n".join(omit_elements)
-
-
 class InvalidCoverageConfigError(Exception):
     pass
 
@@ -340,6 +321,7 @@ async def create_or_update_coverage_config(coverage: CoverageSubsystem) -> Cover
         cp.set("run", "omit", "\npytest.pex/*")
         stream = StringIO()
         cp.write(stream)
+        # We know that .coveragerc doesn't exist, so it's fine to create one.
         file_content = FileContent(".coveragerc", stream.getvalue().encode())
     digest = await Get(Digest, CreateDigest([file_content]))
     return CoverageConfig(digest, file_content.path)

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -336,8 +336,14 @@ def test_extra_output(rule_runner: RuleRunner) -> None:
 
 
 def test_coverage(rule_runner: RuleRunner) -> None:
+    # Note that we test that rewriting the pyproject.toml doesn't cause a collision
+    # between the two code paths by which we pick up that file (coverage and pytest).
     rule_runner.write_files(
-        {f"{PACKAGE}/tests.py": GOOD_TEST, f"{PACKAGE}/BUILD": "python_tests()"}
+        {
+            "pyproject.toml": "[tool.coverage.report]\n[tool.pytest.ini_options]",
+            f"{PACKAGE}/tests.py": GOOD_TEST,
+            f"{PACKAGE}/BUILD": "python_tests()",
+        }
     )
     tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="tests.py"))
     result = run_pytest(rule_runner, tgt, extra_args=["--test-use-coverage"])


### PR DESCRIPTION
We rewrite standard config files (e.g., pyproject.toml) to modify the coverage config. 
This caused a collision when we merge digests that contain the rewritten and original 
versions of the same file.

[ci skip-rust]

[ci skip-build-wheels]