### PR TITLE
Don't strip source roots when building dists with an existing setup.py

### DIFF
--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -52,7 +52,6 @@ from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.base.specs import AddressSpecs, AscendantAddresses
 from pants.core.goals.package import BuiltPackage, BuiltPackageArtifact, PackageFieldSet
 from pants.core.target_types import FileSourceField, ResourceSourceField
-from pants.core.util_rules.stripped_source_files import StrippedFileName, StrippedFileNameRequest
 from pants.engine.addresses import Address, UnparsedAddressInputs
 from pants.engine.collection import Collection, DeduplicatedCollection
 from pants.engine.fs import (
@@ -511,19 +510,8 @@ async def generate_chroot(
                 targets=transitive_targets.closure, include_resources=True, include_files=True
             ),
         )
-        source_digest = source_files.source_files.snapshot.digest
-        # To get the stripped target directory we need a dummy path under it. Note that this
-        # is just a dummy string, required because our source root stripping mechanism assumes
-        # that paths are files and starts searching from the parent dir. It doesn't correspond
-        # to an actual file on disk, so there are no collision issues.
-        stripped = await Get(
-            StrippedFileName,
-            StrippedFileNameRequest(
-                os.path.join(request.exported_target.target.address.spec_path, "dummy.py")
-            ),
-        )
-        working_directory = os.path.dirname(stripped.value)
-        chroot_digest = source_digest
+        chroot_digest = source_files.source_files.snapshot.digest
+        working_directory = request.exported_target.target.address.spec_path
     return DistBuildChroot(chroot_digest, working_directory)
 
 

--- a/src/python/pants/backend/python/goals/setup_py_test.py
+++ b/src/python/pants/backend/python/goals/setup_py_test.py
@@ -183,7 +183,7 @@ def test_use_existing_setup_script(chroot_rule_runner) -> None:
             "src/python/foo/resources/js/code.js": "",
             "files/BUILD": 'file(source="README.txt")',
             "files/README.txt": "",
-            "src/python/BUILD": textwrap.dedent(
+            "BUILD": textwrap.dedent(
                 """
                 python_distribution(
                     name='foo-dist',
@@ -199,13 +199,14 @@ def test_use_existing_setup_script(chroot_rule_runner) -> None:
                 python_sources(name="setup", dependencies=["src/python/foo"])
                 """
             ),
-            "src/python/setup.py": textwrap.dedent(
+            "setup.py": textwrap.dedent(
                 """
                 from setuptools import setup
 
                 setup(
                     name = "foo",
                     version = "1.2.3",
+                    package_dir={"": "src/python"},
                     packages = ["foo"],
                 )
                 """
@@ -230,15 +231,15 @@ def test_use_existing_setup_script(chroot_rule_runner) -> None:
         [
             "setup.py",
             "files/README.txt",
-            "foo/bar/__init__.py",
-            "foo/bar/bar.py",
-            "foo/bar/bar.pyi",
-            "foo/resources/js/code.js",
-            "foo/__init__.py",
-            "foo/foo.py",
+            "src/python/foo/bar/__init__.py",
+            "src/python/foo/bar/bar.py",
+            "src/python/foo/bar/bar.pyi",
+            "src/python/foo/resources/js/code.js",
+            "src/python/foo/__init__.py",
+            "src/python/foo/foo.py",
         ],
         None,
-        Address("src/python", target_name="foo-dist"),
+        Address("", target_name="foo-dist"),
     )
 
 


### PR DESCRIPTION
When generating a setup.py we strip source roots, which is fine because we
control the expected layout in the generated setup.py.

However we were reusing that code path when working with an existing setup.py,
and that is incorrect - the existing setup.py expects paths relative to itself, and it
may not be in the same source root as the code it builds (e.g., it could be at the
root, while the code it builds is in src/python).

We now get sources separately for the existing setup.py case. This has the added
advantage of not running package and resource discovery logic that is only used
for generating setup.py.

[ci skip-rust]
[ci skip-build-wheels]