### PR TITLE
[internal] kotlin: do not expose kotlin parser's lockfile to users

### DIFF
--- a/build-support/bin/_generate_all_lockfiles_helper.py
+++ b/build-support/bin/_generate_all_lockfiles_helper.py
@@ -17,7 +17,6 @@ from pants.backend.codegen.thrift.scrooge.subsystem import ScroogeSubsystem
 from pants.backend.docker.subsystems.dockerfile_parser import DockerfileParser
 from pants.backend.java.lint.google_java_format.subsystem import GoogleJavaFormatSubsystem
 from pants.backend.java.subsystems.junit import JUnit
-from pants.backend.kotlin.dependency_inference.kotlin_parser import KotlinParserTool
 from pants.backend.kotlin.lint.ktlint.subsystem import KtlintSubsystem
 from pants.backend.python.goals.coverage_py import CoverageSubsystem
 from pants.backend.python.lint.autoflake.subsystem import Autoflake
@@ -122,7 +121,6 @@ AllTools = (
         ScroogeSubsystem, backend="pants.backend.experimental.codegen.thrift.scrooge.scala"
     ),
     DefaultTool.jvm(AvroSubsystem, backend="pants.backend.experimental.codegen.avro.java"),
-    DefaultTool.jvm(KotlinParserTool, backend="pants.backend.experimental.kotlin"),
     DefaultTool.jvm(KtlintSubsystem, backend="pants.backend.experimental.kotlin.lint.ktlint"),
 )
 

--- a/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
@@ -8,7 +8,7 @@ import pkgutil
 from dataclasses import dataclass
 from typing import Any, Iterator
 
-from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import DEFAULT_TOOL_LOCKFILE, GenerateToolLockfileSentinel
 from pants.core.util_rules.source_files import SourceFiles
 from pants.engine.fs import CreateDigest, DigestContents, Directory, FileContent
 from pants.engine.internals.native_engine import AddPrefix, Digest, MergeDigests, RemovePrefix
@@ -318,7 +318,8 @@ def generate_kotlin_parser_lockfile_request(
         artifact_option_name="n/a",
         lockfile_option_name="n/a",
         resolve_name=KotlinParserToolLockfileSentinel.resolve_name,
-        lockfile_dest="src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.lock",
+        read_lockfile_dest=DEFAULT_TOOL_LOCKFILE,
+        write_lockfile_dest="src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.lock",
         default_lockfile_resource=(
             "pants.backend.kotlin.dependency_inference",
             "kotlin_parser.lock",


### PR DESCRIPTION
Do not expose the Kotlin parser's lockfile to users.

[ci skip-rust]

[ci skip-build-wheels]