### PR TITLE
don't generate default tool lockfiles (Cherry pick of #15488)

### DIFF
--- a/src/python/pants/jvm/resolve/jvm_tool.py
+++ b/src/python/pants/jvm/resolve/jvm_tool.py
@@ -187,7 +187,9 @@ async def setup_lockfile_request_from_tool(
     return GenerateJvmLockfile(
         artifacts=artifacts,
         resolve_name=request.resolve_name,
-        lockfile_dest=request.write_lockfile_dest,
+        lockfile_dest=request.write_lockfile_dest
+        if request.read_lockfile_dest != DEFAULT_TOOL_LOCKFILE
+        else DEFAULT_TOOL_LOCKFILE,
     )
 
 


### PR DESCRIPTION
Do not generate tool lockfiles if the tool is using the default lockfile. The bug was probably introduced by me in #15242.

Closes https://github.com/pantsbuild/pants/issues/15460.

[ci skip-rust]
[ci skip-build-wheels]