### PR TITLE
Rename "process-execution" to "pants-sandbox"

### DIFF
--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -141,7 +141,7 @@ def strip_v2_chroot_path(v: bytes | str) -> str:
     """
     if isinstance(v, bytes):
         v = v.decode()
-    return re.sub(r"/.*/pants-sandbox[a-zA-Z0-9]+/", "", v)
+    return re.sub(r"/.*/pants-sandbox-[a-zA-Z0-9]+/", "", v)
 
 
 def hard_wrap(s: str, *, indent: int = 0, width: int = 96) -> list[str]:

--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -141,7 +141,7 @@ def strip_v2_chroot_path(v: bytes | str) -> str:
     """
     if isinstance(v, bytes):
         v = v.decode()
-    return re.sub(r"/.*/process-execution[a-zA-Z0-9]+/", "", v)
+    return re.sub(r"/.*/pants-sandbox[a-zA-Z0-9]+/", "", v)
 
 
 def hard_wrap(s: str, *, indent: int = 0, width: int = 96) -> list[str]:

--- a/src/python/pants/util/strutil_test.py
+++ b/src/python/pants/util/strutil_test.py
@@ -59,9 +59,9 @@ def test_strip_chroot_path() -> None:
         strip_v2_chroot_path(
             dedent(
                 """\
-            Would reformat /private/var/folders/sx/pdpbqz4x5cscn9hhfpbsbqvm0000gn/T/pants-sandbox3zt5Ph/src/python/example.py
-            Would reformat /var/folders/sx/pdpbqz4x5cscn9hhfpbsbqvm0000gn/T/pants-sandboxOCnquv/test.py
-            Would reformat /custom-tmpdir/pants-sandbox7zt4pH/custom_tmpdir.py
+            Would reformat /private/var/folders/sx/pdpbqz4x5cscn9hhfpbsbqvm0000gn/T/pants-sandbox-3zt5Ph/src/python/example.py
+            Would reformat /var/folders/sx/pdpbqz4x5cscn9hhfpbsbqvm0000gn/T/pants-sandbox-OCnquv/test.py
+            Would reformat /custom-tmpdir/pants-sandbox-7zt4pH/custom_tmpdir.py
 
             Some other output.
             """
@@ -78,16 +78,21 @@ def test_strip_chroot_path() -> None:
         )
     )
 
-    # A subdir must be prefixed with `pants-sandbox`, then some characters after it.
+    # A subdir must be prefixed with `pants-sandbox-`, then some characters after it.
     assert (
-        strip_v2_chroot_path("/var/process_executionOCnquv/test.py")
-        == "/var/process_executionOCnquv/test.py"
+        strip_v2_chroot_path("/var/pants_sandbox_OCnquv/test.py")
+        == "/var/pants_sandbox_OCnquv/test.py"
+    )
+    assert (
+        strip_v2_chroot_path("/var/pants_sandboxOCnquv/test.py")
+        == "/var/pants_sandboxOCnquv/test.py"
     )
     assert strip_v2_chroot_path("/var/pants-sandbox/test.py") == "/var/pants-sandbox/test.py"
 
     # Our heuristic requires absolute paths.
     assert (
-        strip_v2_chroot_path("var/pants-sandboxOCnquv/test.py") == "var/pants-sandboxOCnquv/test.py"
+        strip_v2_chroot_path("var/pants-sandbox-OCnquv/test.py")
+        == "var/pants-sandbox-OCnquv/test.py"
     )
 
     # Confirm we can handle values with no chroot path.

--- a/src/python/pants/util/strutil_test.py
+++ b/src/python/pants/util/strutil_test.py
@@ -59,9 +59,9 @@ def test_strip_chroot_path() -> None:
         strip_v2_chroot_path(
             dedent(
                 """\
-            Would reformat /private/var/folders/sx/pdpbqz4x5cscn9hhfpbsbqvm0000gn/T/process-execution3zt5Ph/src/python/example.py
-            Would reformat /var/folders/sx/pdpbqz4x5cscn9hhfpbsbqvm0000gn/T/process-executionOCnquv/test.py
-            Would reformat /custom-tmpdir/process-execution7zt4pH/custom_tmpdir.py
+            Would reformat /private/var/folders/sx/pdpbqz4x5cscn9hhfpbsbqvm0000gn/T/pants-sandbox3zt5Ph/src/python/example.py
+            Would reformat /var/folders/sx/pdpbqz4x5cscn9hhfpbsbqvm0000gn/T/pants-sandboxOCnquv/test.py
+            Would reformat /custom-tmpdir/pants-sandbox7zt4pH/custom_tmpdir.py
 
             Some other output.
             """
@@ -78,19 +78,16 @@ def test_strip_chroot_path() -> None:
         )
     )
 
