### PR TITLE
[internal] BSP: use seperate config file for defining groups for BSP build targets

### DIFF
--- a/src/python/pants/backend/java/bsp/rules.py
+++ b/src/python/pants/backend/java/bsp/rules.py
@@ -13,7 +13,6 @@ from pants.bsp.spec.base import BuildTargetIdentifier, StatusCode
 from pants.bsp.util_rules.compile import BSPCompileRequest, BSPCompileResult
 from pants.bsp.util_rules.lifecycle import BSPLanguageSupport
 from pants.bsp.util_rules.targets import (
-    BSPBuildTargetInternal,
     BSPBuildTargetsMetadataRequest,
     BSPBuildTargetsMetadataResult,
 )
@@ -92,8 +91,7 @@ async def handle_bsp_java_options_request(
     request: HandleJavacOptionsRequest,
     build_root: BuildRoot,
 ) -> HandleJavacOptionsResult:
-    bsp_target = await Get(BSPBuildTargetInternal, BuildTargetIdentifier, request.bsp_target_id)
-    targets = await Get(Targets, BSPBuildTargetInternal, bsp_target)
+    targets = await Get(Targets, BuildTargetIdentifier, request.bsp_target_id)
 
     coarsened_targets = await Get(CoarsenedTargets, Addresses(tgt.address for tgt in targets))
     resolve = await Get(CoursierResolveKey, CoarsenedTargets, coarsened_targets)

--- a/src/python/pants/backend/java/bsp/rules.py
+++ b/src/python/pants/backend/java/bsp/rules.py
@@ -8,13 +8,12 @@ from dataclasses import dataclass
 from pants.backend.java.bsp.spec import JavacOptionsItem, JavacOptionsParams, JavacOptionsResult
 from pants.backend.java.target_types import JavaFieldSet, JavaSourceField
 from pants.base.build_root import BuildRoot
-from pants.base.specs import AddressSpecs
 from pants.bsp.protocol import BSPHandlerMapping
 from pants.bsp.spec.base import BuildTargetIdentifier, StatusCode
 from pants.bsp.util_rules.compile import BSPCompileRequest, BSPCompileResult
 from pants.bsp.util_rules.lifecycle import BSPLanguageSupport
 from pants.bsp.util_rules.targets import (
-    BSPBuildTargets,
+    BSPBuildTargetInternal,
     BSPBuildTargetsMetadataRequest,
     BSPBuildTargetsMetadataResult,
 )
@@ -92,16 +91,9 @@ class HandleJavacOptionsResult:
 async def handle_bsp_java_options_request(
     request: HandleJavacOptionsRequest,
     build_root: BuildRoot,
-    bsp_build_targets: BSPBuildTargets,
 ) -> HandleJavacOptionsResult:
