### PR TITLE
Add support for parsing address parameters to CLI specs parsing (cherrypick of #14949)

### DIFF
--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -12,6 +12,7 @@ from typing import ClassVar, Iterable
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.engine.fs import GlobExpansionConjunction, PathGlobs
 from pants.util.dirutil import fast_relpath_optional, recursive_dirname
+from pants.util.frozendict import FrozenDict
 from pants.util.meta import frozen_after_init
 
 
@@ -42,6 +43,7 @@ class AddressLiteralSpec(AddressSpec):
     path_component: str
     target_component: str | None = None
     generated_component: str | None = None
+    parameters: FrozenDict[str, str] = FrozenDict()
 
     def __str__(self) -> str:
         tgt = f":{self.target_component}" if self.target_component else ""
@@ -51,7 +53,11 @@ class AddressLiteralSpec(AddressSpec):
     @property
     def is_directory_shorthand(self) -> bool:
         """Is in the format `path/to/dir`, which is shorthand for `path/to/dir:dir`."""
-        return self.target_component is None and self.generated_component is None
+        return (
+            self.target_component is None
+            and self.generated_component is None
+            and not self.parameters
+        )
 
 
 @dataclass(frozen=True)  # type: ignore[misc]
@@ -261,9 +267,7 @@ class DirLiteralSpec(FilesystemSpec):
 
     def to_address_literal(self) -> AddressLiteralSpec:
         """For now, `dir` can also be shorthand for `dir:dir`."""
-        return AddressLiteralSpec(
-            path_component=self.v, target_component=None, generated_component=None
-        )
+        return AddressLiteralSpec(path_component=self.v)
 
 
 @frozen_after_init

--- a/src/python/pants/base/specs_parser.py
+++ b/src/python/pants/base/specs_parser.py
@@ -22,6 +22,8 @@ from pants.base.specs import (
     SiblingAddresses,
     Specs,
 )
+from pants.engine.internals import native_engine
+from pants.util.frozendict import FrozenDict
 from pants.util.ordered_set import OrderedSet
 
 
@@ -71,37 +73,40 @@ class SpecsParser:
 
         :raises: CmdLineSpecParser.BadSpecError if the address selector could not be parsed.
         """
-        if spec.endswith("::"):
-            spec_path = spec[: -len("::")]
-            return DescendantAddresses(directory=self._normalize_spec_path(spec_path))
-        if spec.endswith(":"):
-            spec_path = spec[: -len(":")]
-            return SiblingAddresses(directory=self._normalize_spec_path(spec_path))
-        if ":" in spec or "#" in spec:
-            tgt_parts = spec.split(":", maxsplit=1)
-            path_component = tgt_parts[0]
-            if len(tgt_parts) == 1:
-                target_component = None
-                generated_parts = path_component.split("#", maxsplit=1)
-                if len(generated_parts) == 1:
-                    generated_component = None
-                else:
-                    path_component, generated_component = generated_parts
-            else:
-                generated_parts = tgt_parts[1].split("#", maxsplit=1)
-                if len(generated_parts) == 1:
-                    target_component = generated_parts[0]
-                    generated_component = None
-                else:
-                    target_component, generated_component = generated_parts
+        (
+            is_ignored,
+            (
+                path_component,
+                target_component,
+                generated_component,
+                parameters,
+            ),
+            wildcard,
+        ) = native_engine.address_spec_parse(spec)
+
+        def assert_not_ignored(spec_descriptor: str) -> None:
+            if is_ignored:
+                raise self.BadSpecError(
+                    f"The {spec_descriptor} spec `{spec}` does not support ignore (`!`) syntax."
+                )
+
+        if wildcard == "::":
+            assert_not_ignored("address wildcard")
+            return DescendantAddresses(directory=self._normalize_spec_path(path_component))
+        if wildcard == ":":
+            assert_not_ignored("address wildcard")
+            return SiblingAddresses(directory=self._normalize_spec_path(path_component))
+        if target_component or generated_component or parameters:
+            assert_not_ignored("address")
             return AddressLiteralSpec(
                 path_component=self._normalize_spec_path(path_component),
                 target_component=target_component,
                 generated_component=generated_component,
+                parameters=FrozenDict(sorted(parameters)),
             )
-        if spec.startswith("!"):
-            return FileIgnoreSpec(spec[1:])
-        if "*" in spec:
+        if is_ignored:
+            return FileIgnoreSpec(path_component)
+        if "*" in path_component:
             return FileGlobSpec(spec)
         if PurePath(spec).suffix:
             return FileLiteralSpec(self._normalize_spec_path(spec))

--- a/src/python/pants/base/specs_parser_test.py
+++ b/src/python/pants/base/specs_parser_test.py
@@ -21,12 +21,18 @@ from pants.base.specs import (
     Spec,
 )
 from pants.base.specs_parser import SpecsParser
+from pants.util.frozendict import FrozenDict
 
 
 def address_literal(
-    directory: str, name: str | None, generated: str | None = None
+    directory: str,
+    name: str | None = None,
+    generated: str | None = None,
+    parameters: dict[str, str] | None = None,
 ) -> AddressLiteralSpec:
-    return AddressLiteralSpec(directory, name, generated)
+    return AddressLiteralSpec(
+        directory, name, generated, FrozenDict(sorted(parameters.items()) if parameters else ())
+    )
 
 
 def desc(directory: str) -> DescendantAddresses:
@@ -66,6 +72,9 @@ def assert_spec_parsed(build_root: Path, spec_str: str, expected_spec: Spec) -> 
         (":root", address_literal("", "root")),
         ("//:root", address_literal("", "root")),
         ("a", dir_literal("a")),
+        ("a@k=v", address_literal("a", parameters={"k": "v"})),
+        ("a@k=v,x=y", address_literal("a", parameters={"k": "v", "x": "y"})),
+        ("a:b@k=v", address_literal("a", "b", parameters={"k": "v"})),
         ("a:a", address_literal("a", "a")),
         ("a/b", dir_literal("a/b")),
         ("a/b:b", address_literal("a/b", "b")),

--- a/src/python/pants/build_graph/address_test.py
+++ b/src/python/pants/build_graph/address_test.py
@@ -12,6 +12,8 @@ from pants.build_graph.address import (
     InvalidParameters,
     InvalidSpecPath,
     InvalidTargetName,
+    UnsupportedIgnore,
+    UnsupportedWildcard,
 )
 from pants.util.frozendict import FrozenDict
 
@@ -110,7 +112,6 @@ def test_address_input_parse_bad_path_component(spec: str) -> None:
 @pytest.mark.parametrize(
     "spec,expected",
     [
-        ("a:", "non-empty target name"),
         ("a@t", "one or more key=value pairs"),
         ("a@=", "one or more key=value pairs"),
         ("a@t,y", "one or more key=value pairs"),
@@ -128,7 +129,6 @@ def test_address_input_parse(spec: str, expected: str) -> None:
     "spec",
     [
         "",
-        "a::",
         "//",
         "//:!t",
         "//:?",
@@ -140,6 +140,35 @@ def test_address_input_parse(spec: str, expected: str) -> None:
 )
 def test_address_bad_target_component(spec: str) -> None:
     with pytest.raises(InvalidTargetName):
+        AddressInput.parse(spec).dir_to_address()
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        "!",
+        "!a",
+        "!a:x",
+        "!a#x",
+    ],
+)
+def test_address_bad_ignore(spec: str) -> None:
+    with pytest.raises(UnsupportedIgnore):
+        AddressInput.parse(spec).dir_to_address()
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        "a::",
+        "a:",
+        "a:b:",
+        "a:b::",
+        "a#b:",
+    ],
+)
+def test_address_bad_wildcard(spec: str) -> None:
+    with pytest.raises(UnsupportedWildcard):
         AddressInput.parse(spec).dir_to_address()
 
 

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -191,7 +191,12 @@ async def addresses_from_address_specs(
     literal_wrapped_targets = await MultiGet(
         Get(
             WrappedTarget,
-            AddressInput(spec.path_component, spec.target_component, spec.generated_component),
+            AddressInput(
+                spec.path_component,
+                spec.target_component,
+                spec.generated_component,
+                spec.parameters,
+            ),
         )
         for spec in address_specs.literals
     )

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -24,7 +24,9 @@ from pants.engine.process import InteractiveProcessResult
 class AddressParseException(Exception):
     pass
 
-def address_parse(spec: str) -> tuple[str, str | None, str | None, tuple[tuple[str, str], ...]]: ...
+def address_spec_parse(
+    spec: str,
+) -> tuple[bool, tuple[str, str | None, str | None, tuple[tuple[str, str], ...]], str | None]: ...
 
 # ------------------------------------------------------------------------------
 # Scheduler

--- a/src/python/pants/init/specs_calculator.py
+++ b/src/python/pants/init/specs_calculator.py
@@ -72,6 +72,7 @@ def calculate_specs(
                 path_component=address_input.path_component,
                 target_component=address_input.target_component,
                 generated_component=address_input.generated_component,
+                parameters=address_input.parameters,
             )
         )
     return Specs(AddressSpecs(address_specs, filter_by_global_options=True), FilesystemSpecs([]))

--- a/src/rust/engine/address/src/lib.rs
+++ b/src/rust/engine/address/src/lib.rs
@@ -32,18 +32,30 @@ pub struct AddressInput<'a> {
   pub parameters: Vec<(&'a str, &'a str)>,
 }
 
+pub struct SpecInput<'a> {
+  /// True if the spec started with an `!`.
+  pub is_ignored: bool,
+  /// The address (or literal, if no target/generated/parameters were specified) portion.
+  pub address: AddressInput<'a>,
+  /// If a spec wildcard was specified (`:` or `::`), its value.
+  pub wildcard: Option<&'a str>,
+}
+
 peg::parser! {
-    grammar relative_address_parser() for str {
+    grammar parsers() for str {
         rule path() -> &'input str = s:$([^':' | '@' | '#']*) { s }
 
         rule target_name() -> &'input str
-            = quiet!{ s:$([^'#' | '@']+) { s } }
+            = quiet!{ s:$([^'#' | '@' | ':']+) { s } }
             / expected!("a non-empty target name to follow a `:`.")
 
-        rule target() -> &'input str = ":" s:target_name() { s }
+        rule target() -> &'input str =
+          // NB: We use `&[_]` to differentiate from a wildcard by ensuring that a non-EOF
+          // character follows the `:`.
+          ":" &[_] s:target_name() { s }
 
         rule generated_name() -> &'input str
-            = quiet!{ s:$([^'@']+) { s } }
+            = quiet!{ s:$([^'@' | ':']+) { s } }
             / expected!("a non-empty generated target name to follow a `#`.")
 
         rule generated() -> &'input str = "#" s:generated_name() { s }
@@ -52,10 +64,10 @@ peg::parser! {
             = "@" parameters:parameter() ++ "," { parameters }
 
         rule parameter() -> (&'input str, &'input str)
-            = quiet!{ key:$([^'=']+) "=" value:$([^',']*) { (key, value) } }
+            = quiet!{ key:$([^'=' | ':']+) "=" value:$([^',' | ':']*) { (key, value) } }
             / expected!("one or more key=value pairs to follow a `@`.")
 
-        pub(crate) rule relative_address() -> AddressInput<'input>
+        rule address() -> AddressInput<'input>
             = path:path() target:target()? generated:generated()? parameters:parameters()? {
                 AddressInput {
                     path,
@@ -64,12 +76,22 @@ peg::parser! {
                     parameters: parameters.unwrap_or_else(Vec::new),
                 }
             }
+
+        rule ignore() -> () = "!" {}
+
+        rule wildcard() -> &'input str = s:$("::" / ":") { s }
+
+        pub(crate) rule spec() -> SpecInput<'input>
+            = is_ignored:ignore()? address:address() wildcard:wildcard()? {
+                SpecInput {
+                    is_ignored: is_ignored == Some(()),
+                    address,
+                    wildcard,
+                }
+            }
     }
 }
 
-pub fn parse_address(value: &str) -> Result<AddressInput, String> {
-  let relative_address = relative_address_parser::relative_address(value)
-    .map_err(|e| format!("Failed to parse Address `{value}`: {e}"))?;
-
-  Ok(relative_address)
+pub fn parse_address_spec(value: &str) -> Result<SpecInput, String> {
+  parsers::spec(value).map_err(|e| format!("Failed to parse address spec `{value}`: {e}"))
 }

--- a/src/rust/engine/src/externs/address.rs
+++ b/src/rust/engine/src/externs/address.rs
@@ -5,8 +5,6 @@ use pyo3::create_exception;
 use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
 
-use address::parse_address;
-
 create_exception!(native_engine, AddressParseException, PyException);
 
 pub fn register(py: Python, m: &PyModule) -> PyResult<()> {
@@ -14,12 +12,14 @@ pub fn register(py: Python, m: &PyModule) -> PyResult<()> {
     "AddressParseException",
     py.get_type::<AddressParseException>(),
   )?;
-  m.add_function(wrap_pyfunction!(address_parse, m)?)?;
+  m.add_function(wrap_pyfunction!(address_spec_parse, m)?)?;
   Ok(())
 }
 
-// TODO: If more of `pants.build_graph.address.AddressInput` is ported to Rust, it might be worth
-// moving the definition into the `address` crate. But for now, this is a tuple.
+/// 1. a path component
+/// 2. a target component
+/// 3. a generated component
+/// 4. a sequence of key/value parameters
 type ParsedAddress<'a> = (
   &'a str,
   Option<&'a str>,
@@ -27,19 +27,31 @@ type ParsedAddress<'a> = (
   Vec<(&'a str, &'a str)>,
 );
 
-/// Parses an Address spec into:
-/// 1. a path component
-/// 2. a target component
-/// 3. a sequence of key/value parameters
-/// 4. a generated component
+/// 1. an is_ignored boolean
+/// 2. an address
+/// 3. an optional wildcard component (`:` or `::`)
+type ParsedSpec<'a> = (bool, ParsedAddress<'a>, Option<&'a str>);
+
+/// Parses an "address spec", which may come from the CLI or from a BUILD file.
 ///
+/// The underlying parser will accept some combinations of syntax which may not (yet) be legal in
+/// certain contexts. For example: a `!` ignore or `::` wildcard may be successfully parsed even
+/// when other address syntax is used: if the combination of syntax is not legal in a particular
+/// context, the caller should validate that.
+///
+/// TODO: If more of spec/address validation is ported to Rust, it might be worth defining a
+/// pyclass for the return type.
 #[pyfunction]
-fn address_parse(spec: &str) -> PyResult<ParsedAddress> {
-  let address = parse_address(spec).map_err(AddressParseException::new_err)?;
+fn address_spec_parse(spec_str: &str) -> PyResult<ParsedSpec> {
+  let spec = address::parse_address_spec(spec_str).map_err(AddressParseException::new_err)?;
   Ok((
-    address.path,
-    address.target,
-    address.generated,
-    address.parameters,
+    spec.is_ignored,
+    (
+      spec.address.path,
+      spec.address.target,
+      spec.address.generated,
+      spec.address.parameters,
+    ),
+    spec.wildcard,
   ))
 }


### PR DESCRIPTION
 #14347 added support for `Address` parameters, which are used via the `parametrize` builtin. But we had not yet added support for parsing parametrized addresses to CLI specs parsing.

This change adds support for parsing parametrized addresses in CLI specs by generalizing the parser that was added in #14346 to support parsing the additional syntax required for CLI specs (`!` ignores and `:`/`::` wildcards), and then using the same parser (with different validation) for both `Address` and `Specs` parsing.

Fixes #14521.

[ci skip-build-wheels]