### PR TITLE
Always error on non-existent file arguments

### DIFF
--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -295,35 +295,26 @@ class FilesystemSpecs:
         self.ignores = tuple(ignores)
 
     @staticmethod
-    def _generate_path_globs(
-        specs: Iterable[FilesystemSpec], glob_match_error_behavior: GlobMatchErrorBehavior
-    ) -> PathGlobs:
+    def _generate_path_globs(specs: Iterable[FilesystemSpec]) -> PathGlobs:
         return PathGlobs(
             globs=(s.to_glob() for s in specs),
-            glob_match_error_behavior=glob_match_error_behavior,
+            glob_match_error_behavior=GlobMatchErrorBehavior.error,
             # We validate that _every_ glob is valid.
             conjunction=GlobExpansionConjunction.all_match,
-            description_of_origin=(
-                None
-                if glob_match_error_behavior == GlobMatchErrorBehavior.ignore
-                else "file/directory arguments"
-            ),
+            description_of_origin="file/directory arguments",
         )
 
     def path_globs_for_spec(
         self,
         spec: FileLiteralSpec | FileGlobSpec | DirLiteralSpec,
-        glob_match_error_behavior: GlobMatchErrorBehavior,
     ) -> PathGlobs:
         """Generate PathGlobs for the specific spec, automatically including the instance's
         FileIgnoreSpecs."""
-        return self._generate_path_globs((spec, *self.ignores), glob_match_error_behavior)
+        return self._generate_path_globs((spec, *self.ignores))
 
-    def to_path_globs(self, glob_match_error_behavior: GlobMatchErrorBehavior) -> PathGlobs:
+    def to_path_globs(self) -> PathGlobs:
         """Generate a single PathGlobs for the instance."""
-        return self._generate_path_globs(
-            (*self.file_includes, *self.dir_includes, *self.ignores), glob_match_error_behavior
-        )
+        return self._generate_path_globs((*self.file_includes, *self.dir_includes, *self.ignores))
 
     def __bool__(self) -> bool:
         return bool(self.file_includes) or bool(self.dir_includes) or bool(self.ignores)

--- a/src/python/pants/engine/internals/specs_rules.py
+++ b/src/python/pants/engine/internals/specs_rules.py
@@ -177,13 +177,7 @@ async def addresses_from_filesystem_specs(
 ) -> Addresses:
     """Find the owner(s) for each FilesystemSpec."""
     paths_per_include = await MultiGet(
-        Get(
-            Paths,
-            PathGlobs,
-            filesystem_specs.path_globs_for_spec(
-                spec, owners_not_found_behavior.to_glob_match_error_behavior()
-            ),
-        )
+        Get(Paths, PathGlobs, filesystem_specs.path_globs_for_spec(spec))
         for spec in filesystem_specs.file_includes
     )
     owners_per_include = await MultiGet(
@@ -240,9 +234,7 @@ def setup_specs_filter(global_options: GlobalOptions) -> SpecsFilter:
 
 
 @rule(desc="Find all sources from input specs", level=LogLevel.DEBUG)
-async def resolve_specs_snapshot(
-    specs: Specs, owners_not_found_behavior: OwnersNotFoundBehavior
-) -> SpecsSnapshot:
+async def resolve_specs_snapshot(specs: Specs) -> SpecsSnapshot:
     """Resolve all files matching the given specs.
 
     Address specs will use their `SourcesField` field, and Filesystem specs will use whatever args
@@ -256,13 +248,7 @@ async def resolve_specs_snapshot(
     )
 
     filesystem_specs_digest = (
-        await Get(
-            Digest,
-            PathGlobs,
-            specs.filesystem_specs.to_path_globs(
-                owners_not_found_behavior.to_glob_match_error_behavior()
-            ),
-        )
+        await Get(Digest, PathGlobs, specs.filesystem_specs.to_path_globs())
         if specs.filesystem_specs
         else None
     )

--- a/src/python/pants/engine/internals/specs_rules_test.py
+++ b/src/python/pants/engine/internals/specs_rules_test.py
@@ -587,12 +587,13 @@ def test_filesystem_specs_glob(rule_runner: RuleRunner) -> None:
 
 
 def test_filesystem_specs_nonexistent_file(rule_runner: RuleRunner) -> None:
-    spec = FileLiteralSpec("demo/fake.txt")
-    with engine_error(contains='Unmatched glob from file/directory arguments: "demo/fake.txt"'):
-        resolve_filesystem_specs(rule_runner, [spec])
+    rule_runner.write_files({"valid.txt": ""})
+    valid_spec = FileLiteralSpec("valid.txt")
 
-    rule_runner.set_options(["--owners-not-found-behavior=ignore"])
-    assert not resolve_filesystem_specs(rule_runner, [spec])
+    with engine_error(contains='Unmatched glob from file/directory arguments: "demo/fake.txt"'):
+        resolve_filesystem_specs(rule_runner, [FileLiteralSpec("demo/fake.txt"), valid_spec])
+    with engine_error(contains='Unmatched glob from file/directory arguments: "demo/*.txt"'):
+        resolve_filesystem_specs(rule_runner, [FileGlobSpec("demo/*.txt"), valid_spec])
 
 
 def test_filesystem_specs_no_owner(rule_runner: RuleRunner) -> None:


### PR DESCRIPTION
Right now, `--owners-not-found-behavior` controls whether we error or not on unmatched file arguments, like `./pants test spot_the_typoo.py`. But we need to get rid of that option (https://github.com/pantsbuild/pants/issues/15529) as it blocks target-less goals like `count-loc` from properly working with file arguments. We have a bad coupling.

The simplest fix is for us to simply always error, which was our default behavior before. It seems to usually be a typo/bug if you are running on files that don't exist.

If necessary, we could add `--nonexistent-file-arguments-behavior`? Non-existent files often come into play w/ Git when something is deleted. (Note: `--changed-since` will special-case `FilesystemSpecs` to not error on deleted files. See https://github.com/pantsbuild/pants/pull/14434.)

[ci skip-rust]
[ci skip-build-wheels]