### PR TITLE
Fix the placement of the pex verbosity args.

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -171,8 +171,9 @@ async def setup_pex_cli_process(
     if request.concurrency_available > 0:
         global_args.extend(["--jobs", "{pants_concurrency}"])
 
-    if pex_runtime_env.verbosity > 0:
-        global_args.append(f"-{'v' * pex_runtime_env.verbosity}")
+    verbosity_args = (
+        [f"-{'v' * pex_runtime_env.verbosity}"] if pex_runtime_env.verbosity > 0 else []
+    )
 
     resolve_args = (
         [*cert_args, "--python-path", create_path_env_var(pex_env.interpreter_search_paths)]
@@ -182,6 +183,7 @@ async def setup_pex_cli_process(
     args = [
         *global_args,
         *request.subcommand,
+        *verbosity_args,
         *resolve_args,
         # NB: This comes at the end because it may use `--` passthrough args, # which must come at
         # the end.


### PR DESCRIPTION
The pex subcommands mechanism registers the -v flag twice,
once at the global position and once for each subcommand.
The net effect is that the second registration shadows the first in
the resulting options object.

This may be something to address in pex (the global -v does nothing
so we should probably not register it), but the practical upshot
for Pants is that we have to provide the -v flag after the subcommand
name for it to take effect.

[ci skip-rust]

[ci skip-build-wheels]