### PR TITLE
Differentiate and propagate missing digest errors

### DIFF
--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -42,7 +42,7 @@ use log::{debug, error, warn};
 use parking_lot::Mutex;
 use protos::gen::build::bazel::remote::execution::v2 as remexec;
 use protos::require_digest;
-use store::Store;
+use store::{Store, StoreError};
 use tokio::signal::unix::{signal, SignalKind};
 use tokio::task;
 use tokio_stream::wrappers::SignalStream;
@@ -196,7 +196,7 @@ impl BuildResultFS {
           .runtime
           .block_on(async move { store.load_file_bytes_with(digest, |_| ()).await })
         {
-          Ok(Some(())) => {
+          Ok(()) => {
             let executable_inode = self.next_inode;
             self.next_inode += 1;
             let non_executable_inode = self.next_inode;
@@ -224,7 +224,7 @@ impl BuildResultFS {
               non_executable_inode
             }))
           }
-          Ok(None) => Ok(None),
+          Err(StoreError::MissingDigest { .. }) => Ok(None),
           Err(err) => Err(err.to_string()),
         }
       }
@@ -240,7 +240,7 @@ impl BuildResultFS {
           .runtime
           .block_on(async move { store.load_directory(digest).await })
         {
-          Ok(Some(_)) => {
+          Ok(_) => {
             // TODO: Kick off some background futures to pre-load the contents of this Directory into
             // an in-memory cache. Keep a background CPU pool driving those Futures.
             let inode = self.next_inode;
@@ -256,7 +256,7 @@ impl BuildResultFS {
             );
             Ok(Some(inode))
           }
-          Ok(None) => Ok(None),
+          Err(StoreError::MissingDigest { .. }) => Ok(None),
           Err(err) => Err(err.to_string()),
         }
       }
@@ -335,7 +335,7 @@ impl BuildResultFS {
             .block_on(async move { store.load_directory(digest).await });
 
           match maybe_directory {
-            Ok(Some(directory)) => {
+            Ok(directory) => {
               let mut entries = vec![
                 ReaddirEntry {
                   inode: inode,
@@ -396,7 +396,7 @@ impl BuildResultFS {
 
               Ok(entries)
             }
-            Ok(None) => Err(libc::ENOENT),
+            Err(StoreError::MissingDigest { .. }) => Err(libc::ENOENT),
             Err(err) => {
               error!("Error loading directory {:?}: {}", digest, err);
               Err(libc::EINVAL)
@@ -477,14 +477,18 @@ impl fuser::Filesystem for BuildResultFS {
             .and_then(|cache_entry| {
               let store = self.store.clone();
               let parent_digest = cache_entry.digest;
-              self
+              let directory = self
                 .runtime
                 .block_on(async move { store.load_directory(parent_digest).await })
-                .map_err(|err| {
-                  error!("Error reading directory {:?}: {}", parent_digest, err);
-                  libc::EINVAL
-                })?
-                .and_then(|directory| self.node_for_digest(&directory, filename))
+                .map_err(|err| match err {
+                  StoreError::MissingDigest { .. } => libc::ENOENT,
+                  err => {
+                    error!("Error reading directory {:?}: {}", parent_digest, err);
+                    libc::EINVAL
+                  }
+                })?;
+              self
+                .node_for_digest(&directory, filename)
                 .ok_or(libc::ENOENT)
             })
             .and_then(|node| match node {
@@ -583,19 +587,20 @@ impl fuser::Filesystem for BuildResultFS {
                 })
                 .await
             })
-            .map(|v| {
-              if v.is_none() {
-                let maybe_reply = reply2.lock().take();
-                if let Some(reply) = maybe_reply {
-                  reply.error(libc::ENOENT);
-                }
-              }
-            })
             .or_else(|err| {
-              error!("Error loading bytes for {:?}: {}", digest, err);
               let maybe_reply = reply2.lock().take();
-              if let Some(reply) = maybe_reply {
-                reply.error(libc::EINVAL);
+              match err {
+                StoreError::MissingDigest { .. } => {
+                  if let Some(reply) = maybe_reply {
+                    reply.error(libc::ENOENT);
+                  }
+                }
+                err => {
+                  error!("Error loading bytes for {:?}: {}", digest, err);
+                  if let Some(reply) = maybe_reply {
+                    reply.error(libc::EINVAL);
+                  }
+                }
               }
               Ok(())
             });

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -225,7 +225,7 @@ impl BuildResultFS {
             }))
           }
           Ok(None) => Ok(None),
-          Err(err) => Err(err),
+          Err(err) => Err(err.to_string()),
         }
       }
     }
@@ -257,7 +257,7 @@ impl BuildResultFS {
             Ok(Some(inode))
           }
           Ok(None) => Ok(None),
-          Err(err) => Err(err),
+          Err(err) => Err(err.to_string()),
         }
       }
     }

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -466,15 +466,11 @@ async fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
             .parse::<usize>()
             .expect("size_bytes must be a non-negative number");
           let digest = Digest::new(fingerprint, size_bytes);
-          let write_result = store
-            .load_file_bytes_with(digest, |bytes| io::stdout().write_all(bytes).unwrap())
-            .await?;
-          write_result.ok_or_else(|| {
-            ExitError(
-              format!("File with digest {:?} not found", digest),
-              ExitCode::NotFound,
-            )
-          })
+          Ok(
+            store
+              .load_file_bytes_with(digest, |bytes| io::stdout().write_all(bytes).unwrap())
+              .await?,
+          )
         }
         ("save", args) => {
           let path = PathBuf::from(args.value_of("path").unwrap());
@@ -630,53 +626,36 @@ async fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
             .await?;
         }
 
-        let proto_bytes: Option<Vec<u8>> = match args.value_of("output-format").unwrap() {
-          "binary" => {
-            let maybe_directory = store.load_directory(digest.as_digest()).await?;
-            maybe_directory.map(|d| d.to_bytes().to_vec())
-          }
-          "text" => {
-            let maybe_p = store.load_directory(digest.as_digest()).await?;
-            maybe_p.map(|p| format!("{:?}\n", p).as_bytes().to_vec())
-          }
-          "recursive-file-list" => {
-            let maybe_v = expand_files(store, digest.as_digest()).await?;
-            maybe_v
-              .map(|v| {
-                v.into_iter()
-                  .map(|(name, _digest)| format!("{}\n", name))
-                  .collect::<Vec<String>>()
-                  .join("")
-              })
-              .map(String::into_bytes)
-          }
-          "recursive-file-list-with-digests" => {
-            let maybe_v = expand_files(store, digest.as_digest()).await?;
-            maybe_v
-              .map(|v| {
-                v.into_iter()
-                  .map(|(name, digest)| {
-                    format!("{} {:<16} {}\n", digest.hash, digest.size_bytes, name)
-                  })
-                  .collect::<Vec<String>>()
-                  .join("")
-              })
-              .map(String::into_bytes)
-          }
+        let proto_bytes: Vec<u8> = match args.value_of("output-format").unwrap() {
+          "binary" => store
+            .load_directory(digest.as_digest())
+            .await?
+            .to_bytes()
+            .to_vec(),
+          "text" => format!("{:?}\n", store.load_directory(digest.as_digest()).await?)
+            .as_bytes()
+            .to_vec(),
+          "recursive-file-list" => expand_files(store, digest.as_digest())
+            .await?
+            .into_iter()
+            .map(|(name, _digest)| format!("{}\n", name))
+            .collect::<Vec<String>>()
+            .join("")
+            .into_bytes(),
+          "recursive-file-list-with-digests" => expand_files(store, digest.as_digest())
+            .await?
+            .into_iter()
+            .map(|(name, digest)| format!("{} {:<16} {}\n", digest.hash, digest.size_bytes, name))
+            .collect::<Vec<String>>()
+            .join("")
+            .into_bytes(),
           format => {
             return Err(format!("Unexpected value of --output-format arg: {}", format).into())
           }
         };
-        match proto_bytes {
-          Some(bytes) => {
-            io::stdout().write_all(&bytes).unwrap();
-            Ok(())
-          }
-          None => Err(ExitError(
-            format!("Directory with digest {:?} not found", digest),
-            ExitCode::NotFound,
-          )),
-        }
+
+        io::stdout().write_all(&proto_bytes).unwrap();
+        Ok(())
       }
       (_, _) => unimplemented!(),
     },
@@ -688,26 +667,17 @@ async fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
         .parse::<usize>()
         .expect("size_bytes must be a non-negative number");
       let digest = Digest::new(fingerprint, size_bytes);
-      let v = match store
+      let bytes = match store
         .load_file_bytes_with(digest, Bytes::copy_from_slice)
