### PR TITLE
Use new, consistent CLI args semantics for `tailor` if `use_deprecated_cli_args_semantics = false`

### DIFF
--- a/src/python/pants/backend/cc/goals/tailor_test.py
+++ b/src/python/pants/backend/cc/goals/tailor_test.py
@@ -38,7 +38,9 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
     putative_targets = rule_runner.request(
         PutativeTargets,
         [
-            PutativeCCTargetsRequest(PutativeTargetsSearchPaths(("",))),
+            PutativeCCTargetsRequest(
+                PutativeTargetsSearchPaths(("src/native/owned", "src/native/unowned"))
+            ),
             AllOwnedSources(["src/native/owned/OwnedFile.cc"]),
         ],
     )

--- a/src/python/pants/backend/codegen/avro/tailor_test.py
+++ b/src/python/pants/backend/codegen/avro/tailor_test.py
@@ -40,7 +40,7 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
     pts = rule_runner.request(
         PutativeTargets,
         [
-            PutativeAvroTargetsRequest(PutativeTargetsSearchPaths(("",))),
+            PutativeAvroTargetsRequest(PutativeTargetsSearchPaths(("avro/foo", "avro/foo/bar"))),
             AllOwnedSources(["avro/foo/bar/baz1.avdl"]),
         ],
     )

--- a/src/python/pants/backend/codegen/protobuf/tailor_test.py
+++ b/src/python/pants/backend/codegen/protobuf/tailor_test.py
@@ -40,7 +40,9 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
     pts = rule_runner.request(
         PutativeTargets,
         [
-            PutativeProtobufTargetsRequest(PutativeTargetsSearchPaths(("",))),
+            PutativeProtobufTargetsRequest(
+                PutativeTargetsSearchPaths(("protos/foo", "protos/foo/bar"))
+            ),
             AllOwnedSources(["protos/foo/bar/baz1.proto"]),
         ],
     )

--- a/src/python/pants/backend/codegen/soap/tailor_test.py
+++ b/src/python/pants/backend/codegen/soap/tailor_test.py
@@ -39,7 +39,7 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
     pts = rule_runner.request(
         PutativeTargets,
         [
-            PutativeWsdlTargetsRequest(PutativeTargetsSearchPaths(("",))),
+            PutativeWsdlTargetsRequest(PutativeTargetsSearchPaths(("src/wsdl", "src/wsdl/dir1"))),
             AllOwnedSources(["src/wsdl/simple.wsdl"]),
         ],
     )

--- a/src/python/pants/backend/codegen/thrift/tailor_test.py
+++ b/src/python/pants/backend/codegen/thrift/tailor_test.py
@@ -40,7 +40,9 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
     pts = rule_runner.request(
         PutativeTargets,
         [
-            PutativeThriftTargetsRequest(PutativeTargetsSearchPaths(("",))),
+            PutativeThriftTargetsRequest(
+                PutativeTargetsSearchPaths(("thrifts/foo", "thrifts/foo/bar"))
+            ),
             AllOwnedSources(["thrifts/foo/bar/baz1.thrift"]),
         ],
     )

--- a/src/python/pants/backend/docker/goals/tailor_test.py
+++ b/src/python/pants/backend/docker/goals/tailor_test.py
@@ -32,7 +32,9 @@ def test_find_putative_targets() -> None:
     pts = rule_runner.request(
         PutativeTargets,
         [
-            PutativeDockerTargetsRequest(PutativeTargetsSearchPaths(("src/",))),
+            PutativeDockerTargetsRequest(
+                PutativeTargetsSearchPaths(("src/docker_ok", "src/docker_orphan"))
+            ),
             AllOwnedSources(["src/docker_ok/Dockerfile"]),
         ],
     )

--- a/src/python/pants/backend/go/goals/tailor_test.py
+++ b/src/python/pants/backend/go/goals/tailor_test.py
@@ -56,7 +56,7 @@ def test_find_go_mod_targets(rule_runner: RuleRunner) -> None:
     putative_targets = rule_runner.request(
         PutativeTargets,
         [
-            PutativeGoTargetsRequest(PutativeTargetsSearchPaths(("",))),
+            PutativeGoTargetsRequest(PutativeTargetsSearchPaths(("unowned", "owned"))),
             AllOwnedSources(["owned/go.mod"]),
         ],
     )
@@ -87,7 +87,11 @@ def test_find_go_package_targets(rule_runner: RuleRunner) -> None:
     putative_targets = rule_runner.request(
         PutativeTargets,
         [
-            PutativeGoTargetsRequest(PutativeTargetsSearchPaths(("",))),
+            PutativeGoTargetsRequest(
+                PutativeTargetsSearchPaths(
+                    ("unowned", "owned", "unowned/testdata", "unowned/vendor", "unowned/cmd/vendor")
+                )
+            ),
             AllOwnedSources(["owned/f.go"]),
         ],
     )
