### PR TITLE
Revert "Deprecate `[python].tailor_ignore_solitary_init_files` in favor of more useful `[python].tailor_ignore_empty_init_files` (#15469)"

### DIFF
--- a/src/python/pants/backend/python/goals/tailor.py
+++ b/src/python/pants/backend/python/goals/tailor.py
@@ -32,7 +32,7 @@ from pants.core.goals.tailor import (
 )
 from pants.engine.fs import DigestContents, PathGlobs, Paths
 from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.rules import collect_rules, rule, rule_helper
+from pants.engine.rules import collect_rules, rule
 from pants.engine.target import Target, UnexpandedTargets
 from pants.engine.unions import UnionRule
 from pants.source.filespec import Filespec, matches_filespec
@@ -84,63 +84,6 @@ def is_entry_point(content: bytes) -> bool:
     return _entry_point_re.search(content) is not None
 
 
-@rule_helper
-async def _find_source_targets(
-    py_files_globs: PathGlobs, all_owned_sources: AllOwnedSources, python_setup: PythonSetup
-) -> list[PutativeTarget]:
-    ignore_solitary_explicitly_set = not python_setup.options.is_default(
-        "tailor_ignore_solitary_init_files"
-    )
-    ignore_solitary = (
-        python_setup.tailor_ignore_solitary_init_files
-        if ignore_solitary_explicitly_set
-        else python_setup.tailor_ignore_empty_init_files
-    )
-
-    result = []
-    check_if_init_file_empty: list[tuple[str, str]] = []  # (dirname, filename)
-
-    all_py_files = await Get(Paths, PathGlobs, py_files_globs)
-    unowned_py_files = set(all_py_files.files) - set(all_owned_sources)
-    classified_unowned_py_files = classify_source_files(unowned_py_files)
-    for tgt_type, paths in classified_unowned_py_files.items():
-        for dirname, filenames in group_by_dir(paths).items():
-            name: str | None
-            if issubclass(tgt_type, PythonTestsGeneratorTarget):
-                name = "tests"
-            elif issubclass(tgt_type, PythonTestUtilsGeneratorTarget):
-                name = "test_utils"
-            else:
-                name = None
-            if (
-                ignore_solitary
-                and tgt_type == PythonSourcesGeneratorTarget
-                and filenames in ({"__init__.py"}, {"__init__.pyi"})
-            ):
-                if not ignore_solitary_explicitly_set:
-                    check_if_init_file_empty.append((dirname, next(iter(filenames))))
-                continue
-            result.append(
-                PutativeTarget.for_target_type(
-                    tgt_type, path=dirname, name=name, triggering_sources=sorted(filenames)
-                )
-            )
-
-    if check_if_init_file_empty:
-        init_contents = await Get(
-            DigestContents, PathGlobs([os.path.join(d, f) for d, f in check_if_init_file_empty])
-        )
-        result.extend(
-            PutativeTarget.for_target_type(
-                PythonSourcesGeneratorTarget, path=d, name=None, triggering_sources=[f]
-            )
-            for (d, f), file_content in zip(check_if_init_file_empty, init_contents)
-            if file_content.content.strip()
-        )
-
-    return result
-
-
 @rule(level=LogLevel.DEBUG, desc="Determine candidate Python targets to create")
 async def find_putative_targets(
     req: PutativePythonTargetsRequest,
@@ -149,12 +92,32 @@ async def find_putative_targets(
 ) -> PutativeTargets:
     pts = []
 
-    all_py_files_globs: PathGlobs = req.search_paths.path_globs("*.py")
     if python_setup.tailor_source_targets:
-        source_targets = await _find_source_targets(
-            all_py_files_globs, all_owned_sources, python_setup
-        )
-        pts.extend(source_targets)
+        # Find library/test/test_util targets.
+        all_py_files_globs: PathGlobs = req.search_paths.path_globs("*.py")
+        all_py_files = await Get(Paths, PathGlobs, all_py_files_globs)
+        unowned_py_files = set(all_py_files.files) - set(all_owned_sources)
+        classified_unowned_py_files = classify_source_files(unowned_py_files)
+        for tgt_type, paths in classified_unowned_py_files.items():
+            for dirname, filenames in group_by_dir(paths).items():
+                name: str | None
+                if issubclass(tgt_type, PythonTestsGeneratorTarget):
+                    name = "tests"
+                elif issubclass(tgt_type, PythonTestUtilsGeneratorTarget):
+                    name = "test_utils"
+                else:
+                    name = None
+                if (
+                    python_setup.tailor_ignore_solitary_init_files
+                    and tgt_type == PythonSourcesGeneratorTarget
+                    and filenames == {"__init__.py"}
+                ):
+                    continue
+                pts.append(
+                    PutativeTarget.for_target_type(
+                        tgt_type, path=dirname, name=name, triggering_sources=sorted(filenames)
+                    )
+                )
 
     if python_setup.tailor_requirements_targets:
         # Find requirements files.

--- a/src/python/pants/backend/python/goals/tailor_test.py
+++ b/src/python/pants/backend/python/goals/tailor_test.py
@@ -242,17 +242,19 @@ def test_find_putative_targets_for_entry_points(rule_runner: RuleRunner) -> None
     )
 
 
