### PR TITLE
Fix `tailor` detection of existing `python_requirements` targets (Cherry-pick of #15363)

### DIFF
--- a/src/python/pants/backend/python/goals/tailor.py
+++ b/src/python/pants/backend/python/goals/tailor.py
@@ -132,7 +132,7 @@ async def find_putative_targets(
                     name=name,
                     type_alias="python_requirements",
                     triggering_sources=[req_file],
-                    owned_sources=[req_file],
+                    owned_sources=[name],
                     kwargs={} if name == "requirements.txt" else {"source": name},
                 )
             )

--- a/src/python/pants/backend/python/goals/tailor_test.py
+++ b/src/python/pants/backend/python/goals/tailor_test.py
@@ -11,6 +11,7 @@ from pants.backend.python.goals.tailor import (
     classify_source_files,
     is_entry_point,
 )
+from pants.backend.python.macros.python_requirements import PythonRequirementsTargetGenerator
 from pants.backend.python.target_types import (
     PexBinary,
     PythonSourcesGeneratorTarget,
@@ -67,8 +68,8 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(["--no-python-tailor-ignore-solitary-init-files"])
     rule_runner.write_files(
         {
-            "3rdparty/requirements.txt": "",
             "3rdparty/requirements-test.txt": "",
+            "already_owned/requirements.txt": "",
             **{
                 f"src/python/foo/{fp}": ""
                 for fp in (
@@ -90,7 +91,7 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
             PutativePythonTargetsRequest(PutativeTargetsSearchPaths(("",))),
             AllOwnedSources(
                 [
-                    "3rdparty/requirements.txt",
+                    "already_owned/requirements.txt",
                     "src/python/foo/bar/__init__.py",
                     "src/python/foo/bar/baz1.py",
                 ]
@@ -100,13 +101,11 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
     assert (
         PutativeTargets(
             [
-                PutativeTarget(
-                    "3rdparty",
-                    "requirements-test.txt",
-                    "python_requirements",
-                    ("3rdparty/requirements-test.txt",),
-                    ("3rdparty/requirements-test.txt",),
-                    addressable=True,
+                PutativeTarget.for_target_type(
+                    PythonRequirementsTargetGenerator,
+                    path="3rdparty",
+                    name="requirements-test.txt",
+                    triggering_sources=["3rdparty/requirements-test.txt"],
                     kwargs={"source": "requirements-test.txt"},
                 ),
                 PutativeTarget.for_target_type(

--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -30,6 +30,8 @@ from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import collect_rules, goal_rule, rule
 from pants.engine.target import (
     AllUnexpandedTargets,
+    MultipleSourcesField,
+    OptionalSingleSourceField,
     SourcesField,
     SourcesPaths,
     SourcesPathsRequest,
@@ -64,7 +66,9 @@ class PutativeTargetsSearchPaths:
 @memoized
 def default_sources_for_target_type(tgt_type: type[Target]) -> tuple[str, ...]:
     for field in tgt_type.core_fields:
-        if issubclass(field, SourcesField):
+        if issubclass(field, OptionalSingleSourceField):
+            return (field.default,) if field.default else tuple()
+        if issubclass(field, MultipleSourcesField):
             return field.default or tuple()
     return tuple()
 
@@ -123,10 +127,16 @@ class PutativeTarget:
         if name is None:
             name = os.path.basename(path)
 
-        explicit_sources = (kwargs or {}).get("sources")
+        kwargs = kwargs or {}
+        explicit_sources = cast(
+            "tuple[str, ...] | None",
+            (kwargs["source"],) if "source" in kwargs else kwargs.get("sources"),
+        )
         if explicit_sources is not None and not isinstance(explicit_sources, tuple):
             raise TypeError(
-                "Explicit sources passed to PutativeTarget.for_target_type must be a Tuple[str]."
+                "`source` or `sources` passed to PutativeTarget.for_target_type(kwargs=)`, but "
+                "it was not the correct type. `source` must be `str` and `sources` must be "
+                f"`tuple[str, ...]`. Was `{explicit_sources}` with type `{type(explicit_sources)}`."
             )
 
         default_sources = default_sources_for_target_type(target_type)
@@ -134,7 +144,7 @@ class PutativeTarget:
             raise AssertionError(
                 f"A target of type {target_type.__name__} was proposed at "
                 f"address {path}:{name} with explicit sources {', '.join(explicit_sources or triggering_sources)}, "
-                "but this target type does not have a `sources` field."
+                "but this target type does not have a `source` or `sources` field."
             )
         owned_sources = explicit_sources or default_sources or tuple()
         return cls(

--- a/src/python/pants/core/goals/tailor_test.py
+++ b/src/python/pants/core/goals/tailor_test.py
@@ -607,7 +607,7 @@ def test_target_type_with_no_sources_field(rule_runner: RuleRunner) -> None:
         _ = PutativeTarget.for_target_type(FortranModule, "dir", "dir", ["a.f90"])
     expected_msg = (
         "A target of type FortranModule was proposed at address dir:dir with explicit sources a.f90, "
-        "but this target type does not have a `sources` field."
+        "but this target type does not have a `source` or `sources` field."
     )
     assert str(excinfo.value) == expected_msg
 


### PR DESCRIPTION
The docstring for `owning_sources` says it is supposed to be a glob, not a full file path.

While fixing this, we fix `PutativeTarget.for_target_type` to work with the `SingleSourceField`. It's possible there are bugs in our Docker `tailor` implementation because this uses it. But not sure.

[ci skip-rust]
[ci skip-build-wheels]