### PR TITLE
[internal] Rename `cwd()` to `build_file_dir()`

### DIFF
--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -245,7 +245,7 @@ def test_target_adaptor_parsed_correctly(target_adaptor_rule_runner: RuleRunner)
                         "helloworld/util",
                         "helloworld/util:tests",
                     ],
-                    cwd_test=f"cwd is: {cwd()}"
+                    build_file_dir=f"build file's dir is: {build_file_dir()}"
                 )
                 """
             )
@@ -264,7 +264,7 @@ def test_target_adaptor_parsed_correctly(target_adaptor_rule_runner: RuleRunner)
     # NB: TargetAdaptors do not validate what fields are valid. The Target API should error
     # when encountering this, but it's fine at this stage.
     assert target_adaptor.kwargs["fake_field"] == 42
-    assert target_adaptor.kwargs["cwd_test"] == "cwd is: helloworld/dir"
+    assert target_adaptor.kwargs["build_file_dir"] == "build file's dir is: helloworld/dir"
 
 
 def test_target_adaptor_not_found(target_adaptor_rule_runner: RuleRunner) -> None:

--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -9,6 +9,7 @@ import tokenize
 from dataclasses import dataclass
 from difflib import get_close_matches
 from io import StringIO
+from pathlib import PurePath
 from typing import Any, Iterable
 
 from pants.base.exceptions import MappingError
@@ -107,7 +108,10 @@ class Parser:
                 parse_state.add(target_adaptor)
                 return target_adaptor
 
-        symbols: dict[str, Any] = {**object_aliases.objects, "cwd": parse_state.rel_path}
+        symbols: dict[str, Any] = {
+            **object_aliases.objects,
+            "build_file_dir": lambda: PurePath(parse_state.rel_path()),
+        }
         symbols.update(
             (alias, Registrar(alias))
             for alias in target_type_aliases

--- a/src/python/pants/engine/internals/parser_test.py
+++ b/src/python/pants/engine/internals/parser_test.py
@@ -40,7 +40,7 @@ def test_unrecogonized_symbol() -> None:
             "If you expect to see more symbols activated in the below list,"
             f" refer to {doc_url('enabling-backends')} for all available"
             " backends to activate.\n\n"
-            f"All registered symbols: ['caof', 'cwd', {fmt_extra_sym}'obj', 'prelude', 'tgt']"
+            f"All registered symbols: ['build_file_dir', 'caof', {fmt_extra_sym}'obj', 'prelude', 'tgt']"
         )
 
     test_targs = ["fake1", "fake2", "fake3", "fake4", "fake5"]


### PR DESCRIPTION
Improves on https://github.com/pantsbuild/pants/pull/14827, where `cwd` is a misnomer because that's not actually the working directory.

We also considered `current_dir`, but the word `current` can be ambiguous. This uses `_dir` rather than `_directory` for less typing.

[ci skip-rust]
[ci skip-build-wheels]