### PR TITLE
`filter` options work with any goal now, not only the `filter` goal

### DIFF
--- a/src/python/pants/backend/project_info/filter_targets_test.py
+++ b/src/python/pants/backend/project_info/filter_targets_test.py
@@ -8,8 +8,9 @@ from textwrap import dedent
 
 import pytest
 
-from pants.backend.project_info import filter_targets
+from pants.backend.project_info import filter_targets, list_targets
 from pants.backend.project_info.filter_targets import FilterGoal, TargetGranularity
+from pants.backend.project_info.list_targets import List
 from pants.engine.rules import rule
 from pants.engine.target import (
     GeneratedTargets,
@@ -79,6 +80,7 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *filter_targets.rules(),
+            *list_targets.rules(),
             generate_mock_generated_target,
             UnionRule(GenerateTargetsRequest, MockGenerateTargetsRequest),
         ],
@@ -95,7 +97,7 @@ def assert_targets(
     tag_regex: list[str] | None = None,
     granularity: TargetGranularity = TargetGranularity.all_targets,
 ) -> None:
-    result = rule_runner.run_goal_rule(
+    filter_result = rule_runner.run_goal_rule(
         FilterGoal,
         args=[
             f"--target-type={target_type or []}",
@@ -105,7 +107,20 @@ def assert_targets(
             "::",
         ],
     )
-    assert set(result.stdout.splitlines()) == expected
+    assert set(filter_result.stdout.splitlines()) == expected
+
+    # Also run with `list` to prove that the filters work from any goal.
+    list_result = rule_runner.run_goal_rule(
+        List,
+        global_args=[
+            f"--filter-target-type={target_type or []}",
+            f"--filter-address-regex={address_regex or []}",
+            f"--filter-tag-regex={tag_regex or []}",
+            f"--filter-granularity={granularity.value}",
+            "::",
+        ],
+    )
+    assert set(list_result.stdout.splitlines()) == expected
 
 
 def test_no_filters_provided(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, DefaultDict
 
+from pants.backend.project_info.filter_targets import FilterSubsystem
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.goal import GoalSubsystem
 from pants.engine.rules import Rule, RuleIndex
@@ -32,7 +33,7 @@ _RESERVED_NAMES = {"api-types", "global", "goals", "subsystems", "targets", "too
 
 
 # Subsystems used outside of any rule.
-_GLOBAL_SUBSYSTEMS: set[type[Subsystem]] = {GlobalOptions, Changed, CliOptions}
+_GLOBAL_SUBSYSTEMS: set[type[Subsystem]] = {GlobalOptions, Changed, CliOptions, FilterSubsystem}
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/engine/internals/mapper_test.py
+++ b/src/python/pants/engine/internals/mapper_test.py
@@ -7,6 +7,7 @@ from textwrap import dedent
 
 import pytest
 
+from pants.backend.project_info.filter_targets import FilterSubsystem, TargetGranularity
 from pants.build_graph.address import Address
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.internals.mapper import (
@@ -18,7 +19,8 @@ from pants.engine.internals.mapper import (
 )
 from pants.engine.internals.parser import BuildFilePreludeSymbols, Parser
 from pants.engine.internals.target_adaptor import TargetAdaptor
-from pants.engine.target import Tags, Target
+from pants.engine.target import RegisteredTargetTypes, Tags, Target
+from pants.testutil.option_util import create_goal_subsystem
 from pants.util.frozendict import FrozenDict
 
 
@@ -131,23 +133,44 @@ def test_address_family_duplicate_names() -> None:
 
 
 def test_specs_filter() -> None:
-    specs_filter = SpecsFilter.create(tags=["-a", "+b"], exclude_target_regexps=["skip-me"])
-
-    class MockTgt(Target):
-        alias = "tgt"
+    class MockTgt1(Target):
+        alias = "tgt1"
         core_fields = (Tags,)
 
-    def make_tgt(name: str, tags: list[str] | None = None) -> MockTgt:
-        return MockTgt({Tags.alias: tags}, Address("", target_name=name))
+    class MockTgt2(Target):
+        alias = "tgt2"
+        core_fields = (Tags,)
 
-    untagged_tgt = make_tgt(name="untagged")
-    b_tagged_tgt = make_tgt(name="b-tagged", tags=["b"])
-    b_tagged_exclude_regex_tgt = make_tgt(name="skip-me", tags=["b"])
-    a_and_b_tagged_tgt = make_tgt(name="a-and-b-tagged", tags=["a", "b"])
+    specs_filter = SpecsFilter.create(
+        create_goal_subsystem(
+            FilterSubsystem,
+            target_type=["tgt1"],
+            tag_regex=[],
+            address_regex=[],
+            granularity=TargetGranularity.all_targets,
+        ),
+        RegisteredTargetTypes({"tgt1": MockTgt1, "tgt2": MockTgt2}),
+        tags=["-a", "+b"],
+        exclude_target_regexps=["skip-me"],
+    )
 
-    def matches(tgt: MockTgt) -> bool:
+    def make_tgt1(name: str, tags: list[str] | None = None) -> MockTgt1:
+        return MockTgt1({Tags.alias: tags}, Address("", target_name=name))
+
+    def make_tgt2(name: str, tags: list[str] | None = None) -> MockTgt2:
+        return MockTgt2({Tags.alias: tags}, Address("", target_name=name))
+
+    untagged_tgt = make_tgt1(name="untagged")
+    b_tagged_tgt = make_tgt1(name="b-tagged", tags=["b"])
+    b_tagged_exclude_regex_tgt = make_tgt1(name="skip-me", tags=["b"])
+    a_and_b_tagged_tgt = make_tgt1(name="a-and-b-tagged", tags=["a", "b"])
+
+    # Even though this has the tag `b`, it should be excluded because the target type.
+    tgt2 = make_tgt2("tgt2", tags=["b"])
+
+    def matches(tgt: Target) -> bool:
         return specs_filter.matches(tgt)
 
     assert matches(b_tagged_tgt) is True
-    for t in (untagged_tgt, b_tagged_exclude_regex_tgt, a_and_b_tagged_tgt):
+    for t in (untagged_tgt, b_tagged_exclude_regex_tgt, a_and_b_tagged_tgt, tgt2):
         assert matches(t) is False

--- a/src/python/pants/engine/internals/specs_rules.py
+++ b/src/python/pants/engine/internals/specs_rules.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 from pathlib import PurePath
 from typing import Iterable
 
+from pants.backend.project_info.filter_targets import FilterSubsystem
 from pants.base.specs import (
     AddressLiteralSpec,
     AncestorGlobSpec,
@@ -229,9 +230,16 @@ def filter_targets(targets: Targets, specs_filter: SpecsFilter) -> FilteredTarge
 
 
 @rule
-def setup_specs_filter(global_options: GlobalOptions) -> SpecsFilter:
+def setup_specs_filter(
+    global_options: GlobalOptions,
+    filter_subsystem: FilterSubsystem,
+    registered_target_types: RegisteredTargetTypes,
+) -> SpecsFilter:
     return SpecsFilter.create(
-        tags=global_options.tag, exclude_target_regexps=global_options.exclude_target_regexp
+        filter_subsystem,
+        registered_target_types,
+        tags=global_options.tag,
+        exclude_target_regexps=global_options.exclude_target_regexp,
     )
 
 


### PR DESCRIPTION
Before: `./pants filter --target-type=python_test :: | xargs ./pants test`
After: `./pants --filter-target-type=python_test ::`

A follow-up will deprecate the `filter` goal, which is now virtually identical to `list`.

[ci skip-rust]