### PR TITLE
Add `extra_env_vars` field to `experimental_shell_command` target.

### DIFF
--- a/src/python/pants/backend/shell/shell_command.py
+++ b/src/python/pants/backend/shell/shell_command.py
@@ -14,6 +14,7 @@ from pants.backend.shell.builtin import BASH_BUILTIN_COMMANDS
 from pants.backend.shell.shell_setup import ShellSetup
 from pants.backend.shell.target_types import (
     ShellCommandCommandField,
+    ShellCommandExtraEnvVarsField,
     ShellCommandLogOutputField,
     ShellCommandOutputsField,
     ShellCommandRunWorkdirField,
@@ -115,6 +116,7 @@ async def prepare_shell_command_process(
     timeout = shell_command.get(ShellCommandTimeoutField).value
     tools = shell_command.get(ShellCommandToolsField, default_raw_value=()).value
     outputs = shell_command.get(ShellCommandOutputsField).value or ()
+    extra_env_vars = shell_command.get(ShellCommandExtraEnvVarsField).value or ()
 
     if not command:
         raise ValueError(
@@ -161,6 +163,9 @@ async def prepare_shell_command_process(
                     tool_request,
                     rationale=f"execute `{shell_command.alias}` {shell_command.address}",
                 )
+
+    extra_env = await Get(Environment, EnvironmentRequest(extra_env_vars))
+    command_env.update(extra_env)
 
     transitive_targets = await Get(
         TransitiveTargets,

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -301,6 +301,17 @@ class ShellCommandToolsField(StringSequenceField):
     )
 
 
+class ShellCommandExtraEnvVarsField(StringSequenceField):
+    alias = "extra_env_vars"
+    help = softwrap(
+        """
+        Additional environment variables to include in the shell process.
+        Entries are strings in the form `ENV_VAR=value` to use explicitly; or just
+        `ENV_VAR` to copy the value of a variable in Pants's own environment.
+        """
+    )
+
+
 class ShellCommandLogOutputField(BoolField):
     alias = "log_output"
     default = False
@@ -324,6 +335,7 @@ class ShellCommandTarget(Target):
         ShellCommandSourcesField,
         ShellCommandTimeoutField,
         ShellCommandToolsField,
+        ShellCommandExtraEnvVarsField,
     )
     help = softwrap(
         """


### PR DESCRIPTION
Closes #15728

[ci skip-rust]
[ci skip-build-wheels]