### PR TITLE
Upgrade Pex to 2.1.76.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -14,7 +14,7 @@ humbug==0.2.7
 
 ijson==3.1.4
 packaging==21.3
-pex==2.1.75
+pex==2.1.76
 psutil==5.9.0
 pytest>=6.2.4,<8  # This should be compatible with pytest.py, although it can be looser so that we don't over-constrain pantsbuild.pants.testutil
 python-lsp-jsonrpc==1.0.0

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -18,7 +18,7 @@
 //     "ijson==3.1.4",
 //     "mypy-typing-asserts==0.1.1",
 //     "packaging==21.3",
-//     "pex==2.1.75",
+//     "pex==2.1.76",
 //     "psutil==5.9.0",
 //     "pydevd-pycharm==203.5419.8",
 //     "pytest<8,>=6.2.4",
@@ -548,13 +548,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "71a7f9b2466801090c6c05da1c7172562aa23b71df564fcae382de98433c0651",
-              "url": "https://files.pythonhosted.org/packages/fb/93/68786dc561fce8dccb5bd38b3f40b3f4bc1888ccba97d91f49e311588f21/pex-2.1.75-py2.py3-none-any.whl"
+              "hash": "3e131489681ec9003c3d4bb98cf22b1a60cf6dcd0e6690cbe18301e63134a48f",
+              "url": "https://files.pythonhosted.org/packages/ba/05/3c490316c42ea0772fdd68bd105473b8120941bfdedf9281f8e43311a399/pex-2.1.76-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1b9244e3f656658a3c169cb766121a58dcc67c49166fda80f6f2f75154ea7f44",
-              "url": "https://files.pythonhosted.org/packages/54/38/03ad7608b066898b7cb7e1066019363e6f348e10c36aa57674298def18f8/pex-2.1.75.tar.gz"
+              "hash": "6bf7b4b73ebb411ed2498411b77b49aa008624b9faa22d3edc732983c34a447f",
+              "url": "https://files.pythonhosted.org/packages/49/c9/bfeab0a623e6e2ab1a900094a90e326ff00a2a642114b78393f5813505af/pex-2.1.76.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -562,7 +562,7 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.11,>=2.7",
-          "version": "2.1.75"
+          "version": "2.1.76"
         },
         {
           "artifacts": [
@@ -1509,42 +1509,42 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375",
-              "url": "https://files.pythonhosted.org/packages/52/c5/df7953fe6065185af5956265e3b16f13c2826c2b1ba23d43154f3af453bc/zipp-3.7.0-py3-none-any.whl"
+              "hash": "c4f6e5bbf48e74f7a38e7cc5b0480ff42b0ae5178957d564d18932525d5cf099",
+              "url": "https://files.pythonhosted.org/packages/80/0e/16a7ee38617aab6a624e95948d314097cc2669edae9b02ded53309941cfc/zipp-3.8.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d",
-              "url": "https://files.pythonhosted.org/packages/94/64/3115548d41cb001378099cb4fc6a6889c64ef43ac1b0e68c9e80b55884fa/zipp-3.7.0.tar.gz"
+              "hash": "56bf8aadb83c24db6c4b577e13de374ccfb67da2078beba1d037c17980bf43ad",
+              "url": "https://files.pythonhosted.org/packages/cc/3c/3e8c69cd493297003da83f26ccf1faea5dd7da7892a0a7c965ac3bcba7bf/zipp-3.8.0.tar.gz"
             }
           ],
           "project_name": "zipp",
           "requires_dists": [
             "func-timeout; extra == \"testing\"",
             "jaraco.itertools; extra == \"testing\"",
-            "jaraco.packaging>=8.2; extra == \"docs\"",
+            "jaraco.packaging>=9; extra == \"docs\"",
             "pytest-black>=0.3.7; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-checkdocs>=2.4; extra == \"testing\"",
             "pytest-cov; extra == \"testing\"",
             "pytest-enabler>=1.0.1; extra == \"testing\"",
             "pytest-flake8; extra == \"testing\"",
-            "pytest-mypy; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
+            "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest>=6; extra == \"testing\"",
             "rst.linker>=1.9; extra == \"docs\"",
             "sphinx; extra == \"docs\""
           ],
           "requires_python": ">=3.7",
