### PR TITLE
Support setting env vars in individual distribution builds.

### DIFF
--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -1303,6 +1303,19 @@ class SDistConfigSettingsField(ConfigSettingsField):
     help = "PEP-517 config settings to pass to the build backend when building an sdist."
 
 
+class BuildBackendEnvVarsField(StringSequenceField):
+    alias = "env_vars"
+    required = False
+    help = softwrap(
+        """
+        Environment variables to set when running the PEP-517 build backend.
+
+        Entries are either strings in the form `ENV_VAR=value` to set an explicit value;
+        or just `ENV_VAR` to copy the value from Pants's own environment.
+        """
+    )
+
+
 class GenerateSetupField(TriBoolField):
     alias = "generate_setup"
     required = False
@@ -1350,6 +1363,7 @@ class PythonDistribution(Target):
         SDistField,
         WheelConfigSettingsField,
         SDistConfigSettingsField,
+        BuildBackendEnvVarsField,
         LongDescriptionPathField,
     )
     help = softwrap(

--- a/src/python/pants/backend/python/util_rules/dists.py
+++ b/src/python/pants/backend/python/util_rules/dists.py
@@ -123,6 +123,7 @@ class DistBuildRequest:
     sdist_config_settings: FrozenDict[str, tuple[str, ...]] | None = None
 
     extra_build_time_requirements: tuple[Pex, ...] = tuple()
+    extra_build_time_env: Mapping[str, str] | None = None
 
 
 @dataclass(frozen=True)
@@ -214,6 +215,7 @@ async def run_pep517_build(request: DistBuildRequest, python_setup: PythonSetup)
     merged_digest = await Get(Digest, MergeDigests((request.input, backend_shim_digest)))
 
     extra_env = {
+        **(request.extra_build_time_env or {}),
         "PEX_EXTRA_SYS_PATH": os.pathsep.join(request.build_time_source_roots),
     }
     if python_setup.macos_big_sur_compatibility and is_macos_big_sur():


### PR DESCRIPTION
This is necessary, rather than just using the global subprocess
environment mechanism, because we may want to use env vars to
affect the build in different targets in the same run.

E.g., one target may build with mypyc and another may build without.

[ci skip-rust]

[ci skip-build-wheels]