### PR TITLE
`_TargetParametrizations` now requires `_TargetParametrizationsRequest`

### DIFF
--- a/src/python/pants/backend/codegen/avro/target_types_test.py
+++ b/src/python/pants/backend/codegen/avro/target_types_test.py
@@ -9,7 +9,7 @@ from textwrap import dedent
 from pants.backend.codegen.avro import target_types
 from pants.backend.codegen.avro.target_types import AvroSourcesGeneratorTarget, AvroSourceTarget
 from pants.engine.addresses import Address
-from pants.engine.internals.graph import _TargetParametrizations
+from pants.engine.internals.graph import _TargetParametrizations, _TargetParametrizationsRequest
 from pants.engine.target import SingleSourceField, Tags
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -18,7 +18,7 @@ def test_generate_source_targets() -> None:
     rule_runner = RuleRunner(
         rules=[
             *target_types.rules(),
-            QueryRule(_TargetParametrizations, [Address]),
+            QueryRule(_TargetParametrizations, [_TargetParametrizationsRequest]),
         ],
         target_types=[AvroSourcesGeneratorTarget],
     )
@@ -47,7 +47,12 @@ def test_generate_source_targets() -> None:
         )
 
     generated = rule_runner.request(
-        _TargetParametrizations, [Address("src/avro", target_name="lib")]
+        _TargetParametrizations,
+        [
+            _TargetParametrizationsRequest(
+                Address("src/avro", target_name="lib"), description_of_origin="tests"
+            )
+        ],
     ).parametrizations
     assert set(generated.values()) == {
         gen_tgt("f1.avsc", tags=["overridden"]),

--- a/src/python/pants/backend/codegen/protobuf/target_types_test.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types_test.py
@@ -12,7 +12,7 @@ from pants.backend.codegen.protobuf.target_types import (
     ProtobufSourceTarget,
 )
 from pants.engine.addresses import Address
-from pants.engine.internals.graph import _TargetParametrizations
+from pants.engine.internals.graph import _TargetParametrizations, _TargetParametrizationsRequest
 from pants.engine.target import SingleSourceField, Tags
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -21,7 +21,7 @@ def test_generate_source_targets() -> None:
     rule_runner = RuleRunner(
         rules=[
             *target_types.rules(),
-            QueryRule(_TargetParametrizations, [Address]),
+            QueryRule(_TargetParametrizations, [_TargetParametrizationsRequest]),
         ],
         target_types=[ProtobufSourcesGeneratorTarget],
     )
@@ -50,7 +50,12 @@ def test_generate_source_targets() -> None:
         )
 
     generated = rule_runner.request(
-        _TargetParametrizations, [Address("src/proto", target_name="lib")]
+        _TargetParametrizations,
+        [
+            _TargetParametrizationsRequest(
+                Address("src/proto", target_name="lib"), description_of_origin="tests"
+            )
+        ],
     ).parametrizations
     assert set(generated.values()) == {
         gen_tgt("f1.proto", tags=["overridden"]),

--- a/src/python/pants/backend/codegen/soap/target_types_test.py
+++ b/src/python/pants/backend/codegen/soap/target_types_test.py
@@ -9,7 +9,7 @@ from textwrap import dedent
 from pants.backend.codegen.soap import target_types
 from pants.backend.codegen.soap.target_types import WsdlSourcesGeneratorTarget, WsdlSourceTarget
 from pants.engine.addresses import Address
-from pants.engine.internals.graph import _TargetParametrizations
+from pants.engine.internals.graph import _TargetParametrizations, _TargetParametrizationsRequest
 from pants.engine.target import SingleSourceField, Tags
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -18,7 +18,7 @@ def test_generate_source_targets() -> None:
     rule_runner = RuleRunner(
         rules=[
             *target_types.rules(),
-            QueryRule(_TargetParametrizations, [Address]),
+            QueryRule(_TargetParametrizations, [_TargetParametrizationsRequest]),
         ],
         target_types=[WsdlSourcesGeneratorTarget],
     )
@@ -47,7 +47,12 @@ def test_generate_source_targets() -> None:
         )
 
     generated = rule_runner.request(
-        _TargetParametrizations, [Address(source_root, target_name="lib")]
+        _TargetParametrizations,
+        [
+            _TargetParametrizationsRequest(
+                Address(source_root, target_name="lib"), description_of_origin="tests"
+            )
+        ],
     ).parametrizations
     assert set(generated.values()) == {
         gen_tgt("f1.wsdl"),

--- a/src/python/pants/backend/codegen/thrift/target_types_test.py
+++ b/src/python/pants/backend/codegen/thrift/target_types_test.py
@@ -12,7 +12,7 @@ from pants.backend.codegen.thrift.target_types import (
     ThriftSourceTarget,
 )
 from pants.engine.addresses import Address
-from pants.engine.internals.graph import _TargetParametrizations
+from pants.engine.internals.graph import _TargetParametrizations, _TargetParametrizationsRequest
 from pants.engine.target import SingleSourceField, Tags
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -21,7 +21,7 @@ def test_generate_source_targets() -> None:
     rule_runner = RuleRunner(
         rules=[
             *target_types.rules(),
-            QueryRule(_TargetParametrizations, [Address]),
+            QueryRule(_TargetParametrizations, [_TargetParametrizationsRequest]),
         ],
         target_types=[ThriftSourcesGeneratorTarget],
     )
@@ -50,7 +50,12 @@ def test_generate_source_targets() -> None:
         )
 
     generated = rule_runner.request(
-        _TargetParametrizations, [Address("src/thrift", target_name="lib")]
+        _TargetParametrizations,
+        [
+            _TargetParametrizationsRequest(
+                Address("src/thrift", target_name="lib"), description_of_origin="tests"
+            )
+        ],
     ).parametrizations
     assert set(generated.values()) == {
         gen_tgt("f1.thrift", tags=["overridden"]),

--- a/src/python/pants/backend/go/target_type_rules_test.py
+++ b/src/python/pants/backend/go/target_type_rules_test.py
@@ -37,7 +37,7 @@ from pants.core.target_types import (
     TargetGeneratorSourcesHelperTarget,
 )
 from pants.engine.addresses import Addresses
-from pants.engine.internals.graph import _TargetParametrizations
+from pants.engine.internals.graph import _TargetParametrizations, _TargetParametrizationsRequest
 from pants.engine.rules import QueryRule
 from pants.engine.target import (
     Dependencies,
@@ -65,7 +65,7 @@ def rule_runner() -> RuleRunner:
             *build_pkg.rules(),
             *link.rules(),
             *assembly.rules(),
-            QueryRule(_TargetParametrizations, [Address]),
+            QueryRule(_TargetParametrizations, [_TargetParametrizationsRequest]),
             QueryRule(Addresses, [DependenciesRequest]),
             QueryRule(GoBinaryMainPackage, [GoBinaryMainPackageRequest]),
             QueryRule(InjectedDependencies, [InjectGoBinaryMainDependencyRequest]),
@@ -202,7 +202,10 @@ def test_generate_package_targets(rule_runner: RuleRunner) -> None:
             "src/go/another_dir/subdir/f.go": "",
         }
     )
