### PR TITLE
Docs: show language specific file examples in sources field in the help

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/target_types.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types.py
@@ -17,6 +17,7 @@ from pants.engine.target import (
     TargetFilesGeneratorSettingsRequest,
     Targets,
     generate_file_based_overrides_field_help_message,
+    generate_multiple_sources_field_help_message,
 )
 from pants.engine.unions import UnionRule
 from pants.util.docutil import doc_url
@@ -93,6 +94,9 @@ def generator_settings(
 class ProtobufSourcesGeneratingSourcesField(MultipleSourcesField):
     default = ("*.proto",)
     expected_file_extensions = (".proto",)
+    help = generate_multiple_sources_field_help_message(
+        "Example: `sources=['example.proto', 'new_*.proto', '!old_ignore*.proto']`"
+    )
 
 
 class ProtobufSourcesOverridesField(OverridesField):

--- a/src/python/pants/backend/codegen/thrift/target_types.py
+++ b/src/python/pants/backend/codegen/thrift/target_types.py
@@ -16,6 +16,7 @@ from pants.engine.target import (
     TargetFilesGeneratorSettingsRequest,
     Targets,
     generate_file_based_overrides_field_help_message,
+    generate_multiple_sources_field_help_message,
 )
 from pants.engine.unions import UnionRule
 from pants.util.docutil import doc_url
@@ -85,6 +86,9 @@ class ThriftSourceTarget(Target):
 class ThriftSourcesGeneratingSourcesField(MultipleSourcesField):
     default = ("*.thrift",)
     expected_file_extensions = (".thrift",)
+    help = generate_multiple_sources_field_help_message(
+        "Example: `sources=['example.thrift', 'new_*.thrift', '!old_ignore.thrift']`"
+    )
 
 
 class ThriftSourcesOverridesField(OverridesField):

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -24,6 +24,7 @@ from pants.engine.target import (
     Target,
     TargetGenerator,
     ValidNumbers,
+    generate_multiple_sources_field_help_message,
 )
 from pants.util.strutil import softwrap
 
@@ -151,6 +152,13 @@ class GoPackageSourcesField(MultipleSourcesField):
     default = ("*.go", "*.s")
     expected_file_extensions = (".go", ".s")
     ban_subdirectories = True
+    help = generate_multiple_sources_field_help_message(
+        softwrap(
+            """
+            Example: `sources=['example.go', '*_test.go', '!test_ignore.go']`.
+            """
+        )
+    )
 
     @classmethod
     def compute_value(

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -153,11 +153,7 @@ class GoPackageSourcesField(MultipleSourcesField):
     expected_file_extensions = (".go", ".s")
     ban_subdirectories = True
     help = generate_multiple_sources_field_help_message(
-        softwrap(
-            """
-            Example: `sources=['example.go', '*_test.go', '!test_ignore.go']`.
-            """
-        )
+        "Example: `sources=['example.go', '*_test.go', '!test_ignore.go']`"
     )
 
     @classmethod

--- a/src/python/pants/backend/helm/target_types.py
+++ b/src/python/pants/backend/helm/target_types.py
@@ -22,6 +22,7 @@ from pants.engine.target import (
     TargetFilesGenerator,
     Targets,
     TriBoolField,
+    generate_multiple_sources_field_help_message,
 )
 from pants.util.docutil import bin_name
 from pants.util.strutil import softwrap
@@ -96,6 +97,9 @@ class HelmChartMetaSourceField(SingleSourceField):
 class HelmChartSourcesField(MultipleSourcesField):
     default = ("values.yaml", "templates/*.yaml", "templates/*.tpl")
     expected_file_extensions = (".yaml", ".yml", ".tpl")
+    help = generate_multiple_sources_field_help_message(
+        "Example: `sources=['values.yaml', 'templates/*.yaml', '!values_ignore.yaml']`"
+    )
 
 
 class HelmChartDependenciesField(Dependencies):
@@ -227,6 +231,9 @@ class HelmUnitTestGeneratingSourcesField(MultipleSourcesField):
     expected_file_extensions = (
         ".yaml",
         ".yml",
+    )
+    help = generate_multiple_sources_field_help_message(
+        "Example: `sources=['*_test.yaml', '!ignore_test.yaml']`"
     )
 
 

--- a/src/python/pants/backend/java/target_types.py
+++ b/src/python/pants/backend/java/target_types.py
@@ -14,6 +14,7 @@ from pants.engine.target import (
     SingleSourceField,
     Target,
     TargetFilesGenerator,
+    generate_multiple_sources_field_help_message,
 )
 from pants.jvm.target_types import (
     JunitTestSourceField,
@@ -21,6 +22,7 @@ from pants.jvm.target_types import (
     JvmProvidesTypesField,
     JvmResolveField,
 )
+from pants.util.strutil import softwrap
 
 
 class JavaSourceField(SingleSourceField):
@@ -29,6 +31,13 @@ class JavaSourceField(SingleSourceField):
 
 class JavaGeneratorSourcesField(MultipleSourcesField):
     expected_file_extensions = (".java",)
+    help = generate_multiple_sources_field_help_message(
+        softwrap(
+            """
+            Example: `sources=['Example.java', '*Test.java', '!TestIgnore.java']`.
+            """
+        )
+    )
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/java/target_types.py
+++ b/src/python/pants/backend/java/target_types.py
@@ -22,7 +22,6 @@ from pants.jvm.target_types import (
     JvmProvidesTypesField,
     JvmResolveField,
 )
-from pants.util.strutil import softwrap
 
 
 class JavaSourceField(SingleSourceField):
@@ -31,13 +30,6 @@ class JavaSourceField(SingleSourceField):
 
 class JavaGeneratorSourcesField(MultipleSourcesField):
     expected_file_extensions = (".java",)
-    help = generate_multiple_sources_field_help_message(
-        softwrap(
-            """
-            Example: `sources=['Example.java', '*Test.java', '!TestIgnore.java']`.
-            """
-        )
-    )
 
 
 @dataclass(frozen=True)
@@ -78,6 +70,9 @@ class JunitTestTarget(Target):
 
 class JavaTestsGeneratorSourcesField(JavaGeneratorSourcesField):
     default = ("*Test.java",)
+    help = generate_multiple_sources_field_help_message(
+        """Example: `sources=['*Test.java', '!TestIgnore.java']`."""
+    )
 
 
 class JunitTestsGeneratorTarget(TargetFilesGenerator):
@@ -117,6 +112,9 @@ class JavaSourceTarget(Target):
 
 class JavaSourcesGeneratorSourcesField(JavaGeneratorSourcesField):
     default = ("*.java",) + tuple(f"!{pat}" for pat in JavaTestsGeneratorSourcesField.default)
+    help = generate_multiple_sources_field_help_message(
+        "Example: `sources=['Example.java', 'New*.java', '!OldExample.java']`"
+    )
 
 
 class JavaSourcesGeneratorTarget(TargetFilesGenerator):

--- a/src/python/pants/backend/java/target_types.py
+++ b/src/python/pants/backend/java/target_types.py
@@ -71,7 +71,7 @@ class JunitTestTarget(Target):
 class JavaTestsGeneratorSourcesField(JavaGeneratorSourcesField):
     default = ("*Test.java",)
     help = generate_multiple_sources_field_help_message(
-        """Example: `sources=['*Test.java', '!TestIgnore.java']`."""
+        "Example: `sources=['*Test.java', '!TestIgnore.java']`"
     )
 
 

--- a/src/python/pants/backend/kotlin/target_types.py
+++ b/src/python/pants/backend/kotlin/target_types.py
@@ -16,6 +16,7 @@ from pants.engine.target import (
     StringSequenceField,
     Target,
     TargetFilesGenerator,
+    generate_multiple_sources_field_help_message,
 )
 from pants.jvm.target_types import (
     JunitTestSourceField,
@@ -90,6 +91,9 @@ class KotlinSourceTarget(Target):
 
 class KotlinSourcesGeneratorSourcesField(KotlinGeneratorSourcesField):
     default = ("*.kt",)
+    help = generate_multiple_sources_field_help_message(
+        "Example: `sources=['Example.kt', 'New*.kt', '!OldIgnore.kt']`"
+    )
 
 
 class KotlinSourcesGeneratorTarget(TargetFilesGenerator):
@@ -139,6 +143,9 @@ class KotlinJunitTestTarget(Target):
 
 class KotlinJunitTestsGeneratorSourcesField(KotlinGeneratorSourcesField):
     default = ("*Test.kt",)
+    help = generate_multiple_sources_field_help_message(
+        "Example: `sources=['*Test.kt', '!TestIgnore.kt']`"
+    )
 
 
 class KotlinJunitTestsGeneratorTarget(TargetFilesGenerator):

--- a/src/python/pants/backend/python/docs/sphinx/target_types.py
+++ b/src/python/pants/backend/python/docs/sphinx/target_types.py
@@ -13,6 +13,7 @@ from pants.engine.target import (
     InvalidFieldException,
     MultipleSourcesField,
     Target,
+    generate_multiple_sources_field_help_message,
 )
 from pants.util.strutil import softwrap
 
@@ -22,6 +23,9 @@ class SphinxProjectSourcesField(MultipleSourcesField):
     default = ("conf.py", "**/*.rst")
     expected_file_extensions = (".py", ".rst")
     uses_source_roots = False
+    help = generate_multiple_sources_field_help_message(
+        "Example: `sources=['conf.py', 'new_*.rst', '!old_ignore.rst']`"
+    )
 
     def validate_resolved_files(self, files: Sequence[str]) -> None:
         super().validate_resolved_files(files)

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -60,6 +60,7 @@ from pants.engine.target import (
     TriBoolField,
     ValidNumbers,
     generate_file_based_overrides_field_help_message,
+    generate_multiple_sources_field_help_message,
 )
 from pants.option.option_types import BoolOption
 from pants.option.subsystem import Subsystem
@@ -86,6 +87,13 @@ class PythonSourceField(SingleSourceField):
 
 class PythonGeneratingSourcesBase(MultipleSourcesField):
     expected_file_extensions: ClassVar[tuple[str, ...]] = ("", ".py", ".pyi")
+    help = generate_multiple_sources_field_help_message(
+        softwrap(
+            """
+            Example: `sources=['example.py', 'test_*.py', '!test_ignore.py']`.
+            """
+        )
+    )
 
 
 class InterpreterConstraintsField(StringSequenceField):

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -87,13 +87,6 @@ class PythonSourceField(SingleSourceField):
 
 class PythonGeneratingSourcesBase(MultipleSourcesField):
     expected_file_extensions: ClassVar[tuple[str, ...]] = ("", ".py", ".pyi")
-    help = generate_multiple_sources_field_help_message(
-        softwrap(
-            """
-            Example: `sources=['example.py', 'test_*.py', '!test_ignore.py']`.
-            """
-        )
-    )
 
 
 class InterpreterConstraintsField(StringSequenceField):
@@ -819,6 +812,9 @@ class PythonTestTarget(Target):
 class PythonTestsGeneratingSourcesField(PythonGeneratingSourcesBase):
     expected_file_extensions = (".py", "")  # Note that this does not include `.pyi`.
     default = ("test_*.py", "*_test.py", "tests.py")
+    help = generate_multiple_sources_field_help_message(
+        "Example: `sources=['test_*.py', '*_test.py', 'tests.py']`"
+    )
 
     def validate_resolved_files(self, files: Sequence[str]) -> None:
         super().validate_resolved_files(files)
@@ -895,6 +891,9 @@ class PythonSourcesOverridesField(OverridesField):
 
 class PythonTestUtilsGeneratingSourcesField(PythonGeneratingSourcesBase):
     default = ("conftest.py", "test_*.pyi", "*_test.pyi", "tests.pyi")
+    help = generate_multiple_sources_field_help_message(
+        "Example: `sources=['conftest.py', 'test_*.pyi', '*_test.pyi', 'tests.pyi']`"
+    )
 
 
 class PythonSourcesGeneratingSourcesField(PythonGeneratingSourcesBase):
@@ -902,6 +901,9 @@ class PythonSourcesGeneratingSourcesField(PythonGeneratingSourcesBase):
         ("*.py", "*.pyi")
         + tuple(f"!{pat}" for pat in PythonTestsGeneratingSourcesField.default)
         + tuple(f"!{pat}" for pat in PythonTestUtilsGeneratingSourcesField.default)
+    )
+    help = generate_multiple_sources_field_help_message(
+        "Example: `sources=['example.py', 'new_*.py', '!old_ignore.py']`"
     )
 
 

--- a/src/python/pants/backend/scala/target_types.py
+++ b/src/python/pants/backend/scala/target_types.py
@@ -18,6 +18,7 @@ from pants.engine.target import (
     TargetFilesGenerator,
     TargetFilesGeneratorSettings,
     TargetFilesGeneratorSettingsRequest,
+    generate_multiple_sources_field_help_message,
 )
 from pants.engine.unions import UnionRule
 from pants.jvm.target_types import (
@@ -107,6 +108,9 @@ class ScalatestTestTarget(Target):
 
 class ScalatestTestsGeneratorSourcesField(ScalaGeneratorSourcesField):
     default = ("*Spec.scala", "*Suite.scala")
+    help = generate_multiple_sources_field_help_message(
+        "Example: `sources=['*Spec.scala', '!SuiteIgnore.scala']`"
+    )
 
 
 class ScalatestTestsGeneratorTarget(TargetFilesGenerator):
@@ -158,6 +162,9 @@ class ScalaJunitTestTarget(Target):
 
 class ScalaJunitTestsGeneratorSourcesField(ScalaGeneratorSourcesField):
     default = ("*Test.scala",)
+    help = generate_multiple_sources_field_help_message(
+        "Example: `sources=['*Test.scala', '!TestIgnore.scala']`"
+    )
 
 
 class ScalaJunitTestsGeneratorTarget(TargetFilesGenerator):
@@ -208,6 +215,9 @@ class ScalaSourcesGeneratorSourcesField(ScalaGeneratorSourcesField):
         "*.scala",
         *(f"!{pat}" for pat in (ScalaJunitTestsGeneratorSourcesField.default)),
         *(f"!{pat}" for pat in (ScalatestTestsGeneratorSourcesField.default)),
+    )
+    help = generate_multiple_sources_field_help_message(
+        "Example: `sources=['Example.scala', 'New*.scala', '!OldIgnore.scala']`"
     )
 
 

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -26,6 +26,7 @@ from pants.engine.target import (
     TargetFilesGeneratorSettingsRequest,
     ValidNumbers,
     generate_file_based_overrides_field_help_message,
+    generate_multiple_sources_field_help_message,
 )
 from pants.engine.unions import UnionRule
 from pants.util.enums import match
@@ -169,6 +170,9 @@ class Shunit2TestTarget(Target):
 
 class Shunit2TestsGeneratorSourcesField(ShellGeneratingSourcesBase):
     default = ("*_test.sh", "test_*.sh", "tests.sh")
+    help = generate_multiple_sources_field_help_message(
+        "Example: `sources=['test.sh', 'test_*.sh', '!test_ignore.sh']`"
+    )
 
 
 class Shunit2TestsOverrideField(OverridesField):
@@ -216,6 +220,9 @@ class ShellSourceTarget(Target):
 
 class ShellSourcesGeneratingSourcesField(ShellGeneratingSourcesBase):
     default = ("*.sh",) + tuple(f"!{pat}" for pat in Shunit2TestsGeneratorSourcesField.default)
+    help = generate_multiple_sources_field_help_message(
+        "Example: `sources=['example.sh', 'new_*.sh', '!old_ignore.sh']`"
+    )
 
 
 class ShellSourcesOverridesField(OverridesField):

--- a/src/python/pants/backend/terraform/target_types.py
+++ b/src/python/pants/backend/terraform/target_types.py
@@ -12,6 +12,7 @@ from pants.engine.target import (
     FieldSet,
     MultipleSourcesField,
     Target,
+    generate_multiple_sources_field_help_message,
 )
 from pants.util.strutil import softwrap
 
@@ -20,6 +21,9 @@ class TerraformModuleSourcesField(MultipleSourcesField):
     default = ("*.tf",)
     expected_file_extensions = (".tf",)
     ban_subdirectories = True
+    help = generate_multiple_sources_field_help_message(
+        "Example: `sources=['example.tf', 'new_*.tf', '!old_ignore.tf']`"
+    )
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -53,6 +53,7 @@ from pants.engine.target import (
     TargetFilesGenerator,
     Targets,
     generate_file_based_overrides_field_help_message,
+    generate_multiple_sources_field_help_message,
 )
 from pants.engine.unions import UnionRule
 from pants.util.docutil import bin_name
@@ -220,6 +221,9 @@ async def hydrate_file_source(request: GenerateFileSourceRequest) -> GeneratedSo
 class FilesGeneratingSourcesField(MultipleSourcesField):
     required = True
     uses_source_roots = False
+    help = generate_multiple_sources_field_help_message(
+        "Example: `sources=['example.txt', 'new_*.md', '!old_ignore.csv']`"
+    )
 
 
 class FilesOverridesField(OverridesField):
@@ -431,6 +435,9 @@ async def hydrate_resource_source(request: GenerateResourceSourceRequest) -> Gen
 
 class ResourcesGeneratingSourcesField(MultipleSourcesField):
     required = True
+    help = generate_multiple_sources_field_help_message(
+        "Example: `sources=['example.txt', 'new_*.md', '!old_ignore.csv']`"
+    )
 
 
 class ResourcesOverridesField(OverridesField):

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -2779,6 +2779,19 @@ class OverridesField(AsyncFieldMixin, Field):
         return result
 
 
+def generate_multiple_sources_field_help_message(files_example: str) -> str:
+    return softwrap(
+        """
+        A list of files and globs that belong to this target.
+
+        Paths are relative to the BUILD file's directory. You can ignore files/globs by
+        prefixing them with `!`.
+
+        """
+        + files_example
+    )
+
+
 def generate_file_based_overrides_field_help_message(
     generated_target_name: str, example: str
 ) -> str:


### PR DESCRIPTION
Fixes #14711

I think this should keep things simple yet flexible enough to serve our needs. There is a helper function targets may use to construct a string with file examples.

The base class will still have `help` field with the generic message (including default file examples). If desired, individual targets may choose to use own file examples. 

I believe this is particularly helpful for Pants users who work with a single programming language because the help messages are tailored to their development environment semantics.

Please see the command and the outputs:

```
./pants help python_sources | grep -B 10 "Example:"
./pants help java_sources | grep -B 10 "Example:"
./pants help go_package | grep -B 10 "Example:"
./pants help scala_sources | grep -B 10 "Example:"
```

Output (Java, Python, Go has own file examples; Scala falls back on the base class examples):

```
sources
    type: Iterable[str] | None
    default: ('*.py', '*.pyi', '!test_*.py', '!*_test.py', '!tests.py', '!conftest.py', '!test_*.pyi', '!*_test.pyi', '!tests.pyi')

    A list of files and globs that belong to this target.
    
    Paths are relative to the BUILD file's directory. You can ignore files/globs by prefixing
    them with `!`.
    
    Example: `sources=['example.py', 'test_*.py', '!test_ignore.py']`.

sources
    type: Iterable[str] | None
    default: ('*.java', '!*Test.java')

    A list of files and globs that belong to this target.
    
    Paths are relative to the BUILD file's directory. You can ignore files/globs by prefixing
    them with `!`.
    
    Example: `sources=['Example.java', '*Test.java', '!TestIgnore.java']`.

sources
    type: Iterable[str] | None
    default: ('*.go', '*.s')

    A list of files and globs that belong to this target.
    
    Paths are relative to the BUILD file's directory. You can ignore files/globs by prefixing
    them with `!`.
    
    Example: `sources=['example.go', '*_test.go', '!test_ignore.go']`.

sources
    type: Iterable[str] | None
    default: ('*.scala', '!*Test.scala', '!*Spec.scala', '!*Suite.scala')

    A list of files and globs that belong to this target.
    
    Paths are relative to the BUILD file's directory. You can ignore files/globs by prefixing
    them with `!`.
    
    Example: `sources=['example.ext', 'test_*.ext', '!test_ignore.ext']`.

```

[ci skip-rust]
[ci skip-build-wheels]