### PR TITLE
Disambiguate Helm dependencies considering the explictly provided ones.

### DIFF
--- a/src/python/pants/backend/helm/dependency_inference/chart.py
+++ b/src/python/pants/backend/helm/dependency_inference/chart.py
@@ -9,12 +9,18 @@ from pants.backend.helm.resolve.artifacts import (
     ThirdPartyArtifactMapping,
 )
 from pants.backend.helm.subsystems.helm import HelmSubsystem
-from pants.backend.helm.target_types import HelmChartMetaSourceField
+from pants.backend.helm.target_types import HelmChartDependenciesField, HelmChartMetaSourceField
 from pants.backend.helm.util_rules.chart_metadata import HelmChartDependency, HelmChartMetadata
 from pants.engine.addresses import Address
-from pants.engine.internals.selectors import Get
+from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import collect_rules, rule
-from pants.engine.target import InferDependenciesRequest, InferredDependencies
+from pants.engine.target import (
+    DependenciesRequest,
+    ExplicitlyProvidedDependencies,
+    InferDependenciesRequest,
+    InferredDependencies,
+    WrappedTarget,
+)
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import OrderedSet
@@ -42,24 +48,44 @@ async def infer_chart_dependencies_via_metadata(
     third_party_mapping: ThirdPartyArtifactMapping,
     subsystem: HelmSubsystem,
 ) -> InferredDependencies:
+    original_addr = request.sources_field.address
+    wrapped_tgt = await Get(WrappedTarget, Address, original_addr)
+    tgt = wrapped_tgt.target
+
     # Parse Chart.yaml for explicitly set dependencies.
-    metadata = await Get(HelmChartMetadata, HelmChartMetaSourceField, request.sources_field)
+    explicitly_provided_deps, metadata = await MultiGet(
+        Get(ExplicitlyProvidedDependencies, DependenciesRequest(tgt[HelmChartDependenciesField])),
+        Get(HelmChartMetadata, HelmChartMetaSourceField, request.sources_field),
+    )
 
     # Associate dependencies in Chart.yaml with addresses.
     dependencies: OrderedSet[Address] = OrderedSet()
     for chart_dep in metadata.dependencies:
-        # Check if this is a third party dependency declared as `helm_artifact`.
-        artifact_addr = third_party_mapping.get(chart_dep.remote_spec(subsystem.remotes()))
-        if artifact_addr:
-            dependencies.add(artifact_addr)
-            continue
+        candidate_addrs = []
 
-        # Treat the dependency as a first party one.
-        first_party_addr = first_party_mapping.get(chart_dep.name)
-        if not first_party_addr:
-            raise UnknownHelmChartDependency(request.sources_field.address, chart_dep)
+        first_party_dep = first_party_mapping.get(chart_dep.name)
+        if first_party_dep:
+            candidate_addrs.append(first_party_dep)
 
-        dependencies.add(first_party_addr)
+        third_party_dep = third_party_mapping.get(chart_dep.remote_spec(subsystem.remotes()))
+        if third_party_dep:
+            candidate_addrs.append(third_party_dep)
+
+        if not candidate_addrs:
+            raise UnknownHelmChartDependency(original_addr, chart_dep)
+
+        matches = frozenset(candidate_addrs).difference(explicitly_provided_deps.includes)
+
+        explicitly_provided_deps.maybe_warn_of_ambiguous_dependency_inference(
+            matches,
+            original_addr,
+            context=f"The Helm chart {original_addr} declares `{chart_dep.name}` as dependency",
+            import_reference="helm dependency",
+        )
+
+        maybe_disambiguated = explicitly_provided_deps.disambiguated(matches)
+        if maybe_disambiguated:
+            dependencies.add(maybe_disambiguated)
 
     logger.debug(
         f"Inferred {pluralize(len(dependencies), 'dependency')} for target at address: {request.sources_field.address}"

--- a/src/python/pants/backend/helm/dependency_inference/chart_test.py
+++ b/src/python/pants/backend/helm/dependency_inference/chart_test.py
@@ -49,15 +49,7 @@ def test_infer_chart_dependencies(rule_runner: RuleRunner) -> None:
                 )
                 """
             ),
-            "src/bar/BUILD": """helm_chart()""",
-            "src/bar/Chart.yaml": dedent(
-                """\
-                apiVersion: v2
-                name: bar
-                version: 0.1.0
-                """
-            ),
-            "src/foo/BUILD": """helm_chart()""",
+            "src/foo/BUILD": """helm_chart(dependencies=["//src/quxx"])""",
             "src/foo/Chart.yaml": dedent(
                 """\
                 apiVersion: v2
