### PR TITLE
Upgrade Rust to 1.60.0.

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -53,7 +53,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.59.0-*
+        path: '~/.rustup/toolchains/1.60.0-*
 
           ~/.rustup/update-hashes
 
@@ -215,7 +215,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.59.0-*
+        path: '~/.rustup/toolchains/1.60.0-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,7 +53,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.59.0-*
+        path: '~/.rustup/toolchains/1.60.0-*
 
           ~/.rustup/update-hashes
 
@@ -214,7 +214,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.59.0-*
+        path: '~/.rustup/toolchains/1.60.0-*
 
           ~/.rustup/update-hashes
 
@@ -415,7 +415,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
-        path: '~/.rustup/toolchains/1.59.0-*
+        path: '~/.rustup/toolchains/1.60.0-*
 
           ~/.rustup/update-hashes
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.59.0"
+channel = "1.60.0"
 components = [
   "cargo",
   "clippy",

--- a/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
@@ -169,7 +169,7 @@ impl NailgunPool {
   ///
   /// Find the least recently used idle (but not necessarily usable) process in the pool.
   ///
-  fn find_lru_idle(pool_entries: &mut Vec<PoolEntry>) -> Result<Option<usize>, String> {
+  fn find_lru_idle(pool_entries: &mut [PoolEntry]) -> Result<Option<usize>, String> {
     // 24 hours of clock skew would be surprising?
     let mut lru_age = Instant::now() + Duration::from_secs(60 * 60 * 24);
     let mut lru = None;


### PR DESCRIPTION
The changelog is here:
  https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1600-2022-04-07

[ci skip-build-wheels]