### PR TITLE
Support for env var interpolation in config files.

### DIFF
--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -133,12 +133,11 @@ class OptionsBootstrapper:
                     read_file(path, binary_mode=True),
                 )
 
-            env = {k: v for k, v in env.items() if k.startswith("PANTS_")}
             bargs = cls._get_bootstrap_args(args)
 
             config_file_paths = cls.get_config_file_paths(env=env, args=args)
             config_files_products = [filecontent_for(p) for p in config_file_paths]
-            pre_bootstrap_config = Config.load(config_files_products)
+            pre_bootstrap_config = Config.load(config_files_products, env=env)
 
             initial_bootstrap_options = cls.parse_bootstrap_options(
                 env, bargs, pre_bootstrap_config
@@ -160,9 +159,8 @@ class OptionsBootstrapper:
             post_bootstrap_config = Config.load(
                 full_config_files_products,
                 seed_values=bootstrap_option_values.as_dict(),
+                env=env,
             )
-
-            env_tuples = tuple(sorted(env.items(), key=lambda x: x[0]))
 
             # Finally, we expand any aliases and re-populate the bootstrap args, in case there
             # were any from aliases.
@@ -186,6 +184,11 @@ class OptionsBootstrapper:
             # remote pants runners.
             os.environ["PANTS_BIN_NAME"] = bootstrap_option_values.pants_bin_name
 
+            env_tuples = tuple(
+                sorted(
+                    (item for item in env.items() if item[0].startswith("PANTS_")),
+                )
+            )
             return cls(
                 env_tuples=env_tuples,
                 bootstrap_args=bargs,


### PR DESCRIPTION
The existing `%()s` interpolation syntax can be used with a new `env`
object. For example, to interpolate the current home directory you
would use `%(env.HOME)s` or to interpolate [12-factor
credentials](https://12factor.net/config) you might use something like
`%(env.AWS_ACCESS_KEY_ID)s`.

Closes #10399

[ci skip-rust]
[ci skip-build-wheels]