### PR TITLE
Fix use of `@` in path names (Cherry-pick of #15226)

### DIFF
--- a/src/python/pants/build_graph/address_test.py
+++ b/src/python/pants/build_graph/address_test.py
@@ -75,6 +75,10 @@ def test_address_input_parse_spec() -> None:
     assert_parsed(
         "a#gen@k1=v1", generated_component="gen", path_component="a", parameters={"k1": "v1"}
     )
+    assert_parsed("a@t", path_component="a@t")
+    assert_parsed("a@=", path_component="a@=")
+    assert_parsed("a@t,y", path_component="a@t,y")
+    assert_parsed("a@2.png:../t", path_component="a@2.png", target_component="../t")
 
     # Absolute spec
     assert_parsed("//a/b/c", path_component="a/b/c")
@@ -112,9 +116,6 @@ def test_address_input_parse_bad_path_component(spec: str) -> None:
 @pytest.mark.parametrize(
     "spec,expected",
     [
-        ("a@t", "one or more key=value pairs"),
-        ("a@=", "one or more key=value pairs"),
-        ("a@t,y", "one or more key=value pairs"),
         ("a@t=,y", "one or more key=value pairs"),
         ("a#", "non-empty generated target name"),
     ],

--- a/src/rust/engine/address/src/lib.rs
+++ b/src/rust/engine/address/src/lib.rs
@@ -43,7 +43,8 @@ pub struct SpecInput<'a> {
 
 peg::parser! {
     grammar parsers() for str {
-        rule path() -> &'input str = s:$([^':' | '@' | '#']*) { s }
+        rule path() -> &'input str =
+            s:$(([^':' | '@' | '#'] / ("@" !parameter()))*) { s }
 
         rule target_name() -> &'input str
             = quiet!{ s:$([^'#' | '@' | ':']+) { s } }


### PR DESCRIPTION
Fix use of `@` in path names as long as they are not followed by parameter syntax.

Fixes #15217.
