### PR TITLE
[internal] Move prior_formatter_result` to `FmtRequest` (+refactors)

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
@@ -10,7 +10,6 @@ from pants.backend.codegen.protobuf.target_types import (
 )
 from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.core.util_rules.system_binaries import (
     BinaryShims,
     BinaryShimsRequest,
@@ -45,14 +44,8 @@ class BufFormatRequest(FmtRequest):
     name = "buf-format"
 
 
-@dataclass(frozen=True)
-class Setup:
-    process: Process
-    original_snapshot: Snapshot
-
-
 @rule(level=LogLevel.DEBUG)
-async def setup_buf_format(request: BufFormatRequest, buf: BufSubsystem) -> Setup:
+async def setup_buf_format_process(request: BufFormatRequest, buf: BufSubsystem) -> Process:
     diff_binary = await Get(DiffBinary, DiffBinaryRequest())
     download_buf_get = Get(
         DownloadedExternalTool, ExternalToolRequest, buf.get_request(Platform.current)
@@ -66,23 +59,11 @@ async def setup_buf_format(request: BufFormatRequest, buf: BufSubsystem) -> Setu
             output_directory=".bin",
         ),
     )
-    source_files_get = Get(
-        SourceFiles,
-        SourceFilesRequest(field_set.sources for field_set in request.field_sets),
-    )
-    downloaded_buf, binary_shims, source_files = await MultiGet(
-        download_buf_get, binary_shims_get, source_files_get
-    )
-
-    source_files_snapshot = (
-        source_files.snapshot
-        if request.prior_formatter_result is None
-        else request.prior_formatter_result
-    )
+    downloaded_buf, binary_shims = await MultiGet(download_buf_get, binary_shims_get)
 
     input_digest = await Get(
         Digest,
-        MergeDigests((source_files_snapshot.digest, downloaded_buf.digest, binary_shims.digest)),
+        MergeDigests((request.snapshot.digest, downloaded_buf.digest, binary_shims.digest)),
     )
 
     argv = [
@@ -91,35 +72,29 @@ async def setup_buf_format(request: BufFormatRequest, buf: BufSubsystem) -> Setu
         "-w",
         *buf.format_args,
         "--path",
-        ",".join(source_files_snapshot.files),
+        ",".join(request.snapshot.files),
     ]
     process = Process(
         argv=argv,
         input_digest=input_digest,
-        output_files=source_files_snapshot.files,
+        output_files=request.snapshot.files,
         description=f"Run buf format on {pluralize(len(request.field_sets), 'file')}.",
         level=LogLevel.DEBUG,
         env={
             "PATH": binary_shims.bin_directory,
         },
     )
-    return Setup(process, original_snapshot=source_files_snapshot)
+    return process
 
 
 @rule(desc="Format with buf format", level=LogLevel.DEBUG)
 async def run_buf_format(request: BufFormatRequest, buf: BufSubsystem) -> FmtResult:
     if buf.skip_format:
         return FmtResult.skip(formatter_name=request.name)
-    setup = await Get(Setup, BufFormatRequest, request)
-    result = await Get(ProcessResult, Process, setup.process)
+    process = await Get(Process, BufFormatRequest, request)
+    result = await Get(ProcessResult, Process, process)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult(
-        setup.original_snapshot,
-        output_snapshot,
-        stdout=result.stdout.decode(),
-        stderr=result.stderr.decode(),
-        formatter_name=request.name,
-    )
+    return FmtResult.create(request, result, output_snapshot)
 
 
 def rules():

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules_integration_test.py
@@ -62,7 +62,7 @@ def run_buf(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            BufFormatRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            BufFormatRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
 

--- a/src/python/pants/backend/go/lint/gofmt/rules.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules.py
@@ -12,7 +12,6 @@ from pants.backend.go.subsystems import golang
 from pants.backend.go.subsystems.golang import GoRoot
 from pants.backend.go.target_types import GoPackageSourcesField
 from pants.core.goals.fmt import FmtRequest, FmtResult
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest
 from pants.engine.internals.native_engine import Snapshot
 from pants.engine.internals.selectors import Get
@@ -40,53 +39,31 @@ class GofmtRequest(FmtRequest):
     name = GofmtSubsystem.options_scope
 
 
-@dataclass(frozen=True)
-class Setup:
-    process: Process
-    original_snapshot: Snapshot
-
-
 @rule(level=LogLevel.DEBUG)
-async def setup_gofmt(request: GofmtRequest, goroot: GoRoot) -> Setup:
-    source_files = await Get(
-        SourceFiles,
-        SourceFilesRequest(field_set.sources for field_set in request.field_sets),
-    )
-    source_files_snapshot = (
-        source_files.snapshot
-        if request.prior_formatter_result is None
-        else request.prior_formatter_result
-    )
-
+async def setup_gofmt_process(request: GofmtRequest, goroot: GoRoot) -> Process:
     argv = (
         os.path.join(goroot.path, "bin/gofmt"),
         "-w",
-        *source_files_snapshot.files,
+        *request.snapshot.files,
     )
     process = Process(
         argv=argv,
-        input_digest=source_files_snapshot.digest,
-        output_files=source_files_snapshot.files,
-        description=f"Run gofmt on {pluralize(len(source_files_snapshot.files), 'file')}.",
+        input_digest=request.snapshot.digest,
+        output_files=request.snapshot.files,
+        description=f"Run gofmt on {pluralize(len(request.snapshot.files), 'file')}.",
         level=LogLevel.DEBUG,
     )
-    return Setup(process=process, original_snapshot=source_files_snapshot)
+    return process
 
 
 @rule(desc="Format with gofmt")
 async def gofmt_fmt(request: GofmtRequest, gofmt: GofmtSubsystem) -> FmtResult:
     if gofmt.skip:
         return FmtResult.skip(formatter_name=request.name)
-    setup = await Get(Setup, GofmtRequest, request)
-    result = await Get(ProcessResult, Process, setup.process)
+    process = await Get(Process, GofmtRequest, request)
+    result = await Get(ProcessResult, Process, process)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult(
-        setup.original_snapshot,
-        output_snapshot,
-        stdout=result.stdout.decode(),
-        stderr=result.stderr.decode(),
-        formatter_name=request.name,
-    )
+    return FmtResult.create(request, result, output_snapshot)
 
 
 def rules():

--- a/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
@@ -120,7 +120,7 @@ def run_gofmt(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            GofmtRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            GofmtRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/java/lint/google_java_format/rules.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules.py
@@ -8,10 +8,9 @@ from pants.backend.java.lint.google_java_format.subsystem import GoogleJavaForma
 from pants.backend.java.target_types import JavaSourceField
 from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest
 from pants.engine.internals.native_engine import Snapshot
-from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.internals.selectors import Get
 from pants.engine.process import ProcessResult
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import FieldSet, Target
@@ -46,35 +45,18 @@ class GoogleJavaFormatToolLockfileSentinel(GenerateToolLockfileSentinel):
     resolve_name = GoogleJavaFormatSubsystem.options_scope
 
 
-@dataclass(frozen=True)
-class Setup:
-    process: JvmProcess
-    original_snapshot: Snapshot
-
 
 @rule(level=LogLevel.DEBUG)
-async def setup_google_java_format(
+async def setup_google_java_format_process(
     request: GoogleJavaFormatRequest,
     tool: GoogleJavaFormatSubsystem,
     jdk: InternalJdk,
-) -> Setup:
+) -> JvmProcess:
 
     lockfile_request = await Get(
         GenerateJvmLockfileFromTool, GoogleJavaFormatToolLockfileSentinel()
     )
-    source_files, tool_classpath = await MultiGet(
-        Get(
-            SourceFiles,
-            SourceFilesRequest(field_set.source for field_set in request.field_sets),
-        ),
-        Get(ToolClasspath, ToolClasspathRequest(lockfile=lockfile_request)),
-    )
-
-    source_files_snapshot = (
-        source_files.snapshot
-        if request.prior_formatter_result is None
-        else request.prior_formatter_result
-    )
+    tool_classpath = await Get(ToolClasspath, ToolClasspathRequest(lockfile=lockfile_request))
 
     toolcp_relpath = "__toolcp"
     extra_immutable_input_digests = {
@@ -96,22 +78,22 @@ async def setup_google_java_format(
         "com.google.googlejavaformat.java.Main",
         *(["--aosp"] if tool.aosp else []),
         "--replace",
-        *source_files_snapshot.files,
+        *request.snapshot.files,
     ]
 
     process = JvmProcess(
         jdk=jdk,
         argv=args,
         classpath_entries=tool_classpath.classpath_entries(toolcp_relpath),
-        input_digest=source_files_snapshot.digest,
+        input_digest=request.snapshot.digest,
         extra_immutable_input_digests=extra_immutable_input_digests,
         extra_nailgun_keys=extra_immutable_input_digests,
-        output_files=source_files_snapshot.files,
+        output_files=request.snapshot.files,
         description=f"Run Google Java Format on {pluralize(len(request.field_sets), 'file')}.",
         level=LogLevel.DEBUG,
     )
 
-    return Setup(process, original_snapshot=source_files_snapshot)
+    return process
 
 
 @rule(desc="Format with Google Java Format", level=LogLevel.DEBUG)
@@ -120,16 +102,10 @@ async def google_java_format_fmt(
 ) -> FmtResult:
     if tool.skip:
         return FmtResult.skip(formatter_name=request.name)
-    setup = await Get(Setup, GoogleJavaFormatRequest, request)
-    result = await Get(ProcessResult, JvmProcess, setup.process)
+    process = await Get(JvmProcess, GoogleJavaFormatRequest, request)
+    result = await Get(ProcessResult, JvmProcess, process)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult(
-        setup.original_snapshot,
-        output_snapshot,
-        stdout=strip_v2_chroot_path(result.stdout),
-        stderr=strip_v2_chroot_path(result.stderr),
-        formatter_name=request.name,
-    )
+    return FmtResult.create(request, result, output_snapshot, strip_chroot_path=True)
 
 
 @rule

--- a/src/python/pants/backend/java/lint/google_java_format/rules_integration_test.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules_integration_test.py
@@ -92,7 +92,7 @@ def run_google_java_format(rule_runner: RuleRunner, targets: list[Target]) -> Fm
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            GoogleJavaFormatRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            GoogleJavaFormatRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/python/lint/autoflake/rules.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules.py
@@ -9,10 +9,8 @@ from pants.backend.python.target_types import InterpreterConstraintsField, Pytho
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtRequest, FmtResult
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest
 from pants.engine.internals.native_engine import Snapshot
-from pants.engine.internals.selectors import MultiGet
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import FieldSet, Target
@@ -38,27 +36,9 @@ class AutoflakeRequest(FmtRequest):
     name = Autoflake.options_scope
 
 
-@dataclass(frozen=True)
-class Setup:
-    process: Process
-    original_snapshot: Snapshot
-
-
 @rule(level=LogLevel.DEBUG)
-async def setup_autoflake(request: AutoflakeRequest, autoflake: Autoflake) -> Setup:
-    autoflake_pex_get = Get(VenvPex, PexRequest, autoflake.to_pex_request())
-
-    source_files_get = Get(
-        SourceFiles,
-        SourceFilesRequest(field_set.source for field_set in request.field_sets),
-    )
-
-    source_files, autoflake_pex = await MultiGet(source_files_get, autoflake_pex_get)
-    source_files_snapshot = (
-        source_files.snapshot
-        if request.prior_formatter_result is None
-        else request.prior_formatter_result
-    )
+async def setup_autoflake_process(request: AutoflakeRequest, autoflake: Autoflake) -> Process:
+    autoflake_pex = await Get(VenvPex, PexRequest, autoflake.to_pex_request())
 
     process = await Get(
         Process,
@@ -68,31 +48,25 @@ async def setup_autoflake(request: AutoflakeRequest, autoflake: Autoflake) -> Se
                 "--in-place",
                 "--remove-all-unused-imports",
                 *autoflake.args,
-                *source_files_snapshot.files,
+                *request.snapshot.files,
             ),
-            input_digest=source_files_snapshot.digest,
-            output_files=source_files_snapshot.files,
+            input_digest=request.snapshot.digest,
+            output_files=request.snapshot.files,
             description=f"Run Autoflake on {pluralize(len(request.field_sets), 'file')}.",
             level=LogLevel.DEBUG,
         ),
     )
-    return Setup(process, original_snapshot=source_files_snapshot)
+    return process
 
 
 @rule(desc="Format with Autoflake", level=LogLevel.DEBUG)
 async def autoflake_fmt(request: AutoflakeRequest, autoflake: Autoflake) -> FmtResult:
     if autoflake.skip:
         return FmtResult.skip(formatter_name=request.name)
-    setup = await Get(Setup, AutoflakeRequest, request)
-    result = await Get(ProcessResult, Process, setup.process)
+    process = await Get(Process, AutoflakeRequest, request)
+    result = await Get(ProcessResult, Process, process)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult(
-        setup.original_snapshot,
-        output_snapshot,
-        stdout=strip_v2_chroot_path(result.stdout),
-        stderr=strip_v2_chroot_path(result.stderr),
-        formatter_name=request.name,
-    )
+    return FmtResult.create(request, result, output_snapshot, strip_chroot_path=True)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/autoflake/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules_integration_test.py
@@ -63,7 +63,7 @@ def run_autoflake(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            AutoflakeRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            AutoflakeRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -80,7 +80,7 @@ def run_black(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            BlackRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            BlackRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -10,10 +10,9 @@ from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtRequest, FmtResult
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.core.util_rules.source_files import SourceFiles
 from pants.engine.fs import Digest
 from pants.engine.internals.native_engine import Snapshot
-from pants.engine.internals.selectors import MultiGet
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import FieldSet, Target
@@ -38,12 +37,6 @@ class DocformatterRequest(FmtRequest):
     name = Docformatter.options_scope
 
 
-@dataclass(frozen=True)
-class Setup:
-    process: Process
-    original_snapshot: Snapshot
-
-
 def generate_args(
     *, source_files: SourceFiles, docformatter: Docformatter, check_only: bool
 ) -> Tuple[str, ...]:
@@ -51,19 +44,9 @@ def generate_args(
 
 
 @rule(level=LogLevel.DEBUG)
-async def setup_docformatter(request: DocformatterRequest, docformatter: Docformatter) -> Setup:
-    docformatter_pex_get = Get(VenvPex, PexRequest, docformatter.to_pex_request())
-    source_files_get = Get(
-        SourceFiles,
-        SourceFilesRequest(field_set.source for field_set in request.field_sets),
-    )
-    source_files, docformatter_pex = await MultiGet(source_files_get, docformatter_pex_get)
+async def setup_docformatter_process(request: DocformatterRequest, docformatter: Docformatter) -> Process:
+    docformatter_pex = await Get(VenvPex, PexRequest, docformatter.to_pex_request())
 
-    source_files_snapshot = (
-        source_files.snapshot
-        if request.prior_formatter_result is None
-        else request.prior_formatter_result
-    )
     process = await Get(
         Process,
         VenvPexProcess(
@@ -71,31 +54,25 @@ async def setup_docformatter(request: DocformatterRequest, docformatter: Docform
             argv=(
                 "--in-place",
                 *docformatter.args,
-                *source_files_snapshot.files,
+                *request.snapshot.files,
             ),
-            input_digest=source_files_snapshot.digest,
-            output_files=source_files_snapshot.files,
+            input_digest=request.snapshot.digest,
+            output_files=request.snapshot.files,
             description=(f"Run Docformatter on {pluralize(len(request.field_sets), 'file')}."),
             level=LogLevel.DEBUG,
         ),
     )
-    return Setup(process, original_snapshot=source_files_snapshot)
+    return process
 
 
 @rule(desc="Format with docformatter", level=LogLevel.DEBUG)
 async def docformatter_fmt(request: DocformatterRequest, docformatter: Docformatter) -> FmtResult:
     if docformatter.skip:
         return FmtResult.skip(formatter_name=request.name)
-    setup = await Get(Setup, DocformatterRequest, request)
-    result = await Get(ProcessResult, Process, setup.process)
+    process = await Get(Process, DocformatterRequest, request)
+    result = await Get(ProcessResult, Process, process)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult(
-        setup.original_snapshot,
-        output_snapshot,
-        stdout=result.stdout.decode(),
-        stderr=result.stderr.decode(),
-        formatter_name=request.name,
-    )
+    return FmtResult.create(request, result, output_snapshot, strip_chroot_path=True)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -59,7 +59,7 @@ def run_docformatter(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            DocformatterRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            DocformatterRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -12,7 +12,6 @@ from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, PexResolveInfo, VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.internals.native_engine import Snapshot
 from pants.engine.process import Process, ProcessResult
@@ -39,12 +38,6 @@ class IsortRequest(FmtRequest):
     name = Isort.options_scope
 
 
-@dataclass(frozen=True)
-class Setup:
-    process: Process
-    original_snapshot: Snapshot
-
-
 def generate_argv(
     source_files: tuple[str, ...], isort: Isort, *, is_isort5: bool
 ) -> Tuple[str, ...]:
@@ -69,23 +62,12 @@ def generate_argv(
 
 
 @rule(level=LogLevel.DEBUG)
-async def setup_isort(request: IsortRequest, isort: Isort) -> Setup:
+async def setup_isort_process(request: IsortRequest, isort: Isort) -> Process:
     isort_pex_get = Get(VenvPex, PexRequest, isort.to_pex_request())
-    source_files_get = Get(
-        SourceFiles,
-        SourceFilesRequest(field_set.source for field_set in request.field_sets),
+    config_files_get = Get(
+        ConfigFiles, ConfigFilesRequest, isort.config_request(request.snapshot.dirs)
     )
-    source_files, isort_pex = await MultiGet(source_files_get, isort_pex_get)
-
-    source_files_snapshot = (
-        source_files.snapshot
-        if request.prior_formatter_result is None
-        else request.prior_formatter_result
-    )
-
-    config_files = await Get(
-        ConfigFiles, ConfigFilesRequest, isort.config_request(source_files_snapshot.dirs)
-    )
+    config_files, isort_pex = await MultiGet(config_files_get, isort_pex_get)
 
     # Isort 5+ changes how config files are handled. Determine which semantics we should use.
     is_isort5 = False
@@ -97,37 +79,31 @@ async def setup_isort(request: IsortRequest, isort: Isort) -> Setup:
         )
 
     input_digest = await Get(
-        Digest, MergeDigests((source_files_snapshot.digest, config_files.snapshot.digest))
+        Digest, MergeDigests((request.snapshot.digest, config_files.snapshot.digest))
     )
 
     process = await Get(
         Process,
         VenvPexProcess(
             isort_pex,
-            argv=generate_argv(source_files_snapshot.files, isort, is_isort5=is_isort5),
+            argv=generate_argv(request.snapshot.files, isort, is_isort5=is_isort5),
             input_digest=input_digest,
-            output_files=source_files_snapshot.files,
+            output_files=request.snapshot.files,
             description=f"Run isort on {pluralize(len(request.field_sets), 'file')}.",
             level=LogLevel.DEBUG,
         ),
     )
-    return Setup(process, original_snapshot=source_files_snapshot)
+    return process
 
 
 @rule(desc="Format with isort", level=LogLevel.DEBUG)
 async def isort_fmt(request: IsortRequest, isort: Isort) -> FmtResult:
     if isort.skip:
         return FmtResult.skip(formatter_name=request.name)
-    setup = await Get(Setup, IsortRequest, request)
-    result = await Get(ProcessResult, Process, setup.process)
+    process = await Get(Process, IsortRequest, request)
+    result = await Get(ProcessResult, Process, process)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult(
-        setup.original_snapshot,
-        output_snapshot,
-        stdout=strip_v2_chroot_path(result.stdout),
-        stderr=strip_v2_chroot_path(result.stderr),
-        formatter_name=request.name,
-    )
+    return FmtResult.create(request, result, output_snapshot, strip_chroot_path=True)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -67,7 +67,7 @@ def run_isort(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            IsortRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            IsortRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/python/lint/pyupgrade/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/rules_integration_test.py
@@ -73,7 +73,7 @@ def run_pyupgrade(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            PyUpgradeRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            PyUpgradeRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/python/lint/yapf/rules.py
+++ b/src/python/pants/backend/python/lint/yapf/rules.py
@@ -10,7 +10,6 @@ from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.internals.native_engine import Snapshot
 from pants.engine.process import Process, ProcessResult
@@ -37,32 +36,16 @@ class YapfRequest(FmtRequest):
     name = Yapf.options_scope
 
 
-@dataclass(frozen=True)
-class Setup:
-    process: Process
-    original_snapshot: Snapshot
-
-
 @rule(level=LogLevel.DEBUG)
-async def setup_yapf(request: YapfRequest, yapf: Yapf) -> Setup:
+async def setup_yapf_process(request: YapfRequest, yapf: Yapf) -> Process:
     yapf_pex_get = Get(VenvPex, PexRequest, yapf.to_pex_request())
-    source_files_get = Get(
-        SourceFiles,
-        SourceFilesRequest(field_set.source for field_set in request.field_sets),
+    config_files_get = Get(
+        ConfigFiles, ConfigFilesRequest, yapf.config_request(request.snapshot.dirs)
     )
-    source_files, yapf_pex = await MultiGet(source_files_get, yapf_pex_get)
+    config_files, yapf_pex = await MultiGet(config_files_get, yapf_pex_get)
 
-    source_files_snapshot = (
-        source_files.snapshot
-        if request.prior_formatter_result is None
-        else request.prior_formatter_result
-    )
-
-    config_files = await Get(
-        ConfigFiles, ConfigFilesRequest, yapf.config_request(source_files_snapshot.dirs)
-    )
     input_digest = await Get(
-        Digest, MergeDigests((source_files_snapshot.digest, config_files.snapshot.digest))
+        Digest, MergeDigests((request.snapshot.digest, config_files.snapshot.digest))
     )
 
     process = await Get(
@@ -73,31 +56,25 @@ async def setup_yapf(request: YapfRequest, yapf: Yapf) -> Setup:
                 *yapf.args,
                 "--in-place",
                 *(("--style", yapf.config) if yapf.config else ()),
-                *source_files_snapshot.files,
+                *request.snapshot.files,
             ),
             input_digest=input_digest,
-            output_files=source_files_snapshot.files,
+            output_files=request.snapshot.files,
             description=f"Run yapf on {pluralize(len(request.field_sets), 'file')}.",
             level=LogLevel.DEBUG,
         ),
     )
-    return Setup(process, original_snapshot=source_files_snapshot)
+    return process
 
 
 @rule(desc="Format with yapf", level=LogLevel.DEBUG)
 async def yapf_fmt(request: YapfRequest, yapf: Yapf) -> FmtResult:
     if yapf.skip:
         return FmtResult.skip(formatter_name=request.name)
-    setup = await Get(Setup, YapfRequest, request)
-    result = await Get(ProcessResult, Process, setup.process)
+    process = await Get(Process, YapfRequest, request)
+    result = await Get(ProcessResult, Process, process)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult(
-        setup.original_snapshot,
-        output_snapshot,
-        stdout=result.stdout.decode(),
-        stderr=result.stderr.decode(),
-        formatter_name=request.name,
-    )
+    return FmtResult.create(request, result, output_snapshot)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/yapf/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/yapf/rules_integration_test.py
@@ -69,7 +69,7 @@ def run_yapf(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            YapfRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            YapfRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/scala/lint/scalafmt/rules_integration_test.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules_integration_test.py
@@ -112,7 +112,7 @@ def run_scalafmt(rule_runner: RuleRunner, targets: list[Target]) -> FmtResult:
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            ScalafmtRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            ScalafmtRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/shell/lint/shfmt/rules.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules.py
@@ -9,7 +9,6 @@ from pants.backend.shell.target_types import ShellSourceField
 from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.internals.native_engine import Snapshot
 from pants.engine.platform import Platform
@@ -37,37 +36,21 @@ class ShfmtRequest(FmtRequest):
     name = Shfmt.options_scope
 
 
-@dataclass(frozen=True)
-class Setup:
-    process: Process
-    original_snapshot: Snapshot
-
 
 @rule(level=LogLevel.DEBUG)
-async def setup_shfmt(request: ShfmtRequest, shfmt: Shfmt) -> Setup:
+async def setup_shfmt(request: ShfmtRequest, shfmt: Shfmt) -> Process:
     download_shfmt_get = Get(
         DownloadedExternalTool, ExternalToolRequest, shfmt.get_request(Platform.current)
     )
-    source_files_get = Get(
-        SourceFiles,
-        SourceFilesRequest(field_set.sources for field_set in request.field_sets),
+    config_files_get = Get(
+        ConfigFiles, ConfigFilesRequest, shfmt.config_request(request.snapshot.dirs)
     )
-    downloaded_shfmt, source_files = await MultiGet(download_shfmt_get, source_files_get)
-
-    source_files_snapshot = (
-        source_files.snapshot
-        if request.prior_formatter_result is None
-        else request.prior_formatter_result
-    )
-
-    config_files = await Get(
-        ConfigFiles, ConfigFilesRequest, shfmt.config_request(source_files_snapshot.dirs)
-    )
+    downloaded_shfmt, config_files = await MultiGet(download_shfmt_get, config_files_get)
 
     input_digest = await Get(
         Digest,
         MergeDigests(
-            (source_files_snapshot.digest, downloaded_shfmt.digest, config_files.snapshot.digest)
+            (request.snapshot.digest, downloaded_shfmt.digest, config_files.snapshot.digest)
         ),
     )
 
@@ -76,32 +59,26 @@ async def setup_shfmt(request: ShfmtRequest, shfmt: Shfmt) -> Setup:
         "-l",
         "-w",
         *shfmt.args,
-        *source_files_snapshot.files,
+        *request.snapshot.files,
     ]
     process = Process(
         argv=argv,
         input_digest=input_digest,
-        output_files=source_files_snapshot.files,
+        output_files=request.snapshot.files,
         description=f"Run shfmt on {pluralize(len(request.field_sets), 'file')}.",
         level=LogLevel.DEBUG,
     )
-    return Setup(process, original_snapshot=source_files_snapshot)
+    return process
 
 
 @rule(desc="Format with shfmt", level=LogLevel.DEBUG)
 async def shfmt_fmt(request: ShfmtRequest, shfmt: Shfmt) -> FmtResult:
     if shfmt.skip:
         return FmtResult.skip(formatter_name=request.name)
-    setup = await Get(Setup, ShfmtRequest, request)
-    result = await Get(ProcessResult, Process, setup.process)
+    process = await Get(Process, ShfmtRequest, request)
+    result = await Get(ProcessResult, Process, process)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult(
-        setup.original_snapshot,
-        output_snapshot,
-        stdout=result.stdout.decode(),
-        stderr=result.stderr.decode(),
-        formatter_name=request.name,
-    )
+    return FmtResult.create(request, result, output_snapshot)
 
 
 def rules():

--- a/src/python/pants/backend/shell/lint/shfmt/rules_integration_test.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules_integration_test.py
@@ -87,7 +87,7 @@ def run_shfmt(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            ShfmtRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            ShfmtRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
@@ -67,7 +67,7 @@ async def tffmt_fmt(request: TffmtRequest, tffmt: TfFmtSubsystem) -> FmtResult:
     output_snapshot = await Get(Snapshot, Digest, output_digest)
 
     fmt_result = FmtResult(
-        input=setup.original_snapshot,
+        input=request.snapshot,
         output=output_snapshot,
         stdout=stdout_content,
         stderr=stderr_content,

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt_integration_test.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt_integration_test.py
@@ -112,7 +112,7 @@ def run_tffmt(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            TffmtRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            TffmtRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/core/goals/style_request.py
+++ b/src/python/pants/core/goals/style_request.py
@@ -14,7 +14,7 @@ from typing_extensions import Protocol
 from pants.core.util_rules.distdir import DistDir
 from pants.engine.collection import Collection
 from pants.engine.engine_aware import EngineAwareParameter
-from pants.engine.fs import EMPTY_DIGEST, Digest, Snapshot, Workspace
+from pants.engine.fs import EMPTY_DIGEST, Digest, Workspace
 from pants.engine.target import FieldSet
 from pants.util.meta import frozen_after_init
 from pants.util.strutil import path_safe
@@ -95,17 +95,12 @@ class StyleRequest(Generic[_FS], EngineAwareParameter, metaclass=ABCMeta):
     name: ClassVar[str]
 
     field_sets: Collection[_FS]
-    # TODO: Move this onto `FmtRequest`.
-    prior_formatter_result: Snapshot | None = None
 
     def __init__(
         self,
         field_sets: Iterable[_FS],
-        *,
-        prior_formatter_result: Snapshot | None = None,
     ) -> None:
         self.field_sets = Collection[_FS](field_sets)
-        self.prior_formatter_result = prior_formatter_result
 
     def debug_hint(self) -> str:
         return self.name


### PR DESCRIPTION
The crux of this PR is removing the `prior_formatting_result` from `StyleRequest` and into `FmtRequest` (and rename it to `snapshot`).

This is done by refactoring `lint` to provide the snapshot to the `FmtRequest`s it creates.

Then comes the retrofits where we no longer need to request the source files.

But then also we don't need the `original_digest` because we can count on it being `request.snapshot`. So more retrofits.


[ci skip-rust]