### PR TITLE
Fix `tag` filtering with `--changed-dependees`

### DIFF
--- a/src/python/pants/engine/internals/mapper.py
+++ b/src/python/pants/engine/internals/mapper.py
@@ -190,3 +190,6 @@ class SpecsFilter:
         """Check that the target matches the provided `--tag` and `--exclude-target-regexp`
         options."""
         return self._tag_filter(target) and not self._is_excluded_by_pattern(target.address)
+
+    def __bool__(self) -> bool:
+        return bool(self.tags or self.exclude_target_regexps)

--- a/src/python/pants/vcs/changed_integration_test.py
+++ b/src/python/pants/vcs/changed_integration_test.py
@@ -157,6 +157,11 @@ def test_delete_generated_target(repo: str) -> None:
     for dependees in DependeesOption:
         assert_list_stdout(repo, ["//:lib"], dependees=dependees)
 
+    # Make sure that our fix for https://github.com/pantsbuild/pants/issues/15544 does not break
+    # this test when using `--tag`.
+    for dependees in (DependeesOption.NONE, DependeesOption.TRANSITIVE):
+        assert_list_stdout(repo, ["//:lib"], dependees=dependees, extra_args=["--tag=a"])
+
     # If we also edit a sibling generated target, we should still (for now at least) include the
     # target generator.
     append_to_file(repo, "app.sh", "# foo")
@@ -207,4 +212,16 @@ def test_tag_filtering(repo: str) -> None:
         ["//app.sh:lib", "//transitive.sh:lib"],
         dependees=DependeesOption.TRANSITIVE,
         extra_args=["--tag=-b"],
+    )
+
+    # Regression test for https://github.com/pantsbuild/pants/issues/15544. Don't filter
+    # `--changed-since` roots until the very end if using `--changed-dependees`.
+    #
+    # We change `dep.sh`, which has the tag `b`. When we filter for only tag `a`, we should still
+    # find the dependees of `dep.sh`, like `app.sh`, and only then apply the filter.
+    reset_edits()
+    append_to_file(repo, "dep.sh", "# foo")
+    assert_list_stdout(repo, [], dependees=DependeesOption.NONE, extra_args=["--tag=a"])
+    assert_list_stdout(
+        repo, ["//app.sh:lib"], dependees=DependeesOption.TRANSITIVE, extra_args=["--tag=a"]
     )


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/15544.

[ci skip-rust]
[ci skip-build-wheels]