### PR TITLE
Don't include `description_of_origin` in `__eq__` and `__hash__` for `PathGlobs`

### DIFF
--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Iterable, Optional, Tuple, Union
@@ -133,7 +134,7 @@ class PathGlobs:
     globs: Tuple[str, ...]
     glob_match_error_behavior: GlobMatchErrorBehavior
     conjunction: GlobExpansionConjunction
-    description_of_origin: str | None
+    description_of_origin: str | None = dataclasses.field(compare=False, hash=False)
 
     def __init__(
         self,


### PR DESCRIPTION
This caused memoization to not happen when it could.

`description_of_origin` is only used in error messages for when `PathGlobs` do not match. If using `error` mode, then we will eagerly error and never encounter the second instance.

`warn` mode is trickier. We will no longer warn the second time, when maybe we want to? For example, `:tgt1` and `:tgt2` both have invalid `sources` fields and `--unmatched-build-file-globs=warn` -- is it important to us that we show both warnings?

[ci skip-rust]