### PR TITLE
Adds JDK autoconfiguration support to scala BSP metadata setup 

### DIFF
--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -272,7 +272,7 @@ async def bsp_resolve_scala_metadata(
     )
 
     jvm_build_target = JvmBuildTarget(
-        java_home=Path(coursier_java_home).as_uri(), 
+        java_home=Path(coursier_java_home).as_uri(),
         java_version=f"1.{jdk.jre_major_version}",
     )
 

--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -327,6 +327,10 @@ class DiffBinary(BinaryPath):
     pass
 
 
+class ReadlinkBinary(BinaryPath):
+    pass
+
+
 class GitBinaryException(Exception):
     pass
 
@@ -690,6 +694,14 @@ async def find_diff() -> DiffBinary:
     return DiffBinary(first_path.path, first_path.fingerprint)
 
 
+@rule(desc="Finding the `readlink` binary", level=LogLevel.DEBUG)
+async def find_readlink() -> ReadlinkBinary:
+    request = BinaryPathRequest(binary_name="readlink", search_path=SEARCH_PATHS)
+    paths = await Get(BinaryPaths, BinaryPathRequest, request)
+    first_path = paths.first_path_or_raise(request, rationale="defererence symlinks")
+    return ReadlinkBinary(first_path.path, first_path.fingerprint)
+
+
 @rule(desc="Finding the `git` binary", level=LogLevel.DEBUG)
 async def find_git() -> GitBinary:
     request = BinaryPathRequest(binary_name="git", search_path=SEARCH_PATHS)
@@ -734,6 +746,10 @@ class DiffBinaryRequest:
     pass
 
 
+class ReadlinkBinaryRequest:
+    pass
+
+
 class GitBinaryRequest:
     pass
 
@@ -761,6 +777,13 @@ async def find_tar_wrapper(_: TarBinaryRequest, tar_binary: TarBinary) -> TarBin
 @rule
 async def find_mkdir_wrapper(_: MkdirBinaryRequest, mkdir_binary: MkdirBinary) -> MkdirBinary:
     return mkdir_binary
+
+
+@rule
+async def find_readlink_wrapper(
+    _: ReadlinkBinaryRequest, readlink_binary: ReadlinkBinary
+) -> ReadlinkBinary:
+    return readlink_binary
 
 
 @rule

--- a/src/python/pants/jvm/jdk_rules.py
+++ b/src/python/pants/jvm/jdk_rules.py
@@ -95,6 +95,7 @@ class JdkEnvironment:
     coursier: Coursier
     jre_major_version: int
     global_jvm_options: tuple[str, ...]
+    java_home_command: str
 
     bin_dir: ClassVar[str] = "__jdk"
     jdk_preparation_script: ClassVar[str] = f"{bin_dir}/jdk.sh"
@@ -138,6 +139,7 @@ class InternalJdk(JdkEnvironment):
             env.coursier,
             env.jre_major_version,
             env.global_jvm_options,
+            env.java_home_command,
         )
 
 
@@ -293,6 +295,7 @@ async def prepare_jdk_environment(
         nailgun_jar=os.path.join(JdkEnvironment.bin_dir, nailgun.filenames[0]),
         coursier=coursier,
         jre_major_version=jre_major_version,
+        java_home_command=java_home_command,
     )
 
 


### PR DESCRIPTION
This adds automatic configuration of the JDK to BPS Scala projects by leaking cache paths out of the sandbox during a process. It seems to work!

![2022-05-11 at 1 52 PM](https://user-images.githubusercontent.com/622300/167950998-5116b6e4-8fad-4d45-baae-5eb55cc7a0c9.png)

Closes #15284 