### PR TITLE
Improve `name=` used for Python requirement target generators with `tailor`

### DIFF
--- a/src/python/pants/backend/python/goals/tailor.py
+++ b/src/python/pants/backend/python/goals/tailor.py
@@ -131,7 +131,7 @@ async def find_putative_targets(
             Get(DigestContents, PathGlobs, req.search_paths.path_globs("pyproject.toml")),
         )
 
-        def add_req_targets(files: Iterable[str], alias: str, target_name) -> None:
+        def add_req_targets(files: Iterable[str], alias: str, target_name: str) -> None:
             unowned_files = set(files) - set(all_owned_sources)
             for fp in unowned_files:
                 path, name = os.path.split(fp)

--- a/src/python/pants/backend/python/goals/tailor.py
+++ b/src/python/pants/backend/python/goals/tailor.py
@@ -131,14 +131,14 @@ async def find_putative_targets(
             Get(DigestContents, PathGlobs, req.search_paths.path_globs("pyproject.toml")),
         )
 
-        def add_req_targets(files: Iterable[str], alias: str) -> None:
+        def add_req_targets(files: Iterable[str], alias: str, target_name) -> None:
             unowned_files = set(files) - set(all_owned_sources)
             for fp in unowned_files:
                 path, name = os.path.split(fp)
                 pts.append(
                     PutativeTarget(
                         path=path,
-                        name=name,
+                        name=target_name,
                         type_alias=alias,
                         triggering_sources=[fp],
                         owned_sources=[name],
@@ -150,11 +150,12 @@ async def find_putative_targets(
                     )
                 )
 
-        add_req_targets(all_requirements_files.files, "python_requirements")
-        add_req_targets(all_pipenv_lockfile_files.files, "pipenv_requirements")
+        add_req_targets(all_requirements_files.files, "python_requirements", "reqs")
+        add_req_targets(all_pipenv_lockfile_files.files, "pipenv_requirements", "pipenv")
         add_req_targets(
             {fc.path for fc in all_pyproject_toml_contents if b"[tool.poetry" in fc.content},
             "poetry_requirements",
+            "poetry",
         )
 
     if python_setup.tailor_pex_binary_targets:

--- a/src/python/pants/backend/python/goals/tailor_test.py
+++ b/src/python/pants/backend/python/goals/tailor_test.py
@@ -113,19 +113,19 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
                 PutativeTarget.for_target_type(
                     PipenvRequirementsTargetGenerator,
                     path="3rdparty",
-                    name="Pipfile.lock",
+                    name="pipenv",
                     triggering_sources=["3rdparty/Pipfile.lock"],
                 ),
                 PutativeTarget.for_target_type(
                     PoetryRequirementsTargetGenerator,
                     path="3rdparty",
-                    name="pyproject.toml",
+                    name="poetry",
                     triggering_sources=["3rdparty/pyproject.toml"],
                 ),
                 PutativeTarget.for_target_type(
                     PythonRequirementsTargetGenerator,
                     path="3rdparty",
-                    name="requirements-test.txt",
+                    name="reqs",
                     triggering_sources=["3rdparty/requirements-test.txt"],
                     kwargs={"source": "requirements-test.txt"},
                 ),


### PR DESCRIPTION
We were using the file-name, which was a hold-over from when we had Context-Aware Object Factories and the `name=` was ignored. This was an oversight that we were still doing this.

[ci skip-rust]
[ci skip-build-wheels]