### PR TITLE
Prepare the 2.10.1rc0 release.

### DIFF
--- a/src/python/pants/notes/2.10.x.md
+++ b/src/python/pants/notes/2.10.x.md
@@ -1,5 +1,23 @@
 # 2.10.x Release Series
 
+## 2.10.1rc0 (Apr 07, 2022)
+
+### User API Changes
+
+* Upgrade Pex to 2.1.73. (Cherry-pick of #14875) ([#15028](https://github.com/pantsbuild/pants/pull/15028))
+
+### Bug fixes
+
+* Do not use a repository-PEX if a PEX has platforms specified (cherrypick of #15031) ([#15033](https://github.com/pantsbuild/pants/pull/15033))
+
+* Fix Pylint config check strings (Cherry-pick of #14946) ([#14948](https://github.com/pantsbuild/pants/pull/14948))
+
+* add cache key for all Go SDK invocations (Cherry pick of #14897) ([#14902](https://github.com/pantsbuild/pants/pull/14902))
+
+### Documentation
+
+* Fix presented provider backend for rules/subsystems. (Cherry pick of #14999) ([#15023](https://github.com/pantsbuild/pants/pull/15023))
+
 ## 2.10.0 (Mar 23, 2022)
 
 The first stable release of the `2.10.x` branch, with no changes since the previous `rc`!


### PR DESCRIPTION
[ci skip-rust]