### PR TITLE
`update-build-files` now takes CLI args for which BUILD files to change

### DIFF
--- a/src/python/pants/core/goals/update_build_files_test.py
+++ b/src/python/pants/core/goals/update_build_files_test.py
@@ -80,7 +80,7 @@ def generic_goal_rule_runner() -> RuleRunner:
 def test_goal_rewrite_mode(generic_goal_rule_runner: RuleRunner) -> None:
     """Checks that we correctly write the changes and pipe fixers to each other."""
     generic_goal_rule_runner.write_files({"BUILD": "line\n", "dir/BUILD": "line 1\nline 2\n"})
-    result = generic_goal_rule_runner.run_goal_rule(UpdateBuildFilesGoal)
+    result = generic_goal_rule_runner.run_goal_rule(UpdateBuildFilesGoal, args=["::"])
     assert result.exit_code == 0
     assert result.stdout == dedent(
         """\
@@ -103,7 +103,9 @@ def test_goal_check_mode(generic_goal_rule_runner: RuleRunner) -> None:
     """Checks that we correctly set the exit code and pipe fixers to each other."""
     generic_goal_rule_runner.write_files({"BUILD": "line\n", "dir/BUILD": "line 1\nline 2\n"})
     result = generic_goal_rule_runner.run_goal_rule(
-        UpdateBuildFilesGoal, global_args=["--pants-bin-name=./custom_pants"], args=["--check"]
+        UpdateBuildFilesGoal,
+        global_args=["--pants-bin-name=./custom_pants"],
+        args=["--check", "::"],
     )
     assert result.exit_code == 1
     assert result.stdout == dedent(
@@ -147,7 +149,9 @@ def black_rule_runner() -> RuleRunner:
 
 def test_black_fixer_fixes(black_rule_runner: RuleRunner) -> None:
     black_rule_runner.write_files({"BUILD": "tgt( name =  't' )"})
-    result = black_rule_runner.run_goal_rule(UpdateBuildFilesGoal, env_inherit=BLACK_ENV_INHERIT)
+    result = black_rule_runner.run_goal_rule(
+        UpdateBuildFilesGoal, args=["::"], env_inherit=BLACK_ENV_INHERIT
+    )
     assert result.exit_code == 0
     assert result.stdout == dedent(
         """\
@@ -160,7 +164,9 @@ def test_black_fixer_fixes(black_rule_runner: RuleRunner) -> None:
 
 def test_black_fixer_noops(black_rule_runner: RuleRunner) -> None:
     black_rule_runner.write_files({"BUILD": 'tgt(name="t")\n'})
-    result = black_rule_runner.run_goal_rule(UpdateBuildFilesGoal, env_inherit=BLACK_ENV_INHERIT)
+    result = black_rule_runner.run_goal_rule(
+        UpdateBuildFilesGoal, args=["::"], env_inherit=BLACK_ENV_INHERIT
+    )
     assert result.exit_code == 0
     assert Path(black_rule_runner.build_root, "BUILD").read_text() == 'tgt(name="t")\n'
 
@@ -170,6 +176,7 @@ def test_black_fixer_args(black_rule_runner: RuleRunner) -> None:
     result = black_rule_runner.run_goal_rule(
         UpdateBuildFilesGoal,
         global_args=["--black-args='--skip-string-normalization'"],
+        args=["::"],
         env_inherit=BLACK_ENV_INHERIT,
     )
     assert result.exit_code == 0
@@ -183,7 +190,9 @@ def test_black_config(black_rule_runner: RuleRunner) -> None:
             "BUILD": "tgt(name='t')\n",
         },
     )
-    result = black_rule_runner.run_goal_rule(UpdateBuildFilesGoal, env_inherit=BLACK_ENV_INHERIT)
+    result = black_rule_runner.run_goal_rule(
+        UpdateBuildFilesGoal, args=["::"], env_inherit=BLACK_ENV_INHERIT
+    )
     assert result.exit_code == 0
     assert Path(black_rule_runner.build_root, "BUILD").read_text() == "tgt(name='t')\n"
 
