### PR TITLE
Update default interpreter constraints and universe.

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -62,7 +62,7 @@ class PythonProtobufMypyPlugin(PythonToolRequirementsBase):
     default_version = "mypy-protobuf==2.10"
 
     register_interpreter_constraints = True
-    default_interpreter_constraints = ["CPython>=3.6"]
+    default_interpreter_constraints = ["CPython>=3.7,<4"]
 
     register_lockfile = True
     default_lockfile_resource = (

--- a/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
+++ b/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
@@ -37,7 +37,7 @@ class DockerfileParser(PythonToolRequirementsBase):
     default_version = "dockerfile==3.2.0"
 
     register_interpreter_constraints = True
-    default_interpreter_constraints = ["CPython>=3.7"]
+    default_interpreter_constraints = ["CPython>=3.7,<4"]
 
     register_lockfile = True
     default_lockfile_resource = (_DOCKERFILE_PACKAGE, "dockerfile_lockfile.txt")

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -114,7 +114,7 @@ class CoverageSubsystem(PythonToolBase):
     default_main = ConsoleScript("coverage")
 
     register_interpreter_constraints = True
-    default_interpreter_constraints = ["CPython>=3.6,<4"]
+    default_interpreter_constraints = ["CPython>=3.7,<4"]
 
     register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.subsystems", "coverage_py_lockfile.txt")

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -32,7 +32,7 @@ class Black(PythonToolBase):
     default_main = ConsoleScript("black")
 
     register_interpreter_constraints = True
-    default_interpreter_constraints = ["CPython>=3.6.2"]
+    default_interpreter_constraints = ["CPython>=3.7,<4"]
 
     register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.lint.black", "lockfile.txt")

--- a/src/python/pants/backend/python/lint/docformatter/subsystem.py
+++ b/src/python/pants/backend/python/lint/docformatter/subsystem.py
@@ -23,7 +23,7 @@ class Docformatter(PythonToolBase):
     default_main = ConsoleScript("docformatter")
 
     register_interpreter_constraints = True
-    default_interpreter_constraints = ["CPython>=3.6"]
+    default_interpreter_constraints = ["CPython>=3.7,<4"]
 
     register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.lint.docformatter", "lockfile.txt")

--- a/src/python/pants/backend/python/lint/pyupgrade/subsystem.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/subsystem.py
@@ -26,7 +26,7 @@ class PyUpgrade(PythonToolBase):
     default_main = ConsoleScript("pyupgrade")
 
     register_interpreter_constraints = True
-    default_interpreter_constraints = ["CPython>=3.7"]
+    default_interpreter_constraints = ["CPython>=3.7,<4"]
 
     register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.lint.pyupgrade", "lockfile.txt")

--- a/src/python/pants/backend/python/lint/yapf/subsystem.py
+++ b/src/python/pants/backend/python/lint/yapf/subsystem.py
@@ -29,7 +29,7 @@ class Yapf(PythonToolBase):
     default_main = ConsoleScript("yapf")
 
     register_interpreter_constraints = True
-    default_interpreter_constraints = ["CPython>=3.6"]
+    default_interpreter_constraints = ["CPython>=3.7,<4"]
 
     register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.lint.yapf", "lockfile.txt")

--- a/src/python/pants/backend/python/packaging/pyoxidizer/subsystem.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/subsystem.py
@@ -19,6 +19,6 @@ class PyOxidizer(PythonToolBase):
     default_main = ConsoleScript("pyoxidizer")
 
     register_interpreter_constraints = True
-    default_interpreter_constraints = ["CPython>=3.8"]
+    default_interpreter_constraints = ["CPython>=3.8,<4"]
 
     args = ArgsListOption(example="--release")

--- a/src/python/pants/backend/python/subsystems/lambdex.py
+++ b/src/python/pants/backend/python/subsystems/lambdex.py
@@ -20,7 +20,7 @@ class Lambdex(PythonToolBase):
     default_main = ConsoleScript("lambdex")
 
     register_interpreter_constraints = True
-    default_interpreter_constraints = ["CPython>=3.6,<3.10"]
+    default_interpreter_constraints = ["CPython>=3.7,<3.10"]
 
     register_lockfile = True
     default_lockfile_resource = (

--- a/src/python/pants/backend/python/subsystems/poetry.py
+++ b/src/python/pants/backend/python/subsystems/poetry.py
@@ -27,7 +27,7 @@ class PoetrySubsystem(PythonToolRequirementsBase):
     default_version = "poetry==1.1.8"
 
     register_interpreter_constraints = True
-    default_interpreter_constraints = ["CPython>=3.6"]
+    default_interpreter_constraints = ["CPython>=3.7,<4"]
 
 
 # We must monkeypatch Poetry to include `setuptools` and `wheel` in the lockfile. This was fixed

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -40,8 +40,8 @@ class PythonSetup(Subsystem):
     options_scope = "python"
     help = "Options for Pants's Python backend."
 
-    default_interpreter_constraints = ["CPython>=3.6,<4"]
-    default_interpreter_universe = ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
+    default_interpreter_constraints = ["CPython>=3.7,<4"]
+    default_interpreter_universe = ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
 
     interpreter_constraints = StrListOption(
         "--interpreter-constraints",

--- a/src/python/pants/backend/python/subsystems/twine.py
+++ b/src/python/pants/backend/python/subsystems/twine.py
@@ -35,7 +35,7 @@ class TwineSubsystem(PythonToolBase):
     default_extra_requirements = ["colorama>=0.4.3"]
 
     register_interpreter_constraints = True
-    default_interpreter_constraints = ["CPython>=3.6"]
+    default_interpreter_constraints = ["CPython>=3.7,<4"]
 
     register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.subsystems", "twine_lockfile.txt")

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -79,7 +79,7 @@ class MyPy(PythonToolBase):
 
     # See `mypy/rules.py`. We only use these default constraints in some situations.
     register_interpreter_constraints = True
-    default_interpreter_constraints = ["CPython>=3.6"]
+    default_interpreter_constraints = ["CPython>=3.7,<4"]
 
     register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.typecheck.mypy", "lockfile.txt")

--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -38,7 +38,7 @@ class TerraformHcl2Parser(PythonToolRequirementsBase):
     default_version = "python-hcl2==3.0.3"
 
     register_interpreter_constraints = True
-    default_interpreter_constraints = ["CPython>=3.6"]
+    default_interpreter_constraints = ["CPython>=3.7,<4"]
 
     register_lockfile = True
     default_lockfile_resource = ("pants.backend.terraform", "hcl2_lockfile.txt")


### PR DESCRIPTION
Fixes #14722 

* Bump the default minimum version in constraints from 3.6 to 3.7, now that 3.6 is EOL.
* Set an explicit max of <4 on constraints.
* Add 3.11 to the universe of known interpreter versions.

[ci skip-rust]

[ci skip-build-wheels]