### PR TITLE
Fix deprecation message for `--filter-target-type` with deprecated target alias

### DIFF
--- a/src/python/pants/backend/project_info/filter_targets_test.py
+++ b/src/python/pants/backend/project_info/filter_targets_test.py
@@ -5,181 +5,225 @@ from __future__ import annotations
 
 import re
 from textwrap import dedent
-from typing import Sequence
 
 import pytest
 
-from pants.backend.project_info.filter_targets import (
-    FilterSubsystem,
-    TargetGranularity,
-    filter_targets,
-)
-from pants.engine.addresses import Address
+from pants.backend.project_info import filter_targets
+from pants.backend.project_info.filter_targets import FilterGoal, TargetGranularity
+from pants.engine.rules import rule
 from pants.engine.target import (
-    RegisteredTargetTypes,
+    GeneratedTargets,
+    GenerateTargetsRequest,
+    MultipleSourcesField,
+    SingleSourceField,
     Tags,
     Target,
-    Targets,
+    TargetFilesGenerator,
+    TargetGenerator,
     UnrecognizedTargetTypeException,
 )
-from pants.testutil.option_util import create_goal_subsystem, create_options_bootstrapper
-from pants.testutil.rule_runner import mock_console, run_rule_with_mocks
+from pants.engine.unions import UnionRule
+from pants.testutil.rule_runner import RuleRunner, engine_error
 
 
 class MockTarget(Target):
     alias = "tgt"
     core_fields = (Tags,)
+    deprecated_alias = "deprecated_tgt"
+    deprecated_alias_removal_version = "99.9.0.dev0"
 
 
-def run_goal(
-    targets: Sequence[Target],
+class MockGeneratedFileTarget(Target):
+    alias = "file_generated"
+    core_fields = (SingleSourceField, Tags)
+
+
+class MockFileTargetGenerator(TargetFilesGenerator):
+    alias = "file_generator"
+    generated_target_cls = MockGeneratedFileTarget
+    core_fields = (MultipleSourcesField, Tags)
+    copied_fields = (Tags,)
+    moved_fields = ()
+
+
+class MockGeneratedNonfileTarget(Target):
+    alias = "nonfile_generated"
+    core_fields = (Tags,)
+
+
+class MockNonfileTargetGenerator(TargetGenerator):
+    alias = "nonfile_generator"
+    core_fields = (Tags,)
+    copied_fields = (Tags,)
+    moved_fields = ()
+
+
+class MockGenerateTargetsRequest(GenerateTargetsRequest):
+    generate_from = MockNonfileTargetGenerator
+
+
+@rule
+async def generate_mock_generated_target(request: MockGenerateTargetsRequest) -> GeneratedTargets:
+    return GeneratedTargets(
+        request.generator,
+        [
+            MockGeneratedNonfileTarget(
+                request.template, request.generator.address.create_generated("gen")
+            )
+        ],
+    )
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *filter_targets.rules(),
+            generate_mock_generated_target,
+            UnionRule(GenerateTargetsRequest, MockGenerateTargetsRequest),
+        ],
+        target_types=[MockTarget, MockFileTargetGenerator, MockNonfileTargetGenerator],
+    )
+
+
+def assert_targets(
+    rule_runner: RuleRunner,
+    expected: set[str],
     *,
     target_type: list[str] | None = None,
     address_regex: list[str] | None = None,
     tag_regex: list[str] | None = None,
-    granularity: TargetGranularity | None = None,
-    expect_stderr: bool = False,
-) -> str:
-    with mock_console(create_options_bootstrapper()) as (console, stdio_reader):
-        run_rule_with_mocks(
-            filter_targets,
-            rule_args=[
-                Targets(targets),
-                create_goal_subsystem(
-                    FilterSubsystem,
-                    sep="\\n",
-                    output_file=None,
-                    target_type=target_type or [],
-                    address_regex=address_regex or [],
-                    tag_regex=tag_regex or [],
-                    granularity=granularity or TargetGranularity.all_targets,
-                    # Deprecated.
-                    type=[],
-                    target=[],
-                    regex=[],
-                    ancestor=[],
-                ),
-                console,
-                RegisteredTargetTypes.create({type(tgt) for tgt in targets}),
-            ],
-        )
-        if expect_stderr:
-            assert stdio_reader.get_stderr()
-        else:
-            assert not stdio_reader.get_stderr()
-        return stdio_reader.get_stdout()
-
-
-def test_no_filters_provided() -> None:
-    # `filter` behaves like `list` when there are no specified filters. Note that it includes
-    # generated targets.
-    addresses = (
-        Address("", target_name="t2"),
-        Address("", target_name="t1"),
-        Address("", target_name="gen", relative_file_path="f.ext"),
-        Address("", target_name="gen", generated_name="foo"),
+    granularity: TargetGranularity = TargetGranularity.all_targets,
+) -> None:
+    result = rule_runner.run_goal_rule(
+        FilterGoal,
+        args=[
+            f"--target-type={target_type or []}",
+            f"--address-regex={address_regex or []}",
+            f"--tag-regex={tag_regex or []}",
+            f"--granularity={granularity.value}",
+            "::",
+        ],
     )
