### PR TITLE
[internal] Pass `prior_formatter_result` in `lint`to `FmtRequest`

### DIFF
--- a/src/python/pants/backend/terraform/style.py
+++ b/src/python/pants/backend/terraform/style.py
@@ -8,10 +8,10 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Iterable
 
-from pants.backend.terraform.target_types import TerraformFieldSet
 from pants.backend.terraform.tool import TerraformProcess
 from pants.build_graph.address import Address
-from pants.core.goals.style_request import StyleRequest
+from pants.core.goals.check import CheckRequest
+from pants.core.goals.fmt import FmtRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import MergeDigests, Snapshot
 from pants.engine.internals.selectors import Get, MultiGet
@@ -24,10 +24,10 @@ from pants.util.strutil import pluralize
 @frozen_after_init
 @dataclass(unsafe_hash=True)
 class StyleSetupRequest:
-    request: StyleRequest[TerraformFieldSet]
+    request: FmtRequest | CheckRequest
     args: tuple[str, ...]
 
-    def __init__(self, request: StyleRequest[TerraformFieldSet], args: Iterable[str]):
+    def __init__(self, request: FmtRequest | CheckRequest, args: Iterable[str]):
         self.request = request
         self.args = tuple(args)
 
@@ -48,11 +48,14 @@ async def setup_terraform_style(setup_request: StyleSetupRequest) -> StyleSetup:
         for field_set in setup_request.request.field_sets
     )
 
-    source_files_snapshot = getattr(setup_request.request, "prior_formatter_result", None)
-    if source_files_snapshot is None:
-        source_files_snapshot = await Get(
+    source_files_snapshot = (
+        setup_request.request.prior_formatter_result
+        if isinstance(setup_request.request, FmtRequest)
+        else await Get(
             Snapshot, MergeDigests(sfs.snapshot.digest for sfs in source_files_by_field_set)
         )
+    )
+    assert source_files_snapshot is not None
 
     # `terraform` operates on a directory-by-directory basis. First determine the directories in
     # the snapshot. This does not use `source_files_snapshot.dirs` because that will be empty if the files

--- a/src/python/pants/backend/terraform/style.py
+++ b/src/python/pants/backend/terraform/style.py
@@ -48,11 +48,11 @@ async def setup_terraform_style(setup_request: StyleSetupRequest) -> StyleSetup:
         for field_set in setup_request.request.field_sets
     )
 
-    source_files_snapshot = (
-        await Get(Snapshot, MergeDigests(sfs.snapshot.digest for sfs in source_files_by_field_set))
-        if setup_request.request.prior_formatter_result is None
-        else setup_request.request.prior_formatter_result
-    )
+    source_files_snapshot = getattr(setup_request.request, "prior_formatter_result", None)
+    if source_files_snapshot is None:
+        source_files_snapshot = await Get(
+            Snapshot, MergeDigests(sfs.snapshot.digest for sfs in source_files_by_field_set)
+        )
 
     # `terraform` operates on a directory-by-directory basis. First determine the directories in
     # the snapshot. This does not use `source_files_snapshot.dirs` because that will be empty if the files

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -108,7 +108,7 @@ class FmtResult(EngineAwareReturnType):
 @union
 @frozen_after_init
 @dataclass(unsafe_hash=True)
-class FmtRequest(StyleRequest):
+class FmtRequest(StyleRequest[_FS]):
     prior_formatter_result: Snapshot | None
 
     def __init__(self, field_sets: Iterable[_FS], prior_formatter_result: Snapshot) -> None:

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -109,6 +109,7 @@ class FmtResult(EngineAwareReturnType):
 @frozen_after_init
 @dataclass(unsafe_hash=True)
 class FmtRequest(StyleRequest[_FS]):
+    # TODO NB: The name and type are historical and should likely be changed
     prior_formatter_result: Snapshot | None
 
     def __init__(self, field_sets: Iterable[_FS], prior_formatter_result: Snapshot) -> None:

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -111,7 +111,7 @@ class FmtResult(EngineAwareReturnType):
 class FmtRequest(StyleRequest):
     prior_formatter_result: Snapshot | None
 
