### PR TITLE
[internal] bsp: fix base directory selection when empty

### DIFF
--- a/src/python/pants/bsp/util_rules/targets.py
+++ b/src/python/pants/bsp/util_rules/targets.py
@@ -384,7 +384,9 @@ async def generate_one_bsp_build_target_request(
             request.bsp_target.definition.base_directory
         )
     elif roots:
-        base_directory = roots[0]
+        # TODO: Technically we don't need to choose a base directory but it does guide the IDE in where
+        # to place the build target in the IDE's UI. Thus, for now, just choose the first directory.
+        base_directory = sorted(roots)[0] if roots else None
 
     return GenerateOneBSPBuildTargetResult(
         build_target=BuildTarget(


### PR DESCRIPTION
Fix selection of a base directory for a build target when there are no source roots to avoid an exception.

[ci skip-rust]