### PR TITLE
Deprecate `filter` goal now that `filter` options can be used from any goal

### DIFF
--- a/src/python/pants/backend/project_info/filter_targets.py
+++ b/src/python/pants/backend/project_info/filter_targets.py
@@ -159,7 +159,7 @@ def filter_targets(
         "using `filter` as a goal",
         softwrap(
             f"""
-            You can now specify `filter` arguments with any goal, e.g. `{bin_name()} 
+            You can now specify `filter` arguments with any goal, e.g. `{bin_name()}
             --filter-target-type=python_test test ::`.
 
             This means that the `filter` goal is now identical to `list`. For example, rather than

--- a/src/python/pants/backend/project_info/filter_targets.py
+++ b/src/python/pants/backend/project_info/filter_targets.py
@@ -14,6 +14,7 @@ from pants.engine.goal import Goal, GoalSubsystem, LineOriented
 from pants.engine.rules import collect_rules, goal_rule
 from pants.engine.target import RegisteredTargetTypes, Tags, Target, UnrecognizedTargetTypeException
 from pants.option.option_types import EnumOption, StrListOption
+from pants.util.docutil import bin_name
 from pants.util.enums import match
 from pants.util.filtering import TargetFilter, and_filters, create_filters
 from pants.util.memo import memoized
@@ -153,6 +154,25 @@ def warn_deprecated_target_type(tgt_type: type[Target]) -> None:
 def filter_targets(
     addresses: Addresses, filter_subsystem: FilterSubsystem, console: Console
 ) -> FilterGoal:
+    warn_or_error(
+        "2.14.0.dev0",
+        "using `filter` as a goal",
+        softwrap(
+            f"""
+            You can now specify `filter` arguments with any goal, e.g. `{bin_name()} 
+            --filter-target-type=python_test test ::`.
+
+            This means that the `filter` goal is now identical to `list`. For example, rather than
+            `{bin_name()} filter --target-type=python_test ::`, use
+            `{bin_name()} --filter-target-type=python_test list ::`.
+
+            Often, the `filter` goal was combined with `xargs` to build pipelines of commands. You
+            can often now simplify those to a single command. Rather than `{bin_name()} filter
+            --target-type=python_test filter :: | xargs {bin_name()} test`, simply use
+            `{bin_name()} --filter-target-type=python_test test ::`.
+            """
+        ),
+    )
     # `SpecsFilter` will have already filtered for us. There isn't much reason for this goal to
     # exist anymore.
     with filter_subsystem.line_oriented(console) as print_stdout:

--- a/src/python/pants/engine/internals/specs_rules.py
+++ b/src/python/pants/engine/internals/specs_rules.py
@@ -357,7 +357,7 @@ class NoApplicableTargetsException(Exception):
         )
         if filedeps_goal_works:
             remedy += (
-                f", or run `{pants_filter_command} filedeps ::` to find all " "applicable files."
+                f", or run `{pants_filter_command} filedeps ::` to find all applicable files."
             )
         else:
             remedy += "."

--- a/src/python/pants/engine/internals/specs_rules.py
+++ b/src/python/pants/engine/internals/specs_rules.py
@@ -356,9 +356,7 @@ class NoApplicableTargetsException(Exception):
             f"list ::` to find all applicable targets in your project"
         )
         if filedeps_goal_works:
-            remedy += (
-                f", or run `{pants_filter_command} filedeps ::` to find all applicable files."
-            )
+            remedy += f", or run `{pants_filter_command} filedeps ::` to find all applicable files."
         else:
             remedy += "."
         msg += remedy

--- a/src/python/pants/engine/internals/specs_rules.py
+++ b/src/python/pants/engine/internals/specs_rules.py
@@ -349,16 +349,15 @@ class NoApplicableTargetsException(Exception):
             tgt.class_has_field(SourcesField, union_membership) for tgt in applicable_target_types
         )
         pants_filter_command = (
-            f"{bin_name()} filter --target-type={','.join(applicable_target_aliases)} ::"
+            f"{bin_name()} --filter-target-type={','.join(applicable_target_aliases)}"
         )
         remedy = (
-            f"Please specify relevant file and/or target arguments. Run `{pants_filter_command}` to "
-            "find all applicable targets in your project"
+            f"Please specify relevant file and/or target arguments. Run `{pants_filter_command} "
+            f"list ::` to find all applicable targets in your project"
         )
         if filedeps_goal_works:
             remedy += (
-                f", or run `{pants_filter_command} | xargs {bin_name()} filedeps` to find all "
-                "applicable files."
+                f", or run `{pants_filter_command} filedeps ::` to find all " "applicable files."
             )
         else:
             remedy += "."

--- a/src/python/pants/engine/internals/specs_rules_test.py
+++ b/src/python/pants/engine/internals/specs_rules_test.py
@@ -993,9 +993,9 @@ def test_no_applicable_targets_exception() -> None:
         goal_description="the `foo` goal",
     )
     remedy = (
-        "Please specify relevant file and/or target arguments. Run `./pants filter "
-        "--target-type=tgt1,tgt2 ::` to find all applicable targets in your project, or run "
-        "`./pants filter --target-type=tgt1,tgt2 :: | xargs ./pants filedeps` to find all "
+        "Please specify relevant file and/or target arguments. Run `./pants "
+        "--filter-target-type=tgt1,tgt2 list ::` to find all applicable targets in your project, "
+        "or run `./pants --filter-target-type=tgt1,tgt2 filedeps ::` to find all "
         "applicable files."
     )
     assert (

--- a/src/python/pants/engine/internals/specs_rules_test.py
+++ b/src/python/pants/engine/internals/specs_rules_test.py
@@ -969,8 +969,8 @@ def test_no_applicable_targets_exception() -> None:
         goal_description="the `foo` goal",
     )
     remedy = (
-        "Please specify relevant file and/or target arguments. Run `./pants filter "
-        "--target-type=tgt1 ::` to find all applicable targets in your project."
+        "Please specify relevant file and/or target arguments. Run `./pants "
+        "--filter-target-type=tgt1 list ::` to find all applicable targets in your project."
     )
     assert (
         dedent(

--- a/src/python/pants/init/specs_calculator.py
+++ b/src/python/pants/init/specs_calculator.py
@@ -43,7 +43,7 @@ def calculate_specs(
             "`use_deprecated_directory_cli_args_semantics` defaulting to True",
             softwrap(
                 f"""
-                Currently, a directory argument like `{bin_name} test dir` is shorthand for the
+                Currently, a directory argument like `{bin_name()} test dir` is shorthand for the
                 target `dir:dir`, i.e. the target that leaves off `name=`.
 
                 In Pants 2.14, by default, a directory argument will instead match all


### PR DESCRIPTION
We want to avoid a proliferation of goals, which means fewer APIs for users to learn (a good thing).

[ci skip-rust]
[ci skip-build-wheels]