@@ -211,7 +220,7 @@ def run_yapf(
     rule_runner.write_files({"BUILD": build_content})
     goal_result = rule_runner.run_goal_rule(
         UpdateBuildFilesGoal,
-        args=["--update-build-files-formatter=yapf"],
+        args=["--update-build-files-formatter=yapf", "::"],
         global_args=extra_args or (),
         env_inherit=BLACK_ENV_INHERIT,
     )

--- a/src/python/pants/core/goals/update_build_files_test.py
+++ b/src/python/pants/core/goals/update_build_files_test.py
@@ -29,6 +29,7 @@ from pants.core.goals.update_build_files import (
     maybe_rename_deprecated_targets,
     update_build_files,
 )
+from pants.core.target_types import GenericTarget
 from pants.core.util_rules import config_files
 from pants.engine.rules import SubsystemRule, rule
 from pants.engine.target import RegisteredTargetTypes, StringField, Target, TargetGenerator
@@ -52,7 +53,7 @@ class MockRewriteReverseLines(RewrittenBuildFileRequest):
 @rule
 def add_line(request: MockRewriteAddLine) -> RewrittenBuildFile:
     return RewrittenBuildFile(
-        request.path, (*request.lines, "added line"), change_descriptions=("Add a new line",)
+        request.path, (*request.lines, "# added line"), change_descriptions=("Add a new line",)
     )
 
 
@@ -79,7 +80,7 @@ def generic_goal_rule_runner() -> RuleRunner:
 
 def test_goal_rewrite_mode(generic_goal_rule_runner: RuleRunner) -> None:
     """Checks that we correctly write the changes and pipe fixers to each other."""
-    generic_goal_rule_runner.write_files({"BUILD": "line\n", "dir/BUILD": "line 1\nline 2\n"})
+    generic_goal_rule_runner.write_files({"BUILD": "# line\n", "dir/BUILD": "# line 1\n# line 2\n"})
     result = generic_goal_rule_runner.run_goal_rule(UpdateBuildFilesGoal, args=["::"])
     assert result.exit_code == 0
     assert result.stdout == dedent(
@@ -92,16 +93,18 @@ def test_goal_rewrite_mode(generic_goal_rule_runner: RuleRunner) -> None:
           - Reverse lines
         """
     )
-    assert Path(generic_goal_rule_runner.build_root, "BUILD").read_text() == "added line\nline\n"
+    assert (
+        Path(generic_goal_rule_runner.build_root, "BUILD").read_text() == "# added line\n# line\n"
+    )
     assert (
         Path(generic_goal_rule_runner.build_root, "dir/BUILD").read_text()
-        == "added line\nline 2\nline 1\n"
+        == "# added line\n# line 2\n# line 1\n"
     )
 
 
 def test_goal_check_mode(generic_goal_rule_runner: RuleRunner) -> None:
     """Checks that we correctly set the exit code and pipe fixers to each other."""
-    generic_goal_rule_runner.write_files({"BUILD": "line\n", "dir/BUILD": "line 1\nline 2\n"})
+    generic_goal_rule_runner.write_files({"BUILD": "# line\n", "dir/BUILD": "# line 1\n# line 2\n"})
     result = generic_goal_rule_runner.run_goal_rule(
         UpdateBuildFilesGoal,
         global_args=["--pants-bin-name=./custom_pants"],
@@ -120,8 +123,10 @@ def test_goal_check_mode(generic_goal_rule_runner: RuleRunner) -> None:
         To fix `update-build-files` failures, run `./custom_pants update-build-files`.
         """
     )
-    assert Path(generic_goal_rule_runner.build_root, "BUILD").read_text() == "line\n"
-    assert Path(generic_goal_rule_runner.build_root, "dir/BUILD").read_text() == "line 1\nline 2\n"
+    assert Path(generic_goal_rule_runner.build_root, "BUILD").read_text() == "# line\n"
+    assert (
+        Path(generic_goal_rule_runner.build_root, "dir/BUILD").read_text() == "# line 1\n# line 2\n"
+    )
 
 
 # ------------------------------------------------------------------------------------------
@@ -143,12 +148,13 @@ def black_rule_runner() -> RuleRunner:
             SubsystemRule(Black),
             SubsystemRule(UpdateBuildFilesSubsystem),
             UnionRule(RewrittenBuildFileRequest, FormatWithBlackRequest),
-        )
+        ),
+        target_types=[GenericTarget],
     )
 
 
 def test_black_fixer_fixes(black_rule_runner: RuleRunner) -> None:
-    black_rule_runner.write_files({"BUILD": "tgt( name =  't' )"})
+    black_rule_runner.write_files({"BUILD": "target( name =  't' )"})
     result = black_rule_runner.run_goal_rule(
         UpdateBuildFilesGoal, args=["::"], env_inherit=BLACK_ENV_INHERIT
     )
