### PR TITLE
[internal] Fix assignment of wrong type when reading `lint_strict` field value

### DIFF
--- a/src/python/pants/backend/helm/goals/lint.py
+++ b/src/python/pants/backend/helm/goals/lint.py
@@ -40,7 +40,7 @@ async def run_helm_lint(request: HelmLintRequest, helm_subsystem: HelmSubsystem)
     def create_process(chart: HelmChart, field_set: HelmLintFieldSet) -> HelmProcess:
         argv = ["lint", chart.path]
 
-        strict = field_set.lint_strict or helm_subsystem.lint_strict
+        strict: bool = field_set.lint_strict.value or helm_subsystem.lint_strict
         if strict:
             argv.append("--strict")
 

--- a/src/python/pants/backend/helm/goals/lint_test.py
+++ b/src/python/pants/backend/helm/goals/lint_test.py
@@ -124,7 +124,7 @@ def test_global_lint_strict_chart_failing(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
             "BUILD": "helm_chart(name='mychart')",
-            "Chart.yaml": gen_chart_file("mychart", version="0.1.0", icon="wrong URL"),
+            "Chart.yaml": gen_chart_file("mychart", version="0.1.0", icon=None),
             "values.yaml": HELM_VALUES_FILE,
             "templates/_helpers.tpl": HELM_TEMPLATE_HELPERS_FILE,
             "templates/ingress.yaml": K8S_INGRESS_FILE_WITH_LINT_WARNINGS,
@@ -143,9 +143,7 @@ def test_lint_strict_chart_passing(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
             "BUILD": "helm_chart(name='mychart', lint_strict=True)",
-            "Chart.yaml": gen_chart_file(
-                "mychart", version="0.1.0", icon="http://wwww.example.com/icon.png"
-            ),
+            "Chart.yaml": gen_chart_file("mychart", version="0.1.0", icon=None),
             "values.yaml": HELM_VALUES_FILE,
             "templates/_helpers.tpl": HELM_TEMPLATE_HELPERS_FILE,
             "templates/service.yaml": K8S_SERVICE_FILE,


### PR DESCRIPTION
The was something weird in the way I had initially implemented the tests for the `lint` goal in the Helm backend so I did a close inspection with fresh eyes and noticed that the `run_helm_lint` rule was using the wrong type, making the `if strict:` test always return true.

The fix adds a type ascription to ensure it typechecks and removes extra clutter in the tests.