### PR TITLE
Preserve tombstones for workunits which complete while they still have children (cherrypick of #15088)

### DIFF
--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -456,7 +456,7 @@ impl ByteStore {
     async {
       in_workunit!(
         "list_missing_digests",
-        Level::Debug,
+        Level::Trace,
         |_workunit| async move {
           let store2 = store.clone();
           let client = store2.cas_client.as_ref().clone();

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -89,10 +89,14 @@ impl crate::CommandRunner for CommandRunner {
             // When we successfully use the cache, we change the description and increase the level
             // (but not so much that it will be logged by default).
             workunit.update_metadata(|initial| {
-              initial.map(|initial| WorkunitMetadata {
-                desc: initial.desc.as_ref().map(|desc| format!("Hit: {}", desc)),
-                level: Level::Debug,
-                ..initial
+              initial.map(|(initial, _)| {
+                (
+                  WorkunitMetadata {
+                    desc: initial.desc.as_ref().map(|desc| format!("Hit: {}", desc)),
+                    ..initial
+                  },
+                  Level::Debug,
+                )
               })
             });
             Ok(result)

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -299,16 +299,14 @@ impl CommandRunner {
               // When we successfully use the cache, we change the description and increase the level
               // (but not so much that it will be logged by default).
               workunit.update_metadata(|initial| {
-                initial.map(|initial|
-                WorkunitMetadata {
+                initial.map(|(initial, _)|
+                (WorkunitMetadata {
                   desc: initial
                     .desc
                     .as_ref()
                     .map(|desc| format!("Hit: {}", desc)),
-                  level: Level::Debug,
                   ..initial
-
-                })
+                }, Level::Debug))
               });
               Ok((cached_response, true))
             } else {

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -691,7 +691,7 @@ async fn workunit_to_py_value(
       ),
       (
         externs::store_utf8(py, "level"),
-        externs::store_utf8(py, &metadata.level.to_string()),
+        externs::store_utf8(py, &workunit.level.to_string()),
       ),
     ];
 

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -434,24 +434,29 @@ impl WrappedNode for ExecuteProcess {
     let definition = serde_json::to_string(&request)
       .map_err(|e| throw(format!("Failed to serialize process: {}", e)))?;
     workunit.update_metadata(|initial| {
-      initial.map(|initial| WorkunitMetadata {
-        stdout: Some(res.stdout_digest),
-        stderr: Some(res.stderr_digest),
-        user_metadata: vec![
-          (
-            "definition".to_string(),
-            UserMetadataItem::ImmediateString(definition),
-          ),
-          (
-            "source".to_string(),
-            UserMetadataItem::ImmediateString(format!("{:?}", res.metadata.source)),
-          ),
-          (
-            "exit_code".to_string(),
-            UserMetadataItem::ImmediateInt(res.exit_code as i64),
-          ),
-        ],
-        ..initial
+      initial.map(|(initial, level)| {
+        (
+          WorkunitMetadata {
+            stdout: Some(res.stdout_digest),
+            stderr: Some(res.stderr_digest),
+            user_metadata: vec![
+              (
+                "definition".to_string(),
+                UserMetadataItem::ImmediateString(definition),
+              ),
+              (
+                "source".to_string(),
+                UserMetadataItem::ImmediateString(format!("{:?}", res.metadata.source)),
+              ),
+              (
+                "exit_code".to_string(),
+                UserMetadataItem::ImmediateInt(res.exit_code as i64),
+              ),
+            ],
+            ..initial
+          },
+          level,
+        )
       })
     });
     if let Some(total_elapsed) = res.metadata.total_elapsed {

--- a/src/rust/engine/workunit_store/src/tests.rs
+++ b/src/rust/engine/workunit_store/src/tests.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use internment::Intern;
 
-use crate::{Level, SpanId, WorkunitMetadata, WorkunitState, WorkunitStore};
+use crate::{Level, ParentIds, SpanId, WorkunitMetadata, WorkunitState, WorkunitStore};
 
 #[test]
 fn heavy_hitters_basic() {
@@ -59,6 +59,30 @@ fn straggling_workunits_blocked_path() {
 }
 
 #[tokio::test]
+async fn disabled_workunit_is_filtered() {
+  // Create a chain of completed workunits like: Info -> Trace -> Info (where `Trace` is below the
+  // minimum level recoded in the store).
+  let ws = create_store(
+    vec![],
+    vec![],
+    vec![
+      wu_level(0, None, Level::Info),
+      wu_level(1, Some(0), Level::Trace),
+      wu_level(2, Some(1), Level::Info),
+    ],
+  );
+
+  // Confirm that latest_workunits reports the two Info level workunits while fixing up parent links.
+  let (_, completed) = ws.latest_workunits(Level::Info);
+  assert_eq!(completed.len(), 2);
+  assert_eq!(completed[0].parent_ids, ParentIds::new());
+  assert_eq!(
+    completed[1].parent_ids,
+    vec![SpanId(0)].into_iter().collect::<ParentIds>()
+  );
+}
+
+#[tokio::test]
 async fn workunit_escalation_is_recorded() {
   // Create a store which will disable Debug level workunits.
   let ws = WorkunitStore::new(true, Level::Info);
@@ -75,12 +99,14 @@ async fn workunit_escalation_is_recorded() {
         // Ensure that it has no metadata (i.e.: is disabled).
         assert!(metadata.is_none());
 
-        // Then return new metadata to raise the workunit's level.
-        Some(WorkunitMetadata {
-          level: Level::Info,
-          desc: Some(new_desc.to_owned()),
-          ..WorkunitMetadata::default()
-        })
+        // Then return new metadata and raise the workunit's level.
+        Some((
+          WorkunitMetadata {
+            desc: Some(new_desc.to_owned()),
+            ..WorkunitMetadata::default()
+          },
+          Level::Info,
+        ))
       });
     }
   )
@@ -128,11 +154,11 @@ fn create_store(
 ) -> WorkunitStore {
   let completed_ids = completed
     .iter()
-    .map(|(span_id, _, _)| *span_id)
+    .map(|(_, span_id, _, _)| *span_id)
     .collect::<HashSet<_>>();
   let blocked_ids = blocked
     .iter()
-    .map(|(span_id, _, _)| *span_id)
+    .map(|(_, span_id, _, _)| *span_id)
     .collect::<HashSet<_>>();
   let ws = WorkunitStore::new(true, log::Level::Debug);
 
@@ -142,18 +168,19 @@ fn create_store(
     .chain(blocked.into_iter())
     .chain(completed.into_iter())
     .collect::<Vec<_>>();
-  all.sort_by(|a, b| a.0.cmp(&b.0));
+  all.sort_by(|a, b| a.1.cmp(&b.1));
 
   // Start all workunits in SpanId order.
   let workunits = all
     .into_iter()
-    .map(|(span_id, parent_id, metadata)| {
+    .map(|(level, span_id, parent_id, metadata)| {
       if let Some(parent_id) = parent_id {
         assert!(span_id > parent_id);
       }
       ws._start_workunit(
         span_id,
         Intern::new(format!("{}", span_id.0)).as_ref(),
+        level,
         parent_id,
         Some(metadata),
       )
@@ -178,21 +205,18 @@ fn create_store(
 
 // Used with `create_store` to quickly create a tree of anonymous workunits (with names equal to
 // their SpanIds).
-type AnonymousWorkunit = (SpanId, Option<SpanId>, WorkunitMetadata);
+type AnonymousWorkunit = (Level, SpanId, Option<SpanId>, WorkunitMetadata);
 
 fn wu_root(span_id: u64) -> AnonymousWorkunit {
-  wu_meta(span_id, None, WorkunitMetadata::default())
+  wu_level(span_id, None, Level::Info)
 }
 
 fn wu(span_id: u64, parent_id: u64) -> AnonymousWorkunit {
-  wu_meta(span_id, Some(parent_id), WorkunitMetadata::default())
+  wu_level(span_id, Some(parent_id), Level::Info)
 }
 
-fn wu_meta(
-  span_id: u64,
-  parent_id: Option<u64>,
-  mut metadata: WorkunitMetadata,
-) -> AnonymousWorkunit {
+fn wu_level(span_id: u64, parent_id: Option<u64>, level: Level) -> AnonymousWorkunit {
+  let mut metadata = WorkunitMetadata::default();
   metadata.desc = Some(format!("{}", span_id));
-  (SpanId(span_id), parent_id.map(SpanId), metadata)
+  (level, SpanId(span_id), parent_id.map(SpanId), metadata)
 }


### PR DESCRIPTION
#15080 was caused by two factors:

1. #14541 made counters global via a new API, and attached them (as deprecated) to "the root workunit" (with "has no parent id" as the heuristic that something was the root workunit).
2. #14856 moved to calculating the parent(s) of a node based on a running graph of workunits (to allow #14680 to eventually add multiple parents), which meant that when nodes completed out of order, we might not have any parents for them.

Together: this meant that when workunits completed asynchronously, we might not have parents for them, and because of the deprecation, we would attach the counters to multiple workunits. A consumer which was aggregating the counters would end up with an inaccurate total.

Fixes #15080.