### PR TITLE
Require setting `description_of_origin` with `AddressInput` and `UnparsedAddressInputs`

### DIFF
--- a/src/python/pants/backend/codegen/thrift/scrooge/java/subsystem.py
+++ b/src/python/pants/backend/codegen/thrift/scrooge/java/subsystem.py
@@ -28,4 +28,8 @@ class ScroogeJavaSubsystem(Subsystem):
 
     @property
     def runtime_dependencies(self) -> UnparsedAddressInputs:
-        return UnparsedAddressInputs(self._runtime_dependencies, owning_address=None)
+        return UnparsedAddressInputs(
+            self._runtime_dependencies,
+            owning_address=None,
+            description_of_origin=f"the option `[{self.options_scope}].runtime_dependencies`",
+        )

--- a/src/python/pants/backend/codegen/thrift/scrooge/scala/subsystem.py
+++ b/src/python/pants/backend/codegen/thrift/scrooge/scala/subsystem.py
@@ -29,4 +29,8 @@ class ScroogeScalaSubsystem(Subsystem):
 
     @property
     def runtime_dependencies(self) -> UnparsedAddressInputs:
-        return UnparsedAddressInputs(self._runtime_dependencies, owning_address=None)
+        return UnparsedAddressInputs(
+            self._runtime_dependencies,
+            owning_address=None,
+            description_of_origin=f"the option `[{self.options_scope}].runtime_dependencies`",
+        )

--- a/src/python/pants/backend/docker/util_rules/dependencies.py
+++ b/src/python/pants/backend/docker/util_rules/dependencies.py
@@ -33,6 +33,7 @@ async def inject_docker_dependencies(
             UnparsedAddressInputs(
                 (v for v in dockerfile_info.from_image_build_args.to_dict().values() if v),
                 owning_address=dockerfile_info.address,
+                description_of_origin="TODO(#14468)",
             ),
         )
     )

