### PR TITLE
Index resources in BSP, and expose transitive dependencies in `compile` to allow tests to consume them

### DIFF
--- a/src/python/pants/bsp/rules.py
+++ b/src/python/pants/bsp/rules.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pants.bsp.context import BSPContext
-from pants.bsp.util_rules import compile, lifecycle, targets
+from pants.bsp.util_rules import compile, lifecycle, resources, targets
 from pants.engine.internals.session import SessionValues
 from pants.engine.rules import collect_rules, rule
 
@@ -18,5 +18,6 @@ def rules():
         *collect_rules(),
         *compile.rules(),
         *lifecycle.rules(),
+        *resources.rules(),
         *targets.rules(),
     )

--- a/src/python/pants/bsp/spec/resources.py
+++ b/src/python/pants/bsp/spec/resources.py
@@ -1,0 +1,51 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from pants.bsp.spec.base import BuildTargetIdentifier, Uri
+
+# -----------------------------------------------------------------------------------------------
+# Resources Request
+# See https://build-server-protocol.github.io/docs/specification.html#resources-request
+# -----------------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ResourcesParams:
+    targets: tuple[BuildTargetIdentifier, ...]
+
+    @classmethod
+    def from_json_dict(cls, d: dict[str, Any]) -> Any:
+        return cls(
+            targets=tuple(BuildTargetIdentifier.from_json_dict(x) for x in d["targets"]),
+        )
+
+    def to_json_dict(self) -> dict[str, Any]:
+        return {"targets": [tgt.to_json_dict() for tgt in self.targets]}
+
+
+@dataclass(frozen=True)
+class ResourcesItem:
+    target: BuildTargetIdentifier
+    # List of resource files.
+    resources: tuple[Uri, ...]
+
+    def to_json_dict(self):
+        result = {
+            "target": self.target.to_json_dict(),
+            "resources": self.resources,
+        }
+        return result
+
+
+@dataclass(frozen=True)
+class ResourcesResult:
+    items: tuple[ResourcesItem, ...]
+
+    def to_json_dict(self) -> dict[str, Any]:
+        return {
+            "items": [ri.to_json_dict() for ri in self.items],
+        }

--- a/src/python/pants/bsp/util_rules/lifecycle.py
+++ b/src/python/pants/bsp/util_rules/lifecycle.py
@@ -32,6 +32,7 @@ class BSPLanguageSupport:
     can_test: bool = False
     can_run: bool = False
     can_debug: bool = False
+    can_provide_resources: bool = False
 
 
 # -----------------------------------------------------------------------------------------------
