### PR TITLE
[internal] jvm: move prefixed `resolve` and `jdk` fields to jvm package (Cherry-pick of #15169)

### DIFF
--- a/src/python/pants/backend/codegen/avro/java/rules.py
+++ b/src/python/pants/backend/codegen/avro/java/rules.py
@@ -8,7 +8,11 @@ from pathlib import PurePath
 from typing import Iterable
 
 from pants.backend.codegen.avro.java.subsystem import AvroSubsystem
-from pants.backend.codegen.avro.target_types import AvroSourceField
+from pants.backend.codegen.avro.target_types import (
+    AvroSourceField,
+    AvroSourcesGeneratorTarget,
+    AvroSourceTarget,
+)
 from pants.backend.java.target_types import JavaSourceField
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
@@ -39,6 +43,7 @@ from pants.jvm.jdk_rules import InternalJdk, JvmProcess
 from pants.jvm.resolve import jvm_tool
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
+from pants.jvm.target_types import PrefixedJvmJdkField, PrefixedJvmResolveField
 from pants.source.source_root import SourceRoot, SourceRootRequest
 from pants.util.logging import LogLevel
 
@@ -218,4 +223,8 @@ def rules():
         *jdk_rules.rules(),
         UnionRule(GenerateSourcesRequest, GenerateJavaFromAvroRequest),
         UnionRule(GenerateToolLockfileSentinel, AvroToolLockfileSentinel),
+        AvroSourceTarget.register_plugin_field(PrefixedJvmJdkField),
+        AvroSourcesGeneratorTarget.register_plugin_field(PrefixedJvmJdkField),
+        AvroSourceTarget.register_plugin_field(PrefixedJvmResolveField),
+        AvroSourcesGeneratorTarget.register_plugin_field(PrefixedJvmResolveField),
     )

--- a/src/python/pants/backend/codegen/protobuf/java/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/java/rules.py
@@ -32,7 +32,7 @@ from pants.engine.target import (
     TransitiveTargetsRequest,
 )
 from pants.engine.unions import UnionRule
-from pants.jvm.target_types import JvmJdkField
+from pants.jvm.target_types import PrefixedJvmJdkField, PrefixedJvmResolveField
 from pants.source.source_root import SourceRoot, SourceRootRequest
 from pants.util.logging import LogLevel
 
@@ -121,10 +121,6 @@ async def generate_java_from_protobuf(
     return GeneratedSources(source_root_restored)
 
 
-class PrefixedJvmJdkField(JvmJdkField):
-    alias = "jvm_jdk"
-
-
 def rules():
     return [
         *collect_rules(),
@@ -132,4 +128,6 @@ def rules():
         UnionRule(GenerateSourcesRequest, GenerateJavaFromProtobufRequest),
         ProtobufSourceTarget.register_plugin_field(PrefixedJvmJdkField),
         ProtobufSourcesGeneratorTarget.register_plugin_field(PrefixedJvmJdkField),
+        ProtobufSourceTarget.register_plugin_field(PrefixedJvmResolveField),
+        ProtobufSourcesGeneratorTarget.register_plugin_field(PrefixedJvmResolveField),
     ]

--- a/src/python/pants/backend/codegen/protobuf/scala/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/rules.py
@@ -51,7 +51,7 @@ from pants.jvm.jdk_rules import InternalJdk, JvmProcess
 from pants.jvm.resolve.common import ArtifactRequirements, Coordinate, GatherJvmCoordinatesRequest
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
-from pants.jvm.target_types import JvmJdkField
+from pants.jvm.target_types import PrefixedJvmJdkField
 from pants.source.source_root import SourceRoot, SourceRootRequest
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
@@ -334,10 +334,6 @@ def generate_scalapbc_lockfile_request(
     _: ScalapbcToolLockfileSentinel, tool: ScalaPBSubsystem
 ) -> GenerateJvmLockfileFromTool:
     return GenerateJvmLockfileFromTool.create(tool)
-
-
-class PrefixedJvmJdkField(JvmJdkField):
-    alias = "jvm_jdk"
 
 
 def rules():

--- a/src/python/pants/backend/codegen/soap/java/rules.py
+++ b/src/python/pants/backend/codegen/soap/java/rules.py
@@ -8,7 +8,11 @@ from dataclasses import dataclass
 from pants.backend.codegen.soap.java import extra_fields
 from pants.backend.codegen.soap.java.extra_fields import JavaModuleField, JavaPackageField
 from pants.backend.codegen.soap.java.jaxws import JaxWsTools
-from pants.backend.codegen.soap.target_types import WsdlSourceField
+from pants.backend.codegen.soap.target_types import (
+    WsdlSourceField,
+    WsdlSourcesGeneratorTarget,
+    WsdlSourceTarget,
+)
 from pants.backend.java.target_types import JavaSourceField
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
@@ -38,6 +42,7 @@ from pants.jvm.jdk_rules import InternalJdk, JvmProcess
 from pants.jvm.resolve import jvm_tool
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
+from pants.jvm.target_types import PrefixedJvmJdkField, PrefixedJvmResolveField
 from pants.source.source_root import SourceRoot, SourceRootRequest
 from pants.util.logging import LogLevel
 
@@ -183,4 +188,8 @@ def rules():
         *jdk_rules.rules(),
         UnionRule(GenerateSourcesRequest, GenerateJavaFromWsdlRequest),
         UnionRule(GenerateToolLockfileSentinel, JaxWsToolsLockfileSentinel),
+        WsdlSourceTarget.register_plugin_field(PrefixedJvmJdkField),
+        WsdlSourcesGeneratorTarget.register_plugin_field(PrefixedJvmJdkField),
+        WsdlSourceTarget.register_plugin_field(PrefixedJvmResolveField),
+        WsdlSourcesGeneratorTarget.register_plugin_field(PrefixedJvmResolveField),
     ]

