### PR TITLE
upgrade to Rust v1.61.0

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -53,7 +53,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}-v1
-        path: '~/.rustup/toolchains/1.60.0-*
+        path: '~/.rustup/toolchains/1.61.0-*
 
           ~/.rustup/update-hashes
 
@@ -205,7 +205,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}-v1
-        path: '~/.rustup/toolchains/1.60.0-*
+        path: '~/.rustup/toolchains/1.61.0-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,7 +53,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}-v1
-        path: '~/.rustup/toolchains/1.60.0-*
+        path: '~/.rustup/toolchains/1.61.0-*
 
           ~/.rustup/update-hashes
 
@@ -204,7 +204,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}-v1
-        path: '~/.rustup/toolchains/1.60.0-*
+        path: '~/.rustup/toolchains/1.61.0-*
 
           ~/.rustup/update-hashes
 
@@ -397,7 +397,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}-v1
-        path: '~/.rustup/toolchains/1.60.0-*
+        path: '~/.rustup/toolchains/1.61.0-*
 
           ~/.rustup/update-hashes
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.60.0"
+channel = "1.61.0"
 components = [
   "cargo",
   "clippy",

--- a/src/rust/engine/src/session.rs
+++ b/src/rust/engine/src/session.rs
@@ -453,7 +453,8 @@ impl Sessions {
   /// Waits at most `timeout` for Sessions to complete.
   ///
   pub async fn shutdown(&self, timeout: Duration) -> Result<(), String> {
-    if let Some(sessions) = self.sessions.lock().take() {
+    let sessions_opt = self.sessions.lock().take();
+    if let Some(sessions) = sessions_opt {
       // Collect clones of the cancellation tokens for each Session, which allows us to watch for
       // them to have been dropped.
       let (build_ids, cancellation_latches): (Vec<_>, Vec<_>) = sessions


### PR DESCRIPTION
Upgrade to Rust v1.61.0 including fixing a clippy lint. [Announcement](https://blog.rust-lang.org/2022/05/19/Rust-1.61.0.html)