### PR TITLE
Merge list values across config files.

### DIFF
--- a/src/python/pants/option/config.py
+++ b/src/python/pants/option/config.py
@@ -128,17 +128,18 @@ class Config:
 
         return all_seed_values
 
-    def get(self, section, option) -> str | None:
-        """Retrieves option from the specified section (or 'DEFAULT').
+    def get(self, section, option) -> list[str]:
+        """Retrieves the option value from the specified section (or 'DEFAULT').
 
         If the specified section does not exist or is missing a definition for the option, the value
         is looked up in the DEFAULT section.  If there is still no definition found, returns None.
         """
-        for vals in reversed(self.values):
+        available_vals = []
+        for vals in self.values:
             val = vals.get_value(section, option)
             if val is not None:
-                return val
-        return None
+                available_vals.append(val)
+        return available_vals
 
     def sources(self) -> list[str]:
         """Returns the sources of this config as a list of filenames."""

--- a/src/python/pants/option/config.py
+++ b/src/python/pants/option/config.py
@@ -129,11 +129,7 @@ class Config:
         return all_seed_values
 
     def get(self, section, option) -> list[str]:
-        """Retrieves the option value from the specified section (or 'DEFAULT').
-
-        If the specified section does not exist or is missing a definition for the option, the value
-        is looked up in the DEFAULT section.  If there is still no definition found, returns None.
-        """
+        """Retrieves an option value from each config file in which it appears."""
         available_vals = []
         for vals in self.values:
             val = vals.get_value(section, option)

--- a/src/python/pants/option/custom_types_test.py
+++ b/src/python/pants/option/custom_types_test.py
@@ -65,10 +65,12 @@ def test_flatten_shlexed_list() -> None:
 
 
 class TestCustomTypes:
-    def assert_list_parsed(self, s: str, *, expected: ParsedList) -> None:
+    @staticmethod
+    def assert_list_parsed(s: str, *, expected: ParsedList) -> None:
         assert expected == ListValueComponent.create(s).val
 
-    def assert_split_list(self, s: str, *, expected: List[str]) -> None:
+    @staticmethod
+    def assert_split_list(s: str, *, expected: List[str]) -> None:
         assert expected == ListValueComponent._split_modifier_expr(s)
 
     def test_unset_bool(self):
@@ -149,7 +151,6 @@ class TestCustomTypes:
         self.assert_split_list("+1,2],-[3,4", expected=["+1,2]", "-[3,4"])
         self.assert_split_list("+(1,2],-[3,4)", expected=["+(1,2]", "-[3,4)"])
 
-    #
     @pytest.mark.xfail(
         reason="The heuristic list modifier expression splitter cannot handle certain very unlikely cases."
     )

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -168,9 +168,10 @@ class OptionsBootstrapper:
             # were any from aliases.
             # stuhood: This could potentially break the rust client when aliases are used:
             # https://github.com/pantsbuild/pants/pull/13228#discussion_r728223889
+            alias_vals = post_bootstrap_config.get("cli", "alias")
             alias_dict = parse_expression(
                 name="cli.alias",
-                val=post_bootstrap_config.get("cli", "alias") or "{}",
+                val=alias_vals[-1] if alias_vals else "{}",
                 acceptable_types=dict,
             )
             alias = CliAlias.from_dict(alias_dict)

--- a/src/python/pants/option/options_test.py
+++ b/src/python/pants/option/options_test.py
@@ -509,8 +509,16 @@ def test_scope_deprecation_default_config_section(caplog) -> None:
 
 class OptionsTest(unittest.TestCase):
     @staticmethod
-    def _create_config(config: dict[str, dict[str, str]] | None = None) -> Config:
-        return Config.load([FileContent("test_config.toml", toml.dumps(config or {}).encode())])
+    def _create_config(
+        config: dict[str, dict[str, str]] | None = None,
+        config2: dict[str, dict[str, str]] | None = None,
+    ) -> Config:
+        return Config.load(
+            [
+                FileContent("test_config.toml", toml.dumps(config or {}).encode()),
+                FileContent("test_config2.toml", toml.dumps(config2 or {}).encode()),
+            ]
+        )
 
     def _parse(
         self,
@@ -518,12 +526,13 @@ class OptionsTest(unittest.TestCase):
         flags: str = "",
         env: dict[str, str] | None = None,
         config: dict[str, dict[str, Any]] | None = None,
+        config2: dict[str, dict[str, Any]] | None = None,
         bootstrap_option_values=None,
     ) -> Options:
         args = ["./pants", *shlex.split(flags)]
         options = Options.create(
             env=env or {},
-            config=self._create_config(config),
+            config=self._create_config(config, config2),
             known_scope_infos=OptionsTest._known_scope_infos,
             args=args,
             bootstrap_option_values=bootstrap_option_values,
@@ -771,10 +780,14 @@ class OptionsTest(unittest.TestCase):
             flags: str = "",
             env_val: str | None = None,
             config_val: str | None = None,
+            config2_val: str | None = None,
         ) -> None:
             env = {"PANTS_GLOBAL_LISTY": env_val} if env_val else None
             config = {"GLOBAL": {"listy": config_val}} if config_val else None
-            global_options = self._parse(flags=flags, env=env, config=config).for_global_scope()
+            config2 = {"GLOBAL": {"listy": config2_val}} if config2_val else None
+            global_options = self._parse(
+                flags=flags, env=env, config=config, config2=config2
+            ).for_global_scope()
             assert global_options.listy == expected
 
         default = [1, 2, 3]
@@ -795,8 +808,12 @@ class OptionsTest(unittest.TestCase):
         check(
             flags="--listy=+[8,9]",
             env_val="+[6,7]",
-            config_val="+[4,5]",
-            expected=[*default, 4, 5, 6, 7, 8, 9],
+            config_val="+[4,5],+[45]",
+            expected=[*default, 4, 5, 45, 6, 7, 8, 9],
+        )
+        check(
+            config_val="+[4,5],-[4]",
+            expected=[*default, 5],
         )
 
         # Appending and filtering across env, config and flags (in the right order).
@@ -804,7 +821,8 @@ class OptionsTest(unittest.TestCase):
             flags="--listy=-[1,5,6]",
             env_val="+[6,7]",
             config_val="+[4,5]",
-            expected=[2, 3, 4, 7],
+            config2_val="+[99]",
+            expected=[2, 3, 4, 99, 7],
         )
         check(
             flags="--listy=+[8,9]",
@@ -812,6 +830,17 @@ class OptionsTest(unittest.TestCase):
             config_val="+[4,5],-[3]",
             expected=[1, 2, 8, 9],
         )
+        # Appending a value from a fromfile.
+        with temporary_file(binary_mode=False) as fp:
+            fp.write("-[3]")
+            fp.close()
+            check(
+                flags="--listy=+[8,9]",
+                env_val="-[4,5]",
+                config_val="+[4,5]",
+                config2_val=f"@{fp.name}",
+                expected=[1, 2, 8, 9],
+            )
 
         # Overwriting from env, then appending and filtering.
         check(
@@ -826,7 +855,8 @@ class OptionsTest(unittest.TestCase):
             flags="--listy=+[8,9]",
             env_val="+[6,7]",
             config_val="[4,5]",
-            expected=[4, 5, 6, 7, 8, 9],
+            config2_val="-[4]",
+            expected=[5, 6, 7, 8, 9],
         )
 
         # Overwriting from flags.
@@ -971,9 +1001,13 @@ class OptionsTest(unittest.TestCase):
             expected: dict[str, str],
             flags: str = "",
             config_val: str | None = None,
+            config2_val: str | None = None,
         ) -> None:
             config = {"GLOBAL": {"dicty": config_val}} if config_val else None
-            global_options = self._parse(flags=flags, config=config).for_global_scope()
+            config2 = {"GLOBAL": {"dicty": config2_val}} if config2_val else None
+            global_options = self._parse(
+                flags=flags, config=config, config2=config2
+            ).for_global_scope()
             assert global_options.dicty == expected
 
         default = {"a": "b"}
@@ -987,6 +1021,12 @@ class OptionsTest(unittest.TestCase):
 
         check(config_val='{"c": "d"}', expected=specified_args)
         check(config_val='+{"c": "d"}', expected=all_args)
+        check(
+            config_val='+{"c": "d"}',
+            config2_val='+{"e": "f"}',
+            flags='--dicty=\'+{"g": "h"}\'',
+            expected={**all_args, "e": "f", "g": "h"},
+        )
         check(
             config_val='+{"c": "d"}',
             flags='--dicty=\'+{"e": "f"}\'',

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -631,19 +631,13 @@ class Parser:
         flag_details = None if flag_val is None else "from command-line flag"
 
         # Rank all available values.
-        # Note that some of these values may already be of the value type, but type conversion
-        # is idempotent, so this is OK.
-
         values_to_rank = [
-            (to_value_type(x), detail)
-            for (x, detail) in [
-                (flag_val, flag_details),
-                (env_val, env_details),
-                (config_val, config_details),
-                (config_default_val, config_details),
-                (kwargs.get("default"), None),
-                (None, None),
-            ]
+            (flag_val, flag_details),
+            (env_val, env_details),
+            (config_val, config_details),
+            (config_default_val, config_details),
+            (to_value_type(kwargs.get("default")), None),
+            (None, None),
         ]
         # Note that ranked_vals will always have at least one element, and all elements will be
         # instances of RankedValue (so none will be None, although they may wrap a None value).

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -581,28 +581,40 @@ class Parser:
             else:
                 return val_or_str
 
+        # Helper function to merge multiple values from a single rank (e.g., multiple flags,
+        # or multiple config files).
+        def merge_in_rank(vals):
+            if not vals:
+                return None
+            expanded_vals = [to_value_type(expand(x)) for x in vals]
+            if is_list_option(kwargs):
+                return ListValueComponent.merge(expanded_vals)
+            if is_dict_option(kwargs):
+                return DictValueComponent.merge(expanded_vals)
+            return expanded_vals[-1]  # Last value wins.
+
         # Get value from config files, and capture details about its derivation.
         config_details = None
         config_section = GLOBAL_SCOPE_CONFIG_SECTION if self._scope == GLOBAL_SCOPE else self._scope
-        config_default_val_or_str = expand(self._config.get(DEFAULT_SECTION, dest))
-        config_val_or_str = expand(self._config.get(config_section, dest))
+        config_default_val = merge_in_rank(self._config.get(DEFAULT_SECTION, dest))
+        config_val = merge_in_rank(self._config.get(config_section, dest))
         config_source_files = self._config.get_sources_for_option(config_section, dest)
         if config_source_files:
             config_details = f"from {', '.join(config_source_files)}"
 
         # Get value from environment, and capture details about its derivation.
         env_vars = self.get_env_var_names(self._scope, dest)
-        env_val_or_str = None
+        env_val = None
         env_details = None
         if self._env:
             for env_var in env_vars:
                 if env_var in self._env:
-                    env_val_or_str = expand(self._env.get(env_var))
+                    env_val = merge_in_rank([self._env.get(env_var)])
                     env_details = f"from env var {env_var}"
                     break
 
         # Get value from cmd-line flags.
-        flag_vals = [to_value_type(expand(x)) for x in flag_val_strs]
+        flag_vals = list(flag_val_strs)
         if kwargs.get("passthrough"):
             # NB: Passthrough arguments are either of type `str` or `shell_str`
             # (see self._validate): the former never need interpretation, and the latter do not
@@ -611,23 +623,11 @@ class Parser:
             flag_vals.append(
                 ListValueComponent(ListValueComponent.MODIFY, [*passthru_arg_strs], [])
             )
-
-        if is_list_option(kwargs):
-            # Note: It's important to set flag_val to None if no flags were specified, so we can
-            # distinguish between no flags set vs. explicit setting of the value to [].
-            flag_val = ListValueComponent.merge(flag_vals) if flag_vals else None
-        elif is_dict_option(kwargs):
-            # Note: It's important to set flag_val to None if no flags were specified, so we can
-            # distinguish between no flags set vs. explicit setting of the value to {}.
-            flag_val = DictValueComponent.merge(flag_vals) if flag_vals else None
-        elif len(flag_vals) > 1:
+        if len(flag_vals) > 1 and not (is_list_option(kwargs) or is_dict_option(kwargs)):
             raise ParseError(
                 f"Multiple cmd line flags specified for option {dest} in {self._scope_str()}"
             )
-        elif len(flag_vals) == 1:
-            flag_val = flag_vals[0]
-        else:
-            flag_val = None
+        flag_val = merge_in_rank(flag_vals)
         flag_details = None if flag_val is None else "from command-line flag"
 
         # Rank all available values.
@@ -638,9 +638,9 @@ class Parser:
             (to_value_type(x), detail)
             for (x, detail) in [
                 (flag_val, flag_details),
-                (env_val_or_str, env_details),
-                (config_val_or_str, config_details),
-                (config_default_val_or_str, config_details),
+                (env_val, env_details),
+                (config_val, config_details),
+                (config_default_val, config_details),
                 (kwargs.get("default"), None),
                 (None, None),
             ]


### PR DESCRIPTION
Previously we treated them like scalars, so they could only overwrite previous values.

Fixes #14679


[ci skip-rust]

[ci skip-build-wheels]