### PR TITLE
Add `cwd()` symbol to BUILD files

### DIFF
--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -233,29 +233,30 @@ def target_adaptor_rule_runner() -> RuleRunner:
 def test_target_adaptor_parsed_correctly(target_adaptor_rule_runner: RuleRunner) -> None:
     target_adaptor_rule_runner.write_files(
         {
-            "helloworld/BUILD": dedent(
+            "helloworld/dir/BUILD": dedent(
                 """\
                 mock_tgt(
                     fake_field=42,
                     dependencies=[
                         # Because we don't follow dependencies or even parse dependencies, this
                         # self-cycle should be fine.
-                        "helloworld",
+                        ":dir",
                         ":sibling",
                         "helloworld/util",
                         "helloworld/util:tests",
                     ],
+                    cwd_test=f"cwd is: {cwd()}"
                 )
                 """
             )
         }
     )
-    addr = Address("helloworld")
+    addr = Address("helloworld/dir")
     target_adaptor = target_adaptor_rule_runner.request(TargetAdaptor, [addr])
-    assert target_adaptor.name == "helloworld"
+    assert target_adaptor.name == "dir"
     assert target_adaptor.type_alias == "mock_tgt"
     assert target_adaptor.kwargs["dependencies"] == [
-        "helloworld",
+        ":dir",
         ":sibling",
         "helloworld/util",
         "helloworld/util:tests",
@@ -263,6 +264,7 @@ def test_target_adaptor_parsed_correctly(target_adaptor_rule_runner: RuleRunner)
     # NB: TargetAdaptors do not validate what fields are valid. The Target API should error
     # when encountering this, but it's fine at this stage.
     assert target_adaptor.kwargs["fake_field"] == 42
+    assert target_adaptor.kwargs["cwd_test"] == "cwd is: helloworld/dir"
 
 
 def test_target_adaptor_not_found(target_adaptor_rule_runner: RuleRunner) -> None:

--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -107,13 +107,7 @@ class Parser:
                 parse_state.add(target_adaptor)
                 return target_adaptor
 
-        class Cwd:
-            """Lets you call `cwd()` in a BUILD file to get the relative path."""
-
-            def __call__(self) -> str:
-                return parse_state.rel_path()
-
-        symbols: dict[str, Any] = {**object_aliases.objects, "cwd": Cwd()}
+        symbols: dict[str, Any] = {**object_aliases.objects, "cwd": parse_state.rel_path}
         symbols.update(
             (alias, Registrar(alias))
             for alias in target_type_aliases

--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -107,7 +107,13 @@ class Parser:
                 parse_state.add(target_adaptor)
                 return target_adaptor
 
-        symbols: dict[str, Any] = dict(object_aliases.objects)
+        class Cwd:
+            """Lets you call `cwd()` in a BUILD file to get the relative path."""
+
+            def __call__(self) -> str:
+                return parse_state.rel_path()
+
+        symbols: dict[str, Any] = {**object_aliases.objects, "cwd": Cwd()}
         symbols.update(
             (alias, Registrar(alias))
             for alias in target_type_aliases

--- a/src/python/pants/engine/internals/parser_test.py
+++ b/src/python/pants/engine/internals/parser_test.py
@@ -40,7 +40,7 @@ def test_unrecogonized_symbol() -> None:
             "If you expect to see more symbols activated in the below list,"
             f" refer to {doc_url('enabling-backends')} for all available"
             " backends to activate.\n\n"
-            f"All registered symbols: ['caof', {fmt_extra_sym}'obj', 'prelude', 'tgt']"
+            f"All registered symbols: ['caof', 'cwd', {fmt_extra_sym}'obj', 'prelude', 'tgt']"
         )
 
     test_targs = ["fake1", "fake2", "fake3", "fake4", "fake5"]


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/14757.

Note that we will soon be removing context-aware object factories (CAOF) because they are not engine-safe. So we implement this through a hardcoded implementation in `parser.py` rather than using a CAOF like we did with v1. That's simpler, anyways.

[ci skip-build-wheels]
[ci skip-rust]