### PR TITLE
[internal] jvm: split lockfile access into read and write paths

### DIFF
--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -725,16 +725,16 @@ async def materialize_classpath_for_tool(request: ToolClasspathRequest) -> ToolC
         lockfile_req = request.lockfile
         assert lockfile_req is not None
         regen_command = f"`{GenerateLockfilesSubsystem.name} --resolve={lockfile_req.resolve_name}`"
-        if lockfile_req.lockfile_dest == DEFAULT_TOOL_LOCKFILE:
+        if lockfile_req.read_lockfile_dest == DEFAULT_TOOL_LOCKFILE:
             lockfile_bytes = importlib.resources.read_binary(
                 *lockfile_req.default_lockfile_resource
             )
             resolution = CoursierResolvedLockfile.from_serialized(lockfile_bytes)
         else:
-            lockfile_snapshot = await Get(Snapshot, PathGlobs([lockfile_req.lockfile_dest]))
+            lockfile_snapshot = await Get(Snapshot, PathGlobs([lockfile_req.read_lockfile_dest]))
             if not lockfile_snapshot.files:
                 raise ValueError(
-                    f"No lockfile found at {lockfile_req.lockfile_dest}, which is configured "
+                    f"No lockfile found at {lockfile_req.read_lockfile_dest}, which is configured "
                     f"by the option {lockfile_req.lockfile_option_name}."
                     f"Run {regen_command} to generate it."
                 )
@@ -743,7 +743,7 @@ async def materialize_classpath_for_tool(request: ToolClasspathRequest) -> ToolC
                 CoursierResolvedLockfile,
                 CoursierResolveKey(
                     name=lockfile_req.resolve_name,
-                    path=lockfile_req.lockfile_dest,
+                    path=lockfile_req.read_lockfile_dest,
                     digest=lockfile_snapshot.digest,
                 ),
             )
@@ -759,7 +759,7 @@ async def materialize_classpath_for_tool(request: ToolClasspathRequest) -> ToolC
             lockfile_inputs, LockfileContext.TOOL
         ):
             raise ValueError(
-                f"The lockfile {lockfile_req.lockfile_dest} (configured by the option "
+                f"The lockfile {lockfile_req.read_lockfile_dest} (configured by the option "
                 f"{lockfile_req.lockfile_option_name}) was generated with different requirements "
                 f"than are currently set via {lockfile_req.artifact_option_name}. Run "
                 f"{regen_command} to regenerate the lockfile."

--- a/src/python/pants/jvm/resolve/jvm_tool.py
+++ b/src/python/pants/jvm/resolve/jvm_tool.py
@@ -159,7 +159,8 @@ class GenerateJvmLockfileFromTool:
     artifact_option_name: str
     lockfile_option_name: str
     resolve_name: str
-    lockfile_dest: str
+    read_lockfile_dest: str  # Path to lockfile when reading, or DEFAULT_TOOL_LOCKFILE to read from resource.
+    write_lockfile_dest: str  # Path to lockfile when generating the lockfile.
     default_lockfile_resource: tuple[str, str]
 
     @classmethod
@@ -169,7 +170,8 @@ class GenerateJvmLockfileFromTool:
             artifact_option_name=f"[{tool.options_scope}].artifacts",
             lockfile_option_name=f"[{tool.options_scope}].lockfile",
             resolve_name=tool.options_scope,
-            lockfile_dest=tool.lockfile,
+            read_lockfile_dest=tool.lockfile,
+            write_lockfile_dest=tool.lockfile,
             default_lockfile_resource=tool.default_lockfile_resource,
         )
 
@@ -183,7 +185,9 @@ async def setup_lockfile_request_from_tool(
         GatherJvmCoordinatesRequest(request.artifact_inputs, request.artifact_option_name),
     )
     return GenerateJvmLockfile(
-        artifacts=artifacts, resolve_name=request.resolve_name, lockfile_dest=request.lockfile_dest
+        artifacts=artifacts,
+        resolve_name=request.resolve_name,
+        lockfile_dest=request.write_lockfile_dest,
     )
 
 


### PR DESCRIPTION
Split `GenerateJvmLockfileFromTool.lockfile_dest` into read and write fields (`read_lockfile_dest` and `write_lockfile_dest`) to support tool lockfiles that are not exposed to users via `JvmToolBase`.

When using `JvmToolBase`, both fields will be the same, but for tool lockfiles that should not be exposed to users (for example, as done for the Scala parser in https://github.com/pantsbuild/pants/pull/15222), `read_lockfile_dest` can be set to `DEFAULT_TOOL_LOCKFILE` to enable reading from the resource, while still setting `write_lockfile_dest` to the path to use when re-generating that resource.

[ci skip-rust]

[ci skip-build-wheels]