### PR TITLE
Fix detection of `--help` when specs given

### DIFF
--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -230,7 +230,11 @@ class ArgSplitter:
     def likely_a_spec(self, arg: str) -> bool:
         """Return whether `arg` looks like a spec, rather than a goal name."""
         # Check if it's an ignore spec.
-        if arg.startswith("-") and arg not in self._single_dash_goal_aliases:
+        if (
+            arg.startswith("-")
+            and arg not in self._single_dash_goal_aliases
+            and not arg.startswith("--")
+        ):
             return True
         return any(c in arg for c in (os.path.sep, ".", ":", "*", "#")) or os.path.exists(
             os.path.join(self._buildroot, arg)

--- a/src/python/pants/option/arg_splitter_test.py
+++ b/src/python/pants/option/arg_splitter_test.py
@@ -81,7 +81,6 @@ def test_is_spec(tmp_path: Path, splitter: ArgSplitter, known_scope_infos: list[
         "a/b/*.txt",
         "a/b/test*",
         "a/**/*",
-        "-",
         "a/b.txt:tgt",
         "a/b.txt:../tgt",
         "dir#gen",
@@ -99,6 +98,9 @@ def test_is_spec(tmp_path: Path, splitter: ArgSplitter, known_scope_infos: list[
     for s in unambiguous_specs:
         assert splitter.likely_a_spec(s) is True
         assert splitter.likely_a_spec(f"-{s}") is True
+
+    assert splitter.likely_a_spec("-") is True
+    assert splitter.likely_a_spec("--") is False
 
     # With directories on disk to tiebreak.
     splitter = ArgSplitter(known_scope_infos, tmp_path.as_posix())
@@ -363,6 +365,24 @@ def help_no_arguments_test(command_line: str, *scopes: str, **expected):
         ),
         help_test(
             "./pants test src/foo/bar:baz -h",
+            expected_goals=["test"],
+            expected_scope_to_flags={"": [], "test": [], "help": []},
+            expected_specs=["src/foo/bar:baz"],
+        ),
+        help_test(
+            "./pants test src/foo/bar:baz --help",
+            expected_goals=["test"],
+            expected_scope_to_flags={"": [], "test": [], "help": []},
+            expected_specs=["src/foo/bar:baz"],
+        ),
+        help_test(
+            "./pants --help test src/foo/bar:baz",
+            expected_goals=["test"],
+            expected_scope_to_flags={"": [], "test": [], "help": []},
+            expected_specs=["src/foo/bar:baz"],
+        ),
+        help_test(
+            "./pants test --help src/foo/bar:baz",
             expected_goals=["test"],
             expected_scope_to_flags={"": [], "test": [], "help": []},
             expected_specs=["src/foo/bar:baz"],


### PR DESCRIPTION
Part of https://github.com/pantsbuild/pants/issues/15660.

This specifically fixes the case:

```
$ ./pants test src/python/pants/bsp/protocol_test.py --help
11:00:27.87 [INFO] Completed: Run Pytest - src/python/pants/bsp/protocol_test.py:tests succeeded.

✓ src/python/pants/bsp/protocol_test.py:tests succeeded in 1.10s (cached locally).
```

Now, we get

```
❯ ./pants test --help src/python/pants/util
Unknown entity: src/python/pants/util
Did you mean python_test_utils?
```

We must decide with https://github.com/pantsbuild/pants/pull/15646 whether we want to try detecting this is a spec, and if so, ignore it.

[ci skip-rust]
[ci skip-build-wheels]