### PR TITLE
Fix empty `sys.path` entries causing an error during invalidation glob calculation. (cherrypick of #14819)

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1563,13 +1563,16 @@ class GlobalOptions(Subsystem):
         for glob in potentially_absolute_globs:
             # NB: We use `relpath` here because these paths are untrusted, and might need to be
             # normalized in addition to being relativized.
-            glob_relpath = os.path.relpath(glob, buildroot)
+            glob_relpath = (
+                os.path.relpath(glob, buildroot) if os.path.isabs(glob) else os.path.normpath(glob)
+            )
             if glob_relpath == "." or glob_relpath.startswith(".."):
                 logger.debug(
                     f"Changes to {glob}, outside of the buildroot, will not be invalidated."
                 )
-            else:
-                invalidation_globs.update([glob_relpath, glob_relpath + "/**"])
+                continue
+
+            invalidation_globs.update([glob_relpath, glob_relpath + "/**"])
 
         # Explicitly specified globs are already relative, and are added verbatim.
         invalidation_globs.update(

--- a/src/python/pants/option/global_options_test.py
+++ b/src/python/pants/option/global_options_test.py
@@ -130,9 +130,12 @@ def test_execution_options_remote_addresses() -> None:
 
 
 def test_invalidation_globs() -> None:
-    # Confirm that an un-normalized relative path in the pythonpath is filtered out.
+    # Confirm that an un-normalized relative path in the pythonpath is filtered out, and that an
+    # empty entry (i.e.: a relative path for the current directory) doesn't cause an error.
     suffix = "something-ridiculous"
-    ob = OptionsBootstrapper.create(env={}, args=[f"--pythonpath=../{suffix}"], allow_pantsrc=False)
+    ob = OptionsBootstrapper.create(
+        env={}, args=[f"--pythonpath=../{suffix}", "--pythonpath="], allow_pantsrc=False
+    )
     globs = GlobalOptions.compute_pantsd_invalidation_globs(
         get_buildroot(), ob.bootstrap_options.for_global_scope()
     )


### PR DESCRIPTION
Fixes #11954.

[ci skip-rust]