-    def __init__(self, field_sets: Iterable[_FS], prior_formatter_result: Snapshot | None) -> None:
+    def __init__(self, field_sets: Iterable[_FS], prior_formatter_result: Snapshot) -> None:
         self.prior_formatter_result = prior_formatter_result
         super().__init__(field_sets)
 

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -7,7 +7,7 @@ import itertools
 import logging
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import TypeVar
+from typing import Iterable, TypeVar
 
 from pants.core.goals.style_request import (
     StyleRequest,
@@ -22,13 +22,15 @@ from pants.engine.fs import Digest, MergeDigests, Snapshot, SnapshotDiff, Worksp
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.internals.native_engine import EMPTY_SNAPSHOT
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
-from pants.engine.target import SourcesField, Targets
+from pants.engine.target import FieldSet, SourcesField, Targets
 from pants.engine.unions import UnionMembership, union
 from pants.option.option_types import IntOption, StrListOption
 from pants.util.collections import partition_sequentially
 from pants.util.logging import LogLevel
+from pants.util.meta import frozen_after_init
 
 _F = TypeVar("_F", bound="FmtResult")
+_FS = TypeVar("_FS", bound=FieldSet)
 
 logger = logging.getLogger(__name__)
 
@@ -104,8 +106,14 @@ class FmtResult(EngineAwareReturnType):
 
 
 @union
+@frozen_after_init
+@dataclass(unsafe_hash=True)
 class FmtRequest(StyleRequest):
-    pass
+    prior_formatter_result: Snapshot | None
+
+    def __init__(self, field_sets: Iterable[_FS], prior_formatter_result: Snapshot | None) -> None:
+        self.prior_formatter_result = prior_formatter_result
+        super().__init__(field_sets)
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -261,8 +261,7 @@ async def lint(
             size_max=4 * lint_subsystem.batch_size,
         )
         for partition in partitions:
-            if partition:
-                yield partition
+            yield partition
 
     def batch_by_type(
         request_types: Iterable[type[_SR]],

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import itertools
 import logging
 from dataclasses import dataclass
-from typing import Any, ClassVar, Iterable, Iterator, Type, cast
+from typing import Any, ClassVar, Iterable, Iterator, Type, TypeVar, cast
 
 from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.core.goals.style_request import (
@@ -17,6 +17,7 @@ from pants.core.goals.style_request import (
     write_reports,
 )
 from pants.core.util_rules.distdir import DistDir
+from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.console import Console
 from pants.engine.engine_aware import EngineAwareParameter, EngineAwareReturnType
 from pants.engine.fs import EMPTY_DIGEST, Digest, SpecsSnapshot, Workspace
@@ -33,6 +34,8 @@ from pants.util.meta import frozen_after_init
 from pants.util.strutil import strip_v2_chroot_path
 
 logger = logging.getLogger(__name__)
+
+_SR = TypeVar("_SR", bound=StyleRequest)
 
 
 class AmbiguousRequestNamesError(Exception):
@@ -225,61 +228,82 @@ async def lint(
         "Iterable[type[LintTargetsRequest]]", union_membership.get(LintTargetsRequest)
     )
     fmt_target_request_types = cast("Iterable[type[FmtRequest]]", union_membership.get(FmtRequest))
-    target_request_types = [
-        *lint_target_request_types,
-        *fmt_target_request_types,
-    ]
-    file_request_types = union_membership[LintFilesRequest]
+    file_request_types = cast(
+        "Iterable[type[LintFilesRequest]]", union_membership[LintFilesRequest]
+    )
 
-    _check_ambiguous_request_names(*target_request_types, *file_request_types)
+    _check_ambiguous_request_names(
+        *lint_target_request_types, *fmt_target_request_types, *file_request_types
+    )
 
     specified_names = determine_specified_tool_names(
         "lint",
         lint_subsystem.only,
-        target_request_types,
+        [
+            *lint_target_request_types,
+            *fmt_target_request_types,
+        ],
         extra_valid_names={request.name for request in file_request_types},
     )
-    target_requests = tuple(
-        request_type(
-            request_type.field_set_type.create(target)
-            for target in targets
-            if (
-                request_type.name in specified_names
-                and request_type.field_set_type.is_applicable(target)
-            )
-        )
-        for request_type in target_request_types
-    )
 
-    def address_str(fs: FieldSet) -> str:
-        return fs.address.spec
+    def is_specified(request_type: type[StyleRequest] | type[LintFilesRequest]):
+        return request_type.name in specified_names
+
+    lint_target_request_types = filter(is_specified, lint_target_request_types)
+    fmt_target_request_types = filter(is_specified, fmt_target_request_types)
+    file_request_types = filter(is_specified, file_request_types)
 
     def batch(field_sets: Iterable[FieldSet]) -> Iterator[list[FieldSet]]:
-        return partition_sequentially(
+        partitions = partition_sequentially(
             field_sets,
-            key=address_str,
+            key=lambda fs: fs.address.spec,
             size_target=lint_subsystem.batch_size,
             size_max=4 * lint_subsystem.batch_size,
         )
+        for partition in partitions:
+            if partition:
+                yield partition
+
+    def batch_by_type(
+        request_types: Iterable[type[_SR]],
+    ) -> tuple[tuple[type[_SR], list[FieldSet]], ...]:
+        return tuple(
+            (request_type, field_set_batch)
+            for request_type in request_types
+            for field_set_batch in batch(
+                request_type.field_set_type.create(target)
+                for target in targets
+                if request_type.field_set_type.is_applicable(target)
+            )
+        )
 
     lint_target_requests = (
-        request.__class__(field_set_batch)
-        for request in target_requests
-        if isinstance(request, LintTargetsRequest) and request.field_sets
-        for field_set_batch in batch(request.field_sets)
+        request_type(batch) for request_type, batch in batch_by_type(lint_target_request_types)
     )
+
+    batched_fmt_request_pairs = batch_by_type(fmt_target_request_types)
+    all_fmt_source_batches = await MultiGet(
+        Get(
+            SourceFiles,
+            SourceFilesRequest(
+                getattr(field_set, "sources", getattr(field_set, "source", None))
+                for field_set in batch
+            ),
+        )
+        for _, batch in batched_fmt_request_pairs
+    )
+
     fmt_requests = (
-        request.__class__(field_set_batch)
-        for request in target_requests
-        if isinstance(request, FmtRequest) and request.field_sets
-        for field_set_batch in batch(request.field_sets)
+        request_type(
+            batch,  # type: ignore # TODO: Why does mypy complain?
+            prior_formatter_result=source_files_snapshot.snapshot,
+        )
+        for (request_type, batch), source_files_snapshot in zip(
+            batched_fmt_request_pairs, all_fmt_source_batches
+        )
     )
     file_requests = (
-        tuple(
-            request_type(specs_snapshot.snapshot.files)
-            for request_type in file_request_types
-            if request_type.name in specified_names
-        )
+        tuple(request_type(specs_snapshot.snapshot.files) for request_type in file_request_types)
         if specs_snapshot.snapshot.files
         else ()
     )

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -295,7 +295,7 @@ async def lint(
 
     fmt_requests = (
         request_type(
-            batch,  # type: ignore # TODO: Why does mypy complain?
+            batch,
             prior_formatter_result=source_files_snapshot.snapshot,
         )
         for (request_type, batch), source_files_snapshot in zip(

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
+from dataclasses import dataclass
 from pathlib import Path
 from textwrap import dedent
 from typing import Iterable, Optional, Sequence, Tuple, Type
@@ -22,6 +23,7 @@ from pants.core.goals.lint import (
     lint,
 )
 from pants.core.util_rules.distdir import DistDir
+from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import SpecsSnapshot, Workspace
 from pants.engine.internals.native_engine import EMPTY_DIGEST, EMPTY_SNAPSHOT, Digest, Snapshot
@@ -37,8 +39,10 @@ class MockTarget(Target):
     core_fields = (MultipleSourcesField,)
 
 
+@dataclass(frozen=True)
 class MockLinterFieldSet(FieldSet):
     required_fields = (MultipleSourcesField,)
+    sources: MultipleSourcesField
 
 
 class MockLintRequest(LintTargetsRequest, metaclass=ABCMeta):
@@ -185,6 +189,11 @@ def run_lint_rule(
                 DistDir(relpath=Path("dist")),
             ],
             mock_gets=[
+                MockGet(
+                    output_type=SourceFiles,
+                    input_type=SourceFilesRequest,
+                    mock=lambda _: SourceFiles(EMPTY_SNAPSHOT, ()),
+                ),
                 MockGet(
                     output_type=LintResults,
                     input_type=LintTargetsRequest,

--- a/src/python/pants/core/goals/style_request.py
+++ b/src/python/pants/core/goals/style_request.py
@@ -14,7 +14,7 @@ from typing_extensions import Protocol
 from pants.core.util_rules.distdir import DistDir
 from pants.engine.collection import Collection
 from pants.engine.engine_aware import EngineAwareParameter
-from pants.engine.fs import EMPTY_DIGEST, Digest, Snapshot, Workspace
+from pants.engine.fs import EMPTY_DIGEST, Digest, Workspace
 from pants.engine.target import FieldSet
 from pants.util.meta import frozen_after_init
 from pants.util.strutil import path_safe
@@ -95,17 +95,12 @@ class StyleRequest(Generic[_FS], EngineAwareParameter, metaclass=ABCMeta):
     name: ClassVar[str]
 
     field_sets: Collection[_FS]
-    # TODO: Move this onto `FmtRequest`.
-    prior_formatter_result: Snapshot | None = None
 
     def __init__(
         self,
         field_sets: Iterable[_FS],
-        *,
-        prior_formatter_result: Snapshot | None = None,
     ) -> None:
         self.field_sets = Collection[_FS](field_sets)
-        self.prior_formatter_result = prior_formatter_result
 
     def debug_hint(self) -> str:
         return self.name


### PR DESCRIPTION
This is the first PR in a series of cleanups for the formatter plugin code now that https://github.com/pantsbuild/pants/pull/14903 is in. Now that `lint` knows which requests are for formatters and which aren't we can safely request the snapshot of the sources for `FmtRequest`s so it doesn't have the "lint or fmt" song-and-dance w.r.t. the input snapshot.

[ci skip-rust]
[ci skip-build-wheels]