### PR TITLE
rule_helpers dont need to be static

### DIFF
--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -280,7 +280,7 @@ def _uncacheable_rule(*args, **kwargs) -> Callable:
 
 
 def rule_helper(func: Callable) -> Callable:
-    """Decorator which marks a static function as a "rule helper".
+    """Decorator which marks a function as a "rule helper".
 
     Functions marked as rule helpers are allowed to be called by rules and other rule helpers
     and can `await Get/MultiGet`. The rule parser adds these functions' awaitables to the rule's


### PR DESCRIPTION
[ci skip-rust]
[ci skip-build-wheels]