### PR TITLE
Correctly describe the origin of invalid specs, e.g. `--paths-from`

### DIFF
--- a/src/python/pants/backend/go/goals/tailor.py
+++ b/src/python/pants/backend/go/goals/tailor.py
@@ -95,7 +95,10 @@ async def find_putative_go_targets(
         ]
         existing_targets = await Get(
             UnexpandedTargets,
-            RawSpecs(ancestor_globs=tuple(AncestorGlobSpec(d) for d in main_package_dirs)),
+            RawSpecs(
+                ancestor_globs=tuple(AncestorGlobSpec(d) for d in main_package_dirs),
+                description_of_origin="the `go_binary` tailor rule",
+            ),
         )
         owned_main_packages = await MultiGet(
             Get(GoBinaryMainPackage, GoBinaryMainPackageRequest(t[GoBinaryMainPackageField]))

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -277,7 +277,13 @@ async def determine_main_pkg_for_go_binary(
             )
         return GoBinaryMainPackage(wrapped_specified_tgt.target.address)
 
-    candidate_targets = await Get(Targets, RawSpecs(dir_globs=(DirGlobSpec(addr.spec_path),)))
+    candidate_targets = await Get(
+        Targets,
+        RawSpecs(
+            dir_globs=(DirGlobSpec(addr.spec_path),),
+            description_of_origin="the `go_binary` dependency inference rule",
+        ),
+    )
     relevant_pkg_targets = [
         tgt
         for tgt in candidate_targets

--- a/src/python/pants/backend/go/util_rules/go_mod.py
+++ b/src/python/pants/backend/go/util_rules/go_mod.py
@@ -44,7 +44,11 @@ class OwningGoMod:
 async def find_nearest_go_mod(request: OwningGoModRequest) -> OwningGoMod:
     # We don't expect `go_mod` targets to be generated, so we can use UnexpandedTargets.
     candidate_targets = await Get(
-        UnexpandedTargets, RawSpecs(ancestor_globs=(AncestorGlobSpec(request.address.spec_path),))
+        UnexpandedTargets,
+        RawSpecs(
+            ancestor_globs=(AncestorGlobSpec(request.address.spec_path),),
+            description_of_origin="the `OwningGoMod` rule",
+        ),
     )
 
     # Sort by address.spec_path in descending order so the nearest go_mod target is sorted first.

--- a/src/python/pants/backend/project_info/paths.py
+++ b/src/python/pants/backend/project_info/paths.py
@@ -103,14 +103,18 @@ async def paths(
             Targets,
             Specs,
             specs_parser.parse_specs(
-                [path_from], convert_dir_literal_to_address_literal=convert_dir_literals
+                [path_from],
+                description_of_origin="the option `--paths-from`",
+                convert_dir_literal_to_address_literal=convert_dir_literals,
             ),
         ),
         Get(
             Targets,
             Specs,
             specs_parser.parse_specs(
-                [path_to], convert_dir_literal_to_address_literal=convert_dir_literals
+                [path_to],
+                description_of_origin="the option `--paths-to`",
+                convert_dir_literal_to_address_literal=convert_dir_literals,
             ),
         ),
     )

--- a/src/python/pants/backend/project_info/peek_test.py
+++ b/src/python/pants/backend/project_info/peek_test.py
@@ -195,7 +195,10 @@ def test_get_target_data(rule_runner: RuleRunner) -> None:
             "foo/b.txt": "",
         }
     )
