### PR TITLE
WIP: [internal] Move `prior_formatter_result` to `FmtRequest` (+refactors) 

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
@@ -94,13 +94,7 @@ async def run_buf_format(request: BufFormatRequest, buf: BufSubsystem) -> FmtRes
     process = await Get(Process, BufFormatRequest, request)
     result = await Get(ProcessResult, Process, process)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult(
-        request.snapshot,
-        output_snapshot,
-        stdout=result.stdout.decode(),
-        stderr=result.stderr.decode(),
-        formatter_name=request.name,
-    )
+    return FmtResult.create(request, result, output_snapshot)
 
 
 def rules():

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
@@ -10,7 +10,6 @@ from pants.backend.codegen.protobuf.target_types import (
 )
 from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.core.util_rules.system_binaries import (
     BinaryShims,
     BinaryShimsRequest,
@@ -66,23 +65,11 @@ async def setup_buf_format(request: BufFormatRequest, buf: BufSubsystem) -> Setu
             output_directory=".bin",
         ),
     )
-    source_files_get = Get(
-        SourceFiles,
-        SourceFilesRequest(field_set.sources for field_set in request.field_sets),
-    )
-    downloaded_buf, binary_shims, source_files = await MultiGet(
-        download_buf_get, binary_shims_get, source_files_get
-    )
-
-    source_files_snapshot = (
-        source_files.snapshot
-        if request.prior_formatter_result is None
-        else request.prior_formatter_result
-    )
+    downloaded_buf, binary_shims = await MultiGet(download_buf_get, binary_shims_get)
 
     input_digest = await Get(
         Digest,
-        MergeDigests((source_files_snapshot.digest, downloaded_buf.digest, binary_shims.digest)),
+        MergeDigests((request.snapshot.digest, downloaded_buf.digest, binary_shims.digest)),
     )
 
     argv = [
@@ -91,19 +78,19 @@ async def setup_buf_format(request: BufFormatRequest, buf: BufSubsystem) -> Setu
         "-w",
         *buf.format_args,
         "--path",
-        ",".join(source_files_snapshot.files),
+        ",".join(request.snapshot.files),
     ]
     process = Process(
         argv=argv,
         input_digest=input_digest,
-        output_files=source_files_snapshot.files,
+        output_files=request.snapshot.files,
         description=f"Run buf format on {pluralize(len(request.field_sets), 'file')}.",
         level=LogLevel.DEBUG,
         env={
             "PATH": binary_shims.bin_directory,
         },
     )
