### PR TITLE
Work around poisoned cache for macOS CI

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -75,16 +75,6 @@ jobs:
         restore-keys: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-
 
           '
-    - name: Cache Pants Virtualenv
-      uses: actions/cache@v3
-      with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}
-
-          '
-        path: '~/.cache/pants/pants_dev_deps
-
-          '
     - id: get-engine-hash
       name: Get native engine hash
       run: 'echo "::set-output name=hash::$(./build-support/bin/rust/print_engine_hash.sh)"
@@ -237,16 +227,6 @@ jobs:
         restore-keys: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-
 
           '
-    - name: Cache Pants Virtualenv
-      uses: actions/cache@v3
-      with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}
-
-          '
-        path: '~/.cache/pants/pants_dev_deps
-
-          '
     - id: get-engine-hash
       name: Get native engine hash
       run: 'echo "::set-output name=hash::$(./build-support/bin/rust/print_engine_hash.sh)"
@@ -347,16 +327,6 @@ jobs:
         }}.*'']" >> $GITHUB_ENV
 
         '
-    - name: Cache Pants Virtualenv
-      uses: actions/cache@v3
-      with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}
-
-          '
-        path: '~/.cache/pants/pants_dev_deps
-
-          '
     - name: Download native binaries
       uses: actions/download-artifact@v2
       with:
@@ -446,16 +416,6 @@ jobs:
         '
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
-    - name: Cache Pants Virtualenv
-      uses: actions/cache@v3
-      with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}
-
-          '
-        path: '~/.cache/pants/pants_dev_deps
-
-          '
     - name: Download native binaries
       uses: actions/download-artifact@v2
       with:
@@ -529,16 +489,6 @@ jobs:
         '
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
-    - name: Cache Pants Virtualenv
-      uses: actions/cache@v3
-      with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}
-
-          '
-        path: '~/.cache/pants/pants_dev_deps
-
-          '
     - name: Download native binaries
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -50,7 +50,7 @@ jobs:
 
         '
     - name: Cache Rust toolchain
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
         path: '~/.rustup/toolchains/1.60.0-*
@@ -61,7 +61,7 @@ jobs:
 
           '
     - name: Cache Cargo
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
           }}
@@ -76,7 +76,7 @@ jobs:
 
           '
     - name: Cache Pants Virtualenv
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
           ''pants.toml'') }}
@@ -92,7 +92,7 @@ jobs:
         '
       shell: bash
     - name: Cache native engine
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-engine-${{ steps.get-engine-hash.outputs.hash }}
 
@@ -212,7 +212,7 @@ jobs:
 
         '
     - name: Cache Rust toolchain
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
         path: '~/.rustup/toolchains/1.60.0-*
@@ -223,7 +223,7 @@ jobs:
 
           '
     - name: Cache Cargo
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
           }}
@@ -238,7 +238,7 @@ jobs:
 
           '
     - name: Cache Pants Virtualenv
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
           ''pants.toml'') }}
@@ -254,7 +254,7 @@ jobs:
         '
       shell: bash
     - name: Cache native engine
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-engine-${{ steps.get-engine-hash.outputs.hash }}
 
@@ -348,7 +348,7 @@ jobs:
 
         '
     - name: Cache Pants Virtualenv
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
           ''pants.toml'') }}
@@ -447,7 +447,7 @@ jobs:
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - name: Cache Pants Virtualenv
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
           ''pants.toml'') }}
@@ -530,7 +530,7 @@ jobs:
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - name: Cache Pants Virtualenv
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
           ''pants.toml'') }}

--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -52,7 +52,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
+        key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}-v1
         path: '~/.rustup/toolchains/1.60.0-*
 
           ~/.rustup/update-hashes
@@ -64,7 +64,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
-          }}
+          }}-v1
 
           '
         path: '~/.cargo/registry
@@ -73,6 +73,16 @@ jobs:
 
           '
         restore-keys: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-
+
+          '
+    - name: Cache Pants Virtualenv
+      uses: actions/cache@v3
+      with:
+        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
+          ''pants.toml'') }}-v1
+
+          '
+        path: '~/.cache/pants/pants_dev_deps
 
           '
     - id: get-engine-hash
@@ -84,7 +94,7 @@ jobs:
     - name: Cache native engine
       uses: actions/cache@v3
       with:
-        key: '${{ runner.os }}-engine-${{ steps.get-engine-hash.outputs.hash }}
+        key: '${{ runner.os }}-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
 
           '
         path: '.pants