-    generated = rule_runner.request(_TargetParametrizations, [Address("src/go")]).parametrizations
+    generated = rule_runner.request(
+        _TargetParametrizations,
+        [_TargetParametrizationsRequest(Address("src/go"), description_of_origin="tests")],
+    ).parametrizations
 
     file_tgts = [
         TargetGeneratorSourcesHelperTarget(

--- a/src/python/pants/backend/helm/target_types_test.py
+++ b/src/python/pants/backend/helm/target_types_test.py
@@ -18,7 +18,7 @@ from pants.backend.helm.testutil import (
     K8S_SERVICE_FILE,
 )
 from pants.engine.addresses import Address
-from pants.engine.internals.graph import _TargetParametrizations
+from pants.engine.internals.graph import _TargetParametrizations, _TargetParametrizationsRequest
 from pants.engine.target import SingleSourceField, Tags
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -27,7 +27,7 @@ def test_generate_source_targets() -> None:
     rule_runner = RuleRunner(
         rules=[
             *target_types.rules(),
-            QueryRule(_TargetParametrizations, [Address]),
+            QueryRule(_TargetParametrizations, [_TargetParametrizationsRequest]),
         ],
         target_types=[HelmUnitTestTestsGeneratorTarget, HelmChartTarget],
     )
@@ -56,7 +56,13 @@ def test_generate_source_targets() -> None:
         )
 
     generated = rule_runner.request(
-        _TargetParametrizations, [Address(f"{source_root}/tests", target_name="foo_tests")]
+        _TargetParametrizations,
+        [
+            _TargetParametrizationsRequest(
+                Address(f"{source_root}/tests", target_name="foo_tests"),
+                description_of_origin="tests",
+            )
+        ],
     ).parametrizations
     assert set(generated.values()) == {
         gen_tgt("service_test.yaml"),

--- a/src/python/pants/backend/plugin_development/pants_requirements_test.py
+++ b/src/python/pants/backend/plugin_development/pants_requirements_test.py
@@ -16,7 +16,7 @@ from pants.backend.python.target_types import (
     PythonRequirementsField,
 )
 from pants.engine.addresses import Address
-from pants.engine.internals.graph import _TargetParametrizations
+from pants.engine.internals.graph import _TargetParametrizations, _TargetParametrizationsRequest
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
@@ -37,7 +37,7 @@ def test_target_generator() -> None:
     rule_runner = RuleRunner(
         rules=(
             *pants_requirements.rules(),
-            QueryRule(_TargetParametrizations, [Address]),
+            QueryRule(_TargetParametrizations, [_TargetParametrizationsRequest]),
         ),
         target_types=[PantsRequirementsTargetGenerator],
     )
@@ -54,7 +54,12 @@ def test_target_generator() -> None:
     )
 
     result = rule_runner.request(
-        _TargetParametrizations, [Address("", target_name="default")]
+        _TargetParametrizations,
+        [
+            _TargetParametrizationsRequest(
+                Address("", target_name="default"), description_of_origin="tests"
+            )
+        ],
     ).parametrizations
     assert len(result) == 2
     pants_req = next(t for t in result.values() if t.address.generated_name == "pantsbuild.pants")
@@ -73,7 +78,12 @@ def test_target_generator() -> None:
         assert not t[PythonRequirementResolveField].value
 
     result = rule_runner.request(
-        _TargetParametrizations, [Address("", target_name="no_testutil")]
+        _TargetParametrizations,
+        [
+            _TargetParametrizationsRequest(
+                Address("", target_name="no_testutil"), description_of_origin="tests"
+            )
+        ],
     ).parametrizations
     assert len(result) == 1
     assert next(iter(result.keys())).generated_name == "pantsbuild.pants"

--- a/src/python/pants/backend/python/macros/pipenv_requirements_test.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements_test.py
@@ -12,7 +12,7 @@ from pants.backend.python.macros.pipenv_requirements import PipenvRequirementsTa
 from pants.backend.python.target_types import PythonRequirementTarget
 from pants.core.target_types import TargetGeneratorSourcesHelperTarget
 from pants.engine.addresses import Address
-from pants.engine.internals.graph import _TargetParametrizations
+from pants.engine.internals.graph import _TargetParametrizations, _TargetParametrizationsRequest
 from pants.engine.target import Target
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -22,7 +22,7 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=(
             *pipenv_requirements.rules(),
-            QueryRule(_TargetParametrizations, [Address]),
+            QueryRule(_TargetParametrizations, [_TargetParametrizationsRequest]),
         ),
         target_types=[PipenvRequirementsTargetGenerator],
     )
