### PR TITLE
Remove deprecated `register_options` support.

### DIFF
--- a/src/python/pants/option/subsystem.py
+++ b/src/python/pants/option/subsystem.py
@@ -9,13 +9,11 @@ import re
 from abc import ABCMeta
 from typing import Any, ClassVar, TypeVar
 
-from pants.base.deprecated import deprecated
 from pants.engine.internals.selectors import AwaitableConstraints, Get
 from pants.option.errors import OptionsError
 from pants.option.option_types import collect_options_info
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.scope import Scope, ScopedOptions, ScopeInfo, normalize_scope
-from pants.util.docutil import doc_url
 
 
 class Subsystem(metaclass=ABCMeta):
@@ -96,20 +94,6 @@ class Subsystem(metaclass=ABCMeta):
         """Returns a ScopeInfo instance representing this Subsystem's options scope."""
         cls.validate_scope()
         return cls.create_scope_info(scope=cls.options_scope, subsystem_cls=cls)
-
-    @classmethod
-    @deprecated(
-        removal_version="2.12.0.dev2",
-        hint=(
-            "Options are now registered by declaring class attributes using the types in "
-            f"pants/option/option_types.py. See {doc_url('plugin-upgrade-guide')}"
-        ),
-    )
-    def register_options(cls, register):
-        """Register options for this Subsystem.
-
-        Subclasses may override and call register(*args, **kwargs).
-        """
 
     @classmethod
     def register_options_on_scope(cls, options):

--- a/src/python/pants/option/subsystem_test.py
+++ b/src/python/pants/option/subsystem_test.py
@@ -59,7 +59,7 @@ def test_is_valid_scope_name() -> None:
     check_false("foo-bar-")
 
 
-def test_deprecated_register_options(caplog) -> None:
+def test_register_options_blessed(caplog) -> None:
     class GoodToGo(Subsystem):
         options_scope = "good-to-go"
 
@@ -72,25 +72,4 @@ def test_deprecated_register_options(caplog) -> None:
     )
     GoodToGo.register_options_on_scope(options)
 
-    assert not caplog.records
-
-    class OldAndDusty(Subsystem):
-        options_scope = "good-to-go"
-
-        @classmethod
-        def register_options(cls, register):
-            return super().register_options(register)
-
-    options = Options.create(
-        env={},
-        config=Config.load([]),
-        known_scope_infos=[OldAndDusty.get_scope_info()],
-        args=["./pants"],
-        bootstrap_option_values=None,
-    )
-    OldAndDusty.register_options_on_scope(options)
-
-    assert (
-        "DEPRECATED: pants.option.subsystem.register_options() is scheduled to be removed"
-        in caplog.text
-    )
+    assert not caplog.records, "The current blessed means of registering options should never warn."


### PR DESCRIPTION
Subsystems should now use the `*Option` types in the `pants.option` module.

[ci skip-rust]
[ci skip-build-wheels]