-        .await?
+        .await
       {
-        None => {
-          let maybe_dir = store.load_directory(digest).await?;
-          maybe_dir.map(|dir| dir.to_bytes())
-        }
-        Some(bytes) => Some(bytes),
+        Err(StoreError::MissingDigest { .. }) => store.load_directory(digest).await?.to_bytes(),
+        Err(e) => return Err(e.into()),
+        Ok(bytes) => bytes,
       };
-      match v {
-        Some(bytes) => {
-          io::stdout().write_all(&bytes).unwrap();
-          Ok(())
-        }
-        None => Err(ExitError(
-          format!("Digest {:?} not found", digest),
-          ExitCode::NotFound,
-        )),
-      }
+
+      io::stdout().write_all(&bytes).unwrap();
+      Ok(())
     }
     ("directories", sub_match) => match expect_subcommand(sub_match) {
       ("list", _) => {
@@ -739,17 +709,13 @@ fn expect_subcommand(matches: &clap::ArgMatches) -> (&str, &clap::ArgMatches) {
     .unwrap_or_else(|| panic!("Expected subcommand. See `--help`."))
 }
 
-async fn expand_files(
-  store: Store,
-  digest: Digest,
-) -> Result<Option<Vec<(String, Digest)>>, StoreError> {
+async fn expand_files(store: Store, digest: Digest) -> Result<Vec<(String, Digest)>, StoreError> {
   let files = Arc::new(Mutex::new(Vec::new()));
-  let vec_opt = expand_files_helper(store, digest, String::new(), files.clone()).await?;
-  Ok(vec_opt.map(|_| {
-    let mut v = Arc::try_unwrap(files).unwrap().into_inner();
-    v.sort_by(|(l, _), (r, _)| l.cmp(r));
-    v
-  }))
+  expand_files_helper(store, digest, String::new(), files.clone()).await?;
+
+  let mut v = Arc::try_unwrap(files).unwrap().into_inner();
+  v.sort_by(|(l, _), (r, _)| l.cmp(r));
+  Ok(v)
 }
 
 fn expand_files_helper(
@@ -757,44 +723,39 @@ fn expand_files_helper(
   digest: Digest,
   prefix: String,
   files: Arc<Mutex<Vec<(String, Digest)>>>,
-) -> BoxFuture<'static, Result<Option<()>, StoreError>> {
+) -> BoxFuture<'static, Result<(), StoreError>> {
   async move {
-    let maybe_dir = store.load_directory(digest).await?;
-    match maybe_dir {
-      Some(dir) => {
-        {
-          let mut files_unlocked = files.lock();
-          for file in &dir.files {
-            let file_digest = require_digest(file.digest.as_ref())?;
-            files_unlocked.push((format!("{}{}", prefix, file.name), file_digest));
-          }
-        }
-        let subdirs_and_digests = dir
-          .directories
-          .iter()
-          .map(move |subdir| {
-            let digest = require_digest(subdir.digest.as_ref());
-            digest.map(|digest| (subdir, digest))
-          })
-          .collect::<Result<Vec<_>, _>>()?;
-        future::try_join_all(
-          subdirs_and_digests
-            .into_iter()
-            .map(move |(subdir, digest)| {
-              expand_files_helper(
-                store.clone(),
-                digest,
-                format!("{}{}/", prefix, subdir.name),
-                files.clone(),
-              )
-            })
-            .collect::<Vec<_>>(),
-        )
-        .await
-        .map(|_| Some(()))
+    let dir = store.load_directory(digest).await?;
+    {
+      let mut files_unlocked = files.lock();
+      for file in &dir.files {
+        let file_digest = require_digest(file.digest.as_ref())?;
+        files_unlocked.push((format!("{}{}", prefix, file.name), file_digest));
       }
-      None => Ok(None),
     }
+    let subdirs_and_digests = dir
+      .directories
+      .iter()
+      .map(move |subdir| {
+        let digest = require_digest(subdir.digest.as_ref());
+        digest.map(|digest| (subdir, digest))
+      })
+      .collect::<Result<Vec<_>, _>>()?;
+    future::try_join_all(
+      subdirs_and_digests
+        .into_iter()
+        .map(move |(subdir, digest)| {
+          expand_files_helper(
+            store.clone(),
+            digest,
+            format!("{}{}/", prefix, subdir.name),
+            files.clone(),
+          )
+        })
+        .collect::<Vec<_>>(),
+    )
+    .await
+    .map(|_| ())
   }
   .boxed()
 }

--- a/src/rust/engine/fs/store/src/snapshot_ops.rs
+++ b/src/rust/engine/fs/store/src/snapshot_ops.rs
@@ -99,8 +99,7 @@ async fn render_merge_error<T: SnapshotOps + 'static>(
           String::from_utf8_lossy(bytes.to_vec().as_slice()).to_string()
         })
         .await
-        .map_err(|e| e.to_string())?
-        .unwrap_or_else(|| "<could not load contents>".to_string());
+        .unwrap_or_else(|_| "<could not load contents>".to_string());
       let detail = format!("{}{}", header, contents);
       let res: Result<_, String> = Ok((file.name().to_owned(), detail));
       res
@@ -170,7 +169,7 @@ pub trait SnapshotOps: Clone + Send + Sync + 'static {
     &self,
     digest: Digest,
     f: F,
-  ) -> Result<Option<T>, Self::Error>;
+  ) -> Result<T, Self::Error>;
 
   async fn load_digest_trie(&self, digest: DirectoryDigest) -> Result<DigestTrie, Self::Error>;
 

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -158,7 +158,6 @@ async fn recover_from_missing_store_contents() {
     let output_dir = store
       .load_directory(output_dir_digest.as_digest())
       .await
-      .unwrap()
       .unwrap();
     let output_child_digest = output_dir
       .files

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -12,12 +12,12 @@ use workunit_store::{RunningWorkunit, WorkunitStore};
 
 use crate::{
   CommandRunner as CommandRunnerTrait, Context, FallibleProcessResultWithPlatform, ImmutableInputs,
-  NamedCaches, Process, ProcessMetadata,
+  NamedCaches, Process, ProcessError, ProcessMetadata,
 };
 
 struct RoundtripResults {
-  uncached: Result<FallibleProcessResultWithPlatform, String>,
-  maybe_cached: Result<FallibleProcessResultWithPlatform, String>,
+  uncached: Result<FallibleProcessResultWithPlatform, ProcessError>,
+  maybe_cached: Result<FallibleProcessResultWithPlatform, ProcessError>,
 }
 
 fn create_local_runner() -> (Box<dyn CommandRunnerTrait>, Store, TempDir) {

--- a/src/rust/engine/process_execution/src/immutable_inputs.rs
+++ b/src/rust/engine/process_execution/src/immutable_inputs.rs
@@ -6,7 +6,7 @@ use async_oncecell::OnceCell;
 use fs::{DirectoryDigest, Permissions, RelativePath};
 use hashing::Digest;
 use parking_lot::Mutex;
-use store::Store;
+use store::{Store, StoreError};
 use tempfile::TempDir;
 
 use crate::WorkdirSymlink;
@@ -40,7 +40,7 @@ impl ImmutableInputs {
   }
 
   /// Returns an absolute Path to immutably consume the given Digest from.
-  async fn path(&self, directory_digest: DirectoryDigest) -> Result<PathBuf, String> {
+  async fn path(&self, directory_digest: DirectoryDigest) -> Result<PathBuf, StoreError> {
     let digest = directory_digest.as_digest();
     let cell = self.contents.lock().entry(digest).or_default().clone();
 
@@ -105,7 +105,7 @@ impl ImmutableInputs {
   pub(crate) async fn local_paths(
     &self,
     immutable_inputs: &BTreeMap<RelativePath, DirectoryDigest>,
-  ) -> Result<Vec<WorkdirSymlink>, String> {
+  ) -> Result<Vec<WorkdirSymlink>, StoreError> {
     let dsts = futures::future::try_join_all(
       immutable_inputs
         .values()

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -29,6 +29,7 @@ extern crate derivative;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::{TryFrom, TryInto};
+use std::fmt::{self, Display};
 use std::path::PathBuf;
 
 use async_trait::async_trait;
@@ -42,7 +43,7 @@ use itertools::Itertools;
 use protos::gen::build::bazel::remote::execution::v2 as remexec;
 use remexec::ExecutedActionMetadata;
 use serde::{Deserialize, Serialize};
-use store::{SnapshotOps, Store};
+use store::{SnapshotOps, Store, StoreError};
 use workunit_store::{RunId, RunningWorkunit, WorkunitStore};
 
 pub mod bounded;
@@ -79,6 +80,49 @@ pub use crate::children::ManagedChild;
 pub use crate::immutable_inputs::ImmutableInputs;
 pub use crate::named_caches::{CacheName, NamedCaches};
 pub use crate::remote_cache::RemoteCacheWarningsBehavior;
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ProcessError {
+  // A Digest was not present in either of the local or remote Stores.
+  MissingDigest(String, Digest),
+  // All other error types.
+  Unclassified(String),
+}
+
+impl ProcessError {
+  pub fn enrich(self, prefix: &str) -> Self {
+    match self {
+      Self::MissingDigest(s, d) => Self::MissingDigest(format!("{prefix}: {s}"), d),
+      Self::Unclassified(s) => Self::Unclassified(format!("{prefix}: {s}")),
+    }
+  }
+}
+
+impl Display for ProcessError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      Self::MissingDigest(s, d) => {
+        write!(f, "{s}: {d:?}")
+      }
+      Self::Unclassified(s) => write!(f, "{s}"),
+    }
+  }
+}
+
+impl From<StoreError> for ProcessError {
+  fn from(err: StoreError) -> Self {
+    match err {
+      StoreError::MissingDigest(s, d) => Self::MissingDigest(s, d),
+      StoreError::Unclassified(s) => Self::Unclassified(s),
+    }
+  }
+}
+
+impl From<String> for ProcessError {
+  fn from(err: String) -> Self {
+    Self::Unclassified(err)
+  }
+}
 
 #[derive(
   PartialOrd, Ord, Clone, Copy, Debug, DeepSizeOf, Eq, PartialEq, Hash, Serialize, Deserialize,
@@ -254,7 +298,7 @@ impl InputDigests {
     input_files: DirectoryDigest,
     immutable_inputs: BTreeMap<RelativePath, DirectoryDigest>,
     use_nailgun: Vec<RelativePath>,
-  ) -> Result<Self, String> {
+  ) -> Result<Self, StoreError> {
     // Collect all digests into `complete`.
     let mut complete_digests = try_join_all(
       immutable_inputs
@@ -288,17 +332,20 @@ impl InputDigests {
     })
   }
 
-  pub async fn new_from_merged(store: &Store, from: Vec<InputDigests>) -> Result<Self, String> {
+  pub async fn new_from_merged(store: &Store, from: Vec<InputDigests>) -> Result<Self, StoreError> {
     let mut merged_immutable_inputs = BTreeMap::new();
     for input_digests in from.iter() {
       let size_before = merged_immutable_inputs.len();
       let immutable_inputs = &input_digests.immutable_inputs;
       merged_immutable_inputs.append(&mut immutable_inputs.clone());
       if size_before + immutable_inputs.len() != merged_immutable_inputs.len() {
-        return Err(format!(
-          "Tried to merge two-or-more immutable inputs at the same path with different values! \
+        return Err(
+          format!(
+            "Tried to merge two-or-more immutable inputs at the same path with different values! \
             The collision involved one of the entries in: {immutable_inputs:?}"
-        ));
+          )
+          .into(),
+        );
       }
     }
 
@@ -747,7 +794,7 @@ pub trait CommandRunner: Send + Sync {
     context: Context,
     workunit: &mut RunningWorkunit,
     req: Process,
-  ) -> Result<FallibleProcessResultWithPlatform, String>;
+  ) -> Result<FallibleProcessResultWithPlatform, ProcessError>;
 }
 
 // TODO(#8513) possibly move to the MEPR struct, or to the hashing crate?

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -24,7 +24,7 @@ use futures::stream::{BoxStream, StreamExt, TryStreamExt};
 use log::{debug, info};
 use nails::execution::ExitCode;
 use shell_quote::bash;
-use store::{OneOffStoreFileByDigest, Snapshot, Store};
+use store::{OneOffStoreFileByDigest, Snapshot, Store, StoreError};
 use tokio::process::{Child, Command};
 use tokio::sync::RwLock;
 use tokio::time::{timeout, Duration};
@@ -34,7 +34,7 @@ use workunit_store::{in_workunit, Level, Metric, RunningWorkunit};
 
 use crate::{
   Context, FallibleProcessResultWithPlatform, ImmutableInputs, NamedCaches, Platform, Process,
-  ProcessResultMetadata, ProcessResultSource,
+  ProcessError, ProcessResultMetadata, ProcessResultSource,
 };
 
 pub const USER_EXECUTABLE_MODE: u32 = 0o100755;
@@ -252,7 +252,7 @@ impl super::CommandRunner for CommandRunner {
     context: Context,
     _workunit: &mut RunningWorkunit,
     req: Process,
-  ) -> Result<FallibleProcessResultWithPlatform, String> {
+  ) -> Result<FallibleProcessResultWithPlatform, ProcessError> {
     let req_debug_repr = format!("{:#?}", req);
     in_workunit!(
       "run_local_process",
@@ -326,7 +326,7 @@ impl super::CommandRunner for CommandRunner {
             //
             // Given that this is expected to be rare, we dump the entire process definition in the
             // error.
-            format!("Failed to execute: {}\n\n{}", req_debug_repr, msg)
+            ProcessError::Unclassified(format!("Failed to execute: {}\n\n{}", req_debug_repr, msg))
           })
           .await;
 
@@ -475,7 +475,7 @@ pub trait CapturedWorkdir {
     workdir_token: Self::WorkdirToken,
     exclusive_spawn: bool,
     platform: Platform,
-  ) -> Result<FallibleProcessResultWithPlatform, String> {
+  ) -> Result<FallibleProcessResultWithPlatform, ProcessError> {
     let start_time = Instant::now();
 
     // Spawn the process.
@@ -570,7 +570,7 @@ pub trait CapturedWorkdir {
           metadata: result_metadata,
         })
       }
-      Err(msg) => Err(msg),
+      Err(msg) => Err(msg.into()),
     }
   }
 
@@ -641,7 +641,7 @@ pub async fn prepare_workdir(
   executor: task_executor::Executor,
   named_caches: &NamedCaches,
   immutable_inputs: &ImmutableInputs,
-) -> Result<bool, String> {
+) -> Result<bool, StoreError> {
   // Collect the symlinks to create for immutable inputs or named caches.
   let workdir_symlinks = immutable_inputs
     .local_paths(&req.input_digests.immutable_inputs)
@@ -677,7 +677,7 @@ pub async fn prepare_workdir(
         Permissions::Writable,
       )
       .await
-  },)
+  })
   .await?;
 
   let workdir_path2 = workdir_path.clone();

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -798,12 +798,10 @@ async fn run_command_locally_in_dir(
   let original = runner.run(Context::default(), workunit, req.into()).await?;
   let stdout_bytes = store
     .load_file_bytes_with(original.stdout_digest, |bytes| bytes.to_vec())
-    .await?
-    .unwrap();
+    .await?;
   let stderr_bytes = store
     .load_file_bytes_with(original.stderr_digest, |bytes| bytes.to_vec())
-    .await?
-    .unwrap();
+    .await?;
   Ok(LocalTestResult {
     original,
     stdout_bytes,

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -13,7 +13,9 @@ use tokio::net::TcpStream;
 use workunit_store::{in_workunit, Metric, RunningWorkunit};
 
 use crate::local::{prepare_workdir, CapturedWorkdir, ChildOutput};
-use crate::{Context, FallibleProcessResultWithPlatform, InputDigests, Platform, Process};
+use crate::{
+  Context, FallibleProcessResultWithPlatform, InputDigests, Platform, Process, ProcessError,
+};
 
 #[cfg(test)]
 pub mod tests;
@@ -114,7 +116,7 @@ impl super::CommandRunner for CommandRunner {
     context: Context,
     workunit: &mut RunningWorkunit,
     req: Process,
-  ) -> Result<FallibleProcessResultWithPlatform, String> {
+  ) -> Result<FallibleProcessResultWithPlatform, ProcessError> {
     if req.input_digests.use_nailgun.is_empty() {
       trace!("The request is not nailgunnable! Short-circuiting to regular process execution");
       return self.inner.run(context, workunit, req).await;

--- a/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
@@ -22,7 +22,7 @@ use task_executor::Executor;
 use tempfile::TempDir;
 
 use crate::local::prepare_workdir;
-use crate::{ImmutableInputs, NamedCaches, Process, ProcessMetadata};
+use crate::{ImmutableInputs, NamedCaches, Process, ProcessError, ProcessMetadata};
 
 lazy_static! {
   static ref NAILGUN_PORT_REGEX: Regex = Regex::new(r".*\s+port\s+(\d+)\.$").unwrap();
@@ -88,7 +88,7 @@ impl NailgunPool {
     server_process: Process,
     named_caches: &NamedCaches,
     immutable_inputs: &ImmutableInputs,
-  ) -> Result<BorrowedNailgunProcess, String> {
+  ) -> Result<BorrowedNailgunProcess, ProcessError> {
     let name = server_process.description.clone();
     let requested_fingerprint = NailgunProcessFingerprint::new(name.clone(), &server_process)?;
     let mut process_ref = {
@@ -340,7 +340,7 @@ impl NailgunProcess {
     named_caches: &NamedCaches,
     immutable_inputs: &ImmutableInputs,
     nailgun_server_fingerprint: NailgunProcessFingerprint,
-  ) -> Result<NailgunProcess, String> {
+  ) -> Result<NailgunProcess, ProcessError> {
     let workdir = tempfile::Builder::new()
       .prefix("pants-sandbox-")
       .tempdir_in(workdir_base)

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -698,7 +698,7 @@ impl CommandRunner {
         Err(err) => match err {
           ExecutionError::Fatal(e) => {
             workunit.increment_counter(Metric::RemoteExecutionRPCErrors, 1);
-            return Err(e.into());
+            return Err(e);
           }
           ExecutionError::Retryable(e) => {
             // Check if the number of request attempts sent thus far have exceeded the number
@@ -1294,7 +1294,6 @@ pub fn extract_output_files(
             "Error when storing the output file directory info in the remote CAS: {:?}",
             error
           )
-          .into()
         },
       );
 

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -32,7 +32,7 @@ use remexec::{
   execution_client::ExecutionClient, Action, Command, ExecuteRequest, ExecuteResponse,
   ExecutedActionMetadata, ServerCapabilities, WaitExecutionRequest,
 };
-use store::{Snapshot, SnapshotOps, Store, StoreFileByDigest};
+use store::{Snapshot, SnapshotOps, Store, StoreError, StoreFileByDigest};
 use tonic::metadata::BinaryMetadataValue;
 use tonic::{Code, Request, Status};
 use tryfuture::try_future;
@@ -43,7 +43,7 @@ use workunit_store::{
 };
 
 use crate::{
-  Context, FallibleProcessResultWithPlatform, Platform, Process, ProcessCacheScope,
+  Context, FallibleProcessResultWithPlatform, Platform, Process, ProcessCacheScope, ProcessError,
   ProcessMetadata, ProcessResultMetadata, ProcessResultSource,
 };
 
@@ -69,10 +69,11 @@ pub enum OperationOrStatus {
 
 #[derive(Debug, PartialEq)]
 pub enum ExecutionError {
-  // String is the error message.
-  Fatal(String),
-  // Digests are Files and Directories which have been reported to be missing. May be incomplete.
-  MissingDigests(Vec<Digest>),
+  Fatal(ProcessError),
+  // Digests are Files and Directories which have been reported to be missing remotely (unlike
+  // `{Process,Store}Error::MissingDigest`, which indicates that a digest doesn't exist anywhere
+  // in the configured Stores). May be incomplete.
+  MissingRemoteDigests(Vec<Digest>),
   // The server indicated that the request hit a timeout. Generally this is the timeout that the
   // client has pushed down on the ExecutionRequest.
   Timeout,
@@ -392,31 +393,37 @@ impl CommandRunner {
 
     for violation in &precondition_failure.violations {
       if violation.r#type != "MISSING" {
-        return ExecutionError::Fatal(format!(
-          "Unknown PreconditionFailure violation: {:?}",
-          violation
-        ));
+        return ExecutionError::Fatal(
+          format!("Unknown PreconditionFailure violation: {:?}", violation).into(),
+        );
       }
 
       let parts: Vec<_> = violation.subject.split('/').collect();
       if parts.len() != 3 || parts[0] != "blobs" {
-        return ExecutionError::Fatal(format!(
-          "Received FailedPrecondition MISSING but didn't recognize subject {}",
-          violation.subject
-        ));
+        return ExecutionError::Fatal(
+          format!(
+            "Received FailedPrecondition MISSING but didn't recognize subject {}",
+            violation.subject
+          )
+          .into(),
+        );
       }
 
       let fingerprint = match Fingerprint::from_hex_string(parts[1]) {
         Ok(f) => f,
         Err(e) => {
-          return ExecutionError::Fatal(format!("Bad digest in missing blob: {}: {}", parts[1], e))
+          return ExecutionError::Fatal(
+            format!("Bad digest in missing blob: {}: {}", parts[1], e).into(),
+          )
         }
       };
 
       let size = match parts[2].parse::<usize>() {
         Ok(s) => s,
         Err(e) => {
-          return ExecutionError::Fatal(format!("Missing blob had bad size: {}: {}", parts[2], e))
+          return ExecutionError::Fatal(
+            format!("Missing blob had bad size: {}: {}", parts[2], e).into(),
+          )
         }
       };
 
@@ -425,11 +432,13 @@ impl CommandRunner {
 
     if missing_digests.is_empty() {
       return ExecutionError::Fatal(
-        "Error from remote execution: FailedPrecondition, but no details".to_owned(),
+        "Error from remote execution: FailedPrecondition, but no details"
+          .to_owned()
+          .into(),
       );
     }
 
-    ExecutionError::MissingDigests(missing_digests)
+    ExecutionError::MissingRemoteDigests(missing_digests)
   }
 
   // pub(crate) for testing
@@ -447,16 +456,19 @@ impl CommandRunner {
         use protos::gen::google::longrunning::operation::Result as OperationResult;
         let execute_response = match operation.result {
           Some(OperationResult::Response(response_any)) => {
-            remexec::ExecuteResponse::decode(&response_any.value[..])
-              .map_err(|e| ExecutionError::Fatal(format!("Invalid ExecuteResponse: {:?}", e)))?
+            remexec::ExecuteResponse::decode(&response_any.value[..]).map_err(|e| {
+              ExecutionError::Fatal(format!("Invalid ExecuteResponse: {:?}", e).into())
+            })?
           }
           Some(OperationResult::Error(rpc_status)) => {
             warn!("protocol violation: REv2 prohibits setting Operation::error");
-            return Err(ExecutionError::Fatal(format_error(&rpc_status)));
+            return Err(ExecutionError::Fatal(format_error(&rpc_status).into()));
           }
           None => {
             return Err(ExecutionError::Fatal(
-              "Operation finished but no response supplied".to_string(),
+              "Operation finished but no response supplied"
+                .to_owned()
+                .into(),
             ));
           }
         };
@@ -478,7 +490,9 @@ impl CommandRunner {
           } else {
             warn!("REv2 protocol violation: action result not set");
             return Err(ExecutionError::Fatal(
-              "REv2 protocol violation: action result not set".into(),
+              "REv2 protocol violation: action result not set"
+                .to_owned()
+                .into(),
             ));
           };
 
@@ -495,7 +509,7 @@ impl CommandRunner {
             },
           )
           .await
-          .map_err(ExecutionError::Fatal);
+          .map_err(|e| ExecutionError::Fatal(e.into()));
         }
 
         rpc_status
@@ -510,11 +524,13 @@ impl CommandRunner {
 
       Code::FailedPrecondition => {
         let details = if status.details.is_empty() {
-          return Err(ExecutionError::Fatal(status.message));
+          return Err(ExecutionError::Fatal(status.message.into()));
         } else if status.details.len() > 1 {
           // TODO(tonic): Should we be able to handle multiple details protos?
           return Err(ExecutionError::Fatal(
-            "too many detail protos for precondition failure".into(),
+            "too many detail protos for precondition failure"
+              .to_owned()
+              .into(),
           ));
         } else {
           &status.details[0]
@@ -522,19 +538,21 @@ impl CommandRunner {
 
         let full_name = format!("type.googleapis.com/{}", "google.rpc.PreconditionFailure");
         if details.type_url != full_name {
-          return Err(ExecutionError::Fatal(format!(
+          return Err(ExecutionError::Fatal(
+            format!(
             "Received PreconditionFailure, but didn't know how to resolve it: {}, protobuf type {}",
             status.message, details.type_url
-          )));
+          )
+            .into(),
+          ));
         }
 
         // Decode the precondition failure.
         let precondition_failure = PreconditionFailure::decode(Cursor::new(&details.value))
           .map_err(|e| {
-            ExecutionError::Fatal(format!(
-              "Error deserializing PreconditionFailure proto: {:?}",
-              e
-            ))
+            ExecutionError::Fatal(
+              format!("Error deserializing PreconditionFailure proto: {:?}", e).into(),
+            )
           })?;
 
         Err(self.extract_missing_digests(&precondition_failure))
@@ -545,10 +563,13 @@ impl CommandRunner {
       | Code::ResourceExhausted
       | Code::Unavailable
       | Code::Unknown => Err(ExecutionError::Retryable(status.message)),
-      code => Err(ExecutionError::Fatal(format!(
-        "Error from remote execution: {:?}: {:?}",
-        code, status.message,
-      ))),
+      code => Err(ExecutionError::Fatal(
+        format!(
+          "Error from remote execution: {:?}: {:?}",
+          code, status.message,
+        )
+        .into(),
+      )),
     }
   }
 
@@ -566,7 +587,7 @@ impl CommandRunner {
     process: Process,
     context: &Context,
     workunit: &mut RunningWorkunit,
-  ) -> Result<FallibleProcessResultWithPlatform, String> {
+  ) -> Result<FallibleProcessResultWithPlatform, ProcessError> {
     const MAX_RETRIES: u32 = 5;
     const MAX_BACKOFF_DURATION: Duration = Duration::from_secs(10);
 
@@ -646,7 +667,7 @@ impl CommandRunner {
               if num_retries >= MAX_RETRIES {
                 workunit.increment_counter(Metric::RemoteExecutionRPCErrors, 1);
                 return Err(
-                  "Too many failures from server. The last event was the server disconnecting with no error given.".to_owned(),
+                  "Too many failures from server. The last event was the server disconnecting with no error given.".to_owned().into(),
                 );
               } else {
                 // Increment the retry counter and allow loop to retry.
@@ -677,7 +698,7 @@ impl CommandRunner {
         Err(err) => match err {
           ExecutionError::Fatal(e) => {
             workunit.increment_counter(Metric::RemoteExecutionRPCErrors, 1);
-            return Err(e);
+            return Err(e.into());
           }
           ExecutionError::Retryable(e) => {
             // Check if the number of request attempts sent thus far have exceeded the number
@@ -686,16 +707,15 @@ impl CommandRunner {
             trace!("retryable error: {}", e);
             if num_retries >= MAX_RETRIES {
               workunit.increment_counter(Metric::RemoteExecutionRPCErrors, 1);
-              return Err(format!(
-                "Too many failures from server. The last error was: {}",
-                e
-              ));
+              return Err(
+                format!("Too many failures from server. The last error was: {}", e).into(),
+              );
             } else {
               // Increment the retry counter and allow loop to retry.
               num_retries += 1;
             }
           }
-          ExecutionError::MissingDigests(missing_digests) => {
+          ExecutionError::MissingRemoteDigests(missing_digests) => {
             trace!(
               "Server reported missing digests; trying to upload: {:?}",
               missing_digests,
@@ -708,7 +728,7 @@ impl CommandRunner {
           }
           ExecutionError::Timeout => {
             workunit.increment_counter(Metric::RemoteExecutionTimeouts, 1);
-            return populate_fallible_execution_result_for_timeout(
+            let result = populate_fallible_execution_result_for_timeout(
               &self.store,
               context,
               &process.description,
@@ -716,7 +736,8 @@ impl CommandRunner {
               start_time.elapsed(),
               self.platform,
             )
-            .await;
+            .await?;
+            return Ok(result);
           }
         },
       }
@@ -732,7 +753,7 @@ impl crate::CommandRunner for CommandRunner {
     context: Context,
     _workunit: &mut RunningWorkunit,
     request: Process,
-  ) -> Result<FallibleProcessResultWithPlatform, String> {
+  ) -> Result<FallibleProcessResultWithPlatform, ProcessError> {
     // Retrieve capabilities for this server.
     let capabilities = self.get_capabilities().await?;
     trace!("RE capabilities: {:?}", &capabilities);
@@ -832,10 +853,7 @@ impl crate::CommandRunner for CommandRunner {
               &build_id, deadline_duration
             );
             workunit.increment_counter(Metric::RemoteExecutionTimeouts, 1);
-            Err(format!(
-              "remote execution timed out after {:?}",
-              deadline_duration
-            ))
+            Err(format!("remote execution timed out after {:?}", deadline_duration).into())
           }
         }
       },
@@ -1072,15 +1090,15 @@ pub async fn populate_fallible_execution_result_for_timeout(
 /// of the ActionResult/ExecuteResponse stored in the local cache. When
 /// `treat_tree_digest_as_final_directory_hack` is true, then that final merged directory
 /// will be extracted from the tree_digest of the single output directory.
-pub fn populate_fallible_execution_result(
+pub async fn populate_fallible_execution_result(
   store: Store,
   run_id: RunId,
   action_result: &remexec::ActionResult,
   platform: Platform,
   treat_tree_digest_as_final_directory_hack: bool,
   source: ProcessResultSource,
-) -> BoxFuture<Result<FallibleProcessResultWithPlatform, String>> {
-  future::try_join3(
+) -> Result<FallibleProcessResultWithPlatform, StoreError> {
+  let (stdout_digest, stderr_digest, output_directory) = future::try_join3(
     extract_stdout(&store, action_result),
     extract_stderr(&store, action_result),
     extract_output_files(
@@ -1089,28 +1107,25 @@ pub fn populate_fallible_execution_result(
       treat_tree_digest_as_final_directory_hack,
     ),
   )
-  .and_then(
-    move |(stdout_digest, stderr_digest, output_directory)| async move {
-      Ok(FallibleProcessResultWithPlatform {
-        stdout_digest,
-        stderr_digest,
-        exit_code: action_result.exit_code,
-        output_directory,
-        platform,
-        metadata: action_result.execution_metadata.clone().map_or(
-          ProcessResultMetadata::new(None, source, run_id),
-          |metadata| ProcessResultMetadata::new_from_metadata(metadata, source, run_id),
-        ),
-      })
-    },
-  )
-  .boxed()
+  .await?;
+
+  Ok(FallibleProcessResultWithPlatform {
+    stdout_digest,
+    stderr_digest,
+    exit_code: action_result.exit_code,
+    output_directory,
+    platform,
+    metadata: action_result.execution_metadata.clone().map_or(
+      ProcessResultMetadata::new(None, source, run_id),
+      |metadata| ProcessResultMetadata::new_from_metadata(metadata, source, run_id),
+    ),
+  })
 }
 
 fn extract_stdout<'a>(
   store: &Store,
   action_result: &'a remexec::ActionResult,
-) -> BoxFuture<'a, Result<Digest, String>> {
+) -> BoxFuture<'a, Result<Digest, StoreError>> {
   let store = store.clone();
   async move {
     if let Some(digest_proto) = &action_result.stdout_digest {
@@ -1133,7 +1148,7 @@ fn extract_stdout<'a>(
 fn extract_stderr<'a>(
   store: &Store,
   action_result: &'a remexec::ActionResult,
-) -> BoxFuture<'a, Result<Digest, String>> {
+) -> BoxFuture<'a, Result<Digest, StoreError>> {
   let store = store.clone();
   async move {
     if let Some(digest_proto) = &action_result.stderr_digest {
@@ -1157,7 +1172,7 @@ pub fn extract_output_files(
   store: Store,
   action_result: &remexec::ActionResult,
   treat_tree_digest_as_final_directory_hack: bool,
-) -> BoxFuture<'static, Result<DirectoryDigest, String>> {
+) -> BoxFuture<'static, Result<DirectoryDigest, StoreError>> {
   // HACK: The caching CommandRunner stores the digest of the Directory that merges all output
   // files and output directories in the `tree_digest` field of the `output_directories` field
   // of the ActionResult/ExecuteResponse stored in the local cache. When
@@ -1169,18 +1184,22 @@ pub fn extract_output_files(
       &[ref directory] => {
         match require_digest(directory.tree_digest.as_ref()) {
           Ok(digest) => {
-            return future::ready::<Result<_, String>>(Ok(DirectoryDigest::from_persisted_digest(
-              digest,
-            )))
+            return future::ready::<Result<_, StoreError>>(Ok(
+              DirectoryDigest::from_persisted_digest(digest),
+            ))
             .boxed()
           }
-          Err(err) => return futures::future::err(err).boxed(),
+          Err(err) => return futures::future::err(err.into()).boxed(),
         };
       }
       _ => {
         return futures::future::err(
-          "illegal state: treat_tree_digest_as_final_directory_hack expected single output directory".to_owned()
-        ).boxed();
+          "illegal state: treat_tree_digest_as_final_directory_hack \
+          expected single output directory"
+            .to_owned()
+            .into(),
+        )
+        .boxed();
       }
     }
   }
@@ -1213,7 +1232,7 @@ pub fn extract_output_files(
       })
       .map_err(|err| {
         format!(
-          "Error saving remote output directory to local cache: {:?}",
+          "Error saving remote output directory to local cache: {}",
           err
         )
       }),
@@ -1275,6 +1294,7 @@ pub fn extract_output_files(
             "Error when storing the output file directory info in the remote CAS: {:?}",
             error
           )
+          .into()
         },
       );
 
@@ -1285,7 +1305,7 @@ pub fn extract_output_files(
 
     store
       .merge(directory_digests)
-      .map_err(|err| format!("Error when merging output files and directories: {:?}", err))
+      .map_err(|err| err.enrich("Error when merging output files and directories"))
       .await
   }
   .boxed()
@@ -1328,7 +1348,7 @@ pub async fn check_action_cache(
   store: Store,
   eager_fetch: bool,
   timeout_duration: Duration,
-) -> Result<Option<FallibleProcessResultWithPlatform>, String> {
+) -> Result<Option<FallibleProcessResultWithPlatform>, ProcessError> {
   in_workunit!(
     "check_action_cache",
     Level::Debug,
@@ -1407,7 +1427,8 @@ pub async fn check_action_cache(
           }
           _ => {
             workunit.increment_counter(Metric::RemoteCacheReadErrors, 1);
-            Err(status_to_str(status))
+            // TODO: Ensure that we're catching missing digests.
+            Err(status_to_str(status).into())
           }
         },
       }
@@ -1449,7 +1470,7 @@ pub async fn ensure_action_uploaded(
   command_digest: Digest,
   action_digest: Digest,
   input_files: Option<DirectoryDigest>,
-) -> Result<(), String> {
+) -> Result<(), StoreError> {
   in_workunit!(
     "ensure_action_uploaded",
     Level::Trace,

--- a/src/rust/engine/process_execution/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_cache_tests.rs
@@ -21,7 +21,7 @@ use workunit_store::{RunId, RunningWorkunit, WorkunitStore};
 use crate::remote::{ensure_action_stored_locally, make_execute_request};
 use crate::{
   CommandRunner as CommandRunnerTrait, Context, FallibleProcessResultWithPlatform, Platform,
-  Process, ProcessMetadata, ProcessResultMetadata, ProcessResultSource,
+  Process, ProcessError, ProcessMetadata, ProcessResultMetadata, ProcessResultSource,
   RemoteCacheWarningsBehavior,
 };
 
@@ -30,7 +30,7 @@ const CACHE_READ_TIMEOUT: Duration = Duration::from_secs(5);
 /// A mock of the local runner used for better hermeticity of the tests.
 #[derive(Clone)]
 struct MockLocalCommandRunner {
-  result: Result<FallibleProcessResultWithPlatform, String>,
+  result: Result<FallibleProcessResultWithPlatform, ProcessError>,
   call_counter: Arc<AtomicUsize>,
   delay: Duration,
 }
@@ -63,7 +63,7 @@ impl CommandRunnerTrait for MockLocalCommandRunner {
     _context: Context,
     _workunit: &mut RunningWorkunit,
     _req: Process,
-  ) -> Result<FallibleProcessResultWithPlatform, String> {
+  ) -> Result<FallibleProcessResultWithPlatform, ProcessError> {
     sleep(self.delay).await;
     self.call_counter.fetch_add(1, Ordering::SeqCst);
     self.result.clone()
@@ -562,7 +562,7 @@ async fn make_action_result_basic() {
       _context: Context,
       _workunit: &mut RunningWorkunit,
       _req: Process,
-    ) -> Result<FallibleProcessResultWithPlatform, String> {
+    ) -> Result<FallibleProcessResultWithPlatform, ProcessError> {
       unimplemented!()
     }
   }

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -1221,7 +1221,6 @@ async fn ensure_inline_stdio_is_stored() {
       local_store
         .load_file_bytes_with(test_stdout.digest(), |v| Bytes::copy_from_slice(v))
         .await
-        .unwrap()
         .unwrap(),
       test_stdout.bytes()
     );
@@ -1229,7 +1228,6 @@ async fn ensure_inline_stdio_is_stored() {
       local_store
         .load_file_bytes_with(test_stderr.digest(), |v| Bytes::copy_from_slice(v))
         .await
-        .unwrap()
         .unwrap(),
       test_stderr.bytes()
     );
@@ -2303,12 +2301,10 @@ pub(crate) async fn run_cmd_runner<R: crate::CommandRunner>(
     .await?;
   let stdout_bytes = store
     .load_file_bytes_with(original.stdout_digest, |bytes| bytes.to_vec())
-    .await?
-    .unwrap();
+    .await?;
   let stderr_bytes = store
     .load_file_bytes_with(original.stderr_digest, |bytes| bytes.to_vec())
-    .await?
-    .unwrap();
+    .await?;
   Ok(RemoteTestResult {
     original,
     stdout_bytes,
@@ -2360,12 +2356,10 @@ async fn run_command_remote(
 
   let stdout_bytes = store
     .load_file_bytes_with(original.stdout_digest, |bytes| bytes.to_vec())
-    .await?
-    .unwrap();
+    .await?;
   let stderr_bytes = store
     .load_file_bytes_with(original.stderr_digest, |bytes| bytes.to_vec())
-    .await?
-    .unwrap();
+    .await?;
   Ok(RemoteTestResult {
     original,
     stdout_bytes,
@@ -2415,13 +2409,11 @@ async fn extract_execute_response(
   let stdout_bytes: Vec<u8> = store
     .load_file_bytes_with(original.stdout_digest, |bytes| bytes.to_vec())
     .await
-    .unwrap()
     .unwrap();
 
   let stderr_bytes: Vec<u8> = store
     .load_file_bytes_with(original.stderr_digest, |bytes| bytes.to_vec())
     .await
-    .unwrap()
     .unwrap();
 
   Ok(RemoteTestResult {

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -15,7 +15,7 @@ use protos::gen::google::longrunning::Operation;
 use remexec::ExecutedActionMetadata;
 use spectral::prelude::*;
 use spectral::{assert_that, string::StrAssertions};
-use store::{SnapshotOps, Store};
+use store::{SnapshotOps, Store, StoreError};
 use tempfile::TempDir;
 use testutil::data::{TestData, TestDirectory, TestTree};
 use testutil::{owned_string_vec, relative_paths};
@@ -24,7 +24,7 @@ use workunit_store::{RunId, WorkunitStore};
 use crate::remote::{digest, CommandRunner, ExecutionError, OperationOrStatus};
 use crate::{
   CommandRunner as CommandRunnerTrait, Context, FallibleProcessResultWithPlatform, InputDigests,
-  Platform, Process, ProcessCacheScope, ProcessMetadata,
+  Platform, Process, ProcessCacheScope, ProcessError, ProcessMetadata,
 };
 use fs::{RelativePath, EMPTY_DIRECTORY_DIGEST};
 use std::any::type_name;
@@ -886,8 +886,8 @@ async fn server_rejecting_execute_request_gives_error() {
   let error = run_command_remote(mock_server.address(), execute_request)
     .await
     .expect_err("Want Err");
-  assert_that(&error).contains("InvalidArgument");
-  assert_that(&error).contains("Did not expect this request");
+  assert_that(&error.to_string()).contains("InvalidArgument");
+  assert_that(&error.to_string()).contains("Did not expect this request");
 }
 
 #[tokio::test]
@@ -1325,7 +1325,7 @@ async fn initial_response_error() {
     .await
     .expect_err("Want Err");
 
-  assert_eq!(result, "Internal: Something went wrong");
+  assert_eq!(result.to_string(), "Internal: Something went wrong");
 }
 
 #[tokio::test]
@@ -1368,7 +1368,10 @@ async fn initial_response_missing_response_and_error() {
     .await
     .expect_err("Want Err");
 
-  assert_eq!(result, "Operation finished but no response supplied");
+  assert_eq!(
+    result.to_string(),
+    "Operation finished but no response supplied"
+  );
 }
 
 #[tokio::test]
@@ -1425,7 +1428,7 @@ async fn fails_after_retry_limit_exceeded() {
     .expect_err("Expected error");
 
   assert_eq!(
-    result,
+    result.to_string(),
     "Too many failures from server. The last error was: the bot running the task appears to be lost"
   );
 }
@@ -1485,7 +1488,7 @@ async fn fails_after_retry_limit_exceeded_with_stream_close() {
     .expect_err("Expected error");
 
   assert_eq!(
-    result,
+    result.to_string(),
     "Too many failures from server. The last event was the server disconnecting with no error given."
   );
 }
@@ -1665,7 +1668,7 @@ async fn execute_missing_file_errors_if_unknown() {
     .run(Context::default(), &mut workunit, cat_roland_request())
     .await
     .expect_err("Want error");
-  assert_contains(&error, &format!("{}", missing_digest.hash));
+  assert_contains(&error.to_string(), &format!("{}", missing_digest.hash));
 }
 
 #[tokio::test]
@@ -1759,7 +1762,7 @@ async fn extract_execute_response_missing_digests() {
 
   assert_eq!(
     extract_execute_response(operation, Platform::Linux_x86_64).await,
-    Err(ExecutionError::MissingDigests(missing_files))
+    Err(ExecutionError::MissingRemoteDigests(missing_files))
   );
 }
 
@@ -1780,7 +1783,7 @@ async fn extract_execute_response_missing_other_things() {
     .unwrap();
 
   match extract_execute_response(operation, Platform::Linux_x86_64).await {
-    Err(ExecutionError::Fatal(err)) => assert_contains(&err, "monkeys"),
+    Err(ExecutionError::Fatal(err)) => assert_contains(&err.to_string(), "monkeys"),
     other => assert!(false, "Want fatal error, got {:?}", other),
   };
 }
@@ -1798,7 +1801,7 @@ async fn extract_execute_response_other_failed_precondition() {
     .unwrap();
 
   match extract_execute_response(operation, Platform::Linux_x86_64).await {
-    Err(ExecutionError::Fatal(err)) => assert_contains(&err, "OUT_OF_CAPACITY"),
+    Err(ExecutionError::Fatal(err)) => assert_contains(&err.to_string(), "OUT_OF_CAPACITY"),
     other => assert!(false, "Want fatal error, got {:?}", other),
   };
 }
@@ -1813,7 +1816,9 @@ async fn extract_execute_response_missing_without_list() {
     .unwrap();
 
   match extract_execute_response(operation, Platform::Linux_x86_64).await {
-    Err(ExecutionError::Fatal(err)) => assert_contains(&err.to_lowercase(), "precondition"),
+    Err(ExecutionError::Fatal(err)) => {
+      assert_contains(&err.to_string().to_lowercase(), "precondition")
+    }
     other => assert!(false, "Want fatal error, got {:?}", other),
   };
 }
@@ -1839,7 +1844,7 @@ async fn extract_execute_response_other_status() {
   };
 
   match extract_execute_response(operation, Platform::Linux_x86_64).await {
-    Err(ExecutionError::Fatal(err)) => assert_contains(&err, "PermissionDenied"),
+    Err(ExecutionError::Fatal(err)) => assert_contains(&err.to_string(), "PermissionDenied"),
     other => assert!(false, "Want fatal error, got {:?}", other),
   };
 }
@@ -2291,7 +2296,7 @@ pub(crate) async fn run_cmd_runner<R: crate::CommandRunner>(
   request: Process,
   command_runner: R,
   store: Store,
-) -> Result<RemoteTestResult, String> {
+) -> Result<RemoteTestResult, ProcessError> {
   let (_, mut workunit) = WorkunitStore::setup_for_tests();
   let original = command_runner
     .run(Context::default(), &mut workunit, request)
@@ -2338,7 +2343,10 @@ fn create_command_runner(
   (command_runner, store)
 }
 
-async fn run_command_remote(address: String, request: Process) -> Result<RemoteTestResult, String> {
+async fn run_command_remote(
+  address: String,
+  request: Process,
+) -> Result<RemoteTestResult, ProcessError> {
   let (_, mut workunit) = WorkunitStore::setup_for_tests();
   let cas = mock::StubCAS::builder()
     .file(&TestData::roland())
@@ -2425,7 +2433,7 @@ async fn extract_execute_response(
 
 async fn extract_output_files_from_response(
   execute_response: &remexec::ExecuteResponse,
-) -> Result<Digest, String> {
+) -> Result<Digest, StoreError> {
   let cas = mock::StubCAS::builder()
     .file(&TestData::roland())
     .directory(&TestDirectory::containing_roland())

--- a/src/rust/engine/src/externs/fs.rs
+++ b/src/rust/engine/src/externs/fs.rs
@@ -36,6 +36,13 @@ pub(crate) fn register(m: &PyModule) -> PyResult<()> {
   Ok(())
 }
 
+// TODO: This method is a marker, but in a followup PR we will need to propagate a particular
+// Exception type out of `@rule` bodies and back into `Failure::MissingDigest`, to allow for retry
+// via #11331.
+pub fn todo_possible_store_missing_digest(e: store::StoreError) -> PyErr {
+  PyException::new_err(e.to_string())
+}
+
 #[pyclass(name = "Digest")]
 #[derive(Clone, Debug, PartialEq)]
 pub struct PyDigest(pub DirectoryDigest);

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1530,11 +1530,6 @@ fn single_file_digests_to_bytes<'py>(
             externs::store_bytes(py, bytes)
           })
           .await
-          .and_then(|maybe_bytes| {
-            maybe_bytes.ok_or_else(|| {
-              format!("Error loading bytes from digest: {:?}", py_file_digest.0).into()
-            })
-          })
       }
     });
 

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -44,7 +44,7 @@ use workunit_store::{
   ArtifactOutput, ObservationMetric, UserMetadataItem, Workunit, WorkunitState, WorkunitStore,
 };
 
-use crate::externs::fs::PyFileDigest;
+use crate::externs::fs::{todo_possible_store_missing_digest, PyFileDigest};
 use crate::{
   externs, nodes, Context, Core, ExecutionRequest, ExecutionStrategyOptions, ExecutionTermination,
   Failure, Function, Intrinsic, Intrinsics, Key, LocalStoreOptions, Params, RemotingOptions, Rule,
@@ -473,7 +473,7 @@ fn py_result_from_root(py: Python, result: Result<Value, Failure>) -> PyResult {
     },
     Err(f) => {
       let (val, python_traceback, engine_traceback) = match f {
-        f @ Failure::Invalidated => {
+        f @ (Failure::Invalidated | Failure::MissingDigest { .. }) => {
           let msg = format!("{}", f);
           let python_traceback = Failure::native_traceback(&msg);
           (
@@ -782,7 +782,7 @@ async fn workunit_to_py_value(
           })?;
         let snapshot = store::Snapshot::from_digest(store, digest.clone())
           .await
-          .map_err(PyException::new_err)?;
+          .map_err(todo_possible_store_missing_digest)?;
         let gil = Python::acquire_gil();
         let py = gil.python();
         crate::nodes::Snapshot::store_snapshot(py, snapshot).map_err(PyException::new_err)?
@@ -1400,7 +1400,7 @@ fn lease_files_in_graph(
         .executor
         .block_on(core.store().lease_all_recursively(digests.iter()))
     })
-    .map_err(PyException::new_err)
+    .map_err(todo_possible_store_missing_digest)
   })
 }
 
@@ -1487,7 +1487,7 @@ fn ensure_remote_has_recursive(
         .executor
         .block_on(core.store().ensure_remote_has_recursive(digests))
     })
-    .map_err(PyException::new_err)?;
+    .map_err(todo_possible_store_missing_digest)?;
     Ok(())
   })
 }
@@ -1507,7 +1507,7 @@ fn ensure_directory_digest_persisted(
         .executor
         .block_on(core.store().ensure_directory_digest_persisted(digest))
     })
-    .map_err(PyException::new_err)?;
+    .map_err(todo_possible_store_missing_digest)?;
     Ok(())
   })
 }
@@ -1531,8 +1531,9 @@ fn single_file_digests_to_bytes<'py>(
           })
           .await
           .and_then(|maybe_bytes| {
-            maybe_bytes
-              .ok_or_else(|| format!("Error loading bytes from digest: {:?}", py_file_digest.0))
+            maybe_bytes.ok_or_else(|| {
+              format!("Error loading bytes from digest: {:?}", py_file_digest.0).into()
+            })
           })
       }
     });
@@ -1540,7 +1541,7 @@ fn single_file_digests_to_bytes<'py>(
     let bytes_values: Vec<PyObject> = py
       .allow_threads(|| core.executor.block_on(future::try_join_all(digest_futures)))
       .map(|values| values.into_iter().map(|val| val.into()).collect())
-      .map_err(PyException::new_err)?;
+      .map_err(todo_possible_store_missing_digest)?;
 
     let output_list = PyList::new(py, &bytes_values);
     Ok(output_list)
@@ -1577,7 +1578,7 @@ fn write_digest(
         )
         .await
     })
-    .map_err(PyValueError::new_err)
+    .map_err(todo_possible_store_missing_digest)
   })
 }
 

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -183,15 +183,13 @@ fn process_request_to_process_result(
       .core
       .store()
       .load_file_bytes_with(result.stdout_digest, |bytes: &[u8]| bytes.to_owned())
-      .await
-      .map_err(throw)?;
+      .await?;
 
     let maybe_stderr = context
       .core
       .store()
       .load_file_bytes_with(result.stderr_digest, |bytes: &[u8]| bytes.to_owned())
-      .await
-      .map_err(throw)?;
+      .await?;
 
     let stdout_bytes = maybe_stdout.ok_or_else(|| {
       throw(format!(
@@ -215,11 +213,11 @@ fn process_request_to_process_result(
       context.core.types.process_result,
       &[
         externs::store_bytes(py, &stdout_bytes),
-        Snapshot::store_file_digest(py, result.stdout_digest).map_err(throw)?,
+        Snapshot::store_file_digest(py, result.stdout_digest)?,
         externs::store_bytes(py, &stderr_bytes),
-        Snapshot::store_file_digest(py, result.stderr_digest).map_err(throw)?,
+        Snapshot::store_file_digest(py, result.stderr_digest)?,
         externs::store_i64(py, result.exit_code.into()),
-        Snapshot::store_directory_digest(py, result.output_directory).map_err(throw)?,
+        Snapshot::store_directory_digest(py, result.output_directory)?,
         externs::unsafe_call(
           py,
           context.core.types.platform,
@@ -252,18 +250,13 @@ fn directory_digest_to_digest_contents(
     let digest = Python::with_gil(|py| {
       let py_digest = (*args[0]).as_ref(py);
       lift_directory_digest(py_digest)
-    })
-    .map_err(throw)?;
+    })?;
 
-    let digest_contents = context
-      .core
-      .store()
-      .contents_for_directory(digest)
-      .await
-      .map_err(throw)?;
+    let digest_contents = context.core.store().contents_for_directory(digest).await?;
 
     let gil = Python::acquire_gil();
-    Snapshot::store_digest_contents(gil.python(), &context, &digest_contents).map_err(throw)
+    let value = Snapshot::store_digest_contents(gil.python(), &context, &digest_contents)?;
+    Ok(value)
   }
   .boxed()
 }
@@ -276,19 +269,11 @@ fn directory_digest_to_digest_entries(
     let digest = Python::with_gil(|py| {
       let py_digest = (*args[0]).as_ref(py);
       lift_directory_digest(py_digest)
-    })
-    .map_err(throw)?;
-    let snapshot = context
-      .core
-      .store()
-      .entries_for_directory(digest)
-      .await
-      .and_then(move |digest_entries| {
-        let gil = Python::acquire_gil();
-        Snapshot::store_digest_entries(gil.python(), &context, &digest_entries)
-      })
-      .map_err(throw)?;
-    Ok(snapshot)
+    })?;
+    let digest_entries = context.core.store().entries_for_directory(digest).await?;
+    let gil = Python::acquire_gil();
+    let value = Snapshot::store_digest_entries(gil.python(), &context, &digest_entries)?;
+    Ok(value)
   }
   .boxed()
 }
@@ -308,14 +293,10 @@ fn remove_prefix_request_to_digest(
       let res: NodeResult<_> = Ok((py_remove_prefix.digest.clone(), prefix));
       res
     })?;
-    let digest = context
-      .core
-      .store()
-      .strip_prefix(digest, &prefix)
-      .await
-      .map_err(throw)?;
+    let digest = context.core.store().strip_prefix(digest, &prefix).await?;
     let gil = Python::acquire_gil();
-    Snapshot::store_directory_digest(gil.python(), digest).map_err(throw)
+    let value = Snapshot::store_directory_digest(gil.python(), digest)?;
+    Ok(value)
   }
   .boxed()
 }
@@ -336,14 +317,10 @@ fn add_prefix_request_to_digest(
         Ok((py_add_prefix.digest.clone(), prefix));
       res
     })?;
-    let digest = context
-      .core
-      .store()
-      .add_prefix(digest, &prefix)
-      .await
-      .map_err(throw)?;
+    let digest = context.core.store().add_prefix(digest, &prefix).await?;
     let gil = Python::acquire_gil();
-    Snapshot::store_directory_digest(gil.python(), digest).map_err(throw)
+    let value = Snapshot::store_directory_digest(gil.python(), digest)?;
+    Ok(value)
   }
   .boxed()
 }
@@ -357,9 +334,9 @@ fn digest_to_snapshot(context: Context, args: Vec<Value>) -> BoxFuture<'static, 
     })?;
     let snapshot = store::Snapshot::from_digest(store, digest).await?;
     let gil = Python::acquire_gil();
-    Snapshot::store_snapshot(gil.python(), snapshot)
+    let value = Snapshot::store_snapshot(gil.python(), snapshot)?;
+    Ok(value)
   }
-  .map_err(throw)
   .boxed()
 }
 
@@ -377,9 +354,10 @@ fn merge_digests_request_to_digest(
         .map(|py_merge_digests| py_merge_digests.0.clone())
         .map_err(|e| throw(format!("{}", e)))
     })?;
-    let digest = store.merge(digests).await.map_err(throw)?;
+    let digest = store.merge(digests).await?;
     let gil = Python::acquire_gil();
-    Snapshot::store_directory_digest(gil.python(), digest).map_err(throw)
+    let value = Snapshot::store_directory_digest(gil.python(), digest)?;
+    Ok(value)
   }
   .boxed()
 }
@@ -392,7 +370,8 @@ fn download_file_to_digest(
     let key = Key::from_value(args.pop().unwrap()).map_err(Failure::from_py_err)?;
     let snapshot = context.get(DownloadedFile(key)).await?;
     let gil = Python::acquire_gil();
-    Snapshot::store_directory_digest(gil.python(), snapshot.into()).map_err(throw)
+    let value = Snapshot::store_directory_digest(gil.python(), snapshot.into())?;
+    Ok(value)
   }
   .boxed()
 }
@@ -409,7 +388,8 @@ fn path_globs_to_digest(
     .map_err(|e| throw(format!("Failed to parse PathGlobs: {}", e)))?;
     let snapshot = context.get(Snapshot::from_path_globs(path_globs)).await?;
     let gil = Python::acquire_gil();
-    Snapshot::store_directory_digest(gil.python(), snapshot.into()).map_err(throw)
+    let value = Snapshot::store_directory_digest(gil.python(), snapshot.into())?;
+    Ok(value)
   }
   .boxed()
 }
