### PR TITLE
RFC: Run python_source directly

### DIFF
--- a/src/python/pants/backend/python/goals/run_pex_binary.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary.py
@@ -72,7 +72,7 @@ async def create_python_source_run_request(
             include_source_files=False,
             # Note that the file for first-party entry points is not in the PEX itself. In that
             # case, it's loaded by setting `PEX_EXTRA_SYS_PATH`.
-            main=entry_point.val or field_set.script.value,
+            main=entry_point.val,
             additional_args=(
                 # *field_set.generate_additional_args(pex_binary_defaults),
                 # N.B.: Since we cobble together the runtime environment via PEX_EXTRA_SYS_PATH


### PR DESCRIPTION
(Not labeling as CI is unimportant)

So this PR is simply a demonstration of how we could enable us to `./pants run path/to/file.py` any `python-source without the need for a `pex_binary` target. This is possible because the `pex_binary` run code doesn't actually involve the packaged pex binary (or any of its settings).

Why am I demonstrating this?
- User simplification: For "scripts" users shouldn't have to declare a `pex_binary` (a target which carries weight) just to run their script. When users run `./pants package ::`, why should we be packaging scripts? How can I run the build pex binary without issuing `package`, then running the artifact?
- Pants consistency: `pex_binary` is a special packageable in that `run` doesn't represent `package` and `run`, `run` in fact does something vastly different than the running the packaged artifact. If we remove the need for people to declare their scripts as `pex_binary`s, we allow ourselves the chance to "fix" `pex_binary` to be consistent with other targets.


