### PR TITLE
Fix `[]` in file names with target generators (#15383)

### DIFF
--- a/src/python/pants/core/target_types_test.py
+++ b/src/python/pants/core/target_types_test.py
@@ -332,6 +332,7 @@ def test_generate_file_and_resource_targets() -> None:
             ),
             "assets/f1.ext": "",
             "assets/f2.ext": "",
+            "assets/f[3].ext": "",
             "assets/subdir/f.ext": "",
         }
     )
@@ -360,10 +361,12 @@ def test_generate_file_and_resource_targets() -> None:
     assert set(generated_files.values()) == {
         gen_file_tgt("f1.ext", tags=["overridden"]),
         gen_file_tgt("f2.ext"),
+        gen_file_tgt("f[[]3].ext"),
         gen_file_tgt("subdir/f.ext"),
     }
     assert set(generated_resources.values()) == {
         gen_resource_tgt("f1.ext", tags=["overridden"]),
         gen_resource_tgt("f2.ext"),
+        gen_resource_tgt("f[[]3].ext"),
         gen_resource_tgt("subdir/f.ext"),
     }

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -328,6 +328,7 @@ def test_address_specs_literals_vs_globs(address_specs_rule_runner: RuleRunner) 
             ),
             "demo/f1.txt": "",
             "demo/f2.txt": "",
+            "demo/f[3].txt": "",
             "demo/subdir/f.txt": "",
             "demo/subdir/f.another_ext": "",
             "demo/subdir/BUILD": "mock_tgt(name='another_ext', sources=['f.another_ext'])",
@@ -363,6 +364,8 @@ def test_address_specs_literals_vs_globs(address_specs_rule_runner: RuleRunner) 
             Address("demo", generated_name="f1.txt"),
             Address("demo", relative_file_path="f2.txt"),
             Address("demo", generated_name="f2.txt"),
+            Address("demo", relative_file_path="f[[]3].txt"),
+            Address("demo", generated_name="f[[]3].txt"),
         },
     )
     assert_resolved(
@@ -382,6 +385,8 @@ def test_address_specs_literals_vs_globs(address_specs_rule_runner: RuleRunner) 
         Address("demo", generated_name="f1.txt"),
         Address("demo", relative_file_path="f2.txt"),
         Address("demo", generated_name="f2.txt"),
+        Address("demo", relative_file_path="f[[]3].txt"),
+        Address("demo", generated_name="f[[]3].txt"),
         Address("demo", relative_file_path="subdir/f.txt"),
         Address("demo", generated_name="subdir/f.txt"),
         Address("demo/subdir", target_name="another_ext"),
@@ -396,6 +401,8 @@ def test_address_specs_literals_vs_globs(address_specs_rule_runner: RuleRunner) 
             Address("demo", generated_name="f1.txt"),
             Address("demo", relative_file_path="f2.txt"),
             Address("demo", generated_name="f2.txt"),
+            Address("demo", relative_file_path="f[[]3].txt"),
+            Address("demo", generated_name="f[[]3].txt"),
         },
     )
 

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import collections.abc
 import dataclasses
 import enum
+import glob as glob_stdlib
 import itertools
 import logging
 import os.path
@@ -1098,6 +1099,10 @@ def _generate_file_level_targets(
     `overrides` allows changing the fields for particular targets. It expects the full file path
      as the key.
     """
+
+    # Paths will have already been globbed, so they should be escaped. See
+    # https://github.com/pantsbuild/pants/issues/15381.
+    paths = [glob_stdlib.escape(path) for path in paths]
 
     def generate_address(base_address: Address, relativized_fp: str) -> Address:
         return (


### PR DESCRIPTION
Fixes #15381.

[ci skip-rust]
