### PR TITLE
Upgrade to Pex 2.1.75 for VCS lock support and deadlock fix (Cherry-pick of #14970)

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -14,7 +14,7 @@ humbug==0.2.7
 
 ijson==3.1.4
 packaging==21.3
-pex==2.1.73
+pex==2.1.75
 psutil==5.9.0
 pytest>=6.2.4,<8  # This should be compatible with pytest.py, although it can be looser so that we don't over-constrain pantsbuild.pants.testutil
 python-lsp-jsonrpc==1.0.0

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -18,7 +18,7 @@
 //     "ijson==3.1.4",
 //     "mypy-typing-asserts==0.1.1",
 //     "packaging==21.3",
-//     "pex==2.1.73",
+//     "pex==2.1.75",
 //     "psutil==5.9.0",
 //     "pydevd-pycharm==203.5419.8",
 //     "pytest<8,>=6.2.4",
@@ -548,13 +548,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "b6610d4f25fbf49f93997f2a889959f064ede535529e1355748b4a116e3b0352",
-              "url": "https://files.pythonhosted.org/packages/df/cb/6f7720c4769486f7e37cbaa457e179944432e62936a25a4b106dbc2a5827/pex-2.1.73-py2.py3-none-any.whl"
+              "hash": "71a7f9b2466801090c6c05da1c7172562aa23b71df564fcae382de98433c0651",
+              "url": "https://files.pythonhosted.org/packages/fb/93/68786dc561fce8dccb5bd38b3f40b3f4bc1888ccba97d91f49e311588f21/pex-2.1.75-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3b1226d2f147d0969d68a306aca34d8fc980eee7b591ace3a5ab922ba5cd1a25",
-              "url": "https://files.pythonhosted.org/packages/25/60/6aeba685a9724d57dd224116bba34854621e1f46267857830b62e9647eff/pex-2.1.73.tar.gz"
+              "hash": "1b9244e3f656658a3c169cb766121a58dcc67c49166fda80f6f2f75154ea7f44",
+              "url": "https://files.pythonhosted.org/packages/54/38/03ad7608b066898b7cb7e1066019363e6f348e10c36aa57674298def18f8/pex-2.1.75.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -562,7 +562,7 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.11,>=2.7",
-          "version": "2.1.73"
+          "version": "2.1.75"
         },
         {
           "artifacts": [
@@ -1538,13 +1538,13 @@
         }
       ],
       "platform_tag": [
-        "cp310",
-        "cp310",
-        "manylinux_2_35_x86_64"
+        "cp39",
+        "cp39",
+        "macosx_11_0_arm64"
       ]
     }
   ],
-  "pex_version": "2.1.73",
+  "pex_version": "2.1.75",
   "prefer_older_binary": false,
   "requirements": [
     "PyYAML<7.0,>=6.0",
@@ -1556,7 +1556,7 @@
     "ijson==3.1.4",
     "mypy-typing-asserts==0.1.1",
     "packaging==21.3",
-    "pex==2.1.73",
+    "pex==2.1.75",
     "psutil==5.9.0",
     "pydevd-pycharm==203.5419.8",
     "pytest<8,>=6.2.4",

--- a/src/python/pants/backend/python/subsystems/lambdex.lock
+++ b/src/python/pants/backend/python/subsystems/lambdex.lock
@@ -49,13 +49,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "b6610d4f25fbf49f93997f2a889959f064ede535529e1355748b4a116e3b0352",
-              "url": "https://files.pythonhosted.org/packages/df/cb/6f7720c4769486f7e37cbaa457e179944432e62936a25a4b106dbc2a5827/pex-2.1.73-py2.py3-none-any.whl"
+              "hash": "71a7f9b2466801090c6c05da1c7172562aa23b71df564fcae382de98433c0651",
+              "url": "https://files.pythonhosted.org/packages/fb/93/68786dc561fce8dccb5bd38b3f40b3f4bc1888ccba97d91f49e311588f21/pex-2.1.75-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3b1226d2f147d0969d68a306aca34d8fc980eee7b591ace3a5ab922ba5cd1a25",
-              "url": "https://files.pythonhosted.org/packages/25/60/6aeba685a9724d57dd224116bba34854621e1f46267857830b62e9647eff/pex-2.1.73.tar.gz"
+              "hash": "1b9244e3f656658a3c169cb766121a58dcc67c49166fda80f6f2f75154ea7f44",
+              "url": "https://files.pythonhosted.org/packages/54/38/03ad7608b066898b7cb7e1066019363e6f348e10c36aa57674298def18f8/pex-2.1.75.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -63,17 +63,17 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.11,>=2.7",
-          "version": "2.1.73"
+          "version": "2.1.75"
         }
       ],
       "platform_tag": [
-        "cp310",
-        "cp310",
-        "manylinux_2_35_x86_64"
+        "cp39",
+        "cp39",
+        "macosx_11_0_arm64"
       ]
     }
   ],
-  "pex_version": "2.1.73",
+  "pex_version": "2.1.75",
   "prefer_older_binary": false,
   "requirements": [
     "lambdex==0.1.6"

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -39,7 +39,7 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."
 
-    default_version = "v2.1.73"
+    default_version = "v2.1.75"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
     version_constraints = ">=2.1.73,<3.0"
 
@@ -50,8 +50,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "0f30b06c02743393b745497580a410d28055b0de022a27cbb8e460845a6ba1c9",
-                    "3723175",
+                    "59804a5115fde3ed0c893e16205fa25d4c02928047aa0c59126a5c4d434ae288",
+                    "3730767",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64"]


### PR DESCRIPTION
# Rust tests and lints will be skipped. Delete if not intended.
[ci skip-rust]

# Building wheels and fs_util will be skipped. Delete if not intended.
[ci skip-build-wheels]