### PR TITLE
Preserve tombstones for workunits which complete while they still have children

### DIFF
--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -456,7 +456,7 @@ impl ByteStore {
     async {
       in_workunit!(
         "list_missing_digests",
-        Level::Debug,
+        Level::Trace,
         |_workunit| async move {
           let store2 = store.clone();
           let client = store2.cas_client.as_ref().clone();

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -89,10 +89,14 @@ impl crate::CommandRunner for CommandRunner {
             // When we successfully use the cache, we change the description and increase the level
             // (but not so much that it will be logged by default).
             workunit.update_metadata(|initial| {
-              initial.map(|initial| WorkunitMetadata {
-                desc: initial.desc.as_ref().map(|desc| format!("Hit: {}", desc)),
-                level: Level::Debug,
-                ..initial
+              initial.map(|(initial, _)| {
+                (
+                  WorkunitMetadata {
+                    desc: initial.desc.as_ref().map(|desc| format!("Hit: {}", desc)),
+                    ..initial
+                  },
+                  Level::Debug,
+                )
               })
             });
             Ok(result)

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -299,16 +299,14 @@ impl CommandRunner {
               // When we successfully use the cache, we change the description and increase the level
               // (but not so much that it will be logged by default).
               workunit.update_metadata(|initial| {
-                initial.map(|initial|
-                WorkunitMetadata {
+                initial.map(|(initial, _)|
+                (WorkunitMetadata {
                   desc: initial
                     .desc
                     .as_ref()
                     .map(|desc| format!("Hit: {}", desc)),
-                  level: Level::Debug,
                   ..initial
-
-                })
+                }, Level::Debug))
               });
               Ok((cached_response, true))
             } else {

--- a/src/rust/engine/src/externs/engine_aware.rs
+++ b/src/rust/engine/src/externs/engine_aware.rs
@@ -11,7 +11,7 @@ use crate::Value;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
-use workunit_store::{ArtifactOutput, Level, RunningWorkunit, UserMetadataItem};
+use workunit_store::{ArtifactOutput, Level, RunningWorkunit, UserMetadataItem, WorkunitMetadata};
 
 // Note: these functions should not panic, but we also don't preserve errors (e.g. to log) because
 // we rely on MyPy to catch TypeErrors with using the APIs incorrectly. So we convert errors to
@@ -22,18 +22,18 @@ pub(crate) struct EngineAwareReturnType;
 
 impl EngineAwareReturnType {
   pub(crate) fn update_workunit(workunit: &mut RunningWorkunit, task_result: &PyAny) {
-    workunit.update_metadata(|old_metadata| {
+    workunit.update_metadata(|old| {
       let new_level = Self::level(task_result);
+
       // If the metadata already existed, or if its level changed, we need to update it.
-      let mut metadata = if new_level.is_some() || old_metadata.is_some() {
-        old_metadata.unwrap_or_default()
+      let (mut metadata, level) = if let Some((metadata, old_level)) = old {
+        (metadata, new_level.unwrap_or(old_level))
+      } else if let Some(level) = new_level {
+        (WorkunitMetadata::default(), level)
       } else {
         return None;
       };
 
-      if let Some(new_level) = new_level {
-        metadata.level = new_level;
-      }
       metadata.message = Self::message(task_result);
       metadata
         .artifacts
@@ -41,7 +41,7 @@ impl EngineAwareReturnType {
       metadata
         .user_metadata
         .extend(metadata_for(task_result).unwrap_or_default());
-      Some(metadata)
+      Some((metadata, level))
     });
   }
 

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -691,7 +691,7 @@ async fn workunit_to_py_value(
       ),
       (
         externs::store_utf8(py, "level"),
-        externs::store_utf8(py, &metadata.level.to_string()),
+        externs::store_utf8(py, &workunit.level.to_string()),
       ),
     ];
 

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -434,24 +434,29 @@ impl WrappedNode for ExecuteProcess {
     let definition = serde_json::to_string(&request)
       .map_err(|e| throw(format!("Failed to serialize process: {}", e)))?;
     workunit.update_metadata(|initial| {
-      initial.map(|initial| WorkunitMetadata {
-        stdout: Some(res.stdout_digest),
-        stderr: Some(res.stderr_digest),
-        user_metadata: vec![
-          (
-            "definition".to_string(),
-            UserMetadataItem::ImmediateString(definition),
-          ),
-          (
-            "source".to_string(),
-            UserMetadataItem::ImmediateString(format!("{:?}", res.metadata.source)),
-          ),
-          (
-            "exit_code".to_string(),
-            UserMetadataItem::ImmediateInt(res.exit_code as i64),
-          ),
-        ],
-        ..initial
+      initial.map(|(initial, level)| {
+        (
+          WorkunitMetadata {
+            stdout: Some(res.stdout_digest),
+            stderr: Some(res.stderr_digest),
+            user_metadata: vec![
+              (
+                "definition".to_string(),
+                UserMetadataItem::ImmediateString(definition),
+              ),
+              (
+                "source".to_string(),
+                UserMetadataItem::ImmediateString(format!("{:?}", res.metadata.source)),
+              ),
+              (
+                "exit_code".to_string(),
+                UserMetadataItem::ImmediateInt(res.exit_code as i64),
+              ),
+            ],
+            ..initial
+          },
+          level,
+        )
       })
     });
     if let Some(total_elapsed) = res.metadata.total_elapsed {

--- a/src/rust/engine/workunit_store/src/tests.rs
+++ b/src/rust/engine/workunit_store/src/tests.rs
@@ -168,7 +168,7 @@ fn create_store(
     .chain(blocked.into_iter())
     .chain(completed.into_iter())
     .collect::<Vec<_>>();
-  all.sort_by(|a, b| a.0.cmp(&b.0));
+  all.sort_by(|a, b| a.1.cmp(&b.1));
 
   // Start all workunits in SpanId order.
   let workunits = all


### PR DESCRIPTION
#15080 was caused by two factors:
1. #14541 made counters global via a new API, and attached them (as deprecated) to "the root workunit" (with "has no parent id" as the heuristic that something was the root workunit).
2. #14856 moved to calculating the parent(s) of a node based on a running graph of workunits (to allow #14680 to eventually add multiple parents), which meant that when nodes completed out of order, we might not have any parents for them.

Together: this meant that when workunits completed asynchronously, we might not have parents for them, and because of the deprecation, we would attach the counters to multiple workunits. A consumer which was aggregating the counters would end up with an inaccurate total.

Fixes #15080.