### PR TITLE
`MyPy` and `Pylint` partition inputs via `CoarsenedTarget` (Cherry-pick of #15141)

### DIFF
--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -522,7 +522,7 @@ def test_partition_targets(rule_runner: RuleRunner) -> None:
         resolve: str,
     ) -> None:
         root_addresses = {t.address for t in roots}
-        assert {t.address for t in partition.root_targets} == root_addresses
+        assert {fs.address for fs in partition.root_field_sets} == root_addresses
         assert {t.address for t in partition.closure} == {
             *root_addresses,
             *(t.address for t in deps),

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -760,7 +760,7 @@ def test_partition_targets(rule_runner: RuleRunner) -> None:
         resolve: str,
     ) -> None:
         root_addresses = {t.address for t in roots}
-        assert {t.address for t in partition.root_targets} == root_addresses
+        assert {fs.address for fs in partition.root_field_sets} == root_addresses
         assert {t.address for t in partition.closure} == {
             *root_addresses,
             *(t.address for t in deps),

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -51,6 +51,7 @@ from pants.engine.target import (
     AllUnexpandedTargets,
     CoarsenedTarget,
     CoarsenedTargets,
+    CoarsenedTargetsRequest,
     Dependencies,
     DependenciesRequest,
     ExplicitlyProvidedDependencies,
@@ -540,16 +541,19 @@ async def transitive_targets(request: TransitiveTargetsRequest) -> TransitiveTar
 
 
 @rule
-async def coarsened_targets(addresses: Addresses) -> CoarsenedTargets:
+def coarsened_targets_request(addresses: Addresses) -> CoarsenedTargetsRequest:
+    return CoarsenedTargetsRequest(addresses)
+
+
+@rule
+async def coarsened_targets(request: CoarsenedTargetsRequest) -> CoarsenedTargets:
     dependency_mapping = await Get(
         _DependencyMapping,
         _DependencyMappingRequest(
-            # NB: We set include_special_cased_deps=True because although computing CoarsenedTargets
-            # requires a transitive graph walk (to ensure that all cycles are actually detected),
-            # the resulting CoarsenedTargets instance is not itself transitive: everything not directly
-            # involved in a cycle with one of the input Addresses is discarded in the output.
-            TransitiveTargetsRequest(addresses, include_special_cased_deps=True),
-            expanded_targets=False,
+            TransitiveTargetsRequest(
+                request.roots, include_special_cased_deps=request.include_special_cased_deps
+            ),
+            expanded_targets=request.expanded_targets,
         ),
     )
     addresses_to_targets = {
@@ -566,7 +570,7 @@ async def coarsened_targets(addresses: Addresses) -> CoarsenedTargets:
 
     coarsened_targets: dict[Address, CoarsenedTarget] = {}
     root_coarsened_targets = []
-    root_addresses_set = set(addresses)
+    root_addresses_set = set(request.roots)
     for component in components:
         component = sorted(component)
         component_set = set(component)

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -626,7 +626,7 @@ async def select_coursier_resolve_for_targets(
     resolve is required for multiple roots (such as when running a `repl` over unrelated code), and
     in that case there might be multiple CoarsenedTargets.
     """
-    targets = [t for ct in coarsened_targets.closure() for t in ct.members]
+    targets = list(coarsened_targets.closure())
 
     # Find a single resolve that is compatible with all targets in the closure.
     compatible_resolve: str | None = None


### PR DESCRIPTION
`CoarsenedTarget`s are structure shared, and because they preserve their internal structure, they can service requests for transitive targets for different roots from the same datastructure. Concretely: Mypy and Pylint can consume `CoarsenedTargets` to execute a single `@rule`-level graph walk, and then compute per-root closures from the resulting `CoarsenedTarget` instances.

This does not address #11270 in a general way (and it punts on #15241, which means that we still need per-root transitive walks), but it might provide a prototypical way to solve that problem on a case-by-case basis.

Performance wise, this moves cold `check ::` for ~1k files from:
* `main`: 32s total, and 26s spent in partitioning
*  `branch`: 19s total, and 13s spent in partitioning

The rest of the time is wrapped up in #15241.
