### PR TITLE
Upgrade Pex to 2.1.73.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -14,7 +14,7 @@ humbug==0.2.7
 
 ijson==3.1.4
 packaging==21.3
-pex==2.1.72
+pex==2.1.73
 psutil==5.9.0
 pytest>=6.2.4,<8  # This should be compatible with pytest.py, although it can be looser so that we don't over-constrain pantsbuild.pants.testutil
 python-lsp-jsonrpc==1.0.0

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -18,7 +18,7 @@
 //     "ijson==3.1.4",
 //     "mypy-typing-asserts==0.1.1",
 //     "packaging==21.3",
-//     "pex==2.1.72",
+//     "pex==2.1.73",
 //     "psutil==5.9.0",
 //     "pydevd-pycharm==203.5419.8",
 //     "pytest<8,>=6.2.4",
@@ -548,13 +548,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "970cab3d33c035a5debe89f6567b4bcf96c5a4c7dd4078d783a1b76db9ae87ba",
-              "url": "https://files.pythonhosted.org/packages/51/7f/95ebe2d0417df4d165087d46bc6a9e49df5bccd01a9b519e1adcf02e3479/pex-2.1.72-py2.py3-none-any.whl"
+              "hash": "b6610d4f25fbf49f93997f2a889959f064ede535529e1355748b4a116e3b0352",
+              "url": "https://files.pythonhosted.org/packages/df/cb/6f7720c4769486f7e37cbaa457e179944432e62936a25a4b106dbc2a5827/pex-2.1.73-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d218670646e0b786d296a8ef60a5f6321b72fd3d6f0469bdd4784a9b2bd5ce60",
-              "url": "https://files.pythonhosted.org/packages/03/c6/bce571e4faabaf4bc5b538136ce5ab574a77119f6f2b40cffde7d2d4bf18/pex-2.1.72.tar.gz"
+              "hash": "3b1226d2f147d0969d68a306aca34d8fc980eee7b591ace3a5ab922ba5cd1a25",
+              "url": "https://files.pythonhosted.org/packages/25/60/6aeba685a9724d57dd224116bba34854621e1f46267857830b62e9647eff/pex-2.1.73.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -562,7 +562,7 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.11,>=2.7",
-          "version": "2.1.72"
+          "version": "2.1.73"
         },
         {
           "artifacts": [
@@ -739,13 +739,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "b555252a95bbb2a37a97b5ac2eb050c436f7989993565f5e0c9128fcaacadd0e",
-              "url": "https://files.pythonhosted.org/packages/36/e6/dea2b8cd72cf0600f3c2572fb5a48b01aa8e8fd8703c830dab972036c34c/pytest-7.1.0-py3-none-any.whl"
+              "hash": "92f723789a8fdd7180b6b06483874feca4c48a5c76968e03bb3e7f806a1869ea",
+              "url": "https://files.pythonhosted.org/packages/d2/ac/556e4410326ce77eeb1d1ec35a3e3ec847fb3e5cb30673729d2eeeffc970/pytest-7.1.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f1089d218cfcc63a212c42896f1b7fbf096874d045e1988186861a1a87d27b47",
-              "url": "https://files.pythonhosted.org/packages/6e/1c/5a8a4ae3548eaa9a082a25cd6118f166d6bbe440300b3c57c4904cc47935/pytest-7.1.0.tar.gz"
+              "hash": "841132caef6b1ad17a9afde46dc4f6cfa59a05f9555aae5151f73bdf2820ca63",
+              "url": "https://files.pythonhosted.org/packages/f0/8c/1fb22b4e526a7461b4797042ed9d9c26a7a69673a148709bf50692b874fb/pytest-7.1.1.tar.gz"
             }
           ],
           "project_name": "pytest",
@@ -768,7 +768,7 @@
             "xmlschema; extra == \"testing\""
           ],
           "requires_python": ">=3.7",
-          "version": "7.1"
+          "version": "7.1.1"
         },
         {
           "artifacts": [
@@ -1538,13 +1538,13 @@
         }
       ],
       "platform_tag": [
-        "cp39",
-        "cp39",
-        "macosx_11_0_arm64"
+        "cp310",
+        "cp310",
+        "manylinux_2_35_x86_64"
       ]
     }
   ],
-  "pex_version": "2.1.72",
+  "pex_version": "2.1.73",
   "prefer_older_binary": false,
   "requirements": [
     "PyYAML<7.0,>=6.0",
@@ -1556,7 +1556,7 @@
     "ijson==3.1.4",
     "mypy-typing-asserts==0.1.1",
     "packaging==21.3",
-    "pex==2.1.72",
+    "pex==2.1.73",
     "psutil==5.9.0",
     "pydevd-pycharm==203.5419.8",
     "pytest<8,>=6.2.4",

--- a/src/python/pants/backend/python/subsystems/lambdex.lock
+++ b/src/python/pants/backend/python/subsystems/lambdex.lock
@@ -49,13 +49,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "970cab3d33c035a5debe89f6567b4bcf96c5a4c7dd4078d783a1b76db9ae87ba",
-              "url": "https://files.pythonhosted.org/packages/51/7f/95ebe2d0417df4d165087d46bc6a9e49df5bccd01a9b519e1adcf02e3479/pex-2.1.72-py2.py3-none-any.whl"
+              "hash": "b6610d4f25fbf49f93997f2a889959f064ede535529e1355748b4a116e3b0352",
+              "url": "https://files.pythonhosted.org/packages/df/cb/6f7720c4769486f7e37cbaa457e179944432e62936a25a4b106dbc2a5827/pex-2.1.73-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d218670646e0b786d296a8ef60a5f6321b72fd3d6f0469bdd4784a9b2bd5ce60",
-              "url": "https://files.pythonhosted.org/packages/03/c6/bce571e4faabaf4bc5b538136ce5ab574a77119f6f2b40cffde7d2d4bf18/pex-2.1.72.tar.gz"
+              "hash": "3b1226d2f147d0969d68a306aca34d8fc980eee7b591ace3a5ab922ba5cd1a25",
+              "url": "https://files.pythonhosted.org/packages/25/60/6aeba685a9724d57dd224116bba34854621e1f46267857830b62e9647eff/pex-2.1.73.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -63,17 +63,17 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.11,>=2.7",
-          "version": "2.1.72"
+          "version": "2.1.73"
         }
       ],
       "platform_tag": [
-        "cp39",
-        "cp39",
-        "macosx_11_0_arm64"
+        "cp310",
+        "cp310",
+        "manylinux_2_35_x86_64"
       ]
     }
   ],
-  "pex_version": "2.1.72",
+  "pex_version": "2.1.73",
   "prefer_older_binary": false,
   "requirements": [
     "lambdex==0.1.6"

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -39,9 +39,9 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."
 
-    default_version = "v2.1.72"
+    default_version = "v2.1.73"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.1.72,<3.0"
+    version_constraints = ">=2.1.73,<3.0"
 
     @classproperty
     def default_known_versions(cls):
@@ -50,8 +50,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "fe5bd1fddf306e40d1828169dfd65c9faed98d2d98ebaba2753d99a91343014d",
-                    "3723386",
+                    "0f30b06c02743393b745497580a410d28055b0de022a27cbb8e460845a6ba1c9",
+                    "3723175",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64"]


### PR DESCRIPTION
This picks up several lockfile fixes.

See the changelog here:
  https://github.com/pantsbuild/pex/releases/tag/v2.1.73

Fixes #14857
Fixes #14859

[ci skip-rust]
[ci skip-build-wheels]