### PR TITLE
Fix ambiguity of Scala package objects with class or object definitions

### DIFF
--- a/src/python/pants/backend/java/goals/debug_goals.py
+++ b/src/python/pants/backend/java/goals/debug_goals.py
@@ -37,7 +37,7 @@ async def dump_java_source_analysis(targets: Targets, console: Console) -> DumpJ
         {"address": str(fs.address), **analysis.to_debug_json_dict()}
         for (fs, analysis) in zip(java_source_field_sets, java_source_analysis)
     ]
-    console.write_stdout(json.dumps(java_source_analysis_json))
+    console.print_stdout(json.dumps(java_source_analysis_json))
     return DumpJavaSourceAnalysis(exit_code=0)
 
 

--- a/src/python/pants/backend/kotlin/dependency_inference/rules.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/rules.py
@@ -69,20 +69,17 @@ async def infer_kotlin_dependencies_via_source_analysis(
 
     dependencies: OrderedSet[Address] = OrderedSet()
     for symbol in symbols:
-        matches = symbol_mapping.addresses_for_symbol(symbol, resolve)
-        if not matches:
-            continue
+        for matches in symbol_mapping.addresses_for_symbol(symbol, resolve).values():
+            explicitly_provided_deps.maybe_warn_of_ambiguous_dependency_inference(
+                matches,
+                address,
+                import_reference="type",
+                context=f"The target {address} imports `{symbol}`",
+            )
 
-        explicitly_provided_deps.maybe_warn_of_ambiguous_dependency_inference(
-            matches,
-            address,
-            import_reference="type",
-            context=f"The target {address} imports `{symbol}`",
-        )
-
-        maybe_disambiguated = explicitly_provided_deps.disambiguated(matches)
-        if maybe_disambiguated:
-            dependencies.add(maybe_disambiguated)
+            maybe_disambiguated = explicitly_provided_deps.disambiguated(matches)
+            if maybe_disambiguated:
+                dependencies.add(maybe_disambiguated)
 
     return InferredDependencies(dependencies)
 

--- a/src/python/pants/backend/kotlin/goals/debug_goals.py
+++ b/src/python/pants/backend/kotlin/goals/debug_goals.py
@@ -39,7 +39,7 @@ async def dump_kotlin_source_analysis(
         {"address": str(fs.address), **analysis.to_debug_json_dict()}
         for (fs, analysis) in zip(kotlin_source_field_sets, kotlin_source_analysis)
     ]
-    console.write_stdout(json.dumps(kotlin_source_analysis_json))
+    console.print_stdout(json.dumps(kotlin_source_analysis_json))
     return DumpKotlinSourceAnalysis(exit_code=0)
 
 

--- a/src/python/pants/backend/scala/dependency_inference/rules.py
+++ b/src/python/pants/backend/scala/dependency_inference/rules.py
@@ -80,20 +80,17 @@ async def infer_scala_dependencies_via_source_analysis(
 
     dependencies: OrderedSet[Address] = OrderedSet()
     for symbol in symbols:
-        matches = symbol_mapping.addresses_for_symbol(symbol, resolve)
-        if not matches:
-            continue
+        for matches in symbol_mapping.addresses_for_symbol(symbol, resolve).values():
+            explicitly_provided_deps.maybe_warn_of_ambiguous_dependency_inference(
+                matches,
+                address,
+                import_reference="type",
+                context=f"The target {address} imports `{symbol}`",
+            )
 
-        explicitly_provided_deps.maybe_warn_of_ambiguous_dependency_inference(
-            matches,
-            address,
-            import_reference="type",
-            context=f"The target {address} imports `{symbol}`",
-        )
-
-        maybe_disambiguated = explicitly_provided_deps.disambiguated(matches)
-        if maybe_disambiguated:
-            dependencies.add(maybe_disambiguated)
+            maybe_disambiguated = explicitly_provided_deps.disambiguated(matches)
+            if maybe_disambiguated:
+                dependencies.add(maybe_disambiguated)
 
     return InferredDependencies(dependencies)
 

--- a/src/python/pants/backend/scala/dependency_inference/symbol_mapper.py
+++ b/src/python/pants/backend/scala/dependency_inference/symbol_mapper.py
@@ -8,12 +8,17 @@ from typing import Mapping
 from pants.backend.scala.dependency_inference.scala_parser import ScalaSourceDependencyAnalysis
 from pants.backend.scala.target_types import ScalaSourceField
 from pants.core.util_rules.source_files import SourceFilesRequest
+from pants.engine.addresses import Address
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import AllTargets, Targets
 from pants.engine.unions import UnionRule
 from pants.jvm.dependency_inference import symbol_mapper
-from pants.jvm.dependency_inference.artifact_mapper import MutableTrieNode
+from pants.jvm.dependency_inference.artifact_mapper import (
+    DEFAULT_SYMBOL_NAMESPACE,
+    MutableTrieNode,
+    SymbolNamespace,
+)
 from pants.jvm.dependency_inference.symbol_mapper import FirstPartyMappingRequest, SymbolMap
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
@@ -35,6 +40,20 @@ def find_all_scala_targets(targets: AllTargets) -> AllScalaTargets:
     return AllScalaTargets(tgt for tgt in targets if tgt.has_field(ScalaSourceField))
 
 
+SCALA_PACKAGE_OBJECT_NAMESPACE: SymbolNamespace = "package object"
+
+
+def _symbol_namespace(address: Address) -> SymbolNamespace:
+    # NB: Although it is not required that `package object`s be declared in files
+    # named `package.scala`, it is a very common (and reasonable) convention. Additionally,
+    # we could technically mark only symbols which were declared _inside_ a `package object`,
+    # rather than using the filename as a heuristic like this.
+    if address.is_file_target and address.filename.endswith("package.scala"):
+        return SCALA_PACKAGE_OBJECT_NAMESPACE
+    else:
+        return DEFAULT_SYMBOL_NAMESPACE
+
+
 @rule(desc="Map all first party Scala targets to their symbols", level=LogLevel.DEBUG)
 async def map_first_party_scala_targets_to_symbols(
     _: FirstPartyScalaTargetsMappingRequest,
@@ -52,10 +71,11 @@ async def map_first_party_scala_targets_to_symbols(
 
     mapping: Mapping[str, MutableTrieNode] = defaultdict(MutableTrieNode)
     for (address, resolve), analysis in address_and_analysis:
+        namespace = _symbol_namespace(address)
         for symbol in analysis.provided_symbols:
-            mapping[resolve].insert(symbol, [address], first_party=True)
+            mapping[resolve].insert(symbol, [address], first_party=True, namespace=namespace)
         for symbol in analysis.provided_symbols_encoded:
-            mapping[resolve].insert(symbol, [address], first_party=True)
+            mapping[resolve].insert(symbol, [address], first_party=True, namespace=namespace)
 
     return SymbolMap((resolve, node.frozen()) for resolve, node in mapping.items())
 

--- a/src/python/pants/backend/scala/goals/debug_goals.py
+++ b/src/python/pants/backend/scala/goals/debug_goals.py
@@ -37,7 +37,7 @@ async def dump_scala_source_analysis(targets: Targets, console: Console) -> Dump
         {"address": str(fs.address), **analysis.to_debug_json_dict()}
         for (fs, analysis) in zip(scala_source_field_sets, scala_source_analysis)
     ]
-    console.write_stdout(json.dumps(scala_source_analysis_json))
+    console.print_stdout(json.dumps(scala_source_analysis_json))
     return DumpScalaSourceAnalysis(exit_code=0)
 
 

--- a/src/python/pants/jvm/goals/debug_goals.py
+++ b/src/python/pants/jvm/goals/debug_goals.py
@@ -20,7 +20,7 @@ class JvmSymbolMap(Goal):
 
 @goal_rule
 async def jvm_symbol_map(console: Console, symbol_mapping: SymbolMapping) -> JvmSymbolMap:
-    console.write_stdout(json.dumps(symbol_mapping.to_json_dict()))
+    console.print_stdout(json.dumps(symbol_mapping.to_json_dict()))
     return JvmSymbolMap(exit_code=0)
 
 


### PR DESCRIPTION
As described in #13849: a `type` alias inside of a `package object` is not ambiguous with a `class` or `object` declared in another file.

This change adds a mechanism to allow for multiple symbol namespaces to be used unambiguously, without consuming rules needing awareness of the namespaces. If a symbol is provided twice in the same namespace, it is ambiguous. But if it is provided in separate namespaces then it is unambiguous.

The actual heuristic used to detect use of a `package object` is not perfect: see the comment in the `_symbol_namespace` function. But the namespacing mechanism will allow us to use a more accurate namespace in future if we want to classify all symbols in the Scala parser (i.e., differentiate `type` from `class`/`object` and put them in separate namespaces directly).

Fixes #13849.