### PR TITLE
[internal] kotlin: parse named declarations and infer deps based on imports

### DIFF
--- a/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
@@ -60,11 +60,13 @@ class KotlinImport:
 @dataclass(frozen=True)
 class KotlinSourceDependencyAnalysis:
     imports: frozenset[KotlinImport]
+    named_declarations: frozenset[str]
 
     @classmethod
     def from_json_dict(cls, d: dict) -> KotlinSourceDependencyAnalysis:
         return cls(
             imports=frozenset(KotlinImport.from_json_dict(i) for i in d["imports"]),
+            named_declarations=frozenset(d["namedDeclarations"]),
         )
 
 

--- a/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser_test.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser_test.py
@@ -77,6 +77,10 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
 
             import java.io.File
 
+            open class Foo {
+              fun grok() {}
+            }
+
             fun main(args: Array<String>) {
             }
             """
@@ -84,3 +88,7 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
     )
 
     assert analysis.imports == {KotlinImport(name="java.io.File", alias=None, is_wildcard=False)}
+    assert analysis.named_declarations == {
+        "org.pantsbuild.backend.kotlin.Foo",
+        "org.pantsbuild.backend.kotlin.main",
+    }

--- a/src/python/pants/backend/kotlin/dependency_inference/rules.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/rules.py
@@ -1,11 +1,86 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-from pants.backend.kotlin.dependency_inference import kotlin_parser
-from pants.engine.rules import collect_rules
+from pants.backend.kotlin.dependency_inference import kotlin_parser, symbol_mapper
+from pants.backend.kotlin.dependency_inference.kotlin_parser import KotlinSourceDependencyAnalysis
+from pants.backend.kotlin.subsystems.kotlin_infer import KotlinInferSubsystem
+from pants.backend.kotlin.target_types import KotlinSourceField
+from pants.build_graph.address import Address
+from pants.core.util_rules.source_files import SourceFilesRequest
+from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.rules import collect_rules, rule
+from pants.engine.target import (
+    Dependencies,
+    DependenciesRequest,
+    ExplicitlyProvidedDependencies,
+    InferDependenciesRequest,
+    InferredDependencies,
+    WrappedTarget,
+)
+from pants.engine.unions import UnionRule
+from pants.jvm.dependency_inference.artifact_mapper import ThirdPartyPackageToArtifactMapping
+from pants.jvm.dependency_inference.symbol_mapper import FirstPartySymbolMapping
+from pants.jvm.subsystems import JvmSubsystem
+from pants.jvm.target_types import JvmResolveField
+from pants.util.ordered_set import OrderedSet
+
+
+class InferKotlinSourceDependencies(InferDependenciesRequest):
+    infer_from = KotlinSourceField
+
+
+@rule(desc="Inferring Kotlin dependencies by analyzing sources")
+async def infer_kotlin_dependencies_via_source_analysis(
+    request: InferKotlinSourceDependencies,
+    kotlin_infer_subsystem: KotlinInferSubsystem,
+    jvm: JvmSubsystem,
+    first_party_symbol_map: FirstPartySymbolMapping,
+    third_party_artifact_mapping: ThirdPartyPackageToArtifactMapping,
+) -> InferredDependencies:
+    if not kotlin_infer_subsystem.imports:
+        return InferredDependencies([])
+
+    address = request.sources_field.address
+    wrapped_tgt = await Get(WrappedTarget, Address, address)
+    tgt = wrapped_tgt.target
+    explicitly_provided_deps, analysis = await MultiGet(
+        Get(ExplicitlyProvidedDependencies, DependenciesRequest(tgt[Dependencies])),
+        Get(KotlinSourceDependencyAnalysis, SourceFilesRequest([request.sources_field])),
+    )
+
+    symbols: OrderedSet[str] = OrderedSet()
+    if kotlin_infer_subsystem.imports:
+        symbols.update(imp.name for imp in analysis.imports)
+
+    resolve = tgt[JvmResolveField].normalized_value(jvm)
+
+    dependencies: OrderedSet[Address] = OrderedSet()
+    for symbol in symbols:
+        first_party_matches = first_party_symbol_map.symbols.addresses_for_symbol(
+            symbol, resolve=resolve
+        )
+        third_party_matches = third_party_artifact_mapping.addresses_for_symbol(symbol, resolve)
+        matches = first_party_matches.union(third_party_matches)
+        if not matches:
+            continue
+
+        explicitly_provided_deps.maybe_warn_of_ambiguous_dependency_inference(
+            matches,
+            address,
+            import_reference="type",
+            context=f"The target {address} imports `{symbol}`",
+        )
+
+        maybe_disambiguated = explicitly_provided_deps.disambiguated(matches)
+        if maybe_disambiguated:
+            dependencies.add(maybe_disambiguated)
+
+    return InferredDependencies(dependencies)
 
 
 def rules():
     return (
         *collect_rules(),
         *kotlin_parser.rules(),
+        *symbol_mapper.rules(),
+        UnionRule(InferDependenciesRequest, InferKotlinSourceDependencies),
     )

--- a/src/python/pants/backend/kotlin/dependency_inference/rules.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/rules.py
@@ -17,6 +17,8 @@ from pants.engine.target import (
     WrappedTarget,
 )
 from pants.engine.unions import UnionRule
+from pants.jvm.dependency_inference import artifact_mapper
+from pants.jvm.dependency_inference import symbol_mapper as jvm_symbol_mapper
 from pants.jvm.dependency_inference.artifact_mapper import ThirdPartyPackageToArtifactMapping
 from pants.jvm.dependency_inference.symbol_mapper import FirstPartySymbolMapping
 from pants.jvm.subsystems import JvmSubsystem
@@ -82,5 +84,7 @@ def rules():
         *collect_rules(),
         *kotlin_parser.rules(),
         *symbol_mapper.rules(),
+        *jvm_symbol_mapper.rules(),
+        *artifact_mapper.rules(),
         UnionRule(InferDependenciesRequest, InferKotlinSourceDependencies),
     )

--- a/src/python/pants/backend/kotlin/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/rules_test.py
@@ -1,0 +1,143 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from textwrap import dedent
+
+import pytest
+
+from pants.backend.kotlin.dependency_inference import kotlin_parser, symbol_mapper
+from pants.backend.kotlin.dependency_inference.rules import InferKotlinSourceDependencies
+from pants.backend.kotlin.dependency_inference.rules import rules as dep_inference_rules
+from pants.backend.kotlin.target_types import KotlinSourceField, KotlinSourcesGeneratorTarget
+from pants.backend.kotlin.target_types import rules as kotlin_target_type_rules
+from pants.build_graph.address import Address
+from pants.core.util_rules import config_files, source_files
+from pants.engine.addresses import Addresses, UnparsedAddressInputs
+from pants.engine.internals.parametrize import Parametrize
+from pants.engine.rules import QueryRule
+from pants.engine.target import (
+    DependenciesRequest,
+    ExplicitlyProvidedDependencies,
+    InferredDependencies,
+    Targets,
+)
+from pants.jvm import jdk_rules
+from pants.jvm.dependency_inference import artifact_mapper
+from pants.jvm.dependency_inference import symbol_mapper as jvm_symbol_mapper
+from pants.jvm.resolve import jvm_tool
+from pants.jvm.testutil import maybe_skip_jdk_test
+from pants.jvm.util_rules import rules as jvm_util_rules
+from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = RuleRunner(
+        rules=[
+            *config_files.rules(),
+            *jvm_tool.rules(),
+            *dep_inference_rules(),
+            *kotlin_parser.rules(),
+            *symbol_mapper.rules(),
+            *kotlin_target_type_rules(),
+            *source_files.rules(),
+            *jvm_util_rules(),
+            *jdk_rules.rules(),
+            *artifact_mapper.rules(),
+            *jvm_symbol_mapper.rules(),
+            QueryRule(Addresses, [DependenciesRequest]),
+            QueryRule(ExplicitlyProvidedDependencies, [DependenciesRequest]),
+            QueryRule(InferredDependencies, [InferKotlinSourceDependencies]),
+            QueryRule(Targets, [UnparsedAddressInputs]),
+        ],
+        target_types=[KotlinSourcesGeneratorTarget],
+        objects={"parametrize": Parametrize},
+    )
+    rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    return rule_runner
+
+
+@maybe_skip_jdk_test
+def test_infer_kotlin_imports_same_target(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                """\
+                kotlin_sources(name = 't')
+                """
+            ),
+            "A.kt": dedent(
+                """\
+                package org.pantsbuild.a
+
+                class A {}
+                """
+            ),
+            "B.kt": dedent(
+                """\
+                package org.pantsbuild.b
+
+                class B {}
+                """
+            ),
+        }
+    )
+
+    target_a = rule_runner.get_target(Address("", target_name="t", relative_file_path="A.kt"))
+    target_b = rule_runner.get_target(Address("", target_name="t", relative_file_path="B.kt"))
+
+    assert rule_runner.request(
+        InferredDependencies,
+        [InferKotlinSourceDependencies(target_a[KotlinSourceField])],
+    ) == InferredDependencies(dependencies=[])
+
+    assert rule_runner.request(
+        InferredDependencies,
+        [InferKotlinSourceDependencies(target_b[KotlinSourceField])],
+    ) == InferredDependencies(dependencies=[])
+
+
+@maybe_skip_jdk_test
+def test_infer_kotlin_imports_with_cycle(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                """\
+                kotlin_sources(name = 'a')
+                """
+            ),
+            "A.kt": dedent(
+                """\
+                package org.pantsbuild.a
+
+                import org.pantsbuild.b.B
+
+                class A {}
+                """
+            ),
+            "sub/BUILD": dedent(
+                """\
+                kotlin_sources(name = 'b',)
+                """
+            ),
+            "sub/B.kt": dedent(
+                """\
+                package org.pantsbuild.b
+
+                import org.pantsbuild.a.A
+
+                class B {}
+                """
+            ),
+        }
+    )
+
+    target_a = rule_runner.get_target(Address("", target_name="a", relative_file_path="A.kt"))
+    target_b = rule_runner.get_target(Address("sub", target_name="b", relative_file_path="B.kt"))
+
+    assert rule_runner.request(
+        InferredDependencies, [InferKotlinSourceDependencies(target_a[KotlinSourceField])]
+    ) == InferredDependencies(dependencies=[target_b.address])
+
+    assert rule_runner.request(
+        InferredDependencies, [InferKotlinSourceDependencies(target_b[KotlinSourceField])]
+    ) == InferredDependencies(dependencies=[target_a.address])

--- a/src/python/pants/backend/kotlin/dependency_inference/symbol_mapper.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/symbol_mapper.py
@@ -1,0 +1,59 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# TODO: add third-party targets here? That would allow us to avoid iterating over AllTargets twice.
+#  See `backend/python/dependency_inference/module_mapper.py` for an example.
+from pants.backend.kotlin.dependency_inference.kotlin_parser import KotlinSourceDependencyAnalysis
+from pants.backend.kotlin.target_types import KotlinSourceField
+from pants.core.util_rules.source_files import SourceFilesRequest
+from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.rules import collect_rules, rule
+from pants.engine.target import AllTargets, Targets
+from pants.engine.unions import UnionRule
+from pants.jvm.dependency_inference.symbol_mapper import FirstPartyMappingRequest, SymbolMap
+from pants.jvm.subsystems import JvmSubsystem
+from pants.jvm.target_types import JvmResolveField
+from pants.util.logging import LogLevel
+
+
+class AllKotlinTargets(Targets):
+    pass
+
+
+class FirstPartyKotlinTargetsMappingRequest(FirstPartyMappingRequest):
+    pass
+
+
+@rule(desc="Find all Kotlin targets in project", level=LogLevel.DEBUG)
+def find_all_kotlin_targets(targets: AllTargets) -> AllKotlinTargets:
+    return AllKotlinTargets(tgt for tgt in targets if tgt.has_field(KotlinSourceField))
+
+
+@rule(desc="Map all first party Kotlin targets to their symbols", level=LogLevel.DEBUG)
+async def map_first_party_kotlin_targets_to_symbols(
+    _: FirstPartyKotlinTargetsMappingRequest,
+    kotlin_targets: AllKotlinTargets,
+    jvm: JvmSubsystem,
+) -> SymbolMap:
+    source_analysis = await MultiGet(
+        Get(KotlinSourceDependencyAnalysis, SourceFilesRequest([target[KotlinSourceField]]))
+        for target in kotlin_targets
+    )
+    address_and_analysis = zip(
+        [(tgt.address, tgt[JvmResolveField].normalized_value(jvm)) for tgt in kotlin_targets],
+        source_analysis,
+    )
+
+    symbol_map = SymbolMap()
+    for (address, resolve), analysis in address_and_analysis:
+        for symbol in analysis.named_declarations:
+            symbol_map.add_symbol(symbol, address, resolve=resolve)
+
+    return symbol_map
+
+
+def rules():
+    return (
+        *collect_rules(),
+        UnionRule(FirstPartyMappingRequest, FirstPartyKotlinTargetsMappingRequest),
+    )

--- a/src/python/pants/backend/kotlin/subsystems/kotlin_infer.py
+++ b/src/python/pants/backend/kotlin/subsystems/kotlin_infer.py
@@ -1,0 +1,15 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from pants.option.option_types import BoolOption
+from pants.option.subsystem import Subsystem
+
+
+class KotlinInferSubsystem(Subsystem):
+    options_scope = "kotlin-infer"
+    help = "Options controlling which dependencies will be inferred for Kotlin targets."
+
+    imports = BoolOption(
+        "--imports",
+        default=True,
+        help="Infer a target's dependencies by parsing import statements from sources.",
+    )


### PR DESCRIPTION
Kotlin dependency inference updates:
- Parse "named declarations" from Kotlin sources which covers functions and classes.
- Infer dependencies based on imports.

[ci skip-rust]

[ci skip-build-wheels]