### PR TITLE
Adding `new_from_merged` constructor to InputDigests

### DIFF
--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -284,8 +284,7 @@ impl InputDigests {
       merged_immutable_inputs.append(&mut immutable_inputs.clone());
       if size_before + immutable_inputs.len() != merged_immutable_inputs.len() {
         return Err(
-          "Tried to merge two-or-more immutable inputs at the same path with different values!"
-            .to_string(),
+          format!("Tried to merge two-or-more immutable inputs at the same path with different values! The collision involved one of the entries in: {immutable_inputs:?}"),
         );
       }
     }

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -283,9 +283,10 @@ impl InputDigests {
       let immutable_inputs = &input_digests.immutable_inputs;
       merged_immutable_inputs.append(&mut immutable_inputs.clone());
       if size_before + immutable_inputs.len() != merged_immutable_inputs.len() {
-        return Err(
-          format!("Tried to merge two-or-more immutable inputs at the same path with different values! The collision involved one of the entries in: {immutable_inputs:?}"),
-        );
+        return Err(format!(
+          "Tried to merge two-or-more immutable inputs at the same path with different values! \
+            The collision involved one of the entries in: {immutable_inputs:?}"
+        ));
       }
     }
 


### PR DESCRIPTION
This is some groundwork for the "Batched" process future change.

The uncached one-process-per-file requests will have their input digests merged to form the input digests of one mega-process.