### PR TITLE
Text in angle brackets needs to be escaped for the docsite.

### DIFF
--- a/src/python/pants/backend/codegen/thrift/apache/subsystem.py
+++ b/src/python/pants/backend/codegen/thrift/apache/subsystem.py
@@ -25,7 +25,7 @@ class ApacheThriftSubsystem(Subsystem):
             Specify absolute paths to directories with the `thrift` binary, e.g. `/usr/bin`.
             Earlier entries will be searched first.
 
-            The special string '<PATH>' will expand to the contents of the PATH env var.
+            The special string `"<PATH>"` will expand to the contents of the PATH env var.
             """
         ),
     )

--- a/src/python/pants/backend/go/subsystems/golang.py
+++ b/src/python/pants/backend/go/subsystems/golang.py
@@ -38,7 +38,7 @@ class GolangSubsystem(Subsystem):
             "A list of paths to search for Go.\n\n"
             "Specify absolute paths to directories with the `go` binary, e.g. `/usr/bin`. "
             "Earlier entries will be searched first.\n\n"
-            "The special string '<PATH>' will expand to the contents of the PATH env var."
+            'The special string `"<PATH>"` will expand to the contents of the PATH env var.'
         ),
     )
     # TODO(#13005): Support multiple Go versions in a project?

--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -36,7 +36,7 @@ class PexRuntimeEnvironment(Subsystem):
         default=["<PATH>"],
         help=(
             "The PATH value that will be used by the PEX subprocess and any subprocesses it "
-            'spawns.\n\nThe special string "<PATH>" will expand to the contents of the PATH '
+            'spawns.\n\nThe special string `"<PATH>"` will expand to the contents of the PATH '
             "env var."
         ),
         advanced=True,

--- a/src/python/pants/backend/shell/shell_setup.py
+++ b/src/python/pants/backend/shell/shell_setup.py
@@ -22,7 +22,7 @@ class ShellSetup(Subsystem):
         help=(
             "The PATH value that will be used to find shells and to run certain processes "
             "like the shunit2 test runner.\n\n"
-            'The special string "<PATH>" will expand to the contents of the PATH env var.'
+            'The special string `"<PATH>"` will expand to the contents of the PATH env var.'
         ),
         advanced=True,
         metavar="<binary-paths>",


### PR DESCRIPTION
This fixes an issue with the docs, that look like this:
![image](https://user-images.githubusercontent.com/72965/162218498-d11711c3-0a34-499e-9496-25cdc1891cc2.png)
