### PR TITLE
Fix `[python-infer].inits` and `[python-infer].conftests` to consider `resolve` field

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -463,7 +463,9 @@ class InferInitDependencies(InferDependenciesRequest):
 
 @rule(desc="Inferring dependencies on `__init__.py` files")
 async def infer_python_init_dependencies(
-    request: InferInitDependencies, python_infer_subsystem: PythonInferSubsystem
+    request: InferInitDependencies,
+    python_infer_subsystem: PythonInferSubsystem,
+    python_setup: PythonSetup,
 ) -> InferredDependencies:
     if (
         not python_infer_subsystem.options.is_default("inits") and not python_infer_subsystem.inits
@@ -485,8 +487,20 @@ async def infer_python_init_dependencies(
         ),
     )
     owners = await MultiGet(Get(Owners, OwnersRequest((f,))) for f in init_files.snapshot.files)
-    owner_tgts = await Get(Targets, Addresses(itertools.chain.from_iterable(owners)))
-    python_owners = [tgt.address for tgt in owner_tgts if tgt.has_field(PythonSourceField)]
+
+    original_tgt, owner_tgts = await MultiGet(
+        Get(WrappedTarget, Address, request.sources_field.address),
+        Get(Targets, Addresses(itertools.chain.from_iterable(owners))),
+    )
+    resolve = original_tgt.target[PythonResolveField].normalized_value(python_setup)
+    python_owners = [
+        tgt.address
+        for tgt in owner_tgts
+        if (
+            tgt.has_field(PythonSourceField)
+            and tgt[PythonResolveField].normalized_value(python_setup) == resolve
+        )
+    ]
     return InferredDependencies(python_owners)
 
 
@@ -498,6 +512,7 @@ class InferConftestDependencies(InferDependenciesRequest):
 async def infer_python_conftest_dependencies(
     request: InferConftestDependencies,
     python_infer_subsystem: PythonInferSubsystem,
+    python_setup: PythonSetup,
 ) -> InferredDependencies:
     if not python_infer_subsystem.conftests:
         return InferredDependencies([])
@@ -514,7 +529,21 @@ async def infer_python_conftest_dependencies(
         Get(Owners, OwnersRequest((f,), OwnersNotFoundBehavior.error))
         for f in conftest_files.snapshot.files
     )
-    return InferredDependencies(itertools.chain.from_iterable(owners))
+
+    original_tgt, owner_tgts = await MultiGet(
+        Get(WrappedTarget, Address, request.sources_field.address),
+        Get(Targets, Addresses(itertools.chain.from_iterable(owners))),
+    )
+    resolve = original_tgt.target[PythonResolveField].normalized_value(python_setup)
+    python_owners = [
+        tgt.address
+        for tgt in owner_tgts
+        if (
+            tgt.has_field(PythonSourceField)
+            and tgt[PythonResolveField].normalized_value(python_setup) == resolve
+        )
+    ]
+    return InferredDependencies(python_owners)
 
 
 # This is a separate function to facilitate tests registering import inference.

--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -330,14 +330,21 @@ def test_infer_python_inits(behavior: InitFilesInference) -> None:
             QueryRule(InferredDependencies, (InferInitDependencies,)),
         ],
         target_types=[PythonSourcesGeneratorTarget],
+        objects={"parametrize": Parametrize},
     )
     rule_runner.set_options(
-        [f"--python-infer-init-files={behavior.value}"], env_inherit=PYTHON_BOOTSTRAP_ENV
+        [
+            f"--python-infer-init-files={behavior.value}",
+            "--python-resolves={'a': '', 'b': ''}",
+            "--python-default-resolve=a",
+            "--python-enable-resolves",
+        ],
+        env_inherit=PYTHON_BOOTSTRAP_ENV,
     )
     rule_runner.write_files(
         {
             "src/python/root/__init__.py": "content",
-            "src/python/root/BUILD": "python_sources()",
+            "src/python/root/BUILD": "python_sources(resolve=parametrize('a', 'b'))",
             "src/python/root/mid/__init__.py": "",
             "src/python/root/mid/BUILD": "python_sources()",
             "src/python/root/mid/leaf/__init__.py": "content",
@@ -363,7 +370,9 @@ def test_infer_python_inits(behavior: InitFilesInference) -> None:
     check(
         Address("src/python/root/mid/leaf", relative_file_path="f.py"),
         [
-            Address("src/python/root", relative_file_path="__init__.py"),
+            Address(
+                "src/python/root", relative_file_path="__init__.py", parameters={"resolve": "a"}
+            ),
             *(
                 []
                 if behavior is InitFilesInference.content_only
@@ -389,16 +398,22 @@ def test_infer_python_conftests() -> None:
             QueryRule(InferredDependencies, (InferConftestDependencies,)),
         ],
         target_types=[PythonTestsGeneratorTarget, PythonTestUtilsGeneratorTarget],
+        objects={"parametrize": Parametrize},
     )
     rule_runner.set_options(
-        ["--source-root-patterns=src/python"],
+        [
+            "--source-root-patterns=src/python",
+            "--python-resolves={'a': '', 'b': ''}",
+            "--python-default-resolve=a",
+            "--python-enable-resolves",
+        ],
         env_inherit={"PATH", "PYENV_ROOT", "HOME"},
     )
 
     rule_runner.write_files(
         {
             "src/python/root/conftest.py": "",
-            "src/python/root/BUILD": "python_test_utils()",
+            "src/python/root/BUILD": "python_test_utils(resolve=parametrize('a', 'b'))",
             "src/python/root/mid/conftest.py": "",
             "src/python/root/mid/BUILD": "python_test_utils()",
             "src/python/root/mid/leaf/conftest.py": "",
@@ -420,7 +435,9 @@ def test_infer_python_conftests() -> None:
         )
     ) == InferredDependencies(
         [
-            Address("src/python/root", relative_file_path="conftest.py"),
+            Address(
+                "src/python/root", relative_file_path="conftest.py", parameters={"resolve": "a"}
+            ),
             Address("src/python/root/mid", relative_file_path="conftest.py"),
             Address("src/python/root/mid/leaf", relative_file_path="conftest.py"),
         ],


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/15762.

[ci skip-rust]