-    stdout = run_goal([MockTarget({}, addr) for addr in addresses])
-    assert stdout == dedent(
-        """\
-        //:gen#foo
-        //:t1
-        //:t2
-        //f.ext:gen
-        """
+    assert set(result.stdout.splitlines()) == expected
+
+
+def test_no_filters_provided(rule_runner: RuleRunner) -> None:
+    """When no filters, list all targets, like the `list` the goal.
+
+    Include target generators and generated targets.
+    """
+    rule_runner.write_files(
+        {
+            "f.txt": "",
+            "BUILD": dedent(
+                """\
+                tgt(name="tgt")
+                file_generator(name="file", sources=["f.txt"])
+                nonfile_generator(name="nonfile")
+                """
+            ),
+        }
+    )
+    assert_targets(
+        rule_runner, {"//:tgt", "//:file", "//f.txt:file", "//:nonfile", "//:nonfile#gen"}
     )
 
 
-def test_filter_by_target_type() -> None:
-    class Fortran(Target):
-        alias = "fortran"
-        core_fields = ()
-        deprecated_alias = "deprecated_fortran"
-        deprecated_alias_removal_version = "99.9.0.dev0"
+def test_filter_by_target_type(rule_runner: RuleRunner, caplog) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                """\
+                tgt(name="tgt")
+                nonfile_generator(name="nonfile")
+                """
+            ),
+        }
+    )
 
-    class Smalltalk(Target):
-        alias = "smalltalk"
-        core_fields = ()
-
-    fortran_targets = [Fortran({}, Address("", target_name=name)) for name in ("f1", "f2")]
-    smalltalk_targets = [Smalltalk({}, Address("", target_name=name)) for name in ("s1", "s2")]
-    targets = [*fortran_targets, *smalltalk_targets]
-
-    assert run_goal(targets, target_type=["fortran"]).strip() == "//:f1\n//:f2"
-    assert run_goal(targets, target_type=["+smalltalk"]).strip() == "//:s1\n//:s2"
-    assert run_goal(targets, target_type=["-smalltalk"]).strip() == "//:f1\n//:f2"
+    assert_targets(rule_runner, {"//:tgt"}, target_type=["tgt"])
+    assert_targets(rule_runner, {"//:nonfile"}, target_type=["+nonfile_generator"])
+    assert_targets(rule_runner, {"//:tgt", "//:nonfile#gen"}, target_type=["-nonfile_generator"])
     # The comma is inside the string, so these are ORed.
-    assert run_goal(targets, target_type=["fortran,smalltalk"]) == dedent(
-        """\
-        //:f1
-        //:f2
-        //:s1
-        //:s2
-        """
-    )
-
-    # The deprecated alias works too.
-    assert (
-        run_goal(targets, target_type=["deprecated_fortran"], expect_stderr=True).strip()
-        == "//:f1\n//:f2"
-    )
-
+    assert_targets(rule_runner, {"//:tgt", "//:nonfile"}, target_type=["tgt,nonfile_generator"])
     # A target can only have one type, so this output should be empty.
-    assert run_goal(targets, target_type=["fortran", "smalltalk"]) == ""
+    assert_targets(rule_runner, set(), target_type=["tgt", "nonfile_generator"])
 
-    with pytest.raises(UnrecognizedTargetTypeException):
-        run_goal(targets, target_type=["invalid"])
+    # Deprecated aliases works too.
+    caplog.clear()
+    assert_targets(rule_runner, {"//:tgt"}, target_type=["deprecated_tgt"])
+    assert caplog.records
+    assert "`--filter-target-type=deprecated_tgt`" in caplog.text
 