-          "version": "3.7"
+          "version": "3.8"
         }
       ],
       "platform_tag": [
-        "cp39",
-        "cp39",
-        "macosx_11_0_arm64"
+        "cp310",
+        "cp310",
+        "manylinux_2_35_x86_64"
       ]
     }
   ],
-  "pex_version": "2.1.75",
+  "pex_version": "2.1.76",
   "prefer_older_binary": false,
   "requirements": [
     "PyYAML<7.0,>=6.0",
@@ -1556,7 +1556,7 @@
     "ijson==3.1.4",
     "mypy-typing-asserts==0.1.1",
     "packaging==21.3",
-    "pex==2.1.75",
+    "pex==2.1.76",
     "psutil==5.9.0",
     "pydevd-pycharm==203.5419.8",
     "pytest<8,>=6.2.4",

--- a/src/python/pants/backend/python/subsystems/lambdex.lock
+++ b/src/python/pants/backend/python/subsystems/lambdex.lock
@@ -49,13 +49,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "71a7f9b2466801090c6c05da1c7172562aa23b71df564fcae382de98433c0651",
-              "url": "https://files.pythonhosted.org/packages/fb/93/68786dc561fce8dccb5bd38b3f40b3f4bc1888ccba97d91f49e311588f21/pex-2.1.75-py2.py3-none-any.whl"
+              "hash": "3e131489681ec9003c3d4bb98cf22b1a60cf6dcd0e6690cbe18301e63134a48f",
+              "url": "https://files.pythonhosted.org/packages/ba/05/3c490316c42ea0772fdd68bd105473b8120941bfdedf9281f8e43311a399/pex-2.1.76-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1b9244e3f656658a3c169cb766121a58dcc67c49166fda80f6f2f75154ea7f44",
-              "url": "https://files.pythonhosted.org/packages/54/38/03ad7608b066898b7cb7e1066019363e6f348e10c36aa57674298def18f8/pex-2.1.75.tar.gz"
+              "hash": "6bf7b4b73ebb411ed2498411b77b49aa008624b9faa22d3edc732983c34a447f",
+              "url": "https://files.pythonhosted.org/packages/49/c9/bfeab0a623e6e2ab1a900094a90e326ff00a2a642114b78393f5813505af/pex-2.1.76.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -63,17 +63,17 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.11,>=2.7",
-          "version": "2.1.75"
+          "version": "2.1.76"
         }
       ],
       "platform_tag": [
-        "cp39",
-        "cp39",
-        "macosx_11_0_arm64"
+        "cp310",
+        "cp310",
+        "manylinux_2_35_x86_64"
       ]
     }
   ],
-  "pex_version": "2.1.75",
+  "pex_version": "2.1.76",
   "prefer_older_binary": false,
   "requirements": [
     "lambdex==0.1.6"

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -39,9 +39,9 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."
 
-    default_version = "v2.1.75"
+    default_version = "v2.1.76"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.1.73,<3.0"
+    version_constraints = ">=2.1.76,<3.0"
 
     @classproperty
     def default_known_versions(cls):
@@ -50,8 +50,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "59804a5115fde3ed0c893e16205fa25d4c02928047aa0c59126a5c4d434ae288",
-                    "3730767",
+                    "71c9a67b7bf8ede5f1bdacbbc2bd3e3df4395499623d9d0d5dfee40ae38ab941",
+                    "3731258",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64"]


### PR DESCRIPTION
This upgrade shores up the workaround in 2.1.75. There are ~no
observable changes for Pants to see, just peace of mind.

The changelog is here:
  https://github.com/pantsbuild/pex/releases/tag/v2.1.76

[ci skip-rust]
[ci skip-build-wheels]