### PR TITLE
Clean PID-specific exception file if empty on process exit

### DIFF
--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -215,10 +215,7 @@ class ExceptionSink:
 
     @classmethod
     def open_pid_specific_error_stream(cls, path):
-        try:
-            ret = safe_open(path, mode="w")
-        except Exception:
-            raise
+        ret = safe_open(path, mode="w")
 
         def unlink_if_empty():
             if os.path.getsize(path) == 0:

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -221,7 +221,7 @@ class ExceptionSink:
             try:
                 if os.path.getsize(path) == 0:
                     os.unlink(path)
-            except Exception:
+            except OSError:
                 pass
 
         # NB: This will only get called if nothing fatal happens, but that's precisely when we want

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -221,6 +221,7 @@ class ExceptionSink:
             raise
 
         def unlink_if_empty():
+            ret.seek(0)
             if ret.read(1) == "":
                 os.unlink(path)
 

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -216,13 +216,12 @@ class ExceptionSink:
     @classmethod
     def open_pid_specific_error_stream(cls, path):
         try:
-            ret = safe_open(path, mode="w+")
+            ret = safe_open(path, mode="w")
         except Exception:
             raise
 
         def unlink_if_empty():
-            ret.seek(0)
-            if ret.read(1) == "":
+            if os.path.getsize(path) == 0:
                 os.unlink(path)
 
         # NB: This will only get called if nothing fatal happens, but that's precisely when we want

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -1,6 +1,7 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import atexit
 import datetime
 import faulthandler
 import logging
@@ -189,7 +190,7 @@ class ExceptionSink:
         shared_log_path = cls.exceptions_log_path(in_dir=new_log_location)
         assert pid_specific_log_path != shared_log_path
         try:
-            pid_specific_error_stream = safe_open(pid_specific_log_path, mode="w")
+            pid_specific_error_stream = cls.open_pid_specific_error_stream(pid_specific_log_path)
             shared_error_stream = safe_open(shared_log_path, mode="a")
         except Exception as e:
             raise cls.ExceptionSinkError(
@@ -211,6 +212,23 @@ class ExceptionSink:
         cls._log_dir = new_log_location
         cls._pid_specific_error_fileobj = pid_specific_error_stream
         cls._shared_error_fileobj = shared_error_stream
+
+    @classmethod
+    def open_pid_specific_error_stream(cls, path):
+        try:
+            ret = safe_open(path, mode="w+")
+        except Exception:
+            raise
+
+        def unlink_if_empty():
+            if ret.read(1) == "":
+                os.unlink(path)
+
+        # NB: This will only get called if nothing fatal happens, but that's precisely when we want
+        # to get called. If anything fatal happens there should be an exception written to the log,
+        # and therefore we don't want to unlink it.
+        atexit.register(unlink_if_empty)
+        return ret
 
     @classmethod
     def exceptions_log_path(cls, for_pid=None, in_dir=None):

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -218,8 +218,11 @@ class ExceptionSink:
         ret = safe_open(path, mode="w")
 
         def unlink_if_empty():
-            if os.path.getsize(path) == 0:
-                os.unlink(path)
+            try:
+                if os.path.getsize(path) == 0:
+                    os.unlink(path)
+            except Exception:
+                pass
 
         # NB: This will only get called if nothing fatal happens, but that's precisely when we want
         # to get called. If anything fatal happens there should be an exception written to the log,


### PR DESCRIPTION
Fixes #14163 by registering a cleanup function at process exit to unlink the file if it isn't empty.

Tested without pantsd:
- If a file generates no exception, cleans up for every `./pants` invocation
- While the `./pants` process is running, writing to the file. Doesn't get cleaned.

Tested with pantsd. When `pants.d` gets reset (`rm -rf .pids`):
- If the file is empty it cleans up, otherwise leaves it

[ci skip-rust]
[ci skip-build-wheels]