### PR TITLE
Fix missing `check` output by allowing disabled workunits to re-enable themselves (cherrypick of #14854, #14856, #14934)

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -3982,6 +3982,7 @@ dependencies = [
  "deepsize",
  "hashing",
  "hdrhistogram",
+ "internment",
  "log",
  "parking_lot 0.12.0",
  "petgraph",

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -3987,6 +3987,7 @@ dependencies = [
  "parking_lot 0.12.0",
  "petgraph",
  "rand 0.8.5",
+ "smallvec",
  "strum",
  "strum_macros",
  "tokio",

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -3980,6 +3980,7 @@ dependencies = [
  "bytes",
  "concrete_time",
  "deepsize",
+ "futures",
  "hashing",
  "hdrhistogram",
  "internment",

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -22,7 +22,7 @@ use remexec::{
   ServerCapabilities,
 };
 use tonic::{Code, Request, Status};
-use workunit_store::{in_workunit, Metric, ObservationMetric, WorkunitMetadata};
+use workunit_store::{in_workunit, Metric, ObservationMetric};
 
 #[derive(Clone)]
 pub struct ByteStore {
@@ -273,11 +273,7 @@ impl ByteStore {
       digest.hash,
       digest.size_bytes,
     );
-    let workunit_name = format!("store_bytes({})", resource_name.clone());
-    let workunit_metadata = WorkunitMetadata {
-      level: Level::Debug,
-      ..WorkunitMetadata::default()
-    };
+    let workunit_desc = format!("Storing bytes at: {resource_name}");
     let store = self.clone();
 
     let mut client = self.byte_stream_client.as_ref().clone();
@@ -319,24 +315,19 @@ impl ByteStore {
       }
     });
 
-    if let Some(workunit_store_handle) = workunit_store::get_workunit_store_handle() {
-      let workunit_store = workunit_store_handle.store;
-      in_workunit!(
-        workunit_store,
-        workunit_name,
-        workunit_metadata,
-        |workunit| async move {
-          let result = result_future.await;
-          if result.is_ok() {
-            workunit.increment_counter(Metric::RemoteStoreBlobBytesUploaded, len as u64);
-          }
-          result
-        },
-      )
-      .await
-    } else {
-      result_future.await
-    }
+    in_workunit!(
+      "store_bytes",
+      Level::Trace,
+      desc = Some(workunit_desc),
+      |workunit| async move {
+        let result = result_future.await;
+        if result.is_ok() {
+          workunit.increment_counter(Metric::RemoteStoreBlobBytesUploaded, len as u64);
+        }
+        result
+      },
+    )
+    .await
   }
 
   pub async fn load_bytes_with<
@@ -357,12 +348,7 @@ impl ByteStore {
       digest.hash,
       digest.size_bytes
     );
-    let workunit_metadata = WorkunitMetadata {
-      level: Level::Trace,
-      desc: Some(format!("Loading bytes at: {resource_name}")),
-      ..WorkunitMetadata::default()
-    };
-    let resource_name = resource_name.clone();
+    let workunit_desc = format!("Loading bytes at: {resource_name}");
     let f = f.clone();
 
     let mut client = self.byte_stream_client.as_ref().clone();
@@ -373,7 +359,7 @@ impl ByteStore {
       let stream_result = client
         .read({
           protos::gen::google::bytestream::ReadRequest {
-            resource_name: resource_name.clone(),
+            resource_name,
             read_offset: 0,
             // 0 means no limit.
             read_limit: 0,
@@ -436,30 +422,26 @@ impl ByteStore {
       }
     };
 
-    if let Some(workunit_store_handle) = workunit_store::get_workunit_store_handle() {
-      workunit_store_handle.store.record_observation(
-        ObservationMetric::RemoteStoreReadBlobTimeMicros,
-        start.elapsed().as_micros() as u64,
-      );
-      in_workunit!(
-        workunit_store_handle.store,
-        "load_bytes_with".to_owned(),
-        workunit_metadata,
-        |workunit| async move {
-          let result = result_future.await;
-          if result.is_ok() {
-            workunit.increment_counter(
-              Metric::RemoteStoreBlobBytesDownloaded,
-              digest.size_bytes as u64,
-            );
-          }
-          result
-        },
-      )
-      .await
-    } else {
-      result_future.await
-    }
+    in_workunit!(
+      "load_bytes_with",
+      Level::Trace,
+      desc = Some(workunit_desc),
+      |workunit| async move {
+        workunit.record_observation(
+          ObservationMetric::RemoteStoreReadBlobTimeMicros,
+          start.elapsed().as_micros() as u64,
+        );
+        let result = result_future.await;
+        if result.is_ok() {
+          workunit.increment_counter(
+            Metric::RemoteStoreBlobBytesDownloaded,
+            digest.size_bytes as u64,
+          );
+        }
+        result
+      },
+    )
+    .await
   }
 
   ///
@@ -471,47 +453,33 @@ impl ByteStore {
     request: remexec::FindMissingBlobsRequest,
   ) -> impl Future<Output = Result<HashSet<Digest>, String>> {
     let store = self.clone();
-    let workunit_name = format!(
-      "list_missing_digests({})",
-      store.instance_name.clone().unwrap_or_default()
-    );
-    let workunit_metadata = WorkunitMetadata {
-      level: Level::Debug,
-      ..WorkunitMetadata::default()
-    };
-    let result_future = async move {
-      let store2 = store.clone();
-      let client = store2.cas_client.as_ref().clone();
-      let response = retry_call(
-        client,
-        move |mut client| {
-          let request = request.clone();
-          async move { client.find_missing_blobs(request).await }
-        },
-        status_is_retryable,
+    async {
+      in_workunit!(
+        "list_missing_digests",
+        Level::Debug,
+        |_workunit| async move {
+          let store2 = store.clone();
+          let client = store2.cas_client.as_ref().clone();
+          let response = retry_call(
+            client,
+            move |mut client| {
+              let request = request.clone();
+              async move { client.find_missing_blobs(request).await }
+            },
+            status_is_retryable,
+          )
+          .await
+          .map_err(status_to_str)?;
+
+          response
+            .into_inner()
+            .missing_blob_digests
+            .iter()
+            .map(|digest| digest.try_into())
+            .collect::<Result<HashSet<_>, _>>()
+        }
       )
       .await
-      .map_err(status_to_str)?;
-
-      response
-        .into_inner()
-        .missing_blob_digests
-        .iter()
-        .map(|digest| digest.try_into())
-        .collect::<Result<HashSet<_>, _>>()
-    };
-    async {
-      if let Some(workunit_store_handle) = workunit_store::get_workunit_store_handle() {
-        in_workunit!(
-          workunit_store_handle.store,
-          workunit_name,
-          workunit_metadata,
-          |_workunit| result_future,
-        )
-        .await
-      } else {
-        result_future.await
-      }
     }
   }
 

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -6,6 +6,7 @@ use grpc_util::tls;
 use hashing::Digest;
 use mock::StubCAS;
 use testutil::data::{TestData, TestDirectory};
+use workunit_store::WorkunitStore;
 
 use crate::remote::ByteStore;
 use crate::tests::{big_file_bytes, big_file_fingerprint, new_cas};
@@ -26,6 +27,7 @@ async fn loads_file() {
 
 #[tokio::test]
 async fn missing_file() {
+  let _ = WorkunitStore::setup_for_tests();
   let cas = StubCAS::empty();
 
   assert_eq!(
@@ -47,6 +49,7 @@ async fn load_directory() {
 
 #[tokio::test]
 async fn missing_directory() {
+  let _ = WorkunitStore::setup_for_tests();
   let cas = StubCAS::empty();
 
   assert_eq!(
@@ -61,6 +64,7 @@ async fn missing_directory() {
 
 #[tokio::test]
 async fn load_file_grpc_error() {
+  let _ = WorkunitStore::setup_for_tests();
   let cas = StubCAS::always_errors();
 
   let error = load_file_bytes(&new_byte_store(&cas), TestData::roland().digest())
@@ -75,6 +79,7 @@ async fn load_file_grpc_error() {
 
 #[tokio::test]
 async fn load_directory_grpc_error() {
+  let _ = WorkunitStore::setup_for_tests();
   let cas = StubCAS::always_errors();
 
   let error = load_directory_proto_bytes(
@@ -148,6 +153,7 @@ async fn write_file_one_chunk() {
 
 #[tokio::test]
 async fn write_file_multiple_chunks() {
+  let _ = WorkunitStore::setup_for_tests();
   let cas = StubCAS::empty();
 
   let store = ByteStore::new(
@@ -263,6 +269,7 @@ async fn list_missing_digests_none_missing() {
 
 #[tokio::test]
 async fn list_missing_digests_some_missing() {
+  let _ = WorkunitStore::setup_for_tests();
   let cas = StubCAS::empty();
 
   let store = new_byte_store(&cas);
@@ -282,6 +289,7 @@ async fn list_missing_digests_some_missing() {
 
 #[tokio::test]
 async fn list_missing_digests_error() {
+  let _ = WorkunitStore::setup_for_tests();
   let cas = StubCAS::always_errors();
 
   let store = new_byte_store(&cas);

--- a/src/rust/engine/process_execution/src/bounded.rs
+++ b/src/rust/engine/process_execution/src/bounded.rs
@@ -13,7 +13,7 @@ use regex::Regex;
 use task_executor::Executor;
 use tokio::sync::{Notify, Semaphore, SemaphorePermit};
 use tokio::time::sleep;
-use workunit_store::{in_workunit, RunningWorkunit, WorkunitMetadata};
+use workunit_store::{in_workunit, RunningWorkunit};
 
 use crate::{Context, FallibleProcessResultWithPlatform, Process};
 
@@ -63,19 +63,15 @@ impl crate::CommandRunner for CommandRunner {
   ) -> Result<FallibleProcessResultWithPlatform, String> {
     let semaphore_acquisition = self.sema.acquire(process.concurrency_available);
     let permit = in_workunit!(
-      context.workunit_store.clone(),
-      "acquire_command_runner_slot".to_owned(),
-      WorkunitMetadata {
-        // TODO: The UI uses the presence of a blocked workunit below a parent as an indication that
-        // the parent is blocked. If this workunit is filtered out, parents nodes which are waiting
-        // for the semaphore will render, even though they are effectively idle.
-        //
-        // https://github.com/pantsbuild/pants/issues/14680 will likely allow for a more principled
-        // solution to this problem, such as removing the mutable `blocking` flag, and then never
-        // filtering blocked workunits at creation time, regardless of level.
-        level: Level::Debug,
-        ..WorkunitMetadata::default()
-      },
+      "acquire_command_runner_slot",
+      // TODO: The UI uses the presence of a blocked workunit below a parent as an indication that
+      // the parent is blocked. If this workunit is filtered out, parents nodes which are waiting
+      // for the semaphore will render, even though they are effectively idle.
+      //
+      // https://github.com/pantsbuild/pants/issues/14680 will likely allow for a more principled
+      // solution to this problem, such as removing the mutable `blocking` flag, and then never
+      // filtering blocked workunits at creation time, regardless of level.
+      Level::Debug,
       |workunit| async move {
         let _blocking_token = workunit.blocking();
         semaphore_acquisition.await

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -88,10 +88,12 @@ impl crate::CommandRunner for CommandRunner {
             }
             // When we successfully use the cache, we change the description and increase the level
             // (but not so much that it will be logged by default).
-            workunit.update_metadata(|initial| WorkunitMetadata {
-              desc: initial.desc.as_ref().map(|desc| format!("Hit: {}", desc)),
-              level: Level::Debug,
-              ..initial
+            workunit.update_metadata(|initial| {
+              initial.map(|initial| WorkunitMetadata {
+                desc: initial.desc.as_ref().map(|desc| format!("Hit: {}", desc)),
+                level: Level::Debug,
+                ..initial
+              })
             });
             Ok(result)
           }

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -69,13 +69,9 @@ impl crate::CommandRunner for CommandRunner {
     let context2 = context.clone();
     let key2 = key.clone();
     let cache_read_result = in_workunit!(
-      context.workunit_store.clone(),
-      "local_cache_read".to_owned(),
-      WorkunitMetadata {
-        level: Level::Trace,
-        desc: Some(format!("Local cache lookup: {}", req.description)),
-        ..WorkunitMetadata::default()
-      },
+      "local_cache_read",
+      Level::Trace,
+      desc = Some(format!("Local cache lookup: {}", req.description)),
       |workunit| async move {
         workunit.increment_counter(Metric::LocalCacheRequests, 1);
 
@@ -126,23 +122,15 @@ impl crate::CommandRunner for CommandRunner {
     let result = self.underlying.run(context.clone(), workunit, req).await?;
     if result.exit_code == 0 || write_failures_to_cache {
       let result = result.clone();
-      in_workunit!(
-        context.workunit_store.clone(),
-        "local_cache_write".to_owned(),
-        WorkunitMetadata {
-          level: Level::Trace,
-          ..WorkunitMetadata::default()
-        },
-        |workunit| async move {
-          if let Err(err) = self.store(&key, &result).await {
-            warn!(
-              "Error storing process execution result to local cache: {} - ignoring and continuing",
-              err
-            );
-            workunit.increment_counter(Metric::LocalCacheWriteErrors, 1);
-          }
+      in_workunit!("local_cache_write", Level::Trace, |workunit| async move {
+        if let Err(err) = self.store(&key, &result).await {
+          warn!(
+            "Error storing process execution result to local cache: {} - ignoring and continuing",
+            err
+          );
+          workunit.increment_counter(Metric::LocalCacheWriteErrors, 1);
         }
-      )
+      })
       .await;
     }
     Ok(result)

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -690,7 +690,6 @@ async fn prepare_workdir_exclusive_relative() {
     work_dir.path().to_owned(),
     &process,
     TestDirectory::recursive().directory_digest(),
-    Context::default(),
     store,
     executor,
     &named_caches,

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -10,7 +10,7 @@ use nails::execution::{self, child_channel, ChildInput, Command};
 use store::Store;
 use task_executor::Executor;
 use tokio::net::TcpStream;
-use workunit_store::{in_workunit, Metric, RunningWorkunit, WorkunitMetadata};
+use workunit_store::{in_workunit, Metric, RunningWorkunit};
 
 use crate::local::{prepare_workdir, CapturedWorkdir, ChildOutput};
 use crate::{Context, FallibleProcessResultWithPlatform, InputDigests, Platform, Process};
@@ -122,15 +122,11 @@ impl super::CommandRunner for CommandRunner {
     debug!("Running request under nailgun:\n {:?}", req);
 
     in_workunit!(
-      context.workunit_store.clone(),
-      "run_nailgun_process".to_owned(),
-      WorkunitMetadata {
-        // NB: See engine::nodes::NodeKey::workunit_level for more information on why this workunit
-        // renders at the Process's level.
-        level: req.level,
-        desc: Some(req.description.clone()),
-        ..WorkunitMetadata::default()
-      },
+      "run_nailgun_process",
+      // NB: See engine::nodes::NodeKey::workunit_level for more information on why this workunit
+      // renders at the Process's level.
+      req.level,
+      desc = Some(req.description.clone()),
       |workunit| async move {
         workunit.increment_counter(Metric::LocalExecutionRequests, 1);
 
@@ -161,7 +157,6 @@ impl super::CommandRunner for CommandRunner {
           .nailgun_pool
           .acquire(
             server_req,
-            context.clone(),
             self.inner.named_caches(),
             self.inner.immutable_inputs(),
           )
@@ -173,7 +168,6 @@ impl super::CommandRunner for CommandRunner {
           nailgun_process.workdir_path().to_owned(),
           &client_req,
           client_req.input_digests.input_files.clone(),
-          context.clone(),
           self.inner.store.clone(),
           self.executor.clone(),
           self.inner.named_caches(),

--- a/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
@@ -22,7 +22,7 @@ use task_executor::Executor;
 use tempfile::TempDir;
 
 use crate::local::prepare_workdir;
-use crate::{Context, ImmutableInputs, NamedCaches, Process, ProcessMetadata};
+use crate::{ImmutableInputs, NamedCaches, Process, ProcessMetadata};
 
 lazy_static! {
   static ref NAILGUN_PORT_REGEX: Regex = Regex::new(r".*\s+port\s+(\d+)\.$").unwrap();
@@ -86,7 +86,6 @@ impl NailgunPool {
   pub async fn acquire(
     &self,
     server_process: Process,
-    context: Context,
     named_caches: &NamedCaches,
     immutable_inputs: &ImmutableInputs,
   ) -> Result<BorrowedNailgunProcess, String> {
@@ -129,7 +128,6 @@ impl NailgunPool {
         name.clone(),
         server_process,
         &self.workdir_base,
-        context,
         &self.store,
         self.executor.clone(),
         named_caches,
@@ -337,7 +335,6 @@ impl NailgunProcess {
     name: String,
     startup_options: Process,
     workdir_base: &Path,
-    context: Context,
     store: &Store,
     executor: Executor,
     named_caches: &NamedCaches,
@@ -357,7 +354,6 @@ impl NailgunProcess {
       workdir.path().to_owned(),
       &startup_options,
       startup_options.input_digests.input_files.clone(),
-      context.clone(),
       store.clone(),
       executor.clone(),
       named_caches,

--- a/src/rust/engine/process_execution/src/nailgun/tests.rs
+++ b/src/rust/engine/process_execution/src/nailgun/tests.rs
@@ -7,7 +7,7 @@ use testutil::owned_string_vec;
 use workunit_store::WorkunitStore;
 
 use crate::nailgun::NailgunPool;
-use crate::{Context, ImmutableInputs, NamedCaches, Process};
+use crate::{ImmutableInputs, NamedCaches, Process};
 
 fn pool(size: usize) -> (NailgunPool, NamedCaches, ImmutableInputs) {
   let _ = WorkunitStore::setup_for_tests();
@@ -34,7 +34,6 @@ async fn run(pool: &(NailgunPool, NamedCaches, ImmutableInputs), port: u16) -> P
         "-c",
         &format!("echo Mock port {}.; sleep 10", port),
       ])),
-      Context::default(),
       &pool.1,
       &pool.2,
     )

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -808,13 +808,15 @@ impl crate::CommandRunner for CommandRunner {
         let result_fut = self.run_execute_request(execute_request, request, &context2, workunit);
         let result = tokio::time::timeout(deadline_duration, result_fut).await;
         if result.is_err() {
-          workunit.update_metadata(|inititial| WorkunitMetadata {
-            level: Level::Error,
-            desc: Some(format!(
-              "remote execution timed out after {:?}",
-              deadline_duration
-            )),
-            ..inititial
+          workunit.update_metadata(|initial| {
+            Some(WorkunitMetadata {
+              level: Level::Error,
+              desc: Some(format!(
+                "remote execution timed out after {:?}",
+                deadline_duration
+              )),
+              ..initial.unwrap_or_default()
+            })
           })
         }
 

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -788,7 +788,6 @@ impl crate::CommandRunner for CommandRunner {
 
     // Upload the action (and related data, i.e. the embedded command and input files).
     ensure_action_uploaded(
-      &context,
       &self.store,
       command_digest,
       action_digest,
@@ -799,15 +798,11 @@ impl crate::CommandRunner for CommandRunner {
     // Submit the execution request to the RE server for execution.
     let context2 = context.clone();
     in_workunit!(
-      context.workunit_store.clone(),
-      "run_execute_request".to_owned(),
-      WorkunitMetadata {
-        // NB: See engine::nodes::NodeKey::workunit_level for more information on why this workunit
-        // renders at the Process's level.
-        level: request.level,
-        desc: Some(request.description.clone()),
-        ..WorkunitMetadata::default()
-      },
+      "run_execute_request",
+      // NB: See engine::nodes::NodeKey::workunit_level for more information on why this workunit
+      // renders at the Process's level.
+      request.level,
+      desc = Some(request.description.clone()),
       |workunit| async move {
         workunit.increment_counter(Metric::RemoteExecutionRequests, 1);
         let result_fut = self.run_execute_request(execute_request, request, &context2, workunit);
@@ -854,7 +849,7 @@ impl crate::CommandRunner for CommandRunner {
 
 fn maybe_add_workunit(
   result_cached: bool,
-  name: &str,
+  name: &'static str,
   time_span: concrete_time::TimeSpan,
   parent_id: Option<SpanId>,
   workunit_store: &WorkunitStore,
@@ -863,13 +858,7 @@ fn maybe_add_workunit(
   if !result_cached {
     let start_time: SystemTime = SystemTime::UNIX_EPOCH + time_span.start.into();
     let end_time: SystemTime = start_time + time_span.duration.into();
-    workunit_store.add_completed_workunit(
-      name.to_string(),
-      start_time,
-      end_time,
-      parent_id,
-      metadata,
-    );
+    workunit_store.add_completed_workunit(name, start_time, end_time, parent_id, metadata);
   }
 }
 
@@ -1338,13 +1327,9 @@ pub async fn check_action_cache(
   timeout_duration: Duration,
 ) -> Result<Option<FallibleProcessResultWithPlatform>, String> {
   in_workunit!(
-    context.workunit_store.clone(),
-    "check_action_cache".to_owned(),
-    WorkunitMetadata {
-      level: Level::Debug,
-      desc: Some(format!("Remote cache lookup for: {}", command_description)),
-      ..WorkunitMetadata::default()
-    },
+    "check_action_cache",
+    Level::Debug,
+    desc = Some(format!("Remote cache lookup for: {}", command_description)),
     |workunit| async move {
       workunit.increment_counter(Metric::RemoteCacheRequests, 1);
 
@@ -1391,13 +1376,9 @@ pub async fn check_action_cache(
           if eager_fetch {
             let response = response.clone();
             in_workunit!(
-              context.workunit_store.clone(),
-              "eager_fetch_action_cache".to_owned(),
-              WorkunitMetadata {
-                level: Level::Trace,
-                desc: Some("eagerly fetching after action cache hit".to_owned()),
-                ..WorkunitMetadata::default()
-              },
+              "eager_fetch_action_cache",
+              Level::Trace,
+              desc = Some("eagerly fetching after action cache hit".to_owned()),
               |_workunit| async move {
                 future::try_join_all(vec![
                   store.ensure_local_has_file(response.stdout_digest).boxed(),
@@ -1459,20 +1440,15 @@ pub async fn ensure_action_stored_locally(
 /// whether we are in a remote execution context, or a pure cache-usage context) are uploaded.
 ///
 pub async fn ensure_action_uploaded(
-  context: &Context,
   store: &Store,
   command_digest: Digest,
   action_digest: Digest,
   input_files: Option<DirectoryDigest>,
 ) -> Result<(), String> {
   in_workunit!(
-    context.workunit_store.clone(),
-    "ensure_action_uploaded".to_owned(),
-    WorkunitMetadata {
-      level: Level::Trace,
-      desc: Some(format!("ensure action uploaded for {:?}", action_digest)),
-      ..WorkunitMetadata::default()
-    },
+    "ensure_action_uploaded",
+    Level::Trace,
+    desc = Some(format!("ensure action uploaded for {:?}", action_digest)),
     |_workunit| async move {
       let mut digests = vec![command_digest, action_digest];
       if let Some(input_files) = input_files {

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -855,7 +855,7 @@ fn maybe_add_workunit(
   workunit_store: &WorkunitStore,
   metadata: WorkunitMetadata,
 ) {
-  if !result_cached {
+  if !result_cached && workunit_store.max_level() >= metadata.level {
     let start_time: SystemTime = SystemTime::UNIX_EPOCH + time_span.start.into();
     let end_time: SystemTime = start_time + time_span.duration.into();
     workunit_store.add_completed_workunit(name, start_time, end_time, parent_id, metadata);

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -298,14 +298,17 @@ impl CommandRunner {
               }
               // When we successfully use the cache, we change the description and increase the level
               // (but not so much that it will be logged by default).
-              workunit.update_metadata(|initial| WorkunitMetadata {
-                desc: initial
-                  .desc
-                  .as_ref()
-                  .map(|desc| format!("Hit: {}", desc)),
-                level: Level::Debug,
-                ..initial
+              workunit.update_metadata(|initial| {
+                initial.map(|initial|
+                WorkunitMetadata {
+                  desc: initial
+                    .desc
+                    .as_ref()
+                    .map(|desc| format!("Hit: {}", desc)),
+                  level: Level::Debug,
+                  ..initial
 
+                })
               });
               Ok((cached_response, true))
             } else {

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -282,14 +282,9 @@ impl CommandRunner {
     .boxed();
 
     // We speculate between reading from the remote cache vs. running locally.
-    let context2 = context.clone();
     in_workunit!(
-      context.workunit_store.clone(),
-      "remote_cache_read_speculation".to_owned(),
-      WorkunitMetadata {
-        level: Level::Trace,
-        ..WorkunitMetadata::default()
-      },
+      "remote_cache_read_speculation",
+      Level::Trace,
       |workunit| async move {
         tokio::select! {
           cache_result = cache_read_future => {
@@ -299,9 +294,7 @@ impl CommandRunner {
               if let Some(time_saved) = cached_response.metadata.time_saved_from_cache(lookup_elapsed) {
                 let time_saved = time_saved.as_millis() as u64;
                 workunit.increment_counter(Metric::RemoteCacheTotalTimeSavedMs, time_saved);
-                context2
-                  .workunit_store
-                  .record_observation(ObservationMetric::RemoteCacheTimeSavedMs, time_saved);
+                workunit.record_observation(ObservationMetric::RemoteCacheTimeSavedMs, time_saved);
               }
               // When we successfully use the cache, we change the description and increase the level
               // (but not so much that it will be logged by default).
@@ -334,7 +327,6 @@ impl CommandRunner {
   /// Stores an execution result into the remote Action Cache.
   async fn update_action_cache(
     &self,
-    context: &Context,
     result: &FallibleProcessResultWithPlatform,
     metadata: &ProcessMetadata,
     command: &Command,
@@ -343,14 +335,7 @@ impl CommandRunner {
   ) -> Result<(), String> {
     // Upload the Action and Command, but not the input files. See #12432.
     // Assumption: The Action and Command have already been stored locally.
-    crate::remote::ensure_action_uploaded(
-      context,
-      &self.store,
-      command_digest,
-      action_digest,
-      None,
-    )
-    .await?;
+    crate::remote::ensure_action_uploaded(&self.store, command_digest, action_digest, None).await?;
 
     // Create an ActionResult from the process result.
     let (action_result, digests_for_action_result) = self
@@ -468,38 +453,15 @@ impl crate::CommandRunner for CommandRunner {
     };
 
     if !hit_cache && (result.exit_code == 0 || write_failures_to_cache) && self.cache_write {
-      // NB: We use a distinct workunit for the start of the cache write so that we guarantee the
-      // counter is recorded, given that the cache write is async and may still be executing after
-      // the Pants session has finished and workunits are no longer processed.
-      //
-      // TODO(#11688): remove this workunit once we have tailing tasks.
-      in_workunit!(
-        context.workunit_store.clone(),
-        "remote_cache_write_setup".to_owned(),
-        WorkunitMetadata {
-          level: Level::Trace,
-          ..WorkunitMetadata::default()
-        },
-        |workunit| async move {
-          workunit.increment_counter(Metric::RemoteCacheWriteAttempts, 1);
-        }
-      )
-      .await;
       let command_runner = self.clone();
       let result = result.clone();
-      let context2 = context.clone();
-      // NB: We use `TaskExecutor::spawn` instead of `tokio::spawn` to ensure logging still works.
       let _write_join = self.executor.spawn(in_workunit!(
-        context.workunit_store,
-        "remote_cache_write".to_owned(),
-        WorkunitMetadata {
-          level: Level::Trace,
-          ..WorkunitMetadata::default()
-        },
+        "remote_cache_write",
+        Level::Trace,
         |workunit| async move {
+          workunit.increment_counter(Metric::RemoteCacheWriteAttempts, 1);
           let write_result = command_runner
             .update_action_cache(
-              &context2,
               &result,
               &command_runner.metadata,
               &command,

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -1071,6 +1071,7 @@ async fn extract_response_with_digest_stdout() {
 
 #[tokio::test]
 async fn extract_response_with_digest_stderr() {
+  let _ = WorkunitStore::setup_for_tests();
   let op_name = "gimme-foo".to_string();
   let testdata = TestData::roland();
   let testdata_empty = TestData::empty();
@@ -1098,6 +1099,7 @@ async fn extract_response_with_digest_stderr() {
 
 #[tokio::test]
 async fn extract_response_with_digest_stdout_osx_remote() {
+  let _ = WorkunitStore::setup_for_tests();
   let op_name = "gimme-foo".to_string();
   let testdata = TestData::roland();
   let testdata_empty = TestData::empty();
@@ -1867,7 +1869,7 @@ async fn remote_workunits_are_stored() {
     .await
     .unwrap();
 
-  let got_workunit_items: HashSet<String> = workunit_store
+  let got_workunit_items: HashSet<&'static str> = workunit_store
     .latest_workunits(log::Level::Trace)
     .1
     .into_iter()
@@ -1875,10 +1877,10 @@ async fn remote_workunits_are_stored() {
     .collect();
 
   let wanted_workunit_items = hashset! {
-    String::from("remote execution action scheduling"),
-    String::from("remote execution worker input fetching"),
-    String::from("remote execution worker command executing"),
-    String::from("remote execution worker output uploading"),
+    "remote execution action scheduling",
+    "remote execution worker input fetching",
+    "remote execution worker command executing",
+    "remote execution worker output uploading",
   };
 
   assert!(got_workunit_items.is_superset(&wanted_workunit_items));
@@ -2022,6 +2024,7 @@ async fn extract_output_files_from_response_two_files_nested() {
 
 #[tokio::test]
 async fn extract_output_files_from_response_just_directory() {
+  let _ = WorkunitStore::setup_for_tests();
   let test_tree: TestTree = TestDirectory::containing_roland().into();
 
   let execute_response = remexec::ExecuteResponse {
@@ -2048,6 +2051,7 @@ async fn extract_output_files_from_response_directories_and_files() {
   // /pets/cats/roland.ext
   // /pets/dogs/robin.ext
 
+  let _ = WorkunitStore::setup_for_tests();
   let execute_response = remexec::ExecuteResponse {
     result: Some(remexec::ActionResult {
       exit_code: 0,
@@ -2085,6 +2089,7 @@ async fn extract_output_files_from_response_directories_and_files() {
 
 #[tokio::test]
 async fn extract_output_files_from_response_no_prefix() {
+  let _ = WorkunitStore::setup_for_tests();
   let execute_response = remexec::ExecuteResponse {
     result: Some(remexec::ActionResult {
       exit_code: 0,

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -43,7 +43,7 @@ use protos::gen::buildbarn::cas::UncachedActionResult;
 use protos::require_digest;
 use store::{SnapshotOps, Store};
 use structopt::StructOpt;
-use workunit_store::{in_workunit, WorkunitMetadata, WorkunitStore};
+use workunit_store::{in_workunit, Level, WorkunitStore};
 
 #[derive(StructOpt)]
 struct CommandSpec {
@@ -326,12 +326,9 @@ async fn main() {
     )) as Box<dyn process_execution::CommandRunner>,
   };
 
-  let result = in_workunit!(
-    workunit_store.clone(),
-    "process_executor".to_owned(),
-    WorkunitMetadata::default(),
-    |workunit| async move { runner.run(Context::default(), workunit, request).await }
-  )
+  let result = in_workunit!("process_executor", Level::Info, |workunit| async move {
+    runner.run(Context::default(), workunit, request).await
+  })
   .await
   .expect("Error executing");
 

--- a/src/rust/engine/src/externs/engine_aware.rs
+++ b/src/rust/engine/src/externs/engine_aware.rs
@@ -18,32 +18,30 @@ use workunit_store::{ArtifactOutput, Level, RunningWorkunit, UserMetadataItem};
 // be like the user did not set extra metadata.
 
 #[derive(Default, Clone, Debug)]
-pub(crate) struct EngineAwareReturnType {
-  level: Option<Level>,
-  message: Option<String>,
-  metadata: Vec<(String, UserMetadataItem)>,
-  artifacts: Vec<(String, ArtifactOutput)>,
-}
+pub(crate) struct EngineAwareReturnType;
 
 impl EngineAwareReturnType {
-  pub(crate) fn from_task_result(task_result: &PyAny) -> Self {
-    Self {
-      level: Self::level(task_result),
-      message: Self::message(task_result),
-      artifacts: Self::artifacts(task_result).unwrap_or_else(Vec::new),
-      metadata: metadata(task_result).unwrap_or_else(Vec::new),
-    }
-  }
+  pub(crate) fn update_workunit(workunit: &mut RunningWorkunit, task_result: &PyAny) {
+    workunit.update_metadata(|old_metadata| {
+      let new_level = Self::level(task_result);
+      // If the metadata already existed, or if its level changed, we need to update it.
+      let mut metadata = if new_level.is_some() || old_metadata.is_some() {
+        old_metadata.unwrap_or_default()
+      } else {
+        return None;
+      };
 
-  pub(crate) fn update_workunit(self, workunit: &mut RunningWorkunit) {
-    workunit.update_metadata(|mut metadata| {
-      if let Some(new_level) = self.level {
+      if let Some(new_level) = new_level {
         metadata.level = new_level;
       }
-      metadata.message = self.message;
-      metadata.artifacts.extend(self.artifacts);
-      metadata.user_metadata.extend(self.metadata);
+      metadata.message = Self::message(task_result);
       metadata
+        .artifacts
+        .extend(Self::artifacts(task_result).unwrap_or_else(Vec::new));
+      metadata
+        .user_metadata
+        .extend(metadata_for(task_result).unwrap_or_else(Vec::new));
+      Some(metadata)
     });
   }
 
@@ -103,11 +101,11 @@ impl EngineAwareParameter {
   }
 
   pub fn metadata(obj: &PyAny) -> Vec<(String, UserMetadataItem)> {
-    metadata(obj).unwrap_or_else(Vec::new)
+    metadata_for(obj).unwrap_or_else(Vec::new)
   }
 }
 
-fn metadata(obj: &PyAny) -> Option<Vec<(String, UserMetadataItem)>> {
+fn metadata_for(obj: &PyAny) -> Option<Vec<(String, UserMetadataItem)>> {
   let metadata_val = obj.call_method0("metadata").ok()?;
   if metadata_val.is_none() {
     return None;

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -673,7 +673,7 @@ async fn workunit_to_py_value(
     let mut dict_entries = vec![
       (
         externs::store_utf8(py, "name"),
-        externs::store_utf8(py, &workunit.name),
+        externs::store_utf8(py, workunit.name),
       ),
       (
         externs::store_utf8(py, "span_id"),
@@ -964,7 +964,7 @@ fn scheduler_live_items<'py>(
   py: Python<'py>,
   py_scheduler: &'py PyScheduler,
   py_session: &'py PySession,
-) -> (Vec<PyObject>, HashMap<String, (usize, usize)>) {
+) -> (Vec<PyObject>, HashMap<&'static str, (usize, usize)>) {
   let (items, sizes) = py_scheduler
     .0
     .core

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1303,19 +1303,19 @@ impl NodeKey {
   /// Provides the `name` field in workunits associated with this node. These names
   /// should be friendly to machine-parsing (i.e. "my_node" rather than "My awesome node!").
   ///
-  pub fn workunit_name(&self) -> String {
+  pub fn workunit_name(&self) -> &'static str {
     match self {
-      NodeKey::Task(ref task) => task.task.display_info.name.clone(),
-      NodeKey::ExecuteProcess(..) => "process".to_string(),
-      NodeKey::Snapshot(..) => "snapshot".to_string(),
-      NodeKey::Paths(..) => "paths".to_string(),
-      NodeKey::DigestFile(..) => "digest_file".to_string(),
-      NodeKey::DownloadedFile(..) => "downloaded_file".to_string(),
-      NodeKey::ReadLink(..) => "read_link".to_string(),
-      NodeKey::Scandir(..) => "scandir".to_string(),
-      NodeKey::Select(..) => "select".to_string(),
-      NodeKey::SessionValues(..) => "session_values".to_string(),
-      NodeKey::RunId(..) => "run_id".to_string(),
+      NodeKey::Task(ref task) => &task.task.as_ref().display_info.name,
+      NodeKey::ExecuteProcess(..) => "process",
+      NodeKey::Snapshot(..) => "snapshot",
+      NodeKey::Paths(..) => "paths",
+      NodeKey::DigestFile(..) => "digest_file",
+      NodeKey::DownloadedFile(..) => "downloaded_file",
+      NodeKey::ReadLink(..) => "read_link",
+      NodeKey::Scandir(..) => "scandir",
+      NodeKey::Select(..) => "select",
+      NodeKey::SessionValues(..) => "session_values",
+      NodeKey::RunId(..) => "run_id",
     }
   }
 
@@ -1348,6 +1348,29 @@ impl NodeKey {
       NodeKey::RunId(..) => None,
     }
   }
+
+  ///
+  /// Filters the given Params to those which are subtypes of EngineAwareParameter.
+  ///
+  fn engine_aware_params<'a>(
+    context: Context,
+    py: Python<'a>,
+    params: &'a Params,
+  ) -> impl Iterator<Item = Value> + 'a {
+    let engine_aware_param_ty = context.core.types.engine_aware_parameter.as_py_type(py);
+    params.keys().filter_map(move |key| {
+      if key
+        .type_id()
+        .as_py_type(py)
+        .is_subclass(engine_aware_param_ty)
+        .unwrap_or(false)
+      {
+        Some(key.to_value())
+      } else {
+        None
+      }
+    })
+  }
 }
 
 #[async_trait]
@@ -1358,61 +1381,31 @@ impl Node for NodeKey {
   type Error = Failure;
 
   async fn run(self, context: Context) -> Result<NodeOutput, Failure> {
-    let workunit_store_handle = workunit_store::expect_workunit_store_handle();
-
     let workunit_name = self.workunit_name();
-    let user_facing_name = self.user_facing_name();
-    let engine_aware_params: Vec<_> = match &self {
-      NodeKey::Task(ref task) => {
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        let engine_aware_param_ty = context.core.types.engine_aware_parameter.as_py_type(py);
-        task
-          .params
-          .keys()
-          .filter_map(|key| {
-            if key
-              .type_id()
-              .as_py_type(py)
-              .is_subclass(engine_aware_param_ty)
-              .unwrap_or(false)
-            {
-              Some(key.to_value())
-            } else {
-              None
-            }
-          })
-          .collect()
-      }
-      _ => vec![],
+    let params = match &self {
+      NodeKey::Task(ref task) => task.params.clone(),
+      _ => Params::default(),
     };
-    let user_metadata = {
-      let gil = Python::acquire_gil();
-      let py = gil.python();
-      engine_aware_params
-        .iter()
-        .flat_map(|val| EngineAwareParameter::metadata((**val).as_ref(py)))
-        .collect()
-    };
-
-    let metadata = WorkunitMetadata {
-      desc: user_facing_name,
-      level: self.workunit_level(),
-      user_metadata,
-      ..WorkunitMetadata::default()
-    };
+    let context2 = context.clone();
 
     in_workunit!(
-      workunit_store_handle.store,
-      self.workunit_name(),
-      metadata,
+      workunit_name,
+      self.workunit_level(),
+      desc = self.user_facing_name(),
+      user_metadata = {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        Self::engine_aware_params(context.clone(), py, &params)
+          .flat_map(|val| EngineAwareParameter::metadata((*val).as_ref(py)))
+          .collect()
+      },
       |workunit| async move {
         // To avoid races, we must ensure that we have installed a watch for the subject before
         // executing the node logic. But in case of failure, we wait to see if the Node itself
         // fails, and prefer that error message if so (because we have little control over the
         // error messages of the watch API).
-        let maybe_watch = if let Some(path) = self.fs_subject() {
-          if let Some(watcher) = &context.core.watcher {
+        let maybe_watch =
+          if let Some((path, watcher)) = self.fs_subject().zip(context.core.watcher.as_ref()) {
             let abs_path = context.core.build_root.join(path);
             watcher
               .watch(abs_path)
@@ -1420,10 +1413,7 @@ impl Node for NodeKey {
               .await
           } else {
             Ok(())
-          }
-        } else {
-          Ok(())
-        };
+          };
 
         let mut result = match self {
           NodeKey::DigestFile(n) => {
@@ -1498,13 +1488,12 @@ impl Node for NodeKey {
           let displayable_param_names: Vec<_> = {
             let gil = Python::acquire_gil();
             let py = gil.python();
-            engine_aware_params
-              .into_iter()
+            Self::engine_aware_params(context2, py, &params)
               .filter_map(|val| EngineAwareParameter::debug_hint((*val).as_ref(py)))
               .collect()
           };
           let failure_name = if displayable_param_names.is_empty() {
-            name
+            name.to_owned()
           } else if displayable_param_names.len() == 1 {
             format!(
               "{} ({})",

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -84,6 +84,10 @@ impl<'x> Params {
   pub fn type_ids(&self) -> impl Iterator<Item = TypeId> + '_ {
     self.0.iter().map(|k| *k.type_id())
   }
+
+  pub fn is_empty(&self) -> bool {
+    self.0.is_empty()
+  }
 }
 
 ///

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -146,10 +146,13 @@ impl Scheduler {
   /// Returns references to all Python objects held alive by the graph, and a summary of sizes of
   /// Rust structs as a count and total size.
   ///
-  pub fn live_items(&self, session: &Session) -> (Vec<Value>, HashMap<String, (usize, usize)>) {
+  pub fn live_items(
+    &self,
+    session: &Session,
+  ) -> (Vec<Value>, HashMap<&'static str, (usize, usize)>) {
     let context = Context::new(self.core.clone(), session.clone());
     let mut items = vec![];
-    let mut sizes: HashMap<String, (usize, usize)> = HashMap::new();
+    let mut sizes: HashMap<&'static str, (usize, usize)> = HashMap::new();
     // TODO: Creation of a Context is exposed in https://github.com/Aeledfyr/deepsize/pull/31.
     let mut deep_context = deepsize::Context::new();
     self.core.graph.visit_live(&context, |k, v| {

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -16,6 +16,7 @@ log = "0.4"
 parking_lot = "0.12"
 petgraph = "0.6"
 rand = "0.8"
+smallvec = "1"
 strum = "0.20"
 strum_macros = "0.23"
 tokio = { version = "1.16", features = ["rt", "sync"] }

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -19,3 +19,6 @@ rand = "0.8"
 strum = "0.20"
 strum_macros = "0.23"
 tokio = { version = "1.16", features = ["rt", "sync"] }
+
+[dev-dependencies]
+internment = "0.6"

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -22,4 +22,6 @@ strum_macros = "0.23"
 tokio = { version = "1.16", features = ["rt", "sync"] }
 
 [dev-dependencies]
+futures = "0.3"
 internment = "0.6"
+tokio = { version = "1.16", features = ["macros"] }

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -97,7 +97,7 @@ type RunningWorkunitGraph = StableDiGraph<SpanId, (), u32>;
 ///
 #[derive(Clone, Debug)]
 pub struct Workunit {
-  pub name: String,
+  pub name: &'static str,
   pub span_id: SpanId,
   pub parent_id: Option<SpanId>,
   pub state: WorkunitState,
@@ -119,7 +119,7 @@ impl Workunit {
     let identifier = if let Some(ref s) = self.metadata.desc {
       s.as_str()
     } else {
-      self.name.as_str()
+      self.name
     };
 
     /* This length calculation doesn't treat multi-byte unicode charcters identically
@@ -620,10 +620,13 @@ impl WorkunitStore {
     self.heavy_hitters_data.lock().heavy_hitters(k)
   }
 
-  fn start_workunit(
+  ///
+  /// NB: Public for macro use. Use `in_workunit!` instead.
+  ///
+  pub fn _start_workunit(
     &self,
     span_id: SpanId,
-    name: String,
+    name: &'static str,
     parent_id: Option<SpanId>,
     metadata: WorkunitMetadata,
   ) -> Workunit {
@@ -686,7 +689,7 @@ impl WorkunitStore {
 
   pub fn add_completed_workunit(
     &self,
-    name: String,
+    name: &'static str,
     start_time: SystemTime,
     end_time: SystemTime,
     parent_id: Option<SpanId>,
@@ -782,12 +785,7 @@ impl WorkunitStore {
   pub fn setup_for_tests() -> (WorkunitStore, RunningWorkunit) {
     let store = WorkunitStore::new(false, Level::Debug);
     store.init_thread_state(None);
-    let workunit = store.start_workunit(
-      SpanId(0),
-      "testing".to_owned(),
-      None,
-      WorkunitMetadata::default(),
-    );
+    let workunit = store._start_workunit(SpanId(0), "testing", None, WorkunitMetadata::default());
     (store.clone(), RunningWorkunit::new(store, Some(workunit)))
   }
 }
@@ -841,35 +839,36 @@ pub fn expect_workunit_store_handle() -> WorkunitStoreHandle {
   get_workunit_store_handle().expect("A WorkunitStore has not been set for this thread.")
 }
 
+/// Run the given async block. If the level given by the WorkunitMetadata is above a configured
+/// threshold, the block will run inside of a workunit recorded in the workunit store.
 ///
-/// NB: Public for macro usage: use the `in_workunit!` macro.
-///
-pub fn _start_workunit(
-  store_handle: &mut WorkunitStoreHandle,
-  name: String,
-  initial_metadata: WorkunitMetadata,
-) -> RunningWorkunit {
-  let span_id = SpanId::new();
-  let parent_id = std::mem::replace(&mut store_handle.parent_id, Some(span_id));
-  let workunit = store_handle
-    .store
-    .start_workunit(span_id, name, parent_id, initial_metadata);
-  RunningWorkunit::new(store_handle.store.clone(), Some(workunit))
-}
-
+/// NB: This macro may only be used on a thread with a WorkunitStore configured (via
+/// `WorkunitStore::init_thread_state`). Although it would be an option to silently ignore
+/// workunits recorded from other threads, that would usually represent a bug caused by failing to
+/// propagate state between threads.
 #[macro_export]
 macro_rules! in_workunit {
-  ($workunit_store: expr, $workunit_name: expr, $workunit_metadata: expr, |$workunit: ident| $f: expr $(,)?) => {{
-    // TODO: The workunit store argument is unused: remove in separate patch.
-    std::mem::drop($workunit_store);
-
+  ($workunit_name: expr, $workunit_level: expr $(, $workunit_field_name:ident = $workunit_field_value:expr)*, |$workunit: ident| $f: expr $(,)?) => {{
     use futures::future::FutureExt;
     let mut store_handle = $crate::expect_workunit_store_handle();
-    // TODO: Move Level out of the metadata to allow skipping construction if disabled.
-    let workunit_metadata = $workunit_metadata;
-    if store_handle.store.max_level() >= workunit_metadata.level {
-      let mut $workunit =
-        $crate::_start_workunit(&mut store_handle, $workunit_name, workunit_metadata);
+    let level: log::Level  = $workunit_level;
+    if store_handle.store.max_level() >= level {
+      let mut $workunit = {
+        let workunit_metadata = $crate::WorkunitMetadata {
+          level,
+          $(
+                $workunit_field_name: $workunit_field_value,
+          )*
+          ..Default::default()
+        };
+        let span_id = $crate::SpanId::new();
+        let parent_id = std::mem::replace(&mut store_handle.parent_id, Some(span_id));
+        let workunit =
+          store_handle
+            .store
+            ._start_workunit(span_id, $workunit_name, parent_id, workunit_metadata);
+        $crate::RunningWorkunit::new(store_handle.store.clone(), Some(workunit))
+      };
       $crate::scope_task_workunit_store_handle(Some(store_handle), async move {
         let result = {
           let $workunit = &mut $workunit;
@@ -902,6 +901,10 @@ pub struct RunningWorkunit {
 impl RunningWorkunit {
   pub fn new(store: WorkunitStore, workunit: Option<Workunit>) -> RunningWorkunit {
     RunningWorkunit { store, workunit }
+  }
+
+  pub fn record_observation(&mut self, metric: ObservationMetric, value: u64) {
+    self.store.record_observation(metric, value);
   }
 
   pub fn increment_counter(&mut self, counter_name: Metric, change: u64) {

--- a/src/rust/engine/workunit_store/src/tests.rs
+++ b/src/rust/engine/workunit_store/src/tests.rs
@@ -2,6 +2,8 @@ use std::collections::HashSet;
 use std::sync::atomic;
 use std::time::Duration;
 
+use internment::Intern;
+
 use crate::{SpanId, WorkunitMetadata, WorkunitState, WorkunitStore};
 
 #[test]
@@ -109,7 +111,12 @@ fn create_store(
       if let Some(parent_id) = parent_id {
         assert!(span_id > parent_id);
       }
-      ws.start_workunit(span_id, format!("{}", span_id.0), parent_id, metadata)
+      ws._start_workunit(
+        span_id,
+        Intern::new(format!("{}", span_id.0)).as_ref(),
+        parent_id,
+        metadata,
+      )
     })
     .collect::<Vec<_>>();
 


### PR DESCRIPTION
Fix missing `check` output by allowing disabled workunits to re-enable themselves (#14934)

#13483 broke the rendering of `EngineAwareReturnType` implementations which relied on starting a workunit at `Level::TRACE`, and then escalating its level to something visible (usually `INFO` or greater) when it completed. `check` outputs for the JVM were strongly affected (see #14867), since they relied on the fact that `FallibleClasspathEntry` escalates to `ERROR` to render compile errors.

To resolve this, we roll back a portion of #13483. Rather than not recording the workunit at all, we instead record it in the `WorkunitStore` as "disabled", which is signaled by a workunit not having any `WorkunitMetadata`. This has some of the efficiency benefits of #13483 (because we continue to skip heap allocating the metadata's fields), but allows a workunit to escalate itself from disabled to enabled as it completes by specifying a non-disabled level in `RunningWorkunit::update_metadata`.

The recording of "disabled" workunits is additionally necessary for #14680, because otherwise workunits which were not actually recorded would break the tracking of multiple parents: when adding a new parent to a workunit, you need an existing `SpanId` corresponding to the work that you are adding a parent to (or else you might accidentally depend on a parent arbitrarily far up the stack).

Fixes #14867.

[ci skip-build-wheels]