### PR TITLE
Upgrade to Pex 2.1.77.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -15,7 +15,7 @@ humbug==0.2.7
 
 ijson==3.1.4
 packaging==21.3
-pex==2.1.76
+pex==2.1.77
 psutil==5.9.0
 # This should be compatible with pytest.py, although it can be looser so that we don't
 # over-constrain pantsbuild.pants.testutil

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -18,7 +18,7 @@
 //     "ijson==3.1.4",
 //     "mypy-typing-asserts==0.1.1",
 //     "packaging==21.3",
-//     "pex==2.1.76",
+//     "pex==2.1.77",
 //     "psutil==5.9.0",
 //     "pydevd-pycharm==203.5419.8",
 //     "pytest<7.1.0,>=6.2.4",
@@ -548,13 +548,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "3e131489681ec9003c3d4bb98cf22b1a60cf6dcd0e6690cbe18301e63134a48f",
-              "url": "https://files.pythonhosted.org/packages/ba/05/3c490316c42ea0772fdd68bd105473b8120941bfdedf9281f8e43311a399/pex-2.1.76-py2.py3-none-any.whl"
+              "hash": "e0f0e754e9e1fdadb8e7d5e0bd0e1f4710fbb57b679ec91e6e5d7313aa12b64d",
+              "url": "https://files.pythonhosted.org/packages/a3/01/aea843da3bdb4d1ee12855e3bb237dfa6f8492b5ff59f7ac644a87719bbf/pex-2.1.77-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6bf7b4b73ebb411ed2498411b77b49aa008624b9faa22d3edc732983c34a447f",
-              "url": "https://files.pythonhosted.org/packages/49/c9/bfeab0a623e6e2ab1a900094a90e326ff00a2a642114b78393f5813505af/pex-2.1.76.tar.gz"
+              "hash": "96fcd16fe9b76b70e68a6cd522ba286c968d7b63ee32869d6f8f18c21c4256f0",
+              "url": "https://files.pythonhosted.org/packages/0c/88/d7a15de41f1cfe2941613bbddc23602b3f688fa76ee3d7bbf09713dca9f6/pex-2.1.77.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -562,7 +562,7 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.11,>=2.7",
-          "version": "2.1.76"
+          "version": "2.1.77"
         },
         {
           "artifacts": [
@@ -1273,209 +1273,209 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "ce620a6563b21aa3fbb1658bc1bfddb484a6dad542de1efb5121eb7bb4f2b93a",
-              "url": "https://files.pythonhosted.org/packages/c5/7d/b3301d5f173087011c017f95cfeab60e420644f279de1cc7faf640e7a8ee/ujson-5.1.0-pp38-pypy38_pp73-win_amd64.whl"
+              "hash": "25522c674b35c33f375586ac98d92ce731e79059424507ecbccbfcbce832d597",
+              "url": "https://files.pythonhosted.org/packages/cd/d2/e97ce7023880756510007f6f8f44a3e0dc77cd261d54733a1ab6eeed0150/ujson-5.2.0-pp38-pypy38_pp73-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b2c7e4afde0d36926b091fa9613b18b65e911fcaa60024e8721f2dcfedc25329",
-              "url": "https://files.pythonhosted.org/packages/00/a1/4b16d0ce1a069a214c989d3f7c0e9d8e7eb45c0ede9d9208b947f9e4e512/ujson-5.1.0-pp37-pypy37_pp73-win_amd64.whl"
+              "hash": "11f735870f189bff1841c720115226894415ab6a7796dee8ab46bc767ea2e743",
+              "url": "https://files.pythonhosted.org/packages/00/b0/2998faca65c9f5afcf4facff0b0cef42110295babab3da3fe27d601bdafa/ujson-5.2.0-cp39-cp39-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "110633a8dda6c8ca78090292231e15381f8b2423e998399d4bc5f135149c722b",
-              "url": "https://files.pythonhosted.org/packages/0f/02/039f1024a614b3c0862435b70933889e74dfc21772df738cfec956f28102/ujson-5.1.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl"
+              "hash": "940f35e9a0969440621445dbb6adffaa2cea77d0262abc74fce78704120c4534",
+              "url": "https://files.pythonhosted.org/packages/0a/65/f197641777f7438a545df512d95f3b21d542cc2233a2be090b888cc49630/ujson-5.2.0-cp39-cp39-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "05aa6c7297a22081f65497b6f586de6b7060ea47c3ecda80896f47200e9dbf04",
-              "url": "https://files.pythonhosted.org/packages/13/cb/a6ad0cf4a2af66de0a43d29f9742c55498179a713076a6231d25121a8750/ujson-5.1.0-cp37-cp37m-musllinux_1_1_aarch64.whl"
+              "hash": "d1e5c635b7c3465ab8d2e3dc97c341ef1801c53a378f1d1d4cb934f6c90ec66c",
+              "url": "https://files.pythonhosted.org/packages/0b/35/a02bd12a90c0cbbfb56a0919782e3fcb63c6632e7486f0035d0a8bdbd3b2/ujson-5.2.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "452990c2b18445a7379a45873527d2ec47789b9289c13a17a3c1cc76b9641126",
-              "url": "https://files.pythonhosted.org/packages/18/a0/814a156e6c26922891832b053130d96015baded951f9035f85e252fe53e9/ujson-5.1.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "6677bee8690c71f5e6cf519a6d8400f04fbd3ff9f6c50f35f1b664bc94546f84",
+              "url": "https://files.pythonhosted.org/packages/0e/bf/03e9aa478cb1c6f4bfed28eb2faa37528f85a2f2116062da2eaa0da67ecc/ujson-5.2.0-cp39-cp39-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "585271d6ad545a2ccfc237582f70c160e627735c89d0ca2bde24afa321bc0750",
-              "url": "https://files.pythonhosted.org/packages/1f/ce/95f98fe20a7147e7604f170c0c4acf648bb02dc394bb0934817223c58769/ujson-5.1.0-cp39-cp39-musllinux_1_1_x86_64.whl"
+              "hash": "a1a55b3310632661a03ce68ccfb92264031aea21626d6fa5c8f6c32e769be7b6",
+              "url": "https://files.pythonhosted.org/packages/20/52/d1f8e27928295c36537f119c785b596c0a1803e4cccda2155258b3fb1f58/ujson-5.2.0-cp37-cp37m-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4dd97e45a0f450ba2c43cda18147e54b8e41e886c22e3506c62f7d61e9e53b0d",
-              "url": "https://files.pythonhosted.org/packages/30/e5/f74e053d28b585457374d2796a86109ab96430d6d1d3fd335d76290d75ff/ujson-5.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "90de04391916c5adc7bbcc69bd778e263ed45cc83c070099cb07ed25068d6a12",
+              "url": "https://files.pythonhosted.org/packages/26/c8/7bb52cce386ceb333a6bd81d9c37cd39379b12b8f65e63dd091a02bf6438/ujson-5.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "00d6ea9702c2eaeaf1a826934eaba1b4c609c873379bf54e36ba7b7e128edf94",
-              "url": "https://files.pythonhosted.org/packages/32/5e/af834e7074e5dc366296db39801cc71a49229b752b0f8c2d73ab3daba0f8/ujson-5.1.0-cp39-cp39-macosx_10_9_x86_64.whl"
+              "hash": "6c5bbe6de6c9a5fe8dca56e36fb5c4a42e1a01d4aae1ac20cd8d7d82ccff9430",
+              "url": "https://files.pythonhosted.org/packages/27/29/79dea3de6973703fab88df7397fed2a7c71bac3ccb908b8909b636efa8de/ujson-5.2.0-cp39-cp39-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a53c4fe8e1c067e6c98b4526e982ed9486f08578ad8eb5f0e94f8cadf0c1d911",
-              "url": "https://files.pythonhosted.org/packages/36/3c/26d9bfbe3ff376f15a1b4f85863ceca5e220bdb3417c393f7b5ed3755116/ujson-5.1.0-cp39-cp39-macosx_11_0_arm64.whl"
+              "hash": "e991b7b3a08ac9e9d3a51589ef1c359c8d44ece730351cfac055684bf3787372",
+              "url": "https://files.pythonhosted.org/packages/46/3f/a97d0311ba272ec0d8e27e6c57e33efddbbcdf109652fadc35b93e14784e/ujson-5.2.0-cp39-cp39-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "06bed66ae62d517f67a61cf53c056800b35ef364270723168a1db62702e2d30c",
-              "url": "https://files.pythonhosted.org/packages/37/89/e20fba42b968c36b1364381a4e9605d28dc4b2b200d4b56169f595c53a3c/ujson-5.1.0-cp37-cp37m-win32.whl"
+              "hash": "b3671e1dfc49a4b4453d89fd7438aa9d7cca28afe329c70eba84e2a5778dbf3f",
+              "url": "https://files.pythonhosted.org/packages/50/4b/88ae3cdb559fe3608bd4c59e99b1e67c683d7fa5a74b985e8fc7308b18cf/ujson-5.2.0-cp39-cp39-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "994eaf4369e6bc24258f59fe8c6345037abcf24557571814e27879851c4353aa",
-              "url": "https://files.pythonhosted.org/packages/3b/d0/588d65017eeef821294b56da57643405b68fdddd3606d1ef39709349262d/ujson-5.1.0-cp38-cp38-win_amd64.whl"
+              "hash": "ed78a5b169ece75a1e1368935ce6ab051dcbcd5c158b9796b2f1fa6cc467a651",
+              "url": "https://files.pythonhosted.org/packages/54/db/eccd64ff3f1f5a5503dcb6cb66d0eebbffbafe0182721452f48fd5db6e07/ujson-5.2.0-cp38-cp38-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "681fed63c948f757466eeb3aea98873e2ab8b2b18e9020c96a97479a513e2018",
-              "url": "https://files.pythonhosted.org/packages/40/d2/9e0f7942fec07540cb25756c6aac8dca271a82081624df9e9a5f347c38a8/ujson-5.1.0-cp39-cp39-musllinux_1_1_aarch64.whl"
+              "hash": "350a3010db0045e1306bbdf889d1bdaee9bb095856c317716f0a74108cf4afe9",
+              "url": "https://files.pythonhosted.org/packages/57/40/f94d440cf70de423620dc7b3422df2eaf00b56c57052f3257e5a523c3d2d/ujson-5.2.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "caeadbf95ce277f1f8f4f71913bc20c01f49fc9228f238920f9ff6f7645d2a5f",
-              "url": "https://files.pythonhosted.org/packages/48/e1/4543b75faf96dcfd2a0e94443707999e0272cb308c4445f265d82a9ef4ac/ujson-5.1.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "6b455a62bd20e890b2124a65df45313b4292dbea851ef38574e5e2de94691ad5",
+              "url": "https://files.pythonhosted.org/packages/58/54/b202b6884ae9e2116eaba2d44d607f20bb17090d74bf90e3317f92bbb93c/ujson-5.2.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e2b1c372583eb4363b42e21222d3a18116a41973781d502d61e1b0daf4b8352f",
-              "url": "https://files.pythonhosted.org/packages/4b/03/e6ae1beefd8c2be1699631e94136941f2b3ecf895253a9884a2b476dca70/ujson-5.1.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl"
+              "hash": "d2357ce7d93eadd29b6efbe72228809948cc59ec6682c20fa6de08aeef1703f8",
+              "url": "https://files.pythonhosted.org/packages/62/80/1806c6ef9b9de74c8027ee636f1ab7304adde30fb406c2ee64fee80ccd9b/ujson-5.2.0-cp37-cp37m-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "51142c9d40439f299594e399bef8892a16586ded54c88d3af926865ca221a177",
-              "url": "https://files.pythonhosted.org/packages/53/f9/89b88587b2e89d06e3f5a3a618e2473d9f9dd2ac4c217402aa0f8d9484d1/ujson-5.1.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "584c558c23ddc21f5b07d2c54ee527731bd9716101c27829023ab7f3ffbaa8fc",
+              "url": "https://files.pythonhosted.org/packages/63/03/a2cf5bf9a6e31388ee29f6cbaec5eb8800abd5bd53a10eb97781c228cef7/ujson-5.2.0-cp37-cp37m-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "74e41a0222e6e8136e38f103d6cc228e4e20f1c35cc80224a42804fd67fb35c8",
-              "url": "https://files.pythonhosted.org/packages/58/ed/39177f6607508dfe4dc20f120f7b62af04e9ed696d4244391bef66b73221/ujson-5.1.0-cp37-cp37m-win_amd64.whl"
+              "hash": "729af63e4de30c54b527b54b4100266f79833c1e8ba35e784f01b44c2aca88d8",
+              "url": "https://files.pythonhosted.org/packages/64/7e/e80d93e7e4e4012551595b3ba106c313baeb3419d2183628cd98ce63a4e9/ujson-5.2.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7a4bed7bd7b288cf73ba47bda27fdd1d78ef6906831489e7f296aef9e786eccb",
-              "url": "https://files.pythonhosted.org/packages/5c/9a/f47c650fd780badf949e432ea9767623f03b5268f4828a2dd43c5e90a8ca/ujson-5.1.0-cp38-cp38-musllinux_1_1_aarch64.whl"
+              "hash": "fb4555df1fe018806ba14cc38786269c8e213930103c6d0ac81e506d09d1de7e",
+              "url": "https://files.pythonhosted.org/packages/66/ee/4c06c86fc3b7a6175d2681efa877be48d146edcebfd5889afc4af6a8674a/ujson-5.2.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "202ae52f4a53f03c42ead6d046b1a146517e93bd757f517bdeef0a26228e0260",
-              "url": "https://files.pythonhosted.org/packages/5f/2a/433d2436a313cecf2ba9434add7a4e181e9336c93945d4a9d7d745208e03/ujson-5.1.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "2c7712da662b92f80442a8efc0df09cea3a5efb42b0dd6a642e36b1b40a260d4",
+              "url": "https://files.pythonhosted.org/packages/77/30/f36097a9d3824dc2348384082c25a209266d5f002f2acb454dc0e201d8a7/ujson-5.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6fc4376266ae67f6d8f9e69386ab950eb84ba345c6fdbeb1884fa5b773c8c76b",
-              "url": "https://files.pythonhosted.org/packages/60/8c/2f8a0fe1e5c28cd53f0375932ccfbb03f51d49aef7944467e31793970093/ujson-5.1.0-cp39-cp39-musllinux_1_1_i686.whl"
+              "hash": "ef868bf01851869a26c0ca5f88036903836c3a6b463c74d96b37f294f6bdeea4",
+              "url": "https://files.pythonhosted.org/packages/a1/76/c6500e32956e21e9c8c1b78a9861d1db657e98f57460935fb0d267021cf7/ujson-5.2.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8dca10174a3bd482d969a2d12d0aec2fdd63fb974e255ec0147e36a516a2d68a",
-              "url": "https://files.pythonhosted.org/packages/6a/be/d198f7bd29150244e1604b469b82d27501b46a83d1f41b340a94cc090bdd/ujson-5.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "d38c2a58c892c680080b22b59eebd77b7c6f4ae24361111fba115f9ed3651dcf",
+              "url": "https://files.pythonhosted.org/packages/a4/2b/2a0bb2759ec341aa06917f86146ce928ff611797c855ccf6ef44dc604a00/ujson-5.2.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b631af423e6d5d35f9f37fbcc4fbdb6085abc1c441cf864c64b7fbb5b150faf7",
-              "url": "https://files.pythonhosted.org/packages/73/90/d9d1222c274933cfd2d4740c215e3d891a60887cec9f0ad094b99978b555/ujson-5.1.0-cp39-cp39-win32.whl"
+              "hash": "b5fcbaabf3d115cb816eb165f3fa5de5c5bc795473a554ae55620d134ddf2d36",
+              "url": "https://files.pythonhosted.org/packages/a4/98/ce463cbd647f64e003cb6e29ac0bd44183f75c787368e2322c21a4964cce/ujson-5.2.0-cp37-cp37m-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a48efcb5d3695b295c26835ed81048da8cd40e76c4fde2940c807aa452b560c9",
-              "url": "https://files.pythonhosted.org/packages/79/66/1f0a9ac8cd225bbf0b34babd22f4b290ae12688d94505d56792e2d7794b6/ujson-5.1.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "a6f3ad3b11578bc4e25d5bd256c938fe2c7c015d8f504bc7835f127ed26a0818",
+              "url": "https://files.pythonhosted.org/packages/aa/68/4618f0a327ea7fee0c768d2904dc90212bef1872ee484ba8bdc86d3b9d5b/ujson-5.2.0-cp37-cp37m-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a88944d2f99db71a3ca0c63d81f37e55b660edde0b07216fb65a3e46403ef004",
-              "url": "https://files.pythonhosted.org/packages/92/4a/2676677f59709517560b2b7eeb027453e86643d54d04687602e76cca4380/ujson-5.1.0.tar.gz"
+              "hash": "dc71ead5706e81fdf1054c8c11e4aaab43527da450a2701213c20717852d1a51",
+              "url": "https://files.pythonhosted.org/packages/ad/d8/94d8b8225536ee15d1fe15b981f66d36949f61b8714a77ac2e329d3cd39d/ujson-5.2.0-cp38-cp38-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d423956f8dfd98a075c9338b886414b6e3c2817dbf67935797466c998af39936",
-              "url": "https://files.pythonhosted.org/packages/9b/7f/f5ddfe349ce4e5f6507cba8d341c8f6e6060011a189c0dca9a56dabd14e0/ujson-5.1.0-cp38-cp38-musllinux_1_1_i686.whl"
+              "hash": "c519743a53bbe8aac6b743bcf50eb83057d1e0341e1ca8f8491f729a885af640",
+              "url": "https://files.pythonhosted.org/packages/ae/cf/2e813f97e40a18a38f39a8eaa9fcb219369ca2fd11a8152edd32fa9b9f2c/ujson-5.2.0-cp38-cp38-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7bbb87f040e618bebe8c6257b3e4e8ae2f708dcbff3270c84718b3360a152799",
-              "url": "https://files.pythonhosted.org/packages/a0/78/e9bc9b752d1797cacad6b66b60217c76a1d97e6ef39e4c48ac480c3cb66a/ujson-5.1.0-cp38-cp38-macosx_10_9_x86_64.whl"
+              "hash": "080da13f81740c076e5f16c254a10d0e32f45d225a5e6b0687a86493cfcfbafb",
+              "url": "https://files.pythonhosted.org/packages/ae/d8/f897fcf4d10078a61da49e85fca8f7ed39e532509b48496ca6c4432f5d8b/ujson-5.2.0-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9937e819196b894ffd00801b24f1042dabda142f355313c3f20410993219bc4f",
-              "url": "https://files.pythonhosted.org/packages/a1/9a/45d8e23674493cb8cbd4cc942a88391e63ddaaf73fdf64c1d3bc9b6ffa96/ujson-5.1.0-cp37-cp37m-musllinux_1_1_x86_64.whl"
+              "hash": "04a8c388b2d16316df3365c81f368955662581f6a4ff033e9aba2dd1ffc9e05e",
+              "url": "https://files.pythonhosted.org/packages/b0/61/448c5be7ad8e409561772a27411c41c76c64030e458dfa8f5ce6d57ea5fd/ujson-5.2.0-cp37-cp37m-win32.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "31671ad99f0395eb881d698f2871dc64ff00fbd4380c5d9bfd8bff3d4c8f8d88",
-              "url": "https://files.pythonhosted.org/packages/a3/fc/d870b117646ad6e5b69b82cb7ecda512cea0b22f3dbe18a9b8132af24f0b/ujson-5.1.0-cp38-cp38-win32.whl"
+              "hash": "c549d5a7652c3a0dd00ef6ff910fb01878bc116c66c94ac455a55cffa32cc229",
+              "url": "https://files.pythonhosted.org/packages/b5/20/6181c88b1e97fbcc458554c2b58c4574ecc492e21cb434736f45f6306772/ujson-5.2.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "838d35eb9006d36f9241e95958d9f4819bcf1ea2ec155daf92d5751c31bcc62b",
-              "url": "https://files.pythonhosted.org/packages/a8/19/2e0ff19bdf243b5d2e7df7dae5a86d52d22b9df8bb7082bc779a48c814e4/ujson-5.1.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "dc5fd1d5b48edd3cc64e89ea94abe231509fdc938bdeafafe9aef3a05810159f",
+              "url": "https://files.pythonhosted.org/packages/b9/ef/3080abfbbd407f50e75bf09534fce51ca68d272a2e6253946c27d4ad6653/ujson-5.2.0-cp38-cp38-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4155a7c29bf330329519027c815e15e381c1fff22f50d26f135584d482bbd95d",
-              "url": "https://files.pythonhosted.org/packages/b6/b8/55da3ad49e3fceb4df743d7e0f294a3483b415bb272bf7674922953470bf/ujson-5.1.0-cp37-cp37m-macosx_10_9_x86_64.whl"
+              "hash": "49ce8521b0cdf210481bd89887fd1bd0a975f66088b1256dafc77c67c8ccb89d",
+              "url": "https://files.pythonhosted.org/packages/bc/86/5651abde72eedae298d4cc231be0c053cc99fc083fae5685750359cc90b8/ujson-5.2.0-cp38-cp38-win32.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "fdac161127ef8e0889180a4c07475457c55fe0bbd644436d8f4c7ef07565d653",
-              "url": "https://files.pythonhosted.org/packages/b7/35/ed7b4a9f01c0899790a538ae0e67970a1cc29452f2e83b0db9e122eee2fe/ujson-5.1.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "0b47a138203bb06bdac03b2a89ac9b2993fd32cb7daded06c966dd84300a5786",
+              "url": "https://files.pythonhosted.org/packages/bd/f3/b0a65aeca9b342e578a33532186b8f4c5cc34c762fef3e68c0cb3d8291d1/ujson-5.2.0-cp39-cp39-win32.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "fa616d0d3c594785c6e9b7f42686bb1c86f9e64aa0f30a72c86d8eb315f54194",
-              "url": "https://files.pythonhosted.org/packages/d3/41/b47d22fd9e2a469c1c554fb6abadd7927b9337c32a434eb673a1d0939b3d/ujson-5.1.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "9acc874128baddeff908736db251597e4cbd007a384730377a59a61b08886599",
+              "url": "https://files.pythonhosted.org/packages/cc/5c/a5640580f5a020e971f933582b1b087b1b69301015a6a08a41b087ed37f4/ujson-5.2.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ce441ab7ad1db592e2db95b6c2a1eb882123532897340afac1342c28819e9833",
-              "url": "https://files.pythonhosted.org/packages/dd/2f/0a20f217989ee4c86d6ad4a46633b542023a1dc1dfcf8e766433bfaf2fe6/ujson-5.1.0-cp37-cp37m-musllinux_1_1_i686.whl"
+              "hash": "d57a87bbc77d66b8a2b74bab66357c3bb6194f5d248f1053fb8044787abde73f",
+              "url": "https://files.pythonhosted.org/packages/d1/93/f59b2d7c7c0bdc55c1e12fe911beba4d4f5b53576443cc36e599228e4e1e/ujson-5.2.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7ba8be1717b1867a85b2413a8585bad0e4507a22d6af2c244e1c74151f6d5cc0",
-              "url": "https://files.pythonhosted.org/packages/df/ed/ebde97f11ae2329e05eb3dbfaf523dc03ad9abe816491d106a0a9d69484b/ujson-5.1.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "163191b88842d874e081707d35de2e205e0e396e70fd068d1038879bca8b17ad",
+              "url": "https://files.pythonhosted.org/packages/e4/fc/2dee0e78162aa1ad03dadde9a9b5c281d6f8bb0eed6810a270486d8fc041/ujson-5.2.0.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "d0b26d9d6eb9a0979d37f28c715e717a409c9e03163e5cd8fa73aab806351ab5",
-              "url": "https://files.pythonhosted.org/packages/e2/d5/53f1aab25df7e57f5cbe423d6d9ef94bc70825ce73761a0a2a5fc6b96685/ujson-5.1.0-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "54ee7c46615b42f7ae9dca90f54d204a4d2041a4c926b08fffa953aa3a246e54",
+              "url": "https://files.pythonhosted.org/packages/e8/6a/d4d147a69204249390fb4254840d56971f4386e3228136c6383475b2a5d2/ujson-5.2.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "083c1078e4de3a39019e590c43865b17e07a763fee25b012e650bb4f42c89703",
-              "url": "https://files.pythonhosted.org/packages/e2/fd/319e8b563ebf083a841408b4cc46a3f1c22c8ae5d2e4d58463b2f9fd5b9b/ujson-5.1.0-cp38-cp38-musllinux_1_1_x86_64.whl"
+              "hash": "bc1a619bad9894dad144184b735c98179c7d92d7b40fbda28eb8b0857bdfdf52",
+              "url": "https://files.pythonhosted.org/packages/eb/d0/2c0e82b9b8e75aa3b4d26ffad59f8150f0a6aa9093c830f9e6a9bfd5d9b0/ujson-5.2.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "68e38122115a8097fbe1cfe52979a797eaff91c10c1bf4b27774e5f30e7f723a",
-              "url": "https://files.pythonhosted.org/packages/f1/8f/088c5257257013b5cfb3a719ef946f5bf7d1fe9306bfe35458bae13908ec/ujson-5.1.0-cp38-cp38-macosx_11_0_arm64.whl"
+              "hash": "d9b1c3d2b22c040a81ff4e5927ce307919f7ac8bf888afded714d925edc8d0a4",
+              "url": "https://files.pythonhosted.org/packages/f2/7d/7b862b11508b830c02a9179330ceb8c21ccd2ef8dc396720c6b9bbe17a51/ujson-5.2.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5304ad25d100d50b5bc8513ef110335df678f66c7ccf3d4728c0c3aa69e08e0c",
-              "url": "https://files.pythonhosted.org/packages/f4/d4/10c4940d8dd5fc779bfaef913eb153c0b63a34a5fcf940a41207a9e64ae1/ujson-5.1.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "a5e374e793b0a3c7df20ee4c8234e89859ddb2b2821cc3300ae94ab5b08fa6d0",
+              "url": "https://files.pythonhosted.org/packages/f3/e2/3ed4e27844306713c35ebaa3cbea20838b7ad0a157a1efc31a6556f14ef4/ujson-5.2.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "368f855779fded560724a6448838304621f498113a116d66bc5ed5ad5ad3ca92",
-              "url": "https://files.pythonhosted.org/packages/fa/f2/1e5e9e136e2e7aca54086f6eed09a780267a40014d479765bf1736000bdf/ujson-5.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "75a886bd89d8e5a004a39a6c5dc8a43bb7fcf05129d2dccd16a59602a612823a",
+              "url": "https://files.pythonhosted.org/packages/f4/66/4a873a93d82be782d385000e85b0a95aac2df2c0c5d7039a7c778241c0b0/ujson-5.2.0-pp37-pypy37_pp73-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "08265db5ccff8b521ff68aee13a417d68cca784d7e711d961b92fda6ccffcc4f",
-              "url": "https://files.pythonhosted.org/packages/fc/f9/79f0f5a0208c035933c2662d7ab18e5b94c6dacf9359f7e1f23d999e24df/ujson-5.1.0-cp39-cp39-win_amd64.whl"
+              "hash": "468d7d8dcbafc3fd40cc73e4a533a7a1d4f935f605c15ae6cac32c6d53c4c6aa",
+              "url": "https://files.pythonhosted.org/packages/f9/62/26eb7d3ee93590ec89032610254d420489bd77072901d70cc366e77709fc/ujson-5.2.0-cp38-cp38-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b09843123425337d2efee5c8ff6519e4dfc7b044db66c8bd560517fc1070a157",
-              "url": "https://files.pythonhosted.org/packages/ff/23/9b175d1796a0d34dfd3baa60c4d51e5b1312781dccac8e51d73dc3024ccf/ujson-5.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "e53388fb092197cb8f956673792aca994872917d897ca42a0abf7a35e293575a",
+              "url": "https://files.pythonhosted.org/packages/fa/7f/e10190d5e622381182e983277f47f9a3a9eabcb792192c6bd62e13e11d54/ujson-5.2.0-cp38-cp38-macosx_10_9_x86_64.whl"
             }
           ],
           "project_name": "ujson",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "5.1"