@@ -67,6 +59,23 @@ def test_infer_chart_dependencies(rule_runner: RuleRunner) -> None:
                 - name: cert-manager
                   repository: "@jetstack"
                 - name: bar
+                - name: quxx
+                """
+            ),
+            "src/bar/BUILD": """helm_chart()""",
+            "src/bar/Chart.yaml": dedent(
+                """\
+                apiVersion: v2
+                name: bar
+                version: 0.1.0
+                """
+            ),
+            "src/quxx/BUILD": """helm_chart()""",
+            "src/quxx/Chart.yaml": dedent(
+                """\
+                apiVersion: v2
+                name: quxx
+                version: 0.1.0
                 """
             ),
         }

--- a/src/python/pants/backend/helm/dependency_inference/chart_test.py
+++ b/src/python/pants/backend/helm/dependency_inference/chart_test.py
@@ -5,7 +5,10 @@ from textwrap import dedent
 
 import pytest
 
-from pants.backend.helm.dependency_inference.chart import InferHelmChartDependenciesRequest
+from pants.backend.helm.dependency_inference.chart import (
+    FirstPartyHelmChartMapping,
+    InferHelmChartDependenciesRequest,
+)
 from pants.backend.helm.dependency_inference.chart import rules as chart_infer_rules
 from pants.backend.helm.resolve import artifacts
 from pants.backend.helm.target_types import (
@@ -20,6 +23,7 @@ from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.rules import QueryRule
 from pants.engine.target import InferredDependencies
 from pants.testutil.rule_runner import RuleRunner
+from pants.util.strutil import bullet_list
 
 
 @pytest.fixture
@@ -31,9 +35,62 @@ def rule_runner() -> RuleRunner:
             *chart.rules(),
             *chart_infer_rules(),
             *target_types_rules(),
+            QueryRule(FirstPartyHelmChartMapping, ()),
             QueryRule(InferredDependencies, (InferHelmChartDependenciesRequest,)),
         ],
     )
+
+
+def test_build_first_party_mapping(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "src/BUILD": "helm_chart(name='foo')",
+            "src/Chart.yaml": dedent(
+                """\
+                apiVersion: v2
+                name: chart-name
+                version: 0.1.0
+                """
+            ),
+        }
+    )
+
+    tgt = rule_runner.get_target(Address("src", target_name="foo"))
+    mapping = rule_runner.request(FirstPartyHelmChartMapping, [])
+    assert mapping["chart-name"] == tgt.address
+
+
+def test_duplicate_first_party_mappings(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "src/foo/BUILD": "helm_chart()",
+            "src/foo/Chart.yaml": dedent(
+                """\
+                apiVersion: v2
+                name: chart-name
+                version: 0.1.0
+                """
+            ),
+            "src/bar/BUILD": "helm_chart()",
+            "src/bar/Chart.yaml": dedent(
+                """\
+                apiVersion: v2
+                name: chart-name
+                version: 0.1.0
+                """
+            ),
+        }
+    )
+
+    expected_err_msg = (
+        "Found more than one `helm_chart` target using the same chart name:\n\n"
+        f"{bullet_list(['src/bar:bar -> chart-name', 'src/foo:foo -> chart-name'])}"
+    )
+
+    with pytest.raises(ExecutionError) as err_info:
+        rule_runner.request(FirstPartyHelmChartMapping, [])
+
+    assert expected_err_msg in err_info.value.args[0]
 
 
 def test_infer_chart_dependencies(rule_runner: RuleRunner) -> None:
@@ -43,7 +100,7 @@ def test_infer_chart_dependencies(rule_runner: RuleRunner) -> None:
                 """\
                 helm_artifact(
                   name="cert-manager",
-                  repository="@jetstack",
+                  repository="https://charts.jetstack.io",
                   artifact="cert-manager",
                   version="v0.7.0"
                 )
