### PR TITLE
Upgrade Pex to 2.1.78.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -15,7 +15,7 @@ humbug==0.2.7
 
 ijson==3.1.4
 packaging==21.3
-pex==2.1.77
+pex==2.1.78
 psutil==5.9.0
 # This should be compatible with pytest.py, although it can be looser so that we don't
 # over-constrain pantsbuild.pants.testutil

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -18,7 +18,7 @@
 //     "ijson==3.1.4",
 //     "mypy-typing-asserts==0.1.1",
 //     "packaging==21.3",
-//     "pex==2.1.77",
+//     "pex==2.1.78",
 //     "psutil==5.9.0",
 //     "pydevd-pycharm==203.5419.8",
 //     "pytest<7.1.0,>=6.2.4",
@@ -548,13 +548,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "e0f0e754e9e1fdadb8e7d5e0bd0e1f4710fbb57b679ec91e6e5d7313aa12b64d",
-              "url": "https://files.pythonhosted.org/packages/a3/01/aea843da3bdb4d1ee12855e3bb237dfa6f8492b5ff59f7ac644a87719bbf/pex-2.1.77-py2.py3-none-any.whl"
+              "hash": "e3d39549c6602235eb158314293143c4e45677e4acfa16ba141320d84ec523b3",
+              "url": "https://files.pythonhosted.org/packages/4a/f0/a90326344a99f4e1fa598efb162dcf0d9fc673943201fdc2e253a3511b81/pex-2.1.78-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "96fcd16fe9b76b70e68a6cd522ba286c968d7b63ee32869d6f8f18c21c4256f0",
-              "url": "https://files.pythonhosted.org/packages/0c/88/d7a15de41f1cfe2941613bbddc23602b3f688fa76ee3d7bbf09713dca9f6/pex-2.1.77.tar.gz"
+              "hash": "d5b58010c3018e6c8b4b55be556803f41b19ab97f40e610e42bc971fdbeea426",
+              "url": "https://files.pythonhosted.org/packages/24/e8/47902b09c9b87642d3e1f04b8660dddfedcd86532189ebd611601d20cb16/pex-2.1.78.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -562,7 +562,7 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.11,>=2.7",
-          "version": "2.1.77"
+          "version": "2.1.78"
         },
         {
           "artifacts": [
@@ -1544,7 +1544,7 @@
       ]
     }
   ],
-  "pex_version": "2.1.77",
+  "pex_version": "2.1.78",
   "prefer_older_binary": false,
   "requirements": [
     "PyYAML<7.0,>=6.0",
@@ -1556,7 +1556,7 @@
     "ijson==3.1.4",
     "mypy-typing-asserts==0.1.1",
     "packaging==21.3",
-    "pex==2.1.77",
+    "pex==2.1.78",
     "psutil==5.9.0",
     "pydevd-pycharm==203.5419.8",
     "pytest<7.1.0,>=6.2.4",

--- a/src/python/pants/backend/python/subsystems/lambdex.lock
+++ b/src/python/pants/backend/python/subsystems/lambdex.lock
@@ -49,13 +49,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "e0f0e754e9e1fdadb8e7d5e0bd0e1f4710fbb57b679ec91e6e5d7313aa12b64d",
-              "url": "https://files.pythonhosted.org/packages/a3/01/aea843da3bdb4d1ee12855e3bb237dfa6f8492b5ff59f7ac644a87719bbf/pex-2.1.77-py2.py3-none-any.whl"
+              "hash": "e3d39549c6602235eb158314293143c4e45677e4acfa16ba141320d84ec523b3",
+              "url": "https://files.pythonhosted.org/packages/4a/f0/a90326344a99f4e1fa598efb162dcf0d9fc673943201fdc2e253a3511b81/pex-2.1.78-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "96fcd16fe9b76b70e68a6cd522ba286c968d7b63ee32869d6f8f18c21c4256f0",
-              "url": "https://files.pythonhosted.org/packages/0c/88/d7a15de41f1cfe2941613bbddc23602b3f688fa76ee3d7bbf09713dca9f6/pex-2.1.77.tar.gz"
+              "hash": "d5b58010c3018e6c8b4b55be556803f41b19ab97f40e610e42bc971fdbeea426",
+              "url": "https://files.pythonhosted.org/packages/24/e8/47902b09c9b87642d3e1f04b8660dddfedcd86532189ebd611601d20cb16/pex-2.1.78.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -63,7 +63,7 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.11,>=2.7",
-          "version": "2.1.77"
+          "version": "2.1.78"
         }
       ],
       "platform_tag": [
@@ -73,7 +73,7 @@
       ]
     }
   ],
-  "pex_version": "2.1.77",
+  "pex_version": "2.1.78",
   "prefer_older_binary": false,
   "requirements": [
     "lambdex==0.1.6"

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -39,9 +39,9 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."
 
-    default_version = "v2.1.77"
+    default_version = "v2.1.78"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.1.77,<3.0"
+    version_constraints = ">=2.1.78,<3.0"
 
     @classproperty
     def default_known_versions(cls):
@@ -50,8 +50,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "7b02ea666c34367b2c841a76e822afd5ccafb1ae44b01b3053044b3323df2524",
-                    "3732702",
+                    "52f5104ac995f50e31c479634ed30502871e72bd7923bbeab00b578924eae828",
+                    "3732692",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64"]


### PR DESCRIPTION
This pulls in a fix for missing artifacts in locks.

See the change log here:
  https://github.com/pantsbuild/pex/releases/tag/v2.1.78

[ci skip-rust]
[ci skip-build-wheels]