### PR TITLE
Add dependency inference for django related packages

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -50,10 +50,13 @@ DEFAULT_MODULE_MAPPING = {
     "cattrs": ("cattr",),
     "django-cors-headers": ("corsheaders",),
     "django-debug-toolbar": ("debug_toolbar",),
+    "django-dotenv": ("dotenv",),
     "django-filter": ("django_filters",),
+    "django-safedelete": ("safedelete",),
     "django-simple-history": ("simple_history",),
     "djangorestframework": ("rest_framework",),
     "enum34": ("enum",),
+    "factory-boy": ("factory",),
     "fluent-logger": ("fluent",),
     "gitpython": ("git",),
     # See https://github.com/googleapis/google-cloud-python#libraries for all Google cloud


### PR DESCRIPTION
As suggested by @benjyw, I added dependency inference for packages we are using that were not already in:
- `django-safedelete`
- `factory-boy`
- `django-dotenv`

I don't know if the duplication with `python-dotenv` in `default_module_mapping.py` I created by adding `django-dotenv` causes any harm or is just added to a list that is looked up. Maybe someone can enlighten me on that part 👼 .