### PR TITLE
Fix help for `--process-total-child-memory-usage` and `--process-per-child-memory-usage`

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -460,6 +460,9 @@ class LocalStoreOptions:
         )
 
 
+_PER_CHILD_MEMORY_USAGE = "512MiB"
+
+
 DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     # Remote execution strategy.
     remote_execution=False,
@@ -470,7 +473,7 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     remote_ca_certs_path=None,
     # Process execution setup.
     process_total_child_memory_usage=None,
-    process_per_child_memory_usage=memory_size("512MiB"),
+    process_per_child_memory_usage=memory_size(_PER_CHILD_MEMORY_USAGE),
     process_execution_local_parallelism=CPU_COUNT,
     process_execution_remote_parallelism=128,
     process_execution_cache_namespace=None,
@@ -1083,23 +1086,28 @@ class BootstrapOptions:
             """
         ),
     )
+
+    _process_total_child_memory_usage = "--process-total-child-memory-usage"
+    _process_per_child_memory_usage_flag = "--process-per-child-memory-usage"
     process_total_child_memory_usage = MemorySizeOption(
-        "--process-total-child-memory-usage",
+        _process_total_child_memory_usage,
         advanced=True,
         default=None,
-        default_help_repr="1GiB",
         help=softwrap(
-            """
-            The maximum memory usage for all child processes.
+            f"""
+            The maximum memory usage for all "pooled" child processes.
 
-            This value participates in precomputing the pool size of child processes used by
-            `pantsd`. A high value would result in a high number of child processes spawned,
-            potentially overconsuming your resources and triggering the OS' OOM killer. A low
-            value would mean a low number of child processes launched and therefore less
-            paralellism for the tasks that need those processes.
+            When set, this value participates in precomputing the pool size of child processes
+            used by Pants (pooling is currently used only for the JVM). When not set, Pants will
+            default to spawning `2 * {_process_execution_local_parallelism_flag}` pooled processes.
 
-            If setting this value, consider also setting a value for the `process-per-child-memory-usage`
-            option too.
+            A high value would result in a high number of child processes spawned, potentially
+            overconsuming your resources and triggering the OS' OOM killer. A low value would
+            mean a low number of child processes launched and therefore less parallelism for the
+            tasks that need those processes.
+
+            If setting this value, consider also adjusting the value of the
+            `{_process_per_child_memory_usage_flag}` option.
 
             You can suffix with `GiB`, `MiB`, `KiB`, or `B` to indicate the unit, e.g.
             `2GiB` or `2.12GiB`. A bare number will be in bytes.
@@ -1107,15 +1115,15 @@ class BootstrapOptions:
         ),
     )
     process_per_child_memory_usage = MemorySizeOption(
-        "--process-per-child-memory-usage",
+        _process_per_child_memory_usage_flag,
         advanced=True,
         default=DEFAULT_EXECUTION_OPTIONS.process_per_child_memory_usage,
-        default_help_repr="512MiB",
+        default_help_repr=_PER_CHILD_MEMORY_USAGE,
         help=softwrap(
-            """
-            The default memory usage for a child process.
+            f"""
+            The default memory usage for a single "pooled" child process.
 
-            Check the documentation for the `process-total-child-memory-usage` for advice on
+            Check the documentation for the `{_process_total_child_memory_usage}` for advice on
             how to choose an appropriate value for this option.
 
             You can suffix with `GiB`, `MiB`, `KiB`, or `B` to indicate the unit, e.g.


### PR DESCRIPTION
In particular, the `--process-total-child-memory-usage` flag was setting `default_help_repr="1GiB"`, even though it did not have a `default`.

Additionally, add some clarifications around which processes are impacted, and what happens when `--process-total-child-memory-usage` is not set. 

[ci skip-rust]
[ci skip-build-wheels]