### PR TITLE
Don't allow multiple flag names for the same option

### DIFF
--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -1,6 +1,5 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 from enum import Enum
 from typing import Any, Iterable, List, Optional, Tuple, Union
 
@@ -11,16 +10,17 @@ from pants.engine.target import IntField, RegisteredTargetTypes, StringField, Ta
 from pants.engine.unions import UnionMembership
 from pants.help.help_info_extracter import HelpInfoExtracter, pretty_print_type_hint, to_help_str
 from pants.option.config import Config
-from pants.option.global_options import GlobalOptions
-from pants.option.option_types import BoolOption, IntOption, StrOption
+from pants.option.global_options import GlobalOptions, LogLevelOption
+from pants.option.option_types import BoolOption, IntOption
 from pants.option.options import Options
 from pants.option.parser import Parser
 from pants.option.ranked_value import Rank, RankedValue
 from pants.option.scope import GLOBAL_SCOPE
 from pants.option.subsystem import Subsystem
+from pants.util.logging import LogLevel
 
 
-class LogLevel(Enum):
+class LogLevelSimple(Enum):
     INFO = "info"
     DEBUG = "debug"
 
@@ -132,8 +132,8 @@ def test_default() -> None:
     do_test(["--foo"], {"type": int, "default": 65536, "default_help_repr": "64KiB"}, "64KiB")
     do_test(["--foo"], {"type": list}, "[]")
     do_test(["--foo"], {"type": dict}, "{}")
-    do_test(["--foo"], {"type": LogLevel}, "None")
-    do_test(["--foo"], {"type": LogLevel, "default": LogLevel.DEBUG}, "debug")
+    do_test(["--foo"], {"type": LogLevelSimple}, "None")
+    do_test(["--foo"], {"type": LogLevelSimple, "default": LogLevelSimple.DEBUG}, "debug")
 
 
 def test_compute_default():
@@ -146,7 +146,7 @@ def test_compute_default():
     do_test("foo", type=str, default="foo")
     do_test(None, type=str, default=None)
     do_test([1, 2, 3], type=list, member_type=int, default=[1, 2, 3])
-    do_test(LogLevel.INFO, type=LogLevel, default=LogLevel.INFO)
+    do_test(LogLevelSimple.INFO, type=LogLevelSimple, default=LogLevelSimple.INFO)
 
 
 def test_deprecated():
@@ -193,13 +193,13 @@ def test_choices() -> None:
 
 
 def test_choices_enum() -> None:
-    kwargs = {"type": LogLevel}
+    kwargs = {"type": LogLevelSimple}
     ohi = HelpInfoExtracter("").get_option_help_info(["--foo"], kwargs)
     assert ohi.choices == ("info", "debug")
 
 
 def test_list_of_enum() -> None:
-    kwargs = {"type": list, "member_type": LogLevel}
+    kwargs = {"type": list, "member_type": LogLevelSimple}
     ohi = HelpInfoExtracter("").get_option_help_info(["--foo"], kwargs)
     assert ohi.choices == ("info", "debug")
 
@@ -230,8 +230,8 @@ def test_get_all_help_info():
         help = "Global options."
 
         opt1 = IntOption("--opt1", default=42, help="Option 1")
-        # We special-case `-l` to allow a short arg. Make sure that works.
-        level = StrOption("-l", "--level", default="info", help="Log level")
+        # This is special in having a short option `-l`. Make sure it works.
+        level = LogLevelOption()
 
     class Foo(Subsystem):
         options_scope = "foo"
@@ -293,197 +293,203 @@ def test_get_all_help_info():
     )
 
     all_help_info_dict = all_help_info.asdict()