@@ -54,6 +55,7 @@ async def bsp_build_initialize(
     test_provider_language_ids = []
     run_provider_language_ids = []
     debug_provider_language_ids = []
+    resources_provider = False
     language_support_impls = union_membership.get(BSPLanguageSupport)
     for lang in language_support_impls:
         if lang.can_compile:
@@ -64,6 +66,8 @@ async def bsp_build_initialize(
             run_provider_language_ids.append(lang.language_id)
         if lang.can_debug:
             debug_provider_language_ids.append(lang.language_id)
+        if lang.can_provide_resources:
+            resources_provider = True
 
     return InitializeBuildResult(
         display_name="Pants",
@@ -79,7 +83,7 @@ async def bsp_build_initialize(
             inverse_sources_provider=None,
             dependency_sources_provider=True,
             dependency_modules_provider=True,
-            resources_provider=None,
+            resources_provider=resources_provider,
             can_reload=None,
             build_target_changed_provider=None,
         ),

--- a/src/python/pants/bsp/util_rules/resources.py
+++ b/src/python/pants/bsp/util_rules/resources.py
@@ -1,0 +1,119 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Type, TypeVar
+
+from pants.bsp.protocol import BSPHandlerMapping
+from pants.bsp.spec.base import BuildTargetIdentifier
+from pants.bsp.spec.resources import ResourcesItem, ResourcesParams, ResourcesResult
+from pants.bsp.util_rules.targets import (
+    BSPBuildTargetInternal,
+    BSPResourcesRequest,
+    BSPResourcesResult,
+)
+from pants.engine.fs import Workspace
+from pants.engine.internals.native_engine import EMPTY_DIGEST, Digest, MergeDigests
+from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.rules import _uncacheable_rule, collect_rules
+from pants.engine.target import FieldSet, Targets
+from pants.engine.unions import UnionMembership, UnionRule
+from pants.util.ordered_set import FrozenOrderedSet
+
+_logger = logging.getLogger(__name__)
+
+_FS = TypeVar("_FS", bound=FieldSet)
+
+
+class ResourcesRequestHandlerMapping(BSPHandlerMapping):
+    method_name = "buildTarget/resources"
+    request_type = ResourcesParams
+    response_type = ResourcesResult
+
+
+@dataclass(frozen=True)
+class ResourcesForOneBSPTargetRequest:
+    bsp_target: BSPBuildTargetInternal
+
+
+@_uncacheable_rule
+async def resources_bsp_target(
+    request: ResourcesForOneBSPTargetRequest,
+    union_membership: UnionMembership,
+) -> BSPResourcesResult:
+    targets = await Get(Targets, BSPBuildTargetInternal, request.bsp_target)
+    resources_request_types: FrozenOrderedSet[Type[BSPResourcesRequest]] = union_membership.get(
+        BSPResourcesRequest
+    )
+    field_sets_by_request_type: dict[Type[BSPResourcesRequest], set[FieldSet]] = defaultdict(set)
+    for target in targets:
+        for resources_request_type in resources_request_types:
+            field_set_type = resources_request_type.field_set_type
+            if field_set_type.is_applicable(target):
+                field_set = field_set_type.create(target)
+                field_sets_by_request_type[resources_request_type].add(field_set)
+
+    resources_results = await MultiGet(
+        Get(
+            BSPResourcesResult,
+            BSPResourcesRequest,
+            resources_request_type(bsp_target=request.bsp_target, field_sets=tuple(field_sets)),
+        )
+        for resources_request_type, field_sets in field_sets_by_request_type.items()
+    )
+
+    resources = tuple(sorted({resource for rr in resources_results for resource in rr.resources}))
+
+    output_digest = await Get(Digest, MergeDigests([rr.output_digest for rr in resources_results]))
+
+    return BSPResourcesResult(
+        resources=resources,
+        output_digest=output_digest,
+    )
+
+
+@_uncacheable_rule
+async def bsp_resources_request(
+    request: ResourcesParams,
+    workspace: Workspace,
+) -> ResourcesResult:
+    bsp_targets = await MultiGet(
+        Get(BSPBuildTargetInternal, BuildTargetIdentifier, bsp_target_id)
+        for bsp_target_id in request.targets
+    )
+
+    resources_results = await MultiGet(
+        Get(
+            BSPResourcesResult,
+            ResourcesForOneBSPTargetRequest(
+                bsp_target=bsp_target,
+            ),
+        )
+        for bsp_target in bsp_targets
+    )
+
+    # TODO: Need to determine how resources are expected to be exposed. Directories? Individual files?
+    # Initially, it looks like loose directories.
+    output_digest = await Get(Digest, MergeDigests([r.output_digest for r in resources_results]))
+    if output_digest != EMPTY_DIGEST:
+        workspace.write_digest(output_digest, path_prefix=".pants.d/bsp")
+
+    return ResourcesResult(
+        tuple(
+            ResourcesItem(
+                target,
+                rr.resources,
+            )
+            for target, rr in zip(request.targets, resources_results)
+        )
+    )
+
+
+def rules():
+    return (
+        *collect_rules(),
+        UnionRule(BSPHandlerMapping, ResourcesRequestHandlerMapping),
+    )

--- a/src/python/pants/bsp/util_rules/targets.py
+++ b/src/python/pants/bsp/util_rules/targets.py
@@ -676,6 +676,10 @@ class BSPCompileResult:
 # -----------------------------------------------------------------------------------------------
 # Resources request.
 # See https://build-server-protocol.github.io/docs/specification.html#resources-request
+#
+# NB: This method is used only for the _indexing_ of resources, and not to add them to the
+# classpath (in the case of JVM targets). BSPCompileRequest implementations need to handle
+# movement of resources to accessible classpath entries.
 # -----------------------------------------------------------------------------------------------
 
 

--- a/src/python/pants/bsp/util_rules/targets.py
+++ b/src/python/pants/bsp/util_rules/targets.py
@@ -16,6 +16,7 @@ from pants.base.build_root import BuildRoot
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.base.specs import AddressSpecs, Specs
 from pants.base.specs_parser import SpecsParser
+from pants.bsp.spec.base import BSPData, BuildTarget, BuildTargetIdentifier, Uri
 from pants.bsp.goal import BSPGoal
 from pants.bsp.protocol import BSPHandlerMapping
 from pants.bsp.spec.base import (
@@ -669,6 +670,31 @@ class BSPCompileResult:
     """Result of compilation of a target capable of target compilation."""
 
     status: StatusCode
+    output_digest: Digest
+
+
+# -----------------------------------------------------------------------------------------------
+# Resources request.
+# See https://build-server-protocol.github.io/docs/specification.html#resources-request
+# -----------------------------------------------------------------------------------------------
+
+
+@union
+@dataclass(frozen=True)
+class BSPResourcesRequest(Generic[_FS]):
+    """Hook to allow language backends to provide resources for targets."""
+
+    field_set_type: ClassVar[Type[_FS]]
+
+    bsp_target: BSPBuildTargetInternal
+    field_sets: tuple[_FS, ...]
+
+
+@dataclass(frozen=True)
+class BSPResourcesResult:
+    """Resources for a target."""
+
+    resources: tuple[Uri, ...]
     output_digest: Digest
 
 

--- a/src/python/pants/bsp/util_rules/targets.py
+++ b/src/python/pants/bsp/util_rules/targets.py
@@ -16,7 +16,6 @@ from pants.base.build_root import BuildRoot
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.base.specs import AddressSpecs, Specs
 from pants.base.specs_parser import SpecsParser
-from pants.bsp.spec.base import BSPData, BuildTarget, BuildTargetIdentifier, Uri
 from pants.bsp.goal import BSPGoal
 from pants.bsp.protocol import BSPHandlerMapping
 from pants.bsp.spec.base import (
@@ -25,6 +24,7 @@ from pants.bsp.spec.base import (
     BuildTargetCapabilities,
     BuildTargetIdentifier,
     StatusCode,
+    Uri,
 )
 from pants.bsp.spec.targets import (
     DependencyModule,

--- a/src/python/pants/jvm/bsp/resources.py
+++ b/src/python/pants/jvm/bsp/resources.py
@@ -1,0 +1,69 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.base.build_root import BuildRoot
+from pants.bsp.spec.base import BuildTargetIdentifier
+from pants.bsp.util_rules.targets import BSPResourcesRequest, BSPResourcesResult
+from pants.core.target_types import ResourceSourceField
+from pants.core.util_rules import stripped_source_files
+from pants.core.util_rules.source_files import SourceFilesRequest
+from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
+from pants.engine.addresses import Addresses
+from pants.engine.fs import AddPrefix, Digest
+from pants.engine.internals.selectors import Get
+from pants.engine.rules import collect_rules, rule_helper
+from pants.engine.target import CoarsenedTargets, SourcesField
+from pants.util.strutil import path_safe
+
+
+def _jvm_resources_directory(target_id: BuildTargetIdentifier) -> str:
+    # TODO: Currently, we have a single BuildTarget per group, and so we include the transitive
+    # resource dependencies in one owning directory. As part of #15051 we'll likely need to find
+    # "owning" BuildTargets for each resources target in order to avoid having all of them
+    # emit the transitive resources.
+    return f"jvm/resources/{path_safe(target_id.uri)}"
+
+
+@rule_helper
+async def _jvm_bsp_resources(
+    request: BSPResourcesRequest,
+    build_root: BuildRoot,
+) -> BSPResourcesResult:
+    """Generically handles a BSPResourcesRequest (subclass).
+
+    This is a `@rule_helper` rather than a `@rule` for the same reason as `_jvm_bsp_compile`.
+    """
+    coarsened_targets = await Get(
+        CoarsenedTargets, Addresses([fs.address for fs in request.field_sets])
+    )
+
+    source_files = await Get(
+        StrippedSourceFiles,
+        SourceFilesRequest(
+            [tgt.get(SourcesField) for tgt in coarsened_targets.closure()],
+            for_sources_types=(ResourceSourceField,),
+            enable_codegen=True,
+        ),
+    )
+
+    rel_resources_dir = _jvm_resources_directory(request.bsp_target.bsp_target_id)
+    output_digest = await Get(
+        Digest,
+        AddPrefix(source_files.snapshot.digest, rel_resources_dir),
+    )
+
+    return BSPResourcesResult(
+        resources=(
+            # NB: IntelliJ requires that directory URIs end in slashes.
+            build_root.pathlib_path.joinpath(".pants.d/bsp", rel_resources_dir).as_uri()
+            + "/",
+        ),
+        output_digest=output_digest,
+    )
+
+
+def rules():
+    return [
+        *collect_rules(),
+        *stripped_source_files.rules(),
+    ]

--- a/src/python/pants/jvm/classpath.py
+++ b/src/python/pants/jvm/classpath.py
@@ -15,6 +15,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import CoarsenedTargets
 from pants.jvm.compile import ClasspathEntry, ClasspathEntryRequest, ClasspathEntryRequestFactory
 from pants.jvm.resolve.key import CoursierResolveKey
+from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
 
@@ -119,6 +120,7 @@ async def loose_classfiles(
                 output_directories=(dest_dir,),
                 description=f"Extract {filename}",
                 immutable_input_digests=dict(ClasspathEntry.immutable_inputs([classpath_entry])),
+                level=LogLevel.TRACE,
             ),
         )
         for filename in ClasspathEntry.immutable_inputs_args([classpath_entry])


### PR DESCRIPTION
#15347 exposed only the direct classpath entries of the BSP `BuildTarget`. This was incorrect for two reasons:
1. `resources` do not have an associated `BuildTarget` of their own (they do not have an [LSP language id](https://microsoft.github.io//language-server-protocol/specifications/lsp/3.17/specification/#textDocumentItem)), and are instead attached to a nearby `BuildTarget`.
2. The transitive dependencies of a `BuildTarget` are not exposed as `BuildTarget` level module dependencies (yet).

This change adjusts the `BSPCompileRequest` implementations for Java and Scala to expose their transitive dependencies, to address both of these issues. #15051 will remove this transitive exposure in favor of module-level dependencies for source code. But it will also need to attach `resources` to a nearby `BuildTarget` deterministically, and expose them as part of that target's `class_directory`.

This change also implements `ResourcesRequest`, although it is _not_ used to add resources to a classpath: only to index them.

Resources are now indexed, and tests can consume the transitive classpath (including resources). Fixes #15050.