### PR TITLE
[internal] cleanup callers of `find_jvm_artifacts_or_raise`

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/scala/dependency_inference.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/dependency_inference.py
@@ -1,5 +1,7 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 from pants.backend.codegen.protobuf.scala.subsystem import ScalaPBSubsystem
@@ -36,7 +38,7 @@ class ScalaPBRuntimeForResolveRequest:
 
 @dataclass(frozen=True)
 class ScalaPBRuntimeForResolve:
-    address: Address
+    addresses: frozenset[Address]
 
 
 @rule
@@ -65,7 +67,7 @@ async def resolve_scalapb_runtime_for_resolve(
             jvm_artifact_targets=jvm_artifact_targets,
             jvm=jvm,
         )
-        return ScalaPBRuntimeForResolve(list(addresses)[0])
+        return ScalaPBRuntimeForResolve(addresses)
     except ConflictingJvmArtifactVersion as ex:
         raise ConflictingScalaPBRuntimeVersionInResolveError(
             request.resolve_name, ex.required_version, ex.found_coordinate
@@ -91,7 +93,7 @@ async def inject_scalapb_runtime_dependency(
     scalapb_runtime_target_info = await Get(
         ScalaPBRuntimeForResolve, ScalaPBRuntimeForResolveRequest(resolve)
     )
-    return InjectedDependencies((scalapb_runtime_target_info.address,))
+    return InjectedDependencies(scalapb_runtime_target_info.addresses)
 
 
 class ConflictingScalaPBRuntimeVersionInResolveError(ValueError):

--- a/src/python/pants/backend/codegen/thrift/apache/java/rules.py
+++ b/src/python/pants/backend/codegen/thrift/apache/java/rules.py
@@ -1,5 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 from pants.backend.codegen.thrift.apache.java import subsystem
@@ -79,7 +81,7 @@ class ApacheThriftJavaRuntimeForResolveRequest:
 
 @dataclass(frozen=True)
 class ApacheThriftJavaRuntimeForResolve:
-    address: Address
+    addresses: frozenset[Address]
 
 
 _LIBTHRIFT_GROUP = "org.apache.thrift"
@@ -104,7 +106,7 @@ async def resolve_apache_thrift_java_runtime_for_resolve(
             jvm_artifact_targets=jvm_artifact_targets,
             jvm=jvm,
         )
-        return ApacheThriftJavaRuntimeForResolve(list(addresses)[0])
+        return ApacheThriftJavaRuntimeForResolve(addresses)
     except MissingJvmArtifacts:
         raise MissingApacheThriftJavaRuntimeInResolveError(
             request.resolve_name,
@@ -122,10 +124,10 @@ async def inject_apache_thrift_java_dependencies(
         return InjectedDependencies()
     resolve = target[JvmResolveField].normalized_value(jvm)
 
-    scalapb_runtime_target_info = await Get(
+    dependencies_info = await Get(
         ApacheThriftJavaRuntimeForResolve, ApacheThriftJavaRuntimeForResolveRequest(resolve)
     )
-    return InjectedDependencies((scalapb_runtime_target_info.address,))
+    return InjectedDependencies(dependencies_info.addresses)
 
 
 class MissingApacheThriftJavaRuntimeInResolveError(ValueError):

--- a/src/python/pants/backend/scala/dependency_inference/rules.py
+++ b/src/python/pants/backend/scala/dependency_inference/rules.py
@@ -119,7 +119,7 @@ class ScalaRuntimeForResolveRequest:
 
 @dataclass(frozen=True)
 class ScalaRuntimeForResolve:
-    address: Address
+    addresses: frozenset[Address]
 
 
 @rule
@@ -144,7 +144,7 @@ async def resolve_scala_library_for_resolve(
             jvm_artifact_targets=jvm_artifact_targets,
             jvm=jvm,
         )
-        return ScalaRuntimeForResolve(list(addresses)[0])
+        return ScalaRuntimeForResolve(addresses)
     except ConflictingJvmArtifactVersion as ex:
         raise ConflictingScalaLibraryVersionInResolveError(
             request.resolve_name, scala_version, ex.found_coordinate
@@ -168,7 +168,7 @@ async def inject_scala_library_dependency(
     scala_library_target_info = await Get(
         ScalaRuntimeForResolve, ScalaRuntimeForResolveRequest(resolve)
     )
-    return InjectedDependencies((scala_library_target_info.address,))
+    return InjectedDependencies(scala_library_target_info.addresses)
 
 
 @rule(desc="Inject dependency on scala plugin artifacts for Scala target.")


### PR DESCRIPTION
Cleanup callers of `find_jvm_artifacts_or_raise` to not assume anything about how many addresses it will return.

[ci skip-rust]

[ci skip-build-wheels]