### PR TITLE
Cache comparison job fixes: round 2

### DIFF
--- a/.github/workflows/cache_comparison.yaml
+++ b/.github/workflows/cache_comparison.yaml
@@ -10,7 +10,7 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v3
       with:
-        fetch-depth: 1024
+        fetch-depth: 10
     - if: github.event_name == 'push'
       name: Get commit message for branch builds
       run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
@@ -35,21 +35,38 @@ jobs:
 
         '
     - env:
+        BASE_REF: ${{ github.event.inputs.baseRef }}
         BUILD_DIFFSPEC: ${{ github.event.inputs.buildDiffspec }}
         BUILD_DIFFSPEC_STEP: ${{ github.event.inputs.buildDiffspecStep }}
-        PANTS_ARGS: ${{ github.event.inputs.pants_args }}
+        PANTS_ARGS: ${{ github.event.inputs.pantsArgs }}
         SOURCE_DIFFSPEC: ${{ github.event.inputs.sourceDiffspec }}
         SOURCE_DIFFSPEC_STEP: ${{ github.event.inputs.sourceDiffspecStep }}
-      name: Cache comparison script
-      run: "./pants package build-support/bin/cache_comparison.py\ndist/build-support.bin/cache_comparison_py.pex\
-        \ \\\n  --args=\"$PANTS_ARGS\" \\\n  --build-diffspec=\"$BUILD_DIFFSPEC\"\
-        \ \\\n  --build-diffspec-step=$BUILD_DIFFSPEC_STEP \\\n  --source-diffspec=\"\
-        $SOURCE_DIFFSPEC\" \\\n  --source-diffspec-step=$SOURCE_DIFFSPEC_STEP\n"
+      name: Prepare cache comparison
+      run: './pants package build-support/bin/cache_comparison.py
+
+        git fetch --no-tags --depth=1024 origin "$BASE_REF"
+
+        '
+    - env:
+        BASE_REF: ${{ github.event.inputs.baseRef }}
+        BUILD_DIFFSPEC: ${{ github.event.inputs.buildDiffspec }}
+        BUILD_DIFFSPEC_STEP: ${{ github.event.inputs.buildDiffspecStep }}
+        PANTS_ARGS: ${{ github.event.inputs.pantsArgs }}
+        SOURCE_DIFFSPEC: ${{ github.event.inputs.sourceDiffspec }}
+        SOURCE_DIFFSPEC_STEP: ${{ github.event.inputs.sourceDiffspecStep }}
+      name: Run cache comparison
+      run: "dist/build-support.bin/cache_comparison_py.pex \\\n  --args=\"$PANTS_ARGS\"\
+        \ \\\n  --build-diffspec=\"$BUILD_DIFFSPEC\" \\\n  --build-diffspec-step=$BUILD_DIFFSPEC_STEP\
+        \ \\\n  --source-diffspec=\"$SOURCE_DIFFSPEC\" \\\n  --source-diffspec-step=$SOURCE_DIFFSPEC_STEP\n"
     timeout-minutes: 90
 name: Cache Comparison
 'on':
   workflow_dispatch:
     inputs:
+      baseRef:
+        default: main
+        required: false
+        type: string
       buildDiffspec:
         required: true
         type: string
@@ -57,7 +74,7 @@ name: Cache Comparison
         default: 1
         required: false
         type: int
-      pants_args:
+      pantsArgs:
         default: 'check lint test ::'
         required: false
         type: string

--- a/.github/workflows/cache_comparison.yaml
+++ b/.github/workflows/cache_comparison.yaml
@@ -29,6 +29,11 @@ jobs:
         echo "EOF" >> $GITHUB_ENV
 
         '
+    - if: github.event_name != 'pull_request'
+      name: Setup toolchain auth
+      run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
+
+        '
     - env:
         BUILD_DIFFSPEC: ${{ github.event.inputs.buildDiffspec }}
         BUILD_DIFFSPEC_STEP: ${{ github.event.inputs.buildDiffspecStep }}

--- a/.github/workflows/cache_comparison.yaml
+++ b/.github/workflows/cache_comparison.yaml
@@ -45,6 +45,7 @@ jobs:
         \ \\\n  --args=\"$PANTS_ARGS\" \\\n  --build-diffspec=\"$BUILD_DIFFSPEC\"\
         \ \\\n  --build-diffspec-step=$BUILD_DIFFSPEC_STEP \\\n  --source-diffspec=\"\
         $SOURCE_DIFFSPEC\" \\\n  --source-diffspec-step=$SOURCE_DIFFSPEC_STEP\n"
