### PR TITLE
`BuildFileAddress` now requires `BuildFileAddressRequest`

### DIFF
--- a/src/python/pants/backend/project_info/filedeps.py
+++ b/src/python/pants/backend/project_info/filedeps.py
@@ -6,7 +6,8 @@ from pathlib import PurePath
 from typing import Iterable
 
 from pants.base.build_root import BuildRoot
-from pants.engine.addresses import Address, Addresses, BuildFileAddress
+from pants.build_graph.address import BuildFileAddressRequest
+from pants.engine.addresses import Addresses, BuildFileAddress
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
@@ -81,7 +82,11 @@ async def file_deps(
         targets = await Get(UnexpandedTargets, Addresses, addresses)
 
     build_file_addresses = await MultiGet(
-        Get(BuildFileAddress, Address, tgt.address) for tgt in targets
+        Get(
+            BuildFileAddress,
+            BuildFileAddressRequest(tgt.address, description_of_origin="CLI arguments"),
+        )
+        for tgt in targets
     )
     unique_rel_paths = {bfa.rel_path for bfa in build_file_addresses}
 

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import os
 from dataclasses import dataclass
 from pathlib import PurePath
@@ -609,12 +610,16 @@ class Address(EngineAwareParameter):
 
 
 @dataclass(frozen=True)
-class BuildFileAddress:
-    """Represents the address of a type materialized from a BUILD file.
-
-    TODO: This type should likely be removed in favor of storing this information on Target.
-    """
+class BuildFileAddressRequest:
+    """A request to find the BUILD file path for an address."""
 
     address: Address
-    # The relative path of the BUILD file this Address came from.
+    description_of_origin: str = dataclasses.field(hash=False, compare=False)
+
+
+@dataclass(frozen=True)
+class BuildFileAddress:
+    """An address, along with the relative file path of its BUILD file."""
+
+    address: Address
     rel_path: str

--- a/src/python/pants/engine/addresses.py
+++ b/src/python/pants/engine/addresses.py
@@ -10,6 +10,9 @@ from pants.base.exceptions import ResolveError
 from pants.build_graph.address import Address as Address
 from pants.build_graph.address import AddressInput as AddressInput  # noqa: F401: rexport.
 from pants.build_graph.address import BuildFileAddress as BuildFileAddress  # noqa: F401: rexport.
+from pants.build_graph.address import (  # noqa: F401: rexport.
+    BuildFileAddressRequest as BuildFileAddressRequest,
+)
 from pants.engine.collection import Collection
 from pants.util.meta import frozen_after_init
 from pants.util.strutil import bullet_list

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from pants.base.exceptions import ResolveError
+from pants.build_graph.address import BuildFileAddressRequest
 from pants.engine.addresses import Address, AddressInput, BuildFileAddress
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import DigestContents, GlobMatchErrorBehavior, PathGlobs, Paths
@@ -134,7 +135,8 @@ async def parse_address_family(
 
 
 @rule
-async def find_build_file(address: Address) -> BuildFileAddress:
+async def find_build_file(request: BuildFileAddressRequest) -> BuildFileAddress:
+    address = request.address
     address_family = await Get(AddressFamily, AddressFamilyDir(address.spec_path))
     owning_address = address.maybe_convert_to_target_generator()
     if address_family.get_target_adaptor(owning_address) is None:

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -9,6 +9,7 @@ from typing import cast
 
 import pytest
 
+from pants.build_graph.address import BuildFileAddressRequest
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.addresses import Address, AddressInput, BuildFileAddress
 from pants.engine.fs import DigestContents, FileContent, PathGlobs
@@ -204,13 +205,15 @@ def test_target_adaptor_not_found(target_adaptor_rule_runner: RuleRunner) -> Non
 
 def test_build_file_address() -> None:
     rule_runner = RuleRunner(
-        rules=[QueryRule(BuildFileAddress, (Address,))], target_types=[MockTgt]
+        rules=[QueryRule(BuildFileAddress, [BuildFileAddressRequest])], target_types=[MockTgt]
     )
     rule_runner.write_files({"helloworld/BUILD.ext": "mock_tgt()"})
 
     def assert_bfa_resolved(address: Address) -> None:
         expected_bfa = BuildFileAddress(address, "helloworld/BUILD.ext")
-        bfa = rule_runner.request(BuildFileAddress, [address])
+        bfa = rule_runner.request(
+            BuildFileAddress, [BuildFileAddressRequest(address, description_of_origin="tests")]
+        )
         assert bfa == expected_bfa
 
     assert_bfa_resolved(Address("helloworld"))

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -14,6 +14,7 @@ from typing import Iterable, NamedTuple, Sequence, cast
 from pants.base.deprecated import resolve_conflicting_options, warn_or_error
 from pants.base.exceptions import ResolveError
 from pants.base.specs import AncestorGlobSpec, RawSpecsWithoutFileOwners, RecursiveGlobSpec
+from pants.build_graph.address import BuildFileAddressRequest
 from pants.engine.addresses import (
     Address,
     Addresses,
@@ -735,7 +736,13 @@ async def find_owners(owners_request: OwnersRequest) -> Owners:
             sources_set = deleted_files
 
         build_file_addresses = await MultiGet(
-            Get(BuildFileAddress, Address, tgt.address) for tgt in candidate_tgts
+            Get(
+                BuildFileAddress,
+                BuildFileAddressRequest(
+                    tgt.address, description_of_origin="<owners rule - cannot trigger>"
+                ),
+            )
+            for tgt in candidate_tgts
         )
 
         for candidate_tgt, bfa in zip(candidate_tgts, build_file_addresses):


### PR DESCRIPTION
See https://github.com/pantsbuild/pants/pull/15759 for the motivation as prework for https://github.com/pantsbuild/pants/issues/14468.

[ci skip-rust]
[ci skip-build-wheels]