### PR TITLE
Fix Pylint config check strings (Cherry-pick of #14946)

### DIFF
--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -166,8 +166,8 @@ class Pylint(PythonToolBase):
             specified=self.config,
             specified_option_name=f"[{self.options_scope}].config",
             discovery=cast(bool, self.options.config_discovery),
-            check_existence=[".pylinrc", *(os.path.join(d, "pylintrc") for d in ("", *dirs))],
-            check_content={"pyproject.toml": b"[tool.pylint]", "setup.cfg": b"[pylint."},
+            check_existence=[".pylintrc", *(os.path.join(d, "pylintrc") for d in ("", *dirs))],
+            check_content={"pyproject.toml": b"[tool.pylint.", "setup.cfg": b"[pylint."},
         )
 
     @property


### PR DESCRIPTION
- According to https://pylint.pycqa.org/en/latest/user_guide/run.html the section _starts with_ `tool.pylint`. (E.g. `[tool.pylint.MASTER]`)
- It's `.pylintrc` not `.pylinrc` (missing "t")