### PR TITLE
Support for finer control over which Docker images to push.

### DIFF
--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -274,6 +274,7 @@ def test_build_image_with_registries(rule_runner: RuleRunner) -> None:
                 docker_image(name="unreg", image_tags=["1.2.3"], registries=[])
                 docker_image(name="def", image_tags=["1.2.3"])
                 docker_image(name="multi", image_tags=["1.2.3"], registries=["@reg2", "@reg1"])
+                docker_image(name="extra_tags", image_tags=["1.2.3"], registries=["@reg1", "@extra"])
                 """
             ),
             "docker/test/Dockerfile": "FROM python:3.8",
@@ -285,6 +286,7 @@ def test_build_image_with_registries(rule_runner: RuleRunner) -> None:
         "registries": {
             "reg1": {"address": "myregistry1domain:port"},
             "reg2": {"address": "myregistry2domain:port", "default": "true"},
+            "extra": {"address": "extra", "extra_image_tags": ["latest"]},
         },
     }
 
@@ -343,6 +345,17 @@ def test_build_image_with_registries(rule_runner: RuleRunner) -> None:
             "Built docker images: \n"
             "  * myregistry2domain:port/multi:1.2.3\n"
             "  * myregistry1domain:port/multi:1.2.3"
+        ),
+        options=options,
+    )
+    assert_build(
+        rule_runner,
+        Address("docker/test", target_name="extra_tags"),
+        (
+            "Built docker images: \n"
+            "  * myregistry1domain:port/extra_tags:1.2.3\n"
+            "  * extra/extra_tags:1.2.3\n"
+            "  * extra/extra_tags:latest"
         ),
         options=options,
     )

--- a/src/python/pants/backend/docker/registries.py
+++ b/src/python/pants/backend/docker/registries.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Generator
+from typing import Any, Iterator
 
 from pants.option.parser import Parser
 from pants.util.frozendict import FrozenDict
@@ -29,6 +29,7 @@ class DockerRegistryOptions:
     address: str
     alias: str = ""
     default: bool = False
+    skip_push: bool = False
 
     @classmethod
     def from_dict(cls, alias: str, d: dict[str, Any]) -> DockerRegistryOptions:
@@ -36,6 +37,7 @@ class DockerRegistryOptions:
             alias=alias,
             address=d["address"],
             default=Parser.ensure_bool(d.get("default", alias == "default")),
+            skip_push=Parser.ensure_bool(d.get("skip_push", DockerRegistryOptions.skip_push)),
         )
 
     def register(self, registries: dict[str, DockerRegistryOptions]) -> None:
@@ -61,7 +63,7 @@ class DockerRegistries:
             registries=FrozenDict(registries),
         )
 
-    def get(self, *aliases_or_addresses: str) -> Generator[DockerRegistryOptions, None, None]:
+    def get(self, *aliases_or_addresses: str) -> Iterator[DockerRegistryOptions]:
         for alias_or_address in aliases_or_addresses:
             if alias_or_address in self.registries:
                 # Get configured registry by "@alias" or "address".

--- a/src/python/pants/backend/docker/registries.py
+++ b/src/python/pants/backend/docker/registries.py
@@ -30,6 +30,7 @@ class DockerRegistryOptions:
     alias: str = ""
     default: bool = False
     skip_push: bool = False
+    extra_image_tags: tuple[str, ...] = ()
 
     @classmethod
     def from_dict(cls, alias: str, d: dict[str, Any]) -> DockerRegistryOptions:
@@ -38,6 +39,9 @@ class DockerRegistryOptions:
             address=d["address"],
             default=Parser.ensure_bool(d.get("default", alias == "default")),
             skip_push=Parser.ensure_bool(d.get("skip_push", DockerRegistryOptions.skip_push)),
+            extra_image_tags=tuple(
+                d.get("extra_image_tags", DockerRegistryOptions.extra_image_tags)
+            ),
         )
 
     def register(self, registries: dict[str, DockerRegistryOptions]) -> None:

--- a/src/python/pants/backend/docker/registries_test.py
+++ b/src/python/pants/backend/docker/registries_test.py
@@ -72,3 +72,19 @@ def test_skip_push() -> None:
     assert reg1.skip_push is False
     assert reg2.skip_push is True
     assert reg3.skip_push is False
+
+
+def test_extra_image_tags() -> None:
+    registries = DockerRegistries.from_dict(
+        {
+            "reg1": {"address": "registry1"},
+            "reg2": {
+                "address": "registry2",
+                "extra_image_tags": ["latest", "v{build_args.VERSION}"],
+            },
+        }
+    )
+
+    reg1, reg2 = registries.get("@reg1", "@reg2")
+    assert reg1.extra_image_tags == ()
+    assert reg2.extra_image_tags == ("latest", "v{build_args.VERSION}")

--- a/src/python/pants/backend/docker/registries_test.py
+++ b/src/python/pants/backend/docker/registries_test.py
@@ -57,3 +57,18 @@ def test_docker_registries() -> None:
     assert next(registries.get("myunregistereddomain:port")) == DockerRegistryOptions(
         address="myunregistereddomain:port"
     )
+
+
+def test_skip_push() -> None:
+    registries = DockerRegistries.from_dict(
+        {
+            "reg1": {"address": "registry1"},
+            "reg2": {"address": "registry2", "skip_push": True},
+            "reg3": {"address": "registry3", "skip_push": "false"},
+        }
+    )
+
+    reg1, reg2, reg3 = registries.get("@reg1", "@reg2", "@reg3")
+    assert reg1.skip_push is False
+    assert reg2.skip_push is True
+    assert reg3.skip_push is False

--- a/src/python/pants/backend/docker/subsystems/docker_options.py
+++ b/src/python/pants/backend/docker/subsystems/docker_options.py
@@ -59,7 +59,7 @@ class DockerOptions(Subsystem):
             A configured registry is marked as default either by setting `default = true`
             or with an alias of `"default"`.
 
-            A `docker_image` may be pushed to subset of registries using the per registry
+            A `docker_image` may be pushed to a subset of registries using the per registry
             `skip_push` option rather then the all or nothing toggle of the field option `skip_push`
             on the `docker_image` target.
 

--- a/src/python/pants/backend/docker/subsystems/docker_options.py
+++ b/src/python/pants/backend/docker/subsystems/docker_options.py
@@ -44,6 +44,8 @@ class DockerOptions(Subsystem):
                     "registry-alias": {
                         "address": "registry-domain:port",
                         "default": bool,
+                        "extra_image_tags": [],
+                        "skip_push": bool,
                     },
                     ...
                 }
@@ -56,6 +58,15 @@ class DockerOptions(Subsystem):
 
             A configured registry is marked as default either by setting `default = true`
             or with an alias of `"default"`.
+
+            A `docker_image` may be pushed to subset of registries using the per registry
+            `skip_push` option rather then the all or nothing toggle of the field option `skip_push`
+            on the `docker_image` target.
+
+            Any image tags that should only be added for specific registries may be provided as the
+            `extra_image_tags` option. The tags may use value formatting the same as for the
+            `image_tags` field of the `docker_image` target.
+
             """
         ),
         fromfile=True,

