### PR TITLE
[internal] go: refactor parsing of analysis metadata

### DIFF
--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -178,10 +178,12 @@ async def run_go_tests(
         GenerateTestMainRequest(
             pkg_digest.digest,
             FrozenOrderedSet(
-                os.path.join(".", pkg_analysis.dir_path, name) for name in pkg_analysis.test_files
+                os.path.join(".", pkg_analysis.dir_path, name)
+                for name in pkg_analysis.test_go_files
             ),
             FrozenOrderedSet(
-                os.path.join(".", pkg_analysis.dir_path, name) for name in pkg_analysis.xtest_files
+                os.path.join(".", pkg_analysis.dir_path, name)
+                for name in pkg_analysis.xtest_go_files
             ),
             import_path,
             field_set.address,
@@ -231,7 +233,7 @@ async def run_go_tests(
             import_path=f"{import_path}_test",
             digest=pkg_digest.digest,
             dir_path=pkg_analysis.dir_path,
-            go_file_names=pkg_analysis.xtest_files,
+            go_file_names=pkg_analysis.xtest_go_files,
             s_file_names=(),  # TODO: Are there .s files for xtest?
             direct_dependencies=tuple(direct_dependencies),
             minimum_go_version=pkg_analysis.minimum_go_version,

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -157,7 +157,7 @@ async def setup_build_go_package_target_request(
             #  package archive?
             # TODO: The `go` tool changes the displayed import path for the package when it has
             #  test files. Do we need to do something similar?
-            go_file_names += _first_party_pkg_analysis.test_files
+            go_file_names += _first_party_pkg_analysis.test_go_files
             if _first_party_pkg_digest.test_embed_config:
                 if embed_config:
                     embed_config = embed_config.merge(_first_party_pkg_digest.test_embed_config)

--- a/src/python/pants/backend/go/util_rules/first_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg.py
@@ -81,8 +81,8 @@ class FirstPartyPkgAnalysis:
     xtest_imports: tuple[str, ...]
 
     go_files: tuple[str, ...]
-    test_files: tuple[str, ...]
-    xtest_files: tuple[str, ...]
+    test_go_files: tuple[str, ...]
+    xtest_go_files: tuple[str, ...]
 
     s_files: tuple[str, ...]
 
@@ -167,8 +167,8 @@ class FallibleFirstPartyPkgAnalysis:
             test_imports=tuple(metadata.get("TestImports", [])),
             xtest_imports=tuple(metadata.get("XTestImports", [])),
             go_files=tuple(metadata.get("GoFiles", [])),
-            test_files=tuple(metadata.get("TestGoFiles", [])),
-            xtest_files=tuple(metadata.get("XTestGoFiles", [])),
+            test_go_files=tuple(metadata.get("TestGoFiles", [])),
+            xtest_go_files=tuple(metadata.get("XTestGoFiles", [])),
             s_files=tuple(metadata.get("SFiles", [])),
             minimum_go_version=minimum_go_version,
             embed_patterns=tuple(metadata.get("EmbedPatterns", [])),

--- a/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
@@ -167,8 +167,8 @@ def test_package_analysis(rule_runner: RuleRunner) -> None:
         assert analysis.test_imports == tuple(test_imports)
         assert analysis.xtest_imports == tuple(xtest_imports)
         assert analysis.go_files == tuple(go_files)
-        assert analysis.test_files == tuple(test_files)
-        assert analysis.xtest_files == tuple(xtest_files)
+        assert analysis.test_go_files == tuple(test_files)
+        assert analysis.xtest_go_files == tuple(xtest_files)
         assert not analysis.s_files
 
         assert analysis.minimum_go_version == "1.16"


### PR DESCRIPTION
- Refactor the parsing of analysis metadata into one function (`FallibleFirstPartyPkgAnalysis.from_process_result`).
- Rename `[x]test_files` fields in `FirstPartyPkgAnalysis` to `[x]test_go_files` to fit with the naming scheme already used for other fields which themselves follow naming scheme from Go's own package analysis.