### PR TITLE
Upgrade Pex to 2.1.84. (Cherry-picks of #15200, #15281 & #15288)

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -15,7 +15,7 @@ humbug==0.2.7
 
 ijson==3.1.4
 packaging==21.3
-pex==2.1.80
+pex==2.1.84
 psutil==5.9.0
 # This should be compatible with pytest.py, although it can be looser so that we don't
 # over-constrain pantsbuild.pants.testutil

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -18,7 +18,7 @@
 //     "ijson==3.1.4",
 //     "mypy-typing-asserts==0.1.1",
 //     "packaging==21.3",
-//     "pex==2.1.80",
+//     "pex==2.1.84",
 //     "psutil==5.9.0",
 //     "pydevd-pycharm==203.5419.8",
 //     "pytest<7.1.0,>=6.2.4",
@@ -548,13 +548,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "3d606eb7045904bb96f879d142aae742d0dc029033d00bdbf6e411a2b2162259",
-              "url": "https://files.pythonhosted.org/packages/02/d2/e0a7e9cfe553cc0f558cbb678af152a11f8ad9f7f16810db9e772f099c0d/pex-2.1.80-py2.py3-none-any.whl"
+              "hash": "7785d2d79633906c692db272d7299530505403415256a9c5c892883a4c057aa4",
+              "url": "https://files.pythonhosted.org/packages/e4/17/68b51b61b24f5d7056a0c8d1758d576c21e0d6a6e43d449d7dc0bfa3b131/pex-2.1.84-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9bd1ccbcba05a60e5a5283649cb745ed7fbe5c493d8fbd3ea9a89deb6eee62fb",
-              "url": "https://files.pythonhosted.org/packages/0e/d2/27ecc4441dde1ceb5edb4cd67f937b544ea17f38be30b85d86ef15f07382/pex-2.1.80.tar.gz"
+              "hash": "b633e32f334e3bf3d453a108b4b632430f8a3de908c1ba13067f7c4fcc07a47c",
+              "url": "https://files.pythonhosted.org/packages/82/e3/a019f70b60596782d22382d5593124d9782a9554271248afb099cfc009ae/pex-2.1.84.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -562,7 +562,7 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.11,>=2.7",
-          "version": "2.1.80"
+          "version": "2.1.84"
         },
         {
           "artifacts": [
@@ -1237,19 +1237,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "ff7500641824f881b2c7bde4cc57e6c3abf03d1e005bae83aca752e77213a5da",
-              "url": "https://files.pythonhosted.org/packages/a2/cc/8b9e4575e16baec35b7e948c1ac6e596dba96eafc8fc0ed42795fb2b709e/types_urllib3-1.26.13-py3-none-any.whl"
+              "hash": "5d2388aa76395b1e3999ff789ea5b3283677dad8e9bcf3d9117ba19271fd35d9",
+              "url": "https://files.pythonhosted.org/packages/cf/c8/1c6693161687b0898ffcb71bce019f85a3d579c2aabe3a0057fd7c5152fb/types_urllib3-1.26.14-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "40f8fb5e8cd7d57e8aefdee3fdd5e930aa1a1bb4179cdadd55226cea588af790",
-              "url": "https://files.pythonhosted.org/packages/72/fb/ee3ec52f24dc4fcac2d685299409b4d10ca5000e88d2515eccc7f2a5ffc7/types-urllib3-1.26.13.tar.gz"
+              "hash": "2a2578e4b36341ccd240b00fccda9826988ff0589a44ba4a664bbd69ef348d27",
+              "url": "https://files.pythonhosted.org/packages/86/75/396edf6735c6531b3e4d5ecb382ea644ad28a601f8262f92279cc092110b/types-urllib3-1.26.14.tar.gz"
             }
           ],
           "project_name": "types-urllib3",
           "requires_dists": [],
           "requires_python": null,
