### PR TITLE
Refactor `prior_formatter_result` and its usage 

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
@@ -91,8 +91,7 @@ async def setup_buf_format(request: BufFormatRequest, buf: BufSubsystem) -> Proc
 async def run_buf_format(request: BufFormatRequest, buf: BufSubsystem) -> FmtResult:
     if buf.skip_format:
         return FmtResult.skip(formatter_name=request.name)
-    process = await Get(Process, BufFormatRequest, request)
-    result = await Get(ProcessResult, Process, process)
+    result = await Get(ProcessResult, BufFormatRequest, request)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
     return FmtResult.create(request, result, output_snapshot)
 

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules_integration_test.py
@@ -62,7 +62,7 @@ def run_buf(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            BufFormatRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            BufFormatRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
 

--- a/src/python/pants/backend/go/lint/gofmt/rules.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules.py
@@ -60,8 +60,7 @@ async def setup_gofmt(request: GofmtRequest, goroot: GoRoot) -> Process:
 async def gofmt_fmt(request: GofmtRequest, gofmt: GofmtSubsystem) -> FmtResult:
     if gofmt.skip:
         return FmtResult.skip(formatter_name=request.name)
-    process = await Get(Process, GofmtRequest, request)
-    result = await Get(ProcessResult, Process, process)
+    result = await Get(ProcessResult, GofmtRequest, request)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
     return FmtResult.create(request, result, output_snapshot)
 

--- a/src/python/pants/backend/go/lint/gofmt/rules.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules.py
@@ -12,7 +12,6 @@ from pants.backend.go.subsystems import golang
 from pants.backend.go.subsystems.golang import GoRoot
 from pants.backend.go.target_types import GoPackageSourcesField
 from pants.core.goals.fmt import FmtRequest, FmtResult
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest
 from pants.engine.internals.native_engine import Snapshot
 from pants.engine.internals.selectors import Get
@@ -40,53 +39,31 @@ class GofmtRequest(FmtRequest):
     name = GofmtSubsystem.options_scope
 
 
-@dataclass(frozen=True)
-class Setup:
-    process: Process
-    original_snapshot: Snapshot
-
-
 @rule(level=LogLevel.DEBUG)
-async def setup_gofmt(request: GofmtRequest, goroot: GoRoot) -> Setup:
-    source_files = await Get(
-        SourceFiles,
-        SourceFilesRequest(field_set.sources for field_set in request.field_sets),
-    )
-    source_files_snapshot = (
-        source_files.snapshot
-        if request.prior_formatter_result is None
-        else request.prior_formatter_result
-    )
-
+async def setup_gofmt(request: GofmtRequest, goroot: GoRoot) -> Process:
     argv = (
         os.path.join(goroot.path, "bin/gofmt"),
         "-w",
-        *source_files_snapshot.files,
+        *request.snapshot.files,
     )
     process = Process(
         argv=argv,
-        input_digest=source_files_snapshot.digest,
-        output_files=source_files_snapshot.files,
-        description=f"Run gofmt on {pluralize(len(source_files_snapshot.files), 'file')}.",
+        input_digest=request.snapshot.digest,
+        output_files=request.snapshot.files,
+        description=f"Run gofmt on {pluralize(len(request.snapshot.files), 'file')}.",
         level=LogLevel.DEBUG,
     )
-    return Setup(process=process, original_snapshot=source_files_snapshot)
+    return process
 
 
 @rule(desc="Format with gofmt")
 async def gofmt_fmt(request: GofmtRequest, gofmt: GofmtSubsystem) -> FmtResult:
     if gofmt.skip:
         return FmtResult.skip(formatter_name=request.name)
-    setup = await Get(Setup, GofmtRequest, request)
-    result = await Get(ProcessResult, Process, setup.process)
+    process = await Get(Process, GofmtRequest, request)
+    result = await Get(ProcessResult, Process, process)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult(
-        setup.original_snapshot,
-        output_snapshot,
-        stdout=result.stdout.decode(),
-        stderr=result.stderr.decode(),
-        formatter_name=request.name,
-    )
+    return FmtResult.create(request, result, output_snapshot)
 
 
 def rules():

--- a/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
@@ -120,7 +120,7 @@ def run_gofmt(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            GofmtRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            GofmtRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/java/lint/google_java_format/rules.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules.py
@@ -8,10 +8,9 @@ from pants.backend.java.lint.google_java_format.subsystem import GoogleJavaForma
 from pants.backend.java.target_types import JavaSourceField
 from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest
 from pants.engine.internals.native_engine import Snapshot
-from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.internals.selectors import Get
 from pants.engine.process import ProcessResult
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import FieldSet, Target
@@ -21,7 +20,7 @@ from pants.jvm.resolve import jvm_tool
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
 from pants.util.logging import LogLevel
-from pants.util.strutil import pluralize, strip_v2_chroot_path
+from pants.util.strutil import pluralize
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +48,6 @@ class GoogleJavaFormatToolLockfileSentinel(GenerateToolLockfileSentinel):
 @dataclass(frozen=True)
 class Setup:
     process: JvmProcess
-    original_snapshot: Snapshot
 
 
 @rule(level=LogLevel.DEBUG)
@@ -62,19 +60,7 @@ async def setup_google_java_format(
     lockfile_request = await Get(
         GenerateJvmLockfileFromTool, GoogleJavaFormatToolLockfileSentinel()
     )
-    source_files, tool_classpath = await MultiGet(
-        Get(
-            SourceFiles,
-            SourceFilesRequest(field_set.source for field_set in request.field_sets),
-        ),
-        Get(ToolClasspath, ToolClasspathRequest(lockfile=lockfile_request)),
-    )
-
-    source_files_snapshot = (
-        source_files.snapshot
-        if request.prior_formatter_result is None
-        else request.prior_formatter_result
-    )
+    tool_classpath = await Get(ToolClasspath, ToolClasspathRequest(lockfile=lockfile_request))
 
     toolcp_relpath = "__toolcp"
     extra_immutable_input_digests = {
@@ -96,22 +82,22 @@ async def setup_google_java_format(
         "com.google.googlejavaformat.java.Main",
         *(["--aosp"] if tool.aosp else []),
         "--replace",
-        *source_files_snapshot.files,
+        *request.snapshot.files,
     ]
 
     process = JvmProcess(
         jdk=jdk,
         argv=args,
         classpath_entries=tool_classpath.classpath_entries(toolcp_relpath),
-        input_digest=source_files_snapshot.digest,
+        input_digest=request.snapshot.digest,
         extra_immutable_input_digests=extra_immutable_input_digests,
         extra_nailgun_keys=extra_immutable_input_digests,
-        output_files=source_files_snapshot.files,
+        output_files=request.snapshot.files,
         description=f"Run Google Java Format on {pluralize(len(request.field_sets), 'file')}.",
         level=LogLevel.DEBUG,
     )
 
-    return Setup(process, original_snapshot=source_files_snapshot)
+    return Setup(process)
 
 
 @rule(desc="Format with Google Java Format", level=LogLevel.DEBUG)
@@ -123,13 +109,7 @@ async def google_java_format_fmt(
     setup = await Get(Setup, GoogleJavaFormatRequest, request)
     result = await Get(ProcessResult, JvmProcess, setup.process)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult(
-        setup.original_snapshot,
-        output_snapshot,
-        stdout=strip_v2_chroot_path(result.stdout),
-        stderr=strip_v2_chroot_path(result.stderr),
-        formatter_name=request.name,
-    )
+    return FmtResult.create(request, result, output_snapshot, strip_chroot_path=True)
 
 
 @rule

--- a/src/python/pants/backend/java/lint/google_java_format/rules_integration_test.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules_integration_test.py
@@ -92,7 +92,7 @@ def run_google_java_format(rule_runner: RuleRunner, targets: list[Target]) -> Fm
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            GoogleJavaFormatRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            GoogleJavaFormatRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/python/lint/autoflake/rules.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules.py
@@ -63,8 +63,7 @@ async def setup_autoflake(request: AutoflakeRequest, autoflake: Autoflake) -> Pr
 async def autoflake_fmt(request: AutoflakeRequest, autoflake: Autoflake) -> FmtResult:
     if autoflake.skip:
         return FmtResult.skip(formatter_name=request.name)
-    process = await Get(Process, AutoflakeRequest, request)
-    result = await Get(ProcessResult, Process, process)
+    result = await Get(ProcessResult, AutoflakeRequest, request)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
     return FmtResult.create(request, result, output_snapshot, strip_chroot_path=True)
 

--- a/src/python/pants/backend/python/lint/autoflake/rules.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules.py
@@ -9,16 +9,14 @@ from pants.backend.python.target_types import InterpreterConstraintsField, Pytho
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtRequest, FmtResult
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest
 from pants.engine.internals.native_engine import Snapshot
-from pants.engine.internals.selectors import MultiGet
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
-from pants.util.strutil import pluralize, strip_v2_chroot_path
+from pants.util.strutil import pluralize
 
 
 @dataclass(frozen=True)
@@ -38,27 +36,9 @@ class AutoflakeRequest(FmtRequest):
     name = Autoflake.options_scope
 
 
-@dataclass(frozen=True)
-class Setup:
-    process: Process
-    original_snapshot: Snapshot
-
-
 @rule(level=LogLevel.DEBUG)
-async def setup_autoflake(request: AutoflakeRequest, autoflake: Autoflake) -> Setup:
-    autoflake_pex_get = Get(VenvPex, PexRequest, autoflake.to_pex_request())
-
-    source_files_get = Get(
-        SourceFiles,
-        SourceFilesRequest(field_set.source for field_set in request.field_sets),
-    )
-
-    source_files, autoflake_pex = await MultiGet(source_files_get, autoflake_pex_get)
-    source_files_snapshot = (
-        source_files.snapshot
-        if request.prior_formatter_result is None
-        else request.prior_formatter_result
-    )
+async def setup_autoflake(request: AutoflakeRequest, autoflake: Autoflake) -> Process:
+    autoflake_pex = await Get(VenvPex, PexRequest, autoflake.to_pex_request())
 
     process = await Get(
         Process,
@@ -68,31 +48,25 @@ async def setup_autoflake(request: AutoflakeRequest, autoflake: Autoflake) -> Se
                 "--in-place",
                 "--remove-all-unused-imports",
                 *autoflake.args,
-                *source_files_snapshot.files,
+                *request.snapshot.files,
             ),
-            input_digest=source_files_snapshot.digest,
-            output_files=source_files_snapshot.files,
+            input_digest=request.snapshot.digest,
+            output_files=request.snapshot.files,
             description=f"Run Autoflake on {pluralize(len(request.field_sets), 'file')}.",
             level=LogLevel.DEBUG,
         ),
     )
-    return Setup(process, original_snapshot=source_files_snapshot)
+    return process
 
 
 @rule(desc="Format with Autoflake", level=LogLevel.DEBUG)
 async def autoflake_fmt(request: AutoflakeRequest, autoflake: Autoflake) -> FmtResult:
     if autoflake.skip:
         return FmtResult.skip(formatter_name=request.name)
-    setup = await Get(Setup, AutoflakeRequest, request)
-    result = await Get(ProcessResult, Process, setup.process)
+    process = await Get(Process, AutoflakeRequest, request)
+    result = await Get(ProcessResult, Process, process)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult(
-        setup.original_snapshot,
-        output_snapshot,
-        stdout=strip_v2_chroot_path(result.stdout),
-        stderr=strip_v2_chroot_path(result.stderr),
-        formatter_name=request.name,
-    )
+    return FmtResult.create(request, result, output_snapshot, strip_chroot_path=True)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/autoflake/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules_integration_test.py
@@ -63,7 +63,7 @@ def run_autoflake(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            AutoflakeRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            AutoflakeRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -12,7 +12,6 @@ from pants.backend.python.util_rules.interpreter_constraints import InterpreterC
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.internals.native_engine import Snapshot
 from pants.engine.internals.selectors import MultiGet
@@ -21,7 +20,7 @@ from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
-from pants.util.strutil import pluralize, strip_v2_chroot_path
+from pants.util.strutil import pluralize
 
 
 @dataclass(frozen=True)
@@ -41,14 +40,8 @@ class BlackRequest(FmtRequest):
     name = Black.options_scope
 
 
-@dataclass(frozen=True)
-class Setup:
-    process: Process
-    original_snapshot: Snapshot
-
-
 @rule(level=LogLevel.DEBUG)
-async def setup_black(request: BlackRequest, black: Black, python_setup: PythonSetup) -> Setup:
+async def setup_black(request: BlackRequest, black: Black, python_setup: PythonSetup) -> Process:
     # Black requires 3.6+ but uses the typed-ast library to work with 2.7, 3.4, 3.5, 3.6, and 3.7.
     # However, typed-ast does not understand 3.8+, so instead we must run Black with Python 3.8+
     # when relevant. We only do this if if <3.8 can't be used, as we don't want a loose requirement
@@ -74,24 +67,14 @@ async def setup_black(request: BlackRequest, black: Black, python_setup: PythonS
         PexRequest,
         black.to_pex_request(interpreter_constraints=tool_interpreter_constraints),
     )
-
-    source_files_get = Get(
-        SourceFiles,
-        SourceFilesRequest(field_set.source for field_set in request.field_sets),
+    config_files_get = Get(
+        ConfigFiles, ConfigFilesRequest, black.config_request(request.snapshot.dirs)
     )
 
-    source_files, black_pex = await MultiGet(source_files_get, black_pex_get)
-    source_files_snapshot = (
-        source_files.snapshot
-        if request.prior_formatter_result is None
-        else request.prior_formatter_result
-    )
+    black_pex, config_files = await MultiGet(black_pex_get, config_files_get)
 
-    config_files = await Get(
-        ConfigFiles, ConfigFilesRequest, black.config_request(source_files_snapshot.dirs)
-    )
     input_digest = await Get(
-        Digest, MergeDigests((source_files_snapshot.digest, config_files.snapshot.digest))
+        Digest, MergeDigests((request.snapshot.digest, config_files.snapshot.digest))
     )
 
     process = await Get(
@@ -103,32 +86,26 @@ async def setup_black(request: BlackRequest, black: Black, python_setup: PythonS
                 "-W",
                 "{pants_concurrency}",
                 *black.args,
-                *source_files_snapshot.files,
+                *request.snapshot.files,
             ),
             input_digest=input_digest,
-            output_files=source_files_snapshot.files,
+            output_files=request.snapshot.files,
             concurrency_available=len(request.field_sets),
             description=f"Run Black on {pluralize(len(request.field_sets), 'file')}.",
             level=LogLevel.DEBUG,
         ),
     )
-    return Setup(process, original_snapshot=source_files_snapshot)
+    return process
 
 
 @rule(desc="Format with Black", level=LogLevel.DEBUG)
 async def black_fmt(request: BlackRequest, black: Black) -> FmtResult:
     if black.skip:
         return FmtResult.skip(formatter_name=request.name)
-    setup = await Get(Setup, BlackRequest, request)
-    result = await Get(ProcessResult, Process, setup.process)
+    process = await Get(Process, BlackRequest, request)
+    result = await Get(ProcessResult, Process, process)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult(
-        setup.original_snapshot,
-        output_snapshot,
-        stdout=strip_v2_chroot_path(result.stdout),
-        stderr=strip_v2_chroot_path(result.stderr),
-        formatter_name=request.name,
-    )
+    return FmtResult.create(request, result, output_snapshot, strip_chroot_path=True)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -102,8 +102,7 @@ async def setup_black(request: BlackRequest, black: Black, python_setup: PythonS
 async def black_fmt(request: BlackRequest, black: Black) -> FmtResult:
     if black.skip:
         return FmtResult.skip(formatter_name=request.name)
-    process = await Get(Process, BlackRequest, request)
-    result = await Get(ProcessResult, Process, process)
+    result = await Get(ProcessResult, BlackRequest, request)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
     return FmtResult.create(request, result, output_snapshot, strip_chroot_path=True)
 

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -80,7 +80,7 @@ def run_black(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            BlackRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            BlackRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Tuple
 
 from pants.backend.python.lint.docformatter.skip_field import SkipDocformatterField
 from pants.backend.python.lint.docformatter.subsystem import Docformatter
@@ -10,10 +9,8 @@ from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtRequest, FmtResult
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest
 from pants.engine.internals.native_engine import Snapshot
-from pants.engine.internals.selectors import MultiGet
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import FieldSet, Target
@@ -38,32 +35,10 @@ class DocformatterRequest(FmtRequest):
     name = Docformatter.options_scope
 
 
-@dataclass(frozen=True)
-class Setup:
-    process: Process
-    original_snapshot: Snapshot
-
-
-def generate_args(
-    *, source_files: SourceFiles, docformatter: Docformatter, check_only: bool
-) -> Tuple[str, ...]:
-    return ("--check" if check_only else "--in-place", *docformatter.args, *source_files.files)
-
-
 @rule(level=LogLevel.DEBUG)
-async def setup_docformatter(request: DocformatterRequest, docformatter: Docformatter) -> Setup:
-    docformatter_pex_get = Get(VenvPex, PexRequest, docformatter.to_pex_request())
-    source_files_get = Get(
-        SourceFiles,
-        SourceFilesRequest(field_set.source for field_set in request.field_sets),
-    )
-    source_files, docformatter_pex = await MultiGet(source_files_get, docformatter_pex_get)
+async def setup_docformatter(request: DocformatterRequest, docformatter: Docformatter) -> Process:
+    docformatter_pex = await Get(VenvPex, PexRequest, docformatter.to_pex_request())
 
-    source_files_snapshot = (
-        source_files.snapshot
-        if request.prior_formatter_result is None
-        else request.prior_formatter_result
-    )
     process = await Get(
         Process,
         VenvPexProcess(
@@ -71,31 +46,25 @@ async def setup_docformatter(request: DocformatterRequest, docformatter: Docform
             argv=(
                 "--in-place",
                 *docformatter.args,
-                *source_files_snapshot.files,
+                *request.snapshot.files,
             ),
-            input_digest=source_files_snapshot.digest,
-            output_files=source_files_snapshot.files,
+            input_digest=request.snapshot.digest,
+            output_files=request.snapshot.files,
             description=(f"Run Docformatter on {pluralize(len(request.field_sets), 'file')}."),
             level=LogLevel.DEBUG,
         ),
     )
-    return Setup(process, original_snapshot=source_files_snapshot)
+    return process
 
 
 @rule(desc="Format with docformatter", level=LogLevel.DEBUG)
 async def docformatter_fmt(request: DocformatterRequest, docformatter: Docformatter) -> FmtResult:
     if docformatter.skip:
         return FmtResult.skip(formatter_name=request.name)
-    setup = await Get(Setup, DocformatterRequest, request)
-    result = await Get(ProcessResult, Process, setup.process)
+    process = await Get(Process, DocformatterRequest, request)
+    result = await Get(ProcessResult, Process, process)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult(
-        setup.original_snapshot,
-        output_snapshot,
-        stdout=result.stdout.decode(),
-        stderr=result.stderr.decode(),
-        formatter_name=request.name,
-    )
+    return FmtResult.create(request, result, output_snapshot)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -61,8 +61,7 @@ async def setup_docformatter(request: DocformatterRequest, docformatter: Docform
 async def docformatter_fmt(request: DocformatterRequest, docformatter: Docformatter) -> FmtResult:
     if docformatter.skip:
         return FmtResult.skip(formatter_name=request.name)
-    process = await Get(Process, DocformatterRequest, request)
-    result = await Get(ProcessResult, Process, process)
+    result = await Get(ProcessResult, DocformatterRequest, request)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
     return FmtResult.create(request, result, output_snapshot)
 

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -59,7 +59,7 @@ def run_docformatter(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            DocformatterRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            DocformatterRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -12,7 +12,6 @@ from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, PexResolveInfo, VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.internals.native_engine import Snapshot
 from pants.engine.process import Process, ProcessResult
@@ -20,7 +19,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
-from pants.util.strutil import pluralize, strip_v2_chroot_path
+from pants.util.strutil import pluralize
 
 
 @dataclass(frozen=True)
@@ -37,12 +36,6 @@ class IsortFieldSet(FieldSet):
 class IsortRequest(FmtRequest):
     field_set_type = IsortFieldSet
     name = Isort.options_scope
-
-
-@dataclass(frozen=True)
-class Setup:
-    process: Process
-    original_snapshot: Snapshot
 
 
 def generate_argv(
@@ -69,23 +62,12 @@ def generate_argv(
 
 
 @rule(level=LogLevel.DEBUG)
-async def setup_isort(request: IsortRequest, isort: Isort) -> Setup:
+async def setup_isort(request: IsortRequest, isort: Isort) -> Process:
     isort_pex_get = Get(VenvPex, PexRequest, isort.to_pex_request())
-    source_files_get = Get(
-        SourceFiles,
-        SourceFilesRequest(field_set.source for field_set in request.field_sets),
+    config_files_get = Get(
+        ConfigFiles, ConfigFilesRequest, isort.config_request(request.snapshot.dirs)
     )
-    source_files, isort_pex = await MultiGet(source_files_get, isort_pex_get)
-
-    source_files_snapshot = (
-        source_files.snapshot
-        if request.prior_formatter_result is None
-        else request.prior_formatter_result
-    )
-
-    config_files = await Get(
-        ConfigFiles, ConfigFilesRequest, isort.config_request(source_files_snapshot.dirs)
-    )
+    isort_pex, config_files = await MultiGet(isort_pex_get, config_files_get)
 
     # Isort 5+ changes how config files are handled. Determine which semantics we should use.
     is_isort5 = False
@@ -97,37 +79,31 @@ async def setup_isort(request: IsortRequest, isort: Isort) -> Setup:
         )
 
     input_digest = await Get(
-        Digest, MergeDigests((source_files_snapshot.digest, config_files.snapshot.digest))
+        Digest, MergeDigests((request.snapshot.digest, config_files.snapshot.digest))
     )
 
     process = await Get(
         Process,
         VenvPexProcess(
             isort_pex,
-            argv=generate_argv(source_files_snapshot.files, isort, is_isort5=is_isort5),
+            argv=generate_argv(request.snapshot.files, isort, is_isort5=is_isort5),
             input_digest=input_digest,
-            output_files=source_files_snapshot.files,
+            output_files=request.snapshot.files,
             description=f"Run isort on {pluralize(len(request.field_sets), 'file')}.",
             level=LogLevel.DEBUG,
         ),
     )
-    return Setup(process, original_snapshot=source_files_snapshot)
+    return process
 
 
 @rule(desc="Format with isort", level=LogLevel.DEBUG)
 async def isort_fmt(request: IsortRequest, isort: Isort) -> FmtResult:
     if isort.skip:
         return FmtResult.skip(formatter_name=request.name)
-    setup = await Get(Setup, IsortRequest, request)
-    result = await Get(ProcessResult, Process, setup.process)
+    process = await Get(Process, IsortRequest, request)
+    result = await Get(ProcessResult, Process, process)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult(
-        setup.original_snapshot,
-        output_snapshot,
-        stdout=strip_v2_chroot_path(result.stdout),
-        stderr=strip_v2_chroot_path(result.stderr),
-        formatter_name=request.name,
-    )
+    return FmtResult.create(request, result, output_snapshot, strip_chroot_path=True)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -100,8 +100,7 @@ async def setup_isort(request: IsortRequest, isort: Isort) -> Process:
 async def isort_fmt(request: IsortRequest, isort: Isort) -> FmtResult:
     if isort.skip:
         return FmtResult.skip(formatter_name=request.name)
-    process = await Get(Process, IsortRequest, request)
-    result = await Get(ProcessResult, Process, process)
+    result = await Get(ProcessResult, IsortRequest, request)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
     return FmtResult.create(request, result, output_snapshot, strip_chroot_path=True)
 

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -67,7 +67,7 @@ def run_isort(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            IsortRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            IsortRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/python/lint/pyupgrade/rules.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/rules.py
@@ -59,8 +59,7 @@ async def setup_pyupgrade_process(request: PyUpgradeRequest, pyupgrade: PyUpgrad
 async def pyupgrade_fmt(request: PyUpgradeRequest, pyupgrade: PyUpgrade) -> FmtResult:
     if pyupgrade.skip:
         return FmtResult.skip(formatter_name=request.name)
-    process = await Get(Process, PyUpgradeRequest, request)
-    result = await Get(FallibleProcessResult, Process, process)
+    result = await Get(FallibleProcessResult, PyUpgradeRequest, request)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
     return FmtResult.create(request, result, output_snapshot)
 

--- a/src/python/pants/backend/python/lint/pyupgrade/rules.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/rules.py
@@ -10,11 +10,9 @@ from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtRequest, FmtResult
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest
 from pants.engine.internals.native_engine import Snapshot
-from pants.engine.internals.selectors import MultiGet
-from pants.engine.process import FallibleProcessResult
+from pants.engine.process import FallibleProcessResult, Process
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
@@ -38,54 +36,33 @@ class PyUpgradeRequest(FmtRequest):
     name = PyUpgrade.options_scope
 
 
-@dataclass(frozen=True)
-class PyUpgradeResult:
-    process_result: FallibleProcessResult
-    original_snapshot: Snapshot
-
-
 @rule(level=LogLevel.DEBUG)
-async def run_pyupgrade(request: PyUpgradeRequest, pyupgrade: PyUpgrade) -> PyUpgradeResult:
-    pyupgrade_pex_get = Get(VenvPex, PexRequest, pyupgrade.to_pex_request())
-    source_files_get = Get(
-        SourceFiles,
-        SourceFilesRequest(field_set.source for field_set in request.field_sets),
-    )
-    source_files, pyupgrade_pex = await MultiGet(source_files_get, pyupgrade_pex_get)
+async def setup_pyupgrade_process(request: PyUpgradeRequest, pyupgrade: PyUpgrade) -> Process:
+    pyupgrade_pex = await Get(VenvPex, PexRequest, pyupgrade.to_pex_request())
 
-    source_files_snapshot = (
-        source_files.snapshot
-        if request.prior_formatter_result is None
-        else request.prior_formatter_result
-    )
-
-    result = await Get(
-        FallibleProcessResult,
+    process = await Get(
+        Process,
         VenvPexProcess(
             pyupgrade_pex,
-            argv=(*pyupgrade.args, *source_files.files),
-            input_digest=source_files_snapshot.digest,
-            output_files=source_files_snapshot.files,
+            argv=(*pyupgrade.args, *request.snapshot.files),
+            input_digest=request.snapshot.digest,
+            output_files=request.snapshot.files,
             description=f"Run pyupgrade on {pluralize(len(request.field_sets), 'file')}.",
             level=LogLevel.DEBUG,
         ),
     )
-    return PyUpgradeResult(result, original_snapshot=source_files_snapshot)
+
+    return process
 
 
 @rule(desc="Format with pyupgrade", level=LogLevel.DEBUG)
-async def pyupgrade_fmt(result: PyUpgradeResult, pyupgrade: PyUpgrade) -> FmtResult:
+async def pyupgrade_fmt(request: PyUpgradeRequest, pyupgrade: PyUpgrade) -> FmtResult:
     if pyupgrade.skip:
-        return FmtResult.skip(formatter_name=PyUpgradeRequest.name)
-
-    output_snapshot = await Get(Snapshot, Digest, result.process_result.output_digest)
-    return FmtResult(
-        result.original_snapshot,
-        output_snapshot,
-        stdout=result.process_result.stdout.decode(),
-        stderr=result.process_result.stderr.decode(),
-        formatter_name=PyUpgradeRequest.name,
-    )
+        return FmtResult.skip(formatter_name=request.name)
+    process = await Get(Process, PyUpgradeRequest, request)
+    result = await Get(FallibleProcessResult, Process, process)
+    output_snapshot = await Get(Snapshot, Digest, result.output_digest)
+    return FmtResult.create(request, result, output_snapshot)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/pyupgrade/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/rules_integration_test.py
@@ -73,7 +73,7 @@ def run_pyupgrade(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            PyUpgradeRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            PyUpgradeRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/python/lint/yapf/rules.py
+++ b/src/python/pants/backend/python/lint/yapf/rules.py
@@ -10,7 +10,6 @@ from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.internals.native_engine import Snapshot
 from pants.engine.process import Process, ProcessResult
@@ -37,32 +36,16 @@ class YapfRequest(FmtRequest):
     name = Yapf.options_scope
 
 
-@dataclass(frozen=True)
-class Setup:
-    process: Process
-    original_snapshot: Snapshot
-
-
 @rule(level=LogLevel.DEBUG)
-async def setup_yapf(request: YapfRequest, yapf: Yapf) -> Setup:
+async def setup_yapf(request: YapfRequest, yapf: Yapf) -> Process:
     yapf_pex_get = Get(VenvPex, PexRequest, yapf.to_pex_request())
-    source_files_get = Get(
-        SourceFiles,
-        SourceFilesRequest(field_set.source for field_set in request.field_sets),
+    config_files_get = Get(
+        ConfigFiles, ConfigFilesRequest, yapf.config_request(request.snapshot.dirs)
     )
-    source_files, yapf_pex = await MultiGet(source_files_get, yapf_pex_get)
+    yapf_pex, config_files = await MultiGet(yapf_pex_get, config_files_get)
 
-    source_files_snapshot = (
-        source_files.snapshot
-        if request.prior_formatter_result is None
-        else request.prior_formatter_result
-    )
-
-    config_files = await Get(
-        ConfigFiles, ConfigFilesRequest, yapf.config_request(source_files_snapshot.dirs)
-    )
     input_digest = await Get(
-        Digest, MergeDigests((source_files_snapshot.digest, config_files.snapshot.digest))
+        Digest, MergeDigests((request.snapshot.digest, config_files.snapshot.digest))
     )
 
     process = await Get(
@@ -73,31 +56,25 @@ async def setup_yapf(request: YapfRequest, yapf: Yapf) -> Setup:
                 *yapf.args,
                 "--in-place",
                 *(("--style", yapf.config) if yapf.config else ()),
-                *source_files_snapshot.files,
+                *request.snapshot.files,
             ),
             input_digest=input_digest,
-            output_files=source_files_snapshot.files,
+            output_files=request.snapshot.files,
             description=f"Run yapf on {pluralize(len(request.field_sets), 'file')}.",
             level=LogLevel.DEBUG,
         ),
     )
-    return Setup(process, original_snapshot=source_files_snapshot)
+    return process
 
 
 @rule(desc="Format with yapf", level=LogLevel.DEBUG)
 async def yapf_fmt(request: YapfRequest, yapf: Yapf) -> FmtResult:
     if yapf.skip:
         return FmtResult.skip(formatter_name=request.name)
-    setup = await Get(Setup, YapfRequest, request)
-    result = await Get(ProcessResult, Process, setup.process)
+    process = await Get(Process, YapfRequest, request)
+    result = await Get(ProcessResult, Process, process)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult(
-        setup.original_snapshot,
-        output_snapshot,
-        stdout=result.stdout.decode(),
-        stderr=result.stderr.decode(),
-        formatter_name=request.name,
-    )
+    return FmtResult.create(request, result, output_snapshot)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/yapf/rules.py
+++ b/src/python/pants/backend/python/lint/yapf/rules.py
@@ -71,8 +71,7 @@ async def setup_yapf(request: YapfRequest, yapf: Yapf) -> Process:
 async def yapf_fmt(request: YapfRequest, yapf: Yapf) -> FmtResult:
     if yapf.skip:
         return FmtResult.skip(formatter_name=request.name)
-    process = await Get(Process, YapfRequest, request)
-    result = await Get(ProcessResult, Process, process)
+    result = await Get(ProcessResult, YapfRequest, request)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
     return FmtResult.create(request, result, output_snapshot)
 

--- a/src/python/pants/backend/python/lint/yapf/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/yapf/rules_integration_test.py
@@ -69,7 +69,7 @@ def run_yapf(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            YapfRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            YapfRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -14,7 +14,6 @@ from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.goals.tailor import group_by_dir
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import (
     Digest,
     DigestSubset,
@@ -183,31 +182,17 @@ async def setup_scalafmt_partition(
 @rule(level=LogLevel.DEBUG)
 async def setup_scalafmt(
     request: ScalafmtRequest,
-    tool: ScalafmtSubsystem,
 ) -> Setup:
     toolcp_relpath = "__toolcp"
 
     lockfile_request = await Get(GenerateJvmLockfileFromTool, ScalafmtToolLockfileSentinel())
-    source_files, tool_classpath = await MultiGet(
-        Get(
-            SourceFiles,
-            SourceFilesRequest(field_set.source for field_set in request.field_sets),
-        ),
+    tool_classpath, config_files = await MultiGet(
         Get(ToolClasspath, ToolClasspathRequest(lockfile=lockfile_request)),
-    )
-
-    source_files_snapshot = (
-        source_files.snapshot
-        if request.prior_formatter_result is None
-        else request.prior_formatter_result
-    )
-
-    config_files = await Get(
-        ScalafmtConfigFiles, GatherScalafmtConfigFilesRequest(source_files_snapshot)
+        Get(ScalafmtConfigFiles, GatherScalafmtConfigFilesRequest(request.snapshot)),
     )
 
     merged_sources_digest = await Get(
-        Digest, MergeDigests([source_files_snapshot.digest, config_files.snapshot.digest])
+        Digest, MergeDigests([request.snapshot.digest, config_files.snapshot.digest])
     )
 
     extra_immutable_input_digests = {
@@ -216,7 +201,7 @@ async def setup_scalafmt(
 
     # Partition the work by which source files share the same config file (regardless of directory).
     source_files_by_config_file: dict[str, set[str]] = defaultdict(set)
-    for source_dir, files_in_source_dir in group_by_dir(source_files_snapshot.files).items():
+    for source_dir, files_in_source_dir in group_by_dir(request.snapshot.files).items():
         config_file = config_files.source_dir_to_config_file[source_dir]
         source_files_by_config_file[config_file].update(
             os.path.join(source_dir, name) for name in files_in_source_dir
@@ -236,7 +221,7 @@ async def setup_scalafmt(
         for config_file, files in source_files_by_config_file.items()
     )
 
-    return Setup(tuple(partitions), original_snapshot=source_files_snapshot)
+    return Setup(tuple(partitions), original_snapshot=request.snapshot)
 
 
 @rule(desc="Format with scalafmt", level=LogLevel.DEBUG)

--- a/src/python/pants/backend/scala/lint/scalafmt/rules_integration_test.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules_integration_test.py
@@ -112,7 +112,7 @@ def run_scalafmt(rule_runner: RuleRunner, targets: list[Target]) -> FmtResult:
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            ScalafmtRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            ScalafmtRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/shell/lint/shfmt/rules.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules.py
@@ -9,7 +9,6 @@ from pants.backend.shell.target_types import ShellSourceField
 from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.internals.native_engine import Snapshot
 from pants.engine.platform import Platform
@@ -37,37 +36,20 @@ class ShfmtRequest(FmtRequest):
     name = Shfmt.options_scope
 
 
-@dataclass(frozen=True)
-class Setup:
-    process: Process
-    original_snapshot: Snapshot
-
-
 @rule(level=LogLevel.DEBUG)
-async def setup_shfmt(request: ShfmtRequest, shfmt: Shfmt) -> Setup:
+async def setup_shfmt(request: ShfmtRequest, shfmt: Shfmt) -> Process:
     download_shfmt_get = Get(
         DownloadedExternalTool, ExternalToolRequest, shfmt.get_request(Platform.current)
     )
-    source_files_get = Get(
-        SourceFiles,
-        SourceFilesRequest(field_set.sources for field_set in request.field_sets),
+    config_files_get = Get(
+        ConfigFiles, ConfigFilesRequest, shfmt.config_request(request.snapshot.dirs)
     )
-    downloaded_shfmt, source_files = await MultiGet(download_shfmt_get, source_files_get)
-
-    source_files_snapshot = (
-        source_files.snapshot
-        if request.prior_formatter_result is None
-        else request.prior_formatter_result
-    )
-
-    config_files = await Get(
-        ConfigFiles, ConfigFilesRequest, shfmt.config_request(source_files_snapshot.dirs)
-    )
+    downloaded_shfmt, config_files = await MultiGet(download_shfmt_get, config_files_get)
 
     input_digest = await Get(
         Digest,
         MergeDigests(
-            (source_files_snapshot.digest, downloaded_shfmt.digest, config_files.snapshot.digest)
+            (request.snapshot.digest, downloaded_shfmt.digest, config_files.snapshot.digest)
         ),
     )
 
@@ -76,32 +58,26 @@ async def setup_shfmt(request: ShfmtRequest, shfmt: Shfmt) -> Setup:
         "-l",
         "-w",
         *shfmt.args,
-        *source_files_snapshot.files,
+        *request.snapshot.files,
     ]
     process = Process(
         argv=argv,
         input_digest=input_digest,
-        output_files=source_files_snapshot.files,
+        output_files=request.snapshot.files,
         description=f"Run shfmt on {pluralize(len(request.field_sets), 'file')}.",
         level=LogLevel.DEBUG,
     )
-    return Setup(process, original_snapshot=source_files_snapshot)
+    return process
 
 
 @rule(desc="Format with shfmt", level=LogLevel.DEBUG)
 async def shfmt_fmt(request: ShfmtRequest, shfmt: Shfmt) -> FmtResult:
     if shfmt.skip:
         return FmtResult.skip(formatter_name=request.name)
-    setup = await Get(Setup, ShfmtRequest, request)
-    result = await Get(ProcessResult, Process, setup.process)
+    process = await Get(Process, ShfmtRequest, request)
+    result = await Get(ProcessResult, Process, process)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult(
-        setup.original_snapshot,
-        output_snapshot,
-        stdout=result.stdout.decode(),
-        stderr=result.stderr.decode(),
-        formatter_name=request.name,
-    )
+    return FmtResult.create(request, result, output_snapshot)
 
 
 def rules():

--- a/src/python/pants/backend/shell/lint/shfmt/rules.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules.py
@@ -74,8 +74,7 @@ async def setup_shfmt(request: ShfmtRequest, shfmt: Shfmt) -> Process:
 async def shfmt_fmt(request: ShfmtRequest, shfmt: Shfmt) -> FmtResult:
     if shfmt.skip:
         return FmtResult.skip(formatter_name=request.name)
-    process = await Get(Process, ShfmtRequest, request)
-    result = await Get(ProcessResult, Process, process)
+    result = await Get(ProcessResult, ShfmtRequest, request)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
     return FmtResult.create(request, result, output_snapshot)
 

--- a/src/python/pants/backend/shell/lint/shfmt/rules_integration_test.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules_integration_test.py
@@ -87,7 +87,7 @@ def run_shfmt(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            ShfmtRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            ShfmtRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt_integration_test.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt_integration_test.py
@@ -112,7 +112,7 @@ def run_tffmt(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            TffmtRequest(field_sets, prior_formatter_result=input_sources.snapshot),
+            TffmtRequest(field_sets, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/terraform/style.py
+++ b/src/python/pants/backend/terraform/style.py
@@ -49,7 +49,7 @@ async def setup_terraform_style(setup_request: StyleSetupRequest) -> StyleSetup:
     )
 
     source_files_snapshot = (
-        setup_request.request.prior_formatter_result
+        setup_request.request.snapshot
         if isinstance(setup_request.request, FmtRequest)
         else await Get(
             Snapshot, MergeDigests(sfs.snapshot.digest for sfs in source_files_by_field_set)

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -295,7 +295,7 @@ async def lint(
     fmt_requests = (
         request_type(
             batch,
-            prior_formatter_result=source_files_snapshot.snapshot,
+            snapshot=source_files_snapshot.snapshot,
         )
         for (request_type, batch), source_files_snapshot in zip(
             batched_fmt_request_pairs, all_fmt_source_batches


### PR DESCRIPTION
The main change here is renaming `prior_formatter_result` to be `snapshot`, and removing `| None` from its type.

Then call-sites must be refactored to remove the `if None` conditional since its never `None`. Which then leads to removing the `source_files` `Get`.
Also, now `original_snapshot` in most formatter's `Setup` is superfluous. So it can be replaced by the `Process` it contains. More refactoring.
Lastly, I added `FmtResult.create` since the `request`/`result` contain most of the requisite info.



[ci skip-rust]
[ci skip-build-wheels]