### PR TITLE
Write test reports to a standard location under the distdir.

### DIFF
--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -333,9 +333,10 @@ class TestSubsystem(GoalSubsystem):
     report = BoolOption(
         "--report", default=False, advanced=True, help="Write test reports to --report-dir."
     )
+    default_report_path = str(PurePath("{distdir}", "test", "reports"))
     _report_dir = StrOption(
         "--report-dir",
-        default=str(PurePath("{distdir}", "test", "reports")),
+        default=default_report_path,
         advanced=True,
         help="Path to write test reports to. Must be relative to the build root.",
     )
@@ -447,7 +448,7 @@ async def run_tests(
             MergeDigests(result.xml_results.digest for result in results if result.xml_results),
         )
         workspace.write_digest(merged_reports, path_prefix=str(report_dir))
-        console.print_stderr(f"\nWrote test reports to `{report_dir}`")
+        console.print_stderr(f"\nWrote test reports to {report_dir}")
 
     if test_subsystem.use_coverage:
         # NB: We must pre-sort the data for itertools.groupby() to work properly, using the same

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -60,6 +60,8 @@ class TestResult(EngineAwareReturnType):
     result_metadata: ProcessResultMetadata | None
 
     coverage_data: CoverageData | None = None
+    # TODO: Rename this to `reports`. There is no guarantee that every language will produce
+    #  XML reports, or only XML reports.
     xml_results: Snapshot | None = None
     # Any extra output (such as from plugins) that the test runner was configured to output.
     extra_output: Snapshot | None = None
@@ -328,9 +330,23 @@ class TestSubsystem(GoalSubsystem):
             "system supports this."
         ),
     )
+    report = BoolOption(
+        "--report", default=False, advanced=True, help="Write test reports to --report-dir."
+    )
+    _report_dir = StrOption(
+        "--report-dir",
+        default=str(PurePath("{distdir}", "test", "reports")),
+        advanced=True,
+        help="Path to write test reports to. Must be relative to the build root.",
+    )
     xml_dir = StrOption(
         "--xml-dir",
         metavar="<DIR>",
+        removal_version="2.13.0.dev0",
+        removal_hint=(
+            "Set the `report` option in [test] scope to emit reports to a standard location under "
+            "dist/. Set the `report-dir` option to customize that location."
+        ),
         default=None,
         advanced=True,
         help=(
@@ -347,6 +363,9 @@ class TestSubsystem(GoalSubsystem):
         ),
     )
 
+    def report_dir(self, distdir: DistDir) -> PurePath:
+        return PurePath(self._report_dir.format(distdir=distdir.relpath))
+
 
 class Test(Goal):
     subsystem_cls = TestSubsystem
@@ -360,7 +379,7 @@ async def run_tests(
     test_subsystem: TestSubsystem,
     workspace: Workspace,
     union_membership: UnionMembership,
-    dist_dir: DistDir,
+    distdir: DistDir,
     run_id: RunId,
 ) -> Test:
     if test_subsystem.debug:
@@ -416,17 +435,19 @@ async def run_tests(
         if result.extra_output and result.extra_output.files:
             workspace.write_digest(
                 result.extra_output.digest,
-                path_prefix=str(dist_dir.relpath / "test" / result.address.path_safe_spec),
+                path_prefix=str(distdir.relpath / "test" / result.address.path_safe_spec),
             )
 
-    if test_subsystem.xml_dir:
-        xml_dir = test_subsystem.xml_dir
-        merged_xml_results = await Get(
+    if test_subsystem.report or test_subsystem.xml_dir:
+        report_dir = (
+            test_subsystem.report_dir(distdir) if test_subsystem.report else test_subsystem.xml_dir
+        )
+        merged_reports = await Get(
             Digest,
             MergeDigests(result.xml_results.digest for result in results if result.xml_results),
         )
-        workspace.write_digest(merged_xml_results, path_prefix=xml_dir)
-        console.print_stderr(f"\nWrote test XML to `{xml_dir}`")
+        workspace.write_digest(merged_reports, path_prefix=str(report_dir))
+        console.print_stderr(f"\nWrote test reports to `{report_dir}`")
 
     if test_subsystem.use_coverage:
         # NB: We must pre-sort the data for itertools.groupby() to work properly, using the same

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -148,7 +148,8 @@ def run_test_rule(
     targets: list[Target],
     debug: bool = False,
     use_coverage: bool = False,
-    xml_dir: str | None = None,
+    report: bool = False,
+    report_dir: str = TestSubsystem.default_report_path,
     output: ShowOutput = ShowOutput.ALL,
     valid_targets: bool = True,
     run_id: RunId = RunId(999),
@@ -157,7 +158,9 @@ def run_test_rule(
         TestSubsystem,
         debug=debug,
         use_coverage=use_coverage,
-        xml_dir=xml_dir,
+        report=report,
+        report_dir=report_dir,
+        xml_dir=None,
         output=output,
         extra_env_vars=[],
     )
@@ -336,18 +339,32 @@ def test_debug_target(rule_runner: RuleRunner) -> None:
     assert exit_code == 0
 
 
-def test_xml_dir(rule_runner: RuleRunner) -> None:
-    xml_dir = "dist/test-results"
+def test_report(rule_runner: RuleRunner) -> None:
     addr1 = Address("", target_name="t1")
     addr2 = Address("", target_name="t2")
     exit_code, stderr = run_test_rule(
         rule_runner,
         field_set=SuccessfulFieldSet,
         targets=[make_target(addr1), make_target(addr2)],
-        xml_dir=xml_dir,
+        report=True,
     )
     assert exit_code == 0
-    assert f"Wrote test XML to `{xml_dir}`" in stderr
+    assert "Wrote test reports to dist/test/reports" in stderr
+
+
+def test_report_dir(rule_runner: RuleRunner) -> None:
+    report_dir = "dist/test-results"
+    addr1 = Address("", target_name="t1")
+    addr2 = Address("", target_name="t2")
+    exit_code, stderr = run_test_rule(
+        rule_runner,
+        field_set=SuccessfulFieldSet,
+        targets=[make_target(addr1), make_target(addr2)],
+        report=True,
+        report_dir=report_dir,
+    )
+    assert exit_code == 0
+    assert f"Wrote test reports to {report_dir}" in stderr
 
 
 def test_coverage(rule_runner: RuleRunner) -> None:


### PR DESCRIPTION
Now users can turn reporting on with --report, without having
to fiddle with the location, but can still modify that location
if necessary. This is similar to how coverage reports work.

Also fixes an issue where we hardcoded `dist/` as the default for
coverage reports, instead of using distdir.

Note that user can, as before, set a custom path outside the
distdir (as they can for coverage reports), but this change makes
it more likely the reports will go to dist/, which is probably gitignored.

[ci skip-rust]

[ci skip-build-wheels]