-    # A subdir must be prefixed with `process-execution`, then some characters after it.
+    # A subdir must be prefixed with `pants-sandbox`, then some characters after it.
     assert (
         strip_v2_chroot_path("/var/process_executionOCnquv/test.py")
         == "/var/process_executionOCnquv/test.py"
     )
-    assert (
-        strip_v2_chroot_path("/var/process-execution/test.py") == "/var/process-execution/test.py"
-    )
+    assert strip_v2_chroot_path("/var/pants-sandbox/test.py") == "/var/pants-sandbox/test.py"
 
     # Our heuristic requires absolute paths.
     assert (
-        strip_v2_chroot_path("var/process-executionOCnquv/test.py")
-        == "var/process-executionOCnquv/test.py"
+        strip_v2_chroot_path("var/pants-sandboxOCnquv/test.py") == "var/pants-sandboxOCnquv/test.py"
     )
 
     # Confirm we can handle values with no chroot path.

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -264,7 +264,7 @@ impl super::CommandRunner for CommandRunner {
         // Set up a temporary workdir, which will optionally be preserved.
         let (workdir_path, maybe_workdir) = {
           let workdir = tempfile::Builder::new()
-            .prefix("pants-sandbox")
+            .prefix("pants-sandbox-")
             .tempdir_in(&self.work_dir_base)
             .map_err(|err| {
               format!(

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -264,7 +264,7 @@ impl super::CommandRunner for CommandRunner {
         // Set up a temporary workdir, which will optionally be preserved.
         let (workdir_path, maybe_workdir) = {
           let workdir = tempfile::Builder::new()
-            .prefix("process-execution")
+            .prefix("pants-sandbox")
             .tempdir_in(&self.work_dir_base)
             .map_err(|err| {
               format!(

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -452,7 +452,7 @@ async fn test_directory_preservation() {
   let subdirs = testutil::file::list_dir(&preserved_work_root);
   assert_eq!(subdirs.len(), 1);
 
-  // Then look for a file like e.g. `/tmp/abc1234/pants-sandbox7zt4pH/roland.ext`
+  // Then look for a file like e.g. `/tmp/abc1234/pants-sandbox-7zt4pH/roland.ext`
   let rolands_path = preserved_work_root.join(&subdirs[0]).join("roland.ext");
   assert!(&rolands_path.exists());
 

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -452,7 +452,7 @@ async fn test_directory_preservation() {
   let subdirs = testutil::file::list_dir(&preserved_work_root);
   assert_eq!(subdirs.len(), 1);
 
-  // Then look for a file like e.g. `/tmp/abc1234/process-execution7zt4pH/roland.ext`
+  // Then look for a file like e.g. `/tmp/abc1234/pants-sandbox7zt4pH/roland.ext`
   let rolands_path = preserved_work_root.join(&subdirs[0]).join("roland.ext");
   assert!(&rolands_path.exists());
 

--- a/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
@@ -342,7 +342,7 @@ impl NailgunProcess {
     nailgun_server_fingerprint: NailgunProcessFingerprint,
   ) -> Result<NailgunProcess, String> {
     let workdir = tempfile::Builder::new()
-      .prefix("pants-sandbox")
+      .prefix("pants-sandbox-")
       .tempdir_in(workdir_base)
       .map_err(|err| format!("Error making tempdir for nailgun server: {:?}", err))?;
 
@@ -492,7 +492,7 @@ async fn clear_workdir(
 ) -> Result<(), String> {
   // Move all content into a temporary directory.
   let garbage_dir = tempfile::Builder::new()
-    .prefix("pants-sandbox")
+    .prefix("pants-sandbox-")
     .tempdir_in(workdir.parent().unwrap())
     .map_err(|err| {
       format!(

--- a/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
@@ -342,7 +342,7 @@ impl NailgunProcess {
     nailgun_server_fingerprint: NailgunProcessFingerprint,
   ) -> Result<NailgunProcess, String> {
     let workdir = tempfile::Builder::new()
-      .prefix("process-execution")
+      .prefix("pants-sandbox")
       .tempdir_in(workdir_base)
       .map_err(|err| format!("Error making tempdir for nailgun server: {:?}", err))?;
 
@@ -492,7 +492,7 @@ async fn clear_workdir(
 ) -> Result<(), String> {
   // Move all content into a temporary directory.
   let garbage_dir = tempfile::Builder::new()
-    .prefix("process-execution")
+    .prefix("pants-sandbox")
     .tempdir_in(workdir.parent().unwrap())
     .map_err(|err| {
       format!(


### PR DESCRIPTION
This makes what the directory represents a lot clearer to the layperson. 

[ci skip-build-wheels]