### PR TITLE
Add `SSL_CERT_DIR` and `SSL_CERT_FILE` to the default for `[subprocess-environment].env_vars`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -282,7 +282,6 @@ jobs:
   build_wheels_linux:
     container: quay.io/pypa/manylinux2014_x86_64:latest
     env:
-      PANTS_CA_CERTS_PATH: /opt/_internal/certs.pem
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: ${{ github.repository_owner == 'pantsbuild' }}

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -487,10 +487,7 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
                     "runs-on": LINUX_VERSION,
                     "container": "quay.io/pypa/manylinux2014_x86_64:latest",
                     "timeout-minutes": 65,
-                    "env": {
-                        **DISABLE_REMOTE_CACHE_ENV,
-                        "PANTS_CA_CERTS_PATH": "/opt/_internal/certs.pem",
-                    },
+                    "env": DISABLE_REMOTE_CACHE_ENV,
                     "if": IS_PANTS_OWNER,
                     "steps": [
                         *checkout(),

--- a/src/python/pants/core/util_rules/subprocess_environment.py
+++ b/src/python/pants/core/util_rules/subprocess_environment.py
@@ -20,9 +20,9 @@ class SubprocessEnvironment(Subsystem):
 
     _env_vars = StrListOption(
         "--env-vars",
-        default=["LANG", "LC_CTYPE", "LC_ALL"],
+        default=["LANG", "LC_CTYPE", "LC_ALL", "SSL_CERT_FILE", "SSL_CERT_DIR"],
         help=(
-            "Environment variables to set for process invocations. "
+            "Environment variables to set for process invocations.\n\n"
             "Entries are either strings in the form `ENV_VAR=value` to set an explicit value; "
             "or just `ENV_VAR` to copy the value from Pants's own environment."
         ),


### PR DESCRIPTION
As explained at https://github.com/pantsbuild/pex/issues/1674 and discussed in https://pantsbuild.slack.com/archives/C0D7TNJHL/p1647388552764289, Python's `ssl` std-lib looks to `SSL_CERT_FILE` when it is not explicitly told what cert to load. Pex's lockfile consumption uses that code path, so by Pants stripping `SSL_CERT_FILE` from the environment by default, certs fail to work in certain environments.

https://github.com/pantsbuild/pex/issues/1674 proposes instead teaching Pex to bundle fallback certs via `certifi`. But we can't control other ecosystems as tightly as Pex like that, so we decided in Slack it makes more sense for us to by default propagate `SSL_CERT_FILE` so that by default things Just Work.

As before, users can override `[GLOBAL].ca_certs_path` if they don't want to rely on the `SSL_CERT_FILE` fallback.

Note that there is some remote caching downside to including `SSL_CERT_FILE` in the default: if the value diverges between machines, then the cache cannot be used. Because this env var seems to be standard with OpenSSL, that's fine. Also, admins trying to optimize cross-machine cache hits can always remove this setting.