### PR TITLE
Change `_generator_sources_helper` to use `source: str` rather than `sources: list[str]`

### DIFF
--- a/src/python/pants/backend/python/macros/pipenv_requirements.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements.py
@@ -81,7 +81,7 @@ async def generate_from_pipenv_requirement(
     }
 
     file_tgt = TargetGeneratorSourcesHelperTarget(
-        {TargetGeneratorSourcesHelperSourcesField.alias: [lock_rel_path]},
+        {TargetGeneratorSourcesHelperSourcesField.alias: lock_rel_path},
         Address(
             request.template_address.spec_path,
             target_name=request.template_address.target_name,

--- a/src/python/pants/backend/python/macros/pipenv_requirements_test.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements_test.py
@@ -79,6 +79,6 @@ def test_pipfile_lock(rule_runner: RuleRunner) -> None:
                 },
                 Address("", target_name="reqs", generated_name="cachetools"),
             ),
-            TargetGeneratorSourcesHelperTarget({"sources": ["Pipfile.lock"]}, file_addr),
+            TargetGeneratorSourcesHelperTarget({"source": "Pipfile.lock"}, file_addr),
         },
     )

--- a/src/python/pants/backend/python/macros/poetry_requirements.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements.py
@@ -443,7 +443,7 @@ async def generate_from_python_requirement(
     }
 
     file_tgt = TargetGeneratorSourcesHelperTarget(
-        {TargetGeneratorSourcesHelperSourcesField.alias: [pyproject_rel_path]},
+        {TargetGeneratorSourcesHelperSourcesField.alias: pyproject_rel_path},
         Address(
             request.template_address.spec_path,
             target_name=request.template_address.target_name,

--- a/src/python/pants/backend/python/macros/poetry_requirements_test.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements_test.py
@@ -505,7 +505,7 @@ def test_pyproject_toml(rule_runner: RuleRunner) -> None:
                 },
                 address=Address("", target_name="reqs", generated_name="Un-Normalized-PROJECT"),
             ),
-            TargetGeneratorSourcesHelperTarget({"sources": ["pyproject.toml"]}, file_addr),
+            TargetGeneratorSourcesHelperTarget({"source": "pyproject.toml"}, file_addr),
         },
     )
 
@@ -528,7 +528,7 @@ def test_source_override(rule_runner: RuleRunner) -> None:
                 {"dependencies": [file_addr.spec], "requirements": ["ansicolors>=1.18.0"]},
                 address=Address("", target_name="reqs", generated_name="ansicolors"),
             ),
-            TargetGeneratorSourcesHelperTarget({"sources": ["subdir/pyproject.toml"]}, file_addr),
+            TargetGeneratorSourcesHelperTarget({"source": "subdir/pyproject.toml"}, file_addr),
         },
     )
 
@@ -557,7 +557,7 @@ def test_no_req_defined_warning(rule_runner: RuleRunner, caplog) -> None:
         """,
         expected_targets={
             TargetGeneratorSourcesHelperTarget(
-                {"sources": ["pyproject.toml"]},
+                {"source": "pyproject.toml"},
                 Address("", target_name="reqs", relative_file_path="pyproject.toml"),
             )
         },

--- a/src/python/pants/backend/python/macros/python_requirements.py
+++ b/src/python/pants/backend/python/macros/python_requirements.py
@@ -93,7 +93,7 @@ async def generate_from_python_requirement(
     }
 
     file_tgt = TargetGeneratorSourcesHelperTarget(
-        {TargetGeneratorSourcesHelperSourcesField.alias: [requirements_rel_path]},
+        {TargetGeneratorSourcesHelperSourcesField.alias: requirements_rel_path},
         Address(
             request.template_address.spec_path,
             target_name=request.template_address.target_name,

--- a/src/python/pants/backend/python/macros/python_requirements_test.py
+++ b/src/python/pants/backend/python/macros/python_requirements_test.py
@@ -114,7 +114,7 @@ def test_requirements_txt(rule_runner: RuleRunner) -> None:
                 },
                 Address("", target_name="reqs", generated_name="pip"),
             ),
-            TargetGeneratorSourcesHelperTarget({"sources": ["requirements.txt"]}, file_addr),
+            TargetGeneratorSourcesHelperTarget({"source": "requirements.txt"}, file_addr),
         },
     )
 
@@ -151,7 +151,7 @@ def test_multiple_versions(rule_runner: RuleRunner) -> None:
                 {"requirements": ["repletewateringcan>=7"], "dependencies": [file_addr.spec]},
                 Address("", target_name="reqs", generated_name="repletewateringcan"),
             ),
-            TargetGeneratorSourcesHelperTarget({"sources": ["requirements.txt"]}, file_addr),
+            TargetGeneratorSourcesHelperTarget({"source": "requirements.txt"}, file_addr),
         },
     )
 
@@ -181,6 +181,6 @@ def test_source_override(rule_runner: RuleRunner) -> None:
                 {"requirements": ["ansicolors>=1.18.0"], "dependencies": [file_addr.spec]},
                 Address("", target_name="reqs", generated_name="ansicolors"),
             ),
-            TargetGeneratorSourcesHelperTarget({"sources": ["subdir/requirements.txt"]}, file_addr),
+            TargetGeneratorSourcesHelperTarget({"source": "subdir/requirements.txt"}, file_addr),
         },
     )

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -390,15 +390,15 @@ def map_assets_by_path(
 # -----------------------------------------------------------------------------------------------
 
 
-class TargetGeneratorSourcesHelperSourcesField(MultipleSourcesField):
+class TargetGeneratorSourcesHelperSourcesField(SingleSourceField):
     uses_source_roots = False
     required = True
 
 
 class TargetGeneratorSourcesHelperTarget(Target):
     """Target generators that work by reading in some source file(s) should also generate this
-    target and add it as a dependency to every generated target so that `--changed-since` works
-    properly.
+    target once per file, and add it as a dependency to every generated target so that `--changed-
+    since` works properly.
 
     See https://github.com/pantsbuild/pants/issues/13118 for discussion of why this is necessary and
     alternatives considered.
@@ -410,8 +410,8 @@ class TargetGeneratorSourcesHelperTarget(Target):
         """
         A private helper target type used by some target generators.
 
-        This tracks their `sources` field so that `--changed-since --changed-dependees` works
-        properly for generated targets.
+        This tracks their `source` / `sources` field so that `--changed-since --changed-dependees`
+        works properly for generated targets.
         """
     )
 


### PR DESCRIPTION
Prework for https://github.com/pantsbuild/pants/issues/14736.

Our target generation address assumes that first-party generated targets refer to a single file (or directory). With Go, we might have both `go.mod` and `go.sum`, though — so really we need to generate 1-2 `_generator_sources_helper` targets.

[ci skip-rust]
[ci skip-build-wheels]