### PR TITLE
Work around poisoned cache for macOS CI (#15324)

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -49,9 +49,9 @@ jobs:
 
         '
     - name: Cache Rust toolchain
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
+        key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}-v1
         path: '~/.rustup/toolchains/1.58.1-*
 
           ~/.rustup/update-hashes
@@ -60,10 +60,10 @@ jobs:
 
           '
     - name: Cache Cargo
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
-          }}
+          }}-v1
 
           '
         path: '~/.cargo/registry
@@ -75,10 +75,10 @@ jobs:
 
           '
     - name: Cache Pants Virtualenv
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}
+          ''pants.toml'') }}-v1
 
           '
         path: '~/.cache/pants/pants_dev_deps
@@ -91,9 +91,9 @@ jobs:
         '
       shell: bash
     - name: Cache native engine
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
-        key: '${{ runner.os }}-engine-${{ steps.get-engine-hash.outputs.hash }}
+        key: '${{ runner.os }}-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
 
           '
         path: '.pants
@@ -200,9 +200,9 @@ jobs:
 
         '
     - name: Cache Rust toolchain
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
+        key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}-v1
         path: '~/.rustup/toolchains/1.58.1-*
 
           ~/.rustup/update-hashes
@@ -211,10 +211,10 @@ jobs:
 
           '
     - name: Cache Cargo
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
-          }}
+          }}-v1
 
           '
         path: '~/.cargo/registry
@@ -226,10 +226,10 @@ jobs:
 
           '
     - name: Cache Pants Virtualenv
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}
+          ''pants.toml'') }}-v1
 
           '
         path: '~/.cache/pants/pants_dev_deps
@@ -242,9 +242,9 @@ jobs:
         '
       shell: bash
     - name: Cache native engine
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
-        key: '${{ runner.os }}-engine-${{ steps.get-engine-hash.outputs.hash }}
+        key: '${{ runner.os }}-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
 
           '
         path: '.pants
@@ -321,10 +321,10 @@ jobs:
 
         '
     - name: Cache Pants Virtualenv
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}
+          ''pants.toml'') }}-v1
 
           '
         path: '~/.cache/pants/pants_dev_deps
@@ -420,10 +420,10 @@ jobs:
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - name: Cache Pants Virtualenv
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}
+          ''pants.toml'') }}-v1
 
           '
         path: '~/.cache/pants/pants_dev_deps
@@ -503,10 +503,10 @@ jobs:
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - name: Cache Pants Virtualenv
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}
+          ''pants.toml'') }}-v1
 
           '
         path: '~/.cache/pants/pants_dev_deps

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,9 +49,9 @@ jobs:
 
         '
     - name: Cache Rust toolchain
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
+        key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}-v1
         path: '~/.rustup/toolchains/1.58.1-*
 
           ~/.rustup/update-hashes
@@ -60,10 +60,10 @@ jobs:
 
           '
     - name: Cache Cargo
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
-          }}
+          }}-v1
 
           '
         path: '~/.cargo/registry
@@ -75,10 +75,10 @@ jobs:
 
           '
     - name: Cache Pants Virtualenv
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}
+          ''pants.toml'') }}-v1
 
           '
         path: '~/.cache/pants/pants_dev_deps
@@ -91,9 +91,9 @@ jobs:
         '
       shell: bash
     - name: Cache native engine
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
-        key: '${{ runner.os }}-engine-${{ steps.get-engine-hash.outputs.hash }}
+        key: '${{ runner.os }}-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
 
           '
         path: '.pants
@@ -199,9 +199,9 @@ jobs:
 
         '
     - name: Cache Rust toolchain
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
+        key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}-v1
         path: '~/.rustup/toolchains/1.58.1-*
 
           ~/.rustup/update-hashes
@@ -210,10 +210,10 @@ jobs:
 
           '
     - name: Cache Cargo
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
-          }}
+          }}-v1
 
           '
         path: '~/.cargo/registry
@@ -225,10 +225,10 @@ jobs:
 
           '
     - name: Cache Pants Virtualenv
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}
+          ''pants.toml'') }}-v1
 
           '
         path: '~/.cache/pants/pants_dev_deps