@@ -427,7 +407,8 @@ fn path_globs_to_paths(
     .map_err(|e| throw(format!("Failed to parse PathGlobs: {}", e)))?;
     let paths = context.get(Paths::from_path_globs(path_globs)).await?;
     let gil = Python::acquire_gil();
-    Paths::store_paths(gil.python(), &core, &paths).map_err(throw)
+    let value = Paths::store_paths(gil.python(), &core, &paths)?;
+    Ok(value)
   }
   .boxed()
 }
@@ -494,7 +475,7 @@ fn create_digest_to_digest(
           CreateDigestItem::Dir(path) => store
             .create_empty_dir(&path)
             .await
-            .map_err(|e| format!("{:?}", e)),
+            .map_err(|e| e.to_string()),
         }
       }
     })
@@ -502,10 +483,11 @@ fn create_digest_to_digest(
 
   let store = context.core.store();
   async move {
-    let digests = future::try_join_all(digest_futures).await.map_err(throw)?;
-    let digest = store.merge(digests).await.map_err(throw)?;
+    let digests = future::try_join_all(digest_futures).await?;
+    let digest = store.merge(digests).await?;
     let gil = Python::acquire_gil();
-    Snapshot::store_directory_digest(gil.python(), digest).map_err(throw)
+    let value = Snapshot::store_directory_digest(gil.python(), digest)?;
+    Ok(value)
   }
   .boxed()
 }
