### PR TITLE
[internal] remove non-existent backend name in docs generator

### DIFF
--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -222,7 +222,6 @@ def run_pants_help_all() -> dict[str, Any]:
         "pants.backend.experimental.scala",
         "pants.backend.experimental.scala.lint.scalafmt",
         "pants.backend.experimental.terraform",
-        "pants.backend.experimental.terraform.lint.tffmt",
         "pants.backend.google_cloud_function.python",
         "pants.backend.plugin_development",
         "pants.backend.python",


### PR DESCRIPTION
Remove `pants.backend.experimental.terraform.lint.tffmt` as a backend from the docs generator, as it doesn't exist. My bad for adding it in the first place. :(

[ci skip-rust]

[ci skip-build-wheels]