### PR TITLE
Ignore `__pycache__` by default with `--pants-ignore`

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -750,7 +750,7 @@ class BootstrapOptions:
     pants_ignore = StrListOption(
         "--pants-ignore",
         advanced=True,
-        default=[".*/", _default_rel_distdir],
+        default=[".*/", _default_rel_distdir, "__pycache__"],
         help=softwrap(
             """
             Paths to ignore for all filesystem operations performed by pants


### PR DESCRIPTION
I noticed while iterating on our `run_pants` integration tests that `pants_ignore` does not include `__pycache__` by default. This causes our tests to invalidate the file watcher more than necessary, as the tests end up compiling all of Pants's `.py` files.

It seems very likely users will have already set `__pycache__` in their `.gitignore`, but it does not hurt to include here.

[ci skip-rust]
[ci skip-build-wheels]