### PR TITLE
Work around Git CVE-2022-24765 related failures.

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -9,13 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - name: Configure Git
-      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
-
-        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -12,6 +12,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 10
+    - name: Configure Git
+      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
+
+        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV

--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -17,13 +17,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - name: Configure Git
-      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
-
-        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
@@ -183,13 +179,9 @@ jobs:
           change, category:performance, category:bugfix, category:documentation, category:internal
         mode: exactly
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - name: Configure Git
-      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
-
-        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
@@ -323,13 +315,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - name: Configure Git
-      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
-
-        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
@@ -403,13 +391,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - name: Configure Git
-      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
-
-        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
@@ -506,13 +490,9 @@ jobs:
     runs-on: macos-10.15
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - name: Configure Git
-      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
-
-        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV

--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -20,6 +20,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 10
+    - name: Configure Git
+      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
+
+        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
@@ -182,6 +186,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 10
+    - name: Configure Git
+      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
+
+        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
@@ -318,6 +326,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 10
+    - name: Configure Git
+      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
+
+        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
@@ -394,6 +406,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 10
+    - name: Configure Git
+      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
+
+        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
@@ -493,6 +509,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 10
+    - name: Configure Git
+      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
+
+        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -305,6 +305,10 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
+    - name: Configure Git
+      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
+
+        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,13 +17,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - name: Configure Git
-      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
-
-        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
@@ -182,13 +178,9 @@ jobs:
           change, category:performance, category:bugfix, category:documentation, category:internal
         mode: exactly
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - name: Configure Git
-      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
-
-        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
@@ -310,13 +302,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - name: Configure Git
-      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
-
-        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
@@ -395,13 +383,9 @@ jobs:
     runs-on: macos-10.15
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - name: Configure Git
-      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
-
-        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
@@ -512,13 +496,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - name: Configure Git
-      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
-
-        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
@@ -591,13 +571,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - name: Configure Git
-      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
-
-        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
@@ -693,13 +669,9 @@ jobs:
     runs-on: macos-10.15
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - name: Configure Git
-      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
-
-        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,6 +20,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 10
+    - name: Configure Git
+      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
+
+        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
@@ -181,6 +185,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 10
+    - name: Configure Git
+      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
+
+        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
@@ -305,6 +313,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 10
+    - name: Configure Git
+      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
+
+        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
@@ -386,6 +398,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 10
+    - name: Configure Git
+      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
+
+        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
@@ -499,6 +515,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 10
+    - name: Configure Git
+      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
+
+        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
@@ -574,6 +594,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 10
+    - name: Configure Git
+      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
+
+        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
@@ -672,6 +696,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 10
+    - name: Configure Git
+      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
+
+        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -97,6 +97,18 @@ def checkout() -> Sequence[Step]:
             "uses": "actions/checkout@v2",
             "with": {"fetch-depth": 10},
         },
+        # Work around https://github.com/actions/checkout/issues/760
+        # See:
+        # + https://github.blog/2022-04-12-git-security-vulnerability-announced
+        # + https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24765
+        {
+            "name": "Configure Git",
+            "run": dedent(
+                """\
+                git config --global safe.directory "$GITHUB_WORKSPACE"
+                """
+            ),
+        },
         # For a push event, the commit we care about is HEAD itself.
         # This CI currently only runs on PRs, so this is future-proofing.
         {

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -86,9 +86,9 @@ def ensure_category_label() -> Sequence[Step]:
     ]
 
 
-def checkout() -> Sequence[Step]:
+def checkout(containerized: bool = False) -> Sequence[Step]:
     """Get prior commits and the commit message."""
-    return [
+    steps = [
         # See https://github.community/t/accessing-commit-message-in-pull-request-event/17158/8
         # for details on how we get the commit message here.
         # We need to fetch a few commits back, to be able to access HEAD^2 in the PR case.
@@ -97,33 +97,53 @@ def checkout() -> Sequence[Step]:
             "uses": "actions/checkout@v3",
             "with": {"fetch-depth": 10},
         },
-        # For a push event, the commit we care about is HEAD itself.
-        # This CI currently only runs on PRs, so this is future-proofing.
-        {
-            "name": "Get commit message for branch builds",
-            "if": "github.event_name == 'push'",
-            "run": dedent(
-                """\
+    ]
+    if containerized:
+        steps.append(
+            # Work around https://github.com/actions/checkout/issues/760 for our container jobs.
+            # See:
+            # + https://github.blog/2022-04-12-git-security-vulnerability-announced
+            # + https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24765
+            {
+                "name": "Configure Git",
+                "run": dedent(
+                    """\
+                    git config --global safe.directory "$GITHUB_WORKSPACE"
+                    """
+                ),
+            }
+        )
+    steps.extend(
+        [
+            # For a push event, the commit we care about is HEAD itself.
+            # This CI currently only runs on PRs, so this is future-proofing.
+            {
+                "name": "Get commit message for branch builds",
+                "if": "github.event_name == 'push'",
+                "run": dedent(
+                    """\
                 echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
                 echo "$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
                 echo "EOF" >> $GITHUB_ENV
                 """
-            ),
-        },
-        # For a pull_request event, the commit we care about is the second parent of the merge
-        # commit. This CI currently only runs on PRs, so this is future-proofing.
-        {
-            "name": "Get commit message for PR builds",
-            "if": "github.event_name == 'pull_request'",
-            "run": dedent(
-                """\
+                ),
+            },
+            # For a pull_request event, the commit we care about is the second parent of the merge
+            # commit. This CI currently only runs on PRs, so this is future-proofing.
+            {
+                "name": "Get commit message for PR builds",
+                "if": "github.event_name == 'pull_request'",
+                "run": dedent(
+                    """\
                 echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
                 echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
                 echo "EOF" >> $GITHUB_ENV
                 """
-            ),
-        },
-    ]
+                ),
+            },
+        ]
+    )
+    return steps
 
 
 def setup_toolchain_auth() -> Step:
@@ -527,7 +547,7 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
                     "timeout-minutes": 65,
                     **build_wheels_common,
                     "steps": [
-                        *checkout(),
+                        *checkout(containerized=True),
                         install_rustup(),
                         {
                             "name": "Expose Pythons",

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -94,20 +94,8 @@ def checkout() -> Sequence[Step]:
         # We need to fetch a few commits back, to be able to access HEAD^2 in the PR case.
         {
             "name": "Check out code",
-            "uses": "actions/checkout@v2",
+            "uses": "actions/checkout@v3",
             "with": {"fetch-depth": 10},
-        },
-        # Work around https://github.com/actions/checkout/issues/760
-        # See:
-        # + https://github.blog/2022-04-12-git-security-vulnerability-announced
-        # + https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24765
-        {
-            "name": "Configure Git",
-            "run": dedent(
-                """\
-                git config --global safe.directory "$GITHUB_WORKSPACE"
-                """
-            ),
         },
         # For a push event, the commit we care about is HEAD itself.
         # This CI currently only runs on PRs, so this is future-proofing.


### PR DESCRIPTION
We see the following in CI:
```
fatal: unsafe repository (/__w/pants/pants is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /__w/pants/pants
```

Add the `$GITHUB_WORKSPACE` (`/__w/pants/pants`) to fix.