### PR TITLE
Move `get_git` deprecation to start in `2.14.0.dev0` (Cherry-pick of #15423)

### DIFF
--- a/src/python/pants/base/build_environment.py
+++ b/src/python/pants/base/build_environment.py
@@ -211,7 +211,11 @@ class _GitInitialized(Enum):
 _Git: _GitInitialized | Git | None = _GitInitialized.NO
 
 
-@deprecated("2.14.0.dev0", "Use QueryRule(MaybeGitWorktree, [GitWorktreeRequest]) instead.")
+@deprecated(
+    start_version="2.14.0.dev0",
+    removal_version="2.15.0.dev0",
+    hint="Use QueryRule(MaybeGitWorktree, [GitWorktreeRequest]) instead.",
+)
 def get_git() -> Git | None:
     """Returns Git, if available."""
     global _Git


### PR DESCRIPTION
Bump `get_git` deprecation to start in `2.14.0.dev0`, because it is challenging to consume a `@rule` via a `Get` in a backwards-compatible way (see #15421). A `QueryRule` can be installed conditionally, but not a `Get` (since they will always be detected via `@rule`'s static analysis).

[ci skip-rust]
[ci skip-build-wheels]
