### PR TITLE
Work around Git CVE-2022-24765 related failures. (Cherry-pick of #14670 & #15173)

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
     - if: github.event_name == 'push'

--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -77,7 +77,7 @@ jobs:
     - name: Cache Pants Virtualenv
       uses: actions/cache@v2
       with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''pants/3rdparty/python/**'',
+        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
           ''pants.toml'') }}
 
           '
@@ -232,7 +232,7 @@ jobs:
     - name: Cache Pants Virtualenv
       uses: actions/cache@v2
       with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''pants/3rdparty/python/**'',
+        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
           ''pants.toml'') }}
 
           '
@@ -331,7 +331,7 @@ jobs:
     - name: Cache Pants Virtualenv
       uses: actions/cache@v2
       with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''pants/3rdparty/python/**'',
+        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
           ''pants.toml'') }}
 
           '
@@ -420,7 +420,7 @@ jobs:
     - name: Cache Pants Virtualenv
       uses: actions/cache@v2
       with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''pants/3rdparty/python/**'',
+        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
           ''pants.toml'') }}
 
           '
@@ -503,7 +503,7 @@ jobs:
     - name: Cache Pants Virtualenv
       uses: actions/cache@v2
       with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''pants/3rdparty/python/**'',
+        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
           ''pants.toml'') }}
 
           '

--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
     - if: github.event_name == 'push'
@@ -171,7 +171,7 @@ jobs:
     runs-on: macos-10.15
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
     - if: github.event_name == 'push'
@@ -296,7 +296,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
     - if: github.event_name == 'push'
@@ -374,7 +374,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
     - if: github.event_name == 'push'
@@ -461,7 +461,7 @@ jobs:
     runs-on: macos-10.15
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
     - if: github.event_name == 'push'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
     - if: github.event_name == 'push'
@@ -170,7 +170,7 @@ jobs:
     runs-on: macos-10.15
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
     - if: github.event_name == 'push'
@@ -297,9 +297,13 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
+    - name: Configure Git
+      run: 'git config --global safe.directory "$GITHUB_WORKSPACE"
+
+        '
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
@@ -375,7 +379,7 @@ jobs:
     runs-on: macos-10.15
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
     - if: github.event_name == 'push'
@@ -471,7 +475,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
     - if: github.event_name == 'push'
@@ -548,7 +552,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
     - if: github.event_name == 'push'
@@ -634,7 +638,7 @@ jobs:
     runs-on: macos-10.15
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 10
     - if: github.event_name == 'push'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -77,7 +77,7 @@ jobs:
     - name: Cache Pants Virtualenv
       uses: actions/cache@v2
       with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''pants/3rdparty/python/**'',
+        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
           ''pants.toml'') }}
 
           '
@@ -231,7 +231,7 @@ jobs:
     - name: Cache Pants Virtualenv
       uses: actions/cache@v2
       with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''pants/3rdparty/python/**'',
+        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
           ''pants.toml'') }}
 
           '
@@ -510,7 +510,7 @@ jobs:
     - name: Cache Pants Virtualenv
       uses: actions/cache@v2
       with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''pants/3rdparty/python/**'',
+        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
           ''pants.toml'') }}
 
           '
@@ -598,7 +598,7 @@ jobs:
     - name: Cache Pants Virtualenv
       uses: actions/cache@v2
       with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''pants/3rdparty/python/**'',
+        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
           ''pants.toml'') }}
 
           '
@@ -680,7 +680,7 @@ jobs:
     - name: Cache Pants Virtualenv
       uses: actions/cache@v2
       with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''pants/3rdparty/python/**'',
+        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
           ''pants.toml'') }}
 
           '

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -146,7 +146,7 @@ def pants_virtualenv_cache() -> Step:
         "uses": "actions/cache@v2",
         "with": {
             "path": "~/.cache/pants/pants_dev_deps\n",
-            "key": "${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles('pants/3rdparty/python/**', 'pants.toml') }}\n",
+            "key": "${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles('3rdparty/python/**', 'pants.toml') }}\n",
         },
     }
 

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -68,44 +68,64 @@ IS_PANTS_OWNER = "${{ github.repository_owner == 'pantsbuild' }}"
 # ----------------------------------------------------------------------
 
 
-def checkout() -> Sequence[Step]:
+def checkout(containerized: bool = False) -> Sequence[Step]:
     """Get prior commits and the commit message."""
-    return [
+    steps = [
         # See https://github.community/t/accessing-commit-message-in-pull-request-event/17158/8
         # for details on how we get the commit message here.
         # We need to fetch a few commits back, to be able to access HEAD^2 in the PR case.
         {
             "name": "Check out code",
-            "uses": "actions/checkout@v2",
+            "uses": "actions/checkout@v3",
             "with": {"fetch-depth": 10},
         },
-        # For a push event, the commit we care about is HEAD itself.
-        # This CI currently only runs on PRs, so this is future-proofing.
-        {
-            "name": "Get commit message for branch builds",
-            "if": "github.event_name == 'push'",
-            "run": dedent(
-                """\
+    ]
+    if containerized:
+        steps.append(
+            # Work around https://github.com/actions/checkout/issues/760 for our container jobs.
+            # See:
+            # + https://github.blog/2022-04-12-git-security-vulnerability-announced
+            # + https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24765
+            {
+                "name": "Configure Git",
+                "run": dedent(
+                    """\
+                    git config --global safe.directory "$GITHUB_WORKSPACE"
+                    """
+                ),
+            }
+        )
+    steps.extend(
+        [
+            # For a push event, the commit we care about is HEAD itself.
+            # This CI currently only runs on PRs, so this is future-proofing.
+            {
+                "name": "Get commit message for branch builds",
+                "if": "github.event_name == 'push'",
+                "run": dedent(
+                    """\
                 echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
                 echo "$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
                 echo "EOF" >> $GITHUB_ENV
                 """
-            ),
-        },
-        # For a pull_request event, the commit we care about is the second parent of the merge
-        # commit. This CI currently only runs on PRs, so this is future-proofing.
-        {
-            "name": "Get commit message for PR builds",
-            "if": "github.event_name == 'pull_request'",
-            "run": dedent(
-                """\
+                ),
+            },
+            # For a pull_request event, the commit we care about is the second parent of the merge
+            # commit. This CI currently only runs on PRs, so this is future-proofing.
+            {
+                "name": "Get commit message for PR builds",
+                "if": "github.event_name == 'pull_request'",
+                "run": dedent(
+                    """\
                 echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
                 echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
                 echo "EOF" >> $GITHUB_ENV
                 """
-            ),
-        },
-    ]
+                ),
+            },
+        ]
+    )
+    return steps
 
 
 def setup_toolchain_auth() -> Step:
@@ -475,7 +495,7 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
                     "env": DISABLE_REMOTE_CACHE_ENV,
                     "if": IS_PANTS_OWNER,
                     "steps": [
-                        *checkout(),
+                        *checkout(containerized=True),
                         install_rustup(),
                         {
                             "name": "Expose Pythons",


### PR DESCRIPTION
We see the following in CI:
```
fatal: unsafe repository (/__w/pants/pants is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /__w/pants/pants
```

Add the `$GITHUB_WORKSPACE` (`/__w/pants/pants`) to fix container builds.

(cherry picked from commit 7bcf679448366761a37115f5e0ed0f5739831eaf)