### PR TITLE
Add support for Helm unittest

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -26,7 +26,6 @@ backend_packages.add = [
   "pants.backend.experimental.scala",
   "pants.backend.experimental.scala.lint.scalafmt",
   "pants.backend.experimental.scala.debug_goals",
-  # "pants.backend.experimental.helm",
   "internal_plugins.releases",
 ]
 plugins = [

--- a/pants.toml
+++ b/pants.toml
@@ -146,7 +146,7 @@ args = ["--external-sources"]
 args = ["-i 2", "-ci", "-sr"]
 
 [pytest]
-args = ["--no-header", "-vv"]
+args = ["--no-header"]
 extra_requirements.add = [
   "ipdb",
   "pytest-html",

--- a/pants.toml
+++ b/pants.toml
@@ -26,7 +26,7 @@ backend_packages.add = [
   "pants.backend.experimental.scala",
   "pants.backend.experimental.scala.lint.scalafmt",
   "pants.backend.experimental.scala.debug_goals",
-  "pants.backend.experimental.helm",
+  # "pants.backend.experimental.helm",
   "internal_plugins.releases",
 ]
 plugins = [

--- a/pants.toml
+++ b/pants.toml
@@ -146,7 +146,7 @@ args = ["--external-sources"]
 args = ["-i 2", "-ci", "-sr"]
 
 [pytest]
-args = ["--no-header"]
+args = ["--no-header", "-vv"]
 extra_requirements.add = [
   "ipdb",
   "pytest-html",

--- a/pants.toml
+++ b/pants.toml
@@ -26,6 +26,7 @@ backend_packages.add = [
   "pants.backend.experimental.scala",
   "pants.backend.experimental.scala.lint.scalafmt",
   "pants.backend.experimental.scala.debug_goals",
+  "pants.backend.experimental.helm",
   "internal_plugins.releases",
 ]
 plugins = [

--- a/src/python/pants/backend/experimental/helm/register.py
+++ b/src/python/pants/backend/experimental/helm/register.py
@@ -2,13 +2,14 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.backend.helm.goals import lint, package
-from pants.backend.helm.target_types import HelmChartTarget
+from pants.backend.helm.target_types import HelmChartTarget, HelmUnitTestTestTarget, HelmUnitTestTestsGeneratorTarget
+from pants.backend.helm.target_types import rules as target_types_rules
 from pants.backend.helm.util_rules import chart, sources, tool
 
 
 def target_types():
-    return [HelmChartTarget]
+    return [HelmChartTarget, HelmUnitTestTestTarget, HelmUnitTestTestsGeneratorTarget]
 
 
 def rules():
-    return [*chart.rules(), *lint.rules(), *package.rules(), *sources.rules(), *tool.rules()]
+    return [*chart.rules(), *lint.rules(), *package.rules(), *sources.rules(), *tool.rules(), *target_types_rules()]

--- a/src/python/pants/backend/experimental/helm/register.py
+++ b/src/python/pants/backend/experimental/helm/register.py
@@ -2,7 +2,11 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.backend.helm.goals import lint, package
-from pants.backend.helm.target_types import HelmChartTarget, HelmUnitTestTestTarget, HelmUnitTestTestsGeneratorTarget
+from pants.backend.helm.target_types import (
+    HelmChartTarget,
+    HelmUnitTestTestsGeneratorTarget,
+    HelmUnitTestTestTarget,
+)
 from pants.backend.helm.target_types import rules as target_types_rules
 from pants.backend.helm.test.unittest import rules as test_rules
 from pants.backend.helm.util_rules import chart, sources, tool
@@ -13,4 +17,12 @@ def target_types():
 
 
 def rules():
-    return [*chart.rules(), *lint.rules(), *package.rules(), *test_rules(), *sources.rules(), *tool.rules(), *target_types_rules()]
+    return [
+        *chart.rules(),
+        *lint.rules(),
+        *package.rules(),
+        *test_rules(),
+        *sources.rules(),
+        *tool.rules(),
+        *target_types_rules(),
+    ]

--- a/src/python/pants/backend/experimental/helm/register.py
+++ b/src/python/pants/backend/experimental/helm/register.py
@@ -4,6 +4,7 @@
 from pants.backend.helm.goals import lint, package
 from pants.backend.helm.target_types import HelmChartTarget, HelmUnitTestTestTarget, HelmUnitTestTestsGeneratorTarget
 from pants.backend.helm.target_types import rules as target_types_rules
+from pants.backend.helm.test.unittest import rules as test_rules
 from pants.backend.helm.util_rules import chart, sources, tool
 
 
@@ -12,4 +13,4 @@ def target_types():
 
 
 def rules():
-    return [*chart.rules(), *lint.rules(), *package.rules(), *sources.rules(), *tool.rules(), *target_types_rules()]
+    return [*chart.rules(), *lint.rules(), *package.rules(), *test_rules(), *sources.rules(), *tool.rules(), *target_types_rules()]

--- a/src/python/pants/backend/helm/BUILD
+++ b/src/python/pants/backend/helm/BUILD
@@ -2,3 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_sources()
+
+python_tests(name="tests")

--- a/src/python/pants/backend/helm/dependency_inference/BUILD
+++ b/src/python/pants/backend/helm/dependency_inference/BUILD
@@ -1,0 +1,6 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_sources()
+
+python_tests(name="tests")

--- a/src/python/pants/backend/helm/dependency_inference/unittest.py
+++ b/src/python/pants/backend/helm/dependency_inference/unittest.py
@@ -1,0 +1,49 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+
+from pants.backend.helm.target_types import AllHelmChartTargets, HelmUnitTestChartField
+from pants.engine.addresses import Address
+from pants.engine.rules import collect_rules, rule
+from pants.engine.target import InjectDependenciesRequest, InjectedDependencies, Target
+from pants.engine.unions import UnionRule
+
+
+class InvalidUnitTestTestFolder(Exception):
+    def __init__(self, address: Address, found_folder: str) -> None:
+        super().__init__(
+            f"`helm_unittest_test` target at {address.spec_path} is at the wrong folder, "
+            "it should be inside a `tests` folder under the Helm chart root sources but it was found at: {found_folder}"
+        )
+
+
+class InjectHelmUnitTestChartDependencyRequest(InjectDependenciesRequest):
+    inject_for = HelmUnitTestChartField
+
+
+@rule
+async def inject_chart_dependency_into_unittests(
+    request: InjectHelmUnitTestChartDependencyRequest, all_helm_charts: AllHelmChartTargets
+) -> InjectedDependencies:
+    unittest_target_addr: Address = request.dependencies_field.address
+
+    unittest_target_relpath = os.path.splitext(unittest_target_addr.spec_path)[0]
+    if unittest_target_relpath != "tests" and os.path.dirname(unittest_target_relpath) != "tests":
+        raise InvalidUnitTestTestFolder(unittest_target_addr, unittest_target_relpath)
+
+    putative_chart_path = os.path.splitext(unittest_target_relpath)[0]
+
+    def is_parent_chart(target: Target) -> bool:
+        chart_folder = os.path.dirname(target.address.spec_path)
+        return chart_folder == putative_chart_path or target.address.spec_path == ""
+
+    parent_chart_addrs = [tgt.address for tgt in all_helm_charts if is_parent_chart(tgt)]
+    return InjectedDependencies(parent_chart_addrs)
+
+
+def rules():
+    return [
+        *collect_rules(),
+        UnionRule(InjectDependenciesRequest, InjectHelmUnitTestChartDependencyRequest),
+    ]

--- a/src/python/pants/backend/helm/dependency_inference/unittest.py
+++ b/src/python/pants/backend/helm/dependency_inference/unittest.py
@@ -1,6 +1,7 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import logging
 import os
 
 from pants.backend.helm.target_types import AllHelmChartTargets, HelmUnitTestChartField
@@ -8,13 +9,24 @@ from pants.engine.addresses import Address
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import InjectDependenciesRequest, InjectedDependencies, Target
 from pants.engine.unions import UnionRule
+from pants.util.strutil import bullet_list, pluralize
+
+logger = logging.getLogger(__name__)
 
 
 class InvalidUnitTestTestFolder(Exception):
     def __init__(self, address: Address, found_folder: str) -> None:
         super().__init__(
             f"`helm_unittest_test` target at {address.spec_path} is at the wrong folder, "
-            "it should be inside a `tests` folder under the Helm chart root sources but it was found at: {found_folder}"
+            f"it should be inside a `tests` folder under the Helm chart root sources, it was found at: {found_folder}"
+        )
+
+
+class AmbiguousHelmUnitTestChart(Exception):
+    def __init__(self, *, target_addr: str, putative_addresses: list[str]) -> None:
+        super().__init__(
+            f"The actual Helm chart for the target at '{target_addr}' is ambiguous and can not be inferred. "
+            f"Found {pluralize(len(putative_addresses), 'candidate')}:\n{bullet_list(putative_addresses)}"
         )
 
 
@@ -28,17 +40,26 @@ async def inject_chart_dependency_into_unittests(
 ) -> InjectedDependencies:
     unittest_target_addr: Address = request.dependencies_field.address
 
-    unittest_target_relpath = os.path.splitext(unittest_target_addr.spec_path)[0]
-    if unittest_target_relpath != "tests" and os.path.dirname(unittest_target_relpath) != "tests":
-        raise InvalidUnitTestTestFolder(unittest_target_addr, unittest_target_relpath)
-
-    putative_chart_path = os.path.splitext(unittest_target_relpath)[0]
+    putative_chart_path, unittest_target_dir = os.path.split(unittest_target_addr.spec_path)
+    if unittest_target_dir != "tests":
+        raise InvalidUnitTestTestFolder(unittest_target_addr, unittest_target_addr.spec_path)
 
     def is_parent_chart(target: Target) -> bool:
-        chart_folder = os.path.dirname(target.address.spec_path)
-        return chart_folder == putative_chart_path or target.address.spec_path == ""
+        chart_folder = target.address.spec_path
+        return chart_folder == putative_chart_path
 
     parent_chart_addrs = [tgt.address for tgt in all_helm_charts if is_parent_chart(tgt)]
+    if len(parent_chart_addrs) > 1:
+        raise AmbiguousHelmUnitTestChart(
+            target_addr=unittest_target_addr.spec,
+            putative_addresses=[addr.spec for addr in parent_chart_addrs],
+        )
+
+    if len(parent_chart_addrs) == 1:
+        logger.debug(
+            f"Found Helm chart at '{parent_chart_addrs[0].spec}' for unittest at: {unittest_target_addr.spec}"
+        )
+
     return InjectedDependencies(parent_chart_addrs)
 
 

--- a/src/python/pants/backend/helm/dependency_inference/unittest_test.py
+++ b/src/python/pants/backend/helm/dependency_inference/unittest_test.py
@@ -11,7 +11,7 @@ from pants.backend.helm.dependency_inference.unittest import (
 from pants.backend.helm.dependency_inference.unittest import rules as inject_deps_rules
 from pants.backend.helm.target_types import (
     HelmChartTarget,
-    HelmUnitTestChartField,
+    HelmUnitTestDependenciesField,
     HelmUnitTestTestsGeneratorTarget,
     HelmUnitTestTestTarget,
 )
@@ -64,7 +64,7 @@ def test_injects_single_chart(rule_runner: RuleRunner) -> None:
     unittest_tgt = rule_runner.get_target(Address("tests", target_name="foo_tests"))
     injected_deps = rule_runner.request(
         InjectedDependencies,
-        [InjectHelmUnitTestChartDependencyRequest(unittest_tgt[HelmUnitTestChartField])],
+        [InjectHelmUnitTestChartDependencyRequest(unittest_tgt[HelmUnitTestDependenciesField])],
     )
 
     assert len(injected_deps) == 1
@@ -100,11 +100,19 @@ def test_injects_parent_chart(rule_runner: RuleRunner) -> None:
 
     chart1_injected_deps = rule_runner.request(
         InjectedDependencies,
-        [InjectHelmUnitTestChartDependencyRequest(chart1_unittest_tgt[HelmUnitTestChartField])],
+        [
+            InjectHelmUnitTestChartDependencyRequest(
+                chart1_unittest_tgt[HelmUnitTestDependenciesField]
+            )
+        ],
     )
     chart2_injected_deps = rule_runner.request(
         InjectedDependencies,
-        [InjectHelmUnitTestChartDependencyRequest(chart2_unittest_tgt[HelmUnitTestChartField])],
+        [
+            InjectHelmUnitTestChartDependencyRequest(
+                chart2_unittest_tgt[HelmUnitTestDependenciesField]
+            )
+        ],
     )
 
     assert len(chart1_injected_deps) == 1

--- a/src/python/pants/backend/helm/dependency_inference/unittest_test.py
+++ b/src/python/pants/backend/helm/dependency_inference/unittest_test.py
@@ -1,0 +1,66 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import textwrap
+
+import pytest
+
+from pants.backend.helm.dependency_inference.unittest import (
+    InjectHelmUnitTestChartDependencyRequest,
+)
+from pants.backend.helm.dependency_inference.unittest import rules as inject_deps_rules
+from pants.backend.helm.target_types import (
+    HelmChartTarget,
+    HelmUnitTestChartField,
+    HelmUnitTestTestsGeneratorTarget,
+    HelmUnitTestTestTarget,
+)
+from pants.backend.helm.target_types import rules as target_types_rules
+from pants.backend.helm.testutil import HELM_CHART_FILE, HELM_VALUES_FILE, K8S_SERVICE_FILE
+from pants.build_graph.address import Address
+from pants.engine.rules import QueryRule
+from pants.engine.target import InjectedDependencies
+from pants.testutil.rule_runner import RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        target_types=[HelmChartTarget, HelmUnitTestTestsGeneratorTarget, HelmUnitTestTestTarget],
+        rules=[
+            *target_types_rules(),
+            *inject_deps_rules(),
+            QueryRule(InjectedDependencies, (InjectHelmUnitTestChartDependencyRequest,)),
+        ],
+    )
+
+
+def test_injects_chart_as_special_dependency(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": textwrap.dedent(
+                """\
+                helm_chart(name="foo")
+                """
+            ),
+            "Chart.yaml": HELM_CHART_FILE,
+            "values.yaml": HELM_VALUES_FILE,
+            "templates/service.yaml": K8S_SERVICE_FILE,
+            "tests/BUILD": textwrap.dedent(
+                """\
+                helm_unittest_tests(name="foo_tests", sources=["*_test.yaml"])
+                """
+            ),
+            "tests/service_test.yaml": "",
+        }
+    )
+
+    chart_tgt = rule_runner.get_target(Address("", target_name="foo"))
+    unittest_tgt = rule_runner.get_target(Address("tests", target_name="foo_tests"))
+    injected_deps = rule_runner.request(
+        InjectedDependencies,
+        [InjectHelmUnitTestChartDependencyRequest(unittest_tgt[HelmUnitTestChartField])],
+    )
+
+    assert len(injected_deps) == 1
+    assert list(injected_deps)[0] == chart_tgt.address

--- a/src/python/pants/backend/helm/goals/package.py
+++ b/src/python/pants/backend/helm/goals/package.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 def _helm_artifact_filename(chart_metadata: HelmChartMetadata) -> str:
     return f"{chart_metadata.name}-{chart_metadata.version}.tgz"
 
+
 @dataclass(frozen=True)
 class HelmPackageFieldSet(HelmChartFieldSet, PackageFieldSet):
     output_path: HelmChartOutputPathField

--- a/src/python/pants/backend/helm/goals/package.py
+++ b/src/python/pants/backend/helm/goals/package.py
@@ -31,7 +31,6 @@ logger = logging.getLogger(__name__)
 def _helm_artifact_filename(chart_metadata: HelmChartMetadata) -> str:
     return f"{chart_metadata.name}-{chart_metadata.version}.tgz"
 
-
 @dataclass(frozen=True)
 class HelmPackageFieldSet(HelmChartFieldSet, PackageFieldSet):
     output_path: HelmChartOutputPathField

--- a/src/python/pants/backend/helm/subsystems/BUILD
+++ b/src/python/pants/backend/helm/subsystems/BUILD
@@ -2,3 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_sources()
+
+python_tests(name="tests")

--- a/src/python/pants/backend/helm/subsystems/helm.py
+++ b/src/python/pants/backend/helm/subsystems/helm.py
@@ -8,6 +8,7 @@ from typing import cast
 
 from pants.core.util_rules.external_tool import TemplatedExternalTool
 from pants.engine.platform import Platform
+from pants.engine.rules import SubsystemRule
 
 
 class HelmSubsystem(TemplatedExternalTool):
@@ -44,3 +45,7 @@ class HelmSubsystem(TemplatedExternalTool):
     @property
     def lint_strict(self) -> bool:
         return cast("bool", self.options.lint_strict)
+
+
+def rules():
+    return [SubsystemRule(HelmSubsystem)]

--- a/src/python/pants/backend/helm/subsystems/helm.py
+++ b/src/python/pants/backend/helm/subsystems/helm.py
@@ -4,11 +4,10 @@
 from __future__ import annotations
 
 import os
-from typing import cast
 
 from pants.core.util_rules.external_tool import TemplatedExternalTool
 from pants.engine.platform import Platform
-from pants.engine.rules import SubsystemRule
+from pants.option.option_types import BoolOption
 
 
 class HelmSubsystem(TemplatedExternalTool):
@@ -30,22 +29,11 @@ class HelmSubsystem(TemplatedExternalTool):
         "macos_x86_64": "darwin-amd64",
     }
 
-    @classmethod
-    def register_options(cls, register):
-        super().register_options(register)
-        register(
-            "--lint-strict", type=bool, default=False, help="Enables strict linting of Helm charts"
-        )
+    lint_strict = BoolOption(
+        "--lint-strict", default=False, help="Enables strict linting of Helm charts"
+    )
 
     def generate_exe(self, plat: Platform) -> str:
         mapped_plat = self.default_url_platform_mapping[plat.value]
         bin_path = os.path.join(mapped_plat, "helm")
         return bin_path
-
-    @property
-    def lint_strict(self) -> bool:
-        return cast("bool", self.options.lint_strict)
-
-
-def rules():
-    return [SubsystemRule(HelmSubsystem)]

--- a/src/python/pants/backend/helm/subsystems/unittest.py
+++ b/src/python/pants/backend/helm/subsystems/unittest.py
@@ -4,7 +4,7 @@
 from enum import Enum
 from typing import cast
 
-from pants.backend.helm.util_rules.plugins import HelmPluginSubsystem
+from pants.backend.helm.util_rules.plugins import HelmPluginPlatform, HelmPluginSubsystem
 from pants.engine.platform import Platform
 
 
@@ -48,6 +48,10 @@ class HelmUnitTestPlugin(HelmPluginSubsystem):
 
     def generate_exe(self, _: Platform) -> str:
         return "./untt"
+
+    def map_platform(self, platf: Platform) -> HelmPluginPlatform:
+        mapped_platf_parts = self.default_url_platform_mapping[platf.name].split("-")
+        return HelmPluginPlatform(os=mapped_platf_parts[0], arch=mapped_platf_parts[1])
 
     @property
     def output_type(self) -> HelmUnitTestReportFormat:

--- a/src/python/pants/backend/helm/subsystems/unittest.py
+++ b/src/python/pants/backend/helm/subsystems/unittest.py
@@ -6,8 +6,8 @@ from typing import cast
 
 from pants.backend.helm.util_rules.plugins import (
     ExternalHelmPlugin,
-    HelmPluginBinding,
-    HelmPluginRequest,
+    ExternalHelmPluginBinding,
+    ExternalHelmPluginRequest,
 )
 from pants.engine.platform import Platform
 from pants.engine.rules import SubsystemRule, collect_rules, rule
@@ -60,15 +60,15 @@ class HelmUnitTestSubsystem(ExternalHelmPlugin):
         return cast(HelmUnitTestReportFormat, self.options.output_type)
 
 
-class HelmUnitTestPluginBinding(HelmPluginBinding[HelmUnitTestSubsystem]):
+class HelmUnitTestPluginBinding(ExternalHelmPluginBinding[HelmUnitTestSubsystem]):
     plugin_subsystem_cls = HelmUnitTestSubsystem
 
 
 @rule
 def download_plugin_request(
     _: HelmUnitTestPluginBinding, subsystem: HelmUnitTestSubsystem
-) -> HelmPluginRequest:
-    return HelmPluginRequest(
+) -> ExternalHelmPluginRequest:
+    return ExternalHelmPluginRequest(
         plugin_name=subsystem.plugin_name, tool_request=subsystem.get_request(Platform.current)
     )
 
@@ -77,5 +77,5 @@ def rules():
     return [
         *collect_rules(),
         SubsystemRule(HelmUnitTestSubsystem),
-        UnionRule(HelmPluginBinding, HelmUnitTestPluginBinding),
+        UnionRule(ExternalHelmPluginBinding, HelmUnitTestPluginBinding),
     ]

--- a/src/python/pants/backend/helm/subsystems/unittest.py
+++ b/src/python/pants/backend/helm/subsystems/unittest.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from enum import Enum
-from typing import cast
 
 from pants.backend.helm.util_rules.plugins import (
     ExternalHelmPlugin,
@@ -10,8 +9,9 @@ from pants.backend.helm.util_rules.plugins import (
     ExternalHelmPluginRequest,
 )
 from pants.engine.platform import Platform
-from pants.engine.rules import SubsystemRule, collect_rules, rule
+from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
+from pants.option.option_types import EnumOption
 
 
 class HelmUnitTestReportFormat(Enum):
@@ -42,22 +42,14 @@ class HelmUnitTestSubsystem(ExternalHelmPlugin):
         "macos_x86_64": "macos-amd64",
     }
 
-    @classmethod
-    def register_options(cls, register):
-        super().register_options(register)
-        register(
-            "--output-type",
-            type=HelmUnitTestReportFormat,
-            default=HelmUnitTestReportFormat.XUNIT,
-            help="Output type used for the test report",
-        )
+    output_type = EnumOption(
+        "--output-type",
+        default=HelmUnitTestReportFormat.XUNIT,
+        help="Output type used for the test report",
+    )
 
     def generate_exe(self, _: Platform) -> str:
         return "./untt"
-
-    @property
-    def output_type(self) -> HelmUnitTestReportFormat:
-        return cast(HelmUnitTestReportFormat, self.options.output_type)
 
 
 class HelmUnitTestPluginBinding(ExternalHelmPluginBinding[HelmUnitTestSubsystem]):
@@ -74,6 +66,5 @@ def download_plugin_request(
 def rules():
     return [
         *collect_rules(),
-        SubsystemRule(HelmUnitTestSubsystem),
         UnionRule(ExternalHelmPluginBinding, HelmUnitTestPluginBinding),
     ]

--- a/src/python/pants/backend/helm/subsystems/unittest.py
+++ b/src/python/pants/backend/helm/subsystems/unittest.py
@@ -68,9 +68,7 @@ class HelmUnitTestPluginBinding(ExternalHelmPluginBinding[HelmUnitTestSubsystem]
 def download_plugin_request(
     _: HelmUnitTestPluginBinding, subsystem: HelmUnitTestSubsystem
 ) -> ExternalHelmPluginRequest:
-    return ExternalHelmPluginRequest(
-        plugin_name=subsystem.plugin_name, tool_request=subsystem.get_request(Platform.current)
-    )
+    return ExternalHelmPluginRequest.from_subsystem(subsystem)
 
 
 def rules():

--- a/src/python/pants/backend/helm/subsystems/unittest.py
+++ b/src/python/pants/backend/helm/subsystems/unittest.py
@@ -1,0 +1,50 @@
+from pants.backend.helm.util_rules.plugins import HelmPluginSubsystem
+from enum import Enum
+from typing import cast
+from pants.engine.platform import Platform
+
+
+class HelmUnitTestReportFormat(Enum):
+    """The report format used for the unit tests."""
+
+    XUNIT = "XUnit"
+    NUNIT = "NUnit"
+    JUNIT = "JUnit"
+
+
+class HelmUnitTestPlugin(HelmPluginSubsystem):
+    options_scope = "helm-unittest"
+    plugin_name = "unittest"
+    help = "BDD styled unit test framework for Kubernetes Helm charts as a Helm plugin."
+
+    default_version = "0.2.8"
+    default_known_versions = [
+        "0.2.8|linux_x86_64|d7c452559ad4406a1197435394fbcffe51198060de1aa9b4cb6feaf876776ba0|18299096",
+        "0.2.8|linux_arm64 |c793e241b063f0540ad9b4acc0a02e5a101bd9daea5bdf4d8562e9b2337fedb2|16943867",
+        "0.2.8|macos_x86_64|1dc95699320894bdebf055c4f4cc084c2cfa0133d3cb7fd6a4c0adca94df5c96|18161928",
+        "0.2.8|macos_arm64 |436e3167c26f71258b96e32c2877b4f97c051064db941de097cf3db2fc861342|17621648",
+    ]
+    default_url_template = "https://github.com/quintush/helm-unittest/releases/download/v{version}/helm-unittest-{platform}-{version}.tgz"
+    default_url_platform_mapping = {
+        "linux_arm64": "linux-arm64",
+        "linux_x86_64": "linux-amd64",
+        "macos_arm64": "macos-arm64",
+        "macos_x86_64": "macos-amd64",
+    }
+
+    @classmethod
+    def register_options(cls, register):
+        super().register_options(register)
+        register(
+            "--output-type",
+            type=HelmUnitTestReportFormat,
+            default=HelmUnitTestReportFormat.XUNIT,
+            help="Output type used for the test report",
+        )
+
+    def generate_exe(self, _: Platform) -> str:
+        return "./untt"
+
+    @property
+    def output_type(self) -> HelmUnitTestReportFormat:
+        return cast(HelmUnitTestReportFormat, self.options.output_type)

--- a/src/python/pants/backend/helm/subsystems/unittest.py
+++ b/src/python/pants/backend/helm/subsystems/unittest.py
@@ -1,6 +1,10 @@
-from pants.backend.helm.util_rules.plugins import HelmPluginSubsystem
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 from enum import Enum
 from typing import cast
+
+from pants.backend.helm.util_rules.plugins import HelmPluginSubsystem
 from pants.engine.platform import Platform
 
 

--- a/src/python/pants/backend/helm/subsystems/unittest_test.py
+++ b/src/python/pants/backend/helm/subsystems/unittest_test.py
@@ -1,0 +1,45 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from pants.backend.helm.subsystems import unittest
+from pants.backend.helm.util_rules import tool
+from pants.backend.helm.util_rules.tool import HelmProcess
+from pants.core.util_rules import external_tool
+from pants.engine import process
+from pants.engine.fs import EMPTY_DIGEST
+from pants.engine.process import ProcessResult
+from pants.engine.rules import QueryRule
+from pants.testutil.rule_runner import RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *external_tool.rules(),
+            *tool.rules(),
+            *process.rules(),
+            *unittest.rules(),
+            QueryRule(ProcessResult, (HelmProcess,)),
+        ]
+    )
+
+
+def test_install_plugin(rule_runner: RuleRunner) -> None:
+    plugin_ls_process = HelmProcess(
+        argv=["plugin", "ls"],
+        input_digest=EMPTY_DIGEST,
+        description="Verify installation of Helm plugins",
+    )
+
+    process_result = rule_runner.request(ProcessResult, [plugin_ls_process])
+    plugin_table = process_result.stdout.decode().splitlines()[1:]
+    loaded_plugins = [re.split(r"\t+", line.rstrip())[0] for line in plugin_table]
+
+    assert loaded_plugins == ["unittest"]

--- a/src/python/pants/backend/helm/subsystems/unittest_test.py
+++ b/src/python/pants/backend/helm/subsystems/unittest_test.py
@@ -45,7 +45,7 @@ def test_install_plugin(rule_runner: RuleRunner) -> None:
     #    NAME           VERSION DESCRIPTION
     #    plugin_name    0.1.0   Some plugin description
     #
-    # So to build the test expectation we parse that output and keeping
+    # So to build the test expectation we parse that output keeping
     # the plugin's name and version to be used in the comparison
     plugin_table_rows = process_result.stdout.decode().splitlines()[1:]
     loaded_plugins = [

--- a/src/python/pants/backend/helm/subsystems/unittest_test.py
+++ b/src/python/pants/backend/helm/subsystems/unittest_test.py
@@ -8,6 +8,7 @@ import re
 import pytest
 
 from pants.backend.helm.subsystems import unittest
+from pants.backend.helm.subsystems.unittest import HelmUnitTestSubsystem
 from pants.backend.helm.util_rules import tool
 from pants.backend.helm.util_rules.tool import HelmProcess
 from pants.core.util_rules import external_tool
@@ -39,7 +40,19 @@ def test_install_plugin(rule_runner: RuleRunner) -> None:
     )
 
     process_result = rule_runner.request(ProcessResult, [plugin_ls_process])
-    plugin_table = process_result.stdout.decode().splitlines()[1:]
-    loaded_plugins = [re.split(r"\t+", line.rstrip())[0] for line in plugin_table]
 
-    assert loaded_plugins == ["unittest"]
+    # The result of the `helm plugin ls` command is a table with a header like
+    #    NAME           VERSION DESCRIPTION
+    #    plugin_name    0.1.0   Some plugin description
+    #
+    # So to build the test expectation we parse that output and keeping
+    # the plugin's name and version to be used in the comparison
+    plugin_table_rows = process_result.stdout.decode().splitlines()[1:]
+    loaded_plugins = [
+        (columns[0].strip(), columns[1].strip())
+        for columns in (re.split(r"\t+", line.rstrip()) for line in plugin_table_rows)
+    ]
+
+    assert loaded_plugins == [
+        (HelmUnitTestSubsystem.plugin_name, HelmUnitTestSubsystem.default_version)
+    ]

--- a/src/python/pants/backend/helm/target_types.py
+++ b/src/python/pants/backend/helm/target_types.py
@@ -105,3 +105,4 @@ class HelmChartFieldSet(FieldSet):
     chart: HelmChartMetaSourceField
     sources: HelmChartSourcesField
     dependencies: HelmChartDependenciesField
+    lint_strict: HelmChartLintStrictField

--- a/src/python/pants/backend/helm/target_types.py
+++ b/src/python/pants/backend/helm/target_types.py
@@ -14,6 +14,7 @@ from pants.engine.target import (
     MultipleSourcesField,
     SingleSourceField,
     Target,
+    TargetFilesGenerator,
     TriBoolField,
 )
 from pants.util.docutil import bin_name
@@ -105,3 +106,51 @@ class HelmChartFieldSet(FieldSet):
     chart: HelmChartMetaSourceField
     sources: HelmChartSourcesField
     dependencies: HelmChartDependenciesField
+
+
+# -----------------------------------------------------------------------------------------------
+# `helm_unittest_test` target
+# -----------------------------------------------------------------------------------------------
+
+class HelmUnitTestDependenciesField(Dependencies):
+    pass
+
+class HelmUnitTestSourceField(SingleSourceField):
+    expected_file_extensions = (
+        ".yaml",
+        ".yml",
+    )
+
+class HelmUnitTestTestTarget(Target):
+    alias = "helm_unittest_test"
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        HelmUnitTestSourceField,
+        HelmUnitTestDependenciesField
+    )
+    help = "A single helm-unittest suite file"
+
+# -----------------------------------------------------------------------------------------------
+# `helm_unittest_tests` target generator
+# -----------------------------------------------------------------------------------------------
+
+class HelmUnitTestGeneratingSourcesField(MultipleSourcesField):
+    default = ("*_test.yaml",)
+    expected_file_extensions = (
+        ".yaml",
+        ".yml",
+    )
+
+class HelmUnitTestTestsGeneratorTarget(TargetFilesGenerator):
+    alias = "helm_unittest_tests"
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        HelmUnitTestDependenciesField,
+        HelmUnitTestGeneratingSourcesField
+    )
+    generated_target_cls = HelmUnitTestTestTarget
+    copied_fields = (
+        *COMMON_TARGET_FIELDS,
+        HelmUnitTestDependenciesField
+    )
+    help = f"Generates a `{HelmUnitTestTestTarget.alias}` target per each file in the `{HelmUnitTestGeneratingSourcesField.alias}` field"

