### PR TITLE
Add optional StringSequenceField.valid_choices

### DIFF
--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1502,23 +1502,8 @@ class InvalidFieldChoiceException(InvalidFieldException):
         valid_choices: Iterable[Any],
     ) -> None:
         super().__init__(
-            f"The {repr(field_alias)} field in target {address} must be one of "
-            f"{sorted(valid_choices)}, but was {repr(raw_value)}."
-        )
-
-
-class InvalidSequenceFieldChoiceException(InvalidFieldException):
-    def __init__(
-        self,
-        address: Address,
-        field_alias: str,
-        raw_value: Optional[Any],
-        *,
-        valid_choices: Iterable[Any],
-    ) -> None:
-        super().__init__(
-            f"Each item in the {repr(field_alias)} field in target {address} must be "
-            f"one of {sorted(valid_choices)}, but one item was {repr(raw_value)}."
+            f"Values for the {repr(field_alias)} field in target {address} must be one of "
+            f"{sorted(valid_choices)}, but {repr(raw_value)} was provided."
         )
 
 
@@ -1750,7 +1735,7 @@ class StringSequenceField(SequenceField[str]):
             )
             for choice in value_or_default:
                 if choice not in valid_choices:
-                    raise InvalidSequenceFieldChoiceException(
+                    raise InvalidFieldChoiceException(
                         address, cls.alias, choice, valid_choices=valid_choices
                     )
         return value_or_default

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1813,15 +1813,15 @@ def _validate_choices(
     *,
     valid_choices: Union[Type[Enum], Tuple[Any, ...]],
 ) -> None:
-    valid_choices = set(
+    _valid_choices = set(
         valid_choices
         if isinstance(valid_choices, tuple)
         else (choice.value for choice in valid_choices)
     )
     for choice in values:
-        if choice not in valid_choices:
+        if choice not in _valid_choices:
             raise InvalidFieldChoiceException(
-                address, field_alias, choice, valid_choices=valid_choices
+                address, field_alias, choice, valid_choices=_valid_choices
             )
 
 

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -28,7 +28,6 @@ from pants.engine.target import (
     InvalidFieldException,
     InvalidFieldTypeException,
     InvalidGeneratedTargetException,
-    InvalidSequenceFieldChoiceException,
     InvalidTargetException,
     MultipleSourcesField,
     NestedDictStringToStringField,
@@ -795,9 +794,9 @@ def test_string_sequence_field_valid_choices() -> None:
     assert GivenStrings(None, addr).value is None
     assert GivenEnum(None, addr).value == ("kale",)
 
-    with pytest.raises(InvalidSequenceFieldChoiceException):
+    with pytest.raises(InvalidFieldChoiceException):
         GivenStrings(["carrot"], addr)
-    with pytest.raises(InvalidSequenceFieldChoiceException):
+    with pytest.raises(InvalidFieldChoiceException):
         GivenEnum(["carrot"], addr)
 
 


### PR DESCRIPTION
This enhances StringSequenceField so that it can validate that each string is one of a limited set. Users just have to set `valid_choices` on their field to an enum or a sequence (list/tuple) of strings.

history:
I wrote this in https://github.com/st2sandbox/st2/blob/pants/pants-plugins/uses_services/target_types.py
and @Eric-Arellano suggested I submit it as a PR in https://github.com/st2sandbox/st2/issues/7 where they reviewed my plugins to give me helpful feedback.

[ci skip-rust]
[ci skip-build-wheels]