### PR TITLE
`tailor` always sets a target's `name=` and uses less ambiguous names now

### DIFF
--- a/src/python/pants/backend/cc/goals/tailor.py
+++ b/src/python/pants/backend/cc/goals/tailor.py
@@ -55,7 +55,7 @@ async def find_putative_targets(
         for dirname, filenames in group_by_dir(paths).items():
             putative_targets.append(
                 PutativeTarget.for_target_type(
-                    tgt_type, path=dirname, name=None, triggering_sources=sorted(filenames)
+                    tgt_type, path=dirname, name="lib", triggering_sources=sorted(filenames)
                 )
             )
 

--- a/src/python/pants/backend/cc/goals/tailor.py
+++ b/src/python/pants/backend/cc/goals/tailor.py
@@ -55,7 +55,7 @@ async def find_putative_targets(
         for dirname, filenames in group_by_dir(paths).items():
             putative_targets.append(
                 PutativeTarget.for_target_type(
-                    tgt_type, path=dirname, name="lib", triggering_sources=sorted(filenames)
+                    tgt_type, path=dirname, name="cc", triggering_sources=sorted(filenames)
                 )
             )
 

--- a/src/python/pants/backend/cc/goals/tailor_test.py
+++ b/src/python/pants/backend/cc/goals/tailor_test.py
@@ -48,7 +48,7 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
                 PutativeTarget.for_target_type(
                     CCSourcesGeneratorTarget,
                     "src/native/unowned",
-                    "lib",
+                    "cc",
                     ["UnownedFile.c"],
                 ),
             ]

--- a/src/python/pants/backend/cc/goals/tailor_test.py
+++ b/src/python/pants/backend/cc/goals/tailor_test.py
@@ -48,7 +48,7 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
                 PutativeTarget.for_target_type(
                     CCSourcesGeneratorTarget,
                     "src/native/unowned",
-                    "unowned",
+                    "lib",
                     ["UnownedFile.c"],
                 ),
             ]

--- a/src/python/pants/backend/codegen/avro/tailor.py
+++ b/src/python/pants/backend/codegen/avro/tailor.py
@@ -49,7 +49,7 @@ async def find_putative_targets(
         PutativeTarget.for_target_type(
             AvroSourcesGeneratorTarget,
             path=dirname,
-            name=None,
+            name="avro",
             triggering_sources=sorted(filenames),
         )
         for dirname, filenames in group_by_dir(unowned_avro_files).items()

--- a/src/python/pants/backend/codegen/avro/tailor_test.py
+++ b/src/python/pants/backend/codegen/avro/tailor_test.py
@@ -50,13 +50,13 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
                 PutativeTarget.for_target_type(
                     AvroSourcesGeneratorTarget,
                     path="avro/foo",
-                    name=None,
+                    name="avro",
                     triggering_sources=["f.avsc"],
                 ),
                 PutativeTarget.for_target_type(
                     AvroSourcesGeneratorTarget,
                     path="avro/foo/bar",
-                    name=None,
+                    name="avro",
                     triggering_sources=["baz2.avpr", "baz3.avsc"],
                 ),
             ]
@@ -90,13 +90,13 @@ def test_find_putative_targets_subset(rule_runner: RuleRunner) -> None:
                 PutativeTarget.for_target_type(
                     AvroSourcesGeneratorTarget,
                     path="avro/foo/bar",
-                    name=None,
+                    name="avro",
                     triggering_sources=["bar.avsc"],
                 ),
                 PutativeTarget.for_target_type(
                     AvroSourcesGeneratorTarget,
                     path="avro/foo/qux",
-                    name=None,
+                    name="avro",
                     triggering_sources=["qux.avsc"],
                 ),
             ]

--- a/src/python/pants/backend/codegen/protobuf/tailor.py
+++ b/src/python/pants/backend/codegen/protobuf/tailor.py
@@ -39,7 +39,7 @@ async def find_putative_targets(
         PutativeTarget.for_target_type(
             ProtobufSourcesGeneratorTarget,
             path=dirname,
-            name=None,
+            name="protos",
             triggering_sources=sorted(filenames),
         )
         for dirname, filenames in group_by_dir(unowned_proto_files).items()

--- a/src/python/pants/backend/codegen/protobuf/tailor_test.py
+++ b/src/python/pants/backend/codegen/protobuf/tailor_test.py
@@ -50,13 +50,13 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
                 PutativeTarget.for_target_type(
                     ProtobufSourcesGeneratorTarget,
                     path="protos/foo",
-                    name=None,
+                    name="protos",
                     triggering_sources=["f.proto"],
                 ),
                 PutativeTarget.for_target_type(
                     ProtobufSourcesGeneratorTarget,
                     path="protos/foo/bar",
-                    name=None,
+                    name="protos",
                     triggering_sources=["baz2.proto", "baz3.proto"],
                 ),
             ]
