### PR TITLE
Have `generate_docs` error on bad pantsbuild URLs (Cherry-pick of #15592)

### DIFF
--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -40,6 +40,8 @@ from pants.version import MAJOR_MINOR
 
 logger = logging.getLogger(__name__)
 
+DOC_URL_RE = re.compile(r"https://www.pantsbuild.org/v(\d+\.[^/]+)/docs/(?P<slug>[a-zA-Z0-9_-]+)")
+
 
 def main() -> None:
     logging.basicConfig(format="[%(levelname)s]: %(message)s", level=logging.INFO)
@@ -50,17 +52,21 @@ def main() -> None:
 
     version = determine_pants_version(args.no_prompt)
     help_info = run_pants_help_all()
-    doc_urls = DocUrlMatcher().find_doc_urls(value_strs_iter(help_info))
+    doc_urls = find_doc_urls(value_strs_iter(help_info))
     logger.info("Found the following docsite URLs:")
     for url in sorted(doc_urls):
         logger.info(f"  {url}")
-    logger.info("Fetching titles...")
-    slug_to_title = get_titles(doc_urls)
-    logger.info("Found the following titles:")
-    for slug, title in sorted(slug_to_title.items()):
-        logger.info(f"  {slug}: {title}")
-    rewritten_help_info = rewrite_value_strs(help_info, slug_to_title)
-    generator = ReferenceGenerator(args, version, rewritten_help_info)
+
+    if not args.skip_check_urls:
+        logger.info("Fetching titles...")
+        slug_to_title = get_titles(doc_urls)
+        logger.info("Found the following titles:")
+        for slug, title in sorted(slug_to_title.items()):
+            logger.info(f"  {slug}: {title}")
+
+        help_info = rewrite_value_strs(help_info, slug_to_title)
+
+    generator = ReferenceGenerator(args, version, help_info)
     if args.sync:
         generator.sync()
     else:
@@ -86,29 +92,21 @@ def determine_pants_version(no_prompt: bool) -> str:
 
 # Code to replace doc urls with appropriate markdown, for rendering on the docsite.
 
-_doc_url_pattern = r"https://www.pantsbuild.org/v(\d+\.[^/]+)/docs/(?P<slug>[a-zA-Z0-9_-]+)"
+
+def get_doc_slug(url: str) -> str:
+    mo = DOC_URL_RE.match(url)
+    if not mo:
+        raise ValueError(f"Not a docsite URL: {url}")
+    return cast(str, mo.group("slug"))
 
 
-class DocUrlMatcher:
-    """Utilities for regex matching docsite URLs."""
-
-    def __init__(self):
-        self._doc_url_re = re.compile(_doc_url_pattern)
-
-    def slug_for_url(self, url: str) -> str:
-        mo = self._doc_url_re.match(url)
-        if not mo:
-            raise ValueError(f"Not a docsite URL: {url}")
-        return cast(str, mo.group("slug"))
-
-    def find_doc_urls(self, strs: Iterable[str]) -> set[str]:
-        """Find all the docsite urls in the given strings."""
-        return {mo.group(0) for s in strs for mo in self._doc_url_re.finditer(s)}
+def find_doc_urls(strs: Iterable[str]) -> set[str]:
+    """Find all the docsite urls in the given strings."""
+    return {mo.group(0) for s in strs for mo in DOC_URL_RE.finditer(s)}
 
 
 class DocUrlRewriter:
     def __init__(self, slug_to_title: dict[str, str]):
-        self._doc_url_re = re.compile(_doc_url_pattern)
         self._slug_to_title = slug_to_title
 
     def _rewrite_url(self, mo: re.Match) -> str:
@@ -121,7 +119,7 @@ class DocUrlRewriter:
         return f"[{title}](doc:{slug})"
 
     def rewrite(self, s: str) -> str:
-        return self._doc_url_re.sub(self._rewrite_url, s)
+        return DOC_URL_RE.sub(self._rewrite_url, s)
 
 
 class TitleFinder(HTMLParser):
@@ -145,29 +143,38 @@ class TitleFinder(HTMLParser):
             self._title = data.strip()
 
     @property
-    def title(self) -> str | None:
-        return self._title
+    def title(self) -> str:
+        return self._title or ""
 
 
-def get_title_from_page_content(page_content: str) -> str:
-    title_finder = TitleFinder()
-    title_finder.feed(page_content)
-    return title_finder.title or ""
+def get_url(url: str):
+    response = requests.get(url)
+    if response.status_code != 200:
+        die(
+            softwrap(
+                f"""
+                Error getting URL: {url}
 
+                If the URL is pantsbuild.org, a `doc_url` link might be using the wrong slug or the
+                docs for this version might be unpublished. Otherwise, the link might be dead.
 
-def get_title(url: str) -> str:
-    return get_title_from_page_content(requests.get(url).text)
+                You can use `--skip-check-urls` to skip.
+                """
+            )
+        )
+    return response
 
 
 def get_titles(urls: set[str]) -> dict[str, str]:
     """Return map from slug->title for each given docsite URL."""
 
-    matcher = DocUrlMatcher()
     # TODO: Parallelize the http requests.
     #  E.g., by turning generate_docs.py into a plugin goal and using the engine.
     ret = {}
     for url in urls:
-        ret[matcher.slug_for_url(url)] = get_title(url)
+        title_finder = TitleFinder()
+        title_finder.feed(get_url(url).text)
+        ret[get_doc_slug(url)] = title_finder.title
     return ret
 
 
@@ -196,6 +203,12 @@ def create_parser() -> argparse.ArgumentParser:
         "the renderer.",
     )
     parser.add_argument("--api-key", help="The readme.io API key to use. Required for --sync.")
