### PR TITLE
BSP compile exposes loose classfiles to allow IntelliJ to invoke tests

### DIFF
--- a/src/python/pants/backend/java/bsp/rules.py
+++ b/src/python/pants/backend/java/bsp/rules.py
@@ -10,11 +10,12 @@ from pants.backend.java.target_types import JavaFieldSet, JavaSourceField
 from pants.base.build_root import BuildRoot
 from pants.bsp.protocol import BSPHandlerMapping
 from pants.bsp.spec.base import BuildTargetIdentifier, StatusCode
-from pants.bsp.util_rules.compile import BSPCompileRequest, BSPCompileResult
 from pants.bsp.util_rules.lifecycle import BSPLanguageSupport
 from pants.bsp.util_rules.targets import (
     BSPBuildTargetsMetadataRequest,
     BSPBuildTargetsMetadataResult,
+    BSPCompileRequest,
+    BSPCompileResult,
     BSPResolveFieldFactoryRequest,
     BSPResolveFieldFactoryResult,
 )
@@ -78,9 +79,7 @@ def bsp_resolve_field_factory(
 async def bsp_resolve_java_metadata(
     _: JavaBSPBuildTargetsMetadataRequest,
 ) -> BSPBuildTargetsMetadataResult:
-    return BSPBuildTargetsMetadataResult(
-        can_compile=True,
-    )
+    return BSPBuildTargetsMetadataResult()
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/backend/java/bsp/rules.py
+++ b/src/python/pants/backend/java/bsp/rules.py
@@ -22,6 +22,7 @@ from pants.engine.rules import collect_rules, rule
 from pants.engine.target import FieldSet
 from pants.engine.unions import UnionRule
 from pants.jvm.bsp.compile import _jvm_bsp_compile, jvm_classes_directory
+from pants.jvm.bsp.compile import rules as jvm_compile_rules
 from pants.jvm.compile import ClasspathEntryRequestFactory
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
@@ -141,6 +142,7 @@ async def bsp_java_compile_request(
 def rules():
     return (
         *collect_rules(),
+        *jvm_compile_rules(),
         UnionRule(BSPLanguageSupport, JavaBSPLanguageSupport),
         UnionRule(BSPResolveFieldFactoryRequest, JavaBSPResolveFieldFactoryRequest),
         UnionRule(BSPBuildTargetsMetadataRequest, JavaBSPBuildTargetsMetadataRequest),

--- a/src/python/pants/backend/java/bsp/rules.py
+++ b/src/python/pants/backend/java/bsp/rules.py
@@ -1,15 +1,13 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-import dataclasses
 import logging
-import os
 from dataclasses import dataclass
 
 from pants.backend.java.bsp.spec import JavacOptionsItem, JavacOptionsParams, JavacOptionsResult
 from pants.backend.java.target_types import JavaFieldSet, JavaSourceField
 from pants.base.build_root import BuildRoot
 from pants.bsp.protocol import BSPHandlerMapping
-from pants.bsp.spec.base import BuildTargetIdentifier, StatusCode
+from pants.bsp.spec.base import BuildTargetIdentifier
 from pants.bsp.util_rules.lifecycle import BSPLanguageSupport
 from pants.bsp.util_rules.targets import (
     BSPBuildTargetsMetadataRequest,
@@ -19,19 +17,12 @@ from pants.bsp.util_rules.targets import (
     BSPResolveFieldFactoryRequest,
     BSPResolveFieldFactoryResult,
 )
-from pants.engine.addresses import Addresses
-from pants.engine.fs import CreateDigest, DigestEntries
-from pants.engine.internals.native_engine import EMPTY_DIGEST, Digest
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import collect_rules, rule
-from pants.engine.target import CoarsenedTargets, FieldSet, Targets
+from pants.engine.target import FieldSet
 from pants.engine.unions import UnionRule
-from pants.jvm.compile import (
-    ClasspathEntryRequest,
-    ClasspathEntryRequestFactory,
-    FallibleClasspathEntry,
-)
-from pants.jvm.resolve.key import CoursierResolveKey
+from pants.jvm.bsp.compile import _jvm_bsp_compile, jvm_classes_directory
+from pants.jvm.compile import ClasspathEntryRequestFactory
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
 
@@ -109,18 +100,13 @@ async def handle_bsp_java_options_request(
     request: HandleJavacOptionsRequest,
     build_root: BuildRoot,
 ) -> HandleJavacOptionsResult:
-    targets = await Get(Targets, BuildTargetIdentifier, request.bsp_target_id)
-
-    coarsened_targets = await Get(CoarsenedTargets, Addresses(tgt.address for tgt in targets))
-    resolve = await Get(CoursierResolveKey, CoarsenedTargets, coarsened_targets)
-
     return HandleJavacOptionsResult(
         JavacOptionsItem(
             target=request.bsp_target_id,
             options=(),
             classpath=(),
             class_directory=build_root.pathlib_path.joinpath(
-                f".pants.d/bsp/jvm/resolves/{resolve.name}/classes"
+                f".pants.d/bsp/{jvm_classes_directory(request.bsp_target_id)}"
             ).as_uri(),
         )
     )
@@ -148,46 +134,8 @@ class JavaBSPCompileRequest(BSPCompileRequest):
 async def bsp_java_compile_request(
     request: JavaBSPCompileRequest, classpath_entry_request: ClasspathEntryRequestFactory
 ) -> BSPCompileResult:
-    coarsened_targets = await Get(
-        CoarsenedTargets, Addresses([fs.address for fs in request.field_sets])
-    )
-    resolve = await Get(CoursierResolveKey, CoarsenedTargets, coarsened_targets)
-
-    results = await MultiGet(
-        Get(
-            FallibleClasspathEntry,
-            ClasspathEntryRequest,
-            classpath_entry_request.for_targets(component=coarsened_target, resolve=resolve),
-        )
-        for coarsened_target in coarsened_targets
-    )
-
-    status = StatusCode.OK
-    if any(r.exit_code != 0 for r in results):
-        status = StatusCode.ERROR
-
-    output_digest = EMPTY_DIGEST
-    if status == StatusCode.OK:
-        output_entries = []
-        for result in results:
-            if not result.output:
-                continue
-            entries = await Get(DigestEntries, Digest, result.output.digest)
-            output_entries.extend(
-                [
-                    dataclasses.replace(
-                        entry,
-                        path=f"jvm/resolves/{resolve.name}/lib/{os.path.basename(entry.path)}",
-                    )
-                    for entry in entries
-                ]
-            )
-        output_digest = await Get(Digest, CreateDigest(output_entries))
-
-    return BSPCompileResult(
-        status=status,
-        output_digest=output_digest,
-    )
+    result: BSPCompileResult = await _jvm_bsp_compile(request, classpath_entry_request)
+    return result
 
 
 def rules():

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -24,11 +24,12 @@ from pants.base.build_root import BuildRoot
 from pants.bsp.protocol import BSPHandlerMapping
 from pants.bsp.spec.base import BuildTarget, BuildTargetIdentifier, StatusCode
 from pants.bsp.spec.targets import DependencyModule
-from pants.bsp.util_rules.compile import BSPCompileRequest, BSPCompileResult
 from pants.bsp.util_rules.lifecycle import BSPLanguageSupport
 from pants.bsp.util_rules.targets import (
     BSPBuildTargetsMetadataRequest,
     BSPBuildTargetsMetadataResult,
+    BSPCompileRequest,
+    BSPCompileResult,
     BSPDependencyModulesRequest,
     BSPDependencyModulesResult,
     BSPResolveFieldFactoryRequest,
@@ -173,7 +174,11 @@ async def bsp_resolve_scala_metadata(
 ) -> BSPBuildTargetsMetadataResult:
     resolves = {fs.resolve.normalized_value(jvm) for fs in request.field_sets}
     if len(resolves) > 1:
-        raise ValueError("Cannot provide Scala metadata for multiple resolves.")
+        raise ValueError(
+            "Cannot provide Scala metadata for multiple resolves. Please set the "
+            "`resolve = jvm:$resolve` field in your `[experimental-bsp].groups_config_files` to "
+            "select the relevant resolve to use."
+        )
     resolve = list(resolves)[0]
     scala_version = scala.version_for_resolve(resolve)
 
@@ -194,7 +199,6 @@ async def bsp_resolve_scala_metadata(
             platform=ScalaPlatform.JVM,
             jars=scala_jar_uris,
         ),
-        can_compile=True,
         digest=scala_runtime.content.digest,
     )
 

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -48,6 +48,7 @@ from pants.engine.target import (
 )
 from pants.engine.unions import UnionRule
 from pants.jvm.bsp.compile import _jvm_bsp_compile, jvm_classes_directory
+from pants.jvm.bsp.compile import rules as jvm_compile_rules
 from pants.jvm.bsp.spec import MavenDependencyModule, MavenDependencyModuleArtifact
 from pants.jvm.compile import ClasspathEntryRequestFactory
 from pants.jvm.resolve.common import ArtifactRequirement, ArtifactRequirements, Coordinate
@@ -421,6 +422,7 @@ async def bsp_scala_compile_request(
 def rules():
     return (
         *collect_rules(),
+        *jvm_compile_rules(),
         UnionRule(BSPLanguageSupport, ScalaBSPLanguageSupport),
         UnionRule(BSPBuildTargetsMetadataRequest, ScalaBSPBuildTargetsMetadataRequest),
         UnionRule(BSPResolveFieldFactoryRequest, ScalaBSPResolveFieldFactoryRequest),

--- a/src/python/pants/backend/scala/compile/scalac.py
+++ b/src/python/pants/backend/scala/compile/scalac.py
@@ -182,6 +182,10 @@ async def compile_scala_source(
                 *local_plugins.args(local_scalac_plugins_relpath),
                 *(("-classpath", classpath_arg) if classpath_arg else ()),
                 *scalac.args,
+                # NB: We set a non-existent main-class so that using `-d` produces a `jar` manifest
+                # with stable content.
+                "-Xmain-class",
+                "no.main.class",
                 "-d",
                 output_file,
                 *sorted(

--- a/src/python/pants/bsp/util_rules/compile.py
+++ b/src/python/pants/bsp/util_rules/compile.py
@@ -7,44 +7,25 @@ import time
 import uuid
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import ClassVar, Generic, Type, TypeVar
+from typing import Type, TypeVar
 
 from pants.bsp.context import BSPContext
 from pants.bsp.protocol import BSPHandlerMapping
 from pants.bsp.spec.base import BuildTargetIdentifier, StatusCode, TaskId
 from pants.bsp.spec.compile import CompileParams, CompileReport, CompileResult, CompileTask
 from pants.bsp.spec.task import TaskFinishParams, TaskStartParams
-from pants.bsp.util_rules.targets import BSPBuildTargetInternal
+from pants.bsp.util_rules.targets import BSPBuildTargetInternal, BSPCompileRequest, BSPCompileResult
 from pants.engine.fs import Workspace
 from pants.engine.internals.native_engine import EMPTY_DIGEST, Digest, MergeDigests
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import _uncacheable_rule, collect_rules
 from pants.engine.target import FieldSet, Targets
-from pants.engine.unions import UnionMembership, UnionRule, union
+from pants.engine.unions import UnionMembership, UnionRule
 from pants.util.ordered_set import FrozenOrderedSet
 
 _logger = logging.getLogger(__name__)
 
 _FS = TypeVar("_FS", bound=FieldSet)
-
-
-@union
-@dataclass(frozen=True)
-class BSPCompileRequest(Generic[_FS]):
-    """Hook to allow language backends to compile targets."""
-
-    field_set_type: ClassVar[Type[_FS]]
-
-    bsp_target: BSPBuildTargetInternal
-    field_sets: tuple[_FS, ...]
-
-
-@dataclass(frozen=True)
-class BSPCompileResult:
-    """Result of compilation of a target capable of target compilation."""
-
-    status: StatusCode
-    output_digest: Digest
 
 
 class CompileRequestHandlerMapping(BSPHandlerMapping):

--- a/src/python/pants/jvm/bsp/compile.py
+++ b/src/python/pants/jvm/bsp/compile.py
@@ -1,0 +1,78 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import dataclasses
+import os
+
+from pants.bsp.spec.base import BuildTargetIdentifier, StatusCode
+from pants.bsp.util_rules.targets import BSPCompileRequest, BSPCompileResult
+from pants.engine.addresses import Addresses
+from pants.engine.fs import CreateDigest, DigestEntries
+from pants.engine.internals.native_engine import EMPTY_DIGEST, Digest
+from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.rules import rule_helper
+from pants.engine.target import CoarsenedTargets
+from pants.jvm.compile import (
+    ClasspathEntryRequest,
+    ClasspathEntryRequestFactory,
+    FallibleClasspathEntry,
+)
+from pants.jvm.resolve.key import CoursierResolveKey
+from pants.util.strutil import path_safe
+
+
+def jvm_classes_directory(target_id: BuildTargetIdentifier) -> str:
+    return f"jvm/classes/{path_safe(target_id.uri)}"
+
+
+@rule_helper
+async def _jvm_bsp_compile(
+    request: BSPCompileRequest, classpath_entry_request: ClasspathEntryRequestFactory
+) -> BSPCompileResult:
+    """Generically handles a BSPCompileRequest (subclass).
+
+    This is a `@rule_helper` rather than a `@rule`, because BSP backends like `java` and `scala`
+    independently declare their `BSPCompileRequest` union members. We can't register a single shared
+    `BSPCompileRequest` @union member for all JVM because their FieldSets are also declared via
+    @unions, and we can't forward the implementation of a @union to another the way we might with
+    an abstract class.
+    """
+    coarsened_targets = await Get(
+        CoarsenedTargets, Addresses([fs.address for fs in request.field_sets])
+    )
+    resolve = await Get(CoursierResolveKey, CoarsenedTargets, coarsened_targets)
+
+    results = await MultiGet(
+        Get(
+            FallibleClasspathEntry,
+            ClasspathEntryRequest,
+            classpath_entry_request.for_targets(component=coarsened_target, resolve=resolve),
+        )
+        for coarsened_target in coarsened_targets
+    )
+
+    status = StatusCode.OK
+    if any(r.exit_code != 0 for r in results):
+        status = StatusCode.ERROR
+
+    output_digest = EMPTY_DIGEST
+    if status == StatusCode.OK:
+        output_entries = []
+        for result in results:
+            if not result.output:
+                continue
+            entries = await Get(DigestEntries, Digest, result.output.digest)
+            output_entries.extend(
+                [
+                    dataclasses.replace(
+                        entry,
+                        path=f"{jvm_classes_directory(request.bsp_target.bsp_target_id)}/{os.path.basename(entry.path)}",
+                    )
+                    for entry in entries
+                ]
+            )
+        output_digest = await Get(Digest, CreateDigest(output_entries))
+
+    return BSPCompileResult(
+        status=status,
+        output_digest=output_digest,
+    )

--- a/src/python/pants/jvm/classpath.py
+++ b/src/python/pants/jvm/classpath.py
@@ -7,7 +7,10 @@ import logging
 from dataclasses import dataclass
 from typing import Iterator
 
-from pants.engine.fs import Digest
+from pants.core.util_rules import system_binaries
+from pants.core.util_rules.system_binaries import UnzipBinary
+from pants.engine.fs import Digest, MergeDigests, RemovePrefix
+from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import CoarsenedTargets
 from pants.jvm.compile import ClasspathEntry, ClasspathEntryRequest, ClasspathEntryRequestFactory
@@ -87,5 +90,47 @@ async def classpath(
     return Classpath(classpath_entries, resolve)
 
 
+@dataclass(frozen=True)
+class LooseClassfiles:
+    """The contents of a classpath entry as loose classfiles.
+
+    Note that `ClasspathEntry` and `Classpath` both guarantee that they contain JAR files, and so
+    creating loose classfiles from them involves extracting their entry.
+    """
+
+    digest: Digest
+
+
+@rule
+async def loose_classfiles(
+    classpath_entry: ClasspathEntry, unzip_binary: UnzipBinary
+) -> LooseClassfiles:
+    dest_dir = "dest"
+    process_results = await MultiGet(
+        Get(
+            ProcessResult,
+            Process(
+                argv=[
+                    unzip_binary.path,
+                    "-d",
+                    dest_dir,
+                    filename,
+                ],
+                output_directories=(dest_dir,),
+                description=f"Extract {filename}",
+                immutable_input_digests=dict(ClasspathEntry.immutable_inputs([classpath_entry])),
+            ),
+        )
+        for filename in ClasspathEntry.immutable_inputs_args([classpath_entry])
+    )
+
+    merged_digest = await Get(Digest, MergeDigests(pr.output_digest for pr in process_results))
+
+    return LooseClassfiles(await Get(Digest, RemovePrefix(merged_digest, dest_dir)))
+
+
 def rules():
-    return collect_rules()
+    return [
+        *collect_rules(),
+        *system_binaries.rules(),
+    ]


### PR DESCRIPTION
As described in https://github.com/pantsbuild/pants/issues/15050#issuecomment-1119084586: neither IntelliJ nor VSCode actually use the [`buildTarget/test`](https://build-server-protocol.github.io/docs/specification.html#test-request) endpoint. IntelliJ instead consumes the loose classfiles produced by [`buildTarget/compile`](https://build-server-protocol.github.io/docs/specification.html#compile-request).

This change begins populating the classes directory on a BSP-build-target basis, which is sufficient to allow IntelliJ to run tests, with some caveats. Before #15050 can be called complete, we should:
* Automatically set the JDK via #15284. Without this, test runs are very likely to encounter a class version mismatch until a user adjusts the project settings to set a JDK (IntelliJ defaults to 8, we default to 11).
* Add support for resources (currently ignored because they don't install a `@union` for compile, afaict) and ensure that the transitive dependencies of the BSP target roots are exposed as libraries. Whether a particular target is exposed as JARs via [`buildTarget/dependencyModules`](https://build-server-protocol.github.io/docs/specification.html#dependency-modules-request) or as an actual `BSPTarget` (via #15051) is an open question.