### PR TITLE
[internal] Upgrade the Toolchain Pants Plugin to 0.20.0

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -30,7 +30,7 @@ backend_packages.add = [
 ]
 plugins = [
   "hdrhistogram",  # For use with `--stats-log`.
-  "toolchain.pants.plugin==0.19.0",
+  "toolchain.pants.plugin==0.20.0",
 ]
 
 # The invalidation globs cover the PYTHONPATH by default, but we exclude some files that are on the


### PR DESCRIPTION
Released 0.20.0 to pypi.
https://pypi.org/project/toolchain.pants.plugin/0.20.0/


** NOTE ** this is for the 2.11 branch