-
-def test_filter_by_address_regex() -> None:
-    targets = [
-        MockTarget({}, addr)
-        for addr in (
-            Address("dir1", target_name="lib"),
-            Address("dir2", target_name="lib"),
-            Address("common", target_name="tests"),
-        )
-    ]
-    assert run_goal(targets, address_regex=[r"^dir"]).strip() == "dir1:lib\ndir2:lib"
-    assert run_goal(targets, address_regex=[r"+dir1:lib$"]).strip() == "dir1:lib"
-    assert run_goal(targets, address_regex=["-dir"]).strip() == "common:tests"
-    # The comma ORs the regex.
-    assert run_goal(targets, address_regex=["dir1,common"]).strip() == "common:tests\ndir1:lib"
-    # This ANDs the regex.
-    assert run_goal(targets, address_regex=[r"^dir", "2:lib$"]).strip() == "dir2:lib"
-
-    # Invalid regex.
-    with pytest.raises(re.error):
-        run_goal(targets, tag_regex=["("])
+    with engine_error(UnrecognizedTargetTypeException):
+        assert_targets(rule_runner, set(), target_type=["invalid"])
 
 
-def test_filter_by_tag_regex() -> None:
-    targets = [
-        MockTarget({"tags": ["tag1"]}, Address("", target_name="t1")),
-        MockTarget({"tags": ["tag2"]}, Address("", target_name="t2")),
-        MockTarget({"tags": ["tag1", "tag2"]}, Address("", target_name="both")),
-        MockTarget({}, Address("", target_name="no_tags")),
-    ]
-    assert run_goal(targets, tag_regex=[r"t.?g2$"]).strip() == "//:both\n//:t2"
-    assert run_goal(targets, tag_regex=["+tag1"]).strip() == "//:both\n//:t1"
-    assert run_goal(targets, tag_regex=["-tag"]).strip() == "//:no_tags"
-    # The comma ORs the regex.
-    assert run_goal(targets, tag_regex=[r"t.?g2$,tag1"]).strip() == "//:both\n//:t1\n//:t2"
-    # This ANDs the regex.
-    assert run_goal(targets, tag_regex=[r"t.?g2$", "tag1"]).strip() == "//:both"
-
-    # Invalid regex.
-    with pytest.raises(re.error):
-        run_goal(targets, tag_regex=["("])
-
-
-def test_filter_by_granularity() -> None:
-    targets = [
-        MockTarget({}, Address("p1")),
-        MockTarget({}, Address("p1", relative_file_path="file.txt")),
-    ]
-    assert (
-        run_goal(targets, granularity=TargetGranularity.all_targets).strip() == "p1:p1\np1/file.txt"
+def test_filter_by_address_regex(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "dir1/BUILD": "tgt(name='lib')",
+            "dir2/BUILD": "tgt(name='lib')",
+            "common/BUILD": "tgt(name='tests')",
+        }
     )
-    assert run_goal(targets, granularity=TargetGranularity.build_targets).strip() == "p1:p1"
-    assert run_goal(targets, granularity=TargetGranularity.file_targets).strip() == "p1/file.txt"
+    assert_targets(rule_runner, {"dir1:lib", "dir2:lib"}, address_regex=[r"^dir"])
+    assert_targets(rule_runner, {"dir1:lib"}, address_regex=[r"+dir1:lib$"])
+    assert_targets(rule_runner, {"common:tests"}, address_regex=["-dir"])
+    # The comma ORs the regex.
+    assert_targets(rule_runner, {"common:tests", "dir1:lib"}, address_regex=["dir1,common"])
+    # This ANDs the regex.
+    assert_targets(rule_runner, {"dir2:lib"}, address_regex=[r"^dir", "2:lib$"])
+
+    # Invalid regex.
+    with engine_error(re.error):
+        assert_targets(rule_runner, set(), address_regex=["("])
+
+
+def test_filter_by_tag_regex(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                """\
+                tgt(name="no-tags")
+                tgt(name="t1", tags=["tag1"])
+                tgt(name="t2", tags=["tag2"])
+                tgt(name="both", tags=["tag1", "tag2"])
+                """
+            ),
+        }
+    )
+    assert_targets(rule_runner, {"//:both", "//:t2"}, tag_regex=[r"t.?g2$"])
+    assert_targets(rule_runner, {"//:both", "//:t1"}, tag_regex=["+tag1"])
+    assert_targets(rule_runner, {"//:no-tags"}, tag_regex=["-tag"])
+    # The comma ORs the regex.
+    assert_targets(rule_runner, {"//:both", "//:t1", "//:t2"}, tag_regex=[r"t.?g2$,tag1"])
+    # This ANDs the regex.
+    assert_targets(rule_runner, {"//:both"}, tag_regex=[r"t.?g2$", "tag1"])
+
+    # Invalid regex.
+    with engine_error(re.error):
+        assert_targets(rule_runner, set(), tag_regex=["("])
+
+
+def test_filter_by_granularity(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "f.txt": "",
+            "BUILD": dedent(
+                """\
+                tgt(name="tgt")
+                file_generator(name="file", sources=["f.txt"])
+                nonfile_generator(name="nonfile")
+                """
+            ),
+        }
+    )
+    file_targets = {"//f.txt:file"}
+    build_targets = {"//:tgt", "//:file", "//:nonfile", "//:nonfile#gen"}
+    assert_targets(
+        rule_runner, {*file_targets, *build_targets}, granularity=TargetGranularity.all_targets
+    )
+    assert_targets(rule_runner, file_targets, granularity=TargetGranularity.file_targets)
+    assert_targets(rule_runner, build_targets, granularity=TargetGranularity.build_targets)


### PR DESCRIPTION
This rewrites the tests for `filter_targets.py` to use `RuleRunner` rather than `run_goal_with_mocks`, which is necessary prework for getting the `--filter` options to work with any goal.

While rewriting, I discovered our logic for `--target-type` deprecations is invalid. We were inspecting the individual target, rather than the argument provided to `--target-type`.

[ci skip-rust]
[ci skip-build-wheels]