### PR TITLE
`update-build-files` falls back to interpreter constraints from tool lockfile for Black and Yapf

### DIFF
--- a/src/python/pants/backend/python/util_rules/lockfile_metadata.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_metadata.py
@@ -37,7 +37,7 @@ class PythonLockfileMetadata(LockfileMetadata):
     def new(
         valid_for_interpreter_constraints: InterpreterConstraints,
         requirements: set[PipRequirement],
-    ) -> LockfileMetadata:
+    ) -> PythonLockfileMetadata:
         """Call the most recent version of the `LockfileMetadata` class to construct a concrete
         instance.
 

--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -17,8 +17,15 @@ from colors import green, red
 
 from pants.backend.python.lint.black.subsystem import Black
 from pants.backend.python.lint.yapf.subsystem import Yapf
+from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.util_rules import pex
+from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
+from pants.backend.python.util_rules.pex_requirements import (
+    EntireLockfile,
+    LoadedLockfile,
+    LoadedLockfileRequest,
+)
 from pants.base.deprecated import warn_or_error
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.engine.console import Console
@@ -38,7 +45,7 @@ from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.internals.build_files import BuildFileOptions
 from pants.engine.internals.parser import ParseError
 from pants.engine.process import ProcessResult
-from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
+from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule, rule_helper
 from pants.engine.target import RegisteredTargetTypes, TargetGenerator
 from pants.engine.unions import UnionMembership, UnionRule, union
 from pants.option.option_types import BoolOption, EnumOption
@@ -292,6 +299,36 @@ async def update_build_files(
     return UpdateBuildFilesGoal(exit_code=1 if update_build_files_subsystem.check else 0)
 
 
+@rule_helper
+async def _find_python_interpreter_constraints_from_lockfile(
+    subsystem: PythonToolBase,
+) -> InterpreterConstraints:
+    """If a lockfile is used, will try to find the interpreter constraints used to generate the
+    lock.
+
+    This allows us to work around https://github.com/pantsbuild/pants/issues/14912.
+    """
+    # If the tool's interpreter constraints are explicitly set, or it is not using a lockfile at
+    # all, then we should use the tool's interpreter constraints option.
+    if not subsystem.options.is_default("interpreter_constraints") or not subsystem.uses_lockfile:
+        return subsystem.interpreter_constraints
+
+    # If using Pants's default lockfile, we can simply use the tool's default interpreter
+    # constraints, which we trust were used to generate Pants's default tool lockfile.
+    if not subsystem.uses_custom_lockfile:
+        return InterpreterConstraints(subsystem.default_interpreter_constraints)
+
+    # Else, try to load the metadata block from the lockfile.
+    requirements = subsystem.pex_requirements()
+    assert isinstance(requirements, EntireLockfile)
+    lockfile = await Get(LoadedLockfile, LoadedLockfileRequest(requirements.lockfile))
+    return (
+        lockfile.metadata.valid_for_interpreter_constraints
+        if lockfile.metadata
+        else subsystem.interpreter_constraints
+    )
+
+
 # ------------------------------------------------------------------------------------------
 # Yapf formatter fixer
 # ------------------------------------------------------------------------------------------
@@ -305,7 +342,8 @@ class FormatWithYapfRequest(RewrittenBuildFileRequest):
 async def format_build_file_with_yapf(
     request: FormatWithYapfRequest, yapf: Yapf
 ) -> RewrittenBuildFile:
-    yapf_pex_get = Get(VenvPex, PexRequest, yapf.to_pex_request())
+    yapf_ics = await _find_python_interpreter_constraints_from_lockfile(yapf)
+    yapf_pex_get = Get(VenvPex, PexRequest, yapf.to_pex_request(interpreter_constraints=yapf_ics))
     build_file_digest_get = Get(Digest, CreateDigest([request.to_file_content()]))
     config_files_get = Get(
         ConfigFiles, ConfigFilesRequest, yapf.config_request(recursive_dirname(request.path))
@@ -358,7 +396,10 @@ class FormatWithBlackRequest(RewrittenBuildFileRequest):
 async def format_build_file_with_black(
     request: FormatWithBlackRequest, black: Black
 ) -> RewrittenBuildFile:
-    black_pex_get = Get(VenvPex, PexRequest, black.to_pex_request())
+    black_ics = await _find_python_interpreter_constraints_from_lockfile(black)
+    black_pex_get = Get(
+        VenvPex, PexRequest, black.to_pex_request(interpreter_constraints=black_ics)
+    )
     build_file_digest_get = Get(Digest, CreateDigest([request.to_file_content()]))
     config_files_get = Get(
         ConfigFiles, ConfigFilesRequest, black.config_request(recursive_dirname(request.path))

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -558,20 +558,24 @@ def run_rule_with_mocks(
     """
 
     task_rule = getattr(rule, "rule", None)
-    if task_rule is None:
-        raise TypeError(f"Expected to receive a decorated `@rule`; got: {rule}")
+    rule_helper = getattr(rule, "rule_helper", None)
+    if task_rule is None and rule_helper is None:
+        raise TypeError(f"Expected to receive a decorated `@rule` or `@rule_helper`; got: {rule}")
 
-    if len(rule_args) != len(task_rule.input_selectors):
-        raise ValueError(
-            f"Rule expected to receive arguments of the form: {task_rule.input_selectors}; got: {rule_args}"
-        )
+    # Perform additional validation on `@rule` that the correct args are provided. We don't have
+    # an easy way to do this for `@rule_helper` yet.
+    if task_rule:
+        if len(rule_args) != len(task_rule.input_selectors):
+            raise ValueError(
+                f"Rule expected to receive arguments of the form: {task_rule.input_selectors}; got: {rule_args}"
+            )
 
-    if len(mock_gets) != len(task_rule.input_gets):
-        raise ValueError(
-            f"Rule expected to receive Get providers for:\n"
-            f"{pformat(task_rule.input_gets)}\ngot:\n"
-            f"{pformat(mock_gets)}"
-        )
+        if len(mock_gets) != len(task_rule.input_gets):
+            raise ValueError(
+                f"Rule expected to receive Get providers for:\n"
+                f"{pformat(task_rule.input_gets)}\ngot:\n"
+                f"{pformat(mock_gets)}"
+            )
 
     res = rule(*(rule_args or ()))
     if not isinstance(res, (CoroutineType, GeneratorType)):


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/14912.

To test this, we teach `run_rule_with_mocks` how to handle `@rule_helper`.

[ci skip-rust]
[ci skip-build-wheels]