@@ -204,7 +214,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
+        key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}-v1
         path: '~/.rustup/toolchains/1.60.0-*
 
           ~/.rustup/update-hashes
@@ -216,7 +226,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
-          }}
+          }}-v1
 
           '
         path: '~/.cargo/registry
@@ -225,6 +235,16 @@ jobs:
 
           '
         restore-keys: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-
+
+          '
+    - name: Cache Pants Virtualenv
+      uses: actions/cache@v3
+      with:
+        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
+          ''pants.toml'') }}-v1
+
+          '
+        path: '~/.cache/pants/pants_dev_deps
 
           '
     - id: get-engine-hash
@@ -236,7 +256,7 @@ jobs:
     - name: Cache native engine
       uses: actions/cache@v3
       with:
-        key: '${{ runner.os }}-engine-${{ steps.get-engine-hash.outputs.hash }}
+        key: '${{ runner.os }}-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
 
           '
         path: '.pants
@@ -327,6 +347,16 @@ jobs:
         }}.*'']" >> $GITHUB_ENV
 
         '
+    - name: Cache Pants Virtualenv
+      uses: actions/cache@v3
+      with:
+        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
+          ''pants.toml'') }}-v1
+
+          '
+        path: '~/.cache/pants/pants_dev_deps
+
+          '
     - name: Download native binaries
       uses: actions/download-artifact@v2
       with:
@@ -416,6 +446,16 @@ jobs:
         '
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
+    - name: Cache Pants Virtualenv
+      uses: actions/cache@v3
+      with:
+        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
+          ''pants.toml'') }}-v1
+
+          '
+        path: '~/.cache/pants/pants_dev_deps
+
+          '
     - name: Download native binaries
       uses: actions/download-artifact@v2
       with:
@@ -489,6 +529,16 @@ jobs:
         '
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
+    - name: Cache Pants Virtualenv
+      uses: actions/cache@v3
+      with:
+        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
+          ''pants.toml'') }}-v1
+
+          '
+        path: '~/.cache/pants/pants_dev_deps
+
+          '
     - name: Download native binaries
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,16 +75,6 @@ jobs:
         restore-keys: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-
 
           '
-    - name: Cache Pants Virtualenv
-      uses: actions/cache@v3
-      with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}
-
-          '
-        path: '~/.cache/pants/pants_dev_deps
-
-          '
     - id: get-engine-hash
       name: Get native engine hash
       run: 'echo "::set-output name=hash::$(./build-support/bin/rust/print_engine_hash.sh)"
@@ -234,16 +224,6 @@ jobs:
 
           '
         restore-keys: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-
-
-          '
-    - name: Cache Pants Virtualenv
-      uses: actions/cache@v3
-      with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}
-
-          '
-        path: '~/.cache/pants/pants_dev_deps
 
           '
     - id: get-engine-hash
@@ -532,16 +512,6 @@ jobs:
         }}.*'']" >> $GITHUB_ENV
 
         '
-    - name: Cache Pants Virtualenv
-      uses: actions/cache@v3
-      with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}
-
-          '
-        path: '~/.cache/pants/pants_dev_deps
-
-          '
     - name: Download native binaries
       uses: actions/download-artifact@v2
       with:
@@ -630,16 +600,6 @@ jobs:
         '
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
-    - name: Cache Pants Virtualenv
-      uses: actions/cache@v3
-      with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}
-
-          '
-        path: '~/.cache/pants/pants_dev_deps
-
-          '
     - name: Download native binaries
       uses: actions/download-artifact@v2
       with:
@@ -712,16 +672,6 @@ jobs:
         '
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
-    - name: Cache Pants Virtualenv
-      uses: actions/cache@v3
-      with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}
-
-          '
-        path: '~/.cache/pants/pants_dev_deps
-
-          '
     - name: Download native binaries
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,7 +52,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
+        key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}-v1
         path: '~/.rustup/toolchains/1.60.0-*
 
           ~/.rustup/update-hashes
@@ -64,7 +64,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
-          }}
+          }}-v1
 
           '
         path: '~/.cargo/registry
@@ -73,6 +73,16 @@ jobs:
 
           '
         restore-keys: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-
+
+          '
+    - name: Cache Pants Virtualenv
+      uses: actions/cache@v3
+      with:
+        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
+          ''pants.toml'') }}-v1
+
+          '
+        path: '~/.cache/pants/pants_dev_deps
 
           '
     - id: get-engine-hash
@@ -84,7 +94,7 @@ jobs:
     - name: Cache native engine
       uses: actions/cache@v3
       with:
