### PR TITLE
Make the global --no-process-cleanup conserve the `run` tmpdir.

### DIFF
--- a/src/python/pants/backend/cc/dependency_inference/rules.py
+++ b/src/python/pants/backend/cc/dependency_inference/rules.py
@@ -47,7 +47,7 @@ class AllCCTargets(Targets):
 
 
 @rule(desc="Find all CC targets in project", level=LogLevel.DEBUG)
-def find_all_protobuf_targets(targets: AllTargets) -> AllCCTargets:
+def find_all_cc_targets(targets: AllTargets) -> AllCCTargets:
     return AllCCTargets(tgt for tgt in targets if tgt.has_field(CCSourceField))
 
 

--- a/src/python/pants/backend/python/util_rules/vcs_versioning.py
+++ b/src/python/pants/backend/python/util_rules/vcs_versioning.py
@@ -126,7 +126,7 @@ class AllVCSVersionTargets(Targets):
 
 
 @rule(desc="Find all vcs_version targets in project", level=LogLevel.DEBUG)
-def find_all_protobuf_targets(targets: AllTargets) -> AllVCSVersionTargets:
+def find_all_vcs_version_targets(targets: AllTargets) -> AllVCSVersionTargets:
     return AllVCSVersionTargets(tgt for tgt in targets if tgt.has_field(VersionGenerateToField))
 
 

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+import sys
 from typing import cast
 
 import pytest
@@ -98,7 +99,7 @@ def single_target_run(
 
 
 def test_normal_run(rule_runner: RuleRunner) -> None:
-    program_text = b'#!/usr/bin/python\nprint("hello")'
+    program_text = f'#!{sys.executable}\nprint("hello")'.encode()
     res = single_target_run(
         rule_runner,
         Address("some/addr"),
@@ -108,7 +109,7 @@ def test_normal_run(rule_runner: RuleRunner) -> None:
 
 
 def test_materialize_input_files(rule_runner: RuleRunner) -> None:
-    program_text = b'#!/usr/bin/python\nprint("hello")'
+    program_text = f'#!{sys.executable}\nprint("hello")'.encode()
     binary = create_mock_run_request(rule_runner, program_text)
     with mock_console(rule_runner.options_bootstrapper):
         result = rule_runner.run_interactive_process(
@@ -122,6 +123,6 @@ def test_materialize_input_files(rule_runner: RuleRunner) -> None:
 
 
 def test_failed_run(rule_runner: RuleRunner) -> None:
-    program_text = b'#!/usr/bin/python\nraise RuntimeError("foo")'
+    program_text = f'#!{sys.executable}\nraise RuntimeError("foo")'.encode()
     res = single_target_run(rule_runner, Address("some/addr"), program_text=program_text)
     assert res.exit_code == 1

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -64,7 +64,9 @@ def single_target_run(
             run,
             rule_args=[
                 create_goal_subsystem(RunSubsystem, args=[], cleanup=True),
-                create_subsystem(GlobalOptions, pants_workdir=rule_runner.pants_workdir),
+                create_subsystem(
+                    GlobalOptions, pants_workdir=rule_runner.pants_workdir, process_cleanup=True
+                ),
                 workspace,
                 BuildRoot(),
                 rule_runner.environment,

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -109,7 +109,10 @@ def temporary_dir(
     You may specify the following keyword args:
     :param root_dir: The parent directory to create the temporary directory.
     :param cleanup: Whether or not to clean up the temporary directory.
+    :param suffix: If not None the directory name will end with this suffix.
     :param permissions: If provided, sets the directory permissions to this mode.
+    :param prefix: If not None, the directory name will begin with this prefix,
+                   otherwise a default prefix is used.
     """
     path = tempfile.mkdtemp(dir=root_dir, suffix=suffix, prefix=prefix)
 


### PR DESCRIPTION
It seems intuitive that it should, and the --no-run-cleanup option is still
available for the more selective behavior of just preserving the run
process's tmpdir, rather than all process tmpdirs.

Also fixes the names of a couple of unrelated copypasta rules. This didn't justify
its own change and CI run.

[ci skip-rust]

[ci skip-build-wheels]