+    timeout-minutes: 90
 name: Cache Comparison
 'on':
   workflow_dispatch:
@@ -57,7 +58,7 @@ name: Cache Comparison
         required: false
         type: int
       pants_args:
-        default: 'check fmt lint ::'
+        default: 'check lint test ::'
         required: false
         type: string
       sourceDiffspec:

--- a/.github/workflows/cache_comparison.yaml
+++ b/.github/workflows/cache_comparison.yaml
@@ -34,6 +34,19 @@ jobs:
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
 
         '
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Tell Pants to use Python ${{ matrix.python-version }}
+      run: 'echo "PY=python${{ matrix.python-version }}" >> $GITHUB_ENV
+
+        echo "PANTS_PYTHON_INTERPRETER_CONSTRAINTS=[''==${{ matrix.python-version
+        }}.*'']" >> $GITHUB_ENV
+
+        '
+    - name: Expose Pythons
+      uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - env:
         BASE_REF: ${{ github.event.inputs.baseRef }}
         BUILD_DIFFSPEC: ${{ github.event.inputs.buildDiffspec }}
@@ -58,6 +71,10 @@ jobs:
       run: "dist/build-support.bin/cache_comparison_py.pex \\\n  --args=\"$PANTS_ARGS\"\
         \ \\\n  --build-diffspec=\"$BUILD_DIFFSPEC\" \\\n  --build-diffspec-step=$BUILD_DIFFSPEC_STEP\
         \ \\\n  --source-diffspec=\"$SOURCE_DIFFSPEC\" \\\n  --source-diffspec-step=$SOURCE_DIFFSPEC_STEP\n"
+    strategy:
+      matrix:
+        python-version:
+        - '3.7'
     timeout-minutes: 90
 name: Cache Comparison
 'on':

--- a/.github/workflows/cache_comparison.yaml
+++ b/.github/workflows/cache_comparison.yaml
@@ -48,29 +48,27 @@ jobs:
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - env:
-        BASE_REF: ${{ github.event.inputs.baseRef }}
-        BUILD_DIFFSPEC: ${{ github.event.inputs.buildDiffspec }}
-        BUILD_DIFFSPEC_STEP: ${{ github.event.inputs.buildDiffspecStep }}
-        PANTS_ARGS: ${{ github.event.inputs.pantsArgs }}
-        SOURCE_DIFFSPEC: ${{ github.event.inputs.sourceDiffspec }}
-        SOURCE_DIFFSPEC_STEP: ${{ github.event.inputs.sourceDiffspecStep }}
+        BASE_REF: ${{ github.event.inputs.base_ref }}
+        BUILD_COMMIT: ${{ github.event.inputs.build_commit }}
+        PANTS_ARGS: ${{ github.event.inputs.pants_args }}
+        SOURCE_DIFFSPEC: ${{ github.event.inputs.source_diffspec }}
+        SOURCE_DIFFSPEC_STEP: ${{ github.event.inputs.source_diffspec_step }}
       name: Prepare cache comparison
-      run: './pants package build-support/bin/cache_comparison.py
+      run: 'MODE=debug ./pants package build-support/bin/cache_comparison.py
 
         git fetch --no-tags --depth=1024 origin "$BASE_REF"
 
         '
     - env:
-        BASE_REF: ${{ github.event.inputs.baseRef }}
-        BUILD_DIFFSPEC: ${{ github.event.inputs.buildDiffspec }}
-        BUILD_DIFFSPEC_STEP: ${{ github.event.inputs.buildDiffspecStep }}
-        PANTS_ARGS: ${{ github.event.inputs.pantsArgs }}
-        SOURCE_DIFFSPEC: ${{ github.event.inputs.sourceDiffspec }}
-        SOURCE_DIFFSPEC_STEP: ${{ github.event.inputs.sourceDiffspecStep }}
+        BASE_REF: ${{ github.event.inputs.base_ref }}
+        BUILD_COMMIT: ${{ github.event.inputs.build_commit }}
+        PANTS_ARGS: ${{ github.event.inputs.pants_args }}
+        SOURCE_DIFFSPEC: ${{ github.event.inputs.source_diffspec }}
+        SOURCE_DIFFSPEC_STEP: ${{ github.event.inputs.source_diffspec_step }}
       name: Run cache comparison
       run: "dist/build-support.bin/cache_comparison_py.pex \\\n  --args=\"$PANTS_ARGS\"\
-        \ \\\n  --build-diffspec=\"$BUILD_DIFFSPEC\" \\\n  --build-diffspec-step=$BUILD_DIFFSPEC_STEP\
-        \ \\\n  --source-diffspec=\"$SOURCE_DIFFSPEC\" \\\n  --source-diffspec-step=$SOURCE_DIFFSPEC_STEP\n"
+        \ \\\n  --build-commit=\"$BUILD_COMMIT\" \\\n  --source-diffspec=\"$SOURCE_DIFFSPEC\"\
+        \ \\\n  --source-diffspec-step=$SOURCE_DIFFSPEC_STEP\n"
     strategy:
       matrix:
         python-version:
@@ -80,25 +78,21 @@ name: Cache Comparison
 'on':
   workflow_dispatch:
     inputs:
-      baseRef:
+      base_ref:
         default: main
         required: false
         type: string
-      buildDiffspec:
+      build_commit:
         required: true
         type: string
-      buildDiffspecStep:
-        default: 1
-        required: false
-        type: int
-      pantsArgs:
+      pants_args:
         default: 'check lint test ::'
         required: false
         type: string
-      sourceDiffspec:
+      source_diffspec:
         required: true
         type: string
-      sourceDiffspecStep:
+      source_diffspec_step:
         default: 1
         required: false
         type: int

--- a/build-support/bin/cache_comparison.py
+++ b/build-support/bin/cache_comparison.py
@@ -95,7 +95,11 @@ def timings_for_build(
 
 
 def timing_for_commit(commit: Commit, args: list[str], cache_namespace: str) -> TimeInSeconds:
+    # Checkout the commit, and ensure that the native code is built by running the `pants` script.
     checkout(commit)
+    run(["--no-pantsd", "--version"], use_pex=False)
+
+    # Then time the actual run with the PEX.
     start = time()
     run(args, cache_namespace=cache_namespace)
     return time() - start

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -761,6 +761,7 @@ def generate() -> dict[Path, str]:
                         # TODO: This depth is arbitrary, but is meant to capture the most
                         # likely `diffspecs` used as arguments.
                         *checkout(fetch_depth=1024),
+                        setup_toolchain_auth(),
                         {
                             "name": "Cache comparison script",
                             "run": dedent(

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -642,7 +642,7 @@ def cache_comparison_inputs() -> tuple[dict[str, Any], dict[str, Any]]:
                 "pants_args",
                 "PANTS_ARGS",
                 "string",
-                default="check fmt lint ::",
+                default="check lint test ::",
             ),
         ]
     )
@@ -757,6 +757,7 @@ def generate() -> dict[Path, str]:
             "jobs": {
                 "cache_comparison": {
                     "runs-on": "ubuntu-latest",
+                    "timeout-minutes": 90,
                     "steps": [
                         # TODO: This depth is arbitrary, but is meant to capture the most
                         # likely `diffspecs` used as arguments.

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -657,13 +657,18 @@ def cache_comparison_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
         "cache_comparison": {
             "runs-on": "ubuntu-latest",
             "timeout-minutes": 90,
+            # TODO: This job doesn't actually need to run as a matrix, but `setup_primary_python`
+            # assumes that jobs are.
+            "strategy": {"matrix": {"python-version": [PYTHON37_VERSION]}},
             "steps": [
                 *checkout(),
                 setup_toolchain_auth(),
+                *setup_primary_python(),
+                expose_all_pythons(),
                 {
                     "name": "Prepare cache comparison",
                     "run": dedent(
-                        # TODO: The fetch depth is arbitrary, but is meant to capture the
+                        # NB: The fetch depth is arbitrary, but is meant to capture the
                         # most likely `diffspecs` used as arguments.
                         """\
                                 ./pants package build-support/bin/cache_comparison.py


### PR DESCRIPTION
A bunch of fixes discovered while getting #15183 working against `2.10.x` and `2.11.x`.

The largest change is that each instance of the job now runs for one build commit (against a series of source/input commits). This better matches one of the primary usecases for the job (bisecting to find a regression) and allows for more parallelism.

Note though: this job is fairly limited by the fact that the source commits are in the `pantsbuild/pants` repository, because many of our `BUILD` files, configuration, and lockfiles are implicitly tied to the source version of pants that is being used. The source commit range needs to be chosen carefully in order to be compatible with the binary commit. It's likely that either supporting running against non-`pantsbuild/pants` repositories, or supporting cherry-pick fixup commits should be future work.

<img width="331" alt="cache-comparison-example-inputs" src="https://user-images.githubusercontent.com/46740/164799218-c241f047-972d-44c3-9c8b-9b6f6e272cee.png">
