### PR TITLE
FmtResult now operates on Snapshots

### DIFF
--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -14,12 +14,13 @@ from pants.core.goals.lint import LintResult, LintResults, LintTargetsRequest
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, MergeDigests
+from pants.engine.internals.native_engine import Snapshot
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
-from pants.util.strutil import pluralize
+from pants.util.strutil import pluralize, strip_v2_chroot_path
 
 
 @dataclass(frozen=True)
@@ -47,7 +48,7 @@ class SetupRequest:
 @dataclass(frozen=True)
 class Setup:
     process: Process
-    original_digest: Digest
+    original_snapshot: Snapshot
 
 
 def generate_argv(
@@ -120,7 +121,7 @@ async def setup_isort(setup_request: SetupRequest, isort: Isort) -> Setup:
             level=LogLevel.DEBUG,
         ),
     )
-    return Setup(process, original_digest=source_files_snapshot.digest)
+    return Setup(process, original_snapshot=source_files_snapshot)
 
 
 @rule(desc="Format with isort", level=LogLevel.DEBUG)
@@ -129,11 +130,13 @@ async def isort_fmt(request: IsortRequest, isort: Isort) -> FmtResult:
         return FmtResult.skip(formatter_name=request.name)
     setup = await Get(Setup, SetupRequest(request, check_only=False))
     result = await Get(ProcessResult, Process, setup.process)
