### PR TITLE
Only infer an __init__.py dep on a python_sources-generated target.

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -477,7 +477,9 @@ async def infer_python_init_dependencies(
         ),
     )
     owners = await MultiGet(Get(Owners, OwnersRequest((f,))) for f in init_files.snapshot.files)
-    return InferredDependencies(itertools.chain.from_iterable(owners))
+    owner_tgts = await Get(Targets, Addresses(itertools.chain.from_iterable(owners)))
+    python_owners = [tgt.address for tgt in owner_tgts if tgt.has_field(PythonSourceField)]
+    return InferredDependencies(python_owners)
 
 
 class InferConftestDependencies(InferDependenciesRequest):


### PR DESCRIPTION
Or, to be precise, anything with a PythonSources field.

If the \_\_init__.py also belongs to a files() target, say because
the repo consumes itself as test data, then previously that would
cause us to infer a production dep on the "file as testdata", as
well as any python_sources() target.

Now we check that we're inferring these deps on the intended
python_sources target.

Admittedly this is an unlikely scenario, but is one I have hit
in practice, so we might as well be robust.

[ci skip-rust]

[ci skip-build-wheels]