### PR TITLE
Don't install Pex-style lockfile when no requirements used (Cherry-pick of #15706)

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -428,18 +428,19 @@ async def build_pex(
             loaded_lockfile = request.requirements.from_superset
             # NB: This is also validated in the constructor.
             assert loaded_lockfile.is_pex_native
-            requirements_digests.append(loaded_lockfile.lockfile_digest)
-            argv.extend(["--lock", loaded_lockfile.lockfile_path])
-            argv.extend(pex_lock_resolver_args)
+            if request.requirements.req_strings:
+                requirements_digests.append(loaded_lockfile.lockfile_digest)
+                argv.extend(["--lock", loaded_lockfile.lockfile_path])
+                argv.extend(pex_lock_resolver_args)
 
-            if loaded_lockfile.metadata:
-                validate_metadata(
-                    loaded_lockfile.metadata,
-                    request.interpreter_constraints,
-                    loaded_lockfile.original_lockfile,
-                    request.requirements.req_strings,
-                    python_setup,
-                )
+                if loaded_lockfile.metadata:
+                    validate_metadata(
+                        loaded_lockfile.metadata,
+                        request.interpreter_constraints,
+                        loaded_lockfile.original_lockfile,
+                        request.requirements.req_strings,
+                        python_setup,
+                    )
         else:
             assert request.requirements.from_superset is None
 


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/15705.

[ci skip-rust]
[ci skip-build-wheels]