### PR TITLE
Add default mapping for pygithub

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -86,6 +86,7 @@ DEFAULT_MODULE_MAPPING = {
     "psycopg2-binary": ("psycopg2",),
     "pycrypto": ("Crypto",),
     "pyhamcrest": ("hamcrest",),
+    "pygithub": ("github",),
     "pygobject": ("gi",),
     "pyjwt": ("jwt",),
     "pyopenssl": ("OpenSSL",),


### PR DESCRIPTION
Adds default mapping necessary for `pygithub` => `github`. https://pypi.org/project/PyGithub/

Side Note: I was unable to successfully run `./pants test src/python/pants/util/frozendict_test.py` as outlined in the [contributing docs](https://www.pantsbuild.org/docs/contributor-overview). I believe this is related to python <= 3.8 not working on apple silicon.

<details>
<summary>Test Output</summary>
<p>

```sh
10:18:35.14 [INFO] Canceled: Building pytest.pex from 3rdparty/python/pytest.lock
10:18:36.52 [INFO] Completed: Building 1 requirement for requirements.pex from the 3rdparty/python/user_reqs.lock resolve: pytest<7.1.0,>=6.2.4
10:18:36.91 [INFO] Completed: Building pytest.pex from 3rdparty/python/pytest.lock
10:18:36.91 [ERROR] 1 Exception encountered:

Engine traceback:
  in select
  in pants.core.goals.test.run_tests
  in pants.backend.python.goals.pytest_runner.run_python_test (src/python/pants/util/frozendict_test.py:tests)
  in pants.backend.python.goals.pytest_runner.setup_pytest_for_target
  in pants.backend.python.util_rules.pex.create_pex (pytest.pex)
  in pants.backend.python.util_rules.pex.build_pex (pytest.pex)
  in pants.engine.process.fallible_to_exec_result_or_raise
Traceback (most recent call last):
  File "/Users/KHowa8/code/pants/src/python/pants/engine/process.py", line 272, in fallible_to_exec_result_or_raise
    raise ProcessExecutionFailure(
pants.engine.process.ProcessExecutionFailure: Process 'Building pytest.pex from 3rdparty/python/pytest.lock' failed with exit code 1.
stdout:

stderr:
    ERROR: Command errored out with exit status 1:
     command: /Users/KHowa8/.cache/pants/named_caches/pex_root/venvs/s/011fcb29/venv/bin/python3.7 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/qs/501mdfv5309fbjv3wxcln9gw0000gp/T/process-executionB9VlLd/.tmp/pip-req-build-s3eo3mxf/setup.py'"'"'; __file__='"'"'/private/var/folders/qs/501mdfv5309fbjv3wxcln9gw0000gp/T/process-executionB9VlLd/.tmp/pip-req-build-s3eo3mxf/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' --no-user-cfg egg_info --egg-base /private/var/folders/qs/501mdfv5309fbjv3wxcln9gw0000gp/T/process-executionB9VlLd/.tmp/pip-pip-egg-info-c0el9qfm
         cwd: /private/var/folders/qs/501mdfv5309fbjv3wxcln9gw0000gp/T/process-executionB9VlLd/.tmp/pip-req-build-s3eo3mxf/
    Complete output (11 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/Users/KHowa8/.cache/pants/named_caches/pex_root/venvs/s/011fcb29/venv/lib/python3.7/site-packages/setuptools/__init__.py", line 37, in <module>
        from setuptools.dist import Distribution, Feature  # vendor:skip
      File "/Users/KHowa8/.cache/pants/named_caches/pex_root/venvs/s/011fcb29/venv/lib/python3.7/site-packages/setuptools/dist.py", line 57, in <module>
        from setuptools import windows_support  # vendor:skip
      File "/Users/KHowa8/.cache/pants/named_caches/pex_root/venvs/s/011fcb29/venv/lib/python3.7/site-packages/setuptools/windows_support.py", line 2, in <module>
        import ctypes
      File "/Users/KHowa8/.pyenv/versions/3.7.13/lib/python3.7/ctypes/__init__.py", line 7, in <module>
        from _ctypes import Union, Structure, Array
    ModuleNotFoundError: No module named '_ctypes'
    ----------------------------------------
    ERROR: Command errored out with exit status 1:
     command: /Users/KHowa8/.cache/pants/named_caches/pex_root/venvs/s/011fcb29/venv/bin/python3.7 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/qs/501mdfv5309fbjv3wxcln9gw0000gp/T/process-executionB9VlLd/.tmp/pip-req-build-n6reu3vt/setup.py'"'"'; __file__='"'"'/private/var/folders/qs/501mdfv5309fbjv3wxcln9gw0000gp/T/process-executionB9VlLd/.tmp/pip-req-build-n6reu3vt/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' --no-user-cfg egg_info --egg-base /private/var/folders/qs/501mdfv5309fbjv3wxcln9gw0000gp/T/process-executionB9VlLd/.tmp/pip-pip-egg-info-mq5ruwbz
         cwd: /private/var/folders/qs/501mdfv5309fbjv3wxcln9gw0000gp/T/process-executionB9VlLd/.tmp/pip-req-build-n6reu3vt/
    Complete output (13 lines):
    /Users/KHowa8/.cache/pants/named_caches/pex_root/venvs/s/011fcb29/venv/lib/python3.7/site-packages/pkg_resources/__init__.py:1940: UserWarning: /private/var/folders/qs/501mdfv5309fbjv3wxcln9gw0000gp/T/process-executionB9VlLd/.tmp/pip-req-build-n6reu3vt/._icdiff.egg-info could not be properly decoded in UTF-8
      warnings.warn(msg)
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/Users/KHowa8/.cache/pants/named_caches/pex_root/venvs/s/011fcb29/venv/lib/python3.7/site-packages/setuptools/__init__.py", line 37, in <module>
        from setuptools.dist import Distribution, Feature  # vendor:skip
      File "/Users/KHowa8/.cache/pants/named_caches/pex_root/venvs/s/011fcb29/venv/lib/python3.7/site-packages/setuptools/dist.py", line 57, in <module>
        from setuptools import windows_support  # vendor:skip
      File "/Users/KHowa8/.cache/pants/named_caches/pex_root/venvs/s/011fcb29/venv/lib/python3.7/site-packages/setuptools/windows_support.py", line 2, in <module>
        import ctypes
      File "/Users/KHowa8/.pyenv/versions/3.7.13/lib/python3.7/ctypes/__init__.py", line 7, in <module>
        from _ctypes import Union, Structure, Array
    ModuleNotFoundError: No module named '_ctypes'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
    ERROR: Command errored out with exit status 1:
     command: /Users/KHowa8/.cache/pants/named_caches/pex_root/venvs/s/011fcb29/venv/bin/python3.7 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/qs/501mdfv5309fbjv3wxcln9gw0000gp/T/process-executionB9VlLd/.tmp/pip-req-build-ijfj2o1e/setup.py'"'"'; __file__='"'"'/private/var/folders/qs/501mdfv5309fbjv3wxcln9gw0000gp/T/process-executionB9VlLd/.tmp/pip-req-build-ijfj2o1e/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' --no-user-cfg egg_info --egg-base /private/var/folders/qs/501mdfv5309fbjv3wxcln9gw0000gp/T/process-executionB9VlLd/.tmp/pip-pip-egg-info-xsgfi71_
         cwd: /private/var/folders/qs/501mdfv5309fbjv3wxcln9gw0000gp/T/process-executionB9VlLd/.tmp/pip-req-build-ijfj2o1e/
    Complete output (11 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/Users/KHowa8/.cache/pants/named_caches/pex_root/venvs/s/011fcb29/venv/lib/python3.7/site-packages/setuptools/__init__.py", line 37, in <module>
        from setuptools.dist import Distribution, Feature  # vendor:skip
      File "/Users/KHowa8/.cache/pants/named_caches/pex_root/venvs/s/011fcb29/venv/lib/python3.7/site-packages/setuptools/dist.py", line 57, in <module>
        from setuptools import windows_support  # vendor:skip
      File "/Users/KHowa8/.cache/pants/named_caches/pex_root/venvs/s/011fcb29/venv/lib/python3.7/site-packages/setuptools/windows_support.py", line 2, in <module>
        import ctypes
      File "/Users/KHowa8/.pyenv/versions/3.7.13/lib/python3.7/ctypes/__init__.py", line 7, in <module>
        from _ctypes import Union, Structure, Array
    ModuleNotFoundError: No module named '_ctypes'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
Traceback (most recent call last):
  File "/Users/KHowa8/.cache/pants/named_caches/pex_root/installed_wheels/6a5463833452712ecf58a573b1b489c81d14aaed599e955c2af85cf793217a42/pex-2.1.84-py2.py3-none-any.whl/pex/jobs.py", line 512, in execute_parallel
    yield spawn_result.spawned_job.await_result()
  File "/Users/KHowa8/.cache/pants/named_caches/pex_root/installed_wheels/6a5463833452712ecf58a573b1b489c81d14aaed599e955c2af85cf793217a42/pex-2.1.84-py2.py3-none-any.whl/pex/jobs.py", line 216, in await_result
    job.wait()
  File "/Users/KHowa8/.cache/pants/named_caches/pex_root/installed_wheels/6a5463833452712ecf58a573b1b489c81d14aaed599e955c2af85cf793217a42/pex-2.1.84-py2.py3-none-any.whl/pex/jobs.py", line 75, in wait
    self._check_returncode(stderr)
  File "/Users/KHowa8/.cache/pants/named_caches/pex_root/installed_wheels/6a5463833452712ecf58a573b1b489c81d14aaed599e955c2af85cf793217a42/pex-2.1.84-py2.py3-none-any.whl/pex/jobs.py", line 144, in _check_returncode
    raise self.create_error(msg, stderr=stderr)
  File "/Users/KHowa8/.cache/pants/named_caches/pex_root/installed_wheels/6a5463833452712ecf58a573b1b489c81d14aaed599e955c2af85cf793217a42/pex-2.1.84-py2.py3-none-any.whl/pex/jobs.py", line 130, in create_error
    message=msg,
pex.jobs.Error: Executing /Users/KHowa8/.cache/pants/named_caches/pex_root/venvs/4a4903f4a53b18a8968a4b2bac7896c88ae1b1da/82b4909efecc2bbe750b1ca2cb66a81ec429d15a/pex --disable-pip-version-check --no-python-version-warning --exists-action a --use-deprecated legacy-resolver --isolated -q --cache-dir /Users/KHowa8/.cache/pants/named_caches/pex_root wheel --no-deps --wheel-dir /Users/KHowa8/.cache/pants/named_caches/pex_root/built_wheels/sdists/ipdb-0.13.9.tar.gz/951bd9a64731c444fd907a5ce268543020086a697f6be08f7cc2c9a752a278c5/cp37-cp37m.b5d7ddcd50654bbaa8b6629bec6253d1 /Users/KHowa8/.cache/pants/named_caches/pex_root/downloads/951bd9a64731c444fd907a5ce268543020086a697f6be08f7cc2c9a752a278c5/ipdb-0.13.9.tar.gz --index-url https://pypi.org/simple --retries 5 --timeout 15 failed with 1

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/KHowa8/.cache/pants/named_caches/pex_root/unzipped_pexes/479026d892c9306a8907938e1e49f73e1514eabe/.bootstrap/pex/pex.py", line 504, in execute
    exit_value = self._wrap_coverage(self._wrap_profiling, self._execute)
  File "/Users/KHowa8/.cache/pants/named_caches/pex_root/unzipped_pexes/479026d892c9306a8907938e1e49f73e1514eabe/.bootstrap/pex/pex.py", line 409, in _wrap_coverage
    return runner(*args)
  File "/Users/KHowa8/.cache/pants/named_caches/pex_root/unzipped_pexes/479026d892c9306a8907938e1e49f73e1514eabe/.bootstrap/pex/pex.py", line 440, in _wrap_profiling
    return runner(*args)
  File "/Users/KHowa8/.cache/pants/named_caches/pex_root/unzipped_pexes/479026d892c9306a8907938e1e49f73e1514eabe/.bootstrap/pex/pex.py", line 560, in _execute
    return self.execute_entry(self._pex_info.entry_point)
  File "/Users/KHowa8/.cache/pants/named_caches/pex_root/unzipped_pexes/479026d892c9306a8907938e1e49f73e1514eabe/.bootstrap/pex/pex.py", line 696, in execute_entry
    return self.execute_pkg_resources(entry_point)
  File "/Users/KHowa8/.cache/pants/named_caches/pex_root/unzipped_pexes/479026d892c9306a8907938e1e49f73e1514eabe/.bootstrap/pex/pex.py", line 728, in execute_pkg_resources
    return runner()
  File "/Users/KHowa8/.cache/pants/named_caches/pex_root/installed_wheels/6a5463833452712ecf58a573b1b489c81d14aaed599e955c2af85cf793217a42/pex-2.1.84-py2.py3-none-any.whl/pex/bin/pex.py", line 766, in main
    env=env,
  File "/Users/KHowa8/.cache/pants/named_caches/pex_root/installed_wheels/6a5463833452712ecf58a573b1b489c81d14aaed599e955c2af85cf793217a42/pex-2.1.84-py2.py3-none-any.whl/pex/bin/pex.py", line 786, in do_main
    cache=ENV.PEX_ROOT,
  File "/Users/KHowa8/.cache/pants/named_caches/pex_root/installed_wheels/6a5463833452712ecf58a573b1b489c81d14aaed599e955c2af85cf793217a42/pex-2.1.84-py2.py3-none-any.whl/pex/bin/pex.py", line 648, in build_pex
    max_parallel_jobs=pip_configuration.max_jobs,
  File "/Users/KHowa8/.cache/pants/named_caches/pex_root/installed_wheels/6a5463833452712ecf58a573b1b489c81d14aaed599e955c2af85cf793217a42/pex-2.1.84-py2.py3-none-any.whl/pex/resolve/lock_resolver.py", line 396, in resolve_from_lock
    max_parallel_jobs=max_parallel_jobs,
  File "/Users/KHowa8/.cache/pants/named_caches/pex_root/installed_wheels/6a5463833452712ecf58a573b1b489c81d14aaed599e955c2af85cf793217a42/pex-2.1.84-py2.py3-none-any.whl/pex/resolver.py", line 711, in install_distributions
    max_parallel_jobs=max_parallel_jobs,
  File "/Users/KHowa8/.cache/pants/named_caches/pex_root/installed_wheels/6a5463833452712ecf58a573b1b489c81d14aaed599e955c2af85cf793217a42/pex-2.1.84-py2.py3-none-any.whl/pex/resolver.py", line 606, in build_wheels
    max_jobs=max_parallel_jobs,
  File "/Users/KHowa8/.cache/pants/named_caches/pex_root/installed_wheels/6a5463833452712ecf58a573b1b489c81d14aaed599e955c2af85cf793217a42/pex-2.1.84-py2.py3-none-any.whl/pex/jobs.py", line 493, in execute_parallel
    raise error
  File "/Users/KHowa8/.cache/pants/named_caches/pex_root/installed_wheels/6a5463833452712ecf58a573b1b489c81d14aaed599e955c2af85cf793217a42/pex-2.1.84-py2.py3-none-any.whl/pex/jobs.py", line 515, in execute_parallel
    result = error_handler.handle_job_error(spawn_result.item, e)
  File "/Users/KHowa8/.cache/pants/named_caches/pex_root/installed_wheels/6a5463833452712ecf58a573b1b489c81d14aaed599e955c2af85cf793217a42/pex-2.1.84-py2.py3-none-any.whl/pex/jobs.py", line 399, in handle_job_error
    raise self._raise_type(self.job_error_message(item, job_error))
pex.resolve.resolvers.Untranslatable: pid 14568 -> /Users/KHowa8/.cache/pants/named_caches/pex_root/venvs/4a4903f4a53b18a8968a4b2bac7896c88ae1b1da/82b4909efecc2bbe750b1ca2cb66a81ec429d15a/pex --disable-pip-version-check --no-python-version-warning --exists-action a --use-deprecated legacy-resolver --isolated -q --cache-dir /Users/KHowa8/.cache/pants/named_caches/pex_root wheel --no-deps --wheel-dir /Users/KHowa8/.cache/pants/named_caches/pex_root/built_wheels/sdists/ipdb-0.13.9.tar.gz/951bd9a64731c444fd907a5ce268543020086a697f6be08f7cc2c9a752a278c5/cp37-cp37m.b5d7ddcd50654bbaa8b6629bec6253d1 /Users/KHowa8/.cache/pants/named_caches/pex_root/downloads/951bd9a64731c444fd907a5ce268543020086a697f6be08f7cc2c9a752a278c5/ipdb-0.13.9.tar.gz --index-url https://pypi.org/simple --retries 5 --timeout 15 exited with 1 and STDERR:
None



Use `--no-process-cleanup` to preserve process chroots for inspection.
```

</p>
</details>
