### PR TITLE
Ban `terraform_module` referring to subdirectories

### DIFF
--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -138,6 +138,7 @@ class GoModTarget(TargetGenerator):
 class GoPackageSourcesField(MultipleSourcesField):
     default = ("*.go", "*.s")
     expected_file_extensions = (".go", ".s")
+    ban_subdirectories = True
 
     @classmethod
     def compute_value(
@@ -148,18 +149,6 @@ class GoPackageSourcesField(MultipleSourcesField):
             raise InvalidFieldException(
                 f"The {repr(cls.alias)} field in target {address} must be set to files/globs in "
                 f"the target's directory, but it was set to {repr(value_or_default)}."
-            )
-
-        # Ban recursive globs and subdirectories. We assume that a `go_package` corresponds
-        # to exactly one directory.
-        invalid_globs = [
-            glob for glob in (value_or_default or ()) if "**" in glob or os.path.sep in glob
-        ]
-        if invalid_globs:
-            raise InvalidFieldException(
-                f"The {repr(cls.alias)} field in target {address} must only have globs for the "
-                f"target's directory, i.e. it cannot include values with `**` and `{os.path.sep}`, "
-                f"but it was set to: {sorted(value_or_default)}"
             )
         return value_or_default
 

--- a/src/python/pants/backend/terraform/target_types.py
+++ b/src/python/pants/backend/terraform/target_types.py
@@ -18,6 +18,7 @@ from pants.engine.target import (
 class TerraformModuleSourcesField(MultipleSourcesField):
     default = ("*.tf",)
     expected_file_extensions = (".tf",)
+    ban_subdirectories = True
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1893,11 +1893,14 @@ class MultipleSourcesField(SourcesField, StringSequenceField):
             invalid_globs = [glob for glob in (value or ()) if "**" in glob or os.path.sep in glob]
             if invalid_globs:
                 raise InvalidFieldException(
-                    f"The {repr(cls.alias)} field in target {address} must only have globs for the "
-                    f"target's directory, i.e. it cannot include values with `**` and `{os.path.sep}`, "
-                    f"but it was set to: {sorted(value or ())}"
+                    softwrap(
+                        f"""
+                        The {repr(cls.alias)} field in target {address} must only have globs for
+                        the target's directory, i.e. it cannot include values with `**` or
+                        `{os.path.sep}`. It was set to: {sorted(value or ())}
+                        """
+                    )
                 )
-
         return value
 
 

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1895,7 +1895,7 @@ class MultipleSourcesField(SourcesField, StringSequenceField):
                 raise InvalidFieldException(
                     f"The {repr(cls.alias)} field in target {address} must only have globs for the "
                     f"target's directory, i.e. it cannot include values with `**` and `{os.path.sep}`, "
-                    f"but it was set to: {sorted(value)}"
+                    f"but it was set to: {sorted(value or ())}"
                 )
 
         return value

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -1025,6 +1025,17 @@ def test_single_source_field_bans_globs() -> None:
         TestSingleSourceField("!f.ext", Address("project"))
 
 
+def test_multiple_sources_field_ban_subdirs() -> None:
+    class TestSources(MultipleSourcesField):
+        ban_subdirectories = True
+
+    assert TestSources(["f.ext"], Address("project")).value == ("f.ext",)
+    with pytest.raises(InvalidFieldException):
+        TestSources(["**"], Address("project"))
+    with pytest.raises(InvalidFieldException):
+        TestSources(["dir/f.ext"], Address("project"))
+
+
 # -----------------------------------------------------------------------------------------------
 # Test `ExplicitlyProvidedDependencies` helper functions
 # -----------------------------------------------------------------------------------------------


### PR DESCRIPTION
We were already assuming this, only not enforcing it. This is crucial to how "atom" targets work. We can now be confident that the target always refers to one directory.

[ci skip-rust]
[ci skip-build-wheels]