### PR TITLE
Avoid previous releases for `pants_requirements`.

### DIFF
--- a/src/python/pants/backend/plugin_development/pants_requirements.py
+++ b/src/python/pants/backend/plugin_development/pants_requirements.py
@@ -16,7 +16,8 @@ from pants.engine.target import (
     TargetGenerator,
 )
 from pants.engine.unions import UnionRule
-from pants.version import MAJOR_MINOR, PANTS_SEMVER
+from pants.util.strutil import softwrap
+from pants.version import PANTS_SEMVER
 
 
 class PantsRequirementsTestutilField(BoolField):
@@ -27,20 +28,24 @@ class PantsRequirementsTestutilField(BoolField):
 
 class PantsRequirementsTargetGenerator(TargetGenerator):
     alias = "pants_requirements"
-    help = (
-        "Generate `python_requirement` targets for Pants itself to use with Pants plugins.\n\n"
-        "This is useful when writing plugins so that you can build and test your "
-        "plugin using Pants. The generated targets will have the correct version based on the "
-        "`version` in your `pants.toml`, and they will work with dependency inference.\n\n"
-        "Because the Plugin API is not yet stable, the version is set automatically for you "
-        "to improve stability. If you're currently using a dev release, the version will be set to "
-        "that exact dev release. If you're using a release candidate (rc) or stable release, the "
-        "version will allow any non-dev-release release within the release series, e.g. "
-        f"`>={MAJOR_MINOR}.0rc0,<{PANTS_SEMVER.major}.{PANTS_SEMVER.minor + 1}`.\n\n"
-        "(If this versioning scheme does not work for you, you can directly create "
-        "`python_requirement` targets for `pantsbuild.pants` and `pantsbuild.pants.testutil`. We "
-        "also invite you to share your ideas at "
-        "https://github.com/pantsbuild/pants/issues/new/choose)"
+    help = softwrap(
+        f"""
+        Generate `python_requirement` targets for Pants itself to use with Pants plugins.
+
+        This is useful when writing plugins so that you can build and test your plugin using
+        Pants. The generated targets will have the correct version based on the `version` in your
+        `pants.toml`, and they will work with dependency inference.
+
+        Because the Plugin API is not yet stable, the version is set automatically for you to
+        improve stability. If you're currently using a dev release, the version will be set to that
+        exact dev release. If you're using a release candidate (rc) or stable release, the version
+        will allow any non-dev-release release within the release series going forward,
+        e.g. `>={PANTS_SEMVER},<{PANTS_SEMVER.major}.{PANTS_SEMVER.minor + 1}`.
+
+        (If this versioning scheme does not work for you, you can directly create
+        `python_requirement` targets for `pantsbuild.pants` and `pantsbuild.pants.testutil`. We also
+        invite you to share your ideas at https://github.com/pantsbuild/pants/issues/new/choose)
+        """
     )
     generated_target_cls = PythonRequirementTarget
     core_fields = (
@@ -57,11 +62,9 @@ class GenerateFromPantsRequirementsRequest(GenerateTargetsRequest):
 
 def determine_version() -> str:
     # Because the Plugin API is not stable, it can have breaking changes in-between dev releases.
-    # Technically, it can also have breaking changes between rcs in the same release series, but
-    # this is much less likely.
     #
     # So, we require exact matches when developing against a dev release, but only require
-    # matching the release series if on an rc or stable release.
+    # matching the release series going forward if on an rc or stable release.
     #
     # If this scheme does not work for users, they can:
     #
@@ -71,10 +74,7 @@ def determine_version() -> str:
     return (
         f"=={PANTS_SEMVER}"
         if PANTS_SEMVER.is_devrelease
-        else (
-            f">={PANTS_SEMVER.major}.{PANTS_SEMVER.minor}.0rc0,"
-            f"<{PANTS_SEMVER.major}.{PANTS_SEMVER.minor + 1}"
-        )
+        else f">={PANTS_SEMVER},<{PANTS_SEMVER.major}.{PANTS_SEMVER.minor + 1}"
     )
 
 

--- a/src/python/pants/backend/plugin_development/pants_requirements_test.py
+++ b/src/python/pants/backend/plugin_development/pants_requirements_test.py
@@ -24,8 +24,9 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
     "pants_version,expected",
     (
         ("2.4.0.dev1", "==2.4.0.dev1"),
-        ("2.4.0rc1", ">=2.4.0rc0,<2.5"),
-        ("2.4.0", ">=2.4.0rc0,<2.5"),
+        ("2.4.0rc1", ">=2.4.0rc1,<2.5"),
+        ("2.4.0", ">=2.4.0,<2.5"),
+        ("2.4.5", ">=2.4.5,<2.5"),
     ),
 )
 def test_determine_version(monkeypatch, pants_version: str, expected: str) -> None:


### PR DESCRIPTION
In order to avoid surprises when there are subtle or unforeseen changes between stable patch releases, the `pants_requirements` target should pin from the current version and up to but not including the next stable release.

Edit: The original issue was caused by a bad interpreter constraint, and had nothing to do with the required versions.
Original text:
~To avoid situations where changed dependencies between rc's (or patch versions) may cause resolve conflicts for lock files, keep the lower bound on the constraint at the current Pants version, rather than snapping to the first `.0rc0` version in the stable release series.~

```
  ProcessExecutionFailure: Process 'Generate lockfile for 3rdparty-deps' failed with exit code 1.
stdout:

stderr:
ERROR: Cannot install pantsbuild-pants==2.11.0rc0 and pantsbuild-pants==2.11.0rc1 because these package versions have conflicting dependencies.
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies
pid 8619 -> /Users/x/.cache/pants/named_caches/pex_root/venvs/d73eb1958462afae0ef27208a6356f1bd127bac9/5227c1516c74d286d844078a1012386b2283a2d5/pex --disable-pip-version-check --no-python-version-warning --exists-action a --isolated -q --cache-dir /Users/x/.cache/pants/named_caches/pex_root --log /private/tmp/tmp9rzue6fg/pip.log download --dest /private/tmp/tmprv074hpp/Users.x..pyenv.versions.3.7.12.bin.python3.7 pantsbuild.pants.testutil<2.12,>=2.11.0rc0 pantsbuild.pants<2.12,>=2.11.0rc0 --index-url https://pypi.org/simple/ --retries 5 --timeout 15 exited with 1 and STDERR:
 
 The conflict is caused by:
     pantsbuild-pants 2.11.0rc1 depends on pex==2.1.75
     pantsbuild-pants 2.11.0rc0 depends on pex==2.1.72
 
 To fix this you could try to:
 1. loosen the range of package versions you've specified
 2. remove package versions to allow pip attempt to solve the dependency conflict
 ```

