### PR TITLE
Ban using short option names like `-x`, except for pre-blessed values

### DIFF
--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -73,8 +73,7 @@ class ArgSplitter:
 
     Recognizes, e.g.:
 
-    ./pants check --foo lint -y target1: dir f.ext
-    ./pants check --foo lint -y target1: dir f.ext
+    ./pants check --foo lint target1: dir f.ext
     ./pants --global-opt check target1: dir f.ext --check-flag
     ./pants --check-flag check target1: dir f.ext
     ./pants goal -- passthru foo
@@ -276,7 +275,7 @@ class ArgSplitter:
         if not self._unconsumed_args:
             return False
         arg = self._unconsumed_args[-1]
-        if not arg.startswith("-"):
+        if not arg.startswith("--"):
             return False
         return not self._at_standalone_double_dash() and not self._at_scope()
 

--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -273,12 +273,12 @@ class ArgSplitter:
         return default_scope, flag
 
     def _at_flag(self) -> bool:
-        return (
-            bool(self._unconsumed_args)
-            and self._unconsumed_args[-1].startswith("-")
-            and not self._at_standalone_double_dash()
-            and not self._at_scope()
-        )
+        if not self._unconsumed_args:
+            return False
+        arg = self._unconsumed_args[-1]
+        if not arg.startswith("-"):
+            return False
+        return not self._at_standalone_double_dash() and not self._at_scope()
 
     def _at_scope(self) -> bool:
         return bool(self._unconsumed_args) and self._unconsumed_args[-1] in self._known_scopes

--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -174,7 +174,7 @@ class ArgSplitter:
                 assign_flag_to_scope(flag, scope)
             scope, flags = self._consume_scope()
 
-        while self._unconsumed_args and not self._at_double_dash():
+        while self._unconsumed_args and not self._at_standalone_double_dash():
             if self._at_flag():
                 arg = self._unconsumed_args.pop()
                 # We assume any args here are in global scope.
@@ -193,7 +193,7 @@ class ArgSplitter:
             elif not goals and NO_GOAL_NAME in self._known_goal_scopes:
                 builtin_goal = NO_GOAL_NAME
 
-        if self._at_double_dash():
+        if self._at_standalone_double_dash():
             self._unconsumed_args.pop()
             passthru = list(reversed(self._unconsumed_args))
 
@@ -276,12 +276,13 @@ class ArgSplitter:
         return (
             bool(self._unconsumed_args)
             and self._unconsumed_args[-1].startswith("-")
-            and not self._at_double_dash()
+            and not self._at_standalone_double_dash()
             and not self._at_scope()
         )
 
     def _at_scope(self) -> bool:
         return bool(self._unconsumed_args) and self._unconsumed_args[-1] in self._known_scopes
 
-    def _at_double_dash(self) -> bool:
+    def _at_standalone_double_dash(self) -> bool:
+        """At the value `--`, used to start passthrough args."""
         return bool(self._unconsumed_args) and self._unconsumed_args[-1] == "--"