@@ -36,7 +36,14 @@ def assert_pipenv_requirements(
     expected_targets: set[Target],
 ) -> None:
     rule_runner.write_files({"BUILD": build_file_entry, "Pipfile.lock": dumps(pipfile_lock)})
-    result = rule_runner.request(_TargetParametrizations, [Address("", target_name="reqs")])
+    result = rule_runner.request(
+        _TargetParametrizations,
+        [
+            _TargetParametrizationsRequest(
+                Address("", target_name="reqs"), description_of_origin="tests"
+            )
+        ],
+    )
     assert set(result.parametrizations.values()) == expected_targets
 
 

--- a/src/python/pants/backend/python/macros/poetry_requirements_test.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements_test.py
@@ -26,7 +26,7 @@ from pants.backend.python.pip_requirement import PipRequirement
 from pants.backend.python.target_types import PythonRequirementTarget
 from pants.core.target_types import TargetGeneratorSourcesHelperTarget
 from pants.engine.addresses import Address
-from pants.engine.internals.graph import _TargetParametrizations
+from pants.engine.internals.graph import _TargetParametrizations, _TargetParametrizationsRequest
 from pants.engine.target import Target
 from pants.testutil.rule_runner import QueryRule, RuleRunner, engine_error
 from pants.util.strutil import softwrap