@@ -521,18 +503,16 @@ fn digest_subset_to_digest(
       let py_path_globs = externs::getattr(py_digest_subset, "globs").unwrap();
       let py_digest = externs::getattr(py_digest_subset, "digest").unwrap();
       let res: NodeResult<_> = Ok((
-        Snapshot::lift_prepared_path_globs(py_path_globs).map_err(throw)?,
-        lift_directory_digest(py_digest).map_err(throw)?,
+        Snapshot::lift_prepared_path_globs(py_path_globs)?,
+        lift_directory_digest(py_digest)?,
       ));
       res
     })?;
     let subset_params = SubsetParams { globs: path_globs };
-    let digest = store
-      .subset(original_digest, subset_params)
-      .await
-      .map_err(throw)?;
+    let digest = store.subset(original_digest, subset_params).await?;
     let gil = Python::acquire_gil();
-    Snapshot::store_directory_digest(gil.python(), digest).map_err(throw)
+    let value = Snapshot::store_directory_digest(gil.python(), digest)?;
+    Ok(value)
   }
   .boxed()
 }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -935,8 +935,7 @@ impl DownloadedFile {
         .store()
         .load_file_bytes_with(digest, |_| ())
         .await
-        .unwrap_or(None)
-        == Some(()));
+        .is_ok());
 
     if !usable_in_store {
       downloads::download(core.clone(), url, file_name, digest).await?;


### PR DESCRIPTION
In order to begin lazily fetching digests for #11331, we need to be able to differentiate errors caused by missing digests.

This change introduces `{StoreError,ProcessError,Failure}::MissingDigest`, which are bubbled up to the level of graph `Node`s, and which will allow us to introduce retry in a followup change. `MissingDigest` is produced by `load_bytes_with` and a few other low-level `Store` methods (which now return an `Err(MissingDigest)` rather than `Option`).

There should not be any behavior changes.