### PR TITLE
BSP resolve filtering observes computed default values of resolve fields

### DIFF
--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -31,6 +31,8 @@ from pants.bsp.util_rules.targets import (
     BSPBuildTargetsMetadataResult,
     BSPDependencyModulesRequest,
     BSPDependencyModulesResult,
+    BSPResolveFieldFactoryRequest,
+    BSPResolveFieldFactoryResult,
 )
 from pants.engine.addresses import Addresses
 from pants.engine.fs import (
@@ -89,12 +91,14 @@ class ScalaMetadataFieldSet(FieldSet):
     resolve: JvmResolveField
 
 
+class ScalaBSPResolveFieldFactoryRequest(BSPResolveFieldFactoryRequest):
+    resolve_prefix = "jvm"
+
+
 class ScalaBSPBuildTargetsMetadataRequest(BSPBuildTargetsMetadataRequest):
     language_id = LANGUAGE_ID
     can_merge_metadata_from = ("java",)
     field_set_type = ScalaMetadataFieldSet
-    resolve_prefix = "jvm"
-    resolve_field = JvmResolveField
 
 
 @dataclass(frozen=True)
@@ -148,6 +152,16 @@ async def materialize_scala_runtime_jars(
     )
     materialized_classpath = await Get(Snapshot, Digest, materialized_classpath_digest)
     return MaterializeScalaRuntimeJarsResult(materialized_classpath)
+
+
+@rule
+def bsp_resolve_field_factory(
+    request: ScalaBSPResolveFieldFactoryRequest,
+    jvm: JvmSubsystem,
+) -> BSPResolveFieldFactoryResult:
+    return BSPResolveFieldFactoryResult(
+        lambda target: target.get(JvmResolveField).normalized_value(jvm)
+    )
 
 
 @rule
@@ -456,6 +470,7 @@ def rules():
         *collect_rules(),
         UnionRule(BSPLanguageSupport, ScalaBSPLanguageSupport),
         UnionRule(BSPBuildTargetsMetadataRequest, ScalaBSPBuildTargetsMetadataRequest),
+        UnionRule(BSPResolveFieldFactoryRequest, ScalaBSPResolveFieldFactoryRequest),
         UnionRule(BSPHandlerMapping, ScalacOptionsHandlerMapping),
         UnionRule(BSPHandlerMapping, ScalaMainClassesHandlerMapping),
         UnionRule(BSPHandlerMapping, ScalaTestClassesHandlerMapping),

--- a/src/python/pants/bsp/util_rules/targets.py
+++ b/src/python/pants/bsp/util_rules/targets.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import ClassVar, Generic, Sequence, Type, TypeVar
 
 import toml
+from typing_extensions import Protocol
 
 from pants.base.build_root import BuildRoot
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
@@ -43,7 +44,7 @@ from pants.engine.target import (
     SourcesField,
     SourcesPaths,
     SourcesPathsRequest,
-    StringField,
+    Target,
     Targets,
 )
 from pants.engine.unions import UnionMembership, UnionRule, union
@@ -58,14 +59,34 @@ _FS = TypeVar("_FS", bound=FieldSet)
 
 @union
 @dataclass(frozen=True)
-class BSPResolveFilterRequest(Generic[_FS]):
+class BSPResolveFieldFactoryRequest(Generic[_FS]):
+    """Requests an implementation of `BSPResolveFieldFactory` which can filter resolve fields.
+
+    TODO: This is to work around the fact that Field value defaulting cannot have arbitrary
+    subsystem requirements, and so `JvmResolveField` and `PythonResolveField` have methods
+    which compute the true value of the field given a subsytem argument. Consumers need to
+    be type aware, and `@rules` cannot have dynamic requirements.
+
+    See https://github.com/pantsbuild/pants/issues/12934 about potentially allowing unions
+    (including Field registrations) to have `@rule_helper` methods, which would allow the
+    computation of an AsyncFields to directly require a subsystem.
+    """
+
     resolve_prefix: ClassVar[str]
-    resolve_field: ClassVar[Type[StringField]]
+
+
+# TODO: Workaround for https://github.com/python/mypy/issues/5485, because we cannot directly use
+# a Callable.
+class _ResolveFieldFactory(Protocol):
+    def __call__(self, target: Target) -> str | None:
+        pass
 
 
 @dataclass(frozen=True)
-class BSPResolveFilter:
-    include: Callable[[str], bool]
+class BSPResolveFieldFactoryResult:
+    """Computes the resolve field value for a Target, if applicable."""
+
+    resolve_field_value: _ResolveFieldFactory
 
 
 @union
@@ -246,19 +267,17 @@ async def resolve_bsp_build_target_addresses(
             f"prefix like `$lang:$filter`, but the configured value: `{resolve_filter}` did not."
         )
 
-    requests = union_membership.get(BSPResolveFilterRequest)
-    filters = await MultiGet(
-        Get(BSPResolveFilter, BSPResolveFilterRequest, request)
-        for request in requests
+    # TODO: See `BSPResolveFieldFactoryRequest` re: this awkwardness.
+    factories = await MultiGet(
+        Get(BSPResolveFieldFactoryResult, BSPResolveFieldFactoryRequest, request())
+        for request in union_membership.get(BSPResolveFieldFactoryRequest)
+        if request.resolve_prefix == resolve_prefix
     )
 
-    resolve_field_filters = [
-        bbtmr.resolve_field, 
-        for bbtmr, resolve_filter in zip(requests, filters)
-        if bbtmr.resolve_prefix == resolve_prefix
-    ]
     return Targets(
-        t for t in targets if any(t.get(f).value == resolve_value for f in resolve_fields)
+        t
+        for t in targets
+        if any((factory.resolve_field_value)(t) == resolve_value for factory in factories)
     )
 
 


### PR DESCRIPTION
The underlying issue causing us not to have any metadata to merge in #15201 was that the targets in the example were using the default resolve, and the resolve filtering from #15064 was not accounting for default values.

This fixes resolve filtering by adding another union which returns a type which can compute the resolve Field value (using a subsystem in this case).