### PR TITLE
Upgrade Pex to 2.1.83.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -15,7 +15,7 @@ humbug==0.2.7
 
 ijson==3.1.4
 packaging==21.3
-pex==2.1.82
+pex==2.1.83
 psutil==5.9.0
 # This should be compatible with pytest.py, although it can be looser so that we don't
 # over-constrain pantsbuild.pants.testutil

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -18,7 +18,7 @@
 //     "ijson==3.1.4",
 //     "mypy-typing-asserts==0.1.1",
 //     "packaging==21.3",
-//     "pex==2.1.82",
+//     "pex==2.1.83",
 //     "psutil==5.9.0",
 //     "pydevd-pycharm==203.5419.8",
 //     "pytest<7.1.0,>=6.2.4",
@@ -548,13 +548,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "55bad4a5ec5234ed38be048e447f5141040b1b34b402590df3634e184e328878",
-              "url": "https://files.pythonhosted.org/packages/83/7a/19323757673123bfd3ebea98903da0a534b482dd360f71bff3475fc9b0d3/pex-2.1.82-py2.py3-none-any.whl"
+              "hash": "79fe416ad37aaaf4eb42873188e2d7509df1589edf3e75072a828d79d525eda7",
+              "url": "https://files.pythonhosted.org/packages/62/b7/fc2945105ae6f355afce3bc256a1854ceebcb14997af0079c29f7ab1a403/pex-2.1.83-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5706e970a3ed3c7ff8dc4fa57f35247a7f09bd7f10b536baa341f44b64576d89",
-              "url": "https://files.pythonhosted.org/packages/5a/56/ffefb9ce4512e68b956722d3916cee0f180be03ed4894cb7945d75acec26/pex-2.1.82.tar.gz"
+              "hash": "67a10afc4ec492129d90a0496e09dfde1110c802d8e3d5219daed1c44e379d65",
+              "url": "https://files.pythonhosted.org/packages/e1/15/bb22e9c5c2a5c2f9ab967aa09451eb39a8cdc8c606a755a8e5a4c7ff887d/pex-2.1.83.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -562,7 +562,7 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.11,>=2.7",
-          "version": "2.1.82"
+          "version": "2.1.83"
         },
         {
           "artifacts": [
@@ -1538,14 +1538,14 @@
         }
       ],
       "platform_tag": [
-        "cp310",
-        "cp310",
+        "cp37",
+        "cp37m",
         "manylinux_2_35_x86_64"
       ]
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.82",
+  "pex_version": "2.1.83",
   "prefer_older_binary": false,
   "requirements": [
     "PyYAML<7.0,>=6.0",
@@ -1557,7 +1557,7 @@
     "ijson==3.1.4",
     "mypy-typing-asserts==0.1.1",
     "packaging==21.3",
-    "pex==2.1.82",
+    "pex==2.1.83",
     "psutil==5.9.0",
     "pydevd-pycharm==203.5419.8",
     "pytest<7.1.0,>=6.2.4",

--- a/src/python/pants/backend/python/subsystems/lambdex.lock
+++ b/src/python/pants/backend/python/subsystems/lambdex.lock
@@ -49,13 +49,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "55bad4a5ec5234ed38be048e447f5141040b1b34b402590df3634e184e328878",
-              "url": "https://files.pythonhosted.org/packages/83/7a/19323757673123bfd3ebea98903da0a534b482dd360f71bff3475fc9b0d3/pex-2.1.82-py2.py3-none-any.whl"
+              "hash": "79fe416ad37aaaf4eb42873188e2d7509df1589edf3e75072a828d79d525eda7",
+              "url": "https://files.pythonhosted.org/packages/62/b7/fc2945105ae6f355afce3bc256a1854ceebcb14997af0079c29f7ab1a403/pex-2.1.83-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5706e970a3ed3c7ff8dc4fa57f35247a7f09bd7f10b536baa341f44b64576d89",
-              "url": "https://files.pythonhosted.org/packages/5a/56/ffefb9ce4512e68b956722d3916cee0f180be03ed4894cb7945d75acec26/pex-2.1.82.tar.gz"
+              "hash": "67a10afc4ec492129d90a0496e09dfde1110c802d8e3d5219daed1c44e379d65",
+              "url": "https://files.pythonhosted.org/packages/e1/15/bb22e9c5c2a5c2f9ab967aa09451eb39a8cdc8c606a755a8e5a4c7ff887d/pex-2.1.83.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -63,18 +63,18 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.11,>=2.7",
-          "version": "2.1.82"
+          "version": "2.1.83"
         }
       ],
       "platform_tag": [
-        "cp310",
-        "cp310",
+        "cp37",
+        "cp37m",
         "manylinux_2_35_x86_64"
       ]
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.82",
+  "pex_version": "2.1.83",
   "prefer_older_binary": false,
   "requirements": [
     "lambdex==0.1.6"

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -39,9 +39,9 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."
 
-    default_version = "v2.1.82"
+    default_version = "v2.1.83"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.1.82,<3.0"
+    version_constraints = ">=2.1.83,<3.0"
 
     @classproperty
     def default_known_versions(cls):
@@ -50,8 +50,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "f39219166e8e47ebf2386079bd66ba3ae337d6d70edf6465a774968a75988825",
-                    "3741517",
+                    "0a5e73e6e268cc9c7cb78790b8475df846b361ded567e57c6df3847de654ca87",
+                    "3741694",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64"]


### PR DESCRIPTION
This picks up a fix for the ambient interpreter not matching ICs for
universal locks that resolve sdist primary artifacts. See the Pex
changelog here:
  https://github.com/pantsbuild/pex/releases/tag/v2.1.83

[ci skip-rust]
[ci skip-build-wheels]