### PR TITLE
Fix lockfile generation for duplicate `jvm_artifact` targets with `jar` fields.

### DIFF
--- a/src/python/pants/backend/scala/resolve/lockfile_test.py
+++ b/src/python/pants/backend/scala/resolve/lockfile_test.py
@@ -16,7 +16,7 @@ from pants.core.util_rules import external_tool, source_files, system_binaries
 from pants.engine.internals import build_files, graph
 from pants.jvm import jdk_rules
 from pants.jvm.goals import lockfile
-from pants.jvm.goals.lockfile import GenerateJvmLockfile, RequestedJVMserResolveNames
+from pants.jvm.goals.lockfile import GenerateJvmLockfile, RequestedJVMUserResolveNames
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.jvm.resolve.jvm_tool import rules as coursier_jvm_tool_rules
@@ -44,7 +44,7 @@ def rule_runner() -> RuleRunner:
             *graph.rules(),
             *build_files.rules(),
             *target_types.rules(),
-            QueryRule(UserGenerateLockfiles, (RequestedJVMserResolveNames,)),
+            QueryRule(UserGenerateLockfiles, (RequestedJVMUserResolveNames,)),
             QueryRule(GenerateLockfileResult, (GenerateJvmLockfile,)),
         ],
         target_types=[JvmArtifactTarget, ScalaSourceTarget, ScalaSourcesGeneratorTarget],
@@ -71,7 +71,7 @@ def test_missing_scala_library_triggers_error(rule_runner: RuleRunner) -> None:
     with engine_error(ValueError, contains="does not contain a requirement for the Scala runtime"):
         _ = rule_runner.request(
             UserGenerateLockfiles,
-            [RequestedJVMserResolveNames(["foo"])],
+            [RequestedJVMUserResolveNames(["foo"])],
         )
 
 
@@ -101,5 +101,5 @@ def test_conflicting_scala_library_triggers_error(rule_runner: RuleRunner) -> No
     ):
         _ = rule_runner.request(
             UserGenerateLockfiles,
-            [RequestedJVMserResolveNames(["foo"])],
+            [RequestedJVMUserResolveNames(["foo"])],
         )

