### PR TITLE
`run_pants()` no longer sets a custom `--pants-workdir` for tests 

### DIFF
--- a/src/python/pants/base/exception_sink_integration_test.py
+++ b/src/python/pants/base/exception_sink_integration_test.py
@@ -12,7 +12,7 @@ import pytest
 
 from pants.base.build_environment import get_buildroot
 from pants.base.exception_sink import ExceptionSink
-from pants.testutil.pants_integration_test import run_pants_with_workdir
+from pants.testutil.pants_integration_test import run_pants
 from pants.util.dirutil import read_file
 from pants_test.pantsd.pantsd_integration_test_base import PantsDaemonIntegrationTestBase
 
@@ -76,7 +76,7 @@ Signal {signum} \\({signame}\\) was raised\\. Exiting with failure\\.
 
 
 def test_logs_unhandled_exception(tmp_path: Path) -> None:
-    pants_run = run_pants_with_workdir(
+    pants_run = run_pants(
         # The backtrace should be omitted when --print-stacktrace=False.
         [*lifecycle_stub_cmdline(), "--no-print-stacktrace"],
         workdir=tmp_path.as_posix(),

--- a/src/python/pants/core/goals/run_integration_test.py
+++ b/src/python/pants/core/goals/run_integration_test.py
@@ -7,7 +7,7 @@ from textwrap import dedent
 
 from pants.testutil.pants_integration_test import (
     ensure_daemon,
-    run_pants_with_workdir_without_waiting,
+    run_pants_without_waiting,
     temporary_workdir,
 )
 
@@ -38,7 +38,7 @@ def test_run_then_edit(use_pantsd: bool) -> None:
         Path(name).write_text(content)
 
     with temporary_workdir() as workdir:
-        client_handle = run_pants_with_workdir_without_waiting(
+        client_handle = run_pants_without_waiting(
             [
                 "--backend-packages=['pants.backend.python']",
                 "run",

--- a/src/python/pants/option/options_integration_test.py
+++ b/src/python/pants/option/options_integration_test.py
@@ -9,7 +9,6 @@ from pants.fs.fs import safe_filename_from_path
 from pants.testutil.pants_integration_test import (
     ensure_daemon,
     run_pants,
-    run_pants_with_workdir,
     setup_tmpdir,
 )
 
@@ -104,7 +103,7 @@ def test_pants_symlink_workdirs(tmp_path: Path) -> None:
     physical_workdir_base = tmp_path / "workdirs"
     physical_workdir = physical_workdir_base / safe_filename_from_path(symlink_workdir.as_posix())
 
-    pants_run = run_pants_with_workdir(
+    pants_run = run_pants(
         [f"--pants-physical-workdir-base={physical_workdir_base.as_posix()}", "help"],
         workdir=symlink_workdir.as_posix(),
     )

--- a/src/python/pants/option/options_integration_test.py
+++ b/src/python/pants/option/options_integration_test.py
@@ -6,11 +6,7 @@ from pathlib import Path
 from textwrap import dedent
 
 from pants.fs.fs import safe_filename_from_path
-from pants.testutil.pants_integration_test import (
-    ensure_daemon,
-    run_pants,
-    setup_tmpdir,
-)
+from pants.testutil.pants_integration_test import ensure_daemon, run_pants, setup_tmpdir
 
 
 def test_invalid_options() -> None:

--- a/src/python/pants/testutil/pants_integration_test.py
+++ b/src/python/pants/testutil/pants_integration_test.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 from contextlib import contextmanager
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Iterator, List, Mapping, Union
 
 import pytest
@@ -19,7 +20,7 @@ from pants.option.config import TomlSerializer
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.pantsd.pants_daemon_client import PantsDaemonClient
 from pants.util.contextutil import temporary_dir
-from pants.util.dirutil import fast_relpath, safe_file_dump, safe_mkdir, safe_open
+from pants.util.dirutil import fast_relpath, safe_file_dump, safe_mkdir
 from pants.util.osutil import Pid
 from pants.util.strutil import ensure_binary
 
@@ -105,7 +106,7 @@ def run_pants_without_waiting(
 
     if config:
         toml_file_name = "pants.test_config.toml"
-        with safe_open(toml_file_name, mode="w") as fp:
+        with Path(toml_file_name).open("w") as fp:
             fp.write(TomlSerializer(config).serialize())
         args.append(f"--pants-config-files={toml_file_name}")
 

--- a/src/python/pants/testutil/pants_integration_test.py
+++ b/src/python/pants/testutil/pants_integration_test.py
@@ -33,7 +33,6 @@ class PantsResult:
     exit_code: int
     stdout: str
     stderr: str
-    workdir: str
     pid: Pid
 
     def _format_unexpected_error_code_msg(self, msg: str | None) -> str:
@@ -75,7 +74,6 @@ class PantsJoinHandle:
             exit_code=self.process.returncode,
             stdout=stdout.decode(),
             stderr=stderr.decode(),
-            workdir=self.workdir,
             pid=self.process.pid,
         )
 

--- a/src/python/pants/vcs/changed_integration_test.py
+++ b/src/python/pants/vcs/changed_integration_test.py
@@ -11,7 +11,7 @@ from typing import Iterator
 import pytest
 
 from pants.base.build_environment import get_buildroot
-from pants.testutil.pants_integration_test import run_pants_with_workdir
+from pants.testutil.pants_integration_test import run_pants
 from pants.util.contextutil import environment_as, temporary_dir
 from pants.vcs.changed import DependeesOption
 
@@ -102,7 +102,7 @@ def assert_list_stdout(
     *,
     extra_args: list[str] | None = None,
 ) -> None:
-    result = run_pants_with_workdir(
+    result = run_pants(
         [
             *(extra_args or ()),
             "--changed-since=HEAD",

--- a/src/python/pants/vcs/changed_integration_test.py
+++ b/src/python/pants/vcs/changed_integration_test.py
@@ -10,31 +10,31 @@ from typing import Iterator
 
 import pytest
 
-from pants.base.build_environment import get_buildroot
 from pants.testutil.pants_integration_test import run_pants
-from pants.util.contextutil import environment_as, temporary_dir
+from pants.util.contextutil import environment_as
 from pants.vcs.changed import DependeesOption
 
 
 def _run_git(command: list[str]) -> None:
-    subprocess.run(
-        ["git", *command], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
-    )
+    subprocess.run(["git", *command], check=True)
 
 
-@pytest.fixture
-def repo() -> Iterator[str]:
-    with temporary_dir(root_dir=get_buildroot()) as worktree, environment_as(
-        GIT_CONFIG_GLOBAL="/dev/null"
-    ):
+@pytest.fixture(autouse=True)
+def init_repo() -> Iterator[None]:
+    with environment_as(GIT_CONFIG_GLOBAL="/dev/null"):
+        if Path(".git").exists():
+            reset_edits()
+            yield
+            return
+
         _run_git(["init"])
         _run_git(["config", "user.email", "you@example.com"])
         _run_git(["config", "user.name", "Your Name"])
 
         project = {
             ".gitignore": dedent(
-                f"""\
-                {worktree}
+                """\
+                .pants.d
                 .pids
                 """
             ),
@@ -72,8 +72,8 @@ def repo() -> Iterator[str]:
             create_file(fp, content)
 
         _run_git(["add", "."])
-        _run_git(["commit", "-m", "blah"])
-        yield worktree
+        _run_git(["commit", "-m", "init repo"])
+        yield
 
 
 def create_file(fp: str, content: str) -> None:
@@ -96,7 +96,6 @@ def reset_edits() -> None:
 
 
 def assert_list_stdout(
-    workdir: str,
     expected: list[str],
     dependees: DependeesOption = DependeesOption.NONE,
     *,
@@ -109,7 +108,6 @@ def assert_list_stdout(
             f"--changed-dependees={dependees.value}",
             "list",
         ],
-        workdir=workdir,
         # We must set `hermetic=False` for some reason.
         hermetic=False,
     )
@@ -117,35 +115,32 @@ def assert_list_stdout(
     assert sorted(result.stdout.strip().splitlines()) == sorted(expected)
 
 
-def test_no_changes(repo: str) -> None:
-    assert_list_stdout(repo, [])
+def test_no_changes() -> None:
+    assert_list_stdout([])
 
 
-def test_change_no_deps(repo: str) -> None:
+def test_change_no_deps() -> None:
     append_to_file("standalone.sh", "# foo")
     for dependees in DependeesOption:
-        assert_list_stdout(repo, ["//:standalone"], dependees=dependees)
+        assert_list_stdout(["//:standalone"], dependees=dependees)
 
 
-def test_change_transitive_dep(repo: str) -> None:
+def test_change_transitive_dep() -> None:
     append_to_file("transitive.sh", "# foo")
-    assert_list_stdout(repo, ["//transitive.sh:lib"])
+    assert_list_stdout(["//transitive.sh:lib"])
+    assert_list_stdout(["//dep.sh:lib", "//transitive.sh:lib"], dependees=DependeesOption.DIRECT)
     assert_list_stdout(
-        repo, ["//dep.sh:lib", "//transitive.sh:lib"], dependees=DependeesOption.DIRECT
-    )
-    assert_list_stdout(
-        repo,
         ["//app.sh:lib", "//dep.sh:lib", "//transitive.sh:lib"],
         dependees=DependeesOption.TRANSITIVE,
     )
 
 
-def test_unowned_file(repo: str) -> None:
+def test_unowned_file() -> None:
     create_file("dir/some_file.ext", "")
-    assert_list_stdout(repo, [])
+    assert_list_stdout([])
 
 
-def test_delete_generated_target(repo: str) -> None:
+def test_delete_generated_target() -> None:
     """If a generated target is deleted, we claim the target generator was modified.
 
     It's unlikely these are actually the semantics we want...See:
@@ -154,26 +149,26 @@ def test_delete_generated_target(repo: str) -> None:
     """
     delete_file("transitive.sh")
     for dependees in DependeesOption:
-        assert_list_stdout(repo, ["//:lib"], dependees=dependees)
+        assert_list_stdout(["//:lib"], dependees=dependees)
 
     # Make sure that our fix for https://github.com/pantsbuild/pants/issues/15544 does not break
     # this test when using `--tag`.
     for dependees in (DependeesOption.NONE, DependeesOption.TRANSITIVE):
-        assert_list_stdout(repo, ["//:lib"], dependees=dependees, extra_args=["--tag=a"])
+        assert_list_stdout(["//:lib"], dependees=dependees, extra_args=["--tag=a"])
 
     # If we also edit a sibling generated target, we should still (for now at least) include the
     # target generator.
     append_to_file("app.sh", "# foo")
     for dependees in DependeesOption:
-        assert_list_stdout(repo, ["//:lib", "//app.sh:lib"], dependees=dependees)
+        assert_list_stdout(["//:lib", "//app.sh:lib"], dependees=dependees)
 
 
-def test_delete_atom_target(repo: str) -> None:
+def test_delete_atom_target() -> None:
     delete_file("standalone.sh")
-    assert_list_stdout(repo, ["//:standalone"])
+    assert_list_stdout(["//:standalone"])
 
 
-def test_change_build_file(repo: str) -> None:
+def test_change_build_file() -> None:
     """Every target in a BUILD file is changed when it's edited.
 
     This is because we don't know what the target was like before-hand, so we're overly
@@ -181,25 +176,23 @@ def test_change_build_file(repo: str) -> None:
     """
     append_to_file("BUILD", "# foo")
     # Note that the target generator `//:lib` does not show up.
-    assert_list_stdout(
-        repo, ["//app.sh:lib", "//dep.sh:lib", "//transitive.sh:lib", "//:standalone"]
-    )
+    assert_list_stdout(["//app.sh:lib", "//dep.sh:lib", "//transitive.sh:lib", "//:standalone"])
 
 
-def test_different_build_file_changed(repo: str) -> None:
+def test_different_build_file_changed() -> None:
     """Only invalidate if the BUILD file where a target is defined has changed, even if the changed
     BUILD file is in the same directory."""
     create_file("BUILD.other", "")
-    assert_list_stdout(repo, [])
+    assert_list_stdout([])
 
 
-def test_tag_filtering(repo: str) -> None:
+def test_tag_filtering() -> None:
     append_to_file("dep.sh", "# foo")
     append_to_file("standalone.sh", "# foo")
-    assert_list_stdout(repo, ["//dep.sh:lib"], extra_args=["--tag=+b"])
-    assert_list_stdout(repo, ["//:standalone"], extra_args=["--tag=-b"])
+    assert_list_stdout(["//dep.sh:lib"], extra_args=["--tag=+b"])
+    assert_list_stdout(["//:standalone"], extra_args=["--tag=-b"])
     assert_list_stdout(
-        repo, ["//dep.sh:lib"], dependees=DependeesOption.TRANSITIVE, extra_args=["--tag=+b"]
+        ["//dep.sh:lib"], dependees=DependeesOption.TRANSITIVE, extra_args=["--tag=+b"]
     )
 
     # Regression test for https://github.com/pantsbuild/pants/issues/14977: make sure a generated
@@ -207,7 +200,6 @@ def test_tag_filtering(repo: str) -> None:
     reset_edits()
     append_to_file("transitive.sh", "# foo")
     assert_list_stdout(
-        repo,
         ["//app.sh:lib", "//transitive.sh:lib"],
         dependees=DependeesOption.TRANSITIVE,
         extra_args=["--tag=-b"],
@@ -220,7 +212,7 @@ def test_tag_filtering(repo: str) -> None:
     # find the dependees of `dep.sh`, like `app.sh`, and only then apply the filter.
     reset_edits()
     append_to_file("dep.sh", "# foo")
-    assert_list_stdout(repo, [], dependees=DependeesOption.NONE, extra_args=["--tag=a"])
+    assert_list_stdout([], dependees=DependeesOption.NONE, extra_args=["--tag=a"])
     assert_list_stdout(
-        repo, ["//app.sh:lib"], dependees=DependeesOption.TRANSITIVE, extra_args=["--tag=a"]
+        ["//app.sh:lib"], dependees=DependeesOption.TRANSITIVE, extra_args=["--tag=a"]
     )

--- a/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
@@ -20,8 +20,7 @@ from pants.testutil.pants_integration_test import (
     kill_daemon,
     read_pants_log,
     run_pants,
-    run_pants_with_workdir,
-    run_pants_with_workdir_without_waiting,
+    run_pants_without_waiting,
 )
 from pants.util.collections import recursively_update
 from pants.util.contextutil import temporary_dir
@@ -76,7 +75,7 @@ def launch_waiter(
         child_pid_file,
         str(cleanup_wait_time),
     ]
-    client_handle = run_pants_with_workdir_without_waiting(argv, workdir=workdir, config=config)
+    client_handle = run_pants_without_waiting(argv, workdir=workdir, config=config)
     waiter_pid = -1
     for _ in attempts("The waiter process should have written its pid."):
         waiter_pid_str = maybe_read_file(waiter_pid_file)
@@ -152,17 +151,17 @@ class PantsDaemonIntegrationTestBase(unittest.TestCase):
     @staticmethod
     def run_pants(*args, **kwargs) -> PantsResult:
         # We set our own ad-hoc pantsd configuration in most of these tests.
-        return run_pants(*args, **{**kwargs, **{"use_pantsd": False}})
+        return run_pants(*args, **{**kwargs, "use_pantsd": False})
 
     @staticmethod
     def run_pants_with_workdir(*args, **kwargs) -> PantsResult:
         # We set our own ad-hoc pantsd configuration in most of these tests.
-        return run_pants_with_workdir(*args, **{**kwargs, **{"use_pantsd": False}})
+        return run_pants(*args, **{**kwargs, "use_pantsd": False})
 
     @staticmethod
     def run_pants_with_workdir_without_waiting(*args, **kwargs) -> PantsJoinHandle:
         # We set our own ad-hoc pantsd configuration in most of these tests.
-        return run_pants_with_workdir_without_waiting(*args, **{**kwargs, **{"use_pantsd": False}})
+        return run_pants_without_waiting(*args, **{**kwargs, "use_pantsd": False})
 
     @contextmanager
     def pantsd_test_context(

--- a/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
@@ -151,17 +151,17 @@ class PantsDaemonIntegrationTestBase(unittest.TestCase):
     @staticmethod
     def run_pants(*args, **kwargs) -> PantsResult:
         # We set our own ad-hoc pantsd configuration in most of these tests.
-        return run_pants(*args, **{**kwargs, "use_pantsd": False})
+        return run_pants(*args, **{**kwargs, "use_pantsd": False})  # type: ignore
 
     @staticmethod
     def run_pants_with_workdir(*args, **kwargs) -> PantsResult:
         # We set our own ad-hoc pantsd configuration in most of these tests.
-        return run_pants(*args, **{**kwargs, "use_pantsd": False})
+        return run_pants(*args, **{**kwargs, "use_pantsd": False})  # type: ignore
 
     @staticmethod
     def run_pants_with_workdir_without_waiting(*args, **kwargs) -> PantsJoinHandle:
         # We set our own ad-hoc pantsd configuration in most of these tests.
-        return run_pants_without_waiting(*args, **{**kwargs, "use_pantsd": False})
+        return run_pants_without_waiting(*args, **{**kwargs, "use_pantsd": False})  # type: ignore
 
     @contextmanager
     def pantsd_test_context(


### PR DESCRIPTION
I don't think it was necessary to set a custom `--pants-workdir` - we can simply use the default of `.pants.d`.

This allows us to merge `run_pants_with_workdir` into `run_pants`, and to rename `run_pants_with_workdir_without_waiting` into `run_pants_without_waiting`.

For this to land, we must be careful to purge Pantsd and the `.pants.d` folders across individual tests. I suspect this was not an issue before because `--pants-workdir` is marked `daemon=True` and we were changing the workdir every time. This is more obvious now.