### PR TITLE
Work around Git CVE-2022-24765 related failures. (Cherry-pick of #15173)

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
     - if: github.event_name == 'push'

--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
     - if: github.event_name == 'push'
@@ -167,7 +167,7 @@ jobs:
     runs-on: macos-10.15
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
     - if: github.event_name == 'push'
@@ -288,7 +288,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
     - if: github.event_name == 'push'
@@ -364,7 +364,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
     - if: github.event_name == 'push'
@@ -463,7 +463,7 @@ jobs:
     runs-on: macos-10.15
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
     - if: github.event_name == 'push'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
     - if: github.event_name == 'push'
@@ -166,7 +166,7 @@ jobs:
     runs-on: macos-10.15
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
     - if: github.event_name == 'push'
@@ -289,9 +289,13 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
+    - name: Configure Git
+      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
+
+        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
@@ -369,7 +373,7 @@ jobs:
     runs-on: macos-10.15
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
     - if: github.event_name == 'push'
@@ -467,7 +471,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
     - if: github.event_name == 'push'
@@ -542,7 +546,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
     - if: github.event_name == 'push'
@@ -640,7 +644,7 @@ jobs:
     runs-on: macos-10.15
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
     - if: github.event_name == 'push'

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -67,44 +67,64 @@ IS_PANTS_OWNER = "${{ github.repository_owner == 'pantsbuild' }}"
 # ----------------------------------------------------------------------
 
 
-def checkout() -> Sequence[Step]:
+def checkout(containerized: bool = False) -> Sequence[Step]:
     """Get prior commits and the commit message."""
-    return [
+    steps = [
         # See https://github.community/t/accessing-commit-message-in-pull-request-event/17158/8
         # for details on how we get the commit message here.
         # We need to fetch a few commits back, to be able to access HEAD^2 in the PR case.
         {
             "name": "Check out code",
-            "uses": "actions/checkout@v2",
+            "uses": "actions/checkout@v3",
             "with": {"fetch-depth": 10},
         },
-        # For a push event, the commit we care about is HEAD itself.
-        # This CI currently only runs on PRs, so this is future-proofing.
-        {
-            "name": "Get commit message for branch builds",
-            "if": "github.event_name == 'push'",
-            "run": dedent(
-                """\
+    ]
+    if containerized:
+        steps.append(
+            # Work around https://github.com/actions/checkout/issues/760 for our container jobs.
+            # See:
+            # + https://github.blog/2022-04-12-git-security-vulnerability-announced
+            # + https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24765
+            {
+                "name": "Configure Git",
+                "run": dedent(
+                    """\
+                    git config --global safe.directory "$GITHUB_WORKSPACE"
+                    """
+                ),
+            }
+        )
+    steps.extend(
+        [
+            # For a push event, the commit we care about is HEAD itself.
+            # This CI currently only runs on PRs, so this is future-proofing.
+            {
+                "name": "Get commit message for branch builds",
+                "if": "github.event_name == 'push'",
+                "run": dedent(
+                    """\
                 echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
                 echo "$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
                 echo "EOF" >> $GITHUB_ENV
                 """
-            ),
-        },
-        # For a pull_request event, the commit we care about is the second parent of the merge
-        # commit. This CI currently only runs on PRs, so this is future-proofing.
-        {
-            "name": "Get commit message for PR builds",
-            "if": "github.event_name == 'pull_request'",
-            "run": dedent(
-                """\
+                ),
+            },
+            # For a pull_request event, the commit we care about is the second parent of the merge
+            # commit. This CI currently only runs on PRs, so this is future-proofing.
+            {
+                "name": "Get commit message for PR builds",
+                "if": "github.event_name == 'pull_request'",
+                "run": dedent(
+                    """\
                 echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
                 echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
                 echo "EOF" >> $GITHUB_ENV
                 """
-            ),
-        },
-    ]
+                ),
+            },
+        ]
+    )
+    return steps
 
 
 def setup_toolchain_auth() -> Step:
@@ -495,7 +515,7 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
                     "env": DISABLE_REMOTE_CACHE_ENV,
                     "if": IS_PANTS_OWNER,
                     "steps": [
-                        *checkout(),
+                        *checkout(containerized=True),
                         install_rustup(),
                         {
                             "name": "Expose Pythons",


### PR DESCRIPTION
We see the following in CI:
```
fatal: unsafe repository (/__w/pants/pants is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /__w/pants/pants
```

Add the `$GITHUB_WORKSPACE` (`/__w/pants/pants`) to fix container builds.

(cherry picked from commit 7bcf679448366761a37115f5e0ed0f5739831eaf)