### PR TITLE
Revert `tags` changes, except for the `python_tests` bug fix

### DIFF
--- a/src/python/pants/backend/codegen/export_codegen_goal.py
+++ b/src/python/pants/backend/codegen/export_codegen_goal.py
@@ -8,12 +8,12 @@ from pants.engine.fs import Digest, MergeDigests, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
 from pants.engine.target import (
-    FilteredTargets,
     GenerateSourcesRequest,
     HydratedSources,
     HydrateSourcesRequest,
     RegisteredTargetTypes,
     SourcesField,
+    Targets,
 )
 from pants.engine.unions import UnionMembership
 
@@ -35,7 +35,7 @@ class ExportCodegen(Goal):
 
 @goal_rule
 async def export_codegen(
-    targets: FilteredTargets,
+    targets: Targets,
     union_membership: UnionMembership,
     workspace: Workspace,
     dist_dir: DistDir,

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -686,7 +686,6 @@ class SkipPythonTestsField(BoolField):
 
 
 _PYTHON_TEST_MOVED_FIELDS = (
-    *COMMON_TARGET_FIELDS,
     PythonTestsDependenciesField,
     PythonResolveField,
     PythonTestsTimeoutField,
@@ -699,7 +698,12 @@ _PYTHON_TEST_MOVED_FIELDS = (
 
 class PythonTestTarget(Target):
     alias = "python_test"
-    core_fields = (*_PYTHON_TEST_MOVED_FIELDS, PythonTestsDependenciesField, PythonTestSourceField)
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        *_PYTHON_TEST_MOVED_FIELDS,
+        PythonTestsDependenciesField,
+        PythonTestSourceField,
+    )
     help = (
         "A single Python test file, written in either Pytest style or unittest style.\n\n"
         "All test util code, including `conftest.py`, should go into a dedicated `python_source` "
@@ -744,9 +748,13 @@ class PythonTestsOverrideField(OverridesField):
 
 class PythonTestsGeneratorTarget(TargetFilesGenerator):
     alias = "python_tests"
-    core_fields = (PythonTestsGeneratingSourcesField, PythonTestsOverrideField)
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        PythonTestsGeneratingSourcesField,
+        PythonTestsOverrideField,
+    )
     generated_target_cls = PythonTestTarget
-    copied_fields = ()
+    copied_fields = COMMON_TARGET_FIELDS
     moved_fields = _PYTHON_TEST_MOVED_FIELDS
     settings_request_cls = PythonFilesGeneratorSettingsRequest
     help = "Generate a `python_test` target for each file in the `sources` field."

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -686,6 +686,7 @@ class SkipPythonTestsField(BoolField):
 
 
 _PYTHON_TEST_MOVED_FIELDS = (
+    *COMMON_TARGET_FIELDS,
     PythonTestsDependenciesField,
     PythonResolveField,
     PythonTestsTimeoutField,
@@ -698,12 +699,7 @@ _PYTHON_TEST_MOVED_FIELDS = (
 
 class PythonTestTarget(Target):
     alias = "python_test"
-    core_fields = (
-        *COMMON_TARGET_FIELDS,
-        *_PYTHON_TEST_MOVED_FIELDS,
-        PythonTestsDependenciesField,
-        PythonTestSourceField,
-    )
+    core_fields = (*_PYTHON_TEST_MOVED_FIELDS, PythonTestsDependenciesField, PythonTestSourceField)
     help = (
         "A single Python test file, written in either Pytest style or unittest style.\n\n"
         "All test util code, including `conftest.py`, should go into a dedicated `python_source` "
@@ -748,13 +744,9 @@ class PythonTestsOverrideField(OverridesField):
 
 class PythonTestsGeneratorTarget(TargetFilesGenerator):
     alias = "python_tests"
-    core_fields = (
-        *COMMON_TARGET_FIELDS,
-        PythonTestsGeneratingSourcesField,
-        PythonTestsOverrideField,
-    )
+    core_fields = (PythonTestsGeneratingSourcesField, PythonTestsOverrideField)
     generated_target_cls = PythonTestTarget
-    copied_fields = COMMON_TARGET_FIELDS
+    copied_fields = ()
     moved_fields = _PYTHON_TEST_MOVED_FIELDS
     settings_request_cls = PythonFilesGeneratorSettingsRequest
     help = "Generate a `python_test` target for each file in the `sources` field."

--- a/src/python/pants/core/goals/check.py
+++ b/src/python/pants/core/goals/check.py
@@ -21,7 +21,7 @@ from pants.engine.fs import EMPTY_DIGEST, Digest, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, QueryRule, collect_rules, goal_rule
-from pants.engine.target import FilteredTargets
+from pants.engine.target import Targets
 from pants.engine.unions import UnionMembership, union
 from pants.option.option_types import StrListOption
 from pants.util.logging import LogLevel
@@ -160,7 +160,7 @@ class Check(Goal):
 async def check(
     console: Console,
     workspace: Workspace,
-    targets: FilteredTargets,
+    targets: Targets,
     dist_dir: DistDir,
     union_membership: UnionMembership,
     check_subsystem: CheckSubsystem,

--- a/src/python/pants/core/goals/export.py
+++ b/src/python/pants/core/goals/export.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Iterable, Mapping, Sequence, cast
+from typing import Iterable, Mapping, cast
 
 from pants.base.build_root import BuildRoot
 from pants.core.util_rules.distdir import DistDir
@@ -17,7 +17,7 @@ from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.internals.selectors import Effect, Get, MultiGet
 from pants.engine.process import InteractiveProcess, InteractiveProcessResult
 from pants.engine.rules import collect_rules, goal_rule
-from pants.engine.target import FilteredTargets, Target
+from pants.engine.target import Targets
 from pants.engine.unions import UnionMembership, union
 from pants.util.dirutil import safe_rmtree
 from pants.util.frozendict import FrozenDict
@@ -36,7 +36,7 @@ class ExportRequest:
     Subclass and install a member of this type to export data.
     """
 
-    targets: Sequence[Target]
+    targets: Targets
 
 
 @frozen_after_init
@@ -107,7 +107,7 @@ class Export(Goal):
 @goal_rule
 async def export(
     console: Console,
-    targets: FilteredTargets,
+    targets: Targets,
     workspace: Workspace,
     union_membership: UnionMembership,
     build_root: BuildRoot,

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -21,7 +21,7 @@ from pants.engine.fs import EMPTY_DIGEST, Digest, MergeDigests, Snapshot, Worksp
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import FallibleProcessResult, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
-from pants.engine.target import FilteredTargets, SourcesField, Targets
+from pants.engine.target import SourcesField, Targets
 from pants.engine.unions import UnionMembership, union
 from pants.option.option_types import IntOption, StrListOption
 from pants.util.collections import partition_sequentially
@@ -155,7 +155,7 @@ class Fmt(Goal):
 @goal_rule
 async def fmt(
     console: Console,
-    targets: FilteredTargets,
+    targets: Targets,
     fmt_subsystem: FmtSubsystem,
     workspace: Workspace,
     union_membership: UnionMembership,

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -22,7 +22,7 @@ from pants.engine.fs import EMPTY_DIGEST, Digest, SpecsSnapshot, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
-from pants.engine.target import FieldSet, FilteredTargets
+from pants.engine.target import FieldSet, Targets
 from pants.engine.unions import UnionMembership, union
 from pants.option.option_types import IntOption, StrListOption
 from pants.util.collections import partition_sequentially
@@ -185,7 +185,7 @@ class Lint(Goal):
 async def lint(
     console: Console,
     workspace: Workspace,
-    targets: FilteredTargets,
+    targets: Targets,
     specs_snapshot: SpecsSnapshot,
     lint_subsystem: LintSubsystem,
     union_membership: UnionMembership,

--- a/src/python/pants/core/goals/repl.py
+++ b/src/python/pants/core/goals/repl.py
@@ -6,7 +6,7 @@ import os
 from abc import ABC
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import ClassVar, Iterable, Mapping, Optional, Sequence, Tuple
+from typing import ClassVar, Iterable, Mapping, Optional, Tuple
 
 from pants.base.build_root import BuildRoot
 from pants.engine.addresses import Addresses
@@ -17,7 +17,7 @@ from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.internals.native_engine import EMPTY_DIGEST
 from pants.engine.process import InteractiveProcess, InteractiveProcessResult
 from pants.engine.rules import Effect, Get, collect_rules, goal_rule
-from pants.engine.target import FilteredTargets, Target
+from pants.engine.target import Targets
 from pants.engine.unions import UnionMembership, union
 from pants.option.global_options import GlobalOptions
 from pants.option.option_types import BoolOption, StrOption
@@ -37,7 +37,7 @@ class ReplImplementation(ABC):
 
     name: ClassVar[str]
 
-    targets: Sequence[Target]
+    targets: Targets
     chroot: str  # Absolute path of the chroot the sources will be materialized to.
 
     def in_chroot(self, relpath: str) -> str:
@@ -102,7 +102,7 @@ async def run_repl(
     console: Console,
     workspace: Workspace,
     repl_subsystem: ReplSubsystem,
-    specified_targets: FilteredTargets,
+    specified_targets: Targets,
     build_root: BuildRoot,
     union_membership: UnionMembership,
     global_options: GlobalOptions,

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -14,7 +14,7 @@ from pants.base.specs import AddressSpecs
 from pants.engine.addresses import Address, Addresses, AddressInput, BuildFileAddress
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import DigestContents, GlobMatchErrorBehavior, PathGlobs, Paths
-from pants.engine.internals.mapper import AddressFamily, AddressMap, SpecsFilter
+from pants.engine.internals.mapper import AddressFamily, AddressMap, AddressSpecsFilter
 from pants.engine.internals.parametrize import _TargetParametrizations
 from pants.engine.internals.parser import BuildFilePreludeSymbols, Parser, error_on_imports
 from pants.engine.internals.target_adaptor import TargetAdaptor
@@ -172,8 +172,8 @@ async def find_target_adaptor(address: Address) -> TargetAdaptor:
 
 
 @rule
-def setup_address_specs_filter(global_options: GlobalOptions) -> SpecsFilter:
-    return SpecsFilter(
+def setup_address_specs_filter(global_options: GlobalOptions) -> AddressSpecsFilter:
+    return AddressSpecsFilter(
         tags=global_options.tag, exclude_target_regexps=global_options.exclude_target_regexp
     )
 
@@ -182,7 +182,7 @@ def setup_address_specs_filter(global_options: GlobalOptions) -> SpecsFilter:
 async def addresses_from_address_specs(
     address_specs: AddressSpecs,
     build_file_options: BuildFileOptions,
-    specs_filter: SpecsFilter,
+    specs_filter: AddressSpecsFilter,
 ) -> Addresses:
     matched_addresses: OrderedSet[Address] = OrderedSet()
     filtering_disabled = address_specs.filter_by_global_options is False

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -39,7 +39,6 @@ from pants.engine.fs import (
     SpecsSnapshot,
 )
 from pants.engine.internals import native_engine
-from pants.engine.internals.mapper import SpecsFilter
 from pants.engine.internals.parametrize import Parametrize, _TargetParametrization
 from pants.engine.internals.parametrize import (  # noqa: F401
     _TargetParametrizations as _TargetParametrizations,
@@ -60,7 +59,6 @@ from pants.engine.target import (
     FieldSet,
     FieldSetsPerTarget,
     FieldSetsPerTargetRequest,
-    FilteredTargets,
     GeneratedSources,
     GeneratedTargets,
     GenerateSourcesRequest,
@@ -344,11 +342,6 @@ async def resolve_targets(
     return Targets(expanded_targets)
 
 
-@rule
-def filter_targets(targets: Targets, specs_filter: SpecsFilter) -> FilteredTargets:
-    return FilteredTargets(tgt for tgt in targets if specs_filter.matches(tgt))
-
-
 @rule(desc="Find all targets in the project", level=LogLevel.DEBUG)
 async def find_all_targets(_: AllTargetsRequest) -> AllTargets:
     tgts = await Get(Targets, AddressSpecs([MaybeEmptyDescendantAddresses("")]))
@@ -619,7 +612,6 @@ class OwnersRequest:
 
     sources: tuple[str, ...]
     owners_not_found_behavior: OwnersNotFoundBehavior = OwnersNotFoundBehavior.ignore
-    filter_by_global_options: bool = False
 
 
 class Owners(Collection[Address]):
@@ -642,18 +634,10 @@ async def find_owners(owners_request: OwnersRequest) -> Owners:
     # glob.
     live_candidate_specs = tuple(AscendantAddresses(directory=d) for d in live_dirs)
     deleted_candidate_specs = tuple(AscendantAddresses(directory=d) for d in deleted_dirs)
-    live_get: Get[FilteredTargets | Targets, AddressSpecs]
-    if owners_request.filter_by_global_options:
-        live_get = Get(
-            FilteredTargets, AddressSpecs(live_candidate_specs, filter_by_global_options=True)
-        )
-        deleted_get = Get(
-            UnexpandedTargets, AddressSpecs(deleted_candidate_specs, filter_by_global_options=True)
-        )
-    else:
-        live_get = Get(Targets, AddressSpecs(live_candidate_specs))
-        deleted_get = Get(UnexpandedTargets, AddressSpecs(deleted_candidate_specs))
-    live_candidate_tgts, deleted_candidate_tgts = await MultiGet(live_get, deleted_get)
+    live_candidate_tgts, deleted_candidate_tgts = await MultiGet(
+        Get(Targets, AddressSpecs(live_candidate_specs)),
+        Get(UnexpandedTargets, AddressSpecs(deleted_candidate_specs)),
+    )
 
     matching_addresses: OrderedSet[Address] = OrderedSet()
     unmatched_sources = set(owners_request.sources)
@@ -678,7 +662,7 @@ async def find_owners(owners_request: OwnersRequest) -> Owners:
             # primary ownership, but the target still should match the file. We can't use
             # `tgt.get()` because this is a mixin, and there technically may be >1 field.
             secondary_owner_fields = tuple(
-                field
+                field  # type: ignore[misc]
                 for field in candidate_tgt.field_values.values()
                 if isinstance(field, SecondaryOwnerMixin)
             )
@@ -763,8 +747,7 @@ async def addresses_from_filesystem_specs(
         for spec in filesystem_specs.file_includes
     )
     owners_per_include = await MultiGet(
-        Get(Owners, OwnersRequest(paths.files, filter_by_global_options=True))
-        for paths in paths_per_include
+        Get(Owners, OwnersRequest(sources=paths.files)) for paths in paths_per_include
     )
     addresses: set[Address] = set()
     for spec, owners in zip(filesystem_specs.file_includes, owners_per_include):
@@ -1320,7 +1303,7 @@ async def find_valid_field_sets_for_target_roots(
 ) -> TargetRootsToFieldSets:
     # NB: This must be in an `await Get`, rather than the rule signature, to avoid a rule graph
     # issue.
-    targets = await Get(FilteredTargets, Specs, specs)
+    targets = await Get(Targets, Specs, specs)
     field_sets_per_target = await Get(
         FieldSetsPerTarget, FieldSetsPerTargetRequest(request.field_set_superclass, targets)
     )

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -15,7 +15,6 @@ import pytest
 from pants.base.specs import (
     AddressLiteralSpec,
     AddressSpecs,
-    DescendantAddresses,
     FileGlobSpec,
     FileLiteralSpec,
     FilesystemSpec,
@@ -58,7 +57,6 @@ from pants.engine.target import (
     DependenciesRequest,
     ExplicitlyProvidedDependencies,
     FieldSet,
-    FilteredTargets,
     GeneratedSources,
     GenerateSourcesRequest,
     HydratedSources,
@@ -107,13 +105,7 @@ class SpecialCasedDeps2(SpecialCasedDependencies):
 
 class MockTarget(Target):
     alias = "target"
-    core_fields = (
-        MockDependencies,
-        MultipleSourcesField,
-        SpecialCasedDeps1,
-        SpecialCasedDeps2,
-        Tags,
-    )
+    core_fields = (MockDependencies, MultipleSourcesField, SpecialCasedDeps1, SpecialCasedDeps2)
     deprecated_alias = "deprecated_target"
     deprecated_alias_removal_version = "9.9.9.dev0"
 
@@ -144,7 +136,6 @@ def transitive_targets_rule_runner() -> RuleRunner:
             QueryRule(CoarsenedTargets, [Addresses]),
             QueryRule(Targets, [DependenciesRequest]),
             QueryRule(TransitiveTargets, [TransitiveTargetsRequest]),
-            QueryRule(FilteredTargets, [Specs]),
         ],
         target_types=[MockTarget, MockTargetGenerator, MockGeneratedTarget],
     )
@@ -627,66 +618,6 @@ def test_find_all_targets(transitive_targets_rule_runner: RuleRunner) -> None:
     assert {t.address for t in all_unexpanded} == {*expected, Address("", target_name="generator")}
 
 
-def test_filtered_targets(transitive_targets_rule_runner: RuleRunner) -> None:
-    transitive_targets_rule_runner.write_files(
-        {
-            "addr_specs/f1.txt": "",
-            "addr_specs/f2.txt": "",
-            "addr_specs/BUILD": dedent(
-                """\
-                generator(
-                    sources=["*.txt"],
-                    tags=["a"],
-                    overrides={"f2.txt": {"tags": ["b"]}},
-                )
-
-                target(name='t', tags=["a"])
-                """
-            ),
-            "fs_specs/f1.txt": "",
-            "fs_specs/f2.txt": "",
-            "fs_specs/BUILD": dedent(
-                """\
-                generator(
-                    sources=["*.txt"],
-                    tags=["a"],
-                    overrides={"f2.txt": {"tags": ["b"]}},
-                )
-
-                target(name='t', sources=["f1.txt"], tags=["a"])
-                """
-            ),
-        }
-    )
-    specs = Specs(
-        AddressSpecs([DescendantAddresses("addr_specs")], filter_by_global_options=True),
-        FilesystemSpecs([FileGlobSpec("fs_specs/*.txt")]),
-    )
-
-    def check(tags_option: str | None, expected: set[Address]) -> None:
-        if tags_option:
-            transitive_targets_rule_runner.set_options([f"--tag={tags_option}"])
-        result = transitive_targets_rule_runner.request(FilteredTargets, [specs])
-        assert {t.address for t in result} == expected
-
-    addr_f1 = Address("addr_specs", relative_file_path="f1.txt")
-    addr_f2 = Address("addr_specs", relative_file_path="f2.txt")
-    addr_direct = Address("addr_specs", target_name="t")
-
-    fs_f1 = Address("fs_specs", relative_file_path="f1.txt")
-    fs_f2 = Address("fs_specs", relative_file_path="f2.txt")
-    fs_direct = Address("fs_specs", target_name="t")
-
-    all_a_tags = {addr_f1, addr_direct, fs_f1, fs_direct}
-    all_b_tags = {addr_f2, fs_f2}
-
-    check(None, {*all_a_tags, *all_b_tags})
-    check("a", all_a_tags)
-    check("b", all_b_tags)
-    check("-a", all_b_tags)
-    check("-b", all_a_tags)
-
-
 def test_resolve_specs_snapshot() -> None:
     """This tests that convert filesystem specs and/or address specs into a single snapshot.
 
@@ -910,22 +841,18 @@ def test_filesystem_specs_glob(specs_rule_runner: RuleRunner) -> None:
                 """\
                 generator(name='generator', sources=['*.txt'])
                 target(name='not-generator', sources=['*.txt'])
-                target(name='skip-me', sources=['*.txt'])
-                target(name='bad-tag', sources=['*.txt'], tags=['skip'])
                 """
             ),
         }
     )
-    specs_rule_runner.set_options(["--tag=-skip", "--exclude-target-regexp=skip-me"])
-    all_unskipped_addresses = [
+    all_addresses = [
         Address("demo", target_name="not-generator"),
         Address("demo", target_name="generator", relative_file_path="f1.txt"),
         Address("demo", target_name="generator", relative_file_path="f2.txt"),
     ]
 
     assert (
-        resolve_filesystem_specs(specs_rule_runner, [FileGlobSpec("demo/*.txt")])
-        == all_unskipped_addresses
+        resolve_filesystem_specs(specs_rule_runner, [FileGlobSpec("demo/*.txt")]) == all_addresses
     )
     # We should deduplicate between glob and literal specs.
     assert (
@@ -933,7 +860,7 @@ def test_filesystem_specs_glob(specs_rule_runner: RuleRunner) -> None:
             specs_rule_runner,
             [FileGlobSpec("demo/*.txt"), FileLiteralSpec("demo/f1.txt")],
         )
-        == all_unskipped_addresses
+        == all_addresses
     )
 
 

--- a/src/python/pants/engine/internals/mapper.py
+++ b/src/python/pants/engine/internals/mapper.py
@@ -154,7 +154,7 @@ class AddressFamily:
 
 @frozen_after_init
 @dataclass(unsafe_hash=True)
-class SpecsFilter:
+class AddressSpecsFilter:
     """Filters addresses with the `--tags` and `--exclude-target-regexp` options."""
 
     tags: tuple[str, ...]

--- a/src/python/pants/engine/internals/mapper_test.py
+++ b/src/python/pants/engine/internals/mapper_test.py
@@ -12,9 +12,9 @@ from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.internals.mapper import (
     AddressFamily,
     AddressMap,
+    AddressSpecsFilter,
     DifferingFamiliesError,
     DuplicateNameError,
-    SpecsFilter,
 )
 from pants.engine.internals.parser import BuildFilePreludeSymbols, Parser
 from pants.engine.internals.target_adaptor import TargetAdaptor
@@ -130,8 +130,8 @@ def test_address_family_duplicate_names() -> None:
         )
 
 
-def test_specs_filter() -> None:
-    specs_filter = SpecsFilter(tags=["-a", "+b"], exclude_target_regexps=["skip-me"])
+def test_address_specs_filter_tags() -> None:
+    specs_filter = AddressSpecsFilter(tags=["-a", "+b"])
 
     class MockTgt(Target):
         alias = "tgt"
@@ -142,12 +142,11 @@ def test_specs_filter() -> None:
 
     untagged_tgt = make_tgt(name="untagged")
     b_tagged_tgt = make_tgt(name="b-tagged", tags=["b"])
-    b_tagged_exclude_regex_tgt = make_tgt(name="skip-me", tags=["b"])
     a_and_b_tagged_tgt = make_tgt(name="a-and-b-tagged", tags=["a", "b"])
 
     def matches(tgt: MockTgt) -> bool:
         return specs_filter.matches(tgt)
 
+    assert matches(untagged_tgt) is False
     assert matches(b_tagged_tgt) is True
-    for t in (untagged_tgt, b_tagged_exclude_regex_tgt, a_and_b_tagged_tgt):
-        assert matches(t) is False
+    assert matches(a_and_b_tagged_tgt) is False

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -652,25 +652,6 @@ class Targets(Collection[Target]):
         return self[0]
 
 
-# This distinct type is necessary because of https://github.com/pantsbuild/pants/issues/14977.
-#
-# NB: We still proactively apply filtering inside `AddressSpecs` and `FilesystemSpecs`, which is
-# earlier in the rule pipeline of `Specs -> Addresses -> UnexpandedTargets -> Targets ->
-# FilteredTargets`. That is necessary so that project-introspection goals like `list` which don't
-# use `FilteredTargets` still have filtering applied.
-class FilteredTargets(Collection[Target]):
-    """A heterogenous collection of Target instances that have been filtered with the global options
-    `--tag` and `--exclude-target-regexp`.
-
-    Outside of the extra filtering, this type is identical to `Targets`, including its handling of
-    target generators.
-    """
-
-    def expect_single(self) -> Target:
-        assert_single_address([tgt.address for tgt in self])
-        return self[0]
-
-
 class UnexpandedTargets(Collection[Target]):
     """Like `Targets`, but will not replace target generators with their generated targets (e.g.
     replace `python_sources` "BUILD targets" with generated `python_source` "file targets")."""

--- a/src/python/pants/vcs/changed.py
+++ b/src/python/pants/vcs/changed.py
@@ -39,7 +39,7 @@ class ChangedAddresses(Collection[Address]):
 
 @rule
 async def find_changed_owners(request: ChangedRequest) -> ChangedAddresses:
-    owners = await Get(Owners, OwnersRequest(request.sources, filter_by_global_options=True))
+    owners = await Get(Owners, OwnersRequest(request.sources))
     if request.dependees == DependeesOption.NONE:
         return ChangedAddresses(owners)
     dependees_with_roots = await Get(


### PR DESCRIPTION
Revert https://github.com/pantsbuild/pants/pull/15413. It did fix two bugs, but was too risky.

In particular, it resulted in https://github.com/pantsbuild/pants/issues/15544. I wasn't able to cherry-pick the fix https://github.com/pantsbuild/pants/pull/15546 because the tests have diverged too much. So instead, we should revert.

However, we keep the fix for `python_tests`, which was a 2.11-specific regression.