### PR TITLE
Fix unrecognized field error and `update-build-files` to handle target generator moved fields (Cherry-pick of #14847)

### DIFF
--- a/src/python/pants/core/goals/update_build_files_test.py
+++ b/src/python/pants/core/goals/update_build_files_test.py
@@ -22,6 +22,7 @@ from pants.core.goals.update_build_files import (
     RewrittenBuildFileRequest,
     UpdateBuildFilesGoal,
     UpdateBuildFilesSubsystem,
+    determine_renamed_field_types,
     format_build_file_with_black,
     format_build_file_with_yapf,
     maybe_rename_deprecated_fields,
@@ -30,8 +31,10 @@ from pants.core.goals.update_build_files import (
 )
 from pants.core.util_rules import config_files
 from pants.engine.rules import SubsystemRule, rule
-from pants.engine.unions import UnionRule
+from pants.engine.target import RegisteredTargetTypes, StringField, Target, TargetGenerator
+from pants.engine.unions import UnionMembership, UnionRule
 from pants.testutil.rule_runner import GoalRuleResult, RuleRunner
+from pants.util.frozendict import FrozenDict
 
 # ------------------------------------------------------------------------------------------
 # Generic goal
@@ -286,6 +289,34 @@ def test_rename_deprecated_target_types_rewrite(lines: list[str], expected: list
 # ------------------------------------------------------------------------------------------
 
 
+def test_determine_renamed_fields() -> None:
+    class DeprecatedField(StringField):
+        alias = "new_name"
+        deprecated_alias = "old_name"
+        deprecated_alias_removal_version = "99.9.0.dev0"
+
+    class OkayField(StringField):
+        alias = "okay"
+
+    class Tgt(Target):
+        alias = "tgt"
+        core_fields = (DeprecatedField, OkayField)
+        deprecated_alias = "deprecated_tgt"
+        deprecated_alias_removal_version = "99.9.0.dev0"
+
+    class TgtGenerator(TargetGenerator):
+        alias = "generator"
+        core_fields = ()
+        moved_fields = (DeprecatedField, OkayField)
+
+    registered_targets = RegisteredTargetTypes.create([Tgt, TgtGenerator])
+    result = determine_renamed_field_types(registered_targets, UnionMembership({}))
+    deprecated_fields = FrozenDict({DeprecatedField.deprecated_alias: DeprecatedField.alias})
+    assert result.target_field_renames == FrozenDict(
+        {k: deprecated_fields for k in (TgtGenerator.alias, Tgt.alias, Tgt.deprecated_alias)}
+    )
+
+
 @pytest.mark.parametrize(
     "lines",
     (
@@ -320,7 +351,7 @@ def test_rename_deprecated_field_types_noops(lines: list[str]) -> None:
 )
 def test_rename_deprecated_field_types_rewrite(lines: list[str], expected: list[str]) -> None:
     result = maybe_rename_deprecated_fields(
-        RenameDeprecatedTargetsRequest("BUILD", tuple(lines), colors_enabled=False),
+        RenameDeprecatedFieldsRequest("BUILD", tuple(lines), colors_enabled=False),
         RenamedFieldTypes.from_dict({"tgt1": {"deprecated_name": "new_name"}}),
     )
     assert result.change_descriptions

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -351,9 +351,20 @@ class Target:
             valid_aliases.add(field_type.alias)
             aliases_to_field_types[field_type.alias] = field_type
             if field_type.deprecated_alias is not None:
+                valid_aliases.add(field_type.deprecated_alias)
                 aliases_to_field_types[field_type.deprecated_alias] = field_type
+
         for alias, value in unhydrated_values.items():
             if alias not in aliases_to_field_types:
+                if isinstance(self, TargetGenerator):
+                    # Even though moved_fields don't live on the target generator, they are valid
+                    # for users to specify. It's intentional that these are only used for
+                    # `InvalidFieldException` and are not stored as normal fields with
+                    # `aliases_to_field_types`.
+                    for field_type in self.moved_fields:
+                        valid_aliases.add(field_type.alias)
+                        if field_type.deprecated_alias is not None:
+                            valid_aliases.add(field_type.deprecated_alias)
                 raise InvalidFieldException(
                     f"Unrecognized field `{alias}={value}` in target {address}. Valid fields for "
                     f"the target type `{self.alias}`: {sorted(valid_aliases)}.",


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/14839.

I debated playing with changing more core functions like `Target.class_field_types`, but I think that has too much fallout. It's better to have the appropriate call-sites (`help`, unrecognized field error, and `update-build-files`) indicate they need moved fields.

[ci skip-rust]
[ci skip-build-wheels]