### PR TITLE
Add options to turn off `tailor` on a per-language basis

### DIFF
--- a/src/python/pants/backend/codegen/avro/avro_subsystem.py
+++ b/src/python/pants/backend/codegen/avro/avro_subsystem.py
@@ -1,0 +1,19 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from pants.option.option_types import BoolOption
+from pants.option.subsystem import Subsystem
+
+
+class AvroSubsystem(Subsystem):
+    options_scope = "avro"
+    help = "General Avro codegen settings."
+
+    tailor = BoolOption(
+        "--tailor",
+        default=True,
+        help="If true, add `avro_sources` targets with the `tailor` goal.",
+        advanced=True,
+    )

--- a/src/python/pants/backend/codegen/avro/tailor.py
+++ b/src/python/pants/backend/codegen/avro/tailor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from pants.backend.codegen.avro.avro_subsystem import AvroSubsystem
 from pants.backend.codegen.avro.target_types import AvroSourcesGeneratorTarget
 from pants.core.goals.tailor import (
     AllOwnedSources,
@@ -27,8 +28,13 @@ class PutativeAvroTargetsRequest(PutativeTargetsRequest):
 
 @rule(level=LogLevel.DEBUG, desc="Determine candidate Protobuf targets to create")
 async def find_putative_targets(
-    req: PutativeAvroTargetsRequest, all_owned_sources: AllOwnedSources
+    req: PutativeAvroTargetsRequest,
+    all_owned_sources: AllOwnedSources,
+    avro_subsystem: AvroSubsystem,
 ) -> PutativeTargets:
+    if not avro_subsystem.tailor:
+        return PutativeTargets()
+
     all_avsc_files, all_avpr_files, all_avdl_files = await MultiGet(
         Get(Paths, PathGlobs, req.search_paths.path_globs("*.avsc")),
         Get(Paths, PathGlobs, req.search_paths.path_globs("*.avpr")),

--- a/src/python/pants/backend/codegen/protobuf/protoc.py
+++ b/src/python/pants/backend/codegen/protobuf/protoc.py
@@ -34,6 +34,12 @@ class Protoc(TemplatedExternalTool):
         default=True,
         help="Infer Protobuf dependencies on other Protobuf files by analyzing import statements.",
     )
+    tailor = BoolOption(
+        "--tailor",
+        default=True,
+        help="If true, add `protobuf_sources` targets with the `tailor` goal.",
+        advanced=True,
+    )
 
     def generate_exe(self, plat: Platform) -> str:
         return "./bin/protoc"

--- a/src/python/pants/backend/codegen/protobuf/tailor.py
+++ b/src/python/pants/backend/codegen/protobuf/tailor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from pants.backend.codegen.protobuf.protoc import Protoc
 from pants.backend.codegen.protobuf.target_types import ProtobufSourcesGeneratorTarget
 from pants.core.goals.tailor import (
     AllOwnedSources,
@@ -27,8 +28,11 @@ class PutativeProtobufTargetsRequest(PutativeTargetsRequest):
 
 @rule(level=LogLevel.DEBUG, desc="Determine candidate Protobuf targets to create")
 async def find_putative_targets(
-    req: PutativeProtobufTargetsRequest, all_owned_sources: AllOwnedSources
+    req: PutativeProtobufTargetsRequest, all_owned_sources: AllOwnedSources, protoc: Protoc
 ) -> PutativeTargets:
+    if not protoc.tailor:
+        return PutativeTargets()
+
     all_proto_files = await Get(Paths, PathGlobs, req.search_paths.path_globs("*.proto"))
     unowned_proto_files = set(all_proto_files.files) - set(all_owned_sources)
     pts = [

--- a/src/python/pants/backend/codegen/soap/soap_subsystem.py
+++ b/src/python/pants/backend/codegen/soap/soap_subsystem.py
@@ -1,0 +1,19 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from pants.option.option_types import BoolOption
+from pants.option.subsystem import Subsystem
+
+
+class SoapSubsystem(Subsystem):
+    options_scope = "soap"
+    help = "General SOAP/WSDL codegen settings."
+
+    tailor = BoolOption(
+        "--tailor",
+        default=True,
+        help="If true, add `wsdl_sources` targets with the `tailor` goal.",
+        advanced=True,
+    )

--- a/src/python/pants/backend/codegen/soap/tailor.py
+++ b/src/python/pants/backend/codegen/soap/tailor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from pants.backend.codegen.soap.soap_subsystem import SoapSubsystem
 from pants.backend.codegen.soap.target_types import WsdlSourcesGeneratorTarget
 from pants.core.goals.tailor import (
     AllOwnedSources,
@@ -27,8 +28,13 @@ class PutativeWsdlTargetsRequest(PutativeTargetsRequest):
 
 @rule(level=LogLevel.DEBUG, desc="Determine candidate WSDL targets to create")
 async def find_putative_targets(
-    req: PutativeWsdlTargetsRequest, all_owned_sources: AllOwnedSources
+    req: PutativeWsdlTargetsRequest,
+    all_owned_sources: AllOwnedSources,
+    soap_subsystem: SoapSubsystem,
 ) -> PutativeTargets:
+    if not soap_subsystem.tailor:
+        return PutativeTargets()
+
     all_wsdl_files = await Get(Paths, PathGlobs, req.search_paths.path_globs("*.wsdl"))
     unowned_wsdl_files = set(all_wsdl_files.files) - set(all_owned_sources)
     pts = [

--- a/src/python/pants/backend/codegen/thrift/subsystem.py
+++ b/src/python/pants/backend/codegen/thrift/subsystem.py
@@ -15,3 +15,9 @@ class ThriftSubsystem(Subsystem):
         default=True,
         help="Infer Thrift dependencies on other Thrift files by analyzing import statements.",
     )
+    tailor = BoolOption(
+        "--tailor",
+        default=True,
+        help="If true, add `thrift-sources` targets with the `tailor` goal.",
+        advanced=True,
+    )

--- a/src/python/pants/backend/codegen/thrift/subsystem.py
+++ b/src/python/pants/backend/codegen/thrift/subsystem.py
@@ -18,6 +18,6 @@ class ThriftSubsystem(Subsystem):
     tailor = BoolOption(
         "--tailor",
         default=True,
-        help="If true, add `thrift-sources` targets with the `tailor` goal.",
+        help="If true, add `thrift_sources` targets with the `tailor` goal.",
         advanced=True,
     )

--- a/src/python/pants/backend/codegen/thrift/tailor.py
+++ b/src/python/pants/backend/codegen/thrift/tailor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from pants.backend.codegen.thrift.subsystem import ThriftSubsystem
 from pants.backend.codegen.thrift.target_types import ThriftSourcesGeneratorTarget
 from pants.core.goals.tailor import (
     AllOwnedSources,
@@ -27,8 +28,13 @@ class PutativeThriftTargetsRequest(PutativeTargetsRequest):
 
 @rule(level=LogLevel.DEBUG, desc="Determine candidate Thrift targets to create")
 async def find_putative_thrift_targets(
-    req: PutativeThriftTargetsRequest, all_owned_sources: AllOwnedSources
+    req: PutativeThriftTargetsRequest,
+    all_owned_sources: AllOwnedSources,
+    thrift_subsystem: ThriftSubsystem,
 ) -> PutativeTargets:
+    if not thrift_subsystem.tailor:
+        return PutativeTargets()
+
     all_thrift_files = await Get(Paths, PathGlobs, req.search_paths.path_globs("*.thrift"))
     unowned_thrift_files = set(all_thrift_files.files) - set(all_owned_sources)
     pts = [

--- a/src/python/pants/backend/docker/goals/tailor.py
+++ b/src/python/pants/backend/docker/goals/tailor.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 
+from pants.backend.docker.subsystems.docker_options import DockerOptions
 from pants.backend.docker.target_types import DockerImageSourceField, DockerImageTarget
 from pants.core.goals.tailor import (
     AllOwnedSources,
@@ -27,8 +28,11 @@ class PutativeDockerTargetsRequest(PutativeTargetsRequest):
 
 @rule(level=LogLevel.DEBUG, desc="Determine candidate Docker targets to create")
 async def find_putative_targets(
-    req: PutativeDockerTargetsRequest, all_owned_sources: AllOwnedSources
+    req: PutativeDockerTargetsRequest, all_owned_sources: AllOwnedSources, docker: DockerOptions
 ) -> PutativeTargets:
+    if not docker.tailor:
+        return PutativeTargets()
+
     all_dockerfiles = await Get(Paths, PathGlobs, req.search_paths.path_globs("*Dockerfile*"))
     unowned_dockerfiles = set(all_dockerfiles.files) - set(all_owned_sources)
     pts = []

--- a/src/python/pants/backend/docker/subsystems/docker_options.py
+++ b/src/python/pants/backend/docker/subsystems/docker_options.py
@@ -214,6 +214,13 @@ class DockerOptions(Subsystem):
         advanced=True,
     )
 
+    tailor = BoolOption(
+        "--tailor",
+        default=True,
+        help="If true, add `docker_image` targets with the `tailor` goal.",
+        advanced=True,
+    )
+
     @property
     def build_args(self) -> tuple[str, ...]:
         return tuple(sorted(set(self._build_args)))

--- a/src/python/pants/backend/go/goals/tailor.py
+++ b/src/python/pants/backend/go/goals/tailor.py
@@ -8,6 +8,7 @@ import re
 from dataclasses import dataclass
 from pathlib import PurePath
 
+from pants.backend.go.subsystems.golang import GolangSubsystem
 from pants.backend.go.target_types import (
     GoBinaryMainPackage,
     GoBinaryMainPackageField,
@@ -45,75 +46,76 @@ def has_package_main(content: bytes) -> bool:
 
 @rule(level=LogLevel.DEBUG, desc="Determine candidate Go targets to create")
 async def find_putative_go_targets(
-    request: PutativeGoTargetsRequest, all_owned_sources: AllOwnedSources
+    request: PutativeGoTargetsRequest,
+    all_owned_sources: AllOwnedSources,
+    golang_subsystem: GolangSubsystem,
 ) -> PutativeTargets:
     putative_targets = []
 
-    all_go_mod_files, all_go_files, all_go_files_digest_contents = await MultiGet(
-        Get(Paths, PathGlobs, request.search_paths.path_globs("go.mod")),
-        Get(Paths, PathGlobs, request.search_paths.path_globs("*.go")),
-        Get(DigestContents, PathGlobs, request.search_paths.path_globs("*.go")),
-    )
-
-    # Add `go_mod` targets.
-    unowned_go_mod_files = set(all_go_mod_files.files) - set(all_owned_sources)
-    for dirname, filenames in group_by_dir(unowned_go_mod_files).items():
-        putative_targets.append(
-            PutativeTarget.for_target_type(
-                GoModTarget,
-                path=dirname,
-                name=None,
-                triggering_sources=sorted(filenames),
+    if golang_subsystem.tailor_go_mod_targets:
+        all_go_mod_files = await Get(Paths, PathGlobs, request.search_paths.path_globs("go.mod"))
+        unowned_go_mod_files = set(all_go_mod_files.files) - set(all_owned_sources)
+        for dirname, filenames in group_by_dir(unowned_go_mod_files).items():
+            putative_targets.append(
+                PutativeTarget.for_target_type(
+                    GoModTarget,
+                    path=dirname,
+                    name=None,
+                    triggering_sources=sorted(filenames),
+                )
             )
-        )
 
-    # Add `go_package` targets.
-    unowned_go_files = set(all_go_files.files) - set(all_owned_sources)
-    for dirname, filenames in group_by_dir(unowned_go_files).items():
-        # Ignore paths that have `testdata` or `vendor` in them.
-        # From `go help packages`: Note, however, that a directory named vendor that itself contains code
-        # is not a vendored package: cmd/vendor would be a command named vendor.
-        dirname_parts = PurePath(dirname).parts
-        if "testdata" in dirname_parts or "vendor" in dirname_parts[0:-1]:
-            continue
-        putative_targets.append(
-            PutativeTarget.for_target_type(
-                GoPackageTarget,
-                path=dirname,
-                name=None,
-                triggering_sources=sorted(filenames),
+    if golang_subsystem.tailor_package_targets:
+        all_go_files = await Get(Paths, PathGlobs, request.search_paths.path_globs("*.go"))
+        unowned_go_files = set(all_go_files.files) - set(all_owned_sources)
+        for dirname, filenames in group_by_dir(unowned_go_files).items():
+            # Ignore paths that have `testdata` or `vendor` in them.
+            # From `go help packages`: Note, however, that a directory named vendor that itself contains code
+            # is not a vendored package: cmd/vendor would be a command named vendor.
+            dirname_parts = PurePath(dirname).parts
+            if "testdata" in dirname_parts or "vendor" in dirname_parts[0:-1]:
+                continue
+            putative_targets.append(
+                PutativeTarget.for_target_type(
+                    GoPackageTarget,
+                    path=dirname,
+                    name=None,
+                    triggering_sources=sorted(filenames),
+                )
             )
-        )
 
-    # Add `go_binary` targets.
-    main_package_dirs = [
-        os.path.dirname(file_content.path)
-        for file_content in all_go_files_digest_contents
-        if has_package_main(file_content.content)
-    ]
-    existing_targets = await Get(
-        UnexpandedTargets, AddressSpecs(AscendantAddresses(d) for d in main_package_dirs)
-    )
-    owned_main_packages = await MultiGet(
-        Get(GoBinaryMainPackage, GoBinaryMainPackageRequest(t[GoBinaryMainPackageField]))
-        for t in existing_targets
-        if t.has_field(GoBinaryMainPackageField)
-    )
-    unowned_main_package_dirs = set(main_package_dirs) - {
-        # NB: We assume the `go_package` lives in the directory it's defined, which we validate
-        # by e.g. banning `**` in its sources field.
-        pkg.address.spec_path
-        for pkg in owned_main_packages
-    }
-    putative_targets.extend(
-        PutativeTarget.for_target_type(
-            GoBinaryTarget,
-            path=main_pkg_dir,
-            name="bin",
-            triggering_sources=tuple(),
+    if golang_subsystem.tailor_binary_targets:
+        all_go_files_digest_contents = await Get(
+            DigestContents, PathGlobs, request.search_paths.path_globs("*.go")
         )
-        for main_pkg_dir in unowned_main_package_dirs
-    )
+        main_package_dirs = [
+            os.path.dirname(file_content.path)
+            for file_content in all_go_files_digest_contents
+            if has_package_main(file_content.content)
+        ]
+        existing_targets = await Get(
+            UnexpandedTargets, AddressSpecs(AscendantAddresses(d) for d in main_package_dirs)
+        )
+        owned_main_packages = await MultiGet(
+            Get(GoBinaryMainPackage, GoBinaryMainPackageRequest(t[GoBinaryMainPackageField]))
+            for t in existing_targets
+            if t.has_field(GoBinaryMainPackageField)
+        )
+        unowned_main_package_dirs = set(main_package_dirs) - {
+            # NB: We assume the `go_package` lives in the directory it's defined, which we validate
+            # by e.g. banning `**` in its sources field.
+            pkg.address.spec_path
+            for pkg in owned_main_packages
+        }
+        putative_targets.extend(
+            PutativeTarget.for_target_type(
+                GoBinaryTarget,
+                path=main_pkg_dir,
+                name="bin",
+                triggering_sources=tuple(),
+            )
+            for main_pkg_dir in unowned_main_package_dirs
+        )
 
     return PutativeTargets(putative_targets)
 

--- a/src/python/pants/backend/go/subsystems/golang.py
+++ b/src/python/pants/backend/go/subsystems/golang.py
@@ -17,7 +17,7 @@ from pants.core.util_rules.system_binaries import (
 from pants.engine.environment import Environment, EnvironmentRequest
 from pants.engine.process import Process, ProcessCacheScope, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.option.option_types import StrListOption, StrOption
+from pants.option.option_types import BoolOption, StrListOption, StrOption
 from pants.option.subsystem import Subsystem
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
@@ -90,6 +90,40 @@ class GolangSubsystem(Subsystem):
             Environment variables to set when invoking the `go` tool.
             Entries are either strings in the form `ENV_VAR=value` to set an explicit value;
             or just `ENV_VAR` to copy the value from Pants's own environment.
+            """
+        ),
+        advanced=True,
+    )
+
+    tailor_go_mod_targets = BoolOption(
+        "--tailor-go-mod-targets",
+        default=True,
+        help=softwrap(
+            """
+            If true, add a `go_mod` target with the `tailor` goal wherever there is a
+            `go.mod` file.
+            """
+        ),
+        advanced=True,
+    )
+    tailor_package_targets = BoolOption(
+        "--tailor-package-targets",
+        default=True,
+        help=softwrap(
+            """
+            If true, add a `go_package` target with the `tailor` goal in every directory with a
+            `.go` file.
+            """
+        ),
+        advanced=True,
+    )
+    tailor_binary_targets = BoolOption(
+        "--tailor-binary-targets",
+        default=True,
+        help=softwrap(
+            """
+            If true, add a `go_binary` target with the `tailor` goal in every directory with a
+            `.go` file with `package main`.
             """
         ),
         advanced=True,

--- a/src/python/pants/backend/helm/subsystems/helm.py
+++ b/src/python/pants/backend/helm/subsystems/helm.py
@@ -76,6 +76,12 @@ class HelmSubsystem(TemplatedExternalTool):
             """
         ),
     )
+    tailor = BoolOption(
+        "--tailor",
+        default=True,
+        help="If true, add `helm_chart` targets with the `tailor` goal.",
+        advanced=True,
+    )
 
     def generate_exe(self, plat: Platform) -> str:
         mapped_plat = self.default_url_platform_mapping[plat.value]

--- a/src/python/pants/backend/java/subsystems/javac.py
+++ b/src/python/pants/backend/java/subsystems/javac.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import logging
 
-from pants.option.option_types import ArgsListOption
+from pants.option.option_types import ArgsListOption, BoolOption
 from pants.option.subsystem import Subsystem
 
 logger = logging.getLogger(__name__)
@@ -17,3 +17,10 @@ class JavacSubsystem(Subsystem):
     help = "The javac Java source compiler."
 
     args = ArgsListOption(example="-g -deprecation")
+
+    tailor_source_targets = BoolOption(
+        "--tailor-source-targets",
+        default=True,
+        help="If true, add `java_sources` and `java_tests` targets with the `tailor` goal.",
+        advanced=True,
+    )

--- a/src/python/pants/backend/kotlin/subsystems/kotlin.py
+++ b/src/python/pants/backend/kotlin/subsystems/kotlin.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import logging
 
-from pants.option.option_types import DictOption
+from pants.option.option_types import BoolOption, DictOption
 from pants.option.subsystem import Subsystem
 from pants.util.strutil import softwrap
 
@@ -27,6 +27,12 @@ class KotlinSubsystem(Subsystem):
             targets consuming that resolve.
             """
         ),
+    )
+    tailor_source_targets = BoolOption(
+        "--tailor-source-targets",
+        default=True,
+        help="If true, add `kotlin_sources` targets with the `tailor` goal.",
+        advanced=True,
     )
 
     def version_for_resolve(self, resolve: str) -> str:

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -434,7 +434,7 @@ class PythonSetup(Subsystem):
             """
             If true, add `python_requirements` target generators with the `tailor` goal for
             requirements files.
-            
+
             This matches any file with the pattern `*requirements*.txt`. You will need to manually
             add `python_requirements` for different file names like `reqs.txt`.
             """

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -399,16 +399,30 @@ class PythonSetup(Subsystem):
         ),
         advanced=True,
     )
+
+    tailor_source_targets = BoolOption(
+        "--tailor-source-targets",
+        default=True,
+        help=softwrap(
+            """
+            If true, add `python_sources`, `python_tests`, and `python_test_utils` targets with
+            the `tailor` goal."""
+        ),
+        advanced=True,
+    )
     tailor_ignore_solitary_init_files = BoolOption(
         "--tailor-ignore-solitary-init-files",
         default=True,
         help=softwrap(
             """
-            Don't tailor `python_sources` targets for solitary `__init__.py` files, as
-            those usually exist as import scaffolding rather than true library code.
+            If true, don't add `python_sources` targets for solitary `__init__.py` files with the
+            `tailor` goal.
 
-            Set to False if you commonly have packages containing real code in
-            `__init__.py` and there are no other .py files in the package.
+            Solitary `__init__.py` files usually exist as import scaffolding rather than true
+            library code, so it can be noisy to add BUILD files.
+
+            Set to false if you commonly have packages containing real code in
+            `__init__.py` without other `.py` files in the package.
             """
         ),
         advanced=True,
@@ -416,15 +430,29 @@ class PythonSetup(Subsystem):
     tailor_requirements_targets = BoolOption(
         "--tailor-requirements-targets",
         default=True,
-        help="Tailor python_requirements() targets for requirements files.",
+        help=softwrap(
+            """
+            If true, add `python_requirements` target generators with the `tailor` goal for
+            requirements files.
+            
+            This matches any file with the pattern `*requirements*.txt`. You will need to manually
+            add `python_requirements` for different file names like `reqs.txt`.
+            """
+        ),
         advanced=True,
     )
     tailor_pex_binary_targets = BoolOption(
         "--tailor-pex-binary-targets",
         default=True,
-        help="Tailor pex_binary() targets for Python entry point files.",
+        help=softwrap(
+            """
+            If true, add `pex_binary` targets for Python files with a `__main__` clause with the
+            `tailor` goal.
+            """
+        ),
         advanced=True,
     )
+
     macos_big_sur_compatibility = BoolOption(
         "--macos-big-sur-compatibility",
         default=False,

--- a/src/python/pants/backend/scala/goals/tailor.py
+++ b/src/python/pants/backend/scala/goals/tailor.py
@@ -7,6 +7,7 @@ import os
 from dataclasses import dataclass
 from typing import Iterable
 
+from pants.backend.scala.subsystems.scala import ScalaSubsystem
 from pants.backend.scala.target_types import (
     ScalaJunitTestsGeneratorSourcesField,
     ScalaJunitTestsGeneratorTarget,
@@ -65,20 +66,22 @@ def classify_source_files(paths: Iterable[str]) -> dict[type[Target], set[str]]:
 async def find_putative_targets(
     req: PutativeScalaTargetsRequest,
     all_owned_sources: AllOwnedSources,
+    scala_subsystem: ScalaSubsystem,
 ) -> PutativeTargets:
-    all_scala_files_globs = req.search_paths.path_globs("*.scala")
-    all_scala_files = await Get(Paths, PathGlobs, all_scala_files_globs)
-    unowned_scala_files = set(all_scala_files.files) - set(all_owned_sources)
-    classified_unowned_scala_files = classify_source_files(unowned_scala_files)
-
     putative_targets = []
-    for tgt_type, paths in classified_unowned_scala_files.items():
-        for dirname, filenames in group_by_dir(paths).items():
-            putative_targets.append(
-                PutativeTarget.for_target_type(
-                    tgt_type, path=dirname, name=None, triggering_sources=sorted(filenames)
+
+    if scala_subsystem.tailor_source_targets:
+        all_scala_files_globs = req.search_paths.path_globs("*.scala")
+        all_scala_files = await Get(Paths, PathGlobs, all_scala_files_globs)
+        unowned_scala_files = set(all_scala_files.files) - set(all_owned_sources)
+        classified_unowned_scala_files = classify_source_files(unowned_scala_files)
+        for tgt_type, paths in classified_unowned_scala_files.items():
+            for dirname, filenames in group_by_dir(paths).items():
+                putative_targets.append(
+                    PutativeTarget.for_target_type(
+                        tgt_type, path=dirname, name=None, triggering_sources=sorted(filenames)
+                    )
                 )
-            )
 
     return PutativeTargets(putative_targets)
 

--- a/src/python/pants/backend/scala/subsystems/scala.py
+++ b/src/python/pants/backend/scala/subsystems/scala.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import logging
 
-from pants.option.option_types import DictOption
+from pants.option.option_types import BoolOption, DictOption
 from pants.option.subsystem import Subsystem
 from pants.util.strutil import softwrap
 
@@ -32,6 +32,16 @@ class ScalaSubsystem(Subsystem):
             maintained for a resolve. To support multiple Scala versions, use multiple resolves.
             """
         ),
+    )
+    tailor_source_targets = BoolOption(
+        "--tailor-source-targets",
+        default=True,
+        help=softwrap(
+            """
+            If true, add `scala_sources`, `scala_junit_tests`, and `scalatest_tests` targets with
+            the `tailor` goal."""
+        ),
+        advanced=True,
     )
 
     def version_for_resolve(self, resolve: str) -> str:

--- a/src/python/pants/backend/shell/shell_setup.py
+++ b/src/python/pants/backend/shell/shell_setup.py
@@ -37,6 +37,16 @@ class ShellSetup(Subsystem):
         help="Infer Shell dependencies on other Shell files by analyzing `source` statements.",
         advanced=True,
     )
+    tailor = BoolOption(
+        "--tailor",
+        default=True,
+        help=softwrap(
+            """
+            If true, add `shell_sources` and `shunit2_tests` targets with
+            the `tailor` goal."""
+        ),
+        advanced=True,
+    )
 
     @memoized_method
     def executable_search_path(self, env: Environment) -> tuple[str, ...]:

--- a/src/python/pants/backend/shell/tailor.py
+++ b/src/python/pants/backend/shell/tailor.py
@@ -7,6 +7,7 @@ import os
 from dataclasses import dataclass
 from typing import Iterable
 
+from pants.backend.shell.shell_setup import ShellSetup
 from pants.backend.shell.target_types import (
     ShellSourcesGeneratorTarget,
     Shunit2TestsGeneratorSourcesField,
@@ -46,8 +47,11 @@ def classify_source_files(paths: Iterable[str]) -> dict[type[Target], set[str]]:
 
 @rule(level=LogLevel.DEBUG, desc="Determine candidate shell targets to create")
 async def find_putative_targets(
-    req: PutativeShellTargetsRequest, all_owned_sources: AllOwnedSources
+    req: PutativeShellTargetsRequest, all_owned_sources: AllOwnedSources, shell_setup: ShellSetup
 ) -> PutativeTargets:
+    if not shell_setup.tailor:
+        return PutativeTargets()
+
     all_shell_files = await Get(Paths, PathGlobs, req.search_paths.path_globs("*.sh"))
     unowned_shell_files = set(all_shell_files.files) - set(all_owned_sources)
     classified_unowned_shell_files = classify_source_files(unowned_shell_files)

--- a/src/python/pants/backend/terraform/goals/tailor.py
+++ b/src/python/pants/backend/terraform/goals/tailor.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from pants.backend.terraform.target_types import TerraformModuleTarget
+from pants.backend.terraform.tool import TerraformTool
 from pants.core.goals.tailor import (
     AllOwnedSources,
     PutativeTarget,
@@ -28,8 +29,12 @@ class PutativeTerraformTargetsRequest(PutativeTargetsRequest):
 @rule(level=LogLevel.DEBUG, desc="Determine candidate Terraform targets to create")
 async def find_putative_terrform_module_targets(
     request: PutativeTerraformTargetsRequest,
+    terraform: TerraformTool,
     all_owned_sources: AllOwnedSources,
 ) -> PutativeTargets:
+    if not terraform.tailor:
+        return PutativeTargets()
+
     all_terraform_files = await Get(Paths, PathGlobs, request.search_paths.path_globs("*.tf"))
     unowned_terraform_files = set(all_terraform_files.files) - set(all_owned_sources)
 

--- a/src/python/pants/backend/terraform/tool.py
+++ b/src/python/pants/backend/terraform/tool.py
@@ -14,6 +14,7 @@ from pants.engine.internals.selectors import Get
 from pants.engine.platform import Platform
 from pants.engine.process import Process
 from pants.engine.rules import collect_rules, rule
+from pants.option.option_types import BoolOption
 from pants.util.logging import LogLevel
 from pants.util.meta import classproperty
 
@@ -40,6 +41,13 @@ class TerraformTool(TemplatedExternalTool):
             "1.0.7|macos_x86_64|80ae021d6143c7f7cbf4571f65595d154561a2a25fd934b7a8ccc1ebf3014b9b|33020029",
             "1.0.7|linux_x86_64|bc79e47649e2529049a356f9e60e06b47462bf6743534a10a4c16594f443be7b|32671441",
         ]
+
+    tailor = BoolOption(
+        "--tailor",
+        default=True,
+        help="If true, add `terraform_module` targets with the `tailor` goal.",
+        advanced=True,
+    )
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
In the past 3 months, at least 2 users have considered implementing their own `tailor` implementation for Python. But they can't because Pants forces you into our `python_sources` implementation if you activate `pants.backend.python`.

This PR means that every specific `tailor` implementation can be turned off.

Note that for some backends, we simply call the option `--tailor` when it seems very likely we won't add new target types, for brevity. For example, Docker is likely to only have `docker_image` (at least via `tailor`). If that gamble pays off, we can deprecate.