-    tds = rule_runner.request(TargetDatas, [RawSpecs(recursive_globs=(RecursiveGlobSpec("foo"),))])
+    tds = rule_runner.request(
+        TargetDatas,
+        [RawSpecs(recursive_globs=(RecursiveGlobSpec("foo"),), description_of_origin="tests")],
+    )
     assert list(tds) == [
         TargetData(
             GenericTarget({"dependencies": [":baz"]}, Address("foo", target_name="bar")),

--- a/src/python/pants/backend/python/goals/export_test.py
+++ b/src/python/pants/backend/python/goals/export_test.py
@@ -63,7 +63,12 @@ def test_export_venvs(rule_runner: RuleRunner) -> None:
             env_inherit={"PATH", "PYENV_ROOT"},
         )
         targets = rule_runner.request(
-            Targets, [RawSpecs(recursive_globs=(RecursiveGlobSpec("src/foo"),))]
+            Targets,
+            [
+                RawSpecs(
+                    recursive_globs=(RecursiveGlobSpec("src/foo"),), description_of_origin="tests"
+                )
+            ],
         )
         all_results = rule_runner.request(ExportResults, [ExportVenvsRequest(targets)])
 

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -930,7 +930,13 @@ async def get_exporting_owner(owned_dependency: OwnedDependency) -> ExportedTarg
     """
     target = owned_dependency.target
     ancestor_addrs = AncestorGlobSpec(target.address.spec_path)
-    ancestor_tgts = await Get(Targets, RawSpecs(ancestor_globs=(ancestor_addrs,)))
+    ancestor_tgts = await Get(
+        Targets,
+        RawSpecs(
+            ancestor_globs=(ancestor_addrs,),
+            description_of_origin="the `python_distribution` `package` rules",
+        ),
+    )
     # Note that addresses sort by (spec_path, target_name), and all these targets are
     # ancestors of the given target, i.e., their spec_paths are all prefixes. So sorting by
     # address will effectively sort by closeness of ancestry to the given target.

--- a/src/python/pants/backend/python/goals/tailor.py
+++ b/src/python/pants/backend/python/goals/tailor.py
@@ -186,7 +186,10 @@ async def find_putative_targets(
         entry_point_dirs = {os.path.dirname(entry_point) for entry_point in entry_points}
         possible_existing_binary_targets = await Get(
             UnexpandedTargets,
-            RawSpecs(ancestor_globs=tuple(AncestorGlobSpec(d) for d in entry_point_dirs)),
+            RawSpecs(
+                ancestor_globs=tuple(AncestorGlobSpec(d) for d in entry_point_dirs),
+                description_of_origin="the `pex_binary` tailor rule",
+            ),
         )
         possible_existing_binary_entry_points = await MultiGet(
             Get(ResolvedPexEntryPoint, ResolvePexEntryPointRequest(t[PexEntryPointField]))

--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -143,6 +143,7 @@ async def infer_terraform_module_dependencies(
         RawSpecs(
             dir_globs=tuple(DirGlobSpec(path) for path in candidate_spec_paths),
             unmatched_glob_behavior=GlobMatchErrorBehavior.ignore,
+            description_of_origin="the `terraform_module` dependency inference rule",
         ),
     )
     # TODO: Need to either implement the standard ambiguous dependency logic or ban >1 terraform_module

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import dataclasses
 import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -233,7 +234,7 @@ class RawSpecs:
     either `Specs` or `RawSpecs` in rules, e.g. to find what targets exist in a directory.
     """
 
-    description_of_origin: str
+    description_of_origin: str = dataclasses.field(compare=False, hash=False)
 
     address_literals: tuple[AddressLiteralSpec, ...] = ()
     file_literals: tuple[FileLiteralSpec, ...] = ()
@@ -345,7 +346,7 @@ class RawSpecsWithoutFileOwners:
     `Get(Addresses, RawSpecs)`, which will result in this rule being used.
     """
 
-    description_of_origin: str
+    description_of_origin: str = dataclasses.field(compare=False, hash=False)
 
     address_literals: tuple[AddressLiteralSpec, ...] = ()
     dir_literals: tuple[DirLiteralSpec, ...] = ()
@@ -432,7 +433,7 @@ class RawSpecsWithOnlyFileOwners:
     `Get(Addresses, RawSpecs)`, which will result in this rule being used.
     """
 
-    description_of_origin: str
+    description_of_origin: str = dataclasses.field(compare=False, hash=False)
 
     file_literals: tuple[FileLiteralSpec, ...] = ()
     file_globs: tuple[FileGlobSpec, ...] = ()

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -234,7 +234,7 @@ class RawSpecs:
     either `Specs` or `RawSpecs` in rules, e.g. to find what targets exist in a directory.
     """
 
-    description_of_origin: str = dataclasses.field(compare=False, hash=False)
+    description_of_origin: str
 
     address_literals: tuple[AddressLiteralSpec, ...] = ()
     file_literals: tuple[FileLiteralSpec, ...] = ()
@@ -346,7 +346,7 @@ class RawSpecsWithoutFileOwners:
     `Get(Addresses, RawSpecs)`, which will result in this rule being used.
     """
 
-    description_of_origin: str = dataclasses.field(compare=False, hash=False)
+    description_of_origin: str
 
     address_literals: tuple[AddressLiteralSpec, ...] = ()
     dir_literals: tuple[DirLiteralSpec, ...] = ()
@@ -433,7 +433,7 @@ class RawSpecsWithOnlyFileOwners:
     `Get(Addresses, RawSpecs)`, which will result in this rule being used.
     """
 
-    description_of_origin: str = dataclasses.field(compare=False, hash=False)
+    description_of_origin: str
 
     file_literals: tuple[FileLiteralSpec, ...] = ()
     file_globs: tuple[FileGlobSpec, ...] = ()

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -204,7 +204,10 @@ class AncestorGlobSpec(Spec):
 
 
 def _create_path_globs(
-    globs: Iterable[str], unmatched_glob_behavior: GlobMatchErrorBehavior
+    globs: Iterable[str],
+    unmatched_glob_behavior: GlobMatchErrorBehavior,
+    *,
+    description_of_origin: str,
 ) -> PathGlobs:
     return PathGlobs(
         globs=globs,
@@ -212,7 +215,9 @@ def _create_path_globs(
         # We validate that _every_ glob is valid.
         conjunction=GlobExpansionConjunction.all_match,
         description_of_origin=(
-            None if unmatched_glob_behavior == GlobMatchErrorBehavior.ignore else "CLI arguments"
+            None
+            if unmatched_glob_behavior == GlobMatchErrorBehavior.ignore
+            else description_of_origin
         ),
     )
 
@@ -227,6 +232,8 @@ class RawSpecs:
     When you want to operate on what the user specified, use `Specs`. Otherwise, you can use
     either `Specs` or `RawSpecs` in rules, e.g. to find what targets exist in a directory.
     """
+
+    description_of_origin: str
 
     address_literals: tuple[AddressLiteralSpec, ...] = ()
     file_literals: tuple[FileLiteralSpec, ...] = ()
@@ -245,6 +252,7 @@ class RawSpecs:
         cls,
         specs: Iterable[Spec],
         *,
+        description_of_origin: str,
         convert_dir_literal_to_address_literal: bool,
         unmatched_glob_behavior: GlobMatchErrorBehavior = GlobMatchErrorBehavior.error,
         filter_by_global_options: bool = False,
@@ -283,13 +291,14 @@ class RawSpecs:
             else:
                 raise AssertionError(f"Unexpected type of Spec: {repr(spec)}")
         return RawSpecs(
-            tuple(address_literals),
-            tuple(file_literals),
-            tuple(file_globs),
-            tuple(dir_literals),
-            tuple(dir_globs),
-            tuple(recursive_globs),
-            tuple(ancestor_globs),
+            address_literals=tuple(address_literals),
+            file_literals=tuple(file_literals),
+            file_globs=tuple(file_globs),
+            dir_literals=tuple(dir_literals),
+            dir_globs=tuple(dir_globs),
+            recursive_globs=tuple(recursive_globs),
+            ancestor_globs=tuple(ancestor_globs),
+            description_of_origin=description_of_origin,
             unmatched_glob_behavior=unmatched_glob_behavior,
             filter_by_global_options=filter_by_global_options,
             from_change_detection=from_change_detection,
@@ -324,6 +333,7 @@ class RawSpecs:
                 if self.from_change_detection
                 else self.unmatched_glob_behavior
             ),
+            description_of_origin=self.description_of_origin,
         )
 
 
