### PR TITLE
Add `update_env` to `process_execution::local`.

### DIFF
--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -334,6 +334,9 @@ impl Default for InputDigests {
 ///
 /// A process to be executed.
 ///
+/// When executing a `Process` using the `local::CommandRunner`, any `{chroot}` placeholders in the
+/// environment variables are replaced with the temporary sandbox path.
+///
 #[derive(DeepSizeOf, Derivative, Clone, Debug, Eq, Serialize)]
 #[derivative(PartialEq, Hash)]
 pub struct Process {

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -288,6 +288,11 @@ impl super::CommandRunner for CommandRunner {
           }
         };
 
+        // Start working on a mutable version of the process.
+        let mut req = req;
+        // Update env, replacing `{chroot}` placeholders with `workdir_path`.
+        update_env(&workdir_path, &mut req);
+
         // Prepare the workdir.
         let exclusive_spawn = prepare_workdir(
           workdir_path.clone(),
@@ -594,6 +599,23 @@ pub trait CapturedWorkdir {
     req: Process,
     exclusive_spawn: bool,
   ) -> Result<BoxStream<'c, Result<ChildOutput, String>>, String>;
+}
+
+/// Updates the Process env.
+///
+/// Mutates the env for the process `req`, replacing any `{chroot}` placeholders with
+/// `workdir_path`.
+///
+/// This matches the behavior of interactive processes executed by the `run` goal.
+///
+pub fn update_env(workdir_path: &Path, req: &mut Process) {
+  if let Some(workdir) = workdir_path.to_str() {
+    for value in req.env.values_mut() {
+      if value.contains("{chroot}") {
+        *value = value.replace("{chroot}", workdir);
+      }
+    }
+  }
 }
 
 /// Prepares the given workdir for use by the given Process.

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -608,6 +608,8 @@ pub trait CapturedWorkdir {
 ///
 /// This matches the behavior of interactive processes executed by the `run` goal.
 ///
+/// TODO: align this with the code path for interactive processes. Related issue #14386.
+///
 pub fn update_env(workdir_path: &Path, req: &mut Process) {
   if let Some(workdir) = workdir_path.to_str() {
     for value in req.env.values_mut() {


### PR DESCRIPTION
Replaces any `{chroot}` placeholders in the requested process env with the sandbox workdir.

This reflects the behavior for interactive processes executed with the `run` goal.