### PR TITLE
Allow for arbitrary suffixes when extracting

### DIFF
--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -116,11 +116,11 @@ async def maybe_extract_archive(request: MaybeExtractArchiveRequest) -> Extracte
 
     archive_path = snapshot.files[0]
     archive_suffix = request.use_suffix or "".join(PurePath(archive_path).suffixes)
-    is_zip = archive_suffix == ".zip"
-    is_tar = archive_suffix in (
+    is_zip = archive_suffix.endswith(".zip")
+    is_tar = archive_suffix.endswith(
         (".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tbz2", ".tar.xz", ".txz", ".tar.lz4")
     )
-    is_gz = not is_tar and archive_suffix == ".gz"
+    is_gz = not is_tar and archive_suffix.endswith(".gz")
     if not is_zip and not is_tar and not is_gz:
         return ExtractedArchive(request.digest)
 

--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from pathlib import PurePath
 
 from pants.core.util_rules import system_binaries
 from pants.core.util_rules.system_binaries import SEARCH_PATHS
@@ -72,33 +73,58 @@ async def create_archive(request: CreateArchive) -> Digest:
 
 
 @dataclass(frozen=True)
+class MaybeExtractArchiveRequest:
+    """A request to extract a single archive file (otherwise returns the input digest).
+
+    :param digest: The digest of the archive to maybe extract. If the archive contains a single file
+        which matches a known suffix, the `ExtractedArchive` will contain the extracted digest.
+        Otherwise the `ExtractedArchive` will contain this digest.
+    :param use_suffix: If provided, extracts the single file archive as if it had this suffix.
+        Useful in situations where the file is archived then renamed.
+        (E.g. A Python `.whl` is a renamed `.zip`, so the client should provide `".zip"`)
+    """
+
+    digest: Digest
+    use_suffix: str | None = None
+
+
+@dataclass(frozen=True)
 class ExtractedArchive:
     """The result of extracting an archive."""
 
     digest: Digest
 
 
+@rule
+async def convert_digest_to_MaybeExtractArchiveRequest(
+    digest: Digest,
+) -> MaybeExtractArchiveRequest:
+    """Backwards-compatibility helper."""
+    return MaybeExtractArchiveRequest(digest)
+
+
 @rule(desc="Extracting an archive file", level=LogLevel.DEBUG)
-async def maybe_extract_archive(digest: Digest) -> ExtractedArchive:
+async def maybe_extract_archive(request: MaybeExtractArchiveRequest) -> ExtractedArchive:
     """If digest contains a single archive file, extract it, otherwise return the input digest."""
     extract_archive_dir = "__extract_archive_dir"
     snapshot, output_dir_digest = await MultiGet(
-        Get(Snapshot, Digest, digest),
+        Get(Snapshot, Digest, request.digest),
         Get(Digest, CreateDigest([Directory(extract_archive_dir)])),
     )
     if len(snapshot.files) != 1:
-        return ExtractedArchive(digest)
+        return ExtractedArchive(request.digest)
 
     archive_path = snapshot.files[0]
-    is_zip = archive_path.endswith(".zip")
-    is_tar = archive_path.endswith(
+    archive_suffix = request.use_suffix or "".join(PurePath(archive_path).suffixes)
+    is_zip = archive_suffix == ".zip"
+    is_tar = archive_suffix in (
         (".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tbz2", ".tar.xz", ".txz", ".tar.lz4")
     )
-    is_gz = not is_tar and archive_path.endswith(".gz")
+    is_gz = not is_tar and archive_suffix == ".gz"
     if not is_zip and not is_tar and not is_gz:
-        return ExtractedArchive(digest)
+        return ExtractedArchive(request.digest)
 
-    merge_digest_get = Get(Digest, MergeDigests((digest, output_dir_digest)))
+    merge_digest_get = Get(Digest, MergeDigests((request.digest, output_dir_digest)))
     if is_zip:
         input_digest, unzip_binary = await MultiGet(
             merge_digest_get,
@@ -111,7 +137,9 @@ async def maybe_extract_archive(digest: Digest) -> ExtractedArchive:
             merge_digest_get,
             Get(TarBinary, TarBinaryRequest()),
         )
-        argv = tar_binary.extract_archive_argv(archive_path, extract_archive_dir)
+        argv = tar_binary.extract_archive_argv(
+            archive_path, extract_archive_dir, archive_suffix=archive_suffix
+        )
         # `tar` expects to find a couple binaries like `gzip` and `xz` by looking on the PATH.
         env = {"PATH": os.pathsep.join(SEARCH_PATHS)}
     else:
@@ -133,8 +161,8 @@ async def maybe_extract_archive(digest: Digest) -> ExtractedArchive:
             output_directories=(extract_archive_dir,),
         ),
     )
