### PR TITLE
Merge the JVM first and third party mappings

### DIFF
--- a/src/python/pants/backend/java/dependency_inference/rules.py
+++ b/src/python/pants/backend/java/dependency_inference/rules.py
@@ -126,7 +126,7 @@ async def infer_java_dependencies_and_exports_via_source_analysis(
     dependencies: OrderedSet[Address] = OrderedSet()
     exports: OrderedSet[Address] = OrderedSet()
     for typ in types:
-        first_party_matches = first_party_dep_map.symbols.addresses_for_symbol(typ, resolve=resolve)
+        first_party_matches = first_party_dep_map.addresses_for_symbol(typ, resolve)
         third_party_matches = (
             third_party_artifact_mapping.addresses_for_symbol(typ, resolve)
             if java_infer_subsystem.third_party_imports

--- a/src/python/pants/backend/java/dependency_inference/rules.py
+++ b/src/python/pants/backend/java/dependency_inference/rules.py
@@ -26,7 +26,7 @@ from pants.engine.target import (
 )
 from pants.engine.unions import UnionRule
 from pants.jvm.dependency_inference import artifact_mapper
-from pants.jvm.dependency_inference.symbol_mapper import FirstPartySymbolMapping
+from pants.jvm.dependency_inference.symbol_mapper import SymbolMapping
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
@@ -64,7 +64,7 @@ async def infer_java_dependencies_and_exports_via_source_analysis(
     request: JavaInferredDependenciesAndExportsRequest,
     java_infer_subsystem: JavaInferSubsystem,
     jvm: JvmSubsystem,
-    symbol_mapping: FirstPartySymbolMapping,
+    symbol_mapping: SymbolMapping,
 ) -> JavaInferredDependencies:
     if not java_infer_subsystem.imports and not java_infer_subsystem.consumed_types:
         return JavaInferredDependencies(FrozenOrderedSet([]), FrozenOrderedSet([]))

--- a/src/python/pants/backend/java/dependency_inference/rules.py
+++ b/src/python/pants/backend/java/dependency_inference/rules.py
@@ -71,7 +71,6 @@ async def infer_java_dependencies_and_exports_via_source_analysis(
     if (
         not java_infer_subsystem.imports
         and not java_infer_subsystem.consumed_types
-        and not java_infer_subsystem.third_party_imports
     ):
         return JavaInferredDependencies(FrozenOrderedSet([]), FrozenOrderedSet([]))
 
@@ -127,11 +126,7 @@ async def infer_java_dependencies_and_exports_via_source_analysis(
     exports: OrderedSet[Address] = OrderedSet()
     for typ in types:
         first_party_matches = first_party_dep_map.addresses_for_symbol(typ, resolve)
-        third_party_matches = (
-            third_party_artifact_mapping.addresses_for_symbol(typ, resolve)
-            if java_infer_subsystem.third_party_imports
-            else FrozenOrderedSet()
-        )
+        third_party_matches = third_party_artifact_mapping.addresses_for_symbol(typ, resolve)
         matches = first_party_matches.union(third_party_matches)
         if not matches:
             continue

--- a/src/python/pants/backend/java/dependency_inference/rules.py
+++ b/src/python/pants/backend/java/dependency_inference/rules.py
@@ -26,7 +26,6 @@ from pants.engine.target import (
 )
 from pants.engine.unions import UnionRule
 from pants.jvm.dependency_inference import artifact_mapper
-from pants.jvm.dependency_inference.artifact_mapper import ThirdPartyPackageToArtifactMapping
 from pants.jvm.dependency_inference.symbol_mapper import FirstPartySymbolMapping
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
@@ -65,13 +64,9 @@ async def infer_java_dependencies_and_exports_via_source_analysis(
     request: JavaInferredDependenciesAndExportsRequest,
     java_infer_subsystem: JavaInferSubsystem,
     jvm: JvmSubsystem,
-    first_party_dep_map: FirstPartySymbolMapping,
-    third_party_artifact_mapping: ThirdPartyPackageToArtifactMapping,
+    symbol_mapping: FirstPartySymbolMapping,
 ) -> JavaInferredDependencies:
-    if (
-        not java_infer_subsystem.imports
-        and not java_infer_subsystem.consumed_types
-    ):
+    if not java_infer_subsystem.imports and not java_infer_subsystem.consumed_types:
         return JavaInferredDependencies(FrozenOrderedSet([]), FrozenOrderedSet([]))
 
     address = request.source.address
@@ -125,9 +120,7 @@ async def infer_java_dependencies_and_exports_via_source_analysis(
     dependencies: OrderedSet[Address] = OrderedSet()
     exports: OrderedSet[Address] = OrderedSet()
     for typ in types:
-        first_party_matches = first_party_dep_map.addresses_for_symbol(typ, resolve)
-        third_party_matches = third_party_artifact_mapping.addresses_for_symbol(typ, resolve)
-        matches = first_party_matches.union(third_party_matches)
+        matches = symbol_mapping.addresses_for_symbol(typ, resolve)
         if not matches:
             continue
 

--- a/src/python/pants/backend/java/goals/debug_goals.py
+++ b/src/python/pants/backend/java/goals/debug_goals.py
@@ -12,24 +12,7 @@ from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import collect_rules, goal_rule
 from pants.engine.target import Targets
-from pants.jvm.dependency_inference.symbol_mapper import SymbolMapping
-
-
-class DumpFirstPartyDepMapSubsystem(GoalSubsystem):
-    name = "java-dump-first-party-dep-map"
-    help = "Dump dependency inference data for Java dep inference."
-
-
-class DumpFirstPartyDepMap(Goal):
-    subsystem_cls = DumpFirstPartyDepMapSubsystem
-
-
-@goal_rule
-async def dump_dep_inference_data(
-    console: Console, symbol_mapping: SymbolMapping
-) -> DumpFirstPartyDepMap:
-    console.write_stdout(json.dumps(symbol_mapping.to_json_dict()))
-    return DumpFirstPartyDepMap(exit_code=0)
+from pants.jvm.goals import debug_goals
 
 
 class DumpJavaSourceAnalysisSubsystem(GoalSubsystem):
@@ -62,4 +45,5 @@ def rules():
     return [
         *collect_rules(),
         *java_rules(),
+        *debug_goals.rules(),
     ]

--- a/src/python/pants/backend/java/goals/debug_goals.py
+++ b/src/python/pants/backend/java/goals/debug_goals.py
@@ -12,7 +12,7 @@ from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import collect_rules, goal_rule
 from pants.engine.target import Targets
-from pants.jvm.dependency_inference.symbol_mapper import FirstPartySymbolMapping
+from pants.jvm.dependency_inference.symbol_mapper import SymbolMapping
 
 
 class DumpFirstPartyDepMapSubsystem(GoalSubsystem):
@@ -26,9 +26,9 @@ class DumpFirstPartyDepMap(Goal):
 
 @goal_rule
 async def dump_dep_inference_data(
-    console: Console, first_party_dep_map: FirstPartySymbolMapping
+    console: Console, symbol_mapping: SymbolMapping
 ) -> DumpFirstPartyDepMap:
-    console.write_stdout(json.dumps(first_party_dep_map.to_json_dict()))
+    console.write_stdout(json.dumps(symbol_mapping.to_json_dict()))
     return DumpFirstPartyDepMap(exit_code=0)
 
 

--- a/src/python/pants/backend/java/goals/debug_goals.py
+++ b/src/python/pants/backend/java/goals/debug_goals.py
@@ -28,7 +28,7 @@ class DumpFirstPartyDepMap(Goal):
 async def dump_dep_inference_data(
     console: Console, first_party_dep_map: FirstPartySymbolMapping
 ) -> DumpFirstPartyDepMap:
-    console.write_stdout(json.dumps(first_party_dep_map.symbols.to_json_dict()))
+    console.write_stdout(json.dumps(first_party_dep_map.to_json_dict()))
     return DumpFirstPartyDepMap(exit_code=0)
 
 

--- a/src/python/pants/backend/java/subsystems/java_infer.py
+++ b/src/python/pants/backend/java/subsystems/java_infer.py
@@ -25,6 +25,8 @@ class JavaInferSubsystem(Subsystem):
         "--third-party-imports",
         default=True,
         help="Infer a target's third-party dependencies using Java import statements.",
+        removal_version="2.13.0.dev0",
+        removal_hint="Controlled by the `--imports` flag.",
     )
     # TODO: Move to `coursier` or a generic `jvm` subsystem.
     third_party_import_mapping = DictOption[Any](

--- a/src/python/pants/backend/kotlin/dependency_inference/rules.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/rules.py
@@ -28,7 +28,6 @@ from pants.jvm.dependency_inference import artifact_mapper
 from pants.jvm.dependency_inference import symbol_mapper as jvm_symbol_mapper
 from pants.jvm.dependency_inference.artifact_mapper import (
     AllJvmArtifactTargets,
-    ThirdPartyPackageToArtifactMapping,
     find_jvm_artifacts_or_raise,
 )
 from pants.jvm.dependency_inference.symbol_mapper import FirstPartySymbolMapping
@@ -47,8 +46,7 @@ async def infer_kotlin_dependencies_via_source_analysis(
     request: InferKotlinSourceDependencies,
     kotlin_infer_subsystem: KotlinInferSubsystem,
     jvm: JvmSubsystem,
-    first_party_symbol_map: FirstPartySymbolMapping,
-    third_party_artifact_mapping: ThirdPartyPackageToArtifactMapping,
+    symbol_mapping: FirstPartySymbolMapping,
 ) -> InferredDependencies:
     if not kotlin_infer_subsystem.imports:
         return InferredDependencies([])
@@ -71,9 +69,7 @@ async def infer_kotlin_dependencies_via_source_analysis(
 
     dependencies: OrderedSet[Address] = OrderedSet()
     for symbol in symbols:
-        first_party_matches = first_party_symbol_map.addresses_for_symbol(symbol, resolve)
-        third_party_matches = third_party_artifact_mapping.addresses_for_symbol(symbol, resolve)
-        matches = first_party_matches.union(third_party_matches)
+        matches = symbol_mapping.addresses_for_symbol(symbol, resolve)
         if not matches:
             continue
 

--- a/src/python/pants/backend/kotlin/dependency_inference/rules.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/rules.py
@@ -71,9 +71,7 @@ async def infer_kotlin_dependencies_via_source_analysis(
 
     dependencies: OrderedSet[Address] = OrderedSet()
     for symbol in symbols:
-        first_party_matches = first_party_symbol_map.symbols.addresses_for_symbol(
-            symbol, resolve=resolve
-        )
+        first_party_matches = first_party_symbol_map.addresses_for_symbol(symbol, resolve)
         third_party_matches = third_party_artifact_mapping.addresses_for_symbol(symbol, resolve)
         matches = first_party_matches.union(third_party_matches)
         if not matches:

--- a/src/python/pants/backend/kotlin/dependency_inference/rules.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/rules.py
@@ -30,7 +30,7 @@ from pants.jvm.dependency_inference.artifact_mapper import (
     AllJvmArtifactTargets,
     find_jvm_artifacts_or_raise,
 )
-from pants.jvm.dependency_inference.symbol_mapper import FirstPartySymbolMapping
+from pants.jvm.dependency_inference.symbol_mapper import SymbolMapping
 from pants.jvm.resolve.common import Coordinate
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
@@ -46,7 +46,7 @@ async def infer_kotlin_dependencies_via_source_analysis(
     request: InferKotlinSourceDependencies,
     kotlin_infer_subsystem: KotlinInferSubsystem,
     jvm: JvmSubsystem,
-    symbol_mapping: FirstPartySymbolMapping,
+    symbol_mapping: SymbolMapping,
 ) -> InferredDependencies:
     if not kotlin_infer_subsystem.imports:
         return InferredDependencies([])

--- a/src/python/pants/backend/kotlin/dependency_inference/symbol_mapper.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/symbol_mapper.py
@@ -1,8 +1,9 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-# TODO: add third-party targets here? That would allow us to avoid iterating over AllTargets twice.
-#  See `backend/python/dependency_inference/module_mapper.py` for an example.
+from collections import defaultdict
+from typing import Mapping
+
 from pants.backend.kotlin.dependency_inference.kotlin_parser import KotlinSourceDependencyAnalysis
 from pants.backend.kotlin.target_types import KotlinSourceField
 from pants.core.util_rules.source_files import SourceFilesRequest
@@ -10,12 +11,15 @@ from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import AllTargets, Targets
 from pants.engine.unions import UnionRule
+from pants.jvm.dependency_inference.artifact_mapper import MutableTrieNode
 from pants.jvm.dependency_inference.symbol_mapper import FirstPartyMappingRequest, SymbolMap
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
 from pants.util.logging import LogLevel
 
 
+# TODO: add third-party targets here? That would allow us to avoid iterating over AllTargets twice.
+#  See `backend/python/dependency_inference/module_mapper.py` for an example.
 class AllKotlinTargets(Targets):
     pass
 
@@ -44,12 +48,12 @@ async def map_first_party_kotlin_targets_to_symbols(
         source_analysis,
     )
 
-    symbol_map = SymbolMap()
+    mapping: Mapping[str, MutableTrieNode] = defaultdict(MutableTrieNode)
     for (address, resolve), analysis in address_and_analysis:
         for symbol in analysis.named_declarations:
-            symbol_map.add_symbol(symbol, address, resolve=resolve)
+            mapping[resolve].insert(symbol, [address], first_party=True)
 
-    return symbol_map
+    return SymbolMap((resolve, node.frozen()) for resolve, node in mapping.items())
 
 
 def rules():

--- a/src/python/pants/backend/kotlin/goals/debug_goals.py
+++ b/src/python/pants/backend/kotlin/goals/debug_goals.py
@@ -12,6 +12,7 @@ from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import collect_rules, goal_rule
 from pants.engine.target import Targets
+from pants.jvm.goals import debug_goals
 
 
 class DumpKotlinSourceAnalysisSubsystem(GoalSubsystem):
@@ -46,4 +47,5 @@ def rules():
     return [
         *collect_rules(),
         *kotlin_rules(),
+        *debug_goals.rules(),
     ]

--- a/src/python/pants/backend/scala/dependency_inference/rules.py
+++ b/src/python/pants/backend/scala/dependency_inference/rules.py
@@ -82,9 +82,7 @@ async def infer_scala_dependencies_via_source_analysis(
 
     dependencies: OrderedSet[Address] = OrderedSet()
     for symbol in symbols:
-        first_party_matches = first_party_symbol_map.symbols.addresses_for_symbol(
-            symbol, resolve=resolve
-        )
+        first_party_matches = first_party_symbol_map.addresses_for_symbol(symbol, resolve)
         third_party_matches = third_party_artifact_mapping.addresses_for_symbol(symbol, resolve)
         matches = first_party_matches.union(third_party_matches)
         if not matches:

--- a/src/python/pants/backend/scala/dependency_inference/rules.py
+++ b/src/python/pants/backend/scala/dependency_inference/rules.py
@@ -41,7 +41,7 @@ from pants.jvm.dependency_inference.artifact_mapper import (
     MissingJvmArtifacts,
     find_jvm_artifacts_or_raise,
 )
-from pants.jvm.dependency_inference.symbol_mapper import FirstPartySymbolMapping
+from pants.jvm.dependency_inference.symbol_mapper import SymbolMapping
 from pants.jvm.resolve.common import Coordinate
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
@@ -57,7 +57,7 @@ async def infer_scala_dependencies_via_source_analysis(
     request: InferScalaSourceDependencies,
     scala_infer_subsystem: ScalaInferSubsystem,
     jvm: JvmSubsystem,
-    symbol_mapping: FirstPartySymbolMapping,
+    symbol_mapping: SymbolMapping,
 ) -> InferredDependencies:
     if not scala_infer_subsystem.imports:
         return InferredDependencies([])

--- a/src/python/pants/backend/scala/dependency_inference/rules.py
+++ b/src/python/pants/backend/scala/dependency_inference/rules.py
@@ -39,7 +39,6 @@ from pants.jvm.dependency_inference.artifact_mapper import (
     AllJvmArtifactTargets,
     ConflictingJvmArtifactVersion,
     MissingJvmArtifacts,
-    ThirdPartyPackageToArtifactMapping,
     find_jvm_artifacts_or_raise,
 )
 from pants.jvm.dependency_inference.symbol_mapper import FirstPartySymbolMapping
@@ -58,8 +57,7 @@ async def infer_scala_dependencies_via_source_analysis(
     request: InferScalaSourceDependencies,
     scala_infer_subsystem: ScalaInferSubsystem,
     jvm: JvmSubsystem,
-    first_party_symbol_map: FirstPartySymbolMapping,
-    third_party_artifact_mapping: ThirdPartyPackageToArtifactMapping,
+    symbol_mapping: FirstPartySymbolMapping,
 ) -> InferredDependencies:
     if not scala_infer_subsystem.imports:
         return InferredDependencies([])
@@ -82,9 +80,7 @@ async def infer_scala_dependencies_via_source_analysis(
 
     dependencies: OrderedSet[Address] = OrderedSet()
     for symbol in symbols:
-        first_party_matches = first_party_symbol_map.addresses_for_symbol(symbol, resolve)
-        third_party_matches = third_party_artifact_mapping.addresses_for_symbol(symbol, resolve)
-        matches = first_party_matches.union(third_party_matches)
+        matches = symbol_mapping.addresses_for_symbol(symbol, resolve)
         if not matches:
             continue
 

--- a/src/python/pants/backend/scala/goals/debug_goals.py
+++ b/src/python/pants/backend/scala/goals/debug_goals.py
@@ -12,6 +12,7 @@ from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import collect_rules, goal_rule
 from pants.engine.target import Targets
+from pants.jvm.goals import debug_goals
 
 
 class DumpScalaSourceAnalysisSubsystem(GoalSubsystem):
@@ -44,4 +45,5 @@ def rules():
     return [
         *collect_rules(),
         *scala_rules(),
+        *debug_goals.rules(),
     ]

--- a/src/python/pants/jvm/dependency_inference/artifact_mapper.py
+++ b/src/python/pants/jvm/dependency_inference/artifact_mapper.py
@@ -235,7 +235,7 @@ def find_all_jvm_provides_fields(targets: AllTargets) -> AllJvmTypeProvidingTarg
     )
 
 
-class ThirdPartyPackageToArtifactMapping(FrozenDict[_ResolveName, FrozenTrieNode]):
+class ThirdPartySymbolMapping(FrozenDict[_ResolveName, FrozenTrieNode]):
     """The third party symbols provided by all `jvm_artifact` targets."""
 
 
@@ -267,11 +267,11 @@ async def find_available_third_party_artifacts(
 
 
 @rule
-async def compute_java_third_party_artifact_mapping(
+async def compute_java_third_party_symbol_mapping(
     java_infer_subsystem: JavaInferSubsystem,
     available_artifacts: AvailableThirdPartyArtifacts,
     all_jvm_type_providing_tgts: AllJvmTypeProvidingTargets,
-) -> ThirdPartyPackageToArtifactMapping:
+) -> ThirdPartySymbolMapping:
     """Implements the mapping logic from the `jvm_artifact` and `java-infer` help."""
 
     def symbol_from_package_pattern(package_pattern: str) -> tuple[str, bool]:
@@ -313,7 +313,7 @@ async def compute_java_third_party_artifact_mapping(
             for mapping in mappings.values():
                 mapping.insert(provides_type, [], first_party=True, recursive=False)
 
-    return ThirdPartyPackageToArtifactMapping(
+    return ThirdPartySymbolMapping(
         FrozenDict(
             (resolve_name, FrozenTrieNode(mapping)) for resolve_name, mapping in mappings.items()
         )

--- a/src/python/pants/jvm/dependency_inference/artifact_mapper.py
+++ b/src/python/pants/jvm/dependency_inference/artifact_mapper.py
@@ -201,9 +201,10 @@ class FrozenTrieNode:
         if not isinstance(other, FrozenTrieNode):
             return False
         return (
-            self._children == other._children
-            and self.recursive == other.recursive
+            self.recursive == other.recursive
+            and self.first_party == other.first_party
             and self.addresses == other.addresses
+            and self._children == other._children
         )
 
     def __repr__(self):
@@ -234,16 +235,8 @@ def find_all_jvm_provides_fields(targets: AllTargets) -> AllJvmTypeProvidingTarg
     )
 
 
-@dataclass(frozen=True)
-class ThirdPartyPackageToArtifactMapping:
-    mapping_roots: FrozenDict[_ResolveName, FrozenTrieNode]
-
-    def addresses_for_symbol(self, symbol: str, resolve: str) -> FrozenOrderedSet[Address]:
-        node = self.mapping_roots.get(resolve)
-        # Note that it's possible to have a resolve with no associated artifacts.
-        if not node:
-            return FrozenOrderedSet()
-        return node.addresses_for_symbol(symbol)
+class ThirdPartyPackageToArtifactMapping(FrozenDict[_ResolveName, FrozenTrieNode]):
+    """The third party symbols provided by all `jvm_artifact` targets."""
 
 
 @rule

--- a/src/python/pants/jvm/dependency_inference/artifact_mapper_test.py
+++ b/src/python/pants/jvm/dependency_inference/artifact_mapper_test.py
@@ -129,7 +129,7 @@ def test_third_party_mapping_parsing(rule_runner: RuleRunner) -> None:
     )
 
     mapping = rule_runner.request(ThirdPartyPackageToArtifactMapping, [])
-    root_node = mapping.mapping_roots["jvm-default"]
+    root_node = mapping["jvm-default"]
 
     # Handy trie traversal function to placate mypy
     def traverse(*children) -> FrozenTrieNode:

--- a/src/python/pants/jvm/dependency_inference/artifact_mapper_test.py
+++ b/src/python/pants/jvm/dependency_inference/artifact_mapper_test.py
@@ -22,7 +22,7 @@ from pants.engine.target import Dependencies, DependenciesRequest
 from pants.jvm.dependency_inference.artifact_mapper import (
     FrozenTrieNode,
     MutableTrieNode,
-    ThirdPartyPackageToArtifactMapping,
+    ThirdPartySymbolMapping,
 )
 from pants.jvm.dependency_inference.symbol_mapper import JvmFirstPartyPackageMappingException
 from pants.jvm.jdk_rules import rules as java_util_rules
@@ -54,7 +54,7 @@ def rule_runner() -> RuleRunner:
             *system_binaries.rules(),
             *util_rules(),
             QueryRule(Addresses, [DependenciesRequest]),
-            QueryRule(ThirdPartyPackageToArtifactMapping, []),
+            QueryRule(ThirdPartySymbolMapping, []),
         ],
         objects={"parametrize": Parametrize},
         target_types=[
@@ -128,7 +128,7 @@ def test_third_party_mapping_parsing(rule_runner: RuleRunner) -> None:
         }
     )
 
-    mapping = rule_runner.request(ThirdPartyPackageToArtifactMapping, [])
+    mapping = rule_runner.request(ThirdPartySymbolMapping, [])
     root_node = mapping["jvm-default"]
 
     # Handy trie traversal function to placate mypy

--- a/src/python/pants/jvm/dependency_inference/symbol_mapper.py
+++ b/src/python/pants/jvm/dependency_inference/symbol_mapper.py
@@ -14,7 +14,7 @@ from pants.engine.unions import UnionMembership, union
 from pants.jvm.dependency_inference.artifact_mapper import (
     AllJvmTypeProvidingTargets,
     FrozenTrieNode,
-    ThirdPartyPackageToArtifactMapping,
+    ThirdPartySymbolMapping,
 )
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmProvidesTypesField, JvmResolveField
@@ -53,7 +53,7 @@ class SymbolMap(FrozenDict[_ResolveName, FrozenTrieNode]):
 
 
 @dataclass(frozen=True)
-class FirstPartySymbolMapping:
+class SymbolMapping:
     """The merged first and third party symbols provided by all inference implementations."""
 
     mapping_roots: FrozenDict[_ResolveName, FrozenTrieNode]
@@ -78,8 +78,8 @@ async def merge_symbol_mappings(
     union_membership: UnionMembership,
     targets_that_provide_types: AllJvmTypeProvidingTargets,
     jvm: JvmSubsystem,
-    third_party_mapping: ThirdPartyPackageToArtifactMapping,
-) -> FirstPartySymbolMapping:
+    third_party_mapping: ThirdPartySymbolMapping,
+) -> SymbolMapping:
     all_firstparty_mappings = await MultiGet(
         Get(
             SymbolMap,
@@ -94,7 +94,7 @@ async def merge_symbol_mappings(
     ]
 
     resolves = {resolve for mapping in all_mappings for resolve in mapping.keys()}
-    mapping = FirstPartySymbolMapping(
+    mapping = SymbolMapping(
         FrozenDict(
             (
                 resolve,

--- a/src/python/pants/jvm/goals/debug_goals.py
+++ b/src/python/pants/jvm/goals/debug_goals.py
@@ -1,0 +1,30 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import json
+
+from pants.engine.console import Console
+from pants.engine.goal import Goal, GoalSubsystem
+from pants.engine.rules import collect_rules, goal_rule
+from pants.jvm.dependency_inference.symbol_mapper import SymbolMapping
+
+
+class JvmSymbolMapSubsystem(GoalSubsystem):
+    name = "jvm-symbol-map"
+    help = "Dump the JVM dependency inference symbol mapping."
+
+
+class JvmSymbolMap(Goal):
+    subsystem_cls = JvmSymbolMapSubsystem
+
+
+@goal_rule
+async def jvm_symbol_map(console: Console, symbol_mapping: SymbolMapping) -> JvmSymbolMap:
+    console.write_stdout(json.dumps(symbol_mapping.to_json_dict()))
+    return JvmSymbolMap(exit_code=0)
+
+
+def rules():
+    return [
+        *collect_rules(),
+    ]


### PR DESCRIPTION
Resolving #13849 will involve adding more differentiation between the "namespaces" that symbols are declared in. But as #14960 suggests, the first and third party mappings provide features that one another need in order to provide recursive matches (not to mention the thirdparty mapping trie being more memory efficient).

So, to prepare for #13849 and #14960, this change eagerly merges the first and third party mappings under the `(Frozen)TrieNode` structure. It also cleans up type and debug-goal names.