### PR TITLE
[internal] Add helm backend to init/BUILD and generate_docs

### DIFF
--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -209,6 +209,7 @@ def run_pants_help_all() -> dict[str, Any]:
         "pants.backend.docker",
         "pants.backend.docker.lint.hadolint",
         "pants.backend.experimental.go",
+        "pants.backend.experimental.helm",
         "pants.backend.experimental.java",
         "pants.backend.experimental.java.lint.google_java_format",
         "pants.backend.experimental.python",

--- a/src/python/pants/init/BUILD
+++ b/src/python/pants/init/BUILD
@@ -16,6 +16,7 @@ target(
         "src/python/pants/backend/experimental/debian",
         "src/python/pants/backend/experimental/go",
         "src/python/pants/backend/experimental/go/lint/vet",
+        "src/python/pants/backend/experimental/helm",
         "src/python/pants/backend/experimental/java",
         "src/python/pants/backend/experimental/java/debug_goals",
         "src/python/pants/backend/experimental/java/lint/google_java_format",


### PR DESCRIPTION
Follow up for #14658 adding missing hooks for the new experimental Helm backend