### PR TITLE
`lint` only finds targets and files if the relevant linters were specified

### DIFF
--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -11,6 +11,7 @@ from typing import Iterable, Optional, Sequence, Tuple, Type
 
 import pytest
 
+from pants.base.specs import Specs
 from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.core.goals.lint import (
     AmbiguousRequestNamesError,
@@ -27,7 +28,7 @@ from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import SpecsSnapshot, Workspace
 from pants.engine.internals.native_engine import EMPTY_DIGEST, EMPTY_SNAPSHOT, Digest, Snapshot
-from pants.engine.target import FieldSet, MultipleSourcesField, Target, Targets
+from pants.engine.target import FieldSet, FilteredTargets, MultipleSourcesField, Target
 from pants.engine.unions import UnionMembership
 from pants.testutil.option_util import create_goal_subsystem
 from pants.testutil.rule_runner import MockGet, RuleRunner, mock_console, run_rule_with_mocks
@@ -177,15 +178,13 @@ def run_lint_rule(
         only=only or [],
         skip_formatters=skip_formatters,
     )
-    specs_snapshot = SpecsSnapshot(rule_runner.make_snapshot_of_empty_files(["f.txt"]))
     with mock_console(rule_runner.options_bootstrapper) as (console, stdio_reader):
         result: Lint = run_rule_with_mocks(
             lint,
             rule_args=[
                 console,
                 Workspace(rule_runner.scheduler, _enforce_effects=False),
-                Targets(targets),
-                specs_snapshot,
+                Specs(),
                 lint_subsystem,
                 union_membership,
                 DistDir(relpath=Path("dist")),
@@ -210,6 +209,18 @@ def run_lint_rule(
                     output_type=FmtResult,
                     input_type=FmtRequest,
                     mock=lambda mock_request: mock_request.fmt_result,
+                ),
+                MockGet(
+                    output_type=FilteredTargets,
+                    input_type=Specs,
+                    mock=lambda _: FilteredTargets(targets),
+                ),
+                MockGet(
+                    output_type=SpecsSnapshot,
+                    input_type=Specs,
+                    mock=lambda _: SpecsSnapshot(
+                        rule_runner.make_snapshot_of_empty_files(["f.txt"])
+                    ),
                 ),
             ],
             union_membership=union_membership,


### PR DESCRIPTION
Before:

```
❯ hyperfine -w 1 -r 5 './pants --no-pantsd lint --only=docformatter ::'
Benchmark 1: ./pants --no-pantsd lint --only=docformatter ::
  Time (mean ± σ):      6.907 s ±  0.651 s    [User: 5.204 s, System: 0.876 s]
  Range (min … max):    6.299 s …  7.950 s    5 runs
```

After:

```
❯ hyperfine -w 1 -r 5 './pants --no-pantsd lint --only=docformatter ::'
Benchmark 1: ./pants --no-pantsd lint --only=docformatter ::
  Time (mean ± σ):      6.478 s ±  0.111 s    [User: 4.995 s, System: 0.779 s]
  Range (min … max):    6.369 s …  6.666 s    5 runs
```

[ci skip-rust]
[ci skip-build-wheels]