### PR TITLE
add experimental kotlin backend to distribution 

### DIFF
--- a/src/python/pants/backend/experimental/java/register.py
+++ b/src/python/pants/backend/experimental/java/register.py
@@ -59,5 +59,5 @@ def rules():
         *run_deploy_jar.rules(),
         *war_rules(),
         *java_bsp_rules.rules(),
-        *archive.rules()
+        *archive.rules(),
     ]

--- a/src/python/pants/backend/experimental/java/register.py
+++ b/src/python/pants/backend/experimental/java/register.py
@@ -13,6 +13,7 @@ from pants.backend.java.target_types import (
     JunitTestTarget,
 )
 from pants.backend.java.target_types import rules as target_types_rules
+from pants.core.util_rules import archive
 from pants.jvm import classpath, jdk_rules, resources, run_deploy_jar
 from pants.jvm import util_rules as jvm_util_rules
 from pants.jvm.dependency_inference import symbol_mapper
@@ -58,4 +59,5 @@ def rules():
         *run_deploy_jar.rules(),
         *war_rules(),
         *java_bsp_rules.rules(),
+        *archive.rules()
     ]

--- a/src/python/pants/backend/experimental/kotlin/register.py
+++ b/src/python/pants/backend/experimental/kotlin/register.py
@@ -5,11 +5,12 @@ from pants.backend.kotlin.goals import check, tailor
 from pants.backend.kotlin.target_types import KotlinSourcesGeneratorTarget, KotlinSourceTarget
 from pants.backend.kotlin.target_types import rules as target_types_rules
 from pants.core.util_rules import source_files, system_binaries
-from pants.jvm import classpath, jdk_rules, resources
+from pants.jvm import classpath, jdk_rules, resources, run_deploy_jar
 from pants.jvm import util_rules as jvm_util_rules
 from pants.jvm.goals import lockfile
+from pants.jvm.package import deploy_jar, war
 from pants.jvm.resolve import coursier_fetch, coursier_setup, jvm_tool
-from pants.jvm.target_types import JvmArtifactTarget
+from pants.jvm.target_types import DeployJarTarget, JvmArtifactTarget, JvmWarTarget
 
 
 def target_types():
@@ -17,6 +18,8 @@ def target_types():
         JvmArtifactTarget,
         KotlinSourceTarget,
         KotlinSourcesGeneratorTarget,
+        DeployJarTarget,
+        JvmWarTarget,
     ]
 
 
@@ -36,4 +39,7 @@ def rules():
         *resources.rules(),
         *system_binaries.rules(),
         *source_files.rules(),
+        *deploy_jar.rules(),
+        *run_deploy_jar.rules(),
+        *war.rules(),
     ]

--- a/src/python/pants/backend/experimental/kotlin/register.py
+++ b/src/python/pants/backend/experimental/kotlin/register.py
@@ -5,19 +5,16 @@ from pants.backend.kotlin.goals import check, tailor
 from pants.backend.kotlin.target_types import KotlinSourcesGeneratorTarget, KotlinSourceTarget
 from pants.backend.kotlin.target_types import rules as target_types_rules
 from pants.core.util_rules import source_files, system_binaries
-from pants.jvm import classpath, jdk_rules, resources, run_deploy_jar
+from pants.jvm import classpath, jdk_rules, resources
 from pants.jvm import util_rules as jvm_util_rules
-from pants.jvm.package.war import rules as war_rules
-from pants.jvm.resolve import coursier_fetch, coursier_setup, jvm_tool
-from pants.jvm.target_types import DeployJarTarget, JvmArtifactTarget, JvmWarTarget
 from pants.jvm.goals import lockfile
+from pants.jvm.resolve import coursier_fetch, coursier_setup, jvm_tool
+from pants.jvm.target_types import JvmArtifactTarget
 
 
 def target_types():
     return [
-        DeployJarTarget,
         JvmArtifactTarget,
-        JvmWarTarget,
         KotlinSourceTarget,
         KotlinSourcesGeneratorTarget,
     ]
@@ -37,8 +34,6 @@ def rules():
         *target_types_rules(),
         *jvm_tool.rules(),
         *resources.rules(),
-        *run_deploy_jar.rules(),
-        *war_rules(),
         *system_binaries.rules(),
         *source_files.rules(),
     ]

--- a/src/python/pants/backend/experimental/kotlin/register.py
+++ b/src/python/pants/backend/experimental/kotlin/register.py
@@ -10,6 +10,7 @@ from pants.jvm import util_rules as jvm_util_rules
 from pants.jvm.package.war import rules as war_rules
 from pants.jvm.resolve import coursier_fetch, coursier_setup, jvm_tool
 from pants.jvm.target_types import DeployJarTarget, JvmArtifactTarget, JvmWarTarget
+from pants.jvm.goals import lockfile
 
 
 def target_types():
@@ -28,6 +29,7 @@ def rules():
         *check.rules(),
         *tailor.rules(),
         *classpath.rules(),
+        *lockfile.rules(),
         *coursier_fetch.rules(),
         *coursier_setup.rules(),
         *jvm_util_rules.rules(),

--- a/src/python/pants/init/BUILD
+++ b/src/python/pants/init/BUILD
@@ -27,6 +27,8 @@ target(
         "src/python/pants/backend/experimental/java",
         "src/python/pants/backend/experimental/java/debug_goals",
         "src/python/pants/backend/experimental/java/lint/google_java_format",
+        "src/python/pants/backend/experimental/kotlin",
+        "src/python/pants/backend/experimental/kotlin/lint/ktlint",
         "src/python/pants/backend/experimental/python",
         "src/python/pants/backend/experimental/python/lint/autoflake",
         "src/python/pants/backend/experimental/python/lint/pyupgrade",


### PR DESCRIPTION
Add the experimental Kotlin backend to the Pants distribution. Adjusts some of the registration logic to fix a rule graph error and put the packaging rules at the bottom of the list.