-    digest = await Get(Digest, RemovePrefix(result.output_digest, extract_archive_dir))
-    return ExtractedArchive(digest)
+    resulting_digest = await Get(Digest, RemovePrefix(result.output_digest, extract_archive_dir))
+    return ExtractedArchive(resulting_digest)
 
 
 def rules():

--- a/src/python/pants/core/util_rules/archive_test.py
+++ b/src/python/pants/core/util_rules/archive_test.py
@@ -7,11 +7,16 @@ import subprocess
 import tarfile
 import zipfile
 from io import BytesIO
+from typing import Callable, cast
 
 import pytest
 
 from pants.core.util_rules import archive, system_binaries
-from pants.core.util_rules.archive import CreateArchive, ExtractedArchive
+from pants.core.util_rules.archive import (
+    CreateArchive,
+    ExtractedArchive,
+    MaybeExtractArchiveRequest,
+)
 from pants.core.util_rules.system_binaries import ArchiveFormat
 from pants.engine.fs import Digest, DigestContents, FileContent
 from pants.testutil.rule_runner import QueryRule, RuleRunner
@@ -25,9 +30,30 @@ def rule_runner() -> RuleRunner:
             *system_binaries.rules(),
             QueryRule(Digest, [CreateArchive]),
             QueryRule(ExtractedArchive, [Digest]),
+            QueryRule(ExtractedArchive, [MaybeExtractArchiveRequest]),
         ],
     )
 
