### PR TITLE
[internal] BSP: cleanup target resolve and source roots computation

### DIFF
--- a/src/python/pants/backend/java/bsp/rules.py
+++ b/src/python/pants/backend/java/bsp/rules.py
@@ -14,9 +14,9 @@ from pants.bsp.spec.base import BuildTargetIdentifier, StatusCode
 from pants.bsp.util_rules.compile import BSPCompileFieldSet, BSPCompileResult
 from pants.bsp.util_rules.lifecycle import BSPLanguageSupport
 from pants.bsp.util_rules.targets import (
+    BSPBuildTargets,
     BSPBuildTargetsMetadataRequest,
     BSPBuildTargetsMetadataResult,
-    BSPBuildTargetsNew,
 )
 from pants.engine.addresses import Addresses
 from pants.engine.fs import CreateDigest, DigestEntries
@@ -92,7 +92,7 @@ class HandleJavacOptionsResult:
 async def handle_bsp_java_options_request(
     request: HandleJavacOptionsRequest,
     build_root: BuildRoot,
-    bsp_build_targets: BSPBuildTargetsNew,
+    bsp_build_targets: BSPBuildTargets,
 ) -> HandleJavacOptionsResult:
     bsp_target_name = request.bsp_target_id.uri[len("pants:") :]
     if bsp_target_name not in bsp_build_targets.targets_mapping:

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -24,7 +24,7 @@ from pants.bsp.spec.targets import DependencyModule
 from pants.bsp.util_rules.compile import BSPCompileFieldSet, BSPCompileResult
 from pants.bsp.util_rules.lifecycle import BSPLanguageSupport
 from pants.bsp.util_rules.targets import (
-    BSPBuildTargets,
+    BSPBuildTargetInternal,
     BSPBuildTargetsMetadataRequest,
     BSPBuildTargetsMetadataResult,
     BSPDependencyModulesRequest,
@@ -207,16 +207,13 @@ class HandleScalacOptionsResult:
 async def handle_bsp_scalac_options_request(
     request: HandleScalacOptionsRequest,
     build_root: BuildRoot,
-    bsp_build_targets: BSPBuildTargets,
     workspace: Workspace,
 ) -> HandleScalacOptionsResult:
-    bsp_target_name = request.bsp_target_id.uri[len("pants:") :]
-    if bsp_target_name not in bsp_build_targets.targets_mapping:
-        raise ValueError(f"Invalid BSP target name: {request.bsp_target_id}")
+    bsp_target = await Get(BSPBuildTargetInternal, BuildTargetIdentifier, request.bsp_target_id)
     targets = await Get(
         Targets,
         AddressSpecs,
-        bsp_build_targets.targets_mapping[bsp_target_name].specs.address_specs,
+        bsp_target.specs.address_specs,
     )
     coarsened_targets = await Get(CoarsenedTargets, Addresses(tgt.address for tgt in targets))
     resolve = await Get(CoursierResolveKey, CoarsenedTargets, coarsened_targets)

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -24,9 +24,9 @@ from pants.bsp.spec.targets import DependencyModule
 from pants.bsp.util_rules.compile import BSPCompileFieldSet, BSPCompileResult
 from pants.bsp.util_rules.lifecycle import BSPLanguageSupport
 from pants.bsp.util_rules.targets import (
+    BSPBuildTargets,
     BSPBuildTargetsMetadataRequest,
     BSPBuildTargetsMetadataResult,
-    BSPBuildTargetsNew,
     BSPDependencyModulesRequest,
     BSPDependencyModulesResult,
 )
@@ -207,7 +207,7 @@ class HandleScalacOptionsResult:
 async def handle_bsp_scalac_options_request(
     request: HandleScalacOptionsRequest,
     build_root: BuildRoot,
-    bsp_build_targets: BSPBuildTargetsNew,
+    bsp_build_targets: BSPBuildTargets,
     workspace: Workspace,
 ) -> HandleScalacOptionsResult:
     bsp_target_name = request.bsp_target_id.uri[len("pants:") :]

--- a/src/python/pants/bsp/util_rules/targets.py
+++ b/src/python/pants/bsp/util_rules/targets.py
@@ -81,6 +81,17 @@ class BSPBuildTargetInternal:
 
 
 @dataclass(frozen=True)
+class BSPBuildTargetSourcesInfo:
+    """Source files and roots for a BSP build target.
+
+    It is a separate class so that it is computed lazily only when called for by an RPC call.
+    """
+
+    source_files: frozenset[str]
+    source_roots: frozenset[str]
+
+
+@dataclass(frozen=True)
 class BSPBuildTargets:
     targets_mapping: FrozenDict[str, BSPBuildTargetInternal]
 
@@ -124,6 +135,28 @@ async def resolve_bsp_build_target_identifier(
         raise ValueError(f"Unknown BSP target name: {target_name}")
 
     return target_internal
+
+
+@rule
+async def resolve_bsp_build_target_source_roots(
+    bsp_target: BSPBuildTargetInternal,
+) -> BSPBuildTargetSourcesInfo:
+    targets = await Get(Targets, AddressSpecs, bsp_target.specs.address_specs)
+    targets_with_sources = [tgt for tgt in targets if tgt.has_field(SourcesField)]
+    sources_paths = await MultiGet(
+        Get(SourcesPaths, SourcesPathsRequest(tgt[SourcesField])) for tgt in targets_with_sources
+    )
+    merged_source_files: set[str] = set()
+    for sp in sources_paths:
+        merged_source_files.update(sp.files)
+    source_roots_result = await Get(
+        SourceRootsResult, SourceRootsRequest, SourceRootsRequest.for_files(merged_source_files)
+    )
+    source_root_paths = {x.path for x in source_roots_result.path_to_root.values()}
+    return BSPBuildTargetSourcesInfo(
+        source_files=frozenset(merged_source_files),
+        source_roots=frozenset(source_root_paths),
+    )
 
 
 # -----------------------------------------------------------------------------------------------
@@ -225,32 +258,21 @@ async def generate_one_bsp_build_target_request(
     metadata = metadata_results_by_lang_id[metadata_merge_order[-1].language_id].metadata
     digest = await Get(Digest, MergeDigests([r.digest for r in metadata_results]))
 
-    # Determine base directory for this build target using source roots.
-    targets_with_sources = [tgt for tgt in targets if tgt.has_field(SourcesField)]
-    sources_paths = await MultiGet(
-        Get(SourcesPaths, SourcesPathsRequest(tgt[SourcesField])) for tgt in targets_with_sources
-    )
-    _logger.info(f"sources_paths = {sources_paths}")
-    merged_source_files: set[str] = set()
-    for sp in sources_paths:
-        merged_source_files.update(sp.files)
-
-    source_roots_result = await Get(
-        SourceRootsResult, SourceRootsRequest, SourceRootsRequest.for_files(merged_source_files)
-    )
-    source_root_paths = {x.path for x in source_roots_result.path_to_root.values()}
-    if len(source_root_paths) == 0:
-        base_dir = build_root.pathlib_path
-    elif len(source_root_paths) == 1:
-        base_dir = build_root.pathlib_path.joinpath(list(source_root_paths)[0])
+    # Determine "base directory" for this build target using source roots.
+    # TODO: This actually has nothing to do with source roots. It should probably be computed as an ancestor
+    # directory or else be configurable by the user. It is used as a hint in IntelliJ for where to place the
+    # corresponding IntelliJ module.
+    source_info = await Get(BSPBuildTargetSourcesInfo, BSPBuildTargetInternal, request.bsp_target)
+    if source_info.source_roots:
+        roots = [build_root.pathlib_path.joinpath(p) for p in source_info.source_roots]
     else:
-        raise ValueError("Multiple source roots not supported for BSP build target.")
+        roots = [build_root.pathlib_path]
 
     return GenerateOneBSPBuildTargetResult(
         build_target=BuildTarget(
             id=BuildTargetIdentifier(f"pants:{request.bsp_target.name}"),
             display_name=request.bsp_target.name,
-            base_directory=base_dir.as_uri(),
+            base_directory=roots[0].as_uri(),
             tags=(),
             capabilities=BuildTargetCapabilities(
                 can_compile=any(r.can_compile for r in metadata_results),
@@ -313,34 +335,12 @@ async def materialize_bsp_build_target_sources(
     build_root: BuildRoot,
 ) -> MaterializeBuildTargetSourcesResult:
     bsp_target = await Get(BSPBuildTargetInternal, BuildTargetIdentifier, request.bsp_target_id)
-    targets = await Get(
-        Targets,
-        AddressSpecs,
-        bsp_target.specs.address_specs,
-    )
-    targets_with_sources = [tgt for tgt in targets if tgt.has_field(SourcesField)]
+    source_info = await Get(BSPBuildTargetSourcesInfo, BSPBuildTargetInternal, bsp_target)
 
-    sources_paths = await MultiGet(
-        Get(SourcesPaths, SourcesPathsRequest(tgt[SourcesField])) for tgt in targets_with_sources
-    )
-    merged_sources_dirs: set[str] = set()
-    merged_sources_files: set[str] = set()
-    for sp in sources_paths:
-        merged_sources_dirs.update(sp.dirs)
-        merged_sources_files.update(sp.files)
-    _logger.info(f"merged_sources_dirs={merged_sources_dirs}")
-    _logger.info(f"merged_sources_files={merged_sources_files}")
-
-    source_roots_result = await Get(
-        SourceRootsResult, SourceRootsRequest, SourceRootsRequest.for_files(merged_sources_files)
-    )
-    source_root_paths = {x.path for x in source_roots_result.path_to_root.values()}
-    if len(source_root_paths) == 0:
-        base_dir = build_root.pathlib_path
-    elif len(source_root_paths) == 1:
-        base_dir = build_root.pathlib_path.joinpath(list(source_root_paths)[0])
+    if source_info.source_roots:
+        roots = [build_root.pathlib_path.joinpath(p) for p in source_info.source_roots]
     else:
-        raise ValueError("Multiple source roots not supported for BSP build target.")
+        roots = [build_root.pathlib_path]
 
     sources_item = SourcesItem(
         target=request.bsp_target_id,
@@ -350,9 +350,9 @@ async def materialize_bsp_build_target_sources(
                 kind=SourceItemKind.FILE,
                 generated=False,
             )
-            for filename in sorted(merged_sources_files)
+            for filename in sorted(source_info.source_files)
         ),
-        roots=(base_dir.as_uri(),),
+        roots=tuple(r.as_uri() for r in roots),
     )
 
     return MaterializeBuildTargetSourcesResult(sources_item)


### PR DESCRIPTION
Cleanups of BSP rules:

- Refactor resolution of BSP build target identifiers to the internal Pants metadata into a single rule.
- Compute source files and roots for a BSP build target in one place.