@@ -334,6 +344,8 @@ class RawSpecsWithoutFileOwners:
     This exists to work around a cycle in the rule graph. Usually, consumers should use the simpler
     `Get(Addresses, RawSpecs)`, which will result in this rule being used.
     """
+
+    description_of_origin: str
 
     address_literals: tuple[AddressLiteralSpec, ...] = ()
     dir_literals: tuple[DirLiteralSpec, ...] = ()
@@ -347,11 +359,12 @@ class RawSpecsWithoutFileOwners:
     @classmethod
     def from_raw_specs(cls, specs: RawSpecs) -> RawSpecsWithoutFileOwners:
         return RawSpecsWithoutFileOwners(
-            specs.address_literals,
-            specs.dir_literals,
-            specs.dir_globs,
-            specs.recursive_globs,
-            specs.ancestor_globs,
+            address_literals=specs.address_literals,
+            dir_literals=specs.dir_literals,
+            dir_globs=specs.dir_globs,
+            recursive_globs=specs.recursive_globs,
+            ancestor_globs=specs.ancestor_globs,
+            description_of_origin=specs.description_of_origin,
             unmatched_glob_behavior=specs.unmatched_glob_behavior,
             filter_by_global_options=specs.filter_by_global_options,
         )
@@ -402,7 +415,11 @@ class RawSpecsWithoutFileOwners:
         validation_path_globs = (
             PathGlobs(())
             if self.unmatched_glob_behavior == GlobMatchErrorBehavior.ignore
-            else _create_path_globs((*validation_includes, *ignores), self.unmatched_glob_behavior)
+            else _create_path_globs(
+                (*validation_includes, *ignores),
+                self.unmatched_glob_behavior,
+                description_of_origin=self.description_of_origin,
+            )
         )
         return build_path_globs, validation_path_globs
 
@@ -415,6 +432,8 @@ class RawSpecsWithOnlyFileOwners:
     `Get(Addresses, RawSpecs)`, which will result in this rule being used.
     """
 
