### PR TITLE
Update `MAINTAINERS.md` for new maintainers.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,8 +1,11 @@
 Active Maintainers
 ==================
 
+* Alexey Tereshenkov
 * Andreas Stenius
 * Benjy Weinberger
+* Carina C. Zona
+* Christopher Neugebauer
 * Daniel McClanahan
 * Daniel Wagner-Hall
 * Eric Arellano
@@ -11,6 +14,7 @@ Active Maintainers
 * Ity Kaul
 * Patrick Lawson
 * John Sirois
+* Joshua Cannon
 * Kris Wilson
 * Nora Howard
 * Stu Hood


### PR DESCRIPTION
While we have this file, we should keep it updated. If we were to remove it though, we'd want to link directly to https://github.com/orgs/pantsbuild/teams/maintainers/members.

[ci skip-rust]
[ci skip-build-wheels]