--- a/src/python/pants/backend/docker/util_rules/docker_build_context.py
+++ b/src/python/pants/backend/docker/util_rules/docker_build_context.py
@@ -283,6 +283,7 @@ async def create_docker_build_context(
             UnparsedAddressInputs(
                 dockerfile_build_args.values(),
                 owning_address=dockerfile_info.address,
+                description_of_origin="TODO(#14468)",
             ),
         )
         # Map those addresses to the corresponding built image ref (tag).

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -265,7 +265,13 @@ async def determine_main_pkg_for_go_binary(
         wrapped_specified_tgt = await Get(
             WrappedTarget,
             AddressInput,
-            AddressInput.parse(request.field.value, relative_to=addr.spec_path),
+            AddressInput.parse(
+                request.field.value,
+                relative_to=addr.spec_path,
+                description_of_origin=(
+                    f"the `{request.field.alias}` field from the target {request.field.address}"
+                ),
+            ),
         )
         if not wrapped_specified_tgt.target.has_field(GoPackageSourcesField):
             raise InvalidFieldException(

--- a/src/python/pants/backend/kotlin/compile/kotlinc_plugins.py
+++ b/src/python/pants/backend/kotlin/compile/kotlinc_plugins.py
@@ -130,7 +130,11 @@ async def resolve_kotlinc_plugins_for_target(
         candidate_plugins.append(plugin)
         artifact_field = plugin[KotlincPluginArtifactField]
         address_input = AddressInput.parse(
-            artifact_field.value, relative_to=target.address.spec_path
+            artifact_field.value,
+            relative_to=target.address.spec_path,
+            description_of_origin=(
+                f"the `{artifact_field.alias}` field from the target {artifact_field.address}"
+            )
         )
         artifact_address_gets.append(Get(Address, AddressInput, address_input))
 

--- a/src/python/pants/backend/kotlin/compile/kotlinc_plugins.py
+++ b/src/python/pants/backend/kotlin/compile/kotlinc_plugins.py
@@ -134,7 +134,7 @@ async def resolve_kotlinc_plugins_for_target(
             relative_to=target.address.spec_path,
             description_of_origin=(
                 f"the `{artifact_field.alias}` field from the target {artifact_field.address}"
-            )
+            ),
         )
         artifact_address_gets.append(Get(Address, AddressInput, address_input))
 

--- a/src/python/pants/backend/kotlin/target_types.py
+++ b/src/python/pants/backend/kotlin/target_types.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from pants.engine.rules import collect_rules
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
+    AsyncFieldMixin,
     Dependencies,
     FieldSet,
     MultipleSourcesField,
@@ -171,7 +172,7 @@ class KotlinJunitTestsGeneratorTarget(TargetFilesGenerator):
 # -----------------------------------------------------------------------------------------------
 
 
-class KotlincPluginArtifactField(StringField):
+class KotlincPluginArtifactField(StringField, AsyncFieldMixin):
     alias = "artifact"
     required = True
     value: str

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -162,7 +162,11 @@ class Flake8(PythonToolBase):
 
     @property
     def source_plugins(self) -> UnparsedAddressInputs:
-        return UnparsedAddressInputs(self._source_plugins, owning_address=None)
+        return UnparsedAddressInputs(
+            self._source_plugins,
+            owning_address=None,
+            description_of_origin=f"the option `[{self.options_scope}].source_plugins`",
+        )
 
 
 # --------------------------------------------------------------------------------------

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -162,7 +162,11 @@ class Pylint(PythonToolBase):
 
     @property
     def source_plugins(self) -> UnparsedAddressInputs:
-        return UnparsedAddressInputs(self._source_plugins, owning_address=None)
+        return UnparsedAddressInputs(
+            self._source_plugins,
+            owning_address=None,
+            description_of_origin=f"the option `[{self.options_scope}].source_plugins`",
+        )
 
 
 # --------------------------------------------------------------------------------------

--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -316,7 +316,12 @@ async def resolve_python_distribution_entry_points(
     # Intermediate step, as Get(Targets) returns a deduplicated set.. which breaks in case of
     # multiple input refs that maps to the same target.
     target_addresses = await Get(
-        Addresses, UnparsedAddressInputs(target_refs, owning_address=address)
+        Addresses,
+        UnparsedAddressInputs(
+            target_refs,
+            owning_address=address,
+            description_of_origin=f"TODO(#14468)",
+        ),
     )
     address_by_ref = dict(zip(target_refs, target_addresses))
     targets = await Get(Targets, Addresses, target_addresses)

--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -320,7 +320,7 @@ async def resolve_python_distribution_entry_points(
         UnparsedAddressInputs(
             target_refs,
             owning_address=address,
-            description_of_origin=f"TODO(#14468)",
+            description_of_origin="TODO(#14468)",
         ),
     )
     address_by_ref = dict(zip(target_refs, target_addresses))

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -172,7 +172,11 @@ class MyPy(PythonToolBase):
 
     @property
     def source_plugins(self) -> UnparsedAddressInputs:
-        return UnparsedAddressInputs(self._source_plugins, owning_address=None)
+        return UnparsedAddressInputs(
+            self._source_plugins,
+            owning_address=None,
+            description_of_origin=f"the option `[{self.options_scope}].source_plugins`",
+        )
 
     def check_and_warn_if_python_version_configured(self, config: FileContent | None) -> bool:
         """Determine if we can dynamically set `--python-version` and warn if not."""

--- a/src/python/pants/backend/scala/compile/scalac_plugins.py
+++ b/src/python/pants/backend/scala/compile/scalac_plugins.py
@@ -121,7 +121,11 @@ async def resolve_scala_plugins_for_target(
         candidate_plugins.append(plugin)
         artifact_field = plugin[ScalacPluginArtifactField]
         address_input = AddressInput.parse(
-            artifact_field.value, relative_to=target.address.spec_path
+            artifact_field.value,
+            relative_to=target.address.spec_path,
+            description_of_origin=(
+                f"the `{artifact_field.alias}` field from the target {artifact_field.address}"
+            )
         )
         artifact_address_gets.append(Get(Address, AddressInput, address_input))
 

--- a/src/python/pants/backend/scala/compile/scalac_plugins.py
+++ b/src/python/pants/backend/scala/compile/scalac_plugins.py
@@ -125,7 +125,7 @@ async def resolve_scala_plugins_for_target(
             relative_to=target.address.spec_path,
             description_of_origin=(
                 f"the `{artifact_field.alias}` field from the target {artifact_field.address}"
-            )
+            ),
         )
         artifact_address_gets.append(Get(Address, AddressInput, address_input))
 

--- a/src/python/pants/backend/scala/target_types.py
+++ b/src/python/pants/backend/scala/target_types.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
+    AsyncFieldMixin,
     Dependencies,
     FieldSet,
     MultipleSourcesField,
@@ -18,7 +19,7 @@ from pants.engine.target import (
     TargetFilesGenerator,
     TargetFilesGeneratorSettings,
     TargetFilesGeneratorSettingsRequest,
-    generate_multiple_sources_field_help_message, AsyncFieldMixin,
+    generate_multiple_sources_field_help_message,
 )
 from pants.engine.unions import UnionRule
 from pants.jvm.target_types import (

--- a/src/python/pants/backend/scala/target_types.py
+++ b/src/python/pants/backend/scala/target_types.py
@@ -18,7 +18,7 @@ from pants.engine.target import (
     TargetFilesGenerator,
     TargetFilesGeneratorSettings,
     TargetFilesGeneratorSettingsRequest,
-    generate_multiple_sources_field_help_message,
+    generate_multiple_sources_field_help_message, AsyncFieldMixin,
 )
 from pants.engine.unions import UnionRule
 from pants.jvm.target_types import (
@@ -245,7 +245,7 @@ class ScalaSourcesGeneratorTarget(TargetFilesGenerator):
 # -----------------------------------------------------------------------------------------------
 
 
-class ScalacPluginArtifactField(StringField):
+class ScalacPluginArtifactField(StringField, AsyncFieldMixin):
     alias = "artifact"
     required = True
     value: str

--- a/src/python/pants/bsp/spec/base.py
+++ b/src/python/pants/bsp/spec/base.py
@@ -46,7 +46,7 @@ class BuildTargetIdentifier:
                 f"Unknown URI scheme for BSP BuildTargetIdentifier. Expected scheme `pants`, but URI was: {self.uri}"
             )
         raw_addr = self.uri[len("pants:") :]
-        return AddressInput.parse(raw_addr)
+        return AddressInput.parse(raw_addr, description_of_origin="TODO(#14468)")
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -57,6 +57,7 @@ class AddressInput:
     target_component: str | None
     generated_component: str | None
     parameters: FrozenDict[str, str]
+    description_of_origin: str
 
     def __init__(
         self,
@@ -65,19 +66,21 @@ class AddressInput:
         *,
         generated_component: str | None = None,
         parameters: Mapping[str, str] = FrozenDict(),
+        description_of_origin: str,
     ) -> None:
         self.path_component = path_component
         self.target_component = target_component
         self.generated_component = generated_component
         self.parameters = FrozenDict(parameters)
+        self.description_of_origin = description_of_origin
 
         if not self.target_component:
             if self.target_component is not None:
                 raise InvalidTargetName(
                     softwrap(
                         f"""
-                        Address spec `{self.path_component}` sets the name component to the empty
-                        string, which is not legal.
+                        Address spec `{self.path_component}` from {self.description_of_origin} sets
+                        the name component to the empty string, which is not legal.
                         """
                     )
                 )
@@ -85,8 +88,8 @@ class AddressInput:
                 raise InvalidTargetName(
                     softwrap(
                         f"""
-                        Address spec has no name part, but it's necessary because the path is the
-                        build root (`{self.path_component}`).
+                        Address spec from {self.description_of_origin} has no name part, but it's
+                        necessary because the path is the build root (`{self.path_component}`).
                         """
                     )
                 )
@@ -122,6 +125,7 @@ class AddressInput:
         *,
         relative_to: str | None = None,
         subproject_roots: Sequence[str] | None = None,
+        description_of_origin: str,
     ) -> AddressInput:
         """Parse a string into an AddressInput.
 
@@ -130,6 +134,8 @@ class AddressInput:
           interprets the missing spec_path part as `relative_to`.
         :param subproject_roots: Paths that correspond with embedded build roots under
           the current build root.
+        :param description_of_origin: where the AddressInput comes from, e.g. "CLI arguments" or
+          "the option `--paths-from`". This is used for better error messages.
 
         For example:
 
@@ -213,6 +219,7 @@ class AddressInput:
             target_component,
             generated_component=generated_component,
             parameters=FrozenDict(sorted(parameters)),
+            description_of_origin=description_of_origin,
         )
 
     def file_to_address(self) -> Address:

--- a/src/python/pants/build_graph/address_test.py
+++ b/src/python/pants/build_graph/address_test.py
@@ -27,7 +27,7 @@ def test_address_input_parse_spec() -> None:
         generated_component: str | None = None,
         relative_to: str | None = None,
     ) -> None:
-        ai = AddressInput.parse(spec, relative_to=relative_to)
+        ai = AddressInput.parse(spec, relative_to=relative_to, description_of_origin="tests")
         assert ai.path_component == path_component
         if target_component is None:
             assert ai.target_component is None
@@ -109,7 +109,7 @@ def test_address_input_parse_spec() -> None:
 )
 def test_address_input_parse_bad_path_component(spec: str) -> None:
     with pytest.raises(InvalidSpecPath):
-        AddressInput.parse(spec)
+        AddressInput.parse(spec, description_of_origin="tests")
 
 
 @pytest.mark.parametrize(
@@ -121,7 +121,7 @@ def test_address_input_parse_bad_path_component(spec: str) -> None:
 )
 def test_address_input_parse(spec: str, expected: str) -> None:
     with pytest.raises(AddressParseException) as e:
-        AddressInput.parse(spec)
+        AddressInput.parse(spec, description_of_origin="tests")
     assert expected in str(e.value)
 
 
@@ -140,7 +140,7 @@ def test_address_input_parse(spec: str, expected: str) -> None:
 )
 def test_address_bad_target_component(spec: str) -> None:
     with pytest.raises(InvalidTargetName):
-        AddressInput.parse(spec).dir_to_address()
+        AddressInput.parse(spec, description_of_origin="tests").dir_to_address()
 
 
 @pytest.mark.parametrize(
@@ -155,19 +155,19 @@ def test_address_bad_target_component(spec: str) -> None:
 )
 def test_address_bad_wildcard(spec: str) -> None:
     with pytest.raises(UnsupportedWildcard):
-        AddressInput.parse(spec).dir_to_address()
+        AddressInput.parse(spec, description_of_origin="tests").dir_to_address()
 
 
 @pytest.mark.parametrize("spec", ["//:t#gen!", "//:t#gen?", "//:t#gen=", "//:t#gen#"])
 def test_address_generated_name(spec: str) -> None:
     with pytest.raises(InvalidTargetName):
-        AddressInput.parse(spec).dir_to_address()
+        AddressInput.parse(spec, description_of_origin="tests").dir_to_address()
 
 
 @pytest.mark.parametrize("spec", ["//:t@k=#gen", "//:t@k#gen=v"])
 def test_address_invalid_params(spec: str) -> None:
     with pytest.raises(InvalidParameters):
-        AddressInput.parse(spec).dir_to_address()
+        AddressInput.parse(spec, description_of_origin="tests").dir_to_address()
 
 
 def test_address_input_subproject_spec() -> None:
@@ -177,6 +177,7 @@ def test_address_input_subproject_spec() -> None:
             spec,
             relative_to=relative_to,
             subproject_roots=["subprojectA", "path/to/subprojectB"],
+            description_of_origin="tests",
         )
 
     # Ensure that a spec in subprojectA is determined correctly.
@@ -220,41 +221,49 @@ def test_address_input_subproject_spec() -> None:
 
 
 def test_address_input_from_file() -> None:
-    assert AddressInput("a/b/c.txt", target_component=None).file_to_address() == Address(
-        "a/b", relative_file_path="c.txt"
-    )
-
-    assert AddressInput("a/b/c.txt", target_component="original").file_to_address() == Address(
-        "a/b", target_name="original", relative_file_path="c.txt"
-    )
-    assert AddressInput("a/b/c.txt", target_component="../original").file_to_address() == Address(
-        "a", target_name="original", relative_file_path="b/c.txt"
-    )
     assert AddressInput(
-        "a/b/c.txt", target_component="../../original"
+        "a/b/c.txt", target_component=None, description_of_origin="tests"
+    ).file_to_address() == Address("a/b", relative_file_path="c.txt")
+
+    assert AddressInput(
+        "a/b/c.txt", target_component="original", description_of_origin="tests"
+    ).file_to_address() == Address("a/b", target_name="original", relative_file_path="c.txt")
+    assert AddressInput(
+        "a/b/c.txt", target_component="../original", description_of_origin="tests"
+    ).file_to_address() == Address("a", target_name="original", relative_file_path="b/c.txt")
+    assert AddressInput(
+        "a/b/c.txt", target_component="../../original", description_of_origin="tests"
     ).file_to_address() == Address("", target_name="original", relative_file_path="a/b/c.txt")
 
     # These refer to targets "below" the file, which is illegal.
     with pytest.raises(InvalidTargetName):
-        AddressInput("f.txt", target_component="subdir/tgt").file_to_address()
+        AddressInput(
+            "f.txt", target_component="subdir/tgt", description_of_origin="tests"
+        ).file_to_address()
     with pytest.raises(InvalidTargetName):
-        AddressInput("f.txt", target_component="subdir../tgt").file_to_address()
+        AddressInput(
+            "f.txt", target_component="subdir../tgt", description_of_origin="tests"
+        ).file_to_address()
     with pytest.raises(InvalidTargetName):
-        AddressInput("a/f.txt", target_component="../a/original").file_to_address()
+        AddressInput(
+            "a/f.txt", target_component="../a/original", description_of_origin="tests"
+        ).file_to_address()
 
     # Top-level files must include a target_name.
     with pytest.raises(InvalidTargetName):
-        AddressInput("f.txt").file_to_address()
-    assert AddressInput("f.txt", target_component="tgt").file_to_address() == Address(
-        "", relative_file_path="f.txt", target_name="tgt"
-    )
+        AddressInput("f.txt", description_of_origin="tests").file_to_address()
+    assert AddressInput(
+        "f.txt", target_component="tgt", description_of_origin="tests"
+    ).file_to_address() == Address("", relative_file_path="f.txt", target_name="tgt")
 
 
 def test_address_input_from_dir() -> None:
-    assert AddressInput("a").dir_to_address() == Address("a")
-    assert AddressInput("a", target_component="b").dir_to_address() == Address("a", target_name="b")
+    assert AddressInput("a", description_of_origin="tests").dir_to_address() == Address("a")
     assert AddressInput(
-        "a", target_component="b", generated_component="gen"
+        "a", target_component="b", description_of_origin="tests"
+    ).dir_to_address() == Address("a", target_name="b")
+    assert AddressInput(
+        "a", target_component="b", generated_component="gen", description_of_origin="tests"
     ).dir_to_address() == Address("a", target_name="b", generated_name="gen")
 
 
@@ -444,53 +453,75 @@ def test_address_create_generated() -> None:
 @pytest.mark.parametrize(
     "addr,expected",
     [
-        (Address("a/b/c"), AddressInput("a/b/c", target_component="c")),
-        (Address("a/b/c", target_name="tgt"), AddressInput("a/b/c", "tgt")),
+        (
+            Address("a/b/c"),
+            AddressInput("a/b/c", target_component="c", description_of_origin="tests"),
+        ),
+        (
+            Address("a/b/c", target_name="tgt"),
+            AddressInput("a/b/c", "tgt", description_of_origin="tests"),
+        ),
         (
             Address("a/b/c", target_name="tgt", generated_name="gen"),
-            AddressInput("a/b/c", "tgt", generated_component="gen"),
+            AddressInput("a/b/c", "tgt", generated_component="gen", description_of_origin="tests"),
         ),
         (
             Address("a/b/c", target_name="tgt", generated_name="dir/gen"),
-            AddressInput("a/b/c", "tgt", generated_component="dir/gen"),
+            AddressInput(
+                "a/b/c", "tgt", generated_component="dir/gen", description_of_origin="tests"
+            ),
         ),
-        (Address("a/b/c", relative_file_path="f.txt"), AddressInput("a/b/c/f.txt")),
+        (
+            Address("a/b/c", relative_file_path="f.txt"),
+            AddressInput("a/b/c/f.txt", description_of_origin="tests"),
+        ),
         (
             Address("a/b/c", relative_file_path="f.txt", target_name="tgt"),
-            AddressInput("a/b/c/f.txt", "tgt"),
+            AddressInput("a/b/c/f.txt", "tgt", description_of_origin="tests"),
         ),
-        (Address("", target_name="tgt"), AddressInput("", "tgt")),
+        (Address("", target_name="tgt"), AddressInput("", "tgt", description_of_origin="tests")),
         (
             Address("", target_name="tgt", generated_name="gen"),
-            AddressInput("", "tgt", generated_component="gen"),
+            AddressInput("", "tgt", generated_component="gen", description_of_origin="tests"),
         ),
-        (Address("", target_name="tgt", relative_file_path="f.txt"), AddressInput("f.txt", "tgt")),
+        (
+            Address("", target_name="tgt", relative_file_path="f.txt"),
+            AddressInput("f.txt", "tgt", description_of_origin="tests"),
+        ),
         (
             Address("a/b/c", relative_file_path="subdir/f.txt"),
-            AddressInput("a/b/c/subdir/f.txt", "../c"),
+            AddressInput("a/b/c/subdir/f.txt", "../c", description_of_origin="tests"),
         ),
         (
             Address("a/b/c", relative_file_path="subdir/f.txt", target_name="tgt"),
-            AddressInput("a/b/c/subdir/f.txt", "../tgt"),
+            AddressInput("a/b/c/subdir/f.txt", "../tgt", description_of_origin="tests"),
         ),
         (
             Address("", target_name="t", parameters={"k": "v"}),
-            AddressInput("", "t", parameters={"k": "v"}),
+            AddressInput("", "t", parameters={"k": "v"}, description_of_origin="tests"),
         ),
         (
             Address("", target_name="t", parameters={"k": "v"}, generated_name="gen"),
-            AddressInput("", "t", parameters={"k": "v"}, generated_component="gen"),
+            AddressInput(
+                "",
+                "t",
+                parameters={"k": "v"},
+                generated_component="gen",
+                description_of_origin="tests",
+            ),
         ),
         (
             Address("", target_name="t", parameters={"k": ""}),
-            AddressInput("", "t", parameters={"k": ""}),
+            AddressInput("", "t", parameters={"k": ""}, description_of_origin="tests"),
         ),
         (
             Address("", target_name="t", parameters={"k1": "v1", "k2": "v2"}),
-            AddressInput("", "t", parameters={"k1": "v1", "k2": "v2"}),
+            AddressInput(
+                "", "t", parameters={"k1": "v1", "k2": "v2"}, description_of_origin="tests"
+            ),
         ),
     ],
 )
 def test_address_spec_to_address_input(addr: Address, expected: AddressInput) -> None:
     """Check that Address.spec <-> AddressInput.parse() is idempotent."""
-    assert AddressInput.parse(addr.spec) == expected
+    assert AddressInput.parse(addr.spec, description_of_origin="tests") == expected

--- a/src/python/pants/engine/addresses.py
+++ b/src/python/pants/engine/addresses.py
@@ -51,16 +51,22 @@ class UnparsedAddressInputs:
     references like `:sibling` work properly.
 
     Unlike the `dependencies` field, this type does not work with `!` and `!!` ignores.
+
+    Set `description_of_origin` to a value like "CLI arguments" or "the `dependencies` field
+    from {tgt.address}". It is used for better error messages.
     """
 
     values: tuple[str, ...]
     relative_to: str | None
+    description_of_origin: str
 
     def __init__(
         self,
         values: Iterable[str],
         *,
         owning_address: Address | None,
+        description_of_origin: str,
     ) -> None:
         self.values = tuple(values)
         self.relative_to = owning_address.spec_path if owning_address else None
+        self.description_of_origin = description_of_origin

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -108,27 +108,35 @@ def test_resolve_address() -> None:
         assert rule_runner.request(Address, [address_input]) == expected
 
     assert_is_expected(
-        AddressInput("a/b/c.txt"), Address("a/b", target_name=None, relative_file_path="c.txt")
+        AddressInput("a/b/c.txt", description_of_origin="tests"),
+        Address("a/b", target_name=None, relative_file_path="c.txt"),
     )
     assert_is_expected(
-        AddressInput("a/b"), Address("a/b", target_name=None, relative_file_path=None)
+        AddressInput("a/b", description_of_origin="tests"),
+        Address("a/b", target_name=None, relative_file_path=None),
     )
 
-    assert_is_expected(AddressInput("a/b", target_component="c"), Address("a/b", target_name="c"))
     assert_is_expected(
-        AddressInput("a/b/c.txt", target_component="c"),
+        AddressInput("a/b", target_component="c", description_of_origin="tests"),
+        Address("a/b", target_name="c"),
+    )
+    assert_is_expected(
+        AddressInput("a/b/c.txt", target_component="c", description_of_origin="tests"),
         Address("a/b", relative_file_path="c.txt", target_name="c"),
     )
 
     # Top-level addresses will not have a path_component, unless they are a file address.
     assert_is_expected(
-        AddressInput("f.txt", target_component="original"),
+        AddressInput("f.txt", target_component="original", description_of_origin="tests"),
         Address("", relative_file_path="f.txt", target_name="original"),
     )
-    assert_is_expected(AddressInput("", target_component="t"), Address("", target_name="t"))
+    assert_is_expected(
+        AddressInput("", target_component="t", description_of_origin="tests"),
+        Address("", target_name="t"),
+    )
 
     with pytest.raises(ExecutionError) as exc:
-        rule_runner.request(Address, [AddressInput("a/b/fake")])
+        rule_runner.request(Address, [AddressInput("a/b/fake", description_of_origin="tests")])
     assert "'a/b/fake' does not exist on disk" in str(exc.value)
 
 

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -970,6 +970,9 @@ async def determine_explicitly_provided_dependencies(
         AddressInput.parse,
         relative_to=request.field.address.spec_path,
         subproject_roots=subproject_roots,
+        description_of_origin=(
+            f"the `{request.field.alias}` field from the target {request.field.address}"
+        ),
     )
 
     addresses: list[AddressInput] = []
@@ -1090,6 +1093,9 @@ async def resolve_dependencies(
                     addr,
                     relative_to=tgt.address.spec_path,
                     subproject_roots=subproject_roots,
+                    description_of_origin=(
+                        f"the `{special_cased_field.alias}` field from the target {tgt.address}"
+                    ),
                 ),
             )
             for special_cased_field in special_cased_fields
@@ -1135,7 +1141,10 @@ async def resolve_unparsed_address_inputs(
             Address,
             AddressInput,
             AddressInput.parse(
-                v, relative_to=request.relative_to, subproject_roots=subproject_roots
+                v,
+                relative_to=request.relative_to,
+                subproject_roots=subproject_roots,
+                description_of_origin=request.description_of_origin,
             ),
         )
         for v in request.values

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -1640,7 +1640,8 @@ async def infer_smalltalk_dependencies(request: InferSmalltalkDependencies) -> I
         file_content.content.decode().splitlines() for file_content in digest_contents
     )
     resolved = await MultiGet(
-        Get(Address, AddressInput, AddressInput.parse(line)) for line in all_lines
+        Get(Address, AddressInput, AddressInput.parse(line, description_of_origin="smalltalk rule"))
+        for line in all_lines
     )
     return InferredDependencies(resolved)
 
@@ -1926,7 +1927,9 @@ def test_resolve_unparsed_address_inputs() -> None:
         Addresses,
         [
             UnparsedAddressInputs(
-                ["project:t1", ":t2"], owning_address=Address("project", target_name="t3")
+                ["project:t1", ":t2"],
+                owning_address=Address("project", target_name="t3"),
+                description_of_origin="tests",
             )
         ],
     )