+    description_of_origin: str
+
     file_literals: tuple[FileLiteralSpec, ...] = ()
     file_globs: tuple[FileGlobSpec, ...] = ()
 
@@ -425,8 +444,9 @@ class RawSpecsWithOnlyFileOwners:
     @classmethod
     def from_raw_specs(cls, specs: RawSpecs) -> RawSpecsWithOnlyFileOwners:
         return RawSpecsWithOnlyFileOwners(
-            specs.file_literals,
-            specs.file_globs,
+            description_of_origin=specs.description_of_origin,
+            file_literals=specs.file_literals,
+            file_globs=specs.file_globs,
             unmatched_glob_behavior=specs.unmatched_glob_behavior,
             filter_by_global_options=specs.filter_by_global_options,
             from_change_detection=specs.from_change_detection,
@@ -439,7 +459,11 @@ class RawSpecsWithOnlyFileOwners:
             if self.from_change_detection
             else self.unmatched_glob_behavior
         )
-        return _create_path_globs((spec.to_glob(),), unmatched_glob_behavior)
+        return _create_path_globs(
+            (spec.to_glob(),),
+            unmatched_glob_behavior,
+            description_of_origin=self.description_of_origin,
+        )
 
     def all_specs(self) -> Iterator[FileLiteralSpec | FileGlobSpec]:
         yield from self.file_literals
