### PR TITLE
add cache key for all Go SDK invocations (Cherry pick of #14897)

### DIFF
--- a/src/python/pants/backend/go/util_rules/sdk.py
+++ b/src/python/pants/backend/go/util_rules/sdk.py
@@ -94,6 +94,7 @@ async def setup_go_sdk_process(
     go_sdk_run: GoSdkRunSetup,
     bash: BashBinary,
     golang_subsystem: GolangSubsystem,
+    goroot: GoRoot,
 ) -> Process:
     input_digest, env_vars = await MultiGet(
         Get(Digest, MergeDigests([go_sdk_run.digest, request.input_digest])),
@@ -105,6 +106,8 @@ async def setup_go_sdk_process(
             **env_vars,
             **request.env,
             GoSdkRunSetup.CHDIR_ENV: request.working_dir or "",
+            # TODO: Maybe could just use MAJOR.MINOR for version part here?
+            "__PANTS_GO_SDK_CACHE_KEY": f"{goroot.version}/{goroot.goos}/{goroot.goarch}",
         },
         input_digest=input_digest,
         description=request.description,


### PR DESCRIPTION
## Problem

At my company, we tried to upgrade from Go 1.16 to Go 1.17, but Pants invocations with the Go backend were failing with errors similar to the following:

```
pants.engine.process.ProcessExecutionFailure: Process 'Link Go binary: ./package_analyzer' failed with exit code 1.
stdout:
cannot find package internal/buildcfg (using -importcfg)
cannot find package internal/itoa (using -importcfg)
cannot find package go/internal/typeparams (using -importcfg)
cannot find package internal/abi (using -importcfg)
cannot find package internal/goexperiment (using -importcfg)
```

As it turns out, the Go backend was using a cached stdlib import analysis from Go 1.16 to produce the import config, and the "missing" packages are packages introduced in Go 1.17. The Go version was not incorporated into the cache key for Go SDK invocations to prevent this issue. This occurs because the hash of the Go tooling is not part of the input root any more because we invoke Go from a system path and don't fingerprint it.

## Solution

Incorporate version, GOOS, and GOARCH into Go SDK invocations as cache key.

[ci skip-rust]

[ci skip-build-wheels]