-    return Setup(process, original_snapshot=source_files_snapshot)
+    return Setup(process, original_snapshot=request.snapshot)
 
 
 @rule(desc="Format with buf format", level=LogLevel.DEBUG)

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules_integration_test.py
@@ -62,7 +62,7 @@ def run_buf(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            BufFormatRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            BufFormatRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
 

--- a/src/python/pants/backend/go/lint/gofmt/rules.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules.py
@@ -12,7 +12,6 @@ from pants.backend.go.subsystems import golang
 from pants.backend.go.subsystems.golang import GoRoot
 from pants.backend.go.target_types import GoPackageSourcesField
 from pants.core.goals.fmt import FmtRequest, FmtResult
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest
 from pants.engine.internals.native_engine import Snapshot
 from pants.engine.internals.selectors import Get
@@ -48,29 +47,19 @@ class Setup:
 
 @rule(level=LogLevel.DEBUG)
 async def setup_gofmt(request: GofmtRequest, goroot: GoRoot) -> Setup:
-    source_files = await Get(
-        SourceFiles,
-        SourceFilesRequest(field_set.sources for field_set in request.field_sets),
-    )
-    source_files_snapshot = (
-        source_files.snapshot
-        if request.prior_formatter_result is None
-        else request.prior_formatter_result
-    )
-
     argv = (
         os.path.join(goroot.path, "bin/gofmt"),
         "-w",
-        *source_files_snapshot.files,
+        *request.snapshot.files,
     )
     process = Process(
         argv=argv,
-        input_digest=source_files_snapshot.digest,
-        output_files=source_files_snapshot.files,
-        description=f"Run gofmt on {pluralize(len(source_files_snapshot.files), 'file')}.",
+        input_digest=request.snapshot.digest,
+        output_files=request.snapshot.files,
+        description=f"Run gofmt on {pluralize(len(request.snapshot.files), 'file')}.",
         level=LogLevel.DEBUG,
     )
-    return Setup(process=process, original_snapshot=source_files_snapshot)
+    return Setup(process=process, original_snapshot=request.snapshot)
 
 
 @rule(desc="Format with gofmt")

--- a/src/python/pants/backend/go/lint/gofmt/rules.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules.py
@@ -63,13 +63,7 @@ async def gofmt_fmt(request: GofmtRequest, gofmt: GofmtSubsystem) -> FmtResult:
     process = await Get(Process, GofmtRequest, request)
     result = await Get(ProcessResult, Process, process)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult(
-        request.snapshot,
-        output_snapshot,
-        stdout=result.stdout.decode(),
-        stderr=result.stderr.decode(),
-        formatter_name=request.name,
-    )
+    return FmtResult.create(request, result, output_snapshot)
 
 
 def rules():

--- a/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
@@ -120,7 +120,7 @@ def run_gofmt(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            GofmtRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            GofmtRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/java/lint/google_java_format/rules.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules.py
@@ -109,13 +109,7 @@ async def google_java_format_fmt(
     setup = await Get(Setup, GoogleJavaFormatRequest, request)
     result = await Get(ProcessResult, JvmProcess, setup.process)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult(
-        request.snapshot,
-        output_snapshot,
-        stdout=strip_v2_chroot_path(result.stdout),
-        stderr=strip_v2_chroot_path(result.stderr),
-        formatter_name=request.name,
-    )
+    return FmtResult.create(request, result, output_snapshot, strip_chroot_path=True)
 
 
 @rule

--- a/src/python/pants/backend/java/lint/google_java_format/rules.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules.py
@@ -48,7 +48,6 @@ class GoogleJavaFormatToolLockfileSentinel(GenerateToolLockfileSentinel):
 @dataclass(frozen=True)
 class Setup:
     process: JvmProcess
-    original_snapshot: Snapshot
 
 
 @rule(level=LogLevel.DEBUG)
@@ -98,7 +97,7 @@ async def setup_google_java_format(
         level=LogLevel.DEBUG,
     )
 
-    return Setup(process, original_snapshot=request.snapshot)
+    return Setup(process)
 
 
 @rule(desc="Format with Google Java Format", level=LogLevel.DEBUG)
@@ -111,7 +110,7 @@ async def google_java_format_fmt(
     result = await Get(ProcessResult, JvmProcess, setup.process)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
     return FmtResult(
-        setup.original_snapshot,
+        request.snapshot,
         output_snapshot,
         stdout=strip_v2_chroot_path(result.stdout),
         stderr=strip_v2_chroot_path(result.stderr),

--- a/src/python/pants/backend/java/lint/google_java_format/rules.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules.py
@@ -20,7 +20,7 @@ from pants.jvm.resolve import jvm_tool
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
 from pants.util.logging import LogLevel
-from pants.util.strutil import pluralize, strip_v2_chroot_path
+from pants.util.strutil import pluralize
 
 logger = logging.getLogger(__name__)
 

--- a/src/python/pants/backend/java/lint/google_java_format/rules_integration_test.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules_integration_test.py
@@ -92,7 +92,7 @@ def run_google_java_format(rule_runner: RuleRunner, targets: list[Target]) -> Fm
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            GoogleJavaFormatRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            GoogleJavaFormatRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/python/lint/autoflake/rules.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules.py
@@ -66,13 +66,7 @@ async def autoflake_fmt(request: AutoflakeRequest, autoflake: Autoflake) -> FmtR
     process = await Get(Process, AutoflakeRequest, request)
     result = await Get(ProcessResult, Process, process)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult(
-        request.snapshot,
-        output_snapshot,
-        stdout=strip_v2_chroot_path(result.stdout),
-        stderr=strip_v2_chroot_path(result.stderr),
-        formatter_name=request.name,
-    )
+    return FmtResult.create(request, result, output_snapshot, strip_chroot_path=True)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/autoflake/rules.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules.py
@@ -16,7 +16,7 @@ from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
-from pants.util.strutil import pluralize, strip_v2_chroot_path
+from pants.util.strutil import pluralize
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/lint/autoflake/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules_integration_test.py
@@ -63,7 +63,7 @@ def run_autoflake(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            AutoflakeRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            AutoflakeRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -12,7 +12,6 @@ from pants.backend.python.util_rules.interpreter_constraints import InterpreterC
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.internals.native_engine import Snapshot
 from pants.engine.internals.selectors import MultiGet
@@ -74,24 +73,14 @@ async def setup_black(request: BlackRequest, black: Black, python_setup: PythonS
         PexRequest,
         black.to_pex_request(interpreter_constraints=tool_interpreter_constraints),
     )
-
-    source_files_get = Get(
-        SourceFiles,
-        SourceFilesRequest(field_set.source for field_set in request.field_sets),
+    config_files_get = Get(
+        ConfigFiles, ConfigFilesRequest, black.config_request(request.snapshot.dirs)
     )
 
-    source_files, black_pex = await MultiGet(source_files_get, black_pex_get)
-    source_files_snapshot = (
-        source_files.snapshot
-        if request.prior_formatter_result is None
-        else request.prior_formatter_result
-    )
+    black_pex, config_files = await MultiGet(black_pex_get, config_files_get)
 
-    config_files = await Get(
-        ConfigFiles, ConfigFilesRequest, black.config_request(source_files_snapshot.dirs)
-    )
     input_digest = await Get(
-        Digest, MergeDigests((source_files_snapshot.digest, config_files.snapshot.digest))
+        Digest, MergeDigests((request.snapshot.digest, config_files.snapshot.digest))
     )
 
     process = await Get(
@@ -103,16 +92,16 @@ async def setup_black(request: BlackRequest, black: Black, python_setup: PythonS
                 "-W",
                 "{pants_concurrency}",
                 *black.args,
-                *source_files_snapshot.files,
+                *request.snapshot.files,
             ),
             input_digest=input_digest,
-            output_files=source_files_snapshot.files,
+            output_files=request.snapshot.files,
             concurrency_available=len(request.field_sets),
             description=f"Run Black on {pluralize(len(request.field_sets), 'file')}.",
             level=LogLevel.DEBUG,
         ),
     )
-    return Setup(process, original_snapshot=source_files_snapshot)
+    return Setup(process, original_snapshot=request.snapshot)
 
 
 @rule(desc="Format with Black", level=LogLevel.DEBUG)

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -105,13 +105,7 @@ async def black_fmt(request: BlackRequest, black: Black) -> FmtResult:
     process = await Get(Process, BlackRequest, request)
     result = await Get(ProcessResult, Process, process)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult(
-        request.snapshot,
-        output_snapshot,
-        stdout=strip_v2_chroot_path(result.stdout),
-        stderr=strip_v2_chroot_path(result.stderr),
-        formatter_name=request.name,
-    )
+    return FmtResult.create(request, result, output_snapshot, strip_chroot_path=True)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -20,7 +20,7 @@ from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
-from pants.util.strutil import pluralize, strip_v2_chroot_path
+from pants.util.strutil import pluralize
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -80,7 +80,7 @@ def run_black(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            BlackRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            BlackRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Tuple
 
 from pants.backend.python.lint.docformatter.skip_field import SkipDocformatterField
 from pants.backend.python.lint.docformatter.subsystem import Docformatter
@@ -10,7 +9,6 @@ from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtRequest, FmtResult
-from pants.core.util_rules.source_files import SourceFiles
 from pants.engine.fs import Digest
 from pants.engine.internals.native_engine import Snapshot
 from pants.engine.process import Process, ProcessResult

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -66,13 +66,7 @@ async def docformatter_fmt(request: DocformatterRequest, docformatter: Docformat
     process = await Get(Process, DocformatterRequest, request)
     result = await Get(ProcessResult, Process, process)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult(
-        request.snapshot,
-        output_snapshot,
-        stdout=result.stdout.decode(),
-        stderr=result.stderr.decode(),
-        formatter_name=request.name,
-    )
+    return FmtResult.create(request, result, output_snapshot, strip_chroot_path=True)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -59,7 +59,7 @@ def run_docformatter(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            DocformatterRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            DocformatterRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -19,7 +19,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
-from pants.util.strutil import pluralize, strip_v2_chroot_path
+from pants.util.strutil import pluralize
 
 
 @dataclass(frozen=True)
@@ -36,6 +36,7 @@ class IsortFieldSet(FieldSet):
 class IsortRequest(FmtRequest):
     field_set_type = IsortFieldSet
     name = Isort.options_scope
+
 
 def generate_argv(
     source_files: tuple[str, ...], isort: Isort, *, is_isort5: bool
@@ -103,6 +104,7 @@ async def isort_fmt(request: IsortRequest, isort: Isort) -> FmtResult:
     result = await Get(ProcessResult, Process, process)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
     return FmtResult.create(request, result, output_snapshot, strip_chroot_path=True)
+
 
 def rules():
     return [

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -102,14 +102,7 @@ async def isort_fmt(request: IsortRequest, isort: Isort) -> FmtResult:
     process = await Get(Process, IsortRequest, request)
     result = await Get(ProcessResult, Process, process)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult(
-        request.snapshot,
-        output_snapshot,
-        stdout=strip_v2_chroot_path(result.stdout),
-        stderr=strip_v2_chroot_path(result.stderr),
-        formatter_name=request.name,
-    )
-
+    return FmtResult.create(request, result, output_snapshot, strip_chroot_path=True)
 
 def rules():
     return [

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -67,7 +67,7 @@ def run_isort(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            IsortRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            IsortRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/python/lint/pyupgrade/rules.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/rules.py
@@ -36,7 +36,6 @@ class PyUpgradeRequest(FmtRequest):
     name = PyUpgrade.options_scope
 
 
-
 @rule(level=LogLevel.DEBUG)
 async def setup_pyupgrade_process(request: PyUpgradeRequest, pyupgrade: PyUpgrade) -> Process:
     pyupgrade_pex = await Get(VenvPex, PexRequest, pyupgrade.to_pex_request())
@@ -50,7 +49,7 @@ async def setup_pyupgrade_process(request: PyUpgradeRequest, pyupgrade: PyUpgrad
             output_files=request.snapshot.files,
             description=f"Run pyupgrade on {pluralize(len(request.field_sets), 'file')}.",
             level=LogLevel.DEBUG,
-        )
+        ),
     )
 
     return process

--- a/src/python/pants/backend/python/lint/pyupgrade/rules.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/rules.py
@@ -63,13 +63,7 @@ async def pyupgrade_fmt(request: PyUpgradeRequest, pyupgrade: PyUpgrade) -> FmtR
     process = await Get(Process, PyUpgradeRequest, request)
     result = await Get(FallibleProcessResult, Process, process)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult(
-        request.snapshot,
-        output_snapshot,
-        stdout=result.process_result.stdout.decode(),
-        stderr=result.process_result.stderr.decode(),
-        formatter_name=PyUpgradeRequest.name,
-    )
+    return FmtResult.create(request, result, output_snapshot)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/pyupgrade/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/rules_integration_test.py
@@ -73,7 +73,7 @@ def run_pyupgrade(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            PyUpgradeRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            PyUpgradeRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/python/lint/yapf/rules.py
+++ b/src/python/pants/backend/python/lint/yapf/rules.py
@@ -75,13 +75,7 @@ async def yapf_fmt(request: YapfRequest, yapf: Yapf) -> FmtResult:
     process = await Get(Process, YapfRequest, request)
     result = await Get(ProcessResult, Process, process)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult(
-        request.snapshot,
-        output_snapshot,
-        stdout=result.stdout.decode(),
-        stderr=result.stderr.decode(),
-        formatter_name=request.name,
-    )
+    return FmtResult.create(request, result, output_snapshot)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/yapf/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/yapf/rules_integration_test.py
@@ -69,7 +69,7 @@ def run_yapf(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            YapfRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            YapfRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -14,7 +14,6 @@ from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.goals.tailor import group_by_dir
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import (
     Digest,
     DigestSubset,
@@ -188,26 +187,13 @@ async def setup_scalafmt(
     toolcp_relpath = "__toolcp"
 
     lockfile_request = await Get(GenerateJvmLockfileFromTool, ScalafmtToolLockfileSentinel())
-    source_files, tool_classpath = await MultiGet(
-        Get(
-            SourceFiles,
-            SourceFilesRequest(field_set.source for field_set in request.field_sets),
-        ),
+    tool_classpath, config_files = await MultiGet(
         Get(ToolClasspath, ToolClasspathRequest(lockfile=lockfile_request)),
-    )
-
-    source_files_snapshot = (
-        source_files.snapshot
-        if request.prior_formatter_result is None
-        else request.prior_formatter_result
-    )
-
-    config_files = await Get(
-        ScalafmtConfigFiles, GatherScalafmtConfigFilesRequest(source_files_snapshot)
+        Get(ScalafmtConfigFiles, GatherScalafmtConfigFilesRequest(request.snapshot)),
     )
 
     merged_sources_digest = await Get(
-        Digest, MergeDigests([source_files_snapshot.digest, config_files.snapshot.digest])
+        Digest, MergeDigests([request.snapshot.digest, config_files.snapshot.digest])
     )
 
     extra_immutable_input_digests = {
@@ -216,7 +202,7 @@ async def setup_scalafmt(
 
     # Partition the work by which source files share the same config file (regardless of directory).
     source_files_by_config_file: dict[str, set[str]] = defaultdict(set)
-    for source_dir, files_in_source_dir in group_by_dir(source_files_snapshot.files).items():
+    for source_dir, files_in_source_dir in group_by_dir(request.snapshot.files).items():
         config_file = config_files.source_dir_to_config_file[source_dir]
         source_files_by_config_file[config_file].update(
             os.path.join(source_dir, name) for name in files_in_source_dir
@@ -236,7 +222,7 @@ async def setup_scalafmt(
         for config_file, files in source_files_by_config_file.items()
     )
 
-    return Setup(tuple(partitions), original_snapshot=source_files_snapshot)
+    return Setup(tuple(partitions), original_snapshot=request.snapshot)
 
 
 @rule(desc="Format with scalafmt", level=LogLevel.DEBUG)

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -67,7 +67,6 @@ class Partition:
 @dataclass(frozen=True)
 class Setup:
     partitions: tuple[Partition, ...]
-    original_snapshot: Snapshot
 
 
 @dataclass(frozen=True)
@@ -222,7 +221,7 @@ async def setup_scalafmt(
         for config_file, files in source_files_by_config_file.items()
     )
 
-    return Setup(tuple(partitions), original_snapshot=request.snapshot)
+    return Setup(tuple(partitions))
 
 
 @rule(desc="Format with scalafmt", level=LogLevel.DEBUG)
@@ -257,7 +256,7 @@ async def scalafmt_fmt(request: ScalafmtRequest, tool: ScalafmtSubsystem) -> Fmt
     output_snapshot = await Get(Snapshot, Digest, output_digest)
 
     fmt_result = FmtResult(
-        input=setup.original_snapshot,
+        input=request.snapshot,
         output=output_snapshot,
         stdout=stdout_content,
         stderr=stderr_content,

--- a/src/python/pants/backend/scala/lint/scalafmt/rules_integration_test.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules_integration_test.py
@@ -112,7 +112,7 @@ def run_scalafmt(rule_runner: RuleRunner, targets: list[Target]) -> FmtResult:
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            ScalafmtRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            ScalafmtRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/shell/lint/shfmt/rules.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules.py
@@ -77,13 +77,7 @@ async def shfmt_fmt(request: ShfmtRequest, shfmt: Shfmt) -> FmtResult:
     process = await Get(Process, ShfmtRequest, request)
     result = await Get(ProcessResult, Process, process)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult(
-        request.snapshot,
-        output_snapshot,
-        stdout=result.stdout.decode(),
-        stderr=result.stderr.decode(),
-        formatter_name=request.name,
-    )
+    return FmtResult.create(request, result, output_snapshot)
 
 
 def rules():

--- a/src/python/pants/backend/shell/lint/shfmt/rules.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules.py
@@ -9,7 +9,6 @@ from pants.backend.shell.target_types import ShellSourceField
 from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.internals.native_engine import Snapshot
 from pants.engine.platform import Platform
@@ -48,26 +47,15 @@ async def setup_shfmt(request: ShfmtRequest, shfmt: Shfmt) -> Setup:
     download_shfmt_get = Get(
         DownloadedExternalTool, ExternalToolRequest, shfmt.get_request(Platform.current)
     )
-    source_files_get = Get(
-        SourceFiles,
-        SourceFilesRequest(field_set.sources for field_set in request.field_sets),
+    config_files_get = Get(
+        ConfigFiles, ConfigFilesRequest, shfmt.config_request(request.snapshot.dirs)
     )
-    downloaded_shfmt, source_files = await MultiGet(download_shfmt_get, source_files_get)
-
-    source_files_snapshot = (
-        source_files.snapshot
-        if request.prior_formatter_result is None
-        else request.prior_formatter_result
-    )
-
-    config_files = await Get(
-        ConfigFiles, ConfigFilesRequest, shfmt.config_request(source_files_snapshot.dirs)
-    )
+    downloaded_shfmt, config_files = await MultiGet(download_shfmt_get, config_files_get)
 
     input_digest = await Get(
         Digest,
         MergeDigests(
-            (source_files_snapshot.digest, downloaded_shfmt.digest, config_files.snapshot.digest)
+            (request.snapshot.digest, downloaded_shfmt.digest, config_files.snapshot.digest)
         ),
     )
 
@@ -76,16 +64,16 @@ async def setup_shfmt(request: ShfmtRequest, shfmt: Shfmt) -> Setup:
         "-l",
         "-w",
         *shfmt.args,
-        *source_files_snapshot.files,
+        *request.snapshot.files,
     ]
     process = Process(
         argv=argv,
         input_digest=input_digest,
-        output_files=source_files_snapshot.files,
+        output_files=request.snapshot.files,
         description=f"Run shfmt on {pluralize(len(request.field_sets), 'file')}.",
         level=LogLevel.DEBUG,
     )
-    return Setup(process, original_snapshot=source_files_snapshot)
+    return Setup(process, original_snapshot=request.snapshot)
 
 
 @rule(desc="Format with shfmt", level=LogLevel.DEBUG)

--- a/src/python/pants/backend/shell/lint/shfmt/rules_integration_test.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules_integration_test.py
@@ -87,7 +87,7 @@ def run_shfmt(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            ShfmtRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            ShfmtRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
@@ -67,7 +67,7 @@ async def tffmt_fmt(request: TffmtRequest, tffmt: TfFmtSubsystem) -> FmtResult:
     output_snapshot = await Get(Snapshot, Digest, output_digest)
 
     fmt_result = FmtResult(
-        input=setup.original_snapshot,
+        input=request.snapshot,
         output=output_snapshot,
         stdout=stdout_content,
         stderr=stderr_content,

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt_integration_test.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt_integration_test.py
@@ -112,7 +112,7 @@ def run_tffmt(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            TffmtRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            TffmtRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/terraform/style.py
+++ b/src/python/pants/backend/terraform/style.py
@@ -13,7 +13,8 @@ from pants.backend.terraform.tool import TerraformProcess
 from pants.build_graph.address import Address
 from pants.core.goals.style_request import StyleRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.engine.fs import MergeDigests, Snapshot
+from pants.engine.fs import Snapshot
+from pants.engine.internals.native_engine import MergeDigests
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import collect_rules, rule
 from pants.util.logging import LogLevel
@@ -50,8 +51,8 @@ async def setup_terraform_style(setup_request: StyleSetupRequest) -> StyleSetup:
 
     source_files_snapshot = (
         await Get(Snapshot, MergeDigests(sfs.snapshot.digest for sfs in source_files_by_field_set))
-        if setup_request.request.prior_formatter_result is None
-        else setup_request.request.prior_formatter_result
+        if getattr(setup_request.request, "snapshot", None) is None
+        else getattr(setup_request.request, "snapshot")
     )
 
     # `terraform` operates on a directory-by-directory basis. First determine the directories in

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -16,7 +16,6 @@ from pants.core.goals.style_request import (
     style_batch_size_help,
 )
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.engine.collection import Collection
 from pants.engine.console import Console
 from pants.engine.engine_aware import EngineAwareReturnType
 from pants.engine.fs import Digest, MergeDigests, Snapshot, SnapshotDiff, Workspace
@@ -135,8 +134,8 @@ class FmtRequest(StyleRequest):
     snapshot: Snapshot
 
     def __init__(self, field_sets: Iterable[_FS], snapshot: Snapshot) -> None:
-        super().__init__(field_sets)
         self.snapshot = snapshot
+        super().__init__(field_sets)
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -135,7 +135,7 @@ class FmtRequest(StyleRequest):
     snapshot: Snapshot
 
     def __init__(self, field_sets: Iterable[_FS], snapshot: Snapshot) -> None:
-        self.field_sets = Collection[_FS](field_sets)
+        super().__init__(field_sets)
         self.snapshot = snapshot
 
 

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -37,6 +37,7 @@ logger = logging.getLogger(__name__)
 
 _SR = TypeVar("_SR", bound=StyleRequest)
 
+
 class AmbiguousRequestNamesError(Exception):
     def __init__(
         self,
@@ -227,7 +228,9 @@ async def lint(
         "Iterable[type[LintTargetsRequest]]", union_membership.get(LintTargetsRequest)
     )
     fmt_target_request_types = cast("Iterable[type[FmtRequest]]", union_membership.get(FmtRequest))
-    file_request_types = cast("Iterable[type[LintFilesRequest]]", union_membership[LintFilesRequest])
+    file_request_types = cast(
+        "Iterable[type[LintFilesRequest]]", union_membership[LintFilesRequest]
+    )
 
     _check_ambiguous_request_names(
         *lint_target_request_types, *fmt_target_request_types, *file_request_types

--- a/src/python/pants/core/goals/style_request.py
+++ b/src/python/pants/core/goals/style_request.py
@@ -14,7 +14,7 @@ from typing_extensions import Protocol
 from pants.core.util_rules.distdir import DistDir
 from pants.engine.collection import Collection
 from pants.engine.engine_aware import EngineAwareParameter
-from pants.engine.fs import EMPTY_DIGEST, Digest, Snapshot, Workspace
+from pants.engine.fs import EMPTY_DIGEST, Digest, Workspace
 from pants.engine.target import FieldSet
 from pants.util.meta import frozen_after_init
 from pants.util.strutil import path_safe
@@ -95,17 +95,12 @@ class StyleRequest(Generic[_FS], EngineAwareParameter, metaclass=ABCMeta):
     name: ClassVar[str]
 
     field_sets: Collection[_FS]
-    # TODO: Move this onto `FmtRequest`.
-    prior_formatter_result: Snapshot | None = None
 
     def __init__(
         self,
         field_sets: Iterable[_FS],
-        *,
-        prior_formatter_result: Snapshot | None = None,
     ) -> None:
         self.field_sets = Collection[_FS](field_sets)
-        self.prior_formatter_result = prior_formatter_result
 
     def debug_hint(self) -> str:
         return self.name


### PR DESCRIPTION
The crux of this PR is removing the `prior_formatting_result` from `StyleRequest` and into `FmtRequest` (and rename it to `snapshot`).

This is done by refactoring `lint` to provide the snapshot to the `FmtRequest`s it creates.

Then comes the retrofits where we no longer need to request the source files.

But then also we don't need the `original_digest` because we can count on it being `request.snapshot`. So more retrofits.


[ci skip-rust]