--- a/src/python/pants/backend/helm/target_types.py
+++ b/src/python/pants/backend/helm/target_types.py
@@ -105,4 +105,3 @@ class HelmChartFieldSet(FieldSet):
     chart: HelmChartMetaSourceField
     sources: HelmChartSourcesField
     dependencies: HelmChartDependenciesField
-    lint_strict: HelmChartLintStrictField

--- a/src/python/pants/backend/helm/target_types.py
+++ b/src/python/pants/backend/helm/target_types.py
@@ -181,13 +181,13 @@ class HelmUnitTestTestsGeneratorTarget(TargetFilesGenerator):
     alias = "helm_unittest_tests"
     core_fields = (
         *COMMON_TARGET_FIELDS,
+        HelmUnitTestGeneratingSourcesField,
         HelmUnitTestDependenciesField,
         HelmUnitTestChartField,
-        HelmUnitTestGeneratingSourcesField,
     )
     generated_target_cls = HelmUnitTestTestTarget
-    copied_fields = (*COMMON_TARGET_FIELDS, HelmUnitTestChartField, HelmUnitTestDependenciesField)
-    moved_fields = ()
+    copied_fields = COMMON_TARGET_FIELDS
+    moved_fields = (HelmUnitTestDependenciesField, HelmUnitTestChartField)
     help = f"Generates a `{HelmUnitTestTestTarget.alias}` target per each file in the `{HelmUnitTestGeneratingSourcesField.alias}` field"
 
 

