### PR TITLE
Require that a target's `interpreter_constraints` are a subset of their dependencies' (Cherry-pick of #15373)

### DIFF
--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -3,9 +3,8 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
 from dataclasses import dataclass
-from typing import Mapping, Tuple
+from typing import Tuple
 
 from pants.backend.python.lint.pylint.subsystem import (
     Pylint,
@@ -13,8 +12,7 @@ from pants.backend.python.lint.pylint.subsystem import (
     PylintFirstPartyPlugins,
 )
 from pants.backend.python.subsystems.setup import PythonSetup
-from pants.backend.python.target_types import InterpreterConstraintsField, PythonResolveField
-from pants.backend.python.util_rules import pex_from_targets
+from pants.backend.python.util_rules import partition, pex_from_targets
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import (
     Pex,
@@ -35,10 +33,10 @@ from pants.engine.collection import Collection
 from pants.engine.fs import CreateDigest, Digest, Directory, MergeDigests, RemovePrefix
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import CoarsenedTarget, CoarsenedTargets, CoarsenedTargetsRequest, Target
+from pants.engine.target import CoarsenedTargets, Target
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
-from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
+from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.strutil import pluralize
 
 
@@ -177,61 +175,24 @@ async def pylint_lint_partition(
     )
 
 
-# TODO(#15241): Improve the performance of this, especially by not needing to calculate transitive
-#  targets per field set. Doing that would require changing how we calculate interpreter
-#  constraints to be more like how we determine resolves, i.e. only inspecting the root target
-#  (and later validating the closure is compatible).
 @rule(desc="Determine if necessary to partition Pylint input", level=LogLevel.DEBUG)
 async def pylint_determine_partitions(
     request: PylintRequest, python_setup: PythonSetup, first_party_plugins: PylintFirstPartyPlugins
 ) -> PylintPartitions:
-    # We batch targets by their interpreter constraints + resolve to ensure, for example, that all
-    # Python targets run together and all Python 3 targets run together.
-    #
-    # Note that Pylint uses the AST of the interpreter that runs it. So, we include any plugin
-    # targets in this interpreter constraints calculation. However, we don't have to consider the
-    # resolve of the plugin targets, per https://github.com/pantsbuild/pants/issues/14320.
-    coarsened_targets = await Get(
-        CoarsenedTargets,
-        CoarsenedTargetsRequest(
-            (field_set.address for field_set in request.field_sets), expanded_targets=True
-        ),
+    resolve_and_interpreter_constraints_to_coarsened_targets = (
+        await partition._by_interpreter_constraints_and_resolve(request.field_sets, python_setup)
     )
-    coarsened_targets_by_address = coarsened_targets.by_address()
 
-    resolve_and_interpreter_constraints_to_coarsened_targets: Mapping[
-        tuple[str, InterpreterConstraints],
-        tuple[OrderedSet[PylintFieldSet], OrderedSet[CoarsenedTarget]],
-    ] = defaultdict(lambda: (OrderedSet(), OrderedSet()))
-    for root in request.field_sets:
-        ct = coarsened_targets_by_address[root.address]
-        # NB: If there is a cycle in the roots, we still only take the first resolve, as the other
-        # members will be validated when the partition is actually built.
-        resolve = ct.representative[PythonResolveField].normalized_value(python_setup)
-        # NB: We need to consume the entire un-memoized closure here. See the method comment.
-        interpreter_constraints = InterpreterConstraints.create_from_compatibility_fields(
-            (
-                *(
-                    tgt[InterpreterConstraintsField]
-                    for tgt in ct.closure()
-                    if tgt.has_field(InterpreterConstraintsField)
-                ),
-                *first_party_plugins.interpreter_constraints_fields,
-            ),
-            python_setup,
-        )
-        roots, root_cts = resolve_and_interpreter_constraints_to_coarsened_targets[
-            (resolve, interpreter_constraints)
-        ]
-        roots.add(root)
-        root_cts.add(ct)
+    first_party_ics = InterpreterConstraints.create_from_compatibility_fields(
+        first_party_plugins.interpreter_constraints_fields, python_setup
+    )
 
     return PylintPartitions(
         PylintPartition(
             FrozenOrderedSet(roots),
             FrozenOrderedSet(CoarsenedTargets(root_cts).closure()),
             resolve if len(python_setup.resolves) > 1 else None,
-            interpreter_constraints,
+            InterpreterConstraints.merge((interpreter_constraints, first_party_ics)),
         )
         for (resolve, interpreter_constraints), (roots, root_cts) in sorted(
             resolve_and_interpreter_constraints_to_coarsened_targets.items()

--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -11,6 +11,7 @@ import dataclasses
 import logging
 import os.path
 from collections import defaultdict
+from dataclasses import dataclass
 from itertools import chain
 from textwrap import dedent
 from typing import DefaultDict, Dict, Generator, Optional, Tuple, cast
@@ -24,6 +25,7 @@ from pants.backend.python.goals.setup_py import InvalidEntryPoint
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (
     EntryPoint,
+    InterpreterConstraintsField,
     PexBinariesGeneratorTarget,
     PexBinary,
     PexBinaryDependenciesField,
@@ -40,6 +42,8 @@ from pants.backend.python.target_types import (
     ResolvePexEntryPointRequest,
     ResolvePythonDistributionEntryPointsRequest,
 )
+from pants.backend.python.util_rules.interpreter_constraints import interpreter_constraints_contains
+from pants.base.deprecated import deprecated_conditional
 from pants.engine.addresses import Address, Addresses, UnparsedAddressInputs
 from pants.engine.fs import GlobMatchErrorBehavior, PathGlobs, Paths
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
@@ -47,6 +51,7 @@ from pants.engine.target import (
     Dependencies,
     DependenciesRequest,
     ExplicitlyProvidedDependencies,
+    FieldSet,
     GeneratedTargets,
     GenerateTargetsRequest,
     InjectDependenciesRequest,
@@ -55,6 +60,8 @@ from pants.engine.target import (
     TargetFilesGeneratorSettings,
     TargetFilesGeneratorSettingsRequest,
     Targets,
+    ValidatedDependencies,
+    ValidateDependenciesRequest,
     WrappedTarget,
 )
 from pants.engine.unions import UnionMembership, UnionRule
@@ -62,6 +69,7 @@ from pants.source.source_root import SourceRoot, SourceRootRequest
 from pants.util.docutil import doc_url
 from pants.util.frozendict import FrozenDict
 from pants.util.ordered_set import OrderedSet
+from pants.util.strutil import bullet_list, softwrap
 
 logger = logging.getLogger(__name__)
 
@@ -433,6 +441,70 @@ async def inject_python_distribution_dependencies(
     )
 
 
+# -----------------------------------------------------------------------------------------------
+# Dependency validation
+# -----------------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DependencyValidationFieldSet(FieldSet):
+    required_fields = (InterpreterConstraintsField,)
+
+    interpreter_constraints: InterpreterConstraintsField
+
+
+class PythonValidateDependenciesRequest(ValidateDependenciesRequest):
+    field_set_type = DependencyValidationFieldSet
+
+
+@rule
+async def validate_python_dependencies(
+    request: PythonValidateDependenciesRequest,
+    python_setup: PythonSetup,
+) -> ValidatedDependencies:
+    dependencies = await MultiGet(Get(WrappedTarget, Address, d) for d in request.dependencies)
+
+    # Validate that the ICs for dependencies are all compatible with our own.
+    target_ics = request.field_set.interpreter_constraints.value_or_global_default(python_setup)
+    non_subset_items = []
+    for dep in dependencies:
+        if not dep.target.has_field(InterpreterConstraintsField):
+            continue
+        dep_ics = dep.target[InterpreterConstraintsField].value_or_global_default(python_setup)
+        if not interpreter_constraints_contains(
+            dep_ics, target_ics, python_setup.interpreter_universe
+        ):
+            non_subset_items.append(f"{dep_ics}: {dep.target.address}")
+
+    # TODO: When this deprecation triggers, it should be converted into an exception, and
+    # all usages of the InterpreterConstraints methods:
+    #   * compute_for_targets
+    #   * create_from_compatibility_fields
+    #   * create_from_targets
+    # ... should be replaced with calls to InterpreterConstraintsField.value_or_global_default.
+    deprecated_conditional(
+        lambda: bool(non_subset_items),
+        removal_version="2.13.0.dev2",
+        entity=(
+            "the `interpreter_constraints` of a target not being a subset "
+            "of its dependencies' `interpreter_constraints`"
+        ),
+        hint=softwrap(
+            f"""
+            The target {request.field_set.address} has the `interpreter_constraints` {target_ics},
+            which are not a subset of the `interpreter_constraints` of some of its dependencies:
+
+            {bullet_list(sorted(non_subset_items))}
+
+            To fix this, you should likely adjust {request.field_set.address}'s
+            `interpreter_constraints` to match the narrowest range in the above list.
+            """
+        ),
+    )
+
+    return ValidatedDependencies()
+
+
 def rules():
     return (
         *collect_rules(),
@@ -441,4 +513,5 @@ def rules():
         UnionRule(GenerateTargetsRequest, GenerateTargetsFromPexBinaries),
         UnionRule(InjectDependenciesRequest, InjectPexBinaryEntryPointDependency),
         UnionRule(InjectDependenciesRequest, InjectPythonDistributionDependencies),
+        UnionRule(ValidateDependenciesRequest, PythonValidateDependenciesRequest),
     )

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem_test.py
@@ -212,7 +212,7 @@ def test_setup_lockfile_interpreter_constraints(rule_runner: RuleRunner) -> None
             python_sources(name='lib2', dependencies=[":lib1"], interpreter_constraints=['==3.9.*'])
             """
         ),
-        [">=3.8,==3.9.*"],
+        ["==3.9.*"],
     )
     assert_lockfile_request(
         dedent(

--- a/src/python/pants/backend/python/util_rules/interpreter_constraints.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import functools
 import itertools
 from collections import defaultdict
-from typing import Iterable, Iterator, Sequence, TypeVar
+from typing import Iterable, Iterator, Sequence, Tuple, TypeVar
 
 from pkg_resources import Requirement
 from typing_extensions import Protocol
@@ -15,9 +15,10 @@ from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import InterpreterConstraintsField
 from pants.build_graph.address import Address
 from pants.engine.engine_aware import EngineAwareParameter
-from pants.engine.target import Target
+from pants.engine.target import CoarsenedTarget, Target
 from pants.util.docutil import bin_name
 from pants.util.frozendict import FrozenDict
+from pants.util.memo import memoized
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 
 
@@ -36,8 +37,23 @@ class FieldSetWithInterpreterConstraints(Protocol):
 _FS = TypeVar("_FS", bound=FieldSetWithInterpreterConstraints)
 
 
+RawConstraints = Tuple[str, ...]
+
+
 # The current maxes are 2.7.18 and 3.6.15.  We go much higher, for safety.
 _PATCH_VERSION_UPPER_BOUND = 30
+
+
+@memoized
+def interpreter_constraints_contains(
+    a: RawConstraints, b: RawConstraints, interpreter_universe: tuple[str, ...]
+) -> bool:
+    """A memoized version of `InterpreterConstraints.contains`.
+
+    This is a function in order to keep the memoization cache on the module rather than on an
+    instance. It can't go on `PythonSetup`, since that would cause a cycle with this module.
+    """
+    return InterpreterConstraints(a).contains(InterpreterConstraints(b), interpreter_universe)
 
 
 # Normally we would subclass `DeduplicatedCollection`, but we want a custom constructor.
@@ -75,6 +91,95 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
         except ValueError:
             parsed_requirement = Requirement.parse(f"CPython{constraint}")
         return parsed_requirement
+
+    @classmethod
+    def compute_for_targets(
+        cls, cts: Sequence[CoarsenedTarget], python_setup: PythonSetup
+    ) -> list[InterpreterConstraints | None] | None:
+        """Compute the InterpreterConstraints for the given (Coarsened)Target instances.
+
+        If any reachable target has ICs which are not compatible with its dependencies (i.e., are
+        not a subset), then the entire result is None. TODO: When the deprecations below trigger,
+        this should turn into an error, and the return value should become infallible.
+
+        If a (Coarsened)Target root does not have ICs of its own, then its entry in the return value
+        will be None.
+
+        TODO: See the deprecation in `target_types_rules.validate_python_dependencies`.
+        """
+
+        interpreter_constraints: dict[CoarsenedTarget, set[RawConstraints]] = {}
+
+        def compute(ct: CoarsenedTarget) -> set[RawConstraints] | None:
+            """Validate a CoarsenedTarget, and return its computed constraints.
+
+            A CT will only have multiple constraints if it is acting as an alias for its
+            dependencies, because it doesn't have constraints of its own.
+            """
+            ics = interpreter_constraints.get(ct)
+            if ics is not None:
+                return ics
+
+            # Validate that all members of a cycle have the same ICs.
+            ics = {
+                tgt[InterpreterConstraintsField].value_or_global_default(python_setup)
+                for tgt in ct.members
+                if tgt.has_field(InterpreterConstraintsField)
+            }
+
+            if len(ics) > 1:
+                return None
+
+            # Collect the distinct interpreter constraints of dependencies.
+            dependency_interpreter_constraints = defaultdict(list)
+            for dependency in ct.dependencies:
+                dependency_ics = compute(dependency)
+                if dependency_ics is None:
+                    return None
+                for d_ics in dependency_ics:
+                    dependency_interpreter_constraints[d_ics].append(dependency)
+
+            if ics:
+                single_ics = next(iter(ics))
+                # Validate that the ICs for dependencies are all compatible with our own.
+                if not all(
+                    interpreter_constraints_contains(
+                        d_ics, single_ics, python_setup.interpreter_universe
+                    )
+                    for d_ics, targets in dependency_interpreter_constraints.items()
+                ):
+                    return None
+            else:
+                # If there are no interpreter constraints in a CT, then it acts like an alias for
+                # the targets it points to.
+                ics = set(dependency_interpreter_constraints)
+
+            interpreter_constraints[ct] = ics
+            return ics
+
+        def canonical(ics: set[RawConstraints]) -> InterpreterConstraints | None:
+            """If a CoarsenedTarget has multiple ICs, it's because it didn't have any of its own."""
+            if len(ics) == 1:
+                return InterpreterConstraints(next(iter(ics)))
+            else:
+                return None
+
+        result = []
+        for ct in cts:
+            root_ics = compute(ct)
+            if root_ics is None:
+                # TODO: When the deprecation triggers, `compute` should eagerly raise instead.
+                return None
+            result.append(canonical(root_ics))
+        return result
+
+    @classmethod
+    def merge(cls, ics: Iterable[InterpreterConstraints]) -> InterpreterConstraints:
+        return InterpreterConstraints(
+            cls.merge_constraint_sets(
+                tuple(str(requirement) for requirement in ic) for ic in ics if ic
+            )
+        )
 
     @classmethod
     def merge_constraint_sets(cls, constraint_sets: Iterable[Iterable[str]]) -> list[Requirement]:
@@ -145,6 +250,7 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
     def create_from_targets(
         cls, targets: Iterable[Target], python_setup: PythonSetup
     ) -> InterpreterConstraints:
+        """TODO: See the deprecation in `target_types_rules.validate_python_dependencies`."""
         return cls.create_from_compatibility_fields(
             (
                 tgt[InterpreterConstraintsField]
@@ -158,6 +264,7 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
     def create_from_compatibility_fields(
         cls, fields: Iterable[InterpreterConstraintsField], python_setup: PythonSetup
     ) -> InterpreterConstraints:
+        """TODO: See the deprecation in `target_types_rules.validate_python_dependencies`."""
         constraint_sets = {field.value_or_global_default(python_setup) for field in fields}
         # This will OR within each field and AND across fields.
         merged_constraints = cls.merge_constraint_sets(constraint_sets)
@@ -352,6 +459,8 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
 
         This is restricted to the set of minor Python versions specified in `universe`.
         """
+        if self == other:
+            return True
         this = self.enumerate_python_versions(interpreter_universe)
         that = other.enumerate_python_versions(interpreter_universe)
         return this.issuperset(that)

--- a/src/python/pants/backend/python/util_rules/partition.py
+++ b/src/python/pants/backend/python/util_rules/partition.py
@@ -1,0 +1,69 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Iterable, Mapping, TypeVar
+
+from pants.backend.python.subsystems.setup import PythonSetup
+from pants.backend.python.target_types import PythonResolveField
+from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
+from pants.engine.rules import Get, rule_helper
+from pants.engine.target import CoarsenedTarget, CoarsenedTargets, CoarsenedTargetsRequest, FieldSet
+from pants.util.ordered_set import OrderedSet
+
+ResolveName = str
+
+FS = TypeVar("FS", bound=FieldSet)
+
+
+@rule_helper
+async def _by_interpreter_constraints_and_resolve(
+    field_sets: Iterable[FS],
+    python_setup: PythonSetup,
+) -> Mapping[
+    tuple[ResolveName, InterpreterConstraints],
+    tuple[OrderedSet[FS], OrderedSet[CoarsenedTarget]],
+]:
+    coarsened_targets = await Get(
+        CoarsenedTargets,
+        CoarsenedTargetsRequest(
+            (field_set.address for field_set in field_sets), expanded_targets=True
+        ),
+    )
+
+    coarsened_targets_by_address = coarsened_targets.by_address()
+    ics = InterpreterConstraints.compute_for_targets(coarsened_targets, python_setup)
+    if ics is None:
+        interpreter_constraints_by_coarsened_target = {
+            ct: InterpreterConstraints.create_from_targets(ct.closure(), python_setup)
+            for ct in coarsened_targets
+        }
+    else:
+        interpreter_constraints_by_coarsened_target = {
+            ct: ic for ct, ic in zip(coarsened_targets, ics) if ic is not None
+        }
+
+    resolve_and_interpreter_constraints_to_coarsened_targets: Mapping[
+        tuple[str, InterpreterConstraints],
+        tuple[OrderedSet[FS], OrderedSet[CoarsenedTarget]],
+    ] = defaultdict(lambda: (OrderedSet(), OrderedSet()))
+    for root in field_sets:
+        ct = coarsened_targets_by_address[root.address]
+        # If there is a cycle in the roots, we still only take the first resolve, as the other
+        # members will be validated when the partition is actually built.
+        resolve = ct.representative[PythonResolveField].normalized_value(python_setup)
+        interpreter_constraints = interpreter_constraints_by_coarsened_target.get(ct)
+        # If a CoarsenedTarget did not have IntepreterConstraints, then it's because it didn't
+        # contain any targets with the field, and so there is no point checking it.
+        if interpreter_constraints is None:
+            continue
+
+        roots, root_cts = resolve_and_interpreter_constraints_to_coarsened_targets[
+            (resolve, interpreter_constraints)
+        ]
+        roots.add(root)
+        root_cts.add(ct)
+
+    return resolve_and_interpreter_constraints_to_coarsened_targets

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -91,6 +91,8 @@ from pants.engine.target import (
     TransitiveTargetsRequest,
     UnexpandedTargets,
     UnrecognizedTargetTypeException,
+    ValidatedDependencies,
+    ValidateDependenciesRequest,
     WrappedTarget,
     _generate_file_level_targets,
 )
@@ -509,7 +511,7 @@ async def transitive_dependency_mapping(request: _DependencyMappingRequest) -> _
     )
 
 
-@rule(desc="Resolve transitive targets")
+@rule(desc="Resolve transitive targets", level=LogLevel.DEBUG)
 async def transitive_targets(request: TransitiveTargetsRequest) -> TransitiveTargets:
     """Find all the targets transitively depended upon by the target roots."""
 
@@ -547,7 +549,7 @@ def coarsened_targets_request(addresses: Addresses) -> CoarsenedTargetsRequest:
     return CoarsenedTargetsRequest(addresses)
 
 
-@rule
+@rule(desc="Resolve coarsened targets", level=LogLevel.DEBUG)
 async def coarsened_targets(request: CoarsenedTargetsRequest) -> CoarsenedTargets:
     dependency_mapping = await Get(
         _DependencyMapping,
@@ -1134,18 +1136,34 @@ async def resolve_dependencies(
             for addr in special_cased_field.to_unparsed_address_inputs().values
         )
 
-    result = {
-        addr
-        for addr in (
-            *generated_addresses,
-            *explicitly_provided_includes,
-            *itertools.chain.from_iterable(injected),
-            *itertools.chain.from_iterable(inferred),
-            *special_cased,
+    result = Addresses(
+        sorted(
+            {
+                addr
+                for addr in (
+                    *generated_addresses,
+                    *explicitly_provided_includes,
+                    *itertools.chain.from_iterable(injected),
+                    *itertools.chain.from_iterable(inferred),
+                    *special_cased,
+                )
+                if addr not in explicitly_provided.ignores
+            }
         )
-        if addr not in explicitly_provided.ignores
-    }
-    return Addresses(sorted(result))
+    )
+
+    # Validate dependencies.
+    _ = await MultiGet(
+        Get(
+            ValidatedDependencies,
+            ValidateDependenciesRequest,
+            vd_request_type(vd_request_type.field_set_type.create(tgt), result),  # type: ignore[misc]
+        )
+        for vd_request_type in union_membership.get(ValidateDependenciesRequest)
+        if vd_request_type.field_set_type.is_applicable(tgt)  # type: ignore[misc]
+    )
+
+    return result
 
 
 @rule(desc="Resolve addresses")

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -37,7 +37,7 @@ from typing import (
 from typing_extensions import final
 
 from pants.base.deprecated import warn_or_error
-from pants.engine.addresses import Address, UnparsedAddressInputs, assert_single_address
+from pants.engine.addresses import Address, Addresses, UnparsedAddressInputs, assert_single_address
 from pants.engine.collection import Collection, DeduplicatedCollection
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import (
@@ -2520,6 +2520,28 @@ class InferredDependencies:
 
     def __iter__(self) -> Iterator[Address]:
         return iter(self.dependencies)
+
+
+FS = TypeVar("FS", bound="FieldSet")
+
+
+@union
+@dataclass(frozen=True)
+class ValidateDependenciesRequest(Generic[FS], ABC):
+    """A request to validate dependencies after they have been computed.
+
+    An implementing rule should raise an exception if dependencies are invalid.
+    """
+
+    field_set_type: ClassVar[Type[FS]]
+
+    field_set: FS
+    dependencies: Addresses
+
+
+@dataclass(frozen=True)
+class ValidatedDependencies:
+    pass
 
 
 class SpecialCasedDependencies(StringSequenceField, AsyncFieldMixin):


### PR DESCRIPTION
As described in #15241: we currently compute per-target interpreter constraints by doing per-target graph walks, which is both a scalability bottleneck (because you can almost never use the constraints directly on a target: you must compute them), and complex for users to reason about.

This change adds a `ValidateDependenciesRequest` union, which allows backends to validate the computed dependencies of a target. The python backend uses validation to deprecate the condition from #15241. When that deprecation triggers, most/all callsites which currently use `create_from_compatibility_fields`, `create_from_targets`, or the new `compute_from_targets` can instead directly consume the ICs of a root target in the graph.

This change also (temporarily) adds an `InterpreterConstraints.compute_from_targets` method which computes (in transitive-dependency-linear time) that the dependencies of a target have a superset of its own `interpreter_constraints`. This method allows us to (again, temporarily: see above) apply the optimization of avoiding set merging if targets are already valid. 

Reduces the runtime of un-memoized-but-cached `./pants check ::` by 10%.

Fixes #15241, fixes #15301, fixes #11072.
