### PR TITLE
[internal] scala: use lockfile for dependency inference parser

### DIFF
--- a/3rdparty/jvm/io/circe/BUILD
+++ b/3rdparty/jvm/io/circe/BUILD
@@ -1,10 +1,11 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+# Note: This target must be kept in sync with `ScalaParserTool`.
 jvm_artifact(
     name="circe-generic",
     group="io.circe",
     artifact="circe-generic_2.13",
     version="0.14.1",
-    resolve="scala_parser",
+    resolve="scala_parser_dev",
 )

--- a/3rdparty/jvm/io/circe/BUILD
+++ b/3rdparty/jvm/io/circe/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-# Note: This target must be kept in sync with `ScalaParserTool`.
+# Note: This target must be kept in sync with the requirements in `generate_scala_parser_lockfile_request`.
 jvm_artifact(
     name="circe-generic",
     group="io.circe",

--- a/3rdparty/jvm/org/scalameta/BUILD
+++ b/3rdparty/jvm/org/scalameta/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-# Note: This target must be kept in sync with `ScalaParserTool`.
+# Note: This target must be kept in sync with the requirements in `generate_scala_parser_lockfile_request`.
 jvm_artifact(
     name="scalameta",
     group="org.scalameta",

--- a/3rdparty/jvm/org/scalameta/BUILD
+++ b/3rdparty/jvm/org/scalameta/BUILD
@@ -1,11 +1,12 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+# Note: This target must be kept in sync with `ScalaParserTool`.
 jvm_artifact(
     name="scalameta",
     group="org.scalameta",
     artifact="scalameta_2.13",
     version="4.4.30",
     packages=["scala.meta.**"],
-    resolve="scala_parser",
+    resolve="scala_parser_dev",
 )

--- a/build-support/bin/_generate_all_lockfiles_helper.py
+++ b/build-support/bin/_generate_all_lockfiles_helper.py
@@ -37,7 +37,6 @@ from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.subsystems.setuptools import Setuptools
 from pants.backend.python.subsystems.twine import TwineSubsystem
 from pants.backend.python.typecheck.mypy.subsystem import MyPy
-from pants.backend.scala.dependency_inference.scala_parser import ScalaParserTool
 from pants.backend.scala.lint.scalafmt.subsystem import ScalafmtSubsystem
 from pants.backend.scala.subsystems.scalatest import Scalatest
 from pants.backend.terraform.dependency_inference import TerraformHcl2Parser
@@ -116,7 +115,6 @@ AllTools = (
     # JVM
     DefaultTool.jvm(JUnit),
     DefaultTool.jvm(GoogleJavaFormatSubsystem),
-    DefaultTool.jvm(ScalaParserTool),
     DefaultTool.jvm(ScalafmtSubsystem),
     DefaultTool.jvm(ScalaPBSubsystem, backend="pants.backend.experimental.codegen.protobuf.scala"),
     DefaultTool.jvm(Scalatest),

--- a/build-support/bin/_generate_all_lockfiles_helper.py
+++ b/build-support/bin/_generate_all_lockfiles_helper.py
@@ -37,6 +37,7 @@ from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.subsystems.setuptools import Setuptools
 from pants.backend.python.subsystems.twine import TwineSubsystem
 from pants.backend.python.typecheck.mypy.subsystem import MyPy
+from pants.backend.scala.dependency_inference.scala_parser import ScalaParserTool
 from pants.backend.scala.lint.scalafmt.subsystem import ScalafmtSubsystem
 from pants.backend.scala.subsystems.scalatest import Scalatest
 from pants.backend.terraform.dependency_inference import TerraformHcl2Parser
@@ -115,6 +116,7 @@ AllTools = (
     # JVM
     DefaultTool.jvm(JUnit),
     DefaultTool.jvm(GoogleJavaFormatSubsystem),
+    DefaultTool.jvm(ScalaParserTool),
     DefaultTool.jvm(ScalafmtSubsystem),
     DefaultTool.jvm(ScalaPBSubsystem, backend="pants.backend.experimental.codegen.protobuf.scala"),
     DefaultTool.jvm(Scalatest),

--- a/pants.toml
+++ b/pants.toml
@@ -203,10 +203,11 @@ jvm_testprojects = "3rdparty/jvm/testprojects.lockfile"
 # classpath. Consequently, we isolate it to its own lockfile.
 java_parser = "src/python/pants/backend/java/dependency_inference/java_parser.lockfile"
 # Has the same isolation requirements as `java_parser`.
-scala_parser = "src/python/pants/backend/scala/dependency_inference/scala_parser.lockfile"
+# Note: The jvm_artifact target in this resolve must be kept in sync with `ScalaParserTool`.
+scala_parser_dev = "src/python/pants/backend/scala/dependency_inference/scala_parser.lock"
 
 [scala]
-version_for_resolve = { "scala_parser" = '2.13.7' }
+version_for_resolve = { "scala_parser_dev" = "2.13.8" }
 
 [toolchain-setup]
 repo = "pants"

--- a/pants.toml
+++ b/pants.toml
@@ -203,7 +203,8 @@ jvm_testprojects = "3rdparty/jvm/testprojects.lockfile"
 # classpath. Consequently, we isolate it to its own lockfile.
 java_parser = "src/python/pants/backend/java/dependency_inference/java_parser.lockfile"
 # Has the same isolation requirements as `java_parser`.
-# Note: The jvm_artifact targets in this resolve must be kept in sync with `ScalaParserTool`.
+# Note: The jvm_artifact targets in this resolve must be kept in sync with with the requirements
+# in `generate_scala_parser_lockfile_request`.
 scala_parser_dev = "src/python/pants/backend/scala/dependency_inference/scala_parser.lock"
 
 [scala]

--- a/pants.toml
+++ b/pants.toml
@@ -203,7 +203,7 @@ jvm_testprojects = "3rdparty/jvm/testprojects.lockfile"
 # classpath. Consequently, we isolate it to its own lockfile.
 java_parser = "src/python/pants/backend/java/dependency_inference/java_parser.lockfile"
 # Has the same isolation requirements as `java_parser`.
-# Note: The jvm_artifact target in this resolve must be kept in sync with `ScalaParserTool`.
+# Note: The jvm_artifact targets in this resolve must be kept in sync with `ScalaParserTool`.
 scala_parser_dev = "src/python/pants/backend/scala/dependency_inference/scala_parser.lock"
 
 [scala]

--- a/src/python/pants/backend/scala/dependency_inference/BUILD
+++ b/src/python/pants/backend/scala/dependency_inference/BUILD
@@ -2,22 +2,22 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_sources(dependencies=[":scala_resources"])
-resources(name="scala_resources", sources=["*.scala", "scala_parser.lockfile"])
+resources(name="scala_resources", sources=["*.scala", "scala_parser.lock"])
 
 python_tests(name="tests", timeout=240)
 
 # Targets for developing on the Scala parser outside of engine rules.
 scala_sources(
     name="scala_parser",
-    resolve="scala_parser",
+    resolve="scala_parser_dev",
     # TODO: Allow the parser files to be formatted.
     skip_scalafmt=True,
 )
 
 jvm_artifact(
-    name="org.scala-lang_scala-library_2.13.7",
+    name="org.scala-lang_scala-library_2.13.8",
     group="org.scala-lang",
     artifact="scala-library",
-    version="2.13.7",
-    resolve="scala_parser",
+    version="2.13.8",
+    resolve="scala_parser_dev",
 )

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.lock
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.lock
@@ -7,7 +7,7 @@
 #   "version": 1,
 #   "generated_with_requirements": [
 #     "io.circe:circe-generic_2.13:0.14.1,url=not_provided,jar=not_provided",
-#     "org.scala-lang:scala-library:2.13.7,url=not_provided,jar=not_provided",
+#     "org.scala-lang:scala-library:2.13.8,url=not_provided,jar=not_provided",
 #     "org.scalameta:scalameta_2.13:4.4.30,url=not_provided,jar=not_provided"
 #   ]
 # }
@@ -18,13 +18,13 @@ file_name = "com.chuusai_shapeless_2.13_2.3.7.jar"
 [[entries.directDependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 
@@ -86,7 +86,7 @@ packaging = "jar"
 [[entries.directDependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -98,7 +98,7 @@ packaging = "jar"
 [[entries.dependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 
@@ -133,7 +133,7 @@ packaging = "jar"
 [[entries.directDependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -157,7 +157,7 @@ packaging = "jar"
 [[entries.dependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 
@@ -180,7 +180,7 @@ packaging = "jar"
 [[entries.directDependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 [[entries.directDependencies]]
@@ -198,7 +198,7 @@ packaging = "jar"
 [[entries.dependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -245,7 +245,7 @@ packaging = "jar"
 [[entries.directDependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -269,7 +269,7 @@ packaging = "jar"
 [[entries.dependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -304,13 +304,13 @@ file_name = "io.circe_circe-numbers_2.13_0.14.1.jar"
 [[entries.directDependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 
@@ -353,13 +353,13 @@ file_name = "org.scala-lang.modules_scala-collection-compat_2.13_2.4.4.jar"
 [[entries.directDependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 
@@ -388,7 +388,7 @@ packaging = "jar"
 [[entries.directDependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 [[entries.directDependencies]]
@@ -412,7 +412,7 @@ packaging = "jar"
 [[entries.dependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -433,28 +433,28 @@ serialized_bytes_length = 12092802
 [[entries]]
 directDependencies = []
 dependencies = []
-file_name = "org.scala-lang_scala-library_2.13.7.jar"
+file_name = "org.scala-lang_scala-library_2.13.8.jar"
 
 [entries.coord]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 [entries.file_digest]
-fingerprint = "a8bc08f3b9ff93d0496032bf2677163071b8d212992f41dbf04212e07d91616b"
-serialized_bytes_length = 6004712
+fingerprint = "a0882b82514190c2bac7d1a459872a75f005fc0f3e88b2bc0390367146e35db7"
+serialized_bytes_length = 6003601
 [[entries]]
 file_name = "org.scala-lang_scala-reflect_2.13.7.jar"
 [[entries.directDependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 
@@ -495,7 +495,7 @@ packaging = "jar"
 [[entries.dependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -530,7 +530,7 @@ packaging = "jar"
 [[entries.directDependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -566,7 +566,7 @@ packaging = "jar"
 [[entries.dependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 
@@ -618,7 +618,7 @@ file_name = "org.scalameta_parsers_2.13_4.4.30.jar"
 [[entries.directDependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 [[entries.directDependencies]]
@@ -666,7 +666,7 @@ packaging = "jar"
 [[entries.dependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -701,7 +701,7 @@ file_name = "org.scalameta_scalameta_2.13_4.4.30.jar"
 [[entries.directDependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 [[entries.directDependencies]]
@@ -773,7 +773,7 @@ packaging = "jar"
 [[entries.dependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -826,7 +826,7 @@ file_name = "org.scalameta_trees_2.13_4.4.30.jar"
 [[entries.directDependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 [[entries.directDependencies]]
@@ -880,7 +880,7 @@ packaging = "jar"
 [[entries.dependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -909,7 +909,7 @@ file_name = "org.typelevel_cats-core_2.13_2.6.1.jar"
 [[entries.directDependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 [[entries.directDependencies]]
@@ -927,7 +927,7 @@ packaging = "jar"
 [[entries.dependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -956,13 +956,13 @@ file_name = "org.typelevel_cats-kernel_2.13_2.6.1.jar"
 [[entries.directDependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 
@@ -979,13 +979,13 @@ file_name = "org.typelevel_simulacrum-scalafix-annotations_2.13_0.5.4.jar"
 [[entries.directDependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
-version = "2.13.7"
+version = "2.13.8"
 packaging = "jar"
 
 

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -39,6 +39,10 @@ from pants.util.ordered_set import FrozenOrderedSet
 logger = logging.getLogger(__name__)
 
 
+_PARSER_SCALA_VERSION = "2.13.8"
+_PARSER_SCALA_BINARY_VERSION = _PARSER_SCALA_VERSION.rpartition(".")[0]
+
+
 class ScalaParserTool(JvmToolBase):
     options_scope = "scala-parser"
     name = "Scala Parser for Dependency Inference"
@@ -48,9 +52,9 @@ class ScalaParserTool(JvmToolBase):
     # Note: These requirements must be kept in sync with the corresponding `jvm_artifact` targets for
     # the `scala_parser_dev` resolve.
     default_artifacts = (
-        "org.scalameta:scalameta_2.13:4.4.30",
-        "io.circe:circe-generic_2.13:0.14.1",
-        "org.scala-lang:scala-library:2.13.8",
+        f"org.scalameta:scalameta_{_PARSER_SCALA_BINARY_VERSION}:4.4.30",
+        f"io.circe:circe-generic_{_PARSER_SCALA_BINARY_VERSION}:0.14.1",
+        f"org.scala-lang:scala-library:{_PARSER_SCALA_VERSION}",
     )
     default_lockfile_resource = (
         "pants.backend.scala.dependency_inference",
@@ -294,17 +298,17 @@ async def setup_scala_parser_classfiles(jdk: InternalJdk) -> ScalaParserCompiled
                         Coordinate(
                             group="org.scala-lang",
                             artifact="scala-compiler",
-                            version="2.13.8",
+                            version=_PARSER_SCALA_VERSION,
                         ),
                         Coordinate(
                             group="org.scala-lang",
                             artifact="scala-library",
-                            version="2.13.8",
+                            version=_PARSER_SCALA_VERSION,
                         ),
                         Coordinate(
                             group="org.scala-lang",
                             artifact="scala-reflect",
-                            version="2.13.8",
+                            version=_PARSER_SCALA_VERSION,
                         ),
                     ]
                 ),

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -9,7 +9,7 @@ import pkgutil
 from dataclasses import dataclass
 from typing import Any, Iterator, Mapping
 
-from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import DEFAULT_TOOL_LOCKFILE, GenerateToolLockfileSentinel
 from pants.core.util_rules.source_files import SourceFiles
 from pants.engine.fs import (
     AddPrefix,
@@ -354,7 +354,8 @@ def generate_scala_parser_lockfile_request(
         artifact_option_name="n/a",
         lockfile_option_name="n/a",
         resolve_name=ScalaParserToolLockfileSentinel.resolve_name,
-        lockfile_dest="src/python/pants/backend/scala/dependency_inference/scala_parser.lock",
+        read_lockfile_dest=DEFAULT_TOOL_LOCKFILE,
+        write_lockfile_dest="src/python/pants/backend/scala/dependency_inference/scala_parser.lock",
         default_lockfile_resource=(
             "pants.backend.scala.dependency_inference",
             "scala_parser.lock",


### PR DESCRIPTION
Use a lockfile for the Scala dependency inference parser when used as a tool (which is how it is primarily used). The Pants repository had a `scala_parser` resolve for development purposes, but that was not used at runtime when the parser was actually invoked for end users.

Rename that resolve to `scala_parser_dev` to avoid any confusion with the `scala-parser` tool resolve and have it share the tool's lockfile. (A comment informs readers that they must keep the requirements in `scala_parser.py` and the `jvm_artifact` targets in the `scala_parser_dev` resolve in sync, or else Pants will probably ask for the lockfile to be regenerated.)

[ci skip-rust]