### PR TITLE
Have `generate_docs` error on bad pantsbuild URLs

### DIFF
--- a/build-support/bin/generate_docs_test.py
+++ b/build-support/bin/generate_docs_test.py
@@ -53,7 +53,9 @@ def test_get_title_from_page_content():
       <body>Welcome to Pants, the ergonomic build system!</body>
     """
     )
-    assert TitleFinder().feed(page_content).title == ["Welcome to Pants!"]
+    title_finder = TitleFinder()
+    title_finder.feed(page_content)
+    assert title_finder.title == "Welcome to Pants!"
 
 
 def test_doc_url_rewriter():

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -30,7 +30,7 @@ class PythonProtobufSubsystem(Subsystem):
         f"""
         Options related to the Protobuf Python backend.
 
-        See {doc_url('protobuf')}.
+        See {doc_url('protobuf-python')}.
         """
     )
 

--- a/src/python/pants/backend/codegen/protobuf/target_types.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types.py
@@ -66,7 +66,9 @@ class ProtobufSourceTarget(Target):
         f"""
         A single Protobuf file used to generate various languages.
 
-        See {doc_url('protobuf')}.
+        See language-specific docs:
+            Python: {doc_url('protobuf-python')}
+            Go: {doc_url('protobuf-go')}
         """
     )
 

--- a/src/python/pants/backend/codegen/thrift/target_types.py
+++ b/src/python/pants/backend/codegen/thrift/target_types.py
@@ -72,7 +72,8 @@ class ThriftSourceTarget(Target):
         f"""
         A single Thrift file used to generate various languages.
 
-        See {doc_url('thrift')}.
+        See language-specific docs:
+            Python: {doc_url('thrift-python')}
         """
     )
 

--- a/src/python/pants/backend/google_cloud_function/python/target_types.py
+++ b/src/python/pants/backend/google_cloud_function/python/target_types.py
@@ -260,7 +260,7 @@ class PythonGoogleCloudFunction(Target):
         f"""
         A self-contained Python function suitable for uploading to Google Cloud Function.
 
-        See {doc_url('python-google-cloud-function')}.
+        See {doc_url('google-cloud-function-python')}.
         """
     )
 

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -97,7 +97,7 @@ class PythonSetup(Subsystem):
             requirements, regardless of using Pex vs. Poetry for the lockfile generator.
             Support is coming in a future Pants release. In the meantime, the workaround is to host
             the files in a custom repository with `[python-repos]`
-            ({doc_url('3rdparty-dependencies#custom-repositories')}).
+            ({doc_url('python-third-party-dependencies#custom-repositories')}).
 
             You may also run into issues generating lockfiles when using Poetry as the generator,
             rather than Pex. See the option `[python].lockfile_generator` for more


### PR DESCRIPTION
Fixes #11578 by erroring if we get a non-200 status on a pantsbuild.org URL. Also fixed a few URLs it caught.

I originally wrote this code in a way that we'd validate all URLs (as @Eric-Arellano suggests), however it choked on our URL templates (`"https://github.com/bufbuild/buf/releases/download/{version}/buf-{platform}.tar.gz"`) and I didn't want to throw the baby out with the bathwater trying to fix that.

Additionally, this will consistently fail on `main`, due to the docs not existing yet, so added `--skip-check-urls` to skip the checking.

I shied away from doing this kind of validation in a test, because that means the tests would rely on network connection, which I'm not a big fan of (and if we're validating any URL, the test could get very "flaky").

Also includes a little refactoring.

[ci skip-rust]