### PR TITLE
Replace `SpecsSnapshot` with lazier `SpecsPaths`

### DIFF
--- a/src/python/pants/backend/project_info/count_loc.py
+++ b/src/python/pants/backend/project_info/count_loc.py
@@ -7,11 +7,11 @@ from pants.core.util_rules.external_tool import (
     TemplatedExternalTool,
 )
 from pants.engine.console import Console
-from pants.engine.fs import Digest, MergeDigests, SpecsSnapshot
+from pants.engine.fs import Digest, MergeDigests, PathGlobs, SpecsPaths
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import Get, collect_rules, goal_rule
+from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
 from pants.option.option_types import ArgsListOption
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
@@ -62,27 +62,26 @@ class CountLinesOfCode(Goal):
 async def count_loc(
     console: Console,
     succinct_code_counter: SuccinctCodeCounter,
-    specs_snapshot: SpecsSnapshot,
+    specs_paths: SpecsPaths,
 ) -> CountLinesOfCode:
-    if not specs_snapshot.snapshot.files:
+    if not specs_paths.files:
         return CountLinesOfCode(exit_code=0)
 
-    scc_program = await Get(
-        DownloadedExternalTool,
-        ExternalToolRequest,
-        succinct_code_counter.get_request(Platform.current),
+    specs_digest, scc_program = await MultiGet(
+        Get(Digest, PathGlobs(globs=specs_paths.files)),
+        Get(
+            DownloadedExternalTool,
+            ExternalToolRequest,
+            succinct_code_counter.get_request(Platform.current),
+        ),
     )
-    input_digest = await Get(
-        Digest, MergeDigests((scc_program.digest, specs_snapshot.snapshot.digest))
-    )
+    input_digest = await Get(Digest, MergeDigests((scc_program.digest, specs_digest)))
     result = await Get(
         ProcessResult,
         Process(
             argv=(scc_program.exe, *succinct_code_counter.args),
             input_digest=input_digest,
-            description=(
-                f"Count lines of code for {pluralize(len(specs_snapshot.snapshot.files), 'file')}"
-            ),
+            description=f"Count lines of code for {pluralize(len(specs_paths.files), 'file')}",
             level=LogLevel.DEBUG,
         ),
     )

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -21,7 +21,7 @@ from pants.core.util_rules.distdir import DistDir
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.console import Console
 from pants.engine.engine_aware import EngineAwareParameter, EngineAwareReturnType
-from pants.engine.fs import EMPTY_DIGEST, Digest, SpecsSnapshot, Workspace
+from pants.engine.fs import EMPTY_DIGEST, Digest, SpecsPaths, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
@@ -299,8 +299,8 @@ async def lint(
         Specs,
         specs if lint_target_request_types or fmt_target_request_types else Specs(),
     )
-    _get_specs_snapshot = Get(SpecsSnapshot, Specs, specs if file_request_types else Specs())
-    targets, specs_snapshot = await MultiGet(_get_targets, _get_specs_snapshot)
+    _get_specs_paths = Get(SpecsPaths, Specs, specs if file_request_types else Specs())
+    targets, specs_paths = await MultiGet(_get_targets, _get_specs_paths)
 
     def batch(field_sets: Iterable[FieldSet]) -> Iterator[list[FieldSet]]:
         partitions = partition_sequentially(
@@ -356,8 +356,8 @@ async def lint(
         )
 
     file_requests = (
-        tuple(request_type(specs_snapshot.snapshot.files) for request_type in file_request_types)
-        if specs_snapshot.snapshot.files
+        tuple(request_type(specs_paths.files) for request_type in file_request_types)
+        if specs_paths.files
         else ()
     )
 

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -26,7 +26,7 @@ from pants.core.goals.lint import (
 from pants.core.util_rules.distdir import DistDir
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
-from pants.engine.fs import SpecsSnapshot, Workspace
+from pants.engine.fs import SpecsPaths, Workspace
 from pants.engine.internals.native_engine import EMPTY_DIGEST, EMPTY_SNAPSHOT, Digest, Snapshot
 from pants.engine.target import FieldSet, FilteredTargets, MultipleSourcesField, Target
 from pants.engine.unions import UnionMembership
@@ -216,11 +216,9 @@ def run_lint_rule(
                     mock=lambda _: FilteredTargets(targets),
                 ),
                 MockGet(
-                    output_type=SpecsSnapshot,
+                    output_type=SpecsPaths,
                     input_type=Specs,
-                    mock=lambda _: SpecsSnapshot(
-                        rule_runner.make_snapshot_of_empty_files(["f.txt"])
-                    ),
+                    mock=lambda _: SpecsPaths(("f.txt",), ()),
                 ),
             ],
             union_membership=union_membership,

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -249,14 +249,12 @@ class Workspace(SideEffecting):
 
 
 @dataclass(frozen=True)
-class SpecsSnapshot:
+class SpecsPaths(Paths):
     """All files matched by command line specs.
 
     `@goal_rule`s may request this when they only need source files to operate and do not need any
     target information. This allows running on files with no owning targets.
     """
-
-    snapshot: Snapshot
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Digesting is a much heavier operation than finding file paths. It requires more IO resources, and has worse cache semantics because we care about file content rather than only file names. Hence the `Paths` type: https://github.com/pantsbuild/pants/pull/10741

This change allows target-less goals to only digest files they actually care about, e.g. `update-build-files` now only digests BUILD files.

Before:

```
❯ hyperfine -w 1 -r 5 './pants --no-pantsd update-build-files --check --no-fmt ::'
Benchmark 1: ./pants --no-pantsd update-build-files --check --no-fmt ::
  Time (mean ± σ):      5.238 s ±  0.052 s    [User: 4.159 s, System: 0.541 s]
  Range (min … max):    5.195 s …  5.324 s    5 runs
```

After:

```
❯ hyperfine -w 1 -r 5 './pants --no-pantsd update-build-files --check --no-fmt ::'
Benchmark 1: ./pants --no-pantsd update-build-files --check --no-fmt ::
  Time (mean ± σ):      5.100 s ±  0.070 s    [User: 3.888 s, System: 0.480 s]
  Range (min … max):    5.044 s …  5.211 s    5 runs
```

[ci skip-rust]
[ci skip-build-wheels]