### PR TITLE
fix missing field check in go protobuf rules (Cherry pick of #15105)

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/go/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/go/rules.py
@@ -196,7 +196,11 @@ async def setup_full_package_build_request(
     all_sources = await Get(
         SourceFiles,
         SourceFilesRequest(
-            sources_fields=(tgt[ProtobufSourceField] for tgt in transitive_targets.closure),
+            sources_fields=(
+                tgt[ProtobufSourceField]
+                for tgt in transitive_targets.closure
+                if tgt.has_field(ProtobufSourceField)
+            ),
             for_sources_types=(ProtobufSourceField,),
             enable_codegen=True,
         ),


### PR DESCRIPTION
A user using both Go and Python protobuf codegen reported a failure on Slack where Pants tried to access a `ProtobufSourceField` field in a `python_requirement` target. The Go protobuf rules are missing a field existence check to prevent such issues.

[ci skip-rust]
[ci skip-build-wheels]