### PR TITLE
[internal] inject ScalaPB runtime dependency

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/scala/dependency_inference.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/dependency_inference.py
@@ -43,8 +43,8 @@ async def resolve_scalapb_runtime_for_resolve(
     scalapb: ScalaPBSubsystem,
 ) -> ScalaPBRuntimeForResolve:
     scala_version = scala_subsystem.version_for_resolve(request.resolve_name)
-    # TODO: Does not handle Scala 3 suffix which is just `_3`.
-    scala_binary_version = ".".join(scala_version.split(".")[0:2])
+    # TODO: Does not handle Scala 3 suffix which is just `_3` nor X.Y.Z versions.
+    scala_binary_version, _, _ = scala_version.rpartition(".")
     version = scalapb.version
 
     for tgt in jvm_artifact_targets:

--- a/src/python/pants/backend/codegen/protobuf/scala/dependency_inference.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/dependency_inference.py
@@ -1,0 +1,127 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from dataclasses import dataclass
+
+from pants.backend.codegen.protobuf.scala.subsystem import ScalaPBSubsystem
+from pants.backend.codegen.protobuf.target_types import ProtobufDependenciesField
+from pants.backend.scala.subsystems.scala import ScalaSubsystem
+from pants.build_graph.address import Address
+from pants.engine.internals.selectors import Get
+from pants.engine.rules import collect_rules, rule
+from pants.engine.target import InjectDependenciesRequest, InjectedDependencies, WrappedTarget
+from pants.engine.unions import UnionRule
+from pants.jvm.dependency_inference.artifact_mapper import AllJvmArtifactTargets
+from pants.jvm.resolve.common import ArtifactRequirement, Coordinate
+from pants.jvm.subsystems import JvmSubsystem
+from pants.jvm.target_types import JvmResolveField
+from pants.util.docutil import bin_name
+
+_SCALAPB_RUNTIME_GROUP = "com.thesamet.scalapb"
+_SCALAPB_RUNTIME_ARTIFACT = "scalapb-runtime"
+
+
+class InjectScalaPBRuntimeDependencyRequest(InjectDependenciesRequest):
+    inject_for = ProtobufDependenciesField
+
+
+@dataclass(frozen=True)
+class ScalaPBRuntimeForResolveRequest:
+    resolve_name: str
+
+
+@dataclass(frozen=True)
+class ScalaPBRuntimeForResolve:
+    address: Address
+
+
+@rule
+async def resolve_scalapb_runtime_for_resolve(
+    request: ScalaPBRuntimeForResolveRequest,
+    jvm_artifact_targets: AllJvmArtifactTargets,
+    jvm: JvmSubsystem,
+    scala_subsystem: ScalaSubsystem,
+    scalapb: ScalaPBSubsystem,
+) -> ScalaPBRuntimeForResolve:
+    scala_version = scala_subsystem.version_for_resolve(request.resolve_name)
+    # TODO: Does not handle Scala 3 suffix which is just `_3`.
+    scala_binary_version = ".".join(scala_version.split(".")[0:2])
+    version = scalapb.version
+
+    for tgt in jvm_artifact_targets:
+        if tgt[JvmResolveField].normalized_value(jvm) != request.resolve_name:
+            continue
+
+        artifact = ArtifactRequirement.from_jvm_artifact_target(tgt)
+        if (
+            artifact.coordinate.group != _SCALAPB_RUNTIME_GROUP
+            or artifact.coordinate.artifact != f"{_SCALAPB_RUNTIME_ARTIFACT}_{scala_binary_version}"
+        ):
+            continue
+
+        if artifact.coordinate.version != version:
+            raise ConflictingScalaPBRuntimeVersionInResolveError(
+                request.resolve_name, version, artifact.coordinate
+            )
+
+        return ScalaPBRuntimeForResolve(tgt.address)
+
+    raise MissingScalaPBRuntimeInResolveError(request.resolve_name, version, scala_binary_version)
+
+
+@rule
+async def inject_scalapb_runtime_dependency(
+    request: InjectScalaPBRuntimeDependencyRequest,
+    jvm: JvmSubsystem,
+) -> InjectedDependencies:
+    wrapped_target = await Get(WrappedTarget, Address, request.dependencies_field.address)
+    target = wrapped_target.target
+
+    if not target.has_field(JvmResolveField):
+        return InjectedDependencies()
+    resolve = target[JvmResolveField].normalized_value(jvm)
+
+    scalapb_runtime_target_info = await Get(
+        ScalaPBRuntimeForResolve, ScalaPBRuntimeForResolveRequest(resolve)
+    )
+    return InjectedDependencies((scalapb_runtime_target_info.address,))
+
+
+class ConflictingScalaPBRuntimeVersionInResolveError(ValueError):
+    """Exception for when there is a conflicting ScalaPB version in a resolve."""
+
+    def __init__(
+        self, resolve_name: str, required_version: str, conflicting_coordinate: Coordinate
+    ) -> None:
+        super().__init__(
+            f"The JVM resolve `{resolve_name}` contains a `jvm_artifact` for version {conflicting_coordinate.version} "
+            f"of the ScalaPB runtime. This conflicts with version {required_version} which is the configured version "
+            "of ScalaPB for this resolve from the `[scalapb].version` option. "
+            "Please remove the `jvm_artifact` target with JVM coordinate "
+            f"{conflicting_coordinate.to_coord_str()}, then re-run "
+            f"`{bin_name()} generate-lockfiles --resolve={resolve_name}`"
+        )
+
+
+class MissingScalaPBRuntimeInResolveError(ValueError):
+    def __init__(self, resolve_name: str, version: str, scala_binary_version: str) -> None:
+        super().__init__(
+            f"The JVM resolve `{resolve_name}` does not contain a requirement for the ScalaPB runtime. "
+            "Since at least one Scala target type in this repository consumes a `protobuf_sources` target "
+            "in this resolve, the resolve must contain a `jvm_artifact` target for the ScalaPB runtime.\n\n"
+            "Please add the following `jvm_artifact` target somewhere in the repository and re-run "
+            f"`{bin_name()} generate-lockfiles --resolve={resolve_name}`:\n"
+            "jvm_artifact(\n"
+            f'  name="{_SCALAPB_RUNTIME_GROUP}_{_SCALAPB_RUNTIME_ARTIFACT}_{scala_binary_version}",\n'
+            f'  group="{_SCALAPB_RUNTIME_GROUP}",\n',
+            f'  artifact="{_SCALAPB_RUNTIME_ARTIFACT}_{scala_binary_version}",\n',
+            f'  version="{version}",\n',
+            f'  resolve="{resolve_name}",\n',
+            ")",
+        )
+
+
+def rules():
+    return (
+        *collect_rules(),
+        UnionRule(InjectDependenciesRequest, InjectScalaPBRuntimeDependencyRequest),
+    )