+
+@pytest.fixture(
+    params=[pytest.param(True, id="fake_suffix"), pytest.param(False, id="actual_suffix")]
+)
+def extract_from_file_info(request, rule_runner):
+    use_fake_suffix = request.param
+
+    def impl(suffix: str, contents: bytes) -> DigestContents:
+        snapshot_file_suffix = ".slimfit" if use_fake_suffix else suffix
+        input_snapshot = rule_runner.make_snapshot({f"test{snapshot_file_suffix}": contents})
+        request = MaybeExtractArchiveRequest(
+            digest=input_snapshot.digest, use_suffix=suffix if use_fake_suffix else None
+        )
+        extracted_archive = rule_runner.request(ExtractedArchive, [request])
+        return cast(DigestContents, rule_runner.request(DigestContents, [extracted_archive.digest]))
+
+    return impl
+
+
+ExtractorFixtureT = Callable[[str, bytes], Digest]
 
 FILES = {"foo": b"bar", "hello/world": b"Hello, World!"}
 EXPECTED_DIGEST_CONTENTS = DigestContents(
@@ -36,21 +62,18 @@ EXPECTED_DIGEST_CONTENTS = DigestContents(
 
 
 @pytest.mark.parametrize("compression", [zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED])
-def test_extract_zip(rule_runner: RuleRunner, compression: int) -> None:
+def test_extract_zip(extract_from_file_info: ExtractorFixtureT, compression: int) -> None:
     io = BytesIO()
     with zipfile.ZipFile(io, "w", compression=compression) as zf:
         for name, content in FILES.items():
             zf.writestr(name, content)
     io.flush()
-    input_snapshot = rule_runner.make_snapshot({"test.zip": io.getvalue()})
-
-    extracted_archive = rule_runner.request(ExtractedArchive, [input_snapshot.digest])
-    digest_contents = rule_runner.request(DigestContents, [extracted_archive.digest])
+    digest_contents = extract_from_file_info(".zip", io.getvalue())
     assert digest_contents == EXPECTED_DIGEST_CONTENTS
 
 
 @pytest.mark.parametrize("compression", ["", "gz", "bz2", "xz"])
-def test_extract_tar(rule_runner: RuleRunner, compression: str) -> None:
+def test_extract_tar(extract_from_file_info: ExtractorFixtureT, compression: str) -> None:
     io = BytesIO()
     mode = f"w:{compression}" if compression else "w"
     with tarfile.open(mode=mode, fileobj=io) as tf:
@@ -58,15 +81,12 @@ def test_extract_tar(rule_runner: RuleRunner, compression: str) -> None:
             tarinfo = tarfile.TarInfo(name)
             tarinfo.size = len(content)
             tf.addfile(tarinfo, BytesIO(content))
-    ext = f"tar.{compression}" if compression else "tar"
-    input_snapshot = rule_runner.make_snapshot({f"test.{ext}": io.getvalue()})
-
-    extracted_archive = rule_runner.request(ExtractedArchive, [input_snapshot.digest])
-    digest_contents = rule_runner.request(DigestContents, [extracted_archive.digest])
+    ext = f".tar.{compression}" if compression else ".tar"
+    digest_contents = extract_from_file_info(ext, io.getvalue())
     assert digest_contents == EXPECTED_DIGEST_CONTENTS
 
 
-def test_extract_tarlz4(rule_runner: RuleRunner):
+def test_extract_tarlz4(extract_from_file_info: ExtractorFixtureT):
     if subprocess.run(["lz4", "--help"], check=False).returncode != 0:
         pytest.skip(reason="lz4 not on PATH")
 
@@ -76,13 +96,11 @@ def test_extract_tarlz4(rule_runner: RuleRunner):
         b"AEECAIDAgAUNQAC7zQwNzAAMDE1NzYyACAwjgBCCwIADwAC7FtwYW50cxMBDwIA"
         b"///////////////////////////////////////////////3UAAAAAAAAAAAABhrfd0="
     )
-    input_snapshot = rule_runner.make_snapshot({"test.tar.lz4": archive_content})
-    extracted_archive = rule_runner.request(ExtractedArchive, [input_snapshot.digest])
-    digest_contents = rule_runner.request(DigestContents, [extracted_archive.digest])
+    digest_contents = extract_from_file_info(".tar.lz4", archive_content)
     assert digest_contents == DigestContents([FileContent("tmp/msg/txt.txt", b"pants")])
 
 
-def test_extract_gz(rule_runner: RuleRunner) -> None:
+def test_extract_gz(extract_from_file_info: ExtractorFixtureT, rule_runner: RuleRunner) -> None:
     # NB: `gz` files are only compressed, and are not archives: they represent a single file.
     name = "test"
     content = b"Hello world!\n"
@@ -90,11 +108,8 @@ def test_extract_gz(rule_runner: RuleRunner) -> None:
     with gzip.GzipFile(fileobj=io, mode="w") as gzf:
         gzf.write(content)
     io.flush()
-    input_snapshot = rule_runner.make_snapshot({f"{name}.gz": io.getvalue()})
-
     rule_runner.set_options(args=[], env_inherit={"PATH", "PYENV_ROOT", "HOME"})
-    extracted_archive = rule_runner.request(ExtractedArchive, [input_snapshot.digest])
-    digest_contents = rule_runner.request(DigestContents, [extracted_archive.digest])
+    digest_contents = extract_from_file_info(".gz", io.getvalue())
     assert digest_contents == DigestContents([FileContent(name, content)])
 
 

--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -306,10 +306,12 @@ class TarBinary(BinaryPath):
         )
         return (self.path, f"c{compression}f", output_filename, *input_files)
 
-    def extract_archive_argv(self, archive_path: str, extract_path: str) -> tuple[str, ...]:
+    def extract_archive_argv(
+        self, archive_path: str, extract_path: str, *, archive_suffix: str
+    ) -> tuple[str, ...]:
         # Note that the `output_dir` must already exist.
         # The caller should validate that it's a valid `.tar` file.
-        prog_args = ("-Ilz4",) if archive_path.endswith(".lz4") else ()
+        prog_args = ("-Ilz4",) if archive_suffix == ".tar.lz4" else ()
         return (self.path, *prog_args, "-xf", archive_path, "-C", extract_path)
 
 


### PR DESCRIPTION
Allows for extraction of renamed files without having to manually rename.

[ci skip-rust]
[ci skip-build-wheels]