### PR TITLE
Fix `--changed-since` with directories unknown to Pants

### DIFF
--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -22,7 +22,7 @@ from pants.engine.addresses import (
     UnparsedAddressInputs,
 )
 from pants.engine.collection import Collection
-from pants.engine.fs import EMPTY_SNAPSHOT, PathGlobs, Paths, Snapshot
+from pants.engine.fs import EMPTY_SNAPSHOT, GlobMatchErrorBehavior, PathGlobs, Paths, Snapshot
 from pants.engine.internals import native_engine
 from pants.engine.internals.parametrize import Parametrize, _TargetParametrization
 from pants.engine.internals.parametrize import (  # noqa: F401
@@ -685,13 +685,17 @@ async def find_owners(owners_request: OwnersRequest) -> Owners:
         live_get = Get(
             FilteredTargets,
             RawSpecsWithoutFileOwners(
-                ancestor_globs=live_candidate_specs, filter_by_global_options=True
+                ancestor_globs=live_candidate_specs,
+                filter_by_global_options=True,
+                unmatched_glob_behavior=GlobMatchErrorBehavior.ignore,
             ),
         )
         deleted_get = Get(
             UnexpandedTargets,
             RawSpecsWithoutFileOwners(
-                ancestor_globs=deleted_candidate_specs, filter_by_global_options=True
+                ancestor_globs=deleted_candidate_specs,
+                filter_by_global_options=True,
+                unmatched_glob_behavior=GlobMatchErrorBehavior.ignore,
             ),
         )
     else:

--- a/src/python/pants/vcs/changed_integration_test.py
+++ b/src/python/pants/vcs/changed_integration_test.py
@@ -100,6 +100,7 @@ def _run_pants_goal(
         [
             *(extra_args or ()),
             "--changed-since=HEAD",
+            "--print-stacktrace",
             f"--changed-dependees={dependees.value}",
             goal,
         ],
@@ -280,3 +281,11 @@ def test_tag_filtering(repo: str) -> None:
 
     assert_list_stdout(repo, ["//app.sh:lib"], DependeesOption.TRANSITIVE, extra_args=["--tag=a"])
     assert_count_loc(repo, DependeesOption.TRANSITIVE, expected_num_files=1, extra_args=["--tag=a"])
+
+
+def test_pants_ignored_file(repo: str) -> None:
+    """Regression test for
+    https://github.com/pantsbuild/pants/issues/15655#issuecomment-1140081185."""
+    create_file(".ignored/f.txt", "")
+    assert_list_stdout(repo, [], DependeesOption.NONE)
+    assert_count_loc(repo, DependeesOption.NONE, expected_num_files=0)


### PR DESCRIPTION
Fixes a regression from https://github.com/pantsbuild/pants/pull/15570. When you had a changed file in a directory Pants does not find because it was deleted or it's in `--pants-ignore`, we would error.

Note that we still error when you explicitly run on the directory, like `./pants list does-not-exist`, per `--unmatched-cli-globs`. This only impacts `--changed-since`.

[ci skip-rust]