### PR TITLE
Fix ProtobufSourcesOverridesField help message

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/target_types.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types.py
@@ -100,8 +100,8 @@ class ProtobufSourcesOverridesField(OverridesField):
         ProtobufSourceTarget.alias,
         (
             "overrides={\n"
-            '  "foo.proto": {"grpc": True]},\n'
-            '  "bar.proto": {"description": "our user model"]},\n'
+            '  "foo.proto": {"grpc": True},\n'
+            '  "bar.proto": {"description": "our user model"},\n'
             '  ("foo.proto", "bar.proto"): {"tags": ["overridden"]},\n'
             "}"
         ),


### PR DESCRIPTION
The help message for `overrides` on `protobuf_sources()` currently contain a couple of syntax errors. This PR fixes that :)