### PR TITLE
Remove transitive `InterpreterConstraint` merging deprecation

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -387,11 +387,17 @@ async def infer_python_dependencies_via_source(
 
     _wrapped_tgt = await Get(WrappedTarget, Address, request.sources_field.address)
     tgt = _wrapped_tgt.target
+    interpreter_constraints = InterpreterConstraints.create_from_targets([tgt], python_setup)
+    if interpreter_constraints is None:
+        # TODO: This would represent a target with a PythonSource field, but no
+        # InterpreterConstraints field. #15400 would allow inference to require both
+        # fields.
+        return InferredDependencies([])
     parsed_dependencies = await Get(
         ParsedPythonDependencies,
         ParsePythonDependenciesRequest(
             cast(PythonSourceField, request.sources_field),
-            InterpreterConstraints.create_from_targets([tgt], python_setup),
+            interpreter_constraints,
             string_imports=python_infer_subsystem.string_imports,
             string_imports_min_dots=python_infer_subsystem.string_imports_min_dots,
             assets=python_infer_subsystem.assets,

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -166,7 +166,9 @@ async def setup_pytest_for_target(
     )
     all_targets = transitive_targets.closure
 
-    interpreter_constraints = InterpreterConstraints.create_from_targets(all_targets, python_setup)
+    interpreter_constraints = InterpreterConstraints.create_from_compatibility_fields(
+        [request.field_set.interpreter_constraints], python_setup
+    )
 
     requirements_pex_get = Get(Pex, RequirementsPexRequest([request.field_set.address]))
     pytest_pex_get = Get(

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -94,7 +94,9 @@ async def _bandit_interpreter_constraints(python_setup: PythonSetup) -> Interpre
         for tgt in all_tgts
         if BanditFieldSet.is_applicable(tgt)
     }
-    constraints = InterpreterConstraints(itertools.chain.from_iterable(unique_constraints))
+    constraints = InterpreterConstraints(
+        itertools.chain.from_iterable(ic for ic in unique_constraints if ic)
+    )
     return constraints or InterpreterConstraints(python_setup.interpreter_constraints)
 
 

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -89,7 +89,9 @@ async def _black_interpreter_constraints(
         code_constraints = InterpreterConstraints.create_from_targets(
             (tgt for tgt in all_tgts if not tgt.get(SkipBlackField).value), python_setup
         )
-        if code_constraints.requires_python38_or_newer(python_setup.interpreter_universe):
+        if code_constraints is not None and code_constraints.requires_python38_or_newer(
+            python_setup.interpreter_universe
+        ):
             constraints = code_constraints
     return constraints
 

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -241,17 +241,17 @@ async def _flake8_interpreter_constraints(
     # This ORs all unique interpreter constraints. The net effect is that every possible Python
     # interpreter used will be covered.
     all_tgts = await Get(AllTargets, AllTargetsRequest())
-    relevant_targets = tuple(tgt for tgt in all_tgts if Flake8FieldSet.is_applicable(tgt))
-    unique_constraints = set()
-    for tgt in relevant_targets:
-        if tgt.has_field(InterpreterConstraintsField):
-            constraints_field = tgt[InterpreterConstraintsField]
-            unique_constraints.add(
-                InterpreterConstraints.create_from_compatibility_fields(
-                    (constraints_field, *first_party_plugins.interpreter_constraints_fields),
-                    python_setup,
-                )
-            )
+    unique_constraints = {
+        InterpreterConstraints.create_from_compatibility_fields(
+            (
+                tgt[InterpreterConstraintsField],
+                *first_party_plugins.interpreter_constraints_fields,
+            ),
+            python_setup,
+        )
+        for tgt in all_tgts
+        if Flake8FieldSet.is_applicable(tgt)
+    }
     if not unique_constraints:
         unique_constraints.add(
             InterpreterConstraints.create_from_compatibility_fields(

--- a/src/python/pants/backend/python/lint/pylint/subsystem_test.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem_test.py
@@ -180,42 +180,6 @@ def test_setup_lockfile_interpreter_constraints(rule_runner: RuleRunner) -> None
         ["==2.7.*", global_constraint, ">=3.8"],
     )
 
-    # Also consider direct deps (but not transitive). They should be ANDed within each target's
-    # closure like normal, but then ORed across each closure.
-    assert_lockfile_request(
-        dedent(
-            """\
-            python_sources(
-                name='transitive_dep', interpreter_constraints=['==99'], skip_pylint=True,
-            )
-            python_sources(
-                name='dep',
-                dependencies=[":transitive_dep"],
-                interpreter_constraints=['==2.7.*', '==3.8.*'],
-                skip_pylint=True,
-            )
-            python_sources(name='app', dependencies=[":dep"], interpreter_constraints=['==2.7.*'])
-            """
-        ),
-        ["==2.7.*", "==2.7.*,==3.8.*"],
-    )
-    assert_lockfile_request(
-        dedent(
-            """\
-            python_sources(
-                name='lib1', interpreter_constraints=['==2.7.*', '==3.8.*'], skip_pylint=True
-            )
-            python_sources(name='app1', dependencies=[":lib1"], interpreter_constraints=['==2.7.*'])
-
-            python_sources(
-                name='lib2', interpreter_constraints=['>=3.7'], skip_pylint=True
-            )
-            python_sources(name='app2', dependencies=[":lib2"], interpreter_constraints=['==3.9.*'])
-            """
-        ),
-        ["==2.7.*", "==2.7.*,==3.8.*", ">=3.7,==3.9.*"],
-    )
-
     # Check that source_plugins are included, even if they aren't linted directly. Plugins
     # consider transitive deps.
     assert_lockfile_request(

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -18,6 +18,7 @@ from pants.backend.python.subsystems.python_tool_base import ExportToolOption, P
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (
     ConsoleScript,
+    InterpreterConstraintsField,
     PythonTestsExtraEnvVarsField,
     PythonTestSourceField,
     PythonTestsTimeoutField,
@@ -48,6 +49,7 @@ class PythonTestFieldSet(TestFieldSet):
     required_fields = (PythonTestSourceField,)
 
     source: PythonTestSourceField
+    interpreter_constraints: InterpreterConstraintsField
     timeout: PythonTestsTimeoutField
     runtime_package_dependencies: RuntimePackageDependenciesField
     extra_env_vars: PythonTestsExtraEnvVarsField
@@ -208,7 +210,9 @@ async def _pytest_interpreter_constraints(python_setup: PythonSetup) -> Interpre
         InterpreterConstraints.create_from_targets(transitive_targets.closure, python_setup)
         for transitive_targets in transitive_targets_per_test
     }
-    constraints = InterpreterConstraints(itertools.chain.from_iterable(unique_constraints))
+    constraints = InterpreterConstraints(
+        itertools.chain.from_iterable(ic for ic in unique_constraints if ic)
+    )
     return constraints or InterpreterConstraints(python_setup.interpreter_constraints)
 
 

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -15,6 +15,7 @@ from pants.backend.python.subsystems.python_tool_base import ExportToolOption, P
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (
     ConsoleScript,
+    InterpreterConstraintsField,
     PythonRequirementsField,
     PythonSourceField,
 )
@@ -33,8 +34,6 @@ from pants.engine.rules import Get, collect_rules, rule, rule_helper
 from pants.engine.target import (
     AllTargets,
     AllTargetsRequest,
-    CoarsenedTargets,
-    CoarsenedTargetsRequest,
     FieldSet,
     Target,
     TransitiveTargets,
@@ -62,6 +61,7 @@ class MyPyFieldSet(FieldSet):
     required_fields = (PythonSourceField,)
 
     sources: PythonSourceField
+    interpreter_constraints: InterpreterConstraintsField
 
     @classmethod
     def opt_out(cls, tgt: Target) -> bool:
@@ -283,25 +283,14 @@ async def _mypy_interpreter_constraints(
     constraints = mypy.interpreter_constraints
     if mypy.options.is_default("interpreter_constraints"):
         all_tgts = await Get(AllTargets, AllTargetsRequest())
-
-        coarsened_targets = await Get(
-            CoarsenedTargets,
-            CoarsenedTargetsRequest(
-                (tgt.address for tgt in all_tgts if MyPyFieldSet.is_applicable(tgt)),
-                expanded_targets=True,
-            ),
+        unique_constraints = {
+            InterpreterConstraints.create_from_targets([tgt], python_setup)
+            for tgt in all_tgts
+            if MyPyFieldSet.is_applicable(tgt)
+        }
+        code_constraints = InterpreterConstraints(
+            itertools.chain.from_iterable(ic for ic in unique_constraints if ic)
         )
-
-        ics = InterpreterConstraints.compute_for_targets(coarsened_targets, python_setup)
-        if ics is None:
-            unique_constraints = {
-                InterpreterConstraints.create_from_targets(ct.closure(), python_setup)
-                for ct in coarsened_targets
-            }
-        else:
-            unique_constraints = {ic for ic in ics if ic}
-
-        code_constraints = InterpreterConstraints(itertools.chain.from_iterable(unique_constraints))
         if code_constraints.requires_python38_or_newer(python_setup.interpreter_universe):
             constraints = code_constraints
     return constraints

--- a/src/python/pants/backend/python/util_rules/interpreter_constraints.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints.py
@@ -188,7 +188,12 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
     def create_from_compatibility_fields(
         cls, fields: Iterable[InterpreterConstraintsField], python_setup: PythonSetup
     ) -> InterpreterConstraints:
-        """TODO: See the deprecation in `target_types_rules.validate_python_dependencies`."""
+        """Returns merged InterpreterConstraints for the given `InterpreterConstraintsField`s.
+
+        NB: Because Python targets validate that they have ICs which are a subset of their
+        dependencies, merging constraints like this is only necessary when you are _mixing_ code
+        which might not have any inter-dependencies, such as when you're merging un-related roots.
+        """
         constraint_sets = {field.value_or_global_default(python_setup) for field in fields}
         # This will OR within each field and AND across fields.
         merged_constraints = cls.merge_constraint_sets(constraint_sets)

--- a/src/python/pants/backend/python/util_rules/interpreter_constraints.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints.py
@@ -15,7 +15,7 @@ from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import InterpreterConstraintsField
 from pants.build_graph.address import Address
 from pants.engine.engine_aware import EngineAwareParameter
-from pants.engine.target import CoarsenedTarget, Target
+from pants.engine.target import Target
 from pants.util.docutil import bin_name
 from pants.util.frozendict import FrozenDict
 from pants.util.memo import memoized
@@ -93,87 +93,6 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
         return parsed_requirement
 
     @classmethod
-    def compute_for_targets(
-        cls, cts: Sequence[CoarsenedTarget], python_setup: PythonSetup
-    ) -> list[InterpreterConstraints | None] | None:
-        """Compute the InterpreterConstraints for the given (Coarsened)Target instances.
-
-        If any reachable target has ICs which are not compatible with its dependencies (i.e., are
-        not a subset), then the entire result is None. TODO: When the deprecations below trigger,
-        this should turn into an error, and the return value should become infallible.
-
-        If a (Coarsened)Target root does not have ICs of its own, then its entry in the return value
-        will be None.
-
-        TODO: See the deprecation in `target_types_rules.validate_python_dependencies`.
-        """
-
-        interpreter_constraints: dict[CoarsenedTarget, set[RawConstraints]] = {}
-
-        def compute(ct: CoarsenedTarget) -> set[RawConstraints] | None:
-            """Validate a CoarsenedTarget, and return its computed constraints.
-
-            A CT will only have multiple constraints if it is acting as an alias for its
-            dependencies, because it doesn't have constraints of its own.
-            """
-            ics = interpreter_constraints.get(ct)
-            if ics is not None:
-                return ics
-
-            # Validate that all members of a cycle have the same ICs.
-            ics = {
-                tgt[InterpreterConstraintsField].value_or_global_default(python_setup)
-                for tgt in ct.members
-                if tgt.has_field(InterpreterConstraintsField)
-            }
-
-            if len(ics) > 1:
-                return None
-
-            # Collect the distinct interpreter constraints of dependencies.
-            dependency_interpreter_constraints = defaultdict(list)
-            for dependency in ct.dependencies:
-                dependency_ics = compute(dependency)
-                if dependency_ics is None:
-                    return None
-                for d_ics in dependency_ics:
-                    dependency_interpreter_constraints[d_ics].append(dependency)
-
-            if ics:
-                single_ics = next(iter(ics))
-                # Validate that the ICs for dependencies are all compatible with our own.
-                if not all(
-                    interpreter_constraints_contains(
-                        d_ics, single_ics, python_setup.interpreter_universe
-                    )
-                    for d_ics, targets in dependency_interpreter_constraints.items()
-                ):
-                    return None
-            else:
-                # If there are no interpreter constraints in a CT, then it acts like an alias for
-                # the targets it points to.
-                ics = set(dependency_interpreter_constraints)
-
-            interpreter_constraints[ct] = ics
-            return ics
-
-        def canonical(ics: set[RawConstraints]) -> InterpreterConstraints | None:
-            """If a CoarsenedTarget has multiple ICs, it's because it didn't have any of its own."""
-            if len(ics) == 1:
-                return InterpreterConstraints(next(iter(ics)))
-            else:
-                return None
-
-        result = []
-        for ct in cts:
-            root_ics = compute(ct)
-            if root_ics is None:
-                # TODO: When the deprecation triggers, `compute` should eagerly raise instead.
-                return None
-            result.append(canonical(root_ics))
-        return result
-
-    @classmethod
     def merge(cls, ics: Iterable[InterpreterConstraints]) -> InterpreterConstraints:
         return InterpreterConstraints(
             cls.merge_constraint_sets(tuple(str(requirement) for requirement in ic) for ic in ics)
@@ -247,16 +166,23 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
     @classmethod
     def create_from_targets(
         cls, targets: Iterable[Target], python_setup: PythonSetup
-    ) -> InterpreterConstraints:
-        """TODO: See the deprecation in `target_types_rules.validate_python_dependencies`."""
-        return cls.create_from_compatibility_fields(
-            (
-                tgt[InterpreterConstraintsField]
-                for tgt in targets
-                if tgt.has_field(InterpreterConstraintsField)
-            ),
-            python_setup,
-        )
+    ) -> InterpreterConstraints | None:
+        """Returns merged InterpreterConstraints for the given Targets.
+
+        If none of the given Targets have InterpreterConstraintsField, returns None.
+
+        NB: Because Python targets validate that they have ICs which are a subset of their
+        dependencies, merging constraints like this is only necessary when you are _mixing_ code
+        which might not have any inter-dependencies, such as when you're merging un-related roots.
+        """
+        fields = [
+            tgt[InterpreterConstraintsField]
+            for tgt in targets
+            if tgt.has_field(InterpreterConstraintsField)
+        ]
+        if not fields:
+            return None
+        return cls.create_from_compatibility_fields(fields, python_setup)
 
     @classmethod
     def create_from_compatibility_fields(

--- a/src/python/pants/backend/python/util_rules/interpreter_constraints_test.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints_test.py
@@ -10,17 +10,13 @@ import pytest
 from pkg_resources import Requirement
 
 from pants.backend.python.subsystems.setup import PythonSetup
-from pants.backend.python.target_types import (
-    InterpreterConstraintsField,
-    PythonSourcesGeneratorTarget,
-    PythonSourceTarget,
-)
+from pants.backend.python.target_types import InterpreterConstraintsField
 from pants.backend.python.util_rules.interpreter_constraints import (
     _PATCH_VERSION_UPPER_BOUND,
     InterpreterConstraints,
 )
 from pants.build_graph.address import Address
-from pants.engine.target import CoarsenedTarget, FieldSet, Target
+from pants.engine.target import FieldSet
 from pants.testutil.option_util import create_subsystem
 from pants.util.frozendict import FrozenDict
 from pants.util.ordered_set import FrozenOrderedSet
@@ -452,51 +448,6 @@ def test_contains(candidate, target, matches) -> None:
             InterpreterConstraints(target), ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
         )
         == matches
-    )
-
-
-@pytest.mark.parametrize(
-    "root_ics,ics_by_path_spec",
-    (
-        (["==3.5.*", None], {"root1": "==3.5.*", "inner": ">=3.5"}),
-        (None, {"root1": "==3.5.*", "inner": ">=3.6"}),
-        (["==3.7.*", ">=3.5"], {"root1": "==3.7.*", "inner": ">=3.6", "leaf": ">=3.5"}),
-        (["==3.5.*", ">=3.5"], {"root1": "==3.5.*", "leaf": ">=3.5"}),
-        (None, {"root1": "==3.5.*", "leaf": ">=3.6"}),
-        ([None, "==3.5.*"], {"root2": "==3.5.*", "root3": "==3.5.*"}),
-        (None, {"root2": "==3.5.*", "root3": "==3.6.*"}),
-        (None, {"root2": "==3.5.*", "root3": ">=3.5"}),
-    ),
-)
-def test_validate_targets(
-    root_ics: list[str | None] | None, ics_by_path_spec: dict[str, str]
-) -> None:
-    def t(path_spec: str) -> Target:
-        address = Address(path_spec)
-        ics = ics_by_path_spec.get(path_spec)
-        if ics is None:
-            return PythonSourcesGeneratorTarget({}, address)
-        else:
-            return PythonSourceTarget(
-                {InterpreterConstraintsField.alias: [ics], "source": f"{path_spec}.py"}, address
-            )
-
-    expected = (
-        [(InterpreterConstraints([ics]) if ics else None) for ics in root_ics] if root_ics else None
-    )
-    assert expected == InterpreterConstraints.compute_for_targets(
-        [
-            CoarsenedTarget(
-                [t("root1")],
-                [CoarsenedTarget([t("inner")], [CoarsenedTarget([t("leaf")], [])])],
-            ),
-            CoarsenedTarget([t("root2"), t("root3")], [CoarsenedTarget([t("leaf")], [])]),
-        ],
-        create_subsystem(
-            PythonSetup,
-            interpreter_constraints=[],
-            interpreter_versions_universe=["3.5", "3.6", "3.7"],
-        ),
     )
 
 

--- a/testprojects/src/python/native/BUILD
+++ b/testprojects/src/python/native/BUILD
@@ -22,5 +22,5 @@ pex_binary(
     name="main",
     entry_point="main.py",
     dependencies=[":dist", ":main_lib"],
-    interpreter_constraints=["==3.7.*"],
+    interpreter_constraints=["==3.9.*"],
 )


### PR DESCRIPTION
Removes the deprecation from #15373 by converting it into an error, and then assuming the condition in `mypy`, `pylint`, and `pytest` (all of which used transitive dependencies, and previously AND'd their constraints).