### PR TITLE
[internal] kotlin: add goal to dump source analysis

### DIFF
--- a/src/python/pants/backend/experimental/kotlin/debug_goals/BUILD
+++ b/src/python/pants/backend/experimental/kotlin/debug_goals/BUILD
@@ -1,0 +1,4 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_sources()

--- a/src/python/pants/backend/experimental/kotlin/debug_goals/register.py
+++ b/src/python/pants/backend/experimental/kotlin/debug_goals/register.py
@@ -1,0 +1,7 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from pants.backend.kotlin.goals import debug_goals
+
+
+def rules():
+    return debug_goals.rules()

--- a/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
@@ -6,7 +6,7 @@ import json
 import os
 import pkgutil
 from dataclasses import dataclass
-from typing import Iterator
+from typing import Any, Iterator
 
 from pants.backend.kotlin.subsystems.kotlin import DEFAULT_KOTLIN_VERSION
 from pants.core.util_rules.source_files import SourceFiles
@@ -57,6 +57,13 @@ class KotlinImport:
             alias=d.get("alias"),
             is_wildcard=d["isWildcard"],
         )
+
+    def to_debug_json_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "alias": self.alias,
+            "is_wildcard": self.is_wildcard,
+        }
 
 
 @dataclass(frozen=True)
@@ -120,6 +127,17 @@ class KotlinSourceDependencyAnalysis:
             ),
             scopes=frozenset(d["scopes"]),
         )
+
+    def to_debug_json_dict(self) -> dict[str, Any]:
+        return {
+            "package": self.package,
+            "imports": [imp.to_debug_json_dict() for imp in self.imports],
+            "named_declarations": list(self.named_declarations),
+            "consumed_symbols_by_scope": {
+                k: sorted(v) for k, v in self.consumed_symbols_by_scope.items()
+            },
+            "scopes": list(self.scopes),
+        }
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/kotlin/goals/debug_goals.py
+++ b/src/python/pants/backend/kotlin/goals/debug_goals.py
@@ -1,0 +1,49 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import json
+
+from pants.backend.experimental.kotlin.register import rules as kotlin_rules
+from pants.backend.kotlin.dependency_inference.kotlin_parser import KotlinSourceDependencyAnalysis
+from pants.backend.kotlin.target_types import KotlinFieldSet
+from pants.core.util_rules.source_files import SourceFilesRequest
+from pants.engine.console import Console
+from pants.engine.goal import Goal, GoalSubsystem
+from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.rules import collect_rules, goal_rule
+from pants.engine.target import Targets
+
+
+class DumpKotlinSourceAnalysisSubsystem(GoalSubsystem):
+    name = "kotlin-dump-source-analysis"
+    help = "Dump source analysis for kotlin_source targets."
+
+
+class DumpKotlinSourceAnalysis(Goal):
+    subsystem_cls = DumpKotlinSourceAnalysisSubsystem
+
+
+@goal_rule
+async def dump_kotlin_source_analysis(
+    targets: Targets, console: Console
+) -> DumpKotlinSourceAnalysis:
+    kotlin_source_field_sets = [
+        KotlinFieldSet.create(tgt) for tgt in targets if KotlinFieldSet.is_applicable(tgt)
+    ]
+    kotlin_source_analysis = await MultiGet(
+        Get(KotlinSourceDependencyAnalysis, SourceFilesRequest([fs.sources]))
+        for fs in kotlin_source_field_sets
+    )
+    kotlin_source_analysis_json = [
+        {"address": str(fs.address), **analysis.to_debug_json_dict()}
+        for (fs, analysis) in zip(kotlin_source_field_sets, kotlin_source_analysis)
+    ]
+    console.write_stdout(json.dumps(kotlin_source_analysis_json))
+    return DumpKotlinSourceAnalysis(exit_code=0)
+
+
+def rules():
+    return [
+        *collect_rules(),
+        *kotlin_rules(),
+    ]

--- a/src/python/pants/init/BUILD
+++ b/src/python/pants/init/BUILD
@@ -28,6 +28,7 @@ target(
         "src/python/pants/backend/experimental/java/debug_goals",
         "src/python/pants/backend/experimental/java/lint/google_java_format",
         "src/python/pants/backend/experimental/kotlin",
+        "src/python/pants/backend/experimental/kotlin/debug_goals",
         "src/python/pants/backend/experimental/kotlin/lint/ktlint",
         "src/python/pants/backend/experimental/python",
         "src/python/pants/backend/experimental/python/lint/autoflake",


### PR DESCRIPTION
Add `kotlin-dump-source-analysis` goal to dump Kotlin source analysis, similar to the existing `java-dump-source-analysis` and `scala-dump-source-analysis` debug goals.

[ci skip-rust]