### PR TITLE
Improve error messages for invalid addresses

### DIFF
--- a/src/python/pants/build_graph/address_test.py
+++ b/src/python/pants/build_graph/address_test.py
@@ -267,6 +267,31 @@ def test_address_input_from_dir() -> None:
     ).dir_to_address() == Address("a", target_name="b", generated_name="gen")
 
 
+@pytest.mark.parametrize(
+    "addr,expected",
+    [
+        (AddressInput("dir", description_of_origin="tests"), "dir"),
+        (AddressInput("dir", "tgt", description_of_origin="tests"), "dir:tgt"),
+        (AddressInput("", "tgt", description_of_origin="tests"), "//:tgt"),
+        (AddressInput("dir", generated_component="gen", description_of_origin="tests"), "dir#gen"),
+        (
+            AddressInput("dir", "tgt", generated_component="gen", description_of_origin="tests"),
+            "dir#gen:tgt",
+        ),
+        (
+            AddressInput("dir", parameters={"k1": "v", "k2": "v"}, description_of_origin="tests"),
+            "dir@k1=v,k2=v",
+        ),
+        (
+            AddressInput("dir", "tgt", parameters={"k": "v"}, description_of_origin="tests"),
+            "dir:tgt@k=v",
+        ),
+    ],
+)
+def test_address_input_spec(addr: AddressInput, expected: str) -> None:
+    assert addr.spec == expected
+
+
 def test_address_normalize_target_name() -> None:
     assert Address("a/b/c", target_name="c") == Address("a/b/c", target_name=None)
     assert Address("a/b/c", target_name="c", relative_file_path="f.txt") == Address(

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -17,6 +17,7 @@ from pants.engine.internals.target_adaptor import TargetAdaptor
 from pants.engine.rules import Get, collect_rules, rule
 from pants.option.global_options import GlobalOptions
 from pants.util.frozendict import FrozenDict
+from pants.util.strutil import softwrap
 
 
 @dataclass(frozen=True)
@@ -79,8 +80,13 @@ async def resolve_address(address_input: AddressInput) -> Address:
         if address_input.target_component:
             spec += f":{address_input.target_component}"
         raise ResolveError(
-            f"The file or directory '{address_input.path_component}' does not exist on disk in the "
-            f"workspace, so the address '{spec}' cannot be resolved."
+            softwrap(
+                f"""
+                The file or directory '{address_input.path_component}' does not exist on disk in
+                the workspace, so the address '{spec}' from {address_input.description_of_origin}
+                cannot be resolved.
+                """
+            )
         )
 
 


### PR DESCRIPTION
Part of https://github.com/pantsbuild/pants/issues/14468.

File address does not exist:

> ResolveError: The file or directory 'build-support/fake.txt' does not exist on disk in the workspace, so the address 'build-support/fake.txt' from the `files` field from the target //:demo cannot be resolved.

Wildcard used:

> UnsupportedWildcard: The address `dir:` from the `files` field from the target //:demo included a wildcard (`:`), which is not supported.

Absolute path:

> InvalidSpecPath: Invalid address /dir from the `files` field from the target //:demo. Cannot use absolute paths.

Invalid path component:

> InvalidSpecPath: Invalid address `dir/./f.txt` from the `files` field from the target //:demo. It has an un-normalized path part: '/.'.

Invalid parameter:

> InvalidParameters: Invalid address `dir/f.txt@k!=v` from the `files` field from the target //:demo. It has illegal characters in parameter keys: `{'!'}` in `k!=v`.

Missing target name for build root:

> InvalidTargetName: Addresses for generated first-party targets in the build root must include which target generator they come from, such as `pants.toml:original_target`. However, `pants.toml` from the `files` field from the target //:demo did not have a target name.

Generated target, too many `../`:

> Invalid address `build-support/common.sh:../../tgt` from the `files` field from the target //:demo. The target name portion of the address `../../tgt` has too many `../`, which means it refers to a directory above the file path `build-support/common.sh`. Expected no more than 1 instances of `../` in `../../tgt`, but found 2 instances.

Generated target, target is from subdir:

> InvalidTargetName: Invalid address `build-support/common.sh:subdir/tgt` from the `files` field from the target //:demo. The target name portion of the address must refer to a target defined in the same directory or a parent directory of the file path `build-support/common.sh`, but the value `subdir/tgt` is a subdirectory.
 
[ci skip-rust]
[ci skip-build-wheels]