+    parser.add_argument(
+        "--skip-check-urls",
+        action="store_true",
+        default=False,
+        help="Skip checking URLs (including pantsbuild.org ones).",
+    )
     return parser
 
 

--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -36,6 +36,7 @@ from readme_api import DocRef, ReadmeAPI
 
 from pants.base.build_environment import get_buildroot, get_pants_cachedir
 from pants.help.help_info_extracter import to_help_str
+from pants.util.strutil import softwrap
 from pants.version import MAJOR_MINOR
 
 logger = logging.getLogger(__name__)

--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -98,7 +98,7 @@ def get_doc_slug(url: str) -> str:
     mo = DOC_URL_RE.match(url)
     if not mo:
         raise ValueError(f"Not a docsite URL: {url}")
-    return cast(str, mo.group("slug"))
+    return mo.group("slug")
 
 
 def find_doc_urls(strs: Iterable[str]) -> set[str]:

--- a/build-support/bin/generate_docs_test.py
+++ b/build-support/bin/generate_docs_test.py
@@ -4,12 +4,7 @@
 import textwrap
 
 import pytest
-from generate_docs import (
-    DocUrlMatcher,
-    DocUrlRewriter,
-    get_title_from_page_content,
-    value_strs_iter,
-)
+from generate_docs import DocUrlRewriter, TitleFinder, find_doc_urls, get_doc_slug, value_strs_iter
 
 from pants.util.docutil import doc_url
 
@@ -27,23 +22,22 @@ def test_gather_value_strs():
 
 @pytest.mark.parametrize("slug", ["foo-bar", "baz3", "qux"])
 def test_slug_for_url(slug: str) -> None:
-    assert DocUrlMatcher().slug_for_url(doc_url(slug)) == slug
+    assert get_doc_slug(doc_url(slug)) == slug
 
 
 def test_slug_for_url_error() -> None:
     with pytest.raises(ValueError) as excinfo:
-        DocUrlMatcher().slug_for_url("https://notthedocsite.com/v2.6/foobar")
+        get_doc_slug("https://notthedocsite.com/v2.6/foobar")
     assert "Not a docsite URL" in str(excinfo.value)
 
 
 def test_find_doc_urls() -> None:
-    matcher = DocUrlMatcher()
     strs = [
         f"See {doc_url('foo-bar')} for details.",
         f"See {doc_url('qux')}.",  # Don't capture trailing dot.
         f"See {doc_url('foo-bar')} and {doc_url('baz3')}",  # Multiple urls in string.
     ]
