### PR TITLE
Fix missing `check` output by allowing disabled workunits to re-enable themselves

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -3980,6 +3980,7 @@ dependencies = [
  "bytes",
  "concrete_time",
  "deepsize",
+ "futures",
  "hashing",
  "hdrhistogram",
  "internment",

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -88,10 +88,12 @@ impl crate::CommandRunner for CommandRunner {
             }
             // When we successfully use the cache, we change the description and increase the level
             // (but not so much that it will be logged by default).
-            workunit.update_metadata(|initial| WorkunitMetadata {
-              desc: initial.desc.as_ref().map(|desc| format!("Hit: {}", desc)),
-              level: Level::Debug,
-              ..initial
+            workunit.update_metadata(|initial| {
+              initial.map(|initial| WorkunitMetadata {
+                desc: initial.desc.as_ref().map(|desc| format!("Hit: {}", desc)),
+                level: Level::Debug,
+                ..initial
+              })
             });
             Ok(result)
           }

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -808,13 +808,15 @@ impl crate::CommandRunner for CommandRunner {
         let result_fut = self.run_execute_request(execute_request, request, &context2, workunit);
         let result = tokio::time::timeout(deadline_duration, result_fut).await;
         if result.is_err() {
-          workunit.update_metadata(|inititial| WorkunitMetadata {
-            level: Level::Error,
-            desc: Some(format!(
-              "remote execution timed out after {:?}",
-              deadline_duration
-            )),
-            ..inititial
+          workunit.update_metadata(|initial| {
+            Some(WorkunitMetadata {
+              level: Level::Error,
+              desc: Some(format!(
+                "remote execution timed out after {:?}",
+                deadline_duration
+              )),
+              ..initial.unwrap_or_default()
+            })
           })
         }
 

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -298,14 +298,17 @@ impl CommandRunner {
               }
               // When we successfully use the cache, we change the description and increase the level
               // (but not so much that it will be logged by default).
-              workunit.update_metadata(|initial| WorkunitMetadata {
-                desc: initial
-                  .desc
-                  .as_ref()
-                  .map(|desc| format!("Hit: {}", desc)),
-                level: Level::Debug,
-                ..initial
+              workunit.update_metadata(|initial| {
+                initial.map(|initial|
+                WorkunitMetadata {
+                  desc: initial
+                    .desc
+                    .as_ref()
+                    .map(|desc| format!("Hit: {}", desc)),
+                  level: Level::Debug,
+                  ..initial
 
+                })
               });
               Ok((cached_response, true))
             } else {

--- a/src/rust/engine/src/externs/engine_aware.rs
+++ b/src/rust/engine/src/externs/engine_aware.rs
@@ -18,32 +18,30 @@ use workunit_store::{ArtifactOutput, Level, RunningWorkunit, UserMetadataItem};
 // be like the user did not set extra metadata.
 
 #[derive(Default, Clone, Debug)]
-pub(crate) struct EngineAwareReturnType {
-  level: Option<Level>,
-  message: Option<String>,
-  metadata: Vec<(String, UserMetadataItem)>,
-  artifacts: Vec<(String, ArtifactOutput)>,
-}
+pub(crate) struct EngineAwareReturnType;
 
 impl EngineAwareReturnType {
-  pub(crate) fn from_task_result(task_result: &PyAny) -> Self {
-    Self {
-      level: Self::level(task_result),
-      message: Self::message(task_result),
-      artifacts: Self::artifacts(task_result).unwrap_or_else(Vec::new),
-      metadata: metadata(task_result).unwrap_or_else(Vec::new),
-    }
-  }
+  pub(crate) fn update_workunit(workunit: &mut RunningWorkunit, task_result: &PyAny) {
+    workunit.update_metadata(|old_metadata| {
+      let new_level = Self::level(task_result);
+      // If the metadata already existed, or if its level changed, we need to update it.
+      let mut metadata = if new_level.is_some() || old_metadata.is_some() {
+        old_metadata.unwrap_or_default()
+      } else {
+        return None;
+      };
 
-  pub(crate) fn update_workunit(self, workunit: &mut RunningWorkunit) {
-    workunit.update_metadata(|mut metadata| {
-      if let Some(new_level) = self.level {
+      if let Some(new_level) = new_level {
         metadata.level = new_level;
       }
-      metadata.message = self.message;
-      metadata.artifacts.extend(self.artifacts);
-      metadata.user_metadata.extend(self.metadata);
+      metadata.message = Self::message(task_result);
       metadata
+        .artifacts
+        .extend(Self::artifacts(task_result).unwrap_or_else(Vec::new));
+      metadata
+        .user_metadata
+        .extend(metadata_for(task_result).unwrap_or_else(Vec::new));
+      Some(metadata)
     });
   }
 
@@ -103,11 +101,11 @@ impl EngineAwareParameter {
   }
 
   pub fn metadata(obj: &PyAny) -> Vec<(String, UserMetadataItem)> {
-    metadata(obj).unwrap_or_else(Vec::new)
+    metadata_for(obj).unwrap_or_else(Vec::new)
   }
 }
 
-fn metadata(obj: &PyAny) -> Option<Vec<(String, UserMetadataItem)>> {
+fn metadata_for(obj: &PyAny) -> Option<Vec<(String, UserMetadataItem)>> {
   let metadata_val = obj.call_method0("metadata").ok()?;
   if metadata_val.is_none() {
     return None;

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -22,4 +22,6 @@ strum_macros = "0.23"
 tokio = { version = "1.16", features = ["rt", "sync"] }
 
 [dev-dependencies]
+futures = "0.3"
 internment = "0.6"
+tokio = { version = "1.16", features = ["macros"] }


### PR DESCRIPTION
#13483 broke the rendering of `EngineAwareReturnType` implementations which relied on starting a workunit at `Level::TRACE`, and then escalating its level to something visible (usually `INFO` or greater) when it completed. `check` outputs for the JVM were strongly affected (see #14867), since they relied on the fact that `FallibleClasspathEntry` escalates to `ERROR` to render compile errors.

To resolve this, we roll back a portion of #13483. Rather than not recording the workunit at all, we instead record it in the `WorkunitStore` as "disabled", which is signaled by a workunit not having any `WorkunitMetadata`. This has some of the efficiency benefits of #13483 (because we continue to skip heap allocating the metadata's fields), but allows a workunit to escalate itself from disabled to enabled as it completes by specifying a non-disabled level in `RunningWorkunit::update_metadata`.

The recording of "disabled" workunits is additionally necessary for #14680, because otherwise workunits which were not actually recorded would break the tracking of multiple parents: when adding a new parent to a workunit, you need an existing `SpanId` corresponding to the work that you are adding a parent to (or else you might accidentally depend on a parent arbitrarily far up the stack).

Fixes #14867.