### PR TITLE
Add `experimental-explorer` builtin goal.

### DIFF
--- a/src/python/pants/engine/explorer.py
+++ b/src/python/pants/engine/explorer.py
@@ -1,0 +1,67 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable, TypeVar, cast
+
+from pants.base.exiter import ExitCode
+from pants.build_graph.build_configuration import BuildConfiguration
+from pants.engine.internals.scheduler import SchedulerSession
+from pants.engine.internals.selectors import Params
+from pants.engine.rules import QueryRule
+from pants.engine.unions import UnionRule, union
+from pants.help.help_info_extracter import AllHelpInfo
+
+T = TypeVar("T")
+
+
+@union
+@dataclass(frozen=True)
+class ExplorerServerRequest:
+    address: str
+    port: int
+    request_state: RequestState
+
+    @classmethod
+    def rules_for_implementation(cls, impl: type):
+        return (
+            UnionRule(cls, impl),
+            QueryRule(ExplorerServer, (impl,)),
+        )
+
+
+@dataclass(frozen=True)
+class ExplorerServer:
+    main: Callable[[], ExitCode]
+
+    def run(self) -> ExitCode:
+        # Work around a mypy issue with a callable attribute.  Related to
+        # https://github.com/python/mypy/issues/6910.  What has me bugged out is why we don't see
+        # this issue with `WorkunitsCallbackFactory.callback_factory` too, for instance.
+        main = cast("Callable[[], ExitCode]", getattr(self, "main"))
+        return main()
+
+
+@dataclass(frozen=True)
+class RequestState:
+    all_help_info: AllHelpInfo
+    build_configuration: BuildConfiguration
+    scheduler_session: SchedulerSession
+
+    def product_request(
+        self,
+        product: type[T],
+        subjects: Iterable[Any] = (),
+        poll: bool = False,
+        timeout: float | None = None,
+    ) -> T:
+        result = self.scheduler_session.product_request(
+            product,
+            [Params(*subjects)],
+            poll=poll,
+            timeout=timeout,
+        )
+        assert len(result) == 1
+        return cast(T, result[0])

--- a/src/python/pants/goal/builtins.py
+++ b/src/python/pants/goal/builtins.py
@@ -7,6 +7,7 @@ from pants.bsp.goal import BSPGoal
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.goal import help
 from pants.goal.builtin_goal import BuiltinGoal
+from pants.goal.explorer import ExplorerBuiltinGoal
 
 
 def register_builtin_goals(build_configuration: BuildConfiguration.Builder) -> None:
@@ -15,6 +16,7 @@ def register_builtin_goals(build_configuration: BuildConfiguration.Builder) -> N
 
 def builtin_goals() -> tuple[type[BuiltinGoal], ...]:
     return (
+        ExplorerBuiltinGoal,
         help.AllHelpBuiltinGoal,
         help.NoGoalHelpBuiltinGoal,
         help.ThingHelpBuiltinGoal,

--- a/src/python/pants/goal/explorer.py
+++ b/src/python/pants/goal/explorer.py
@@ -1,0 +1,77 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import logging
+
+from pants.base.exiter import ExitCode
+from pants.base.specs import Specs
+from pants.build_graph.build_configuration import BuildConfiguration
+from pants.engine.explorer import ExplorerServer, ExplorerServerRequest, RequestState
+from pants.engine.target import RegisteredTargetTypes
+from pants.engine.unions import UnionMembership
+from pants.goal.builtin_goal import BuiltinGoal
+from pants.help.help_info_extracter import HelpInfoExtracter
+from pants.init.engine_initializer import GraphSession
+from pants.option.option_types import IntOption, StrOption
+from pants.option.options import Options
+from pants.util.strutil import softwrap
+
+logger = logging.getLogger(__name__)
+
+
+class ExplorerBuiltinGoal(BuiltinGoal):
+    name = "experimental-explorer"
+    help = "Run the Pants Explorer Web UI server."
+    address = StrOption("--address", default="localhost", help="Server address to bind to.")
+    port = IntOption("--port", default=8000, help="Server port to bind to.")
+
+    def run(
+        self,
+        build_config: BuildConfiguration,
+        graph_session: GraphSession,
+        options: Options,
+        specs: Specs,
+        union_membership: UnionMembership,
+    ) -> ExitCode:
+        for server_request_type in union_membership.get(ExplorerServerRequest):
+            logger.info(f"Using {server_request_type.__name__} to create the explorer server.")
+            break
+        else:
+            logger.error(
+                softwrap(
+                    """
+                    There is no Explorer backend server implementation registered.
+
+                    Activate a backend/plugin that registers an implementation for the
+                    `ExplorerServerRequest` union to fix this issue.
+                    """
+                )
+            )
+            return 127
+
+        all_help_info = HelpInfoExtracter.get_all_help_info(
+            options,
+            union_membership,
+            graph_session.goal_consumed_subsystem_scopes,
+            RegisteredTargetTypes.create(build_config.target_types),
+            build_config,
+        )
+        request_state = RequestState(
+            all_help_info=all_help_info,
+            build_configuration=build_config,
+            scheduler_session=graph_session.scheduler_session,
+        )
+        server_request = server_request_type(
+            address=self.address,
+            port=self.port,
+            request_state=request_state,
+        )
+        server = request_state.product_request(
+            ExplorerServer,
+            (server_request,),
+            poll=True,
+            timeout=90,
+        )
+        return server.run()


### PR DESCRIPTION
This goal is the user interface to start a explorer backend API server, but relies on plugins to
provide the actual server implementation.

This is the minimum amount of code required to be in core Pants for: #14348    

Everything else will be loaded dynamically by plugins/backends.

[ci skip-rust]