### PR TITLE
`lint` only finds targets and files if the relevant linters were specified (Cherry-pick of #15579)

### DIFF
--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -8,6 +8,7 @@ import logging
 from dataclasses import dataclass
 from typing import Any, ClassVar, Iterable, Iterator, Type, TypeVar, cast
 
+from pants.base.specs import Specs
 from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.core.goals.style_request import (
     StyleRequest,
@@ -250,8 +251,7 @@ def _get_error_code(results: tuple[LintResults, ...]) -> int:
 async def lint(
     console: Console,
     workspace: Workspace,
-    targets: FilteredTargets,
-    specs_snapshot: SpecsSnapshot,
+    specs: Specs,
     lint_subsystem: LintSubsystem,
     union_membership: UnionMembership,
     dist_dir: DistDir,
@@ -271,10 +271,7 @@ async def lint(
     specified_names = determine_specified_tool_names(
         "lint",
         lint_subsystem.only,
-        [
-            *lint_target_request_types,
-            *fmt_target_request_types,
-        ],
+        [*lint_target_request_types, *fmt_target_request_types],
         extra_valid_names={request.name for request in file_request_types},
     )
 
@@ -284,6 +281,14 @@ async def lint(
     lint_target_request_types = filter(is_specified, lint_target_request_types)
     fmt_target_request_types = filter(is_specified, fmt_target_request_types)
     file_request_types = filter(is_specified, file_request_types)
+
+    _get_targets = Get(
+        FilteredTargets,
+        Specs,
+        specs if lint_target_request_types or fmt_target_request_types else Specs(),
+    )
+    _get_specs_snapshot = Get(SpecsSnapshot, Specs, specs if file_request_types else Specs())
+    targets, specs_snapshot = await MultiGet(_get_targets, _get_specs_snapshot)
 
     def batch(field_sets: Iterable[FieldSet]) -> Iterator[list[FieldSet]]:
         partitions = partition_sequentially(

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -285,9 +285,9 @@ async def lint(
     _get_targets = Get(
         FilteredTargets,
         Specs,
-        specs if lint_target_request_types or fmt_target_request_types else Specs(),
+        specs if lint_target_request_types or fmt_target_request_types else Specs.empty(),
     )
-    _get_specs_snapshot = Get(SpecsSnapshot, Specs, specs if file_request_types else Specs())
+    _get_specs_snapshot = Get(SpecsSnapshot, Specs, specs if file_request_types else Specs.empty())
     targets, specs_snapshot = await MultiGet(_get_targets, _get_specs_snapshot)
 
     def batch(field_sets: Iterable[FieldSet]) -> Iterator[list[FieldSet]]:

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -182,7 +182,7 @@ def run_lint_rule(
             rule_args=[
                 console,
                 Workspace(rule_runner.scheduler, _enforce_effects=False),
-                Specs(),
+                Specs.empty(),
                 lint_subsystem,
                 union_membership,
                 DistDir(relpath=Path("dist")),

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -11,6 +11,7 @@ from typing import Iterable, Optional, Sequence, Tuple, Type
 
 import pytest
 
+from pants.base.specs import Specs
 from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.core.goals.lint import (
     AmbiguousRequestNamesError,
@@ -27,7 +28,7 @@ from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import SpecsSnapshot, Workspace
 from pants.engine.internals.native_engine import EMPTY_DIGEST, EMPTY_SNAPSHOT, Digest, Snapshot
-from pants.engine.target import FieldSet, MultipleSourcesField, Target, Targets
+from pants.engine.target import FieldSet, FilteredTargets, MultipleSourcesField, Target
 from pants.engine.unions import UnionMembership
 from pants.testutil.option_util import create_goal_subsystem
 from pants.testutil.rule_runner import MockGet, RuleRunner, mock_console, run_rule_with_mocks
@@ -175,15 +176,13 @@ def run_lint_rule(
         batch_size=batch_size,
         only=only or [],
     )
-    specs_snapshot = SpecsSnapshot(rule_runner.make_snapshot_of_empty_files(["f.txt"]))
     with mock_console(rule_runner.options_bootstrapper) as (console, stdio_reader):
         result: Lint = run_rule_with_mocks(
             lint,
             rule_args=[
                 console,
                 Workspace(rule_runner.scheduler, _enforce_effects=False),
-                Targets(targets),
-                specs_snapshot,
+                Specs(),
                 lint_subsystem,
                 union_membership,
                 DistDir(relpath=Path("dist")),
@@ -208,6 +207,18 @@ def run_lint_rule(
                     output_type=FmtResult,
                     input_type=FmtRequest,
                     mock=lambda mock_request: mock_request.fmt_result,
+                ),
+                MockGet(
+                    output_type=FilteredTargets,
+                    input_type=Specs,
+                    mock=lambda _: FilteredTargets(targets),
+                ),
+                MockGet(
+                    output_type=SpecsSnapshot,
+                    input_type=Specs,
+                    mock=lambda _: SpecsSnapshot(
+                        rule_runner.make_snapshot_of_empty_files(["f.txt"])
+                    ),
                 ),
             ],
             union_membership=union_membership,


### PR DESCRIPTION
Before:

```
❯ hyperfine -w 1 -r 5 './pants --no-pantsd lint --only=docformatter ::'
Benchmark 1: ./pants --no-pantsd lint --only=docformatter ::
  Time (mean ± σ):      6.907 s ±  0.651 s    [User: 5.204 s, System: 0.876 s]
  Range (min … max):    6.299 s …  7.950 s    5 runs
```

After:

```
❯ hyperfine -w 1 -r 5 './pants --no-pantsd lint --only=docformatter ::'
Benchmark 1: ./pants --no-pantsd lint --only=docformatter ::
  Time (mean ± σ):      6.478 s ±  0.111 s    [User: 4.995 s, System: 0.779 s]
  Range (min … max):    6.369 s …  6.666 s    5 runs
```

[ci skip-rust]
[ci skip-build-wheels]