### PR TITLE
Upgrade default Protoc version to 3.20.1 (native Apple Silicon support)

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/protoc.py
+++ b/src/python/pants/backend/codegen/protobuf/protoc.py
@@ -11,12 +11,12 @@ class Protoc(TemplatedExternalTool):
     options_scope = "protoc"
     help = "The protocol buffer compiler (https://developers.google.com/protocol-buffers)."
 
-    default_version = "3.11.4"
+    default_version = "3.20.1"
     default_known_versions = [
-        "3.11.4|linux_arm64 |f24c9fa1fc4a7770b8a5da66e515cb8a638d086ad2afa633abb97137c5f029a8|1481946",
-        "3.11.4|linux_x86_64|6d0f18cd84b918c7b3edd0203e75569e0c8caecb1367bbbe409b45e28514f5be|1591191",
-        "3.11.4|macos_arm64 |8c6af11e1058efe953830ecb38324c0e0fd2fb67df3891896d138c535932e7db|2482119",
-        "3.11.4|macos_x86_64|8c6af11e1058efe953830ecb38324c0e0fd2fb67df3891896d138c535932e7db|2482119",
+        "3.20.1|linux_arm64 |8a5a51876259f934cd2acc2bc59dba0e9a51bd631a5c37a4b9081d6e4dbc7591|1804837",
+        "3.20.1|linux_x86_64|3a0e900f9556fbcac4c3a913a00d07680f0fdf6b990a341462d822247b265562|1714731",
+        "3.20.1|macos_arm64 |b362acae78542872bb6aac8dba73aaf0dc6e94991b8b0a065d6c3e703fec2a8b|2708249",
+        "3.20.1|macos_x86_64|b4f36b18202d54d343a66eebc9f8ae60809a2a96cc2d1b378137550bbe4cf33c|2708249",
     ]
     default_url_template = (
         "https://github.com/protocolbuffers/protobuf/releases/download/"
@@ -25,7 +25,7 @@ class Protoc(TemplatedExternalTool):
     default_url_platform_mapping = {
         "linux_arm64": "linux-aarch_64",
         "linux_x86_64": "linux-x86_64",
-        "macos_arm64": "osx-x86_64",  # May require rosetta, but output is arch-independent
+        "macos_arm64": "osx-aarch_64",
         "macos_x86_64": "osx-x86_64",
     }
 


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/14416.

[ci skip-rust]
[ci skip-build-wheels]