### PR TITLE
Remove deprecated traceback formatting argument

### DIFF
--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -425,7 +425,7 @@ impl Failure {
       locals.set_item("tb", tb).unwrap();
       locals.set_item("val", &val).unwrap();
       py.eval(
-        "''.join(traceback.format_exception(value=val, tb=tb))",
+        "''.join(traceback.format_exception(None, value=val, tb=tb))",
         None,
         Some(locals),
       )

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -425,7 +425,7 @@ impl Failure {
       locals.set_item("tb", tb).unwrap();
       locals.set_item("val", &val).unwrap();
       py.eval(
-        "''.join(traceback.format_exception(etype=None, value=val, tb=tb))",
+        "''.join(traceback.format_exception(value=val, tb=tb))",
         None,
         Some(locals),
       )


### PR DESCRIPTION
The [`etype` argument to `format_exception`](https://docs.python.org/3/library/traceback.html#traceback.format_exception) has been ignored since Python `3.5`, and is removed in Python `3.10`.

Fixes #15310.

[ci skip-build-wheels]