### PR TITLE
Swap the order of generated names and parameters in Addresses.

### DIFF
--- a/src/python/pants/build_graph/address_test.py
+++ b/src/python/pants/build_graph/address_test.py
@@ -9,6 +9,7 @@ from pants.build_graph.address import (
     Address,
     AddressInput,
     AddressParseException,
+    InvalidParameters,
     InvalidSpecPath,
     InvalidTargetName,
 )
@@ -69,6 +70,9 @@ def test_address_input_parse_spec() -> None:
     # Parameters
     assert_parsed("a@k=v", path_component="a", parameters={"k": "v"})
     assert_parsed("a@k1=v1,k2=v2", path_component="a", parameters={"k1": "v1", "k2": "v2"})
+    assert_parsed(
+        "a#gen@k1=v1", generated_component="gen", path_component="a", parameters={"k1": "v1"}
+    )
 
     # Absolute spec
     assert_parsed("//a/b/c", path_component="a/b/c")
@@ -109,7 +113,6 @@ def test_address_input_parse_bad_path_component(spec: str) -> None:
         ("a:", "non-empty target name"),
         ("a@t", "one or more key=value pairs"),
         ("a@=", "one or more key=value pairs"),
-        ("a@t=", "one or more key=value pairs"),
         ("a@t,y", "one or more key=value pairs"),
         ("a@t=,y", "one or more key=value pairs"),
         ("a#", "non-empty generated target name"),
@@ -140,9 +143,15 @@ def test_address_bad_target_component(spec: str) -> None:
         AddressInput.parse(spec).dir_to_address()
 
 
-@pytest.mark.parametrize("spec", ["//:t#gen@", "//:t#gen!", "//:t#gen?", "//:t#gen=", "//:t#gen#"])
+@pytest.mark.parametrize("spec", ["//:t#gen!", "//:t#gen?", "//:t#gen=", "//:t#gen#"])
 def test_address_generated_name(spec: str) -> None:
     with pytest.raises(InvalidTargetName):
+        AddressInput.parse(spec).dir_to_address()
+
+
+@pytest.mark.parametrize("spec", ["//:t@k=#gen", "//:t@k#gen=v"])
+def test_address_invalid_params(spec: str) -> None:
+    with pytest.raises(InvalidParameters):
         AddressInput.parse(spec).dir_to_address()
 
 
@@ -357,8 +366,8 @@ def test_address_spec() -> None:
     )
     assert_spec(
         Address("a/b", generated_name="gen", parameters={"k": "v"}),
-        expected="a/b@k=v#gen",
-        expected_path_spec="a.b@@k=v@gen",
+        expected="a/b#gen@k=v",
+        expected_path_spec="a.b@gen@@k=v",
     )
     assert_spec(
         Address("a/b", relative_file_path="f.ext", parameters={"k": "v"}),
@@ -452,6 +461,14 @@ def test_address_create_generated() -> None:
         (
             Address("", target_name="t", parameters={"k": "v"}),
             AddressInput("", "t", parameters=FrozenDict({"k": "v"})),
+        ),
+        (
+            Address("", target_name="t", parameters={"k": "v"}, generated_name="gen"),
+            AddressInput("", "t", parameters=FrozenDict({"k": "v"}), generated_component="gen"),
+        ),
+        (
+            Address("", target_name="t", parameters={"k": ""}),
+            AddressInput("", "t", parameters=FrozenDict({"k": ""})),
         ),
         (
             Address("", target_name="t", parameters={"k1": "v1", "k2": "v2"}),

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -24,7 +24,7 @@ from pants.engine.process import InteractiveProcessResult
 class AddressParseException(Exception):
     pass
 
-def address_parse(spec: str) -> tuple[str, str | None, tuple[tuple[str, str], ...], str | None]: ...
+def address_parse(spec: str) -> tuple[str, str | None, str | None, tuple[tuple[str, str], ...]]: ...
 
 # ------------------------------------------------------------------------------
 # Scheduler

--- a/src/rust/engine/src/externs/address.rs
+++ b/src/rust/engine/src/externs/address.rs
@@ -23,8 +23,8 @@ pub fn register(py: Python, m: &PyModule) -> PyResult<()> {
 type ParsedAddress<'a> = (
   &'a str,
   Option<&'a str>,
-  Vec<(&'a str, &'a str)>,
   Option<&'a str>,
+  Vec<(&'a str, &'a str)>,
 );
 
 /// Parses an Address spec into:
@@ -39,7 +39,7 @@ fn address_parse(spec: &str) -> PyResult<ParsedAddress> {
   Ok((
     address.path,
     address.target,
-    address.parameters,
     address.generated,
+    address.parameters,
   ))
 }


### PR DESCRIPTION
During design for #13882, we agreed that parameters should come after the generated name for targets, but the initial version landed with the opposite order. This change swaps them to the agreed upon order.

[ci skip-build-wheels]