### PR TITLE
`MyPy` and `Pylint` partition inputs via `CoarsenedTarget`

### DIFF
--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -522,7 +522,7 @@ def test_partition_targets(rule_runner: RuleRunner) -> None:
         resolve: str,
     ) -> None:
         root_addresses = {t.address for t in roots}
-        assert {t.address for t in partition.root_targets} == root_addresses
+        assert {fs.address for fs in partition.root_field_sets} == root_addresses
         assert {t.address for t in partition.closure} == {
             *root_addresses,
             *(t.address for t in deps),

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -760,7 +760,7 @@ def test_partition_targets(rule_runner: RuleRunner) -> None:
         resolve: str,
     ) -> None:
         root_addresses = {t.address for t in roots}
-        assert {t.address for t in partition.root_targets} == root_addresses
+        assert {fs.address for fs in partition.root_field_sets} == root_addresses
         assert {t.address for t in partition.closure} == {
             *root_addresses,
             *(t.address for t in deps),

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -552,7 +552,9 @@ async def coarsened_targets(request: CoarsenedTargetsRequest) -> CoarsenedTarget
     dependency_mapping = await Get(
         _DependencyMapping,
         _DependencyMappingRequest(
-            TransitiveTargetsRequest(request.roots, include_special_cased_deps=request.include_special_cased_deps),
+            TransitiveTargetsRequest(
+                request.roots, include_special_cased_deps=request.include_special_cased_deps
+            ),
             expanded_targets=request.expanded_targets,
         ),
     )

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -51,6 +51,7 @@ from pants.engine.target import (
     AllUnexpandedTargets,
     CoarsenedTarget,
     CoarsenedTargets,
+    CoarsenedTargetsRequest,
     Dependencies,
     DependenciesRequest,
     ExplicitlyProvidedDependencies,
@@ -542,16 +543,17 @@ async def transitive_targets(request: TransitiveTargetsRequest) -> TransitiveTar
 
 
 @rule
-async def coarsened_targets(addresses: Addresses) -> CoarsenedTargets:
+def coarsened_targets_request(addresses: Addresses) -> CoarsenedTargetsRequest:
+    return CoarsenedTargetsRequest(addresses)
+
+
+@rule
+async def coarsened_targets(request: CoarsenedTargetsRequest) -> CoarsenedTargets:
     dependency_mapping = await Get(
         _DependencyMapping,
         _DependencyMappingRequest(
-            # NB: We set include_special_cased_deps=True because although computing CoarsenedTargets
-            # requires a transitive graph walk (to ensure that all cycles are actually detected),
-            # the resulting CoarsenedTargets instance is not itself transitive: everything not directly
-            # involved in a cycle with one of the input Addresses is discarded in the output.
-            TransitiveTargetsRequest(addresses, include_special_cased_deps=True),
-            expanded_targets=False,
+            TransitiveTargetsRequest(request.roots, include_special_cased_deps=request.include_special_cased_deps),
+            expanded_targets=request.expanded_targets,
         ),
     )
     addresses_to_targets = {
@@ -568,7 +570,7 @@ async def coarsened_targets(addresses: Addresses) -> CoarsenedTargets:
 
     coarsened_targets: dict[Address, CoarsenedTarget] = {}
     root_coarsened_targets = []
-    root_addresses_set = set(addresses)
+    root_addresses_set = set(request.roots)
     for component in components:
         component = sorted(component)
         component_set = set(component)

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -24,6 +24,7 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
+    Set,
     Tuple,
     Type,
     TypeVar,
@@ -689,6 +690,25 @@ class CoarsenedTarget(EngineAwareParameter):
         """The addresses and type aliases of all members of the cycle."""
         return bullet_list(sorted(f"{t.address.spec}\t({type(t).alias})" for t in self.members))
 
+    def closure(self, visited: Set[CoarsenedTarget] | None = None) -> Iterator[Target]:
+        """All Targets reachable from this root."""
+        return (t for ct in self.coarsened_closure(visited) for t in ct.members)
+
+    def coarsened_closure(
+        self, visited: Set[CoarsenedTarget] | None = None
+    ) -> Iterator[CoarsenedTarget]:
+        """All CoarsenedTargets reachable from this root."""
+
+        visited = visited or set()
+        queue = deque([self])
+        while queue:
+            ct = queue.popleft()
+            if ct in visited:
+                continue
+            visited.add(ct)
+            yield ct
+            queue.extend(ct.dependencies)
+
     def __hash__(self) -> int:
         return self._hashcode
 
@@ -718,18 +738,19 @@ class CoarsenedTargets(Collection[CoarsenedTarget]):
     To collect all reachable CoarsenedTarget members, use `def closure`.
     """
 
-    def closure(self) -> Iterator[CoarsenedTarget]:
-        """All CoarsenedTargets reachable from these CoarsenedTarget roots."""
+    def by_address(self) -> dict[Address, CoarsenedTarget]:
+        """Compute a mapping from Address to containing CoarsenedTarget."""
+        return {t.address: ct for ct in self for t in ct.members}
 
-        visited = set()
-        queue = deque(self)
-        while queue:
-            ct = queue.popleft()
-            if ct in visited:
-                continue
-            visited.add(ct)
-            yield ct
-            queue.extend(ct.dependencies)
+    def closure(self) -> Iterator[Target]:
+        """All Targets reachable from these CoarsenedTarget roots."""
+        visited: Set[CoarsenedTarget] = set()
+        return (t for root in self for t in root.closure(visited))
+
+    def coarsened_closure(self) -> Iterator[CoarsenedTarget]:
+        """All CoarsenedTargets reachable from these CoarsenedTarget roots."""
+        visited: Set[CoarsenedTarget] = set()
+        return (ct for root in self for ct in root.coarsened_closure(visited))
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -753,6 +753,23 @@ class CoarsenedTargets(Collection[CoarsenedTarget]):
         return (ct for root in self for ct in root.coarsened_closure(visited))
 
 
+@frozen_after_init
+@dataclass(unsafe_hash=True)
+class CoarsenedTargetsRequest:
+    """A request to get CoarsenedTargets for input roots."""
+
+    roots: Tuple[Address, ...]
+    expanded_targets: bool
+    include_special_cased_deps: bool
+
+    def __init__(
+            self, roots: Iterable[Address], *, expanded_targets: bool = False, include_special_cased_deps: bool = False
+    ) -> None:
+        self.roots = tuple(roots)
+        self.expanded_targets = expanded_targets
+        self.include_special_cased_deps = include_special_cased_deps
+
+
 @dataclass(frozen=True)
 class TransitiveTargets:
     """A set of Target roots, and their transitive, flattened, de-duped dependencies.

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -763,7 +763,11 @@ class CoarsenedTargetsRequest:
     include_special_cased_deps: bool
 
     def __init__(
-            self, roots: Iterable[Address], *, expanded_targets: bool = False, include_special_cased_deps: bool = False
+        self,
+        roots: Iterable[Address],
+        *,
+        expanded_targets: bool = False,
+        include_special_cased_deps: bool = False,
     ) -> None:
         self.roots = tuple(roots)
         self.expanded_targets = expanded_targets

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -626,7 +626,7 @@ async def select_coursier_resolve_for_targets(
     resolve is required for multiple roots (such as when running a `repl` over unrelated code), and
     in that case there might be multiple CoarsenedTargets.
     """
-    targets = [t for ct in coarsened_targets.closure() for t in ct.members]
+    targets = list(coarsened_targets.closure())
 
     # Find a single resolve that is compatible with all targets in the closure.
     compatible_resolve: str | None = None


### PR DESCRIPTION
`CoarsenedTarget`s are structure shared, and because they preserve their internal structure, they can service requests for transitive targets for different roots from the same datastructure. Concretely: Mypy and Pylint can consume `CoarsenedTargets` to execute a single `@rule`-level graph walk, and then compute per-root closures from the resulting `CoarsenedTarget` instances.

This does not address #11270 in a general way (and it punts on #15241, which means that we still need per-root transitive walks), but it might provide a prototypical way to solve that problem on a case-by-case basis.

Performance wise, this moves cold `check ::` for ~1k files from:
* `main`: 32s total, and 26s spent in partitioning
*  `branch`: 19s total, and 13s spent in partitioning

The rest of the time is wrapped up in #15241.