### PR TITLE
[internal] cleanup linters to remove separate "setup" rules

### DIFF
--- a/src/python/pants/backend/java/lint/google_java_format/skip_field.py
+++ b/src/python/pants/backend/java/lint/google_java_format/skip_field.py
@@ -1,7 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.java.target_types import JavaSourceField, JavaSourceTarget
+from pants.backend.java.target_types import JavaSourcesGeneratorTarget, JavaSourceTarget
 from pants.engine.target import BoolField
 
 
@@ -12,4 +12,7 @@ class SkipGoogleJavaFormatField(BoolField):
 
 
 def rules():
-    return [JavaSourceTarget.register_plugin_field(JavaSourceField)]
+    return [
+        JavaSourceTarget.register_plugin_field(SkipGoogleJavaFormatField),
+        JavaSourcesGeneratorTarget.register_plugin_field(SkipGoogleJavaFormatField),
+    ]


### PR DESCRIPTION
Cleanup linters still using a "setup" rule to remove to setup rules since they are no longer necessary.

Also fixes registration of the "skip_googlejavaformat" field which was incorrect.

[ci skip-build-wheels]