### PR TITLE
Ensure in CI that every PR has a category label.

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -15,6 +15,16 @@ jobs:
     name: Bootstrap Pants, test+lint Rust (Linux)
     runs-on: ubuntu-20.04
     steps:
+    - env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      if: github.event_name == 'pull_request'
+      name: Ensure category label
+      uses: mheap/github-action-required-labels@v1
+      with:
+        count: 1
+        labels: category:new feature, category:user api change, category:plugin api
+          change, category:performance, category:bugfix, category:documentation, category:internal
+        mode: exactly
     - name: Check out code
       uses: actions/checkout@v2
       with:
@@ -166,6 +176,16 @@ jobs:
     name: Bootstrap Pants, test Rust (macOS)
     runs-on: macos-10.15
     steps:
+    - env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      if: github.event_name == 'pull_request'
+      name: Ensure category label
+      uses: mheap/github-action-required-labels@v1
+      with:
+        count: 1
+        labels: category:new feature, category:user api change, category:plugin api
+          change, category:performance, category:bugfix, category:documentation, category:internal
+        mode: exactly
     - name: Check out code
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,16 @@ jobs:
     name: Bootstrap Pants, test+lint Rust (Linux)
     runs-on: ubuntu-20.04
     steps:
+    - env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      if: github.event_name == 'pull_request'
+      name: Ensure category label
+      uses: mheap/github-action-required-labels@v1
+      with:
+        count: 1
+        labels: category:new feature, category:user api change, category:plugin api
+          change, category:performance, category:bugfix, category:documentation, category:internal
+        mode: exactly
     - name: Check out code
       uses: actions/checkout@v2
       with:
@@ -165,6 +175,16 @@ jobs:
     name: Bootstrap Pants, test Rust (macOS)
     runs-on: macos-10.15
     steps:
+    - env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      if: github.event_name == 'pull_request'
+      name: Ensure category label
+      uses: mheap/github-action-required-labels@v1
+      with:
+        count: 1
+        labels: category:new feature, category:user api change, category:plugin api
+          change, category:performance, category:bugfix, category:documentation, category:internal
+        mode: exactly
     - name: Check out code
       uses: actions/checkout@v2
       with:

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -67,6 +67,25 @@ IS_PANTS_OWNER = "${{ github.repository_owner == 'pantsbuild' }}"
 # ----------------------------------------------------------------------
 
 
+def ensure_category_label() -> Sequence[Step]:
+    """Check that exactly one category label is present on a pull request."""
+    return [
+        {
+            "if": "github.event_name == 'pull_request'",
+            "name": "Ensure category label",
+            "uses": "mheap/github-action-required-labels@v1",
+            "env": {"GITHUB_TOKEN": "${{ secrets.GITHUB_TOKEN }}"},
+            "with": {
+                "mode": "exactly",
+                "count": 1,
+                "labels": "category:new feature, category:user api change, "
+                "category:plugin api change, category:performance, category:bugfix, "
+                "category:documentation, category:internal",
+            },
+        }
+    ]
+
+
 def checkout() -> Sequence[Step]:
     """Get prior commits and the commit message."""
     return [
@@ -300,6 +319,7 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
             "timeout-minutes": 40,
             "if": IS_PANTS_OWNER,
             "steps": [
+                *ensure_category_label(),
                 *checkout(),
                 *setup_primary_python(),
                 *bootstrap_caches(),
@@ -396,6 +416,7 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
             "timeout-minutes": 40,
             "if": IS_PANTS_OWNER,
             "steps": [
+                *ensure_category_label(),
                 *checkout(),
                 *setup_primary_python(),
                 *bootstrap_caches(),


### PR DESCRIPTION
The check runs only during the bootstrapping jobs.

See https://github.com/mheap/github-action-required-labels for
details on the setup. The use of GITHUB_TOKEN is necessary
for "Rerun all/failed jobs" to pick up new labels without requiring
a new commit. 

Note that GitHub Actions sets GITHUB_TOKEN automatically in secrets,
it doesn't need to be set manually via the web UI or otherwise.