### PR TITLE
Unify glob-matching implementations to fix malformed snapshot created by subsetting (cherrypick of #14889)

### DIFF
--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -47,9 +47,7 @@ use parking_lot::Mutex;
 use protos::require_digest;
 use serde_derive::Serialize;
 use std::collections::BTreeMap;
-use store::{
-  Snapshot, SnapshotOps, SnapshotOpsError, Store, StoreFileByDigest, SubsetParams, UploadSummary,
-};
+use store::{Snapshot, SnapshotOps, Store, StoreFileByDigest, SubsetParams, UploadSummary};
 
 #[derive(Debug)]
 enum ExitCode {
@@ -622,11 +620,7 @@ async fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
               .strip_prefix(subset_digest, &RelativePath::new(prefix_to_strip)?)
               .await;
           }
-          digest = result.map_err(|err| match err {
-            SnapshotOpsError::String(string)
-            | SnapshotOpsError::DigestMergeFailure(string)
-            | SnapshotOpsError::GlobMatchError(string) => string,
-          })?;
+          digest = result?;
 
           // TODO: The below operations don't strictly need persistence: we could render the
           // relevant `DigestTrie` directly. See #13112.

--- a/src/rust/engine/fs/src/directory.rs
+++ b/src/rust/engine/fs/src/directory.rs
@@ -100,19 +100,7 @@ impl DirectoryDigest {
   ///
   /// Use of this method should be rare: code should prefer to pass around a `DirectoryDigest` rather
   /// than to create one from a `Digest` (as the latter requires loading the content from disk).
-  ///
-  /// TODO: If a callsite needs to create a `DirectoryDigest` as a convenience (i.e. in a location
-  /// where its signature could be changed to accept a `DirectoryDigest` instead of constructing
-  /// one) during the porting effort of #13112, it should use `todo_from_digest` rather than
-  /// `from_persisted_digest`.
   pub fn from_persisted_digest(digest: Digest) -> Self {
-    Self { digest, tree: None }
-  }
-
-  /// Marks a callsite that is creating a `DirectoryDigest` as a temporary convenience, rather than
-  /// accepting a `DirectoryDigest` in its signature. All usages of this method should be removed
-  /// before closing #13112.
-  pub fn todo_from_digest(digest: Digest) -> Self {
     Self { digest, tree: None }
   }
 
@@ -157,6 +145,15 @@ pub struct Name(Intern<String>);
 // static. Switching to `ArcIntern` would get accurate counts at the cost of performance and size.
 known_deep_size!(0; Name);
 
+impl Name {
+  pub fn new(name: &str) -> Self {
+    if cfg!(debug_assertions) {
+      assert!(Path::new(name).components().count() < 2)
+    }
+    Name(Intern::from(name))
+  }
+}
+
 impl Deref for Name {
   type Target = Intern<String>;
 
@@ -194,7 +191,7 @@ pub struct Directory {
 }
 
 impl Directory {
-  fn new(name: Name, entries: Vec<Entry>) -> Self {
+  pub(crate) fn new(name: Name, entries: Vec<Entry>) -> Self {
     Self::from_digest_tree(name, DigestTrie(entries.into()))
   }
 
@@ -650,7 +647,7 @@ impl DigestTrie {
   /// Return the Entry at the given relative path in the trie, or None if no such path was present.
   ///
   /// An error will be returned if the given path attempts to traverse below a file entry.
-  pub fn entry<'a>(&'a self, path: &RelativePath) -> Result<Option<&'a Entry>, String> {
+  pub fn entry<'a>(&'a self, path: &Path) -> Result<Option<&'a Entry>, String> {
     let mut tree = self;
     let mut path_so_far = PathBuf::new();
     let mut components = path.components().peekable();
@@ -660,8 +657,11 @@ impl DigestTrie {
 
       let matching_entry = tree
         .entries()
-        .iter()
-        .find(|entry| Path::new(entry.name().as_ref()).as_os_str() == component);
+        .binary_search_by_key(&component, |entry| {
+          Path::new(entry.name().as_ref()).as_os_str()
+        })
+        .ok()
+        .map(|idx| &tree.entries()[idx]);
       if components.peek().is_none() {
         return Ok(matching_entry);
       }
@@ -699,16 +699,15 @@ impl DigestTrie {
       return Ok(trees.pop().unwrap());
     }
 
-    // Merge and sort Entries.
+    // Merge sorted Entries.
     let input_entries = trees
       .iter()
-      .map(|tree| tree.entries())
-      .flatten()
-      .sorted_by(|a, b| a.name().cmp(&b.name()));
+      .map(|tree| tree.entries().iter())
+      .kmerge_by(|a, b| a.name() < b.name());
 
     // Then group by name, and merge into an output list.
     let mut entries: Vec<Entry> = Vec::new();
-    for (name, group) in &input_entries.into_iter().group_by(|e| e.name()) {
+    for (name, group) in &input_entries.group_by(|e| e.name()) {
       let mut group = group.peekable();
       let first = group.next().unwrap();
       if group.peek().is_none() {

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -48,12 +48,12 @@ pub enum PathGlob {
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub(crate) struct GlobParsedSource(String);
+struct GlobParsedSource(String);
 
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct PathGlobIncludeEntry {
-  pub input: GlobParsedSource,
-  pub globs: Vec<PathGlob>,
+  input: GlobParsedSource,
+  globs: Vec<PathGlob>,
 }
 
 impl PathGlob {
@@ -239,18 +239,6 @@ impl PathGlob {
   }
 }
 
-///
-/// This struct extracts out just the include and exclude globs from the `PreparedPathGlobs`
-/// struct. It is a temporary measure to try to share some code between the glob matching
-/// implementation in this file and in snapshot_ops.rs.
-///
-/// TODO(#9967): Remove this struct!
-///
-pub struct ExpandablePathGlobs {
-  pub include: Vec<PathGlob>,
-  pub exclude: Arc<GitignoreStyleExcludes>,
-}
-
 #[derive(Debug, Clone)]
 pub struct PreparedPathGlobs {
   pub(crate) include: Vec<PathGlobIncludeEntry>,
@@ -261,13 +249,6 @@ pub struct PreparedPathGlobs {
 }
 
 impl PreparedPathGlobs {
-  pub fn as_expandable_globs(&self) -> ExpandablePathGlobs {
-    ExpandablePathGlobs {
-      include: Iterator::flatten(self.include.iter().map(|pgie| pgie.globs.clone())).collect(),
-      exclude: self.exclude.clone(),
-    }
-  }
-
   fn parse_patterns_from_include(
     include: &[PathGlobIncludeEntry],
   ) -> Result<Vec<glob::Pattern>, String> {

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -36,8 +36,7 @@ pub use crate::directory::{
   DigestTrie, DirectoryDigest, EMPTY_DIGEST_TREE, EMPTY_DIRECTORY_DIGEST,
 };
 pub use crate::glob_matching::{
-  ExpandablePathGlobs, GlobMatching, PathGlob, PreparedPathGlobs, DOUBLE_STAR_GLOB,
-  SINGLE_STAR_GLOB,
+  GlobMatching, PathGlob, PreparedPathGlobs, DOUBLE_STAR_GLOB, SINGLE_STAR_GLOB,
 };
 
 use std::cmp::min;
@@ -663,6 +662,59 @@ impl Vfs<io::Error> for Arc<PosixFS> {
 
   fn mk_error(msg: &str) -> io::Error {
     io::Error::new(io::ErrorKind::Other, msg)
+  }
+}
+
+#[async_trait]
+impl Vfs<String> for DigestTrie {
+  async fn read_link(&self, link: &Link) -> Result<PathBuf, String> {
+    // DigestTrie does not currently support Links.
+    Err(format!("{:?} does not exist within this Snapshot.", link))
+  }
+
+  async fn scandir(&self, dir: Dir) -> Result<Arc<DirectoryListing>, String> {
+    // TODO(#14890): Change interface to take a reference to an Entry, and to avoid absolute paths.
+    // That would avoid both the need to handle this root case, and the need to recurse in `entry`
+    // down into children.
+    let directory = if dir.0.components().next().is_none() {
+      directory::Directory::new(directory::Name::new(""), self.entries().into())
+    } else {
+      let entry = self
+        .entry(&dir.0)?
+        .ok_or_else(|| format!("{:?} does not exist within this Snapshot.", dir))?;
+      match entry {
+        directory::Entry::File(_) => {
+          return Err(format!(
+            "Path `{}` was a file rather than a directory.",
+            dir.0.display()
+          ))
+        }
+        directory::Entry::Directory(d) => d.clone(),
+      }
+    };
+
+    Ok(Arc::new(DirectoryListing(
+      directory
+        .tree()
+        .entries()
+        .iter()
+        .map(|child| match child {
+          directory::Entry::File(f) => Stat::File(File {
+            path: dir.0.join(f.name().as_ref()),
+            is_executable: f.is_executable(),
+          }),
+          directory::Entry::Directory(d) => Stat::Dir(Dir(dir.0.join(d.name().as_ref()))),
+        })
+        .collect(),
+    )))
+  }
+
+  fn is_ignored(&self, _stat: &Stat) -> bool {
+    false
+  }
+
+  fn mk_error(msg: &str) -> String {
+    msg.to_owned()
   }
 }
 

--- a/src/rust/engine/fs/src/posixfs_tests.rs
+++ b/src/rust/engine/fs/src/posixfs_tests.rs
@@ -1,18 +1,14 @@
-use tempfile;
-use testutil;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use hashing::EMPTY_DIGEST;
+use testutil::make_file;
 
 use crate::{
-  Dir, DirectoryListing, File, GitignoreStyleExcludes, GlobExpansionConjunction, GlobMatching,
-  Link, PathGlobs, PathStat, PathStatGetter, PosixFS, Stat, StrictGlobMatching, SymlinkBehavior,
-  Vfs,
+  DigestTrie, Dir, DirectoryListing, File, GitignoreStyleExcludes, GlobExpansionConjunction,
+  GlobMatching, Link, PathGlobs, PathStat, PathStatGetter, PosixFS, Stat, StrictGlobMatching,
+  SymlinkBehavior, Vfs,
 };
-
-use async_trait::async_trait;
-use std;
-use std::collections::HashMap;
-use std::path::{Components, Path, PathBuf};
-use std::sync::Arc;
-use testutil::make_file;
 
 #[tokio::test]
 async fn is_executable_false() {
@@ -325,7 +321,30 @@ async fn memfs_expand_basic() {
   // Create two files, with the effect that there is a nested directory for the longer path.
   let p1 = PathBuf::from("some/file");
   let p2 = PathBuf::from("some/other");
-  let fs = Arc::new(MemFS::new(vec![p1.clone(), p2.join("file")]));
+  let p3 = p2.join("file");
+
+  let fs = DigestTrie::from_path_stats(
+    vec![
+      PathStat::file(
+        p1.clone(),
+        File {
+          path: p1.clone(),
+          is_executable: false,
+        },
+      ),
+      PathStat::file(
+        p3.clone(),
+        File {
+          path: p3.clone(),
+          is_executable: false,
+        },
+      ),
+    ],
+    &vec![(p1.clone(), EMPTY_DIGEST), (p3, EMPTY_DIGEST)]
+      .into_iter()
+      .collect(),
+  )
+  .unwrap();
   let globs = PathGlobs::new(
     vec!["some/*".into()],
     StrictGlobMatching::Ignore,
@@ -443,77 +462,4 @@ async fn test_basic_gitignore_functionality() {
   assert!(posix_fs_2.is_ignored(&stats[1]));
   assert!(!posix_fs_2.is_ignored(&stats[2]));
   assert!(posix_fs_2.is_ignored(&stats[3]));
-}
-
-///
-/// An in-memory implementation of Vfs, useful for precisely reproducing glob matching behavior for
-/// a set of file paths.
-///
-pub struct MemFS {
-  contents: HashMap<Dir, Arc<DirectoryListing>>,
-}
-
-impl MemFS {
-  pub fn new(paths: Vec<PathBuf>) -> MemFS {
-    let mut unordered_contents = HashMap::new();
-    let empty_path = PathBuf::new();
-    for path in paths {
-      Self::add_path(&mut unordered_contents, &empty_path, path.components());
-    }
-    let contents = unordered_contents
-      .into_iter()
-      .map(|(dir, mut stats)| {
-        stats.sort_by(|a, b| a.path().cmp(b.path()));
-        (dir, Arc::new(DirectoryListing(stats)))
-      })
-      .collect();
-    MemFS { contents }
-  }
-
-  fn add_path(
-    contents: &mut HashMap<Dir, Vec<Stat>>,
-    path_so_far: &Path,
-    mut remainder: Components,
-  ) -> bool {
-    if let Some(component) = remainder.next() {
-      // The component represents a directory if it has child components: otherwise, a file.
-      let path = path_so_far.join(component);
-      let stat = if Self::add_path(contents, &path, remainder) {
-        Stat::dir(path)
-      } else {
-        Stat::file(path, false)
-      };
-      contents
-        .entry(Dir(path_so_far.to_owned()))
-        .or_insert_with(Vec::new)
-        .push(stat);
-      true
-    } else {
-      false
-    }
-  }
-}
-
-#[async_trait]
-impl Vfs<String> for Arc<MemFS> {
-  async fn read_link(&self, link: &Link) -> Result<PathBuf, String> {
-    // The creation of a static filesystem does not allow for Links.
-    Err(format!("{:?} does not exist within this filesystem.", link))
-  }
-
-  async fn scandir(&self, dir: Dir) -> Result<Arc<DirectoryListing>, String> {
-    self
-      .contents
-      .get(&dir)
-      .cloned()
-      .ok_or_else(|| format!("{:?} does not exist within this filesystem.", dir))
-  }
-
-  fn is_ignored(&self, _stat: &Stat) -> bool {
-    false
-  }
-
-  fn mk_error(msg: &str) -> String {
-    msg.to_owned()
-  }
 }

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -41,7 +41,7 @@ use hashing::Digest;
 use protos::gen::build::bazel::remote::execution::v2 as remexec;
 use remexec::ExecutedActionMetadata;
 use serde::{Deserialize, Serialize};
-use store::{SnapshotOps, SnapshotOpsError, Store};
+use store::{SnapshotOps, Store};
 use workunit_store::{RunId, RunningWorkunit, WorkunitStore};
 
 pub mod bounded;
@@ -241,7 +241,7 @@ impl InputDigests {
     input_files: DirectoryDigest,
     immutable_inputs: BTreeMap<RelativePath, DirectoryDigest>,
     use_nailgun: Vec<RelativePath>,
-  ) -> Result<Self, SnapshotOpsError> {
+  ) -> Result<Self, String> {
     // Collect all digests into `complete`.
     let mut complete_digests = try_join_all(
       immutable_inputs

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -304,7 +304,7 @@ fn remove_prefix_request_to_digest(
         .extract::<PyRef<PyRemovePrefix>>()
         .map_err(|e| throw(format!("{}", e)))?;
       let prefix = RelativePath::new(&py_remove_prefix.prefix)
-        .map_err(|e| throw(format!("The `prefix` must be relative: {:?}", e)))?;
+        .map_err(|e| throw(format!("The `prefix` must be relative: {}", e)))?;
       let res: NodeResult<_> = Ok((py_remove_prefix.digest.clone(), prefix));
       res
     })?;
@@ -313,7 +313,7 @@ fn remove_prefix_request_to_digest(
       .store()
       .strip_prefix(digest, &prefix)
       .await
-      .map_err(|e| throw(format!("{:?}", e)))?;
+      .map_err(throw)?;
     let gil = Python::acquire_gil();
     Snapshot::store_directory_digest(gil.python(), digest).map_err(throw)
   }
@@ -331,7 +331,7 @@ fn add_prefix_request_to_digest(
         .extract::<PyRef<PyAddPrefix>>()
         .map_err(|e| throw(format!("{}", e)))?;
       let prefix = RelativePath::new(&py_add_prefix.prefix)
-        .map_err(|e| throw(format!("The `prefix` must be relative: {:?}", e)))?;
+        .map_err(|e| throw(format!("The `prefix` must be relative: {}", e)))?;
       let res: NodeResult<(DirectoryDigest, RelativePath)> =
         Ok((py_add_prefix.digest.clone(), prefix));
       res
@@ -341,7 +341,7 @@ fn add_prefix_request_to_digest(
       .store()
       .add_prefix(digest, &prefix)
       .await
-      .map_err(|e| throw(format!("{:?}", e)))?;
+      .map_err(throw)?;
     let gil = Python::acquire_gil();
     Snapshot::store_directory_digest(gil.python(), digest).map_err(throw)
   }
@@ -377,10 +377,7 @@ fn merge_digests_request_to_digest(
         .map(|py_merge_digests| py_merge_digests.0.clone())
         .map_err(|e| throw(format!("{}", e)))
     })?;
-    let digest = store
-      .merge(digests)
-      .await
-      .map_err(|e| throw(format!("{:?}", e)))?;
+    let digest = store.merge(digests).await.map_err(throw)?;
     let gil = Python::acquire_gil();
     Snapshot::store_directory_digest(gil.python(), digest).map_err(throw)
   }
@@ -506,10 +503,7 @@ fn create_digest_to_digest(
   let store = context.core.store();
   async move {
     let digests = future::try_join_all(digest_futures).await.map_err(throw)?;
-    let digest = store
-      .merge(digests)
-      .await
-      .map_err(|e| throw(format!("{:?}", e)))?;
+    let digest = store.merge(digests).await.map_err(throw)?;
     let gil = Python::acquire_gil();
     Snapshot::store_directory_digest(gil.python(), digest).map_err(throw)
   }
@@ -536,7 +530,7 @@ fn digest_subset_to_digest(
     let digest = store
       .subset(original_digest, subset_params)
       .await
-      .map_err(|e| throw(format!("{:?}", e)))?;
+      .map_err(throw)?;
     let gil = Python::acquire_gil();
     Snapshot::store_directory_digest(gil.python(), digest).map_err(throw)
   }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -314,7 +314,7 @@ impl ExecuteProcess {
 
     input_digests_fut?
       .await
-      .map_err(|e| format!("Failed to merge input digests for process: {:?}", e))
+      .map_err(|e| format!("Failed to merge input digests for process: {}", e))
   }
 
   fn lift_process(value: &PyAny, input_digests: InputDigests) -> Result<Process, String> {


### PR DESCRIPTION
#14858 reported that an invalid `Snapshot` was being created, and reproducing in debug mode triggered `debug_assertions` related to the validity of `remexec::Directory`s created by the subset matching code.

Although porting the existing subset-matching code to `DigestTrie` _and_ fixing the bug would be one option, we've wanted to remove duplication between the "apply globs to a `Snapshot`" and "apply globs to the filesystem" codepaths for a long time (see #9967), and fixing the bug by unifying the codepaths kills two birds with one stone.

This change ports to implementing subset matching using `Vfs::expand_globs`, followed by the creation of a new `Snapshot` from the matches. This is definitely not as optimized as the direct subset matching was (`./cargo bench -p store -- subset` reports a change from ~20ms to ~100ms for 10k files), but it opens the door to unified optimization of _both_ our glob-expansion code and in-memory glob matching in parallel: see #14890.

Fixes #9967, fixes #14858, fixes #12462, and fixes #13112.

[ci skip-build-wheels]