### PR TITLE
Enable codegen on relocated files (Cherry-pick of #15100)

### DIFF
--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -247,7 +247,11 @@ async def relocate_files(request: RelocateFilesViaCodegenRequest) -> GeneratedSo
     original_files_sources = await MultiGet(
         Get(
             HydratedSources,
-            HydrateSourcesRequest(tgt.get(SourcesField), for_sources_types=(FileSourceField,)),
+            HydrateSourcesRequest(
+                tgt.get(SourcesField),
+                for_sources_types=(FileSourceField,),
+                enable_codegen=True,
+            ),
         )
         for tgt in original_file_targets
     )

--- a/src/python/pants/core/target_types_test.py
+++ b/src/python/pants/core/target_types_test.py
@@ -162,6 +162,52 @@ def test_relocated_files() -> None:
     )
 
 
+def test_relocated_relocated_files() -> None:
+    rule_runner = RuleRunner(
+        rules=[
+            *target_type_rules(),
+            *archive.rules(),
+            *source_files.rules(),
+            *system_binaries.rules(),
+            QueryRule(GeneratedSources, [RelocateFilesViaCodegenRequest]),
+            QueryRule(TransitiveTargets, [TransitiveTargetsRequest]),
+            QueryRule(SourceFiles, [SourceFilesRequest]),
+        ],
+        target_types=[FilesGeneratorTarget, RelocatedFiles],
+    )
+
+    rule_runner.write_files(
+        {
+            "original_prefix/file.txt": "",
+            "BUILD": dedent(
+                """\
+                files(name="original", sources=["original_prefix/file.txt"])
+
+                relocated_files(
+                    name="relocated",
+                    files_targets=[":original"],
+                    src="original_prefix",
+                    dest="intermediate_prefix",
+                )
+
+                relocated_files(
+                    name="double_relocated",
+                    files_targets=[":relocated"],
+                    src="intermediate_prefix",
+                    dest="final_prefix",
+                )
+                """
+            ),
+        }
+    )
+
+    tgt = rule_runner.get_target(Address("", target_name="double_relocated"))
+    result = rule_runner.request(
+        GeneratedSources, [RelocateFilesViaCodegenRequest(EMPTY_SNAPSHOT, tgt)]
+    )
+    assert result.snapshot.files == ("final_prefix/file.txt",)
+
+
 def test_archive() -> None:
     """Integration test for the `archive` target type.
 


### PR DESCRIPTION
I have a codegenerator generating a file target and was surprised when it wasn't relocated. No reason relocated files can't participate in the codegen games. 

[ci skip-rust]
[ci skip-build-wheels]