### PR TITLE
Disallow `!` patterns in `build_ignore`. (Cherry-pick of #15366)

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1316,10 +1316,9 @@ class GlobalOptions(BootstrapOptions, Subsystem):
     build_ignore = StrListOption(
         "--build-ignore",
         help=(
-            "Paths to ignore when identifying BUILD files.\n\n"
+            "Path globs or literals to ignore when identifying BUILD files.\n\n"
             "This does not affect any other filesystem operations; use `--pants-ignore` for "
-            "that instead.\n\n"
-            "Patterns use the gitignore pattern syntax (https://git-scm.com/docs/gitignore)."
+            "that instead."
         ),
         advanced=True,
     )
@@ -1462,6 +1461,13 @@ class GlobalOptions(BootstrapOptions, Subsystem):
 
         validate_remote_headers("remote_execution_headers")
         validate_remote_headers("remote_store_headers")
+
+        illegal_build_ignores = [i for i in opts.build_ignore if i.startswith("!")]
+        if illegal_build_ignores:
+            raise OptionsError(
+                "The `--build-ignore` option does not support negated globs, but was "
+                f"given: {illegal_build_ignores}."
+            )
 
     @staticmethod
     def create_py_executor(bootstrap_options: OptionValueContainer) -> PyExecutor:


### PR DESCRIPTION
As discussed in #15336, including a negation in `build_ignore` (unlike `pants_ignore`, which is interpreted directly by the `ignore` crate) amounts to adding an include pattern, which will not work as expected.

Closes #15336.

[ci skip-rust]
[ci skip-build-wheels]
