### PR TITLE
[internal] BSP: stub out remaining scala RPCs

### DIFF
--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -15,6 +15,8 @@ from pants.backend.scala.bsp.spec import (
     ScalaMainClassesParams,
     ScalaMainClassesResult,
     ScalaPlatform,
+    ScalaTestClassesParams,
+    ScalaTestClassesResult,
 )
 from pants.backend.scala.subsystems.scala import ScalaSubsystem
 from pants.backend.scala.target_types import ScalaSourceField
@@ -284,6 +286,27 @@ async def bsp_scala_main_classes_request(request: ScalaMainClassesParams) -> Sca
 
 
 # -----------------------------------------------------------------------------------------------
+# Scala Test Classes Request
+# See https://build-server-protocol.github.io/docs/extensions/scala.html#scala-test-classes-request
+# -----------------------------------------------------------------------------------------------
+
+
+class ScalaTestClassesHandlerMapping(BSPHandlerMapping):
+    method_name = "buildTarget/scalaTestClasses"
+    request_type = ScalaTestClassesParams
+    response_type = ScalaTestClassesResult
+
+
+@rule
+async def bsp_scala_test_classes_request(request: ScalaTestClassesParams) -> ScalaTestClassesResult:
+    # TODO: This is a stub. VSCode/Metals calls this RPC and expects it to exist.
+    return ScalaTestClassesResult(
+        items=(),
+        origin_id=request.origin_id,
+    )
+
+
+# -----------------------------------------------------------------------------------------------
 # Dependency Modules
 # -----------------------------------------------------------------------------------------------
 
@@ -430,6 +453,7 @@ def rules():
         UnionRule(BSPBuildTargetsMetadataRequest, ScalaBSPBuildTargetsMetadataRequest),
         UnionRule(BSPHandlerMapping, ScalacOptionsHandlerMapping),
         UnionRule(BSPHandlerMapping, ScalaMainClassesHandlerMapping),
+        UnionRule(BSPHandlerMapping, ScalaTestClassesHandlerMapping),
         UnionRule(BSPCompileFieldSet, ScalaBSPCompileFieldSet),
         UnionRule(BSPDependencyModulesRequest, ScalaBSPDependencyModulesRequest),
     )

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -12,6 +12,8 @@ from pants.backend.scala.bsp.spec import (
     ScalacOptionsItem,
     ScalacOptionsParams,
     ScalacOptionsResult,
+    ScalaMainClassesParams,
+    ScalaMainClassesResult,
     ScalaPlatform,
 )
 from pants.backend.scala.subsystems.scala import ScalaSubsystem
@@ -261,6 +263,27 @@ async def bsp_scalac_options_request(request: ScalacOptionsParams) -> ScalacOpti
 
 
 # -----------------------------------------------------------------------------------------------
+# Scala Main Classes Request
+# See https://build-server-protocol.github.io/docs/extensions/scala.html#scala-main-classes-request
+# -----------------------------------------------------------------------------------------------
+
+
+class ScalaMainClassesHandlerMapping(BSPHandlerMapping):
+    method_name = "buildTarget/scalaMainClasses"
+    request_type = ScalaMainClassesParams
+    response_type = ScalaMainClassesResult
+
+
+@rule
+async def bsp_scala_main_classes_request(request: ScalaMainClassesParams) -> ScalaMainClassesResult:
+    # TODO: This is a stub. VSCode/Metals calls this RPC and expects it to exist.
+    return ScalaMainClassesResult(
+        items=(),
+        origin_id=request.origin_id,
+    )
+
+
+# -----------------------------------------------------------------------------------------------
 # Dependency Modules
 # -----------------------------------------------------------------------------------------------
 
@@ -406,6 +429,7 @@ def rules():
         UnionRule(BSPLanguageSupport, ScalaBSPLanguageSupport),
         UnionRule(BSPBuildTargetsMetadataRequest, ScalaBSPBuildTargetsMetadataRequest),
         UnionRule(BSPHandlerMapping, ScalacOptionsHandlerMapping),
+        UnionRule(BSPHandlerMapping, ScalaMainClassesHandlerMapping),
         UnionRule(BSPCompileFieldSet, ScalaBSPCompileFieldSet),
         UnionRule(BSPDependencyModulesRequest, ScalaBSPDependencyModulesRequest),
     )

--- a/src/python/pants/backend/scala/bsp/spec.py
+++ b/src/python/pants/backend/scala/bsp/spec.py
@@ -86,7 +86,7 @@ class ScalacOptionsParams:
             targets=tuple(BuildTargetIdentifier.from_json_dict(x) for x in d["targets"]),
         )
 
-    def to_json_dict(self):
+    def to_json_dict(self) -> dict[str, Any]:
         return {
             "targets": [tgt.to_json_dict() for tgt in self.targets],
         }
@@ -109,7 +109,7 @@ class ScalacOptionsItem:
     # The output directory for classfiles produced by this target
     class_directory: Uri
 
