### PR TITLE
`dir:` and `dir::` work on target-less goals like `count-loc`

### DIFF
--- a/src/python/pants/backend/project_info/regex_lint.py
+++ b/src/python/pants/backend/project_info/regex_lint.py
@@ -80,9 +80,7 @@ class RegexLintSubsystem(Subsystem):
 
         To activate this with the `lint` goal, you must set `[regex-lint].config`.
 
-        Unlike other linters, this can run on files not owned by targets, such as BUILD files. To
-        run on those, use `lint '**'` rather than `lint ::`, for example. We are exploring how to
-        improve this gotchas.
+        Unlike other linters, this can run on files not owned by targets, such as BUILD files.
         """
     )
 

--- a/src/python/pants/base/specs_test.py
+++ b/src/python/pants/base/specs_test.py
@@ -26,6 +26,7 @@ def assert_build_file_globs(
 
 def test_dir_glob() -> None:
     spec = DirGlobSpec("dir/subdir")
+    assert spec.to_glob() == "dir/subdir/*"
     assert spec.matches_target("") is False
     assert spec.matches_target("dir") is False
     assert spec.matches_target("dir/subdir") is True
@@ -38,6 +39,7 @@ def test_dir_glob() -> None:
     )
 
     spec = DirGlobSpec("")
+    assert spec.to_glob() == "*"
     assert spec.matches_target("") is True
     assert spec.matches_target("dir") is False
     assert_build_file_globs(
@@ -49,6 +51,7 @@ def test_dir_glob() -> None:
 
 def test_recursive_glob() -> None:
     spec = RecursiveGlobSpec("dir/subdir")
+    assert spec.to_glob() == "dir/subdir/**"
     assert spec.matches_target("") is False
     assert spec.matches_target("dir") is False
     assert spec.matches_target("dir/subdir") is True
@@ -62,6 +65,7 @@ def test_recursive_glob() -> None:
     )
 
     spec = RecursiveGlobSpec("")
+    assert spec.to_glob() == "**"
     assert spec.matches_target("") is True
     assert spec.matches_target("dir") is True
     assert spec.matches_target("another_dir") is True

--- a/src/python/pants/engine/internals/specs_rules.py
+++ b/src/python/pants/engine/internals/specs_rules.py
@@ -256,9 +256,9 @@ async def resolve_specs_snapshot(specs: Specs) -> SpecsSnapshot:
 
     digests = [hydrated_sources.snapshot.digest for hydrated_sources in all_hydrated_sources]
 
-    with_files_owners = SpecsWithOnlyFileOwners.from_specs(specs)
+    specs_snapshot_path_globs = specs.to_specs_snapshot_path_globs()
     filtered_out_sources_paths: set[str] = set()
-    if with_files_owners:
+    if specs_snapshot_path_globs.globs:
         filtered_out_targets = FrozenOrderedSet(unfiltered_targets).difference(
             FrozenOrderedSet(filtered_targets)
         )
@@ -271,11 +271,7 @@ async def resolve_specs_snapshot(specs: Specs) -> SpecsSnapshot:
             itertools.chain.from_iterable(paths.files for paths in all_sources_paths)
         )
 
-        target_less_digest = await Get(
-            Digest,
-            PathGlobs,
-            with_files_owners.to_path_globs(),
-        )
+        target_less_digest = await Get(Digest, PathGlobs, specs_snapshot_path_globs)
         digests.append(target_less_digest)
 
     if filtered_out_sources_paths:


### PR DESCRIPTION
`./pants count-loc ::` now works even if you have no BUILD files yet.

This completes most of the proposal at https://docs.google.com/document/d/1WWQM-X6kHoSCKwItqf61NiKFWNSlpnTC5QNu3ul9RDk/edit. Remaining tasks:

* Change `DirLiteralSpec` to match directories, not be shorthand for the target `dir:dir`
* Fix `tailor` and `update-build-files` to use these new specs, https://github.com/pantsbuild/pants/issues/15563
* Consider adding ignore specs, https://github.com/pantsbuild/pants/issues/15539
* Audit that every goal warns you when no targets/files matched.

[ci skip-rust]
[ci skip-build-wheels]