### PR TITLE
[internal] kotlin: infer dependencies on Kotlin runtime jars

### DIFF
--- a/src/python/pants/backend/kotlin/dependency_inference/rules.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/rules.py
@@ -141,7 +141,7 @@ async def resolve_kotlin_runtime_for_resolve(
 
 
 @rule(desc="Inject dependency on Kotlin runtime artifacts for Kotlin targets.")
-async def inject_scala_library_dependency(
+async def inject_kotlin_stdlib_dependency(
     request: InjectKotlinRuntimeDependencyRequest,
     jvm: JvmSubsystem,
 ) -> InjectedDependencies:

--- a/src/python/pants/backend/kotlin/target_types.py
+++ b/src/python/pants/backend/kotlin/target_types.py
@@ -40,6 +40,10 @@ class KotlinGeneratorFieldSet(FieldSet):
     sources: KotlinGeneratorSourcesField
 
 
+class KotlinDependenciesField(Dependencies):
+    pass
+
+
 # -----------------------------------------------------------------------------------------------
 # `kotlin_source` and `kotlin_sources` targets
 # -----------------------------------------------------------------------------------------------
@@ -49,7 +53,7 @@ class KotlinSourceTarget(Target):
     alias = "kotlin_source"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        Dependencies,
+        KotlinDependenciesField,
         KotlinSourceField,
         JvmResolveField,
         JvmProvidesTypesField,
@@ -71,7 +75,7 @@ class KotlinSourcesGeneratorTarget(TargetFilesGenerator):
     generated_target_cls = KotlinSourceTarget
     copied_fields = COMMON_TARGET_FIELDS
     moved_fields = (
-        Dependencies,
+        KotlinDependenciesField,
         JvmResolveField,
         JvmJdkField,
         JvmProvidesTypesField,


### PR DESCRIPTION
Infer dependencies on the Kotlin runtime jars: kotlin-stdlib, kotlin-reflect, and kotlin-script-runtime.

[ci skip-rust]