@@ -439,7 +439,7 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *poetry_requirements.rules(),
-            QueryRule(_TargetParametrizations, [Address]),
+            QueryRule(_TargetParametrizations, [_TargetParametrizationsRequest]),
         ],
         target_types=[PoetryRequirementsTargetGenerator],
     )
@@ -454,7 +454,14 @@ def assert_poetry_requirements(
     pyproject_toml_relpath: str = "pyproject.toml",
 ) -> None:
     rule_runner.write_files({"BUILD": build_file_entry, pyproject_toml_relpath: pyproject_toml})
-    result = rule_runner.request(_TargetParametrizations, [Address("", target_name="reqs")])
+    result = rule_runner.request(
+        _TargetParametrizations,
+        [
+            _TargetParametrizationsRequest(
+                Address("", target_name="reqs"), description_of_origin="tests"
+            )
+        ],
+    )
     assert set(result.parametrizations.values()) == expected_targets
 
 

--- a/src/python/pants/backend/python/macros/python_requirements_test.py
+++ b/src/python/pants/backend/python/macros/python_requirements_test.py
@@ -12,7 +12,7 @@ from pants.backend.python.macros.python_requirements import PythonRequirementsTa
 from pants.backend.python.target_types import PythonRequirementTarget
 from pants.core.target_types import TargetGeneratorSourcesHelperTarget
 from pants.engine.addresses import Address
-from pants.engine.internals.graph import _TargetParametrizations
+from pants.engine.internals.graph import _TargetParametrizations, _TargetParametrizationsRequest
 from pants.engine.target import Target
 from pants.testutil.rule_runner import QueryRule, RuleRunner, engine_error
 
@@ -22,7 +22,7 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *python_requirements.rules(),
-            QueryRule(_TargetParametrizations, [Address]),
+            QueryRule(_TargetParametrizations, [_TargetParametrizationsRequest]),
         ],
         target_types=[PythonRequirementsTargetGenerator],
     )
@@ -37,7 +37,14 @@ def assert_python_requirements(
     requirements_txt_relpath: str = "requirements.txt",
 ) -> None:
     rule_runner.write_files({"BUILD": build_file_entry, requirements_txt_relpath: requirements_txt})
-    result = rule_runner.request(_TargetParametrizations, [Address("", target_name="reqs")])
+    result = rule_runner.request(
+        _TargetParametrizations,
+        [
+            _TargetParametrizationsRequest(
+                Address("", target_name="reqs"), description_of_origin="tests"
+            )
+        ],
+    )
     assert set(result.parametrizations.values()) == expected_targets
 
 

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -28,6 +28,9 @@ from pants.engine.internals.parametrize import Parametrize, _TargetParametrizati
 from pants.engine.internals.parametrize import (  # noqa: F401
     _TargetParametrizations as _TargetParametrizations,
 )
+from pants.engine.internals.parametrize import (  # noqa: F401
+    _TargetParametrizationsRequest as _TargetParametrizationsRequest,
+)
 from pants.engine.internals.target_adaptor import TargetAdaptor
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
@@ -145,13 +148,13 @@ def warn_deprecated_field_type(field_type: type[Field]) -> None:
 
 @rule
 async def resolve_target_parametrizations(
-    address: Address,
+    request: _TargetParametrizationsRequest,
     registered_target_types: RegisteredTargetTypes,
     union_membership: UnionMembership,
     target_types_to_generate_requests: TargetTypesToGenerateTargetsRequests,
     unmatched_build_file_globs: UnmatchedBuildFileGlobs,
 ) -> _TargetParametrizations:
-    assert not address.is_generated_target and not address.is_parametrized
+    address = request.address
 
     target_adaptor = await Get(TargetAdaptor, Address, address)
     target_type = registered_target_types.aliases_to_types.get(target_adaptor.type_alias, None)
@@ -301,7 +304,10 @@ async def resolve_target(
     target_types_to_generate_requests: TargetTypesToGenerateTargetsRequests,
 ) -> WrappedTarget:
     base_address = address.maybe_convert_to_target_generator()
