### PR TITLE
Fix boolean logic when merging interpreter constraints.

### DIFF
--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -51,16 +51,22 @@ async def black_fmt(request: BlackRequest, black: Black, python_setup: PythonSet
     # the machine.
     tool_interpreter_constraints = black.interpreter_constraints
     if black.options.is_default("interpreter_constraints"):
-        distinct_constraints = InterpreterConstraints.group_field_sets_by_constraints(
-            request.field_sets, python_setup
-        ).keys()
-        for constraints in distinct_constraints:
-            if constraints.requires_python38_or_newer(python_setup.interpreter_universe):
-                # We've found at least one constraint that requires 3.8, so we know we must run
-                # black on 3.8+, and this constraint is as good as any (in the sense that we
-                # expect a compatible interpreter to exist).
-                tool_interpreter_constraints = constraints
-                break
+        try:
+            # Don't compute this unless we have to, since it might fail.
+            all_interpreter_constraints = InterpreterConstraints.create_from_compatibility_fields(
+                (field_set.interpreter_constraints for field_set in request.field_sets),
+                python_setup,
+            )
+        except ValueError:
+            raise ValueError(
+                "Could not compute an interpreter to run Black on, due to conflicting requirements "
+                "in the repo.\nPlease set `[black].interpreter_constraints` explicitly in "
+                "pants.toml to a suitable interpreter."
+            )
+        if all_interpreter_constraints.requires_python38_or_newer(
+            python_setup.interpreter_universe
+        ):
+            tool_interpreter_constraints = all_interpreter_constraints
 
     black_pex_get = Get(
         VenvPex,

--- a/src/python/pants/backend/python/subsystems/setuptools_test.py
+++ b/src/python/pants/backend/python/subsystems/setuptools_test.py
@@ -62,6 +62,7 @@ def test_setup_lockfile_interpreter_constraints() -> None:
             python_distribution(
                 name="dist",
                 dependencies=[":lib"],
+                interpreter_constraints=["==2.7.*"],
                 provides=python_artifact(name="dist"),
             )
             """
@@ -71,10 +72,9 @@ def test_setup_lockfile_interpreter_constraints() -> None:
     assert_ics(
         dedent(
             """\
-            python_sources(name="lib", interpreter_constraints=["==2.7.*", "==3.5.*"])
             python_distribution(
                 name="dist",
-                dependencies=[":lib"],
+                interpreter_constraints=["==2.7.*", "==3.5.*"],
                 provides=python_artifact(name="dist"),
             )
             """
@@ -90,17 +90,15 @@ def test_setup_lockfile_interpreter_constraints() -> None:
     assert_ics(
         dedent(
             """\
-            python_sources(name="lib1", interpreter_constraints=["==2.7.*"])
             python_distribution(
                 name="dist1",
-                dependencies=[":lib1"],
+                interpreter_constraints=["==2.7.*"],
                 provides=python_artifact(name="dist"),
             )
 
-            python_sources(name="lib2", interpreter_constraints=["==3.5.*"])
             python_distribution(
                 name="dist2",
-                dependencies=[":lib2"],
+                interpreter_constraints=["==3.5.*"],
                 provides=python_artifact(name="dist"),
             )
             """
@@ -110,17 +108,15 @@ def test_setup_lockfile_interpreter_constraints() -> None:
     assert_ics(
         dedent(
             """\
-            python_sources(name="lib1", interpreter_constraints=["==2.7.*", "==3.5.*"])
             python_distribution(
                 name="dist1",
-                dependencies=[":lib1"],
+                interpreter_constraints=["==2.7.*", "==3.5.*"],
                 provides=python_artifact(name="dist"),
             )
 
-            python_sources(name="lib2", interpreter_constraints=[">=3.5"])
             python_distribution(
                 name="dist2",
-                dependencies=[":lib2"],
+                interpreter_constraints=[">=3.5"],
                 provides=python_artifact(name="dist"),
             )
             """
@@ -141,6 +137,7 @@ def test_setup_lockfile_interpreter_constraints() -> None:
             python_distribution(
                 name="dist2",
                 dependencies=[":lib2"],
+                interpreter_constraints=["==2.7.*"],
                 provides=python_artifact(name="dist"),
             )
 
@@ -148,6 +145,7 @@ def test_setup_lockfile_interpreter_constraints() -> None:
             python_distribution(
                 name="dist3",
                 dependencies=[":lib3"],
+                interpreter_constraints=[">=3.6"],
                 provides=python_artifact(name="dist"),
             )
             """

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -1333,6 +1333,7 @@ class PythonDistribution(Target):
     alias = "python_distribution"
     core_fields = (
         *COMMON_TARGET_FIELDS,
+        InterpreterConstraintsField,
         PythonDistributionDependenciesField,
         PythonDistributionEntryPointsField,
         PythonProvidesField,

--- a/src/python/pants/backend/python/util_rules/interpreter_constraints_test.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints_test.py
@@ -129,13 +129,40 @@ def test_merge_interpreter_constraints() -> None:
     # No interpreter is shorthand for CPython, which is how Pex behaves
     assert_merged(inp=[[">=3.5"], ["CPython==3.7.*"]], expected=["CPython>=3.5,==3.7.*"])
 
-    # Different Python interpreters, which are guaranteed to fail when ANDed but are safe when ORed.
-    with pytest.raises(ValueError):
-        InterpreterConstraints.merge_constraint_sets([["CPython==3.7.*"], ["PyPy==43.0"]])
-    assert_merged(inp=[["CPython==3.7.*", "PyPy==43.0"]], expected=["CPython==3.7.*", "PyPy==43.0"])
-
-    # Ensure we can handle empty input.
+    # Handle empty constraints correctly.
+    assert_merged(inp=[[], []], expected=[])
+    assert_merged(inp=[[], ["==3.8.*"]], expected=["CPython==3.8.*"])
+    assert_merged(inp=[[">=3.8.2"], [], ["==3.8.*"]], expected=["CPython>=3.8.2,==3.8.*"])
     assert_merged(inp=[], expected=[])
+
+    # Handle mixed types correctly when there is a solution.
+    assert_merged(inp=[["CPython==3.7.*", "PyPy==43.0"]], expected=["CPython==3.7.*", "PyPy==43.0"])
+    assert_merged(
+        inp=[["CPython==3.7.*", "PyPy>=43.0"], ["PyPy<44.0"]], expected=["PyPy>=43.0,<44.0"]
+    )
+    assert_merged(
+        inp=[
+            ["CPython==3.7.*", "Jython", "PyPy>=43.0"],
+            ["PyPy<44.0", "Jython>=1.2"],
+            ["Jython<1.3", "PyPy<44.0"],
+        ],
+        expected=["PyPy>=43.0,<44.0", "Jython>=1.2,<1.3"],
+    )
+
+    # Ensure we error when there is no solution.
+    def assert_impossible(constraints, expected_msg):
+        with pytest.raises(ValueError) as excinfo:
+            print(InterpreterConstraints.merge_constraint_sets(constraints))
+        assert str(excinfo.value) == (
+            "These interpreter constraints cannot be merged, as they require conflicting "
+            f"interpreter types: {expected_msg}"
+        )
+
+    assert_impossible([["CPython==3.7.*"], ["PyPy==43.0"]], "(CPython==3.7.*) AND (PyPy==43.0)")
+    assert_impossible(
+        [["CPython==3.7.*", "Jython>=1.2"], ["PyPy==43.0", "Stackless<3.7"]],
+        "(CPython==3.7.* OR Jython>=1.2) AND (PyPy==43.0 OR Stackless<3.7)",
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Previously we eagerly failed when ANDing two constraints from
different interprerter types. Now we represent that as a special
"impossible" requirement, because the final boolean expression
may still be possible on other OR branches.

E.g., previously we failed on

`(CPython==3.7.* OR PyPy>=43.0) AND (PyPy==43.5)`

whereas now we correctly merge this as

`(PyPy>=43.0,==43.5)`

Where the impossible branch of `(CPython==3.7.* AND PyPy==43.5)`
is ignored in the final OR.

We now error only if the final OR has no possible branches.

We also now correctly handle empty constraints. They should represent
"no constraints", i.e., "any interpreter is allowed", and so shouldn't
be in the final OR.

E.g., previously we merged `(() AND (>=3.7))` as `()` (because the cross-product
we used in the computation was empty), and now we correctly merge those as
`(>=3.7)`.

Also adds an `interpreter_constraints` field to `python_distribution`, to make
it easy to parametrize a wheel on multiple interpreter constraints.

[ci skip-rust]

[ci skip-build-wheels]