### PR TITLE
kotlin: remove stray scala references

### DIFF
--- a/src/python/pants/backend/experimental/kotlin/lint/ktlint/register.py
+++ b/src/python/pants/backend/experimental/kotlin/lint/ktlint/register.py
@@ -1,7 +1,7 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.experimental.scala.register import rules as all_kotlin_rules
+from pants.backend.experimental.kotlin.register import rules as all_kotlin_rules
 from pants.backend.kotlin.lint.ktlint import rules as ktlint_rules
 from pants.backend.kotlin.lint.ktlint import skip_field
 

--- a/src/python/pants/backend/kotlin/goals/check.py
+++ b/src/python/pants/backend/kotlin/goals/check.py
@@ -28,7 +28,7 @@ class KotlincCheckRequest(CheckRequest):
 
 
 @rule(desc="Check compilation for Kotlin", level=LogLevel.DEBUG)
-async def scalac_check(
+async def kotlinc_check(
     request: KotlincCheckRequest,
     classpath_entry_request: ClasspathEntryRequestFactory,
 ) -> CheckResults:


### PR DESCRIPTION
- Switch reference to `scala` backend in the `ktlint` backend to the `kotlin` backend.  Otherwise, registering ktlint brings in the Scala backend!
- Rename a Kotlin rule which has "scala" in its name.

[ci skip-rust]