### PR TITLE
gitignore Pyenv's .python-version file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ __pycache__/
 .classpath
 .factorypath
 .python
+.python-version
 .pydevproject
 .pytest_cache/
 codegen/classes/


### PR DESCRIPTION
Pyenv creates this file when you call `pyenv local`,
to set the local interpreter for the cwd.
It is just a local artifact that shouldn't be accidentally
pulled into the repo.

[ci skip-rust]

[ci skip-build-wheels]