### PR TITLE
[internal] kotlin: add kotlin parser for eventual dependency inference 

### DIFF
--- a/src/python/pants/backend/experimental/kotlin/register.py
+++ b/src/python/pants/backend/experimental/kotlin/register.py
@@ -1,6 +1,7 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from pants.backend.kotlin.compile import kotlinc
+from pants.backend.kotlin.dependency_inference.rules import rules as dep_inf_rules
 from pants.backend.kotlin.goals import check, tailor
 from pants.backend.kotlin.target_types import KotlinSourcesGeneratorTarget, KotlinSourceTarget
 from pants.backend.kotlin.target_types import rules as target_types_rules
@@ -30,6 +31,7 @@ def rules():
         *classpath.rules(),
         *coursier_fetch.rules(),
         *coursier_setup.rules(),
+        *dep_inf_rules(),
         *jvm_util_rules.rules(),
         *jdk_rules.rules(),
         *target_types_rules(),

--- a/src/python/pants/backend/kotlin/dependency_inference/BUILD
+++ b/src/python/pants/backend/kotlin/dependency_inference/BUILD
@@ -1,0 +1,7 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_sources(dependencies=[":kotlin_resources"])
+resources(name="kotlin_resources", sources=["*.kt"])
+
+python_tests(name="tests", timeout=240)

--- a/src/python/pants/backend/kotlin/dependency_inference/KotlinParser.kt
+++ b/src/python/pants/backend/kotlin/dependency_inference/KotlinParser.kt
@@ -1,14 +1,72 @@
 package org.pantsbuild.backend.kotlin.dependency_inference
 
+import kotlinx.serialization.*
+import kotlinx.serialization.json.*
+
+import com.intellij.openapi.util.Disposer
+import com.intellij.psi.PsiManager
+import com.intellij.testFramework.LightVirtualFile
+import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.idea.KotlinFileType
+import org.jetbrains.kotlin.psi.KtFile
+
 import java.io.File
 import java.io.FileWriter
+
+// KtFile: https://github.com/JetBrains/kotlin/blob/master/compiler/psi/src/org/jetbrains/kotlin/psi/KtFile.kt
+
+@Serializable
+data class KotlinImport(
+    val name: String,
+    val alias: String?,
+    val isWildcard: Boolean,
+)
+
+@Serializable
+data class KotlinAnalysis(
+    val imports: List<KotlinImport>,
+)
+
+fun parse(code: String): KtFile {
+    val disposable = Disposer.newDisposable()
+    try {
+        val env = KotlinCoreEnvironment.createForProduction(
+            disposable, CompilerConfiguration(), EnvironmentConfigFiles.JVM_CONFIG_FILES)
+        val file = LightVirtualFile("temp.kt", KotlinFileType.INSTANCE, code)
+        return PsiManager.getInstance(env.project).findFile(file) as KtFile
+    } finally {
+        disposable.dispose()
+    }
+}
+
+fun analyze(file: KtFile): KotlinAnalysis {
+    val imports = file.importDirectives.map { importDirective ->
+      val name = importDirective.getName()
+      KotlinImport(
+        name=importDirective.getName() ?: "",
+        alias=null,
+        isWildcard=false,
+      )
+    }
+
+    return KotlinAnalysis(imports)
+}
 
 fun main(args: Array<String>) {
     val analysisOutputPath = args[0]
     val sourceToAnalyze = args[1]
 
+    val parsed = parse(sourceToAnalyze)
+    val analysis = analyze(parsed)
+
     val outputFile = File(analysisOutputPath)
-    val writer = FileWriter(outputFile)
-    writer.write("{\"imports\":[]}")
-    writer.close()
+        val writer = FileWriter(outputFile)
+    try {
+        val analysisOutput = Json.encodeToString(analysis)
+        writer.write(analysisOutput)
+    } finally {
+        writer.close()
+    }
 }

--- a/src/python/pants/backend/kotlin/dependency_inference/KotlinParser.kt
+++ b/src/python/pants/backend/kotlin/dependency_inference/KotlinParser.kt
@@ -1,0 +1,14 @@
+package org.pantsbuild.backend.kotlin.dependency_inference
+
+import java.io.File
+import java.io.FileWriter
+
+fun main(args: Array<String>) {
+    val analysisOutputPath = args[0]
+    val sourceToAnalyze = args[1]
+
+    val outputFile = File(analysisOutputPath)
+    val writer = FileWriter(outputFile)
+    writer.write("{\"imports\":[]}")
+    writer.close()
+}

