### PR TITLE
Store workunits as a DAG rather than a tree

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -3987,6 +3987,7 @@ dependencies = [
  "parking_lot 0.12.0",
  "petgraph",
  "rand 0.8.5",
+ "smallvec",
  "strum",
  "strum_macros",
  "tokio",

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -855,7 +855,7 @@ fn maybe_add_workunit(
   workunit_store: &WorkunitStore,
   metadata: WorkunitMetadata,
 ) {
-  if !result_cached {
+  if !result_cached && workunit_store.max_level() >= metadata.level {
     let start_time: SystemTime = SystemTime::UNIX_EPOCH + time_span.start.into();
     let end_time: SystemTime = start_time + time_span.duration.into();
     workunit_store.add_completed_workunit(name, start_time, end_time, parent_id, metadata);

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -16,6 +16,7 @@ log = "0.4"
 parking_lot = "0.12"
 petgraph = "0.6"
 rand = "0.8"
+smallvec = "1"
 strum = "0.20"
 strum_macros = "0.23"
 tokio = { version = "1.16", features = ["rt", "sync"] }


### PR DESCRIPTION
As described in #14680: due to memoization, workunits are most accurately represented as a DAG, rather than as a tree.

This PR changes the _storage_ of workunits from a tree to a DAG by giving workunits multiple parents. But it does not yet actually add multiple parents to a workunit, which will be accomplished in a followup change. This portion is worth landing separately because it eases the fix for #14867, while the actual addition of multiple parents is not necessary for that fix.