### PR TITLE
Fix a breakage in building release pexes.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -351,13 +351,13 @@ jobs:
       name: Build wheels
       run: '[[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && export MODE=debug
 
+        ./build-support/bin/release.sh build-local-pex
+
         ./build-support/bin/release.sh build-wheels
 
         USE_PY38=true ./build-support/bin/release.sh build-wheels
 
         USE_PY39=true ./build-support/bin/release.sh build-wheels
-
-        ./build-support/bin/release.sh build-local-pex
 
         ./build-support/bin/release.sh build-fs-util
 
@@ -450,13 +450,13 @@ jobs:
       name: Build wheels
       run: '[[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && export MODE=debug
 
+        ./build-support/bin/release.sh build-local-pex
+
         ./build-support/bin/release.sh build-wheels
 
         USE_PY38=true ./build-support/bin/release.sh build-wheels
 
         USE_PY39=true ./build-support/bin/release.sh build-wheels
-
-        ./build-support/bin/release.sh build-local-pex
 
         ./build-support/bin/release.sh build-fs-util
 

--- a/build-support/bin/deploy_to_s3.py
+++ b/build-support/bin/deploy_to_s3.py
@@ -41,6 +41,8 @@ def deploy() -> None:
             # distinct shards—which may finish building their wheels at different times—to not
             # overwrite otherwise-identical wheels.
             "--size-only",
+            # Turn off the dynamic progress display, which clutters the CI output.
+            "--no-progress",
             "--acl",
             "public-read",
             "dist/deploy",

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -471,12 +471,16 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
                     "run": dedent(
                         # We use MODE=debug on PR builds to speed things up, given that those are
                         # only smoke tests of our release process.
+                        # Note that the build-local-pex run is just for smoke-testing that pex
+                        # builds work, and it must come *before* the build-wheels runs, since
+                        # it cleans out `dist/deploy`, which the build-wheels runs populate for
+                        # later attention by deploy_to_s3.py.
                         """\
                         [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && export MODE=debug
+                        ./build-support/bin/release.sh build-local-pex
                         ./build-support/bin/release.sh build-wheels
                         USE_PY38=true ./build-support/bin/release.sh build-wheels
                         USE_PY39=true ./build-support/bin/release.sh build-wheels
-                        ./build-support/bin/release.sh build-local-pex
                         ./build-support/bin/release.sh build-fs-util
                         """
                     ),


### PR DESCRIPTION
Issue is subtle, and was introduced in #14813 

This is more evidence that we should look into moving away from all the custom release scriptery, and rely more on regular pantsisms.