### PR TITLE
Unify glob-matching implementations to fix malformed snapshot created by subsetting

### DIFF
--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -47,9 +47,7 @@ use parking_lot::Mutex;
 use protos::require_digest;
 use serde_derive::Serialize;
 use std::collections::BTreeMap;
-use store::{
-  Snapshot, SnapshotOps, SnapshotOpsError, Store, StoreFileByDigest, SubsetParams, UploadSummary,
-};
+use store::{Snapshot, SnapshotOps, Store, StoreFileByDigest, SubsetParams, UploadSummary};
 
 #[derive(Debug)]
 enum ExitCode {
@@ -622,11 +620,7 @@ async fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
               .strip_prefix(subset_digest, &RelativePath::new(prefix_to_strip)?)
               .await;
           }
-          digest = result.map_err(|err| match err {
-            SnapshotOpsError::String(string)
-            | SnapshotOpsError::DigestMergeFailure(string)
-            | SnapshotOpsError::GlobMatchError(string) => string,
-          })?;
+          digest = result?;
 
           // TODO: The below operations don't strictly need persistence: we could render the
           // relevant `DigestTrie` directly. See #13112.

--- a/src/rust/engine/fs/src/directory.rs
+++ b/src/rust/engine/fs/src/directory.rs
@@ -157,6 +157,15 @@ pub struct Name(Intern<String>);
 // static. Switching to `ArcIntern` would get accurate counts at the cost of performance and size.
 known_deep_size!(0; Name);
 