--- a/src/python/pants/backend/codegen/protobuf/scala/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/rules.py
@@ -344,7 +344,7 @@ def rules():
         ProtobufSourcesGeneratorTarget.register_plugin_field(PrefixedJvmJdkField),
         ProtobufSourceTarget.register_plugin_field(PrefixedJvmResolveField),
         ProtobufSourcesGeneratorTarget.register_plugin_field(PrefixedJvmResolveField),
-        # Rules to avoid rule grpah errors.
+        # Rules to avoid rule graph errors.
         *artifact_mapper.rules(),
         *distdir.rules(),
     ]

--- a/src/python/pants/backend/codegen/protobuf/scala/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/rules.py
@@ -17,6 +17,7 @@ from pants.backend.codegen.protobuf.target_types import (
 )
 from pants.backend.scala.target_types import ScalaSourceField
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
+from pants.core.util_rules import distdir
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.core.util_rules.source_files import SourceFilesRequest
 from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
@@ -44,6 +45,7 @@ from pants.engine.target import (
 )
 from pants.engine.unions import UnionRule
 from pants.jvm.compile import ClasspathEntry
+from pants.jvm.dependency_inference import artifact_mapper
 from pants.jvm.goals import lockfile
 from pants.jvm.jdk_rules import InternalJdk, JvmProcess
 from pants.jvm.resolve.common import ArtifactRequirements, Coordinate, GatherJvmCoordinatesRequest
@@ -342,4 +344,7 @@ def rules():
         ProtobufSourcesGeneratorTarget.register_plugin_field(PrefixedJvmJdkField),
         ProtobufSourceTarget.register_plugin_field(PrefixedJvmResolveField),
         ProtobufSourcesGeneratorTarget.register_plugin_field(PrefixedJvmResolveField),
+        # Rules to avoid rule grpah errors.
+        *artifact_mapper.rules(),
+        *distdir.rules(),
     ]

--- a/src/python/pants/backend/codegen/protobuf/scala/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/rules.py
@@ -6,10 +6,11 @@ import os
 import pkgutil
 from dataclasses import dataclass
 
+from pants.backend.codegen import export_codegen_goal
 from pants.backend.codegen.protobuf.protoc import Protoc
