### PR TITLE
Frontload PR label checks to occur before any other jobs.

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -13,18 +13,9 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: ${{ github.repository_owner == 'pantsbuild' }}
     name: Bootstrap Pants, test+lint Rust (Linux)
+    needs: check_labels
     runs-on: ubuntu-20.04
     steps:
-    - env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      if: github.event_name == 'pull_request'
-      name: Ensure category label
-      uses: mheap/github-action-required-labels@v1
-      with:
-        count: 1
-        labels: category:new feature, category:user api change, category:plugin api
-          change, category:performance, category:bugfix, category:documentation, category:internal
-        mode: exactly
     - name: Check out code
       uses: actions/checkout@v2
       with:
@@ -174,6 +165,7 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: ${{ github.repository_owner == 'pantsbuild' }}
     name: Bootstrap Pants, test Rust (macOS)
+    needs: check_labels
     runs-on: macos-10.15
     steps:
     - env:
@@ -301,6 +293,21 @@ jobs:
         - '3.8'
         - '3.9'
     timeout-minutes: 40
+  check_labels:
+    if: ${{ github.repository_owner == 'pantsbuild' }}
+    name: Ensure PR has a category label
+    runs-on: ubuntu-20.04
+    steps:
+    - env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      if: github.event_name == 'pull_request'
+      name: Ensure category label
+      uses: mheap/github-action-required-labels@v1
+      with:
+        count: 1
+        labels: category:new feature, category:user api change, category:plugin api
+          change, category:performance, category:bugfix, category:documentation, category:internal
+        mode: exactly
   lint_python:
     if: ${{ github.repository_owner == 'pantsbuild' }}
     name: Lint Python and Shell

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,18 +13,9 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: ${{ github.repository_owner == 'pantsbuild' }}
     name: Bootstrap Pants, test+lint Rust (Linux)
+    needs: check_labels
     runs-on: ubuntu-20.04
     steps:
-    - env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      if: github.event_name == 'pull_request'
-      name: Ensure category label
-      uses: mheap/github-action-required-labels@v1
-      with:
-        count: 1
-        labels: category:new feature, category:user api change, category:plugin api
-          change, category:performance, category:bugfix, category:documentation, category:internal
-        mode: exactly
     - name: Check out code
       uses: actions/checkout@v2
       with:
@@ -173,6 +164,7 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: ${{ github.repository_owner == 'pantsbuild' }}
     name: Bootstrap Pants, test Rust (macOS)
+    needs: check_labels
     runs-on: macos-10.15
     steps:
     - env:
@@ -306,6 +298,7 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: ${{ github.repository_owner == 'pantsbuild' }}
     name: Build wheels and fs_util (Linux x86/64)
+    needs: check_labels
     runs-on: ubuntu-20.04
     steps:
     - name: Check out code
@@ -386,6 +379,7 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: ${{ github.repository_owner == 'pantsbuild' }}
     name: Build wheels and fs_util (macOS x86/64)
+    needs: check_labels
     runs-on: macos-10.15
     steps:
     - name: Check out code
@@ -480,6 +474,21 @@ jobs:
       name: Deploy to S3
       run: ./build-support/bin/deploy_to_s3.py
     timeout-minutes: 80
+  check_labels:
+    if: ${{ github.repository_owner == 'pantsbuild' }}
+    name: Ensure PR has a category label
+    runs-on: ubuntu-20.04
+    steps:
+    - env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      if: github.event_name == 'pull_request'
+      name: Ensure category label
+      uses: mheap/github-action-required-labels@v1
+      with:
+        count: 1
+        labels: category:new feature, category:user api change, category:plugin api
+          change, category:performance, category:bugfix, category:documentation, category:internal
+        mode: exactly
   lint_python:
     if: ${{ github.repository_owner == 'pantsbuild' }}
     name: Lint Python and Shell


### PR DESCRIPTION
Since the label checks were running within jobs used for other purposes, they would tie up waiting for macOS shards to be available. Making them a pre-req of all other relevant jobs prevents anything from starting until the label has been checked.