### PR TITLE
Fix a bug in the python venv export logic. (cherrypick #15294)

### DIFF
--- a/src/python/pants/backend/python/goals/export_test.py
+++ b/src/python/pants/backend/python/goals/export_test.py
@@ -69,7 +69,9 @@ def test_export_venvs(rule_runner: RuleRunner) -> None:
             assert len(result.post_processing_cmds) == 2
 
             ppc0 = result.post_processing_cmds[0]
-            assert ppc0.argv == (
+            assert ppc0.argv[1:] == (
+                # The first arg is the full path to the python interpreter, which we
+                # don't easily know here, so we ignore it in this comparison.
                 os.path.join("{digest_root}", ".", "pex"),
                 os.path.join("{digest_root}", "requirements.pex"),
                 "venv",

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -217,6 +217,12 @@ class PexRequest(EngineAwareParameter):
                 f"Given platform constraints {self.platforms} for internal only pex request: "
                 f"{self}."
             )
+        if self.internal_only and self.complete_platforms:
+            raise ValueError(
+                "Internal only PEXes can only constrain interpreters with interpreter_constraints."
+                f"Given complete_platform constraints {self.complete_platforms} for internal only "
+                f"pex request: {self}."
+            )
         if self.python and self.platforms:
             raise ValueError(
                 "Only one of platforms or a specific interpreter may be set. Got "
@@ -347,6 +353,7 @@ async def build_pex(
     # `--interpreter-constraint` only makes sense in the context of building locally. These two
     # flags are mutually exclusive. See https://github.com/pantsbuild/pex/issues/957.
     if request.platforms or request.complete_platforms:
+        # Note that this means that this is not an internal-only pex.
         # TODO(#9560): consider validating that these platforms are valid with the interpreter
         #  constraints.
         argv.extend(request.platforms.generate_pex_arg_list())


### PR DESCRIPTION
Previously, and partly as a legacy of an older implementation, we acted as if the requirements pex
had interpreter constraints baked into it. We relied on this when detecting the version of that interpreter.

But a requirements pex is internal-only, and so has no interpreter constraints. So in practice we
were picking whatever interpreter was used to run the pex, and that may not have been compatible
with the relevant constraints.

Now we always use a compatible interpreter.

[ci skip-rust]

[ci skip-build-wheels]