### PR TITLE
Upgrade hadolint to 2.10.0 and add linux arm64 support

### DIFF
--- a/src/python/pants/backend/docker/lint/hadolint/rules_integration_test.py
+++ b/src/python/pants/backend/docker/lint/hadolint/rules_integration_test.py
@@ -107,7 +107,7 @@ def test_multiple_targets(rule_runner: RuleRunner) -> None:
 def test_config_files(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            ".hadolint.yaml": "ignored: [DL3006, DL3011]",
+            ".hadolint.yaml": "ignored: [DL3006, DL3061, DL3011]",
             "a/Dockerfile": BAD_FILE,
             "a/BUILD": "docker_image()",
             "b/Dockerfile": BAD_FILE,

--- a/src/python/pants/backend/docker/lint/hadolint/subsystem.py
+++ b/src/python/pants/backend/docker/lint/hadolint/subsystem.py
@@ -14,13 +14,12 @@ class Hadolint(TemplatedExternalTool):
     name = "Hadolint"
     help = "A linter for Dockerfiles."
 
-    default_version = "v2.8.0"
-    # TODO: https://github.com/hadolint/hadolint/issues/411 tracks building and releasing
-    #  hadolint for Linux ARM64.
+    default_version = "v2.10.0"
     default_known_versions = [
-        "v2.8.0|macos_x86_64|27985f257a216ecab06a16e643e8cb0123e7145b5d526cfcb4ce7a31fe99f357|2428944",
-        "v2.8.0|macos_arm64 |27985f257a216ecab06a16e643e8cb0123e7145b5d526cfcb4ce7a31fe99f357|2428944",  # same as mac x86
-        "v2.8.0|linux_x86_64|9dfc155139a1e1e9b3b28f3de9907736b9dfe7cead1c3a0ae7ff0158f3191674|5895708",
+        "v2.10.0|macos_x86_64|59f0523069a857ae918b8ac0774230013f7bcc00c1ea28119c2311353120867a|2514960",
+        "v2.10.0|macos_arm64 |59f0523069a857ae918b8ac0774230013f7bcc00c1ea28119c2311353120867a|2514960",  # same as mac x86
+        "v2.10.0|linux_x86_64|8ee6ff537341681f9e91bae2d5da451b15c575691e33980893732d866d3cefc4|2301804",
+        "v2.10.0|linux_arm64 |b53d5ab10707a585c9e72375d51b7357522300b5329cfa3f91e482687176e128|27954520",
     ]
     default_url_template = (
         "https://github.com/hadolint/hadolint/releases/download/{version}/hadolint-{platform}"
@@ -28,6 +27,7 @@ class Hadolint(TemplatedExternalTool):
     default_url_platform_mapping = {
         "macos_arm64": "Darwin-x86_64",
         "macos_x86_64": "Darwin-x86_64",
+        "linux_arm64": "linux.aarch64",
         "linux_x86_64": "Linux-x86_64",
     }
 

--- a/src/python/pants/backend/docker/lint/hadolint/subsystem.py
+++ b/src/python/pants/backend/docker/lint/hadolint/subsystem.py
@@ -27,7 +27,7 @@ class Hadolint(TemplatedExternalTool):
     default_url_platform_mapping = {
         "macos_arm64": "Darwin-x86_64",
         "macos_x86_64": "Darwin-x86_64",
-        "linux_arm64": "linux.aarch64",
+        "linux_arm64": "Linux-arm64",
         "linux_x86_64": "Linux-x86_64",
     }
 


### PR DESCRIPTION
## Issue(s)
Fixes https://github.com/pantsbuild/pants/issues/15316

## Summary
This upgrades hadolint to 2.10.0 and adds linux arm64 support since that is now available.
Hadolint Changelog: https://github.com/hadolint/hadolint/releases


