### PR TITLE
Upgrade Pex to 2.1.73. (Cherry-pick of #14875)

### DIFF
--- a/3rdparty/python/lockfiles/user_reqs.txt
+++ b/3rdparty/python/lockfiles/user_reqs.txt
@@ -17,7 +17,7 @@
 #     "humbug==0.2.7",
 #     "ijson==3.1.4",
 #     "packaging==21.3",
-#     "pex==2.1.71",
+#     "pex==2.1.73",
 #     "psutil==5.9.0",
 #     "pydevd-pycharm==203.5419.8",
 #     "pytest<8,>=6.2.4",
@@ -39,10 +39,10 @@
 ansicolors==1.1.8 \
     --hash=sha256:00d2dde5a675579325902536738dd27e4fac1fd68f773fe36c21044eb559e187 \
     --hash=sha256:99f94f5e3348a0bcd43c82e5fc4414013ccc19d70bd939ad71e0133ce9c372e0
-atomicwrites==1.4.0; python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.4.0" \
+atomicwrites==1.4.0; python_version >= "3.7" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.7" and python_full_version >= "3.4.0" \
     --hash=sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197 \
     --hash=sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a
-attrs==21.4.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6" \
+attrs==21.4.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7" \
     --hash=sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4 \
     --hash=sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd
 certifi==2021.10.8; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" \
@@ -54,7 +54,7 @@ charset-normalizer==2.0.12; python_full_version >= "3.6.0" and python_version >=
 chevron==0.14.0 \
     --hash=sha256:fbf996a709f8da2e745ef763f482ce2d311aa817d287593a5b990d6d6e4f0443 \
     --hash=sha256:87613aafdf6d77b6a90ff073165a61ae5086e21ad49057aa0e53681601800ebf
-colorama==0.4.4; python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.5.0" \
+colorama==0.4.4; python_version >= "3.7" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.7" and python_full_version >= "3.5.0" \
     --hash=sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2 \
     --hash=sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b
 fasteners==0.16.3 \
@@ -132,19 +132,19 @@ ijson==3.1.4 \
     --hash=sha256:97e4df67235fae40d6195711223520d2c5bf1f7f5087c2963fcde44d72ebf448 \
     --hash=sha256:3d10eee52428f43f7da28763bb79f3d90bbbeea1accb15de01e40a00885b6e89 \
     --hash=sha256:1d1003ae3c6115ec9b587d29dd136860a81a23c7626b682e2b5b12c9fd30e4ea
-importlib-metadata==4.11.2; python_version < "3.8" and python_version >= "3.7" \
-    --hash=sha256:d16e8c1deb60de41b8e8ed21c1a7b947b0bc62fab7e1d470bcdf331cea2e6735 \
-    --hash=sha256:b36ffa925fe3139b2f6ff11d6925ffd4fa7bc47870165e3ac260ac7b4f91e6ac
-iniconfig==1.1.1; python_version >= "3.6" \
+importlib-metadata==4.11.3; python_version < "3.8" and python_version >= "3.7" \
+    --hash=sha256:1208431ca90a8cca1a6b8af391bb53c1a2db74e5d1cef6ddced95d4b2062edc6 \
+    --hash=sha256:ea4c597ebf37142f827b8f39299579e31685c31d3a438b59f469406afd0f2539
+iniconfig==1.1.1; python_version >= "3.7" \
     --hash=sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3 \
     --hash=sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32
 packaging==21.3; python_version >= "3.6" \
     --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522 \
     --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb
-pex==2.1.71; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0" and python_version < "3.11") \
-    --hash=sha256:7b65897566bb5bcbc2d3c62adaad61db3a2a100244250ec61dcd59a3e4f5fe1f \
-    --hash=sha256:8c9ec9e2ea432f55f512eb7591459d26edc88769a178d16dd3023e41364c2a8c
-pluggy==1.0.0; python_version >= "3.6" \
+pex==2.1.73; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0" and python_version < "3.11") \
+    --hash=sha256:b6610d4f25fbf49f93997f2a889959f064ede535529e1355748b4a116e3b0352 \
+    --hash=sha256:3b1226d2f147d0969d68a306aca34d8fc980eee7b591ace3a5ab922ba5cd1a25
+pluggy==1.0.0; python_version >= "3.7" \
     --hash=sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3 \
     --hash=sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159
 psutil==5.9.0; (python_version >= "2.6" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0") \
@@ -180,17 +180,17 @@ psutil==5.9.0; (python_version >= "2.6" and python_full_version < "3.0.0") or (p
     --hash=sha256:4e2fb92e3aeae3ec3b7b66c528981fd327fb93fd906a77215200404444ec1845 \
     --hash=sha256:7d190ee2eaef7831163f254dc58f6d2e2a22e27382b936aab51c835fc080c3d3 \
     --hash=sha256:869842dbd66bb80c3217158e629d6fceaecc3a3166d3d1faee515b05dd26ca25
-py==1.11.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6" \
+py==1.11.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7" \
     --hash=sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378 \
     --hash=sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719
 pydevd-pycharm==203.5419.8 \
     --hash=sha256:21e8035830546d89caf8669b0d01d4626c9c8d51799b591d522a6fd5a50b539c
-pyparsing==3.0.7; python_version >= "3.6" \
+pyparsing==3.0.7; python_version >= "3.7" \
     --hash=sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484 \
     --hash=sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea
-pytest==7.0.1; python_version >= "3.6" \
-    --hash=sha256:9ce3ff477af913ecf6321fe337b93a2c0dcf2a0a1439c43f5452112c1e4280db \
-    --hash=sha256:e30905a0c131d3d94b89624a1cc5afec3e0ba2fbdb151867d8e0ebd49850f171
+pytest==7.1.1; python_version >= "3.7" \
+    --hash=sha256:92f723789a8fdd7180b6b06483874feca4c48a5c76968e03bb3e7f806a1869ea \
+    --hash=sha256:841132caef6b1ad17a9afde46dc4f6cfa59a05f9555aae5151f73bdf2820ca63
 python-dateutil==2.8.2; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5" \
     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
     --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9
@@ -283,66 +283,66 @@ types-setuptools==57.4.7 \
 types-toml==0.10.3 \
     --hash=sha256:215a7a79198651ec5bdfd66193c1e71eb681a42f3ef7226c9af3123ced62564a \
     --hash=sha256:988457744d9774d194e3539388772e3a685d8057b7c4a89407afeb0a6cbd1b14
-types-urllib3==1.26.10 \
-    --hash=sha256:a26898f530e6c3f43f25b907f2b884486868ffd56a9faa94cbf9b3eb6e165d6a \
-    --hash=sha256:d755278d5ecd7a7a6479a190e54230f241f1a99c19b81518b756b19dc69e518c
+types-urllib3==1.26.11 \
+    --hash=sha256:24d64e441168851eb05f1d022de18ae31558f5649c8f1117e384c2e85e31315b \
+    --hash=sha256:bd0abc01e9fb963e4fddd561a56d21cc371b988d1245662195c90379077139cd
 typing-extensions==4.0.1; python_version >= "3.6" \
     --hash=sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b \
     --hash=sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e
-ujson==5.1.0; python_version >= "3.7" \
-    --hash=sha256:644552d1e89983c08d0c24358fbcb5829ae5b5deee9d876e16d20085cfa7dc81 \
-    --hash=sha256:0cae4a9c141856f7ad1a79c17ff1aaebf7fd8faa2f2c2614c37d6f82ed261d96 \
-    --hash=sha256:4ba63b789d83ca92237dbc72041a268d91559f981c01763a107105878bae442e \
-    --hash=sha256:fe4e8f71e2fd42dce245bace7e2aa97dabef13926750a351eadca89a1e0f1abd \
-    --hash=sha256:6f73946c047a38640b1f5a2a459237b7bdc417ab028a76c796e4eea984b359b9 \
-    --hash=sha256:afe91153c2046fa8210b92def513124e0ea5b87ad8fa4c14fef8197204b980f1 \
-    --hash=sha256:b1ef400fc73ab0cb61b74a662ad4207917223aba6f933a9fea9b0fbe75de2361 \
-    --hash=sha256:5c8a884d60dd2eed2fc95a9474d57ead82adf254f54caffb3d9e8ed185c49aba \
-    --hash=sha256:173b90a2c2836ee42f708df88ecfe3efbc4d868df73c9fcea8cb8f6f3ab93892 \
-    --hash=sha256:6c45ad95e82155372d9908774db46e0ef7880af28a734d0b14eaa4f505e64982 \
-    --hash=sha256:4155a7c29bf330329519027c815e15e381c1fff22f50d26f135584d482bbd95d \
-    --hash=sha256:fa616d0d3c594785c6e9b7f42686bb1c86f9e64aa0f30a72c86d8eb315f54194 \
-    --hash=sha256:a48efcb5d3695b295c26835ed81048da8cd40e76c4fde2940c807aa452b560c9 \
-    --hash=sha256:838d35eb9006d36f9241e95958d9f4819bcf1ea2ec155daf92d5751c31bcc62b \
-    --hash=sha256:05aa6c7297a22081f65497b6f586de6b7060ea47c3ecda80896f47200e9dbf04 \
-    --hash=sha256:ce441ab7ad1db592e2db95b6c2a1eb882123532897340afac1342c28819e9833 \
-    --hash=sha256:9937e819196b894ffd00801b24f1042dabda142f355313c3f20410993219bc4f \
-    --hash=sha256:06bed66ae62d517f67a61cf53c056800b35ef364270723168a1db62702e2d30c \
-    --hash=sha256:74e41a0222e6e8136e38f103d6cc228e4e20f1c35cc80224a42804fd67fb35c8 \
-    --hash=sha256:7bbb87f040e618bebe8c6257b3e4e8ae2f708dcbff3270c84718b3360a152799 \
-    --hash=sha256:68e38122115a8097fbe1cfe52979a797eaff91c10c1bf4b27774e5f30e7f723a \
-    --hash=sha256:b09843123425337d2efee5c8ff6519e4dfc7b044db66c8bd560517fc1070a157 \
-    --hash=sha256:8dca10174a3bd482d969a2d12d0aec2fdd63fb974e255ec0147e36a516a2d68a \
-    --hash=sha256:202ae52f4a53f03c42ead6d046b1a146517e93bd757f517bdeef0a26228e0260 \
-    --hash=sha256:7a4bed7bd7b288cf73ba47bda27fdd1d78ef6906831489e7f296aef9e786eccb \
-    --hash=sha256:d423956f8dfd98a075c9338b886414b6e3c2817dbf67935797466c998af39936 \
-    --hash=sha256:083c1078e4de3a39019e590c43865b17e07a763fee25b012e650bb4f42c89703 \
-    --hash=sha256:31671ad99f0395eb881d698f2871dc64ff00fbd4380c5d9bfd8bff3d4c8f8d88 \
-    --hash=sha256:994eaf4369e6bc24258f59fe8c6345037abcf24557571814e27879851c4353aa \
-    --hash=sha256:00d6ea9702c2eaeaf1a826934eaba1b4c609c873379bf54e36ba7b7e128edf94 \
-    --hash=sha256:a53c4fe8e1c067e6c98b4526e982ed9486f08578ad8eb5f0e94f8cadf0c1d911 \
-    --hash=sha256:368f855779fded560724a6448838304621f498113a116d66bc5ed5ad5ad3ca92 \
-    --hash=sha256:4dd97e45a0f450ba2c43cda18147e54b8e41e886c22e3506c62f7d61e9e53b0d \
-    --hash=sha256:caeadbf95ce277f1f8f4f71913bc20c01f49fc9228f238920f9ff6f7645d2a5f \
-    --hash=sha256:681fed63c948f757466eeb3aea98873e2ab8b2b18e9020c96a97479a513e2018 \
-    --hash=sha256:6fc4376266ae67f6d8f9e69386ab950eb84ba345c6fdbeb1884fa5b773c8c76b \
-    --hash=sha256:585271d6ad545a2ccfc237582f70c160e627735c89d0ca2bde24afa321bc0750 \
-    --hash=sha256:b631af423e6d5d35f9f37fbcc4fbdb6085abc1c441cf864c64b7fbb5b150faf7 \
-    --hash=sha256:08265db5ccff8b521ff68aee13a417d68cca784d7e711d961b92fda6ccffcc4f \
-    --hash=sha256:e2b1c372583eb4363b42e21222d3a18116a41973781d502d61e1b0daf4b8352f \
-    --hash=sha256:51142c9d40439f299594e399bef8892a16586ded54c88d3af926865ca221a177 \
-    --hash=sha256:7ba8be1717b1867a85b2413a8585bad0e4507a22d6af2c244e1c74151f6d5cc0 \
-    --hash=sha256:d0b26d9d6eb9a0979d37f28c715e717a409c9e03163e5cd8fa73aab806351ab5 \
-    --hash=sha256:b2c7e4afde0d36926b091fa9613b18b65e911fcaa60024e8721f2dcfedc25329 \
-    --hash=sha256:110633a8dda6c8ca78090292231e15381f8b2423e998399d4bc5f135149c722b \
-    --hash=sha256:fdac161127ef8e0889180a4c07475457c55fe0bbd644436d8f4c7ef07565d653 \
-    --hash=sha256:452990c2b18445a7379a45873527d2ec47789b9289c13a17a3c1cc76b9641126 \
-    --hash=sha256:5304ad25d100d50b5bc8513ef110335df678f66c7ccf3d4728c0c3aa69e08e0c \
-    --hash=sha256:ce620a6563b21aa3fbb1658bc1bfddb484a6dad542de1efb5121eb7bb4f2b93a \
-    --hash=sha256:a88944d2f99db71a3ca0c63d81f37e55b660edde0b07216fb65a3e46403ef004
-urllib3==1.26.8; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "4" \
-    --hash=sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed \
-    --hash=sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c
-zipp==3.7.0; python_version < "3.8" and python_version >= "3.7" \
-    --hash=sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375 \
-    --hash=sha256:9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d
+ujson==5.2.0; python_version >= "3.7" \
+    --hash=sha256:754e9da96a24535ae5ab2a52e1d1dfc65a6a717c14063855b83f327fdf2173ea \
+    --hash=sha256:6227597d0201ceadc902d1a8edaffaeb244050b197368ed25e6f6be0df170a6f \
+    --hash=sha256:be909514a47b6272e34cd1213feee324ca35a354e07f1ae3aba12d3694a5279f \
+    --hash=sha256:489d495431c80dc0048c4551a0d6cdbf1209e2d274f47c3f72415c91842eeb68 \
+    --hash=sha256:4d1ed3897e45477b2a4a1371186df299b13938d4d44d850953a4bb0ea4cb38f3 \
+    --hash=sha256:102b8eb5e15e6c5537426414d180c28dbf0489e51f7c22b706511ac84aae4458 \
+    --hash=sha256:2c04456de1fc92cc7062904c176c74e6ea220469b949508be42e819646a28457 \
+    --hash=sha256:a3c6798035b574ceba747de83f3223a622622b7ab77a24f8b4fbea2cb92f14b0 \
+    --hash=sha256:27a254a150e46980608b16ef3b609e703173492cfa738f4644c81d7e7d77494c \
+    --hash=sha256:8c3f7578a62d9255650ef32e78d3345e98262e064c9ba3f205311b4c9eb507a6 \
+    --hash=sha256:584c558c23ddc21f5b07d2c54ee527731bd9716101c27829023ab7f3ffbaa8fc \
+    --hash=sha256:d57a87bbc77d66b8a2b74bab66357c3bb6194f5d248f1053fb8044787abde73f \
+    --hash=sha256:fb4555df1fe018806ba14cc38786269c8e213930103c6d0ac81e506d09d1de7e \
+    --hash=sha256:d38c2a58c892c680080b22b59eebd77b7c6f4ae24361111fba115f9ed3651dcf \
+    --hash=sha256:a6f3ad3b11578bc4e25d5bd256c938fe2c7c015d8f504bc7835f127ed26a0818 \
+    --hash=sha256:b5fcbaabf3d115cb816eb165f3fa5de5c5bc795473a554ae55620d134ddf2d36 \
+    --hash=sha256:a1a55b3310632661a03ce68ccfb92264031aea21626d6fa5c8f6c32e769be7b6 \
+    --hash=sha256:04a8c388b2d16316df3365c81f368955662581f6a4ff033e9aba2dd1ffc9e05e \
+    --hash=sha256:d2357ce7d93eadd29b6efbe72228809948cc59ec6682c20fa6de08aeef1703f8 \
+    --hash=sha256:e53388fb092197cb8f956673792aca994872917d897ca42a0abf7a35e293575a \
+    --hash=sha256:dc71ead5706e81fdf1054c8c11e4aaab43527da450a2701213c20717852d1a51 \
+    --hash=sha256:350a3010db0045e1306bbdf889d1bdaee9bb095856c317716f0a74108cf4afe9 \
+    --hash=sha256:9acc874128baddeff908736db251597e4cbd007a384730377a59a61b08886599 \
+    --hash=sha256:c549d5a7652c3a0dd00ef6ff910fb01878bc116c66c94ac455a55cffa32cc229 \
+    --hash=sha256:ed78a5b169ece75a1e1368935ce6ab051dcbcd5c158b9796b2f1fa6cc467a651 \
+    --hash=sha256:468d7d8dcbafc3fd40cc73e4a533a7a1d4f935f605c15ae6cac32c6d53c4c6aa \
+    --hash=sha256:dc5fd1d5b48edd3cc64e89ea94abe231509fdc938bdeafafe9aef3a05810159f \
+    --hash=sha256:49ce8521b0cdf210481bd89887fd1bd0a975f66088b1256dafc77c67c8ccb89d \
+    --hash=sha256:c519743a53bbe8aac6b743bcf50eb83057d1e0341e1ca8f8491f729a885af640 \
+    --hash=sha256:b3671e1dfc49a4b4453d89fd7438aa9d7cca28afe329c70eba84e2a5778dbf3f \
+    --hash=sha256:11f735870f189bff1841c720115226894415ab6a7796dee8ab46bc767ea2e743 \
+    --hash=sha256:90de04391916c5adc7bbcc69bd778e263ed45cc83c070099cb07ed25068d6a12 \
+    --hash=sha256:2c7712da662b92f80442a8efc0df09cea3a5efb42b0dd6a642e36b1b40a260d4 \
+    --hash=sha256:d9b1c3d2b22c040a81ff4e5927ce307919f7ac8bf888afded714d925edc8d0a4 \
+    --hash=sha256:6c5bbe6de6c9a5fe8dca56e36fb5c4a42e1a01d4aae1ac20cd8d7d82ccff9430 \
+    --hash=sha256:940f35e9a0969440621445dbb6adffaa2cea77d0262abc74fce78704120c4534 \
+    --hash=sha256:6677bee8690c71f5e6cf519a6d8400f04fbd3ff9f6c50f35f1b664bc94546f84 \
+    --hash=sha256:0b47a138203bb06bdac03b2a89ac9b2993fd32cb7daded06c966dd84300a5786 \
+    --hash=sha256:e991b7b3a08ac9e9d3a51589ef1c359c8d44ece730351cfac055684bf3787372 \
+    --hash=sha256:d1e5c635b7c3465ab8d2e3dc97c341ef1801c53a378f1d1d4cb934f6c90ec66c \
+    --hash=sha256:ef868bf01851869a26c0ca5f88036903836c3a6b463c74d96b37f294f6bdeea4 \
+    --hash=sha256:a5e374e793b0a3c7df20ee4c8234e89859ddb2b2821cc3300ae94ab5b08fa6d0 \
+    --hash=sha256:080da13f81740c076e5f16c254a10d0e32f45d225a5e6b0687a86493cfcfbafb \
+    --hash=sha256:75a886bd89d8e5a004a39a6c5dc8a43bb7fcf05129d2dccd16a59602a612823a \
+    --hash=sha256:54ee7c46615b42f7ae9dca90f54d204a4d2041a4c926b08fffa953aa3a246e54 \
+    --hash=sha256:6b455a62bd20e890b2124a65df45313b4292dbea851ef38574e5e2de94691ad5 \
+    --hash=sha256:bc1a619bad9894dad144184b735c98179c7d92d7b40fbda28eb8b0857bdfdf52 \
+    --hash=sha256:729af63e4de30c54b527b54b4100266f79833c1e8ba35e784f01b44c2aca88d8 \
+    --hash=sha256:25522c674b35c33f375586ac98d92ce731e79059424507ecbccbfcbce832d597 \
+    --hash=sha256:163191b88842d874e081707d35de2e205e0e396e70fd068d1038879bca8b17ad
+urllib3==1.26.9; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "4" \
+    --hash=sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14 \
+    --hash=sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e
+zipp==3.8.0; python_version < "3.8" and python_version >= "3.7" \
+    --hash=sha256:c4f6e5bbf48e74f7a38e7cc5b0480ff42b0ae5178957d564d18932525d5cf099 \
+    --hash=sha256:56bf8aadb83c24db6c4b577e13de374ccfb67da2078beba1d037c17980bf43ad

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -14,7 +14,7 @@ humbug==0.2.7
 
 ijson==3.1.4
 packaging==21.3
-pex==2.1.71
+pex==2.1.73
 psutil==5.9.0
 pytest>=6.2.4,<8  # This should be compatible with pytest.py, although it can be looser so that we don't over-constrain pantsbuild.pants.testutil
 python-lsp-jsonrpc==1.0.0

--- a/src/python/pants/backend/python/subsystems/lambdex_lockfile.txt
+++ b/src/python/pants/backend/python/subsystems/lambdex_lockfile.txt
@@ -17,6 +17,6 @@
 lambdex==0.1.6; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0" and python_version < "3.10") \
     --hash=sha256:cb685b106617fbd1afd26d6e9472b2e0c99df8574c6d358aee4e6c13aeef8eb1 \
     --hash=sha256:6d1a95c8a31baa703edece8e36a705045b0203c7e886812c27a4dd945aa694e0
-pex==2.1.71; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "3.10" \
-    --hash=sha256:7b65897566bb5bcbc2d3c62adaad61db3a2a100244250ec61dcd59a3e4f5fe1f \
-    --hash=sha256:8c9ec9e2ea432f55f512eb7591459d26edc88769a178d16dd3023e41364c2a8c
+pex==2.1.77; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "3.10" \
+    --hash=sha256:e0f0e754e9e1fdadb8e7d5e0bd0e1f4710fbb57b679ec91e6e5d7313aa12b64d \
+    --hash=sha256:96fcd16fe9b76b70e68a6cd522ba286c968d7b63ee32869d6f8f18c21c4256f0

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -42,9 +42,9 @@ class PexCli(TemplatedExternalTool):
     deprecated_options_scope = "download-pex-bin"
     deprecated_options_scope_removal_version = "2.11.0.dev0"
 
-    default_version = "v2.1.71"
+    default_version = "v2.1.73"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.1.71,<3.0"
+    version_constraints = ">=2.1.73,<3.0"
 
     @classproperty
     def default_known_versions(cls):
@@ -53,8 +53,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "d7fddbdfc374b78768fee6729a53077593a6ad6834df401fff4061ad5602cb19",
-                    "3734831",
+                    "0f30b06c02743393b745497580a410d28055b0de022a27cbb8e460845a6ba1c9",
+                    "3723175",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64"]


### PR DESCRIPTION
This picks up several lockfile fixes.

See the changelog here:
  https://github.com/pantsbuild/pex/releases/tag/v2.1.73

Fixes #14857
Fixes #14859

(cherry picked from commit 365407d6bcfbc7764488d3950dc152a6ed9d3a1e)

Prompted by #14983

[ci skip-rust]
[ci skip-build-wheels]