### PR TITLE
Fix lockfile generation for Docker, Terraform, and Clang-format to not require Python backend

### DIFF
--- a/src/python/pants/backend/cc/lint/clangformat/BUILD
+++ b/src/python/pants/backend/cc/lint/clangformat/BUILD
@@ -5,7 +5,8 @@ python_sources(dependencies=[":lockfile"])
 resource(name="lockfile", source="clangformat.lock")
 
 python_tests(
-    name="rules_integration_test",
-    sources=["rules_integration_test.py"],
-    timeout=240,
+    name="tests",
+    overrides={
+        "rules_integration_test.py": {"timeout": 240},
+    },
 )

--- a/src/python/pants/backend/cc/lint/clangformat/subsystem_test.py
+++ b/src/python/pants/backend/cc/lint/clangformat/subsystem_test.py
@@ -1,0 +1,18 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from pants.testutil.pants_integration_test import run_pants
+
+
+def test_generate_lockfile_without_python_backend() -> None:
+    """Regression test for https://github.com/pantsbuild/pants/issues/14876."""
+    run_pants(
+        [
+            "--backend-packages=pants.backend.experimental.cc.lint.clangformat",
+            "--clang-format-lockfile=cf.lock",
+            "generate-lockfiles",
+            "--resolve=clang-format",
+        ]
+    ).assert_success()

--- a/src/python/pants/backend/docker/subsystems/dockerfile_parser_test.py
+++ b/src/python/pants/backend/docker/subsystems/dockerfile_parser_test.py
@@ -16,6 +16,7 @@ from pants.backend.python.target_types import PexBinary
 from pants.backend.python.util_rules.pex import rules as pex_rules
 from pants.engine.addresses import Address
 from pants.engine.internals.scheduler import ExecutionError
+from pants.testutil.pants_integration_test import run_pants
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
@@ -196,3 +197,15 @@ def test_baseimage_tags(rule_runner: RuleRunner) -> None:
         # Stage 2 is not pinned with a tag.
         "stage3 v0.54.0",
     )
+
+
+def test_generate_lockfile_without_python_backend() -> None:
+    """Regression test for https://github.com/pantsbuild/pants/issues/14876."""
+    run_pants(
+        [
+            "--backend-packages=pants.backend.docker",
+            "--dockerfile-parser-lockfile=dp.lock",
+            "generate-lockfiles",
+            "--resolve=dockerfile-parser",
+        ]
+    ).assert_success()

--- a/src/python/pants/backend/experimental/cc/lint/clangformat/register.py
+++ b/src/python/pants/backend/experimental/cc/lint/clangformat/register.py
@@ -12,6 +12,7 @@ from typing import Iterable
 
 from pants.backend.cc.lint.clangformat import rules as clangformat_rules
 from pants.backend.cc.lint.clangformat import skip_field, subsystem
+from pants.backend.python.goals import lockfile as python_lockfile
 from pants.engine.rules import Rule
 from pants.engine.unions import UnionRule
 
@@ -21,4 +22,5 @@ def rules() -> Iterable[Rule | UnionRule]:
         *clangformat_rules.rules(),
         *skip_field.rules(),
         *subsystem.rules(),
+        *python_lockfile.rules(),
     )

--- a/src/python/pants/backend/experimental/terraform/register.py
+++ b/src/python/pants/backend/experimental/terraform/register.py
@@ -1,6 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from pants.backend.python.goals import lockfile as python_lockfile
 from pants.backend.python.util_rules.pex import rules as pex_rules
 from pants.backend.terraform import dependency_inference, style, tool
 from pants.backend.terraform.goals import check, tailor
@@ -25,4 +26,5 @@ def rules():
         *style.rules(),
         *pex_rules(),
         *tffmt_rules(),
+        *python_lockfile.rules(),
     ]

--- a/src/python/pants/backend/terraform/dependency_inference_test.py
+++ b/src/python/pants/backend/terraform/dependency_inference_test.py
@@ -22,6 +22,7 @@ from pants.engine.target import (
     InferredDependencies,
     SourcesField,
 )
+from pants.testutil.pants_integration_test import run_pants
 from pants.testutil.python_interpreter_selection import all_major_minor_python_versions
 from pants.testutil.rule_runner import RuleRunner
 from pants.util.ordered_set import FrozenOrderedSet
@@ -137,3 +138,15 @@ def test_hcl_parser_wrapper_runs(rule_runner: RuleRunner, major_minor_interprete
 
     lines = {line for line in result.stdout.decode("utf-8").splitlines() if line}
     assert lines == {"grok", "foo/hello/world"}
+
+
+def test_generate_lockfile_without_python_backend() -> None:
+    """Regression test for https://github.com/pantsbuild/pants/issues/14876."""
+    run_pants(
+        [
+            "--backend-packages=pants.backend.experimental.terraform",
+            "--terraform-hcl2-parser-lockfile=tf.lock",
+            "generate-lockfiles",
+            "--resolve=terraform-hcl2-parser",
+        ]
+    ).assert_success()

--- a/src/python/pants/init/BUILD
+++ b/src/python/pants/init/BUILD
@@ -13,6 +13,8 @@ target(
         "src/python/pants/backend/codegen/thrift/apache/python",
         "src/python/pants/backend/docker",
         "src/python/pants/backend/docker/lint/hadolint",
+        "src/python/pants/backend/experimental/cc",
+        "src/python/pants/backend/experimental/cc/lint/clangformat",
         "src/python/pants/backend/experimental/codegen/avro/java",
         "src/python/pants/backend/experimental/codegen/protobuf/go",
         "src/python/pants/backend/experimental/codegen/protobuf/java",


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/14876.

[ci skip-rust]