### PR TITLE
Add `[python-infer].init_files` as more intuitive replacement for `[python-infer].inits`

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -180,10 +180,12 @@ class PythonInferSubsystem(Subsystem):
             """
         ),
         removal_version="2.14.0.dev1",
-        removal_hint=(
-            "Use the more powerful option `[python-infer].init_files`. For identical"
-            "behavior, set to 'always'. Otherwise, we recommend the default of `content_only` "
-            "(simply delete the option `[python-infer].inits` to trigger the default)."
+        removal_hint=softwrap(
+            """
+            Use the more powerful option `[python-infer].init_files`. For identical
+            behavior, set to 'always'. Otherwise, we recommend the default of `content_only`
+            (simply delete the option `[python-infer].inits` to trigger the default).
+            """
         ),
     )
 

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -154,7 +154,7 @@ class PythonInferSubsystem(Subsystem):
             dependencies, e.g. they will not show up in `{bin_name()} dependencies` and their own
             dependencies will not be used.
 
-            By default, Pants only adds a "proper" dependency if there is content in the 
+            By default, Pants only adds a "proper" dependency if there is content in the
             `__init__.py` file. This makes sure that dependencies are added when likely necessary
             to build, while also avoiding adding unnecessary dependencies. While accurate, those
             unnecessary dependencies can complicate setting metadata like the

--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -10,6 +10,7 @@ from pants.backend.python.dependency_inference.rules import (
     InferConftestDependencies,
     InferInitDependencies,
     InferPythonImportDependencies,
+    InitFilesInference,
     PythonInferSubsystem,
     UnownedDependencyError,
     UnownedDependencyUsage,
@@ -315,7 +316,11 @@ def test_infer_python_assets(caplog) -> None:
     )
 
 
-def test_infer_python_inits() -> None:
+@pytest.mark.parametrize(
+    "behavior",
+    [InitFilesInference.never, InitFilesInference.content_only, InitFilesInference.always],
+)
+def test_infer_python_inits(behavior: InitFilesInference) -> None:
     rule_runner = RuleRunner(
         rules=[
             *ancestor_files.rules(),
@@ -328,44 +333,50 @@ def test_infer_python_inits() -> None:
         target_types=[PythonSourcesGeneratorTarget],
     )
     rule_runner.set_options(
-        ["--python-infer-inits", "--source-root-patterns=src/python"],
-        env_inherit={"PATH", "PYENV_ROOT", "HOME"},
+        [f"--python-infer-init-files={behavior.value}"], env_inherit=PYTHON_BOOTSTRAP_ENV
     )
-
     rule_runner.write_files(
         {
-            "src/python/root/__init__.py": "",
+            "src/python/root/__init__.py": "content",
             "src/python/root/BUILD": "python_sources()",
             "src/python/root/mid/__init__.py": "",
             "src/python/root/mid/BUILD": "python_sources()",
-            "src/python/root/mid/leaf/__init__.py": "",
+            "src/python/root/mid/leaf/__init__.py": "content",
             "src/python/root/mid/leaf/f.py": "",
             "src/python/root/mid/leaf/BUILD": "python_sources()",
-            "src/python/type_stub/__init__.pyi": "",
+            "src/python/type_stub/__init__.pyi": "content",
             "src/python/type_stub/foo.pyi": "",
             "src/python/type_stub/BUILD": "python_sources()",
         }
     )
 
-    def run_dep_inference(address: Address) -> InferredDependencies:
+    def check(address: Address, expected: list[Address]) -> None:
         target = rule_runner.get_target(address)
-        return rule_runner.request(
+        result = rule_runner.request(
             InferredDependencies,
             [InferInitDependencies(target[PythonSourceField])],
         )
+        if behavior == InitFilesInference.never:
+            assert not result
+        else:
+            assert result == InferredDependencies(expected)
 
-    assert run_dep_inference(
-        Address("src/python/root/mid/leaf", relative_file_path="f.py")
-    ) == InferredDependencies(
+    check(
+        Address("src/python/root/mid/leaf", relative_file_path="f.py"),
         [
             Address("src/python/root", relative_file_path="__init__.py"),
-            Address("src/python/root/mid", relative_file_path="__init__.py"),
+            *(
+                []
+                if behavior is InitFilesInference.content_only
+                else [Address("src/python/root/mid", relative_file_path="__init__.py")]
+            ),
             Address("src/python/root/mid/leaf", relative_file_path="__init__.py"),
         ],
     )
-    assert run_dep_inference(
-        Address("src/python/type_stub", relative_file_path="foo.pyi")
-    ) == InferredDependencies([Address("src/python/type_stub", relative_file_path="__init__.pyi")])
+    check(
+        Address("src/python/type_stub", relative_file_path="foo.pyi"),
+        [Address("src/python/type_stub", relative_file_path="__init__.pyi")],
+    )
 
 
 def test_infer_python_conftests() -> None:

--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 from textwrap import dedent
 
 import pytest
@@ -316,10 +318,7 @@ def test_infer_python_assets(caplog) -> None:
     )
 
 
-@pytest.mark.parametrize(
-    "behavior",
-    [InitFilesInference.never, InitFilesInference.content_only, InitFilesInference.always],
-)
+@pytest.mark.parametrize("behavior", InitFilesInference)
 def test_infer_python_inits(behavior: InitFilesInference) -> None:
     rule_runner = RuleRunner(
         rules=[

--- a/src/python/pants/backend/python/typecheck/mypy/BUILD
+++ b/src/python/pants/backend/python/typecheck/mypy/BUILD
@@ -16,7 +16,7 @@ python_tests(
     name="mypyc_integration_test",
     sources=["mypyc_integration_test.py"],
     dependencies=["testprojects/src/python:mypyc_fib_directory"],
-    timeout=120,
+    timeout=220,
     # We want to make sure we can build with mypyc on both macOS and Linux.
     tags=["platform_specific_behavior"],
 )


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/15337. We now do a sensible thing by default with `__init__.py` files.

For users who have not set `[python-infer].inits` explicitly, this may result in new dependencies being picked up! That is somewhat breaking of a change. However, it is unlikely to happen because the user will have likely already set `[python-infer].inits` if there was content.

[ci skip-rust]