### PR TITLE
[internal] Make Pants aware of the Linux ARM architecture

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -54,7 +54,7 @@ class PexCli(TemplatedExternalTool):
                     "3748292",
                 )
             )
-            for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64"]
+            for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64", "linux_arm64"]
         ]
 
 

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -87,6 +87,8 @@ pub enum Platform {
   Macos_x86_64,
   Macos_arm64,
   Linux_x86_64,
+  Linux_arm64,
+  Linux_aarch64,
 }
 
 impl Platform {
@@ -100,6 +102,15 @@ impl Platform {
         ..
       } if sysname.to_lowercase() == "linux" && machine.to_lowercase() == "x86_64" => {
         Ok(Platform::Linux_x86_64)
+      }
+      uname::Info {
+        ref sysname,
+        ref machine,
+        ..
+      } if sysname.to_lowercase() == "linux"
+        && (machine.to_lowercase() == "arm64" || machine.to_lowercase() == "aarch64") =>
+      {
+        Ok(Platform::Linux_arm64)
       }
       uname::Info {
         ref sysname,
@@ -131,6 +142,8 @@ impl From<Platform> for String {
   fn from(platform: Platform) -> String {
     match platform {
       Platform::Linux_x86_64 => "linux_x86_64".to_string(),
+      Platform::Linux_arm64 => "linux_arm64".to_string(),
+      Platform::Linux_aarch64 => "linux_aarch64".to_string(),
       Platform::Macos_arm64 => "macos_arm64".to_string(),
       Platform::Macos_x86_64 => "macos_x86_64".to_string(),
     }
@@ -144,6 +157,8 @@ impl TryFrom<String> for Platform {
       "macos_arm64" => Ok(Platform::Macos_arm64),
       "macos_x86_64" => Ok(Platform::Macos_x86_64),
       "linux_x86_64" => Ok(Platform::Linux_x86_64),
+      "linux_aarch64" => Ok(Platform::Linux_aarch64),
+      "linux_arm64" => Ok(Platform::Linux_arm64),
       other => Err(format!(
         "Unknown platform {:?} encountered in parsing",
         other

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -88,7 +88,6 @@ pub enum Platform {
   Macos_arm64,
   Linux_x86_64,
   Linux_arm64,
-  Linux_aarch64,
 }
 
 impl Platform {
@@ -143,7 +142,6 @@ impl From<Platform> for String {
     match platform {
       Platform::Linux_x86_64 => "linux_x86_64".to_string(),
       Platform::Linux_arm64 => "linux_arm64".to_string(),
-      Platform::Linux_aarch64 => "linux_aarch64".to_string(),
       Platform::Macos_arm64 => "macos_arm64".to_string(),
       Platform::Macos_x86_64 => "macos_x86_64".to_string(),
     }
@@ -157,7 +155,6 @@ impl TryFrom<String> for Platform {
       "macos_arm64" => Ok(Platform::Macos_arm64),
       "macos_x86_64" => Ok(Platform::Macos_x86_64),
       "linux_x86_64" => Ok(Platform::Linux_x86_64),
-      "linux_aarch64" => Ok(Platform::Linux_aarch64),
       "linux_arm64" => Ok(Platform::Linux_arm64),
       other => Err(format!(
         "Unknown platform {:?} encountered in parsing",


### PR DESCRIPTION
This is related to #12183. Having these changes, I was able to run Pants from sources on a repository on an aarch64 Linux machine (Nvidia Tegra).

```
$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 18.04.3 LTS
Release:        18.04
Codename:       bionic

$ uname -a
Linux machine-name 4.9.140-tegra #1 SMP PREEMPT Mon Aug 12 21:29:52 PDT 2019 aarch64 aarch64 aarch64 GNU/Linux
```

I had to mention ARM architecture to make it a "valid" architecture. Pants built fine and I am able to run it from sources on my own repository. Based on changes mentioned in https://github.com/pantsbuild/pants/issues/12183#issuecomment-1003180020.

```
$ ./pants_from_sources --local-store-files-max-size-bytes=25000000000 version
2.13.0.dev2

$ ./pants_from_sources --local-store-files-max-size-bytes=25000000000 test ::
```

After running `./pants test ::` in the Pants repository itself, there were many failing tests because certain dependencies are not available on ARM.

Now will try to build a wheel locally.

---

### Building a wheel: 

```
$ USE_PY38=true build-support/bin/release.sh build-wheels
```

### Installing a wheel:

```
$ python3.8 -m venv pantsenv
$ source pantsenv/bin/activate
$ pip install wheel pip --upgrade
$ pip install pants/dist/pantsbuild.pants-2.13.0.dev2+gitc0386feb-cp38-cp38-linux_aarch64.whl
$ which pants
/home/user/directory/pantsenv/bin/pants

$ export PANTS_LOCAL_STORE_FILES_MAX_SIZE_BYTES=25000000000
$ pants version
17:08:41.68 [INFO] Initializing scheduler...
17:08:42.09 [INFO] Scheduler initialized.
2.13.0.dev2+gitc0386feb

$ cd my-project
$ pants filter --target-type=pex_binary ::
# getting list of pex_binary in a custom repository
```