--- a/src/python/pants/engine/internals/specs_rules.py
+++ b/src/python/pants/engine/internals/specs_rules.py
@@ -67,7 +67,7 @@ logger = logging.getLogger(__name__)
 
 @rule_helper
 async def _determine_literal_addresses_from_raw_specs(
-    literal_specs: tuple[AddressLiteralSpec, ...]
+    literal_specs: tuple[AddressLiteralSpec, ...], *, description_of_origin: str
 ) -> tuple[WrappedTarget, ...]:
     literal_addresses = await MultiGet(
         Get(
@@ -77,6 +77,7 @@ async def _determine_literal_addresses_from_raw_specs(
                 spec.target_component,
                 generated_component=spec.generated_component,
                 parameters=spec.parameters,
+                description_of_origin=description_of_origin,
             ),
         )
         for spec in literal_specs
@@ -114,7 +115,7 @@ async def addresses_from_raw_specs_without_file_owners(
     filtering_disabled = specs.filter_by_global_options is False
 
     literal_wrapped_targets = await _determine_literal_addresses_from_raw_specs(
-        specs.address_literals
+        specs.address_literals, description_of_origin=specs.description_of_origin
     )
     matched_addresses.update(
         wrapped_tgt.target.address

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -2332,11 +2332,15 @@ class Dependencies(StringSequenceField, AsyncFieldMixin):
 
     @memoized_property
     def unevaluated_transitive_excludes(self) -> UnparsedAddressInputs:
-        if not self.supports_transitive_excludes or not self.value:
-            return UnparsedAddressInputs((), owning_address=self.address)
+        val = (
+            (v[2:] for v in self.value if v.startswith("!!"))
+            if self.supports_transitive_excludes and self.value
+            else ()
+        )
         return UnparsedAddressInputs(
-            (v[2:] for v in self.value if v.startswith("!!")),
+            val,
             owning_address=self.address,
+            description_of_origin=f"the `{self.alias}` field from the target {self.address}",
         )
 
 
@@ -2607,7 +2611,11 @@ class SpecialCasedDependencies(StringSequenceField, AsyncFieldMixin):
     """
 
     def to_unparsed_address_inputs(self) -> UnparsedAddressInputs:
-        return UnparsedAddressInputs(self.value or (), owning_address=self.address)
+        return UnparsedAddressInputs(
+            self.value or (),
+            owning_address=self.address,
+            description_of_origin=f"the `{self.alias}` from the target {self.address}",
+        )
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/init/specs_calculator.py
+++ b/src/python/pants/init/specs_calculator.py
@@ -98,7 +98,7 @@ def calculate_specs(
 
     address_literal_specs = []
     for address in cast(ChangedAddresses, changed_addresses):
-        address_input = AddressInput.parse(address.spec)
+        address_input = AddressInput.parse(address.spec, description_of_origin="`--changed-since`")
         address_literal_specs.append(
             AddressLiteralSpec(
                 path_component=address_input.path_component,

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -550,7 +550,10 @@ async def coursier_fetch_one_coord(
     req: ArtifactRequirement
     if request.pants_address:
         targets = await Get(
-            Targets, UnparsedAddressInputs([request.pants_address], owning_address=None)
+            Targets,
+            UnparsedAddressInputs(
+                [request.pants_address], owning_address=None, description_of_origin="TODO(#14468)"
+            ),
         )
         req = ArtifactRequirement(request.coord, jar=targets[0][JvmArtifactJarSourceField])
     else:

--- a/src/python/pants/jvm/resolve/jvm_tool.py
+++ b/src/python/pants/jvm/resolve/jvm_tool.py
@@ -122,7 +122,9 @@ async def gather_coordinates_for_jvm_lockfile(
                 pass
 
         try:
-            address_input = AddressInput.parse(artifact_input)
+            address_input = AddressInput.parse(
+                artifact_input, description_of_origin=f"the option `{request.option_name}`"
+            )
             candidate_address_inputs.add(address_input)
         except Exception:
             bad_artifact_inputs.append(artifact_input)


### PR DESCRIPTION
This will allow us to enrich the error messages for https://github.com/pantsbuild/pants/issues/14468, which will be done in a followup.

Some of the callers are not yet implemented, but that's fine because this doesn't update error messages yet except for two cases that should not happen in the wild.

[ci skip-rust]
[ci skip-build-wheels]