### PR TITLE
[internal] kotlin: add dependency inference based on consumed symbols

### DIFF
--- a/src/python/pants/backend/kotlin/dependency_inference/KotlinParser.kt
+++ b/src/python/pants/backend/kotlin/dependency_inference/KotlinParser.kt
@@ -55,10 +55,9 @@ fun nameFromExpression(expression: KtExpression?): Name? {
     if (expression == null) {
         return null
     }
-    return if (expression is KtSimpleNameExpression) {
-        (expression as KtSimpleNameExpression).getReferencedNameAsName()
-    } else {
-        return null
+    return when (expression) {
+        is KtSimpleNameExpression -> expression.getReferencedNameAsName()
+        else -> null
     }
 }
 
@@ -67,17 +66,17 @@ fun fqNameFromExpression(expression: KtExpression?): FqName? {
         return null
     }
 
-    return if (expression is KtDotQualifiedExpression) {
-        val dotQualifiedExpression = expression as KtDotQualifiedExpression
-        val parentFqn: FqName? = fqNameFromExpression(dotQualifiedExpression.receiverExpression)
-        val child: Name = nameFromExpression(dotQualifiedExpression.selectorExpression) ?: return parentFqn
-        if (parentFqn != null) {
-            parentFqn.child(child)
-        } else null
-    } else if (expression is KtSimpleNameExpression) {
-        FqName.topLevel(expression.getReferencedNameAsName())
-    } else {
-        return null
+    return when (expression) {
+        is KtDotQualifiedExpression -> {
+            val dotQualifiedExpression = expression as KtDotQualifiedExpression
+            val parentFqn: FqName? = fqNameFromExpression(dotQualifiedExpression.receiverExpression)
+            val child: Name = nameFromExpression(dotQualifiedExpression.selectorExpression) ?: return parentFqn
+            if (parentFqn != null) {
+                parentFqn.child(child)
+            } else null
+        }
+        is KtSimpleNameExpression -> FqName.topLevel(expression.getReferencedNameAsName())
+        else -> null
     }
 }
 fun analyze(file: KtFile): KotlinAnalysis {

--- a/src/python/pants/backend/kotlin/dependency_inference/KotlinParser.kt
+++ b/src/python/pants/backend/kotlin/dependency_inference/KotlinParser.kt
@@ -58,7 +58,7 @@ fun nameFromExpression(expression: KtExpression?): Name? {
     return if (expression is KtSimpleNameExpression) {
         (expression as KtSimpleNameExpression).getReferencedNameAsName()
     } else {
-        throw IllegalArgumentException("Can't construct name for: " + expression.javaClass.toString())
+        return null
     }
 }
 
@@ -77,7 +77,7 @@ fun fqNameFromExpression(expression: KtExpression?): FqName? {
     } else if (expression is KtSimpleNameExpression) {
         FqName.topLevel(expression.getReferencedNameAsName())
     } else {
-        throw IllegalArgumentException("Can't construct fqn for: " + expression.javaClass.toString())
+        return null
     }
 }
 fun analyze(file: KtFile): KotlinAnalysis {

--- a/src/python/pants/backend/kotlin/dependency_inference/KotlinParser.kt
+++ b/src/python/pants/backend/kotlin/dependency_inference/KotlinParser.kt
@@ -1,9 +1,5 @@
 package org.pantsbuild.backend.kotlin.dependency_inference
 
-import java.nio.file.Files
-import java.nio.file.Paths
-import java.nio.charset.StandardCharsets
-
 import com.google.gson.Gson
 import com.intellij.openapi.util.Disposer
 import com.intellij.psi.PsiManager
@@ -12,11 +8,20 @@ import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.idea.KotlinFileType
-import org.jetbrains.kotlin.psi.KtNamedDeclaration
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtImportList
+import org.jetbrains.kotlin.psi.KtNamedDeclaration
+import org.jetbrains.kotlin.psi.KtPackageDirective
+import org.jetbrains.kotlin.psi.KtSimpleNameExpression
 import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
-import org.jetbrains.kotlin.psi.namedDeclarationRecursiveVisitor
-
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Paths
 
 // KtFile: https://github.com/JetBrains/kotlin/blob/8bc29a30111081ee0b0dbe06d1f648a789909a27/compiler/psi/src/org/jetbrains/kotlin/psi/KtFile.kt
 
@@ -27,8 +32,11 @@ data class KotlinImport(
 )
 
 data class KotlinAnalysis(
+    val `package`: String,
     val imports: List<KotlinImport>,
     val namedDeclarations: List<String>,
+    val scopes: List<String>,
+    val consumedSymbolsByScope: Map<String, List<String>>
 )
 
 fun parse(code: String): KtFile {
@@ -43,7 +51,38 @@ fun parse(code: String): KtFile {
     }
 }
 
+fun nameFromExpression(expression: KtExpression?): Name? {
+    if (expression == null) {
+        return null
+    }
+    return if (expression is KtSimpleNameExpression) {
+        (expression as KtSimpleNameExpression).getReferencedNameAsName()
+    } else {
+        throw IllegalArgumentException("Can't construct name for: " + expression.javaClass.toString())
+    }
+}
+
+fun fqNameFromExpression(expression: KtExpression?): FqName? {
+    if (expression == null) {
+        return null
+    }
+
+    return if (expression is KtDotQualifiedExpression) {
+        val dotQualifiedExpression = expression as KtDotQualifiedExpression
+        val parentFqn: FqName? = fqNameFromExpression(dotQualifiedExpression.receiverExpression)
+        val child: Name = nameFromExpression(dotQualifiedExpression.selectorExpression) ?: return parentFqn
+        if (parentFqn != null) {
+            parentFqn.child(child)
+        } else null
+    } else if (expression is KtSimpleNameExpression) {
+        FqName.topLevel(expression.getReferencedNameAsName())
+    } else {
+        throw IllegalArgumentException("Can't construct fqn for: " + expression.javaClass.toString())
+    }
+}
 fun analyze(file: KtFile): KotlinAnalysis {
+    val pkg = file.packageFqName.asString()
+
     val imports = file.importDirectives.map { importDirective ->
         val name = importDirective.importedFqName
         if (name != null) {
@@ -67,7 +106,58 @@ fun analyze(file: KtFile): KotlinAnalysis {
     }
     visitor.visitKtFile(file, null)
 
-    return KotlinAnalysis(imports.filterNotNull(), visitor.symbols)
+    val consumedSymbolsVisitor = object : KtTreeVisitorVoid() {
+        val symbolsByScope = mutableMapOf<String, MutableSet<String>>()
+        val scopes = mutableSetOf<String>(pkg)
+        var currentScope = pkg
+
+        override fun visitClassOrObject(classOrObject: KtClassOrObject) {
+            val oldScope = currentScope
+            val classId = classOrObject.getClassId()
+            if (classId != null && !classId.isLocal) {
+                currentScope = classId.asFqNameString()
+                scopes.add(currentScope)
+            }
+            super.visitClassOrObject(classOrObject)
+            currentScope = oldScope
+        }
+
+        // Skip recursing for imports directives and the package directive so they do not show up
+        // the consumed symbols analysis.
+        override fun visitImportList(importList: KtImportList) {}
+        override fun visitPackageDirective(directive: KtPackageDirective) {}
+
+        override fun visitDotQualifiedExpression(expr: KtDotQualifiedExpression) {
+            val fqName = fqNameFromExpression(expr)
+            if (fqName != null) {
+                if (!symbolsByScope.contains(currentScope)) {
+                    symbolsByScope.put(currentScope, mutableSetOf<String>())
+                }
+                val symbolsForScope = symbolsByScope.get(currentScope)
+                symbolsForScope?.add(fqName.asString())
+            }
+        }
+
+        override fun visitSimpleNameExpression(expr: KtSimpleNameExpression) {
+            val fqName = fqNameFromExpression(expr)
+            if (fqName != null) {
+                if (!symbolsByScope.contains(currentScope)) {
+                    symbolsByScope.put(currentScope, mutableSetOf<String>())
+                }
+                val symbolsForScope = symbolsByScope.get(currentScope)
+                symbolsForScope?.add(fqName.asString())
+            }
+        }
+    }
+    consumedSymbolsVisitor.visitKtFile(file)
+
+    return KotlinAnalysis(
+        pkg,
+        imports.filterNotNull(),
+        visitor.symbols,
+        consumedSymbolsVisitor.scopes.toList(),
+        consumedSymbolsVisitor.symbolsByScope.mapValues { it.value.toList() },
+    )
 }
 
 fun main(args: Array<String>) {

--- a/src/python/pants/backend/kotlin/dependency_inference/KotlinParser.kt
+++ b/src/python/pants/backend/kotlin/dependency_inference/KotlinParser.kt
@@ -122,7 +122,7 @@ fun analyze(file: KtFile): KotlinAnalysis {
         }
 
         // Skip recursing for imports directives and the package directive so they do not show up
-        // the consumed symbols analysis.
+        // in the consumed symbols analysis.
         override fun visitImportList(importList: KtImportList) {}
         override fun visitPackageDirective(directive: KtPackageDirective) {}
 

--- a/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser_test.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser_test.py
@@ -99,20 +99,22 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
         "org.pantsbuild.backend.kotlin.Foo",
         "org.pantsbuild.backend.kotlin.main",
     }
-    assert analysis.consumed_symbols_by_scope == FrozenDict({
-        "org.pantsbuild.backend.kotlin.Foo": frozenset(
-            {
-                "X",
-                "Y",
-            }
-        ),
-        "org.pantsbuild.backend.kotlin": frozenset(
-            {
-                "Array",
-                "String",
-            }
-        ),
-    })
+    assert analysis.consumed_symbols_by_scope == FrozenDict(
+        {
+            "org.pantsbuild.backend.kotlin.Foo": frozenset(
+                {
+                    "X",
+                    "Y",
+                }
+            ),
+            "org.pantsbuild.backend.kotlin": frozenset(
+                {
+                    "Array",
+                    "String",
+                }
+            ),
+        }
+    )
     assert analysis.scopes == {
         "org.pantsbuild.backend.kotlin",
         "org.pantsbuild.backend.kotlin.Foo",

--- a/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser_test.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser_test.py
@@ -22,6 +22,7 @@ from pants.jvm import jdk_rules
 from pants.jvm import util_rules as jvm_util_rules
 from pants.jvm.resolve import jvm_tool
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, RuleRunner, logging
+from pants.util.frozendict import FrozenDict
 
 
 @pytest.fixture
@@ -78,8 +79,13 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
             import java.io.File
 
             open class Foo {
-              fun grok() {}
+              fun grok() {
+                val x = X()
+                val y = Y()
+              }
             }
+
+            class Bar {}
 
             fun main(args: Array<String>) {
             }
@@ -89,6 +95,26 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
 
     assert analysis.imports == {KotlinImport(name="java.io.File", alias=None, is_wildcard=False)}
     assert analysis.named_declarations == {
+        "org.pantsbuild.backend.kotlin.Bar",
         "org.pantsbuild.backend.kotlin.Foo",
         "org.pantsbuild.backend.kotlin.main",
+    }
+    assert analysis.consumed_symbols_by_scope == FrozenDict({
+        "org.pantsbuild.backend.kotlin.Foo": frozenset(
+            {
+                "X",
+                "Y",
+            }
+        ),
+        "org.pantsbuild.backend.kotlin": frozenset(
+            {
+                "Array",
+                "String",
+            }
+        ),
+    })
+    assert analysis.scopes == {
+        "org.pantsbuild.backend.kotlin",
+        "org.pantsbuild.backend.kotlin.Foo",
+        "org.pantsbuild.backend.kotlin.Bar",
     }

--- a/src/python/pants/backend/kotlin/dependency_inference/rules.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/rules.py
@@ -52,6 +52,8 @@ async def infer_kotlin_dependencies_via_source_analysis(
     symbols: OrderedSet[str] = OrderedSet()
     if kotlin_infer_subsystem.imports:
         symbols.update(imp.name for imp in analysis.imports)
+    if kotlin_infer_subsystem.consumed_types:
+        symbols.update(analysis.fully_qualified_consumed_symbols())
 
     resolve = tgt[JvmResolveField].normalized_value(jvm)
 

--- a/src/python/pants/backend/kotlin/subsystems/kotlin_infer.py
+++ b/src/python/pants/backend/kotlin/subsystems/kotlin_infer.py
@@ -13,3 +13,9 @@ class KotlinInferSubsystem(Subsystem):
         default=True,
         help="Infer a target's dependencies by parsing import statements from sources.",
     )
+
+    consumed_types = BoolOption(
+        "--consumed-types",
+        default=True,
+        help="Infer a target's dependencies by parsing consumed types from sources.",
+    )


### PR DESCRIPTION
Add dependency inference for Kotlin based on a file's consumed symbols.