-    bsp_target_name = request.bsp_target_id.uri[len("pants:") :]
-    if bsp_target_name not in bsp_build_targets.targets_mapping:
-        raise ValueError(f"Invalid BSP target name: {request.bsp_target_id}")
-    targets = await Get(
-        Targets,
-        AddressSpecs,
-        bsp_build_targets.targets_mapping[bsp_target_name].specs.address_specs,
-    )
+    bsp_target = await Get(BSPBuildTargetInternal, BuildTargetIdentifier, request.bsp_target_id)
+    targets = await Get(Targets, BSPBuildTargetInternal, bsp_target)
 
     coarsened_targets = await Get(CoarsenedTargets, Addresses(tgt.address for tgt in targets))
     resolve = await Get(CoursierResolveKey, CoarsenedTargets, coarsened_targets)

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -27,7 +27,6 @@ from pants.bsp.spec.targets import DependencyModule
 from pants.bsp.util_rules.compile import BSPCompileRequest, BSPCompileResult
 from pants.bsp.util_rules.lifecycle import BSPLanguageSupport
 from pants.bsp.util_rules.targets import (
-    BSPBuildTargetInternal,
     BSPBuildTargetsMetadataRequest,
     BSPBuildTargetsMetadataResult,
     BSPDependencyModulesRequest,
@@ -212,8 +211,7 @@ async def handle_bsp_scalac_options_request(
     build_root: BuildRoot,
     workspace: Workspace,
 ) -> HandleScalacOptionsResult:
-    bsp_target = await Get(BSPBuildTargetInternal, BuildTargetIdentifier, request.bsp_target_id)
-    targets = await Get(Targets, BSPBuildTargetInternal, bsp_target)
+    targets = await Get(Targets, BuildTargetIdentifier, request.bsp_target_id)
     coarsened_targets = await Get(CoarsenedTargets, Addresses(tgt.address for tgt in targets))
     resolve = await Get(CoursierResolveKey, CoarsenedTargets, coarsened_targets)
     lockfile = await Get(CoursierResolvedLockfile, CoursierResolveKey, resolve)

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -21,7 +21,6 @@ from pants.backend.scala.bsp.spec import (
 from pants.backend.scala.subsystems.scala import ScalaSubsystem
 from pants.backend.scala.target_types import ScalaFieldSet, ScalaSourceField
 from pants.base.build_root import BuildRoot
-from pants.base.specs import AddressSpecs
 from pants.bsp.protocol import BSPHandlerMapping
 from pants.bsp.spec.base import BuildTarget, BuildTargetIdentifier, StatusCode
 from pants.bsp.spec.targets import DependencyModule
@@ -214,11 +213,7 @@ async def handle_bsp_scalac_options_request(
     workspace: Workspace,
 ) -> HandleScalacOptionsResult:
     bsp_target = await Get(BSPBuildTargetInternal, BuildTargetIdentifier, request.bsp_target_id)
-    targets = await Get(
-        Targets,
-        AddressSpecs,
-        bsp_target.specs.address_specs,
-    )
+    targets = await Get(Targets, BSPBuildTargetInternal, bsp_target)
     coarsened_targets = await Get(CoarsenedTargets, Addresses(tgt.address for tgt in targets))
     resolve = await Get(CoursierResolveKey, CoarsenedTargets, coarsened_targets)
     lockfile = await Get(CoursierResolvedLockfile, CoursierResolveKey, resolve)

--- a/src/python/pants/bsp/goal.py
+++ b/src/python/pants/bsp/goal.py
@@ -66,31 +66,31 @@ class BSPGoal(BuiltinGoal):
         advanced=True,
     )
 
-    targets_config_files = FileListOption(
-        "--targets-config-files",
+    groups_config_files = FileListOption(
+        "--groups-config-files",
         help=(
-            'A list of config files that define the "build targets" exposed to IDEs via Build Server Protocol.\n\n'
+            "A list of config files that define groups of Pants targets to expose to IDEs via Build Server Protocol.\n\n"
             "Pants generally uses fine-grained targets to define the components of a build (in many cases on a file-by-file "
             "basis). Many IDEs, however, favor coarse-grained targets that contain large numbers of source files. "
-            "To accomodate this distinction, the Pants BSP server will use the target definitions present in the "
-            "config files specified for this option to aggregate Pants targets into the BSP build targets exposed "
-            "to IDEs.\n\n"
-            "Each config file is a TOML file with a `targets` dictionary with the following format for an entry:\n\n"
-            '    # The dictionary key is the "build target identifier" used in BSP requests. This must be unique.\n'
-            "    [targets.bspTargetId123]:\n"
-            '    name = "Display Name"  # Name shown to the user in the IDE.\n'
-            '    base_directory = "path/from/build/root"  # Hint to the IDE for where the build target should live.\n'
-            "    # One or more Pants address specs defining what targets to include in the BSP build target.\n"
+            "To accommodate this distinction, the Pants BSP server will compute a set of BSP build targets to use "
+            "from the groups specified in the config files set for this option. Each group will become one or more "
+            "BSP build targets.\n\n"
+            "Each config file is a TOML file with a `groups` dictionary with the following format for an entry:\n\n"
+            "    # The dictionary key is used to identify the group. It must be unique.\n"
+            "    [groups.ID1]:\n"
+            "    # One or more Pants address specs defining what targets to include in the group.\n"
             "    addresses = [\n"
             '      "src/jvm::",\n'
             '      "tests/jvm::",\n'
             "    ]\n"
-            "    # Filter targets to a specific resolve. Targets in a BSP build target must be from a single resolve.\n"
+            "    # Filter targets to a specific resolve. Targets in a group must be from a single resolve.\n"
             "    # Format of filter is `TYPE:RESOLVE_NAME`. The only supported TYPE is `jvm`. RESOLVE_NAME must be\n"
             "    # a valid resolve name.\n"
             '    resolve = "jvm:jvm-default"\n'
+            '    display_name = "Display Name"  # (Optional) Name shown to the user in the IDE.\n'
+            '    base_directory = "path/from/build/root"  # (Optional) Hint to the IDE for where the build target should "live."\n'
             "\n"
-            "Pants will merge the contents of the files together. If the same ID is used for a target definition, "
+            "Pants will merge the contents of the config files together. If the same ID is used for a group definition, "
             "in multiple config files, the definition in the latter config file will take effect."
         ),
     )

--- a/src/python/pants/bsp/util_rules/BUILD
+++ b/src/python/pants/bsp/util_rules/BUILD
@@ -4,4 +4,3 @@
 python_sources()
 
 python_tests(name="tests")
-

--- a/src/python/pants/bsp/util_rules/BUILD
+++ b/src/python/pants/bsp/util_rules/BUILD
@@ -2,3 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_sources()
+
+python_tests(name="tests")
+

--- a/src/python/pants/bsp/util_rules/targets.py
+++ b/src/python/pants/bsp/util_rules/targets.py
@@ -8,7 +8,10 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import ClassVar, Generic, Sequence, Type, TypeVar
 
+import toml
+
 from pants.base.build_root import BuildRoot
+from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.base.specs import AddressSpecs, Specs
 from pants.base.specs_parser import SpecsParser
 from pants.bsp.goal import BSPGoal
@@ -30,7 +33,7 @@ from pants.bsp.spec.targets import (
     WorkspaceBuildTargetsParams,
     WorkspaceBuildTargetsResult,
 )
-from pants.engine.fs import Workspace
+from pants.engine.fs import DigestContents, PathGlobs, Workspace
 from pants.engine.internals.native_engine import EMPTY_DIGEST, Digest, MergeDigests
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import _uncacheable_rule, collect_rules, rule
@@ -75,9 +78,18 @@ class BSPBuildTargetsMetadataResult:
 
 
 @dataclass(frozen=True)
+class BSPTargetDefinition:
+    display_name: str
+    base_directory: str
+    addresses: tuple[str, ...]
+    resolve_filter: str | None
+
+
+@dataclass(frozen=True)
 class BSPBuildTargetInternal:
     name: str
     specs: Specs
+    definition: BSPTargetDefinition
 
     @property
     def bsp_target_id(self) -> BuildTargetIdentifier:
@@ -103,25 +115,78 @@ class BSPBuildTargets:
 @dataclass(frozen=True)
 class _ParseOneBSPMappingRequest:
     name: str
-    raw_specs: tuple[str, ...]
+    definition: BSPTargetDefinition
 
 
 @rule
 async def parse_one_bsp_mapping(request: _ParseOneBSPMappingRequest) -> BSPBuildTargetInternal:
     specs_parser = SpecsParser()
-    specs = specs_parser.parse_specs(request.raw_specs)
-    return BSPBuildTargetInternal(request.name, specs)
+    specs = specs_parser.parse_specs(request.definition.addresses)
+    return BSPBuildTargetInternal(request.name, specs, request.definition)
 
 
 @rule
 async def materialize_bsp_build_targets(bsp_goal: BSPGoal) -> BSPBuildTargets:
+    definitions: dict[str, BSPTargetDefinition] = {}
+    for config_file in bsp_goal.targets_config_files:
+        config_contents = await Get(
+            DigestContents,
+            PathGlobs(
+                [config_file],
+                glob_match_error_behavior=GlobMatchErrorBehavior.error,
+                description_of_origin=f"BSP config file `{config_file}`",
+            ),
+        )
+        if len(config_contents) == 0:
+            raise ValueError(f"BSP targets config file `{config_file}` does not exist.")
+        elif len(config_contents) > 1:
+            raise ValueError(
+                f"BSP targets config file specified as `{config_file}` matches multiple files. Please do not use wildcards."
+            )
+
+        config = toml.loads(config_contents[0].content.decode())
+
+        if "targets" not in config:
+            raise ValueError(
+                f"BSP targets config file `{config_file}` is missing the `targets` dictionary."
+            )
+        targets = config["targets"]
+        if not isinstance(targets, dict):
+            raise ValueError(
+                f"BSP targets config file `{config_file}` contains a `targets` config that is not a dictionary."
+            )
+
+        for id, d in targets.items():
+            display_name = d.get("display_name")
+            if display_name is None:
+                display_name = id
+
+            base_directory = d.get("base_directory")
+
+            addresses = d.get("addresses", [])
+            if not addresses:
+                raise ValueError(
+                    f"BSP targets config file `{config_file}` contains target ID `{id}` which "
+                    "no address specs defined via the `addresses` property. Please specify at least "
+                    "one address spec."
+                )
+
+            resolve_filter = d.get("resolve")
+
+            definitions[id] = BSPTargetDefinition(
+                display_name=display_name,
+                base_directory=base_directory,
+                addresses=tuple(addresses),
+                resolve_filter=resolve_filter,
+            )
+
     bsp_internal_targets = await MultiGet(
-        Get(BSPBuildTargetInternal, _ParseOneBSPMappingRequest(name, tuple(value)))
-        for name, value in bsp_goal.target_mapping.items()
+        Get(BSPBuildTargetInternal, _ParseOneBSPMappingRequest(name, definition))
+        for name, definition in definitions.items()
     )
     target_mapping = {
         key: bsp_internal_target
-        for key, bsp_internal_target in zip(bsp_goal.target_mapping.keys(), bsp_internal_targets)
+        for key, bsp_internal_target in zip(definitions.keys(), bsp_internal_targets)
     }
     return BSPBuildTargets(FrozenDict(target_mapping))
 
@@ -142,10 +207,16 @@ async def resolve_bsp_build_target_identifier(
 
 
 @rule
+async def resolve_bsp_build_target_addresses(bsp_target: BSPBuildTargetInternal) -> Targets:
+    targets = await Get(Targets, AddressSpecs, bsp_target.specs.address_specs)
+    return targets
+
+
+@rule
 async def resolve_bsp_build_target_source_roots(
     bsp_target: BSPBuildTargetInternal,
 ) -> BSPBuildTargetSourcesInfo:
-    targets = await Get(Targets, AddressSpecs, bsp_target.specs.address_specs)
+    targets = await Get(Targets, BSPBuildTargetInternal, bsp_target)
     targets_with_sources = [tgt for tgt in targets if tgt.has_field(SourcesField)]
     sources_paths = await MultiGet(
         Get(SourcesPaths, SourcesPathsRequest(tgt[SourcesField])) for tgt in targets_with_sources
@@ -215,7 +286,7 @@ async def generate_one_bsp_build_target_request(
     build_root: BuildRoot,
 ) -> GenerateOneBSPBuildTargetResult:
     # Find all Pants targets that are part of this BSP build target.
-    targets = await Get(Targets, AddressSpecs, request.bsp_target.specs.address_specs)
+    targets = await Get(Targets, BSPBuildTargetInternal, request.bsp_target)
 
     # Classify the targets by the language backends that claim them to provide metadata for them.
     field_sets_by_lang_id: dict[str, OrderedSet[FieldSet]] = defaultdict(OrderedSet)
@@ -437,11 +508,7 @@ async def resolve_one_dependency_module(
     union_membership: UnionMembership,
 ) -> ResolveOneDependencyModuleResult:
     bsp_target = await Get(BSPBuildTargetInternal, BuildTargetIdentifier, request.bsp_target_id)
-    targets = await Get(
-        Targets,
-        AddressSpecs,
-        bsp_target.specs.address_specs,
-    )
+    targets = await Get(Targets, BSPBuildTargetInternal, bsp_target)
 
     field_sets_by_request_type: dict[
         Type[BSPDependencyModulesRequest], list[FieldSet]

--- a/src/python/pants/bsp/util_rules/targets.py
+++ b/src/python/pants/bsp/util_rules/targets.py
@@ -510,8 +510,7 @@ async def resolve_one_dependency_module(
     request: ResolveOneDependencyModuleRequest,
     union_membership: UnionMembership,
 ) -> ResolveOneDependencyModuleResult:
-    bsp_target = await Get(BSPBuildTargetInternal, BuildTargetIdentifier, request.bsp_target_id)
-    targets = await Get(Targets, BSPBuildTargetInternal, bsp_target)
+    targets = await Get(Targets, BuildTargetIdentifier, request.bsp_target_id)
 
     field_sets_by_request_type: dict[
         Type[BSPDependencyModulesRequest], list[FieldSet]

--- a/src/python/pants/bsp/util_rules/targets.py
+++ b/src/python/pants/bsp/util_rules/targets.py
@@ -128,7 +128,7 @@ async def parse_one_bsp_mapping(request: _ParseOneBSPMappingRequest) -> BSPBuild
 @rule
 async def materialize_bsp_build_targets(bsp_goal: BSPGoal) -> BSPBuildTargets:
     definitions: dict[str, BSPTargetDefinition] = {}
-    for config_file in bsp_goal.targets_config_files:
+    for config_file in bsp_goal.groups_config_files:
         config_contents = await Get(
             DigestContents,
             PathGlobs(

--- a/src/python/pants/bsp/util_rules/targets_test.py
+++ b/src/python/pants/bsp/util_rules/targets_test.py
@@ -50,7 +50,7 @@ def test_config_file_parsing(rule_runner: RuleRunner) -> None:
         }
     )
     rule_runner.set_options(
-        ["--experimental-bsp-targets-config-files=['first.toml', 'second.toml']"]
+        ["--experimental-bsp-groups-config-files=['first.toml', 'second.toml']"]
     )
 
     bsp_build_targets = rule_runner.request(BSPBuildTargets, ())

--- a/src/python/pants/bsp/util_rules/targets_test.py
+++ b/src/python/pants/bsp/util_rules/targets_test.py
@@ -25,7 +25,7 @@ def test_config_file_parsing(rule_runner: RuleRunner) -> None:
         {
             "first.toml": textwrap.dedent(
                 """\
-            [targets.foo]
+            [groups.foo]
             display_name = "Foo"
             base_directory = "src/jvm"
             addresses = ["src/jvm::"]
@@ -34,13 +34,13 @@ def test_config_file_parsing(rule_runner: RuleRunner) -> None:
             ),
             "second.toml": textwrap.dedent(
                 """\
-            [targets.foo]
+            [groups.foo]
             display_name = "Foo for My Team"
             base_directory = "src/jvm"
             addresses = ["src/jvm::", "my-team/src/jvm::"]
             resolve = "jvm:jvm-default"
 
-            [targets.bar]
+            [groups.bar]
             display_name = "Bar"
             base_directory = "bar/src/jvm"
             addresses = ["bar/src/jvm::"]

--- a/src/python/pants/bsp/util_rules/targets_test.py
+++ b/src/python/pants/bsp/util_rules/targets_test.py
@@ -1,0 +1,80 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import textwrap
+
+import pytest
+
+from pants.bsp.rules import rules as bsp_rules
+from pants.bsp.util_rules.targets import BSPBuildTargets, BSPTargetDefinition
+from pants.engine.rules import QueryRule
+from pants.testutil.rule_runner import RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *bsp_rules(),
+            QueryRule(BSPBuildTargets, ()),
+        ]
+    )
+
+
+def test_config_file_parsing(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "first.toml": textwrap.dedent(
+                """\
+            [targets.foo]
+            display_name = "Foo"
+            base_directory = "src/jvm"
+            addresses = ["src/jvm::"]
+            resolve = "jvm:jvm-default"
+            """
+            ),
+            "second.toml": textwrap.dedent(
+                """\
+            [targets.foo]
+            display_name = "Foo for My Team"
+            base_directory = "src/jvm"
+            addresses = ["src/jvm::", "my-team/src/jvm::"]
+            resolve = "jvm:jvm-default"
+
+            [targets.bar]
+            display_name = "Bar"
+            base_directory = "bar/src/jvm"
+            addresses = ["bar/src/jvm::"]
+            resolve = "jvm:bar"
+            """
+            ),
+        }
+    )
+    rule_runner.set_options(
+        ["--experimental-bsp-targets-config-files=['first.toml', 'second.toml']"]
+    )
+
+    bsp_build_targets = rule_runner.request(BSPBuildTargets, ())
+
+    definitions = {
+        (name, btgt.definition) for name, btgt in bsp_build_targets.targets_mapping.items()
+    }
+    assert definitions == {
+        (
+            "foo",
+            BSPTargetDefinition(
+                display_name="Foo for My Team",
+                base_directory="src/jvm",
+                addresses=("src/jvm::", "my-team/src/jvm::"),
+                resolve_filter="jvm:jvm-default",
+            ),
+        ),
+        (
+            "bar",
+            BSPTargetDefinition(
+                display_name="Bar",
+                base_directory="bar/src/jvm",
+                addresses=("bar/src/jvm::",),
+                resolve_filter="jvm:bar",
+            ),
+        ),
+    }


### PR DESCRIPTION
Introduce a separate config file in TOML format for defining groupings of source code used in computing BSP build targets. This allows more metadata to be specified in the definition of BSP build targets without making configuration in `pants.toml` unwieldy. The `--experimental-bsp-groups-config-files` option takes a list of config file paths that are merged together to form the final set of groups used to compute the BSP build targets.

Each config file contains a `groups` dictionary where entries look as follows:

```
# The dictionary key is used to identify the group. It must be unique.
[groups.ID1]:
# One or more Pants address specs defining what targets to include in the group.
addresses = [
    "src/jvm::",
    "tests/jvm::",
]
# Filter targets to a specific resolve. Targets in a group must be from a single resolve.
# Format of filter is `TYPE:RESOLVE_NAME`. The only supported TYPE is `jvm`. RESOLVE_NAME must be
# a valid resolve name.
resolve = "jvm:jvm-default"
display_name = "Display Name"  # (Optional) Name shown to the user in the IDE.
base_directory = "path/from/build/root"  # (Optional) Hint to the IDE for where the build target should "live."
```

Note: Filtering by resolve will be implemented in a follow-on PR since it entails changes to interfaces between core BSP rules and language-specific BSP rules which would make this PR more complex than it needs to be.