### PR TITLE
Make PEX lockfile subsetting incremental

### DIFF
--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -87,7 +87,6 @@ async def export_virtualenv(
         Pex,
         RequirementsPexRequest(
             (tgt.address for tgt in request.root_python_targets),
-            internal_only=True,
             hardcoded_interpreter_constraints=min_interpreter,
         ),
     )

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -168,9 +168,7 @@ async def setup_pytest_for_target(
 
     interpreter_constraints = InterpreterConstraints.create_from_targets(all_targets, python_setup)
 
-    requirements_pex_get = Get(
-        Pex, RequirementsPexRequest([request.field_set.address], internal_only=True)
-    )
+    requirements_pex_get = Get(Pex, RequirementsPexRequest([request.field_set.address]))
     pytest_pex_get = Get(
         Pex,
         PexRequest(

--- a/src/python/pants/backend/python/goals/repl.py
+++ b/src/python/pants/backend/python/goals/repl.py
@@ -16,6 +16,7 @@ from pants.backend.python.util_rules.pex_environment import PexEnvironment
 from pants.backend.python.util_rules.pex_from_targets import (
     InterpreterConstraintsRequest,
     NoCompatibleResolveException,
+    PexFromTargetsRequest,
     RequirementsPexRequest,
 )
 from pants.backend.python.util_rules.python_sources import (
@@ -74,7 +75,14 @@ async def create_python_repl_request(
         Get(TransitiveTargets, TransitiveTargetsRequest(request.addresses)),
     )
 
-    requirements_request = Get(Pex, RequirementsPexRequest(request.addresses, internal_only=True))
+    requirements_request = Get(
+        Pex,
+        PexFromTargetsRequest(
+            request.addresses,
+            internal_only=True,
+            output_filename="requirements.pex",
+        ),
+    )
     local_dists_request = Get(
         LocalDistsPex,
         LocalDistsPexRequest(
@@ -128,7 +136,7 @@ async def create_ipython_repl_request(
         Get(TransitiveTargets, TransitiveTargetsRequest(request.addresses)),
     )
 
-    requirements_request = Get(Pex, RequirementsPexRequest(request.addresses, internal_only=True))
+    requirements_request = Get(Pex, RequirementsPexRequest(request.addresses))
     sources_request = Get(
         PythonSourceFiles, PythonSourceFilesRequest(transitive_targets.closure, include_files=True)
     )

--- a/src/python/pants/backend/python/goals/repl.py
+++ b/src/python/pants/backend/python/goals/repl.py
@@ -16,7 +16,6 @@ from pants.backend.python.util_rules.pex_environment import PexEnvironment
 from pants.backend.python.util_rules.pex_from_targets import (
     InterpreterConstraintsRequest,
     NoCompatibleResolveException,
-    PexFromTargetsRequest,
     RequirementsPexRequest,
 )
 from pants.backend.python.util_rules.python_sources import (
@@ -75,14 +74,7 @@ async def create_python_repl_request(
         Get(TransitiveTargets, TransitiveTargetsRequest(request.addresses)),
     )
 
-    requirements_request = Get(
-        Pex,
-        PexFromTargetsRequest(
-            request.addresses,
-            internal_only=True,
-            output_filename="requirements.pex",
-        ),
-    )
+    requirements_request = Get(Pex, RequirementsPexRequest(request.addresses))
     local_dists_request = Get(
         LocalDistsPex,
         LocalDistsPexRequest(

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -82,7 +82,6 @@ async def pylint_lint_partition(
             # a different version for the requirements than the other two PEXes, which can result
             # in a PEX runtime error about missing dependencies.
             hardcoded_interpreter_constraints=partition.interpreter_constraints,
-            internal_only=True,
         ),
     )
 

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -134,7 +134,6 @@ async def mypy_typecheck_partition(
         RequirementsPexRequest(
             (tgt.address for tgt in partition.root_targets),
             hardcoded_interpreter_constraints=partition.interpreter_constraints,
-            internal_only=True,
         ),
     )
     extra_type_stubs_pex_get = Get(

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -444,6 +444,7 @@ async def build_pex(
             )
             requirement_count = _pex_lockfile_requirement_count(lock_bytes)
             argv.extend(["--lock", lock_path])
+            argv.extend(request.requirements.req_strings)
         else:
             header_delimiter = "#"
             # Note: this is a very naive heuristic. It will overcount because entries often

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -635,6 +635,12 @@ async def _setup_constraints_repository_pex(
 @frozen_after_init
 @dataclass(unsafe_hash=True)
 class RequirementsPexRequest:
+    """Requests a PEX containing only thirdparty requirements for internal/non-portable use.
+
+    Used as part of an optimization to reduce the "overhead" (in terms of both time and space) of
+    thirdparty requirements by taking advantage of certain PEX features.
+    """
+
     addresses: tuple[Address, ...]
     hardcoded_interpreter_constraints: InterpreterConstraints | None
 

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -46,6 +46,7 @@ from pants.engine.target import Target, TransitiveTargets, TransitiveTargetsRequ
 from pants.util.docutil import doc_url
 from pants.util.logging import LogLevel
 from pants.util.meta import frozen_after_init
+from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.strutil import bullet_list, path_safe
 
 logger = logging.getLogger(__name__)
@@ -337,7 +338,6 @@ async def determine_requirement_strings_in_closure(
 @dataclass(unsafe_hash=True)
 class _RepositoryPexRequest:
     addresses: Addresses
-    requirements: PexRequirements
     hardcoded_interpreter_constraints: InterpreterConstraints | None
     platforms: PexPlatforms
     complete_platforms: CompletePlatforms
@@ -347,7 +347,6 @@ class _RepositoryPexRequest:
     def __init__(
         self,
         addresses: Iterable[Address],
-        requirements: PexRequirements,
         *,
         internal_only: bool,
         hardcoded_interpreter_constraints: InterpreterConstraints | None = None,
@@ -356,7 +355,6 @@ class _RepositoryPexRequest:
         additional_lockfile_args: tuple[str, ...] = (),
     ) -> None:
         self.addresses = Addresses(addresses)
-        self.requirements = requirements
         self.internal_only = internal_only
         self.hardcoded_interpreter_constraints = hardcoded_interpreter_constraints
         self.platforms = platforms
@@ -376,7 +374,57 @@ class _ConstraintsRepositoryPexRequest:
 
 
 @rule(level=LogLevel.DEBUG)
-async def create_pex_from_targets(request: PexFromTargetsRequest) -> PexRequest:
+async def create_pex_from_targets(
+    request: PexFromTargetsRequest, python_setup: PythonSetup
+) -> PexRequest:
+    requirements: PexRequirements | Lockfile = PexRequirements()
+    if request.include_requirements:
+        requirements = await Get(PexRequirements, _PexRequirementsRequest(request.addresses))
+
+        should_return_entire_lockfile = (
+            python_setup.run_against_entire_lockfile and request.internal_only
+        )
+        should_request_repository_pex = should_return_entire_lockfile or (
+            python_setup.resolve_all_constraints and python_setup.requirement_constraints
+        )
+        if should_request_repository_pex:
+            repository_pex_request = await Get(
+                OptionalPexRequest,
+                _RepositoryPexRequest(
+                    request.addresses,
+                    hardcoded_interpreter_constraints=request.hardcoded_interpreter_constraints,
+                    platforms=request.platforms,
+                    complete_platforms=request.complete_platforms,
+                    internal_only=request.internal_only,
+                    additional_lockfile_args=request.additional_lockfile_args,
+                ),
+            )
+            if should_return_entire_lockfile:
+                if repository_pex_request.maybe_pex_request is None:
+                    raise ValueError(
+                        "[python].run_against_entire_lockfile was set, but could not find a "
+                        "lockfile or constraints file for this target set. See "
+                        f"{doc_url('python-third-party-dependencies')} for details."
+                    )
+                return repository_pex_request.maybe_pex_request
+
+            repository_pex = await Get(OptionalPex, OptionalPexRequest, repository_pex_request)
+            requirements = dataclasses.replace(
+                requirements, repository_pex=repository_pex.maybe_pex
+            )
+        elif python_setup.enable_resolves:
+            chosen_resolve = await Get(
+                ChosenPythonResolve, ChosenPythonResolveRequest(request.addresses)
+            )
+            requirements = Lockfile(
+                file_path=chosen_resolve.lockfile_path,
+                file_path_description_of_origin=(
+                    f"the resolve `{chosen_resolve.name}` (from `[python].resolves`)"
+                ),
+                resolve_name=chosen_resolve.name,
+                req_strings=requirements.req_strings,
+            )
+
     interpreter_constraints = await Get(
         InterpreterConstraints,
         InterpreterConstraintsRequest,
@@ -424,26 +472,6 @@ async def create_pex_from_targets(request: PexFromTargetsRequest) -> PexRequest:
     )
 
     description = request.description
-
-    if request.include_requirements:
-        requirements = await Get(PexRequirements, _PexRequirementsRequest(request.addresses))
-    else:
-        requirements = PexRequirements()
-
-    if requirements:
-        repository_pex = await Get(
-            OptionalPex,
-            _RepositoryPexRequest(
-                request.addresses,
-                requirements=requirements,
-                hardcoded_interpreter_constraints=request.hardcoded_interpreter_constraints,
-                platforms=request.platforms,
-                complete_platforms=request.complete_platforms,
-                internal_only=request.internal_only,
-                additional_lockfile_args=request.additional_lockfile_args,
-            ),
-        )
-        requirements = dataclasses.replace(requirements, repository_pex=repository_pex.maybe_pex)
 
     return PexRequest(
         output_filename=request.output_filename,
@@ -503,7 +531,8 @@ async def get_repository_pex(
                     f"the resolve `{chosen_resolve.name}` (from `[python].resolves`)"
                 ),
                 resolve_name=chosen_resolve.name,
-                req_strings=request.requirements.req_strings,
+                # NB: PEX interprets `--lock` with no `req_strings` as "install the entire lockfile"
+                req_strings=FrozenOrderedSet(),
             ),
             interpreter_constraints=interpreter_constraints,
             platforms=request.platforms,
@@ -606,55 +635,29 @@ async def _setup_constraints_repository_pex(
 @dataclass(unsafe_hash=True)
 class RequirementsPexRequest:
     addresses: tuple[Address, ...]
-    internal_only: bool
     hardcoded_interpreter_constraints: InterpreterConstraints | None
 
     def __init__(
         self,
         addresses: Iterable[Address],
         *,
-        internal_only: bool,
         hardcoded_interpreter_constraints: InterpreterConstraints | None = None,
     ) -> None:
         self.addresses = Addresses(addresses)
-        self.internal_only = internal_only
         self.hardcoded_interpreter_constraints = hardcoded_interpreter_constraints
 
 
 @rule
-async def get_requirements_pex(request: RequirementsPexRequest, setup: PythonSetup) -> PexRequest:
-    if setup.run_against_entire_lockfile and request.internal_only:
-        requirements = await Get(
-            PexRequirements, _PexRequirementsRequest(Addresses(request.addresses))
-        )
-        opt_pex_request = await Get(
-            OptionalPexRequest,
-            _RepositoryPexRequest(
-                addresses=sorted(request.addresses),
-                requirements=requirements,
-                internal_only=request.internal_only,
-                hardcoded_interpreter_constraints=request.hardcoded_interpreter_constraints,
-            ),
-        )
-        if opt_pex_request.maybe_pex_request is None:
-            raise ValueError(
-                "[python].run_against_entire_lockfile was set, but could not find a "
-                "lockfile or constraints file for this target set. See "
-                f"{doc_url('python-third-party-dependencies')} for details."
-            )
-        return opt_pex_request.maybe_pex_request
-
-    pex_request = await Get(
-        PexRequest,
-        PexFromTargetsRequest(
-            addresses=sorted(request.addresses),
-            output_filename="requirements.pex",
-            internal_only=request.internal_only,
-            include_source_files=False,
-            hardcoded_interpreter_constraints=request.hardcoded_interpreter_constraints,
-        ),
+async def generalize_requirementspexrequest(
+    request: RequirementsPexRequest,
+) -> PexFromTargetsRequest:
+    return PexFromTargetsRequest(
+        addresses=sorted(request.addresses),
+        output_filename="requirements.pex",
+        internal_only=True,
+        include_source_files=False,
+        hardcoded_interpreter_constraints=request.hardcoded_interpreter_constraints,
     )
-    return pex_request
 
 
 def rules():

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -532,6 +532,7 @@ async def get_repository_pex(
                 ),
                 resolve_name=chosen_resolve.name,
                 # NB: PEX interprets `--lock` with no `req_strings` as "install the entire lockfile"
+                # And we don't use `req_strings` if the resolve isn't a PEX lockfile.
                 req_strings=FrozenOrderedSet(),
             ),
             interpreter_constraints=interpreter_constraints,


### PR DESCRIPTION
# Background

This PR has 2 facets:
- Moving most of the `RequirementsPexRequest` rule handling into `PexFromTargetsRequest` rule handling to help streamline where the changes are for this.
- Passing the requirement strings on the command-line to PEX in the PEX lockfile case (along with `--lock`) so PEX doesn't need pip to resolve anything.

The result of this is that:
1. user's shouldn't have to trade-off `[python].run_against_entire_lockfile` or not. It was always be more space and time performant this way (the thing to remember here is PEX will use symlinks (if told) or hardlinks to ensure we aren't copying the giant wheels around)
2. Users using `--changed` now will only request the dependencies needed for the operation, and will only download what isn't already cached.
3. because of 1. upgrades to Pants which  add new arguments to the PEX process invocation, therefore invalidating caches, no longer invalidate the repository PEX.

# Metrics

On 2.11.x (96d51788af46dc4b39812664aa861b8b07a85d7e) Vs this PR (+ https://github.com/pantsbuild/pex/pull/1694)

For cold cache, I run the following commands to warm up
```
rm -rf ~/.cache/pants/lmdb_store/
rm -rf ~/.cache/pants/named_caches/
rm -rf .pids
./pants_from_sources help
```

Notes:
- 64-core machine
- black, (internal copyright formatter), flake8, isort, :exclamation:mypy , and pylint
- I'm using `[pex].venv_use_symlinks = true`

## Full lint

This case models a CI run, which might be on a completely cold machine (case-and-point this repo's GHA). It also models upgrades to Pants' version where the PEX args differ, as well as updates to the lockfile, both invalidating the cache.

`time ./pants_from_sources lint ::`

| - | 2.11.x  | This PR |
| -------------  | ------------- | ------------- |
| time - real  | 9m48.887s | 5m10.263s  |
| time - user |    36m7.188s | 53m21.293s  |
| time - sys |     4m29.392s  | 6m18.442s  |
| space - lmdb_store | 2.3G | 1.4GB |
| space - named_caches | 11G | 9.5GB |

On 2.11.X, installing `repository.pex` took 8m24s seconds, and acts like a giant tentpole (https://github.com/pantsbuild/pants/issues/11303 and https://github.com/pantsbuild/pants/issues/14886 are very relevant)

## Incremental (--changed) lint

This case models developer runs.

(Since I'm not changing any files in my branch, I'll just ask to lint a single file. Then ask to lint a completely different file to model the "incremental" nature)
`time ./pants_from_sources lint path/to/a_test_file.py`
followed by `time ./pants_from_sources lint different-path/to/a_different_file.py`

First file:

| - | 2.11.x | This PR  |
| -------------  | ------------- | ------------- |
| time - real  | 7m47.071s |  0m40.998s |
| time - user |    8m50.894s |  1m24.781s |
| time - sys |     1m30.338s  | 0m13.899s  |
| space - lmdb_store | 2.3G | 61M |
| space - named_caches | 10G | 383M |

Second file:
(note this file has a transitive dependency on `mxnet` which is very large)

| - | 2.11.x  | This PR  |
| -------------  | ------------- | ------------- |
| time - real  | 0m16.437s |  2m39.155s |
| time - user | 0m22.137s |  3m33.879s |
| time - sys | 0m9.119s  |  0m20.483s |
| space - lmdb_store | 2.3G | 865M |
| space - named_caches | 10G | 5.4G |

[ci skip-rust]