### PR TITLE
Add `--no-use-deprecated-directory-cli-args-semantics` so that directory arguments match all files/targets in the directory

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -66,6 +66,8 @@ ignore_warnings.add = [
   "DEPRECATED: pants.base.build_environment.get_git"
 ]
 
+use_deprecated_directory_cli_args_semantics = false
+
 unmatched_build_file_globs = "error"
 
 # NB: Users must still set `--remote-cache-{read,write}` to enable the remote cache.

--- a/src/python/pants/base/specs_parser.py
+++ b/src/python/pants/base/specs_parser.py
@@ -106,11 +106,12 @@ class SpecsParser:
         self,
         specs: Iterable[str],
         *,
+        convert_dir_literal_to_address_literal: bool,
         unmatched_glob_behavior: GlobMatchErrorBehavior = GlobMatchErrorBehavior.error,
     ) -> Specs:
         return Specs.create(
             (self.parse_spec(spec) for spec in specs),
-            convert_dir_literal_to_address_literal=True,
+            convert_dir_literal_to_address_literal=convert_dir_literal_to_address_literal,
             unmatched_glob_behavior=unmatched_glob_behavior,
             filter_by_global_options=True,
         )

--- a/src/python/pants/bsp/util_rules/targets.py
+++ b/src/python/pants/bsp/util_rules/targets.py
@@ -165,7 +165,9 @@ class _ParseOneBSPMappingRequest:
 @rule
 async def parse_one_bsp_mapping(request: _ParseOneBSPMappingRequest) -> BSPBuildTargetInternal:
     specs_parser = SpecsParser()
-    specs = specs_parser.parse_specs(request.definition.addresses)
+    specs = specs_parser.parse_specs(
+        request.definition.addresses, convert_dir_literal_to_address_literal=False
+    )
     return BSPBuildTargetInternal(request.name, specs, request.definition)
 
 

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -926,7 +926,10 @@ def test_streaming_workunits_expanded_specs(run_tracker: RunTracker) -> None:
             "src/python/others/b.py": "print('')",
         }
     )
-    specs = SpecsParser().parse_specs(["src/python/somefiles::", "src/python/others/b.py"])
+    specs = SpecsParser().parse_specs(
+        ["src/python/somefiles::", "src/python/others/b.py"],
+        convert_dir_literal_to_address_literal=False,
+    )
 
     class Callback(WorkunitsCallback):
         @property

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -798,7 +798,9 @@ def assert_generated(
     if dependencies is not None:
         # TODO: Adjust the `TransitiveTargets` API to expose the complete mapping.
         #   see https://github.com/pantsbuild/pants/issues/11270
-        specs = SpecsParser(rule_runner.build_root).parse_specs(["::"])
+        specs = SpecsParser(rule_runner.build_root).parse_specs(
+            ["::"], convert_dir_literal_to_address_literal=False
+        )
         addresses = rule_runner.request(Addresses, [specs])
         dependency_mapping = rule_runner.request(
             _DependencyMapping,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1640,11 +1640,12 @@ class GlobalOptions(BootstrapOptions, Subsystem):
         default=True,
         help=softwrap(
             f"""
-            If true, directory arguments like `{bin_name()} test dir` are shorthand for the target
-            `dir:dir`, i.e. the target that leaves off `name=`.
+            If true, Pants will use the old, deprecated semantics for directory arguments like
+            `{bin_name()} test dir`: directories are shorthand for the target `dir:dir`, i.e. the
+            target that leaves off `name=`.
 
-            Otherwise, directory arguments will match all targets in the directory, e.g.
-            `{bin_name()} test dir` will run all tests in `dir`.
+            If false, Pants will use the new semantics: directory arguments will match all files
+            and targets in the directory, e.g. `{bin_name()} test dir` will run all tests in `dir`.
 
             The new semantics will become the default in Pants 2.14, and the old semantics will be
             removed in 2.15.

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1635,6 +1635,23 @@ class GlobalOptions(BootstrapOptions, Subsystem):
         advanced=True,
     )
 
+    use_deprecated_directory_cli_args_semantics = BoolOption(
+        "--use-deprecated-directory-cli-args-semantics",
+        default=True,
+        help=softwrap(
+            f"""
+            If true, directory arguments like `{bin_name()} test dir` are shorthand for the target
+            `dir:dir`, i.e. the target that leaves off `name=`.
+
+            Otherwise, directory arguments will match all targets in the directory, e.g.
+            `{bin_name()} test dir` will run all tests in `dir`.
+
+            The new semantics will become the default in Pants 2.14, and the old semantics will be
+            removed in 2.15.
+            """
+        ),
+    )
+
     @classmethod
     def validate_instance(cls, opts):
         """Validates an instance of global options for cases that are not prohibited via

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -320,7 +320,9 @@ class RuleRunner:
         raw_specs = self.options_bootstrapper.full_options_for_scopes(
             [GlobalOptions.get_scope_info(), goal.subsystem_cls.get_scope_info()]
         ).specs
-        specs = SpecsParser(self.build_root).parse_specs(raw_specs)
+        specs = SpecsParser(self.build_root).parse_specs(
+            raw_specs, convert_dir_literal_to_address_literal=True
+        )
 
         stdout, stderr = StringIO(), StringIO()
         console = Console(stdout=stdout, stderr=stderr, use_colors=False, session=self.scheduler)


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/14209.

We use an option to toggle the semantics to respect our deprecation policy.

## Semantics

With `SpecsSnapshot`, the dir literal simply matches all files in the directory.

With `Addresses`, the dir literal matches all targets that "reside" in the directory, and it's guaranteed to not run against anything else. Tangibly, `./pants test dir` will only ever run tests inside `dir`. This contrasts with `DirGlobSpec` like `dir:`, which will match target generators that reside in the dir; if the target generator uses `**` recursive globs in its `sources` field, `./pants test dir:` would run on all those subdirs.

We decided in Slack that it is much more intuitive for users if `./pants test dir` only ever runs over `dir`. If you do want the target generator behavior, you can still use `dir:`. This also makes it easier for us to move away from 1:1:1, if we desire, as your target generator `sources` no longer impacts how directory specs work.

Unfortunately, it means that target generators will not show up with project introspection like `list`. We decided in Slack that that is acceptable, especially because https://docs.google.com/document/d/1jSCJ3pwvIMg5duafsr8KmiLOO_2ARMaYCSrb8K85JQc/edit would mean that we no longer even have a way to address 95% of target generators.

[ci skip-rust]
[ci skip-build-wheels]