### PR TITLE
Support the `{chroot}` env placeholder for all interactive processes that are not executed in the workspace.

### DIFF
--- a/src/python/pants/core/goals/publish.py
+++ b/src/python/pants/core/goals/publish.py
@@ -240,6 +240,7 @@ async def run_publish(console: Console, publish: PublishSubsystem) -> Publish:
             outputs.append(pub.get_output_data(published=False, status=status))
             continue
 
+        logger.debug(f"Execute {pub.process}")
         res = await Effect(InteractiveProcessResult, InteractiveProcess, pub.process)
         if res.exit_code == 0:
             sigil = console.sigil_succeeded()

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -606,7 +606,8 @@ pub trait CapturedWorkdir {
 /// Mutates the env for the process `req`, replacing any `{chroot}` placeholders with
 /// `workdir_path`.
 ///
-/// This matches the behavior of interactive processes executed by the `run` goal.
+/// This matches the behavior of interactive processes executed in a temporary directory and those
+/// executed by the `run` goal.
 ///
 /// TODO: align this with the code path for interactive processes. Related issue #14386.
 ///

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -665,8 +665,17 @@ fn interactive_process(
       command.arg(arg);
     }
 
+    let mut env = env;
     if let Some(ref tempdir) = maybe_tempdir {
       command.current_dir(tempdir.path());
+
+      // Replace any references to `{chroot}` in the environment variables with the path to the
+      // temporary directory. This matches `engine.process_execution.local:update_env()`.
+      for value in env.values_mut() {
+        if value.contains("{chroot}") {
+          *value = value.replace("{chroot}", tempdir.path().to_str().unwrap());
+        }
+      }
     }
 
     command.env_clear();


### PR DESCRIPTION
The fix #15340 only addressed regular `Process` requests, with the intention of #15341 to leverage the support from the `run` goal, however `publish` does not use that code path, and thus does not yet have support for the `{chroot}` placeholder for env values.

This PR introduces generic support for the `{chroot}` placeholder also for `InteractiveProcess` requests that are not to be executed in the workspace. (the `run` goal executes the interactive processes in the workspace).
