### PR TITLE
Disable excess stats logging in CI.

### DIFF
--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -6,10 +6,6 @@ remote_cache_write = true
 # We want to continue to get logs when remote caching errors.
 remote_cache_warnings = "backoff"
 
-[stats]
-log = true
-memory_summary = true
-
 [test]
 use_coverage = true
 


### PR DESCRIPTION
These outputs roughly double the size of our CI output, but neither of them is actively under investigation.

[ci skip-rust]
[ci skip-build-wheels]