### PR TITLE
Use abspath to sandbox in PATH for docker tool shims. (#15341)

### DIFF
--- a/src/python/pants/backend/docker/util_rules/docker_binary.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary.py
@@ -150,7 +150,7 @@ async def find_docker(
         ),
     )
     tools_path = ".shims"
-    extra_env = {"PATH": os.path.join(tools_path, tools.bin_directory)}
+    extra_env = {"PATH": os.path.join("{chroot}", tools_path, tools.bin_directory)}
     extra_input_digests = {tools_path: tools.digest}
 
     return DockerBinary(


### PR DESCRIPTION
Fixes #15322 
Pre req PR #15340 
Supersedes #15330 

[ci skip-rust]