@@ -459,11 +483,18 @@ class Specs:
     directory,  you can directly use `RawSpecs`.
     """
 
-    includes: RawSpecs = RawSpecs()
-    ignores: RawSpecs = RawSpecs()
+    includes: RawSpecs
+    ignores: RawSpecs
 
     def __bool__(self) -> bool:
         return bool(self.includes) or bool(self.ignores)
+
+    @classmethod
+    def empty(self) -> Specs:
+        return Specs(
+            RawSpecs(description_of_origin="<not used>"),
+            RawSpecs(description_of_origin="<not used>"),
+        )
 
     def arguments_provided_description(self) -> str | None:
         """A description of what the user specified, e.g. 'target arguments'."""

--- a/src/python/pants/base/specs_parser.py
+++ b/src/python/pants/base/specs_parser.py
@@ -115,6 +115,7 @@ class SpecsParser:
         self,
         specs: Iterable[str],
         *,
+        description_of_origin: str,
         convert_dir_literal_to_address_literal: bool,
         unmatched_glob_behavior: GlobMatchErrorBehavior = GlobMatchErrorBehavior.error,
     ) -> Specs:
@@ -129,12 +130,14 @@ class SpecsParser:
 
         includes = RawSpecs.create(
             include_specs,
+            description_of_origin=description_of_origin,
             convert_dir_literal_to_address_literal=convert_dir_literal_to_address_literal,
             unmatched_glob_behavior=unmatched_glob_behavior,
             filter_by_global_options=True,
         )
         ignores = RawSpecs.create(
             ignore_specs,
+            description_of_origin=description_of_origin,
             convert_dir_literal_to_address_literal=convert_dir_literal_to_address_literal,
             unmatched_glob_behavior=unmatched_glob_behavior,
             # By setting the below to False, we will end up matching some targets

--- a/src/python/pants/base/specs_test.py
+++ b/src/python/pants/base/specs_test.py
@@ -58,7 +58,7 @@ def test_dir_literal() -> None:
     assert spec.matches_target_residence_dir("dir/subdir/nested") is False
     assert spec.matches_target_residence_dir("another/subdir") is False
     assert_build_file_globs(
-        RawSpecsWithoutFileOwners(dir_literals=(spec,)),
+        RawSpecsWithoutFileOwners(dir_literals=(spec,), description_of_origin="tests"),
         expected_build_globs={"BUILD", "dir/BUILD", "dir/subdir/BUILD"},
         expected_validation_globs={"dir/subdir/*"},
     )
@@ -68,7 +68,7 @@ def test_dir_literal() -> None:
     assert spec.matches_target_residence_dir("") is True
     assert spec.matches_target_residence_dir("dir") is False
     assert_build_file_globs(
-        RawSpecsWithoutFileOwners(dir_literals=(spec,)),
+        RawSpecsWithoutFileOwners(dir_literals=(spec,), description_of_origin="tests"),
         expected_build_globs={"BUILD"},
         expected_validation_globs={"*"},
     )
@@ -83,7 +83,7 @@ def test_dir_glob() -> None:
     assert spec.matches_target_residence_dir("dir/subdir/nested") is False
     assert spec.matches_target_residence_dir("another/subdir") is False
     assert_build_file_globs(
-        RawSpecsWithoutFileOwners(dir_globs=(spec,)),
+        RawSpecsWithoutFileOwners(dir_globs=(spec,), description_of_origin="tests"),
         expected_build_globs={"BUILD", "dir/BUILD", "dir/subdir/BUILD"},
         expected_validation_globs={"dir/subdir/*"},
     )
@@ -93,7 +93,7 @@ def test_dir_glob() -> None:
     assert spec.matches_target_residence_dir("") is True
     assert spec.matches_target_residence_dir("dir") is False
     assert_build_file_globs(
-        RawSpecsWithoutFileOwners(dir_globs=(spec,)),
+        RawSpecsWithoutFileOwners(dir_globs=(spec,), description_of_origin="tests"),
         expected_build_globs={"BUILD"},
         expected_validation_globs={"*"},
     )
@@ -109,7 +109,7 @@ def test_recursive_glob() -> None:
     assert spec.matches_target_residence_dir("dir/subdir/nested/again") is True
     assert spec.matches_target_residence_dir("another/subdir") is False
     assert_build_file_globs(
-        RawSpecsWithoutFileOwners(recursive_globs=(spec,)),
+        RawSpecsWithoutFileOwners(recursive_globs=(spec,), description_of_origin="tests"),
         expected_build_globs={"BUILD", "dir/BUILD", "dir/subdir/BUILD", "dir/subdir/**/BUILD"},
         expected_validation_globs={"dir/subdir/**"},
     )
@@ -120,7 +120,7 @@ def test_recursive_glob() -> None:
     assert spec.matches_target_residence_dir("dir") is True
     assert spec.matches_target_residence_dir("another_dir") is True
     assert_build_file_globs(
-        RawSpecsWithoutFileOwners(recursive_globs=(spec,)),
+        RawSpecsWithoutFileOwners(recursive_globs=(spec,), description_of_origin="tests"),
         expected_build_globs={"BUILD", "**/BUILD"},
         expected_validation_globs={"**"},
     )
@@ -134,7 +134,7 @@ def test_ancestor_glob() -> None:
     assert spec.matches_target_residence_dir("dir/subdir/nested") is False
     assert spec.matches_target_residence_dir("another/subdir") is False
     assert_build_file_globs(
-        RawSpecsWithoutFileOwners(ancestor_globs=(spec,)),
+        RawSpecsWithoutFileOwners(ancestor_globs=(spec,), description_of_origin="tests"),
         expected_build_globs={"BUILD", "dir/BUILD", "dir/subdir/BUILD"},
         expected_validation_globs={"dir/subdir/*"},
     )
@@ -143,7 +143,7 @@ def test_ancestor_glob() -> None:
     assert spec.matches_target_residence_dir("") is True
     assert spec.matches_target_residence_dir("dir") is False
     assert_build_file_globs(
-        RawSpecsWithoutFileOwners(ancestor_globs=(spec,)),
+        RawSpecsWithoutFileOwners(ancestor_globs=(spec,), description_of_origin="tests"),
         expected_build_globs={"BUILD"},
         expected_validation_globs={"*"},
     )

--- a/src/python/pants/bsp/util_rules/targets.py
+++ b/src/python/pants/bsp/util_rules/targets.py
@@ -166,7 +166,9 @@ class _ParseOneBSPMappingRequest:
 async def parse_one_bsp_mapping(request: _ParseOneBSPMappingRequest) -> BSPBuildTargetInternal:
     specs_parser = SpecsParser()
     specs = specs_parser.parse_specs(
-        request.definition.addresses, convert_dir_literal_to_address_literal=False
+        request.definition.addresses,
+        description_of_origin=f"the BSP mapping {request.name}",
+        convert_dir_literal_to_address_literal=False,
     ).includes
     return BSPBuildTargetInternal(request.name, specs, request.definition)
 

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -297,9 +297,9 @@ async def lint(
     _get_targets = Get(
         FilteredTargets,
         Specs,
-        specs if lint_target_request_types or fmt_target_request_types else Specs(),
+        specs if lint_target_request_types or fmt_target_request_types else Specs.empty(),
     )
-    _get_specs_paths = Get(SpecsPaths, Specs, specs if file_request_types else Specs())
+    _get_specs_paths = Get(SpecsPaths, Specs, specs if file_request_types else Specs.empty())
     targets, specs_paths = await MultiGet(_get_targets, _get_specs_paths)
 
     def batch(field_sets: Iterable[FieldSet]) -> Iterator[list[FieldSet]]:

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -184,7 +184,7 @@ def run_lint_rule(
             rule_args=[
                 console,
                 Workspace(rule_runner.scheduler, _enforce_effects=False),
-                Specs(),
+                Specs.empty(),
                 lint_subsystem,
                 union_membership,
                 DistDir(relpath=Path("dist")),

--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -483,7 +483,10 @@ async def restrict_conflicting_sources(ptgt: PutativeTarget) -> DisjointSourcePu
     source_dirs = {os.path.dirname(path) for path in source_path_set}
     possible_owners = await Get(
         UnexpandedTargets,
-        RawSpecs(ancestor_globs=tuple(AncestorGlobSpec(d) for d in source_dirs)),
+        RawSpecs(
+            ancestor_globs=tuple(AncestorGlobSpec(d) for d in source_dirs),
+            description_of_origin="the `tailor` goal",
+        ),
     )
     possible_owners_sources = await MultiGet(
         Get(SourcesPaths, SourcesPathsRequest(t.get(SourcesField))) for t in possible_owners

--- a/src/python/pants/core/goals/tailor_test.py
+++ b/src/python/pants/core/goals/tailor_test.py
@@ -434,27 +434,39 @@ def test_group_by_dir() -> None:
 
 
 def test_specs_to_dirs() -> None:
-    assert specs_to_dirs(RawSpecs()) == ("",)
-    assert specs_to_dirs(RawSpecs(address_literals=(AddressLiteralSpec("src/python/foo"),))) == (
-        "src/python/foo",
-    )
-    assert specs_to_dirs(RawSpecs(dir_literals=(DirLiteralSpec("src/python/foo"),))) == (
-        "src/python/foo",
-    )
+    assert specs_to_dirs(RawSpecs(description_of_origin="tests")) == ("",)
+    assert specs_to_dirs(
+        RawSpecs(
+            address_literals=(AddressLiteralSpec("src/python/foo"),), description_of_origin="tests"
+        )
+    ) == ("src/python/foo",)
+    assert specs_to_dirs(
+        RawSpecs(dir_literals=(DirLiteralSpec("src/python/foo"),), description_of_origin="tests")
+    ) == ("src/python/foo",)
     assert specs_to_dirs(
         RawSpecs(
             address_literals=(
                 AddressLiteralSpec("src/python/foo"),
                 AddressLiteralSpec("src/python/bar"),
-            )
+            ),
+            description_of_origin="tests",
         )
     ) == ("src/python/foo", "src/python/bar")
 
     with pytest.raises(ValueError):
-        specs_to_dirs(RawSpecs(file_literals=(FileLiteralSpec("src/python/foo.py"),)))
+        specs_to_dirs(
+            RawSpecs(
+                file_literals=(FileLiteralSpec("src/python/foo.py"),), description_of_origin="tests"
+            )
+        )
 
     with pytest.raises(ValueError):
-        specs_to_dirs(RawSpecs(address_literals=(AddressLiteralSpec("src/python/bar", "tgt"),)))
+        specs_to_dirs(
+            RawSpecs(
+                address_literals=(AddressLiteralSpec("src/python/bar", "tgt"),),
+                description_of_origin="tests",
+            )
+        )
 
     with pytest.raises(ValueError):
         specs_to_dirs(
@@ -463,7 +475,8 @@ def test_specs_to_dirs() -> None:
                     AddressLiteralSpec(
                         "src/python/bar", target_component=None, generated_component="gen"
                     ),
-                )
+                ),
+                description_of_origin="tests",
             )
         )
 

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -316,7 +316,7 @@ class TestStreamingWorkunit(SchedulerTestBase):
             callbacks=[tracker],
             report_interval_seconds=0.01,
             max_workunit_verbosity=max_workunit_verbosity,
-            specs=Specs(),
+            specs=Specs.empty(),
             options_bootstrapper=create_options_bootstrapper([]),
             allow_async_completion=False,
         )
@@ -702,7 +702,7 @@ def test_counters(rule_runner: RuleRunner, run_tracker: RunTracker) -> None:
         callbacks=[tracker],
         report_interval_seconds=0.01,
         max_workunit_verbosity=LogLevel.TRACE,
-        specs=Specs(),
+        specs=Specs.empty(),
         options_bootstrapper=create_options_bootstrapper([]),
         allow_async_completion=False,
     )
@@ -743,7 +743,7 @@ def test_more_complicated_engine_aware(rule_runner: RuleRunner, run_tracker: Run
         callbacks=[tracker],
         report_interval_seconds=0.01,
         max_workunit_verbosity=LogLevel.TRACE,
-        specs=Specs(),
+        specs=Specs.empty(),
         options_bootstrapper=create_options_bootstrapper([]),
         allow_async_completion=False,
     )
@@ -803,7 +803,7 @@ def test_process_digests_on_streaming_workunits(
         callbacks=[tracker],
         report_interval_seconds=0.01,
         max_workunit_verbosity=LogLevel.DEBUG,
-        specs=Specs(),
+        specs=Specs.empty(),
         options_bootstrapper=create_options_bootstrapper([]),
         allow_async_completion=False,
     )
@@ -834,7 +834,7 @@ def test_process_digests_on_streaming_workunits(
         callbacks=[tracker],
         report_interval_seconds=0.01,
         max_workunit_verbosity=LogLevel.DEBUG,
-        specs=Specs(),
+        specs=Specs.empty(),
         options_bootstrapper=create_options_bootstrapper([]),
         allow_async_completion=False,
     )
@@ -897,7 +897,7 @@ def test_context_object_on_streaming_workunits(
         callbacks=[Callback()],
         report_interval_seconds=0.01,
         max_workunit_verbosity=LogLevel.INFO,
-        specs=Specs(),
+        specs=Specs.empty(),
         options_bootstrapper=create_options_bootstrapper([]),
         allow_async_completion=False,
     )
@@ -929,6 +929,7 @@ def test_streaming_workunits_expanded_specs(run_tracker: RunTracker) -> None:
     specs = SpecsParser().parse_specs(
         ["src/python/somefiles::", "src/python/others/b.py"],
         convert_dir_literal_to_address_literal=False,
+        description_of_origin="tests",
     )
 
     class Callback(WorkunitsCallback):

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -849,7 +849,7 @@ def assert_generated(
         # TODO: Adjust the `TransitiveTargets` API to expose the complete mapping.
         #   see https://github.com/pantsbuild/pants/issues/11270
         specs = SpecsParser(rule_runner.build_root).parse_specs(
-            ["::"], convert_dir_literal_to_address_literal=False
+            ["::"], convert_dir_literal_to_address_literal=False, description_of_origin="tests"
         )
         addresses = rule_runner.request(Addresses, [specs])
         dependency_mapping = rule_runner.request(

--- a/src/python/pants/engine/internals/specs_rules_test.py
+++ b/src/python/pants/engine/internals/specs_rules_test.py
@@ -392,27 +392,19 @@ def test_raw_specs_without_file_owners_do_not_exist(rule_runner: RuleRunner) -> 
     assert_resolve_error(AddressLiteralSpec("real", "fake_tgt"), expected=str(did_you_mean))
     assert_resolve_error(AddressLiteralSpec("real/f.txt", "fake_tgt"), expected=str(did_you_mean))
 
-    assert_resolve_error(
-        DirGlobSpec("fake"), expected='Unmatched glob from CLI arguments: "fake/*"'
-    )
+    assert_resolve_error(DirGlobSpec("fake"), expected='Unmatched glob from tests: "fake/*"')
     assert_does_not_error(DirGlobSpec("empty"))
     assert_does_not_error(DirGlobSpec("fake"), ignore_nonexistent=True)
 
-    assert_resolve_error(
-        DirLiteralSpec("fake"), expected='Unmatched glob from CLI arguments: "fake/*"'
-    )
+    assert_resolve_error(DirLiteralSpec("fake"), expected='Unmatched glob from tests: "fake/*"')
     assert_does_not_error(DirLiteralSpec("empty"))
     assert_does_not_error(DirLiteralSpec("fake"), ignore_nonexistent=True)
 
-    assert_resolve_error(
-        RecursiveGlobSpec("fake"), expected='Unmatched glob from CLI arguments: "fake/**"'
-    )
+    assert_resolve_error(RecursiveGlobSpec("fake"), expected='Unmatched glob from tests: "fake/**"')
     assert_does_not_error(RecursiveGlobSpec("empty"))
     assert_does_not_error(RecursiveGlobSpec("fake"), ignore_nonexistent=True)
 
-    assert_resolve_error(
-        AncestorGlobSpec("fake"), expected='Unmatched glob from CLI arguments: "fake/*"'
-    )
+    assert_resolve_error(AncestorGlobSpec("fake"), expected='Unmatched glob from tests: "fake/*"')
     assert_does_not_error(AncestorGlobSpec("empty"))
     assert_does_not_error(AncestorGlobSpec("fake"), ignore_nonexistent=True)
 
@@ -634,7 +626,7 @@ def test_raw_specs_with_only_file_owners_glob(rule_runner: RuleRunner) -> None:
 
 def test_raw_specs_with_only_file_owners_nonexistent_file(rule_runner: RuleRunner) -> None:
     spec = FileLiteralSpec("demo/fake.txt")
-    with engine_error(contains='Unmatched glob from CLI arguments: "demo/fake.txt"'):
+    with engine_error(contains='Unmatched glob from tests: "demo/fake.txt"'):
         resolve_raw_specs_with_only_file_owners(rule_runner, [spec])
 
     assert not resolve_raw_specs_with_only_file_owners(rule_runner, [spec], ignore_nonexistent=True)

--- a/src/python/pants/init/specs_calculator.py
+++ b/src/python/pants/init/specs_calculator.py
@@ -57,6 +57,7 @@ def calculate_specs(
         )
     specs = SpecsParser().parse_specs(
         options.specs,
+        description_of_origin="CLI arguments",
         unmatched_glob_behavior=unmatched_cli_globs,
         convert_dir_literal_to_address_literal=convert_dir_literal_to_address_literal,
     )
@@ -116,8 +117,9 @@ def calculate_specs(
             unmatched_glob_behavior=unmatched_cli_globs,
             filter_by_global_options=True,
             from_change_detection=True,
+            description_of_origin="`--changed-since`",
         ),
-        ignores=RawSpecs(),
+        ignores=RawSpecs(description_of_origin="`--changed-since`"),
     )
 
 

--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -327,7 +327,9 @@ def test_resolve_with_a_jar(rule_runner: RuleRunner) -> None:
         }
     )
 
-    targets = rule_runner.request(Targets, [RawSpecs(recursive_globs=(RecursiveGlobSpec(""),))])
+    targets = rule_runner.request(
+        Targets, [RawSpecs(recursive_globs=(RecursiveGlobSpec(""),), description_of_origin="tests")]
+    )
     jeremy_target = targets[0]
 
     jar_field = jeremy_target[JvmArtifactJarSourceField]

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -331,7 +331,9 @@ class RuleRunner:
             [GlobalOptions.get_scope_info(), goal.subsystem_cls.get_scope_info()]
         ).specs
         specs = SpecsParser(self.build_root).parse_specs(
-            raw_specs, convert_dir_literal_to_address_literal=True
+            raw_specs,
+            convert_dir_literal_to_address_literal=True,
+            description_of_origin="RuleRunner.run_goal_rule()",
         )
 
         stdout, stderr = StringIO(), StringIO()


### PR DESCRIPTION
Before:

```
❯ ./pants paths --from=fake/f.py --to=src/python/pants/util/strutil.py
12:54:23.99 [ERROR] 1 Exception encountered:

  Exception: Unmatched glob from CLI arguments
```

After:

```
❯ ./pants paths --from=fake/f.py --to=src/python/pants/util/strutil.py
12:54:23.99 [ERROR] 1 Exception encountered:

  Exception: Unmatched glob from the option `--paths-from`: "fake/f.py"
```

It was a lie to hardcode "CLI arguments". 

Most of these rules should never error because we only error if the directory of the CLI specs do not exist, and we programmatically compute the specs based on already existing targets. But still, this gives us much better debugging if those assumptions are violated.

This also unblocks us from https://github.com/pantsbuild/pants/issues/14468. The `Specs` will be able to pass down their `description_of_origin` to `AddressInput` for much better errors with invalid `AddressLiteralSpec`s.

[ci skip-build-wheels]