### PR TITLE
Stop caching venv in CI due to poisoned cache (#15342)

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -74,16 +74,6 @@ jobs:
         restore-keys: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-
 
           '
-    - name: Cache Pants Virtualenv
-      uses: actions/cache@v3
-      with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}-v1
-
-          '
-        path: '~/.cache/pants/pants_dev_deps
-
-          '
     - id: get-engine-hash
       name: Get native engine hash
       run: 'echo "::set-output name=hash::$(./build-support/bin/rust/print_engine_hash.sh)"
@@ -225,16 +215,6 @@ jobs:
         restore-keys: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-
 
           '
-    - name: Cache Pants Virtualenv
-      uses: actions/cache@v3
-      with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}-v1
-
-          '
-        path: '~/.cache/pants/pants_dev_deps
-
-          '
     - id: get-engine-hash
       name: Get native engine hash
       run: 'echo "::set-output name=hash::$(./build-support/bin/rust/print_engine_hash.sh)"
@@ -320,16 +300,6 @@ jobs:
         }}.*'']" >> $GITHUB_ENV
 
         '
-    - name: Cache Pants Virtualenv
-      uses: actions/cache@v3
-      with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}-v1
-
-          '
-        path: '~/.cache/pants/pants_dev_deps
-
-          '
     - name: Download native binaries
       uses: actions/download-artifact@v2
       with:
@@ -419,16 +389,6 @@ jobs:
         '
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
-    - name: Cache Pants Virtualenv
-      uses: actions/cache@v3
-      with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}-v1
-
-          '
-        path: '~/.cache/pants/pants_dev_deps
-
-          '
     - name: Download native binaries
       uses: actions/download-artifact@v2
       with:
@@ -502,16 +462,6 @@ jobs:
         '
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
-    - name: Cache Pants Virtualenv
-      uses: actions/cache@v3
-      with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}-v1
-
-          '
-        path: '~/.cache/pants/pants_dev_deps
-
-          '
     - name: Download native binaries
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,16 +74,6 @@ jobs:
         restore-keys: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-
 
           '
-    - name: Cache Pants Virtualenv
-      uses: actions/cache@v3
-      with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}-v1
-
-          '
-        path: '~/.cache/pants/pants_dev_deps
-
-          '
     - id: get-engine-hash
       name: Get native engine hash
       run: 'echo "::set-output name=hash::$(./build-support/bin/rust/print_engine_hash.sh)"
@@ -222,16 +212,6 @@ jobs:
 
           '
         restore-keys: '${{ runner.os }}-cargo-${{ hashFiles(''rust-toolchain'') }}-
-
-          '
-    - name: Cache Pants Virtualenv
-      uses: actions/cache@v3
-      with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}-v1
-
-          '
-        path: '~/.cache/pants/pants_dev_deps
 
           '
     - id: get-engine-hash
@@ -503,16 +483,6 @@ jobs:
         }}.*'']" >> $GITHUB_ENV
 
         '
-    - name: Cache Pants Virtualenv
-      uses: actions/cache@v3
-      with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}-v1
-
-          '
-        path: '~/.cache/pants/pants_dev_deps
-
-          '
     - name: Download native binaries
       uses: actions/download-artifact@v2
       with:
@@ -601,16 +571,6 @@ jobs:
         '
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
-    - name: Cache Pants Virtualenv
-      uses: actions/cache@v3
-      with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}-v1
-
-          '
-        path: '~/.cache/pants/pants_dev_deps
-
-          '
     - name: Download native binaries
       uses: actions/download-artifact@v2
       with:
@@ -683,16 +643,6 @@ jobs:
         '
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
-    - name: Cache Pants Virtualenv
-      uses: actions/cache@v3
-      with:
-        key: '${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles(''3rdparty/python/**'',
-          ''pants.toml'') }}-v1
-
-          '
-        path: '~/.cache/pants/pants_dev_deps
-
-          '
     - name: Download native binaries
       uses: actions/download-artifact@v2
       with:

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -139,17 +139,6 @@ def setup_toolchain_auth() -> Step:
     }
 
 
-def pants_virtualenv_cache() -> Step:
-    return {
-        "name": "Cache Pants Virtualenv",
-        "uses": "actions/cache@v3",
-        "with": {
-            "path": "~/.cache/pants/pants_dev_deps\n",
-            "key": "${{ runner.os }}-pants-venv-${{ matrix.python-version }}-${{ hashFiles('3rdparty/python/**', 'pants.toml') }}-v1\n",
-        },
-    }
-
-
 def global_env() -> Env:
     return {
         "PANTS_CONFIG_FILES": "+['pants.ci.toml']",
@@ -219,7 +208,6 @@ def install_go() -> Step:
 def bootstrap_caches() -> Sequence[Step]:
     return [
         *rust_caches(),
-        pants_virtualenv_cache(),
         # NB: This caching is only intended for the bootstrap jobs to avoid them needing to
         # re-compile when possible. Compare to the upload-artifact and download-artifact actions,
         # which are how the bootstrap jobs share the compiled binaries with the other jobs like
@@ -377,7 +365,6 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
                 download_apache_thrift(),
                 *setup_primary_python(),
                 expose_all_pythons(),
-                pants_virtualenv_cache(),
                 native_binaries_download(),
                 setup_toolchain_auth(),
                 {"name": "Run Python tests", "run": "./pants test ::\n"},
@@ -394,7 +381,6 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
             "steps": [
                 *checkout(),
                 *setup_primary_python(),
-                pants_virtualenv_cache(),
                 native_binaries_download(),
                 setup_toolchain_auth(),
                 {
@@ -446,7 +432,6 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
                 install_jdk(),
                 *setup_primary_python(),
                 expose_all_pythons(),
-                pants_virtualenv_cache(),
                 native_binaries_download(),
                 setup_toolchain_auth(),
                 {


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/15324 was not sufficient. 

Some jobs in the same CI run will work with the cache, but then others like Lint will fail. But it's also not consistent across PRs. So I expect that GitHub is not being stable with the Python's installation path anymore.