--- a/src/python/pants/jvm/goals/lockfile.py
+++ b/src/python/pants/jvm/goals/lockfile.py
@@ -79,7 +79,7 @@ async def generate_jvm_lockfile(
     return GenerateLockfileResult(lockfile_digest, request.resolve_name, request.lockfile_dest)
 
 
-class RequestedJVMserResolveNames(RequestedUserResolveNames):
+class RequestedJVMUserResolveNames(RequestedUserResolveNames):
     pass
 
 
@@ -94,7 +94,7 @@ def determine_jvm_user_resolves(
     return KnownUserResolveNames(
         names=tuple(jvm_subsystem.resolves.keys()),
         option_name=f"[{jvm_subsystem.options_scope}].resolves",
-        requested_resolve_names_cls=RequestedJVMserResolveNames,
+        requested_resolve_names_cls=RequestedJVMUserResolveNames,
     )
 
 
@@ -128,7 +128,7 @@ async def validate_jvm_artifacts_for_resolve(
 
 @rule
 async def setup_user_lockfile_requests(
-    requested: RequestedJVMserResolveNames,
+    requested: RequestedJVMUserResolveNames,
     all_targets: AllTargets,
     jvm_subsystem: JvmSubsystem,
 ) -> UserGenerateLockfiles:
@@ -162,5 +162,5 @@ def rules():
         *coursier_fetch.rules(),
         UnionRule(GenerateLockfile, GenerateJvmLockfile),
         UnionRule(KnownUserResolveNamesRequest, KnownJVMUserResolveNamesRequest),
-        UnionRule(RequestedUserResolveNames, RequestedJVMserResolveNames),
+        UnionRule(RequestedUserResolveNames, RequestedJVMUserResolveNames),
     )

--- a/src/python/pants/jvm/goals/lockfile_test.py
+++ b/src/python/pants/jvm/goals/lockfile_test.py
@@ -11,6 +11,7 @@ from pants.core.goals.generate_lockfiles import GenerateLockfileResult, UserGene
 from pants.core.util_rules import source_files
 from pants.core.util_rules.external_tool import rules as external_tool_rules
 from pants.engine.fs import DigestContents, FileDigest
+from pants.engine.internals.parametrize import Parametrize
 from pants.jvm.goals import lockfile
 from pants.jvm.goals.lockfile import GenerateJvmLockfile, RequestedJVMUserResolveNames
 from pants.jvm.resolve.common import (
@@ -23,7 +24,6 @@ from pants.jvm.resolve.coursier_fetch import CoursierLockfileEntry, CoursierReso
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.jvm.resolve.lockfile_metadata import JVMLockfileMetadata
-from pants.engine.internals.parametrize import Parametrize
 from pants.jvm.target_types import JvmArtifactTarget
 from pants.jvm.testutil import maybe_skip_jdk_test
 from pants.jvm.util_rules import rules as util_rules

--- a/src/python/pants/jvm/goals/lockfile_test.py
+++ b/src/python/pants/jvm/goals/lockfile_test.py
@@ -12,7 +12,7 @@ from pants.core.util_rules import source_files
 from pants.core.util_rules.external_tool import rules as external_tool_rules
 from pants.engine.fs import DigestContents, FileDigest
 from pants.jvm.goals import lockfile
-from pants.jvm.goals.lockfile import GenerateJvmLockfile, RequestedJVMserResolveNames
+from pants.jvm.goals.lockfile import GenerateJvmLockfile, RequestedJVMUserResolveNames
 from pants.jvm.resolve.common import (
     ArtifactRequirement,
     ArtifactRequirements,
@@ -40,7 +40,7 @@ def rule_runner() -> RuleRunner:
             *external_tool_rules(),
             *source_files.rules(),
             *util_rules(),
-            QueryRule(UserGenerateLockfiles, [RequestedJVMserResolveNames]),
+            QueryRule(UserGenerateLockfiles, [RequestedJVMUserResolveNames]),
             QueryRule(GenerateLockfileResult, [GenerateJvmLockfile]),
         ],
         target_types=[JvmArtifactTarget],
@@ -119,7 +119,7 @@ def test_multiple_resolves(rule_runner: RuleRunner) -> None:
     )
     rule_runner.set_options(["--jvm-resolves={'a': 'a.lock', 'b': 'b.lock'}"], env_inherit={"PATH"})
 
-    result = rule_runner.request(UserGenerateLockfiles, [RequestedJVMserResolveNames(["a", "b"])])
+    result = rule_runner.request(UserGenerateLockfiles, [RequestedJVMUserResolveNames(["a", "b"])])
     hamcrest_core = ArtifactRequirement(Coordinate("org.hamcrest", "hamcrest-core", "1.3"))
     assert set(result) == {
         GenerateJvmLockfile(

--- a/src/python/pants/jvm/goals/lockfile_test.py
+++ b/src/python/pants/jvm/goals/lockfile_test.py
@@ -23,6 +23,7 @@ from pants.jvm.resolve.coursier_fetch import CoursierLockfileEntry, CoursierReso
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.jvm.resolve.lockfile_metadata import JVMLockfileMetadata
+from pants.engine.internals.parametrize import Parametrize
 from pants.jvm.target_types import JvmArtifactTarget
 from pants.jvm.testutil import maybe_skip_jdk_test
 from pants.jvm.util_rules import rules as util_rules
@@ -43,6 +44,7 @@ def rule_runner() -> RuleRunner:
             QueryRule(GenerateLockfileResult, [GenerateJvmLockfile]),
         ],
         target_types=[JvmArtifactTarget],
+        objects={"parametrize": Parametrize},
     )
     rule_runner.set_options([], env_inherit={"PATH"})
     return rule_runner
@@ -84,25 +86,16 @@ def test_generate_lockfile(rule_runner: RuleRunner) -> None:
 
 @maybe_skip_jdk_test
 def test_multiple_resolves(rule_runner: RuleRunner) -> None:
-    # TODO: Adjust to use https://github.com/pantsbuild/pants/pull/14408 for the
-    # duplicated artifact.
     rule_runner.write_files(
         {
             "BUILD": dedent(
                 """\
                 jvm_artifact(
-                    name='hamcrest_a',
+                    name='hamcrest',
                     group='org.hamcrest',
                     artifact='hamcrest-core',
                     version="1.3",
-                    resolve="a",
-                )
-                jvm_artifact(
-                    name='hamcrest_b',
-                    group='org.hamcrest',
-                    artifact='hamcrest-core',
-                    version="1.3",
-                    resolve="b",
+                    resolve=parametrize("a", "b"),
                 )
 
                 jvm_artifact(

--- a/src/python/pants/jvm/resolve/common.py
+++ b/src/python/pants/jvm/resolve/common.py
@@ -142,7 +142,7 @@ class Coordinates(DeduplicatedCollection[Coordinate]):
     """An ordered list of `Coordinate`s."""
 
 
-@dataclass(frozen=True, order=True)
+@dataclass(frozen=True)
 class ArtifactRequirement:
     """A single Maven-style coordinate for a JVM dependency, along with information of how to fetch
     the dependency if it is not to be fetched from a Maven repository."""


### PR DESCRIPTION
#15218 demonstrates a fairly obscure issue where a mostly-duplicated `jvm_artifact` target which defined a `jar` field would find that the first few fields in an `ArtifactRequirement` were equal before attempting to compare a `JvmArtifactJarSourceField` field, which would fail.

Rather than sorting `ArtifactRequirement` instances, we can instead ensure that the input targets are sorted.

Fixes #15218.