### PR TITLE
jvm: fix incorrect check for root-only `ClasspathEntryRequest` implementations (Cherry pick of #15494)

### DIFF
--- a/src/python/pants/jvm/compile.py
+++ b/src/python/pants/jvm/compile.py
@@ -118,7 +118,7 @@ class ClasspathEntryRequestFactory:
                 consume_only.append(impl)
 
         if len(compatible) == 1:
-            if not root and impl.root_only:
+            if not root and compatible[0].root_only:
                 raise ClasspathRootOnlyWasInner(
                     "The following targets had dependees, but can only be used as roots in a "
                     f"build graph:\n{component.bullet_list()}"


### PR DESCRIPTION
The conditional logic which checked for a root-only `ClasspathEntryRequest` implementation in a non-root position looked at a loop variable which could be unrelated to the compatible `ClasspathEntryRequest` implementation at issue. 

Solution: Check the root-only status of the compatible `ClasspathEntryRequest` implementation and avoid checking the loop variable.

h/t to @stuhood for spotting the bug. https://github.com/pantsbuild/example-kotlin/pull/1#issuecomment-1127985443

[ci skip-rust]

[ci skip-build-wheels]