--- a/src/python/pants/backend/codegen/thrift/apache/java/rules.py
+++ b/src/python/pants/backend/codegen/thrift/apache/java/rules.py
@@ -7,7 +7,12 @@ from pants.backend.codegen.thrift.apache.rules import (
     GeneratedThriftSources,
     GenerateThriftSourcesRequest,
 )
-from pants.backend.codegen.thrift.target_types import ThriftDependenciesField, ThriftSourceField
+from pants.backend.codegen.thrift.target_types import (
+    ThriftDependenciesField,
+    ThriftSourceField,
+    ThriftSourcesGeneratorTarget,
+    ThriftSourceTarget,
+)
 from pants.backend.java.target_types import JavaSourceField
 from pants.engine.addresses import Addresses, UnparsedAddressInputs
 from pants.engine.fs import AddPrefix, Digest, Snapshot
@@ -20,6 +25,7 @@ from pants.engine.target import (
     InjectedDependencies,
 )
 from pants.engine.unions import UnionRule
+from pants.jvm.target_types import PrefixedJvmJdkField, PrefixedJvmResolveField
 from pants.source.source_root import SourceRoot, SourceRootRequest
 from pants.util.logging import LogLevel
 
@@ -74,4 +80,8 @@ def rules():
         *subsystem.rules(),
         UnionRule(GenerateSourcesRequest, GenerateJavaFromThriftRequest),
         UnionRule(InjectDependenciesRequest, InjectApacheThriftJavaDependencies),
+        ThriftSourceTarget.register_plugin_field(PrefixedJvmJdkField),
+        ThriftSourcesGeneratorTarget.register_plugin_field(PrefixedJvmJdkField),
+        ThriftSourceTarget.register_plugin_field(PrefixedJvmResolveField),
+        ThriftSourcesGeneratorTarget.register_plugin_field(PrefixedJvmResolveField),
     )

--- a/src/python/pants/backend/codegen/thrift/apache/java/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/thrift/apache/java/rules_integration_test.py
@@ -17,10 +17,45 @@ from pants.backend.codegen.thrift.target_types import (
 from pants.build_graph.address import Address
 from pants.core.util_rules import source_files, stripped_source_files
 from pants.engine.internals import graph
+from pants.engine.internals.native_engine import FileDigest
 from pants.engine.rules import QueryRule
 from pants.engine.target import GeneratedSources, HydratedSources, HydrateSourcesRequest
+from pants.jvm.resolve.common import ArtifactRequirement, Coordinate, Coordinates
+from pants.jvm.resolve.coursier_fetch import CoursierLockfileEntry
+from pants.jvm.resolve.coursier_test_util import TestCoursierWrapper
+from pants.jvm.target_types import JvmArtifactTarget
 from pants.source import source_root
 from pants.testutil.rule_runner import RuleRunner, logging
+
+LIBTHRIFT_RESOLVE = TestCoursierWrapper.new(
+    entries=(
+        CoursierLockfileEntry(
+            coord=Coordinate(
+                group="org.apache.thrift",
+                artifact="libthrift",
+                version="0.15.0",
+            ),
+            file_name="libthrift-0.15.0.jar",
+            direct_dependencies=Coordinates([]),
+            dependencies=Coordinates([]),
+            file_digest=FileDigest(
+                "e9c47420147cbb87a6df08bc36da04e2be1561967b5ef82d2f3ef9ec090d85d0",
+                305670,
+            ),
+        ),
+        # Note: The transitive dependencies of libthrift have been intentionally omitted from this resolve.
+    ),
+).serialize(
+    [
+        ArtifactRequirement(
+            Coordinate(
+                group="org.apache.thrift",
+                artifact="libthrift",
+                version="0.15.0",
+            )
+        )
+    ]
+)
 
 
 @pytest.fixture
@@ -37,7 +72,7 @@ def rule_runner() -> RuleRunner:
             QueryRule(HydratedSources, [HydrateSourcesRequest]),
             QueryRule(GeneratedSources, [GenerateJavaFromThriftRequest]),
         ],
-        target_types=[ThriftSourcesGeneratorTarget],
+        target_types=[ThriftSourcesGeneratorTarget, JvmArtifactTarget],
     )
 
 
