### PR TITLE
Record Scala `package object` as provided name (Cherry-pick of #15582)

### DIFF
--- a/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
+++ b/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
@@ -202,6 +202,7 @@ class SourceAnalysisTraverser extends Traverser {
       visitMods(mods)
       val name = extractName(nameNode)
       recordScope(name)
+      recordProvidedName(name, sawObject = true)
       visitTemplate(templ, name)
     }
 

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
@@ -408,7 +408,7 @@ def test_package_object(rule_runner: RuleRunner) -> None:
             """
         ),
     )
-    assert sorted(analysis.provided_symbols) == ["foo.bar.Hello"]
+    assert sorted(analysis.provided_symbols) == ["foo.bar", "foo.bar.Hello"]
 
 
 def test_extract_annotations(rule_runner: RuleRunner) -> None:


### PR DESCRIPTION
The package object should also be recorded as provided name, as it also behaves as an object. 

An example that will fail without this fix:

File t.scala:
```
package object example {
   trait T[A]
}
```

File a.scala:
```
package example

package object a {
   implicit val tString: T[String] = new T[String] {}
}
```

File b.scala:
```
package example.b

import example.T
import example.a._

object B {
   val x = implicitly[T[String]]
}
```