--- a/src/python/pants/backend/helm/target_types.py
+++ b/src/python/pants/backend/helm/target_types.py
@@ -6,15 +6,19 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from pants.core.goals.package import OutputPathField
+from pants.engine.rules import collect_rules, rule
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
+    AllTargets,
     BoolField,
     Dependencies,
     FieldSet,
     MultipleSourcesField,
     SingleSourceField,
+    SpecialCasedDependencies,
     Target,
     TargetFilesGenerator,
+    Targets,
     TriBoolField,
 )
 from pants.util.docutil import bin_name
@@ -108,12 +112,28 @@ class HelmChartFieldSet(FieldSet):
     dependencies: HelmChartDependenciesField
 
 
+class AllHelmChartTargets(Targets):
+    pass
+
+
+@rule
+def all_helm_chart_targets(all_targets: AllTargets) -> AllHelmChartTargets:
+    return AllHelmChartTargets([tgt for tgt in all_targets if HelmChartFieldSet.is_applicable(tgt)])
+
+
 # -----------------------------------------------------------------------------------------------
 # `helm_unittest_test` target
 # -----------------------------------------------------------------------------------------------
 
+
+class HelmUnitTestChartField(SpecialCasedDependencies):
+    alias = "chart"
+    help = f"Dependency on a `{HelmChartTarget.alias}` target that provides with templates for the Helm unit tests."
+
+
 class HelmUnitTestDependenciesField(Dependencies):
     pass
