### PR TITLE
Render compile task progress for BSP

### DIFF
--- a/src/python/pants/bsp/context.py
+++ b/src/python/pants/bsp/context.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Callable
 
 from pants.bsp.spec.lifecycle import InitializeBuildParams
-from pants.bsp.spec.task import BSPNotification
+from pants.bsp.spec.notification import BSPNotification
 
 # Wrapper type to provide BSP rules with the ability to interact with the BSP protocol driver.
 #

--- a/src/python/pants/bsp/protocol.py
+++ b/src/python/pants/bsp/protocol.py
@@ -15,7 +15,7 @@ from pylsp_jsonrpc.exceptions import (  # type: ignore[import]
 from pylsp_jsonrpc.streams import JsonRpcStreamReader, JsonRpcStreamWriter  # type: ignore[import]
 
 from pants.bsp.context import BSPContext
-from pants.bsp.spec.task import BSPNotification
+from pants.bsp.spec.notification import BSPNotification
 from pants.engine.fs import Workspace
 from pants.engine.internals.scheduler import SchedulerSession
 from pants.engine.internals.selectors import Params

--- a/src/python/pants/bsp/protocol.py
+++ b/src/python/pants/bsp/protocol.py
@@ -148,6 +148,10 @@ class BSPConnection:
             request = method_mapping.request_type.from_json_dict(params)
         except Exception:
             return _make_error_future(JsonRpcInvalidRequest())
+
+        # TODO: This should not be necessary: see https://github.com/pantsbuild/pants/issues/15435.
+        self._scheduler_session.new_run_id()
+
         workspace = Workspace(self._scheduler_session)
         params = Params(request, workspace)
         execution_request = self._scheduler_session.execution_request(

--- a/src/python/pants/bsp/spec/log.py
+++ b/src/python/pants/bsp/spec/log.py
@@ -1,0 +1,54 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from pants.bsp.spec.base import TaskId
+from pants.bsp.spec.notification import BSPNotification
+
+# -----------------------------------------------------------------------------------------------
+# Log message
+# See https://build-server-protocol.github.io/docs/specification.html#log-message
+# -----------------------------------------------------------------------------------------------
+
+
+class MessageType(Enum):
+    # An error message.
+    ERROR = 1
+    # A warning message.
+    WARNING = 2
+    # An information message.
+    INFO = 3
+    # A log message.
+    LOG = 4
+
+
+@dataclass(frozen=True)
+class LogMessageParams(BSPNotification):
+    notification_name = "build/logMessage"
+
+    # The message type. See {@link MessageType}
+    type_: MessageType
+
+    # The actual message
+    message: str
+
+    # The task id if any.
+    task: TaskId | None = None
+
+    # The request id that originated this notification.
+    origin_id: str | None = None
+
+    def to_json_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "message": self.message,
+            "type": self.type_.value,
+        }
+        if self.task is not None:
+            result["task"] = self.task.to_json_dict()
+        if self.origin_id is not None:
+            result["originId"] = self.origin_id
+        return result

--- a/src/python/pants/bsp/spec/notification.py
+++ b/src/python/pants/bsp/spec/notification.py
@@ -1,0 +1,15 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+
+class BSPNotification:
+    """Base class for all notifications so that a notification carries its RPC method name."""
+
+    notification_name: ClassVar[str]
+
+    def to_json_dict(self) -> dict[str, Any]:
+        raise NotImplementedError

--- a/src/python/pants/bsp/spec/task.py
+++ b/src/python/pants/bsp/spec/task.py
@@ -4,20 +4,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, ClassVar
+from typing import Any
 
 from pants.bsp.spec.base import StatusCode, TaskId
 from pants.bsp.spec.compile import CompileReport, CompileTask
-
-
-class BSPNotification:
-    """Base class for all notifications so that a notification carries its RPC method name."""
-
-    notification_name: ClassVar[str]
-
-    def to_json_dict(self) -> dict[str, Any]:
-        raise NotImplementedError
-
+from pants.bsp.spec.notification import BSPNotification
 
 # -----------------------------------------------------------------------------------------------
 # Task Notifications

--- a/src/python/pants/bsp/util_rules/compile.py
+++ b/src/python/pants/bsp/util_rules/compile.py
@@ -18,7 +18,7 @@ from pants.bsp.util_rules.targets import BSPBuildTargetInternal, BSPCompileReque
 from pants.engine.fs import Workspace
 from pants.engine.internals.native_engine import EMPTY_DIGEST, Digest, MergeDigests
 from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.rules import _uncacheable_rule, collect_rules
+from pants.engine.rules import _uncacheable_rule, collect_rules, rule
 from pants.engine.target import FieldSet, Targets
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.util.ordered_set import FrozenOrderedSet
@@ -46,7 +46,7 @@ class CompileOneBSPTargetRequest:
     arguments: tuple[str, ...] | None = ()
 
 
-@_uncacheable_rule
+@rule
 async def compile_bsp_target(
     request: CompileOneBSPTargetRequest,
     bsp_context: BSPContext,

--- a/src/python/pants/bsp/util_rules/compile.py
+++ b/src/python/pants/bsp/util_rules/compile.py
@@ -64,12 +64,16 @@ async def compile_bsp_target(
                 field_set = field_set_type.create(target)
                 field_sets_by_request_type[compile_request_type].add(field_set)
 
-    task_id = TaskId(id=uuid.uuid4().hex)
+    task_id = TaskId(
+        id=uuid.uuid4().hex, parents=((request.origin_id,) if request.origin_id else None)
+    )
+    message = f"Compilation of {request.bsp_target.bsp_target_id.uri}"
 
     bsp_context.notify_client(
         TaskStartParams(
             task_id=task_id,
             event_time=int(time.time() * 1000),
+            message=message,
             data=CompileTask(target=request.bsp_target.bsp_target_id),
         )
     )
@@ -78,7 +82,9 @@ async def compile_bsp_target(
         Get(
             BSPCompileResult,
             BSPCompileRequest,
-            compile_request_type(bsp_target=request.bsp_target, field_sets=tuple(field_sets)),
+            compile_request_type(
+                bsp_target=request.bsp_target, field_sets=tuple(field_sets), task_id=task_id
+            ),
         )
         for compile_request_type, field_sets in field_sets_by_request_type.items()
     )
@@ -91,6 +97,7 @@ async def compile_bsp_target(
         TaskFinishParams(
             task_id=task_id,
             event_time=int(time.time() * 1000),
+            message=message,
             status=status,
             data=CompileReport(
                 target=request.bsp_target.bsp_target_id,

--- a/src/python/pants/bsp/util_rules/resources.py
+++ b/src/python/pants/bsp/util_rules/resources.py
@@ -18,7 +18,7 @@ from pants.bsp.util_rules.targets import (
 from pants.engine.fs import Workspace
 from pants.engine.internals.native_engine import EMPTY_DIGEST, Digest, MergeDigests
 from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.rules import _uncacheable_rule, collect_rules
+from pants.engine.rules import _uncacheable_rule, collect_rules, rule
 from pants.engine.target import FieldSet, Targets
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.util.ordered_set import FrozenOrderedSet
@@ -39,7 +39,7 @@ class ResourcesForOneBSPTargetRequest:
     bsp_target: BSPBuildTargetInternal
 
 
-@_uncacheable_rule
+@rule
 async def resources_bsp_target(
     request: ResourcesForOneBSPTargetRequest,
     union_membership: UnionMembership,

--- a/src/python/pants/bsp/util_rules/targets.py
+++ b/src/python/pants/bsp/util_rules/targets.py
@@ -24,6 +24,7 @@ from pants.bsp.spec.base import (
     BuildTargetCapabilities,
     BuildTargetIdentifier,
     StatusCode,
+    TaskId,
     Uri,
 )
 from pants.bsp.spec.targets import (
@@ -663,6 +664,7 @@ class BSPCompileRequest(Generic[_FS]):
 
     bsp_target: BSPBuildTargetInternal
     field_sets: tuple[_FS, ...]
+    task_id: TaskId
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/jvm/bsp/compile.py
+++ b/src/python/pants/jvm/bsp/compile.py
@@ -1,13 +1,18 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.bsp.spec.base import BuildTargetIdentifier, StatusCode
+import time
+from dataclasses import dataclass
+
+from pants.bsp.context import BSPContext
+from pants.bsp.spec.base import BuildTargetIdentifier, StatusCode, TaskId
+from pants.bsp.spec.task import TaskProgressParams
 from pants.bsp.util_rules.targets import BSPCompileRequest, BSPCompileResult
 from pants.engine.addresses import Addresses
 from pants.engine.fs import AddPrefix, Digest, MergeDigests
 from pants.engine.internals.native_engine import EMPTY_DIGEST
 from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.rules import collect_rules, rule_helper
+from pants.engine.rules import collect_rules, rule, rule_helper
 from pants.engine.target import CoarsenedTargets
 from pants.jvm import classpath
 from pants.jvm.classpath import LooseClassfiles
@@ -24,6 +29,30 @@ from pants.util.strutil import path_safe
 
 def jvm_classes_directory(target_id: BuildTargetIdentifier) -> str:
     return f"jvm/classes/{path_safe(target_id.uri)}"
+
+
+@dataclass(frozen=True)
+class BSPClasspathEntryRequest:
+    """A wrapper around a `ClasspathEntryRequest` which notifies the BSP client on completion."""
+
+    request: ClasspathEntryRequest
+    task_id: TaskId
+
+
+@rule
+async def notify_for_classpath_entry(
+    request: BSPClasspathEntryRequest,
+    context: BSPContext,
+) -> FallibleClasspathEntry:
+    entry = await Get(FallibleClasspathEntry, ClasspathEntryRequest, request.request)
+    context.notify_client(
+        TaskProgressParams(
+            task_id=request.task_id,
+            event_time=int(time.time() * 1000),
+            message=entry.message(),
+        )
+    )
+    return entry
 
 
 @rule_helper
@@ -53,8 +82,10 @@ async def _jvm_bsp_compile(
     results = await MultiGet(
         Get(
             FallibleClasspathEntry,
-            ClasspathEntryRequest,
-            classpath_entry_request.for_targets(component=coarsened_target, resolve=resolve),
+            BSPClasspathEntryRequest(
+                classpath_entry_request.for_targets(component=coarsened_target, resolve=resolve),
+                task_id=request.task_id,
+            ),
         )
         for coarsened_target in coarsened_targets.coarsened_closure()
         if not any(JvmArtifactFieldSet.is_applicable(t) for t in coarsened_target.members)


### PR DESCRIPTION
Adds BSP [task notifications](https://build-server-protocol.github.io/docs/specification.html#task-notifications) for compile tasks, to render individual Pants (coarsened) targets as progress within the compile for a particular BSP `BuildTarget`. 

#14885 discusses unifying the `StreamingWorkunitHandler` infrastructure with task notifications (which is expanded on in #15426). While that might still be a good idea in the medium term, deciding how to filter workunits to make them fully useful to BSP is challenging, and so was broken out into #15426.

Fixes #14885. 

[ci skip-rust]
[ci skip-build-wheels]