### PR TITLE
Add Protobuf formatting using buf format (Cherry pick of #14907)

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
@@ -1,0 +1,148 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from dataclasses import dataclass
+
+from pants.backend.codegen.protobuf.lint.buf.skip_field import SkipBufFormatField
+from pants.backend.codegen.protobuf.lint.buf.subsystem import BufSubsystem
+from pants.backend.codegen.protobuf.target_types import (
+    ProtobufDependenciesField,
+    ProtobufSourceField,
+)
+from pants.core.goals.fmt import FmtRequest, FmtResult
+from pants.core.goals.lint import LintResult, LintResults, LintTargetsRequest
+from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
+from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.core.util_rules.system_binaries import (
+    BinaryShims,
+    BinaryShimsRequest,
+    DiffBinary,
+    DiffBinaryRequest,
+)
+from pants.engine.fs import Digest, MergeDigests
+from pants.engine.internals.native_engine import Snapshot
+from pants.engine.platform import Platform
+from pants.engine.process import FallibleProcessResult, Process, ProcessResult
+from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.target import FieldSet, Target
+from pants.engine.unions import UnionRule
+from pants.util.logging import LogLevel
+from pants.util.strutil import pluralize
+
+
+@dataclass(frozen=True)
+class BufFieldSet(FieldSet):
+    required_fields = (ProtobufSourceField,)
+
+    sources: ProtobufSourceField
+    dependencies: ProtobufDependenciesField
+
+    @classmethod
+    def opt_out(cls, tgt: Target) -> bool:
+        return tgt.get(SkipBufFormatField).value
+
+
+class BufFormatRequest(LintTargetsRequest, FmtRequest):
+    field_set_type = BufFieldSet
+    name = "buf-format"
+
+
+@dataclass(frozen=True)
+class SetupRequest:
+    request: BufFormatRequest
+    check_only: bool
+
+
+@dataclass(frozen=True)
+class Setup:
+    process: Process
+    original_snapshot: Snapshot
+
+
+@rule(level=LogLevel.DEBUG)
+async def setup_buf_format(setup_request: SetupRequest, buf: BufSubsystem) -> Setup:
+    diff_binary = await Get(DiffBinary, DiffBinaryRequest())
+    download_buf_get = Get(
+        DownloadedExternalTool, ExternalToolRequest, buf.get_request(Platform.current)
+    )
+    binary_shims_get = Get(
+        BinaryShims,
+        BinaryShimsRequest,
+        BinaryShimsRequest.for_paths(
+            diff_binary,
+            rationale="buf format requires diff in linting mode",
+            output_directory=".bin",
+        ),
+    )
+    source_files_get = Get(
+        SourceFiles,
+        SourceFilesRequest(field_set.sources for field_set in setup_request.request.field_sets),
+    )
+    downloaded_buf, binary_shims, source_files = await MultiGet(
+        download_buf_get, binary_shims_get, source_files_get
+    )
+
+    source_files_snapshot = (
+        source_files.snapshot
+        if setup_request.request.prior_formatter_result is None
+        else setup_request.request.prior_formatter_result
+    )
+
+    input_digest = await Get(
+        Digest,
+        MergeDigests((source_files_snapshot.digest, downloaded_buf.digest, binary_shims.digest)),
+    )
+
+    argv = [
+        downloaded_buf.exe,
+        "format",
+        # If linting, use `-d` to error with a diff and `--exit-code` to exit with a non-zero exit code if
+        # the file is not already formatted. Else, write the change with `-w`.
+        *(["-d", "--exit-code"] if setup_request.check_only else ["-w"]),
+        *buf.format_args,
+        "--path",
+        ",".join(source_files_snapshot.files),
+    ]
+    process = Process(
+        argv=argv,
+        input_digest=input_digest,
+        output_files=source_files_snapshot.files,
+        description=f"Run buf format on {pluralize(len(setup_request.request.field_sets), 'file')}.",
+        level=LogLevel.DEBUG,
+        env={
+            "PATH": binary_shims.bin_directory,
+        },
+    )
+    return Setup(process, original_snapshot=source_files_snapshot)
+
+
+@rule(desc="Format with buf format", level=LogLevel.DEBUG)
+async def run_buf_format(request: BufFormatRequest, buf: BufSubsystem) -> FmtResult:
+    if buf.skip_format:
+        return FmtResult.skip(formatter_name=request.name)
+    setup = await Get(Setup, SetupRequest(request, check_only=False))
+    result = await Get(ProcessResult, Process, setup.process)
+    output_snapshot = await Get(Snapshot, Digest, result.output_digest)
+    return FmtResult(
+        setup.original_snapshot,
+        output_snapshot,
+        stdout=result.stdout.decode(),
+        stderr=result.stderr.decode(),
+        formatter_name=request.name,
+    )
+
+
+@rule(desc="Lint with buf format", level=LogLevel.DEBUG)
+async def run_buf_lint(request: BufFormatRequest, buf: BufSubsystem) -> LintResults:
+    if buf.skip_format:
+        return LintResults([], linter_name=request.name)
+    setup = await Get(Setup, SetupRequest(request, check_only=True))
+    result = await Get(FallibleProcessResult, Process, setup.process)
+    return LintResults([LintResult.from_fallible_process_result(result)], linter_name=request.name)
+
+
+def rules():
+    return [
+        *collect_rules(),
+        UnionRule(FmtRequest, BufFormatRequest),
+        UnionRule(LintTargetsRequest, BufFormatRequest),
+    ]

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules_integration_test.py
@@ -1,0 +1,143 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import pytest
+
+from pants.backend.codegen.protobuf.lint.buf.format_rules import BufFieldSet, BufFormatRequest
+from pants.backend.codegen.protobuf.lint.buf.format_rules import rules as buf_rules
+from pants.backend.codegen.protobuf.target_types import ProtobufSourcesGeneratorTarget
+from pants.backend.codegen.protobuf.target_types import rules as target_types_rules
+from pants.core.goals.fmt import FmtResult
+from pants.core.goals.lint import LintResult, LintResults
+from pants.core.util_rules import config_files, external_tool, source_files
+from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.engine.addresses import Address
+from pants.engine.fs import CreateDigest, FileContent
+from pants.engine.internals.native_engine import Digest, Snapshot
+from pants.engine.target import Target
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *buf_rules(),
+            *config_files.rules(),
+            *external_tool.rules(),
+            *source_files.rules(),
+            *target_types_rules(),
+            QueryRule(LintResults, [BufFormatRequest]),
+            QueryRule(FmtResult, [BufFormatRequest]),
+            QueryRule(SourceFiles, [SourceFilesRequest]),
+        ],
+        target_types=[ProtobufSourcesGeneratorTarget],
+    )
+
+
+GOOD_FILE = 'syntax = "proto3";\n\npackage foo.v1;\nmessage Foo {}\n'
+BAD_FILE = 'syntax = "proto3";\n\npackage foo.v1;\nmessage Foo {\n}\n'
+
+
+def run_buf(
+    rule_runner: RuleRunner,
+    targets: list[Target],
+    *,
+    extra_args: list[str] | None = None,
+) -> tuple[tuple[LintResult, ...], FmtResult]:
+    rule_runner.set_options(
+        [
+            "--backend-packages=pants.backend.codegen.protobuf.lint.buf",
+            *(extra_args or ()),
+        ],
+        env_inherit={"PATH"},
+    )
+    field_sets = [BufFieldSet.create(tgt) for tgt in targets]
+    results = rule_runner.request(LintResults, [BufFormatRequest(field_sets)])
+    input_sources = rule_runner.request(
+        SourceFiles,
+        [
+            SourceFilesRequest(field_set.sources for field_set in field_sets),
+        ],
+    )
+    fmt_result = rule_runner.request(
+        FmtResult,
+        [
+            BufFormatRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+        ],
+    )
+
+    return results.results, fmt_result
+
+
+def get_snapshot(rule_runner: RuleRunner, source_files: dict[str, str]) -> Snapshot:
+    files = [FileContent(path, content.encode()) for path, content in source_files.items()]
+    digest = rule_runner.request(Digest, [CreateDigest(files)])
+    return rule_runner.request(Snapshot, [digest])
+
+
+def test_passing(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files({"f.proto": GOOD_FILE, "BUILD": "protobuf_sources(name='t')"})
+    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.proto"))
+    lint_results, fmt_result = run_buf(rule_runner, [tgt])
+    assert len(lint_results) == 1
+    assert lint_results[0].exit_code == 0
+    assert lint_results[0].stdout == ""
+    assert lint_results[0].stderr == ""
+    assert fmt_result.stdout == ""
+    assert fmt_result.output == get_snapshot(rule_runner, {"f.proto": GOOD_FILE})
+    assert fmt_result.did_change is False
+
+
+def test_failing(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files({"f.proto": BAD_FILE, "BUILD": "protobuf_sources(name='t')"})
+    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.proto"))
+    lint_results, fmt_result = run_buf(rule_runner, [tgt])
+    assert len(lint_results) == 1
+    assert lint_results[0].exit_code == 100
+    assert "f.proto.orig" in lint_results[0].stdout
+    assert fmt_result.output == get_snapshot(rule_runner, {"f.proto": GOOD_FILE})
+    assert fmt_result.did_change is True
+
+
+def test_multiple_targets(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {"good.proto": GOOD_FILE, "bad.proto": BAD_FILE, "BUILD": "protobuf_sources(name='t')"}
+    )
+    tgts = [
+        rule_runner.get_target(Address("", target_name="t", relative_file_path="good.proto")),
+        rule_runner.get_target(Address("", target_name="t", relative_file_path="bad.proto")),
+    ]
+    lint_results, fmt_result = run_buf(rule_runner, tgts)
+    assert len(lint_results) == 1
+    assert lint_results[0].exit_code == 100
+    assert "bad.proto.orig" in lint_results[0].stdout
+    assert "good.proto" not in lint_results[0].stdout
+    assert fmt_result.output == get_snapshot(
+        rule_runner, {"good.proto": GOOD_FILE, "bad.proto": GOOD_FILE}
+    )
+    assert fmt_result.did_change is True
+
+
+def test_passthrough_args(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files({"f.proto": GOOD_FILE, "BUILD": "protobuf_sources(name='t')"})
+    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.proto"))
+    lint_results, fmt_result = run_buf(rule_runner, [tgt], extra_args=["--buf-format-args=--debug"])
+    assert len(lint_results) == 1
+    assert lint_results[0].exit_code == 0
+    assert lint_results[0].stdout == ""
+    assert "DEBUG" in lint_results[0].stderr
+    assert fmt_result.stdout == ""
+    assert fmt_result.output == get_snapshot(rule_runner, {"f.proto": GOOD_FILE})
+    assert fmt_result.did_change is False
+
+
+def test_skip(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files({"f.proto": BAD_FILE, "BUILD": "protobuf_sources(name='t')"})
+    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.proto"))
+    lint_results, fmt_result = run_buf(rule_runner, [tgt], extra_args=["--buf-format-skip"])
+    assert not lint_results
+    assert fmt_result.skipped is True
+    assert fmt_result.did_change is False

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules_integration_test.py
@@ -8,8 +8,8 @@ from textwrap import dedent
 
 import pytest
 
-from pants.backend.codegen.protobuf.lint.buf.rules import BufFieldSet, BufRequest
-from pants.backend.codegen.protobuf.lint.buf.rules import rules as buf_rules
+from pants.backend.codegen.protobuf.lint.buf.lint_rules import BufFieldSet, BufLintRequest
+from pants.backend.codegen.protobuf.lint.buf.lint_rules import rules as buf_rules
 from pants.backend.codegen.protobuf.target_types import ProtobufSourcesGeneratorTarget
 from pants.backend.codegen.protobuf.target_types import rules as target_types_rules
 from pants.core.goals.lint import LintResult, LintResults
@@ -28,7 +28,7 @@ def rule_runner() -> RuleRunner:
             *external_tool.rules(),
             *stripped_source_files.rules(),
             *target_types_rules(),
-            QueryRule(LintResults, [BufRequest]),
+            QueryRule(LintResults, [BufLintRequest]),
         ],
         target_types=[ProtobufSourcesGeneratorTarget],
     )
@@ -55,7 +55,7 @@ def run_buf(
     )
     results = rule_runner.request(
         LintResults,
-        [BufRequest(BufFieldSet.create(tgt) for tgt in targets)],
+        [BufLintRequest(BufFieldSet.create(tgt) for tgt in targets)],
     )
     return results.results
 

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/register.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/register.py
@@ -2,8 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.backend.codegen.protobuf.lint.buf import skip_field
-from pants.backend.codegen.protobuf.lint.buf.rules import rules as buf_rules
+from pants.backend.codegen.protobuf.lint.buf.format_rules import rules as buf_format_rules
+from pants.backend.codegen.protobuf.lint.buf.lint_rules import rules as buf_lint_rules
 
 
 def rules():
-    return (*buf_rules(), *skip_field.rules())
+    return (*buf_format_rules(), *buf_lint_rules(), *skip_field.rules())

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/skip_field.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/skip_field.py
@@ -8,14 +8,22 @@ from pants.backend.codegen.protobuf.target_types import (
 from pants.engine.target import BoolField
 
 
-class SkipBufField(BoolField):
+class SkipBufFormatField(BoolField):
+    alias = "skip_buf_format"
+    default = False
+    help = "If true, don't run `buf format` on this target's code."
+
+
+class SkipBufLintField(BoolField):
     alias = "skip_buf_lint"
     default = False
-    help = "If true, don't lint this target's code with Buf."
+    help = "If true, don't run `buf lint` on this target's code."
 
 
 def rules():
     return [
-        ProtobufSourceTarget.register_plugin_field(SkipBufField),
-        ProtobufSourcesGeneratorTarget.register_plugin_field(SkipBufField),
+        ProtobufSourceTarget.register_plugin_field(SkipBufFormatField),
+        ProtobufSourceTarget.register_plugin_field(SkipBufLintField),
+        ProtobufSourcesGeneratorTarget.register_plugin_field(SkipBufFormatField),
+        ProtobufSourcesGeneratorTarget.register_plugin_field(SkipBufLintField),
     ]

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/subsystem.py
@@ -9,16 +9,16 @@ from pants.option.option_types import ArgsListOption, SkipOption
 
 
 class BufSubsystem(TemplatedExternalTool):
-    options_scope = "buf-lint"
+    options_scope = "buf"
     name = "Buf"
-    help = "A linter for Protocol Buffers (https://github.com/bufbuild/buf)."
+    help = "A linter and formatter for Protocol Buffers (https://github.com/bufbuild/buf)."
 
-    default_version = "v1.0.0"
+    default_version = "v1.3.0"
     default_known_versions = [
-        "v1.0.0|linux_arm64 |c4b095268fe0fc8de2ad76c7b4677ccd75f25623d5b1f971082a6b7f43ff1eb0|13378006",
-        "v1.0.0|linux_x86_64|5f0ff97576cde9e43ec86959046169f18ec5bcc08e31d82dcc948d057212f7bf|14511545",
-        "v1.0.0|macos_arm64 |e922c277487d941c4b056cac6c1b4c6e5004e8f3dda65ae2d72d8b10da193297|15147463",
-        "v1.0.0|macos_x86_64|8963e1ab7685aac59b8805cc7d752b06a572b1c747a6342a9e73b94ccdf89ddb|15187858",
+        "v1.3.0|linux_arm64 |fbfd53c501451b36900247734bfa4cbe86ae05d0f51bc298de8711d5ee374ee5|13940828",
+        "v1.3.0|linux_x86_64|e29c4283b1cd68ada41fa493171c41d7605750d258fcd6ecdf692a63fae95213|15267162",
+        "v1.3.0|macos_arm64 |147985d7f2816a545792e38b26178ff4027bf16cd3712f6e387a4e3692a16deb|15391890",
+        "v1.3.0|macos_x86_64|3b6bd2e5a5dd758178aee01fb067261baf5d31bfebe93336915bfdf7b21928c4|15955291",
     ]
     default_url_template = (
         "https://github.com/bufbuild/buf/releases/download/{version}/buf-{platform}.tar.gz"
@@ -30,8 +30,10 @@ class BufSubsystem(TemplatedExternalTool):
         "linux_x86_64": "Linux-x86_64",
     }
 
-    skip = SkipOption("lint")
-    args = ArgsListOption(example="--error-format json")
+    skip_format = SkipOption("fmt", "lint", flag_name="--format-skip")
+    skip_lint = SkipOption("lint", flag_name="--lint-skip")
+    format_args = ArgsListOption(example="--error-format json", flag_name="--format-args")
+    lint_args = ArgsListOption(example="--error-format json", flag_name="--lint-args")
 
     def generate_exe(self, plat: Platform) -> str:
         return "./buf/bin/buf"

--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -316,6 +316,10 @@ class ChmodBinary(BinaryPath):
     pass
 
 
+class DiffBinary(BinaryPath):
+    pass
+
+
 # -------------------------------------------------------------------------------------------
 # Binaries Rules
 # -------------------------------------------------------------------------------------------
@@ -632,6 +636,14 @@ async def find_chmod() -> ChmodBinary:
     return ChmodBinary(first_path.path, first_path.fingerprint)
 
 
+@rule(desc="Finding the `diff` binary", level=LogLevel.DEBUG)
+async def find_diff() -> DiffBinary:
+    request = BinaryPathRequest(binary_name="diff", search_path=SEARCH_PATHS)
+    paths = await Get(BinaryPaths, BinaryPathRequest, request)
+    first_path = paths.first_path_or_raise(request, rationale="compare files line by line")
+    return DiffBinary(first_path.path, first_path.fingerprint)
+
+
 # -------------------------------------------------------------------------------------------
 # Rules for lazy requests
 # TODO(#12946): Get rid of this when it becomes possible to use `Get()` with only one arg.
@@ -659,6 +671,10 @@ class MkdirBinaryRequest:
 
 
 class ChmodBinaryRequest:
+    pass
+
+
+class DiffBinaryRequest:
     pass
 
 
@@ -690,6 +706,11 @@ async def find_mkdir_wrapper(_: MkdirBinaryRequest, mkdir_binary: MkdirBinary) -
 @rule
 async def find_chmod_wrapper(_: ChmodBinaryRequest, chmod_binary: ChmodBinary) -> ChmodBinary:
     return chmod_binary
+
+
+@rule
+async def find_diff_wrapper(_: DiffBinaryRequest, diff_binary: DiffBinary) -> DiffBinary:
+    return diff_binary
 
 
 def rules():

--- a/src/python/pants/option/option_types.py
+++ b/src/python/pants/option/option_types.py
@@ -761,12 +761,12 @@ class DictOption(_OptionBase["dict[str, _ValueT]", "dict[str, _ValueT]"], Generi
 class SkipOption(BoolOption[bool]):
     """A --skip option (for an invocable tool)."""
 
-    def __new__(cls, goal: str, *other_goals: str):
+    def __new__(cls, goal: str, *other_goals: str, flag_name: str = "--skip"):
         goals = (goal,) + other_goals
         invocation_str = " and ".join([f"`{bin_name()} {goal}`" for goal in goals])
         return super().__new__(
             cls,  # type: ignore[arg-type]
-            "--skip",
+            flag_name,
             default=False,  # type: ignore[arg-type]
             help=(
                 lambda subsystem_cls: (
@@ -788,12 +788,13 @@ class ArgsListOption(ShellStrListOption):
         # This should be set when callers can alternatively use "--" followed by the arguments,
         # instead of having to provide "--[scope]-args='--arg1 --arg2'".
         passthrough: bool | None = None,
+        flag_name: str = "--args",
     ):
         if extra_help:
             extra_help = "\n\n" + extra_help
         instance = super().__new__(
             cls,  # type: ignore[arg-type]
-            "--args",
+            flag_name,
             help=(
                 lambda subsystem_cls: (
                     f"Arguments to pass directly to {tool_name or subsystem_cls.name}, "


### PR DESCRIPTION
This PR adds support for Protobuf formatting using the newly released `buf format`. I took the libery of bumping the default version of `buf`since `buf format` requires Buf v1.2.0 and above. Right now there's no check to make sure the user is actually on >v1.2.0, but that shouldn't be too hard to add if needed.