### PR TITLE
[Plugin API change] Remove default help message from MultipleSourcesField

### DIFF
--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1991,16 +1991,6 @@ class MultipleSourcesField(SourcesField, StringSequenceField):
     """
 
     alias = "sources"
-    help = softwrap(
-        """
-        A list of files and globs that belong to this target.
-
-        Paths are relative to the BUILD file's directory. You can ignore files/globs by
-        prefixing them with `!`.
-
-        Example: `sources=['example.ext', 'test_*.ext', '!test_ignore.ext']`.
-        """
-    )
 
     ban_subdirectories: ClassVar[bool] = False
 

--- a/src/python/pants/init/BUILD
+++ b/src/python/pants/init/BUILD
@@ -17,6 +17,6 @@ python_sources(
 python_tests(
     name="tests",
     overrides={
-        "load_backends_integration_test.py": {"timeout": 300},
+        "load_backends_integration_test.py": {"timeout": 450},
     },
 )

--- a/src/python/pants/init/load_backends_integration_test.py
+++ b/src/python/pants/init/load_backends_integration_test.py
@@ -22,7 +22,7 @@ def discover_backends() -> List[str]:
 
 def assert_backends_load(backends: List[str]) -> None:
     run_pants(
-        ["--no-verify-config", "--version"], config={"GLOBAL": {"backend_packages": backends}}
+        ["--no-verify-config", "help-all"], config={"GLOBAL": {"backend_packages": backends}}
     ).assert_success(f"Failed to load: {backends}")
 
 


### PR DESCRIPTION
We would like plugin authors to provide custom examples of the files for the type of sources for a given target. Therefore, the default help message is now removed.

The integration test that loads all backends is modified to run `help-all` goal so that we can make sure that all plugins' targets have own help defined.

[ci skip-rust]
[ci skip-build-wheels]