### PR TITLE
Go can use both `file` and `resource` targets

### DIFF
--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -29,7 +29,7 @@ from pants.backend.go.util_rules.import_analysis import ImportConfig, ImportConf
 from pants.backend.go.util_rules.link import LinkedGoBinary, LinkGoBinaryRequest
 from pants.backend.go.util_rules.tests_analysis import GeneratedTestMain, GenerateTestMainRequest
 from pants.core.goals.test import TestDebugRequest, TestFieldSet, TestResult, TestSubsystem
-from pants.core.target_types import FileSourceField
+from pants.core.target_types import FileSourceField, ResourceSourceField
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import EMPTY_FILE_DIGEST, AddPrefix, Digest, MergeDigests
 from pants.engine.process import FallibleProcessResult, Process, ProcessCacheScope
@@ -289,7 +289,7 @@ async def run_go_tests(
             SourceFiles,
             SourceFilesRequest(
                 (dep.get(SourcesField) for dep in dependencies),
-                for_sources_types=(FileSourceField,),
+                for_sources_types=(FileSourceField, ResourceSourceField),
                 enable_codegen=True,
             ),
         ),

--- a/src/python/pants/backend/go/goals/test_test.py
+++ b/src/python/pants/backend/go/goals/test_test.py
@@ -25,7 +25,7 @@ from pants.backend.go.util_rules import (
 )
 from pants.backend.go.util_rules.sdk import GoSdkProcess
 from pants.core.goals.test import TestResult
-from pants.core.target_types import FileTarget
+from pants.core.target_types import FileTarget, ResourceTarget
 from pants.core.util_rules import source_files
 from pants.engine.addresses import Address
 from pants.engine.process import ProcessResult
@@ -51,7 +51,7 @@ def rule_runner() -> RuleRunner:
             QueryRule(TestResult, [GoTestFieldSet]),
             QueryRule(ProcessResult, [GoSdkProcess]),
         ],
-        target_types=[GoModTarget, GoPackageTarget, FileTarget],
+        target_types=[GoModTarget, GoPackageTarget, FileTarget, ResourceTarget],
     )
     rule_runner.set_options(["--go-test-args=-v -bench=."], env_inherit={"PATH"})
     return rule_runner
@@ -617,7 +617,7 @@ def test_compilation_error(rule_runner: RuleRunner) -> None:
     assert "failed to parse" in result.stderr
 
 
-def test_file_dependencies(rule_runner: RuleRunner) -> None:
+def test_resource_dependencies(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
             "f.txt": "",
@@ -626,7 +626,7 @@ def test_file_dependencies(rule_runner: RuleRunner) -> None:
                 """
                 go_mod(name='mod')
                 go_package(dependencies=[":testdata", "//:root"])
-                file(name="testdata", source="testdata/f.txt")
+                resource(name="testdata", source="testdata/f.txt")
                 """
             ),
             "foo/go.mod": "module foo",

--- a/src/python/pants/backend/go/util_rules/first_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg.py
@@ -21,7 +21,7 @@ from pants.backend.go.util_rules.go_mod import (
 )
 from pants.backend.go.util_rules.pkg_analyzer import PackageAnalyzerSetup
 from pants.build_graph.address import Address
-from pants.core.target_types import ResourceSourceField
+from pants.core.target_types import FileSourceField, ResourceSourceField
 from pants.core.util_rules import source_files
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.engine_aware import EngineAwareParameter
@@ -307,9 +307,9 @@ async def setup_first_party_pkg_digest(
                     # TODO(#13795): Error if you depend on resources above the go_package?
                     if t.address.spec_path.startswith(request.address.spec_path)
                 ),
-                for_sources_types=(ResourceSourceField,),
-                # TODO: Switch to True. We need to be confident though that the generated files
-                #  are located below the go_package.
+                for_sources_types=(FileSourceField, ResourceSourceField),
+                # TODO(#13795): Switch to True. We need to be confident though that the generated
+                #  files are located below the go_package.
                 enable_codegen=False,
             ),
         )


### PR DESCRIPTION
Per https://docs.google.com/document/d/1pGib2ZJiyltfij0aZMm81S2XbATa8s6_ghuLnf2Xr_k/edit#heading=h.nigy6wpeltj9, there was literally no reason at all to require `embeds` to come from `resource` but testdata from `file`. Go doesn't even use source roots!

[ci skip-rust]
[ci skip-build-wheels]