### PR TITLE
Add build_root_dir BUILD symbol

### DIFF
--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -245,7 +245,8 @@ def test_target_adaptor_parsed_correctly(target_adaptor_rule_runner: RuleRunner)
                         "helloworld/util",
                         "helloworld/util:tests",
                     ],
-                    build_file_dir=f"build file's dir is: {build_file_dir()}"
+                    build_file_dir=f"build file's dir is: {build_file_dir()}",
+                    build_root_dir=f"build root's dir is: {build_root_dir()}",
                 )
                 """
             )
@@ -265,6 +266,9 @@ def test_target_adaptor_parsed_correctly(target_adaptor_rule_runner: RuleRunner)
     # when encountering this, but it's fine at this stage.
     assert target_adaptor.kwargs["fake_field"] == 42
     assert target_adaptor.kwargs["build_file_dir"] == "build file's dir is: helloworld/dir"
+    assert target_adaptor.kwargs["build_root_dir"].startswith(
+        "build root's dir is: /tmp/_BUILD_ROOT"
+    )
 
 
 def test_target_adaptor_not_found(target_adaptor_rule_runner: RuleRunner) -> None:

--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -102,6 +102,7 @@ class Parser:
         symbols: dict[str, Any] = {
             **object_aliases.objects,
             "build_file_dir": lambda: PurePath(parse_state.rel_path()),
+            "build_root_dir": lambda: PurePath(build_root),
         }
         symbols.update((alias, Registrar(alias)) for alias in target_type_aliases)
 

--- a/src/python/pants/engine/internals/parser_test.py
+++ b/src/python/pants/engine/internals/parser_test.py
@@ -40,7 +40,7 @@ def test_unrecogonized_symbol() -> None:
             "If you expect to see more symbols activated in the below list,"
             f" refer to {doc_url('enabling-backends')} for all available"
             " backends to activate.\n\n"
-            f"All registered symbols: ['build_file_dir', 'caof', {fmt_extra_sym}'obj', 'prelude', 'tgt']"
+            f"All registered symbols: ['build_file_dir', 'build_root_dir' 'caof', {fmt_extra_sym}'obj', 'prelude', 'tgt']"
         )
 
     test_targs = ["fake1", "fake2", "fake3", "fake4", "fake5"]


### PR DESCRIPTION
It's possibly useful to have the build root dir (absolute path) in build files, so adding it.

[ci skip-rust]
[ci skip-build-wheels]