-@pytest.mark.parametrize("ignore", [True, False])
-def test_ignore_empty_init(rule_runner: RuleRunner, ignore: bool) -> None:
+def test_ignore_solitary_init(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "project/__init__.py": "",
-            "project/d1/__init__.py": "# content",
-            "project/d2/__init__.py": "",
-            "project/d2/f.py": "",
+            f"src/python/foo/{fp}": ""
+            for fp in (
+                "__init__.py",
+                "bar/__init__.py",
+                "bar/bar.py",
+                "baz/__init__.py",
+                "qux/qux.py",
+            )
         }
     )
-    rule_runner.set_options([f"--python-tailor-ignore-empty-init-files={ignore}"])
     pts = rule_runner.request(
         PutativeTargets,
         [
@@ -260,30 +262,22 @@ def test_ignore_empty_init(rule_runner: RuleRunner, ignore: bool) -> None:
             AllOwnedSources([]),
         ],
     )
-    result = {
-        PutativeTarget.for_target_type(
-            PythonSourcesGeneratorTarget,
-            "project/d1",
-            None,
-            ["__init__.py"],
-        ),
-        PutativeTarget.for_target_type(
-            PythonSourcesGeneratorTarget,
-            "project/d2",
-            None,
-            ["__init__.py", "f.py"],
-        ),
-    }
-    if not ignore:
-        result.add(
-            PutativeTarget.for_target_type(
-                PythonSourcesGeneratorTarget,
-                "project",
-                None,
-                ["__init__.py"],
-            )
+    assert (
+        PutativeTargets(
+            [
+                PutativeTarget.for_target_type(
+                    PythonSourcesGeneratorTarget,
+                    "src/python/foo/bar",
+                    "bar",
+                    ["__init__.py", "bar.py"],
+                ),
+                PutativeTarget.for_target_type(
+                    PythonSourcesGeneratorTarget, "src/python/foo/qux", "qux", ["qux.py"]
+                ),
+            ]
         )
-    assert result == set(pts)
+        == pts
+    )
 
 
 def test_is_entry_point_true() -> None:

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -426,30 +426,6 @@ class PythonSetup(Subsystem):
             """
         ),
         advanced=True,
-        removal_version="2.14.0.dev0",
-        removal_hint=(
-            "Use `[python].tailor_ignore_empty_init_files`, which checks that the `__init__.py`"
-            "file is both solitary and also empty."
-        ),
-    )
-    tailor_ignore_empty_init_files = BoolOption(
-        "--tailor-ignore-empty-init-files",
-        default=True,
-        help=softwrap(
-            """
-            If true, don't add `python_sources` targets for `__init__.py` files that are both empty
-            and where there are no other Python files in the directory.
-
-            Empty and solitary `__init__.py` files usually exist as import scaffolding rather than
-            true library code, so it can be noisy to add BUILD files.
-
-            Even if this option is set to true, Pants will still ensure the empty `__init__.py`
-            files are included in the sandbox when running processes.
-
-            If you set to false, you may also want to set `[python-infer].init_files = "always"`.
-            """
-        ),
-        advanced=True,
     )
     tailor_requirements_targets = BoolOption(
         "--tailor-requirements-targets",


### PR DESCRIPTION
Flaky CI.

This reverts commit 0905ff13785ab76e3f0672e49db2061f6c209aa5.

[ci skip-rust]
[ci skip-build-wheels]