### PR TITLE
Make required fields sort first on the docsite and in the './pants help target' output

### DIFF
--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -424,7 +424,9 @@ class ReferenceGenerator:
                     "required" if field["required"] else f"default: <code>{default_str}</code>"
                 )
                 field["description"] = str(field["description"])
-            target["fields"] = sorted(target["fields"], key=lambda fld: cast(str, fld["alias"]))
+            target["fields"] = sorted(
+                target["fields"], key=lambda fld: (-fld["required"], cast(str, fld["alias"]))
+            )
             target["description"] = str(target["description"])
 
         return cast(Dict[str, Dict[str, Any]], target_info)

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -293,8 +293,7 @@ class HelpPrinter(MaybeColor):
             print(formatted_desc)
         print(f"\n\nActivated by {self.maybe_magenta(tinfo.provider)}")
         print("Valid fields:")
-        for field in sorted(tinfo.fields, key=lambda x: x.alias):
-            print()
+        for field in sorted(tinfo.fields, key=lambda x: (-x.required, x.alias)):
             print(self.maybe_magenta(field.alias))
             indent = "    "
             required_or_default = "required" if field.required else f"default: {field.default}"

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -294,6 +294,7 @@ class HelpPrinter(MaybeColor):
         print(f"\n\nActivated by {self.maybe_magenta(tinfo.provider)}")
         print("Valid fields:")
         for field in sorted(tinfo.fields, key=lambda x: (-x.required, x.alias)):
+            print()
             print(self.maybe_magenta(field.alias))
             indent = "    "
             required_or_default = "required" if field.required else f"default: {field.default}"


### PR DESCRIPTION
Fixes #15147.

This PR adds sorting order for the target fields. They are now going to be sorted first by being required/optional with required fields showing up first. After this, they are sorted by alias (lexicographically). This makes required fields showing up first in the docsite and in the `./pants help target` command.

Getting help locally with this PR (the only required fields `provides` is listed first, the rest of the fields are shown afterwords sorted in ascending order):

```
$ ./pants help python_distribution

`python_distribution` target
----------------------------

A publishable Python setuptools distribution (e.g. an sdist or wheel).

See https://www.pantsbuild.org/v2.13/docs/python-distributions.


Activated by pants.backend.python
Valid fields:

provides
    type: PythonArtifact
    required

    The setup.py kwargs for the external artifact built from this target.
		...    

dependencies
    type: Iterable[str] | None
    default: None

    Addresses to other targets that this target depends on, e.g. ['helloworld/subdir:lib', 'helloworld/main.py:lib', '3rdparty:reqs#django'].
    
    ...
	
description
    type: str | None
    default: None

    A human-readable description of the target.
		...

entry_points
    type: Dict[str, Dict[str, str]] | None
    default: None

    Any entry points, such as `console_scripts` and `gui_scripts`.
```

Generating docsite:

```
$ ./pants run build-support/bin/generate_docs.py
```

Previewing the markdown files generated:

![image](https://user-images.githubusercontent.com/59651540/169704433-c0b21644-2cda-46d0-91b0-c4bb4f44aa77.png)


[ci skip-rust] 
[ci skip-build-wheels]