### PR TITLE
Fix Requires-Python for pantsbuild.pants wheel.

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -119,6 +119,10 @@ ignore_adding_targets = [
 venv_use_symlinks = true
 
 [python]
+# N.B.: When adjusting this to support new Python versions, you must update the Pants
+# `python_distrobution` targets, currently:
+# + src/python/pants:pants-packaged
+# + src/python/pants/testutil:testutil_wheel
 interpreter_constraints = [">=3.7,<3.10"]
 macos_big_sur_compatibility = true
 resolves = { python-default = "3rdparty/python/user_reqs.lock" }

--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -27,6 +27,8 @@ python_distribution(
         # consumers of pantsbuild.pants are using a compatible interpreter.
         # TODO(7344): the tuple syntax for ext_modules is deprecated. Use Extension once we support it.
         ext_modules=[("native_engine", {"sources": ["pants/dummy.c"]})],
+        # N.B.: Must match [python] interpreter_constraints in pants.toml.
+        python_requires=">=3.7,<3.10",
     ),
     entry_points={"console_scripts": {"pants": "src/python/pants/bin:pants"}},
 )

--- a/src/python/pants/testutil/BUILD
+++ b/src/python/pants/testutil/BUILD
@@ -13,6 +13,7 @@ python_distribution(
         name="pantsbuild.pants.testutil",
         description="Test support for writing Pants plugins.",
         classifiers=["Topic :: Software Development :: Testing"],
+        # N.B.: Must match [python] interpreter_constraints in pants.toml.
         python_requires=">=3.7,<3.10",
     ),
 )


### PR DESCRIPTION
This slipped through the cracks with the introduction of filling in this
metadata in distributions in #15071.

[ci skip-rust]