### PR TITLE
Prevent ambiguous LintFilesRequest and LintTargetsRequest names

### DIFF
--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -202,10 +202,10 @@ def _check_ambiguous_request_names(
     *requests: Type[LintFilesRequest] | Type[LintTargetsRequest],
 ) -> None:
     for name, request_group in itertools.groupby(requests, key=lambda target: target.name):
-        request_group_list = list(request_group)
+        request_group_set = set(request_group)
 
-        if len(request_group_list) > 1:
-            raise AmbiguousRequestNamesError(name, set(request_group_list))
+        if len(request_group_set) > 1:
+            raise AmbiguousRequestNamesError(name, request_group_set)
 
 
 @goal_rule

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -61,10 +61,6 @@ class SuccessfulRequest(MockLintRequest):
         return 0
 
 
-class AmbiguousLintTargetsRequest(LintTargetsRequest):
-    name = "FilesLinter"
-
-
 class FailingRequest(MockLintRequest):
     name = "FailingLinter"
 
@@ -318,12 +314,15 @@ def test_streaming_output_partitions() -> None:
 
 
 def test_duplicated_names(rule_runner: RuleRunner) -> None:
+    class AmbiguousLintTargetsRequest(LintTargetsRequest):
+        name = "FilesLinter"  # also used by MockFilesRequest
+
     with pytest.raises(AmbiguousRequestNamesError):
         run_lint_rule(
             rule_runner,
             lint_request_types=[
                 AmbiguousLintTargetsRequest,
             ],
-            run_files_linter=True,
+            run_files_linter=True,  # needed for MockFilesRequest
             targets=[],
         )

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -61,12 +61,8 @@ class SuccessfulRequest(MockLintRequest):
         return 0
 
 
-class DuplicatedSuccessfulRequest(MockLintRequest):
-    name = "SuccessfulLinter"
-
-    @staticmethod
-    def exit_code(_: Iterable[Address]) -> int:
-        return 0
+class AmbiguousLintTargetsRequest(LintTargetsRequest):
+    name = "FilesLinter"
 
 
 class FailingRequest(MockLintRequest):
@@ -326,8 +322,8 @@ def test_duplicated_names(rule_runner: RuleRunner) -> None:
         run_lint_rule(
             rule_runner,
             lint_request_types=[
-                SuccessfulRequest,
-                DuplicatedSuccessfulRequest,
+                AmbiguousLintTargetsRequest,
             ],
+            run_files_linter=True,
             targets=[],
         )

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -11,6 +11,7 @@ from typing import Iterable, Optional, Sequence, Tuple, Type
 import pytest
 
 from pants.core.goals.lint import (
+    AmbiguousRequestNamesError,
     Lint,
     LintFilesRequest,
     LintResult,
@@ -53,6 +54,14 @@ class MockLintRequest(LintTargetsRequest, metaclass=ABCMeta):
 
 
 class SuccessfulRequest(MockLintRequest):
+    name = "SuccessfulLinter"
+
+    @staticmethod
+    def exit_code(_: Iterable[Address]) -> int:
+        return 0
+
+
+class DuplicatedSuccessfulRequest(MockLintRequest):
     name = "SuccessfulLinter"
 
     @staticmethod
@@ -310,3 +319,15 @@ def test_streaming_output_partitions() -> None:
 
         """
     )
+
+
+def test_duplicated_names(rule_runner: RuleRunner) -> None:
+    with pytest.raises(AmbiguousRequestNamesError):
+        run_lint_rule(
+            rule_runner,
+            lint_request_types=[
+                SuccessfulRequest,
+                DuplicatedSuccessfulRequest,
+            ],
+            targets=[],
+        )


### PR DESCRIPTION
Some simple validation to make sure that two or more `LintTargetsRequest` don't use the same name which, based on https://github.com/pantsbuild/pants/pull/14907#discussion_r834964838, can cause some havoc. I assume this can cause issues in most goals, so might be interesting to add to more places as well.