### PR TITLE
Deprecate `--owners-not-found-behavior` and set default to `ignore`

### DIFF
--- a/src/python/pants/engine/internals/specs_rules_test.py
+++ b/src/python/pants/engine/internals/specs_rules_test.py
@@ -621,11 +621,12 @@ def test_specs_with_only_file_owners_nonexistent_file(rule_runner: RuleRunner) -
     with engine_error(contains='Unmatched glob from file/directory arguments: "demo/fake.txt"'):
         resolve_specs_with_only_file_owners(rule_runner, [spec])
 
-    rule_runner.set_options(["--unmatched-cli-globs=ignore", "--owners-not-found-behavior=ignore"])
+    rule_runner.set_options(["--unmatched-cli-globs=ignore"])
     assert not resolve_specs_with_only_file_owners(rule_runner, [spec])
 
 
 def test_specs_with_only_file_owners_no_owner(rule_runner: RuleRunner) -> None:
+    rule_runner.set_options(["--owners-not-found-behavior=error"])
     rule_runner.write_files({"no_owners/f.txt": ""})
     # Error for literal specs.
     with pytest.raises(ExecutionError) as exc:

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1524,7 +1524,7 @@ class GlobalOptions(BootstrapOptions, Subsystem):
 
     owners_not_found_behavior = EnumOption(
         "--owners-not-found-behavior",
-        default=OwnersNotFoundBehavior.error,
+        default=OwnersNotFoundBehavior.ignore,
         help=softwrap(
             """
             What to do when file arguments do not have any owning target. This happens when
@@ -1532,6 +1532,17 @@ class GlobalOptions(BootstrapOptions, Subsystem):
             """
         ),
         advanced=True,
+        removal_version="2.14.0.dev0",
+        removal_hint=softwrap(
+            """
+            This option is no longer useful with Pants because we have goals that work without any
+            targets, e.g. the `count-loc` goal or the `regex-lint` linter from the `lint` goal. This
+            option caused us to error on valid use cases.
+
+            For goals that require targets, like `list`, the unowned file will simply be ignored. If
+            no owners are found at all, most goals will warn and some like `run` will error.
+            """
+        ),
     )
 
     build_patterns = StrListOption(


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/15529. `./pants count-loc` now works on file arguments, even on a brand new repository!

Technically, changing the default value is breaking our deprecation policy. I believe the old behavior was broken enough that this is justified.