-    def to_json_dict(self):
+    def to_json_dict(self) -> dict[str, Any]:
         return {
             "target": self.target.to_json_dict(),
             "options": self.options,
@@ -124,3 +124,88 @@ class ScalacOptionsResult:
 
     def to_json_dict(self):
         return {"items": [item.to_json_dict() for item in self.items]}
+
+
+# -----------------------------------------------------------------------------------------------
+# Scala Main Classes Request
+# See https://build-server-protocol.github.io/docs/extensions/scala.html#scala-main-classes-request
+# -----------------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ScalaMainClassesParams:
+    targets: tuple[BuildTargetIdentifier, ...]
+
+    # An optional number uniquely identifying a client request.
+    origin_id: str | None = None
+
+    @classmethod
+    def from_json_dict(cls, d):
+        return cls(
+            targets=tuple(BuildTargetIdentifier.from_json_dict(x) for x in d["targets"]),
+            origin_id=d.get("originId"),
+        )
+
+    def to_json_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "targets": [tgt.to_json_dict() for tgt in self.targets],
+        }
+        if self.origin_id is not None:
+            result["originId"] = self.origin_id
+        return result
+
+
+@dataclass(frozen=True)
+class ScalaMainClass:
+    # The main class to run.
+    class_: str
+
+    # The user arguments to the main entrypoint.
+    arguments: tuple[str, ...]
+
+    # The jvm options for the application.
+    jvm_options: tuple[str, ...]
+
+    # The environment variables for the application.
+    environment_variables: tuple[str, ...] | None = None
+
+    def to_json_dict(self) -> dict[str, Any]:
+        result = {
+            "class": self.class_,
+            "arguments": self.arguments,
+            "jvmOptions": self.jvm_options,
+        }
+        if self.environment_variables is not None:
+            result["environmentVariables"] = self.environment_variables
+        return result
+
+
+@dataclass(frozen=True)
+class ScalaMainClassesItem:
+    # The build target that contains the test classes.
+    target: BuildTargetIdentifier
+
+    # The main class item.
+    classes: tuple[ScalaMainClass, ...]
+
+    def to_json_dict(self) -> dict[str, Any]:
+        return {
+            "target": self.target.to_json_dict(),
+            "classes": self.classes,
+        }
+
+
+@dataclass(frozen=True)
+class ScalaMainClassesResult:
+    items: tuple[ScalaMainClassesItem, ...]
+
+    # An optional id of the request that triggered this result.
+    origin_id: str | None = None
+
+    def to_json_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "items": [item.to_json_dict() for item in self.items],
+        }
+        if self.origin_id is not None:
+            result["originId"] = self.origin_id
+        return result

--- a/src/python/pants/backend/scala/bsp/spec.py
+++ b/src/python/pants/backend/scala/bsp/spec.py
@@ -209,3 +209,71 @@ class ScalaMainClassesResult:
         if self.origin_id is not None:
             result["originId"] = self.origin_id
         return result
+
+
+# -----------------------------------------------------------------------------------------------
+# Scala Test Classes Request
+# See https://build-server-protocol.github.io/docs/extensions/scala.html#scala-test-classes-request
+# -----------------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ScalaTestClassesParams:
+    targets: tuple[BuildTargetIdentifier, ...]
+
+    # An optional number uniquely identifying a client request.
+    origin_id: str | None = None
+
+    @classmethod
+    def from_json_dict(cls, d):
+        return cls(
+            targets=tuple(BuildTargetIdentifier.from_json_dict(x) for x in d["targets"]),
+            origin_id=d.get("originId"),
+        )
+
+    def to_json_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "targets": [tgt.to_json_dict() for tgt in self.targets],
+        }
+        if self.origin_id is not None:
+            result["originId"] = self.origin_id
+        return result
+
+
+@dataclass(frozen=True)
+class ScalaTestClassesItem:
+    # The build target that contains the test classes.
+    target: BuildTargetIdentifier
+
+    # Name of the the framework to which classes belong.
+    # It's optional in order to maintain compatibility, however it is expected
+    # from the newer implementations to not leave that field unspecified.
+    framework: str | None
+
+    # The fully qualified names of the test classes in this target
+    classes: tuple[str, ...]
+
+    def to_json_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "target": self.target.to_json_dict(),
+            "classes": self.classes,
+        }
+        if self.framework is not None:
+            result["framework"] = self.framework
+        return result
+
+
+@dataclass(frozen=True)
+class ScalaTestClassesResult:
+    items: tuple[ScalaTestClassesItem, ...]
+
+    # An optional id of the request that triggered this result.
+    origin_id: str | None = None
+
+    def to_json_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "items": [item.to_json_dict() for item in self.items],
+        }
+        if self.origin_id is not None:
+            result["originId"] = self.origin_id
+        return result


### PR DESCRIPTION
Stub out the remaining Scala-specific BSP RPCs: Scala Main Classes Request and Scala Test Classes Request. IntelliJ does not appear to call these RPCs by default, but VSCode/Metals does. This PR allows VSCode/Metals to proceed further in importing a project.