### PR TITLE
Update release helper to handle the new MacOS ARM64 wheel.

### DIFF
--- a/build-support/bin/_release_helper.py
+++ b/build-support/bin/_release_helper.py
@@ -1239,13 +1239,14 @@ def check_pants_wheels_present(check_dir: str | Path) -> None:
         if not local_files:
             missing_packages.append(package.name)
             continue
-        if is_cross_platform(local_files) and len(local_files) != 6:
-            formatted_local_files = ", ".join(f.name for f in local_files)
+        if is_cross_platform(local_files) and len(local_files) != 7:
+            formatted_local_files = "\n    ".join(sorted(f.name for f in local_files))
             missing_packages.append(
                 softwrap(
                     f"""
-                    {package.name} (expected 6 wheels, {{macosx, linux}} x {{cp37m, cp38, cp39}},
-                    but found {formatted_local_files})
+                    {package.name}. Expected 7 wheels ({{cp37m, cp38, cp39}} x
+                    {{macosx-x86_64, linux-x86_64}} + cp39-macosx),
+                    but found {len(local_files)}:\n    {formatted_local_files}
                     """
                 )
             )


### PR DESCRIPTION
[ci skip-rust]

[ci skip-build-wheels]