### PR TITLE
Fix non-deterministic order of `jvm_artifact(.., excludes=..)` (Cherry-pick of #15542)

### DIFF
--- a/src/python/pants/jvm/resolve/common.py
+++ b/src/python/pants/jvm/resolve/common.py
@@ -197,7 +197,7 @@ class ArtifactRequirement:
             "jar": self.jar.address.spec if self.jar else "not_provided",
         }
         if self.excludes:
-            attrs["excludes"] = ",".join(self.excludes)
+            attrs["excludes"] = ",".join(sorted(self.excludes))
 
         return self.coordinate.to_coord_arg_str(attrs)
 


### PR DESCRIPTION
This solves pants randomly requires to generate lockfiles because of `jvm_artifact` with multiple excludes.