### PR TITLE
Error on unowned internal Python dependencies

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -131,6 +131,7 @@ lockfile_generator = "pex"
 
 [python-infer]
 assets = true
+unowned_dependency_behavior = "error"
 
 [docformatter]
 args = ["--wrap-summaries=100", "--wrap-descriptions=100"]

--- a/src/python/pants/backend/docker/subsystems/dockerfile_wrapper_script.py
+++ b/src/python/pants/backend/docker/subsystems/dockerfile_wrapper_script.py
@@ -70,7 +70,7 @@ _image_ref_regexp = re.compile(
 
 def main(cmd: str, args: list[str]) -> None:
     # import here to allow the rest of the file to be tested without a dependency on dockerfile
-    from dockerfile import Command, parse_file, parse_string
+    from dockerfile import Command, parse_file, parse_string  # pants: no-infer-dep
 
     @dataclass(frozen=True)
     class ParsedDockerfile:

--- a/src/python/pants/backend/terraform/hcl2_parser.py
+++ b/src/python/pants/backend/terraform/hcl2_parser.py
@@ -28,8 +28,9 @@ def resolve_pure_path(base: PurePath, relative_path: PurePath) -> PurePath:
 
 
 def extract_module_source_paths(path: PurePath, raw_content: bytes) -> Set[str]:
-    # Import here so we can still test this file with pytest (since `hcl2` is not present in normal Pants venv.)
-    import hcl2  # type: ignore[import]
+    # Import here so we can still test this file with pytest (since `hcl2` is not present in
+    # normal Pants venv.)
+    import hcl2  # type: ignore[import]  # pants: no-infer-dep
 
     content = raw_content.decode("utf-8")
     parsed_content = hcl2.loads(content)

--- a/src/python/pants/goal/stats_aggregator.py
+++ b/src/python/pants/goal/stats_aggregator.py
@@ -120,7 +120,7 @@ class StatsAggregatorCallback(WorkunitsCallback):
 
         if not (self.log and self.has_histogram_module):
             return
-        from hdrh.histogram import HdrHistogram
+        from hdrh.histogram import HdrHistogram  # pants: no-infer-dep
 
         histograms = context.get_observation_histograms()["histograms"]
         if not histograms:

--- a/testprojects/src/python/native/name.py
+++ b/testprojects/src/python/native/name.py
@@ -1,7 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from native import impl  # type: ignore[attr-defined]
+from native import impl  # type: ignore[attr-defined]  # pants: no-infer-dep
 
 
 def get_name():


### PR DESCRIPTION
The dogfooding is good, especially as we consider changing the default for Pants to be warn or error (https://github.com/pantsbuild/pants/issues/15326).