### PR TITLE
[internal] Use static workunit names, and lazily construct metadata based on the level

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -3998,6 +3998,7 @@ dependencies = [
  "deepsize",
  "hashing",
  "hdrhistogram",
+ "internment",
  "log",
  "parking_lot 0.12.0",
  "petgraph 0.5.1",

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -793,7 +793,7 @@ impl Store {
       None => {
         log::debug!("Missing file digest from remote store: {:?}", file_digest);
         in_workunit!(
-          "missing_file_counter".to_owned(),
+          "missing_file_counter",
           WorkunitMetadata {
             level: Level::Trace,
             ..WorkunitMetadata::default()

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -64,7 +64,7 @@ use remexec::{ServerCapabilities, Tree};
 use serde_derive::Serialize;
 use sharded_lmdb::DEFAULT_LEASE_TIME;
 use tryfuture::try_future;
-use workunit_store::{in_workunit, Level, Metric, WorkunitMetadata};
+use workunit_store::{in_workunit, Level, Metric};
 
 use crate::remote::ByteStoreError;
 
@@ -794,10 +794,7 @@ impl Store {
         log::debug!("Missing file digest from remote store: {:?}", file_digest);
         in_workunit!(
           "missing_file_counter",
-          WorkunitMetadata {
-            level: Level::Trace,
-            ..WorkunitMetadata::default()
-          },
+          Level::Trace,
           |workunit| async move {
             workunit.increment_counter(Metric::RemoteStoreMissingDigest, 1);
           },

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -64,7 +64,7 @@ use remexec::{ServerCapabilities, Tree};
 use serde_derive::Serialize;
 use sharded_lmdb::DEFAULT_LEASE_TIME;
 use tryfuture::try_future;
-use workunit_store::{get_workunit_store_handle, in_workunit, Level, Metric, WorkunitMetadata};
+use workunit_store::{in_workunit, Level, Metric, WorkunitMetadata};
 
 use crate::remote::ByteStoreError;
 
@@ -792,20 +792,17 @@ impl Store {
       Some(_) => Ok(()),
       None => {
         log::debug!("Missing file digest from remote store: {:?}", file_digest);
-        if let Some(workunit_store_handle) = get_workunit_store_handle() {
-          in_workunit!(
-            workunit_store_handle.store,
-            "missing_file_counter".to_owned(),
-            WorkunitMetadata {
-              level: Level::Trace,
-              ..WorkunitMetadata::default()
-            },
-            |workunit| async move {
-              workunit.increment_counter(Metric::RemoteStoreMissingDigest, 1);
-            },
-          )
-          .await;
-        }
+        in_workunit!(
+          "missing_file_counter".to_owned(),
+          WorkunitMetadata {
+            level: Level::Trace,
+            ..WorkunitMetadata::default()
+          },
+          |workunit| async move {
+            workunit.increment_counter(Metric::RemoteStoreMissingDigest, 1);
+          },
+        )
+        .await;
         Err("File did not exist in the remote store.".to_owned())
       }
     }

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -6,6 +6,7 @@ use grpc_util::tls;
 use hashing::Digest;
 use mock::StubCAS;
 use testutil::data::{TestData, TestDirectory};
+use workunit_store::WorkunitStore;
 
 use crate::remote::ByteStore;
 use crate::tests::{big_file_bytes, big_file_fingerprint, new_cas};
@@ -26,6 +27,7 @@ async fn loads_file() {
 
 #[tokio::test]
 async fn missing_file() {
+  let _ = WorkunitStore::setup_for_tests();
   let cas = StubCAS::empty();
 
   assert_eq!(
@@ -47,6 +49,7 @@ async fn load_directory() {
 
 #[tokio::test]
 async fn missing_directory() {
+  let _ = WorkunitStore::setup_for_tests();
   let cas = StubCAS::empty();
 
   assert_eq!(
@@ -61,6 +64,7 @@ async fn missing_directory() {
 
 #[tokio::test]
 async fn load_file_grpc_error() {
+  let _ = WorkunitStore::setup_for_tests();
   let cas = StubCAS::always_errors();
 
   let error = load_file_bytes(&new_byte_store(&cas), TestData::roland().digest())
@@ -75,6 +79,7 @@ async fn load_file_grpc_error() {
 
 #[tokio::test]
 async fn load_directory_grpc_error() {
+  let _ = WorkunitStore::setup_for_tests();
   let cas = StubCAS::always_errors();
 
   let error = load_directory_proto_bytes(
@@ -148,6 +153,7 @@ async fn write_file_one_chunk() {
 
 #[tokio::test]
 async fn write_file_multiple_chunks() {
+  let _ = WorkunitStore::setup_for_tests();
   let cas = StubCAS::empty();
 
   let store = ByteStore::new(
@@ -263,6 +269,7 @@ async fn list_missing_digests_none_missing() {
 
 #[tokio::test]
 async fn list_missing_digests_some_missing() {
+  let _ = WorkunitStore::setup_for_tests();
   let cas = StubCAS::empty();
 
   let store = new_byte_store(&cas);
@@ -282,6 +289,7 @@ async fn list_missing_digests_some_missing() {
 
 #[tokio::test]
 async fn list_missing_digests_error() {
+  let _ = WorkunitStore::setup_for_tests();
   let cas = StubCAS::always_errors();
 
   let store = new_byte_store(&cas);

--- a/src/rust/engine/process_execution/src/bounded.rs
+++ b/src/rust/engine/process_execution/src/bounded.rs
@@ -63,7 +63,7 @@ impl crate::CommandRunner for CommandRunner {
   ) -> Result<FallibleProcessResultWithPlatform, String> {
     let semaphore_acquisition = self.sema.acquire(process.concurrency_available);
     let permit = in_workunit!(
-      "acquire_command_runner_slot".to_owned(),
+      "acquire_command_runner_slot",
       WorkunitMetadata {
         // TODO: The UI uses the presence of a blocked workunit below a parent as an indication that
         // the parent is blocked. If this workunit is filtered out, parents nodes which are waiting

--- a/src/rust/engine/process_execution/src/bounded.rs
+++ b/src/rust/engine/process_execution/src/bounded.rs
@@ -13,7 +13,7 @@ use regex::Regex;
 use task_executor::Executor;
 use tokio::sync::{Notify, Semaphore, SemaphorePermit};
 use tokio::time::sleep;
-use workunit_store::{in_workunit, RunningWorkunit, WorkunitMetadata};
+use workunit_store::{in_workunit, RunningWorkunit};
 
 use crate::{Context, FallibleProcessResultWithPlatform, Process};
 
@@ -64,17 +64,14 @@ impl crate::CommandRunner for CommandRunner {
     let semaphore_acquisition = self.sema.acquire(process.concurrency_available);
     let permit = in_workunit!(
       "acquire_command_runner_slot",
-      WorkunitMetadata {
-        // TODO: The UI uses the presence of a blocked workunit below a parent as an indication that
-        // the parent is blocked. If this workunit is filtered out, parents nodes which are waiting
-        // for the semaphore will render, even though they are effectively idle.
-        //
-        // https://github.com/pantsbuild/pants/issues/14680 will likely allow for a more principled
-        // solution to this problem, such as removing the mutable `blocking` flag, and then never
-        // filtering blocked workunits at creation time, regardless of level.
-        level: Level::Debug,
-        ..WorkunitMetadata::default()
-      },
+      // TODO: The UI uses the presence of a blocked workunit below a parent as an indication that
+      // the parent is blocked. If this workunit is filtered out, parents nodes which are waiting
+      // for the semaphore will render, even though they are effectively idle.
+      //
+      // https://github.com/pantsbuild/pants/issues/14680 will likely allow for a more principled
+      // solution to this problem, such as removing the mutable `blocking` flag, and then never
+      // filtering blocked workunits at creation time, regardless of level.
+      Level::Debug,
       |workunit| async move {
         let _blocking_token = workunit.blocking();
         semaphore_acquisition.await

--- a/src/rust/engine/process_execution/src/bounded.rs
+++ b/src/rust/engine/process_execution/src/bounded.rs
@@ -63,7 +63,6 @@ impl crate::CommandRunner for CommandRunner {
   ) -> Result<FallibleProcessResultWithPlatform, String> {
     let semaphore_acquisition = self.sema.acquire(process.concurrency_available);
     let permit = in_workunit!(
-      context.workunit_store.clone(),
       "acquire_command_runner_slot".to_owned(),
       WorkunitMetadata {
         // TODO: The UI uses the presence of a blocked workunit below a parent as an indication that

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -69,7 +69,7 @@ impl crate::CommandRunner for CommandRunner {
     let context2 = context.clone();
     let key2 = key.clone();
     let cache_read_result = in_workunit!(
-      "local_cache_read".to_owned(),
+      "local_cache_read",
       WorkunitMetadata {
         level: Level::Trace,
         desc: Some(format!("Local cache lookup: {}", req.description)),
@@ -126,7 +126,7 @@ impl crate::CommandRunner for CommandRunner {
     if result.exit_code == 0 || write_failures_to_cache {
       let result = result.clone();
       in_workunit!(
-        "local_cache_write".to_owned(),
+        "local_cache_write",
         WorkunitMetadata {
           level: Level::Trace,
           ..WorkunitMetadata::default()

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -69,7 +69,6 @@ impl crate::CommandRunner for CommandRunner {
     let context2 = context.clone();
     let key2 = key.clone();
     let cache_read_result = in_workunit!(
-      context.workunit_store.clone(),
       "local_cache_read".to_owned(),
       WorkunitMetadata {
         level: Level::Trace,
@@ -127,7 +126,6 @@ impl crate::CommandRunner for CommandRunner {
     if result.exit_code == 0 || write_failures_to_cache {
       let result = result.clone();
       in_workunit!(
-        context.workunit_store.clone(),
         "local_cache_write".to_owned(),
         WorkunitMetadata {
           level: Level::Trace,

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -255,7 +255,7 @@ impl super::CommandRunner for CommandRunner {
   ) -> Result<FallibleProcessResultWithPlatform, String> {
     let req_debug_repr = format!("{:#?}", req);
     in_workunit!(
-      "run_local_process".to_owned(),
+      "run_local_process",
       WorkunitMetadata {
         // NB: See engine::nodes::NodeKey::workunit_level for more information on why this workunit
         // renders at the Process's level.
@@ -648,7 +648,7 @@ pub async fn prepare_workdir(
   let store2 = store.clone();
   let workdir_path_2 = workdir_path.clone();
   in_workunit!(
-    "setup_sandbox".to_owned(),
+    "setup_sandbox",
     WorkunitMetadata {
       level: Level::Debug,
       ..WorkunitMetadata::default()

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -255,7 +255,6 @@ impl super::CommandRunner for CommandRunner {
   ) -> Result<FallibleProcessResultWithPlatform, String> {
     let req_debug_repr = format!("{:#?}", req);
     in_workunit!(
-      context.workunit_store.clone(),
       "run_local_process".to_owned(),
       WorkunitMetadata {
         // NB: See engine::nodes::NodeKey::workunit_level for more information on why this workunit
@@ -297,7 +296,6 @@ impl super::CommandRunner for CommandRunner {
           workdir_path.clone(),
           &req,
           req.input_digests.input_files.clone(),
-          context.clone(),
           self.store.clone(),
           self.executor.clone(),
           &self.named_caches,
@@ -617,7 +615,6 @@ pub async fn prepare_workdir(
   workdir_path: PathBuf,
   req: &Process,
   materialized_input_digest: DirectoryDigest,
-  context: Context,
   store: Store,
   executor: task_executor::Executor,
   named_caches: &NamedCaches,
@@ -651,7 +648,6 @@ pub async fn prepare_workdir(
   let store2 = store.clone();
   let workdir_path_2 = workdir_path.clone();
   in_workunit!(
-    context.workunit_store.clone(),
     "setup_sandbox".to_owned(),
     WorkunitMetadata {
       level: Level::Debug,

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -690,7 +690,6 @@ async fn prepare_workdir_exclusive_relative() {
     work_dir.path().to_owned(),
     &process,
     TestDirectory::recursive().directory_digest(),
-    Context::default(),
     store,
     executor,
     &named_caches,

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -10,7 +10,7 @@ use nails::execution::{self, child_channel, ChildInput, Command};
 use store::Store;
 use task_executor::Executor;
 use tokio::net::TcpStream;
-use workunit_store::{in_workunit, Metric, RunningWorkunit, WorkunitMetadata};
+use workunit_store::{in_workunit, Metric, RunningWorkunit};
 
 use crate::local::{prepare_workdir, CapturedWorkdir, ChildOutput};
 use crate::{Context, FallibleProcessResultWithPlatform, InputDigests, Platform, Process};
@@ -123,13 +123,10 @@ impl super::CommandRunner for CommandRunner {
 
     in_workunit!(
       "run_nailgun_process",
-      WorkunitMetadata {
-        // NB: See engine::nodes::NodeKey::workunit_level for more information on why this workunit
-        // renders at the Process's level.
-        level: req.level,
-        desc: Some(req.description.clone()),
-        ..WorkunitMetadata::default()
-      },
+      // NB: See engine::nodes::NodeKey::workunit_level for more information on why this workunit
+      // renders at the Process's level.
+      req.level,
+      desc = Some(req.description.clone()),
       |workunit| async move {
         workunit.increment_counter(Metric::LocalExecutionRequests, 1);
 

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -122,7 +122,6 @@ impl super::CommandRunner for CommandRunner {
     debug!("Running request under nailgun:\n {:?}", req);
 
     in_workunit!(
-      context.workunit_store.clone(),
       "run_nailgun_process".to_owned(),
       WorkunitMetadata {
         // NB: See engine::nodes::NodeKey::workunit_level for more information on why this workunit
@@ -161,7 +160,6 @@ impl super::CommandRunner for CommandRunner {
           .nailgun_pool
           .acquire(
             server_req,
-            context.clone(),
             self.inner.named_caches(),
             self.inner.immutable_inputs(),
           )
@@ -173,7 +171,6 @@ impl super::CommandRunner for CommandRunner {
           nailgun_process.workdir_path().to_owned(),
           &client_req,
           client_req.input_digests.input_files.clone(),
-          context.clone(),
           self.inner.store.clone(),
           self.executor.clone(),
           self.inner.named_caches(),

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -122,7 +122,7 @@ impl super::CommandRunner for CommandRunner {
     debug!("Running request under nailgun:\n {:?}", req);
 
     in_workunit!(
-      "run_nailgun_process".to_owned(),
+      "run_nailgun_process",
       WorkunitMetadata {
         // NB: See engine::nodes::NodeKey::workunit_level for more information on why this workunit
         // renders at the Process's level.

--- a/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
@@ -22,7 +22,7 @@ use task_executor::Executor;
 use tempfile::TempDir;
 
 use crate::local::prepare_workdir;
-use crate::{Context, ImmutableInputs, NamedCaches, Process, ProcessMetadata};
+use crate::{ImmutableInputs, NamedCaches, Process, ProcessMetadata};
 
 lazy_static! {
   static ref NAILGUN_PORT_REGEX: Regex = Regex::new(r".*\s+port\s+(\d+)\.$").unwrap();
@@ -86,7 +86,6 @@ impl NailgunPool {
   pub async fn acquire(
     &self,
     server_process: Process,
-    context: Context,
     named_caches: &NamedCaches,
     immutable_inputs: &ImmutableInputs,
   ) -> Result<BorrowedNailgunProcess, String> {
@@ -129,7 +128,6 @@ impl NailgunPool {
         name.clone(),
         server_process,
         &self.workdir_base,
-        context,
         &self.store,
         self.executor.clone(),
         named_caches,
@@ -337,7 +335,6 @@ impl NailgunProcess {
     name: String,
     startup_options: Process,
     workdir_base: &Path,
-    context: Context,
     store: &Store,
     executor: Executor,
     named_caches: &NamedCaches,
@@ -357,7 +354,6 @@ impl NailgunProcess {
       workdir.path().to_owned(),
       &startup_options,
       startup_options.input_digests.input_files.clone(),
-      context.clone(),
       store.clone(),
       executor.clone(),
       named_caches,

--- a/src/rust/engine/process_execution/src/nailgun/tests.rs
+++ b/src/rust/engine/process_execution/src/nailgun/tests.rs
@@ -7,7 +7,7 @@ use testutil::owned_string_vec;
 use workunit_store::WorkunitStore;
 
 use crate::nailgun::NailgunPool;
-use crate::{Context, ImmutableInputs, NamedCaches, Process};
+use crate::{ImmutableInputs, NamedCaches, Process};
 
 fn pool(size: usize) -> (NailgunPool, NamedCaches, ImmutableInputs) {
   let _ = WorkunitStore::setup_for_tests();
@@ -34,7 +34,6 @@ async fn run(pool: &(NailgunPool, NamedCaches, ImmutableInputs), port: u16) -> P
         "-c",
         &format!("echo Mock port {}.; sleep 10", port),
       ])),
-      Context::default(),
       &pool.1,
       &pool.2,
     )

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -798,7 +798,7 @@ impl crate::CommandRunner for CommandRunner {
     // Submit the execution request to the RE server for execution.
     let context2 = context.clone();
     in_workunit!(
-      "run_execute_request".to_owned(),
+      "run_execute_request",
       WorkunitMetadata {
         // NB: See engine::nodes::NodeKey::workunit_level for more information on why this workunit
         // renders at the Process's level.
@@ -852,7 +852,7 @@ impl crate::CommandRunner for CommandRunner {
 
 fn maybe_add_workunit(
   result_cached: bool,
-  name: &str,
+  name: &'static str,
   time_span: concrete_time::TimeSpan,
   parent_id: Option<SpanId>,
   workunit_store: &WorkunitStore,
@@ -861,13 +861,7 @@ fn maybe_add_workunit(
   if !result_cached {
     let start_time: SystemTime = SystemTime::UNIX_EPOCH + time_span.start.into();
     let end_time: SystemTime = start_time + time_span.duration.into();
-    workunit_store.add_completed_workunit(
-      name.to_string(),
-      start_time,
-      end_time,
-      parent_id,
-      metadata,
-    );
+    workunit_store.add_completed_workunit(name, start_time, end_time, parent_id, metadata);
   }
 }
 
@@ -1336,7 +1330,7 @@ pub async fn check_action_cache(
   timeout_duration: Duration,
 ) -> Result<Option<FallibleProcessResultWithPlatform>, String> {
   in_workunit!(
-    "check_action_cache".to_owned(),
+    "check_action_cache",
     WorkunitMetadata {
       level: Level::Debug,
       desc: Some(format!("Remote cache lookup for: {}", command_description)),
@@ -1388,7 +1382,7 @@ pub async fn check_action_cache(
           if eager_fetch {
             let response = response.clone();
             in_workunit!(
-              "eager_fetch_action_cache".to_owned(),
+              "eager_fetch_action_cache",
               WorkunitMetadata {
                 level: Level::Trace,
                 desc: Some("eagerly fetching after action cache hit".to_owned()),
@@ -1461,7 +1455,7 @@ pub async fn ensure_action_uploaded(
   input_files: Option<DirectoryDigest>,
 ) -> Result<(), String> {
   in_workunit!(
-    "ensure_action_uploaded".to_owned(),
+    "ensure_action_uploaded",
     WorkunitMetadata {
       level: Level::Trace,
       desc: Some(format!("ensure action uploaded for {:?}", action_digest)),

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -799,13 +799,10 @@ impl crate::CommandRunner for CommandRunner {
     let context2 = context.clone();
     in_workunit!(
       "run_execute_request",
-      WorkunitMetadata {
-        // NB: See engine::nodes::NodeKey::workunit_level for more information on why this workunit
-        // renders at the Process's level.
-        level: request.level,
-        desc: Some(request.description.clone()),
-        ..WorkunitMetadata::default()
-      },
+      // NB: See engine::nodes::NodeKey::workunit_level for more information on why this workunit
+      // renders at the Process's level.
+      request.level,
+      desc = Some(request.description.clone()),
       |workunit| async move {
         workunit.increment_counter(Metric::RemoteExecutionRequests, 1);
         let result_fut = self.run_execute_request(execute_request, request, &context2, workunit);
@@ -1331,11 +1328,8 @@ pub async fn check_action_cache(
 ) -> Result<Option<FallibleProcessResultWithPlatform>, String> {
   in_workunit!(
     "check_action_cache",
-    WorkunitMetadata {
-      level: Level::Debug,
-      desc: Some(format!("Remote cache lookup for: {}", command_description)),
-      ..WorkunitMetadata::default()
-    },
+    Level::Debug,
+    desc = Some(format!("Remote cache lookup for: {}", command_description)),
     |workunit| async move {
       workunit.increment_counter(Metric::RemoteCacheRequests, 1);
 
@@ -1383,11 +1377,8 @@ pub async fn check_action_cache(
             let response = response.clone();
             in_workunit!(
               "eager_fetch_action_cache",
-              WorkunitMetadata {
-                level: Level::Trace,
-                desc: Some("eagerly fetching after action cache hit".to_owned()),
-                ..WorkunitMetadata::default()
-              },
+              Level::Trace,
+              desc = Some("eagerly fetching after action cache hit".to_owned()),
               |_workunit| async move {
                 future::try_join_all(vec![
                   store.ensure_local_has_file(response.stdout_digest).boxed(),
@@ -1456,11 +1447,8 @@ pub async fn ensure_action_uploaded(
 ) -> Result<(), String> {
   in_workunit!(
     "ensure_action_uploaded",
-    WorkunitMetadata {
-      level: Level::Trace,
-      desc: Some(format!("ensure action uploaded for {:?}", action_digest)),
-      ..WorkunitMetadata::default()
-    },
+    Level::Trace,
+    desc = Some(format!("ensure action uploaded for {:?}", action_digest)),
     |_workunit| async move {
       let mut digests = vec![command_digest, action_digest];
       if let Some(input_files) = input_files {

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -788,7 +788,6 @@ impl crate::CommandRunner for CommandRunner {
 
     // Upload the action (and related data, i.e. the embedded command and input files).
     ensure_action_uploaded(
-      &context,
       &self.store,
       command_digest,
       action_digest,
@@ -799,7 +798,6 @@ impl crate::CommandRunner for CommandRunner {
     // Submit the execution request to the RE server for execution.
     let context2 = context.clone();
     in_workunit!(
-      context.workunit_store.clone(),
       "run_execute_request".to_owned(),
       WorkunitMetadata {
         // NB: See engine::nodes::NodeKey::workunit_level for more information on why this workunit
@@ -1338,7 +1336,6 @@ pub async fn check_action_cache(
   timeout_duration: Duration,
 ) -> Result<Option<FallibleProcessResultWithPlatform>, String> {
   in_workunit!(
-    context.workunit_store.clone(),
     "check_action_cache".to_owned(),
     WorkunitMetadata {
       level: Level::Debug,
@@ -1391,7 +1388,6 @@ pub async fn check_action_cache(
           if eager_fetch {
             let response = response.clone();
             in_workunit!(
-              context.workunit_store.clone(),
               "eager_fetch_action_cache".to_owned(),
               WorkunitMetadata {
                 level: Level::Trace,
@@ -1459,14 +1455,12 @@ pub async fn ensure_action_stored_locally(
 /// whether we are in a remote execution context, or a pure cache-usage context) are uploaded.
 ///
 pub async fn ensure_action_uploaded(
-  context: &Context,
   store: &Store,
   command_digest: Digest,
   action_digest: Digest,
   input_files: Option<DirectoryDigest>,
 ) -> Result<(), String> {
   in_workunit!(
-    context.workunit_store.clone(),
     "ensure_action_uploaded".to_owned(),
     WorkunitMetadata {
       level: Level::Trace,

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -282,9 +282,7 @@ impl CommandRunner {
     .boxed();
 
     // We speculate between reading from the remote cache vs. running locally.
-    let context2 = context.clone();
     in_workunit!(
-      context.workunit_store.clone(),
       "remote_cache_read_speculation".to_owned(),
       WorkunitMetadata {
         level: Level::Trace,
@@ -299,9 +297,7 @@ impl CommandRunner {
               if let Some(time_saved) = cached_response.metadata.time_saved_from_cache(lookup_elapsed) {
                 let time_saved = time_saved.as_millis() as u64;
                 workunit.increment_counter(Metric::RemoteCacheTotalTimeSavedMs, time_saved);
-                context2
-                  .workunit_store
-                  .record_observation(ObservationMetric::RemoteCacheTimeSavedMs, time_saved);
+                workunit.record_observation(ObservationMetric::RemoteCacheTimeSavedMs, time_saved);
               }
               // When we successfully use the cache, we change the description and increase the level
               // (but not so much that it will be logged by default).
@@ -334,7 +330,6 @@ impl CommandRunner {
   /// Stores an execution result into the remote Action Cache.
   async fn update_action_cache(
     &self,
-    context: &Context,
     result: &FallibleProcessResultWithPlatform,
     metadata: &ProcessMetadata,
     command: &Command,
@@ -343,14 +338,7 @@ impl CommandRunner {
   ) -> Result<(), String> {
     // Upload the Action and Command, but not the input files. See #12432.
     // Assumption: The Action and Command have already been stored locally.
-    crate::remote::ensure_action_uploaded(
-      context,
-      &self.store,
-      command_digest,
-      action_digest,
-      None,
-    )
-    .await?;
+    crate::remote::ensure_action_uploaded(&self.store, command_digest, action_digest, None).await?;
 
     // Create an ActionResult from the process result.
     let (action_result, digests_for_action_result) = self
@@ -468,38 +456,19 @@ impl crate::CommandRunner for CommandRunner {
     };
 
     if !hit_cache && (result.exit_code == 0 || write_failures_to_cache) && self.cache_write {
-      // NB: We use a distinct workunit for the start of the cache write so that we guarantee the
-      // counter is recorded, given that the cache write is async and may still be executing after
-      // the Pants session has finished and workunits are no longer processed.
-      //
-      // TODO(#11688): remove this workunit once we have tailing tasks.
-      in_workunit!(
-        context.workunit_store.clone(),
-        "remote_cache_write_setup".to_owned(),
-        WorkunitMetadata {
-          level: Level::Trace,
-          ..WorkunitMetadata::default()
-        },
-        |workunit| async move {
-          workunit.increment_counter(Metric::RemoteCacheWriteAttempts, 1);
-        }
-      )
-      .await;
       let command_runner = self.clone();
       let result = result.clone();
-      let context2 = context.clone();
       // NB: We use `TaskExecutor::spawn` instead of `tokio::spawn` to ensure logging still works.
       let _write_join = self.executor.spawn(in_workunit!(
-        context.workunit_store,
         "remote_cache_write".to_owned(),
         WorkunitMetadata {
           level: Level::Trace,
           ..WorkunitMetadata::default()
         },
         |workunit| async move {
+          workunit.increment_counter(Metric::RemoteCacheWriteAttempts, 1);
           let write_result = command_runner
             .update_action_cache(
-              &context2,
               &result,
               &command_runner.metadata,
               &command,

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -283,7 +283,7 @@ impl CommandRunner {
 
     // We speculate between reading from the remote cache vs. running locally.
     in_workunit!(
-      "remote_cache_read_speculation".to_owned(),
+      "remote_cache_read_speculation",
       WorkunitMetadata {
         level: Level::Trace,
         ..WorkunitMetadata::default()
@@ -460,7 +460,7 @@ impl crate::CommandRunner for CommandRunner {
       let result = result.clone();
       // NB: We use `TaskExecutor::spawn` instead of `tokio::spawn` to ensure logging still works.
       let _write_join = self.executor.spawn(in_workunit!(
-        "remote_cache_write".to_owned(),
+        "remote_cache_write",
         WorkunitMetadata {
           level: Level::Trace,
           ..WorkunitMetadata::default()

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -284,10 +284,7 @@ impl CommandRunner {
     // We speculate between reading from the remote cache vs. running locally.
     in_workunit!(
       "remote_cache_read_speculation",
-      WorkunitMetadata {
-        level: Level::Trace,
-        ..WorkunitMetadata::default()
-      },
+      Level::Trace,
       |workunit| async move {
         tokio::select! {
           cache_result = cache_read_future => {
@@ -458,13 +455,9 @@ impl crate::CommandRunner for CommandRunner {
     if !hit_cache && (result.exit_code == 0 || write_failures_to_cache) && self.cache_write {
       let command_runner = self.clone();
       let result = result.clone();
-      // NB: We use `TaskExecutor::spawn` instead of `tokio::spawn` to ensure logging still works.
       let _write_join = self.executor.spawn(in_workunit!(
         "remote_cache_write",
-        WorkunitMetadata {
-          level: Level::Trace,
-          ..WorkunitMetadata::default()
-        },
+        Level::Trace,
         |workunit| async move {
           workunit.increment_counter(Metric::RemoteCacheWriteAttempts, 1);
           let write_result = command_runner

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -1867,7 +1867,7 @@ async fn remote_workunits_are_stored() {
     .await
     .unwrap();
 
-  let got_workunit_items: HashSet<String> = workunit_store
+  let got_workunit_items: HashSet<&'static str> = workunit_store
     .latest_workunits(log::Level::Trace)
     .1
     .into_iter()
@@ -1875,10 +1875,10 @@ async fn remote_workunits_are_stored() {
     .collect();
 
   let wanted_workunit_items = hashset! {
-    String::from("remote execution action scheduling"),
-    String::from("remote execution worker input fetching"),
-    String::from("remote execution worker command executing"),
-    String::from("remote execution worker output uploading"),
+    "remote execution action scheduling",
+    "remote execution worker input fetching",
+    "remote execution worker command executing",
+    "remote execution worker output uploading",
   };
 
   assert!(got_workunit_items.is_superset(&wanted_workunit_items));

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -1071,6 +1071,7 @@ async fn extract_response_with_digest_stdout() {
 
 #[tokio::test]
 async fn extract_response_with_digest_stderr() {
+  let _ = WorkunitStore::setup_for_tests();
   let op_name = "gimme-foo".to_string();
   let testdata = TestData::roland();
   let testdata_empty = TestData::empty();
@@ -1098,6 +1099,7 @@ async fn extract_response_with_digest_stderr() {
 
 #[tokio::test]
 async fn extract_response_with_digest_stdout_osx_remote() {
+  let _ = WorkunitStore::setup_for_tests();
   let op_name = "gimme-foo".to_string();
   let testdata = TestData::roland();
   let testdata_empty = TestData::empty();
@@ -2022,6 +2024,7 @@ async fn extract_output_files_from_response_two_files_nested() {
 
 #[tokio::test]
 async fn extract_output_files_from_response_just_directory() {
+  let _ = WorkunitStore::setup_for_tests();
   let test_tree: TestTree = TestDirectory::containing_roland().into();
 
   let execute_response = remexec::ExecuteResponse {
@@ -2048,6 +2051,7 @@ async fn extract_output_files_from_response_directories_and_files() {
   // /pets/cats/roland.ext
   // /pets/dogs/robin.ext
 
+  let _ = WorkunitStore::setup_for_tests();
   let execute_response = remexec::ExecuteResponse {
     result: Some(remexec::ActionResult {
       exit_code: 0,
@@ -2085,6 +2089,7 @@ async fn extract_output_files_from_response_directories_and_files() {
 
 #[tokio::test]
 async fn extract_output_files_from_response_no_prefix() {
+  let _ = WorkunitStore::setup_for_tests();
   let execute_response = remexec::ExecuteResponse {
     result: Some(remexec::ActionResult {
       exit_code: 0,

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -327,7 +327,7 @@ async fn main() {
   };
 
   let result = in_workunit!(
-    "process_executor".to_owned(),
+    "process_executor",
     WorkunitMetadata::default(),
     |workunit| async move { runner.run(Context::default(), workunit, request).await }
   )

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -43,7 +43,7 @@ use protos::gen::buildbarn::cas::UncachedActionResult;
 use protos::require_digest;
 use store::{SnapshotOps, Store};
 use structopt::StructOpt;
-use workunit_store::{in_workunit, WorkunitMetadata, WorkunitStore};
+use workunit_store::{in_workunit, Level, WorkunitStore};
 
 #[derive(StructOpt)]
 struct CommandSpec {
@@ -326,11 +326,9 @@ async fn main() {
     )) as Box<dyn process_execution::CommandRunner>,
   };
 
-  let result = in_workunit!(
-    "process_executor",
-    WorkunitMetadata::default(),
-    |workunit| async move { runner.run(Context::default(), workunit, request).await }
-  )
+  let result = in_workunit!("process_executor", Level::Info, |workunit| async move {
+    runner.run(Context::default(), workunit, request).await
+  })
   .await
   .expect("Error executing");
 

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -327,7 +327,6 @@ async fn main() {
   };
 
   let result = in_workunit!(
-    workunit_store.clone(),
     "process_executor".to_owned(),
     WorkunitMetadata::default(),
     |workunit| async move { runner.run(Context::default(), workunit, request).await }

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -673,7 +673,7 @@ async fn workunit_to_py_value(
     let mut dict_entries = vec![
       (
         externs::store_utf8(py, "name"),
-        externs::store_utf8(py, &workunit.name),
+        externs::store_utf8(py, workunit.name),
       ),
       (
         externs::store_utf8(py, "span_id"),
@@ -964,7 +964,7 @@ fn scheduler_live_items<'py>(
   py: Python<'py>,
   py_scheduler: &'py PyScheduler,
   py_session: &'py PySession,
-) -> (Vec<PyObject>, HashMap<String, (usize, usize)>) {
+) -> (Vec<PyObject>, HashMap<&'static str, (usize, usize)>) {
   let (items, sizes) = py_scheduler
     .0
     .core

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1303,19 +1303,19 @@ impl NodeKey {
   /// Provides the `name` field in workunits associated with this node. These names
   /// should be friendly to machine-parsing (i.e. "my_node" rather than "My awesome node!").
   ///
-  pub fn workunit_name(&self) -> String {
+  pub fn workunit_name(&self) -> &'static str {
     match self {
-      NodeKey::Task(ref task) => task.task.display_info.name.clone(),
-      NodeKey::ExecuteProcess(..) => "process".to_string(),
-      NodeKey::Snapshot(..) => "snapshot".to_string(),
-      NodeKey::Paths(..) => "paths".to_string(),
-      NodeKey::DigestFile(..) => "digest_file".to_string(),
-      NodeKey::DownloadedFile(..) => "downloaded_file".to_string(),
-      NodeKey::ReadLink(..) => "read_link".to_string(),
-      NodeKey::Scandir(..) => "scandir".to_string(),
-      NodeKey::Select(..) => "select".to_string(),
-      NodeKey::SessionValues(..) => "session_values".to_string(),
-      NodeKey::RunId(..) => "run_id".to_string(),
+      NodeKey::Task(ref task) => &task.task.as_ref().display_info.name,
+      NodeKey::ExecuteProcess(..) => "process",
+      NodeKey::Snapshot(..) => "snapshot",
+      NodeKey::Paths(..) => "paths",
+      NodeKey::DigestFile(..) => "digest_file",
+      NodeKey::DownloadedFile(..) => "downloaded_file",
+      NodeKey::ReadLink(..) => "read_link",
+      NodeKey::Scandir(..) => "scandir",
+      NodeKey::Select(..) => "select",
+      NodeKey::SessionValues(..) => "session_values",
+      NodeKey::RunId(..) => "run_id",
     }
   }
 
@@ -1400,7 +1400,7 @@ impl Node for NodeKey {
       ..WorkunitMetadata::default()
     };
 
-    in_workunit!(self.workunit_name(), metadata, |workunit| async move {
+    in_workunit!(workunit_name, metadata, |workunit| async move {
       // To avoid races, we must ensure that we have installed a watch for the subject before
       // executing the node logic. But in case of failure, we wait to see if the Node itself
       // fails, and prefer that error message if so (because we have little control over the
@@ -1498,7 +1498,7 @@ impl Node for NodeKey {
             .collect()
         };
         let failure_name = if displayable_param_names.is_empty() {
-          name
+          name.to_owned()
         } else if displayable_param_names.len() == 1 {
           format!(
             "{} ({})",

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -84,6 +84,10 @@ impl<'x> Params {
   pub fn type_ids(&self) -> impl Iterator<Item = TypeId> + '_ {
     self.0.iter().map(|k| *k.type_id())
   }
+
+  pub fn is_empty(&self) -> bool {
+    self.0.is_empty()
+  }
 }
 
 ///

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -146,10 +146,13 @@ impl Scheduler {
   /// Returns references to all Python objects held alive by the graph, and a summary of sizes of
   /// Rust structs as a count and total size.
   ///
-  pub fn live_items(&self, session: &Session) -> (Vec<Value>, HashMap<String, (usize, usize)>) {
+  pub fn live_items(
+    &self,
+    session: &Session,
+  ) -> (Vec<Value>, HashMap<&'static str, (usize, usize)>) {
     let context = Context::new(self.core.clone(), session.clone());
     let mut items = vec![];
-    let mut sizes: HashMap<String, (usize, usize)> = HashMap::new();
+    let mut sizes: HashMap<&'static str, (usize, usize)> = HashMap::new();
     // TODO: Creation of a Context is exposed in https://github.com/Aeledfyr/deepsize/pull/31.
     let mut deep_context = deepsize::Context::new();
     self.core.graph.visit_live(&context, |k, v| {

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -19,3 +19,6 @@ rand = "0.8"
 strum = "0.20"
 strum_macros = "0.23"
 tokio = { version = "1.16", features = ["rt", "sync"] }
+
+[dev-dependencies]
+internment = "0.6"

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -97,7 +97,7 @@ type RunningWorkunitGraph = StableDiGraph<SpanId, (), u32>;
 ///
 #[derive(Clone, Debug)]
 pub struct Workunit {
-  pub name: String,
+  pub name: &'static str,
   pub span_id: SpanId,
   pub parent_id: Option<SpanId>,
   pub state: WorkunitState,
@@ -119,7 +119,7 @@ impl Workunit {
     let identifier = if let Some(ref s) = self.metadata.desc {
       s.as_str()
     } else {
-      self.name.as_str()
+      self.name
     };
 
     /* This length calculation doesn't treat multi-byte unicode charcters identically
@@ -626,7 +626,7 @@ impl WorkunitStore {
   pub fn _start_workunit(
     &self,
     span_id: SpanId,
-    name: String,
+    name: &'static str,
     parent_id: Option<SpanId>,
     metadata: WorkunitMetadata,
   ) -> Workunit {
@@ -689,7 +689,7 @@ impl WorkunitStore {
 
   pub fn add_completed_workunit(
     &self,
-    name: String,
+    name: &'static str,
     start_time: SystemTime,
     end_time: SystemTime,
     parent_id: Option<SpanId>,
@@ -785,12 +785,7 @@ impl WorkunitStore {
   pub fn setup_for_tests() -> (WorkunitStore, RunningWorkunit) {
     let store = WorkunitStore::new(false, Level::Debug);
     store.init_thread_state(None);
-    let workunit = store._start_workunit(
-      SpanId(0),
-      "testing".to_owned(),
-      None,
-      WorkunitMetadata::default(),
-    );
+    let workunit = store._start_workunit(SpanId(0), "testing", None, WorkunitMetadata::default());
     (store.clone(), RunningWorkunit::new(store, Some(workunit)))
   }
 }

--- a/src/rust/engine/workunit_store/src/tests.rs
+++ b/src/rust/engine/workunit_store/src/tests.rs
@@ -109,7 +109,7 @@ fn create_store(
       if let Some(parent_id) = parent_id {
         assert!(span_id > parent_id);
       }
-      ws.start_workunit(span_id, format!("{}", span_id.0), parent_id, metadata)
+      ws._start_workunit(span_id, format!("{}", span_id.0), parent_id, metadata)
     })
     .collect::<Vec<_>>();
 

--- a/src/rust/engine/workunit_store/src/tests.rs
+++ b/src/rust/engine/workunit_store/src/tests.rs
@@ -2,6 +2,8 @@ use std::collections::HashSet;
 use std::sync::atomic;
 use std::time::Duration;
 
+use internment::Intern;
+
 use crate::{SpanId, WorkunitMetadata, WorkunitState, WorkunitStore};
 
 #[test]
@@ -109,7 +111,12 @@ fn create_store(
       if let Some(parent_id) = parent_id {
         assert!(span_id > parent_id);
       }
-      ws._start_workunit(span_id, format!("{}", span_id.0), parent_id, metadata)
+      ws._start_workunit(
+        span_id,
+        Intern::new(format!("{}", span_id.0)).as_ref(),
+        parent_id,
+        metadata,
+      )
     })
     .collect::<Vec<_>>();
 


### PR DESCRIPTION
This change cleans up a few TODOs around workunit storage.

Workunit names are almost entirely `&'static str`, with the notable exception of `NodeKey::Task` names (which are the Python function names of `@rules`). But #14683 began interning `Task` structs, which made `Task` names static as well. This change moves to storing workunit names as `&'static str`.

Additionally, because the `Level` is a field of the `WorkunitMetadata`, the `WorkunitMetadata` was forced to be constructed, even for workunits whose level meant that they would not be rendered. Since the `WorkunitMetadata` contains heavy fields like the string description and user-metadata, this change moves to constructing the `WorkunitMetadata` via lazily evaluated `key=value` arguments to the `in_workunit!` macro (which also has the advantage of being more concise).

Finally: an unused argument to `in_workunit!` is removed.

Speeds up common runs by ~2%.