### PR TITLE
Revert "Upgrade Pex to 2.1.74. (#14911)"

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -14,7 +14,7 @@ humbug==0.2.7
 
 ijson==3.1.4
 packaging==21.3
-pex==2.1.74
+pex==2.1.73
 psutil==5.9.0
 pytest>=6.2.4,<8  # This should be compatible with pytest.py, although it can be looser so that we don't over-constrain pantsbuild.pants.testutil
 python-lsp-jsonrpc==1.0.0

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -18,7 +18,7 @@
 //     "ijson==3.1.4",
 //     "mypy-typing-asserts==0.1.1",
 //     "packaging==21.3",
-//     "pex==2.1.74",
+//     "pex==2.1.73",
 //     "psutil==5.9.0",
 //     "pydevd-pycharm==203.5419.8",
 //     "pytest<8,>=6.2.4",
@@ -548,13 +548,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "2f68e2481aefb285d6e2322c711e399ef14b8b3cd4b5fb6f8d331100334b7539",
-              "url": "https://files.pythonhosted.org/packages/6a/34/9ba6df6e5166d94ceba005deb65f235b67c04768b92fcde7942c45226ed7/pex-2.1.74-py2.py3-none-any.whl"
+              "hash": "b6610d4f25fbf49f93997f2a889959f064ede535529e1355748b4a116e3b0352",
+              "url": "https://files.pythonhosted.org/packages/df/cb/6f7720c4769486f7e37cbaa457e179944432e62936a25a4b106dbc2a5827/pex-2.1.73-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4b228ec044a7fb4a45b66d86045712fa4cc8bafe5c35771ac93b48ecec85a508",
-              "url": "https://files.pythonhosted.org/packages/7d/aa/86f647b2486f5902c3a2885d42b81837a1fa7d564e47e1575af67d929286/pex-2.1.74.tar.gz"
+              "hash": "3b1226d2f147d0969d68a306aca34d8fc980eee7b591ace3a5ab922ba5cd1a25",
+              "url": "https://files.pythonhosted.org/packages/25/60/6aeba685a9724d57dd224116bba34854621e1f46267857830b62e9647eff/pex-2.1.73.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -562,7 +562,7 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.11,>=2.7",
-          "version": "2.1.74"
+          "version": "2.1.73"
         },
         {
           "artifacts": [
@@ -1544,7 +1544,7 @@
       ]
     }
   ],
-  "pex_version": "2.1.74",
+  "pex_version": "2.1.73",
   "prefer_older_binary": false,
   "requirements": [
     "PyYAML<7.0,>=6.0",
@@ -1556,7 +1556,7 @@
     "ijson==3.1.4",
     "mypy-typing-asserts==0.1.1",
     "packaging==21.3",
-    "pex==2.1.74",
+    "pex==2.1.73",
     "psutil==5.9.0",
     "pydevd-pycharm==203.5419.8",
     "pytest<8,>=6.2.4",

--- a/src/python/pants/backend/python/subsystems/lambdex.lock
+++ b/src/python/pants/backend/python/subsystems/lambdex.lock
@@ -49,13 +49,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "2f68e2481aefb285d6e2322c711e399ef14b8b3cd4b5fb6f8d331100334b7539",
-              "url": "https://files.pythonhosted.org/packages/6a/34/9ba6df6e5166d94ceba005deb65f235b67c04768b92fcde7942c45226ed7/pex-2.1.74-py2.py3-none-any.whl"
+              "hash": "b6610d4f25fbf49f93997f2a889959f064ede535529e1355748b4a116e3b0352",
+              "url": "https://files.pythonhosted.org/packages/df/cb/6f7720c4769486f7e37cbaa457e179944432e62936a25a4b106dbc2a5827/pex-2.1.73-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4b228ec044a7fb4a45b66d86045712fa4cc8bafe5c35771ac93b48ecec85a508",
-              "url": "https://files.pythonhosted.org/packages/7d/aa/86f647b2486f5902c3a2885d42b81837a1fa7d564e47e1575af67d929286/pex-2.1.74.tar.gz"
+              "hash": "3b1226d2f147d0969d68a306aca34d8fc980eee7b591ace3a5ab922ba5cd1a25",
+              "url": "https://files.pythonhosted.org/packages/25/60/6aeba685a9724d57dd224116bba34854621e1f46267857830b62e9647eff/pex-2.1.73.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -63,7 +63,7 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.11,>=2.7",
-          "version": "2.1.74"
+          "version": "2.1.73"
         }
       ],
       "platform_tag": [
@@ -73,7 +73,7 @@
       ]
     }
   ],
-  "pex_version": "2.1.74",
+  "pex_version": "2.1.73",
   "prefer_older_binary": false,
   "requirements": [
     "lambdex==0.1.6"

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -39,9 +39,9 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."
 
-    default_version = "v2.1.74"
+    default_version = "v2.1.73"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.1.74,<3.0"
+    version_constraints = ">=2.1.73,<3.0"
 
     @classproperty
     def default_known_versions(cls):
@@ -50,8 +50,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "7fea722b0faa5c5e802a327d3f75c8c363eb23460f1e5ddce7d45056105502de",
-                    "3730463",
+                    "0f30b06c02743393b745497580a410d28055b0de022a27cbb8e460845a6ba1c9",
+                    "3723175",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64"]


### PR DESCRIPTION
Due to https://github.com/pantsbuild/pex/issues/1693, which two of us encountered locally and encountered in CI https://github.com/pantsbuild/pants/runs/5696720972?check_suite_focus=true#step:12:89. We've never seen this error before today, so seems likely to be related to the Pex upgrade.

[ci skip-rust]
[ci skip-build-wheels]