### PR TITLE
Clarify wildcard AddressInput error

### DIFF
--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -228,7 +228,7 @@ class AddressInput:
             raise UnsupportedWildcard(
                 softwrap(
                     f"""
-                    The address `{spec}` from {description_of_origin} included a wildcard
+                    The address `{spec}` from {description_of_origin} ended in a wildcard
                     (`{wildcard}`), which is not supported.
                     """
                 )


### PR DESCRIPTION
Clarify the issue isn't having the character `:`. The issue is ending with that character, which makes it a wildcard rather than part of `dir:tgt`.

[ci skip-rust]
[ci skip-build-wheels]