### PR TITLE
`--changed-dependees` no longer runs on sibling targets from same target generator

### DIFF
--- a/src/python/pants/vcs/BUILD
+++ b/src/python/pants/vcs/BUILD
@@ -6,7 +6,7 @@ python_sources()
 python_tests(
     name="tests",
     overrides={
-        "changed_integration_test.py": {"timeout": 400},
+        "changed_integration_test.py": {"timeout": 90},
         "git_test.py": {"timeout": 120},
     },
 )

--- a/src/python/pants/vcs/BUILD
+++ b/src/python/pants/vcs/BUILD
@@ -6,7 +6,7 @@ python_sources()
 python_tests(
     name="tests",
     overrides={
-        "changed_integration_test.py": {"timeout": 90},
+        "changed_integration_test.py": {"timeout": 500},
         "git_test.py": {"timeout": 120},
     },
 )

--- a/src/python/pants/vcs/changed_integration_test.py
+++ b/src/python/pants/vcs/changed_integration_test.py
@@ -132,11 +132,11 @@ def test_change_transitive_dep(repo: str) -> None:
     append_to_file(repo, "transitive.sh", "# foo")
     assert_list_stdout(repo, ["//transitive.sh:lib"])
     assert_list_stdout(
-        repo, ["//:lib", "//dep.sh:lib", "//transitive.sh:lib"], dependees=DependeesOption.DIRECT
+        repo, ["//dep.sh:lib", "//transitive.sh:lib"], dependees=DependeesOption.DIRECT
     )
     assert_list_stdout(
         repo,
-        ["//:lib", "//app.sh:lib", "//dep.sh:lib", "//transitive.sh:lib"],
+        ["//app.sh:lib", "//dep.sh:lib", "//transitive.sh:lib"],
         dependees=DependeesOption.TRANSITIVE,
     )
 
@@ -156,6 +156,12 @@ def test_delete_generated_target(repo: str) -> None:
     delete_file(repo, "transitive.sh")
     for dependees in DependeesOption:
         assert_list_stdout(repo, ["//:lib"], dependees=dependees)
+
+    # If we also edit a sibling generated target, we should still (for now at least) include the
+    # target generator.
+    append_to_file(repo, "app.sh", "# foo")
+    for dependees in DependeesOption:
+        assert_list_stdout(repo, ["//:lib", "//app.sh:lib"], dependees=dependees)
 
 
 def test_delete_atom_target(repo: str) -> None:
@@ -198,7 +204,7 @@ def test_tag_filtering(repo: str) -> None:
     append_to_file(repo, "transitive.sh", "# foo")
     assert_list_stdout(
         repo,
-        ["//:lib", "//app.sh:lib", "//transitive.sh:lib"],
+        ["//app.sh:lib", "//transitive.sh:lib"],
         dependees=DependeesOption.TRANSITIVE,
         extra_args=["--tag=-b"],
     )


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/15313.

While a target generator depending on its generated targets is somewhat useful for project introspection goals...it is very annoying for `--changed-since`. It means that `./pants --changed-since=HEAD --changed-dependees=direct test` will _always_ run on all sibling targets from the same generator!

The simple fix is to filter out target generators with `--changed-dependees`. Their alias mechanism is not useful.

[ci skip-rust]
[ci skip-build-wheels]