### PR TITLE
Improve `name=` used for Python requirement target generators with `tailor` (Cherry-pick of #15507)

### DIFF
--- a/src/python/pants/backend/python/goals/tailor.py
+++ b/src/python/pants/backend/python/goals/tailor.py
@@ -129,7 +129,7 @@ async def find_putative_targets(
             pts.append(
                 PutativeTarget(
                     path=path,
-                    name=name,
+                    name="reqs",
                     type_alias="python_requirements",
                     triggering_sources=[req_file],
                     owned_sources=[name],

--- a/src/python/pants/backend/python/goals/tailor_test.py
+++ b/src/python/pants/backend/python/goals/tailor_test.py
@@ -104,7 +104,7 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
                 PutativeTarget.for_target_type(
                     PythonRequirementsTargetGenerator,
                     path="3rdparty",
-                    name="requirements-test.txt",
+                    name="reqs",
                     triggering_sources=["3rdparty/requirements-test.txt"],
                     kwargs={"source": "requirements-test.txt"},
                 ),


### PR DESCRIPTION
We were using the file-name, which was a hold-over from when we had Context-Aware Object Factories and the `name=` was ignored. This was an oversight that we were still doing this.

[ci skip-rust]
[ci skip-build-wheels]