@@ -90,13 +90,13 @@ def test_find_putative_targets_subset(rule_runner: RuleRunner) -> None:
                 PutativeTarget.for_target_type(
                     ProtobufSourcesGeneratorTarget,
                     path="protos/foo/bar",
-                    name=None,
+                    name="protos",
                     triggering_sources=["bar.proto"],
                 ),
                 PutativeTarget.for_target_type(
                     ProtobufSourcesGeneratorTarget,
                     path="protos/foo/qux",
-                    name=None,
+                    name="protos",
                     triggering_sources=["qux.proto"],
                 ),
             ]

--- a/src/python/pants/backend/codegen/soap/tailor.py
+++ b/src/python/pants/backend/codegen/soap/tailor.py
@@ -41,7 +41,7 @@ async def find_putative_targets(
         PutativeTarget.for_target_type(
             WsdlSourcesGeneratorTarget,
             path=dirname,
-            name=None,
+            name="wsdl",
             triggering_sources=sorted(filenames),
         )
         for dirname, filenames in group_by_dir(unowned_wsdl_files).items()

--- a/src/python/pants/backend/codegen/soap/tailor_test.py
+++ b/src/python/pants/backend/codegen/soap/tailor_test.py
@@ -49,7 +49,7 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
                 PutativeTarget.for_target_type(
                     WsdlSourcesGeneratorTarget,
                     path="src/wsdl/dir1",
-                    name=None,
+                    name="wsdl",
                     triggering_sources=["hello.wsdl", "world.wsdl"],
                 ),
             ]

--- a/src/python/pants/backend/codegen/thrift/tailor.py
+++ b/src/python/pants/backend/codegen/thrift/tailor.py
@@ -41,7 +41,7 @@ async def find_putative_thrift_targets(
         PutativeTarget.for_target_type(
             ThriftSourcesGeneratorTarget,
             path=dirname,
-            name=None,
+            name="thrift",
             triggering_sources=sorted(filenames),
         )
         for dirname, filenames in group_by_dir(unowned_thrift_files).items()

--- a/src/python/pants/backend/codegen/thrift/tailor_test.py
+++ b/src/python/pants/backend/codegen/thrift/tailor_test.py
@@ -50,13 +50,13 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
                 PutativeTarget.for_target_type(
                     ThriftSourcesGeneratorTarget,
                     path="thrifts/foo",
-                    name=None,
+                    name="thrift",
                     triggering_sources=["f.thrift"],
                 ),
                 PutativeTarget.for_target_type(
                     ThriftSourcesGeneratorTarget,
                     path="thrifts/foo/bar",
-                    name=None,
+                    name="thrift",
                     triggering_sources=["baz2.thrift", "baz3.thrift"],
                 ),
             ]
@@ -90,13 +90,13 @@ def test_find_putative_targets_subset(rule_runner: RuleRunner) -> None:
                 PutativeTarget.for_target_type(
                     ThriftSourcesGeneratorTarget,
                     path="thrifts/foo/bar",
-                    name=None,
+                    name="thrift",
                     triggering_sources=["bar.thrift"],
                 ),
                 PutativeTarget.for_target_type(
                     ThriftSourcesGeneratorTarget,
                     path="thrifts/foo/qux",
-                    name=None,
+                    name="thrift",
                     triggering_sources=["qux.thrift"],
                 ),
             ]

--- a/src/python/pants/backend/go/goals/tailor.py
+++ b/src/python/pants/backend/go/goals/tailor.py
@@ -60,7 +60,7 @@ async def find_putative_go_targets(
                 PutativeTarget.for_target_type(
                     GoModTarget,
                     path=dirname,
-                    name=None,
+                    name="mod",
                     triggering_sources=sorted(filenames),
                 )
             )
