### PR TITLE
[internal] kotlin: add kotlin and ktlint backends to docs

### DIFF
--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -215,6 +215,8 @@ def run_pants_help_all() -> dict[str, Any]:
         "pants.backend.experimental.helm",
         "pants.backend.experimental.java",
         "pants.backend.experimental.java.lint.google_java_format",
+        "pants.backend.experimental.kotlin",
+        "pants.backend.experimental.kotlin.lint.ktlint",
         "pants.backend.experimental.python",
         "pants.backend.experimental.python.lint.autoflake",
         "pants.backend.experimental.python.lint.pyupgrade",


### PR DESCRIPTION
Add the kotlin and ktlint backends to the docs.

[ci skip-build-wheels]