@@ -159,20 +165,20 @@ def test_black_fixer_fixes(black_rule_runner: RuleRunner) -> None:
           - Format with Black
         """
     )
-    assert Path(black_rule_runner.build_root, "BUILD").read_text() == 'tgt(name="t")\n'
+    assert Path(black_rule_runner.build_root, "BUILD").read_text() == 'target(name="t")\n'
 
 
 def test_black_fixer_noops(black_rule_runner: RuleRunner) -> None:
-    black_rule_runner.write_files({"BUILD": 'tgt(name="t")\n'})
+    black_rule_runner.write_files({"BUILD": 'target(name="t")\n'})
     result = black_rule_runner.run_goal_rule(
         UpdateBuildFilesGoal, args=["::"], env_inherit=BLACK_ENV_INHERIT
     )
     assert result.exit_code == 0
-    assert Path(black_rule_runner.build_root, "BUILD").read_text() == 'tgt(name="t")\n'
+    assert Path(black_rule_runner.build_root, "BUILD").read_text() == 'target(name="t")\n'
 
 
 def test_black_fixer_args(black_rule_runner: RuleRunner) -> None:
-    black_rule_runner.write_files({"BUILD": "tgt(name='t')\n"})
+    black_rule_runner.write_files({"BUILD": "target(name='t')\n"})
     result = black_rule_runner.run_goal_rule(
         UpdateBuildFilesGoal,
         global_args=["--black-args='--skip-string-normalization'"],
@@ -180,21 +186,21 @@ def test_black_fixer_args(black_rule_runner: RuleRunner) -> None:
         env_inherit=BLACK_ENV_INHERIT,
     )
     assert result.exit_code == 0
-    assert Path(black_rule_runner.build_root, "BUILD").read_text() == "tgt(name='t')\n"
+    assert Path(black_rule_runner.build_root, "BUILD").read_text() == "target(name='t')\n"
 
 
 def test_black_config(black_rule_runner: RuleRunner) -> None:
     black_rule_runner.write_files(
         {
             "pyproject.toml": "[tool.black]\nskip-string-normalization = 'true'\n",
-            "BUILD": "tgt(name='t')\n",
+            "BUILD": "target(name='t')\n",
         },
     )
     result = black_rule_runner.run_goal_rule(
         UpdateBuildFilesGoal, args=["::"], env_inherit=BLACK_ENV_INHERIT
     )
     assert result.exit_code == 0
-    assert Path(black_rule_runner.build_root, "BUILD").read_text() == "tgt(name='t')\n"
+    assert Path(black_rule_runner.build_root, "BUILD").read_text() == "target(name='t')\n"
 
 
 # ------------------------------------------------------------------------------------------
@@ -215,7 +221,8 @@ def run_yapf(
             SubsystemRule(Yapf),
             SubsystemRule(UpdateBuildFilesSubsystem),
             UnionRule(RewrittenBuildFileRequest, FormatWithYapfRequest),
-        )
+        ),
+        target_types=[GenericTarget],
     )
     rule_runner.write_files({"BUILD": build_content})
     goal_result = rule_runner.run_goal_rule(
@@ -229,7 +236,7 @@ def run_yapf(
 
 
 def test_yapf_fixer_fixes() -> None:
-    result, build = run_yapf("tgt( name =  't' )")
+    result, build = run_yapf("target( name =  't' )")
     assert result.exit_code == 0
     assert result.stdout == dedent(
         """\
@@ -237,14 +244,14 @@ def test_yapf_fixer_fixes() -> None:
           - Format with Yapf
         """
     )
-    assert build == "tgt(name='t')\n"
+    assert build == "target(name='t')\n"
 
 
 def test_yapf_fixer_noops() -> None:
-    result, build = run_yapf('tgt(name="t")\n')
+    result, build = run_yapf('target(name="t")\n')
     assert result.exit_code == 0
     assert not result.stdout
-    assert build == 'tgt(name="t")\n'
+    assert build == 'target(name="t")\n'
 
 
 # ------------------------------------------------------------------------------------------


### PR DESCRIPTION
First part of https://github.com/pantsbuild/pants/issues/15563. You can now do, for example:

* `./pants update-build-files ::`
* `./pants update-build-files dir/BUILD`

Note that this deprecates leaving off arguments. Even if we think that may be desirable, I strongly encourage us to be consistent with all other goals. That will leave the semantics of "no args" open to us to change in the future, e.g. to mean something like `--changed-since=implicit`. If we are not consistent, then that semantics change will be much harder to pull off.

[ci skip-rust]
[ci skip-build-wheels]