### PR TITLE
Fix `tailor` detection of existing `python_requirements` targets (Cherry-pick of #15363)

### DIFF
--- a/src/python/pants/backend/python/goals/tailor.py
+++ b/src/python/pants/backend/python/goals/tailor.py
@@ -134,7 +134,7 @@ async def find_putative_targets(
                     name=name,
                     type_alias="python_requirements",
                     triggering_sources=[req_file],
-                    owned_sources=[req_file],
+                    owned_sources=[name],
                     addressable=not global_options.use_deprecated_python_macros,
                     kwargs={} if name == "requirements.txt" else {"source": name},
                 )

--- a/src/python/pants/backend/python/goals/tailor_test.py
+++ b/src/python/pants/backend/python/goals/tailor_test.py
@@ -11,6 +11,7 @@ from pants.backend.python.goals.tailor import (
     classify_source_files,
     is_entry_point,
 )
+from pants.backend.python.macros.python_requirements import PythonRequirementsTargetGenerator
 from pants.backend.python.target_types import (
     PexBinary,
     PythonSourcesGeneratorTarget,
@@ -69,8 +70,8 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
     )
     rule_runner.write_files(
         {
-            "3rdparty/requirements.txt": "",
             "3rdparty/requirements-test.txt": "",
+            "already_owned/requirements.txt": "",
             **{
                 f"src/python/foo/{fp}": ""
                 for fp in (
@@ -92,7 +93,7 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
             PutativePythonTargetsRequest(PutativeTargetsSearchPaths(("",))),
             AllOwnedSources(
                 [
-                    "3rdparty/requirements.txt",
+                    "already_owned/requirements.txt",
                     "src/python/foo/bar/__init__.py",
                     "src/python/foo/bar/baz1.py",
                 ]
@@ -102,13 +103,11 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
     assert (
         PutativeTargets(
             [
-                PutativeTarget(
-                    "3rdparty",
-                    "requirements-test.txt",
-                    "python_requirements",
-                    ("3rdparty/requirements-test.txt",),
-                    ("3rdparty/requirements-test.txt",),
-                    addressable=True,
+                PutativeTarget.for_target_type(
+                    PythonRequirementsTargetGenerator,
+                    path="3rdparty",
+                    name="requirements-test.txt",
+                    triggering_sources=["3rdparty/requirements-test.txt"],
                     kwargs={"source": "requirements-test.txt"},
                 ),
                 PutativeTarget.for_target_type(

--- a/src/python/pants/core/goals/tailor_test.py
+++ b/src/python/pants/core/goals/tailor_test.py
@@ -607,7 +607,7 @@ def test_target_type_with_no_sources_field(rule_runner: RuleRunner) -> None:
         _ = PutativeTarget.for_target_type(FortranModule, "dir", "dir", ["a.f90"])
     expected_msg = (
         "A target of type FortranModule was proposed at address dir:dir with explicit sources a.f90, "
-        "but this target type does not have a `sources` field."
+        "but this target type does not have a `source` or `sources` field."
     )
     assert str(excinfo.value) == expected_msg
 


### PR DESCRIPTION
The docstring for `owning_sources` says it is supposed to be a glob, not a full file path.

While fixing this, we fix `PutativeTarget.for_target_type` to work with the `SingleSourceField`. It's possible there are bugs in our Docker `tailor` implementation because this uses it. But not sure.

[ci skip-rust]
[ci skip-build-wheels]