@@ -125,7 +129,16 @@ def test_find_go_binary_targets(rule_runner: RuleRunner) -> None:
     putative_targets = rule_runner.request(
         PutativeTargets,
         [
-            PutativeGoTargetsRequest(PutativeTargetsSearchPaths(("",))),
+            PutativeGoTargetsRequest(
+                PutativeTargetsSearchPaths(
+                    (
+                        "missing_binary_tgt",
+                        "tgt_already_exists",
+                        "missing_pkg_and_binary_tgt",
+                        "main_set_to_different_dir",
+                    )
+                )
+            ),
             AllOwnedSources(
                 [
                     "missing_binary_tgt/app.go",

--- a/src/python/pants/backend/helm/goals/tailor_test.py
+++ b/src/python/pants/backend/helm/goals/tailor_test.py
@@ -37,7 +37,9 @@ def test_find_helm_charts(rule_runner: RuleRunner) -> None:
     putative_targets = rule_runner.request(
         PutativeTargets,
         [
-            PutativeHelmChartTargetsRequest(PutativeTargetsSearchPaths(("src/",))),
+            PutativeHelmChartTargetsRequest(
+                PutativeTargetsSearchPaths(("src/owned", "src/foo", "src/bar"))
+            ),
             AllOwnedSources(["src/owned/Chart.yaml"]),
         ],
     )

--- a/src/python/pants/backend/java/goals/tailor_test.py
+++ b/src/python/pants/backend/java/goals/tailor_test.py
@@ -51,7 +51,9 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
     putative_targets = rule_runner.request(
         PutativeTargets,
         [
-            PutativeJavaTargetsRequest(PutativeTargetsSearchPaths(("",))),
+            PutativeJavaTargetsRequest(
+                PutativeTargetsSearchPaths(("src/java", "src/java/unowned"))
+            ),
             AllOwnedSources(["src/java/owned/OwnedFile.java"]),
         ],
     )

--- a/src/python/pants/backend/javascript/goals/tailor_test.py
+++ b/src/python/pants/backend/javascript/goals/tailor_test.py
@@ -39,7 +39,7 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
     putative_targets = rule_runner.request(
         PutativeTargets,
         [
-            PutativeJSTargetsRequest(PutativeTargetsSearchPaths(("",))),
+            PutativeJSTargetsRequest(PutativeTargetsSearchPaths(("src/owned", "src/unowned"))),
             AllOwnedSources(["src/owned/OwnedFile.js"]),
         ],
     )

--- a/src/python/pants/backend/kotlin/goals/tailor_test.py
+++ b/src/python/pants/backend/kotlin/goals/tailor_test.py
@@ -38,7 +38,9 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
     putative_targets = rule_runner.request(
         PutativeTargets,
         [
-            PutativeKotlinTargetsRequest(PutativeTargetsSearchPaths(("",))),
+            PutativeKotlinTargetsRequest(
+                PutativeTargetsSearchPaths(("src/kotlin/owned", "src/kotlin/unowned"))
+            ),
             AllOwnedSources(["src/kotlin/owned/OwnedFile.kt"]),
         ],
     )

--- a/src/python/pants/backend/python/goals/tailor_test.py
+++ b/src/python/pants/backend/python/goals/tailor_test.py
@@ -95,7 +95,17 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
     pts = rule_runner.request(
         PutativeTargets,
         [
-            PutativePythonTargetsRequest(PutativeTargetsSearchPaths(("",))),
+            PutativePythonTargetsRequest(
+                PutativeTargetsSearchPaths(
+                    (
+                        "3rdparty",
+                        "already_owned",
+                        "no_match",
+                        "src/python/foo",
+                        "src/python/foo/bar",
+                    )
+                )
+            ),
             AllOwnedSources(
                 [
                     "already_owned/requirements.txt",
@@ -223,7 +233,7 @@ def test_find_putative_targets_for_entry_points(rule_runner: RuleRunner) -> None
     pts = rule_runner.request(
         PutativeTargets,
         [
-            PutativePythonTargetsRequest(PutativeTargetsSearchPaths(("",))),
+            PutativePythonTargetsRequest(PutativeTargetsSearchPaths(("src/python/foo",))),
             AllOwnedSources(
                 [f"src/python/foo/{name}" for name in mains] + ["src/python/foo/__main__.py"]
             ),
@@ -268,7 +278,16 @@ def test_ignore_solitary_init(rule_runner: RuleRunner) -> None:
     pts = rule_runner.request(
         PutativeTargets,
         [
-            PutativePythonTargetsRequest(PutativeTargetsSearchPaths(("",))),
+            PutativePythonTargetsRequest(
+                PutativeTargetsSearchPaths(
+                    (
+                        "src/python/foo",
+                        "src/python/foo/bar",
+                        "src/python/foo/baz",
+                        "src/python/foo/qux",
+                    )
+                )
+            ),
             AllOwnedSources([]),
         ],
     )

--- a/src/python/pants/backend/shell/tailor_test.py
+++ b/src/python/pants/backend/shell/tailor_test.py
@@ -56,7 +56,9 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
     pts = rule_runner.request(
         PutativeTargets,
         [
-            PutativeShellTargetsRequest(PutativeTargetsSearchPaths(("",))),
+            PutativeShellTargetsRequest(
+                PutativeTargetsSearchPaths(("src/sh/foo", "src/sh/foo/bar"))
+            ),
             AllOwnedSources(["src/sh/foo/bar/baz1.sh", "src/sh/foo/bar/baz1_test.sh"]),
         ],
     )

--- a/src/python/pants/backend/terraform/goals/tailor_test.py
+++ b/src/python/pants/backend/terraform/goals/tailor_test.py
@@ -37,7 +37,11 @@ def test_find_putative_targets() -> None:
     pts = rule_runner.request(
         PutativeTargets,
         [
-            PutativeTerraformTargetsRequest(PutativeTargetsSearchPaths(("",))),
+            PutativeTerraformTargetsRequest(
+                PutativeTargetsSearchPaths(
+                    ("prod/terraform/owned-module", "prod/terraform/unowned-module")
+                )
+            ),
             AllOwnedSources(["prod/terraform/owned-module/versions.tf"]),
         ],
     )

--- a/src/python/pants/core/goals/tailor_test.py
+++ b/src/python/pants/core/goals/tailor_test.py
@@ -561,7 +561,7 @@ def test_all_owned_sources(rule_runner: RuleRunner) -> None:
 def test_target_type_with_no_sources_field(rule_runner: RuleRunner) -> None:
     putative_targets = rule_runner.request(
         PutativeTargets,
-        [MockPutativeFortranModuleRequest(PutativeTargetsSearchPaths(tuple("")))],
+        [MockPutativeFortranModuleRequest(PutativeTargetsSearchPaths(("dir",)))],
     )
     assert putative_targets == PutativeTargets(
         [PutativeTarget.for_target_type(FortranModule, "dir", "dir", [])]

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1657,6 +1657,12 @@ class GlobalOptions(BootstrapOptions, Subsystem):
 
             The new semantics will become the default in Pants 2.14, and the old semantics will be
             removed in 2.15.
+
+            This also impacts the behavior of the `tailor` goal. If this option is true, 
+            `{bin_name()} tailor` without additional arguments will run over the whole project, and
+            `{bin_name()} tailor dir` will run over `dir` and all recursive sub-directories. If
+            false, you must specify arguments, like `{bin_name()} tailor ::` to run over the
+            whole project; specifying a directory will only add targets for that directory.
             """
         ),
     )

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1658,7 +1658,7 @@ class GlobalOptions(BootstrapOptions, Subsystem):
             The new semantics will become the default in Pants 2.14, and the old semantics will be
             removed in 2.15.
 
-            This also impacts the behavior of the `tailor` goal. If this option is true, 
+            This also impacts the behavior of the `tailor` goal. If this option is true,
             `{bin_name()} tailor` without additional arguments will run over the whole project, and
             `{bin_name()} tailor dir` will run over `dir` and all recursive sub-directories. If
             false, you must specify arguments, like `{bin_name()} tailor ::` to run over the


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/15563. You can now run `./pants tailor ::` and  even `./pants --changed-since=HEAD tailor`!

Rather than adding a dedicated option to `tailor`, we piggy-back off of the global option `use_deprecated_cli_args_semantics`. This will make it easier for new users to do the correct thing right away. We'll have them set this when creating the initial BUILD file.

## Quirk: file literals

Usually, `./pants tailor dir/f.py` would imply only consider if you need to add a target for `f.py`. Even if `f_test.py` needs a target, don't consider it.

However, that is pretty hard for us to implement and I don't think it's desirable. For example, I don't think it's desirable to create `python_sources(source=["f.py"])` when we normally would have used the default source globs; that is not future-proof. It is especially egregious with `./pants --changed-since=HEAD tailor`, where you presumably want to add targets for the whole directory, not just the new file.

[ci skip-rust]
[ci skip-build-wheels]