### PR TITLE
[internal] Upgrade toolchain pants plugin

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -30,7 +30,7 @@ backend_packages.add = [
 ]
 plugins = [
   "hdrhistogram",  # For use with `--stats-log`.
-  "toolchain.pants.plugin==0.17.0",
+  "toolchain.pants.plugin==0.18.0",
 ]
 
 # The invalidation globs cover the PYTHONPATH by default, but we exclude some files that are on the


### PR DESCRIPTION
Changelog: https://docs.toolchain.com/docs/toolchain-pants-plugin-changelog#0180----2022-04-08

As per the changelog, this version adds support for the new options API (while also being compatible with the old one)
