### PR TITLE
[internal] Remove deprecated empty generator sources lists

### DIFF
--- a/src/python/pants/backend/project_info/count_loc_test.py
+++ b/src/python/pants/backend/project_info/count_loc_test.py
@@ -98,6 +98,6 @@ def test_files_without_owners(rule_runner: RuleRunner) -> None:
 
 def test_no_sources_exits_gracefully(rule_runner: RuleRunner) -> None:
     py_dir = "src/py/foo"
-    rule_runner.write_files({f"{py_dir}/BUILD": "python_sources(sources=[])"})
+    rule_runner.write_files({f"{py_dir}/BUILD": "python_sources()"})
     result = rule_runner.run_goal_rule(CountLinesOfCode, args=[py_dir])
     assert result == GoalRuleResult.noop()

--- a/src/python/pants/backend/project_info/peek_test.py
+++ b/src/python/pants/backend/project_info/peek_test.py
@@ -172,7 +172,7 @@ def rule_runner() -> RuleRunner:
 
 
 def test_non_matching_build_target(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files({"some_name/BUILD": "files(sources=[])"})
+    rule_runner.write_files({"some_name/BUILD": "target()"})
     result = rule_runner.run_goal_rule(Peek, args=["other_name"])
     assert result.stdout == "[]\n"
 

--- a/src/python/pants/backend/python/goals/setup_py_test.py
+++ b/src/python/pants/backend/python/goals/setup_py_test.py
@@ -596,11 +596,12 @@ def test_generate_long_description_field_from_non_existing_file(
 def test_invalid_binary(chroot_rule_runner: RuleRunner) -> None:
     chroot_rule_runner.write_files(
         {
+            "src/python/invalid_binary/lib.py": "",
             "src/python/invalid_binary/app1.py": "",
             "src/python/invalid_binary/app2.py": "",
             "src/python/invalid_binary/BUILD": textwrap.dedent(
                 """\
-                python_sources(name='not_a_binary', sources=[])
+                python_sources(name='not_a_binary', sources=['lib.py'])
                 pex_binary(name='invalid_entrypoint_unowned1', entry_point='app1.py')
                 pex_binary(name='invalid_entrypoint_unowned2', entry_point='invalid_binary.app2')
                 python_distribution(
@@ -979,8 +980,8 @@ def test_owned_dependencies() -> None:
         {
             "src/python/foo/bar/baz/BUILD": textwrap.dedent(
                 """
-                python_sources(name='baz1', sources=[])
-                python_sources(name='baz2', sources=[])
+                python_sources(name='baz1')
+                python_sources(name='baz2')
                 """
             ),
             "src/python/foo/bar/resource.txt": "",
@@ -1103,8 +1104,8 @@ def test_get_owner_simple(exporting_owner_rule_runner: RuleRunner) -> None:
         {
             "src/python/foo/bar/baz/BUILD": textwrap.dedent(
                 """
-                python_sources(name='baz1', sources=[])
-                python_sources(name='baz2', sources=[])
+                python_sources(name='baz1')
+                python_sources(name='baz2')
                 """
             ),
             "src/python/foo/bar/resource.ext": "",
@@ -1186,7 +1187,7 @@ def test_get_owner_siblings(exporting_owner_rule_runner: RuleRunner) -> None:
         {
             "src/python/siblings/BUILD": textwrap.dedent(
                 """
-                python_sources(name='sibling1', sources=[])
+                python_sources(name='sibling1')
                 python_distribution(
                     name='sibling2',
                     dependencies=['src/python/siblings:sibling1'],
@@ -1214,7 +1215,7 @@ def test_get_owner_not_an_ancestor(exporting_owner_rule_runner: RuleRunner) -> N
         {
             "src/python/notanancestor/aaa/BUILD": textwrap.dedent(
                 """
-                python_sources(name='aaa', sources=[])
+                python_sources(name='aaa')
                 """
             ),
             "src/python/notanancestor/bbb/BUILD": textwrap.dedent(
@@ -1242,7 +1243,7 @@ def test_get_owner_multiple_ancestor_generations(exporting_owner_rule_runner: Ru
         {
             "src/python/aaa/bbb/ccc/BUILD": textwrap.dedent(
                 """
-                python_sources(name='ccc', sources=[])
+                python_sources(name='ccc')
                 """
             ),
             "src/python/aaa/bbb/BUILD": textwrap.dedent(

--- a/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints_test.py
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints_test.py
@@ -31,7 +31,7 @@ def rule_runner() -> RuleRunner:
 def write_files(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "lib1/BUILD": "python_sources(sources=[], interpreter_constraints=['==2.7.*', '>=3.5'])",
+            "lib1/BUILD": "python_sources(interpreter_constraints=['==2.7.*', '>=3.5'])",
             # We leave off `interpreter_constraints`, which results in using
             # `[python].interpreter_constraints` instead. Also, we create files so that we
             # can test how generated file-level targets render.

--- a/src/python/pants/engine/streaming_workunit_handler_integration_test.py
+++ b/src/python/pants/engine/streaming_workunit_handler_integration_test.py
@@ -53,7 +53,7 @@ def confirm_eventual_success(log_dest: str) -> None:
 
 
 def test_list() -> None:
-    run(["list", "{tmpdir}/foo::"], files={"foo/BUILD": "files(sources=[])"})
+    run(["list", "{tmpdir}/foo::"], files={"foo/BUILD": "target()"})
 
 
 def test_help() -> None:

--- a/tests/python/pants_test/integration/build_ignore_integration_test.py
+++ b/tests/python/pants_test/integration/build_ignore_integration_test.py
@@ -5,7 +5,7 @@ from pants.testutil.pants_integration_test import run_pants, setup_tmpdir
 
 
 def test_build_ignore_list() -> None:
-    with setup_tmpdir({"dir/BUILD": "files(sources=[])"}) as tmpdir:
+    with setup_tmpdir({"dir/BUILD": "target()"}) as tmpdir:
         ignore_result = run_pants([f"--build-ignore={tmpdir}/dir", "list", f"{tmpdir}/dir"])
         no_ignore_result = run_pants(["list", f"{tmpdir}/dir"])
     ignore_result.assert_failure()

--- a/tests/python/pants_test/logging/native_engine_logging_integration_test.py
+++ b/tests/python/pants_test/logging/native_engine_logging_integration_test.py
@@ -10,7 +10,7 @@ from pants_test.pantsd.pantsd_integration_test_base import PantsDaemonIntegratio
 def test_native_logging() -> None:
     expected_msg = r"\[DEBUG\] Launching \d+ root"
 
-    with setup_tmpdir({"foo/BUILD": "files(sources=[])"}) as tmpdir:
+    with setup_tmpdir({"foo/BUILD": "target()"}) as tmpdir:
         pants_run = run_pants(
             ["-linfo", "--backend-packages=pants.backend.python", "list", f"{tmpdir}/foo::"]
         )
@@ -27,7 +27,7 @@ def test_native_logging() -> None:
 class PantsdNativeLoggingTest(PantsDaemonIntegrationTestBase):
     def test_pantsd_file_logging(self) -> None:
         with self.pantsd_successful_run_context("debug") as ctx:
-            with setup_tmpdir({"foo/BUILD": "files(sources=[])"}) as tmpdir:
+            with setup_tmpdir({"foo/BUILD": "target()"}) as tmpdir:
                 daemon_run = ctx.runner(
                     ["--backend-packages=pants.backend.python", "list", f"{tmpdir}/foo::"]
                 )

--- a/tests/python/pants_test/pantsd/pantsd_integration_test.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test.py
@@ -62,7 +62,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
 
     def test_pantsd_run(self):
         with self.pantsd_successful_run_context(log_level="debug") as ctx:
-            with setup_tmpdir({"foo/BUILD": "files(sources=[])"}) as tmpdir:
+            with setup_tmpdir({"foo/BUILD": "target()"}) as tmpdir:
                 ctx.runner(["list", f"{tmpdir}/foo::"])
                 ctx.checker.assert_started()
 


### PR DESCRIPTION
Remove the deprecated use of `sources=[]` lists for generators for #14766.

[ci skip-rust]
[ci skip-build-wheels]