### PR TITLE
Upgrade Pex to 2.1.79. (Cherry-pick of #15125)

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -15,7 +15,7 @@ humbug==0.2.7
 
 ijson==3.1.4
 packaging==21.3
-pex==2.1.78
+pex==2.1.79
 psutil==5.9.0
 # This should be compatible with pytest.py, although it can be looser so that we don't
 # over-constrain pantsbuild.pants.testutil

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -18,7 +18,7 @@
 //     "ijson==3.1.4",
 //     "mypy-typing-asserts==0.1.1",
 //     "packaging==21.3",
-//     "pex==2.1.78",
+//     "pex==2.1.79",
 //     "psutil==5.9.0",
 //     "pydevd-pycharm==203.5419.8",
 //     "pytest<7.1.0,>=6.2.4",
@@ -548,13 +548,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "e3d39549c6602235eb158314293143c4e45677e4acfa16ba141320d84ec523b3",
-              "url": "https://files.pythonhosted.org/packages/4a/f0/a90326344a99f4e1fa598efb162dcf0d9fc673943201fdc2e253a3511b81/pex-2.1.78-py2.py3-none-any.whl"
+              "hash": "758d257069757e96e4931cc34941afe991b788434dee2af024e2457d5f4de0dd",
+              "url": "https://files.pythonhosted.org/packages/f7/f8/f267be1887c212f585986cecbf4bb7c7d75138c5ad8516ad4c2885458b13/pex-2.1.79-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d5b58010c3018e6c8b4b55be556803f41b19ab97f40e610e42bc971fdbeea426",
-              "url": "https://files.pythonhosted.org/packages/24/e8/47902b09c9b87642d3e1f04b8660dddfedcd86532189ebd611601d20cb16/pex-2.1.78.tar.gz"
+              "hash": "5c8aa87ff4592f57667cf53a355b647f5f33ae41b944f39eb067ec0c3acf850f",
+              "url": "https://files.pythonhosted.org/packages/67/6f/ec1a1898b64eb1778218547792fa91e138a7a460d89adc7d3d8e01e8a942/pex-2.1.79.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -562,7 +562,7 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.11,>=2.7",
-          "version": "2.1.78"
+          "version": "2.1.79"
         },
         {
           "artifacts": [
@@ -718,13 +718,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484",
-              "url": "https://files.pythonhosted.org/packages/80/c1/23fd82ad3121656b585351aba6c19761926bb0db2ebed9e4ff09a43a3fcc/pyparsing-3.0.7-py3-none-any.whl"
+              "hash": "ef7b523f6356f763771559412c0d7134753f037822dad1b16945b7b846f7ad06",
+              "url": "https://files.pythonhosted.org/packages/d9/41/d9cfb4410589805cd787f8a82cddd13142d9bf7449d12adf2d05a4a7d633/pyparsing-3.0.8-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea",
-              "url": "https://files.pythonhosted.org/packages/d6/60/9bed18f43275b34198eb9720d4c1238c68b3755620d20df0afd89424d32b/pyparsing-3.0.7.tar.gz"
+              "hash": "7bf433498c016c4314268d95df76c81b842a4cb2b276fa3312cfb1e1d85f6954",
+              "url": "https://files.pythonhosted.org/packages/31/df/789bd0556e65cf931a5b87b603fcf02f79ff04d5379f3063588faaf9c1e4/pyparsing-3.0.8.tar.gz"
             }
           ],
           "project_name": "pyparsing",
@@ -732,8 +732,8 @@
             "jinja2; extra == \"diagrams\"",
             "railroad-diagrams; extra == \"diagrams\""
           ],
-          "requires_python": ">=3.6",
-          "version": "3.0.7"
+          "requires_python": ">=3.6.8",
+          "version": "3.0.8"
         },
         {
           "artifacts": [
@@ -1544,7 +1544,8 @@
       ]
     }
   ],
-  "pex_version": "2.1.78",
+  "path_mappings": {},
+  "pex_version": "2.1.79",
   "prefer_older_binary": false,
   "requirements": [
     "PyYAML<7.0,>=6.0",
@@ -1556,7 +1557,7 @@
     "ijson==3.1.4",
     "mypy-typing-asserts==0.1.1",
     "packaging==21.3",
-    "pex==2.1.78",
+    "pex==2.1.79",
     "psutil==5.9.0",
     "pydevd-pycharm==203.5419.8",
     "pytest<7.1.0,>=6.2.4",

--- a/src/python/pants/backend/python/subsystems/lambdex.lock
+++ b/src/python/pants/backend/python/subsystems/lambdex.lock
@@ -49,13 +49,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "e3d39549c6602235eb158314293143c4e45677e4acfa16ba141320d84ec523b3",
-              "url": "https://files.pythonhosted.org/packages/4a/f0/a90326344a99f4e1fa598efb162dcf0d9fc673943201fdc2e253a3511b81/pex-2.1.78-py2.py3-none-any.whl"
+              "hash": "758d257069757e96e4931cc34941afe991b788434dee2af024e2457d5f4de0dd",
+              "url": "https://files.pythonhosted.org/packages/f7/f8/f267be1887c212f585986cecbf4bb7c7d75138c5ad8516ad4c2885458b13/pex-2.1.79-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d5b58010c3018e6c8b4b55be556803f41b19ab97f40e610e42bc971fdbeea426",
-              "url": "https://files.pythonhosted.org/packages/24/e8/47902b09c9b87642d3e1f04b8660dddfedcd86532189ebd611601d20cb16/pex-2.1.78.tar.gz"
+              "hash": "5c8aa87ff4592f57667cf53a355b647f5f33ae41b944f39eb067ec0c3acf850f",
+              "url": "https://files.pythonhosted.org/packages/67/6f/ec1a1898b64eb1778218547792fa91e138a7a460d89adc7d3d8e01e8a942/pex-2.1.79.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -63,7 +63,7 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.11,>=2.7",
-          "version": "2.1.78"
+          "version": "2.1.79"
         }
       ],
       "platform_tag": [
@@ -73,7 +73,8 @@
       ]
     }
   ],
-  "pex_version": "2.1.78",
+  "path_mappings": {},
+  "pex_version": "2.1.79",
   "prefer_older_binary": false,
   "requirements": [
     "lambdex==0.1.6"

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -39,9 +39,9 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."
 
-    default_version = "v2.1.78"
+    default_version = "v2.1.79"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.1.78,<3.0"
+    version_constraints = ">=2.1.79,<3.0"
 
     @classproperty
     def default_known_versions(cls):
@@ -50,8 +50,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "52f5104ac995f50e31c479634ed30502871e72bd7923bbeab00b578924eae828",
-                    "3732692",
+                    "45b774bfe433aa353bd7c0a1c83264d00b6da1d82a7d126d2685443867f1eb69",
+                    "3735810",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64"]


### PR DESCRIPTION
This picks up a bug fix for some `--lock` resolves missing transitive
extras.

See the changelog here:
  https://github.com/pantsbuild/pex/releases/tag/v2.1.79

(cherry picked from commit 3d4a88befb28cb38c00eb5064cc5079746fa2827)

[ci skip-rust]
[ci skip-build-wheels]