--- a/src/python/pants/option/arg_splitter_test.py
+++ b/src/python/pants/option/arg_splitter_test.py
@@ -125,26 +125,26 @@ def goal_split_test(command_line: str, **expected):
     [
         # Basic arg splitting, various flag combos.
         (
-            "./pants --check-long-flag -g check -c test -i "
+            "./pants --check-long-flag --gg check --cc test --ii "
             "src/java/org/pantsbuild/foo src/java/org/pantsbuild/bar:baz",
             dict(
                 expected_goals=["check", "test"],
                 expected_scope_to_flags={
-                    "": ["-g"],
-                    "check": ["--long-flag", "-c"],
-                    "test": ["-i"],
+                    "": ["--gg"],
+                    "check": ["--long-flag", "--cc"],
+                    "test": ["--ii"],
                 },
                 expected_specs=["src/java/org/pantsbuild/foo", "src/java/org/pantsbuild/bar:baz"],
             ),
         ),
         (
-            "./pants -farg --fff=arg check --gg-gg=arg-arg -g test --iii "
+            "./pants --fff=arg check --gg-gg=arg-arg test --iii "
             "--check-long-flag src/java/org/pantsbuild/foo src/java/org/pantsbuild/bar:baz",
             dict(
                 expected_goals=["check", "test"],
                 expected_scope_to_flags={
-                    "": ["-farg", "--fff=arg"],
-                    "check": ["--gg-gg=arg-arg", "-g", "--long-flag"],
+                    "": ["--fff=arg"],
+                    "check": ["--gg-gg=arg-arg", "--long-flag"],
                     "test": ["--iii"],
                 },
                 expected_specs=["src/java/org/pantsbuild/foo", "src/java/org/pantsbuild/bar:baz"],
@@ -237,13 +237,13 @@ def test_passthru_args(splitter: ArgSplitter) -> None:
     )
     assert_valid_split(
         splitter,
-        "./pants -farg --fff=arg check --gg-gg=arg-arg -g test --iii "
+        "./pants --fff=arg check --gg-gg=arg-arg test --iii "
         "--check-long-flag src/java/org/pantsbuild/foo src/java/org/pantsbuild/bar:baz -- "
         "passthru1 passthru2",
         expected_goals=["check", "test"],
         expected_scope_to_flags={
-            "": ["-farg", "--fff=arg"],
-            "check": ["--gg-gg=arg-arg", "-g", "--long-flag"],
+            "": ["--fff=arg"],
+            "check": ["--gg-gg=arg-arg", "--long-flag"],
             "test": ["--iii"],
         },
         expected_specs=["src/java/org/pantsbuild/foo", "src/java/org/pantsbuild/bar:baz"],
@@ -329,13 +329,13 @@ def help_no_arguments_test(command_line: str, *scopes: str, **expected):
         help_test(
             "./pants -f",
             expected_goals=[],
-            expected_scope_to_flags={"": ["-f"]},
+            expected_scope_to_flags={"": [], "-f": []},
             expected_specs=[],
         ),
         help_test(
             "./pants help check -x",
             expected_goals=["check"],
-            expected_scope_to_flags={"": [], "help": ["-x"], "check": []},
+            expected_scope_to_flags={"": [], "-x": [], "help": [], "check": []},
             expected_specs=[],
         ),
         help_test(

--- a/src/python/pants/option/errors.py
+++ b/src/python/pants/option/errors.py
@@ -79,12 +79,8 @@ class OptionAlreadyRegistered(RegistrationError):
     """An option with this name was already registered on this scope."""
 
 
-class OptionNameDash(RegistrationError):
-    """Option name must begin with a dash."""
-
-
 class OptionNameDoubleDash(RegistrationError):
-    """Long option name must begin with a double-dash."""
+    """Option name must begin with a double-dash."""
 
 
 class PassthroughType(RegistrationError):

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -43,7 +43,6 @@ from pants.option.errors import (
     MutuallyExclusiveOptionError,
     NoOptionNames,
     OptionAlreadyRegistered,
-    OptionNameDash,
     OptionNameDoubleDash,
     ParseError,
     PassthroughType,
@@ -396,11 +395,10 @@ class Parser:
 
         if not args:
             error(NoOptionNames)
-        # validate args.
+        # Validate args.
         for arg in args:
-            if not arg.startswith("-"):
-                error(OptionNameDash, arg_name=arg)
-            if not arg.startswith("--") and len(arg) > 2:
+            # We ban short args like `-x`, except for special casing the global option `-l`.
+            if not arg.startswith("--") and not (self.scope == GLOBAL_SCOPE and arg == "-l"):
                 error(OptionNameDoubleDash, arg_name=arg)
 
         # Validate kwargs.


### PR DESCRIPTION
We have some genuinely useful short args:

* `-linfo`, aka `--level=info`
* `-v`, aka `--version`
* `-h`, aka `--help`

But otherwise, short args are an antipattern with Pants because we have so many diverse options & short args are cryptic. While short args work well for ~single-purpose tools like Pex and pip, with Pants, it's not worth the cost to clarity.

Crucially, short args block using `-` for ignore specs in https://github.com/pantsbuild/pants/issues/15539. Using `-` rather than `!` is highly preferrable because you don't need `''` shell escaping, and it aligns with `--tag` excludes. By only allowing these 3 blessed short args, we remove the ambiguity of ignore specs vs. short args.