-          "version": "1.26.13"
+          "version": "1.26.14"
         },
         {
           "artifacts": [
@@ -1538,14 +1538,14 @@
         }
       ],
       "platform_tag": [
-        "cp310",
-        "cp310",
+        "cp37",
+        "cp37m",
         "manylinux_2_35_x86_64"
       ]
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.80",
+  "pex_version": "2.1.84",
   "prefer_older_binary": false,
   "requirements": [
     "PyYAML<7.0,>=6.0",
@@ -1557,7 +1557,7 @@
     "ijson==3.1.4",
     "mypy-typing-asserts==0.1.1",
     "packaging==21.3",
-    "pex==2.1.80",
+    "pex==2.1.84",
     "psutil==5.9.0",
     "pydevd-pycharm==203.5419.8",
     "pytest<7.1.0,>=6.2.4",

--- a/src/python/pants/backend/python/subsystems/lambdex.lock
+++ b/src/python/pants/backend/python/subsystems/lambdex.lock
@@ -49,13 +49,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "3d606eb7045904bb96f879d142aae742d0dc029033d00bdbf6e411a2b2162259",
-              "url": "https://files.pythonhosted.org/packages/02/d2/e0a7e9cfe553cc0f558cbb678af152a11f8ad9f7f16810db9e772f099c0d/pex-2.1.80-py2.py3-none-any.whl"
+              "hash": "7785d2d79633906c692db272d7299530505403415256a9c5c892883a4c057aa4",
+              "url": "https://files.pythonhosted.org/packages/e4/17/68b51b61b24f5d7056a0c8d1758d576c21e0d6a6e43d449d7dc0bfa3b131/pex-2.1.84-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9bd1ccbcba05a60e5a5283649cb745ed7fbe5c493d8fbd3ea9a89deb6eee62fb",
-              "url": "https://files.pythonhosted.org/packages/0e/d2/27ecc4441dde1ceb5edb4cd67f937b544ea17f38be30b85d86ef15f07382/pex-2.1.80.tar.gz"
+              "hash": "b633e32f334e3bf3d453a108b4b632430f8a3de908c1ba13067f7c4fcc07a47c",
+              "url": "https://files.pythonhosted.org/packages/82/e3/a019f70b60596782d22382d5593124d9782a9554271248afb099cfc009ae/pex-2.1.84.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -63,18 +63,18 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.11,>=2.7",
-          "version": "2.1.80"
+          "version": "2.1.84"
         }
       ],
       "platform_tag": [
-        "cp310",
-        "cp310",
+        "cp37",
+        "cp37m",
         "manylinux_2_35_x86_64"
       ]
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.80",
+  "pex_version": "2.1.84",
   "prefer_older_binary": false,
   "requirements": [
     "lambdex==0.1.6"

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -39,9 +39,9 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."
 
-    default_version = "v2.1.80"
+    default_version = "v2.1.84"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.1.80,<3.0"
+    version_constraints = ">=2.1.84,<3.0"
 
     @classproperty
     def default_known_versions(cls):
@@ -50,8 +50,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "5485e1e770ef93e6450eee8d2d7ab495e192e5033c1f37d2b20aa306684196be",
-                    "3741488",
+                    "e17018c3bc902f0717fd4b2806f6cbb35cfafa5180d8cfa094b9fff11197805b",
+                    "3741845",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64"]


### PR DESCRIPTION
This change upgrades Pex from 2.1.80 up through 2.1.84 to pull in
several fixes.
---
Upgrade Pex to 2.1.82. (#15200)

This fixes a corner-case for distributions built with setuptools that
have funky project names.

See the changelog here:
  https://github.com/pantsbuild/pex/releases/tag/v2.1.82

(cherry picked from commit f8b672c4478408ef226f24769c191e9f594cdd87)

Upgrade Pex to 2.1.83. (#15281)

This picks up a fix for the ambient interpreter not matching ICs for
universal locks that resolve sdist primary artifacts. See the Pex
changelog here:
  https://github.com/pantsbuild/pex/releases/tag/v2.1.83

(cherry picked from commit 465381eaf7c54595ec35f529e9d500671cd6ab93)

Upgrade Pex to 2.1.84. (#15288)

This picks up a fix for handling pre-release versions in `--lock`
resolves. See the changelog here:
  https://github.com/pantsbuild/pex/releases/tag/v2.1.84

(cherry picked from commit 6c10ee8372d69eb635a1b986d958405c5c331fe0)

[ci skip-rust]
[ci skip-build-wheels]