### PR TITLE
Require that a target's `interpreter_constraints` are a subset of their dependencies'

### DIFF
--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -13,7 +13,7 @@ from pants.backend.python.lint.pylint.subsystem import (
     PylintFirstPartyPlugins,
 )
 from pants.backend.python.subsystems.setup import PythonSetup
-from pants.backend.python.target_types import InterpreterConstraintsField, PythonResolveField
+from pants.backend.python.target_types import PythonResolveField
 from pants.backend.python.util_rules import pex_from_targets
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import (
@@ -177,20 +177,10 @@ async def pylint_lint_partition(
     )
 
 
-# TODO(#15241): Improve the performance of this, especially by not needing to calculate transitive
-#  targets per field set. Doing that would require changing how we calculate interpreter
-#  constraints to be more like how we determine resolves, i.e. only inspecting the root target
-#  (and later validating the closure is compatible).
 @rule(desc="Determine if necessary to partition Pylint input", level=LogLevel.DEBUG)
 async def pylint_determine_partitions(
     request: PylintRequest, python_setup: PythonSetup, first_party_plugins: PylintFirstPartyPlugins
 ) -> PylintPartitions:
-    # We batch targets by their interpreter constraints + resolve to ensure, for example, that all
-    # Python targets run together and all Python 3 targets run together.
-    #
-    # Note that Pylint uses the AST of the interpreter that runs it. So, we include any plugin
-    # targets in this interpreter constraints calculation. However, we don't have to consider the
-    # resolve of the plugin targets, per https://github.com/pantsbuild/pants/issues/14320.
     coarsened_targets = await Get(
         CoarsenedTargets,
         CoarsenedTargetsRequest(
@@ -199,39 +189,50 @@ async def pylint_determine_partitions(
     )
     coarsened_targets_by_address = coarsened_targets.by_address()
 
+    ics = InterpreterConstraints.compute_for_targets(coarsened_targets, python_setup)
+    if ics is None:
+        # TODO: This case will be removed after the deprecation in `compute_for_targets`
+        # triggers.
+        interpreter_constraints_by_coarsened_target = {
+            ct: InterpreterConstraints.create_from_targets(ct.closure(), python_setup)
+            for ct in coarsened_targets
+        }
+    else:
+        interpreter_constraints_by_coarsened_target = {
+            ct: ic for ct, ic in zip(coarsened_targets, ics) if ic is not None
+        }
+
     resolve_and_interpreter_constraints_to_coarsened_targets: Mapping[
         tuple[str, InterpreterConstraints],
         tuple[OrderedSet[PylintFieldSet], OrderedSet[CoarsenedTarget]],
     ] = defaultdict(lambda: (OrderedSet(), OrderedSet()))
     for root in request.field_sets:
         ct = coarsened_targets_by_address[root.address]
-        # NB: If there is a cycle in the roots, we still only take the first resolve, as the other
+        # If there is a cycle in the roots, we still only take the first resolve, as the other
         # members will be validated when the partition is actually built.
         resolve = ct.representative[PythonResolveField].normalized_value(python_setup)
-        # NB: We need to consume the entire un-memoized closure here. See the method comment.
-        interpreter_constraints = InterpreterConstraints.create_from_compatibility_fields(
-            (
-                *(
-                    tgt[InterpreterConstraintsField]
-                    for tgt in ct.closure()
-                    if tgt.has_field(InterpreterConstraintsField)
-                ),
-                *first_party_plugins.interpreter_constraints_fields,
-            ),
-            python_setup,
-        )
+        interpreter_constraints = interpreter_constraints_by_coarsened_target.get(ct)
+        # If a CoarsenedTarget did not have IntepreterConstraints, then it's because it didn't
+        # contain any targets with the field, and so there is no point checking it.
+        if interpreter_constraints is None:
+            continue
+
         roots, root_cts = resolve_and_interpreter_constraints_to_coarsened_targets[
             (resolve, interpreter_constraints)
         ]
         roots.add(root)
         root_cts.add(ct)
 
+    first_party_ics = InterpreterConstraints.create_from_compatibility_fields(
+        first_party_plugins.interpreter_constraints_fields, python_setup
+    )
+
     return PylintPartitions(
         PylintPartition(
             FrozenOrderedSet(roots),
             FrozenOrderedSet(CoarsenedTargets(root_cts).closure()),
             resolve if len(python_setup.resolves) > 1 else None,
-            interpreter_constraints,
+            InterpreterConstraints.merge((interpreter_constraints, first_party_ics)),
         )
         for (resolve, interpreter_constraints), (roots, root_cts) in sorted(
             resolve_and_interpreter_constraints_to_coarsened_targets.items()

--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -476,6 +476,12 @@ async def validate_python_dependencies(
         ):
             non_subset_items.append(f"{dep_ics}: {dep.target.address}")
 
+    # TODO: When this deprecation triggers, it should be converted into an exception, and
+    # all usages of the InterpreterConstraints methods:
+    #   * compute_for_targets
+    #   * create_from_compatibility_fields
+    #   * create_from_targets
+    # ... should be replaced with calls to InterpreterConstraintsField.value_or_global_default.
     deprecated_conditional(
         lambda: bool(non_subset_items),
         removal_version="2.14.0.dev1",

--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -484,7 +484,7 @@ async def validate_python_dependencies(
     # ... should be replaced with calls to InterpreterConstraintsField.value_or_global_default.
     deprecated_conditional(
         lambda: bool(non_subset_items),
-        removal_version="2.14.0.dev1",
+        removal_version="2.13.0.dev2",
         entity=(
             "the `interpreter_constraints` of a target not being a subset "
             "of its dependencies' `interpreter_constraints`"

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -4,19 +4,18 @@
 from __future__ import annotations
 
 import itertools
-from collections import defaultdict
 from dataclasses import dataclass
-from typing import Iterable, Mapping, Optional, Tuple
+from typing import Iterable, Optional, Tuple
 
 from pants.backend.python.subsystems.setup import PythonSetup
-from pants.backend.python.target_types import PythonResolveField, PythonSourceField
+from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.typecheck.mypy.skip_field import SkipMyPyField
 from pants.backend.python.typecheck.mypy.subsystem import (
     MyPy,
     MyPyConfigFile,
     MyPyFirstPartyPlugins,
 )
-from pants.backend.python.util_rules import pex_from_targets
+from pants.backend.python.util_rules import partition, pex_from_targets
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import Pex, PexRequest, VenvPex, VenvPexProcess
 from pants.backend.python.util_rules.pex_from_targets import RequirementsPexRequest
@@ -31,13 +30,7 @@ from pants.engine.collection import Collection
 from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests, RemovePrefix
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import (
-    CoarsenedTarget,
-    CoarsenedTargets,
-    CoarsenedTargetsRequest,
-    FieldSet,
-    Target,
-)
+from pants.engine.target import CoarsenedTargets, FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
@@ -262,50 +255,10 @@ async def mypy_typecheck_partition(
 async def mypy_determine_partitions(
     request: MyPyRequest, mypy: MyPy, python_setup: PythonSetup
 ) -> MyPyPartitions:
-    coarsened_targets = await Get(
-        CoarsenedTargets,
-        CoarsenedTargetsRequest(
-            (field_set.address for field_set in request.field_sets), expanded_targets=True
-        ),
+
+    resolve_and_interpreter_constraints_to_coarsened_targets = (
+        await partition._by_interpreter_constraints_and_resolve(request.field_sets, python_setup)
     )
-    coarsened_targets_by_address = coarsened_targets.by_address()
-
-    ics = InterpreterConstraints.compute_for_targets(coarsened_targets, python_setup)
-    if ics is None:
-        # TODO: This case should be removed after the deprecation in `compute_for_targets`
-        # triggers.
-        interpreter_constraints_by_coarsened_target = {
-            ct: (
-                InterpreterConstraints.create_from_targets(ct.closure(), python_setup)
-                or mypy.interpreter_constraints
-            )
-            for ct in coarsened_targets
-        }
-    else:
-        interpreter_constraints_by_coarsened_target = {
-            ct: ic for ct, ic in zip(coarsened_targets, ics) if ic is not None
-        }
-
-    resolve_and_interpreter_constraints_to_coarsened_targets: Mapping[
-        tuple[str, InterpreterConstraints],
-        tuple[OrderedSet[MyPyFieldSet], OrderedSet[CoarsenedTarget]],
-    ] = defaultdict(lambda: (OrderedSet(), OrderedSet()))
-    for root in request.field_sets:
-        ct = coarsened_targets_by_address[root.address]
-        # If there is a cycle in the roots, we still only take the first resolve, as the other
-        # members will be validated when the partition is actually built.
-        resolve = ct.representative[PythonResolveField].normalized_value(python_setup)
-        interpreter_constraints = interpreter_constraints_by_coarsened_target.get(ct)
-        # If a CoarsenedTarget did not have IntepreterConstraints, then it's because it didn't
-        # contain any targets with the field, and so there is no point checking it.
-        if interpreter_constraints is None:
-            continue
-
-        roots, root_cts = resolve_and_interpreter_constraints_to_coarsened_targets[
-            (resolve, interpreter_constraints)
-        ]
-        roots.add(root)
-        root_cts.add(ct)
 
     return MyPyPartitions(
         MyPyPartition(

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -293,8 +293,6 @@ async def _mypy_interpreter_constraints(
 
         ics = InterpreterConstraints.compute_for_targets(coarsened_targets, python_setup)
         if ics is None:
-            # TODO: This case should be removed after the deprecation in `compute_for_targets`
-            # triggers.
             unique_constraints = {
                 InterpreterConstraints.create_from_targets(ct.closure(), python_setup)
                 for ct in coarsened_targets

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -29,10 +29,12 @@ from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.engine.addresses import Addresses, UnparsedAddressInputs
 from pants.engine.fs import EMPTY_DIGEST, Digest, DigestContents, FileContent
-from pants.engine.rules import Get, MultiGet, collect_rules, rule, rule_helper
+from pants.engine.rules import Get, collect_rules, rule, rule_helper
 from pants.engine.target import (
     AllTargets,
     AllTargetsRequest,
+    CoarsenedTargets,
+    CoarsenedTargetsRequest,
     FieldSet,
     Target,
     TransitiveTargets,
@@ -280,15 +282,26 @@ async def _mypy_interpreter_constraints(
     constraints = mypy.interpreter_constraints
     if mypy.options.is_default("interpreter_constraints"):
         all_tgts = await Get(AllTargets, AllTargetsRequest())
-        all_transitive_targets = await MultiGet(
-            Get(TransitiveTargets, TransitiveTargetsRequest([tgt.address]))
-            for tgt in all_tgts
-            if MyPyFieldSet.is_applicable(tgt)
+
+        coarsened_targets = await Get(
+            CoarsenedTargets,
+            CoarsenedTargetsRequest(
+                (tgt.address for tgt in all_tgts if MyPyFieldSet.is_applicable(tgt)),
+                expanded_targets=True,
+            ),
         )
-        unique_constraints = {
-            InterpreterConstraints.create_from_targets(transitive_targets.closure, python_setup)
-            for transitive_targets in all_transitive_targets
-        }
+
+        ics = InterpreterConstraints.compute_for_targets(coarsened_targets, python_setup)
+        if ics is None:
+            # TODO: This case should be removed after the deprecation in `compute_for_targets`
+            # triggers.
+            unique_constraints = {
+                InterpreterConstraints.create_from_targets(ct.closure(), python_setup)
+                for ct in coarsened_targets
+            }
+        else:
+            unique_constraints = {ic for ic in ics if ic}
+
         code_constraints = InterpreterConstraints(itertools.chain.from_iterable(unique_constraints))
         if code_constraints.requires_python38_or_newer(python_setup.interpreter_universe):
             constraints = code_constraints

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem_test.py
@@ -212,7 +212,7 @@ def test_setup_lockfile_interpreter_constraints(rule_runner: RuleRunner) -> None
             python_sources(name='lib2', dependencies=[":lib1"], interpreter_constraints=['==3.9.*'])
             """
         ),
-        [">=3.8,==3.9.*"],
+        ["==3.9.*"],
     )
     assert_lockfile_request(
         dedent(

--- a/src/python/pants/backend/python/util_rules/partition.py
+++ b/src/python/pants/backend/python/util_rules/partition.py
@@ -1,0 +1,71 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Iterable, Mapping, TypeVar
+
+from pants.backend.python.subsystems.setup import PythonSetup
+from pants.backend.python.target_types import PythonResolveField
+from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
+from pants.engine.rules import Get, rule_helper
+from pants.engine.target import CoarsenedTarget, CoarsenedTargets, CoarsenedTargetsRequest, FieldSet
+from pants.util.ordered_set import OrderedSet
+
+ResolveName = str
+
+FS = TypeVar("FS", bound=FieldSet)
+
+
+@rule_helper
+async def _by_interpreter_constraints_and_resolve(
+    field_sets: Iterable[FS],
+    python_setup: PythonSetup,
+) -> Mapping[
+    tuple[ResolveName, InterpreterConstraints],
+    tuple[OrderedSet[FS], OrderedSet[CoarsenedTarget]],
+]:
+    coarsened_targets = await Get(
+        CoarsenedTargets,
+        CoarsenedTargetsRequest(
+            (field_set.address for field_set in field_sets), expanded_targets=True
+        ),
+    )
+
+    coarsened_targets_by_address = coarsened_targets.by_address()
+    ics = InterpreterConstraints.compute_for_targets(coarsened_targets, python_setup)
+    if ics is None:
+        # TODO: This case should be removed after the deprecation in `compute_for_targets`
+        # triggers.
+        interpreter_constraints_by_coarsened_target = {
+            ct: InterpreterConstraints.create_from_targets(ct.closure(), python_setup)
+            for ct in coarsened_targets
+        }
+    else:
+        interpreter_constraints_by_coarsened_target = {
+            ct: ic for ct, ic in zip(coarsened_targets, ics) if ic is not None
+        }
+
+    resolve_and_interpreter_constraints_to_coarsened_targets: Mapping[
+        tuple[str, InterpreterConstraints],
+        tuple[OrderedSet[FS], OrderedSet[CoarsenedTarget]],
+    ] = defaultdict(lambda: (OrderedSet(), OrderedSet()))
+    for root in field_sets:
+        ct = coarsened_targets_by_address[root.address]
+        # If there is a cycle in the roots, we still only take the first resolve, as the other
+        # members will be validated when the partition is actually built.
+        resolve = ct.representative[PythonResolveField].normalized_value(python_setup)
+        interpreter_constraints = interpreter_constraints_by_coarsened_target.get(ct)
+        # If a CoarsenedTarget did not have IntepreterConstraints, then it's because it didn't
+        # contain any targets with the field, and so there is no point checking it.
+        if interpreter_constraints is None:
+            continue
+
+        roots, root_cts = resolve_and_interpreter_constraints_to_coarsened_targets[
+            (resolve, interpreter_constraints)
+        ]
+        roots.add(root)
+        root_cts.add(ct)
+
+    return resolve_and_interpreter_constraints_to_coarsened_targets

--- a/src/python/pants/backend/python/util_rules/partition.py
+++ b/src/python/pants/backend/python/util_rules/partition.py
@@ -36,8 +36,6 @@ async def _by_interpreter_constraints_and_resolve(
     coarsened_targets_by_address = coarsened_targets.by_address()
     ics = InterpreterConstraints.compute_for_targets(coarsened_targets, python_setup)
     if ics is None:
-        # TODO: This case should be removed after the deprecation in `compute_for_targets`
-        # triggers.
         interpreter_constraints_by_coarsened_target = {
             ct: InterpreterConstraints.create_from_targets(ct.closure(), python_setup)
             for ct in coarsened_targets

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -509,7 +509,7 @@ async def transitive_dependency_mapping(request: _DependencyMappingRequest) -> _
     )
 
 
-@rule(desc="Resolve transitive targets")
+@rule(desc="Resolve transitive targets", level=LogLevel.DEBUG)
 async def transitive_targets(request: TransitiveTargetsRequest) -> TransitiveTargets:
     """Find all the targets transitively depended upon by the target roots."""
 
@@ -547,7 +547,7 @@ def coarsened_targets_request(addresses: Addresses) -> CoarsenedTargetsRequest:
     return CoarsenedTargetsRequest(addresses)
 
 
-@rule
+@rule(desc="Resolve coarsened targets", level=LogLevel.DEBUG)
 async def coarsened_targets(request: CoarsenedTargetsRequest) -> CoarsenedTargets:
     dependency_mapping = await Get(
         _DependencyMapping,

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -36,7 +36,7 @@ from typing import (
 from typing_extensions import final
 
 from pants.base.deprecated import warn_or_error
-from pants.engine.addresses import Address, UnparsedAddressInputs, assert_single_address
+from pants.engine.addresses import Address, Addresses, UnparsedAddressInputs, assert_single_address
 from pants.engine.collection import Collection, DeduplicatedCollection
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import (
@@ -2515,6 +2515,28 @@ class InferredDependencies:
 
     def __iter__(self) -> Iterator[Address]:
         return iter(self.dependencies)
+
+
+FS = TypeVar("FS", bound="FieldSet")
+
+
+@union
+@dataclass(frozen=True)
+class ValidateDependenciesRequest(Generic[FS], ABC):
+    """A request to validate dependencies after they have been computed.
+
+    An implementing rule should raise an exception if dependencies are invalid.
+    """
+
+    field_set_type: ClassVar[Type[FS]]
+
+    field_set: FS
+    dependencies: Addresses
+
+
+@dataclass(frozen=True)
+class ValidatedDependencies:
+    pass
 
 
 class SpecialCasedDependencies(StringSequenceField, AsyncFieldMixin):


### PR DESCRIPTION
As described in #15241: we currently compute per-target interpreter constraints by doing per-target graph walks, which is both a scalability bottleneck (because you can almost never use the constraints directly on a target: you must compute them), and complex for users to reason about.

This change adds a `ValidateDependenciesRequest` union, which allows backends to validate the computed dependencies of a target. The python backend uses validation to deprecate the condition from #15241. When that deprecation triggers, most/all callsites which currently use `create_from_compatibility_fields`, `create_from_targets`, or the new `compute_from_targets` can instead directly consume the ICs of a root target in the graph.

This change also (temporarily) adds an `InterpreterConstraints.compute_from_targets` method which computes (in transitive-dependency-linear time) that the dependencies of a target have a superset of its own `interpreter_constraints`. This method allows us to (again, temporarily: see above) apply the optimization of avoiding set merging if targets are already valid. 

Reduces the runtime of un-memoized-but-cached `./pants check ::` by 10%.

Fixes #15241, fixes #15301, fixes #11072.