### PR TITLE
Better error message when an address does not exist

### DIFF
--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -610,11 +610,14 @@ class Address(EngineAwareParameter):
 
 
 @dataclass(frozen=True)
-class BuildFileAddressRequest:
+class BuildFileAddressRequest(EngineAwareParameter):
     """A request to find the BUILD file path for an address."""
 
     address: Address
     description_of_origin: str = dataclasses.field(hash=False, compare=False)
+
+    def debug_hint(self) -> str:
+        return self.address.spec
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -14,7 +14,7 @@ from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import DigestContents, GlobMatchErrorBehavior, PathGlobs, Paths
 from pants.engine.internals.mapper import AddressFamily, AddressMap
 from pants.engine.internals.parser import BuildFilePreludeSymbols, Parser, error_on_imports
-from pants.engine.internals.target_adaptor import TargetAdaptor
+from pants.engine.internals.target_adaptor import TargetAdaptor, TargetAdaptorRequest
 from pants.engine.rules import Get, collect_rules, rule
 from pants.option.global_options import GlobalOptions
 from pants.util.frozendict import FrozenDict
@@ -141,7 +141,8 @@ async def find_build_file(request: BuildFileAddressRequest) -> BuildFileAddress:
     owning_address = address.maybe_convert_to_target_generator()
     if address_family.get_target_adaptor(owning_address) is None:
         raise ResolveError.did_you_mean(
-            bad_name=owning_address.target_name,
+            owning_address,
+            description_of_origin=request.description_of_origin,
             known_names=address_family.target_names,
             namespace=address_family.namespace,
         )
@@ -154,18 +155,20 @@ async def find_build_file(request: BuildFileAddressRequest) -> BuildFileAddress:
 
 
 @rule
-async def find_target_adaptor(address: Address) -> TargetAdaptor:
+async def find_target_adaptor(request: TargetAdaptorRequest) -> TargetAdaptor:
     """Hydrate a TargetAdaptor so that it may be converted into the Target API."""
+    address = request.address
     if address.is_generated_target:
         raise AssertionError(
             "Generated targets are not defined in BUILD files, and so do not have "
-            f"TargetAdaptors: {address}"
+            f"TargetAdaptors: {request}"
         )
     address_family = await Get(AddressFamily, AddressFamilyDir(address.spec_path))
     target_adaptor = address_family.get_target_adaptor(address)
     if target_adaptor is None:
         raise ResolveError.did_you_mean(
-            bad_name=address.target_name,
+            address,
+            description_of_origin=request.description_of_origin,
             known_names=address_family.target_names,
             namespace=address_family.namespace,
         )

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -32,7 +32,7 @@ from pants.engine.internals.parametrize import (  # noqa: F401
 from pants.engine.internals.parametrize import (  # noqa: F401
     _TargetParametrizationsRequest as _TargetParametrizationsRequest,
 )
-from pants.engine.internals.target_adaptor import TargetAdaptor
+from pants.engine.internals.target_adaptor import TargetAdaptor, TargetAdaptorRequest
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     AllTargets,
@@ -157,7 +157,10 @@ async def resolve_target_parametrizations(
 ) -> _TargetParametrizations:
     address = request.address
 
-    target_adaptor = await Get(TargetAdaptor, Address, address)
+    target_adaptor = await Get(
+        TargetAdaptor,
+        TargetAdaptorRequest(address, description_of_origin=request.description_of_origin),
+    )
     target_type = registered_target_types.aliases_to_types.get(target_adaptor.type_alias, None)
     if target_type is None:
         raise UnrecognizedTargetTypeException(

--- a/src/python/pants/engine/internals/target_adaptor.py
+++ b/src/python/pants/engine/internals/target_adaptor.py
@@ -3,9 +3,23 @@
 
 from __future__ import annotations
 
+import dataclasses
+from dataclasses import dataclass
 from typing import Any
 
 from typing_extensions import final
+
+from pants.build_graph.address import Address
+from pants.engine.engine_aware import EngineAwareParameter
+
+
+@dataclass(frozen=True)
+class TargetAdaptorRequest(EngineAwareParameter):
+    address: Address
+    description_of_origin: str = dataclasses.field(hash=False, compare=False)
+
+    def debug_hint(self) -> str:
+        return self.address.spec
 
 
 @final


### PR DESCRIPTION
Part of https://github.com/pantsbuild/pants/issues/14468.

Before:

```
❯ ./pants list src/python/pants/util:fake
15:56:13.27 [ERROR] 1 Exception encountered:

ResolveError: 'fake' was not found in namespace 'src/python/pants/util'. Did you mean one of:
  :tests
  :util
```

After:

```
❯ ./pants list src/python/pants/util:fake
15:56:13.27 [ERROR] 1 Exception encountered:

ResolveError: The address src/python/pants/util:fake from CLI arguments does not exist.

The target name ':fake' is not defined in the directory src/python/pants/util. Did you mean one of these target names?

  * :tests
  * :util
```

[ci skip-rust]
[ci skip-build-wheels]