### PR TITLE
Add console level filter option

### DIFF
--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -220,6 +220,7 @@ def set_per_run_log_path(path: str | None) -> None: ...
 def maybe_set_panic_handler() -> None: ...
 def stdio_initialize(
     level: int,
+    console_level_filter: int,
     show_rust_3rdparty_logs: bool,
     show_target: bool,
     log_levels_by_target: dict[str, int],

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -220,7 +220,7 @@ def set_per_run_log_path(path: str | None) -> None: ...
 def maybe_set_panic_handler() -> None: ...
 def stdio_initialize(
     level: int,
-    console_level_filter: int,
+    console_level_filter: int | None,
     show_rust_3rdparty_logs: bool,
     show_target: bool,
     log_levels_by_target: dict[str, int],

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -162,10 +162,9 @@ def initialize_stdio(global_bootstrap_options: OptionValueContainer) -> Iterator
     * PantsDaemon, immediately on startup. The process will then default to sending stdio to the log
       until client connections arrive, at which point `stdio_destination` is used per-connection.
     """
-    console_level_filter = global_bootstrap_options.console_level_filter
     with initialize_stdio_raw(
         global_bootstrap_options.level,
-        global_bootstrap_options.level if console_level_filter is None else console_level_filter,
+        global_bootstrap_options.console_level_filter,
         global_bootstrap_options.log_show_rust_3rdparty,
         global_bootstrap_options.show_log_target,
         _get_log_levels_by_target(global_bootstrap_options),
@@ -179,7 +178,7 @@ def initialize_stdio(global_bootstrap_options: OptionValueContainer) -> Iterator
 @contextmanager
 def initialize_stdio_raw(
     global_level: LogLevel,
-    console_level_filter: LogLevel,
+    console_level_filter: LogLevel | None,
     log_show_rust_3rdparty: bool,
     show_target: bool,
     log_levels_by_target: dict[str, LogLevel],
@@ -204,7 +203,7 @@ def initialize_stdio_raw(
     try:
         raw_stdin, sys.stdout, sys.stderr = native_engine.stdio_initialize(
             global_level.level,
-            console_level_filter.level,
+            None if console_level_filter is None else console_level_filter.level,
             log_show_rust_3rdparty,
             show_target,
             {k: v.level for k, v in log_levels_by_target.items()},

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -162,8 +162,10 @@ def initialize_stdio(global_bootstrap_options: OptionValueContainer) -> Iterator
     * PantsDaemon, immediately on startup. The process will then default to sending stdio to the log
       until client connections arrive, at which point `stdio_destination` is used per-connection.
     """
+    console_level_filter = global_bootstrap_options.console_level_filter
     with initialize_stdio_raw(
         global_bootstrap_options.level,
+        global_bootstrap_options.level if console_level_filter is None else console_level_filter,
         global_bootstrap_options.log_show_rust_3rdparty,
         global_bootstrap_options.show_log_target,
         _get_log_levels_by_target(global_bootstrap_options),
@@ -177,6 +179,7 @@ def initialize_stdio(global_bootstrap_options: OptionValueContainer) -> Iterator
 @contextmanager
 def initialize_stdio_raw(
     global_level: LogLevel,
+    console_level_filter: LogLevel,
     log_show_rust_3rdparty: bool,
     show_target: bool,
     log_levels_by_target: dict[str, LogLevel],
@@ -201,6 +204,7 @@ def initialize_stdio_raw(
     try:
         raw_stdin, sys.stdout, sys.stderr = native_engine.stdio_initialize(
             global_level.level,
+            console_level_filter.level,
             log_show_rust_3rdparty,
             show_target,
             {k: v.level for k, v in log_levels_by_target.items()},

--- a/src/python/pants/init/logging_integration_test.py
+++ b/src/python/pants/init/logging_integration_test.py
@@ -1,7 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.testutil.pants_integration_test import run_pants, setup_tmpdir
+from pants.testutil.pants_integration_test import PantsResult, run_pants, setup_tmpdir
 
 PLUGIN = """
 import logging
@@ -38,21 +38,21 @@ def rules():
     return logger.rules()
 """
 
+GLOBAL_LEVEL = "globalLevel"
+INFO_OVERRIDE = "infoOverride"
+DEBUG_OVERRIDE = "debugOverride"
 
-def test_log_by_level() -> None:
-    """Check that overriding log levels works for logs both coming from Rust and from Python.
 
-    This also checks that we correctly log `Starting` and `Completed` messages when the dynamic UI
-    is disabled.
-    """
+def run_pants_with_opts(*extra_options: str) -> PantsResult:
     with setup_tmpdir({"plugins/logger.py": PLUGIN, "plugins/register.py": REGISTER}) as tmpdir:
-        result = run_pants(
+        return run_pants(
             [
                 f"--pythonpath={tmpdir}",
                 "--backend-packages=plugins",
                 "--no-dynamic-ui",
                 "--show-log-target",
                 "--level=warn",
+                *extra_options,
                 (
                     "--log-levels-by-target={"
                     "'plugins.logger.infoOverride': 'info', "
@@ -63,22 +63,38 @@ def test_log_by_level() -> None:
             ]
         )
 
-    global_level = "globalLevel"
-    info_override = "infoOverride"
-    debug_override = "debugOverride"
 
-    for logger in (global_level, info_override, debug_override):
+def test_log_by_level() -> None:
+    """Check that overriding log levels works for logs both coming from Rust and from Python.
+
+    This also checks that we correctly log `Starting` and `Completed` messages when the dynamic UI
+    is disabled.
+    """
+    result = run_pants_with_opts()
+
+    for logger in (GLOBAL_LEVEL, INFO_OVERRIDE, DEBUG_OVERRIDE):
         assert f"[WARN] (plugins.logger.{logger}) warn log" in result.stderr
 
-    for logger in (info_override, debug_override):
+    for logger in (INFO_OVERRIDE, DEBUG_OVERRIDE):
         assert f"[INFO] (plugins.logger.{logger}) info log" in result.stderr
     assert "[INFO] (plugins.logger.globalLevel) info log" not in result.stderr
 
     assert "[DEBUG] (plugins.logger.debugOverride) debug log" in result.stderr
-    for logger in (global_level, info_override):
+    for logger in (GLOBAL_LEVEL, INFO_OVERRIDE):
         assert f"[DEBUG] (plugins.logger.{logger} debug log" not in result.stderr
 
     # Check that overriding levels for Rust code works, and also that we log Starting and Completed
     # properly.
     assert "[DEBUG] (workunit_store) Starting: `logger` goal" in result.stderr
     assert "[DEBUG] (workunit_store) Completed: `logger` goal" in result.stderr
+
+
+def test_console_level_filter() -> None:
+    result = run_pants_with_opts("--console-level-filter=warn")
+
+    for logger in (GLOBAL_LEVEL, INFO_OVERRIDE, DEBUG_OVERRIDE):
+        assert f"[WARN] (plugins.logger.{logger}) warn log" in result.stderr
+        assert f"[INFO] (plugins.logger.{logger}) info log" not in result.stderr
+        assert f"[DEBUG] (plugins.logger.{logger} debug log" not in result.stderr
+
+    assert "workunit_store" not in result.stderr

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -535,7 +535,14 @@ class BootstrapOptions:
         "--level",
         default=LogLevel.INFO,
         daemon=True,
-        help="Set the logging level.",
+        help="Set the global logging level.",
+    )
+    log_file_level = EnumOption(
+        "--console-level-filter",
+        default=None,
+        enum_type=LogLevel,
+        daemon=True,
+        help="Filters the logs printed to the console to be of this level or higher.",
     )
     show_log_target = BoolOption(
         "--show-log-target",

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -535,7 +535,7 @@ class BootstrapOptions:
         "--level",
         default=LogLevel.INFO,
         daemon=True,
-        help="Set the global logging level.",
+        help="Set the logging level.",
     )
     log_file_level = EnumOption(
         "--console-level-filter",

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -84,7 +84,7 @@ def logging(original_function=None, *, level: LogLevel = LogLevel.INFO):
         def wrapper(*args, **kwargs):
             stdout_fileno, stderr_fileno = sys.stdout.fileno(), sys.stderr.fileno()
             with temporary_dir() as tempdir, initialize_stdio_raw(
-                level, False, False, {}, True, [], tempdir
+                level, level, False, False, {}, True, [], tempdir
             ), stdin_context() as stdin, stdio_destination(
                 stdin.fileno(), stdout_fileno, stderr_fileno
             ):

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1580,7 +1580,7 @@ fn write_digest(
 #[pyfunction]
 fn stdio_initialize(
   level: u64,
-  console_level_filter: u64,
+  console_level_filter: Option<u64>,
   show_rust_3rdparty_logs: bool,
   show_target: bool,
   log_levels_by_target: HashMap<String, u64>,

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1580,6 +1580,7 @@ fn write_digest(
 #[pyfunction]
 fn stdio_initialize(
   level: u64,
+  console_level_filter: u64,
   show_rust_3rdparty_logs: bool,
   show_target: bool,
   log_levels_by_target: HashMap<String, u64>,
@@ -1607,6 +1608,7 @@ fn stdio_initialize(
 
   Logger::init(
     level,
+    console_level_filter,
     show_rust_3rdparty_logs,
     show_target,
     log_levels_by_target,


### PR DESCRIPTION
Closes #15004 by introducing a new `--console-level-filter` option. 

I went this route as we basically want an option that doesn't imply it sets a level, just filters from configured level. Since console will almost always need to be the same or less verbose than logs, it wins the filter options.

Then intent is for users (especially CI) to configure a high console level (like warn) with a low global level (like debug). Then CI UI has trimmed relevant info but the uploaded log artifact has everything needed to debug.

Happy to discuss better name.