### PR TITLE
[internal] BSP: get third-party deps working for Scala

### DIFF
--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -39,6 +39,7 @@ from pants.jvm.compile import (
     ClasspathEntryRequestFactory,
     FallibleClasspathEntry,
 )
+from pants.jvm.compile import ClasspathEntryRequest, FallibleClasspathEntry
 from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.jvm.resolve.key import CoursierResolveKey

--- a/src/python/pants/bsp/spec/base.py
+++ b/src/python/pants/bsp/spec/base.py
@@ -12,7 +12,6 @@ from pants.build_graph.address import Address, AddressInput
 # Basic JSON Structures
 # See https://build-server-protocol.github.io/docs/specification.html#basic-json-structures
 # -----------------------------------------------------------------------------------------------
-from pants.util.meta import classproperty
 
 Uri = str
 

--- a/src/python/pants/bsp/spec/base.py
+++ b/src/python/pants/bsp/spec/base.py
@@ -12,6 +12,7 @@ from pants.build_graph.address import Address, AddressInput
 # Basic JSON Structures
 # See https://build-server-protocol.github.io/docs/specification.html#basic-json-structures
 # -----------------------------------------------------------------------------------------------
+from pants.util.meta import classproperty
 
 Uri = str
 

--- a/src/python/pants/bsp/spec/targets.py
+++ b/src/python/pants/bsp/spec/targets.py
@@ -176,6 +176,7 @@ class DependencyModulesParams:
         }
 
 
+@dataclass(frozen=True)
 class DependencyModule:
     # Module name
     name: str

--- a/src/python/pants/bsp/util_rules/targets.py
+++ b/src/python/pants/bsp/util_rules/targets.py
@@ -42,6 +42,7 @@ from pants.engine.target import (
     Targets,
     WrappedTarget,
 )
+from pants.engine.target import SourcesField, SourcesPaths, SourcesPathsRequest, WrappedTarget
 from pants.engine.unions import UnionMembership, UnionRule, union
 from pants.source.source_root import SourceRootsRequest, SourceRootsResult
 from pants.util.frozendict import FrozenDict


### PR DESCRIPTION
Get third-party dependencies working for Scala code. IntelliJ does not call the `buildTarget/dependencyModules` BSP endpoint, while VSCode Metals does call it. IntelliJ only looks at the `classpath` attribute returned by the `buildTarget/scalacOptions` endpoint.