### PR TITLE
add registration for the Go Protobuf backend (Cherry pick of #14874)

### DIFF
--- a/src/python/pants/backend/experimental/codegen/protobuf/go/BUILD
+++ b/src/python/pants/backend/experimental/codegen/protobuf/go/BUILD
@@ -1,0 +1,4 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_sources()

--- a/src/python/pants/backend/experimental/codegen/protobuf/go/register.py
+++ b/src/python/pants/backend/experimental/codegen/protobuf/go/register.py
@@ -1,0 +1,24 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from pants.backend.codegen import export_codegen_goal
+from pants.backend.codegen.protobuf import protobuf_dependency_inference, tailor
+from pants.backend.codegen.protobuf import target_types as protobuf_target_types
+from pants.backend.codegen.protobuf.go import rules as go_protobuf_rules
+from pants.backend.codegen.protobuf.target_types import (
+    ProtobufSourcesGeneratorTarget,
+    ProtobufSourceTarget,
+)
+
+
+def target_types():
+    return [ProtobufSourcesGeneratorTarget, ProtobufSourceTarget]
+
+
+def rules():
+    return [
+        *go_protobuf_rules.rules(),
+        *protobuf_target_types.rules(),
+        *protobuf_dependency_inference.rules(),
+        *tailor.rules(),
+        *export_codegen_goal.rules(),
+    ]


### PR DESCRIPTION
Add registration module for the Go Protobuf backend (as `pants.backend.experimental.codegen.protobuf.go`).

[ci skip-rust]

[ci skip-build-wheels]