### PR TITLE
Tailor __main__.py files as pex binaries

### DIFF
--- a/src/python/pants/backend/python/goals/tailor.py
+++ b/src/python/pants/backend/python/goals/tailor.py
@@ -161,13 +161,14 @@ async def find_putative_targets(
     if python_setup.tailor_pex_binary_targets:
         # Find binary targets.
 
-        # Get all files whose content indicates that they are entry points.
+        # Get all files whose content indicates that they are entry points or are __main__.py files.
         digest_contents = await Get(DigestContents, PathGlobs, all_py_files_globs)
+        all_main_py = await Get(Paths, PathGlobs, req.search_paths.path_globs("__main__.py"))
         entry_points = [
             file_content.path
             for file_content in digest_contents
             if is_entry_point(file_content.content)
-        ]
+        ] + list(all_main_py.files)
 
         # Get the modules for these entry points.
         src_roots = await Get(

--- a/src/python/pants/backend/python/goals/tailor.py
+++ b/src/python/pants/backend/python/goals/tailor.py
@@ -164,7 +164,6 @@ async def find_putative_targets(
         # Get all files whose content indicates that they are entry points or are __main__.py files.
         digest_contents = await Get(DigestContents, PathGlobs, all_py_files_globs)
         all_main_py = await Get(Paths, PathGlobs, req.search_paths.path_globs("__main__.py"))
-        print(all_main_py)
         entry_points = [
             file_content.path
             for file_content in digest_contents

--- a/src/python/pants/backend/python/goals/tailor.py
+++ b/src/python/pants/backend/python/goals/tailor.py
@@ -164,6 +164,7 @@ async def find_putative_targets(
         # Get all files whose content indicates that they are entry points or are __main__.py files.
         digest_contents = await Get(DigestContents, PathGlobs, all_py_files_globs)
         all_main_py = await Get(Paths, PathGlobs, req.search_paths.path_globs("__main__.py"))
+        print(all_main_py)
         entry_points = [
             file_content.path
             for file_content in digest_contents

--- a/src/python/pants/backend/python/goals/tailor_test.py
+++ b/src/python/pants/backend/python/goals/tailor_test.py
@@ -199,7 +199,7 @@ def test_find_putative_targets_subset(rule_runner: RuleRunner) -> None:
 
 
 def test_find_putative_targets_for_entry_points(rule_runner: RuleRunner) -> None:
-    mains = ("main1.py", "main2.py", "main3.py", "__main__.py")
+    mains = ("main1.py", "main2.py", "main3.py")
     rule_runner.write_files(
         {
             f"src/python/foo/{name}": textwrap.dedent(
@@ -217,13 +217,16 @@ def test_find_putative_targets_for_entry_points(rule_runner: RuleRunner) -> None
                 "pex_binary(name='main1', entry_point='main1.py')\n"
                 "pex_binary(name='main2', entry_point='foo.main2')\n"
             ),
+            "src/python/foo/__main__.py": "",
         }
     )
     pts = rule_runner.request(
         PutativeTargets,
         [
             PutativePythonTargetsRequest(PutativeTargetsSearchPaths(("",))),
-            AllOwnedSources([f"src/python/foo/{name}" for name in mains]),
+            AllOwnedSources(
+                [f"src/python/foo/{name}" for name in mains] + ["src/python/foo/__main__.py"]
+            ),
         ],
     )
     assert (

--- a/src/python/pants/backend/python/goals/tailor_test.py
+++ b/src/python/pants/backend/python/goals/tailor_test.py
@@ -199,7 +199,7 @@ def test_find_putative_targets_subset(rule_runner: RuleRunner) -> None:
 
 
 def test_find_putative_targets_for_entry_points(rule_runner: RuleRunner) -> None:
-    mains = ("main1.py", "main2.py", "main3.py")
+    mains = ("main1.py", "main2.py", "main3.py", "__main__.py")
     rule_runner.write_files(
         {
             f"src/python/foo/{name}": textwrap.dedent(
@@ -235,6 +235,13 @@ def test_find_putative_targets_for_entry_points(rule_runner: RuleRunner) -> None
                     "main3",
                     [],
                     kwargs={"entry_point": "main3.py"},
+                ),
+                PutativeTarget.for_target_type(
+                    PexBinary,
+                    "src/python/foo",
+                    "__main__",
+                    [],
+                    kwargs={"entry_point": "__main__.py"},
                 ),
             ]
         )

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -450,8 +450,8 @@ class PythonSetup(Subsystem):
         default=True,
         help=softwrap(
             """
-            If true, add `pex_binary` targets for Python files with a `__main__` clause with the
-            `tailor` goal.
+            If true, add `pex_binary` targets for Python files named `__main__.py` or with a
+            `__main__` clause with the `tailor` goal.
             """
         ),
         advanced=True,


### PR DESCRIPTION
Fixes #15295 by doing what it says on the tin.

[ci skip-rust]