### PR TITLE
Show help whenever possible.

### DIFF
--- a/src/python/pants/goal/help.py
+++ b/src/python/pants/goal/help.py
@@ -81,7 +81,8 @@ class ThingHelpBuiltinGoalBase(HelpBuiltinGoalBase):
         # them is deemed "likely a spec" by `pants.option.arg_splitter:ArgSplitter.likely_a_spec()`.
         return ThingHelp(
             advanced=self._advanced,
-            things=tuple(options.goals) + tuple(options.unknown_goals) + tuple(options.specs),
+            things=tuple(options.goals) + tuple(options.unknown_goals),
+            likely_specs=tuple(options.specs),
         )
 
 

--- a/src/python/pants/goal/help.py
+++ b/src/python/pants/goal/help.py
@@ -79,6 +79,7 @@ class ThingHelpBuiltinGoalBase(HelpBuiltinGoalBase):
     def create_help_request(self, options: Options) -> HelpRequest:
         # Include the `options.specs` for things to give help on, as args with any . : * or # in
         # them is deemed "likely a spec" by `pants.option.arg_splitter:ArgSplitter.likely_a_spec()`.
+        # We want to support getting help on API types that may contain periods.
         return ThingHelp(
             advanced=self._advanced,
             things=tuple(options.goals) + tuple(options.unknown_goals),

--- a/src/python/pants/help/help_integration_test.py
+++ b/src/python/pants/help/help_integration_test.py
@@ -204,3 +204,11 @@ def test_help_provided_target_plugin_field() -> None:
         )
         in pants_run.stdout
     )
+
+
+def test_help_ignore_specs() -> None:
+    pants_run = run_pants(
+        ["test", "src/python/pants/bsp/protocol_test.py", "--help"],
+    )
+    pants_run.assert_success()
+    assert "`test` goal options" in pants_run.stdout

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -161,17 +161,16 @@ class HelpPrinter(MaybeColor):
         Note: Ony useful if called after options have been registered.
         """
         help_request = cast(ThingHelp, self._help_request)
-        things = set(help_request.things)
+        things = set(help_request.things + help_request.likely_specs)
         help_table = self._get_thing_help_table()
         maybe_unknown_things = {thing for thing in things if thing not in help_table}
         disambiguated_things, unknown_things = self._disambiguate_things(
             maybe_unknown_things, help_table.keys()
         )
         things = things - maybe_unknown_things | disambiguated_things
+        unknown_things -= set(help_request.likely_specs)
 
-        if unknown_things and not things:
-            # Ignore unknown things if there are known things to show help for.
-
+        if unknown_things:
             # Only print help and suggestions for the first unknown thing.
             # It gets confusing to try and show suggestions for multiple cases.
             thing = unknown_things.pop()

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -167,7 +167,11 @@ class HelpPrinter(MaybeColor):
         disambiguated_things, unknown_things = self._disambiguate_things(
             maybe_unknown_things, help_table.keys()
         )
-        if unknown_things:
+        things = things - maybe_unknown_things | disambiguated_things
+
+        if unknown_things and not things:
+            # Ignore unknown things if there are known things to show help for.
+
             # Only print help and suggestions for the first unknown thing.
             # It gets confusing to try and show suggestions for multiple cases.
             thing = unknown_things.pop()
@@ -183,7 +187,6 @@ class HelpPrinter(MaybeColor):
             )
             return 1
 
-        things = things - maybe_unknown_things | disambiguated_things
         if not things:
             self._print_global_help()
             return 0

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -161,6 +161,7 @@ class HelpPrinter(MaybeColor):
         Note: Ony useful if called after options have been registered.
         """
         help_request = cast(ThingHelp, self._help_request)
+        # API types may end up in `likely_specs`, so include them in things to get help for.
         things = set(help_request.things + help_request.likely_specs)
         help_table = self._get_thing_help_table()
         maybe_unknown_things = {thing for thing in things if thing not in help_table}
@@ -168,6 +169,7 @@ class HelpPrinter(MaybeColor):
             maybe_unknown_things, help_table.keys()
         )
         things = things - maybe_unknown_things | disambiguated_things
+        # Filter out likely specs from unknown things, as we don't want them to interfere.
         unknown_things -= set(help_request.likely_specs)
 
         if unknown_things:

--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -40,6 +40,7 @@ class ThingHelp(HelpRequest):
 
     advanced: bool = False
     things: tuple[str, ...] = ()
+    likely_specs: tuple[str, ...] = ()
 
 
 class VersionHelp(HelpRequest):


### PR DESCRIPTION
Part 2/2 closes #15660 
Part 1/2 was #15664 

Given `./pants test src/python/pants/bsp/protocol_test.py src/python/:: --help` we should show help for `test`, disregarding the "unknown" things (specs) that follow.