### PR TITLE
Fix `--changed-since` with directories unknown to Pants when `--changed-dependees` is used

### DIFF
--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -699,9 +699,19 @@ async def find_owners(owners_request: OwnersRequest) -> Owners:
             ),
         )
     else:
-        live_get = Get(Targets, RawSpecsWithoutFileOwners(ancestor_globs=live_candidate_specs))
+        live_get = Get(
+            Targets,
+            RawSpecsWithoutFileOwners(
+                ancestor_globs=live_candidate_specs,
+                unmatched_glob_behavior=GlobMatchErrorBehavior.ignore,
+            ),
+        )
         deleted_get = Get(
-            UnexpandedTargets, RawSpecsWithoutFileOwners(ancestor_globs=deleted_candidate_specs)
+            UnexpandedTargets,
+            RawSpecsWithoutFileOwners(
+                ancestor_globs=deleted_candidate_specs,
+                unmatched_glob_behavior=GlobMatchErrorBehavior.ignore,
+            ),
         )
     live_candidate_tgts, deleted_candidate_tgts = await MultiGet(live_get, deleted_get)
 

--- a/src/python/pants/vcs/changed_integration_test.py
+++ b/src/python/pants/vcs/changed_integration_test.py
@@ -287,5 +287,6 @@ def test_pants_ignored_file(repo: str) -> None:
     """Regression test for
     https://github.com/pantsbuild/pants/issues/15655#issuecomment-1140081185."""
     create_file(".ignored/f.txt", "")
-    assert_list_stdout(repo, [], DependeesOption.NONE)
-    assert_count_loc(repo, DependeesOption.NONE, expected_num_files=0)
+    for dependees in (DependeesOption.NONE, DependeesOption.DIRECT):
+        assert_list_stdout(repo, [], dependees)
+        assert_count_loc(repo, dependees, expected_num_files=0)


### PR DESCRIPTION
Part 2 of https://github.com/pantsbuild/pants/pull/15714. I didn't update the `--dependees` codepath properly.

Closes https://github.com/pantsbuild/pants/issues/15655.

[ci skip-rust]