### PR TITLE
Fix lockfile generation for duplicate `jvm_artifact` targets with `jar` fields. (Cherry-pick of #15219)

### DIFF
--- a/src/python/pants/jvm/resolve/common.py
+++ b/src/python/pants/jvm/resolve/common.py
@@ -140,7 +140,7 @@ class Coordinates(DeduplicatedCollection[Coordinate]):
     """An ordered list of `Coordinate`s."""
 
 
-@dataclass(frozen=True, order=True)
+@dataclass(frozen=True)
 class ArtifactRequirement:
     """A single Maven-style coordinate for a JVM dependency, along with information of how to fetch
     the dependency if it is not to be fetched from a Maven repository."""


### PR DESCRIPTION
#15218 demonstrates a fairly obscure issue where a mostly-duplicated `jvm_artifact` target which defined a `jar` field would find that the first few fields in an `ArtifactRequirement` were equal before attempting to compare a `JvmArtifactJarSourceField` field, which would fail.

Rather than sorting `ArtifactRequirement` instances, we can instead ensure that the input targets are sorted.

Fixes #15218.
