### PR TITLE
Filter BSP targets using the configured `group` `resolve`.

### DIFF
--- a/src/python/pants/backend/java/bsp/rules.py
+++ b/src/python/pants/backend/java/bsp/rules.py
@@ -53,6 +53,8 @@ class JavaBSPBuildTargetsMetadataRequest(BSPBuildTargetsMetadataRequest):
     language_id = LANGUAGE_ID
     can_merge_metadata_from = ()
     field_set_type = JavaMetadataFieldSet
+    resolve_prefix = "jvm"
+    resolve_field = JvmResolveField
 
 
 @rule

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -93,6 +93,8 @@ class ScalaBSPBuildTargetsMetadataRequest(BSPBuildTargetsMetadataRequest):
     language_id = LANGUAGE_ID
     can_merge_metadata_from = ("java",)
     field_set_type = ScalaMetadataFieldSet
+    resolve_prefix = "jvm"
+    resolve_field = JvmResolveField
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/bsp/util_rules/compile.py
+++ b/src/python/pants/bsp/util_rules/compile.py
@@ -9,7 +9,6 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import ClassVar, Generic, Type, TypeVar
 
-from pants.base.specs import AddressSpecs
 from pants.bsp.context import BSPContext
 from pants.bsp.protocol import BSPHandlerMapping
 from pants.bsp.spec.base import BuildTargetIdentifier, StatusCode, TaskId
@@ -72,7 +71,7 @@ async def compile_bsp_target(
     bsp_context: BSPContext,
     union_membership: UnionMembership,
 ) -> BSPCompileResult:
-    targets = await Get(Targets, AddressSpecs, request.bsp_target.specs.address_specs)
+    targets = await Get(Targets, BSPBuildTargetInternal, request.bsp_target)
     compile_request_types: FrozenOrderedSet[Type[BSPCompileRequest]] = union_membership.get(
         BSPCompileRequest
     )


### PR DESCRIPTION
Fixes #15049.

[ci skip-rust]
[ci skip-build-wheels]