@@ -241,9 +241,9 @@ jobs:
         '
       shell: bash
     - name: Cache native engine
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
-        key: '${{ runner.os }}-engine-${{ steps.get-engine-hash.outputs.hash }}
+        key: '${{ runner.os }}-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
 
           '
         path: '.pants
@@ -402,9 +402,9 @@ jobs:
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - name: Cache Rust toolchain
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}
+        key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}-v1
         path: '~/.rustup/toolchains/1.58.1-*
 
           ~/.rustup/update-hashes
@@ -413,10 +413,10 @@ jobs:
 
           '
     - name: Cache Cargo
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
-          }}
+          }}-v1
 
           '
         path: '~/.cargo/registry
@@ -504,10 +504,10 @@ jobs:
 
         '
     - name: Cache Pants Virtualenv
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}
+          ''pants.toml'') }}-v1
 
           '
         path: '~/.cache/pants/pants_dev_deps
@@ -602,10 +602,10 @@ jobs:
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - name: Cache Pants Virtualenv
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}
+          ''pants.toml'') }}-v1
 
           '
         path: '~/.cache/pants/pants_dev_deps
@@ -684,10 +684,10 @@ jobs:
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - name: Cache Pants Virtualenv
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}
+          ''pants.toml'') }}-v1
 
           '
         path: '~/.cache/pants/pants_dev_deps

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -142,10 +142,10 @@ def setup_toolchain_auth() -> Step:
 def pants_virtualenv_cache() -> Step:
     return {
         "name": "Cache Pants Virtualenv",
-        "uses": "actions/cache@v2",
+        "uses": "actions/cache@v3",
         "with": {
             "path": "~/.cache/pants/pants_dev_deps\n",
-            "key": "${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles('3rdparty/python/**', 'pants.toml') }}\n",
+            "key": "${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles('3rdparty/python/**', 'pants.toml') }}-v1\n",
         },
     }
 
@@ -179,18 +179,18 @@ def rust_caches() -> Sequence[Step]:
     return [
         {
             "name": "Cache Rust toolchain",
-            "uses": "actions/cache@v2",
+            "uses": "actions/cache@v3",
             "with": {
                 "path": f"~/.rustup/toolchains/{rust_channel()}-*\n~/.rustup/update-hashes\n~/.rustup/settings.toml\n",
-                "key": "${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}",
+                "key": "${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}-v1",
             },
         },
         {
             "name": "Cache Cargo",
-            "uses": "actions/cache@v2",
+            "uses": "actions/cache@v3",
             "with": {
                 "path": "~/.cargo/registry\n~/.cargo/git\n",
-                "key": "${{ runner.os }}-cargo-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('src/rust/engine/Cargo.*') }}\n",
+                "key": "${{ runner.os }}-cargo-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('src/rust/engine/Cargo.*') }}-v1\n",
                 "restore-keys": "${{ runner.os }}-cargo-${{ hashFiles('rust-toolchain') }}-\n",
             },
         },
@@ -232,10 +232,10 @@ def bootstrap_caches() -> Sequence[Step]:
         },
         {
             "name": "Cache native engine",
-            "uses": "actions/cache@v2",
+            "uses": "actions/cache@v3",
             "with": {
                 "path": "\n".join(NATIVE_FILES),
-                "key": "${{ runner.os }}-engine-${{ steps.get-engine-hash.outputs.hash }}\n",
+                "key": "${{ runner.os }}-engine-${{ steps.get-engine-hash.outputs.hash }}-v1\n",
             },
         },
     ]


### PR DESCRIPTION
The cache is poisoned for the macOS virtual environment because it looks like the symlink to /Users/runner/hostedtoolcache/Python/3.7.12/x64/bin/python3.7 no longer exists.

`hashFiles()` expects relative paths, so I could not figure out how to include the underlying interpreter path in our hash key. Instead, this simply adds a manually controlled `-v1` suffix to each cache key. We can bump this whenever we have cache poisoning.

[ci skip-rust]
[ci skip-build-wheels]