@@ -79,7 +79,7 @@ async def find_putative_go_targets(
                 PutativeTarget.for_target_type(
                     GoPackageTarget,
                     path=dirname,
-                    name=None,
+                    name="pkg",
                     triggering_sources=sorted(filenames),
                 )
             )

--- a/src/python/pants/backend/go/goals/tailor_test.py
+++ b/src/python/pants/backend/go/goals/tailor_test.py
@@ -63,7 +63,7 @@ def test_find_go_mod_targets(rule_runner: RuleRunner) -> None:
     assert putative_targets == PutativeTargets(
         [
             PutativeTarget.for_target_type(
-                GoModTarget, path="unowned", name=None, triggering_sources=["go.mod"]
+                GoModTarget, path="unowned", name="mod", triggering_sources=["go.mod"]
             )
         ]
     )
@@ -96,13 +96,13 @@ def test_find_go_package_targets(rule_runner: RuleRunner) -> None:
             PutativeTarget.for_target_type(
                 GoPackageTarget,
                 path="unowned",
-                name=None,
+                name="pkg",
                 triggering_sources=["f.go", "f1.go"],
             ),
             PutativeTarget.for_target_type(
                 GoPackageTarget,
                 path="unowned/cmd/vendor",
-                name=None,
+                name="pkg",
                 triggering_sources=["main.go"],
             ),
         ]
@@ -146,7 +146,7 @@ def test_find_go_binary_targets(rule_runner: RuleRunner) -> None:
             PutativeTarget.for_target_type(
                 GoPackageTarget,
                 path="missing_pkg_and_binary_tgt",
-                name="missing_pkg_and_binary_tgt",
+                name="pkg",
                 triggering_sources=["app.go"],
                 kwargs={},
             ),