-        key: '${{ runner.os }}-engine-${{ steps.get-engine-hash.outputs.hash }}
+        key: '${{ runner.os }}-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
 
           '
         path: '.pants
@@ -203,7 +213,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
+        key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}-v1
         path: '~/.rustup/toolchains/1.60.0-*
 
           ~/.rustup/update-hashes
@@ -215,7 +225,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
-          }}
+          }}-v1
 
           '
         path: '~/.cargo/registry
@@ -224,6 +234,16 @@ jobs:
 
           '
         restore-keys: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-
+
+          '
+    - name: Cache Pants Virtualenv
+      uses: actions/cache@v3
+      with:
+        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
+          ''pants.toml'') }}-v1
+
+          '
+        path: '~/.cache/pants/pants_dev_deps
 
           '
     - id: get-engine-hash
@@ -235,7 +255,7 @@ jobs:
     - name: Cache native engine
       uses: actions/cache@v3
       with:
-        key: '${{ runner.os }}-engine-${{ steps.get-engine-hash.outputs.hash }}
+        key: '${{ runner.os }}-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
 
           '
         path: '.pants
@@ -398,7 +418,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
+        key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}-v1
         path: '~/.rustup/toolchains/1.60.0-*
 
           ~/.rustup/update-hashes
@@ -410,7 +430,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
-          }}
+          }}-v1
 
           '
         path: '~/.cargo/registry
@@ -512,6 +532,16 @@ jobs:
         }}.*'']" >> $GITHUB_ENV
 
         '
+    - name: Cache Pants Virtualenv
+      uses: actions/cache@v3
+      with:
+        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
+          ''pants.toml'') }}-v1
+
+          '
+        path: '~/.cache/pants/pants_dev_deps
+
+          '
     - name: Download native binaries
       uses: actions/download-artifact@v2
       with:
@@ -600,6 +630,16 @@ jobs:
         '
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
+    - name: Cache Pants Virtualenv
+      uses: actions/cache@v3
+      with:
+        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
+          ''pants.toml'') }}-v1
+
+          '
+        path: '~/.cache/pants/pants_dev_deps
+
+          '
     - name: Download native binaries
       uses: actions/download-artifact@v2
       with:
@@ -672,6 +712,16 @@ jobs:
         '
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
+    - name: Cache Pants Virtualenv
+      uses: actions/cache@v3
+      with:
+        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
+          ''pants.toml'') }}-v1
+
+          '
+        path: '~/.cache/pants/pants_dev_deps
+
+          '
     - name: Download native binaries
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,7 +50,7 @@ jobs:
 
         '
     - name: Cache Rust toolchain
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
         path: '~/.rustup/toolchains/1.60.0-*
@@ -61,7 +61,7 @@ jobs:
 
           '
     - name: Cache Cargo
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
           }}
@@ -76,7 +76,7 @@ jobs:
 
           '
     - name: Cache Pants Virtualenv
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
           ''pants.toml'') }}
@@ -92,7 +92,7 @@ jobs:
         '
       shell: bash
     - name: Cache native engine
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-engine-${{ steps.get-engine-hash.outputs.hash }}
 
@@ -211,7 +211,7 @@ jobs:
 
         '
     - name: Cache Rust toolchain
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
         path: '~/.rustup/toolchains/1.60.0-*
@@ -222,7 +222,7 @@ jobs:
 
           '
     - name: Cache Cargo
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
           }}
@@ -237,7 +237,7 @@ jobs:
 
           '
     - name: Cache Pants Virtualenv
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
           ''pants.toml'') }}
@@ -253,7 +253,7 @@ jobs:
         '
       shell: bash
     - name: Cache native engine
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-engine-${{ steps.get-engine-hash.outputs.hash }}
 
@@ -416,7 +416,7 @@ jobs:
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - name: Cache Rust toolchain
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
         path: '~/.rustup/toolchains/1.60.0-*
@@ -427,7 +427,7 @@ jobs:
 
           '
     - name: Cache Cargo
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
           }}
@@ -533,7 +533,7 @@ jobs:
 
         '
     - name: Cache Pants Virtualenv
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
           ''pants.toml'') }}
@@ -631,7 +631,7 @@ jobs:
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - name: Cache Pants Virtualenv
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
           ''pants.toml'') }}
