### PR TITLE
Upgrade Pex to 2.1.88.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -15,7 +15,7 @@ humbug==0.2.7
 
 ijson==3.1.4
 packaging==21.3
-pex==2.1.87
+pex==2.1.88
 psutil==5.9.0
 # This should be compatible with pytest.py, although it can be looser so that we don't
 # over-constrain pantsbuild.pants.testutil

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -18,7 +18,7 @@
 //     "ijson==3.1.4",
 //     "mypy-typing-asserts==0.1.1",
 //     "packaging==21.3",
-//     "pex==2.1.87",
+//     "pex==2.1.88",
 //     "psutil==5.9.0",
 //     "pydevd-pycharm==203.5419.8",
 //     "pytest<7.1.0,>=6.2.4",
@@ -548,13 +548,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "3e8deb7acbe884122c560dba64e56b5e6eb3eed6683513443a613e73266c2cdb",
-              "url": "https://files.pythonhosted.org/packages/61/2a/6299e5a1fe18a395802fd2cbfaa6229112e8b95627adead6942f2a0466e5/pex-2.1.87-py2.py3-none-any.whl"
+              "hash": "73990dd2091c635d02b12af579f9556ef78902f86e728cd0ec37946f24d78468",
+              "url": "https://files.pythonhosted.org/packages/48/6e/3fc3ec72f44902d5ee46bdeb7cbca2c5e78eb7992d38e71ca582f5e230a4/pex-2.1.88-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2cf387a729675b1c0474f4f7a098db9fc3644d8f6d13fa4cc8613c0f2ee7c2b5",
-              "url": "https://files.pythonhosted.org/packages/fc/b0/a2018b64226bab09082d1ee35f71773a429e87625dbd24b83c27e8bdcb10/pex-2.1.87.tar.gz"
+              "hash": "943526b9d7ecdcfcb8cad1ec12f8274e232f5509289bd5feb827991e14ec8637",
+              "url": "https://files.pythonhosted.org/packages/53/9b/ee497ec129139135f8df6039e971962fbc90447082d60f6d8163c905c5fd/pex-2.1.88.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -562,7 +562,7 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.11,>=2.7",
-          "version": "2.1.87"
+          "version": "2.1.88"
         },
         {
           "artifacts": [
@@ -1545,7 +1545,7 @@
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.87",
+  "pex_version": "2.1.88",
   "prefer_older_binary": false,
   "requirements": [
     "PyYAML<7.0,>=6.0",
@@ -1557,7 +1557,7 @@
     "ijson==3.1.4",
     "mypy-typing-asserts==0.1.1",
     "packaging==21.3",
-    "pex==2.1.87",
+    "pex==2.1.88",
     "psutil==5.9.0",
     "pydevd-pycharm==203.5419.8",
     "pytest<7.1.0,>=6.2.4",

--- a/src/python/pants/backend/python/subsystems/lambdex.lock
+++ b/src/python/pants/backend/python/subsystems/lambdex.lock
@@ -49,13 +49,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "3e8deb7acbe884122c560dba64e56b5e6eb3eed6683513443a613e73266c2cdb",
-              "url": "https://files.pythonhosted.org/packages/61/2a/6299e5a1fe18a395802fd2cbfaa6229112e8b95627adead6942f2a0466e5/pex-2.1.87-py2.py3-none-any.whl"
+              "hash": "73990dd2091c635d02b12af579f9556ef78902f86e728cd0ec37946f24d78468",
+              "url": "https://files.pythonhosted.org/packages/48/6e/3fc3ec72f44902d5ee46bdeb7cbca2c5e78eb7992d38e71ca582f5e230a4/pex-2.1.88-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2cf387a729675b1c0474f4f7a098db9fc3644d8f6d13fa4cc8613c0f2ee7c2b5",
-              "url": "https://files.pythonhosted.org/packages/fc/b0/a2018b64226bab09082d1ee35f71773a429e87625dbd24b83c27e8bdcb10/pex-2.1.87.tar.gz"
+              "hash": "943526b9d7ecdcfcb8cad1ec12f8274e232f5509289bd5feb827991e14ec8637",
+              "url": "https://files.pythonhosted.org/packages/53/9b/ee497ec129139135f8df6039e971962fbc90447082d60f6d8163c905c5fd/pex-2.1.88.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -63,7 +63,7 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.11,>=2.7",
-          "version": "2.1.87"
+          "version": "2.1.88"
         }
       ],
       "platform_tag": [
@@ -74,7 +74,7 @@
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.87",
+  "pex_version": "2.1.88",
   "prefer_older_binary": false,
   "requirements": [
     "lambdex==0.1.6"

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -39,9 +39,9 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."
 
-    default_version = "v2.1.87"
+    default_version = "v2.1.88"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.1.87,<3.0"
+    version_constraints = ">=2.1.88,<3.0"
 
     @classproperty
     def default_known_versions(cls):
@@ -50,8 +50,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "862a7e3949a2ec9479e10a20012be88726e883c390f19eb33ca2cc4017bdbdf8",
-                    "3748064",
+                    "ea8f696dac3b1ddac2fe7af288251c63ca4ea0dd16808f01e60b26b21c84a260",
+                    "3748292",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64"]


### PR DESCRIPTION
This picks up a fix for handling unparseable `~/.netrc` credentials
gracefully.

See the changelog here:
  https://github.com/pantsbuild/pex/releases/tag/v2.1.88

[ci skip-rust]
[ci skip-build-wheels]