### PR TITLE
Fix when the same `python_requirement` defines both type stub and implementation

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -8,6 +8,7 @@ import itertools
 import logging
 from collections import defaultdict
 from dataclasses import dataclass
+from functools import total_ordering
 from pathlib import PurePath
 from typing import DefaultDict, Iterable, Mapping, Tuple
 
@@ -39,9 +40,15 @@ logger = logging.getLogger(__name__)
 ResolveName = str
 
 
+@total_ordering
 class ModuleProviderType(enum.Enum):
     TYPE_STUB = enum.auto()
     IMPL = enum.auto()
+
+    def __lt__(self, other) -> bool:
+        if not isinstance(other, ModuleProviderType):
+            return NotImplemented
+        return self.name < other.name
 
 
 @dataclass(frozen=True, order=True)


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/15111. This is a particular edge case when the same python module has multiple entries, and those entries come from the same target.

The better fix is https://github.com/pantsbuild/pants/issues/14719.

[ci skip-rust]
[ci skip-build-wheels]