--- a/src/python/pants/backend/helm/goals/tailor.py
+++ b/src/python/pants/backend/helm/goals/tailor.py
@@ -49,7 +49,7 @@ async def find_putative_helm_targets(
         putative_targets.append(
             PutativeTarget.for_target_type(
                 HelmChartTarget,
-                name="chart",
+                name="helm",
                 path=dirname,
                 triggering_sources=[filename],
             )

--- a/src/python/pants/backend/helm/goals/tailor.py
+++ b/src/python/pants/backend/helm/goals/tailor.py
@@ -49,7 +49,7 @@ async def find_putative_helm_targets(
         putative_targets.append(
             PutativeTarget.for_target_type(
                 HelmChartTarget,
-                name=os.path.basename(dirname),
+                name="chart",
                 path=dirname,
                 triggering_sources=[filename],
             )

--- a/src/python/pants/backend/helm/goals/tailor_test.py
+++ b/src/python/pants/backend/helm/goals/tailor_test.py
@@ -44,7 +44,7 @@ def test_find_helm_charts(rule_runner: RuleRunner) -> None:
     def expected_target(path: str, triggering_source: str) -> PutativeTarget:
         return PutativeTarget.for_target_type(
             HelmChartTarget,
-            name="chart",
+            name="helm",
             path=path,
             triggering_sources=[triggering_source],
         )

--- a/src/python/pants/backend/helm/goals/tailor_test.py
+++ b/src/python/pants/backend/helm/goals/tailor_test.py
@@ -1,7 +1,6 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import os
 
 import pytest
 
@@ -45,7 +44,7 @@ def test_find_helm_charts(rule_runner: RuleRunner) -> None:
     def expected_target(path: str, triggering_source: str) -> PutativeTarget:
         return PutativeTarget.for_target_type(
             HelmChartTarget,
-            name=os.path.basename(path),
+            name="chart",
             path=path,
             triggering_sources=[triggering_source],
         )

--- a/src/python/pants/backend/java/goals/tailor.py
+++ b/src/python/pants/backend/java/goals/tailor.py
@@ -59,7 +59,7 @@ async def find_putative_targets(
 
         for tgt_type, paths in classified_unowned_java_files.items():
             for dirname, filenames in group_by_dir(paths).items():
-                name = "tests" if tgt_type == JunitTestsGeneratorTarget else None
+                name = "tests" if tgt_type == JunitTestsGeneratorTarget else "lib"
                 putative_targets.append(
                     PutativeTarget.for_target_type(
                         tgt_type, path=dirname, name=name, triggering_sources=sorted(filenames)

--- a/src/python/pants/backend/java/goals/tailor.py
+++ b/src/python/pants/backend/java/goals/tailor.py
@@ -59,7 +59,7 @@ async def find_putative_targets(
 
         for tgt_type, paths in classified_unowned_java_files.items():
             for dirname, filenames in group_by_dir(paths).items():
-                name = "tests" if tgt_type == JunitTestsGeneratorTarget else "lib"
+                name = "junit" if tgt_type == JunitTestsGeneratorTarget else "java"
                 putative_targets.append(
                     PutativeTarget.for_target_type(
                         tgt_type, path=dirname, name=name, triggering_sources=sorted(filenames)

--- a/src/python/pants/backend/java/goals/tailor_test.py
+++ b/src/python/pants/backend/java/goals/tailor_test.py
@@ -59,12 +59,12 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
         PutativeTargets(
             [
                 PutativeTarget.for_target_type(
-                    JavaSourcesGeneratorTarget, "src/java/unowned", "lib", ["UnownedFile.java"]
+                    JavaSourcesGeneratorTarget, "src/java/unowned", "java", ["UnownedFile.java"]
                 ),
                 PutativeTarget.for_target_type(
                     JunitTestsGeneratorTarget,
                     "src/java/unowned",
-                    "tests",
+                    "junit",
                     ["UnownedFileTest.java"],
                 ),
             ]

--- a/src/python/pants/backend/java/goals/tailor_test.py
+++ b/src/python/pants/backend/java/goals/tailor_test.py
@@ -59,7 +59,7 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
         PutativeTargets(
             [
                 PutativeTarget.for_target_type(
-                    JavaSourcesGeneratorTarget, "src/java/unowned", "unowned", ["UnownedFile.java"]
+                    JavaSourcesGeneratorTarget, "src/java/unowned", "lib", ["UnownedFile.java"]
                 ),
                 PutativeTarget.for_target_type(
                     JunitTestsGeneratorTarget,

--- a/src/python/pants/backend/javascript/goals/tailor.py
+++ b/src/python/pants/backend/javascript/goals/tailor.py
@@ -55,7 +55,7 @@ async def find_putative_targets(
         for dirname, filenames in group_by_dir(paths).items():
             putative_targets.append(
                 PutativeTarget.for_target_type(
-                    tgt_type, path=dirname, name="lib", triggering_sources=sorted(filenames)
+                    tgt_type, path=dirname, name="js", triggering_sources=sorted(filenames)
                 )
             )
 

--- a/src/python/pants/backend/javascript/goals/tailor.py
+++ b/src/python/pants/backend/javascript/goals/tailor.py
@@ -55,7 +55,7 @@ async def find_putative_targets(
         for dirname, filenames in group_by_dir(paths).items():
             putative_targets.append(
                 PutativeTarget.for_target_type(
-                    tgt_type, path=dirname, name=None, triggering_sources=sorted(filenames)
+                    tgt_type, path=dirname, name="lib", triggering_sources=sorted(filenames)
                 )
             )
 

--- a/src/python/pants/backend/javascript/goals/tailor_test.py
+++ b/src/python/pants/backend/javascript/goals/tailor_test.py
@@ -49,7 +49,7 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
                 PutativeTarget.for_target_type(
                     JSSourcesGeneratorTarget,
                     "src/unowned",
-                    "unowned",
+                    "lib",
                     ["UnownedFile1.js", "UnownedFile2.js"],
                 ),
             ]

--- a/src/python/pants/backend/javascript/goals/tailor_test.py
+++ b/src/python/pants/backend/javascript/goals/tailor_test.py
@@ -49,7 +49,7 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
                 PutativeTarget.for_target_type(
                     JSSourcesGeneratorTarget,
                     "src/unowned",
-                    "lib",
+                    "js",
                     ["UnownedFile1.js", "UnownedFile2.js"],
                 ),
             ]

--- a/src/python/pants/backend/kotlin/goals/tailor.py
+++ b/src/python/pants/backend/kotlin/goals/tailor.py
@@ -52,7 +52,7 @@ async def find_putative_targets(
             for dirname, filenames in group_by_dir(paths).items():
                 putative_targets.append(
                     PutativeTarget.for_target_type(
-                        tgt_type, path=dirname, name="lib", triggering_sources=sorted(filenames)
+                        tgt_type, path=dirname, name="kotlin", triggering_sources=sorted(filenames)
                     )
                 )
 

--- a/src/python/pants/backend/kotlin/goals/tailor.py
+++ b/src/python/pants/backend/kotlin/goals/tailor.py
@@ -52,7 +52,7 @@ async def find_putative_targets(
             for dirname, filenames in group_by_dir(paths).items():
                 putative_targets.append(
                     PutativeTarget.for_target_type(
-                        tgt_type, path=dirname, name=None, triggering_sources=sorted(filenames)
+                        tgt_type, path=dirname, name="lib", triggering_sources=sorted(filenames)
                     )
                 )
 

--- a/src/python/pants/backend/kotlin/goals/tailor_test.py
+++ b/src/python/pants/backend/kotlin/goals/tailor_test.py
@@ -48,7 +48,7 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
                 PutativeTarget.for_target_type(
                     KotlinSourcesGeneratorTarget,
                     "src/kotlin/unowned",
-                    "unowned",
+                    "lib",
                     ["UnownedFile.kt"],
                 ),
             ]

--- a/src/python/pants/backend/kotlin/goals/tailor_test.py
+++ b/src/python/pants/backend/kotlin/goals/tailor_test.py
@@ -48,7 +48,7 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
                 PutativeTarget.for_target_type(
                     KotlinSourcesGeneratorTarget,
                     "src/kotlin/unowned",
-                    "lib",
+                    "kotlin",
                     ["UnownedFile.kt"],
                 ),
             ]

--- a/src/python/pants/backend/python/goals/tailor.py
+++ b/src/python/pants/backend/python/goals/tailor.py
@@ -101,11 +101,11 @@ async def find_putative_targets(
         for tgt_type, paths in classified_unowned_py_files.items():
             for dirname, filenames in group_by_dir(paths).items():
                 if issubclass(tgt_type, PythonTestsGeneratorTarget):
-                    name = "tests"
+                    name = "py_tests"
                 elif issubclass(tgt_type, PythonTestUtilsGeneratorTarget):
-                    name = "test_utils"
+                    name = "py_test_utils"
                 else:
-                    name = "lib"
+                    name = "py"
                 if (
                     python_setup.tailor_ignore_solitary_init_files
                     and tgt_type == PythonSourcesGeneratorTarget
@@ -130,14 +130,14 @@ async def find_putative_targets(
             Get(DigestContents, PathGlobs, req.search_paths.path_globs("pyproject.toml")),
         )
 
-        def add_req_targets(files: Iterable[str], alias: str) -> None:
+        def add_req_targets(files: Iterable[str], alias: str, tgt_name: str) -> None:
             unowned_files = set(files) - set(all_owned_sources)
             for fp in unowned_files:
                 path, name = os.path.split(fp)
                 pts.append(
                     PutativeTarget(
                         path=path,
-                        name=name,
+                        name=tgt_name,
                         type_alias=alias,
                         triggering_sources=[fp],
                         owned_sources=[name],
@@ -149,11 +149,12 @@ async def find_putative_targets(
                     )
                 )
 
-        add_req_targets(all_requirements_files.files, "python_requirements")
-        add_req_targets(all_pipenv_lockfile_files.files, "pipenv_requirements")
+        add_req_targets(all_requirements_files.files, "python_requirements", "reqs"),
+        add_req_targets(all_pipenv_lockfile_files.files, "pipenv_requirements", "pipenv")
         add_req_targets(
             {fc.path for fc in all_pyproject_toml_contents if b"[tool.poetry" in fc.content},
             "poetry_requirements",
+            "poetry",
         )
 
     if python_setup.tailor_pex_binary_targets:

--- a/src/python/pants/backend/python/goals/tailor.py
+++ b/src/python/pants/backend/python/goals/tailor.py
@@ -100,13 +100,12 @@ async def find_putative_targets(
         classified_unowned_py_files = classify_source_files(unowned_py_files)
         for tgt_type, paths in classified_unowned_py_files.items():
             for dirname, filenames in group_by_dir(paths).items():
-                name: str | None
                 if issubclass(tgt_type, PythonTestsGeneratorTarget):
                     name = "tests"
                 elif issubclass(tgt_type, PythonTestUtilsGeneratorTarget):
                     name = "test_utils"
                 else:
-                    name = None
+                    name = "lib"
                 if (
                     python_setup.tailor_ignore_solitary_init_files
                     and tgt_type == PythonSourcesGeneratorTarget

--- a/src/python/pants/backend/python/goals/tailor_test.py
+++ b/src/python/pants/backend/python/goals/tailor_test.py
@@ -130,12 +130,12 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
                     kwargs={"source": "requirements-test.txt"},
                 ),
                 PutativeTarget.for_target_type(
-                    PythonSourcesGeneratorTarget, "src/python/foo", None, ["__init__.py"]
+                    PythonSourcesGeneratorTarget, "src/python/foo", "lib", ["__init__.py"]
                 ),
                 PutativeTarget.for_target_type(
                     PythonSourcesGeneratorTarget,
                     "src/python/foo/bar",
-                    None,
+                    "lib",
                     ["baz2.py", "baz3.py"],
                 ),
                 PutativeTarget.for_target_type(
@@ -190,7 +190,7 @@ def test_find_putative_targets_subset(rule_runner: RuleRunner) -> None:
                     ["bar_test.py"],
                 ),
                 PutativeTarget.for_target_type(
-                    PythonSourcesGeneratorTarget, "src/python/foo/qux", None, ["qux.py"]
+                    PythonSourcesGeneratorTarget, "src/python/foo/qux", "lib", ["qux.py"]
                 ),
             ]
         )
@@ -268,11 +268,11 @@ def test_ignore_solitary_init(rule_runner: RuleRunner) -> None:
                 PutativeTarget.for_target_type(
                     PythonSourcesGeneratorTarget,
                     "src/python/foo/bar",
-                    "bar",
+                    "lib",
                     ["__init__.py", "bar.py"],
                 ),
                 PutativeTarget.for_target_type(
-                    PythonSourcesGeneratorTarget, "src/python/foo/qux", "qux", ["qux.py"]
+                    PythonSourcesGeneratorTarget, "src/python/foo/qux", "lib", ["qux.py"]
                 ),
             ]
         )

--- a/src/python/pants/backend/python/goals/tailor_test.py
+++ b/src/python/pants/backend/python/goals/tailor_test.py
@@ -113,41 +113,41 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
                 PutativeTarget.for_target_type(
                     PipenvRequirementsTargetGenerator,
                     path="3rdparty",
-                    name="Pipfile.lock",
+                    name="pipenv",
                     triggering_sources=["3rdparty/Pipfile.lock"],
                 ),
                 PutativeTarget.for_target_type(
                     PoetryRequirementsTargetGenerator,
                     path="3rdparty",
-                    name="pyproject.toml",
+                    name="poetry",
                     triggering_sources=["3rdparty/pyproject.toml"],
                 ),
                 PutativeTarget.for_target_type(
                     PythonRequirementsTargetGenerator,
                     path="3rdparty",
-                    name="requirements-test.txt",
+                    name="reqs",
                     triggering_sources=["3rdparty/requirements-test.txt"],
                     kwargs={"source": "requirements-test.txt"},
                 ),
                 PutativeTarget.for_target_type(
-                    PythonSourcesGeneratorTarget, "src/python/foo", "lib", ["__init__.py"]
+                    PythonSourcesGeneratorTarget, "src/python/foo", "py", ["__init__.py"]
                 ),
                 PutativeTarget.for_target_type(
                     PythonSourcesGeneratorTarget,
                     "src/python/foo/bar",
-                    "lib",
+                    "py",
                     ["baz2.py", "baz3.py"],
                 ),
                 PutativeTarget.for_target_type(
                     PythonTestsGeneratorTarget,
                     "src/python/foo/bar",
-                    "tests",
+                    "py_tests",
                     ["baz1_test.py", "baz2_test.py"],
                 ),
                 PutativeTarget.for_target_type(
                     PythonTestUtilsGeneratorTarget,
                     "src/python/foo/bar",
-                    "test_utils",
+                    "py_test_utils",
                     ["conftest.py"],
                 ),
             ]
@@ -186,11 +186,11 @@ def test_find_putative_targets_subset(rule_runner: RuleRunner) -> None:
                 PutativeTarget.for_target_type(
                     PythonTestsGeneratorTarget,
                     "src/python/foo/bar",
-                    "tests",
+                    "py_tests",
                     ["bar_test.py"],
                 ),
                 PutativeTarget.for_target_type(
-                    PythonSourcesGeneratorTarget, "src/python/foo/qux", "lib", ["qux.py"]
+                    PythonSourcesGeneratorTarget, "src/python/foo/qux", "py", ["qux.py"]
                 ),
             ]
         )
@@ -268,11 +268,11 @@ def test_ignore_solitary_init(rule_runner: RuleRunner) -> None:
                 PutativeTarget.for_target_type(
                     PythonSourcesGeneratorTarget,
                     "src/python/foo/bar",
-                    "lib",
+                    "py",
                     ["__init__.py", "bar.py"],
                 ),
                 PutativeTarget.for_target_type(
-                    PythonSourcesGeneratorTarget, "src/python/foo/qux", "lib", ["qux.py"]
+                    PythonSourcesGeneratorTarget, "src/python/foo/qux", "py", ["qux.py"]
                 ),
             ]
         )

--- a/src/python/pants/backend/scala/goals/tailor.py
+++ b/src/python/pants/backend/scala/goals/tailor.py
@@ -79,7 +79,7 @@ async def find_putative_targets(
             for dirname, filenames in group_by_dir(paths).items():
                 putative_targets.append(
                     PutativeTarget.for_target_type(
-                        tgt_type, path=dirname, name=None, triggering_sources=sorted(filenames)
+                        tgt_type, path=dirname, name="lib", triggering_sources=sorted(filenames)
                     )
                 )
 

--- a/src/python/pants/backend/scala/goals/tailor.py
+++ b/src/python/pants/backend/scala/goals/tailor.py
@@ -79,7 +79,7 @@ async def find_putative_targets(
             for dirname, filenames in group_by_dir(paths).items():
                 putative_targets.append(
                     PutativeTarget.for_target_type(
-                        tgt_type, path=dirname, name="lib", triggering_sources=sorted(filenames)
+                        tgt_type, path=dirname, name="scala", triggering_sources=sorted(filenames)
                     )
                 )
 

--- a/src/python/pants/backend/shell/tailor.py
+++ b/src/python/pants/backend/shell/tailor.py
@@ -58,7 +58,7 @@ async def find_putative_targets(
     pts = []
     for tgt_type, paths in classified_unowned_shell_files.items():
         for dirname, filenames in group_by_dir(paths).items():
-            name = "tests" if tgt_type == Shunit2TestsGeneratorTarget else None
+            name = "tests" if tgt_type == Shunit2TestsGeneratorTarget else "lib"
             pts.append(
                 PutativeTarget.for_target_type(
                     tgt_type, path=dirname, name=name, triggering_sources=sorted(filenames)

--- a/src/python/pants/backend/shell/tailor.py
+++ b/src/python/pants/backend/shell/tailor.py
@@ -58,7 +58,7 @@ async def find_putative_targets(
     pts = []
     for tgt_type, paths in classified_unowned_shell_files.items():
         for dirname, filenames in group_by_dir(paths).items():
-            name = "tests" if tgt_type == Shunit2TestsGeneratorTarget else "lib"
+            name = "shunit2" if tgt_type == Shunit2TestsGeneratorTarget else "shell"
             pts.append(
                 PutativeTarget.for_target_type(
                     tgt_type, path=dirname, name=name, triggering_sources=sorted(filenames)

--- a/src/python/pants/backend/shell/tailor_test.py
+++ b/src/python/pants/backend/shell/tailor_test.py
@@ -66,19 +66,19 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
                 PutativeTarget.for_target_type(
                     ShellSourcesGeneratorTarget,
                     path="src/sh/foo",
-                    name="lib",
+                    name="shell",
                     triggering_sources=["f.sh"],
                 ),
                 PutativeTarget.for_target_type(
                     ShellSourcesGeneratorTarget,
                     path="src/sh/foo/bar",
-                    name="lib",
+                    name="shell",
                     triggering_sources=["baz2.sh", "baz3.sh"],
                 ),
                 PutativeTarget.for_target_type(
                     Shunit2TestsGeneratorTarget,
                     path="src/sh/foo/bar",
-                    name="tests",
+                    name="shunit2",
                     triggering_sources=["baz2_test.sh"],
                 ),
             ]
@@ -115,13 +115,13 @@ def test_find_putative_targets_subset(rule_runner: RuleRunner) -> None:
                 PutativeTarget.for_target_type(
                     Shunit2TestsGeneratorTarget,
                     path="src/sh/foo/bar",
-                    name="tests",
+                    name="shunit2",
                     triggering_sources=["bar_test.sh"],
                 ),
                 PutativeTarget.for_target_type(
                     ShellSourcesGeneratorTarget,
                     path="src/sh/foo/qux",
-                    name="lib",
+                    name="shell",
                     triggering_sources=["qux.sh"],
                 ),
             ]

--- a/src/python/pants/backend/shell/tailor_test.py
+++ b/src/python/pants/backend/shell/tailor_test.py
@@ -66,13 +66,13 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
                 PutativeTarget.for_target_type(
                     ShellSourcesGeneratorTarget,
                     path="src/sh/foo",
-                    name=None,
+                    name="lib",
                     triggering_sources=["f.sh"],
                 ),
                 PutativeTarget.for_target_type(
                     ShellSourcesGeneratorTarget,
                     path="src/sh/foo/bar",
-                    name=None,
+                    name="lib",
                     triggering_sources=["baz2.sh", "baz3.sh"],
                 ),
                 PutativeTarget.for_target_type(
@@ -121,7 +121,7 @@ def test_find_putative_targets_subset(rule_runner: RuleRunner) -> None:
                 PutativeTarget.for_target_type(
                     ShellSourcesGeneratorTarget,
                     path="src/sh/foo/qux",
-                    name=None,
+                    name="lib",
                     triggering_sources=["qux.sh"],
                 ),
             ]

--- a/src/python/pants/backend/terraform/goals/tailor.py
+++ b/src/python/pants/backend/terraform/goals/tailor.py
@@ -42,7 +42,7 @@ async def find_putative_terrform_module_targets(
         PutativeTarget.for_target_type(
             TerraformModuleTarget,
             path=dirname,
-            name="tf",
+            name="terraform",
             triggering_sources=sorted(filenames),
         )
         for dirname, filenames in group_by_dir(unowned_terraform_files).items()

--- a/src/python/pants/backend/terraform/goals/tailor.py
+++ b/src/python/pants/backend/terraform/goals/tailor.py
@@ -42,7 +42,7 @@ async def find_putative_terrform_module_targets(
         PutativeTarget.for_target_type(
             TerraformModuleTarget,
             path=dirname,
-            name=None,
+            name="tf",
             triggering_sources=sorted(filenames),
         )
         for dirname, filenames in group_by_dir(unowned_terraform_files).items()

--- a/src/python/pants/backend/terraform/goals/tailor_test.py
+++ b/src/python/pants/backend/terraform/goals/tailor_test.py
@@ -47,7 +47,7 @@ def test_find_putative_targets() -> None:
                 PutativeTarget.for_target_type(
                     TerraformModuleTarget,
                     "prod/terraform/unowned-module",
-                    "unowned-module",
+                    "tf",
                     ("versions.tf",),
                 ),
             ]

--- a/src/python/pants/backend/terraform/goals/tailor_test.py
+++ b/src/python/pants/backend/terraform/goals/tailor_test.py
@@ -47,7 +47,7 @@ def test_find_putative_targets() -> None:
                 PutativeTarget.for_target_type(
                     TerraformModuleTarget,
                     "prod/terraform/unowned-module",
-                    "tf",
+                    "terraform",
                     ("versions.tf",),
                 ),
             ]


### PR DESCRIPTION
Just like https://github.com/pantsbuild/pants/pull/15470, this is the first part in fixing how we handle `name`, per https://docs.google.com/document/d/1jSCJ3pwvIMg5duafsr8KmiLOO_2ARMaYCSrb8K85JQc/edit?usp=sharing and https://github.com/pantsbuild/pants/issues/12286 

The goal is to not have to set `name=` 95% of the time for target generators. So this change will eventually be ~reverted (for target generators, but not "atom targets" like `docker_image`).

But the deprecation plan is very hard to pull off and means that we first need to start with deprecating the current default for `name=` and instead always set it, for now.

[ci skip-rust]
[ci skip-build-wheels]