### PR TITLE
`resource` target does not always require a source root

### DIFF
--- a/src/python/pants/core/util_rules/source_files.py
+++ b/src/python/pants/core/util_rules/source_files.py
@@ -20,7 +20,7 @@ class SourceFiles:
     snapshot: Snapshot
 
     # The subset of files in snapshot that are not intended to have an associated source root.
-    # That is, the sources of unrooted resources() targets.
+    # That is, the sources of files and unrooted resources() targets.
     unrooted_files: Tuple[str, ...]
 
     @property

--- a/src/python/pants/core/util_rules/stripped_source_files_test.py
+++ b/src/python/pants/core/util_rules/stripped_source_files_test.py
@@ -56,10 +56,11 @@ def test_strip_snapshot(rule_runner: RuleRunner) -> None:
     def get_stripped_files_for_snapshot(
         paths: list[str],
         *,
+        unstripped: Sequence[str] = (),
         source_root_patterns: Sequence[str] = ("src/python", "src/java", "tests/python"),
     ) -> list[str]:
-        input_snapshot = rule_runner.make_snapshot_of_empty_files(paths)
-        request = SourceFiles(input_snapshot, ())
+        input_snapshot = rule_runner.make_snapshot_of_empty_files((*paths, *unstripped))
+        request = SourceFiles(input_snapshot, tuple(unstripped))
         return get_stripped_files(rule_runner, request, source_root_patterns=source_root_patterns)
 
     # Normal source roots
@@ -76,6 +77,10 @@ def test_strip_snapshot(rule_runner: RuleRunner) -> None:
     assert get_stripped_files_for_snapshot(["tests/python/project_test/example.py"]) == [
         "project_test/example.py"
     ]
+
+    assert get_stripped_files_for_snapshot(
+        ["src/python/project/example.py"], unstripped=["no-root/data.json"]
+    ) == ["no-root/data.json", "project/example.py"]
 
     # Unrecognized source root
     unrecognized_source_root = "no-source-root/example.txt"


### PR DESCRIPTION
This is actually the bulk of the heavy lifting for https://docs.google.com/document/d/1pGib2ZJiyltfij0aZMm81S2XbATa8s6_ghuLnf2Xr_k/.

Basically allows resources to be rooted (and do not show up in `unrooted_files` as well as unrooted (therefore do).

Most other changes are dominoes lined up from this change.

[ci skip-rust]
[ci skip-build-wheels]