### PR TITLE
Revert "Enable codegen on relocated files (Cherry-pick of #15100) (#15116)"

### DIFF
--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -207,11 +207,7 @@ async def relocate_files(request: RelocateFilesViaCodegenRequest) -> GeneratedSo
     original_files_sources = await MultiGet(
         Get(
             HydratedSources,
-            HydrateSourcesRequest(
-                tgt.get(SourcesField),
-                for_sources_types=(FileSourceField,),
-                enable_codegen=True,
-            ),
+            HydrateSourcesRequest(tgt.get(SourcesField), for_sources_types=(FileSourceField,)),
         )
         for tgt in original_file_targets
     )

--- a/src/python/pants/core/target_types_test.py
+++ b/src/python/pants/core/target_types_test.py
@@ -159,52 +159,6 @@ def test_relocated_files() -> None:
     )
 
 
-def test_relocated_relocated_files() -> None:
-    rule_runner = RuleRunner(
-        rules=[
-            *target_type_rules(),
-            *archive.rules(),
-            *source_files.rules(),
-            *system_binaries.rules(),
-            QueryRule(GeneratedSources, [RelocateFilesViaCodegenRequest]),
-            QueryRule(TransitiveTargets, [TransitiveTargetsRequest]),
-            QueryRule(SourceFiles, [SourceFilesRequest]),
-        ],
-        target_types=[FilesGeneratorTarget, RelocatedFiles],
-    )
-
-    rule_runner.write_files(
-        {
-            "original_prefix/file.txt": "",
-            "BUILD": dedent(
-                """\
-                files(name="original", sources=["original_prefix/file.txt"])
-
-                relocated_files(
-                    name="relocated",
-                    files_targets=[":original"],
-                    src="original_prefix",
-                    dest="intermediate_prefix",
-                )
-
-                relocated_files(
-                    name="double_relocated",
-                    files_targets=[":relocated"],
-                    src="intermediate_prefix",
-                    dest="final_prefix",
-                )
-                """
-            ),
-        }
-    )
-
-    tgt = rule_runner.get_target(Address("", target_name="double_relocated"))
-    result = rule_runner.request(
-        GeneratedSources, [RelocateFilesViaCodegenRequest(EMPTY_SNAPSHOT, tgt)]
-    )
-    assert result.snapshot.files == ("final_prefix/file.txt",)
-
-
 def test_archive() -> None:
     """Integration test for the `archive` target type.
 


### PR DESCRIPTION

This reverts commit 2b453636988d874b2c9e9cc9a203786acab25ea4.

[ci skip-rust]

[ci skip-build-wheels]