### PR TITLE
Fix `__str__` for `AddressLiteralSpec` to include parameters

### DIFF
--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -41,7 +41,11 @@ class AddressLiteralSpec(Spec):
     def __str__(self) -> str:
         tgt = f":{self.target_component}" if self.target_component else ""
         generated = f"#{self.generated_component}" if self.generated_component else ""
-        return f"{self.path_component}{tgt}{generated}"
+        params = ""
+        if self.parameters:
+            rhs = ",".join(f"{k}={v}" for k, v in self.parameters.items())
+            params = f"@{rhs}"
+        return f"{self.path_component}{tgt}{generated}{params}"
 
     @property
     def is_directory_shorthand(self) -> bool:

--- a/src/python/pants/base/specs_test.py
+++ b/src/python/pants/base/specs_test.py
@@ -3,13 +3,37 @@
 
 from __future__ import annotations
 
+import pytest
+
 from pants.base.specs import (
+    AddressLiteralSpec,
     AncestorGlobSpec,
     DirGlobSpec,
     DirLiteralSpec,
     RecursiveGlobSpec,
     SpecsWithoutFileOwners,
 )
+from pants.util.frozendict import FrozenDict
+
+
+@pytest.mark.parametrize(
+    "spec,expected",
+    [
+        (AddressLiteralSpec("dir"), "dir"),
+        (AddressLiteralSpec("dir/f.txt"), "dir/f.txt"),
+        (AddressLiteralSpec("dir", "tgt"), "dir:tgt"),
+        (AddressLiteralSpec("dir", None, "gen"), "dir#gen"),
+        (AddressLiteralSpec("dir", "tgt", "gen"), "dir:tgt#gen"),
+        (
+            AddressLiteralSpec("dir", None, None, FrozenDict({"k1": "v1", "k2": "v2"})),
+            "dir@k1=v1,k2=v1",
+        ),
+        (AddressLiteralSpec("dir", "tgt", None, FrozenDict({"k": "v"})), "dir:tgt@k=v"),
+        (AddressLiteralSpec("dir", "tgt", "gen", FrozenDict({"k": "v"})), "dir:tgt#gen@k=v"),
+    ],
+)
+def address_literal_str(spec: AddressLiteralSpec, expected: str) -> None:
+    assert str(spec) == expected
 
 
 def assert_build_file_globs(


### PR DESCRIPTION
[ci skip-rust]
[ci skip-build-wheels]