### PR TITLE
go: make go protobuf codegen fallible

### DIFF
--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -117,8 +117,10 @@ async def setup_build_go_package_target_request(
 
     codegen_request = maybe_get_codegen_request_type(target, union_membership)
     if codegen_request:
-        codegen_result = await Get(BuildGoPackageRequest, GoCodegenBuildRequest, codegen_request)
-        return FallibleBuildGoPackageRequest(codegen_result, codegen_result.import_path)
+        codegen_result = await Get(
+            FallibleBuildGoPackageRequest, GoCodegenBuildRequest, codegen_request
+        )
+        return codegen_result
 
     embed_config: EmbedConfig | None = None
     if target.has_field(GoPackageSourcesField):

--- a/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
@@ -49,7 +49,7 @@ class GoCodegenBuildFilesRequest(GoCodegenBuildRequest):
 
 
 @rule
-async def generate_from_file(request: GoCodegenBuildFilesRequest) -> BuildGoPackageRequest:
+async def generate_from_file(request: GoCodegenBuildFilesRequest) -> FallibleBuildGoPackageRequest:
     content = dedent(
         """\
         package gen
@@ -71,14 +71,17 @@ async def generate_from_file(request: GoCodegenBuildFilesRequest) -> BuildGoPack
     thirdparty_dep = await Get(FallibleBuildGoPackageRequest, BuildGoPackageTargetRequest(deps[0]))
     assert thirdparty_dep.request is not None
 
-    return BuildGoPackageRequest(
+    return FallibleBuildGoPackageRequest(
+        request=BuildGoPackageRequest(
+            import_path="codegen.com/gen",
+            digest=digest,
+            dir_path="codegen",
+            go_file_names=("f.go",),
+            s_file_names=(),
+            direct_dependencies=(thirdparty_dep.request,),
+            minimum_go_version=None,
+        ),
         import_path="codegen.com/gen",
-        digest=digest,
-        dir_path="codegen",
-        go_file_names=("f.go",),
-        s_file_names=(),
-        direct_dependencies=(thirdparty_dep.request,),
-        minimum_go_version=None,
     )
 
 


### PR DESCRIPTION
Teach Go protobuf codegen to output `FallibleBuildGoPackageRequest` instead of `BuildGoPackageRequest` so that `./pants check` can proceed even if there are errors.