### PR TITLE
Disallow `!` patterns in `build_ignore`. (Cherry-pick of #15366)

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1460,12 +1460,10 @@ class GlobalOptions(BootstrapOptions, Subsystem):
         "--build-ignore",
         help=softwrap(
             """
-            Paths to ignore when identifying BUILD files.
+            Path globs or literals to ignore when identifying BUILD files.
 
             This does not affect any other filesystem operations; use `--pants-ignore` for
             that instead.
-
-            Patterns use the gitignore pattern syntax (https://git-scm.com/docs/gitignore).
             """
         ),
         advanced=True,
@@ -1619,6 +1617,13 @@ class GlobalOptions(BootstrapOptions, Subsystem):
 
         validate_remote_headers("remote_execution_headers")
         validate_remote_headers("remote_store_headers")
+
+        illegal_build_ignores = [i for i in opts.build_ignore if i.startswith("!")]
+        if illegal_build_ignores:
+            raise OptionsError(
+                "The `--build-ignore` option does not support negated globs, but was "
+                f"given: {illegal_build_ignores}."
+            )
 
     @staticmethod
     def create_py_executor(bootstrap_options: OptionValueContainer) -> PyExecutor:


### PR DESCRIPTION
As discussed in #15336, including a negation in `build_ignore` (unlike `pants_ignore`, which is interpreted directly by the `ignore` crate) amounts to adding an include pattern, which will not work as expected.

Closes #15336.

[ci skip-rust]
[ci skip-build-wheels]