+          "version": "5.2"
         },
         {
           "artifacts": [
@@ -1538,13 +1538,13 @@
         }
       ],
       "platform_tag": [
-        "cp36",
-        "cp36m",
-        "macosx_10_16_x86_64"
+        "cp310",
+        "cp310",
+        "manylinux_2_35_x86_64"
       ]
     }
   ],
-  "pex_version": "2.1.76",
+  "pex_version": "2.1.77",
   "prefer_older_binary": false,
   "requirements": [
     "PyYAML<7.0,>=6.0",
@@ -1556,7 +1556,7 @@
     "ijson==3.1.4",
     "mypy-typing-asserts==0.1.1",
     "packaging==21.3",
-    "pex==2.1.76",
+    "pex==2.1.77",
     "psutil==5.9.0",
     "pydevd-pycharm==203.5419.8",
     "pytest<7.1.0,>=6.2.4",

--- a/src/python/pants/backend/python/subsystems/lambdex.lock
+++ b/src/python/pants/backend/python/subsystems/lambdex.lock
@@ -49,13 +49,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "3e131489681ec9003c3d4bb98cf22b1a60cf6dcd0e6690cbe18301e63134a48f",
-              "url": "https://files.pythonhosted.org/packages/ba/05/3c490316c42ea0772fdd68bd105473b8120941bfdedf9281f8e43311a399/pex-2.1.76-py2.py3-none-any.whl"
+              "hash": "e0f0e754e9e1fdadb8e7d5e0bd0e1f4710fbb57b679ec91e6e5d7313aa12b64d",
+              "url": "https://files.pythonhosted.org/packages/a3/01/aea843da3bdb4d1ee12855e3bb237dfa6f8492b5ff59f7ac644a87719bbf/pex-2.1.77-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6bf7b4b73ebb411ed2498411b77b49aa008624b9faa22d3edc732983c34a447f",
-              "url": "https://files.pythonhosted.org/packages/49/c9/bfeab0a623e6e2ab1a900094a90e326ff00a2a642114b78393f5813505af/pex-2.1.76.tar.gz"
+              "hash": "96fcd16fe9b76b70e68a6cd522ba286c968d7b63ee32869d6f8f18c21c4256f0",
+              "url": "https://files.pythonhosted.org/packages/0c/88/d7a15de41f1cfe2941613bbddc23602b3f688fa76ee3d7bbf09713dca9f6/pex-2.1.77.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -63,7 +63,7 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.11,>=2.7",
-          "version": "2.1.76"
+          "version": "2.1.77"
         }
       ],
       "platform_tag": [
@@ -73,7 +73,7 @@
       ]
     }
   ],
-  "pex_version": "2.1.76",
+  "pex_version": "2.1.77",
   "prefer_older_binary": false,
   "requirements": [
     "lambdex==0.1.6"

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -39,9 +39,9 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."
 
-    default_version = "v2.1.76"
+    default_version = "v2.1.77"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.1.76,<3.0"
+    version_constraints = ">=2.1.77,<3.0"
 
     @classproperty
     def default_known_versions(cls):
@@ -50,8 +50,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "71c9a67b7bf8ede5f1bdacbbc2bd3e3df4395499623d9d0d5dfee40ae38ab941",
-                    "3731258",
+                    "7b02ea666c34367b2c841a76e822afd5ccafb1ae44b01b3053044b3323df2524",
+                    "3732702",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64"]


### PR DESCRIPTION
This pulls in a fix for pathologically slow locks.

See the changelog here:
  https://github.com/pantsbuild/pex/releases/tag/v2.1.77

Fixes #14998

[ci skip-rust]
[ci skip-build-wheels]