### PR TITLE
Fix error output of parametrize()

### DIFF
--- a/src/python/pants/engine/internals/parametrize.py
+++ b/src/python/pants/engine/internals/parametrize.py
@@ -56,8 +56,8 @@ class Parametrize:
                 raise Exception(
                     f"In {self}:\n  Positional argument `{arg}` contained separator characters "
                     f"(`{'`,`'.join(banned_chars)}`).\n\n"
-                    "To use `{arg}` as a parameter, you can pass it as a keyword argument to "
-                    "give it an alias. For example: `parametrize(short_memorable_name='{arg}')`"
+                    f"To use `{arg}` as a parameter, you can pass it as a keyword argument to "
+                    f"give it an alias. For example: `parametrize(short_memorable_name='{arg}')`"
                 )
             parameters[arg] = arg
         return parameters


### PR DESCRIPTION
In case of banned characters, the output contained the string {arg},
when it should have been evaluated as an f-string.

Changed the string to an f-string to fix the bug.