-    assert matcher.find_doc_urls(strs) == {doc_url(slug) for slug in ["foo-bar", "baz3", "qux"]}
+    assert find_doc_urls(strs) == {doc_url(slug) for slug in ["foo-bar", "baz3", "qux"]}
 
 
 def test_get_title_from_page_content():
@@ -59,7 +53,9 @@ def test_get_title_from_page_content():
       <body>Welcome to Pants, the ergonomic build system!</body>
     """
     )
-    assert get_title_from_page_content(page_content) == "Welcome to Pants!"
+    title_finder = TitleFinder()
+    title_finder.feed(page_content)
+    assert title_finder.title == "Welcome to Pants!"
 
 
 def test_doc_url_rewriter():

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -25,7 +25,7 @@ from pants.util.docutil import doc_url, git_url
 
 class PythonProtobufSubsystem(Subsystem):
     options_scope = "python-protobuf"
-    help = f"Options related to the Protobuf Python backend.\n\nSee {doc_url('protobuf')}."
+    help = f"Options related to the Protobuf Python backend.\n\nSee {doc_url('protobuf-python')}."
 
     mypy_plugin = BoolOption(
         "--mypy-plugin",

--- a/src/python/pants/backend/codegen/protobuf/target_types.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types.py
@@ -63,7 +63,9 @@ class ProtobufSourceTarget(Target):
     )
     help = (
         "A single Protobuf file used to generate various languages.\n\n"
-        f"See {doc_url('protobuf')}."
+        f"See language-specific docs:\n"
+        f"    Python: {doc_url('protobuf-python')}\n"
+        f"    Go: {doc_url('protobuf-go')}"
     )
 
 

--- a/src/python/pants/backend/codegen/thrift/target_types.py
+++ b/src/python/pants/backend/codegen/thrift/target_types.py
@@ -67,7 +67,10 @@ class ThriftSourceTarget(Target):
         ThriftDependenciesField,
         ThriftSourceField,
     )
-    help = f"A single Thrift file used to generate various languages.\n\nSee {doc_url('thrift')}."
+    help = (
+        "A single Thrift file used to generate various languages.\n\n"
+        f"See {doc_url('thrift-python')}."
+    )
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/backend/google_cloud_function/python/target_types.py
+++ b/src/python/pants/backend/google_cloud_function/python/target_types.py
@@ -247,7 +247,7 @@ class PythonGoogleCloudFunction(Target):
     )
     help = (
         "A self-contained Python function suitable for uploading to Google Cloud Function.\n\n"
-        f"See {doc_url('python-google-cloud-function')}."
+        f"See {doc_url('google-cloud-function-python')}."
     )
 
     def validate(self) -> None:

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -87,7 +87,7 @@ class PythonSetup(Subsystem):
             "requirements, regardless of using Pex vs. Poetry for the lockfile generator. "
             "Support is coming in a future Pants release. In the meantime, the workaround is to "
             "host the files in a custom repository with `[python-repos]` "
-            f"({doc_url('3rdparty-dependencies#custom-repositories')}).\n\n"
+            f"({doc_url('python-third-party-dependencies#custom-repositories')}).\n\n"
             "You may also run into issues generating lockfiles when using Poetry as the generator, "
             "rather than Pex. See the option `[python].lockfile_generator` for more "
             "information.\n\n"


### PR DESCRIPTION
Fixes #11578 by erroring if we get a non-200 status on a pantsbuild.org URL. Also fixed a few URLs it caught.

I originally wrote this code in a way that we'd validate all URLs (as @Eric-Arellano suggests), however it choked on our URL templates ("https://github.com/bufbuild/buf/releases/download/{version}/buf-{platform}.tar.gz") and I didn't want to throw the baby out with the bathwater trying to fix that.

Additionally, this will consistently fail on main, due to the docs not existing yet, so added --skip-check-urls to skip the checking.

I shied away from doing this kind of validation in a test, because that means the tests would rely on network connection, which I'm not a big fan of (and if we're validating any URL, the test could get very "flaky").

Also includes a little refactoring.

[ci skip-rust]