+
 
 class HelmUnitTestSourceField(SingleSourceField):
     expected_file_extensions = (
@@ -121,18 +141,33 @@ class HelmUnitTestSourceField(SingleSourceField):
         ".yml",
     )
 
+
 class HelmUnitTestTestTarget(Target):
     alias = "helm_unittest_test"
     core_fields = (
         *COMMON_TARGET_FIELDS,
         HelmUnitTestSourceField,
-        HelmUnitTestDependenciesField
+        HelmUnitTestChartField,
+        HelmUnitTestDependenciesField,
     )
     help = "A single helm-unittest suite file"
+
+
+class AllHelmUnitTestTestTargets(Targets):
+    pass
+
+
+@rule
+def all_helm_unittest_test_targets(all_targets: AllTargets) -> AllHelmUnitTestTestTargets:
+    return AllHelmUnitTestTestTargets(
+        [tgt for tgt in all_targets if tgt.has_field(HelmUnitTestSourceField)]
+    )
+
 
 # -----------------------------------------------------------------------------------------------
 # `helm_unittest_tests` target generator
 # -----------------------------------------------------------------------------------------------
+
 
 class HelmUnitTestGeneratingSourcesField(MultipleSourcesField):
     default = ("*_test.yaml",)
@@ -141,16 +176,20 @@ class HelmUnitTestGeneratingSourcesField(MultipleSourcesField):
         ".yml",
     )
 
+
 class HelmUnitTestTestsGeneratorTarget(TargetFilesGenerator):
     alias = "helm_unittest_tests"
     core_fields = (
         *COMMON_TARGET_FIELDS,
         HelmUnitTestDependenciesField,
-        HelmUnitTestGeneratingSourcesField
+        HelmUnitTestChartField,
+        HelmUnitTestGeneratingSourcesField,
     )
     generated_target_cls = HelmUnitTestTestTarget
-    copied_fields = (
-        *COMMON_TARGET_FIELDS,
-        HelmUnitTestDependenciesField
-    )
+    copied_fields = (*COMMON_TARGET_FIELDS, HelmUnitTestChartField, HelmUnitTestDependenciesField)
+    moved_fields = ()
     help = f"Generates a `{HelmUnitTestTestTarget.alias}` target per each file in the `{HelmUnitTestGeneratingSourcesField.alias}` field"
+
+
+def rules():
+    return collect_rules()

--- a/src/python/pants/backend/helm/target_types.py
+++ b/src/python/pants/backend/helm/target_types.py
@@ -15,7 +15,6 @@ from pants.engine.target import (
     FieldSet,
     MultipleSourcesField,
     SingleSourceField,
-    SpecialCasedDependencies,
     Target,
     TargetFilesGenerator,
     Targets,
@@ -126,11 +125,6 @@ def all_helm_chart_targets(all_targets: AllTargets) -> AllHelmChartTargets:
 # -----------------------------------------------------------------------------------------------
 
 
-class HelmUnitTestChartField(SpecialCasedDependencies):
-    alias = "chart"
-    help = f"Dependency on a `{HelmChartTarget.alias}` target that provides with templates for the Helm unit tests."
-
-
 class HelmUnitTestDependenciesField(Dependencies):
     pass
 
@@ -147,7 +141,6 @@ class HelmUnitTestTestTarget(Target):
     core_fields = (
         *COMMON_TARGET_FIELDS,
         HelmUnitTestSourceField,
-        HelmUnitTestChartField,
         HelmUnitTestDependenciesField,
     )
     help = "A single helm-unittest suite file"
@@ -183,11 +176,10 @@ class HelmUnitTestTestsGeneratorTarget(TargetFilesGenerator):
         *COMMON_TARGET_FIELDS,
         HelmUnitTestGeneratingSourcesField,
         HelmUnitTestDependenciesField,
-        HelmUnitTestChartField,
     )
     generated_target_cls = HelmUnitTestTestTarget
     copied_fields = COMMON_TARGET_FIELDS
-    moved_fields = (HelmUnitTestDependenciesField, HelmUnitTestChartField)
+    moved_fields = (HelmUnitTestDependenciesField,)
     help = f"Generates a `{HelmUnitTestTestTarget.alias}` target per each file in the `{HelmUnitTestGeneratingSourcesField.alias}` field"
 
 

--- a/src/python/pants/backend/helm/target_types_test.py
+++ b/src/python/pants/backend/helm/target_types_test.py
@@ -1,0 +1,63 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import os
+
+from pants.backend.helm import target_types
+from pants.backend.helm.target_types import (
+    HelmChartTarget,
+    HelmUnitTestTestsGeneratorTarget,
+    HelmUnitTestTestTarget,
+)
+from pants.backend.helm.testutil import (
+    HELM_CHART_FILE,
+    HELM_TEMPLATE_HELPERS_FILE,
+    HELM_VALUES_FILE,
+    K8S_SERVICE_FILE,
+)
+from pants.engine.addresses import Address
+from pants.engine.internals.graph import _TargetParametrizations
+from pants.engine.target import SingleSourceField, Tags
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+
+def test_generate_source_targets() -> None:
+    rule_runner = RuleRunner(
+        rules=[
+            *target_types.rules(),
+            QueryRule(_TargetParametrizations, [Address]),
+        ],
+        target_types=[HelmUnitTestTestsGeneratorTarget, HelmChartTarget],
+    )
+
+    source_root = "src/chart"
+    rule_runner.write_files(
+        {
+            f"{source_root}/BUILD": """helm_chart(name="foo")""",
+            f"{source_root}/Chart.yaml": HELM_CHART_FILE,
+            f"{source_root}/values.yaml": HELM_VALUES_FILE,
+            f"{source_root}/templates/_helpers.tpl": HELM_TEMPLATE_HELPERS_FILE,
+            f"{source_root}/templates/service.yaml": K8S_SERVICE_FILE,
+            f"{source_root}/tests/BUILD": "helm_unittest_tests(name='foo_tests')",
+            f"{source_root}/tests/service_test.yaml": "",
+        }
+    )
+
+    def gen_tgt(rel_fp: str, tags: list[str] | None = None) -> HelmUnitTestTestTarget:
+        return HelmUnitTestTestTarget(
+            {
+                SingleSourceField.alias: rel_fp,
+                Tags.alias: tags,
+            },
+            Address(f"{source_root}/tests", target_name="foo_tests", relative_file_path=rel_fp),
+            residence_dir=os.path.dirname(os.path.join(f"{source_root}/tests", rel_fp)),
+        )
+
+    generated = rule_runner.request(
+        _TargetParametrizations, [Address(f"{source_root}/tests", target_name="foo_tests")]
+    ).parametrizations
+    assert set(generated.values()) == {
+        gen_tgt("service_test.yaml"),
+    }

--- a/src/python/pants/backend/helm/test/BUILD
+++ b/src/python/pants/backend/helm/test/BUILD
@@ -1,0 +1,4 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_sources()

--- a/src/python/pants/backend/helm/test/BUILD
+++ b/src/python/pants/backend/helm/test/BUILD
@@ -2,3 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_sources()
+
+python_tests(name="tests")

--- a/src/python/pants/backend/helm/test/unittest.py
+++ b/src/python/pants/backend/helm/test/unittest.py
@@ -73,11 +73,11 @@ async def run_helm_unittest(
     test_subsystem: TestSubsystem,
     unittest_subsystem: HelmUnitTestSubsystem,
 ) -> TestResult:
