### PR TITLE
Add `--unmatched-cli-globs`, which before was controlled by `--owners-not-found-behavior`

### DIFF
--- a/src/python/pants/engine/internals/specs_rules_test.py
+++ b/src/python/pants/engine/internals/specs_rules_test.py
@@ -621,7 +621,7 @@ def test_specs_with_only_file_owners_nonexistent_file(rule_runner: RuleRunner) -
     with engine_error(contains='Unmatched glob from file/directory arguments: "demo/fake.txt"'):
         resolve_specs_with_only_file_owners(rule_runner, [spec])
 
-    rule_runner.set_options(["--owners-not-found-behavior=ignore"])
+    rule_runner.set_options(["--unmatched-cli-globs=ignore", "--owners-not-found-behavior=ignore"])
     assert not resolve_specs_with_only_file_owners(rule_runner, [spec])
 
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -82,6 +82,17 @@ class UnmatchedBuildFileGlobs(Enum):
         return GlobMatchErrorBehavior(self.value)
 
 
+class UnmatchedCliGlobs(Enum):
+    """What to do when globs do not match in CLI args."""
+
+    ignore = "ignore"
+    warn = "warn"
+    error = "error"
+
+    def to_glob_match_error_behavior(self) -> GlobMatchErrorBehavior:
+        return GlobMatchErrorBehavior(self.value)
+
+
 class OwnersNotFoundBehavior(Enum):
     """What to do when a file argument cannot be mapped to an owning target."""
 
@@ -1487,6 +1498,21 @@ class GlobalOptions(BootstrapOptions, Subsystem):
             """
             What to do when files and globs specified in BUILD files, such as in the
             `sources` field, cannot be found.
+
+            This usually happens when the files do not exist on your machine. It can also happen
+            if they are ignored by the `[GLOBAL].pants_ignore` option, which causes the files to be
+            invisible to Pants.
+            """
+        ),
+        advanced=True,
+    )
+    unmatched_cli_globs = EnumOption(
+        "--unmatched-cli-globs",
+        default=UnmatchedCliGlobs.error,
+        help=softwrap(
+            """
+            What to do when command line arguments, e.g. files and globs like `dir::`, cannot be
+            found.
 
             This usually happens when the files do not exist on your machine. It can also happen
             if they are ignored by the `[GLOBAL].pants_ignore` option, which causes the files to be


### PR DESCRIPTION
Right now, `--owners-not-found-behavior` controls whether we error or not on unmatched file arguments, like `./pants test spot_the_typoo.py`. But we need to get rid of that option (https://github.com/pantsbuild/pants/issues/15529) as it blocks target-less goals like `count-loc` from properly working with file arguments. We have a bad coupling.

The fix is to add an option `--unmatched-cli-globs`. The name mirrors `--unmatched-build-file-globs` from https://github.com/pantsbuild/pants/pull/15555.

This option is not yet fully wired up—it only works for `FileLiteralSpec` and `FileGlobSpec`, but not yet `DirGlobSpec` (`dir:`) and `RecursiveGlobSpec` (`dir::`). That will happen in a followup.

[ci skip-rust]
[ci skip-build-wheels]