### PR TITLE
Eagerly skip tools with default lockfiles in `export-lockfiles` goal

### DIFF
--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -72,7 +72,7 @@ class GeneratePythonLockfile(GenerateLockfile):
         rather than the option `--interpreter-constraints`, you must pass the arg
         `interpreter_constraints`.
         """
-        if not subsystem.uses_lockfile:
+        if not subsystem.uses_custom_lockfile:
             return cls(
                 requirements=FrozenOrderedSet(),
                 interpreter_constraints=InterpreterConstraints(),

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -104,14 +104,14 @@ class BanditLockfileSentinel(GenerateToolLockfileSentinel):
 @rule(
     desc=(
         "Determine all Python interpreter versions used by Bandit in your project (for lockfile "
-        "usage)"
+        "generation)"
     ),
     level=LogLevel.DEBUG,
 )
 async def setup_bandit_lockfile(
     _: BanditLockfileSentinel, bandit: Bandit, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
-    if not bandit.uses_lockfile:
+    if not bandit.uses_custom_lockfile:
         return GeneratePythonLockfile.from_tool(
             bandit, use_pex=python_setup.generate_lockfiles_with_pex
         )
@@ -128,7 +128,13 @@ class BanditExportSentinel(ExportPythonToolSentinel):
     pass
 
 
-@rule
+@rule(
+    desc=(
+        "Determine all Python interpreter versions used by Bandit in your project (for "
+        "`export` goal)"
+    ),
+    level=LogLevel.DEBUG,
+)
 async def bandit_export(
     _: BanditExportSentinel, bandit: Bandit, python_setup: PythonSetup
 ) -> ExportPythonTool:

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -98,13 +98,13 @@ class BlackLockfileSentinel(GenerateToolLockfileSentinel):
 
 
 @rule(
-    desc="Determine if Black should use Python 3.8+ (for lockfile usage)",
+    desc="Determine Black interpreter constraints (for lockfile generation)",
     level=LogLevel.DEBUG,
 )
 async def setup_black_lockfile(
     _: BlackLockfileSentinel, black: Black, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
-    if not black.uses_lockfile:
+    if not black.uses_custom_lockfile:
         return GeneratePythonLockfile.from_tool(
             black, use_pex=python_setup.generate_lockfiles_with_pex
         )
@@ -119,7 +119,7 @@ class BlackExportSentinel(ExportPythonToolSentinel):
     pass
 
 
-@rule
+@rule(desc="Determine MyPy interpreter constraints (for `export` goal)", level=LogLevel.DEBUG)
 async def black_export(
     _: BlackExportSentinel, black: Black, python_setup: PythonSetup
 ) -> ExportPythonTool:

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -274,7 +274,7 @@ class Flake8LockfileSentinel(GenerateToolLockfileSentinel):
 @rule(
     desc=(
         "Determine all Python interpreter versions used by Flake8 in your project (for lockfile "
-        "usage)"
+        "generation)"
     ),
     level=LogLevel.DEBUG,
 )
@@ -284,7 +284,7 @@ async def setup_flake8_lockfile(
     flake8: Flake8,
     python_setup: PythonSetup,
 ) -> GeneratePythonLockfile:
-    if not flake8.uses_lockfile:
+    if not flake8.uses_custom_lockfile:
         return GeneratePythonLockfile.from_tool(
             flake8, use_pex=python_setup.generate_lockfiles_with_pex
         )
@@ -307,7 +307,13 @@ class Flake8ExportSentinel(ExportPythonToolSentinel):
     pass
 
 
-@rule
+@rule(
+    desc=(
+        "Determine all Python interpreter versions used by Flake8 in your project (for "
+        "`export` goal)"
+    ),
+    level=LogLevel.DEBUG,
+)
 async def flake8_export(
     _: Flake8ExportSentinel,
     flake8: Flake8,

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -284,7 +284,7 @@ class PylintLockfileSentinel(GenerateToolLockfileSentinel):
 @rule(
     desc=(
         "Determine all Python interpreter versions used by Pylint in your project (for "
-        "lockfile usage)"
+        "lockfile generation)"
     ),
     level=LogLevel.DEBUG,
 )
@@ -294,7 +294,7 @@ async def setup_pylint_lockfile(
     pylint: Pylint,
     python_setup: PythonSetup,
 ) -> GeneratePythonLockfile:
-    if not pylint.uses_lockfile:
+    if not pylint.uses_custom_lockfile:
         return GeneratePythonLockfile.from_tool(
             pylint, use_pex=python_setup.generate_lockfiles_with_pex
         )
@@ -317,7 +317,13 @@ class PylintExportSentinel(ExportPythonToolSentinel):
     pass
 
 
-@rule
+@rule(
+    desc=(
+        "Determine all Python interpreter versions used by Pylint in your project (for "
+        "`export` goal)"
+    ),
+    level=LogLevel.DEBUG,
+)
 async def pylint_export(
     _: PylintExportSentinel,
     pylint: Pylint,

--- a/src/python/pants/backend/python/subsystems/ipython.py
+++ b/src/python/pants/backend/python/subsystems/ipython.py
@@ -52,14 +52,14 @@ class IPythonLockfileSentinel(GenerateToolLockfileSentinel):
 @rule(
     desc=(
         "Determine all Python interpreter versions used by iPython in your project (for lockfile "
-        "usage)"
+        "generation)"
     ),
     level=LogLevel.DEBUG,
 )
 async def setup_ipython_lockfile(
     _: IPythonLockfileSentinel, ipython: IPython, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
-    if not ipython.uses_lockfile:
+    if not ipython.uses_custom_lockfile:
         return GeneratePythonLockfile.from_tool(
             ipython, use_pex=python_setup.generate_lockfiles_with_pex
         )

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -217,14 +217,14 @@ class PytestLockfileSentinel(GenerateToolLockfileSentinel):
 @rule(
     desc=(
         "Determine all Python interpreter versions used by Pytest in your project (for "
-        "lockfile usage)"
+        "lockfile generation)"
     ),
     level=LogLevel.DEBUG,
 )
 async def setup_pytest_lockfile(
     _: PytestLockfileSentinel, pytest: PyTest, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
-    if not pytest.uses_lockfile:
+    if not pytest.uses_custom_lockfile:
         return GeneratePythonLockfile.from_tool(
             pytest, use_pex=python_setup.generate_lockfiles_with_pex
         )
@@ -241,7 +241,13 @@ class PytestExportSentinel(ExportPythonToolSentinel):
     pass
 
 
-@rule
+@rule(
+    desc=(
+        "Determine all Python interpreter versions used by Pytest in your project (for "
+        "`export` goal)"
+    ),
+    level=LogLevel.DEBUG,
+)
 async def pytest_export(
     _: PytestExportSentinel, pytest: PyTest, python_setup: PythonSetup
 ) -> ExportPythonTool:

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -178,7 +178,19 @@ class PythonToolRequirementsBase(Subsystem):
 
     @property
     def uses_lockfile(self) -> bool:
+        """Return true if the tool is installed from a lockfile.
+
+        Note that this lockfile may be the default lockfile Pants distributes.
+        """
         return self.register_lockfile and self.lockfile != NO_TOOL_LOCKFILE
+
+    @property
+    def uses_custom_lockfile(self) -> bool:
+        """Return true if the tool is installed from a custom lockfile the user sets up."""
+        return self.register_lockfile and self.lockfile not in (
+            NO_TOOL_LOCKFILE,
+            DEFAULT_TOOL_LOCKFILE,
+        )
 
     @property
     def interpreter_constraints(self) -> InterpreterConstraints:

--- a/src/python/pants/backend/python/subsystems/setuptools.py
+++ b/src/python/pants/backend/python/subsystems/setuptools.py
@@ -58,7 +58,7 @@ class SetuptoolsLockfileSentinel(GenerateToolLockfileSentinel):
 async def setup_setuptools_lockfile(
     _: SetuptoolsLockfileSentinel, setuptools: Setuptools, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
-    if not setuptools.uses_requirements_from_source_plugins:
+    if not setuptools.uses_custom_lockfile:
         return GeneratePythonLockfile.from_tool(
             setuptools, use_pex=python_setup.generate_lockfiles_with_pex
         )

--- a/src/python/pants/backend/python/subsystems/setuptools.py
+++ b/src/python/pants/backend/python/subsystems/setuptools.py
@@ -49,13 +49,16 @@ class SetuptoolsLockfileSentinel(GenerateToolLockfileSentinel):
 
 
 @rule(
-    desc="Determine all Python interpreter versions used by setuptools in your project",
+    desc=(
+        "Determine all Python interpreter versions used by setuptools in your project "
+        "(for lockfile generation)"
+    ),
     level=LogLevel.DEBUG,
 )
 async def setup_setuptools_lockfile(
     _: SetuptoolsLockfileSentinel, setuptools: Setuptools, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
-    if not setuptools.uses_lockfile:
+    if not setuptools.uses_requirements_from_source_plugins:
         return GeneratePythonLockfile.from_tool(
             setuptools, use_pex=python_setup.generate_lockfiles_with_pex
         )

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -305,7 +305,7 @@ class MyPyLockfileSentinel(GenerateToolLockfileSentinel):
 
 
 @rule(
-    desc="Determine if MyPy should use Python 3.8+ (for lockfile usage)",
+    desc="Determine MyPy interpreter constraints (for lockfile generation)",
     level=LogLevel.DEBUG,
 )
 async def setup_mypy_lockfile(
@@ -314,7 +314,7 @@ async def setup_mypy_lockfile(
     mypy: MyPy,
     python_setup: PythonSetup,
 ) -> GeneratePythonLockfile:
-    if not mypy.uses_lockfile:
+    if not mypy.uses_custom_lockfile:
         return GeneratePythonLockfile.from_tool(
             mypy, use_pex=python_setup.generate_lockfiles_with_pex
         )
@@ -337,7 +337,7 @@ class MyPyExportSentinel(ExportPythonToolSentinel):
     pass
 
 
-@rule
+@rule(desc="Determine MyPy interpreter constraints (for `export` goal)", level=LogLevel.DEBUG)
 async def mypy_export(
     _: MyPyExportSentinel,
     mypy: MyPy,


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/15302.

This also improves the `help` message for the `export` goal integration for tools that must compute interpreter constraints, which is slow.

[ci skip-rust]