### PR TITLE
`regex-lint` only reads files that will be checked

### DIFF
--- a/src/python/pants/backend/project_info/regex_lint_test.py
+++ b/src/python/pants/backend/project_info/regex_lint_test.py
@@ -116,13 +116,9 @@ class TestMultiMatcherTest:
             .lstrip()
             .encode("utf8")
         )
-        assert (("python_header",), ("no_six",)) == matcher.check_content(
-            ("python_header", "no_six"), py_file_content, "utf8"
+        assert RegexMatchResult("f.py", ("python_header",), ("no_six",)) == matcher.check_content(
+            "f.py", py_file_content, ("python_header", "no_six"), "utf8"
         )
-
-        assert RegexMatchResult(
-            "foo/bar/baz.py", ("python_header",), ("no_six",)
-        ) == matcher.check_source_file("foo/bar/baz.py", py_file_content)
 
     def test_multiple_encodings_error(self, matcher: MultiMatcher) -> None:
         with pytest.raises(


### PR DESCRIPTION
It's a waste of resources/memory to use `DigestContents` on files that won't even be matched. Once we merge https://github.com/pantsbuild/pants/pull/15577, it would mean that we materialize the entire repository into `DigestContents` with `./pants lint ::`!

This will pair particularly nicely with https://github.com/pantsbuild/pants/issues/15578, which means we won't even digest files that get ignored.

--

Both benchmarks have https://github.com/pantsbuild/pants/pull/15577 applied.

Before:

```
❯ hyperfine -w 1 -r 5 './pants --no-pantsd lint --only=regex-lint ::'
Benchmark 1: ./pants --no-pantsd lint --only=regex-lint ::
  Time (mean ± σ):      5.447 s ±  0.130 s    [User: 4.230 s, System: 0.580 s]
  Range (min … max):    5.294 s …  5.589 s    5 runs
```

After:

```
❯ hyperfine -w 1 -r 5 './pants --no-pantsd lint --only=regex-lint ::'
Benchmark 1: ./pants --no-pantsd lint --only=regex-lint ::
  Time (mean ± σ):      5.300 s ±  0.102 s    [User: 4.189 s, System: 0.549 s]
  Range (min … max):    5.176 s …  5.438 s    5 runs
```