### PR TITLE
Address specs for parametrized target templates expand to their created targets (Cherry pick of #15126)

### DIFF
--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from pants.base.exceptions import ResolveError
-from pants.base.specs import AddressLiteralSpec, AddressSpecs
+from pants.base.specs import AddressSpecs
 from pants.engine.addresses import Address, Addresses, AddressInput, BuildFileAddress
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import DigestContents, GlobMatchErrorBehavior, PathGlobs, Paths

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from pants.base.exceptions import ResolveError
-from pants.base.specs import AddressSpecs
+from pants.base.specs import AddressLiteralSpec, AddressSpecs
 from pants.engine.addresses import Address, Addresses, AddressInput, BuildFileAddress
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import DigestContents, GlobMatchErrorBehavior, PathGlobs, Paths
@@ -18,7 +18,7 @@ from pants.engine.internals.mapper import AddressFamily, AddressMap, AddressSpec
 from pants.engine.internals.parametrize import _TargetParametrizations
 from pants.engine.internals.parser import BuildFilePreludeSymbols, Parser, error_on_imports
 from pants.engine.internals.target_adaptor import TargetAdaptor
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.rules import Get, MultiGet, collect_rules, rule, rule_helper
 from pants.engine.target import WrappedTarget
 from pants.option.global_options import GlobalOptions
 from pants.util.docutil import bin_name, doc_url
@@ -178,6 +178,45 @@ def setup_address_specs_filter(global_options: GlobalOptions) -> AddressSpecsFil
     )
 
 