--- a/src/python/pants/backend/kotlin/dependency_inference/KotlinParser.kt
+++ b/src/python/pants/backend/kotlin/dependency_inference/KotlinParser.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.idea.KotlinFileType
 import org.jetbrains.kotlin.psi.KtFile
 
 
-// KtFile: https://github.com/JetBrains/kotlin/blob/master/compiler/psi/src/org/jetbrains/kotlin/psi/KtFile.kt
+// KtFile: https://github.com/JetBrains/kotlin/blob/8bc29a30111081ee0b0dbe06d1f648a789909a27/compiler/psi/src/org/jetbrains/kotlin/psi/KtFile.kt
 
 data class KotlinImport(
     val name: String,

--- a/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
@@ -1,0 +1,212 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+import json
+import os
+import pkgutil
+from dataclasses import dataclass
+
+from pants.backend.kotlin.subsystems.kotlin import DEFAULT_KOTLIN_VERSION
+from pants.core.util_rules.source_files import SourceFiles
+from pants.engine.fs import CreateDigest, DigestContents, Directory, FileContent
+from pants.engine.internals.native_engine import AddPrefix, Digest, MergeDigests, RemovePrefix
+from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.process import FallibleProcessResult, ProcessExecutionFailure, ProcessResult
+from pants.engine.rules import collect_rules, rule
+from pants.jvm.compile import ClasspathEntry
+from pants.jvm.jdk_rules import InternalJdk, JvmProcess
+from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
+from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
+from pants.option.global_options import ProcessCleanupOption
+from pants.util.logging import LogLevel
+
+_KOTLIN_PARSER_ARTIFACT_REQUIREMENTS = ArtifactRequirements.from_coordinates(
+    [
+        Coordinate(
+            group="org.jetbrains.kotlin",
+            artifact="kotlin-compiler-embeddable",
+            version=DEFAULT_KOTLIN_VERSION,  # TODO: Make this follow the resolve?
+        )
+    ]
+)
+
+
+@dataclass(frozen=True)
+class KotlinSourceDependencyAnalysis:
+    imports: frozenset[str]
+
+    @classmethod
+    def from_json_dict(cls, d: dict) -> KotlinSourceDependencyAnalysis:
+        return cls(
+            imports=frozenset(d["imports"]),
+        )
+
+
+@dataclass(frozen=True)
+class FallibleKotlinSourceDependencyAnalysisResult:
+    process_result: FallibleProcessResult
+
+
+class KotlinParserCompiledClassfiles(ClasspathEntry):
+    pass
+
+
+@rule(level=LogLevel.DEBUG)
+async def analyze_kotlin_source_dependencies(
+    jdk: InternalJdk,
+    processor_classfiles: KotlinParserCompiledClassfiles,
+    source_files: SourceFiles,
+) -> FallibleKotlinSourceDependencyAnalysisResult:
+    if len(source_files.files) > 1:
+        raise ValueError(
+            f"analyze_scala_source_dependencies expects sources with exactly 1 source file, but found {len(source_files.snapshot.files)}."
+        )
+    elif len(source_files.files) == 0:
+        raise ValueError(
+            "analyze_scala_source_dependencies expects sources with exactly 1 source file, but found none."
+        )
+    source_prefix = "__source_to_analyze"
+    source_path = os.path.join(source_prefix, source_files.files[0])
+    processorcp_relpath = "__processorcp"
+    toolcp_relpath = "__toolcp"
+
+    (tool_classpath, prefixed_source_files_digest,) = await MultiGet(
+        Get(
+            ToolClasspath,
+            ToolClasspathRequest(artifact_requirements=_KOTLIN_PARSER_ARTIFACT_REQUIREMENTS),
+        ),
+        Get(Digest, AddPrefix(source_files.snapshot.digest, source_prefix)),
+    )
+
+    extra_immutable_input_digests = {
+        toolcp_relpath: tool_classpath.digest,
+        processorcp_relpath: processor_classfiles.digest,
+    }
+
+    analysis_output_path = "__source_analysis.json"
+
+    process_result = await Get(
+        FallibleProcessResult,
+        JvmProcess(
+            jdk=jdk,
+            classpath_entries=[
+                *tool_classpath.classpath_entries(toolcp_relpath),
+                processorcp_relpath,
+            ],
+            argv=[
+                "org.pantsbuild.backend.kotlin.dependency_inference.KotlinParserKt",
+                analysis_output_path,
+                source_path,
+            ],
+            input_digest=prefixed_source_files_digest,
+            extra_immutable_input_digests=extra_immutable_input_digests,
+            output_files=(analysis_output_path,),
+            extra_nailgun_keys=extra_immutable_input_digests,
+            description=f"Analyzing {source_files.files[0]}",
+            level=LogLevel.DEBUG,
+        ),
+    )
+
+    return FallibleKotlinSourceDependencyAnalysisResult(process_result=process_result)
+
+
+@rule(level=LogLevel.DEBUG)
+async def resolve_fallible_result_to_analysis(
+    fallible_result: FallibleKotlinSourceDependencyAnalysisResult,
+    process_cleanup: ProcessCleanupOption,
+) -> KotlinSourceDependencyAnalysis:
+    # TODO(#12725): Just convert directly to a ProcessResult like this:
+    # result = await Get(ProcessResult, FallibleProcessResult, fallible_result.process_result)
+    if fallible_result.process_result.exit_code == 0:
+        analysis_contents = await Get(
+            DigestContents, Digest, fallible_result.process_result.output_digest
+        )
+        analysis = json.loads(analysis_contents[0].content)
+        return KotlinSourceDependencyAnalysis.from_json_dict(analysis)
+    raise ProcessExecutionFailure(
+        fallible_result.process_result.exit_code,
+        fallible_result.process_result.stdout,
+        fallible_result.process_result.stderr,
+        "Kotlin source dependency analysis failed.",
+        process_cleanup=process_cleanup.val,
+    )
+
+
+@rule
+async def setup_kotlin_parser_classfiles(jdk: InternalJdk) -> KotlinParserCompiledClassfiles:
+    dest_dir = "classfiles"
+
+    parser_source_content = pkgutil.get_data(
+        "pants.backend.kotlin.dependency_inference", "KotlinParser.kt"
+    )
+    if not parser_source_content:
+        raise AssertionError("Unable to find KotlinParser.kt resource.")
+
+    parser_source = FileContent("KotlinParser.kt", parser_source_content)
+
+    tool_classpath, parser_classpath, source_digest = await MultiGet(
+        Get(
+            ToolClasspath,
+            ToolClasspathRequest(
+                prefix="__toolcp",
+                artifact_requirements=ArtifactRequirements.from_coordinates(
+                    [
+                        Coordinate(
+                            group="org.jetbrains.kotlin",
+                            artifact="kotlin-compiler",
+                            version=DEFAULT_KOTLIN_VERSION,  # TODO: Pull from resolve or hard-code Kotlin version?
+                        ),
+                    ]
+                ),
+            ),
+        ),
+        Get(
+            ToolClasspath,
+            ToolClasspathRequest(
+                prefix="__parsercp", artifact_requirements=_KOTLIN_PARSER_ARTIFACT_REQUIREMENTS
+            ),
+        ),
+        Get(Digest, CreateDigest([parser_source, Directory(dest_dir)])),
+    )
+
+    merged_digest = await Get(
+        Digest,
+        MergeDigests(
+            (
+                tool_classpath.digest,
+                parser_classpath.digest,
+                source_digest,
+            )
+        ),
+    )
+
+    process_result = await Get(
+        ProcessResult,
+        JvmProcess(
+            jdk=jdk,
+            classpath_entries=tool_classpath.classpath_entries(),
+            argv=[
+                "org.jetbrains.kotlin.cli.jvm.K2JVMCompiler",
+                "-classpath",
+                ":".join(parser_classpath.classpath_entries()),
+                "-d",
+                dest_dir,
+                parser_source.path,
+            ],
+            input_digest=merged_digest,
+            output_directories=(dest_dir,),
+            description="Compile Kolin parser for dependency inference with kotlinc",
+            level=LogLevel.DEBUG,
+            # NB: We do not use nailgun for this process, since it is launched exactly once.
+            use_nailgun=False,
+        ),
+    )
+    stripped_classfiles_digest = await Get(
+        Digest, RemovePrefix(process_result.output_digest, dest_dir)
+    )
+    return KotlinParserCompiledClassfiles(digest=stripped_classfiles_digest)
+
+
+def rules():
+    return collect_rules()

--- a/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
@@ -89,11 +89,11 @@ async def analyze_kotlin_source_dependencies(
 
     if len(source_files.files) > 1:
         raise ValueError(
-            f"analyze_scala_source_dependencies expects sources with exactly 1 source file, but found {len(source_files.snapshot.files)}."
+            f"analyze_kotlin_source_dependencies expects sources with exactly 1 source file, but found {len(source_files.snapshot.files)}."
         )
     elif len(source_files.files) == 0:
         raise ValueError(
-            "analyze_scala_source_dependencies expects sources with exactly 1 source file, but found none."
+            "analyze_kotlin_source_dependencies expects sources with exactly 1 source file, but found none."
         )
     source_prefix = "__source_to_analyze"
     source_path = os.path.join(source_prefix, source_files.files[0])

--- a/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser_test.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser_test.py
@@ -8,7 +8,10 @@ import pytest
 
 from pants.backend.kotlin import target_types
 from pants.backend.kotlin.dependency_inference import kotlin_parser
-from pants.backend.kotlin.dependency_inference.kotlin_parser import KotlinSourceDependencyAnalysis, KotlinImport
+from pants.backend.kotlin.dependency_inference.kotlin_parser import (
+    KotlinImport,
+    KotlinSourceDependencyAnalysis,
+)
 from pants.backend.kotlin.target_types import KotlinSourceField, KotlinSourceTarget
 from pants.build_graph.address import Address
 from pants.core.util_rules import source_files
@@ -36,7 +39,7 @@ def rule_runner() -> RuleRunner:
         ],
         target_types=[KotlinSourceTarget],
     )
