### PR TITLE
Don't give a subsequent formatter an empty snapshot after skipping (Cherry-pick of #15483)

### DIFF
--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -286,7 +286,8 @@ async def fmt_language(language_fmt_request: _LanguageFmtRequest) -> _LanguageFm
             continue
         result = await Get(FmtResult, FmtRequest, request)
         results.append(result)
-        prior_formatter_result = result.output
+        if not result.skipped:
+            prior_formatter_result = result.output
     return _LanguageFmtResults(
         tuple(results),
         input=original_sources.snapshot.digest,


### PR DESCRIPTION
Fixes #15406 by not piping a skipped formatter result into the next formatter.

[ci skip-rust]
[ci skip-build-wheels]