+@rule_helper
+async def _determine_literal_addresses_from_specs(
+    literal_specs: tuple[AddressLiteralSpec, ...]
+) -> tuple[WrappedTarget, ...]:
+    literal_addresses = await MultiGet(
+        Get(
+            Address,
+            AddressInput(
+                spec.path_component,
+                spec.target_component,
+                spec.generated_component,
+                spec.parameters,
+            ),
+        )
+        for spec in literal_specs
+    )
+
+    # We replace references to parametrized target templates with all their created targets. For
+    # example:
+    #  - dir:tgt -> (dir:tgt@k=v1, dir:tgt@k=v2)
+    #  - dir:tgt@k=v -> (dir:tgt@k=v,another=a, dir:tgt@k=v,another=b), but not anything
+    #       where @k=v is not true.
+    literal_parametrizations = await MultiGet(
+        Get(_TargetParametrizations, Address, address.maybe_convert_to_target_generator())
+        for address in literal_addresses
+    )
+
+    # Note that if the address is not in the _TargetParametrizations, we must fall back to that
+    # address's value. This will allow us to error that the address is invalid.
+    all_candidate_addresses = itertools.chain.from_iterable(
+        list(params.get_all_superset_targets(address)) or [address]
+        for address, params in zip(literal_addresses, literal_parametrizations)
+    )
+
+    # We eagerly call the `WrappedTarget` rule because it will validate that every final address
+    # actually exists, such as with generated target addresses.
+    return await MultiGet(Get(WrappedTarget, Address, addr) for addr in all_candidate_addresses)
+
+
 @rule
 async def addresses_from_address_specs(
     address_specs: AddressSpecs,
@@ -187,19 +226,7 @@ async def addresses_from_address_specs(
     matched_addresses: OrderedSet[Address] = OrderedSet()
     filtering_disabled = address_specs.filter_by_global_options is False
 
-    # Resolve all `AddressLiteralSpec`s. Will error on invalid addresses.
-    literal_wrapped_targets = await MultiGet(
-        Get(
-            WrappedTarget,
-            AddressInput(
-                spec.path_component,
-                spec.target_component,
-                spec.generated_component,
-                spec.parameters,
-            ),
-        )
-        for spec in address_specs.literals
-    )
+    literal_wrapped_targets = await _determine_literal_addresses_from_specs(address_specs.literals)
     matched_addresses.update(
         wrapped_tgt.target.address
         for wrapped_tgt in literal_wrapped_targets

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -129,7 +129,7 @@ class ResolveField(StringField):
 
 class MockTgt(Target):
     alias = "mock_tgt"
-    core_fields = (Dependencies, MultipleSourcesField, Tags)
+    core_fields = (Dependencies, MultipleSourcesField, Tags, ResolveField)
 
 
 class MockGeneratedTarget(Target):
@@ -591,16 +591,87 @@ def test_address_specs_parametrize(
             "demo/BUILD": dedent(
                 """\
                 generator(sources=['f.txt'], resolve=parametrize("a", "b"))
+                mock_tgt(sources=['f.txt'], name="not_gen", resolve=parametrize("a", "b"))
                 """
             ),
         }
     )
 
-    assert resolve_address_specs(address_specs_rule_runner, [DescendantAddresses(""),]) == {
+    def assert_resolved(spec: AddressSpec, expected: set[Address]) -> None:
+        assert resolve_address_specs(address_specs_rule_runner, [spec]) == expected
+
+    not_gen_resolve_a = Address("demo", target_name="not_gen", parameters={"resolve": "a"})
+    not_gen_resolve_b = Address("demo", target_name="not_gen", parameters={"resolve": "b"})
+    generator_resolve_a = {
         Address("demo", generated_name="f.txt", parameters={"resolve": "a"}),
-        Address("demo", generated_name="f.txt", parameters={"resolve": "b"}),
         Address("demo", relative_file_path="f.txt", parameters={"resolve": "a"}),
-        Address("demo", relative_file_path="f.txt", parameters={"resolve": "b"}),
         Address("demo", parameters={"resolve": "a"}),
-        Address("demo", parameters={"resolve": "b"}),
+        Address("demo", target_name="not_gen", parameters={"resolve": "a"}),
     }
+    generator_resolve_b = {
+        Address("demo", generated_name="f.txt", parameters={"resolve": "b"}),
+        Address("demo", relative_file_path="f.txt", parameters={"resolve": "b"}),
+        Address("demo", parameters={"resolve": "b"}),
+        Address("demo", target_name="not_gen", parameters={"resolve": "b"}),
+    }
+
+    assert_resolved(
+        DescendantAddresses(""),
+        {*generator_resolve_a, *generator_resolve_b, not_gen_resolve_a, not_gen_resolve_b},
+    )
+
+    # A literal address for a parameterized target works as expected.
+    assert_resolved(
+        AddressLiteralSpec(
+            "demo", target_component="not_gen", parameters=FrozenDict({"resolve": "a"})
+        ),
+        {not_gen_resolve_a},
+    )
+    assert_resolved(
+        AddressLiteralSpec("demo", parameters=FrozenDict({"resolve": "a"})),
+        {Address("demo", parameters={"resolve": "a"})},
+    )
+    assert_resolved(
+        AddressLiteralSpec(
+            "demo", generated_component="f.txt", parameters=FrozenDict({"resolve": "a"})
+        ),
+        {Address("demo", generated_name="f.txt", parameters={"resolve": "a"})},
+    )
+    assert_resolved(
+        # A direct reference to the parametrized target generator.
+        AddressLiteralSpec("demo", parameters=FrozenDict({"resolve": "a"})),
+        {Address("demo", parameters={"resolve": "a"})},
+    )
+
+    # A literal address for a parametrized template should be expanded with the matching targets.
+    assert_resolved(
+        AddressLiteralSpec("demo", target_component="not_gen"),
+        {not_gen_resolve_a, not_gen_resolve_b},
+    )
+
+    # The above affordance plays nicely with target generation.
+    assert_resolved(
+        # Note that this returns references to the two target generators. Certain goals like
+        # `test` may then later replace those with their generated targets.
+        AddressLiteralSpec("demo"),
+        {Address("demo", parameters={"resolve": r}) for r in ("a", "b")},
+    )
+    assert_resolved(
+        AddressLiteralSpec("demo", generated_component="f.txt"),
+        {Address("demo", generated_name="f.txt", parameters={"resolve": r}) for r in ("a", "b")},
+    )
+    assert_resolved(
+        AddressLiteralSpec("demo/f.txt"),
+        {
+            Address("demo", relative_file_path="f.txt", parameters={"resolve": r})
+            for r in ("a", "b")
+        },
+    )
+
+    # Error on invalid targets.
+    def assert_errors(spec: AddressLiteralSpec) -> None:
+        with engine_error(ValueError):
+            resolve_address_specs(address_specs_rule_runner, [spec])
+
+    assert_errors(AddressLiteralSpec("demo", parameters=FrozenDict({"fake": "v"})))
+    assert_errors(AddressLiteralSpec("demo", parameters=FrozenDict({"resolve": "fake"})))

--- a/src/python/pants/engine/internals/parametrize.py
+++ b/src/python/pants/engine/internals/parametrize.py
@@ -171,6 +171,29 @@ class _TargetParametrizations(Collection[_TargetParametrization]):
                 return instance
         return None
 
+    def get_all_superset_targets(self, address: Address) -> Iterator[Address]:
+        """Yield the input address itself, or any parameterized addresses which are a superset of
+        the input address.
+
+        For example, an input address `dir:tgt` may yield `(dir:tgt@k=v1, dir:tgt@k=v2)`.
+
+        If no targets are a match, will yield nothing.
+        """
+        # Check for exact matches.
+        if self.get(address) is not None:
+            yield address
+            return
+
+        for parametrization in self:
+            if parametrization.original_target is not None and address.is_parametrized_subset_of(
+                parametrization.original_target.address
+            ):
+                yield parametrization.original_target.address
+
+            for parametrized_tgt in parametrization.parametrization.values():
+                if address.is_parametrized_subset_of(parametrized_tgt.address):
+                    yield parametrized_tgt.address
+
     def get_subset(self, address: Address, consumer: Target) -> Target:
         """Find the Target with the given Address, or with fields matching the given consumer."""
         # Check for exact matches.


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/15108.

Target generators are tricky. As shown in the test, using `demo:tests` on say `python_tests` with parametrization will give back `demo:tests@k=a` and `demo:tests@k=b`. I at first thought that it would give back all of the generated targets instead, but this is the correct behavior. Most goals like `test` will replace those target generators with their generated targets.

[ci skip-rust]
[ci skip-build-wheels]