-    rule_runner.set_options(args=["-ldebug", "--no-process-cleanup"], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
     return rule_runner
 
 
@@ -80,6 +83,4 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
         ),
     )
 
-    assert analysis.imports == {
-        KotlinImport(name="java.io.File", alias=None, is_wildcard=False)
-    }
+    assert analysis.imports == {KotlinImport(name="java.io.File", alias=None, is_wildcard=False)}

--- a/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser_test.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser_test.py
@@ -1,0 +1,80 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from pants.backend.kotlin import target_types
+from pants.backend.kotlin.dependency_inference import kotlin_parser
+from pants.backend.kotlin.dependency_inference.kotlin_parser import KotlinSourceDependencyAnalysis
+from pants.backend.kotlin.target_types import KotlinSourceField, KotlinSourceTarget
+from pants.build_graph.address import Address
+from pants.core.util_rules import source_files
+from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.engine.rules import QueryRule
+from pants.engine.target import SourcesField
+from pants.jvm import jdk_rules
+from pants.jvm import util_rules as jvm_util_rules
+from pants.jvm.resolve import jvm_tool
+from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = RuleRunner(
+        rules=[
+            *kotlin_parser.rules(),
+            *jvm_tool.rules(),
+            *source_files.rules(),
+            *jdk_rules.rules(),
+            *target_types.rules(),
+            *jvm_util_rules.rules(),
+            QueryRule(SourceFiles, (SourceFilesRequest,)),
+            QueryRule(KotlinSourceDependencyAnalysis, (SourceFiles,)),
+        ],
+        target_types=[KotlinSourceTarget],
+    )
+    rule_runner.set_options(args=["-ldebug"], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    return rule_runner
+
+
+def _analyze(rule_runner: RuleRunner, source: str) -> KotlinSourceDependencyAnalysis:
+    rule_runner.write_files(
+        {
+            "BUILD": """kotlin_source(name="source", source="Source.kt")""",
+            "Source.kt": source,
+        }
+    )
+
+    target = rule_runner.get_target(address=Address("", target_name="source"))
+
+    source_files = rule_runner.request(
+        SourceFiles,
+        [
+            SourceFilesRequest(
+                (target.get(SourcesField),),
+                for_sources_types=(KotlinSourceField,),
+                enable_codegen=True,
+            )
+        ],
+    )
+
+    return rule_runner.request(KotlinSourceDependencyAnalysis, [source_files])
+
+
+def test_parser_simple(rule_runner: RuleRunner) -> None:
+    analysis = _analyze(
+        rule_runner,
+        textwrap.dedent(
+            """\
+            package org.pantsbuild.backend.kotlin
+
+            fun main(args: Array<String>) {
+            }
+            """
+        ),
+    )
+
+    assert analysis.imports == set()

--- a/src/python/pants/backend/kotlin/dependency_inference/rules.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/rules.py
@@ -1,0 +1,11 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from pants.backend.kotlin.dependency_inference import kotlin_parser
+from pants.engine.rules import collect_rules
+
+
+def rules():
+    return (
+        *collect_rules(),
+        *kotlin_parser.rules(),
+    )


### PR DESCRIPTION
Add a Kotlin parser using the IntelliJ PSI parser built into the Kotlin compiler.