--- a/src/python/pants/backend/docker/util_rules/docker_binary.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary.py
@@ -91,18 +91,13 @@ class DockerBinary(BinaryPath):
             cache_scope=ProcessCacheScope.PER_SESSION,
         )
 
-    def push_image(
-        self, tags: tuple[str, ...], env: Mapping[str, str] | None = None
-    ) -> tuple[Process, ...]:
-        return tuple(
-            Process(
-                argv=(self.path, "push", tag),
-                cache_scope=ProcessCacheScope.PER_SESSION,
-                description=f"Pushing docker image {tag}",
-                env=self._get_process_environment(env or {}),
-                immutable_input_digests=self.extra_input_digests,
-            )
-            for tag in tags
+    def push_image(self, tag: str, env: Mapping[str, str] | None = None) -> Process:
+        return Process(
+            argv=(self.path, "push", tag),
+            cache_scope=ProcessCacheScope.PER_SESSION,
+            description=f"Pushing docker image {tag}",
+            env=self._get_process_environment(env or {}),
+            immutable_input_digests=self.extra_input_digests,
         )
 
     def run_image(

--- a/src/python/pants/backend/docker/util_rules/docker_binary_test.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary_test.py
@@ -64,18 +64,14 @@ def test_docker_binary_build_image(docker_path: str, docker: DockerBinary) -> No
 
 
 def test_docker_binary_push_image(docker_path: str, docker: DockerBinary) -> None:
-    assert docker.push_image(()) == ()
-
     image_ref = "registry/repo/name:tag"
-    push_request = docker.push_image((image_ref,))
-    assert push_request == (
-        Process(
-            argv=(docker_path, "push", image_ref),
-            cache_scope=ProcessCacheScope.PER_SESSION,
-            description="",  # The description field is marked `compare=False`
-        ),
+    push_request = docker.push_image(image_ref)
+    assert push_request == Process(
+        argv=(docker_path, "push", image_ref),
+        cache_scope=ProcessCacheScope.PER_SESSION,
+        description="",  # The description field is marked `compare=False`
     )
-    assert push_request[0].description == f"Pushing docker image {image_ref}"
+    assert push_request.description == f"Pushing docker image {image_ref}"
 
 
 def test_docker_binary_run_image(docker_path: str, docker: DockerBinary) -> None:


### PR DESCRIPTION
Closes #14114 

Introduces the `skip_push` and `extra_image_tags` options to Docker registries configuration.

Example use in `pants.toml`:
```toml
[docker.registries.color-infra]
address = "123456789.dkr.ecr.us-east-1.amazonaws.com"
default = true

[docker.registries.color-stub]
# Allow locally built images to be references as `color/registry:latest`.
address = "color"
default = true
skip_push = true
extra_image_tags = ["latest"]
```
