### PR TITLE
Add a workflow for comparing remote cache performance across builds

### DIFF
--- a/.github/workflows/cache_comparison.yaml
+++ b/.github/workflows/cache_comparison.yaml
@@ -1,0 +1,64 @@
+# GENERATED, DO NOT EDIT!
+# To change, edit `build-support/bin/generate_github_workflows.py` and run:
+#   ./pants run build-support/bin/generate_github_workflows.py
+
+
+jobs:
+  cache_comparison:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 1024
+    - if: github.event_name == 'push'
+      name: Get commit message for branch builds
+      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
+
+        echo "$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
+
+        echo "EOF" >> $GITHUB_ENV
+
+        '
+    - if: github.event_name == 'pull_request'
+      name: Get commit message for PR builds
+      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
+
+        echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
+
+        echo "EOF" >> $GITHUB_ENV
+
+        '
+    - env:
+        BUILD_DIFFSPEC: ${{ github.event.inputs.buildDiffspec }}
+        BUILD_DIFFSPEC_STEP: ${{ github.event.inputs.buildDiffspecStep }}
+        PANTS_ARGS: ${{ github.event.inputs.pants_args }}
+        SOURCE_DIFFSPEC: ${{ github.event.inputs.sourceDiffspec }}
+        SOURCE_DIFFSPEC_STEP: ${{ github.event.inputs.sourceDiffspecStep }}
+      name: Cache comparison script
+      run: "./pants package build-support/bin/cache_comparison.py\ndist/build-support.bin/cache_comparison_py.pex\
+        \ \\\n  --args=\"$PANTS_ARGS\" \\\n  --build-diffspec=\"$BUILD_DIFFSPEC\"\
+        \ \\\n  --build-diffspec-step=$BUILD_DIFFSPEC_STEP \\\n  --source-diffspec=\"\
+        $SOURCE_DIFFSPEC\" \\\n  --source-diffspec-step=$SOURCE_DIFFSPEC_STEP\"\n"
+name: Cache Comparison
+'on':
+  workflow_dispatch:
+    inputs:
+      buildDiffspec:
+        required: true
+        type: string
+      buildDiffspecStep:
+        default: 1
+        required: false
+        type: int
+      pants_args:
+        default: 'check fmt lint ::'
+        required: false
+        type: string
+      sourceDiffspec:
+        required: true
+        type: string
+      sourceDiffspecStep:
+        default: 1
+        required: false
+        type: int

--- a/build-support/bin/BUILD
+++ b/build-support/bin/BUILD
@@ -18,6 +18,7 @@ python_tests(name="py_tests", overrides={"reversion_test.py": {"timeout": 90}})
 
 pex_binaries(
     entry_points=[
+        "cache_comparison.py",
         "changelog.py",
         "check_banned_imports.py",
         "check_inits.py",

--- a/build-support/bin/cache_comparison.py
+++ b/build-support/bin/cache_comparison.py
@@ -1,0 +1,138 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import shutil
+import subprocess
+import sys
+from time import time
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "A (remote) cache comparison tool, which automates testing a range of Pants "
+            "builds (each in isolated cache namespaces) against a range of sources."
+        )
+    )
+
+    parser.add_argument(
+        "-a",
+        "--args",
+        default="check lint test ::",
+        help="The arguments to test each source commit with.",
+    )
+    parser.add_argument(
+        "-b",
+        "--build-diffspec",
+        help="The diffspec (e.g.: `main~10..main`) which selects the Pants builds to compare.",
+    )
+    parser.add_argument(
+        "--build-diffspec-step",
+        default=1,
+        help="The number of commits to step by within `--build-diffspec`.",
+    )
+    parser.add_argument(
+        "-s",
+        "--source-diffspec",
+        help=(
+            "The diffspec (e.g.: `main~10..main`) which selects the Pants-repo source commits "
+            "to run each Pants build against."
+        ),
+    )
+    parser.add_argument(
+        "--source-diffspec-step",
+        default=1,
+        help="The number of commits to step by within `--source-diffspec`.",
+    )
+    return parser
+
+
+def main() -> None:
+    args = create_parser().parse_args()
+    build_commits = commits_in_range(args.build_diffspec, args.build_diffspec_step)
+    source_commits = commits_in_range(args.source_diffspec, args.source_diffspec_step)
+    timings = timings_by_build(
+        shlex.split(args.args),
+        build_commits,
+        source_commits,
+    )
+    json.dump(timings, indent=2, fp=sys.stdout)
+
+
+Commit = str
+
+
+TimeInSeconds = float
+
+
+def commits_in_range(diffspec: str, step: int) -> list[Commit]:
+    all_commits = list(
+        subprocess.run(
+            ["git", "log", "--format=format:%h", diffspec, "--"],
+            stdout=subprocess.PIPE,
+            check=True,
+        )
+        .stdout.decode()
+        .splitlines()
+    )
+    return list(reversed(all_commits))[::step]
+
+
+def timings_by_build(
+    args: list[str], build_commits: list[Commit], source_commits: list[Commit]
+) -> list[tuple[Commit, list[TimeInSeconds]]]:
+    """For each build commit, build a PEX, and then collect timings for each source commit."""
+    result = []
+    for build_commit in build_commits:
+        cache_namespace = f"cache-comparison-{build_commit}-{time()}"
+        # Build a PEX for the commit, then ensure that `pantsd` is not running.
+        checkout(build_commit)
+        run(["package", "src/python/pants/bin:pants"], cache_namespace, use_pex=False)
+        shutil.rmtree(".pids")
+        # Then collect a runtime for each commit in the range.
+        result.append(
+            (
+                build_commit,
+                [
+                    timing_for_commit(source_commit, args, cache_namespace)
+                    for source_commit in source_commits
+                ],
+            )
+        )
+    return result
+
+
+def timing_for_commit(commit: Commit, args: list[str], cache_namespace: str) -> TimeInSeconds:
+    checkout(commit)
+    start = time()
+    run(args, cache_namespace)
+    return time() - start
+
+
+def checkout(commit: Commit) -> None:
+    subprocess.run(["git", "checkout", commit], check=True)
+
+
+def run(args: list[str], cache_namespace: str, *, use_pex: bool = True) -> None:
+    cmd = "dist/src.python.pants.bin/pants.pex" if use_pex else "./pants"
+    subprocess.run(
+        [cmd, *pants_options(cache_namespace), *args],
+        check=True,
+    )
+
+
+def pants_options(cache_namespace: str) -> list[str]:
+    return [
+        "--no-local-cache",
+        "--pants-config-files=pants.ci.toml",
+        f"--process-execution-cache-namespace={cache_namespace}",
+    ]
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This change adds a script and corresponding manually-triggered Github Actions workflow to compare (remote) cache performance across builds. It was inspired by some infrastructure for release vetting used at Twitter.

The script builds a PEX per build commit (selected by `--build-diffspec(-step)`) and collects the runtimes for a goal across a series of source commits (selected by `--source-diffspec(-step)`). The build commits are the commits actually under comparison, while the source commits are the input dataset to test them on.

Each series of builds runs with only the remote cache enabled, and in a separate cache namespace. This significantly improves reproducibility, but means that the first source commit for each build will always be completely cold.