### PR TITLE
[docs] Add language specific file examples for sources help message of a target

### DIFF
--- a/src/python/pants/backend/cc/target_types.py
+++ b/src/python/pants/backend/cc/target_types.py
@@ -14,6 +14,7 @@ from pants.engine.target import (
     SingleSourceField,
     Target,
     TargetFilesGenerator,
+    generate_multiple_sources_field_help_message,
 )
 
 CC_FILE_EXTENSIONS = (".c", ".h", ".cc", ".cpp", ".hpp")
@@ -58,6 +59,9 @@ class CCSourceTarget(Target):
 
 class CCSourcesGeneratorSourcesField(CCGeneratorSourcesField):
     default = tuple(f"*{ext}" for ext in CC_FILE_EXTENSIONS)
+    help = generate_multiple_sources_field_help_message(
+        "Example: `sources=['example.cpp', 'new_*.cc', '!old_ignore.cc']`"
+    )
 
 
 class CCSourcesGeneratorTarget(TargetFilesGenerator):

--- a/src/python/pants/backend/codegen/avro/target_types.py
+++ b/src/python/pants/backend/codegen/avro/target_types.py
@@ -13,6 +13,7 @@ from pants.engine.target import (
     TargetFilesGenerator,
     Targets,
     generate_file_based_overrides_field_help_message,
+    generate_multiple_sources_field_help_message,
 )
 from pants.util.docutil import doc_url
 from pants.util.logging import LogLevel
@@ -67,6 +68,9 @@ class AvroSourceTarget(Target):
 class AvroSourcesGeneratingSourcesField(MultipleSourcesField):
     default = ("*.avsc", "*.avpr", "*.avdl")
     expected_file_extensions = (".avsc", ".avpr", ".avdl")
+    help = generate_multiple_sources_field_help_message(
+        "Example: `sources=['example.avsc', 'new_*.avpr', '!old_ignore.avdl']`"
+    )
 
 
 class AvroSourcesOverridesField(OverridesField):


### PR DESCRIPTION
Have discovered a few more places that need to have an own help.

[ci skip-rust]
[ci skip-build-wheels]