### PR TITLE
`python_sources` and `python_tests` target generators no longer impact interpreter constraints calculations

### DIFF
--- a/src/python/pants/backend/python/lint/black/subsystem_test.py
+++ b/src/python/pants/backend/python/lint/black/subsystem_test.py
@@ -29,12 +29,12 @@ def test_setup_lockfile_interpreter_constraints() -> None:
 
     global_constraint = "==3.9.*"
     rule_runner.set_options(
-        ["--black-lockfile=lockfile.txt"],
+        ["--black-lockfile=lockfile.txt", "--no-python-infer-imports"],
         env={"PANTS_PYTHON_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"},
     )
 
     def assert_ics(build_file: str, expected: list[str]) -> None:
-        rule_runner.write_files({"project/BUILD": build_file})
+        rule_runner.write_files({"project/BUILD": build_file, "project/f.py": ""})
         lockfile_request = rule_runner.request(GeneratePythonLockfile, [BlackLockfileSentinel()])
         assert lockfile_request.interpreter_constraints == InterpreterConstraints(expected)
 

--- a/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints.py
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints.py
@@ -15,8 +15,8 @@ from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, Outputting
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
 from pants.engine.target import (
+    AllTargets,
     AllTargetsRequest,
-    AllUnexpandedTargets,
     RegisteredTargetTypes,
     TransitiveTargets,
     TransitiveTargetsRequest,
@@ -69,8 +69,7 @@ async def py_constraints(
             )
             return PyConstraintsGoal(exit_code=1)
 
-        # TODO: Stop including the target generator? I don't think it's relevant for this goal.
-        all_targets = await Get(AllUnexpandedTargets, AllTargetsRequest())
+        all_targets = await Get(AllTargets, AllTargetsRequest())
         all_python_targets = tuple(
             t for t in all_targets if t.has_field(InterpreterConstraintsField)
         )

--- a/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints_test.py
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints_test.py
@@ -14,7 +14,9 @@ from pants.backend.python.mixed_interpreter_constraints.py_constraints import (
 )
 from pants.backend.python.target_types import (
     PythonSourcesGeneratorTarget,
+    PythonSourceTarget,
     PythonTestsGeneratorTarget,
+    PythonTestTarget,
 )
 from pants.core.target_types import FileTarget
 from pants.testutil.rule_runner import GoalRuleResult, RuleRunner
@@ -24,17 +26,23 @@ from pants.testutil.rule_runner import GoalRuleResult, RuleRunner
 def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=(*py_constraints_rules(), *target_types_rules.rules()),
-        target_types=[FileTarget, PythonSourcesGeneratorTarget, PythonTestsGeneratorTarget],
+        target_types=[
+            FileTarget,
+            PythonSourcesGeneratorTarget,
+            PythonTestsGeneratorTarget,
+            PythonSourceTarget,
+            PythonTestTarget,
+        ],
     )
 
 
 def write_files(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
+            "lib1/a.py": "",
             "lib1/BUILD": "python_sources(interpreter_constraints=['==2.7.*', '>=3.5'])",
             # We leave off `interpreter_constraints`, which results in using
-            # `[python].interpreter_constraints` instead. Also, we create files so that we
-            # can test how generated file-level targets render.
+            # `[python].interpreter_constraints` instead.
             "lib2/a.py": "",
             "lib2/b.py": "",
             "lib2/BUILD": "python_sources()",
@@ -43,7 +51,7 @@ def write_files(rule_runner: RuleRunner) -> None:
                 """\
                 python_sources(
                     dependencies=['lib1', 'lib2/a.py', 'lib2/b.py'],
-                    interpreter_constraints=['==3.7.*'],
+                    interpreter_constraints=['==3.8.*'],
                 )
                 """
             ),
@@ -68,7 +76,7 @@ def test_no_matches(rule_runner: RuleRunner, caplog) -> None:
     assert len(caplog.records) == 1
     assert (
         "No Python files/targets matched for the `py-constraints` goal. All target types with "
-        "Python interpreter constraints: python_sources, python_tests"
+        "Python interpreter constraints: python_source, python_test"
     ) in caplog.text
 
 
@@ -77,10 +85,9 @@ def test_render_constraints(rule_runner: RuleRunner) -> None:
     result = run_goal(rule_runner, ["app:app"])
     assert result.stdout == dedent(
         """\
-        Final merged constraints: CPython==2.7.*,==3.7.*,>=3.6 OR CPython==3.7.*,>=3.5,>=3.6
+        Final merged constraints: CPython==2.7.*,==3.8.*,>=3.6 OR CPython==3.8.*,>=3.5,>=3.6
 
-        CPython==3.7.*
-          app:app
+        CPython==3.8.*
           app/a.py
 
         CPython>=3.6
@@ -88,7 +95,7 @@ def test_render_constraints(rule_runner: RuleRunner) -> None:
           lib2/b.py
 
         CPython==2.7.* OR CPython>=3.5
-          lib1:lib1
+          lib1/a.py
         """
     )
 
