### PR TITLE
Enable codegen on relocated files (Cherry-pick of #15100)

### DIFF
--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -207,7 +207,11 @@ async def relocate_files(request: RelocateFilesViaCodegenRequest) -> GeneratedSo
     original_files_sources = await MultiGet(
         Get(
             HydratedSources,
-            HydrateSourcesRequest(tgt.get(SourcesField), for_sources_types=(FileSourceField,)),
+            HydrateSourcesRequest(
+                tgt.get(SourcesField),
+                for_sources_types=(FileSourceField,),
+                enable_codegen=True,
+            ),
         )
         for tgt in original_file_targets
     )


### PR DESCRIPTION
I have a codegenerator generating a file target and was surprised when it wasn't relocated. No reason relocated files can't participate in the codegen games. 

[ci skip-rust]
[ci skip-build-wheels]