### PR TITLE
[internal] kotlin: add `--kotlinc-args` option

### DIFF
--- a/src/python/pants/backend/kotlin/compile/kotlinc.py
+++ b/src/python/pants/backend/kotlin/compile/kotlinc.py
@@ -7,6 +7,7 @@ import logging
 
 from pants.backend.java.target_types import JavaFieldSet, JavaGeneratorFieldSet
 from pants.backend.kotlin.subsystems.kotlin import KotlinSubsystem
+from pants.backend.kotlin.subsystems.kotlinc import KotlincSubsystem
 from pants.backend.kotlin.target_types import (
     KotlinFieldSet,
     KotlinGeneratorFieldSet,
@@ -49,6 +50,7 @@ def compute_output_jar_filename(ctgt: CoarsenedTarget) -> str:
 @rule(desc="Compile with kotlinc")
 async def compile_kotlin_source(
     kotlin: KotlinSubsystem,
+    kotlinc: KotlincSubsystem,
     request: CompileKotlinSourceRequest,
 ) -> FallibleClasspathEntry:
     # Request classpath entries for our direct dependencies.
@@ -158,6 +160,7 @@ async def compile_kotlin_source(
                 *(("-classpath", classpath_arg) if classpath_arg else ()),
                 "-d",
                 output_file,
+                *kotlinc.args,
                 *sorted(
                     itertools.chain.from_iterable(
                         sources.snapshot.files

--- a/src/python/pants/backend/kotlin/subsystems/kotlinc.py
+++ b/src/python/pants/backend/kotlin/subsystems/kotlinc.py
@@ -1,0 +1,15 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from pants.option.option_types import ArgsListOption
+from pants.option.subsystem import Subsystem
+
+
+class KotlincSubsystem(Subsystem):
+    options_scope = "kotlinc"
+    name = "kotlinc"
+    help = "The Kotlin programming language (https://kotlinlang.org/)."
+
+    args = ArgsListOption(
+        example="-Werror",
+        extra_help="See https://kotlinlang.org/docs/compiler-reference.html for supported arguments.",
+    )


### PR DESCRIPTION
Add `--kotlinc-args` option for passing arguments to the kotlin compiler.

[ci skip-build-wheels]