### PR TITLE
Don't WARN when a spec matches no relevant targets.

### DIFF
--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -333,6 +333,7 @@ class FilesystemSpecs:
 class Specs:
     address_specs: AddressSpecs
     filesystem_specs: FilesystemSpecs
+    from_change_detection: bool = False
 
     @property
     def provided(self) -> bool:

--- a/src/python/pants/init/specs_calculator.py
+++ b/src/python/pants/init/specs_calculator.py
@@ -75,7 +75,11 @@ def calculate_specs(
                 parameters=address_input.parameters,
             )
         )
-    return Specs(AddressSpecs(address_specs, filter_by_global_options=True), FilesystemSpecs([]))
+    return Specs(
+        AddressSpecs(address_specs, filter_by_global_options=True),
+        FilesystemSpecs([]),
+        from_change_detection=True,
+    )
 
 
 def rules():


### PR DESCRIPTION
This warning has its uses (e.g., if you accidentally ran on the wrong target),
but on balance, with hindsight, it seems more distracting and confusing than useful.

This is especially true with glob specs or `--changed`: "Run all the tests under foo/::" 
can be satisfied vacuously if there are no tests under foo/::, and ditto "Run all the tests
that are affected by git changes". So it's weird to issue a warning. 

In such cases we should adhere to the principle that "the empty set is not a
special case", and just let things hold vacuously.

Of course we can still ERROR when a goal absolutely needs a target in order
to make any sense at all.

[ci skip-rust]

[ci skip-build-wheels]