### PR TITLE
Deprecate `PythonToolBase.to_pex_request()` in favor of `PythonToolPexRequest`

### DIFF
--- a/src/python/pants/backend/awslambda/python/rules.py
+++ b/src/python/pants/backend/awslambda/python/rules.py
@@ -14,13 +14,13 @@ from pants.backend.awslambda.python.target_types import (
     ResolvePythonAwsHandlerRequest,
 )
 from pants.backend.python.subsystems.lambdex import Lambdex
+from pants.backend.python.subsystems.python_tool_base import PythonToolPexRequest
 from pants.backend.python.target_types import PexCompletePlatformsField
 from pants.backend.python.util_rules import pex_from_targets
 from pants.backend.python.util_rules.pex import (
     CompletePlatforms,
     Pex,
     PexPlatforms,
-    PexRequest,
     VenvPex,
     VenvPexProcess,
 )
@@ -120,7 +120,7 @@ async def package_python_awslambda(
     )
 
     lambdex_pex, pex_result, handler, transitive_targets = await MultiGet(
-        Get(VenvPex, PexRequest, lambdex.to_pex_request()),
+        Get(VenvPex, PythonToolPexRequest(lambdex)),
         Get(Pex, PexFromTargetsRequest, pex_request),
         Get(ResolvedPythonAwsHandler, ResolvePythonAwsHandlerRequest(field_set.handler)),
         Get(TransitiveTargets, TransitiveTargetsRequest([field_set.address])),

--- a/src/python/pants/backend/codegen/protobuf/python/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules.py
@@ -11,9 +11,10 @@ from pants.backend.codegen.protobuf.python.python_protobuf_subsystem import (
     PythonProtobufSubsystem,
 )
 from pants.backend.codegen.protobuf.target_types import ProtobufGrpcToggleField, ProtobufSourceField
+from pants.backend.python.subsystems.python_tool_base import PythonToolPexRequest
 from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules import pex
-from pants.backend.python.util_rules.pex import PexResolveInfo, VenvPex, VenvPexRequest
+from pants.backend.python.util_rules.pex import PexRequest, PexResolveInfo, VenvPex, VenvPexRequest
 from pants.backend.python.util_rules.pex_environment import PexEnvironment
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.core.util_rules.source_files import SourceFilesRequest
@@ -100,7 +101,7 @@ async def generate_python_from_protobuf(
     mypy_pex = None
 
     if python_protobuf_subsystem.mypy_plugin:
-        mypy_request = python_protobuf_mypy_plugin.to_pex_request()
+        mypy_request = await Get(PexRequest, PythonToolPexRequest(python_protobuf_mypy_plugin))
         mypy_pex = await Get(
             VenvPex,
             VenvPexRequest(bin_names=[protoc_gen_mypy_script], pex_request=mypy_request),

--- a/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
+++ b/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
@@ -12,10 +12,13 @@ from pants.backend.docker.target_types import DockerImageSourceField
 from pants.backend.docker.util_rules.docker_build_args import DockerBuildArgs
 from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.lockfile import GeneratePythonLockfile
-from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
+from pants.backend.python.subsystems.python_tool_base import (
+    PythonToolPexRequest,
+    PythonToolRequirementsBase,
+)
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import EntryPoint
-from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
+from pants.backend.python.util_rules.pex import VenvPex, VenvPexProcess
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
@@ -82,9 +85,10 @@ async def setup_parser(dockerfile_parser: DockerfileParser) -> ParserSetup:
 
     parser_pex = await Get(
         VenvPex,
-        PexRequest,
-        dockerfile_parser.to_pex_request(
-            main=EntryPoint(PurePath(parser_content.path).stem), sources=parser_digest
+        PythonToolPexRequest(
+            dockerfile_parser,
+            main=EntryPoint(PurePath(parser_content.path).stem),
+            sources=parser_digest,
         ),
     )
     return ParserSetup(parser_pex)

--- a/src/python/pants/backend/google_cloud_function/python/rules.py
+++ b/src/python/pants/backend/google_cloud_function/python/rules.py
@@ -14,13 +14,13 @@ from pants.backend.google_cloud_function.python.target_types import (
     ResolvePythonGoogleHandlerRequest,
 )
 from pants.backend.python.subsystems.lambdex import Lambdex
+from pants.backend.python.subsystems.python_tool_base import PythonToolPexRequest
 from pants.backend.python.target_types import PexCompletePlatformsField
 from pants.backend.python.util_rules import pex_from_targets
 from pants.backend.python.util_rules.pex import (
     CompletePlatforms,
     Pex,
     PexPlatforms,
-    PexRequest,
     VenvPex,
     VenvPexProcess,
 )
@@ -115,16 +115,8 @@ async def package_python_google_cloud_function(
         additional_lockfile_args=additional_pex_args,
     )
 
-    lambdex_request = PexRequest(
-        output_filename="lambdex.pex",
-        internal_only=True,
-        requirements=lambdex.pex_requirements(),
-        interpreter_constraints=lambdex.interpreter_constraints,
-        main=lambdex.main,
-    )
-
     lambdex_pex, pex_result, handler, transitive_targets = await MultiGet(
-        Get(VenvPex, PexRequest, lambdex_request),
+        Get(VenvPex, PythonToolPexRequest(lambdex)),
         Get(Pex, PexFromTargetsRequest, pex_request),
         Get(ResolvedPythonGoogleHandler, ResolvePythonGoogleHandlerRequest(field_set.handler)),
         Get(TransitiveTargets, TransitiveTargetsRequest([field_set.address])),

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -14,10 +14,10 @@ import toml
 
 from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.lockfile import GeneratePythonLockfile
-from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import PythonToolBase, PythonToolPexRequest
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import ConsoleScript
-from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
+from pants.backend.python.util_rules.pex import VenvPex, VenvPexProcess
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
     PythonSourceFilesRequest,
@@ -356,7 +356,7 @@ class CoverageSetup:
 
 @rule
 async def setup_coverage(coverage: CoverageSubsystem) -> CoverageSetup:
-    pex = await Get(VenvPex, PexRequest, coverage.to_pex_request())
+    pex = await Get(VenvPex, PythonToolPexRequest(coverage))
     return CoverageSetup(pex)
 
 

--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -9,10 +9,11 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import DefaultDict, Iterable, cast
 
+from pants.backend.python.subsystems.python_tool_base import PythonToolPexRequest
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import PythonResolveField
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.pex import Pex, PexProcess, PexRequest
+from pants.backend.python.util_rules.pex import Pex, PexProcess
 from pants.backend.python.util_rules.pex_cli import PexPEX
 from pants.backend.python.util_rules.pex_from_targets import RequirementsPexRequest
 from pants.core.goals.export import (
@@ -65,7 +66,7 @@ class ExportPythonToolSentinel:
 @dataclass(frozen=True)
 class ExportPythonTool(EngineAwareParameter):
     resolve_name: str
-    pex_request: PexRequest
+    pex_request: PythonToolPexRequest
 
     def debug_hint(self) -> str | None:
         return self.resolve_name
@@ -156,7 +157,7 @@ async def export_virtualenv(
 @rule
 async def export_tool(request: ExportPythonTool, pex_pex: PexPEX) -> ExportResult:
     dest = os.path.join("python", "virtualenvs", "tools")
-    pex = await Get(Pex, PexRequest, request.pex_request)
+    pex = await Get(Pex, PythonToolPexRequest, request.pex_request)
 
     # NOTE: We add a unique-per-tool prefix to the pex_pex path to avoid conflicts when
     # multiple tools are concurrently exporting. Without this prefix all the `export_tool`

--- a/src/python/pants/backend/python/goals/publish.py
+++ b/src/python/pants/backend/python/goals/publish.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
+from pants.backend.python.subsystems.python_tool_base import PythonToolPexRequest
 from pants.backend.python.subsystems.twine import TwineSubsystem
 from pants.backend.python.target_types import PythonDistribution
-from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
+from pants.backend.python.util_rules.pex import VenvPex, VenvPexProcess
 from pants.core.goals.publish import (
     PublishFieldSet,
     PublishOutputData,
@@ -171,7 +172,7 @@ async def twine_upload(
         )
 
     twine_pex, packages_digest, config_files = await MultiGet(
-        Get(VenvPex, PexRequest, twine_subsystem.to_pex_request()),
+        Get(VenvPex, PythonToolPexRequest(twine_subsystem)),
         Get(Digest, MergeDigests(pkg.digest for pkg in request.packages)),
         Get(ConfigFiles, ConfigFilesRequest, twine_subsystem.config_request()),
     )

--- a/src/python/pants/backend/python/goals/repl.py
+++ b/src/python/pants/backend/python/goals/repl.py
@@ -7,11 +7,12 @@ import os
 from typing import Iterable
 
 from pants.backend.python.subsystems.ipython import IPython
+from pants.backend.python.subsystems.python_tool_base import PythonToolPexRequest
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import PythonResolveField
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.local_dists import LocalDistsPex, LocalDistsPexRequest
-from pants.backend.python.util_rules.pex import Pex, PexRequest
+from pants.backend.python.util_rules.pex import Pex
 from pants.backend.python.util_rules.pex_environment import PexEnvironment
 from pants.backend.python.util_rules.pex_from_targets import (
     InterpreterConstraintsRequest,
@@ -134,7 +135,7 @@ async def create_ipython_repl_request(
     )
 
     ipython_request = Get(
-        Pex, PexRequest, ipython.to_pex_request(interpreter_constraints=interpreter_constraints)
+        Pex, PythonToolPexRequest(ipython, interpreter_constraints=interpreter_constraints)
     )
 
     requirements_pex, sources, ipython_pex = await MultiGet(

--- a/src/python/pants/backend/python/lint/autoflake/rules.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules.py
@@ -5,9 +5,10 @@ from dataclasses import dataclass
 
 from pants.backend.python.lint.autoflake.skip_field import SkipAutoflakeField
 from pants.backend.python.lint.autoflake.subsystem import Autoflake
+from pants.backend.python.subsystems.python_tool_base import PythonToolPexRequest
 from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules import pex
-from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
+from pants.backend.python.util_rules.pex import VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.engine.fs import Digest
 from pants.engine.internals.native_engine import Snapshot
@@ -39,8 +40,7 @@ class AutoflakeRequest(FmtRequest):
 async def autoflake_fmt(request: AutoflakeRequest, autoflake: Autoflake) -> FmtResult:
     if autoflake.skip:
         return FmtResult.skip(formatter_name=request.name)
-    autoflake_pex = await Get(VenvPex, PexRequest, autoflake.to_pex_request())
-
+    autoflake_pex = await Get(VenvPex, PythonToolPexRequest(autoflake))
     result = await Get(
         ProcessResult,
         VenvPexProcess(

--- a/src/python/pants/backend/python/lint/autoflake/subsystem.py
+++ b/src/python/pants/backend/python/lint/autoflake/subsystem.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
 from pants.backend.python.goals.lockfile import GeneratePythonLockfile
-from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import PythonToolBase, PythonToolPexRequest
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import ConsoleScript
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
@@ -55,9 +55,7 @@ class AutoflakeExportSentinel(ExportPythonToolSentinel):
 
 @rule
 def autoflake_export(_: AutoflakeExportSentinel, autoflake: Autoflake) -> ExportPythonTool:
-    return ExportPythonTool(
-        resolve_name=autoflake.options_scope, pex_request=autoflake.to_pex_request()
-    )
+    return ExportPythonTool(autoflake.options_scope, PythonToolPexRequest(autoflake))
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -5,10 +5,11 @@ from dataclasses import dataclass
 from typing import Tuple
 
 from pants.backend.python.lint.bandit.subsystem import Bandit, BanditFieldSet
+from pants.backend.python.subsystems.python_tool_base import PythonToolPexRequest
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
+from pants.backend.python.util_rules.pex import VenvPex, VenvPexProcess
 from pants.core.goals.lint import REPORT_DIR, LintResult, LintResults, LintTargetsRequest
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
@@ -42,11 +43,8 @@ def generate_argv(source_files: SourceFiles, bandit: Bandit) -> Tuple[str, ...]:
 
 @rule(level=LogLevel.DEBUG)
 async def bandit_lint_partition(partition: BanditPartition, bandit: Bandit) -> LintResult:
-
     bandit_pex_get = Get(
-        VenvPex,
-        PexRequest,
-        bandit.to_pex_request(interpreter_constraints=partition.interpreter_constraints),
+        VenvPex, PythonToolPexRequest(interpreter_constraints=partition.interpreter_constraints)
     )
 
     config_files_get = Get(ConfigFiles, ConfigFilesRequest, bandit.config_request)

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -44,7 +44,8 @@ def generate_argv(source_files: SourceFiles, bandit: Bandit) -> Tuple[str, ...]:
 @rule(level=LogLevel.DEBUG)
 async def bandit_lint_partition(partition: BanditPartition, bandit: Bandit) -> LintResult:
     bandit_pex_get = Get(
-        VenvPex, PythonToolPexRequest(interpreter_constraints=partition.interpreter_constraints)
+        VenvPex,
+        PythonToolPexRequest(bandit, interpreter_constraints=partition.interpreter_constraints),
     )
 
     config_files_get = Get(ConfigFiles, ConfigFilesRequest, bandit.config_request)

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -10,7 +10,7 @@ from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
 from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.lint.bandit.skip_field import SkipBanditField
-from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import PythonToolBase, PythonToolPexRequest
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (
     ConsoleScript,
@@ -134,8 +134,7 @@ async def bandit_export(
 ) -> ExportPythonTool:
     constraints = await _bandit_interpreter_constraints(python_setup)
     return ExportPythonTool(
-        resolve_name=bandit.options_scope,
-        pex_request=bandit.to_pex_request(interpreter_constraints=constraints),
+        bandit.options_scope, PythonToolPexRequest(bandit, interpreter_constraints=constraints)
     )
 
 

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -5,11 +5,12 @@ from dataclasses import dataclass
 
 from pants.backend.python.lint.black.skip_field import SkipBlackField
 from pants.backend.python.lint.black.subsystem import Black
+from pants.backend.python.subsystems.python_tool_base import PythonToolPexRequest
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import InterpreterConstraintsField, PythonSourceField
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
+from pants.backend.python.util_rules.pex import VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.engine.fs import Digest, MergeDigests
@@ -65,9 +66,7 @@ async def black_fmt(request: BlackRequest, black: Black, python_setup: PythonSet
     )
 
     black_pex_get = Get(
-        VenvPex,
-        PexRequest,
-        black.to_pex_request(interpreter_constraints=tool_interpreter_constraints),
+        VenvPex, PythonToolPexRequest(black, interpreter_constraints=tool_interpreter_constraints)
     )
     config_files_get = Get(
         ConfigFiles, ConfigFilesRequest, black.config_request(request.snapshot.dirs)

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -10,7 +10,7 @@ from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
 from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.lint.black.skip_field import SkipBlackField
-from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import PythonToolBase, PythonToolPexRequest
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import ConsoleScript
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
@@ -125,8 +125,7 @@ async def black_export(
 ) -> ExportPythonTool:
     constraints = await _black_interpreter_constraints(black, python_setup)
     return ExportPythonTool(
-        resolve_name=black.options_scope,
-        pex_request=black.to_pex_request(interpreter_constraints=constraints),
+        black.options_scope, PythonToolPexRequest(black, interpreter_constraints=constraints)
     )
 
 

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -5,9 +5,10 @@ from dataclasses import dataclass
 
 from pants.backend.python.lint.docformatter.skip_field import SkipDocformatterField
 from pants.backend.python.lint.docformatter.subsystem import Docformatter
+from pants.backend.python.subsystems.python_tool_base import PythonToolPexRequest
 from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules import pex
-from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
+from pants.backend.python.util_rules.pex import VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.engine.fs import Digest
 from pants.engine.internals.native_engine import Snapshot
@@ -39,7 +40,7 @@ class DocformatterRequest(FmtRequest):
 async def docformatter_fmt(request: DocformatterRequest, docformatter: Docformatter) -> FmtResult:
     if docformatter.skip:
         return FmtResult.skip(formatter_name=request.name)
-    docformatter_pex = await Get(VenvPex, PexRequest, docformatter.to_pex_request())
+    docformatter_pex = await Get(VenvPex, PythonToolPexRequest(docformatter))
     result = await Get(
         ProcessResult,
         VenvPexProcess(

--- a/src/python/pants/backend/python/lint/docformatter/subsystem.py
+++ b/src/python/pants/backend/python/lint/docformatter/subsystem.py
@@ -5,7 +5,7 @@
 from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
 from pants.backend.python.goals.lockfile import GeneratePythonLockfile
-from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import PythonToolBase, PythonToolPexRequest
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import ConsoleScript
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
@@ -56,9 +56,7 @@ class DocformatterExportSentinel(ExportPythonToolSentinel):
 def docformatter_export(
     _: DocformatterExportSentinel, docformatter: Docformatter
 ) -> ExportPythonTool:
-    return ExportPythonTool(
-        resolve_name=docformatter.options_scope, pex_request=docformatter.to_pex_request()
-    )
+    return ExportPythonTool(docformatter.options_scope, PythonToolPexRequest(docformatter))
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -10,10 +10,11 @@ from pants.backend.python.lint.flake8.subsystem import (
     Flake8FieldSet,
     Flake8FirstPartyPlugins,
 )
+from pants.backend.python.subsystems.python_tool_base import PythonToolPexRequest
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
+from pants.backend.python.util_rules.pex import VenvPex, VenvPexProcess
 from pants.core.goals.lint import REPORT_DIR, LintResult, LintResults, LintTargetsRequest
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
@@ -52,8 +53,8 @@ async def flake8_lint_partition(
 ) -> LintResult:
     flake8_pex_get = Get(
         VenvPex,
-        PexRequest,
-        flake8.to_pex_request(
+        PythonToolPexRequest(
+            flake8,
             interpreter_constraints=partition.interpreter_constraints,
             extra_requirements=first_party_plugins.requirement_strings,
         ),

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -10,7 +10,7 @@ from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
 from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.lint.flake8.skip_field import SkipFlake8Field
-from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import PythonToolBase, PythonToolPexRequest
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (
     ConsoleScript,
@@ -316,8 +316,9 @@ async def flake8_export(
 ) -> ExportPythonTool:
     constraints = await _flake8_interpreter_constraints(first_party_plugins, python_setup)
     return ExportPythonTool(
-        resolve_name=flake8.options_scope,
-        pex_request=flake8.to_pex_request(
+        flake8.options_scope,
+        PythonToolPexRequest(
+            flake8,
             interpreter_constraints=constraints,
             extra_requirements=first_party_plugins.requirement_strings,
         ),

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -7,9 +7,10 @@ from typing import Tuple
 
 from pants.backend.python.lint.isort.skip_field import SkipIsortField
 from pants.backend.python.lint.isort.subsystem import Isort
+from pants.backend.python.subsystems.python_tool_base import PythonToolPexRequest
 from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules import pex
-from pants.backend.python.util_rules.pex import PexRequest, PexResolveInfo, VenvPex, VenvPexProcess
+from pants.backend.python.util_rules.pex import PexResolveInfo, VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.engine.fs import Digest, MergeDigests
@@ -65,7 +66,7 @@ def generate_argv(
 async def isort_fmt(request: IsortRequest, isort: Isort) -> FmtResult:
     if isort.skip:
         return FmtResult.skip(formatter_name=request.name)
-    isort_pex_get = Get(VenvPex, PexRequest, isort.to_pex_request())
+    isort_pex_get = Get(VenvPex, PythonToolPexRequest(isort))
     config_files_get = Get(
         ConfigFiles, ConfigFilesRequest, isort.config_request(request.snapshot.dirs)
     )

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -9,7 +9,7 @@ from typing import Iterable
 from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
 from pants.backend.python.goals.lockfile import GeneratePythonLockfile
-from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import PythonToolBase, PythonToolPexRequest
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import ConsoleScript
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
@@ -112,7 +112,7 @@ class IsortExportSentinel(ExportPythonToolSentinel):
 
 @rule
 def isort_export(_: IsortExportSentinel, isort: Isort) -> ExportPythonTool:
-    return ExportPythonTool(resolve_name=isort.options_scope, pex_request=isort.to_pex_request())
+    return ExportPythonTool(isort.options_scope, PythonToolPexRequest(isort))
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -12,6 +12,7 @@ from pants.backend.python.lint.pylint.subsystem import (
     PylintFieldSet,
     PylintFirstPartyPlugins,
 )
+from pants.backend.python.subsystems.python_tool_base import PythonToolPexRequest
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (
     InterpreterConstraintsField,
@@ -94,8 +95,8 @@ async def pylint_lint_partition(
 
     pylint_pex_get = Get(
         Pex,
-        PexRequest,
-        pylint.to_pex_request(
+        PythonToolPexRequest(
+            pylint,
             interpreter_constraints=partition.interpreter_constraints,
             extra_requirements=first_party_plugins.requirement_strings,
         ),

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -12,7 +12,7 @@ from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
 from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.lint.pylint.skip_field import SkipPylintField
-from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import PythonToolBase, PythonToolPexRequest
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (
     ConsoleScript,
@@ -326,8 +326,9 @@ async def pylint_export(
 ) -> ExportPythonTool:
     constraints = await _pylint_interpreter_constraints(first_party_plugins, python_setup)
     return ExportPythonTool(
-        resolve_name=pylint.options_scope,
-        pex_request=pylint.to_pex_request(
+        pylint.options_scope,
+        PythonToolPexRequest(
+            pylint,
             interpreter_constraints=constraints,
             extra_requirements=first_party_plugins.requirement_strings,
         ),

--- a/src/python/pants/backend/python/lint/pyupgrade/rules.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/rules.py
@@ -6,9 +6,10 @@ from dataclasses import dataclass
 
 from pants.backend.python.lint.pyupgrade.skip_field import SkipPyUpgradeField
 from pants.backend.python.lint.pyupgrade.subsystem import PyUpgrade
+from pants.backend.python.subsystems.python_tool_base import PythonToolPexRequest
 from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules import pex
-from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
+from pants.backend.python.util_rules.pex import VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.engine.fs import Digest
 from pants.engine.internals.native_engine import Snapshot
@@ -40,9 +41,7 @@ class PyUpgradeRequest(FmtRequest):
 async def pyupgrade_fmt(request: PyUpgradeRequest, pyupgrade: PyUpgrade) -> FmtResult:
     if pyupgrade.skip:
         return FmtResult.skip(formatter_name=request.name)
-
-    pyupgrade_pex = await Get(VenvPex, PexRequest, pyupgrade.to_pex_request())
-
+    pyupgrade_pex = await Get(VenvPex, PythonToolPexRequest(pyupgrade))
     result = await Get(
         FallibleProcessResult,
         VenvPexProcess(

--- a/src/python/pants/backend/python/lint/pyupgrade/subsystem.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/subsystem.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
 from pants.backend.python.goals.lockfile import GeneratePythonLockfile
-from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import PythonToolBase, PythonToolPexRequest
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import ConsoleScript
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
@@ -57,9 +57,7 @@ class PyUpgradeExportSentinel(ExportPythonToolSentinel):
 
 @rule
 def pyupgrade_export(_: PyUpgradeExportSentinel, pyupgrade: PyUpgrade) -> ExportPythonTool:
-    return ExportPythonTool(
-        resolve_name=pyupgrade.options_scope, pex_request=pyupgrade.to_pex_request()
-    )
+    return ExportPythonTool(pyupgrade.options_scope, PythonToolPexRequest(pyupgrade))
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/yapf/rules.py
+++ b/src/python/pants/backend/python/lint/yapf/rules.py
@@ -5,9 +5,10 @@ from dataclasses import dataclass
 
 from pants.backend.python.lint.yapf.skip_field import SkipYapfField
 from pants.backend.python.lint.yapf.subsystem import Yapf
+from pants.backend.python.subsystems.python_tool_base import PythonToolPexRequest
 from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules import pex
-from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
+from pants.backend.python.util_rules.pex import VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.engine.fs import Digest, MergeDigests
@@ -40,7 +41,7 @@ class YapfRequest(FmtRequest):
 async def yapf_fmt(request: YapfRequest, yapf: Yapf) -> FmtResult:
     if yapf.skip:
         return FmtResult.skip(formatter_name=request.name)
-    yapf_pex_get = Get(VenvPex, PexRequest, yapf.to_pex_request())
+    yapf_pex_get = Get(VenvPex, PythonToolPexRequest(yapf))
     config_files_get = Get(
         ConfigFiles, ConfigFilesRequest, yapf.config_request(request.snapshot.dirs)
     )

--- a/src/python/pants/backend/python/lint/yapf/subsystem.py
+++ b/src/python/pants/backend/python/lint/yapf/subsystem.py
@@ -9,7 +9,7 @@ from typing import Iterable
 from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
 from pants.backend.python.goals.lockfile import GeneratePythonLockfile
-from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import PythonToolBase, PythonToolPexRequest
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import ConsoleScript
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
@@ -107,7 +107,7 @@ class YapfExportSentinel(ExportPythonToolSentinel):
 
 @rule
 def yapf_export(_: YapfExportSentinel, yapf: Yapf) -> ExportPythonTool:
-    return ExportPythonTool(resolve_name=yapf.options_scope, pex_request=yapf.to_pex_request())
+    return ExportPythonTool(yapf.options_scope, PythonToolPexRequest(yapf))
 
 
 def rules():

--- a/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
@@ -20,8 +20,9 @@ from pants.backend.python.packaging.pyoxidizer.target_types import (
     PyOxidizerTarget,
     PyOxidizerUnclassifiedResources,
 )
+from pants.backend.python.subsystems.python_tool_base import PythonToolPexRequest
 from pants.backend.python.target_types import GenerateSetupField, WheelField
-from pants.backend.python.util_rules.pex import Pex, PexProcess, PexRequest
+from pants.backend.python.util_rules.pex import Pex, PexProcess
 from pants.core.goals.package import BuiltPackage, BuiltPackageArtifact, PackageFieldSet
 from pants.core.goals.run import RunFieldSet, RunRequest
 from pants.core.util_rules.system_binaries import BashBinary
@@ -141,7 +142,7 @@ async def package_pyoxidizer_binary(
     logger.debug(f"Configuration used for {field_set.address}: {rendered_config}")
 
     pyoxidizer_pex, config_digest = await MultiGet(
-        Get(Pex, PexRequest, pyoxidizer.to_pex_request()),
+        Get(Pex, PythonToolPexRequest(pyoxidizer)),
         Get(Digest, CreateDigest([FileContent("pyoxidizer.bzl", rendered_config.encode("utf-8"))])),
     )
     input_digest = await Get(

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -14,7 +14,7 @@ from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
 from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.pip_requirement import PipRequirement
-from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import PythonToolBase, PythonToolPexRequest
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (
     ConsoleScript,
@@ -247,8 +247,7 @@ async def pytest_export(
 ) -> ExportPythonTool:
     constraints = await _pytest_interpreter_constraints(python_setup)
     return ExportPythonTool(
-        resolve_name=pytest.options_scope,
-        pex_request=pytest.to_pex_request(interpreter_constraints=constraints),
+        pytest.options_scope, PythonToolPexRequest(interpreter_constraints=constraints)
     )
 
 

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -247,7 +247,7 @@ async def pytest_export(
 ) -> ExportPythonTool:
     constraints = await _pytest_interpreter_constraints(python_setup)
     return ExportPythonTool(
-        pytest.options_scope, PythonToolPexRequest(interpreter_constraints=constraints)
+        pytest.options_scope, PythonToolPexRequest(pytest, interpreter_constraints=constraints)
     )
 
 

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -287,7 +287,7 @@ class PythonToolBase(PythonToolRequirementsBase):
         main: MainSpecification | None = None,
         sources: Digest | None = None,
     ) -> PexRequest:
-        return super().to_pex_request(
+        return super().to_pex_request(  # type: ignore[no-any-return]
             interpreter_constraints=interpreter_constraints,
             extra_requirements=extra_requirements,
             main=main or self.main,

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -199,10 +199,10 @@ class PythonToolRequirementsBase(Subsystem):
             """
             Use `Get(PexRequest, PythonToolPexRequest)` instead, which behaves the same as before.
             This change allows us to implement https://github.com/pantsbuild/pants/issues/12449.
-        
+
             Tip: you can directly use `Get(VenvPex, PythonToolPexRequest)`, for example, which the
             engine will satisfy with PythonToolPexRequest -> PexRequest -> VenvPex.
-            
+
             Warning: You must also make sure that you register `python_tool_base.rules()`.
             """
         ),

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Iterable, Optional, Tuple
 
+from pants.backend.python.subsystems.python_tool_base import PythonToolPexRequest
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import PythonResolveField, PythonSourceField
 from pants.backend.python.typecheck.mypy.skip_field import SkipMyPyField
@@ -155,8 +156,8 @@ async def mypy_typecheck_partition(
 
     mypy_pex_get = Get(
         VenvPex,
-        PexRequest,
-        mypy.to_pex_request(
+        PythonToolPexRequest(
+            mypy,
             interpreter_constraints=tool_interpreter_constraints,
             extra_requirements=first_party_plugins.requirement_strings,
         ),

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -11,7 +11,7 @@ from typing import Iterable
 from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
 from pants.backend.python.goals.lockfile import GeneratePythonLockfile
-from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import PythonToolBase, PythonToolPexRequest
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (
     ConsoleScript,
@@ -346,8 +346,9 @@ async def mypy_export(
 ) -> ExportPythonTool:
     constraints = await _mypy_interpreter_constraints(mypy, python_setup)
     return ExportPythonTool(
-        resolve_name=mypy.options_scope,
-        pex_request=mypy.to_pex_request(
+        mypy.options_scope,
+        PythonToolPexRequest(
+            mypy,
             interpreter_constraints=constraints,
             extra_requirements=first_party_plugins.requirement_strings,
         ),

--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -8,10 +8,13 @@ from pathlib import PurePath
 
 from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.lockfile import GeneratePythonLockfile
-from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
+from pants.backend.python.subsystems.python_tool_base import (
+    PythonToolPexRequest,
+    PythonToolRequirementsBase,
+)
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import EntryPoint
-from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
+from pants.backend.python.util_rules.pex import VenvPex, VenvPexProcess
 from pants.backend.terraform.target_types import TerraformModuleSourcesField
 from pants.base.specs import AddressSpecs, MaybeEmptySiblingAddresses
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
@@ -81,9 +84,8 @@ async def setup_parser(hcl2_parser: TerraformHcl2Parser) -> ParserSetup:
 
     parser_pex = await Get(
         VenvPex,
-        PexRequest,
-        hcl2_parser.to_pex_request(
-            main=EntryPoint(PurePath(parser_content.path).stem), sources=parser_digest
+        PythonToolPexRequest(
+            hcl2_parser, main=EntryPoint(PurePath(parser_content.path).stem), sources=parser_digest
         ),
     )
     return ParserSetup(parser_pex)

--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -17,8 +17,9 @@ from colors import green, red
 
 from pants.backend.python.lint.black.subsystem import Black
 from pants.backend.python.lint.yapf.subsystem import Yapf
+from pants.backend.python.subsystems.python_tool_base import PythonToolPexRequest
 from pants.backend.python.util_rules import pex
-from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
+from pants.backend.python.util_rules.pex import VenvPex, VenvPexProcess
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.engine.console import Console
 from pants.engine.engine_aware import EngineAwareParameter
@@ -290,7 +291,7 @@ class FormatWithYapfRequest(RewrittenBuildFileRequest):
 async def format_build_file_with_yapf(
     request: FormatWithYapfRequest, yapf: Yapf
 ) -> RewrittenBuildFile:
-    yapf_pex_get = Get(VenvPex, PexRequest, yapf.to_pex_request())
+    yapf_pex_get = Get(VenvPex, PythonToolPexRequest(yapf))
     build_file_digest_get = Get(Digest, CreateDigest([request.to_file_content()]))
     config_files_get = Get(
         ConfigFiles, ConfigFilesRequest, yapf.config_request(recursive_dirname(request.path))
@@ -343,7 +344,7 @@ class FormatWithBlackRequest(RewrittenBuildFileRequest):
 async def format_build_file_with_black(
     request: FormatWithBlackRequest, black: Black
 ) -> RewrittenBuildFile:
-    black_pex_get = Get(VenvPex, PexRequest, black.to_pex_request())
+    black_pex_get = Get(VenvPex, PythonToolPexRequest(black))
     build_file_digest_get = Get(Digest, CreateDigest([request.to_file_content()]))
     config_files_get = Get(
         ConfigFiles, ConfigFilesRequest, black.config_request(recursive_dirname(request.path))


### PR DESCRIPTION
To implement the highly requested https://github.com/pantsbuild/pants/issues/12449, we will need to start using the engine to evaluate the requirement strings of a Python tool. This means that we must use a rule, rather than a pure Python method.

A follow up will also need to deprecate the `pex_requirements()` method.

[ci skip-rust]
[ci skip-build-wheels]