@@ -57,7 +114,7 @@ def test_infer_chart_dependencies(rule_runner: RuleRunner) -> None:
                 version: 0.1.0
                 dependencies:
                 - name: cert-manager
-                  repository: "@jetstack"
+                  repository: "https://charts.jetstack.io"
                 - name: bar
                 - name: quxx
                 """
@@ -82,11 +139,9 @@ def test_infer_chart_dependencies(rule_runner: RuleRunner) -> None:
     )
 
     source_root_patterns = ("/src/*",)
-    repositories_opts = """{"jetstack": {"address": "https://charts.jetstack.io"}}"""
     rule_runner.set_options(
         [
             f"--source-root-patterns={repr(source_root_patterns)}",
-            f"--helm-classic-repositories={repositories_opts}",
         ]
     )
 
@@ -96,6 +151,47 @@ def test_infer_chart_dependencies(rule_runner: RuleRunner) -> None:
     )
     assert set(inferred_deps.dependencies) == {
         Address("3rdparty/helm/jetstack", target_name="cert-manager"),
+        Address("src/bar", target_name="bar"),
+    }
+
+
+def test_disambiguate_chart_dependencies(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "3rdparty/bar/BUILD": dedent(
+                """\
+                helm_artifact(artifact="bar", version="0.1.0", registry="oci://example.com/charts")
+                """
+            ),
+            "src/foo/BUILD": """helm_chart(dependencies=["!//3rdparty/bar"])""",
+            "src/foo/Chart.yaml": dedent(
+                """\
+                apiVersion: v2
+                name: foo
+                version: 0.1.0
+                dependencies:
+                - name: bar
+                """
+            ),
+            "src/bar/BUILD": """helm_chart()""",
+            "src/bar/Chart.yaml": dedent(
+                """\
+                apiVersion: v2
+                name: bar
+                version: 0.1.0
+                """
+            ),
+        }
+    )
+
+    source_root_patterns = ("/src/*",)
+    rule_runner.set_options([f"--source-root-patterns={repr(source_root_patterns)}"])
+
+    tgt = rule_runner.get_target(Address("src/foo", target_name="foo"))
+    inferred_deps = rule_runner.request(
+        InferredDependencies, [InferHelmChartDependenciesRequest(tgt[HelmChartMetaSourceField])]
+    )
+    assert set(inferred_deps.dependencies) == {
         Address("src/bar", target_name="bar"),
     }
 

--- a/src/python/pants/backend/helm/resolve/artifacts_test.py
+++ b/src/python/pants/backend/helm/resolve/artifacts_test.py
@@ -8,12 +8,11 @@ from textwrap import dedent
 import pytest
 
 from pants.backend.helm.resolve.artifacts import (
-    FirstPartyArtifactMapping,
     HelmArtifact,
-    HelmArtifactClassicRepositoryLocation,
-    HelmArtifactRegistryLocation,
+    HelmArtifactClassicRepositoryLocationSpec,
+    HelmArtifactRegistryLocationSpec,
     HelmArtifactRequirement,
-    ThirdPartyArtifactMapping,
+    ThirdPartyHelmArtifactMapping,
 )
 from pants.backend.helm.resolve.artifacts import rules as artifacts_rules
 from pants.backend.helm.target_types import (
@@ -22,16 +21,9 @@ from pants.backend.helm.target_types import (
     HelmChartTarget,
 )
 from pants.backend.helm.target_types import rules as target_types_rules
-from pants.backend.helm.testutil import (
-    HELM_TEMPLATE_HELPERS_FILE,
-    HELM_VALUES_FILE,
-    K8S_SERVICE_FILE,
-)
 from pants.engine.addresses import Address
-from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
-from pants.util.strutil import bullet_list
 
 
 @pytest.fixture
@@ -42,71 +34,9 @@ def rule_runner() -> RuleRunner:
             *artifacts_rules(),
             *target_types_rules(),
             QueryRule(AllHelmArtifactTargets, ()),
-            QueryRule(FirstPartyArtifactMapping, ()),
-            QueryRule(ThirdPartyArtifactMapping, ()),
+            QueryRule(ThirdPartyHelmArtifactMapping, ()),
         ],
     )
-
-
-def test_build_first_party_mapping(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files(
-        {
-            "src/BUILD": "helm_chart(name='foo')",
-            "src/Chart.yaml": dedent(
-                """\
-                apiVersion: v2
-                name: chart-name
-                version: 0.1.0
-                """
-            ),
-            "src/values.yaml": HELM_VALUES_FILE,
-            "src/templates/_helpers.tpl": HELM_TEMPLATE_HELPERS_FILE,
-            "src/templates/service.yaml": K8S_SERVICE_FILE,
-        }
-    )
-
-    tgt = rule_runner.get_target(Address("src", target_name="foo"))
-    mapping = rule_runner.request(FirstPartyArtifactMapping, [])
-    assert mapping["chart-name"] == tgt.address
-
-
-def test_duplicate_first_party_artifact_mappings(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files(
-        {
-            "src/foo/BUILD": "helm_chart()",
-            "src/foo/Chart.yaml": dedent(
-                """\
-                apiVersion: v2
-                name: chart-name
-                version: 0.1.0
-                """
-            ),
-            "src/foo/values.yaml": HELM_VALUES_FILE,
-            "src/foo/templates/_helpers.tpl": HELM_TEMPLATE_HELPERS_FILE,
-            "src/foo/templates/service.yaml": K8S_SERVICE_FILE,
-            "src/bar/BUILD": "helm_chart()",
-            "src/bar/Chart.yaml": dedent(
-                """\
-                apiVersion: v2
-                name: chart-name
-                version: 0.1.0
-                """
-            ),
-            "src/bar/values.yaml": HELM_VALUES_FILE,
-            "src/bar/templates/_helpers.tpl": HELM_TEMPLATE_HELPERS_FILE,
-            "src/bar/templates/service.yaml": K8S_SERVICE_FILE,
-        }
-    )
-
-    expected_err_msg = (
-        "Found more than one `helm_chart` target using the same chart name:\n\n"
-        f"{bullet_list(['src/bar:bar -> chart-name', 'src/foo:foo -> chart-name'])}"
-    )
-
-    with pytest.raises(ExecutionError) as err_info:
-        rule_runner.request(FirstPartyArtifactMapping, [])
-
-    assert expected_err_msg in err_info.value.args[0]
 
 
 def test_build_third_party_mapping(rule_runner: RuleRunner) -> None:
@@ -116,15 +46,22 @@ def test_build_third_party_mapping(rule_runner: RuleRunner) -> None:
                 """\
                 helm_artifact(
                   name="foo",
-                  registry="oci://www.example.com",
+                  registry="oci://www.example.com/",
                   repository="charts",
                   artifact="foo",
                   version="0.1.0",
                 )
                 helm_artifact(
                   name="bar",
-                  repository="@example",
+                  repository="https://www.example.com/charts",
                   artifact="bar",
+                  version="0.1.0",
+                )
+                helm_artifact(
+                  name="quux",
+                  registry="@quux",
+                  repository="quux-charts",
+                  artifact="quux",
                   version="0.1.0",
                 )
                 """
@@ -136,7 +73,7 @@ def test_build_third_party_mapping(rule_runner: RuleRunner) -> None:
         requirement=HelmArtifactRequirement(
             name="foo",
             version="0.1.0",
-            location=HelmArtifactRegistryLocation(
+            location=HelmArtifactRegistryLocationSpec(
                 registry="oci://www.example.com", repository="charts"
             ),
         ),
@@ -146,21 +83,36 @@ def test_build_third_party_mapping(rule_runner: RuleRunner) -> None:
         requirement=HelmArtifactRequirement(
             name="bar",
             version="0.1.0",
-            location=HelmArtifactClassicRepositoryLocation("@example"),
+            location=HelmArtifactClassicRepositoryLocationSpec("https://www.example.com/charts"),
         ),
         address=Address("3rdparty/helm/example", target_name="bar"),
     )
+    expected_quux = HelmArtifact(
+        requirement=HelmArtifactRequirement(
+            name="quux",
+            version="0.1.0",
+            location=HelmArtifactRegistryLocationSpec(registry="@quux", repository="quux-charts"),
+        ),
+        address=Address("3rdparty/helm/example", target_name="quux"),
+    )
 
-    repositories_opts = """{"example": {"address": "https://www.example.com/charts"}}"""
-    rule_runner.set_options([f"--helm-classic-repositories={repositories_opts}"])
+    registries_opts = """{"quux": {"address": "oci://www.example.com"}}"""
+    rule_runner.set_options(
+        [
+            f"--helm-registries={registries_opts}",
+        ]
+    )
 
     tgts = rule_runner.request(AllHelmArtifactTargets, [])
     artifacts = [HelmArtifact.from_target(tgt) for tgt in tgts]
 
-    assert len(artifacts) == 2
+    assert len(artifacts) == 3
     assert expected_foo in artifacts
     assert expected_bar in artifacts
+    assert expected_quux in artifacts
 
-    mapping = rule_runner.request(ThirdPartyArtifactMapping, [])
+    mapping = rule_runner.request(ThirdPartyHelmArtifactMapping, [])
+    assert len(mapping) == 3
     assert mapping["oci://www.example.com/charts/foo"] == expected_foo.address
-    assert mapping["example/bar"] == expected_bar.address
+    assert mapping["https://www.example.com/charts/bar"] == expected_bar.address
+    assert mapping["oci://www.example.com/quux-charts/quux"] == expected_quux.address

--- a/src/python/pants/backend/helm/resolve/remotes.py
+++ b/src/python/pants/backend/helm/resolve/remotes.py
@@ -112,6 +112,11 @@ class HelmRemotes:
                 yield HelmClassicRepository(address=alias_or_address)
 
     @memoized_method
+    def registries(self) -> tuple[HelmRegistry, ...]:
+        deduped_regs = {r for _, r in self.all.items() if isinstance(r, HelmRegistry)}
+        return tuple(deduped_regs)
+
+    @memoized_method
     def classic_repositories(self) -> tuple[HelmClassicRepository, ...]:
         deduped_repos = {r for _, r in self.all.items() if isinstance(r, HelmClassicRepository)}
         return tuple(deduped_repos)

--- a/src/python/pants/backend/helm/resolve/remotes.py
+++ b/src/python/pants/backend/helm/resolve/remotes.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-from abc import ABC
 from dataclasses import dataclass
 from typing import Any, Iterator, cast
 
@@ -24,32 +23,15 @@ class InvalidHelmRegistryAddress(ValueError):
         )
 
 
-class InvalidHelmClassicRepositoryAddress(ValueError):
-    def __init__(self, alias: str, address: str) -> None:
-        super().__init__(
-            f"The classic repository '{alias}' can not have an OCI address URL "
-            f"(using protocol '{OCI_REGISTRY_PROTOCOL}'). The given address was instead: {address}"
-        )
-
-
 class HelmRemoteAliasNotFoundError(ValueError):
     def __init__(self, alias: str) -> None:
         super().__init__(f"There is no Helm remote configured with alias: {alias}")
 
 
 @dataclass(frozen=True)
-class HelmRemote(ABC):
+class HelmRegistry:
     address: str
     alias: str = ""
-
-    def register(self, remotes: dict[str, HelmRemote]) -> None:
-        remotes[self.address] = self
-        if self.alias:
-            remotes[f"@{self.alias}"] = self
-
-
-@dataclass(frozen=True)
-class HelmRegistry(HelmRemote):
     default: bool = False
 
     @classmethod
@@ -64,30 +46,26 @@ class HelmRegistry(HelmRemote):
         if not self.address.startswith(OCI_REGISTRY_PROTOCOL):
             raise InvalidHelmRegistryAddress(self.alias, self.address)
 
+    def register(self, remotes: dict[str, HelmRegistry]) -> None:
+        remotes[self.address] = self
+        if self.alias:
+            remotes[f"@{self.alias}"] = self
 
-@dataclass(frozen=True)
-class HelmClassicRepository(HelmRemote):
-    @classmethod
-    def from_dict(cls, alias: str, d: dict[str, Any]) -> HelmClassicRepository:
-        return cls(alias=alias, address=cast(str, d["address"]).rstrip("/"))
-
-    def __post_init__(self) -> None:
-        if self.address.startswith(OCI_REGISTRY_PROTOCOL):
-            raise InvalidHelmClassicRepositoryAddress(self.alias, self.address)
+    @property
+    def ref(self) -> str:
+        return self.address
 
 
 @dataclass(frozen=True)
 class HelmRemotes:
     default: tuple[HelmRegistry, ...]
-    all: FrozenDict[str, HelmRemote]
+    all: FrozenDict[str, HelmRegistry]
 
     @classmethod
-    def from_dicts(cls, d_regs: dict[str, Any], d_repos: dict[str, Any]) -> HelmRemotes:
-        remotes: dict[str, HelmRemote] = {}
+    def from_dict(cls, d_regs: dict[str, Any]) -> HelmRemotes:
+        remotes: dict[str, HelmRegistry] = {}
         for alias, opts in d_regs.items():
             HelmRegistry.from_dict(alias, opts).register(remotes)
-        for alias, opts in d_repos.items():
-            HelmClassicRepository.from_dict(alias, opts).register(remotes)
         return cls(
             default=tuple(
                 sorted(
@@ -98,7 +76,7 @@ class HelmRemotes:
             all=FrozenDict(remotes),
         )
 
-    def get(self, *aliases_or_addresses: str) -> Iterator[HelmRemote]:
+    def get(self, *aliases_or_addresses: str) -> Iterator[HelmRegistry]:
         for alias_or_address in aliases_or_addresses:
             if alias_or_address in self.all:
                 yield self.all[alias_or_address]
@@ -108,24 +86,15 @@ class HelmRemotes:
                 yield from self.default
             elif alias_or_address.startswith(OCI_REGISTRY_PROTOCOL):
                 yield HelmRegistry(address=alias_or_address)
-            else:
-                yield HelmClassicRepository(address=alias_or_address)
 
     @memoized_method
     def registries(self) -> tuple[HelmRegistry, ...]:
         deduped_regs = {r for _, r in self.all.items() if isinstance(r, HelmRegistry)}
         return tuple(deduped_regs)
 
-    @memoized_method
-    def classic_repositories(self) -> tuple[HelmClassicRepository, ...]:
-        deduped_repos = {r for _, r in self.all.items() if isinstance(r, HelmClassicRepository)}
-        return tuple(deduped_repos)
-
     @property
     def default_registry(self) -> HelmRegistry | None:
         remote = self.all.get("default")
-        if remote:
-            return cast(HelmRegistry, remote)
         if not remote and self.default:
-            return self.default[0]
-        return None
+            remote = self.default[0]
+        return remote

--- a/src/python/pants/backend/helm/resolve/remotes_test.py
+++ b/src/python/pants/backend/helm/resolve/remotes_test.py
@@ -1,13 +1,11 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import cast
 
 import pytest
 
 from pants.backend.helm.resolve.remotes import (
     ALL_DEFAULT_HELM_REGISTRIES,
-    HelmClassicRepository,
     HelmRegistry,
     HelmRemoteAliasNotFoundError,
     HelmRemotes,
@@ -15,18 +13,19 @@ from pants.backend.helm.resolve.remotes import (
 
 
 def test_helm_remotes() -> None:
-    remotes = HelmRemotes.from_dicts(
-        {"reg1": {"address": "oci://www.example.com"}},
-        {"repo1": {"address": "https://www.example.com"}},
+    remotes = HelmRemotes.from_dict(
+        {
+            "reg1": {"address": "oci://www.example.com"},
+            "reg2": {"address": "oci://www.example.com/subfolder"},
+        },
     )
 
     assert remotes.default == ()
     assert list(remotes.get()) == []
     assert len(list(remotes.get("@reg1"))) == 1
-    assert len(list(remotes.get("@repo1"))) == 1
-    assert len(list(remotes.get("@reg1", "@repo1"))) == 2
+    assert len(list(remotes.get("@reg1", "@reg2"))) == 2
     assert next(remotes.get("@reg1")).address == "oci://www.example.com"
-    assert next(remotes.get("@repo1")).address == "https://www.example.com"
+    assert next(remotes.get("@reg2")).address == "oci://www.example.com/subfolder"
 
     with pytest.raises(HelmRemoteAliasNotFoundError):
         list(remotes.get("@reg3"))
@@ -34,23 +33,18 @@ def test_helm_remotes() -> None:
     assert list(remotes.get("oci://www.example.com/charts")) == [
         HelmRegistry(address="oci://www.example.com/charts")
     ]
-    assert list(remotes.get("https://www.example.com/charts")) == [
-        HelmClassicRepository(address="https://www.example.com/charts")
-    ]
 
     # Test defaults.
-    remotes = HelmRemotes.from_dicts(
+    remotes = HelmRemotes.from_dict(
         {
             "default": {"address": "oci://www.example.com/default"},
             "reg1": {"address": "oci://www.example.com/charts1", "default": "false"},
             "reg2": {"address": "oci://www.example.com/charts2", "default": "true"},
             "reg3": {"address": "oci://www.example.com/charts3", "default": "true"},
         },
-        {},
     )
-    print(remotes.default)
 
-    assert cast(HelmRegistry, next(remotes.get("@reg2"))).default is True
+    assert next(remotes.get("@reg2")).default is True
     assert [r.address for r in remotes.default] == [
         "oci://www.example.com/charts2",
         "oci://www.example.com/charts3",

--- a/src/python/pants/backend/helm/subsystems/helm.py
+++ b/src/python/pants/backend/helm/subsystems/helm.py
@@ -7,12 +7,7 @@ import os
 from typing import Any
 
 from pants.backend.helm.resolve.remotes import HelmRemotes
-from pants.backend.helm.target_types import (
-    HelmArtifactRepositoryField,
-    HelmArtifactTarget,
-    HelmChartTarget,
-    HelmRegistriesField,
-)
+from pants.backend.helm.target_types import HelmChartTarget, HelmRegistriesField
 from pants.core.util_rules.external_tool import TemplatedExternalTool
 from pants.engine.platform import Platform
 from pants.option.option_types import BoolOption, DictOption
@@ -44,26 +39,6 @@ registries_help = softwrap(
     """
 )
 