-    parametrizations = await Get(_TargetParametrizations, Address, base_address)
+    parametrizations = await Get(
+        _TargetParametrizations,
+        _TargetParametrizationsRequest(base_address, description_of_origin="TODO(#14468)"),
+    )
     if address.is_generated_target:
         # TODO: This is an accommodation to allow using file/generator Addresses for
         # non-generator atom targets. See https://github.com/pantsbuild/pants/issues/14419.
@@ -339,8 +345,10 @@ async def resolve_targets(
             parametrizations_gets.append(
                 Get(
                     _TargetParametrizations,
-                    Address,
-                    tgt.address.maybe_convert_to_target_generator(),
+                    _TargetParametrizationsRequest(
+                        tgt.address.maybe_convert_to_target_generator(),
+                        description_of_origin="TODO(#14468)",
+                    ),
                 )
             )
         else:
@@ -1051,7 +1059,13 @@ async def resolve_dependencies(
     generated_addresses: tuple[Address, ...] = ()
     if target_types_to_generate_requests.is_generator(tgt) and not tgt.address.is_generated_target:
         parametrizations = await Get(
-            _TargetParametrizations, Address, tgt.address.maybe_convert_to_target_generator()
+            _TargetParametrizations,
+            _TargetParametrizationsRequest(
+                tgt.address.maybe_convert_to_target_generator(),
+                description_of_origin=(
+                    f"the target generator {tgt.address.maybe_convert_to_target_generator()}"
+                ),
+            ),
         )
         generated_addresses = tuple(parametrizations.generated_for(tgt.address).keys())
 
@@ -1060,7 +1074,15 @@ async def resolve_dependencies(
     explicitly_provided_includes: Iterable[Address] = explicitly_provided.includes
     if request.field.address.is_parametrized and explicitly_provided_includes:
         explicit_dependency_parametrizations = await MultiGet(
-            Get(_TargetParametrizations, Address, address.maybe_convert_to_target_generator())
+            Get(
+                _TargetParametrizations,
+                _TargetParametrizationsRequest(
+                    address.maybe_convert_to_target_generator(),
+                    description_of_origin=(
+                        f"the `{request.field.alias}` field of the target {tgt.address}"
+                    ),
+                ),
+            )
             for address in explicitly_provided_includes
         )
 

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -25,7 +25,7 @@ from pants.engine.internals.graph import (
     _DependencyMappingRequest,
     _TargetParametrizations,
 )
-from pants.engine.internals.parametrize import Parametrize
+from pants.engine.internals.parametrize import Parametrize, _TargetParametrizationsRequest
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.rules import Get, MultiGet, rule
 from pants.engine.target import (
@@ -818,7 +818,7 @@ def generated_targets_rule_runner() -> RuleRunner:
         rules=[
             QueryRule(Addresses, [Specs]),
             QueryRule(_DependencyMapping, [_DependencyMappingRequest]),
-            QueryRule(_TargetParametrizations, [Address]),
+            QueryRule(_TargetParametrizations, [_TargetParametrizationsRequest]),
         ],
         target_types=[MockTargetGenerator, MockGeneratedTarget],
         objects={"parametrize": Parametrize},
@@ -840,7 +840,10 @@ def assert_generated(
             **{os.path.join(address.spec_path, f): "" for f in files},
         }
     )
-    parametrizations = rule_runner.request(_TargetParametrizations, [address])
+    parametrizations = rule_runner.request(
+        _TargetParametrizations,
+        [_TargetParametrizationsRequest(address, description_of_origin="tests")],
+    )
     assert expected == {
         t for parametrization in parametrizations for t in parametrization.parametrization.values()
     }


### PR DESCRIPTION
Prework for https://github.com/pantsbuild/pants/issues/14468.

This unblocks us from updating the rule for `Address -> TargetAdaptor` to now have a `description_of_origin`, which will allow us to have a better error message when the `Address` does not actually exist.

We must still update our rules for `Address -> WrappedTarget` and `Addresses -> UnexpandedTargets` to also now take the `description_of_origin`.

--

Unlike https://github.com/pantsbuild/pants/pull/15731, we set `description_of_origin` as `hash=False` and `compare=False`. This avoids unnecessary graph invalidation. 

--

This also deletes some backend-specific tests for generating file targets. There was no need, as that is now generalized in `graph.py`.