### PR TITLE
Support for sharding tests.

### DIFF
--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -355,6 +355,26 @@ class TestSubsystem(GoalSubsystem):
             """
         ),
     )
+    shard = StrOption(
+        "--shard",
+        default="",
+        help=softwrap(
+            """
+            A shard specification of the form "k/N", where N is a positive integer and k is a
+            non-negative integer less than N.
+
+            If set, the request input targets will be partitioned into N disjoint subsets of
+            roughly equal size, and only the k'th subset will be used, with all others discarded.
+
+            Useful for splitting large numbers of test files across multiple machines in CI.
+            For example, you can run three shards with --shard=0/3, --shard=1/3, --shard=2/3.
+
+            Note that the shards are roughly equal in size as measured by number of files.
+            No attempt is made to consider the size of different files, the time they have
+            taken to run in the past, or other such sophisticated measures.
+            """
+        ),
+    )
 
     def report_dir(self, distdir: DistDir) -> PurePath:
         return PurePath(self._report_dir.format(distdir=distdir.relpath))
@@ -406,6 +426,7 @@ async def run_tests(
             TestFieldSet,
             goal_description=f"the `{test_subsystem.name}` goal",
             no_applicable_targets_behavior=NoApplicableTargetsBehavior.warn,
+            shard_spec=test_subsystem.shard,
         ),
     )
     results = await MultiGet(

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -163,6 +163,7 @@ def run_test_rule(
         xml_dir=None,
         output=output,
         extra_env_vars=[],
+        shard="",
     )
     workspace = Workspace(rule_runner.scheduler, _enforce_effects=False)
     union_membership = UnionMembership(

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -7,6 +7,7 @@ import functools
 import itertools
 import logging
 import os.path
+import zlib
 from dataclasses import dataclass
 from pathlib import PurePath
 from typing import Iterable, NamedTuple, Sequence
@@ -1377,9 +1378,9 @@ async def find_valid_field_sets_for_target_roots(
 
     if request.num_shards > 0:
         sharded_targets_to_applicable_field_sets = {
-            key: value
-            for key, value in targets_to_applicable_field_sets.items()
-            if hash(key) % request.num_shards == request.shard
+            tgt: value
+            for tgt, value in targets_to_applicable_field_sets.items()
+            if request.is_in_shard(tgt.address.spec)
         }
         result = TargetRootsToFieldSets(sharded_targets_to_applicable_field_sets)
     else:

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -7,7 +7,6 @@ import functools
 import itertools
 import logging
 import os.path
-import zlib
 from dataclasses import dataclass
 from pathlib import PurePath
 from typing import Iterable, NamedTuple, Sequence

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -1375,7 +1375,16 @@ async def find_valid_field_sets_for_target_roots(
         ):
             logger.warning(str(no_applicable_exception))
 
-    result = TargetRootsToFieldSets(targets_to_applicable_field_sets)
+    if request.num_shards > 0:
+        sharded_targets_to_applicable_field_sets = {
+            key: value
+            for key, value in targets_to_applicable_field_sets.items()
+            if hash(key) % request.num_shards == request.shard
+        }
+        result = TargetRootsToFieldSets(sharded_targets_to_applicable_field_sets)
+    else:
+        result = TargetRootsToFieldSets(targets_to_applicable_field_sets)
+
     if not request.expect_single_field_set:
         return result
     if len(result.targets) > 1:

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1353,11 +1353,12 @@ class NoApplicableTargetsBehavior(Enum):
     error = "error"
 
 
-def parse_shard_spec(shard_spec: str) -> Tuple[int, int]:
+def parse_shard_spec(shard_spec: str, origin: str = "") -> Tuple[int, int]:
     def invalid():
+        origin_str = f" from {origin}" if origin else ""
         return ValueError(
-            f'Invalid shard specification {shard_spec}. Use a string of the form "k/N" where '
-            "k and N are integers, and 0 <= k < N ."
+            f"Invalid shard specification {shard_spec}{origin_str}. Use a string of the form "
+            '"k/N" where k and N are integers, and 0 <= k < N .'
         )
 
     if not shard_spec:
@@ -1396,9 +1397,10 @@ class TargetRootsToFieldSetsRequest(Generic[_FS]):
         goal_description: str,
         no_applicable_targets_behavior: NoApplicableTargetsBehavior,
         expect_single_field_set: bool = False,
-        shard_spec: str = "",
+        shard: int = 0,
+        num_shards: int = -1,
     ) -> None:
-        if expect_single_field_set and shard_spec:
+        if expect_single_field_set and num_shards != -1:
             raise ValueError(
                 "At most one of shard_spec and expect_single_field_set may be set"
                 " on a TargetRootsToFieldSetsRequest instance"
@@ -1407,7 +1409,8 @@ class TargetRootsToFieldSetsRequest(Generic[_FS]):
         self.goal_description = goal_description
         self.no_applicable_targets_behavior = no_applicable_targets_behavior
         self.expect_single_field_set = expect_single_field_set
-        self.shard, self.num_shards = parse_shard_spec(shard_spec)
+        self.shard = shard
+        self.num_shards = num_shards
 
     def is_in_shard(self, key: str) -> bool:
         return get_shard(key, self.num_shards) == self.shard

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -41,6 +41,7 @@ from pants.engine.target import (
     StringSequenceField,
     Target,
     ValidNumbers,
+    parse_shard_spec,
     targets_with_sources_types,
 )
 from pants.engine.unions import UnionMembership
@@ -1370,3 +1371,30 @@ def test_overrides_field_normalization() -> None:
                 (Paths(("dir/foo.ext", "dir/bar.ext"), ()), PathGlobs([]), tgt1_override),
             ],
         )
+
+
+# -----------------------------------------------------------------------------------------------
+# Test utility functions
+# -----------------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "shard_spec,expected",
+    (
+        ("0/4", (0, 4)),
+        ("1/4", (1, 4)),
+        ("2/4", (2, 4)),
+        ("3/4", (3, 4)),
+        ("0/2", (0, 2)),
+        ("1/2", (1, 2)),
+        ("0/1", (0, 1)),
+    ),
+)
+def test_parse_shard_spec_good(shard_spec, expected) -> None:
+    assert parse_shard_spec(shard_spec) == expected
+
+
+@pytest.mark.parametrize("shard_spec", ("0/0", "1/1", "4/4", "5/4", "-1/4", "foo/4"))
+def test_parse_shard_spec_bad(shard_spec) -> None:
+    with pytest.raises(ValueError):
+        parse_shard_spec(shard_spec)

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -41,8 +41,9 @@ from pants.engine.target import (
     StringSequenceField,
     Target,
     ValidNumbers,
+    get_shard,
     parse_shard_spec,
-    targets_with_sources_types, get_shard,
+    targets_with_sources_types,
 )
 from pants.engine.unions import UnionMembership
 from pants.option.global_options import FilesNotFoundBehavior

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -42,7 +42,7 @@ from pants.engine.target import (
     Target,
     ValidNumbers,
     parse_shard_spec,
-    targets_with_sources_types,
+    targets_with_sources_types, get_shard,
 )
 from pants.engine.unions import UnionMembership
 from pants.option.global_options import FilesNotFoundBehavior
@@ -1398,3 +1398,8 @@ def test_parse_shard_spec_good(shard_spec, expected) -> None:
 def test_parse_shard_spec_bad(shard_spec) -> None:
     with pytest.raises(ValueError):
         parse_shard_spec(shard_spec)
+
+
+def test_get_shard() -> None:
+    assert get_shard("foo/bar/1", 2) == 0
+    assert get_shard("foo/bar/4", 2) == 1


### PR DESCRIPTION
Provides generic support for sharding target roots, but only
exposes it to users for the test goal, for now.

It may be applicable to other goals, such as package, so we
can consider adding it there in the future.

But as I'm not sure if there might be unintended consequences
or confusion when applied generally, this is not a global option.

Note that only root targets are sharded. Obviously once we start
pulling in dependencies we cannot shard in any sensible way.

[ci skip-rust]

[ci skip-build-wheels]