### PR TITLE
add cattrs to DEFAULT_MODULE_MAPPING

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -47,6 +47,7 @@ DEFAULT_MODULE_MAPPING = {
     "azure-storage-queue": ("azure.storage.queue",),
     "beautifulsoup4": ("bs4",),
     "bitvector": ("BitVector",),
+    "cattrs": ("cattr",),
     "django-cors-headers": ("corsheaders",),
     "django-debug-toolbar": ("debug_toolbar",),
     "django-filter": ("django_filters",),


### PR DESCRIPTION
add cattrs, a nifty serialization library (https://pypi.org/project/cattrs/), to DEFAULT_MODULE_MAPPING