### PR TITLE
Fix `tags` to work with filesystem arguments, `overrides` field, and `python_tests` (Cherry-pick of #15394)

### DIFF
--- a/src/python/pants/backend/codegen/export_codegen_goal.py
+++ b/src/python/pants/backend/codegen/export_codegen_goal.py
@@ -8,12 +8,12 @@ from pants.engine.fs import Digest, MergeDigests, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
 from pants.engine.target import (
+    FilteredTargets,
     GenerateSourcesRequest,
     HydratedSources,
     HydrateSourcesRequest,
     RegisteredTargetTypes,
     SourcesField,
-    Targets,
 )
 from pants.engine.unions import UnionMembership
 
@@ -35,7 +35,7 @@ class ExportCodegen(Goal):
 
 @goal_rule
 async def export_codegen(
-    targets: Targets,
+    targets: FilteredTargets,
     union_membership: UnionMembership,
     workspace: Workspace,
     dist_dir: DistDir,

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -776,7 +776,6 @@ class SkipPythonTestsField(BoolField):
 
 
 _PYTHON_TEST_MOVED_FIELDS = (
-    *COMMON_TARGET_FIELDS,
     PythonTestsDependenciesField,
     PythonResolveField,
     PythonTestsTimeoutField,
@@ -789,7 +788,12 @@ _PYTHON_TEST_MOVED_FIELDS = (
 
 class PythonTestTarget(Target):
     alias = "python_test"
-    core_fields = (*_PYTHON_TEST_MOVED_FIELDS, PythonTestsDependenciesField, PythonTestSourceField)
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        *_PYTHON_TEST_MOVED_FIELDS,
+        PythonTestsDependenciesField,
+        PythonTestSourceField,
+    )
     help = softwrap(
         f"""
         A single Python test file, written in either Pytest style or unittest style.
@@ -838,9 +842,13 @@ class PythonTestsOverrideField(OverridesField):
 
 class PythonTestsGeneratorTarget(TargetFilesGenerator):
     alias = "python_tests"
-    core_fields = (PythonTestsGeneratingSourcesField, PythonTestsOverrideField)
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        PythonTestsGeneratingSourcesField,
+        PythonTestsOverrideField,
+    )
     generated_target_cls = PythonTestTarget
-    copied_fields = ()
+    copied_fields = COMMON_TARGET_FIELDS
     moved_fields = _PYTHON_TEST_MOVED_FIELDS
     settings_request_cls = PythonFilesGeneratorSettingsRequest
     help = "Generate a `python_test` target for each file in the `sources` field."

--- a/src/python/pants/core/goals/check.py
+++ b/src/python/pants/core/goals/check.py
@@ -21,7 +21,7 @@ from pants.engine.fs import EMPTY_DIGEST, Digest, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, QueryRule, collect_rules, goal_rule
-from pants.engine.target import Targets
+from pants.engine.target import FilteredTargets
 from pants.engine.unions import UnionMembership, union
 from pants.option.option_types import StrListOption
 from pants.util.logging import LogLevel
@@ -160,7 +160,7 @@ class Check(Goal):
 async def check(
     console: Console,
     workspace: Workspace,
-    targets: Targets,
+    targets: FilteredTargets,
     dist_dir: DistDir,
     union_membership: UnionMembership,
     check_subsystem: CheckSubsystem,

--- a/src/python/pants/core/goals/export.py
+++ b/src/python/pants/core/goals/export.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Iterable, Mapping, cast
+from typing import Iterable, Mapping, Sequence, cast
 
 from pants.base.build_root import BuildRoot
 from pants.core.util_rules.distdir import DistDir
@@ -17,7 +17,7 @@ from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.internals.selectors import Effect, Get, MultiGet
 from pants.engine.process import InteractiveProcess, InteractiveProcessResult
 from pants.engine.rules import collect_rules, goal_rule
-from pants.engine.target import Targets
+from pants.engine.target import FilteredTargets, Target
 from pants.engine.unions import UnionMembership, union
 from pants.util.dirutil import safe_rmtree
 from pants.util.frozendict import FrozenDict
@@ -36,7 +36,7 @@ class ExportRequest:
     Subclass and install a member of this type to export data.
     """
 
-    targets: Targets
+    targets: Sequence[Target]
 
 
 @frozen_after_init
@@ -107,7 +107,7 @@ class Export(Goal):
 @goal_rule
 async def export(
     console: Console,
-    targets: Targets,
+    targets: FilteredTargets,
     workspace: Workspace,
     union_membership: UnionMembership,
     build_root: BuildRoot,

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -23,7 +23,7 @@ from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.internals.native_engine import EMPTY_SNAPSHOT
 from pants.engine.process import FallibleProcessResult, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
-from pants.engine.target import FieldSet, SourcesField, Targets
+from pants.engine.target import FieldSet, FilteredTargets, SourcesField, Targets
 from pants.engine.unions import UnionMembership, union
 from pants.option.option_types import IntOption, StrListOption
 from pants.util.collections import partition_sequentially
@@ -183,7 +183,7 @@ class Fmt(Goal):
 @goal_rule
 async def fmt(
     console: Console,
-    targets: Targets,
+    targets: FilteredTargets,
     fmt_subsystem: FmtSubsystem,
     workspace: Workspace,
     union_membership: UnionMembership,

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -24,7 +24,7 @@ from pants.engine.fs import EMPTY_DIGEST, Digest, SpecsSnapshot, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
-from pants.engine.target import FieldSet, Targets
+from pants.engine.target import FieldSet, FilteredTargets
 from pants.engine.unions import UnionMembership, union
 from pants.option.option_types import IntOption, StrListOption
 from pants.util.collections import partition_sequentially
@@ -250,7 +250,7 @@ def _get_error_code(results: tuple[LintResults, ...]) -> int:
 async def lint(
     console: Console,
     workspace: Workspace,
-    targets: Targets,
+    targets: FilteredTargets,
     specs_snapshot: SpecsSnapshot,
     lint_subsystem: LintSubsystem,
     union_membership: UnionMembership,

--- a/src/python/pants/core/goals/repl.py
+++ b/src/python/pants/core/goals/repl.py
@@ -6,7 +6,7 @@ import os
 from abc import ABC
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import ClassVar, Iterable, Mapping, Optional, Tuple
+from typing import ClassVar, Iterable, Mapping, Optional, Sequence, Tuple
 
 from pants.base.build_root import BuildRoot
 from pants.engine.addresses import Addresses
@@ -17,7 +17,7 @@ from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.internals.native_engine import EMPTY_DIGEST
 from pants.engine.process import InteractiveProcess, InteractiveProcessResult
 from pants.engine.rules import Effect, Get, collect_rules, goal_rule
-from pants.engine.target import Targets
+from pants.engine.target import FilteredTargets, Target
 from pants.engine.unions import UnionMembership, union
 from pants.option.global_options import GlobalOptions
 from pants.option.option_types import BoolOption, StrOption
@@ -37,7 +37,7 @@ class ReplImplementation(ABC):
 
     name: ClassVar[str]
 
-    targets: Targets
+    targets: Sequence[Target]
     chroot: str  # Absolute path of the chroot the sources will be materialized to.
 
     def in_chroot(self, relpath: str) -> str:
@@ -102,7 +102,7 @@ async def run_repl(
     console: Console,
     workspace: Workspace,
     repl_subsystem: ReplSubsystem,
-    specified_targets: Targets,
+    specified_targets: FilteredTargets,
     build_root: BuildRoot,
     union_membership: UnionMembership,
     global_options: GlobalOptions,

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -14,7 +14,7 @@ from pants.base.specs import AddressLiteralSpec, AddressSpecs
 from pants.engine.addresses import Address, Addresses, AddressInput, BuildFileAddress
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import DigestContents, GlobMatchErrorBehavior, PathGlobs, Paths
-from pants.engine.internals.mapper import AddressFamily, AddressMap, AddressSpecsFilter
+from pants.engine.internals.mapper import AddressFamily, AddressMap, SpecsFilter
 from pants.engine.internals.parametrize import _TargetParametrizations
 from pants.engine.internals.parser import BuildFilePreludeSymbols, Parser, error_on_imports
 from pants.engine.internals.target_adaptor import TargetAdaptor
@@ -172,8 +172,8 @@ async def find_target_adaptor(address: Address) -> TargetAdaptor:
 
 
 @rule
-def setup_address_specs_filter(global_options: GlobalOptions) -> AddressSpecsFilter:
-    return AddressSpecsFilter(
+def setup_address_specs_filter(global_options: GlobalOptions) -> SpecsFilter:
+    return SpecsFilter(
         tags=global_options.tag, exclude_target_regexps=global_options.exclude_target_regexp
     )
 
@@ -221,7 +221,7 @@ async def _determine_literal_addresses_from_specs(
 async def addresses_from_address_specs(
     address_specs: AddressSpecs,
     build_file_options: BuildFileOptions,
-    specs_filter: AddressSpecsFilter,
+    specs_filter: SpecsFilter,
 ) -> Addresses:
     matched_addresses: OrderedSet[Address] = OrderedSet()
     filtering_disabled = address_specs.filter_by_global_options is False

--- a/src/python/pants/engine/internals/mapper.py
+++ b/src/python/pants/engine/internals/mapper.py
@@ -154,7 +154,7 @@ class AddressFamily:
 
 @frozen_after_init
 @dataclass(unsafe_hash=True)
-class AddressSpecsFilter:
+class SpecsFilter:
     """Filters addresses with the `--tags` and `--exclude-target-regexp` options."""
 
     tags: tuple[str, ...]

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -652,6 +652,25 @@ class Targets(Collection[Target]):
         return self[0]
 
 
+# This distinct type is necessary because of https://github.com/pantsbuild/pants/issues/14977.
+#
+# NB: We still proactively apply filtering inside `AddressSpecs` and `FilesystemSpecs`, which is
+# earlier in the rule pipeline of `Specs -> Addresses -> UnexpandedTargets -> Targets ->
+# FilteredTargets`. That is necessary so that project-introspection goals like `list` which don't
+# use `FilteredTargets` still have filtering applied.
+class FilteredTargets(Collection[Target]):
+    """A heterogenous collection of Target instances that have been filtered with the global options
+    `--tag` and `--exclude-target-regexp`.
+
+    Outside of the extra filtering, this type is identical to `Targets`, including its handling of
+    target generators.
+    """
+
+    def expect_single(self) -> Target:
+        assert_single_address([tgt.address for tgt in self])
+        return self[0]
+
+
 class UnexpandedTargets(Collection[Target]):
     """Like `Targets`, but will not replace target generators with their generated targets (e.g.
     replace `python_sources` "BUILD targets" with generated `python_source` "file targets")."""

--- a/src/python/pants/vcs/changed.py
+++ b/src/python/pants/vcs/changed.py
@@ -40,7 +40,7 @@ class ChangedAddresses(Collection[Address]):
 
 @rule
 async def find_changed_owners(request: ChangedRequest) -> ChangedAddresses:
-    owners = await Get(Owners, OwnersRequest(request.sources))
+    owners = await Get(Owners, OwnersRequest(request.sources, filter_by_global_options=True))
     if request.dependees == DependeesOption.NONE:
         return ChangedAddresses(owners)
     dependees_with_roots = await Get(


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/14977 and https://github.com/pantsbuild/pants/issues/11123, along with a bug that `python_tests` was moving rather than copying the `tags` field.

As explained in https://github.com/pantsbuild/pants/issues/14977, it is necessary to filter targets after we have replaced target generators with generated targets (`UnexpandedTargets -> Targets`). The cleanest way I could think to do that is adding `FilteredTargets`.

We must still proactively filter inside `AddressSpecs` and `FilesystemSpecs`, as explained in a code comment, to ensure that project introspection goals like `list` behave properly.

Note that `--changed-since` already worked, unlike filesystem arguments, because we convert the result of it into `AddressSpecs`.