-    expected_all_help_info_dict = {
-        "scope_to_help_info": {
-            GLOBAL_SCOPE: {
-                "scope": GLOBAL_SCOPE,
-                "description": "Global options.",
-                "provider": "",
-                "is_goal": False,
-                "deprecated_scope": None,
-                "basic": (
-                    {
-                        "display_args": ("--opt1=<int>",),
-                        "comma_separated_display_args": "--opt1=<int>",
-                        "scoped_cmd_line_args": ("--opt1",),
-                        "unscoped_cmd_line_args": ("--opt1",),
-                        "config_key": "opt1",
-                        "env_var": "PANTS_OPT1",
-                        "value_history": {
-                            "ranked_values": (
-                                {"rank": Rank.NONE, "value": None, "details": None},
-                                {"rank": Rank.HARDCODED, "value": 42, "details": None},
-                            ),
-                        },
-                        "typ": int,
-                        "default": 42,
-                        "help": "Option 1",
-                        "deprecation_active": False,
-                        "deprecated_message": None,
-                        "removal_version": None,
-                        "removal_hint": None,
-                        "choices": None,
-                        "comma_separated_choices": None,
-                    },
-                    {
-                        "display_args": ("-l=<str>", "--level=<str>"),
-                        "comma_separated_display_args": "-l=<str>, --level=<str>",
-                        "scoped_cmd_line_args": ("-l", "--level"),
-                        "unscoped_cmd_line_args": ("-l", "--level"),
-                        "config_key": "level",
-                        "env_var": "PANTS_LEVEL",
-                        "value_history": {
-                            "ranked_values": (
-                                {"rank": Rank.NONE, "value": None, "details": None},
-                                {"rank": Rank.HARDCODED, "value": "info", "details": None},
-                            ),
-                        },
-                        "typ": str,
-                        "default": "info",
-                        "help": "Log level",
-                        "deprecation_active": False,
-                        "deprecated_message": None,
-                        "removal_version": None,
-                        "removal_hint": None,
-                        "choices": None,
-                        "comma_separated_choices": None,
-                    },
-                ),
-                "advanced": tuple(),
-                "deprecated": tuple(),
-            },
-            "foo": {
-                "scope": "foo",
-                "provider": "help_info_extracter_test",
-                "description": "A foo.",
-                "is_goal": False,
-                "deprecated_scope": None,
-                "basic": (),
-                "advanced": (
-                    {
-                        "display_args": ("--[no-]foo-opt2",),
-                        "comma_separated_display_args": "--[no-]foo-opt2",
-                        "scoped_cmd_line_args": ("--foo-opt2", "--no-foo-opt2"),
-                        "unscoped_cmd_line_args": ("--opt2", "--no-opt2"),
-                        "config_key": "opt2",
-                        "env_var": "PANTS_FOO_OPT2",
-                        "value_history": {
-                            "ranked_values": (
-                                {"rank": Rank.NONE, "value": None, "details": None},
-                                {"rank": Rank.HARDCODED, "value": True, "details": None},
-                            ),
-                        },
-                        "typ": bool,
-                        "default": True,
-                        "help": "Option 2",
-                        "deprecation_active": False,
-                        "deprecated_message": None,
-                        "removal_version": None,
-                        "removal_hint": None,
-                        "choices": None,
-                        "comma_separated_choices": None,
-                    },
-                ),
-                "deprecated": tuple(),
-            },
-            "bar": {
-                "scope": "bar",
-                "provider": "help_info_extracter_test",
-                "description": "The bar goal.",
-                "is_goal": True,
-                "deprecated_scope": "bar-old",
-                "basic": tuple(),
-                "advanced": tuple(),
-                "deprecated": tuple(),
-            },
-            "bar-old": {
-                "scope": "bar-old",
-                "provider": "help_info_extracter_test",
-                "description": "The bar goal.",
-                "is_goal": True,
-                "deprecated_scope": "bar-old",
-                "basic": tuple(),
-                "advanced": tuple(),
-                "deprecated": tuple(),
-            },
-        },
-        "rule_output_type_to_rule_infos": {
-            "Foo": (
-                {
-                    "description": None,
-                    "help": "A foo.",
-                    "input_gets": ("Get(ScopedOptions, Scope, ..)",),
-                    "input_types": (),
-                    "name": "construct_scope_foo",
-                    "output_desc": None,
-                    "output_type": "Foo",
-                    "provider": "help_info_extracter_test",
-                },
-            ),
-            "Target": (
-                {
-                    "description": None,
-                    "help": "This rule is for testing info extraction only.",
-                    "input_gets": (),
-                    "input_types": ("Foo",),
-                    "name": "pants.help.help_info_extracter_test.test_get_all_help_info.rule_info_test",
-                    "output_desc": (
-                        "A Target represents an addressable set of metadata.\n\n    Set the "
-                        "`help` class property with a description, which will be used in "
-                        "`./pants help`. For the\n    best rendering, use soft wrapping (e.g. "
-                        "implicit string concatenation) within paragraphs, but\n    hard wrapping "
-                        "(`\n`) to separate distinct paragraphs and/or lists.\n    "
+    expected_scope_to_help__global = {
+        "scope": GLOBAL_SCOPE,
+        "description": "Global options.",
+        "provider": "",
+        "is_goal": False,
+        "deprecated_scope": None,
+        "basic": (
+            {
+                "display_args": ("--opt1=<int>",),
+                "comma_separated_display_args": "--opt1=<int>",
+                "scoped_cmd_line_args": ("--opt1",),
+                "unscoped_cmd_line_args": ("--opt1",),
+                "config_key": "opt1",
+                "env_var": "PANTS_OPT1",
+                "value_history": {
+                    "ranked_values": (
+                        {"rank": Rank.NONE, "value": None, "details": None},
+                        {"rank": Rank.HARDCODED, "value": 42, "details": None},
                     ),
-                    "output_type": "Target",
-                    "provider": "help_info_extracter_test",
                 },
-            ),
-        },
-        "name_to_goal_info": {
-            "bar": {
-                "name": "bar",
-                "provider": "help_info_extracter_test",
-                "description": "The bar goal.",
-                "consumed_scopes": ("somescope", "used_by_bar"),
-                "is_implemented": True,
+                "typ": int,
+                "default": 42,
+                "help": "Option 1",
+                "deprecation_active": False,
+                "deprecated_message": None,
+                "removal_version": None,
+                "removal_hint": None,
+                "choices": None,
+                "comma_separated_choices": None,
             },
-            "bar-old": {
-                "name": "bar",
-                "provider": "help_info_extracter_test",
-                "description": "The bar goal.",
-                "consumed_scopes": ("somescope", "used_by_bar-old"),
-                "is_implemented": True,
+            {
+                "display_args": ("-l=<LogLevel>", "--level=<LogLevel>"),
+                "comma_separated_display_args": "-l=<LogLevel>, --level=<LogLevel>",
+                "scoped_cmd_line_args": ("-l", "--level"),
+                "unscoped_cmd_line_args": ("-l", "--level"),
+                "config_key": "level",
+                "env_var": "PANTS_LEVEL",
+                "value_history": {
+                    "ranked_values": (
+                        {"rank": Rank.NONE, "value": None, "details": None},
+                        {"rank": Rank.HARDCODED, "value": LogLevel.INFO, "details": None},
+                    ),
+                },
+                "typ": LogLevel,
+                "default": LogLevel.INFO,
+                "help": "Set the logging level.",
+                "deprecation_active": False,
+                "deprecated_message": None,
+                "removal_version": None,
+                "removal_hint": None,
+                "choices": ("trace", "debug", "info", "warn", "error"),
+                "comma_separated_choices": "trace, debug, info, warn, error",
             },
-        },
-        "name_to_target_type_info": {
-            "baz_library": {
-                "alias": "baz_library",
+        ),
+        "advanced": tuple(),
+        "deprecated": tuple(),
+    }
+    expected_scope_to_help__foo = {
+        "scope": "foo",
+        "provider": "help_info_extracter_test",
+        "description": "A foo.",
+        "is_goal": False,
+        "deprecated_scope": None,
+        "basic": (),
+        "advanced": (
+            {
+                "display_args": ("--[no-]foo-opt2",),
+                "comma_separated_display_args": "--[no-]foo-opt2",
+                "scoped_cmd_line_args": ("--foo-opt2", "--no-foo-opt2"),
+                "unscoped_cmd_line_args": ("--opt2", "--no-opt2"),
+                "config_key": "opt2",
+                "env_var": "PANTS_FOO_OPT2",
+                "value_history": {
+                    "ranked_values": (
+                        {"rank": Rank.NONE, "value": None, "details": None},
+                        {"rank": Rank.HARDCODED, "value": True, "details": None},
+                    ),
+                },
+                "typ": bool,
+                "default": True,
+                "help": "Option 2",
+                "deprecation_active": False,
+                "deprecated_message": None,
+                "removal_version": None,
+                "removal_hint": None,
+                "choices": None,
+                "comma_separated_choices": None,
+            },
+        ),
+        "deprecated": tuple(),
+    }
+    expected_scope_to_help__bar = {
+        "scope": "bar",
+        "provider": "help_info_extracter_test",
+        "description": "The bar goal.",
+        "is_goal": True,
+        "deprecated_scope": "bar-old",
+        "basic": tuple(),
+        "advanced": tuple(),
+        "deprecated": tuple(),
+    }
+    expected_scope_to_help__bar_old = {
+        "scope": "bar-old",
+        "provider": "help_info_extracter_test",
+        "description": "The bar goal.",
+        "is_goal": True,
+        "deprecated_scope": "bar-old",
+        "basic": tuple(),
+        "advanced": tuple(),
+        "deprecated": tuple(),
+    }
+    scope_to_help_info = all_help_info_dict["scope_to_help_info"]
+    assert scope_to_help_info[GLOBAL_SCOPE] == expected_scope_to_help__global
+    assert scope_to_help_info["foo"] == expected_scope_to_help__foo
+    assert scope_to_help_info["bar"] == expected_scope_to_help__bar
+    assert scope_to_help_info["bar-old"] == expected_scope_to_help__bar_old
+
+    rule_output_help = all_help_info_dict["rule_output_type_to_rule_infos"]
+    assert rule_output_help == {
+        "Foo": (
+            {
+                "description": None,
+                "help": "A foo.",
+                "input_gets": ("Get(ScopedOptions, Scope, ..)",),
+                "input_types": (),
+                "name": "construct_scope_foo",
+                "output_desc": None,
+                "output_type": "Foo",
                 "provider": "help_info_extracter_test",
-                "summary": "A library of baz-es.",
-                "description": "A library of baz-es.\n\nUse it however you like.",
-                "fields": (
-                    {
-                        "alias": "qux",
-                        "provider": "",
-                        "default": "'blahblah'",
-                        "description": "A qux string.",
-                        "required": False,
-                        "type_hint": "str | None",
-                    },
-                    {
-                        "alias": "quux",
-                        "provider": "",
-                        "default": None,
-                        "description": "A quux int.\n\nMust be non-zero. Or zero. "
-                        "Whatever you like really.",
-                        "required": True,
-                        "type_hint": "int",
-                    },
+            },
+        ),
+        "Target": (
+            {
+                "description": None,
+                "help": "This rule is for testing info extraction only.",
+                "input_gets": (),
+                "input_types": ("Foo",),
+                "name": "pants.help.help_info_extracter_test.test_get_all_help_info.rule_info_test",
+                "output_desc": (
+                    "A Target represents an addressable set of metadata.\n\n    Set the "
+                    "`help` class property with a description, which will be used in "
+                    "`./pants help`. For the\n    best rendering, use soft wrapping (e.g. "
+                    "implicit string concatenation) within paragraphs, but\n    hard wrapping "
+                    "(`\n`) to separate distinct paragraphs and/or lists.\n    "
                 ),
-            }
+                "output_type": "Target",
+                "provider": "help_info_extracter_test",
+            },
+        ),
+    }
+
+    name_to_goal_info = all_help_info_dict["name_to_goal_info"]
+    assert name_to_goal_info == {
+        "bar": {
+            "name": "bar",
+            "provider": "help_info_extracter_test",
+            "description": "The bar goal.",
+            "consumed_scopes": ("somescope", "used_by_bar"),
+            "is_implemented": True,
+        },
+        "bar-old": {
+            "name": "bar",
+            "provider": "help_info_extracter_test",
+            "description": "The bar goal.",
+            "consumed_scopes": ("somescope", "used_by_bar-old"),
+            "is_implemented": True,
         },
     }
-    assert expected_all_help_info_dict == all_help_info_dict
+
+    name_to_target_type_info = all_help_info_dict["name_to_target_type_info"]
+    assert name_to_target_type_info == {
+        "baz_library": {
+            "alias": "baz_library",
+            "provider": "help_info_extracter_test",
+            "summary": "A library of baz-es.",
+            "description": "A library of baz-es.\n\nUse it however you like.",
+            "fields": (
+                {
+                    "alias": "qux",
+                    "provider": "",
+                    "default": "'blahblah'",
+                    "description": "A qux string.",
+                    "required": False,
+                    "type_hint": "str | None",
+                },
+                {
+                    "alias": "quux",
+                    "provider": "",
+                    "default": None,
+                    "description": "A quux int.\n\nMust be non-zero. Or zero. "
+                    "Whatever you like really.",
+                    "required": True,
+                    "type_hint": "int",
+                },
+            ),
+        }
+    }
 
 
 def test_pretty_print_type_hint() -> None:

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -505,6 +505,25 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
 DEFAULT_LOCAL_STORE_OPTIONS = LocalStoreOptions()
 
 
+class LogLevelOption(EnumOption):
+    """The `--level` option.
+
+    This is a dedicated class because it's the only option where we allow both the short flag `-l`
+    and the long flag `--level`.
+    """
+
+    def __new__(cls):
+        self = super().__new__(
+            cls,
+            "--level",
+            default=LogLevel.INFO,
+            daemon=True,
+            help="Set the logging level.",
+        )
+        self._flag_names = ("--level", "-l")
+        return self
+
+
 class BootstrapOptions:
     """The set of options necessary to create a Scheduler.
 
@@ -548,14 +567,7 @@ class BootstrapOptions:
         default=False,
         help="Re-resolve plugins, even if previously resolved.",
     )
-    level = EnumOption(
-        "--level",
-        default=LogLevel.INFO,
-        daemon=True,
-        help="Set the logging level.",
-        # This is the only option where we allow a short flag name.
-        _unsafe_short_flag_name="-l",
-    )
+    level = LogLevelOption()
     show_log_target = BoolOption(
         "--show-log-target",
         default=False,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -549,11 +549,12 @@ class BootstrapOptions:
         help="Re-resolve plugins, even if previously resolved.",
     )
     level = EnumOption(
-        "-l",
         "--level",
         default=LogLevel.INFO,
         daemon=True,
         help="Set the logging level.",
+        # This is the only option where we allow a short flag name.
+        _unsafe_short_flag_name="-l",
     )
     show_log_target = BoolOption(
         "--show-log-target",

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -505,23 +505,23 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
 DEFAULT_LOCAL_STORE_OPTIONS = LocalStoreOptions()
 
 
-class LogLevelOption(EnumOption):
+class LogLevelOption(EnumOption[LogLevel, LogLevel]):
     """The `--level` option.
 
     This is a dedicated class because it's the only option where we allow both the short flag `-l`
     and the long flag `--level`.
     """
 
-    def __new__(cls):
+    def __new__(cls) -> LogLevelOption:
         self = super().__new__(
-            cls,
+            cls,  # type: ignore[arg-type]
             "--level",
             default=LogLevel.INFO,
             daemon=True,
             help="Set the logging level.",
         )
         self._flag_names = ("--level", "-l")
-        return self
+        return self  # type: ignore[return-value]
 
 
 class BootstrapOptions:

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -520,7 +520,7 @@ class LogLevelOption(EnumOption[LogLevel, LogLevel]):
             daemon=True,
             help="Set the logging level.",
         )
-        self._flag_names = ("--level", "-l")
+        self._flag_names = ("-l", "--level")
         return self  # type: ignore[return-value]
 
 

--- a/src/python/pants/option/option_types.py
+++ b/src/python/pants/option/option_types.py
@@ -98,9 +98,8 @@ class _OptionBase(Generic[_OptT, _DefaultT]):
     ):
         """Construct a new Option descriptor.
 
-        :param flag_name: Either the long "--" or short "-" flag name (E.g. "--skip")
-        :param additional_flag_names: Additional flag names (if `flag_name` is set to the short
-            name).
+        :param flag_name: The argument name, starting with "--", e.g. "--skip".
+        :param additional_flag_names: Additional flag names. Usually this should be left off.
         :param default: The default value the property will return if unspecified by the user. Note
             that for "scalar" option types (like StrOption and IntOption) this can either be an
             instance of the scalar type or `None`, but __must__ be provided.

--- a/src/python/pants/option/option_types.py
+++ b/src/python/pants/option/option_types.py
@@ -95,7 +95,6 @@ class _OptionBase(Generic[_OptT, _DefaultT]):
         # Internal bells/whistles
         daemon: bool | None = None,
         fingerprint: bool | None = None,
-        _unsafe_short_flag_name: str | None = None,
     ):
         """Construct a new Option descriptor.
 
@@ -130,9 +129,7 @@ class _OptionBase(Generic[_OptT, _DefaultT]):
             user when running `help`.
         """
         self = super().__new__(cls)
-        self._flag_names = (
-            (_unsafe_short_flag_name, flag_name) if _unsafe_short_flag_name else (flag_name,)
-        )
+        self._flag_names = (flag_name,)
         self._default = default
         self._help = help
         self._register_if = register_if or (lambda cls: True)  # type: ignore[assignment]
@@ -441,7 +438,6 @@ class EnumOption(_OptionBase[_OptT, _DefaultT]):
         # Internal bells/whistles
         daemon: bool | None = None,
         fingerprint: bool | None = None,
-        _unsafe_short_flag_name: str | None = None,
     ) -> EnumOption[_EnumT, _EnumT]:
         ...
 
@@ -466,7 +462,6 @@ class EnumOption(_OptionBase[_OptT, _DefaultT]):
         # Internal bells/whistles
         daemon: bool | None = None,
         fingerprint: bool | None = None,
-        _unsafe_short_flag_name: str | None = None,
     ) -> EnumOption[_EnumT, _EnumT]:
         ...
 
@@ -491,7 +486,6 @@ class EnumOption(_OptionBase[_OptT, _DefaultT]):
         # Internal bells/whistles
         daemon: bool | None = None,
         fingerprint: bool | None = None,
-        _unsafe_short_flag_name: str | None = None,
     ) -> EnumOption[_EnumT, None]:
         ...
 
@@ -514,7 +508,6 @@ class EnumOption(_OptionBase[_OptT, _DefaultT]):
         # Internal bells/whistles
         daemon=None,
         fingerprint=None,
-        _unsafe_short_flag_name: str | None = None,
     ):
         instance = super().__new__(
             cls,
@@ -531,7 +524,6 @@ class EnumOption(_OptionBase[_OptT, _DefaultT]):
             removal_hint=removal_hint,
             daemon=daemon,
             fingerprint=fingerprint,
-            _unsafe_short_flag_name=_unsafe_short_flag_name,
         )
         instance._enum_type = enum_type
         return instance


### PR DESCRIPTION
We never use two flags for the same option anymore, except for `-l` and `--level`. In https://github.com/pantsbuild/pants/pull/10982, we moved away from this approach under the argument that there should be one way to refer to the option. Otherwise users get confused whether things are the same etc.

This enforces that expectation with the new Options API, but not yet the underlying `parser.py` which still needs to accommodate `-l` and `--level` being the same thing.

[ci skip-rust]
[ci skip-build-wheels]