### PR TITLE
Remove redundancy in how we apply DEFAULTs in config.

### DIFF
--- a/src/python/pants/option/config.py
+++ b/src/python/pants/option/config.py
@@ -262,6 +262,8 @@ class _ConfigValues:
         section_values = self.section_to_values.get(section)
         if section_values is None:
             return None
+        if option not in section_values:
+            return None
 
         stringify = partial(
             self._stringify_val,
@@ -269,11 +271,6 @@ class _ConfigValues:
             section=section,
             section_values=section_values,
         )
-
-        if option not in section_values:
-            if option in self.defaults:
-                return stringify(raw_value=self.defaults[option])
-            return None
 
         option_value = section_values[option]
         if not isinstance(option_value, dict):

--- a/src/python/pants/option/config_test.py
+++ b/src/python/pants/option/config_test.py
@@ -145,16 +145,10 @@ class ConfigTest(unittest.TestCase):
         # Check the DEFAULT section
         for option, value in {**self.default_seed_values, **FILE_1.default_values}.items():
             assert self.config.get(section="DEFAULT", option=option) == value
-        # Check the combined values, including that each section has the default seed values
+        # Check the combined values.
         for section, section_values in self.expected_combined_values.items():
-            for option, value in {**section_values, **self.default_seed_values}.items():
+            for option, value in section_values.items():
                 assert self.config.get(section=section, option=option) == value
-        # Check that each section from file1 also has file1's default values, unless that section
-        # explicitly overrides the default
-        for section, section_values in FILE_1.expected_options.items():
-            for option, default_value in FILE_1.default_values.items():
-                expected = default_value if option not in section_values else section_values[option]
-                assert self.config.get(section=section, option=option) == expected
 
     def test_empty(self) -> None:
         config = Config.load([])

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -586,9 +586,7 @@ class Parser:
         config_section = GLOBAL_SCOPE_CONFIG_SECTION if self._scope == GLOBAL_SCOPE else self._scope
         config_default_val_or_str = expand(self._config.get(DEFAULT_SECTION, dest))
         config_val_or_str = expand(self._config.get(config_section, dest))
-        config_source_files = self._config.get_sources_for_option(
-            config_section, dest
-        ) or self._config.get_sources_for_option(DEFAULT_SECTION, dest)
+        config_source_files = self._config.get_sources_for_option(config_section, dest)
         if config_source_files:
             config_details = f"from {', '.join(config_source_files)}"
 


### PR DESCRIPTION
Previously we redundantly did so 3 times - once during
config parsing, and twice during options parsing.
Presumably this was a legacy of the repeated patchworking
of this venerable part of the codebase.

This change removes the expansion of defaults into every
config section, which is unnecessary for returning defaults
and also unnecessary for interpolation.

It also removes one of the places in which we substituted
the default for missing config values during options parsing.

It leaves just the one required application, where the DEFAULT
values are one of the RankedValues used to select the final
option value.

[ci skip-rust]

[ci skip-build-wheels]