### PR TITLE
add go protobuf backend to init/BUILD (Cherry pick of #14979)

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/go/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/go/rules.py
@@ -14,8 +14,19 @@ from pants.backend.codegen.protobuf.target_types import (
     ProtobufGrpcToggleField,
     ProtobufSourceField,
 )
+from pants.backend.go import target_type_rules
 from pants.backend.go.target_type_rules import ImportPathToPackages
 from pants.backend.go.target_types import GoPackageSourcesField
+from pants.backend.go.util_rules import (
+    assembly,
+    build_pkg,
+    build_pkg_target,
+    first_party_pkg,
+    go_mod,
+    link,
+    sdk,
+    third_party_pkg,
+)
 from pants.backend.go.util_rules.build_pkg import (
     BuildGoPackageRequest,
     FallibleBuildGoPackageRequest,
@@ -30,6 +41,7 @@ from pants.backend.go.util_rules.first_party_pkg import (
 )
 from pants.backend.go.util_rules.pkg_analyzer import PackageAnalyzerSetup
 from pants.backend.go.util_rules.sdk import GoSdkProcess
+from pants.backend.python.util_rules import pex
 from pants.build_graph.address import Address
 from pants.core.goals.tailor import group_by_dir
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
@@ -604,4 +616,15 @@ def rules():
         UnionRule(GenerateSourcesRequest, GenerateGoFromProtobufRequest),
         UnionRule(GoCodegenBuildRequest, GoCodegenBuildProtobufRequest),
         UnionRule(InferDependenciesRequest, InferGoProtobufDependenciesRequest),
+        # Rules needed for this to pass src/python/pants/init/load_backends_integration_test.py:
+        *assembly.rules(),
+        *build_pkg.rules(),
+        *build_pkg_target.rules(),
+        *first_party_pkg.rules(),
+        *go_mod.rules(),
+        *link.rules(),
+        *sdk.rules(),
+        *target_type_rules.rules(),
+        *third_party_pkg.rules(),
+        *pex.rules(),
     )

--- a/src/python/pants/init/BUILD
+++ b/src/python/pants/init/BUILD
@@ -14,6 +14,7 @@ target(
         "src/python/pants/backend/docker",
         "src/python/pants/backend/docker/lint/hadolint",
         "src/python/pants/backend/experimental/codegen/avro/java",
+        "src/python/pants/backend/experimental/codegen/protobuf/go",
         "src/python/pants/backend/experimental/codegen/protobuf/java",
         "src/python/pants/backend/experimental/codegen/protobuf/scala",
         "src/python/pants/backend/experimental/codegen/thrift/apache/java",


### PR DESCRIPTION
I forgot to add the Go Protobuf. backend into the `init/BUILD` so it did not make it into the distribution.

[ci skip-rust]