### PR TITLE
[internal] improve error message to be less confusing

### DIFF
--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -1211,7 +1211,12 @@ pub fn extract_output_files(
           .add_prefix(directory_digest, &RelativePath::new(dir.path)?)
           .await
       })
-      .map_err(|err| format!("Error saving remote output directory: {:?}", err)),
+      .map_err(|err| {
+        format!(
+          "Error saving remote output directory to local cache: {:?}",
+          err
+        )
+      }),
     );
   }
 


### PR DESCRIPTION
As reported in https://github.com/pantsbuild/pants/issues/15188, the error message when failing to save a remote output directory to the local cache can be improved. This adds the phrase "to local cache" to make clearer what operation errored.

Closes https://github.com/pantsbuild/pants/issues/15188

[ci skip-build-wheels]