### PR TITLE
kotlin: the `plugin_id` field on `kotlinc_plugin` target is optional (Cherry-pick of #15459)

### DIFF
--- a/src/python/pants/backend/kotlin/target_types.py
+++ b/src/python/pants/backend/kotlin/target_types.py
@@ -118,7 +118,6 @@ class KotlincPluginArtifactField(StringField):
 
 class KotlincPluginIdField(StringField):
     alias = "plugin_id"
-    required = True
     help = softwrap(
         """
         The ID for `kotlinc` to use when setting options for the plugin.


### PR DESCRIPTION
The `plugin_id` field on the `kotlinc_plugin` target has a default and should not have been marked as required.

[ci skip-rust]