-classic_repositories_help = softwrap(
-    f"""
-    Configure Helm Classic repositories. The schema for a registry entry is as follows:
-
-        {{
-            "repository-alias": {{
-                "address": "http://repository-domain:port",
-            }},
-            ...
-        }}
-
-    Classic repositories are used to provide support for Helm third party charts available at Chart Museum
-    or similar places.
-
-    To be able to reference third party charts in classic repos, you need to assign an alias to each of them
-    as per the previous schema and then declare a `{HelmArtifactTarget.alias}` target and set its
-    `{HelmArtifactRepositoryField.alias}` to the given alias of the classic repository prefixed by a `@`.
-    """
-)
-
 
 class HelmSubsystem(TemplatedExternalTool):
     options_scope = "helm"
@@ -85,9 +60,6 @@ class HelmSubsystem(TemplatedExternalTool):
     }
 
     _registries = DictOption[Any]("--registries", help=registries_help, fromfile=True)
-    _classic_repositories = DictOption[Any](
-        "--classic-repositories", help=classic_repositories_help, fromfile=True
-    )
     lint_strict = BoolOption(
         "--lint-strict", default=False, help="Enables strict linting of Helm charts"
     )
@@ -99,4 +71,4 @@ class HelmSubsystem(TemplatedExternalTool):
 
     @memoized_method
     def remotes(self) -> HelmRemotes:
-        return HelmRemotes.from_dicts(self._registries, self._classic_repositories)
+        return HelmRemotes.from_dict(self._registries)

--- a/src/python/pants/backend/helm/target_types.py
+++ b/src/python/pants/backend/helm/target_types.py
@@ -228,14 +228,22 @@ class HelmUnitTestTestsGeneratorTarget(TargetFilesGenerator):
 
 class HelmArtifactRegistryField(StringField):
     alias = "registry"
-    help = (
-        "Registry alias (prefixed by `@`) configured in `[helm.registries]` for the Helm artifact."
+    help = softwrap(
+        """
+        Either registry alias (prefixed by `@`) configured in `[helm.registries]` for the
+        Helm artifact or the full OCI registry URL.
+        """
     )
 
 
 class HelmArtifactRepositoryField(StringField):
     alias = "repository"
-    help = "Either an alias (prefixed by `@`) to a classic Helm repository configured in `[helm.registries]` or a path inside an OCI registry."
+    help = softwrap(
+        f"""
+        Either a HTTP(S) URL to a classic repository, or a path inside an OCI registry (when
+        `{HelmArtifactRegistryField.alias}` is provided).
+        """
+    )
 
 
 class HelmArtifactArtifactField(StringField):

--- a/src/python/pants/backend/helm/util_rules/chart_metadata.py
+++ b/src/python/pants/backend/helm/util_rules/chart_metadata.py
@@ -11,7 +11,6 @@ from typing import Any, cast
 
 import yaml
 
-from pants.backend.helm.resolve.remotes import OCI_REGISTRY_PROTOCOL, HelmRemotes
 from pants.backend.helm.target_types import HelmChartMetaSourceField
 from pants.backend.helm.util_rules.yaml_utils import snake_case_attr_dict
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
@@ -86,18 +85,6 @@ class HelmChartDependency:
         if self.import_values:
             d["import-values"] = list(self.import_values)
         return d
-
-    def remote_spec(self, remotes: HelmRemotes) -> str:
-        if not self.repository:
-            registry = remotes.default_registry
-            if registry:
-                return f"{registry.address}/{self.name}"
-            return self.name
-        elif self.repository.startswith(OCI_REGISTRY_PROTOCOL):
-            return f"{self.repository}/{self.name}"
-        else:
-            remote = remotes.all[self.repository]
-            return f"{remote.alias}/{self.name}"
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Closes #15094 and #15095 which were discovered when working on a PoC for producing Helm lockfiles. 

Removing the need to configure Helm classic repositories leads to a more general solution when fetching 3rd party artifacts and makes it easier to pupulate into the chart's metadata any dependency that may not been listed in `Chart.yaml`, but specified in the `dependencies` field of a `helm_chart`.