@@ -103,10 +110,8 @@ def test_constraints_summary(rule_runner: RuleRunner) -> None:
     assert result.stdout == dedent(
         """\
         Target,Constraints,Transitive Constraints,# Dependencies,# Dependees\r
-        app:app,CPython==3.7.*,"CPython==2.7.*,==3.7.*,>=3.6 OR CPython==3.7.*,>=3.5,>=3.6",4,0\r
-        app/a.py,CPython==3.7.*,"CPython==2.7.*,==3.7.*,>=3.6 OR CPython==3.7.*,>=3.5,>=3.6",3,1\r
-        lib1:lib1,CPython==2.7.* OR CPython>=3.5,CPython==2.7.* OR CPython>=3.5,0,2\r
-        lib2:lib2,CPython>=3.6,CPython>=3.6,2,0\r
+        app/a.py,CPython==3.8.*,"CPython==2.7.*,==3.8.*,>=3.6 OR CPython==3.8.*,>=3.5,>=3.6",3,1\r
+        lib1/a.py,CPython==2.7.* OR CPython>=3.5,CPython==2.7.* OR CPython>=3.5,0,3\r
         lib2/a.py,CPython>=3.6,CPython>=3.6,0,3\r
         lib2/b.py,CPython>=3.6,CPython>=3.6,0,3\r
         """

--- a/src/python/pants/backend/python/subsystems/ipython_test.py
+++ b/src/python/pants/backend/python/subsystems/ipython_test.py
@@ -27,12 +27,12 @@ def test_setup_lockfile_interpreter_constraints() -> None:
 
     global_constraint = "==3.9.*"
     rule_runner.set_options(
-        ["--ipython-lockfile=lockfile.txt"],
+        ["--ipython-lockfile=lockfile.txt", "--no-python-infer-imports"],
         env={"PANTS_PYTHON_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"},
     )
 
     def assert_ics(build_file: str, expected: list[str]) -> None:
-        rule_runner.write_files({"project/BUILD": build_file})
+        rule_runner.write_files({"project/BUILD": build_file, "project/f.py": ""})
         lockfile_request = rule_runner.request(GeneratePythonLockfile, [IPythonLockfileSentinel()])
         assert lockfile_request.interpreter_constraints == InterpreterConstraints(expected)
 

--- a/src/python/pants/backend/python/subsystems/pytest_test.py
+++ b/src/python/pants/backend/python/subsystems/pytest_test.py
@@ -34,13 +34,14 @@ def test_setup_lockfile_interpreter_constraints() -> None:
 
     global_constraint = "==3.9.*"
     rule_runner.set_options(
-        ["--pytest-lockfile=lockfile.txt"],
+        ["--pytest-lockfile=lockfile.txt", "--no-python-infer-imports"],
         env={"PANTS_PYTHON_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"},
-        env_inherit={"PATH", "PYENV_ROOT", "HOME"},
     )
 
     def assert_ics(build_file: str, expected: list[str]) -> None:
-        rule_runner.write_files({"project/BUILD": build_file, "project/f_test.py": ""})
+        rule_runner.write_files(
+            {"project/BUILD": build_file, "project/f.py": "", "project/f_test.py": ""}
+        )
         lockfile_request = rule_runner.request(GeneratePythonLockfile, [PytestLockfileSentinel()])
         assert lockfile_request.interpreter_constraints == InterpreterConstraints(expected)
 

--- a/src/python/pants/backend/python/subsystems/setuptools_test.py
+++ b/src/python/pants/backend/python/subsystems/setuptools_test.py
@@ -28,12 +28,12 @@ def test_setup_lockfile_interpreter_constraints() -> None:
 
     global_constraint = "==3.9.*"
     rule_runner.set_options(
-        ["--setuptools-lockfile=lockfile.txt"],
+        ["--setuptools-lockfile=lockfile.txt", "--no-python-infer-imports"],
         env={"PANTS_PYTHON_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"},
     )
 
     def assert_ics(build_file: str, expected: list[str]) -> None:
-        rule_runner.write_files({"project/BUILD": build_file})
+        rule_runner.write_files({"project/BUILD": build_file, "project/f.py": ""})
         lockfile_request = rule_runner.request(
             GeneratePythonLockfile, [SetuptoolsLockfileSentinel()]
         )

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -688,18 +688,14 @@ _PYTHON_TEST_MOVED_FIELDS = (
     PythonTestsTimeoutField,
     RuntimePackageDependenciesField,
     PythonTestsExtraEnvVarsField,
+    InterpreterConstraintsField,
     SkipPythonTestsField,
 )
 
 
 class PythonTestTarget(Target):
     alias = "python_test"
-    core_fields = (
-        *_PYTHON_TEST_MOVED_FIELDS,
-        PythonTestsDependenciesField,
-        PythonTestSourceField,
-        InterpreterConstraintsField,
-    )
+    core_fields = (*_PYTHON_TEST_MOVED_FIELDS, PythonTestsDependenciesField, PythonTestSourceField)
     help = (
         "A single Python test file, written in either Pytest style or unittest style.\n\n"
         "All test util code, including `conftest.py`, should go into a dedicated `python_source` "
@@ -747,7 +743,7 @@ class PythonTestsGeneratorTarget(TargetFilesGenerator):
     core_fields = (PythonTestsGeneratingSourcesField, PythonTestsOverrideField)
     generated_target_cls = PythonTestTarget
     copied_fields = ()
-    moved_fields = (*_PYTHON_TEST_MOVED_FIELDS, InterpreterConstraintsField)
+    moved_fields = _PYTHON_TEST_MOVED_FIELDS
     settings_request_cls = PythonFilesGeneratorSettingsRequest
     help = "Generate a `python_test` target for each file in the `sources` field."
 

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -744,14 +744,10 @@ class PythonTestsOverrideField(OverridesField):
 
 class PythonTestsGeneratorTarget(TargetFilesGenerator):
     alias = "python_tests"
-    core_fields = (
-        PythonTestsGeneratingSourcesField,
-        InterpreterConstraintsField,
-        PythonTestsOverrideField,
-    )
+    core_fields = (PythonTestsGeneratingSourcesField, PythonTestsOverrideField)
     generated_target_cls = PythonTestTarget
-    copied_fields = (InterpreterConstraintsField,)
-    moved_fields = _PYTHON_TEST_MOVED_FIELDS
+    copied_fields = ()
+    moved_fields = (*_PYTHON_TEST_MOVED_FIELDS, InterpreterConstraintsField)
     settings_request_cls = PythonFilesGeneratorSettingsRequest
     help = "Generate a `python_test` target for each file in the `sources` field."
 
@@ -807,14 +803,8 @@ class PythonTestUtilsGeneratorTarget(TargetFilesGenerator):
         PythonSourcesOverridesField,
     )
     generated_target_cls = PythonSourceTarget
-    copied_fields = (
-        *COMMON_TARGET_FIELDS,
-        InterpreterConstraintsField,
-    )
-    moved_fields = (
-        PythonResolveField,
-        Dependencies,
-    )
+    copied_fields = COMMON_TARGET_FIELDS
+    moved_fields = (PythonResolveField, Dependencies, InterpreterConstraintsField)
     settings_request_cls = PythonFilesGeneratorSettingsRequest
     help = (
         "Generate a `python_source` target for each file in the `sources` field.\n\n"
@@ -833,18 +823,11 @@ class PythonSourcesGeneratorTarget(TargetFilesGenerator):
     core_fields = (
         *COMMON_TARGET_FIELDS,
         PythonSourcesGeneratingSourcesField,
-        InterpreterConstraintsField,
         PythonSourcesOverridesField,
     )
     generated_target_cls = PythonSourceTarget
-    copied_fields = (
-        *COMMON_TARGET_FIELDS,
-        InterpreterConstraintsField,
-    )
-    moved_fields = (
-        PythonResolveField,
-        Dependencies,
-    )
+    copied_fields = COMMON_TARGET_FIELDS
+    moved_fields = (PythonResolveField, Dependencies, InterpreterConstraintsField)
     settings_request_cls = PythonFilesGeneratorSettingsRequest
     help = (
         "Generate a `python_source` target for each file in the `sources` field.\n\n"


### PR DESCRIPTION
It's always been somewhat broken that we consider the interpreter constraints of `python_sources` and `python_tests`. Those are solely target generators: what really matters are the atom targets. 

We only didn't realize this because the modeling wasn't very clear until splitting generators vs. atoms, and then particularly introducing the concept of "moved fields".

Concretely, this has some implications:

- If you depend on a `python_sources` target, you now only use the ICs of the targets it generates, not the target generator itself. These might be different due to `overrides`.
- `py-constraints` goal no longer includes target generators in its output
- `peek` on `python_sources` no longer shows `interpreter_constraints`

Fixing this not only clears up modeling, but I believe unblocks us from parametrizing the `interpreter_constraints` field with `parametrize()`.

Unfortunately, I don't see any way to gracefully deprecate this. We will call attention in the release notes, like with https://github.com/pantsbuild/pants/pull/14766.

Note that `PluginField` is currently always copied rather than moved, which means that `python_interpreter_constraints` on a `protobuf_sources` target still has the old behavior. This is broken.