+impl Name {
+  pub fn new(name: &str) -> Self {
+    if cfg!(debug_assertions) {
+      assert!(Path::new(name).components().count() < 2)
+    }
+    Name(Intern::from(name))
+  }
+}
+
 impl Deref for Name {
   type Target = Intern<String>;
 
@@ -194,7 +203,7 @@ pub struct Directory {
 }
 
 impl Directory {
-  fn new(name: Name, entries: Vec<Entry>) -> Self {
+  pub(crate) fn new(name: Name, entries: Vec<Entry>) -> Self {
     Self::from_digest_tree(name, DigestTrie(entries.into()))
   }
 
@@ -650,7 +659,7 @@ impl DigestTrie {
   /// Return the Entry at the given relative path in the trie, or None if no such path was present.
   ///
   /// An error will be returned if the given path attempts to traverse below a file entry.
-  pub fn entry<'a>(&'a self, path: &RelativePath) -> Result<Option<&'a Entry>, String> {
+  pub fn entry<'a>(&'a self, path: &Path) -> Result<Option<&'a Entry>, String> {
     let mut tree = self;
     let mut path_so_far = PathBuf::new();
     let mut components = path.components().peekable();

--- a/src/rust/engine/fs/src/directory.rs
+++ b/src/rust/engine/fs/src/directory.rs
@@ -100,19 +100,7 @@ impl DirectoryDigest {
   ///
   /// Use of this method should be rare: code should prefer to pass around a `DirectoryDigest` rather
   /// than to create one from a `Digest` (as the latter requires loading the content from disk).
-  ///
-  /// TODO: If a callsite needs to create a `DirectoryDigest` as a convenience (i.e. in a location
-  /// where its signature could be changed to accept a `DirectoryDigest` instead of constructing
-  /// one) during the porting effort of #13112, it should use `todo_from_digest` rather than
-  /// `from_persisted_digest`.
   pub fn from_persisted_digest(digest: Digest) -> Self {
-    Self { digest, tree: None }
-  }
-
-  /// Marks a callsite that is creating a `DirectoryDigest` as a temporary convenience, rather than
-  /// accepting a `DirectoryDigest` in its signature. All usages of this method should be removed
-  /// before closing #13112.
-  pub fn todo_from_digest(digest: Digest) -> Self {
     Self { digest, tree: None }
   }
 

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -48,12 +48,12 @@ pub enum PathGlob {
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub(crate) struct GlobParsedSource(String);
+struct GlobParsedSource(String);
 
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct PathGlobIncludeEntry {
-  pub input: GlobParsedSource,
-  pub globs: Vec<PathGlob>,
+  input: GlobParsedSource,
+  globs: Vec<PathGlob>,
 }
 
 impl PathGlob {
@@ -239,18 +239,6 @@ impl PathGlob {
   }
 }
 
-///
-/// This struct extracts out just the include and exclude globs from the `PreparedPathGlobs`
-/// struct. It is a temporary measure to try to share some code between the glob matching
-/// implementation in this file and in snapshot_ops.rs.
-///
-/// TODO(#9967): Remove this struct!
-///
-pub struct ExpandablePathGlobs {
-  pub include: Vec<PathGlob>,
-  pub exclude: Arc<GitignoreStyleExcludes>,
-}
-
 #[derive(Debug, Clone)]
 pub struct PreparedPathGlobs {
   pub(crate) include: Vec<PathGlobIncludeEntry>,
@@ -261,13 +249,6 @@ pub struct PreparedPathGlobs {
 }
 
 impl PreparedPathGlobs {
-  pub fn as_expandable_globs(&self) -> ExpandablePathGlobs {
-    ExpandablePathGlobs {
-      include: Iterator::flatten(self.include.iter().map(|pgie| pgie.globs.clone())).collect(),
-      exclude: self.exclude.clone(),
-    }
-  }
-
   fn parse_patterns_from_include(
     include: &[PathGlobIncludeEntry],
   ) -> Result<Vec<glob::Pattern>, String> {

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -36,8 +36,7 @@ pub use crate::directory::{
   DigestTrie, DirectoryDigest, EMPTY_DIGEST_TREE, EMPTY_DIRECTORY_DIGEST,
 };
 pub use crate::glob_matching::{
-  ExpandablePathGlobs, GlobMatching, PathGlob, PreparedPathGlobs, DOUBLE_STAR_GLOB,
-  SINGLE_STAR_GLOB,
+  GlobMatching, PathGlob, PreparedPathGlobs, DOUBLE_STAR_GLOB, SINGLE_STAR_GLOB,
 };
 
 use std::cmp::min;

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -667,6 +667,59 @@ impl Vfs<io::Error> for Arc<PosixFS> {
 }
 
 #[async_trait]
+impl Vfs<String> for DigestTrie {
+  async fn read_link(&self, link: &Link) -> Result<PathBuf, String> {
+    // DigestTrie does not currently support Links.
+    Err(format!("{:?} does not exist within this Snapshot.", link))
+  }
+
+  async fn scandir(&self, dir: Dir) -> Result<Arc<DirectoryListing>, String> {
+    // TODO(#14890): Change interface to take a reference to an Entry, and to avoid absolute paths.
+    // That would avoid both the need to handle this root case, and the need to recurse in `entry`
+    // down into children.
+    let directory = if dir.0.components().next().is_none() {
+      directory::Directory::new(directory::Name::new(""), self.entries().into())
+    } else {
+      let entry = self
+        .entry(&dir.0)?
+        .ok_or_else(|| format!("{:?} does not exist within this Snapshot.", dir))?;
+      match entry {
+        directory::Entry::File(_) => {
+          return Err(format!(
+            "Path `{}` was a file rather than a directory.",
+            dir.0.display()
+          ))
+        }
+        directory::Entry::Directory(d) => d.clone(),
+      }
+    };
+
+    Ok(Arc::new(DirectoryListing(
+      directory
+        .tree()
+        .entries()
+        .iter()
+        .map(|child| match child {
+          directory::Entry::File(f) => Stat::File(File {
+            path: dir.0.join(f.name().as_ref()),
+            is_executable: f.is_executable(),
+          }),
+          directory::Entry::Directory(d) => Stat::Dir(Dir(dir.0.join(d.name().as_ref()))),
+        })
+        .collect(),
+    )))
+  }
+
+  fn is_ignored(&self, _stat: &Stat) -> bool {
+    false
+  }
+
+  fn mk_error(msg: &str) -> String {
+    msg.to_owned()
+  }
+}
+
+#[async_trait]
 pub trait PathStatGetter<E> {
   async fn path_stats(&self, paths: Vec<PathBuf>) -> Result<Vec<Option<PathStat>>, E>;
 }

--- a/src/rust/engine/fs/src/posixfs_tests.rs
+++ b/src/rust/engine/fs/src/posixfs_tests.rs
@@ -1,18 +1,14 @@
-use tempfile;
-use testutil;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use hashing::EMPTY_DIGEST;
+use testutil::make_file;
 
 use crate::{
-  Dir, DirectoryListing, File, GitignoreStyleExcludes, GlobExpansionConjunction, GlobMatching,
-  Link, PathGlobs, PathStat, PathStatGetter, PosixFS, Stat, StrictGlobMatching, SymlinkBehavior,
-  Vfs,
+  DigestTrie, Dir, DirectoryListing, File, GitignoreStyleExcludes, GlobExpansionConjunction,
+  GlobMatching, Link, PathGlobs, PathStat, PathStatGetter, PosixFS, Stat, StrictGlobMatching,
+  SymlinkBehavior, Vfs,
 };
-
-use async_trait::async_trait;
-use std;
-use std::collections::HashMap;
-use std::path::{Components, Path, PathBuf};
-use std::sync::Arc;
-use testutil::make_file;
 
 #[tokio::test]
 async fn is_executable_false() {
@@ -325,7 +321,30 @@ async fn memfs_expand_basic() {
   // Create two files, with the effect that there is a nested directory for the longer path.
   let p1 = PathBuf::from("some/file");
   let p2 = PathBuf::from("some/other");
-  let fs = Arc::new(MemFS::new(vec![p1.clone(), p2.join("file")]));
+  let p3 = p2.join("file");
+
+  let fs = DigestTrie::from_path_stats(
+    vec![
+      PathStat::file(
+        p1.clone(),
+        File {
+          path: p1.clone(),
+          is_executable: false,
+        },
+      ),
+      PathStat::file(
+        p3.clone(),
+        File {
+          path: p3.clone(),
+          is_executable: false,
+        },
+      ),
+    ],
+    &vec![(p1.clone(), EMPTY_DIGEST), (p3, EMPTY_DIGEST)]
+      .into_iter()
+      .collect(),
+  )
+  .unwrap();
   let globs = PathGlobs::new(
     vec!["some/*".into()],
     StrictGlobMatching::Ignore,
@@ -443,77 +462,4 @@ async fn test_basic_gitignore_functionality() {
   assert!(posix_fs_2.is_ignored(&stats[1]));
   assert!(!posix_fs_2.is_ignored(&stats[2]));
   assert!(posix_fs_2.is_ignored(&stats[3]));
-}
-
-///
-/// An in-memory implementation of Vfs, useful for precisely reproducing glob matching behavior for
-/// a set of file paths.
-///
-pub struct MemFS {
-  contents: HashMap<Dir, Arc<DirectoryListing>>,
-}
-
-impl MemFS {
-  pub fn new(paths: Vec<PathBuf>) -> MemFS {
-    let mut unordered_contents = HashMap::new();
-    let empty_path = PathBuf::new();
-    for path in paths {
-      Self::add_path(&mut unordered_contents, &empty_path, path.components());
-    }
-    let contents = unordered_contents
-      .into_iter()
-      .map(|(dir, mut stats)| {
-        stats.sort_by(|a, b| a.path().cmp(b.path()));
-        (dir, Arc::new(DirectoryListing(stats)))
-      })
-      .collect();
-    MemFS { contents }
-  }
-
-  fn add_path(
-    contents: &mut HashMap<Dir, Vec<Stat>>,
-    path_so_far: &Path,
-    mut remainder: Components,
-  ) -> bool {
-    if let Some(component) = remainder.next() {
-      // The component represents a directory if it has child components: otherwise, a file.
-      let path = path_so_far.join(component);
-      let stat = if Self::add_path(contents, &path, remainder) {
-        Stat::dir(path)
-      } else {
-        Stat::file(path, false)
-      };
-      contents
-        .entry(Dir(path_so_far.to_owned()))
-        .or_insert_with(Vec::new)
-        .push(stat);
-      true
-    } else {
-      false
-    }
-  }
-}
-
-#[async_trait]
-impl Vfs<String> for Arc<MemFS> {
-  async fn read_link(&self, link: &Link) -> Result<PathBuf, String> {
-    // The creation of a static filesystem does not allow for Links.
-    Err(format!("{:?} does not exist within this filesystem.", link))
-  }
-
-  async fn scandir(&self, dir: Dir) -> Result<Arc<DirectoryListing>, String> {
-    self
-      .contents
-      .get(&dir)
-      .cloned()
-      .ok_or_else(|| format!("{:?} does not exist within this filesystem.", dir))
-  }
-
-  fn is_ignored(&self, _stat: &Stat) -> bool {
-    false
-  }
-
-  fn mk_error(msg: &str) -> String {
-    msg.to_owned()
-  }
 }

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -33,7 +33,7 @@ mod snapshot_ops;
 mod snapshot_ops_tests;
 #[cfg(test)]
 mod snapshot_tests;
-pub use crate::snapshot_ops::{SnapshotOps, SnapshotOpsError, SubsetParams};
+pub use crate::snapshot_ops::{SnapshotOps, SubsetParams};
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Debug;
@@ -512,7 +512,7 @@ impl Store {
             )
           })?;
           if cfg!(debug_assertions) {
-            protos::verify_directory_canonical(digest, &directory).unwrap();
+            protos::verify_directory_canonical(digest, &directory)?;
           }
           Ok(directory)
         },

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -385,7 +385,11 @@ impl Store {
     let mut directories = Vec::new();
     tree.walk(&mut |_, entry| match entry {
       directory::Entry::Directory(d) => {
-        directories.push((Some(d.digest()), d.as_remexec_directory().to_bytes()))
+        let directory = d.as_remexec_directory();
+        if cfg!(debug_assertions) {
+          protos::verify_directory_canonical(d.digest(), &directory).unwrap();
+        }
+        directories.push((Some(d.digest()), directory.to_bytes()))
       }
       directory::Entry::File(_) => (),
     });
@@ -410,14 +414,18 @@ impl Store {
     initial_lease: bool,
   ) -> Result<Digest, String> {
     let local = self.local.clone();
-    local
+    let digest = local
       .store_bytes(
         EntryType::Directory,
         None,
         directory.to_bytes(),
         initial_lease,
       )
-      .await
+      .await?;
+    if cfg!(debug_assertions) {
+      protos::verify_directory_canonical(digest, directory)?;
+    }
+    Ok(digest)
   }
 
   ///

--- a/src/rust/engine/fs/store/src/snapshot_ops.rs
+++ b/src/rust/engine/fs/store/src/snapshot_ops.rs
@@ -1,25 +1,21 @@
 // Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+use std::collections::HashMap;
 use std::convert::From;
 use std::iter::Iterator;
-use std::path::PathBuf;
-use std::sync::Arc;
 
 use async_trait::async_trait;
 use bytes::BytesMut;
 use fs::{
-  directory, DigestTrie, DirectoryDigest, ExpandablePathGlobs, GitignoreStyleExcludes, PathGlob,
-  PreparedPathGlobs, RelativePath, DOUBLE_STAR_GLOB, EMPTY_DIRECTORY_DIGEST, SINGLE_STAR_GLOB,
+  directory, DigestTrie, DirectoryDigest, GlobMatching, PreparedPathGlobs, RelativePath,
+  EMPTY_DIRECTORY_DIGEST,
 };
 use futures::future::{self, FutureExt};
-use glob::Pattern;
-use hashing::{Digest, EMPTY_DIGEST};
-use indexmap::{self, IndexMap};
+use hashing::Digest;
 use itertools::Itertools;
 use log::log_enabled;
 use protos::gen::build::bazel::remote::execution::v2 as remexec;
-use protos::require_digest;
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub enum SnapshotOpsError {
@@ -173,384 +169,6 @@ async fn render_merge_error<T: SnapshotOps + 'static>(
 }
 
 ///
-/// When we evaluate a recursive glob during the subset() operation, we perform some relatively
-/// complex logic to coalesce globs in subdirectories, and to short-circuit retrieving
-/// subdirectories from the store at all if we don't need to inspect their contents
-/// (e.g. if a glob ends in "**"). This struct isolates that complexity, allowing the code in
-/// subset() to just operate on the higher-level GlobbedFilesAndDirectories struct.
-///
-struct IntermediateGlobbedFilesAndDirectories {
-  globbed_files: IndexMap<PathBuf, remexec::FileNode>,
-  globbed_directories: IndexMap<PathBuf, remexec::DirectoryNode>,
-  cur_dir_files: IndexMap<PathBuf, remexec::FileNode>,
-  cur_dir_directories: IndexMap<PathBuf, remexec::DirectoryNode>,
-  todo_directories: IndexMap<PathBuf, Vec<RestrictedPathGlob>>,
-  prefix: PathBuf,
-  multiple_globs: MultipleGlobs,
-}
-
-struct GlobbedFilesAndDirectories {
-  // All of the subdirectories of the source Directory that is currently being subsetted,
-  // *regardless of whether the glob is matched yet*.
-  cur_dir_directories: IndexMap<PathBuf, remexec::DirectoryNode>,
-  // All of the files of the source Directory matching the current glob.
-  globbed_files: IndexMap<PathBuf, remexec::FileNode>,
-  // All of the matching subdirectories of the source Directory *after* being subsetted to match the
-  // current glob.
-  globbed_directories: IndexMap<PathBuf, remexec::DirectoryNode>,
-  // All of the matching subdirectories of the source Directory, *before* being subsetted to match
-  // the current glob.
-  todo_directories: IndexMap<PathBuf, Vec<RestrictedPathGlob>>,
-  exclude: Arc<GitignoreStyleExcludes>,
-}
-
-impl IntermediateGlobbedFilesAndDirectories {
-  fn from_cur_dir_and_globs(
-    cur_dir: remexec::Directory,
-    multiple_globs: MultipleGlobs,
-    prefix: PathBuf,
-  ) -> Self {
-    let cur_dir_files: IndexMap<PathBuf, remexec::FileNode> = cur_dir
-      .files
-      .into_iter()
-      .map(|file_node| (PathBuf::from(file_node.name.clone()), file_node))
-      .collect();
-    let cur_dir_directories: IndexMap<PathBuf, remexec::DirectoryNode> = cur_dir
-      .directories
-      .into_iter()
-      .map(|directory_node| (PathBuf::from(directory_node.name.clone()), directory_node))
-      .collect();
-
-    let globbed_files: IndexMap<PathBuf, remexec::FileNode> = IndexMap::new();
-    let globbed_directories: IndexMap<PathBuf, remexec::DirectoryNode> = IndexMap::new();
-    let todo_directories: IndexMap<PathBuf, Vec<RestrictedPathGlob>> = IndexMap::new();
-
-    IntermediateGlobbedFilesAndDirectories {
-      globbed_files,
-      globbed_directories,
-      cur_dir_files,
-      cur_dir_directories,
-      todo_directories,
-      prefix,
-      multiple_globs,
-    }
-  }
-
-  async fn populate_globbed_files_and_directories(
-    self,
-  ) -> Result<GlobbedFilesAndDirectories, SnapshotOpsError> {
-    let IntermediateGlobbedFilesAndDirectories {
-      mut globbed_files,
-      mut globbed_directories,
-      // NB: When iterating over files, we can remove them from `cur_dir_files` after they are
-      // successfully matched once, hence the `mut` declaration. This is a small
-      // optimization. However, when iterating over directories, different DirWildcard instances
-      // within a single Vec<PathGlob> can result in having multiple different DirWildcard instances
-      // created after matching against a single directory node! So we do *not* mark
-      // `cur_dir_directories` as `mut`.
-      mut cur_dir_files,
-      cur_dir_directories,
-      mut todo_directories,
-      prefix,
-      multiple_globs: MultipleGlobs { include, exclude },
-    } = self;
-
-    // Populate globbed_{files,directories} by iterating over all the globs.
-    for path_glob in include.into_iter() {
-      let wildcard = match &path_glob {
-        RestrictedPathGlob::Wildcard { wildcard } => wildcard,
-        RestrictedPathGlob::DirWildcard { wildcard, .. } => wildcard,
-      };
-
-      // TODO(#12462): Remove allow once upstream resolves https://github.com/rust-lang/rust-clippy/issues/6066.
-      #[allow(clippy::needless_collect)]
-      let matching_files: Vec<PathBuf> = cur_dir_files
-        .keys()
-        .filter(|path| {
-          // NB: match just the current path component against the wildcard, but use the prefix
-          // when checking against the `exclude` patterns!
-          wildcard.matches_path(path) && !exclude.is_ignored_path(&prefix.join(path), false)
-        })
-        .cloned()
-        .collect();
-      for file_path in matching_files.into_iter() {
-        // NB: remove any matched files from `cur_dir_files`, so they are successfully matched
-        // against at most once.
-        let file_node = cur_dir_files.remove(&file_path).unwrap();
-        globbed_files.insert(file_path, file_node);
-      }
-
-      // TODO(#12462): Remove allow once upstream resolves https://github.com/rust-lang/rust-clippy/issues/6066.
-      #[allow(clippy::needless_collect)]
-      let matching_directories: Vec<PathBuf> = cur_dir_directories
-        .keys()
-        .filter(|path| {
-          // NB: match just the current path component against the wildcard, but use the prefix
-          // when checking against the `exclude` patterns!
-          wildcard.matches_path(path) && !exclude.is_ignored_path(&prefix.join(path), true)
-        })
-        .cloned()
-        .collect();
-      for directory_path in matching_directories.into_iter() {
-        // NB: do *not* remove the directory for `cur_dir_directories` after it is matched
-        // successfully once!
-        let directory_node = cur_dir_directories.get(&directory_path).unwrap();
-
-        // TODO(#9967): Figure out how to consume the existing glob matching logic that works on
-        // `Vfs` instances!
-        match &path_glob {
-          RestrictedPathGlob::Wildcard { wildcard } => {
-            // NB: We interpret globs such that the *only* way to have a glob match the contents of
-            // a whole directory is to end in '/**' or '/**/*'.
-
-            if exclude.maybe_is_parent_of_ignored_path(&directory_path) {
-              // Leave this directory in todo_directories, so we process ignore patterns correctly.
-              continue;
-            }
-
-            if *wildcard == *DOUBLE_STAR_GLOB {
-              globbed_directories.insert(directory_path, directory_node.clone());
-            } else if !globbed_directories.contains_key(&directory_path) {
-              // We know this matched a directory node, but not its contents. We produce an empty
-              // directory here. We avoid doing this if we have already globbed a full directory,
-              // since we take the union of all matched subglobs.
-              let mut empty_node = directory_node.clone();
-              empty_node.digest = Some(to_bazel_digest(EMPTY_DIGEST));
-              globbed_directories.insert(directory_path, empty_node);
-            };
-          }
-          RestrictedPathGlob::DirWildcard {
-            wildcard,
-            remainder,
-          } => {
-            let mut subdir_globs: Vec<RestrictedPathGlob> = vec![];
-            if (*wildcard == *DOUBLE_STAR_GLOB) || (*wildcard == *SINGLE_STAR_GLOB) {
-              // Here we short-circuit all cases which would swallow up a directory without
-              // subsetting it or needing to perform any further recursive work.
-              let is_short_circuit_pattern: bool = match &remainder[..] {
-                [] => true,
-                // NB: Very often, /**/* is seen ending zsh-style globs, which means the same as
-                // ending in /**. Because we want to *avoid* recursing and just use the subdirectory
-                // as-is for /**/* and /**, we `continue` here in both cases.
-                [single_glob] if *single_glob == *SINGLE_STAR_GLOB => true,
-                [double_glob] if *double_glob == *DOUBLE_STAR_GLOB => true,
-                [double_glob, single_glob]
-                  if *double_glob == *DOUBLE_STAR_GLOB && *single_glob == *SINGLE_STAR_GLOB =>
-                {
-                  true
-                }
-                _ => false,
-              };
-              if is_short_circuit_pattern
-                && !exclude.maybe_is_parent_of_ignored_path(&directory_path)
-              {
-                globbed_directories.insert(directory_path, directory_node.clone());
-                continue;
-              }
-              // In this case, there is a remainder glob which will be used to subset the contents
-              // of any subdirectories. We ensure ** is recursive by cloning the ** and all the
-              // remainder globs and pushing it to `subdir_globs` whenever we need to recurse into
-              // subdirectories.
-              let with_double_star = RestrictedPathGlob::DirWildcard {
-                wildcard: wildcard.clone(),
-                remainder: remainder.clone(),
-              };
-              subdir_globs.push(with_double_star);
-            } else {
-              assert_ne!(0, remainder.len());
-            }
-            match remainder.len() {
-              0 => (),
-              1 => {
-                let next_glob = RestrictedPathGlob::Wildcard {
-                  wildcard: remainder.get(0).unwrap().clone(),
-                };
-                subdir_globs.push(next_glob);
-              }
-              _ => {
-                let next_glob = RestrictedPathGlob::DirWildcard {
-                  wildcard: remainder.get(0).unwrap().clone(),
-                  remainder: remainder[1..].to_vec(),
-                };
-                subdir_globs.push(next_glob);
-              }
-            }
-            // Append to the existing globs, and collate at the end of this iteration.
-            let entry = todo_directories
-              .entry(directory_path)
-              .or_insert_with(Vec::new);
-            entry.extend(subdir_globs);
-          }
-        }
-      }
-    }
-
-    Ok(GlobbedFilesAndDirectories {
-      cur_dir_directories,
-      globbed_files,
-      globbed_directories,
-      todo_directories,
-      exclude,
-    })
-  }
-}
-
-async fn snapshot_glob_match<T: SnapshotOps + 'static>(
-  store: T,
-  digest: Digest,
-  path_globs: PreparedPathGlobs,
-) -> Result<Digest, SnapshotOpsError> {
-  // Split the globs into PathGlobs that can be incrementally matched against individual directory
-  // components.
-  let initial_match_context = UnexpandedSubdirectoryContext {
-    digest,
-    multiple_globs: path_globs.as_expandable_globs().into(),
-  };
-  let mut unexpanded_stack: IndexMap<PathBuf, UnexpandedSubdirectoryContext> =
-    [(PathBuf::new(), initial_match_context)]
-      .iter()
-      .map(|(a, b)| (a.clone(), b.clone()))
-      .collect();
-  let mut partially_expanded_stack: IndexMap<PathBuf, PartiallyExpandedDirectoryContext> =
-    IndexMap::new();
-
-  // 1. Determine all the digests we need to recurse through and modify in order to respect a glob
-  // which may match over multiple contiguous directory components.
-  while let Some((
-    prefix,
-    UnexpandedSubdirectoryContext {
-      digest,
-      multiple_globs,
-    },
-  )) = unexpanded_stack.pop()
-  {
-    // 1a. Extract a single level of directory structure from the digest.
-    let cur_dir = store
-      .load_directory(digest)
-      .await?
-      .ok_or_else(|| format!("directory digest {:?} was not found!", digest))?;
-
-    // 1b. Filter files and directories by globs.
-    let intermediate_globbed = IntermediateGlobbedFilesAndDirectories::from_cur_dir_and_globs(
-      cur_dir,
-      multiple_globs,
-      prefix.clone(),
-    );
-    let GlobbedFilesAndDirectories {
-      cur_dir_directories,
-      globbed_files,
-      globbed_directories,
-      todo_directories,
-      exclude,
-    } = intermediate_globbed
-      .populate_globbed_files_and_directories()
-      .await?;
-
-    // 1c. Push context structs that specify unexpanded directories onto `unexpanded_stack`.
-    let dependencies: Vec<PathBuf> = todo_directories
-      .keys()
-      .filter_map(|subdir_path| {
-        // If we ever encounter a directory *with* a remainder, we have to ensure that that
-        // directory is *not* in `globbed_directories`, which are *not* subsetted at all.
-        // NB: Because our goal is to *union* all of the includes, if a directory is in
-        // `globbed_directories`, we can skip processing it for subsetting here!
-        if globbed_directories.contains_key(subdir_path) {
-          None
-        } else {
-          Some(prefix.join(subdir_path))
-        }
-      })
-      .collect();
-
-    for (subdir_name, all_path_globs) in todo_directories.into_iter() {
-      let full_name = prefix.join(&subdir_name);
-      let bazel_digest = cur_dir_directories
-        .get(&subdir_name)
-        .unwrap()
-        .digest
-        .clone();
-      // TODO(tonic): Use require_digest here by figure out how to properly return the error.
-      let digest = require_digest(bazel_digest.as_ref())
-        .map_err(|msg| SnapshotOpsError::String(format!("Failed to parse digest: {}", msg)))?;
-      let multiple_globs = MultipleGlobs {
-        include: all_path_globs,
-        exclude: exclude.clone(),
-      };
-      unexpanded_stack.insert(
-        full_name,
-        UnexpandedSubdirectoryContext {
-          digest,
-          multiple_globs,
-        },
-      );
-    }
-
-    // 1d. Push a context struct onto `partially_expanded_stack` which has "dependencies" on all
-    // subdirectories to be globbed in `directory_promises`. IndexMap is backed by a vector and can
-    // act as a stack, so we can be sure that when we finally retrieve this context struct from the
-    // stack, we will have already globbed all of its subdirectories.
-    let partially_expanded_context = PartiallyExpandedDirectoryContext {
-      files: globbed_files.into_iter().map(|(_, node)| node).collect(),
-      known_directories: globbed_directories
-        .into_iter()
-        .map(|(_, node)| node)
-        .collect(),
-      directory_promises: dependencies,
-    };
-    partially_expanded_stack.insert(prefix, partially_expanded_context);
-  }
-
-  // 2. Zip back up the recursively subsetted directory protos.
-  let mut completed_digests: IndexMap<PathBuf, Digest> = IndexMap::new();
-  while let Some((
-    prefix,
-    PartiallyExpandedDirectoryContext {
-      files,
-      known_directories,
-      directory_promises,
-    },
-  )) = partially_expanded_stack.pop()
-  {
-    let completed_nodes: Vec<remexec::DirectoryNode> = directory_promises
-        .into_iter()
-        .map(|dependency| {
-          // NB: Note that all "dependencies" here are subdirectories that need to be globbed before
-          // their parent directory can be entered into the store.
-          let digest = completed_digests.get(&dependency).ok_or_else(|| {
-            format!(
-              "expected subdirectory to glob {:?} to be available from completed_digests {:?} -- internal error",
-              &dependency, &completed_digests
-            )
-          })?;
-          // NB: Get the name *relative* to the current directory.
-          let name = dependency.strip_prefix(prefix.clone()).map_err(|e| format!("{:?}", e))?;
-          let fixed_directory_node = remexec::DirectoryNode {
-            name: format!("{}", name.display()),
-            digest: Some(to_bazel_digest(*digest)),
-          };
-          Ok(fixed_directory_node)
-        })
-        .collect::<Result<Vec<remexec::DirectoryNode>, String>>()?;
-
-    // Create the new protobuf with the merged nodes.
-    let all_directories: Vec<remexec::DirectoryNode> = known_directories
-      .into_iter()
-      .chain(completed_nodes.into_iter())
-      .collect();
-    let final_directory = remexec::Directory {
-      files,
-      directories: all_directories,
-      ..remexec::Directory::default()
-    };
-    let digest = store.record_directory(&final_directory).await?;
-    completed_digests.insert(prefix, digest);
-  }
-
-  let final_digest = completed_digests.get(&PathBuf::new()).unwrap();
-  Ok(*final_digest)
-}
-
-///
 /// High-level operations to manipulate and merge `Digest`s.
 ///
 /// These methods take care to avoid redundant work when traversing Directory protos. Prefer to use
@@ -616,16 +234,22 @@ pub trait SnapshotOps: Clone + Send + Sync + 'static {
     &self,
     directory_digest: DirectoryDigest,
     params: SubsetParams,
-  ) -> Result<DirectoryDigest, SnapshotOpsError> {
-    // TODO: Port subset for #13112. For now, we just ensure that the directory is persisted so
-    // that we can load it while subsetting.
-    let input_digest = directory_digest.todo_as_digest();
-    let tree = self.load_digest_trie(directory_digest).await?;
-    let _ = self.record_digest_trie(tree).await?;
+  ) -> Result<DirectoryDigest, String> {
+    let input_tree = self.load_digest_trie(directory_digest.clone()).await?;
+    let path_stats = input_tree
+      .expand_globs(params.globs, None)
+      .await
+      .map_err(|err| format!("Error matching globs against {directory_digest:?}: {}", err))?;
 
-    let SubsetParams { globs } = params;
-    let output_digest = snapshot_glob_match(self.clone(), input_digest, globs).await?;
-    Ok(DirectoryDigest::todo_from_digest(output_digest))
+    let mut files = HashMap::new();
+    input_tree.walk(&mut |path, entry| match entry {
+      directory::Entry::File(f) => {
+        files.insert(path.to_owned(), f.digest());
+      }
+      directory::Entry::Directory(_) => (),
+    });
+
+    Ok(DigestTrie::from_path_stats(path_stats, &files)?.into())
   }
 
   async fn create_empty_dir(
@@ -634,67 +258,4 @@ pub trait SnapshotOps: Clone + Send + Sync + 'static {
   ) -> Result<DirectoryDigest, SnapshotOpsError> {
     self.add_prefix(EMPTY_DIRECTORY_DIGEST.clone(), path).await
   }
-}
-
-struct PartiallyExpandedDirectoryContext {
-  pub files: Vec<remexec::FileNode>,
-  pub known_directories: Vec<remexec::DirectoryNode>,
-  pub directory_promises: Vec<PathBuf>,
-}
-
-#[derive(Clone, Debug)]
-enum RestrictedPathGlob {
-  Wildcard {
-    wildcard: Pattern,
-  },
-  DirWildcard {
-    wildcard: Pattern,
-    remainder: Vec<Pattern>,
-  },
-}
-
-impl From<PathGlob> for RestrictedPathGlob {
-  fn from(glob: PathGlob) -> Self {
-    match glob {
-      PathGlob::Wildcard { wildcard, .. } => RestrictedPathGlob::Wildcard { wildcard },
-      PathGlob::DirWildcard {
-        wildcard,
-        remainder,
-        ..
-      } => RestrictedPathGlob::DirWildcard {
-        wildcard,
-        remainder,
-      },
-    }
-  }
-}
-
-// TODO(tonic): Replace uses of this method with `.into` or equivalent.
-fn to_bazel_digest(digest: Digest) -> remexec::Digest {
-  remexec::Digest {
-    hash: digest.hash.to_hex(),
-    size_bytes: digest.size_bytes as i64,
-  }
-}
-
-#[derive(Clone)]
-struct MultipleGlobs {
-  pub include: Vec<RestrictedPathGlob>,
-  pub exclude: Arc<GitignoreStyleExcludes>,
-}
-
-impl From<ExpandablePathGlobs> for MultipleGlobs {
-  fn from(globs: ExpandablePathGlobs) -> Self {
-    let ExpandablePathGlobs { include, exclude } = globs;
-    MultipleGlobs {
-      include: include.into_iter().map(|x| x.into()).collect(),
-      exclude,
-    }
-  }
-}
-
-#[derive(Clone)]
-struct UnexpandedSubdirectoryContext {
-  pub digest: Digest,
-  pub multiple_globs: MultipleGlobs,
 }

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -41,7 +41,7 @@ use hashing::Digest;
 use protos::gen::build::bazel::remote::execution::v2 as remexec;
 use remexec::ExecutedActionMetadata;
 use serde::{Deserialize, Serialize};
-use store::{SnapshotOps, SnapshotOpsError, Store};
+use store::{SnapshotOps, Store};
 use workunit_store::{RunId, RunningWorkunit, WorkunitStore};
 
 pub mod bounded;
@@ -241,7 +241,7 @@ impl InputDigests {
     input_files: DirectoryDigest,
     immutable_inputs: BTreeMap<RelativePath, DirectoryDigest>,
     use_nailgun: Vec<RelativePath>,
-  ) -> Result<Self, SnapshotOpsError> {
+  ) -> Result<Self, String> {
     // Collect all digests into `complete`.
     let mut complete_digests = try_join_all(
       immutable_inputs

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -304,7 +304,7 @@ fn remove_prefix_request_to_digest(
         .extract::<PyRef<PyRemovePrefix>>()
         .map_err(|e| throw(format!("{}", e)))?;
       let prefix = RelativePath::new(&py_remove_prefix.prefix)
-        .map_err(|e| throw(format!("The `prefix` must be relative: {:?}", e)))?;
+        .map_err(|e| throw(format!("The `prefix` must be relative: {}", e)))?;
       let res: NodeResult<_> = Ok((py_remove_prefix.digest.clone(), prefix));
       res
     })?;
@@ -313,7 +313,7 @@ fn remove_prefix_request_to_digest(
       .store()
       .strip_prefix(digest, &prefix)
       .await
-      .map_err(|e| throw(format!("{:?}", e)))?;
+      .map_err(throw)?;
     let gil = Python::acquire_gil();
     Snapshot::store_directory_digest(gil.python(), digest).map_err(throw)
   }
@@ -331,7 +331,7 @@ fn add_prefix_request_to_digest(
         .extract::<PyRef<PyAddPrefix>>()
         .map_err(|e| throw(format!("{}", e)))?;
       let prefix = RelativePath::new(&py_add_prefix.prefix)
-        .map_err(|e| throw(format!("The `prefix` must be relative: {:?}", e)))?;
+        .map_err(|e| throw(format!("The `prefix` must be relative: {}", e)))?;
       let res: NodeResult<(DirectoryDigest, RelativePath)> =
         Ok((py_add_prefix.digest.clone(), prefix));
       res
@@ -341,7 +341,7 @@ fn add_prefix_request_to_digest(
       .store()
       .add_prefix(digest, &prefix)
       .await
-      .map_err(|e| throw(format!("{:?}", e)))?;
+      .map_err(throw)?;
     let gil = Python::acquire_gil();
     Snapshot::store_directory_digest(gil.python(), digest).map_err(throw)
   }
@@ -377,10 +377,7 @@ fn merge_digests_request_to_digest(
         .map(|py_merge_digests| py_merge_digests.0.clone())
         .map_err(|e| throw(format!("{}", e)))
     })?;
-    let digest = store
-      .merge(digests)
-      .await
-      .map_err(|e| throw(format!("{:?}", e)))?;
+    let digest = store.merge(digests).await.map_err(throw)?;
     let gil = Python::acquire_gil();
     Snapshot::store_directory_digest(gil.python(), digest).map_err(throw)
   }
@@ -506,10 +503,7 @@ fn create_digest_to_digest(
   let store = context.core.store();
   async move {
     let digests = future::try_join_all(digest_futures).await.map_err(throw)?;
-    let digest = store
-      .merge(digests)
-      .await
-      .map_err(|e| throw(format!("{:?}", e)))?;
+    let digest = store.merge(digests).await.map_err(throw)?;
     let gil = Python::acquire_gil();
     Snapshot::store_directory_digest(gil.python(), digest).map_err(throw)
   }
@@ -536,7 +530,7 @@ fn digest_subset_to_digest(
     let digest = store
       .subset(original_digest, subset_params)
       .await
-      .map_err(|e| throw(format!("{:?}", e)))?;
+      .map_err(throw)?;
     let gil = Python::acquire_gil();
     Snapshot::store_directory_digest(gil.python(), digest).map_err(throw)
   }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -314,7 +314,7 @@ impl ExecuteProcess {
 
     input_digests_fut?
       .await
-      .map_err(|e| format!("Failed to merge input digests for process: {:?}", e))
+      .map_err(|e| format!("Failed to merge input digests for process: {}", e))
   }
 
   fn lift_process(value: &PyAny, input_digests: InputDigests) -> Result<Process, String> {


### PR DESCRIPTION
#14858 reported that an invalid `Snapshot` was being created, and reproducing in debug mode triggered `debug_assertions` related to the validity of `remexec::Directory`s created by the subset matching code.

Although porting the existing subset-matching code to `DigestTrie` _and_ fixing the bug would be one option, we've wanted to remove duplication between the "apply globs to a `Snapshot`" and "apply globs to the filesystem" codepaths for a long time (see #9967), and fixing the bug by unifying the codepaths kills two birds with one stone.

This change ports to implementing subset matching using `Vfs::expand_globs`, followed by the creation of a new `Snapshot` from the matches. This is definitely not as optimized as the direct subset matching was (`./cargo bench -p store -- subset` reports a change from ~20ms to ~100ms for 10k files), but it opens the door to unified optimization of _both_ our glob-expansion code and in-memory glob matching in parallel: see #14890.

Fixes #9967, fixes #14858, fixes #12462, and fixes #13112.