### PR TITLE
Change default `[python].resolves` from `3rdparty/python/default_lockfile.txt` to `3rdparty/python/default.lock`

### DIFF
--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -165,7 +165,7 @@ class PythonSetup(Subsystem):
             "--resolves",
             advanced=True,
             type=dict,
-            default={"python-default": "3rdparty/python/user_requirements.lock"},
+            default={"python-default": "3rdparty/python/default.lock"},
             help=(
                 "A mapping of logical names to lockfile paths used in your project.\n\n"
                 "Many organizations only need a single resolve for their whole project, which is "

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -165,7 +165,7 @@ class PythonSetup(Subsystem):
             "--resolves",
             advanced=True,
             type=dict,
-            default={"python-default": "3rdparty/python/default_lock.txt"},
+            default={"python-default": "3rdparty/python/user_requirements.lock"},
             help=(
                 "A mapping of logical names to lockfile paths used in your project.\n\n"
                 "Many organizations only need a single resolve for their whole project, which is "
@@ -193,6 +193,8 @@ class PythonSetup(Subsystem):
                 "If a target can work with multiple resolves, create a distinct target per "
                 "resolve. This will be made more ergonomic in an upcoming Pants release through a "
                 "new `parametrize` feature.\n\n"
+                "You can name the lockfile paths what you would like; Pants does not expect a "
+                "certain file extension or location.\n\n"
                 "Only applies if `[python].enable_resolves` is true."
             ),
         )


### PR DESCRIPTION
## Problem

In Pants 2.11, we add support for Pex lockfiles. While it is not illegal to call a Pex lockfile `default_lockfile.txt`, using `.txt` is a misnomer: it's actually a JSONC file. But we also decided in https://github.com/pantsbuild/pants/pull/13930 that we want to call lockfiles `.lock` to emphasize you should not hand-edit them.

## Solution

Use the same naming scheme from https://github.com/pantsbuild/pants/pull/13930 that JVM uses: `3rdparty/python/default.lock`.

When changing from Poetry to Pex lockfiles, no need to rename the file.

### Alternative name

I personally like `3rdparty/python/user_requirements.lock` more than the `default.lock`. But we already have a convention from JVM and we should not break those users. So the consistency seemed valuable here.

There's probably wisdom in using `default.lock`: it works better if you add a second lockfile but keep the normal `python-default`.

[ci skip-rust]
[ci skip-build-wheels]