### PR TITLE
Change the default `remote_cache_warnings` warnings behavior to `backoff`. (Cherry-pick of #15745)

### DIFF
--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -3,8 +3,6 @@ colors = true
 
 remote_cache_read = true
 remote_cache_write = true
-# We want to continue to get logs when remote caching errors.
-remote_cache_warnings = "backoff"
 
 [stats]
 log = true

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -481,7 +481,7 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     remote_store_batch_api_size_limit=4194304,
     # Remote cache setup.
     remote_cache_eager_fetch=True,
-    remote_cache_warnings=RemoteCacheWarningsBehavior.first_only,
+    remote_cache_warnings=RemoteCacheWarningsBehavior.backoff,
     remote_cache_rpc_concurrency=128,
     remote_cache_read_timeout_millis=1500,
     # Remote execution setup.
@@ -1321,7 +1321,7 @@ class BootstrapOptions:
         advanced=True,
         help=softwrap(
             """
-            Whether to log remote cache failures at the `warn` log level.
+            How frequently to log remote cache failures at the `warn` log level.
 
             All errors not logged at the `warn` level will instead be logged at the
             `debug` level.


### PR DESCRIPTION
When we initially set this, we were concerned with error noise, but in practice the backoff setting gives a very reasonable amount of (desirable) output.

[ci skip-build-wheels]
[ci skip-rust]
