### PR TITLE
Fix incorrect digest for JVM multiple `jvm_artifact(.., jar=..)` entries (Cherry-pick of #15571)

### DIFF
--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -341,19 +341,29 @@ async def prepare_coursier_resolve_info(
         excludes_digest = await Get(Digest, CreateDigest([excludes_file_content]))
         extra_args += ["--local-exclude-file", LOCAL_EXCLUDE_FILE]
 
-    jar_files = await Get(SourceFiles, SourceFilesRequest(i[1] for i in jars))
-    jar_file_paths = jar_files.snapshot.files
+    jar_file_sources = await MultiGet(
+        Get(SourceFiles, SourceFilesRequest([jar_source_field])) for _, jar_source_field in jars
+    )
+    jar_file_paths = [jar_file_source.snapshot.files[0] for jar_file_source in jar_file_sources]
 
     resolvable_jar_requirements = [
         dataclasses.replace(
             req, jar=None, url=f"file:{Coursier.working_directory_placeholder}/{path}"
         )
-        for req, path in zip((i[0] for i in jars), jar_file_paths)
+        for (req, _), path in zip(jars, jar_file_paths)
     ]
 
     to_resolve = chain(no_jars, resolvable_jar_requirements)
 
-    digest = await Get(Digest, MergeDigests([jar_files.snapshot.digest, excludes_digest]))
+    digest = await Get(
+        Digest,
+        MergeDigests(
+            [
+                *(jar_file_source.snapshot.digest for jar_file_source in jar_file_sources),
+                excludes_digest,
+            ]
+        ),
+    )
 
     return CoursierResolveInfo(
         coord_arg_strings=frozenset(req.to_coord_arg_str() for req in to_resolve),


### PR DESCRIPTION
As reported in #15537, multiple `jvm_artifact(.., jar=..)` entries are not sorted correctly when they are associated with their content.

`Snapshot`s always have sorted contents: to associate files with particular entries, we need to create separate `Snapshot`s per jar.

Fixes #15537.

[ci skip-rust]
[ci skip-build-wheels]
