### PR TITLE
Cherry-pick script improvements

### DIFF
--- a/build-support/bin/cherry_pick.sh
+++ b/build-support/bin/cherry_pick.sh
@@ -36,16 +36,21 @@ fi
 
 COMMIT=$(gh pr view "$PR_NUM" --json mergeCommit --jq '.mergeCommit.oid')
 TITLE=$(gh pr view "$PR_NUM" --json title --jq '.title')
-BODY=$(gh pr view "$PR_NUM" --json body --jq '.body')
+BODY_FILE=$(mktemp /tmp/github.cherrypick.XXXXXX)
+PR_CREATE_CMD=(gh pr create --base "$MILESTONE" --title "$TITLE (Cherry-pick of #$PR_NUM)" --body-file "$BODY_FILE")
+BRANCH_NAME="cherry-pick-$PR_NUM-to-$MILESTONE"
 
 if [[ -z $COMMIT ]]; then
   fail "Wasn't able to retrieve merge commit for $PR_NUM."
 fi
 
-BRANCH_NAME="cherry-pick-$PR_NUM-to-$MILESTONE"
+gh pr view "$PR_NUM" --json body --jq '.body' > "$BODY_FILE"
 git fetch https://github.com/pantsbuild/pants "$MILESTONE"
 git checkout -b "$BRANCH_NAME" FETCH_HEAD
-git cherry-pick "$COMMIT"
-gh pr create --base "$MILESTONE" --title "$TITLE (Cherry-pick of #$PR_NUM)" --body "$BODY"
+git cherry-pick "$COMMIT" ||
+  fail "\nPlease fix the above conflicts, commit, and then run:\n  ${PR_CREATE_CMD[*]}"
+
+"${PR_CREATE_CMD[@]}"
+rm "$BODY_FILE"
 
 echo "Don't forget to remove the 'needs-cherrypick' label from PR #$PR_NUM!"

--- a/build-support/bin/cherry_pick.sh
+++ b/build-support/bin/cherry_pick.sh
@@ -36,7 +36,7 @@ fi
 
 COMMIT=$(gh pr view "$PR_NUM" --json mergeCommit --jq '.mergeCommit.oid')
 TITLE=$(gh pr view "$PR_NUM" --json title --jq '.title')
-BODY_FILE=$(mktemp /tmp/github.cherrypick.XXXXXX)
+BODY_FILE=$(mktemp "/tmp/github.cherrypick.$PR_NUM.$MILESTONE.XXXXXX")
 PR_CREATE_CMD=(gh pr create --base "$MILESTONE" --title "$TITLE (Cherry-pick of #$PR_NUM)" --body-file "$BODY_FILE")
 BRANCH_NAME="cherry-pick-$PR_NUM-to-$MILESTONE"
 


### PR DESCRIPTION
Use a file for the PR body, and render the command to use to create the PR if conflicts need to be resolved.

[ci skip-rust]
[ci skip-build-wheels]