@@ -111,6 +146,18 @@ def test_generates_python(rule_runner: RuleRunner) -> None:
                 """
             ),
             "tests/thrift/test_thrifts/BUILD": "thrift_sources(dependencies=['src/thrift/dir2'])",
+            "3rdparty/jvm/default.lock": LIBTHRIFT_RESOLVE,
+            "3rdparty/BUILD": dedent(
+                """\
+                jvm_artifact(
+                  name="org.apache.thrift_libthrift",
+                  group="org.apache.thrift",
+                  artifact="libthrift",
+                  version="0.15.0",
+                  resolve="jvm-default",
+                )
+                """
+            ),
         }
     )
 

--- a/src/python/pants/backend/codegen/thrift/scrooge/java/rules.py
+++ b/src/python/pants/backend/codegen/thrift/scrooge/java/rules.py
@@ -5,7 +5,12 @@ from pants.backend.codegen.thrift.scrooge.rules import (
     GeneratedScroogeThriftSources,
     GenerateScroogeThriftSourcesRequest,
 )
-from pants.backend.codegen.thrift.target_types import ThriftDependenciesField, ThriftSourceField
+from pants.backend.codegen.thrift.target_types import (
+    ThriftDependenciesField,
+    ThriftSourceField,
+    ThriftSourcesGeneratorTarget,
+    ThriftSourceTarget,
+)
 from pants.backend.java.target_types import JavaSourceField
 from pants.engine.addresses import Addresses, UnparsedAddressInputs
 from pants.engine.fs import AddPrefix, Digest, Snapshot
@@ -18,6 +23,7 @@ from pants.engine.target import (
     InjectedDependencies,
 )
 from pants.engine.unions import UnionRule
+from pants.jvm.target_types import PrefixedJvmJdkField, PrefixedJvmResolveField
 from pants.source.source_root import SourceRoot, SourceRootRequest
 from pants.util.logging import LogLevel
 
@@ -69,4 +75,8 @@ def rules():
         *collect_rules(),
         UnionRule(GenerateSourcesRequest, GenerateJavaFromThriftRequest),
         UnionRule(InjectDependenciesRequest, InjectScroogeJavaDependencies),
+        ThriftSourceTarget.register_plugin_field(PrefixedJvmJdkField),
+        ThriftSourcesGeneratorTarget.register_plugin_field(PrefixedJvmJdkField),
+        ThriftSourceTarget.register_plugin_field(PrefixedJvmResolveField),
+        ThriftSourcesGeneratorTarget.register_plugin_field(PrefixedJvmResolveField),
     )

--- a/src/python/pants/backend/codegen/thrift/scrooge/rules.py
+++ b/src/python/pants/backend/codegen/thrift/scrooge/rules.py
@@ -5,7 +5,11 @@ from dataclasses import dataclass
 from pants.backend.codegen.thrift.scrooge import additional_fields
 from pants.backend.codegen.thrift.scrooge.additional_fields import ScroogeFinagleBoolField
 from pants.backend.codegen.thrift.scrooge.subsystem import ScroogeSubsystem
-from pants.backend.codegen.thrift.target_types import ThriftSourceField
+from pants.backend.codegen.thrift.target_types import (
+    ThriftSourceField,
+    ThriftSourcesGeneratorTarget,
+    ThriftSourceTarget,
+)
 from pants.build_graph.address import Address
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
@@ -19,6 +23,7 @@ from pants.jvm.goals import lockfile
 from pants.jvm.jdk_rules import InternalJdk, JvmProcess
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
+from pants.jvm.target_types import PrefixedJvmJdkField, PrefixedJvmResolveField
 from pants.source.source_root import SourceRootsRequest, SourceRootsResult
 from pants.util.logging import LogLevel
 
@@ -139,4 +144,8 @@ def rules():
         *additional_fields.rules(),
         *lockfile.rules(),
         UnionRule(GenerateToolLockfileSentinel, ScroogeToolLockfileSentinel),
+        ThriftSourceTarget.register_plugin_field(PrefixedJvmJdkField),
+        ThriftSourcesGeneratorTarget.register_plugin_field(PrefixedJvmJdkField),
+        ThriftSourceTarget.register_plugin_field(PrefixedJvmResolveField),
+        ThriftSourcesGeneratorTarget.register_plugin_field(PrefixedJvmResolveField),
     ]

--- a/src/python/pants/jvm/target_types.py
+++ b/src/python/pants/jvm/target_types.py
@@ -62,6 +62,14 @@ class JvmJdkField(StringField):
     )
 
 
+class PrefixedJvmJdkField(JvmJdkField):
+    alias = "jvm_jdk"
+
+
+class PrefixedJvmResolveField(JvmResolveField):
+    alias = "jvm_resolve"
+
+
 # -----------------------------------------------------------------------------------------------
 # `jvm_artifact` targets
 # -----------------------------------------------------------------------------------------------


### PR DESCRIPTION
Move the prefixed `resolve` and `jdk` fields (`jvm_resolve` and `jvm_jdk`, respectively) to the `pants.jvm` package to remove duplication. Also register the prefixed fields in Thrift, Avro, and WSDL jvm codegen backends.

[ci skip-rust]

[ci skip-build-wheels]