+from pants.backend.codegen.protobuf.scala import dependency_inference
 from pants.backend.codegen.protobuf.scala.subsystem import PluginArtifactSpec, ScalaPBSubsystem
 from pants.backend.codegen.protobuf.target_types import (
-    ProtobufDependenciesField,
     ProtobufSourceField,
     ProtobufSourcesGeneratorTarget,
     ProtobufSourceTarget,
@@ -19,7 +20,6 @@ from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.core.util_rules.source_files import SourceFilesRequest
 from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
-from pants.engine.addresses import Addresses, UnparsedAddressInputs
 from pants.engine.environment import Environment, EnvironmentRequest
 from pants.engine.fs import (
     AddPrefix,
@@ -39,8 +39,6 @@ from pants.engine.rules import collect_rules, rule
 from pants.engine.target import (
     GeneratedSources,
     GenerateSourcesRequest,
-    InjectDependenciesRequest,
-    InjectedDependencies,
     TransitiveTargets,
     TransitiveTargetsRequest,
 )
@@ -51,7 +49,7 @@ from pants.jvm.jdk_rules import InternalJdk, JvmProcess
 from pants.jvm.resolve.common import ArtifactRequirements, Coordinate, GatherJvmCoordinatesRequest
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
-from pants.jvm.target_types import JvmJdkField
+from pants.jvm.target_types import JvmJdkField, JvmResolveField
 from pants.source.source_root import SourceRoot, SourceRootRequest
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
@@ -206,18 +204,6 @@ async def generate_scala_from_protobuf(
     return GeneratedSources(source_root_restored)
 
 
-class InjectScalaProtobufDependencies(InjectDependenciesRequest):
-    inject_for = ProtobufDependenciesField
-
-
-@rule
-async def inject_scalapb_dependencies(
-    _: InjectScalaProtobufDependencies, scalapb: ScalaPBSubsystem
-) -> InjectedDependencies:
-    addresses = await Get(Addresses, UnparsedAddressInputs, scalapb.runtime_dependencies)
-    return InjectedDependencies(addresses)
-
-
 @rule
 async def materialize_jvm_plugin(request: MaterializeJvmPluginRequest) -> MaterializedJvmPlugin:
     requirements = await Get(
@@ -340,12 +326,20 @@ class PrefixedJvmJdkField(JvmJdkField):
     alias = "jvm_jdk"
 
 
+class PrefixedJvmResolveField(JvmResolveField):
+    alias = "jvm_resolve"
+
+
 def rules():
     return [
         *collect_rules(),
         *lockfile.rules(),
+        *export_codegen_goal.rules(),
+        *dependency_inference.rules(),
         UnionRule(GenerateSourcesRequest, GenerateScalaFromProtobufRequest),
         UnionRule(GenerateToolLockfileSentinel, ScalapbcToolLockfileSentinel),
         ProtobufSourceTarget.register_plugin_field(PrefixedJvmJdkField),
         ProtobufSourcesGeneratorTarget.register_plugin_field(PrefixedJvmJdkField),
+        ProtobufSourceTarget.register_plugin_field(PrefixedJvmResolveField),
+        ProtobufSourcesGeneratorTarget.register_plugin_field(PrefixedJvmResolveField),
     ]

--- a/src/python/pants/backend/codegen/protobuf/scala/subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/subsystem.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from pants.engine.addresses import UnparsedAddressInputs
 from pants.jvm.resolve.jvm_tool import JvmToolBase
-from pants.option.option_types import StrListOption, TargetListOption
+from pants.option.option_types import StrListOption
 from pants.util.docutil import git_url
 from pants.util.strutil import softwrap
 
@@ -43,19 +42,6 @@ class ScalaPBSubsystem(JvmToolBase):
     )
     default_lockfile_url = git_url(default_lockfile_path)
 
-    _runtime_dependencies = TargetListOption(
-        "--runtime-dependencies",
-        help=lambda cls: softwrap(
-            f"""
-            A list of addresses to `jvm_artifact` targets for the runtime
-            dependencies needed for generated Scala code to work. For example,
-            `['3rdparty/jvm:scalapb-runtime']`. These dependencies will
-            be automatically added to every `protobuf_sources` target. At the very least,
-            this option must be set to a `jvm_artifact` for the
-            `com.thesamet.scalapb:scalapb-runtime_SCALAVER:{cls.default_version}` runtime library.
-            """
-        ),
-    )
     _jvm_plugins = StrListOption(
         "--jvm-plugins",
         help=softwrap(
@@ -72,10 +58,6 @@ class ScalaPBSubsystem(JvmToolBase):
             """
         ),
     )
-
-    @property
-    def runtime_dependencies(self) -> UnparsedAddressInputs:
-        return UnparsedAddressInputs(self._runtime_dependencies, owning_address=None)
 
     @property
     def jvm_plugins(self) -> tuple[PluginArtifactSpec, ...]:


### PR DESCRIPTION
Inject ScalaPB runtime dependency from `protobuf_sources` target to `jvm_artifact` in the applicable resolve with the `scalapb-runtime` jar. Adds `jvm_resolve` field to `protobuf_sources` targets.