### PR TITLE
Upgrade the Toolchain pants plugin in the 2.11 branch

### DIFF
--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -35,6 +35,8 @@ restricted_token_matches =  """{
 
 [buildsense]
 enable = true
+log_final_upload_latency = true
+collect_platform_data = true
 
 [subprocess-environment]
 env_vars.add = [

--- a/pants.toml
+++ b/pants.toml
@@ -30,7 +30,7 @@ backend_packages.add = [
 ]
 plugins = [
   "hdrhistogram",  # For use with `--stats-log`.
-  "toolchain.pants.plugin==0.17.0",
+  "toolchain.pants.plugin==0.19.0",
 ]
 
 # The invalidation globs cover the PYTHONPATH by default, but we exclude some files that are on the


### PR DESCRIPTION
Using an old version the the plugin is ill advised.
it is better to use the newest version even in branches.

*NOTE: THIS PR is for the 2.11 branch*