### PR TITLE
Always ignore paths which are not files, directories, or links.

### DIFF
--- a/src/python/pants/engine/fs_test.py
+++ b/src/python/pants/engine/fs_test.py
@@ -4,6 +4,7 @@ import hashlib
 import os
 import pkgutil
 import shutil
+import socket
 import ssl
 import tarfile
 import time
@@ -283,6 +284,22 @@ def test_path_globs_ignore_pattern(rule_runner: RuleRunner) -> None:
         ["**", "!*.ln"],
         expected_files=["4.txt", "a/3.txt", "a/b/1.txt", "a/b/2"],
         expected_dirs=["a", "a/b"],
+    )
+
+
+def test_path_globs_ignore_sock(rule_runner: RuleRunner) -> None:
+    sock_path = os.path.join(rule_runner.build_root, "sock.sock")
+    with socket.socket(socket.AF_UNIX) as sock:
+        sock.bind(sock_path)
+    assert os.path.exists(sock_path)
+    assert not os.path.isfile(sock_path)
+
+    rule_runner.write_files({"non-sock.txt": ""})
+    assert_path_globs(
+        rule_runner,
+        ["**"],
+        expected_files=["non-sock.txt"],
+        expected_dirs=[],
     )
 
 

--- a/src/rust/engine/fs/src/posixfs_tests.rs
+++ b/src/rust/engine/fs/src/posixfs_tests.rs
@@ -115,9 +115,12 @@ async fn stat_symlink_oblivious() {
 
 #[tokio::test]
 async fn stat_other() {
-  new_posixfs("/dev")
-    .stat_sync(PathBuf::from("null"))
-    .expect_err("Want error");
+  assert_eq!(
+    new_posixfs("/dev")
+      .stat_sync(PathBuf::from("null"))
+      .unwrap(),
+    None,
+  );
 }
 
 #[tokio::test]


### PR DESCRIPTION
As described in #13284, Pants currently errors for unrecognized path types. Although this is maximally defensive, it has not proven to be useful.

Since `git` completely ignores these file types, it seems reasonable for us to do so as well.

Fixes #13284 and fixes #15772.