### PR TITLE
[internal] kotlin: switch to "embeddable" compiler and Kotlin v1.6.20

### DIFF
--- a/src/python/pants/backend/kotlin/compile/kotlinc.py
+++ b/src/python/pants/backend/kotlin/compile/kotlinc.py
@@ -115,7 +115,12 @@ async def compile_kotlin_source(
                     [
                         Coordinate(
                             group="org.jetbrains.kotlin",
-                            artifact="kotlin-compiler",
+                            artifact="kotlin-compiler-embeddable",
+                            version=kotlin_version,
+                        ),
+                        Coordinate(
+                            group="org.jetbrains.kotlin",
+                            artifact="kotlin-scripting-compiler-embeddable",
                             version=kotlin_version,
                         ),
                     ]

--- a/src/python/pants/backend/kotlin/compile/kotlinc.py
+++ b/src/python/pants/backend/kotlin/compile/kotlinc.py
@@ -83,13 +83,13 @@ async def compile_kotlin_source(
         ),
     )
 
-    component_members_and_scala_source_files = [
+    component_members_and_kotlin_source_files = [
         (target, sources)
         for target, sources in component_members_and_source_files
         if sources.snapshot.digest != EMPTY_DIGEST
     ]
 
-    if not component_members_and_scala_source_files:
+    if not component_members_and_kotlin_source_files:
         # Is a generator, and so exports all of its direct deps.
         exported_digest = await Get(
             Digest, MergeDigests(cpe.digest for cpe in direct_dependency_classpath_entries)
@@ -125,7 +125,10 @@ async def compile_kotlin_source(
         Get(
             Digest,
             MergeDigests(
-                (sources.snapshot.digest for _, sources in component_members_and_scala_source_files)
+                (
+                    sources.snapshot.digest
+                    for _, sources in component_members_and_kotlin_source_files
+                )
             ),
         ),
         Get(JdkEnvironment, JdkRequest, JdkRequest.from_target(request.component)),
@@ -153,7 +156,7 @@ async def compile_kotlin_source(
                 *sorted(
                     itertools.chain.from_iterable(
                         sources.snapshot.files
-                        for _, sources in component_members_and_scala_source_files
+                        for _, sources in component_members_and_kotlin_source_files
                     )
                 ),
             ],

--- a/src/python/pants/backend/kotlin/subsystems/kotlin.py
+++ b/src/python/pants/backend/kotlin/subsystems/kotlin.py
@@ -9,7 +9,7 @@ from pants.option.option_types import DictOption
 from pants.option.subsystem import Subsystem
 from pants.util.strutil import softwrap
 
-DEFAULT_KOTLIN_VERSION = "1.6.0"
+DEFAULT_KOTLIN_VERSION = "1.6.20"
 
 _logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Upgrade the default version of Kotlin from v1.6.0 to v1.6.20.

Related changes:
- Use the "embeddable" compiler artifacts which are shaded. After [a discussion with a Kotlin developer on Kotlin Slack](https://kotlinlang.slack.com/archives/C0B8PUJGZ/p1650374743908909), this is necessary to support kotlinc plugins because the plugin artifacts published to Maven Central are compiled against the shaded "embeddable" artifacts and not the unshaded ones. (Kotlin compiler plugins will be implemented by https://github.com/pantsbuild/pants/pull/15184.)
- Add "kotlin-scripting-compiler-embeddable" artifact to compiler classpath in anticipation of `.kts` support, but mainly out of an abundance of caution to ensure the compiler classpath is complete.
- Refactor `src/python/pants/backend/kotlin/compile/kotlinc_test.py` to make it easier to construct the lockfiles used for testing and also to upgrade to v1.6.20.