### PR TITLE
softwrap improvements

### DIFF
--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -230,6 +230,8 @@ def softwrap(text: str) -> str:
         - Replaces all occurrences of multiple spaces in a sentence with a single space
         - Replaces all occurrences of multiple newlines with exactly 2 newlines
         - Replaces singular newlines with a space (to turn a paragraph into one long line)
+            - Unless the following line is indented, in which case the newline and indentation
+              are preserved.
         - Double-newlines are preserved
         - Extra indentation is preserved, and also preserves the indented line's ending
             (If your indented line needs to be continued due to it being longer than the suggested
@@ -250,8 +252,8 @@ def softwrap(text: str) -> str:
     result_strs = []
     for i, line in enumerate(lines):
         line = _super_space_re.sub(r"\1 \2", line)
-        next_line = lines[i + 1] if i + 1 < len(lines) else None
-        if "\n" in (line, next_line) or line.startswith(" "):
+        next_line = lines[i + 1] if i + 1 < len(lines) else ""
+        if "\n" in (line, next_line) or line.startswith(" ") or next_line.startswith(" "):
             result_strs.append(line)
         else:
             result_strs.append(line.rstrip())

--- a/src/python/pants/util/strutil_test.py
+++ b/src/python/pants/util/strutil_test.py
@@ -1,6 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import textwrap
 from textwrap import dedent
 
 import pytest
@@ -248,6 +249,25 @@ def test_softwrap_multiline() -> None:
     assert (
         softwrap(
             """
+                Do you believe in:
+                    UFOs
+                    astral projections
+                    mental telepathy
+                    ...
+            """
+        )
+        == (
+            "Do you believe in:"
+            "\n"
+            "    UFOs\n"
+            "    astral projections\n"
+            "    mental telepathy\n"
+            "    ..."
+        )
+    )
+    assert (
+        softwrap(
+            """
                 Roll Call:
 
                     ```
@@ -300,6 +320,41 @@ def test_softwrap_multiline() -> None:
         )
     )
     assert softwrap("A\n\n\nB") == "A\n\nB"
+    assert (
+        softwrap(
+            f"""
+                Roll Call:
+                {bullet_list(["Dr. Peter Venkman", "Dr. Egon Spengler", "Dr. Raymond Stantz"])}
+                All here.
+            """
+        )
+        == (
+            "Roll Call:\n"
+            "  * Dr. Peter Venkman\n"
+            "  * Dr. Egon Spengler\n"
+            "  * Dr. Raymond Stantz\n"
+            "All here."
+        )
+    )
+    # This models when we output stdout/stderr. The canonical way to do that is to indent every line
+    #   so that softwrap preserves common indentation and the output "looks right"
+    stdout = "* Dr. Peter Venkman\n* Dr. Egon Spengler\n* Dr. Raymond Stantz"
+    assert (
+        softwrap(
+            f"""
+                Roll Call:
+                {textwrap.indent(stdout, " "*2)}
+                All here.
+            """
+        )
+        == (
+            "Roll Call:\n"
+            "  * Dr. Peter Venkman\n"
+            "  * Dr. Egon Spengler\n"
+            "  * Dr. Raymond Stantz\n"
+            "All here."
+        )
+    )
 
 
 _TEST_MEMORY_SIZES_PARAMS = [


### PR DESCRIPTION
Improving `softwrap` to not turn newline into space if the next line is indented. This allows for fewer newlines required (namely don't need a double-newline before an indented block).

I also added a test to demonstrate how we can softwrap with arbitrary strings in them with newlines being "preserved" (namely when we dump stdout/stderr). (FWIW I think we should have a generic helper specifically for stdout/stderr as I've seen `stdout: None` which is somewhat unhelpful, but that's open for a different debate).

[ci skip-rust]
[ci skip-build-wheels]