-    chart_targets, transitive_targets = await MultiGet(
+    chart_deps_targets, transitive_targets = await MultiGet(
         Get(Targets, DependenciesRequest(field_set.chart, include_special_cased_deps=True)),
         Get(TransitiveTargets, TransitiveTargetsRequest([field_set.address])),
     )
-    chart_targets = [target for target in chart_targets if HelmChartFieldSet.is_applicable(target)]
+    chart_targets = [tgt for tgt in chart_deps_targets if HelmChartFieldSet.is_applicable(tgt)]
     if len(chart_targets) == 0:
         raise MissingUnitTestChartDependency(field_set.address)
 

--- a/src/python/pants/backend/helm/test/unittest.py
+++ b/src/python/pants/backend/helm/test/unittest.py
@@ -4,6 +4,7 @@
 import logging
 from dataclasses import dataclass
 
+from pants.backend.helm.dependency_inference.unittest import rules as dependency_rules
 from pants.backend.helm.subsystems.unittest import HelmUnitTestSubsystem
 from pants.backend.helm.subsystems.unittest import rules as subsystem_rules
 from pants.backend.helm.target_types import (
@@ -148,4 +149,9 @@ async def generate_helm_unittest_debug_request(field_set: HelmUnitTestFieldSet) 
 
 
 def rules():
-    return [*collect_rules(), *subsystem_rules(), UnionRule(TestFieldSet, HelmUnitTestFieldSet)]
+    return [
+        *collect_rules(),
+        *subsystem_rules(),
+        *dependency_rules(),
+        UnionRule(TestFieldSet, HelmUnitTestFieldSet),
+    ]

--- a/src/python/pants/backend/helm/test/unittest.py
+++ b/src/python/pants/backend/helm/test/unittest.py
@@ -4,7 +4,8 @@
 import logging
 from dataclasses import dataclass
 
-from pants.backend.helm.subsystems.unittest import HelmUnitTestPlugin
+from pants.backend.helm.subsystems.unittest import HelmUnitTestSubsystem
+from pants.backend.helm.subsystems.unittest import rules as subsystem_rules
 from pants.backend.helm.target_types import (
     HelmChartFieldSet,
     HelmUnitTestChartField,
@@ -65,7 +66,7 @@ class HelmUnitTestFieldSet(TestFieldSet):
 async def run_helm_unittest(
     field_set: HelmUnitTestFieldSet,
     test_subsystem: TestSubsystem,
-    unittest_subsystem: HelmUnitTestPlugin,
+    unittest_subsystem: HelmUnitTestSubsystem,
 ) -> TestResult:
     chart_deps_targets, transitive_targets = await MultiGet(
         Get(Targets, DependenciesRequest(field_set.chart, include_special_cased_deps=True)),
@@ -125,7 +126,7 @@ async def run_helm_unittest(
             description=f"Running Helm unittest on: {field_set.address}",
             input_digest=input_digest,
             cache_scope=cache_scope,
-            output_dirs=(reports_dir,),
+            output_directories=(reports_dir,),
         ),
     )
     xml_result_subset = await Get(
@@ -147,4 +148,4 @@ async def generate_helm_unittest_debug_request(field_set: HelmUnitTestFieldSet) 
 
 
 def rules():
-    return [*collect_rules(), UnionRule(TestFieldSet, HelmUnitTestFieldSet)]
+    return [*collect_rules(), *subsystem_rules(), UnionRule(TestFieldSet, HelmUnitTestFieldSet)]

--- a/src/python/pants/backend/helm/test/unittest.py
+++ b/src/python/pants/backend/helm/test/unittest.py
@@ -139,7 +139,7 @@ async def run_helm_unittest(
 
 @rule
 async def generate_helm_unittest_debug_request(field_set: HelmUnitTestFieldSet) -> TestDebugRequest:
-    raise NotImplementedError("This is a stub")
+    raise NotImplementedError("Can not debug Helm unit tests")
 
 
 def rules():

--- a/src/python/pants/backend/helm/test/unittest.py
+++ b/src/python/pants/backend/helm/test/unittest.py
@@ -75,7 +75,10 @@ async def run_helm_unittest(
 ) -> TestResult:
     chart_deps_targets, transitive_targets = await MultiGet(
         Get(Targets, DependenciesRequest(field_set.chart, include_special_cased_deps=True)),
-        Get(TransitiveTargets, TransitiveTargetsRequest([field_set.address])),
+        Get(
+            TransitiveTargets,
+            TransitiveTargetsRequest([field_set.address], include_special_cased_deps=False),
+        ),
     )
     chart_targets = [tgt for tgt in chart_deps_targets if HelmChartFieldSet.is_applicable(tgt)]
     if len(chart_targets) == 0:

--- a/src/python/pants/backend/helm/test/unittest.py
+++ b/src/python/pants/backend/helm/test/unittest.py
@@ -1,0 +1,150 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import logging
+from dataclasses import dataclass
+
+from pants.backend.helm.subsystems.unittest import HelmUnitTestPlugin
+from pants.backend.helm.target_types import (
+    HelmChartFieldSet,
+    HelmUnitTestChartField,
+    HelmUnitTestDependenciesField,
+    HelmUnitTestSourceField,
+)
+from pants.backend.helm.util_rules.chart import HelmChart, HelmChartRequest
+from pants.backend.helm.util_rules.tool import HelmProcess
+from pants.core.goals.test import TestDebugRequest, TestFieldSet, TestResult, TestSubsystem
+from pants.core.target_types import ResourceSourceField
+from pants.core.util_rules.source_files import SourceFilesRequest
+from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
+from pants.engine.fs import (
+    AddPrefix,
+    Digest,
+    DigestSubset,
+    MergeDigests,
+    PathGlobs,
+    RemovePrefix,
+    Snapshot,
+)
+from pants.engine.internals.selectors import MultiGet
+from pants.engine.process import FallibleProcessResult, ProcessCacheScope
+from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.target import (
+    DependenciesRequest,
+    SourcesField,
+    Targets,
+    TransitiveTargets,
+    TransitiveTargetsRequest,
+)
+from pants.engine.unions import UnionRule
+from pants.util.logging import LogLevel
+
+logger = logging.getLogger(__name__)
+
+
+class MissingUnitTestChartDependencyException(Exception):
+    """Indicates that no chart has been found as dependency of the `helm_unittest_test` or
+    `helm_unittest_tests` targets."""
+
+    def __init__(self, address) -> None:
+        super().__init__(
+            f"No valid `helm_chart` target has been found as a dependency for target at '{address}'."
+        )
+
+
+@dataclass(frozen=True)
+class HelmUnitTestFieldSet(TestFieldSet):
+    required_fields = (HelmUnitTestSourceField, HelmUnitTestChartField)
+
+    sources: HelmUnitTestSourceField
+    chart: HelmUnitTestChartField
+    dependencies: HelmUnitTestDependenciesField
+
+
+@rule(desc="Run Helm Unittest", level=LogLevel.DEBUG)
+async def run_helm_unittest(
+    field_set: HelmUnitTestFieldSet,
+    test_subsystem: TestSubsystem,
+    unittest_subsystem: HelmUnitTestPlugin,
+) -> TestResult:
+    chart_deps_targets, transitive_targets = await MultiGet(
+        Get(Targets, DependenciesRequest(field_set.chart, include_special_cased_deps=True)),
+        Get(TransitiveTargets, TransitiveTargetsRequest([field_set.address])),
+    )
+    chart_targets = [
+        target for target in chart_deps_targets if HelmChartFieldSet.is_applicable(target)
+    ]
+    if len(chart_targets) == 0:
+        raise MissingUnitTestChartDependencyException(field_set.address)
+
+    chart = await Get(HelmChart, HelmChartRequest, HelmChartRequest.from_target(chart_targets[0]))
+
+    source_files = await Get(
+        StrippedSourceFiles,
+        SourceFilesRequest(
+            sources_fields=[
+                field_set.sources,
+                *(
+                    tgt.get(SourcesField)
+                    for tgt in transitive_targets.dependencies
+                    if not HelmChartFieldSet.is_applicable(tgt)
+                ),
+            ],
+            for_sources_types=(HelmUnitTestSourceField, ResourceSourceField),
+            enable_codegen=True,
+        ),
+    )
+    prefixed_test_files_digest = await Get(
+        Digest, AddPrefix(source_files.snapshot.digest, chart.path)
+    )
+
+    reports_dir = "__reports_dir"
+    reports_file = f"{reports_dir}/{field_set.address.path_safe_spec}.xml"
+
+    input_digest = await Get(
+        Digest, MergeDigests([chart.snapshot.digest, prefixed_test_files_digest])
+    )
+
+    # Cache test runs only if they are successful, or not at all if `--test-force`.
+    cache_scope = (
+        ProcessCacheScope.PER_SESSION if test_subsystem.force else ProcessCacheScope.SUCCESSFUL
+    )
+
+    process_result = await Get(
+        FallibleProcessResult,
+        HelmProcess(
+            argv=[
+                unittest_subsystem.plugin_name,
+                "--helm3",
+                "--output-type",
+                unittest_subsystem.output_type.value,
+                "--output-file",
+                reports_file,
+                chart.path,
+            ],
+            description=f"Running Helm unittest on: {field_set.address}",
+            input_digest=input_digest,
+            cache_scope=cache_scope,
+            output_dirs=(reports_dir,),
+        ),
+    )
+    xml_result_subset = await Get(
+        Digest, DigestSubset(process_result.output_digest, PathGlobs([f"{reports_dir}/**"]))
+    )
+    xml_results = await Get(Snapshot, RemovePrefix(xml_result_subset, reports_dir))
+
+    return TestResult.from_fallible_process_result(
+        process_result,
+        address=field_set.address,
+        output_setting=test_subsystem.output,
+        xml_results=xml_results,
+    )
+
+
+@rule
+async def generate_helm_unittest_debug_request(field_set: HelmUnitTestFieldSet) -> TestDebugRequest:
+    raise NotImplementedError("This is a stub")
+
+
+def rules():
+    return [*collect_rules(), UnionRule(TestFieldSet, HelmUnitTestFieldSet)]

--- a/src/python/pants/backend/helm/test/unittest_test.py
+++ b/src/python/pants/backend/helm/test/unittest_test.py
@@ -77,3 +77,40 @@ def test_simple_success(rule_runner: RuleRunner) -> None:
 
     assert result.exit_code == 0
     assert result.xml_results and result.xml_results.files
+    assert result.xml_results.files == (f"{target.address.path_safe_spec}.xml",)
+
+
+def test_simple_failure(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": "helm_chart(name='mychart')",
+            "Chart.yaml": HELM_CHART_FILE,
+            "values.yaml": HELM_VALUES_FILE,
+            "templates/_helpers.tpl": HELM_TEMPLATE_HELPERS_FILE,
+            "templates/service.yaml": K8S_SERVICE_FILE,
+            "tests/BUILD": "helm_unittest_test(name='test', source='service_test.yaml')",
+            "tests/service_test.yaml": dedent(
+                """\
+                suite: test service
+                templates:
+                  - service.yaml
+                values:
+                  - ../values.yaml
+                tests:
+                  - it: should work
+                    asserts:
+                      - isKind:
+                          of: Ingress
+                      - equal:
+                          path: spec.type
+                          value: ClusterIP
+                """
+            ),
+        }
+    )
+
+    target = rule_runner.get_target(Address("tests", target_name="test"))
+    field_set = HelmUnitTestFieldSet.create(target)
+
+    result = rule_runner.request(TestResult, [field_set])
+    assert result.exit_code == 1

--- a/src/python/pants/backend/helm/test/unittest_test.py
+++ b/src/python/pants/backend/helm/test/unittest_test.py
@@ -5,7 +5,6 @@ from textwrap import dedent
 
 import pytest
 
-from pants.backend.helm.dependency_inference.unittest import rules as unittest_dependency_rules
 from pants.backend.helm.target_types import HelmChartTarget, HelmUnitTestTestTarget
 from pants.backend.helm.target_types import rules as target_types_rules
 from pants.backend.helm.test.unittest import HelmUnitTestFieldSet
@@ -36,7 +35,6 @@ def rule_runner() -> RuleRunner:
             *test_rules(),
             *stripped_source_files.rules(),
             *source_root_rules(),
-            *unittest_dependency_rules(),
             *target_types_rules(),
             QueryRule(TestResult, (HelmUnitTestFieldSet,)),
         ],

--- a/src/python/pants/backend/helm/test/unittest_test.py
+++ b/src/python/pants/backend/helm/test/unittest_test.py
@@ -1,0 +1,81 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from textwrap import dedent
+
+import pytest
+
+from pants.backend.helm.dependency_inference.unittest import rules as unittest_dependency_rules
+from pants.backend.helm.target_types import HelmChartTarget, HelmUnitTestTestTarget
+from pants.backend.helm.target_types import rules as target_types_rules
+from pants.backend.helm.test.unittest import HelmUnitTestFieldSet
+from pants.backend.helm.test.unittest import rules as test_rules
+from pants.backend.helm.testutil import (
+    HELM_CHART_FILE,
+    HELM_TEMPLATE_HELPERS_FILE,
+    HELM_VALUES_FILE,
+    K8S_SERVICE_FILE,
+)
+from pants.backend.helm.util_rules import chart, tool
+from pants.core.goals.test import TestResult
+from pants.core.util_rules import external_tool, stripped_source_files
+from pants.engine.addresses import Address
+from pants.engine.rules import QueryRule
+from pants.source.source_root import rules as source_root_rules
+from pants.testutil.rule_runner import RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        target_types=[HelmChartTarget, HelmUnitTestTestTarget],
+        rules=[
+            *external_tool.rules(),
+            *tool.rules(),
+            *chart.rules(),
+            *test_rules(),
+            *stripped_source_files.rules(),
+            *source_root_rules(),
+            *unittest_dependency_rules(),
+            *target_types_rules(),
+            QueryRule(TestResult, (HelmUnitTestFieldSet,)),
+        ],
+    )
+
+
+def test_simple_success(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": "helm_chart(name='mychart')",
+            "Chart.yaml": HELM_CHART_FILE,
+            "values.yaml": HELM_VALUES_FILE,
+            "templates/_helpers.tpl": HELM_TEMPLATE_HELPERS_FILE,
+            "templates/service.yaml": K8S_SERVICE_FILE,
+            "tests/BUILD": "helm_unittest_test(name='test', source='service_test.yaml')",
+            "tests/service_test.yaml": dedent(
+                """\
+                suite: test service
+                templates:
+                  - service.yaml
+                values:
+                  - ../values.yaml
+                tests:
+                  - it: should work
+                    asserts:
+                      - isKind:
+                          of: Service
+                      - equal:
+                          path: spec.type
+                          value: ClusterIP
+                """
+            ),
+        }
+    )
+
+    target = rule_runner.get_target(Address("tests", target_name="test"))
+    field_set = HelmUnitTestFieldSet.create(target)
+
+    result = rule_runner.request(TestResult, [field_set])
+
+    assert result.exit_code == 0
+    assert result.xml_results and result.xml_results.files

--- a/src/python/pants/backend/helm/util_rules/chart.py
+++ b/src/python/pants/backend/helm/util_rules/chart.py
@@ -237,8 +237,6 @@ class HelmChart:
     metadata: HelmChartMetadata
     snapshot: Snapshot
 
-    lint_strict: bool | None
-
     @property
     def path(self) -> str:
         return self.metadata.name

--- a/src/python/pants/backend/helm/util_rules/chart.py
+++ b/src/python/pants/backend/helm/util_rules/chart.py
@@ -233,8 +233,6 @@ class HelmChart:
     metadata: HelmChartMetadata
     snapshot: Snapshot
 
-    lint_strict: bool | None
-
     @property
     def path(self) -> str:
         return self.metadata.name

--- a/src/python/pants/backend/helm/util_rules/chart.py
+++ b/src/python/pants/backend/helm/util_rules/chart.py
@@ -11,6 +11,7 @@ from typing import Any, cast
 import yaml
 
 from pants.backend.helm.target_types import HelmChartFieldSet, HelmChartMetaSourceField
+from pants.backend.helm.util_rules import sources
 from pants.backend.helm.util_rules.sources import HelmChartSourceFiles, HelmChartSourceFilesRequest
 from pants.backend.helm.util_rules.yaml_utils import yaml_attr_dict
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
@@ -343,4 +344,4 @@ async def get_helm_chart(request: HelmChartRequest) -> HelmChart:
 
 
 def rules():
-    return collect_rules()
+    return [*collect_rules(), *sources.rules()]

--- a/src/python/pants/backend/helm/util_rules/chart.py
+++ b/src/python/pants/backend/helm/util_rules/chart.py
@@ -116,7 +116,6 @@ class HelmChartDependency:
         return d
 
 
-<<<<<<< HEAD
 @dataclass(frozen=True)
 class HelmChartMaintainer:
     name: str
@@ -137,9 +136,6 @@ class HelmChartMaintainer:
 
 
 DEFAULT_API_VERSION = "v2"
-=======
-DEFAULT_API_VERSION = "v1"
->>>>>>> Test producing a Helm chart package
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/helm/util_rules/chart.py
+++ b/src/python/pants/backend/helm/util_rules/chart.py
@@ -233,6 +233,8 @@ class HelmChart:
     metadata: HelmChartMetadata
     snapshot: Snapshot
 
+    lint_strict: bool | None
+
     @property
     def path(self) -> str:
         return self.metadata.name

--- a/src/python/pants/backend/helm/util_rules/chart.py
+++ b/src/python/pants/backend/helm/util_rules/chart.py
@@ -237,6 +237,8 @@ class HelmChart:
     metadata: HelmChartMetadata
     snapshot: Snapshot
 
+    lint_strict: bool | None
+
     @property
     def path(self) -> str:
         return self.metadata.name

--- a/src/python/pants/backend/helm/util_rules/chart.py
+++ b/src/python/pants/backend/helm/util_rules/chart.py
@@ -12,6 +12,7 @@ import yaml
 
 from pants.backend.helm.target_types import HelmChartFieldSet, HelmChartMetaSourceField
 from pants.backend.helm.util_rules.sources import HelmChartSourceFiles, HelmChartSourceFilesRequest
+from pants.backend.helm.util_rules.yaml_utils import yaml_attr_dict
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.engine.addresses import Address
 from pants.engine.fs import (
@@ -64,27 +65,6 @@ class AmbiguousChartMetadataException(Exception):
     pass
 
 
-def _as_python_attribute_name(str: str) -> str:
-    base_string = str.replace("-", "_")
-
-    result = ""
-    idx = 0
-    for c in base_string:
-        char_to_add = c
-        if char_to_add.isupper():
-            char_to_add = c.lower()
-            if idx > 0:
-                result += "_"
-        result += char_to_add
-        idx += 1
-
-    return result
-
-
-def _attr_dict(d: dict[str, Any]) -> dict[str, Any]:
-    return {_as_python_attribute_name(name): value for name, value in d.items()}
-
-
 @dataclass(frozen=True)
 class HelmChartDependency:
     name: str
@@ -97,7 +77,7 @@ class HelmChartDependency:
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> HelmChartDependency:
-        return cls(**_attr_dict(d))
+        return cls(**yaml_attr_dict(d))
 
     def to_json_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {"name": self.name}
@@ -174,7 +154,7 @@ class HelmChartMetadata:
         sources = d.pop("sources", [])
         annotations = d.pop("annotations", {})
 
-        attrs = _attr_dict(d)
+        attrs = yaml_attr_dict(d)
 
         return cls(
             api_version=api_version,

--- a/src/python/pants/backend/helm/util_rules/chart.py
+++ b/src/python/pants/backend/helm/util_rules/chart.py
@@ -13,7 +13,7 @@ import yaml
 from pants.backend.helm.target_types import HelmChartFieldSet, HelmChartMetaSourceField
 from pants.backend.helm.util_rules import sources
 from pants.backend.helm.util_rules.sources import HelmChartSourceFiles, HelmChartSourceFilesRequest
-from pants.backend.helm.util_rules.yaml_utils import yaml_attr_dict
+from pants.backend.helm.util_rules.yaml_utils import snake_case_attr_dict
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.engine.addresses import Address
 from pants.engine.fs import (
@@ -78,7 +78,7 @@ class HelmChartDependency:
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> HelmChartDependency:
-        return cls(**yaml_attr_dict(d))
+        return cls(**snake_case_attr_dict(d))
 
     def to_json_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {"name": self.name}
@@ -155,7 +155,7 @@ class HelmChartMetadata:
         sources = d.pop("sources", [])
         annotations = d.pop("annotations", {})
 
-        attrs = yaml_attr_dict(d)
+        attrs = snake_case_attr_dict(d)
 
         return cls(
             api_version=api_version,

--- a/src/python/pants/backend/helm/util_rules/chart.py
+++ b/src/python/pants/backend/helm/util_rules/chart.py
@@ -116,6 +116,7 @@ class HelmChartDependency:
         return d
 
 
+<<<<<<< HEAD
 @dataclass(frozen=True)
 class HelmChartMaintainer:
     name: str
@@ -136,6 +137,9 @@ class HelmChartMaintainer:
 
 
 DEFAULT_API_VERSION = "v2"
+=======
+DEFAULT_API_VERSION = "v1"
+>>>>>>> Test producing a Helm chart package
 
 
 @dataclass(frozen=True)
@@ -190,6 +194,10 @@ class HelmChartMetadata:
     @classmethod
     def from_bytes(cls, content: bytes) -> HelmChartMetadata:
         return cls.from_dict(yaml.safe_load(content))
+
+    @property
+    def artifact_name(self) -> str:
+        return f"{self.name}-{self.version}"
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {

--- a/src/python/pants/backend/helm/util_rules/chart_test.py
+++ b/src/python/pants/backend/helm/util_rules/chart_test.py
@@ -91,6 +91,7 @@ def test_collects_single_chart_sources(
     assert helm_chart.metadata == expected_metadata
     assert len(helm_chart.snapshot.files) == 4
     assert helm_chart.address == address
+    assert helm_chart.lint_strict == lint_strict
 
 
 def test_gathers_local_subchart_sources_using_explicit_dependency(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/helm/util_rules/chart_test.py
+++ b/src/python/pants/backend/helm/util_rules/chart_test.py
@@ -91,7 +91,6 @@ def test_collects_single_chart_sources(
     assert helm_chart.metadata == expected_metadata
     assert len(helm_chart.snapshot.files) == 4
     assert helm_chart.address == address
-    assert helm_chart.lint_strict == lint_strict
 
 
 def test_gathers_local_subchart_sources_using_explicit_dependency(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/helm/util_rules/plugins.py
+++ b/src/python/pants/backend/helm/util_rules/plugins.py
@@ -20,6 +20,7 @@ from pants.core.util_rules.external_tool import (
 from pants.engine.collection import Collection
 from pants.engine.fs import Digest, DigestContents, DigestSubset, PathGlobs
 from pants.engine.internals.selectors import MultiGet
+from pants.engine.platform import Platform
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.unions import UnionMembership, union
 from pants.option.subsystem import Subsystem
@@ -87,14 +88,14 @@ class HelmPluginMetadata:
         return HelmPluginMetadata.from_dict(yaml.safe_load(content))
 
 
-_HelmPluginSubsystem = TypeVar("_HelmPluginSubsystem", bound=HelmPluginSubsystem)
+_ExternalHelmPlugin = TypeVar("_ExternalHelmPlugin", bound=ExternalHelmPlugin)
 _GHP = TypeVar("_GHP", bound="ExternalHelmPluginBinding")
 
 
 @union
 @dataclass(frozen=True)
-class ExternalHelmPluginBinding(Generic[_HelmPluginSubsystem], metaclass=ABCMeta):
-    plugin_subsystem_cls: ClassVar[Type[HelmPluginSubsystem]]
+class ExternalHelmPluginBinding(Generic[_ExternalHelmPlugin], metaclass=ABCMeta):
+    plugin_subsystem_cls: ClassVar[Type[ExternalHelmPlugin]]
 
     name: str
 
@@ -108,6 +109,12 @@ class ExternalHelmPluginBinding(Generic[_HelmPluginSubsystem], metaclass=ABCMeta
 class ExternalHelmPluginRequest:
     plugin_name: str
     tool_request: ExternalToolRequest
+
+    @classmethod
+    def from_subsystem(cls, subsystem: ExternalHelmPlugin) -> ExternalHelmPluginRequest:
+        return cls(
+            plugin_name=subsystem.plugin_name, tool_request=subsystem.get_request(Platform.current)
+        )
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/helm/util_rules/plugins.py
+++ b/src/python/pants/backend/helm/util_rules/plugins.py
@@ -1,18 +1,36 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 from __future__ import annotations
 
 from abc import ABCMeta
-from typing import ClassVar, Type, TypeVar
-from dataclasses import dataclass
-from typing_extensions import final
-from pants.engine.unions import UnionMembership, union
-from pants.engine.fs import Digest
+from dataclasses import dataclass, field
+from typing import Any, ClassVar
+
+import yaml
+
+from pants.backend.helm.util_rules.yaml_utils import yaml_attr_dict
 from pants.core.util_rules.external_tool import (
     DownloadedExternalTool,
     ExternalToolRequest,
     TemplatedExternalTool,
 )
-from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.fs import Digest, DigestContents, DigestSubset, PathGlobs
 from pants.engine.platform import Platform
+from pants.engine.rules import Get, collect_rules, rule
+
+
+class HelmPluginMetadataFileNotFound(Exception):
+    def __init__(self, plugin_name: str) -> None:
+        super().__init__(f"Helm plugin `{plugin_name}` is missing the `plugin.yaml` metadata file.")
+
+
+class HelmPluginMissingCommand(ValueError):
+    def __init__(self, plugin_name: str) -> None:
+        super().__init__(
+            f"Helm plugin `{plugin_name}` is missing either `platformCommand` entries or a single `command` entry."
+        )
+
 
 class HelmPluginSubsystem(TemplatedExternalTool, metaclass=ABCMeta):
     plugin_name: ClassVar[str]
@@ -24,21 +42,65 @@ class DownloadHelmPlugin:
 
 
 @dataclass(frozen=True)
-class HelmPlugin:
-    name: str
-    version: str
-    digest: Digest
+class HelmPluginPlatformCommand:
+    os: str
+    arch: str
+    command: str
 
     @classmethod
-    def from_downloaded_external_tool(
-        cls, plugin: HelmPluginSubsystem, tool: DownloadedExternalTool
-    ) -> HelmPlugin:
-        return cls(name=plugin.plugin_name, version=plugin.version, digest=tool.digest)
+    def from_dict(cls, d: dict[str, Any]) -> HelmPluginPlatformCommand:
+        return cls(**yaml_attr_dict(d))
+
+
+@dataclass(frozen=True)
+class HelmPluginMetadata:
+    name: str
+    version: str
+    usage: str | None = None
+    description: str | None = None
+    ignore_flags: bool | None = None
+    command: str | None = None
+    platform_command: tuple[HelmPluginPlatformCommand, ...] = field(default_factory=tuple)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> HelmPluginMetadata:
+        platform_command = [
+            HelmPluginPlatformCommand.from_dict(d) for d in d.pop("platformCommand", [])
+        ]
+
+        attrs = yaml_attr_dict(d)
+        return cls(platform_command=tuple(platform_command), **attrs)
+
+    @classmethod
+    def from_bytes(cls, content: bytes) -> HelmPluginMetadata:
+        return HelmPluginMetadata.from_dict(yaml.safe_load(content))
+
+
+@dataclass(frozen=True)
+class HelmPlugin:
+    metadata: HelmPluginMetadata
+    digest: Digest
+
 
 @rule
 async def download_helm_plugin(request: DownloadHelmPlugin) -> HelmPlugin:
-  downloaded_tool = await Get(DownloadedExternalTool, ExternalToolRequest, request.subsystem.get_request(Platform.current))
-  return HelmPlugin.from_downloaded_external_tool(request.subsystem, downloaded_tool)
+    downloaded_tool = await Get(
+        DownloadedExternalTool, ExternalToolRequest, request.subsystem.get_request(Platform.current)
+    )
+
+    metadata_file = await Get(
+        Digest, DigestSubset(downloaded_tool.digest, PathGlobs(["**/plugin.yaml"]))
+    )
+    metadata_content = await Get(DigestContents, Digest, metadata_file)
+    if len(metadata_content) == 0:
+        raise HelmPluginMetadataFileNotFound(request.subsystem.plugin_name)
+
+    metadata = HelmPluginMetadata.from_bytes(metadata_content[0].content)
+    if not metadata.command and not metadata.platform_command:
+        raise HelmPluginMissingCommand(request.subsystem.plugin_name)
+
+    return HelmPlugin(metadata=metadata, digest=downloaded_tool.digest)
+
 
 def rules():
-  return collect_rules()
+    return collect_rules()

--- a/src/python/pants/backend/helm/util_rules/plugins.py
+++ b/src/python/pants/backend/helm/util_rules/plugins.py
@@ -12,6 +12,7 @@ import yaml
 from typing_extensions import final
 
 from pants.backend.helm.util_rules.yaml_utils import yaml_attr_dict
+from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.core.util_rules.external_tool import (
     DownloadedExternalTool,
     ExternalToolRequest,
@@ -154,7 +155,15 @@ async def download_external_helm_plugin(request: ExternalHelmPluginRequest) -> H
     downloaded_tool = await Get(DownloadedExternalTool, ExternalToolRequest, request.tool_request)
 
     metadata_file = await Get(
-        Digest, DigestSubset(downloaded_tool.digest, PathGlobs(["plugin.yaml"]))
+        Digest,
+        DigestSubset(
+            downloaded_tool.digest,
+            PathGlobs(
+                ["plugin.yaml"],
+                glob_match_error_behavior=GlobMatchErrorBehavior.error,
+                description_of_origin=request.plugin_name,
+            ),
+        ),
     )
     metadata_content = await Get(DigestContents, Digest, metadata_file)
     if len(metadata_content) == 0:

--- a/src/python/pants/backend/helm/util_rules/plugins.py
+++ b/src/python/pants/backend/helm/util_rules/plugins.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from abc import ABCMeta
 from dataclasses import dataclass, field
-from typing import Any, ClassVar, Iterable
+from typing import Any, ClassVar, Generic, Iterable, Type, TypeVar, final
 
 import yaml
 
@@ -15,9 +15,13 @@ from pants.core.util_rules.external_tool import (
     ExternalToolRequest,
     TemplatedExternalTool,
 )
+from pants.engine.collection import Collection
 from pants.engine.fs import Digest, DigestContents, DigestSubset, PathGlobs
+from pants.engine.internals.selectors import MultiGet
 from pants.engine.platform import Platform
 from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.unions import UnionMembership, union
+from pants.util.frozendict import FrozenDict
 from pants.util.strutil import bullet_list
 
 
@@ -57,11 +61,6 @@ class HelmPluginSubsystem(TemplatedExternalTool, metaclass=ABCMeta):
 
 
 @dataclass(frozen=True)
-class DownloadHelmPlugin:
-    subsystem: HelmPluginSubsystem
-
-
-@dataclass(frozen=True)
 class HelmPluginPlatformCommand:
     os: str
     arch: str
@@ -88,19 +87,44 @@ class HelmPluginMetadata:
     ignore_flags: bool | None = None
     command: str | None = None
     platform_command: tuple[HelmPluginPlatformCommand, ...] = field(default_factory=tuple)
+    hooks: FrozenDict[str, str] = field(default_factory=FrozenDict)
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> HelmPluginMetadata:
         platform_command = [
             HelmPluginPlatformCommand.from_dict(d) for d in d.pop("platformCommand", [])
         ]
+        hooks = d.pop("hooks", {})
 
         attrs = yaml_attr_dict(d)
-        return cls(platform_command=tuple(platform_command), **attrs)
+        return cls(platform_command=tuple(platform_command), hooks=FrozenDict(hooks), **attrs)
 
     @classmethod
     def from_bytes(cls, content: bytes) -> HelmPluginMetadata:
         return HelmPluginMetadata.from_dict(yaml.safe_load(content))
+
+
+_HelmPluginSubsystem = TypeVar("_HelmPluginSubsystem", bound=HelmPluginSubsystem)
+_GHP = TypeVar("_GHP", bound="GlobalHelmPlugin")
+
+
+@union
+@dataclass(frozen=True)
+class GlobalHelmPlugin(Generic[_HelmPluginSubsystem], metaclass=ABCMeta):
+    plugin_subsystem_cls: ClassVar[Type[HelmPluginSubsystem]]
+
+    name: str
+
+    @final
+    @classmethod
+    def create(cls: Type[_GHP]) -> _GHP:
+        return cls(name=cls.plugin_subsystem_cls.plugin_name)
+
+
+@dataclass(frozen=True)
+class HelmPluginRequest:
+    plugin_name: str
+    tool_request: ExternalToolRequest
 
 
 @dataclass(frozen=True)
@@ -108,35 +132,53 @@ class HelmPlugin:
     metadata: HelmPluginMetadata
     digest: Digest
 
+    @property
+    def name(self) -> str:
+        return self.metadata.name
+
+
+class HelmPlugins(Collection[HelmPlugin]):
+    pass
+
 
 @rule
-async def download_helm_plugin(request: DownloadHelmPlugin) -> HelmPlugin:
-    downloaded_tool = await Get(
-        DownloadedExternalTool, ExternalToolRequest, request.subsystem.get_request(Platform.current)
+async def download_all_global_helm_plugins(union_membership: UnionMembership) -> HelmPlugins:
+    all_plugin_settings = union_membership.get(GlobalHelmPlugin)
+    requests = await MultiGet(
+        Get(HelmPluginRequest, GlobalHelmPlugin, plugin_settings.create())
+        for plugin_settings in all_plugin_settings
     )
+    plugins = await MultiGet(Get(HelmPlugin, HelmPluginRequest, request) for request in requests)
+    return HelmPlugins(plugins)
+
+
+@rule
+async def download_helm_plugin(request: HelmPluginRequest) -> HelmPlugin:
+    downloaded_tool = await Get(DownloadedExternalTool, ExternalToolRequest, request.tool_request)
 
     metadata_file = await Get(
-        Digest, DigestSubset(downloaded_tool.digest, PathGlobs(["**/plugin.yaml"]))
+        Digest, DigestSubset(downloaded_tool.digest, PathGlobs(["plugin.yaml"]))
     )
     metadata_content = await Get(DigestContents, Digest, metadata_file)
     if len(metadata_content) == 0:
-        raise HelmPluginMetadataFileNotFound(request.subsystem.plugin_name)
+        raise HelmPluginMetadataFileNotFound(request.plugin_name)
 
     metadata = HelmPluginMetadata.from_bytes(metadata_content[0].content)
     if not metadata.command and not metadata.platform_command:
-        raise HelmPluginMissingCommand(request.subsystem.plugin_name)
+        raise HelmPluginMissingCommand(request.plugin_name)
 
-    if metadata.platform_command:
-        current_helm_platf = request.subsystem.map_platform(Platform.current)
-        supported_cmds = [
-            cmd for cmd in metadata.platform_command if cmd.supports_platform(current_helm_platf)
-        ]
-        if len(supported_cmds) == 0:
-            raise HelmPluginPlatformNotSupported(
-                request.subsystem.plugin_name,
-                Platform.current,
-                [f"{cmd.platform}" for cmd in metadata.platform_command],
-            )
+    # TODO
+    # if metadata.platform_command:
+    #     current_helm_platf = request.subsystem.map_platform(Platform.current)
+    #     supported_cmds = [
+    #         cmd for cmd in metadata.platform_command if cmd.supports_platform(current_helm_platf)
+    #     ]
+    #     if len(supported_cmds) == 0:
+    #         raise HelmPluginPlatformNotSupported(
+    #             request.plugin_name,
+    #             Platform.current,
+    #             [f"{cmd.platform}" for cmd in metadata.platform_command],
+    #         )
 
     return HelmPlugin(metadata=metadata, digest=downloaded_tool.digest)
 

--- a/src/python/pants/backend/helm/util_rules/plugins.py
+++ b/src/python/pants/backend/helm/util_rules/plugins.py
@@ -161,7 +161,7 @@ async def download_external_helm_plugin(request: ExternalHelmPluginRequest) -> H
             PathGlobs(
                 ["plugin.yaml"],
                 glob_match_error_behavior=GlobMatchErrorBehavior.error,
-                description_of_origin=request.plugin_name,
+                description_of_origin=f"The Helm plugin `{request.plugin_name}`",
             ),
         ),
     )

--- a/src/python/pants/backend/helm/util_rules/plugins.py
+++ b/src/python/pants/backend/helm/util_rules/plugins.py
@@ -11,7 +11,7 @@ from typing import Any, ClassVar, Generic, Type, TypeVar
 import yaml
 from typing_extensions import final
 
-from pants.backend.helm.util_rules.yaml_utils import yaml_attr_dict
+from pants.backend.helm.util_rules.yaml_utils import snake_case_attr_dict
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.core.util_rules.external_tool import (
     DownloadedExternalTool,
@@ -60,7 +60,7 @@ class HelmPluginPlatformCommand:
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> HelmPluginPlatformCommand:
-        return cls(**yaml_attr_dict(d))
+        return cls(**snake_case_attr_dict(d))
 
 
 @dataclass(frozen=True)
@@ -81,7 +81,7 @@ class HelmPluginMetadata:
         ]
         hooks = d.pop("hooks", {})
 
-        attrs = yaml_attr_dict(d)
+        attrs = snake_case_attr_dict(d)
         return cls(platform_command=tuple(platform_command), hooks=FrozenDict(hooks), **attrs)
 
     @classmethod

--- a/src/python/pants/backend/helm/util_rules/plugins.py
+++ b/src/python/pants/backend/helm/util_rules/plugins.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from abc import ABCMeta
+from typing import ClassVar, Type, TypeVar
+from dataclasses import dataclass
+from typing_extensions import final
+from pants.engine.unions import UnionMembership, union
+from pants.engine.fs import Digest
+from pants.core.util_rules.external_tool import (
+    DownloadedExternalTool,
+    ExternalToolRequest,
+    TemplatedExternalTool,
+)
+from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.platform import Platform
+
+class HelmPluginSubsystem(TemplatedExternalTool, metaclass=ABCMeta):
+    plugin_name: ClassVar[str]
+
+
+@dataclass(frozen=True)
+class DownloadHelmPlugin:
+    subsystem: HelmPluginSubsystem
+
+
+@dataclass(frozen=True)
+class HelmPlugin:
+    name: str
+    version: str
+    digest: Digest
+
+    @classmethod
+    def from_downloaded_external_tool(
+        cls, plugin: HelmPluginSubsystem, tool: DownloadedExternalTool
+    ) -> HelmPlugin:
+        return cls(name=plugin.plugin_name, version=plugin.version, digest=tool.digest)
+
+@rule
+async def download_helm_plugin(request: DownloadHelmPlugin) -> HelmPlugin:
+  downloaded_tool = await Get(DownloadedExternalTool, ExternalToolRequest, request.subsystem.get_request(Platform.current))
+  return HelmPlugin.from_downloaded_external_tool(request.subsystem, downloaded_tool)
+
+def rules():
+  return collect_rules()

--- a/src/python/pants/backend/helm/util_rules/tool.py
+++ b/src/python/pants/backend/helm/util_rules/tool.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 from typing import Iterable, Mapping
 
 from pants.backend.helm.subsystems.helm import HelmSubsystem
-from pants.backend.helm.subsystems.helm import rules as helm_rules
 from pants.backend.helm.util_rules.plugins import HelmPlugins
 from pants.backend.helm.util_rules.plugins import rules as plugins_rules
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
@@ -179,4 +178,4 @@ def helm_process(request: HelmProcess, helm_binary: HelmBinary) -> Process:
 
 
 def rules():
-    return [*collect_rules(), *helm_rules(), *plugins_rules()]
+    return [*collect_rules(), *plugins_rules()]

--- a/src/python/pants/backend/helm/util_rules/yaml_utils.py
+++ b/src/python/pants/backend/helm/util_rules/yaml_utils.py
@@ -1,6 +1,8 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 from typing import Any, Mapping
 
 

--- a/src/python/pants/backend/helm/util_rules/yaml_utils.py
+++ b/src/python/pants/backend/helm/util_rules/yaml_utils.py
@@ -1,0 +1,25 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from typing import Any
+
+
+def _as_python_attribute_name(str: str) -> str:
+    base_string = str.replace("-", "_")
+
+    result = ""
+    idx = 0
+    for c in base_string:
+        char_to_add = c
+        if char_to_add.isupper():
+            char_to_add = c.lower()
+            if idx > 0:
+                result += "_"
+        result += char_to_add
+        idx += 1
+
+    return result
+
+
+def yaml_attr_dict(d: dict[str, Any]) -> dict[str, Any]:
+    return {_as_python_attribute_name(name): value for name, value in d.items()}

--- a/src/python/pants/backend/helm/util_rules/yaml_utils.py
+++ b/src/python/pants/backend/helm/util_rules/yaml_utils.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 from typing import Any, Mapping
 
 
-def _as_python_attribute_name(str: str) -> str:
+def _to_snake_case(str: str) -> str:
+    """Translates an camel-case or kebab-case identifier by a snake-case one."""
     base_string = str.replace("-", "_")
 
     result = ""
@@ -23,5 +24,6 @@ def _as_python_attribute_name(str: str) -> str:
     return result
 
 
-def yaml_attr_dict(d: Mapping[str, Any]) -> dict[str, Any]:
-    return {_as_python_attribute_name(name): value for name, value in d.items()}
+def snake_case_attr_dict(d: Mapping[str, Any]) -> dict[str, Any]:
+    """Transforms all keys in the given mapping to be snake-case."""
+    return {_to_snake_case(name): value for name, value in d.items()}

--- a/src/python/pants/backend/helm/util_rules/yaml_utils.py
+++ b/src/python/pants/backend/helm/util_rules/yaml_utils.py
@@ -1,7 +1,7 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Any
+from typing import Any, Mapping
 
 
 def _as_python_attribute_name(str: str) -> str:
@@ -21,5 +21,5 @@ def _as_python_attribute_name(str: str) -> str:
     return result
 
 
-def yaml_attr_dict(d: dict[str, Any]) -> dict[str, Any]:
+def yaml_attr_dict(d: Mapping[str, Any]) -> dict[str, Any]:
     return {_as_python_attribute_name(name): value for name, value in d.items()}


### PR DESCRIPTION
Implements the `test` goal for Helm charts based on the Helm plugin `unittest` adding two new targets: `helm_unittest_test` and `helm_unittest_tests`. This also means that there is a need to add support for global Helm plugins.

The Helm plugin API has been implemented such that at some point in the feature we can also support first party Helm plugins although that may still require some refactorings.

**This code does not type check at the moment!** This is due some design decisions that could be down to me not fully understanding Pant's API, so happy to receive any feedback on the following:
- A `helm_unittest_test` target needs to have a dependency on a `helm_chart` target.
- This dependency has been implemented in a field that extends `SpecialCasedDependencies` (ideally it should be a `SingleSpecialCasedDependency` kind of field, as there can only be one). This could be a bit niche, although a field of this kind could also be useful for a future implementation of the `helm_deployment` target, as that will need a single dependency on a chart too.
- To not make users having to configure it manually, this dependency is inferred and injected into the given field. This is the source of a few typecheck errors as the `inject_for` field in `InjectDependenciesRequest` only accepts descendants of `Dependencies` field, not `SpecialCasedDependencies`.
- The rule that actuall implements the `test` goal, obtains the chart dependency using a `DependenciesRequest` (we are only interested in direct dependencies). This results in another typecheck error because the `DependenciesRequest` class only accepts descendants of `Dependencies`.

The above breakdown's purpose is just meant as _food for thought_. The easiest way of this is to give up on the usage of the special cased field, and use a _normal_ `Dependencies` field. As everything would work just fine with that, the only caveat is that in the implementation of the `test` goal, instead of the following:

```python
chart_deps_targets, transitive_targets = await MultiGet(
    Get(Targets, DependenciesRequest(field_set.chart, include_special_cased_deps=True)),
    Get(
        TransitiveTargets,
        TransitiveTargetsRequest([field_set.address], include_special_cased_deps=False),
    ),
)
```

It would be replaced by:

```python
direct_deps_targets, transitive_targets = await MultiGet(
    Get(Targets, DependenciesRequest(field_set.dependencies)),
    Get(
        TransitiveTargets,
        TransitiveTargetsRequest([field_set.address]),
    ),
)

chart_deps_targets = [tgt for tgt in direct_deps_targets if HelmChartFieldSet.is_applicable(tgt)]
```