### PR TITLE
Remove `-d` as shorthand for `--logdir`

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -778,7 +778,6 @@ class BootstrapOptions:
     # These logging options are registered in the bootstrap phase so that plugins can log during
     # registration and not so that their values can be interpolated in configs.
     logdir = StrOption(
-        "-d",
         "--logdir",
         advanced=True,
         default=None,

--- a/src/python/pants/option/options_bootstrapper_test.py
+++ b/src/python/pants/option/options_bootstrapper_test.py
@@ -304,7 +304,7 @@ class TestOptionsBootstrapper:
         assert vals.logdir is None
         assert LogLevel.INFO == vals.level
 
-        vals = parse_options("-d/tmp/logs", "-ldebug")
+        vals = parse_options("--logdir=/tmp/logs", "-ldebug")
         assert "/tmp/logs" == vals.logdir
         assert LogLevel.DEBUG == vals.level
 
@@ -317,11 +317,11 @@ class TestOptionsBootstrapper:
                 .for_global_scope()
             )
 
-        vals = parse_options("main", "args", "-d/tmp/frogs", "--", "-d/tmp/logs")
-        assert "/tmp/frogs" == vals.logdir
+        vals = parse_options("main", "args", "-lwarn", "--", "-lerror")
+        assert LogLevel.WARN == vals.level
 
-        vals = parse_options("main", "args", "--", "-d/tmp/logs")
-        assert vals.logdir is None
+        vals = parse_options("main", "args", "--", "-lerror")
+        assert LogLevel.INFO == vals.level
 
     def test_bootstrap_options_explicit_config_path(self) -> None:
         def config_path(*args, **env):


### PR DESCRIPTION
First off, I don't think this option actually does anything currently... https://github.com/pantsbuild/pants/issues/15004#issuecomment-1135395887

Even if it did, `-d` is really confusing. It's not an enum option, so the user sets to an open-ended value like `./pants -dmy_dir`. It's clearer to do `./pants --logdir=my_dir`. This is unlike `-linfo`/`-ldebug`, which is more intuitive.

Fixing this also helps to free up the `-` symbol so that we can use it for ignore specs as an improvement over `!`, which would require shell escaping. https://github.com/pantsbuild/pants/issues/15539

[ci skip-rust]