### PR TITLE
Remove undocumented CLI file arguments ignore syntax

### DIFF
--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -262,7 +262,6 @@ class FilesystemSpecs:
     def __init__(self, specs: Iterable[FilesystemSpec]) -> None:
         file_includes = []
         dir_includes = []
-        ignores = []
         for spec in specs:
             if isinstance(spec, (FileLiteralSpec, FileGlobSpec)):
                 file_includes.append(spec)
@@ -272,7 +271,6 @@ class FilesystemSpecs:
                 raise AssertionError(f"Unexpected type of FilesystemSpec: {repr(self)}")
         self.file_includes = tuple(file_includes)
         self.dir_includes = tuple(dir_includes)
-        self.ignores = tuple(ignores)
 
     @staticmethod
     def _generate_path_globs(

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -232,23 +232,6 @@ class FileGlobSpec(FilesystemSpec):
 
 
 @dataclass(frozen=True)
-class FileIgnoreSpec(FilesystemSpec):
-    """A spec to ignore certain files or globs."""
-
-    glob: str
-
-    def __post_init__(self) -> None:
-        if self.glob.startswith("!"):
-            raise ValueError(f"The `glob` for {self} should not start with `!`.")
-
-    def __str__(self) -> str:
-        return f"!{self.glob}"
-
-    def to_glob(self) -> str:
-        return f"!{self.glob}"
-
-
-@dataclass(frozen=True)
 class DirLiteralSpec(FilesystemSpec):
     """A literal dir path, e.g. `some/dir`.
 
@@ -275,7 +258,6 @@ class DirLiteralSpec(FilesystemSpec):
 class FilesystemSpecs:
     file_includes: tuple[FileLiteralSpec | FileGlobSpec, ...]
     dir_includes: tuple[DirLiteralSpec, ...]
-    ignores: tuple[FileIgnoreSpec, ...]
 
     def __init__(self, specs: Iterable[FilesystemSpec]) -> None:
         file_includes = []
@@ -286,8 +268,6 @@ class FilesystemSpecs:
                 file_includes.append(spec)
             elif isinstance(spec, DirLiteralSpec):
                 dir_includes.append(spec)
-            elif isinstance(spec, FileIgnoreSpec):
-                ignores.append(spec)
             else:
                 raise AssertionError(f"Unexpected type of FilesystemSpec: {repr(self)}")
         self.file_includes = tuple(file_includes)
@@ -315,18 +295,17 @@ class FilesystemSpecs:
         spec: FileLiteralSpec | FileGlobSpec | DirLiteralSpec,
         glob_match_error_behavior: GlobMatchErrorBehavior,
     ) -> PathGlobs:
-        """Generate PathGlobs for the specific spec, automatically including the instance's
-        FileIgnoreSpecs."""
-        return self._generate_path_globs((spec, *self.ignores), glob_match_error_behavior)
+        """Generate PathGlobs for the specific spec."""
+        return self._generate_path_globs([spec], glob_match_error_behavior)
 
     def to_path_globs(self, glob_match_error_behavior: GlobMatchErrorBehavior) -> PathGlobs:
         """Generate a single PathGlobs for the instance."""
         return self._generate_path_globs(
-            (*self.file_includes, *self.dir_includes, *self.ignores), glob_match_error_behavior
+            (*self.file_includes, *self.dir_includes), glob_match_error_behavior
         )
 
     def __bool__(self) -> bool:
-        return bool(self.file_includes) or bool(self.dir_includes) or bool(self.ignores)
+        return bool(self.file_includes) or bool(self.dir_includes)
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/base/specs_parser_test.py
+++ b/src/python/pants/base/specs_parser_test.py
@@ -14,7 +14,6 @@ from pants.base.specs import (
     DescendantAddresses,
     DirLiteralSpec,
     FileGlobSpec,
-    FileIgnoreSpec,
     FileLiteralSpec,
     FilesystemSpec,
     SiblingAddresses,
@@ -53,10 +52,6 @@ def file_literal(file: str) -> FileLiteralSpec:
 
 def file_glob(val: str) -> FileGlobSpec:
     return FileGlobSpec(val)
-
-
-def ignore(val: str) -> FileIgnoreSpec:
-    return FileIgnoreSpec(val)
 
 
 def assert_spec_parsed(build_root: Path, spec_str: str, expected_spec: Spec) -> None:
@@ -136,11 +131,6 @@ def test_files(tmp_path: Path) -> None:
 @pytest.mark.parametrize("spec", ["*", "**/*", "a/b/*", "a/b/test_*.py", "a/b/**/test_*"])
 def test_file_globs(tmp_path: Path, spec: str) -> None:
     assert_spec_parsed(tmp_path, spec, file_glob(spec))
-
-
-@pytest.mark.parametrize("spec", ["!", "!a/b/", "!/a/b/*"])
-def test_excludes(tmp_path: Path, spec: str) -> None:
-    assert_spec_parsed(tmp_path, spec, ignore(spec[1:]))
 
 
 def test_dir_literals(tmp_path: Path) -> None:

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -39,10 +39,6 @@ class InvalidParameters(InvalidAddress):
     """Indicate invalid parameter values for `Address`."""
 
 
-class UnsupportedIgnore(InvalidAddress):
-    """Indicate that a `!` ignore was used."""
-
-
 class UnsupportedWildcard(InvalidAddress):
     """Indicate that an address wildcard was used."""
 

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -157,7 +157,6 @@ class AddressInput:
             return os.path.normpath(subproject)
 
         (
-            is_ignored,
             (
                 path_component,
                 target_component,
@@ -166,13 +165,6 @@ class AddressInput:
             ),
             wildcard,
         ) = native_engine.address_spec_parse(spec)
-
-        if is_ignored:
-            # NB: BUILD dependency ignore parsing occurs at a different level, because AddressInput
-            # does not support encoding negation.
-            raise UnsupportedIgnore(
-                f"The address `{spec}` was prefixed with a `!` ignore, which is not supported."
-            )
 
         if wildcard:
             raise UnsupportedWildcard(

--- a/src/python/pants/build_graph/address_test.py
+++ b/src/python/pants/build_graph/address_test.py
@@ -12,7 +12,6 @@ from pants.build_graph.address import (
     InvalidParameters,
     InvalidSpecPath,
     InvalidTargetName,
-    UnsupportedIgnore,
     UnsupportedWildcard,
 )
 from pants.util.frozendict import FrozenDict

--- a/src/python/pants/build_graph/address_test.py
+++ b/src/python/pants/build_graph/address_test.py
@@ -147,20 +147,6 @@ def test_address_bad_target_component(spec: str) -> None:
 @pytest.mark.parametrize(
     "spec",
     [
-        "!",
-        "!a",
-        "!a:x",
-        "!a#x",
-    ],
-)
-def test_address_bad_ignore(spec: str) -> None:
-    with pytest.raises(UnsupportedIgnore):
-        AddressInput.parse(spec).dir_to_address()
-
-
-@pytest.mark.parametrize(
-    "spec",
-    [
         "a::",
         "a:",
         "a:b:",

--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -553,7 +553,6 @@ def specs_to_dirs(specs: Specs) -> tuple[str, ...]:
     dir_specs = [dir_spec.v for dir_spec in specs.filesystem_specs.dir_includes]
     other_specs: list[Spec] = [
         *specs.filesystem_specs.file_includes,
-        *specs.filesystem_specs.ignores,
         *specs.address_specs.globs,
     ]
     for spec in specs.address_specs.literals:

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -26,7 +26,7 @@ class AddressParseException(Exception):
 
 def address_spec_parse(
     spec: str,
-) -> tuple[bool, tuple[str, str | None, str | None, tuple[tuple[str, str], ...]], str | None]: ...
+) -> tuple[tuple[str, str | None, str | None, tuple[tuple[str, str], ...]], str | None]: ...
 
 # ------------------------------------------------------------------------------
 # Scheduler

--- a/src/rust/engine/address/src/lib.rs
+++ b/src/rust/engine/address/src/lib.rs
@@ -33,8 +33,6 @@ pub struct AddressInput<'a> {
 }
 
 pub struct SpecInput<'a> {
-  /// True if the spec started with an `!`.
-  pub is_ignored: bool,
   /// The address (or literal, if no target/generated/parameters were specified) portion.
   pub address: AddressInput<'a>,
   /// If a spec wildcard was specified (`:` or `::`), its value.
@@ -78,14 +76,12 @@ peg::parser! {
                 }
             }
 
-        rule ignore() -> () = "!" {}
 
         rule wildcard() -> &'input str = s:$("::" / ":") { s }
 
         pub(crate) rule spec() -> SpecInput<'input>
-            = is_ignored:ignore()? address:address() wildcard:wildcard()? {
+            = address:address() wildcard:wildcard()? {
                 SpecInput {
-                    is_ignored: is_ignored == Some(()),
                     address,
                     wildcard,
                 }

--- a/src/rust/engine/src/externs/address.rs
+++ b/src/rust/engine/src/externs/address.rs
@@ -27,10 +27,9 @@ type ParsedAddress<'a> = (
   Vec<(&'a str, &'a str)>,
 );
 
-/// 1. an is_ignored boolean
-/// 2. an address
-/// 3. an optional wildcard component (`:` or `::`)
-type ParsedSpec<'a> = (bool, ParsedAddress<'a>, Option<&'a str>);
+/// 1. an address
+/// 2. an optional wildcard component (`:` or `::`)
+type ParsedSpec<'a> = (ParsedAddress<'a>, Option<&'a str>);
 
 /// Parses an "address spec", which may come from the CLI or from a BUILD file.
 ///
@@ -45,7 +44,6 @@ type ParsedSpec<'a> = (bool, ParsedAddress<'a>, Option<&'a str>);
 fn address_spec_parse(spec_str: &str) -> PyResult<ParsedSpec> {
   let spec = address::parse_address_spec(spec_str).map_err(AddressParseException::new_err)?;
   Ok((
-    spec.is_ignored,
     (
       spec.address.path,
       spec.address.target,


### PR DESCRIPTION
We currently allow you to ignore a file or file glob on the CLI: `./pants lint 'project/*.py' '!project/not_me.py'`. It will cause the file to not be included when evaluating `FilesystemSpecs`.

However, the feature is incomplete. This should work, but it does not: `./pants lint project/foo.py:tgt '!project/foo.py'`. `FilesystemIgnoreSpec` is not involved with `AddressSpecs` at all.

This undocumented feature is causing issues with the unification of specs for target-less (`count-loc`) and target-aware (`test`) goals: https://docs.google.com/document/d/1WWQM-X6kHoSCKwItqf61NiKFWNSlpnTC5QNu3ul9RDk/edit#heading=h.1h4j0d5mazhu. So I propose that we remove it, and then add back a proper, fully-fleshed out ignore mechanism later for every spec type, e.g. `!dir::`.

> This undocumented feature

A user poll in Slack showed 10 have never heard of the feature vs 1 maintainer who has but has never used it. (3/10 who did not know are maintainers!)