### PR TITLE
Upgrade Pex to 2.1.84.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -15,7 +15,7 @@ humbug==0.2.7
 
 ijson==3.1.4
 packaging==21.3
-pex==2.1.83
+pex==2.1.84
 psutil==5.9.0
 # This should be compatible with pytest.py, although it can be looser so that we don't
 # over-constrain pantsbuild.pants.testutil

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -18,7 +18,7 @@
 //     "ijson==3.1.4",
 //     "mypy-typing-asserts==0.1.1",
 //     "packaging==21.3",
-//     "pex==2.1.83",
+//     "pex==2.1.84",
 //     "psutil==5.9.0",
 //     "pydevd-pycharm==203.5419.8",
 //     "pytest<7.1.0,>=6.2.4",
@@ -548,13 +548,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "79fe416ad37aaaf4eb42873188e2d7509df1589edf3e75072a828d79d525eda7",
-              "url": "https://files.pythonhosted.org/packages/62/b7/fc2945105ae6f355afce3bc256a1854ceebcb14997af0079c29f7ab1a403/pex-2.1.83-py2.py3-none-any.whl"
+              "hash": "7785d2d79633906c692db272d7299530505403415256a9c5c892883a4c057aa4",
+              "url": "https://files.pythonhosted.org/packages/e4/17/68b51b61b24f5d7056a0c8d1758d576c21e0d6a6e43d449d7dc0bfa3b131/pex-2.1.84-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "67a10afc4ec492129d90a0496e09dfde1110c802d8e3d5219daed1c44e379d65",
-              "url": "https://files.pythonhosted.org/packages/e1/15/bb22e9c5c2a5c2f9ab967aa09451eb39a8cdc8c606a755a8e5a4c7ff887d/pex-2.1.83.tar.gz"
+              "hash": "b633e32f334e3bf3d453a108b4b632430f8a3de908c1ba13067f7c4fcc07a47c",
+              "url": "https://files.pythonhosted.org/packages/82/e3/a019f70b60596782d22382d5593124d9782a9554271248afb099cfc009ae/pex-2.1.84.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -562,7 +562,7 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.11,>=2.7",
-          "version": "2.1.83"
+          "version": "2.1.84"
         },
         {
           "artifacts": [
@@ -1237,19 +1237,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "ff7500641824f881b2c7bde4cc57e6c3abf03d1e005bae83aca752e77213a5da",
-              "url": "https://files.pythonhosted.org/packages/a2/cc/8b9e4575e16baec35b7e948c1ac6e596dba96eafc8fc0ed42795fb2b709e/types_urllib3-1.26.13-py3-none-any.whl"
+              "hash": "5d2388aa76395b1e3999ff789ea5b3283677dad8e9bcf3d9117ba19271fd35d9",
+              "url": "https://files.pythonhosted.org/packages/cf/c8/1c6693161687b0898ffcb71bce019f85a3d579c2aabe3a0057fd7c5152fb/types_urllib3-1.26.14-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "40f8fb5e8cd7d57e8aefdee3fdd5e930aa1a1bb4179cdadd55226cea588af790",
-              "url": "https://files.pythonhosted.org/packages/72/fb/ee3ec52f24dc4fcac2d685299409b4d10ca5000e88d2515eccc7f2a5ffc7/types-urllib3-1.26.13.tar.gz"
+              "hash": "2a2578e4b36341ccd240b00fccda9826988ff0589a44ba4a664bbd69ef348d27",
+              "url": "https://files.pythonhosted.org/packages/86/75/396edf6735c6531b3e4d5ecb382ea644ad28a601f8262f92279cc092110b/types-urllib3-1.26.14.tar.gz"
             }
           ],
           "project_name": "types-urllib3",
           "requires_dists": [],
           "requires_python": null,
-          "version": "1.26.13"
+          "version": "1.26.14"
         },
         {
           "artifacts": [
@@ -1545,7 +1545,7 @@
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.83",
+  "pex_version": "2.1.84",
   "prefer_older_binary": false,
   "requirements": [
     "PyYAML<7.0,>=6.0",
@@ -1557,7 +1557,7 @@
     "ijson==3.1.4",
     "mypy-typing-asserts==0.1.1",
     "packaging==21.3",
-    "pex==2.1.83",
+    "pex==2.1.84",
     "psutil==5.9.0",
     "pydevd-pycharm==203.5419.8",
     "pytest<7.1.0,>=6.2.4",

--- a/src/python/pants/backend/python/subsystems/lambdex.lock
+++ b/src/python/pants/backend/python/subsystems/lambdex.lock
@@ -49,13 +49,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "79fe416ad37aaaf4eb42873188e2d7509df1589edf3e75072a828d79d525eda7",
-              "url": "https://files.pythonhosted.org/packages/62/b7/fc2945105ae6f355afce3bc256a1854ceebcb14997af0079c29f7ab1a403/pex-2.1.83-py2.py3-none-any.whl"
+              "hash": "7785d2d79633906c692db272d7299530505403415256a9c5c892883a4c057aa4",
+              "url": "https://files.pythonhosted.org/packages/e4/17/68b51b61b24f5d7056a0c8d1758d576c21e0d6a6e43d449d7dc0bfa3b131/pex-2.1.84-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "67a10afc4ec492129d90a0496e09dfde1110c802d8e3d5219daed1c44e379d65",
-              "url": "https://files.pythonhosted.org/packages/e1/15/bb22e9c5c2a5c2f9ab967aa09451eb39a8cdc8c606a755a8e5a4c7ff887d/pex-2.1.83.tar.gz"
+              "hash": "b633e32f334e3bf3d453a108b4b632430f8a3de908c1ba13067f7c4fcc07a47c",
+              "url": "https://files.pythonhosted.org/packages/82/e3/a019f70b60596782d22382d5593124d9782a9554271248afb099cfc009ae/pex-2.1.84.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -63,7 +63,7 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.11,>=2.7",
-          "version": "2.1.83"
+          "version": "2.1.84"
         }
       ],
       "platform_tag": [
@@ -74,7 +74,7 @@
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.83",
+  "pex_version": "2.1.84",
   "prefer_older_binary": false,
   "requirements": [
     "lambdex==0.1.6"

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -39,9 +39,9 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."
 
-    default_version = "v2.1.83"
+    default_version = "v2.1.84"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.1.83,<3.0"
+    version_constraints = ">=2.1.84,<3.0"
 
     @classproperty
     def default_known_versions(cls):
@@ -50,8 +50,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "0a5e73e6e268cc9c7cb78790b8475df846b361ded567e57c6df3847de654ca87",
-                    "3741694",
+                    "e17018c3bc902f0717fd4b2806f6cbb35cfafa5180d8cfa094b9fff11197805b",
+                    "3741845",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64"]


### PR DESCRIPTION
This picks up a fix for handling pre-release versions in `--lock`
resolves. See the changelog here:
  https://github.com/pantsbuild/pex/releases/tag/v2.1.84

[ci skip-rust]
[ci skip-build-wheels]