### PR TITLE
[internal] bsp: show experimental-bsp goal in help

### DIFF
--- a/src/python/pants/bsp/goal.py
+++ b/src/python/pants/bsp/goal.py
@@ -36,10 +36,6 @@ class BSPGoal(BuiltinGoal):
     name = "experimental-bsp"
     help = "Setup repository for Build Server Protocol (https://build-server-protocol.github.io/)."
 
-    @classmethod
-    def activated(cls, union_membership: UnionMembership) -> bool:
-        return False
-
     server = BoolOption(
         "--server",
         default=False,


### PR DESCRIPTION
Make the `experimental-bsp` goal visible in help messages.

[ci skip-rust]

[ci skip-build-wheels]