### PR TITLE
[WIP] [internal] fix immutable inputs bug on macOS

### DIFF
--- a/src/rust/engine/process_execution/src/immutable_inputs.rs
+++ b/src/rust/engine/process_execution/src/immutable_inputs.rs
@@ -225,7 +225,7 @@ mod tests {
       .workdir_path()
       .join(test_directory.digest().hash.to_hex());
     tokio::fs::create_dir_all(&digest_dir).await.unwrap();
-    tokio::fs::set_permissions(&digest_dir, std::fs::Permissions::from_mode(0o444))
+    tokio::fs::set_permissions(&digest_dir, std::fs::Permissions::from_mode(0o555))
       .await
       .unwrap();
 


### PR DESCRIPTION
https://github.com/pantsbuild/pants/issues/13899 describes a bug with immutable inputs where there is a failure to move the materialized digest's directory atomically on macOS.

No fix yet, this PR only contains a unit test that reproduces the issue.

[ci skip-build-wheels]