### PR TITLE
golang: add more cache keys based on tool IDs

### DIFF
--- a/src/python/pants/backend/go/util_rules/assembly.py
+++ b/src/python/pants/backend/go/util_rules/assembly.py
@@ -148,9 +148,10 @@ async def setup_assembly_pre_compilation(
 async def link_assembly_post_compilation(
     request: AssemblyPostCompilationRequest,
 ) -> AssemblyPostCompilation:
-    merged_digest, pack_tool_id = await MultiGet(
+    merged_digest, asm_tool_id = await MultiGet(
         Get(Digest, MergeDigests([request.compilation_result, *request.assembly_digests])),
-        Get(GoSdkToolIDResult, GoSdkToolIDRequest("pack")),
+        # Use `go tool asm` tool ID since `go tool pack` does not have a version argument.
+        Get(GoSdkToolIDResult, GoSdkToolIDRequest("asm")),
     )
     pack_result = await Get(
         FallibleProcessResult,
@@ -167,7 +168,7 @@ async def link_assembly_post_compilation(
                 ),
             ),
             env={
-                "__PANTS_GO_PACK_TOOL_ID": pack_tool_id.tool_id,
+                "__PANTS_GO_ASM_TOOL_ID": asm_tool_id.tool_id,
             },
             description=f"Link assembly files to Go package archive for {request.dir_path}",
             output_files=("__pkg__.a",),

--- a/src/python/pants/backend/go/util_rules/link.py
+++ b/src/python/pants/backend/go/util_rules/link.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from pants.backend.go.util_rules.sdk import GoSdkProcess
+from pants.backend.go.util_rules.sdk import GoSdkProcess, GoSdkToolIDRequest, GoSdkToolIDResult
 from pants.engine.fs import Digest
 from pants.engine.process import ProcessResult
 from pants.engine.rules import Get, collect_rules, rule
@@ -30,6 +30,7 @@ class LinkedGoBinary:
 
 @rule
 async def link_go_binary(request: LinkGoBinaryRequest) -> LinkedGoBinary:
+    link_tool_id = await Get(GoSdkToolIDResult, GoSdkToolIDRequest("link"))
     result = await Get(
         ProcessResult,
         GoSdkProcess(
@@ -44,6 +45,9 @@ async def link_go_binary(request: LinkGoBinaryRequest) -> LinkedGoBinary:
                 "-buildmode=exe",  # seen in `go build -x` output
                 *request.archives,
             ),
+            env={
+                "__PANTS_GO_LINK_TOOL_ID": link_tool_id.tool_id,
+            },
             description=f"Link Go binary: {request.output_filename}",
             output_files=(request.output_filename,),
         ),


### PR DESCRIPTION
As reported in https://github.com/pantsbuild/pants/issues/15144, upgrading Pants has caused problems for a user of the Go backend because the files produced by even patchlevel releases of Go are incompatible and need to be invalidated. Add more cache keys to fix this issue.

[ci skip-rust]

[ci skip-build-wheels]