-    return FmtResult.from_process_result(
-        result,
-        original_digest=setup.original_digest,
+    output_snapshot = await Get(Snapshot, Digest, result.output_digest)
+    return FmtResult(
+        setup.original_snapshot,
+        output_snapshot,
+        stdout=strip_v2_chroot_path(result.stdout),
+        stderr=strip_v2_chroot_path(result.stderr),
         formatter_name=request.name,
-        strip_chroot_path=True,
     )
 
 

--- a/src/python/pants/backend/python/lint/pyupgrade/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/rules_integration_test.py
@@ -17,6 +17,7 @@ from pants.core.util_rules import config_files, source_files
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
+from pants.engine.internals.native_engine import Snapshot
 from pants.engine.target import Target
 from pants.testutil.python_interpreter_selection import all_major_minor_python_versions
 from pants.testutil.rule_runner import QueryRule, RuleRunner
@@ -81,9 +82,10 @@ def run_pyupgrade(
     return lint_results.results, fmt_result
 
 
-def get_digest(rule_runner: RuleRunner, source_files: dict[str, str]) -> Digest:
+def get_snapshot(rule_runner: RuleRunner, source_files: dict[str, str]) -> Snapshot:
     files = [FileContent(path, content.encode()) for path, content in source_files.items()]
-    return rule_runner.request(Digest, [CreateDigest(files)])
+    digest = rule_runner.request(Digest, [CreateDigest(files)])
+    return rule_runner.request(Snapshot, [digest])
 
 
 @pytest.mark.platform_specific_behavior
@@ -102,7 +104,7 @@ def test_passing(rule_runner: RuleRunner, major_minor_interpreter: str) -> None:
     assert len(lint_results) == 1
     assert lint_results[0].exit_code == 0
     assert lint_results[0].stderr == ""
-    assert fmt_result.output == get_digest(rule_runner, {"f.py": PY_36_GOOD_FILE})
+    assert fmt_result.output == get_snapshot(rule_runner, {"f.py": PY_36_GOOD_FILE})
     assert fmt_result.did_change is False
 
 
@@ -114,7 +116,7 @@ def test_failing(rule_runner: RuleRunner) -> None:
     assert lint_results[0].exit_code == 1
     assert "Rewriting f.py" in lint_results[0].stderr
     assert fmt_result.skipped is False
-    assert fmt_result.output == get_digest(rule_runner, {"f.py": PY_36_FIXED_BAD_FILE})
+    assert fmt_result.output == get_snapshot(rule_runner, {"f.py": PY_36_FIXED_BAD_FILE})
     assert fmt_result.did_change is True
 
 
@@ -132,7 +134,7 @@ def test_multiple_targets(rule_runner: RuleRunner) -> None:
     assert "Rewriting bad.py" in lint_results[0].stderr
     assert "good.py" not in lint_results[0].stderr
     assert "good.py" not in lint_results[0].stdout
-    assert fmt_result.output == get_digest(
+    assert fmt_result.output == get_snapshot(
         rule_runner, {"good.py": PY_36_GOOD_FILE, "bad.py": PY_36_FIXED_BAD_FILE}
     )
     assert fmt_result.did_change is True
@@ -153,7 +155,9 @@ def test_passthrough_args(rule_runner: RuleRunner) -> None:
     assert len(lint_results) == 1
     assert lint_results[0].exit_code == 1
     assert "Rewriting some_file_name.py" in lint_results[0].stderr
-    assert fmt_result.output == get_digest(rule_runner, {"some_file_name.py": PY_38_FIXED_BAD_FILE})
+    assert fmt_result.output == get_snapshot(
+        rule_runner, {"some_file_name.py": PY_38_FIXED_BAD_FILE}
+    )
     assert fmt_result.did_change is True
 
 

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -75,7 +75,7 @@ class Partition:
 @dataclass(frozen=True)
 class Setup:
     partitions: tuple[Partition, ...]
-    original_digest: Digest
+    original_snapshot: Snapshot
 
 
 @dataclass(frozen=True)
@@ -249,7 +249,7 @@ async def setup_scalafmt(
         for config_file, files in source_files_by_config_file.items()
     )
 
-    return Setup(tuple(partitions), original_digest=source_files_snapshot.digest)
+    return Setup(tuple(partitions), original_snapshot=source_files_snapshot)
 
 
 @rule(desc="Format with scalafmt", level=LogLevel.DEBUG)
@@ -281,10 +281,11 @@ async def scalafmt_fmt(request: ScalafmtRequest, tool: ScalafmtSubsystem) -> Fmt
 
     # Merge all of the outputs into a single output.
     output_digest = await Get(Digest, MergeDigests([r.output_digest for r in results]))
+    output_snapshot = await Get(Snapshot, Digest, output_digest)
 
     fmt_result = FmtResult(
-        input=setup.original_digest,
-        output=output_digest,
+        input=setup.original_snapshot,
+        output=output_snapshot,
         stdout=stdout_content,
         stderr=stderr_content,
         formatter_name=request.name,

--- a/src/python/pants/backend/shell/lint/shfmt/rules_integration_test.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules_integration_test.py
@@ -17,6 +17,7 @@ from pants.core.util_rules import config_files, external_tool, source_files
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
+from pants.engine.internals.native_engine import Snapshot
 from pants.engine.target import Target
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -95,9 +96,10 @@ def run_shfmt(
     return lint_results.results, fmt_result
 
 
-def get_digest(rule_runner: RuleRunner, source_files: dict[str, str]) -> Digest:
+def get_snapshot(rule_runner: RuleRunner, source_files: dict[str, str]) -> Snapshot:
     files = [FileContent(path, content.encode()) for path, content in source_files.items()]
-    return rule_runner.request(Digest, [CreateDigest(files)])
+    digest = rule_runner.request(Digest, [CreateDigest(files)])
+    return rule_runner.request(Snapshot, [digest])
 
 
 def test_passing(rule_runner: RuleRunner) -> None:
@@ -108,7 +110,7 @@ def test_passing(rule_runner: RuleRunner) -> None:
     assert lint_results[0].exit_code == 0
     assert lint_results[0].stderr == ""
     assert fmt_result.stdout == ""
-    assert fmt_result.output == get_digest(rule_runner, {"f.sh": GOOD_FILE})
+    assert fmt_result.output == get_snapshot(rule_runner, {"f.sh": GOOD_FILE})
     assert fmt_result.did_change is False
 
 
@@ -120,7 +122,7 @@ def test_failing(rule_runner: RuleRunner) -> None:
     assert lint_results[0].exit_code == 1
     assert "f.sh.orig" in lint_results[0].stdout
     assert fmt_result.stdout == "f.sh\n"
-    assert fmt_result.output == get_digest(rule_runner, {"f.sh": GOOD_FILE})
+    assert fmt_result.output == get_snapshot(rule_runner, {"f.sh": GOOD_FILE})
     assert fmt_result.did_change is True
 
 
@@ -138,7 +140,9 @@ def test_multiple_targets(rule_runner: RuleRunner) -> None:
     assert "bad.sh.orig" in lint_results[0].stdout
     assert "good.sh" not in lint_results[0].stdout
     assert "bad.sh\n" == fmt_result.stdout
-    assert fmt_result.output == get_digest(rule_runner, {"good.sh": GOOD_FILE, "bad.sh": GOOD_FILE})
+    assert fmt_result.output == get_snapshot(
+        rule_runner, {"good.sh": GOOD_FILE, "bad.sh": GOOD_FILE}
+    )
     assert fmt_result.did_change is True
 
 
@@ -162,7 +166,7 @@ def test_config_files(rule_runner: RuleRunner) -> None:
     assert "a/f.sh.orig" in lint_results[0].stdout
     assert "b/f.sh.orig" not in lint_results[0].stdout
     assert fmt_result.stdout == "a/f.sh\n"
-    assert fmt_result.output == get_digest(
+    assert fmt_result.output == get_snapshot(
         rule_runner, {"a/f.sh": FIXED_NEEDS_CONFIG_FILE, "b/f.sh": NEEDS_CONFIG_FILE}
     )
     assert fmt_result.did_change is True
@@ -176,7 +180,7 @@ def test_passthrough_args(rule_runner: RuleRunner) -> None:
     assert lint_results[0].exit_code == 1
     assert "f.sh.orig" in lint_results[0].stdout
     assert fmt_result.stdout == "f.sh\n"
-    assert fmt_result.output == get_digest(rule_runner, {"f.sh": FIXED_NEEDS_CONFIG_FILE})
+    assert fmt_result.output == get_snapshot(rule_runner, {"f.sh": FIXED_NEEDS_CONFIG_FILE})
     assert fmt_result.did_change is True
 
 

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
@@ -11,6 +11,7 @@ from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.core.goals.lint import LintResult, LintResults, LintTargetsRequest
 from pants.core.util_rules import external_tool
 from pants.engine.fs import Digest, MergeDigests
+from pants.engine.internals.native_engine import Snapshot
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.process import FallibleProcessResult, ProcessResult
 from pants.engine.rules import collect_rules, rule
@@ -65,10 +66,11 @@ async def tffmt_fmt(request: TffmtRequest, tffmt: TfFmtSubsystem) -> FmtResult:
 
     # Merge all of the outputs into a single output.
     output_digest = await Get(Digest, MergeDigests(r.output_digest for r in results))
+    output_snapshot = await Get(Snapshot, Digest, output_digest)
 
     fmt_result = FmtResult(
-        input=setup.original_digest,
-        output=output_digest,
+        input=setup.original_snapshot,
+        output=output_snapshot,
         stdout=stdout_content,
         stderr=stderr_content,
         formatter_name=request.name,

--- a/src/python/pants/backend/terraform/style.py
+++ b/src/python/pants/backend/terraform/style.py
@@ -13,7 +13,7 @@ from pants.backend.terraform.tool import TerraformProcess
 from pants.build_graph.address import Address
 from pants.core.goals.style_request import StyleRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.engine.fs import Digest, MergeDigests, Snapshot
+from pants.engine.fs import MergeDigests, Snapshot
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import collect_rules, rule
 from pants.util.logging import LogLevel
@@ -35,7 +35,7 @@ class StyleSetupRequest:
 @dataclass(frozen=True)
 class StyleSetup:
     directory_to_process: dict[str, tuple[TerraformProcess, tuple[Address, ...]]]
-    original_digest: Digest
+    original_snapshot: Snapshot
 
 
 @rule(level=LogLevel.DEBUG)
@@ -85,7 +85,7 @@ async def setup_terraform_style(setup_request: StyleSetupRequest) -> StyleSetup:
         directory_to_process[directory] = (process, addresses)
 
     return StyleSetup(
-        directory_to_process=directory_to_process, original_digest=source_files_snapshot.digest
+        directory_to_process=directory_to_process, original_snapshot=source_files_snapshot
     )
 
 

--- a/src/python/pants/core/goals/fmt_test.py
+++ b/src/python/pants/core/goals/fmt_test.py
@@ -47,7 +47,7 @@ class FortranFmtRequest(FmtRequest):
 @rule
 async def fortran_fmt(request: FortranFmtRequest) -> FmtResult:
     output = (
-        await Get(Snapshot, Digest, await Get(Digest, CreateDigest([FORTRAN_FILE])))
+        await Get(Snapshot, CreateDigest([FORTRAN_FILE]))
         if any(fs.address.target_name == "needs_formatting" for fs in request.field_sets)
         else EMPTY_SNAPSHOT
     )


### PR DESCRIPTION
In order to handle the upcoming change to "unify" both `fmt` and `lint` processes for formatters, we need to have the `message` of `FmtResult` be based on a diff of 2 `Snapshot`s. Since `message` can't participate in `async/await`, we need to change `FmtResult` so it already has those snapshots available (namely `input` and `output`).

This is unfortunately boilerplate for the callers, but that can potentially be cleaned up later a myriad of ways.

This also should be essentially no overhead as `fmt.py` was already doing this query (although it was doing it conditionally. I suspect doing it unconditionally will have very little impact on perf because this is guaranteed to be cached if the output digest differs from the input).

[ci skip-rust]