### PR TITLE
support relative address syntax for JVM compiler plugin artifacts (Cherry-pick of #15462)

### DIFF
--- a/src/python/pants/backend/kotlin/compile/kotlinc_plugins.py
+++ b/src/python/pants/backend/kotlin/compile/kotlinc_plugins.py
@@ -133,7 +133,7 @@ async def resolve_kotlinc_plugins_for_target(
 
     artifact_addresses = await MultiGet(
         # `is not None` is solely to satiate mypy. artifact field is required.
-        Get(Address, AddressInput, AddressInput.parse(ai))
+        Get(Address, AddressInput, AddressInput.parse(ai, relative_to=target.address.spec_path))
         for ai in artifact_address_inputs
         if ai is not None
     )

--- a/src/python/pants/backend/kotlin/compile/kotlinc_test.py
+++ b/src/python/pants/backend/kotlin/compile/kotlinc_test.py
@@ -524,8 +524,7 @@ def test_compile_with_kotlinc_plugin(rule_runner: RuleRunner) -> None:
                     name = "allopen",
                     plugin_id = "org.jetbrains.kotlin.allopen",
                     plugin_args = ["annotation=lib.MarkOpen"],
-                    # TODO: Support relative addresses.
-                    artifact = "lib:allopen_lib",
+                    artifact = ":allopen_lib",
                 )
 
                 kotlin_sources()

--- a/src/python/pants/backend/scala/compile/scalac_plugins.py
+++ b/src/python/pants/backend/scala/compile/scalac_plugins.py
@@ -105,7 +105,6 @@ async def resolve_scala_plugins_for_target(
     jvm: JvmSubsystem,
     scalac: Scalac,
 ) -> ScalaPluginTargetsForTarget:
-
     target = request.target
     resolve = request.resolve_name
 
@@ -125,7 +124,7 @@ async def resolve_scala_plugins_for_target(
 
     artifact_addresses = await MultiGet(
         # `is not None` is solely to satiate mypy. artifact field is required.
-        Get(Address, AddressInput, AddressInput.parse(ai))
+        Get(Address, AddressInput, AddressInput.parse(ai, relative_to=target.address.spec_path))
         for ai in artifact_address_inputs
         if ai is not None
     )

--- a/src/python/pants/backend/scala/compile/scalac_test.py
+++ b/src/python/pants/backend/scala/compile/scalac_test.py
@@ -519,8 +519,7 @@ def test_compile_with_scalac_plugin(rule_runner: RuleRunner) -> None:
 
                 scalac_plugin(
                     name = "acyclic",
-                    # TODO: Support relative addresses.
-                    artifact = "lib:acyclic_lib",
+                    artifact = ":acyclic_lib",
                 )
 
                 scala_sources(
@@ -617,8 +616,7 @@ def test_compile_with_local_scalac_plugin(rule_runner: RuleRunner) -> None:
 
                 scalac_plugin(
                     name = "acyclic",
-                    # TODO: Support relative addresses.
-                    artifact = "lib:acyclic_lib",
+                    artifact = ":acyclic_lib",
                 )
 
                 scala_sources(
@@ -728,8 +726,7 @@ def test_compile_with_multiple_scalac_plugins(rule_runner: RuleRunner) -> None:
                 scalac_plugin(
                     name="kind-projector",
                     plugin_name="kind-projector",
-                    # TODO: Support relative addresses.
-                    artifact="lib:kind-projector-lib",
+                    artifact=":kind-projector-lib",
                 )
 
                 jvm_artifact(
@@ -742,8 +739,7 @@ def test_compile_with_multiple_scalac_plugins(rule_runner: RuleRunner) -> None:
                 scalac_plugin(
                     name="better-monadic-for",
                     plugin_name="bm4",
-                    # TODO: Support relative addresses.
-                    artifact="lib:better-monadic-for-lib",
+                    artifact=":better-monadic-for-lib",
                 )
                 """
             ),


### PR DESCRIPTION
Support relative address syntax for the `artifact` field on `scalac_plugin` and `kotlinc_plugin` targets.

[ci skip-rust]

Note: The cherry-pick had a conflict due to changes in kotlinc_test.py.