### PR TITLE
Require keyword arguments for `AddressInput`

### DIFF
--- a/src/python/pants/backend/kotlin/compile/kotlinc_plugins.py
+++ b/src/python/pants/backend/kotlin/compile/kotlinc_plugins.py
@@ -122,22 +122,19 @@ async def resolve_kotlinc_plugins_for_target(
         plugin_names_by_resolve = kotlinc.parsed_default_plugins()
         plugin_ids = tuple(plugin_names_by_resolve.get(resolve, ()))
 
-    candidate_plugins: list[Target] = []
+    candidate_plugins = []
+    artifact_address_gets = []
     for plugin in all_kotlinc_plugins:
-        if _plugin_id(plugin) in plugin_ids:
-            candidate_plugins.append(plugin)
+        if _plugin_id(plugin) not in plugin_ids:
+            continue
+        candidate_plugins.append(plugin)
+        artifact_field = plugin[KotlincPluginArtifactField]
+        address_input = AddressInput.parse(
+            artifact_field.value, relative_to=target.address.spec_path
+        )
+        artifact_address_gets.append(Get(Address, AddressInput, address_input))
 
-    artifact_address_inputs = (
-        plugin[KotlincPluginArtifactField].value for plugin in candidate_plugins
-    )
-
-    artifact_addresses = await MultiGet(
-        # `is not None` is solely to satiate mypy. artifact field is required.
-        Get(Address, AddressInput, AddressInput.parse(ai, relative_to=target.address.spec_path))
-        for ai in artifact_address_inputs
-        if ai is not None
-    )
-
+    artifact_addresses = await MultiGet(artifact_address_gets)
     candidate_artifacts = await Get(Targets, Addresses(artifact_addresses))
 
     plugins: dict[str, tuple[Target, Target]] = {}  # Maps plugin ID to relevant JVM artifact

--- a/src/python/pants/backend/kotlin/target_types.py
+++ b/src/python/pants/backend/kotlin/target_types.py
@@ -174,6 +174,7 @@ class KotlinJunitTestsGeneratorTarget(TargetFilesGenerator):
 class KotlincPluginArtifactField(StringField):
     alias = "artifact"
     required = True
+    value: str
     help = "The address of a `jvm_artifact` that defines a plugin for `kotlinc`."
 
 

--- a/src/python/pants/backend/scala/compile/scalac_plugins.py
+++ b/src/python/pants/backend/scala/compile/scalac_plugins.py
@@ -113,22 +113,19 @@ async def resolve_scala_plugins_for_target(
         plugin_names_by_resolve = scalac.parsed_default_plugins()
         plugin_names = tuple(plugin_names_by_resolve.get(resolve, ()))
 
-    candidate_plugins: list[Target] = []
+    candidate_plugins = []
+    artifact_address_gets = []
     for plugin in all_scala_plugins:
-        if _plugin_name(plugin) in plugin_names:
-            candidate_plugins.append(plugin)
+        if _plugin_name(plugin) not in plugin_names:
+            continue
+        candidate_plugins.append(plugin)
+        artifact_field = plugin[ScalacPluginArtifactField]
+        address_input = AddressInput.parse(
+            artifact_field.value, relative_to=target.address.spec_path
+        )
+        artifact_address_gets.append(Get(Address, AddressInput, address_input))
 
-    artifact_address_inputs = (
-        plugin[ScalacPluginArtifactField].value for plugin in candidate_plugins
-    )
-
-    artifact_addresses = await MultiGet(
-        # `is not None` is solely to satiate mypy. artifact field is required.
-        Get(Address, AddressInput, AddressInput.parse(ai, relative_to=target.address.spec_path))
-        for ai in artifact_address_inputs
-        if ai is not None
-    )
-
+    artifact_addresses = await MultiGet(artifact_address_gets)
     candidate_artifacts = await Get(Targets, Addresses(artifact_addresses))
 
     plugins: dict[str, tuple[Target, Target]] = {}  # Maps plugin name to relevant JVM artifact

--- a/src/python/pants/backend/scala/target_types.py
+++ b/src/python/pants/backend/scala/target_types.py
@@ -248,6 +248,7 @@ class ScalaSourcesGeneratorTarget(TargetFilesGenerator):
 class ScalacPluginArtifactField(StringField):
     alias = "artifact"
     required = True
+    value: str
     help = "The address of a `jvm_artifact` that defines a plugin for `scalac`."
 
 

--- a/src/python/pants/build_graph/address_test.py
+++ b/src/python/pants/build_graph/address_test.py
@@ -475,19 +475,19 @@ def test_address_create_generated() -> None:
         ),
         (
             Address("", target_name="t", parameters={"k": "v"}),
-            AddressInput("", "t", parameters=FrozenDict({"k": "v"})),
+            AddressInput("", "t", parameters={"k": "v"}),
         ),
         (
             Address("", target_name="t", parameters={"k": "v"}, generated_name="gen"),
-            AddressInput("", "t", parameters=FrozenDict({"k": "v"}), generated_component="gen"),
+            AddressInput("", "t", parameters={"k": "v"}, generated_component="gen"),
         ),
         (
             Address("", target_name="t", parameters={"k": ""}),
-            AddressInput("", "t", parameters=FrozenDict({"k": ""})),
+            AddressInput("", "t", parameters={"k": ""}),
         ),
         (
             Address("", target_name="t", parameters={"k1": "v1", "k2": "v2"}),
-            AddressInput("", "t", parameters=FrozenDict({"k1": "v1", "k2": "v2"})),
+            AddressInput("", "t", parameters={"k1": "v1", "k2": "v2"}),
         ),
     ],
 )

--- a/src/python/pants/engine/addresses.py
+++ b/src/python/pants/engine/addresses.py
@@ -1,8 +1,10 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Iterable, Optional, Sequence, Tuple
+from typing import Iterable, Sequence
 
 from pants.base.exceptions import ResolveError
 from pants.build_graph.address import Address as Address
@@ -51,9 +53,14 @@ class UnparsedAddressInputs:
     Unlike the `dependencies` field, this type does not work with `!` and `!!` ignores.
     """
 
-    values: Tuple[str, ...]
-    relative_to: Optional[str]
+    values: tuple[str, ...]
+    relative_to: str | None
 
-    def __init__(self, values: Iterable[str], *, owning_address: Optional[Address]) -> None:
+    def __init__(
+        self,
+        values: Iterable[str],
+        *,
+        owning_address: Address | None,
+    ) -> None:
         self.values = tuple(values)
         self.relative_to = owning_address.spec_path if owning_address else None

--- a/src/python/pants/engine/internals/specs_rules.py
+++ b/src/python/pants/engine/internals/specs_rules.py
@@ -75,8 +75,8 @@ async def _determine_literal_addresses_from_raw_specs(
             AddressInput(
                 spec.path_component,
                 spec.target_component,
-                spec.generated_component,
-                spec.parameters,
+                generated_component=spec.generated_component,
+                parameters=spec.parameters,
             ),
         )
         for spec in literal_specs


### PR DESCRIPTION
Prework for https://github.com/pantsbuild/pants/issues/14468, where we will add `description_of_origin: str` to these types.

This also refactors our plugin code for Scala and Kotlin plugins, which will be needed for the next PR.

[ci skip-rust]
[ci skip-build-wheels]