@@ -713,7 +713,7 @@ jobs:
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - name: Cache Pants Virtualenv
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
           ''pants.toml'') }}

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -239,7 +239,7 @@ def install_go() -> Step:
 def bootstrap_caches() -> Sequence[Step]:
     return [
         *rust_caches(),
-        pants_virtualenv_cache(),
+        # pants_virtualenv_cache(),
         # NB: This caching is only intended for the bootstrap jobs to avoid them needing to
         # re-compile when possible. Compare to the upload-artifact and download-artifact actions,
         # which are how the bootstrap jobs share the compiled binaries with the other jobs like
@@ -404,7 +404,7 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
                 download_apache_thrift(),
                 *setup_primary_python(),
                 expose_all_pythons(),
-                pants_virtualenv_cache(),
+                # pants_virtualenv_cache(),
                 native_binaries_download(),
                 setup_toolchain_auth(),
                 {"name": "Run Python tests", "run": "./pants test ::\n"},
@@ -421,7 +421,7 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
             "steps": [
                 *checkout(),
                 *setup_primary_python(),
-                pants_virtualenv_cache(),
+                # pants_virtualenv_cache(),
                 native_binaries_download(),
                 setup_toolchain_auth(),
                 {
@@ -475,7 +475,7 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
                 install_jdk(),
                 *setup_primary_python(),
                 expose_all_pythons(),
-                pants_virtualenv_cache(),
+                # pants_virtualenv_cache(),
                 native_binaries_download(),
                 setup_toolchain_auth(),
                 {

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -162,7 +162,7 @@ def setup_toolchain_auth() -> Step:
 def pants_virtualenv_cache() -> Step:
     return {
         "name": "Cache Pants Virtualenv",
-        "uses": "actions/cache@v2",
+        "uses": "actions/cache@v3",
         "with": {
             "path": "~/.cache/pants/pants_dev_deps\n",
             "key": "${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles('3rdparty/python/**', 'pants.toml') }}\n",
@@ -199,7 +199,7 @@ def rust_caches() -> Sequence[Step]:
     return [
         {
             "name": "Cache Rust toolchain",
-            "uses": "actions/cache@v2",
+            "uses": "actions/cache@v3",
             "with": {
                 "path": f"~/.rustup/toolchains/{rust_channel()}-*\n~/.rustup/update-hashes\n~/.rustup/settings.toml\n",
                 "key": "${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}",
@@ -207,7 +207,7 @@ def rust_caches() -> Sequence[Step]:
         },
         {
             "name": "Cache Cargo",
-            "uses": "actions/cache@v2",
+            "uses": "actions/cache@v3",
             "with": {
                 "path": "~/.cargo/registry\n~/.cargo/git\n",
                 "key": "${{ runner.os }}-cargo-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('src/rust/engine/Cargo.*') }}\n",
@@ -252,7 +252,7 @@ def bootstrap_caches() -> Sequence[Step]:
         },
         {
             "name": "Cache native engine",
-            "uses": "actions/cache@v2",
+            "uses": "actions/cache@v3",
             "with": {
                 "path": "\n".join(NATIVE_FILES),
                 "key": "${{ runner.os }}-engine-${{ steps.get-engine-hash.outputs.hash }}\n",

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -165,7 +165,7 @@ def pants_virtualenv_cache() -> Step:
         "uses": "actions/cache@v3",
         "with": {
             "path": "~/.cache/pants/pants_dev_deps\n",
-            "key": "${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles('3rdparty/python/**', 'pants.toml') }}\n",
+            "key": "${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles('3rdparty/python/**', 'pants.toml') }}-v1\n",
         },
     }
 
@@ -202,7 +202,7 @@ def rust_caches() -> Sequence[Step]:
             "uses": "actions/cache@v3",
             "with": {
                 "path": f"~/.rustup/toolchains/{rust_channel()}-*\n~/.rustup/update-hashes\n~/.rustup/settings.toml\n",
-                "key": "${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}",
+                "key": "${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}-v1",
             },
         },
         {
@@ -210,7 +210,7 @@ def rust_caches() -> Sequence[Step]:
             "uses": "actions/cache@v3",
             "with": {
                 "path": "~/.cargo/registry\n~/.cargo/git\n",
-                "key": "${{ runner.os }}-cargo-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('src/rust/engine/Cargo.*') }}\n",
+                "key": "${{ runner.os }}-cargo-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('src/rust/engine/Cargo.*') }}-v1\n",
                 "restore-keys": "${{ runner.os }}-cargo-${{ hashFiles('rust-toolchain') }}-\n",
             },
         },
@@ -239,7 +239,7 @@ def install_go() -> Step:
 def bootstrap_caches() -> Sequence[Step]:
     return [
         *rust_caches(),
-        # pants_virtualenv_cache(),
+        pants_virtualenv_cache(),
         # NB: This caching is only intended for the bootstrap jobs to avoid them needing to
         # re-compile when possible. Compare to the upload-artifact and download-artifact actions,
         # which are how the bootstrap jobs share the compiled binaries with the other jobs like
@@ -255,7 +255,7 @@ def bootstrap_caches() -> Sequence[Step]:
             "uses": "actions/cache@v3",
             "with": {
                 "path": "\n".join(NATIVE_FILES),
-                "key": "${{ runner.os }}-engine-${{ steps.get-engine-hash.outputs.hash }}\n",
+                "key": "${{ runner.os }}-engine-${{ steps.get-engine-hash.outputs.hash }}-v1\n",
             },
         },
     ]
@@ -404,7 +404,7 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
                 download_apache_thrift(),
                 *setup_primary_python(),
                 expose_all_pythons(),
-                # pants_virtualenv_cache(),
+                pants_virtualenv_cache(),
                 native_binaries_download(),
                 setup_toolchain_auth(),
                 {"name": "Run Python tests", "run": "./pants test ::\n"},
@@ -421,7 +421,7 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
             "steps": [
                 *checkout(),
                 *setup_primary_python(),
-                # pants_virtualenv_cache(),
+                pants_virtualenv_cache(),
                 native_binaries_download(),
                 setup_toolchain_auth(),
                 {
@@ -475,7 +475,7 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
                 install_jdk(),
                 *setup_primary_python(),
                 expose_all_pythons(),
-                # pants_virtualenv_cache(),
+                pants_virtualenv_cache(),
                 native_binaries_download(),
                 setup_toolchain_auth(),
                 {

--- a/pants
+++ b/pants
@@ -7,7 +7,7 @@
 # The script defaults to running with either Python 3.7 or Python 3.8. To use another Python version,
 # prefix the script with `PY=python3.8`.
 
-set -eo pipefail
+set -eox pipefail
 
 HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
@@ -59,6 +59,9 @@ function exec_pants_bare() {
     fi
     set -e
   fi
+
+  ls -l "$(venv_dir)"
+  ls -l "$(venv_dir)/bin"
 
   # shellcheck disable=SC2086
   PYTHONPATH="${PANTS_SRCPATH}:${PYTHONPATH}" RUNNING_PANTS_FROM_SOURCES=1 \

--- a/pants
+++ b/pants
@@ -7,7 +7,7 @@
 # The script defaults to running with either Python 3.7 or Python 3.8. To use another Python version,
 # prefix the script with `PY=python3.8`.
 
-set -eox pipefail
+set -eo pipefail
 
 HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
@@ -44,11 +44,6 @@ function exec_pants_bare() {
 
   # Redirect activation and native bootstrap to ensure that they don't interfere with stdout.
   activate_pants_venv 1>&2
-
-  ls -l "$(venv_dir)"
-  ls -l "$(venv_dir)/bin"
-  "$(venv_dir)/bin/python" --version
-
   bootstrap_native_code 1>&2
 
   if [ -n "${USE_NATIVE_PANTS}" ]; then

--- a/pants
+++ b/pants
@@ -44,6 +44,11 @@ function exec_pants_bare() {
 
   # Redirect activation and native bootstrap to ensure that they don't interfere with stdout.
   activate_pants_venv 1>&2
+
+  ls -l "$(venv_dir)"
+  ls -l "$(venv_dir)/bin"
+  "$(venv_dir)/bin/python" --version
+
   bootstrap_native_code 1>&2
 
   if [ -n "${USE_NATIVE_PANTS}" ]; then
@@ -59,9 +64,6 @@ function exec_pants_bare() {
     fi
     set -e
   fi
-
-  ls -l "$(venv_dir)"
-  ls -l "$(venv_dir)/bin"
 
   # shellcheck disable=SC2086
   PYTHONPATH="${PANTS_SRCPATH}:${PYTHONPATH}" RUNNING_PANTS_FROM_SOURCES=1 \


### PR DESCRIPTION
The cache is poisoned for the macOS virtual environment because it looks like the symlink to /Users/runner/hostedtoolcache/Python/3.7.12/x64/bin/python3.7 no longer exists.

`hashFiles()` expects relative paths, so I could not figure out how to include the underlying interpreter path in our hash key. Instead, this simply adds a manually controlled `-v1` suffix to each cache key. We can bump this whenever we have cache poisoning.

[ci skip-rust]
[ci skip-build-wheels]